### PR TITLE
feat(review): add calibrated post-build scorecard v4

### DIFF
--- a/agents_extensions/shared/curriculum-lifecycle/config/certification-profiles.v1.yaml
+++ b/agents_extensions/shared/curriculum-lifecycle/config/certification-profiles.v1.yaml
@@ -19,7 +19,7 @@ profiles:
     family: core
     readiness_profile: core
     pbr:
-      adapter: post-build-review.v3
+      adapter: post-build-review.v4
       required: true
     independent_review:
       required_for_mutation: true
@@ -33,7 +33,7 @@ profiles:
     family: core
     readiness_profile: core
     pbr:
-      adapter: post-build-review.v3
+      adapter: post-build-review.v4
       required: true
     independent_review:
       required_for_mutation: true
@@ -47,7 +47,7 @@ profiles:
     family: seminar
     readiness_profile: seminar
     pbr:
-      adapter: post-build-review.v3
+      adapter: post-build-review.v4
       required: true
     independent_review:
       required_for_mutation: true
@@ -61,7 +61,7 @@ profiles:
     family: seminar
     readiness_profile: bio
     pbr:
-      adapter: post-build-review.v3
+      adapter: post-build-review.v4
       required: true
     independent_review:
       required_for_mutation: true

--- a/agents_extensions/shared/curriculum-lifecycle/schema/certification-profiles.v1.schema.json
+++ b/agents_extensions/shared/curriculum-lifecycle/schema/certification-profiles.v1.schema.json
@@ -47,7 +47,7 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["adapter", "required"],
-          "properties": {"adapter": {"const": "post-build-review.v3"}, "required": {"const": true}}
+          "properties": {"adapter": {"const": "post-build-review.v4"}, "required": {"const": true}}
         },
         "independent_review": {"$ref": "#/$defs/mutationGate"},
         "integration": {"$ref": "#/$defs/mutationGate"},

--- a/agents_extensions/shared/skills/post-build-review/SKILL.md
+++ b/agents_extensions/shared/skills/post-build-review/SKILL.md
@@ -69,8 +69,8 @@ artifacts. Report findings; do not fix the module during this invocation.
 - Disposition policy: [contracts/combined-disposition-policy.md](contracts/combined-disposition-policy.md)
 - Size policy: [contracts/evidence-derived-size-policy-contract.md](contracts/evidence-derived-size-policy-contract.md)
 - Track configuration: [config/track-policy.v1.yaml](config/track-policy.v1.yaml)
-- Current output schema: [schema/review-result.v3.schema.json](schema/review-result.v3.schema.json)
-- Historical schemas: [schema/review-result.v1.schema.json](schema/review-result.v1.schema.json), [schema/review-result.v2.schema.json](schema/review-result.v2.schema.json)
+- Current output schema: [schema/review-result.v4.schema.json](schema/review-result.v4.schema.json)
+- Historical schemas: [schema/review-result.v1.schema.json](schema/review-result.v1.schema.json), [schema/review-result.v2.schema.json](schema/review-result.v2.schema.json), [schema/review-result.v3.schema.json](schema/review-result.v3.schema.json)
 
 The runner assembles the common prompt plus exactly one family prompt. Do not
 manually concatenate or substitute other review prompts.
@@ -81,6 +81,12 @@ manually concatenate or substitute other review prompts.
   the track audit, or `--run-mdx-generation-validate`; those paths may write to
   the repository.
 - Never let semantic `PASS` override a deterministic blocker/high finding.
+- Treat v4 dimension scores and `minimum_dimension_score` as diagnostic,
+  evidence-backed reporting only. Never use them as readiness thresholds,
+  disposition inputs, score sidecars, or retry-selection criteria.
+- Treat `10.0` as an attestation about findings linked to that dimension, not
+  as evidence that the whole result has no claim or learner-evidence findings.
+  The strict normalizer rejects any finding that has no dimension/ledger owner.
 - Never infer audio, video, image, text, or interactive content from metadata.
   If the reviewer cannot inspect evidence required by a learner task, record it
   as `reviewer_unverified` and return `INCOMPLETE`.

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,7 +1,7 @@
-review_protocol_version: 3.0.0
+review_protocol_version: 4.0.0
 deterministic_contract_version: 1.2.1
-semantic_prompt_version: 3.0.0
-track_policy_version: 1.5.0
+semantic_prompt_version: 4.0.0
+track_policy_version: 1.6.0
 
 defaults:
   semantic_requirements:
@@ -69,7 +69,7 @@ families:
           severity: high
           message: Public-media rights remain unresolved.
     skip_policy:
-      llm_qg: capabilities_absorbed_by_semantic_v3
+      llm_qg: capabilities_absorbed_by_semantic_v4
       mdx_generation_validate: accepted_read_only_omission
       external_resource_liveness: advisory_external
   seminar:
@@ -98,7 +98,7 @@ families:
           severity: high
           message: Public-media rights remain unresolved; use text-only until cleared.
     skip_policy:
-      llm_qg: capabilities_absorbed_by_semantic_v3
+      llm_qg: capabilities_absorbed_by_semantic_v4
       mdx_generation_validate: accepted_read_only_omission
       external_resource_liveness: advisory_external
 

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -3,6 +3,21 @@ deterministic_contract_version: 1.2.1
 semantic_prompt_version: 4.0.0
 track_policy_version: 1.6.0
 
+score_calibration:
+  bands:
+    PASS:
+      minimum: 8.0
+      maximum: 10.0
+      includes_maximum: true
+    REVISE:
+      minimum: 6.0
+      maximum: 8.0
+      includes_maximum: false
+    BLOCK:
+      minimum: 0.0
+      maximum: 6.0
+      includes_maximum: false
+
 defaults:
   semantic_requirements:
     learner_evidence_ledger: required_when_applicable

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -63,7 +63,7 @@ inside this result only: they never set readiness, demote a warning, change the
 categorical verdict, or authorize a release. `BLOCK` is this contract's name
 for the legacy standing-rule `REJECT`; the quality target remains 9+.
 
-Use these half-open bands exactly: `PASS` `[8.0, 10.0]`, `REVISE` `[6.0, 8.0)`,
+Use these bands exactly: `PASS` `[8.0, 10.0]`, `REVISE` `[6.0, 8.0)`,
 `BLOCK` `[0.0, 6.0)`, and `INCOMPLETE` `null`. Use at most one decimal place.
 Apply the following anchored rubric within the bands:
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Common semantic post-build review prompt
 
-Semantic prompt version: `3.0.0`
+Semantic prompt version: `4.0.0`
 
 Review the resolved built module, not an imagined template. Deterministic facts
 and mechanically verifiable track rules are already in the resolved context;
@@ -55,6 +55,45 @@ location. Do not reuse a generic compliment as evidence across dimensions.
 `INCOMPLETE` may omit excerpts only when its finding explains why the evidence
 could not be inspected.
 
+## Diagnostic score calibration
+
+For every quality dimension, return the exact raw keys `status`, `score`,
+`score_rationale`, `evidence`, and `finding_ids`. Scores are diagnostic evidence
+inside this result only: they never set readiness, demote a warning, change the
+categorical verdict, or authorize a release. `BLOCK` is this contract's name
+for the legacy standing-rule `REJECT`; the quality target remains 9+.
+
+Use these half-open bands exactly: `PASS` `[8.0, 10.0]`, `REVISE` `[6.0, 8.0)`,
+`BLOCK` `[0.0, 6.0)`, and `INCOMPLETE` `null`. Use at most one decimal place.
+Apply the following anchored rubric within the bands:
+
+- Return `10.0` if and only if that dimension has no findings.
+- `9.0`–`9.9` meets the quality target with only bounded, low-severity
+  headroom; `8.0`–`8.9` is release-safe but has a more consequential,
+  concrete low-severity improvement.
+- `7.0`–`7.9` needs one focused material revision while most of the dimension
+  remains strong; `6.0`–`6.9` has a substantial material defect that requires
+  broader revision.
+- `4.0`–`5.9` has a blocking defect despite some usable evidence; `0.0`–`3.9`
+  is fundamentally unusable, unsafe, or unsupported for that dimension.
+- Every score below `10.0` must link to at least one evidence-backed finding in
+  that dimension and its rationale must name the concrete gap to `10.0`.
+- Every semantic finding must be referenced by at least one quality dimension,
+  contradicted/imprecise/unattested claim, or non-verified learner-evidence
+  entry. A `10.0` attests that the dimension has no linked finding; it never
+  erases a separately owned claim or learner-evidence finding from the result.
+- A Russianism, calque, or fabrication-class finding for a dimension caps that
+  dimension at `6.0`. The current finding structure has no stable hard-class
+  field, so this cap is a reviewer contract exercised by calibration fixtures;
+  never evade it by reclassifying or omitting the finding.
+- Scores are comparable only when `(semantic_prompt_version, reviewer.family,
+  reviewer.model, reviewer.effort)` is identical. Never compare, average, rank,
+  or aggregate scores across a different tuple.
+
+`score` is a JSON number for `PASS`, `REVISE`, or `BLOCK`, and `null` if and
+only if the status is `INCOMPLETE`. `score_rationale` is a non-empty string for
+numeric scores and `null` if and only if the status is `INCOMPLETE`.
+
 Before returning, mechanically search every quality-dimension `excerpt` in its
 referenced target file. Each excerpt must be one contiguous, byte-for-byte
 substring; never splice fragments, normalize punctuation, or add an ellipsis.
@@ -99,6 +138,8 @@ equal the statuses actually present in that array.
   "quality_dimensions": {
     "pedagogical": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
+      "score": 10.0,
+      "score_rationale": "No pedagogical finding identifies a gap to 10.0.",
       "evidence": [
         {
           "location": "repo-relative target file and locator",
@@ -109,21 +150,29 @@ equal the statuses actually present in that array.
     },
     "naturalness": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
+      "score": 10.0,
+      "score_rationale": "No naturalness finding identifies a gap to 10.0.",
       "evidence": [{"location": "path:locator", "excerpt": "exact excerpt"}],
       "finding_ids": []
     },
     "decolonization": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
+      "score": 10.0,
+      "score_rationale": "No decolonization finding identifies a gap to 10.0.",
       "evidence": [{"location": "path:locator", "excerpt": "exact excerpt"}],
       "finding_ids": []
     },
     "engagement": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
+      "score": 10.0,
+      "score_rationale": "No engagement finding identifies a gap to 10.0.",
       "evidence": [{"location": "path:locator", "excerpt": "exact excerpt"}],
       "finding_ids": []
     },
     "tone": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
