### PR TITLE
fix(bridge): auto-detect a grok session as the grok-build sender

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -97,14 +97,18 @@ def _detect_caller_identity_from_env() -> str | None:
         return claude_name.strip().lower()
     if os.environ.get("CODEX_SESSION"):
         return "codex"
-    # The native `grok` CLI exports GROK_AGENT for every tool shell it spawns
-    # (tool-verified 2026-07-15; model-independent — grok-4.5, grok-5, … all set
-    # it), and it is the only grok-intrinsic identity marker available: GROK_HOME,
-    # GROK_SESSION*, XAI_*, AI_AGENT, and SESSION_HANDOFF_AGENT are all unset in
-    # grok shells. The native CLI IS the `grok-build` lane. Checked BEFORE the
-    # soft CLAUDE_PROJECT_DIR heuristic so a leaked CLAUDE_* var can't misroute a
-    # grok caller to the claude inbox (the "grok asked claude, got empty" class).
-    if os.environ.get("GROK_AGENT"):
+    # The native `grok` CLI hardcodes `export GROK_AGENT=1` in every tool-shell
+    # bootstrap (verified 2026-07-15 in the grok-0.2.101 binary's
+    # xai_grok_tools::computer::local::shell_state; model-independent — grok-4.5,
+    # grok-5, … all inherit it), and it is the only grok-intrinsic identity
+    # marker available: GROK_HOME, GROK_SESSION*, XAI_*, AI_AGENT, and
+    # SESSION_HANDOFF_AGENT are all unset in grok shells. The native CLI IS the
+    # `grok-build` lane. Match the sentinel EXACTLY ("1"): GROK_AGENT is also a
+    # documented agent-profile *name* selector, so a truthy check would
+    # false-positive on `GROK_AGENT=my-custom-agent`. Checked BEFORE the soft
+    # CLAUDE_PROJECT_DIR heuristic so a leaked CLAUDE_* var can't misroute a grok
+    # caller to the claude inbox (the "grok asked claude, got empty" class).
+    if os.environ.get("GROK_AGENT") == "1":
         return "grok-build"
     if os.environ.get("CLAUDE_PROJECT_DIR") or os.environ.get("CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS"):
         return "claude"

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -65,6 +65,7 @@ _CALLER_IDENTITY_ENV_HINTS = (
     "SESSION_HANDOFF_AGENT",
     "CLAUDE_AGENT_NAME",
     "CODEX_SESSION",
+    "GROK_AGENT",
     "CLAUDE_PROJECT_DIR",
     "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS",
     "GEMINI_SESSION",
@@ -96,6 +97,15 @@ def _detect_caller_identity_from_env() -> str | None:
         return claude_name.strip().lower()
     if os.environ.get("CODEX_SESSION"):
         return "codex"
+    # The native `grok` CLI exports GROK_AGENT for every tool shell it spawns
+    # (tool-verified 2026-07-15; model-independent — grok-4.5, grok-5, … all set
+    # it), and it is the only grok-intrinsic identity marker available: GROK_HOME,
+    # GROK_SESSION*, XAI_*, AI_AGENT, and SESSION_HANDOFF_AGENT are all unset in
+    # grok shells. The native CLI IS the `grok-build` lane. Checked BEFORE the
+    # soft CLAUDE_PROJECT_DIR heuristic so a leaked CLAUDE_* var can't misroute a
+    # grok caller to the claude inbox (the "grok asked claude, got empty" class).
+    if os.environ.get("GROK_AGENT"):
+        return "grok-build"
     if os.environ.get("CLAUDE_PROJECT_DIR") or os.environ.get("CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS"):
         return "claude"
     if os.environ.get("GEMINI_SESSION"):

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -822,6 +822,53 @@ def test_detect_caller_identity_unknown_handoff_falls_through(monkeypatch):
     assert _cli._detect_caller_identity_from_env() == "claude"
 
 
+def _clear_identity_env(monkeypatch) -> None:
+    for var in (
+        "SESSION_HANDOFF_AGENT",
+        "CLAUDE_AGENT_NAME",
+        "CODEX_SESSION",
+        "GROK_AGENT",
+        "CLAUDE_PROJECT_DIR",
+        "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS",
+        "GEMINI_SESSION",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_detect_caller_identity_grok_agent_maps_to_grok_build(monkeypatch):
+    # The native grok CLI exports GROK_AGENT for every tool shell it spawns
+    # (model-independent). It must auto-detect as the grok-build lane so a grok
+    # session can `ab ask-claude` without --from and get the reply back.
+    _clear_identity_env(monkeypatch)
+    monkeypatch.setenv("GROK_AGENT", "1")
+
+    assert _cli._detect_caller_identity_from_env() == "grok-build"
+
+
+def test_detect_caller_identity_grok_agent_beats_soft_claude_heuristic(monkeypatch):
+    # A grok session that inherited a stray CLAUDE_* var must still resolve to
+    # grok-build, never misroute to the claude inbox (the "empty result" class).
+    _clear_identity_env(monkeypatch)
+    monkeypatch.setenv("GROK_AGENT", "1")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/tmp/claude-project")
+
+    assert _cli._detect_caller_identity_from_env() == "grok-build"
+
+
+def test_detect_caller_identity_explicit_handoff_still_wins_over_grok_agent(monkeypatch):
+    # An explicit, validated SESSION_HANDOFF_AGENT is authoritative over the
+    # weaker GROK_AGENT marker.
+    _clear_identity_env(monkeypatch)
+    monkeypatch.setenv("GROK_AGENT", "1")
+    monkeypatch.setenv("SESSION_HANDOFF_AGENT", "codex")
+
+    assert _cli._detect_caller_identity_from_env() == "codex"
+
+
+def test_grok_build_is_valid_agent():
+    assert "grok-build" in _channels.VALID_AGENTS
+
+
 def test_claude_infra_is_valid_agent():
     assert "claude-infra" in _channels.VALID_AGENTS
 

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -855,6 +855,16 @@ def test_detect_caller_identity_grok_agent_beats_soft_claude_heuristic(monkeypat
     assert _cli._detect_caller_identity_from_env() == "grok-build"
 
 
+def test_detect_caller_identity_grok_agent_profile_name_is_not_a_false_positive(monkeypatch):
+    # GROK_AGENT doubles as an agent-profile *name* selector; only the tool-shell
+    # sentinel value "1" means "spawned by a grok CLI shell". A profile name must
+    # NOT be mistaken for the grok-build lane — it falls through to normal detect.
+    _clear_identity_env(monkeypatch)
+    monkeypatch.setenv("GROK_AGENT", "my-custom-agent")
+
+    assert _cli._detect_caller_identity_from_env() is None
+
+
 def test_detect_caller_identity_explicit_handoff_still_wins_over_grok_agent(monkeypatch):
     # An explicit, validated SESSION_HANDOFF_AGENT is authoritative over the
     # weaker GROK_AGENT marker.


### PR DESCRIPTION
Follow-up to #5218. The bridge auto-detected claude/codex/gemini callers but **not grok**, so a grok session had to pass `--from grok-build` on every `ask-*` or its reply misrouted (the "grok asked claude, got empty" class).

## Model-independent, tool-verified
Probed the live grok session env: the native `grok` CLI exports **`GROK_AGENT`** for every tool shell it spawns — set by **every grok model** (grok-4.5, grok-5, …), so this is future-proof. It is the ONLY grok-intrinsic marker; `GROK_HOME`, `GROK_SESSION*`, `XAI_*`, `AI_AGENT`, `SESSION_HANDOFF_AGENT` are all unset in grok shells. The native CLI **is** the `grok-build` lane.

## Fix
`_detect_caller_identity_from_env`: `GROK_AGENT` → `"grok-build"`, placed **before** the soft `CLAUDE_PROJECT_DIR` heuristic so a leaked `CLAUDE_*` var can't misroute a grok caller to the claude inbox. An explicit, validated `SESSION_HANDOFF_AGENT` still wins over it.

## Verified end-to-end
`GROK_AGENT=1 ab ask-claude - --task-id t` (**no `--from`**) → `From: grok-build → To: claude`; Claude's reply ("Paris") routed to grok-build's inbox. 39 tests pass (4 new: GROK_AGENT→grok-build, beats soft claude heuristic, explicit handoff still wins, grok-build is a valid agent).

With this + #5218, a grok session collaborates with claude using the same `ask-* -` piped form as every other lane, zero flags. Lane: infra/bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)