### PR TITLE
feat(infra): add Claudex launcher

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -18,8 +18,36 @@ Project-local wrappers for interactive agent sessions:
 
 ```bash
 ./start-claude.sh
+./start-claudex.sh
 ./start-codex.sh
 ```
+
+`start-claudex.sh` keeps Claude Code's interface while routing the lead model
+to GPT-5.6 Sol through a local CLIProxyAPI server. Its subagents default to Sol;
+select a lower-cost tier without changing the lead:
+
+```bash
+./start-claudex.sh --subagent terra
+./start-claudex.sh --subagent luna --epic harness
+CLAUDEX_SUBAGENT=terra ./start-claudex.sh
+```
+
+On macOS, install and connect CLIProxyAPI once before launching:
+
+```bash
+brew install cliproxyapi
+brew services start cliproxyapi
+cliproxyapi --codex-login
+```
+
+See the [CLIProxyAPI quick start](https://help.router-for.me/introduction/quick-start)
+for upstream installation details.
+
+The launcher uses `http://127.0.0.1:8317` and CLIProxyAPI's documented dummy
+client token by default. Override them with `CLAUDEX_BASE_URL` and
+`CLAUDEX_AUTH_TOKEN`; credentials are inherited only by the launched process
+and are never written to the repository. `--subagent` accepts `sol`, `terra`,
+or `luna` (and their full `gpt-5.6-*` model IDs).
 
 `start-codex.sh` launches Codex with:
 

--- a/start-claudex.sh
+++ b/start-claudex.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Run Claude Code on GPT-5.6 Sol through CLIProxyAPI.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LEAD_MODEL="gpt-5.6-sol"
+SUBAGENT="${CLAUDEX_SUBAGENT:-sol}"
+FORWARD_ARGS=()
+
+usage() {
+    cat <<'EOF'
+Usage: ./start-claudex.sh [--subagent sol|terra|luna] [CLAUDE_ARGS...]
+
+Launch Claude Code with GPT-5.6 Sol as the lead model and a configurable
+GPT-5.6 subagent model. Other arguments are forwarded to start-claude.sh.
+
+Options:
+  --subagent MODEL  Subagent tier: sol (default), terra, or luna
+  -h, --help        Show this help
+
+Environment:
+  CLAUDEX_SUBAGENT   Default subagent tier
+  CLAUDEX_BASE_URL   CLIProxyAPI URL (default: http://127.0.0.1:8317)
+  CLAUDEX_AUTH_TOKEN CLIProxyAPI token (default: sk-dummy)
+EOF
+}
+
+resolve_model() {
+    case "$1" in
+        sol|gpt-5.6-sol) printf '%s\n' 'gpt-5.6-sol' ;;
+        terra|gpt-5.6-terra) printf '%s\n' 'gpt-5.6-terra' ;;
+        luna|gpt-5.6-luna) printf '%s\n' 'gpt-5.6-luna' ;;
+        *) return 1 ;;
+    esac
+}
+
+while (($#)); do
+    case "$1" in
+        --subagent)
+            if (($# < 2)); then
+                echo "Error: --subagent requires sol, terra, or luna." >&2
+                exit 2
+            fi
+            SUBAGENT="$2"
+            shift 2
+            ;;
+        --subagent=*)
+            SUBAGENT="${1#*=}"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --model|--model=*)
+            echo "Error: Claudex keeps the lead model on $LEAD_MODEL; configure only --subagent." >&2
+            exit 2
+            ;;
+        *)
+            FORWARD_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if ! SUBAGENT_MODEL="$(resolve_model "$SUBAGENT")"; then
+    echo "Error: unsupported subagent '$SUBAGENT' (choose sol, terra, or luna)." >&2
+    exit 2
+fi
+
+export ANTHROPIC_BASE_URL="${CLAUDEX_BASE_URL:-http://127.0.0.1:8317}"
+ANTHROPIC_BASE_URL="${ANTHROPIC_BASE_URL%/}"
+# CLIProxyAPI's documented public placeholder, not a repository credential.
+export ANTHROPIC_AUTH_TOKEN="${CLAUDEX_AUTH_TOKEN:-sk-dummy}"
+unset ANTHROPIC_API_KEY
+export CLAUDE_CODE_SUBAGENT_MODEL="$SUBAGENT_MODEL"
+export CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1
+export CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3
+export ENABLE_TOOL_SEARCH=false
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "Error: curl is required to check CLIProxyAPI." >&2
+    exit 1
+fi
+
+if ! curl --fail --silent --show-error --output /dev/null --header @- \
+    --connect-timeout 1 --max-time 3 "$ANTHROPIC_BASE_URL/v1/models" \
+    <<< "Authorization: Bearer $ANTHROPIC_AUTH_TOKEN"; then
+    echo "Error: CLIProxyAPI check failed at $ANTHROPIC_BASE_URL (unreachable or credential rejected)." >&2
+    echo "   macOS: brew install cliproxyapi && brew services start cliproxyapi" >&2
+    echo "   Connect: cliproxyapi --codex-login" >&2
+    exit 1
+fi
+
+echo "Claudex: lead=$LEAD_MODEL subagent=$SUBAGENT_MODEL proxy=$ANTHROPIC_BASE_URL"
+exec "$PROJECT_DIR/start-claude.sh" --model "$LEAD_MODEL" "${FORWARD_ARGS[@]}"

