### PR TITLE
refactor(launcher): start Codex from canonical main

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -24,17 +24,22 @@ Project-local wrappers for interactive agent sessions:
 `start-codex.sh` launches Codex with:
 
 - interactive Codex in dangerous bypass mode
+- live web search and multi-agent support enabled
 - `CODEX_SESSION=1` so repo scripts can detect an interactive Codex session
-- default target `worktree`, with `--main` or `CODEX_TARGET=main` available when Codex must work directly in the primary main checkout
+- the canonical `main` checkout as its working root; the launcher does not create or refresh a detached interactive worktree
+- generated Codex config and rollover state bootstrapped before launch
 - repo subprocess defaults unchanged unless you explicitly override env vars
 
 Override before launch if needed:
 
 ```bash
 CODEX_DISPATCH_MODE=workspace-write CODEX_BRIDGE_MODE=safe ./start-codex.sh
-./start-codex.sh --main
-CODEX_TARGET=main ./start-codex.sh
 ```
+
+Implementation work still follows `AGENTS.md`: create a scoped dispatch
+worktree instead of editing or committing from the primary checkout. The
+launcher also sets `GIT_OPTIONAL_LOCKS=0` so read-oriented Git commands do not
+refresh the primary index unnecessarily.
 
 ---
 

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -52,7 +52,7 @@ rate-limit headroom checks, mode validation, cwd enforcement.
 ## Session resume policy — the rule that matters
 
 | Path | Resume? | Why |
-|---|---|---|
+| --- | --- | --- |
 | Your interactive Claude Code | not affected by runtime | Keep `--continue`, handoffs, etc. The runtime doesn't touch your session. |
 | Bridge `_claude.py` / `_gemini.py` | **yes** | Cache economics — 95% of our tokens are cache reads. Dropping resume here would reproduce the 2026-03-21 cost fiasco (5.8B tokens in 2 days, rate-limited for a week). |
 | Bridge `_codex.py` | **no** | Codex quota is per-message, not per-token. Resume saves nothing. And cross-worktree session carry-over is the #1 footgun (Codex's own warning, msg #28506). |
@@ -70,7 +70,7 @@ If you need to change this policy, edit `registry.py`, not the call site.
 Three modes, same meaning across all adapters:
 
 | Mode | Meaning | Typical use |
-|---|---|---|
+| --- | --- | --- |
 | `read-only` | CLI runs with read-only filesystem sandbox | Consultation, questions, reviews |
 | `workspace-write` | CLI can write files in cwd | Coding tasks, refactors, batch fixes |
 | `danger` | Sandbox bypassed entirely | Only when explicitly needed (e.g., setup scripts) |
@@ -177,7 +177,7 @@ provider/model substitution is forbidden.
 v1 adapter coverage:
 
 | Lane | Route override support |
-|---|---|
+| --- | --- |
 | `deepseek`, `qwen`, `grok` | Hermes provider + model via runner route metadata and `--provider` when forced. |
 | `agy` | Model override through the existing `--model` mapping; provider is informational unless encoded by the CLI model label. |
 | Other adapters | Model-only chains work when the adapter's existing `model` argument can express the route. |
@@ -192,7 +192,7 @@ private git worktree so its writes are isolated from the main checkout.
 Two layouts are currently supported:
 
 | Layout | Path | Status | Triggered by |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | **dispatch subtree** (new) | `.worktrees/dispatch/{agent}/{task}/` | **default** for new dispatches | `--worktree` (bare, no path) |
 | flat (legacy) | `.worktrees/{agent}-{task}/` | deprecated, still accepted | `--worktree <explicit-path>` under `.worktrees/` |
 | custom | anywhere you point it | accepted | `--worktree <explicit-path>` anywhere |
@@ -200,12 +200,11 @@ Two layouts are currently supported:
 `delegate.py list` and `delegate.py status` print a deprecation notice
 when they encounter a flat-layout worktree.
 
-Two non-dispatch worktrees live alongside these and are **out of scope**
-for delegate lifecycle — don't prune or rename:
-- `.worktrees/codex-interactive/` — the persistent interactive session
-  from `start-codex.sh` (detached HEAD, symlinks to `.venv`, `data/`,
-  `starlight/node_modules`).
-- Any operator-created `.worktrees/*` that predates the dispatch layout.
+Operator-created non-dispatch worktrees may live alongside these and are **out
+of scope** for delegate lifecycle; do not prune or rename them without proving
+ownership. `start-codex.sh` itself runs from the canonical `main` checkout and
+does not own a persistent worktree. Legacy `.worktrees/codex-interactive/`
+checkouts remain protected as operator-created state until explicitly removed.
 
 ### Stale-base safety (the actual #1476 bug)
 
