### PR TITLE
fix(atlas): marked, decolonized Kaikki etymology fallback behind mphdict-primary (#5263)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -4507,12 +4507,28 @@ def _kaikki_etymology_text_is_usable(text: str) -> bool:
     return not _KAIKKI_GARBLED_ETYMOLOGY_RE.search(text)
 
 
+# Decolonization guard (#M-13 / .claude/rules/ukrainian-linguistics.md §1,§6): a Ukrainian etymology
+# must never be framed via Russian/Belarusian comparison. "Old East Slavic" / "East Slavic" are the
+# correct decolonized terms and contain neither marker, so they pass; a "Compare Russian …" /
+# "Belarusian …" Kaikki etymology is rejected (section falls to honestly `uncovered`) rather than
+# surfaced with imperial framing.
+_KAIKKI_IMPERIAL_COMPARISON_RE = re.compile(
+    r"\b(Russian|Belarusian|Belorussian|Byelorussian)\b", re.IGNORECASE
+)
+
+
+def _kaikki_etymology_is_decolonized(text: str) -> bool:
+    return not _KAIKKI_IMPERIAL_COMPARISON_RE.search(text)
+
+
 def _kaikki_etymology(lookup: dict[str, dict[str, Any]], lemma: str) -> dict | None:
     row = _kaikki_row(lookup, lemma)
     if not row:
         return None
     text = clean_html_entities(str(row.get("etymology_text") or "").strip()[:600])
     if not _kaikki_etymology_text_is_usable(text):
+        return None
+    if not _kaikki_etymology_is_decolonized(text):
         return None
     return {"text": text, "source": KAIKKI_SOURCE}
 
@@ -4609,11 +4625,13 @@ def _with_base_etymology_label(etymology: dict, base_form: str) -> dict:
 def _etymology(
     conn: sqlite3.Connection, lemma: str, kaikki_lookup: dict[str, dict[str, Any]] | None = None
 ) -> dict | None:
-    """Offline ЕСУМ etymology from mphdict; no mirror or Wiktionary fallback."""
+    """ЕСУМ etymology from offline mphdict (primary, authoritative); falls back to a decolonized,
+    source-marked Kaikki/Wiktionary etymology for lemmas mphdict lacks (Option C, #5263). The Горох
+    mirror and the legacy ЕСУМ FTS table stay OFF (mirror labels banned; ЕСУМ redundant with mphdict)."""
     lookup_word = _lookup_key(_base_lemma(lemma))
     if lookup_word in _COMPOSITIONAL_ETYMOLOGY_EXCLUSIONS:
         return None
-    return _mphdict_etymology(lemma)
+    return _mphdict_etymology(lemma) or _kaikki_etymology(kaikki_lookup or {}, lemma)
 
 
 _GRAC_FREQUENCY_CACHE_DATA: dict[str, Any] | None = None

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -4519,7 +4519,7 @@ _KAIKKI_IMPERIAL_COMPARISON_RE = re.compile(
     # рф → "Російська Федерація"). Word-anchored (\b) so it does NOT false-positive on Амвросій
     # (Ambrose) or on legitimate Moscow-referent words (москва/москвич), which carry honest
     # compositional etymologies rather than imperial framing of a Ukrainian concept.
-    r"|\b(росі[яюї]|російськ|росіян|малоросі|рф|білорус)",
+    r"|\b(росі[яюїє]|російськ|росіян|малоросі|рф|білорус)",
     re.IGNORECASE,
 )
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -4524,8 +4524,14 @@ _KAIKKI_IMPERIAL_COMPARISON_RE = re.compile(
 )
 
 
+# Ukrainian dictionary prose marks stress with combining acute/grave (Малоро́сія, Росі́я). Strip only
+# those before the imperial-comparison match so accented Cyrillic still matches; the precomposed
+# letters ї/й (U+0457/U+0439) are untouched — only U+0301/U+0300 are removed.
+_KAIKKI_STRESS_MARKS = str.maketrans("", "", "́̀")  # combining acute + grave (stress)
+
+
 def _kaikki_etymology_is_decolonized(text: str) -> bool:
-    return not _KAIKKI_IMPERIAL_COMPARISON_RE.search(text)
+    return not _KAIKKI_IMPERIAL_COMPARISON_RE.search(text.translate(_KAIKKI_STRESS_MARKS))
 
 
 def _kaikki_etymology(lookup: dict[str, dict[str, Any]], lemma: str) -> dict | None:

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -4513,7 +4513,14 @@ def _kaikki_etymology_text_is_usable(text: str) -> bool:
 # "Belarusian …" Kaikki etymology is rejected (section falls to honestly `uncovered`) rather than
 # surfaced with imperial framing.
 _KAIKKI_IMPERIAL_COMPARISON_RE = re.compile(
-    r"\b(Russian|Belarusian|Belorussian|Byelorussian)\b", re.IGNORECASE
+    # English base country names, adjectives, and plurals (Russia/Russian/Russians, Belarus/…),
+    r"\b(Russia|Russian|Russians|Belarus|Belarusian|Belarusians|Belorussia|Belorussian|Byelorussia|Byelorussian)\b"
+    # plus embedded Cyrillic imperial references (Kaikki etymology prose often embeds them, e.g.
+    # рф → "Російська Федерація"). Word-anchored (\b) so it does NOT false-positive on Амвросій
+    # (Ambrose) or on legitimate Moscow-referent words (москва/москвич), which carry honest
+    # compositional etymologies rather than imperial framing of a Ukrainian concept.
+    r"|\b(росі[яюї]|російськ|росіян|малоросі|рф|білорус)",
+    re.IGNORECASE,
 )
 
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "9cf22907acc7b9cf2d7498bff127066d283165d57b12c6e96ae6fd454cd16c30",
+  "fingerprint": "d96858ced0e150e48e19b153417bd0114485ec5963185cb71e6c7563cea9f322",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "ac10b8757ac8cea7b0fcf354f6487701abe4c8f81c5c6e0d3bb64ab8e65db150"
+        "sha256": "1201a02bcb5a3912e866b56ea62a82f21ca49fa22fba49360c246c4ac5f7e728"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "d96858ced0e150e48e19b153417bd0114485ec5963185cb71e6c7563cea9f322",
+  "fingerprint": "f29a4e81c8ef81e2eb815d8a3ca21c20a6a495e43339b83e367b222b0afa309d",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "1201a02bcb5a3912e866b56ea62a82f21ca49fa22fba49360c246c4ac5f7e728"
+        "sha256": "ca617005bafb8de789c75edbd7e1d6c10b898ffa42bdca0eec4e6bd180cb28ec"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "bc06f327e6f1ed4c943d4c9896be42ec18910a7e14e0ac3733db961defc528df",
+  "fingerprint": "9cf22907acc7b9cf2d7498bff127066d283165d57b12c6e96ae6fd454cd16c30",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "0d3284b5fa039362775f1b4f40b073c557d46bda3e160435f3e32eb9adc4d91b"
+        "sha256": "ac10b8757ac8cea7b0fcf354f6487701abe4c8f81c5c6e0d3bb64ab8e65db150"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "28516ef3672eb3d9556c90eb3a259608f6b5062f92c3ce69cce0ca01a3f64162",
+  "fingerprint": "bc06f327e6f1ed4c943d4c9896be42ec18910a7e14e0ac3733db961defc528df",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "c77c6c30373895a2398221ec565f96df4097962320d3b131016759ac5061447f"
+        "sha256": "0d3284b5fa039362775f1b4f40b073c557d46bda3e160435f3e32eb9adc4d91b"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1874,6 +1874,7 @@ def test_kaikki_etymology_decolonization_guard(monkeypatch) -> None:
         "Named after the emperor Paul I of Russia.",       # base country name (was leaking)
         "See орк for the usage referring to Russians.",    # plural (was leaking)
         "Initialism of Російська Федерація.",              # Cyrillic (was leaking)
+        "Coined during the war with Росією.",              # Cyrillic instrumental case (paradigm gap)
         "Back-formation from Малоро́сія (little Russia).",
     ]:
         assert ety(imperial) is None, imperial

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1858,15 +1858,35 @@ def test_etymology_has_no_kaikki_cognate_fallback(monkeypatch) -> None:
 
 def test_kaikki_etymology_decolonization_guard(monkeypatch) -> None:
     # The Kaikki fallback surfaces clean/decolonized etymologies but rejects Russian/Belarusian
