### PR TITLE
fix(rollover): reconcile superseded native intents

### DIFF
--- a/agents_extensions/shared/skills/thread-rollover/SKILL.md
+++ b/agents_extensions/shared/skills/thread-rollover/SKILL.md
@@ -107,6 +107,31 @@ If a native tool is absent or fails, use `record-native-result --failed
 `native-action` first. It reconciles exact native state before authorizing a
 mutation and will not repeat an acknowledged action while read-back is pending.
 
+Each prepared packet has its own deterministic native operation ID, even when
+an explicit `prepare --force-new-replacement` stays in the same generation.
+Forced preparation may supersede only an untouched predecessor intent: no
+binding, create authorization, acknowledgement, actual action, or failure may
+exist. The old immutable plan remains in place; an exact supersession document,
+blocked receipt, and successor reference make retries fail closed. Never edit,
+delete, or reuse an immutable receipt to resolve a collision.
+
+For a legacy lease whose current packet references a pristine immutable plan
+for a different rollover ID, do not create or fork a task. Repair the exact
+receipt collision with app/operator evidence that `create_thread` was never
+called:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py repair-native-intent \
+  --agent codex --lineage-id <lineage-id> --rollover-id <current-rollover-id> \
+  --evidence "App stopped before create_thread; exact receipt and binding are pristine."
+```
+
+The command persists the packet-specific transition first, marks only the exact
+legacy intent `superseded_before_native_create`, and updates the lease last. It
+is idempotent for the same exact successor and refuses ambiguous, partial, or
+already-authorized native state. After success, begin again at `native-action
+--action create`; the repair command itself performs no native mutation.
+
 ## Resume and confirm
 
 In the fresh task, use the exact paths returned by `detect` or `resume`. First

--- a/docs/best-practices/codex-thread-handoff.md
+++ b/docs/best-practices/codex-thread-handoff.md
@@ -117,6 +117,10 @@ This writes the lineage-scoped lease and packet plus an immutable Task Family
 Manager transition plan and receipt. `intended_title` is human-readable when
 the durable metadata is supplied. Without all three required fields, the safe
 fallback includes lineage and generation. `Resume codex rollover` is forbidden.
+The Task Family Manager family remains stable for one lineage generation, while
+the operation ID is deterministic for the exact rollover packet. A forced
+same-generation packet therefore cannot collide with or rewrite an older
+immutable operation.
 
 It does not modify git-tracked handoff files by default.
 
@@ -278,6 +282,41 @@ Dry-run without writing files:
 ```bash
 .venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent codex --dry-run
 ```
