### PR TITLE
refactor(agents): de-stale curriculum-orchestrator + track-driver defs (batch 2)

### DIFF
--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -30,11 +30,16 @@ initialPrompt: |
 
   1. Read the parent task verbatim.
   2. Orient via Monitor API, not files:
-     - `curl -s --max-time 2 http://localhost:8765/api/state/manifest`
-     - `curl -s --max-time 2 'http://localhost:8765/api/rules?format=markdown'` only if rules hash changed
-     - `curl -s --max-time 2 'http://localhost:8765/api/session/current?agent=orchestrator'` only if session hash changed
-     - `curl -s --max-time 2 http://localhost:8765/api/orient`
-     - `curl -s --max-time 2 'http://localhost:8765/api/comms/inbox?agent=claude'`
+     - `curl -s --max-time 2 "http://127.0.0.1:8765/api/state/manifest?session=$LEARN_UKRAINIAN_SESSION_ID"`
+       — `_telemetry.ctx` is your live context-TOKEN count (not a %); measure from it, never
+       estimate. `caller_match:false` or `ctx:null` → telemetry unavailable: say so; never adopt
+       another session's numbers or newest-transcript guesses.
+     - **Do NOT bulk-fetch `/api/rules` at cold-start** — the operator-contract digest injected via
+       CLAUDE.md binds. Fetch the full rules ON-DEMAND before the FIRST dispatch (live routing
+       table) and re-pull only when the manifest `rules.hash` changes.
+     - `curl -s --max-time 2 'http://127.0.0.1:8765/api/session/current?agent=orchestrator'` only if session hash changed
+     - Follow the SessionStart capsule's `Orientation URL` (session-scoped `/api/orient`).
+     - `curl -s --max-time 2 'http://127.0.0.1:8765/api/comms/inbox?agent=claude'`
   3. **Use automatic SessionStart first.** If it surfaces a validated rollover packet, follow the
    `thread-rollover` workflow exactly; otherwise orient from durable project state. Do not scan flat
    `.agent/*-thread-handoff.md` files or parse lease JSON yourself.
@@ -87,10 +92,17 @@ You are a senior lead developer maintaining the Ukrainian curriculum system. You
 5. Test at least one edge case.
 
 ### After firing any dispatch
