### PR TITLE
feat(review): canonical closeout review scope for local-code-review

### DIFF
--- a/agents_extensions/shared/skills/local-code-review/SKILL.md
+++ b/agents_extensions/shared/skills/local-code-review/SKILL.md
@@ -1,25 +1,58 @@
 ---
 name: local-code-review
-description: Working-tree (uncommitted diff) code review with cross-model adversarial pass — Gemini reviews, Codex challenges false positives, surviving findings get applied. Use BEFORE commit. For PR-level review, use the official `/code-review:code-review` plugin instead.
-argument-hint: "[files|diff|all]"
+description: Canonical closeout-review workflow — freezes scope, resolves the exact review target (local/commit/branch/PR), runs a non-mutating review, resolves a cross-family reviewer, and requires separate behavior proof for user-visible changes. Use before declaring any change done.
+argument-hint: "[local | commit <sha> | branch <branch> <base> | pr <number>]"
 ---
 
-# Local Code Review: $ARGUMENTS
+# Closeout Review: $ARGUMENTS
 
-> **Scope**: working-tree only — uncommitted edits in your active session. For pull-request review use the official `/code-review:code-review` plugin command (it fans out 5 parallel Sonnet agents + Haiku confidence-scoring and posts back via `gh pr comment`).
+> **Scope**: this is the closeout gate for a change you (or another agent)
+> already made — not a PR-comment bot. For posting inline PR comments, use
+> the official `/code-review:code-review` plugin instead; this skill can
+> still drive the target-selection and scope-freeze steps underneath it.
 
-## Parse Arguments
+This skill defines **orchestration and policy** for closeout review. It does
+not implement the strict finding verifier or reviewer process isolation —
+those are separate, later slices (issue #5281 children 2 and 3). What it
+does guarantee:
 
-The user provides one of:
+- the review target is explicit and deterministic — never inferred from
+  whatever the working tree happens to look like;
+- scope is frozen once, before the first review pass, and visibly
+  re-checked as the review/fix loop runs;
+- review preparation never mutates the source tree;
+- the reviewer is a different model **family** from the author, resolved
+  by a single canonical helper — not re-derived per skill invocation;
+- every finding is adjudicated explicitly — nothing is silently dropped,
+  and nothing is applied "as-is" without an adjudication;
+- CLI/API/UI/generated-artifact changes require a separate, source-blind
+  behavior proof — code review alone cannot close them out.
 
-1. **No args or "diff"**: Review only files changed since last commit (`git diff --name-only` + `git diff --cached --name-only`)
-2. **"all"**: Review all staged + unstaged changes
-3. **Specific files**: `scripts/build/v7_build.py scripts/build/linear_pipeline.py`
+## Parse arguments
+
+`$ARGUMENTS` selects the review target **mode**, explicitly — never inferred
+from `git status`:
+
+1. `local` — staged + unstaged + untracked changes in the working tree.
+2. `commit <sha>` — one already-made commit, diffed against its parent.
+3. `branch <branch> <base>` — a branch diffed against an explicit base ref.
+4. `pr <number>` — a PR diffed against its **actual** base (not an assumed
+   default branch).
+
+If the user gives you a PR number, a commit SHA, or says "review my branch,"
+that is the mode — do not fall back to `local` because the working tree
+looks clean. A clean working tree is not evidence that a commit or PR was
+reviewed (see Step 1 below).
 
 ## Execute
 
-Read and follow the full local code review checklist at [`local-code-review-checklist.md`](local-code-review-checklist.md).
+Read and follow [`local-code-review-checklist.md`](local-code-review-checklist.md)
+in full. It drives `.venv/bin/python -m scripts.review.closeout_cli` for every
+step that has a deterministic answer (target resolution, scope-baseline
+freeze and breakers, reviewer resolution, findings adjudication) and tells
+you exactly what to reason about yourself.
 
 ## Output
 
-Print a structured report to the conversation. Do NOT write a file unless specifically asked.
+Print a structured report to the conversation (the checklist's Step 8 gives
+the exact shape). Do NOT write a file unless specifically asked.

--- a/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
+++ b/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
@@ -31,7 +31,8 @@ Every subcommand is `.venv/bin/python -m scripts.review.closeout_cli --state-fil
 .venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
   target --mode branch --branch <branch> --base <base-ref> --repo-root .
 
-# pr: actual PR base (never an assumed default branch)
+# pr: actual PR base (never an assumed default branch), merge-base semantics —
+# diffs against the fork point, not the base branch's possibly-since-moved tip
 .venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
   target --mode pr --pr <number> --repo-root .
 ```
@@ -115,6 +116,27 @@ order alone decides) but **fail-closed on domain/data-egress**: leaving
 specific egress policy (e.g. a China-hosted lane), it does not admit them
 by default.
 
+**Multi-model harnesses (e.g. Cursor) are fail-closed, not a synthetic
+family.** A harness that can run more than one underlying model (Cursor)
+is never itself a model family — `--author-model cursor` alone resolves
+to nothing selectable. Disambiguate it one of two ways:
+
+```bash
+# Composite form: "<harness>:<concrete-model>"
+--author-model "cursor:gpt-5.6-sol"
+--author-model "cursor:claude-opus-4-8"
+
+# Or an explicit, validated author-family override (e.g. from session logs)
+--author-model "cursor" --author-family "anthropic"
+```
+
+An unrecognized `--author-model`, a bare ambiguous harness with no
+disambiguation, or an `--author-family` that disagrees with the model
+embedded in `--author-model` all resolve to `selected: null` with a
+non-null `fail_closed_reason` — **do not treat a null `selected` as "no
+reviewer needed"**; it means the author's identity could not be resolved
+and you must supply better input before proceeding.
+
 Read the `selected` field for the formal, blocking reviewer. Read `advisory`
 for consult-only candidates — most notably `openai_frontier`: it always
 resolves to a concrete model (currently `gpt-5.6-sol`), and it is
@@ -185,10 +207,26 @@ implementation action — the ledger only records that it happened.
 ## Step 6: Re-check scope after any fix
 
 After applying findings, re-check the breakers before calling the review
-done:
+done. For `mode=local` the working tree alone is the signal:
 
 ```bash
 .venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" check-expansion --repo-root .
+```
+
+For `mode=commit`/`branch`/`pr`, fixes land as **commits**, not working-tree
+changes — a clean tree after committing a fix proves nothing. Pass the
+reviewed head explicitly (typically `HEAD` right after committing the fix)
+so the breaker re-diffs the frozen `base_sha` against the real post-fix
+state instead of silently seeing "nothing changed":
+
+```bash
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
+  check-expansion --repo-root . --current-head HEAD
+```
+
+Then record the cycle:
+
+```bash
 .venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" record-cycle --outstanding-count <N>
 ```
 
@@ -219,13 +257,35 @@ Distinguish three layers explicitly in your report:
    would, with no reference to the diff.
 
 **CLI/API/UI/generated-artifact changes cannot be declared done from code
-review alone.** If the frozen target touches any user-visible surface
-(a CLI flag, an HTTP endpoint, UI, or a generated artifact like deployed
-skill mirrors or built docs), run the project's `verify` skill (or drive it
-manually) and record what you actually observed — not what the diff implies
-should happen. If nothing in the frozen target has a runtime surface (pure
-test/doc-only changes), say so explicitly instead of running a proof that
-has nothing to exercise.
+review alone.** If the frozen target touches any user-visible surface (a CLI
+flag, an HTTP endpoint, UI, or a generated artifact like deployed skill
+mirrors or built docs), drive it exactly as a source-blind user would and
+record what you actually observed — not what the diff implies should
+happen. There is no repo-wide "verify" skill or tool that does this for
+you generically; do not invoke or reference one that doesn't exist. Use
+whatever real, product-specific surface applies:
+
+- **Python CLI** (e.g. this closeout CLI itself): invoke the actual
+  entry point from a shell with real arguments —
+  `.venv/bin/python -m <module> <args>` — and read its stdout/stderr/exit
+  code, not the source.
+- **HTTP endpoint / Monitor API**: `curl` the real route and inspect the
+  response body/status code.
+- **Browser-facing UI**: drive it with `mcp__claude-in-chrome__*` (or the
+  `/run` skill, which launches this project's app) and observe the
+  rendered page, not the component source.
+- **Generated artifact** (deployed skill mirrors, built docs, MDX output):
+  run the actual generator/deploy script (e.g. `scripts/deploy_prompts.sh`,
+  `scripts/lint/lint_agent_skills.py`, the relevant build script) and read
+  its output/exit code.
+- **No dedicated tooling exists for this specific surface**: say so
+  explicitly, then describe the exact manual steps you took (commands run,
+  inputs given, outputs observed) so the proof is reproducible from the
+  report alone.
+
+If nothing in the frozen target has a runtime surface (pure test/doc-only
+changes), say so explicitly instead of running a proof that has nothing to
+exercise.
 
 ---
 

--- a/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
+++ b/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
@@ -271,9 +271,11 @@ whatever real, product-specific surface applies:
   code, not the source.
 - **HTTP endpoint / Monitor API**: `curl` the real route and inspect the
   response body/status code.
-- **Browser-facing UI**: drive it with `mcp__claude-in-chrome__*` (or the
-  `/run` skill, which launches this project's app) and observe the
-  rendered page, not the component source.
+- **Browser-facing UI**: use a browser-control capability that is actually
+  available in the current harness, or the repository's existing UI/E2E
+  command for that surface, and observe the rendered page. If neither is
+  available, document reproducible manual steps instead of naming a tool or
+  skill that the current environment does not provide.
 - **Generated artifact** (deployed skill mirrors, built docs, MDX output):
   run the actual generator/deploy script (e.g. `scripts/deploy_prompts.sh`,
   `scripts/lint/lint_agent_skills.py`, the relevant build script) and read

--- a/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
+++ b/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
@@ -71,6 +71,14 @@ workflow YAML, config, schemas, and documentation are changed paths just
 as much as `.py`/`.ts` files, and none of them are silently excluded from
 scope or from review in the steps below.
 
+**Both `target` and `freeze` are one-shot per state file.** Once a baseline
+is frozen, `target` refuses to re-resolve (it would silently swap out what
+the frozen baseline claims to describe) and `freeze` refuses a second call
+(it would silently reset the cycle history). Both fail closed with a
+non-zero exit and leave the state file untouched. Starting a genuinely new
+review — a different target, a redone freeze — means picking a new
+`$STATE_FILE`, not reusing one whose baseline is already frozen.
+
 ---
 
 ## Step 3: Deterministic / static checks (non-mutating)

--- a/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
+++ b/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
@@ -1,192 +1,260 @@
-# Local Code Review Checklist
+# Closeout Review Checklist
 
-> **Scope**: working-tree only — uncommitted edits in your active session. For pull-request review use the official `/code-review:code-review` plugin command instead.
+> **Scope**: the closeout gate for a change already made — freezes scope,
+> resolves the exact target, runs a non-mutating review, resolves a
+> cross-family reviewer, and requires separate behavior proof for
+> user-visible changes. For PR-comment posting, use `/code-review:code-review`.
 
-Run every check in order. Report findings at the end. Fix anything fixable before reporting.
+All state for one review lives in a single JSON file so every step below
+can be a separate CLI call. Pick a path once per review and reuse it:
+
+```
+STATE_FILE=.agent/review-closeout/<short-slug>.json
+```
+
+Every subcommand is `.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" ...`.
 
 ---
 
-## Step 1: Identify changed files
-
-```
-git diff --name-only HEAD
-git diff --cached --name-only
-git status --short
-```
-
-If the user specified files, use those instead. Filter to `.py`, `.ts`, `.tsx`, `.js` files only.
-
----
-
-## Step 2: Ruff lint (Python files only)
-
-Run ruff on every changed `.py` file:
+## Step 1: Resolve the target — explicit mode, never inferred
 
 ```bash
-.venv/bin/ruff check --fix {files}
+# local: staged + unstaged + untracked, diffed against HEAD
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
+  target --mode local --repo-root .
+
+# commit: one already-made commit vs its parent
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
+  target --mode commit --commit <sha> --repo-root .
+
+# branch: explicit base, merge-base semantics
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
+  target --mode branch --branch <branch> --base <base-ref> --repo-root .
+
+# pr: actual PR base (never an assumed default branch)
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
+  target --mode pr --pr <number> --repo-root .
 ```
 
-If ruff finds unfixable issues, report them. If `--fix` resolves them, note what was fixed.
+**A clean local working tree is not proof that a commit or PR was
+reviewed.** `mode=local` on a clean tree returns `clean_tree: true` with
+`base_sha`/`head_sha` both `null` — those `null`s are the structural guard:
+a report built from that target cannot claim it verified a specific commit
+or PR, because there is no SHA to point at. If the user asked you to review
+a commit or a PR, resolve that mode explicitly — do not read "nothing
+uncommitted right now" as "already reviewed."
+
+This step never pushes. `pr` mode may `git fetch` the two SHAs it needs
+(read-only) if they aren't already reachable locally — fetching to obtain a
+target is fine; pushing a branch just so a diff exists is not, and this CLI
+never does it.
 
 ---
 
-## Step 3: Project-specific checks
-
-For each changed Python file, check for:
-
-### 3a. Model constants
-
-- Any hardcoded model strings (`"claude-opus-4-6"`, `"claude-sonnet-4-6"`, `"gemini-3.1-pro-preview"`, `"gemini-3-flash-preview"`)?
-- Should they come from `batch_gemini_config.py` instead?
-
-### 3b. Import hygiene
-
-- Any `import re` or `import json` inside a function when already imported at module level?
-- Any unused imports?
-
-### 3c. SQLite connection management
-
-- Any `sqlite3.connect()` calls that open a new connection per invocation instead of reusing?
-- Any connections not closed in a `finally` block or context manager?
-
-### 3d. Silent failures
-
-- Any bare `except: pass` or `except Exception: pass` that swallows errors?
-- Any functions that return `None` on failure without logging?
-
-### 3e. Dead code
-
-- Any functions defined but never called? (Check with grep for the function name across the codebase)
-- Any unreachable branches (code after `return`)?
-
-### 3f. Type hints
-
-- Do new/changed functions have return type annotations?
-- Do function parameters have type annotations?
-
-### 3g. Test coverage
-
-- Does every new/changed function have a corresponding test?
-- If not, flag which functions need tests.
-
----
-
-## Step 4: Simplify pass
-
-For each changed file, check for:
-- Duplicated logic that could be extracted to a shared function
-- Overly complex conditions that could be simplified
-- Functions longer than 50 lines that should be split
-- Magic numbers that should be named constants
-
----
-
-## Step 5: Cross-agent review (when available)
-
-If Gemini is available, send the diff for adversarial review:
+## Step 2: Freeze the scope baseline — before the first review pass
 
 ```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini \
-  "Code review this diff. Find bugs, logic errors, missed edge cases, and style issues." \
-  --task-id code-review --model gemini-3.1-pro-preview
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" freeze \
+  --issue "<issue/request reference>" \
+  --intended-behavior "<what this change is supposed to do>" \
+  --non-goals "<what it explicitly does not do>" \
+  --owner-boundary "<the paths/surfaces this change owns>" \
+  --review-profile "<code|infra|content|...>" \
+  --risk "<low|medium|high>"
 ```
 
-**If Gemini is unavailable (currently down)**: Skip this step. Note "Gemini review skipped (service unavailable)" in the report.
+This prints the frozen baseline block — display it verbatim before
+starting review. It captures the target's **every** changed path and
+non-test LOC count, with no file-extension allowlist: shell scripts,
+workflow YAML, config, schemas, and documentation are changed paths just
+as much as `.py`/`.ts` files, and none of them are silently excluded from
+scope or from review in the steps below.
 
 ---
 
-## Step 5b: Challenge round (anti-false-positive)
+## Step 3: Deterministic / static checks (non-mutating)
 
-Reviewer findings include false positives — the writer's choice was correct and the reviewer pattern-matched on a surface signal. Auto-applying every finding produces churn and sometimes regresses the diff.
+Run linters and type checks in **check-only** mode. Review preparation
+must never mutate the source tree:
 
-Send the FINDINGS LIST from Step 5 to a **different** agent (Codex, since Gemini was the reviewer) for an adversarial pass that argues *for* the writer:
+- Python: `.venv/bin/ruff check {files}` — **never `--fix`** during review
+  prep. A fix is a finding like any other; applying it is Step 6's job,
+  done explicitly, by the accountable agent.
+- TypeScript/JS: `npx tsc --noEmit`, `npx eslint {files}` (no `--fix`).
+- Do not run formatters, code generators, migrations, package installs, or
+  any other command that changes files on disk as part of preparing this
+  review. If a deterministic check has an autofix flag, run it in
+  check/report mode only.
+
+Report failures; do not silently correct them here.
+
+---
+
+## Step 4: Resolve the cross-family reviewer
+
+Pull a fresh routing snapshot, then resolve:
 
 ```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-codex - \
-  --task-id code-review-challenge --to-model gpt-5.5 <<'EOF'
-Below is a code diff and a list of issues raised by a reviewer agent.
-Your job: identify which findings are LIKELY FALSE POSITIVES where the
-writer's choice was correct, and which are real bugs. Be skeptical of
-the reviewer. Pattern-match on these false-positive shapes:
+curl -s 'http://localhost:8765/api/state/routing-budget?fresh_codexbar=true' \
+  | .venv/bin/python -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps(d.get("lane_health", d)))' \
+  > /tmp/routing-snapshot.json
 
-- "missing tests" when the function is trivially a thin wrapper or pure config
-- "silent failure" when the bare except is intentional and documented inline
-- "magic number" when the number is a domain constant (HTTP status, port, etc.)
-- "dead code" when grep missed dynamic import / re-export / test fixture
-- "type hints missing" when the function is `__init__` or matches a typing.Protocol
-
-For each finding emit ONE LINE in this exact format:
-
-  KEEP <finding_id>: <one-sentence rationale>
-  DROP <finding_id>: <one-sentence why it's a false positive>
-  EVIDENCE_NEEDED <finding_id>: <what to check before deciding>
-
-Do not invent new findings. Only adjudicate the ones supplied.
-
----DIFF---
-{paste git diff output here}
----FINDINGS---
-{paste numbered finding list from Step 5 here}
-EOF
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" resolve-reviewer \
+  --author-model "<the author's actual model/seat, e.g. claude, codex, deepseek-v4-pro>" \
+  --review-profile "<same profile as Step 2>" \
+  --risk "<same risk as Step 2>" \
+  --domain "<code | folk_content | ... — only set non-default if it applies>" \
+  --data-egress-policy "<omit unless this run is genuinely local-interactive>" \
+  --routing-snapshot-file /tmp/routing-snapshot.json
 ```
 
-**Filter rule for Step 6 application:**
-- `KEEP` findings → apply the fix
-- `DROP` findings → skip silently (do not apply, do not surface to user unless they ask)
-- `EVIDENCE_NEEDED` findings → run the suggested check; if it confirms the bug, apply; if not, drop
+If the Monitor API isn't reachable, omit `--routing-snapshot-file` — the
+resolver is fail-open on health (no signal reads as healthy, so ladder
+order alone decides) but **fail-closed on domain/data-egress**: leaving
+`--data-egress-policy` unset excludes any candidate that requires a
+specific egress policy (e.g. a China-hosted lane), it does not admit them
+by default.
 
-**If Codex is unavailable**: Skip this step. Note "Challenge round skipped (Codex unavailable)" in the report; apply Gemini's findings as-is.
+Read the `selected` field for the formal, blocking reviewer. Read `advisory`
+for consult-only candidates — most notably `openai_frontier`: it always
+resolves to a concrete model (currently `gpt-5.6-sol`), and it is
+**advisory-only** when the author is OpenAI-family. An advisory verdict is
+useful input; it is never a substitute for the formal gate. `trace` shows
+every candidate walked and why it was excluded/selected/advisory — quote
+it in the report so a substitution is never silent.
 
-**Cross-model invariant**: the challenger MUST be a different model family from the reviewer (per `SELF_REVIEW_DETECTED` audit gate intent). If Gemini reviewed, Codex challenges. If Codex reviewed (rare for this skill), DeepSeek-pro challenges.
+Dispatch the actual review to `selected.concrete_model` (or the advisory
+model, clearly labeled as advisory, if `selected` is null). Ask it to find
+bugs, logic errors, missed edge cases, and security/reuse issues in the
+frozen target's diff — nothing outside `frozen_files`.
+
+**Sibling instances**: if the reviewer or you spot the same bug pattern
+elsewhere in the codebase, only widen the *look* to sibling instances of
+that exact bug class within the frozen touched surfaces — not a general
+audit of the owning module, and not files outside `frozen_files` unless a
+sibling instance is actually found there (in which case treat it as a new
+finding subject to the same breakers as everything else, not a freebie).
 
 ---
 
-## Step 6: Run affected tests
+## Step 5: Record and adjudicate findings — nothing dropped, nothing "as-is"
+
+For every finding, raise it, then adjudicate it:
 
 ```bash
-.venv/bin/pytest {relevant_test_files} -v --tb=short
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" finding raise \
+  --id F1 --summary "<one-line summary>" --source "reviewer:<concrete_model>"
+
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" finding adjudicate \
+  --id F1 --disposition "<in_scope_blocker|follow_up|stop_and_escalate>" \
+  --rationale "<why this disposition>"
 ```
 
-Find relevant tests by matching changed file names to test files:
-- `scripts/build/v7_build.py` → `tests/test_v7_writer_dispatch.py`
-- `scripts/audit/core.py` → `tests/test_audit_core.py`
-- etc.
+Disposition guide:
 
-If no matching test file exists, flag it.
+- **`in_scope_blocker`** — a real, verified bug inside the frozen scope
+  that must be fixed before this closes out.
+- **`follow_up`** — real but not blocking (out of frozen scope, or minor);
+  track it, do not fix it here.
+- **`stop_and_escalate`** — fixing it would itself blow a breaker (Step 6):
+  it changes the public/task contract, crosses an owner boundary, needs a
+  canonical design decision, or the fix/review loop already failed to
+  converge. Escalate instead of patching around it.
+
+**If the reviewer/challenger is unavailable**, raise the finding anyway (if
+you have one from your own read) and leave it unadjudicated — do not
+invent a disposition to unblock yourself, and do not apply it "as-is."
+`scripts.review.findings.FindingsLedger.apply` structurally refuses to
+apply anything that wasn't adjudicated to `in_scope_blocker`; there is no
+CLI path around that. Run `finding report` at any point to see every
+finding's full history, including ones still marked `UNADJUDICATED` — they
+must appear in your final report, not vanish from it.
+
+Only apply a fix for a finding once it is adjudicated `in_scope_blocker`:
+
+```bash
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" finding apply --id F1
+```
+
+(or `finding skip --id F1 --rationale "..."` for an explicit, rationale-carrying
+decision not to act on it.) Applying the fix itself is your explicit
+implementation action — the ledger only records that it happened.
 
 ---
 
-## Step 7: Report
+## Step 6: Re-check scope after any fix
 
-Output a structured report:
+After applying findings, re-check the breakers before calling the review
+done:
+
+```bash
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" check-expansion --repo-root .
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" record-cycle --outstanding-count <N>
+```
+
+Stop and reclassify (treat as `stop_and_escalate`, do not keep patching) when:
+
+- `check-expansion` triggers — review-triggered files or non-test LOC
+  exceed 2x the frozen baseline;
+- `record-cycle` triggers — two review-triggered patch cycles in a row
+  failed to shrink the outstanding-finding count;
+- the fix changes the public/task contract or crosses the owner boundary
+  frozen in Step 2;
+- a canonical contract/design decision is required to proceed.
+
+**Only** these justify pushing through a tripped breaker anyway: active
+data loss, a crash, a broken install/upgrade, a release blocker, or a
+concrete security exposure. "It would be nice to fix this too" is never
+one of them.
+
+---
+
+## Step 7: Behavior proof (separate from code review)
+
+Distinguish three layers explicitly in your report:
+
+1. **Deterministic/static checks** — Step 3's linters/type checks.
+2. **Source-aware code review** — Steps 4-5's reviewer verdict.
+3. **Source-blind behavior proof** — actually driving the change as a user
+   would, with no reference to the diff.
+
+**CLI/API/UI/generated-artifact changes cannot be declared done from code
+review alone.** If the frozen target touches any user-visible surface
+(a CLI flag, an HTTP endpoint, UI, or a generated artifact like deployed
+skill mirrors or built docs), run the project's `verify` skill (or drive it
+manually) and record what you actually observed — not what the diff implies
+should happen. If nothing in the frozen target has a runtime surface (pure
+test/doc-only changes), say so explicitly instead of running a proof that
+has nothing to exercise.
+
+---
+
+## Step 8: Report
 
 ```
-## Code Review Report
+## Closeout Review Report
 
-### Files reviewed
-- {file1} ({lines_changed} lines changed)
-- {file2} ...
+### Scope baseline (frozen, Step 2)
+{verbatim baseline block}
 
-### Ruff
-{ruff findings or "Clean"}
+### Deterministic checks (Step 3)
+{ruff/tsc/eslint results — clean or failures, never auto-fixed here}
 
-### Project checks
-{findings per category, or "Clean" per category}
+### Reviewer resolution (Step 4)
+Selected: {concrete_model or "none — see trace"}
+Advisory: {advisory candidates, if any}
+Trace: {full candidate trace, so every exclusion/substitution is visible}
 
-### Simplify
-{suggestions or "No issues"}
+### Findings (Step 5)
+{every finding: id, summary, disposition, rationale, applied/skipped/unadjudicated —
+ from `finding report`, verbatim. Never omit an unadjudicated finding.}
 
-### Cross-agent review
-{Gemini findings or "Skipped (unavailable)"}
+### Scope breakers (Step 6)
+{expansion/cycle breaker results; note any stop_and_escalate and why}
 
-### Challenge round
-{N findings KEPT, M findings DROPPED, K need evidence — or "Skipped (Codex unavailable)"}
-
-### Tests
-{test results or "No matching tests found — NEEDS TESTS: {functions}"}
+### Behavior proof (Step 7)
+{what was exercised end-to-end, or "not applicable — no runtime surface changed"}
 
 ### Summary
-{X issues found: Y critical, Z major, W minor}
-{list of fixes applied}
-{list of issues remaining}
+{final disposition: closed out / stop_and_escalate with reason / blocked on X}
 ```

--- a/scripts/review/__init__.py
+++ b/scripts/review/__init__.py
@@ -1,0 +1,6 @@
+"""Canonical closeout-review orchestration: target selection, scope freeze,
+findings adjudication, and reviewer resolution.
+
+See ``agents_extensions/shared/skills/local-code-review/`` for the skill
+that drives these modules, and issue #5283 for the design this implements.
+"""

--- a/scripts/review/closeout_cli.py
+++ b/scripts/review/closeout_cli.py
@@ -29,8 +29,10 @@ from scripts.review.scope_baseline import (
 from scripts.review.target_resolution import (
     ReviewTarget,
     TargetResolutionError,
+    diff_against_base,
     resolve_local_target,
     resolve_review_target,
+    rev_parse,
 )
 
 
@@ -139,13 +141,63 @@ def _baseline_from_state(state: dict) -> ScopeBaseline:
 
 
 def _cmd_check_expansion(args: argparse.Namespace) -> int:
+    """Re-measure the frozen target's mode against its current state.
+
+    ``local`` mode is re-resolved from the working tree, same as before — it
+    has no committed endpoint by definition. Every other mode (commit/branch/
+    pr) is frozen against a committed base/head, so a clean working tree
+    tells us nothing: review-triggered fixes land as *commits*, not
+    uncommitted changes. Re-resolving those modes means re-diffing the
+    frozen ``base_sha`` against an explicit ``--current-head`` (the reviewed
+    head after fixes) — never re-querying ``gh pr view`` or re-deriving the
+    mode from ``git status``, since either could silently drift from the
+    mode the baseline was actually frozen under.
+    """
     state = _load_state(args.state_file)
     if not state.get("baseline"):
         print(json.dumps({"error": "no frozen baseline yet — run `freeze` first"}), file=sys.stderr)
         return 1
     baseline = _baseline_from_state(state)
-    current = resolve_local_target(Path(args.repo_root).resolve())
-    result = check_expansion_breaker(baseline, frozenset(current.changed_paths), current.non_test_loc)
+    repo_root = Path(args.repo_root).resolve()
+    target_args = state.get("target_args") or {}
+    mode = target_args.get("mode") or baseline.target.mode
+
+    try:
+        if mode == "local":
+            current = resolve_local_target(repo_root)
+            current_files = frozenset(current.changed_paths)
+            current_non_test_loc = current.non_test_loc
+        else:
+            if not args.current_head:
+                print(
+                    json.dumps(
+                        {
+                            "error": (
+                                f"check-expansion for mode={mode!r} requires --current-head "
+                                "(the explicit reviewed head after any committed fixes) — "
+                                "a clean local working tree is not evidence that committed "
+                                "fixes were re-measured against the frozen baseline"
+                            )
+                        }
+                    ),
+                    file=sys.stderr,
+                )
+                return 1
+            if not baseline.target.base_sha:
+                print(
+                    json.dumps({"error": f"frozen baseline for mode={mode!r} has no base_sha to re-diff against"}),
+                    file=sys.stderr,
+                )
+                return 1
+            current_head_sha = rev_parse(repo_root, args.current_head)
+            changed_paths, non_test_loc = diff_against_base(repo_root, baseline.target.base_sha, current_head_sha)
+            current_files = frozenset(changed_paths)
+            current_non_test_loc = non_test_loc
+    except TargetResolutionError as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 1
+
+    result = check_expansion_breaker(baseline, current_files, current_non_test_loc)
     print(json.dumps({"triggered": result.triggered, "reason": result.reason}, indent=2))
     return 0
 
@@ -175,6 +227,7 @@ def _cmd_resolve_reviewer(args: argparse.Namespace) -> int:
         data_egress_policy=args.data_egress_policy,
         isolation_required=args.isolation_required,
         routing_snapshot=routing_snapshot,
+        author_family=args.author_family,
     )
     resolution = resolve_reviewer(inputs)
     print(
@@ -184,6 +237,7 @@ def _cmd_resolve_reviewer(args: argparse.Namespace) -> int:
                 "advisory": [asdict(a) for a in resolution.advisory],
                 "trace": [asdict(t) for t in resolution.trace],
                 "substitution_note": resolution.substitution_note,
+                "fail_closed_reason": resolution.fail_closed_reason,
             },
             indent=2,
         )
