### PR TITLE
fix(harness): resolve --epic harness to claude-infra + lean infra cold-start

### DIFF
--- a/agents_extensions/shared/agents/infra-orchestrator.md
+++ b/agents_extensions/shared/agents/infra-orchestrator.md
@@ -37,8 +37,30 @@ initialPrompt: |
      Acting on a stale picture is the #1 re-collision class. Read open PRs first, then drive.
   3. Use the validated packet surfaced by automatic SessionStart when one exists; otherwise continue with
      durable orientation. Do not scan flat `.agent/*-thread-handoff.md` paths or parse rollover leases yourself.
-  4. Orient via Monitor API, not files: `http://localhost:8765/api/state/manifest`,
-     `/api/orient`, `/api/delegate/active`, `/api/worktrees`, `/api/comms/inbox?agent=claude-infra`.
+     Handoff identity for this lane is `claude-infra` (also when launched with `--epic harness` — #5201);
+     never expect a phantom `claude-harness` slot.
+  4. Orient via Monitor API (127.0.0.1:8765), lane-scoped — pull SIGNAL, not the whole contract:
+     - `curl -s --max-time 2 "http://127.0.0.1:8765/api/state/manifest?session=$CLAUDE_CODE_SESSION_ID"`
+       — small (hashes + identity). The `?session=` param is how you get `_telemetry.ctx` (your live
+       context-TOKEN count, not a %); MEASURE ctx from it, never estimate. (Known gap #5265: an
+       unresolved session returns `session-transcript-not-found` + `caller_match:false` → ctx null,
+       and the response OMITS the `newest_transcript` sidecar. Until it lands, if `caller_match` is
+       false re-request the manifest WITHOUT `?session=` and read `_telemetry.newest_transcript.ctx`
+       — that sidecar is present ONLY on no-session requests — yours when you're the only session here.)
+     - **Do NOT bulk-fetch `/api/rules` at cold-start.** The operator-contract digest is ALREADY
+       injected into your system prompt (CLAUDE.md § Operator Contract) — that binds. The full
+       endpoint is ~76 KB and, with the telemetry footer enabled (the live config), returns a full
+       body + no ETag/304 on a matching `If-None-Match` — so re-pulling it every cold-start is pure
+       duplication. Fetch it (or `docs/best-practices/agent-activity-matrix.md`)
+       ON-DEMAND, once, before your FIRST dispatch (for the live model-assignment/routing table), and
+       re-pull only when the manifest `rules.hash` changed. API down → offline fallback
+       `agents_extensions/shared/rules/*.md`.
+     - `curl -s --max-time 2 "http://127.0.0.1:8765/api/orient?session=$CLAUDE_CODE_SESSION_ID"`
+       — live queue / PR / worktree orient; pass `?session=` so `_telemetry.ctx` is populated.
+     - `curl -s --max-time 2 http://127.0.0.1:8765/api/delegate/active` — verify claimed in-flight
+       dispatches before believing the handoff.
+     - `curl -s --max-time 2 http://127.0.0.1:8765/api/worktrees`
+     - `curl -s --max-time 2 'http://127.0.0.1:8765/api/comms/inbox?agent=claude-infra'`
      If the API times out, say "API down, falling back" and read the handoff + `memory/MEMORY.md` + `CLAUDE.md`.
   5. ⚠️ IDENTITY GUARDRAIL — use the `thread-rollover` skill and SessionStart engine output. A packet bound
      to another thread is a stop condition; never adopt it or inspect a different agent's packet.

--- a/agents_extensions/shared/agents/infra-orchestrator.md
+++ b/agents_extensions/shared/agents/infra-orchestrator.md
@@ -43,10 +43,9 @@ initialPrompt: |
      - `curl -s --max-time 2 "http://127.0.0.1:8765/api/state/manifest?session=$CLAUDE_CODE_SESSION_ID"`
        — small (hashes + identity). The `?session=` param is how you get `_telemetry.ctx` (your live
        context-TOKEN count, not a %); MEASURE ctx from it, never estimate. (Known gap #5265: an
-       unresolved session returns `session-transcript-not-found` + `caller_match:false` → ctx null,
-       and the response OMITS the `newest_transcript` sidecar. Until it lands, if `caller_match` is
-       false re-request the manifest WITHOUT `?session=` and read `_telemetry.newest_transcript.ctx`
-       — that sidecar is present ONLY on no-session requests — yours when you're the only session here.)
+       unresolved session returns `session-transcript-not-found` + `caller_match:false` → ctx null.
+       If caller-matched telemetry is unavailable, state that it is unavailable rather than adopting
+       another session's telemetry.)
      - **Do NOT bulk-fetch `/api/rules` at cold-start.** The operator-contract digest is ALREADY
        injected into your system prompt (CLAUDE.md § Operator Contract) — that binds. The full
        endpoint is ~76 KB and, with the telemetry footer enabled (the live config), returns a full
@@ -55,8 +54,9 @@ initialPrompt: |
        ON-DEMAND, once, before your FIRST dispatch (for the live model-assignment/routing table), and
        re-pull only when the manifest `rules.hash` changed. API down → offline fallback
        `agents_extensions/shared/rules/*.md`.
-     - `curl -s --max-time 2 "http://127.0.0.1:8765/api/orient?session=$CLAUDE_CODE_SESSION_ID"`
-       — live queue / PR / worktree orient; pass `?session=` so `_telemetry.ctx` is populated.
+     - `curl -s --max-time 2 "http://127.0.0.1:8765/api/orient?lean=true&session=$CLAUDE_CODE_SESSION_ID"`
+       — lean cold-start orientation; pull only critical signals (active worktree and PR targets).
+       Preserve full orient or explicit sections as ON-DEMAND only.
      - `curl -s --max-time 2 http://127.0.0.1:8765/api/delegate/active` — verify claimed in-flight
        dispatches before believing the handoff.
      - `curl -s --max-time 2 http://127.0.0.1:8765/api/worktrees`

--- a/docs/session-state/current.claude-infra.md
+++ b/docs/session-state/current.claude-infra.md
@@ -4,13 +4,15 @@
 > harness, Atlas/lexicon. SEPARATE from the folk/seminar Claude (agent `claude`) and from
 > the curriculum track-orchestrators.
 >
-> **Handoff identity:** `claude-infra`. Launch with **`./start-claude.sh --agent infra-orchestrator`**:
-> the launcher derives `SESSION_HANDOFF_AGENT=claude-infra` from the `--agent` selection (via
-> `scripts/lib/handoff_identity.sh`), so the SessionStart hook routes cold-start to this lane's own slot
-> (`.agent/claude-infra-thread-handoff.md`) instead of the shared `claude` slot. A bare `claude` /
-> `./start-claude.sh` with no `--agent` (or `--agent curriculum-orchestrator`) defaults to agent `claude`,
-> which the folk driver and track-orchestrators also use — that shared slot is the cold-start collision
-> this lane was created to avoid. (One launcher, one agent flag — there is no separate `start-claude-infra.sh`.)
+> **Handoff identity:** `claude-infra`. Launch with **`./start-claude.sh --agent infra-orchestrator`**
+> and/or **`--epic harness`**: the launcher derives `SESSION_HANDOFF_AGENT=claude-infra` from either
+> flag (via `scripts/lib/handoff_identity.sh` — harness is a canonical alias for this lane, not a
+> phantom `claude-harness` slot; #5201), so the SessionStart hook routes cold-start to this lane's own
+> slot (`.agent/claude-infra-thread-handoff.md` + `.agent/thread-rollovers/claude-infra/`) instead of
+> the shared `claude` slot. A bare `claude` / `./start-claude.sh` with no `--agent` (or
+> `--agent curriculum-orchestrator`) defaults to agent `claude`, which the folk driver and
+> track-orchestrators also use — that shared slot is the cold-start collision this lane was created
+> to avoid. (One launcher, one agent/epic flag — there is no separate `start-claude-infra.sh`.)
 
 ## Cold-start
 1. `git fetch origin`

--- a/docs/session-state/current.claude-infra.md
+++ b/docs/session-state/current.claude-infra.md
@@ -17,8 +17,10 @@
 ## Cold-start
 1. `git fetch origin`
 2. `gh pr list --search 'author:@me' --state open`
-3. `curl -sS http://127.0.0.1:8765/api/orient`
-4. Read the live queue: `.agent/claude-infra-thread-handoff.md` (gitignored, machine-local — START HERE).
+3. Use the validated automatic SessionStart rollover output as authoritative. Do not manually parse flat handoff files or leases if a rollover packet was surfaced at startup.
+4. If the SessionStart hook output is unavailable, or the API is down, or the hook explicitly surfaces the legacy file, use the legacy flat file fallback: `.agent/claude-infra-thread-handoff.md` (gitignored, machine-local).
+5. Orient via Monitor API (lean cold-start mode): `curl -s --max-time 2 "http://127.0.0.1:8765/api/orient?lean=true&session=$CLAUDE_CODE_SESSION_ID"`
+
 
 ## Lane boundaries
 - Infra/code only. Do NOT touch the folk/seminar content lane

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -55,7 +55,17 @@ eq "$(handoff_epic_from_argv)" "" "empty argv (epic)"
 # --- epic → slot mapping: epic beats agent-type; empty epic maps to nothing ---
 eq "$(handoff_identity_for_epic atlas)" "claude-atlas" "epic atlas → claude-atlas"
 eq "$(handoff_identity_for_epic hramatka)" "claude-hramatka" "epic hramatka → claude-hramatka"
+eq "$(handoff_identity_for_epic harness)" "claude-infra" "epic harness → claude-infra (#5201)"
+eq "$(handoff_identity_for_epic infra)" "claude-infra" "epic infra → claude-infra alias"
 eq "$(handoff_identity_for_epic)" "" "no epic → empty slot"
+
+# --- e2e: --epic harness resolves the infra lane slot (not phantom claude-harness) ---
+epic="$(handoff_epic_from_argv --epic harness --agent infra-orchestrator)"
+eq "$(handoff_identity_for_epic "$epic")" "claude-infra" "e2e: --epic harness → claude-infra"
+# Phantom claude-harness must NEVER be the resolved slot for this lane.
+if [[ "$(handoff_identity_for_epic harness)" == "claude-harness" ]]; then
+  fail "harness epic must not invent phantom claude-harness slot (#5201)"
+fi
 
 # --- strip: --epic (both forms) removed, everything else preserved in order ---
 stripped="$(strip_epic_from_argv --chrome --epic atlas --agent curriculum-orchestrator | tr '\0' ' ')"

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -413,6 +413,32 @@ assert_contains "$output" "Thread rollover health (read-only)" "post compact hea
 assert_contains "$output" '\"status\": \"pending_start\"' "post compact packet"
 assert_not_contains "$output" "confirm-started" "post compact no confirmation"
 
+# 17. #5201: --epic harness resolves to the claude-infra slot. A live
+#     pending_start packet under claude-infra MUST surface at SessionStart —
+#     never a silent cold start under the phantom claude-harness slot.
+# shellcheck source=scripts/lib/handoff_identity.sh
+source "$REPO_ROOT/scripts/lib/handoff_identity.sh"
+harness_slot="$(handoff_identity_for_epic harness)"
+eq_slot() {
+  # local assert: harness epic must resolve to claude-infra
+  if [[ "$1" != "$2" ]]; then
+    fail "#5201 harness slot: expected [$2], got [$1]"
+  fi
+}
+eq_slot "$harness_slot" "claude-infra"
+setup_fixture "$fixture_root"
+prepare_fixture "$fixture_root" claude-infra old-infra-harness
+# Phantom slot: if the launcher still exported claude-harness, SessionStart
+# would cold-start past the live infra packet. Prove the bug path is cold.
+output_phantom="$(run_hook "$fixture_root" 0 claude-harness)"
+assert_contains "$output_phantom" "COLD START: NO LIVE THREAD ROLLOVER" "phantom claude-harness is blind (#5201)"
+assert_not_contains "$output_phantom" "PENDING THREAD ROLLOVER DETECTED" "phantom claude-harness is blind (#5201)"
+# Canonical slot (what --epic harness must export): live packet is surfaced.
+output_harness="$(run_hook "$fixture_root" 0 "$harness_slot")"
+assert_contains "$output_harness" "PENDING THREAD ROLLOVER DETECTED" "epic harness surfaces claude-infra packet (#5201)"
+assert_contains "$output_harness" "--agent claude-infra" "epic harness surfaces claude-infra packet (#5201)"
+assert_not_contains "$output_harness" "COLD START: NO LIVE THREAD ROLLOVER" "epic harness surfaces claude-infra packet (#5201)"
+
 printf 'marker_hit_stdout_bytes=%s\n' "$marker_bytes"
 printf 'fallback_warn_count=%s\n' "$fallback_warn_count"
 printf 'ok - session setup hook handoff fixtures passed\n'

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -123,12 +123,21 @@ epic_name_valid() {
 }
 
 # handoff_identity_for_epic "<epic-name>"
-# Echo the per-epic SESSION_HANDOFF_AGENT slot (claude-<epic>), or nothing when
-# no epic is given. An explicit epic BEATS the agent-type mapping: two sessions
-# of the same agent type on different epics must not share a handoff slot
+# Echo the per-epic SESSION_HANDOFF_AGENT slot, or nothing when no epic is given.
+# Default: claude-<epic>. An explicit epic BEATS the agent-type mapping so two
+# sessions of the same agent type on different epics never share a handoff slot
 # (root cause of the 2026-07-13 atlas/hramatka/main lane collision).
+#
+# Canonical-slot aliases: some epics are NOT free-standing lanes — they already
+# have a durable handoff identity elsewhere. Mapping them to a phantom
+# claude-<epic> slot hides live packets and causes silent cold starts (#5201).
+# harness (infra & fleet reliability / --epic harness) → claude-infra, the same
+# slot as --agent infra-orchestrator (lineage dir, session-state, inbox).
 handoff_identity_for_epic() {
   local epic="${1:-}"
   [ -n "$epic" ] || return 0
-  printf 'claude-%s' "$epic"
+  case "$epic" in
+    harness|infra) printf '%s' 'claude-infra' ;;
+    *) printf 'claude-%s' "$epic" ;;
+  esac
 }

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -139,10 +139,12 @@ export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
 # a LAUNCHER-ONLY flag (stripped before exec — the claude CLI does not know it).
 # It pins the session to one epic lane: SESSION_EPIC is exported for the
 # SessionStart hook to print a binding assignment banner, and the handoff slot
-# becomes claude-<epic> so two sessions of the SAME agent type on DIFFERENT
-# epics never share (or clobber) a thread handoff. Without --epic the hook
-# tells the session to ASK the user instead of defaulting to a lane — the
-# 2026-07-13 atlas/hramatka/main lane collision is the reason this exists.
+# becomes claude-<epic> (with canonical aliases: harness/infra → claude-infra
+# so packets under the durable infra slot surface — #5201) so two sessions of
+# the SAME agent type on DIFFERENT epics never share (or clobber) a thread
+# handoff. Without --epic the hook tells the session to ASK the user instead of
+# defaulting to a lane — the 2026-07-13 atlas/hramatka/main lane collision is
+# the reason this exists.
 _forward_args=("$@")
 if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
     # shellcheck source=scripts/lib/handoff_identity.sh

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -334,7 +334,10 @@ def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
     assert "If either fact is absent, use `unknown`" in prompt
     assert "Only an actionable response authorizes `set_thread_archived`" in prompt
     assert "must register and title this exact native replacement before resume" in prompt
-    assert "Keep the invoking checkout clean at prepared HEAD abc123def0456789 through resume and confirmation (clean fast-forward advances are tolerated)." in prompt
+    assert (
+        "Keep the invoking checkout clean at prepared HEAD abc123def0456789 through resume and confirmation (clean fast-forward advances are tolerated)."
+        in prompt
+    )
     assert "Context estimate: 86.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
     assert "orchestrator_control.py inbox --recent 20 --include-results" in prompt
 
@@ -451,6 +454,7 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     def make_is_ancestor(ancestry_map):
         def is_ancestor(expected, current):
             return ancestry_map.get((expected, current))
+
         return is_ancestor
 
     # 1. Descent accepted: prepared is ancestor of current
@@ -458,27 +462,29 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     assert th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_ok) is None
 
     # 2. Divergence rejected: neither is ancestor
-    is_ancestor_diverged = make_is_ancestor({
-        (prepared_head, current_head): False,
-        (current_head, prepared_head): False,
-    })
+    is_ancestor_diverged = make_is_ancestor(
+        {
+            (prepared_head, current_head): False,
+            (current_head, prepared_head): False,
+        }
+    )
     err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_diverged)
     assert f"invoking checkout HEAD {current_head} has diverged from prepared HEAD {prepared_head}" in err
 
     # 3. Rewind rejected: current is strict ancestor of prepared
