### PR TITLE
chore(streams): register ULIF integration epic #5224 under atlas-intake

### DIFF
--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -14,7 +14,7 @@ streams:
     epics: [4387, 4700]        # umbrella + UX-quality-wave child board
   atlas-intake:
     title: "Word Atlas full-corpus intake"
-    epics: [4220, 4378]        # intake epic + entry-model DB epic
+    epics: [4220, 4378, 5224]        # intake epic + entry-model DB epic
   corpus-channels:
     title: "Corpus channels — acquisition & ingestion"
     epics: [4706]


### PR DESCRIPTION
Registers ULIF source-integration epic #5224 under the atlas-intake stream so child tasks #5225–#5230 are valid stream members. One-line registry addition. Refs #5224.