### PR TITLE
fix(bridge): ask-claude honors '-' stdin + first-class recipient choices for all agents

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -404,6 +404,13 @@ def _handle_codex_usage(args) -> None:
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser."""
+    # Recipient/inbox choices must cover EVERY valid agent, not just the
+    # original claude/gemini/codex trio — otherwise grok-build, grok, agy, and
+    # cursor cannot be targeted by `send --to`, listed by `inbox --for`, or
+    # cleared by `ack-all`, which silently second-classes those lanes.
+    from ._channels import VALID_RECIPIENT_AGENTS
+
+    recipient_choices = sorted(VALID_RECIPIENT_AGENTS)
     parser = argparse.ArgumentParser(
         description=(
             "Bridge CLI for Claude, Gemini, and Codex message passing.\n"
@@ -433,7 +440,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--for",
         dest="for_llm",
         default="gemini",
-        choices=["gemini", "claude", "codex"],
+        choices=recipient_choices,
         help="Check inbox for which agent (default: gemini)",
     )
 
@@ -448,7 +455,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--to",
         dest="to_llm",
         default="claude",
-        choices=["claude", "gemini", "codex"],
+        choices=recipient_choices,
         help="Target agent (default: claude)",
     )
     send_parser.add_argument("--from", dest="from_llm", default="gemini", help="Sender agent name (default: gemini)")
@@ -464,7 +471,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # ack-all
     ack_all_parser = subparsers.add_parser("ack-all", help="Acknowledge ALL unread messages for an agent")
-    ack_all_parser.add_argument("agent", choices=["claude", "gemini", "codex"], help="Agent whose inbox to clear")
+    ack_all_parser.add_argument("agent", choices=recipient_choices, help="Agent whose inbox to clear")
 
     # conversation
     conv_parser = subparsers.add_parser("conversation", help="Get conversation history")
@@ -544,8 +551,10 @@ def _build_parser() -> argparse.ArgumentParser:
     asks_parser.add_argument("--task-id", help="Only show asks for this task ID")
 
     # ask-claude
-    ask_claude_parser = subparsers.add_parser("ask-claude", help="Send message AND invoke Claude (one-step)")
-    ask_claude_parser.add_argument("content", help="Message content")
+    ask_claude_parser = subparsers.add_parser(
+        "ask-claude", help="Send message AND invoke Claude (one-step; use '-' to read from stdin)"
+    )
+    ask_claude_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
     ask_claude_parser.add_argument("--task-id", required=True, help="Task ID (required for session tracking)")
     ask_claude_parser.add_argument("--type", default="query", help="Message type (default: query)")
     ask_claude_parser.add_argument("--data", help="Path to data file to attach")
@@ -1290,11 +1299,16 @@ def _handle_ask_claude(args):
     data = None
     if args.data:
         data = Path(args.data).read_text()
+    # Parity with every other ask-* handler: `-` reads the message body from
+    # stdin. Without this, `ask-claude - --task-id X < prompt.md` sent the
+    # literal string "-" as the message, so Claude received an empty prompt and
+    # the caller got an empty/unhelpful reply (the grok "empty result" bug).
+    content = sys.stdin.read() if args.content == "-" else args.content
     kwargs = {"review": True} if getattr(args, "review", False) else {}
     kwargs.update(_review_target_kwargs(args))
     from_llm = _resolve_from_llm(args)
     ask_claude(
-        args.content,
+        content,
         args.task_id,
         args.type,
         data,

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -824,3 +824,46 @@ def test_detect_caller_identity_unknown_handoff_falls_through(monkeypatch):
 
 def test_claude_infra_is_valid_agent():
     assert "claude-infra" in _channels.VALID_AGENTS
+
+
+def test_ask_claude_reads_body_from_stdin_on_dash(monkeypatch):
+    # Regression for the grok "empty result" bug: ask-claude used args.content
+    # directly, so `ask-claude - < prompt.md` sent the literal "-" as the body.
+    # Every other ask-* handler resolves "-" to stdin; ask-claude must too.
+    captured: dict[str, object] = {}
+
+    def _fake_ask_claude(content, *_args, **_kwargs):
+        captured["content"] = content
+
+    monkeypatch.setattr(_cli, "ask_claude", _fake_ask_claude)
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(read=lambda: "the real question body"))
+
+    exit_code = _run_cli(["ask-claude", "-", "--task-id", "t-stdin", "--from", "grok-build"])
+
+    assert exit_code == 0
+    assert captured["content"] == "the real question body"
+
+
+def test_ask_claude_literal_content_is_not_treated_as_stdin(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _fake_ask_claude(content, *_args, **_kwargs):
+        captured["content"] = content
+
+    monkeypatch.setattr(_cli, "ask_claude", _fake_ask_claude)
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(read=lambda: "SHOULD-NOT-BE-USED"))
+
+    exit_code = _run_cli(["ask-claude", "a literal question", "--task-id", "t-lit", "--from", "grok-build"])
+
+    assert exit_code == 0
+    assert captured["content"] == "a literal question"
+
+
+def test_recipient_choices_cover_every_valid_agent():
+    # Regression: inbox --for / send --to / ack-all hardcoded {claude,gemini,codex},
+    # silently second-classing grok-build, grok, agy, and cursor.
+    parser = _cli._build_parser()
+    for agent in ("grok-build", "grok", "agy", "cursor"):
+        assert parser.parse_args(["inbox", "--for", agent]).for_llm == agent
+        assert parser.parse_args(["ack-all", agent]).agent == agent
+        assert parser.parse_args(["send", "hi", "--to", agent]).to_llm == agent


### PR DESCRIPTION
## The bug (reported: "grok cannot ask claude, asking claude gives empty result")

Root-caused to three grok-hostile spots in the bridge CLI:

**Bug C (the "empty result") —** `ask-claude` was the ONLY `ask-*` handler that did not resolve `-` to stdin. Every other handler (`ask-codex`, `ask-agy`, `ask-grok-build`, …) has `content = sys.stdin.read() if args.content == "-" else args.content`; `_handle_ask_claude` passed `args.content` directly. So a grok reusing the `-` stdin convention ran `ab ask-claude - < prompt.md` → the literal string `"-"` became the message body → Claude received an empty prompt → the caller got an empty/unhelpful reply. Reproduced (Claude literally answered *"Your message came through empty (body was just '-')"*) and fixed.

**Bug B (grok second-classed) —** `inbox --for`, `send --to`, and `ack-all` hardcoded `{claude,gemini,codex}`, so `grok-build`/`grok`/`agy`/`cursor` could not be targeted, listed, or cleared. Widened to every `VALID_RECIPIENT_AGENT`.

## Not in this PR (separate follow-ups)
- **Sender auto-detect (Bug A):** `_detect_caller_identity_from_env` has no grok branch, so a grok that omits `--from` either errors ("Cannot infer sender") or misdetects as claude if a stray `CLAUDE_*` var leaks. Proper fix = grok onboarding exports `SESSION_HANDOFF_AGENT=grok-build` (the bridge already honors it, first) — that's the grok onboarding pack (user-gated). **Workaround today:** pass `--from grok-build`.

## Verification
- Unit: `ask-claude -` reads stdin; literal content is untouched; all recipient choices accept grok-build/grok/agy/cursor. 35 passed.
- End-to-end: `echo 'capital of Ukraine?' | ab ask-claude - --from grok-build` → Claude replied **"Kyiv"**, routed to grok-build's inbox and retrievable by id.

Lane: infra/bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)