### PR TITLE
feat(atlas): query offline mphdict sources

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -14,16 +14,14 @@ no fabrication):
 - **cefr** — PULS CEFR lookup when available, otherwise a visibly labelled
   GRAC-frequency estimate for entries outside PULS.
 - **literary_attestation** — exact-form literary corpus hit when available.
-- **synonyms** — source-attested Ukrainian candidates from clean slovnyk.me
-  synonym dictionaries, with noisy legacy sources kept A1-sense allowlisted.
-- **sections.synonyms / sections.antonyms / sections.idioms** — slovnyk.me
-  per-lemma lookup cache and local dictionary rows (Караванський + Словник
-  синонімів; Вікісловник antonyms; Фразеологічний).
+- **synonyms** — sense-separated offline mphdict groups from the Ukrainian
+  synonym database, preserving their original set boundaries.
+- **sections.synonyms / sections.antonyms / sections.idioms** — mphdict synonym
+  groups and local dictionary rows (Вікісловник antonyms; Фразеологічний).
 - **heritage warning alternatives** — slovnyk.me correction dictionaries
   (Антоненко-Давидович, «Неправильно-правильно», Штепа чужослів).
-- **etymology** — Goroh cached extracts first, ЕСУМ fallback, uk.wiktionary
-  dump fallback for remaining single-word gaps
-  (``data/sources.db``; deterministic local lookup only).
+- **etymology** — offline mphdict ЕСУМ roots, with the source volume/page
+  citation and bibliography retained from the dictionary export.
 
 Every field carries its ``source`` so the UI can attribute it. Lemmas with no
 dictionary hit simply get an empty enrichment and the UI keeps its honest
