### PR TITLE
chore(gitignore): ignore audit/local-qg-shadow/ (local-only shadow evidence was blocking fleet dispatches)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,11 @@ audit/*-qg-bakeoff*/*.json
 # (audit/2026-07-07-*/, audit/2026-07-08-*/): every NEW dated dir was an
 # untracked-write guard landmine until someone extended this file by hand.
 audit/20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*/
+# QG shadow-driver per-module evidence is local-only BY DESIGN (#5186 point 5:
+# "Per-module MD = local evidence, not committed"). The driver writes here in
+# the primary checkout, so without this line every write-capable dispatch in
+# the fleet is blocked by the untracked-write guard while a shadow run exists.
+audit/local-qg-shadow/
 
 
 # Python


### PR DESCRIPTION
## What

One line: gitignore `audit/local-qg-shadow/`.

## Why (root cause, observed live)

The #5186 production shadow driver writes per-module capture evidence into `audit/local-qg-shadow/<module-hash>/` in the **primary checkout**. The fleet-reviewed design says this is local evidence, not committed (issue #5186, point 5: "Per-module MD = local evidence, not committed") — but the dir was never added to `.gitignore`.

Consequence: while any shadow run's artifacts exist, the primary checkout reads untracked-dirty and the dispatch pre-flight guard refuses **every write-capable dispatch in the fleet**:

```
❌ primary checkout is dirty; refusing write-capable dispatch …
   dirty files: ?? audit/local-qg-shadow/folk-vesnianky-hayivky-…/artifacts/qg-shadow-run.json, …
```

Two consecutive dispatches bounced on this tonight (2026-07-14 ~22:40Z). Same landmine class as the dated-audit-dir entries at `.gitignore:60-65`, fixed the same way, adjacent to them.

Local `.git/info/exclude` is not an option — the primary-checkout write guard (correctly) blocks writing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)