-    is_ancestor_rewind = make_is_ancestor({
-        (prepared_head, current_head): False,
-        (current_head, prepared_head): True,
-    })
+    is_ancestor_rewind = make_is_ancestor(
+        {
+            (prepared_head, current_head): False,
+            (current_head, prepared_head): True,
+        }
+    )
     err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_rewind)
-    assert f"invoking checkout HEAD {current_head} is a rewind (strict ancestor of prepared HEAD {prepared_head})" in err
+    assert (
+        f"invoking checkout HEAD {current_head} is a rewind (strict ancestor of prepared HEAD {prepared_head})" in err
+    )
 
     # 4. Dirty-at-descent rejected: prepared is ancestor, but tree is dirty
-    dirty_state = {
-        **clean,
-        "full_head": current_head,
-        "modified_files": [{"status": "M", "path": "tracked.txt"}]
-    }
+    dirty_state = {**clean, "full_head": current_head, "modified_files": [{"status": "M", "path": "tracked.txt"}]}
     err = th.checkout_continuity_error(replacement, dirty_state, is_ancestor=is_ancestor_ok)
     assert "invoking checkout must be clean" in err
 
@@ -492,10 +498,12 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     assert "does not match prepared HEAD" in err
     assert "ancestry undeterminable" in err
 