@@ -241,6 +295,16 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_expansion = sub.add_parser("check-expansion", help="Check the 2x files/LOC scope-expansion breaker")
     p_expansion.add_argument("--repo-root", default=".")
+    p_expansion.add_argument(
+        "--current-head",
+        default=None,
+        help=(
+            "Required for commit/branch/pr-mode targets: the explicit reviewed head "
+            "(e.g. HEAD, or a specific SHA) to re-diff against the frozen base_sha "
+            "after committed fixes. Ignored for mode=local, which re-resolves from "
+            "the working tree instead."
+        ),
+    )
     p_expansion.set_defaults(func=_cmd_check_expansion)
 
     p_cycle = sub.add_parser("record-cycle", help="Record one review/fix cycle's outstanding-finding count")
@@ -248,7 +312,23 @@ def _build_parser() -> argparse.ArgumentParser:
     p_cycle.set_defaults(func=_cmd_record_cycle)
 
     p_reviewer = sub.add_parser("resolve-reviewer", help="Resolve the cross-family reviewer for this author")
-    p_reviewer.add_argument("--author-model", required=True)
+    p_reviewer.add_argument(
+        "--author-model",
+        required=True,
+        help=(
+            "Concrete seat/model id, or '<ambiguous-harness>:<concrete-model>' "
+            "(e.g. 'cursor:gpt-5.6-sol') to disambiguate a multi-model harness session."
+        ),
+    )
+    p_reviewer.add_argument(
+        "--author-family",
+        default=None,
+        help=(
+            "Explicit, caller-asserted author model family (e.g. from session logs). "
+            "Required to disambiguate a bare ambiguous-harness --author-model; optional "
+            "corroboration otherwise — a mismatch is a fail-closed conflict."
+        ),
+    )
     p_reviewer.add_argument("--review-profile", default="code")
     p_reviewer.add_argument("--risk", default="medium")
     p_reviewer.add_argument("--domain", default="code")

