### PR TITLE
fix(orchestration): integrate rollover task lifecycle

### DIFF
--- a/agents_extensions/shared/skills/thread-rollover/SKILL.md
+++ b/agents_extensions/shared/skills/thread-rollover/SKILL.md
@@ -5,9 +5,10 @@ description: Prepare, resume, validate, and confirm a durable Codex thread rollo
 
 # Thread Rollover
 
-Use `--agent codex` for every Codex orchestrator command. Never fork, continue,
-copy provider history, or select an ambiguous task. Use the Codex app to create a
-fresh task titled `Rollover <lineage-id> <rollover-id>` after `prepare` prints both IDs.
+Use `--agent codex` for every Codex command. Never fork, continue, copy provider
+history, or select a task by title. The repository owns the durable transition
+plan and receipts; the app-capable agent owns the native create/title/archive
+calls. Repo-local Python never writes Codex state directly.
 
 ## Health
 
@@ -28,15 +29,83 @@ For a known packet, inspect health without changing it.
 ## Rollover
 
 Prepare only from the active Codex thread; this reserves every packet path and
-keeps cleanup false.
+keeps cleanup false. Supply durable epic, goal, and phase metadata together when
+known; `--next-phase` is optional.
 
 ```bash
-.venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent codex --active-thread-id "$CODEX_THREAD_ID"
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare \
+  --agent codex \
+  --active-thread-id "$CODEX_THREAD_ID" \
+  --epic-title "<durable epic label>" \
+  --goal "<current goal>" \
+  --phase "<current phase>" \
+  --next-phase "<next phase>"
 ```
 
-Read the resulting `handoff_file`, then create the fresh Codex app task with the
-unique title above. Do not use a fork, copied provider history, or an ambiguous
-existing task.
+`prepare` returns `intended_title`, exact native lifecycle IDs, and a
+`create_thread` action. The title is derived from the supplied metadata, for
+example `Curriculum lifecycle — P5 CI unblock → P6`. If those fields are not
+available, the fallback includes the durable lineage and generation. Never use
+`Resume codex rollover` or another generic title.
+
+In an app-capable task:
+
+1. Ask the receipt whether native creation is authorized:
+
+   ```bash
+   .venv/bin/python scripts/orchestration/thread_handoff.py native-action \
+     --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+     --action create
+   ```
+
+2. Only when it returns `needs_native_action: true`, call native
+   `create_thread` once with the returned bootstrap prompt and the local project
+   environment. A queued `clientThreadId` is not an exact task identity; wait
+   for a real `threadId` or record a failure and stop. Immediately persist the
+   successful result before binding, so a crash cannot authorize a duplicate:
+
+   ```bash
+   .venv/bin/python scripts/orchestration/thread_handoff.py record-native-result \
+     --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+     --action create --succeeded \
+     --evidence "create_thread returned threadId <exact-thread-id>"
+   ```
+
+3. Bind that exact replacement to the exact predecessor and persist both typed
+   relations:
+
+   ```bash
+   .venv/bin/python scripts/orchestration/thread_handoff.py register-created \
+     --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+     --replacement-thread-id <exact-thread-id> \
+     --evidence "native create_thread result <exact-thread-id>"
+   ```
+
+4. Ask the receipt for the exact title mutation:
+
+   ```bash
+   .venv/bin/python scripts/orchestration/thread_handoff.py native-action \
+     --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+     --action title
+   ```
+
+   Only when it returns `needs_native_action: true`, call native
+   `set_thread_title` with its exact `arguments`. Persist the native result
+   before read-back, then reconcile it:
+
+   ```bash
+   .venv/bin/python scripts/orchestration/thread_handoff.py record-native-result \
+     --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+     --action title --succeeded --evidence "set_thread_title acknowledged"
+   .venv/bin/python scripts/orchestration/thread_handoff.py reconcile-native \
+     --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+     --action title
+   ```
+
+If a native tool is absent or fails, use `record-native-result --failed
+--error "..."` for the attempted action and stop. On retry, run
+`native-action` first. It reconciles exact native state before authorizing a
+mutation and will not repeat an acknowledged action while read-back is pending.
 
 ## Resume and confirm
 
@@ -59,3 +128,29 @@ Monitor facts and never pad anchors.
 Create `strict_answers_path` only from the questions-only view after restoring
 context. `confirm-started` unlocks cleanup only when the separate challenge proof
 and strict verdict both bind to the exact reserved packet paths and pass 10/10.
+
+## Archive the confirmed predecessor
+
+After `confirm-started` succeeds, read the exact `predecessor_thread_id` through
+the native app. Archive only if authoritative app state proves that exact task
+is idle and unpinned. Never infer pin state from its absence: use `unknown` and
+preserve the predecessor when the app does not expose it.
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py native-action \
+  --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+  --action archive --source-status idle --pin-state unpinned \
+  --evidence "native read_thread/app state for exact predecessor UUID"
+```
+
+Only a response with `needs_native_action: true` authorizes native
+`set_thread_archived` with the returned exact arguments. Then persist and
+reconcile exactly as for title, using `--action archive`. Any missing proof,
+unconfirmed replacement, title mismatch, ambiguous identity, running status,
+pinned/unknown pin state, app/API absence, or partial failure leaves the exact
+predecessor visible and records a retryable blocker. Unrelated tasks are never
+archive candidates.
+
+This archive step does not replace or weaken the existing automation cleanup
+gate. Delete or pause an old heartbeat only after `confirm-started` reports
+`old_automation_ready_to_delete: true`.

--- a/docs/best-practices/codex-thread-handoff.md
+++ b/docs/best-practices/codex-thread-handoff.md
@@ -5,12 +5,16 @@ or orchestrator heartbeat thread approaches the auto-compaction zone.
 
 ## Verified Capabilities
 
-Verified locally on 2026-05-30:
+Verified locally through 2026-07-15:
 
-- Codex app tools are exposed in this environment for `create_thread`,
-  `list_threads`, `read_thread`, `send_message_to_thread`,
-  `set_thread_title`, `set_thread_pinned`, `set_thread_archived`, and
-  `automation_update`.
+- Codex app tools can expose `create_thread`, `list_threads`, `read_thread`,
+  `send_message_to_thread`, `set_thread_title`, `set_thread_pinned`,
+  `set_thread_archived`, and `automation_update`. Availability is runtime
+  dependent and must be checked in the app-capable task.
+- Native `read_thread` status is suitable for exact-identity reconciliation,
+  but the current response does not provide authoritative pin state. A missing
+  pin field is `unknown`, not proof of `unpinned`, so automatic predecessor
+  archive remains blocked unless another native app fact supplies it.
 - Those app tools are not callable from a repo-local Python subprocess.
   Local automation must therefore generate state, prompts, and guardrails
   without depending on them.
@@ -35,12 +39,16 @@ The handoff system has three separate layers:
 - Worker inbox: delegate task state and result excerpts collected from
   `batch_state/tasks/`.
 
-The thread rollover layer uses a local thread lease plus a generated bootstrap
-prompt, scoped by agent name:
+The thread rollover layer uses a lineage-scoped lease, a generated bootstrap
+prompt, and a Task Family Manager transition operation:
 
-- Lease state: `.agent/<agent>-thread-lease.json` (gitignored)
-- Bootstrap prompt: `.agent/<agent>-thread-bootstrap.md` (gitignored)
-- Thread rollover packet: `.agent/<agent>-thread-handoff.md` (gitignored)
+- Lease state: `.agent/thread-rollovers/<agent>/<lineage-id>/lease.json`
+  (gitignored)
+- Packet directory:
+  `.agent/thread-rollovers/<agent>/<lineage-id>/generation-NNNN/<rollover-id>/`
+  (gitignored)
+- Native transition plan, binding, events, and receipts:
+  `.agent/task-families/<family-id>/operations/<operation-id>/` (gitignored)
 - Durable Codex orchestrator handoff:
   `docs/session-state/codex-orchestrator-handoff.md`
 - Codex role handoff pointer:
@@ -68,7 +76,10 @@ The lease records:
 - active orchestrator generation and thread id, when known
 - active heartbeat automation id, when known
 - replacement generation
-- replacement status: `pending_start` or `started`
+- replacement status: `pending_start`, `resumed`, or `started`
+- deterministic intended title and its durable source metadata
+- exact source/replacement native IDs and typed `replacement_of` plus
+  `rollover_generation_of` relations after native creation
 - bootstrap prompt path
 - cleanup guard: `old_automation_ready_to_delete`
 
@@ -84,6 +95,11 @@ zone:
 ```bash
 .venv/bin/python scripts/orchestration/thread_handoff.py prepare \
   --agent orchestrator \
+  --active-thread-id <current-thread-id> \
+  --epic-title "<durable epic label>" \
+  --goal "<current goal>" \
+  --phase "<current phase>" \
+  --next-phase "<next phase>" \
   --context-percent 86
 ```
 
@@ -97,18 +113,49 @@ If the active thread id or automation id is known, include them:
   --context-percent 86
 ```
 
-This writes:
-
-- `.agent/orchestrator-thread-lease.json`
-- `.agent/orchestrator-thread-bootstrap.md`
-- `.agent/orchestrator-thread-handoff.md`
+This writes the lineage-scoped lease and packet plus an immutable Task Family
+Manager transition plan and receipt. `intended_title` is human-readable when
+the durable metadata is supplied. Without all three required fields, the safe
+fallback includes lineage and generation. `Resume codex rollover` is forbidden.
 
 It does not modify git-tracked handoff files by default.
 
-The generated prompt is the exact replacement-thread bootstrap. If the Codex
-app `create_thread` tool is available to the current agent, use it with that
-prompt. If it is not available, create one new Codex UI thread manually and
-paste the generated prompt. That is the only unavoidable UI action.
+The generated prompt is the exact replacement-thread bootstrap. The
+app-capable path first runs `native-action --action create` and calls native
+`create_thread` only when authorized. It must obtain a real `threadId`; a queued
+`clientThreadId` is not sufficient to bind identity. It immediately records
+the successful native result, then runs `register-created` with the exact
+replacement UUID and asks
+`native-action --action title` for the exact mutation, calls native
+`set_thread_title` only when authorized, records the acknowledgement or
+failure, and reconciles native read-back. If an app API is absent, record the
+failure and preserve the durable operation for retry rather than creating or
+choosing another task by title.
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py native-action \
+  --agent orchestrator --lineage-id <lineage-id> \
+  --rollover-id <rollover-id> --action create
+# After native create_thread returns an exact threadId:
+.venv/bin/python scripts/orchestration/thread_handoff.py record-native-result \
+  --agent orchestrator --lineage-id <lineage-id> \
+  --rollover-id <rollover-id> --action create --succeeded \
+  --evidence "create_thread returned exact threadId"
+.venv/bin/python scripts/orchestration/thread_handoff.py register-created \
+  --agent orchestrator --lineage-id <lineage-id> \
+  --rollover-id <rollover-id> \
+  --replacement-thread-id <exact-replacement-thread-id> \
+  --evidence "native create_thread result"
+.venv/bin/python scripts/orchestration/thread_handoff.py native-action \
+  --agent orchestrator --lineage-id <lineage-id> \
+  --rollover-id <rollover-id> --action title
+```
+
+Use the returned exact `arguments` with native `set_thread_title`, then run
+`record-native-result --action title --succeeded --evidence "..."` and
+`reconcile-native --action title`. For a failed native call, use `--failed
+--error "..."`. Always retry through `native-action`; its receipt and read-back
+logic prevent duplicate successful mutations.
 
 The bootstrap starts with a checklist that is deliberately hard to skip:
 
@@ -135,19 +182,35 @@ The replacement thread reads both durable role state and thread rollover state:
 - durable role state:
   `docs/session-state/codex-orchestrator-handoff.md`
 - local thread rollover packet:
-  `.agent/orchestrator-thread-handoff.md`
+  the exact `handoff_file` under
+  `.agent/thread-rollovers/orchestrator/<lineage-id>/generation-NNNN/<rollover-id>/`
 
 After the replacement thread is visibly running, confirm it:
 
 ```bash
 .venv/bin/python scripts/orchestration/thread_handoff.py confirm-started \
   --agent orchestrator \
-  --new-thread-id <replacement-thread-id>
+  --lineage-id <lineage-id> \
+  --rollover-id <rollover-id> \
+  --new-thread-id <replacement-thread-id> \
+  --canary-proof <reserved-canary-proof-path> \
+  --strict-probe <reserved-strict-probe-path> \
+  --strict-verdict <reserved-strict-verdict-path>
 ```
 
 Only if the output shows `"old_automation_ready_to_delete": true` may the old
 heartbeat automation be deleted or paused through the Codex app
-`automation_update` tool.
+`automation_update` tool. This existing proof gate is independent from and not
+weakened by task archival.
+
+After confirmation, inspect the exact `predecessor_thread_id` through the app.
+Run `native-action --action archive` with authoritative status and pin facts.
+The command authorizes native `set_thread_archived` only when the exact bound
+predecessor is idle and unpinned, the replacement title is reconciled, and the
+canary plus strict 10/10 recall and cleanup proofs all pass. Pinned, running,
+ambiguous, unrelated, or unconfirmed tasks are preserved. Unknown status or pin
+state is a durable blocker. Record and reconcile an authorized archive exactly
+as for title.
 
 ## Non-Orchestrator Agent Rollover
 
@@ -159,10 +222,9 @@ Agents other than the orchestrator write only their own handoff by default:
   --context-percent 86
 ```
 
-That writes `.agent/codex-thread-lease.json`,
-`.agent/codex-thread-bootstrap.md`, and
-`.agent/codex-thread-handoff.md`. It does not modify
-`docs/session-state/current.md` and does not touch durable role handoff files.
+That writes only the Codex lineage-scoped runtime packet and Task Family
+Manager operation. It does not modify `docs/session-state/current.md` and does
+not touch durable role handoff files.
 
 `--write-current` is deprecated and rejected unless paired with
 `--allow-git-router`. Use that pair only for an explicitly approved
@@ -174,7 +236,12 @@ Confirm the replacement with the same agent name:
 ```bash
 .venv/bin/python scripts/orchestration/thread_handoff.py confirm-started \
   --agent codex \
-  --new-thread-id <replacement-thread-id>
+  --lineage-id <lineage-id> \
+  --rollover-id <rollover-id> \
+  --new-thread-id <replacement-thread-id> \
+  --canary-proof <reserved-canary-proof-path> \
+  --strict-probe <reserved-strict-probe-path> \
+  --strict-verdict <reserved-strict-verdict-path>
 ```
 
 ## Safety Checks
@@ -236,11 +303,20 @@ source_head=$(git rev-parse HEAD)
   --agent codex \
   --active-thread-id <predecessor-task-id> \
   --active-automation-id <predecessor-automation-id> \
+  --epic-title "Rollover smoke" \
+  --goal "restart verification" \
+  --phase "claim" \
+  --next-phase "confirm" \
   | tee "$evidence/prepare.json"
 lineage_id=$(jq -r .lineage_id "$evidence/prepare.json")
 rollover_id=$(jq -r .rollover_id "$evidence/prepare.json")
 lease_rel=$(jq -r .state_file "$evidence/prepare.json")
 lease="$canonical/$lease_rel"
