### PR TITLE
fix: recover preparation drift from QG arming

### DIFF
--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -995,6 +995,7 @@ def request_preparation_rebuild(
                 "INTEGRATION_REQUIRED",
                 "PBR_PASS_QG_PENDING",
                 "PRODUCTION_QG_REQUIRED",
+                "AWAITING_PRODUCTION_QG_ARMING",
             }
             if ledger["state"] not in allowed_states:
                 raise CompletionError(
@@ -1030,6 +1031,8 @@ def request_preparation_rebuild(
                 },
             )
             ledger["routing"] = None
+            ledger["publication"] = None
+            ledger["production_qg_authorization"] = None
             _validate(ledger, LEDGER_SCHEMA_PATH, "track-completion ledger")
             _atomic_write_json(path, ledger)
             return path, ledger

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -633,6 +633,61 @@ def test_preparation_rebuild_routing_rejects_incomplete_inputs_and_learner_drift
         )
 
 
+def test_preparation_rebuild_from_awaiting_production_qg_arming_clears_stale_fields(
+    fake_repo: tuple[Path, Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, config_path, ledger_root = fake_repo
+    path, core_ledger = _start(fake_repo, "a1/core-built")
+    run_id = core_ledger["run"]["run_id"]
+    assert core_ledger["state"] == "POST_BUILD_REVIEW_REQUIRED"
+    snapshot = tc.resolve_target("a1/core-built", repo_root=repo, config=tc.load_config(config_path))
+    post_build = _result(snapshot, repo, status="PASS")
+    post_build_path = _result_file(tmp_path, "post-build-pass.json")
+    monkeypatch.setattr(tc, "_load_post_build_result", lambda _path: post_build)
+    _, core_ledger = tc.record_review(
+        "a1/core-built",
+        run_id=run_id,
+        result_path=post_build_path,
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+    assert core_ledger["state"] == "AWAITING_PRODUCTION_QG_ARMING"
+
+    core_ledger["routing"] = {"owners": ["built_artifact"], "findings": []}
+    core_ledger["publication"] = {
+        "pr": 5255,
+        "merge_sha": "a" * 40,
+        "recorded_at": "2026-07-15T00:00:00Z",
+    }
+    core_ledger["production_qg_authorization"] = {
+        "qualification_path": "qualification.json",
+        "qualification_sha256": "b" * 64,
+        "human_arming_path": "human-arming.json",
+        "human_arming_sha256": "c" * 64,
+        "approval_id": "deploy-approval-5255",
+        "route": {"family": "gemini", "model": "fixture", "effort": "high"},
+    }
+    tc._atomic_write_json(path, core_ledger)
+
+    profiles = repo / "agents_extensions/shared/prompt-contracts/profiles/curriculum-lifecycle.v1.yaml"
+    profiles.write_text(profiles.read_text(encoding="utf-8") + "# preparation drift\n", encoding="utf-8")
+
+    _, rebuilt = tc.request_preparation_rebuild(
+        "a1/core-built",
+        run_id=run_id,
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+    assert rebuilt["state"] == "BUILD_REQUIRED"
+    rebuild_event = rebuilt["history"][-1]
+    assert rebuild_event["event"] == "PREPARATION_REBUILD_REQUIRED"
+    assert rebuilt["routing"] is None
+    assert rebuilt["publication"] is None
+    assert rebuilt["production_qg_authorization"] is None
+
+
 def test_review_rejects_unrecorded_drift_and_routes_plan_findings(
     fake_repo: tuple[Path, Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- allow canonical preparation rebuild recovery from `AWAITING_PRODUCTION_QG_ARMING`
- clear stale publication and production-QG authorization before routing to `BUILD_REQUIRED`
- cover the recovery path and fail-closed invariants with a regression test

## Verification

- `.venv/bin/python -m pytest -q tests/test_track_completion.py` — 16 passed
- `.venv/bin/ruff check agents_extensions/shared/skills/track-completion/scripts/track_completion.py tests/test_track_completion.py` — passed
- `git diff --check` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

## Independent review

AGY / Gemini 3.1 Pro (High) reviewed commit `aa65784064bbc6a0f8b4191119bd307e3524336c` and returned PASS with no findings. It confirmed the state allowlist, clearing of `routing`, `publication`, and `production_qg_authorization`, fail-closed learner-drift behavior, and regression coverage.

Fixes #5279