### PR TITLE
fix(ci): E2E playwright venv missing jsonschema — advisory check always red on frontend PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -934,7 +934,9 @@ jobs:
       run: |
         python -m venv .venv
         .venv/bin/python -m pip install --upgrade pip
-        .venv/bin/python -m pip install PyYAML
+        # jsonschema: `npm run build` imports scripts/audit via meta_validator —
+        # keep this list in sync with the `frontend` job's venv above.
+        .venv/bin/python -m pip install PyYAML jsonschema
 
     - name: Restore Atlas lexicon manifest cache
       id: atlas-manifest-cache


### PR DESCRIPTION
## What

One word: the E2E playwright job's venv now installs `PyYAML jsonschema` (mirroring the `frontend` job), plus a sync comment.

## Why

`npm run build` in the E2E preview step imports the audit core chain (`scripts/audit/core.py` → `phases_gates.py` → `checks/meta_validator.py` → `import jsonschema`). The E2E venv only had PyYAML, so the job died at build, before any Playwright test ran — every frontend-touching PR showed a red advisory check (observed on #5172, CI run 29373383574):

```
File ".../scripts/audit/checks/meta_validator.py", line 11, in <module>
    import jsonschema
ModuleNotFoundError: No module named 'jsonschema'
```

The check is advisory (excluded from CI Gate, ci.yml:1003) so nothing was blocked — but a permanently-red check is alarm-fatigue debt and hides real E2E regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)