### PR TITLE
feat(harness): grok judge family in layerb bridge

### DIFF
--- a/scripts/audit/layerb_judge_bridge.py
+++ b/scripts/audit/layerb_judge_bridge.py
@@ -14,6 +14,13 @@ shared adapter deliberately has more recovery behavior than this boundary may
 allow.  ``codex exec`` accepts one prompt, so this bridge uses the documented
 flattened-prompt mitigation set for the lean qualification only.
 
+The qualified Grok Build route invokes the native ``grok`` CLI directly.  It
+uses a fresh ``GROK_HOME`` with only its OAuth credential, an empty built-in
+tool allowlist, an MCP deny rule, and a caller-supplied fresh session UUID.
+The native CLI persists that exact session's authoritative ``updates.jsonl``
+and detailed ``events.jsonl`` under the scoped home; both must be complete
+strict JSONL, tool-free, and model-pinned before a response is accepted.
+
 The Gemini family deliberately remains fail-closed.  Agy's ``--log-file``
 does not itself record every tool event (the existing runtime must locate a
 separate per-conversation transcript from it), so it cannot yet satisfy this
@@ -31,11 +38,13 @@ import re
 import subprocess
 import sys
 import tempfile
+import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 if __package__ in {None, ""}:
     project_root = Path(__file__).resolve().parents[2]
@@ -45,10 +54,11 @@ if __package__ in {None, ""}:
 from scripts.agent_runtime.tool_calls import normalize_tool_calls, parse_json_events
 from scripts.audit import layerb_shadow
 