+      "score": 10.0,
+      "score_rationale": "No tone finding identifies a gap to 10.0.",
       "evidence": [{"location": "path:locator", "excerpt": "exact excerpt"}],
       "finding_ids": []
     }
@@ -179,4 +228,7 @@ only supported claims.
 Every quality-dimension `finding_id` must reference a semantic finding. A
 dimension marked `REVISE` requires a medium/high finding, `BLOCK` requires a
 blocker, and `PASS` cannot reference a material finding. The overall verdict
-must fail closed when any dimension is not `PASS`.
+must fail closed when any dimension is not `PASS`. Do not repair, clamp,
+downgrade, round, reconcile, or otherwise change a score to fit a band.
+Do not emit an orphan semantic finding: every finding must be owned by a
+dimension, claim-ledger entry, or learner-evidence-ledger entry.

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Core semantic post-build review prompt
 
-Semantic prompt version: `3.0.0`
+Semantic prompt version: `4.0.0`
 
 Apply this only to A1-C2 core tracks, after the common prompt.
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Seminar semantic post-build review prompt
 
-Semantic prompt version: `3.0.0`
+Semantic prompt version: `4.0.0`
 
 Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
 after the common prompt.

--- a/agents_extensions/shared/skills/post-build-review/schema/review-result.v4.schema.json
+++ b/agents_extensions/shared/skills/post-build-review/schema/review-result.v4.schema.json
@@ -1,0 +1,349 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/post-build-review.result.v4.schema.json",
+  "title": "Post-build review result v4",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "review_protocol_version",
+    "deterministic_contract_version",
+    "semantic_prompt_version",
+    "track_policy_version",
+    "prompt_sha256",
+    "reproducibility_key",
+    "target",
+    "source_hashes",
+    "reviewer",
+    "semantic_response",
+    "deterministic",
+    "semantic",
+    "findings",
+    "combined_disposition",
+    "minimum_dimension_score"
+  ],
+  "properties": {
+    "schema_version": {"const": "post-build-review.result.v4"},
+    "review_protocol_version": {"$ref": "#/$defs/semver"},
+    "deterministic_contract_version": {"$ref": "#/$defs/semver"},
+    "semantic_prompt_version": {"$ref": "#/$defs/semver"},
+    "track_policy_version": {"$ref": "#/$defs/semver"},
+    "prompt_sha256": {"$ref": "#/$defs/sha256"},
+    "reproducibility_key": {"$ref": "#/$defs/sha256"},
+    "target": {"$ref": "#/$defs/target"},
+    "source_hashes": {
+      "type": "object",
+      "minProperties": 2,
+      "additionalProperties": {"$ref": "#/$defs/sha256"}
+    },
+    "reviewer": {"$ref": "#/$defs/reviewer"},
+    "semantic_response": {"$ref": "#/$defs/semanticResponse"},
+    "deterministic": {"$ref": "#/$defs/deterministic"},
+    "semantic": {"$ref": "#/$defs/semantic"},
+    "minimum_dimension_score": {"type": ["number", "null"], "minimum": 0, "maximum": 10},
+    "findings": {"type": "array", "items": {"$ref": "#/$defs/finding"}},
+    "combined_disposition": {"$ref": "#/$defs/disposition"}
+  },
+  "$defs": {
+    "semver": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "nonempty": {"type": "string", "minLength": 1},
+    "modality": {"enum": ["text", "audio", "video", "image", "interactive"]},
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["track", "slug", "semantic_family", "layout", "files"],
+      "properties": {
+        "track": {"$ref": "#/$defs/nonempty"},
+        "slug": {"$ref": "#/$defs/nonempty"},
+        "semantic_family": {"enum": ["core", "seminar"]},
+        "layout": {"enum": ["directory", "flat"]},
+        "files": {
+          "type": "object",
+          "required": ["plan", "content"],
+          "additionalProperties": {"$ref": "#/$defs/nonempty"}
+        }
+      }
+    },
+    "reviewer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent", "family", "model", "effort", "capabilities"],
+      "properties": {
+        "agent": {"$ref": "#/$defs/nonempty"},
+        "family": {"$ref": "#/$defs/nonempty"},
+        "model": {"$ref": "#/$defs/nonempty"},
+        "effort": {"$ref": "#/$defs/nonempty"},
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/modality"}
+        }
+      }
+    },
+    "semanticResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["raw_sha256", "byte_count", "parser", "parse_status", "contract_status", "error"],
+      "properties": {
+        "raw_sha256": {"$ref": "#/$defs/sha256"},
+        "byte_count": {"type": "integer", "minimum": 0},
+        "parser": {"const": "strict-json-object-v1"},
+        "parse_status": {"enum": ["valid", "invalid"]},
+        "contract_status": {"enum": ["valid", "invalid", "not_evaluated"]},
+        "error": {"type": ["string", "null"]}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"parse_status": {"const": "invalid"}}},
+          "then": {
+            "properties": {
+              "contract_status": {"const": "not_evaluated"},
+              "error": {"type": "string", "minLength": 1}
+            }
+          }
+        },
+        {
+          "if": {"properties": {"contract_status": {"const": "valid"}}},
+          "then": {
+            "properties": {
+              "parse_status": {"const": "valid"},
+              "error": {"type": "null"}
+            }
+          }
+        },
+        {
+          "if": {"properties": {"contract_status": {"const": "invalid"}}},
+          "then": {
+            "properties": {
+              "parse_status": {"const": "valid"},
+              "error": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["argv", "executed_argv", "cwd", "exit_code", "stdout_sha256", "stderr_sha256", "config_path", "config_version"],
+      "properties": {
+        "argv": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/nonempty"}},
+        "executed_argv": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/nonempty"}},
+        "cwd": {"const": "."},
+        "exit_code": {"type": "integer"},
+        "stdout_sha256": {"$ref": "#/$defs/sha256"},
+        "stderr_sha256": {"$ref": "#/$defs/sha256"},
+        "config_path": {"$ref": "#/$defs/nonempty"},
+        "config_version": {"$ref": "#/$defs/nonempty"}
+      }
+    },
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "provenance", "result", "error"],
+      "properties": {
+        "status": {"enum": ["complete", "error"]},
+        "provenance": {"$ref": "#/$defs/provenance"},
+        "result": {"type": ["object", "null"], "additionalProperties": true},
+        "error": {"type": ["string", "null"]}
+      }
+    },
+    "skip": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["category", "disposition", "reason"],
+      "properties": {
+        "category": {"$ref": "#/$defs/nonempty"},
+        "disposition": {"$ref": "#/$defs/nonempty"},
+        "reason": {"type": "string"}
+      }
+    },
+    "evidenceRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "modality", "location", "evidence"],
+      "properties": {
+        "id": {"$ref": "#/$defs/nonempty"},
+        "modality": {"$ref": "#/$defs/modality"},
+        "location": {"$ref": "#/$defs/nonempty"},
+        "evidence": {"$ref": "#/$defs/nonempty"}
+      }
+    },
+    "deterministic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["track_audit", "size_policy", "policy_findings", "evidence_requirements", "skip_assessments", "aggregate"],
+      "properties": {
+        "track_audit": {"$ref": "#/$defs/stage"},
+        "size_policy": {"$ref": "#/$defs/stage"},
+        "policy_findings": {"type": "array", "items": {"$ref": "#/$defs/finding"}},
+        "evidence_requirements": {"type": "array", "items": {"$ref": "#/$defs/evidenceRequirement"}},
+        "skip_assessments": {"type": "array", "items": {"$ref": "#/$defs/skip"}},
+        "aggregate": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "findings_by_severity", "reasons"],
+          "properties": {
+            "status": {"enum": ["clear", "review", "block", "incomplete"]},
+            "findings_by_severity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["blocker", "high", "medium", "low", "info"],
+              "properties": {
+                "blocker": {"type": "integer", "minimum": 0},
+                "high": {"type": "integer", "minimum": 0},
+                "medium": {"type": "integer", "minimum": 0},
+                "low": {"type": "integer", "minimum": 0},
+                "info": {"type": "integer", "minimum": 0}
+              }
+            },
+            "reasons": {"type": "array", "items": {"$ref": "#/$defs/nonempty"}}
+          }
+        }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source", "category", "severity", "message", "evidence", "location"],
+      "properties": {
+        "id": {"$ref": "#/$defs/nonempty"},
+        "issue_id": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]*$"},
+        "source": {"enum": ["deterministic", "track_policy", "semantic"]},
+        "category": {"$ref": "#/$defs/nonempty"},
+        "severity": {"enum": ["blocker", "high", "medium", "low", "info"]},
+        "message": {"$ref": "#/$defs/nonempty"},
+        "evidence": {"$ref": "#/$defs/nonempty"},
+        "location": {"type": ["string", "null"]}
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"source": {"const": "semantic"}},
+            "required": ["source"]
+          },
+          "then": {"required": ["issue_id"]}
+        }
+      ]
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "claims_total", "claims_checked", "claims_supported"],
+      "properties": {
+        "status": {"enum": ["complete", "incomplete", "not_applicable"]},
+        "claims_total": {"type": "integer", "minimum": 0},
+        "claims_checked": {"type": "integer", "minimum": 0},
+        "claims_supported": {"type": "integer", "minimum": 0}
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "claim", "location", "status", "evidence", "finding_id"],
+      "properties": {
+        "id": {"$ref": "#/$defs/nonempty"},
+        "claim": {"$ref": "#/$defs/nonempty"},
+        "location": {"$ref": "#/$defs/nonempty"},
+        "status": {"enum": ["supported", "contradicted", "imprecise", "unattested", "unverifiable"]},
+        "evidence": {"$ref": "#/$defs/nonempty"},
+        "finding_id": {"type": ["string", "null"]}
+      }
+    },
+    "learnerEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "location", "task", "modality", "source", "access_status", "verification_method", "finding_id"],
+      "properties": {
+        "id": {"$ref": "#/$defs/nonempty"},
+        "location": {"$ref": "#/$defs/nonempty"},
+        "task": {"$ref": "#/$defs/nonempty"},
+        "modality": {"$ref": "#/$defs/modality"},
+        "source": {"$ref": "#/$defs/nonempty"},
+        "access_status": {"enum": ["verified_access", "metadata_only", "inaccessible", "not_provided", "reviewer_unverified"]},
+        "verification_method": {"$ref": "#/$defs/nonempty"},
+        "finding_id": {"type": ["string", "null"]}
+      }
+    },
+    "dimensionEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["location", "excerpt"],
+      "properties": {
+        "location": {"$ref": "#/$defs/nonempty"},
+        "excerpt": {"type": "string", "minLength": 8}
+      }
+    },
+    "qualityDimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "score", "score_rationale", "evidence", "finding_ids"],
+      "properties": {
+        "status": {"enum": ["PASS", "REVISE", "BLOCK", "INCOMPLETE"]},
+        "score": {"type": ["number", "null"], "minimum": 0, "maximum": 10},
+        "score_rationale": {"type": ["string", "null"]},
+        "evidence": {"type": "array", "items": {"$ref": "#/$defs/dimensionEvidence"}},
+        "finding_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/nonempty"}
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"status": {"const": "INCOMPLETE"}}, "required": ["status"]},
+          "then": {
+            "properties": {
+              "score": {"const": null},
+              "score_rationale": {"const": null}
+            }
+          },
+          "else": {
+            "properties": {
+              "score": {"type": "number", "minimum": 0, "maximum": 10},
+              "score_rationale": {"$ref": "#/$defs/nonempty"}
+            }
+          }
+        }
+      ]
+    },
+    "qualityDimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pedagogical", "naturalness", "decolonization", "engagement", "tone"],
+      "properties": {
+        "pedagogical": {"$ref": "#/$defs/qualityDimension"},
+        "naturalness": {"$ref": "#/$defs/qualityDimension"},
+        "decolonization": {"$ref": "#/$defs/qualityDimension"},
+        "engagement": {"$ref": "#/$defs/qualityDimension"},
+        "tone": {"$ref": "#/$defs/qualityDimension"}
+      }
+    },
+    "semantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family", "verdict", "summary", "quality_dimensions", "claim_coverage", "claim_ledger", "learner_evidence_ledger", "findings"],
+      "properties": {
+        "family": {"enum": ["core", "seminar"]},
+        "verdict": {"enum": ["PASS", "REVISE", "BLOCK", "INCOMPLETE"]},
+        "summary": {"type": "string"},
+        "quality_dimensions": {"$ref": "#/$defs/qualityDimensions"},
+        "claim_coverage": {"$ref": "#/$defs/coverage"},
+        "claim_ledger": {"type": "array", "items": {"$ref": "#/$defs/claim"}},
+        "learner_evidence_ledger": {"type": "array", "items": {"$ref": "#/$defs/learnerEvidence"}},
+        "findings": {"type": "array", "items": {"$ref": "#/$defs/finding"}}
+      }
+    },
+    "disposition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reasons"],
+      "properties": {
+        "status": {"enum": ["PASS", "REVISE", "BLOCK", "INCOMPLETE"]},
+        "reasons": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/nonempty"}}
+      }
+    }
+  }
+}

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -18,7 +18,7 @@ review as an operator completion gate.
 
 ## Start or resume
 
