### PR TITLE
fix(lifecycle): recover publish-stage identity drift

### DIFF
--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -916,6 +916,7 @@ def record_change(
                 "REPAIR_REQUIRED",
                 "AUDIT_TOOLING_REQUIRED",
                 "REVIEWER_INSTABILITY",
+                "PUBLISH_REQUIRED",
                 "INTEGRATION_REQUIRED",
             }
             if ledger["state"] not in allowed_states:

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -940,8 +940,12 @@ def test_cross_family_review_gate_and_publication(
     assert ledger["run"]["status"] == "completed"
 
 
-def test_integration_drift_can_be_recorded_and_restarts_post_build_review(
-    fake_repo: tuple[Path, Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("repair_state", ["PUBLISH_REQUIRED", "INTEGRATION_REQUIRED"])
+def test_post_review_drift_can_be_recorded_and_restarts_post_build_review(
+    fake_repo: tuple[Path, Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    repair_state: str,
 ) -> None:
     repo, config_path, ledger_root = fake_repo
     _, ledger = _start(fake_repo, "a1/core-unbuilt")
@@ -992,7 +996,7 @@ def test_integration_drift_can_be_recorded_and_restarts_post_build_review(
         ledger_root=ledger_root,
     )
     assert ledger["state"] == "INDEPENDENT_REVIEW_REQUIRED"
-    ledger["state"] = "INTEGRATION_REQUIRED"
+    ledger["state"] = repair_state
     tc._atomic_write_json(
         tc.ledger_path_for(
             snapshot,


### PR DESCRIPTION
## Summary

- allow a real identity-changing repair to be recorded from `PUBLISH_REQUIRED`;
- route that repair back through fresh post-build review using the existing fail-closed path;
- extend the regression test to cover both publish-stage and integration-stage drift recovery.

All existing no-op, author-family, owner-routing, and stale-publication/QG reset guards remain unchanged.

## Verification

- `.venv/bin/python -m pytest tests/test_track_completion.py -q` — 17 passed
- `.venv/bin/ruff check agents_extensions/shared/skills/track-completion/scripts/track_completion.py tests/test_track_completion.py` — passed
- `git diff --check` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

Closes #5291
Parent stream epic: #4431