### PR TITLE
feat(review): strict evidence contract and closeout receipts

### DIFF
--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -31,9 +31,15 @@ and non-JSON chatter **fail closed**.
    Missing-code claims use contextual evidence and must not invent a diff line
    for code that is not there.
 3. **No invented line numbers**: every location must resolve on the exact
-   frozen head/local snapshot.
+   frozen head/local snapshot. Prefer an exact match at the claimed
+   `start_line`; identical text earlier in the file must not steal a later
+   true match. `end_line` must equal the exact verbatim span (no inflated
+   ranges that intersect unrelated changed lines). On mismatch, report the
+   deterministic first actual match and `line_mismatch`.
 4. **Path safety**: no absolute paths, no `..`, no drive paths, no symlink
    escapes, no paths outside the reviewed changed surface.
+5. **Decode/read failures** become a stable fail-closed evidence outcome
+   (`quote_missing` with detail), never an uncaught exception.
 
 ## Canonical reviewer JSON
 
@@ -93,44 +99,102 @@ Bind verification to one explicit mode from `scripts.review.target_resolution`
 | `branch` | branch vs explicit base (merge-base) |
 | `pr` | PR head vs merge-base with its base branch |
 
-Evidence matching:
+### Target-input fingerprint (not reviewer JSON)
 
-- Compare with **line-ending normalization only** (CRLF/CR → LF).
-- Do **not** strip backticks, punctuation, or collapse whitespace.
-- Report the **actual matched line** when the quote is found elsewhere
-  (`line_mismatch`).
-- Distinct outcomes: `verified`, `line_mismatch`, `quote_missing`,
-  `malformed`, `out_of_scope`.
-- A structurally valid report with invalid evidence is **not** a clean review.
+`input_sha256` on the receipt is the **target-input fingerprint**: a
+deterministic SHA-256 over target metadata plus the exact patch bytes (and
+untracked file bytes in local mode) needed to reconstruct the reviewed
+surface. It **must** change when a local source, the changed-path set,
+base/head, or committed content changes.
 
-Stale checks (fail closed):
+Reviewer JSON is hashed separately as `reviewer_output_sha256`.
 
-- `--expected-head` must match the resolved target head (non-local modes).
-- `--expected-input-sha256` must match the SHA-256 of the review input bytes.
-- Paths outside the frozen changed set, unsafe paths, and symlink escapes fail.
+### Two-stage runner usage
 
-## Runner command
+**Stage 1 — source-blind capture (before the reviewer runs):**
 
-Local / CI (no GitHub mutation):
+```bash
+.venv/bin/python scripts/verify_review.py --emit-target-manifest \
+  --mode local --repo-root .
+# → JSON with mode, head_sha (when applicable), changed_paths, input_sha256
+```
+
+**Stage 2 — verify after review (same mode/target):**
 
 ```bash
 .venv/bin/python scripts/verify_review.py --from-stdin --mode local \
+  --expected-input-sha256 "$TARGET_INPUT_SHA" \
+  --expected-head "$HEAD_SHA" \   # non-local modes
+  --issue-ref '#NNNN' \
+  --scope-json '{"owner_boundary":"path/or/paths"}' \
+  --author-model '...' --author-family '...' --author-harness '...' \
+  --author-selection-reason '...' \
+  --reviewer-model '...' --reviewer-family '...' --reviewer-harness '...' \
+  --reviewer-selection-reason '...' \
+  --tests-json '{"commands":["pytest ..."],"passed":true}' \
+  --behavior-proof-json '{"source_aware":{"status":"pass"},"source_blind":{"status":"pass"}}' \
+  --routing-lineage-json '{"implementation_agent":"...","accountable_advisor":"..."}' \
+  --dispositions-json '{"F001":{"disposition":"in_scope_blocker","rationale":"..."}}' \
+  --receipt-path /tmp/review-receipt.json
+```
+
+Stale / incomplete gates (fail closed):
+
+- `--expected-input-sha256` is **required** for `clean` / `actionable`.
+  Absence → `incomplete` (never green). Mismatch → `stale`.
+- `--expected-head` must match the resolved target head (non-local modes).
+- Paths outside the frozen changed set, unsafe paths, and symlink escapes fail.
+
+## Envelope provenance (fail closed, generic)
+
+The runner **never** fabricates routing lineage or task-specific agent
+defaults. Placeholders `unknown`, `unspecified`, and `not_provided` fail.
+
+A valid **clean** or **actionable** receipt requires:
+
+- concrete `issue_ref` (not empty / placeholder);
+- non-empty frozen `scope` with at least one concrete value;
+- complete author and reviewer `model` / `family` / `harness` /
+  `selection_reason` (no placeholders);
+- non-empty `tests`;
+- both `source_aware` and `source_blind` keys in `behavior_proof`;
+- explicit non-empty `routing_lineage` (supplied by the runner; not invented);
+- for every finding: disposition key present, disposition ∈
+  `in_scope_blocker` | `follow_up` | `stop_and_escalate`, non-empty rationale;
+  unknown or missing finding IDs rejected.
+
+Malformed or incomplete envelope data may still emit a receipt, but exits
+`incomplete` or `invalid` — **never** `0`/`1`.
+
+## Runner command
+
+Local / CI (no GitHub mutation) — full envelope example:
+
+```bash
+TARGET_SHA=$(.venv/bin/python scripts/verify_review.py --emit-target-manifest \
+  --mode local --repo-root . | .venv/bin/python -c 'import json,sys; print(json.load(sys.stdin)["input_sha256"])')
+
+.venv/bin/python scripts/verify_review.py --from-stdin --mode local \
+  --expected-input-sha256 "$TARGET_SHA" \
   --issue-ref '#5284' \
+  --scope-json '{"owner_boundary":"scripts/verify_review.py"}' \
   --author-model 'gpt-5.6-sol' --author-family openai --author-harness codex \
   --author-selection-reason 'accountable-author' \
   --reviewer-model 'grok-4.5' --reviewer-family xai --reviewer-harness grok-build \
   --reviewer-selection-reason 'cross-family-gate' \
   --tests-json '{"commands":["pytest tests/test_verify_review.py"],"passed":true}' \
   --behavior-proof-json '{"source_aware":{"status":"pass"},"source_blind":{"status":"n/a","reason":"no user-visible surface"}}' \
+  --routing-lineage-json '{"implementation_agent":"runner-supplied","accountable_advisor":"runner-supplied"}' \
   --receipt-path /tmp/review-receipt.json
 ```
 
 Commit / branch / PR targets:
 
 ```bash
-.venv/bin/python scripts/verify_review.py --review-file review.json --mode commit --commit HEAD
-.venv/bin/python scripts/verify_review.py --from-stdin --mode branch --branch feature/x --base origin/main
-.venv/bin/python scripts/verify_review.py --from-stdin --mode pr --pr 5286
+.venv/bin/python scripts/verify_review.py --review-file review.json --mode commit --commit HEAD \
+  --expected-input-sha256 "$TARGET_SHA" --expected-head "$HEAD" ...
+.venv/bin/python scripts/verify_review.py --from-stdin --mode branch --branch feature/x --base origin/main ...
+.venv/bin/python scripts/verify_review.py --from-stdin --mode pr --pr 5286 ...
 ```
 
 GitHub comment posting remains **opt-in** (`--post-comment` with `--issue`)
@@ -140,11 +204,11 @@ and is never the only durable proof path. Prefer stdout or `--receipt-path`.
 
 | Code | Name | Meaning |
 | --- | --- | --- |
-| 0 | `clean` | Valid JSON, overall correct, no findings, all evidence verified |
-| 1 | `actionable` | Valid review with findings or overall `incorrect` (evidence OK) |
+| 0 | `clean` | Valid JSON, overall correct, no findings, evidence OK, complete envelope + target fingerprint |
+| 1 | `actionable` | Valid review with findings or overall `incorrect` (evidence OK + complete envelope) |
 | 2 | `invalid` | Non-JSON, legacy text, schema violation, unsafe/malformed structure |
-| 3 | `incomplete` | Empty input or overall `uncertain` with no findings |
-| 4 | `stale` | Head SHA or input hash mismatch |
+| 3 | `incomplete` | Empty input, overall `uncertain` with no findings, or incomplete envelope / missing expected fingerprint |
+| 4 | `stale` | Head SHA or target-input fingerprint mismatch |
 | 5 | `unverifiable` | `quote_missing`, `line_mismatch`, or `out_of_scope` on any finding |
 
 ## Deterministic receipt (runner-built)
@@ -154,22 +218,14 @@ The **runner** — not the reviewer — emits a receipt
 
 - originating issue and frozen scope;
 - author and reviewer model / family / harness / selection reason;
-- target mode, base SHA, head SHA, changed paths, non-test LOC, input SHA-256;
-- per-finding validation outcome (and optional accountable disposition/rationale);
+- target mode, base SHA, head SHA, changed paths, non-test LOC,
+  **target-input** `input_sha256`;
+- separate `reviewer_output_sha256`;
+- per-finding validation outcome (and disposition/rationale when supplied);
 - tests and source-aware / source-blind behavior proof;
 - final disposition and exit code;
-- routing lineage (implementation agent, accountable advisor; **do not** embed
-  transient quota percentages as defaults).
-
-Example routing lineage for this infrastructure slice:
-
-```json
-{
-  "implementation_agent": "grok/5284-strict-review-receipts",
-  "accountable_advisor": "GPT-5.6 Sol",
-  "selection_note": "Grok 4.5 high substituted for the issue's provisional Claude developer due to live routing-budget recommendation; GPT-5.6 Sol remains accountable advisor/integrator and cross-family reviewer."
-}
-```
+- routing lineage **only when the runner supplies it** (never hardcoded
+  task-specific defaults; **do not** embed transient quota percentages).
 
 Runtime receipts are **generated evidence**. Write them to stdout or an
 explicit local path. They must **not** enter forbidden PR artifacts:
@@ -186,14 +242,17 @@ Multi-finding validation order is deterministic: sort by
 
 1. Freeze scope and resolve the exact target (`scripts.review.closeout_cli` /
    `target_resolution`).