-1. Preserve the legacy parity boundary documented below. Post-build review v3
+1. Preserve the legacy parity boundary documented below. Post-build review v4
    owns semantic readiness; the outer skill owns lifecycle and persistence.
 2. Satisfy repository issue, stream, worktree, research-classification, and
    pending-decision preflight before mutation. Work in the existing scoped
@@ -211,10 +211,11 @@ The repository-backed feature audit has these binding dispositions:
 
 | Capability | Completion disposition |
 | --- | --- |
-| Pedagogical, naturalness, decolonization, engagement, tone; scaffolding/leakage canaries; Ukrainian/factual/decolonization/media evidence | ABSORB into post-build prompt v3, schema, strict normalizer, and regression tests |
+| Pedagogical, naturalness, decolonization, engagement, tone; scaffolding/leakage canaries; Ukrainian/factual/decolonization/media evidence | ABSORB into post-build prompt v4, schema, strict normalizer, and regression tests |
 | Deterministic surface/activity/vocabulary/resource/route/size checks | ABSORB through post-build preparation; never invoke separately |
 | Author lineage, repairability, freshness, bounded correction, and stability | REPLACE with ledger identities, deterministic owners, fresh review, and `REVIEWER_INSTABILITY` |
-| Numeric scores, warning demotion, parser salvage, merged retries, score sidecars, DB/mtime readiness, same-route median independence | REJECT |
+| Schema-bound, evidence-backed in-result diagnostic dimension scores and a reporting-only minimum | ACCEPT; categorical semantic and deterministic gates remain authoritative |
+| Numeric score authority, numeric readiness thresholds, score sidecars, score-based disposition, warning demotion, parser salvage, merged retries, DB/mtime readiness, same-route median independence | REJECT |
 | Canary calibration, cost/circuit experiments, deep-read evaluation, and V7's internal LLM-QG while it remains | RETAIN-EVAL only; none can complete the outer state machine |
 
 Before deprecating separate operator invocation, tests must prove current and

--- a/agents_extensions/shared/skills/track-completion/config/track-completion.v1.yaml
+++ b/agents_extensions/shared/skills/track-completion/config/track-completion.v1.yaml
@@ -130,7 +130,7 @@ identity_paths:
   - agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
   - agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
   - agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
-  - agents_extensions/shared/skills/post-build-review/schema/review-result.v3.schema.json
+  - agents_extensions/shared/skills/post-build-review/schema/review-result.v4.schema.json
   - agents_extensions/shared/skills/post-build-review/SKILL.md
   - agents_extensions/shared/skills/apply-plan-fixes/SKILL.md
   - agents_extensions/shared/skills/apply-plan-fixes/apply-plan-fixes-prompt.md
@@ -161,7 +161,7 @@ certification_identity_paths:
     - agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
     - agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
     - agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
-    - agents_extensions/shared/skills/post-build-review/schema/review-result.v3.schema.json
+    - agents_extensions/shared/skills/post-build-review/schema/review-result.v4.schema.json
     - scripts/audit/post_build_review.py
     - scripts/audit/track_deterministic_audit.py
     - scripts/audit/module_size_policy_audit.py

--- a/docs/architecture/adr/adr-012-code-driven-curriculum-lifecycle.md
+++ b/docs/architecture/adr/adr-012-code-driven-curriculum-lifecycle.md
@@ -53,7 +53,10 @@ The existing `$track-completion` implementation remains the module engine. It is
 extended behind compatible schemas rather than replaced. Existing BIO readiness
 gates supply the first PREPARE adapter pattern; V7 remains the BUILD adapter;
 `$post-build-review` remains the first CERTIFY adapter. No adapter's internal
-cache, score, sidecar, or generated report may become lifecycle authority.
+cache, score, sidecar, or generated report may become lifecycle authority. Its
+v4 result may retain schema-bound, evidence-backed per-dimension diagnostic
+scores and a reporting-only minimum, while categorical semantic and
+deterministic gates remain the only release authority.
 
 ### Derived lifecycle
 
@@ -154,8 +157,14 @@ Production LLM-QG is an optional adapter and remains disarmed. Enabling it requi
 a repository-backed qualification artifact, complete dry-run, route/model/prompt/
 gate canary, budget rails, circuit breaker, resumable evidence, and explicit human
 arming. Its useful cache, lineage, grounding, canary, and cost controls may be
-reused. Legacy `llm_qg.json`, numeric score thresholds, file mtimes, SQLite rows,
-parser salvage, median sampling, and in-gate mutation remain non-authoritative.
+reused. The lifecycle explicitly rejects numeric score authority, numeric
+readiness thresholds, score sidecars, score-based disposition, warning
+demotion, parser salvage, merged retries, DB/mtime readiness, and same-route
+median independence. Legacy `llm_qg.json`, file mtimes, SQLite rows, median
+sampling, and in-gate mutation remain non-authoritative. In contrast, the v4
+post-build result accepts only schema-bound, evidence-backed in-result
+diagnostic dimension scores and a reporting-only minimum; those values do not
+alter the categorical gates.
 
 Final certification is a derived state: all gates required by the current track
 profile are current and passing, and all material independent-review findings are

--- a/docs/architecture/curriculum-lifecycle-prompt-responsibility-parity.md
+++ b/docs/architecture/curriculum-lifecycle-prompt-responsibility-parity.md
@@ -47,7 +47,8 @@ The repeated mechanics are assigned once:
 | Durable report paths and remediation batches | Runtime ledger/status `CODE`; compact `REFERENCE` output |
 | Model/helper routing, ownership, and output budgets | Fleet `CONFIG` and coordinator `CODE` |
 | Telemetry and final response | Integration/telemetry adapter `CODE` and schema `CONFIG` |
-| Numeric quality scores used as readiness | Semantic criteria absorbed into explicit findings; legacy authority `DEPRECATE` |
+| Schema-bound, evidence-backed in-result diagnostic scores and reporting-only minimum | `ACCEPT`: v4 evidence fields; categorical semantic and deterministic gates remain authoritative |
+| Numeric score authority, numeric readiness thresholds, score sidecars, score-based disposition, warning demotion, parser salvage, merged retries, DB/mtime readiness, same-route median independence | `REJECT`: no lifecycle authority or retry-selection role |
 
 ## File-by-file parity
 

--- a/docs/runbooks/post-build-review.md
+++ b/docs/runbooks/post-build-review.md
@@ -26,7 +26,7 @@ and combines both layers inside an invocation-unique directory allocated under
 | Mechanically verifiable track rules | `post-build-review/config/track-policy.v1.yaml` |
 | Semantic judgment | `post-build-review/prompts/*.md` |
 | Orchestration order and run isolation | `post-build-review/SKILL.md` plus `post_build_review.py allocate` |
-| Output shape | `post-build-review/schema/review-result.v3.schema.json` |
+| Output shape | `post-build-review/schema/review-result.v4.schema.json` |
 | Operator maintenance | This runbook |
 
 The evidence-derived size contract consumes the existing size-policy audit. It
@@ -47,6 +47,8 @@ Every result records:
 - exact raw semantic-response SHA-256, byte count, parser status, and contract status
 - atomic claim ledger with count-consistency enforcement
 - explicit pedagogical, naturalness, decolonization, engagement, and tone coverage
+- calibrated per-dimension diagnostic scores with score rationales and a
+  reporting-only `minimum_dimension_score` (never an average or release gate)
 - deterministic argv/cwd/exit/output hashes/config provenance
 - source-file hashes and a normalized reproducibility key
 
@@ -60,9 +62,17 @@ Bump the version responsible for a behavior change:
 | Track mapping, mechanical rule, skip classification | `track_policy_version` |
 
 Use semantic versioning. A breaking schema change requires a new schema id/file