+.venv/bin/python scripts/orchestration/thread_handoff.py native-action \
+  --agent codex --lineage-id "$lineage_id" \
+  --rollover-id "$rollover_id" --action create \
+  | tee "$evidence/create-action.json"
+test "$(jq -r .needs_native_action "$evidence/create-action.json")" = true
 ```
 
 Create one genuinely fresh Codex app project task and record its new task id
@@ -254,6 +330,30 @@ fresh=<absolute-app-worktree-path>
 initial_replacement_task_id=<fresh-task-id>
 printf '%s\n' "$initial_replacement_task_id" \
   > "$evidence/initial-replacement-task-id.txt"
+.venv/bin/python scripts/orchestration/thread_handoff.py record-native-result \
+  --agent codex --lineage-id "$lineage_id" \
+  --rollover-id "$rollover_id" --action create --succeeded \
+  --evidence "smoke create_thread returned $initial_replacement_task_id"
+.venv/bin/python scripts/orchestration/thread_handoff.py register-created \
+  --agent codex --lineage-id "$lineage_id" \
+  --rollover-id "$rollover_id" \
+  --replacement-thread-id "$initial_replacement_task_id" \
+  --evidence "fresh smoke create_thread result" \
+  | tee "$evidence/register-created.json"
+.venv/bin/python scripts/orchestration/thread_handoff.py native-action \
+  --agent codex --lineage-id "$lineage_id" \
+  --rollover-id "$rollover_id" --action title \
+  | tee "$evidence/title-action.json"
+# The app-capable agent calls set_thread_title with title-action.json's exact
+# arguments, then persists its acknowledgement before read-back.
+.venv/bin/python scripts/orchestration/thread_handoff.py record-native-result \
+  --agent codex --lineage-id "$lineage_id" \
+  --rollover-id "$rollover_id" --action title --succeeded \
+  --evidence "smoke set_thread_title acknowledgement"
+.venv/bin/python scripts/orchestration/thread_handoff.py reconcile-native \
+  --agent codex --lineage-id "$lineage_id" \
+  --rollover-id "$rollover_id" --action title \
+  | tee "$evidence/title-reconcile.json"
 bash "$fresh/scripts/lib/thread_rollover_link.sh" "$canonical" "$fresh" \
   | tee "$evidence/fresh-bootstrap.txt"
 git -C "$canonical" worktree list | tee "$evidence/worktrees.txt"
@@ -357,8 +457,10 @@ worktree. First require both checkouts to remain clean and at `source_head`, the
 restore the canonical checkout with `git -C "$canonical" switch main`. Treat an
 index lock as live unless `lsof` proves no process owns it; remove only a proven
 stale lock before switching. Stop for manual recovery if either checkout is
-dirty or any Git process still owns the lock. Archive the smoke tasks and remove
-only their clean app worktrees.
+dirty or any Git process still owns the lock. Archive the exact confirmed
+predecessor only through the authorized native archive sequence above. Preserve
+every task whose status, pin state, identity, or relation is unknown, and remove
+only clean app worktrees whose exact ownership is proven.
 
 Keep all captured evidence under `/tmp/rollover-smoke-*`; the packet itself
 stays under gitignored `.agent/thread-rollovers/`. Delete or pause the

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -115,10 +115,69 @@ resume_fixture() {
   local state_file="$3"
   local replacement_thread_id="$4"
   local rollover_id
+  local source_thread_id
+  local intended_title
+  local db_path
 
   rollover_id=$("$REPO_ROOT/.venv/bin/python" -c \
     'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["replacement"]["rollover_id"])' \
     "$state_file")
+  source_thread_id=$("$REPO_ROOT/.venv/bin/python" -c \
+    'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["active"]["thread_id"])' \
+    "$state_file")
+  intended_title=$("$REPO_ROOT/.venv/bin/python" -c \
+    'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["replacement"]["display"]["title"])' \
+    "$state_file")
+  db_path="$root/state_session-fixture.sqlite"
+
+  "$REPO_ROOT/.venv/bin/python" - "$db_path" "$source_thread_id" "$replacement_thread_id" "$root" <<'PYEOF'
+import sqlite3
+import sys
+
+db_path, source_id, replacement_id, cwd = sys.argv[1:]
+with sqlite3.connect(db_path) as connection:
+    connection.execute(
+        "CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT, cwd TEXT, "
+        "archived INTEGER, archived_at TEXT, host TEXT)"
+    )
+    connection.executemany(
+        "INSERT INTO threads VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (source_id, "confirmed predecessor", cwd, 0, None, "fixture"),
+            (replacement_id, "Resume codex rollover", cwd, 0, None, "fixture"),
+        ],
+    )
+PYEOF
+
+  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    --repo-root "$root" --monitor-base-url http://127.0.0.1:1 native-action --agent "$agent" \
+    --state-file "$state_file" --rollover-id "$rollover_id" --action create >/dev/null
+  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    --repo-root "$root" --monitor-base-url http://127.0.0.1:1 record-native-result --agent "$agent" \
+    --state-file "$state_file" --rollover-id "$rollover_id" --action create --succeeded \
+    --evidence "fixture create_thread returned $replacement_thread_id" >/dev/null
+  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    --repo-root "$root" --monitor-base-url http://127.0.0.1:1 register-created --agent "$agent" \
+    --state-file "$state_file" --rollover-id "$rollover_id" --replacement-thread-id "$replacement_thread_id" \
+    --db "$db_path" --evidence "fixture exact native create result" >/dev/null
+  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    --repo-root "$root" --monitor-base-url http://127.0.0.1:1 native-action --agent "$agent" \
+    --state-file "$state_file" --rollover-id "$rollover_id" --action title --db "$db_path" >/dev/null
+  "$REPO_ROOT/.venv/bin/python" - "$db_path" "$replacement_thread_id" "$intended_title" <<'PYEOF'
+import sqlite3
+import sys
+
+db_path, replacement_id, intended_title = sys.argv[1:]
+with sqlite3.connect(db_path) as connection:
+    connection.execute("UPDATE threads SET title = ? WHERE id = ?", (intended_title, replacement_id))
+PYEOF
+  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    --repo-root "$root" --monitor-base-url http://127.0.0.1:1 record-native-result --agent "$agent" \
+    --state-file "$state_file" --rollover-id "$rollover_id" --action title --succeeded \
+    --evidence "fixture set_thread_title acknowledged" >/dev/null
+  "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    --repo-root "$root" --monitor-base-url http://127.0.0.1:1 reconcile-native --agent "$agent" \
+    --state-file "$state_file" --rollover-id "$rollover_id" --action title --db "$db_path" >/dev/null
 
   HOME="$TMP_ROOT/home" XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" XDG_DATA_HOME="$TMP_ROOT/xdg-data" XDG_STATE_HOME="$TMP_ROOT/xdg-state" GH_CONFIG_DIR="$TMP_ROOT/gh" PATH="/usr/bin:/bin" \
     "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
@@ -332,16 +391,19 @@ assert_contains "$output" "Multiple live pending rollovers found for agent codex
 
 # 15. Resumed packet for current thread allowed; mismatch blocks.
 setup_fixture "$fixture_root"
-prepare_fixture "$fixture_root" codex old-thread
+source_thread_id="00000000-0000-4000-8000-000000000011"
+replacement_thread_id="00000000-0000-4000-8000-000000000012"
+other_thread_id="00000000-0000-4000-8000-000000000013"
+prepare_fixture "$fixture_root" codex "$source_thread_id"
 state_file="$(find_rollover_lease "$fixture_root" codex)"
-resume_fixture "$fixture_root" codex "$state_file" old-thread
-output="$(run_hook "$fixture_root" 0 codex old-thread)"
+resume_fixture "$fixture_root" codex "$state_file" "$replacement_thread_id"
+output="$(run_hook "$fixture_root" 0 codex "$replacement_thread_id")"
 assert_contains "$output" "RESUMED THREAD ROLLOVER DETECTED" "resumed same thread"
 assert_not_contains "$output" "PENDING THREAD ROLLOVER DETECTED" "resumed same thread"
 
-output="$(run_hook "$fixture_root" 0 codex other-thread)"
+output="$(run_hook "$fixture_root" 0 codex "$other_thread_id")"
 assert_contains "$output" "live rollover is already bound to a different replacement thread" "resumed bound other thread"
-assert_contains "$output" "old-thread" "resumed bound other thread"
+assert_contains "$output" "$replacement_thread_id" "resumed bound other thread"
 
 # 16. PostCompact remains read-only and surfaces packet health only.
 setup_fixture "$fixture_root"

--- a/scripts/orchestration/task_family/graph.py
+++ b/scripts/orchestration/task_family/graph.py
@@ -22,8 +22,11 @@ def _display_role(role: str) -> str:
     return role
 
 
-def _bounded_title(base_title: str, roles: tuple[str, ...]) -> str:
+def bounded_title(base_title: str, roles: tuple[str, ...] = ()) -> str:
+    """Bound display text without changing the exact-ID identity model."""
     base = base_title.strip()
+    if not base:
+        raise ValueError("title must be non-empty")
     suffix = " · ".join(_display_role(role) for role in roles)
     if not suffix:
         available = CODEX_TITLE_MAX_CHARS
@@ -238,6 +241,6 @@ def rename_mapping(graph: FamilyGraph, base_title: str) -> tuple[TitleRename, ..
     changes: list[TitleRename] = []
     for node in sorted(graph.nodes_by_id.values(), key=lambda item: item.task_id):
         roles = graph.roles_by_task[node.task_id]
-        new_title = _bounded_title(base_title, roles)
+        new_title = bounded_title(base_title, roles)
         changes.append(TitleRename(node.task_id, node.title, new_title, roles))
     return tuple(changes)

--- a/scripts/orchestration/task_family/rollover.py
+++ b/scripts/orchestration/task_family/rollover.py
@@ -1,0 +1,866 @@
+"""Task Family Manager adapter for Codex rollover-native actions.
+
+Repo-local Python cannot invoke Codex app tools. This module owns the durable
+exact-ID plan, typed family binding, native acknowledgements, read-back
+reconciliation, and retry decisions used by the app-capable rollover skill.
+It never writes Codex state directly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Literal
+
+from . import codex_state
+from .graph import bounded_title, discover_task_family
+from .model import (
+    LifecycleEvent,
+    LifecycleState,
+    OperationReceipt,
+    ReceiptAction,
+    RelationType,
+    TaskFamilyManifest,
+    TaskNode,
+    TaskRelation,
+    utc_now,
+)
+from .planner import sha256_digest
+from .storage import TaskFamilyStorage
+
+PLAN_SCHEMA_VERSION = 1
+NATIVE_ACTIONS = frozenset({"create", "title", "archive"})
+PinState = Literal["unpinned", "pinned", "unknown"]
+
+
+def _clean_display(value: str | None, label: str) -> str | None:
+    if value is None:
+        return None
+    cleaned = " ".join(value.split())
+    if not cleaned:
+        raise ValueError(f"{label} must be non-empty when supplied")
+    if any(ord(character) < 32 for character in cleaned):
+        raise ValueError(f"{label} contains control characters")
+    return cleaned
+
+
+def rollover_title(
+    *,
+    agent: str,
+    lineage_id: str,
+    generation: int,
+    epic_title: str | None,
+    goal: str | None,
+    phase: str | None,
+    next_phase: str | None = None,
+) -> tuple[str, str, dict[str, str | None]]:
+    """Return a bounded human title or a unique lineage/generation fallback."""
+    fields = {
+        "epic_title": _clean_display(epic_title, "epic title"),
+        "goal": _clean_display(goal, "goal"),
+        "phase": _clean_display(phase, "phase"),
+        "next_phase": _clean_display(next_phase, "next phase"),
+    }
+    required = (fields["epic_title"], fields["goal"], fields["phase"])
+    if any(required) and not all(required):
+        raise ValueError("epic title, goal, and phase must be supplied together")
+    if all(required):
+        base = f"{fields['epic_title']} — {fields['phase']} {fields['goal']}"
+        if fields["next_phase"]:
+            base += f" → {fields['next_phase']}"
+        source = "durable_metadata"
+    else:
+        if generation < 1:
+            raise ValueError("rollover generation must be positive")
+        agent_label = _clean_display(agent, "agent")
+        assert agent_label is not None
+        base = f"{agent_label[:6].title()} continuity — {lineage_id} · g{generation:04d}"
+        source = "lineage_generation_fallback"
+    title = bounded_title(base)
+    if title.casefold() in {"resume codex rollover", "rollover"}:
+        raise ValueError("generic rollover titles are forbidden")
+    return title, source, fields
+
+
+def transition_identity(*, lineage_id: str, generation: int) -> tuple[str, str]:
+    """Return stable TFM family and operation IDs for safe retries."""
+    family_id = f"rollover-{lineage_id}-g{generation:04d}"
+    operation_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"learn-ukrainian:{family_id}:native-transition"))
+    return family_id, operation_id
+
+
+def _plan_digest(payload: dict[str, Any]) -> str:
+    immutable = dict(payload)
+    immutable.pop("digest", None)
+    return sha256_digest(immutable)
+
+
+def _load_plan(storage: TaskFamilyStorage) -> dict[str, Any]:
+    plan = storage.read_json(storage.rollover_plan_path)
+    if plan.get("schema_version") != PLAN_SCHEMA_VERSION or plan.get("kind") != "rollover_native_transition":
+        raise ValueError("persisted rollover transition plan is malformed")
+    digest = plan.get("digest")
+    if not isinstance(digest, str) or digest != _plan_digest(plan):
+        raise ValueError("persisted rollover transition plan digest mismatch")
+    return plan
+
+
+def _load_binding(storage: TaskFamilyStorage) -> dict[str, Any]:
+    binding = storage.read_json(storage.rollover_binding_path)
+    if binding.get("schema_version") != PLAN_SCHEMA_VERSION or binding.get("kind") != "rollover_native_binding":
+        raise ValueError("persisted rollover binding is malformed")
+    if binding.get("plan_digest") != _load_plan(storage)["digest"]:
+        raise ValueError("persisted rollover binding does not match the immutable plan")
+    return binding
+
+
+def _event(
+    storage: TaskFamilyStorage,
+    *,
+    state: LifecycleState,
+    kind: str,
+    details: dict[str, Any],
+) -> None:
+    storage.append_event(
+        LifecycleEvent(
+            event_id=str(uuid.uuid4()),
+            occurred_at=utc_now(),
+            state=state,
+            kind=kind,
+            details=details,
+        )
+    )
+
+
+def _action_key(action: ReceiptAction) -> tuple[str, str, str]:
+    return action.resource_type, action.resource_id, action.action
+
+
+def _append_receipt(
+    storage: TaskFamilyStorage,
+    *,
+    final_state: LifecycleState | None = None,
+    actual: ReceiptAction | None = None,
+    skipped: ReceiptAction | None = None,
+    failure: ReceiptAction | None = None,
+) -> OperationReceipt:
+    receipt = storage.load_receipt()
+
+    def add_unique(items: tuple[ReceiptAction, ...], item: ReceiptAction | None) -> tuple[ReceiptAction, ...]:
+        if item is None or _action_key(item) in {_action_key(existing) for existing in items}:
+            return items
+        return (*items, item)
+
+    updated = replace(
+        receipt,
+        final_state=final_state or receipt.final_state,
+        actual=add_unique(receipt.actual, actual),
+        skipped=add_unique(receipt.skipped, skipped),
+        failures=(*receipt.failures, failure) if failure is not None else receipt.failures,
+        events=storage.load_events(),
+    )
+    storage.write_receipt(updated)
+    return updated
+
+
+def prepare_transition(
+    *,
+    repo_root: Path,
+    agent: str,
+    lineage_id: str,
+    rollover_id: str,
+    generation: int,
+    source_thread_id: str,
+    intended_title: str,
+    title_source: str,
+    bootstrap_prompt_path: str,
+) -> dict[str, Any]:
+    family_id, operation_id = transition_identity(lineage_id=lineage_id, generation=generation)
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    payload: dict[str, Any] = {
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "kind": "rollover_native_transition",
+        "family_id": family_id,
+        "operation_id": operation_id,
+        "agent": agent,
+        "lineage_id": lineage_id,
+        "rollover_id": rollover_id,
+        "generation": generation,
+        "project_root": str(repo_root.resolve()),
+        "source_thread_id": source_thread_id,
+        "intended_title": intended_title,
+        "title_source": title_source,
+        "bootstrap_prompt_path": bootstrap_prompt_path,
+        "relation_types": [RelationType.REPLACEMENT_OF.value, RelationType.ROLLOVER_GENERATION_OF.value],
+    }
+    payload["digest"] = _plan_digest(payload)
+    storage.write_immutable_json(storage.rollover_plan_path, payload)
+    if not storage.receipt_path.exists():
+        planned = (
+            ReceiptAction("rollover", rollover_id, (source_thread_id,), "create_replacement", "Use native create_thread once."),
+            ReceiptAction("rollover", rollover_id, (source_thread_id,), "title_replacement", intended_title),
+            ReceiptAction("task", source_thread_id, (source_thread_id,), "archive_confirmed_predecessor", "Proof and app-state gated."),
+        )
+        _event(
+            storage,
+            state=LifecycleState.PLANNED,
+            kind="rollover_native_intent_prepared",
+            details={"plan_digest": payload["digest"]},
+        )
+        storage.write_receipt(
+            OperationReceipt(
+                operation_id,
+                family_id,
+                payload["digest"],
+                LifecycleState.PLANNED,
+                planned=planned,
+                events=storage.load_events(),
+            )
+        )
+        storage.write_state(
+            LifecycleState.PLANNED,
+            details={"status": "awaiting_native_create", "plan_digest": payload["digest"]},
+        )
+    else:
+        receipt = storage.load_receipt()
+        if receipt.plan_digest != payload["digest"]:
+            raise ValueError("existing rollover receipt does not match the immutable transition plan")
+    return {
+        "family_id": family_id,
+        "operation_id": operation_id,
+        "plan_digest": payload["digest"],
+        "receipt_path": str(storage.receipt_path),
+        "status": storage.load_state()["details"].get("status"),
+    }
+
+
+def bind_replacement(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+    source: codex_state.ThreadRecord,
+    replacement: codex_state.ThreadRecord,
+    db_path: Path,
+    evidence: str,
+) -> dict[str, Any]:
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    plan = _load_plan(storage)
+    source_id = plan["source_thread_id"]
+    if source.thread_id != source_id:
+        raise ValueError("native binding source does not match the persisted predecessor")
+    if replacement.thread_id == source_id:
+        raise ValueError("replacement thread must differ from the predecessor")
+    if not evidence.strip():
+        raise ValueError("native create evidence is required")
+    project_root = plan["project_root"]
+    source_metadata = {"cwd": source.cwd, **({"host": source.host} if source.host else {})}
+    replacement_metadata = {"cwd": replacement.cwd, **({"host": replacement.host} if replacement.host else {})}
+    manifest = TaskFamilyManifest(
+        family_id=family_id,
+        seed_task_id=source_id,
+        nodes=(
+            TaskNode(source_id, source.title, project_root, metadata=source_metadata),
+            TaskNode(replacement.thread_id, replacement.title, project_root, metadata=replacement_metadata),
+        ),
+        relations=(
+            TaskRelation(replacement.thread_id, source_id, RelationType.REPLACEMENT_OF, evidence),
+            TaskRelation(replacement.thread_id, source_id, RelationType.ROLLOVER_GENERATION_OF, evidence),
+        ),
+    )
+    graph = discover_task_family(manifest)
+    if not graph.is_valid:
+        raise ValueError("invalid rollover task family: " + "; ".join(blocker.message for blocker in graph.blockers))
+    storage.write_manifest(manifest)
+    binding = {
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "kind": "rollover_native_binding",
+        "plan_digest": plan["digest"],
+        "source_thread_id": source_id,
+        "replacement_thread_id": replacement.thread_id,
+        "source_title": source.title,
+        "replacement_initial_title": replacement.title,
+        "intended_title": plan["intended_title"],
+        "source_cwd": source.cwd,
+        "replacement_cwd": replacement.cwd,
+        "source_host": source.host,
+        "replacement_host": replacement.host,
+        "db_path": str(db_path),
+        "relations": [relation.to_dict() for relation in manifest.relations],
+        "evidence": evidence,
+    }
+    storage.write_immutable_json(storage.rollover_binding_path, binding)
+    actual = ReceiptAction(
+        "task",
+        replacement.thread_id,
+        (replacement.thread_id, source_id),
+        "create_replacement",
+        evidence,
+    )
+    if _action_key(actual) in {_action_key(item) for item in storage.load_receipt().actual}:
+        skipped = ReceiptAction(
+            "task",
+            replacement.thread_id,
+            (replacement.thread_id, source_id),
+            "create_retry_readback",
+            "Exact binding already persisted; no second create call.",
+        )
+        _event(
+            storage,
+            state=LifecycleState.VERIFIED,
+            kind="native_create_retry_reconciled",
+            details={"replacement_thread_id": replacement.thread_id},
+        )
+        _append_receipt(storage, skipped=skipped)
+    else:
+        _event(
+            storage,
+            state=LifecycleState.VERIFIED,
+            kind="native_create_bound",
+            details={"replacement_thread_id": replacement.thread_id, "evidence": evidence},
+        )
+        _append_receipt(storage, actual=actual)
+    storage.write_state(
+        LifecycleState.VERIFIED,
+        details={"status": "awaiting_native_title", "replacement_thread_id": replacement.thread_id},
+    )
+    return binding
+
+
+def _has_actual(storage: TaskFamilyStorage, action: str) -> bool:
+    return any(item.action == action for item in storage.load_receipt().actual)
+
+
+def _last_ack(storage: TaskFamilyStorage, action: str) -> bool | None:
+    prefix = f"native_{action}_ack_"
+    matches = [event for event in storage.load_events() if event.kind.startswith(prefix)]
+    if not matches:
+        return None
+    return matches[-1].kind == f"native_{action}_ack_succeeded"
+
+
+def record_native_result(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+    action: str,
+    succeeded: bool,
+    evidence: str,
+    error: str = "",
+) -> dict[str, Any]:
+    if action not in NATIVE_ACTIONS:
+        raise ValueError(f"unsupported native rollover action: {action}")
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    plan = _load_plan(storage)
+    binding = _load_binding(storage) if action != "create" and storage.rollover_binding_path.exists() else None
+    endpoint = "replacement" if action == "title" else "source"
+    resource_id = plan["rollover_id"] if binding is None else binding[f"{endpoint}_thread_id"]
+    if not evidence.strip():
+        raise ValueError("native action evidence is required")
+    if succeeded:
+        _event(
+            storage,
+            state=LifecycleState.VERIFIED,
+            kind=f"native_{action}_ack_succeeded",
+            details={"resource_id": resource_id, "evidence": evidence},
+        )
+        actual = ReceiptAction(
+            "task" if binding else "rollover",
+            resource_id,
+            (resource_id,),
+            f"native_{action}_ack",
+            evidence,
+        )
+        _append_receipt(storage, actual=actual)
+        status = f"native_{action}_acknowledged"
+    else:
+        message = error.strip() or "native action failed without an error detail"
+        recovery = f"Retry the exact {action} action after checking the receipt; never choose a new task by title."
+        _event(
+            storage,
+            state=LifecycleState.BLOCKED,
+            kind=f"native_{action}_ack_failed",
+            details={"resource_id": resource_id, "evidence": evidence, "error": message},
+        )
+        failure = ReceiptAction(
+            "task" if binding else "rollover",
+            resource_id,
+            (resource_id,),
+            f"native_{action}_failed",
+            evidence,
+            message,
+            recovery,
+        )
+        _append_receipt(storage, failure=failure)
+        storage.write_state(
+            LifecycleState.BLOCKED,
+            details={"status": f"native_{action}_failed", "recovery": recovery},
+        )
+        status = f"native_{action}_failed"
+    return {
+        "ok": succeeded,
+        "action": action,
+        "resource_id": resource_id,
+        "status": status,
+        "receipt_path": str(storage.receipt_path),
+    }
+
+
+def record_blocker(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+    action: str,
+    error: str,
+    evidence: str,
+) -> dict[str, Any]:
+    """Persist a pre-mutation failure without misreporting a native call."""
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    plan = _load_plan(storage)
+    binding = _load_binding(storage) if storage.rollover_binding_path.exists() else None
+    endpoint = "replacement" if action == "title" else "source"
+    resource_id = plan["rollover_id"] if binding is None else binding[f"{endpoint}_thread_id"]
+    recovery = "Repair the exact precondition, then ask for the same persisted action again."
+    failure = ReceiptAction(
+        "task" if binding else "rollover",
+        resource_id,
+        (resource_id,),
+        f"{action}_preflight_blocked",
+        evidence,
+        error,
+        recovery,
+    )
+    _event(
+        storage,
+        state=LifecycleState.BLOCKED,
+        kind=f"rollover_{action}_preflight_blocked",
+        details={"resource_id": resource_id, "error": error, "evidence": evidence},
+    )
+    _append_receipt(storage, failure=failure)
+    storage.write_state(
+        LifecycleState.BLOCKED,
+        details={"status": f"{action}_preflight_blocked", "error": error, "recovery": recovery},
+    )
+    return {
+        "ok": False,
+        "action": action,
+        "status": "blocked",
+        "task_id": resource_id,
+        "error": error,
+        "receipt_path": str(storage.receipt_path),
+    }
+
+
+def request_create_action(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+) -> dict[str, Any]:
+    """Return one retry-safe native create decision before exact-ID binding."""
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    plan = _load_plan(storage)
+    if storage.rollover_binding_path.exists():
+        binding = _load_binding(storage)
+        skipped = ReceiptAction(
+            "task",
+            binding["replacement_thread_id"],
+            (binding["replacement_thread_id"], plan["source_thread_id"]),
+            "create_retry_readback",
+            "Exact replacement binding already exists; no second native create is authorized.",
+        )
+        _event(
+            storage,
+            state=LifecycleState.VERIFIED,
+            kind="native_create_retry_reconciled",
+            details={"replacement_thread_id": binding["replacement_thread_id"]},
+        )
+        _append_receipt(storage, skipped=skipped)
+        return {
+            "ok": True,
+            "action": "create",
+            "status": "already_bound",
+            "needs_native_action": False,
+            "replacement_thread_id": binding["replacement_thread_id"],
+            "receipt_path": str(storage.receipt_path),
+        }
+    if _last_ack(storage, "create") is True:
+        recovery = "Recover the exact threadId from the acknowledged create result, then run register-created."
+        if not any(item.action == "create_binding_missing_after_ack" for item in storage.load_receipt().failures):
+            failure = ReceiptAction(
+                "rollover",
+                plan["rollover_id"],
+                (plan["source_thread_id"],),
+                "create_binding_missing_after_ack",
+                "Native create succeeded, but exact replacement binding is incomplete.",
+                "A second create is forbidden after a successful native acknowledgement.",
+                recovery,
+            )
+            _event(
+                storage,
+                state=LifecycleState.BLOCKED,
+                kind="native_create_binding_missing_after_ack",
+                details={"rollover_id": plan["rollover_id"]},
+            )
+            _append_receipt(storage, failure=failure)
+        storage.write_state(
+            LifecycleState.BLOCKED,
+            details={"status": "awaiting_create_binding", "recovery": recovery},
+        )
+        return {
+            "ok": False,
+            "action": "create",
+            "status": "awaiting_create_binding",
+            "needs_native_action": False,
+            "recovery": recovery,
+            "receipt_path": str(storage.receipt_path),
+        }
+    storage.write_state(
+        LifecycleState.PLANNED,
+        details={"status": "awaiting_native_create", "source_thread_id": plan["source_thread_id"]},
+    )
+    return {
+        "ok": True,
+        "action": "create",
+        "status": "needs_native_action",
+        "needs_native_action": True,
+        "tool": "create_thread",
+        "bootstrap_prompt_path": plan["bootstrap_prompt_path"],
+        "intended_title": plan["intended_title"],
+        "source_thread_id": plan["source_thread_id"],
+        "receipt_path": str(storage.receipt_path),
+    }
+
+
+def _exact_record(binding: dict[str, Any], *, action: str, db_path: Path) -> codex_state.ThreadRecord:
+    endpoint = "replacement" if action == "title" else "source"
+    task_id = binding[f"{endpoint}_thread_id"]
+    record = codex_state.read_thread_record(db_path, task_id=task_id)
+    expected_cwd = binding[f"{endpoint}_cwd"]
+    expected_host = binding[f"{endpoint}_host"]
+    if record.cwd != expected_cwd or (expected_host is not None and record.host != expected_host):
+        raise codex_state.CodexStateContextError(
+            "exact rollover task cwd or host no longer matches the native binding"
+        )
+    return record
+
+
+def reconcile_action(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+    action: Literal["title", "archive"],
+    db_path: Path,
+) -> dict[str, Any]:
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    binding = _load_binding(storage)
+    endpoint = "replacement" if action == "title" else "source"
+    reconciled_action = f"{action}_reconciled"
+    if _has_actual(storage, reconciled_action):
+        skipped = ReceiptAction(
+            "task",
+            binding[f"{endpoint}_thread_id"],
+            (),
+            f"{action}_retry_readback",
+            "Already reconciled; no second native mutation was performed.",
+        )
+        final_state = LifecycleState.VERIFIED if action == "title" else LifecycleState.TASKS_ARCHIVED
+        _event(
+            storage,
+            state=final_state,
+            kind=f"native_{action}_retry_reconciled",
+            details={"readback_only": True},
+        )
+        _append_receipt(storage, skipped=skipped)
+        return {"ok": True, "action": action, "status": "already_reconciled", "readback_only": True}
+    try:
+        if action == "title":
+            record = _exact_record(binding, action=action, db_path=db_path)
+            if record.title != binding["intended_title"]:
+                raise codex_state.CodexStateContextError(
+                    "replacement title has not reached the persisted intended title"
+                )
+            final_state = LifecycleState.VERIFIED
+        else:
+            record = codex_state.await_task_target(
+                task_id=binding["source_thread_id"],
+                expected_title=binding["source_title"],
+                expected_cwd=binding["source_cwd"],
+                expected_host=binding["source_host"],
+                expected_archived=True,
+                db_path=db_path,
+            )
+            final_state = LifecycleState.TASKS_ARCHIVED
+    except (codex_state.CodexStateError, ValueError) as exc:
+        task_id = binding[f"{endpoint}_thread_id"]
+        recovery = "Do not repeat a successful native acknowledgement; retry read-back first."
+        failure = ReceiptAction(
+            "task",
+            task_id,
+            (task_id,),
+            f"{action}_reconciliation_failed",
+            "Native read-back did not reach the exact persisted target.",
+            str(exc),
+            recovery,
+        )
+        _event(
+            storage,
+            state=LifecycleState.BLOCKED,
+            kind=f"native_{action}_reconciliation_failed",
+            details={"task_id": task_id, "error": str(exc), "native_ack": _last_ack(storage, action)},
+        )
+        _append_receipt(storage, failure=failure)
+        storage.write_state(
+            LifecycleState.BLOCKED,
+            details={"status": f"{action}_reconciliation_failed", "native_ack": _last_ack(storage, action)},
+        )
+        return {
+            "ok": False,
+            "action": action,
+            "status": "reconciliation_failed",
+            "error": str(exc),
+            "native_ack": _last_ack(storage, action),
+        }
+    task_id = record.thread_id
+    actual = ReceiptAction(
+        "task",
+        task_id,
+        (task_id,),
+        reconciled_action,
+        "Native DB read-back verified the exact persisted target.",
+    )
+    readback_only = _last_ack(storage, action) is not True
+    _event(
+        storage,
+        state=final_state,
+        kind=f"native_{action}_reconciled",
+        details={"task_id": task_id, "readback_only": readback_only},
+    )
+    _append_receipt(storage, final_state=final_state, actual=actual)
+    storage.write_state(final_state, details={"status": reconciled_action, "task_id": task_id})
+    return {
+        "ok": True,
+        "action": action,
+        "status": reconciled_action,
+        "task_id": task_id,
+        "readback_only": readback_only,
+    }
+
+
+def _confirmation_blockers(state: dict[str, Any], binding: dict[str, Any]) -> list[str]:
+    replacement = state.get("replacement") or {}
+    cleanup = state.get("cleanup") or {}
+    blockers: list[str] = []
+    if replacement.get("status") != "started":
+        blockers.append("replacement is not confirmed started")
+    if replacement.get("thread_id") != binding["replacement_thread_id"]:
+        blockers.append("confirmed replacement identity does not match the native binding")
+    if replacement.get("resumed_thread_id") != binding["replacement_thread_id"]:
+        blockers.append("resumed replacement identity does not match the native binding")
+    if (state.get("active") or {}).get("thread_id") != binding["source_thread_id"]:
+        blockers.append("persisted predecessor identity does not match the native binding")
+    if cleanup.get("old_automation_ready_to_delete") is not True:
+        blockers.append("existing confirmation cleanup proof gate is still locked")
+    proof = replacement.get("canary_proof") or {}
+    verdict = replacement.get("strict_verdict") or {}
+    if proof.get("verdict") != "PASS":
+        blockers.append("script canary proof is not PASS")
+    if verdict.get("verdict") != "PASS" or verdict.get("correct") != 10 or verdict.get("k") != 10:
+        blockers.append("strict recall verdict is not PASS 10/10")
+    return blockers
+
+
+def authorize_archive(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+    state: dict[str, Any],
+    source_status: str,
+    pin_state: PinState,
+    evidence: str,
+) -> dict[str, Any]:
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    binding = _load_binding(storage)
+    blockers = _confirmation_blockers(state, binding)
+    if not _has_actual(storage, "title_reconciled"):
+        blockers.append("replacement title has not been reconciled")
+    if source_status.strip().lower() != "idle":
+        blockers.append(f"predecessor status is not authoritatively idle: {source_status or 'unknown'}")
+    if pin_state != "unpinned":
+        blockers.append(f"predecessor pin state is not authoritatively unpinned: {pin_state}")
+    if not evidence.strip():
+        blockers.append("app task-state evidence is missing")
+    if blockers:
+        message = "; ".join(blockers)
+        recovery = (
+            "Retry only after exact idle and unpinned app evidence is available "
+            "for the persisted predecessor UUID."
+        )
+        failure = ReceiptAction(
+            "task",
+            binding["source_thread_id"],
+            (binding["source_thread_id"],),
+            "archive_authorization_blocked",
+            f"Predecessor preserved. App evidence: {evidence or 'missing'}",
+            message,
+            recovery,
+        )
+        _event(
+            storage,
+            state=LifecycleState.BLOCKED,
+            kind="rollover_archive_authorization_blocked",
+            details={"task_id": binding["source_thread_id"], "blockers": blockers, "evidence": evidence},
+        )
+        _append_receipt(storage, failure=failure)
+        storage.write_state(
+            LifecycleState.BLOCKED,
+            details={"status": "archive_authorization_blocked", "blockers": blockers},
+        )
+        return {
+            "ok": False,
+            "status": "blocked",
+            "task_id": binding["source_thread_id"],
+            "blockers": blockers,
+            "receipt_path": str(storage.receipt_path),
+        }
+    replacement = state["replacement"]
+    authorization = {
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "kind": "rollover_predecessor_archive_authorization",
+        "plan_digest": _load_plan(storage)["digest"],
+        "source_thread_id": binding["source_thread_id"],
+        "replacement_thread_id": binding["replacement_thread_id"],
+        "source_status": "idle",
+        "pin_state": "unpinned",
+        "evidence": evidence,
+        "canary_proof_sha256": sha256_digest(replacement["canary_proof"]),
+        "strict_verdict_sha256": sha256_digest(replacement["strict_verdict"]),
+        "confirmed_at": replacement["confirmed_at"],
+    }
+    if storage.rollover_archive_authorization_path.exists():
+        existing_authorization = storage.read_json(storage.rollover_archive_authorization_path)
+        stable_existing = dict(existing_authorization)
+        stable_existing.pop("evidence", None)
+        stable_retry = dict(authorization)
+        stable_retry.pop("evidence", None)
+        if stable_existing != stable_retry:
+            raise ValueError("persisted predecessor archive authorization no longer matches the proof state")
+    else:
+        storage.write_immutable_json(storage.rollover_archive_authorization_path, authorization)
+    _event(
+        storage,
+        state=LifecycleState.VERIFIED,
+        kind="rollover_archive_authorized",
+        details={"task_id": binding["source_thread_id"], "evidence": evidence},
+    )
+    storage.write_state(
+        LifecycleState.VERIFIED,
+        details={"status": "awaiting_native_archive", "task_id": binding["source_thread_id"]},
+    )
+    return {
+        "ok": True,
+        "status": "actionable",
+        "task_id": binding["source_thread_id"],
+        "tool": "set_thread_archived",
+        "arguments": {"threadId": binding["source_thread_id"], "archived": True},
+        "receipt_path": str(storage.receipt_path),
+    }
+
+
+def request_action(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+    action: Literal["title", "archive"],
+    db_path: Path,
+    state: dict[str, Any] | None = None,
+    source_status: str = "unknown",
+    pin_state: PinState = "unknown",
+    evidence: str = "",
+) -> dict[str, Any]:
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    binding = _load_binding(storage)
+    if action == "archive":
+        if state is None:
+            raise ValueError("rollover lease state is required for archive authorization")
+        authorization = authorize_archive(
+            repo_root=repo_root,
+            family_id=family_id,
+            operation_id=operation_id,
+            state=state,
+            source_status=source_status,
+            pin_state=pin_state,
+            evidence=evidence,
+        )
+        if not authorization["ok"]:
+            return authorization
+    try:
+        current = _exact_record(binding, action=action, db_path=db_path)
+    except (codex_state.CodexStateError, ValueError) as exc:
+        return record_blocker(
+            repo_root=repo_root,
+            family_id=family_id,
+            operation_id=operation_id,
+            action=action,
+            error=str(exc),
+            evidence="native read-back preflight",
+        )
+    target_satisfied = (
+        current.title == binding["intended_title"] if action == "title" else current.archived
+    )
+    if target_satisfied:
+        reconciled = reconcile_action(
+            repo_root=repo_root,
+            family_id=family_id,
+            operation_id=operation_id,
+            action=action,
+            db_path=db_path,
+        )
+        return {**reconciled, "needs_native_action": False}
+    if _last_ack(storage, action) is True:
+        reconciled = reconcile_action(
+            repo_root=repo_root,
+            family_id=family_id,
+            operation_id=operation_id,
+            action=action,
+            db_path=db_path,
+        )
+        return {
+            **reconciled,
+            "needs_native_action": False,
+            "status": "awaiting_readback",
+            "recovery": "Retry reconciliation only; the native action already acknowledged success.",
+        }
+    endpoint = "replacement" if action == "title" else "source"
+    task_id = binding[f"{endpoint}_thread_id"]
+    if action == "title":
+        tool = "set_thread_title"
+        arguments = {"threadId": task_id, "title": binding["intended_title"]}
+    else:
+        tool = "set_thread_archived"
+        arguments = {"threadId": task_id, "archived": True}
+    storage.write_state(
+        LifecycleState.VERIFIED,
+        details={"status": f"awaiting_native_{action}", "task_id": task_id},
+    )
+    return {
+        "ok": True,
+        "action": action,
+        "status": "needs_native_action",
+        "needs_native_action": True,
+        "task_id": task_id,
+        "tool": tool,
+        "arguments": arguments,
+        "receipt_path": str(storage.receipt_path),
+    }
+
+
+def resolve_db(value: str | Path) -> Path:
+    """Resolve ``auto`` with the same fail-closed discovery as the TFM CLI."""
+    return codex_state.discover_state_database(None if str(value) == "auto" else Path(value))

--- a/scripts/orchestration/task_family/storage.py
+++ b/scripts/orchestration/task_family/storage.py
@@ -106,6 +106,21 @@ class TaskFamilyStorage:
         return self.root / "rename-plan.json"
 
     @property
+    def rollover_plan_path(self) -> Path:
+        """Immutable exact-ID plan for one native rollover transition."""
+        return self.root / "rollover-plan.json"
+
+    @property
+    def rollover_binding_path(self) -> Path:
+        """Immutable native-created replacement identity and typed relations."""
+        return self.root / "rollover-binding.json"
+
+    @property
+    def rollover_archive_authorization_path(self) -> Path:
+        """Immutable post-confirmation authorization for one predecessor archive."""
+        return self.root / "rollover-archive-authorization.json"
+
+    @property
     def lock_path(self) -> Path:
         return self.root / ".operation.lock"
 

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -31,12 +31,16 @@ from typing import Any
 try:
     from scripts import context_canary
     from scripts.orchestration import thread_handoff_canary
+    from scripts.orchestration.task_family import codex_state as task_family_codex_state
+    from scripts.orchestration.task_family import rollover as task_family_rollover
 except ModuleNotFoundError as exc:
     if __package__ or exc.name != "scripts":
         raise
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     import context_canary
     import thread_handoff_canary
+    from orchestration.task_family import codex_state as task_family_codex_state
+    from orchestration.task_family import rollover as task_family_rollover
 
 SCHEMA_VERSION = 2
 DEFAULT_MONITOR_BASE_URL = "http://127.0.0.1:8765"
@@ -671,6 +675,10 @@ def prepare_state(
     active_automation_id: str | None,
     context_percent: float | None,
     force_new_replacement: bool,
+    epic_title: str | None = None,
+    goal: str | None = None,
+    phase: str | None = None,
+    next_phase: str | None = None,
 ) -> dict[str, Any]:
     if state.get("schema_version") != SCHEMA_VERSION:
         raise ValueError("schema v2 state is required; migrate v1 explicitly before preparing")
@@ -727,6 +735,19 @@ def prepare_state(
     generation = int((prepared["active"] or {}).get("generation", 0)) + 1
     rollover_id = new_rollover_id()
     packet_paths = replacement_packet_paths(agent, lineage_id, generation, rollover_id)
+    intended_title, title_source, display_metadata = task_family_rollover.rollover_title(
+        agent=agent,
+        lineage_id=lineage_id,
+        generation=generation,
+        epic_title=epic_title,
+        goal=goal,
+        phase=phase,
+        next_phase=next_phase,
+    )
+    family_id, operation_id = task_family_rollover.transition_identity(
+        lineage_id=lineage_id,
+        generation=generation,
+    )
     replacement = {
         "rollover_id": rollover_id,
         "lineage_id": lineage_id,
@@ -735,6 +756,18 @@ def prepare_state(
         "prepared_at": isoformat_z(now),
         "thread_id": None,
         "canary_challenge": new_canary_challenge(),
+        "display": {
+            **display_metadata,
+            "title": intended_title,
+            "title_source": title_source,
+        },
+        "native_lifecycle": {
+            "family_id": family_id,
+            "operation_id": operation_id,
+            "source_thread_id": requested_thread_id,
+            "replacement_thread_id": None,
+            "status": "awaiting_native_create",
+        },
         **packet_paths,
     }
     prepared["replacement"] = replacement
@@ -806,6 +839,28 @@ def validate_live_lease(
         binding_error = source_checkout_binding_error(replacement)
         if binding_error:
             return None, binding_error
+        if "display" in replacement or "native_lifecycle" in replacement:
+            display = replacement.get("display")
+            if (
+                not isinstance(display, dict)
+                or not isinstance(display.get("title"), str)
+                or not display["title"].strip()
+                or len(display["title"]) > 60
+                or display["title"].casefold() in {"resume codex rollover", "rollover"}
+            ):
+                return None, "replacement display metadata is missing, generic, or malformed"
+            expected_family_id, expected_operation_id = task_family_rollover.transition_identity(
+                lineage_id=lineage_id,
+                generation=generation,
+            )
+            native = replacement.get("native_lifecycle")
+            if (
+                not isinstance(native, dict)
+                or native.get("family_id") != expected_family_id
+                or native.get("operation_id") != expected_operation_id
+                or native.get("source_thread_id") != active["thread_id"]
+            ):
+                return None, "replacement native lifecycle identity is missing, forged, or malformed"
         expected_paths = replacement_packet_paths(agent, lineage_id, generation, rollover_id)
         for key, expected in expected_paths.items():
             if replacement.get(key) != expected:
@@ -907,10 +962,16 @@ def confirm_started(
 
     confirmed = dict(state)
     replacement = dict(confirmed["replacement"])
+    active = confirmed.get("active")
+    if not isinstance(active, dict) or not isinstance(active.get("thread_id"), str) or not active["thread_id"].strip():
+        raise ValueError("confirmed rollover has no exact predecessor thread identity")
     if replacement.get("status") != "resumed":
         raise ValueError("replacement must be resumed through the rollover packet before confirmation")
     if replacement.get("resumed_thread_id") != new_thread_id.strip():
         raise ValueError("--new-thread-id does not match the thread that resumed this rollover")
+    native = replacement.get("native_lifecycle")
+    if isinstance(native, dict) and native.get("replacement_thread_id") != new_thread_id.strip():
+        raise ValueError("--new-thread-id does not match the exact native-created replacement")
     proof, proof_error = thread_handoff_canary.load_and_validate_pass_proof(
         canary_proof,
         rollover_id=str(replacement.get("rollover_id") or ""),
@@ -932,6 +993,11 @@ def confirm_started(
         replacement["automation_id"] = new_automation_id
     replacement["canary_proof"] = proof
     replacement["strict_verdict"] = strict_evidence
+    if isinstance(native, dict):
+        native = dict(native)
+        native["status"] = "confirmed_started"
+        native["confirmed_at"] = isoformat_z(now)
+        replacement["native_lifecycle"] = native
     confirmed["replacement"] = replacement
 
     cleanup = dict(confirmed.get("cleanup") or {})
@@ -958,6 +1024,13 @@ def resume_state(
     thread_id = replacement_thread_id.strip()
     if not thread_id:
         raise ValueError("--replacement-thread-id is required")
+    native = replacement.get("native_lifecycle")
+    if isinstance(native, dict):
+        bound_thread_id = native.get("replacement_thread_id")
+        if not isinstance(bound_thread_id, str) or not bound_thread_id.strip():
+            raise ValueError("native-created replacement must be registered before resume")
+        if bound_thread_id != thread_id:
+            raise ValueError("--replacement-thread-id does not match the exact native-created replacement")
     existing = replacement.get("resumed_thread_id")
     if existing and existing != thread_id:
         raise ValueError("pending rollover is already bound to a different replacement thread")
@@ -966,6 +1039,11 @@ def resume_state(
     replacement["status"] = "resumed"
     replacement["resumed_thread_id"] = thread_id
     replacement.setdefault("resumed_at", isoformat_z(now))
+    if isinstance(native, dict):
+        native = dict(native)
+        native["status"] = "resumed"
+        native["resumed_at"] = replacement["resumed_at"]
+        replacement["native_lifecycle"] = native
     resumed = dict(state)
     resumed["replacement"] = replacement
     resumed["updated_at"] = isoformat_z(now)
@@ -1088,6 +1166,7 @@ def render_bootstrap_prompt(
     github = snapshot["github"]
     active = state.get("active") or {}
     replacement = state.get("replacement") or {}
+    display = replacement.get("display") or {}
     prompt_path = replacement.get("bootstrap_prompt_path") or "unknown"
     handoff_path = handoff_path or Path(replacement.get("handoff_path") or "unknown")
     role_handoff_path = role_handoff_path or default_handoff_path(agent)
@@ -1119,6 +1198,7 @@ def render_bootstrap_prompt(
                 f"Work locally in {git.get('repo_root')}.",
                 "",
                 f"You are the replacement {agent_label} thread.",
+                f"Task title: {display.get('title', 'unknown')}",
                 f"Replacement generation: {replacement_generation}",
                 f"Rollover id: {rollover_id}",
                 f"Previous active generation: {active_generation}",
@@ -1140,6 +1220,8 @@ def render_bootstrap_prompt(
                 "- Do not edit generated status/audit/review artifacts, linter configs, or .python-version.",
                 "- Do not write docs/session-state/current.md for thread rollover.",
                 "- Do not delete or migrate the old heartbeat automation until the confirm-started command below has succeeded.",
+                "- Do not archive the predecessor unless the exact post-confirmation native action is authorized with idle and unpinned app evidence.",
+                "- The predecessor app task must register and title this exact native replacement before resume. If registration is not yet visible, preserve this task and retry the same packet; never create or select another task.",
                 "",
                 *first_turn_checklist_lines(
                     repo_root=str(git.get("repo_root")),
@@ -1163,6 +1245,8 @@ def render_bootstrap_prompt(
                 f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {rollover_id} --replacement-thread-id <replacement-thread-id> --challenge {canary_challenge} --proof-file {canary_proof_path.as_posix()}",
                 f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --new-thread-id <replacement-thread-id> --canary-proof {canary_proof_path.as_posix()} --strict-probe {strict_probe_path.as_posix()} --strict-verdict {strict_verdict_path.as_posix()}",
                 "```",
