### PR TITLE
test(qg): prove production shadow invariants

### DIFF
--- a/tests/audit/test_qg_shadow_run.py
+++ b/tests/audit/test_qg_shadow_run.py
@@ -102,6 +102,49 @@ def test_shadow_driver_captures_lifecycle_and_advisory_verdicts(tmp_path: Path) 
     assert _count(tmp_path / "shadow.db", "llm_qg_shadow_findings") == len(report["records"])
 
 
+def test_shadow_driver_threads_writer_family_from_module_metadata(tmp_path: Path) -> None:
+    module_dir = _module(tmp_path)
+    (module_dir / "writer_meta.json").write_text('{"writer_family": "anthropic"}\n', encoding="utf-8")
+
+    result = qg_shadow_run.run_shadow_module(
+        _target(module_dir),
+        audit_dir=tmp_path / "audit",
+        shadow_db=tmp_path / "shadow.db",
+        reviewer=_dispatch,
+        live_reviewer=False,
+        reviewer_model_id="test-reviewer",
+        reviewer_family="test-family",
+        max_cost_usd=1.0,
+        layerb_dry_run=True,
+    )
+
+    artifact = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    assert artifact["writer_family"] == "anthropic"
+    assert artifact["writer_lineage"]["source"].endswith("writer_meta.json")
+    assert artifact["writer_family"] != "fixture"
+
+
+def test_shadow_driver_rejects_tau_other_than_attested_value(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(qg_shadow_run.layerb_shadow, "DEFAULT_TAU", 0.74)
+
+    with pytest.raises(RuntimeError, match=r"pinned tau=0\.75"):
+        qg_shadow_run.run_shadow_module(
+            _target(_module(tmp_path)),
+            audit_dir=tmp_path / "audit",
+            shadow_db=tmp_path / "shadow.db",
+            author_family="openai",
+            reviewer=_dispatch,
+            live_reviewer=False,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+            max_cost_usd=1.0,
+            layerb_dry_run=True,
+        )
+
+
 def test_shadow_driver_never_writes_canonical_llm_qg_runs(tmp_path: Path) -> None:
     module_dir = _module(tmp_path)
     canonical_db = tmp_path / "llm_qg.db"


### PR DESCRIPTION
## M-4 verifiable-claim preamble

This is a proof-completion follow-up to merged [PR #5191](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5191), which implemented the #5186 production shadow driver. It adds the two previously missing direct acceptance tests. No live folk capture or paid judge invocation was run.

- **Serializer shared with `qg_bakeoff`, no behavior change.** The merged implementation imports `serialize_qg_run_v2` from both `scripts/audit/qg_bakeoff.py` and `scripts/audit/qg_shadow_run.py`; its unchanged artifact regression test passed.
- **`tau=0.75` is enforced and all other values are rejected.** `test_shadow_driver_rejects_tau_other_than_attested_value` changes Layer-B’s tau to `0.74` and asserts the production driver raises `RuntimeError`.
- **`writer_family` is threaded from real module metadata, never `fixture`.** `test_shadow_driver_threads_writer_family_from_module_metadata` supplies `writer_meta.json`, asserts `anthropic` reaches the artifact, and asserts it is not `fixture`.
- **Shadow rows land in a sibling store, not canonical `llm_qg_runs`.** Existing lifecycle/isolation test verifies `llm_qg_shadow_runs` changes while canonical `llm_qg_runs` remains unchanged.

### Raw verification output

```text
$ .venv/bin/ruff check tests/audit/test_qg_shadow_run.py scripts/audit/qg_shadow_run.py scripts/audit/qg_run_serializer.py scripts/audit/llm_qg_shadow_store.py scripts/audit/qg_bakeoff.py
All checks passed!

$ .venv/bin/python -m pytest tests/audit/test_qg_shadow_run.py tests/audit/test_qg_run_serializer.py tests/audit/test_qg_bakeoff.py tests/test_qg_bakeoff_multirun.py tests/test_qg_bakeoff_emitter.py -q
collected 100 items
============================= 100 passed in 1.14s =============================
```

```text
$ stubbed qg_shadow_run lifecycle (layerb dry-run; no paid judge)
processed=1 calls=0 cost_usd=0.000000 partial=False
{"artifact_sha256":"f1a6034b572f6bf7c6a653dedecda4b266fe1cd373732d456e70e6c6a76f7754","content_sha":"c2527151f562685b9b384ba8e71fc1d6d3dd6ec1e2a617497cfbf38b382f0226","counts":{"llm_qg_shadow_findings":1,"llm_qg_shadow_runs":1},"layerb_exit_code":0,"tier2_run_id":"qg-workflow-0404acfa78bd4efa9241ef68b3310ed6"}
```

Independent cross-family review: AGY/Gemini (`gemini-3.1-pro-high`) approved this focused proof patch with no blockers.

Refs #5186 #4764 #4542

No auto-merge: orchestrator-owned merge remains gated on CI and review disposition.