-    is_ancestor_partial_none = make_is_ancestor({
-        (prepared_head, current_head): False,
-        (current_head, prepared_head): None,
-    })
+    is_ancestor_partial_none = make_is_ancestor(
+        {
+            (prepared_head, current_head): False,
+            (current_head, prepared_head): None,
+        }
+    )
     err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_partial_none)
     assert "does not match prepared HEAD" in err
     assert "ancestry undeterminable" in err
@@ -1399,6 +1407,74 @@ def test_confirmation_refuses_unresumed_and_identity_mismatched_rollovers(tmp_pa
             strict_verdict=strict_verdict,
             state_root=tmp_path,
         )
+
+
+def test_epic_harness_session_start_surfaces_claude_infra_pending_packet(tmp_path: Path, capsys, monkeypatch) -> None:
+    """#5201: --epic harness must resolve to claude-infra and surface its packet.
+
+    Regression: handoff_identity_for_epic used to invent ``claude-harness``, so
+    SessionStart reported COLD START while a validated pending_start packet sat
+    under ``claude-infra``. Identity guardrail stays intact — a packet bound to
+    another thread is still a stop condition (covered elsewhere).
+    """
+    import subprocess
+
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+
+    # Launcher mapping: --epic harness → claude-infra (not phantom claude-harness).
+    identity_sh = Path(__file__).resolve().parents[2] / "scripts" / "lib" / "handoff_identity.sh"
+    mapped = subprocess.check_output(
+        ["bash", "-c", f'source "{identity_sh}" && handoff_identity_for_epic harness'],
+        text=True,
+    ).strip()
+    assert mapped == "claude-infra", f"--epic harness must map to claude-infra, got {mapped!r}"
+    assert mapped != "claude-harness"
+
+    # Real lane packet lives under claude-infra (prepare as the lane does).
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "prepare",
+                "--agent",
+                "claude-infra",
+                "--active-thread-id",
+                "old-infra-thread",
+            ]
+        )
+        == 0
+    )
+    prepared_payload = json.loads(capsys.readouterr().out)
+    assert prepared_payload["agent"] == "claude-infra"
+
+    # Phantom slot: silent miss (the pre-fix failure mode).
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "claude-harness"]) == 0
+    assert json.loads(capsys.readouterr().out) == {"agent": "claude-harness", "status": "none"}
+
+    # Resolved slot (post-fix): SessionStart must surface the pending packet.
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "detect",
+                "--agent",
+                mapped,
+                "--format",
+                "session-start",
+                "--current-thread-id",
+                "new-infra-thread",
+            ]
+        )
+        == 0
+    )
+    startup = capsys.readouterr().out
+    assert "PENDING THREAD ROLLOVER DETECTED" in startup
+    assert "COLD START: NO LIVE THREAD ROLLOVER" not in startup
+    assert "--agent claude-infra" in startup
+    assert prepared_payload["lineage_id"] in startup
+    assert prepared_payload["rollover_id"] in startup
 
 
 def test_detect_is_structured_fail_closed_and_reports_reserved_packet_paths(tmp_path: Path, capsys, monkeypatch):

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -1409,74 +1409,6 @@ def test_confirmation_refuses_unresumed_and_identity_mismatched_rollovers(tmp_pa
         )
 
 
