### PR TITLE
fix(harness/llm_qg): normalize trace model keys comparison consistently on both sides

### DIFF
--- a/scripts/audit/layerb_judge_bridge.py
+++ b/scripts/audit/layerb_judge_bridge.py
@@ -91,6 +91,9 @@ _TRACE_ACTIVITY_RE = re.compile(
     r"(?:^|[^a-z0-9])(tool|function|mcp|web|browser|terminal|shell|computer)(?:$|[^a-z0-9])", re.I
 )
 _TRACE_MODEL_KEYS = frozenset({"model", "model_id", "model_version", "modelversion", "resolved_model"})
+# _TRACE_MODEL_KEYS mixes raw and normalized spellings; normalize the set once
+# so keys like "model_id" (→ "modelid") actually match after normalization.
+_NORMALIZED_TRACE_MODEL_KEYS = frozenset(re.sub(r"[^a-z0-9]", "", key) for key in _TRACE_MODEL_KEYS)
 _TRACE_METADATA_KEYS = frozenset(
     {"type", "event", "kind", "name", "namespace", "tool", "toolname", "function", "category", "operation"}
 )
@@ -921,7 +924,7 @@ def _resolved_models(events: Sequence[Mapping[str, Any]]) -> set[str]:
         for payload in _mapping_values(event):
             for key, value in payload.items():
                 normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
-                if normalized_key in _TRACE_MODEL_KEYS and isinstance(value, str) and value.strip():
+                if normalized_key in _NORMALIZED_TRACE_MODEL_KEYS and isinstance(value, str) and value.strip():
                     models.add(value.strip())
     return models
 
@@ -1053,9 +1056,6 @@ def _grok_updates_allowlisted(updates: Sequence[Mapping[str, Any]]) -> bool:
     return True
 
 
-# _TRACE_MODEL_KEYS mixes raw and normalized spellings; normalize the set once
-# so keys like "model_id" (→ "modelid") actually match after normalization.
-_NORMALIZED_TRACE_MODEL_KEYS = frozenset(re.sub(r"[^a-z0-9]", "", key) for key in _TRACE_MODEL_KEYS)
 
 
 def _collect_grok_trace_models(value: Any, models: set[str]) -> None:

--- a/tests/test_layerb_judge_bridge.py
+++ b/tests/test_layerb_judge_bridge.py
@@ -1473,3 +1473,28 @@ def test_grok_print_config_rejects_retired_model_pin(capsys: pytest.CaptureFixtu
         ["--judge-family", "grok", "--judge-model", "grok-build", "--print-config"]
     ) == 2
     assert "Grok Layer-B judges must use grok-4.5" in capsys.readouterr().err
+
+
+def test_codex_trace_keys_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A model_id-style key (e.g., model_id, model_version, resolved_model) should match and accept
+    for key in ("model_id", "model_version", "resolved_model", "model"):
+        _stub_codex(
+            monkeypatch,
+            output=_result(),
+            events=[{"type": "session_meta", key: PINNED_CODEX_MODEL}, {"type": "task_complete"}],
+        )
+        response = layerb_judge_bridge.run_bridge(_request(), _config())
+        assert _relation(response)["relation"] == "ENTAILS", f"Failed to match key: {key}"
+        assert response.get("_bridge_conservative_reason") is None
+
+    # An unknown model under a model_id-style key must still be rejected (fail-closed, model_pin)
+    for key in ("model_id", "model_version", "resolved_model", "model"):
+        _stub_codex(
+            monkeypatch,
+            output=_result(),
+            events=[{"type": "session_meta", key: "gpt-5.6-other"}, {"type": "task_complete"}],
+        )
+        response = layerb_judge_bridge.run_bridge(_request(), _config())
+        assert _relation(response)["relation"] == "ABSTAIN", f"Failed to reject wrong model with key: {key}"
+        assert response.get("_bridge_conservative_reason") == "model_pin", f"Failed to reject wrong model with key: {key}"
+


### PR DESCRIPTION
Fixes #5204.

### Failing-vs-Fixed Key Match:
- **Failing key match**: The key check in `_resolved_models` compared the normalized key from trace events (`normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())`) against the un-normalized set `_TRACE_MODEL_KEYS = {"model", "model_id", "model_version", "modelversion", "resolved_model"}`. Because normalized keys cannot contain underscores, keys like `model_id`, `model_version`, and `resolved_model` never matched.
- **Fixed key match**: The check now compares `normalized_key` against `_NORMALIZED_TRACE_MODEL_KEYS = {"model", "modelid", "modelversion", "resolvedmodel"}` which is normalized consistently on both sides.

### Reject-Still-Works Test:
```python
def test_codex_trace_keys_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
    # A model_id-style key (e.g., model_id, model_version, resolved_model) should match and accept
    for key in ("model_id", "model_version", "resolved_model", "model"):
        _stub_codex(
            monkeypatch,
            output=_result(),
            events=[{"type": "session_meta", key: PINNED_CODEX_MODEL}, {"type": "task_complete"}],
        )
        response = layerb_judge_bridge.run_bridge(_request(), _config())
        assert _relation(response)["relation"] == "ENTAILS", f"Failed to match key: {key}"
        assert response.get("_bridge_conservative_reason") is None

    # An unknown model under a model_id-style key must still be rejected (fail-closed, model_pin)
    for key in ("model_id", "model_version", "resolved_model", "model"):
        _stub_codex(
            monkeypatch,
            output=_result(),
            events=[{"type": "session_meta", key: "gpt-5.6-other"}, {"type": "task_complete"}],
        )
        response = layerb_judge_bridge.run_bridge(_request(), _config())
        assert _relation(response)["relation"] == "ABSTAIN", f"Failed to reject wrong model with key: {key}"
        assert response.get("_bridge_conservative_reason") == "model_pin", f"Failed to reject wrong model with key: {key}"
```
