### PR TITLE
feat(lifecycle): compose seminar direction policies

### DIFF
--- a/agents_extensions/shared/curriculum-lifecycle/config/pilot-matrix.v1.yaml
+++ b/agents_extensions/shared/curriculum-lifecycle/config/pilot-matrix.v1.yaml
@@ -19,9 +19,18 @@ identity_paths:
   - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core-c1.md
   - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core-c2.md
   - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-bio.md
+  - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-bio-v1-2.md
   - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-folk.md
+  - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-folk-v1-2.md
+  - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-hist-v1-2.md
+  - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-istorio-v1-2.md
+  - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-lit-v1-2.md
+  - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-oes-v1-2.md
+  - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-ruth-v1-2.md
   - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar.md
+  - agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-v1-2.md
   - agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v2.yaml
+  - agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v3.yaml
   - agents_extensions/shared/prompt-contracts/profiles/curriculum-lifecycle.v1.yaml
   - agents_extensions/shared/prompt-contracts/registry.v1.yaml
   - agents_extensions/shared/prompt-contracts/schema/curriculum-lifecycle-input.v1.schema.json
@@ -51,8 +60,8 @@ rows:
     family: seminar
     prompt_profile: seminar-folk
     prompt_assertions:
-      required: [FOLK seminar policy, learner to create a recording]
-      forbidden: [BIO seminar policy]
+      required: [Shared seminar experience policy, FOLK seminar direction, Audio or visual evidence exists only]
+      forbidden: ['BIO only: make the learner exposition a sourced life story']
     expected:
       module_state: built
       preparation_state: stale
@@ -73,8 +82,8 @@ rows:
     family: seminar
     prompt_profile: seminar-folk
     prompt_assertions:
-      required: [FOLK seminar policy]
-      forbidden: [BIO seminar policy]
+      required: [Shared seminar experience policy, FOLK seminar direction]
+      forbidden: ['BIO only: make the learner exposition a sourced life story']
     expected:
       module_state: built
       preparation_state: stale
@@ -95,8 +104,8 @@ rows:
     family: seminar
     prompt_profile: seminar-folk
     prompt_assertions:
-      required: [FOLK seminar policy]
-      forbidden: [BIO seminar policy]
+      required: [Shared seminar experience policy, FOLK seminar direction]
+      forbidden: ['BIO only: make the learner exposition a sourced life story']
     expected:
       module_state: built
       preparation_state: stale
@@ -117,8 +126,8 @@ rows:
     family: seminar
     prompt_profile: seminar-folk
     prompt_assertions:
-      required: [FOLK seminar policy]
-      forbidden: [BIO seminar policy]
+      required: [Shared seminar experience policy, FOLK seminar direction]
+      forbidden: ['BIO only: make the learner exposition a sourced life story']
     expected:
       module_state: built
       preparation_state: stale
@@ -146,8 +155,8 @@ rows:
     family: seminar
     prompt_profile: seminar-folk
     prompt_assertions:
-      required: [FOLK seminar policy]
-      forbidden: [BIO seminar policy]
+      required: [Shared seminar experience policy, FOLK seminar direction]
+      forbidden: ['BIO only: make the learner exposition a sourced life story']
     expected:
       module_state: built
       preparation_state: stale
@@ -172,8 +181,8 @@ rows:
     family: seminar
     prompt_profile: seminar-bio
     prompt_assertions:
-      required: [BIO seminar policy, biographical claims]
-      forbidden: [FOLK seminar policy]
+      required: [Shared seminar experience policy, BIO seminar direction, sourced life story, vital status]
+      forbidden: [FOLK seminar direction]
     expected:
       module_state: built
       preparation_state: stale
@@ -280,8 +289,8 @@ rows:
     family: seminar
     prompt_profile: seminar-bio
     prompt_assertions:
-      required: [BIO seminar policy]
-      forbidden: [FOLK seminar policy]
+      required: [Shared seminar experience policy, BIO seminar direction, sourced life story, vital status]
+      forbidden: [FOLK seminar direction]
     expected:
       module_state: unbuilt
       preparation_state: current
@@ -341,10 +350,10 @@ rows:
     scenario: unbuilt-seminar
     selector: hist/trypillian-civilization
     family: seminar