-def test_epic_harness_session_start_surfaces_claude_infra_pending_packet(tmp_path: Path, capsys, monkeypatch) -> None:
-    """#5201: --epic harness must resolve to claude-infra and surface its packet.
-
-    Regression: handoff_identity_for_epic used to invent ``claude-harness``, so
-    SessionStart reported COLD START while a validated pending_start packet sat
-    under ``claude-infra``. Identity guardrail stays intact — a packet bound to
-    another thread is still a stop condition (covered elsewhere).
-    """
-    import subprocess
-
-    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
-
-    # Launcher mapping: --epic harness → claude-infra (not phantom claude-harness).
-    identity_sh = Path(__file__).resolve().parents[2] / "scripts" / "lib" / "handoff_identity.sh"
-    mapped = subprocess.check_output(
-        ["bash", "-c", f'source "{identity_sh}" && handoff_identity_for_epic harness'],
-        text=True,
-    ).strip()
-    assert mapped == "claude-infra", f"--epic harness must map to claude-infra, got {mapped!r}"
-    assert mapped != "claude-harness"
-
-    # Real lane packet lives under claude-infra (prepare as the lane does).
-    assert (
-        th.main(
-            [
-                "--repo-root",
-                str(tmp_path),
-                "prepare",
-                "--agent",
-                "claude-infra",
-                "--active-thread-id",
-                "old-infra-thread",
-            ]
-        )
-        == 0
-    )
-    prepared_payload = json.loads(capsys.readouterr().out)
-    assert prepared_payload["agent"] == "claude-infra"
-
-    # Phantom slot: silent miss (the pre-fix failure mode).
-    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "claude-harness"]) == 0
-    assert json.loads(capsys.readouterr().out) == {"agent": "claude-harness", "status": "none"}
-
-    # Resolved slot (post-fix): SessionStart must surface the pending packet.
-    assert (
-        th.main(
-            [
-                "--repo-root",
-                str(tmp_path),
-                "detect",
-                "--agent",
-                mapped,
-                "--format",
-                "session-start",
-                "--current-thread-id",
-                "new-infra-thread",
-            ]
-        )
-        == 0
-    )
-    startup = capsys.readouterr().out
-    assert "PENDING THREAD ROLLOVER DETECTED" in startup
-    assert "COLD START: NO LIVE THREAD ROLLOVER" not in startup
-    assert "--agent claude-infra" in startup
-    assert prepared_payload["lineage_id"] in startup
-    assert prepared_payload["rollover_id"] in startup
-
-
 def test_detect_is_structured_fail_closed_and_reports_reserved_packet_paths(tmp_path: Path, capsys, monkeypatch):
     monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
     assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 0
