### PR TITLE
feat(api): context-aware cold start — pass session id for _telemetry.ctx (#5265)

### DIFF
--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -28,10 +28,14 @@ functional role.
 Shell equivalent:
 
 ```bash
-curl -s http://localhost:8765/api/state/manifest         # ~1 KB index
-curl -s http://localhost:8765/api/rules?format=markdown  # only if hash changed
+# Pass your session id on the telemetry-bearing endpoints (manifest/rules/orient) so responses
+# carry live context-window telemetry (_telemetry.ctx) instead of null. Claude Code exports it as
+# $CLAUDE_CODE_SESSION_ID; empty is fine (the API falls back to a best-effort newest-transcript hint).
+S="${CLAUDE_CODE_SESSION_ID:-}"
+curl -s "http://localhost:8765/api/state/manifest?session=$S"           # ~1 KB index
+curl -s "http://localhost:8765/api/rules?format=markdown&session=$S"    # only if hash changed
 curl -s 'http://localhost:8765/api/session/current?agent=orchestrator'  # only if hash changed
-curl -s http://localhost:8765/api/orient                 # always-fresh, has meta
+curl -s "http://localhost:8765/api/orient?lean=true&session=$S"         # lean, always-fresh, has meta
 # Known functional role only: replace `quality` with the assigned role.
 curl -s 'http://localhost:8765/api/knowledge/cold-start?role=quality'  # role-scoped pointers
 # Generic or genuinely role-unknown session: skip the role-scoped request; remain pointer-free.

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -76,17 +76,22 @@ ETag and cache semantics are unchanged.
 **Recommended cold-start sequence (GH #1309, since P1):**
 
 ```bash
+# Pass your session id on telemetry-bearing endpoints (manifest/rules/orient) so responses carry
+# live context-window telemetry (_telemetry.ctx) instead of null. Claude Code exports it as
+# $CLAUDE_CODE_SESSION_ID; empty is fine (falls back to a best-effort newest-transcript hint).
+S="${CLAUDE_CODE_SESSION_ID:-}"
+
 # 1. Tiny index of per-component hashes — decide what to fetch.
-curl -s http://localhost:8765/api/state/manifest
+curl -s "http://localhost:8765/api/state/manifest?session=$S"
 
 # 2. Only fetch components whose hash changed since last session.
-curl -s http://localhost:8765/api/rules?format=markdown     # ~1.3 KB
+curl -s "http://localhost:8765/api/rules?format=markdown&session=$S"     # ~1.3 KB
 curl -s 'http://localhost:8765/api/session/current?agent=orchestrator'  # ~1-3 KB
 
 # 3. Lean cold-start orient — git, runtime, delegate, bridge, governance, health, hints.
 #    Skips the heavy pipeline/issues/wiki sections (fetch those on demand once you have a
 #    lane, e.g. ?sections=pipeline). Drop ?lean=true for the full legacy payload.
-curl -s 'http://localhost:8765/api/orient?lean=true'
+curl -s "http://localhost:8765/api/orient?lean=true&session=$S"
 # Use ?fresh=true right after you committed or filed an issue.
 
 # 4. Optional: do I have unread channel deliveries?

--- a/scripts/ai_agent_bridge/monitor_client.py
+++ b/scripts/ai_agent_bridge/monitor_client.py
@@ -200,7 +200,10 @@ class MonitorClient:
         """
         url = self.base_url + path
         merged_headers = dict(headers or {})
-        if self.session_id and "X-Session-Id" not in merged_headers:
+        # Only inject when the caller has not already supplied the header in ANY case — urllib
+        # title-cases header keys, so a caller's ``x-session-id`` would otherwise collide with and
+        # be clobbered by the injected value. An explicit caller header always wins.
+        if self.session_id and not any(k.lower() == "x-session-id" for k in merged_headers):
             merged_headers["X-Session-Id"] = self.session_id
         req = urllib.request.Request(url, headers=merged_headers)
         try:

--- a/scripts/ai_agent_bridge/monitor_client.py
+++ b/scripts/ai_agent_bridge/monitor_client.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -166,9 +167,15 @@ class MonitorClient:
         base_url: str = DEFAULT_BASE_URL,
         *,
         timeout_s: float = DEFAULT_TIMEOUT_S,
+        session_id: str | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.timeout_s = timeout_s
+        # Send the caller's session id (Claude Code exports $CLAUDE_CODE_SESSION_ID) as the
+        # X-Session-Id header on every request, so telemetry-bearing responses carry live
+        # context-window telemetry (_telemetry.ctx) instead of null. Empty/absent is fine — the
+        # API degrades to a best-effort newest-transcript hint.
+        self.session_id = session_id or os.environ.get("CLAUDE_CODE_SESSION_ID") or None
 
     # -- low-level HTTP --------------------------------------------
 
@@ -192,7 +199,10 @@ class MonitorClient:
         ``bootstrap()`` with an unhandled ``HTTPError``.
         """
         url = self.base_url + path
-        req = urllib.request.Request(url, headers=headers or {})
+        merged_headers = dict(headers or {})
+        if self.session_id and "X-Session-Id" not in merged_headers:
+            merged_headers["X-Session-Id"] = self.session_id
+        req = urllib.request.Request(url, headers=merged_headers)
         try:
             with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
                 body = resp.read().decode("utf-8", errors="replace")

--- a/tests/test_monitor_client_sdk.py
+++ b/tests/test_monitor_client_sdk.py
@@ -320,3 +320,9 @@ def test_monitor_client_injects_session_id_header(monkeypatch):
     monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
     monitor_client.MonitorClient()._get("/api/x")
     assert captured["req"].get_header("X-session-id") is None
+
+    # 4. A caller-supplied header wins in ANY case — urllib title-cases keys, so a lowercase
+    #    x-session-id must not be clobbered by the injected session id.
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "sid-env")
+    monitor_client.MonitorClient()._get("/api/x", headers={"x-session-id": "caller-explicit"})
+    assert captured["req"].get_header("X-session-id") == "caller-explicit"