-    # comparison framing (#M-13 / ukrainian-linguistics.md §1,§6).
+    # framing — English adjective/noun/plural AND embedded Cyrillic (#M-13 / ukrainian-linguistics.md
+    # §1,§6). Regression cases from the #5264 cross-family review (agy: base names/plurals leaked;
+    # codex: Cyrillic leaked) plus the false-positives that a naive broadening would introduce.
     monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
-    clean = {"дім": {"ipa": [], "etymology_text": "From Proto-Slavic *domъ.", "pos": ["noun"]}}
-    imperial = {"дім": {"ipa": [], "etymology_text": "Compare Russian дом (dom).", "pos": ["noun"]}}
 
-    result = _etymology(conn, "дім", clean)
-    assert result is not None and result["source"] == KAIKKI_SOURCE
-    assert _etymology(conn, "дім", imperial) is None
+    def ety(text: str):
+        return _etymology(conn, "проба", {"проба": {"ipa": [], "etymology_text": text, "pos": ["noun"]}})
+
+    # REJECTED — imperial framing (English adjective/noun/plural + embedded Cyrillic) → uncovered:
+    for imperial in [
+        "Compare Russian дом (dom).",
+        "cf. Belarusian ба́завы.",
+        "Named after the emperor Paul I of Russia.",       # base country name (was leaking)
+        "See орк for the usage referring to Russians.",    # plural (was leaking)
+        "Initialism of Російська Федерація.",              # Cyrillic (was leaking)
+        "Back-formation from Малоро́сія (little Russia).",
+    ]:
+        assert ety(imperial) is None, imperial
+
+    # PASSED — clean/decolonized etymologies surface, source-marked non-authoritative:
+    for clean in [
+        "From Proto-Slavic *domъ.",
+        "From Old East Slavic мѣсто.",
+        "From Амвросій (Amvrosij, male given name) + -ївка.",  # NOT imperial (Ambrose ≠ Russia)
+        "Inherited from Old Ruthenian москва.",               # Moscow-referent word, honest etymology
+    ]:
+        r = ety(clean)
+        assert r is not None and r["source"] == KAIKKI_SOURCE, clean
 
 
 def test_etymology_ignores_garbled_legacy_tree_text(monkeypatch) -> None:

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1750,7 +1750,9 @@ def test_kaikki_meaning_uses_direct_glosses() -> None:
     }
 
 