-2. Dispatch the reviewer with `--review` so this protocol is prepended.
-3. Reviewer reads the **exact target** (worktree / `git show <head>:<path>` /
+2. **Emit target manifest** (`--emit-target-manifest`) and record
+   `input_sha256` (+ head when applicable).
+3. Dispatch the reviewer with `--review` so this protocol is prepended.
+4. Reviewer reads the **exact target** (worktree / `git show <head>:<path>` /
    PR head), not a different checkout.
-4. Reviewer returns **only** `code-review-findings.v1` JSON.
-5. Run `scripts/verify_review.py` with the same mode/base/head constraints.
-6. Read the receipt:
+5. Reviewer returns **only** `code-review-findings.v1` JSON.
+6. Run `scripts/verify_review.py` with the same mode/base/head constraints,
+   `--expected-input-sha256`, and a complete envelope.
+7. Read the receipt:
    - `clean` → proceed to merge/closeout.
    - `actionable` → adjudicate and fix only in-scope blockers.
    - `invalid` / `incomplete` / `stale` / `unverifiable` → reject the review
      output; re-run after correcting structure, freshness, or evidence — do not
-     treat bad evidence as a green closeout.
+     treat bad evidence or incomplete provenance as a green closeout.

--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -156,15 +156,25 @@ A valid **clean** or **actionable** receipt requires:
 - non-empty frozen `scope` with at least one concrete value;
 - complete author and reviewer `model` / `family` / `harness` /
   `selection_reason` (no placeholders);
-- non-empty `tests`;
-- both `source_aware` and `source_blind` keys in `behavior_proof`;
+- **cross-family gate**: `author.family` and `reviewer.family` must be
+  concrete and different (case-insensitive). Same-family lineage cannot
+  exit `clean` (final disposition is non-clean / `actionable`);
+- `tests` with concrete `commands` and `passed: true`, **or** explicitly
+  supported `status: "n/a"` with a non-empty `reason`. `passed: false` /
+  `status: "fail"` makes the receipt non-clean / `actionable` (never exit 0);
+- both `source_aware` and `source_blind` in `behavior_proof`, each with
+  `status: "pass"` or `status: "n/a"` + non-empty `reason`. `status: "fail"`
+  is non-clean / `actionable`; missing/invalid status is `incomplete`;
 - explicit non-empty `routing_lineage` (supplied by the runner; not invented);
 - for every finding: disposition key present, disposition ∈
   `in_scope_blocker` | `follow_up` | `stop_and_escalate`, non-empty rationale;
   unknown or missing finding IDs rejected.
 
-Malformed or incomplete envelope data may still emit a receipt, but exits
-`incomplete` or `invalid` — **never** `0`/`1`.
+Malformed runner envelope JSON (`--scope-json`, `--tests-json`,
+`--behavior-proof-json`, `--dispositions-json`, `--routing-lineage-json`)
+exits `invalid` (2) with structured error output. Incomplete envelope data
+exits `incomplete` (3). Explicit failed proof / same-family exits
+`actionable` (1) — **never** `0` when the formal closeout gate fails.
 
 ## Runner command
 

--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -1,56 +1,199 @@
 # Universal Review Protocol
 
+> **Canonical contract (v1):** versioned JSON schema
+> `schemas/code-review-findings.v1.schema.json`, validated by
+> `scripts/verify_review.py`. Legacy loose `FINDING:` text is **removed** as a
+> dual source of truth (issue #5284). Reviewers must emit **only** schema-valid
+> JSON — no prose wrapper, no markdown fences around the payload.
+
 ## Evidence requirement — NON-NEGOTIABLE
 
-Every finding you return MUST include:
-1. **Exact `file:line` reference** — quote the literal line number from the file on the branch you reviewed.
-2. **Verbatim quote** of the current code/text, copy-pasted exactly as it appears.
-3. **The correction** with a one-paragraph justification of why the current code/text is wrong.
-4. **Source citation if available**.
+Every finding MUST include:
 
-Findings without all four elements will be DISCARDED by the verifier.
-If you are not certain the text you are quoting is verbatim from the file, DO NOT include it.
-Mark each finding `SEVERITY: {blocker | major | minor | nit}`.
+1. **Stable ID**, title, body, priority `P0`–`P3`, confidence `0..1`, and category.
+2. **Code location** — repository-relative path plus `start_line` / `end_line`
+   and `claim_type` (`present` | `missing`).
+3. **Verbatim evidence** copied exactly from the reviewed target (only
+   line-ending normalization is applied during verification).
+4. **Why it is wrong** and the **smallest correct fix**.
+5. **Source citation(s)** or explicit `["none"]`.
 
-## Hallucination Guards
+Unknown fields, missing required fields, unsafe paths, invalid enums/ranges,
+and non-JSON chatter **fail closed**.
 
-1. **DIFF vs FILE distinction**: lines outside the diff still exist on the branch. A reviewer claiming something is "missing" must prove absence in the FILE, not just in the DIFF.
-2. **Mandatory FINDING format**: every finding must use the schema below.
-3. **"Missing" claims require proof of absence**: give a verbatim grep miss or quote the relevant file line. "I don't see it in the diff" is not evidence.
-4. **No invented line numbers**: every `file:line` reference must resolve to a real line on the branch at review time.
-5. **Self-check before submitting**: ask "could the code I think is missing actually exist at a line I haven't read?" If yes, read more before reporting it.
+## Hallucination guards
 
-## Mandatory Per-Finding Schema
+1. **DIFF vs FILE**: lines outside the diff still exist on the branch. A
+   “missing” claim must prove absence with **file** evidence (`claim_type:
+   "missing"` plus verbatim context), not “I don’t see it in the diff.”
+2. **Primary location on the change**: for `claim_type: "present"`, the
+   primary line range must land on a **changed line** of the frozen target.
+   Missing-code claims use contextual evidence and must not invent a diff line
+   for code that is not there.
+3. **No invented line numbers**: every location must resolve on the exact
+   frozen head/local snapshot.
+4. **Path safety**: no absolute paths, no `..`, no drive paths, no symlink
+   escapes, no paths outside the reviewed changed surface.
 
-```text
-FINDING:
-FILE:LINE: <path>:<n>
-CURRENT CODE (verbatim from branch):
+## Canonical reviewer JSON
+
+```json
+{
+  "schema_version": "code-review-findings.v1",
+  "overall": {
+    "correctness": "correct",
+    "explanation": "No defects found on the frozen target.",
+    "confidence": 0.9
+  },
+  "findings": [
+    {
+      "id": "F001",
+      "title": "Short title",
+      "body": "Full finding narrative.",
+      "priority": "P1",
+      "confidence": 0.85,
+      "category": "bug",
+      "location": {
+        "path": "scripts/example.py",
+        "start_line": 12,
+        "end_line": 12,
+        "claim_type": "present"
+      },
+      "verbatim": "exact = line_from_file",
+      "why_wrong": "One paragraph on the defect.",
+      "smallest_fix": "Minimal correct change.",
+      "sources": ["none"]
+    }
+  ]
+}
 ```
-<copy-paste from file>
+
+Categories: `bug`, `security`, `correctness`, `regression`, `api`, `tests`,
+`docs`, `performance`, `style`, `other`.
+
+### Compatibility / removal decision
+
+| Format | Status |
+| --- | --- |
+| `schema_version: code-review-findings.v1` JSON | **Canonical** |
+| Legacy `FINDING:` / `FILE:LINE:` text blocks | **Removed** — verifier exits `invalid` |
+
+Do not maintain two canonical formats indefinitely. Update any prompt that
+still shows the old text block to this JSON contract.
+
+## Exact-target verification
+
+Bind verification to one explicit mode from `scripts.review.target_resolution`
+(PR #5286 foundation — do not invent a parallel target API):
+
+| Mode | Meaning |
+| --- | --- |
+| `local` | staged + unstaged + untracked vs HEAD |
+| `commit` | single commit vs its parent |
+| `branch` | branch vs explicit base (merge-base) |
+| `pr` | PR head vs merge-base with its base branch |
+
+Evidence matching:
+
+- Compare with **line-ending normalization only** (CRLF/CR → LF).
+- Do **not** strip backticks, punctuation, or collapse whitespace.
+- Report the **actual matched line** when the quote is found elsewhere
+  (`line_mismatch`).
+- Distinct outcomes: `verified`, `line_mismatch`, `quote_missing`,
+  `malformed`, `out_of_scope`.
+- A structurally valid report with invalid evidence is **not** a clean review.
+
+Stale checks (fail closed):
+
+- `--expected-head` must match the resolved target head (non-local modes).
+- `--expected-input-sha256` must match the SHA-256 of the review input bytes.
+- Paths outside the frozen changed set, unsafe paths, and symlink escapes fail.
+
+## Runner command
+
+Local / CI (no GitHub mutation):
+
+```bash
+.venv/bin/python scripts/verify_review.py --from-stdin --mode local \
+  --issue-ref '#5284' \
+  --author-model 'gpt-5.6-sol' --author-family openai --author-harness codex \
+  --author-selection-reason 'accountable-author' \
+  --reviewer-model 'grok-4.5' --reviewer-family xai --reviewer-harness grok-build \
+  --reviewer-selection-reason 'cross-family-gate' \
+  --tests-json '{"commands":["pytest tests/test_verify_review.py"],"passed":true}' \
+  --behavior-proof-json '{"source_aware":{"status":"pass"},"source_blind":{"status":"n/a","reason":"no user-visible surface"}}' \
+  --receipt-path /tmp/review-receipt.json
 ```
-WHY WRONG:
-<one paragraph>
-FIX:
-<patch or instruction>
-SEVERITY: {blocker | major | minor | nit}
-SOURCE: <citation or "none">
+
+Commit / branch / PR targets:
+
+```bash
+.venv/bin/python scripts/verify_review.py --review-file review.json --mode commit --commit HEAD
+.venv/bin/python scripts/verify_review.py --from-stdin --mode branch --branch feature/x --base origin/main
+.venv/bin/python scripts/verify_review.py --from-stdin --mode pr --pr 5286
 ```
 
-Findings without all fields are DISCARDED by `scripts/verify_review.py`.
+GitHub comment posting remains **opt-in** (`--post-comment` with `--issue`)
+and is never the only durable proof path. Prefer stdout or `--receipt-path`.
 
-## Universal Review Loop
+### Stable exit codes
 
-1. Dispatch the reviewer with `--review` so this protocol is prepended before any channel or task-specific context.
-2. The reviewer reads the actual files on the branch, not just the diff.
-3. The reviewer returns only schema-complete `FINDING:` blocks with verbatim evidence.
-4. Run `.venv/bin/python scripts/verify_review.py --from-stdin` on pasted output, or `.venv/bin/python scripts/verify_review.py --issue <N>` to verify the latest issue comment.
-5. Read the JSONL outcomes:
-   - `verified`: quote exists at the claimed line
-   - `line_mismatch`: quote exists, but not at the claimed line
-   - `quote_missing`: quoted code/text is not present on the branch
-   - `discarded`: malformed finding with missing required fields
-6. Decide the next step:
-   - If findings are `verified`, address or rebut them normally.
-   - If findings are `line_mismatch`, treat them as weak evidence and re-check the file before acting.
-   - If findings are `quote_missing` or `discarded`, reject those findings; do not auto-retry in a loop.
+| Code | Name | Meaning |
+| --- | --- | --- |
+| 0 | `clean` | Valid JSON, overall correct, no findings, all evidence verified |
+| 1 | `actionable` | Valid review with findings or overall `incorrect` (evidence OK) |
+| 2 | `invalid` | Non-JSON, legacy text, schema violation, unsafe/malformed structure |
+| 3 | `incomplete` | Empty input or overall `uncertain` with no findings |
+| 4 | `stale` | Head SHA or input hash mismatch |
+| 5 | `unverifiable` | `quote_missing`, `line_mismatch`, or `out_of_scope` on any finding |
+
+## Deterministic receipt (runner-built)
+
+The **runner** — not the reviewer — emits a receipt
+(`schema_version: code-review-receipt.v1`) containing:
+
+- originating issue and frozen scope;
+- author and reviewer model / family / harness / selection reason;
+- target mode, base SHA, head SHA, changed paths, non-test LOC, input SHA-256;
+- per-finding validation outcome (and optional accountable disposition/rationale);
+- tests and source-aware / source-blind behavior proof;
+- final disposition and exit code;
+- routing lineage (implementation agent, accountable advisor; **do not** embed
+  transient quota percentages as defaults).
+
+Example routing lineage for this infrastructure slice:
+
+```json
+{
+  "implementation_agent": "grok/5284-strict-review-receipts",
+  "accountable_advisor": "GPT-5.6 Sol",
+  "selection_note": "Grok 4.5 high substituted for the issue's provisional Claude developer due to live routing-budget recommendation; GPT-5.6 Sol remains accountable advisor/integrator and cross-family reviewer."
+}
+```
+
+Runtime receipts are **generated evidence**. Write them to stdout or an
+explicit local path. They must **not** enter forbidden PR artifacts:
+
+- `status/*.json`
+- `audit/*-review.md`
+- `review/*-review.md`
+- `data/telemetry/**`
+
+Multi-finding validation order is deterministic: sort by
+`(path, start_line, end_line, id)`.
+
+## Universal review loop
+
+1. Freeze scope and resolve the exact target (`scripts.review.closeout_cli` /
+   `target_resolution`).
+2. Dispatch the reviewer with `--review` so this protocol is prepended.
+3. Reviewer reads the **exact target** (worktree / `git show <head>:<path>` /
+   PR head), not a different checkout.
+4. Reviewer returns **only** `code-review-findings.v1` JSON.
+5. Run `scripts/verify_review.py` with the same mode/base/head constraints.
+6. Read the receipt:
+   - `clean` → proceed to merge/closeout.
+   - `actionable` → adjudicate and fix only in-scope blockers.
+   - `invalid` / `incomplete` / `stale` / `unverifiable` → reject the review
+     output; re-run after correcting structure, freshness, or evidence — do not
+     treat bad evidence as a green closeout.

--- a/schemas/code-review-findings.v1.schema.json
+++ b/schemas/code-review-findings.v1.schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/code-review-findings.v1.schema.json",
+  "title": "Code review findings v1",
+  "description": "Strict reviewer output for scripts/verify_review.py (issue #5284). Fail-closed: additionalProperties false throughout.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "overall", "findings"],
+  "properties": {
+    "schema_version": {
+      "const": "code-review-findings.v1"
+    },
+    "overall": {
+      "$ref": "#/$defs/overall"
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    }
+  },
+  "$defs": {
+    "nonempty": {
+      "type": "string",
+      "minLength": 1
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["P0", "P1", "P2", "P3"]
+    },
+    "category": {
+      "type": "string",
+      "enum": [
+        "bug",
+        "security",
+        "correctness",
+        "regression",
+        "api",
+        "tests",
+        "docs",
+        "performance",
+        "style",
+        "other"
+      ]
+    },
+    "claim_type": {
+      "type": "string",
+      "enum": ["present", "missing"],
+      "description": "present: defect at a changed line. missing: evidence-backed absence claim; location is contextual evidence, not a pretend diff line for the missing code."
+    },
+    "repo_relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$"
+    },
+    "line_number": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "overall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correctness", "explanation", "confidence"],
+      "properties": {
+        "correctness": {
+          "type": "string",
+          "enum": ["correct", "incorrect", "uncertain"]
+        },
+        "explanation": {
+          "$ref": "#/$defs/nonempty"
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        }
+      }
+    },
+    "location": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "start_line", "end_line", "claim_type"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/repo_relative_path"
+        },
+        "start_line": {
+          "$ref": "#/$defs/line_number"
+        },
+        "end_line": {
+          "$ref": "#/$defs/line_number"
+        },
+        "claim_type": {
+          "$ref": "#/$defs/claim_type"
+        }
+      }
+    },
+    "sources": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "const": "none"
+          },
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "not": {
+              "const": "none"
+            }
+          }
+        }
+      ]
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "title",
+        "body",
+        "priority",
+        "confidence",
+        "category",
+        "location",
+        "verbatim",
+        "why_wrong",
+        "smallest_fix",
+        "sources"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$"
+        },
+        "title": {
+          "$ref": "#/$defs/nonempty"
+        },
+        "body": {
+          "$ref": "#/$defs/nonempty"
+        },
+        "priority": {
+          "$ref": "#/$defs/priority"
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        },
+        "category": {
+          "$ref": "#/$defs/category"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        },
+        "verbatim": {
+          "$ref": "#/$defs/nonempty",
+          "description": "Verbatim current code/evidence from the exact review target. Only line-ending normalization is applied during verification."
+        },
+        "why_wrong": {
+          "$ref": "#/$defs/nonempty"
+        },
+        "smallest_fix": {
+          "$ref": "#/$defs/nonempty"
+        },
+        "sources": {
+          "$ref": "#/$defs/sources"
+        }
+      }
+    }
+  }
+}

--- a/scripts/review/evidence.py
+++ b/scripts/review/evidence.py
@@ -1,0 +1,308 @@
+"""Exact-target evidence verification for structured code-review findings.
+
+Bound to :class:`scripts.review.target_resolution.ReviewTarget`. Verifies
+verbatim quotes with **line-ending normalization only** — no backtick
+stripping, no whitespace collapsing, no punctuation removal. Path safety
+rejects absolute paths, drive paths, ``..``, symlink escapes, and locations
+outside the reviewed target / changed surface.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.common.git_context import sanitized_git_env
+from scripts.review.target_resolution import ReviewTarget
+
+# Outcomes preserved as distinct classes (issue #5284).
+OUTCOME_VERIFIED = "verified"
+OUTCOME_LINE_MISMATCH = "line_mismatch"
+OUTCOME_QUOTE_MISSING = "quote_missing"
+OUTCOME_MALFORMED = "malformed"
+OUTCOME_OUT_OF_SCOPE = "out_of_scope"
+
+EVIDENCE_OUTCOMES = frozenset(
+    {
+        OUTCOME_VERIFIED,
+        OUTCOME_LINE_MISMATCH,
+        OUTCOME_QUOTE_MISSING,
+        OUTCOME_MALFORMED,
+        OUTCOME_OUT_OF_SCOPE,
+    }
+)
+
+_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:")
+_HUNK_RE = re.compile(r"^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@")
+
+
+class EvidenceError(RuntimeError):
+    """Evidence loading or path resolution failed closed."""
+
+
+@dataclass(frozen=True)
+class EvidenceCheckResult:
+    outcome: str
+    matched_line: int | None = None
+    matched_text: str | None = None
+    detail: str = ""
+
+
+def normalize_line_endings(text: str) -> str:
+    """Documented normalization: CRLF/CR → LF only. Nothing else."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def split_lines_preserve_content(text: str) -> list[str]:
+    """Split on LF after line-ending normalization. Keep empty lines; no strip."""
+    normalized = normalize_line_endings(text)
+    if normalized == "":
+        return []
+    # splitlines(keepends=False) drops a trailing empty segment after final \n,
+    # which matches how editors present "lines of a file."
+    if normalized.endswith("\n"):
+        normalized = normalized[:-1]
+    return normalized.split("\n")
+
+
+def is_safe_repo_relative_path(path: str) -> bool:
+    """Structural path-string check (no filesystem I/O)."""
+    if not path or not isinstance(path, str):
+        return False
+    if path.startswith(("/", "\\")):
+        return False
+    if _DRIVE_PATH_RE.match(path):
+        return False
+    if "\\" in path:
+        return False
+    parts = path.split("/")
+    return not any(p in ("", ".", "..") for p in parts)
+
+
+def resolve_safe_path(repo_root: Path, rel_path: str) -> Path:
+    """Resolve ``rel_path`` under ``repo_root``; reject escapes and symlink walks out."""
+    if not is_safe_repo_relative_path(rel_path):
+        raise EvidenceError(f"unsafe_path:{rel_path!r}")
+    root = repo_root.resolve()
+    candidate = (root / rel_path).resolve(strict=False)
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise EvidenceError(f"path_escapes_repo:{rel_path!r}") from exc
+    # If the path exists and is a symlink, ensure the real file is still in-repo.
+    if candidate.exists() or candidate.is_symlink():
+        real = candidate.resolve(strict=False)
+        try:
+            real.relative_to(root)
+        except ValueError as exc:
+            raise EvidenceError(f"symlink_escape:{rel_path!r}") from exc
+        return real
+    return candidate
+
+
+def _run_git(args: list[str], cwd: Path, *, timeout: float = 30.0) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=sanitized_git_env(),
+    )
+
+
+def load_file_text(repo_root: Path, rel_path: str, target: ReviewTarget) -> str:
+    """Load file content from the exact review target (local tree or head SHA)."""
+    safe = resolve_safe_path(repo_root, rel_path)
+    if target.mode == "local":
+        if not safe.is_file():
+            raise EvidenceError(f"file_unavailable:{rel_path}")
+        return safe.read_text(encoding="utf-8")
+    if not target.head_sha:
+        raise EvidenceError("target_missing_head_sha")
+    # git path uses the repo-relative form, not the resolved real path.
+    proc = _run_git(["show", f"{target.head_sha}:{rel_path}"], repo_root)
+    if proc.returncode != 0:
+        raise EvidenceError(f"file_unavailable:{rel_path}:{proc.stderr.strip()}")
+    return proc.stdout
+
+
+def _parse_new_side_lines(diff_text: str) -> set[int]:
+    """Parse ``git diff -U0`` unified diff for new-side line numbers."""
+    lines: set[int] = set()
+    current: int | None = None
+    remaining = 0
+    for raw in diff_text.splitlines():
+        hunk = _HUNK_RE.match(raw)
+        if hunk:
+            start = int(hunk.group(1))
+            count = int(hunk.group(2) or "1")
+            current = start
+            remaining = count
+            if count == 0:
+                current = None
+            continue
+        if current is None:
+            continue
+        if raw.startswith("+") and not raw.startswith("+++"):
+            lines.add(current)
+            current += 1
+            remaining -= 1
+            if remaining <= 0:
+                current = None
+        elif (raw.startswith("-") and not raw.startswith("---")) or raw.startswith("\\"):
+            continue
+        else:
+            # context (shouldn't appear with -U0) or noise
+            if remaining > 0 and not raw.startswith(("+", "-", "@")):
+                current += 1
+                remaining -= 1
+                if remaining <= 0:
+                    current = None
+    return lines
+
+
+def changed_lines_map(repo_root: Path, target: ReviewTarget) -> dict[str, set[int]]:
+    """Map each changed path to the set of new-side line numbers introduced/altered.
+
+    Untracked files in local mode: every line is treated as changed.
+    """
+    result: dict[str, set[int]] = {p: set() for p in target.changed_paths}
+    if target.mode == "local":
+        for path in target.changed_paths:
+            full = resolve_safe_path(repo_root, path)
+            # Untracked?
+            status = _run_git(["status", "--porcelain", "--", path], repo_root)
+            status_line = (status.stdout or "").strip()
+            if status_line.startswith("??"):
+                if full.is_file():
+                    text = full.read_text(encoding="utf-8", errors="ignore")
+                    n = len(split_lines_preserve_content(text))
+                    result[path] = set(range(1, n + 1)) if n else set()
+                continue
+            # Tracked working-tree changes (staged + unstaged) vs HEAD.
+            proc = _run_git(["diff", "-U0", "HEAD", "--", path], repo_root)
+            result[path] |= _parse_new_side_lines(proc.stdout or "")
+            cached = _run_git(["diff", "-U0", "--cached", "HEAD", "--", path], repo_root)
+            result[path] |= _parse_new_side_lines(cached.stdout or "")
+        return result
+
+    if not target.base_sha or not target.head_sha:
+        raise EvidenceError("target_missing_base_or_head_for_changed_lines")
+    for path in target.changed_paths:
+        proc = _run_git(
+            ["diff", "-U0", target.base_sha, target.head_sha, "--", path],
+            repo_root,
+        )
+        if proc.returncode != 0:
+            raise EvidenceError(f"diff_failed:{path}:{proc.stderr.strip()}")
+        result[path] = _parse_new_side_lines(proc.stdout or "")
+    return result
+
+
+def find_verbatim_match(
+    file_text: str, quote: str
+) -> tuple[int | None, str | None]:
+    """Return (1-based start line, matched text) if quote is a contiguous match.
+
+    Matching uses line-ending normalization only. The first match wins
+    (deterministic for a fixed file).
+    """
+    file_lines = split_lines_preserve_content(file_text)
+    quote_lines = split_lines_preserve_content(quote)
+    if not quote_lines:
+        return None, None
+    n = len(quote_lines)
+    for i in range(0, len(file_lines) - n + 1):
+        window = file_lines[i : i + n]
+        if window == quote_lines:
+            matched = "\n".join(window)
+            return i + 1, matched
+    return None, None
+
+
+def verify_finding_evidence(
+    finding: dict,
+    *,
+    repo_root: Path,
+    target: ReviewTarget,
+    changed_lines: dict[str, set[int]],
+) -> EvidenceCheckResult:
+    """Validate one schema-valid finding against the frozen target."""
+    location = finding.get("location") or {}
+    path = location.get("path")
+    start_line = location.get("start_line")
+    end_line = location.get("end_line")
+    claim_type = location.get("claim_type")
+    verbatim = finding.get("verbatim")
+
+    if not isinstance(path, str) or not is_safe_repo_relative_path(path):
+        return EvidenceCheckResult(OUTCOME_MALFORMED, detail="unsafe_or_invalid_path")
+    if not isinstance(start_line, int) or not isinstance(end_line, int):
+        return EvidenceCheckResult(OUTCOME_MALFORMED, detail="invalid_line_types")
+    if start_line < 1 or end_line < start_line:
+        return EvidenceCheckResult(OUTCOME_MALFORMED, detail="invalid_line_range")
+    if claim_type not in ("present", "missing"):
+        return EvidenceCheckResult(OUTCOME_MALFORMED, detail="invalid_claim_type")
+    if not isinstance(verbatim, str) or not verbatim:
+        return EvidenceCheckResult(OUTCOME_MALFORMED, detail="empty_verbatim")
+
+    try:
+        resolve_safe_path(repo_root, path)
+    except EvidenceError as exc:
+        return EvidenceCheckResult(OUTCOME_MALFORMED, detail=str(exc))
+
+    if path not in target.changed_paths:
+        return EvidenceCheckResult(
+            OUTCOME_OUT_OF_SCOPE,
+            detail=f"path_not_in_changed_paths:{path}",
+        )
+
+    try:
+        file_text = load_file_text(repo_root, path, target)
+    except EvidenceError as exc:
+        return EvidenceCheckResult(OUTCOME_QUOTE_MISSING, detail=str(exc))
+
+    matched_line, matched_text = find_verbatim_match(file_text, verbatim)
+    if matched_line is None:
+        return EvidenceCheckResult(
+            OUTCOME_QUOTE_MISSING,
+            detail="verbatim_not_found",
+        )
+
+    claimed = start_line
+    if matched_line != claimed:
+        # Prefer line_mismatch over out_of_scope so a wrong line number that
+        # still quotes real code surfaces the actual matched line.
+        return EvidenceCheckResult(
+            OUTCOME_LINE_MISMATCH,
+            matched_line=matched_line,
+            matched_text=matched_text,
+            detail=f"matched_at_line:{matched_line}",
+        )
+
+    path_changed = changed_lines.get(path, set())
+    primary_lines = set(range(start_line, end_line + 1))
+    # present: primary location must land on a changed line.
+    # missing: contextual evidence may sit on an unchanged line; do not invent
+    # a diff line for the absent code.
+    if claim_type == "present" and not primary_lines & path_changed:
+        return EvidenceCheckResult(
+            OUTCOME_OUT_OF_SCOPE,
+            matched_line=matched_line,
+            matched_text=matched_text,
+            detail=(
+                f"primary_location_not_on_changed_line:"
+                f"{path}:{start_line}-{end_line}"
+            ),
+        )
+
+    return EvidenceCheckResult(
+        OUTCOME_VERIFIED,
+        matched_line=matched_line,
+        matched_text=matched_text,
+        detail=f"matched_at_line:{matched_line}",
+    )

--- a/scripts/review/evidence.py
+++ b/scripts/review/evidence.py
@@ -41,6 +41,17 @@ _HUNK_RE = re.compile(r"^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@")
 
 TARGET_INPUT_FINGERPRINT_VERSION = "target-input-v1"
 
+# Stable git-diff flags for target-input fingerprint surfaces. Avoid default
+# abbreviated index lines, external diff drivers, textconv filters, and rename
+# detection so fingerprint bytes are exact and config-stable.
+CANONICAL_DIFF_ARGS = (
+    "--binary",
+    "--full-index",
+    "--no-ext-diff",
+    "--no-textconv",
+    "--no-renames",
+)
+
 
 class EvidenceError(RuntimeError):
     """Evidence loading or path resolution failed closed."""
@@ -232,7 +243,11 @@ def changed_lines_map(repo_root: Path, target: ReviewTarget) -> dict[str, set[in
 
 
 def path_surface_bytes(repo_root: Path, target: ReviewTarget, rel_path: str) -> bytes:
-    """Exact patch or untracked file bytes for one path on the reviewed surface."""
+    """Exact patch or untracked file bytes for one path on the reviewed surface.
+
+    Tracked paths use canonical git-diff arguments (binary + full-index, no
+    ext-diff/textconv/renames). Untracked local paths hash raw file bytes.
+    """
     if not is_safe_repo_relative_path(rel_path):
         raise EvidenceError(f"unsafe_path:{rel_path!r}")
     if target.mode == "local":
@@ -246,8 +261,11 @@ def path_surface_bytes(repo_root: Path, target: ReviewTarget, rel_path: str) -> 
                 return safe.read_bytes()
             except OSError as exc:
                 raise EvidenceError(f"read_failed:{rel_path}:{exc}") from exc
-        # Working tree vs HEAD (staged + unstaged combined).
-        proc = _run_git_bytes(["diff", "HEAD", "--", rel_path], repo_root)
+        # Working tree vs HEAD (staged + unstaged combined), canonical form.
+        proc = _run_git_bytes(
+            ["diff", *CANONICAL_DIFF_ARGS, "HEAD", "--", rel_path],
+            repo_root,
+        )
         if proc.returncode not in (0, 1):
             err = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
             raise EvidenceError(f"diff_failed:{rel_path}:{err}")
@@ -256,7 +274,14 @@ def path_surface_bytes(repo_root: Path, target: ReviewTarget, rel_path: str) -> 
     if not target.base_sha or not target.head_sha:
         raise EvidenceError("target_missing_base_or_head_for_fingerprint")
     proc = _run_git_bytes(
-        ["diff", target.base_sha, target.head_sha, "--", rel_path],
+        [
+            "diff",
+            *CANONICAL_DIFF_ARGS,
+            target.base_sha,
+            target.head_sha,
+            "--",
+            rel_path,
+        ],
         repo_root,
     )
     if proc.returncode not in (0, 1):

--- a/scripts/review/evidence.py
+++ b/scripts/review/evidence.py
@@ -9,6 +9,8 @@ outside the reviewed target / changed surface.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import subprocess
 from dataclasses import dataclass
@@ -36,6 +38,8 @@ EVIDENCE_OUTCOMES = frozenset(
 
 _DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:")
 _HUNK_RE = re.compile(r"^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@")
+
+TARGET_INPUT_FINGERPRINT_VERSION = "target-input-v1"
 
 
 class EvidenceError(RuntimeError):
@@ -114,13 +118,31 @@ def _run_git(args: list[str], cwd: Path, *, timeout: float = 30.0) -> subprocess
     )
 
 
+def _run_git_bytes(
+    args: list[str], cwd: Path, *, timeout: float = 30.0
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+        timeout=timeout,
+        env=sanitized_git_env(),
+    )
+
+
 def load_file_text(repo_root: Path, rel_path: str, target: ReviewTarget) -> str:
     """Load file content from the exact review target (local tree or head SHA)."""
     safe = resolve_safe_path(repo_root, rel_path)
     if target.mode == "local":
         if not safe.is_file():
             raise EvidenceError(f"file_unavailable:{rel_path}")
-        return safe.read_text(encoding="utf-8")
+        try:
+            return safe.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise EvidenceError(f"decode_failed:{rel_path}") from exc
+        except OSError as exc:
+            raise EvidenceError(f"read_failed:{rel_path}:{exc}") from exc
     if not target.head_sha:
         raise EvidenceError("target_missing_head_sha")
     # git path uses the repo-relative form, not the resolved real path.
@@ -179,7 +201,13 @@ def changed_lines_map(repo_root: Path, target: ReviewTarget) -> dict[str, set[in
             status_line = (status.stdout or "").strip()
             if status_line.startswith("??"):
                 if full.is_file():
-                    text = full.read_text(encoding="utf-8", errors="ignore")
+                    try:
+                        text = full.read_text(encoding="utf-8")
+                    except (UnicodeDecodeError, OSError):
+                        # Fail closed for line accounting: empty set means present
+                        # claims cannot invent a verified changed line.
+                        result[path] = set()
+                        continue
                     n = len(split_lines_preserve_content(text))
                     result[path] = set(range(1, n + 1)) if n else set()
                 continue
@@ -203,13 +231,106 @@ def changed_lines_map(repo_root: Path, target: ReviewTarget) -> dict[str, set[in
     return result
 
 
+def path_surface_bytes(repo_root: Path, target: ReviewTarget, rel_path: str) -> bytes:
+    """Exact patch or untracked file bytes for one path on the reviewed surface."""
+    if not is_safe_repo_relative_path(rel_path):
+        raise EvidenceError(f"unsafe_path:{rel_path!r}")
+    if target.mode == "local":
+        status = _run_git(["status", "--porcelain", "--", rel_path], repo_root)
+        status_line = (status.stdout or "").strip()
+        if status_line.startswith("??"):
+            safe = resolve_safe_path(repo_root, rel_path)
+            if not safe.is_file():
+                raise EvidenceError(f"file_unavailable:{rel_path}")
+            try:
+                return safe.read_bytes()
+            except OSError as exc:
+                raise EvidenceError(f"read_failed:{rel_path}:{exc}") from exc
+        # Working tree vs HEAD (staged + unstaged combined).
+        proc = _run_git_bytes(["diff", "HEAD", "--", rel_path], repo_root)
+        if proc.returncode not in (0, 1):
+            err = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+            raise EvidenceError(f"diff_failed:{rel_path}:{err}")
+        return proc.stdout or b""
+
+    if not target.base_sha or not target.head_sha:
+        raise EvidenceError("target_missing_base_or_head_for_fingerprint")
+    proc = _run_git_bytes(
+        ["diff", target.base_sha, target.head_sha, "--", rel_path],
+        repo_root,
+    )
+    if proc.returncode not in (0, 1):
+        err = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise EvidenceError(f"diff_failed:{rel_path}:{err}")
+    return proc.stdout or b""
+
+
+def compute_target_input_fingerprint(repo_root: Path, target: ReviewTarget) -> str:
+    """Deterministic SHA-256 of target metadata plus exact patch/untracked bytes.
+
+    Identifies the validated review target/bundle (not reviewer JSON). Changes
+    when local sources, the changed-path set, base/head, or committed content
+    change.
+    """
+    working_tree_head = ""
+    if target.mode == "local":
+        head_proc = _run_git(["rev-parse", "HEAD"], repo_root)
+        if head_proc.returncode == 0:
+            working_tree_head = (head_proc.stdout or "").strip()
+
+    meta = {
+        "fingerprint_version": TARGET_INPUT_FINGERPRINT_VERSION,
+        "mode": target.mode,
+        "base_sha": target.base_sha or "",
+        "head_sha": target.head_sha or "",
+        "working_tree_head": working_tree_head,
+        "changed_paths": list(target.changed_paths),
+        "non_test_loc": target.non_test_loc,
+        "clean_tree": target.clean_tree,
+        "description": target.description,
+    }
+    hasher = hashlib.sha256()
+    hasher.update(TARGET_INPUT_FINGERPRINT_VERSION.encode("utf-8"))
+    hasher.update(b"\0")
+    hasher.update(
+        json.dumps(meta, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    )
+    for path in target.changed_paths:
+        surface = path_surface_bytes(repo_root, target, path)
+        hasher.update(b"\0path:")
+        hasher.update(path.encode("utf-8"))
+        hasher.update(b"\0len:")
+        hasher.update(f"{len(surface)}".encode("ascii"))
+        hasher.update(b"\0")
+        hasher.update(surface)
+    return hasher.hexdigest()
+
+
+def build_target_manifest(repo_root: Path, target: ReviewTarget) -> dict:
+    """Source-blind capture of head + target-input fingerprint before review."""
+    input_sha256 = compute_target_input_fingerprint(repo_root, target)
+    return {
+        "schema_version": "code-review-target-manifest.v1",
+        "mode": target.mode,
+        "base_sha": target.base_sha,
+        "head_sha": target.head_sha,
+        "changed_paths": list(target.changed_paths),
+        "non_test_loc": target.non_test_loc,
+        "clean_tree": target.clean_tree,
+        "description": target.description,
+        "input_sha256": input_sha256,
+    }
+
+
 def find_verbatim_match(
     file_text: str, quote: str
 ) -> tuple[int | None, str | None]:
-    """Return (1-based start line, matched text) if quote is a contiguous match.
+    """Return (1-based start line, matched text) of the first contiguous match.
 
-    Matching uses line-ending normalization only. The first match wins
-    (deterministic for a fixed file).
+    Matching uses line-ending normalization only. First match is deterministic
+    for reporting an alternate location when the claimed range does not match.
     """
     file_lines = split_lines_preserve_content(file_text)
     quote_lines = split_lines_preserve_content(quote)
@@ -222,6 +343,30 @@ def find_verbatim_match(
             matched = "\n".join(window)
             return i + 1, matched
     return None, None
+
+
+def match_at_line(file_text: str, quote: str, start_line: int) -> tuple[bool, str | None]:
+    """True if ``quote`` matches contiguously starting at 1-based ``start_line``."""
+    file_lines = split_lines_preserve_content(file_text)
+    quote_lines = split_lines_preserve_content(quote)
+    if not quote_lines or start_line < 1:
+        return False, None
+    idx = start_line - 1
+    end = idx + len(quote_lines)
+    if end > len(file_lines):
+        return False, None
+    window = file_lines[idx:end]
+    if window != quote_lines:
+        return False, None
+    return True, "\n".join(window)
+
+
+def expected_end_line_for_quote(start_line: int, quote: str) -> int:
+    """Inclusive end_line that exactly covers the verbatim span."""
+    n = len(split_lines_preserve_content(quote))
+    if n < 1:
+        return start_line
+    return start_line + n - 1
 
 
 def verify_finding_evidence(
@@ -265,23 +410,44 @@ def verify_finding_evidence(
         file_text = load_file_text(repo_root, path, target)
     except EvidenceError as exc:
         return EvidenceCheckResult(OUTCOME_QUOTE_MISSING, detail=str(exc))
-
-    matched_line, matched_text = find_verbatim_match(file_text, verbatim)
-    if matched_line is None:
+    except (UnicodeDecodeError, OSError) as exc:
         return EvidenceCheckResult(
             OUTCOME_QUOTE_MISSING,
-            detail="verbatim_not_found",
+            detail=f"read_or_decode_failed:{path}:{exc}",
         )
 
-    claimed = start_line
-    if matched_line != claimed:
-        # Prefer line_mismatch over out_of_scope so a wrong line number that
-        # still quotes real code surfaces the actual matched line.
+    quote_lines = split_lines_preserve_content(verbatim)
+    expected_end = expected_end_line_for_quote(start_line, verbatim)
+    alternate_line, alternate_text = find_verbatim_match(file_text, verbatim)
+
+    # Range must equal the exact verbatim span (blocks inflated ranges that
+    # intersect unrelated changed lines).
+    if end_line != expected_end:
         return EvidenceCheckResult(
             OUTCOME_LINE_MISMATCH,
-            matched_line=matched_line,
-            matched_text=matched_text,
-            detail=f"matched_at_line:{matched_line}",
+            matched_line=alternate_line,
+            matched_text=alternate_text,
+            detail=(
+                f"range_span_mismatch:claimed={start_line}-{end_line} "
+                f"expected_end={expected_end} quote_lines={len(quote_lines)}"
+                + (f" actual_match_at={alternate_line}" if alternate_line is not None else "")
+            ),
+        )
+
+    at_claim, matched_text = match_at_line(file_text, verbatim, start_line)
+    if at_claim:
+        matched_line = start_line
+    else:
+        if alternate_line is None:
+            return EvidenceCheckResult(
+                OUTCOME_QUOTE_MISSING,
+                detail="verbatim_not_found",
+            )
+        return EvidenceCheckResult(
+            OUTCOME_LINE_MISMATCH,
+            matched_line=alternate_line,
+            matched_text=alternate_text,
+            detail=f"matched_at_line:{alternate_line}",
         )
 
     path_changed = changed_lines.get(path, set())

--- a/scripts/review/review_contract.py
+++ b/scripts/review/review_contract.py
@@ -1,0 +1,448 @@
+"""Strict structured code-review contract: schema validation, exits, receipts.
+
+Canonical format is versioned JSON (``code-review-findings.v1``). Legacy
+``FINDING:`` text blocks are **removed** as a dual source of truth — they fail
+closed as invalid input (issue #5284 compatibility decision).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from scripts.review.evidence import (
+    OUTCOME_LINE_MISMATCH,
+    OUTCOME_MALFORMED,
+    OUTCOME_OUT_OF_SCOPE,
+    OUTCOME_QUOTE_MISSING,
+    OUTCOME_VERIFIED,
+    EvidenceCheckResult,
+    changed_lines_map,
+    normalize_line_endings,
+    verify_finding_evidence,
+)
+from scripts.review.target_resolution import ReviewTarget
+
+SCHEMA_VERSION = "code-review-findings.v1"
+RECEIPT_SCHEMA_VERSION = "code-review-receipt.v1"
+SCHEMA_RELATIVE_PATH = "schemas/code-review-findings.v1.schema.json"
+
+# Stable exit classes (documented in docs/review-protocol.md).
+EXIT_CLEAN = 0
+EXIT_ACTIONABLE = 1
+EXIT_INVALID = 2
+EXIT_INCOMPLETE = 3
+EXIT_STALE = 4
+EXIT_UNVERIFIABLE = 5
+
+EXIT_NAMES = {
+    EXIT_CLEAN: "clean",
+    EXIT_ACTIONABLE: "actionable",
+    EXIT_INVALID: "invalid",
+    EXIT_INCOMPLETE: "incomplete",
+    EXIT_STALE: "stale",
+    EXIT_UNVERIFIABLE: "unverifiable",
+}
+
+_LEGACY_FINDING_RE = re.compile(r"(?m)^FINDING:\s*$")
+
+
+class ContractError(RuntimeError):
+    """Structured review input failed closed before evidence verification."""
+
+    def __init__(self, message: str, *, exit_code: int = EXIT_INVALID) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def package_repo_root() -> Path:
+    """Root of the learn-ukrainian checkout that ships the schema (not the review target)."""
+    return Path(__file__).resolve().parents[2]
+
+
+def schema_path(tooling_root: Path | None = None) -> Path:
+    root = tooling_root or package_repo_root()
+    return root / SCHEMA_RELATIVE_PATH
+
+
+def load_schema(tooling_root: Path | None = None) -> dict[str, Any]:
+    path = schema_path(tooling_root)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ContractError(f"schema_unavailable:{path}:{exc}", exit_code=EXIT_INVALID) from exc
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _looks_like_legacy_text(raw: str) -> bool:
+    return bool(_LEGACY_FINDING_RE.search(raw))
+
+
+def parse_reviewer_json(raw: str) -> dict[str, Any]:
+    """Parse reviewer stdout as a single JSON object. Fail closed on chatter."""
+    text = raw.strip()
+    if not text:
+        raise ContractError("empty_review_input", exit_code=EXIT_INCOMPLETE)
+    if _looks_like_legacy_text(text) and not text.lstrip().startswith("{"):
+        raise ContractError(
+            "legacy_FINDING_text_removed: use schema_version "
+            f"{SCHEMA_VERSION!r} JSON (see docs/review-protocol.md)",
+            exit_code=EXIT_INVALID,
+        )
+    # Reject non-JSON wrapper chatter: entire payload must be one JSON value.
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        # Also try: JSON embedded only if the whole stripped text is JSON —
+        # no fence stripping, no prose extraction (fail closed).
+        raise ContractError(
+            f"non_json_or_chatter:{exc.msg}",
+            exit_code=EXIT_INVALID,
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ContractError("review_root_must_be_object", exit_code=EXIT_INVALID)
+    return payload
+
+
+def validate_reviewer_payload(
+    payload: dict[str, Any],
+    *,
+    schema: dict[str, Any] | None = None,
+    tooling_root: Path | None = None,
+) -> dict[str, Any]:
+    """Strict JSON Schema validation (Draft 2020-12). Unknown fields fail."""
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError as exc:  # pragma: no cover - venv always has jsonschema
+        raise ContractError("jsonschema_unavailable", exit_code=EXIT_INVALID) from exc
+
+    sch = schema if schema is not None else load_schema(tooling_root)
+    validator = Draft202012Validator(sch)
+    errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path))
+    if errors:
+        first = errors[0]
+        path = ".".join(str(p) for p in first.absolute_path) or "(root)"
+        raise ContractError(
+            f"schema_violation:{path}:{first.message}",
+            exit_code=EXIT_INVALID,
+        )
+
+    # Extra structural checks not fully expressible in JSON Schema alone.
+    findings = payload["findings"]
+    ids = [f["id"] for f in findings]
+    if len(ids) != len(set(ids)):
+        raise ContractError("duplicate_finding_ids", exit_code=EXIT_INVALID)
+    for finding in findings:
+        loc = finding["location"]
+        if loc["end_line"] < loc["start_line"]:
+            raise ContractError(
+                f"invalid_line_range:{finding['id']}",
+                exit_code=EXIT_INVALID,
+            )
+    return payload
+
+
+def sort_findings_deterministically(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Stable multi-finding order: path, start_line, end_line, id."""
+    return sorted(
+        findings,
+        key=lambda f: (
+            f["location"]["path"],
+            f["location"]["start_line"],
+            f["location"]["end_line"],
+            f["id"],
+        ),
+    )
+
+
+@dataclass
+class FindingValidation:
+    id: str
+    outcome: str
+    matched_line: int | None = None
+    matched_text: str | None = None
+    detail: str = ""
+    disposition: str | None = None
+    disposition_rationale: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "outcome": self.outcome,
+            "matched_line": self.matched_line,
+            "matched_text": self.matched_text,
+            "detail": self.detail,
+            "disposition": self.disposition,
+            "disposition_rationale": self.disposition_rationale,
+        }
+
+
+@dataclass
+class AgentIdentity:
+    model: str
+    family: str
+    harness: str
+    selection_reason: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass
+class VerifyContext:
+    """Runner-supplied envelope data (not trusted from the reviewer)."""
+
+    issue_ref: str
+    scope: dict[str, Any]
+    author: AgentIdentity
+    reviewer: AgentIdentity
+    target: ReviewTarget
+    repo_root: Path
+    input_sha256: str
+    expected_head: str | None = None
+    expected_input_sha256: str | None = None
+    tests: dict[str, Any] = field(default_factory=dict)
+    behavior_proof: dict[str, Any] = field(default_factory=dict)
+    dispositions: dict[str, dict[str, str]] = field(default_factory=dict)
+    routing_lineage: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class VerifyResult:
+    exit_code: int
+    final_disposition: str
+    payload: dict[str, Any] | None
+    validations: list[FindingValidation]
+    receipt: dict[str, Any]
+    error: str | None = None
+
+
+def _check_stale(ctx: VerifyContext) -> str | None:
+    if ctx.expected_input_sha256 and ctx.expected_input_sha256 != ctx.input_sha256:
+        return (
+            f"stale_input_hash:expected={ctx.expected_input_sha256} "
+            f"actual={ctx.input_sha256}"
+        )
+    if ctx.expected_head:
+        if ctx.target.mode == "local":
+            return "stale_head_not_applicable_to_local_mode"
+        if not ctx.target.head_sha:
+            return "stale_head:target_missing_head"
+        if ctx.expected_head != ctx.target.head_sha:
+            return (
+                f"stale_head:expected={ctx.expected_head} "
+                f"actual={ctx.target.head_sha}"
+            )
+    return None
+
+
+def _classify_exit(
+    payload: dict[str, Any],
+    validations: list[FindingValidation],
+) -> tuple[int, str]:
+    outcomes = {v.outcome for v in validations}
+    if OUTCOME_MALFORMED in outcomes:
+        return EXIT_INVALID, EXIT_NAMES[EXIT_INVALID]
+    bad_evidence = outcomes & {
+        OUTCOME_QUOTE_MISSING,
+        OUTCOME_LINE_MISMATCH,
+        OUTCOME_OUT_OF_SCOPE,
+    }
+    if bad_evidence:
+        return EXIT_UNVERIFIABLE, EXIT_NAMES[EXIT_UNVERIFIABLE]
+
+    overall = payload["overall"]
+    correctness = overall["correctness"]
+    findings = payload["findings"]
+    if correctness == "uncertain" and not findings:
+        return EXIT_INCOMPLETE, EXIT_NAMES[EXIT_INCOMPLETE]
+    if correctness == "incorrect" or findings:
+        return EXIT_ACTIONABLE, EXIT_NAMES[EXIT_ACTIONABLE]
+    if correctness == "correct" and not findings:
+        return EXIT_CLEAN, EXIT_NAMES[EXIT_CLEAN]
+    # correct + findings should not happen often; still actionable.
+    return EXIT_ACTIONABLE, EXIT_NAMES[EXIT_ACTIONABLE]
+
+
+def build_receipt(
+    ctx: VerifyContext,
+    *,
+    payload: dict[str, Any] | None,
+    validations: list[FindingValidation],
+    exit_code: int,
+    final_disposition: str,
+    error: str | None = None,
+) -> dict[str, Any]:
+    target = ctx.target
+    receipt: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "issue_ref": ctx.issue_ref,
+        "scope": ctx.scope,
+        "author": ctx.author.to_dict(),
+        "reviewer": ctx.reviewer.to_dict(),
+        "target": {
+            "mode": target.mode,
+            "base_sha": target.base_sha,
+            "head_sha": target.head_sha,
+            "changed_paths": list(target.changed_paths),
+            "non_test_loc": target.non_test_loc,
+            "clean_tree": target.clean_tree,
+            "description": target.description,
+            "input_sha256": ctx.input_sha256,
+        },
+        "findings": [v.to_dict() for v in validations],
+        "tests": ctx.tests,
+        "behavior_proof": ctx.behavior_proof,
+        "final_disposition": final_disposition,
+        "exit_code": exit_code,
+        "error": error,
+        "routing_lineage": ctx.routing_lineage
+        or {
+            "implementation_agent": "grok/5284-strict-review-receipts",
+            "accountable_advisor": "GPT-5.6 Sol",
+            "selection_note": (
+                "Grok 4.5 high substituted for the issue's provisional Claude "
+                "developer due to live routing-budget recommendation; "
+                "GPT-5.6 Sol remains accountable advisor/integrator and "
+                "cross-family reviewer."
+            ),
+        },
+    }
+    if payload is not None:
+        receipt["reviewer_payload"] = {
+            "schema_version": payload.get("schema_version"),
+            "overall": payload.get("overall"),
+            "finding_ids": [f["id"] for f in payload.get("findings", [])],
+        }
+    return receipt
+
+
+def verify_review(
+    raw_input: str,
+    ctx: VerifyContext,
+    *,
+    schema: dict[str, Any] | None = None,
+) -> VerifyResult:
+    """Full pipeline: parse → schema → stale checks → evidence → receipt."""
+    input_hash = sha256_text(raw_input)
+    # Prefer the hash the runner computed when building ctx, but keep consistency.
+    if ctx.input_sha256 and ctx.input_sha256 != input_hash:
+        # Runner may have hashed a different byte string; trust recomputed hash
+        # for the receipt and treat expected hash checks against ctx fields.
+        pass
+    ctx.input_sha256 = input_hash
+
+    stale = _check_stale(ctx)
+    if stale:
+        receipt = build_receipt(
+            ctx,
+            payload=None,
+            validations=[],
+            exit_code=EXIT_STALE,
+            final_disposition=EXIT_NAMES[EXIT_STALE],
+            error=stale,
+        )
+        return VerifyResult(
+            exit_code=EXIT_STALE,
+            final_disposition=EXIT_NAMES[EXIT_STALE],
+            payload=None,
+            validations=[],
+            receipt=receipt,
+            error=stale,
+        )
+
+    try:
+        payload = parse_reviewer_json(raw_input)
+        payload = validate_reviewer_payload(payload, schema=schema)
+    except ContractError as exc:
+        receipt = build_receipt(
+            ctx,
+            payload=None,
+            validations=[],
+            exit_code=exc.exit_code,
+            final_disposition=EXIT_NAMES.get(exc.exit_code, "invalid"),
+            error=str(exc),
+        )
+        return VerifyResult(
+            exit_code=exc.exit_code,
+            final_disposition=EXIT_NAMES.get(exc.exit_code, "invalid"),
+            payload=None,
+            validations=[],
+            receipt=receipt,
+            error=str(exc),
+        )
+
+    findings = sort_findings_deterministically(list(payload["findings"]))
+    payload = {**payload, "findings": findings}
+
+    try:
+        line_map = changed_lines_map(ctx.repo_root, ctx.target)
+    except Exception as exc:  # fail closed
+        err = f"changed_lines_unavailable:{exc}"
+        receipt = build_receipt(
+            ctx,
+            payload=payload,
+            validations=[],
+            exit_code=EXIT_UNVERIFIABLE,
+            final_disposition=EXIT_NAMES[EXIT_UNVERIFIABLE],
+            error=err,
+        )
+        return VerifyResult(
+            exit_code=EXIT_UNVERIFIABLE,
+            final_disposition=EXIT_NAMES[EXIT_UNVERIFIABLE],
+            payload=payload,
+            validations=[],
+            receipt=receipt,
+            error=err,
+        )
+
+    validations: list[FindingValidation] = []
+    for finding in findings:
+        check: EvidenceCheckResult = verify_finding_evidence(
+            finding,
+            repo_root=ctx.repo_root,
+            target=ctx.target,
+            changed_lines=line_map,
+        )
+        disp = ctx.dispositions.get(finding["id"], {})
+        validations.append(
+            FindingValidation(
+                id=finding["id"],
+                outcome=check.outcome,
+                matched_line=check.matched_line,
+                matched_text=check.matched_text,
+                detail=check.detail,
+                disposition=disp.get("disposition"),
+                disposition_rationale=disp.get("rationale"),
+            )
+        )
+
+    exit_code, final_disposition = _classify_exit(payload, validations)
+    receipt = build_receipt(
+        ctx,
+        payload=payload,
+        validations=validations,
+        exit_code=exit_code,
+        final_disposition=final_disposition,
+        error=None,
+    )
+    return VerifyResult(
+        exit_code=exit_code,
+        final_disposition=final_disposition,
+        payload=payload,
+        validations=validations,
+        receipt=receipt,
+        error=None,
+    )
+
+
+def normalize_for_hash(raw: str) -> str:
+    """Expose line-ending-only normalization for callers that need it."""
+    return normalize_line_endings(raw)

--- a/scripts/review/review_contract.py
+++ b/scripts/review/review_contract.py
@@ -19,9 +19,10 @@ from scripts.review.evidence import (
     OUTCOME_MALFORMED,
     OUTCOME_OUT_OF_SCOPE,
     OUTCOME_QUOTE_MISSING,
-    OUTCOME_VERIFIED,
     EvidenceCheckResult,
+    EvidenceError,
     changed_lines_map,
+    compute_target_input_fingerprint,
     normalize_line_endings,
     verify_finding_evidence,
 )
@@ -47,6 +48,23 @@ EXIT_NAMES = {
     EXIT_STALE: "stale",
     EXIT_UNVERIFIABLE: "unverifiable",
 }
+
+ALLOWED_DISPOSITIONS = frozenset(
+    {
+        "in_scope_blocker",
+        "follow_up",
+        "stop_and_escalate",
+    }
+)
+
+# Explicitly rejected identity / envelope placeholders (fail closed).
+PLACEHOLDER_VALUES = frozenset(
+    {
+        "unknown",
+        "unspecified",
+        "not_provided",
+    }
+)
 
 _LEGACY_FINDING_RE = re.compile(r"(?m)^FINDING:\s*$")
 
@@ -83,6 +101,13 @@ def sha256_text(text: str) -> str:
 
 def _looks_like_legacy_text(raw: str) -> bool:
     return bool(_LEGACY_FINDING_RE.search(raw))
+
+
+def _is_placeholder(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return True
+    return stripped.lower() in PLACEHOLDER_VALUES
 
 
 def parse_reviewer_json(raw: str) -> dict[str, Any]:
@@ -205,8 +230,12 @@ class VerifyContext:
     reviewer: AgentIdentity
     target: ReviewTarget
     repo_root: Path
+    # Target-input fingerprint (validated review surface), not reviewer JSON.
     input_sha256: str
+    # SHA-256 of the reviewer JSON bytes (recorded separately on the receipt).
+    reviewer_output_sha256: str = ""
     expected_head: str | None = None
+    # Required for clean/actionable: expected target-input fingerprint.
     expected_input_sha256: str | None = None
     tests: dict[str, Any] = field(default_factory=dict)
     behavior_proof: dict[str, Any] = field(default_factory=dict)
@@ -222,6 +251,128 @@ class VerifyResult:
     validations: list[FindingValidation]
     receipt: dict[str, Any]
     error: str | None = None
+
+
+def _identity_errors(label: str, identity: AgentIdentity) -> list[str]:
+    errors: list[str] = []
+    for field_name in ("model", "family", "harness", "selection_reason"):
+        value = getattr(identity, field_name)
+        if not isinstance(value, str) or _is_placeholder(value):
+            errors.append(f"{label}.{field_name}_missing_or_placeholder")
+    return errors
+
+
+def validate_closeout_envelope(
+    ctx: VerifyContext,
+    *,
+    finding_ids: list[str],
+) -> tuple[int, str] | None:
+    """Return (exit_code, error) when envelope cannot support clean/actionable.
+
+    Never fabricates lineage. Placeholder values fail closed.
+    """
+    errors: list[str] = []
+
+    if not isinstance(ctx.issue_ref, str) or _is_placeholder(ctx.issue_ref):
+        errors.append("issue_ref_missing_or_placeholder")
+
+    if not isinstance(ctx.scope, dict) or not ctx.scope:
+        errors.append("scope_empty")
+    else:
+        # Require at least one concrete non-empty value.
+        concrete = False
+        for value in ctx.scope.values():
+            if value is None:
+                continue
+            if isinstance(value, str) and _is_placeholder(value):
+                continue
+            if isinstance(value, (list, dict)) and not value:
+                continue
+            concrete = True
+            break
+        if not concrete:
+            errors.append("scope_lacks_concrete_values")
+
+    errors.extend(_identity_errors("author", ctx.author))
+    errors.extend(_identity_errors("reviewer", ctx.reviewer))
+
+    if not isinstance(ctx.tests, dict) or not ctx.tests:
+        errors.append("tests_empty")
+
+    if not isinstance(ctx.behavior_proof, dict):
+        errors.append("behavior_proof_invalid")
+    else:
+        for key in ("source_aware", "source_blind"):
+            proof = ctx.behavior_proof.get(key)
+            if not isinstance(proof, dict) or not proof:
+                errors.append(f"behavior_proof.{key}_missing")
+
+    if not isinstance(ctx.routing_lineage, dict) or not ctx.routing_lineage:
+        errors.append("routing_lineage_empty")
+    else:
+        for key, value in ctx.routing_lineage.items():
+            if not isinstance(key, str) or not key.strip():
+                errors.append("routing_lineage_invalid_key")
+                break
+            if not isinstance(value, str) or _is_placeholder(value):
+                errors.append(f"routing_lineage.{key}_missing_or_placeholder")
+
+    if not ctx.expected_input_sha256 or _is_placeholder(str(ctx.expected_input_sha256)):
+        errors.append("expected_input_sha256_required")
+
+    finding_id_set = set(finding_ids)
+    disposition_keys = set(ctx.dispositions.keys())
+    unknown = sorted(disposition_keys - finding_id_set)
+    missing = sorted(finding_id_set - disposition_keys)
+    if unknown:
+        errors.append(f"disposition_unknown_ids:{','.join(unknown)}")
+    if missing:
+        errors.append(f"disposition_missing_ids:{','.join(missing)}")
+    for fid in finding_ids:
+        entry = ctx.dispositions.get(fid)
+        if not isinstance(entry, dict):
+            continue
+        disp = entry.get("disposition")
+        rationale = entry.get("rationale")
+        if not isinstance(disp, str) or disp not in ALLOWED_DISPOSITIONS:
+            errors.append(f"disposition_invalid:{fid}")
+        if not isinstance(rationale, str) or not rationale.strip():
+            errors.append(f"disposition_rationale_empty:{fid}")
+
+    if not errors:
+        return None
+
+    # Structural/placeholder failures are incomplete (not invalid schema of
+    # reviewer JSON). Unknown disposition enums / unknown IDs are invalid
+    # envelope data → EXIT_INVALID when only those fire; mix defaults to
+    # incomplete so absence of required runner fields stays EXIT_INCOMPLETE.
+    hard = any(
+        e.startswith(
+            (
+                "disposition_unknown_ids:",
+                "disposition_invalid:",
+            )
+        )
+        for e in errors
+    )
+    code = EXIT_INVALID if hard and all(
+        e.startswith(("disposition_unknown_ids:", "disposition_invalid:", "disposition_rationale_empty:", "disposition_missing_ids:"))
+        for e in errors
+    ) else EXIT_INCOMPLETE
+    # Prefer incomplete when any required runner field is absent.
+    if any(
+        not e.startswith(
+            (
+                "disposition_unknown_ids:",
+                "disposition_invalid:",
+                "disposition_rationale_empty:",
+                "disposition_missing_ids:",
+            )
+        )
+        for e in errors
+    ):
+        code = EXIT_INCOMPLETE
+    return code, "envelope_incomplete:" + ";".join(errors)
 
 
 def _check_stale(ctx: VerifyContext) -> str | None:
@@ -280,6 +431,7 @@ def build_receipt(
     final_disposition: str,
     error: str | None = None,
 ) -> dict[str, Any]:
+    """Build a runner receipt. Never fabricates routing lineage or identities."""
     target = ctx.target
     receipt: dict[str, Any] = {
         "schema_version": RECEIPT_SCHEMA_VERSION,
@@ -295,25 +447,18 @@ def build_receipt(
             "non_test_loc": target.non_test_loc,
             "clean_tree": target.clean_tree,
             "description": target.description,
+            # Target-input fingerprint of the validated review surface.
             "input_sha256": ctx.input_sha256,
         },
+        "reviewer_output_sha256": ctx.reviewer_output_sha256,
         "findings": [v.to_dict() for v in validations],
         "tests": ctx.tests,
         "behavior_proof": ctx.behavior_proof,
         "final_disposition": final_disposition,
         "exit_code": exit_code,
         "error": error,
-        "routing_lineage": ctx.routing_lineage
-        or {
-            "implementation_agent": "grok/5284-strict-review-receipts",
-            "accountable_advisor": "GPT-5.6 Sol",
-            "selection_note": (
-                "Grok 4.5 high substituted for the issue's provisional Claude "
-                "developer due to live routing-budget recommendation; "
-                "GPT-5.6 Sol remains accountable advisor/integrator and "
-                "cross-family reviewer."
-            ),
-        },
+        # Explicit runner-supplied lineage only — empty when not provided.
+        "routing_lineage": dict(ctx.routing_lineage),
     }
     if payload is not None:
         receipt["reviewer_payload"] = {
@@ -330,14 +475,33 @@ def verify_review(
     *,
     schema: dict[str, Any] | None = None,
 ) -> VerifyResult:
-    """Full pipeline: parse → schema → stale checks → evidence → receipt."""
-    input_hash = sha256_text(raw_input)
-    # Prefer the hash the runner computed when building ctx, but keep consistency.
-    if ctx.input_sha256 and ctx.input_sha256 != input_hash:
-        # Runner may have hashed a different byte string; trust recomputed hash
-        # for the receipt and treat expected hash checks against ctx fields.
-        pass
-    ctx.input_sha256 = input_hash
+    """Full pipeline: target fingerprint → parse → schema → evidence → receipt."""
+    reviewer_output_sha = sha256_text(raw_input)
+    ctx.reviewer_output_sha256 = reviewer_output_sha
+
+    try:
+        target_fp = compute_target_input_fingerprint(ctx.repo_root, ctx.target)
+    except EvidenceError as exc:
+        err = f"target_fingerprint_unavailable:{exc}"
+        ctx.input_sha256 = ""
+        receipt = build_receipt(
+            ctx,
+            payload=None,
+            validations=[],
+            exit_code=EXIT_UNVERIFIABLE,
+            final_disposition=EXIT_NAMES[EXIT_UNVERIFIABLE],
+            error=err,
+        )
+        return VerifyResult(
+            exit_code=EXIT_UNVERIFIABLE,
+            final_disposition=EXIT_NAMES[EXIT_UNVERIFIABLE],
+            payload=None,
+            validations=[],
+            receipt=receipt,
+            error=err,
+        )
+
+    ctx.input_sha256 = target_fp
 
     stale = _check_stale(ctx)
     if stale:
@@ -419,19 +583,31 @@ def verify_review(
                 matched_line=check.matched_line,
                 matched_text=check.matched_text,
                 detail=check.detail,
-                disposition=disp.get("disposition"),
-                disposition_rationale=disp.get("rationale"),
+                disposition=disp.get("disposition") if isinstance(disp, dict) else None,
+                disposition_rationale=disp.get("rationale") if isinstance(disp, dict) else None,
             )
         )
 
     exit_code, final_disposition = _classify_exit(payload, validations)
+    error: str | None = None
+
+    # Clean/actionable require complete provenance + expected target fingerprint.
+    if exit_code in (EXIT_CLEAN, EXIT_ACTIONABLE):
+        envelope = validate_closeout_envelope(
+            ctx,
+            finding_ids=[f["id"] for f in findings],
+        )
+        if envelope is not None:
+            exit_code, error = envelope
+            final_disposition = EXIT_NAMES[exit_code]
+
     receipt = build_receipt(
         ctx,
         payload=payload,
         validations=validations,
         exit_code=exit_code,
         final_disposition=final_disposition,
-        error=None,
+        error=error,
     )
     return VerifyResult(
         exit_code=exit_code,
@@ -439,7 +615,7 @@ def verify_review(
         payload=payload,
         validations=validations,
         receipt=receipt,
-        error=None,
+        error=error,
     )
 
 

--- a/scripts/review/review_contract.py
+++ b/scripts/review/review_contract.py
@@ -90,9 +90,16 @@ def schema_path(tooling_root: Path | None = None) -> Path:
 def load_schema(tooling_root: Path | None = None) -> dict[str, Any]:
     path = schema_path(tooling_root)
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise ContractError(f"schema_unavailable:{path}:{exc}", exit_code=EXIT_INVALID) from exc
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ContractError(
+            f"schema_invalid_json:{path}:{exc.msg}",
+            exit_code=EXIT_INVALID,
+        ) from exc
 
 
 def sha256_text(text: str) -> str:
@@ -108,6 +115,10 @@ def _is_placeholder(value: str) -> bool:
     if not stripped:
         return True
     return stripped.lower() in PLACEHOLDER_VALUES
+
+
+def _canonical_family(value: str) -> str:
+    return value.strip().lower()
 
 
 def parse_reviewer_json(raw: str) -> dict[str, Any]:
@@ -145,10 +156,18 @@ def validate_reviewer_payload(
     """Strict JSON Schema validation (Draft 2020-12). Unknown fields fail."""
     try:
         from jsonschema import Draft202012Validator
+        from jsonschema.exceptions import SchemaError
     except ImportError as exc:  # pragma: no cover - venv always has jsonschema
         raise ContractError("jsonschema_unavailable", exit_code=EXIT_INVALID) from exc
 
     sch = schema if schema is not None else load_schema(tooling_root)
+    try:
+        Draft202012Validator.check_schema(sch)
+    except SchemaError as exc:
+        raise ContractError(
+            f"schema_meta_invalid:{exc.message}",
+            exit_code=EXIT_INVALID,
+        ) from exc
     validator = Draft202012Validator(sch)
     errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path))
     if errors:
@@ -262,22 +281,113 @@ def _identity_errors(label: str, identity: AgentIdentity) -> list[str]:
     return errors
 
 
+def _tests_envelope_status(tests: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Validate tests closeout semantics.
+
+    Returns (incomplete_errors, proof_failures).
+    Successful closeout needs concrete commands + ``passed: true``, or explicit
+    supported ``status: n/a`` with a non-empty reason. Explicit failure
+    (``passed: false`` / ``status: fail``) is a proof failure, not incomplete.
+    """
+    incomplete: list[str] = []
+    failures: list[str] = []
+    if not isinstance(tests, dict) or not tests:
+        return ["tests_empty"], failures
+
+    status_raw = tests.get("status")
+    status = status_raw.strip().lower() if isinstance(status_raw, str) else None
+    passed = tests.get("passed")
+    commands = tests.get("commands")
+    reason = tests.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        rationale = tests.get("rationale")
+        reason = rationale if isinstance(rationale, str) else reason
+
+    if status in {"fail", "failed"}:
+        failures.append("tests_failed")
+        return incomplete, failures
+    if passed is False:
+        failures.append("tests_failed")
+        return incomplete, failures
+    if status in {"n/a", "na"}:
+        if not isinstance(reason, str) or not reason.strip():
+            incomplete.append("tests_na_reason_empty")
+        return incomplete, failures
+    if passed is True:
+        if not isinstance(commands, list) or not commands:
+            incomplete.append("tests_commands_missing")
+        elif not all(isinstance(c, str) and c.strip() for c in commands):
+            incomplete.append("tests_commands_invalid")
+        return incomplete, failures
+
+    incomplete.append("tests_result_missing_or_invalid")
+    return incomplete, failures
+
+
+def _behavior_proof_envelope_status(
+    behavior_proof: Any,
+) -> tuple[list[str], list[str]]:
+    """Validate source-aware / source-blind proof semantics.
+
+    Each side must be ``status: pass`` or ``status: n/a`` with a non-empty
+    reason. Explicit ``fail`` is a proof failure (non-clean/actionable).
+    Missing or invalid status remains incomplete.
+    """
+    incomplete: list[str] = []
+    failures: list[str] = []
+    if not isinstance(behavior_proof, dict):
+        return ["behavior_proof_invalid"], failures
+
+    for key in ("source_aware", "source_blind"):
+        proof = behavior_proof.get(key)
+        if not isinstance(proof, dict) or not proof:
+            incomplete.append(f"behavior_proof.{key}_missing")
+            continue
+        status_raw = proof.get("status")
+        if not isinstance(status_raw, str) or not status_raw.strip():
+            incomplete.append(f"behavior_proof.{key}_status_missing")
+            continue
+        status = status_raw.strip().lower()
+        if status == "fail":
+            failures.append(f"behavior_proof.{key}_failed")
+            continue
+        if status == "pass":
+            continue
+        if status in {"n/a", "na"}:
+            reason = proof.get("reason")
+            if not isinstance(reason, str) or not reason.strip():
+                rationale = proof.get("rationale")
+                reason = rationale if isinstance(rationale, str) else reason
+            if not isinstance(reason, str) or not reason.strip():
+                incomplete.append(f"behavior_proof.{key}_na_reason_empty")
+            continue
+        incomplete.append(f"behavior_proof.{key}_status_invalid")
+    return incomplete, failures
+
+
 def validate_closeout_envelope(
     ctx: VerifyContext,
     *,
     finding_ids: list[str],
 ) -> tuple[int, str] | None:
-    """Return (exit_code, error) when envelope cannot support clean/actionable.
+    """Return (exit_code, error) when envelope cannot support clean closeout.
 
     Never fabricates lineage. Placeholder values fail closed.
+
+    Structural / missing / invalid envelope fields → ``EXIT_INCOMPLETE`` (or
+    ``EXIT_INVALID`` for hard disposition errors alone). Explicit proof
+    failures (failed tests, failed behavior proof, same-family author/reviewer)
+    → ``EXIT_ACTIONABLE`` so the receipt is non-clean and never exits 0.
     """
-    errors: list[str] = []
+    incomplete: list[str] = []
+    proof_failures: list[str] = []
+    hard_errors: list[str] = []
 
     if not isinstance(ctx.issue_ref, str) or _is_placeholder(ctx.issue_ref):
-        errors.append("issue_ref_missing_or_placeholder")
+        incomplete.append("issue_ref_missing_or_placeholder")
 
     if not isinstance(ctx.scope, dict) or not ctx.scope:
-        errors.append("scope_empty")
+        incomplete.append("scope_empty")
     else:
         # Require at least one concrete non-empty value.
         concrete = False
@@ -291,43 +401,55 @@ def validate_closeout_envelope(
             concrete = True
             break
         if not concrete:
-            errors.append("scope_lacks_concrete_values")
+            incomplete.append("scope_lacks_concrete_values")
 
-    errors.extend(_identity_errors("author", ctx.author))
-    errors.extend(_identity_errors("reviewer", ctx.reviewer))
+    incomplete.extend(_identity_errors("author", ctx.author))
+    incomplete.extend(_identity_errors("reviewer", ctx.reviewer))
 
-    if not isinstance(ctx.tests, dict) or not ctx.tests:
-        errors.append("tests_empty")
+    # Formal closeout requires concrete, distinct families (case-insensitive).
+    author_family_ok = not any(
+        e.startswith("author.family_") for e in incomplete
+    )
+    reviewer_family_ok = not any(
+        e.startswith("reviewer.family_") for e in incomplete
+    )
+    if (
+        author_family_ok
+        and reviewer_family_ok
+        and _canonical_family(ctx.author.family)
+        == _canonical_family(ctx.reviewer.family)
+    ):
+        proof_failures.append("same_family_review")
 
-    if not isinstance(ctx.behavior_proof, dict):
-        errors.append("behavior_proof_invalid")
-    else:
-        for key in ("source_aware", "source_blind"):
-            proof = ctx.behavior_proof.get(key)
-            if not isinstance(proof, dict) or not proof:
-                errors.append(f"behavior_proof.{key}_missing")
+    t_incomplete, t_failures = _tests_envelope_status(ctx.tests)
+    incomplete.extend(t_incomplete)
+    proof_failures.extend(t_failures)
+
+    b_incomplete, b_failures = _behavior_proof_envelope_status(ctx.behavior_proof)
+    incomplete.extend(b_incomplete)
+    proof_failures.extend(b_failures)
 
     if not isinstance(ctx.routing_lineage, dict) or not ctx.routing_lineage:
-        errors.append("routing_lineage_empty")
+        incomplete.append("routing_lineage_empty")
     else:
         for key, value in ctx.routing_lineage.items():
             if not isinstance(key, str) or not key.strip():
-                errors.append("routing_lineage_invalid_key")
+                incomplete.append("routing_lineage_invalid_key")
                 break
             if not isinstance(value, str) or _is_placeholder(value):
-                errors.append(f"routing_lineage.{key}_missing_or_placeholder")
+                incomplete.append(f"routing_lineage.{key}_missing_or_placeholder")
 
     if not ctx.expected_input_sha256 or _is_placeholder(str(ctx.expected_input_sha256)):
-        errors.append("expected_input_sha256_required")
+        incomplete.append("expected_input_sha256_required")
 
     finding_id_set = set(finding_ids)
     disposition_keys = set(ctx.dispositions.keys())
     unknown = sorted(disposition_keys - finding_id_set)
     missing = sorted(finding_id_set - disposition_keys)
     if unknown:
-        errors.append(f"disposition_unknown_ids:{','.join(unknown)}")
+        hard_errors.append(f"disposition_unknown_ids:{','.join(unknown)}")
     if missing:
-        errors.append(f"disposition_missing_ids:{','.join(missing)}")
+        incomplete.append(f"disposition_missing_ids:{','.join(missing)}")
     for fid in finding_ids:
         entry = ctx.dispositions.get(fid)
         if not isinstance(entry, dict):
@@ -335,44 +457,27 @@ def validate_closeout_envelope(
         disp = entry.get("disposition")
         rationale = entry.get("rationale")
         if not isinstance(disp, str) or disp not in ALLOWED_DISPOSITIONS:
-            errors.append(f"disposition_invalid:{fid}")
+            hard_errors.append(f"disposition_invalid:{fid}")
         if not isinstance(rationale, str) or not rationale.strip():
-            errors.append(f"disposition_rationale_empty:{fid}")
+            incomplete.append(f"disposition_rationale_empty:{fid}")
 
-    if not errors:
+    if not incomplete and not proof_failures and not hard_errors:
         return None
 
-    # Structural/placeholder failures are incomplete (not invalid schema of
-    # reviewer JSON). Unknown disposition enums / unknown IDs are invalid
-    # envelope data → EXIT_INVALID when only those fire; mix defaults to
-    # incomplete so absence of required runner fields stays EXIT_INCOMPLETE.
-    hard = any(
-        e.startswith(
-            (
-                "disposition_unknown_ids:",
-                "disposition_invalid:",
-            )
+    # Prefer incomplete when required runner fields are absent/invalid.
+    if incomplete:
+        return (
+            EXIT_INCOMPLETE,
+            "envelope_incomplete:" + ";".join(incomplete + hard_errors + proof_failures),
         )
-        for e in errors
-    )
-    code = EXIT_INVALID if hard and all(
-        e.startswith(("disposition_unknown_ids:", "disposition_invalid:", "disposition_rationale_empty:", "disposition_missing_ids:"))
-        for e in errors
-    ) else EXIT_INCOMPLETE
-    # Prefer incomplete when any required runner field is absent.
-    if any(
-        not e.startswith(
-            (
-                "disposition_unknown_ids:",
-                "disposition_invalid:",
-                "disposition_rationale_empty:",
-                "disposition_missing_ids:",
-            )
+    # Explicit failed proof / same-family → non-clean actionable (never exit 0).
+    if proof_failures:
+        return (
+            EXIT_ACTIONABLE,
+            "envelope_proof_failed:" + ";".join(proof_failures + hard_errors),
         )
-        for e in errors
-    ):
-        code = EXIT_INCOMPLETE
-    return code, "envelope_incomplete:" + ";".join(errors)
+    # Unknown disposition ids / invalid enums alone → invalid envelope.
+    return EXIT_INVALID, "envelope_invalid:" + ";".join(hard_errors)
 
 
 def _check_stale(ctx: VerifyContext) -> str | None:

--- a/scripts/verify_review.py
+++ b/scripts/verify_review.py
@@ -5,12 +5,26 @@ Canonical reviewer output is versioned JSON (``code-review-findings.v1``).
 Legacy ``FINDING:`` text is rejected. Verification binds to an exact
 local/commit/branch/PR target from ``scripts.review.target_resolution``.
 
+Two-stage usage (target freshness):
+
+  1. Capture target manifest / fingerprint *before* the reviewer runs
+     (source-blind; no review JSON required)::
+
+         .venv/bin/python scripts/verify_review.py --emit-target-manifest \\
+           --mode local --repo-root .
+
+  2. After the reviewer returns JSON, verify with the same mode/target and
+     pass ``--expected-input-sha256`` (target-input fingerprint from step 1)
+     plus identity/scope/tests/behavior-proof/lineage envelope fields.
+     ``input_sha256`` on the receipt is the recomputed target fingerprint;
+     ``reviewer_output_sha256`` records the reviewer JSON separately.
+
 Exit codes (stable):
   0 clean valid review
   1 valid review with actionable findings / incorrect overall
   2 invalid (schema, non-JSON, legacy text, malformed)
   3 incomplete
-  4 stale (head / input hash)
+  4 stale (head / target-input hash)
   5 unverifiable (quote/line/scope evidence failure)
 
 GitHub posting is opt-in (``--post-comment``). Receipts go to stdout and/or
@@ -31,10 +45,12 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from scripts.review.evidence import build_target_manifest
 from scripts.review.review_contract import (
     EXIT_INVALID,
     AgentIdentity,
     VerifyContext,
+    compute_target_input_fingerprint,
     sha256_text,
     verify_review,
 )
@@ -110,6 +126,7 @@ def _post_summary(issue: int, receipt: dict) -> None:
         f"- disposition: {receipt.get('final_disposition')}",
         f"- exit_code: {receipt.get('exit_code')}",
         f"- input_sha256: {(receipt.get('target') or {}).get('input_sha256')}",
+        f"- reviewer_output_sha256: {receipt.get('reviewer_output_sha256')}",
     ]
     for name in (
         "verified",
@@ -124,7 +141,10 @@ def _post_summary(issue: int, receipt: dict) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Verify structured code-review JSON against an exact target."
+        description=(
+            "Verify structured code-review JSON against an exact target, "
+            "or emit a source-blind target manifest/fingerprint."
+        )
     )
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--issue", type=int, help="Read latest issue comment as review JSON")
@@ -133,6 +153,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--review-file",
         type=Path,
         help="Read review JSON from a local file",
+    )
+    source.add_argument(
+        "--emit-target-manifest",
+        action="store_true",
+        help=(
+            "Source-blind: resolve the target and print head + target-input "
+            "fingerprint JSON (no reviewer input). Capture before review."
+        ),
     )
 
     parser.add_argument(
@@ -153,29 +181,37 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--expected-input-sha256",
-        help="Fail EXIT_STALE if review input SHA-256 differs",
+        help=(
+            "Expected target-input fingerprint (from --emit-target-manifest). "
+            "Required for clean/actionable; mismatch → EXIT_STALE."
+        ),
     )
 
-    parser.add_argument("--issue-ref", default="", help="Originating issue/request id for receipt")
+    # No placeholder defaults — empty means missing; closeout fails closed.
+    parser.add_argument(
+        "--issue-ref",
+        default="",
+        help="Originating issue/request id for receipt (required for clean/actionable)",
+    )
     parser.add_argument(
         "--scope-json",
         default="",
-        help="Frozen scope JSON object or path (runner-supplied)",
+        help="Frozen scope JSON object or path (required for clean/actionable)",
     )
 
-    parser.add_argument("--author-model", default="unknown")
-    parser.add_argument("--author-family", default="unknown")
-    parser.add_argument("--author-harness", default="unknown")
-    parser.add_argument("--author-selection-reason", default="not_provided")
-    parser.add_argument("--reviewer-model", default="unknown")
-    parser.add_argument("--reviewer-family", default="unknown")
-    parser.add_argument("--reviewer-harness", default="unknown")
-    parser.add_argument("--reviewer-selection-reason", default="not_provided")
+    parser.add_argument("--author-model", default="")
+    parser.add_argument("--author-family", default="")
+    parser.add_argument("--author-harness", default="")
+    parser.add_argument("--author-selection-reason", default="")
+    parser.add_argument("--reviewer-model", default="")
+    parser.add_argument("--reviewer-family", default="")
+    parser.add_argument("--reviewer-harness", default="")
+    parser.add_argument("--reviewer-selection-reason", default="")
 
     parser.add_argument(
         "--tests-json",
         default="",
-        help="JSON object describing tests run (runner-supplied)",
+        help="JSON object describing tests run (required for clean/actionable)",
     )
     parser.add_argument(
         "--behavior-proof-json",
@@ -185,12 +221,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dispositions-json",
         default="",
-        help='JSON object mapping finding id → {"disposition","rationale"}',
+        help=(
+            'JSON object mapping finding id → {"disposition","rationale"}; '
+            "dispositions: in_scope_blocker|follow_up|stop_and_escalate"
+        ),
     )
     parser.add_argument(
         "--routing-lineage-json",
         default="",
-        help="JSON object recording implementation/routing provenance",
+        help="JSON object recording implementation/routing provenance (required; never fabricated)",
     )
 
     parser.add_argument(
@@ -211,13 +250,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-
-    if args.post_comment and args.issue is None:
-        parser.error("--post-comment requires --issue")
-
+def _resolve_target(args: argparse.Namespace):
     repo_root = Path(args.repo_root).resolve()
     try:
         target = resolve_review_target(
@@ -231,7 +264,33 @@ def main(argv: list[str] | None = None) -> int:
     except TargetResolutionError as exc:
         err = {"error": str(exc), "final_disposition": "invalid", "exit_code": EXIT_INVALID}
         print(json.dumps(err, ensure_ascii=False), file=sys.stderr)
-        return EXIT_INVALID
+        raise SystemExit(EXIT_INVALID) from exc
+    return repo_root, target
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.post_comment and args.issue is None:
+        parser.error("--post-comment requires --issue")
+
+    repo_root, target = _resolve_target(args)
+
+    if args.emit_target_manifest:
+        try:
+            manifest = build_target_manifest(repo_root, target)
+        except Exception as exc:
+            print(
+                json.dumps(
+                    {"error": f"target_manifest_failed:{exc}", "exit_code": EXIT_INVALID},
+                    ensure_ascii=False,
+                ),
+                file=sys.stderr,
+            )
+            return EXIT_INVALID
+        print(json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
 
     try:
         raw = _read_review(args.issue, args.from_stdin, args.review_file)
@@ -239,7 +298,15 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps({"error": f"read_review_failed:{exc}"}, ensure_ascii=False), file=sys.stderr)
         return EXIT_INVALID
 
-    issue_ref = args.issue_ref or (f"#{args.issue}" if args.issue else "unspecified")
+    # Prefer explicit --issue-ref; otherwise derive only a concrete #N from --issue.
+    # Never invent "unspecified".
+    if args.issue_ref:
+        issue_ref = args.issue_ref
+    elif args.issue is not None:
+        issue_ref = f"#{args.issue}"
+    else:
+        issue_ref = ""
+
     scope = _load_json_arg(args.scope_json or None, label="--scope-json")
     tests = _load_json_arg(args.tests_json or None, label="--tests-json")
     behavior_proof = _load_json_arg(
@@ -251,6 +318,18 @@ def main(argv: list[str] | None = None) -> int:
     routing_lineage = _load_json_arg(
         args.routing_lineage_json or None, label="--routing-lineage-json"
     )
+
+    try:
+        target_fp = compute_target_input_fingerprint(repo_root, target)
+    except Exception as exc:
+        print(
+            json.dumps(
+                {"error": f"target_fingerprint_failed:{exc}", "exit_code": EXIT_INVALID},
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+        )
+        return EXIT_INVALID
 
     ctx = VerifyContext(
         issue_ref=issue_ref,
@@ -269,9 +348,10 @@ def main(argv: list[str] | None = None) -> int:
         ),
         target=target,
         repo_root=repo_root,
-        input_sha256=sha256_text(raw),
+        input_sha256=target_fp,
+        reviewer_output_sha256=sha256_text(raw),
         expected_head=args.expected_head,
-        expected_input_sha256=args.expected_input_sha256,
+        expected_input_sha256=args.expected_input_sha256 or None,
         tests=tests,
         behavior_proof=behavior_proof,
         dispositions={

--- a/scripts/verify_review.py
+++ b/scripts/verify_review.py
@@ -1,16 +1,54 @@
+#!/usr/bin/env python3
+"""Strict structured code-review verifier and receipt runner (issue #5284).
+
+Canonical reviewer output is versioned JSON (``code-review-findings.v1``).
+Legacy ``FINDING:`` text is rejected. Verification binds to an exact
+local/commit/branch/PR target from ``scripts.review.target_resolution``.
+
+Exit codes (stable):
+  0 clean valid review
+  1 valid review with actionable findings / incorrect overall
+  2 invalid (schema, non-JSON, legacy text, malformed)
+  3 incomplete
+  4 stale (head / input hash)
+  5 unverifiable (quote/line/scope evidence failure)
+
+GitHub posting is opt-in (``--post-comment``). Receipts go to stdout and/or
+``--receipt-path`` — never to status/, audit/*-review.md, review/*-review.md,
+or telemetry paths.
+"""
+
 from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
 
-FINDING_RE = re.compile(r"(?ms)^FINDING:\s*\n(?P<body>.*?)(?=^FINDING:|\Z)")
-QUOTE_RE = re.compile(
-    r"^CURRENT CODE \(verbatim from branch\):\s*```(?:\w+)?\n(?P<quote>.*?)\n```",
-    re.M | re.S,
+# Allow ``.venv/bin/python scripts/verify_review.py`` as well as ``-m``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.review.review_contract import (
+    EXIT_INVALID,
+    AgentIdentity,
+    VerifyContext,
+    sha256_text,
+    verify_review,
+)
+from scripts.review.target_resolution import (
+    TargetResolutionError,
+    resolve_review_target,
+)
+
+FORBIDDEN_RECEIPT_MARKERS = (
+    "/status/",
+    "/audit/",
+    "-review.md",
+    "/telemetry/",
+    "data/telemetry",
 )
 
 
@@ -20,111 +58,260 @@ def _run(cmd: list[str], input_text: str | None = None) -> str:
     ).stdout
 
 
-def _read_review(issue: int | None, from_stdin: bool) -> str:
+def _read_review(issue: int | None, from_stdin: bool, review_file: Path | None) -> str:
     if from_stdin:
         return sys.stdin.read()
+    if review_file is not None:
+        return review_file.read_text(encoding="utf-8")
+    if issue is None:
+        raise SystemExit("one of --from-stdin, --review-file, or --issue is required")
     data = json.loads(_run(["gh", "issue", "view", str(issue), "--json", "comments"]))
     comments = data.get("comments") or []
     return comments[-1]["body"] if comments else ""
 
 
-def _normalize_lines(text: str) -> list[tuple[int, str]]:
-    rows = []
-    for line_no, raw in enumerate(text.replace("```", "").replace("`", "").splitlines(), start=1):
-        clean = " ".join(raw.strip().split())
-        if clean:
-            rows.append((line_no, clean))
-    return rows
-
-
-def _parse_finding(body: str, finding_id: int) -> dict[str, object]:
-    line_match = re.search(r"^FILE:LINE:\s*(.+):(\d+)\s*$", body, re.M)
-    quote_match = QUOTE_RE.search(body)
-    missing = [
-        name
-        for name, ok in (
-            ("file_line", bool(line_match)),
-            ("current_code", bool(quote_match)),
-            ("why_wrong", bool(re.search(r"^WHY WRONG:\s*$", body, re.M))),
-            ("fix", bool(re.search(r"^FIX:\s*$", body, re.M))),
-            ("severity", bool(re.search(r"^SEVERITY:\s*(blocker|major|minor|nit)\s*$", body, re.M))),
-        )
-        if not ok
-    ]
-    if missing:
-        return {"finding_id": finding_id, "outcome": "discarded", "reason": f"missing_fields:{','.join(missing)}"}
-    return {
-        "finding_id": finding_id,
-        "file": line_match.group(1),
-        "line": int(line_match.group(2)),
-        "quote": quote_match.group("quote"),
-    }
-
-
-def _origin_branch_ref(branch: str) -> str:
-    """Return the remote-tracking ref used for branch quote verification."""
-    normalized = branch.strip()
-    if not normalized or normalized.startswith(("origin/", "refs/", "-")):
-        raise ValueError("--branch must be a branch name without origin/ or refs/ prefixes")
-    return f"origin/{normalized}"
-
-
-def _load_file(path: str, branch: str | None) -> str:
-    if branch is None:
-        return Path(path).read_text("utf-8")
-    return _run(["git", "show", f"{_origin_branch_ref(branch)}:{path}"])
-
-
-def _verify_finding(finding: dict[str, object], branch: str | None) -> dict[str, object]:
-    if finding.get("outcome") == "discarded":
-        return finding
+def _load_json_arg(raw: str | None, *, label: str) -> dict:
+    if not raw:
+        return {}
+    path = Path(raw)
+    text = path.read_text(encoding="utf-8") if path.is_file() else raw
     try:
-        file_rows = _normalize_lines(_load_file(str(finding["file"]), branch))
-    except Exception as exc:
-        return {**finding, "outcome": "quote_missing", "evidence": f"file_unavailable:{exc}"}
-    quote_rows = [text for _, text in _normalize_lines(str(finding["quote"]))]
-    start = next(
-        (
-            i
-            for i in range(len(file_rows) - len(quote_rows) + 1)
-            if [text for _, text in file_rows[i:i + len(quote_rows)]] == quote_rows
-        ),
-        -1,
-    )
-    if start < 0:
-        return {**finding, "outcome": "quote_missing", "evidence": "normalized_quote_not_found"}
-    actual_line = file_rows[start][0]
-    outcome = "verified" if actual_line == finding["line"] else "line_mismatch"
-    return {**finding, "outcome": outcome, "evidence": f"matched_at_line:{actual_line}"}
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid JSON for {label}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SystemExit(f"{label} must be a JSON object")
+    return value
 
 
-def _post_summary(issue: int, results: list[dict[str, object]]) -> None:
+def _receipt_path_allowed(path: Path) -> bool:
+    posix = path.as_posix()
+    lowered = posix.lower()
+    if any(marker in lowered for marker in FORBIDDEN_RECEIPT_MARKERS):
+        return False
+    # Explicit denylist for repo artifact layouts.
+    parts = path.parts
+    if "status" in parts and path.suffix == ".json":
+        return False
+    if "audit" in parts and path.name.endswith("-review.md"):
+        return False
+    if "review" in parts and path.name.endswith("-review.md"):
+        return False
+    return "telemetry" not in parts
+
+
+def _post_summary(issue: int, receipt: dict) -> None:
     counts: dict[str, int] = {}
-    for result in results:
-        counts[str(result["outcome"])] = counts.get(str(result["outcome"]), 0) + 1
-    lines = [f"verify_review summary for latest comment on #{issue}:"]
-    lines.extend(f"- {name}: {counts.get(name, 0)}" for name in ("verified", "line_mismatch", "quote_missing", "discarded"))
+    for item in receipt.get("findings") or []:
+        outcome = str(item.get("outcome") or "unknown")
+        counts[outcome] = counts.get(outcome, 0) + 1
+    lines = [
+        f"verify_review receipt for #{issue}:",
+        f"- disposition: {receipt.get('final_disposition')}",
+        f"- exit_code: {receipt.get('exit_code')}",
+        f"- input_sha256: {(receipt.get('target') or {}).get('input_sha256')}",
+    ]
+    for name in (
+        "verified",
+        "line_mismatch",
+        "quote_missing",
+        "malformed",
+        "out_of_scope",
+    ):
+        lines.append(f"- {name}: {counts.get(name, 0)}")
     _run(["gh", "issue", "comment", str(issue), "--body", "\n".join(lines)])
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify structured code-review JSON against an exact target."
+    )
     source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument("--issue", type=int)
-    source.add_argument("--from-stdin", action="store_true")
-    parser.add_argument("--branch")
-    parser.add_argument("--post-comment", action="store_true")
-    args = parser.parse_args()
+    source.add_argument("--issue", type=int, help="Read latest issue comment as review JSON")
+    source.add_argument("--from-stdin", action="store_true", help="Read review JSON from stdin")
+    source.add_argument(
+        "--review-file",
+        type=Path,
+        help="Read review JSON from a local file",
+    )
+
+    parser.add_argument(
+        "--mode",
+        choices=["local", "commit", "branch", "pr"],
+        default="local",
+        help="Exact review target mode (default: local)",
+    )
+    parser.add_argument("--repo-root", default=".", help="Repository root for the target")
+    parser.add_argument("--commit", help="Commit SHA/ref for mode=commit")
+    parser.add_argument("--branch", help="Branch ref for mode=branch")
+    parser.add_argument("--base", help="Base ref for mode=branch")
+    parser.add_argument("--pr", type=int, dest="pr_number", help="PR number for mode=pr")
+
+    parser.add_argument(
+        "--expected-head",
+        help="Fail EXIT_STALE if target head SHA differs from this value",
+    )
+    parser.add_argument(
+        "--expected-input-sha256",
+        help="Fail EXIT_STALE if review input SHA-256 differs",
+    )
+
+    parser.add_argument("--issue-ref", default="", help="Originating issue/request id for receipt")
+    parser.add_argument(
+        "--scope-json",
+        default="",
+        help="Frozen scope JSON object or path (runner-supplied)",
+    )
+
+    parser.add_argument("--author-model", default="unknown")
+    parser.add_argument("--author-family", default="unknown")
+    parser.add_argument("--author-harness", default="unknown")
+    parser.add_argument("--author-selection-reason", default="not_provided")
+    parser.add_argument("--reviewer-model", default="unknown")
+    parser.add_argument("--reviewer-family", default="unknown")
+    parser.add_argument("--reviewer-harness", default="unknown")
+    parser.add_argument("--reviewer-selection-reason", default="not_provided")
+
+    parser.add_argument(
+        "--tests-json",
+        default="",
+        help="JSON object describing tests run (runner-supplied)",
+    )
+    parser.add_argument(
+        "--behavior-proof-json",
+        default="",
+        help="JSON object with source_aware / source_blind proof fields",
+    )
+    parser.add_argument(
+        "--dispositions-json",
+        default="",
+        help='JSON object mapping finding id → {"disposition","rationale"}',
+    )
+    parser.add_argument(
+        "--routing-lineage-json",
+        default="",
+        help="JSON object recording implementation/routing provenance",
+    )
+
+    parser.add_argument(
+        "--receipt-path",
+        type=Path,
+        help="Write full receipt JSON to this local path (must not be a forbidden artifact path)",
+    )
+    parser.add_argument(
+        "--print-findings",
+        action="store_true",
+        help="Also print per-finding validation JSONL before the receipt",
+    )
+    parser.add_argument(
+        "--post-comment",
+        action="store_true",
+        help="Opt-in: post a short summary comment on --issue (not the only durable path)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
     if args.post_comment and args.issue is None:
         parser.error("--post-comment requires --issue")
 
-    review = _read_review(args.issue, args.from_stdin)
-    results = [_verify_finding(_parse_finding(m.group("body"), i), args.branch) for i, m in enumerate(FINDING_RE.finditer(review), start=1)]
-    for result in results:
-        print(json.dumps(result, ensure_ascii=False))
+    repo_root = Path(args.repo_root).resolve()
+    try:
+        target = resolve_review_target(
+            args.mode,
+            repo_root,
+            commit=args.commit,
+            branch=args.branch,
+            base=args.base,
+            pr_number=args.pr_number,
+        )
+    except TargetResolutionError as exc:
+        err = {"error": str(exc), "final_disposition": "invalid", "exit_code": EXIT_INVALID}
+        print(json.dumps(err, ensure_ascii=False), file=sys.stderr)
+        return EXIT_INVALID
+
+    try:
+        raw = _read_review(args.issue, args.from_stdin, args.review_file)
+    except Exception as exc:
+        print(json.dumps({"error": f"read_review_failed:{exc}"}, ensure_ascii=False), file=sys.stderr)
+        return EXIT_INVALID
+
+    issue_ref = args.issue_ref or (f"#{args.issue}" if args.issue else "unspecified")
+    scope = _load_json_arg(args.scope_json or None, label="--scope-json")
+    tests = _load_json_arg(args.tests_json or None, label="--tests-json")
+    behavior_proof = _load_json_arg(
+        args.behavior_proof_json or None, label="--behavior-proof-json"
+    )
+    dispositions = _load_json_arg(
+        args.dispositions_json or None, label="--dispositions-json"
+    )
+    routing_lineage = _load_json_arg(
+        args.routing_lineage_json or None, label="--routing-lineage-json"
+    )
+
+    ctx = VerifyContext(
+        issue_ref=issue_ref,
+        scope=scope,
+        author=AgentIdentity(
+            model=args.author_model,
+            family=args.author_family,
+            harness=args.author_harness,
+            selection_reason=args.author_selection_reason,
+        ),
+        reviewer=AgentIdentity(
+            model=args.reviewer_model,
+            family=args.reviewer_family,
+            harness=args.reviewer_harness,
+            selection_reason=args.reviewer_selection_reason,
+        ),
+        target=target,
+        repo_root=repo_root,
+        input_sha256=sha256_text(raw),
+        expected_head=args.expected_head,
+        expected_input_sha256=args.expected_input_sha256,
+        tests=tests,
+        behavior_proof=behavior_proof,
+        dispositions={
+            str(k): v if isinstance(v, dict) else {"disposition": str(v)}
+            for k, v in dispositions.items()
+        },
+        routing_lineage={str(k): str(v) for k, v in routing_lineage.items()},
+    )
+
+    result = verify_review(raw, ctx)
+
+    if args.print_findings:
+        for item in result.validations:
+            print(json.dumps(item.to_dict(), ensure_ascii=False))
+
+    receipt_json = json.dumps(result.receipt, ensure_ascii=False, indent=2, sort_keys=True)
+    print(receipt_json)
+
+    if args.receipt_path is not None:
+        if not _receipt_path_allowed(args.receipt_path):
+            print(
+                json.dumps(
+                    {
+                        "error": (
+                            "receipt_path_forbidden: do not write receipts under "
+                            "status/, audit/*-review.md, review/*-review.md, or telemetry/"
+                        )
+                    },
+                    ensure_ascii=False,
+                ),
+                file=sys.stderr,
+            )
+            return EXIT_INVALID
+        args.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        args.receipt_path.write_text(receipt_json + "\n", encoding="utf-8")
+
     if args.post_comment:
-        _post_summary(args.issue, results)
-    return 1 if any(result["outcome"] == "quote_missing" for result in results) else 0
+        _post_summary(args.issue, result.receipt)
+
+    return result.exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/verify_review.py
+++ b/scripts/verify_review.py
@@ -49,6 +49,7 @@ from scripts.review.evidence import build_target_manifest
 from scripts.review.review_contract import (
     EXIT_INVALID,
     AgentIdentity,
+    ContractError,
     VerifyContext,
     compute_target_input_fingerprint,
     sha256_text,
@@ -87,16 +88,30 @@ def _read_review(issue: int | None, from_stdin: bool, review_file: Path | None) 
 
 
 def _load_json_arg(raw: str | None, *, label: str) -> dict:
+    """Parse a JSON object from a CLI string or file path.
+
+    Malformed / unreadable inputs raise :class:`ContractError` with
+    ``EXIT_INVALID`` so the runner exits 2 (never a string ``SystemExit`` → 1).
+    """
     if not raw:
         return {}
     path = Path(raw)
-    text = path.read_text(encoding="utf-8") if path.is_file() else raw
+    try:
+        text = path.read_text(encoding="utf-8") if path.is_file() else raw
+    except OSError as exc:
+        raise ContractError(
+            f"{label}_unreadable:{exc}",
+            exit_code=EXIT_INVALID,
+        ) from exc
     try:
         value = json.loads(text)
     except json.JSONDecodeError as exc:
-        raise SystemExit(f"invalid JSON for {label}: {exc}") from exc
+        raise ContractError(
+            f"{label}_invalid_json:{exc.msg}",
+            exit_code=EXIT_INVALID,
+        ) from exc
     if not isinstance(value, dict):
-        raise SystemExit(f"{label} must be a JSON object")
+        raise ContractError(f"{label}_must_be_object", exit_code=EXIT_INVALID)
     return value
 
 
@@ -307,17 +322,31 @@ def main(argv: list[str] | None = None) -> int:
     else:
         issue_ref = ""
 
-    scope = _load_json_arg(args.scope_json or None, label="--scope-json")
-    tests = _load_json_arg(args.tests_json or None, label="--tests-json")
-    behavior_proof = _load_json_arg(
-        args.behavior_proof_json or None, label="--behavior-proof-json"
-    )
-    dispositions = _load_json_arg(
-        args.dispositions_json or None, label="--dispositions-json"
-    )
-    routing_lineage = _load_json_arg(
-        args.routing_lineage_json or None, label="--routing-lineage-json"
-    )
+    try:
+        scope = _load_json_arg(args.scope_json or None, label="--scope-json")
+        tests = _load_json_arg(args.tests_json or None, label="--tests-json")
+        behavior_proof = _load_json_arg(
+            args.behavior_proof_json or None, label="--behavior-proof-json"
+        )
+        dispositions = _load_json_arg(
+            args.dispositions_json or None, label="--dispositions-json"
+        )
+        routing_lineage = _load_json_arg(
+            args.routing_lineage_json or None, label="--routing-lineage-json"
+        )
+    except ContractError as exc:
+        print(
+            json.dumps(
+                {
+                    "error": str(exc),
+                    "final_disposition": "invalid",
+                    "exit_code": EXIT_INVALID,
+                },
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+        )
+        return EXIT_INVALID
 
     try:
         target_fp = compute_target_input_fingerprint(repo_root, target)

--- a/tests/ai_agent_bridge/test_verify_review.py
+++ b/tests/ai_agent_bridge/test_verify_review.py
@@ -1,119 +1,18 @@
+"""Bridge-facing tests: review protocol prompt loading (not FINDING text).
+
+Structured verifier behavior lives in ``tests/test_verify_review.py`` (issue #5284).
+Legacy ``FINDING:`` text is no longer accepted by ``scripts/verify_review.py``.
+"""
+
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-import verify_review
 from ai_agent_bridge import _channels, _inbox, _prompts
 from ai_agent_bridge._inbox import _ClaimedDelivery, _ClaimedThread
-
-
-def _finding(path: str, line: int, quote: str, *, include_fix: bool = True) -> str:
-    parts = [
-        "FINDING:",
-        f"FILE:LINE: {path}:{line}",
-        "CURRENT CODE (verbatim from branch):",
-        "```",
-        quote,
-        "```",
-        "WHY WRONG:",
-        "This is wrong.",
-    ]
-    if include_fix:
-        parts.extend(["FIX:", "Replace it."])
-    parts.extend(["SEVERITY: major", "SOURCE: none"])
-    return "\n".join(parts)
-
-
-def test_verify_review_outcomes(monkeypatch):
-    files = {
-        "origin/main:ok.py": "a = 1\nb = 2\n",
-        "origin/main:mismatch.py": "x = 0\nvalue = 2\n",
-        "origin/main:missing.py": "z = 9\n",
-    }
-    monkeypatch.setattr(verify_review, "_run", lambda cmd, input_text=None: files[cmd[-1]])
-    review = "\n\n".join(
-        [
-            _finding("ok.py", 2, "b = 2"),
-            _finding("mismatch.py", 1, "value = 2"),
-            _finding("missing.py", 1, "value = 2"),
-        ]
-    )
-
-    results = [
-        verify_review._verify_finding(
-            verify_review._parse_finding(match.group("body"), idx),
-            "main",
-        )
-        for idx, match in enumerate(
-            verify_review.FINDING_RE.finditer(review), start=1
-        )
-    ]
-
-    assert [result["outcome"] for result in results] == [
-        "verified",
-        "line_mismatch",
-        "quote_missing",
-    ]
-
-
-def test_malformed_finding_is_discarded_with_reason():
-    result = verify_review._parse_finding(
-        _finding("bad.py", 1, "value = 2", include_fix=False),
-        7,
-    )
-    assert result["outcome"] == "discarded"
-    assert result["reason"] == "missing_fields:fix"
-
-
-def test_issue_mode_reads_latest_comment_and_posts_summary(
-    monkeypatch, capsys
-):
-    review = _finding("ok.py", 2, "b = 2")
-    calls: list[list[str]] = []
-
-    def _fake_run(cmd, input_text=None):
-        calls.append(cmd)
-        if cmd[:3] == ["gh", "issue", "view"]:
-            return json.dumps({"comments": [{"body": "old"}, {"body": review}]})
-        if cmd[:2] == ["git", "show"]:
-            return "a = 1\nb = 2\n"
-        if cmd[:3] == ["gh", "issue", "comment"]:
-            return ""
-        raise AssertionError(cmd)
-
-    monkeypatch.setattr(verify_review, "_run", _fake_run)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["verify_review.py", "--issue", "1331", "--branch", "main", "--post-comment"],
-    )
-
-    assert verify_review.main() == 0
-    out = capsys.readouterr().out.strip().splitlines()
-    assert json.loads(out[0])["outcome"] == "verified"
-    assert calls[-1][:3] == ["gh", "issue", "comment"]
-
-
-def test_verify_review_branch_mode_never_uses_a_local_branch_or_worktree(monkeypatch):
-    commands: list[list[str]] = []
-
-    def fake_run(command, input_text=None):
-        commands.append(command)
-        assert input_text is None
-        return "value = 1\n"
-
-    monkeypatch.setattr(verify_review, "_run", fake_run)
-
-    assert verify_review._load_file("path/to/file.py", "feature/review") == "value = 1\n"
-    assert commands == [["git", "show", "origin/feature/review:path/to/file.py"]]
-    with pytest.raises(ValueError, match="without origin"):
-        verify_review._load_file("path/to/file.py", "origin/feature/review")
 
 
 def test_review_protocol_is_loaded_at_call_time(tmp_path, monkeypatch):
@@ -165,7 +64,14 @@ def test_build_agent_prompt_review_prefix_precedes_channel_context(monkeypatch):
     monkeypatch.setattr(
         _channels,
         "read",
-        lambda channel, tail=10: [{"created_at": "2026-04-19T12:00:00", "from_agent": "user", "round_index": 0, "body": "older"}],
+        lambda channel, tail=10: [
+            {
+                "created_at": "2026-04-19T12:00:00",
+                "from_agent": "user",
+                "round_index": 0,
+                "body": "older",
+            }
+        ],
     )
 
     prompt = _channels.build_agent_prompt("pipeline", "new", review=True)["prompt"]
@@ -215,3 +121,13 @@ def test_inbox_thread_prompt_includes_review_prefix_before_context(monkeypatch):
 
     prompt = _inbox._build_thread_prompt("codex", claimed, has_session=False)
     assert prompt.index("PROTO") < prompt.index("CTX") < prompt.index("root body")
+
+
+def test_review_protocol_doc_declares_json_contract_and_legacy_removal():
+    """docs/review-protocol.md must document the #5284 JSON contract."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "docs" / "review-protocol.md").read_text(encoding="utf-8")
+    assert "code-review-findings.v1" in text
+    assert "Legacy" in text or "legacy" in text
+    assert "EXIT" in text or "exit" in text
+    assert "receipt" in text.lower()

--- a/tests/test_verify_review.py
+++ b/tests/test_verify_review.py
@@ -1,0 +1,720 @@
+"""Tests for strict structured review verification (issue #5284)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scripts.verify_review as verify_review_cli
+from scripts.common.git_context import sanitized_git_env
+from scripts.review.evidence import (
+    OUTCOME_LINE_MISMATCH,
+    OUTCOME_OUT_OF_SCOPE,
+    OUTCOME_QUOTE_MISSING,
+    OUTCOME_VERIFIED,
+    EvidenceError,
+    find_verbatim_match,
+    is_safe_repo_relative_path,
+    normalize_line_endings,
+    resolve_safe_path,
+    split_lines_preserve_content,
+)
+from scripts.review.review_contract import (
+    EXIT_ACTIONABLE,
+    EXIT_CLEAN,
+    EXIT_INCOMPLETE,
+    EXIT_INVALID,
+    EXIT_STALE,
+    EXIT_UNVERIFIABLE,
+    SCHEMA_VERSION,
+    AgentIdentity,
+    ContractError,
+    VerifyContext,
+    parse_reviewer_json,
+    sha256_text,
+    sort_findings_deterministically,
+    validate_reviewer_payload,
+    verify_review,
+)
+from scripts.review.target_resolution import (
+    resolve_branch_target,
+    resolve_commit_target,
+    resolve_local_target,
+    resolve_pr_target,
+)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+        env=sanitized_git_env(),
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "trunk")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "app.py").write_text("print('v1')\nvalue = 1\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _identity(**overrides: str) -> AgentIdentity:
+    base = {
+        "model": "test-model",
+        "family": "test-family",
+        "harness": "test-harness",
+        "selection_reason": "fixture",
+    }
+    base.update(overrides)
+    return AgentIdentity(**base)
+
+
+def _clean_payload() -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "correct",
+            "explanation": "No issues on the frozen target.",
+            "confidence": 0.95,
+        },
+        "findings": [],
+    }
+
+
+def _finding(
+    *,
+    fid: str = "F001",
+    path: str = "app.py",
+    start: int = 2,
+    end: int | None = None,
+    verbatim: str = "value = 2",
+    claim_type: str = "present",
+    priority: str = "P1",
+    category: str = "bug",
+) -> dict:
+    return {
+        "id": fid,
+        "title": f"Title {fid}",
+        "body": f"Body for {fid}",
+        "priority": priority,
+        "confidence": 0.8,
+        "category": category,
+        "location": {
+            "path": path,
+            "start_line": start,
+            "end_line": end if end is not None else start,
+            "claim_type": claim_type,
+        },
+        "verbatim": verbatim,
+        "why_wrong": "It is wrong because the constant is incorrect.",
+        "smallest_fix": "Set value = 1 instead.",
+        "sources": ["none"],
+    }
+
+
+def _ctx(
+    repo: Path,
+    target,
+    raw: str,
+    **kwargs,
+) -> VerifyContext:
+    return VerifyContext(
+        issue_ref=kwargs.get("issue_ref", "#5284"),
+        scope=kwargs.get("scope", {"owner_boundary": "scripts/verify_review.py"}),
+        author=kwargs.get("author", _identity(model="gpt-5.6-sol", family="openai")),
+        reviewer=kwargs.get(
+            "reviewer",
+            _identity(
+                model="grok-4.5",
+                family="xai",
+                harness="grok-build",
+                selection_reason="routing-substitution-cross-family",
+            ),
+        ),
+        target=target,
+        repo_root=repo,
+        input_sha256=sha256_text(raw),
+        expected_head=kwargs.get("expected_head"),
+        expected_input_sha256=kwargs.get("expected_input_sha256"),
+        tests=kwargs.get("tests", {"commands": ["pytest"], "passed": True}),
+        behavior_proof=kwargs.get(
+            "behavior_proof",
+            {
+                "source_aware": {"status": "pass"},
+                "source_blind": {"status": "n/a", "reason": "no user-visible surface"},
+            },
+        ),
+        dispositions=kwargs.get("dispositions", {}),
+        routing_lineage=kwargs.get(
+            "routing_lineage",
+            {
+                "implementation_agent": "grok/5284-strict-review-receipts",
+                "accountable_advisor": "GPT-5.6 Sol",
+            },
+        ),
+    )
+
+
+# --- normalization / path safety ---------------------------------------------
+
+
+def test_line_ending_normalization_only():
+    assert normalize_line_endings("a\r\nb\rc") == "a\nb\nc"
+    # Whitespace and backticks are preserved for matching.
+    left = 'x = "a  b"'
+    right = 'x = "a  b"'
+    assert find_verbatim_match(left + "\n", right)[0] == 1
+    assert find_verbatim_match('x = "a b"\n', 'x = "a  b"')[0] is None
+    assert find_verbatim_match("`code`\n", "code")[0] is None
+
+
+def test_split_lines_preserves_internal_whitespace():
+    lines = split_lines_preserve_content("  a  \n\tb\n")
+    assert lines == ["  a  ", "\tb"]
+
+
+def test_unsafe_paths_rejected(tmp_path):
+    repo = _init_repo(tmp_path)
+    assert not is_safe_repo_relative_path("/etc/passwd")
+    assert not is_safe_repo_relative_path("C:\\Windows\\System32")
+    assert not is_safe_repo_relative_path("../outside")
+    assert not is_safe_repo_relative_path("foo/../bar")
+    assert not is_safe_repo_relative_path("")
+    assert is_safe_repo_relative_path("app.py")
+    with pytest.raises(EvidenceError):
+        resolve_safe_path(repo, "../outside")
+
+
+def test_symlink_escape_rejected(tmp_path):
+    repo = _init_repo(tmp_path)
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret\n", encoding="utf-8")
+    link = repo / "link_escape"
+    link.symlink_to(outside)
+    with pytest.raises(EvidenceError, match=r"symlink_escape|path_escapes"):
+        # resolve_safe_path follows the symlink and must fail closed.
+        resolve_safe_path(repo, "link_escape")
+
+
+# --- schema / parse ----------------------------------------------------------
+
+
+def test_schema_rejects_unknown_fields_and_bad_enums():
+    payload = _clean_payload()
+    payload["extra"] = True
+    with pytest.raises(ContractError, match="schema_violation"):
+        validate_reviewer_payload(payload)
+
+    payload = _clean_payload()
+    payload["findings"] = [_finding(priority="P9")]
+    with pytest.raises(ContractError, match="schema_violation"):
+        validate_reviewer_payload(payload)
+
+    payload = _clean_payload()
+    payload["findings"] = [_finding()]
+    payload["findings"][0]["confidence"] = 1.5
+    with pytest.raises(ContractError, match="schema_violation"):
+        validate_reviewer_payload(payload)
+
+
+def test_legacy_finding_text_fails_closed():
+    legacy = "FINDING:\nFILE:LINE: app.py:1\n"
+    with pytest.raises(ContractError, match="legacy_FINDING"):
+        parse_reviewer_json(legacy)
+
+
+def test_non_json_chatter_fails_closed():
+    with pytest.raises(ContractError, match="non_json"):
+        parse_reviewer_json('Here is my review:\n{"schema_version": "x"}\nThanks!')
+
+
+def test_empty_input_is_incomplete():
+    with pytest.raises(ContractError) as exc:
+        parse_reviewer_json("   ")
+    assert exc.value.exit_code == EXIT_INCOMPLETE
+
+
+def test_multi_finding_order_is_deterministic():
+    findings = [
+        _finding(fid="Z", path="b.py", start=2),
+        _finding(fid="A", path="a.py", start=5),
+        _finding(fid="B", path="a.py", start=1),
+    ]
+    ordered = sort_findings_deterministically(findings)
+    assert [f["id"] for f in ordered] == ["B", "A", "Z"]
+
+
+# --- target modes ------------------------------------------------------------
+
+
+def test_local_target_verified_and_clean(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    assert "app.py" in target.changed_paths
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "value should remain 1.",
+            "confidence": 0.9,
+        },
+        "findings": [_finding(start=2, verbatim="value = 2")],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.exit_code == EXIT_ACTIONABLE
+    assert result.validations[0].outcome == OUTCOME_VERIFIED
+    assert result.validations[0].matched_line == 2
+    assert result.receipt["target"]["mode"] == "local"
+    assert result.receipt["target"]["input_sha256"] == sha256_text(raw)
+    assert result.receipt["author"]["family"] == "openai"
+    assert result.receipt["reviewer"]["model"] == "grok-4.5"
+
+
+def test_local_clean_review_exit_zero(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.exit_code == EXIT_CLEAN
+    assert result.final_disposition == "clean"
+
+
+def test_commit_target_quote_and_line_checks(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    _git(repo, "commit", "-aq", "-m", "bad value")
+    target = resolve_commit_target(repo, "HEAD")
+
+    # verified
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "bad constant",
+            "confidence": 0.9,
+        },
+        "findings": [_finding(start=2, verbatim="value = 2")],
+    }
+    raw = json.dumps(payload)
+    ok = verify_review(raw, _ctx(repo, target, raw))
+    assert ok.validations[0].outcome == OUTCOME_VERIFIED
+
+    # line_mismatch: quote exists at 2 but claimed 1
+    payload["findings"] = [_finding(start=1, verbatim="value = 2")]
+    raw = json.dumps(payload)
+    mm = verify_review(raw, _ctx(repo, target, raw))
+    assert mm.validations[0].outcome == OUTCOME_LINE_MISMATCH
+    assert mm.validations[0].matched_line == 2
+    assert mm.exit_code == EXIT_UNVERIFIABLE
+
+    # quote_missing
+    payload["findings"] = [_finding(start=2, verbatim="value = 999")]
+    raw = json.dumps(payload)
+    qm = verify_review(raw, _ctx(repo, target, raw))
+    assert qm.validations[0].outcome == OUTCOME_QUOTE_MISSING
+    assert qm.exit_code == EXIT_UNVERIFIABLE
+
+
+def test_branch_target(tmp_path):
+    repo = _init_repo(tmp_path)
+    _git(repo, "branch", "feature")
+    _git(repo, "checkout", "-q", "feature")
+    (repo / "app.py").write_text("print('v1')\nvalue = 3\n", encoding="utf-8")
+    _git(repo, "commit", "-aq", "-m", "feature change")
+    target = resolve_branch_target(repo, "feature", "trunk")
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "value wrong",
+            "confidence": 0.7,
+        },
+        "findings": [_finding(start=2, verbatim="value = 3")],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.validations[0].outcome == OUTCOME_VERIFIED
+    assert result.receipt["target"]["mode"] == "branch"
+    assert result.receipt["target"]["base_sha"]
+    assert result.receipt["target"]["head_sha"]
+
+
+def test_pr_target(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    # Simulate a second commit as PR head.
+    (repo / "app.py").write_text("print('v1')\nvalue = 4\n", encoding="utf-8")
+    _git(repo, "commit", "-aq", "-m", "pr head")
+    head2 = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    base = _git(repo, "rev-parse", "HEAD^").stdout.strip()
+
+    def fake_gh(args, cwd, timeout=30.0):
+        class R:
+            returncode = 0
+            stdout = json.dumps(
+                {
+                    "number": 99,
+                    "baseRefName": "trunk",
+                    "baseRefOid": base,
+                    "headRefName": "feature",
+                    "headRefOid": head2,
+                }
+            )
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(
+        "scripts.review.target_resolution._run_gh",
+        fake_gh,
+    )
+    target = resolve_pr_target(repo, 99)
+    assert target.mode == "pr"
+    assert target.head_sha == head2
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "pr defect",
+            "confidence": 0.8,
+        },
+        "findings": [_finding(start=2, verbatim="value = 4")],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.validations[0].outcome == OUTCOME_VERIFIED
+    assert result.receipt["target"]["mode"] == "pr"
+    # unused var guard
+    assert head
+
+
+# --- scope / stale / adversarial ---------------------------------------------
+
+
+def test_unknown_changed_path_is_out_of_scope(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "x",
+            "confidence": 0.5,
+        },
+        "findings": [
+            _finding(path="other.py", start=1, verbatim="nope"),
+        ],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.validations[0].outcome == OUTCOME_OUT_OF_SCOPE
+    assert result.exit_code == EXIT_UNVERIFIABLE
+
+
+def test_unchanged_line_out_of_scope_for_present_claim(tmp_path):
+    repo = _init_repo(tmp_path)
+    # Change only line 2; claim present defect on line 1 (unchanged content).
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "x",
+            "confidence": 0.5,
+        },
+        "findings": [
+            _finding(start=1, verbatim="print('v1')"),
+        ],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.validations[0].outcome == OUTCOME_OUT_OF_SCOPE
+
+
+def test_missing_claim_allows_contextual_evidence_without_changed_line(tmp_path):
+    """Missing-code claims need path-in-scope + verbatim context, not a fake diff line."""
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    # Contextual evidence on an unchanged line is OK for claim_type=missing.
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "guard missing after print",
+            "confidence": 0.6,
+        },
+        "findings": [
+            _finding(
+                start=1,
+                verbatim="print('v1')",
+                claim_type="missing",
+            )
+        ],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.validations[0].outcome == OUTCOME_VERIFIED
+
+
+def test_stale_head_fails_closed(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    _git(repo, "commit", "-aq", "-m", "v2")
+    target = resolve_commit_target(repo, "HEAD")
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(repo, target, raw, expected_head="0" * 40),
+    )
+    assert result.exit_code == EXIT_STALE
+    assert "stale_head" in (result.error or "")
+
+
+def test_stale_input_hash_fails_closed(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(repo, target, raw, expected_input_sha256="deadbeef" * 8),
+    )
+    assert result.exit_code == EXIT_STALE
+    assert "stale_input_hash" in (result.error or "")
+
+
+def test_absolute_path_in_finding_fails_schema():
+    payload = _clean_payload()
+    f = _finding(path="/tmp/evil.py")
+    payload["findings"] = [f]
+    with pytest.raises(ContractError, match="schema_violation"):
+        validate_reviewer_payload(payload)
+
+
+def test_dotdot_path_in_finding_fails_schema():
+    payload = _clean_payload()
+    f = _finding(path="../secrets.py")
+    payload["findings"] = [f]
+    with pytest.raises(ContractError, match="schema_violation"):
+        validate_reviewer_payload(payload)
+
+
+def test_multi_finding_all_preserved_and_ordered(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\nextra = 3\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "two issues",
+            "confidence": 0.8,
+        },
+        "findings": [
+            _finding(fid="F2", start=3, verbatim="extra = 3"),
+            _finding(fid="F1", start=2, verbatim="value = 2"),
+        ],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert [v.id for v in result.validations] == ["F1", "F2"]
+    assert all(v.outcome == OUTCOME_VERIFIED for v in result.validations)
+    assert result.exit_code == EXIT_ACTIONABLE
+
+
+def test_uncertain_without_findings_is_incomplete(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('x')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "uncertain",
+            "explanation": "Could not finish review.",
+            "confidence": 0.2,
+        },
+        "findings": [],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.exit_code == EXIT_INCOMPLETE
+
+
+def test_invalid_schema_exit(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('x')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps({"schema_version": "nope", "overall": {}, "findings": []})
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.exit_code == EXIT_INVALID
+
+
+def test_receipt_includes_required_envelope_fields(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(raw, _ctx(repo, target, raw))
+    r = result.receipt
+    assert r["schema_version"] == "code-review-receipt.v1"
+    assert r["issue_ref"] == "#5284"
+    assert "scope" in r
+    assert r["author"]["model"]
+    assert r["reviewer"]["selection_reason"]
+    assert r["target"]["changed_paths"]
+    assert r["target"]["input_sha256"]
+    assert r["tests"]["passed"] is True
+    assert "source_aware" in r["behavior_proof"]
+    assert "source_blind" in r["behavior_proof"]
+    assert r["routing_lineage"]["accountable_advisor"] == "GPT-5.6 Sol"
+    assert r["final_disposition"] == "clean"
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_receipt_path_and_forbidden_paths(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    review = tmp_path / "review.json"
+    review.write_text(json.dumps(_clean_payload()), encoding="utf-8")
+    receipt = tmp_path / "out" / "receipt.json"
+
+    code = verify_review_cli.main(
+        [
+            "--review-file",
+            str(review),
+            "--mode",
+            "local",
+            "--repo-root",
+            str(repo),
+            "--receipt-path",
+            str(receipt),
+            "--issue-ref",
+            "#5284",
+        ]
+    )
+    assert code == EXIT_CLEAN
+    assert receipt.is_file()
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    assert data["final_disposition"] == "clean"
+
+    forbidden = tmp_path / "data" / "telemetry" / "receipt.json"
+    code2 = verify_review_cli.main(
+        [
+            "--review-file",
+            str(review),
+            "--mode",
+            "local",
+            "--repo-root",
+            str(repo),
+            "--receipt-path",
+            str(forbidden),
+        ]
+    )
+    assert code2 == EXIT_INVALID
+
+
+def test_cli_issue_mode_posts_opt_in_comment(tmp_path, monkeypatch, capsys):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "bad",
+            "confidence": 0.9,
+        },
+        "findings": [_finding(start=2, verbatim="value = 2")],
+    }
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, input_text=None):
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"comments": [{"body": json.dumps(payload)}]})
+        if cmd[:3] == ["gh", "issue", "comment"]:
+            return ""
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(verify_review_cli, "_run", fake_run)
+    code = verify_review_cli.main(
+        [
+            "--issue",
+            "5284",
+            "--mode",
+            "local",
+            "--repo-root",
+            str(repo),
+            "--post-comment",
+            "--print-findings",
+        ]
+    )
+    assert code == EXIT_ACTIONABLE
+    out = capsys.readouterr().out
+    assert "verified" in out
+    assert calls[-1][:3] == ["gh", "issue", "comment"]
+
+
+def test_cli_stdin_legacy_text_exit_invalid(tmp_path, monkeypatch, capsys):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("x\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "stdin", type("S", (), {"read": lambda self: "FINDING:\nFILE:LINE: app.py:1\n"})())
+    code = verify_review_cli.main(
+        ["--from-stdin", "--mode", "local", "--repo-root", str(repo)]
+    )
+    assert code == EXIT_INVALID
+
+
+def test_dispositions_attached_on_receipt(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "bad",
+            "confidence": 0.9,
+        },
+        "findings": [_finding(start=2, verbatim="value = 2")],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={
+                "F001": {
+                    "disposition": "in_scope_blocker",
+                    "rationale": "Introduced by this change.",
+                }
+            },
+        ),
+    )
+    assert result.validations[0].disposition == "in_scope_blocker"
+    assert "Introduced" in (result.validations[0].disposition_rationale or "")

--- a/tests/test_verify_review.py
+++ b/tests/test_verify_review.py
@@ -19,8 +19,11 @@ from scripts.review.evidence import (
     OUTCOME_QUOTE_MISSING,
     OUTCOME_VERIFIED,
     EvidenceError,
+    build_target_manifest,
+    compute_target_input_fingerprint,
     find_verbatim_match,
     is_safe_repo_relative_path,
+    match_at_line,
     normalize_line_endings,
     resolve_safe_path,
     split_lines_preserve_content,
@@ -127,47 +130,110 @@ def _finding(
     }
 
 
+def _full_envelope_kwargs(repo: Path, target, **overrides):
+    """Runner envelope sufficient for clean/actionable closeout."""
+    fp = compute_target_input_fingerprint(repo, target)
+    base = {
+        "issue_ref": "#5284",
+        "scope": {"owner_boundary": "scripts/verify_review.py"},
+        "author": _identity(model="author-model", family="author-family"),
+        "reviewer": _identity(
+            model="reviewer-model",
+            family="reviewer-family",
+            harness="reviewer-harness",
+            selection_reason="cross-family-gate",
+        ),
+        "tests": {"commands": ["pytest"], "passed": True},
+        "behavior_proof": {
+            "source_aware": {"status": "pass"},
+            "source_blind": {"status": "pass", "note": "cli-proof"},
+        },
+        "routing_lineage": {
+            "implementation_agent": "test-impl",
+            "accountable_advisor": "test-advisor",
+        },
+        "expected_input_sha256": fp,
+        "dispositions": {},
+    }
+    base.update(overrides)
+    return base
+
+
 def _ctx(
     repo: Path,
     target,
     raw: str,
     **kwargs,
 ) -> VerifyContext:
+    env = _full_envelope_kwargs(repo, target, **kwargs)
     return VerifyContext(
-        issue_ref=kwargs.get("issue_ref", "#5284"),
-        scope=kwargs.get("scope", {"owner_boundary": "scripts/verify_review.py"}),
-        author=kwargs.get("author", _identity(model="gpt-5.6-sol", family="openai")),
-        reviewer=kwargs.get(
-            "reviewer",
-            _identity(
-                model="grok-4.5",
-                family="xai",
-                harness="grok-build",
-                selection_reason="routing-substitution-cross-family",
-            ),
-        ),
+        issue_ref=env["issue_ref"],
+        scope=env["scope"],
+        author=env["author"],
+        reviewer=env["reviewer"],
         target=target,
         repo_root=repo,
-        input_sha256=sha256_text(raw),
-        expected_head=kwargs.get("expected_head"),
-        expected_input_sha256=kwargs.get("expected_input_sha256"),
-        tests=kwargs.get("tests", {"commands": ["pytest"], "passed": True}),
-        behavior_proof=kwargs.get(
-            "behavior_proof",
+        input_sha256=env.get("input_sha256", env["expected_input_sha256"] or ""),
+        reviewer_output_sha256=sha256_text(raw),
+        expected_head=env.get("expected_head"),
+        expected_input_sha256=env.get("expected_input_sha256"),
+        tests=env["tests"],
+        behavior_proof=env["behavior_proof"],
+        dispositions=env["dispositions"],
+        routing_lineage=env["routing_lineage"],
+    )
+
+
+def _cli_envelope_args(repo: Path, *, dispositions: dict | None = None) -> list[str]:
+    target = resolve_local_target(repo)
+    fp = compute_target_input_fingerprint(repo, target)
+    args = [
+        "--mode",
+        "local",
+        "--repo-root",
+        str(repo),
+        "--expected-input-sha256",
+        fp,
+        "--issue-ref",
+        "#5284",
+        "--scope-json",
+        json.dumps({"owner_boundary": "app.py"}),
+        "--author-model",
+        "author-model",
+        "--author-family",
+        "author-family",
+        "--author-harness",
+        "author-harness",
+        "--author-selection-reason",
+        "fixture",
+        "--reviewer-model",
+        "reviewer-model",
+        "--reviewer-family",
+        "reviewer-family",
+        "--reviewer-harness",
+        "reviewer-harness",
+        "--reviewer-selection-reason",
+        "cross-family-gate",
+        "--tests-json",
+        json.dumps({"commands": ["pytest"], "passed": True}),
+        "--behavior-proof-json",
+        json.dumps(
             {
                 "source_aware": {"status": "pass"},
-                "source_blind": {"status": "n/a", "reason": "no user-visible surface"},
-            },
+                "source_blind": {"status": "pass"},
+            }
         ),
-        dispositions=kwargs.get("dispositions", {}),
-        routing_lineage=kwargs.get(
-            "routing_lineage",
+        "--routing-lineage-json",
+        json.dumps(
             {
-                "implementation_agent": "grok/5284-strict-review-receipts",
-                "accountable_advisor": "GPT-5.6 Sol",
-            },
+                "implementation_agent": "test-impl",
+                "accountable_advisor": "test-advisor",
+            }
         ),
-    )
+    ]
+    if dispositions is not None:
+        args.extend(["--dispositions-json", json.dumps(dispositions)])
+    return args
 
 
 # --- normalization / path safety ---------------------------------------------
@@ -278,14 +344,31 @@ def test_local_target_verified_and_clean(tmp_path):
         "findings": [_finding(start=2, verbatim="value = 2")],
     }
     raw = json.dumps(payload)
-    result = verify_review(raw, _ctx(repo, target, raw))
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={
+                "F001": {
+                    "disposition": "in_scope_blocker",
+                    "rationale": "bad constant",
+                }
+            },
+        ),
+    )
     assert result.exit_code == EXIT_ACTIONABLE
     assert result.validations[0].outcome == OUTCOME_VERIFIED
     assert result.validations[0].matched_line == 2
     assert result.receipt["target"]["mode"] == "local"
-    assert result.receipt["target"]["input_sha256"] == sha256_text(raw)
-    assert result.receipt["author"]["family"] == "openai"
-    assert result.receipt["reviewer"]["model"] == "grok-4.5"
+    # input_sha256 is target fingerprint, not reviewer JSON hash
+    assert result.receipt["target"]["input_sha256"] == compute_target_input_fingerprint(
+        repo, target
+    )
+    assert result.receipt["reviewer_output_sha256"] == sha256_text(raw)
+    assert result.receipt["author"]["family"] == "author-family"
+    assert result.receipt["reviewer"]["model"] == "reviewer-model"
 
 
 def test_local_clean_review_exit_zero(tmp_path):
@@ -315,7 +398,17 @@ def test_commit_target_quote_and_line_checks(tmp_path):
         "findings": [_finding(start=2, verbatim="value = 2")],
     }
     raw = json.dumps(payload)
-    ok = verify_review(raw, _ctx(repo, target, raw))
+    ok = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={
+                "F001": {"disposition": "in_scope_blocker", "rationale": "x"},
+            },
+        ),
+    )
     assert ok.validations[0].outcome == OUTCOME_VERIFIED
 
     # line_mismatch: quote exists at 2 but claimed 1
@@ -351,7 +444,17 @@ def test_branch_target(tmp_path):
         "findings": [_finding(start=2, verbatim="value = 3")],
     }
     raw = json.dumps(payload)
-    result = verify_review(raw, _ctx(repo, target, raw))
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={
+                "F001": {"disposition": "follow_up", "rationale": "scope note"},
+            },
+        ),
+    )
     assert result.validations[0].outcome == OUTCOME_VERIFIED
     assert result.receipt["target"]["mode"] == "branch"
     assert result.receipt["target"]["base_sha"]
@@ -400,7 +503,17 @@ def test_pr_target(tmp_path, monkeypatch):
         "findings": [_finding(start=2, verbatim="value = 4")],
     }
     raw = json.dumps(payload)
-    result = verify_review(raw, _ctx(repo, target, raw))
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={
+                "F001": {"disposition": "in_scope_blocker", "rationale": "pr"},
+            },
+        ),
+    )
     assert result.validations[0].outcome == OUTCOME_VERIFIED
     assert result.receipt["target"]["mode"] == "pr"
     # unused var guard
@@ -474,7 +587,17 @@ def test_missing_claim_allows_contextual_evidence_without_changed_line(tmp_path)
         ],
     }
     raw = json.dumps(payload)
-    result = verify_review(raw, _ctx(repo, target, raw))
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={
+                "F001": {"disposition": "follow_up", "rationale": "context ok"},
+            },
+        ),
+    )
     assert result.validations[0].outcome == OUTCOME_VERIFIED
 
 
@@ -538,7 +661,18 @@ def test_multi_finding_all_preserved_and_ordered(tmp_path):
         ],
     }
     raw = json.dumps(payload)
-    result = verify_review(raw, _ctx(repo, target, raw))
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={
+                "F1": {"disposition": "in_scope_blocker", "rationale": "a"},
+                "F2": {"disposition": "follow_up", "rationale": "b"},
+            },
+        ),
+    )
     assert [v.id for v in result.validations] == ["F1", "F2"]
     assert all(v.outcome == OUTCOME_VERIFIED for v in result.validations)
     assert result.exit_code == EXIT_ACTIONABLE
@@ -584,12 +718,238 @@ def test_receipt_includes_required_envelope_fields(tmp_path):
     assert r["author"]["model"]
     assert r["reviewer"]["selection_reason"]
     assert r["target"]["changed_paths"]
-    assert r["target"]["input_sha256"]
+    assert r["target"]["input_sha256"] == compute_target_input_fingerprint(repo, target)
+    assert r["reviewer_output_sha256"] == sha256_text(raw)
     assert r["tests"]["passed"] is True
     assert "source_aware" in r["behavior_proof"]
     assert "source_blind" in r["behavior_proof"]
-    assert r["routing_lineage"]["accountable_advisor"] == "GPT-5.6 Sol"
+    assert r["routing_lineage"]["accountable_advisor"] == "test-advisor"
     assert r["final_disposition"] == "clean"
+
+
+# --- fingerprint / location / envelope (review cycle 1) ----------------------
+
+
+def test_target_fingerprint_changes_after_local_mutation(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    target1 = resolve_local_target(repo)
+    fp1 = compute_target_input_fingerprint(repo, target1)
+    (repo / "app.py").write_text("print('v1')\nvalue = 3\n", encoding="utf-8")
+    target2 = resolve_local_target(repo)
+    fp2 = compute_target_input_fingerprint(repo, target2)
+    assert fp1 != fp2
+    assert len(fp1) == 64
+
+
+def test_missing_expected_fingerprint_cannot_exit_clean(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(repo, target, raw, expected_input_sha256=None),
+    )
+    assert result.exit_code == EXIT_INCOMPLETE
+    assert "expected_input_sha256" in (result.error or "")
+
+
+def test_missing_lineage_cannot_exit_clean(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(repo, target, raw, routing_lineage={}),
+    )
+    assert result.exit_code == EXIT_INCOMPLETE
+    assert "routing_lineage" in (result.error or "")
+    assert result.receipt["routing_lineage"] == {}
+
+
+def test_placeholder_identity_cannot_exit_clean(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            author=_identity(model="unknown", family="unspecified"),
+            reviewer=_identity(selection_reason="not_provided"),
+        ),
+    )
+    assert result.exit_code == EXIT_INCOMPLETE
+    assert "placeholder" in (result.error or "")
+
+
+def test_receipt_does_not_fabricate_lineage(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(repo, target, raw, routing_lineage={}),
+    )
+    lineage = result.receipt["routing_lineage"]
+    assert "grok/5284" not in json.dumps(lineage)
+    assert "GPT-5.6" not in json.dumps(lineage)
+    assert lineage == {}
+
+
+def test_duplicate_quote_later_occurrence_verifies(tmp_path):
+    repo = _init_repo(tmp_path)
+    # Same line text appears twice; claim the later occurrence.
+    (repo / "app.py").write_text(
+        "flag = True\nshared = 1\nmiddle = 0\nshared = 1\n",
+        encoding="utf-8",
+    )
+    target = resolve_local_target(repo)
+    assert match_at_line(
+        (repo / "app.py").read_text(encoding="utf-8"), "shared = 1", 4
+    )[0]
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "later dup",
+            "confidence": 0.8,
+        },
+        "findings": [_finding(start=4, end=4, verbatim="shared = 1")],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={
+                "F001": {"disposition": "in_scope_blocker", "rationale": "dup"},
+            },
+        ),
+    )
+    assert result.validations[0].outcome == OUTCOME_VERIFIED
+    assert result.validations[0].matched_line == 4
+    assert result.exit_code == EXIT_ACTIONABLE
+
+
+def test_inflated_range_fails_line_mismatch(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\nextra = 9\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    # One-line quote claiming a multi-line inflated range.
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "inflated",
+            "confidence": 0.8,
+        },
+        "findings": [_finding(start=2, end=3, verbatim="value = 2")],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.validations[0].outcome == OUTCOME_LINE_MISMATCH
+    assert "range_span_mismatch" in result.validations[0].detail
+    assert result.exit_code == EXIT_UNVERIFIABLE
+
+
+def test_short_range_fails_line_mismatch(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "short range",
+            "confidence": 0.8,
+        },
+        "findings": [
+            _finding(start=1, end=1, verbatim="a = 1\nb = 2"),
+        ],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.validations[0].outcome == OUTCOME_LINE_MISMATCH
+    assert "range_span_mismatch" in result.validations[0].detail
+
+
+def test_decode_failure_is_fail_closed_evidence(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+
+    def boom(*_a, **_k):
+        raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad")
+
+    monkeypatch.setattr("scripts.review.evidence.load_file_text", boom)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "x",
+            "confidence": 0.5,
+        },
+        "findings": [_finding(start=2, verbatim="value = 2")],
+    }
+    raw = json.dumps(payload)
+    result = verify_review(raw, _ctx(repo, target, raw))
+    assert result.validations[0].outcome == OUTCOME_QUOTE_MISSING
+    assert "decode" in result.validations[0].detail or "read_or_decode" in result.validations[
+        0
+    ].detail
+    assert result.exit_code == EXIT_UNVERIFIABLE
+
+
+def test_disposition_unknown_id_and_missing_rationale(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "x",
+            "confidence": 0.9,
+        },
+        "findings": [_finding(start=2, verbatim="value = 2")],
+    }
+    raw = json.dumps(payload)
+    # Unknown disposition key
+    r1 = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={
+                "OTHER": {"disposition": "in_scope_blocker", "rationale": "x"},
+            },
+        ),
+    )
+    assert r1.exit_code not in (EXIT_CLEAN, EXIT_ACTIONABLE)
+    assert "disposition" in (r1.error or "")
+
+    # Missing rationale
+    r2 = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            dispositions={"F001": {"disposition": "in_scope_blocker", "rationale": ""}},
+        ),
+    )
+    assert r2.exit_code == EXIT_INCOMPLETE
+    assert "rationale" in (r2.error or "")
 
 
 # --- CLI ---------------------------------------------------------------------
@@ -606,30 +966,24 @@ def test_cli_receipt_path_and_forbidden_paths(tmp_path, monkeypatch):
         [
             "--review-file",
             str(review),
-            "--mode",
-            "local",
-            "--repo-root",
-            str(repo),
+            * _cli_envelope_args(repo),
             "--receipt-path",
             str(receipt),
-            "--issue-ref",
-            "#5284",
         ]
     )
     assert code == EXIT_CLEAN
     assert receipt.is_file()
     data = json.loads(receipt.read_text(encoding="utf-8"))
     assert data["final_disposition"] == "clean"
+    assert data["reviewer_output_sha256"]
+    assert data["target"]["input_sha256"] != data["reviewer_output_sha256"]
 
     forbidden = tmp_path / "data" / "telemetry" / "receipt.json"
     code2 = verify_review_cli.main(
         [
             "--review-file",
             str(review),
-            "--mode",
-            "local",
-            "--repo-root",
-            str(repo),
+            * _cli_envelope_args(repo),
             "--receipt-path",
             str(forbidden),
         ]
@@ -664,10 +1018,15 @@ def test_cli_issue_mode_posts_opt_in_comment(tmp_path, monkeypatch, capsys):
         [
             "--issue",
             "5284",
-            "--mode",
-            "local",
-            "--repo-root",
-            str(repo),
+            * _cli_envelope_args(
+                repo,
+                dispositions={
+                    "F001": {
+                        "disposition": "in_scope_blocker",
+                        "rationale": "introduced here",
+                    }
+                },
+            ),
             "--post-comment",
             "--print-findings",
         ]
@@ -686,6 +1045,141 @@ def test_cli_stdin_legacy_text_exit_invalid(tmp_path, monkeypatch, capsys):
         ["--from-stdin", "--mode", "local", "--repo-root", str(repo)]
     )
     assert code == EXIT_INVALID
+
+
+def test_cli_emit_target_manifest_source_blind(tmp_path, capsys):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    code = verify_review_cli.main(
+        ["--emit-target-manifest", "--mode", "local", "--repo-root", str(repo)]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["schema_version"] == "code-review-target-manifest.v1"
+    assert data["mode"] == "local"
+    assert "app.py" in data["changed_paths"]
+    assert len(data["input_sha256"]) == 64
+    # Mutate and re-emit — fingerprint must change.
+    (repo / "app.py").write_text("print('v1')\nvalue = 9\n", encoding="utf-8")
+    code2 = verify_review_cli.main(
+        ["--emit-target-manifest", "--mode", "local", "--repo-root", str(repo)]
+    )
+    assert code2 == 0
+    data2 = json.loads(capsys.readouterr().out)
+    assert data2["input_sha256"] != data["input_sha256"]
+
+
+def test_cli_missing_lineage_cannot_exit_clean(tmp_path, capsys):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    review = tmp_path / "review.json"
+    review.write_text(json.dumps(_clean_payload()), encoding="utf-8")
+    target = resolve_local_target(repo)
+    fp = compute_target_input_fingerprint(repo, target)
+    code = verify_review_cli.main(
+        [
+            "--review-file",
+            str(review),
+            "--mode",
+            "local",
+            "--repo-root",
+            str(repo),
+            "--expected-input-sha256",
+            fp,
+            "--issue-ref",
+            "#5284",
+            "--scope-json",
+            json.dumps({"owner": "app.py"}),
+            "--author-model",
+            "a",
+            "--author-family",
+            "b",
+            "--author-harness",
+            "c",
+            "--author-selection-reason",
+            "d",
+            "--reviewer-model",
+            "e",
+            "--reviewer-family",
+            "f",
+            "--reviewer-harness",
+            "g",
+            "--reviewer-selection-reason",
+            "h",
+            "--tests-json",
+            json.dumps({"passed": True}),
+            "--behavior-proof-json",
+            json.dumps(
+                {
+                    "source_aware": {"status": "pass"},
+                    "source_blind": {"status": "pass"},
+                }
+            ),
+            # deliberately omit --routing-lineage-json
+        ]
+    )
+    assert code == EXIT_INCOMPLETE
+    data = json.loads(capsys.readouterr().out)
+    assert data["exit_code"] == EXIT_INCOMPLETE
+    assert data["final_disposition"] != "clean"
+
+
+def test_cli_duplicate_later_and_inflated_range(tmp_path, capsys):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text(
+        "shared = 1\nx = 0\nshared = 1\n",
+        encoding="utf-8",
+    )
+    # Later duplicate verifies via CLI
+    payload_ok = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "later",
+            "confidence": 0.8,
+        },
+        "findings": [_finding(start=3, end=3, verbatim="shared = 1")],
+    }
+    review = tmp_path / "ok.json"
+    review.write_text(json.dumps(payload_ok), encoding="utf-8")
+    code = verify_review_cli.main(
+        [
+            "--review-file",
+            str(review),
+            * _cli_envelope_args(
+                repo,
+                dispositions={
+                    "F001": {"disposition": "in_scope_blocker", "rationale": "later"},
+                },
+            ),
+        ]
+    )
+    assert code == EXIT_ACTIONABLE
+    capsys.readouterr()
+
+    # Inflated range fails
+    payload_bad = {
+        "schema_version": SCHEMA_VERSION,
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "inflated",
+            "confidence": 0.8,
+        },
+        "findings": [_finding(start=3, end=10, verbatim="shared = 1")],
+    }
+    review2 = tmp_path / "bad.json"
+    review2.write_text(json.dumps(payload_bad), encoding="utf-8")
+    code2 = verify_review_cli.main(
+        [
+            "--review-file",
+            str(review2),
+            * _cli_envelope_args(repo),
+        ]
+    )
+    assert code2 == EXIT_UNVERIFIABLE
+    data = json.loads(capsys.readouterr().out)
+    assert data["findings"][0]["outcome"] == OUTCOME_LINE_MISMATCH
 
 
 def test_dispositions_attached_on_receipt(tmp_path):
@@ -718,3 +1212,12 @@ def test_dispositions_attached_on_receipt(tmp_path):
     )
     assert result.validations[0].disposition == "in_scope_blocker"
     assert "Introduced" in (result.validations[0].disposition_rationale or "")
+    assert result.exit_code == EXIT_ACTIONABLE
+
+
+def test_build_target_manifest_matches_fingerprint_helper(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v1')\nvalue = 2\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    manifest = build_target_manifest(repo, target)
+    assert manifest["input_sha256"] == compute_target_input_fingerprint(repo, target)

--- a/tests/test_verify_review.py
+++ b/tests/test_verify_review.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import scripts.verify_review as verify_review_cli
 from scripts.common.git_context import sanitized_git_env
 from scripts.review.evidence import (
+    CANONICAL_DIFF_ARGS,
     OUTCOME_LINE_MISMATCH,
     OUTCOME_OUT_OF_SCOPE,
     OUTCOME_QUOTE_MISSING,
@@ -25,6 +26,7 @@ from scripts.review.evidence import (
     is_safe_repo_relative_path,
     match_at_line,
     normalize_line_endings,
+    path_surface_bytes,
     resolve_safe_path,
     split_lines_preserve_content,
 )
@@ -39,6 +41,7 @@ from scripts.review.review_contract import (
     AgentIdentity,
     ContractError,
     VerifyContext,
+    load_schema,
     parse_reviewer_json,
     sha256_text,
     sort_findings_deterministically,
@@ -1221,3 +1224,382 @@ def test_build_target_manifest_matches_fingerprint_helper(tmp_path):
     target = resolve_local_target(repo)
     manifest = build_target_manifest(repo, target)
     assert manifest["input_sha256"] == compute_target_input_fingerprint(repo, target)
+
+
+# --- closeout gate / fingerprint / invalid CLI (review cycle 2) --------------
+
+
+def test_failed_tests_cannot_exit_clean(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            tests={"commands": ["pytest"], "passed": False},
+        ),
+    )
+    assert result.exit_code == EXIT_ACTIONABLE
+    assert result.final_disposition == "actionable"
+    assert "tests_failed" in (result.error or "")
+    assert result.exit_code != EXIT_CLEAN
+
+
+def test_failed_behavior_proof_cannot_exit_clean(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            behavior_proof={
+                "source_aware": {"status": "fail"},
+                "source_blind": {"status": "fail"},
+            },
+        ),
+    )
+    assert result.exit_code == EXIT_ACTIONABLE
+    assert "behavior_proof.source_aware_failed" in (result.error or "")
+    assert "behavior_proof.source_blind_failed" in (result.error or "")
+
+
+def test_same_family_lineage_cannot_exit_clean(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            author=_identity(model="author-model", family="OpenAI"),
+            reviewer=_identity(
+                model="reviewer-model",
+                family="openai",
+                selection_reason="same-family-advisory",
+            ),
+        ),
+    )
+    assert result.exit_code == EXIT_ACTIONABLE
+    assert "same_family_review" in (result.error or "")
+    assert result.final_disposition != "clean"
+
+
+def test_justified_na_tests_and_behavior_proof_can_exit_clean(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            tests={
+                "status": "n/a",
+                "reason": "no automated suite for docs-only surface",
+            },
+            behavior_proof={
+                "source_aware": {"status": "pass"},
+                "source_blind": {
+                    "status": "n/a",
+                    "reason": "no user-visible surface",
+                },
+            },
+        ),
+    )
+    assert result.exit_code == EXIT_CLEAN
+    assert result.error is None
+
+
+def test_missing_behavior_status_is_incomplete(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            behavior_proof={
+                "source_aware": {"note": "present without status"},
+                "source_blind": {"status": "pass"},
+            },
+        ),
+    )
+    assert result.exit_code == EXIT_INCOMPLETE
+    assert "behavior_proof.source_aware_status_missing" in (result.error or "")
+
+
+def test_tests_passed_without_commands_is_incomplete(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(repo, target, raw, tests={"passed": True}),
+    )
+    assert result.exit_code == EXIT_INCOMPLETE
+    assert "tests_commands_missing" in (result.error or "")
+
+
+def test_tracked_binary_same_length_mutation_changes_fingerprint(tmp_path):
+    repo = _init_repo(tmp_path)
+    blob_a = b"\x00\x01\x02\x03AAAA"
+    blob_b = b"\x00\x01\x02\x03BBBB"
+    assert len(blob_a) == len(blob_b)
+    (repo / "asset.bin").write_bytes(blob_a)
+    _git(repo, "add", "asset.bin")
+    _git(repo, "commit", "-q", "-m", "add binary")
+    (repo / "asset.bin").write_bytes(blob_b)
+    target = resolve_local_target(repo)
+    assert "asset.bin" in target.changed_paths
+    surface = path_surface_bytes(repo, target, "asset.bin")
+    # Full-index + binary surface carries content identity, not only abbrev.
+    assert b"index " in surface
+    index_line = next(
+        line for line in surface.splitlines() if line.startswith(b"index ")
+    )
+    # full-index: two 40-char hex object ids separated by ".."
+    assert b".." in index_line
+    left, right = index_line.split(b" ", 1)[1].split(b" ")[0].split(b"..")
+    assert len(left) == 40 and len(right) == 40
+    assert all(c in b"0123456789abcdef" for c in left + right)
+    fp1 = compute_target_input_fingerprint(repo, target)
+    (repo / "asset.bin").write_bytes(blob_a)  # mutate back to committed
+    # Same content as HEAD → no change surface for this path; force second
+    # same-length mutation different from both prior blobs? Use third blob.
+    blob_c = b"\x00\x01\x02\x03CCCC"
+    (repo / "asset.bin").write_bytes(blob_c)
+    target2 = resolve_local_target(repo)
+    fp2 = compute_target_input_fingerprint(repo, target2)
+    assert fp1 != fp2
+    # Untracked path still hashes raw bytes.
+    (repo / "new.bin").write_bytes(blob_a)
+    target3 = resolve_local_target(repo)
+    assert "new.bin" in target3.changed_paths
+    untracked = path_surface_bytes(repo, target3, "new.bin")
+    assert untracked == blob_a
+
+
+def test_fingerprint_not_controlled_by_abbrev_formatting(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    (repo / "asset.bin").write_bytes(b"\xff\xfeBINARY-DATA-01")
+    _git(repo, "add", "asset.bin")
+    _git(repo, "commit", "-q", "-m", "bin")
+    (repo / "asset.bin").write_bytes(b"\xff\xfeBINARY-DATA-02")
+    target = resolve_local_target(repo)
+    fp_default = compute_target_input_fingerprint(repo, target)
+
+    # Even if process env requests ultra-short abbrev, canonical flags win.
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def tracking_run(cmd, **kwargs):
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "git":
+            calls.append(list(cmd))
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", tracking_run)
+    # Local git config that would otherwise shrink index lines.
+    _git(repo, "config", "core.abbrev", "4")
+    fp_short = compute_target_input_fingerprint(repo, target)
+    assert fp_short == fp_default
+    # Fingerprint path uses the stable flag set.
+    diff_calls = [c for c in calls if "diff" in c]
+    assert any(all(flag in c for flag in CANONICAL_DIFF_ARGS) for c in diff_calls)
+    surface = path_surface_bytes(repo, target, "asset.bin")
+    index_line = next(line for line in surface.splitlines() if line.startswith(b"index "))
+    ids = index_line.split(b" ", 1)[1].split(b" ")[0].split(b"..")
+    assert all(len(part) == 40 for part in ids)
+
+
+def test_load_schema_invalid_json_is_contract_error(tmp_path, monkeypatch):
+    bad = tmp_path / "schemas"
+    bad.mkdir()
+    schema_file = bad / "code-review-findings.v1.schema.json"
+    schema_file.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setattr(
+        "scripts.review.review_contract.package_repo_root",
+        lambda: tmp_path,
+    )
+    with pytest.raises(ContractError, match="schema_invalid_json") as exc:
+        load_schema()
+    assert exc.value.exit_code == EXIT_INVALID
+
+
+def test_load_schema_unreadable_is_contract_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "scripts.review.review_contract.package_repo_root",
+        lambda: tmp_path / "missing-root",
+    )
+    with pytest.raises(ContractError, match="schema_unavailable") as exc:
+        load_schema()
+    assert exc.value.exit_code == EXIT_INVALID
+
+
+def test_invalid_meta_schema_is_contract_error():
+    with pytest.raises(ContractError, match="schema_meta_invalid") as exc:
+        validate_reviewer_payload(_clean_payload(), schema={"type": "not-a-type"})
+    assert exc.value.exit_code == EXIT_INVALID
+
+
+def test_cli_malformed_envelope_json_exits_invalid(tmp_path, capsys):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    review = tmp_path / "review.json"
+    review.write_text(json.dumps(_clean_payload()), encoding="utf-8")
+    labels = (
+        "--scope-json",
+        "--tests-json",
+        "--behavior-proof-json",
+        "--dispositions-json",
+        "--routing-lineage-json",
+    )
+    for label in labels:
+        args = [
+            "--review-file",
+            str(review),
+            "--mode",
+            "local",
+            "--repo-root",
+            str(repo),
+            label,
+            "{not-json",
+        ]
+        code = verify_review_cli.main(args)
+        assert code == EXIT_INVALID, label
+        err = capsys.readouterr().err
+        data = json.loads(err)
+        assert data["exit_code"] == EXIT_INVALID
+        assert data["final_disposition"] == "invalid"
+        assert "invalid_json" in data["error"]
+
+
+def test_cli_failed_proof_and_same_family_non_clean(tmp_path, capsys):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    review = tmp_path / "review.json"
+    review.write_text(json.dumps(_clean_payload()), encoding="utf-8")
+    target = resolve_local_target(repo)
+    fp = compute_target_input_fingerprint(repo, target)
+    base = [
+        "--review-file",
+        str(review),
+        "--mode",
+        "local",
+        "--repo-root",
+        str(repo),
+        "--expected-input-sha256",
+        fp,
+        "--issue-ref",
+        "#5284",
+        "--scope-json",
+        json.dumps({"owner": "app.py"}),
+        "--author-model",
+        "a",
+        "--author-family",
+        "openai",
+        "--author-harness",
+        "h",
+        "--author-selection-reason",
+        "author",
+        "--reviewer-model",
+        "b",
+        "--reviewer-harness",
+        "h",
+        "--reviewer-selection-reason",
+        "review",
+        "--routing-lineage-json",
+        json.dumps({"implementation_agent": "impl"}),
+    ]
+
+    # Failed tests + failed behavior proof
+    code = verify_review_cli.main(
+        [
+            *base,
+            "--reviewer-family",
+            "xai",
+            "--tests-json",
+            json.dumps({"commands": ["pytest"], "passed": False}),
+            "--behavior-proof-json",
+            json.dumps(
+                {
+                    "source_aware": {"status": "fail"},
+                    "source_blind": {"status": "fail"},
+                }
+            ),
+        ]
+    )
+    assert code == EXIT_ACTIONABLE
+    data = json.loads(capsys.readouterr().out)
+    assert data["final_disposition"] == "actionable"
+    assert data["exit_code"] == EXIT_ACTIONABLE
+    assert "tests_failed" in (data.get("error") or "")
+
+    # Same-family with otherwise green proof
+    code2 = verify_review_cli.main(
+        [
+            *base,
+            "--reviewer-family",
+            "OpenAI",
+            "--tests-json",
+            json.dumps({"commands": ["pytest"], "passed": True}),
+            "--behavior-proof-json",
+            json.dumps(
+                {
+                    "source_aware": {"status": "pass"},
+                    "source_blind": {"status": "pass"},
+                }
+            ),
+        ]
+    )
+    assert code2 == EXIT_ACTIONABLE
+    data2 = json.loads(capsys.readouterr().out)
+    assert data2["final_disposition"] == "actionable"
+    assert "same_family_review" in (data2.get("error") or "")
+
+
+def test_cli_subprocess_malformed_scope_exits_2(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    review = tmp_path / "review.json"
+    review.write_text(json.dumps(_clean_payload()), encoding="utf-8")
+    root = Path(__file__).resolve().parent.parent
+    proc = subprocess.run(
+        [
+            str(root / ".venv" / "bin" / "python"),
+            str(root / "scripts" / "verify_review.py"),
+            "--review-file",
+            str(review),
+            "--mode",
+            "local",
+            "--repo-root",
+            str(repo),
+            "--scope-json",
+            "{not-json",
+        ],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=sanitized_git_env(),
+    )
+    assert proc.returncode == EXIT_INVALID
+    err = json.loads(proc.stderr)
+    assert err["exit_code"] == EXIT_INVALID
+    assert "invalid_json" in err["error"]


### PR DESCRIPTION
## Summary

- replace loose `FINDING:` parsing with a strict versioned JSON contract;
- bind evidence checks to the exact local/commit/branch/PR target from #5286;
- add deterministic review receipts, stable exit classes, path guards, and adversarial tests.

## Tracking

Closes #5284
Parent: #5281
Stream epic: #4707

## Routing provenance

The issue's provisional Claude developer was substituted before work began because the live CodexBar routing signal showed Claude near its weekly cap and Grok with 97% headroom. Implementation used native Grok 4.5 at high effort. GPT-5.6 Sol owns integration and the formal cross-family review gate.

## Verification at initial head `cc730bc548558d795c6fee620ce4ed12848cada2`

- `.venv/bin/python -m pytest tests/test_verify_review.py tests/ai_agent_bridge/test_verify_review.py tests/test_review_target_resolution.py tests/test_review_findings_ledger.py -q` — 62 passed;
- `.venv/bin/ruff check ...` — passed;
- `git diff --check origin/main...HEAD` — passed;
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed.

## Review state

The initial GPT-5.6 Sol review found in-scope blockers around target-input freshness, receipt lineage completeness, and exact location matching. They are being corrected on this branch before the review gate can pass. Auto-merge is not armed.