-    prompt_profile: seminar-generic
+    prompt_profile: seminar-hist
     prompt_assertions:
-      required: [Seminar family policy]
-      forbidden: [BIO seminar policy, FOLK seminar policy]
+      required: [Shared seminar experience policy, HIST seminar direction, historical problem]
+      forbidden: ['BIO only: make the learner exposition a sourced life story', FOLK seminar direction]
     expected:
       module_state: unbuilt
       preparation_state: current

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-bio-v1-2.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-bio-v1-2.md
@@ -1,0 +1,19 @@
+# BIO seminar direction
+
+BIO only: make the learner exposition a sourced life story rather than a list of
+dates and roles or a seminar script. Build a documented arc through formation,
+choices, constraints, work, public roles, reception, and consequences. Use
+verified letters, testimony, objects, places, relationships, or archival moments
+to make the person present when the evidence supports them; never infer private
+emotion, motive, belief, or psychology.
+
+Verify chronology, identity, education, roles, relationships, works, awards,
+repression or recognition, quotations, and image rights against the declared
+dossier and attributable authorities. Check the subject's vital status. For a
+living person, forbid obituary-style framing such as “Останні роки” or
+“Спадщина”; use accurate framing such as “Сучасний етап” or “Вплив”.
+
+Keep language or work analysis proportionate to what it reveals about the life,
+historical setting, and reception. Put extended learner procedures in activities.
+Do not export this sourced-life-story, protagonist, or life-arc requirement to any
+other seminar track.

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-folk-v1-2.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-folk-v1-2.md
@@ -1,0 +1,14 @@
+# FOLK seminar direction
+
+Treat folklore as oral, variable, situated performance and folk culture as
+documented community practice. Identify collector, performer or community,
+place, date, variant, medium, and publication context when evidence permits.
+Compare variants and functions without presenting a reconstructed original as
+fact. Audio or visual evidence exists only when the referenced media was directly
+verified.
+
+Apply the registered FOLK framing standard. Reject pagan-core/Christian-shell
+stories, invented occult belief, magic or demonology as an explanatory default,
+and Soviet/Russian ethnographic language that makes Ukrainians primitive,
+superstitious, or derivative. Do not replace oral-performance analysis with a
+hero's biography, a fixed literary-text model, or unsourced atmosphere.

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-hist-v1-2.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-hist-v1-2.md
@@ -1,0 +1,14 @@
+# HIST seminar direction
+
+Organize HIST around a historical problem: chronology, process, change,
+causation, contingency, and consequence. Make Ukrainian actors subjects of the
+history. Use primary documents and material evidence where they fit the period;
+consult the Literary RAG, `litopys.org.ua`/Izbornyk, and the registered historical
+source hierarchy when relevant. Verified `Реальна Історія` material may support
+media or secondary context but cannot replace primary evidence or claim-level
+verification.
+
+Distinguish established fact, source testimony, scholarly interpretation, and
+contested causality. Expose anachronism, imperial periodization, false
+common-heritage claims, and teleological hindsight. Do not force the topic into a
+single protagonist's biography or a personal life arc.

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-istorio-v1-2.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-istorio-v1-2.md
@@ -1,0 +1,11 @@
+# ISTORIO seminar direction
+
+Make the construction of historical knowledge the object of study. Compare
+sources, archives, historians, concepts, and methods; examine provenance,
+selection, silences, periodization, disagreement, and changes in interpretation.
+Show what evidence permits, what it does not permit, and why accounts diverge.
+
+Keep Ukrainian historiographical agency visible and identify imperial or Soviet
+categories that structure the record. Do not turn ISTORIO into a second HIST
+retelling, a chronology quiz, or an author's biography: learners must practice
+source criticism and comparison of interpretations.

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-lit-v1-2.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-lit-v1-2.md
@@ -1,0 +1,15 @@
+# LIT seminar direction
+
+Center the primary work and the learner's encounter with its language, form,
+voice, genre, structure, imagery, and competing interpretations. Anchor claims in
+accessible passages and verified edition/source identity. Author context and
+biography may clarify the work but must not replace close reading; plot summary
+must not replace literary analysis.
+
+Respect the selected `{{track}}` emphasis: `lit-drama` includes performance and
+staging; `lit-essay` argument and voice; `lit-hist-fic` evidence versus invention;
+`lit-fantastika` speculative devices and worldbuilding; `lit-war` representation,
+testimony, and ethics; `lit-humor` comic technique and context; `lit-youth` reader,
+form, and audience. Generic `lit` remains work-centered. Use Literary RAG or
+`litopys.org.ua`/Izbornyk when the work or period fits, never as a substitute for
+the actual text or edition.

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-oes-v1-2.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-oes-v1-2.md
@@ -1,0 +1,13 @@
+# OES seminar direction
+
+Make primary-text philology central: identify manuscript or edition, date,
+provenance, script, period forms, genre, and editorial intervention. Give the
+learner enough verified text, gloss, translation, and uncertainty to compare
+forms rather than memorize labels. Use the Literary RAG and verified
+`litopys.org.ua`/Izbornyk witnesses appropriate to the text.
+
+Distinguish attested form, editorial normalization, reconstruction, and modern
+translation. Do not project modern standard Ukrainian backward, erase manuscript
+variation, or reproduce imperial “Old Russian” ownership claims. The module is
+philological inquiry, not a modern grammar lesson or a biography of a ruler or
+author.

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-ruth-v1-2.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-ruth-v1-2.md
@@ -1,0 +1,13 @@
+# RUTH seminar direction
+
+Work within the attested 14th–18th-century Ruthenian/Early Ukrainian context.
+Center verified documents and editions, their orthography, grammar, genre,
+chancery or confessional setting, multilingual contact, and sociolinguistic use.
+Use the Literary RAG and appropriate `litopys.org.ua`/Izbornyk witnesses; preserve
+historical forms while making gloss and translation evidence visible to learners.
+
+Relate forms to OES and later Ukrainian only where the evidence supports the
+comparison. Distinguish attestation, editorial normalization, and reconstruction,
+and avoid both imperial ownership categories and a simple teleology toward the
+modern standard. Do not substitute event chronology, author biography, or generic
+archaic atmosphere for historical-language analysis.

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-v1-2.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-v1-2.md
@@ -1,0 +1,33 @@
+# Shared seminar experience policy
+
+Apply this policy to the complete learner-facing module, from its opening through
+its final task, before applying the selected track direction. Each section must
+advance the track inquiry with new source evidence, disciplinary analysis, or a
+necessary synthesis. Consolidate repeated definitions, transitions, and
+conclusions. Remove orchestration and instructor-script language such as
+“На рівні C1” when it does not teach the subject itself.
+
+Keep exposition readable as exposition. Move multi-step exercise directions to
+the activity surface when they interrupt the subject text; retain brief questions
+only when they create genuine inquiry or forward movement. Build engagement from
+verified particulars, primary evidence, consequential disagreement, and
+disciplinary surprise. Never invent drama, inner states, motives, beliefs, or a
+universal story arc to make a module feel human.
+
+Require analysis, evaluation, or synthesis as C1/C2 evidence. Recall may prepare
+the learner but cannot be the only assessed work. Every production task must have
+an accessible canonical `model_answer` or `model_answers` entry. Apply the
+registered track/plan activity policy and its current density rules; do not import
+CORE puzzle types or numeric floors from another track.
+
+Verify every factual, quotation, media, image-rights, linguistic, and source claim
+with attributable evidence appropriate to the track. Use the registered source
+hierarchy and corpus for the period and evidence type, reject low-quality or
+imperial/propaganda framing, and run the applicable Ukrainian semantic-transfer,
+Russicism, morphology, and naturalness checks. Preserve Ukrainian agency and
+distinguish documented fact, interpretation, and uncertainty.
+
+Track narrative and argumentative forms are boundaries, not interchangeable
+templates. A life story belongs to BIO; historical causation, historiographical
+method, textual criticism, oral-performance analysis, and historical philology
+belong only where their selected direction requires them.

