### PR TITLE
feat(harness): add judged LLM-QG shadow driver

### DIFF
--- a/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
+++ b/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
@@ -62,6 +62,61 @@ lineage is unavailable, the live call fails closed. If the reviewer family
 matches the author family, the call is blocked as self-review; there is no
 silent fallback to a same-family reviewer.
 
+## Production factuality shadow run
+
+`qg_shadow_run.py` captures one **fresh, live** Tier-2 review of a built folk
+module, including the full learner-facing module, activities, vocabulary, and
+resources surface. It does not invoke `qg_bakeoff` or create a fixture. The
+capture is serialized as `qg_bakeoff_run.v2` only because that is the stable
+replay artifact contract consumed by `layerb_shadow`.
+
+The driver resolves real writer lineage before dispatch (explicit family,
+module metadata, then git `X-Agent` history) and errors if it cannot do so.
+It runs Layer B at the pinned `tau=0.75` only, writes a local audit artifact and
+per-module Markdown evidence, then persists advisory rows in the separate
+`llm_qg_shadow.db`. It neither reads nor writes canonical `llm_qg_runs`; Monitor
+and build gating ignore the shadow database until an explicit cutover.
+
+For a dry-ish end-to-end capture, use `--layerb-dry-run`: Tier 2 still runs, but
+the tool-disabled judge does not. A judged invocation instead requires the
+attested judge command, exact route identity, attestation, labels, and frozen
+qualification manifests; `layerb_shadow` verifies all of them.
+
+```bash
+.venv/bin/python scripts/audit/qg_shadow_run.py \
+  --module-dir curriculum/l2-uk-en/folk/vesnianky-hayivky \
+  --level folk \
+  --author-family claude \
+  --canary-artifact seminar=PATH_TO_PASSING_CANARY.json \
+  --max-cost-usd 1.00 \
+  --max-llm-calls 3 \
+  --layerb-dry-run \
+  --audit-dir audit/local-qg-shadow \
+  --shadow-db data/telemetry/llm_qg_shadow.db
+```
+
+The resulting Markdown, replay artifact, Layer-B report, and local SQLite
+database are operational evidence and must not be committed.
+
+### Reviewer prompt compatibility contract
+
+The Tier-2 reviewer prompt and emitted `fact_checks` remain compatible with the
+attested factuality judge only when all of the following hold:
+
+- A `CONFIRMED` or contradiction verdict has an actual captured
+  `mcp__sources__*` call; model memory or an uncaptured citation never counts.
+- Evidence excerpts are contiguous quotations from that tool output (a light
+  ellipsis is permitted) and keep the source query visible. Paraphrase must
+  never be presented as a quote.
+- Keep the established shape: claim → tool reference → quoted excerpt →
+  verdict. Do not invent a parallel verdict schema.
+- Authors prefer claims supported by the indexed sources and retain opaque
+  canonical `source_ref` keys. Claims outside that corpus go to human audit.
+- The reviewer captures evidence and makes its own verdict; the separate,
+  tool-disabled Layer-B judge audits grounding. Do not pre-judge grounding in
+  the reviewer prompt.
+- Shadow verdicts are advisory only until a separately approved cutover.
+
 ## Cost Controls
 
 Use `--dry-run` before broad reviewer spend:

