### PR TITLE
fix(harness): lift Grok flat judge rows

### DIFF
--- a/scripts/audit/layerb_collect_emissions.py
+++ b/scripts/audit/layerb_collect_emissions.py
@@ -753,6 +753,11 @@ def _route_metadata(
         "tools": [],
         "tool_access": {"enabled": False, "mcp": False},
     }
+    # Fresh output directories and no --resume remain a defence-in-depth
+    # operational rule for Grok qualification. This identity fold independently
+    # prevents a response cache from crossing a flat-contract revision.
+    if str(args.judge_family).casefold() == "grok":
+        bridge_config["family_internal_sha"] = layerb_judge_bridge.grok_flat_contract_fingerprint()
     route_data = {
         "family": args.judge_family,
         "resolved_model": args.judge_model,
@@ -896,7 +901,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--dry-run", action="store_true", help="Reconstruct and serialize windows without calling the judge."
     )
-    parser.add_argument("--resume", action="store_true", help="Reuse validated per-module response cache entries.")
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Reuse validated per-module response cache entries. Grok qualification must use a fresh output directory "
+            "without --resume; the flat-contract identity fold is defence in depth."
+        ),
+    )
     return parser.parse_args(argv)
 
 

--- a/scripts/audit/layerb_judge_bridge.py
+++ b/scripts/audit/layerb_judge_bridge.py
@@ -39,6 +39,7 @@ import subprocess
 import sys
 import tempfile
 import uuid
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from hashlib import sha256
@@ -56,6 +57,8 @@ from scripts.audit import layerb_shadow
 
 BRIDGE_VERSION = "qg-layer-b-judge-bridge.v5"
 PROMPT_TEMPLATE_VERSION = "qg-layer-b-judge-bridge-prompt.v2-flattened"