--- a/agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v3.yaml
+++ b/agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v3.yaml
@@ -1,0 +1,126 @@
+manifest_version: prompt-manifest.v1
+prompt_id: curriculum-lifecycle.module
+version: 1.2.0
+input_schema: agents_extensions/shared/prompt-contracts/schema/curriculum-lifecycle-input.v1.schema.json
+output_schema: agents_extensions/shared/prompt-contracts/schema/curriculum-lifecycle-output.v1.schema.json
+policy_ids:
+  operator-contract: agents_extensions/shared/rules/operator-expectations.md
+  workflow: agents_extensions/shared/rules/workflow.md
+compatible:
+  families: [core, seminar]
+  routes: [tool-capable]
+fragments:
+  contract.base:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-common.md
+    section: contract-base
+    includes: []
+  family.core:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core.md
+    section: family-policy
+    includes: [contract.base]
+  level.core-a1:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core-a1.md
+    section: family-policy
+    includes: [contract.base]
+  level.core-a2:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core-a2.md
+    section: family-policy
+    includes: [contract.base]
+  level.core-b1:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core-b1.md
+    section: family-policy
+    includes: [contract.base]
+  level.core-b2:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core-b2.md
+    section: family-policy
+    includes: [contract.base]
+  level.core-c1:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core-c1.md
+    section: family-policy
+    includes: [contract.base]
+  level.core-c2:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core-c2.md
+    section: family-policy
+    includes: [contract.base]
+  family.seminar:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-v1-2.md
+    section: seminar-policy
+    includes: [contract.base]
+  track.seminar-bio:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-bio-v1-2.md
+    section: track-policy
+    includes: [family.seminar]
+  track.seminar-hist:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-hist-v1-2.md
+    section: track-policy
+    includes: [family.seminar]
+  track.seminar-istorio:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-istorio-v1-2.md
+    section: track-policy
+    includes: [family.seminar]
+  track.seminar-lit:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-lit-v1-2.md
+    section: track-policy
+    includes: [family.seminar]
+  track.seminar-folk:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-folk-v1-2.md
+    section: track-policy
+    includes: [family.seminar]
+  track.seminar-oes:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-oes-v1-2.md
+    section: track-policy
+    includes: [family.seminar]
+  track.seminar-ruth:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar-ruth-v1-2.md
+    section: track-policy
+    includes: [family.seminar]
+variants:
+  core:
+    family: core
+    roots: [family.core]
+  core-a1:
+    family: core
+    roots: [level.core-a1]
+  core-a2:
+    family: core
+    roots: [level.core-a2]
+  core-b1:
+    family: core
+    roots: [level.core-b1]
+  core-b2:
+    family: core
+    roots: [level.core-b2]
+  core-c1:
+    family: core
+    roots: [level.core-c1]
+  core-c2:
+    family: core
+    roots: [level.core-c2]
+  seminar-bio:
+    family: seminar
+    roots: [track.seminar-bio]
+  seminar-hist:
+    family: seminar
+    roots: [track.seminar-hist]
+  seminar-istorio:
+    family: seminar
+    roots: [track.seminar-istorio]
+  seminar-lit:
+    family: seminar
+    roots: [track.seminar-lit]
+  seminar-folk:
+    family: seminar
+    roots: [track.seminar-folk]
+  seminar-oes:
+    family: seminar
+    roots: [track.seminar-oes]
+  seminar-ruth:
+    family: seminar
+    roots: [track.seminar-ruth]
+  seminar-generic:
+    family: seminar
+    roots: [family.seminar]
+  seminar:
+    family: seminar
+    roots: [family.seminar]
+deprecation: null

