### PR TITLE
fix(delegate): honor registry defaults in dispatch telemetry (#5215)

### DIFF
--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -208,14 +208,14 @@ def _resolve_model_from_defaults(agent_name: str, requested_model: str | None) -
         value = _codex_config().get("model")
         return str(value).strip() if isinstance(value, str) and str(value).strip() else None
     if agent_name == "gemini":
-        return _nested_lookup(
+        configured_model = _nested_lookup(
             _gemini_settings(),
             ("model", "defaultModel", "selectedModel", "modelName", "default_model"),
         )
-    if agent_name in ("grok", "deepseek", "qwen"):
-        return _default_model_for(agent_name)
-    if agent_name == "claude":
-        return _default_model_for(agent_name)
+        # The adapter always passes ``model or self.default_model``.  When
+        # no local Gemini setting is readable, record the registry default
+        # that the adapter will actually receive instead of "unknown".
+        return configured_model or _default_model_for(agent_name)
     return _default_model_for(agent_name)
 
 

--- a/tests/test_dispatch_telemetry.py
+++ b/tests/test_dispatch_telemetry.py
@@ -4,20 +4,54 @@ from __future__ import annotations
 
 import logging
 import sys
+from importlib import import_module
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.adapters.base import InvocationPlan
+from agent_runtime.registry import AGENTS
 from agent_runtime.result import ParseResult
 from agent_runtime.runner import invoke
 from agent_runtime.telemetry import (
     _reset_version_cache_for_tests,
+    _resolve_model_from_defaults,
     resolve_dispatch_start_telemetry,
     resolve_invocation_telemetry,
 )
 from agent_runtime.usage import _reset_rate_limit_cache_for_tests
+
+
+def test_resolve_model_from_defaults_uses_registry_for_grok_build():
+    """Regression for #5215: never pass the lane name to native Grok."""
+    assert _resolve_model_from_defaults("grok-build", None) == "grok-4.5"
+
+
+def test_gemini_default_resolution_falls_back_to_registry(monkeypatch):
+    """A missing local config must not make telemetry disagree with its adapter."""
+    monkeypatch.setattr("agent_runtime.telemetry._gemini_settings", lambda: {})
+
+    assert _resolve_model_from_defaults("gemini", None) == AGENTS["gemini"]["default_model"]
+
+
+@pytest.mark.parametrize("agent_name", sorted(AGENTS))
+def test_every_registry_default_matches_no_override_resolution_and_adapter(agent_name, monkeypatch):
+    """Registry defaults are the no-override dispatch contract for every lane."""
+    monkeypatch.setattr("agent_runtime.telemetry._gemini_settings", lambda: {})
+    entry = AGENTS[agent_name]
+    module_name, class_name = entry["adapter"].split(":", 1)
+    adapter_class = getattr(import_module(module_name.removeprefix("scripts.")), class_name)
+
+    resolved_model = _resolve_model_from_defaults(agent_name, None)
+
+    assert resolved_model == entry["default_model"]
+    # Each adapter uses ``model or self.default_model``; equality guarantees
+    # the no-override value reaches the adapter as its accepted default rather
+    # than leaking an agent registry key (for example, ``grok-build``).
+    assert resolved_model == adapter_class.default_model
 
 
 def test_resolve_dispatch_start_telemetry_codex_model_from_registry_effort_from_config(tmp_path, monkeypatch):

--- a/tests/test_grok_build_adapter.py
+++ b/tests/test_grok_build_adapter.py
@@ -84,8 +84,9 @@ def test_model_and_effort_flags(tmp_path):
     assert _val(plan.cmd, "--effort") == "high"
 
 
-def test_default_effort_is_applied(tmp_path):
+def test_no_override_builds_explicit_registry_default_model(tmp_path):
     plan = _build("x", tmp_path)
+    assert _val(plan.cmd, "-m") == registry.get_agent_entry("grok-build")["default_model"]
     assert _val(plan.cmd, "-m") == GROK_BUILD_DEFAULT_MODEL
     assert _val(plan.cmd, "--effort") == GROK_BUILD_DEFAULT_EFFORT
 
@@ -209,7 +210,10 @@ def test_grok_build_lane_defaults_to_grok_45():
 
 
 def test_grok_build_rejects_retired_model_pin(tmp_path):
-    with pytest.raises(ValueError, match="unsupported Grok model"):
+    with pytest.raises(
+        ValueError,
+        match=r"^GrokBuildAdapter: unsupported Grok model 'grok-build'; allowed: \['grok-4\.5'\]$",
+    ):
         _build("x", tmp_path, model="grok-build", effort="high")
 
 


### PR DESCRIPTION
Closes #5215

## Summary
- Resolves no-override telemetry from each registry default, including the missing-config Gemini fallback.
- Adds a registry-wide regression contract: every agent resolves to the model declared by its registered adapter, preventing agent-name model leaks such as `grok-build`.
- Strengthens native Grok coverage: no-override invocation explicitly emits the registry default and an unsupported model fails in the adapter before any CLI spawn.

## Red → green evidence
- **Red condition:** the previous Gemini no-config expression was `_nested_lookup({}, model_keys) -> None`, while `GeminiAdapter` runs `model or self.default_model`; telemetry could therefore record `unknown` despite a concrete adapter default.
- **Green:** `_resolve_model_from_defaults("grok-build", None) == "grok-4.5"`; the registry-wide test asserts no-override resolution equals both every registry and adapter default.
- Native Grok argv built from the resolved no-override value: `/usr/local/bin/grok … -m grok-4.5 --effort high`.
- `delegate.py dispatch --agent grok-build --task-id grok-build-model-fix-5215-dry-run --prompt "dry-run model resolution verification" --dry-run` recorded `"model": "grok-4.5"` (the dry-run CLI prints only its task id; the adapter argv test verifies the explicit `-m` flag).

## Verification
- `.venv/bin/python -m pytest tests/test_dispatch_telemetry.py tests/test_grok_build_adapter.py -q` → **44 passed**
- `.venv/bin/python -m pytest tests/ -k "telemetry or grok or dispatch or model_resolution" -q -o addopts=''` → **463 passed, 1 skipped, 11415 deselected**
- `.venv/bin/ruff check scripts/agent_runtime/telemetry.py tests/test_dispatch_telemetry.py tests/test_grok_build_adapter.py` → **All checks passed**
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` → **PASS**

No auto-merge enabled; awaiting independent cross-family review.