--- a/scripts/review/closeout_cli.py
+++ b/scripts/review/closeout_cli.py
@@ -1,0 +1,290 @@
+"""CLI for the local-code-review closeout workflow.
+
+Ties together target resolution, scope-baseline freezing/breakers, findings
+adjudication, and reviewer resolution behind one state file so an agent
+driving the skill in ``agents_extensions/shared/skills/local-code-review/``
+can call a subcommand per step instead of re-deriving the logic by hand.
+
+State lives in a single JSON file (``--state-file``, an ``.agent/`` scratch
+path by convention) for the duration of one closeout review. Every
+subcommand is read-mostly against the repo — nothing here runs ``ruff --fix``,
+formatters, generators, or any other mutating command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from scripts.review.findings import FindingEvent, FindingsLedger, FindingsLedgerError
+from scripts.review.reviewer_resolver import ResolverInputs, resolve_reviewer
+from scripts.review.scope_baseline import (
+    ScopeBaseline,
+    check_cycle_convergence_breaker,
+    check_expansion_breaker,
+)
+from scripts.review.target_resolution import (
+    ReviewTarget,
+    TargetResolutionError,
+    resolve_local_target,
+    resolve_review_target,
+)
+
+
+def _load_state(state_file: Path) -> dict:
+    if not state_file.exists():
+        return {"target": None, "target_args": None, "baseline": None, "cycle_outstanding_counts": [], "findings": []}
+    return json.loads(state_file.read_text(encoding="utf-8"))
+
+
+def _save_state(state_file: Path, state: dict) -> None:
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _target_from_dict(data: dict) -> ReviewTarget:
+    return ReviewTarget(
+        mode=data["mode"],
+        base_sha=data["base_sha"],
+        head_sha=data["head_sha"],
+        changed_paths=tuple(data["changed_paths"]),
+        non_test_loc=data["non_test_loc"],
+        clean_tree=data["clean_tree"],
+        description=data["description"],
+    )
+
+
+def _ledger_from_state(state: dict) -> FindingsLedger:
+    return FindingsLedger.from_events(FindingEvent(**raw) for raw in state.get("findings", []))
+
+
+def _cmd_target(args: argparse.Namespace) -> int:
+    state = _load_state(args.state_file)
+    try:
+        target = resolve_review_target(
+            args.mode,
+            Path(args.repo_root).resolve(),
+            commit=args.commit,
+            branch=args.branch,
+            base=args.base,
+            pr_number=args.pr,
+        )
+    except TargetResolutionError as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 1
+
+    state["target"] = asdict(target)
+    state["target_args"] = {
+        "repo_root": str(Path(args.repo_root).resolve()),
+        "mode": args.mode,
+        "commit": args.commit,
+        "branch": args.branch,
+        "base": args.base,
+        "pr": args.pr,
+    }
+    _save_state(args.state_file, state)
+    print(json.dumps(asdict(target), indent=2))
+    return 0
+
+
+def _cmd_freeze(args: argparse.Namespace) -> int:
+    state = _load_state(args.state_file)
+    if not state.get("target"):
+        print(json.dumps({"error": "no target resolved yet — run the `target` subcommand first"}), file=sys.stderr)
+        return 1
+
+    target = _target_from_dict(state["target"])
+    baseline = ScopeBaseline.freeze(
+        issue_ref=args.issue,
+        intended_behavior=args.intended_behavior,
+        non_goals=args.non_goals,
+        owner_boundary=args.owner_boundary,
+        target=target,
+        review_profile=args.review_profile,
+        risk=args.risk,
+    )
+    state["baseline"] = {
+        "issue_ref": baseline.issue_ref,
+        "intended_behavior": baseline.intended_behavior,
+        "non_goals": baseline.non_goals,
+        "owner_boundary": baseline.owner_boundary,
+        "target": asdict(baseline.target),
+        "review_profile": baseline.review_profile,
+        "risk": baseline.risk,
+        "frozen_files": sorted(baseline.frozen_files),
+        "frozen_non_test_loc": baseline.frozen_non_test_loc,
+    }
+    state["cycle_outstanding_counts"] = []
+    _save_state(args.state_file, state)
+    print(baseline.render())
+    return 0
+
+
+def _baseline_from_state(state: dict) -> ScopeBaseline:
+    data = state["baseline"]
+    return ScopeBaseline(
+        issue_ref=data["issue_ref"],
+        intended_behavior=data["intended_behavior"],
+        non_goals=data["non_goals"],
+        owner_boundary=data["owner_boundary"],
+        target=_target_from_dict(data["target"]),
+        review_profile=data["review_profile"],
+        risk=data["risk"],
+        frozen_files=frozenset(data["frozen_files"]),
+        frozen_non_test_loc=data["frozen_non_test_loc"],
+    )
+
+
+def _cmd_check_expansion(args: argparse.Namespace) -> int:
+    state = _load_state(args.state_file)
+    if not state.get("baseline"):
+        print(json.dumps({"error": "no frozen baseline yet — run `freeze` first"}), file=sys.stderr)
+        return 1
+    baseline = _baseline_from_state(state)
+    current = resolve_local_target(Path(args.repo_root).resolve())
+    result = check_expansion_breaker(baseline, frozenset(current.changed_paths), current.non_test_loc)
+    print(json.dumps({"triggered": result.triggered, "reason": result.reason}, indent=2))
+    return 0
+
+
+def _cmd_record_cycle(args: argparse.Namespace) -> int:
+    state = _load_state(args.state_file)
+    if not state.get("baseline"):
+        print(json.dumps({"error": "no frozen baseline yet — run `freeze` first"}), file=sys.stderr)
+        return 1
+    state.setdefault("cycle_outstanding_counts", []).append(args.outstanding_count)
+    result = check_cycle_convergence_breaker(state["cycle_outstanding_counts"])
+    _save_state(args.state_file, state)
+    print(json.dumps({"triggered": result.triggered, "reason": result.reason, "history": state["cycle_outstanding_counts"]}, indent=2))
+    return 0
+
+
+def _cmd_resolve_reviewer(args: argparse.Namespace) -> int:
+    routing_snapshot = None
+    if args.routing_snapshot_file:
+        routing_snapshot = json.loads(Path(args.routing_snapshot_file).read_text(encoding="utf-8"))
+    inputs = ResolverInputs(
+        author_model=args.author_model,
+        review_profile=args.review_profile,
+        risk=args.risk,
+        domain=args.domain,
+        required_capabilities=frozenset(args.required_capability or []),
+        data_egress_policy=args.data_egress_policy,
+        isolation_required=args.isolation_required,
+        routing_snapshot=routing_snapshot,
+    )
+    resolution = resolve_reviewer(inputs)
+    print(
+        json.dumps(
+            {
+                "selected": asdict(resolution.selected) if resolution.selected else None,
+                "advisory": [asdict(a) for a in resolution.advisory],
+                "trace": [asdict(t) for t in resolution.trace],
+                "substitution_note": resolution.substitution_note,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def _cmd_finding(args: argparse.Namespace) -> int:
+    state = _load_state(args.state_file)
+    ledger = _ledger_from_state(state)
+    try:
+        if args.finding_action == "raise":
+            ledger.raise_finding(args.id, summary=args.summary, source=args.source)
+        elif args.finding_action == "adjudicate":
+            ledger.adjudicate(args.id, disposition=args.disposition, rationale=args.rationale)
+        elif args.finding_action == "apply":
+            ledger.apply(args.id)
+        elif args.finding_action == "skip":
+            ledger.skip(args.id, rationale=args.rationale)
+        elif args.finding_action == "report":
+            print(ledger.render_report())
+            return 0
+    except FindingsLedgerError as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 1
+
+    state["findings"] = [asdict(e) for e in ledger.events()]
+    _save_state(args.state_file, state)
+    print(json.dumps({"ok": True, "finding_id": args.id}))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state-file", required=True, type=Path)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_target = sub.add_parser("target", help="Resolve the review target (local/commit/branch/pr)")
+    p_target.add_argument("--mode", required=True, choices=["local", "commit", "branch", "pr"])
+    p_target.add_argument("--repo-root", default=".")
+    p_target.add_argument("--commit")
+    p_target.add_argument("--branch")
+    p_target.add_argument("--base")
+    p_target.add_argument("--pr", type=int)
+    p_target.set_defaults(func=_cmd_target)
+
+    p_freeze = sub.add_parser("freeze", help="Freeze the scope baseline from the resolved target")
+    p_freeze.add_argument("--issue", required=True)
+    p_freeze.add_argument("--intended-behavior", required=True)
+    p_freeze.add_argument("--non-goals", required=True)
+    p_freeze.add_argument("--owner-boundary", required=True)
+    p_freeze.add_argument("--review-profile", default="code")
+    p_freeze.add_argument("--risk", default="medium")
+    p_freeze.set_defaults(func=_cmd_freeze)
+
+    p_expansion = sub.add_parser("check-expansion", help="Check the 2x files/LOC scope-expansion breaker")
+    p_expansion.add_argument("--repo-root", default=".")
+    p_expansion.set_defaults(func=_cmd_check_expansion)
+
+    p_cycle = sub.add_parser("record-cycle", help="Record one review/fix cycle's outstanding-finding count")
+    p_cycle.add_argument("--outstanding-count", required=True, type=int)
+    p_cycle.set_defaults(func=_cmd_record_cycle)
+
+    p_reviewer = sub.add_parser("resolve-reviewer", help="Resolve the cross-family reviewer for this author")
+    p_reviewer.add_argument("--author-model", required=True)
+    p_reviewer.add_argument("--review-profile", default="code")
+    p_reviewer.add_argument("--risk", default="medium")
+    p_reviewer.add_argument("--domain", default="code")
+    p_reviewer.add_argument("--required-capability", action="append")
+    p_reviewer.add_argument("--data-egress-policy")
+    p_reviewer.add_argument("--isolation-required", action="store_true")
+    p_reviewer.add_argument("--routing-snapshot-file")
+    p_reviewer.set_defaults(func=_cmd_resolve_reviewer)
+
+    p_finding = sub.add_parser("finding", help="Record/adjudicate/apply/skip/report findings")
+    finding_sub = p_finding.add_subparsers(dest="finding_action", required=True)
+    fr = finding_sub.add_parser("raise")
+    fr.add_argument("--id", required=True)
+    fr.add_argument("--summary", required=True)
+    fr.add_argument("--source", required=True)
+    fa = finding_sub.add_parser("adjudicate")
+    fa.add_argument("--id", required=True)
+    fa.add_argument("--disposition", required=True, choices=["in_scope_blocker", "follow_up", "stop_and_escalate"])
+    fa.add_argument("--rationale", required=True)
+    fap = finding_sub.add_parser("apply")
+    fap.add_argument("--id", required=True)
+    fs = finding_sub.add_parser("skip")
+    fs.add_argument("--id", required=True)
+    fs.add_argument("--rationale", required=True)
+    frep = finding_sub.add_parser("report")
+    frep.add_argument("--id", required=False, default=None, help="unused, present for CLI symmetry")
+    p_finding.set_defaults(func=_cmd_finding)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/review/closeout_cli.py
+++ b/scripts/review/closeout_cli.py
@@ -65,6 +65,19 @@ def _ledger_from_state(state: dict) -> FindingsLedger:
 
 def _cmd_target(args: argparse.Namespace) -> int:
     state = _load_state(args.state_file)
+    if state.get("baseline"):
+        print(
+            json.dumps(
+                {
+                    "error": (
+                        "baseline already frozen for this state file — the target is immutable "
+                        "once frozen; start a new review with a new --state-file"
+                    )
+                }
+            ),
+            file=sys.stderr,
+        )
+        return 1
     try:
         target = resolve_review_target(
             args.mode,
@@ -94,6 +107,19 @@ def _cmd_target(args: argparse.Namespace) -> int:
 
 def _cmd_freeze(args: argparse.Namespace) -> int:
     state = _load_state(args.state_file)
+    if state.get("baseline"):
+        print(
+            json.dumps(
+                {
+                    "error": (
+                        "baseline already frozen for this state file — freeze may only be called "
+                        "once; start a new review with a new --state-file"
+                    )
+                }
+            ),
+            file=sys.stderr,
+        )
+        return 1
     if not state.get("target"):
         print(json.dumps({"error": "no target resolved yet — run the `target` subcommand first"}), file=sys.stderr)
         return 1
@@ -206,6 +232,12 @@ def _cmd_record_cycle(args: argparse.Namespace) -> int:
     state = _load_state(args.state_file)
     if not state.get("baseline"):
         print(json.dumps({"error": "no frozen baseline yet — run `freeze` first"}), file=sys.stderr)
+        return 1
+    if args.outstanding_count < 0:
+        print(
+            json.dumps({"error": f"--outstanding-count must be >= 0, got {args.outstanding_count}"}),
+            file=sys.stderr,
+        )
         return 1
     state.setdefault("cycle_outstanding_counts", []).append(args.outstanding_count)
     result = check_cycle_convergence_breaker(state["cycle_outstanding_counts"])

--- a/scripts/review/findings.py
+++ b/scripts/review/findings.py
@@ -1,0 +1,146 @@
+"""Findings ledger: append-only record of every finding raised during a
+closeout review, its adjudication(s), and whether it was applied.
+
+The ledger never overwrites or removes an entry — every ``raise_finding`` /
+``adjudicate`` / ``apply`` / ``skip`` call appends a new event. A finding
+that a challenger never got to stays visibly ``unadjudicated`` instead of
+disappearing, and :meth:`FindingsLedger.apply` structurally cannot fire on
+anything that wasn't adjudicated to ``in_scope_blocker`` — there is no path
+in this API to apply a finding "as-is."
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+Disposition = Literal["in_scope_blocker", "follow_up", "stop_and_escalate"]
+EventKind = Literal["raised", "adjudicated", "applied", "skipped"]
+
+
+class FindingsLedgerError(RuntimeError):
+    """An operation would violate the append-only / explicit-adjudication contract."""
+
+
+@dataclass(frozen=True)
+class FindingEvent:
+    finding_id: str
+    event: EventKind
+    summary: str | None = None
+    source: str | None = None
+    disposition: Disposition | None = None
+    rationale: str | None = None
+
+
+class FindingsLedger:
+    def __init__(self) -> None:
+        self._events: list[FindingEvent] = []
+
+    @classmethod
+    def from_events(cls, events: Iterable[FindingEvent]) -> FindingsLedger:
+        """Rehydrate a ledger from a previously persisted event list.
+
+        Used to round-trip a ledger through a JSON state file across CLI
+        invocations without re-deriving history — every event is replayed
+        verbatim, so nothing is silently dropped on reload either.
+        """
+        ledger = cls()
+        ledger._events = list(events)
+        return ledger
+
+    def events(self) -> tuple[FindingEvent, ...]:
+        return tuple(self._events)
+
+    def all_finding_ids(self) -> tuple[str, ...]:
+        ids: list[str] = []
+        for event in self._events:
+            if event.event == "raised" and event.finding_id not in ids:
+                ids.append(event.finding_id)
+        return tuple(ids)
+
+    def _history(self, finding_id: str) -> list[FindingEvent]:
+        return [e for e in self._events if e.finding_id == finding_id]
+
+    def _require_raised(self, finding_id: str) -> None:
+        if not any(e.event == "raised" for e in self._history(finding_id)):
+            raise FindingsLedgerError(f"finding {finding_id!r} was never raised")
+
+    def latest_disposition(self, finding_id: str) -> Disposition | None:
+        for event in reversed(self._history(finding_id)):
+            if event.event == "adjudicated":
+                return event.disposition
+        return None
+
+    def is_applied(self, finding_id: str) -> bool:
+        return any(e.event == "applied" for e in self._history(finding_id))
+
+    def raise_finding(self, finding_id: str, *, summary: str, source: str) -> None:
+        """Record a new finding. Duplicate ids are rejected — re-raising the
+        same id would silently merge two distinct findings' histories."""
+        if any(e.event == "raised" for e in self._history(finding_id)):
+            raise FindingsLedgerError(f"finding {finding_id!r} was already raised")
+        self._events.append(FindingEvent(finding_id, "raised", summary=summary, source=source))
+
+    def adjudicate(self, finding_id: str, *, disposition: Disposition, rationale: str) -> None:
+        """Record an adjudication. Callable more than once (e.g. a later
+        review cycle re-adjudicates); every prior adjudication stays in the
+        event log, so nothing is silently overwritten."""
+        self._require_raised(finding_id)
+        if not rationale.strip():
+            raise FindingsLedgerError(f"finding {finding_id!r}: adjudication requires a non-empty rationale")
+        self._events.append(
+            FindingEvent(finding_id, "adjudicated", disposition=disposition, rationale=rationale)
+        )
+
+    def apply(self, finding_id: str) -> None:
+        """Record that the accountable agent applied this finding's fix.
+
+        Requires the *latest* adjudication to be ``in_scope_blocker``. There
+        is no way to reach this state without an explicit adjudication —
+        an unadjudicated finding (challenger unavailable, review skipped)
+        cannot be applied "as-is."
+        """
+        self._require_raised(finding_id)
+        disposition = self.latest_disposition(finding_id)
+        if disposition is None:
+            raise FindingsLedgerError(
+                f"finding {finding_id!r} is unadjudicated — cannot apply without adjudication"
+            )
+        if disposition != "in_scope_blocker":
+            raise FindingsLedgerError(
+                f"finding {finding_id!r} is adjudicated as {disposition!r}, not in_scope_blocker — "
+                "re-adjudicate before applying"
+            )
+        self._events.append(FindingEvent(finding_id, "applied"))
+
+    def skip(self, finding_id: str, *, rationale: str) -> None:
+        """Record an explicit, rationale-carrying decision not to apply a finding."""
+        self._require_raised(finding_id)
+        if not rationale.strip():
+            raise FindingsLedgerError(f"finding {finding_id!r}: skip requires a non-empty rationale")
+        self._events.append(FindingEvent(finding_id, "skipped", rationale=rationale))
+
+    def unadjudicated(self) -> tuple[str, ...]:
+        """Findings that were raised but never adjudicated — e.g. the
+        challenger/reviewer was unavailable. Surfaced explicitly rather
+        than silently dropped from the report."""
+        return tuple(fid for fid in self.all_finding_ids() if self.latest_disposition(fid) is None)
+
+    def render_report(self) -> str:
+        """Every finding and its full event history — nothing dropped."""
+        lines = []
+        for finding_id in self.all_finding_ids():
+            history = self._history(finding_id)
+            raised = next(e for e in history if e.event == "raised")
+            lines.append(f"## {finding_id}: {raised.summary} (source: {raised.source})")
+            for event in history[1:]:
+                if event.event == "adjudicated":
+                    lines.append(f"  - adjudicated: {event.disposition} — {event.rationale}")
+                elif event.event == "applied":
+                    lines.append("  - applied")
+                elif event.event == "skipped":
+                    lines.append(f"  - skipped: {event.rationale}")
+            if len(history) == 1:
+                lines.append("  - UNADJUDICATED (no reviewer/challenger verdict recorded)")
+        return "\n".join(lines) if lines else "(no findings raised)"

--- a/scripts/review/findings.py
+++ b/scripts/review/findings.py
@@ -141,6 +141,6 @@ class FindingsLedger:
                     lines.append("  - applied")
                 elif event.event == "skipped":
                     lines.append(f"  - skipped: {event.rationale}")
-            if len(history) == 1:
+            if self.latest_disposition(finding_id) is None:
                 lines.append("  - UNADJUDICATED (no reviewer/challenger verdict recorded)")
         return "\n".join(lines) if lines else "(no findings raised)"