+                "",
+                "After confirmation, read the exact predecessor through the native app. Run `native-action --action archive` with its authoritative status and pin facts. If either fact is absent, use `unknown`; the durable receipt must block and preserve the predecessor. Only an actionable response authorizes `set_thread_archived` for the returned exact UUID, followed by `record-native-result` and `reconcile-native`.",
                 "",
                 "Only after that command reports old_automation_ready_to_delete=true may the old heartbeat automation be deleted or paused.",
                 "",
@@ -1528,6 +1612,10 @@ def cmd_prepare(args: argparse.Namespace) -> int:
             active_automation_id=args.active_automation_id,
             context_percent=args.context_percent,
             force_new_replacement=args.force_new_replacement,
+            epic_title=args.epic_title,
+            goal=args.goal,
+            phase=args.phase,
+            next_phase=args.next_phase,
         )
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "state_file": rel(state_path, state_root)}, indent=2))
@@ -1598,6 +1686,9 @@ def cmd_prepare(args: argparse.Namespace) -> int:
             "strict_answers_file": replacement["strict_answers_path"],
             "strict_verdict_file": replacement["strict_verdict_path"],
             "canary_proof_file": replacement["canary_proof_path"],
+            "intended_title": replacement["display"]["title"],
+            "title_source": replacement["display"]["title_source"],
+            "native_lifecycle": replacement["native_lifecycle"],
             "bootstrap_prompt": prompt,
         }
         print(json.dumps(output, indent=2))