@@ -1792,3 +1724,71 @@ def test_confirmation_revalidates_probe_before_handwritten_pass_can_unlock_clean
     assert resumed == before_confirmation
     assert resumed["replacement"]["status"] == "resumed"
     assert resumed["cleanup"]["old_automation_ready_to_delete"] is False
+
+
+def test_epic_harness_session_start_surfaces_claude_infra_pending_packet(tmp_path: Path, capsys, monkeypatch) -> None:
+    """#5201: --epic harness must resolve to claude-infra and surface its packet.
+
+    Regression: handoff_identity_for_epic used to invent ``claude-harness``, so
+    SessionStart reported COLD START while a validated pending_start packet sat
+    under ``claude-infra``. Identity guardrail stays intact — a packet bound to
+    another thread is still a stop condition (covered elsewhere).
+    """
+    import subprocess
+
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+
+    # Launcher mapping: --epic harness → claude-infra (not phantom claude-harness).
+    identity_sh = Path(__file__).resolve().parents[2] / "scripts" / "lib" / "handoff_identity.sh"
+    mapped = subprocess.check_output(
+        ["bash", "-c", f'source "{identity_sh}" && handoff_identity_for_epic harness'],
+        text=True,
+    ).strip()
+    assert mapped == "claude-infra", f"--epic harness must map to claude-infra, got {mapped!r}"
+    assert mapped != "claude-harness"
+
+    # Real lane packet lives under claude-infra (prepare as the lane does).
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "prepare",
+                "--agent",
+                "claude-infra",
+                "--active-thread-id",
+                "old-infra-thread",
+            ]
+        )
+        == 0
+    )
+    prepared_payload = json.loads(capsys.readouterr().out)
+    assert prepared_payload["agent"] == "claude-infra"
+
+    # Phantom slot: silent miss (the pre-fix failure mode).
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "claude-harness"]) == 0
+    assert json.loads(capsys.readouterr().out) == {"agent": "claude-harness", "status": "none"}
+
+    # Resolved slot (post-fix): SessionStart must surface the pending packet.
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "detect",
+                "--agent",
+                mapped,
+                "--format",
+                "session-start",
+                "--current-thread-id",
+                "new-infra-thread",
+            ]
+        )
+        == 0
+    )
+    startup = capsys.readouterr().out
+    assert "PENDING THREAD ROLLOVER DETECTED" in startup
+    assert "COLD START: NO LIVE THREAD ROLLOVER" not in startup
+    assert "--agent claude-infra" in startup
+    assert prepared_payload["lineage_id"] in startup
+    assert prepared_payload["rollover_id"] in startup

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -334,10 +334,7 @@ def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
     assert "If either fact is absent, use `unknown`" in prompt
     assert "Only an actionable response authorizes `set_thread_archived`" in prompt
     assert "must register and title this exact native replacement before resume" in prompt