@@ -244,7 +243,7 @@ Task-ids that already include the agent name (our common convention:
 normalizer strips a leading `{agent}-` or `{agent}/` before prefixing:
 
 | Agent | Task-id | Branch |
-|---|---|---|
+| --- | --- | --- |
 | codex | `codex-1472-foo` | `codex/1472-foo` |
 | codex | `codex/1472-foo` | `codex/1472-foo` |
 | codex | `1472-foo` | `codex/1472-foo` |

--- a/scripts/audit/test_deploy_extensions.sh
+++ b/scripts/audit/test_deploy_extensions.sh
@@ -74,21 +74,29 @@ out="$(deploy_agent_extensions "$WORK_DIR/empty" agents:deploy)" \
 contains "$out" "not found" "missing package.json warns instead of failing"
 
 # --- launchers actually use the helper (regression guard on the wiring) ---
-for launcher in start-claude.sh; do
-  grep -q 'deploy_extensions.sh' "$REPO_ROOT/$launcher" \
-    || fail "$launcher no longer sources deploy_extensions.sh"
-  grep -q 'deploy_agent_extensions' "$REPO_ROOT/$launcher" \
-    || fail "$launcher no longer calls deploy_agent_extensions"
-  # ^[^#]* keeps the guard from false-positiving on comments that merely
-  # describe the old pattern (deepseek review recommendation, PR #4843).
-  if grep -E '^[^#]*npm run [a-z:]*deploy.*(\|\| true|2>/dev/null)' "$REPO_ROOT/$launcher" >/dev/null; then
-    fail "$launcher reintroduced a fail-silent npm deploy"
-  fi
-done
+launcher=start-claude.sh
+grep -q 'deploy_extensions.sh' "$REPO_ROOT/$launcher" \
+  || fail "$launcher no longer sources deploy_extensions.sh"
+grep -q 'deploy_agent_extensions' "$REPO_ROOT/$launcher" \
+  || fail "$launcher no longer calls deploy_agent_extensions"
+# ^[^#]* keeps the guard from false-positiving on comments that merely
+# describe the old pattern (deepseek review recommendation, PR #4843).
+if grep -E '^[^#]*npm run [a-z:]*deploy.*(\|\| true|2>/dev/null)' "$REPO_ROOT/$launcher" >/dev/null; then
+  fail "$launcher reintroduced a fail-silent npm deploy"
+fi
 
 grep -q 'thread_rollover_link.sh' "$REPO_ROOT/start-codex.sh" \
   || fail "start-codex.sh no longer sources the Codex checkout bootstrap"
 grep -q 'bootstrap_codex_checkout' "$REPO_ROOT/start-codex.sh" \
   || fail "start-codex.sh no longer bootstraps the target checkout"
+grep -q -- '--git-common-dir' "$REPO_ROOT/start-codex.sh" \
+  || fail "start-codex.sh no longer resolves the canonical checkout"
+grep -q 'branch --show-current' "$REPO_ROOT/start-codex.sh" \
+  || fail "start-codex.sh no longer requires canonical main"
+grep -q 'GIT_OPTIONAL_LOCKS=0' "$REPO_ROOT/start-codex.sh" \
+  || fail "start-codex.sh no longer suppresses optional primary-index locks"
+if grep -Eq 'codex-interactive|git worktree add|checkout --detach' "$REPO_ROOT/start-codex.sh"; then
+  fail "start-codex.sh reintroduced a detached interactive worktree"
+fi
 
 echo "ok - deploy extensions fixtures passed"

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -1,185 +1,36 @@
 #!/bin/bash
-# Learn Ukrainian - Codex Wrapper
-# Default: starts Codex in a dedicated git worktree so it has its own
-# .git/index and never races with another agent on git locks.
-# Optional: pass --main (or set CODEX_TARGET=main) to run in the repository's
-# primary main checkout instead when Codex needs to take over that workspace.
+# Launch interactive Codex from the repository's canonical main checkout.
 
-set -e
+set -euo pipefail
 
-# shellcheck source=scripts/lib/thread_rollover_link.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/lib/thread_rollover_link.sh"
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:${PATH:-}"
+# Avoid optional index refresh locks while the primary checkout is used for
+# orientation. Task writes still belong in scoped dispatch worktrees.
+export GIT_OPTIONAL_LOCKS=0
 
-# Ensure common local bin paths are available
-export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
-hash -r 2>/dev/null || true
-
-# Get the checkout containing this script, then resolve the repository's
-# primary main checkout so the launcher behaves consistently from any worktree.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$SCRIPT_DIR"
-CODEX_TARGET="${CODEX_TARGET:-worktree}"
-CODEX_ARGS=()
-CODEX_FLAGS=(--dangerously-bypass-approvals-and-sandbox --search)
+GIT_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir)"
+PROJECT_DIR="$(dirname "$GIT_COMMON_DIR")"
 