--- a/scripts/review/reviewer_resolver.py
+++ b/scripts/review/reviewer_resolver.py
@@ -53,8 +53,6 @@ _FAMILY_BY_EXACT_SEAT: dict[str, str] = {
     "grok-tools": "xai",
     "deepseek": "deepseek",
     "deepseek-tools": "deepseek",
-    "cursor": "cursor",
-    "cursor-tools": "cursor",
     "pool": "poolside",
     "glm": "zhipu",
     "qwen": "alibaba",
@@ -106,6 +104,83 @@ def resolve_family(seat_or_model: str) -> str:
         if canonical.startswith(prefix):
             return family
     return "unknown"
+
+
+# --- ambiguous-harness / fail-closed author identity --------------------------
+
+# Harnesses that route to more than one underlying model family depending on
+# per-session configuration — the harness name alone is NOT a model family.
+# Cursor is multi-model (a session may run GPT, Claude, or another model
+# underneath); resolving it to a synthetic "cursor" family would let an
+# author dodge the cross-family requirement whenever the real underlying
+# model happens to collide with whatever the ladder picks.
+AMBIGUOUS_HARNESS_SEATS: frozenset[str] = frozenset({"cursor", "cursor-tools"})
+
+# Concrete model-vendor families a caller may assert via an explicit
+# ``author_family`` override. Deliberately excludes harness pseudo-families
+# (nothing routes to "cursor" as if it were a vendor) and the fail-closed
+# sentinels below — an override must name a real family or be rejected.
+_VALID_CONCRETE_FAMILIES: frozenset[str] = frozenset(
+    {"anthropic", "openai", "google", "xai", "deepseek", "poolside", "zhipu", "alibaba"}
+)
+
+# Fail-closed author-identity outcomes: none of these is a real model family,
+# and a caller must never treat one as matching (or not matching) any
+# candidate's family — resolve_reviewer refuses to select a formal reviewer
+# for any of them.
+UNKNOWN_AUTHOR_FAMILY = "unknown"
+AMBIGUOUS_AUTHOR_FAMILY = "ambiguous"
+CONFLICTING_AUTHOR_FAMILY = "conflict"
+UNRESOLVED_AUTHOR_FAMILIES: frozenset[str] = frozenset(
+    {UNKNOWN_AUTHOR_FAMILY, AMBIGUOUS_AUTHOR_FAMILY, CONFLICTING_AUTHOR_FAMILY}
+)
+
+
+def resolve_author_family(author_model: str, author_family: str | None = None) -> str:
+    """Resolve the author's model family, failing closed for ambiguous harnesses.
+
+    ``author_model`` is either a concrete seat/model id (resolved exactly as
+    :func:`resolve_family` always has), or a ``"<harness>:<concrete-model>"``
+    composite for a multi-model harness (e.g. ``"cursor:gpt-5.6-sol"``,
+    ``"cursor:claude-opus-4-8"``) that disambiguates which model that harness
+    session actually ran. ``author_family`` is an optional explicit,
+    caller-asserted family (e.g. from session logs) used to corroborate or,
+    for a bare ambiguous-harness identity with no embedded model, to supply
+    the disambiguation on its own.
+
+    Returns a concrete family string, or one of the fail-closed sentinels:
+
+    - ``"unknown"`` — no usable identity signal at all.
+    - ``"ambiguous"`` — a multi-model harness with no concrete model and no
+      valid override to disambiguate it.
+    - ``"conflict"`` — the embedded/resolved model family and an explicit
+      ``author_family`` override disagree.
+
+    Callers (:func:`resolve_reviewer`) must never select a formal reviewer
+    against a fail-closed sentinel — an unresolved author identity is not
+    evidence that a candidate is (or isn't) the same family.
+    """
+    normalized = (author_model or "").strip().lower()
+    override = (author_family or "").strip().lower() or None
+    if override is not None and override not in _VALID_CONCRETE_FAMILIES:
+        override = None  # an invalid/unrecognized override does not count as validated
+
+    harness_token, sep, embedded = normalized.partition(":")
+    if sep and harness_token in AMBIGUOUS_HARNESS_SEATS and embedded.strip():
+        resolved = resolve_family(embedded.strip())
+    elif normalized in AMBIGUOUS_HARNESS_SEATS or (normalize_seat(normalized) or "") in AMBIGUOUS_HARNESS_SEATS:
+        resolved = None  # bare ambiguous harness, no embedded concrete model
+    else:
+        resolved = resolve_family(normalized)
+
+    if resolved is None:
+        # Bare ambiguous harness: only a validated override can disambiguate it.
+        return override if override else AMBIGUOUS_AUTHOR_FAMILY
+    if resolved == "unknown":
+        return override if override else UNKNOWN_AUTHOR_FAMILY
+    if override and override != resolved:
+        return CONFLICTING_AUTHOR_FAMILY
+    return resolved
 
 
 # --- candidates ---------------------------------------------------------------
@@ -186,6 +261,9 @@ def _health_rank(status: str | None) -> int:
 
 @dataclass(frozen=True)
 class ResolverInputs:
+    # Concrete seat/model id, OR a "<ambiguous-harness>:<concrete-model>"
+    # composite (e.g. "cursor:gpt-5.6-sol") disambiguating a multi-model
+    # harness session. See resolve_author_family for the exact contract.
     author_model: str
     review_profile: str = "code"
     risk: str = "medium"
@@ -198,6 +276,11 @@ class ResolverInputs:
     # ("healthy" | "degraded" | "near_cap" | "unhealthy"). Optional — omit for a
     # snapshot-blind resolution (ladder order alone decides).
     routing_snapshot: Mapping[str, str] | None = None
+    # Explicit, caller-asserted author model family (e.g. from session logs),
+    # validated against _VALID_CONCRETE_FAMILIES. Required to disambiguate a
+    # bare ambiguous-harness author_model; optional corroboration otherwise —
+    # a mismatch against the resolved family is a fail-closed conflict.
+    author_family: str | None = None
 
 
 @dataclass(frozen=True)
@@ -216,6 +299,12 @@ class ReviewerResolution:
     advisory: tuple[CandidateResult, ...]
     trace: tuple[CandidateResult, ...]
     substitution_note: str | None
+    # Set (non-None) instead of walking the ladder at all when the author's
+    # model family could not be resolved to a concrete family — unknown,
+    # ambiguous-harness, or conflicting-signal identities never get a formal
+    # reviewer selected, since there is nothing reliable to diff a
+    # candidate's family against.
+    fail_closed_reason: str | None = None
 
 
 def _health_of(candidate: ReviewerCandidate, snapshot: Mapping[str, str] | None) -> str | None:
@@ -261,7 +350,11 @@ def evaluate_candidate(
     data-egress fail-closed behavior is testable per-candidate, including for
     candidates that aren't in the default ladder (e.g. ``GLM``, ``QWEN``).
     """
-    family = author_family if author_family is not None else resolve_family(inputs.author_model)
+    family = (
+        author_family
+        if author_family is not None
+        else resolve_author_family(inputs.author_model, inputs.author_family)
+    )
     health = _health_of(candidate, inputs.routing_snapshot)
     same_family = candidate.family == family
 
@@ -298,8 +391,32 @@ def resolve_reviewer(
     """Walk the ladder in order; the first rung with an eligible candidate
     wins (health breaks ties within that rung). Advisory-only candidates
     (e.g. ``openai_frontier`` for an OpenAI-family author) are always
-    surfaced separately, regardless of which rung is selected."""
-    author_family = resolve_family(inputs.author_model)
+    surfaced separately, regardless of which rung is selected.
+
+    Fails closed — no candidate walked, ``selected`` stays ``None`` — when
+    the author's model family cannot be resolved to a concrete family (an
+    unrecognized identity, a bare ambiguous-model harness with no
+    disambiguation, or a conflicting override). See
+    :func:`resolve_author_family`.
+    """
+    author_family = resolve_author_family(inputs.author_model, inputs.author_family)
+    if author_family in UNRESOLVED_AUTHOR_FAMILIES:
+        reason = {
+            UNKNOWN_AUTHOR_FAMILY: (
+                f"author identity unknown — cannot resolve a model family from "
+                f"author_model={inputs.author_model!r}"
+            ),
+            AMBIGUOUS_AUTHOR_FAMILY: (
+                f"author harness is multi-model and ambiguous (author_model={inputs.author_model!r}) — "
+                "supply a concrete author model (e.g. 'cursor:gpt-5.6-sol') or a validated author_family override"
+            ),
+            CONFLICTING_AUTHOR_FAMILY: (
+                f"author identity conflict — the model embedded in author_model={inputs.author_model!r} "
+                f"disagrees with the declared author_family={inputs.author_family!r} override"
+            ),
+        }[author_family]
+        return ReviewerResolution(selected=None, advisory=(), trace=(), substitution_note=None, fail_closed_reason=reason)
+
     trace: list[CandidateResult] = []
     advisory: list[CandidateResult] = []
     selected: CandidateResult | None = None

--- a/scripts/review/reviewer_resolver.py
+++ b/scripts/review/reviewer_resolver.py
@@ -1,0 +1,337 @@
+"""Canonical cross-family reviewer resolver for code-review closeout.
+
+Family follows the MODEL, not the harness or CLI name — the same underlying
+model reachable through different tooling (native CLI, hermes, a `-tools`
+V7 seat) always resolves to the same family, so an author can't dodge the
+cross-family requirement by switching harness. Domain and data-egress
+exclusions are fail-closed: an unspecified or non-matching policy excludes
+a gated candidate, it does not admit it. Lane *health* is fail-open (no
+signal ≠ unhealthy, matching ``scripts/api/lane_health.py``'s convention)
+and used only as a tie-breaker among candidates that already passed every
+hard filter.
+
+This module intentionally does not duplicate the full routing table from
+``agents_extensions/shared/rules/model-assignment.md`` — it owns a small,
+tested policy layer (the default code-review ladder + the family/exclusion
+tables below) and documents its provenance inline. Update both together if
+the canonical routing doc changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Literal
+
+from scripts.agent_runtime.agent_identity import normalize_seat, tools_writer_runtime_agent
+
+CandidateStatus = Literal["eligible", "selected", "advisory_only", "excluded"]
+
+# --- family resolution -------------------------------------------------------
+
+# Exact seat/model id -> family. Includes native-CLI names, `-tools` V7 writer/
+# reviewer seat aliases, and Hermes-hosted aliases so the SAME model resolves
+# to the SAME family everywhere it's reachable.
+_FAMILY_BY_EXACT_SEAT: dict[str, str] = {
+    "claude": "anthropic",
+    "claude-tools": "anthropic",
+    "sonnet": "anthropic",
+    "opus": "anthropic",
+    "haiku": "anthropic",
+    "fable": "anthropic",
+    "codex": "openai",
+    "codex-tools": "openai",
+    "openai_frontier": "openai",
+    "gemini": "google",
+    "gemini-tools": "google",
+    "agy": "google",
+    "agy-tools": "google",
+    "gemma": "google",
+    "grok": "xai",
+    "grok-build": "xai",
+    "grok-hermes": "xai",
+    "grok-tools": "xai",
+    "deepseek": "deepseek",
+    "deepseek-tools": "deepseek",
+    "cursor": "cursor",
+    "cursor-tools": "cursor",
+    "pool": "poolside",
+    "glm": "zhipu",
+    "qwen": "alibaba",
+    "qwen-tools": "alibaba",
+}
+
+# Model-id prefixes, for concrete model strings not covered by the seat table
+# above (e.g. "gpt-5.6-sol", "deepseek-v4-flash", "grok-4.5").
+_FAMILY_BY_MODEL_PREFIX: tuple[tuple[str, str], ...] = (
+    ("claude-", "anthropic"),
+    ("sonnet-", "anthropic"),
+    ("opus-", "anthropic"),
+    ("haiku-", "anthropic"),
+    ("fable-", "anthropic"),
+    ("gpt-", "openai"),
+    ("o1", "openai"),
+    ("o3", "openai"),
+    ("gemini-", "google"),
+    ("gemma-", "google"),
+    ("grok-", "xai"),
+    ("deepseek-", "deepseek"),
+    ("qwen", "alibaba"),
+    ("glm-", "zhipu"),
+)
+
+
+def resolve_family(seat_or_model: str) -> str:
+    """Resolve a seat/CLI-alias/model-id string to its model family.
+
+    Returns ``"unknown"`` for anything unrecognized — callers must not treat
+    unknown as any specific family (including the author's own), since that
+    would either wrongly admit or wrongly exclude a candidate.
+    """
+    normalized = (seat_or_model or "").strip().lower()
+    if not normalized:
+        return "unknown"
+
+    canonical = normalize_seat(normalized) or normalized
+    if canonical in _FAMILY_BY_EXACT_SEAT:
+        return _FAMILY_BY_EXACT_SEAT[canonical]
+
+    if canonical.endswith("-tools"):
+        base = tools_writer_runtime_agent(canonical)
+        if base in _FAMILY_BY_EXACT_SEAT:
+            return _FAMILY_BY_EXACT_SEAT[base]
+        canonical = base
+
+    for prefix, family in _FAMILY_BY_MODEL_PREFIX:
+        if canonical.startswith(prefix):
+            return family
+    return "unknown"
+
+
+# --- candidates ---------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ReviewerCandidate:
+    name: str
+    family: str
+    concrete_model: str
+    requires_silence_timeout: bool = False
+    # Fail-closed data-egress gate: eligible only when the caller's
+    # data_egress_policy exactly matches this value. None = no egress gate.
+    requires_data_egress_policy: str | None = None
+    # Hard exclusion regardless of anything else (e.g. cost policy).
+    always_excluded_reason: str | None = None
+    capabilities: frozenset[str] = field(default_factory=frozenset)
+    # Domains (review_profile-adjacent, e.g. "folk_content") where this
+    # candidate is a hard no per model-assignment.md carve-outs.
+    domain_excluded_from: frozenset[str] = field(default_factory=frozenset)
+    # Author families for which this candidate is advisory-only rather than
+    # hard-excluded on a same-family match (e.g. openai_frontier for an
+    # OpenAI-family author: still consulted, never the formal gate).
+    advisory_only_for_author_families: frozenset[str] = field(default_factory=frozenset)
+
+
+DEEPSEEK_V4_FLASH = ReviewerCandidate(
+    name="deepseek-v4-flash",
+    family="deepseek",
+    concrete_model="deepseek-v4-flash",
+    requires_silence_timeout=True,
+    domain_excluded_from=frozenset({"folk_content"}),
+)
+GROK_4_5 = ReviewerCandidate(name="grok-4.5", family="xai", concrete_model="grok-4.5")
+POOL = ReviewerCandidate(name="pool", family="poolside", concrete_model="laguna-m.1")
+OPENAI_FRONTIER = ReviewerCandidate(
+    name="openai_frontier",
+    family="openai",
+    concrete_model="gpt-5.6-sol",
+    advisory_only_for_author_families=frozenset({"openai"}),
+)
+
+# Rungs in priority order; each rung is itself an ordered list of candidates
+# (health breaks ties within a rung; the first rung with any eligible
+# candidate wins over later rungs regardless of health).
+DEFAULT_CODE_LADDER: tuple[tuple[ReviewerCandidate, ...], ...] = (
+    (DEEPSEEK_V4_FLASH,),
+    (GROK_4_5,),
+    (POOL,),
+    (OPENAI_FRONTIER,),
+)
+
+# Known hard-filtered candidates outside the default ladder — kept here so the
+# fail-closed exclusion logic is directly testable even where model-assignment.md
+# doesn't route code review through them by default.
+QWEN = ReviewerCandidate(
+    name="qwen",
+    family="alibaba",
+    concrete_model="qwen3-max",
+    always_excluded_reason="excluded from routine/automatic routing (cost) — model-assignment.md",
+)
+GLM = ReviewerCandidate(
+    name="glm",
+    family="zhipu",
+    concrete_model="glm-5.2",
+    requires_data_egress_policy="local_interactive",
+)
+
+_HEALTH_RANK: dict[str, int] = {"healthy": 0, "degraded": 1, "near_cap": 2, "unhealthy": 3}
+
+
+def _health_rank(status: str | None) -> int:
+    # Fail-open: no signal for this lane is read as healthy, not unhealthy —
+    # matches scripts/api/lane_health.py's fail-open convention.
+    if status is None:
+        return 0
+    return _HEALTH_RANK.get(status, 0)
+
+
+@dataclass(frozen=True)
+class ResolverInputs:
+    author_model: str
+    review_profile: str = "code"
+    risk: str = "medium"
+    domain: str = "code"
+    required_capabilities: frozenset[str] = field(default_factory=frozenset)
+    # Fail-closed: None/unrecognized means the strictest reading, not "anything goes."
+    data_egress_policy: str | None = None
+    isolation_required: bool = False
+    # Fresh CodexBar/routing-budget snapshot: seat or family name -> health status
+    # ("healthy" | "degraded" | "near_cap" | "unhealthy"). Optional — omit for a
+    # snapshot-blind resolution (ladder order alone decides).
+    routing_snapshot: Mapping[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class CandidateResult:
+    name: str
+    concrete_model: str
+    family: str
+    status: CandidateStatus
+    reason: str | None
+    health: str | None
+
+
+@dataclass(frozen=True)
+class ReviewerResolution:
+    selected: CandidateResult | None
+    advisory: tuple[CandidateResult, ...]
+    trace: tuple[CandidateResult, ...]
+    substitution_note: str | None
+
+
+def _health_of(candidate: ReviewerCandidate, snapshot: Mapping[str, str] | None) -> str | None:
+    if not snapshot:
+        return None
+    return snapshot.get(candidate.name) or snapshot.get(candidate.family)
+
+
+def _hard_exclusion_reason(candidate: ReviewerCandidate, inputs: ResolverInputs) -> str | None:
+    """Non-family exclusions: cost policy, domain carve-out, data-egress
+    (fail-closed), missing required capability. Family/advisory handling is
+    the caller's job — this only covers filters that apply regardless."""
+    if candidate.always_excluded_reason:
+        return candidate.always_excluded_reason
+    if inputs.domain in candidate.domain_excluded_from:
+        return f"hard domain exclusion: {candidate.name} is excluded from {inputs.domain!r} review"
+    if (
+        candidate.requires_data_egress_policy is not None
+        and inputs.data_egress_policy != candidate.requires_data_egress_policy
+    ):
+        return (
+            f"data-egress policy fail-closed: {candidate.name} requires "
+            f"data_egress_policy={candidate.requires_data_egress_policy!r}, "
+            f"got {inputs.data_egress_policy!r}"
+        )
+    missing = inputs.required_capabilities - candidate.capabilities
+    if missing:
+        return f"missing required capabilities: {sorted(missing)}"
+    if inputs.isolation_required and "isolation" not in candidate.capabilities:
+        return "isolation required but candidate does not support process isolation"
+    return None
+
+
+def evaluate_candidate(
+    candidate: ReviewerCandidate,
+    inputs: ResolverInputs,
+    *,
+    author_family: str | None = None,
+) -> CandidateResult:
+    """Evaluate one candidate against ``inputs`` independent of ladder position.
+
+    Exposed directly (not just via :func:`resolve_reviewer`) so domain and
+    data-egress fail-closed behavior is testable per-candidate, including for
+    candidates that aren't in the default ladder (e.g. ``GLM``, ``QWEN``).
+    """
+    family = author_family if author_family is not None else resolve_family(inputs.author_model)
+    health = _health_of(candidate, inputs.routing_snapshot)
+    same_family = candidate.family == family
+
+    if same_family and family in candidate.advisory_only_for_author_families:
+        return CandidateResult(
+            candidate.name,
+            candidate.concrete_model,
+            candidate.family,
+            "advisory_only",
+            f"same family as author ({family}) — advisory-only, not a formal cross-family gate",
+            health,
+        )
+    if same_family:
+        return CandidateResult(
+            candidate.name,
+            candidate.concrete_model,
+            candidate.family,
+            "excluded",
+            f"same family as author ({family}) — cross-family review requires a different family",
+            health,
+        )
+
+    reason = _hard_exclusion_reason(candidate, inputs)
+    if reason:
+        return CandidateResult(candidate.name, candidate.concrete_model, candidate.family, "excluded", reason, health)
+
+    return CandidateResult(candidate.name, candidate.concrete_model, candidate.family, "eligible", None, health)
+
+
+def resolve_reviewer(
+    inputs: ResolverInputs,
+    ladder: tuple[tuple[ReviewerCandidate, ...], ...] = DEFAULT_CODE_LADDER,
+) -> ReviewerResolution:
+    """Walk the ladder in order; the first rung with an eligible candidate
+    wins (health breaks ties within that rung). Advisory-only candidates
+    (e.g. ``openai_frontier`` for an OpenAI-family author) are always
+    surfaced separately, regardless of which rung is selected."""
+    author_family = resolve_family(inputs.author_model)
+    trace: list[CandidateResult] = []
+    advisory: list[CandidateResult] = []
+    selected: CandidateResult | None = None
+
+    for rung in ladder:
+        rung_eligible: list[CandidateResult] = []
+        for candidate in rung:
+            result = evaluate_candidate(candidate, inputs, author_family=author_family)
+            trace.append(result)
+            if result.status == "advisory_only":
+                advisory.append(result)
+            elif result.status == "eligible":
+                rung_eligible.append(result)
+
+        if selected is None and rung_eligible:
+            best = min(rung_eligible, key=lambda r: _health_rank(r.health))
+            promoted = CandidateResult(best.name, best.concrete_model, best.family, "selected", None, best.health)
+            for i, entry in enumerate(trace):
+                if entry is best:
+                    trace[i] = promoted
+                    break
+            selected = promoted
+
+    substitution_note = None
+    if selected is not None:
+        default_first = ladder[0][0] if ladder and ladder[0] else None
+        if default_first is not None and selected.name != default_first.name:
+            substitution_note = f"substituted {selected.name} for default first pick {default_first.name}"
+
+    return ReviewerResolution(
+        selected=selected,
+        advisory=tuple(advisory),
+        trace=tuple(trace),
+        substitution_note=substitution_note,
+    )

--- a/scripts/review/scope_baseline.py
+++ b/scripts/review/scope_baseline.py
@@ -1,0 +1,199 @@
+"""Scope baseline: freeze the closeout review's boundaries before the first
+review pass runs, then detect when review-triggered changes (or a proposed
+fix) have grown past them.
+
+The baseline is frozen once, from a single :class:`ReviewTarget`. Every
+later check compares against that frozen snapshot — never against whatever
+the tree looks like *now* — so scope creep during the review/fix loop is
+visible instead of silently absorbed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Literal
+
+from scripts.review.target_resolution import ReviewTarget
+
+Disposition = Literal["in_scope_blocker", "follow_up", "stop_and_escalate"]
+
+# Only these reasons justify expanding scope past a tripped breaker.
+CRITICAL_OVERRIDE_REASONS = frozenset(
+    {
+        "active_data_loss",
+        "crash",
+        "broken_install_or_upgrade",
+        "release_blocker",
+        "concrete_security_exposure",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ScopeBaseline:
+    """The frozen scope statement, displayed before the first review pass."""
+
+    issue_ref: str
+    intended_behavior: str
+    non_goals: str
+    owner_boundary: str
+    target: ReviewTarget
+    review_profile: str
+    risk: str
+    frozen_files: frozenset[str]
+    frozen_non_test_loc: int
+
+    @classmethod
+    def freeze(
+        cls,
+        *,
+        issue_ref: str,
+        intended_behavior: str,
+        non_goals: str,
+        owner_boundary: str,
+        target: ReviewTarget,
+        review_profile: str,
+        risk: str,
+    ) -> ScopeBaseline:
+        return cls(
+            issue_ref=issue_ref,
+            intended_behavior=intended_behavior,
+            non_goals=non_goals,
+            owner_boundary=owner_boundary,
+            target=target,
+            review_profile=review_profile,
+            risk=risk,
+            frozen_files=frozenset(target.changed_paths),
+            frozen_non_test_loc=target.non_test_loc,
+        )
+
+    def render(self) -> str:
+        """Human-readable baseline block. Displayed once, before review starts."""
+        lines = [
+            f"Issue: {self.issue_ref}",
+            f"Intended behavior: {self.intended_behavior}",
+            f"Non-goals: {self.non_goals}",
+            f"Owner boundary: {self.owner_boundary}",
+            f"Mode: {self.target.mode}",
+            f"Base SHA: {self.target.base_sha or '(none)'}",
+            f"Head SHA: {self.target.head_sha or '(none)'}",
+            f"Changed paths ({len(self.frozen_files)}): {', '.join(sorted(self.frozen_files)) or '(none)'}",
+            f"Non-test LOC: {self.frozen_non_test_loc}",
+            f"Review profile: {self.review_profile}",
+            f"Risk: {self.risk}",
+        ]
+        if self.target.mode == "local" and self.target.clean_tree:
+            lines.append("NOTE: clean local tree only — NOT evidence that a commit or PR was reviewed.")
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class BreakerResult:
+    triggered: bool
+    reason: str | None = None
+
+
+def check_expansion_breaker(
+    baseline: ScopeBaseline,
+    current_files: frozenset[str],
+    current_non_test_loc: int,
+) -> BreakerResult:
+    """Trip when review-triggered changes exceed 2x the frozen files or LOC.
+
+    A frozen baseline of zero files/LOC (an empty local diff, or a doc-only
+    change) can't be doubled by arithmetic — any expansion at all crosses it.
+    """
+    frozen_file_count = len(baseline.frozen_files)
+    total_files = len(baseline.frozen_files | current_files)
+    file_limit_exceeded = (
+        total_files > frozen_file_count * 2 if frozen_file_count else total_files > 0
+    )
+    if file_limit_exceeded:
+        return BreakerResult(
+            True,
+            f"review-triggered files ({total_files}) exceed 2x frozen baseline ({frozen_file_count})",
+        )
+
+    loc_limit_exceeded = (
+        current_non_test_loc > baseline.frozen_non_test_loc * 2
+        if baseline.frozen_non_test_loc
+        else current_non_test_loc > 0
+    )
+    if loc_limit_exceeded:
+        return BreakerResult(
+            True,
+            f"review-triggered non-test LOC ({current_non_test_loc}) exceeds "
+            f"2x frozen baseline ({baseline.frozen_non_test_loc})",
+        )
+    return BreakerResult(False)
+
+
+def check_cycle_convergence_breaker(cycle_outstanding_counts: list[int]) -> BreakerResult:
+    """Trip when two review-triggered patch cycles in a row fail to converge.
+
+    ``cycle_outstanding_counts`` is the outstanding-finding count after each
+    review pass, oldest first (e.g. ``[5, 4, 4]`` — pass 2 made progress,
+    pass 3 stalled). Two consecutive passes that don't shrink the count trip
+    the breaker.
+    """
+    non_converging_streak = 0
+    for prev, curr in pairwise(cycle_outstanding_counts):
+        if curr >= prev:
+            non_converging_streak += 1
+        else:
+            non_converging_streak = 0
+        if non_converging_streak >= 2:
+            return BreakerResult(
+                True,
+                f"two review-triggered patch cycles did not converge: {cycle_outstanding_counts}",
+            )
+    return BreakerResult(False)
+
+
+def check_contract_boundary_breaker(
+    *,
+    changes_public_contract: bool,
+    crosses_owner_boundary: bool,
+) -> BreakerResult:
+    """Trip when a fix changes the public/task contract or an owner boundary."""
+    if changes_public_contract:
+        return BreakerResult(True, "fix changes the public/task contract")
+    if crosses_owner_boundary:
+        return BreakerResult(True, "fix crosses the owner boundary")
+    return BreakerResult(False)
+
+
+def check_design_decision_breaker(*, requires_canonical_decision: bool) -> BreakerResult:
+    """Trip when a canonical contract/design decision is required to proceed."""
+    if requires_canonical_decision:
+        return BreakerResult(True, "a canonical contract/design decision is required")
+    return BreakerResult(False)
+
+
+def critical_override_applies(reason: str | None) -> bool:
+    """Only active data loss, crash, broken install/upgrade, release blocker,
+    or concrete security exposure justify expanding scope past a tripped
+    breaker. Anything else — including "it would be nice to fix too" — does
+    not."""
+    return reason in CRITICAL_OVERRIDE_REASONS
+
+
+def classify_finding(
+    *,
+    is_blocking: bool,
+    in_frozen_scope: bool,
+    requires_scope_expansion: bool,
+    critical_override_reason: str | None = None,
+) -> Disposition:
+    """Classify one verified finding into its disposition.
+
+    A finding whose fix would expand scope is escalated unless a critical
+    override reason applies — in which case it's treated as in-scope (the
+    override exists precisely so real emergencies aren't stuck in follow-up).
+    """
+    if requires_scope_expansion and not critical_override_applies(critical_override_reason):
+        return "stop_and_escalate"
+    if is_blocking and in_frozen_scope:
+        return "in_scope_blocker"
+    return "follow_up"

--- a/scripts/review/target_resolution.py
+++ b/scripts/review/target_resolution.py
@@ -95,6 +95,11 @@ def _rev_parse(repo_root: Path, ref: str) -> str:
     return proc.stdout.strip()
 
 
+def rev_parse(repo_root: Path, ref: str) -> str:
+    """Public wrapper: resolve ``ref`` to a full SHA. Read-only."""
+    return _rev_parse(repo_root, ref)
+
+
 def _numstat_loc(repo_root: Path, diff_range: list[str]) -> tuple[tuple[str, ...], int]:
     """Return (changed_paths, non_test_loc) for a ``git diff --numstat`` range."""
     proc = _run_git(["diff", "--numstat", *diff_range], repo_root)
@@ -118,6 +123,15 @@ def _numstat_loc(repo_root: Path, diff_range: list[str]) -> tuple[tuple[str, ...
         removed = int(removed_raw) if removed_raw.isdigit() else 0
         loc += added + removed
     return tuple(changed), loc
+
+
+def diff_against_base(repo_root: Path, base_sha: str, head_sha: str) -> tuple[tuple[str, ...], int]:
+    """Public wrapper: (changed_paths, non_test_loc) for an explicit
+    ``base_sha..head_sha`` range. Read-only — used to re-measure a frozen
+    commit/branch/PR target's full diff after committed fixes land, without
+    re-resolving the target from scratch (e.g. re-querying ``gh pr view``,
+    whose live base/head could have moved since the target was frozen)."""
+    return _numstat_loc(repo_root, [base_sha, head_sha])
 
 
 def _untracked_paths(repo_root: Path) -> tuple[str, ...]:
@@ -233,7 +247,17 @@ def _ensure_commit_available(repo_root: Path, sha: str) -> None:
 
 
 def resolve_pr_target(repo_root: Path, pr_number: int) -> ReviewTarget:
-    """A PR's diff using its actual base (not an assumed default branch)."""
+    """A PR's diff using the merge-base with its actual base branch (not an
+    assumed default branch, and not the base branch's possibly-moved tip).
+
+    ``baseRefOid`` is the base branch's *current tip* at query time, not
+    necessarily the commit the PR actually forked from — the base branch can
+    advance after the feature diverged. Diffing straight against that tip
+    would pull in every commit the base gained since divergence as if the PR
+    introduced them. The merge-base is the fork point and is what a diff
+    must be computed against; the base tip is retained only in
+    ``description`` for provenance.
+    """
     proc = _run_gh(
         [
             "pr",
@@ -251,24 +275,34 @@ def resolve_pr_target(repo_root: Path, pr_number: int) -> ReviewTarget:
     except json.JSONDecodeError as exc:
         raise TargetResolutionError(f"invalid JSON from gh pr view #{pr_number}") from exc
 
-    base_sha = str(payload.get("baseRefOid") or "").strip()
+    base_tip_sha = str(payload.get("baseRefOid") or "").strip()
     head_sha = str(payload.get("headRefOid") or "").strip()
     base_ref_name = str(payload.get("baseRefName") or "").strip()
     head_ref_name = str(payload.get("headRefName") or "").strip()
-    if not base_sha or not head_sha:
+    if not base_tip_sha or not head_sha:
         raise TargetResolutionError(f"PR #{pr_number} payload missing base/head SHA")
 
-    _ensure_commit_available(repo_root, base_sha)
+    _ensure_commit_available(repo_root, base_tip_sha)
     _ensure_commit_available(repo_root, head_sha)
-    changed_paths, non_test_loc = _numstat_loc(repo_root, [base_sha, head_sha])
+    merge_base_proc = _run_git(["merge-base", base_tip_sha, head_sha], repo_root)
+    if merge_base_proc.returncode != 0:
+        raise TargetResolutionError(
+            f"no merge-base between PR #{pr_number} base {base_tip_sha!r} and head {head_sha!r}: "
+            f"{merge_base_proc.stderr.strip()}"
+        )
+    merge_base_sha = merge_base_proc.stdout.strip()
+    changed_paths, non_test_loc = _numstat_loc(repo_root, [merge_base_sha, head_sha])
     return ReviewTarget(
         mode="pr",
-        base_sha=base_sha,
+        base_sha=merge_base_sha,
         head_sha=head_sha,
         changed_paths=changed_paths,
         non_test_loc=non_test_loc,
         clean_tree=False,
-        description=f"PR #{pr_number}: {head_ref_name}@{head_sha[:12]} vs actual base {base_ref_name}@{base_sha[:12]}",
+        description=(
+            f"PR #{pr_number}: {head_ref_name}@{head_sha[:12]} vs merge-base {merge_base_sha[:12]} "
+            f"(base tip {base_ref_name}@{base_tip_sha[:12]})"
+        ),
     )
 
 

--- a/scripts/review/target_resolution.py
+++ b/scripts/review/target_resolution.py
@@ -1,0 +1,332 @@
+"""Deterministic review-target selection.
+
+Four explicit modes — ``local`` / ``commit`` / ``branch`` / ``pr`` — chosen
+by the caller, never inferred from working-tree state. This matters because
+a clean working tree under ``local`` mode must never be read as proof that a
+commit or PR was reviewed: each mode records its own base/head SHAs so a
+report can't conflate "nothing uncommitted right now" with "the committed
+change was reviewed."
+
+Resolution never mutates repository or remote state. PR-mode resolution may
+``git fetch`` the two SHAs it needs (read-only), but never pushes — a target
+that only exists on the remote is a reason to fetch, not to push a local
+branch just so a diff exists.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.common.git_context import sanitized_git_env
+
+TEST_DIR_MARKERS = ("tests/", "__tests__/", "test/")
+TEST_FILE_PREFIXES = ("test_",)
+TEST_FILE_SUFFIXES = (
+    "_test.py",
+    ".test.ts",
+    ".test.tsx",
+    ".test.js",
+    ".test.jsx",
+    ".spec.ts",
+    ".spec.tsx",
+    ".spec.js",
+    ".spec.jsx",
+)
+
+
+class TargetResolutionError(RuntimeError):
+    """A review target could not be resolved deterministically."""
+
+
+@dataclass(frozen=True)
+class ReviewTarget:
+    """One resolved review target. Immutable — the scope baseline freezes on it."""
+
+    mode: str
+    base_sha: str | None
+    head_sha: str | None
+    changed_paths: tuple[str, ...]
+    non_test_loc: int
+    clean_tree: bool
+    description: str
+
+
+def is_test_path(path: str) -> bool:
+    """True if ``path`` looks like a test file, for non-test LOC accounting."""
+    normalized = path.replace("\\", "/")
+    name = normalized.rsplit("/", 1)[-1]
+    if any(marker in f"{normalized}/" for marker in TEST_DIR_MARKERS):
+        return True
+    if name.startswith(TEST_FILE_PREFIXES):
+        return True
+    return any(name.endswith(suffix) for suffix in TEST_FILE_SUFFIXES)
+
+
+def _run_git(args: list[str], cwd: Path, *, timeout: float = 30.0) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=sanitized_git_env(),
+    )
+
+
+def _run_gh(args: list[str], cwd: Path, *, timeout: float = 30.0) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args],
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _rev_parse(repo_root: Path, ref: str) -> str:
+    proc = _run_git(["rev-parse", ref], repo_root)
+    if proc.returncode != 0:
+        raise TargetResolutionError(f"cannot resolve ref {ref!r}: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def _numstat_loc(repo_root: Path, diff_range: list[str]) -> tuple[tuple[str, ...], int]:
+    """Return (changed_paths, non_test_loc) for a ``git diff --numstat`` range."""
+    proc = _run_git(["diff", "--numstat", *diff_range], repo_root)
+    if proc.returncode != 0:
+        raise TargetResolutionError(f"git diff --numstat failed: {proc.stderr.strip()}")
+    changed: list[str] = []
+    loc = 0
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t", 2)
+        if len(parts) != 3:
+            continue
+        added_raw, removed_raw, path = parts
+        changed.append(path)
+        if is_test_path(path):
+            continue
+        # Binary files report "-" for both counts; they contribute 0 LOC
+        # but still count as a changed path.
+        added = int(added_raw) if added_raw.isdigit() else 0
+        removed = int(removed_raw) if removed_raw.isdigit() else 0
+        loc += added + removed
+    return tuple(changed), loc
+
+
+def _untracked_paths(repo_root: Path) -> tuple[str, ...]:
+    proc = _run_git(["status", "--porcelain", "--untracked-files=all"], repo_root)
+    if proc.returncode != 0:
+        raise TargetResolutionError(f"git status failed: {proc.stderr.strip()}")
+    untracked = []
+    for line in proc.stdout.splitlines():
+        if line.startswith("??"):
+            untracked.append(line[3:].strip())
+    return tuple(untracked)
+
+
+def _untracked_loc(repo_root: Path, paths: tuple[str, ...]) -> int:
+    total = 0
+    for rel_path in paths:
+        if is_test_path(rel_path):
+            continue
+        full = repo_root / rel_path
+        if not full.is_file():
+            continue
+        try:
+            text = full.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        total += len(text.splitlines())
+    return total
+
+
+def resolve_local_target(repo_root: Path) -> ReviewTarget:
+    """Staged + unstaged + untracked working-tree changes, diffed against HEAD.
+
+    ``base_sha``/``head_sha`` are ``None`` — this mode has no committed
+    endpoints by definition. A caller must not treat a ``clean_tree=True``
+    result here as evidence that a *commit* or *PR* was reviewed; that
+    requires a separate ``commit``/``branch``/``pr`` resolution.
+    """
+    tracked_changed, tracked_loc = _numstat_loc(repo_root, ["HEAD"])
+    untracked = _untracked_paths(repo_root)
+    untracked_loc = _untracked_loc(repo_root, untracked)
+    changed_paths = tuple(dict.fromkeys([*tracked_changed, *untracked]))
+    clean_tree = len(changed_paths) == 0
+    description = (
+        "local working tree: no staged/unstaged/untracked changes (nothing to review)"
+        if clean_tree
+        else f"local working tree: {len(changed_paths)} changed path(s) vs HEAD"
+    )
+    return ReviewTarget(
+        mode="local",
+        base_sha=None,
+        head_sha=None,
+        changed_paths=changed_paths,
+        non_test_loc=tracked_loc + untracked_loc,
+        clean_tree=clean_tree,
+        description=description,
+    )
+
+
+def resolve_commit_target(repo_root: Path, commit: str) -> ReviewTarget:
+    """A single already-made commit, diffed against its first parent."""
+    head_sha = _rev_parse(repo_root, commit)
+    base_proc = _run_git(["rev-parse", f"{commit}^"], repo_root)
+    if base_proc.returncode != 0:
+        raise TargetResolutionError(
+            f"cannot resolve parent of {commit!r} (root commit is not supported): {base_proc.stderr.strip()}"
+        )
+    base_sha = base_proc.stdout.strip()
+    changed_paths, non_test_loc = _numstat_loc(repo_root, [base_sha, head_sha])
+    return ReviewTarget(
+        mode="commit",
+        base_sha=base_sha,
+        head_sha=head_sha,
+        changed_paths=changed_paths,
+        non_test_loc=non_test_loc,
+        clean_tree=False,
+        description=f"commit {head_sha[:12]} vs parent {base_sha[:12]}",
+    )
+
+
+def resolve_branch_target(repo_root: Path, branch: str, base: str) -> ReviewTarget:
+    """A branch diffed against an explicit base ref (merge-base semantics)."""
+    head_sha = _rev_parse(repo_root, branch)
+    base_ref_sha = _rev_parse(repo_root, base)
+    merge_base_proc = _run_git(["merge-base", base_ref_sha, head_sha], repo_root)
+    if merge_base_proc.returncode != 0:
+        raise TargetResolutionError(
+            f"no merge-base between {base!r} and {branch!r}: {merge_base_proc.stderr.strip()}"
+        )
+    merge_base_sha = merge_base_proc.stdout.strip()
+    changed_paths, non_test_loc = _numstat_loc(repo_root, [merge_base_sha, head_sha])
+    return ReviewTarget(
+        mode="branch",
+        base_sha=merge_base_sha,
+        head_sha=head_sha,
+        changed_paths=changed_paths,
+        non_test_loc=non_test_loc,
+        clean_tree=False,
+        description=f"branch {branch} vs base {base} (merge-base {merge_base_sha[:12]})",
+    )
+
+
+def _ensure_commit_available(repo_root: Path, sha: str) -> None:
+    check = _run_git(["cat-file", "-e", f"{sha}^{{commit}}"], repo_root)
+    if check.returncode == 0:
+        return
+    # Read-only fetch of the missing object — never a push, never a new local branch.
+    fetch = _run_git(["fetch", "origin", sha], repo_root, timeout=60.0)
+    if fetch.returncode != 0:
+        raise TargetResolutionError(f"commit {sha!r} unreachable locally and fetch failed: {fetch.stderr.strip()}")
+    recheck = _run_git(["cat-file", "-e", f"{sha}^{{commit}}"], repo_root)
+    if recheck.returncode != 0:
+        raise TargetResolutionError(f"commit {sha!r} still unreachable after fetch")
+
+
+def resolve_pr_target(repo_root: Path, pr_number: int) -> ReviewTarget:
+    """A PR's diff using its actual base (not an assumed default branch)."""
+    proc = _run_gh(
+        [
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "number,baseRefName,baseRefOid,headRefName,headRefOid",
+        ],
+        repo_root,
+    )
+    if proc.returncode != 0:
+        raise TargetResolutionError(f"gh pr view failed for #{pr_number}: {proc.stderr.strip() or proc.stdout.strip()}")
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise TargetResolutionError(f"invalid JSON from gh pr view #{pr_number}") from exc
+
+    base_sha = str(payload.get("baseRefOid") or "").strip()
+    head_sha = str(payload.get("headRefOid") or "").strip()
+    base_ref_name = str(payload.get("baseRefName") or "").strip()
+    head_ref_name = str(payload.get("headRefName") or "").strip()
+    if not base_sha or not head_sha:
+        raise TargetResolutionError(f"PR #{pr_number} payload missing base/head SHA")
+
+    _ensure_commit_available(repo_root, base_sha)
+    _ensure_commit_available(repo_root, head_sha)
+    changed_paths, non_test_loc = _numstat_loc(repo_root, [base_sha, head_sha])
+    return ReviewTarget(
+        mode="pr",
+        base_sha=base_sha,
+        head_sha=head_sha,
+        changed_paths=changed_paths,
+        non_test_loc=non_test_loc,
+        clean_tree=False,
+        description=f"PR #{pr_number}: {head_ref_name}@{head_sha[:12]} vs actual base {base_ref_name}@{base_sha[:12]}",
+    )
+
+
+def resolve_review_target(
+    mode: str,
+    repo_root: Path,
+    *,
+    commit: str | None = None,
+    branch: str | None = None,
+    base: str | None = None,
+    pr_number: int | None = None,
+) -> ReviewTarget:
+    """Dispatch to the mode-specific resolver. ``mode`` must be explicit."""
+    if mode == "local":
+        return resolve_local_target(repo_root)
+    if mode == "commit":
+        if not commit:
+            raise TargetResolutionError("mode=commit requires --commit")
+        return resolve_commit_target(repo_root, commit)
+    if mode == "branch":
+        if not branch or not base:
+            raise TargetResolutionError("mode=branch requires --branch and --base")
+        return resolve_branch_target(repo_root, branch, base)
+    if mode == "pr":
+        if pr_number is None:
+            raise TargetResolutionError("mode=pr requires --pr")
+        return resolve_pr_target(repo_root, pr_number)
+    raise TargetResolutionError(f"unknown mode {mode!r} (expected local/commit/branch/pr)")
+
+
+def _main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", required=True, choices=["local", "commit", "branch", "pr"])
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--commit")
+    parser.add_argument("--branch")
+    parser.add_argument("--base")
+    parser.add_argument("--pr", type=int, dest="pr_number")
+    args = parser.parse_args(argv)
+
+    try:
+        target = resolve_review_target(
+            args.mode,
+            Path(args.repo_root).resolve(),
+            commit=args.commit,
+            branch=args.branch,
+            base=args.base,
+            pr_number=args.pr_number,
+        )
+    except TargetResolutionError as exc:
+        print(json.dumps({"error": str(exc)}), file=__import__("sys").stderr)
+        return 1
+
+    print(json.dumps(target.__dict__, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -1,0 +1,145 @@
+"""Tests for scripts/review/closeout_cli.py — the state-file-backed CLI that
+wires target resolution, scope baseline, findings, and reviewer resolution
+together for the local-code-review skill."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.common.git_context import sanitized_git_env
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    # sanitized_git_env() strips GIT_DIR/GIT_WORK_TREE/etc — without it, running
+    # this suite from inside a `git commit` pre-commit hook leaks the OUTER
+    # repo's git env into these calls and silently operates on the wrong repo.
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), check=True, capture_output=True, text=True, env=sanitized_git_env()
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "trunk")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "app.py").write_text("print('v1')\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _run_cli(state_file: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    project_root = Path(__file__).resolve().parent.parent
+    return subprocess.run(
+        [".venv/bin/python", "-m", "scripts.review.closeout_cli", "--state-file", str(state_file), *args],
+        cwd=str(project_root),
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_full_flow_target_freeze_expansion_cycle_reviewer_findings(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    state_file = tmp_path / "state.json"
+
+    target_proc = _run_cli(state_file, "target", "--mode", "local", "--repo-root", str(repo))
+    assert target_proc.returncode == 0, target_proc.stderr
+    target_payload = json.loads(target_proc.stdout)
+    assert target_payload["changed_paths"] == ["feature.py"]
+
+    freeze_proc = _run_cli(
+        state_file,
+        "freeze",
+        "--issue",
+        "#5283",
+        "--intended-behavior",
+        "add feature",
+        "--non-goals",
+        "no refactors",
+        "--owner-boundary",
+        "repo root",
+        "--review-profile",
+        "infra",
+        "--risk",
+        "low",
+    )
+    assert freeze_proc.returncode == 0, freeze_proc.stderr
+    assert "#5283" in freeze_proc.stdout
+
+    # No further local changes yet — expansion breaker must not trigger.
+    expansion_proc = _run_cli(state_file, "check-expansion", "--repo-root", str(repo))
+    assert json.loads(expansion_proc.stdout)["triggered"] is False
+
+    # Simulate review-triggered scope creep: many more files than 2x baseline.
+    for i in range(5):
+        (repo / f"extra{i}.py").write_text("x = 1\n" * 20, encoding="utf-8")
+    expansion_proc2 = _run_cli(state_file, "check-expansion", "--repo-root", str(repo))
+    result2 = json.loads(expansion_proc2.stdout)
+    assert result2["triggered"] is True
+
+    cycle_proc = _run_cli(state_file, "record-cycle", "--outstanding-count", "5")
+    assert json.loads(cycle_proc.stdout)["triggered"] is False
+    cycle_proc2 = _run_cli(state_file, "record-cycle", "--outstanding-count", "5")
+    cycle_proc3 = _run_cli(state_file, "record-cycle", "--outstanding-count", "5")
+    assert json.loads(cycle_proc3.stdout)["triggered"] is True
+
+    reviewer_proc = _run_cli(state_file, "resolve-reviewer", "--author-model", "claude")
+    assert reviewer_proc.returncode == 0, reviewer_proc.stderr
+    resolution = json.loads(reviewer_proc.stdout)
+    assert resolution["selected"]["name"] == "deepseek-v4-flash"
+
+    raise_proc = _run_cli(state_file, "finding", "raise", "--id", "F1", "--summary", "issue", "--source", "reviewer:grok")
+    assert raise_proc.returncode == 0, raise_proc.stderr
+    apply_before_adjudicate = _run_cli(state_file, "finding", "apply", "--id", "F1")
+    assert apply_before_adjudicate.returncode != 0
+
+    adjudicate_proc = _run_cli(
+        state_file, "finding", "adjudicate", "--id", "F1", "--disposition", "in_scope_blocker", "--rationale", "real bug"
+    )
+    assert adjudicate_proc.returncode == 0, adjudicate_proc.stderr
+    apply_proc = _run_cli(state_file, "finding", "apply", "--id", "F1")
+    assert apply_proc.returncode == 0, apply_proc.stderr
+
+    report_proc = _run_cli(state_file, "finding", "report")
+    assert "F1" in report_proc.stdout
+    assert "applied" in report_proc.stdout
+
+    # State persisted across every invocation via one JSON file.
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state["baseline"]["issue_ref"] == "#5283"
+    assert state["cycle_outstanding_counts"] == [5, 5, 5]
+    assert len(state["findings"]) == 3  # raised, adjudicated, applied
+
+
+def test_check_expansion_before_freeze_errors(tmp_path):
+    repo = _init_repo(tmp_path)
+    state_file = tmp_path / "state.json"
+    proc = _run_cli(state_file, "check-expansion", "--repo-root", str(repo))
+    assert proc.returncode != 0
+    assert "freeze" in proc.stderr
+
+
+def test_freeze_before_target_errors(tmp_path):
+    state_file = tmp_path / "state.json"
+    proc = _run_cli(
+        state_file,
+        "freeze",
+        "--issue",
+        "#1",
+        "--intended-behavior",
+        "x",
+        "--non-goals",
+        "y",
+        "--owner-boundary",
+        "z",
+    )
+    assert proc.returncode != 0
+    assert "target" in proc.stderr

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -223,3 +223,79 @@ def test_freeze_before_target_errors(tmp_path):
     )
     assert proc.returncode != 0
     assert "target" in proc.stderr
+
+
+def _freeze_kwargs(issue: str = "#5283") -> tuple[str, ...]:
+    return (
+        "freeze",
+        "--issue",
+        issue,
+        "--intended-behavior",
+        "add feature",
+        "--non-goals",
+        "no refactors",
+        "--owner-boundary",
+        "repo root",
+    )
+
+
+def test_target_and_freeze_are_immutable_once_baseline_frozen(tmp_path):
+    """Once a baseline is frozen, `target` must reject replacing the target
+    and `freeze` must reject a second call — both must fail without mutating
+    the original target, baseline, cycle history, or findings. A new review
+    must use a new state file instead."""
+    repo = _init_repo(tmp_path)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    state_file = tmp_path / "state.json"
+
+    target_proc = _run_cli(state_file, "target", "--mode", "local", "--repo-root", str(repo))
+    assert target_proc.returncode == 0, target_proc.stderr
+
+    freeze_proc = _run_cli(state_file, *_freeze_kwargs())
+    assert freeze_proc.returncode == 0, freeze_proc.stderr
+
+    cycle_proc = _run_cli(state_file, "record-cycle", "--outstanding-count", "3")
+    assert cycle_proc.returncode == 0, cycle_proc.stderr
+    raise_proc = _run_cli(state_file, "finding", "raise", "--id", "F1", "--summary", "issue", "--source", "self-review")
+    assert raise_proc.returncode == 0, raise_proc.stderr
+
+    state_before = json.loads(state_file.read_text(encoding="utf-8"))
+
+    # Adding more files after freeze, then trying to re-target, must be rejected.
+    (repo / "extra.py").write_text("x = 1\n", encoding="utf-8")
+    retarget_proc = _run_cli(state_file, "target", "--mode", "local", "--repo-root", str(repo))
+    assert retarget_proc.returncode != 0
+    assert "immutable" in retarget_proc.stderr or "already frozen" in retarget_proc.stderr
+
+    refreeze_proc = _run_cli(state_file, *_freeze_kwargs(issue="#9999"))
+    assert refreeze_proc.returncode != 0
+    assert "already frozen" in refreeze_proc.stderr
+
+    state_after = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state_after == state_before
+    assert state_after["target"]["changed_paths"] == ["feature.py"]
+    assert state_after["baseline"]["issue_ref"] == "#5283"
+    assert state_after["cycle_outstanding_counts"] == [3]
+    assert len(state_after["findings"]) == 1
+
+
+def test_record_cycle_rejects_negative_outstanding_count(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    state_file = tmp_path / "state.json"
+
+    _run_cli(state_file, "target", "--mode", "local", "--repo-root", str(repo))
+    _run_cli(state_file, *_freeze_kwargs())
+    ok_proc = _run_cli(state_file, "record-cycle", "--outstanding-count", "2")
+    assert ok_proc.returncode == 0, ok_proc.stderr
+
+    state_before = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state_before["cycle_outstanding_counts"] == [2]
+
+    bad_proc = _run_cli(state_file, "record-cycle", "--outstanding-count", "-1")
+    assert bad_proc.returncode != 0
+    assert "outstanding-count" in bad_proc.stderr
+
+    state_after = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state_after == state_before
+    assert state_after["cycle_outstanding_counts"] == [2]

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -119,6 +119,86 @@ def test_full_flow_target_freeze_expansion_cycle_reviewer_findings(tmp_path):
     assert len(state["findings"]) == 3  # raised, adjudicated, applied
 
 
+def test_check_expansion_commit_mode_measures_committed_fixes_not_clean_tree(tmp_path):
+    """A commit/branch/pr-mode baseline must be re-measured against the
+    committed post-fix head, not the (always-clean) local working tree.
+
+    Before the fix, check-expansion always called resolve_local_target,
+    which reads clean_tree=True/no changed_paths for *any* committed fix —
+    silently hiding real scope creep that landed as a commit rather than an
+    uncommitted change.
+    """
+    repo = _init_repo(tmp_path)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "feature.py")
+    _git(repo, "commit", "-q", "-m", "feature commit")
+    state_file = tmp_path / "state.json"
+
+    target_proc = _run_cli(state_file, "target", "--mode", "commit", "--commit", "HEAD", "--repo-root", str(repo))
+    assert target_proc.returncode == 0, target_proc.stderr
+    assert json.loads(target_proc.stdout)["changed_paths"] == ["feature.py"]
+
+    freeze_proc = _run_cli(
+        state_file,
+        "freeze",
+        "--issue",
+        "#5286",
+        "--intended-behavior",
+        "add feature",
+        "--non-goals",
+        "no refactors",
+        "--owner-boundary",
+        "repo root",
+    )
+    assert freeze_proc.returncode == 0, freeze_proc.stderr
+
+    # Positive: no further commits yet — re-diffing frozen base vs current
+    # HEAD (still the same commit) must not trigger.
+    expansion_clean = _run_cli(state_file, "check-expansion", "--repo-root", str(repo), "--current-head", "HEAD")
+    assert expansion_clean.returncode == 0, expansion_clean.stderr
+    assert json.loads(expansion_clean.stdout)["triggered"] is False
+
+    # Negative (the bug this guards): commit review-triggered scope creep,
+    # leaving the working tree clean again. A resolve_local_target-based
+    # check would see clean_tree=True and silently miss this.
+    for i in range(5):
+        (repo / f"extra{i}.py").write_text("x = 1\n" * 20, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "review-triggered fix that overshot scope")
+    assert _git(repo, "status", "--porcelain").stdout.strip() == ""  # tree is clean
+
+    expansion_after_commit = _run_cli(state_file, "check-expansion", "--repo-root", str(repo), "--current-head", "HEAD")
+    assert expansion_after_commit.returncode == 0, expansion_after_commit.stderr
+    result = json.loads(expansion_after_commit.stdout)
+    assert result["triggered"] is True
+
+
+def test_check_expansion_non_local_mode_requires_current_head(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "feature.py")
+    _git(repo, "commit", "-q", "-m", "feature commit")
+    state_file = tmp_path / "state.json"
+
+    _run_cli(state_file, "target", "--mode", "commit", "--commit", "HEAD", "--repo-root", str(repo))
+    _run_cli(
+        state_file,
+        "freeze",
+        "--issue",
+        "#5286",
+        "--intended-behavior",
+        "add feature",
+        "--non-goals",
+        "no refactors",
+        "--owner-boundary",
+        "repo root",
+    )
+
+    proc = _run_cli(state_file, "check-expansion", "--repo-root", str(repo))
+    assert proc.returncode != 0
+    assert "--current-head" in proc.stderr
+
+
 def test_check_expansion_before_freeze_errors(tmp_path):
     repo = _init_repo(tmp_path)
     state_file = tmp_path / "state.json"

--- a/tests/test_review_findings_ledger.py
+++ b/tests/test_review_findings_ledger.py
@@ -1,0 +1,129 @@
+"""Tests for scripts/review/findings.py — append-only adjudication ledger.
+
+Named distinctly from tests/test_review_findings.py, which covers the
+unrelated curriculum-content pipeline.review_findings module.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.review.findings import FindingsLedger, FindingsLedgerError
+
+
+def test_raise_finding_then_list_all_ids():
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="bug one", source="reviewer:deepseek")
+    ledger.raise_finding("F2", summary="bug two", source="reviewer:deepseek")
+    assert ledger.all_finding_ids() == ("F1", "F2")
+
+
+def test_duplicate_raise_rejected():
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="bug one", source="reviewer:deepseek")
+    with pytest.raises(FindingsLedgerError):
+        ledger.raise_finding("F1", summary="different bug reusing the id", source="reviewer:grok")
+
+
+def test_adjudicate_unknown_finding_rejected():
+    ledger = FindingsLedger()
+    with pytest.raises(FindingsLedgerError):
+        ledger.adjudicate("ghost", disposition="follow_up", rationale="n/a")
+
+
+def test_adjudicate_requires_non_empty_rationale():
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="bug", source="reviewer:grok")
+    with pytest.raises(FindingsLedgerError):
+        ledger.adjudicate("F1", disposition="follow_up", rationale="   ")
+
+
+def test_apply_requires_adjudication_first():
+    """The core anti-'apply as-is' guard: no adjudication, no apply."""
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="bug", source="reviewer:grok")
+    with pytest.raises(FindingsLedgerError):
+        ledger.apply("F1")
+
+
+def test_apply_requires_in_scope_blocker_disposition():
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="bug", source="reviewer:grok")
+    ledger.adjudicate("F1", disposition="follow_up", rationale="not urgent, track separately")
+    with pytest.raises(FindingsLedgerError):
+        ledger.apply("F1")
+
+
+def test_apply_succeeds_after_in_scope_blocker_adjudication():
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="bug", source="reviewer:grok")
+    ledger.adjudicate("F1", disposition="in_scope_blocker", rationale="breaks the acceptance criteria")
+    ledger.apply("F1")
+    assert ledger.is_applied("F1") is True
+
+
+def test_stop_and_escalate_cannot_be_applied():
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="bug", source="reviewer:grok")
+    ledger.adjudicate("F1", disposition="stop_and_escalate", rationale="fix crosses owner boundary")
+    with pytest.raises(FindingsLedgerError):
+        ledger.apply("F1")
+
+
+def test_re_adjudication_preserves_prior_history_not_overwrite():
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="bug", source="reviewer:grok")
+    ledger.adjudicate("F1", disposition="follow_up", rationale="initial pass: looked minor")
+    ledger.adjudicate("F1", disposition="in_scope_blocker", rationale="cycle 2: actually blocks acceptance criteria")
+    adjudications = [e for e in ledger.events() if e.finding_id == "F1" and e.event == "adjudicated"]
+    assert len(adjudications) == 2
+    assert adjudications[0].rationale == "initial pass: looked minor"
+    assert adjudications[1].rationale == "cycle 2: actually blocks acceptance criteria"
+    # latest_disposition reflects the most recent, but the first is not erased.
+    assert ledger.latest_disposition("F1") == "in_scope_blocker"
+
+
+def test_skip_requires_raised_and_rationale():
+    ledger = FindingsLedger()
+    with pytest.raises(FindingsLedgerError):
+        ledger.skip("ghost", rationale="n/a")
+    ledger.raise_finding("F1", summary="bug", source="reviewer:grok")
+    with pytest.raises(FindingsLedgerError):
+        ledger.skip("F1", rationale="")
+    ledger.skip("F1", rationale="deferred to follow-up ticket #9999")
+    assert any(e.event == "skipped" for e in ledger.events())
+
+
+def test_unadjudicated_surfaces_findings_with_no_verdict():
+    """Simulates 'challenger/reviewer unavailable' — the finding must show up,
+    not vanish from the report."""
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="reviewer was down for this one", source="self-review")
+    ledger.raise_finding("F2", summary="this one got adjudicated", source="reviewer:grok")
+    ledger.adjudicate("F2", disposition="follow_up", rationale="minor style nit")
+    assert ledger.unadjudicated() == ("F1",)
+
+
+def test_render_report_includes_every_finding_and_full_history():
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="unadjudicated finding", source="self-review")
+    ledger.raise_finding("F2", summary="applied finding", source="reviewer:grok")
+    ledger.adjudicate("F2", disposition="in_scope_blocker", rationale="real bug")
+    ledger.apply("F2")
+    ledger.raise_finding("F3", summary="skipped finding", source="reviewer:grok")
+    ledger.skip("F3", rationale="false positive, writer's choice was correct")
+
+    report = ledger.render_report()
+    assert "F1" in report and "UNADJUDICATED" in report
+    assert "F2" in report and "applied" in report
+    assert "F3" in report and "skipped" in report and "false positive" in report
+
+
+def test_render_report_empty_ledger():
+    ledger = FindingsLedger()
+    assert ledger.render_report() == "(no findings raised)"