-def test_etymology_has_no_kaikki_fallback_when_mphdict_has_no_root(monkeypatch) -> None:
+def test_etymology_falls_back_to_marked_kaikki_when_mphdict_has_no_root(monkeypatch) -> None:
+    # Option C (#5263): on an mphdict miss, a clean/decolonized Kaikki etymology is surfaced,
+    # source-marked non-authoritative (upgradeable) — no longer suppressed.
     monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
     lookup = {
@@ -1761,7 +1763,11 @@ def test_etymology_has_no_kaikki_fallback_when_mphdict_has_no_root(monkeypatch) 
         }
     }
 
-    assert _etymology(conn, "місто", lookup) is None
+    result = _etymology(conn, "місто", lookup)
+    assert result is not None
+    assert result["source"] == KAIKKI_SOURCE
+    assert "Old East Slavic" in result["text"]
+    assert "Russian" not in result["text"]
 
 
 def test_etymology_does_not_fall_back_to_derived_base_forms(monkeypatch) -> None:
@@ -1845,7 +1851,22 @@ def test_etymology_has_no_kaikki_cognate_fallback(monkeypatch) -> None:
         }
     }
 
+    # Option C (#5263): rejected now by the DECOLONIZATION guard (Russian/Belarusian comparison),
+    # not by "no fallback". A cognate-comparison etymology must never be surfaced (#M-13).
     assert _etymology(conn, "базовий", lookup) is None
+
+
+def test_kaikki_etymology_decolonization_guard(monkeypatch) -> None:
+    # The Kaikki fallback surfaces clean/decolonized etymologies but rejects Russian/Belarusian
+    # comparison framing (#M-13 / ukrainian-linguistics.md §1,§6).
+    monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
+    conn = _conn()
+    clean = {"дім": {"ipa": [], "etymology_text": "From Proto-Slavic *domъ.", "pos": ["noun"]}}
+    imperial = {"дім": {"ipa": [], "etymology_text": "Compare Russian дом (dom).", "pos": ["noun"]}}
+
+    result = _etymology(conn, "дім", clean)
+    assert result is not None and result["source"] == KAIKKI_SOURCE
+    assert _etymology(conn, "дім", imperial) is None
 
 
 def test_etymology_ignores_garbled_legacy_tree_text(monkeypatch) -> None:
@@ -1862,7 +1883,9 @@ def test_etymology_ignores_garbled_legacy_tree_text(monkeypatch) -> None:
     assert _etymology(conn, "Японія", lookup) is None
 
 