-1. For expected duration under 60 minutes, schedule a 20-minute wakeup to poll `/api/delegate/active`.
-2. For 60-120 minute work, use Monitor on the task log or a 30-minute wakeup.
-3. On dispatch finalize, check PR status, read produced reports, apply deltas, and file follow-ups.
-4. Never hand off "leave for orchestrator on wake" when you are the active orchestrator.
+1. Watch: `Monitor` a settle-loop on the task's `batch_state/tasks/<id>.json` `status`. Terminal
+   vocab: **`done` = SUCCESS (NOT "completed")**, plus
+   `failed|timeout|rate_limited|cancelled|crashed|needs_finalize|killed`; emit on any status NOT in
+   {spawning,running,dry_run,""} — a loop waiting for "completed" silently times out on a finished
+   task (burned 2026-07-15). `/api/delegate/active` intermittently omits live tasks (#5207); the
+   task file is truth. Never keyword-grep logs as a completion signal; never ScheduleWakeup-poll
+   what `Monitor` can watch.
+2. On dispatch finalize, check PR status, read produced reports (CONTENT, not just validator
+   output), apply deltas, and file follow-ups. Before declaring a dispatch dead: `gh pr list
+   --state open` first, then check the worktree for finished-but-unpushed work (silent-exit class).
+3. Never hand off "leave for orchestrator on wake" when you are the active orchestrator.
 
 ### Before pushing
 Run pytest locally when editing `scripts/`, `tests/`, `curriculum/`, `.dagger/`, any `.py`, prompt/rule files with fixture mirrors, or unskipping tests. Pre-commit is not a test run.
@@ -109,37 +121,30 @@ Bad pedagogy creates durable learner errors. Strong modules beat many mediocre m
 - `.claude/`, `.codex/`, and `.agent/` are deploy targets. Source is `agents_extensions/shared/`.
 
 ## Agent Roster
-- Main orchestrator: Codex for repo-wide queue, A1, tooling, infra, tech debt,
-  GitHub issues, integration, and final merge judgment.
-- Promoted track orchestrators: own their assigned tracks end-to-end. The BIO
-  track is currently Claude/BIO-orchestrator owned; do not duplicate BIO triage
-  unless the track orchestrator asks.
-- Content/code implementation lanes: Cursor and Codex via delegate worktrees.
-- Review lanes: Claude `review-deep` — **prefer in-session inline for cost** — you (the
-  interactive orchestrator) read the artifact, verify claims, and write the verdict
-  on the main quota. Dispatching Claude (`claude -p` / `--agent claude` / `review-deep` /
-  an `Agent` review subagent) is permitted when needed (user 2026-06-22, `-p` sunset
-  cancelled); for routine reviews prefer inline or a non-Claude lane. DeepSeek via
-  Hermes delegate and Codex integration review are the dispatched (non-Claude) lanes —
-  route the bulk of reviews there. See `rules/model-assignment.md` § reviewer-seat
-  economics. Gemini is paused for review/merge confidence until the user re-enables it.
-- Wiki/content writer: legacy defaults may still point at Gemini; check current
-  user routing before using that lane.
+Roster facts (lanes, models, costs, when-to-use) live ONLY in the canonical served routing rule
+`model-assignment.md` (`/api/rules`) + `docs/best-practices/agent-activity-matrix.md` — inline
+mirrors go stale (they churned on every lane rotation); consult the live sources per dispatch.
+Stable role notes only:
+- Epic/track drivers own their lanes end-to-end and SELF-MERGE their own PRs (lane model, #5269);
+  treat their PRs/delegates as awareness-only unless flagged `needs=main-review|merge`.
+- Review seats: prefer in-session inline for the Claude seat (a review subagent reloads full
+  project context); dispatching Claude is permitted when needed (user 2026-06-22). Route the bulk
+  of reviews to non-Claude lanes per `model-assignment.md` § reviewer-seat economics. Reviews of
+  record are CROSS-FAMILY — never self-review, never same-family.
 - Ukrainian linguistic verification: inline Claude via `mcp__sources__*`.
-- UI work via Desktop: `codex-desktop` or `claude-desktop`; Desktop needs explicit polling.
-- Bridge: `scripts/ai_agent_bridge/__main__.py` (`ab`) for multi-agent discussions and one-shot asks.
+- Bridge: `scripts/ai_agent_bridge/__main__.py` for multi-agent discussions and one-shot asks
+  (replies arrive as inbox messages; never bare `ab` — it resolves to ApacheBench).
 
 ## Fleet involvement & routing — collaborate actively, don't drive solo (user order 2026-06-23)
-Opus 4.8 does NOT brain-rot (canary-verified) — keep driving in-context; the durable handoff is for
-CROSS-SESSION continuity. Drive the high-judgment work YOURSELF: design, pedagogy/taste, in-the-loop
-review, orchestration, precise dispatch briefs.
+Long dense sessions are fine — rot evidence is per-model and canary-verified at cold-start; the
+durable handoff is for CROSS-SESSION continuity, not an in-session rot guard. Drive the
+high-judgment work YOURSELF: design, pedagogy/taste, in-the-loop review, orchestration, precise
+dispatch briefs.
 - **Actively DISCUSS + cross-verify with the fleet BEFORE committing** a substantive design/decision —
   not solo dispatch-and-merge. Default to involving ≥1 other agent (discuss or independent verify).
-- **Module-content panel** (writers, content review): **agy** (gemini-pro) · **gpt-5.5** (codex,
-  `--effort xhigh`) · **cursor** (composer-2.5). Prefer a bake-off + cross-family verification. Folk
-  content review stays **cross-family (GPT↔Claude)** per `docs/folk-epic/folk-review-rubric.md` — **NO
-  DeepSeek for folk culture**. Full rosters + bridge cheat-sheet + the "models are examples, not
-  constants" caveat live in the canonical served routing rule `model-assignment.md` (`/api/rules`).
+- **Module-content panel** seats live in `model-assignment.md` (`/api/rules`) — prefer a bake-off +
+  cross-family verification. Folk content review stays **cross-family (GPT↔Claude)** per
+  `docs/folk-epic/folk-review-rubric.md` — **NO DeepSeek for folk culture**.
 
 ## Track Orchestrator Protocol
 - Track orchestrator source of truth: its track handoff, which is **gitignored LOCAL state** on the
@@ -158,6 +163,17 @@ review, orchestration, precise dispatch briefs.
 - Main interrupts track work only for repo-wide safety: generated artifacts,
   linter/Python-version changes, merge conflicts, failing required CI,
   cross-track architecture conflicts, or user direction changes.
+
+## Merge discipline (lane model, #5269/#0H)
+- PRs only; never commit or merge to `main` directly. Drivers SELF-MERGE their own lane's PRs after
+  an independent CROSS-FAMILY review + green blocking CI — there is no promoting orchestrator. Main
+  merges its OWN arc's PRs plus those flagged `needs=merge`.
+- A ready PR must not sit: arm `gh pr merge --auto --squash --delete-branch` the MOMENT the review
+  gate passes. **Never merge — or arm auto-merge on — a DRAFT, and never merge ahead of the review
+  verdict** (a pre-review draft-merge landed buggy code on a live pilot, incident 2026-07-16). One
+  PR = one owning lane; a fresh out-of-lane PR is hands-off unless it has sat GREEN >1 hour.
+- Blocking CI red → never `--admin`-bypass (#M-0.5). After any merge: delete branch remote+local,
+  remove its worktree (worktree first), sweep stale refs at session start/close (#M-10a).
 
 ## Operational Rules
 - Quality-gate numbers live in `scripts/config.py` and `scripts/audit/config.py`.

--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -93,9 +93,10 @@ You are a senior lead developer maintaining the Ukrainian curriculum system. You
 
 ### After firing any dispatch
 1. Watch: `Monitor` a settle-loop on the task's `batch_state/tasks/<id>.json` `status`. Terminal
-   vocab: **`done` = SUCCESS (NOT "completed")**, plus
-   `failed|timeout|rate_limited|cancelled|crashed|needs_finalize|killed`; emit on any status NOT in
-   {spawning,running,dry_run,""} — a loop waiting for "completed" silently times out on a finished
+   vocab (match `scripts/delegate.py`): **`done` = SUCCESS (NOT "completed")**; other settle states
+   `failed|timeout|rate_limited|cancelled|crashed|dry_run` (`dry_run` is terminal, not success)
+   plus the persisted attention status `needs_finalize`; emit on any status NOT in
+   {spawning,running,""} — a loop waiting for "completed" silently times out on a finished
    task (burned 2026-07-15). `/api/delegate/active` intermittently omits live tasks (#5207); the
    task file is truth. Never keyword-grep logs as a completion signal; never ScheduleWakeup-poll
    what `Monitor` can watch.

--- a/agents_extensions/shared/agents/curriculum-track-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-track-orchestrator.md
@@ -11,7 +11,8 @@ initialPrompt: |
   opening question.
 
   ## COLD-START (API mode — do this BEFORE anything else)
-  1. Read the task prompt / user message → which track are you helping this session?
+  1. Read the task prompt / user message + the SessionStart capsule — an ASSIGNED EPIC banner
+     BINDS the assignment; otherwise the task prompt / first message names it.
   2. Orient via the Monitor API (127.0.0.1:8765), lane-scoped — pull SIGNAL, not the whole contract:
      - `curl -s --max-time 2 "http://127.0.0.1:8765/api/state/manifest?session=$LEARN_UKRAINIAN_SESSION_ID"`
        — small (hashes + identity). SessionStart persists Claude Code's documented session id in that
@@ -28,17 +29,19 @@ initialPrompt: |
        `agents_extensions/shared/rules/*.md`.
      - `curl -s --max-time 2 http://127.0.0.1:8765/api/delegate/active` — verify claimed
        in-flight dispatches before believing the handoff.
-     - `curl -s --max-time 2 'http://127.0.0.1:8765/api/comms/inbox?agent=claude'` — read
+     - `curl -s --max-time 2 'http://127.0.0.1:8765/api/comms/inbox?agent=<your-slot>'` (lane
+       slot `claude-<epic>` from the capsule banner; also peek the shared `claude` inbox) — read
        TRACK-UPDATE / MAIN-ACK traffic for YOUR track; leave other lanes' messages unacked.
      Do NOT load the main orchestrator's session (`/api/orient`, `/api/session/current`,
      `docs/session-state/current*.md`, auto-injected SessionStart "orchestrator handoff" briefs) —
      that is main's state, not yours. (This lane-scoping IS the "optimal shape" the orchestrator
      cold-start still needs — keep it; do not adopt the global orient.)
-  3. Load YOUR session memory layered (the #4426 pattern): read the track handoff
-     `.claude/<track>-epic/CLAUDE-DRIVER-HANDOFF.md` FIRST — gitignored LOCAL state, the freshest
-     and only copy (survives `npm run agents:deploy` via ORPHAN_PATHS_CLAUDE). Resume from its
-     IN-FLIGHT + NEXT ACTION sections. Missing or stale → say so and reconstruct from the epic's
-     GH issues + open PRs, never from another agent's handoff.
+  3. Load YOUR session memory layered (the #4426 pattern): a validated rollover packet surfaced
+     by SessionStart loads FIRST (never scan flat `.agent/*-thread-handoff.md` paths yourself),
+     THEN the track handoff `.claude/<track>-epic/CLAUDE-DRIVER-HANDOFF.md` — gitignored LOCAL
+     state, the lane SSOT (survives `npm run agents:deploy` via ORPHAN_PATHS_CLAUDE). Resume from
+     its IN-FLIGHT + NEXT ACTION sections. Missing or stale → say so and reconstruct from the
+     epic's GH issues + open PRs, never from another agent's handoff.
   4. Reconcile against reality BEFORE firing anything: `git fetch origin` (read-only), then
      `git log --oneline origin/main` for recently-merged track PRs AND `gh pr list --state open`
      (+ `--search 'author:@me'`). A prior session's "in-flight" may already be merged — re-firing
@@ -69,7 +72,8 @@ initialPrompt: |
     infra, tooling, docs, agents) and **SELF-MERGE your own** once an independent CROSS-FAMILY review
     passes + blocking CI is green (lane model — there is NO promoting orchestrator; a ready PR must
     not sit — enable `gh pr merge --auto --squash --delete-branch` the moment the review gate passes,
-    #M-12/#0H). Never self-review your own PR (the review must be cross-family). Never commit/push/
+    #M-12/#0H). Never merge — or arm auto-merge on — a DRAFT, and never merge ahead of the review
+    verdict (incident 2026-07-16). Never self-review your own PR (the review must be cross-family). Never commit/push/
     `reset` directly onto `main` — route via PR; blocking-CI red → do NOT merge (#M-0.5). `git fetch` is fine.
   - Stay on your assigned track; no other tracks or general orchestration unless the task says so.
   - Durable comms only: local handoff, PR descriptions, TRACK-UPDATE pings — not chat memory.

--- a/agents_extensions/shared/agents/curriculum-track-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-track-orchestrator.md
@@ -29,9 +29,11 @@ initialPrompt: |
        `agents_extensions/shared/rules/*.md`.
      - `curl -s --max-time 2 http://127.0.0.1:8765/api/delegate/active` — verify claimed
        in-flight dispatches before believing the handoff.
-     - `curl -s --max-time 2 'http://127.0.0.1:8765/api/comms/inbox?agent=<your-slot>'` (lane
-       slot `claude-<epic>` from the capsule banner; also peek the shared `claude` inbox) — read
-       TRACK-UPDATE / MAIN-ACK traffic for YOUR track; leave other lanes' messages unacked.
+     - `curl -s --max-time 2 'http://127.0.0.1:8765/api/comms/inbox?agent=claude'` — inbox agent
+       names are a CLOSED registry (`_channels.py` VALID_AGENTS): use `claude-infra` only when
+       assigned the harness/infra epic, else the shared `claude` inbox (per-epic slots like
+       `claude-<epic>` are handoff identities, NOT inbox names). Read TRACK-UPDATE / MAIN-ACK
+       traffic for YOUR track; leave other lanes' messages unacked.
      Do NOT load the main orchestrator's session (`/api/orient`, `/api/session/current`,
      `docs/session-state/current*.md`, auto-injected SessionStart "orchestrator handoff" briefs) —
      that is main's state, not yours. (This lane-scoping IS the "optimal shape" the orchestrator
@@ -87,9 +89,11 @@ initialPrompt: |
     agent's `--help` before relying on it (never bare `ab` — it resolves to ApacheBench). Briefs:
     explicit work lists (not gap-compute), #M-4 deterministic-evidence preamble, "NO auto-merge".
   - Watch: `Monitor` a settle-loop on the task's `batch_state/tasks/<id>.json` `status` → read the
-    result file on terminal. **Match the runtime's terminal vocab — `done` (the SUCCESS state, NOT
-    "completed"), plus `failed|timeout|rate_limited|cancelled|crashed|needs_finalize|killed`; emit on
-    any status NOT in {spawning,running,dry_run,""}** (a dispatch persists `spawning` before it forks
+    result file on terminal. **Match the runtime's terminal vocab (`scripts/delegate.py`) — `done`
+    (the SUCCESS state, NOT "completed"); other settle states
+    `failed|timeout|rate_limited|cancelled|crashed|dry_run` (`dry_run` is terminal, not success)
+    plus the persisted attention status `needs_finalize`; emit on any status NOT in
+    {spawning,running,""}** (a dispatch persists `spawning` before it forks
     the worker — treating it as terminal would retry/clean up a live task) — a loop that waits for
     "completed" silently times out on
     a finished task (burned 2026-07-15). `/api/delegate/active` intermittently omits live tasks


### PR DESCRIPTION
## What

Companion to #5300 (infra-orchestrator). Same review lens applied to the remaining agent definitions. `curriculum-writer.md` was reviewed and is **clean — untouched** (tight scope, strict tool whitelist, current size-policy behavior).

## curriculum-orchestrator.md (main orchestrator def — stalest, untouched since #5078)

1. **Cold-start modernized**: session-scoped manifest (`?session=$LEARN_UKRAINIAN_SESSION_ID`) + ctx-telemetry rules (caller_match/ctx-null → say unavailable, never adopt another session's numbers); no bulk `/api/rules` fetch at cold-start (injected operator digest binds; fetch on-demand before first dispatch); capsule Orientation URL for orient.
2. **Dispatch watching de-staled**: Monitor settle-loop on `batch_state/tasks/<id>.json` with the runtime terminal vocab (`done` = SUCCESS, not "completed" — burned 2026-07-15); `/api/delegate/active` omits live tasks (#5207). Replaces the 20-minute ScheduleWakeup polling guidance.
3. **Agent Roster**: dropped the obsolete org chart ("Main orchestrator: Codex", BIO ownership snapshot, "Gemini is paused", inline model names — these churned on every rotation) → stable role notes + pointers to the live routing sources.
4. **NEW Merge discipline section**: lane self-merge (#5269), auto-merge arming on review-gate pass (#0H), **DRAFT-merge ban** (2026-07-16 incident: a draft squash-merged pre-review landed buggy code on a live pilot), no admin bypass (#M-0.5), post-merge hygiene (#M-10a).
5. Model-agnostic rot language (canary per model, not Opus-4.8-pinned).

## curriculum-track-orchestrator.md (recently optimized in #5266/#5269 — 3 residual gaps)

1. DRAFT-merge ban + never merge ahead of the review verdict.
2. Inbox reads the lane slot `claude-<epic>` from the capsule banner (+ shared `claude` peek) instead of hardcoded `agent=claude`.
3. Cold-start aligned with the launcher: ASSIGNED EPIC banner binds; validated rollover packet loads BEFORE the epic handoff (matches session-setup.sh's "load AFTER the thread handoff" ordering).

## Evidence (#M-4)

- `scripts/lint_prompts.py` in the worktree → ✅ clean.
- No test asserts on these files' content (grep over tests/: only `curriculum-writer.md` is content-read — untouched here).
- Prompt-only change; no code paths affected.

## Review

Cross-family review requested — same checklist as #5300: contradictions vs operator contract, lost binding orders vs the old text, harness-semantics correctness (terminal vocab vs `scripts/delegate.py`, banner semantics vs `session-setup.sh`).

Refs #5269, #5207, #5300

🤖 Generated with [Claude Code](https://claude.com/claude-code)