+GROK_FLAT_SCHEMA_BUILDER_VERSION = "qg-layer-b-judge-grok-flat-schema.v1"
+GROK_PROMPT_TEMPLATE_VERSION = "qg-layer-b-judge-grok-flat-prompt.v1"
 DEFAULT_MODELS = {
     "codex": "gpt-5.6-terra",
     "grok": "grok-4.5",
@@ -187,6 +190,32 @@ FLATTENED_PROMPT_TEMPLATE_MATERIAL = "\n\n".join(
     (SYSTEM_PROMPT_TEMPLATE, IMMOVABLE_POLICY_BOUNDARY, UNTRUSTED_REASSERTION)
 )
 
+GROK_FLAT_OUTPUT_SHAPE_INSTRUCTION = """OUTPUT-SHAPE — GROK FLAT CONTRACT
+For this Grok request, return one bare top-level JSON array, not an object and
+not a nested envelope. The array has exactly one row for every requested
+(fact_check_id, candidate_id) pair. Every row must use these canonical field
+names: fact_check_id, candidate_id, relation, support_spans, confidence, and
+prompt_injection_observed. Omitting confidence is invalid; confidence must be
+"high".
+
+Do not use the key `spans`; the key must be `support_spans`.
+
+This is a shape-only example; do not copy its relation or spans unless the
+candidate evidence supports them:
+{example_row}
+
+Return only the JSON array. Do not return schema_version, fact_checks,
+source_relations, prose, Markdown, or code fences."""
+
+GROK_FLAT_PROMPT_TEMPLATE_MATERIAL = "\n\n".join(
+    (
+        SYSTEM_PROMPT_TEMPLATE,
+        GROK_FLAT_OUTPUT_SHAPE_INSTRUCTION,
+        IMMOVABLE_POLICY_BOUNDARY,
+        UNTRUSTED_REASSERTION,
+    )
+)
+
 _UNTRUSTED_BLOCK_RE = re.compile(
     r"\A<<<BEGIN_UNTRUSTED_TOOL_OUTPUT\n"
     r"nonce=(?P<nonce>[^\n]+)\n"
@@ -211,6 +240,10 @@ class BridgeInvocationError(RuntimeError):
             raise ValueError(f"unknown conservative reason {reason!r}")
         self.reason = reason
         super().__init__(reason)
+
+
+class GrokFlatLiftError(ValueError):
+    """The flat Grok response cannot be safely regrouped into an envelope."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -265,14 +298,22 @@ class BridgeConfig:
             tool_enforcement = "unqualified transport is never invoked"
             disabled_features = []
             config_overrides = []
-        return {
+        if self.family == "grok":
+            grok_flat_contract = grok_flat_contract_material()
+            prompt_template_version = grok_flat_contract["prompt_template_version"]
+            prompt_template_sha256 = grok_flat_contract["prompt_template_sha256"]
+        else:
+            grok_flat_contract = None
+            prompt_template_version = PROMPT_TEMPLATE_VERSION
+            prompt_template_sha256 = _sha256_text(FLATTENED_PROMPT_TEMPLATE_MATERIAL)
+        material = {
             "bridge_version": BRIDGE_VERSION,
             "family": self.family,
             "model": self.model,
             "model_version": self.model_version,
             "transport": self.transport,
-            "prompt_template_version": PROMPT_TEMPLATE_VERSION,
-            "prompt_template_sha256": _sha256_text(FLATTENED_PROMPT_TEMPLATE_MATERIAL),
+            "prompt_template_version": prompt_template_version,
+            "prompt_template_sha256": prompt_template_sha256,
             "judge_input_version": layerb_shadow.JUDGE_INPUT_VERSION,
             "judge_output_version": layerb_shadow.JUDGE_OUTPUT_VERSION,
             "seat_transport": {
@@ -308,6 +349,9 @@ class BridgeConfig:
                 "note": "Neither subscription CLI exposes a judge-specific setting; unavailable values are attested, not fabricated.",
             },
         }
+        if grok_flat_contract is not None:
+            material["grok_flat_contract"] = grok_flat_contract
+        return material
 
     def to_dict(self) -> dict[str, Any]:
         material = self.material()
@@ -343,6 +387,22 @@ def _sha256_text(value: str) -> str:
 
 def _sha256_json(value: Any) -> str:
     return _sha256_text(_canonical_json(value))
+
+
+def grok_flat_contract_material() -> dict[str, str]:
+    """Return the Grok-only request-contract inputs that must invalidate cache reuse."""
+
+    return {
+        "schema_builder_version": GROK_FLAT_SCHEMA_BUILDER_VERSION,
+        "prompt_template_version": GROK_PROMPT_TEMPLATE_VERSION,
+        "prompt_template_sha256": _sha256_text(GROK_FLAT_PROMPT_TEMPLATE_MATERIAL),
+    }
+
+
+def grok_flat_contract_fingerprint() -> str:
+    """Hash the Grok-only request contract without changing Codex attestation bytes."""
+
+    return _sha256_json(grok_flat_contract_material())
 
 
 def _require_string(value: Mapping[str, Any], key: str, context: str) -> str:
@@ -497,6 +557,31 @@ def build_codex_prompt(parsed: ParsedRequest) -> str:
     )
 
 
+def build_grok_prompt(parsed: ParsedRequest) -> str:
+    """Build the Grok-only flat-output prompt without changing Codex material."""
+
+    first_fact = parsed.request["fact_checks"][0]
+    first_source = first_fact["candidate_sources"][0]
+    example_row = _canonical_json(
+        {
+            "fact_check_id": str(first_fact["fact_check_id"]),
+            "candidate_id": str(first_source["candidate_id"]),
+            "relation": "ABSTAIN",
+            "support_spans": [],
+            "confidence": "high",
+            "prompt_injection_observed": False,
+        }
+    )
+    return "\n\n".join(
+        (
+            build_system_prompt(parsed.request),
+            GROK_FLAT_OUTPUT_SHAPE_INSTRUCTION.format(example_row=example_row),
+            IMMOVABLE_POLICY_BOUNDARY,
+            build_user_message(parsed),
+        )
+    )
+
+
 def _flattened_injection_screen(parsed: ParsedRequest) -> bool:
     """Reject only injection-shaped canonical metadata before a flattened prompt runs."""
 
@@ -625,6 +710,44 @@ def output_json_schema_for_request(parsed: ParsedRequest) -> dict[str, Any]:
     return {**schema, "properties": properties}
 
 
+def grok_flat_output_schema() -> dict[str, Any]:
+    """Return Grok's generic flat row contract for config attestation only."""
+
+    canonical = output_json_schema()
+    source_relation = canonical["properties"]["fact_checks"]["items"]["properties"]["source_relations"]["items"]
+    row_properties = {"fact_check_id": {"type": "string"}, **source_relation["properties"]}
+    return {
+        "type": "array",
+        "items": {
+            **source_relation,
+            "properties": row_properties,
+            "required": ["fact_check_id", *source_relation["required"]],
+        },
+    }
+
+
+def grok_flat_output_schema_for_request(parsed: ParsedRequest) -> dict[str, Any]:
+    """Pin Grok's Draft-4 flat row tuple to a parsed request's identifiers."""
+
+    generic = grok_flat_output_schema()
+    generic_row = generic["items"]
+    rows: list[dict[str, Any]] = []
+    for fact in parsed.request["fact_checks"]:
+        fact_check_id = str(fact["fact_check_id"])
+        for source in fact["candidate_sources"]:
+            properties = dict(generic_row["properties"])
+            properties["fact_check_id"] = {"type": "string", "enum": [fact_check_id]}
+            properties["candidate_id"] = {"type": "string", "enum": [str(source["candidate_id"])]}
+            rows.append({**generic_row, "properties": properties})
+    return {
+        "type": "array",
+        "items": rows,
+        "additionalItems": False,
+        "minItems": len(rows),
+        "maxItems": len(rows),
+    }
+
+
 def build_codex_judge_argv(
     *, config: BridgeConfig, scratch_dir: Path, schema_path: Path, output_path: Path
 ) -> list[str]:
@@ -668,7 +791,7 @@ def build_grok_judge_argv(
         "--output-format",
         "json",
         "--json-schema",
-        _canonical_json(output_json_schema_for_request(parsed) if parsed is not None else output_json_schema()),
+        _canonical_json(grok_flat_output_schema_for_request(parsed) if parsed is not None else grok_flat_output_schema()),
         "--no-alt-screen",
         "--verbatim",
         "--max-turns",
@@ -961,6 +1084,85 @@ def _grok_trace_models(*, updates: Sequence[Mapping[str, Any]], events: Sequence
     return models
 
 
+_GROK_CANONICAL_ROW_FIELDS = (
+    "candidate_id",
+    "relation",
+    "support_spans",
+    "confidence",
+    "prompt_injection_observed",
+)
+_GROK_TRAILING_FENCE_RE = re.compile(r"\s*(?:```(?:json)?\s*)?\Z", re.IGNORECASE)
+
+# The #5208 live smoke emitted canonical support_spans and confidence="high".
+# Therefore spans -> support_spans stays disabled: this lift must remain a
+# pure structural regroup with no field aliases, defaults, or coercions.
+
+
+def _strict_grok_json_value(text: str) -> Any:
+    """Extract one Grok JSON value while rejecting non-fence trailing prose."""
+
+    decoder = json.JSONDecoder()
+    for matched in re.finditer(r"[\[{]", text):
+        candidate = text[matched.start() :]
+        try:
+            decoded, end = decoder.raw_decode(candidate)
+        except json.JSONDecodeError:
+            continue
+        if _GROK_TRAILING_FENCE_RE.fullmatch(candidate[end:]) is None:
+            raise BridgeInvocationError("output_decode")
+        return decoded
+    raise BridgeInvocationError("output_decode")
+
+
+def _lift_grok_flat_rows(rows: Sequence[Any], parsed: ParsedRequest) -> dict[str, Any]:
+    """Purely regroup the verified Grok flat row multiset into the public envelope."""
+
+    try:
+        expected_pairs = [
+            (str(fact["fact_check_id"]), str(source["candidate_id"]))
+            for fact in parsed.request["fact_checks"]
+            for source in fact["candidate_sources"]
+        ]
+    except (KeyError, TypeError) as exc:
+        raise GrokFlatLiftError("parsed request has no complete flat-row identifiers") from exc
+
+    observed_pairs: list[tuple[str, str]] = []
+    rows_by_pair: dict[tuple[str, str], Mapping[str, Any]] = {}
+    try:
+        for index, row in enumerate(rows):
+            if not isinstance(row, Mapping):
+                raise GrokFlatLiftError(f"flat row {index} is not an object")
+            fact_check_id = row.get("fact_check_id")
+            candidate_id = row.get("candidate_id")
+            if not isinstance(fact_check_id, str) or not fact_check_id:
+                raise GrokFlatLiftError(f"flat row {index} has no fact_check_id")
+            if not isinstance(candidate_id, str) or not candidate_id:
+                raise GrokFlatLiftError(f"flat row {index} has no candidate_id")
+            pair = (fact_check_id, candidate_id)
+            if pair in rows_by_pair:
+                raise GrokFlatLiftError(f"flat rows contain duplicate identifier pair {pair!r}")
+            observed_pairs.append(pair)
+            rows_by_pair[pair] = row
+    except (KeyError, TypeError) as exc:
+        raise GrokFlatLiftError("flat rows cannot be structurally inspected") from exc
+
+    if Counter(observed_pairs) != Counter(expected_pairs):
+        raise GrokFlatLiftError("flat-row identifier multiset differs from the request")
+
+    try:
+        facts = []
+        for fact in parsed.request["fact_checks"]:
+            fact_check_id = str(fact["fact_check_id"])
+            source_relations = []
+            for source in fact["candidate_sources"]:
+                row = rows_by_pair[(fact_check_id, str(source["candidate_id"]))]
+                source_relations.append({field: row[field] for field in _GROK_CANONICAL_ROW_FIELDS if field in row})
+            facts.append({"fact_check_id": fact_check_id, "source_relations": source_relations})
+    except (KeyError, TypeError) as exc:
+        raise GrokFlatLiftError("flat rows cannot be regrouped in request order") from exc
+    return {"schema_version": layerb_shadow.JUDGE_OUTPUT_VERSION, "fact_checks": facts}
+
+
 def _strict_grok_stdout(stdout: str, *, expected_session_id: str) -> str:
     """Require the one documented Grok JSON envelope for the planned session."""
 
@@ -1075,7 +1277,7 @@ def invoke_grok(parsed: ParsedRequest, config: BridgeConfig) -> ModelResult:
                 config=config,
                 scratch_dir=scratch_dir,
                 session_id=session_id,
-                prompt=build_codex_prompt(parsed),
+                prompt=build_grok_prompt(parsed),
                 parsed=parsed,
             ),
             text=True,
@@ -1176,12 +1378,29 @@ def run_bridge(request: Mapping[str, Any], config: BridgeConfig) -> dict[str, An
             raise BridgeInvocationError("transport_exit")
         else:
             raise BridgeInvocationError("transport_exit")
-        try:
-            decoded = json.loads(model_result.text)
-        except json.JSONDecodeError as exc:
-            raise BridgeInvocationError("output_decode") from exc
-        if not isinstance(decoded, Mapping):
-            raise BridgeInvocationError("output_decode")
+        if config.family == "grok":
+            decoded = _strict_grok_json_value(model_result.text)
+            if not isinstance(decoded, list):
+                raise BridgeInvocationError("output_decode")
+            try:
+                decoded = _lift_grok_flat_rows(decoded, parsed)
+            except GrokFlatLiftError:
+                response = conservative_response(
+                    parsed, reason="envelope_alignment", evidence_pattern_hits=evidence_pattern_hits
+                )
+                forensics = _write_grok_validation_forensics(parsed, model_result.raw_stdout)
+                if forensics is not None:
+                    response["_bridge_forensics"] = forensics
+                if model_result.observed:
+                    response["_shadow_observed"] = model_result.observed
+                return response
+        else:
+            try:
+                decoded = json.loads(model_result.text)
+            except json.JSONDecodeError as exc:
+                raise BridgeInvocationError("output_decode") from exc
+            if not isinstance(decoded, Mapping):
+                raise BridgeInvocationError("output_decode")
         try:
             response, substitutions = layerb_shadow.normalize_judge_module_response(
                 decoded, expected_windows_by_fact=_expected_windows_by_fact(parsed)

--- a/tests/test_layerb_collect_emissions.py
+++ b/tests/test_layerb_collect_emissions.py
@@ -521,6 +521,37 @@ def test_route_identity_hashes_bridge_version(tmp_path: Path) -> None:
     )
 
 
+def test_grok_route_identity_adds_only_the_flat_contract_fingerprint(tmp_path: Path) -> None:
+    non_grok_args = layerb_collect_emissions.parse_args(
+        _collector_args(tmp_path / "main.json", tmp_path / "probe.json", tmp_path / "non-grok-output", calls=1)
+    )
+    grok_args = layerb_collect_emissions.parse_args(
+        _collector_args(
+            tmp_path / "main.json", tmp_path / "probe.json", tmp_path / "grok-output", calls=1, family="GROK"
+        )
+    )
+
+    non_grok_route, _non_grok_judge_route, _non_grok_seat_key, _non_grok_seat_metadata = (
+        layerb_collect_emissions._route_metadata(non_grok_args)
+    )
+    grok_route, _grok_judge_route, _grok_seat_key, _grok_seat_metadata = layerb_collect_emissions._route_metadata(
+        grok_args
+    )
+
+    assert grok_route.bridge_config_sha256 != non_grok_route.bridge_config_sha256
+    assert grok_route.bridge_config_sha256 == layerb_collect_emissions._sha256_json(
+        {
+            "argv": [str(VENV_PYTHON), str(STUB)],
+            "bridge_version": layerb_judge_bridge.BRIDGE_VERSION,
+            "judge_input_version": layerb_collect_emissions.layerb_shadow.JUDGE_INPUT_VERSION,
+            "prompt_version": layerb_collect_emissions.layerb_shadow.PROMPT_VERSION,
+            "tools": [],
+            "tool_access": {"enabled": False, "mcp": False},
+            "family_internal_sha": layerb_judge_bridge.grok_flat_contract_fingerprint(),
+        }
+    )
+
+
 def test_happy_path_emission_shape_matches_scorer_response_contract(tmp_path: Path, monkeypatch) -> None:
     main_path, probe_path, main_case, _probe_case = _datasets(tmp_path)
     counter = tmp_path / "calls.log"

--- a/tests/test_layerb_judge_bridge.py
+++ b/tests/test_layerb_judge_bridge.py
@@ -81,6 +81,16 @@ def _result(
     }
 
 
+def _flat_rows(envelope: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten a canonical test envelope exactly as Grok is required to emit it."""
+
+    return [
+        {"fact_check_id": fact["fact_check_id"], **relation}
+        for fact in envelope["fact_checks"]
+        for relation in fact["source_relations"]
+    ]
+
+
 def _model_trace(model: str = PINNED_CODEX_MODEL) -> list[dict[str, Any]]:
     return [{"type": "session_meta", "model": model}, {"type": "task_complete"}]
 
@@ -207,7 +217,11 @@ def _stub_grok(
             "\n".join(json.dumps(event) for event in trace_updates), encoding="utf-8"
         )
         if outer_stdout is None:
-            serialized = output if isinstance(output, str) else json.dumps(output, ensure_ascii=False)
+            serialized = (
+                output
+                if isinstance(output, str)
+                else json.dumps(_flat_rows(output) if isinstance(output, dict) else output, ensure_ascii=False)
+            )
             stdout = json.dumps(
                 {
                     "text": serialized,
@@ -344,43 +358,34 @@ def test_grok_pinned_schema_uses_request_ordered_draft4_tuples_and_id_enums() ->
         }
     )
 
-    schema = layerb_judge_bridge.output_json_schema_for_request(layerb_judge_bridge.parse_request(request))
-    generic = layerb_judge_bridge.output_json_schema()
-    fact_checks = schema["properties"]["fact_checks"]
+    schema = layerb_judge_bridge.grok_flat_output_schema_for_request(layerb_judge_bridge.parse_request(request))
+    generic = layerb_judge_bridge.grok_flat_output_schema()
 
-    assert fact_checks["minItems"] == fact_checks["maxItems"] == 2
-    assert fact_checks["additionalItems"] is False
-    assert [fact["properties"]["fact_check_id"]["enum"] for fact in fact_checks["items"]] == [
-        ["fact-1"],
-        ["fact-2"],
+    assert schema["type"] == "array"
+    assert schema["minItems"] == schema["maxItems"] == 4
+    assert schema["additionalItems"] is False
+    assert [
+        (row["properties"]["fact_check_id"]["enum"], row["properties"]["candidate_id"]["enum"])
+        for row in schema["items"]
+    ] == [
+        (["fact-1"], ["candidate-1"]),
+        (["fact-1"], ["candidate-2"]),
+        (["fact-2"], ["candidate-2"]),
+        (["fact-2"], ["candidate-1"]),
     ]
-    assert all("const" not in fact["properties"]["fact_check_id"] for fact in fact_checks["items"])
-    assert fact_checks["items"][0]["properties"]["source_relations"]["items"] != []
-    assert [
-        relation["properties"]["candidate_id"]["enum"]
-        for relation in fact_checks["items"][0]["properties"]["source_relations"]["items"]
-    ] == [["candidate-1"], ["candidate-2"]]
-    assert [
-        relation["properties"]["candidate_id"]["enum"]
-        for relation in fact_checks["items"][1]["properties"]["source_relations"]["items"]
-    ] == [["candidate-2"], ["candidate-1"]]
-    for fact in fact_checks["items"]:
-        relations = fact["properties"]["source_relations"]
-        assert relations["minItems"] == relations["maxItems"] == 2
-        assert relations["additionalItems"] is False
-        for relation in relations["items"]:
-            assert (
-                relation["properties"]["relation"]
-                == generic["properties"]["fact_checks"]["items"]["properties"]["source_relations"]["items"][
-                    "properties"
-                ]["relation"]
-            )
-            assert (
-                relation["properties"]["support_spans"]
-                == generic["properties"]["fact_checks"]["items"]["properties"]["source_relations"]["items"][
-                    "properties"
-                ]["support_spans"]
-            )
+    for row in schema["items"]:
+        assert row["additionalProperties"] is False
+        assert row["required"] == [
+            "fact_check_id",
+            "candidate_id",
+            "relation",
+            "support_spans",
+            "confidence",
+            "prompt_injection_observed",
+        ]
+        assert "const" not in row["properties"]["fact_check_id"]
+        assert row["properties"]["relation"] == generic["items"]["properties"]["relation"]
+        assert row["properties"]["support_spans"] == generic["items"]["properties"]["support_spans"]
 
 
 def test_codex_prompt_is_policy_first_and_reasserts_before_untrusted_block() -> None:
@@ -395,6 +400,21 @@ def test_codex_prompt_is_policy_first_and_reasserts_before_untrusted_block() -> 
     assert prompt.index("<<<BEGIN_UNTRUSTED_TOOL_OUTPUT") < prompt.index(raw)
     for relation in layerb_shadow.ALLOWED_RELATIONS:
         assert relation in prompt
+
+
+def test_grok_prompt_keeps_shared_safety_policy_and_hardens_the_flat_contract() -> None:
+    parsed = layerb_judge_bridge.parse_request(_request())
+
+    prompt = layerb_judge_bridge.build_grok_prompt(parsed)
+
+    assert prompt.startswith(layerb_judge_bridge.build_system_prompt(parsed.request))
+    assert layerb_judge_bridge.GROK_FLAT_OUTPUT_SHAPE_INSTRUCTION.splitlines()[0] in prompt
+    assert 'Do not use the key `spans`; the key must be `support_spans`.' in prompt
+    assert '"support_spans":[]' in prompt
+    assert '"confidence":"high"' in prompt
+    assert prompt.index(layerb_judge_bridge.IMMOVABLE_POLICY_BOUNDARY) < prompt.index(
+        "<<<BEGIN_UNTRUSTED_TOOL_OUTPUT"
+    )
 
 
 def test_codex_happy_path_uses_output_file_strict_schema_scoped_home_and_trace(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -436,10 +456,10 @@ def test_grok_happy_path_uses_strict_envelope_scoped_home_and_complete_tool_free
     assert argv[:3] == [
         "grok",
         "-p",
-        layerb_judge_bridge.build_codex_prompt(layerb_judge_bridge.parse_request(request)),
+        layerb_judge_bridge.build_grok_prompt(layerb_judge_bridge.parse_request(request)),
     ]
     assert argv[argv.index("--output-format") + 1] == "json"
-    assert json.loads(argv[argv.index("--json-schema") + 1]) == layerb_judge_bridge.output_json_schema_for_request(
+    assert json.loads(argv[argv.index("--json-schema") + 1]) == layerb_judge_bridge.grok_flat_output_schema_for_request(
         layerb_judge_bridge.parse_request(request)
     )
     assert argv[argv.index("--max-turns") + 1] == "1"
@@ -450,6 +470,112 @@ def test_grok_happy_path_uses_strict_envelope_scoped_home_and_complete_tool_free
     for flag in layerb_judge_bridge.GROK_CONFIG_FLAGS:
         assert flag in argv
     assert seen["scoped_config"] == "# Layer-B judge scoped home: intentionally no MCP or plugin configuration.\n"
+
+
+def test_grok_lift_regroups_flat_rows_by_request_ids_not_emission_order() -> None:
+    parsed = layerb_judge_bridge.parse_request(_two_candidate_request())
+    emitted = _flat_rows(_two_candidate_result())[::-1]
+
+    lifted = layerb_judge_bridge._lift_grok_flat_rows(emitted, parsed)
+
+    relations = lifted["fact_checks"][0]["source_relations"]
+    assert [relation["candidate_id"] for relation in relations] == ["candidate-1", "candidate-2"]
+    assert relations[0]["relation"] == "CONTRADICTS"
+    assert "probe_marker" not in relations[0]
+
+
+def test_grok_missing_canonical_field_reaches_the_unchanged_wall_as_abstain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = _flat_rows(_two_candidate_result())
+    rows[1].pop("confidence")
+    _stub_grok(monkeypatch, output=rows)
+
+    response = layerb_judge_bridge.run_bridge(_two_candidate_request(), _config("grok"))
+
+    relations = response["fact_checks"][0]["source_relations"]
+    assert relations[0]["relation"] == "CONTRADICTS"
+    assert relations[1] == layerb_shadow.conservative_candidate_response("candidate-2")
+    assert response["_bridge_substituted"][0]["candidate_id"] == "candidate-2"
+
+
+def test_grok_spans_alias_remains_disabled_after_the_canonical_name_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = _flat_rows(_two_candidate_result())
+    rows[0]["spans"] = rows[0].pop("support_spans")
+    _stub_grok(monkeypatch, output=rows)
+
+    response = layerb_judge_bridge.run_bridge(_two_candidate_request(), _config("grok"))
+
+    relations = response["fact_checks"][0]["source_relations"]
+    assert relations[0] == layerb_shadow.conservative_candidate_response("candidate-1")
+    assert relations[1]["relation"] == "ENTAILS"
+
+
+@pytest.mark.parametrize("case", ("missing", "duplicate", "unknown", "non_mapping"))
+def test_grok_flat_identifier_multiset_failures_are_module_fatal(
+    monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    rows: list[Any] = _flat_rows(_two_candidate_result())
+    if case == "missing":
+        rows.pop()
+    elif case == "duplicate":
+        rows[1] = dict(rows[0])
+    elif case == "unknown":
+        rows[1]["candidate_id"] = "unexpected-candidate"
+    else:
+        rows[1] = "not-an-object"
+    _stub_grok(monkeypatch, output=rows)
+
+    response = layerb_judge_bridge.run_bridge(_two_candidate_request(), _config("grok"))
+
+    assert response["_bridge_conservative_reason"] == "envelope_alignment"
+    assert response["fact_checks"][0]["source_relations"] == [
+        layerb_shadow.conservative_candidate_response("candidate-1"),
+        layerb_shadow.conservative_candidate_response("candidate-2"),
+    ]
+
+
+def test_grok_preserves_literal_injection_true_when_a_sibling_has_malformed_spans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_grok(monkeypatch, output=_flat_rows(_two_candidate_result(first_injection=True, second_bad_span=True)))
+
+    response = layerb_judge_bridge.run_bridge(_two_candidate_request(), _config("grok"))
+
+    relations = response["fact_checks"][0]["source_relations"]
+    assert relations[0]["prompt_injection_observed"] is True
+    assert relations[1] == layerb_shadow.conservative_candidate_response("candidate-2")
+    assert response["_bridge_substituted"][0]["candidate_id"] == "candidate-2"
+
+
+def test_grok_strict_parser_accepts_fenced_json_after_leading_prose(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = json.dumps(_flat_rows(_result()), ensure_ascii=False)
+    _stub_grok(monkeypatch, output=f"Here is the required output:\n```json\n{rows}\n```")
+
+    response = layerb_judge_bridge.run_bridge(_request(), _config("grok"))
+
+    assert _relation(response)["relation"] == "ENTAILS"
+
+
+def test_grok_strict_parser_rejects_non_whitespace_after_the_first_json_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = json.dumps(_flat_rows(_result()), ensure_ascii=False)
+    _stub_grok(monkeypatch, output=f"{rows}\nThis prose must not be accepted.")
+
+    response = layerb_judge_bridge.run_bridge(_request(), _config("grok"))
+
+    assert response["_bridge_conservative_reason"] == "output_decode"
+
+
+def test_grok_non_array_response_is_conservative(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_grok(monkeypatch, output=json.dumps(_result(), ensure_ascii=False))
+
+    response = layerb_judge_bridge.run_bridge(_request(), _config("grok"))
+
+    assert response["_bridge_conservative_reason"] == "output_decode"
 
 
 @pytest.mark.parametrize(
@@ -965,7 +1091,7 @@ def test_grok_envelope_failure_writes_raw_stdout_forensics_when_configured(
     assert path == forensics_dir / f"{request_sha256}.raw-err"
     assert path.read_text(encoding="utf-8")
     assert sidecar["sha256"] == layerb_judge_bridge._sha256_text(path.read_text(encoding="utf-8"))
-    assert json.loads(path.read_text(encoding="utf-8"))["text"] == json.dumps(malformed, ensure_ascii=False)
+    assert json.loads(path.read_text(encoding="utf-8"))["text"] == json.dumps(_flat_rows(malformed), ensure_ascii=False)
 
 
 def test_grok_envelope_failure_skips_forensics_when_unconfigured(
@@ -1309,13 +1435,15 @@ def test_grok_print_config_golden(capsys: pytest.CaptureFixture[str]) -> None:
 
     # config_sha256 covers the complete canonical attestation, including the
     # argv template, schema, trace proof, and every disabled-tool control.
-    assert config["config_sha256"] == "90c19658c5e1f82e9b0adb2049db63dcabb88e96b205fdd6b067c7b555f21fe1"
+    assert config["config_sha256"] == "0c775127ddc6f82ca55cb042e6d08ae4f4c66348efee6c1b136772f987b0e442"
     assert config["family"] == "grok"
     assert config["model"] == PINNED_GROK_MODEL
     assert config["model_version"] == PINNED_GROK_MODEL
     assert config["transport"] == "grok-build-subscription-traced.v1"
+    assert config["grok_flat_contract"] == layerb_judge_bridge.grok_flat_contract_material()
+    assert config["prompt_template_version"] == layerb_judge_bridge.GROK_PROMPT_TEMPLATE_VERSION
     assert config["seat_transport"] == {
-        "argv_sha256": "8c2013d41cdf7fc094e3680f5713f564d6dbf26b5ad6b4847d7a7dabb7dc5af0",
+        "argv_sha256": "79a0f7024e5225971fe64c6a917adcb875e9a67b8d9174285c27363a4478941e",
         "argv_template": config["seat_transport"]["argv_template"],
         "auth": "user-auth.json symlink only",
         "minimal_config_has_mcp_servers": False,


### PR DESCRIPTION
Fixes #5208

## Root cause

The native Grok judge naturally emits one flat row per `(fact_check_id, candidate_id)`, while the bridge requested a nested canonical envelope. That shape mismatch failed the authoritative normalizer at `envelope_alignment`.

## Change

- Grok alone now receives a request-pinned, bare-array Draft-4 tuple schema and an output-shape prompt with canonical field names, a literal `support_spans`/`confidence:"high"` example, and a `spans` ban.
- The bridge strictly extracts one Grok JSON array, verifies its identifier multiset, then deterministically regroups it in request order before passing it to the unchanged normalizer.
- Grok response-cache identity now includes a flat-contract fingerprint; the CLI documents fresh output directory/no-resume as defence in depth. Codex attestation bytes remain pinned.
- The live canonical-name smoke kept the optional `spans → support_spans` alias disabled.

## Evidence

Live Grok digit-probe stdout contained:

```json
[{"fact_check_id":"fact-1","candidate_id":"candidate-1","relation":"CONTRADICTS","support_spans":[{"start":20,"end":22,"role":"CONTRADICTS"}],"confidence":"high","prompt_injection_observed":false},{"fact_check_id":"fact-1","candidate_id":"candidate-2","relation":"NO_RELATION","support_spans":[],"confidence":"high","prompt_injection_observed":false}]
```

```text
.venv/bin/ruff check scripts/audit/layerb_judge_bridge.py scripts/audit/layerb_collect_emissions.py tests/test_layerb_judge_bridge.py tests/test_layerb_collect_emissions.py
All checks passed!

.venv/bin/pytest -q tests/test_layerb_judge_bridge.py tests/test_layerb_collect_emissions.py tests/test_layerb_qualify.py tests/test_layerb_shadow.py
156 passed in 3.06s

.venv/bin/python scripts/audit/layerb_judge_bridge.py --print-config
a899fc88762f117f5f4ca4f5d16bd6eb4bfecc333629ede8a0a158b9059fc505
```

Independent cross-family review: AGY / Gemini 3.1 Pro approved with no findings (recorded in the PR conversation). The PR is ready for review. No auto-merge was armed; the orchestrator owns that next action.