-if [ "${CODEX_ENABLE_MULTI_AGENT:-1}" != "0" ]; then
-    CODEX_FLAGS+=(--enable multi_agent)
-fi
-
-while [ "$#" -gt 0 ]; do
-    case "$1" in
-        --help-wrapper)
-            cat <<'EOF'
-Usage: ./start-codex.sh [--main|--worktree] [codex args...]
-
-Learn Ukrainian Codex launcher:
- - runs Codex in .worktrees/codex-interactive by default
- - use --main only when intentionally running in the primary checkout
- - always adds --dangerously-bypass-approvals-and-sandbox
- - always adds --search (live web search; user-policy 2026-05-08)
- - enables Codex multi-agent support by default
- - set CODEX_ENABLE_MULTI_AGENT=0 to disable multi-agent support
- - forwards all other arguments to codex unchanged
-EOF
-            exit 0
-            ;;
-        --main)
-            CODEX_TARGET="main"
-            shift
-            ;;
-        --worktree)
-            CODEX_TARGET="worktree"
-            shift
-            ;;
-        *)
-            CODEX_ARGS+=("$1")
-            shift
-            ;;
-    esac
-done
-
-case "$CODEX_TARGET" in
-    main|worktree)
-        ;;
-    *)
-        echo "Error: CODEX_TARGET must be 'main' or 'worktree' (got '$CODEX_TARGET')"
-        exit 1
-        ;;
-esac
-
-echo "Starting Codex in Learn Ukrainian project..."
-echo "Launcher checkout: $SCRIPT_DIR"
-
-echo "Preflight check..."
-MISSING_TOOLS=""
-for tool in git gh codex; do
-    if ! command -v "$tool" &> /dev/null; then
-        MISSING_TOOLS="$MISSING_TOOLS $tool"
-    fi
-done
-
-if [ -n "$MISSING_TOOLS" ]; then
-    echo "Error: Required tools not found:$MISSING_TOOLS"
+if [ "$(git -C "$PROJECT_DIR" branch --show-current)" != "main" ]; then
+    printf 'Error: canonical checkout must be on main: %s\n' "$PROJECT_DIR" >&2
     exit 1
 fi
 
-if git -C "$SCRIPT_DIR" rev-parse --git-dir > /dev/null 2>&1; then
-    MAIN_WORKTREE_DIR=$(
-        git -C "$SCRIPT_DIR" worktree list --porcelain | awk '
-            $1 == "worktree" { path = $2 }
-            $1 == "branch" && $2 == "refs/heads/main" { print path; exit }
-        '
-    )
-    if [ -n "$MAIN_WORKTREE_DIR" ]; then
-        PROJECT_DIR="$MAIN_WORKTREE_DIR"
-    fi
-fi
+# Keep generated Codex config and the canonical rollover state ready before
+# replacing this wrapper process with the interactive CLI.
+# PROJECT_DIR is resolved dynamically.
+# shellcheck disable=SC1091
+source "$PROJECT_DIR/scripts/lib/thread_rollover_link.sh"
+bootstrap_codex_checkout "$PROJECT_DIR" "$PROJECT_DIR" continue
 