--- a/agents_extensions/shared/prompt-contracts/profiles/curriculum-lifecycle.v1.yaml
+++ b/agents_extensions/shared/prompt-contracts/profiles/curriculum-lifecycle.v1.yaml
@@ -7,7 +7,19 @@ selectors:
     b2: core-b2
     c1: core-c1
     c2: core-c2
+    hist: seminar-hist
     bio: seminar-bio
+    lit: seminar-lit
+    istorio: seminar-istorio
+    oes: seminar-oes
+    ruth: seminar-ruth
+    lit-essay: seminar-lit
+    lit-hist-fic: seminar-lit
+    lit-fantastika: seminar-lit
+    lit-war: seminar-lit
+    lit-humor: seminar-lit
+    lit-youth: seminar-lit
+    lit-drama: seminar-lit
     folk: seminar-folk
   manifest_types:
     core: core
@@ -47,13 +59,33 @@ profiles:
     variant: core-c2
   seminar-bio:
     prompt_id: curriculum-lifecycle.module
-    prompt_version: 1.1.0
+    prompt_version: 1.2.0
     variant: seminar-bio
+  seminar-hist:
+    prompt_id: curriculum-lifecycle.module
+    prompt_version: 1.2.0
+    variant: seminar-hist
+  seminar-istorio:
+    prompt_id: curriculum-lifecycle.module
+    prompt_version: 1.2.0
+    variant: seminar-istorio
+  seminar-lit:
+    prompt_id: curriculum-lifecycle.module
+    prompt_version: 1.2.0
+    variant: seminar-lit
   seminar-folk:
     prompt_id: curriculum-lifecycle.module
