### PR TITLE
fix(deploy): shrink Pages build under budget + fail-closed size gate (#5274)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -83,49 +83,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # #5274: normal build leaves BUILD_ETYMOLOGY_ROUTES off (~296 MB). build:full
+      # prerenders ~25k standalone etymology pages and blew the 1 GiB Pages budget.
       - name: Build Site
-        run: npm run build:full
+        run: npm run build
 
       - name: Emit immutable deployment marker
         run: |
           mkdir -p dist/.well-known
           printf '%s\n' "$GITHUB_SHA" > "dist/.well-known/learn-ukrainian-deployment-${GITHUB_SHA}.txt"
 
-      # #4966: published-site size tracking — report MB used vs the 1 GiB GitHub
-      # Pages budget + projected headroom at full-vision scale (20k Atlas words),
-      # on every release, in the job summary. Warns at >=70% budget.
-      - name: Report published-site size + headroom
-        run: |
-          set -euo pipefail
-          SIZE_KB=$(du -sk dist | cut -f1)
-          SIZE_MB=$(( SIZE_KB / 1024 ))
-          BUDGET_MB=1024
-          PCT=$(( SIZE_MB * 100 / BUDGET_MB ))
-          ENTRIES=$(
-            node -e "console.log(require('./src/data/lexicon-browse-meta.json').total ?? 0)" \
-              2>/dev/null || echo 0
-          )
-          {
-            echo "## Published-site size (#4966)"
-            echo ""
-            echo "| Metric | Value |"
-            echo "| --- | --- |"
-            echo "| dist size | **${SIZE_MB} MB** |"
-            echo "| Pages budget used | **${PCT}%** of ${BUDGET_MB} MB |"
-            echo "| Atlas entries | ${ENTRIES} |"
-            if [ "${ENTRIES}" -gt 0 ]; then
-              KB_PER_ENTRY=$(( SIZE_KB / ENTRIES ))
-              PROJ_MB=$(( (SIZE_KB + (20000 - ENTRIES) * KB_PER_ENTRY) / 1024 ))
-              PROJ_PCT=$(( PROJ_MB * 100 / BUDGET_MB ))
-              echo "| all-in KB/entry | ${KB_PER_ENTRY} |"
-              echo "| projected @ 20k entries | ~${PROJ_MB} MB (${PROJ_PCT}% of budget) |"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-          echo "site size: ${SIZE_MB} MB (${PCT}% of ${BUDGET_MB} MB Pages budget), entries=${ENTRIES}"
-          if [ "$PCT" -ge 70 ]; then
-            WARNING="Published site is at ${PCT}% of the ${BUDGET_MB} MB budget (${SIZE_MB} MB)."
-            echo "::warning title=Pages budget::${WARNING}"
-          fi
+      # #5274: fail-closed size gate (replaces advisory 70% warn-only). Runs after
+      # build, before upload-pages-artifact — unknown profile or ≥80% of 1 GiB fails.
+      - name: Check published-site size (fail-closed)
+        working-directory: .
+        env:
+          DEPLOY_PROFILE: github-pages
+        run: .venv/bin/python scripts/deploy/check_site_size.py site/dist
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/scripts/deploy/__init__.py
+++ b/scripts/deploy/__init__.py
@@ -1,0 +1,1 @@
+"""Deploy-time helpers (site size gate, etc.)."""

--- a/scripts/deploy/check_site_size.py
+++ b/scripts/deploy/check_site_size.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Fail-closed published-site size gate for static deploys (#5274).
+
+Profiles (set via ``DEPLOY_PROFILE`` or ``--profile``):
+
+- ``github-pages`` — hard byte cap 900_000_000; warn at 70% of 1 GiB;
+  FAIL at ≥80% of 1 GiB (or the hard cap).
+- ``cloudflare-free`` — file-count cap < 20_000 (Wrangler major ≥3).
+- ``cloudflare-paid`` — file-count cap < 100_000 (Wrangler major ≥3).
+
+Unknown or missing profile → exit non-zero (fail closed).
+
+Usage::
+
+    DEPLOY_PROFILE=github-pages .venv/bin/python scripts/deploy/check_site_size.py site/dist
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+GIB = 1024**3
+GITHUB_PAGES_HARD_CAP_BYTES = 900_000_000
+GITHUB_PAGES_WARN_BYTES = int(GIB * 0.70)
+GITHUB_PAGES_FAIL_BYTES = int(GIB * 0.80)
+LEXICON_TARGET_ENTRIES = 20_000
+
+
+@dataclass(frozen=True)
+class DeployProfile:
+    """Threshold table for one deployment target."""
+
+    name: str
+    max_bytes: int | None = None
+    warn_bytes: int | None = None
+    fail_bytes: int | None = None
+    max_files: int | None = None
+    wrangler_major_note: str | None = None
+
+
+PROFILES: dict[str, DeployProfile] = {
+    "github-pages": DeployProfile(
+        name="github-pages",
+        max_bytes=GITHUB_PAGES_HARD_CAP_BYTES,
+        warn_bytes=GITHUB_PAGES_WARN_BYTES,
+        fail_bytes=GITHUB_PAGES_FAIL_BYTES,
+    ),
+    "cloudflare-free": DeployProfile(
+        name="cloudflare-free",
+        max_files=20_000,
+        wrangler_major_note=(
+            "cloudflare-free requires Wrangler major version ≥3 "
+            "(Workers Assets / Pages upload limits)."
+        ),
+    ),
+    "cloudflare-paid": DeployProfile(
+        name="cloudflare-paid",
+        max_files=100_000,
+        wrangler_major_note=(
+            "cloudflare-paid requires Wrangler major version ≥3 "
+            "(Workers Assets / Pages upload limits)."
+        ),
+    ),
+}
+
+
+@dataclass
+class RouteFamilyStats:
+    name: str
+    bytes: int = 0
+    files: int = 0
+
+
+@dataclass
+class SiteSizeReport:
+    total_bytes: int
+    file_count: int
+    largest_files: list[tuple[int, str]]
+    families: dict[str, RouteFamilyStats]
+    lexicon_page_count: int
+    lexicon_page_bytes: int
+    projected_bytes_at_target: int | None
+    warnings: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+def classify_route_family(rel_posix: str) -> str:
+    """Map a dist-relative path to etymology / lexicon / base."""
+    if rel_posix == "etymology" or rel_posix.startswith("etymology/"):
+        return "etymology"
+    if rel_posix == "lexicon" or rel_posix.startswith("lexicon/"):
+        return "lexicon"
+    return "base"
+
+
+def is_lexicon_word_page(rel_posix: str) -> bool:
+    """True for per-lemma pages: ``lexicon/<slug>/index.html`` only.
+
+    Excludes browse/search shards, API mirrors, and the lexicon index itself.
+    """
+    parts = rel_posix.split("/")
+    return (
+        len(parts) == 3
+        and parts[0] == "lexicon"
+        and parts[2] == "index.html"
+        and parts[1] not in {"browse", "search"}
+    )
+
+
+def scan_dist(dist: Path, *, largest_n: int = 15) -> SiteSizeReport:
+    """Walk ``dist`` and collect byte / file / route-family stats."""
+    if not dist.is_dir():
+        raise FileNotFoundError(f"dist directory not found: {dist}")
+
+    families = {
+        "etymology": RouteFamilyStats("etymology"),
+        "lexicon": RouteFamilyStats("lexicon"),
+        "base": RouteFamilyStats("base"),
+    }
+    sized: list[tuple[int, str]] = []
+    total_bytes = 0
+    file_count = 0
+    lexicon_page_count = 0
+    lexicon_page_bytes = 0
+
+    for path in dist.rglob("*"):
+        if not path.is_file():
+            continue
+        size = path.stat().st_size
+        rel = path.relative_to(dist).as_posix()
+        file_count += 1
+        total_bytes += size
+        sized.append((size, rel))
+        family = families[classify_route_family(rel)]
+        family.bytes += size
+        family.files += 1
+        if is_lexicon_word_page(rel):
+            lexicon_page_count += 1
+            lexicon_page_bytes += size
+
+    sized.sort(key=lambda item: item[0], reverse=True)
+    projected: int | None = None
+    if lexicon_page_count > 0:
+        # Fixed base (everything that is not a per-lemma lexicon page) plus
+        # a per-lexicon-page slope — replaces the old all-in /entries @20k
+        # linear projection that overstated headroom when etymology routes
+        # dominated the tree.
+        base_bytes = total_bytes - lexicon_page_bytes
+        slope = lexicon_page_bytes / lexicon_page_count
+        projected = int(base_bytes + LEXICON_TARGET_ENTRIES * slope)
+
+    return SiteSizeReport(
+        total_bytes=total_bytes,
+        file_count=file_count,
+        largest_files=sized[:largest_n],
+        families=families,
+        lexicon_page_count=lexicon_page_count,
+        lexicon_page_bytes=lexicon_page_bytes,
+        projected_bytes_at_target=projected,
+    )
+
+
+def apply_profile(report: SiteSizeReport, profile: DeployProfile) -> SiteSizeReport:
+    """Mutate ``report`` with warn/fail reasons for ``profile``."""
+    if profile.warn_bytes is not None and report.total_bytes >= profile.warn_bytes:
+        pct = 100.0 * report.total_bytes / GIB
+        report.warnings.append(
+            f"{profile.name}: site is {pct:.1f}% of 1 GiB "
+            f"({report.total_bytes:,} bytes ≥ warn {profile.warn_bytes:,})"
+        )
+
+    fail_threshold = profile.fail_bytes
+    if fail_threshold is not None and report.total_bytes >= fail_threshold:
+        pct = 100.0 * report.total_bytes / GIB
+        report.failures.append(
+            f"{profile.name}: size {report.total_bytes:,} bytes is "
+            f"{pct:.1f}% of 1 GiB (≥ fail {fail_threshold:,})"
+        )
+
+    if profile.max_bytes is not None and report.total_bytes >= profile.max_bytes:
+        report.failures.append(
+            f"{profile.name}: size {report.total_bytes:,} bytes exceeds "
+            f"hard cap {profile.max_bytes:,}"
+        )
+
+    if profile.max_files is not None and report.file_count >= profile.max_files:
+        report.failures.append(
+            f"{profile.name}: file count {report.file_count:,} exceeds "
+            f"cap {profile.max_files:,}"
+        )
+
+    return report
+
+
+def resolve_profile(name: str | None) -> DeployProfile:
+    """Return a known profile or raise ``ValueError`` (fail closed)."""
+    if not name or not str(name).strip():
+        raise ValueError(
+            "DEPLOY_PROFILE is missing or empty — fail closed. "
+            f"Known profiles: {', '.join(sorted(PROFILES))}"
+        )
+    key = str(name).strip()
+    profile = PROFILES.get(key)
+    if profile is None:
+        raise ValueError(
+            f"Unknown DEPLOY_PROFILE {key!r} — fail closed. "
+            f"Known profiles: {', '.join(sorted(PROFILES))}"
+        )
+    return profile
+
+
+def format_bytes(n: int) -> str:
+    """Human-readable byte size (MiB / GiB)."""
+    if n >= GIB:
+        return f"{n / GIB:.2f} GiB"
+    return f"{n / (1024**2):.1f} MiB"
+
+
+def format_report(report: SiteSizeReport, profile: DeployProfile) -> str:
+    """Stdout / job-summary markdown for one scan."""
+    lines: list[str] = [
+        f"## Deploy size gate ({profile.name})",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        f"| total bytes | **{report.total_bytes:,}** ({format_bytes(report.total_bytes)}) |",
+        f"| file count | **{report.file_count:,}** |",
+        f"| budget used | **{100.0 * report.total_bytes / GIB:.1f}%** of 1 GiB |",
+        f"| lexicon word pages | {report.lexicon_page_count:,} "
+        f"({format_bytes(report.lexicon_page_bytes)}) |",
+    ]
+    if report.projected_bytes_at_target is not None:
+        proj = report.projected_bytes_at_target
+        lines.append(
+            f"| projected @ {LEXICON_TARGET_ENTRIES:,} lexicon pages "
+            f"(fixed-base + slope) | ~{format_bytes(proj)} "
+            f"({100.0 * proj / GIB:.1f}% of 1 GiB) |"
+        )
+    if profile.max_bytes is not None:
+        lines.append(f"| hard cap | {profile.max_bytes:,} bytes |")
+    if profile.fail_bytes is not None:
+        lines.append(f"| fail ≥ | {profile.fail_bytes:,} bytes (80% of 1 GiB) |")
+    if profile.warn_bytes is not None:
+        lines.append(f"| warn ≥ | {profile.warn_bytes:,} bytes (70% of 1 GiB) |")
+    if profile.max_files is not None:
+        lines.append(f"| file-count cap | {profile.max_files:,} |")
+    if profile.wrangler_major_note:
+        lines.append(f"| wrangler note | {profile.wrangler_major_note} |")
+
+    lines.extend(["", "### Route families", "", "| Family | Files | Bytes |", "| --- | ---: | ---: |"])
+    for name in ("etymology", "lexicon", "base"):
+        fam = report.families.get(name)
+        if fam is None:
+            lines.append(f"| {name} | 0 | 0 |")
+            continue
+        lines.append(f"| {name} | {fam.files:,} | {fam.bytes:,} ({format_bytes(fam.bytes)}) |")
+
+    lines.extend(["", "### Largest files", ""])
+    for size, rel in report.largest_files:
+        lines.append(f"- `{rel}` — {size:,} ({format_bytes(size)})")
+
+    if report.warnings:
+        lines.extend(["", "### Warnings"])
+        for warning in report.warnings:
+            lines.append(f"- {warning}")
+    if report.failures:
+        lines.extend(["", "### Failures"])
+        for failure in report.failures:
+            lines.append(f"- {failure}")
+    else:
+        lines.extend(["", "**Result:** PASS"])
+
+    return "\n".join(lines) + "\n"
+
+
+def check_site_size(
+    dist: Path,
+    profile_name: str | None,
+    *,
+    largest_n: int = 15,
+) -> tuple[SiteSizeReport, DeployProfile]:
+    """Scan ``dist`` and apply the named profile thresholds."""
+    profile = resolve_profile(profile_name)
+    report = scan_dist(dist, largest_n=largest_n)
+    apply_profile(report, profile)
+    return report, profile
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "dist",
+        type=Path,
+        nargs="?",
+        default=Path("site/dist"),
+        help="Path to the built site dist directory (default: site/dist)",
+    )
+    parser.add_argument(
+        "--profile",
+        default=os.environ.get("DEPLOY_PROFILE"),
+        help="Deploy profile name (default: $DEPLOY_PROFILE)",
+    )
+    parser.add_argument(
+        "--largest",
+        type=int,
+        default=15,
+        help="How many largest files to list (default: 15)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report, profile = check_site_size(args.dist, args.profile, largest_n=args.largest)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    text = format_report(report, profile)
+    sys.stdout.write(text)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(text)
+
+    for warning in report.warnings:
+        print(f"::warning title=Pages budget::{warning}")
+    for failure in report.failures:
+        print(f"::error title=Pages budget::{failure}")
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/etymology-lemma-index.mjs
+++ b/site/src/data/etymology-lemma-index.mjs
@@ -34,7 +34,9 @@ export function buildLemmaRoutes(manifest) {
 
     const group = slugGroups[entry.slug] ?? [];
     routes.set(key, {
-      href: `/etymology/${entry.slug}/`,
+      // Per-word /etymology/<slug>/ pages are offline in normal deploys
+      // (#5274 — Pages budget). Deep-link the lexicon article anchor instead.
+      href: `/lexicon/${entry.lemma}/#etymology`,
       lemma: entry.lemma,
       slug: entry.slug,
       polysemy: group.length > 1,

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -818,7 +818,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
       )}
 
       {enrichment?.etymology && (
-        <section class="atlas-section">
+        <section class="atlas-section" id="etymology">
           <h2>Етимологія</h2>
           <div class="ety-timeline">
             {etymologyStages.map((stage, index) => (

--- a/site/tests/unit/vocab-etymology-link.test.ts
+++ b/site/tests/unit/vocab-etymology-link.test.ts
@@ -11,12 +11,12 @@ import vocabEtymologyLinker from '../../plugins/vocab-etymology-link.mjs';
 
 const resolver = createEtymologyResolver({
   lemmaRoutes: new Map([
-    ['кава', { href: '/etymology/kava/', lemma: 'кава', slug: 'kava', polysemy: false }],
-    ['субота', { href: '/etymology/subota/', lemma: 'субота', slug: 'subota', polysemy: false }],
+    ['кава', { href: '/lexicon/кава/#etymology', lemma: 'кава', slug: 'kava', polysemy: false }],
+    ['субота', { href: '/lexicon/субота/#etymology', lemma: 'субота', slug: 'subota', polysemy: false }],
     [
       'прокидатися',
       {
-        href: '/etymology/prokydatysia/',
+        href: '/lexicon/прокидатися/#etymology',
         lemma: 'прокидатися',
         slug: 'prokydatysia',
         polysemy: false,
@@ -45,9 +45,9 @@ describe('vocab etymology linker', () => {
   });
 
   it('resolves direct, declined, and reflexive VESUM forms', () => {
-    expect(resolveVocabWord('кава', resolver)?.href).toBe('/etymology/kava/');
-    expect(resolveVocabWord('суботу', resolver)?.href).toBe('/etymology/subota/');
-    expect(resolveVocabWord('прокидаюся', resolver)?.href).toBe('/etymology/prokydatysia/');
+    expect(resolveVocabWord('кава', resolver)?.href).toBe('/lexicon/кава/#etymology');
+    expect(resolveVocabWord('суботу', resolver)?.href).toBe('/lexicon/субота/#etymology');
+    expect(resolveVocabWord('прокидаюся', resolver)?.href).toBe('/lexicon/прокидатися/#etymology');
   });
 
   it('links matched words in vocabulary tables and leaves misses plain', async () => {
@@ -62,11 +62,12 @@ describe('vocab etymology linker', () => {
 </TabItem>
 `);
 
-    expect(compiled).toContain('href="/etymology/kava/"');
+    expect(compiled).toContain('href="/lexicon/%D0%BA%D0%B0%D0%B2%D0%B0/#etymology"');
     expect(compiled).toContain('className="vocab-etymology-link"');
     expect(compiled).toContain('data-etymology-slug="kava"');
     expect(compiled).toContain('{"невідоме"}');
     expect(compiled).not.toContain('/etymology/nevidome/');
+    expect(compiled).not.toContain('/etymology/kava/');
   });
 
   it('does not link multi-word phrases or non-vocabulary tabs', async () => {
@@ -87,7 +88,7 @@ describe('vocab etymology linker', () => {
 </TabItem>
 `);
 
-    expect(compiled).not.toContain('href="/etymology/kava/"');
+    expect(compiled).not.toContain('href="/lexicon/%D0%BA%D0%B0%D0%B2%D0%B0/#etymology"');
   });
 
   it('supports Ukrainian vocabulary tabs and table opt-out comments', async () => {
@@ -106,8 +107,8 @@ describe('vocab etymology linker', () => {
 </TabItem>
 `);
 
-    expect(compiled).not.toContain('href="/etymology/kava/"');
-    expect(compiled).toContain('href="/etymology/subota/"');
+    expect(compiled).not.toContain('href="/lexicon/%D0%BA%D0%B0%D0%B2%D0%B0/#etymology"');
+    expect(compiled).toContain('href="/lexicon/%D1%81%D1%83%D0%B1%D0%BE%D1%82%D0%B0/#etymology"');
   });
 
   it('is idempotent when the plugin runs twice', async () => {
@@ -128,6 +129,6 @@ describe('vocab etymology linker', () => {
       ],
     });
 
-    expect(String(compiled).match(/href="\/etymology\/kava\/"/g)).toHaveLength(1);
+    expect(String(compiled).match(/href="\/lexicon\/%D0%BA%D0%B0%D0%B2%D0%B0\/#etymology"/g)).toHaveLength(1);
   });
 });

--- a/tests/test_check_site_size.py
+++ b/tests/test_check_site_size.py
@@ -1,0 +1,139 @@
+"""Unit tests for the fail-closed deploy size gate (#5274)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.deploy.check_site_size import (
+    GITHUB_PAGES_FAIL_BYTES,
+    GITHUB_PAGES_HARD_CAP_BYTES,
+    GITHUB_PAGES_WARN_BYTES,
+    SiteSizeReport,
+    apply_profile,
+    check_site_size,
+    main,
+    resolve_profile,
+    scan_dist,
+)
+
+
+def _write_file(path: Path, size: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+
+
+def _empty_report(**overrides: object) -> SiteSizeReport:
+    base = SiteSizeReport(
+        total_bytes=0,
+        file_count=0,
+        largest_files=[],
+        families={},
+        lexicon_page_count=0,
+        lexicon_page_bytes=0,
+        projected_bytes_at_target=None,
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def test_resolve_profile_fail_closed_on_missing_or_unknown() -> None:
+    with pytest.raises(ValueError, match="fail closed"):
+        resolve_profile(None)
+    with pytest.raises(ValueError, match="fail closed"):
+        resolve_profile("")
+    with pytest.raises(ValueError, match="fail closed"):
+        resolve_profile("not-a-real-profile")
+
+
+def test_github_pages_pass_under_70_percent() -> None:
+    report = _empty_report(total_bytes=GITHUB_PAGES_WARN_BYTES - 1, file_count=1)
+    apply_profile(report, resolve_profile("github-pages"))
+    assert report.ok is True
+    assert report.warnings == []
+    assert report.failures == []
+
+
+def test_github_pages_warn_between_70_and_80_percent() -> None:
+    size = (GITHUB_PAGES_WARN_BYTES + GITHUB_PAGES_FAIL_BYTES) // 2
+    report = _empty_report(total_bytes=size, file_count=1)
+    apply_profile(report, resolve_profile("github-pages"))
+    assert report.ok is True
+    assert any("warn" in w for w in report.warnings)
+    assert report.failures == []
+
+
+def test_github_pages_fail_at_or_above_80_percent() -> None:
+    report = _empty_report(total_bytes=GITHUB_PAGES_FAIL_BYTES, file_count=1)
+    apply_profile(report, resolve_profile("github-pages"))
+    assert report.ok is False
+    assert any("fail" in f for f in report.failures)
+
+
+def test_github_pages_hard_cap_fails() -> None:
+    # Above fail% would already fail; pin just under fail% but at hard cap
+    # is impossible (hard cap 900M > fail 80%≈859M). Assert hard-cap message
+    # when total crosses the absolute ceiling.
+    report = _empty_report(total_bytes=GITHUB_PAGES_HARD_CAP_BYTES, file_count=1)
+    apply_profile(report, resolve_profile("github-pages"))
+    assert report.ok is False
+    assert any("hard cap" in f for f in report.failures)
+
+
+def test_unknown_profile_main_exits_nonzero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dist = tmp_path / "dist"
+    _write_file(dist / "index.html", 32)
+    monkeypatch.delenv("DEPLOY_PROFILE", raising=False)
+    assert main([str(dist), "--profile", "nope"]) == 1
+    assert main([str(dist)]) == 1  # missing profile also fails closed
+
+
+def test_cloudflare_file_count_caps() -> None:
+    free = _empty_report(total_bytes=100, file_count=3)
+    apply_profile(free, resolve_profile("cloudflare-free"))
+    assert free.ok is True
+
+    free_hit = _empty_report(total_bytes=100, file_count=20_000)
+    apply_profile(free_hit, resolve_profile("cloudflare-free"))
+    assert free_hit.ok is False
+    assert any("file count" in f for f in free_hit.failures)
+
+    paid_ok = _empty_report(total_bytes=100, file_count=20_000)
+    apply_profile(paid_ok, resolve_profile("cloudflare-paid"))
+    assert paid_ok.ok is True
+
+    paid_hit = _empty_report(total_bytes=100, file_count=100_000)
+    apply_profile(paid_hit, resolve_profile("cloudflare-paid"))
+    assert paid_hit.ok is False
+    assert any("file count" in f for f in paid_hit.failures)
+
+
+def test_route_families_and_fixed_base_projection(tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    _write_file(dist / "index.html", 1000)  # base
+    _write_file(dist / "etymology" / "index.html", 2000)
+    _write_file(dist / "lexicon" / "index.html", 500)  # not a word page
+    _write_file(dist / "lexicon" / "кава" / "index.html", 4000)
+    _write_file(dist / "lexicon" / "вода" / "index.html", 6000)
+
+    report = scan_dist(dist)
+    assert report.families["base"].bytes == 1000
+    assert report.families["etymology"].bytes == 2000
+    assert report.families["lexicon"].bytes == 500 + 4000 + 6000
+    assert report.lexicon_page_count == 2
+    assert report.lexicon_page_bytes == 10_000
+    # base = total - lexicon word pages = 13500 - 10000 = 3500
+    # slope = 5000; projected @20k = 3500 + 20000*5000
+    assert report.total_bytes == 13_500
+    assert report.projected_bytes_at_target == 3500 + 20_000 * 5_000
+
+
+def test_check_site_size_end_to_end_pass(tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    _write_file(dist / "index.html", 128)
+    report, profile = check_site_size(dist, "github-pages")
+    assert profile.name == "github-pages"
+    assert report.ok is True
+    assert report.file_count == 1

--- a/tests/test_deploy_pages_workflow.py
+++ b/tests/test_deploy_pages_workflow.py
@@ -10,7 +10,7 @@ REQUIREMENTS_LOCK = REPO_ROOT / "requirements-lock.txt"
 
 
 def test_pages_build_installs_atlas_python_dependencies() -> None:
-    """The deploy venv must satisfy imports used by ``npm run build:full``."""
+    """The deploy venv must satisfy imports used by ``npm run build``."""
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     steps = workflow["jobs"]["deploy"]["steps"]
     create_venv = next(step for step in steps if step.get("name") == "Create Python venv")
@@ -23,3 +23,22 @@ def test_pages_build_installs_atlas_python_dependencies() -> None:
 
     assert f".venv/bin/python -m pip install {locked_pyyaml}" in create_venv["run"]
     assert steps.index(create_venv) < steps.index(build_site)
+
+
+def test_pages_deploy_uses_normal_build_and_fail_closed_size_gate() -> None:
+    """#5274: deploy must not run build:full; size gate before artifact upload."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["deploy"]["steps"]
+    by_name = {step.get("name"): step for step in steps}
+
+    build_site = by_name["Build Site"]
+    assert "npm run build" in build_site["run"]
+    assert "build:full" not in build_site["run"]
+
+    size_gate = by_name["Check published-site size (fail-closed)"]
+    assert size_gate["env"]["DEPLOY_PROFILE"] == "github-pages"
+    assert "scripts/deploy/check_site_size.py" in size_gate["run"]
+
+    upload = by_name["Upload artifact"]
+    assert steps.index(size_gate) < steps.index(upload)
+    assert steps.index(build_site) < steps.index(size_gate)


### PR DESCRIPTION
## Summary
- Switch GitHub Pages deploy from `npm run build:full` to `npm run build` so ~25k standalone `/etymology/<slug>/` pages are not prerendered (keeps `/etymology/` gateway + 4 featured demos).
- Repoint vocab etymology deep-links to `/lexicon/<lemma>/#etymology` and add `id="etymology"` on the lexicon article etymology section.
- Replace the advisory 70% size warn with a fail-closed `scripts/deploy/check_site_size.py` gate (`DEPLOY_PROFILE=github-pages`: warn @70% of 1 GiB, FAIL @≥80% / hard cap 900MB; Cloudflare file-count profiles supported for future targets).

Fixes #5274. Unblocks #5230 deploy space.

## Test plan
- [x] `.venv/bin/ruff check` on changed Python
- [x] `.venv/bin/pytest tests/test_check_site_size.py tests/test_deploy_pages_workflow.py`
- [x] `cd site && npm run test` (640 tests)
- [x] Local `npm run build` → 299M / 9197 files; size gate PASS
- [ ] CI Frontend (build + vitest) green
- [ ] Orchestrator cross-family review (do **not** auto-merge from this agent)

## #M-4 evidence

### dist size after `build:full` → `build`
```
$ du -sh site/dist && find site/dist -type f | wc -l
299M	site/dist
    9197
```

### etymology still on a word page
```
$ grep -c "Походження" site/dist/lexicon/кава/index.html
2
$ grep -c 'id="etymology"' site/dist/lexicon/кава/index.html
1
```

### no stray per-word etymology links under lexicon
```
$ grep -rlE '/etymology/[^/" ]+/' site/dist/lexicon | head
(none)
```

### size gate thresholds (synthetic)
```
=== PASS under 70% (bytes=751,619,275) ok=True ===
budget used | **70.0%** of 1 GiB
**Result:** PASS
exit would be 0

=== WARN 70-80% (bytes=805,306,367) ok=True ===
### Warnings
- github-pages: site is 75.0% of 1 GiB (805,306,367 bytes ≥ warn 751,619,276)
**Result:** PASS
exit would be 0

=== FAIL >=80% (bytes=858,993,459) ok=False ===
### Failures
- github-pages: size 858,993,459 bytes is 80.0% of 1 GiB (≥ fail 858,993,459)
exit would be 1

$ .venv/bin/python scripts/deploy/check_site_size.py /tmp/5274-size-demo/dist --profile nope
ERROR: Unknown DEPLOY_PROFILE 'nope' — fail closed. Known profiles: cloudflare-free, cloudflare-paid, github-pages
unknown exit=1
```

### size gate on real local dist
```
$ DEPLOY_PROFILE=github-pages .venv/bin/python scripts/deploy/check_site_size.py site/dist
| total bytes | **291,461,134** (278.0 MiB) |
| file count | **9,197** |
| budget used | **27.1%** of 1 GiB |
| projected @ 20,000 lexicon pages (fixed-base + slope) | ~545.9 MiB (53.3% of 1 GiB) |
| etymology | 5 files | 86,180 |
| lexicon | 8,691 | 230,845,505 |
| base | 501 | 60,529,449 |
**Result:** PASS
```

Note: hrefs use Cyrillic lexicon `url_slug`/`lemma` (e.g. `/lexicon/кава/#etymology`), not latin ESUM slugs — live Atlas routes are Cyrillic.


Made with [Cursor](https://cursor.com)