-and review protocol major version. Schema v1 remains available for historical
-validation; schema v2 also remains historical and new reviews emit v3. Prompt hashes change automatically from the
+and review protocol major version. Schemas v1-v3 remain available for historical
+validation; new reviews emit v4. Prompt hashes change automatically from the
 exact assembled common + family + resolved context.
+
+Dimension scores preserve the accepted raw reviewer response after strict
+Decimal-based validation: `PASS` is `[8.0, 10.0]`, `REVISE` is `[6.0, 8.0)`,
+`BLOCK` is `[0.0, 6.0)`, and `INCOMPLETE` has a null score/rationale. The
+normalizer never repairs, rounds, clamps, downgrades, or reconciles a score.
+`combine_disposition` consumes categorical semantic/deterministic evidence
+only. A score can be compared only for identical semantic prompt, reviewer
+family, reviewer model, and reviewer effort identities.
 
 ## Bug-fix workflow
 

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
@@ -42,13 +43,19 @@ SCHEMA_PATHS = {
     "post-build-review.result.v1": SKILL_ROOT / "schema" / "review-result.v1.schema.json",
     "post-build-review.result.v2": SKILL_ROOT / "schema" / "review-result.v2.schema.json",
     "post-build-review.result.v3": SKILL_ROOT / "schema" / "review-result.v3.schema.json",
+    "post-build-review.result.v4": SKILL_ROOT / "schema" / "review-result.v4.schema.json",
 }
-CURRENT_PACKET_VERSION = "post-build-review.packet.v3"
-CURRENT_RESULT_SCHEMA_VERSION = "post-build-review.result.v3"
+CURRENT_PACKET_VERSION = "post-build-review.packet.v4"
+CURRENT_RESULT_SCHEMA_VERSION = "post-build-review.result.v4"
 TRACK_AUDIT_CONFIG = PROJECT_ROOT / "scripts" / "audit" / "track_deterministic_audit_config.yaml"
 
 CANONICAL_SEVERITIES = ("blocker", "high", "medium", "low", "info")
 QUALITY_DIMENSIONS = ("pedagogical", "naturalness", "decolonization", "engagement", "tone")
