### PR TITLE
fix(harness): pin Grok judge envelope identifiers

### DIFF
--- a/scripts/audit/layerb_collect_emissions.py
+++ b/scripts/audit/layerb_collect_emissions.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -587,6 +588,25 @@ def _evidence_pattern_hits_by_case(
     return dict(by_case)
 
 
+def _bridge_forensics_sidecar(response: Mapping[str, Any]) -> dict[str, str] | None:
+    """Extract a bridge-owned forensic pointer without admitting it to scoring payloads."""
+
+    sidecar = response.get("_bridge_forensics")
+    if not isinstance(sidecar, Mapping):
+        return None
+    path = sidecar.get("path")
+    content_sha256 = sidecar.get("sha256")
+    if (
+        not isinstance(path, str)
+        or not path
+        or not isinstance(content_sha256, str)
+        or len(content_sha256) != 64
+        or any(character not in "0123456789abcdef" for character in content_sha256)
+    ):
+        return None
+    return {"path": path, "sha256": content_sha256}
+
+
 def _failure_response(prepared: PreparedCase) -> dict[str, Any]:
     return {
         "schema_version": layerb_shadow.JUDGE_OUTPUT_VERSION,
@@ -978,7 +998,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         emissions: dict[str, list[dict[str, Any]]] = {}
         manifest: list[dict[str, Any]] = []
         ledger = layerb_shadow.BudgetLedger(args.max_usd, seat_caps, args.max_judge_calls)
-        judge = layerb_shadow.SubprocessJudge(shlex.split(args.judge_command), args.judge_timeout_seconds)
+        judge_environment = dict(os.environ)
+        judge_environment["LAYERB_BRIDGE_FORENSICS_DIR"] = str(output_dir / "forensics")
+        judge = layerb_shadow.SubprocessJudge(
+            shlex.split(args.judge_command), args.judge_timeout_seconds, environment=judge_environment
+        )
         for module, (request, serialized_window_hashes), module_route in zip(
             modules, module_requests, request_routes, strict=True
         ):
@@ -989,6 +1013,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             module_id = _module_id(module)
             call: layerb_shadow.JudgeCall | None = None
             response: Mapping[str, Any] | None = None
+            bridge_forensics: dict[str, str] | None = None
             status = "completed"
             error: str | None = None
             cache_hit = cached is not None
@@ -1003,6 +1028,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     observed = _observed(None, module_route)
                 else:
                     response = dict(response_value)
+                    bridge_forensics = _bridge_forensics_sidecar({"_bridge_forensics": cached.get("bridge_forensics")})
                     call = layerb_shadow.JudgeCall(
                         response=response,
                         prompt_tokens=int(observed_value["prompt_tokens"])
@@ -1021,6 +1047,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 try:
                     call = judge(request, module_route)
                     response = dict(call.response)
+                    bridge_forensics = _bridge_forensics_sidecar(response)
+                    response.pop("_bridge_forensics", None)
                     observed = _observed(call, module_route)
                     ledger.settle(seat_key, reservation, call.cost_usd)
                     atomic_write_json(
@@ -1029,6 +1057,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                             "cache_identity_version": CACHE_VERSION,
                             "request_sha256": request_hash,
                             "response": response,
+                            "bridge_forensics": bridge_forensics,
                             "observed": observed,
                             "route": effective_route.to_dict(),
                             "created_at": _utc_now(),
@@ -1079,6 +1108,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "case_ids": sorted(module_emissions),
                     "request_sha256": request_hash,
                     "raw_response": dict(response) if response is not None else None,
+                    "bridge_forensics": bridge_forensics,
                     "window_sha256": {
                         window["candidate_id"]: window["raw_window_sha256"]
                         for prepared_case in module.cases

--- a/scripts/audit/layerb_judge_bridge.py
+++ b/scripts/audit/layerb_judge_bridge.py
@@ -330,6 +330,7 @@ class ModelResult:
 
     text: str
     observed: dict[str, Any] | None = None
+    raw_stdout: str | None = None
 
 
 def _canonical_json(value: Any) -> str:
@@ -576,6 +577,54 @@ def output_json_schema() -> dict[str, Any]:
     }
 
 
+def output_json_schema_for_request(parsed: ParsedRequest) -> dict[str, Any]:
+    """Bind the generic output schema's envelope identifiers to one request.
+
+    Grok's constraint grammar needs a Draft-4 tuple form here: ``const`` and
+    2020-12 tuple keywords are not reliably honored by subscription CLIs.
+    The normalizer remains the authoritative validation boundary; this only
+    reduces avoidable identifier-transcription failures before it runs.
+    """
+
+    schema = output_json_schema()
+    properties = dict(schema["properties"])
+    generic_facts = properties["fact_checks"]
+    generic_fact = generic_facts["items"]
+    generic_fact_properties = generic_fact["properties"]
+    generic_source_relations = generic_fact_properties["source_relations"]
+    generic_source_relation = generic_source_relations["items"]
+
+    pinned_facts: list[dict[str, Any]] = []
+    for request_fact in parsed.request["fact_checks"]:
+        fact_check_id = str(request_fact["fact_check_id"])
+        pinned_relations: list[dict[str, Any]] = []
+        for source in request_fact["candidate_sources"]:
+            candidate_properties = dict(generic_source_relation["properties"])
+            candidate_properties["candidate_id"] = {"type": "string", "enum": [str(source["candidate_id"])]}
+            pinned_relations.append({**generic_source_relation, "properties": candidate_properties})
+
+        relation_tuple = {
+            **generic_source_relations,
+            "items": pinned_relations,
+            "additionalItems": False,
+            "minItems": len(pinned_relations),
+            "maxItems": len(pinned_relations),
+        }
+        fact_properties = dict(generic_fact_properties)
+        fact_properties["fact_check_id"] = {"type": "string", "enum": [fact_check_id]}
+        fact_properties["source_relations"] = relation_tuple
+        pinned_facts.append({**generic_fact, "properties": fact_properties})
+
+    properties["fact_checks"] = {
+        **generic_facts,
+        "items": pinned_facts,
+        "additionalItems": False,
+        "minItems": len(pinned_facts),
+        "maxItems": len(pinned_facts),
+    }
+    return {**schema, "properties": properties}
+
+
 def build_codex_judge_argv(
     *, config: BridgeConfig, scratch_dir: Path, schema_path: Path, output_path: Path
 ) -> list[str]:
@@ -602,7 +651,14 @@ def build_codex_judge_argv(
     return argv
 
 
-def build_grok_judge_argv(*, config: BridgeConfig, scratch_dir: Path, session_id: str, prompt: str) -> list[str]:
+def build_grok_judge_argv(
+    *,
+    config: BridgeConfig,
+    scratch_dir: Path,
+    session_id: str,
+    prompt: str,
+    parsed: ParsedRequest | None = None,
+) -> list[str]:
     """Build the complete native Grok CLI command with a zero-tool policy."""
 
     argv = [
@@ -612,7 +668,7 @@ def build_grok_judge_argv(*, config: BridgeConfig, scratch_dir: Path, session_id
         "--output-format",
         "json",
         "--json-schema",
-        _canonical_json(output_json_schema()),
+        _canonical_json(output_json_schema_for_request(parsed) if parsed is not None else output_json_schema()),
         "--no-alt-screen",
         "--verbatim",
         "--max-turns",
@@ -1020,6 +1076,7 @@ def invoke_grok(parsed: ParsedRequest, config: BridgeConfig) -> ModelResult:
                 scratch_dir=scratch_dir,
                 session_id=session_id,
                 prompt=build_codex_prompt(parsed),
+                parsed=parsed,
             ),
             text=True,
             capture_output=True,
@@ -1040,7 +1097,24 @@ def invoke_grok(parsed: ParsedRequest, config: BridgeConfig) -> ModelResult:
             scratch_dir=scratch_dir,
             session_id=session_id,
         )
-        return ModelResult(text=text)
+        return ModelResult(text=text, raw_stdout=completed.stdout)
+
+
+def _write_grok_validation_forensics(parsed: ParsedRequest, raw_stdout: str | None) -> dict[str, str] | None:
+    """Best-effort quarantine write for a clean Grok response that fails validation."""
+
+    directory = os.environ.get("LAYERB_BRIDGE_FORENSICS_DIR")
+    if not directory or raw_stdout is None:
+        return None
+    request_sha256 = _sha256_json(parsed.request)
+    try:
+        path = Path(directory) / f"{request_sha256}.raw-err"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(raw_stdout, encoding="utf-8")
+        content_sha256 = _sha256_text(raw_stdout)
+    except (OSError, UnicodeError):
+        return None
+    return {"path": str(path), "sha256": content_sha256}
 
 
 def conservative_response(
@@ -1116,6 +1190,10 @@ def run_bridge(request: Mapping[str, Any], config: BridgeConfig) -> dict[str, An
             response = conservative_response(
                 parsed, reason="envelope_alignment", evidence_pattern_hits=evidence_pattern_hits
             )
+            if config.family == "grok":
+                forensics = _write_grok_validation_forensics(parsed, model_result.raw_stdout)
+                if forensics is not None:
+                    response["_bridge_forensics"] = forensics
         else:
             if substitutions:
                 response["_bridge_substituted"] = substitutions

--- a/scripts/audit/layerb_shadow.py
+++ b/scripts/audit/layerb_shadow.py
@@ -142,9 +142,12 @@ class SubprocessJudge:
     has no access to an in-process tool client.
     """
 
-    def __init__(self, command: Sequence[str], timeout_seconds: float) -> None:
+    def __init__(
+        self, command: Sequence[str], timeout_seconds: float, *, environment: Mapping[str, str] | None = None
+    ) -> None:
         self._command = tuple(command)
         self._timeout_seconds = timeout_seconds
+        self._environment = dict(environment) if environment is not None else None
 
     def __call__(self, request: Mapping[str, Any], route: JudgeRoute) -> JudgeCall:
         started = time.monotonic()
@@ -155,6 +158,7 @@ class SubprocessJudge:
             capture_output=True,
             timeout=self._timeout_seconds,
             check=False,
+            env=self._environment,
         )
         if completed.returncode != 0:
             raise RuntimeError(f"judge command exited {completed.returncode}: {completed.stderr.strip()[:300]}")

--- a/tests/test_layerb_collect_emissions.py
+++ b/tests/test_layerb_collect_emissions.py
@@ -399,6 +399,57 @@ def test_collector_extracts_bridge_sidecar_without_polluting_response() -> None:
     assert "_bridge_substituted" not in emission["response"]
 
 
+def test_collector_passes_and_extracts_grok_forensics_sidecar(tmp_path: Path, monkeypatch) -> None:
+    main_path, probe_path, _main_case, _probe_case = _datasets(tmp_path)
+    output_dir = tmp_path / "collector"
+    captured: dict[str, Any] = {}
+    sidecar = {"path": str(output_dir / "forensics" / ("a" * 64 + ".raw-err")), "sha256": "b" * 64}
+
+    class CapturingJudge:
+        def __init__(self, command, timeout_seconds, *, environment) -> None:
+            captured["command"] = command
+            captured["timeout_seconds"] = timeout_seconds
+            captured["environment"] = environment
+
+        def __call__(self, request, route):
+            parsed = layerb_judge_bridge.parse_request(request)
+            facts = []
+            for fact in parsed.request["fact_checks"]:
+                fact_check_id = str(fact["fact_check_id"])
+                relations = []
+                for source in fact["candidate_sources"]:
+                    candidate_id = str(source["candidate_id"])
+                    raw = parsed.windows_by_fact_candidate[(fact_check_id, candidate_id)]["raw_window"]
+                    relations.append(
+                        {
+                            "candidate_id": candidate_id,
+                            "relation": "ENTAILS",
+                            "support_spans": [{"start": 0, "end": len(raw), "role": "SUPPORTS"}],
+                            "confidence": "high",
+                            "prompt_injection_observed": False,
+                        }
+                    )
+                facts.append({"fact_check_id": fact_check_id, "source_relations": relations})
+            return layerb_collect_emissions.layerb_shadow.JudgeCall(
+                response={
+                    "schema_version": layerb_collect_emissions.layerb_shadow.JUDGE_OUTPUT_VERSION,
+                    "fact_checks": facts,
+                    "_bridge_forensics": sidecar,
+                }
+            )
+
+    monkeypatch.setattr(layerb_collect_emissions.layerb_shadow, "SubprocessJudge", CapturingJudge)
+
+    assert layerb_collect_emissions.main(_collector_args(main_path, probe_path, output_dir, calls=2)) == 0
+    assert captured["environment"]["LAYERB_BRIDGE_FORENSICS_DIR"] == str(output_dir / "forensics")
+    cache = next((output_dir / "cache").glob("*.json"))
+    cache_payload = json.loads(cache.read_text(encoding="utf-8"))
+    assert cache_payload["bridge_forensics"] == sidecar
+    assert "_bridge_forensics" not in cache_payload["response"]
+    manifest = json.loads((output_dir / "raw-call-manifest.json").read_text(encoding="utf-8"))
+    assert all(call["bridge_forensics"] == sidecar for call in manifest["calls"])
+
+
 def test_collector_extracts_detector_sidecar_by_known_pair_and_deduplicates() -> None:
     module, response = _module_response_with_mixed_injection(injection_observed=False)
     response["_evidence_pattern_hits"] = [

--- a/tests/test_layerb_judge_bridge.py
+++ b/tests/test_layerb_judge_bridge.py
@@ -234,6 +234,7 @@ def _validate_single(response: dict[str, Any], raw: str) -> dict[str, Any]:
     returned.pop("_shadow_observed", None)
     returned.pop("_bridge_substituted", None)
     returned.pop("_bridge_conservative_reason", None)
+    returned.pop("_bridge_forensics", None)
     returned.pop("_evidence_pattern_hits", None)
     return layerb_shadow._validate_judge_response(
         returned,
@@ -332,6 +333,56 @@ def test_parse_request_decodes_unicode_window_and_rejects_wrong_schema() -> None
         layerb_judge_bridge.parse_request(request)
 
 
+def test_grok_pinned_schema_uses_request_ordered_draft4_tuples_and_id_enums() -> None:
+    request = _two_candidate_request()
+    first_sources = request["fact_checks"][0]["candidate_sources"]
+    request["fact_checks"].append(
+        {
+            "fact_check_id": "fact-2",
+            "claim": "A second fact preserves a different candidate order.",
+            "candidate_sources": [dict(first_sources[1]), dict(first_sources[0])],
+        }
+    )
+
+    schema = layerb_judge_bridge.output_json_schema_for_request(layerb_judge_bridge.parse_request(request))
+    generic = layerb_judge_bridge.output_json_schema()
+    fact_checks = schema["properties"]["fact_checks"]
+
+    assert fact_checks["minItems"] == fact_checks["maxItems"] == 2
+    assert fact_checks["additionalItems"] is False
+    assert [fact["properties"]["fact_check_id"]["enum"] for fact in fact_checks["items"]] == [
+        ["fact-1"],
+        ["fact-2"],
+    ]
+    assert all("const" not in fact["properties"]["fact_check_id"] for fact in fact_checks["items"])
+    assert fact_checks["items"][0]["properties"]["source_relations"]["items"] != []
+    assert [
+        relation["properties"]["candidate_id"]["enum"]
+        for relation in fact_checks["items"][0]["properties"]["source_relations"]["items"]
+    ] == [["candidate-1"], ["candidate-2"]]
+    assert [
+        relation["properties"]["candidate_id"]["enum"]
+        for relation in fact_checks["items"][1]["properties"]["source_relations"]["items"]
+    ] == [["candidate-2"], ["candidate-1"]]
+    for fact in fact_checks["items"]:
+        relations = fact["properties"]["source_relations"]
+        assert relations["minItems"] == relations["maxItems"] == 2
+        assert relations["additionalItems"] is False
+        for relation in relations["items"]:
+            assert (
+                relation["properties"]["relation"]
+                == generic["properties"]["fact_checks"]["items"]["properties"]["source_relations"]["items"][
+                    "properties"
+                ]["relation"]
+            )
+            assert (
+                relation["properties"]["support_spans"]
+                == generic["properties"]["fact_checks"]["items"]["properties"]["source_relations"]["items"][
+                    "properties"
+                ]["support_spans"]
+            )
+
+
 def test_codex_prompt_is_policy_first_and_reasserts_before_untrusted_block() -> None:
     raw = "evidence-only: ordinary source text"
     parsed = layerb_judge_bridge.parse_request(_request(raw))
@@ -388,7 +439,9 @@ def test_grok_happy_path_uses_strict_envelope_scoped_home_and_complete_tool_free
         layerb_judge_bridge.build_codex_prompt(layerb_judge_bridge.parse_request(request)),
     ]
     assert argv[argv.index("--output-format") + 1] == "json"
-    assert json.loads(argv[argv.index("--json-schema") + 1]) == layerb_judge_bridge.output_json_schema()
+    assert json.loads(argv[argv.index("--json-schema") + 1]) == layerb_judge_bridge.output_json_schema_for_request(
+        layerb_judge_bridge.parse_request(request)
+    )
     assert argv[argv.index("--max-turns") + 1] == "1"
     assert argv[argv.index("-m") + 1] == PINNED_GROK_MODEL
     assert argv[argv.index("--tools") + 1] == ""
@@ -893,6 +946,44 @@ def test_bridge_envelope_failures_remain_module_fatal(monkeypatch: pytest.Monkey
     assert response["_bridge_conservative_reason"] == "envelope_alignment"
 
 
+def test_grok_envelope_failure_writes_raw_stdout_forensics_when_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = _request()
+    malformed = _result()
+    malformed["fact_checks"][0]["fact_check_id"] = "wrong-fact-id"
+    _stub_grok(monkeypatch, output=malformed)
+    forensics_dir = tmp_path / "forensics"
+    monkeypatch.setenv("LAYERB_BRIDGE_FORENSICS_DIR", str(forensics_dir))
+
+    response = layerb_judge_bridge.run_bridge(request, _config("grok"))
+
+    request_sha256 = layerb_judge_bridge._sha256_json(layerb_judge_bridge.parse_request(request).request)
+    sidecar = response["_bridge_forensics"]
+    path = Path(sidecar["path"])
+    assert response["_bridge_conservative_reason"] == "envelope_alignment"
+    assert path == forensics_dir / f"{request_sha256}.raw-err"
+    assert path.read_text(encoding="utf-8")
+    assert sidecar["sha256"] == layerb_judge_bridge._sha256_text(path.read_text(encoding="utf-8"))
+    assert json.loads(path.read_text(encoding="utf-8"))["text"] == json.dumps(malformed, ensure_ascii=False)
+
+
+def test_grok_envelope_failure_skips_forensics_when_unconfigured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = _request()
+    malformed = _result()
+    malformed["fact_checks"][0]["fact_check_id"] = "wrong-fact-id"
+    _stub_grok(monkeypatch, output=malformed)
+    monkeypatch.delenv("LAYERB_BRIDGE_FORENSICS_DIR", raising=False)
+
+    response = layerb_judge_bridge.run_bridge(request, _config("grok"))
+
+    assert response["_bridge_conservative_reason"] == "envelope_alignment"
+    assert "_bridge_forensics" not in response
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_digit_17_not_18_round_trips_bridge_and_collector_with_contradiction_intact(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1209,7 +1300,7 @@ def test_print_config_attests_subscription_isolation_and_no_fabricated_tokens(
     assert config["seat_transport"]["argv_sha256"]
     assert config["seat_transport"]["tokens"] is None
     assert config["tool_access"]["mcp"] is False
-    assert config["config_sha256"]
+    assert config["config_sha256"] == "a899fc88762f117f5f4ca4f5d16bd6eb4bfecc333629ede8a0a158b9059fc505"
 
 
 def test_grok_print_config_golden(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
Refs #5208

## Summary

- Pins Grok's per-request output envelope identifiers with Draft-4 tuple arrays and single-value `enum` IDs, in request order.
- Keeps Codex construction and its attested configuration byte-identical.
- Persists clean-transport Grok validation failures as hash-named `.raw-err` sidecars; the collector passes the forensic directory, retains the pointer in its manifest/cache, and strips it from scored responses.

## #M-4 evidence

### Two-fact pinned schema sample

```json
{
  "fact_checks": {"additionalItems": false, "minItems": 2, "maxItems": 2},
  "fact_item_ids_in_order": [["fact-1"], ["fact-2"]],
  "candidate_ids_in_order": [
    [["candidate-1"], ["candidate-2"]],
    [["candidate-2"], ["candidate-1"]]
  ],
  "relation_tuple_controls": [
    {"additionalItems": false, "minItems": 2, "maxItems": 2},
    {"additionalItems": false, "minItems": 2, "maxItems": 2}
  ]
}
```

### Codex attestation unchanged

Against `origin/main` at `4b49e8f6458747faf2b7f6b3453e865deacce4b8`:

```text
$ git show origin/main:scripts/audit/layerb_judge_bridge.py | .venv/bin/python - --print-config
{"config_sha256":"a899fc88762f117f5f4ca4f5d16bd6eb4bfecc333629ede8a0a158b9059fc505", ...}

$ .venv/bin/python scripts/audit/layerb_judge_bridge.py --print-config
a899fc88762f117f5f4ca4f5d16bd6eb4bfecc333629ede8a0a158b9059fc505
```

The `d9cb6c50…` value cited in #5208 is the existing Grok static attestation, not the Codex configuration SHA.

### Live smoke and probe gate

The historical `grok-build` selector is no longer available in the local subscription CLI (current catalog: `grok-4.5`, `grok-composer-2.5-fast`), so its default smoke exits with “unknown model id.” An explicit `grok-4.5` smoke completed transport but returned conservative `envelope_alignment`.

The fresh collector probe at `audit/2026-07-15-layerb-grok-qual-run/grok-build-r3` therefore stopped before main calls and wrote:

`forensics/5a69d2189434be4fe496ad4e0e28a8a43e5d4ecb246d72c7bf629e2864379c82.raw-err`

First 300 bytes:

```text
{
  "text": "{\"schema_version\":\"qg-layer-b-judge-output.v1\",\"prompt_version\":\"qg-layer-b-shadow-prompt.v1\",\"fact_checks\":[{\"fact_check_id\":\"digit-17-not-18\",\"candidates\":[{\"candidate_id\":\"49710b0e3f5dd051d22a14347789c8ab8802434dd8fcf9d8bddca137ea38870b\",\"relation\":\"CONTRADICTS
```

### Checks

- `.venv/bin/ruff check` on all five changed files
- `.venv/bin/pytest -q tests/test_layerb_judge_bridge.py tests/test_layerb_collect_emissions.py` — 80 passed
- Commit pre-hook including affected suites — 110 passed
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Cross-family final review: AGY review message 2873 — APPROVE.

## Follow-up

This draft intentionally has no auto-merge. It needs a restored/approved Grok qualification model selector before rerunning the full 131-call collection.