+
+### Superseded native-intent recovery
+
+`prepare --force-new-replacement` is fail closed. It supersedes only the exact
+prior intent when its receipt is pristine and no native create was authorized
+or attempted. The successor plan is durable before the live lease can expose
+it. Prepare, legacy repair, and create authorization serialize through the same
+blocking cross-process `fcntl.flock` lineage lock, so competing mutators cannot
+publish different successors. A rejected first prepare may leave only this
+gitignored lock file and its lineage directory; detection considers `lease.json`
+files only. The predecessor immutable plan is never rewritten: its operation gains an
+immutable `rollover-supersession.json`, skipped planned actions, a blocked
+`superseded_before_native_create` state, and the exact successor IDs. Binding,
+actual actions, successful or failed acknowledgements, authorization, and
+ambiguous state all preserve the old packet and block forced replacement.
+
+Older deployments could create a same-generation lease/receipt mismatch. When
+the current lease points to a pristine legacy operation whose immutable plan
+contains a different rollover ID, native creation is forbidden. After verifying
+through the app and receipt that `create_thread` was never called, run:
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py repair-native-intent \
+  --agent codex \
+  --lineage-id <lineage-id> \
+  --rollover-id <current-rollover-id> \
+  --evidence "App stopped before create_thread; exact receipt and binding are pristine."
+```
+
+This command performs no Codex app mutation. It creates the correct
+packet-specific transition, receipts the exact untouched legacy operation, and
+updates the lease last while preserving the bootstrap, checkout binding, canary,
+and cleanup=false guard. Retries must use the same successor and evidence. Do
+not manually edit or delete the lease, plan, receipt, or operation directory.
+After a successful repair, restart at `native-action --action create`.
 
 ## Fresh Codex App Task/Restart Smoke
 

--- a/scripts/orchestration/task_family/rollover.py
+++ b/scripts/orchestration/task_family/rollover.py
@@ -83,10 +83,24 @@ def rollover_title(
     return title, source, fields
 
 
-def transition_identity(*, lineage_id: str, generation: int) -> tuple[str, str]:
-    """Return stable TFM family and operation IDs for safe retries."""
+def legacy_transition_identity(*, lineage_id: str, generation: int) -> tuple[str, str]:
+    """Return the pre-supersession operation identity for exact repair only."""
     family_id = f"rollover-{lineage_id}-g{generation:04d}"
     operation_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"learn-ukrainian:{family_id}:native-transition"))
+    return family_id, operation_id
+
+
+def transition_identity(*, lineage_id: str, generation: int, rollover_id: str) -> tuple[str, str]:
+    """Return a stable family ID and packet-specific operation ID."""
+    if not rollover_id.strip():
+        raise ValueError("rollover_id must be non-empty")
+    family_id = f"rollover-{lineage_id}-g{generation:04d}"
+    operation_id = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"learn-ukrainian:{family_id}:native-transition:{rollover_id}",
+        )
+    )
     return family_id, operation_id
 
 
@@ -113,6 +127,39 @@ def _load_binding(storage: TaskFamilyStorage) -> dict[str, Any]:
     if binding.get("plan_digest") != _load_plan(storage)["digest"]:
         raise ValueError("persisted rollover binding does not match the immutable plan")
     return binding
+
+
+def assert_transition_context(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+    lineage_id: str,
+    rollover_id: str,
+    generation: int,
+    source_thread_id: str,
+) -> dict[str, Any]:
+    """Match one native command to the exact immutable packet plan."""
+    expected_family_id, expected_operation_id = transition_identity(
+        lineage_id=lineage_id,
+        generation=generation,
+        rollover_id=rollover_id,
+    )
+    if family_id != expected_family_id or operation_id != expected_operation_id:
+        raise ValueError("native lifecycle operation does not match the packet-specific transition identity")
+    plan = _load_plan(TaskFamilyStorage(repo_root, family_id, operation_id))
+    expected = {
+        "family_id": family_id,
+        "operation_id": operation_id,
+        "lineage_id": lineage_id,
+        "rollover_id": rollover_id,
+        "generation": generation,
+        "source_thread_id": source_thread_id,
+    }
+    for key, value in expected.items():
+        if plan.get(key) != value:
+            raise ValueError(f"immutable native transition plan does not match lease {key}")
+    return plan
 
 
 def _event(
@@ -175,8 +222,19 @@ def prepare_transition(
     intended_title: str,
     title_source: str,
     bootstrap_prompt_path: str,
+    supersedes: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    family_id, operation_id = transition_identity(lineage_id=lineage_id, generation=generation)
+    family_id, operation_id = transition_identity(
+        lineage_id=lineage_id,
+        generation=generation,
+        rollover_id=rollover_id,
+    )
+    if supersedes is not None:
+        required = {"family_id", "operation_id", "rollover_id"}
+        if set(supersedes) != required or any(not supersedes[key].strip() for key in required):
+            raise ValueError("supersedes must contain exact non-empty family_id, operation_id, and rollover_id")
+        if supersedes["operation_id"] == operation_id or supersedes["rollover_id"] == rollover_id:
+            raise ValueError("a rollover transition cannot supersede itself")
     storage = TaskFamilyStorage(repo_root, family_id, operation_id)
     payload: dict[str, Any] = {
         "schema_version": PLAN_SCHEMA_VERSION,
@@ -194,13 +252,23 @@ def prepare_transition(
         "bootstrap_prompt_path": bootstrap_prompt_path,
         "relation_types": [RelationType.REPLACEMENT_OF.value, RelationType.ROLLOVER_GENERATION_OF.value],
     }
+    if supersedes is not None:
+        payload["supersedes"] = dict(supersedes)
     payload["digest"] = _plan_digest(payload)
     storage.write_immutable_json(storage.rollover_plan_path, payload)
     if not storage.receipt_path.exists():
         planned = (
-            ReceiptAction("rollover", rollover_id, (source_thread_id,), "create_replacement", "Use native create_thread once."),
+            ReceiptAction(
+                "rollover", rollover_id, (source_thread_id,), "create_replacement", "Use native create_thread once."
+            ),
             ReceiptAction("rollover", rollover_id, (source_thread_id,), "title_replacement", intended_title),
-            ReceiptAction("task", source_thread_id, (source_thread_id,), "archive_confirmed_predecessor", "Proof and app-state gated."),
+            ReceiptAction(
+                "task",
+                source_thread_id,
+                (source_thread_id,),
+                "archive_confirmed_predecessor",
+                "Proof and app-state gated.",
+            ),
         )
         _event(
             storage,
@@ -220,7 +288,11 @@ def prepare_transition(
         )
         storage.write_state(
             LifecycleState.PLANNED,
-            details={"status": "awaiting_native_create", "plan_digest": payload["digest"]},
+            details={
+                "status": "supersession_pending" if supersedes is not None else "awaiting_native_create",
+                "plan_digest": payload["digest"],
+                **({"supersedes": dict(supersedes)} if supersedes is not None else {}),
+            },
         )
     else:
         receipt = storage.load_receipt()
@@ -233,6 +305,235 @@ def prepare_transition(
         "receipt_path": str(storage.receipt_path),
         "status": storage.load_state()["details"].get("status"),
     }
+
+
+def assert_transition_supersedable(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+    lineage_id: str,
+    generation: int,
+    source_thread_id: str,
+    successor_rollover_id: str,
+    successor_operation_id: str,
+    expected_rollover_id: str | None = None,
+) -> dict[str, Any]:
+    """Prove an exact native intent has never reached or authorized a native call."""
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    plan = _load_plan(storage)
+    expected = {
+        "family_id": family_id,
+        "operation_id": operation_id,
+        "lineage_id": lineage_id,
+        "generation": generation,
+        "source_thread_id": source_thread_id,
+    }
+    for key, value in expected.items():
+        if plan.get(key) != value:
+            raise ValueError(f"superseded transition {key} does not match the exact predecessor intent")
+    if expected_rollover_id is not None and plan.get("rollover_id") != expected_rollover_id:
+        raise ValueError("superseded transition rollover_id does not match the exact predecessor intent")
+    if plan.get("rollover_id") == successor_rollover_id or operation_id == successor_operation_id:
+        raise ValueError("successor identity must differ from the superseded transition")
+
+    state = storage.load_state()
+    details = state["details"]
+    already_superseded = details.get("status") == "superseded_before_native_create"
+    if already_superseded and (
+        details.get("superseded_by_rollover_id") != successor_rollover_id
+        or details.get("superseded_by_operation_id") != successor_operation_id
+    ):
+        raise ValueError("transition was already superseded by a different exact successor")
+
+    supersession: dict[str, Any] | None = None
+    if storage.rollover_supersession_path.exists():
+        supersession = storage.read_json(storage.rollover_supersession_path)
+        if (
+            supersession.get("schema_version") != PLAN_SCHEMA_VERSION
+            or supersession.get("kind") != "rollover_native_intent_supersession"
+            or supersession.get("plan_digest") != plan["digest"]
+            or supersession.get("family_id") != family_id
+            or supersession.get("rollover_id") != plan["rollover_id"]
+            or supersession.get("superseded_by_rollover_id") != successor_rollover_id
+            or supersession.get("superseded_by_operation_id") != successor_operation_id
+        ):
+            raise ValueError("immutable transition supersession does not match the exact successor")
+    if already_superseded and supersession is None:
+        raise ValueError("superseded transition is missing its immutable exact-successor document")
+
+    receipt = storage.load_receipt()
+    if receipt.family_id != family_id or receipt.operation_id != operation_id or receipt.plan_digest != plan["digest"]:
+        raise ValueError("superseded transition receipt identity or digest is inconsistent")
+    if storage.rollover_binding_path.exists():
+        raise ValueError("transition has an exact replacement binding and cannot be superseded")
+    if receipt.actual:
+        raise ValueError("transition has recorded native or reconciled actions and cannot be superseded")
+    if receipt.failures:
+        raise ValueError("transition has partial or ambiguous failures and cannot be superseded")
+    if already_superseded:
+        event_kinds = [event.kind for event in storage.load_events()]
+        if (
+            state.get("state") != LifecycleState.BLOCKED.value
+            or receipt.final_state is not LifecycleState.BLOCKED
+            or "rollover_native_intent_superseded" not in event_kinds
+        ):
+            raise ValueError("superseded transition receipt, event, or state is incomplete")
+        return {"already_superseded": True, "plan": plan, "supersession_started": True}
+    if state.get("state") != LifecycleState.PLANNED.value or details.get("status") != "awaiting_native_create":
+        raise ValueError("transition is not an untouched native-create intent")
+    permitted_events = {"rollover_native_intent_prepared"}
+    if supersession is not None:
+        permitted_events.add("rollover_native_intent_superseded")
+    unsafe_events = [event.kind for event in storage.load_events() if event.kind not in permitted_events]
+    if unsafe_events:
+        raise ValueError("transition has native-action or ambiguous lifecycle events and cannot be superseded")
+    return {"already_superseded": False, "plan": plan, "supersession_started": supersession is not None}
+
+
+def supersede_unexecuted_transition(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+    lineage_id: str,
+    generation: int,
+    source_thread_id: str,
+    successor_rollover_id: str,
+    successor_operation_id: str,
+    evidence: str,
+    expected_rollover_id: str | None = None,
+) -> dict[str, Any]:
+    """Close an untouched native intent while preserving its immutable evidence."""
+    if not evidence.strip():
+        raise ValueError("native-intent supersession evidence is required")
+    proof = assert_transition_supersedable(
+        repo_root=repo_root,
+        family_id=family_id,
+        operation_id=operation_id,
+        lineage_id=lineage_id,
+        generation=generation,
+        source_thread_id=source_thread_id,
+        successor_rollover_id=successor_rollover_id,
+        successor_operation_id=successor_operation_id,
+        expected_rollover_id=expected_rollover_id,
+    )
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    plan = proof["plan"]
+    if proof["already_superseded"]:
+        return {
+            "status": "already_superseded",
+            "rollover_id": plan["rollover_id"],
+            "superseded_by_rollover_id": successor_rollover_id,
+            "superseded_by_operation_id": successor_operation_id,
+            "receipt_path": str(storage.receipt_path),
+        }
+
+    supersession = {
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "kind": "rollover_native_intent_supersession",
+        "plan_digest": plan["digest"],
+        "family_id": family_id,
+        "rollover_id": plan["rollover_id"],
+        "operation_id": operation_id,
+        "superseded_by_rollover_id": successor_rollover_id,
+        "superseded_by_operation_id": successor_operation_id,
+        "evidence": evidence.strip(),
+    }
+    storage.write_immutable_json(storage.rollover_supersession_path, supersession)
+    if not any(event.kind == "rollover_native_intent_superseded" for event in storage.load_events()):
+        _event(
+            storage,
+            state=LifecycleState.BLOCKED,
+            kind="rollover_native_intent_superseded",
+            details={
+                "rollover_id": plan["rollover_id"],
+                "superseded_by_rollover_id": successor_rollover_id,
+                "superseded_by_operation_id": successor_operation_id,
+                "evidence": evidence.strip(),
+            },
+        )
+    receipt = storage.load_receipt()
+    skipped_keys = {_action_key(item) for item in receipt.skipped}
+    skipped = tuple(
+        item
+        for item in (
+            ReceiptAction(
+                planned.resource_type,
+                planned.resource_id,
+                planned.task_ids,
+                planned.action,
+                f"Superseded before native creation by {successor_rollover_id}; no native mutation was authorized.",
+            )
+            for planned in receipt.planned
+        )
+        if _action_key(item) not in skipped_keys
+    )
+    storage.write_receipt(
+        replace(
+            receipt,
+            final_state=LifecycleState.BLOCKED,
+            skipped=(*receipt.skipped, *skipped),
+            events=storage.load_events(),
+        )
+    )
+    storage.write_state(
+        LifecycleState.BLOCKED,
+        details={
+            "status": "superseded_before_native_create",
+            "rollover_id": plan["rollover_id"],
+            "superseded_by_rollover_id": successor_rollover_id,
+            "superseded_by_operation_id": successor_operation_id,
+        },
+    )
+    return {
+        "status": "superseded",
+        "rollover_id": plan["rollover_id"],
+        "superseded_by_rollover_id": successor_rollover_id,
+        "superseded_by_operation_id": successor_operation_id,
+        "receipt_path": str(storage.receipt_path),
+    }
+
+
+def activate_superseding_transition(
+    *,
+    repo_root: Path,
+    family_id: str,
+    operation_id: str,
+) -> dict[str, Any]:
+    """Unlock create only after the immutable predecessor intent is superseded."""
+    storage = TaskFamilyStorage(repo_root, family_id, operation_id)
+    plan = _load_plan(storage)
+    supersedes = plan.get("supersedes")
+    if not isinstance(supersedes, dict):
+        raise ValueError("transition is not an explicit superseding intent")
+    old_storage = TaskFamilyStorage(repo_root, supersedes["family_id"], supersedes["operation_id"])
+    old_state = old_storage.load_state()
+    old_details = old_state["details"]
+    if (
+        old_details.get("status") != "superseded_before_native_create"
+        or old_details.get("superseded_by_rollover_id") != plan["rollover_id"]
+        or old_details.get("superseded_by_operation_id") != operation_id
+    ):
+        raise ValueError("exact predecessor intent has not been durably superseded by this transition")
+    state = storage.load_state()
+    if state["details"].get("status") == "awaiting_native_create":
+        return {"status": "already_active", "receipt_path": str(storage.receipt_path)}
+    if state["details"].get("status") != "supersession_pending":
+        raise ValueError("superseding transition is not awaiting exact predecessor reconciliation")
+    if not any(event.kind == "rollover_native_intent_activated" for event in storage.load_events()):
+        _event(
+            storage,
+            state=LifecycleState.PLANNED,
+            kind="rollover_native_intent_activated",
+            details={"superseded_operation_id": supersedes["operation_id"]},
+        )
+        _append_receipt(storage)
+    storage.write_state(
+        LifecycleState.PLANNED,
+        details={"status": "awaiting_native_create", "plan_digest": plan["digest"]},
+    )
+    return {"status": "awaiting_native_create", "receipt_path": str(storage.receipt_path)}
 
 
 def bind_replacement(
@@ -463,6 +764,19 @@ def request_create_action(
     """Return one retry-safe native create decision before exact-ID binding."""
     storage = TaskFamilyStorage(repo_root, family_id, operation_id)
     plan = _load_plan(storage)
+    operation_state = storage.load_state()
+    operation_status = operation_state["details"].get("status")
+    if operation_status in {"supersession_pending", "superseded_before_native_create"}:
+        return {
+            "ok": False,
+            "action": "create",
+            "status": operation_status,
+            "needs_native_action": False,
+            "recovery": (
+                "Finish exact predecessor-intent reconciliation. Never create from a pending or superseded receipt."
+            ),
+            "receipt_path": str(storage.receipt_path),
+        }
     if storage.rollover_binding_path.exists():
         binding = _load_binding(storage)
         skipped = ReceiptAction(
@@ -520,8 +834,16 @@ def request_create_action(
         }
     storage.write_state(
         LifecycleState.PLANNED,
-        details={"status": "awaiting_native_create", "source_thread_id": plan["source_thread_id"]},
+        details={"status": "native_create_authorized", "source_thread_id": plan["source_thread_id"]},
     )
+    if not any(event.kind == "native_create_authorized" for event in storage.load_events()):
+        _event(
+            storage,
+            state=LifecycleState.PLANNED,
+            kind="native_create_authorized",
+            details={"rollover_id": plan["rollover_id"], "source_thread_id": plan["source_thread_id"]},
+        )
+        _append_receipt(storage)
     return {
         "ok": True,
         "action": "create",
@@ -542,9 +864,7 @@ def _exact_record(binding: dict[str, Any], *, action: str, db_path: Path) -> cod
     expected_cwd = binding[f"{endpoint}_cwd"]
     expected_host = binding[f"{endpoint}_host"]
     if record.cwd != expected_cwd or (expected_host is not None and record.host != expected_host):
-        raise codex_state.CodexStateContextError(
-            "exact rollover task cwd or host no longer matches the native binding"
-        )
+        raise codex_state.CodexStateContextError("exact rollover task cwd or host no longer matches the native binding")
     return record
 
 
@@ -698,8 +1018,7 @@ def authorize_archive(
     if blockers:
         message = "; ".join(blockers)
         recovery = (
-            "Retry only after exact idle and unpinned app evidence is available "
-            "for the persisted predecessor UUID."
+            "Retry only after exact idle and unpinned app evidence is available for the persisted predecessor UUID."
         )
         failure = ReceiptAction(
             "task",
@@ -811,9 +1130,7 @@ def request_action(
             error=str(exc),
             evidence="native read-back preflight",
         )
-    target_satisfied = (
-        current.title == binding["intended_title"] if action == "title" else current.archived
-    )
+    target_satisfied = current.title == binding["intended_title"] if action == "title" else current.archived
     if target_satisfied:
         reconciled = reconcile_action(
             repo_root=repo_root,

--- a/scripts/orchestration/task_family/storage.py
+++ b/scripts/orchestration/task_family/storage.py
@@ -116,6 +116,11 @@ class TaskFamilyStorage:
         return self.root / "rollover-binding.json"
 
     @property
+    def rollover_supersession_path(self) -> Path:
+        """Immutable exact successor for an untouched rollover transition."""
+        return self.root / "rollover-supersession.json"
+
+    @property
     def rollover_archive_authorization_path(self) -> Path:
         """Immutable post-confirmation authorization for one predecessor archive."""
         return self.root / "rollover-archive-authorization.json"
@@ -136,7 +141,9 @@ class TaskFamilyStorage:
         if self.manifest_path.exists():
             existing = self.read_json(self.manifest_path)
             if existing != manifest.to_dict():
-                raise ValueError("immutable manifest mismatch; create a new operation instead of replacing this manifest")
+                raise ValueError(
+                    "immutable manifest mismatch; create a new operation instead of replacing this manifest"
+                )
             return
         atomic_write_json(self.manifest_path, manifest.to_dict())
 
@@ -147,7 +154,9 @@ class TaskFamilyStorage:
         if self.plan_path.exists():
             existing = self.read_json(self.plan_path)
             if existing.get("digest") != plan.digest:
-                raise ValueError("immutable plan digest mismatch; create a new operation instead of replacing this plan")
+                raise ValueError(
+                    "immutable plan digest mismatch; create a new operation instead of replacing this plan"
+                )
             return
         atomic_write_json(self.plan_path, plan.to_dict())
 

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -33,6 +33,7 @@ try:
     from scripts.orchestration import thread_handoff_canary
     from scripts.orchestration.task_family import codex_state as task_family_codex_state
     from scripts.orchestration.task_family import rollover as task_family_rollover
+    from scripts.orchestration.task_family.storage import advisory_lock as task_family_advisory_lock
 except ModuleNotFoundError as exc:
     if __package__ or exc.name != "scripts":
         raise
@@ -41,6 +42,7 @@ except ModuleNotFoundError as exc:
     import thread_handoff_canary
     from orchestration.task_family import codex_state as task_family_codex_state
     from orchestration.task_family import rollover as task_family_rollover
+    from orchestration.task_family.storage import advisory_lock as task_family_advisory_lock
 
 SCHEMA_VERSION = 2
 DEFAULT_MONITOR_BASE_URL = "http://127.0.0.1:8765"
@@ -214,7 +216,7 @@ def parse_iso_datetime(value: str | None) -> datetime | None:
         return None
     try:
         parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except ValueError:
+    except (KeyError, OSError, TypeError, ValueError):
         return None
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=UTC)
@@ -747,6 +749,7 @@ def prepare_state(
     family_id, operation_id = task_family_rollover.transition_identity(
         lineage_id=lineage_id,
         generation=generation,
+        rollover_id=rollover_id,
     )
     replacement = {
         "rollover_id": rollover_id,
@@ -852,6 +855,7 @@ def validate_live_lease(
             expected_family_id, expected_operation_id = task_family_rollover.transition_identity(
                 lineage_id=lineage_id,
                 generation=generation,
+                rollover_id=rollover_id,
             )
             native = replacement.get("native_lifecycle")
             if (
@@ -1512,7 +1516,39 @@ def check_state(
     return facts, warnings
 
 
+def _rollover_mutation_lock_path(args: argparse.Namespace) -> Path | None:
+    """Resolve one lineage lock without replacing command-specific errors."""
+    try:
+        _, state_root = resolve_roots(args.repo_root)
+        agent = normalize_agent_name(args.agent)
+        if getattr(args, "lineage_id", None):
+            return state_root / default_state_path(agent, args.lineage_id).parent / ".native-intent.lock"
+        if getattr(args, "state_file", None):
+            state_path = resolve_state_path(
+                repo_root=state_root,
+                state_root=state_root,
+                supplied_state_file=args.state_file,
+                default_path=None,
+            )
+            return state_path.parent / ".native-intent.lock"
+        active_thread_id = getattr(args, "active_thread_id", None) or active_thread_id_from_env()
+        if active_thread_id:
+            lineage_id = lineage_id_for(agent, active_thread_id)
+            return state_root / default_state_path(agent, lineage_id).parent / ".native-intent.lock"
+    except ValueError:
+        return None
+    return None
+
+
 def cmd_prepare(args: argparse.Namespace) -> int:
+    lock_path = _rollover_mutation_lock_path(args)
+    if lock_path is None:
+        return _cmd_prepare_locked(args)
+    with task_family_advisory_lock(lock_path):
+        return _cmd_prepare_locked(args)
+
+
+def _cmd_prepare_locked(args: argparse.Namespace) -> int:
     try:
         repo_root, state_root = resolve_roots(args.repo_root)
     except ValueError as exc:
@@ -1603,6 +1639,7 @@ def cmd_prepare(args: argparse.Namespace) -> int:
             )
         )
         return 2
+    previous_replacement = dict(state.get("replacement") or {})
     try:
         prepared_state = prepare_state(
             state,
@@ -1694,9 +1731,54 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         print(json.dumps(output, indent=2))
         return 0
 
+    supersedes: dict[str, str] | None = None
+    if args.force_new_replacement and previous_replacement.get("status") in {"pending_start", "resumed"}:
+        previous_native = previous_replacement.get("native_lifecycle")
+        if not isinstance(previous_native, dict):
+            print(
+                json.dumps(
+                    {
+                        "error": "existing rollover has no exact native lifecycle receipt to supersede",
+                        "state_file": rel(state_path, state_root),
+                        "old_automation_ready_to_delete": False,
+                    },
+                    indent=2,
+                )
+            )
+            return 2
+        supersedes = {
+            "family_id": str(previous_native.get("family_id") or ""),
+            "operation_id": str(previous_native.get("operation_id") or ""),
+            "rollover_id": str(previous_replacement.get("rollover_id") or ""),
+        }
+        try:
+            task_family_rollover.assert_transition_supersedable(
+                repo_root=state_root,
+                family_id=supersedes["family_id"],
+                operation_id=supersedes["operation_id"],
+                lineage_id=lineage_id,
+                generation=int(previous_replacement["generation"]),
+                source_thread_id=prepared_state["active"]["thread_id"],
+                successor_rollover_id=replacement["rollover_id"],
+                successor_operation_id=replacement["native_lifecycle"]["operation_id"],
+                expected_rollover_id=supersedes["rollover_id"],
+            )
+        except (KeyError, OSError, TypeError, ValueError) as exc:
+            print(
+                json.dumps(
+                    {
+                        "error": f"existing native rollover intent cannot be safely superseded: {exc}",
+                        "recovery": "If the immutable plan belongs to an older packet, run repair-native-intent for the current exact lease.",
+                        "state_file": rel(state_path, state_root),
+                        "old_automation_ready_to_delete": False,
+                    },
+                    indent=2,
+                )
+            )
+            return 2
+
     write_text_atomic(bootstrap_path, prompt)
     write_text_atomic(handoff_path, handoff_md)
-    write_json_atomic(state_path, prepared_state)
     try:
         native_transition = task_family_rollover.prepare_transition(
             repo_root=state_root,
@@ -1708,18 +1790,46 @@ def cmd_prepare(args: argparse.Namespace) -> int:
             intended_title=replacement["display"]["title"],
             title_source=replacement["display"]["title_source"],
             bootstrap_prompt_path=replacement["bootstrap_prompt_path"],
+            supersedes=supersedes,
         )
-    except (OSError, ValueError) as exc:
-        replacement["native_lifecycle"]["status"] = "intent_persistence_failed"
-        replacement["native_lifecycle"]["error"] = str(exc)
-        prepared_state["replacement"] = replacement
+        if supersedes is not None:
+            pending_state = dict(prepared_state)
+            pending_replacement = dict(replacement)
+            pending_native = dict(pending_replacement["native_lifecycle"])
+            pending_native["status"] = "supersession_pending"
+            pending_native["supersedes"] = dict(supersedes)
+            pending_replacement["native_lifecycle"] = pending_native
+            pending_state["replacement"] = pending_replacement
+            write_json_atomic(state_path, pending_state)
+            task_family_rollover.supersede_unexecuted_transition(
+                repo_root=state_root,
+                family_id=supersedes["family_id"],
+                operation_id=supersedes["operation_id"],
+                lineage_id=lineage_id,
+                generation=int(previous_replacement["generation"]),
+                source_thread_id=prepared_state["active"]["thread_id"],
+                successor_rollover_id=replacement["rollover_id"],
+                successor_operation_id=replacement["native_lifecycle"]["operation_id"],
+                evidence="Forced prepare superseded an untouched exact native intent after durable preflight.",
+                expected_rollover_id=supersedes["rollover_id"],
+            )
+            task_family_rollover.activate_superseding_transition(
+                repo_root=state_root,
+                family_id=replacement["native_lifecycle"]["family_id"],
+                operation_id=replacement["native_lifecycle"]["operation_id"],
+            )
+            replacement["native_lifecycle"]["supersedes"] = dict(supersedes)
+            native_transition["status"] = "awaiting_native_create"
+            native_transition["superseded"] = dict(supersedes)
         write_json_atomic(state_path, prepared_state)
+    except (OSError, ValueError) as exc:
         print(
             json.dumps(
                 {
                     "error": f"native rollover intent persistence failed: {exc}",
                     "state_file": rel(state_path, state_root),
                     "old_automation_ready_to_delete": False,
+                    "recovery": "Retry the exact repair or prepare command; never invoke native create while supersession is pending.",
                 },
                 indent=2,
             )
@@ -1793,16 +1903,203 @@ def _native_command_context(
     expected_family_id, expected_operation_id = task_family_rollover.transition_identity(
         lineage_id=lineage_id,
         generation=generation,
+        rollover_id=replacement["rollover_id"],
     )
     if native.get("family_id") != expected_family_id or native.get("operation_id") != expected_operation_id:
         raise ValueError("rollover native lifecycle identity does not match its durable lineage")
+    if native.get("status") == "supersession_pending":
+        raise ValueError("rollover native intent supersession is pending; repair it before any native action")
     if native.get("source_thread_id") != (state.get("active") or {}).get("thread_id"):
         raise ValueError("rollover native predecessor does not match the active lease identity")
+    task_family_rollover.assert_transition_context(
+        repo_root=state_root,
+        family_id=native["family_id"],
+        operation_id=native["operation_id"],
+        lineage_id=lineage_id,
+        rollover_id=replacement["rollover_id"],
+        generation=generation,
+        source_thread_id=native["source_thread_id"],
+    )
     bound_replacement_id = native.get("replacement_thread_id")
     resumed_replacement_id = replacement.get("resumed_thread_id") or replacement.get("thread_id")
     if bound_replacement_id and resumed_replacement_id and bound_replacement_id != resumed_replacement_id:
         raise ValueError("rollover native replacement does not match the resumed lease identity")
     return repo_root, state_root, agent, state_path, state, native
+
+
+def cmd_repair_native_intent(args: argparse.Namespace) -> int:
+    lock_path = _rollover_mutation_lock_path(args)
+    if lock_path is None:
+        return _cmd_repair_native_intent_locked(args)
+    with task_family_advisory_lock(lock_path):
+        return _cmd_repair_native_intent_locked(args)
+
+
+def _cmd_repair_native_intent_locked(args: argparse.Namespace) -> int:
+    """Reconcile one legacy same-generation receipt collision without native mutation."""
+    try:
+        repo_root, state_root = resolve_roots(args.repo_root)
+        agent = normalize_agent_name(args.agent)
+        if not args.lineage_id and not args.state_file:
+            raise ValueError("--lineage-id or --state-file is required to locate an isolated rollover")
+        state_path = resolve_state_path(
+            repo_root=repo_root,
+            state_root=state_root,
+            supplied_state_file=args.state_file,
+            default_path=default_state_path(agent, args.lineage_id) if args.lineage_id else None,
+        )
+        state = load_state(state_path)
+        state_error = state_error_payload(state, state_path, state_root)
+        if state_error:
+            raise ValueError(state_error["error"])
+        replacement = dict(state.get("replacement") or {})
+        if replacement.get("rollover_id") != args.rollover_id:
+            raise ValueError("--rollover-id does not match the isolated rollover")
+        if replacement.get("status") != "pending_start":
+            raise ValueError("native-intent repair is limited to an unconfirmed pending_start replacement")
+        lineage_id = replacement.get("lineage_id")
+        generation = replacement.get("generation")
+        active = state.get("active") or {}
+        source_thread_id = active.get("thread_id")
+        display = replacement.get("display")
+        native = replacement.get("native_lifecycle")
+        if (
+            not isinstance(lineage_id, str)
+            or not isinstance(generation, int)
+            or generation < 1
+            or not isinstance(source_thread_id, str)
+            or not source_thread_id.strip()
+            or not isinstance(display, dict)
+            or not isinstance(native, dict)
+        ):
+            raise ValueError("rollover lease lacks exact identity or display metadata required for repair")
+        if native.get("source_thread_id") != source_thread_id or native.get("replacement_thread_id") is not None:
+            raise ValueError("native-intent repair refuses a bound or mismatched replacement")
+
+        successor_family_id, successor_operation_id = task_family_rollover.transition_identity(
+            lineage_id=lineage_id,
+            generation=generation,
+            rollover_id=replacement["rollover_id"],
+        )
+        legacy_family_id, legacy_operation_id = task_family_rollover.legacy_transition_identity(
+            lineage_id=lineage_id,
+            generation=generation,
+        )
+        native_supersedes = native.get("supersedes")
+        if native.get("family_id") == successor_family_id and native.get("operation_id") == successor_operation_id:
+            if not isinstance(native_supersedes, dict):
+                raise ValueError("packet-specific transition lacks its exact superseded receipt reference")
+            supersedes = {
+                "family_id": str(native_supersedes.get("family_id") or ""),
+                "operation_id": str(native_supersedes.get("operation_id") or ""),
+                "rollover_id": str(native_supersedes.get("rollover_id") or ""),
+            }
+        elif native.get("family_id") == legacy_family_id and native.get("operation_id") == legacy_operation_id:
+            proof = task_family_rollover.assert_transition_supersedable(
+                repo_root=state_root,
+                family_id=legacy_family_id,
+                operation_id=legacy_operation_id,
+                lineage_id=lineage_id,
+                generation=generation,
+                source_thread_id=source_thread_id,
+                successor_rollover_id=replacement["rollover_id"],
+                successor_operation_id=successor_operation_id,
+            )
+            supersedes = {
+                "family_id": legacy_family_id,
+                "operation_id": legacy_operation_id,
+                "rollover_id": str(proof["plan"]["rollover_id"]),
+            }
+        else:
+            raise ValueError("lease does not reference the exact legacy or packet-specific native intent")
+
+        if supersedes["rollover_id"] == replacement["rollover_id"]:
+            raise ValueError("legacy receipt already belongs to the current packet; no supersession repair is valid")
+        candidate_native = {
+            "family_id": successor_family_id,
+            "operation_id": successor_operation_id,
+            "source_thread_id": source_thread_id,
+            "replacement_thread_id": None,
+            "status": "supersession_pending",
+            "supersedes": dict(supersedes),
+        }
+        candidate_replacement = dict(replacement)
+        candidate_replacement["native_lifecycle"] = candidate_native
+        candidate_state = dict(state)
+        candidate_state["replacement"] = candidate_replacement
+        validated, validation_error = validate_live_lease(candidate_state, agent=agent, state_path=state_path)
+        if validation_error or validated is None:
+            raise ValueError(f"repaired lease validation failed: {validation_error or 'unknown error'}")
+
+        transition = task_family_rollover.prepare_transition(
+            repo_root=state_root,
+            agent=agent,
+            lineage_id=lineage_id,
+            rollover_id=replacement["rollover_id"],
+            generation=generation,
+            source_thread_id=source_thread_id,
+            intended_title=display["title"],
+            title_source=display["title_source"],
+            bootstrap_prompt_path=replacement["bootstrap_prompt_path"],
+            supersedes=supersedes,
+        )
+        write_json_atomic(state_path, candidate_state)
+        superseded = task_family_rollover.supersede_unexecuted_transition(
+            repo_root=state_root,
+            family_id=supersedes["family_id"],
+            operation_id=supersedes["operation_id"],
+            lineage_id=lineage_id,
+            generation=generation,
+            source_thread_id=source_thread_id,
+            successor_rollover_id=replacement["rollover_id"],
+            successor_operation_id=successor_operation_id,
+            evidence=args.evidence,
+            expected_rollover_id=supersedes["rollover_id"],
+        )
+        activated = task_family_rollover.activate_superseding_transition(
+            repo_root=state_root,
+            family_id=successor_family_id,
+            operation_id=successor_operation_id,
+        )
+        candidate_native["status"] = "awaiting_native_create"
+        candidate_replacement["native_lifecycle"] = candidate_native
+        candidate_state["replacement"] = candidate_replacement
+        candidate_state["updated_at"] = isoformat_z(utc_now())
+        write_json_atomic(state_path, candidate_state)
+        _, final_error = validate_live_lease(candidate_state, agent=agent, state_path=state_path)
+        if final_error:
+            raise ValueError(f"persisted repaired lease failed validation: {final_error}")
+    except (KeyError, OSError, TypeError, ValueError) as exc:
+        print(
+            json.dumps(
+                {
+                    "error": str(exc),
+                    "action": "repair-native-intent",
+                    "old_automation_ready_to_delete": False,
+                },
+                indent=2,
+            )
+        )
+        return 2
+    print(
+        json.dumps(
+            {
+                "status": "native_intent_repaired",
+                "lineage_id": lineage_id,
+                "rollover_id": replacement["rollover_id"],
+                "source_thread_id": source_thread_id,
+                "superseded": superseded,
+                "native_lifecycle": {
+                    **transition,
+                    "status": activated["status"],
+                    "supersedes": supersedes,
+                },
+                "old_automation_ready_to_delete": False,
+            },
+            indent=2,
+        )
+    )
+    return 0
 
 
 def _write_native_status(
@@ -1883,6 +2180,16 @@ def cmd_register_created(args: argparse.Namespace) -> int:
 
 
 def cmd_native_action(args: argparse.Namespace) -> int:
+    if args.action != "create":
+        return _cmd_native_action_locked(args)
+    lock_path = _rollover_mutation_lock_path(args)
+    if lock_path is None:
+        return _cmd_native_action_locked(args)
+    with task_family_advisory_lock(lock_path):
+        return _cmd_native_action_locked(args)
+
+
+def _cmd_native_action_locked(args: argparse.Namespace) -> int:
     try:
         _, state_root, _, state_path, state, native = _native_command_context(args)
         if args.action == "create":
@@ -2346,6 +2653,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     prepare.add_argument("--dry-run", action="store_true", help="Print the generated packet without writing files.")
     prepare.set_defaults(func=cmd_prepare)
+
+    repair_native_intent = subparsers.add_parser(
+        "repair-native-intent",
+        help="Replace one untouched legacy same-generation native receipt with the current packet-specific intent.",
+    )
+    repair_native_intent.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    repair_native_intent.add_argument("--lineage-id", type=argparse_lineage_id)
+    repair_native_intent.add_argument("--state-file", type=Path)
+    repair_native_intent.add_argument("--rollover-id", required=True)
+    repair_native_intent.add_argument(
+        "--evidence",
+        required=True,
+        help="Exact operator/app evidence that the legacy receipt never reached create_thread.",
+    )
+    repair_native_intent.set_defaults(func=cmd_repair_native_intent)
 
     register = subparsers.add_parser(
         "register-created",

--- a/tests/orchestration/task_family/test_rollover.py
+++ b/tests/orchestration/task_family/test_rollover.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import subprocess
+import time
 from pathlib import Path
 from uuid import uuid4
 
@@ -11,7 +13,7 @@ import pytest
 
 from scripts.orchestration.task_family import codex_state, rollover
 from scripts.orchestration.task_family.model import RelationType
-from scripts.orchestration.task_family.storage import TaskFamilyStorage
+from scripts.orchestration.task_family.storage import TaskFamilyStorage, advisory_lock
 
 
 def _write_db(path: Path, rows: list[tuple[str, str, str, int, str | None, str]]) -> None:
@@ -164,6 +166,219 @@ def test_rollover_titles_are_meaningful_bounded_and_have_unique_fallback() -> No
         )
 
 
+def test_transition_identity_is_stable_per_packet_without_splitting_the_family() -> None:
+    first_family, first_operation = rollover.transition_identity(
+        lineage_id="lineage-1234567890abcdef12345678",
+        generation=1,
+        rollover_id="rollover-first",
+    )
+    retry_family, retry_operation = rollover.transition_identity(
+        lineage_id="lineage-1234567890abcdef12345678",
+        generation=1,
+        rollover_id="rollover-first",
+    )
+    second_family, second_operation = rollover.transition_identity(
+        lineage_id="lineage-1234567890abcdef12345678",
+        generation=1,
+        rollover_id="rollover-second",
+    )
+
+    assert first_family == retry_family == second_family
+    assert first_operation == retry_operation
+    assert first_operation != second_operation
+
+
+def test_advisory_lock_blocks_a_second_process_until_release(tmp_path: Path) -> None:
+    lock_path = tmp_path / "lineage" / ".native-intent.lock"
+    ready_path = tmp_path / "child-ready"
+    acquired_path = tmp_path / "child-acquired"
+    code = (
+        "import sys\n"
+        "from pathlib import Path\n"
+        "from scripts.orchestration.task_family.storage import advisory_lock\n"
+        "lock_path, ready_path, acquired_path = map(Path, sys.argv[1:])\n"
+        "ready_path.write_text('ready', encoding='utf-8')\n"
+        "with advisory_lock(lock_path):\n"
+        "    acquired_path.write_text('acquired', encoding='utf-8')\n"
+    )
+    repo_root = Path(__file__).resolve().parents[3]
+    with advisory_lock(lock_path):
+        child = subprocess.Popen(
+            [".venv/bin/python", "-c", code, str(lock_path), str(ready_path), str(acquired_path)],
+            cwd=repo_root,
+        )
+        deadline = time.monotonic() + 5
+        while not ready_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready_path.exists()
+        assert acquired_path.exists() is False
+        assert child.poll() is None
+    stdout, stderr = child.communicate(timeout=5)
+    assert child.returncode == 0, (stdout, stderr)
+    assert acquired_path.read_text(encoding="utf-8") == "acquired"
+
+
+def test_pristine_transition_supersession_is_durable_idempotent_and_blocks_old_create(tmp_path: Path) -> None:
+    source_id = str(uuid4())
+    common = {
+        "repo_root": tmp_path,
+        "agent": "codex",
+        "lineage_id": "lineage-1234567890abcdef12345678",
+        "generation": 1,
+        "source_thread_id": source_id,
+        "intended_title": "Infrastructure — P1 repair rollover",
+        "title_source": "durable_metadata",
+        "bootstrap_prompt_path": "bootstrap.md",
+    }
+    old = rollover.prepare_transition(**common, rollover_id="rollover-old")
+    supersedes = {
+        "family_id": str(old["family_id"]),
+        "operation_id": str(old["operation_id"]),
+        "rollover_id": "rollover-old",
+    }
+    successor = rollover.prepare_transition(**common, rollover_id="rollover-new", supersedes=supersedes)
+    old_storage = TaskFamilyStorage(tmp_path, str(old["family_id"]), str(old["operation_id"]))
+    old_plan = old_storage.rollover_plan_path.read_bytes()
+    kwargs = {
+        "repo_root": tmp_path,
+        "family_id": str(old["family_id"]),
+        "operation_id": str(old["operation_id"]),
+        "lineage_id": common["lineage_id"],
+        "generation": 1,
+        "source_thread_id": source_id,
+        "successor_rollover_id": "rollover-new",
+        "successor_operation_id": str(successor["operation_id"]),
+        "evidence": "No native create was authorized or invoked.",
+        "expected_rollover_id": "rollover-old",
+    }
+
+    first = rollover.supersede_unexecuted_transition(**kwargs)
+    retry = rollover.supersede_unexecuted_transition(**kwargs)
+    activated = rollover.activate_superseding_transition(
+        repo_root=tmp_path,
+        family_id=str(successor["family_id"]),
+        operation_id=str(successor["operation_id"]),
+    )
+
+    assert first["status"] == "superseded"
+    assert retry["status"] == "already_superseded"
+    assert activated["status"] == "awaiting_native_create"
+    assert old_storage.rollover_plan_path.read_bytes() == old_plan
+    assert old_storage.rollover_supersession_path.exists()
+    assert old_storage.load_state()["details"]["status"] == "superseded_before_native_create"
+    receipt = old_storage.load_receipt()
+    assert receipt.actual == ()
+    assert {item.action for item in receipt.skipped} == {item.action for item in receipt.planned}
+    old_action = rollover.request_create_action(
+        repo_root=tmp_path,
+        family_id=str(old["family_id"]),
+        operation_id=str(old["operation_id"]),
+    )
+    assert old_action["needs_native_action"] is False
+    assert old_action["status"] == "superseded_before_native_create"
+    with pytest.raises(ValueError, match="different exact successor"):
+        rollover.assert_transition_supersedable(
+            repo_root=tmp_path,
+            family_id=str(old["family_id"]),
+            operation_id=str(old["operation_id"]),
+            lineage_id=common["lineage_id"],
+            generation=1,
+            source_thread_id=source_id,
+            successor_rollover_id="rollover-other",
+            successor_operation_id=str(uuid4()),
+            expected_rollover_id="rollover-old",
+        )
+
+
+def test_superseding_transition_stays_blocked_until_exact_predecessor_is_superseded(tmp_path: Path) -> None:
+    source_id = str(uuid4())
+    common = {
+        "repo_root": tmp_path,
+        "agent": "codex",
+        "lineage_id": "lineage-1234567890abcdef12345678",
+        "generation": 1,
+        "source_thread_id": source_id,
+        "intended_title": "Infrastructure — P1 activation gate",
+        "title_source": "durable_metadata",
+        "bootstrap_prompt_path": "bootstrap.md",
+    }
+    old = rollover.prepare_transition(**common, rollover_id="rollover-old")
+    supersedes = {
+        "family_id": str(old["family_id"]),
+        "operation_id": str(old["operation_id"]),
+        "rollover_id": "rollover-old",
+    }
+    successor = rollover.prepare_transition(**common, rollover_id="rollover-new", supersedes=supersedes)
+
+    blocked = rollover.request_create_action(
+        repo_root=tmp_path,
+        family_id=str(successor["family_id"]),
+        operation_id=str(successor["operation_id"]),
+    )
+    assert blocked["status"] == "supersession_pending"
+    assert blocked["needs_native_action"] is False
+    with pytest.raises(ValueError, match="has not been durably superseded"):
+        rollover.activate_superseding_transition(
+            repo_root=tmp_path,
+            family_id=str(successor["family_id"]),
+            operation_id=str(successor["operation_id"]),
+        )
+    with pytest.raises(ValueError, match="supersedes must contain"):
+        rollover.prepare_transition(
+            **common,
+            rollover_id="rollover-malformed",
+            supersedes={"operation_id": str(old["operation_id"])},
+        )
+
+
+@pytest.mark.parametrize("unsafe_state", ["binding", "failed_ack", "success_ack", "authorization"])
+def test_supersession_refuses_bound_partial_or_authorized_native_create(
+    tmp_path: Path,
+    unsafe_state: str,
+) -> None:
+    source_id = str(uuid4())
+    transition = rollover.prepare_transition(
+        repo_root=tmp_path,
+        agent="codex",
+        lineage_id="lineage-1234567890abcdef12345678",
+        rollover_id=f"rollover-{unsafe_state}",
+        generation=1,
+        source_thread_id=source_id,
+        intended_title="Infrastructure — P1 fail closed",
+        title_source="durable_metadata",
+        bootstrap_prompt_path="bootstrap.md",
+    )
+    storage = TaskFamilyStorage(tmp_path, str(transition["family_id"]), str(transition["operation_id"]))
+    operation = {
+        "repo_root": tmp_path,
+        "family_id": str(transition["family_id"]),
+        "operation_id": str(transition["operation_id"]),
+    }
+    if unsafe_state == "binding":
+        storage.write_immutable_json(storage.rollover_binding_path, {"binding": "exists"})
+    elif unsafe_state == "authorization":
+        assert rollover.request_create_action(**operation)["needs_native_action"] is True
+    else:
+        rollover.record_native_result(
+            **operation,
+            action="create",
+            succeeded=unsafe_state == "success_ack",
+            evidence="native create response",
+            error="partial failure" if unsafe_state == "failed_ack" else "",
+        )
+
+    with pytest.raises(ValueError, match=r"cannot be superseded|untouched native-create intent"):
+        rollover.assert_transition_supersedable(
+            **operation,
+            lineage_id="lineage-1234567890abcdef12345678",
+            generation=1,
+            source_thread_id=source_id,
+            successor_rollover_id="rollover-successor",
+            successor_operation_id=str(uuid4()),
+            expected_rollover_id=f"rollover-{unsafe_state}",
+        )
+
+
 def test_prepare_and_bind_persist_exact_ids_typed_relations_and_receipt(tmp_path: Path) -> None:
     data = _transition(tmp_path)
     prepared = data["prepared"]
@@ -179,7 +394,9 @@ def test_prepare_and_bind_persist_exact_ids_typed_relations_and_receipt(tmp_path
     assert {relation.source_id for relation in manifest.relations} == {data["replacement_id"]}
     assert {relation.target_id for relation in manifest.relations} == {data["source_id"]}
     receipt = storage.load_receipt()
-    assert any(item.action == "create_replacement" and item.resource_id == data["replacement_id"] for item in receipt.actual)
+    assert any(
+        item.action == "create_replacement" and item.resource_id == data["replacement_id"] for item in receipt.actual
+    )
     assert storage.rollover_binding_path.exists()
     assert "Resume codex rollover" not in storage.read_json(storage.rollover_plan_path)["intended_title"]
     retry = rollover.request_create_action(

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -11,6 +11,8 @@ import pytest
 
 from scripts.orchestration import thread_handoff as th
 from scripts.orchestration import thread_handoff_canary as canary
+from scripts.orchestration.task_family import rollover
+from scripts.orchestration.task_family.storage import TaskFamilyStorage
 
 
 def sample_snapshot(tmp_path: Path) -> dict:
@@ -190,6 +192,7 @@ def test_direct_script_help_from_repository_root():
     assert "Prepare and guard agent-specific thread handoffs." in completed.stdout
     for command in (
         "prepare",
+        "repair-native-intent",
         "register-created",
         "native-action",
         "record-native-result",
@@ -334,7 +337,10 @@ def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
     assert "If either fact is absent, use `unknown`" in prompt
     assert "Only an actionable response authorizes `set_thread_archived`" in prompt
     assert "must register and title this exact native replacement before resume" in prompt
-    assert "Keep the invoking checkout clean at prepared HEAD abc123def0456789 through resume and confirmation (clean fast-forward advances are tolerated)." in prompt
+    assert (
+        "Keep the invoking checkout clean at prepared HEAD abc123def0456789 through resume and confirmation (clean fast-forward advances are tolerated)."
+        in prompt
+    )
     assert "Context estimate: 86.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
     assert "orchestrator_control.py inbox --recent 20 --include-results" in prompt
 
@@ -451,6 +457,7 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     def make_is_ancestor(ancestry_map):
         def is_ancestor(expected, current):
             return ancestry_map.get((expected, current))
+
         return is_ancestor
 
     # 1. Descent accepted: prepared is ancestor of current
@@ -458,27 +465,29 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     assert th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_ok) is None
 
     # 2. Divergence rejected: neither is ancestor
-    is_ancestor_diverged = make_is_ancestor({
-        (prepared_head, current_head): False,
-        (current_head, prepared_head): False,
-    })
+    is_ancestor_diverged = make_is_ancestor(
+        {
+            (prepared_head, current_head): False,
+            (current_head, prepared_head): False,
+        }
+    )
     err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_diverged)
     assert f"invoking checkout HEAD {current_head} has diverged from prepared HEAD {prepared_head}" in err
 
     # 3. Rewind rejected: current is strict ancestor of prepared
-    is_ancestor_rewind = make_is_ancestor({
-        (prepared_head, current_head): False,
-        (current_head, prepared_head): True,
-    })
+    is_ancestor_rewind = make_is_ancestor(
+        {
+            (prepared_head, current_head): False,
+            (current_head, prepared_head): True,
+        }
+    )
     err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_rewind)
-    assert f"invoking checkout HEAD {current_head} is a rewind (strict ancestor of prepared HEAD {prepared_head})" in err
+    assert (
+        f"invoking checkout HEAD {current_head} is a rewind (strict ancestor of prepared HEAD {prepared_head})" in err
+    )
 
     # 4. Dirty-at-descent rejected: prepared is ancestor, but tree is dirty
-    dirty_state = {
-        **clean,
-        "full_head": current_head,
-        "modified_files": [{"status": "M", "path": "tracked.txt"}]
-    }
+    dirty_state = {**clean, "full_head": current_head, "modified_files": [{"status": "M", "path": "tracked.txt"}]}
     err = th.checkout_continuity_error(replacement, dirty_state, is_ancestor=is_ancestor_ok)
     assert "invoking checkout must be clean" in err
 
@@ -492,10 +501,12 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     assert "does not match prepared HEAD" in err
     assert "ancestry undeterminable" in err
 
-    is_ancestor_partial_none = make_is_ancestor({
-        (prepared_head, current_head): False,
-        (current_head, prepared_head): None,
-    })
+    is_ancestor_partial_none = make_is_ancestor(
+        {
+            (prepared_head, current_head): False,
+            (current_head, prepared_head): None,
+        }
+    )
     err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_partial_none)
     assert "does not match prepared HEAD" in err
     assert "ancestry undeterminable" in err
@@ -569,7 +580,8 @@ def test_prepare_rejects_dirty_source_checkout_without_writing_packet(tmp_path: 
     payload = json.loads(capsys.readouterr().out)
     assert "source checkout must be clean before prepare" in payload["error"]
     assert payload["old_automation_ready_to_delete"] is False
-    assert not (tmp_path / ".agent/thread-rollovers").exists()
+    rollover_root = tmp_path / ".agent/thread-rollovers"
+    assert [path for path in rollover_root.rglob("*") if path.is_file() and path.name != ".native-intent.lock"] == []
 
 
 def test_register_created_context_failure_reports_cleanly(tmp_path: Path, capsys):
@@ -621,6 +633,208 @@ def test_native_create_action_is_retry_gate_without_db(tmp_path: Path, capsys, m
     assert action["tool"] == "create_thread"
     assert action["needs_native_action"] is True
     assert action["bootstrap_prompt_path"] == prepared_payload["bootstrap_file"]
+
+
+def test_forced_prepare_supersedes_only_pristine_exact_predecessor_intent(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    command = ["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "old-thread"]
+    assert th.main(command) == 0
+    first = json.loads(capsys.readouterr().out)
+
+    assert th.main([*command, "--force-new-replacement"]) == 0
+    second = json.loads(capsys.readouterr().out)
+
+    assert second["rollover_id"] != first["rollover_id"]
+    assert second["native_lifecycle"]["operation_id"] != first["native_lifecycle"]["operation_id"]
+    old_storage = TaskFamilyStorage(
+        tmp_path,
+        first["native_lifecycle"]["family_id"],
+        first["native_lifecycle"]["operation_id"],
+    )
+    assert old_storage.load_state()["details"]["status"] == "superseded_before_native_create"
+    assert old_storage.rollover_supersession_path.exists()
+    assert old_storage.load_receipt().actual == ()
+    lease = json.loads((tmp_path / second["state_file"]).read_text(encoding="utf-8"))
+    assert lease["replacement"]["rollover_id"] == second["rollover_id"]
+    assert lease["replacement"]["native_lifecycle"]["status"] == "awaiting_native_create"
+    assert "Resume codex rollover" not in second["intended_title"]
+
+
+def test_legacy_receipt_collision_repairs_current_packet_and_never_creates_from_mismatch(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    state = prepared(agent="codex", thread_id="old-thread")
+    replacement = state["replacement"]
+    current_rollover_id = replacement["rollover_id"]
+    current_bootstrap = replacement["bootstrap_prompt_path"]
+    lineage_id = state["lineage_id"]
+    legacy_family_id, legacy_operation_id = rollover.legacy_transition_identity(
+        lineage_id=lineage_id,
+        generation=1,
+    )
+    original_identity = rollover.transition_identity
+    monkeypatch.setattr(
+        rollover,
+        "transition_identity",
+        lambda **kwargs: (legacy_family_id, legacy_operation_id),
+    )
+    rollover.prepare_transition(
+        repo_root=tmp_path,
+        agent="codex",
+        lineage_id=lineage_id,
+        rollover_id="rollover-superseded-packet",
+        generation=1,
+        source_thread_id="old-thread",
+        intended_title=replacement["display"]["title"],
+        title_source=replacement["display"]["title_source"],
+        bootstrap_prompt_path="stale-bootstrap.md",
+    )
+    monkeypatch.setattr(rollover, "transition_identity", original_identity)
+    replacement["native_lifecycle"] = {
+        "family_id": legacy_family_id,
+        "operation_id": legacy_operation_id,
+        "source_thread_id": "old-thread",
+        "replacement_thread_id": None,
+        "status": "needs_native_action",
+        "error": "immutable operation document mismatch: rollover-plan.json",
+    }
+    state_path = th.default_state_path("codex", lineage_id)
+    th.write_json_atomic(tmp_path / state_path, state)
+
+    native_command = [
+        "--repo-root",
+        str(tmp_path),
+        "native-action",
+        "--agent",
+        "codex",
+        "--lineage-id",
+        lineage_id,
+        "--rollover-id",
+        current_rollover_id,
+        "--action",
+        "create",
+    ]
+    assert th.main(native_command) == 2
+    assert "does not match its durable lineage" in json.loads(capsys.readouterr().out)["error"]
+    legacy_storage = TaskFamilyStorage(tmp_path, legacy_family_id, legacy_operation_id)
+    assert [event.kind for event in legacy_storage.load_events()] == ["rollover_native_intent_prepared"]
+
+    repair_command = [
+        "--repo-root",
+        str(tmp_path),
+        "repair-native-intent",
+        "--agent",
+        "codex",
+        "--lineage-id",
+        lineage_id,
+        "--rollover-id",
+        current_rollover_id,
+        "--evidence",
+        "App stopped before create_thread; receipt and binding are pristine.",
+    ]
+    assert th.main(repair_command) == 0
+    repaired = json.loads(capsys.readouterr().out)
+    assert repaired["status"] == "native_intent_repaired"
+    repaired_state = json.loads((tmp_path / state_path).read_text(encoding="utf-8"))
+    repaired_native = repaired_state["replacement"]["native_lifecycle"]
+    expected_family, expected_operation = original_identity(
+        lineage_id=lineage_id,
+        generation=1,
+        rollover_id=current_rollover_id,
+    )
+    assert repaired_native["family_id"] == expected_family
+    assert repaired_native["operation_id"] == expected_operation
+    assert repaired_native["status"] == "awaiting_native_create"
+    assert repaired_state["replacement"]["bootstrap_prompt_path"] == current_bootstrap
+    assert legacy_storage.load_state()["details"]["status"] == "superseded_before_native_create"
+    current_storage = TaskFamilyStorage(tmp_path, expected_family, expected_operation)
+    assert current_storage.read_json(current_storage.rollover_plan_path)["rollover_id"] == current_rollover_id
+    validated, error = th.validate_live_lease(repaired_state, agent="codex", state_path=tmp_path / state_path)
+    assert error is None
+    assert validated is not None
+
+    assert th.main(repair_command) == 0
+    retry = json.loads(capsys.readouterr().out)
+    assert retry["status"] == "native_intent_repaired"
+    assert th.main(native_command) == 0
+    action = json.loads(capsys.readouterr().out)
+    assert action["needs_native_action"] is True
+    assert action["bootstrap_prompt_path"] == current_bootstrap
+
+
+def test_prepare_plan_failure_does_not_publish_a_live_lease(tmp_path: Path, capsys, monkeypatch) -> None:
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    monkeypatch.setattr(
+        th.task_family_rollover,
+        "prepare_transition",
+        lambda **kwargs: (_ for _ in ()).throw(ValueError("simulated persistence failure")),
+    )
+
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread"]) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert "simulated persistence failure" in payload["error"]
+    assert not (
+        tmp_path / th.default_state_path("orchestrator", th.lineage_id_for("orchestrator", "old-thread"))
+    ).exists()
+
+
+def test_prepare_repair_and_create_authorization_share_one_lineage_lock(tmp_path: Path) -> None:
+    lineage_id = "lineage-1234567890abcdef12345678"
+    parser = th.build_parser()
+    prepare_args = parser.parse_args(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "prepare",
+            "--agent",
+            "codex",
+            "--lineage-id",
+            lineage_id,
+            "--active-thread-id",
+            "old-thread",
+        ]
+    )
+    repair_args = parser.parse_args(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "repair-native-intent",
+            "--agent",
+            "codex",
+            "--lineage-id",
+            lineage_id,
+            "--rollover-id",
+            "rollover-current",
+            "--evidence",
+            "no native call",
+        ]
+    )
+    create_args = parser.parse_args(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "native-action",
+            "--agent",
+            "codex",
+            "--lineage-id",
+            lineage_id,
+            "--rollover-id",
+            "rollover-current",
+            "--action",
+            "create",
+        ]
+    )
+
+    expected = tmp_path / th.default_state_path("codex", lineage_id).parent / ".native-intent.lock"
+    assert th._rollover_mutation_lock_path(prepare_args) == expected
+    assert th._rollover_mutation_lock_path(repair_args) == expected
+    assert th._rollover_mutation_lock_path(create_args) == expected
 
 
 def test_resume_and_confirm_independently_recheck_checkout_continuity(tmp_path: Path, capsys, monkeypatch):
@@ -1041,6 +1255,10 @@ def test_pending_prepare_refuses_unless_explicitly_forced():
         force_new_replacement=True,
     )
     assert forced["replacement"]["rollover_id"] != state["replacement"]["rollover_id"]
+    assert (
+        forced["replacement"]["native_lifecycle"]["operation_id"]
+        != state["replacement"]["native_lifecycle"]["operation_id"]
+    )
 
 
 def test_resume_is_deterministic_and_refuses_a_different_thread():


### PR DESCRIPTION
Closes #5271

Stream epic: #4707

## Summary
- derive native operation identity from lineage, generation, and exact rollover packet
- preserve immutable predecessor plans while durably receipting pristine supersession
- add fail-closed repair-native-intent for the proven legacy same-generation collision
- serialize prepare, repair, and create authorization through one cross-process lineage lock
- keep title/archive identity, confirmation, pin/status, and heartbeat cleanup proof gates intact
- update the canonical thread-rollover skill and handoff runbook

## Verification
- 123 pytest cases across task-family, thread-handoff, and handoff identity suites
- handoff identity shell fixtures
- ruff check and format check
- markdownlint on changed docs/skill
- prompt and skill linters
- git diff --check and mandatory artifact/config checks
- X-Agent trailer audit

## Independent review
Claude Opus 4.8 outside-GPT review: PASS. Its concurrency finding was applied with a cross-process fcntl lineage lock and a real two-process contention regression. Follow-up review confirmed the race was closed; remaining verification nits were addressed. Gemini via AGY was attempted first but stalled, so the lane was substituted per the operator routing rules.