-    assert (
-        "Keep the invoking checkout clean at prepared HEAD abc123def0456789 through resume and confirmation (clean fast-forward advances are tolerated)."
-        in prompt
-    )
+    assert "Keep the invoking checkout clean at prepared HEAD abc123def0456789 through resume and confirmation (clean fast-forward advances are tolerated)." in prompt
     assert "Context estimate: 86.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
     assert "orchestrator_control.py inbox --recent 20 --include-results" in prompt
 
@@ -454,7 +451,6 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     def make_is_ancestor(ancestry_map):
         def is_ancestor(expected, current):
             return ancestry_map.get((expected, current))
-
         return is_ancestor
 
     # 1. Descent accepted: prepared is ancestor of current
@@ -462,29 +458,27 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     assert th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_ok) is None
 
     # 2. Divergence rejected: neither is ancestor
-    is_ancestor_diverged = make_is_ancestor(
-        {
-            (prepared_head, current_head): False,
-            (current_head, prepared_head): False,
-        }
-    )
+    is_ancestor_diverged = make_is_ancestor({
+        (prepared_head, current_head): False,
+        (current_head, prepared_head): False,
+    })
     err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_diverged)
     assert f"invoking checkout HEAD {current_head} has diverged from prepared HEAD {prepared_head}" in err
 
     # 3. Rewind rejected: current is strict ancestor of prepared
-    is_ancestor_rewind = make_is_ancestor(
-        {
-            (prepared_head, current_head): False,
-            (current_head, prepared_head): True,
-        }
-    )
+    is_ancestor_rewind = make_is_ancestor({
+        (prepared_head, current_head): False,
+        (current_head, prepared_head): True,
+    })
     err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_rewind)
-    assert (
-        f"invoking checkout HEAD {current_head} is a rewind (strict ancestor of prepared HEAD {prepared_head})" in err
-    )
+    assert f"invoking checkout HEAD {current_head} is a rewind (strict ancestor of prepared HEAD {prepared_head})" in err
 
     # 4. Dirty-at-descent rejected: prepared is ancestor, but tree is dirty
-    dirty_state = {**clean, "full_head": current_head, "modified_files": [{"status": "M", "path": "tracked.txt"}]}
+    dirty_state = {
+        **clean,
+        "full_head": current_head,
+        "modified_files": [{"status": "M", "path": "tracked.txt"}]
+    }
     err = th.checkout_continuity_error(replacement, dirty_state, is_ancestor=is_ancestor_ok)
     assert "invoking checkout must be clean" in err
 