--- a/tests/test_review_findings_ledger.py
+++ b/tests/test_review_findings_ledger.py
@@ -127,3 +127,20 @@ def test_render_report_includes_every_finding_and_full_history():
 def test_render_report_empty_ledger():
     ledger = FindingsLedger()
     assert ledger.render_report() == "(no findings raised)"
+
+
+def test_render_report_raised_then_skipped_still_shows_unadjudicated():
+    """A skip is not an adjudication — latest_disposition stays None, so the
+    report must still flag the finding as UNADJUDICATED even though it also
+    carries a skip rationale. Before the fix, render_report only checked
+    ``len(history) == 1``, so a raised-then-skipped finding (history length 2)
+    silently lost its UNADJUDICATED marker."""
+    ledger = FindingsLedger()
+    ledger.raise_finding("F1", summary="raised then skipped, never adjudicated", source="self-review")
+    ledger.skip("F1", rationale="deferred without a reviewer verdict")
+
+    assert ledger.latest_disposition("F1") is None
+    report = ledger.render_report()
+    assert "F1" in report
+    assert "skipped: deferred without a reviewer verdict" in report
+    assert "UNADJUDICATED" in report

--- a/tests/test_review_reviewer_resolver.py
+++ b/tests/test_review_reviewer_resolver.py
@@ -8,13 +8,17 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.review.reviewer_resolver import (
+    AMBIGUOUS_AUTHOR_FAMILY,
+    CONFLICTING_AUTHOR_FAMILY,
     DEEPSEEK_V4_FLASH,
     GLM,
     GROK_4_5,
     POOL,
     QWEN,
+    UNKNOWN_AUTHOR_FAMILY,
     ResolverInputs,
     evaluate_candidate,
+    resolve_author_family,
     resolve_family,
     resolve_reviewer,
 )
