### PR TITLE
[infra][ci] Fetch full history for pytest ancestry proofs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,6 +704,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          fetch-depth: 0
         if: needs.changes.outputs.python == 'true'
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
Fixes #5222. Unblocks #5157 / #5211; coordination epic #5152.

## Summary

- fetch full repository history only in the `Test (pytest)` job
- preserve the fail-closed historical ancestry proof in the P5 pilot
- keep the P5 implementation PR at its existing 19-file scope

## Root cause

CI run `29385115192` used the default shallow checkout, so valid historical merge `b348d4823f3b4f8d13e8e02db1bc3fdc0ef491cc` was unavailable to the pilot's ancestry check. All 12 failures were confined to `tests/orchestration/test_curriculum_lifecycle_pilot.py`; the remaining suite reported `11147 passed, 164 skipped, 1 xfailed`.

## Verification

- `bash scripts/audit/check_workflows.sh .github/workflows/ci.yml` — actionlint 1.7.12 passed
- `git diff --check` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

## Scope

One file, one line. No runner behavior, tests, protected configs, generated artifacts, or learner content changed.