@@ -498,12 +492,10 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     assert "does not match prepared HEAD" in err
     assert "ancestry undeterminable" in err
 
-    is_ancestor_partial_none = make_is_ancestor(
-        {
-            (prepared_head, current_head): False,
-            (current_head, prepared_head): None,
-        }
-    )
+    is_ancestor_partial_none = make_is_ancestor({
+        (prepared_head, current_head): False,
+        (current_head, prepared_head): None,
+    })
     err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_partial_none)
     assert "does not match prepared HEAD" in err
     assert "ancestry undeterminable" in err
@@ -1495,6 +1487,74 @@ def test_detect_rejects_bad_or_ambiguous_engine_leases(tmp_path: Path, capsys, m
     assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 2
 
 
+def test_epic_harness_session_start_surfaces_claude_infra_pending_packet(tmp_path: Path, capsys, monkeypatch) -> None:
+    """#5201: --epic harness must resolve to claude-infra and surface its packet.
+
+    Regression: handoff_identity_for_epic used to invent ``claude-harness``, so
+    SessionStart reported COLD START while a validated pending_start packet sat
+    under ``claude-infra``. Identity guardrail stays intact — a packet bound to
+    another thread is still a stop condition (covered elsewhere).
+    """
+    import subprocess
+
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+
+    # Launcher mapping: --epic harness → claude-infra (not phantom claude-harness).
+    identity_sh = Path(__file__).resolve().parents[2] / "scripts" / "lib" / "handoff_identity.sh"
+    mapped = subprocess.check_output(
+        ["bash", "-c", f'source "{identity_sh}" && handoff_identity_for_epic harness'],
+        text=True,
+    ).strip()
+    assert mapped == "claude-infra", f"--epic harness must map to claude-infra, got {mapped!r}"
+    assert mapped != "claude-harness"
+
+    # Real lane packet lives under claude-infra (prepare as the lane does).
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "prepare",
+                "--agent",
+                "claude-infra",
+                "--active-thread-id",
+                "old-infra-thread",
+            ]
+        )
+        == 0
+    )
+    prepared_payload = json.loads(capsys.readouterr().out)
+    assert prepared_payload["agent"] == "claude-infra"
+
+    # Phantom slot: silent miss (the pre-fix failure mode).
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "claude-harness"]) == 0
+    assert json.loads(capsys.readouterr().out) == {"agent": "claude-harness", "status": "none"}
+
+    # Resolved slot (post-fix): SessionStart must surface the pending packet.
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "detect",
+                "--agent",
+                mapped,
+                "--format",
+                "session-start",
+                "--current-thread-id",
+                "new-infra-thread",
+            ]
+        )
+        == 0
+    )
+    startup = capsys.readouterr().out
+    assert "PENDING THREAD ROLLOVER DETECTED" in startup
+    assert "COLD START: NO LIVE THREAD ROLLOVER" not in startup
+    assert "--agent claude-infra" in startup
+    assert prepared_payload["lineage_id"] in startup
+    assert prepared_payload["rollover_id"] in startup
+
+
 def test_lifecycle_requires_strict_ten_of_ten_before_cleanup(tmp_path: Path, capsys, monkeypatch):
     monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
     assert (
@@ -1724,71 +1784,3 @@ def test_confirmation_revalidates_probe_before_handwritten_pass_can_unlock_clean
     assert resumed == before_confirmation
     assert resumed["replacement"]["status"] == "resumed"
     assert resumed["cleanup"]["old_automation_ready_to_delete"] is False
-
-
-def test_epic_harness_session_start_surfaces_claude_infra_pending_packet(tmp_path: Path, capsys, monkeypatch) -> None:
-    """#5201: --epic harness must resolve to claude-infra and surface its packet.
-
-    Regression: handoff_identity_for_epic used to invent ``claude-harness``, so
-    SessionStart reported COLD START while a validated pending_start packet sat
-    under ``claude-infra``. Identity guardrail stays intact — a packet bound to
-    another thread is still a stop condition (covered elsewhere).
-    """
-    import subprocess
-
-    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
-
-    # Launcher mapping: --epic harness → claude-infra (not phantom claude-harness).
-    identity_sh = Path(__file__).resolve().parents[2] / "scripts" / "lib" / "handoff_identity.sh"
-    mapped = subprocess.check_output(
-        ["bash", "-c", f'source "{identity_sh}" && handoff_identity_for_epic harness'],
-        text=True,
-    ).strip()
-    assert mapped == "claude-infra", f"--epic harness must map to claude-infra, got {mapped!r}"
-    assert mapped != "claude-harness"
-
-    # Real lane packet lives under claude-infra (prepare as the lane does).
-    assert (
-        th.main(
-            [
-                "--repo-root",
-                str(tmp_path),
-                "prepare",
-                "--agent",
-                "claude-infra",
-                "--active-thread-id",
-                "old-infra-thread",
-            ]
-        )
-        == 0
-    )
-    prepared_payload = json.loads(capsys.readouterr().out)
-    assert prepared_payload["agent"] == "claude-infra"
-
-    # Phantom slot: silent miss (the pre-fix failure mode).
-    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "claude-harness"]) == 0
-    assert json.loads(capsys.readouterr().out) == {"agent": "claude-harness", "status": "none"}
-
-    # Resolved slot (post-fix): SessionStart must surface the pending packet.
-    assert (
-        th.main(
-            [
-                "--repo-root",
-                str(tmp_path),
-                "detect",
-                "--agent",
-                mapped,
-                "--format",
-                "session-start",
-                "--current-thread-id",
-                "new-infra-thread",
-            ]
-        )
-        == 0
-    )
-    startup = capsys.readouterr().out
-    assert "PENDING THREAD ROLLOVER DETECTED" in startup
-    assert "COLD START: NO LIVE THREAD ROLLOVER" not in startup
-    assert "--agent claude-infra" in startup
-    assert prepared_payload["lineage_id"] in startup
-    assert prepared_payload["rollover_id"] in startup