--- a/tests/test_start_claudex.py
+++ b/tests/test_start_claudex.py
@@ -1,0 +1,222 @@
+"""Behavior checks for the CLIProxyAPI-backed Claude Code launcher."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LAUNCHER = _REPO_ROOT / "start-claudex.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_with_fakes(
+    tmp_path: Path,
+    arguments: list[str],
+    env_overrides: dict[str, str] | None = None,
+) -> str:
+    home_bin = tmp_path / "home" / ".local" / "bin"
+    home_bin.mkdir(parents=True)
+    capture = tmp_path / "capture.txt"
+
+    _write_executable(
+        home_bin / "claude",
+        """#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    echo "test-claude"
+    exit 0
+fi
+{
+    printf 'base=%s\n' "$ANTHROPIC_BASE_URL"
+    printf 'auth=%s\n' "$ANTHROPIC_AUTH_TOKEN"
+    printf 'api_key=%s\n' "${ANTHROPIC_API_KEY-unset}"
+    printf 'subagent=%s\n' "$CLAUDE_CODE_SUBAGENT_MODEL"
+    printf 'effort=%s\n' "$CLAUDE_CODE_ALWAYS_ENABLE_EFFORT"
+    printf 'concurrency=%s\n' "$CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY"
+    printf 'tool_search=%s\n' "$ENABLE_TOOL_SEARCH"
+    printf 'epic=%s\n' "${SESSION_EPIC:-}"
+    printf 'arg=%s\n' "$@"
+} > "$CLAUDEX_TEST_CAPTURE"
+""",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "curl", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(fake_bin / "npm", "#!/usr/bin/env bash\nexit 0\n")
+
+    env = os.environ.copy()
+    for variable in (
+        "ANTHROPIC_API_KEY",
+        "CLAUDEX_BASE_URL",
+        "CLAUDEX_AUTH_TOKEN",
+        "CLAUDEX_SUBAGENT",
+    ):
+        env.pop(variable, None)
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "CLAUDEX_TEST_CAPTURE": str(capture),
+        }
+    )
+    env.update(env_overrides or {})
+    result = subprocess.run(
+        [
+            str(_LAUNCHER),
+            *arguments,
+            "--epic",
+            "harness",
+            "--resume",
+            "session-id",
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    return capture.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [
+        ([], "gpt-5.6-sol"),
+        (["--subagent", "sol"], "gpt-5.6-sol"),
+        (["--subagent=terra"], "gpt-5.6-terra"),
+        (["--subagent", "luna"], "gpt-5.6-luna"),
+    ],
+)
+def test_routes_lead_and_subagent_models(tmp_path: Path, arguments: list[str], expected: str) -> None:
+    output = _run_with_fakes(tmp_path, arguments)
+    assert "base=http://127.0.0.1:8317" in output
+    assert "auth=sk-dummy" in output
+    assert "api_key=unset" in output
+    assert f"subagent={expected}" in output
+    assert "effort=1" in output
+    assert "concurrency=3" in output
+    assert "tool_search=false" in output
+    assert "epic=harness" in output
+    assert "arg=--model" in output
+    assert "arg=gpt-5.6-sol" in output
+    assert "arg=session-id" in output
+    assert "arg=harness" not in output
+
+
+def test_forwards_proxy_overrides_without_anthropic_api_key(tmp_path: Path) -> None:
+    output = _run_with_fakes(
+        tmp_path,
+        [],
+        {
+            "ANTHROPIC_API_KEY": "must-be-unset",
+            "CLAUDEX_BASE_URL": "https://proxy.example.com:8443/",
+            "CLAUDEX_AUTH_TOKEN": "custom-token",
+        },
+    )
+
+    assert "base=https://proxy.example.com:8443" in output
+    assert "auth=custom-token" in output
+    assert "api_key=unset" in output
+
+
+def test_rejects_unknown_subagent() -> None:
+    result = subprocess.run(
+        [str(_LAUNCHER), "--subagent", "unknown"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 2
+    assert "unsupported subagent" in result.stderr
+
+
+def test_rejects_missing_subagent_value() -> None:
+    result = subprocess.run(
+        [str(_LAUNCHER), "--subagent"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 2
+    assert "requires sol, terra, or luna" in result.stderr
+
+
+@pytest.mark.parametrize("argument", ["--model", "--model=gpt-5.6-luna"])
+def test_rejects_lead_model_override(argument: str) -> None:
+    result = subprocess.run(
+        [str(_LAUNCHER), argument],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 2
+    assert "keeps the lead model on gpt-5.6-sol" in result.stderr
+
+
+def test_reports_proxy_check_failure(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "curl", "#!/usr/bin/env bash\nexit 22\n")
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    result = subprocess.run(
+        [str(_LAUNCHER)],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 1
+    assert "CLIProxyAPI check failed" in result.stderr
+
+
+def test_reports_missing_curl(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "dirname").symlink_to("/usr/bin/dirname")
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin)
+
+    result = subprocess.run(
+        ["/bin/bash", str(_LAUNCHER)],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 1
+    assert "curl is required" in result.stderr
+
+
+@pytest.mark.parametrize("argument", ["-h", "--help"])
+def test_prints_launcher_help(argument: str) -> None:
+    result = subprocess.run(
+        [str(_LAUNCHER), argument],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0
+    assert "Usage: ./start-claudex.sh" in result.stdout


### PR DESCRIPTION
## Summary
- add a thin `start-claudex.sh` wrapper that keeps GPT-5.6 Sol as lead and selects Sol, Terra, or Luna for Claude Code subagents
- configure and verify the local CLIProxyAPI gateway without persisting credentials
- document installation/usage and add launcher regression coverage

## Validation
- `shellcheck start-claudex.sh`
- `bash -n start-claudex.sh`
- `.venv/bin/ruff check tests/test_start_claudex.py`
- `.venv/bin/ruff format --check tests/test_start_claudex.py`
- `.venv/bin/python -m pytest tests/test_start_claudex.py tests/test_deploy_extensions.py -q` (14 passed)
- `npx markdownlint-cli2 docs/SCRIPTS.md`
- `git diff --cached --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review gate
- Gemini 3.1 Pro adversarial review: 3 kept findings fixed; 2 false positives dropped by independent challenge
- DeepSeek v4 Flash final follow-up: **NO FINDINGS** (`review-start-claudex-tests-final`)

Refs #4707