-def test_etymology_has_no_legacy_wiktionary_fallback(monkeypatch) -> None:
+def test_etymology_falls_back_to_marked_wiktionary_via_kaikki(monkeypatch) -> None:
+    # Option C (#5263): a clean Wiktionary-derived (Kaikki) etymology IS surfaced when mphdict has no
+    # root, source-marked non-authoritative. (The legacy wiktionary_etymology DB TABLE stays unused.)
     monkeypatch.setattr(enrich_manifest_module, "mphdict_etymology", lambda lemma: None)
     conn = _conn()
     lookup = {
@@ -1873,7 +1896,10 @@ def test_etymology_has_no_legacy_wiktionary_fallback(monkeypatch) -> None:
         }
     }
 
-    assert _etymology(conn, "робота", lookup) is None
+    result = _etymology(conn, "робота", lookup)
+    assert result is not None
+    assert result["source"] == KAIKKI_SOURCE
+    assert "Proto-Slavic" in result["text"]
 
 
 def test_etymology_has_no_goroh_mirror_fallback(monkeypatch) -> None:
@@ -1896,12 +1922,16 @@ def test_etymology_has_no_goroh_mirror_fallback(monkeypatch) -> None:
     lookup = {
         "книга": {
             "ipa": [],
-            "etymology_text": "Kaikki etymology text that must not win.",
+            "etymology_text": "Kaikki fallback etymology for книга.",
             "pos": ["noun"],
         }
     }
 
-    assert _etymology(conn, "книга", lookup) is None
+    # Option C (#5263): the Горох MIRROR still never wins; the decolonized Kaikki fallback does, marked.
+    result = _etymology(conn, "книга", lookup)
+    assert result is not None
+    assert result["source"] == KAIKKI_SOURCE
+    assert "Goroh" not in result["text"]
 
 
 def test_enrich_uses_base_form_for_pair_single_form_sections(monkeypatch, tmp_path) -> None:

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1875,6 +1875,7 @@ def test_kaikki_etymology_decolonization_guard(monkeypatch) -> None:
         "See орк for the usage referring to Russians.",    # plural (was leaking)
         "Initialism of Російська Федерація.",              # Cyrillic (was leaking)
         "Coined during the war with Росією.",              # Cyrillic instrumental case (paradigm gap)
+        "From Росі́я (Rosíja) + -ський.",             # stress-marked Cyrillic (combining acute)
         "Back-formation from Малоро́сія (little Russia).",
     ]:
         assert ety(imperial) is None, imperial
@@ -1888,6 +1889,12 @@ def test_kaikki_etymology_decolonization_guard(monkeypatch) -> None:
     ]:
         r = ety(clean)
         assert r is not None and r["source"] == KAIKKI_SOURCE, clean
+
+    # Stress marks are stripped ONLY for the imperial-comparison match; the STORED etymology text
+    # must preserve them (word stress is pedagogically load-bearing).
+    accented = ety("From Old East Slavic мѣ́сто.")
+    assert accented is not None
+    assert "́" in accented["text"]  # combining acute retained in the saved value
 
 
 def test_etymology_ignores_garbled_legacy_tree_text(monkeypatch) -> None:


### PR DESCRIPTION
Implements the owner's **Option C + provenance-marking** decision for Atlas etymology, reconciling #5252's mphdict-ЕСУМ-only narrowing with the full-corpus plan.

## Change
`scripts/lexicon/enrich_manifest.py::_etymology`:
`return _mphdict_etymology(lemma) or _kaikki_etymology(kaikki_lookup or {}, lemma)`
- **mphdict ЕСУМ stays PRIMARY** (authoritative, clean ODbL).
- On a miss, falls back to a **source-marked** Kaikki/Wiktionary etymology (`source="kaikki/Wiktionary (CC BY-SA 3.0)"`) — the marker is the upgrade ledger (later pass can query `enrichment WHERE source LIKE 'kaikki%'` and replace with an authoritative source).
- **Горох mirror + legacy ЕСУМ FTS table stay OFF** (`_source_etymology` not restored).

## Decolonization guard (#M-13 / ukrainian-linguistics.md §1,§6)
New `_kaikki_etymology_is_decolonized`: the Kaikki fallback **rejects** etymologies framed via Russian/Belarusian comparison ("Compare Russian …") → section is honestly `uncovered`, never surfaced with imperial framing. "Old East Slavic" / clean etymologies pass and are marked.

## Tests (149 local pass, ruff clean, freshness gate green)
- Inverted the two clean-Kaikki cases (місто, робота) → assert the marked fallback.
- Updated the goroh-mirror case → assert Kaikki wins over the mirror (mirror still never wins).
- Kept empty-lookup / phrase / garbled / Russian-comparison cases returning None.
- Added `test_kaikki_etymology_decolonization_guard`.

Refs #5263. Reviewer note: this re-adds a marked fallback #5252 removed — independent cross-family review + a real-data decolonization spot-check to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)