@@ -1606,6 +1697,34 @@ def cmd_prepare(args: argparse.Namespace) -> int:
     write_text_atomic(bootstrap_path, prompt)
     write_text_atomic(handoff_path, handoff_md)
     write_json_atomic(state_path, prepared_state)
+    try:
+        native_transition = task_family_rollover.prepare_transition(
+            repo_root=state_root,
+            agent=agent,
+            lineage_id=lineage_id,
+            rollover_id=replacement["rollover_id"],
+            generation=replacement["generation"],
+            source_thread_id=prepared_state["active"]["thread_id"],
+            intended_title=replacement["display"]["title"],
+            title_source=replacement["display"]["title_source"],
+            bootstrap_prompt_path=replacement["bootstrap_prompt_path"],
+        )
+    except (OSError, ValueError) as exc:
+        replacement["native_lifecycle"]["status"] = "intent_persistence_failed"
+        replacement["native_lifecycle"]["error"] = str(exc)
+        prepared_state["replacement"] = replacement
+        write_json_atomic(state_path, prepared_state)
+        print(
+            json.dumps(
+                {
+                    "error": f"native rollover intent persistence failed: {exc}",
+                    "state_file": rel(state_path, state_root),
+                    "old_automation_ready_to_delete": False,
+                },
+                indent=2,
+            )
+        )
+        return 2
     wrote_router = False
     if args.write_current:
         write_text_atomic(router_path, router_md)