--- a/tests/test_monitor_client_sdk.py
+++ b/tests/test_monitor_client_sdk.py
@@ -35,6 +35,18 @@ client = TestClient(api_main.app, raise_server_exceptions=False)
 # ---------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _disable_telemetry_footer(monkeypatch):
+    """Keep these SDK/ETag assertions hermetic against the telemetry footer.
+
+    In a live agent session LEARN_UKRAINIAN_TELEMETRY_FOOTER=1 is set, which appends a
+    ``_telemetry`` footer to /api/rules + /api/session/current responses and perturbs the ETag /
+    304 assertions (they read raw headers). CI runs with the footer off; pin it off here so the
+    tests pass regardless of the ambient env instead of failing only inside an agent session.
+    """
+    monkeypatch.setenv("AGENT_NO_TELEMETRY_FOOTER", "1")
+
+
 @pytest.fixture
 def stub_rules(monkeypatch, tmp_path):
     rule = tmp_path / "rule.md"
@@ -264,3 +276,47 @@ def test_sdk_survives_session_404(monkeypatch, tmp_path):
     )
     assert result.body == ""
     assert result.hash == ""
+
+
+def test_monitor_client_injects_session_id_header(monkeypatch):
+    """The SDK sends the caller's session id as X-Session-Id so telemetry-bearing responses
+    carry _telemetry.ctx (explicit arg wins; else $CLAUDE_CODE_SESSION_ID; else no header)."""
+    import urllib.request as _urllib
+
+    captured: dict[str, object] = {}
+
+    class _Resp:
+        status = 200
+
+        @property
+        def headers(self) -> dict[str, str]:
+            return {}
+
+        def read(self) -> bytes:
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a) -> bool:
+            return False
+
+    def _fake_urlopen(req, timeout=None):
+        captured["req"] = req
+        return _Resp()
+
+    monkeypatch.setattr(_urllib, "urlopen", _fake_urlopen)
+
+    # 1. Explicit session_id is sent (urllib title-cases the header key on the Request).
+    monitor_client.MonitorClient(session_id="sid-explicit")._get("/api/x")
+    assert captured["req"].get_header("X-session-id") == "sid-explicit"
+
+    # 2. Falls back to $CLAUDE_CODE_SESSION_ID when no explicit id is given.
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "sid-env")
+    monitor_client.MonitorClient()._get("/api/x")
+    assert captured["req"].get_header("X-session-id") == "sid-env"
+
+    # 3. No session id anywhere → no header (the API degrades to a best-effort hint).
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    monitor_client.MonitorClient()._get("/api/x")
+    assert captured["req"].get_header("X-session-id") is None

--- a/tests/test_research_registry_p6.py
+++ b/tests/test_research_registry_p6.py
@@ -47,7 +47,7 @@ def test_known_role_bootstrap_contract_is_explicit_in_source() -> None:
     assert "http://localhost:8765/api/knowledge/cold-start?role=quality" in content
     assert "replace `quality` with the assigned role" in content
     assert "Generic or genuinely role-unknown session: skip the role-scoped request; remain pointer-free." in content
-    assert "curl -s http://localhost:8765/api/orient                 # always-fresh, has meta" in content
+    assert 'curl -s "http://localhost:8765/api/orient?lean=true&session=$S"' in content
     assert "/api/orient?role=" not in content
 
     # Deployment is verified separately by scripts/check_rules_deployment.sh;


### PR DESCRIPTION
Second cold-start fix (codex review, #5265): **the API couldn't identify the caller's session, so `_telemetry.ctx` was always `null`** — the context-aware startup couldn't measure the context window.

## Root cause
The cold-start curls hit the telemetry-bearing endpoints (manifest/rules/orient) **without a session id**. The resolver (`session_context_telemetry`) already maps a session id → the caller's transcript correctly — verified in-process it returns a real `ctx` (not null). The id just wasn't being passed.

## Change
- **`MonitorClient`** now sends `X-Session-Id` on every request: explicit `session_id=` arg wins, else `$CLAUDE_CODE_SESSION_ID` (which Claude Code exports), else no header (the API degrades to a best-effort newest-transcript hint). Unit-tested.
- The **documented cold-start sequences** (served `workflow.md` + `MONITOR-API.md`) pass `?session=$CLAUDE_CODE_SESSION_ID` on manifest/rules/orient (and adopt `?lean=true` from #5268).
- **Bonus hermeticity fix:** `test_monitor_client_sdk.py`'s ETag/304 tests were failing *inside a live agent session* (where `LEARN_UKRAINIAN_TELEMETRY_FOOTER=1` appends a footer that perturbs the headers) while passing in CI. An autouse fixture now pins the footer OFF so they're env-independent.

## Note
The running Monitor API instance is **stale** (pre-#5268 — still ignores `?lean=true`); it needs a restart to serve current code, after which lean + session-ctx are live. Code is correct + tested; live-verification waits on that restart.

Refs #5265. 15/15 tests pass; ruff clean.