### PR TITLE
fix(lifecycle): record workflow-only review drift

### DIFF
--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -45,6 +45,10 @@ review as an operator completion gate.
    gitignored runtime state shared across worktrees. A live per-module lease
    rejects concurrent operators. Use `resume --run-id <id>` after interruption;
    never mint a replacement run merely to bypass a lease or stale evidence.
+   If a versioned review-tooling change lands while the exact run is already in
+   `POST_BUILD_REVIEW_REQUIRED`, record it with `record-change --owner-kind
+   audit_tooling`; that transition is accepted only when every target hash is
+   unchanged and the workflow identity actually changed.
    A legacy ledger without a goal is non-authoritative. Use
    `migrate-terminal-goal` with the exact old run id and explicit intent; a
    `PBR_PASS_QG_PENDING` migration must also name its exact PR and 40-character

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -47,8 +47,9 @@ review as an operator completion gate.
    never mint a replacement run merely to bypass a lease or stale evidence.
    If a versioned review-tooling change lands while the exact run is already in
    `POST_BUILD_REVIEW_REQUIRED`, record it with `record-change --owner-kind
-   audit_tooling`; that transition is accepted only when every target hash is
-   unchanged and the workflow identity actually changed.
+   audit_tooling`; that transition is accepted only when the module state,
+   layout, and every target hash are unchanged and the workflow identity
+   actually changed.
    A legacy ledger without a goal is non-authoritative. Use
    `migrate-terminal-goal` with the exact old run id and explicit intent; a
    `PBR_PASS_QG_PENDING` migration must also name its exact PR and 40-character

--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -919,10 +919,23 @@ def record_change(
                 "PUBLISH_REQUIRED",
                 "INTEGRATION_REQUIRED",
             }
-            if ledger["state"] not in allowed_states:
+            pending_review_workflow_refresh = (
+                ledger["state"] == "POST_BUILD_REVIEW_REQUIRED"
+                and owner_kind == "audit_tooling"
+            )
+            if ledger["state"] not in allowed_states and not pending_review_workflow_refresh:
                 raise CompletionError(f"A repair change is not allowed from {ledger['state']}")
             if identity["sha256"] == ledger["current_identity"]["sha256"]:
                 raise CompletionError("No target or workflow identity changed; refusing a no-op repair")
+            if pending_review_workflow_refresh:
+                if identity["target_hashes"] != ledger["current_identity"]["target_hashes"]:
+                    raise CompletionError(
+                        "A pending post-build review accepts audit_tooling refresh only when target hashes are unchanged"
+                    )
+                if identity["workflow_hashes"] == ledger["current_identity"]["workflow_hashes"]:
+                    raise CompletionError(
+                        "A pending post-build review audit_tooling refresh requires workflow identity drift"
+                    )
             if ledger["state"] == "PLAN_REPAIR_REQUIRED" and owner_kind != "plan_workflow":
                 raise CompletionError("Plan-repair state only accepts plan_workflow changes")
             if ledger["state"] == "REVIEWER_INSTABILITY" and owner_kind != "audit_tooling":

--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -928,6 +928,13 @@ def record_change(
             if identity["sha256"] == ledger["current_identity"]["sha256"]:
                 raise CompletionError("No target or workflow identity changed; refusing a no-op repair")
             if pending_review_workflow_refresh:
+                if (
+                    identity["layout"] != ledger["current_identity"]["layout"]
+                    or identity["module_state"] != ledger["current_identity"]["module_state"]
+                ):
+                    raise CompletionError(
+                        "A pending post-build review accepts audit_tooling refresh only when module layout and state are unchanged"
+                    )
                 if identity["target_hashes"] != ledger["current_identity"]["target_hashes"]:
                     raise CompletionError(
                         "A pending post-build review accepts audit_tooling refresh only when target hashes are unchanged"

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -1041,6 +1041,51 @@ def test_legacy_qg_sidecar_cannot_advance_completion(fake_repo: tuple[Path, Path
     assert "llm_qg" not in snapshot.observed_files
 
 
+def test_pending_review_accepts_only_workflow_only_audit_tooling_refresh(
+    fake_repo: tuple[Path, Path, Path],
+) -> None:
+    repo, config_path, ledger_root = fake_repo
+    _, ledger = _start(fake_repo, "bio/seminar-built")
+    run_id = ledger["run"]["run_id"]
+    original_target_hashes = ledger["current_identity"]["target_hashes"]
+
+    workflow = repo / "workflow.txt"
+    workflow.write_text("workflow-v2\n", encoding="utf-8")
+    _, refreshed = tc.record_change(
+        "bio/seminar-built",
+        run_id=run_id,
+        owner_kind="audit_tooling",
+        author_family="codex",
+        summary="Integrated a new post-build review protocol before its pending review.",
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+
+    assert refreshed["state"] == "POST_BUILD_REVIEW_REQUIRED"
+    assert refreshed["current_identity"]["target_hashes"] == original_target_hashes
+    assert refreshed["current_identity"]["workflow_hashes"] != ledger["current_identity"][
+        "workflow_hashes"
+    ]
+    assert refreshed["history"][-1]["details"]["owner_kind"] == "audit_tooling"
+
+    content = repo / "curriculum/l2-uk-en/bio/seminar-built/module.md"
+    content.write_text(content.read_text(encoding="utf-8") + "Незаписана зміна.\n", encoding="utf-8")
+    workflow.write_text("workflow-v3\n", encoding="utf-8")
+
+    with pytest.raises(tc.CompletionError, match="target hashes are unchanged"):
+        tc.record_change(
+            "bio/seminar-built",
+            run_id=run_id,
+            owner_kind="audit_tooling",
+            author_family="codex",
+            summary="Must not disguise learner-surface drift as review tooling.",
+            repo_root=repo,
+            config_path=config_path,
+            ledger_root=ledger_root,
+        )
+
+
 def test_historical_post_build_result_cannot_advance_current_ledger() -> None:
     historical = ROOT / "tests" / "fixtures" / "post_build_review" / "bio-oleksandr-bilash.result.v2.json"
 

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -1042,7 +1042,7 @@ def test_legacy_qg_sidecar_cannot_advance_completion(fake_repo: tuple[Path, Path
 
 
 def test_pending_review_accepts_only_workflow_only_audit_tooling_refresh(
-    fake_repo: tuple[Path, Path, Path],
+    fake_repo: tuple[Path, Path, Path], monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo, config_path, ledger_root = fake_repo
     _, ledger = _start(fake_repo, "bio/seminar-built")
@@ -1080,6 +1080,28 @@ def test_pending_review_accepts_only_workflow_only_audit_tooling_refresh(
             owner_kind="audit_tooling",
             author_family="codex",
             summary="Must not disguise learner-surface drift as review tooling.",
+            repo_root=repo,
+            config_path=config_path,
+            ledger_root=ledger_root,
+        )
+
+    real_build_identity = tc.build_identity
+
+    def relocated_identity(*args: object, **kwargs: object) -> dict[str, Any]:
+        identity = real_build_identity(*args, **kwargs)
+        identity["layout"] = "flat"
+        payload = {key: identity[key] for key in ("module_state", "layout", "target_hashes", "workflow_hashes")}
+        identity["sha256"] = tc.sha256_bytes(tc.stable_json(payload).encode("utf-8"))
+        return identity
+
+    monkeypatch.setattr(tc, "build_identity", relocated_identity)
+    with pytest.raises(tc.CompletionError, match="module layout and state are unchanged"):
+        tc.record_change(
+            "bio/seminar-built",
+            run_id=run_id,
+            owner_kind="audit_tooling",
+            author_family="codex",
+            summary="Must not disguise a layout migration as review tooling.",
             repo_root=repo,
             config_path=config_path,
             ledger_root=ledger_root,


### PR DESCRIPTION
## Summary

- let an active `POST_BUILD_REVIEW_REQUIRED` ledger record an integrated `audit_tooling` workflow refresh
- require every target hash to remain identical and require actual workflow identity drift
- preserve the fresh canonical review gate and reject learner-artifact drift disguised as tooling

## Verification

- `.venv/bin/python -m pytest tests/test_track_completion.py -q` (18 passed)
- `.venv/bin/ruff check agents_extensions/shared/skills/track-completion/scripts/track_completion.py tests/test_track_completion.py`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Part of #5294.