@@ -1631,9 +1750,216 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         "strict_answers_file": replacement["strict_answers_path"],
         "strict_verdict_file": replacement["strict_verdict_path"],
         "canary_proof_file": replacement["canary_proof_path"],
+        "intended_title": replacement["display"]["title"],
+        "title_source": replacement["display"]["title_source"],
+        "native_lifecycle": native_transition,
+        "next_native_action": {
+            "tool": "create_thread",
+            "title_after_create": replacement["display"]["title"],
+            "source_thread_id": prepared_state["active"]["thread_id"],
+        },
     }
     print(json.dumps(output, indent=2))
     return 0
+
+
+def _native_command_context(
+    args: argparse.Namespace,
+) -> tuple[Path, Path, str, Path, dict[str, Any], dict[str, Any]]:
+    repo_root, state_root = resolve_roots(args.repo_root)
+    agent = normalize_agent_name(args.agent)
+    if not args.lineage_id and not args.state_file:
+        raise ValueError("--lineage-id or --state-file is required to locate an isolated rollover")
+    state_path = resolve_state_path(
+        repo_root=repo_root,
+        state_root=state_root,
+        supplied_state_file=args.state_file,
+        default_path=default_state_path(agent, args.lineage_id) if args.lineage_id else None,
+    )
+    state = load_state(state_path)
+    state_error = state_error_payload(state, state_path, state_root)
+    if state_error:
+        raise ValueError(state_error["error"])
+    replacement = state.get("replacement") or {}
+    if replacement.get("rollover_id") != args.rollover_id:
+        raise ValueError("--rollover-id does not match the isolated rollover")
+    native = replacement.get("native_lifecycle")
+    if not isinstance(native, dict) or not native.get("family_id") or not native.get("operation_id"):
+        raise ValueError("rollover has no durable native lifecycle plan")
+    generation = replacement.get("generation")
+    lineage_id = replacement.get("lineage_id")
+    if not isinstance(generation, int) or generation < 1 or not isinstance(lineage_id, str):
+        raise ValueError("rollover native lifecycle identity is malformed")
+    expected_family_id, expected_operation_id = task_family_rollover.transition_identity(
+        lineage_id=lineage_id,
+        generation=generation,
+    )
+    if native.get("family_id") != expected_family_id or native.get("operation_id") != expected_operation_id:
+        raise ValueError("rollover native lifecycle identity does not match its durable lineage")
+    if native.get("source_thread_id") != (state.get("active") or {}).get("thread_id"):
+        raise ValueError("rollover native predecessor does not match the active lease identity")
+    bound_replacement_id = native.get("replacement_thread_id")
+    resumed_replacement_id = replacement.get("resumed_thread_id") or replacement.get("thread_id")
+    if bound_replacement_id and resumed_replacement_id and bound_replacement_id != resumed_replacement_id:
+        raise ValueError("rollover native replacement does not match the resumed lease identity")
+    return repo_root, state_root, agent, state_path, state, native
+
+
+def _write_native_status(
+    state_path: Path,
+    state: dict[str, Any],
+    *,
+    status: str,
+    replacement_thread_id: str | None = None,
+) -> None:
+    replacement = dict(state["replacement"])
+    native = dict(replacement["native_lifecycle"])
+    native["status"] = status
+    if replacement_thread_id is not None:
+        native["replacement_thread_id"] = replacement_thread_id
+    replacement["native_lifecycle"] = native
+    state["replacement"] = replacement
+    state["updated_at"] = isoformat_z(utc_now())
+    write_json_atomic(state_path, state)
+
+
+def cmd_register_created(args: argparse.Namespace) -> int:
+    state_root: Path | None = None
+    native: dict[str, Any] | None = None
+    try:
+        _, state_root, _, state_path, state, native = _native_command_context(args)
+        db_path = task_family_rollover.resolve_db(args.db)
+        source_id = native["source_thread_id"]
+        replacement_id = args.replacement_thread_id.strip()
+        source = task_family_codex_state.read_thread_record(db_path, task_id=source_id)
+        replacement = task_family_codex_state.read_thread_record(db_path, task_id=replacement_id)
+        binding = task_family_rollover.bind_replacement(
+            repo_root=state_root,
+            family_id=native["family_id"],
+            operation_id=native["operation_id"],
+            source=source,
+            replacement=replacement,
+            db_path=db_path,
+            evidence=args.evidence,
+        )
+        _write_native_status(
+            state_path,
+            state,
+            status="replacement_created_bound",
+            replacement_thread_id=replacement_id,
+        )
+    except (OSError, ValueError, task_family_codex_state.CodexStateError) as exc:
+        blocker_error: str | None = None
+        if state_root is not None and native is not None:
+            try:
+                task_family_rollover.record_blocker(
+                    repo_root=state_root,
+                    family_id=native["family_id"],
+                    operation_id=native["operation_id"],
+                    action="create",
+                    error=str(exc),
+                    evidence=getattr(args, "evidence", "native create binding") or "native create binding",
+                )
+            except (OSError, ValueError) as blocker_exc:
+                blocker_error = str(blocker_exc)
+        payload = {"error": str(exc), "action": "register-created"}
+        if blocker_error is not None:
+            payload["receipt_error"] = blocker_error
+        print(json.dumps(payload, indent=2))
+        return 2
+    print(
+        json.dumps(
+            {
+                "status": "replacement_created_bound",
+                "source_thread_id": binding["source_thread_id"],
+                "replacement_thread_id": binding["replacement_thread_id"],
+                "intended_title": binding["intended_title"],
+                "relations": binding["relations"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def cmd_native_action(args: argparse.Namespace) -> int:
+    try:
+        _, state_root, _, state_path, state, native = _native_command_context(args)
+        if args.action == "create":
+            result = task_family_rollover.request_create_action(
+                repo_root=state_root,
+                family_id=native["family_id"],
+                operation_id=native["operation_id"],
+            )
+        else:
+            try:
+                db_path = task_family_rollover.resolve_db(args.db)
+            except (OSError, ValueError, task_family_codex_state.CodexStateError) as exc:
+                result = task_family_rollover.record_blocker(
+                    repo_root=state_root,
+                    family_id=native["family_id"],
+                    operation_id=native["operation_id"],
+                    action=args.action,
+                    error=str(exc),
+                    evidence="Codex DB discovery preflight",
+                )
+            else:
+                result = task_family_rollover.request_action(
+                    repo_root=state_root,
+                    family_id=native["family_id"],
+                    operation_id=native["operation_id"],
+                    action=args.action,
+                    db_path=db_path,
+                    state=state if args.action == "archive" else None,
+                    source_status=args.source_status,
+                    pin_state=args.pin_state,
+                    evidence=args.evidence,
+                )
+        _write_native_status(state_path, state, status=str(result["status"]))
+    except (OSError, ValueError, task_family_codex_state.CodexStateError) as exc:
+        print(json.dumps({"error": str(exc), "action": args.action}, indent=2))
+        return 2
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("ok") else 2
+
+
+def cmd_record_native_result(args: argparse.Namespace) -> int:
+    try:
+        _, state_root, _, state_path, state, native = _native_command_context(args)
+        result = task_family_rollover.record_native_result(
+            repo_root=state_root,
+            family_id=native["family_id"],
+            operation_id=native["operation_id"],
+            action=args.action,
+            succeeded=args.succeeded,
+            evidence=args.evidence,
+            error=args.error,
+        )
+        _write_native_status(state_path, state, status=str(result["status"]))
+    except (OSError, ValueError, task_family_codex_state.CodexStateError) as exc:
+        print(json.dumps({"error": str(exc), "action": args.action}, indent=2))
+        return 2
+    print(json.dumps(result, indent=2))
+    return 0 if result["ok"] else 2
+
+
+def cmd_reconcile_native(args: argparse.Namespace) -> int:
+    try:
+        _, state_root, _, state_path, state, native = _native_command_context(args)
+        db_path = task_family_rollover.resolve_db(args.db)
+        result = task_family_rollover.reconcile_action(
+            repo_root=state_root,
+            family_id=native["family_id"],
+            operation_id=native["operation_id"],
+            action=args.action,
+            db_path=db_path,
+        )
+        _write_native_status(state_path, state, status=str(result["status"]))
+    except (OSError, ValueError, task_family_codex_state.CodexStateError) as exc:
+        print(json.dumps({"error": str(exc), "action": args.action}, indent=2))
+        return 2
+    print(json.dumps(result, indent=2))
+    return 0 if result["ok"] else 2
 
 
 def cmd_confirm_started(args: argparse.Namespace) -> int:
@@ -1712,7 +2038,10 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
                 "state_file": rel(state_path, state_root),
                 "replacement_status": confirmed["replacement"]["status"],
                 "replacement_thread_id": confirmed["replacement"]["thread_id"],
+                "predecessor_thread_id": confirmed["active"]["thread_id"],
+                "native_lifecycle": confirmed["replacement"].get("native_lifecycle"),
                 "old_automation_ready_to_delete": confirmed["cleanup"]["old_automation_ready_to_delete"],
+                "next_native_action": "Run native-action --action archive with authoritative idle and unpinned app evidence; unknown state preserves the predecessor.",
             },
             indent=2,
         )
@@ -1990,6 +2319,10 @@ def build_parser() -> argparse.ArgumentParser:
     prepare.add_argument("--current-file", type=Path, help="Override the shared docs/session-state/current.md router.")
     prepare.add_argument("--active-thread-id")
     prepare.add_argument("--active-automation-id")
+    prepare.add_argument("--epic-title", help="Durable human epic label for the replacement title.")
+    prepare.add_argument("--goal", help="Durable current goal for the replacement title.")
+    prepare.add_argument("--phase", help="Durable current phase for the replacement title.")
+    prepare.add_argument("--next-phase", help="Optional next phase rendered after an arrow.")
     prepare.add_argument("--context-percent", type=float)
     prepare.add_argument("--context-threshold", type=float, default=DEFAULT_CONTEXT_THRESHOLD)
     prepare.add_argument("--force-new-replacement", action="store_true")
@@ -2013,6 +2346,62 @@ def build_parser() -> argparse.ArgumentParser:
     )
     prepare.add_argument("--dry-run", action="store_true", help="Print the generated packet without writing files.")
     prepare.set_defaults(func=cmd_prepare)
+
+    register = subparsers.add_parser(
+        "register-created",
+        help="Bind the exact native-created replacement UUID and typed Task Family Manager relations.",
+    )
+    register.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    register.add_argument("--lineage-id", type=argparse_lineage_id)
+    register.add_argument("--state-file", type=Path)
+    register.add_argument("--rollover-id", required=True)
+    register.add_argument("--replacement-thread-id", required=True)
+    register.add_argument("--db", default="auto")
+    register.add_argument("--evidence", required=True)
+    register.set_defaults(func=cmd_register_created)
+
+    native_action = subparsers.add_parser(
+        "native-action",
+        help="Reconcile first, then emit at most one exact native title/archive action.",
+    )
+    native_action.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    native_action.add_argument("--lineage-id", type=argparse_lineage_id)
+    native_action.add_argument("--state-file", type=Path)
+    native_action.add_argument("--rollover-id", required=True)
+    native_action.add_argument("--action", choices=("create", "title", "archive"), required=True)
+    native_action.add_argument("--db", default="auto")
+    native_action.add_argument("--source-status", default="unknown")
+    native_action.add_argument("--pin-state", choices=("unpinned", "pinned", "unknown"), default="unknown")
+    native_action.add_argument("--evidence", default="")
+    native_action.set_defaults(func=cmd_native_action)
+
+    native_result = subparsers.add_parser(
+        "record-native-result",
+        help="Persist one native tool acknowledgement or failure before read-back reconciliation.",
+    )
+    native_result.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    native_result.add_argument("--lineage-id", type=argparse_lineage_id)
+    native_result.add_argument("--state-file", type=Path)
+    native_result.add_argument("--rollover-id", required=True)
+    native_result.add_argument("--action", choices=tuple(sorted(task_family_rollover.NATIVE_ACTIONS)), required=True)
+    native_result.add_argument("--evidence", required=True)
+    native_result.add_argument("--error", default="")
+    native_result_group = native_result.add_mutually_exclusive_group(required=True)
+    native_result_group.add_argument("--succeeded", dest="succeeded", action="store_true")
+    native_result_group.add_argument("--failed", dest="succeeded", action="store_false")
+    native_result.set_defaults(func=cmd_record_native_result)
+
+    reconcile_native = subparsers.add_parser(
+        "reconcile-native",
+        help="Verify one exact native title/archive target and update the durable receipt.",
+    )
+    reconcile_native.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    reconcile_native.add_argument("--lineage-id", type=argparse_lineage_id)
+    reconcile_native.add_argument("--state-file", type=Path)
+    reconcile_native.add_argument("--rollover-id", required=True)
+    reconcile_native.add_argument("--action", choices=("title", "archive"), required=True)
+    reconcile_native.add_argument("--db", default="auto")
+    reconcile_native.set_defaults(func=cmd_reconcile_native)
 
     confirm = subparsers.add_parser("confirm-started", help="Confirm that the replacement agent thread is running.")
     confirm.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)