+QUALITY_DIMENSION_SCORE_BANDS = {
+    "PASS": (Decimal("8.0"), Decimal("10.0"), True),
+    "REVISE": (Decimal("6.0"), Decimal("8.0"), False),
+    "BLOCK": (Decimal("0.0"), Decimal("6.0"), False),
+}
 REPRODUCIBILITY_FIELDS = (
     "schema_version",
     "review_protocol_version",
@@ -62,8 +69,12 @@ REPRODUCIBILITY_FIELDS = (
     "semantic_response",
     "deterministic",
     "semantic",
+    "minimum_dimension_score",
     "findings",
     "combined_disposition",
+)
+V3_REPRODUCIBILITY_FIELDS = tuple(
+    field for field in REPRODUCIBILITY_FIELDS if field != "minimum_dimension_score"
 )
 SEVERITY_ALIASES = {
     "critical": "blocker",
@@ -968,6 +979,105 @@ def _nonnegative_int(value: object, label: str) -> int:
     return value
 
 
+def _decimal_score(value: object, label: str) -> Decimal:
+    """Validate a JSON numeric score without normalizing reviewer output."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ReviewProtocolError(f"{label} must be a JSON number, not a boolean or string")
+    try:
+        score = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ReviewProtocolError(f"{label} must be a finite decimal number") from exc
+    if not score.is_finite():
+        raise ReviewProtocolError(f"{label} must be a finite decimal number")
+    if score.as_tuple().exponent < -1:
+        raise ReviewProtocolError(f"{label} must use at most one decimal place")
+    if score < Decimal("0.0") or score > Decimal("10.0"):
+        raise ReviewProtocolError(f"{label} must be in the inclusive range 0.0..10.0")
+    return score
+
+
+def _validate_quality_dimension_score(
+    *,
+    dimension: str,
+    status: str,
+    score: object,
+    score_rationale: object,
+    referenced_findings: Sequence[Mapping[str, Any]],
+) -> None:
+    """Enforce score/status calibration from structure, never by repairing text."""
+    label = f"Quality dimension {dimension} score"
+    if status == "INCOMPLETE":
+        if score is not None or score_rationale is not None:
+            raise ReviewProtocolError(
+                f"{label} and score_rationale must be null when the status is INCOMPLETE"
+            )
+        return
+    if score is None or score_rationale is None:
+        raise ReviewProtocolError(
+            f"{label} and score_rationale are required when the status is {status}"
+        )
+    decimal_score = _decimal_score(score, label)
+    _nonempty_string(score_rationale, f"Quality dimension {dimension} score_rationale")
+    lower, upper, includes_upper = QUALITY_DIMENSION_SCORE_BANDS[status]
+    if decimal_score < lower or decimal_score > upper or (
+        decimal_score == upper and not includes_upper
+    ):
+        upper_marker = "]" if includes_upper else ")"
+        raise ReviewProtocolError(
+            f"{label} {decimal_score} is inconsistent with {status}; expected [{lower}, {upper}{upper_marker}"
+        )
+    if decimal_score == Decimal("10.0") and referenced_findings:
+        raise ReviewProtocolError(
+            f"Quality dimension {dimension} score 10.0 requires no dimension findings"
+        )
+    if decimal_score < Decimal("10.0"):
+        if not referenced_findings:
+            raise ReviewProtocolError(
+                f"Quality dimension {dimension} score below 10.0 requires a dimension finding"
+            )
+        if any(not str(finding.get("evidence") or "").strip() for finding in referenced_findings):
+            raise ReviewProtocolError(
+                f"Quality dimension {dimension} score below 10.0 requires evidence-backed findings"
+            )
+
+
+def minimum_dimension_score(dimensions: Mapping[str, Mapping[str, Any]]) -> int | float | None:
+    """Return the reporting-only minimum without averaging or changing raw scores."""
+    numeric_scores: list[tuple[Decimal, int | float]] = []
+    for dimension in QUALITY_DIMENSIONS:
+        score = dimensions[dimension]["score"]
+        if score is None:
+            return None
+        numeric_scores.append((_decimal_score(score, f"Quality dimension {dimension} score"), score))
+    return min(numeric_scores, key=lambda pair: pair[0])[1]
+
+
+def _validate_semantic_finding_ownership(semantic: Mapping[str, Any]) -> None:
+    """Require every semantic finding to have a dimension or ledger owner."""
+    finding_ids = {str(finding["id"]) for finding in semantic["findings"]}
+    owned_finding_ids = {
+        str(finding_id)
+        for assessment in semantic["quality_dimensions"].values()
+        for finding_id in assessment["finding_ids"]
+    }
+    owned_finding_ids.update(
+        str(claim["finding_id"])
+        for claim in semantic["claim_ledger"]
+        if claim["finding_id"] is not None
+    )
+    owned_finding_ids.update(
+        str(item["finding_id"])
+        for item in semantic["learner_evidence_ledger"]
+        if item["finding_id"] is not None
+    )
+    orphan_finding_ids = sorted(finding_ids - owned_finding_ids)
+    if orphan_finding_ids:
+        raise ReviewProtocolError(
+            "Every semantic finding must be referenced by a quality dimension, "
+            "claim, or learner-evidence entry: " + ", ".join(orphan_finding_ids)
+        )
+
+
 def normalize_semantic_result(
     value: Mapping[str, Any],
     family: str,
@@ -1047,7 +1157,7 @@ def normalize_semantic_result(
     _require_exact_keys(raw_dimensions, set(QUALITY_DIMENSIONS), "quality dimensions")
     dimensions: dict[str, dict[str, Any]] = {}
     dimension_statuses = {"PASS", "REVISE", "BLOCK", "INCOMPLETE"}
-    expected_dimension_keys = {"status", "evidence", "finding_ids"}
+    expected_dimension_keys = {"status", "score", "score_rationale", "evidence", "finding_ids"}
     source_lookup = dict(source_texts or {})
     for dimension in QUALITY_DIMENSIONS:
         raw = raw_dimensions[dimension]
@@ -1134,8 +1244,20 @@ def normalize_semantic_result(
             raise ReviewProtocolError(
                 f"Quality dimension {dimension} INCOMPLETE requires a finding"
             )
+        referenced_findings = [
+            finding for finding in findings if finding["id"] in dimension_finding_ids
+        ]
+        _validate_quality_dimension_score(
+            dimension=dimension,
+            status=dimension_status,
+            score=raw["score"],
+            score_rationale=raw["score_rationale"],
+            referenced_findings=referenced_findings,
+        )
         dimensions[dimension] = {
             "status": dimension_status,
+            "score": raw["score"],
+            "score_rationale": raw["score_rationale"],
             "evidence": dimension_evidence,
             "finding_ids": dimension_finding_ids,
         }
@@ -1305,7 +1427,7 @@ def normalize_semantic_result(
     if verdict == "PASS" and any(claim["status"] != "supported" for claim in claims):
         raise ReviewProtocolError("Semantic PASS is inconsistent with a non-supported claim ledger entry")
 
-    return {
+    normalized = {
         "family": family,
         "verdict": verdict,
         "summary": summary,
@@ -1320,6 +1442,8 @@ def normalize_semantic_result(
         "learner_evidence_ledger": evidence_ledger,
         "findings": findings,
     }
+    _validate_semantic_finding_ownership(normalized)
+    return normalized
 
 
 def _incomplete_semantic(family: str, error: str) -> dict[str, Any]:
@@ -1340,6 +1464,8 @@ def _incomplete_semantic(family: str, error: str) -> dict[str, Any]:
         "quality_dimensions": {
             dimension: {
                 "status": "INCOMPLETE",
+                "score": None,
+                "score_rationale": None,
                 "evidence": [],
                 "finding_ids": ["semantic-response-integrity"],
             }
@@ -1423,10 +1549,16 @@ def combine_disposition(
     return {"status": "PASS", "reasons": ["deterministic and semantic review passed"]}
 
 
-def _validate_normalized_quality_dimensions(semantic: Mapping[str, Any]) -> None:
+def _validate_normalized_quality_dimensions(
+    semantic: Mapping[str, Any], *, scores_required: bool = True, ownership_required: bool = True
+) -> None:
     dimensions = semantic["quality_dimensions"]
     finding_severities = {
         str(finding["id"]): str(finding["severity"])
+        for finding in semantic["findings"]
+    }
+    findings_by_id = {
+        str(finding["id"]): finding
         for finding in semantic["findings"]
     }
     nonpassing: dict[str, str] = {}
@@ -1462,8 +1594,19 @@ def _validate_normalized_quality_dimensions(semantic: Mapping[str, Any]) -> None
             raise ReviewProtocolError(
                 f"Quality dimension {dimension} INCOMPLETE requires a finding"
             )
+        if scores_required:
+            _validate_quality_dimension_score(
+                dimension=dimension,
+                status=status,
+                score=assessment["score"],
+                score_rationale=assessment["score_rationale"],
+                referenced_findings=[findings_by_id[finding_id] for finding_id in finding_ids],
+            )
         if status != "PASS":
             nonpassing[dimension] = status
+
+    if ownership_required:
+        _validate_semantic_finding_ownership(semantic)
 
     verdict = str(semantic["verdict"])
     if verdict == "PASS" and nonpassing:
@@ -1488,9 +1631,18 @@ def validate_result(
         schema_path = repo_root / relative.relative_to(PROJECT_ROOT)
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     Draft202012Validator(schema).validate(result)
-    if result.get("schema_version") != CURRENT_RESULT_SCHEMA_VERSION:
+    schema_version = str(result.get("schema_version") or "")
+    if schema_version not in {CURRENT_RESULT_SCHEMA_VERSION, "post-build-review.result.v3"}:
         return
-    _validate_normalized_quality_dimensions(result["semantic"])
+    _validate_normalized_quality_dimensions(
+        result["semantic"],
+        scores_required=schema_version == CURRENT_RESULT_SCHEMA_VERSION,
+        ownership_required=schema_version == CURRENT_RESULT_SCHEMA_VERSION,
+    )
+    if schema_version == CURRENT_RESULT_SCHEMA_VERSION:
+        expected_minimum_score = minimum_dimension_score(result["semantic"]["quality_dimensions"])
+        if result["minimum_dimension_score"] != expected_minimum_score:
+            raise ReviewProtocolError("minimum_dimension_score does not match the dimension scores")
     expected_findings = [
         *_deterministic_findings(result),
         *deepcopy(result["semantic"]["findings"]),
@@ -1502,7 +1654,12 @@ def validate_result(
     )
     if result["combined_disposition"] != expected_disposition:
         raise ReviewProtocolError("Combined disposition does not match canonical precedence")
-    reproducible = {key: deepcopy(result[key]) for key in REPRODUCIBILITY_FIELDS}
+    reproducibility_fields = (
+        REPRODUCIBILITY_FIELDS
+        if schema_version == CURRENT_RESULT_SCHEMA_VERSION
+        else V3_REPRODUCIBILITY_FIELDS
+    )
+    reproducible = {key: deepcopy(result[key]) for key in reproducibility_fields}
     expected_key = sha256_text(_stable_json(reproducible))
     if result["reproducibility_key"] != expected_key:
         raise ReviewProtocolError("Result reproducibility key does not match canonical evidence")
@@ -1566,6 +1723,7 @@ def finalize_review(
         "semantic_response": response_provenance,
         "deterministic": deterministic,
         "semantic": semantic,
+        "minimum_dimension_score": minimum_dimension_score(semantic["quality_dimensions"]),
         "findings": findings,
         "combined_disposition": disposition,
     }

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -152,11 +152,16 @@ def quality_dimension_score_bands(
             raise ReviewProtocolError(
                 f"Track policy score band {status} must define minimum, maximum, and includes_maximum"
             )
-        try:
-            minimum = Decimal(str(band["minimum"]))
-            maximum = Decimal(str(band["maximum"]))
-        except (InvalidOperation, ValueError) as exc:
-            raise ReviewProtocolError(f"Track policy score band {status} bounds must be numeric") from exc
+        raw_minimum = band["minimum"]
+        raw_maximum = band["maximum"]
+        if type(raw_minimum) not in {int, float} or type(raw_maximum) not in {int, float}:
+            raise ReviewProtocolError(
+                f"Track policy score band {status} bounds must be numeric YAML scalars"
+            )
+        minimum = Decimal(str(raw_minimum))
+        maximum = Decimal(str(raw_maximum))
+        if not minimum.is_finite() or not maximum.is_finite():
+            raise ReviewProtocolError(f"Track policy score band {status} bounds must be finite")
         includes_maximum = band["includes_maximum"]
         if type(includes_maximum) is not bool:
             raise ReviewProtocolError(

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -51,11 +51,6 @@ TRACK_AUDIT_CONFIG = PROJECT_ROOT / "scripts" / "audit" / "track_deterministic_a
 
 CANONICAL_SEVERITIES = ("blocker", "high", "medium", "low", "info")
 QUALITY_DIMENSIONS = ("pedagogical", "naturalness", "decolonization", "engagement", "tone")
-QUALITY_DIMENSION_SCORE_BANDS = {
-    "PASS": (Decimal("8.0"), Decimal("10.0"), True),
-    "REVISE": (Decimal("6.0"), Decimal("8.0"), False),
-    "BLOCK": (Decimal("0.0"), Decimal("6.0"), False),
-}
 REPRODUCIBILITY_FIELDS = (
     "schema_version",
     "review_protocol_version",
@@ -134,6 +129,63 @@ def read_yaml(path: Path) -> dict[str, Any]:
     return value
 
 
+def quality_dimension_score_bands(
+    policy: Mapping[str, Any],
+) -> dict[str, tuple[Decimal, Decimal, bool]]:
+    """Resolve the executable score bands from the versioned review policy."""
+    calibration = policy.get("score_calibration")
+    bands = calibration.get("bands") if isinstance(calibration, Mapping) else None
+    expected_statuses = {"PASS", "REVISE", "BLOCK"}
+    if not isinstance(bands, Mapping) or set(bands) != expected_statuses:
+        raise ReviewProtocolError(
+            "Track policy score_calibration.bands must define exactly PASS, REVISE, and BLOCK"
+        )
+
+    resolved: dict[str, tuple[Decimal, Decimal, bool]] = {}
+    for status in ("PASS", "REVISE", "BLOCK"):
+        band = bands[status]
+        if not isinstance(band, Mapping) or set(band) != {
+            "minimum",
+            "maximum",
+            "includes_maximum",
+        }:
+            raise ReviewProtocolError(
+                f"Track policy score band {status} must define minimum, maximum, and includes_maximum"
+            )
+        try:
+            minimum = Decimal(str(band["minimum"]))
+            maximum = Decimal(str(band["maximum"]))
+        except (InvalidOperation, ValueError) as exc:
+            raise ReviewProtocolError(f"Track policy score band {status} bounds must be numeric") from exc
+        includes_maximum = band["includes_maximum"]
+        if type(includes_maximum) is not bool:
+            raise ReviewProtocolError(
+                f"Track policy score band {status} includes_maximum must be boolean"
+            )
+        if minimum < Decimal(0) or maximum > Decimal(10) or minimum >= maximum:
+            raise ReviewProtocolError(
+                f"Track policy score band {status} must be an increasing subset of 0.0..10.0"
+            )
+        resolved[status] = (minimum, maximum, includes_maximum)
+
+    if (
+        resolved["BLOCK"][0] != Decimal(0)
+        or resolved["BLOCK"][1] != resolved["REVISE"][0]
+        or resolved["REVISE"][1] != resolved["PASS"][0]
+        or resolved["PASS"][1] != Decimal(10)
+        or resolved["BLOCK"][2]
+        or resolved["REVISE"][2]
+        or not resolved["PASS"][2]
+    ):
+        raise ReviewProtocolError(
+            "Track policy score bands must be contiguous half-open intervals with an inclusive PASS ceiling"
+        )
+    return resolved
+
+
+QUALITY_DIMENSION_SCORE_BANDS = quality_dimension_score_bands(read_yaml(POLICY_PATH))
+
+
 def load_track_policy(
     path: Path = POLICY_PATH,
     *,
@@ -145,6 +197,7 @@ def load_track_policy(
         "deterministic_contract_version",
         "semantic_prompt_version",
         "track_policy_version",
+        "score_calibration",
         "families",
         "selectors",
         "track_overrides",
@@ -152,6 +205,7 @@ def load_track_policy(
     missing = sorted(required - set(policy))
     if missing:
         raise ReviewProtocolError(f"Track policy missing: {', '.join(missing)}")
+    quality_dimension_score_bands(policy)
     if "tracks" in policy:
         raise ReviewProtocolError("Track policy must derive active tracks from curriculum.yaml")
     families = policy.get("families")

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -370,6 +370,28 @@ def test_score_calibration_fixture_validates_anchored_cases_and_comparability(
         assert (comparison["left"] == comparison["right"]) is comparison["expected"]
 
 
+@pytest.mark.parametrize("invalid_bound", ["8.0", True, float("nan"), float("inf")])
+def test_score_calibration_policy_rejects_non_numeric_or_non_finite_bounds(
+    invalid_bound: object,
+) -> None:
+    policy = pbr.load_track_policy()
+    policy["score_calibration"]["bands"]["PASS"]["minimum"] = invalid_bound
+
+    with pytest.raises(pbr.ReviewProtocolError, match="bounds must be"):
+        pbr.quality_dimension_score_bands(policy)
+
+
+def test_effective_prompt_names_the_closed_pass_band_without_half_open_claim(
+    bilash_packet: dict,
+) -> None:
+    prompt = bilash_packet["semantic_prompt"]
+
+    assert "`PASS` `[8.0, 10.0]`" in prompt
+    assert "`REVISE` `[6.0, 8.0)`" in prompt
+    assert "`BLOCK` `[0.0, 6.0)`" in prompt
+    assert "half-open bands" not in prompt
+
+
 @pytest.mark.parametrize(
     ("label", "mutate", "error_fragment"),
     [

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -21,6 +21,7 @@ BILASH_V1_GOLDEN = FIXTURES / "bio-oleksandr-bilash.result.v1.json"
 BILASH_V2_GOLDEN = FIXTURES / "bio-oleksandr-bilash.result.v2.json"
 REGRESSIONS = FIXTURES / "regressions.v1.yaml"
 CORE_EXEMPLAR = FIXTURES / "core-semantic-exemplar.v1.json"
+SCORE_CALIBRATION = FIXTURES / "score-calibration.v1.yaml"
 
 
 def _reviewer() -> dict[str, object]:
@@ -49,6 +50,8 @@ def _quality_dimensions(packet: dict | None = None) -> dict[str, dict[str, objec
     return {
         dimension: {
             "status": "PASS",
+            "score": 10.0,
+            "score_rationale": "No evidence-backed finding identifies a gap to 10.0.",
             "evidence": [{"location": location, "excerpt": excerpt}],
             "finding_ids": [],
         }
@@ -95,6 +98,30 @@ def _passing_semantic(packet: dict) -> dict:
         ],
         "findings": [],
     }
+
+
+def _claim_owned_finding_semantic(packet: dict) -> dict:
+    semantic = _passing_semantic(packet)
+    semantic["verdict"] = "REVISE"
+    semantic["findings"] = [
+        {
+            "id": "claim-only-language-finding",
+            "issue_id": "CLAIM_ONLY_LANGUAGE_FINDING",
+            "category": "language",
+            "severity": "high",
+            "message": "A claim-specific language defect requires revision.",
+            "evidence": "Synthetic claim-level evidence.",
+            "location": "tests/fixtures/post_build_review:1",
+        }
+    ]
+    semantic["claim_ledger"][0].update(
+        {
+            "status": "contradicted",
+            "finding_id": "claim-only-language-finding",
+        }
+    )
+    semantic["claim_coverage"]["claims_supported"] = 0
+    return semantic
 
 
 def _mechanical_high_deterministic() -> dict:
@@ -274,6 +301,8 @@ def test_quality_dimension_material_finding_preserves_stable_issue_id() -> None:
     semantic["quality_dimensions"]["naturalness"] = {
         **semantic["quality_dimensions"]["naturalness"],
         "status": "REVISE",
+        "score": 7.0,
+        "score_rationale": "The cited passive construction needs revision before it can reach 10.0.",
         "finding_ids": ["awkward-passive"],
     }
 
@@ -281,6 +310,311 @@ def test_quality_dimension_material_finding_preserves_stable_issue_id() -> None:
 
     assert normalized["quality_dimensions"]["naturalness"]["status"] == "REVISE"
     assert normalized["findings"][0]["issue_id"] == "AWKWARD_PASSIVE_RESULT_STATE"
+
+
+def test_score_calibration_fixture_validates_anchored_cases_and_comparability(
+    bilash_packet: dict,
+) -> None:
+    calibration = yaml.safe_load(SCORE_CALIBRATION.read_text(encoding="utf-8"))
+
+    assert calibration["fixture_version"] == "score-calibration.v1"
+    assert calibration["score_bands"] == {
+        **{
+            status: f"[{lower}, {upper}{']' if includes_upper else ')'}"
+            for status, (lower, upper, includes_upper) in pbr.QUALITY_DIMENSION_SCORE_BANDS.items()
+        },
+        "INCOMPLETE": None,
+    }
+    assert calibration["score_anchors"] == {
+        "10.0": "no dimension findings",
+        "[9.0, 10.0)": "quality target with bounded low-severity headroom",
+        "[8.0, 9.0)": "release-safe with a concrete low-severity improvement",
+        "[7.0, 8.0)": "focused material revision while most of the dimension remains strong",
+        "[6.0, 7.0)": "substantial material defect requiring broader revision",
+        "[4.0, 6.0)": "blocking defect with some usable evidence",
+        "[0.0, 4.0)": "fundamentally unusable, unsafe, or unsupported",
+    }
+    for case in calibration["cases"]:
+        semantic = _passing_semantic({"deterministic": {"evidence_requirements": []}})
+        dimension = case["dimension"]
+        semantic["verdict"] = case["verdict"]
+        semantic["quality_dimensions"][dimension].update(case["assessment"])
+        finding = case["finding"]
+        if finding is not None:
+            semantic["findings"] = [finding]
+            semantic["quality_dimensions"][dimension]["finding_ids"] = [finding["id"]]
+        normalized = pbr.normalize_semantic_result(semantic, "seminar", _reviewer())
+
+        assert case["expected"]["valid"] is True
+        if "minimum_dimension_score" in case["expected"]:
+            assert pbr.minimum_dimension_score(normalized["quality_dimensions"]) == case[
+                "expected"
+            ]["minimum_dimension_score"]
+        if "documented_semantic_cap" in case["expected"]:
+            assert normalized["quality_dimensions"][dimension]["score"] == case["expected"][
+                "documented_semantic_cap"
+            ]
+
+    current_result = pbr.finalize_review(
+        bilash_packet, _raw(_passing_semantic(bilash_packet))
+    )
+    current_identity = [
+        current_result["semantic_prompt_version"],
+        *(
+            current_result["reviewer"][key]
+            for key in ("family", "model", "effort")
+        ),
+    ]
+    assert calibration["comparability"][0]["left"] == current_identity
+    for comparison in calibration["comparability"]:
+        assert (comparison["left"] == comparison["right"]) is comparison["expected"]
+
+
+@pytest.mark.parametrize(
+    ("label", "mutate", "error_fragment"),
+    [
+        (
+            "status-score mismatch",
+            lambda semantic: (
+                semantic.update(
+                    {
+                        "findings": [
+                            {
+                                "id": "band-mismatch",
+                                "issue_id": "SCORE_BAND_MISMATCH",
+                                "category": "pedagogy",
+                                "severity": "medium",
+                                "message": "Synthetic band mismatch.",
+                                "evidence": "Synthetic evidence-backed finding.",
+                                "location": "tests/fixtures/post_build_review:1",
+                            }
+                        ]
+                    }
+                ),
+                semantic["quality_dimensions"]["pedagogical"].update(
+                    {"status": "REVISE", "score": 8.0, "finding_ids": ["band-mismatch"]}
+                ),
+            ),
+            "inconsistent with REVISE",
+        ),
+        (
+            "missing rationale",
+            lambda semantic: semantic["quality_dimensions"]["pedagogical"].pop("score_rationale"),
+            "fields are invalid",
+        ),
+        (
+            "out-of-range score",
+            lambda semantic: semantic["quality_dimensions"]["pedagogical"].update({"score": 10.1}),
+            "inclusive range",
+        ),
+        (
+            "excess precision",
+            lambda semantic: semantic["quality_dimensions"]["pedagogical"].update({"score": 8.01}),
+            "at most one decimal",
+        ),
+        (
+            "boolean score",
+            lambda semantic: semantic["quality_dimensions"]["pedagogical"].update({"score": True}),
+            "not a boolean or string",
+        ),
+        (
+            "perfect score with backlog",
+            lambda semantic: (
+                semantic.update(
+                    {
+                        "findings": [
+                            {
+                                "id": "perfect-score-backlog",
+                                "issue_id": "PERFECT_SCORE_BACKLOG",
+                                "category": "pedagogy",
+                                "severity": "low",
+                                "message": "A low-severity gap remains.",
+                                "evidence": "Synthetic evidence for the gap.",
+                                "location": "tests/fixtures/post_build_review:1",
+                            }
+                        ]
+                    }
+                ),
+                semantic["quality_dimensions"]["pedagogical"].update(
+                    {"finding_ids": ["perfect-score-backlog"]}
+                ),
+            ),
+            "score 10.0 requires no dimension findings",
+        ),
+        (
+            "orphan material finding",
+            lambda semantic: semantic.update(
+                {
+                    "findings": [
+                        {
+                            "id": "unowned-language-finding",
+                            "issue_id": "UNOWNED_LANGUAGE_FINDING",
+                            "category": "language",
+                            "severity": "high",
+                            "message": "A Russianism-class defect is present.",
+                            "evidence": "Synthetic evidence-backed language finding.",
+                            "location": "tests/fixtures/post_build_review:1",
+                        }
+                    ]
+                }
+            ),
+            "must be referenced by a quality dimension, claim, or learner-evidence entry",
+        ),
+    ],
+)
+def test_invalid_dimension_scores_fail_closed_without_repair(
+    bilash_packet: dict,
+    label: str,
+    mutate: object,
+    error_fragment: str,
+) -> None:
+    semantic = _passing_semantic(bilash_packet)
+    mutate(semantic)
+
+    result = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert label
+    assert result["semantic_response"]["contract_status"] == "invalid"
+    assert error_fragment in result["semantic_response"]["error"]
+    assert result["semantic"]["verdict"] == "INCOMPLETE"
+    assert result["minimum_dimension_score"] is None
+    assert all(
+        dimension["score"] is None and dimension["score_rationale"] is None
+        for dimension in result["semantic"]["quality_dimensions"].values()
+    )
+
+
+def test_minimum_dimension_score_is_reporting_only_not_a_disposition_input(
+    bilash_packet: dict,
+) -> None:
+    semantic = _passing_semantic(bilash_packet)
+    semantic["findings"] = [
+        {
+            "id": "reporting-only-low-gap",
+            "issue_id": "REPORTING_ONLY_LOW_GAP",
+            "category": "pedagogy",
+            "severity": "low",
+            "message": "A low-severity gap remains.",
+            "evidence": "Synthetic evidence-backed low gap.",
+            "location": "tests/fixtures/post_build_review:1",
+        }
+    ]
+    semantic["quality_dimensions"]["pedagogical"].update(
+        {
+            "score": 8.0,
+            "score_rationale": "The low-severity gap prevents a 10.0 pedagogical score.",
+            "finding_ids": ["reporting-only-low-gap"],
+        }
+    )
+
+    result = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert result["minimum_dimension_score"] == 8.0
+    assert result["combined_disposition"]["status"] == "PASS"
+
+
+def test_minimum_dimension_score_mismatch_fails_even_with_recomputed_key(
+    bilash_packet: dict,
+) -> None:
+    result = pbr.finalize_review(
+        bilash_packet, _raw(_passing_semantic(bilash_packet))
+    )
+    result["minimum_dimension_score"] = 9.9
+    reproducible = {
+        key: copy.deepcopy(result[key]) for key in pbr.REPRODUCIBILITY_FIELDS
+    }
+    result["reproducibility_key"] = pbr.sha256_text(
+        pbr._stable_json(reproducible)
+    )
+
+    with pytest.raises(pbr.ReviewProtocolError, match="minimum_dimension_score"):
+        pbr.validate_result(result)
+
+
+def test_claim_only_owned_finding_preserves_perfect_dimension_vector(
+    bilash_packet: dict,
+) -> None:
+    result = pbr.finalize_review(
+        bilash_packet, _raw(_claim_owned_finding_semantic(bilash_packet))
+    )
+
+    assert result["semantic_response"]["contract_status"] == "valid"
+    assert result["minimum_dimension_score"] == 10.0
+    assert result["combined_disposition"]["status"] == "REVISE"
+
+
+def test_learner_evidence_only_owned_finding_is_not_orphaned(
+    bilash_packet: dict,
+) -> None:
+    semantic = _passing_semantic(bilash_packet)
+    semantic["verdict"] = "INCOMPLETE"
+    semantic["findings"] = [
+        {
+            "id": "learner-evidence-only-finding",
+            "issue_id": "LEARNER_EVIDENCE_ONLY_FINDING",
+            "category": "media",
+            "severity": "high",
+            "message": "Required learner evidence could not be verified.",
+            "evidence": "Synthetic inaccessible learner evidence.",
+            "location": "tests/fixtures/post_build_review:1",
+        }
+    ]
+    semantic["learner_evidence_ledger"].append(
+        {
+            "id": "fixture-unverified-audio",
+            "location": "tests/fixtures/post_build_review:1",
+            "task": "Inspect the required audio evidence.",
+            "modality": "audio",
+            "source": "fixture://unverified-audio",
+            "access_status": "reviewer_unverified",
+            "verification_method": "The route could not inspect the audio bytes.",
+            "finding_id": "learner-evidence-only-finding",
+        }
+    )
+
+    result = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert result["semantic_response"]["contract_status"] == "valid"
+    assert result["minimum_dimension_score"] == 10.0
+    assert result["combined_disposition"]["status"] == "INCOMPLETE"
+
+
+def test_stored_v4_result_rejects_orphan_finding_with_recomputed_key(
+    bilash_packet: dict,
+) -> None:
+    result = pbr.finalize_review(
+        bilash_packet, _raw(_claim_owned_finding_semantic(bilash_packet))
+    )
+    result["semantic"]["claim_ledger"][0].update(
+        {"status": "supported", "finding_id": None}
+    )
+    result["semantic"]["claim_coverage"]["claims_supported"] = 1
+    reproducible = {
+        key: copy.deepcopy(result[key]) for key in pbr.REPRODUCIBILITY_FIELDS
+    }
+    result["reproducibility_key"] = pbr.sha256_text(
+        pbr._stable_json(reproducible)
+    )
+
+    with pytest.raises(pbr.ReviewProtocolError, match="must be referenced"):
+        pbr.validate_result(result)
+
+
+@pytest.mark.parametrize("field", ["dimension", "minimum"])
+def test_v4_schema_bounds_dimension_and_minimum_scores(
+    bilash_packet: dict,
+    field: str,
+) -> None:
+    result = pbr.finalize_review(
+        bilash_packet, _raw(_passing_semantic(bilash_packet))
+    )
+    if field == "dimension":
+        result["semantic"]["quality_dimensions"]["tone"]["score"] = 10.1
+    else:
+        result["minimum_dimension_score"] = 10.1
+
+    with pytest.raises(ValidationError):
+        pbr.validate_result(result)
 
 
 def test_quality_dimension_evidence_must_quote_the_resolved_target() -> None:
@@ -421,7 +755,7 @@ def test_deterministic_provenance_and_skips_are_explicit(bilash_packet: dict) ->
     assert deterministic["track_audit"]["provenance"]["config_version"] == "1"
     skips = {item["category"]: item["disposition"] for item in deterministic["skip_assessments"]}
     assert skips == {
-        "llm_qg": "capabilities_absorbed_by_semantic_v3",
+        "llm_qg": "capabilities_absorbed_by_semantic_v4",
         "mdx_generation_validate": "accepted_read_only_omission",
         "external_resource_liveness": "advisory_external",
     }
@@ -940,11 +1274,28 @@ def test_metadata_only_perceptual_evidence_cannot_be_downgraded_to_info() -> Non
         pbr.normalize_semantic_result(semantic, "seminar", {"capabilities": ["text"]})
 
 
-def test_schema_validates_golden_and_rejects_missing_versions() -> None:
+def test_schema_validates_historical_v1_v2_v3_and_rejects_missing_versions(
+    bilash_packet: dict,
+) -> None:
     historical = json.loads(BILASH_V1_GOLDEN.read_text(encoding="utf-8"))
     pbr.validate_result(historical)
     golden = json.loads(BILASH_V2_GOLDEN.read_text(encoding="utf-8"))
     pbr.validate_result(golden)
+    historical_v3 = pbr.finalize_review(bilash_packet, _raw(_passing_semantic(bilash_packet)))
+    historical_v3["schema_version"] = "post-build-review.result.v3"
+    historical_v3.pop("minimum_dimension_score")
+    for assessment in historical_v3["semantic"]["quality_dimensions"].values():
+        assessment.pop("score")
+        assessment.pop("score_rationale")
+    historical_reproducible = {
+        key: copy.deepcopy(historical_v3[key])
+        for key in pbr.V3_REPRODUCIBILITY_FIELDS
+    }
+    historical_v3["reproducibility_key"] = pbr.sha256_text(pbr._stable_json(historical_reproducible))
+    pbr.validate_result(historical_v3)
+    historical_v3["semantic"]["summary"] = "Tampered historical v3 result."
+    with pytest.raises(pbr.ReviewProtocolError, match="reproducibility key"):
+        pbr.validate_result(historical_v3)
     for field in (
         "review_protocol_version",
         "deterministic_contract_version",
@@ -966,13 +1317,14 @@ def test_current_bilash_result_is_reproducible(bilash_packet: dict) -> None:
     first = pbr.finalize_review(bilash_packet, response)
     second = pbr.finalize_review(bilash_packet, response)
 
-    assert first["schema_version"] == "post-build-review.result.v3"
+    assert first["schema_version"] == "post-build-review.result.v4"
     assert first["reproducibility_key"] == second["reproducibility_key"]
     assert first["combined_disposition"] == second["combined_disposition"]
     assert set(first["semantic"]["quality_dimensions"]) == set(pbr.QUALITY_DIMENSIONS)
+    assert first["minimum_dimension_score"] == 10.0
 
 
-def test_v3_result_rejects_reproducibility_key_tampering(bilash_packet: dict) -> None:
+def test_v4_result_rejects_reproducibility_key_tampering(bilash_packet: dict) -> None:
     result = pbr.finalize_review(bilash_packet, _raw(_passing_semantic(bilash_packet)))
     result["semantic"]["summary"] = "Tampered after canonical finalization."
 
@@ -980,7 +1332,7 @@ def test_v3_result_rejects_reproducibility_key_tampering(bilash_packet: dict) ->
         pbr.validate_result(result)
 
 
-def test_v3_result_revalidates_quality_dimension_consistency(bilash_packet: dict) -> None:
+def test_v4_result_revalidates_quality_dimension_consistency(bilash_packet: dict) -> None:
     result = pbr.finalize_review(bilash_packet, _raw(_passing_semantic(bilash_packet)))
     result["semantic"]["quality_dimensions"]["tone"]["evidence"] = []
     reproducible = {key: copy.deepcopy(result[key]) for key in pbr.REPRODUCIBILITY_FIELDS}
@@ -1067,8 +1419,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "3.0.0"
-    assert len(rows) == 31
+    assert catalog["catalog_version"] == "4.0.0"
+    assert len(rows) == 35
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -1089,6 +1441,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "2.0.0",
         "2.0.1",
         "3.0.0",
+        "4.0.0",
     }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -320,7 +320,7 @@ def test_score_calibration_fixture_validates_anchored_cases_and_comparability(
     assert calibration["fixture_version"] == "score-calibration.v1"
     assert calibration["score_bands"] == {
         **{
-            status: f"[{lower}, {upper}{']' if includes_upper else ')'}"
+            status: f"[{lower:.1f}, {upper:.1f}{']' if includes_upper else ')'}"
             for status, (lower, upper, includes_upper) in pbr.QUALITY_DIMENSION_SCORE_BANDS.items()
         },
         "INCOMPLETE": None,

--- a/tests/fixtures/post_build_review/core-semantic-exemplar.v1.json
+++ b/tests/fixtures/post_build_review/core-semantic-exemplar.v1.json
@@ -5,11 +5,11 @@
     "verdict": "PASS",
     "summary": "Core exemplar with non-factual beginner content and no material semantic findings.",
     "quality_dimensions": {
-      "pedagogical": {"status": "PASS", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []},
-      "naturalness": {"status": "PASS", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []},
-      "decolonization": {"status": "PASS", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []},
-      "engagement": {"status": "PASS", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []},
-      "tone": {"status": "PASS", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []}
+      "pedagogical": {"status": "PASS", "score": 10.0, "score_rationale": "No finding identifies a pedagogical gap to 10.0.", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []},
+      "naturalness": {"status": "PASS", "score": 10.0, "score_rationale": "No finding identifies a naturalness gap to 10.0.", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []},
+      "decolonization": {"status": "PASS", "score": 10.0, "score_rationale": "No finding identifies a decolonization gap to 10.0.", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []},
+      "engagement": {"status": "PASS", "score": 10.0, "score_rationale": "No finding identifies an engagement gap to 10.0.", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []},
+      "tone": {"status": "PASS", "score": 10.0, "score_rationale": "No finding identifies a tone gap to 10.0.", "evidence": [{"location": "fixture.md:1", "excerpt": "Вітаю! Як справи?"}], "finding_ids": []}
     },
     "claim_coverage": {
       "status": "not_applicable",

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 3.0.0
+catalog_version: 4.0.0
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -179,3 +179,27 @@ regressions:
     version_field: review_protocol_version
     input: A schema-valid result is edited after finalization without updating its reproducibility evidence.
     expected: Canonical validation rejects the result before track completion can record it.
+  - bug_id: dimension-score-was-repaired-or-misaligned
+    responsible_layer: schema
+    fixed_in_version: 4.0.0
+    version_field: review_protocol_version
+    input: A score is boolean, missing its rationale, outside 0.0..10.0, has excess precision, or conflicts with its categorical band.
+    expected: Preserve the raw response, reject it without repair, and emit the structured INCOMPLETE semantic outcome.
+  - bug_id: diagnostic-score-affected-disposition
+    responsible_layer: disposition
+    fixed_in_version: 4.0.0
+    version_field: review_protocol_version
+    input: A valid low within-band score accompanies otherwise categorical semantic and deterministic evidence.
+    expected: The result exposes only minimum_dimension_score for reporting; combine_disposition remains categorical and deterministic.
+  - bug_id: hard-language-or-fabrication-score-cap-was-evaded
+    responsible_layer: semantic_prompt
+    fixed_in_version: 4.0.0
+    version_field: semantic_prompt_version
+    input: A Russianism, calque, or fabrication-class finding is linked to a quality dimension.
+    expected: The anchored reviewer contract caps that dimension at 6.0; calibration fixtures retain this semantic rule until a stable hard-class field exists.
+  - bug_id: perfect-score-vector-concealed-an-orphan-finding
+    responsible_layer: orchestration
+    fixed_in_version: 4.0.0
+    version_field: review_protocol_version
+    input: A semantic finding is emitted without a quality-dimension, claim-ledger, or learner-evidence-ledger reference while every dimension claims 10.0.
+    expected: Reject the orphan finding and emit structured INCOMPLETE; a finding must have one explicit dimension or ledger owner.

--- a/tests/fixtures/post_build_review/score-calibration.v1.yaml
+++ b/tests/fixtures/post_build_review/score-calibration.v1.yaml
@@ -1,0 +1,233 @@
+fixture_version: score-calibration.v1
+score_bands:
+  PASS: "[8.0, 10.0]"
+  REVISE: "[6.0, 8.0)"
+  BLOCK: "[0.0, 6.0)"
+  INCOMPLETE: null
+score_anchors:
+  "10.0": no dimension findings
+  "[9.0, 10.0)": quality target with bounded low-severity headroom
+  "[8.0, 9.0)": release-safe with a concrete low-severity improvement
+  "[7.0, 8.0)": focused material revision while most of the dimension remains strong
+  "[6.0, 7.0)": substantial material defect requiring broader revision
+  "[4.0, 6.0)": blocking defect with some usable evidence
+  "[0.0, 4.0)": fundamentally unusable, unsafe, or unsupported
+cases:
+  - id: pass-lower-bound-backed-backlog
+    dimension: pedagogical
+    verdict: PASS
+    assessment:
+      status: PASS
+      score: 8.0
+      score_rationale: A low-severity pedagogical finding leaves a concrete gap to 10.0.
+    finding:
+      id: low-pedagogy-gap
+      issue_id: PEDAGOGICAL_CLARITY_GAP
+      category: pedagogy
+      severity: low
+      message: One instruction could clarify its next learner action.
+      evidence: The task omits an explicit next action.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      minimum_dimension_score: 8.0
+  - id: pass-quality-target-boundary
+    dimension: engagement
+    verdict: PASS
+    assessment:
+      status: PASS
+      score: 9.0
+      score_rationale: A bounded low-severity progression gap prevents a 10.0 engagement score.
+    finding:
+      id: low-progression-gap
+      issue_id: ENGAGEMENT_PROGRESSION_HEADROOM
+      category: engagement
+      severity: low
+      message: One optional extension could add a further progression step.
+      evidence: The activity is complete but offers no optional transfer step.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      minimum_dimension_score: 9.0
+  - id: pass-upper-bound-perfect-no-findings
+    dimension: naturalness
+    verdict: PASS
+    assessment:
+      status: PASS
+      score: 10.0
+      score_rationale: No naturalness finding identifies a gap to 10.0.
+    finding: null
+    expected:
+      valid: true
+      minimum_dimension_score: 10.0
+  - id: revise-lower-bound
+    dimension: engagement
+    verdict: REVISE
+    assessment:
+      status: REVISE
+      score: 6.0
+      score_rationale: The cited activity defect leaves substantial engagement work before 10.0.
+    finding:
+      id: engagement-revision
+      issue_id: ENGAGEMENT_ACTIVITY_GAP
+      category: engagement
+      severity: medium
+      message: The activity does not give the learner a meaningful choice.
+      evidence: The task repeats the same response format without progression.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      minimum_dimension_score: 6.0
+  - id: revise-upper-bound
+    dimension: tone
+    verdict: REVISE
+    assessment:
+      status: REVISE
+      score: 7.9
+      score_rationale: A medium tone finding leaves a narrow but concrete gap to 10.0.
+    finding:
+      id: tone-revision
+      issue_id: TONE_REGISTER_GAP
+      category: tone
+      severity: medium
+      message: One directive is unnecessarily abrupt.
+      evidence: The imperative lacks the surrounding supportive context.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      minimum_dimension_score: 7.9
+  - id: revise-focused-anchor
+    dimension: naturalness
+    verdict: REVISE
+    assessment:
+      status: REVISE
+      score: 7.0
+      score_rationale: One focused medium-severity phrasing defect prevents a 10.0 naturalness score.
+    finding:
+      id: focused-naturalness-revision
+      issue_id: NATURALNESS_FOCUSED_REVISION
+      category: naturalness
+      severity: medium
+      message: One repeated construction is unnatural but locally repairable.
+      evidence: The same marked construction recurs in one bounded passage.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      minimum_dimension_score: 7.0
+  - id: block-upper-bound
+    dimension: decolonization
+    verdict: BLOCK
+    assessment:
+      status: BLOCK
+      score: 5.9
+      score_rationale: The blocker leaves a material decolonization gap to 10.0.
+    finding:
+      id: decolonization-block
+      issue_id: IMPERIAL_FRAMING
+      category: decolonization
+      severity: blocker
+      message: The module repeats an imperial framing.
+      evidence: The cited sentence denies Ukrainian agency.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      minimum_dimension_score: 5.9
+  - id: block-partially-usable-anchor
+    dimension: decolonization
+    verdict: BLOCK
+    assessment:
+      status: BLOCK
+      score: 4.0
+      score_rationale: A blocker prevents release, although other evidence preserves partial value above 0.0.
+    finding:
+      id: blocking-agency-erasure
+      issue_id: DECOLONIZATION_AGENCY_ERASURE
+      category: decolonization
+      severity: blocker
+      message: A central passage erases Ukrainian agency.
+      evidence: The cited framing assigns all historical agency to the imperial center.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      minimum_dimension_score: 4.0
+  - id: block-lower-bound
+    dimension: tone
+    verdict: BLOCK
+    assessment:
+      status: BLOCK
+      score: 0.0
+      score_rationale: The blocker leaves no demonstrated tone quality to credit above the floor.
+    finding:
+      id: tone-floor-block
+      issue_id: TONE_SAFETY_BLOCKER
+      category: tone
+      severity: blocker
+      message: The learner-facing tone is unsafe.
+      evidence: The cited wording is hostile to the learner.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      minimum_dimension_score: 0.0
+  - id: incomplete-null
+    dimension: pedagogical
+    verdict: INCOMPLETE
+    assessment:
+      status: INCOMPLETE
+      score: null
+      score_rationale: null
+    finding:
+      id: pedagogy-unverified
+      issue_id: PEDAGOGY_EVIDENCE_UNAVAILABLE
+      category: pedagogy
+      severity: high
+      message: Required learner evidence could not be inspected.
+      evidence: The required interactive object was unavailable to the reviewer.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      minimum_dimension_score: null
+  - id: hard-language-cap
+    dimension: naturalness
+    verdict: REVISE
+    assessment:
+      status: REVISE
+      score: 6.0
+      score_rationale: The Russianism-class finding caps this dimension at 6.0.
+    finding:
+      id: russianism-calque
+      issue_id: UKRAINIAN_GRAMMAR_CALQUE
+      category: language
+      severity: high
+      message: The phrase is a documented Russian calque.
+      evidence: Project Ukrainian source verification identifies the calque.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      documented_semantic_cap: 6.0
+  - id: hard-fabrication-cap
+    dimension: pedagogical
+    verdict: REVISE
+    assessment:
+      status: REVISE
+      score: 6.0
+      score_rationale: The fabrication-class finding caps this dimension at 6.0.
+    finding:
+      id: fabricated-teaching-fact
+      issue_id: FABRICATED_TEACHING_FACT
+      category: factuality
+      severity: high
+      message: The module teaches a fabricated factual claim.
+      evidence: The cited authoritative source contradicts the claim.
+      location: tests/fixtures/post_build_review:1
+    expected:
+      valid: true
+      documented_semantic_cap: 6.0
+comparability:
+  - id: identical-review-identity-is-comparable
+    left: [4.0.0, fixture, fixture-model, high]
+    right: [4.0.0, fixture, fixture-model, high]
+    expected: true
+  - id: prompt-or-reviewer-identity-drift-is-not-comparable
+    left: [4.0.0, fixture, fixture-model, high]
+    right: [4.0.0, google, gemini-3.1-pro, high]
+    expected: false

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -238,10 +238,10 @@ def _result(
             }
         )
     return {
-        "review_protocol_version": "3.0.0",
+        "review_protocol_version": "4.0.0",
         "deterministic_contract_version": "1.2.1",
-        "semantic_prompt_version": "3.0.0",
-        "track_policy_version": "1.5.0",
+        "semantic_prompt_version": "4.0.0",
+        "track_policy_version": "1.6.0",
         "prompt_sha256": "1" * 64,
         "reproducibility_key": "2" * 64,
         "target": {
@@ -285,7 +285,7 @@ def _certification_artifact(
     }
     if kind == "post-build":
         value["pbr"] = {
-            "adapter": "post-build-review.v3",
+            "adapter": "post-build-review.v4",
             "verdict": "PASS",
             "raw_response_sha256": "a" * 64,
             "workflow_hashes": inputs["workflow_hashes"],


### PR DESCRIPTION
## Summary

- add canonical post-build-review packet/result v4 with evidence-backed `0.0–10.0` diagnostic scores and rationales for all five quality dimensions
- retain categorical semantic plus deterministic evidence as the only fail-closed release gate; expose only a reporting-only minimum and no average
- add strict Decimal/range/precision/band validation, perfect-score/backlog constraints, historical v1–v3 validation, calibration anchors/fixtures, and lifecycle adapter identity v4
- clarify the accepted diagnostic-score boundary in track completion, ADR-012, and the lifecycle parity documentation

## Verification

- `195 passed` across post-build review, track completion, certification evidence, curriculum readiness, and deploy idempotency
- `npm run agents:deploy`
- `bash scripts/check_rules_deployment.sh`
- `.venv/bin/python scripts/audit/check_adrs.py --quiet`
- Ruff, schema/YAML parse, `git diff --check`, forbidden-path audit, `.python-version` check, and X-Agent trailer audit
- independent design review: Claude Opus `REVISE`; all material safeguards incorporated before implementation
- independent implementation review: Claude Opus `PASS` on exact commit `8d1b1d922b`; no unresolved material findings

## Acceptance exemplar

BIO-371 (`bio/andrii-malyshko`) will receive a fresh v4 review after this reusable gate merges. Its already-merged learner content is not changed or duplicated by this PR.

Part of #5294