### PR DESCRIPTION
## Summary

Fixes the infra/harness cold-start that silently missed live rollover packets when launched with `--epic harness`, and leans the infra agent cold-start the same way #5266 leaned the track-driver.

### Problem 1 — #5201 (PRIMARY)
`--epic harness` resolved `SESSION_HANDOFF_AGENT=claude-harness` via the generic `claude-<epic>` pattern, but this lane's packets live under **`claude-infra`**. SessionStart reported `COLD START: NO LIVE THREAD ROLLOVER` while a validated `pending_start` packet sat on disk.

**Fix:** `handoff_identity_for_epic` now maps `harness`/`infra` → `claude-infra` (same durable slot as `--agent infra-orchestrator`). Other epics (`atlas` → `claude-atlas`, etc.) unchanged.

### Problem 2 — mirror #5266 onto infra cold-start
In `infra-orchestrator` source (`agents_extensions/shared/agents/`):
- **Drop** the blanket ~76 KB `/api/rules` fetch at cold-start (operator-contract digest already injected; fetch routing on-demand before first dispatch; re-pull only when `manifest.rules.hash` changes)
- **Wire ctx:** pass `?session=$CLAUDE_CODE_SESSION_ID` to `/api/state/manifest` and `/api/orient`
- Document #5265 transcript-mapping gap + `newest_transcript.ctx` fallback (same mechanism as #5266 — no parallel plumbing)

## Before / after cold-start payload (measured live)

| Endpoint | Before (infra cold-start) | After |
| --- | ---: | ---: |
| `/api/rules?format=markdown` | **75,779 B** every time (no useful 304) | **0** at cold-start (on-demand later) |
| `/api/orient` | 16,902 B, `_telemetry.ctx=null` | ~16,660 B with `?session=` |
| `/api/state/manifest` | 1,315 B, `_telemetry.ctx=null` | ~1,082 B with `?session=` |
| **Total cold-start API body** | **~94 KB** | **~18 KB** (~76 KB saved) |

`_telemetry.ctx` population: with `?session=` the API *attempts* caller-matched ctx. Unresolved sessions still return `session-transcript-not-found` (#5265); instructions fall back to no-session `newest_transcript.ctx` (measured live: **599,276** tokens) so the lane can still measure context. Do not invent a parallel ctx path.

## Slot-bug proof (tests)

1. `handoff_identity_for_epic harness` → `claude-infra` (not `claude-harness`)
2. SessionStart hook fixture: live `claude-infra` `pending_start` + resolved harness slot → **PENDING THREAD ROLLOVER DETECTED**; phantom `claude-harness` → still cold start (proves the old bug)
3. `test_epic_harness_session_start_surfaces_claude_infra_pending_packet` end-to-end in `thread_handoff` detect path

Identity guardrail unchanged: a packet bound to another thread remains a stop condition.

## Files
- `scripts/lib/handoff_identity.sh` — harness/infra → claude-infra
- `scripts/audit/test_handoff_identity.sh` / `test_session_setup_hook.sh` — fixtures
- `tests/orchestration/test_thread_handoff.py` — regression test
- `agents_extensions/shared/agents/infra-orchestrator.md` — lean cold-start
- `start-claude.sh`, `docs/session-state/current.claude-infra.md` — docs

## Verification
- `pytest tests/test_handoff_identity.py tests/test_session_setup_hook.py tests/orchestration/test_thread_handoff.py` (detect/handoff subset + full thread_handoff pre-commit: 59 passed)
- Live API size measurements above
- Does **not** touch #5266 track-driver def

Closes #5201  
Coordinates with #5265 #5266

**No auto-merge** — review gate first.