--- a/tests/orchestration/task_family/test_rollover.py
+++ b/tests/orchestration/task_family/test_rollover.py
@@ -1,0 +1,437 @@
+"""Regression coverage for the native rollover Task Family Manager adapter."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from scripts.orchestration.task_family import codex_state, rollover
+from scripts.orchestration.task_family.model import RelationType
+from scripts.orchestration.task_family.storage import TaskFamilyStorage
+
+
+def _write_db(path: Path, rows: list[tuple[str, str, str, int, str | None, str]]) -> None:
+    connection = sqlite3.connect(path)
+    connection.execute(
+        "CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT, cwd TEXT, "
+        "archived INTEGER, archived_at TEXT, host TEXT)"
+    )
+    connection.executemany("INSERT INTO threads VALUES (?, ?, ?, ?, ?, ?)", rows)
+    connection.commit()
+    connection.close()
+
+
+def _transition(tmp_path: Path) -> dict[str, object]:
+    source_id, replacement_id, unrelated_id = (str(uuid4()) for _ in range(3))
+    lineage_id = "lineage-1234567890abcdef12345678"
+    title, title_source, _ = rollover.rollover_title(
+        agent="codex",
+        lineage_id=lineage_id,
+        generation=1,
+        epic_title="Curriculum lifecycle",
+        goal="CI unblock",
+        phase="P5",
+        next_phase="P6",
+    )
+    prepared = rollover.prepare_transition(
+        repo_root=tmp_path,
+        agent="codex",
+        lineage_id=lineage_id,
+        rollover_id="rollover-abc123",
+        generation=1,
+        source_thread_id=source_id,
+        intended_title=title,
+        title_source=title_source,
+        bootstrap_prompt_path=".agent/thread-rollovers/bootstrap.md",
+    )
+    db = tmp_path / "state_5.sqlite"
+    _write_db(
+        db,
+        [
+            (source_id, "Lifecycle source", str(tmp_path), 0, None, "local"),
+            (replacement_id, "Resume codex rollover", str(tmp_path), 0, None, "local"),
+            (unrelated_id, "Resume codex rollover", str(tmp_path), 0, None, "local"),
+        ],
+    )
+    source = codex_state.read_thread_record(db, task_id=source_id)
+    replacement = codex_state.read_thread_record(db, task_id=replacement_id)
+    binding = rollover.bind_replacement(
+        repo_root=tmp_path,
+        family_id=str(prepared["family_id"]),
+        operation_id=str(prepared["operation_id"]),
+        source=source,
+        replacement=replacement,
+        db_path=db,
+        evidence="native create_thread response threadId",
+    )
+    return {
+        "source_id": source_id,
+        "replacement_id": replacement_id,
+        "unrelated_id": unrelated_id,
+        "lineage_id": lineage_id,
+        "title": title,
+        "db": db,
+        "prepared": prepared,
+        "binding": binding,
+    }
+
+
+def _confirmed_state(data: dict[str, object]) -> dict[str, object]:
+    source_id = str(data["source_id"])
+    replacement_id = str(data["replacement_id"])
+    return {
+        "active": {"thread_id": source_id},
+        "replacement": {
+            "status": "started",
+            "thread_id": replacement_id,
+            "resumed_thread_id": replacement_id,
+            "confirmed_at": "2026-07-15T10:00:00Z",
+            "canary_proof": {"verdict": "PASS", "task": replacement_id},
+            "strict_verdict": {"verdict": "PASS", "correct": 10, "k": 10},
+        },
+        "cleanup": {"old_automation_ready_to_delete": True},
+    }
+
+
+def _title_reconciled(tmp_path: Path, data: dict[str, object]) -> None:
+    prepared = data["prepared"]
+    assert isinstance(prepared, dict)
+    with sqlite3.connect(data["db"]) as connection:
+        connection.execute(
+            "UPDATE threads SET title = ? WHERE id = ?",
+            (data["title"], data["replacement_id"]),
+        )
+        connection.commit()
+    result = rollover.reconcile_action(
+        repo_root=tmp_path,
+        family_id=str(prepared["family_id"]),
+        operation_id=str(prepared["operation_id"]),
+        action="title",
+        db_path=Path(data["db"]),
+    )
+    assert result["ok"] is True
+
+
+def test_rollover_titles_are_meaningful_bounded_and_have_unique_fallback() -> None:
+    title, source, metadata = rollover.rollover_title(
+        agent="codex",
+        lineage_id="lineage-1234567890abcdef12345678",
+        generation=1,
+        epic_title="Curriculum lifecycle",
+        goal="CI unblock",
+        phase="P5",
+        next_phase="P6",
+    )
+    assert title == "Curriculum lifecycle — P5 CI unblock → P6"
+    assert source == "durable_metadata"
+    assert metadata["phase"] == "P5"
+    fallback, fallback_source, _ = rollover.rollover_title(
+        agent="codex",
+        lineage_id="lineage-1234567890abcdef12345678",
+        generation=17,
+        epic_title=None,
+        goal=None,
+        phase=None,
+    )
+    assert "lineage-1234567890abcdef12345678" in fallback
+    assert "g0017" in fallback
+    assert len(fallback) <= 60
+    assert fallback_source == "lineage_generation_fallback"
+    assert "resume codex rollover" not in fallback.casefold()
+    orchestrator_fallback, _, _ = rollover.rollover_title(
+        agent="orchestrator",
+        lineage_id="lineage-fedcba0987654321fedcba09",
+        generation=9999,
+        epic_title=None,
+        goal=None,
+        phase=None,
+    )
+    assert "lineage-fedcba0987654321fedcba09" in orchestrator_fallback
+    assert "g9999" in orchestrator_fallback
+    assert len(orchestrator_fallback) <= 60
+    with pytest.raises(ValueError, match="supplied together"):
+        rollover.rollover_title(
+            agent="codex",
+            lineage_id="lineage-1234567890abcdef12345678",
+            generation=1,
+            epic_title="Infrastructure",
+            goal=None,
+            phase="P1",
+        )
+
+
+def test_prepare_and_bind_persist_exact_ids_typed_relations_and_receipt(tmp_path: Path) -> None:
+    data = _transition(tmp_path)
+    prepared = data["prepared"]
+    assert isinstance(prepared, dict)
+    storage = TaskFamilyStorage(tmp_path, str(prepared["family_id"]), str(prepared["operation_id"]))
+    manifest = storage.load_manifest()
+    assert manifest.seed_task_id == data["source_id"]
+    assert {node.task_id for node in manifest.nodes} == {data["source_id"], data["replacement_id"]}
+    assert {relation.relation_type for relation in manifest.relations} == {
+        RelationType.REPLACEMENT_OF,
+        RelationType.ROLLOVER_GENERATION_OF,
+    }
+    assert {relation.source_id for relation in manifest.relations} == {data["replacement_id"]}
+    assert {relation.target_id for relation in manifest.relations} == {data["source_id"]}
+    receipt = storage.load_receipt()
+    assert any(item.action == "create_replacement" and item.resource_id == data["replacement_id"] for item in receipt.actual)
+    assert storage.rollover_binding_path.exists()
+    assert "Resume codex rollover" not in storage.read_json(storage.rollover_plan_path)["intended_title"]
+    retry = rollover.request_create_action(
+        repo_root=tmp_path,
+        family_id=str(prepared["family_id"]),
+        operation_id=str(prepared["operation_id"]),
+    )
+    assert retry["status"] == "already_bound"
+    assert retry["needs_native_action"] is False
+    assert any(item.action == "create_retry_readback" for item in storage.load_receipt().skipped)
+
+
+def test_create_partial_failure_retries_but_success_ack_blocks_duplicate(tmp_path: Path) -> None:
+    source_id = str(uuid4())
+    transition = rollover.prepare_transition(
+        repo_root=tmp_path,
+        agent="codex",
+        lineage_id="lineage-1234567890abcdef12345678",
+        rollover_id="rollover-create-retry",
+        generation=1,
+        source_thread_id=source_id,
+        intended_title="Infrastructure — P1 native lifecycle",
+        title_source="durable_metadata",
+        bootstrap_prompt_path="bootstrap.md",
+    )
+    kwargs = {
+        "repo_root": tmp_path,
+        "family_id": str(transition["family_id"]),
+        "operation_id": str(transition["operation_id"]),
+    }
+    first = rollover.request_create_action(**kwargs)
+    assert first["needs_native_action"] is True
+    rollover.record_native_result(
+        **kwargs,
+        action="create",
+        succeeded=False,
+        evidence="create_thread error response",
+        error="temporary native failure",
+    )
+    assert rollover.request_create_action(**kwargs)["needs_native_action"] is True
+    rollover.record_native_result(
+        **kwargs,
+        action="create",
+        succeeded=True,
+        evidence="create_thread returned 00000000-0000-0000-0000-000000000002",
+    )
+    blocked = rollover.request_create_action(**kwargs)
+    assert blocked["ok"] is False
+    assert blocked["status"] == "awaiting_create_binding"
+    assert blocked["needs_native_action"] is False
+    storage = TaskFamilyStorage(tmp_path, str(transition["family_id"]), str(transition["operation_id"]))
+    assert any(item.action == "create_binding_missing_after_ack" for item in storage.load_receipt().failures)
+
+
+def test_app_absence_and_db_absence_are_durable_and_fail_closed(tmp_path: Path) -> None:
+    source_id = str(uuid4())
+    transition = rollover.prepare_transition(
+        repo_root=tmp_path,
+        agent="codex",
+        lineage_id="lineage-1234567890abcdef12345678",
+        rollover_id="rollover-app-absent",
+        generation=1,
+        source_thread_id=source_id,
+        intended_title="Infrastructure — P1 native lifecycle",
+        title_source="durable_metadata",
+        bootstrap_prompt_path="bootstrap.md",
+    )
+    blocked = rollover.record_blocker(
+        repo_root=tmp_path,
+        family_id=str(transition["family_id"]),
+        operation_id=str(transition["operation_id"]),
+        action="create",
+        error="create_thread tool unavailable",
+        evidence="app capability discovery",
+    )
+    assert blocked["ok"] is False
+    storage = TaskFamilyStorage(tmp_path, str(transition["family_id"]), str(transition["operation_id"]))
+    assert storage.load_state()["state"] == "blocked"
+    assert storage.load_receipt().failures[-1].action == "create_preflight_blocked"
+    assert not storage.manifest_path.exists()
+
+
+def test_title_partial_failure_retry_and_readback_do_not_create_twice(tmp_path: Path) -> None:
+    data = _transition(tmp_path)
+    prepared = data["prepared"]
+    assert isinstance(prepared, dict)
+    kwargs = {
+        "repo_root": tmp_path,
+        "family_id": str(prepared["family_id"]),
+        "operation_id": str(prepared["operation_id"]),
+    }
+    action = rollover.request_action(**kwargs, action="title", db_path=Path(data["db"]))
+    assert action["needs_native_action"] is True
+    assert action["arguments"] == {"threadId": data["replacement_id"], "title": data["title"]}
+    failed = rollover.record_native_result(
+        **kwargs,
+        action="title",
+        succeeded=False,
+        evidence="set_thread_title response",
+        error="temporary native failure",
+    )
+    assert failed["ok"] is False
+    assert rollover.request_action(**kwargs, action="title", db_path=Path(data["db"]))["needs_native_action"] is True
+    with sqlite3.connect(data["db"]) as connection:
+        connection.execute("UPDATE threads SET title = ? WHERE id = ?", (data["title"], data["replacement_id"]))
+        connection.commit()
+    rollover.record_native_result(
+        **kwargs,
+        action="title",
+        succeeded=True,
+        evidence="set_thread_title success",
+    )
+    reconciled = rollover.reconcile_action(**kwargs, action="title", db_path=Path(data["db"]))
+    assert reconciled["ok"] is True
+    retry = rollover.request_action(**kwargs, action="title", db_path=Path(data["db"]))
+    assert retry["needs_native_action"] is False
+    storage = TaskFamilyStorage(tmp_path, str(prepared["family_id"]), str(prepared["operation_id"]))
+    assert len([item for item in storage.load_receipt().actual if item.action == "create_replacement"]) == 1
+    assert any(item.action == "title_retry_readback" for item in storage.load_receipt().skipped)
+
+
+def test_unconfirmed_predecessor_is_preserved(tmp_path: Path) -> None:
+    data = _transition(tmp_path)
+    _title_reconciled(tmp_path, data)
+    prepared = data["prepared"]
+    assert isinstance(prepared, dict)
+    state = _confirmed_state(data)
+    state["replacement"]["status"] = "resumed"
+    state["cleanup"]["old_automation_ready_to_delete"] = False
+    result = rollover.request_action(
+        repo_root=tmp_path,
+        family_id=str(prepared["family_id"]),
+        operation_id=str(prepared["operation_id"]),
+        action="archive",
+        db_path=Path(data["db"]),
+        state=state,
+        source_status="idle",
+        pin_state="unpinned",
+        evidence="native read_thread response",
+    )
+    assert result["ok"] is False
+    assert any("not confirmed" in blocker or "locked" in blocker for blocker in result["blockers"])
+    assert codex_state.read_thread_record(Path(data["db"]), task_id=str(data["source_id"])).archived is False
+    storage = TaskFamilyStorage(tmp_path, str(prepared["family_id"]), str(prepared["operation_id"]))
+    assert "native read_thread response" in storage.load_receipt().failures[-1].reason
+
+
+@pytest.mark.parametrize(
+    ("source_status", "pin_state", "expected"),
+    [
+        ("active", "unpinned", "not authoritatively idle"),
+        ("idle", "pinned", "not authoritatively unpinned"),
+        ("idle", "unknown", "not authoritatively unpinned"),
+        ("unknown", "unknown", "not authoritatively idle"),
+    ],
+)
+def test_running_pinned_and_unknown_predecessors_are_preserved(
+    tmp_path: Path,
+    source_status: str,
+    pin_state: rollover.PinState,
+    expected: str,
+) -> None:
+    data = _transition(tmp_path)
+    _title_reconciled(tmp_path, data)
+    prepared = data["prepared"]
+    assert isinstance(prepared, dict)
+    result = rollover.authorize_archive(
+        repo_root=tmp_path,
+        family_id=str(prepared["family_id"]),
+        operation_id=str(prepared["operation_id"]),
+        state=_confirmed_state(data),
+        source_status=source_status,
+        pin_state=pin_state,
+        evidence="native read_thread response",
+    )
+    assert result["ok"] is False
+    assert any(expected in blocker for blocker in result["blockers"])
+    assert codex_state.read_thread_record(Path(data["db"]), task_id=str(data["source_id"])).archived is False
+
+
+def test_exact_confirmed_predecessor_archive_failure_retry_preserves_unrelated(tmp_path: Path) -> None:
+    data = _transition(tmp_path)
+    _title_reconciled(tmp_path, data)
+    prepared = data["prepared"]
+    assert isinstance(prepared, dict)
+    kwargs = {
+        "repo_root": tmp_path,
+        "family_id": str(prepared["family_id"]),
+        "operation_id": str(prepared["operation_id"]),
+    }
+    action = rollover.request_action(
+        **kwargs,
+        action="archive",
+        db_path=Path(data["db"]),
+        state=_confirmed_state(data),
+        source_status="idle",
+        pin_state="unpinned",
+        evidence="fresh native read_thread retry: idle, pinned=false",
+    )
+    assert action["needs_native_action"] is True
+    assert action["arguments"] == {"threadId": data["source_id"], "archived": True}
+    rollover.record_native_result(
+        **kwargs,
+        action="archive",
+        succeeded=False,
+        evidence="set_thread_archived response",
+        error="temporary native failure",
+    )
+    retry = rollover.request_action(
+        **kwargs,
+        action="archive",
+        db_path=Path(data["db"]),
+        state=_confirmed_state(data),
+        source_status="idle",
+        pin_state="unpinned",
+        evidence="native read_thread: idle, pinned=false",
+    )
+    assert retry["needs_native_action"] is True
+    rollover.record_native_result(
+        **kwargs,
+        action="archive",
+        succeeded=True,
+        evidence="set_thread_archived success",
+    )
+    with sqlite3.connect(data["db"]) as connection:
+        connection.execute(
+            "UPDATE threads SET archived = 1, archived_at = ? WHERE id = ?",
+            ("2026-07-15T10:05:00Z", data["source_id"]),
+        )
+        connection.commit()
+    reconciled = rollover.reconcile_action(**kwargs, action="archive", db_path=Path(data["db"]))
+    assert reconciled["ok"] is True
+    assert reconciled["task_id"] == data["source_id"]
+    assert codex_state.read_thread_record(Path(data["db"]), task_id=str(data["replacement_id"])).archived is False
+    assert codex_state.read_thread_record(Path(data["db"]), task_id=str(data["unrelated_id"])).archived is False
+    storage = TaskFamilyStorage(tmp_path, str(prepared["family_id"]), str(prepared["operation_id"]))
+    assert len([item for item in storage.load_receipt().actual if item.action == "archive_reconciled"]) == 1
+
+
+def test_persisted_transition_plan_drift_fails_closed(tmp_path: Path) -> None:
+    data = _transition(tmp_path)
+    prepared = data["prepared"]
+    assert isinstance(prepared, dict)
+    storage = TaskFamilyStorage(tmp_path, str(prepared["family_id"]), str(prepared["operation_id"]))
+    plan = storage.read_json(storage.rollover_plan_path)
+    plan["source_thread_id"] = str(uuid4())
+    storage.rollover_plan_path.write_text(json.dumps(plan), encoding="utf-8")
+    with pytest.raises(ValueError, match="digest mismatch"):
+        rollover.request_action(
+            repo_root=tmp_path,
+            family_id=str(prepared["family_id"]),
+            operation_id=str(prepared["operation_id"]),
+            action="title",
+            db_path=Path(data["db"]),
+        )

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -78,8 +78,20 @@ def prepared(*, agent: str = "orchestrator", thread_id: str = "old-thread") -> d
     return state
 
 
+def bind_native_replacement(state: dict, thread_id: str) -> None:
+    state["replacement"]["native_lifecycle"]["replacement_thread_id"] = thread_id
+    state["replacement"]["native_lifecycle"]["status"] = "replacement_created_bound"
+
+
+def bind_native_lease(state_path: Path, thread_id: str) -> None:
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    bind_native_replacement(state, thread_id)
+    th.write_json_atomic(state_path, state)
+
+
 def resumed_with_proof(tmp_path: Path, state: dict, thread_id: str = "new-thread") -> tuple[dict, Path]:
     replacement = state["replacement"]
+    bind_native_replacement(state, thread_id)
     resumed = th.resume_state(
         state,
         rollover_id=replacement["rollover_id"],
@@ -176,8 +188,69 @@ def test_direct_script_help_from_repository_root():
 
     assert completed.returncode == 0, completed.stderr
     assert "Prepare and guard agent-specific thread handoffs." in completed.stdout
-    for command in ("prepare", "confirm-started", "resume", "check", "audit"):
+    for command in (
+        "prepare",
+        "register-created",
+        "native-action",
+        "record-native-result",
+        "reconcile-native",
+        "confirm-started",
+        "resume",
+        "check",
+        "audit",
+    ):
         assert command in completed.stdout
+
+
+def test_prepare_state_records_meaningful_title_and_native_identity():
+    state = th.prepare_state(
+        {"schema_version": th.SCHEMA_VERSION},
+        agent="codex",
+        now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
+        active_thread_id="source-thread",
+        active_automation_id=None,
+        context_percent=86.0,
+        force_new_replacement=False,
+        epic_title="Curriculum lifecycle",
+        goal="CI unblock",
+        phase="P5",
+        next_phase="P6",
+    )
+
+    replacement = state["replacement"]
+    assert replacement["display"]["title"] == "Curriculum lifecycle — P5 CI unblock → P6"
+    assert replacement["display"]["title_source"] == "durable_metadata"
+    assert replacement["native_lifecycle"] == {
+        "family_id": replacement["native_lifecycle"]["family_id"],
+        "operation_id": replacement["native_lifecycle"]["operation_id"],
+        "source_thread_id": "source-thread",
+        "replacement_thread_id": None,
+        "status": "awaiting_native_create",
+    }
+    assert "Resume codex rollover" not in replacement["display"]["title"]
+
+
+def test_prepare_state_uses_unique_non_generic_fallback():
+    state = prepared(agent="codex", thread_id="source-thread")
+
+    title = state["replacement"]["display"]["title"]
+    assert state["lineage_id"] in title
+    assert "g0001" in title
+    assert title.casefold() != "resume codex rollover"
+
+
+def test_prepare_state_rejects_partial_title_metadata():
+    with pytest.raises(ValueError, match="must be supplied together"):
+        th.prepare_state(
+            {"schema_version": th.SCHEMA_VERSION},
+            agent="codex",
+            now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
+            active_thread_id="source-thread",
+            active_automation_id=None,
+            context_percent=None,
+            force_new_replacement=False,
+            epic_title="Curriculum lifecycle",
+        )
 
 
 def test_prepare_state_requires_confirmation_before_cleanup(tmp_path: Path):
@@ -207,6 +280,26 @@ def test_prepare_state_requires_confirmation_before_cleanup(tmp_path: Path):
     assert confirmed["cleanup"]["old_automation_ready_to_delete"] is True
 
 
+def test_confirm_started_requires_exact_predecessor_identity(tmp_path: Path):
+    state = prepared()
+    resumed, proof_path = resumed_with_proof(tmp_path, state)
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, resumed)
+    resumed.pop("active")
+
+    with pytest.raises(ValueError, match="no exact predecessor"):
+        th.confirm_started(
+            resumed,
+            new_thread_id="new-thread",
+            new_automation_id=None,
+            confirmed_by="tester",
+            now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+            canary_proof=proof_path,
+            strict_probe=strict_probe,
+            strict_verdict=strict_verdict,
+            state_root=tmp_path,
+        )
+
+
 def test_confirm_started_rejects_missing_pending_replacement():
     with pytest.raises(ValueError, match="run prepare first"):
         th.confirm_started(
@@ -228,6 +321,7 @@ def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
     prompt = th.render_bootstrap_prompt(sample_snapshot(tmp_path), state, context_threshold=82.0)
 
     assert "You are the replacement Codex orchestrator thread." in prompt
+    assert f"Task title: {state['replacement']['display']['title']}" in prompt
     assert "Role handoff: docs/session-state/codex-orchestrator-handoff.md" in prompt
     assert "Thread handoff: .agent/thread-rollovers/" in prompt
     assert "Global router:" not in prompt
@@ -237,6 +331,9 @@ def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
     assert "git worktree list" in prompt
     assert "confirm-started --agent orchestrator --lineage-id" in prompt
     assert "Only after that command reports old_automation_ready_to_delete=true" in prompt
+    assert "If either fact is absent, use `unknown`" in prompt
+    assert "Only an actionable response authorizes `set_thread_archived`" in prompt
+    assert "must register and title this exact native replacement before resume" in prompt
     assert "Keep the invoking checkout clean at prepared HEAD abc123def0456789 through resume and confirmation (clean fast-forward advances are tolerated)." in prompt
     assert "Context estimate: 86.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
     assert "orchestrator_control.py inbox --recent 20 --include-results" in prompt
@@ -442,6 +539,26 @@ def test_live_lease_requires_binding_but_started_history_remains_compatible():
     assert replacement["status"] == "started"
 
 
+def test_live_lease_keeps_legacy_v2_pending_packet_compatible():
+    state = prepared(agent="codex")
+    state["replacement"].pop("display")
+    state["replacement"].pop("native_lifecycle")
+    state_path = th.default_state_path("codex", state["lineage_id"])
+
+    replacement, error = th.validate_live_lease(state, agent="codex", state_path=state_path)
+
+    assert error is None
+    assert replacement is not None
+    assert replacement["status"] == "pending_start"
+    resumed = th.resume_state(
+        state,
+        rollover_id=replacement["rollover_id"],
+        replacement_thread_id="legacy-replacement",
+        now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+    )
+    assert resumed["replacement"]["resumed_thread_id"] == "legacy-replacement"
+
+
 def test_prepare_rejects_dirty_source_checkout_without_writing_packet(tmp_path: Path, capsys, monkeypatch):
     dirty_snapshot = sample_snapshot(tmp_path)
     dirty_snapshot["git"]["modified_files"] = [{"status": "??", "path": "untracked.txt"}]
@@ -455,12 +572,64 @@ def test_prepare_rejects_dirty_source_checkout_without_writing_packet(tmp_path: 
     assert not (tmp_path / ".agent/thread-rollovers").exists()
 
 
+def test_register_created_context_failure_reports_cleanly(tmp_path: Path, capsys):
+    rc = th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "register-created",
+            "--lineage-id",
+            "lineage-1234567890abcdef12345678",
+            "--rollover-id",
+            "rollover-missing",
+            "--replacement-thread-id",
+            "00000000-0000-0000-0000-000000000002",
+            "--evidence",
+            "native create result",
+        ]
+    )
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["action"] == "register-created"
+    assert "isolated rollover" in payload["error"]
+    assert "NameError" not in payload["error"]
+
+
+def test_native_create_action_is_retry_gate_without_db(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread"]) == 0
+    prepared_payload = json.loads(capsys.readouterr().out)
+
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "native-action",
+                "--lineage-id",
+                prepared_payload["lineage_id"],
+                "--rollover-id",
+                prepared_payload["rollover_id"],
+                "--action",
+                "create",
+            ]
+        )
+        == 0
+    )
+    action = json.loads(capsys.readouterr().out)
+    assert action["tool"] == "create_thread"
+    assert action["needs_native_action"] is True
+    assert action["bootstrap_prompt_path"] == prepared_payload["bootstrap_file"]
+
+
 def test_resume_and_confirm_independently_recheck_checkout_continuity(tmp_path: Path, capsys, monkeypatch):
     clean = sample_snapshot(tmp_path)["git"]
     monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
     assert th.main(["--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread"]) == 0
     packet = json.loads(capsys.readouterr().out)
     state_path = tmp_path / packet["state_file"]
+    bind_native_lease(state_path, "new-thread")
 
     monkeypatch.setattr(th, "gather_git_state", lambda root: {**clean, "full_head": "wrong-head"})
     resume_command = [
@@ -666,6 +835,7 @@ def test_confirm_started_is_scoped_to_selected_agent(tmp_path: Path, capsys):
     orchestrator_path = tmp_path / th.default_state_path("orchestrator", orchestrator_state["lineage_id"])
     claude_path = tmp_path / th.default_state_path("claude", claude_state["lineage_id"])
     th.write_json_atomic(orchestrator_path, orchestrator_state)
+    bind_native_replacement(claude_state, "new-claude")
     resumed = th.resume_state(
         claude_state,
         rollover_id=claude_state["replacement"]["rollover_id"],
@@ -876,6 +1046,14 @@ def test_pending_prepare_refuses_unless_explicitly_forced():
 def test_resume_is_deterministic_and_refuses_a_different_thread():
     state = prepared()
     rollover_id = state["replacement"]["rollover_id"]
+    with pytest.raises(ValueError, match="must be registered"):
+        th.resume_state(
+            state,
+            rollover_id=rollover_id,
+            replacement_thread_id="new-thread",
+            now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+        )
+    bind_native_replacement(state, "new-thread")
     resumed = th.resume_state(
         state,
         rollover_id=rollover_id,
@@ -890,7 +1068,7 @@ def test_resume_is_deterministic_and_refuses_a_different_thread():
     )
 
     assert repeated == resumed
-    with pytest.raises(ValueError, match="different replacement thread"):
+    with pytest.raises(ValueError, match="does not match"):
         th.resume_state(
             resumed,
             rollover_id=rollover_id,
@@ -971,6 +1149,7 @@ def test_cli_requires_exact_rollover_and_reserved_canary_proof(tmp_path: Path, c
     prepared_payload = json.loads(capsys.readouterr().out)
     state_path = tmp_path / prepared_payload["state_file"]
     state = json.loads(state_path.read_text(encoding="utf-8"))
+    bind_native_lease(state_path, "new-thread")
 
     assert (
         th.main(
@@ -1200,6 +1379,7 @@ def test_confirmation_refuses_unresumed_and_identity_mismatched_rollovers(tmp_pa
             strict_verdict=tmp_path / "strict-verdict.json",
             state_root=tmp_path,
         )
+    bind_native_replacement(state, "bound-thread")
     resumed = th.resume_state(
         state,
         rollover_id=replacement["rollover_id"],
@@ -1313,6 +1493,7 @@ def test_lifecycle_requires_strict_ten_of_ten_before_cleanup(tmp_path: Path, cap
         th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "old-thread"]) == 0
     )
     packet = json.loads(capsys.readouterr().out)
+    bind_native_lease(tmp_path / packet["state_file"], "new-thread")
     assert (
         th.main(
             [
@@ -1406,6 +1587,7 @@ def test_confirmation_rejects_nine_of_ten_and_wrong_reserved_paths(tmp_path: Pat
         th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "old-thread"]) == 0
     )
     packet = json.loads(capsys.readouterr().out)
+    bind_native_lease(tmp_path / packet["state_file"], "new-thread")
     assert (
         th.main(
             [

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end acceptance for packet-only Codex thread replacement.
+"""End-to-end acceptance for durable Codex thread replacement.
 
 These tests deliberately cross subprocess, Git-worktree, shell-helper, hook,
 and strict-canary seams. Unit-level state-machine cases remain in
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import sqlite3
 import subprocess
 from pathlib import Path
 
