### PR TITLE
fix(qg): define INTERNAL_LEAKAGE in the live reviewer prompt taxonomy

### DIFF
--- a/scripts/audit/prompts/reviewer_prompt.md
+++ b/scripts/audit/prompts/reviewer_prompt.md
@@ -141,6 +141,7 @@ Identify unidiomatic syntax or expressions, even if they are not lexical Russian
 ### B. Register and AI Leakage
 * **AI Personae & Leakage**: Look for phrases like "As an AI...", "Note to self", or internal pipeline commands. Flag as `AI_LEAKAGE` (`surface_leakage`, `critical`).
 * **Path Leakage**: Look for absolute paths (e.g., `/Users/...`, `/tmp/...`). Flag as `PATH_LEAKAGE` (`surface_leakage`, `critical`).
+* **Internal Leakage**: Look for internal project artifacts leaking into learner-facing text — repo-relative source/script paths (e.g., `scripts/audit/llm_qg.json`), internal gate or pipeline names, debug/build artifacts, issue/PR references. Flag as `INTERNAL_LEAKAGE` (`surface_leakage`, `critical`). Distinct from `PATH_LEAKAGE`: use `INTERNAL_LEAKAGE` when the leak names project internals (even without an absolute filesystem path); use `PATH_LEAKAGE` for generic filesystem paths. If a fragment is both (an absolute path to a project internal), flag both.
 
 ---
 


### PR DESCRIPTION
The `surface-internal-leakage` canary requires the live Tier-2 reviewer to emit `INTERNAL_LEAKAGE`, but the live reviewer prompt never defined that issue id (only `PATH_LEAKAGE` for absolute paths) — the model can't emit an id it was never given, so the canary could NEVER pass. This blocked the shadow driver's first live capture (#5191 proof run: 4/5 canaries found, `missing_issue_ids: [INTERNAL_LEAKAGE]`).

Ports the V7 dim prompt's combined definition (`linear-review-dim.md:305`) into `reviewer_prompt.md` with explicit PATH-vs-INTERNAL disambiguation.

Sibling check: Tier-0 deterministic classifier has no internal-leakage detector (canary targets the LLM tier by design); no issue-id allowlist blocks new ids (open fallback in `_surface_issue_id`).

**Merge evidence pending:** live canary re-run with the fixed prompt (after #5191 lands) — must show `INTERNAL_LEAKAGE` in `found_issue_ids` and `passed: true`; will be posted here before merge.

Refs #5186, #4531

🤖 Generated with [Claude Code](https://claude.com/claude-code)