### PR TITLE
feat(api): lean cold-start preset for /api/orient (#4728)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -83,8 +83,10 @@ curl -s http://localhost:8765/api/state/manifest
 curl -s http://localhost:8765/api/rules?format=markdown     # ~1.3 KB
 curl -s 'http://localhost:8765/api/session/current?agent=orchestrator'  # ~1-3 KB
 
-# 3. Always-fresh: git, pipeline, runtime, wiki, health, hints — with meta.
-curl -s http://localhost:8765/api/orient
+# 3. Lean cold-start orient — git, runtime, delegate, bridge, governance, health, hints.
+#    Skips the heavy pipeline/issues/wiki sections (fetch those on demand once you have a
+#    lane, e.g. ?sections=pipeline). Drop ?lean=true for the full legacy payload.
+curl -s 'http://localhost:8765/api/orient?lean=true'
 # Use ?fresh=true right after you committed or filed an issue.
 
 # 4. Optional: do I have unread channel deliveries?

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -249,6 +249,22 @@ ORIENT_SECTION_HARD_TIMEOUT_S = 5.0
 
 ORIENT_SECTION_KEYS: tuple[str, ...] = tuple(ORIENT_SECTION_TTLS.keys())
 
+# Lean cold-start preset (``?lean=true``): the small, lane-agnostic sections an agent needs to
+# orient BEFORE it has selected work — tree state (git), active dispatches (delegate), pending
+# bridge asks, blocking decisions (governance), health, and the handoff pointers / current goal
+# (session_hints). Excludes the three heavy sections — ``pipeline`` (~2k module stats),
+# ``issues`` (full gh list), ``wiki`` (per-track coverage) — which are fetched on demand via
+# ``?sections=...``. Cuts the default cold-start payload sharply (codex cold-start review; #4728).
+LEAN_ORIENT_SECTIONS: tuple[str, ...] = (
+    "git",
+    "runtime",
+    "delegate",
+    "bridge_pending",
+    "governance",
+    "health",
+    "session_hints",
+)
+
 # Orient sync collectors use a dedicated executor instead of the loop's
 # shared default pool. This isolates cheap orient reads from unrelated
 # ``asyncio.to_thread()`` backlog elsewhere in the process, which was
@@ -750,13 +766,18 @@ async def _cached_orient_section(
     return value, meta
 
 
-def _parse_orient_sections(sections_param: str | None) -> list[str]:
-    """Validate and expand the optional ``sections`` query param."""
+def _parse_orient_sections(sections_param: str | None, *, lean: bool = False) -> list[str]:
+    """Validate and expand the optional ``sections`` query param.
+
+    An explicit ``sections`` list always wins. When it is absent, ``lean`` selects the
+    lightweight cold-start preset (``LEAN_ORIENT_SECTIONS``); otherwise the full payload.
+    """
+    default = list(LEAN_ORIENT_SECTIONS if lean else ORIENT_SECTION_KEYS)
     if sections_param is None:
-        return list(ORIENT_SECTION_KEYS)
+        return default
     keys = [part.strip() for part in sections_param.split(",") if part.strip()]
     if not keys:
-        return list(ORIENT_SECTION_KEYS)
+        return default
     unknown = [key for key in keys if key not in ORIENT_SECTION_TTLS]
     if unknown:
         valid = ", ".join(ORIENT_SECTION_KEYS)
@@ -798,6 +819,12 @@ def _orient_section_specs() -> dict[str, tuple[Callable[..., Any], Any, bool]]:
 async def orient(
     request: Request,
     fresh: bool = False,
+    lean: bool = Query(
+        False,
+        description="Lean cold-start preset: return only the lightweight sections "
+        "(git, runtime, delegate, bridge_pending, governance, health, session_hints), "
+        "skipping the heavy pipeline/issues/wiki. Ignored when 'sections' is given.",
+    ),
     sections: str | None = Query(
         None,
         description="Comma-separated subset of orient sections to collect.",
@@ -829,7 +856,7 @@ async def orient(
     if fresh:
         cache_invalidate("orient_")
 
-    selected = _parse_orient_sections(sections)
+    selected = _parse_orient_sections(sections, lean=lean)
     section_specs = _orient_section_specs()
     gather_results = await asyncio.gather(
         *[

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -137,6 +137,23 @@ def test_orient_returns_all_top_level_keys(monkeypatch):
     assert expected <= set(data)
 
 
+def test_parse_orient_sections_lean_preset_excludes_heavy_sections():
+    # The lean cold-start preset returns only the lightweight sections; the heavy
+    # pipeline/issues/wiki are excluded (fetched on demand). Tested at the pure-function
+    # level: the /api/orient handler is a thin passthrough to this selector.
+    lean = api_main._parse_orient_sections(None, lean=True)
+    assert lean == list(api_main.LEAN_ORIENT_SECTIONS)
+    assert not ({"pipeline", "issues", "wiki"} & set(lean))
+    assert {"git", "delegate", "governance", "health", "session_hints"} <= set(lean)
+
+
+def test_parse_orient_sections_explicit_list_overrides_lean():
+    # An explicit sections list always wins over the lean preset...
+    assert api_main._parse_orient_sections("pipeline", lean=True) == ["pipeline"]
+    # ...and with neither lean nor an explicit list, the full payload is returned.
+    assert api_main._parse_orient_sections(None, lean=False) == list(api_main.ORIENT_SECTION_KEYS)
+
+
 def test_orient_git_exposes_primary_checkout_dirty_signal(monkeypatch, tmp_path):
     original_git_collector = api_main._collect_git_orient_data
     repo = _init_orient_git_repo(tmp_path)


### PR DESCRIPTION
First concrete fix from the cold-start review (codex, on #5265): **/api/orient over-returns before a lane is selected** — all ~2k module stats + full issue/wiki/runtime history.

## Change
Adds `?lean=true` to `/api/orient`:
- Returns only the **lightweight** orientation sections: `git, runtime, delegate, bridge_pending, governance, health, session_hints`.
- **Skips** the heavy `pipeline` (~2k module stats), `issues` (full gh list), and `wiki` sections — fetched on demand via `?sections=...` once a lane is chosen.
- An explicit `?sections=` list **always wins** over `lean`.
- Default (no `lean`, no `sections`) is the **unchanged full payload** (back-compat).

`docs/MONITOR-API.md` cold-start sequence updated to `?lean=true`.

## Tests
Selection logic unit-tested on `_parse_orient_sections` (lean preset excludes heavy sections; explicit list overrides lean; default = full). The handler is a thin passthrough. 22 orient tests pass; ruff clean.

Refs #4728 #5265. Part of the cold-start improvements (lane-scoped orient is the highest-leverage item).