-WORKTREE_DIR="$PROJECT_DIR/.worktrees/codex-interactive"
-
-echo "Project root: $PROJECT_DIR"
-echo "Target checkout: $CODEX_TARGET"
-
-cd "$PROJECT_DIR"
-
-if git rev-parse --git-dir > /dev/null 2>&1; then
-    CURRENT_BRANCH=$(git branch --show-current)
-    echo "Primary checkout branch: $CURRENT_BRANCH"
-fi
-
-TARGET_DIR="$PROJECT_DIR"
-
-if [ "$CODEX_TARGET" = "worktree" ]; then
-    # ── Worktree setup ──────────────────────────────────────────────
-    # Creates a linked worktree at .worktrees/codex-interactive/ that
-    # shares the same git objects but has its OWN index file. This means
-    # Codex can run git status/add/commit freely without creating
-    # .git/index.lock races with other agents in the main checkout.
-    #
-    # The worktree tracks the same branch (main) and stays up to date
-    # via a detached checkout before each launch.
-    if [ ! -d "$WORKTREE_DIR" ]; then
-        echo "Creating Codex worktree at $WORKTREE_DIR..."
-        git worktree add "$WORKTREE_DIR" HEAD --detach
-        echo "Worktree created."
-    else
-        echo "Codex worktree exists at $WORKTREE_DIR"
-        cd "$WORKTREE_DIR"
-        git checkout --detach origin/main 2>/dev/null || git checkout --detach HEAD
-        cd "$PROJECT_DIR"
-        echo "Worktree updated to latest."
-    fi
-
-    # Symlink node_modules so npm/vitest work
-    if [ -d "$PROJECT_DIR/site/node_modules" ] && [ ! -e "$WORKTREE_DIR/site/node_modules" ]; then
-        mkdir -p "$WORKTREE_DIR/site"
-        ln -s "$PROJECT_DIR/site/node_modules" "$WORKTREE_DIR/site/node_modules"
-        echo "Symlinked site/node_modules into worktree"
-    fi
-
-    # Symlink data/ (sources.db, vesum.db) so MCP tools work
-    if [ ! -e "$WORKTREE_DIR/data" ]; then
-        ln -s "$PROJECT_DIR/data" "$WORKTREE_DIR/data"
-        echo "Symlinked data/ into worktree"
-    fi
-
-    TARGET_DIR="$WORKTREE_DIR"
-fi
-
-# Bootstrap the checkout Codex will actually use. The helper shares only the
-# canonical virtualenv and gitignored rollover directory, then deploys the
-# generated hook/config targets. It is also the supported seam for app-created
-# fresh worktrees, which do not inherit ignored .codex files.
-bootstrap_codex_checkout "$PROJECT_DIR" "$TARGET_DIR" continue
-echo "Verified Codex runtime bootstrap in $TARGET_DIR"
-
-echo ""
-echo "LEARN UKRAINIAN - Ukrainian Language Learning"
-echo ""
-if [ "$CODEX_TARGET" = "worktree" ]; then
-    echo "   Codex runs in worktree: $WORKTREE_DIR"
-    echo "   This isolates git operations from the main checkout."
-    echo "   Any commits Codex makes stay in the worktree until you merge them."
-    echo ""
-    echo "   To pull latest from main into the worktree:"
-    echo "       cd $WORKTREE_DIR && git checkout --detach origin/main"
-    echo ""
-    echo "   To clean up the worktree when done:"
-    echo "       git worktree remove $WORKTREE_DIR"
-else
-    echo "   Codex runs in the main checkout: $PROJECT_DIR"
-    echo "   Use this when Codex needs to continue work directly in main."
-    echo "   Git operations here are not isolated from other agents."
-fi
-echo ""
-if [ "${CODEX_ENABLE_MULTI_AGENT:-1}" != "0" ]; then
-    echo "   Multi-agent: enabled"
-else
-    echo "   Multi-agent: disabled"
-fi
-echo ""
-
-echo "Launching Codex in $CODEX_TARGET checkout..."
 export CODEX_SESSION=1
 export CODEX_CANONICAL_REPO_ROOT="$PROJECT_DIR"
-codex "${CODEX_FLAGS[@]}" -C "$TARGET_DIR" "${CODEX_ARGS[@]}"
+
+printf 'Starting Codex in %s\n' "$PROJECT_DIR"
+exec codex \
+    --dangerously-bypass-approvals-and-sandbox \
+    --search \
+    --enable multi_agent \
+    -C "$PROJECT_DIR" \
+    "$@"


### PR DESCRIPTION
## Summary

- launch interactive Codex from the canonical `main` checkout instead of creating or refreshing `.worktrees/codex-interactive`
- shrink `start-codex.sh` from 185 to 36 lines while retaining runtime bootstrap, live search, full-access mode, and multi-agent support
- set `GIT_OPTIONAL_LOCKS=0` for read-oriented main-checkout commands and keep task writes in scoped dispatch worktrees
- update current launcher/worktree docs and make canonical-main/no-detached behavior load-bearing in the deploy fixture

## Verification

- `shellcheck start-codex.sh`
- `shellcheck -x scripts/audit/test_deploy_extensions.sh`
- `bash -n start-codex.sh scripts/audit/test_deploy_extensions.sh`
- `.venv/bin/python -m pytest tests/test_deploy_extensions.py tests/test_handoff_identity.py -q` — 2 passed
- `markdownlint-cli2 docs/SCRIPTS.md docs/agent-runtime-guide.md` — 0 errors
- launcher smoke with a fake Codex executable — `-C /Users/krisztiankoos/projects/learn-ukrainian`, no worktree creation
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — PASS

## Independent review

- Claude Sonnet task `review-start-codex-primary-precommit` identified the optional-index-lock mitigation and two documentation/test hardening points; all were applied
- DeepSeek v4 Flash task `review-start-codex-primary-precommit-r2` reviewed the final exact diff: APPROVE, 0 bugs, 0 regressions, 0 documentation mismatches

Refs #4707