--- a/scripts/audit/llm_qg_shadow_store.py
+++ b/scripts/audit/llm_qg_shadow_store.py
@@ -1,0 +1,148 @@
+"""Separate local persistence for advisory judged LLM-QG shadow runs.
+
+This store is intentionally disjoint from ``llm_qg_store``: Monitor and build
+logic treat canonical Tier-2 evidence as production gate state, while judged
+shadow results remain outcome-only evidence until an explicit cutover.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Mapping, Sequence
+from contextlib import closing
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from scripts.api.config import PROJECT_ROOT
+from scripts.api.resilience import connect_sqlite
+
+DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "telemetry" / "llm_qg_shadow.db"
+SCHEMA_VERSION = "llm_qg_shadow_store.v1"
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def init_db(path: Path | None = None) -> Path:
+    """Create the isolated, versioned shadow persistence schema."""
+
+    resolved = path or DEFAULT_DB_PATH
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    with closing(connect_sqlite(str(resolved))) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS llm_qg_shadow_runs (
+                shadow_run_id TEXT PRIMARY KEY,
+                created_at TEXT NOT NULL,
+                schema_version TEXT NOT NULL,
+                tier2_run_id TEXT NOT NULL,
+                level TEXT NOT NULL,
+                slug TEXT NOT NULL,
+                content_sha TEXT NOT NULL,
+                artifact_path TEXT NOT NULL,
+                artifact_sha256 TEXT NOT NULL,
+                layerb_report_path TEXT NOT NULL,
+                writer_family TEXT NOT NULL,
+                qg_reviewer_family TEXT NOT NULL,
+                tau REAL NOT NULL,
+                summary_json TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_llm_qg_shadow_content
+                ON llm_qg_shadow_runs(level, slug, content_sha, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_llm_qg_shadow_tier2
+                ON llm_qg_shadow_runs(tier2_run_id);
+
+            CREATE TABLE IF NOT EXISTS llm_qg_shadow_findings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                shadow_run_id TEXT NOT NULL,
+                grounding_key TEXT,
+                fact_check_id TEXT,
+                final_decision TEXT,
+                payload_json TEXT NOT NULL,
+                FOREIGN KEY(shadow_run_id) REFERENCES llm_qg_shadow_runs(shadow_run_id)
+                    ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_llm_qg_shadow_findings_run
+                ON llm_qg_shadow_findings(shadow_run_id, id);
+            """
+        )
+        conn.commit()
+    return resolved
+
+
+def record_shadow_run(
+    *,
+    tier2_run_id: str,
+    level: str,
+    slug: str,
+    content_sha: str,
+    artifact_path: Path,
+    artifact_sha256: str,
+    layerb_report_path: Path,
+    writer_family: str,
+    qg_reviewer_family: str,
+    tau: float,
+    summary: Mapping[str, Any],
+    findings: Sequence[Mapping[str, Any]],
+    path: Path | None = None,
+    shadow_run_id: str | None = None,
+) -> str:
+    """Persist advisory outcomes without writing canonical ``llm_qg_runs``."""
+
+    resolved = init_db(path)
+    run_id = shadow_run_id or f"llm-qg-shadow-{uuid4().hex}"
+    with closing(connect_sqlite(str(resolved))) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            """
+            INSERT INTO llm_qg_shadow_runs (
+                shadow_run_id, created_at, schema_version, tier2_run_id,
+                level, slug, content_sha, artifact_path, artifact_sha256,
+                layerb_report_path, writer_family, qg_reviewer_family, tau,
+                summary_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                _now_z(),
+                SCHEMA_VERSION,
+                tier2_run_id,
+                level,
+                slug,
+                content_sha,
+                str(artifact_path),
+                artifact_sha256,
+                str(layerb_report_path),
+                writer_family,
+                qg_reviewer_family,
+                tau,
+                _json(summary),
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO llm_qg_shadow_findings (
+                shadow_run_id, grounding_key, fact_check_id, final_decision, payload_json
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    run_id,
+                    str(row.get("grounding_key") or "") or None,
+                    str(row.get("fact_check_id") or "") or None,
+                    str(row.get("final_decision") or "") or None,
+                    _json(dict(row)),
+                )
+                for row in findings
+            ],
+        )
+        conn.commit()
+    return run_id

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -34,12 +34,12 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.audit import llm_reviewer, llm_reviewer_dispatch, qg_factcheck_scoring, qg_schema
+from scripts.audit.qg_run_serializer import RUN_SCHEMA_VERSION, serialize_qg_run_v2
 from scripts.audit.runtime_tool_events import map_runtime_tool_calls
 
 FIXTURE_DIR = PROJECT_ROOT / "tests" / "fixtures" / "qg_bakeoff"
 DEFAULT_OUTPUT_ROOT = PROJECT_ROOT / "audit"
 BENCHMARK_V1_MANIFEST = PROJECT_ROOT / "benchmarks" / "v1" / "MANIFEST.json"
-RUN_SCHEMA_VERSION = "qg_bakeoff_run.v2"
 SCORECARD_NAME = "SCORECARD.md"
 SCORECARD_STRICT_NAME = "SCORECARD-STRICT.md"
 # Provenance tag for offline ``--regate`` rescoring: live_admissible uses STRICT
@@ -1647,31 +1647,33 @@ def run_one(
         gate_outcomes["grounding"].get("inadmissible_positive_verdicts") or 0
     )
     dispatch = gate_result["dispatch"]
-    artifact = {
-        "schema_version": RUN_SCHEMA_VERSION,
-        "arm": TOOLED_ARM,
-        "run_index": run_index,
-        "created_at": _now_z(),
-        "fixture": _fixture_block(fixture),
-        "model": _model_block(route, dispatch),
-        "status": gate_result["status"],
-        "workflow_verdict": gate_result["workflow_verdict"],
-        "findings_schema_invalid": bool(gate_result.get("findings_schema_invalid")),
-        "response_parse_lenient": bool(gate_result.get("response_parse_lenient")),
-        "attempt_count": gate_result["attempt_count"],
-        "timed_out": False,
-        "transport_retry": {"attempted": False, "reason": None},
-        "dispatch": dispatch,
-        "gate_outcomes": gate_outcomes,
-        "payload": gate_result["payload"],
-        # Raw model response is persisted alongside dispatch.tool_events so a
-        # future normalization/scoring change can be replayed OFFLINE from disk
-        # (no model re-run, no subscription quota burned). See docs note in #4761.
-        "raw_response": gate_result.get("raw_response_text"),
-        "score": score,
-        "tool_call_count": int(dispatch.get("tool_call_count") or 0),
-        "wall_seconds": wall_seconds,
-    }
+    artifact = serialize_qg_run_v2(
+        dispatch,
+        gate_result["payload"],
+        {
+            "schema_version": RUN_SCHEMA_VERSION,
+            "arm": TOOLED_ARM,
+            "run_index": run_index,
+            "created_at": _now_z(),
+            "fixture": _fixture_block(fixture),
+            "model": _model_block(route, dispatch),
+            "status": gate_result["status"],
+            "workflow_verdict": gate_result["workflow_verdict"],
+            "findings_schema_invalid": bool(gate_result.get("findings_schema_invalid")),
+            "response_parse_lenient": bool(gate_result.get("response_parse_lenient")),
+            "attempt_count": gate_result["attempt_count"],
+            "timed_out": False,
+            "transport_retry": {"attempted": False, "reason": None},
+            "gate_outcomes": gate_outcomes,
+            # Raw model response is persisted alongside dispatch.tool_events so a
+            # future normalization/scoring change can be replayed OFFLINE from disk
+            # (no model re-run, no subscription quota burned). See docs note in #4761.
+            "raw_response": gate_result.get("raw_response_text"),
+            "score": score,
+            "tool_call_count": int(dispatch.get("tool_call_count") or 0),
+            "wall_seconds": wall_seconds,
+        },
+    )
     artifact_path.write_text(json.dumps(artifact, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return BakeoffRun(artifact_path=artifact_path, artifact=artifact)
 

--- a/scripts/audit/qg_run_serializer.py
+++ b/scripts/audit/qg_run_serializer.py
@@ -1,0 +1,38 @@
+"""Stable, replay-grade QG run artifact serialization.
+
+The offline bakeoff and production shadow capture deliberately share only this
+artifact contract.  They retain separate execution and routing paths.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+RUN_SCHEMA_VERSION = "qg_bakeoff_run.v2"
+
+
+def serialize_qg_run_v2(
+    dispatch: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    meta: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return a qg_bakeoff_run.v2 artifact without mutating caller data.
+
+    ``meta`` owns run-specific facts such as fixture/target identity, route,
+    gate outcomes, scoring, and timing.  The shared fields are deliberately
+    constrained to the captured dispatcher metadata and canonical reviewer
+    payload so either runner can be replayed by :mod:`layerb_shadow`.
+    """
+
+    if "dispatch" in meta or "payload" in meta:
+        raise ValueError("qg run metadata must not override dispatch or payload")
+    schema_version = meta.get("schema_version", RUN_SCHEMA_VERSION)
+    if schema_version != RUN_SCHEMA_VERSION:
+        raise ValueError(f"qg run serializer requires {RUN_SCHEMA_VERSION}, got {schema_version!r}")
+    return {
+        **dict(meta),
+        "schema_version": RUN_SCHEMA_VERSION,
+        "dispatch": dict(dispatch),
+        "payload": dict(payload),
+    }

--- a/scripts/audit/qg_shadow_run.py
+++ b/scripts/audit/qg_shadow_run.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Capture one live Tier-2 run and judge it in advisory Layer-B shadow mode.
+
+This driver intentionally does not call the offline ``qg_bakeoff`` runner. It
+uses the production QG prompt, policy, dispatcher, and deterministic gates,
+then serializes that one authenticated dispatch into the replay artifact that
+``layerb_shadow`` already understands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+for path in (str(PROJECT_ROOT), str(SCRIPTS_DIR)):
+    with suppress(ValueError):
+        sys.path.remove(path)
+sys.path[:0] = [str(PROJECT_ROOT), str(SCRIPTS_DIR)]
+
+from scripts.audit import layerb_shadow, llm_qg_shadow_store, llm_reviewer_dispatch, qg_workflow
+from scripts.audit.content_surface_gates import policy_for_level
+from scripts.audit.qg_run_serializer import RUN_SCHEMA_VERSION, serialize_qg_run_v2
+
+SHADOW_ARTIFACT_ARM = "production_shadow"
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowRunResult:
+    """Paths and identifiers produced by one advisory shadow run."""
+
+    tier2_run_id: str
+    shadow_run_id: str
+    artifact_path: Path
+    layerb_report_path: Path
+    markdown_path: Path
+    layerb_exit_code: int
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _tier2(record: Mapping[str, Any]) -> dict[str, Any]:
+    workflow = record.get("qg_workflow")
+    tiers = workflow.get("tiers") if isinstance(workflow, Mapping) else []
+    for tier in tiers if isinstance(tiers, list) else []:
+        if isinstance(tier, Mapping) and tier.get("tier") == 2:
+            return dict(tier)
+    raise ValueError("workflow record has no Tier-2 result")
+
+
+def _approved_live_reviewer(
+    target: qg_workflow.ReviewTarget,
+    prompt: str,
+) -> llm_reviewer_dispatch.DispatchResult:
+    """Run the registered live route without module-local raw-response writes."""
+
+    policy = policy_for_level(target.level)
+    route = llm_reviewer_dispatch.route_for_review(
+        policy_family=policy.family,
+        factual_sensitive=policy.family == "seminar",
+    )
+    return llm_reviewer_dispatch.invoke_bridge_route(
+        route,
+        prompt,
+        f"llm-qg-shadow-{target.level}-{target.slug}-{uuid4().hex[:8]}",
+        no_module_persistence=True,
+        module_dir=target.module_dir,
+    )
+
+
+def _require_writer_lineage(
+    target: qg_workflow.ReviewTarget,
+    author_family: str | None,
+) -> llm_reviewer_dispatch.AuthorLineage:
+    lineage = llm_reviewer_dispatch.resolve_author_lineage(
+        level=target.level,
+        slug=target.slug,
+        module_dir=target.module_dir,
+        explicit_author_family=author_family,
+    )
+    if not lineage.available:
+        raise ValueError(
+            "production shadow capture requires resolvable writer lineage; "
+            "pass --author-family or supply build metadata/git X-Agent lineage"
+        )
+    return lineage
+
+
+def _artifact_for_capture(
+    *,
+    target: qg_workflow.ReviewTarget,
+    record: Mapping[str, Any],
+    tier2: Mapping[str, Any],
+    lineage: llm_reviewer_dispatch.AuthorLineage,
+) -> dict[str, Any]:
+    dispatch = tier2.get("dispatch")
+    payload = tier2.get("payload")
+    tier2_run_id = tier2.get("tier2_run_id")
+    if not isinstance(dispatch, Mapping) or not isinstance(payload, Mapping) or not isinstance(tier2_run_id, str):
+        raise ValueError("Tier-2 capture is unavailable; shadow runs require a fresh captured live dispatch")
+    qg_workflow_meta = record.get("qg_workflow") if isinstance(record.get("qg_workflow"), Mapping) else {}
+    reviewer_family = dispatch.get("reviewer_family") or tier2.get("reviewer_family")
+    if not isinstance(reviewer_family, str) or not reviewer_family:
+        raise ValueError("Tier-2 capture has no reviewer lineage")
+    return serialize_qg_run_v2(
+        dispatch,
+        payload,
+        {
+            "schema_version": RUN_SCHEMA_VERSION,
+            "arm": SHADOW_ARTIFACT_ARM,
+            "run_index": 1,
+            "created_at": _now_z(),
+            "target": {
+                "level": target.level,
+                "slug": target.slug,
+                "module_dir": str(target.module_dir),
+                "content_sha": record.get("content_sha"),
+                "prompt_hash": qg_workflow_meta.get("prompt_hash"),
+            },
+            "tier2_run_id": tier2_run_id,
+            "model": {
+                "pin": dispatch.get("reviewer_model_id"),
+                "family": reviewer_family,
+                "route_name": dispatch.get("route_name"),
+            },
+            "status": tier2.get("status"),
+            "workflow_verdict": record.get("workflow_verdict"),
+            "attempt_count": len(tier2.get("retry_history") or ()),
+            "gate_outcomes": tier2.get("gate_outcomes") or {},
+            "raw_response": tier2.get("raw_response"),
+            "retry_history": tier2.get("retry_history") or [],
+            "tool_call_count": dispatch.get("tool_call_count") or 0,
+            "writer_family": lineage.family,
+            "writer_lineage": {"source": lineage.source, "evidence": lineage.evidence},
+            "qg_reviewer_family": reviewer_family,
+        },
+    )
+
+
+def _write_markdown(
+    path: Path,
+    *,
+    target: qg_workflow.ReviewTarget,
+    artifact_path: Path,
+    report_path: Path,
+    report: Mapping[str, Any],
+) -> None:
+    records = report.get("records") if isinstance(report.get("records"), list) else []
+    lines = [
+        "# LLM-QG production shadow evidence",
+        "",
+        "Advisory only: this report does not change canonical LLM-QG gate state.",
+        "",
+        f"- Module: `{target.level}/{target.slug}`",
+        f"- Artifact: `{artifact_path}`",
+        f"- Layer-B report: `{report_path}`",
+        f"- Tau: `{layerb_shadow.DEFAULT_TAU:.2f}`",
+        "",
+        "## Verdict rows",
+        "",
+        "| Fact check | Decision | Relation |",
+        "| --- | --- | --- |",
+    ]
+    verdict_rows = 0
+    for row in records:
+        if not isinstance(row, Mapping):
+            continue
+        verdict_rows += 1
+        lines.append(
+            "| {fact} | {decision} | {relation} |".format(
+                fact=str(row.get("fact_check_id") or "unknown").replace("|", "\\|"),
+                decision=str(row.get("final_decision") or "AUDIT"),
+                relation=str(row.get("aggregate_relation") or "AUDIT"),
+            )
+        )
+    if not verdict_rows:
+        lines.append("| none | AUDIT | no grounded fact checks |")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run_layerb(
+    *,
+    artifact_dir: Path,
+    layerb_dir: Path,
+    layerb_dry_run: bool,
+    max_judge_calls: int | None,
+    judge_command: str | None,
+    judge_family: str | None,
+    judge_model: str | None,
+    judge_model_version: str | None,
+    provider_account_lane: str | None,
+    judge_attestation: Path | None,
+    labels: Path | None,
+    corpus_manifests: Sequence[Path],
+    fixture_manifests: Sequence[Path],
+) -> tuple[int, Path, dict[str, Any]]:
+    args = [
+        "--artifacts-dir",
+        str(artifact_dir),
+        "--audit-dir",
+        str(layerb_dir),
+        "--tau",
+        str(layerb_shadow.DEFAULT_TAU),
+    ]
+    if max_judge_calls is not None:
+        args.extend(("--max-judge-calls", str(max_judge_calls)))
+    if layerb_dry_run:
+        args.append("--dry-run")
+    else:
+        required = {
+            "judge_command": judge_command,
+            "judge_family": judge_family,
+            "judge_model": judge_model,
+            "judge_model_version": judge_model_version,
+            "provider_account_lane": provider_account_lane,
+            "judge_attestation": judge_attestation,
+            "labels": labels,
+        }
+        missing = [name for name, value in required.items() if value is None]
+        if missing:
+            raise ValueError("attested Layer-B shadow requires " + ", ".join(missing))
+        args.extend(
+            (
+                "--judge-command",
+                str(judge_command),
+                "--judge-family",
+                str(judge_family),
+                "--judge-model",
+                str(judge_model),
+                "--judge-model-version",
+                str(judge_model_version),
+                "--provider-account-lane",
+                str(provider_account_lane),
+                "--judge-attestation",
+                str(judge_attestation),
+                "--labels",
+                str(labels),
+            )
+        )
+        for manifest in corpus_manifests:
+            args.extend(("--corpus-manifest", str(manifest)))
+        for manifest in fixture_manifests:
+            args.extend(("--fixture-manifest", str(manifest)))
+    exit_code = layerb_shadow.main(args)
+    if exit_code not in {0, 3}:
+        raise RuntimeError(f"layerb_shadow failed with exit code {exit_code}")
+    report_path = layerb_dir / ("phase1-shadow.partial.json" if exit_code == 3 else "phase1-shadow.json")
+    return exit_code, report_path, json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def run_shadow_module(
+    target: qg_workflow.ReviewTarget,
+    *,
+    audit_dir: Path,
+    shadow_db: Path,
+    author_family: str | None = None,
+    reviewer: qg_workflow.Reviewer | None = None,
+    live_reviewer: bool = True,
+    reviewer_model_id: str = qg_workflow.DEFAULT_REVIEWER_MODEL_ID,
+    reviewer_family: str = qg_workflow.DEFAULT_REVIEWER_FAMILY,
+    canary_artifacts: Mapping[str, Path] | None = None,
+    max_cost_usd: float | None = None,
+    max_llm_calls: int = 3,
+    layerb_dry_run: bool = False,
+    max_judge_calls: int | None = None,
+    judge_command: str | None = None,
+    judge_family: str | None = None,
+    judge_model: str | None = None,
+    judge_model_version: str | None = None,
+    provider_account_lane: str | None = None,
+    judge_attestation: Path | None = None,
+    labels: Path | None = None,
+    corpus_manifests: Sequence[Path] = (),
+    fixture_manifests: Sequence[Path] = (),
+) -> ShadowRunResult:
+    """Run one fresh capture and persist only advisory shadow outcomes."""
+
+    if layerb_shadow.DEFAULT_TAU != 0.75:
+        raise RuntimeError("production shadow requires the pinned tau=0.75")
+    lineage = _require_writer_lineage(target, author_family)
+    effective_reviewer = reviewer or _approved_live_reviewer
+    record = qg_workflow.review_module(
+        target,
+        options=qg_workflow.WorkflowOptions(
+            reviewer_model_id=reviewer_model_id,
+            reviewer_family=reviewer_family,
+            live_reviewer=live_reviewer,
+            author_family=lineage.family,
+            canary_artifacts=canary_artifacts,
+            enable_llm=True,
+            max_cost_usd=max_cost_usd,
+            max_llm_calls=max_llm_calls,
+            use_llm_cache=False,
+            persist_llm_qg=False,
+            record_live_outcomes=False,
+            record_daily_spend=False,
+            capture_tier2=True,
+        ),
+        reviewer=effective_reviewer,
+    )
+    tier2 = _tier2(record)
+    artifact = _artifact_for_capture(target=target, record=record, tier2=tier2, lineage=lineage)
+    tier2_run_id = str(tier2["tier2_run_id"])
+    run_dir = audit_dir / f"{target.level}-{target.slug}-{tier2_run_id.rsplit('-', 1)[-1]}"
+    artifact_dir = run_dir / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=False)
+    artifact_path = artifact_dir / "qg-shadow-run.json"
+    artifact_path.write_text(
+        json.dumps(artifact, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    layerb_exit_code, layerb_report_path, layerb_report = _run_layerb(
+        artifact_dir=artifact_dir,
+        layerb_dir=run_dir / "layerb",
+        layerb_dry_run=layerb_dry_run,
+        max_judge_calls=max_judge_calls,
+        judge_command=judge_command,
+        judge_family=judge_family,
+        judge_model=judge_model,
+        judge_model_version=judge_model_version,
+        provider_account_lane=provider_account_lane,
+        judge_attestation=judge_attestation,
+        labels=labels,
+        corpus_manifests=corpus_manifests,
+        fixture_manifests=fixture_manifests,
+    )
+    markdown_path = run_dir / "shadow-evidence.md"
+    _write_markdown(
+        markdown_path,
+        target=target,
+        artifact_path=artifact_path,
+        report_path=layerb_report_path,
+        report=layerb_report,
+    )
+    shadow_run_id = llm_qg_shadow_store.record_shadow_run(
+        tier2_run_id=tier2_run_id,
+        level=target.level,
+        slug=target.slug,
+        content_sha=str(record.get("content_sha") or ""),
+        artifact_path=artifact_path,
+        artifact_sha256=_sha256(artifact_path),
+        layerb_report_path=layerb_report_path,
+        writer_family=str(lineage.family),
+        qg_reviewer_family=str(tier2.get("reviewer_family") or ""),
+        tau=layerb_shadow.DEFAULT_TAU,
+        summary=layerb_report.get("summary") if isinstance(layerb_report.get("summary"), Mapping) else {},
+        findings=[row for row in layerb_report.get("records", []) if isinstance(row, Mapping)],
+        path=shadow_db,
+    )
+    return ShadowRunResult(
+        tier2_run_id=tier2_run_id,
+        shadow_run_id=shadow_run_id,
+        artifact_path=artifact_path,
+        layerb_report_path=layerb_report_path,
+        markdown_path=markdown_path,
+        layerb_exit_code=layerb_exit_code,
+    )
+
+
+def _canary_artifacts(values: Sequence[str]) -> dict[str, Path]:
+    artifacts: dict[str, Path] = {}
+    for value in values:
+        level, separator, raw_path = value.partition("=")
+        if not separator or not level or not raw_path:
+            raise argparse.ArgumentTypeError("--canary-artifact must use LEVEL=PATH")
+        artifacts[level.strip().lower()] = Path(raw_path)
+    return artifacts
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--module-dir", type=Path, required=True)
+    parser.add_argument("--level", required=True)
+    parser.add_argument("--slug")
+    parser.add_argument("--author-family")
+    parser.add_argument("--audit-dir", type=Path, required=True)
+    parser.add_argument("--shadow-db", type=Path, default=llm_qg_shadow_store.DEFAULT_DB_PATH)
+    parser.add_argument("--canary-artifact", action="append", default=[], metavar="LEVEL=PATH")
+    parser.add_argument("--max-cost-usd", type=float, required=True)
+    parser.add_argument("--max-llm-calls", type=int, default=3)
+    parser.add_argument("--layerb-dry-run", action="store_true", help="Capture Tier-2 but do not dispatch the judge.")
+    parser.add_argument("--max-judge-calls", type=int)
+    parser.add_argument("--judge-command")
+    parser.add_argument("--judge-family")
+    parser.add_argument("--judge-model")
+    parser.add_argument("--judge-model-version")
+    parser.add_argument("--provider-account-lane")
+    parser.add_argument("--judge-attestation", type=Path)
+    parser.add_argument("--labels", type=Path)
+    parser.add_argument("--corpus-manifest", action="append", default=[], type=Path)
+    parser.add_argument("--fixture-manifest", action="append", default=[], type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    target = qg_workflow.ReviewTarget(
+        level=args.level,
+        slug=args.slug or args.module_dir.name,
+        module_dir=args.module_dir,
+    )
+    try:
+        result = run_shadow_module(
+            target,
+            audit_dir=args.audit_dir,
+            shadow_db=args.shadow_db,
+            author_family=args.author_family,
+            canary_artifacts=_canary_artifacts(args.canary_artifact),
+            max_cost_usd=args.max_cost_usd,
+            max_llm_calls=args.max_llm_calls,
+            layerb_dry_run=args.layerb_dry_run,
+            max_judge_calls=args.max_judge_calls,
+            judge_command=args.judge_command,
+            judge_family=args.judge_family,
+            judge_model=args.judge_model,
+            judge_model_version=args.judge_model_version,
+            provider_account_lane=args.provider_account_lane,
+            judge_attestation=args.judge_attestation,
+            labels=args.labels,
+            corpus_manifests=args.corpus_manifest,
+            fixture_manifests=args.fixture_manifest,
+        )
+    except (OSError, ValueError, RuntimeError, argparse.ArgumentTypeError) as exc:
+        print(f"qg shadow error: {exc}", file=sys.stderr)
+        return 2
+    print(f"Shadow artifact: {result.artifact_path}")
+    print(f"Layer-B report: {result.layerb_report_path}")
+    print(f"Local evidence: {result.markdown_path}")
+    return result.layerb_exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -92,6 +92,11 @@ class WorkflowOptions:
     max_daily_cost_usd: float | None = None
     max_module_cost_usd: float | None = None
     fail_closed_on_llm_skip: bool = True
+    use_llm_cache: bool = True
+    persist_llm_qg: bool = True
+    record_live_outcomes: bool = True
+    record_daily_spend: bool = True
+    capture_tier2: bool = False
 
 
 @dataclass(slots=True)
@@ -264,6 +269,11 @@ def dry_run_modules(
         max_daily_cost_usd=dry_options.max_daily_cost_usd,
         max_module_cost_usd=dry_options.max_module_cost_usd,
         fail_closed_on_llm_skip=dry_options.fail_closed_on_llm_skip,
+        use_llm_cache=dry_options.use_llm_cache,
+        persist_llm_qg=dry_options.persist_llm_qg,
+        record_live_outcomes=dry_options.record_live_outcomes,
+        record_daily_spend=dry_options.record_daily_spend,
+        capture_tier2=dry_options.capture_tier2,
     )
     budget = BudgetState()
     records = [
@@ -785,17 +795,21 @@ def _run_tier2(
                 "reviewer_family": reviewer_family,
             }
 
-    cached = llm_qg_store.current_llm_qg_for_module(
-        level,
-        slug,
-        target.module_dir,
-        gate_version=options.gate_version,
-        prompt_hash=prompt_hash,
-        checker_version=CHECKER_VERSION,
-        level_policy_family=policy_family,
-        reviewer_model=reviewer_model_id,
-        route_name=route_name,
-        path=store_path,
+    cached = (
+        llm_qg_store.current_llm_qg_for_module(
+            level,
+            slug,
+            target.module_dir,
+            gate_version=options.gate_version,
+            prompt_hash=prompt_hash,
+            checker_version=CHECKER_VERSION,
+            level_policy_family=policy_family,
+            reviewer_model=reviewer_model_id,
+            route_name=route_name,
+            path=store_path,
+        )
+        if options.use_llm_cache
+        else None
     )
     if cached is not None:
         cached_payload = dict(cached.payload)
@@ -869,15 +883,19 @@ def _run_tier2(
                     "reviewer_family": reviewer_family,
                 }
 
-    stale_cache = _has_stale_cache(
-        level=level,
-        slug=slug,
-        gate_version=options.gate_version,
-        checker_version=CHECKER_VERSION,
-        level_policy_family=policy_family,
-        reviewer_model=reviewer_model_id,
-        route_name=route_name,
-        store_path=store_path,
+    stale_cache = (
+        _has_stale_cache(
+            level=level,
+            slug=slug,
+            gate_version=options.gate_version,
+            checker_version=CHECKER_VERSION,
+            level_policy_family=policy_family,
+            reviewer_model=reviewer_model_id,
+            route_name=route_name,
+            store_path=store_path,
+        )
+        if options.use_llm_cache
+        else False
     )
     estimate = (
         llm_reviewer_dispatch.estimate_route_cost(prompt, route, policy_family=policy_family)
@@ -958,6 +976,7 @@ def _run_tier2(
     dispatch_meta: dict[str, Any]
     tier2_status = "ran"
     workflow_override: str | None = None
+    capture_attempts: list[dict[str, Any]] = []
     while True:
         try:
             raw_response = effective_reviewer(target, attempt_prompt)
@@ -988,6 +1007,14 @@ def _run_tier2(
                 "reviewer_family": reviewer_family,
             }
         response_text, dispatch_meta = _coerce_reviewer_response(raw_response)
+        if options.capture_tier2:
+            capture_attempts.append(
+                {
+                    "attempt": len(capture_attempts) + 1,
+                    "raw_response": response_text,
+                    "dispatch": dict(dispatch_meta),
+                }
+            )
         actual_model_id = str(dispatch_meta.get("reviewer_model_id") or reviewer_model_id)
         actual_family = str(dispatch_meta.get("reviewer_family") or reviewer_family)
         actual_route_name = str(dispatch_meta.get("route_name") or route_name)
@@ -1196,35 +1223,60 @@ def _run_tier2(
         status=tier2_status,
         reason=workflow_override,
     )
-    llm_qg_store.record_llm_qg(
-        level=level,
-        slug=slug,
-        module_dir=target.module_dir,
-        payload=payload,
-        gate_version=options.gate_version,
-        prompt_hash=prompt_hash,
-        checker_version=CHECKER_VERSION,
-        level_policy_family=policy_family,
-        reviewer_model=reviewer_model_id,
-        reviewer_family=reviewer_family,
-        route_name=route_name,
-        tool_call_count=llm_reviewer_dispatch.tool_call_count_from_dispatch_meta(dispatch_meta),
-        tools_used=[str(tool) for tool in (dispatch_meta.get("tools_used") or ())],
-        tool_events=llm_reviewer_dispatch.tool_events_from_dispatch_meta(dispatch_meta),
-        source="qg_workflow",
-        path=store_path,
-    )
+    tier2_run_id = f"qg-workflow-{uuid4().hex}"
+    if options.persist_llm_qg:
+        llm_qg_store.record_llm_qg(
+            level=level,
+            slug=slug,
+            module_dir=target.module_dir,
+            payload=payload,
+            gate_version=options.gate_version,
+            prompt_hash=prompt_hash,
+            checker_version=CHECKER_VERSION,
+            level_policy_family=policy_family,
+            reviewer_model=reviewer_model_id,
+            reviewer_family=reviewer_family,
+            route_name=route_name,
+            tool_call_count=llm_reviewer_dispatch.tool_call_count_from_dispatch_meta(dispatch_meta),
+            tools_used=[str(tool) for tool in (dispatch_meta.get("tools_used") or ())],
+            tool_events=llm_reviewer_dispatch.tool_events_from_dispatch_meta(dispatch_meta),
+            source="qg_workflow",
+            run_id=tier2_run_id,
+            path=store_path,
+        )
+    result = {
+        **base_result,
+        "status": tier2_status,
+        "findings": len(findings),
+        "estimate": estimate,
+        "dispatch": dispatch_meta,
+        "invalid_fact_checks": grounding_gate.invalid_fact_checks,
+        "inadmissible_positive_verdicts": grounding_gate.inadmissible_positive_verdicts,
+    }
+    if options.capture_tier2:
+        result.update(
+            {
+                "tier2_run_id": tier2_run_id,
+                "payload": payload,
+                "raw_response": response_text,
+                "retry_history": capture_attempts,
+                "gate_outcomes": {
+                    "status": tier2_status,
+                    "workflow_override": workflow_override,
+                    "theatre_retried": theatre_retried,
+                    "deep_read_retried": deep_read_retried,
+                    "grounding": {
+                        "ungrounded_findings": grounding_gate.ungrounded_findings,
+                        "required_ungrounded_findings": grounding_gate.required_ungrounded_findings,
+                        "invalid_fact_checks": grounding_gate.invalid_fact_checks,
+                        "inadmissible_positive_verdicts": grounding_gate.inadmissible_positive_verdicts,
+                    },
+                },
+            }
+        )
     return {
         "findings": findings,
-        "result": {
-            **base_result,
-            "status": tier2_status,
-            "findings": len(findings),
-            "estimate": estimate,
-            "dispatch": dispatch_meta,
-            "invalid_fact_checks": grounding_gate.invalid_fact_checks,
-            "inadmissible_positive_verdicts": grounding_gate.inadmissible_positive_verdicts,
-        },
+        "result": result,
         "llm_used": True,
         "workflow_verdict": workflow_override,
         "reviewer_model_id": reviewer_model_id,
@@ -1372,7 +1424,7 @@ def _record_daily_spend(
     estimate: Mapping[str, Any],
     observed_cost_usd: float | None,
 ) -> None:
-    if not options.live_reviewer:
+    if not options.live_reviewer or not options.record_daily_spend:
         return
     llm_reviewer_dispatch.append_daily_spend(
         path=options.daily_spend_path,
@@ -1395,7 +1447,7 @@ def _record_live_tier2_outcome(
     status: str,
     reason: str | None = None,
 ) -> dict[str, Any] | None:
-    if not options.live_reviewer or options.dry_run:
+    if not options.live_reviewer or options.dry_run or not options.record_live_outcomes:
         return None
     return llm_qg_store.record_live_tier2_outcome(
         level=level,

--- a/tests/audit/test_qg_run_serializer.py
+++ b/tests/audit/test_qg_run_serializer.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.audit import llm_reviewer_dispatch, qg_bakeoff
+
+PRE_EXTRACTION_ARTIFACT_SHA256 = "0b06f32e84f99d8e5949b70b3bdf90eb96710d9a411465830f4bee06ce589b20"
+
+
+def test_bakeoff_tooled_artifact_matches_pre_extraction_golden_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The extraction preserves the existing sorted JSON artifact byte-for-byte."""
+
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    monkeypatch.setattr(qg_bakeoff, "_now_z", lambda: "2026-07-14T00:00:00Z")
+    monkeypatch.setattr(qg_bakeoff.time, "monotonic", lambda: 0.0)
+    route = qg_bakeoff.bakeoff_route_for_model("openrouter/test/parity-model")
+    fixture = qg_bakeoff.BakeoffFixture(
+        slug="parity",
+        title="Parity",
+        passage_md="Веснянки — це весняні обрядові пісні.",
+        claims=(
+            qg_bakeoff.FixtureClaim(
+                "claim-1",
+                "Веснянки — це весняні обрядові пісні.",
+                True,
+            ),
+        ),
+    )
+    response = {
+        "findings": [],
+        "fact_checks": [
+            {
+                "claim": "Веснянки — це весняні обрядові пісні.",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "веснянки",
+                    "evidence_excerpt": "Веснянки — це весняні обрядові пісні.",
+                    "tool_call_id": "call-1",
+                },
+            }
+        ],
+        "evidence_gaps": [],
+    }
+
+    def runner(
+        selected_route: llm_reviewer_dispatch.ReviewerRoute,
+        _prompt: str,
+        _task_id: str,
+    ) -> llm_reviewer_dispatch.DispatchResult:
+        return llm_reviewer_dispatch.DispatchResult(
+            response_text=json.dumps(response, ensure_ascii=False),
+            reviewer_model_id=selected_route.reviewer_model_id,
+            reviewer_family=selected_route.reviewer_family,
+            route_name=selected_route.route_name,
+            tool_call_count=1,
+            tools_used=("sources_query_wikipedia",),
+            tool_events=(
+                {
+                    "tool": "sources_query_wikipedia",
+                    "input": {"query": "веснянки"},
+                    "status": "completed",
+                    "tool_call_id": "call-1",
+                    "output": "Веснянки — це весняні обрядові пісні.",
+                },
+            ),
+        )
+
+    artifact = qg_bakeoff.run_one(route, fixture, output_dir=tmp_path, runner=runner)
+
+    assert hashlib.sha256(artifact.artifact_path.read_bytes()).hexdigest() == PRE_EXTRACTION_ARTIFACT_SHA256