-    prompt_version: 1.1.0
+    prompt_version: 1.2.0
     variant: seminar-folk
+  seminar-oes:
+    prompt_id: curriculum-lifecycle.module
+    prompt_version: 1.2.0
+    variant: seminar-oes
+  seminar-ruth:
+    prompt_id: curriculum-lifecycle.module
+    prompt_version: 1.2.0
+    variant: seminar-ruth
   seminar-generic:
     prompt_id: curriculum-lifecycle.module
-    prompt_version: 1.1.0
+    prompt_version: 1.2.0
     variant: seminar-generic

--- a/agents_extensions/shared/prompt-contracts/registry.v1.yaml
+++ b/agents_extensions/shared/prompt-contracts/registry.v1.yaml
@@ -1,7 +1,8 @@
 registry_version: prompt-registry.v1
 prompts:
   curriculum-lifecycle.module:
-    current: 1.1.0
+    current: 1.2.0
     versions:
       1.0.0: agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v1.yaml
       1.1.0: agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v2.yaml
+      1.2.0: agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v3.yaml

--- a/tests/orchestration/test_prompt_contracts.py
+++ b/tests/orchestration/test_prompt_contracts.py
@@ -84,22 +84,82 @@ QUALIFICATION_PROFILES = (
         "C1 CORE policy",
         "528ff17188bf18d6c8dac22330d0462eb9c32de03ad7d317aaac4841cf1a8f86",
     ),
+)
+
+SEMINAR_PROFILES = (
     (
         "seminar-bio",
         "bio",
-        "seminar",
-        "BIO seminar policy",
-        "FOLK seminar policy",
-        "8bd17b01de7d9d470dd53cde7228353b9cfdf57a4ba75250ea7425b1a448e3f5",
+        "BIO seminar direction",
+        "sourced life story",
+        "daa9a78c0057d31aa9324cd2551555ce4d670813554e8cdac485bedd14ed256d",
+    ),
+    (
+        "seminar-hist",
+        "hist",
+        "HIST seminar direction",
+        "historical problem",
+        "e2b7a0aa234efdcd81f4a4cc9f84550ac60a31096060920bab80284ee035167f",
+    ),
+    (
+        "seminar-istorio",
+        "istorio",
+        "ISTORIO seminar direction",
+        "construction of historical knowledge",
+        "b493dfe6794d578e83bb661e9e253609646dc3dcf393b4b9d21a8cb2e919014c",
+    ),
+    (
+        "seminar-lit",
+        "lit",
+        "LIT seminar direction",
+        "Center the primary work",
+        "ef8e2d04f05bb3f3771fde170a1123300ff4520fecaabc15c716634bd301c5c9",
     ),
     (
         "seminar-folk",
         "folk",
-        "seminar",
-        "FOLK seminar policy",
-        "BIO seminar policy",
-        "f2014bfd5d5b3e56c1eef4d7c15b23d962202035f75a9eb44d2785e3c6bd9e74",
+        "FOLK seminar direction",
+        "oral, variable, situated performance",
+        "3f34507a678cd26131648a9afacbc33886a7e0bfad27c3ef3ce1c2f86718d5f5",
     ),
+    (
+        "seminar-oes",
+        "oes",
+        "OES seminar direction",
+        "primary-text philology",
+        "670460aac2f0add90b3c0d7a5ceb498c0c42070aca59b9fdd09b0a71a3404f27",
+    ),
+    (
+        "seminar-ruth",
+        "ruth",
+        "RUTH seminar direction",
+        "14th–18th-century",
+        "b3fbf5a8b55059916a01269e83b6b33f6efe70d4e2ce8106011d5da6e4f039c8",
+    ),
+)
+
+ACTIVE_LIT_TRACKS = (
+    "lit",
+    "lit-essay",
+    "lit-hist-fic",
+    "lit-fantastika",
+    "lit-war",
+    "lit-humor",
+    "lit-youth",
+    "lit-drama",
+)
+
+BIO_ONLY_MARKERS = (
+    "BIO only: make the learner exposition a sourced life story",
+    "Check the subject's vital status",
+    "living person, forbid obituary-style framing",
+)
+
+SHARED_SEMINAR_MARKERS = (
+    "complete learner-facing module",
+    "canonical `model_answer` or `model_answers` entry",
+    "semantic-transfer",
+    "Track narrative and argumentative forms are boundaries",
 )
 
 