@@ -48,8 +52,6 @@ def test_family_resolution_across_model_and_harness_aliases():
         "deepseek-tools": "deepseek",
         "deepseek-v4-flash": "deepseek",
         "deepseek-v4-pro": "deepseek",
-        "cursor": "cursor",
-        "cursor-tools": "cursor",
         "pool": "poolside",
         "glm": "zhipu",
         "glm-5.2": "zhipu",
@@ -63,6 +65,108 @@ def test_family_resolution_across_model_and_harness_aliases():
 def test_family_resolution_unknown_and_empty():
     assert resolve_family("") == "unknown"
     assert resolve_family("some-made-up-seat-xyz") == "unknown"
+
+
+def test_family_resolution_bare_cursor_is_not_a_synthetic_family():
+    """Cursor is a multi-model harness, not a model family on its own — the
+    bare harness name must resolve as unrecognized via resolve_family, same
+    as any other unmapped string. Disambiguating it is resolve_author_family's
+    job (see the Cursor+GPT / Cursor+Claude / ambiguous / conflict fixtures
+    below), not a synthetic "cursor" family entry."""
+    assert resolve_family("cursor") == "unknown"
+    assert resolve_family("cursor-tools") == "unknown"
+
+
+# --- author identity resolution: ambiguous multi-model harnesses --------------
+
+def test_resolve_author_family_cursor_plus_gpt_resolves_openai():
+    assert resolve_author_family("cursor:gpt-5.6-sol") == "openai"
+
+
+def test_resolve_author_family_cursor_plus_claude_resolves_anthropic():
+    assert resolve_author_family("cursor:claude-opus-4-8") == "anthropic"
+
+
+def test_resolve_author_family_bare_cursor_with_no_override_is_ambiguous():
+    assert resolve_author_family("cursor") == AMBIGUOUS_AUTHOR_FAMILY
+    assert resolve_author_family("cursor-tools") == AMBIGUOUS_AUTHOR_FAMILY
+
+
+def test_resolve_author_family_bare_cursor_with_validated_override_resolves():
+    """A bare ambiguous-harness identity can be disambiguated by an explicit,
+    validated author_family override (e.g. from inspecting session logs)."""
+    assert resolve_author_family("cursor", author_family="anthropic") == "anthropic"
+
+
+def test_resolve_author_family_bare_cursor_with_invalid_override_stays_ambiguous():
+    """An override that isn't a recognized concrete family does not count as
+    "validated" — it must not silently rescue the ambiguous state."""
+    assert resolve_author_family("cursor", author_family="not-a-real-family") == AMBIGUOUS_AUTHOR_FAMILY
+
+
+def test_resolve_author_family_unknown_identity():
+    assert resolve_author_family("") == UNKNOWN_AUTHOR_FAMILY
+    assert resolve_author_family("some-made-up-seat-xyz") == UNKNOWN_AUTHOR_FAMILY
+
+
+def test_resolve_author_family_conflicting_signals():
+    """The model embedded in a Cursor composite and an explicit author_family
+    override disagreeing is a conflict, not a silent pick of either side."""
+    assert resolve_author_family("cursor:gpt-5.6-sol", author_family="anthropic") == CONFLICTING_AUTHOR_FAMILY
+
+
+def test_resolve_author_family_fixed_family_alias_unaffected():
+    """Ordinary, non-ambiguous seats keep resolving exactly as before —
+    the ambiguous-harness handling doesn't touch fixed-family aliases."""
+    assert resolve_author_family("claude") == "anthropic"
+    assert resolve_author_family("deepseek-v4-pro") == "deepseek"
+    assert resolve_author_family("grok-build") == "xai"
+
+
+# --- resolve_reviewer fail-closed on unresolved author identity ---------------
+
+def test_resolve_reviewer_fails_closed_for_bare_ambiguous_cursor_author():
+    resolution = resolve_reviewer(ResolverInputs(author_model="cursor"))
+    assert resolution.selected is None
+    assert resolution.trace == ()
+    assert resolution.advisory == ()
+    assert resolution.fail_closed_reason is not None
+    assert "ambiguous" in resolution.fail_closed_reason.lower()
+
+
+def test_resolve_reviewer_fails_closed_for_unknown_author():
+    resolution = resolve_reviewer(ResolverInputs(author_model="totally-unrecognized-seat"))
+    assert resolution.selected is None
+    assert resolution.fail_closed_reason is not None
+    assert "unknown" in resolution.fail_closed_reason.lower()
+
+
+def test_resolve_reviewer_fails_closed_for_conflicting_author_identity():
+    resolution = resolve_reviewer(
+        ResolverInputs(author_model="cursor:gpt-5.6-sol", author_family="anthropic")
+    )
+    assert resolution.selected is None
+    assert resolution.fail_closed_reason is not None
+    assert "conflict" in resolution.fail_closed_reason.lower()
+
+
+def test_resolve_reviewer_cursor_plus_gpt_picks_deepseek_same_as_codex_author():
+    """A disambiguated Cursor+GPT author must be treated exactly like a
+    native codex author for cross-family purposes: deepseek-v4-flash formally
+    selected, openai_frontier advisory-only (same family as the real model)."""
+    resolution = resolve_reviewer(ResolverInputs(author_model="cursor:gpt-5.6-sol"))
+    assert resolution.fail_closed_reason is None
+    assert resolution.selected is not None
+    assert resolution.selected.name == "deepseek-v4-flash"
+    assert len(resolution.advisory) == 1
+    assert resolution.advisory[0].name == "openai_frontier"
+
+
+def test_resolve_reviewer_cursor_plus_claude_picks_deepseek():
+    resolution = resolve_reviewer(ResolverInputs(author_model="cursor:claude-opus-4-8"))
+    assert resolution.fail_closed_reason is None
+    assert resolution.selected is not None
+    assert resolution.selected.name == "deepseek-v4-flash"
 
 
 # --- default code ladder: cross-family selection ------------------------------