--- a/tests/audit/test_qg_shadow_run.py
+++ b/tests/audit/test_qg_shadow_run.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.audit import llm_qg_store, llm_reviewer_dispatch, qg_shadow_run, qg_workflow
+
+
+def _module(tmp_path: Path) -> Path:
+    module_dir = tmp_path / "folk" / "vesnianky-shadow"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text(
+        "# Веснянки\n\nВеснянки — це весняні обрядові пісні.\n",
+        encoding="utf-8",
+    )
+    for name in ("activities.yaml", "vocabulary.yaml", "resources.yaml"):
+        (module_dir / name).write_text("[]\n", encoding="utf-8")
+    return module_dir
+
+
+def _dispatch(
+    _target: qg_workflow.ReviewTarget,
+    _prompt: str,
+) -> llm_reviewer_dispatch.DispatchResult:
+    response = {
+        "findings": [],
+        "fact_checks": [
+            {
+                "claim": "Веснянки — це весняні обрядові пісні.",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "Веснянки",
+                    "evidence_excerpt": "Веснянки — це весняні обрядові пісні.",
+                    "tool_call_id": "call_1",
+                },
+            }
+        ],
+        "evidence_gaps": [],
+    }
+    return llm_reviewer_dispatch.DispatchResult(
+        response_text=json.dumps(response, ensure_ascii=False),
+        reviewer_model_id="test-reviewer",
+        reviewer_family="test-family",
+        route_name="test-route",
+        tool_call_count=1,
+        tools_used=("sources_query_wikipedia",),
+        tool_events=(
+            {
+                "tool": "sources_query_wikipedia",
+                "input": {"query": "Веснянки", "mode": "section"},
+                "status": "completed",
+                "tool_call_id": "call_1",
+                "output": "Веснянки — це весняні обрядові пісні.",
+            },
+        ),
+    )
+
+
+def _target(module_dir: Path) -> qg_workflow.ReviewTarget:
+    return qg_workflow.ReviewTarget(level="folk", slug="vesnianky-shadow", module_dir=module_dir)
+
+
+def _count(db_path: Path, table: str) -> int:
+    with sqlite3.connect(db_path) as conn:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+
+def test_shadow_driver_captures_lifecycle_and_advisory_verdicts(tmp_path: Path) -> None:
+    module_dir = _module(tmp_path)
+
+    result = qg_shadow_run.run_shadow_module(
+        _target(module_dir),
+        audit_dir=tmp_path / "audit",
+        shadow_db=tmp_path / "shadow.db",
+        author_family="openai",
+        reviewer=_dispatch,
+        live_reviewer=False,
+        reviewer_model_id="test-reviewer",
+        reviewer_family="test-family",
+        max_cost_usd=1.0,
+        layerb_dry_run=True,
+    )
+
+    artifact = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    report = json.loads(result.layerb_report_path.read_text(encoding="utf-8"))
+    evidence = result.markdown_path.read_text(encoding="utf-8")
+    assert artifact["schema_version"] == "qg_bakeoff_run.v2"
+    assert artifact["arm"] == "production_shadow"
+    assert artifact["writer_family"] == "openai"
+    assert artifact["dispatch"]["tool_events"][0]["output"] == "Веснянки — це весняні обрядові пісні."
+    assert artifact["payload"]["fact_checks"][0]["grounding"]["tool_call_id"] == "call_1"
+    assert artifact["retry_history"][0]["raw_response"]
+    assert report["configuration"]["tau"] == 0.75
+    assert report["records"]
+    assert "## Verdict rows" in evidence
+    assert _count(tmp_path / "shadow.db", "llm_qg_shadow_runs") == 1
+    assert _count(tmp_path / "shadow.db", "llm_qg_shadow_findings") == len(report["records"])
+
+
+def test_shadow_driver_never_writes_canonical_llm_qg_runs(tmp_path: Path) -> None:
+    module_dir = _module(tmp_path)
+    canonical_db = tmp_path / "llm_qg.db"
+    llm_qg_store.record_llm_qg(
+        level="folk",
+        slug="existing-canonical",
+        module_dir=module_dir,
+        payload={"findings": [], "fact_checks": [], "evidence_gaps": []},
+        gate_version="test.v1",
+        path=canonical_db,
+    )
+    before = _count(canonical_db, "llm_qg_runs")
+
+    qg_shadow_run.run_shadow_module(
+        _target(module_dir),
+        audit_dir=tmp_path / "audit",
+        shadow_db=tmp_path / "shadow.db",
+        author_family="openai",
+        reviewer=_dispatch,
+        live_reviewer=False,
+        reviewer_model_id="test-reviewer",
+        reviewer_family="test-family",
+        max_cost_usd=1.0,
+        layerb_dry_run=True,
+    )
+
+    assert _count(canonical_db, "llm_qg_runs") == before
+    assert _count(tmp_path / "shadow.db", "llm_qg_shadow_runs") == 1
+
+
+def test_shadow_driver_rejects_unresolvable_writer_lineage(tmp_path: Path) -> None:
+    module_dir = _module(tmp_path)
+
+    with pytest.raises(ValueError, match="writer lineage"):
+        qg_shadow_run.run_shadow_module(
+            _target(module_dir),
+            audit_dir=tmp_path / "audit",
+            shadow_db=tmp_path / "shadow.db",
+            reviewer=_dispatch,
+            live_reviewer=False,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+            max_cost_usd=1.0,
+            layerb_dry_run=True,
+        )


