### PR TITLE
feat(audit): load-bearing hramatka QG rule set + lesson_json adapter

### DIFF
--- a/scripts/audit/curriculum_qg_harness.py
+++ b/scripts/audit/curriculum_qg_harness.py
@@ -45,14 +45,15 @@ RULE_SETS = (RULE_SET_CURRICULUM, RULE_SET_HRAMATKA)
 def _hramatka_rules():
     """Lazy-load the separate hramatka rule module (never merge with PHRASE_RULES).
 
-    Imported on demand so ``python scripts/audit/curriculum_qg_harness.py`` keeps
-    working when AUDIT_DIR is on ``sys.path`` (avoids ``scripts.audit`` package
-    __init__ circular imports at module import time).
+    Always resolve via ``scripts.audit.hramatka_qg_rules`` so test monkeypatches
+    and path overrides apply to the same module object as direct imports.
+    Falls back to a sibling import only when the package path is unavailable
+    (CLI invoked with ``scripts/audit`` alone on ``sys.path``).
     """
     try:
-        import hramatka_qg_rules as mod  # type: ignore
-    except ImportError:  # pragma: no cover
         from scripts.audit import hramatka_qg_rules as mod
+    except ImportError:  # pragma: no cover - CLI path with AUDIT_DIR only
+        import hramatka_qg_rules as mod  # type: ignore
     return mod
 DIMENSION_ORDER = (
     "surface_leakage",

--- a/scripts/audit/curriculum_qg_harness.py
+++ b/scripts/audit/curriculum_qg_harness.py
@@ -37,6 +37,23 @@ from llm_qg_store import CONTENT_FILES, content_sha_for_module
 FIXTURE_SCHEMA_VERSION = "curriculum_ua_qg_fixtures.v1"
 EVIDENCE_SCHEMA_VERSION = "curriculum_ua_qg_evidence.v1"
 CHECKER_VERSION = "curriculum_ua_qg_harness.v1"
+RULE_SET_CURRICULUM = "curriculum"
+RULE_SET_HRAMATKA = "hramatka"
+RULE_SETS = (RULE_SET_CURRICULUM, RULE_SET_HRAMATKA)
+
+
+def _hramatka_rules():
+    """Lazy-load the separate hramatka rule module (never merge with PHRASE_RULES).
+
+    Imported on demand so ``python scripts/audit/curriculum_qg_harness.py`` keeps
+    working when AUDIT_DIR is on ``sys.path`` (avoids ``scripts.audit`` package
+    __init__ circular imports at module import time).
+    """
+    try:
+        import hramatka_qg_rules as mod  # type: ignore
+    except ImportError:  # pragma: no cover
+        from scripts.audit import hramatka_qg_rules as mod
+    return mod
 DIMENSION_ORDER = (
     "surface_leakage",
     "level_policy",
@@ -374,8 +391,23 @@ def scan_curriculum_module(
     level: str,
     slug: str | None = None,
     fixture_id: str | None = None,
+    rule_set: str = RULE_SET_CURRICULUM,
 ) -> dict[str, Any]:
-    """Scan one module directory and return compact deterministic evidence."""
+    """Scan one module directory and return compact deterministic evidence.
+
+    ``rule_set`` selects the checker family:
+    - ``curriculum`` (default): writer-failure PHRASE_RULES + surface gates
+    - ``hramatka``: structural/generative checks in ``hramatka_qg_rules``
+    """
+    clean_rule_set = (rule_set or RULE_SET_CURRICULUM).strip().lower()
+    if clean_rule_set == RULE_SET_HRAMATKA:
+        return _hramatka_rules().scan_hramatka_module(
+            module_dir,
+            level=level,
+            slug=slug,
+            fixture_id=fixture_id,
+        )
+
     module_dir = module_dir.resolve()
     clean_level = level.strip().lower()
     clean_slug = slug or module_dir.name
@@ -393,6 +425,7 @@ def scan_curriculum_module(
     config_hash = checker_config_hash()
     return {
         "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "rule_set": RULE_SET_CURRICULUM,
         "module_id": f"{clean_level}/{clean_slug}",
         "level": clean_level,
         "slug": clean_slug,
@@ -403,6 +436,7 @@ def scan_curriculum_module(
         "checker_config": {
             "version": CHECKER_VERSION,
             "config_hash": config_hash,
+            "rule_set": RULE_SET_CURRICULUM,
         },
         "content_sha": content_sha_for_module(module_dir),
         "verdict": aggregate["verdict"],
@@ -532,13 +566,25 @@ def evaluate_fixture(fixture: Mapping[str, Any], *, temp_root: Path) -> dict[str
     }
 
 
-def run_fixtures(path: Path) -> dict[str, Any]:
-    """Run a fixture YAML file and return result rows plus summary."""
+def run_fixtures(path: Path, *, rule_set: str | None = None) -> dict[str, Any]:
+    """Run a fixture YAML file and return result rows plus summary.
+
+    Hramatka fixtures use schema ``hramatka_ua_qg_fixtures.v1`` and are
+    dispatched to ``hramatka_qg_rules.run_fixtures`` (separate rule set).
+    """
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(data, Mapping):
         raise ValueError("fixture file must be a mapping")
-    if data.get("schema_version") != FIXTURE_SCHEMA_VERSION:
-        raise ValueError(f"unsupported fixture schema: {data.get('schema_version')}")
+    schema = data.get("schema_version")
+    requested = (rule_set or data.get("rule_set") or RULE_SET_CURRICULUM)
+    requested = str(requested).strip().lower()
+
+    hramatka = _hramatka_rules()
+    if schema == hramatka.FIXTURE_SCHEMA_VERSION or requested == RULE_SET_HRAMATKA:
+        return hramatka.run_fixtures(path)
+
+    if schema != FIXTURE_SCHEMA_VERSION:
+        raise ValueError(f"unsupported fixture schema: {schema}")
     fixtures = data.get("fixtures")
     if not isinstance(fixtures, list):
         raise ValueError("fixture file must contain a fixtures list")
@@ -553,6 +599,7 @@ def run_fixtures(path: Path) -> dict[str, Any]:
     passed = sum(1 for result in results if result["passed"])
     return {
         "schema_version": FIXTURE_SCHEMA_VERSION,
+        "rule_set": RULE_SET_CURRICULUM,
         "fixture_file": str(path),
         "summary": {
             "total": len(results),
@@ -564,10 +611,17 @@ def run_fixtures(path: Path) -> dict[str, Any]:
 
 
 def _summary_text(payload: Mapping[str, Any]) -> str:
+    rule_set = str(payload.get("rule_set") or RULE_SET_CURRICULUM)
     if "results" in payload:
         summary = payload["summary"]
+        label = (
+            "Hramatka Ukrainian QG Fixtures"
+            if rule_set == RULE_SET_HRAMATKA
+            else "Curriculum Ukrainian QG Fixtures"
+        )
         lines = [
-            "Curriculum Ukrainian QG Fixtures",
+            label,
+            f"Rule set: {rule_set}",
             f"Total: {summary['total']}",
             f"Passed: {summary['passed']}",
             f"Failed: {summary['failed']}",
@@ -579,8 +633,14 @@ def _summary_text(payload: Mapping[str, Any]) -> str:
             )
         return "\n".join(lines)
     aggregate = payload["aggregate"]
+    label = (
+        "Hramatka Ukrainian QG Evidence"
+        if rule_set == RULE_SET_HRAMATKA
+        else "Curriculum Ukrainian QG Evidence"
+    )
     return (
-        "Curriculum Ukrainian QG Evidence\n"
+        f"{label}\n"
+        f"Rule set: {rule_set}\n"
         f"Module: {payload['module_id']}\n"
         f"Verdict: {payload['verdict']}\n"
         f"Min score: {aggregate['min_score']} ({aggregate['min_dim']})"
@@ -592,8 +652,22 @@ def build_parser() -> argparse.ArgumentParser:
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--module-dir", type=Path, help="Module directory to scan.")
     source.add_argument("--fixtures", type=Path, help="Fixture YAML file to run.")
+    source.add_argument(
+        "--lesson-json",
+        type=Path,
+        help="Hramatka lesson_json file (implies --rule-set hramatka).",
+    )
     parser.add_argument("--level", help="Level for --module-dir, e.g. b1.")
     parser.add_argument("--slug", help="Slug for --module-dir. Defaults to directory name.")
+    parser.add_argument(
+        "--rule-set",
+        choices=RULE_SETS,
+        default=RULE_SET_CURRICULUM,
+        help=(
+            "Selectable rule set: 'curriculum' (writer PHRASE_RULES) or "
+            "'hramatka' (structural/generative lesson checks). Default: curriculum."
+        ),
+    )
     parser.add_argument("--format", choices=("json", "summary"), default="summary")
     parser.add_argument("--output", type=Path, help="Optional output path.")
     return parser
@@ -603,15 +677,23 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         if args.fixtures:
-            payload = run_fixtures(args.fixtures)
+            payload = run_fixtures(args.fixtures, rule_set=args.rule_set)
             failed = int(payload["summary"]["failed"])
+        elif args.lesson_json is not None:
+            lesson = json.loads(args.lesson_json.read_text(encoding="utf-8"))
+            payload = _hramatka_rules().scan_hramatka_lesson(
+                lesson,
+                slug=args.slug,
+            )
+            failed = 0 if payload["terminal_verdict"] == "PASS" else 1
         else:
-            if not args.level:
+            if not args.level and args.rule_set != RULE_SET_HRAMATKA:
                 raise ValueError("--module-dir requires --level")
             payload = scan_curriculum_module(
                 args.module_dir,
-                level=args.level,
+                level=args.level or "b1",
                 slug=args.slug,
+                rule_set=args.rule_set,
             )
             failed = 0 if payload["terminal_verdict"] == "PASS" else 1
     except (OSError, ValueError, yaml.YAMLError, json.JSONDecodeError) as exc:

--- a/scripts/audit/hramatka_qg_rules.py
+++ b/scripts/audit/hramatka_qg_rules.py
@@ -500,6 +500,13 @@ def _apostrophe_variants(token: str) -> list[str]:
     return variants
 
 
+# Optional path overrides — tests inject controlled SQLite DBs so CI never
+# depends on ambient sources.db / vesum.db fullness. Production leaves these None.
+_SOURCES_DB_OVERRIDE: Path | None = None
+_VESUM_DB_OVERRIDE: Path | None = None
+_HERITAGE_DB_OVERRIDE: Path | None = None
+
+
 def _vesum_hits(token: str) -> list[dict]:
     """VESUM lookup tolerant of apostrophe orthography and proper-noun case.
 
@@ -507,7 +514,7 @@ def _vesum_hits(token: str) -> list[dict]:
     """
     try:
         for variant in _apostrophe_variants(token):
-            hits = verify_word(variant)
+            hits = verify_word(variant, db_path=_VESUM_DB_OVERRIDE)
             if hits:
                 return hits
     except (FileNotFoundError, OSError, sqlite3.Error) as exc:
@@ -516,11 +523,24 @@ def _vesum_hits(token: str) -> list[dict]:
     return []
 
 
+def _vesum_detector_unavailable() -> bool:
+    """True when this scan already recorded VESUM as unavailable."""
+    store = _ACTIVE_UNAVAILABLE.get()
+    return bool(store and "vesum" in store)
+
+
 def _is_probable_proper_noun(token: str) -> bool:
-    """Capitalized tokens are proper-noun candidates (skip invented/russianism)."""
+    """Capitalized / title-case tokens are proper-noun or sentence-initial candidates.
+
+    Invented-form and russian-shadow gates must not flag place names (Львів),
+    personal names (Оля), or sentence-initial ordinary words that look capitalized.
+    ALL-CAPS acronyms are also excluded (not ordinary invented lemmas).
+    """
     if not token:
         return False
-    return token[0].isupper() and not token.isupper()
+    if token.isupper() and len(token) >= 2:
+        return True
+    return token[0].isupper()
 
 
 def _normalize_option(text: str) -> str:
@@ -636,8 +656,8 @@ def _classify_token(token: str) -> dict[str, Any]:
             "calque_warning": None,
         }
     if _is_probable_proper_noun(token):
-        # Proper nouns absent from VESUM are not russianisms; content lane may still
-        # review them. Deterministic gate stays quiet.
+        # Proper nouns / capitalized names absent from VESUM are not russianisms
+        # or invented forms; content lane may still review them.
         return {
             "classification": "proper_noun",
             "attestations": [],
@@ -649,7 +669,11 @@ def _classify_token(token: str) -> dict[str, Any]:
         }
     # heritage_classifier always overrides when it attests; russian-shadow is a signal.
     try:
-        return classify_surface_form(token.casefold())
+        return classify_surface_form(
+            token.casefold(),
+            db_path=_HERITAGE_DB_OVERRIDE,
+            vesum_db_path=_VESUM_DB_OVERRIDE,
+        )
     except (FileNotFoundError, OSError, sqlite3.Error) as exc:
         _mark_detector_unavailable("heritage_classifier", str(exc))
         return _unknown_token_status()
@@ -659,24 +683,37 @@ def _is_russianism_token(token: str, status: Mapping[str, Any] | None = None) ->
     """Return True when token is a russianism after heritage override."""
     if _is_probable_proper_noun(token):
         return False
+    # Without VESUM we cannot assert "VESUM-absent ∧ russian-shadow".
+    if _vesum_detector_unavailable():
+        return False
     status = status or _classify_token(token)
     if status.get("is_russianism"):
         return True
     if _heritage_safe(status):
         return False
-    if status.get("classification") == "proper_noun":
+    if status.get("classification") in {"proper_noun", "borrowing"}:
         return False
     # VESUM-absent AND russian-shadow AND NOT heritage → russianism
     return bool((not status.get("vesum_attested")) and status.get("russian_shadow"))
 
 
 def _is_invented_form(token: str, status: Mapping[str, Any] | None = None) -> bool:
+    """Flag only lower-case non-proper forms that fail VESUM + heritage gates.
+
+    Precision rules (noisy gate is useless):
+    - Proper nouns / capitalized names / ALL-CAPS → never invented.
+    - Heritage-safe (standard/borrowing/dialect/archaism/historism) → never invented.
+    - VESUM unavailable this scan → stay quiet (cannot prove absence).
+    - Russian-shadow forms route to RUSSIAN_SHADOW_RUSSICISM, not NON_VESUM_FORM.
+    """
     if _is_probable_proper_noun(token):
+        return False
+    if _vesum_detector_unavailable():
         return False
     status = status or _classify_token(token)
     if _heritage_safe(status):
         return False
-    if status.get("classification") == "proper_noun":
+    if status.get("classification") in {"proper_noun", "borrowing"}:
         return False
     if status.get("is_russianism") or status.get("russian_shadow"):
         return False
@@ -713,7 +750,7 @@ def _is_missing_table_error(exc: BaseException) -> bool:
 
 
 def _sources_conn():
-    db = PROJECT_ROOT / "data" / "sources.db"
+    db = _SOURCES_DB_OVERRIDE or (PROJECT_ROOT / "data" / "sources.db")
     if not db.exists():
         return None
     conn = sqlite3.connect(str(db))
@@ -1532,7 +1569,11 @@ def check_empty_learner_surface(ctx: _ScanContext) -> list[dict[str, Any]]:
 
 
 def check_task_language_cefr(ctx: _ScanContext) -> list[dict[str, Any]]:
-    """Tier-2: CEFR of INSTRUCTIONS/ITEMS only; never grade the teacher anchor."""
+    """Tier-2: CEFR of INSTRUCTIONS/ITEMS only; never grade the teacher anchor.
+
+    Lenient by design: only flag words clearly ≥2 CEFR bands above the lesson,
+    only in task language (instruction / item prompts), never proper nouns.
+    """
     findings: list[dict[str, Any]] = []
     lesson_level = _normalize_level(ctx.level)
     act_text = ctx.texts.get("activities.yaml") or ""
@@ -1561,6 +1602,12 @@ def check_task_language_cefr(ctx: _ScanContext) -> list[dict[str, Any]]:
     seen: set[str] = set()
     for path, text in task_strings:
         for token in _cyrillic_tokens(text):
+            # Proper nouns / names are not CEFR-vocab items.
+            if _is_probable_proper_noun(token):
+                continue
+            # Skip very short tokens (particles, answer-key letters).
+            if len(token) < 3:
+                continue
             word_level = _cefr_level_for(token)
             if not word_level:
                 continue

--- a/scripts/audit/hramatka_qg_rules.py
+++ b/scripts/audit/hramatka_qg_rules.py
@@ -1,0 +1,1841 @@
+#!/usr/bin/env python3
+"""Hramatka-specific quality-gate rule set (selectable, never mixed with curriculum PHRASE_RULES).
+
+Deterministic ($0, no-LLM) checks for generative hramatka lesson_json artifacts.
+Call local Python APIs only — never shell out to MCP.
+
+Tier-1: russianism/surzhyk/calque · invalid distractor · answer-key placeholder
+Tier-2: structural activity integrity · empty learner surface · task-language CEFR · invented form
+
+Issue: load-bearing QG for hramatka (#5187 feedback).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+# Prefer sibling imports when AUDIT_DIR is on sys.path (CLI harness mode).
+try:
+    from checks.russicism_detection import check_russicisms, check_ua_gec_calques
+    from llm_qg_store import CONTENT_FILES, content_sha_for_module
+except ImportError:  # pragma: no cover - package import under pytest
+    from scripts.audit.checks.russicism_detection import (
+        check_russicisms,
+        check_ua_gec_calques,
+    )
+    from scripts.audit.llm_qg_store import CONTENT_FILES, content_sha_for_module
+
+from scripts.lexicon.heritage_classifier import (
+    classify_surface_form,
+    has_positive_attestation,
+)
+from scripts.verification.vesum import verify_word
+
+RULE_SET_ID = "hramatka"
+CHECKER_VERSION = "hramatka_ua_qg_rules.v1"
+EVIDENCE_SCHEMA_VERSION = "hramatka_ua_qg_evidence.v1"
+FIXTURE_SCHEMA_VERSION = "hramatka_ua_qg_fixtures.v1"
+
+DIMENSION_ORDER = (
+    "russianism_calque",
+    "distractor_quality",
+    "answer_key_integrity",
+    "activity_structure",
+    "learner_surface",
+    "task_cefr",
+    "invented_form",
+)
+SEVERITY_WEIGHTS = {"critical": 2.5, "warning": 0.75, "info": 0.0}
+
+# Internal / privacy fields — never land in learner-facing serialization.
+_EXCLUDED_KEYS = frozenset(
+    {
+        "provenance",
+        "mark",
+        "phase",
+        "note",
+        "teacher_notes",
+        "teacher-notes",
+        "system_prompt",
+        "system-prompt",
+        "rationale",
+        "metadata",
+        "edited",
+        "last_error",
+        "accepted",
+        "status",
+        "version",
+        "duration",
+        "method",
+        "focus",
+        "id",  # block/activity UUIDs are internal
+        "chars",
+        "source",  # anchor.source is teacher-pipeline provenance
+        "gates",
+        "generator",
+        "external_options",
+    }
+)
+
+# Keys retained when walking activity trees (learner-facing surface).
+_ACTIVITY_KEEP_KEYS = frozenset(
+    {
+        "type",
+        "title",
+        "level",
+        "mode",
+        "activity",
+        "answer_key",
+        "hint",
+        "explanation",
+        "payload",
+        "instruction",
+        "items",
+        "options",
+        "pairs",
+        "prompt",
+        "statement",
+        "term",
+        "gloss",
+        "text",
+        "correct",
+        "left",
+        "right",
+        "index",
+        "left_index",
+        "right_index",
+        "guidance",
+        "blanks",
+        "answers",
+        "blank_count",
+        "stem",
+        "choices",
+        "question",
+        "label",
+        "value",
+        "gloss_lang",
+    }
+)
+
+_CYRILLIC_TOKEN_RE = re.compile(r"[А-Яа-яЁёІіЇїЄєҐґ][А-Яа-яЁёІіЇїЄєҐґ'ʼ’\-]*")
+# Whole-value placeholders only — ellipsis inside a real answer is not a placeholder.
+_PLACEHOLDER_EXACT_RE = re.compile(
+    r"(?:"
+    r"TODO|XXX|TBD|"
+    r"\.\.\.|…|"
+    r"answer\s*here|"
+    r"відповідь\s*тут|"
+    r"placeholder|"
+    r"\[\s*\]|"
+    r"\{\s*\}"
+    r")",
+    re.IGNORECASE,
+)
+_OPTION_PREFIX_RE = re.compile(r"^[а-яіїєґa-z0-9]+[).\:\-]\s*", re.IGNORECASE)
+# Cloze blanks: ____ / {{slot}} / [___] / [___:1]
+_CLOZE_BLANK_RE = re.compile(r"_{2,}|\{\{[^}]+\}\}|\[_{1,}(?::[^\]]+)?\]")
+_APOSTROPHES = ("'", "ʼ", "’", "`")
+_FREE_RESPONSE_TYPES = frozenset(
+    {
+        "continue-sentence",
+        "continue_sentence",
+        "roleplay-dialog",
+        "roleplay",
+        "short-writing",
+        "free-writing",
+        "discussion",
+        "glossary",
+        "reading",
+        "text",
+    }
+)
+
+_CEFR_RANK = {"a1": 1, "a2": 2, "b1": 3, "b2": 4, "c1": 5, "c2": 6}
+_HERITAGE_SAFE = frozenset(
+    {
+        "authentic-archaism",
+        "dialect",
+        "historism",
+        "borrowing",
+        "standard",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptedLesson:
+    """Learner-facing module-dir payload derived from lesson_json."""
+
+    title: str
+    level: str
+    slug: str
+    module_md: str
+    activities: list[dict[str, Any]]
+    vocabulary: list[Any]
+    resources: list[Any]
+    content_hash: str
+    excluded_keys_seen: tuple[str, ...] = ()
+    learner_strings: tuple[tuple[str, str], ...] = ()  # (path, text)
+
+
+@dataclass
+class _ScanContext:
+    level: str
+    texts: dict[str, str]
+    activities: list[dict[str, Any]]
+    learner_strings: list[tuple[str, str]] = field(default_factory=list)
+    findings: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def checker_config_hash() -> str:
+    """Stable hash for the hramatka deterministic rule configuration."""
+    payload = {
+        "checker_version": CHECKER_VERSION,
+        "rule_set": RULE_SET_ID,
+        "dimensions": DIMENSION_ORDER,
+        "severity_weights": SEVERITY_WEIGHTS,
+        "excluded_keys": sorted(_EXCLUDED_KEYS),
+        "checks": [
+            "russianism_calque",
+            "invalid_distractor",
+            "answer_key_placeholder",
+            "structural_activity_integrity",
+            "empty_learner_surface",
+            "task_language_cefr",
+            "invented_form",
+        ],
+    }
+    return _sha256_text(_json_dumps(payload))
+
+
+def _line_no(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _span_for_excerpt(text: str, excerpt: str, line_hint: int | None = None) -> dict[str, int | None]:
+    start = text.find(excerpt)
+    if start < 0 and line_hint:
+        lines = text.splitlines(keepends=True)
+        prefix_len = sum(len(line) for line in lines[: max(line_hint - 1, 0)])
+        line_text = lines[line_hint - 1] if 0 <= line_hint - 1 < len(lines) else ""
+        line_offset = line_text.find(excerpt)
+        if line_offset >= 0:
+            start = prefix_len + line_offset
+    if start < 0:
+        return {"start": None, "end": None}
+    return {"start": start, "end": start + len(excerpt)}
+
+
+def _finding(
+    *,
+    issue_id: str,
+    rule_id: str,
+    dimension: str,
+    severity: str,
+    file: str,
+    line: int,
+    excerpt: str,
+    message: str,
+    text: str,
+    source: str = "hramatka_deterministic",
+) -> dict[str, Any]:
+    span = _span_for_excerpt(text, excerpt, line)
+    return {
+        "issue_id": issue_id,
+        "rule_id": rule_id,
+        "dimension": dimension,
+        "severity": severity,
+        "source": source,
+        "file": file,
+        "line": line,
+        "span": span,
+        "excerpt": excerpt[:160],
+        "message": message,
+    }
+
+
+def _strip_internal(value: Any, *, seen_excluded: set[str] | None = None) -> Any:
+    """Deep-copy JSON-like data, dropping excluded internal keys."""
+    excluded = seen_excluded if seen_excluded is not None else set()
+    if isinstance(value, Mapping):
+        out: dict[str, Any] = {}
+        for key, child in value.items():
+            key_s = str(key)
+            if key_s in _EXCLUDED_KEYS:
+                excluded.add(key_s)
+                continue
+            out[key_s] = _strip_internal(child, seen_excluded=excluded)
+        return out
+    if isinstance(value, list):
+        return [_strip_internal(item, seen_excluded=excluded) for item in value]
+    return value
+
+
+def _collect_strings(value: Any, path: str = "") -> list[tuple[str, str]]:
+    """Collect non-empty string leaves from a learner-facing tree."""
+    out: list[tuple[str, str]] = []
+    if isinstance(value, str):
+        text = value.strip()
+        if text:
+            out.append((path or "text", text))
+        return out
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            out.extend(_collect_strings(child, child_path))
+        return out
+    if isinstance(value, list):
+        for idx, child in enumerate(value):
+            out.extend(_collect_strings(child, f"{path}[{idx}]"))
+        return out
+    return out
+
+
+def _normalize_level(level: Any) -> str:
+    return str(level or "b1").strip().lower()
+
+
+def _slug_from_title(title: str, fallback: str = "hramatka-lesson") -> str:
+    raw = re.sub(r"[^\w\s\-а-яіїєґА-ЯІЇЄҐ]", "", title, flags=re.UNICODE)
+    raw = re.sub(r"\s+", "-", raw.strip()).strip("-").casefold()
+    return raw[:80] if raw else fallback
+
+
+def adapt_lesson_json(
+    lesson: Mapping[str, Any],
+    *,
+    slug: str | None = None,
+) -> AdaptedLesson:
+    """Field-disciplined lesson_json → learner-facing module payload.
+
+    KEEP: title, level, anchor.text, block.activity, block.answer_key, hint/explanation
+    EXCLUDE: provenance, mark, phase, teacher notes, system-prompt, rationale, metadata
+    """
+    if not isinstance(lesson, Mapping):
+        raise ValueError("lesson_json must be a mapping")
+
+    seen_excluded: set[str] = set()
+    title = str(lesson.get("title") or "").strip()
+    level = _normalize_level(lesson.get("level"))
+    clean_slug = slug or _slug_from_title(title)
+
+    anchor = lesson.get("anchor")
+    anchor_text = ""
+    if isinstance(anchor, Mapping):
+        anchor_text = str(anchor.get("text") or "").strip()
+        for key in anchor:
+            if str(key) in _EXCLUDED_KEYS or str(key) in {"source", "chars"}:
+                seen_excluded.add(str(key))
+    elif isinstance(anchor, str):
+        anchor_text = anchor.strip()
+
+    activities: list[dict[str, Any]] = []
+    blocks = lesson.get("blocks")
+    if isinstance(blocks, list):
+        for block in blocks:
+            if not isinstance(block, Mapping):
+                continue
+            for key in block:
+                if str(key) in _EXCLUDED_KEYS:
+                    seen_excluded.add(str(key))
+            cleaned_block: dict[str, Any] = {}
+            block_type = block.get("type")
+            if block_type is not None:
+                cleaned_block["type"] = block_type
+            activity = block.get("activity")
+            if isinstance(activity, Mapping):
+                cleaned_block["activity"] = _strip_internal(activity, seen_excluded=seen_excluded)
+            answer_key = block.get("answer_key")
+            if answer_key is not None:
+                cleaned_block["answer_key"] = _strip_internal(answer_key, seen_excluded=seen_excluded)
+            for keep in ("hint", "explanation"):
+                if keep in block and block[keep] is not None:
+                    cleaned_block[keep] = _strip_internal(block[keep], seen_excluded=seen_excluded)
+            if cleaned_block:
+                activities.append(cleaned_block)
+
+    # Top-level internal keys recorded for auditability of exclusion discipline.
+    for key in lesson:
+        if str(key) in _EXCLUDED_KEYS:
+            seen_excluded.add(str(key))
+
+    module_lines = [f"# {title}" if title else "# Hramatka lesson", ""]
+    if anchor_text:
+        module_lines.extend(["## Anchor", "", anchor_text, ""])
+    for idx, act in enumerate(activities, start=1):
+        act_body = act.get("activity") if isinstance(act.get("activity"), Mapping) else act
+        act_title = ""
+        if isinstance(act_body, Mapping):
+            act_title = str(act_body.get("title") or act.get("type") or f"Activity {idx}")
+        else:
+            act_title = str(act.get("type") or f"Activity {idx}")
+        module_lines.extend([f"## {act_title}", ""])
+        for path, text in _collect_strings(act):
+            if path.endswith(".type") or path.endswith(".level") or path.endswith(".mode"):
+                continue
+            module_lines.append(text)
+            module_lines.append("")
+
+    module_md = "\n".join(module_lines).rstrip() + "\n"
+    learner_strings = _collect_strings({"title": title, "anchor": anchor_text, "activities": activities})
+
+    canonical = {
+        "title": title,
+        "level": level,
+        "slug": clean_slug,
+        "anchor_text": anchor_text,
+        "activities": activities,
+    }
+    content_hash = _sha256_text(_json_dumps(canonical))
+
+    return AdaptedLesson(
+        title=title,
+        level=level,
+        slug=clean_slug,
+        module_md=module_md,
+        activities=activities,
+        vocabulary=[],
+        resources=[],
+        content_hash=content_hash,
+        excluded_keys_seen=tuple(sorted(seen_excluded)),
+        learner_strings=tuple(learner_strings),
+    )
+
+
+def write_adapted_module_dir(adapted: AdaptedLesson, dest: Path) -> Path:
+    """Serialize an AdaptedLesson into CONTENT_FILES under dest."""
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "module.md").write_text(adapted.module_md, encoding="utf-8")
+    (dest / "activities.yaml").write_text(
+        yaml.safe_dump(adapted.activities, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    (dest / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (dest / "resources.yaml").write_text("[]\n", encoding="utf-8")
+    meta = {
+        "rule_set": RULE_SET_ID,
+        "level": adapted.level,
+        "slug": adapted.slug,
+        "title": adapted.title,
+        "content_hash": adapted.content_hash,
+        "excluded_keys_seen": list(adapted.excluded_keys_seen),
+    }
+    (dest / "hramatka_adapter_meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return dest
+
+
+def adapt_lesson_json_to_module_dir(
+    lesson: Mapping[str, Any],
+    dest: Path,
+    *,
+    slug: str | None = None,
+) -> AdaptedLesson:
+    """Adapt lesson_json and write a harness-compatible module directory."""
+    adapted = adapt_lesson_json(lesson, slug=slug)
+    write_adapted_module_dir(adapted, dest)
+    return adapted
+
+
+# ---------------------------------------------------------------------------
+# Token / form helpers
+# ---------------------------------------------------------------------------
+
+
+def _cyrillic_tokens(text: str) -> list[str]:
+    return _CYRILLIC_TOKEN_RE.findall(text)
+
+
+def _apostrophe_variants(token: str) -> list[str]:
+    """Generate apostrophe + case variants for VESUM lookup."""
+    variants: list[str] = []
+    seen: set[str] = set()
+    base_forms = [token, token.casefold()]
+    for form in base_forms:
+        for apo in _APOSTROPHES:
+            candidate = form
+            for other in _APOSTROPHES:
+                candidate = candidate.replace(other, apo)
+            if candidate not in seen:
+                seen.add(candidate)
+                variants.append(candidate)
+        if form not in seen:
+            seen.add(form)
+            variants.append(form)
+    return variants
+
+
+def _vesum_hits(token: str) -> list[dict]:
+    """VESUM lookup tolerant of apostrophe orthography and proper-noun case."""
+    for variant in _apostrophe_variants(token):
+        hits = verify_word(variant)
+        if hits:
+            return hits
+    return []
+
+
+def _is_probable_proper_noun(token: str) -> bool:
+    """Capitalized tokens are proper-noun candidates (skip invented/russianism)."""
+    if not token:
+        return False
+    return token[0].isupper() and not token.isupper()
+
+
+def _normalize_option(text: str) -> str:
+    cleaned = _OPTION_PREFIX_RE.sub("", str(text or "").strip())
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _is_placeholder(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, (list, dict)) and len(value) == 0:
+        return True
+    if isinstance(value, (int, float, bool)):
+        return False
+    text = str(value).strip()
+    if not text:
+        return True
+    # Whole value is a placeholder token, not merely contains "…" inside prose.
+    return bool(_PLACEHOLDER_EXACT_RE.fullmatch(text))
+
+
+def _activity_body(entry: Mapping[str, Any]) -> Mapping[str, Any]:
+    activity = entry.get("activity")
+    if isinstance(activity, Mapping):
+        return activity
+    return entry
+
+
+def _payload(activity: Mapping[str, Any]) -> Mapping[str, Any]:
+    payload = activity.get("payload")
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _answer_key_for(entry: Mapping[str, Any], activity: Mapping[str, Any]) -> Any:
+    """Prefer structured activity-level answer_key over free-text block key."""
+    act_key = activity.get("answer_key")
+    block_key = entry.get("answer_key") if "answer_key" in entry else None
+    if isinstance(act_key, (Mapping, list)):
+        return act_key
+    if block_key is not None:
+        return block_key
+    return act_key
+
+
+def _load_activities_from_module(module_dir: Path) -> list[dict[str, Any]]:
+    path = module_dir / "activities.yaml"
+    if not path.exists():
+        return []
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    if isinstance(data, Mapping) and isinstance(data.get("activities"), list):
+        return [item for item in data["activities"] if isinstance(item, dict)]
+    return []
+
+
+def _read_module_texts(module_dir: Path) -> dict[str, str]:
+    texts: dict[str, str] = {}
+    for name in CONTENT_FILES:
+        path = module_dir / name
+        if path.exists():
+            texts[name] = path.read_text(encoding="utf-8")
+    return texts
+
+
+def _locate_in_texts(texts: Mapping[str, str], excerpt: str) -> tuple[str, int, str]:
+    for name in ("module.md", "activities.yaml", "vocabulary.yaml", "resources.yaml"):
+        text = texts.get(name, "")
+        if excerpt and excerpt in text:
+            return name, _line_no(text, text.find(excerpt)), text
+    # Fallback: module.md body
+    text = texts.get("module.md", "")
+    return "module.md", 1, text
+
+
+def _heritage_safe(status: Mapping[str, Any]) -> bool:
+    classification = str(status.get("classification") or "")
+    if classification in {"authentic-archaism", "dialect", "historism", "borrowing"}:
+        return True
+    return classification == "standard" and bool(
+        status.get("vesum_attested") or has_positive_attestation(status)
+    )
+
+
+def _classify_token(token: str) -> dict[str, Any]:
+    """Classify with VESUM-first short-circuit (performance + apostrophe tolerance)."""
+    if _vesum_hits(token):
+        return {
+            "classification": "standard",
+            "attestations": [{"source": "vesum", "ref": token}],
+            "is_russianism": False,
+            "russian_shadow": False,
+            "vesum_attested": True,
+            "sovietization_risk": 0,
+            "calque_warning": None,
+        }
+    if _is_probable_proper_noun(token):
+        # Proper nouns absent from VESUM are not russianisms; content lane may still
+        # review them. Deterministic gate stays quiet.
+        return {
+            "classification": "proper_noun",
+            "attestations": [],
+            "is_russianism": False,
+            "russian_shadow": False,
+            "vesum_attested": False,
+            "sovietization_risk": 0,
+            "calque_warning": None,
+        }
+    # heritage_classifier always overrides when it attests; russian-shadow is a signal.
+    return classify_surface_form(token.casefold())
+
+
+def _is_russianism_token(token: str, status: Mapping[str, Any] | None = None) -> bool:
+    """Return True when token is a russianism after heritage override."""
+    if _is_probable_proper_noun(token):
+        return False
+    status = status or _classify_token(token)
+    if status.get("is_russianism"):
+        return True
+    if _heritage_safe(status):
+        return False
+    if status.get("classification") == "proper_noun":
+        return False
+    # VESUM-absent AND russian-shadow AND NOT heritage → russianism
+    return bool((not status.get("vesum_attested")) and status.get("russian_shadow"))
+
+
+def _is_invented_form(token: str, status: Mapping[str, Any] | None = None) -> bool:
+    if _is_probable_proper_noun(token):
+        return False
+    status = status or _classify_token(token)
+    if _heritage_safe(status):
+        return False
+    if status.get("classification") == "proper_noun":
+        return False
+    if status.get("is_russianism") or status.get("russian_shadow"):
+        return False
+    if status.get("vesum_attested"):
+        return False
+    # VESUM-absent AND NOT russian-shadow AND NOT heritage
+    return str(status.get("classification") or "unknown") in {"unknown", ""}
+
+
+# ---------------------------------------------------------------------------
+# Synonym + CEFR local lookups (direct SQL; same DBs as sources_db)
+# ---------------------------------------------------------------------------
+
+
+def _sources_conn():
+    import sqlite3
+
+    db = PROJECT_ROOT / "data" / "sources.db"
+    if not db.exists():
+        return None
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _synonym_lemmas(word: str) -> set[str]:
+    """Return known synonym partners for a Ukrainian lemma (local sources.db)."""
+    word_n = word.casefold().strip()
+    if not word_n:
+        return set()
+    partners: set[str] = set()
+    conn = _sources_conn()
+    if conn is None:
+        return partners
+    try:
+        rows = conn.execute(
+            "SELECT words FROM ukrajinet WHERE words LIKE ? COLLATE NOCASE LIMIT 40",
+            (f"%{word_n}%",),
+        ).fetchall()
+        for row in rows:
+            raw = row["words"]
+            try:
+                members = json.loads(raw) if isinstance(raw, str) else raw
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if not isinstance(members, list):
+                continue
+            normalized = [str(m).casefold().strip() for m in members if isinstance(m, str)]
+            # Only pure Cyrillic single-token members count.
+            cyr = [m for m in normalized if _CYRILLIC_TOKEN_RE.fullmatch(m)]
+            if word_n in cyr:
+                partners.update(m for m in cyr if m != word_n)
+    finally:
+        conn.close()
+    return partners
+
+
+def _are_synonyms(a: str, b: str) -> bool:
+    a_n = a.casefold().strip()
+    b_n = b.casefold().strip()
+    if not a_n or not b_n or a_n == b_n:
+        return False
+    return b_n in _synonym_lemmas(a_n) or a_n in _synonym_lemmas(b_n)
+
+
+def _cefr_level_for(word: str) -> str | None:
+    conn = _sources_conn()
+    if conn is None:
+        return None
+    try:
+        row = conn.execute(
+            "SELECT level FROM puls_cefr WHERE word = ? COLLATE NOCASE LIMIT 1",
+            (word,),
+        ).fetchone()
+        if row and row["level"]:
+            return str(row["level"]).strip().lower()
+        row = conn.execute(
+            "SELECT level FROM puls_cefr WHERE lower(word) = ? LIMIT 1",
+            (word.casefold(),),
+        ).fetchone()
+        if row and row["level"]:
+            return str(row["level"]).strip().lower()
+    finally:
+        conn.close()
+    return None
+
+
+def _cefr_exceeds(task_level: str, word_level: str) -> bool:
+    """Flag only clear over-level words (≥2 CEFR bands above the lesson)."""
+    return _CEFR_RANK.get(word_level, 0) >= _CEFR_RANK.get(task_level, 0) + 2
+
+
+def _antonenko_title_hit(text: str) -> list[str]:
+    """Return Antonenko style-guide titles whose *bad multi-word form* appears in text.
+
+    Only multi-token left-hand sides of ``bad – good`` titles count. Single-token
+    left sides (e.g. "Жити–бути") are too ambiguous for a deterministic gate.
+    """
+    conn = _sources_conn()
+    if conn is None:
+        return []
+    hits: list[str] = []
+    folded = text.casefold()
+    try:
+        rows = conn.execute(
+            "SELECT word FROM style_guide WHERE word LIKE '%–%' OR word LIKE '%—%'"
+        ).fetchall()
+        for row in rows:
+            title = str(row["word"] or "").strip()
+            if not title:
+                continue
+            parts = re.split(r"\s*[–—]\s*", title, maxsplit=1)
+            if len(parts) < 2:
+                continue
+            bad_side = parts[0].strip().casefold()
+            # Require multi-word bad form (e.g. "приймати участь").
+            tokens = _cyrillic_tokens(bad_side)
+            if len(tokens) < 2:
+                continue
+            for candidate in re.split(r"[,;]", bad_side):
+                cand = candidate.strip()
+                cand_tokens = _cyrillic_tokens(cand)
+                if len(cand_tokens) < 2:
+                    continue
+                if cand in folded:
+                    hits.append(title)
+                    break
+    finally:
+        conn.close()
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Check classes
+# ---------------------------------------------------------------------------
+
+
+def check_russianism_calque(ctx: _ScanContext) -> list[dict[str, Any]]:
+    """Tier-1: curated regex + UA-GEC + VESUM/shadow with heritage override."""
+    findings: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+
+    surfaces = list(ctx.learner_strings)
+    if not surfaces:
+        for file, text in ctx.texts.items():
+            surfaces.append((file, text))
+
+    for _path, text in surfaces:
+        if not text or not text.strip():
+            continue
+        file, line, file_text = _locate_in_texts(ctx.texts, text[:80] if len(text) > 80 else text)
+
+        # 1) Curated regex / high-precision patterns (reused from qg_adapters stack)
+        for violation in check_russicisms(text, file_path=file):
+            excerpt = str(violation.get("matched") or text[:80])
+            # check_russicisms aggregates; pull matched terms from issue when needed
+            issue = str(violation.get("issue") or "Russicism detected")
+            key = ("RUSSICISM_DETECTED", issue[:80])
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                _finding(
+                    issue_id="RUSSICISM_DETECTED",
+                    rule_id="hramatka_russianism_curated",
+                    dimension="russianism_calque",
+                    severity=str(violation.get("severity") or "warning"),
+                    file=file,
+                    line=line,
+                    excerpt=excerpt if excerpt in file_text else text[:80],
+                    message=issue,
+                    text=file_text,
+                )
+            )
+
+        # 2) UA-GEC exact-span calques — multi-word only (single tokens are too noisy;
+        # curated check_russicisms already covers high-precision single-token forms).
+        for violation in check_ua_gec_calques(text, file_path=file):
+            matched = str(violation.get("matched") or "")
+            if not matched or " " not in matched.strip():
+                continue
+            key = ("UA_GEC_CALQUE", matched.casefold())
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                _finding(
+                    issue_id="UA_GEC_CALQUE",
+                    rule_id="hramatka_ua_gec_calque",
+                    dimension="russianism_calque",
+                    severity="warning",
+                    file=file,
+                    line=line,
+                    excerpt=matched,
+                    message=str(violation.get("issue") or f"UA-GEC calque: {matched}"),
+                    text=file_text,
+                )
+            )
+
+        # 3) Antonenko structured title hits
+        for title in _antonenko_title_hit(text):
+            key = ("ANTONENKO_CALQUE", title.casefold())
+            if key in seen:
+                continue
+            seen.add(key)
+            # Excerpt = bad side of title
+            bad = re.split(r"\s*[–—]\s*|\s+-\s+", title, maxsplit=1)[0].strip()
+            findings.append(
+                _finding(
+                    issue_id="ANTONENKO_CALQUE",
+                    rule_id="hramatka_antonenko_style_guide",
+                    dimension="russianism_calque",
+                    severity="warning",
+                    file=file,
+                    line=line,
+                    excerpt=bad[:160],
+                    message=f"Antonenko-Davydovych style guide flags: {title}",
+                    text=file_text,
+                )
+            )
+
+        # 4) Per-token russian-shadow + heritage override (VESUM-first short-circuit)
+        for token in _cyrillic_tokens(text):
+            if len(token) < 3 or token.endswith("-"):
+                continue
+            status = _classify_token(token)
+            if _heritage_safe(status) or status.get("vesum_attested"):
+                continue
+            if _is_russianism_token(token, status):
+                key = ("RUSSIAN_SHADOW_RUSSICISM", token.casefold())
+                if key in seen:
+                    continue
+                seen.add(key)
+                findings.append(
+                    _finding(
+                        issue_id="RUSSIAN_SHADOW_RUSSICISM",
+                        rule_id="hramatka_russian_shadow_not_heritage",
+                        dimension="russianism_calque",
+                        severity="critical",
+                        file=file,
+                        line=line,
+                        excerpt=token,
+                        message=(
+                            f"Form '{token}' is absent from VESUM with Russian-shadow morphology "
+                            "and no heritage attestation (heritage_classifier does not override)."
+                        ),
+                        text=file_text,
+                    )
+                )
+    return findings
+
+
+def check_invented_forms(ctx: _ScanContext) -> list[dict[str, Any]]:
+    """Tier-2: VESUM-absent AND NOT russian-shadow AND NOT heritage → NON_VESUM_FORM."""
+    findings: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    surfaces = list(ctx.learner_strings) or [(f, t) for f, t in ctx.texts.items()]
+    for _path, text in surfaces:
+        if not text:
+            continue
+        file, line, file_text = _locate_in_texts(ctx.texts, text[:80] if len(text) > 80 else text)
+        for token in _cyrillic_tokens(text):
+            if len(token) < 4 or token.endswith("-"):
+                continue
+            key = token.casefold()
+            if key in seen:
+                continue
+            status = _classify_token(token)
+            if not _is_invented_form(token, status):
+                continue
+            seen.add(key)
+            findings.append(
+                _finding(
+                    issue_id="NON_VESUM_FORM",
+                    rule_id="hramatka_invented_form",
+                    dimension="invented_form",
+                    severity="warning",
+                    file=file,
+                    line=line,
+                    excerpt=token,
+                    message=(
+                        f"Form '{token}' is not in VESUM, has no Russian-shadow signal, "
+                        "and no heritage attestation — likely invented form."
+                    ),
+                    text=file_text,
+                )
+            )
+    return findings
+
+
+def _iter_mc_items(activity: Mapping[str, Any]) -> Iterable[tuple[str, list[str], Any]]:
+    """Yield (prompt, options, correct_answer) for multiple-choice style items."""
+    payload = _payload(activity)
+    items = payload.get("items") or activity.get("items") or []
+    if not isinstance(items, list):
+        return
+    answer_key = activity.get("answer_key")
+    key_items: list[Any] = []
+    if isinstance(answer_key, Mapping) and isinstance(answer_key.get("items"), list):
+        key_items = list(answer_key["items"])
+
+    for idx, item in enumerate(items):
+        if not isinstance(item, Mapping):
+            continue
+        options_raw = item.get("options") or item.get("choices") or []
+        if not isinstance(options_raw, list) or not options_raw:
+            continue
+        options = [str(o) for o in options_raw]
+        correct: Any = item.get("correct")
+        if correct is None and idx < len(key_items):
+            entry = key_items[idx]
+            correct = entry.get("correct") if isinstance(entry, Mapping) else entry
+        yield str(item.get("prompt") or item.get("question") or item.get("stem") or ""), options, correct
+
+
+def _resolve_correct_option(options: Sequence[str], correct: Any) -> str | None:
+    if correct is None:
+        return None
+    if isinstance(correct, bool):
+        return None
+    if isinstance(correct, int):
+        if 0 <= correct < len(options):
+            return options[correct]
+        return None
+    correct_s = str(correct).strip()
+    # Letter key: "а" / "a" / "б"
+    if len(correct_s) == 1:
+        letters_ua = "абвгдеєжзиіїклмнопрстуфхцчшщьюя"
+        letters_en = "abcdefghijklmnopqrstuvwxyz"
+        alphabet = letters_ua if correct_s.casefold() in letters_ua else letters_en
+        try:
+            idx = alphabet.index(correct_s.casefold())
+            if 0 <= idx < len(options):
+                return options[idx]
+        except ValueError:
+            pass
+    # Exact or prefix match against options
+    for opt in options:
+        if opt.strip() == correct_s or _normalize_option(opt) == _normalize_option(correct_s):
+            return opt
+        if opt.strip().casefold().startswith(correct_s.casefold()):
+            return opt
+    return correct_s
+
+
+def check_invalid_distractors(ctx: _ScanContext) -> list[dict[str, Any]]:
+    """Tier-1: distractors must be real VESUM forms, distinct, non-duplicate, non-synonym."""
+    findings: list[dict[str, Any]] = []
+    file_text = ctx.texts.get("activities.yaml") or ctx.texts.get("module.md") or ""
+
+    for act_idx, entry in enumerate(ctx.activities):
+        activity = _activity_body(entry)
+        for item_idx, (_prompt, options, correct) in enumerate(_iter_mc_items(activity)):
+            if len(options) < 2:
+                continue
+            correct_opt = _resolve_correct_option(options, correct)
+            correct_norm = _normalize_option(correct_opt or "")
+            correct_tokens = _cyrillic_tokens(correct_norm)
+            correct_lemma = correct_tokens[0] if len(correct_tokens) == 1 else correct_norm
+
+            seen_norms: set[str] = set()
+            for opt in options:
+                norm = _normalize_option(opt)
+                if not norm:
+                    findings.append(
+                        _finding(
+                            issue_id="INVALID_DISTRACTOR",
+                            rule_id="hramatka_empty_distractor",
+                            dimension="distractor_quality",
+                            severity="critical",
+                            file="activities.yaml",
+                            line=1,
+                            excerpt=str(opt)[:80] or "(empty)",
+                            message=f"Activity[{act_idx}] item[{item_idx}]: empty distractor option.",
+                            text=file_text,
+                        )
+                    )
+                    continue
+
+                # Skip the correct answer itself.
+                if correct_norm and norm.casefold() == correct_norm.casefold():
+                    seen_norms.add(norm.casefold())
+                    continue
+                if correct_opt and opt.strip() == str(correct_opt).strip():
+                    seen_norms.add(norm.casefold())
+                    continue
+
+                # Duplicate / near-duplicate
+                if norm.casefold() in seen_norms:
+                    findings.append(
+                        _finding(
+                            issue_id="DUPLICATE_DISTRACTOR",
+                            rule_id="hramatka_duplicate_distractor",
+                            dimension="distractor_quality",
+                            severity="warning",
+                            file="activities.yaml",
+                            line=1,
+                            excerpt=norm,
+                            message=f"Activity[{act_idx}] item[{item_idx}]: duplicate distractor '{norm}'.",
+                            text=file_text,
+                        )
+                    )
+                    continue
+                seen_norms.add(norm.casefold())
+
+                tokens = _cyrillic_tokens(norm)
+                # Single-token distractors: require VESUM form
+                if len(tokens) == 1:
+                    form = tokens[0]
+                    if not _vesum_hits(form):
+                        findings.append(
+                            _finding(
+                                issue_id="NON_VESUM_DISTRACTOR",
+                                rule_id="hramatka_distractor_not_vesum",
+                                dimension="distractor_quality",
+                                severity="critical",
+                                file="activities.yaml",
+                                line=1,
+                                excerpt=form,
+                                message=(
+                                    f"Activity[{act_idx}] item[{item_idx}]: distractor '{form}' "
+                                    "is not a real Ukrainian form (VESUM)."
+                                ),
+                                text=file_text,
+                            )
+                        )
+                    # Synonym collision with answer
+                    if correct_lemma and _are_synonyms(correct_lemma, form):
+                        findings.append(
+                            _finding(
+                                issue_id="SYNONYM_DISTRACTOR",
+                                rule_id="hramatka_synonym_collision",
+                                dimension="distractor_quality",
+                                severity="critical",
+                                file="activities.yaml",
+                                line=1,
+                                excerpt=form,
+                                message=(
+                                    f"Activity[{act_idx}] item[{item_idx}]: distractor '{form}' "
+                                    f"is a known synonym of the answer '{correct_lemma}'."
+                                ),
+                                text=file_text,
+                            )
+                        )
+                    # Optional morphological collision — only when activity type looks grammatical
+                    act_type = str(activity.get("type") or "").casefold()
+                    if (
+                        "grammar" in act_type
+                        or "morph" in act_type
+                        or "case" in act_type
+                    ) and correct_tokens and len(correct_tokens) == 1:
+                        ans_forms = _vesum_hits(correct_tokens[0])
+                        dis_forms = _vesum_hits(form)
+                        if ans_forms and dis_forms:
+                            ans_tags = {f.get("tags") for f in ans_forms}
+                            dis_tags = {f.get("tags") for f in dis_forms}
+                            if ans_tags & dis_tags and form.casefold() != correct_tokens[0].casefold():
+                                findings.append(
+                                    _finding(
+                                        issue_id="MORPH_COLLISION_DISTRACTOR",
+                                        rule_id="hramatka_morph_collision",
+                                        dimension="distractor_quality",
+                                        severity="info",
+                                        file="activities.yaml",
+                                        line=1,
+                                        excerpt=form,
+                                        message=(
+                                            f"Activity[{act_idx}] item[{item_idx}]: distractor '{form}' "
+                                            "shares morphological tags with the answer — review for grammar items."
+                                        ),
+                                        text=file_text,
+                                    )
+                                )
+                elif not tokens:
+                    # No Ukrainian content at all in distractor
+                    findings.append(
+                        _finding(
+                            issue_id="NON_VESUM_DISTRACTOR",
+                            rule_id="hramatka_distractor_not_vesum",
+                            dimension="distractor_quality",
+                            severity="critical",
+                            file="activities.yaml",
+                            line=1,
+                            excerpt=norm[:80],
+                            message=(
+                                f"Activity[{act_idx}] item[{item_idx}]: distractor has no Ukrainian "
+                                "word forms to verify."
+                            ),
+                            text=file_text,
+                        )
+                    )
+    return findings
+
+
+def check_answer_key_placeholders(ctx: _ScanContext) -> list[dict[str, Any]]:
+    """Tier-1: empty / TODO / XXX / ellipsis / whitespace-only answer keys."""
+    findings: list[dict[str, Any]] = []
+    file_text = ctx.texts.get("activities.yaml") or ctx.texts.get("module.md") or ""
+
+    for act_idx, entry in enumerate(ctx.activities):
+        activity = _activity_body(entry)
+        act_type = str(activity.get("type") or entry.get("type") or "")
+        # Glossary / free-response may legitimately lack rigid answer keys.
+        if act_type in _FREE_RESPONSE_TYPES or act_type in {"reading", "text", "anchor"}:
+            continue
+        answer_key = _answer_key_for(entry, activity)
+        if answer_key is None:
+            findings.append(
+                _finding(
+                    issue_id="ANSWER_KEY_PLACEHOLDER",
+                    rule_id="hramatka_missing_answer_key",
+                    dimension="answer_key_integrity",
+                    severity="critical",
+                    file="activities.yaml",
+                    line=1,
+                    excerpt=f"activity[{act_idx}].answer_key=null",
+                    message=f"Activity[{act_idx}] ({act_type}): answer_key is missing/null.",
+                    text=file_text,
+                )
+            )
+            continue
+        if _is_placeholder(answer_key):
+            excerpt = str(answer_key)[:80] if answer_key is not None else "(empty)"
+            findings.append(
+                _finding(
+                    issue_id="ANSWER_KEY_PLACEHOLDER",
+                    rule_id="hramatka_answer_key_placeholder",
+                    dimension="answer_key_integrity",
+                    severity="critical",
+                    file="activities.yaml",
+                    line=1,
+                    excerpt=excerpt or "(empty)",
+                    message=f"Activity[{act_idx}] ({act_type}): answer_key looks like a placeholder.",
+                    text=file_text,
+                )
+            )
+            continue
+        # Nested empty items list
+        if isinstance(answer_key, Mapping):
+            for nested_key in ("items", "pairs", "answers", "blanks"):
+                nested = answer_key.get(nested_key)
+                if isinstance(nested, list) and len(nested) == 0:
+                    findings.append(
+                        _finding(
+                            issue_id="ANSWER_KEY_PLACEHOLDER",
+                            rule_id="hramatka_answer_key_empty_list",
+                            dimension="answer_key_integrity",
+                            severity="critical",
+                            file="activities.yaml",
+                            line=1,
+                            excerpt=f"answer_key.{nested_key}=[]",
+                            message=(
+                                f"Activity[{act_idx}] ({act_type}): answer_key.{nested_key} is empty."
+                            ),
+                            text=file_text,
+                        )
+                    )
+    return findings
+
+
+def check_structural_integrity(ctx: _ScanContext) -> list[dict[str, Any]]:
+    """Tier-2: schema-level activity integrity (cloze, match-up, MC, empty items)."""
+    findings: list[dict[str, Any]] = []
+    file_text = ctx.texts.get("activities.yaml") or ""
+
+    for act_idx, entry in enumerate(ctx.activities):
+        activity = _activity_body(entry)
+        act_type = str(activity.get("type") or entry.get("type") or payload_type(activity))
+        payload = _payload(activity)
+        answer_key = _answer_key_for(entry, activity)
+
+        items = payload.get("items")
+        if items is not None and isinstance(items, list) and len(items) == 0:
+            findings.append(
+                _finding(
+                    issue_id="EMPTY_PAYLOAD_ITEMS",
+                    rule_id="hramatka_empty_payload_items",
+                    dimension="activity_structure",
+                    severity="critical",
+                    file="activities.yaml",
+                    line=1,
+                    excerpt=f"activity[{act_idx}].payload.items=[]",
+                    message=f"Activity[{act_idx}] ({act_type}): payload.items is empty.",
+                    text=file_text,
+                )
+            )
+
+        # Multiple choice: each item needs ≥2 options
+        if act_type in {"multiple-choice", "mc", "multiple_choice"} or payload.get("type") in {
+            "multiple-choice",
+            "mc",
+        }:
+            raw_items = items if isinstance(items, list) else []
+            for item_idx, item in enumerate(raw_items):
+                if not isinstance(item, Mapping):
+                    continue
+                options = item.get("options") or item.get("choices") or []
+                if not isinstance(options, list) or len(options) < 2:
+                    findings.append(
+                        _finding(
+                            issue_id="MC_TOO_FEW_OPTIONS",
+                            rule_id="hramatka_mc_min_options",
+                            dimension="activity_structure",
+                            severity="critical",
+                            file="activities.yaml",
+                            line=1,
+                            excerpt=str(item.get("prompt") or item)[:80],
+                            message=(
+                                f"Activity[{act_idx}] item[{item_idx}]: multiple-choice needs ≥2 options."
+                            ),
+                            text=file_text,
+                        )
+                    )
+
+        # Match-up cardinality
+        if act_type in {"match-up", "match_up", "matching"} or payload.get("type") in {
+            "match-up",
+            "match_up",
+        }:
+            pairs = payload.get("pairs") or []
+            if isinstance(pairs, list):
+                lefts = [p for p in pairs if isinstance(p, Mapping) and p.get("left") not in (None, "")]
+                rights = [p for p in pairs if isinstance(p, Mapping) and p.get("right") not in (None, "")]
+                if len(lefts) != len(rights):
+                    findings.append(
+                        _finding(
+                            issue_id="MATCHUP_CARDINALITY",
+                            rule_id="hramatka_matchup_cardinality",
+                            dimension="activity_structure",
+                            severity="critical",
+                            file="activities.yaml",
+                            line=1,
+                            excerpt=f"left={len(lefts)} right={len(rights)}",
+                            message=(
+                                f"Activity[{act_idx}]: match-up left/right cardinality mismatch "
+                                f"({len(lefts)} vs {len(rights)})."
+                            ),
+                            text=file_text,
+                        )
+                    )
+                if isinstance(answer_key, Mapping):
+                    key_pairs = answer_key.get("pairs")
+                    if isinstance(key_pairs, list) and pairs and len(key_pairs) != len(pairs):
+                        findings.append(
+                            _finding(
+                                issue_id="ANSWER_KEY_SHAPE",
+                                rule_id="hramatka_matchup_key_shape",
+                                dimension="activity_structure",
+                                severity="critical",
+                                file="activities.yaml",
+                                line=1,
+                                excerpt=f"pairs={len(pairs)} key_pairs={len(key_pairs)}",
+                                message=(
+                                    f"Activity[{act_idx}]: answer_key.pairs length does not match payload pairs."
+                                ),
+                                text=file_text,
+                            )
+                        )
+
+        # Cloze blank count vs answers
+        if act_type in {"cloze", "fill-blank", "fill_blank", "gap-fill"} or payload.get("type") in {
+            "cloze",
+            "fill-blank",
+            "gap-fill",
+        }:
+            stems: list[str] = []
+            if isinstance(payload.get("text"), str):
+                stems.append(str(payload["text"]))
+            if isinstance(items, list):
+                for item in items:
+                    if isinstance(item, str):
+                        stems.append(item)
+                    elif isinstance(item, Mapping):
+                        stems.append(str(item.get("text") or item.get("stem") or item.get("prompt") or ""))
+            blank_count = sum(len(_CLOZE_BLANK_RE.findall(stem)) for stem in stems)
+            # Prefer explicit payload.blanks cardinality when present.
+            payload_blanks = payload.get("blanks")
+            if isinstance(payload_blanks, list) and payload_blanks:
+                blank_count = max(blank_count, len(payload_blanks))
+            answer_count = 0
+            if isinstance(answer_key, Mapping):
+                for key in ("answers", "blanks", "items"):
+                    nested = answer_key.get(key)
+                    if isinstance(nested, list):
+                        answer_count = len(nested)
+                        break
+                if answer_count == 0 and answer_key.get("answer") is not None:
+                    answer_count = 1
+            elif isinstance(answer_key, list):
+                answer_count = len(answer_key)
+            elif isinstance(answer_key, str) and answer_key.strip():
+                # Free-text keys often use " · " / numbered lists.
+                parts = [p for p in re.split(r"\s*[·|;]\s*|\n+", answer_key) if p.strip()]
+                answer_count = len(parts) if parts else 1
+            if blank_count and answer_count and blank_count != answer_count:
+                findings.append(
+                    _finding(
+                        issue_id="CLOZE_BLANK_MISMATCH",
+                        rule_id="hramatka_cloze_blank_count",
+                        dimension="activity_structure",
+                        severity="critical",
+                        file="activities.yaml",
+                        line=1,
+                        excerpt=f"blanks={blank_count} answers={answer_count}",
+                        message=(
+                            f"Activity[{act_idx}]: cloze blank count ({blank_count}) "
+                            f"≠ answer count ({answer_count})."
+                        ),
+                        text=file_text,
+                    )
+                )
+    return findings
+
+
+def payload_type(activity: Mapping[str, Any]) -> str:
+    payload = _payload(activity)
+    return str(payload.get("type") or "")
+
+
+def check_empty_learner_surface(ctx: _ScanContext) -> list[dict[str, Any]]:
+    """Tier-2: blank title / instruction / statement (not only answer_key)."""
+    findings: list[dict[str, Any]] = []
+    file_text = ctx.texts.get("module.md") or ""
+    title_line = next((ln for ln in file_text.splitlines() if ln.startswith("#")), "#")
+    title = title_line.lstrip("#").strip()
+    if not title or title.casefold() in {"hramatka lesson", "untitled"}:
+        findings.append(
+            _finding(
+                issue_id="EMPTY_LEARNER_SURFACE",
+                rule_id="hramatka_empty_title",
+                dimension="learner_surface",
+                severity="critical",
+                file="module.md",
+                line=1,
+                excerpt=title_line[:80] or "(missing title)",
+                message="Lesson title is blank or placeholder.",
+                text=file_text,
+            )
+        )
+
+    act_text = ctx.texts.get("activities.yaml") or ""
+    for act_idx, entry in enumerate(ctx.activities):
+        activity = _activity_body(entry)
+        act_title = str(activity.get("title") or "").strip()
+        if not act_title:
+            findings.append(
+                _finding(
+                    issue_id="EMPTY_LEARNER_SURFACE",
+                    rule_id="hramatka_empty_activity_title",
+                    dimension="learner_surface",
+                    severity="warning",
+                    file="activities.yaml",
+                    line=1,
+                    excerpt=f"activity[{act_idx}].title",
+                    message=f"Activity[{act_idx}]: title is blank.",
+                    text=act_text,
+                )
+            )
+        payload = _payload(activity)
+        act_type = str(activity.get("type") or entry.get("type") or "")
+        instruction = str(payload.get("instruction") or activity.get("instruction") or "").strip()
+        if payload and not instruction and act_type not in _FREE_RESPONSE_TYPES:
+            findings.append(
+                _finding(
+                    issue_id="EMPTY_LEARNER_SURFACE",
+                    rule_id="hramatka_empty_instruction",
+                    dimension="learner_surface",
+                    severity="warning",
+                    file="activities.yaml",
+                    line=1,
+                    excerpt=f"activity[{act_idx}].instruction",
+                    message=f"Activity[{act_idx}]: instruction is blank.",
+                    text=act_text,
+                )
+            )
+        items = payload.get("items")
+        if isinstance(items, list):
+            for item_idx, item in enumerate(items):
+                if isinstance(item, Mapping):
+                    statement = item.get("statement")
+                    if "statement" in item and not str(statement or "").strip():
+                        findings.append(
+                            _finding(
+                                issue_id="EMPTY_LEARNER_SURFACE",
+                                rule_id="hramatka_empty_statement",
+                                dimension="learner_surface",
+                                severity="warning",
+                                file="activities.yaml",
+                                line=1,
+                                excerpt=f"activity[{act_idx}].items[{item_idx}].statement",
+                                message=f"Activity[{act_idx}] item[{item_idx}]: statement is blank.",
+                                text=act_text,
+                            )
+                        )
+    return findings
+
+
+def check_task_language_cefr(ctx: _ScanContext) -> list[dict[str, Any]]:
+    """Tier-2: CEFR of INSTRUCTIONS/ITEMS only; never grade the teacher anchor."""
+    findings: list[dict[str, Any]] = []
+    lesson_level = _normalize_level(ctx.level)
+    act_text = ctx.texts.get("activities.yaml") or ""
+
+    task_strings: list[tuple[str, str]] = []
+    for act_idx, entry in enumerate(ctx.activities):
+        activity = _activity_body(entry)
+        payload = _payload(activity)
+        for key in ("instruction",):
+            val = payload.get(key) or activity.get(key)
+            if isinstance(val, str) and val.strip():
+                task_strings.append((f"activity[{act_idx}].{key}", val))
+        items = payload.get("items")
+        if isinstance(items, list):
+            for item_idx, item in enumerate(items):
+                if isinstance(item, str):
+                    task_strings.append((f"activity[{act_idx}].items[{item_idx}]", item))
+                elif isinstance(item, Mapping):
+                    for field_name in ("prompt", "question", "stem", "statement", "text"):
+                        val = item.get(field_name)
+                        if isinstance(val, str) and val.strip():
+                            task_strings.append(
+                                (f"activity[{act_idx}].items[{item_idx}].{field_name}", val)
+                            )
+
+    seen: set[str] = set()
+    for path, text in task_strings:
+        for token in _cyrillic_tokens(text):
+            word_level = _cefr_level_for(token)
+            if not word_level:
+                continue
+            if not _cefr_exceeds(lesson_level, word_level):
+                continue
+            key = token.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                _finding(
+                    issue_id="TASK_CEFR_OVERLEVEL",
+                    rule_id="hramatka_task_cefr",
+                    dimension="task_cefr",
+                    severity="warning",
+                    file="activities.yaml",
+                    line=1,
+                    excerpt=token,
+                    message=(
+                        f"{path}: task word '{token}' is CEFR {word_level.upper()} "
+                        f"but lesson level is {lesson_level.upper()}."
+                    ),
+                    text=act_text,
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Aggregate / scan
+# ---------------------------------------------------------------------------
+
+
+def _dedupe_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[Any, ...]] = set()
+    out: list[dict[str, Any]] = []
+    for finding in findings:
+        key = (
+            finding.get("issue_id"),
+            finding.get("file"),
+            finding.get("line"),
+            finding.get("excerpt"),
+            finding.get("rule_id"),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(finding)
+    return out
+
+
+def _dimension_scores(findings: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    dimensions: dict[str, dict[str, Any]] = {}
+    for dim in DIMENSION_ORDER:
+        dim_findings = [f for f in findings if f.get("dimension") == dim]
+        penalty = sum(SEVERITY_WEIGHTS.get(str(f.get("severity")), 0.0) for f in dim_findings)
+        score = max(0.0, round(10.0 - penalty, 1))
+        has_critical = any(f.get("severity") == "critical" for f in dim_findings)
+        has_warning = any(f.get("severity") == "warning" for f in dim_findings)
+        dimensions[dim] = {
+            "score": score,
+            "verdict": "FAIL" if has_critical else "WARN" if has_warning else "PASS",
+            "findings": dim_findings,
+        }
+    return dimensions
+
+
+def _aggregate(dimensions: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    scored = {
+        dim: float(entry.get("score", 0.0))
+        for dim, entry in dimensions.items()
+        if isinstance(entry.get("score"), int | float)
+    }
+    min_dim = min(scored, key=scored.__getitem__) if scored else None
+    has_fail = any(entry.get("verdict") == "FAIL" for entry in dimensions.values())
+    has_warn = any(entry.get("verdict") == "WARN" for entry in dimensions.values())
+    return {
+        "verdict": "FAIL" if has_fail else "WARN" if has_warn else "PASS",
+        "terminal_verdict": "FAIL" if has_fail else "PASS",
+        "min_score": scored[min_dim] if min_dim else None,
+        "min_dim": min_dim,
+        "failing_dims": [dim for dim, entry in dimensions.items() if entry.get("verdict") == "FAIL"],
+        "warning_dims": [dim for dim, entry in dimensions.items() if entry.get("verdict") == "WARN"],
+    }
+
+
+def scan_hramatka_module(
+    module_dir: Path,
+    *,
+    level: str | None = None,
+    slug: str | None = None,
+    fixture_id: str | None = None,
+    learner_strings: Sequence[tuple[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Scan an adapted (or hand-built) module directory with hramatka rules."""
+    module_dir = module_dir.resolve()
+    texts = _read_module_texts(module_dir)
+    activities = _load_activities_from_module(module_dir)
+
+    meta_level = level
+    meta_slug = slug or module_dir.name
+    meta_path = module_dir / "hramatka_adapter_meta.json"
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            meta_level = meta_level or meta.get("level")
+            meta_slug = slug or meta.get("slug") or meta_slug
+        except (OSError, json.JSONDecodeError):
+            pass
+    clean_level = _normalize_level(meta_level or "b1")
+
+    strings = list(learner_strings or [])
+    if not strings:
+        strings = _collect_strings({"activities": activities})
+        if texts.get("module.md"):
+            strings.append(("module.md", texts["module.md"]))
+
+    ctx = _ScanContext(
+        level=clean_level,
+        texts=texts,
+        activities=activities,
+        learner_strings=strings,
+    )
+
+    findings = _dedupe_findings(
+        [
+            *check_russianism_calque(ctx),
+            *check_invalid_distractors(ctx),
+            *check_answer_key_placeholders(ctx),
+            *check_structural_integrity(ctx),
+            *check_empty_learner_surface(ctx),
+            *check_task_language_cefr(ctx),
+            *check_invented_forms(ctx),
+        ]
+    )
+    dimensions = _dimension_scores(findings)
+    aggregate = _aggregate(dimensions)
+    config_hash = checker_config_hash()
+
+    return {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "rule_set": RULE_SET_ID,
+        "module_id": f"{clean_level}/{meta_slug}",
+        "level": clean_level,
+        "slug": meta_slug,
+        "checker_config": {
+            "version": CHECKER_VERSION,
+            "config_hash": config_hash,
+            "rule_set": RULE_SET_ID,
+        },
+        "content_sha": content_sha_for_module(module_dir),
+        "verdict": aggregate["verdict"],
+        "terminal_verdict": aggregate["terminal_verdict"],
+        "aggregate": aggregate,
+        "dimensions": dimensions,
+        "checker_runs": [
+            {
+                "source": "hramatka_deterministic",
+                "checker": CHECKER_VERSION,
+                "config_hash": config_hash,
+                "provider": None,
+                "model": None,
+            }
+        ],
+        "llm_review": {
+            "used": False,
+            "required": aggregate["verdict"] != "PASS",
+            "provider": None,
+            "model": None,
+            "reason": (
+                "Residual LLM judge is required for semantic 'accidentally-also-correct' "
+                "distractors and pedagogical fit — not covered deterministically."
+            ),
+        },
+        "provenance": {
+            "created_at": _now_z(),
+            "run_id": f"hramatka-qg-{uuid4().hex}",
+            "source": "hramatka_qg_rules",
+            "fixture_id": fixture_id,
+        },
+    }
+
+
+def scan_hramatka_lesson(
+    lesson: Mapping[str, Any],
+    *,
+    slug: str | None = None,
+    fixture_id: str | None = None,
+    work_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Adapt lesson_json then scan with hramatka rules."""
+    adapted = adapt_lesson_json(lesson, slug=slug)
+    if work_dir is None:
+        with tempfile.TemporaryDirectory(prefix="hramatka-qg-") as raw:
+            dest = Path(raw) / adapted.slug
+            write_adapted_module_dir(adapted, dest)
+            return scan_hramatka_module(
+                dest,
+                level=adapted.level,
+                slug=adapted.slug,
+                fixture_id=fixture_id,
+                learner_strings=adapted.learner_strings,
+            )
+    dest = work_dir / adapted.slug
+    write_adapted_module_dir(adapted, dest)
+    return scan_hramatka_module(
+        dest,
+        level=adapted.level,
+        slug=adapted.slug,
+        fixture_id=fixture_id,
+        learner_strings=adapted.learner_strings,
+    )
+
+
+def _normalize_text(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip().casefold()
+
+
+def _expected_findings_pass(
+    evidence: Mapping[str, Any],
+    expected: list[Mapping[str, Any]],
+) -> tuple[bool, list[dict[str, Any]]]:
+    actual: list[Mapping[str, Any]] = []
+    dimensions = evidence.get("dimensions")
+    if isinstance(dimensions, Mapping):
+        for entry in dimensions.values():
+            if isinstance(entry, Mapping) and isinstance(entry.get("findings"), list):
+                actual.extend(item for item in entry["findings"] if isinstance(item, Mapping))
+
+    missing: list[dict[str, Any]] = []
+    for wanted in expected:
+        issue_id = str(wanted.get("issue_id") or "")
+        excerpt = _normalize_text(wanted.get("excerpt"))
+        dimension = str(wanted.get("dimension") or "")
+        severity = str(wanted.get("severity") or "")
+
+        matched = False
+        for item in actual:
+            if issue_id and item.get("issue_id") != issue_id:
+                continue
+            if dimension and item.get("dimension") != dimension:
+                continue
+            if severity and item.get("severity") != severity:
+                continue
+            actual_excerpt = _normalize_text(item.get("excerpt"))
+            if excerpt and excerpt not in actual_excerpt and actual_excerpt not in excerpt:
+                continue
+            matched = True
+            break
+        if not matched:
+            missing.append(dict(wanted))
+    return not missing, missing
+
+
+def _write_fixture_module(root: Path, fixture: Mapping[str, Any]) -> Path:
+    """Write a fixture as either lesson_json adaptation or raw CONTENT_FILES."""
+    fixture_id = str(fixture.get("id") or "fixture")
+    level = _normalize_level(fixture.get("level") or "b1")
+    slug = str(fixture.get("slug") or fixture_id)
+    module_dir = root / level / slug
+    module_dir.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(fixture.get("lesson_json"), Mapping):
+        adapt_lesson_json_to_module_dir(fixture["lesson_json"], module_dir, slug=slug)
+        return module_dir
+
+    module = fixture.get("module")
+    if not isinstance(module, Mapping):
+        raise ValueError(f"fixture {fixture_id} needs lesson_json or module mapping")
+    for name in CONTENT_FILES:
+        value = module.get(name)
+        if value is None:
+            value = "[]\n" if name.endswith((".yaml", ".yml")) else ""
+        (module_dir / name).write_text(str(value).rstrip() + "\n", encoding="utf-8")
+    return module_dir
+
+
+def evaluate_fixture(fixture: Mapping[str, Any], *, temp_root: Path) -> dict[str, Any]:
+    """Evaluate one labeled hramatka fixture against gold expectations."""
+    fixture_id = str(fixture.get("id") or "")
+    level = _normalize_level(fixture.get("level") or "b1")
+    slug = str(fixture.get("slug") or fixture_id)
+
+    if fixture.get("source_lesson_json"):
+        raw = fixture["source_lesson_json"]
+        path = Path(raw) if Path(str(raw)).is_absolute() else PROJECT_ROOT / str(raw)
+        lesson = json.loads(path.read_text(encoding="utf-8"))
+        evidence = scan_hramatka_lesson(lesson, slug=slug, fixture_id=fixture_id, work_dir=temp_root)
+    elif isinstance(fixture.get("lesson_json"), Mapping):
+        evidence = scan_hramatka_lesson(
+            fixture["lesson_json"],
+            slug=slug,
+            fixture_id=fixture_id,
+            work_dir=temp_root,
+        )
+    else:
+        module_dir = _write_fixture_module(temp_root, fixture)
+        evidence = scan_hramatka_module(
+            module_dir,
+            level=level,
+            slug=slug,
+            fixture_id=fixture_id,
+        )
+
+    expected_verdict = str(fixture.get("expected_verdict") or "").upper()
+    verdict_passed = not expected_verdict or evidence["verdict"] == expected_verdict
+    expected_findings = fixture.get("expected_findings")
+    if not isinstance(expected_findings, list):
+        expected_findings = []
+    findings_passed, missing_findings = _expected_findings_pass(evidence, expected_findings)
+
+    # Load-bearing: a green on a lesson carrying a planted fault is a TEST FAILURE.
+    # (Covered by expected_verdict FAIL + expected_findings matching.)
+    return {
+        "id": fixture_id,
+        "level": level,
+        "slug": slug,
+        "expected_verdict": expected_verdict,
+        "actual_verdict": evidence["verdict"],
+        "passed": verdict_passed and findings_passed,
+        "missing_findings": missing_findings,
+        "evidence": evidence,
+    }
+
+
+def run_fixtures(path: Path) -> dict[str, Any]:
+    """Run a hramatka fixture YAML file."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, Mapping):
+        raise ValueError("fixture file must be a mapping")
+    if data.get("schema_version") != FIXTURE_SCHEMA_VERSION:
+        raise ValueError(f"unsupported fixture schema: {data.get('schema_version')}")
+    fixtures = data.get("fixtures")
+    if not isinstance(fixtures, list):
+        raise ValueError("fixture file must contain a fixtures list")
+
+    with tempfile.TemporaryDirectory(prefix="hramatka-qg-fixtures-") as raw_tmp:
+        tmp_root = Path(raw_tmp)
+        results = [
+            evaluate_fixture(fixture, temp_root=tmp_root)
+            for fixture in fixtures
+            if isinstance(fixture, Mapping)
+        ]
+    passed = sum(1 for result in results if result["passed"])
+    return {
+        "schema_version": FIXTURE_SCHEMA_VERSION,
+        "rule_set": RULE_SET_ID,
+        "fixture_file": str(path),
+        "summary": {
+            "total": len(results),
+            "passed": passed,
+            "failed": len(results) - passed,
+        },
+        "results": results,
+    }
+
+
+def all_findings(evidence: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Flatten dimension findings from evidence."""
+    out: list[dict[str, Any]] = []
+    dimensions = evidence.get("dimensions")
+    if isinstance(dimensions, Mapping):
+        for entry in dimensions.values():
+            if isinstance(entry, Mapping) and isinstance(entry.get("findings"), list):
+                out.extend(f for f in entry["findings"] if isinstance(f, dict))
+    return out

--- a/scripts/audit/hramatka_qg_rules.py
+++ b/scripts/audit/hramatka_qg_rules.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import sqlite3
 import sys
 import tempfile
 from collections.abc import Iterable, Mapping, Sequence
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -499,11 +501,18 @@ def _apostrophe_variants(token: str) -> list[str]:
 
 
 def _vesum_hits(token: str) -> list[dict]:
-    """VESUM lookup tolerant of apostrophe orthography and proper-noun case."""
-    for variant in _apostrophe_variants(token):
-        hits = verify_word(variant)
-        if hits:
-            return hits
+    """VESUM lookup tolerant of apostrophe orthography and proper-noun case.
+
+    Missing VESUM DB → empty + detector_unavailable (never crash the gate).
+    """
+    try:
+        for variant in _apostrophe_variants(token):
+            hits = verify_word(variant)
+            if hits:
+                return hits
+    except (FileNotFoundError, OSError, sqlite3.Error) as exc:
+        _mark_detector_unavailable("vesum", str(exc))
+        return []
     return []
 
 
@@ -591,13 +600,31 @@ def _heritage_safe(status: Mapping[str, Any]) -> bool:
     classification = str(status.get("classification") or "")
     if classification in {"authentic-archaism", "dialect", "historism", "borrowing"}:
         return True
-    return classification == "standard" and bool(
-        status.get("vesum_attested") or has_positive_attestation(status)
-    )
+    try:
+        attested = bool(status.get("vesum_attested") or has_positive_attestation(status))
+    except (FileNotFoundError, OSError, sqlite3.Error) as exc:
+        _mark_detector_unavailable("heritage_classifier", str(exc))
+        attested = bool(status.get("vesum_attested"))
+    return classification == "standard" and attested
+
+
+def _unknown_token_status() -> dict[str, Any]:
+    return {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": False,
+        "russian_shadow": False,
+        "vesum_attested": False,
+        "sovietization_risk": 0,
+        "calque_warning": None,
+    }
 
 
 def _classify_token(token: str) -> dict[str, Any]:
-    """Classify with VESUM-first short-circuit (performance + apostrophe tolerance)."""
+    """Classify with VESUM-first short-circuit (performance + apostrophe tolerance).
+
+    Partial sources.db / missing VESUM → degrade to unknown (no crash).
+    """
     if _vesum_hits(token):
         return {
             "classification": "standard",
@@ -621,7 +648,11 @@ def _classify_token(token: str) -> dict[str, Any]:
             "calque_warning": None,
         }
     # heritage_classifier always overrides when it attests; russian-shadow is a signal.
-    return classify_surface_form(token.casefold())
+    try:
+        return classify_surface_form(token.casefold())
+    except (FileNotFoundError, OSError, sqlite3.Error) as exc:
+        _mark_detector_unavailable("heritage_classifier", str(exc))
+        return _unknown_token_status()
 
 
 def _is_russianism_token(token: str, status: Mapping[str, Any] | None = None) -> bool:
@@ -659,10 +690,29 @@ def _is_invented_form(token: str, status: Mapping[str, Any] | None = None) -> bo
 # Synonym + CEFR local lookups (direct SQL; same DBs as sources_db)
 # ---------------------------------------------------------------------------
 
+# Scan-scoped map of unavailable sub-detectors → reason. Partial sources.db
+# (CI stripped builds) must degrade, never crash the harness.
+_ACTIVE_UNAVAILABLE: ContextVar[dict[str, str] | None] = ContextVar(
+    "hramatka_qg_unavailable_detectors",
+    default=None,
+)
+
+
+def _mark_detector_unavailable(detector: str, reason: str) -> None:
+    store = _ACTIVE_UNAVAILABLE.get()
+    if store is None:
+        return
+    store.setdefault(detector, reason)
+
+
+def _is_missing_table_error(exc: BaseException) -> bool:
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    msg = str(exc).casefold()
+    return "no such table" in msg or "no such column" in msg
+
 
 def _sources_conn():
-    import sqlite3
-
     db = PROJECT_ROOT / "data" / "sources.db"
     if not db.exists():
         return None
@@ -679,6 +729,7 @@ def _synonym_lemmas(word: str) -> set[str]:
     partners: set[str] = set()
     conn = _sources_conn()
     if conn is None:
+        _mark_detector_unavailable("ukrajinet_synonyms", "sources.db missing")
         return partners
     try:
         rows = conn.execute(
@@ -698,6 +749,11 @@ def _synonym_lemmas(word: str) -> set[str]:
             cyr = [m for m in normalized if _CYRILLIC_TOKEN_RE.fullmatch(m)]
             if word_n in cyr:
                 partners.update(m for m in cyr if m != word_n)
+    except sqlite3.OperationalError as exc:
+        if _is_missing_table_error(exc):
+            _mark_detector_unavailable("ukrajinet_synonyms", str(exc))
+            return partners
+        raise
     finally:
         conn.close()
     return partners
@@ -714,6 +770,7 @@ def _are_synonyms(a: str, b: str) -> bool:
 def _cefr_level_for(word: str) -> str | None:
     conn = _sources_conn()
     if conn is None:
+        _mark_detector_unavailable("puls_cefr", "sources.db missing")
         return None
     try:
         row = conn.execute(
@@ -728,6 +785,11 @@ def _cefr_level_for(word: str) -> str | None:
         ).fetchone()
         if row and row["level"]:
             return str(row["level"]).strip().lower()
+    except sqlite3.OperationalError as exc:
+        if _is_missing_table_error(exc):
+            _mark_detector_unavailable("puls_cefr", str(exc))
+            return None
+        raise
     finally:
         conn.close()
     return None
@@ -743,9 +805,12 @@ def _antonenko_title_hit(text: str) -> list[str]:
 
     Only multi-token left-hand sides of ``bad – good`` titles count. Single-token
     left sides (e.g. "Жити–бути") are too ambiguous for a deterministic gate.
+
+    Missing ``style_guide`` (CI stripped sources.db) → empty + detector_unavailable.
     """
     conn = _sources_conn()
     if conn is None:
+        _mark_detector_unavailable("antonenko_style_guide", "sources.db missing")
         return []
     hits: list[str] = []
     folded = text.casefold()
@@ -773,6 +838,11 @@ def _antonenko_title_hit(text: str) -> list[str]:
                 if cand in folded:
                     hits.append(title)
                     break
+    except sqlite3.OperationalError as exc:
+        if _is_missing_table_error(exc):
+            _mark_detector_unavailable("antonenko_style_guide", str(exc))
+            return []
+        raise
     finally:
         conn.close()
     return hits
@@ -781,6 +851,24 @@ def _antonenko_title_hit(text: str) -> list[str]:
 # ---------------------------------------------------------------------------
 # Check classes
 # ---------------------------------------------------------------------------
+
+
+def _safe_curated_russicisms(text: str, file_path: str) -> list[dict]:
+    """Curated regex russicisms; never let a broken helper crash the gate."""
+    try:
+        return list(check_russicisms(text, file_path=file_path) or [])
+    except (OSError, sqlite3.Error, RuntimeError, ValueError) as exc:
+        _mark_detector_unavailable("check_russicisms", str(exc))
+        return []
+
+
+def _safe_ua_gec_calques(text: str, file_path: str) -> list[dict]:
+    """UA-GEC calques (CSV-backed); degrade if the lookup table cannot load."""
+    try:
+        return list(check_ua_gec_calques(text, file_path=file_path) or [])
+    except (OSError, sqlite3.Error, RuntimeError, ValueError) as exc:
+        _mark_detector_unavailable("ua_gec_calques", str(exc))
+        return []
 
 
 def check_russianism_calque(ctx: _ScanContext) -> list[dict[str, Any]]:
@@ -799,7 +887,7 @@ def check_russianism_calque(ctx: _ScanContext) -> list[dict[str, Any]]:
         file, line, file_text = _locate_in_texts(ctx.texts, text[:80] if len(text) > 80 else text)
 
         # 1) Curated regex / high-precision patterns (reused from qg_adapters stack)
-        for violation in check_russicisms(text, file_path=file):
+        for violation in _safe_curated_russicisms(text, file):
             excerpt = str(violation.get("matched") or text[:80])
             # check_russicisms aggregates; pull matched terms from issue when needed
             issue = str(violation.get("issue") or "Russicism detected")
@@ -823,7 +911,7 @@ def check_russianism_calque(ctx: _ScanContext) -> list[dict[str, Any]]:
 
         # 2) UA-GEC exact-span calques — multi-word only (single tokens are too noisy;
         # curated check_russicisms already covers high-precision single-token forms).
-        for violation in check_ua_gec_calques(text, file_path=file):
+        for violation in _safe_ua_gec_calques(text, file):
             matched = str(violation.get("matched") or "")
             if not matched or " " not in matched.strip():
                 continue
@@ -1597,20 +1685,30 @@ def scan_hramatka_module(
         learner_strings=strings,
     )
 
-    findings = _dedupe_findings(
-        [
-            *check_russianism_calque(ctx),
-            *check_invalid_distractors(ctx),
-            *check_answer_key_placeholders(ctx),
-            *check_structural_integrity(ctx),
-            *check_empty_learner_surface(ctx),
-            *check_task_language_cefr(ctx),
-            *check_invented_forms(ctx),
-        ]
-    )
+    unavailable: dict[str, str] = {}
+    token = _ACTIVE_UNAVAILABLE.set(unavailable)
+    try:
+        findings = _dedupe_findings(
+            [
+                *check_russianism_calque(ctx),
+                *check_invalid_distractors(ctx),
+                *check_answer_key_placeholders(ctx),
+                *check_structural_integrity(ctx),
+                *check_empty_learner_surface(ctx),
+                *check_task_language_cefr(ctx),
+                *check_invented_forms(ctx),
+            ]
+        )
+    finally:
+        _ACTIVE_UNAVAILABLE.reset(token)
+
     dimensions = _dimension_scores(findings)
     aggregate = _aggregate(dimensions)
     config_hash = checker_config_hash()
+    detector_status = {
+        name: {"status": "detector_unavailable", "reason": reason}
+        for name, reason in sorted(unavailable.items())
+    }
 
     return {
         "schema_version": EVIDENCE_SCHEMA_VERSION,
@@ -1628,6 +1726,7 @@ def scan_hramatka_module(
         "terminal_verdict": aggregate["terminal_verdict"],
         "aggregate": aggregate,
         "dimensions": dimensions,
+        "detector_status": detector_status,
         "checker_runs": [
             {
                 "source": "hramatka_deterministic",

--- a/tests/audit/test_hramatka_qg_rules.py
+++ b/tests/audit/test_hramatka_qg_rules.py
@@ -3,10 +3,11 @@
 Each check must FIRE on its planted known-bad fixture and a clean lesson must PASS.
 A green on a lesson carrying a planted fault is a test failure.
 
-DB-backed detectors (style_guide / PULS CEFR / ukrajinet / VESUM / heritage) are
-monkeypatched so CI's stripped sources.db cannot rubber-stamp or crash the suite.
-Follows the repo pattern used by textbook_grounding / ulif tests: mock the lookup,
-assert the gate behavior.
+Data-dependent detectors (style_guide / PULS CEFR / ukrajinet / VESUM / heritage)
+run against CONTROLLED temporary SQLite DBs — never ambient sources.db fullness.
+CI and local therefore exercise the same real SQL + gate logic. Production still
+gracefully degrades when tables are missing; tests never rely on that path for
+load-bearing clean→PASS / planted→FAIL assertions.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ import sqlite3
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.audit import hramatka_qg_rules as hq
 from scripts.audit.curriculum_qg_harness import main as harness_main
@@ -39,34 +41,20 @@ FIXTURE_FILE = PROJECT_ROOT / "tests" / "fixtures" / "hramatka_qg" / "fixtures.y
 ACTIVITY_KIT_LESSON = (
     PROJECT_ROOT / "packages" / "activity-kit" / "src" / "fixtures" / "lu.lesson.v1.fixture.json"
 )
-SOURCES_DB = PROJECT_ROOT / "data" / "sources.db"
+HERITAGE_SAMPLE_DB = PROJECT_ROOT / "tests" / "fixtures" / "heritage_sample.db"
 
-# Planted non-forms / shadow forms that must stay VESUM-absent under mocks.
+# Planted non-forms that must stay VESUM-absent under the controlled fixture DB.
 _PLANTED_NON_VESUM = frozenset(
     {
         "зделати",
         "жмурклея",
         "ффффффф",
-        "кушати",  # russian-shadow in planted-russianism fixture
+        "кушати",
     }
 )
-_PLANTED_RUSSIAN_SHADOW = frozenset({"зделати", "кушати"})
-# Fixture CEFR over-level token from planted-overlevel-task (чигати, with г).
 _OVERLEVEL_TOKEN = "чигати"
-_CEFR_OVERLEVEL = {_OVERLEVEL_TOKEN: "c1"}
-# Synonym pair planted in planted-bad-distractors.
-_SYNONYM_PAIRS: dict[str, set[str]] = {
-    "великий": {"видатний"},
-    "видатний": {"великий"},
-}
 
-# Real SQL helpers (captured before autouse mocks replace them).
-_REAL_ANTONENKO_TITLE_HIT = hq._antonenko_title_hit
-_REAL_CEFR_LEVEL_FOR = hq._cefr_level_for
-_REAL_SYNONYM_LEMMAS = hq._synonym_lemmas
-_REAL_SOURCES_CONN = hq._sources_conn
-
-_CYR_OK = re.compile(r"[а-яіїєґ'ʼ’\-]+", re.IGNORECASE)
+_CYR_TOKEN_RE = re.compile(r"[А-Яа-яЁёІіЇїЄєҐґ][А-Яа-яЁёІіЇїЄєҐґ'ʼ’\-]*")
 
 
 def _by_id(report: dict) -> dict[str, dict]:
@@ -77,90 +65,168 @@ def _issue_ids(evidence: dict) -> set[str]:
     return {f["issue_id"] for f in all_findings(evidence)}
 
 
-def _mock_vesum_hits(token: str) -> list[dict]:
-    key = token.casefold()
-    if key in _PLANTED_NON_VESUM:
-        return []
-    # Accept ordinary Cyrillic surface forms as real under the mock.
-    if _CYR_OK.fullmatch(key) and not re.fullmatch(r"ф+", key):
-        return [{"lemma": key, "pos": "unknown", "tags": "mock-vesum"}]
-    return []
+def _collect_fixture_tokens() -> set[str]:
+    """Surface tokens from synthetic fixtures + hard-coded clean lessons in this file."""
+    data = yaml.safe_load(FIXTURE_FILE.read_text(encoding="utf-8"))
+    tokens: set[str] = set()
+    for entry in data.get("fixtures") or []:
+        lesson = entry.get("lesson_json") or {}
+        adapted = adapt_lesson_json(lesson, slug=str(entry.get("id") or "x"))
+        for _path, text in adapted.learner_strings:
+            for tok in _CYR_TOKEN_RE.findall(text or ""):
+                tokens.add(tok.casefold())
+    # Hard-coded clean lessons used by CLI / dispatch / direct-scan tests.
+    extras = (
+        "CLI урок",
+        "Ми вчимося мови.",
+        "Перевірте.",
+        "Ми вчимося.",
+        "Диспетчер",
+        "Ми читаємо.",
+        "Правда",
+        "Прямий скан",
+        "Ми говоримо українською.",
+        "Ми говоримо.",
+        "Чистий",
+        "Калибр",
+        "Треба зделати роботу і приймати участь.",
+        "Участь",
+        "Студенти хочуть приймати участь у святі.",
+        "Вони хочуть приймати участь.",
+        # Proper-noun precision probe (must not false-positive when absent from VESUM).
+        "Львів",
+        "Оля",
+        "НАТО",
+    )
+    for text in extras:
+        for tok in _CYR_TOKEN_RE.findall(text):
+            tokens.add(tok.casefold())
+    return tokens
 
 
-def _mock_classify_token(token: str) -> dict:
-    key = token.casefold()
-    if key in _PLANTED_RUSSIAN_SHADOW:
-        return {
-            "classification": "unknown",
-            "attestations": [],
-            "is_russianism": False,
-            "russian_shadow": True,
-            "vesum_attested": False,
-            "sovietization_risk": 0,
-            "calque_warning": {
-                "type": "russian_shadow_only",
-                "note": "mock planted russian-shadow",
-            },
-        }
-    if key == "жмурклея":
-        return {
-            "classification": "unknown",
-            "attestations": [],
-            "is_russianism": False,
-            "russian_shadow": False,
-            "vesum_attested": False,
-            "sovietization_risk": 0,
-            "calque_warning": None,
-        }
-    if _mock_vesum_hits(token):
-        return {
-            "classification": "standard",
-            "attestations": [{"source": "vesum", "ref": token}],
-            "is_russianism": False,
-            "russian_shadow": False,
-            "vesum_attested": True,
-            "sovietization_risk": 0,
-            "calque_warning": None,
-        }
-    return {
-        "classification": "unknown",
-        "attestations": [],
-        "is_russianism": False,
-        "russian_shadow": False,
-        "vesum_attested": False,
-        "sovietization_risk": 0,
-        "calque_warning": None,
-    }
+def _build_controlled_vesum(path: Path) -> None:
+    """Minimal VESUM forms table: clean tokens present, planted non-forms absent."""
+    tokens = sorted(
+        t
+        for t in _collect_fixture_tokens()
+        if t not in _PLANTED_NON_VESUM and not re.fullmatch(r"ф+", t)
+    )
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE forms (word_form TEXT NOT NULL, lemma TEXT NOT NULL, "
+            "tags TEXT NOT NULL, pos TEXT NOT NULL)"
+        )
+        rows = [(tok, tok, "fixture:mock", "unknown") for tok in tokens]
+        conn.executemany(
+            "INSERT INTO forms(word_form, lemma, tags, pos) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
-def _mock_cefr_level_for(word: str) -> str | None:
-    return _CEFR_OVERLEVEL.get(word.casefold())
-
-
-def _mock_synonym_lemmas(word: str) -> set[str]:
-    return set(_SYNONYM_PAIRS.get(word.casefold().strip(), set()))
-
-
-def _mock_antonenko_title_hit(text: str) -> list[str]:
-    folded = text.casefold()
-    if "приймати участь" in folded:
-        return ["Приймати участь – брати участь"]
-    return []
+def _build_controlled_sources(path: Path) -> None:
+    """Minimal sources.db: style_guide + PULS CEFR + ukrajinet rows the fixtures need."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE style_guide (
+                id INTEGER PRIMARY KEY,
+                word TEXT,
+                section TEXT,
+                text TEXT,
+                source TEXT,
+                word_lower TEXT,
+                excerpt_full TEXT,
+                page TEXT,
+                russianism_pattern TEXT
+            );
+            CREATE TABLE puls_cefr (
+                id INTEGER PRIMARY KEY,
+                word TEXT,
+                guideword TEXT,
+                level TEXT,
+                pos TEXT,
+                type TEXT,
+                text TEXT,
+                source TEXT
+            );
+            CREATE TABLE ukrajinet (
+                id INTEGER PRIMARY KEY,
+                synset_id TEXT,
+                words TEXT,
+                text TEXT,
+                source TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO style_guide(word, section, text, source) VALUES (?, ?, ?, ?)",
+            (
+                "Приймати участь – брати участь",
+                "ДІЄСЛОВА",
+                "fixture calque title",
+                "Antonenko-Davydovych",
+            ),
+        )
+        # Over-level planted token (C1) + level-appropriate baselines that must NOT warn.
+        cefr_rows = [
+            (_OVERLEVEL_TOKEN, "c1"),
+            ("речення", "a1"),
+            ("хліб", "a1"),
+            ("ми", "a1"),
+            ("слово", "a1"),
+            ("читаємо", "a1"),
+            ("великий", "a2"),
+            ("квартира", "a2"),
+        ]
+        for word, level in cefr_rows:
+            conn.execute(
+                "INSERT INTO puls_cefr(word, level, text, source) VALUES (?, ?, ?, ?)",
+                (word, level, f"{word} ({level})", "PULS-fixture"),
+            )
+        conn.execute(
+            "INSERT INTO ukrajinet(synset_id, words, text, source) VALUES (?, ?, ?, ?)",
+            (
+                "fixture-syn-1",
+                json.dumps(["великий", "видатний"], ensure_ascii=False),
+                "Синоніми: великий, видатний",
+                "Ukrajinet-fixture",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 @pytest.fixture(autouse=True)
-def _mock_sources_backed_detectors(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Deterministic DB-backed lookups for CI's stripped sources.db.
+def _controlled_data_layer(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory):
+    """Point hramatka QG at controlled SQLite DBs (real SQL paths, known rows).
 
-    Keeps load-bearing planted-fault → FAIL assertions independent of which
-    tables the runner's sources.db actually contains. Structural / regex checks
-    (placeholders, cloze, MC, curated RUSSICISM_DETECTED) stay live.
+    Exercises the same helpers production uses — not ambient-db degradation.
+    Heritage classifier uses the repo's small sample DB (table shape only);
+    VESUM attestation is forced through the controlled forms table.
     """
-    monkeypatch.setattr(hq, "_vesum_hits", _mock_vesum_hits)
-    monkeypatch.setattr(hq, "_classify_token", _mock_classify_token)
-    monkeypatch.setattr(hq, "_cefr_level_for", _mock_cefr_level_for)
-    monkeypatch.setattr(hq, "_synonym_lemmas", _mock_synonym_lemmas)
-    monkeypatch.setattr(hq, "_antonenko_title_hit", _mock_antonenko_title_hit)
+    root = tmp_path_factory.mktemp("hramatka_qg_controlled")
+    sources = root / "sources.db"
+    vesum = root / "vesum.db"
+    _build_controlled_sources(sources)
+    _build_controlled_vesum(vesum)
+
+    monkeypatch.setattr(hq, "_SOURCES_DB_OVERRIDE", sources)
+    monkeypatch.setattr(hq, "_VESUM_DB_OVERRIDE", vesum)
+    # Prefer sample heritage tables when present; else controlled sources (empty heritage).
+    heritage = HERITAGE_SAMPLE_DB if HERITAGE_SAMPLE_DB.exists() else sources
+    monkeypatch.setattr(hq, "_HERITAGE_DB_OVERRIDE", heritage)
+
+    yield {
+        "sources": sources,
+        "vesum": vesum,
+        "heritage": heritage,
+    }
 
 
 def test_hramatka_fixture_suite_load_bearing() -> None:
@@ -222,6 +288,116 @@ def test_clean_lesson_has_no_findings() -> None:
     clean = _by_id(report)["clean-b1-lesson"]
     assert clean["actual_verdict"] == "PASS"
     assert all_findings(clean["evidence"]) == []
+
+
+def test_controlled_sql_helpers_exercise_real_logic() -> None:
+    """Prove CEFR / synonym / Antonenko hit the controlled rows (not stubs)."""
+    assert hq._cefr_level_for(_OVERLEVEL_TOKEN) == "c1"
+    assert hq._cefr_level_for("речення") == "a1"
+    assert "видатний" in hq._synonym_lemmas("великий")
+    hits = hq._antonenko_title_hit("Студенти хочуть приймати участь у святі.")
+    assert hits, "controlled style_guide must flag 'приймати участь'"
+    assert hq._vesum_hits("квартиру"), "controlled VESUM must attest clean tokens"
+    assert not hq._vesum_hits("жмурклея"), "planted invented form must stay VESUM-absent"
+    assert not hq._vesum_hits("зделати"), "planted russian-shadow form must stay VESUM-absent"
+
+
+def test_proper_noun_and_capitalized_name_not_invented() -> None:
+    """Invented-form must not flag place names / names (Львів-type)."""
+    # Ensure these are ABSENT from controlled VESUM for this assertion.
+    assert not hq._vesum_hits("Харків")  # not in fixture token set
+    assert hq._is_probable_proper_noun("Львів")
+    assert hq._is_probable_proper_noun("Оля")
+    assert hq._is_probable_proper_noun("НАТО")
+    assert not hq._is_invented_form("Львів")
+    assert not hq._is_invented_form("Оля")
+    assert not hq._is_invented_form("НАТО")
+
+    evidence = scan_hramatka_lesson(
+        {
+            "title": "Львів",
+            "level": "B1",
+            "anchor": {"text": "Оля була у Львові біля парку."},
+            "blocks": [
+                {
+                    "type": "true-false",
+                    "activity": {
+                        "type": "true-false",
+                        "title": "Правда",
+                        "payload": {
+                            "type": "true-false",
+                            "instruction": "Перевірте.",
+                            "items": [{"statement": "Оля була у Львові.", "correct": True}],
+                        },
+                        "answer_key": {"items": [{"index": 0, "correct": True}]},
+                    },
+                    "answer_key": "1 П",
+                }
+            ],
+        },
+        slug="proper-noun-clean",
+    )
+    assert evidence["verdict"] == "PASS"
+    assert "NON_VESUM_FORM" not in _issue_ids(evidence)
+
+
+def test_cefr_only_flags_clear_overlevel_in_task_language() -> None:
+    """CEFR must stay quiet for level-appropriate task words; fire only on planted C1."""
+    # A1 lesson with only A1 task words → PASS (no false WARN).
+    clean_a1 = scan_hramatka_lesson(
+        {
+            "title": "Хліб",
+            "level": "A1",
+            "anchor": {"text": "Я їм хліб."},
+            "blocks": [
+                {
+                    "type": "true-false",
+                    "activity": {
+                        "type": "true-false",
+                        "title": "Перевірка",
+                        "payload": {
+                            "type": "true-false",
+                            "instruction": "Чи це хліб?",
+                            "items": [{"statement": "Я їм хліб.", "correct": True}],
+                        },
+                        "answer_key": {"items": [{"index": 0, "correct": True}]},
+                    },
+                    "answer_key": "1 П",
+                }
+            ],
+        },
+        slug="cefr-clean-a1",
+    )
+    assert clean_a1["verdict"] == "PASS"
+    assert "TASK_CEFR_OVERLEVEL" not in _issue_ids(clean_a1)
+
+    # Same level with planted C1 task verb → WARN.
+    over = scan_hramatka_lesson(
+        {
+            "title": "Просте",
+            "level": "A1",
+            "anchor": {"text": "Я їм хліб."},
+            "blocks": [
+                {
+                    "type": "true-false",
+                    "activity": {
+                        "type": "true-false",
+                        "title": "Перевірка",
+                        "payload": {
+                            "type": "true-false",
+                            "instruction": "Чи можна чигати за дверима?",
+                            "items": [{"statement": "Я їм хліб.", "correct": True}],
+                        },
+                        "answer_key": {"items": [{"index": 0, "correct": True}]},
+                    },
+                    "answer_key": "1 П",
+                }
+            ],
+        },
+        slug="cefr-over",
+    )
+    assert over["verdict"] == "WARN"
+    assert "TASK_CEFR_OVERLEVEL" in _issue_ids(over)
 
 
 def test_adapter_excludes_internal_fields_and_keeps_learner_surface(tmp_path: Path) -> None:
@@ -396,6 +572,7 @@ def test_harness_cli_lesson_json(tmp_path: Path) -> None:
     assert code == 0
     assert payload["rule_set"] == RULE_SET_ID
     assert payload["verdict"] == "PASS"
+    assert all_findings(payload) == []
 
 
 def test_curriculum_phrase_rules_do_not_rubber_stamp_hramatka_faults(tmp_path: Path) -> None:
@@ -492,11 +669,11 @@ def test_missing_style_guide_and_cefr_tables_do_not_crash(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Simulate CI stripped sources.db: no style_guide / puls_cefr / ukrajinet.
+    """Production robustness: missing tables → detector_unavailable, no crash.
 
-    Real SQL helpers hit the stripped DB and must mark detector_unavailable
-    without crashing. Load-bearing CEFR/synonym/VESUM mocks stay so planted
-    fixture assertions still hold deterministically.
+    Load-bearing planted/clean assertions still run against controlled data
+    restored after the stripped-DB probe (autouse fixture remains active for
+    the suite; this test only temporarily points sources at a stripped file).
     """
     stripped = tmp_path / "sources.db"
     conn = sqlite3.connect(str(stripped))
@@ -504,17 +681,7 @@ def test_missing_style_guide_and_cefr_tables_do_not_crash(
     conn.commit()
     conn.close()
 
-    def _stripped_conn():
-        c = sqlite3.connect(str(stripped))
-        c.row_factory = sqlite3.Row
-        return c
-
-    monkeypatch.setattr(hq, "_sources_conn", _stripped_conn)
-    # Exercise real SQL helpers against the stripped schema.
-    monkeypatch.setattr(hq, "_antonenko_title_hit", _REAL_ANTONENKO_TITLE_HIT)
-    # Keep CEFR + synonym mocks so load-bearing fixture expectations stay deterministic.
-    monkeypatch.setattr(hq, "_cefr_level_for", _mock_cefr_level_for)
-    monkeypatch.setattr(hq, "_synonym_lemmas", _mock_synonym_lemmas)
+    monkeypatch.setattr(hq, "_SOURCES_DB_OVERRIDE", stripped)
 
     clean = scan_hramatka_lesson(
         {
@@ -540,29 +707,15 @@ def test_missing_style_guide_and_cefr_tables_do_not_crash(
         },
         slug="stripped-clean",
     )
+    # VESUM still controlled → clean PASS; style_guide/CEFR mark unavailable.
     assert clean["verdict"] == "PASS"
     status = clean.get("detector_status") or {}
     assert "antonenko_style_guide" in status
     assert status["antonenko_style_guide"]["status"] == "detector_unavailable"
     assert "no such table" in status["antonenko_style_guide"]["reason"].casefold()
 
-    # Real Antonenko SQL against stripped schema returns empty (no crash).
-    assert _REAL_ANTONENKO_TITLE_HIT("приймати участь у святі") == []
-    # CEFR mock still drives over-level fixture deterministically.
-    assert hq._cefr_level_for(_OVERLEVEL_TOKEN) == "c1"
-
-    report = run_fixtures(FIXTURE_FILE)
-    assert report["summary"]["failed"] == 0, {
-        row["id"]: row.get("missing_findings") or row.get("actual_verdict")
-        for row in report["results"]
-        if not row["passed"]
-    }
-    by_id = _by_id(report)
-    assert by_id["planted-russianism"]["actual_verdict"] == "FAIL"
-    assert by_id["planted-placeholder-key"]["actual_verdict"] == "FAIL"
-    assert by_id["planted-overlevel-task"]["actual_verdict"] == "WARN"
-    assert by_id["planted-bad-distractors"]["actual_verdict"] == "FAIL"
-    assert by_id["clean-b1-lesson"]["actual_verdict"] == "PASS"
+    assert hq._antonenko_title_hit("приймати участь у святі") == []
+    assert hq._cefr_level_for(_OVERLEVEL_TOKEN) is None
 
 
 def test_stripped_cefr_and_synonym_tables_mark_unavailable(
@@ -576,15 +729,7 @@ def test_stripped_cefr_and_synonym_tables_mark_unavailable(
     conn.commit()
     conn.close()
 
-    def _stripped_conn():
-        c = sqlite3.connect(str(stripped))
-        c.row_factory = sqlite3.Row
-        return c
-
-    monkeypatch.setattr(hq, "_sources_conn", _stripped_conn)
-    monkeypatch.setattr(hq, "_cefr_level_for", _REAL_CEFR_LEVEL_FOR)
-    monkeypatch.setattr(hq, "_synonym_lemmas", _REAL_SYNONYM_LEMMAS)
-    monkeypatch.setattr(hq, "_antonenko_title_hit", _REAL_ANTONENKO_TITLE_HIT)
+    monkeypatch.setattr(hq, "_SOURCES_DB_OVERRIDE", stripped)
 
     unavailable: dict[str, str] = {}
     token = hq._ACTIVE_UNAVAILABLE.set(unavailable)
@@ -602,34 +747,48 @@ def test_stripped_cefr_and_synonym_tables_mark_unavailable(
         assert "no such table" in unavailable[name].casefold()
 
 
-def _full_db_has_style_guide() -> bool:
-    if not SOURCES_DB.exists():
-        return False
-    try:
-        conn = sqlite3.connect(f"file:{SOURCES_DB}?mode=ro", uri=True)
-        try:
-            row = conn.execute(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='style_guide' LIMIT 1"
-            ).fetchone()
-            return row is not None
-        finally:
-            conn.close()
-    except sqlite3.Error:
-        return False
+def test_vesum_unavailable_does_not_flood_invented_forms(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When VESUM is missing, NON_VESUM_FORM must stay quiet (cannot prove absence)."""
+    missing = tmp_path / "no-vesum.db"
+    # Do not create the file — verify_word raises FileNotFoundError.
+    monkeypatch.setattr(hq, "_VESUM_DB_OVERRIDE", missing)
+
+    evidence = scan_hramatka_lesson(
+        {
+            "title": "Чистий",
+            "level": "B1",
+            "anchor": {"text": "Ми вчимося мови."},
+            "blocks": [
+                {
+                    "type": "true-false",
+                    "activity": {
+                        "type": "true-false",
+                        "title": "Правда",
+                        "payload": {
+                            "type": "true-false",
+                            "instruction": "Перевірте.",
+                            "items": [{"statement": "Ми вчимося.", "correct": True}],
+                        },
+                        "answer_key": {"items": [{"index": 0, "correct": True}]},
+                    },
+                    "answer_key": "1 П",
+                }
+            ],
+        },
+        slug="vesum-missing-clean",
+    )
+    assert evidence["verdict"] == "PASS"
+    assert "NON_VESUM_FORM" not in _issue_ids(evidence)
+    assert "RUSSIAN_SHADOW_RUSSICISM" not in _issue_ids(evidence)
+    status = evidence.get("detector_status") or {}
+    assert "vesum" in status
 
 
-@pytest.mark.skipif(
-    not _full_db_has_style_guide(),
-    reason="full sources.db with style_guide not present (CI stripped build)",
-)
-def test_live_antonenko_smoke_when_full_db_present(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Optional live-data smoke: real style_guide detector when the full DB exists."""
-    monkeypatch.setattr(hq, "_sources_conn", _REAL_SOURCES_CONN)
-    monkeypatch.setattr(hq, "_antonenko_title_hit", _REAL_ANTONENKO_TITLE_HIT)
-
-    hits = hq._antonenko_title_hit("Студенти хочуть приймати участь у святі.")
-    assert hits, "full style_guide should flag 'приймати участь'"
-
+def test_antonenko_calque_fires_via_controlled_style_guide() -> None:
+    """Deterministic Antonenko path: controlled style_guide row + real SQL helper."""
     evidence = scan_hramatka_lesson(
         {
             "title": "Участь",
@@ -652,10 +811,9 @@ def test_live_antonenko_smoke_when_full_db_present(monkeypatch: pytest.MonkeyPat
                 }
             ],
         },
-        slug="live-antonenko-smoke",
+        slug="antonenko-controlled",
     )
-    # Live style_guide / curated regex fire as warnings; terminal may be WARN or FAIL.
     assert evidence["verdict"] in {"WARN", "FAIL"}
     issues = _issue_ids(evidence)
+    assert "ANTONENKO_CALQUE" in issues
     assert "RUSSICISM_DETECTED" in issues or "ANTONENKO_CALQUE" in issues
-    assert "ANTONENKO_CALQUE" in issues, "live style_guide must surface ANTONENKO_CALQUE"

--- a/tests/audit/test_hramatka_qg_rules.py
+++ b/tests/audit/test_hramatka_qg_rules.py
@@ -1,0 +1,364 @@
+"""Load-bearing tests for hramatka QG rule set.
+
+Each check must FIRE on its planted known-bad fixture and a clean lesson must PASS.
+A green on a lesson carrying a planted fault is a test failure.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.audit.curriculum_qg_harness import main as harness_main
+from scripts.audit.curriculum_qg_harness import run_fixtures as harness_run_fixtures
+from scripts.audit.curriculum_qg_harness import scan_curriculum_module
+from scripts.audit.hramatka_qg_rules import (
+    CHECKER_VERSION,
+    EVIDENCE_SCHEMA_VERSION,
+    RULE_SET_ID,
+    adapt_lesson_json,
+    all_findings,
+    checker_config_hash,
+    run_fixtures,
+    scan_hramatka_lesson,
+    write_adapted_module_dir,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_FILE = PROJECT_ROOT / "tests" / "fixtures" / "hramatka_qg" / "fixtures.yaml"
+ACTIVITY_KIT_LESSON = (
+    PROJECT_ROOT / "packages" / "activity-kit" / "src" / "fixtures" / "lu.lesson.v1.fixture.json"
+)
+
+
+def _by_id(report: dict) -> dict[str, dict]:
+    return {row["id"]: row for row in report["results"]}
+
+
+def _issue_ids(evidence: dict) -> set[str]:
+    return {f["issue_id"] for f in all_findings(evidence)}
+
+
+def test_hramatka_fixture_suite_load_bearing() -> None:
+    """Every synthetic known-bad must be caught; clean lesson must PASS."""
+    report = run_fixtures(FIXTURE_FILE)
+
+    assert report["rule_set"] == RULE_SET_ID
+    assert report["summary"]["failed"] == 0, {
+        row["id"]: row.get("missing_findings") or row.get("actual_verdict")
+        for row in report["results"]
+        if not row["passed"]
+    }
+    assert report["summary"]["total"] >= 10
+
+    by_id = _by_id(report)
+    assert by_id["clean-b1-lesson"]["actual_verdict"] == "PASS"
+    assert by_id["planted-russianism"]["actual_verdict"] == "FAIL"
+    assert by_id["planted-russian-shadow"]["actual_verdict"] == "FAIL"
+    assert by_id["planted-bad-distractors"]["actual_verdict"] == "FAIL"
+    assert by_id["planted-placeholder-key"]["actual_verdict"] == "FAIL"
+    assert by_id["planted-broken-cloze"]["actual_verdict"] == "FAIL"
+    assert by_id["planted-overlevel-task"]["actual_verdict"] == "WARN"
+    assert by_id["planted-invented-form"]["actual_verdict"] == "WARN"
+    assert by_id["planted-empty-surface"]["actual_verdict"] == "FAIL"
+    assert by_id["planted-mc-too-few"]["actual_verdict"] == "FAIL"
+
+
+def test_each_check_fires_on_planted_fault() -> None:
+    report = run_fixtures(FIXTURE_FILE)
+    by_id = _by_id(report)
+
+    cases = {
+        "planted-russianism": "RUSSICISM_DETECTED",
+        "planted-russian-shadow": "RUSSIAN_SHADOW_RUSSICISM",
+        "planted-bad-distractors": "NON_VESUM_DISTRACTOR",
+        "planted-placeholder-key": "ANSWER_KEY_PLACEHOLDER",
+        "planted-broken-cloze": "CLOZE_BLANK_MISMATCH",
+        "planted-overlevel-task": "TASK_CEFR_OVERLEVEL",
+        "planted-invented-form": "NON_VESUM_FORM",
+        "planted-empty-surface": "EMPTY_LEARNER_SURFACE",
+        "planted-mc-too-few": "MC_TOO_FEW_OPTIONS",
+    }
+    for fixture_id, issue_id in cases.items():
+        evidence = by_id[fixture_id]["evidence"]
+        ids = _issue_ids(evidence)
+        assert issue_id in ids, f"{fixture_id} missing {issue_id}; got {sorted(ids)}"
+        # Load-bearing: planted fault must not green
+        assert evidence["verdict"] != "PASS", f"{fixture_id} wrongly PASSed with planted fault"
+
+
+def test_synonym_collision_fires() -> None:
+    report = run_fixtures(FIXTURE_FILE)
+    evidence = _by_id(report)["planted-bad-distractors"]["evidence"]
+    assert "SYNONYM_DISTRACTOR" in _issue_ids(evidence)
+
+
+def test_clean_lesson_has_no_findings() -> None:
+    report = run_fixtures(FIXTURE_FILE)
+    clean = _by_id(report)["clean-b1-lesson"]
+    assert clean["actual_verdict"] == "PASS"
+    assert all_findings(clean["evidence"]) == []
+
+
+def test_adapter_excludes_internal_fields_and_keeps_learner_surface(tmp_path: Path) -> None:
+    lesson = {
+        "title": "Тестовий урок",
+        "level": "B1",
+        "method": "ttt",
+        "status": "ready",
+        "anchor": {
+            "text": "Текст якоря для учнів.",
+            "source": "teacher-paste",
+            "chars": 20,
+        },
+        "blocks": [
+            {
+                "id": "secret-id",
+                "phase": 1,
+                "type": "multiple-choice",
+                "mark": "ok",
+                "note": "teacher only note with phone 099",
+                "provenance": {"source": "generated", "generator": "hramatka"},
+                "activity": {
+                    "type": "multiple-choice",
+                    "title": "Оберіть",
+                    "payload": {
+                        "type": "multiple-choice",
+                        "instruction": "Оберіть відповідь.",
+                        "items": [
+                            {
+                                "prompt": "Де парк?",
+                                "options": ["а) тут", "б) там"],
+                            }
+                        ],
+                    },
+                    "answer_key": {"items": [{"index": 0, "correct": "а"}]},
+                    "provenance": {"source": "teacher-paste"},
+                    "system_prompt": "DO NOT LEAK",
+                    "rationale": "internal",
+                },
+                "answer_key": "1 — а",
+                "hint": "підказка для учня",
+            }
+        ],
+    }
+    adapted = adapt_lesson_json(lesson, slug="adapter-test")
+    write_adapted_module_dir(adapted, tmp_path / "mod")
+
+    module_md = (tmp_path / "mod" / "module.md").read_text(encoding="utf-8")
+    activities = (tmp_path / "mod" / "activities.yaml").read_text(encoding="utf-8")
+    meta = json.loads((tmp_path / "mod" / "hramatka_adapter_meta.json").read_text(encoding="utf-8"))
+
+    assert "Тестовий урок" in module_md
+    assert "Текст якоря для учнів" in module_md
+    assert "Оберіть відповідь" in module_md
+    assert "підказка для учня" in activities or "підказка для учня" in module_md
+
+    # Privacy / correctness exclusions
+    leaked = ("provenance", "system_prompt", "DO NOT LEAK", "teacher only note", "phone 099", "rationale")
+    blob = module_md + activities
+    for fragment in leaked:
+        assert fragment not in blob, f"internal field leaked: {fragment}"
+
+    assert "provenance" in adapted.excluded_keys_seen
+    assert "mark" in adapted.excluded_keys_seen
+    assert "phase" in adapted.excluded_keys_seen
+    assert adapted.level == "b1"
+    assert adapted.content_hash
+    assert meta["content_hash"] == adapted.content_hash
+    assert meta["rule_set"] == RULE_SET_ID
+
+
+def test_adapter_content_hash_stable() -> None:
+    lesson = {
+        "title": "Стабільний",
+        "level": "A2",
+        "anchor": {"text": "Ми вчимося."},
+        "blocks": [],
+    }
+    a = adapt_lesson_json(lesson, slug="stable")
+    b = adapt_lesson_json(lesson, slug="stable")
+    assert a.content_hash == b.content_hash
+    assert a.level == "a2"
+
+
+def test_harness_rule_set_dispatch_selects_hramatka(tmp_path: Path) -> None:
+    """Curriculum harness must route rule_set=hramatka to the separate module."""
+    lesson = {
+        "title": "Диспетчер",
+        "level": "B1",
+        "anchor": {"text": "Ми читаємо."},
+        "blocks": [
+            {
+                "type": "true-false",
+                "activity": {
+                    "type": "true-false",
+                    "title": "Правда",
+                    "payload": {
+                        "type": "true-false",
+                        "instruction": "Перевірте.",
+                        "items": [{"statement": "Ми читаємо.", "correct": True}],
+                    },
+                    "answer_key": {"items": [{"index": 0, "correct": True}]},
+                },
+                "answer_key": "1 П",
+            }
+        ],
+    }
+    adapted = adapt_lesson_json(lesson, slug="dispatch")
+    module_dir = tmp_path / "dispatch"
+    write_adapted_module_dir(adapted, module_dir)
+
+    evidence = scan_curriculum_module(
+        module_dir,
+        level="b1",
+        slug="dispatch",
+        rule_set="hramatka",
+    )
+    assert evidence["rule_set"] == RULE_SET_ID
+    assert evidence["schema_version"] == EVIDENCE_SCHEMA_VERSION
+    assert evidence["checker_config"]["version"] == CHECKER_VERSION
+    assert evidence["checker_config"]["config_hash"] == checker_config_hash()
+    assert evidence["verdict"] == "PASS"
+
+
+def test_harness_fixtures_cli_dispatches_hramatka_schema() -> None:
+    report = harness_run_fixtures(FIXTURE_FILE)
+    assert report["rule_set"] == RULE_SET_ID
+    assert report["summary"]["failed"] == 0
+
+
+def test_harness_cli_lesson_json(tmp_path: Path) -> None:
+    lesson_path = tmp_path / "lesson.json"
+    lesson_path.write_text(
+        json.dumps(
+            {
+                "title": "CLI урок",
+                "level": "B1",
+                "anchor": {"text": "Ми вчимося мови."},
+                "blocks": [
+                    {
+                        "type": "true-false",
+                        "activity": {
+                            "type": "true-false",
+                            "title": "Правда",
+                            "payload": {
+                                "type": "true-false",
+                                "instruction": "Перевірте.",
+                                "items": [{"statement": "Ми вчимося.", "correct": True}],
+                            },
+                            "answer_key": {"items": [{"index": 0, "correct": True}]},
+                        },
+                        "answer_key": "1 П",
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "out.json"
+    code = harness_main(
+        [
+            "--lesson-json",
+            str(lesson_path),
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ]
+    )
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["rule_set"] == RULE_SET_ID
+    assert payload["verdict"] == "PASS"
+
+
+def test_curriculum_phrase_rules_do_not_rubber_stamp_hramatka_faults(tmp_path: Path) -> None:
+    """Curriculum PHRASE_RULES must not be the gate for hramatka content.
+
+    A planted russianism that curriculum phrase rules never contain would PASS
+    under curriculum rules — proving why rule sets must stay separate.
+    """
+    lesson = {
+        "title": "Калибр",
+        "level": "B1",
+        "anchor": {"text": "Треба зделати роботу і приймати участь."},
+        "blocks": [
+            {
+                "type": "true-false",
+                "activity": {
+                    "type": "true-false",
+                    "title": "Правда",
+                    "payload": {
+                        "type": "true-false",
+                        "instruction": "Перевірте.",
+                        "items": [{"statement": "Треба зделати.", "correct": True}],
+                    },
+                    "answer_key": {"items": [{"index": 0, "correct": True}]},
+                },
+                "answer_key": "1 П",
+            }
+        ],
+    }
+    adapted = adapt_lesson_json(lesson, slug="calib")
+    module_dir = tmp_path / "calib"
+    write_adapted_module_dir(adapted, module_dir)
+
+    curriculum = scan_curriculum_module(module_dir, level="b1", slug="calib", rule_set="curriculum")
+    hramatka = scan_curriculum_module(module_dir, level="b1", slug="calib", rule_set="hramatka")
+
+    curriculum_issues = _issue_ids(curriculum)
+    # Curriculum PHRASE_RULES are writer-failure phrases — planted hramatka faults
+    # (зделати / приймати участь) are not among them.
+    assert "RUSSICISM_DETECTED" not in curriculum_issues
+    assert "RUSSIAN_SHADOW_RUSSICISM" not in curriculum_issues
+    assert "AWKWARD_PASSIVE_RESULT_STATE" not in curriculum_issues
+    # Hramatka rules must catch the planted fault.
+    assert hramatka["verdict"] == "FAIL"
+    assert "RUSSICISM_DETECTED" in _issue_ids(hramatka) or "RUSSIAN_SHADOW_RUSSICISM" in _issue_ids(
+        hramatka
+    )
+
+
+def test_scan_hramatka_lesson_direct() -> None:
+    evidence = scan_hramatka_lesson(
+        {
+            "title": "Прямий скан",
+            "level": "B1",
+            "anchor": {"text": "Ми говоримо українською."},
+            "blocks": [
+                {
+                    "type": "true-false",
+                    "activity": {
+                        "type": "true-false",
+                        "title": "Правда",
+                        "payload": {
+                            "type": "true-false",
+                            "instruction": "Перевірте.",
+                            "items": [{"statement": "Ми говоримо.", "correct": True}],
+                        },
+                        "answer_key": {"items": [{"index": 0, "correct": True}]},
+                    },
+                    "answer_key": "1 П",
+                }
+            ],
+        },
+        slug="direct",
+    )
+    assert evidence["verdict"] == "PASS"
+    assert evidence["rule_set"] == RULE_SET_ID
+
+
+def test_activity_kit_fixture_adapter_roundtrip() -> None:
+    """Adapter accepts the real activity-kit lesson shape without crashing."""
+    if not ACTIVITY_KIT_LESSON.exists():
+        return
+    lesson = json.loads(ACTIVITY_KIT_LESSON.read_text(encoding="utf-8"))
+    adapted = adapt_lesson_json(lesson)
+    assert adapted.title
+    assert adapted.level == "b1"
+    assert adapted.activities
+    assert "provenance" in adapted.excluded_keys_seen
+    # Must not leak teacher notes into module.md
+    assert "погляньте перед заняттям" not in adapted.module_md

--- a/tests/audit/test_hramatka_qg_rules.py
+++ b/tests/audit/test_hramatka_qg_rules.py
@@ -2,13 +2,23 @@
 
 Each check must FIRE on its planted known-bad fixture and a clean lesson must PASS.
 A green on a lesson carrying a planted fault is a test failure.
+
+DB-backed detectors (style_guide / PULS CEFR / ukrajinet / VESUM / heritage) are
+monkeypatched so CI's stripped sources.db cannot rubber-stamp or crash the suite.
+Follows the repo pattern used by textbook_grounding / ulif tests: mock the lookup,
+assert the gate behavior.
 """
 
 from __future__ import annotations
 
 import json
+import re
+import sqlite3
 from pathlib import Path
 
+import pytest
+
+from scripts.audit import hramatka_qg_rules as hq
 from scripts.audit.curriculum_qg_harness import main as harness_main
 from scripts.audit.curriculum_qg_harness import run_fixtures as harness_run_fixtures
 from scripts.audit.curriculum_qg_harness import scan_curriculum_module
@@ -29,6 +39,34 @@ FIXTURE_FILE = PROJECT_ROOT / "tests" / "fixtures" / "hramatka_qg" / "fixtures.y
 ACTIVITY_KIT_LESSON = (
     PROJECT_ROOT / "packages" / "activity-kit" / "src" / "fixtures" / "lu.lesson.v1.fixture.json"
 )
+SOURCES_DB = PROJECT_ROOT / "data" / "sources.db"
+
+# Planted non-forms / shadow forms that must stay VESUM-absent under mocks.
+_PLANTED_NON_VESUM = frozenset(
+    {
+        "зделати",
+        "жмурклея",
+        "ффффффф",
+        "кушати",  # russian-shadow in planted-russianism fixture
+    }
+)
+_PLANTED_RUSSIAN_SHADOW = frozenset({"зделати", "кушати"})
+# Fixture CEFR over-level token from planted-overlevel-task (чигати, with г).
+_OVERLEVEL_TOKEN = "чигати"
+_CEFR_OVERLEVEL = {_OVERLEVEL_TOKEN: "c1"}
+# Synonym pair planted in planted-bad-distractors.
+_SYNONYM_PAIRS: dict[str, set[str]] = {
+    "великий": {"видатний"},
+    "видатний": {"великий"},
+}
+
+# Real SQL helpers (captured before autouse mocks replace them).
+_REAL_ANTONENKO_TITLE_HIT = hq._antonenko_title_hit
+_REAL_CEFR_LEVEL_FOR = hq._cefr_level_for
+_REAL_SYNONYM_LEMMAS = hq._synonym_lemmas
+_REAL_SOURCES_CONN = hq._sources_conn
+
+_CYR_OK = re.compile(r"[а-яіїєґ'ʼ’\-]+", re.IGNORECASE)
 
 
 def _by_id(report: dict) -> dict[str, dict]:
@@ -37,6 +75,92 @@ def _by_id(report: dict) -> dict[str, dict]:
 
 def _issue_ids(evidence: dict) -> set[str]:
     return {f["issue_id"] for f in all_findings(evidence)}
+
+
+def _mock_vesum_hits(token: str) -> list[dict]:
+    key = token.casefold()
+    if key in _PLANTED_NON_VESUM:
+        return []
+    # Accept ordinary Cyrillic surface forms as real under the mock.
+    if _CYR_OK.fullmatch(key) and not re.fullmatch(r"ф+", key):
+        return [{"lemma": key, "pos": "unknown", "tags": "mock-vesum"}]
+    return []
+
+
+def _mock_classify_token(token: str) -> dict:
+    key = token.casefold()
+    if key in _PLANTED_RUSSIAN_SHADOW:
+        return {
+            "classification": "unknown",
+            "attestations": [],
+            "is_russianism": False,
+            "russian_shadow": True,
+            "vesum_attested": False,
+            "sovietization_risk": 0,
+            "calque_warning": {
+                "type": "russian_shadow_only",
+                "note": "mock planted russian-shadow",
+            },
+        }
+    if key == "жмурклея":
+        return {
+            "classification": "unknown",
+            "attestations": [],
+            "is_russianism": False,
+            "russian_shadow": False,
+            "vesum_attested": False,
+            "sovietization_risk": 0,
+            "calque_warning": None,
+        }
+    if _mock_vesum_hits(token):
+        return {
+            "classification": "standard",
+            "attestations": [{"source": "vesum", "ref": token}],
+            "is_russianism": False,
+            "russian_shadow": False,
+            "vesum_attested": True,
+            "sovietization_risk": 0,
+            "calque_warning": None,
+        }
+    return {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": False,
+        "russian_shadow": False,
+        "vesum_attested": False,
+        "sovietization_risk": 0,
+        "calque_warning": None,
+    }
+
+
+def _mock_cefr_level_for(word: str) -> str | None:
+    return _CEFR_OVERLEVEL.get(word.casefold())
+
+
+def _mock_synonym_lemmas(word: str) -> set[str]:
+    return set(_SYNONYM_PAIRS.get(word.casefold().strip(), set()))
+
+
+def _mock_antonenko_title_hit(text: str) -> list[str]:
+    folded = text.casefold()
+    if "приймати участь" in folded:
+        return ["Приймати участь – брати участь"]
+    return []
+
+
+@pytest.fixture(autouse=True)
+def _mock_sources_backed_detectors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deterministic DB-backed lookups for CI's stripped sources.db.
+
+    Keeps load-bearing planted-fault → FAIL assertions independent of which
+    tables the runner's sources.db actually contains. Structural / regex checks
+    (placeholders, cloze, MC, curated RUSSICISM_DETECTED) stay live.
+    """
+    monkeypatch.setattr(hq, "_vesum_hits", _mock_vesum_hits)
+    monkeypatch.setattr(hq, "_classify_token", _mock_classify_token)
+    monkeypatch.setattr(hq, "_cefr_level_for", _mock_cefr_level_for)
+    monkeypatch.setattr(hq, "_synonym_lemmas", _mock_synonym_lemmas)
+    monkeypatch.setattr(hq, "_antonenko_title_hit", _mock_antonenko_title_hit)
 
 
 def test_hramatka_fixture_suite_load_bearing() -> None:
@@ -362,3 +486,176 @@ def test_activity_kit_fixture_adapter_roundtrip() -> None:
     assert "provenance" in adapted.excluded_keys_seen
     # Must not leak teacher notes into module.md
     assert "погляньте перед заняттям" not in adapted.module_md
+
+
+def test_missing_style_guide_and_cefr_tables_do_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Simulate CI stripped sources.db: no style_guide / puls_cefr / ukrajinet.
+
+    Real SQL helpers hit the stripped DB and must mark detector_unavailable
+    without crashing. Load-bearing CEFR/synonym/VESUM mocks stay so planted
+    fixture assertions still hold deterministically.
+    """
+    stripped = tmp_path / "sources.db"
+    conn = sqlite3.connect(str(stripped))
+    conn.execute("CREATE TABLE unrelated (id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    def _stripped_conn():
+        c = sqlite3.connect(str(stripped))
+        c.row_factory = sqlite3.Row
+        return c
+
+    monkeypatch.setattr(hq, "_sources_conn", _stripped_conn)
+    # Exercise real SQL helpers against the stripped schema.
+    monkeypatch.setattr(hq, "_antonenko_title_hit", _REAL_ANTONENKO_TITLE_HIT)
+    # Keep CEFR + synonym mocks so load-bearing fixture expectations stay deterministic.
+    monkeypatch.setattr(hq, "_cefr_level_for", _mock_cefr_level_for)
+    monkeypatch.setattr(hq, "_synonym_lemmas", _mock_synonym_lemmas)
+
+    clean = scan_hramatka_lesson(
+        {
+            "title": "Чистий",
+            "level": "B1",
+            "anchor": {"text": "Ми вчимося мови."},
+            "blocks": [
+                {
+                    "type": "true-false",
+                    "activity": {
+                        "type": "true-false",
+                        "title": "Правда",
+                        "payload": {
+                            "type": "true-false",
+                            "instruction": "Перевірте.",
+                            "items": [{"statement": "Ми вчимося.", "correct": True}],
+                        },
+                        "answer_key": {"items": [{"index": 0, "correct": True}]},
+                    },
+                    "answer_key": "1 П",
+                }
+            ],
+        },
+        slug="stripped-clean",
+    )
+    assert clean["verdict"] == "PASS"
+    status = clean.get("detector_status") or {}
+    assert "antonenko_style_guide" in status
+    assert status["antonenko_style_guide"]["status"] == "detector_unavailable"
+    assert "no such table" in status["antonenko_style_guide"]["reason"].casefold()
+
+    # Real Antonenko SQL against stripped schema returns empty (no crash).
+    assert _REAL_ANTONENKO_TITLE_HIT("приймати участь у святі") == []
+    # CEFR mock still drives over-level fixture deterministically.
+    assert hq._cefr_level_for(_OVERLEVEL_TOKEN) == "c1"
+
+    report = run_fixtures(FIXTURE_FILE)
+    assert report["summary"]["failed"] == 0, {
+        row["id"]: row.get("missing_findings") or row.get("actual_verdict")
+        for row in report["results"]
+        if not row["passed"]
+    }
+    by_id = _by_id(report)
+    assert by_id["planted-russianism"]["actual_verdict"] == "FAIL"
+    assert by_id["planted-placeholder-key"]["actual_verdict"] == "FAIL"
+    assert by_id["planted-overlevel-task"]["actual_verdict"] == "WARN"
+    assert by_id["planted-bad-distractors"]["actual_verdict"] == "FAIL"
+    assert by_id["clean-b1-lesson"]["actual_verdict"] == "PASS"
+
+
+def test_stripped_cefr_and_synonym_tables_mark_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Real CEFR / synonym SQL against a table-less DB records detector_unavailable."""
+    stripped = tmp_path / "sources.db"
+    conn = sqlite3.connect(str(stripped))
+    conn.execute("CREATE TABLE unrelated (id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    def _stripped_conn():
+        c = sqlite3.connect(str(stripped))
+        c.row_factory = sqlite3.Row
+        return c
+
+    monkeypatch.setattr(hq, "_sources_conn", _stripped_conn)
+    monkeypatch.setattr(hq, "_cefr_level_for", _REAL_CEFR_LEVEL_FOR)
+    monkeypatch.setattr(hq, "_synonym_lemmas", _REAL_SYNONYM_LEMMAS)
+    monkeypatch.setattr(hq, "_antonenko_title_hit", _REAL_ANTONENKO_TITLE_HIT)
+
+    unavailable: dict[str, str] = {}
+    token = hq._ACTIVE_UNAVAILABLE.set(unavailable)
+    try:
+        assert hq._cefr_level_for("слово") is None
+        assert hq._synonym_lemmas("великий") == set()
+        assert hq._antonenko_title_hit("приймати участь") == []
+    finally:
+        hq._ACTIVE_UNAVAILABLE.reset(token)
+
+    assert "puls_cefr" in unavailable
+    assert "ukrajinet_synonyms" in unavailable
+    assert "antonenko_style_guide" in unavailable
+    for name in ("puls_cefr", "ukrajinet_synonyms", "antonenko_style_guide"):
+        assert "no such table" in unavailable[name].casefold()
+
+
+def _full_db_has_style_guide() -> bool:
+    if not SOURCES_DB.exists():
+        return False
+    try:
+        conn = sqlite3.connect(f"file:{SOURCES_DB}?mode=ro", uri=True)
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='style_guide' LIMIT 1"
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
+
+
+@pytest.mark.skipif(
+    not _full_db_has_style_guide(),
+    reason="full sources.db with style_guide not present (CI stripped build)",
+)
+def test_live_antonenko_smoke_when_full_db_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Optional live-data smoke: real style_guide detector when the full DB exists."""
+    monkeypatch.setattr(hq, "_sources_conn", _REAL_SOURCES_CONN)
+    monkeypatch.setattr(hq, "_antonenko_title_hit", _REAL_ANTONENKO_TITLE_HIT)
+
+    hits = hq._antonenko_title_hit("Студенти хочуть приймати участь у святі.")
+    assert hits, "full style_guide should flag 'приймати участь'"
+
+    evidence = scan_hramatka_lesson(
+        {
+            "title": "Участь",
+            "level": "B1",
+            "anchor": {"text": "Студенти хочуть приймати участь у святі."},
+            "blocks": [
+                {
+                    "type": "true-false",
+                    "activity": {
+                        "type": "true-false",
+                        "title": "Правда",
+                        "payload": {
+                            "type": "true-false",
+                            "instruction": "Перевірте.",
+                            "items": [{"statement": "Вони хочуть приймати участь.", "correct": True}],
+                        },
+                        "answer_key": {"items": [{"index": 0, "correct": True}]},
+                    },
+                    "answer_key": "1 П",
+                }
+            ],
+        },
+        slug="live-antonenko-smoke",
+    )
+    # Live style_guide / curated regex fire as warnings; terminal may be WARN or FAIL.
+    assert evidence["verdict"] in {"WARN", "FAIL"}
+    issues = _issue_ids(evidence)
+    assert "RUSSICISM_DETECTED" in issues or "ANTONENKO_CALQUE" in issues
+    assert "ANTONENKO_CALQUE" in issues, "live style_guide must surface ANTONENKO_CALQUE"

--- a/tests/fixtures/hramatka_qg/fixtures.yaml
+++ b/tests/fixtures/hramatka_qg/fixtures.yaml
@@ -1,0 +1,364 @@
+schema_version: hramatka_ua_qg_fixtures.v1
+rule_set: hramatka
+fixtures:
+  # Clean lesson — every check must stay quiet (PASS).
+  - id: clean-b1-lesson
+    level: b1
+    slug: clean-b1-lesson
+    expected_verdict: PASS
+    lesson_json:
+      title: Квартира біля парку
+      level: B1
+      anchor:
+        text: >
+          Ми шукали квартиру біля парку. Перша квартира була світла й тепла.
+          Друга була дешевша, але темна. Ми обрали третю — вона менша, зате ближча до центру.
+      blocks:
+        - type: true-false
+          activity:
+            type: true-false
+            title: Правда чи ні
+            payload:
+              type: true-false
+              instruction: Перевірте за текстом.
+              items:
+                - statement: Вони шукали квартиру біля парку.
+                  correct: true
+                - statement: Перша квартира була темна.
+                  correct: false
+            answer_key:
+              items:
+                - index: 0
+                  correct: true
+                - index: 1
+                  correct: false
+          answer_key: "1 П · 2 Н"
+        - type: multiple-choice
+          activity:
+            type: multiple-choice
+            title: Оберіть відповідь
+            payload:
+              type: multiple-choice
+              instruction: Оберіть відповідь.
+              items:
+                - prompt: Де була квартира?
+                  options:
+                    - а) біля парку
+                    - б) біля моря
+                    - в) за містом
+            answer_key:
+              items:
+                - index: 0
+                  correct: а
+          answer_key: "1 — а"
+        - type: cloze
+          activity:
+            type: cloze
+            title: Вставте слово
+            payload:
+              type: cloze
+              instruction: Вставте слово.
+              text: "Нова квартира [___:1], ніж стара."
+              blanks:
+                - id: 1
+                  answer: менша
+            answer_key:
+              blanks:
+                - id: 1
+                  answer: менша
+          answer_key: "1 менша"
+
+  # Planted russianism / calque (curated regex + Antonenko).
+  - id: planted-russianism
+    level: b1
+    slug: planted-russianism
+    expected_verdict: FAIL
+    lesson_json:
+      title: Участь у святі
+      level: B1
+      anchor:
+        text: Студенти хочуть приймати участь у святі і кушати борщ.
+      blocks:
+        - type: true-false
+          activity:
+            type: true-false
+            title: Перевірка
+            payload:
+              type: true-false
+              instruction: Перевірте речення.
+              items:
+                - statement: Вони хочуть приймати участь.
+                  correct: true
+            answer_key:
+              items:
+                - index: 0
+                  correct: true
+          answer_key: "1 П"
+    expected_findings:
+      - issue_id: RUSSICISM_DETECTED
+        excerpt: приймати участь
+        dimension: russianism_calque
+
+  # Russian-shadow + non-VESUM (not heritage) → RUSSIAN_SHADOW_RUSSICISM
+  - id: planted-russian-shadow
+    level: b1
+    slug: planted-russian-shadow
+    expected_verdict: FAIL
+    lesson_json:
+      title: Тінь форми
+      level: B1
+      anchor:
+        text: Треба зделати роботу швидко.
+      blocks:
+        - type: true-false
+          activity:
+            type: true-false
+            title: Перевірка
+            payload:
+              type: true-false
+              instruction: Прочитайте речення.
+              items:
+                - statement: Треба зделати роботу.
+                  correct: true
+            answer_key:
+              items:
+                - index: 0
+                  correct: true
+          answer_key: "1 П"
+    expected_findings:
+      - issue_id: RUSSIAN_SHADOW_RUSSICISM
+        excerpt: зделати
+        dimension: russianism_calque
+        severity: critical
+
+  # Non-word distractor + synonym collision.
+  - id: planted-bad-distractors
+    level: b1
+    slug: planted-bad-distractors
+    expected_verdict: FAIL
+    lesson_json:
+      title: Відволікачі
+      level: B1
+      anchor:
+        text: Великий дім стоїть біля річки.
+      blocks:
+        - type: multiple-choice
+          activity:
+            type: multiple-choice
+            title: Оберіть слово
+            payload:
+              type: multiple-choice
+              instruction: Оберіть правильне слово.
+              items:
+                - prompt: Який дім?
+                  options:
+                    - а) великий
+                    - б) видатний
+                    - в) ффффффф
+            answer_key:
+              items:
+                - index: 0
+                  correct: а
+          answer_key: "1 — а"
+    expected_findings:
+      - issue_id: SYNONYM_DISTRACTOR
+        excerpt: видатний
+        dimension: distractor_quality
+        severity: critical
+      - issue_id: NON_VESUM_DISTRACTOR
+        excerpt: ффффффф
+        dimension: distractor_quality
+        severity: critical
+
+  # Placeholder answer key.
+  - id: planted-placeholder-key
+    level: b1
+    slug: planted-placeholder-key
+    expected_verdict: FAIL
+    lesson_json:
+      title: Порожня відповідь
+      level: B1
+      anchor:
+        text: Ми читаємо текст.
+      blocks:
+        - type: multiple-choice
+          activity:
+            type: multiple-choice
+            title: Питання
+            payload:
+              type: multiple-choice
+              instruction: Оберіть відповідь.
+              items:
+                - prompt: Що ми робимо?
+                  options:
+                    - а) читаємо
+                    - б) пишемо
+            answer_key: TODO
+          answer_key: TODO
+    expected_findings:
+      - issue_id: ANSWER_KEY_PLACEHOLDER
+        excerpt: TODO
+        dimension: answer_key_integrity
+        severity: critical
+
+  # Broken cloze blank count.
+  - id: planted-broken-cloze
+    level: b1
+    slug: planted-broken-cloze
+    expected_verdict: FAIL
+    lesson_json:
+      title: Дірка в клозе
+      level: B1
+      anchor:
+        text: Кіт сидить на вікні.
+      blocks:
+        - type: cloze
+          activity:
+            type: cloze
+            title: Вставте
+            payload:
+              type: cloze
+              instruction: Вставте слова.
+              text: "Кіт [___:1] на [___:2]."
+              blanks:
+                - id: 1
+                  answer: сидить
+                - id: 2
+                  answer: вікні
+            answer_key:
+              blanks:
+                - id: 1
+                  answer: сидить
+          answer_key: "1 сидить"
+    expected_findings:
+      - issue_id: CLOZE_BLANK_MISMATCH
+        excerpt: "blanks=2 answers=1"
+        dimension: activity_structure
+        severity: critical
+
+  # Over-level task word (A1 lesson, C1 task verb).
+  - id: planted-overlevel-task
+    level: a1
+    slug: planted-overlevel-task
+    expected_verdict: WARN
+    lesson_json:
+      title: Просте завдання
+      level: A1
+      anchor:
+        text: Я їм хліб.
+      blocks:
+        - type: true-false
+          activity:
+            type: true-false
+            title: Перевірка
+            payload:
+              type: true-false
+              instruction: Чи можна чигати за дверима?
+              items:
+                - statement: Я їм хліб.
+                  correct: true
+            answer_key:
+              items:
+                - index: 0
+                  correct: true
+          answer_key: "1 П"
+    expected_findings:
+      - issue_id: TASK_CEFR_OVERLEVEL
+        excerpt: чигати
+        dimension: task_cefr
+        severity: warning
+
+  # Invented non-VESUM form (not russian-shadow, not heritage).
+  - id: planted-invented-form
+    level: b1
+    slug: planted-invented-form
+    expected_verdict: WARN
+    lesson_json:
+      title: Вигадана форма
+      level: B1
+      anchor:
+        text: У місті з'явилася нова жмурклея біля річки.
+      blocks:
+        - type: true-false
+          activity:
+            type: true-false
+            title: Перевірка
+            payload:
+              type: true-false
+              instruction: Прочитайте речення.
+              items:
+                - statement: У місті є жмурклея.
+                  correct: true
+            answer_key:
+              items:
+                - index: 0
+                  correct: true
+          answer_key: "1 П"
+    expected_findings:
+      - issue_id: NON_VESUM_FORM
+        excerpt: жмурклея
+        dimension: invented_form
+        severity: warning
+
+  # Empty learner surface (blank title).
+  - id: planted-empty-surface
+    level: b1
+    slug: planted-empty-surface
+    expected_verdict: FAIL
+    lesson_json:
+      title: "   "
+      level: B1
+      anchor:
+        text: Текст уроку є.
+      blocks:
+        - type: true-false
+          activity:
+            type: true-false
+            title: ""
+            payload:
+              type: true-false
+              instruction: ""
+              items:
+                - statement: ""
+                  correct: true
+            answer_key:
+              items:
+                - index: 0
+                  correct: true
+          answer_key: "1 П"
+    expected_findings:
+      - issue_id: EMPTY_LEARNER_SURFACE
+        dimension: learner_surface
+        severity: critical
+
+  # MC with fewer than 2 options.
+  - id: planted-mc-too-few
+    level: b1
+    slug: planted-mc-too-few
+    expected_verdict: FAIL
+    lesson_json:
+      title: Мало варіантів
+      level: B1
+      anchor:
+        text: Ми вчимо мову.
+      blocks:
+        - type: multiple-choice
+          activity:
+            type: multiple-choice
+            title: Питання
+            payload:
+              type: multiple-choice
+              instruction: Оберіть.
+              items:
+                - prompt: Що ми робимо?
+                  options:
+                    - а) вчимо
+            answer_key:
+              items:
+                - index: 0
+                  correct: а
+          answer_key: "1 — а"
+    expected_findings:
+      - issue_id: MC_TOO_FEW_OPTIONS
+        dimension: activity_structure
+        severity: critical


### PR DESCRIPTION
## Summary

Makes the curriculum QG harness **load-bearing for hramatka lessons** by shipping a **separate selectable rule set** (never merged with curriculum-writer `PHRASE_RULES`) plus a field-disciplined `lesson_json → module-dir` adapter.

Triggered by #5187 feedback: hramatka pilots (Львів/Борщ/вареники) rubber-stamped PASS with 0 findings because `PHRASE_RULES` are curriculum-writer failure phrases that hramatka content never contains.

### Architecture (do not deviate)
- **New** `scripts/audit/hramatka_qg_rules.py` — separate rule set
- **Wired** into `curriculum_qg_harness.py` via `--rule-set {curriculum,hramatka}` and `--lesson-json`
- Calls **local Python APIs only** (`check_russicisms`, `heritage_classifier`, VESUM, sources.db) — no MCP shell-outs
- `heritage_classifier` always overrides; russian-shadow is a signal, never sole decider

### Tier-1 checks
1. **Russianism/surzhyk/calque** — curated regex + multi-word UA-GEC + Antonenko multi-word titles + VESUM-absent∧russian-shadow∧¬heritage
2. **Invalid distractor** — VESUM form · distinct · non-duplicate · synonym collision
3. **Answer-key placeholder** — empty / TODO / XXX / whole-value ellipsis

### Tier-2 checks
4. Structural activity integrity (cloze blank count, MC ≥2 options, match-up cardinality, empty items)
5. Empty learner surface (title/instruction/statement)
6. Task-language CEFR (instructions/items only; ≥2 bands over lesson)
7. Invented form (`NON_VESUM_FORM`)

### Adapter (#5187)
KEEP: title, level, anchor.text, activity, answer_key, hint/explanation  
EXCLUDE: provenance, mark, phase, teacher notes, system-prompt, rationale, metadata  
Canonical serialization + content hash.

### Calibration (load-bearing proof)
Synthetic known-bad fixtures under `tests/fixtures/hramatka_qg/fixtures.yaml` — a green on a planted fault is a test failure. Real hramatka known-bad lessons: hand-off still open with hramatka lane when next soak retains failures.

## M-4 evidence (each check fires + clean PASS)

| Check | Fixture | Excerpt / signal | Verdict |
| --- | --- | --- | --- |
| clean baseline | `clean-b1-lesson` | 0 findings | **PASS** |
| RUSSICISM_DETECTED | `planted-russianism` | `приймати участь` / `кушати` | FAIL |
| RUSSIAN_SHADOW_RUSSICISM | `planted-russian-shadow` | `зделати` | FAIL |
| NON_VESUM_DISTRACTOR | `planted-bad-distractors` | `ффффффф` | FAIL |
| SYNONYM_DISTRACTOR | `planted-bad-distractors` | `видатний` ≈ `великий` | FAIL |
| ANSWER_KEY_PLACEHOLDER | `planted-placeholder-key` | `TODO` | FAIL |
| CLOZE_BLANK_MISMATCH | `planted-broken-cloze` | blanks=2 answers=1 | FAIL |
| TASK_CEFR_OVERLEVEL | `planted-overlevel-task` | `чигати` C1 on A1 | WARN |
| NON_VESUM_FORM | `planted-invented-form` | `жмурклея` | WARN |
| EMPTY_LEARNER_SURFACE | `planted-empty-surface` | blank title | FAIL |
| MC_TOO_FEW_OPTIONS | `planted-mc-too-few` | 1 option | FAIL |

Also: curriculum `rule_set` does **not** catch planted `зделати`/`приймати участь` (rubber-stamp proof); hramatka rules do.

## Usage

```bash
# Hramatka fixtures (load-bearing)
.venv/bin/python scripts/audit/curriculum_qg_harness.py \
  --fixtures tests/fixtures/hramatka_qg/fixtures.yaml

# Lesson JSON
.venv/bin/python scripts/audit/curriculum_qg_harness.py \
  --lesson-json path/to/lesson.json --format json

# Module dir with hramatka rules
.venv/bin/python scripts/audit/curriculum_qg_harness.py \
  --module-dir path/to/adapted --level b1 --rule-set hramatka
```

## Test plan
- [x] `pytest tests/audit/test_hramatka_qg_rules.py tests/audit/test_curriculum_qg_harness.py` (16 passed)
- [x] `ruff check` on changed files
- [x] CLI `--fixtures tests/fixtures/hramatka_qg/fixtures.yaml` → 10/10
- [x] `lint_agent_trailer.py` PASS
- [ ] Cross-family review (agy/codex) — **no auto-merge**

## Out of scope / follow-ups
- Wire **real** hramatka known-bad soak lessons when retained (coordinate hramatka lane)
- LLM judge for accidentally-also-correct distractors / pedagogical fit (explicitly deferred)