@@ -20,6 +21,10 @@ REPO_PYTHON = REPO_ROOT / ".venv/bin/python"
 HANDOFF = REPO_ROOT / "scripts/orchestration/thread_handoff.py"
 HANDOFF_CANARY = REPO_ROOT / "scripts/orchestration/thread_handoff_canary.py"
 CONTEXT_CANARY = REPO_ROOT / "scripts/context_canary.py"
+SOURCE_THREAD_ID = "00000000-0000-4000-8000-000000000001"
+REPLACEMENT_THREAD_ID = "00000000-0000-4000-8000-000000000002"
+SECOND_SOURCE_THREAD_ID = "00000000-0000-4000-8000-000000000003"
+SECOND_REPLACEMENT_THREAD_ID = "00000000-0000-4000-8000-000000000004"
 
 
 def run(
@@ -77,6 +82,10 @@ def init_repo(tmp_path: Path, *, bootstrap_sources: bool = False) -> tuple[Path,
         "scripts/orchestration/thread_handoff.py",
         "scripts/orchestration/thread_handoff_canary.py",
     ]
+    sources.extend(
+        str(path.relative_to(REPO_ROOT))
+        for path in sorted((REPO_ROOT / "scripts/orchestration/task_family").glob("*.py"))
+    )
     if bootstrap_sources:
         sources.extend(
             [
@@ -123,7 +132,7 @@ def checkout_handoff_command(checkout: Path, *args: str) -> list[str | Path]:
     ]
 
 
-def prepare(primary: Path, *, active_thread_id: str = "old-thread") -> dict:
+def prepare(primary: Path, *, active_thread_id: str = SOURCE_THREAD_ID) -> dict:
     completed = run(
         handoff_command(
             primary,
@@ -149,7 +158,98 @@ def assert_cleanup_locked(primary: Path, packet: dict) -> None:
     assert load_lease(primary, packet)["cleanup"]["old_automation_ready_to_delete"] is False
 
 
-def resume(primary: Path, packet: dict, replacement_thread_id: str = "fresh-thread") -> dict:
+def register_native_replacement(primary: Path, packet: dict, replacement_thread_id: str) -> None:
+    """Simulate the exact native create/title acknowledgements around the local adapter."""
+    lease = load_lease(primary, packet)
+    source_thread_id = lease["active"]["thread_id"]
+    db_path = primary.parent / f"state_{packet['lineage_id']}.sqlite"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT, cwd TEXT, "
+            "archived INTEGER, archived_at TEXT, host TEXT)"
+        )
+        connection.executemany(
+            "INSERT INTO threads VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (source_thread_id, "Confirmed predecessor", str(primary), 0, None, "test"),
+                (replacement_thread_id, "Resume codex rollover", str(primary), 0, None, "test"),
+            ],
+        )
+
+    common = [
+        "--agent",
+        "codex",
+        "--lineage-id",
+        packet["lineage_id"],
+        "--rollover-id",
+        packet["rollover_id"],
+    ]
+    authorized = run(
+        handoff_command(primary, "native-action", *common, "--action", "create"),
+        cwd=primary,
+        check=True,
+    )
+    assert json.loads(authorized.stdout)["needs_native_action"] is True
+    run(
+        handoff_command(
+            primary,
+            "record-native-result",
+            *common,
+            "--action",
+            "create",
+            "--succeeded",
+            "--evidence",
+            f"fixture create_thread returned {replacement_thread_id}",
+        ),
+        cwd=primary,
+        check=True,
+    )
+    run(
+        handoff_command(
+            primary,
+            "register-created",
+            *common,
+            "--replacement-thread-id",
+            replacement_thread_id,
+            "--db",
+            db_path,
+            "--evidence",
+            "fixture exact native create result",
+        ),
+        cwd=primary,
+        check=True,
+    )
+    title_action = run(
+        handoff_command(primary, "native-action", *common, "--action", "title", "--db", db_path),
+        cwd=primary,
+        check=True,
+    )
+    intended_title = json.loads(title_action.stdout)["arguments"]["title"]
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("UPDATE threads SET title = ? WHERE id = ?", (intended_title, replacement_thread_id))
+    run(
+        handoff_command(
+            primary,
+            "record-native-result",
+            *common,
+            "--action",
+            "title",
+            "--succeeded",
+            "--evidence",
+            "fixture set_thread_title acknowledged",
+        ),
+        cwd=primary,
+        check=True,
+    )
+    run(
+        handoff_command(primary, "reconcile-native", *common, "--action", "title", "--db", db_path),
+        cwd=primary,
+        check=True,
+    )
+
+
+def resume(primary: Path, packet: dict, replacement_thread_id: str = REPLACEMENT_THREAD_ID) -> dict:
+    register_native_replacement(primary, packet, replacement_thread_id)
     completed = run(
         handoff_command(
             primary,
@@ -279,7 +379,7 @@ def canary_proof(primary: Path, packet: dict, *, challenge: str | None = None) -
             "--rollover-id",
             packet["rollover_id"],
             "--replacement-thread-id",
-            "fresh-thread",
+            REPLACEMENT_THREAD_ID,
             "--challenge",
             challenge or replacement["canary_challenge"],
             "--proof-file",
@@ -309,7 +409,7 @@ def confirm_command(
         "--rollover-id",
         packet["rollover_id"],
         "--new-thread-id",
-        "fresh-thread",
+        REPLACEMENT_THREAD_ID,
         "--canary-proof",
         str(proof),
         "--strict-probe",
@@ -319,7 +419,7 @@ def confirm_command(
     )
 
 
-def test_packet_only_lifecycle_answers_exactly_ten_questions_and_unlocks_cleanup(tmp_path: Path) -> None:
+def test_native_lifecycle_answers_exactly_ten_questions_and_unlocks_cleanup(tmp_path: Path) -> None:
     primary, _ = init_repo(tmp_path)
     packet = prepare(primary)
     assert_cleanup_locked(primary, packet)
@@ -336,11 +436,12 @@ def test_packet_only_lifecycle_answers_exactly_ten_questions_and_unlocks_cleanup
     assert "thread_handoff.py confirm-started" in bootstrap
     assert "codex exec resume" not in bootstrap
     assert not list(primary.glob(".agent/**/*state_5.sqlite"))
-    assert not list(primary.glob(".agent/**/*.jsonl"))
+    receipts = list(primary.glob(".agent/task-families/**/events.jsonl"))
+    assert len(receipts) == 1
 
     resumed = resume(primary, packet)
-    assert resumed["replacement_thread_id"] == "fresh-thread"
-    assert resumed["replacement_thread_id"] != "old-thread"
+    assert resumed["replacement_thread_id"] == REPLACEMENT_THREAD_ID
+    assert resumed["replacement_thread_id"] != SOURCE_THREAD_ID
     validated = run(
         handoff_command(
             primary,
@@ -383,7 +484,7 @@ def test_pre_confirmation_failures_leave_cleanup_locked(tmp_path: Path, case: st
                 "--agent",
                 "codex",
                 "--active-thread-id",
-                "old-thread",
+                SOURCE_THREAD_ID,
             ),
             cwd=primary,
         )
@@ -399,7 +500,7 @@ def test_pre_confirmation_failures_leave_cleanup_locked(tmp_path: Path, case: st
                 "--rollover-id",
                 "rollover-wrong",
                 "--replacement-thread-id",
-                "fresh-thread",
+                REPLACEMENT_THREAD_ID,
             ),
             cwd=primary,
         )
@@ -465,8 +566,8 @@ def test_failed_replacement_proofs_leave_cleanup_locked(tmp_path: Path, case: st
 
 def test_parallel_lineages_have_distinct_paths_and_reject_cross_claims(tmp_path: Path) -> None:
     primary, _ = init_repo(tmp_path)
-    first = prepare(primary, active_thread_id="old-a")
-    second = prepare(primary, active_thread_id="old-b")
+    first = prepare(primary, active_thread_id=SOURCE_THREAD_ID)
+    second = prepare(primary, active_thread_id=SECOND_SOURCE_THREAD_ID)
     assert first["lineage_id"] != second["lineage_id"]
     assert first["rollover_id"] != second["rollover_id"]
     assert first["state_file"] != second["state_file"]
@@ -483,7 +584,7 @@ def test_parallel_lineages_have_distinct_paths_and_reject_cross_claims(tmp_path:
             "--rollover-id",
             second["rollover_id"],
             "--replacement-thread-id",
-            "cross-claim",
+            SECOND_REPLACEMENT_THREAD_ID,
         ),
         cwd=primary,
     )
@@ -502,7 +603,7 @@ def test_monitor_outage_and_dirty_replacement_never_unlock_cleanup(tmp_path: Pat
             "--agent",
             "codex",
             "--active-thread-id",
-            "old-thread",
+            SOURCE_THREAD_ID,
             "--active-automation-id",
             "automation-old-thread",
         ),
@@ -510,6 +611,7 @@ def test_monitor_outage_and_dirty_replacement_never_unlock_cleanup(tmp_path: Pat
         check=True,
     )
     packet = json.loads(prepared.stdout)
+    register_native_replacement(primary, packet, REPLACEMENT_THREAD_ID)
     resumed = run(
         checkout_handoff_command(
             replacement,
@@ -521,7 +623,7 @@ def test_monitor_outage_and_dirty_replacement_never_unlock_cleanup(tmp_path: Pat
             "--rollover-id",
             packet["rollover_id"],
             "--replacement-thread-id",
-            "fresh-thread",
+            REPLACEMENT_THREAD_ID,
         ),
         cwd=replacement,
         check=True,
@@ -544,7 +646,7 @@ def test_monitor_outage_and_dirty_replacement_never_unlock_cleanup(tmp_path: Pat
             "--rollover-id",
             packet["rollover_id"],
             "--new-thread-id",
-            "fresh-thread",
+            REPLACEMENT_THREAD_ID,
             "--canary-proof",
             str(proof),
             "--strict-probe",


### PR DESCRIPTION
## Summary

- derive deterministic human rollover titles from durable epic/goal/phase metadata, with a unique lineage/generation fallback
- reuse Task Family Manager plans, exact-ID typed relations, receipts, reconciliation, and retry decisions for native create/title/archive actions
- require exact native replacement binding before resume/confirm and authorize predecessor archive only after the existing canary + strict 10/10 + confirm-started gate, authoritative idle status, and authoritative unpinned state
- preserve legacy v2 packets, app/API absence, failed/partial operations, pinned/running/unknown predecessors, and unrelated tasks fail-closed
- update the thread-rollover skill and runbook to match the real app/native boundary
- update restart and SessionStart integration fixtures to execute the real create → receipt → exact bind → title → reconcile lifecycle

## Verification

- `.venv/bin/ruff check` on all changed Python files
- `.venv/bin/python -m pytest tests/orchestration/test_thread_handoff.py tests/orchestration/task_family tests/orchestration/test_thread_restart_e2e.py tests/test_session_setup_hook.py::test_session_setup_hook_handoff_fixtures -q` — 122 passed
- repository pre-commit hook on both commits — passed; follow-up commit ran 11 end-to-end tests
- `.venv/bin/python scripts/lint/lint_agent_skills.py`
- `npx markdownlint-cli2 docs/best-practices/codex-thread-handoff.md agents_extensions/shared/skills/thread-rollover/SKILL.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `bash -n scripts/audit/test_session_setup_hook.sh`, `git diff --check`, and compileall
- first full CI run exposed five stale integration-fixture failures; the fixtures were repaired without relaxing production gates, and the replacement CI run is authoritative

## Independent review

- working-tree AGY/Gemini review #2912: 3 findings; Codex challenge #2915 kept all 3; all fixed and regression-tested
- first pushed branch AGY/Gemini review #2918: CLEAN
- revision-2 AGY/Gemini attempt #2922: provider network failure; substituted per fleet policy
- pushed branch Claude Opus review #2927: CLEAN, no actionable findings
- post-CI-fix AGY/Gemini review #2937 raised one unrelated two-dot comparison false positive; tool-backed three-dot challenge #2939: CLEAN

Fixes #5221
Part of #4707