### PR DESCRIPTION
## Disposition

Implements #5186's production-shadow wiring. This PR is deliberately advisory-only and **does not enable auto-merge**; the orchestrator review gate remains separate.

## What changed

- Extracted `serialize_qg_run_v2(...)` and reused it from the offline bakeoff and production shadow driver.
- Added `qg_shadow_run.py`: fresh full-surface Tier-2 capture, real writer-lineage fail-closed check, replay artifact, pinned Layer-B `tau=0.75`, local evidence Markdown, and separate shadow SQLite run/findings store.
- Kept canonical `llm_qg_runs`, circuit outcomes, spend ledger, and module-local raw-response files untouched in shadow mode.
- Added serializer parity, shadow lifecycle, lineage rejection, and store-isolation tests.
- Documented the shadow runbook and prompt compatibility contract.

## Verifiable evidence

Bakeoff artifact parity, before/after refactor (same fixed fixture and clock):

```text
pre-refactor artifact sha256=0b06f32e84f99d8e5949b70b3bdf90eb96710d9a411465830f4bee06ce589b20
post-refactor artifact sha256=0b06f32e84f99d8e5949b70b3bdf90eb96710d9a411465830f4bee06ce589b20
```

Focused verification (`.venv/bin/python -m pytest ... -q`):

```text
collected 136 items
...
============================= 136 passed in 1.48s ==============================
```

Lint:

```text
.venv/bin/ruff check ...
All checks passed!
markdownlint-cli2 ... Summary: 0 error(s)
```

Cross-family independent review: AGY/Gemini review message `#2834` approved with no blockers; it specifically confirmed canonical-store isolation, artifact parity, fail-closed lineage, exact tau, attested-mode parameter checks, tests, and docs.

### End-to-end live capture disposition

I ran the approved seminar route MCP preflight successfully and attempted a fresh real canary for `folk` before the requested one-module `--layerb-dry-run` capture. The actual canary failed closed, so the driver correctly did **not** produce an artifact or verdict rows and I did not fabricate a passing canary or bypass the policy.

Raw result:

```text
/tmp/qg-shadow-5186-canary.json
{"passed": false, "missing_issue_ids": ["INTERNAL_LEAKAGE"]}
```

The full canary report identified all other required issue IDs but missed `INTERNAL_LEAKAGE`. The new driver's mocked-dispatch lifecycle test does produce the complete artifact → Layer-B dry report → verdict-row/store path; the real live E2E must be rerun after the existing canary gate passes.

Refs #5186