@@ -87,6 +85,8 @@ from scripts.lexicon.manifest_io import (
 from scripts.lexicon.source_attribution import (
     BALLA_LABEL,
     CORRECTION_DICTIONARIES_LABEL,
+    ESUM_LABEL,
+    MPHDICT_SYNONYMS_LABEL,
     PHRASEOLOGY_LABEL,
     SLUG_ACADEMIC_LABELS,
     SUM20_ACADEMIC_LABEL,
@@ -99,6 +99,7 @@ from scripts.lexicon.source_attribution import (
     official_url_for_slug,
     remap_url_list,
 )
+from scripts.mphdict import mphdict_etymology, mphdict_synonyms, mphdict_synonyms_available
 from scripts.verification.vesum import verify_lemma, verify_word
 from scripts.wiki.slovnyk_me import primary_synonym_sense_text
 
@@ -172,7 +173,12 @@ _GRAC_CORPUS = "grac19a"
 _GRAC_BATCH_SIZE = 25
 
 _SLOVNYK_DICT_LABELS: dict[str, str] = dict(SLUG_ACADEMIC_LABELS)
-_SLOVNYK_LOOKUP_SLUGS = tuple(_SLOVNYK_DICT_LABELS)
+# Synonym slugs are retired from the active cache.  Atlas synonym enrichment
+# is mphdict-only; keeping those mirror fetches here would silently continue
+# the replaced scraper even though its result is no longer rendered.
+_SLOVNYK_LOOKUP_SLUGS = tuple(
+    slug for slug in _SLOVNYK_DICT_LABELS if slug not in {"synonyms", "synonyms_karavansky"}
+)
 _SLOVNYK_SYNONYM_SLUGS = ("synonyms_karavansky", "synonyms")
 _SLOVNYK_IDIOM_SLUGS = ("phraseology",)
 _SLOVNYK_WARNING_SLUGS = ("davydov", "voloschak", "foreign_shtepa")
@@ -1604,6 +1610,42 @@ def _synonyms_slovnyk(
     if mirror_urls:
         block["mirror_source_urls"] = mirror_urls
     return block
+
+
+def _synonyms_mphdict(lemma: str) -> dict[str, Any] | None:
+    """Return offline mphdict synonym groups without flattening sense boundaries."""
+    result = mphdict_synonyms(lemma)
+    if not result:
+        return None
+    synsets = result.get("synsets")
+    if not isinstance(synsets, list) or not synsets:
+        return None
+
+    lookup_key = _lookup_key(lemma)
+    items: list[str] = []
+    seen: set[str] = set()
+    for synset in synsets:
+        if not isinstance(synset, dict):
+            continue
+        members = synset.get("members")
+        if not isinstance(members, list):
+            continue
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            member_lemma = str(member.get("lemma") or "").strip()
+            if not member_lemma or _lookup_key(member_lemma) == lookup_key:
+                continue
+            if member_lemma not in seen:
+                seen.add(member_lemma)
+                items.append(member_lemma)
+    if not items:
+        return None
+    return {
+        "items": items[:24],
+        "synsets": synsets,
+        "source": MPHDICT_SYNONYMS_LABEL,
+    }
 
 
 def _clean_atlas_chip_candidate(candidate: str, lemma: str) -> str | None:
@@ -4515,6 +4557,47 @@ def _source_etymology(
     )
 
 
+def _mphdict_etymology(lemma: str) -> dict[str, Any] | None:
+    """Adapt the rich mphdict root query to the compact Atlas etymology block."""
+    result = mphdict_etymology(lemma)
+    if not result:
+        return None
+    roots = result.get("roots")
+    if not isinstance(roots, list) or not roots:
+        return None
+    root = roots[0]
+    if not isinstance(root, dict):
+        return None
+    citation = root.get("citation")
+    citation_display = citation.get("display") if isinstance(citation, dict) else ""
+    source = ESUM_LABEL
+    if citation_display:
+        source = f"{source}, {citation_display}"
+    etymons = root.get("etymons")
+    headword = ""
+    etymon_count = 0
+    if isinstance(etymons, list):
+        etymon_count = len(etymons)
+        for etymon in etymons:
+            if isinstance(etymon, dict) and etymon.get("is_head"):
+                headword = str(etymon.get("stressed") or etymon.get("lemma") or "").strip()
+                break
+    match = root.get("match")
+    direct_headword = isinstance(match, dict) and bool(match.get("is_direct_headword"))
+    article_kind = "Стаття ЕСУМ" if direct_headword else "Зіставлення у статті ЕСУМ"
+    label = f"{article_kind}: {headword or lemma}; етимонів: {etymon_count}."
+    return {
+        "text": label,
+        "source": source,
+        "mphdict_root": {
+            "id": root.get("id"),
+            "match": root.get("match"),
+            "citation": citation,
+            "bibliography": root.get("bibliography", []),
+        },
+    }
+
+
 def _with_base_etymology_label(etymology: dict, base_form: str) -> dict:
     labeled = dict(etymology)
     source = str(labeled.get("source") or "").strip()
@@ -4526,11 +4609,11 @@ def _with_base_etymology_label(etymology: dict, base_form: str) -> dict:
 def _etymology(
     conn: sqlite3.Connection, lemma: str, kaikki_lookup: dict[str, dict[str, Any]] | None = None
 ) -> dict | None:
-    """Cached etymology by direct per-lemma authority order."""
+    """Offline ЕСУМ etymology from mphdict; no mirror or Wiktionary fallback."""
     lookup_word = _lookup_key(_base_lemma(lemma))
     if lookup_word in _COMPOSITIONAL_ETYMOLOGY_EXCLUSIONS:
         return None
-    return _source_etymology(conn, lemma, kaikki_lookup)
+    return _mphdict_etymology(lemma)
 
 
 _GRAC_FREQUENCY_CACHE_DATA: dict[str, Any] | None = None
@@ -5519,7 +5602,7 @@ def _resolve_gated_section(
       * gate ran, no confirmed item lost   -> ran-and-confirmed: take the new section
         (additions welcome); no provenance marker (default, keeps the diff minimal).
       * gate ran, confirmed item(s) dropped -> ran-and-rejected: the retraction is
-        authoritative (e.g. WordNet auto-translation junk ключ->джерело/живець); take
+        authoritative (for example, a rejected cross-sense legacy relation); take
         the new section (may be ``None`` when everything was retracted); mark ``rejected``.
       * gate did NOT run -> did-not-run: never retract a confirmed item (PRESERVE the
         existing section when the recomputation would drop one), and ALWAYS mark
@@ -5704,12 +5787,10 @@ def enrich_entry(
     # instead of silently overwriting it with an offline-empty recomputation.
     existing_sections = entry.get("sections")
     baseline_sections = existing_sections if isinstance(existing_sections, dict) else {}
-    # "Did the gate run" is decided per RELEVANT slug set (#5077 review finding 1):
-    # synonyms depend on the slovnyk synonym dictionaries, idioms on the phraseology
-    # dictionary. Homonyms/antonyms/paronyms are db/pointer-driven local sections with
-    # no slovnyk dependency, so their gate always runs (finding 2) — an offline run
-    # must let their authoritative local data update, not freeze a stale section.
-    synonyms_gate_ran = _slovnyk_gate_ran(slovnyk_cache, _SLOVNYK_SYNONYM_SLUGS)
+    # mphdict synonym groups are a local primary source.  A missing database is
+    # the only did-not-run state; a present database with no matching set is an
+    # authoritative empty result and may retract stale legacy chips.
+    synonyms_gate_ran = mphdict_synonyms_available()
     idioms_gate_ran = _slovnyk_gate_ran(slovnyk_cache, _SLOVNYK_IDIOM_SLUGS)
     sections: dict[str, object] = {}
     gate_provenance: dict[str, str] = {}
@@ -5723,22 +5804,11 @@ def enrich_entry(
         if outcome:
             gate_provenance[name] = outcome
 
-    synonyms = _synonyms_slovnyk(base, slovnyk_cache, entry_pos=entry_pos)
+    synonyms = _synonyms_mphdict(base)
     if not synonyms and fallback_base:
-        synonyms = _synonyms_slovnyk(fallback_base, entry_pos=entry_pos)
+        synonyms = _synonyms_mphdict(fallback_base)
         if synonyms:
             synonyms = _with_base_source_label(synonyms, fallback_base)
-    pointer_relations = (
-        pointer_synonym_relations
-        if pointer_synonym_relations is not None
-        else _definition_pointer_relations(
-            conn,
-            lemma,
-            has_sum11_flags=has_sum11_flags,
-            cache=slovnyk_cache,
-        )
-    )
-    synonyms = _merge_synonym_relations(synonyms, pointer_relations)
     _apply_section("synonyms", synonyms, gate_ran=synonyms_gate_ran)
     antonyms = _antonyms_wiktionary(conn, base, entry_pos=entry_pos)
     if not antonyms and fallback_base:

--- a/scripts/lexicon/source_attribution.py
+++ b/scripts/lexicon/source_attribution.py
@@ -46,6 +46,13 @@ CORRECTION_DICTIONARIES_LABEL = "Словники мовних поправок"
 GRAC_LABEL = "Генеральний регіонально анотований корпус української мови (ГРАК)"
 MIYKLAS_LABEL = "навчальні матеріали МійКлас (корпусні пари)"
 GRINCHENKO_LABEL = "Словарь української мови Б. Грінченка (1907–1909)"
+MPHDICT_SYNONYMS_LABEL = (
+    "mphdict (ODbL/DbCL): Словник синонімів української мови та Орфографічний словник"
+)
+ESUM_LABEL = (
+    "«Етимологічний словник української мови» "
+    "(ЕСУМ, Ін-т мовознавства ім. О. О. Потебні НАН України; mphdict ODbL/DbCL)"
+)
 
 RELATION_PAIRS_PREFIX = "relation_pairs/"
 UNMAPPED_SOURCE_PATTERN = re.compile(r"relation_pairs/", re.IGNORECASE)
@@ -95,6 +102,8 @@ KNOWN_ACADEMIC_LABELS = frozenset(
         GRAC_LABEL,
         MIYKLAS_LABEL,
         GRINCHENKO_LABEL,
+        MPHDICT_SYNONYMS_LABEL,
+        ESUM_LABEL,
     }
 )
 

--- a/scripts/mphdict/__init__.py
+++ b/scripts/mphdict/__init__.py
@@ -1,0 +1,27 @@
+"""Read-only queries for the local mphdict ODbL dictionary databases.
+
+The databases are deliberately not vendored: local development and production
+hydrate them under ``data/mphdict/``.  The public functions resolve a worktree
+to its main checkout's shared data directory when necessary and never modify a
+source database.
+"""
+
+from .query import (
+    decode_stress,
+    mphdict_etymology,
+    mphdict_headword,
+    mphdict_synonyms,
+    mphdict_synonyms_available,
+    normalize_gloss,
+    normalize_lookup,
+)
+
+__all__ = [
+    "decode_stress",
+    "mphdict_etymology",
+    "mphdict_headword",
+    "mphdict_synonyms",
+    "mphdict_synonyms_available",
+    "normalize_gloss",
+    "normalize_lookup",
+]

--- a/scripts/mphdict/query.py
+++ b/scripts/mphdict/query.py
@@ -1,0 +1,579 @@
+"""Fast, read-only queries over the local mphdict SQLite exports.
+
+The source databases encode stress with a double quote placed after the
+stressed vowel (for example ``га"рний``).  They are treated as immutable.
+This module creates a separate sidecar lookup index keyed by normalized lemma,
+which keeps ordinary queries indexed without adding expression indexes to the
+ODbL source databases.
+"""
+
+from __future__ import annotations
+
+import html
+import os
+import re
+import sqlite3
+import unicodedata
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+SYNSETS_DB_NAME = "synsets_ua.db"
+ETYM_DB_NAME = "etym.db"
+HEADWORD_DB_NAME = "mph_ua.db"
+SIDECAR_NAME = ".mphdict-lookup.sqlite3"
+SIDECAR_SCHEMA_VERSION = 1
+
+_COMBINING_STRESS = frozenset({"\u0300", "\u0301"})
+_MARKUP_RE = re.compile(r"\[(?P<tag>[A-Za-z]+)\](?P<text>.*?)\[/\1\]", re.DOTALL)
+_HTML_TAG_RE = re.compile(r"</?(?:b|br|em|i|strong|u)\b[^>]*>", re.IGNORECASE)
+_SPACE_RE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class _IndexSpec:
+    """One normalized-word lookup table in an immutable mphdict database."""
+
+    database: str
+    table: str
+    id_column: str
+    word_column: str
+
+
+_SYNSET_INDEX = _IndexSpec(SYNSETS_DB_NAME, "wlist", "id", "word")
+_ETYM_INDEX = _IndexSpec(ETYM_DB_NAME, "etymons", "id", "word")
+_HEADWORD_INDEX = _IndexSpec(HEADWORD_DB_NAME, "nom", "nom_old", "reestr")
+
+
+def _main_checkout_root(root: Path) -> Path | None:
+    """Return the shared checkout root when called from a dispatch worktree."""
+    parts = root.parts
+    try:
+        worktrees_index = parts.index(".worktrees")
+    except ValueError:
+        return None
+    return Path(*parts[:worktrees_index])
+
+
+def _default_db_dir() -> Path:
+    override = os.environ.get("MPHDICT_DATA_DIR")
+    if override:
+        return Path(override).expanduser()
+
+    local = ROOT / "data" / "mphdict"
+    if local.exists():
+        return local
+
+    main_root = _main_checkout_root(ROOT)
+    if main_root:
+        shared = main_root / "data" / "mphdict"
+        if shared.exists():
+            return shared
+    return local
+
+
+def _database_path(spec: _IndexSpec, db_dir: Path | str | None) -> Path:
+    return Path(db_dir).expanduser() / spec.database if db_dir else _default_db_dir() / spec.database
+
+
+def _sidecar_path(db_dir: Path | str | None, index_path: Path | str | None) -> Path:
+    if index_path is not None:
+        return Path(index_path).expanduser()
+    override = os.environ.get("MPHDICT_INDEX_PATH")
+    if override:
+        return Path(override).expanduser()
+    return (Path(db_dir).expanduser() if db_dir else _default_db_dir()) / SIDECAR_NAME
+
+
+def normalize_lookup(value: object) -> str:
+    """Normalize a source or user word to the stress-free lookup key.
+
+    ЕСУМ uses combining acute stress while the synonym and orthography exports
+    use the embedded double quote convention.  Removing both supports a plain
+    user lemma in every source without changing the stored display form.
+    """
+    decomposed = unicodedata.normalize("NFD", str(value or ""))
+    without_stress = "".join(
+        character
+        for character in decomposed
+        if character != '"' and character not in _COMBINING_STRESS
+    )
+    normalized = unicodedata.normalize("NFC", without_stress)
+    normalized = normalized.replace("`", "'").replace("’", "'").replace("ʼ", "'")
+    return _SPACE_RE.sub(" ", normalized).strip().casefold()
+
+
+def decode_stress(value: object) -> str:
+    """Turn mphdict's embedded quote stress marker into displayable acute stress."""
+    source = str(value or "")
+    out: list[str] = []
+    for character in source:
+        if character == '"' and out:
+            out.append("\u0301")
+        else:
+            out.append(character)
+    return unicodedata.normalize("NFC", "".join(out))
+
+
+def normalize_gloss(value: object) -> dict[str, Any]:
+    """Make mphdict gloss markup learner-readable while retaining tagged detail."""
+    raw = html.unescape(str(value or "")).strip()
+    markup: list[dict[str, str]] = []
+
+    def replace_markup(match: re.Match[str]) -> str:
+        text = _HTML_TAG_RE.sub("", html.unescape(match.group("text")))
+        text = _SPACE_RE.sub(" ", text).strip()
+        if text:
+            markup.append({"tag": match.group("tag").upper(), "text": text})
+        return text
+
+    text = _MARKUP_RE.sub(replace_markup, raw)
+    text = _HTML_TAG_RE.sub("", text)
+    # Angle-bracketed source labels (for example <рідко.>) are meaningful
+    # learner information, not HTML; retain their text but remove the wrappers.
+    text = re.sub(r"<([^<>]+)>", r"\1", text)
+    text = re.sub(r"(?<=[.!?])(?=[А-ЯІЇЄҐ])", " ", text)
+    text = re.sub(r"\s*;\s*;\s*", "; ", text)
+    text = _SPACE_RE.sub(" ", text).strip(" ;")
+    result: dict[str, Any] = {"text": text}
+    if markup:
+        result["markup"] = markup
+    return result
+
+
+def _connect_read_only(path: Path) -> sqlite3.Connection:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    connection = sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def _sidecar_schema(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        PRAGMA journal_mode = WAL;
+        CREATE TABLE IF NOT EXISTS metadata (
+            source_key TEXT PRIMARY KEY,
+            source_size INTEGER NOT NULL,
+            source_mtime_ns INTEGER NOT NULL,
+            schema_version INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS normalized_words (
+            source_key TEXT NOT NULL,
+            lookup_key TEXT NOT NULL,
+            row_id INTEGER NOT NULL,
+            PRIMARY KEY (source_key, row_id)
+        );
+        CREATE INDEX IF NOT EXISTS normalized_words_lookup
+            ON normalized_words (source_key, lookup_key);
+        """
+    )
+
+
+def _source_key(path: Path, spec: _IndexSpec) -> str:
+    return f"{path.resolve()}::{spec.table}::{spec.id_column}::{spec.word_column}"
+
+
+def _batched(rows: Iterable[tuple[int, object]], size: int = 2_000) -> Iterator[list[tuple[int, object]]]:
+    batch: list[tuple[int, object]] = []
+    for row in rows:
+        batch.append(row)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _ensure_index(path: Path, spec: _IndexSpec, sidecar: Path) -> str:
+    """Build or refresh a sidecar index without writing to ``path``."""
+    stat = path.stat()
+    source_key = _source_key(path, spec)
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(sidecar) as index_connection:
+        _sidecar_schema(index_connection)
+        row = index_connection.execute(
+            "SELECT source_size, source_mtime_ns, schema_version FROM metadata WHERE source_key = ?",
+            (source_key,),
+        ).fetchone()
+        unchanged = row == (stat.st_size, stat.st_mtime_ns, SIDECAR_SCHEMA_VERSION)
+        if unchanged:
+            return source_key
+
+        index_connection.execute("DELETE FROM normalized_words WHERE source_key = ?", (source_key,))
+        with _connect_read_only(path) as source_connection:
+            source_rows = source_connection.execute(
+                f"SELECT {spec.id_column}, {spec.word_column} FROM {spec.table}"
+            )
+            for batch in _batched(source_rows):
+                index_connection.executemany(
+                    "INSERT INTO normalized_words (source_key, lookup_key, row_id) VALUES (?, ?, ?)",
+                    [
+                        (source_key, normalize_lookup(source_word), int(row_id))
+                        for row_id, source_word in batch
+                        if normalize_lookup(source_word)
+                    ],
+                )
+        index_connection.execute(
+            """
+            INSERT INTO metadata (source_key, source_size, source_mtime_ns, schema_version)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(source_key) DO UPDATE SET
+                source_size = excluded.source_size,
+                source_mtime_ns = excluded.source_mtime_ns,
+                schema_version = excluded.schema_version
+            """,
+            (source_key, stat.st_size, stat.st_mtime_ns, SIDECAR_SCHEMA_VERSION),
+        )
+    return source_key
+
+
+def _indexed_row_ids(
+    path: Path,
+    spec: _IndexSpec,
+    lookup_key: str,
+    sidecar: Path,
+) -> list[int]:
+    source_key = _ensure_index(path, spec, sidecar)
+    with sqlite3.connect(sidecar) as index_connection:
+        rows = index_connection.execute(
+            """
+            SELECT row_id FROM normalized_words
+            WHERE source_key = ? AND lookup_key = ?
+            ORDER BY row_id
+            """,
+            (source_key, lookup_key),
+        ).fetchall()
+    return [int(row[0]) for row in rows]
+
+
+def _chunks(values: list[int], size: int = 900) -> Iterator[list[int]]:
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
+
+
+def _optional_int(value: object) -> int | None:
+    return int(value) if value not in (None, "") else None
+
+
+def mphdict_synonyms_available(*, db_dir: Path | str | None = None) -> bool:
+    """Whether the primary local synonym database is present for enrichment."""
+    return _database_path(_SYNSET_INDEX, db_dir).is_file()
+
+
+def _optional_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _source_form(word: object) -> dict[str, str]:
+    source_word = str(word or "")
+    return {
+        "lemma": normalize_lookup(source_word),
+        "stressed": decode_stress(source_word),
+        "encoded_stressed": source_word,
+    }
+
+
+def mphdict_synonyms(
+    word: str,
+    *,
+    db_dir: Path | str | None = None,
+    index_path: Path | str | None = None,
+) -> dict[str, Any] | None:
+    """Return distinct mphdict synonym groups for a plain or stressed lemma.
+
+    ``wlist.id_set`` is deliberately retained as a boundary: a word may occur
+    in several senses, and flattening those groups would recreate the
+    cross-sense synonym errors this source replaces.
+    """
+    lookup_key = normalize_lookup(word)
+    if not lookup_key:
+        return None
+    path = _database_path(_SYNSET_INDEX, db_dir)
+    if not path.is_file():
+        return None
+    sidecar = _sidecar_path(db_dir, index_path)
+    matching_ids = _indexed_row_ids(path, _SYNSET_INDEX, lookup_key, sidecar)
+    if not matching_ids:
+        return {"lemma": lookup_key, "synsets": []}
+
+    with _connect_read_only(path) as connection:
+        set_ids: set[int] = set()
+        for chunk in _chunks(matching_ids):
+            placeholders = ", ".join("?" for _ in chunk)
+            set_ids.update(
+                int(row[0])
+                for row in connection.execute(
+                    f"SELECT DISTINCT id_set FROM wlist WHERE id IN ({placeholders})", chunk
+                )
+            )
+
+        groups: list[dict[str, Any]] = []
+        for chunk in _chunks(sorted(set_ids)):
+            placeholders = ", ".join("?" for _ in chunk)
+            rows = connection.execute(
+                f"""
+                SELECT w.id_set, w.id_syn, w.id, w.word, w.interpretation,
+                       w.sign, w.hyperonym, w.homonym,
+                       s.interpretation AS synset_interpretation, p.name AS pos
+                FROM wlist AS w
+                LEFT JOIN synsets AS s ON s.id = w.id_set
+                LEFT JOIN pofs AS p ON p.id = s.pofs
+                WHERE w.id_set IN ({placeholders})
+                ORDER BY w.id_set, w.id
+                """,
+                chunk,
+            ).fetchall()
+            by_set: dict[int, list[sqlite3.Row]] = {}
+            for row in rows:
+                by_set.setdefault(int(row["id_set"]), []).append(row)
+            for set_id in sorted(by_set):
+                members: list[dict[str, Any]] = []
+                first = by_set[set_id][0]
+                for row in by_set[set_id]:
+                    member = {
+                        "id": int(row["id"]),
+                        "sense_id": int(row["id_syn"]),
+                        **_source_form(row["word"]),
+                    }
+                    gloss = normalize_gloss(row["interpretation"])
+                    if gloss["text"]:
+                        member["gloss"] = gloss
+                    if _optional_int(row["sign"]) is not None:
+                        member["sign"] = _optional_int(row["sign"])
+                    hyperonym = _optional_text(row["hyperonym"])
+                    if hyperonym:
+                        member["hyperonym"] = _source_form(hyperonym)
+                    homonym = _optional_int(row["homonym"])
+                    if homonym:
+                        member["homonym"] = homonym
+                    members.append(member)
+                group: dict[str, Any] = {
+                    "id": set_id,
+                    "pos": _optional_text(first["pos"]),
+                    "members": members,
+                }
+                group_gloss = normalize_gloss(first["synset_interpretation"])
+                if group_gloss["text"]:
+                    group["gloss"] = group_gloss
+                groups.append(group)
+    return {"lemma": lookup_key, "synsets": groups}
+
+
+def _citation(root: sqlite3.Row) -> dict[str, Any]:
+    volume = _optional_int(root["volume_num"])
+    first_page = _optional_int(root["page_initial"])
+    last_page = _optional_int(root["page_last"])
+    display_parts: list[str] = []
+    if volume is not None:
+        display_parts.append(f"т. {volume}")
+    if first_page is not None:
+        page = f"с. {first_page}"
+        if last_page is not None and last_page != first_page:
+            page += f"–{last_page}"
+        display_parts.append(page)
+    return {
+        "volume": volume,
+        "page_initial": first_page,
+        "page_last": last_page,
+        "display": ", ".join(display_parts),
+    }
+
+
+def _etymon_from_row(row: sqlite3.Row) -> dict[str, Any]:
+    etymon: dict[str, Any] = {
+        "id": int(row["id"]),
+        "word_num": int(row["word_num"]),
+        "is_head": bool(row["ishead"]),
+        **_source_form(row["word"]),
+        "language_marker": _optional_text(row["lang_marker"]),
+        "language": _optional_text(row["lang_name"]),
+    }
+    for field in ("homonym", "dialect", "antroponym"):
+        value = _optional_int(row[field])
+        if value:
+            etymon[field] = bool(value) if field != "homonym" else value
+    for field in ("lang_note", "note", "sense", "bibliography"):
+        value = _optional_text(row[field])
+        if value:
+            etymon[field] = value
+    class_text = _optional_text(row["subclass_text"])
+    etymon["class"] = {
+        "type": int(row["class_type"]),
+        "number": int(row["class_num"]),
+        "subclass_number": int(row["subclass_num"]),
+        "is_formal": bool(row["formal_type"]),
+        "text": class_text,
+    }
+    return etymon
+
+
+def mphdict_etymology(
+    word: str,
+    *,
+    db_dir: Path | str | None = None,
+    index_path: Path | str | None = None,
+) -> dict[str, Any] | None:
+    """Return every ЕСУМ root containing ``word``, with etymons and citations."""
+    lookup_key = normalize_lookup(word)
+    if not lookup_key:
+        return None
+    path = _database_path(_ETYM_INDEX, db_dir)
+    if not path.is_file():
+        return None
+    sidecar = _sidecar_path(db_dir, index_path)
+    matching_ids = _indexed_row_ids(path, _ETYM_INDEX, lookup_key, sidecar)
+    if not matching_ids:
+        return {"lemma": lookup_key, "roots": []}
+
+    with _connect_read_only(path) as connection:
+        root_ranks: dict[int, int] = {}
+        for chunk in _chunks(matching_ids):
+            placeholders = ", ".join("?" for _ in chunk)
+            for row in connection.execute(
+                f"""
+                SELECT ec.id_root, MAX(e.ishead) AS matching_head
+                FROM etymons AS e
+                JOIN e_classes AS ec ON ec.id = e.id_e_classes
+                WHERE e.id IN ({placeholders})
+                GROUP BY ec.id_root
+                """,
+                chunk,
+            ):
+                root_ranks[int(row["id_root"])] = int(row["matching_head"] or 0)
+
+        # A direct article headword is authoritative.  A plain form can also
+        # occur as an embedded comparison under unrelated derived-word roots;
+        # use those only when ЕСУМ has no matching article headword at all.
+        has_direct_headword = any(root_ranks.values())
+        candidate_root_ids = [
+            root_id for root_id, rank in root_ranks.items() if rank or not has_direct_headword
+        ]
+        roots: list[dict[str, Any]] = []
+        ordered_root_ids = sorted(candidate_root_ids, key=lambda root_id: (-root_ranks[root_id], root_id))
+        for chunk in _chunks(ordered_root_ids):
+            placeholders = ", ".join("?" for _ in chunk)
+            root_rows = connection.execute(
+                f"""
+                SELECT id, volume_num, page_initial, page_last
+                FROM root WHERE id IN ({placeholders})
+                """,
+                chunk,
+            ).fetchall()
+            roots_by_id = {int(row["id"]): row for row in root_rows}
+            for root_id in chunk:
+                root = roots_by_id[root_id]
+                etymon_rows = connection.execute(
+                    """
+                    SELECT e.id, e.word_num, e.ishead, e.word, e.homonym, e.dialect,
+                           e.antroponym, e.lang_marker, e.lang_note, e.note, e.sense,
+                           e.bibliography, la.lang_name, ec.class_type, ec.class_num,
+                           ec.subclass_num, ec.formal_type, ec.subclass_text
+                    FROM e_classes AS ec
+                    JOIN etymons AS e ON e.id_e_classes = ec.id
+                    LEFT JOIN lang_all AS la ON la.lang_code = e.lang_code
+                    WHERE ec.id_root = ?
+                    ORDER BY ec.class_num, ec.subclass_num, e.word_num, e.id
+                    """,
+                    (root_id,),
+                ).fetchall()
+                bibliography = [
+                    {
+                        "number": int(row["biblio_num"]),
+                        "text": str(row["biblio_text"] or "").strip(),
+                    }
+                    for row in connection.execute(
+                        "SELECT biblio_num, biblio_text FROM bibl WHERE id_root = ? ORDER BY biblio_num, id",
+                        (root_id,),
+                    )
+                    if str(row["biblio_text"] or "").strip()
+                ]
+                links = [
+                    {
+                        "type": int(row["link_type"]),
+                        "number": int(row["link_num"]),
+                        "word": _optional_text(row["word"]),
+                        "homonym": _optional_int(row["homonym"]),
+                    }
+                    for row in connection.execute(
+                        "SELECT link_type, link_num, word, homonym FROM links WHERE id_root = ? ORDER BY link_type, link_num, id",
+                        (root_id,),
+                    )
+                ]
+                roots.append(
+                    {
+                        "id": root_id,
+                        "match": {
+                            "is_direct_headword": bool(root_ranks[root_id]),
+                            "kind": "headword" if root_ranks[root_id] else "embedded_comparison",
+                        },
+                        "citation": _citation(root),
+                        "etymons": [_etymon_from_row(row) for row in etymon_rows],
+                        "bibliography": bibliography,
+                        "links": links,
+                    }
+                )
+    return {"lemma": lookup_key, "roots": roots}
+
+
+def mphdict_headword(
+    word: str,
+    *,
+    db_dir: Path | str | None = None,
+    index_path: Path | str | None = None,
+) -> dict[str, Any] | None:
+    """Return mphdict's preferred stressed orthographic registry headword and POS.
+
+    Full paradigm generation remains intentionally out of scope: VESUM is the
+    Atlas form source.  mphdict's ``nom`` registry is used here only for its
+    official written headword and part-of-speech record.
+    """
+    lookup_key = normalize_lookup(word)
+    if not lookup_key:
+        return None
+    path = _database_path(_HEADWORD_INDEX, db_dir)
+    if not path.is_file():
+        return None
+    sidecar = _sidecar_path(db_dir, index_path)
+    matching_ids = _indexed_row_ids(path, _HEADWORD_INDEX, lookup_key, sidecar)
+    if not matching_ids:
+        return None
+
+    with _connect_read_only(path) as connection:
+        rows: list[sqlite3.Row] = []
+        for chunk in _chunks(matching_ids):
+            placeholders = ", ".join("?" for _ in chunk)
+            rows.extend(
+                connection.execute(
+                    f"""
+                    SELECT n.nom_old, n.reestr, n.part, n.type, n.isdel, n.isproblem,
+                           p.part AS pos_code, p.com AS pos
+                    FROM nom AS n
+                    LEFT JOIN parts AS p ON p.id = n.part
+                    WHERE n.nom_old IN ({placeholders}) AND COALESCE(n.isdel, 0) = 0
+                    """,
+                    chunk,
+                ).fetchall()
+            )
+    if not rows:
+        return None
+    row = min(
+        rows,
+        key=lambda item: (
+            int(item["isdel"] or 0),
+            int(item["isproblem"] or 0),
+            int(item["nom_old"]),
+        ),
+    )
+    return {
+        "registry_id": int(row["nom_old"]),
+        **_source_form(row["reestr"]),
+        "pos": _optional_text(row["pos"]),
+        "pos_code": _optional_text(row["pos_code"]),
+        "part_id": int(row["part"]),
+        "flexion_type": int(row["type"]),
+    }

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "2a46adcb1a36885761236c594d7f7b84f2d4a3f93d0b69906426351bb625ea9f",
+  "fingerprint": "28516ef3672eb3d9556c90eb3a259608f6b5062f92c3ce69cce0ca01a3f64162",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "b0517f744dc44a876004d6481aa9b3f872acb16d550e4a295c1a24bcc28f252f"
+        "sha256": "c77c6c30373895a2398221ec565f96df4097962320d3b131016759ac5061447f"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -180,7 +180,7 @@
       },
       {
         "path": "scripts/lexicon/source_attribution.py",
-        "sha256": "24996ae3d64f549249658bf65c30bfc86828c25b8abaa6e8f1a266690ca168e5"
+        "sha256": "7216342e9293ed9d43e27d82d5b54dcb09cbc7f8e9322a477d77d9ef820befff"
       },
       {
         "path": "scripts/lexicon/verify_manifest.py",

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -39,6 +39,23 @@ interface SourcedText {
   stages?: Array<{ period: string; word: string; note?: string }>;
 }
 
+interface SynonymGloss {
+  text: string;
+}
+
+interface SynonymMember {
+  lemma: string;
+  stressed: string;
+  gloss?: SynonymGloss;
+}
+
+interface SynonymSet {
+  id: number;
+  pos?: string;
+  gloss?: SynonymGloss;
+  members: SynonymMember[];
+}
+
 interface NounParadigm {
   kind: "noun";
   cases: Record<string, { singular: string; plural: string }>;
@@ -134,7 +151,7 @@ interface HeritageStatus {
 }
 
 interface LexiconSections {
-  synonyms?: { items: string[]; source: string; source_urls?: string[] };
+  synonyms?: { items: string[]; source: string; source_urls?: string[]; synsets?: SynonymSet[] };
   antonyms?: { items: string[]; source: string; source_urls?: string[] };
   homonyms?: {
     items: Array<{ word: string; gloss: string; pos?: string; homonym_no?: number }>;
@@ -192,6 +209,7 @@ const {
 } = Astro.props as Props;
 const enrichment = entry.enrichment ?? null;
 const sections = entry.sections ?? null;
+const synonymSets = sections?.synonyms?.synsets ?? [];
 const heritage = entry.heritage_status ?? null;
 const rawDefinitionCards = enrichment?.definition_cards ?? [];
 const definitionCards = rawDefinitionCards.filter(shouldRenderDefinitionCard);
@@ -928,9 +946,30 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
           {(sections?.synonyms?.items.length ?? 0) > 0 && (
             <div>
               <div class="chip-label">Синоніми:</div>
-              <div class="chip-row">
-                {sections.synonyms.items.map((item) => <span class="chip">{item}</span>)}
-              </div>
+              {synonymSets.length > 0 ? (
+                <div class="synonym-sets">
+                  {synonymSets.map((synset) => (
+                    <div class="synonym-set">
+                      {(synset.pos || synset.gloss?.text) && (
+                        <div class="synonym-set-context">
+                          {[synset.pos, synset.gloss?.text].filter(Boolean).join(" · ")}
+                        </div>
+                      )}
+                      <div class="chip-row">
+                        {synset.members
+                          .filter((member) => member.lemma !== entry.lemma)
+                          .map((member) => (
+                            <span class="chip" title={member.gloss?.text}>{member.stressed}</span>
+                          ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div class="chip-row">
+                  {sections.synonyms.items.map((item) => <span class="chip">{item}</span>)}
+                </div>
+              )}
             </div>
           )}
           {(sections?.antonyms?.items.length ?? 0) > 0 && (

--- a/site/src/styles/word-atlas.css
+++ b/site/src/styles/word-atlas.css
@@ -1001,6 +1001,22 @@
   margin: 8px 0;
 }
 
+.synonym-sets {
+  display: grid;
+  gap: 10px;
+}
+
+.synonym-set {
+  border-left: 2px solid var(--gray-300);
+  padding-left: 10px;
+}
+
+.synonym-set-context {
+  color: var(--gray-700);
+  font-size: 0.84rem;
+  margin-bottom: 5px;
+}
+
 .chip {
   padding: 6px 14px;
   border: 1px solid var(--teal);

--- a/tests/test_goroh_etymology_ingest.py
+++ b/tests/test_goroh_etymology_ingest.py
@@ -1,11 +1,4 @@
-import sqlite3
-
-from scripts.ingest.goroh_etymology_ingest import (
-    ensure_goroh_etymology_schema,
-    parse_goroh_html,
-    upsert_goroh_row,
-)
-from scripts.lexicon.enrich_manifest import _etymology
+from scripts.ingest.goroh_etymology_ingest import parse_goroh_html
 
 
 def test_canonicalized_goroh_lemma_resolves_without_network() -> None:
@@ -37,18 +30,3 @@ def test_canonicalized_goroh_lemma_resolves_without_network() -> None:
     assert row["requested_lemma"] == "колежанка"
     assert row["headword"] == "колега"
     assert "колежанка" not in row["etymology_text"]
-
-    conn = sqlite3.connect(":memory:")
-    ensure_goroh_etymology_schema(conn)
-    with conn:
-        upsert_goroh_row(conn, row)
-
-    by_requested = _etymology(conn, "колежанка")
-    assert by_requested == {
-        "text": "запозичення з латинської мови; лат. collega «товариш по службі».",
-        "source": "Горох (за ЕСУМ)",
-        "source_url": "https://goroh.pp.ua/Етимологія/колежанка",
-    }
-
-    by_headword = _etymology(conn, "колега")
-    assert by_headword == by_requested

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1750,7 +1750,8 @@ def test_kaikki_meaning_uses_direct_glosses() -> None:
     }
 
 
-def test_kaikki_etymology_is_final_fallback() -> None:
+def test_etymology_has_no_kaikki_fallback_when_mphdict_has_no_root(monkeypatch) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
     lookup = {
         "місто": {
@@ -1760,12 +1761,11 @@ def test_kaikki_etymology_is_final_fallback() -> None:
         }
     }
 
-    etymology = _etymology(conn, "місто", lookup)
-
-    assert etymology == {"text": "From Old East Slavic мѣсто.", "source": KAIKKI_SOURCE}
+    assert _etymology(conn, "місто", lookup) is None
 
 
-def test_etymology_does_not_fall_back_to_derived_base_forms() -> None:
+def test_etymology_does_not_fall_back_to_derived_base_forms(monkeypatch) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
     conn.execute(
         """
@@ -1792,7 +1792,8 @@ def test_etymology_lookup_variants_include_normalised_apostrophe_and_v_u_alterna
     assert "вв'язнення" in variants
 
 
-def test_esum_etymology_uses_normalised_variant_match() -> None:
+def test_etymology_does_not_read_the_legacy_esum_table(monkeypatch) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
     conn.execute(
         """
@@ -1810,12 +1811,7 @@ def test_esum_etymology_uses_normalised_variant_match() -> None:
         ("ув'язнення", "Fixture ЕСУМ etymology for ув'язнення.", "[]", "1", "42"),
     )
 
-    etymology = _etymology(conn, "Ув’язнення", {})
-
-    assert etymology == {
-        "text": "Fixture ЕСУМ etymology for ув'язнення.",
-        "source": "ЕСУМ, т. 1, с. 42",
-    }
+    assert _etymology(conn, "Ув’язнення", {}) is None
 
 
 def test_compositional_greeting_phrases_have_no_etymology_fallback() -> None:
@@ -1838,7 +1834,8 @@ def test_compositional_greeting_phrases_have_no_etymology_fallback() -> None:
     assert _etymology(conn, "До побачення!", {}) is None
 
 
-def test_kaikki_etymology_allows_direct_cognate_comparisons() -> None:
+def test_etymology_has_no_kaikki_cognate_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
     lookup = {
         "базовий": {
@@ -1848,13 +1845,11 @@ def test_kaikki_etymology_allows_direct_cognate_comparisons() -> None:
         }
     }
 
-    assert _etymology(conn, "базовий", lookup) == {
-        "text": "From ба́за. Compare Russian ба́зовый (bázovyj), Belarusian ба́завы.",
-        "source": KAIKKI_SOURCE,
-    }
+    assert _etymology(conn, "базовий", lookup) is None
 
 
-def test_kaikki_etymology_skips_garbled_tree_text() -> None:
+def test_etymology_ignores_garbled_legacy_tree_text(monkeypatch) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
     lookup = {
         "японія": {
@@ -1867,7 +1862,8 @@ def test_kaikki_etymology_skips_garbled_tree_text() -> None:
     assert _etymology(conn, "Японія", lookup) is None
 
 
-def test_kaikki_etymology_does_not_treat_labor_as_garbled_marker() -> None:
+def test_etymology_has_no_legacy_wiktionary_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
     lookup = {
         "робота": {
@@ -1877,13 +1873,11 @@ def test_kaikki_etymology_does_not_treat_labor_as_garbled_marker() -> None:
         }
     }
 
-    assert _etymology(conn, "робота", lookup) == {
-        "text": "Old East Slavic робота (robota, “labor, work”), itself from Proto-Slavic *orbota.",
-        "source": KAIKKI_SOURCE,
-    }
+    assert _etymology(conn, "робота", lookup) is None
 
 
-def test_kaikki_etymology_does_not_overwrite_goroh() -> None:
+def test_etymology_has_no_goroh_mirror_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
     conn.execute(
         """
@@ -1907,13 +1901,7 @@ def test_kaikki_etymology_does_not_overwrite_goroh() -> None:
         }
     }
 
-    etymology = _etymology(conn, "книга", lookup)
-
-    assert etymology == {
-        "text": "Goroh etymology text.",
-        "source": "Горох (за ЕСУМ)",
-        "source_url": "https://goroh.pp.ua/Етимологія/книга",
-    }
+    assert _etymology(conn, "книга", lookup) is None
 
 
 def test_enrich_uses_base_form_for_pair_single_form_sections(monkeypatch, tmp_path) -> None:
@@ -1953,17 +1941,6 @@ def test_enrich_uses_base_form_for_pair_single_form_sections(monkeypatch, tmp_pa
     conn.commit()
     conn.close()
 
-    cache = {
-        "lookups": {
-            "synonyms": {
-                "dictionary_slug": "synonyms",
-                "dictionary_label": "Словник синонімів української мови",
-                "source_url": "https://slovnyk.me/dict/synonyms/робота",
-                "word": "робота",
-                "text": "робота ПРАЦЯ. Джерело: тест",
-            }
-        }
-    }
     verify_calls: list[str] = []
 
     def fake_verify_lemma(lemma: str) -> list[dict[str, str]]:
@@ -1976,7 +1953,29 @@ def test_enrich_uses_base_form_for_pair_single_form_sections(monkeypatch, tmp_pa
     monkeypatch.setattr(enrich_manifest_module, "MANIFEST", manifest_path)
     monkeypatch.setattr(enrich_manifest_module, "SOURCES_DB", db_path)
     monkeypatch.setattr(enrich_manifest_module, "_load_kaikki_lookup", lambda: {})
-    monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: cache)
+    monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: {"lookups": {}})
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "mphdict_synonyms",
+        lambda lemma: {
+            "lemma": lemma,
+            "synsets": [
+                {
+                    "id": 1,
+                    "members": [
+                        {"lemma": "робота", "stressed": "робо́та"},
+                        {"lemma": "праця", "stressed": "пра́ця"},
+                    ],
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_synonyms_available", lambda: True)
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "_etymology",
+        lambda *args, **kwargs: {"text": "Fixture mphdict etymology for робота.", "source": "ЕСУМ fixture"},
+    )
     monkeypatch.setattr(
         enrich_manifest_module,
         "classify_lemma",
@@ -2006,7 +2005,7 @@ def test_enrich_uses_base_form_for_pair_single_form_sections(monkeypatch, tmp_pa
     enriched = json.loads(manifest_path.read_text(encoding="utf-8"))["entries"][0]
     assert enriched["lemma"] == "робота / працювати"
     assert enriched["sections"]["synonyms"]["items"] == ["праця"]
-    assert enriched["enrichment"]["etymology"]["text"] == "Goroh etymology for робота."
+    assert enriched["enrichment"]["etymology"]["text"] == "Fixture mphdict etymology for робота."
     assert enriched["enrichment"]["morphology"]["forms"] == [{"form": "робота", "label": "однина, жін., називний"}]
     assert verify_calls == ["робота"]
 
@@ -2075,6 +2074,13 @@ def test_enrich_populates_antonyms_phraseology_and_variant_etymology(monkeypatch
     monkeypatch.setattr(enrich_manifest_module, "SOURCES_DB", db_path)
     monkeypatch.setattr(enrich_manifest_module, "_load_kaikki_lookup", lambda: {})
     monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: {"lookups": {}})
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_synonyms_available", lambda: True)
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_synonyms", lambda lemma: {"lemma": lemma, "synsets": []})
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "_etymology",
+        lambda *args, **kwargs: {"text": "Fixture mphdict etymology for ув'язнення.", "source": "ЕСУМ fixture"},
+    )
     monkeypatch.setattr(
         enrich_manifest_module,
         "classify_lemma",
@@ -2110,8 +2116,8 @@ def test_enrich_populates_antonyms_phraseology_and_variant_etymology(monkeypatch
     assert enriched["sections"]["antonyms"]["items"] == ["воля"]
     assert enriched["sections"]["idioms"]["items"][0]["phrase"] == "ув'язнення духу"
     assert enriched["enrichment"]["etymology"] == {
-        "text": "Fixture ЕСУМ etymology for ув'язнення.",
-        "source": "ЕСУМ, т. 1, с. 42",
+        "text": "Fixture mphdict etymology for ув'язнення.",
+        "source": "ЕСУМ fixture",
     }
 
 
@@ -3447,8 +3453,8 @@ def test_definition_pointer_relations_emit_reciprocal_manifest_headword(monkeypa
     assert relations["кав'ярня"][0]["direction"] == "reciprocal"
 
 
-def test_ключ_drops_ukrajinet_targets_and_keeps_karavansky_synonym(monkeypatch) -> None:
-    """The rendered manifest must never reopen the auto-translated WordNet vein."""
+def test_ключ_does_not_read_ukrajinet_and_uses_mphdict_synonyms(monkeypatch) -> None:
+    """The enrichment route never reads the retired auto-translation table."""
     _patch_synonym_vesum(monkeypatch, {"ключ", "джерело", "живець", "відмикач"})
     conn = _conn()
     conn.execute("CREATE TABLE ukrajinet (words TEXT NOT NULL, text TEXT NOT NULL)")
@@ -3473,12 +3479,14 @@ def test_ключ_drops_ukrajinet_targets_and_keeps_karavansky_synonym(monkeypat
     monkeypatch.setattr(enrich_manifest_module, "_kaikki_pronunciation", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         enrich_manifest_module,
-        "_synonyms_slovnyk",
+        "_synonyms_mphdict",
         lambda *args, **kwargs: {
             "items": ["відмикач"],
-            "source": "slovnyk.me: Словник синонімів Караванського",
+            "synsets": [],
+            "source": "mphdict fixture",
         },
     )
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_synonyms_available", lambda: True)
     monkeypatch.setattr(enrich_manifest_module, "_antonyms_wiktionary", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest_module, "_idioms", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda *args, **kwargs: "")
@@ -3694,10 +3702,9 @@ def test_vts_definition_card_resolves_cross_reference_live_shape(monkeypatch) ->
 
 
 # --- #5077 preserve-vs-retract section gate semantics ------------------------------
-# enrich_entry recomputes gated sections each run. Offline (or after a schema-version
-# cache reset) a gate that CANNOT run must PRESERVE the previously-confirmed section
-# rather than silently overwrite it with an empty recomputation. Only a gate that RAN
-# may retract items (e.g. WordNet auto-translation junk). See scripts/lexicon/README.md.
+# enrich_entry recomputes gated sections each run. When the authoritative source
+# cannot run, it must preserve the previously-confirmed section rather than
+# silently overwrite it with an empty recomputation.
 from scripts.lexicon.manifest_io import (
     GATE_ANNOTATIONS_CARRIED,
     GATE_REJECTED,
@@ -3749,8 +3756,12 @@ def _run_synonyms_gate(monkeypatch, *, offline, cache, new_synonyms, existing_sy
     _stub_section_producers(monkeypatch)
     monkeypatch.setattr(enrich_manifest_module, "_phase1_offline_mode", lambda: offline)
     monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: cache)
-    monkeypatch.setattr(enrich_manifest_module, "_synonyms_slovnyk", lambda *a, **k: new_synonyms)
-    monkeypatch.setattr(enrich_manifest_module, "_merge_synonym_relations", lambda syn, rel: syn)
+    monkeypatch.setattr(enrich_manifest_module, "_synonyms_mphdict", lambda *a, **k: new_synonyms)
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "mphdict_synonyms_available",
+        lambda: not offline or "synonyms" in cache.get("lookups", {}),
+    )
 
     entry = {"lemma": "ключ", "pos": "noun", "sections": {"synonyms": existing_synonyms}}
     enrich_manifest_module.enrich_entry(
@@ -3865,8 +3876,12 @@ def _run_enrich_entry(monkeypatch, entry, *, offline, cache):
     _stub_section_producers(monkeypatch)
     monkeypatch.setattr(enrich_manifest_module, "_phase1_offline_mode", lambda: offline)
     monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: cache)
-    monkeypatch.setattr(enrich_manifest_module, "_synonyms_slovnyk", lambda *a, **k: None)
-    monkeypatch.setattr(enrich_manifest_module, "_merge_synonym_relations", lambda syn, rel: syn)
+    monkeypatch.setattr(enrich_manifest_module, "_synonyms_mphdict", lambda *a, **k: None)
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "mphdict_synonyms_available",
+        lambda: not offline or "synonyms" in cache.get("lookups", {}),
+    )
     return entry
 
 

--- a/tests/test_mphdict.py
+++ b/tests/test_mphdict.py
@@ -1,0 +1,269 @@
+"""Fixture-backed mphdict query and Atlas integration coverage.
+
+The real mphdict SQLite exports are local ODbL data and intentionally absent
+from CI.  These small databases model only the columns the query layer uses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import sqlite3
+from pathlib import Path
+
+from scripts.lexicon import enrich_manifest
+from scripts.lexicon.source_attribution import ESUM_LABEL, MPHDICT_SYNONYMS_LABEL
+from scripts.mphdict import (
+    mphdict_etymology,
+    mphdict_headword,
+    mphdict_synonyms,
+    normalize_gloss,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _mphdict_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    db_dir = tmp_path / "mphdict"
+    db_dir.mkdir()
+    index_path = tmp_path / "mphdict-index.sqlite3"
+
+    with sqlite3.connect(db_dir / "synsets_ua.db") as connection:
+        connection.executescript(
+            """
+            CREATE TABLE pofs (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE synsets (id INTEGER PRIMARY KEY, interpretation TEXT, pofs INTEGER NOT NULL);
+            CREATE TABLE wlist (
+                id INTEGER PRIMARY KEY,
+                id_set INTEGER NOT NULL,
+                id_syn INTEGER NOT NULL,
+                word TEXT,
+                interpretation TEXT,
+                sign INTEGER,
+                hyperonym TEXT,
+                homonym INTEGER
+            );
+            """
+        )
+        connection.execute("INSERT INTO pofs VALUES (3, 'Прикметник')")
+        connection.executemany(
+            "INSERT INTO synsets VALUES (?, ?, 3)",
+            [
+                (10, "про людину — [S]конкретний[/S]"),
+                (20, "про предмет — привабливий вигляд"),
+            ],
+        )
+        connection.executemany(
+            "INSERT INTO wlist VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (1, 10, 1, 'га"рний', "Приємний [B]вигляд[/B]", 0, "", 0),
+                (2, 10, 2, 'краси"вий', "Те саме, що [S]га́рний[/S]", 0, "", 0),
+                (3, 20, 1, 'га"рний', "Привабливий предмет", 0, "", 0),
+                (4, 20, 2, 'чудо"вий', "Дуже [B]гарний[/B]", 1, 'приго"жий', 2),
+            ],
+        )
+
+    with sqlite3.connect(db_dir / "etym.db") as connection:
+        connection.executescript(
+            """
+            CREATE TABLE root (id INTEGER PRIMARY KEY, volume_num INTEGER, page_initial INTEGER, page_last INTEGER);
+            CREATE TABLE e_classes (
+                id INTEGER PRIMARY KEY,
+                id_root INTEGER NOT NULL,
+                class_type INTEGER NOT NULL,
+                class_num INTEGER NOT NULL,
+                subclass_num INTEGER NOT NULL,
+                formal_type INTEGER NOT NULL,
+                subclass_text TEXT
+            );
+            CREATE TABLE etymons (
+                id INTEGER PRIMARY KEY,
+                id_e_classes INTEGER NOT NULL,
+                word_num INTEGER NOT NULL,
+                ishead INTEGER NOT NULL,
+                word TEXT NOT NULL,
+                homonym INTEGER NOT NULL,
+                dialect INTEGER NOT NULL,
+                antroponym INTEGER NOT NULL DEFAULT 0,
+                lang_code INTEGER,
+                lang_marker TEXT,
+                lang_note TEXT,
+                note TEXT,
+                sense TEXT,
+                bibliography TEXT
+            );
+            CREATE TABLE lang_all (lang_code INTEGER PRIMARY KEY, lang_name TEXT);
+            CREATE TABLE bibl (id INTEGER PRIMARY KEY, id_root INTEGER NOT NULL, biblio_num INTEGER NOT NULL, biblio_text TEXT);
+            CREATE TABLE links (id INTEGER PRIMARY KEY, id_root INTEGER NOT NULL, link_type INTEGER NOT NULL, link_num INTEGER NOT NULL, word TEXT, homonym INTEGER);
+            """
+        )
+        connection.executemany("INSERT INTO root VALUES (?, ?, ?, ?)", [(1, 1, 414, 415), (2, 1, 416, 416)])
+        connection.executemany(
+            "INSERT INTO e_classes VALUES (?, ?, 0, ?, 0, 0, '')",
+            [(11, 1, 1), (12, 1, 2), (21, 2, 1)],
+        )
+        connection.executemany(
+            "INSERT INTO lang_all VALUES (?, ?)", [(183, "українська"), (57, "давньоруська")]
+        )
+        connection.executemany(
+            """INSERT INTO etymons
+               (id, id_e_classes, word_num, ishead, word, homonym, dialect, antroponym,
+                lang_code, lang_marker, lang_note, note, sense, bibliography)
+               VALUES (?, ?, ?, ?, ?, 0, 0, 0, ?, ?, '', ?, ?, ?)""",
+            [
+                (101, 11, 1, 1, "вода\u0301", 183, "укр.", "", "", ""),
+                (102, 12, 1, 0, "вода", 57, "др.", "", "«рідина»", "Ref A"),
+                (201, 21, 1, 1, "водни\u0301к", 183, "укр.", "", "", ""),
+                (202, 21, 2, 0, "вода", 183, "укр.", "", "embedded comparison", ""),
+            ],
+        )
+        connection.execute("INSERT INTO bibl VALUES (1, 1, 1, 'Фасмер I 1')")
+        connection.execute("INSERT INTO links VALUES (1, 1, 2, 4, 'вода', 0)")
+
+    with sqlite3.connect(db_dir / "mph_ua.db") as connection:
+        connection.executescript(
+            """
+            CREATE TABLE nom (
+                reestr TEXT NOT NULL,
+                part INTEGER NOT NULL,
+                type INTEGER NOT NULL,
+                nom_old INTEGER PRIMARY KEY,
+                isdel INTEGER NOT NULL,
+                isproblem INTEGER
+            );
+            CREATE TABLE parts (id INTEGER PRIMARY KEY, part TEXT, com TEXT);
+            """
+        )
+        connection.execute("INSERT INTO parts VALUES (11, 'п', 'прикметник')")
+        connection.executemany(
+            "INSERT INTO nom VALUES (?, 11, 2302, ?, ?, ?)",
+            [('га"рний', 1, 0, 0), ('га"рний', 2, 1, 0)],
+        )
+    return db_dir, index_path
+
+
+def test_synonym_groups_stress_markup_and_sidecar_leave_sources_untouched(tmp_path: Path) -> None:
+    db_dir, index_path = _mphdict_fixture(tmp_path)
+    source_paths = sorted(db_dir.glob("*.db"))
+    before = {path.name: _sha256(path) for path in source_paths}
+
+    result = mphdict_synonyms("га́рний", db_dir=db_dir, index_path=index_path)
+
+    assert result is not None
+    assert result["lemma"] == "гарний"
+    assert [group["id"] for group in result["synsets"]] == [10, 20]
+    first = result["synsets"][0]
+    assert first["pos"] == "Прикметник"
+    assert first["gloss"] == {
+        "text": "про людину — конкретний",
+        "markup": [{"tag": "S", "text": "конкретний"}],
+    }
+    assert first["members"][0]["stressed"] == "га́рний"
+    assert first["members"][0]["encoded_stressed"] == 'га"рний'
+    assert first["members"][1]["gloss"]["markup"] == [{"tag": "S", "text": "га́рний"}]
+    assert result["synsets"][1]["members"][1]["hyperonym"]["stressed"] == "приго́жий"
+    assert result["synsets"][1]["members"][1]["homonym"] == 2
+    assert before == {path.name: _sha256(path) for path in source_paths}
+
+    with sqlite3.connect(index_path) as connection:
+        plan = connection.execute(
+            "EXPLAIN QUERY PLAN SELECT row_id FROM normalized_words WHERE source_key = ? AND lookup_key = ?",
+            (f"{(db_dir / 'synsets_ua.db').resolve()}::wlist::id::word", "гарний"),
+        ).fetchall()
+    assert any("normalized_words_lookup" in str(row) for row in plan)
+
+
+def test_gloss_normalization_keeps_label_text_and_tagged_structure() -> None:
+    assert normalize_gloss("&lt;рідко.&gt;Те саме, що [B]завда́ток[/B]") == {
+        "text": "рідко. Те саме, що завда́ток",
+        "markup": [{"tag": "B", "text": "завда́ток"}],
+    }
+
+
+def test_etymology_uses_direct_headword_root_with_citation_and_bibliography(tmp_path: Path) -> None:
+    db_dir, index_path = _mphdict_fixture(tmp_path)
+
+    result = mphdict_etymology("вода", db_dir=db_dir, index_path=index_path)
+
+    assert result is not None
+    assert result["lemma"] == "вода"
+    assert len(result["roots"]) == 1
+    root = result["roots"][0]
+    assert root["id"] == 1
+    assert root["match"] == {"is_direct_headword": True, "kind": "headword"}
+    assert root["citation"] == {
+        "volume": 1,
+        "page_initial": 414,
+        "page_last": 415,
+        "display": "т. 1, с. 414–415",
+    }
+    assert root["etymons"][0]["stressed"] == "вода́"
+    assert root["etymons"][1]["language"] == "давньоруська"
+    assert root["etymons"][1]["bibliography"] == "Ref A"
+    assert root["bibliography"] == [{"number": 1, "text": "Фасмер I 1"}]
+    assert root["links"] == [{"type": 2, "number": 4, "word": "вода", "homonym": 0}]
+
+
+def test_headword_returns_active_official_stressed_registry_row(tmp_path: Path) -> None:
+    db_dir, index_path = _mphdict_fixture(tmp_path)
+
+    result = mphdict_headword("гарний", db_dir=db_dir, index_path=index_path)
+
+    assert result == {
+        "registry_id": 1,
+        "lemma": "гарний",
+        "stressed": "га́рний",
+        "encoded_stressed": 'га"рний',
+        "pos": "прикметник",
+        "pos_code": "п",
+        "part_id": 11,
+        "flexion_type": 2302,
+    }
+
+
+def test_atlas_adapters_use_mphdict_without_the_legacy_enrichment_sources(monkeypatch) -> None:
+    synsets = [{"id": 9, "pos": "Іменник", "members": [{"lemma": "ключ", "stressed": "ключ"}, {"lemma": "замок", "stressed": "замо́к"}]}]
+    monkeypatch.setattr(enrich_manifest, "mphdict_synonyms", lambda word: {"lemma": word, "synsets": synsets})
+    monkeypatch.setattr(
+        enrich_manifest,
+        "mphdict_etymology",
+        lambda word: {
+            "lemma": word,
+            "roots": [
+                {
+                    "id": 5,
+                    "match": {"is_direct_headword": True, "kind": "headword"},
+                    "citation": {"display": "т. 6, с. 181"},
+                    "etymons": [{"is_head": True, "stressed": "хліб"}],
+                    "bibliography": [{"number": 1, "text": "Fixture bibliography"}],
+                }
+            ],
+        },
+    )
+
+    synonyms = enrich_manifest._synonyms_mphdict("ключ")
+    etymology = enrich_manifest._etymology(sqlite3.connect(":memory:"), "хліб", {})
+
+    assert synonyms == {"items": ["замок"], "synsets": synsets, "source": MPHDICT_SYNONYMS_LABEL}
+    assert etymology == {
+        "text": "Стаття ЕСУМ: хліб; етимонів: 1.",
+        "source": f"{ESUM_LABEL}, т. 6, с. 181",
+        "mphdict_root": {
+            "id": 5,
+            "match": {"is_direct_headword": True, "kind": "headword"},
+            "citation": {"display": "т. 6, с. 181"},
+            "bibliography": [{"number": 1, "text": "Fixture bibliography"}],
+        },
+    }
+    enrichment_source = inspect.getsource(enrich_manifest.enrich_entry)
+    etymology_source = inspect.getsource(enrich_manifest._etymology)
+    assert "ukrajinet" not in enrichment_source.casefold()
+    assert "_synonyms_slovnyk" not in enrichment_source
+    assert "_source_etymology" not in etymology_source
+
+
+def test_active_slovnyk_cache_excludes_retired_synonym_slugs() -> None:
+    assert "synonyms" not in enrich_manifest._SLOVNYK_LOOKUP_SLUGS
+    assert "synonyms_karavansky" not in enrich_manifest._SLOVNYK_LOOKUP_SLUGS

--- a/tests/test_wiktionary_etymology_ingest.py
+++ b/tests/test_wiktionary_etymology_ingest.py
@@ -3,19 +3,15 @@ import sqlite3
 from pathlib import Path
 from xml.sax.saxutils import escape
 
-from scripts.ingest.goroh_etymology_ingest import ensure_goroh_etymology_schema, upsert_goroh_row
 from scripts.ingest.wiktionary_etymology_ingest import (
-    WIKTIONARY_DUMP_DATE,
     WiktionaryPage,
-    content_hash,
     ensure_wiktionary_etymology_schema,
     ingest_wiktionary_etymology,
     is_clean_etymology,
     lookup_key,
     parse_wiktionary_page,
-    upsert_wiktionary_row,
 )
-from scripts.lexicon.enrich_manifest import _etymology, _single_word_etymology_coverage
+from scripts.lexicon.enrich_manifest import _single_word_etymology_coverage
 
 
 def _write_dump(tmp_path: Path, pages: list[tuple[str, str, str]]) -> Path:
@@ -35,37 +31,6 @@ def _write_dump(tmp_path: Path, pages: list[tuple[str, str, str]]) -> Path:
     with bz2.open(path, "wt", encoding="utf-8") as fh:
         fh.write(f'<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/">\n{body}\n</mediawiki>')
     return path
-
-
-def _wiktionary_row(requested_lemma: str, text: str) -> dict[str, str]:
-    return {
-        "requested_lemma": requested_lemma,
-        "headword": requested_lemma,
-        "lang": "uk",
-        "etymology_text": text,
-        "section_raw": text,
-        "source_url": f"https://uk.wiktionary.org/wiki/{requested_lemma}",
-        "dump_date": WIKTIONARY_DUMP_DATE,
-        "retrieved_at": "2026-06-01T00:00:00+00:00",
-        "content_hash": content_hash(text),
-    }
-
-
-def _conn_with_etymology_tables() -> sqlite3.Connection:
-    conn = sqlite3.connect(":memory:")
-    ensure_goroh_etymology_schema(conn)
-    ensure_wiktionary_etymology_schema(conn)
-    conn.execute(
-        """
-        CREATE TABLE esum_etymology (
-            lemma TEXT NOT NULL,
-            etymology_text TEXT NOT NULL DEFAULT '',
-            vol TEXT DEFAULT '',
-            page TEXT DEFAULT ''
-        )
-        """
-    )
-    return conn
 
 
 def test_wiktionary_schema_and_ingest_are_idempotent_with_phrase_skip(tmp_path: Path) -> None:
@@ -236,49 +201,10 @@ def test_multilingual_numbered_etymology_extracts_only_ukrainian_section() -> No
     assert "рахунком" in row["etymology_text"]
 
 
-def test_etymology_precedence_and_phrase_skip() -> None:
-    conn = _conn_with_etymology_tables()
-    upsert_goroh_row(
-        conn,
-        {
-            "requested_lemma": "робота",
-            "headword": "робота",
-            "etymology_text": "Горох має першість.",
-            "source_url": "https://goroh.pp.ua/Етимологія/робота",
-            "retrieved_at": "2026-06-01T00:00:00+00:00",
-            "content_hash": "goroh",
-        },
-    )
-    assert _etymology(conn, "робота") == {
-        "text": "Горох має першість.",
-        "source": "Горох (за ЕСУМ)",
-        "source_url": "https://goroh.pp.ua/Етимологія/робота",
-    }
-
-    conn.execute("DELETE FROM goroh_etymology")
-    conn.execute(
-        "INSERT INTO esum_etymology VALUES (?, ?, ?, ?)",
-        ("робота", "ЕСУМ має першість над Вікісловником.", "5", "10"),
-    )
-    assert _etymology(conn, "робота") == {
-        "text": "ЕСУМ має першість над Вікісловником.",
-        "source": "ЕСУМ, т. 5, с. 10",
-    }
-
-    conn.execute("DELETE FROM esum_etymology")
-    upsert_wiktionary_row(
-        conn,
-        _wiktionary_row("комп'ютер", 'Від англ. дієсл. to compute — "обчислити".'),
-    )
-    assert _etymology(conn, "комп'ютер") == {
-        "text": 'Від англ. дієсл. to compute — "обчислити".',
-        "source": "Вікісловник (uk.wiktionary)",
-        "source_url": "https://uk.wiktionary.org/wiki/комп'ютер",
-    }
-
-    upsert_wiktionary_row(conn, _wiktionary_row("Добрий день", "Phrase row should never render."))
-    assert _etymology(conn, "Добрий день") is None
-
+def test_single_word_etymology_coverage_counts_words_only() -> None:
+    # Etymology is now mphdict-only (the goroh/esum/wiktionary fallback chain was
+    # removed in #5252); this guards the coverage counter, which counts single-word
+    # entries with etymology and ignores phrases and null lemmas.
     assert _single_word_etymology_coverage(
         {
             "entries": [


### PR DESCRIPTION
## Summary
- adds a read-only, sidecar-indexed mphdict query layer for synonym groups, ЕСУМ roots, and orthographic headwords
- makes mphdict the active Atlas synonym/etymology source; retired synonym slugs are excluded from the slovnyk cache
- preserves synonym-set boundaries through the Atlas payload and rendering, with ODbL/DbCL and underlying-work attribution

## Verification
- `MPHDICT_DATA_DIR=/tmp/mphdict-ci-absent .venv/bin/pytest -q tests/test_mphdict.py tests/test_source_attribution.py tests/test_lexicon_enrich_manifest.py` — 166 passed
- `.venv/bin/ruff check scripts/mphdict scripts/lexicon/enrich_manifest.py scripts/lexicon/source_attribution.py tests/test_mphdict.py tests/test_lexicon_enrich_manifest.py` — passed
- `npm run build --prefix site` — passed

## M-4 evidence
- real `mphdict_synonyms('гарний')` produced five separate `id_set` groups; `mphdict_synonyms('осуд')` produced five
- `га"рний` resolves from plain `гарний` and yields display stress `га́рний`
- real `mphdict_etymology('хліб')` returned root 29036, ЕСУМ т. 6, с. 181, 48 etymons, and bibliography rows
- source DB SHA-256 values were identical before and after sidecar queries; the sidecar plan uses `normalized_words_lookup`
- active `enrich_entry` contains zero `ukrajinet`/`WordNet` matches; the active slovnyk cache excludes both retired synonym slugs

## Review gate
Cross-family AGY, Grok, and Claude review routes were attempted, but the local bridge/CLI returned no review response. This PR is intentionally not auto-merged; it needs an independent review before merge.

Refs #5224