-BRIDGE_VERSION = "qg-layer-b-judge-bridge.v4"
+BRIDGE_VERSION = "qg-layer-b-judge-bridge.v5"
 PROMPT_TEMPLATE_VERSION = "qg-layer-b-judge-bridge-prompt.v2-flattened"
 DEFAULT_MODELS = {
     "codex": "gpt-5.6-terra",
+    "grok": "grok-build",
     "gemini": "gemini-3.5-flash-high",
 }
 CODEX_DISABLED_FEATURES = (
@@ -67,6 +77,13 @@ CODEX_DISABLED_FEATURES = (
     "tool_suggest",
 )
 CODEX_CONFIG_OVERRIDES = ("web_search=disabled", "tools.view_image=false")
+GROK_DISABLED_FEATURES = ("Agent",)
+GROK_DENY_RULES = ("MCPTool",)
+GROK_CONFIG_FLAGS = ("--disable-web-search", "--no-memory", "--no-subagents")
+GROK_TOOL_EVENT_TYPES = frozenset(
+    {"tool_started", "tool_completed", "tool_failed", "permission_requested", "permission_resolved"}
+)
+GROK_TRACE_TOOL_KEYS = frozenset({"toolcall", "toolcalls", "toolcallid", "toolname", "functioncall"})
 _TRACE_ACTIVITY_RE = re.compile(
     r"(?:^|[^a-z0-9])(tool|function|mcp|web|browser|terminal|shell|computer)(?:$|[^a-z0-9])", re.I
 )
@@ -195,21 +212,45 @@ class BridgeConfig:
     def transport(self) -> str:
         if self.family == "codex":
             return "codex-subscription-isolated.v1"
+        if self.family == "grok":
+            return "grok-build-subscription-traced.v1"
         if self.family == "gemini":
             return "agy-subscription-unqualified.v1"
         raise BridgeInputError(f"unknown judge family {self.family!r}")
 
     def material(self) -> dict[str, Any]:
-        argv_template = (
-            build_codex_judge_argv(
+        if self.family == "codex":
+            argv_template = build_codex_judge_argv(
                 config=self,
                 scratch_dir=Path("{fresh-empty-scratch-dir}"),
                 schema_path=Path("{strict-output-schema-path}"),
                 output_path=Path("{output-last-message-path}"),
             )
-            if self.family == "codex"
-            else None
-        )
+        elif self.family == "grok":
+            argv_template = build_grok_judge_argv(
+                config=self,
+                scratch_dir=Path("{fresh-empty-scratch-dir}"),
+                session_id="{fresh-session-uuid}",
+                prompt="{flattened-judge-prompt}",
+            )
+        else:
+            argv_template = None
+        scoped_home = self.family in {"codex", "grok"}
+        if self.family == "codex":
+            tool_enforcement = "CLI disabled-features + scoped no-MCP home + fail-closed trace screen"
+            disabled_features = list(CODEX_DISABLED_FEATURES)
+            config_overrides = list(CODEX_CONFIG_OVERRIDES)
+        elif self.family == "grok":
+            tool_enforcement = (
+                "empty built-in CLI allowlist + Agent/MCP deny rules + scoped no-MCP GROK_HOME "
+                "+ fail-closed authoritative updates/events trace screen"
+            )
+            disabled_features = list(GROK_DISABLED_FEATURES)
+            config_overrides = list(GROK_CONFIG_FLAGS)
+        else:
+            tool_enforcement = "unqualified transport is never invoked"
+            disabled_features = []
+            config_overrides = []
         return {
             "bridge_version": BRIDGE_VERSION,
             "family": self.family,
@@ -224,18 +265,28 @@ class BridgeConfig:
                 "argv_template": argv_template,
                 "argv_sha256": _sha256_json(argv_template) if argv_template is not None else None,
                 "scoped_codex_home": self.family == "codex",
+                "scoped_grok_home": self.family == "grok",
                 "minimal_config_has_mcp_servers": False,
-                "auth": "user-auth.json symlink only" if self.family == "codex" else "not invoked",
-                "trace_tool_screen": self.family == "codex",
+                "auth": "user-auth.json symlink only" if scoped_home else "not invoked",
+                "trace_tool_screen": scoped_home,
+                "trace_evidence": (
+                    "fresh scoped Codex rollout JSONL"
+                    if self.family == "codex"
+                    else "fresh UUID session authoritative updates.jsonl plus events.jsonl"
+                    if self.family == "grok"
+                    else None
+                ),
                 "tokens": None,
                 "token_accounting": "collector records configured byte-bound worst case when seat tokens are unavailable",
             },
             "tool_access": {
                 "enabled": False,
                 "mcp": False,
-                "enforcement": "CLI disabled-features + scoped no-MCP home + fail-closed trace screen",
-                "disabled_features": list(CODEX_DISABLED_FEATURES) if self.family == "codex" else [],
-                "config_overrides": list(CODEX_CONFIG_OVERRIDES) if self.family == "codex" else [],
+                "enforcement": tool_enforcement,
+                "disabled_features": disabled_features,
+                "config_overrides": config_overrides,
+                "builtin_tool_allowlist": [] if self.family == "grok" else None,
+                "deny_rules": list(GROK_DENY_RULES) if self.family == "grok" else [],
             },
             "determinism": {
                 "reasoning_effort": None,
@@ -537,6 +588,39 @@ def build_codex_judge_argv(
     return argv
 
 
+def build_grok_judge_argv(*, config: BridgeConfig, scratch_dir: Path, session_id: str, prompt: str) -> list[str]:
+    """Build the complete native Grok CLI command with a zero-tool policy."""
+
+    argv = [
+        "grok",
+        "-p",
+        prompt,
+        "--output-format",
+        "json",
+        "--json-schema",
+        _canonical_json(output_json_schema()),
+        "--no-alt-screen",
+        "--verbatim",
+        "--max-turns",
+        "1",
+        "--cwd",
+        str(scratch_dir),
+        "--session-id",
+        session_id,
+        "-m",
+        config.model,
+        "--tools",
+        "",
+        "--disallowed-tools",
+        ",".join(GROK_DISABLED_FEATURES),
+    ]
+    for flag in GROK_CONFIG_FLAGS:
+        argv.append(flag)
+    for rule in GROK_DENY_RULES:
+        argv.extend(("--deny", rule))
+    return argv
+
+
 def _prepare_scoped_codex_home(scoped_home: Path) -> None:
     """Create a no-MCP Codex home with only a live link to user authentication."""
 
@@ -546,6 +630,20 @@ def _prepare_scoped_codex_home(scoped_home: Path) -> None:
         encoding="utf-8",
     )
     real_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+    real_auth = real_home / "auth.json"
+    if real_auth.is_file():
+        (scoped_home / "auth.json").symlink_to(real_auth)
+
+
+def _prepare_scoped_grok_home(scoped_home: Path) -> None:
+    """Create a fresh Grok home with no configured MCP/plugins and live OAuth."""
+
+    scoped_home.mkdir(parents=True, exist_ok=False)
+    (scoped_home / "config.toml").write_text(
+        "# Layer-B judge scoped home: intentionally no MCP or plugin configuration.\n",
+        encoding="utf-8",
+    )
+    real_home = Path(os.environ.get("GROK_HOME") or Path.home() / ".grok")
     real_auth = real_home / "auth.json"
     if real_auth.is_file():
         (scoped_home / "auth.json").symlink_to(real_auth)
@@ -631,6 +729,129 @@ def _resolved_models(events: Sequence[Mapping[str, Any]]) -> set[str]:
     return models
 
 
+def _read_strict_json_object(path: Path) -> dict[str, Any]:
+    """Read one required trace object without accepting malformed JSON."""
+
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BridgeInvocationError("transport_exit") from exc
+    if not isinstance(value, Mapping):
+        raise BridgeInvocationError("transport_exit")
+    return dict(value)
+
+
+def _read_strict_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a non-empty complete JSONL trace or fail the transport closed."""
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise BridgeInvocationError("transport_exit") from exc
+    events: list[dict[str, Any]] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise BridgeInvocationError("transport_exit") from exc
+        if not isinstance(value, Mapping):
+            raise BridgeInvocationError("transport_exit")
+        events.append(dict(value))
+    if not events:
+        raise BridgeInvocationError("transport_exit")
+    return events
+
+
+def _grok_session_dir(scoped_home: Path, scratch_dir: Path, session_id: str) -> Path:
+    """Return the documented Grok session directory for this fresh invocation."""
+
+    return scoped_home / "sessions" / quote(str(scratch_dir), safe="") / session_id
+
+
+def _value_has_grok_tool_activity(value: Any) -> bool:
+    """Detect a tool-call shape in Grok's authoritative update stream."""
+
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+            if normalized_key in GROK_TRACE_TOOL_KEYS:
+                if isinstance(nested, (list, tuple, Mapping)):
+                    if nested:
+                        return True
+                elif nested:
+                    return True
+            if _value_has_grok_tool_activity(nested):
+                return True
+    elif isinstance(value, (list, tuple)):
+        return any(_value_has_grok_tool_activity(item) for item in value)
+    return False
+
+
+def _grok_trace_has_tool_activity(*, updates: Sequence[Mapping[str, Any]], events: Sequence[Mapping[str, Any]]) -> bool:
+    """Screen both documented Grok traces for any attempted tool use."""
+
+    if normalize_tool_calls(list(updates)):
+        return True
+    for update in updates:
+        event_type = str(update.get("type", "")).lower()
+        if "tool" in event_type or "function" in event_type or _value_has_grok_tool_activity(update):
+            return True
+    for event in events:
+        event_type = str(event.get("type", "")).lower()
+        if event_type in GROK_TOOL_EVENT_TYPES:
+            return True
+        tool_name = event.get("tool_name")
+        if isinstance(tool_name, str) and tool_name.strip():
+            return True
+        if _value_has_grok_tool_activity(event):
+            return True
+    return False
+
+
+def _strict_grok_stdout(stdout: str, *, expected_session_id: str) -> str:
+    """Require the one documented Grok JSON envelope for the planned session."""
+
+    try:
+        value = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise BridgeInvocationError("output_decode") from exc
+    if not isinstance(value, Mapping):
+        raise BridgeInvocationError("output_decode")
+    text = value.get("text")
+    if not isinstance(text, str) or not text.strip():
+        raise BridgeInvocationError("output_missing")
+    if value.get("sessionId") != expected_session_id:
+        raise BridgeInvocationError("transport_exit")
+    if not isinstance(value.get("stopReason"), str) or not isinstance(value.get("requestId"), str):
+        raise BridgeInvocationError("output_decode")
+    return text
+
+
+def _validate_grok_trace(*, config: BridgeConfig, scoped_home: Path, scratch_dir: Path, session_id: str) -> None:
+    """Validate one fresh session's documented tool and model evidence."""
+
+    session_dir = _grok_session_dir(scoped_home, scratch_dir, session_id)
+    summary = _read_strict_json_object(session_dir / "summary.json")
+    if summary.get("grok_home") != str(scoped_home):
+        raise BridgeInvocationError("transport_exit")
+    if summary.get("current_model_id") != config.model_version:
+        raise BridgeInvocationError("model_pin")
+    events = _read_strict_jsonl(session_dir / "events.jsonl")
+    updates = _read_strict_jsonl(session_dir / "updates.jsonl")
+    turns_started = [event for event in events if event.get("type") == "turn_started"]
+    turns_ended = [event for event in events if event.get("type") == "turn_ended"]
+    if len(turns_started) != 1 or len(turns_ended) != 1:
+        raise BridgeInvocationError("transport_exit")
+    if turns_started[0].get("session_id") != session_id:
+        raise BridgeInvocationError("transport_exit")
+    if turns_started[0].get("model_id") != config.model_version:
+        raise BridgeInvocationError("model_pin")
+    if _grok_trace_has_tool_activity(updates=updates, events=events):
+        raise BridgeInvocationError("rollout_tool_activity")
+
+
 def invoke_codex(parsed: ParsedRequest, config: BridgeConfig) -> ModelResult:
     """Run one strict schema Codex subscription-seat judge invocation."""
 
@@ -672,6 +893,43 @@ def invoke_codex(parsed: ParsedRequest, config: BridgeConfig) -> ModelResult:
         models = _resolved_models(events)
         if models != {config.model_version}:
             raise BridgeInvocationError("model_pin")
+        return ModelResult(text=text)
+
+
+def invoke_grok(parsed: ParsedRequest, config: BridgeConfig) -> ModelResult:
+    """Run one strict-schema Grok Build subscription-seat judge invocation."""
+
+    with tempfile.TemporaryDirectory(prefix="layerb-grok-judge-") as temp_dir:
+        root = Path(temp_dir)
+        scratch_dir = root / "scratch"
+        scratch_dir.mkdir()
+        scoped_home = root / "grok-home"
+        session_id = str(uuid.uuid4())
+        _prepare_scoped_grok_home(scoped_home)
+        environment = dict(os.environ)
+        environment["GROK_HOME"] = str(scoped_home)
+        completed = subprocess.run(
+            build_grok_judge_argv(
+                config=config,
+                scratch_dir=scratch_dir,
+                session_id=session_id,
+                prompt=build_codex_prompt(parsed),
+            ),
+            text=True,
+            capture_output=True,
+            timeout=config.timeout_seconds,
+            check=False,
+            env=environment,
+        )
+        if completed.returncode != 0:
+            raise BridgeInvocationError("transport_exit")
+        text = _strict_grok_stdout(completed.stdout, expected_session_id=session_id)
+        _validate_grok_trace(
+            config=config,
+            scoped_home=scoped_home,
+            scratch_dir=scratch_dir,
+            session_id=session_id,
+        )
         return ModelResult(text=text)
 
 
@@ -726,6 +984,8 @@ def run_bridge(request: Mapping[str, Any], config: BridgeConfig) -> dict[str, An
             )
         if config.family == "codex":
             model_result = invoke_codex(parsed, config)
+        elif config.family == "grok":
+            model_result = invoke_grok(parsed, config)
         elif config.family == "gemini":
             # TODO: qualify an agy trace source that records every tool event,
             # then add the agy subscription transport in the immediate follow-up.

--- a/scripts/audit/layerb_judge_bridge.py
+++ b/scripts/audit/layerb_judge_bridge.py
@@ -104,7 +104,20 @@ CONSERVATIVE_REASONS = frozenset(
         "model_pin",
         "envelope_alignment",
         "trace_missing",
+        "trace_unrecognized",
     }
+)
+
+# Closed allowlists of the benign trace shapes this grok CLI version writes for
+# a single tool-disabled judge turn (inventoried from live traces, 2 independent
+# runs, 2026-07-15 — PR #5200). ANY record outside these shapes makes the trace
+# unprovable-tool-free and fails closed as trace_unrecognized: the screen is an
+# allowlist, not a blocklist, so unknown future shapes can never pass silently.
+GROK_EVENT_TYPES_BENIGN = frozenset({"turn_started", "loop_started", "first_token", "phase_changed", "turn_ended"})
+GROK_PHASES_BENIGN = frozenset({"waiting_for_model", "streaming_reasoning", "streaming_text"})
+GROK_UPDATE_METHODS_BENIGN = frozenset({"session/update", "_x.ai/session/update"})
+GROK_SESSION_UPDATES_BENIGN = frozenset(
+    {"user_message_chunk", "agent_thought_chunk", "agent_message_chunk", "turn_completed"}
 )
 
 # This template is intentionally static. Raw tool output is inserted only in
@@ -832,6 +845,66 @@ def _grok_trace_has_tool_activity(*, updates: Sequence[Mapping[str, Any]], event
     return False
 
 
+def _grok_events_allowlisted(events: Sequence[Mapping[str, Any]]) -> bool:
+    """Accept only the closed set of benign single-turn event shapes."""
+
+    for event in events:
+        event_type = event.get("type")
+        if event_type not in GROK_EVENT_TYPES_BENIGN:
+            return False
+        if event_type == "phase_changed" and event.get("phase") not in GROK_PHASES_BENIGN:
+            return False
+    return True
+
+
+def _grok_updates_allowlisted(updates: Sequence[Mapping[str, Any]]) -> bool:
+    """Accept only the documented ACP session/update record shapes."""
+
+    for record in updates:
+        if record.get("method") not in GROK_UPDATE_METHODS_BENIGN:
+            return False
+        params = record.get("params")
+        if not isinstance(params, Mapping):
+            return False
+        update = params.get("update")
+        if not isinstance(update, Mapping):
+            return False
+        if update.get("sessionUpdate") not in GROK_SESSION_UPDATES_BENIGN:
+            return False
+    return True
+
+
+# _TRACE_MODEL_KEYS mixes raw and normalized spellings; normalize the set once
+# so keys like "model_id" (→ "modelid") actually match after normalization.
+_NORMALIZED_TRACE_MODEL_KEYS = frozenset(re.sub(r"[^a-z0-9]", "", key) for key in _TRACE_MODEL_KEYS)
+
+
+def _collect_grok_trace_models(value: Any, models: set[str]) -> None:
+    """Collect every model identifier recorded anywhere in a trace value."""
+
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+            if normalized_key in _NORMALIZED_TRACE_MODEL_KEYS and isinstance(nested, str) and nested.strip():
+                models.add(nested.strip())
+            if normalized_key == "modelusage" and isinstance(nested, Mapping):
+                models.update(str(model_key) for model_key in nested)
+            _collect_grok_trace_models(nested, models)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _collect_grok_trace_models(item, models)
+
+
+def _grok_trace_models(*, updates: Sequence[Mapping[str, Any]], events: Sequence[Mapping[str, Any]]) -> set[str]:
+    """Return the set of model identifiers attested across both traces."""
+
+    models: set[str] = set()
+    for stream in (events, updates):
+        for record in stream:
+            _collect_grok_trace_models(record, models)
+    return models
+
+
 def _strict_grok_stdout(stdout: str, *, expected_session_id: str) -> str:
     """Require the one documented Grok JSON envelope for the planned session."""
 
@@ -870,8 +943,19 @@ def _validate_grok_trace(*, config: BridgeConfig, scoped_home: Path, scratch_dir
         raise BridgeInvocationError("transport_exit")
     if turns_started[0].get("model_id") != config.model_version:
         raise BridgeInvocationError("model_pin")
+    # Known-bad screen first (specific reason), then the closed allowlist:
+    # a trace record outside the inventoried benign shapes is unprovable
+    # tool-free and must fail closed rather than pass unrecognized.
     if _grok_trace_has_tool_activity(updates=updates, events=events):
         raise BridgeInvocationError("rollout_tool_activity")
+    if not _grok_events_allowlisted(events) or not _grok_updates_allowlisted(updates):
+        raise BridgeInvocationError("trace_unrecognized")
+    # Every model identifier attested anywhere in either trace must be the
+    # pinned model — mirrors the Codex _resolved_models whole-trace sweep so a
+    # mid-session fallback recorded outside turn_started cannot pass the pin.
+    trace_models = _grok_trace_models(updates=updates, events=events)
+    if trace_models and trace_models != {config.model_version}:
+        raise BridgeInvocationError("model_pin")
 
 
 def invoke_codex(parsed: ParsedRequest, config: BridgeConfig) -> ModelResult:

--- a/scripts/audit/layerb_judge_bridge.py
+++ b/scripts/audit/layerb_judge_bridge.py
@@ -644,9 +644,13 @@ def _prepare_scoped_grok_home(scoped_home: Path) -> None:
         encoding="utf-8",
     )
     real_home = Path(os.environ.get("GROK_HOME") or Path.home() / ".grok")
-    real_auth = real_home / "auth.json"
-    if real_auth.is_file():
-        (scoped_home / "auth.json").symlink_to(real_auth)
+    # Empirical minimal sign-in set (probed 2026-07-15 with live auth): the grok
+    # CLI requires BOTH auth.json and agent_id; auth.json alone reports
+    # "Not signed in". Session state is deliberately NOT linked (isolation).
+    for credential in ("auth.json", "agent_id"):
+        source = real_home / credential
+        if source.is_file():
+            (scoped_home / credential).symlink_to(source)
 
 
 def _rollout_trace(scoped_home: Path) -> str:
@@ -920,6 +924,10 @@ def invoke_grok(parsed: ParsedRequest, config: BridgeConfig) -> ModelResult:
             timeout=config.timeout_seconds,
             check=False,
             env=environment,
+            # The grok CLI keys its session trace directory by WORKING DIRECTORY
+            # (urlencoded path under sessions/). _validate_grok_trace looks under
+            # the scratch key, so the invocation must actually run there.
+            cwd=scratch_dir,
         )
         if completed.returncode != 0:
             raise BridgeInvocationError("transport_exit")

--- a/scripts/audit/layerb_judge_bridge.py
+++ b/scripts/audit/layerb_judge_bridge.py
@@ -103,6 +103,7 @@ CONSERVATIVE_REASONS = frozenset(
         "rollout_tool_activity",
         "model_pin",
         "envelope_alignment",
+        "trace_missing",
     }
 )
 
@@ -738,6 +739,12 @@ def _read_strict_json_object(path: Path) -> dict[str, Any]:
 
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        # An absent trace file is a distinct evidence failure, not a transport
+        # exit: the transport already returned rc=0 by the time traces are
+        # read. Folding it into transport_exit cost three live diagnosis
+        # loops on 2026-07-14/15 (PR #5200).
+        raise BridgeInvocationError("trace_missing") from exc
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise BridgeInvocationError("transport_exit") from exc
     if not isinstance(value, Mapping):
@@ -750,6 +757,8 @@ def _read_strict_jsonl(path: Path) -> list[dict[str, Any]]:
 
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError as exc:
+        raise BridgeInvocationError("trace_missing") from exc
     except (OSError, UnicodeDecodeError) as exc:
         raise BridgeInvocationError("transport_exit") from exc
     events: list[dict[str, Any]] = []
@@ -769,9 +778,18 @@ def _read_strict_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 def _grok_session_dir(scoped_home: Path, scratch_dir: Path, session_id: str) -> Path:
-    """Return the documented Grok session directory for this fresh invocation."""
+    """Return the documented Grok session directory for this fresh invocation.
 
-    return scoped_home / "sessions" / quote(str(scratch_dir), safe="") / session_id
+    The native CLI keys the session store by its REAL working directory —
+    symlinks resolved. On macOS every tempfile root is behind a symlink
+    (``/tmp`` and ``/var`` both point into ``/private``), so deriving the key
+    from the unresolved path can never match what the CLI writes. Proven
+    empirically on CLI 0.2.101 (PR #5200 debug, 2026-07-15): the CLI wrote
+    ``sessions/%2Fprivate%2Ftmp%2F...`` while the unresolved derivation
+    looked for ``sessions/%2Ftmp%2F...``.
+    """
+
+    return scoped_home / "sessions" / quote(str(Path(scratch_dir).resolve()), safe="") / session_id
 
 
 def _value_has_grok_tool_activity(value: Any) -> bool:

--- a/tests/test_layerb_judge_bridge.py
+++ b/tests/test_layerb_judge_bridge.py
@@ -10,6 +10,7 @@ import pytest
 from scripts.audit import layerb_collect_emissions, layerb_judge_bridge, layerb_qualify, layerb_shadow
 
 PINNED_CODEX_MODEL = "gpt-5.6-terra"
+PINNED_GROK_MODEL = "grok-build"
 
 
 def _window(candidate_id: str = "candidate-1", raw: str = "Kyiv is the capital of Ukraine.") -> dict[str, Any]:
@@ -42,10 +43,15 @@ def _request(
 
 
 def _config(family: str = "codex") -> layerb_judge_bridge.BridgeConfig:
+    model = {
+        "codex": PINNED_CODEX_MODEL,
+        "grok": PINNED_GROK_MODEL,
+        "gemini": "gemini-3.5-flash-high",
+    }[family]
     return layerb_judge_bridge.BridgeConfig(
         family=family,
-        model=PINNED_CODEX_MODEL if family == "codex" else "gemini-3.5-flash-high",
-        model_version=PINNED_CODEX_MODEL if family == "codex" else "gemini-3.5-flash-high",
+        model=model,
+        model_version=model,
         timeout_seconds=90,
     )
 
@@ -76,6 +82,13 @@ def _result(
 
 def _model_trace(model: str = PINNED_CODEX_MODEL) -> list[dict[str, Any]]:
     return [{"type": "session_meta", "model": model}, {"type": "task_complete"}]
+
+
+def _grok_trace(model: str = PINNED_GROK_MODEL) -> list[dict[str, Any]]:
+    return [
+        {"type": "turn_started", "session_id": "{session_id}", "model_id": model},
+        {"type": "turn_ended", "outcome": "completed"},
+    ]
 
 
 def _stub_codex(
@@ -109,6 +122,72 @@ def _stub_codex(
             trace_path.parent.mkdir(parents=True)
             trace_path.write_text("\n".join(json.dumps(event) for event in events), encoding="utf-8")
         return subprocess.CompletedProcess(argv, returncode, stdout="not-json-stdout", stderr="")
+
+    monkeypatch.setattr(layerb_judge_bridge.subprocess, "run", fake_run)
+    return seen
+
+
+def _stub_grok(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    output: dict[str, Any] | str | None = None,
+    events: list[dict[str, Any]] | None = None,
+    updates: list[dict[str, Any]] | None = None,
+    trace_model: str = PINNED_GROK_MODEL,
+    outer_stdout: str | None = None,
+    returncode: int = 0,
+    timeout: bool = False,
+) -> dict[str, Any]:
+    """Stub Grok's strict envelope and its fresh scoped-session trace."""
+
+    seen: dict[str, Any] = {}
+
+    def replace_session_id(value: Any, session_id: str) -> Any:
+        if isinstance(value, str):
+            return session_id if value == "{session_id}" else value
+        if isinstance(value, list):
+            return [replace_session_id(item, session_id) for item in value]
+        if isinstance(value, dict):
+            return {key: replace_session_id(item, session_id) for key, item in value.items()}
+        return value
+
+    def fake_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        seen["invocations"] = seen.get("invocations", 0) + 1
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        if timeout:
+            raise subprocess.TimeoutExpired(argv, kwargs["timeout"])
+        session_id = argv[argv.index("--session-id") + 1]
+        scratch_dir = Path(argv[argv.index("--cwd") + 1])
+        scoped_home = Path(kwargs["env"]["GROK_HOME"])
+        trace_dir = layerb_judge_bridge._grok_session_dir(scoped_home, scratch_dir, session_id)
+        trace_dir.mkdir(parents=True)
+        seen["scoped_config"] = (scoped_home / "config.toml").read_text(encoding="utf-8")
+        (trace_dir / "summary.json").write_text(
+            json.dumps({"grok_home": str(scoped_home), "current_model_id": trace_model}), encoding="utf-8"
+        )
+        trace_events = replace_session_id(events or _grok_trace(trace_model), session_id)
+        (trace_dir / "events.jsonl").write_text(
+            "\n".join(json.dumps(event) for event in trace_events), encoding="utf-8"
+        )
+        trace_updates = updates if updates is not None else [{"type": "assistant", "tool_calls": []}]
+        (trace_dir / "updates.jsonl").write_text(
+            "\n".join(json.dumps(event) for event in trace_updates), encoding="utf-8"
+        )
+        if outer_stdout is None:
+            serialized = output if isinstance(output, str) else json.dumps(output, ensure_ascii=False)
+            stdout = json.dumps(
+                {
+                    "text": serialized,
+                    "stopReason": "EndTurn",
+                    "sessionId": session_id,
+                    "requestId": "request-stub",
+                },
+                ensure_ascii=False,
+            )
+        else:
+            stdout = outer_stdout
+        return subprocess.CompletedProcess(argv, returncode, stdout=stdout, stderr="")
 
     monkeypatch.setattr(layerb_judge_bridge.subprocess, "run", fake_run)
     return seen
@@ -259,6 +338,77 @@ def test_codex_happy_path_uses_output_file_strict_schema_scoped_home_and_trace(m
     assert argv[-1] == "-"
     assert seen["kwargs"]["input"] == layerb_judge_bridge.build_codex_prompt(layerb_judge_bridge.parse_request(request))
     assert seen["scoped_config"] == "# Layer-B judge scoped home: intentionally no MCP configuration.\n"
+
+
+def test_grok_happy_path_uses_strict_envelope_scoped_home_and_complete_tool_free_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request()
+    seen = _stub_grok(monkeypatch, output=_result())
+
+    response = layerb_judge_bridge.run_bridge(request, _config("grok"))
+
+    assert _validate_single(response, "Kyiv is the capital of Ukraine.")["relation"] == "ENTAILS"
+    argv = seen["argv"]
+    assert argv[:3] == [
+        "grok",
+        "-p",
+        layerb_judge_bridge.build_codex_prompt(layerb_judge_bridge.parse_request(request)),
+    ]
+    assert argv[argv.index("--output-format") + 1] == "json"
+    assert json.loads(argv[argv.index("--json-schema") + 1]) == layerb_judge_bridge.output_json_schema()
+    assert argv[argv.index("--max-turns") + 1] == "1"
+    assert argv[argv.index("-m") + 1] == PINNED_GROK_MODEL
+    assert argv[argv.index("--tools") + 1] == ""
+    assert argv[argv.index("--disallowed-tools") + 1] == "Agent"
+    assert argv[argv.index("MCPTool") - 1 : argv.index("MCPTool") + 1] == ["--deny", "MCPTool"]
+    for flag in layerb_judge_bridge.GROK_CONFIG_FLAGS:
+        assert flag in argv
+    assert seen["scoped_config"] == "# Layer-B judge scoped home: intentionally no MCP or plugin configuration.\n"
+
+
+@pytest.mark.parametrize(
+    ("label", "output", "events", "trace_model", "outer_stdout", "reason"),
+    (
+        (
+            "tool_event",
+            _result(),
+            [
+                {"type": "turn_started", "session_id": "{session_id}", "model_id": PINNED_GROK_MODEL},
+                {"type": "tool_started", "tool_name": "run_terminal_cmd"},
+                {"type": "turn_ended", "outcome": "completed"},
+            ],
+            PINNED_GROK_MODEL,
+            None,
+            "rollout_tool_activity",
+        ),
+        ("model_mismatch", _result(), None, "grok-build-other", None, "model_pin"),
+        ("malformed_cli_json", _result(), None, PINNED_GROK_MODEL, "not-json", "output_decode"),
+        ("malformed_model_json", "not-json", None, PINNED_GROK_MODEL, None, "output_decode"),
+    ),
+)
+def test_grok_transport_anomalies_fail_closed_to_abstain(
+    monkeypatch: pytest.MonkeyPatch,
+    label: str,
+    output: dict[str, Any] | str,
+    events: list[dict[str, Any]] | None,
+    trace_model: str,
+    outer_stdout: str | None,
+    reason: str,
+) -> None:
+    _stub_grok(
+        monkeypatch,
+        output=output,
+        events=events,
+        trace_model=trace_model,
+        outer_stdout=outer_stdout,
+    )
+
+    response = layerb_judge_bridge.run_bridge(_request(), _config("grok"))
+
+    assert _relation(response)["relation"] == "ABSTAIN", label
+    assert _validate_single(response, "Kyiv is the capital of Ukraine.")["relation"] == "ABSTAIN"
+    assert response["_bridge_conservative_reason"] == reason
 
 
 def test_collector_module_envelope_multiple_candidates_uses_each_decoded_window(
@@ -760,3 +910,40 @@ def test_print_config_attests_subscription_isolation_and_no_fabricated_tokens(
     assert config["seat_transport"]["tokens"] is None
     assert config["tool_access"]["mcp"] is False
     assert config["config_sha256"]
+
+
+def test_grok_print_config_golden(capsys: pytest.CaptureFixture[str]) -> None:
+    assert layerb_judge_bridge.main(["--judge-family", "grok", "--print-config"]) == 0
+    config = json.loads(capsys.readouterr().out)
+
+    # config_sha256 covers the complete canonical attestation, including the
+    # argv template, schema, trace proof, and every disabled-tool control.
+    assert config["config_sha256"] == "d9cb6c50a5e8a97eee3e30f85fd64234cc0698f4c6aadbefb1f34ab53424dceb"
+    assert config["family"] == "grok"
+    assert config["model"] == PINNED_GROK_MODEL
+    assert config["model_version"] == PINNED_GROK_MODEL
+    assert config["transport"] == "grok-build-subscription-traced.v1"
+    assert config["seat_transport"] == {
+        "argv_sha256": "8830487423f782bd0c3e50f5695fc02cc3f6059433e398d1772e2682224f0bd2",
+        "argv_template": config["seat_transport"]["argv_template"],
+        "auth": "user-auth.json symlink only",
+        "minimal_config_has_mcp_servers": False,
+        "scoped_codex_home": False,
+        "scoped_grok_home": True,
+        "token_accounting": "collector records configured byte-bound worst case when seat tokens are unavailable",
+        "tokens": None,
+        "trace_evidence": "fresh UUID session authoritative updates.jsonl plus events.jsonl",
+        "trace_tool_screen": True,
+    }
+    assert config["tool_access"] == {
+        "builtin_tool_allowlist": [],
+        "config_overrides": ["--disable-web-search", "--no-memory", "--no-subagents"],
+        "deny_rules": ["MCPTool"],
+        "disabled_features": ["Agent"],
+        "enabled": False,
+        "enforcement": (
+            "empty built-in CLI allowlist + Agent/MCP deny rules + scoped no-MCP GROK_HOME "
+            "+ fail-closed authoritative updates/events trace screen"
+        ),
+        "mcp": False,
+    }

--- a/tests/test_layerb_judge_bridge.py
+++ b/tests/test_layerb_judge_bridge.py
@@ -88,7 +88,38 @@ def _model_trace(model: str = PINNED_CODEX_MODEL) -> list[dict[str, Any]]:
 def _grok_trace(model: str = PINNED_GROK_MODEL) -> list[dict[str, Any]]:
     return [
         {"type": "turn_started", "session_id": "{session_id}", "model_id": model},
+        {"type": "loop_started", "loop_index": 0},
+        {"type": "first_token"},
+        {"type": "phase_changed", "phase": "streaming_text"},
         {"type": "turn_ended", "outcome": "completed"},
+    ]
+
+
+def _grok_updates(model: str = PINNED_GROK_MODEL) -> list[dict[str, Any]]:
+    """Mirror the documented ACP session/update records the real CLI writes."""
+
+    return [
+        {
+            "method": "session/update",
+            "timestamp": 1,
+            "params": {
+                "sessionId": "{session_id}",
+                "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "…"}},
+            },
+        },
+        {
+            "method": "_x.ai/session/update",
+            "timestamp": 2,
+            "params": {
+                "sessionId": "{session_id}",
+                "update": {
+                    "sessionUpdate": "turn_completed",
+                    "prompt_id": "prompt-stub",
+                    "stop_reason": "end_turn",
+                    "usage": {"modelCalls": 1, "modelUsage": {model: {"modelCalls": 1}}},
+                },
+            },
+        },
     ]
 
 
@@ -171,7 +202,7 @@ def _stub_grok(
         (trace_dir / "events.jsonl").write_text(
             "\n".join(json.dumps(event) for event in trace_events), encoding="utf-8"
         )
-        trace_updates = updates if updates is not None else [{"type": "assistant", "tool_calls": []}]
+        trace_updates = replace_session_id(updates if updates is not None else _grok_updates(trace_model), session_id)
         (trace_dir / "updates.jsonl").write_text(
             "\n".join(json.dumps(event) for event in trace_updates), encoding="utf-8"
         )
@@ -386,6 +417,21 @@ def test_grok_happy_path_uses_strict_envelope_scoped_home_and_complete_tool_free
         ("model_mismatch", _result(), None, "grok-build-other", None, "model_pin"),
         ("malformed_cli_json", _result(), None, PINNED_GROK_MODEL, "not-json", "output_decode"),
         ("malformed_model_json", "not-json", None, PINNED_GROK_MODEL, None, "output_decode"),
+        (
+            "stdout_session_id_mismatch",
+            _result(),
+            None,
+            PINNED_GROK_MODEL,
+            json.dumps(
+                {
+                    "text": json.dumps(_result(), ensure_ascii=False),
+                    "stopReason": "EndTurn",
+                    "sessionId": "some-other-session",
+                    "requestId": "request-stub",
+                }
+            ),
+            "transport_exit",
+        ),
     ),
 )
 def test_grok_transport_anomalies_fail_closed_to_abstain(
@@ -455,6 +501,214 @@ def test_grok_missing_trace_fails_closed_as_trace_missing(monkeypatch: pytest.Mo
 
     assert _relation(response)["relation"] == "ABSTAIN"
     assert response["_bridge_conservative_reason"] == "trace_missing"
+
+
+@pytest.mark.parametrize(
+    ("label", "events", "updates", "reason"),
+    (
+        (
+            "unknown_event_type",
+            [
+                {"type": "turn_started", "session_id": "{session_id}", "model_id": PINNED_GROK_MODEL},
+                {"type": "telemetry_ping"},
+                {"type": "turn_ended", "outcome": "completed"},
+            ],
+            None,
+            "trace_unrecognized",
+        ),
+        (
+            "unknown_phase",
+            [
+                {"type": "turn_started", "session_id": "{session_id}", "model_id": PINNED_GROK_MODEL},
+                {"type": "phase_changed", "phase": "waiting_for_tool"},
+                {"type": "turn_ended", "outcome": "completed"},
+            ],
+            None,
+            "trace_unrecognized",
+        ),
+        (
+            "acp_tool_call_update",
+            None,
+            [
+                {
+                    "method": "session/update",
+                    "timestamp": 1,
+                    "params": {
+                        "sessionId": "{session_id}",
+                        "update": {
+                            "sessionUpdate": "tool_call",
+                            "toolCallId": "call-1",
+                            "title": "run_terminal_cmd",
+                        },
+                    },
+                }
+            ],
+            "rollout_tool_activity",
+        ),
+        (
+            "unknown_session_update_kind",
+            None,
+            [
+                {
+                    "method": "session/update",
+                    "timestamp": 1,
+                    "params": {"sessionId": "{session_id}", "update": {"sessionUpdate": "plan", "entries": []}},
+                }
+            ],
+            "trace_unrecognized",
+        ),
+        (
+            "unknown_update_method",
+            None,
+            [
+                {
+                    "method": "session/exec",
+                    "timestamp": 1,
+                    "params": {
+                        "sessionId": "{session_id}",
+                        "update": {"sessionUpdate": "agent_message_chunk", "content": {}},
+                    },
+                }
+            ],
+            "trace_unrecognized",
+        ),
+        (
+            "foreign_model_in_usage",
+            None,
+            [
+                {
+                    "method": "_x.ai/session/update",
+                    "timestamp": 1,
+                    "params": {
+                        "sessionId": "{session_id}",
+                        "update": {
+                            "sessionUpdate": "turn_completed",
+                            "prompt_id": "prompt-stub",
+                            "stop_reason": "end_turn",
+                            "usage": {"modelCalls": 2, "modelUsage": {"grok-4-fast": {"modelCalls": 1}}},
+                        },
+                    },
+                }
+            ],
+            "model_pin",
+        ),
+    ),
+)
+def test_grok_trace_allowlist_and_model_sweep_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    label: str,
+    events: list[dict[str, Any]] | None,
+    updates: list[dict[str, Any]] | None,
+    reason: str,
+) -> None:
+    """Unrecognized trace shapes and off-pin models never pass silently."""
+
+    _stub_grok(monkeypatch, output=_result(), events=events, updates=updates)
+
+    response = layerb_judge_bridge.run_bridge(_request(), _config("grok"))
+
+    assert _relation(response)["relation"] == "ABSTAIN", label
+    assert response["_bridge_conservative_reason"] == reason, label
+
+
+def _write_grok_tree(
+    scoped_home: Path,
+    scratch_dir: Path,
+    session_id: str,
+    *,
+    summary: dict[str, Any] | None = None,
+    events: list[dict[str, Any]] | None = None,
+    updates: list[dict[str, Any]] | None = None,
+) -> None:
+    trace_dir = layerb_judge_bridge._grok_session_dir(scoped_home, scratch_dir, session_id)
+    trace_dir.mkdir(parents=True)
+    if summary is None:
+        summary = {"grok_home": str(scoped_home), "current_model_id": PINNED_GROK_MODEL}
+    (trace_dir / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    if events is None:
+        events = [
+            {"type": "turn_started", "session_id": session_id, "model_id": PINNED_GROK_MODEL},
+            {"type": "turn_ended", "outcome": "completed"},
+        ]
+    (trace_dir / "events.jsonl").write_text("\n".join(json.dumps(event) for event in events), encoding="utf-8")
+    if updates is None:
+        updates = [
+            {
+                "method": "session/update",
+                "timestamp": 1,
+                "params": {
+                    "sessionId": session_id,
+                    "update": {"sessionUpdate": "agent_message_chunk", "content": {}},
+                },
+            }
+        ]
+    (trace_dir / "updates.jsonl").write_text("\n".join(json.dumps(record) for record in updates), encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("label", "overrides", "reason"),
+    (
+        (
+            "grok_home_mismatch",
+            {"summary": {"grok_home": "/somewhere/else", "current_model_id": PINNED_GROK_MODEL}},
+            "transport_exit",
+        ),
+        (
+            "events_session_id_mismatch",
+            {
+                "events": [
+                    {"type": "turn_started", "session_id": "another-session", "model_id": PINNED_GROK_MODEL},
+                    {"type": "turn_ended", "outcome": "completed"},
+                ]
+            },
+            "transport_exit",
+        ),
+        (
+            "zero_turns",
+            {"events": [{"type": "first_token"}]},
+            "transport_exit",
+        ),
+        (
+            "double_turn_start",
+            {
+                "events": [
+                    {"type": "turn_started", "session_id": "{sid}", "model_id": PINNED_GROK_MODEL},
+                    {"type": "turn_started", "session_id": "{sid}", "model_id": PINNED_GROK_MODEL},
+                    {"type": "turn_ended", "outcome": "completed"},
+                ]
+            },
+            "transport_exit",
+        ),
+        ("empty_events_file", {"events": []}, "transport_exit"),
+    ),
+)
+def test_validate_grok_trace_negative_shapes(
+    tmp_path: Path, label: str, overrides: dict[str, Any], reason: str
+) -> None:
+    """Each documented trace binding failure raises its exact conservative reason."""
+
+    scoped_home = tmp_path / "grok-home"
+    scoped_home.mkdir()
+    scratch_dir = tmp_path / "scratch"
+    scratch_dir.mkdir()
+    session_id = "session-under-test"
+    events = overrides.get("events")
+    if events is not None:
+        events = [
+            {key: (session_id if value == "{sid}" else value) for key, value in event.items()} for event in events
+        ]
+        overrides = {**overrides, "events": events}
+    _write_grok_tree(scoped_home, scratch_dir, session_id, **overrides)
+
+    with pytest.raises(layerb_judge_bridge.BridgeInvocationError) as excinfo:
+        layerb_judge_bridge._validate_grok_trace(
+            config=_config("grok"),
+            scoped_home=scoped_home,
+            scratch_dir=scratch_dir,
+            session_id=session_id,
+        )
+
+    assert str(excinfo.value) == reason, label
 
 
 def test_collector_module_envelope_multiple_candidates_uses_each_decoded_window(

--- a/tests/test_layerb_judge_bridge.py
+++ b/tests/test_layerb_judge_bridge.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import urllib.parse
 from pathlib import Path
 from typing import Any
 
@@ -409,6 +410,51 @@ def test_grok_transport_anomalies_fail_closed_to_abstain(
     assert _relation(response)["relation"] == "ABSTAIN", label
     assert _validate_single(response, "Kyiv is the capital of Ukraine.")["relation"] == "ABSTAIN"
     assert response["_bridge_conservative_reason"] == reason
+
+
+def test_grok_session_dir_resolves_symlinked_scratch(tmp_path: Path) -> None:
+    """The CLI keys sessions by the REAL cwd; the derivation must match it.
+
+    On macOS every tempfile scratch dir sits behind a symlink (/tmp and /var
+    point into /private), so an unresolved derivation can never find the
+    trace the CLI actually wrote (PR #5200 live debug, 2026-07-15).
+    """
+
+    scoped_home = tmp_path / "grok-home"
+    real_scratch = tmp_path / "real-scratch"
+    real_scratch.mkdir()
+    linked_scratch = tmp_path / "linked-scratch"
+    linked_scratch.symlink_to(real_scratch)
+
+    via_link = layerb_judge_bridge._grok_session_dir(scoped_home, linked_scratch, "session-1")
+    via_real = layerb_judge_bridge._grok_session_dir(scoped_home, real_scratch, "session-1")
+
+    assert via_link == via_real
+    assert via_link.parent.name == urllib.parse.quote(str(real_scratch.resolve()), safe="")
+
+
+def test_grok_missing_trace_fails_closed_as_trace_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A clean transport with an absent session trace is trace_missing, not transport_exit."""
+
+    def fake_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        session_id = argv[argv.index("--session-id") + 1]
+        stdout = json.dumps(
+            {
+                "text": json.dumps(_result(), ensure_ascii=False),
+                "stopReason": "EndTurn",
+                "sessionId": session_id,
+                "requestId": "request-stub",
+            },
+            ensure_ascii=False,
+        )
+        return subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(layerb_judge_bridge.subprocess, "run", fake_run)
+
+    response = layerb_judge_bridge.run_bridge(_request(), _config("grok"))
+
+    assert _relation(response)["relation"] == "ABSTAIN"
+    assert response["_bridge_conservative_reason"] == "trace_missing"
 
 
 def test_collector_module_envelope_multiple_candidates_uses_each_decoded_window(


### PR DESCRIPTION
## Summary

- Adds the xAI/Grok Build `grok` judge family, pinned to `grok-build`, with strict native JSON-schema output handling.
- Invokes the native CLI directly in a fresh, auth-only `GROK_HOME`; it uses an empty built-in tool allowlist, blocks subagents, denies every MCP tool, and disables web search, memory, and subagents.
- Binds evidence to one fresh UUID session and accepts output only after strict `summary.json`, authoritative `updates.jsonl`, and execution `events.jsonl` checks prove the model pin, completed turn, and absence of tool activity.
- Adds mocked selection, tool-event, model-pin, malformed-JSON, and config-attestation golden coverage.

## M-4 evidence

- The existing runtime adapter cannot serve as the evidence anchor: [`grok_build.py:181`](scripts/agent_runtime/adapters/grok_build.py#L181) parses final stdout and returns `tool_calls=[]` unconditionally at [line 222](scripts/agent_runtime/adapters/grok_build.py#L222).
- Native CLI 0.2.101 embedded docs state that every session is saved and tracks tool calls (binary `strings` lines 55286-55297); they identify `$GROK_HOME/sessions/<encoded-cwd>/<session-id>/updates.jsonl` as the authoritative conversation log containing conversation and tool calls (59069-59091).
- The same native docs define `--tools` as the built-in allowlist, warn that MCP meta-tools remain unless denied, document `--disallowed-tools Agent`, and state bare `--deny MCPTool` covers all MCP invocations (58319-58378). The bridge persists no MCP/plugin config and fails closed if its scoped trace is missing, malformed, model-mismatched, or shows a tool/permission event.
- Independent Gemini review approved both the original route (broker reply #2845) and the observed native `turn_ended` trace shape (reply #2847).

## Verification

```text
.venv/bin/ruff check scripts/audit/layerb_judge_bridge.py tests/test_layerb_judge_bridge.py
All checks passed!

.venv/bin/ruff format --check scripts/audit/layerb_judge_bridge.py tests/test_layerb_judge_bridge.py
2 files already formatted

.venv/bin/pytest -q tests/test_layerb_judge_bridge.py
37 passed in 0.48s
```

`--print-config` golden attestation: `bridge_config_sha256=d9cb6c50a5e8a97eee3e30f85fd64234cc0698f4c6aadbefb1f34ab53424dceb`.

## One live smoke (Grok call 1 of 1)

The requested single native Grok invocation was made with a minimal valid `qg-layer-b-judge-input.v1`. Its exact strict bridge output was:

```json
{"schema_version":"qg-layer-b-judge-output.v1","fact_checks":[{"fact_check_id":"live-smoke-fact","source_relations":[{"candidate_id":"candidate-1","relation":"ABSTAIN","support_spans":[],"confidence":"high","prompt_injection_observed":false}]}],"_bridge_conservative_reason":"transport_exit"}
```

This was correctly fail-closed. Local native trace metadata then showed that a completed `turn_ended` event contains `outcome` but no `session_id`; the bridge had already bound the invocation using the documented `turn_started.session_id` and model ID. The invalid `turn_ended.session_id` requirement was removed and mocks were aligned to the observed shape. No second Grok call was made, honoring the one-call limit.

## State

Draft deliberately; **no auto-merge**. It needs one explicitly authorized post-fix Grok smoke before promotion/qualification can rely on this route.

Refs #5197