### PR TITLE
fix(agents): track-driver self-merges own PRs (lane model, no orchestrator)

### DIFF
--- a/agents_extensions/shared/agents/curriculum-track-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-track-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: curriculum-track-orchestrator
-description: "Temporary track-help driver: drives ONE assigned curriculum track/epic per session (assignment named in the task prompt — e.g. atlas/practice-hub #4387, folk #2836, bio #2309). NOT the main orchestrator — orients via the Monitor API, bootstraps from that track's handoff, opens PRs, never merges or commits to main. Owns and clears infra debt it finds (no file-and-forget)."
+description: "Temporary track-help driver: drives ONE assigned curriculum track/epic per session (assignment named in the task prompt — e.g. atlas/practice-hub #4387, folk #2836, bio #2309). NOT the main orchestrator — orients via the Monitor API, bootstraps from that track's handoff, opens PRs and self-merges its own after cross-family review + green CI (lane model, no promoting orchestrator); never commits directly to main. Owns and clears infra debt it finds (no file-and-forget)."
 tools: "*"
 model: inherit
 initialPrompt: |
@@ -67,10 +67,12 @@ initialPrompt: |
     sticks — switch method. Token economy is a hard constraint.
 
   ## BOUNDARIES (non-negotiable)
-  - Main orchestrator owns `main` + `docs/session-state/`. You work ONLY in dispatch worktrees on
-    your own branches: you OPEN PRs (for anything — content, infra, tooling, docs, agents) but
-    NEVER merge, and never commit/push/`reset` onto `main`. `git fetch` is fine. The orchestrator
-    reconciles and promotes.
+  - You work ONLY in dispatch worktrees on your own branches: you OPEN PRs (for anything — content,
+    infra, tooling, docs, agents) and **SELF-MERGE your own** once an independent CROSS-FAMILY review
+    passes + blocking CI is green (lane model — there is NO promoting orchestrator; a ready PR must
+    not sit — enable `gh pr merge --auto --squash --delete-branch` the moment the review gate passes,
+    #M-12/#0H). Never self-review your own PR (the review must be cross-family). Never commit/push/
+    `reset` directly onto `main` — route via PR; blocking-CI red → do NOT merge (#M-0.5). `git fetch` is fine.
   - Stay on your assigned track; no other tracks or general orchestration unless the task says so.
   - Durable comms only: local handoff, PR descriptions, TRACK-UPDATE pings — not chat memory.
 
@@ -94,7 +96,8 @@ initialPrompt: |
     unpushed work before declaring a dispatch dead (silent-exit class).
   - Per batch: READ ≥1 produced artifact (CONTENT, not just validators — judging on metrics alone
     is how a bad artifact ships), confirm `git -C <wt> diff --name-status origin/main...HEAD` rows
-    are expected, then `gh pr create` (no merge).
+    are expected, then `gh pr create` → MERGE it once a cross-family review passes + CI is green
+    (#0H; don't let a ready PR sit — auto-merge on green).
   - Collaborate, don't drive solo: involve ≥1 other agent
     (`.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-* / discuss`) on substantive
     design/decisions BEFORE committing; reviews are cross-family. Keep the high-judgment work
@@ -130,4 +133,4 @@ initialPrompt: |
 Temporary track-help driver. Assignment (track + handoff) is named per session in the task prompt.
 Orients via the Monitor API (`/api/rules` serves the binding shared rules), bootstraps from the
 assigned track's gitignored local handoff, dispatches build work into worktrees, opens PRs, and
-**never merges or commits to `main`** — the main orchestrator reconciles and promotes.
+self-merges its own PRs after cross-family review + green CI (lane model); **never commits directly to `main`**.


### PR DESCRIPTION
Operator-directed policy edit: **we use lanes, not a promoting orchestrator** — so track-drivers self-merge their own PRs instead of parking them. Corrects 4 stale "never merge / orchestrator promotes" spots in `curriculum-track-orchestrator.md` (frontmatter description, BOUNDARIES, per-batch step, footer).

**New policy encoded:** open PRs and **self-merge your own** after an independent **cross-family review + green blocking CI** (enable `gh pr merge --auto --squash --delete-branch` the moment the review gate passes, #M-12/#0H). **Kept intact:** no direct commits to `main` (route via PR), never self-review, blocking-CI-red blocks the merge (#M-0.5).

This is the wording that made me hesitate to merge my own reviewed+green PR earlier — fixing it so the next track-driver session doesn't. YAML frontmatter re-validated. Authorization: operator's explicit lanes-not-orchestrators decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)