--- a/tests/test_review_reviewer_resolver.py
+++ b/tests/test_review_reviewer_resolver.py
@@ -1,0 +1,268 @@
+"""Tests for scripts/review/reviewer_resolver.py — cross-family reviewer resolution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.review.reviewer_resolver import (
+    DEEPSEEK_V4_FLASH,
+    GLM,
+    GROK_4_5,
+    POOL,
+    QWEN,
+    ResolverInputs,
+    evaluate_candidate,
+    resolve_family,
+    resolve_reviewer,
+)
+
+# --- family resolution across model x harness aliases -------------------------
+
+def test_family_resolution_across_model_and_harness_aliases():
+    cases = {
+        "claude": "anthropic",
+        "claude-tools": "anthropic",
+        "sonnet": "anthropic",
+        "opus": "anthropic",
+        "fable": "anthropic",
+        "codex": "openai",
+        "codex-tools": "openai",
+        "gpt-5.6-sol": "openai",
+        "gpt-5.6-terra": "openai",
+        "gpt-5.6-luna": "openai",
+        "gemini": "google",
+        "gemini-tools": "google",
+        "agy": "google",
+        "agy-tools": "google",
+        "gemma": "google",
+        "gemma-4-31b-it": "google",
+        "grok": "xai",
+        "grok-build": "xai",  # permanent historical alias
+        "grok-hermes": "xai",  # demoted hermes-hosted path, still xAI
+        "grok-tools": "xai",  # V7 writer/reviewer seat alias
+        "grok-4.5": "xai",
+        "deepseek": "deepseek",
+        "deepseek-tools": "deepseek",
+        "deepseek-v4-flash": "deepseek",
+        "deepseek-v4-pro": "deepseek",
+        "cursor": "cursor",
+        "cursor-tools": "cursor",
+        "pool": "poolside",
+        "glm": "zhipu",
+        "glm-5.2": "zhipu",
+        "qwen": "alibaba",
+        "qwen-tools": "alibaba",
+    }
+    for seat, expected_family in cases.items():
+        assert resolve_family(seat) == expected_family, f"{seat} -> expected {expected_family}"
+
+
+def test_family_resolution_unknown_and_empty():
+    assert resolve_family("") == "unknown"
+    assert resolve_family("some-made-up-seat-xyz") == "unknown"
+
+
+# --- default code ladder: cross-family selection ------------------------------
+
+def test_default_ladder_picks_deepseek_for_anthropic_author():
+    resolution = resolve_reviewer(ResolverInputs(author_model="claude"))
+    assert resolution.selected is not None
+    assert resolution.selected.name == "deepseek-v4-flash"
+    assert resolution.substitution_note is None
+
+
+def test_default_ladder_excludes_same_family_and_falls_to_next_rung():
+    """Author IS deepseek — deepseek-v4-flash must be excluded (same family),
+    falling through to grok-4.5."""
+    resolution = resolve_reviewer(ResolverInputs(author_model="deepseek-v4-pro"))
+    assert resolution.selected is not None
+    assert resolution.selected.name == "grok-4.5"
+    deepseek_trace = next(r for r in resolution.trace if r.name == "deepseek-v4-flash")
+    assert deepseek_trace.status == "excluded"
+    assert "same family" in deepseek_trace.reason
+    assert resolution.substitution_note is not None
+
+
+def test_default_ladder_grok_author_falls_to_deepseek():
+    resolution = resolve_reviewer(ResolverInputs(author_model="grok-build"))
+    assert resolution.selected is not None
+    assert resolution.selected.name == "deepseek-v4-flash"
+
+
+def test_default_ladder_codex_author_gets_deepseek_and_openai_frontier_is_advisory():
+    resolution = resolve_reviewer(ResolverInputs(author_model="codex"))
+    assert resolution.selected is not None
+    assert resolution.selected.name == "deepseek-v4-flash"
+    assert len(resolution.advisory) == 1
+    assert resolution.advisory[0].name == "openai_frontier"
+    assert resolution.advisory[0].concrete_model == "gpt-5.6-sol"
+    assert resolution.advisory[0].status == "advisory_only"
+
+
+def test_openai_frontier_resolves_to_concrete_model_regardless_of_author():
+    """Even for a non-OpenAI author, openai_frontier must resolve to a concrete
+    model (gpt-5.6-sol) rather than a bare label."""
+    resolution = resolve_reviewer(ResolverInputs(author_model="claude"))
+    frontier_entry = next(r for r in resolution.trace if r.name == "openai_frontier")
+    assert frontier_entry.concrete_model == "gpt-5.6-sol"
+
+
+def test_openai_frontier_never_becomes_the_formal_gate_for_openai_author():
+    """No matter what happens upstream, an OpenAI-family author must never
+    get openai_frontier as the `selected` (formal, blocking) reviewer."""
+    resolution = resolve_reviewer(ResolverInputs(author_model="gpt-5.6-terra"))
+    assert resolution.selected is None or resolution.selected.name != "openai_frontier"
+    assert any(r.name == "openai_frontier" and r.status == "advisory_only" for r in resolution.trace)
+
+
+def test_openai_frontier_is_a_formal_eligible_candidate_for_non_openai_author():
+    """For a non-OpenAI author, openai_frontier is a normal (non-advisory)
+    ladder candidate — just ranked last by default."""
+    resolution = resolve_reviewer(ResolverInputs(author_model="claude"))
+    frontier_entry = next(r for r in resolution.trace if r.name == "openai_frontier")
+    assert frontier_entry.status == "eligible"
+
+
+# --- health tie-break ---------------------------------------------------------
+
+def test_health_does_not_override_ladder_priority_across_rungs():
+    """Health is a tie-breaker AMONG QUALIFIED ROUTES at the same priority —
+    it must not silently reroute away from a healthy-ranked-first candidate
+    just because a routing snapshot marks it degraded. That would make health
+    a hard filter instead of a tie-breaker, and hide a real ladder-priority
+    decision behind lane-health noise."""
+    resolution = resolve_reviewer(
+        ResolverInputs(
+            author_model="claude",
+            routing_snapshot={"deepseek-v4-flash": "unhealthy"},
+        )
+    )
+    assert resolution.selected.name == "deepseek-v4-flash"
+    assert resolution.selected.health == "unhealthy"
+
+
+def test_health_breaks_genuine_ties_within_a_rung():
+    grok_variant = GROK_4_5
+    deepseek_variant = DEEPSEEK_V4_FLASH
+    same_rung_ladder = ((deepseek_variant, grok_variant),)
+    resolution = resolve_reviewer(
+        ResolverInputs(
+            author_model="claude",
+            routing_snapshot={"deepseek-v4-flash": "unhealthy", "grok-4.5": "healthy"},
+        ),
+        ladder=same_rung_ladder,
+    )
+    assert resolution.selected.name == "grok-4.5"
+
+
+def test_health_missing_signal_is_fail_open_not_excluded():
+    resolution = resolve_reviewer(ResolverInputs(author_model="claude", routing_snapshot={}))
+    assert resolution.selected.name == "deepseek-v4-flash"
+    resolution_none = resolve_reviewer(ResolverInputs(author_model="claude", routing_snapshot=None))
+    assert resolution_none.selected.name == "deepseek-v4-flash"
+
+
+# --- domain carve-out (folk content) -------------------------------------------
+
+def test_folk_content_domain_excludes_deepseek():
+    result = evaluate_candidate(
+        DEEPSEEK_V4_FLASH,
+        ResolverInputs(author_model="claude", domain="folk_content"),
+        author_family="anthropic",
+    )
+    assert result.status == "excluded"
+    assert "folk_content" in result.reason
+
+
+def test_non_folk_domain_does_not_exclude_deepseek():
+    result = evaluate_candidate(
+        DEEPSEEK_V4_FLASH,
+        ResolverInputs(author_model="claude", domain="code"),
+        author_family="anthropic",
+    )
+    assert result.status == "eligible"
+
+
+# --- fail-closed data-egress + hard cost exclusions ----------------------------
+
+def test_glm_excluded_when_data_egress_policy_unspecified_fail_closed():
+    result = evaluate_candidate(
+        GLM,
+        ResolverInputs(author_model="claude", data_egress_policy=None),
+        author_family="anthropic",
+    )
+    assert result.status == "excluded"
+    assert "fail-closed" in result.reason
+
+
+def test_glm_excluded_for_wrong_policy_value():
+    result = evaluate_candidate(
+        GLM,
+        ResolverInputs(author_model="claude", data_egress_policy="ci_automated"),
+        author_family="anthropic",
+    )
+    assert result.status == "excluded"
+
+
+def test_glm_eligible_only_for_matching_local_interactive_policy():
+    result = evaluate_candidate(
+        GLM,
+        ResolverInputs(author_model="claude", data_egress_policy="local_interactive"),
+        author_family="anthropic",
+    )
+    assert result.status == "eligible"
+
+
+def test_qwen_always_excluded_regardless_of_policy():
+    result = evaluate_candidate(
+        QWEN,
+        ResolverInputs(author_model="claude", data_egress_policy="local_interactive"),
+        author_family="anthropic",
+    )
+    assert result.status == "excluded"
+    assert "cost" in result.reason
+
+
+# --- required capabilities / isolation ------------------------------------------
+
+def test_missing_required_capability_excludes_candidate():
+    result = evaluate_candidate(
+        POOL,
+        ResolverInputs(author_model="claude", required_capabilities=frozenset({"vesum_mcp"})),
+        author_family="anthropic",
+    )
+    assert result.status == "excluded"
+    assert "capabilities" in result.reason
+
+
+def test_isolation_required_excludes_candidate_without_it():
+    result = evaluate_candidate(
+        GROK_4_5,
+        ResolverInputs(author_model="claude", isolation_required=True),
+        author_family="anthropic",
+    )
+    assert result.status == "excluded"
+    assert "isolation" in result.reason
+
+
+# --- receipt visibility ---------------------------------------------------------
+
+def test_trace_covers_every_ladder_candidate_for_receipt_visibility():
+    resolution = resolve_reviewer(ResolverInputs(author_model="claude"))
+    traced_names = {r.name for r in resolution.trace}
+    assert traced_names == {"deepseek-v4-flash", "grok-4.5", "pool", "openai_frontier"}
+
+
+def test_no_eligible_candidate_leaves_selected_none():
+    """An author family that happens to match every ladder rung (contrived,
+    via a single-candidate custom ladder) must not silently promote an
+    excluded/advisory candidate to selected."""
+    resolution = resolve_reviewer(
+        ResolverInputs(author_model="deepseek-v4-pro"),
+        ladder=((DEEPSEEK_V4_FLASH,),),
+    )
+    assert resolution.selected is None
+    assert resolution.trace[0].status == "excluded"

--- a/tests/test_review_scope_baseline.py
+++ b/tests/test_review_scope_baseline.py
@@ -1,0 +1,218 @@
+"""Tests for scripts/review/scope_baseline.py — frozen scope + breakers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.review.scope_baseline import (
+    ScopeBaseline,
+    check_contract_boundary_breaker,
+    check_cycle_convergence_breaker,
+    check_design_decision_breaker,
+    check_expansion_breaker,
+    classify_finding,
+    critical_override_applies,
+)
+from scripts.review.target_resolution import ReviewTarget
+
+
+def _target(*, changed_paths=("a.py", "b.py"), non_test_loc=40, mode="branch", clean_tree=False):
+    return ReviewTarget(
+        mode=mode,
+        base_sha="base123",
+        head_sha="head456",
+        changed_paths=changed_paths,
+        non_test_loc=non_test_loc,
+        clean_tree=clean_tree,
+        description="test target",
+    )
+
+
+def _baseline(**kwargs):
+    target = _target(**{k: v for k, v in kwargs.items() if k in ("changed_paths", "non_test_loc", "mode", "clean_tree")})
+    return ScopeBaseline.freeze(
+        issue_ref="#5283",
+        intended_behavior="do the thing",
+        non_goals="not that thing",
+        owner_boundary="scripts/review/**",
+        target=target,
+        review_profile="infra",
+        risk="medium",
+    )
+
+
+# --- freeze + render ---------------------------------------------------------
+
+def test_freeze_captures_target_snapshot():
+    baseline = _baseline()
+    assert baseline.frozen_files == {"a.py", "b.py"}
+    assert baseline.frozen_non_test_loc == 40
+
+
+def test_render_includes_all_required_fields():
+    baseline = _baseline()
+    rendered = baseline.render()
+    for expected in ("#5283", "do the thing", "not that thing", "scripts/review/**", "branch", "medium", "infra"):
+        assert expected in rendered
+
+
+def test_render_flags_clean_local_tree_as_not_commit_proof():
+    baseline = _baseline(mode="local", changed_paths=(), non_test_loc=0, clean_tree=True)
+    rendered = baseline.render()
+    assert "NOT evidence" in rendered
+
+
+def test_render_does_not_flag_committed_modes():
+    baseline = _baseline(mode="pr")
+    assert "NOT evidence" not in baseline.render()
+
+
+# --- expansion breaker: positive + negative fixtures --------------------------
+
+def test_expansion_breaker_does_not_trigger_within_2x():
+    baseline = _baseline(changed_paths=("a.py", "b.py"), non_test_loc=40)
+    result = check_expansion_breaker(baseline, frozenset({"a.py", "b.py", "c.py"}), 70)
+    assert result.triggered is False
+
+
+def test_expansion_breaker_triggers_on_file_count_over_2x():
+    baseline = _baseline(changed_paths=("a.py", "b.py"), non_test_loc=40)
+    result = check_expansion_breaker(baseline, frozenset({"a.py", "b.py", "c.py", "d.py", "e.py"}), 40)
+    assert result.triggered is True
+    assert "files" in result.reason
+
+
+def test_expansion_breaker_triggers_on_loc_over_2x():
+    baseline = _baseline(changed_paths=("a.py", "b.py"), non_test_loc=40)
+    result = check_expansion_breaker(baseline, frozenset({"a.py", "b.py"}), 90)
+    assert result.triggered is True
+    assert "LOC" in result.reason
+
+
+def test_expansion_breaker_zero_baseline_any_growth_trips():
+    baseline = _baseline(changed_paths=(), non_test_loc=0)
+    result = check_expansion_breaker(baseline, frozenset({"new.py"}), 5)
+    assert result.triggered is True
+
+
+def test_expansion_breaker_zero_baseline_no_growth_does_not_trip():
+    baseline = _baseline(changed_paths=(), non_test_loc=0)
+    result = check_expansion_breaker(baseline, frozenset(), 0)
+    assert result.triggered is False
+
+
+# --- cycle-convergence breaker: positive + negative fixtures ------------------
+
+def test_cycle_breaker_does_not_trigger_when_converging():
+    result = check_cycle_convergence_breaker([5, 3, 1, 0])
+    assert result.triggered is False
+
+
+def test_cycle_breaker_triggers_on_two_consecutive_stalls():
+    result = check_cycle_convergence_breaker([5, 5, 5])
+    assert result.triggered is True
+    assert "did not converge" in result.reason
+
+
+def test_cycle_breaker_triggers_when_findings_grow():
+    result = check_cycle_convergence_breaker([3, 4, 6])
+    assert result.triggered is True
+
+
+def test_cycle_breaker_single_stall_then_recovery_does_not_trigger():
+    result = check_cycle_convergence_breaker([5, 5, 2])
+    assert result.triggered is False
+
+
+def test_cycle_breaker_too_few_cycles_does_not_trigger():
+    result = check_cycle_convergence_breaker([5])
+    assert result.triggered is False
+    result2 = check_cycle_convergence_breaker([])
+    assert result2.triggered is False
+
+
+# --- contract/owner boundary + design-decision breakers -----------------------
+
+def test_contract_boundary_breaker_negative():
+    result = check_contract_boundary_breaker(changes_public_contract=False, crosses_owner_boundary=False)
+    assert result.triggered is False
+
+
+def test_contract_boundary_breaker_public_contract():
+    result = check_contract_boundary_breaker(changes_public_contract=True, crosses_owner_boundary=False)
+    assert result.triggered is True
+    assert "public/task contract" in result.reason
+
+
+def test_contract_boundary_breaker_owner_boundary():
+    result = check_contract_boundary_breaker(changes_public_contract=False, crosses_owner_boundary=True)
+    assert result.triggered is True
+    assert "owner boundary" in result.reason
+
+
+def test_design_decision_breaker():
+    assert check_design_decision_breaker(requires_canonical_decision=False).triggered is False
+    result = check_design_decision_breaker(requires_canonical_decision=True)
+    assert result.triggered is True
+    assert "design decision" in result.reason
+
+
+# --- critical override -------------------------------------------------------
+
+def test_critical_override_accepts_only_allowlisted_reasons():
+    assert critical_override_applies("active_data_loss") is True
+    assert critical_override_applies("crash") is True
+    assert critical_override_applies("broken_install_or_upgrade") is True
+    assert critical_override_applies("release_blocker") is True
+    assert critical_override_applies("concrete_security_exposure") is True
+
+
+def test_critical_override_rejects_everything_else():
+    assert critical_override_applies(None) is False
+    assert critical_override_applies("it_would_be_nice_too") is False
+    assert critical_override_applies("user_asked_for_more") is False
+
+
+# --- finding classification ---------------------------------------------------
+
+def test_classify_finding_in_scope_blocker():
+    disposition = classify_finding(is_blocking=True, in_frozen_scope=True, requires_scope_expansion=False)
+    assert disposition == "in_scope_blocker"
+
+
+def test_classify_finding_follow_up_when_not_blocking():
+    disposition = classify_finding(is_blocking=False, in_frozen_scope=True, requires_scope_expansion=False)
+    assert disposition == "follow_up"
+
+
+def test_classify_finding_follow_up_when_out_of_scope():
+    disposition = classify_finding(is_blocking=True, in_frozen_scope=False, requires_scope_expansion=False)
+    assert disposition == "follow_up"
+
+
+def test_classify_finding_stop_and_escalate_on_scope_expansion():
+    disposition = classify_finding(is_blocking=True, in_frozen_scope=True, requires_scope_expansion=True)
+    assert disposition == "stop_and_escalate"
+
+
+def test_classify_finding_critical_override_keeps_it_in_scope():
+    disposition = classify_finding(
+        is_blocking=True,
+        in_frozen_scope=True,
+        requires_scope_expansion=True,
+        critical_override_reason="active_data_loss",
+    )
+    assert disposition == "in_scope_blocker"
+
+
+def test_classify_finding_non_critical_reason_still_escalates():
+    disposition = classify_finding(
+        is_blocking=True,
+        in_frozen_scope=True,
+        requires_scope_expansion=True,
+        critical_override_reason="it_would_be_nice_too",
+    )
+    assert disposition == "stop_and_escalate"