@@ -178,8 +238,13 @@ def test_active_tracks_resolve_from_manifest_without_a_second_roster() -> None:
     assert resolved["a1"] == "core-a1"
     assert resolved["c2"] == "core-c2"
     assert resolved["bio"] == "seminar-bio"
+    assert resolved["hist"] == "seminar-hist"
+    assert resolved["istorio"] == "seminar-istorio"
     assert resolved["folk"] == "seminar-folk"
-    assert resolved["hist"] == "seminar-generic"
+    assert resolved["oes"] == "seminar-oes"
+    assert resolved["ruth"] == "seminar-ruth"
+    assert all(resolved[track] == "seminar-lit" for track in ACTIVE_LIT_TRACKS)
+    assert "seminar-generic" not in resolved.values()
     assert {"history", "lit-doc", "lit-crimea"}.isdisjoint(resolved)
 
 
@@ -193,6 +258,21 @@ def test_new_manifest_track_uses_typed_family_default(tmp_path: Path) -> None:
     resolved = contracts.active_track_profiles(repo_root=repo_root)
 
     assert resolved["new-seminar"] == "seminar-generic"
+    context = {
+        "track": "new-seminar",
+        "slug": "pilot",
+        "family": "seminar",
+        "phase": "build",
+        "module_state": "unbuilt",
+        "evidence_identity": "a" * 64,
+    }
+    prompt = contracts.resolve_track_profile(
+        "new-seminar",
+        context=context,
+        repo_root=repo_root,
+    )
+    assert "Shared seminar experience policy" in prompt.rendered_prompt
+    assert "seminar direction" not in prompt.rendered_prompt
 
 
 def test_frozen_legacy_linter_does_not_require_a_suite_for_new_tracks(
@@ -296,14 +376,14 @@ def test_current_contract_keeps_generic_variant_compatibility(
         repo_root=REPO_ROOT,
     )
 
-    assert resolved.version == "1.1.0"
+    assert resolved.version == "1.2.0"
 
 
 @pytest.mark.parametrize(
     ("profile_id", "track", "family", "required_marker", "forbidden_marker", "expected_sha256"),
     QUALIFICATION_PROFILES,
 )
-def test_qualification_profiles_have_exact_level_or_track_policy_without_cross_leakage(
+def test_core_qualification_profiles_have_exact_level_policy_without_cross_leakage(
     profile_id: str,
     track: str,
     family: str,
@@ -330,6 +410,108 @@ def test_qualification_profiles_have_exact_level_or_track_policy_without_cross_l
         "contract.base",
         profile_id.replace("seminar-", "track.seminar-").replace("core-", "level.core-"),
     )
+
+
+@pytest.mark.parametrize(
+    ("profile_id", "track", "direction_marker", "discipline_marker", "expected_sha256"),
+    SEMINAR_PROFILES,
+)
+def test_seminar_profiles_compose_shared_and_exact_direction_without_bio_leakage(
+    profile_id: str,
+    track: str,
+    direction_marker: str,
+    discipline_marker: str,
+    expected_sha256: str,
+) -> None:
+    context = {
+        "track": track,
+        "slug": "pilot",
+        "family": "seminar",
+        "phase": "build",
+        "module_state": "unbuilt",
+        "evidence_identity": "a" * 64,
+    }
+
+    resolved = contracts.resolve_profile(profile_id, context=context, repo_root=REPO_ROOT)
+
+    assert resolved.version == "1.2.0"
+    assert resolved.prompt_sha256 == expected_sha256
+    assert "Shared seminar experience policy" in resolved.rendered_prompt
+    assert all(marker in resolved.rendered_prompt for marker in SHARED_SEMINAR_MARKERS)
+    assert direction_marker in resolved.rendered_prompt
+    assert discipline_marker in resolved.rendered_prompt
+    other_direction_markers = {
+        profile[2]
+        for profile in SEMINAR_PROFILES
+        if profile[0] != profile_id
+    }
+    assert all(marker not in resolved.rendered_prompt for marker in other_direction_markers)
+    assert resolved.fragment_ids == (
+        "contract.base",
+        "family.seminar",
+        f"track.{profile_id}",
+    )
+    if track == "bio":
+        assert all(marker in resolved.rendered_prompt for marker in BIO_ONLY_MARKERS)
+    else:
+        assert all(marker not in resolved.rendered_prompt for marker in BIO_ONLY_MARKERS)
+
+
+@pytest.mark.parametrize("track", ACTIVE_LIT_TRACKS)
+def test_every_active_lit_subtrack_receives_lit_direction(track: str) -> None:
+    context = {
+        "track": track,
+        "slug": "pilot",
+        "family": "seminar",
+        "phase": "build",
+        "module_state": "unbuilt",
+        "evidence_identity": "a" * 64,
+    }
+
+    resolved = contracts.resolve_track_profile(track, context=context, repo_root=REPO_ROOT)
+
+    assert resolved.profile_id == "seminar-lit"
+    assert "LIT seminar direction" in resolved.rendered_prompt
+
+
+@pytest.mark.parametrize(
+    ("variant", "track", "expected_sha256"),
+    [
+        (
+            "seminar-bio",
+            "bio",
+            "8bd17b01de7d9d470dd53cde7228353b9cfdf57a4ba75250ea7425b1a448e3f5",
+        ),
+        (
+            "seminar-folk",
+            "folk",
+            "f2014bfd5d5b3e56c1eef4d7c15b23d962202035f75a9eb44d2785e3c6bd9e74",
+        ),
+    ],
+)
+def test_historical_seminar_contract_bytes_remain_stable(
+    variant: str,
+    track: str,
+    expected_sha256: str,
+) -> None:
+    context = {
+        "track": track,
+        "slug": "pilot",
+        "family": "seminar",
+        "phase": "build",
+        "module_state": "unbuilt",
+        "evidence_identity": "a" * 64,
+    }
+
+    resolved = contracts.resolve_prompt(
+        "curriculum-lifecycle.module",
+        version="1.1.0",
+        variant=variant,
+        context=context,
+        repo_root=REPO_ROOT,
+    )
+
+    assert resolved.prompt_sha256 == expected_sha256
 
 
 def test_resolution_is_identical_across_clean_repository_roots(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add immutable curriculum-lifecycle prompt contract `1.2.0`
- compose one shared full-module seminar experience policy with explicit BIO, HIST, ISTORIO, LIT/subtrack, FOLK, OES, and RUTH directions
- keep sourced life-story, protagonist/life-arc, and vital-status rules BIO-only
- map every active seminar track explicitly while retaining a generic fallback for future manifest tracks
- update the deterministic pilot identity matrix and preserve exact 1.0/1.1 prompt bytes

No learner module content changes.

## Verification

- `prompt_contracts.py audit` — PASS; all 20 active tracks resolved, 1.0/1.1/1.2 registered
- prompt-contract/lifecycle/readiness/track-completion suite — **96 passed**
- curriculum-lifecycle pilot safety suite — **14 passed**
- prompt lint — PASS
- Ruff — PASS
- pre-commit — PASS (secret scan, YAML, whitespace, merge-conflict, repository guards)
- `git diff --check` — PASS
- `lint_agent_trailer.py` — PASS

## Review evidence

- adversarial plan review completed and disposition recorded on #5270
- Gemini local diff review challenged by Codex against repository authority; all three findings were dropped as false positives with evidence
- independent cross-family PR-head review still required before auto-merge

Fixes #5270
Links #4707
