### PR TITLE
fix(site): quiz/activity button contrast in light theme (#5192 §2)

### DIFF
--- a/packages/activity-kit/src/components/Activities.module.css
+++ b/packages/activity-kit/src/components/Activities.module.css
@@ -117,9 +117,11 @@
   text-align: left;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
   transition: all 0.2s ease;
+  font: inherit;
   font-size: 14px;
   font-weight: 500;
 }
@@ -252,9 +254,11 @@
   padding: 7px 14px;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
   transition: all 0.2s ease;
+  font: inherit;
   font-size: 14px;
   font-weight: 500;
 }
@@ -337,11 +341,18 @@
   padding: 5px 14px;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 6px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
+  font: inherit;
   font-size: 13px;
   font-weight: 600;
   transition: all 0.2s ease;
+}
+
+.tfButton.selected {
+  border-color: var(--ifm-color-primary);
+  background: var(--lu-state-active);
 }
 
 .tfButton:hover:not(:disabled) {
@@ -565,38 +576,53 @@
 }
 
 .submitButton,
-.resetButton {
+.resetButton,
+.checkButton,
+.retryButton {
   padding: 7px 20px;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
+  font: inherit;
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.submitButton {
+.submitButton,
+.checkButton {
   background: var(--ifm-color-primary);
-  color: white;
+  color: var(--lu-on-primary);
   border-color: var(--ifm-color-primary);
 }
 
-.submitButton:hover:not(:disabled) {
+.submitButton:hover:not(:disabled),
+.checkButton:hover:not(:disabled) {
   opacity: 0.9;
 }
 
-.submitButton:disabled {
+.submitButton:disabled,
+.checkButton:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.resetButton {
+.resetButton,
+.retryButton {
   background: var(--ifm-color-emphasis-200);
-  color: var(--ifm-font-color-base);
+  color: var(--lu-text);
 }
 
-.resetButton:hover {
+.resetButton:hover,
+.retryButton:hover {
   background: var(--ifm-color-emphasis-300);
+}
+
+.controls {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 1rem;
 }
 
 /* ============= GROUP SORT ============= */
@@ -797,8 +823,10 @@
   padding: 7px 14px;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
+  font: inherit;
   font-size: 14px;
   font-weight: 500;
   transition: all 0.2s ease;
@@ -877,15 +905,16 @@
 }
 
 .checkboxOption.missedAnswer {
-  border-color: #FBBC04 !important;
+  border-color: var(--lu-state-missed-border) !important;
   background: var(--lu-state-missed) !important;
+  color: var(--lu-state-missed-fg);
 }
 
 .checkboxOption.missedAnswer::after {
   content: '\2190 missed';
   margin-left: auto;
   font-size: 0.8rem;
-  color: #B06000;
+  color: var(--lu-state-missed-fg);
   font-weight: 600;
 }
 
@@ -941,9 +970,11 @@
   text-align: left;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
   transition: all 0.2s ease;
+  font: inherit;
   font-size: 14px;
 }
 
@@ -1849,6 +1880,7 @@
 
 .hotspotActive {
   background: var(--ifm-color-warning);
+  color: var(--lu-on-warning);
   transform: translate(-50%, -50%) scale(1.2);
   box-shadow: 0 0 0 4px rgba(255, 193, 7, 0.3);
 }
@@ -2133,8 +2165,8 @@
 }
 
 .scoreMedium {
-  background: rgba(251, 188, 4, 0.2);
-  color: #B06000;
+  background: var(--lu-state-missed);
+  color: var(--lu-state-missed-fg);
 }
 
 .scoreLow {
@@ -2488,7 +2520,7 @@
 
 [data-theme='dark'] .scoreMedium {
   background: var(--lu-state-missed);
-  color: var(--lu-text);
+  color: var(--lu-state-missed-fg);
 }
 
 [data-theme='dark'] .scoreLow {
@@ -2532,6 +2564,7 @@
 /* neutral · hover · selected → blue */
 [data-theme='dark'] .option:hover:not(:disabled),
 [data-theme='dark'] .option.selected,
+[data-theme='dark'] .tfButton.selected,
 [data-theme='dark'] .chip:hover,
 [data-theme='dark'] .blankDropZone:hover,
 [data-theme='dark'] .letterTile,
@@ -2607,4 +2640,5 @@
 [data-theme='dark'] .checkboxOption.missedAnswer,
 [data-theme='dark'] .transcriptionOriginal {
   background: var(--lu-state-missed);
+  color: var(--lu-state-missed-fg);
 }

--- a/site/src/components/Activities.module.css
+++ b/site/src/components/Activities.module.css
@@ -117,9 +117,11 @@
   text-align: left;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
   transition: all 0.2s ease;
+  font: inherit;
   font-size: 14px;
   font-weight: 500;
 }
@@ -252,9 +254,11 @@
   padding: 7px 14px;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
   transition: all 0.2s ease;
+  font: inherit;
   font-size: 14px;
   font-weight: 500;
 }
@@ -337,11 +341,18 @@
   padding: 5px 14px;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 6px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
+  font: inherit;
   font-size: 13px;
   font-weight: 600;
   transition: all 0.2s ease;
+}
+
+.tfButton.selected {
+  border-color: var(--ifm-color-primary);
+  background: var(--lu-state-active);
 }
 
 .tfButton:hover:not(:disabled) {
@@ -565,38 +576,53 @@
 }
 
 .submitButton,
-.resetButton {
+.resetButton,
+.checkButton,
+.retryButton {
   padding: 7px 20px;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
+  font: inherit;
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.submitButton {
+.submitButton,
+.checkButton {
   background: var(--ifm-color-primary);
-  color: white;
+  color: var(--lu-on-primary);
   border-color: var(--ifm-color-primary);
 }
 
-.submitButton:hover:not(:disabled) {
+.submitButton:hover:not(:disabled),
+.checkButton:hover:not(:disabled) {
   opacity: 0.9;
 }
 
-.submitButton:disabled {
+.submitButton:disabled,
+.checkButton:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.resetButton {
+.resetButton,
+.retryButton {
   background: var(--ifm-color-emphasis-200);
-  color: var(--ifm-font-color-base);
+  color: var(--lu-text);
 }
 
-.resetButton:hover {
+.resetButton:hover,
+.retryButton:hover {
   background: var(--ifm-color-emphasis-300);
+}
+
+.controls {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 1rem;
 }
 
 /* ============= GROUP SORT ============= */
@@ -797,8 +823,10 @@
   padding: 7px 14px;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
+  font: inherit;
   font-size: 14px;
   font-weight: 500;
   transition: all 0.2s ease;
@@ -877,15 +905,16 @@
 }
 
 .checkboxOption.missedAnswer {
-  border-color: #FBBC04 !important;
+  border-color: var(--lu-state-missed-border) !important;
   background: var(--lu-state-missed) !important;
+  color: var(--lu-state-missed-fg);
 }
 
 .checkboxOption.missedAnswer::after {
   content: '\2190 missed';
   margin-left: auto;
   font-size: 0.8rem;
-  color: #B06000;
+  color: var(--lu-state-missed-fg);
   font-weight: 600;
 }
 
@@ -941,9 +970,11 @@
   text-align: left;
   border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
-  background: white;
+  background: var(--ifm-card-background-color);
+  color: var(--lu-text);
   cursor: pointer;
   transition: all 0.2s ease;
+  font: inherit;
   font-size: 14px;
 }
 
@@ -1849,6 +1880,7 @@
 
 .hotspotActive {
   background: var(--ifm-color-warning);
+  color: var(--lu-on-warning);
   transform: translate(-50%, -50%) scale(1.2);
   box-shadow: 0 0 0 4px rgba(255, 193, 7, 0.3);
 }
@@ -2133,8 +2165,8 @@
 }
 
 .scoreMedium {
-  background: rgba(251, 188, 4, 0.2);
-  color: #B06000;
+  background: var(--lu-state-missed);
+  color: var(--lu-state-missed-fg);
 }
 
 .scoreLow {
@@ -2488,7 +2520,7 @@
 
 [data-theme='dark'] .scoreMedium {
   background: var(--lu-state-missed);
-  color: var(--lu-text);
+  color: var(--lu-state-missed-fg);
 }
 
 [data-theme='dark'] .scoreLow {
@@ -2532,6 +2564,7 @@
 /* neutral · hover · selected → blue */
 [data-theme='dark'] .option:hover:not(:disabled),
 [data-theme='dark'] .option.selected,
+[data-theme='dark'] .tfButton.selected,
 [data-theme='dark'] .chip:hover,
 [data-theme='dark'] .blankDropZone:hover,
 [data-theme='dark'] .letterTile,
@@ -2607,4 +2640,5 @@
 [data-theme='dark'] .checkboxOption.missedAnswer,
 [data-theme='dark'] .transcriptionOriginal {
   background: var(--lu-state-missed);
+  color: var(--lu-state-missed-fg);
 }

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -55,6 +55,10 @@
   --lu-state-wrong-bg: rgba(198,40,40,.08);
   --lu-state-wrong-fg: #C62828;
   --lu-state-missed: rgba(251,188,4,.15);
+  /* Amber missed-state pair — never use raw --co-warning / #FBBC04 as text on white. */
+  --lu-state-missed-fg: #6B4A0A;
+  --lu-state-missed-border: #9A6700;
+  --lu-on-warning: #1A1A1A;
   --lu-state-drag: rgba(106,27,154,.08);
   --lu-match-right: rgba(230,81,0,.08);
 
@@ -123,6 +127,13 @@
   --ifm-color-primary-lighter: #0066d3;
   --ifm-color-primary-lightest: #1A73E8;
 
+  --ifm-color-success: var(--co-success);
+  --ifm-color-success-dark: #1B5E20;
+  --ifm-color-warning: var(--co-warning);
+  --ifm-color-warning-dark: var(--lu-state-missed-fg);
+  --ifm-color-danger: var(--co-error);
+  --ifm-color-danger-dark: #B71C1C;
+
   --ifm-font-family-base: 'Noto Sans', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --ifm-heading-font-family: 'Noto Sans', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --ifm-font-size-base: 16px;
@@ -159,6 +170,9 @@
   --lu-state-wrong-bg: rgba(210,70,70,.26);
   --lu-state-wrong-fg: #F28B82;
   --lu-state-missed: rgba(251,188,4,.22);
+  --lu-state-missed-fg: #FFC971;
+  --lu-state-missed-border: #FFB300;
+  --lu-on-warning: #1A1A1A;
   --lu-state-drag: rgba(167,130,224,.18);
   --lu-match-right: rgba(230,145,56,.20);
 
@@ -207,6 +221,13 @@
   --ifm-color-primary-light: #70a6da;
   --ifm-color-primary-lighter: #7baedc;
   --ifm-color-primary-lightest: #9fc4e6;
+
+  --ifm-color-success: var(--co-success);
+  --ifm-color-success-dark: #81C995;
+  --ifm-color-warning: var(--co-warning);
+  --ifm-color-warning-dark: var(--lu-state-missed-fg);
+  --ifm-color-danger: var(--co-error);
+  --ifm-color-danger-dark: #F28B82;
 
   --ifm-background-color: #0f0f1a;
   --ifm-background-surface-color: #1a1a2e;

--- a/site/src/styles/course.css
+++ b/site/src/styles/course.css
@@ -1226,7 +1226,8 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--lu-yellow-dark);
+  /* --lu-yellow-dark (#E6B800) fails WCAG AA on --lu-yellow-light (1.77:1). */
+  color: var(--lu-on-yellow);
 }
 
 .rule-box-icon {


### PR DESCRIPTION
## Summary

Fixes #5192 §2 — quiz/activity choice buttons and amber state labels that rendered yellow/amber text on white in light theme, failing WCAG AA (4.5:1).

Root cause: choice buttons (`.option`, `.tfButton`, etc.) had `background: white` with **no explicit `color`**, so inherited/yellow accent tokens could leak through; missed-state and warning surfaces used raw `#FBBC04` / `#B06000` / `--lu-yellow-dark` as foreground on light backgrounds.

## #M-4 — selectors + color pairs

### Primary quiz/TrueFalse buttons (before)

```css
.option {
  background: white;          /* no color — inherited/browser default */
}
.tfButton {
  background: white;          /* no color; .tfButton.selected was missing */
}
```

### Primary quiz/TrueFalse buttons (after)

```css
.option {
  background: var(--ifm-card-background-color);
  color: var(--lu-text);      /* #1c1e21 on #ffffff */
  font: inherit;
}
.tfButton {
  background: var(--ifm-card-background-color);
  color: var(--lu-text);
  font: inherit;
}
.tfButton.selected { … }       /* mirrors .option.selected */
```

Also wired: `.chip`, `.translateOption`, `.noErrorButton`, `.checkButton`/`.retryButton`/`.controls`, `.hotspotActive`, `.scoreMedium`, `.checkboxOption.missedAnswer`.

### Token definitions (`site/src/css/custom.css`)

```css
:root {
  --lu-state-missed-fg: #6B4A0A;
  --lu-state-missed-border: #9A6700;
  --lu-on-warning: #1A1A1A;
  --ifm-color-warning: var(--co-warning);
}
[data-theme='dark'] {
  --lu-state-missed-fg: #FFC971;
  --lu-state-missed-border: #FFB300;
}
```

## Contrast ratios (computed, WCAG AA normal text ≥ 4.5:1)

| Pair | Before | After |
|------|--------|-------|
| `#FFD700` / `#FFFFFF` (`--lu-accent` on white) | **1.40:1 FAIL** | — |
| `#E6B800` / `#FFFFFF` (`--lu-yellow-dark` on white) | **1.87:1 FAIL** | — |
| `#FBBC04` / `#FFFFFF` (`--co-warning` as text) | **1.71:1 FAIL** | — |
| `#B06000` / `#FFF8E6` (missed label) | **4.39:1 FAIL** | — |
| `#212121` / `#FFFFFF` (`--lu-text` on card) | — | **16.10:1 PASS** |
| `#6B4A0A` / `#FFF8E6` (`--lu-state-missed-fg`) | — | **7.60:1 PASS** |
| `#1A1A1A` / `#FBBC04` (`--lu-on-warning` on warning bg) | — | **10.19:1 PASS** |
| `#FFC971` / dark missed bg (dark theme) | — | **8.71:1 PASS** |
| `#E8E8E8` / `#1A1A1A` (dark `--lu-text` on card) | — | **14.20:1 PASS** |

## Theme verification (built CSS grep — no visual claim)

**Light (`:root` tokens in `dist/_astro/CourseLayout.*.css`):**
- `--lu-text:#1c1e21`, `--lu-state-missed-fg:#6b4a0a`, `--lu-on-warning:#1a1a1a`, `--ifm-color-warning:var(--co-warning)`

**Emitted activity rules (`dist/_astro/starlight-compat.*.css`):**
```
._option_…{background:var(--ifm-card-background-color);color:var(--lu-text);…}
._tfButton_…{background:var(--ifm-card-background-color);color:var(--lu-text);…}
._hotspotActive_…{background:var(--ifm-color-warning);color:var(--lu-on-warning);…}
._scoreMedium_…{background:var(--lu-state-missed);color:var(--lu-state-missed-fg)}
```

**Dark (`[data-theme=dark]` in same bundles):**
- `--lu-state-missed-fg:#ffc971`, `--lu-text:#e3e3e3`
- `[data-theme=dark] ._option_…, [data-theme=dark] ._tfButton_…` → `background:var(--ifm-background-color)`
- `[data-theme=dark] ._tfButton_…._selected_…` included in active-state group
- `[data-theme=dark] ._scoreMedium_…{color:var(--lu-state-missed-fg)}`

## Test plan

- [x] `npm run build` in `site/` — **8973 pages built, Complete!**
- [x] `npm run test -- tests/unit/Quiz.test.tsx tests/unit/TrueFalse.test.tsx` — **44 passed**
- [x] `lint_agent_trailer.py` — PASS
- [ ] Cross-family review (not self-merge; **auto-merge NOT armed**)

Refs #5192

Made with [Cursor](https://cursor.com)