--- a/tests/test_review_target_resolution.py
+++ b/tests/test_review_target_resolution.py
@@ -211,6 +211,63 @@ def test_resolve_pr_target_uses_actual_pr_base_not_assumed_default(tmp_path, mon
     assert target.changed_paths == ("pr_change.py",)
 
 
+def test_resolve_pr_target_diffs_merge_base_not_moved_base_tip(tmp_path, monkeypatch):
+    """The base branch can advance after the PR branch diverged from it.
+
+    ``baseRefOid`` from ``gh pr view`` is the base branch's *current* tip,
+    not the commit the PR actually forked from. Diffing straight against
+    that tip would pull in the base's own post-divergence commits as if the
+    PR introduced them. The target must diff against the merge-base (the
+    fork point) instead, and store the merge-base — not the moved tip — as
+    ``base_sha``.
+    """
+    repo = _init_repo(tmp_path)
+    merge_base_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    _git(repo, "checkout", "-q", "-b", "feature")
+    (repo / "pr_change.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "pr_change.py")
+    _git(repo, "commit", "-q", "-m", "pr change")
+    head_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    _git(repo, "checkout", "-q", "trunk")
+    # Base branch advances AFTER the feature branch forked off it.
+    (repo / "unrelated.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "unrelated.py")
+    _git(repo, "commit", "-q", "-m", "base moves on after divergence")
+    base_tip_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert base_tip_sha != merge_base_sha
+
+    import scripts.review.target_resolution as tr
+
+    payload = {
+        "number": 9001,
+        "baseRefName": "trunk",
+        "baseRefOid": base_tip_sha,
+        "headRefName": "feature",
+        "headRefOid": head_sha,
+    }
+
+    def fake_run_gh(args, cwd, timeout=30.0):
+        assert "view" in args
+        return subprocess.CompletedProcess(args, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(tr, "_run_gh", fake_run_gh)
+
+    target = resolve_pr_target(repo, 9001)
+    assert target.mode == "pr"
+    # base_sha is the merge-base (fork point), NOT the base's moved-on tip.
+    assert target.base_sha == merge_base_sha
+    assert target.base_sha != base_tip_sha
+    assert target.head_sha == head_sha
+    # Diff must cover only the PR's own change — not the base's post-fork commit.
+    assert target.changed_paths == ("pr_change.py",)
+    assert "unrelated.py" not in target.changed_paths
+    # Base tip is retained for provenance in the description.
+    assert base_tip_sha[:12] in target.description
+    assert merge_base_sha[:12] in target.description
+
+
 def test_resolve_pr_target_missing_sha_raises(tmp_path, monkeypatch):
     repo = _init_repo(tmp_path)
     import scripts.review.target_resolution as tr

--- a/tests/test_review_target_resolution.py
+++ b/tests/test_review_target_resolution.py
@@ -1,0 +1,243 @@
+"""Tests for scripts/review/target_resolution.py — deterministic target selection."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.common.git_context import sanitized_git_env
+from scripts.review.target_resolution import (
+    TargetResolutionError,
+    is_test_path,
+    resolve_branch_target,
+    resolve_commit_target,
+    resolve_local_target,
+    resolve_pr_target,
+    resolve_review_target,
+)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    # sanitized_git_env() strips GIT_DIR/GIT_WORK_TREE/etc — without it, running
+    # this suite from inside a `git commit` pre-commit hook leaks the OUTER
+    # repo's git env into these calls and silently operates on the wrong repo.
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+        env=sanitized_git_env(),
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Non-protected initial branch name: this repo is an unrelated tmp fixture,
+    # but the project's global git-checkout guard (scripts/agent_runtime/shims/git)
+    # blocks `checkout`/`switch` off of any branch literally named main/master —
+    # it doesn't check repo identity. Naming it "trunk" avoids tripping that guard.
+    _git(repo, "init", "-q", "-b", "trunk")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "app.py").write_text("print('v1')\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+# --- is_test_path -----------------------------------------------------------
+
+def test_is_test_path_recognizes_common_shapes():
+    assert is_test_path("tests/test_foo.py")
+    assert is_test_path("scripts/tests/test_bar.py")
+    assert is_test_path("src/__tests__/thing.test.ts")
+    assert is_test_path("src/component.spec.tsx")
+    assert not is_test_path("scripts/build/v7_build.py")
+    assert not is_test_path("docs/best-practices/code-quality.md")
+
+
+# --- local mode --------------------------------------------------------------
+
+def test_resolve_local_target_clean_tree(tmp_path):
+    repo = _init_repo(tmp_path)
+    target = resolve_local_target(repo)
+    assert target.mode == "local"
+    assert target.clean_tree is True
+    assert target.changed_paths == ()
+    assert target.base_sha is None
+    assert target.head_sha is None
+    assert "nothing to review" in target.description
+
+
+def test_resolve_local_target_clean_tree_is_not_evidence_of_commit_review(tmp_path):
+    """A clean local tree must never be presented as proof a commit/PR was reviewed.
+
+    The mode field plus None SHAs are the structural guard: a report built from
+    this target can't claim it verified a specific commit/PR, because there is
+    no base/head SHA to point at.
+    """
+    repo = _init_repo(tmp_path)
+    # Commit further work — tree is clean, but real committed changes exist.
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    _git(repo, "commit", "-aq", "-m", "v2")
+
+    target = resolve_local_target(repo)
+    assert target.clean_tree is True
+    assert target.mode == "local"
+    assert target.base_sha is None and target.head_sha is None
+    # A caller wanting proof of the v2 commit must use mode=commit explicitly.
+    committed = resolve_commit_target(repo, "HEAD")
+    assert committed.base_sha is not None and committed.head_sha is not None
+    assert "app.py" in committed.changed_paths
+
+
+def test_resolve_local_target_counts_staged_unstaged_and_untracked(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nprint('v2')\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    (repo / "unstaged.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "unstaged.py")
+    _git(repo, "commit", "-q", "-m", "staged change")
+    (repo / "unstaged.py").write_text("x = 1\ny = 2\n", encoding="utf-8")
+    (repo / "new_untracked.py").write_text("z = 3\n", encoding="utf-8")
+
+    target = resolve_local_target(repo)
+    assert target.clean_tree is False
+    assert set(target.changed_paths) >= {"unstaged.py", "new_untracked.py"}
+    assert target.non_test_loc > 0
+
+
+def test_resolve_local_target_excludes_test_files_from_loc(tmp_path):
+    repo = _init_repo(tmp_path)
+    tests_dir = repo / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_app.py").write_text("def test_x():\n    assert True\n", encoding="utf-8")
+
+    target = resolve_local_target(repo)
+    assert "tests/test_app.py" in target.changed_paths
+    assert target.non_test_loc == 0
+
+
+# --- commit mode ---------------------------------------------------------------
+
+def test_resolve_commit_target(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    _git(repo, "commit", "-aq", "-m", "v2 change")
+
+    target = resolve_commit_target(repo, "HEAD")
+    assert target.mode == "commit"
+    assert target.base_sha != target.head_sha
+    assert target.changed_paths == ("app.py",)
+    assert target.non_test_loc == 2  # one line removed, one added
+    assert target.clean_tree is False
+
+
+def test_resolve_commit_target_root_commit_raises(tmp_path):
+    repo = _init_repo(tmp_path)
+    root = _git(repo, "rev-list", "--max-parents=0", "HEAD").stdout.strip()
+    with __import__("pytest").raises(TargetResolutionError):
+        resolve_commit_target(repo, root)
+
+
+# --- branch mode -----------------------------------------------------------------
+
+def test_resolve_branch_target_against_explicit_base(tmp_path):
+    repo = _init_repo(tmp_path)
+    trunk_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "branch", "feature")
+    _git(repo, "checkout", "-q", "feature")
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "feature.py")
+    _git(repo, "commit", "-q", "-m", "add feature")
+    _git(repo, "checkout", "-q", "trunk")
+
+    target = resolve_branch_target(repo, "feature", trunk_sha)
+    assert target.mode == "branch"
+    assert target.changed_paths == ("feature.py",)
+    assert target.base_sha is not None and target.head_sha is not None
+    assert target.base_sha != target.head_sha
+
+
+def test_resolve_branch_target_no_merge_base_raises(tmp_path):
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-q", "--orphan", "orphan-branch")
+    _git(repo, "rm", "-rq", "--cached", ".")
+    (repo / "orphan.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "orphan.py")
+    _git(repo, "commit", "-q", "-m", "orphan root")
+
+    with __import__("pytest").raises(TargetResolutionError):
+        resolve_branch_target(repo, "orphan-branch", "trunk")
+
+
+# --- pr mode (gh calls stubbed) ---------------------------------------------------
+
+def test_resolve_pr_target_uses_actual_pr_base_not_assumed_default(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    base_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    (repo / "pr_change.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "pr_change.py")
+    _git(repo, "commit", "-q", "-m", "pr change")
+    head_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    import scripts.review.target_resolution as tr
+
+    payload = {
+        "number": 5283,
+        "baseRefName": "release/whatever",  # deliberately NOT "main"
+        "baseRefOid": base_sha,
+        "headRefName": "feature-branch",
+        "headRefOid": head_sha,
+    }
+
+    def fake_run_gh(args, cwd, timeout=30.0):
+        assert "view" in args
+        return subprocess.CompletedProcess(args, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(tr, "_run_gh", fake_run_gh)
+
+    target = resolve_pr_target(repo, 5283)
+    assert target.mode == "pr"
+    assert target.base_sha == base_sha
+    assert target.head_sha == head_sha
+    assert "release/whatever" in target.description
+    assert target.changed_paths == ("pr_change.py",)
+
+
+def test_resolve_pr_target_missing_sha_raises(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    import scripts.review.target_resolution as tr
+
+    def fake_run_gh(args, cwd, timeout=30.0):
+        return subprocess.CompletedProcess(args, 0, stdout=json.dumps({"number": 1}), stderr="")
+
+    monkeypatch.setattr(tr, "_run_gh", fake_run_gh)
+    with __import__("pytest").raises(TargetResolutionError):
+        resolve_pr_target(repo, 1)
+
+
+# --- dispatch ---------------------------------------------------------------------
+
+def test_resolve_review_target_requires_explicit_mode_args(tmp_path):
+    repo = _init_repo(tmp_path)
+    with __import__("pytest").raises(TargetResolutionError):
+        resolve_review_target("commit", repo)
+    with __import__("pytest").raises(TargetResolutionError):
+        resolve_review_target("branch", repo, branch="feature")
+    with __import__("pytest").raises(TargetResolutionError):
+        resolve_review_target("pr", repo)
+    with __import__("pytest").raises(TargetResolutionError):
+        resolve_review_target("bogus-mode", repo)
+
+
+def test_resolve_review_target_local_dispatch(tmp_path):
+    repo = _init_repo(tmp_path)
+    target = resolve_review_target("local", repo)
+    assert target.mode == "local"


### PR DESCRIPTION
## Summary

Implements #5283 (parent #5281, stream epic #4707): replaces the stale
`local-code-review` checklist with a canonical, non-mutating closeout
workflow.

- **Target selection** (`scripts/review/target_resolution.py`): deterministic
  `local` / `commit` / `branch` / `pr` modes, chosen explicitly — never
  inferred from working-tree state. A clean local tree is structurally
  incapable of being read as proof a commit/PR was reviewed (`base_sha`/
  `head_sha` are `None` only in `local` mode). PR mode resolves the PR's
  *actual* base via `gh pr view`, never an assumed default branch, and never
  pushes to obtain a target.
- **Scope baseline** (`scripts/review/scope_baseline.py`): freezes issue,
  intended behavior, non-goals, owner boundary, mode/SHAs/changed paths/LOC,
  profile, and risk once, before the first review pass. Implements the 2x
  files/LOC expansion breaker, the two-cycle non-convergence breaker,
  contract/owner-boundary and design-decision breakers, and the critical-only
  override allowlist (data loss, crash, broken install/upgrade, release
  blocker, concrete security exposure).
- **Findings ledger** (`scripts/review/findings.py`): append-only adjudication
  log (`in_scope_blocker` / `follow_up` / `stop_and_escalate`). `apply()`
  structurally refuses anything not adjudicated to `in_scope_blocker` — there
  is no code path to apply a finding "as-is" when a challenger is unavailable.
- **Reviewer resolver** (`scripts/review/reviewer_resolver.py`): family
  follows the model, not the harness (tested across `grok`/`grok-build`/
  `grok-hermes`/`grok-tools`, `claude`/`claude-tools`, `codex`/`gpt-5.6-*`,
  `deepseek`/`deepseek-tools`, etc.). Default code ladder: DeepSeek v4 Flash →
  Grok 4.5 → pool → `openai_frontier` (currently `gpt-5.6-sol`), advisory-only
  when the author is OpenAI-family. Domain/data-egress exclusions are
  fail-closed (unspecified policy excludes a gated candidate, e.g. GLM,
  rather than admitting it); lane health is fail-open and only a tie-breaker
  among already-eligible candidates. Every exclusion/substitution is visible
  in the returned trace.
- **`scripts/review/closeout_cli.py`**: ties the above together behind one
  per-review JSON state file so the rewritten skill
  (`agents_extensions/shared/skills/local-code-review/`) can drive each step
  without re-deriving logic or mutating the source tree. Removes the stale
  Gemini-review-then-Codex-challenge flow and the old "apply findings as-is
  if Codex is unavailable" guidance, and the old `.py/.ts/.tsx/.js`-only
  file filter (no changed shell/workflow/config/schema/doc path is silently
  excluded from scope).

Scoped to orchestration/policy only, per #5281 — the strict finding verifier
(#5281 child 2) and reviewer process isolation (#5281 child 3) are separate
follow-on slices.

## Test plan

- [x] `.venv/bin/pytest tests/test_review_target_resolution.py tests/test_review_scope_baseline.py tests/test_review_findings_ledger.py tests/test_review_reviewer_resolver.py tests/test_review_closeout_cli.py -q` — 77 passed
- [x] `.venv/bin/ruff check scripts/review/ tests/test_review_*.py` — clean
- [x] `.venv/bin/python scripts/lint/lint_agent_skills.py` — OK
- [x] `.venv/bin/python scripts/lint_prompts.py` — clean
- [x] `npm run agents:deploy` — canonical skill source and `.claude`/`.codex`/`.agents` mirrors diffed byte-identical (deploy-parity confirmed)
- [x] `git diff --check` — clean
- [x] Mandatory pre-submit checklist (`AGENTS.md`) — verified manually (no `sys.executable`, protected files untouched, 13 files changed, no auto-generated artifacts)
- [x] Pre-commit hook (ruff + affected-file pytest) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)