### PR TITLE
feat(orchestration): add fleet rollover registry

### DIFF
--- a/agents_extensions/shared/contracts/rollover-registry.md
+++ b/agents_extensions/shared/contracts/rollover-registry.md
@@ -1,0 +1,114 @@
+# Fleet Rollover Registry Contract
+
+The canonical registry is a durable projection of `task-identity.v1`. It does
+not create a second task identity and never uses a title as an identifier.
+
+## Identity and storage
+
+Each record is keyed exactly by `(agent, lineage_id, rollover_id)` and lives at:
+
+```text
+.agent/thread-rollover-registry/v1/<agent>/<lineage-id>/<rollover-id>/record.json
+```
+
+The embedded `task_identity` must validate against
+`agents_extensions/shared/schemas/task-identity.v1.schema.json`. The registry
+key, predecessor/replacement IDs, generation, repository, issue, epic, and
+human-readable title must agree with that envelope. Provider-specific deploy
+copies are generated from `agents_extensions/shared/`; they are not separate
+authorities.
+
+All mutations for one lineage use the same blocking lineage lock. Retrying the
+same operation is idempotent. A different replacement ID for an already-bound
+packet is a conflict, never a second successor.
+
+## Lifecycle
+
+Successful boundaries are ordered:
+
+```text
+PREPARED → AWAITING_NATIVE_CREATE → REPLACEMENT_CREATED → RESUMED
+→ STRICT_RECALL_PASSED → CANARY_PASSED → CONFIRMED
+→ PREDECESSOR_ARCHIVED → HEARTBEAT_RETIRED
+```
+
+`BLOCKED` preserves the last successful boundary. `SUPERSEDED` and
+`ABANDONED_WITH_PROOF` are terminal dispositions. A mutation may not skip a
+successful prerequisite. Confirmed, superseded, abandoned, archived, and
+heartbeat-retired records are excluded from live-pending detection.
+
+## Detection and audit
+
+Exact selectors are ANDed when more than one is supplied:
+
+- `--source-thread-id`
+- `--replacement-thread-id`
+- `--lineage-id`
+- `--rollover-id`
+
+One exact unique match may proceed even while unrelated packets are pending. A
+generic lookup with multiple live matches is read-only and returns every
+candidate's title, issue/epic, exact IDs, state, age, last successful boundary,
+and next safe action. Any corrupt durable source also makes generic detection
+non-mutating. It never chooses by recency, title, or filesystem order.
+
+`audit` classifies every valid or corrupt entry as one of:
+
+- active and resumable;
+- awaiting native action;
+- confirmed but incompletely cleaned;
+- confirmed and fully cleaned;
+- superseded;
+- stale and requiring operator adjudication;
+- inconsistent or corrupt.
+
+Age can produce the stale classification but cannot delete, abandon, or
+supersede continuity state.
+
+## Authoritative reconciliation
+
+`reconcile-exact` consumes an operator-captured JSON snapshot bound to the exact
+registry key. The snapshot contains:
+
+- `source`: exact predecessor ID, archive state, and archive receipt path;
+- `replacement`: existence, exact replacement ID, and native title;
+- `title_receipt`: the exact replacement task ID plus adapter support and exact
+  readback receipt, or an honest unsupported-adapter fallback receipt;
+- `confirmation`: exact replacement ID and durable confirmation proof;
+- `heartbeat`: exact automation ID, cleanup authorization, retirement state,
+  and retirement receipt;
+- `captured_at` and durable `evidence_paths`.
+
+Reconciliation never infers creation, archival, confirmation, or heartbeat
+retirement from a title, task absence, local process absence, or elapsed time.
+It is read-only unless `--apply` is supplied. Apply writes a deterministic
+receipt under the exact registry record and refuses inconsistent snapshots.
+
+## Maintenance
+
+The safe commands are `resume-exact`, `reconcile-exact`,
+`finish-cleanup-exact`, `supersede-exact`, and `abandon-exact`. Cleanup,
+supersession, and abandonment are two-step `--plan` / `--apply` operations.
+Apply validates the immutable plan's digest, action, and exact key before any
+mutation and writes an apply intent plus durable receipt.
+
+Supersession or abandonment proof must assert all of the following and include
+durable evidence paths:
+
+- the packet is not confirmed active;
+- no valid replacement owns the lineage;
+- no native create is unrecorded;
+- no active heartbeat depends on the packet;
+- the selected agent, lineage, and rollover IDs match throughout.
+
+Cleanup additionally requires the exact confirmed successor, exact predecessor
+archive proof, explicit heartbeat-retirement authorization, and exact heartbeat
+retirement proof. One lineage's proof never authorizes another lineage's
+cleanup.
+
+## Migration
+
+Migration scans versioned lease files and immutable task-family plans. Planning
+is read-only. Apply refuses corrupt inputs, preserves historical proof paths and
+receipts, appends a migration event, and writes a migration receipt. It never
+rewrites or deletes legacy history.

--- a/agents_extensions/shared/quick-ref/monitor-api.md
+++ b/agents_extensions/shared/quick-ref/monitor-api.md
@@ -22,6 +22,7 @@ curl -s http://localhost:8765/api/state/summary   # tracks overview (published_m
 ```bash
 curl -s http://localhost:8765/api/delegate/active
 curl -s http://localhost:8765/api/runtime/agents
+# Read-only fleet rollover audit: GET /api/rollovers
 ```
 
 **Start server:** `npm run api` (or `npm run api:bg`). Serves http://localhost:8765 + all dashboards.

--- a/agents_extensions/shared/schemas/rollover-registry.v1.schema.json
+++ b/agents_extensions/shared/schemas/rollover-registry.v1.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "rollover-registry.v1",
+  "title": "Fleet rollover registry record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "key",
+    "task_identity",
+    "title_transition",
+    "state",
+    "last_successful_boundary",
+    "native_creation",
+    "strict_recall",
+    "canary",
+    "confirmation",
+    "predecessor_archival",
+    "heartbeat",
+    "timestamps",
+    "lease_path",
+    "packet_paths",
+    "receipts",
+    "evidence_paths",
+    "terminal_reason",
+    "blocking_reason",
+    "last_reconciliation",
+    "history"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "key": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent", "lineage_id", "rollover_id"],
+      "properties": {
+        "agent": {"type": "string", "pattern": "^[a-z][a-z0-9-]*$"},
+        "lineage_id": {"type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$"},
+        "rollover_id": {"type": "string", "pattern": "^rollover-[a-z0-9]+(?:-[a-z0-9]+)*$"}
+      }
+    },
+    "task_identity": {"$ref": "task-identity.v1"},
+    "title_transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "harness",
+        "native_title_supported",
+        "native_readback_supported",
+        "state",
+        "visible_title",
+        "replacement_task_id",
+        "binding_receipt",
+        "mutation_receipt",
+        "readback_receipt",
+        "fallback_receipt",
+        "events"
+      ],
+      "properties": {
+        "schema_version": {"const": "rollover-title-transition.v1"},
+        "harness": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+        "native_title_supported": {"type": "boolean"},
+        "native_readback_supported": {"type": "boolean"},
+        "state": {
+          "enum": [
+            "awaiting_replacement_binding",
+            "awaiting_native_title",
+            "fallback_recorded",
+            "title_acknowledged",
+            "title_mutation_failed",
+            "title_reconciled",
+            "title_readback_failed"
+          ]
+        },
+        "visible_title": {"type": "string", "minLength": 1, "maxLength": 60},
+        "replacement_task_id": {"type": ["string", "null"]},
+        "binding_receipt": {"type": ["object", "null"]},
+        "mutation_receipt": {"type": ["object", "null"]},
+        "readback_receipt": {"type": ["object", "null"]},
+        "fallback_receipt": {"type": ["object", "null"]},
+        "events": {"type": "array", "items": {"type": "object"}}
+      }
+    },
+    "state": {"$ref": "#/$defs/state"},
+    "last_successful_boundary": {"$ref": "#/$defs/success_state"},
+    "native_creation": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["state", "family_id", "operation_id"],
+      "properties": {
+        "state": {"type": "string", "minLength": 1},
+        "family_id": {"type": ["string", "null"]},
+        "operation_id": {"type": ["string", "null"]}
+      }
+    },
+    "strict_recall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "score", "verdict_path"],
+      "properties": {
+        "state": {"enum": ["pending", "passed", "failed"]},
+        "score": {"type": ["integer", "number", "null"]},
+        "verdict_path": {"type": ["string", "null"]}
+      }
+    },
+    "canary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "proof_path"],
+      "properties": {
+        "state": {"enum": ["pending", "passed", "failed"]},
+        "proof_path": {"type": ["string", "null"]}
+      }
+    },
+    "confirmation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "confirmed_at", "confirmed_by"],
+      "properties": {
+        "state": {"enum": ["pending", "confirmed"]},
+        "confirmed_at": {"type": ["string", "null"]},
+        "confirmed_by": {"type": ["string", "null"]}
+      }
+    },
+    "predecessor_archival": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["state"],
+      "properties": {"state": {"enum": ["pending", "authorized", "archived", "blocked"]}}
+    },
+    "heartbeat": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["automation_id", "state", "cleanup_authorized"],
+      "properties": {
+        "automation_id": {"type": ["string", "null"]},
+        "state": {"type": "string", "minLength": 1},
+        "cleanup_authorized": {"type": "boolean"}
+      }
+    },
+    "timestamps": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["prepared_at", "updated_at"],
+      "properties": {
+        "prepared_at": {"type": "string", "format": "date-time"},
+        "updated_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "lease_path": {"type": ["string", "null"]},
+    "packet_paths": {"type": "object", "additionalProperties": {"type": ["string", "null"]}},
+    "receipts": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "evidence_paths": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "terminal_reason": {"type": ["string", "null"]},
+    "blocking_reason": {"type": ["string", "null"]},
+    "last_reconciliation": {"type": ["object", "null"]},
+    "history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["state", "at", "reason", "evidence_paths"],
+        "properties": {
+          "state": {"$ref": "#/$defs/state"},
+          "at": {"type": "string", "format": "date-time"},
+          "reason": {"type": "string", "minLength": 1},
+          "evidence_paths": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "success_state": {
+      "enum": [
+        "PREPARED",
+        "AWAITING_NATIVE_CREATE",
+        "REPLACEMENT_CREATED",
+        "RESUMED",
+        "STRICT_RECALL_PASSED",
+        "CANARY_PASSED",
+        "CONFIRMED",
+        "PREDECESSOR_ARCHIVED",
+        "HEARTBEAT_RETIRED"
+      ]
+    },
+    "state": {
+      "enum": [
+        "PREPARED",
+        "AWAITING_NATIVE_CREATE",
+        "REPLACEMENT_CREATED",
+        "RESUMED",
+        "STRICT_RECALL_PASSED",
+        "CANARY_PASSED",
+        "CONFIRMED",
+        "PREDECESSOR_ARCHIVED",
+        "HEARTBEAT_RETIRED",
+        "SUPERSEDED",
+        "ABANDONED_WITH_PROOF",
+        "BLOCKED"
+      ]
+    }
+  }
+}

--- a/agents_extensions/shared/skills/thread-rollover/SKILL.md
+++ b/agents_extensions/shared/skills/thread-rollover/SKILL.md
@@ -30,6 +30,29 @@ For a known packet, inspect health without changing it.
 .venv/bin/python scripts/orchestration/thread_handoff.py check --agent codex --lineage-id <lineage-id>
 ```
 
+When more than one unrelated packet is pending, generic detection stays
+read-only and returns actionable candidates. Select the intended packet by
+exact ID; selectors are ANDed and titles never select a packet.
+
+```bash
+.venv/bin/python scripts/orchestration/rollover_registry_cli.py detect \
+  --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id>
+.venv/bin/python scripts/orchestration/rollover_registry_cli.py detect \
+  --agent codex --source-thread-id <predecessor-task-id>
+```
+
+Audit all agents without mutation:
+
+```bash
+.venv/bin/python scripts/orchestration/rollover_registry_cli.py audit
+```
+
+Use `reconcile-exact --snapshot <authoritative-json>` before acting on an
+unrecorded native successor or confusing cleanup state. Reconciliation requires
+exact native IDs, title/readback receipts, confirmation proof, and automation
+facts; a title or missing local process is never proof of creation or cleanup.
+It is read-only unless `--apply` is explicit.
+
 ## Rollover
 
 Prepare only from the active task; this reserves every packet path and keeps
@@ -213,3 +236,11 @@ archive candidates.
 This archive step does not replace or weaken the existing automation cleanup
 gate. Delete or pause an old heartbeat only after `confirm-started` reports
 `old_automation_ready_to_delete: true`.
+
+For stale or duplicate-looking packets, never delete the lease. Use the exact
+registry maintenance commands. `finish-cleanup-exact`, `supersede-exact`, and
+`abandon-exact` require immutable proof and separate `--plan` then `--apply`
+invocations. Apply validates the selected agent/lineage/rollover, plan digest,
+and action before mutation and writes a durable receipt. Age alone can warn but
+cannot authorize a disposition. The complete proof contract is
+`agents_extensions/shared/contracts/rollover-registry.md`.

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1593,18 +1593,46 @@ Payload allowlist is exactly `{task_id, research_id, surface, status}` on top of
 emitter envelope — never a digest body, title, summary, source URL, prompt, role,
 task family, track, owned paths, or context fingerprint.
 
+## Rollover Registry — `/api/rollovers`
+
+### `GET /api/rollovers`
+
+Read-only fleet audit of versioned rollover records. The response classifies
+valid and corrupt packets, reports live-pending counts, and includes exact IDs,
+human-readable task titles, age, last successful boundary, reconciliation
+state, blocking or terminal reason, and the next safe action. HTTP never
+exposes a mutation path.
+
+Optional query parameters are `agent`, `source_thread_id`,
+`replacement_thread_id`, `lineage_id`, `rollover_id`, and `stale_hours`.
+Supplying any exact selector switches to one-record projection mode. Multiple
+selectors are ANDed; no match returns `404`, and an ambiguous match returns
+`409` with candidates instead of selecting one.
+
+```bash
+curl -s "${MONITOR_API_BASE}/api/rollovers" | jq .
+curl -s "${MONITOR_API_BASE}/api/rollovers?agent=codex&lineage_id=<lineage-id>&rollover_id=<rollover-id>" | jq .
+```
+
+The `rollovers` section in `/api/orient` is the compact cold-start projection:
+counts plus live pending or confirmed-but-incompletely-cleaned entries. Use this
+endpoint for complete evidence and registry validation errors. Use
+`scripts/orchestration/rollover_registry_cli.py` for evidence-gated exact
+reconciliation or maintenance.
+
 ## Orientation — `/api/orient`
 
 ### `GET /api/orient`
 
-One-call agent orientation: git, issues, pipeline, runtime, delegate, wiki, health, and session hints.
+One-call agent orientation: git, issues, pipeline, runtime, delegate, rollovers,
+wiki, health, and session hints.
 
 Query params:
 
 - `fresh=true` — invalidate orient-layer caches before gathering (see below).
 - `sections=git,runtime` — comma-separated subset of section keys to
   collect. Valid keys: `git`, `issues`, `pipeline`, `runtime`,
-  `delegate`, `bridge_pending`, `wiki`, `governance`, `health`,
+  `delegate`, `bridge_pending`, `rollovers`, `wiki`, `governance`, `health`,
   `session_hints`. Unknown keys return `400`. Omitted = full payload
   (back-compat). Skipped sections are not collected and are omitted
   from both the top-level payload and `meta`.
@@ -1650,6 +1678,7 @@ failure retries on the next call.
 | `pipeline` | 0 | `fs` | wraps `/api/state/summary`, which carries its **own** 60 s cache. Caching again at the orient layer would stack windows and label up-to-119 s-old data as fresh (#1309 reviewer BLOCKER B2). |
 | `runtime` | 60 | `fs` | agent registry + headroom + recent outcomes |
 | `delegate` | 30 | `fs` | active delegate/codex tasks |
+| `rollovers` | 15 | `fs` | compact fleet rollover counts plus actionable pending or incompletely cleaned entries |
 | `wiki` | 120 | `fs` | per-track wiki compilation coverage |
 | `health` | 15 | `probe` | API/DB/MCP port + file readability |
 | `session_hints` | 60 | `fs` | recent `docs/session-state/*.md` entries |

--- a/docs/best-practices/codex-thread-handoff.md
+++ b/docs/best-practices/codex-thread-handoff.md
@@ -51,6 +51,9 @@ prompt, and a Task Family Manager transition operation:
   (gitignored)
 - Native transition plan, binding, events, and receipts:
   `.agent/task-families/<family-id>/operations/<operation-id>/` (gitignored)
+- Fleet registry projection:
+  `.agent/thread-rollover-registry/v1/<agent>/<lineage-id>/<rollover-id>/record.json`
+  (gitignored)
 - Durable Codex orchestrator handoff:
   `docs/session-state/codex-orchestrator-handoff.md`
 - Codex role handoff pointer:
@@ -344,6 +347,54 @@ Dry-run without writing files:
 ```bash
 .venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent codex --dry-run
 ```
+
+### Fleet audit, exact selection, and maintenance
+
+Several unrelated agents and lineages may legitimately have pending packets at
+the same time. Generic registry detection is therefore fail-closed for mutation
+and returns structured candidates; any corrupt durable source also keeps
+generic detection non-mutating. It never chooses by title, age, or directory
+order. A unique exact selector can proceed while unrelated packets remain
+untouched:
+
+```bash
+.venv/bin/python scripts/orchestration/rollover_registry_cli.py audit
+.venv/bin/python scripts/orchestration/rollover_registry_cli.py detect \
+  --agent codex --source-thread-id <predecessor-task-id>
+.venv/bin/python scripts/orchestration/rollover_registry_cli.py detect \
+  --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id>
+```
+
+For an unrecorded native successor or disputed cleanup state, capture an
+authoritative app/automation snapshot and compare it without mutation:
+
+```bash
+.venv/bin/python scripts/orchestration/rollover_registry_cli.py reconcile-exact \
+  --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+  --snapshot <native-snapshot.json>
+```
+
+Only a consistent result may be repeated with `--apply`. The snapshot binds the
+exact predecessor, replacement, title readback or honest unsupported fallback,
+confirmation proof, archive receipt, automation ID, cleanup authorization, and
+retirement receipt. A title, task absence, local process absence, or stale age
+does not prove a native action.
+
+Cleanup, supersession, and abandonment use immutable evidence-gated plans:
+
+```bash
+.venv/bin/python scripts/orchestration/rollover_registry_cli.py supersede-exact \
+  --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+  --plan --proof-file <proof.json>
+.venv/bin/python scripts/orchestration/rollover_registry_cli.py supersede-exact \
+  --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> \
+  --apply --plan-file <plan.json>
+```
+
+`finish-cleanup-exact` and `abandon-exact` follow the same plan/apply shape.
+Never bulk-delete old leases. See
+`agents_extensions/shared/contracts/rollover-registry.md` for required proof
+assertions and lifecycle boundaries.
 
 ### Superseded native-intent recovery
 

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -78,6 +78,8 @@ from .preload import preload_all
 from .rag_router import router as rag_router
 from .resilience import get_resilience_snapshot, resilience_middleware
 from .reviewer_ghosts_router import router as reviewer_ghosts_router
+from .rollover_router import collect_rollover_orient_data
+from .rollover_router import router as rollover_router
 from .route_contracts import router as contracts_router
 from .rules_router import router as rules_router
 from .runtime_router import router as runtime_router
@@ -170,6 +172,7 @@ app.include_router(
     prefix="/api/state/reviewer-ghosts",
     tags=["reviewer-ghosts"],
 )
+app.include_router(rollover_router, prefix="/api/rollovers", tags=["rollovers"])
 app.include_router(rules_router, prefix="/api/rules", tags=["rules"])
 app.include_router(runtime_router, prefix="/api/runtime")
 app.include_router(session_router, prefix="/api/session", tags=["session"])
@@ -226,6 +229,7 @@ ORIENT_SECTION_TTLS: dict[str, float] = {
     "runtime": 60.0,
     "delegate": 30.0,
     "bridge_pending": 15.0,
+    "rollovers": 15.0,
     "wiki": 120.0,
     "governance": 120.0,
     "health": 15.0,
@@ -239,6 +243,7 @@ ORIENT_SECTION_SOURCES: dict[str, str] = {
     "runtime": "fs",
     "delegate": "fs",
     "bridge_pending": "sqlite",
+    "rollovers": "fs",
     "wiki": "fs",
     "governance": "fs",
     "health": "probe",
@@ -260,6 +265,7 @@ LEAN_ORIENT_SECTIONS: tuple[str, ...] = (
     "runtime",
     "delegate",
     "bridge_pending",
+    "rollovers",
     "governance",
     "health",
     "session_hints",
@@ -514,6 +520,10 @@ def _collect_bridge_pending_orient_data() -> dict:
     from scripts.ai_agent_bridge import _channels  # noqa: PLC0415 — optional broker bridge
 
     return _channels.bridge_pending_summary()
+
+
+def _collect_rollovers_orient_data() -> dict:
+    return collect_rollover_orient_data()
 
 
 def _collect_wiki_orient_data() -> dict:
@@ -797,6 +807,11 @@ def _orient_section_specs() -> dict[str, tuple[Callable[..., Any], Any, bool]]:
         "runtime": (_collect_runtime_orient_data, {}, False),
         "delegate": (_collect_delegate_orient_data, {"active_count": 0, "recent": []}, False),
         "bridge_pending": (_collect_bridge_pending_orient_data, {}, False),
+        "rollovers": (
+            _collect_rollovers_orient_data,
+            {"counts": {}, "actionable": [], "errors": []},
+            False,
+        ),
         "wiki": (_collect_wiki_orient_data, {"by_track": {}}, False),
         "governance": (
             _collect_governance_orient_data,
@@ -822,7 +837,7 @@ async def orient(
     lean: bool = Query(
         False,
         description="Lean cold-start preset: return only the lightweight sections "
-        "(git, runtime, delegate, bridge_pending, governance, health, session_hints), "
+        "(git, runtime, delegate, bridge_pending, rollovers, governance, health, session_hints), "
         "skipping the heavy pipeline/issues/wiki. Ignored when 'sections' is given.",
     ),
     sections: str | None = Query(
@@ -900,6 +915,8 @@ async def orient(
         response["delegate"] = section_data["delegate"]
     if "bridge_pending" in section_data:
         response["bridge_pending"] = section_data["bridge_pending"]
+    if "rollovers" in section_data:
+        response["rollovers"] = section_data["rollovers"]
     if "wiki" in section_data:
         response["wiki"] = section_data["wiki"]
     if "governance" in section_data:

--- a/scripts/api/rollover_router.py
+++ b/scripts/api/rollover_router.py
@@ -1,0 +1,118 @@
+"""Read-only fleet rollover registry and reconciliation API."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from fastapi import APIRouter, HTTPException, Query
+
+from scripts.orchestration import thread_handoff
+from scripts.orchestration.task_family import rollover_registry as registry
+
+from .config import LIVE_REPO_ROOT
+
+router = APIRouter(tags=["rollovers"])
+
+
+def collect_rollover_orient_data() -> dict:
+    """Compact cold-start projection; full evidence remains on this router."""
+    audit = registry.audit_fleet(LIVE_REPO_ROOT)
+    identity_snapshot = thread_handoff.rollover_identity_snapshot(LIVE_REPO_ROOT)
+    actionable = [
+        entry
+        for entry in audit["entries"]
+        if entry["live_pending"] or entry["classification"] == "confirmed but incompletely cleaned"
+    ]
+    return {
+        "schema_version": "rollover-orient.v1",
+        "generated_at": audit["generated_at"],
+        "counts": audit["counts"],
+        "actionable": actionable,
+        "errors": audit["errors"],
+        "task_identity": {
+            "schema_version": identity_snapshot["schema_version"],
+            "candidate_count": identity_snapshot["candidate_count"],
+            "errors": identity_snapshot["errors"],
+        },
+    }
+
+
+@router.get("")
+def rollover_audit(
+    agent: str | None = Query(None),
+    source_thread_id: str | None = Query(None),
+    replacement_thread_id: str | None = Query(None),
+    lineage_id: str | None = Query(None),
+    rollover_id: str | None = Query(None),
+    stale_hours: float = Query(registry.DEFAULT_STALE_HOURS, gt=0),
+) -> dict:
+    """Classify the fleet or return one exact read-only selector projection."""
+    selectors = {
+        "source_thread_id": source_thread_id,
+        "replacement_thread_id": replacement_thread_id,
+        "lineage_id": lineage_id,
+        "rollover_id": rollover_id,
+    }
+    if any(selectors.values()):
+        records, errors = registry.scan_records(LIVE_REPO_ROOT)
+        try:
+            selected = registry.select_exact(records, agent=agent, **selectors)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if not selected:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": "exact rollover selector matched no registry entry", "registry_errors": errors},
+            )
+        if len(selected) > 1:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "exact rollover selector remains ambiguous",
+                    "matches": [registry.candidate_summary(record) for record in selected],
+                    "registry_errors": errors,
+                },
+            )
+        record = selected[0]
+        selected_errors = registry.record_source_errors(LIVE_REPO_ROOT, record, errors)
+        if selected_errors:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "exact rollover selector matched a corrupt durable source",
+                    "candidate": registry.candidate_summary(record),
+                    "registry_errors": selected_errors,
+                },
+            )
+        return {
+            "schema_version": registry.REGISTRY_SCHEMA_VERSION,
+            "mutation_allowed": False,
+            "entry": registry.candidate_summary(record),
+            "classification": registry.classify(
+                record,
+                now=registry.utc_now(),
+                stale_after=timedelta(hours=stale_hours),
+            ).value,
+            "reconciliation": record.get("last_reconciliation"),
+            "receipts": record.get("receipts", []),
+            "evidence_paths": record.get("evidence_paths", []),
+            "blocking_reason": record.get("blocking_reason"),
+            "terminal_reason": record.get("terminal_reason"),
+            "registry_errors": errors,
+        }
+    audit = registry.audit_fleet(LIVE_REPO_ROOT, stale_hours=stale_hours)
+    if agent is not None:
+        try:
+            agent = registry.normalize_agent(agent)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        audit["entries"] = [entry for entry in audit["entries"] if entry["agent"] == agent]
+        audit["counts"] = {
+            "total": len(audit["entries"]),
+            "live_pending": sum(entry["live_pending"] for entry in audit["entries"]),
+            "corrupt": sum(
+                entry["classification"] == registry.AuditClassification.INCONSISTENT_CORRUPT.value
+                for entry in audit["entries"]
+            ),
+        }
+    return audit

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -460,12 +460,22 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
     RouteContract(
         "/api/orient", "exact", "http",
         "One-shot agent and dashboard orientation snapshot.",
-        "Git, GitHub issues, pipeline state, runtime files, delegate state, broker, wiki, governance, health, and session hints.",
+        "Git, GitHub issues, pipeline state, runtime files, delegate state, broker, rollover registry, wiki, governance, health, and session hints.",
         "Per-section TTLs in main.py; ?fresh=true invalidates orient cache entries.",
         ("orient.html", "index.html", "agents"),
         "Aggregates many other API sections.",
         "low/medium when upstream collectors degrade",
         "keep cold-start source of truth",
+    ),
+    RouteContract(
+        "/api/rollovers", "exact", "http",
+        "Read-only fleet rollover audit and exact selector projection.",
+        "Versioned registry records under .agent/thread-rollover-registry/v1/.",
+        "Generated per request; no mutation path is exposed over HTTP.",
+        ("agents", "monitor client", "orchestrators"),
+        "Compact actionable entries are also exposed through /api/orient.",
+        "low — corrupt records are isolated and returned as explicit errors",
+        "keep as the canonical rollover observability surface",
     ),
     RouteContract(
         "/api/knowledge", "prefix", "http",

--- a/scripts/orchestration/rollover_registry_cli.py
+++ b/scripts/orchestration/rollover_registry_cli.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Fleet rollover registry, exact selection, reconciliation, and maintenance CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.orchestration import thread_handoff
+from scripts.orchestration.task_family import rollover_registry as registry
+from scripts.orchestration.task_family.storage import advisory_lock
+
+
+def _roots(repo_root: Path | None) -> tuple[Path, Path]:
+    return thread_handoff.resolve_roots(repo_root)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read JSON evidence {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"JSON evidence must be an object: {path}")
+    return value
+
+
+def _selectors(args: argparse.Namespace) -> dict[str, str | None]:
+    return {
+        "agent": getattr(args, "agent", None),
+        "source_thread_id": getattr(args, "source_thread_id", None),
+        "replacement_thread_id": getattr(args, "selector_replacement_thread_id", None)
+        or getattr(args, "replacement_thread_id", None),
+        "lineage_id": getattr(args, "lineage_id", None),
+        "rollover_id": getattr(args, "rollover_id", None),
+    }
+
+
+def _select_one(state_root: Path, args: argparse.Namespace) -> dict[str, Any]:
+    records, errors = registry.scan_records(state_root)
+    selected = registry.select_exact(records, **_selectors(args))
+    if len(selected) != 1:
+        payload = {
+            "error": "exact rollover selector did not resolve uniquely",
+            "mutation_allowed": False,
+            "selectors": {key: value for key, value in _selectors(args).items() if value},
+            "matches": [registry.candidate_summary(record) for record in selected],
+            "registry_errors": errors,
+        }
+        raise SelectionError(payload)
+    record = selected[0]
+    selected_errors = registry.record_source_errors(state_root, record, errors)
+    if selected_errors:
+        raise SelectionError(
+            {
+                "error": "exact rollover selector matched a corrupt durable source",
+                "mutation_allowed": False,
+                "selectors": {key: value for key, value in _selectors(args).items() if value},
+                "candidate": registry.candidate_summary(record),
+                "registry_errors": selected_errors,
+            }
+        )
+    return record
+
+
+class SelectionError(ValueError):
+    def __init__(self, payload: dict[str, Any]) -> None:
+        super().__init__(str(payload.get("error")))
+        self.payload = payload
+
+
+def _print_error(exc: Exception, *, action: str) -> int:
+    payload = exc.payload if isinstance(exc, SelectionError) else {"error": str(exc), "action": action}
+    print(json.dumps(payload, indent=2))
+    return 2
+
+
+def cmd_detect(args: argparse.Namespace) -> int:
+    try:
+        _, state_root = _roots(args.repo_root)
+        records, errors = registry.scan_records(state_root)
+        agent_records = [record for record in records if record["key"]["agent"] == args.agent]
+        has_exact = any(value for key, value in _selectors(args).items() if key != "agent")
+        if has_exact:
+            record = _select_one(state_root, args)
+            print(
+                json.dumps(
+                    {
+                        "status": "selected",
+                        "mutation_allowed": registry.allows_exact_progress(record),
+                        "candidate": registry.candidate_summary(record),
+                        "packet_paths": record.get("packet_paths"),
+                        "lease_path": record.get("lease_path"),
+                        "unrelated_live_pending": sum(
+                            registry.is_live_pending(item) and item["key"] != record["key"] for item in agent_records
+                        ),
+                        "registry_errors": errors,
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+        live = [record for record in agent_records if registry.is_live_pending(record)]
+        if errors:
+            print(
+                json.dumps(
+                    {
+                        "error": "inconsistent_or_corrupt_rollover_sources",
+                        "agent": args.agent,
+                        "mutation_allowed": False,
+                        "candidates": [registry.candidate_summary(record) for record in live],
+                        "registry_errors": errors,
+                    },
+                    indent=2,
+                )
+            )
+            return 2
+        if len(live) > 1:
+            print(
+                json.dumps(
+                    {
+                        "error": "multiple_live_pending_rollovers",
+                        "agent": args.agent,
+                        "mutation_allowed": False,
+                        "candidates": [registry.candidate_summary(record) for record in live],
+                        "registry_errors": errors,
+                    },
+                    indent=2,
+                )
+            )
+            return 2
+        if not live:
+            print(json.dumps({"agent": args.agent, "status": "none", "registry_errors": errors}, indent=2))
+            return 2 if errors else 0
+        record = live[0]
+        print(
+            json.dumps(
+                {
+                    "agent": args.agent,
+                    "status": "selected",
+                    "mutation_allowed": registry.allows_exact_progress(record),
+                    "candidate": registry.candidate_summary(record),
+                    "packet_paths": record.get("packet_paths"),
+                    "lease_path": record.get("lease_path"),
+                },
+                indent=2,
+            )
+        )
+        return 0
+    except (OSError, ValueError) as exc:
+        return _print_error(exc, action="detect")
+
+
+def cmd_audit(args: argparse.Namespace) -> int:
+    try:
+        _, state_root = _roots(args.repo_root)
+        if args.stale_hours <= 0:
+            raise ValueError("--stale-hours must be positive")
+        result = registry.audit_fleet(state_root, stale_hours=args.stale_hours)
+    except (OSError, ValueError) as exc:
+        return _print_error(exc, action="audit")
+    print(json.dumps(result, indent=2))
+    return 2 if result["errors"] else 0
+
+
+def cmd_migrate(args: argparse.Namespace) -> int:
+    try:
+        _, state_root = _roots(args.repo_root)
+        result = registry.migrate_existing(
+            state_root,
+            apply=args.apply,
+            evidence=args.evidence or "",
+        )
+    except (OSError, ValueError) as exc:
+        return _print_error(exc, action="migrate")
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def cmd_reconcile(args: argparse.Namespace) -> int:
+    try:
+        _, state_root = _roots(args.repo_root)
+        record = _select_one(state_root, args)
+        snapshot = _load_json(args.snapshot)
+        if args.apply:
+            result = registry.apply_reconciliation(state_root, record=record, snapshot=snapshot)
+        else:
+            result = {
+                "mode": "read-only",
+                "mutation_allowed": False,
+                "candidate": registry.candidate_summary(record),
+                "reconciliation": registry.reconcile_snapshot(record, snapshot),
+            }
+    except (OSError, ValueError) as exc:
+        return _print_error(exc, action="reconcile-exact")
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    try:
+        repo_root, state_root = _roots(args.repo_root)
+        record = _select_one(state_root, args)
+        if not registry.allows_exact_progress(record):
+            raise ValueError(
+                f"selected rollover state {record['state']} requires reconciliation or maintenance before resume"
+            )
+        selected_replacement_id = args.replacement_thread_id.strip()
+        if not selected_replacement_id:
+            raise ValueError("--replacement-thread-id is required")
+        if record["task_identity"].get("replacement_task_id") != selected_replacement_id:
+            raise ValueError("--replacement-thread-id does not match the authoritative registry binding")
+        lease_relative = record.get("lease_path")
+        if not isinstance(lease_relative, str) or not lease_relative:
+            raise ValueError("selected registry record has no live lease to resume")
+        lease_path = thread_handoff.repo_local_path(state_root, Path(lease_relative))
+        key = record["key"]
+        with advisory_lock(registry.lineage_lock_path(state_root, agent=key["agent"], lineage_id=key["lineage_id"])):
+            lease = thread_handoff.load_state(lease_path)
+            thread_handoff.require_checkout_continuity(lease.get("replacement") or {}, repo_root)
+            resumed = thread_handoff.resume_state(
+                lease,
+                rollover_id=key["rollover_id"],
+                replacement_thread_id=selected_replacement_id,
+                now=thread_handoff.utc_now(),
+            )
+            thread_handoff.write_rollover_state(
+                lease_path,
+                state_root,
+                resumed,
+                already_locked=True,
+            )
+            current = registry.load_record(state_root, **key)
+    except (OSError, ValueError) as exc:
+        return _print_error(exc, action="resume-exact")
+    print(
+        json.dumps(
+            {
+                "status": "resumed",
+                "candidate": registry.candidate_summary(current),
+                "lease_path": current["lease_path"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def cmd_maintenance(args: argparse.Namespace) -> int:
+    try:
+        _, state_root = _roots(args.repo_root)
+        record = _select_one(state_root, args)
+        action = registry.MaintenanceAction(args.maintenance_action)
+        if args.plan:
+            if args.proof_file is None:
+                raise ValueError("maintenance planning requires --proof-file")
+            result = registry.create_maintenance_plan(
+                state_root,
+                record=record,
+                action=action,
+                proof=_load_json(args.proof_file),
+            )
+        else:
+            if args.plan_file is None:
+                raise ValueError("maintenance apply requires --plan-file")
+            _, plan = registry.load_maintenance_plan(state_root, plan_path=args.plan_file)
+            if plan.get("key") != record.get("key"):
+                raise ValueError("maintenance plan exact IDs do not match the selected registry record")
+            if plan.get("action") != action.value:
+                raise ValueError("maintenance plan action does not match the selected command")
+            result = registry.apply_maintenance_plan(state_root, plan_path=args.plan_file)
+    except (OSError, ValueError) as exc:
+        return _print_error(exc, action=args.maintenance_action)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def _add_exact_selectors(
+    parser: argparse.ArgumentParser,
+    *,
+    require_pair: bool = False,
+    include_replacement: bool = True,
+) -> None:
+    parser.add_argument("--agent", type=registry.normalize_agent, default="codex")
+    parser.add_argument("--source-thread-id")
+    if include_replacement:
+        parser.add_argument("--replacement-thread-id", dest="selector_replacement_thread_id")
+    parser.add_argument("--lineage-id", required=require_pair)
+    parser.add_argument("--rollover-id", required=require_pair)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    detect = subparsers.add_parser("detect", help="Read-only generic or exact rollover detection.")
+    _add_exact_selectors(detect)
+    detect.set_defaults(func=cmd_detect)
+
+    audit = subparsers.add_parser("audit", help="Classify every fleet rollover packet without mutation.")
+    audit.add_argument("--stale-hours", type=float, default=registry.DEFAULT_STALE_HOURS)
+    audit.set_defaults(func=cmd_audit)
+
+    migrate = subparsers.add_parser("migrate", help="Plan or apply non-destructive legacy registry migration.")
+    migration_mode = migrate.add_mutually_exclusive_group(required=True)
+    migration_mode.add_argument("--plan", action="store_true")
+    migration_mode.add_argument("--apply", action="store_true")
+    migrate.add_argument("--evidence")
+    migrate.set_defaults(func=cmd_migrate)
+
+    reconcile = subparsers.add_parser(
+        "reconcile-exact",
+        help="Compare one exact registry entry with an authoritative native/app snapshot.",
+    )
+    _add_exact_selectors(reconcile)
+    reconcile.add_argument("--snapshot", type=Path, required=True)
+    reconcile.add_argument("--apply", action="store_true")
+    reconcile.set_defaults(func=cmd_reconcile)
+
+    resume = subparsers.add_parser("resume-exact", help="Resume one uniquely selected exact packet.")
+    _add_exact_selectors(resume, include_replacement=False)
+    resume.add_argument("--replacement-thread-id", required=True)
+    resume.set_defaults(func=cmd_resume)
+
+    for name, action in (
+        ("finish-cleanup-exact", registry.MaintenanceAction.FINISH_CLEANUP),
+        ("supersede-exact", registry.MaintenanceAction.SUPERSEDE),
+        ("abandon-exact", registry.MaintenanceAction.ABANDON),
+    ):
+        maintenance = subparsers.add_parser(name, help=f"Plan or apply exact {action.value} maintenance.")
+        _add_exact_selectors(maintenance, require_pair=True)
+        mode = maintenance.add_mutually_exclusive_group(required=True)
+        mode.add_argument("--plan", action="store_true")
+        mode.add_argument("--apply", action="store_true")
+        maintenance.add_argument("--proof-file", type=Path)
+        maintenance.add_argument("--plan-file", type=Path)
+        maintenance.set_defaults(func=cmd_maintenance, maintenance_action=action.value)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/task_family/rollover_registry.py
+++ b/scripts/orchestration/task_family/rollover_registry.py
@@ -1,0 +1,1869 @@
+"""Fleet-wide, exact-ID registry for durable thread rollover packets.
+
+The registry projects the existing task-family identity envelope; it does not
+create another task identity.  Its key is exactly ``(agent, lineage_id,
+rollover_id)`` and task titles remain display-only metadata.  Native app facts
+enter only through explicit snapshots or existing immutable receipts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+from referencing import Registry, Resource
+
+from .. import task_identity
+from .planner import canonical_json, sha256_digest
+from .storage import advisory_lock, atomic_write_json
+
+REGISTRY_SCHEMA_VERSION = 1
+REGISTRY_RELATIVE_ROOT = Path(".agent/thread-rollover-registry/v1")
+DEFAULT_STALE_HOURS = 24.0
+LINEAGE_ID_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+ROLLOVER_ID_RE = re.compile(r"^rollover-[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+_ROOT = Path(__file__).resolve().parents[3]
+_REGISTRY_SCHEMA_PATH = _ROOT / "agents_extensions" / "shared" / "schemas" / "rollover-registry.v1.schema.json"
+_TASK_IDENTITY_SCHEMA_PATH = _ROOT / "agents_extensions" / "shared" / "schemas" / "task-identity.v1.schema.json"
+_REGISTRY_SCHEMA = json.loads(_REGISTRY_SCHEMA_PATH.read_text(encoding="utf-8"))
+_TASK_IDENTITY_SCHEMA = json.loads(_TASK_IDENTITY_SCHEMA_PATH.read_text(encoding="utf-8"))
+_SCHEMA_REGISTRY = Registry().with_resource(
+    task_identity.IDENTITY_SCHEMA_VERSION,
+    Resource.from_contents(_TASK_IDENTITY_SCHEMA),
+)
+_REGISTRY_VALIDATOR = Draft202012Validator(
+    _REGISTRY_SCHEMA,
+    registry=_SCHEMA_REGISTRY,
+    format_checker=FormatChecker(),
+)
+
+
+class RolloverState(StrEnum):
+    PREPARED = "PREPARED"
+    AWAITING_NATIVE_CREATE = "AWAITING_NATIVE_CREATE"
+    REPLACEMENT_CREATED = "REPLACEMENT_CREATED"
+    RESUMED = "RESUMED"
+    STRICT_RECALL_PASSED = "STRICT_RECALL_PASSED"
+    CANARY_PASSED = "CANARY_PASSED"
+    CONFIRMED = "CONFIRMED"
+    PREDECESSOR_ARCHIVED = "PREDECESSOR_ARCHIVED"
+    HEARTBEAT_RETIRED = "HEARTBEAT_RETIRED"
+    SUPERSEDED = "SUPERSEDED"
+    ABANDONED_WITH_PROOF = "ABANDONED_WITH_PROOF"
+    BLOCKED = "BLOCKED"
+
+
+class AuditClassification(StrEnum):
+    ACTIVE_RESUMABLE = "active and resumable"
+    AWAITING_NATIVE_ACTION = "awaiting native action"
+    CONFIRMED_INCOMPLETE_CLEANUP = "confirmed but incompletely cleaned"
+    CONFIRMED_FULLY_CLEANED = "confirmed and fully cleaned"
+    SUPERSEDED = "superseded"
+    STALE_ADJUDICATION = "stale and requiring operator adjudication"
+    INCONSISTENT_CORRUPT = "inconsistent or corrupt"
+
+
+class MaintenanceAction(StrEnum):
+    FINISH_CLEANUP = "finish-cleanup"
+    SUPERSEDE = "supersede"
+    ABANDON = "abandon"
+
+
+TERMINAL_STATES = frozenset(
+    {
+        RolloverState.SUPERSEDED,
+        RolloverState.ABANDONED_WITH_PROOF,
+    }
+)
+LIVE_PENDING_STATES = frozenset(
+    {
+        RolloverState.PREPARED,
+        RolloverState.AWAITING_NATIVE_CREATE,
+        RolloverState.REPLACEMENT_CREATED,
+        RolloverState.RESUMED,
+        RolloverState.STRICT_RECALL_PASSED,
+        RolloverState.CANARY_PASSED,
+        RolloverState.BLOCKED,
+    }
+)
+SUCCESS_SEQUENCE = (
+    RolloverState.PREPARED,
+    RolloverState.AWAITING_NATIVE_CREATE,
+    RolloverState.REPLACEMENT_CREATED,
+    RolloverState.RESUMED,
+    RolloverState.STRICT_RECALL_PASSED,
+    RolloverState.CANARY_PASSED,
+    RolloverState.CONFIRMED,
+    RolloverState.PREDECESSOR_ARCHIVED,
+    RolloverState.HEARTBEAT_RETIRED,
+)
+SUCCESS_RANK = {state: index for index, state in enumerate(SUCCESS_SEQUENCE)}
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def isoformat_z(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(UTC)
+
+
+def _clean_agent(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("registry agent must be a string")
+    agent = value.strip().lower()
+    if agent != value or not agent or not agent[0].isalpha() or not all(c.isalnum() or c == "-" for c in agent):
+        raise ValueError("registry agent must be a lowercase path-safe identifier")
+    return agent
+
+
+def normalize_agent(value: str) -> str:
+    return _clean_agent(value)
+
+
+def normalize_lineage_id(value: str) -> str:
+    lineage_id = value.strip().lower()
+    if lineage_id != value or not LINEAGE_ID_RE.fullmatch(lineage_id):
+        raise ValueError("lineage ids must match [a-z][a-z0-9-]{0,63}")
+    return lineage_id
+
+
+def normalize_rollover_id(value: str) -> str:
+    rollover_id = value.strip().lower()
+    if rollover_id != value or not ROLLOVER_ID_RE.fullmatch(rollover_id):
+        raise ValueError("rollover ids must match rollover-[a-z0-9]+(-[a-z0-9]+)*")
+    return rollover_id
+
+
+def _assert_within_state_root(state_root: Path, path: Path, *, label: str) -> Path:
+    root = state_root.resolve()
+    try:
+        path.resolve().relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{label} must remain inside the repository state root") from exc
+    return path
+
+
+def registry_root(state_root: Path) -> Path:
+    return _assert_within_state_root(
+        state_root,
+        state_root.resolve() / REGISTRY_RELATIVE_ROOT,
+        label="rollover registry root",
+    )
+
+
+def record_path(state_root: Path, *, agent: str, lineage_id: str, rollover_id: str) -> Path:
+    return _assert_within_state_root(
+        state_root,
+        registry_root(state_root)
+        / _clean_agent(agent)
+        / normalize_lineage_id(lineage_id)
+        / normalize_rollover_id(rollover_id)
+        / "record.json",
+        label="rollover registry record",
+    )
+
+
+def lineage_lock_path(state_root: Path, *, agent: str, lineage_id: str) -> Path:
+    return _assert_within_state_root(
+        state_root,
+        state_root.resolve()
+        / ".agent"
+        / "thread-rollovers"
+        / _clean_agent(agent)
+        / normalize_lineage_id(lineage_id)
+        / ".native-intent.lock",
+        label="rollover lineage lock",
+    )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read durable JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"durable JSON must be an object: {path}")
+    return value
+
+
+def _validate_existing_json_sources(state_root: Path, values: Iterable[object]) -> None:
+    root = state_root.resolve()
+    for value in values:
+        if not isinstance(value, (str, Path)) or not str(value):
+            continue
+        candidate = Path(value)
+        candidate = candidate if candidate.is_absolute() else root / candidate
+        _assert_within_state_root(state_root, candidate, label="rollover JSON source")
+        if candidate.is_file() and candidate.suffix == ".json":
+            _load_json(candidate)
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _dedupe_strings(values: Iterable[object]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if isinstance(value, str) and value.strip() and value not in result:
+            result.append(value)
+    return result
+
+
+def _require_durable_paths(state_root: Path, values: Iterable[object], *, label: str) -> list[str]:
+    root = state_root.resolve()
+    durable = _dedupe_strings(values)
+    for value in durable:
+        candidate = Path(value)
+        resolved = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"{label} must remain inside the repository state root: {value}") from exc
+        if not resolved.is_file():
+            raise ValueError(f"{label} does not exist as durable evidence: {value}")
+    return durable
+
+
+def _key(record: Mapping[str, Any]) -> tuple[str, str, str]:
+    key = record.get("key")
+    if not isinstance(key, Mapping):
+        raise ValueError("registry record key is missing")
+    return (
+        _clean_agent(key.get("agent")),
+        normalize_lineage_id(str(key.get("lineage_id") or "")),
+        normalize_rollover_id(str(key.get("rollover_id") or "")),
+    )
+
+
+def _identity(record: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    identity = task_identity.validate_identity(record.get("task_identity") or {})
+    transition = task_identity.validate_title_transition(
+        record.get("title_transition") or {},
+        identity,
+    )
+    return identity, transition
+
+
+def validate_record(record: Mapping[str, Any], *, path: Path | None = None) -> dict[str, Any]:
+    errors = sorted(_REGISTRY_VALIDATOR.iter_errors(record), key=lambda item: list(item.absolute_path))
+    if errors:
+        first = errors[0]
+        location = ".".join(str(part) for part in first.absolute_path) or "<root>"
+        raise ValueError(f"rollover registry schema violation at {location}: {first.message}")
+    if record.get("schema_version") != REGISTRY_SCHEMA_VERSION:
+        raise ValueError(f"unsupported rollover registry schema_version: {record.get('schema_version')!r}")
+    agent, lineage_id, rollover_id = _key(record)
+    identity, _ = _identity(record)
+    if identity["lineage_id"] != lineage_id:
+        raise ValueError("task identity lineage does not match the registry key")
+    try:
+        state = RolloverState(str(record.get("state")))
+        last_successful_boundary = RolloverState(str(record.get("last_successful_boundary")))
+    except ValueError as exc:
+        raise ValueError("registry record has an unknown lifecycle state") from exc
+    if last_successful_boundary not in SUCCESS_RANK:
+        raise ValueError("last_successful_boundary must be an ordered successful lifecycle boundary")
+    if state is RolloverState.BLOCKED and not str(record.get("blocking_reason") or "").strip():
+        raise ValueError("blocked registry state requires a blocking reason")
+    if state in TERMINAL_STATES and not str(record.get("terminal_reason") or "").strip():
+        raise ValueError("terminal registry state requires a terminal reason")
+    effective_boundary = last_successful_boundary if state in TERMINAL_STATES or state is RolloverState.BLOCKED else state
+    if (
+        SUCCESS_RANK.get(effective_boundary, -1) >= SUCCESS_RANK[RolloverState.REPLACEMENT_CREATED]
+        and not identity.get("replacement_task_id")
+    ):
+        raise ValueError("replacement-created registry state requires the canonical replacement task identity")
+    if (
+        SUCCESS_RANK.get(effective_boundary, -1) >= SUCCESS_RANK[RolloverState.RESUMED]
+        and identity["lifecycle_state"] not in {"resumed", "confirmed"}
+    ):
+        raise ValueError("resumed registry state requires a resumed canonical task identity")
+    if (
+        SUCCESS_RANK.get(effective_boundary, -1) >= SUCCESS_RANK[RolloverState.CONFIRMED]
+        and identity["lifecycle_state"] != "confirmed"
+    ):
+        raise ValueError("confirmed registry state requires a confirmed canonical task identity")
+    if not isinstance(record.get("timestamps"), Mapping):
+        raise ValueError("registry record requires timestamps")
+    if not isinstance(record.get("history"), list):
+        raise ValueError("registry record history must be a list")
+    packet_paths = record.get("packet_paths")
+    receipts = record.get("receipts")
+    evidence_paths = record.get("evidence_paths")
+    if not isinstance(packet_paths, Mapping) or not isinstance(receipts, list) or not isinstance(evidence_paths, list):
+        raise ValueError("registry packet paths, receipts, and evidence paths are malformed")
+    durable_paths: list[object] = [
+        record.get("lease_path"),
+        *receipts,
+        *evidence_paths,
+        *packet_paths.values(),
+    ]
+    for value in durable_paths:
+        if value is None:
+            continue
+        candidate = Path(str(value))
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ValueError("registry durable paths must be repository-relative and non-traversing")
+    if path is not None:
+        expected = record_path(path.parents[6], agent=agent, lineage_id=lineage_id, rollover_id=rollover_id)
+        if path.resolve() != expected.resolve():
+            raise ValueError("registry record key does not match its canonical path")
+    return dict(record)
+
+
+def load_record(state_root: Path, *, agent: str, lineage_id: str, rollover_id: str) -> dict[str, Any]:
+    path = record_path(state_root, agent=agent, lineage_id=lineage_id, rollover_id=rollover_id)
+    return validate_record(_load_json(path), path=path)
+
+
+def _event(
+    state: RolloverState,
+    *,
+    at: str,
+    reason: str,
+    evidence_paths: Iterable[str] = (),
+    operation_id: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "state": state.value,
+        "at": at,
+        "reason": reason,
+        "evidence_paths": _dedupe_strings(evidence_paths),
+    }
+    if operation_id:
+        payload["operation_id"] = operation_id
+    return payload
+
+
+def _append_history(record: dict[str, Any], event: dict[str, Any]) -> None:
+    history = list(record.get("history") or [])
+    identity = (event.get("state"), event.get("operation_id"), event.get("reason"))
+    if not any((item.get("state"), item.get("operation_id"), item.get("reason")) == identity for item in history):
+        history.append(event)
+    record["history"] = history
+
+
+def _task_family_paths(state_root: Path, native: Mapping[str, Any]) -> dict[str, Path]:
+    family = native.get("family_id")
+    operation = native.get("operation_id")
+    if not isinstance(family, str) or not family or not isinstance(operation, str) or not operation:
+        return {}
+    for label, value in (("family_id", family), ("operation_id", operation)):
+        if value in {".", ".."} or "/" in value or "\\" in value or "\x00" in value:
+            raise ValueError(f"native {label} must be a path-safe component")
+    root = _assert_within_state_root(
+        state_root,
+        state_root / ".agent" / "task-families" / family / "operations" / operation,
+        label="native task-family operation",
+    )
+    return {
+        "root": root,
+        "plan": root / "rollover-plan.json",
+        "binding": root / "rollover-binding.json",
+        "state": root / "state.json",
+        "receipt": root / "receipt.json",
+        "archive_authorization": root / "rollover-archive-authorization.json",
+    }
+
+
+def _effective_state_from_lease(state_root: Path, lease: Mapping[str, Any]) -> tuple[RolloverState, str | None]:
+    replacement = lease.get("replacement")
+    if not isinstance(replacement, Mapping):
+        raise ValueError("lease replacement is missing")
+    native = replacement.get("native_lifecycle")
+    native = native if isinstance(native, Mapping) else {}
+    family_paths = _task_family_paths(state_root, native)
+    task_state: dict[str, Any] = {}
+    if (path := family_paths.get("state")) is not None and path.is_file():
+        task_state = _load_json(path)
+    task_status = (
+        (task_state.get("details") or {}).get("status") if isinstance(task_state.get("details"), Mapping) else None
+    )
+    native_status = native.get("status")
+    blocked_statuses = (task_status, native_status)
+    is_blocked = task_state.get("state") == "blocked" or any(
+        isinstance(value, str) and ("blocked" in value or "failed" in value) for value in blocked_statuses
+    )
+    blocking_reason: str | None = None
+    if is_blocked:
+        task_details = task_state.get("details") if isinstance(task_state.get("details"), Mapping) else {}
+        recorded_status = task_details.get("status") or native_status or "unknown native boundary"
+        recorded_error = task_details.get("error")
+        blocking_reason = f"native rollover boundary blocked: {recorded_status}"
+        if isinstance(recorded_error, str) and recorded_error.strip():
+            blocking_reason += f" ({recorded_error.strip()})"
+    if task_status == "superseded_before_native_create":
+        if (
+            replacement.get("status") in {"resumed", "started"}
+            or (
+                isinstance(native.get("replacement_thread_id"), str)
+                and native["replacement_thread_id"].strip()
+            )
+        ):
+            raise ValueError("superseded-before-create receipt conflicts with an exact native replacement")
+        return RolloverState.SUPERSEDED, blocking_reason
+    if task_status == "archive_reconciled":
+        if is_blocked:
+            raise ValueError("native task-family state cannot be both archived and blocked")
+        return RolloverState.PREDECESSOR_ARCHIVED, None
+    if replacement.get("status") == "started":
+        return RolloverState.CONFIRMED, blocking_reason
+    if is_blocked:
+        return RolloverState.BLOCKED, blocking_reason
+    if replacement.get("status") == "resumed":
+        return RolloverState.RESUMED, None
+    if isinstance(native.get("replacement_thread_id"), str) and native["replacement_thread_id"].strip():
+        return RolloverState.REPLACEMENT_CREATED, None
+    return RolloverState.AWAITING_NATIVE_CREATE, None
+
+
+def _state_prefix(state: RolloverState) -> tuple[RolloverState, ...]:
+    if state in TERMINAL_STATES or state is RolloverState.BLOCKED:
+        return (RolloverState.PREPARED, state)
+    return SUCCESS_SEQUENCE[: SUCCESS_RANK[state] + 1]
+
+
+def record_from_lease(
+    state_root: Path,
+    lease_path: Path,
+    lease: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    now = now or utc_now()
+    _assert_within_state_root(state_root, lease_path, label="rollover lease")
+    agent = _clean_agent(lease.get("agent"))
+    normalized_lease, migrated = task_identity.backfill_legacy_identity(
+        lease,
+        agent=agent,
+        repository=task_identity.DEFAULT_REPOSITORY,
+        now=isoformat_z(now),
+    )
+    lease = normalized_lease
+    lineage_id = normalize_lineage_id(str(lease.get("lineage_id") or ""))
+    replacement = lease.get("replacement")
+    active = lease.get("active")
+    if not isinstance(replacement, Mapping) or not isinstance(active, Mapping):
+        raise ValueError("lease requires active and replacement objects")
+    rollover_id = normalize_rollover_id(str(replacement.get("rollover_id") or ""))
+    if replacement.get("lineage_id") != lineage_id or lease.get("rollover_id") != rollover_id:
+        raise ValueError("lease exact identity fields disagree")
+    source_thread_id = active.get("thread_id")
+    if not isinstance(source_thread_id, str) or not source_thread_id.strip():
+        raise ValueError("lease source thread identity is missing")
+    identity = task_identity.validate_identity(replacement.get("identity") or {})
+    title_transition = task_identity.validate_title_transition(
+        replacement.get("title_transition") or {},
+        identity,
+    )
+    if identity["lineage_id"] != lineage_id:
+        raise ValueError("lease task identity lineage does not match the rollover")
+    if identity["predecessor_task_id"] != source_thread_id:
+        raise ValueError("lease task identity predecessor does not match the active task")
+    native = replacement.get("native_lifecycle")
+    native = native if isinstance(native, Mapping) else {}
+    replacement_thread_id = (
+        native.get("replacement_thread_id") or replacement.get("thread_id") or replacement.get("resumed_thread_id")
+    )
+    if replacement_thread_id and identity.get("replacement_task_id") != replacement_thread_id:
+        raise ValueError("lease task identity replacement does not match the exact native binding")
+    if migrated and isinstance(replacement_thread_id, str):
+        if replacement.get("status") == "resumed":
+            identity = task_identity.mark_resumed(
+                identity,
+                title_transition,
+                replacement_task_id=replacement_thread_id,
+            )
+        elif replacement.get("status") == "started":
+            identity = task_identity.mark_confirmed(
+                identity,
+                title_transition,
+                replacement_task_id=replacement_thread_id,
+            )
+    family_paths = _task_family_paths(state_root, native)
+    packet_path_keys = (
+        "runtime_path",
+        "handoff_path",
+        "bootstrap_prompt_path",
+        "semantic_snapshot_path",
+        "strict_probe_path",
+        "strict_questions_path",
+        "strict_answers_path",
+        "strict_verdict_path",
+        "canary_proof_path",
+    )
+    _validate_existing_json_sources(
+        state_root,
+        [*family_paths.values(), *(replacement.get(key) for key in packet_path_keys)],
+    )
+    state, blocking_reason = _effective_state_from_lease(state_root, lease)
+    strict = replacement.get("strict_verdict")
+    strict = strict if isinstance(strict, Mapping) else {}
+    strict_result = strict.get("verdict") or strict.get("status")
+    strict_state = (
+        "passed" if strict_result == "PASS" else "failed" if isinstance(strict_result, str) else "pending"
+    )
+    strict_score = strict.get("score")
+    if strict_score is None:
+        strict_score = strict.get("correct")
+    canary = replacement.get("canary_proof")
+    canary = canary if isinstance(canary, Mapping) else {}
+    cleanup = lease.get("cleanup")
+    cleanup = cleanup if isinstance(cleanup, Mapping) else {}
+    prepared_at = str(replacement.get("prepared_at") or lease.get("updated_at") or isoformat_z(now))
+    updated_at = str(lease.get("updated_at") or replacement.get("confirmed_at") or prepared_at)
+    evidence = [
+        _relative(lease_path, state_root),
+        *(replacement.get(key) for key in ("handoff_path", "canary_proof_path", "strict_verdict_path")),
+        *(_relative(path, state_root) for path in family_paths.values() if path.is_file()),
+    ]
+    last_success = state
+    if state in TERMINAL_STATES or state is RolloverState.BLOCKED:
+        last_success = RolloverState.AWAITING_NATIVE_CREATE
+        if isinstance(replacement_thread_id, str) and replacement_thread_id.strip():
+            last_success = RolloverState.REPLACEMENT_CREATED
+        if replacement.get("status") in {"resumed", "started"}:
+            last_success = RolloverState.RESUMED
+        if strict_state == "passed":
+            last_success = RolloverState.STRICT_RECALL_PASSED
+        if canary.get("status") == "PASS":
+            last_success = RolloverState.CANARY_PASSED
+        if replacement.get("status") == "started":
+            last_success = RolloverState.CONFIRMED
+        if state in TERMINAL_STATES and SUCCESS_RANK[last_success] >= SUCCESS_RANK[RolloverState.REPLACEMENT_CREATED]:
+            raise ValueError("terminal legacy rollover conflicts with an exact native replacement")
+    history_states = _state_prefix(state)
+    if state in TERMINAL_STATES or state is RolloverState.BLOCKED:
+        history_states = (*SUCCESS_SEQUENCE[: SUCCESS_RANK[last_success] + 1], state)
+    history = [
+        _event(
+            boundary, at=prepared_at if boundary is RolloverState.PREPARED else updated_at, reason="lease projection"
+        )
+        for boundary in history_states
+    ]
+    record = {
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "key": {"agent": agent, "lineage_id": lineage_id, "rollover_id": rollover_id},
+        "task_identity": identity,
+        "title_transition": title_transition,
+        "state": state.value,
+        "last_successful_boundary": last_success.value,
+        "native_creation": {
+            "state": native.get("status") or "legacy_or_unrecorded",
+            "family_id": native.get("family_id"),
+            "operation_id": native.get("operation_id"),
+        },
+        "strict_recall": {
+            "state": strict_state,
+            "score": strict_score,
+            "verdict_path": replacement.get("strict_verdict_path"),
+        },
+        "canary": {
+            "state": "passed" if canary.get("status") == "PASS" else "pending",
+            "proof_path": replacement.get("canary_proof_path"),
+        },
+        "confirmation": {
+            "state": "confirmed" if replacement.get("status") == "started" else "pending",
+            "confirmed_at": replacement.get("confirmed_at"),
+            "confirmed_by": cleanup.get("confirmed_by"),
+        },
+        "predecessor_archival": {
+            "state": "archived"
+            if state in {RolloverState.PREDECESSOR_ARCHIVED, RolloverState.HEARTBEAT_RETIRED}
+            else "pending",
+        },
+        "heartbeat": {
+            "automation_id": active.get("automation_id"),
+            "state": "cleanup_authorized" if cleanup.get("old_automation_ready_to_delete") else "active_or_unknown",
+            "cleanup_authorized": bool(cleanup.get("old_automation_ready_to_delete")),
+        },
+        "timestamps": {"prepared_at": prepared_at, "updated_at": updated_at},
+        "lease_path": _relative(lease_path, state_root),
+        "packet_paths": {
+            key: replacement.get(key) for key in packet_path_keys
+        },
+        "receipts": _dedupe_strings(_relative(path, state_root) for path in family_paths.values() if path.is_file()),
+        "evidence_paths": _dedupe_strings(evidence),
+        "terminal_reason": "superseded by exact task-family receipt" if state is RolloverState.SUPERSEDED else None,
+        "blocking_reason": blocking_reason,
+        "last_reconciliation": None,
+        "history": history,
+    }
+    return validate_record(record)
+
+
+def _merge_projection(existing: dict[str, Any], projected: dict[str, Any]) -> dict[str, Any]:
+    current = RolloverState(existing["state"])
+    candidate = RolloverState(projected["state"])
+    last_success = RolloverState(existing["last_successful_boundary"])
+    projected_last_success = RolloverState(projected["last_successful_boundary"])
+    projected_boundary = (
+        projected_last_success if candidate in TERMINAL_STATES or candidate is RolloverState.BLOCKED else candidate
+    )
+    projection_not_behind = SUCCESS_RANK[projected_boundary] >= SUCCESS_RANK[last_success]
+    projection_advances = SUCCESS_RANK[projected_boundary] > SUCCESS_RANK[last_success]
+    merged = dict(existing)
+    durable_identity, _ = _identity(existing)
+    projected_identity, _ = _identity(projected)
+    immutable_identity_fields = set(durable_identity) - {"replacement_task_id", "lifecycle_state"}
+    for field in immutable_identity_fields:
+        if durable_identity.get(field) != projected_identity.get(field):
+            raise ValueError(f"projected task identity {field} conflicts with the durable registry")
+    durable_replacement = durable_identity.get("replacement_task_id")
+    projected_replacement = projected_identity.get("replacement_task_id")
+    if durable_replacement and projected_replacement and durable_replacement != projected_replacement:
+        raise ValueError("projected replacement_task_id conflicts with the durable registry")
+    if projection_not_behind and (projected_replacement or not durable_replacement):
+        merged["task_identity"] = projected["task_identity"]
+        merged["title_transition"] = projected["title_transition"]
+    for key in ("lease_path", "packet_paths"):
+        value = projected.get(key)
+        if value is not None:
+            merged[key] = value
+    if projection_not_behind:
+        for key in (
+            "native_creation",
+            "strict_recall",
+            "canary",
+            "confirmation",
+            "predecessor_archival",
+            "heartbeat",
+        ):
+            value = projected.get(key)
+            if value is not None:
+                merged[key] = value
+        if current is not RolloverState.BLOCKED or candidate is RolloverState.BLOCKED or projection_advances:
+            merged["blocking_reason"] = projected.get("blocking_reason")
+    merged["receipts"] = _dedupe_strings([*existing.get("receipts", []), *projected.get("receipts", [])])
+    merged["evidence_paths"] = _dedupe_strings(
+        [*existing.get("evidence_paths", []), *projected.get("evidence_paths", [])]
+    )
+    if current not in TERMINAL_STATES:
+        if candidate in TERMINAL_STATES and projection_not_behind:
+            if SUCCESS_RANK.get(last_success, 0) >= SUCCESS_RANK[RolloverState.CONFIRMED]:
+                raise ValueError("confirmed active rollover cannot be superseded by a projected legacy state")
+            merged["state"] = candidate.value
+            merged["last_successful_boundary"] = projected_last_success.value
+            merged["terminal_reason"] = projected.get("terminal_reason")
+        elif candidate is RolloverState.BLOCKED and projection_not_behind:
+            merged["state"] = candidate.value
+            merged["last_successful_boundary"] = projected_last_success.value
+            merged["blocking_reason"] = projected.get("blocking_reason")
+        elif projection_advances:
+            merged["state"] = candidate.value
+            merged["last_successful_boundary"] = candidate.value
+            merged["blocking_reason"] = projected.get("blocking_reason")
+    for event in projected.get("history", []):
+        if (
+            candidate in TERMINAL_STATES or candidate is RolloverState.BLOCKED
+        ) and not projection_not_behind and event.get("state") == candidate.value:
+            continue
+        _append_history(merged, event)
+    timestamps = dict(existing.get("timestamps") or {})
+    timestamps.update({key: value for key, value in projected.get("timestamps", {}).items() if value})
+    merged["timestamps"] = timestamps
+    return validate_record(merged)
+
+
+def sync_from_lease(
+    state_root: Path,
+    lease_path: Path,
+    lease: Mapping[str, Any],
+    *,
+    already_locked: bool = False,
+) -> dict[str, Any]:
+    projected = record_from_lease(state_root, lease_path, lease)
+    agent, lineage_id, rollover_id = _key(projected)
+    path = record_path(state_root, agent=agent, lineage_id=lineage_id, rollover_id=rollover_id)
+
+    def write() -> None:
+        nonlocal projected
+        if path.is_file():
+            projected = _merge_projection(validate_record(_load_json(path), path=path), projected)
+        atomic_write_json(path, projected)
+
+    if already_locked:
+        write()
+    else:
+        with advisory_lock(lineage_lock_path(state_root, agent=agent, lineage_id=lineage_id)):
+            write()
+    return projected
+
+
+def transition(
+    state_root: Path,
+    *,
+    agent: str,
+    lineage_id: str,
+    rollover_id: str,
+    state: RolloverState,
+    reason: str,
+    evidence_paths: Iterable[str] = (),
+    operation_id: str | None = None,
+    updates: Mapping[str, Any] | None = None,
+    already_locked: bool = False,
+) -> dict[str, Any]:
+    path = record_path(state_root, agent=agent, lineage_id=lineage_id, rollover_id=rollover_id)
+
+    def apply() -> dict[str, Any]:
+        record = validate_record(_load_json(path), path=path)
+        if operation_id and any(
+            event.get("operation_id") == operation_id and event.get("state") == state.value
+            for event in record.get("history", [])
+        ):
+            return record
+        current = RolloverState(record["state"])
+        if current in TERMINAL_STATES and current is not state:
+            raise ValueError(f"terminal rollover {current.value} cannot transition to {state.value}")
+        if (
+            state in TERMINAL_STATES
+            and SUCCESS_RANK.get(RolloverState(record["last_successful_boundary"]), 0)
+            >= SUCCESS_RANK[RolloverState.CONFIRMED]
+        ):
+            raise ValueError("confirmed active rollover cannot be superseded or abandoned")
+        if state not in TERMINAL_STATES and state is not RolloverState.BLOCKED:
+            last = RolloverState(record["last_successful_boundary"])
+            if current is RolloverState.BLOCKED and SUCCESS_RANK[state] <= SUCCESS_RANK[last]:
+                raise ValueError("blocked rollover requires authoritative proof beyond its last successful boundary")
+            if SUCCESS_RANK[state] < SUCCESS_RANK.get(last, 0):
+                return record
+            if SUCCESS_RANK[state] > SUCCESS_RANK.get(last, 0) + 1:
+                raise ValueError(
+                    f"rollover boundary {state.value} cannot skip past {last.value}; "
+                    "reconcile and persist each prerequisite boundary"
+                )
+            record["last_successful_boundary"] = state.value
+            record["blocking_reason"] = None
+        record["state"] = state.value
+        at = isoformat_z(utc_now())
+        _append_history(
+            record,
+            _event(state, at=at, reason=reason, evidence_paths=evidence_paths, operation_id=operation_id),
+        )
+        record["timestamps"] = {**record.get("timestamps", {}), "updated_at": at}
+        record["evidence_paths"] = _dedupe_strings([*record.get("evidence_paths", []), *evidence_paths])
+        if state is RolloverState.BLOCKED:
+            record["blocking_reason"] = reason
+        if state in TERMINAL_STATES:
+            record["terminal_reason"] = reason
+        if state is RolloverState.REPLACEMENT_CREATED:
+            record["native_creation"] = {**record["native_creation"], "state": "replacement_created"}
+        elif state is RolloverState.STRICT_RECALL_PASSED:
+            record["strict_recall"] = {**record["strict_recall"], "state": "passed"}
+        elif state is RolloverState.CANARY_PASSED:
+            record["canary"] = {**record["canary"], "state": "passed"}
+        elif state is RolloverState.CONFIRMED:
+            record["confirmation"] = {**record["confirmation"], "state": "confirmed", "confirmed_at": at}
+        elif state is RolloverState.PREDECESSOR_ARCHIVED:
+            record["predecessor_archival"] = {**record["predecessor_archival"], "state": "archived"}
+        elif state is RolloverState.HEARTBEAT_RETIRED:
+            record["heartbeat"] = {**record["heartbeat"], "state": "retired"}
+        if updates:
+            allowed_updates = {
+                "native_creation",
+                "task_identity",
+                "title_transition",
+                "strict_recall",
+                "canary",
+                "confirmation",
+                "predecessor_archival",
+                "heartbeat",
+            }
+            for key, value in updates.items():
+                if key not in allowed_updates:
+                    raise ValueError(f"registry transition update is not allowed for {key}")
+                record[key] = value
+        if state is RolloverState.RESUMED:
+            identity, title_transition = _identity(record)
+            replacement_task_id = identity.get("replacement_task_id")
+            if not isinstance(replacement_task_id, str):
+                raise ValueError("resume requires the canonical replacement task identity")
+            record["task_identity"] = task_identity.mark_resumed(
+                identity,
+                title_transition,
+                replacement_task_id=replacement_task_id,
+            )
+        elif state is RolloverState.CONFIRMED:
+            identity, title_transition = _identity(record)
+            replacement_task_id = identity.get("replacement_task_id")
+            if not isinstance(replacement_task_id, str):
+                raise ValueError("confirmation requires the canonical replacement task identity")
+            record["task_identity"] = task_identity.mark_confirmed(
+                identity,
+                title_transition,
+                replacement_task_id=replacement_task_id,
+            )
+        validate_record(record, path=path)
+        atomic_write_json(path, record)
+        return record
+
+    if already_locked:
+        return apply()
+    with advisory_lock(lineage_lock_path(state_root, agent=agent, lineage_id=lineage_id)):
+        return apply()
+
+
+def _minimal_record_from_plan(state_root: Path, plan_path: Path, plan: Mapping[str, Any]) -> dict[str, Any]:
+    _assert_within_state_root(state_root, plan_path, label="task-family rollover plan")
+    agent = _clean_agent(plan.get("agent"))
+    lineage_id = normalize_lineage_id(str(plan.get("lineage_id") or ""))
+    rollover_id = normalize_rollover_id(str(plan.get("rollover_id") or ""))
+    operation_root = plan_path.parent
+    task_state = _load_json(operation_root / "state.json") if (operation_root / "state.json").is_file() else {}
+    details = task_state.get("details") if isinstance(task_state.get("details"), Mapping) else {}
+    status = details.get("status")
+    state = RolloverState.AWAITING_NATIVE_CREATE
+    if status == "superseded_before_native_create":
+        state = RolloverState.SUPERSEDED
+    elif task_state.get("state") == "blocked" or (
+        isinstance(status, str) and ("blocked" in status or "failed" in status)
+    ):
+        state = RolloverState.BLOCKED
+    binding = (
+        _load_json(operation_root / "rollover-binding.json")
+        if (operation_root / "rollover-binding.json").is_file()
+        else {}
+    )
+    created_at = datetime.fromtimestamp(plan_path.stat().st_mtime, tz=UTC).replace(microsecond=0)
+    source_thread_id = str(plan.get("source_thread_id") or "")
+    if not source_thread_id:
+        raise ValueError("legacy rollover plan has no source thread identity")
+    generation = plan.get("generation")
+    if not isinstance(generation, int) or generation < 1:
+        raise ValueError("legacy rollover plan has no valid generation")
+    plan_identity = plan.get("task_identity")
+    if isinstance(plan_identity, Mapping):
+        identity = task_identity.validate_identity(plan_identity)
+        harness = task_identity.default_harness(agent)
+    else:
+        intended_title = str(plan.get("intended_title") or "").strip()
+        semantic_title = intended_title.split(" — ", 1)[-1].strip()
+        try:
+            task_identity.validate_semantic_title(semantic_title)
+        except ValueError:
+            semantic_title = "Recover predecessor task context"
+        identity = task_identity.build_identity(
+            repository=task_identity.DEFAULT_REPOSITORY,
+            stream_epic=None,
+            stream_epic_url=None,
+            github_issue_number=None,
+            github_issue_url=None,
+            semantic_title=semantic_title,
+            task_family="thread-rollover",
+            role=agent,
+            predecessor_task_id=source_thread_id,
+            replacement_task_id=None,
+            lineage_id=lineage_id,
+            generation=generation,
+            terminal_goal=task_identity.LEGACY_TERMINAL_GOAL,
+            migration_source="legacy-task-family-plan",
+            legacy_fallback=True,
+        )
+        harness = f"{task_identity.default_harness(agent)}-legacy"
+    if identity["lineage_id"] != lineage_id or identity["generation"] != generation:
+        raise ValueError("task-family plan identity does not match its exact lineage and generation")
+    if identity["predecessor_task_id"] != source_thread_id:
+        raise ValueError("task-family plan identity does not match its exact predecessor")
+    title_transition = task_identity.new_title_transition(
+        harness=harness,
+        visible_title_value=identity["visible_title"],
+        prepared_at=isoformat_z(created_at),
+    )
+    bound_replacement = binding.get("replacement_thread_id")
+    if isinstance(bound_replacement, str) and bound_replacement:
+        if state in TERMINAL_STATES:
+            raise ValueError("terminal task-family receipt conflicts with an exact native replacement")
+        identity, title_transition = task_identity.bind_replacement(
+            identity,
+            title_transition,
+            replacement_task_id=bound_replacement,
+            evidence=f"Exact task-family binding at {_relative(operation_root / 'rollover-binding.json', state_root)}.",
+            now=isoformat_z(created_at),
+        )
+        if state is not RolloverState.BLOCKED:
+            state = RolloverState.REPLACEMENT_CREATED
+    last_success = state
+    if state in TERMINAL_STATES or state is RolloverState.BLOCKED:
+        last_success = (
+            RolloverState.REPLACEMENT_CREATED
+            if isinstance(bound_replacement, str) and bound_replacement
+            else RolloverState.AWAITING_NATIVE_CREATE
+        )
+    history_states = _state_prefix(state)
+    if state in TERMINAL_STATES or state is RolloverState.BLOCKED:
+        history_states = (*SUCCESS_SEQUENCE[: SUCCESS_RANK[last_success] + 1], state)
+    operation_json_paths = sorted(
+        path for path in operation_root.iterdir() if path.is_file() and path.name.endswith(".json")
+    )
+    _validate_existing_json_sources(state_root, operation_json_paths)
+    record = {
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "key": {"agent": agent, "lineage_id": lineage_id, "rollover_id": rollover_id},
+        "task_identity": identity,
+        "title_transition": title_transition,
+        "state": state.value,
+        "last_successful_boundary": last_success.value,
+        "native_creation": {
+            "state": status or "awaiting_native_create",
+            "family_id": plan.get("family_id"),
+            "operation_id": plan.get("operation_id"),
+        },
+        "strict_recall": {"state": "pending", "score": None, "verdict_path": None},
+        "canary": {"state": "pending", "proof_path": None},
+        "confirmation": {"state": "pending", "confirmed_at": None, "confirmed_by": None},
+        "predecessor_archival": {"state": "pending"},
+        "heartbeat": {"automation_id": None, "state": "unknown", "cleanup_authorized": False},
+        "timestamps": {"prepared_at": isoformat_z(created_at), "updated_at": isoformat_z(created_at)},
+        "lease_path": None,
+        "packet_paths": {"bootstrap_prompt_path": plan.get("bootstrap_prompt_path")},
+        "receipts": _dedupe_strings(_relative(path, state_root) for path in operation_json_paths),
+        "evidence_paths": [_relative(plan_path, state_root)],
+        "terminal_reason": "superseded by exact task-family receipt" if state is RolloverState.SUPERSEDED else None,
+        "blocking_reason": (
+            f"native task-family boundary blocked: {status or task_state.get('state')}"
+            if state is RolloverState.BLOCKED
+            else None
+        ),
+        "last_reconciliation": None,
+        "history": [
+            _event(boundary, at=isoformat_z(created_at), reason="legacy task-family migration projection")
+            for boundary in history_states
+        ],
+    }
+    return validate_record(record)
+
+
+def discover_legacy_records(
+    state_root: Path,
+) -> tuple[dict[tuple[str, str, str], dict[str, Any]], list[dict[str, Any]]]:
+    records: dict[tuple[str, str, str], dict[str, Any]] = {}
+    errors: list[dict[str, Any]] = []
+    rollover_root = state_root / ".agent" / "thread-rollovers"
+    if rollover_root.is_dir():
+        for lease_path in sorted(rollover_root.glob("*/*/lease.json")):
+            try:
+                record = record_from_lease(state_root, lease_path, _load_json(lease_path))
+                records[_key(record)] = record
+            except (OSError, ValueError) as exc:
+                errors.append({"path": _relative(lease_path, state_root), "error": str(exc)})
+    families_root = state_root / ".agent" / "task-families"
+    if families_root.is_dir():
+        for plan_path in sorted(families_root.glob("rollover-*/operations/*/rollover-plan.json")):
+            try:
+                record = _minimal_record_from_plan(state_root, plan_path, _load_json(plan_path))
+                records.setdefault(_key(record), record)
+            except (OSError, ValueError) as exc:
+                errors.append({"path": _relative(plan_path, state_root), "error": str(exc)})
+    return records, errors
+
+
+def scan_records(
+    state_root: Path,
+    *,
+    include_legacy: bool = True,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    records: dict[tuple[str, str, str], dict[str, Any]] = {}
+    errors: list[dict[str, Any]] = []
+    root = registry_root(state_root)
+    if root.is_dir():
+        for path in sorted(root.glob("*/*/*/record.json")):
+            try:
+                record = validate_record(_load_json(path), path=path)
+                key = _key(record)
+                if key in records:
+                    raise ValueError(f"duplicate registry key {key}")
+                records[key] = record
+            except (OSError, ValueError) as exc:
+                errors.append({"path": _relative(path, state_root), "error": str(exc)})
+    if include_legacy:
+        legacy, legacy_errors = discover_legacy_records(state_root)
+        errors.extend(legacy_errors)
+        for key, projection in legacy.items():
+            if key in records:
+                try:
+                    records[key] = _merge_projection(records[key], projection)
+                except ValueError as exc:
+                    errors.append({"path": records[key].get("lease_path") or str(key), "error": str(exc)})
+            else:
+                records[key] = projection
+    return [records[key] for key in sorted(records)], errors
+
+
+def select_exact(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    agent: str | None = None,
+    source_thread_id: str | None = None,
+    replacement_thread_id: str | None = None,
+    lineage_id: str | None = None,
+    rollover_id: str | None = None,
+) -> list[dict[str, Any]]:
+    selectors = {
+        "source_thread_id": source_thread_id,
+        "replacement_thread_id": replacement_thread_id,
+        "lineage_id": lineage_id,
+        "rollover_id": rollover_id,
+    }
+    if not any(value for value in selectors.values()):
+        raise ValueError("at least one exact rollover selector is required")
+    if agent is not None:
+        agent = _clean_agent(agent)
+    if lineage_id is not None:
+        lineage_id = normalize_lineage_id(lineage_id)
+    if rollover_id is not None:
+        rollover_id = normalize_rollover_id(rollover_id)
+    selected: list[dict[str, Any]] = []
+    for item in records:
+        record = dict(item)
+        key_agent, key_lineage, key_rollover = _key(record)
+        identity, _ = _identity(record)
+        if agent is not None and key_agent != agent:
+            continue
+        if source_thread_id is not None and identity["predecessor_task_id"] != source_thread_id:
+            continue
+        if replacement_thread_id is not None and identity.get("replacement_task_id") != replacement_thread_id:
+            continue
+        if lineage_id is not None and key_lineage != lineage_id:
+            continue
+        if rollover_id is not None and key_rollover != rollover_id:
+            continue
+        selected.append(record)
+    return selected
+
+
+def record_source_errors(
+    state_root: Path,
+    record: Mapping[str, Any],
+    errors: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return scan errors that affect one selected record's durable sources."""
+    agent, lineage_id, rollover_id = _key(record)
+    canonical = _relative(
+        record_path(state_root, agent=agent, lineage_id=lineage_id, rollover_id=rollover_id),
+        state_root,
+    )
+    packet_paths = record.get("packet_paths") if isinstance(record.get("packet_paths"), Mapping) else {}
+    selected_paths = {
+        canonical,
+        record.get("lease_path"),
+        *record.get("receipts", []),
+        *record.get("evidence_paths", []),
+        *packet_paths.values(),
+    }
+    return [dict(error) for error in errors if error.get("path") in selected_paths]
+
+
+def is_live_pending(record: Mapping[str, Any]) -> bool:
+    return RolloverState(str(record.get("state"))) in LIVE_PENDING_STATES
+
+
+def allows_exact_progress(record: Mapping[str, Any]) -> bool:
+    """Return whether ordinary exact progress is safe without blocker adjudication."""
+    state = RolloverState(str(record.get("state")))
+    return state in LIVE_PENDING_STATES and state is not RolloverState.BLOCKED
+
+
+def _age_seconds(record: Mapping[str, Any], *, now: datetime) -> int | None:
+    timestamps = record.get("timestamps")
+    if not isinstance(timestamps, Mapping):
+        return None
+    changed = parse_timestamp(timestamps.get("updated_at") or timestamps.get("prepared_at"))
+    if changed is None:
+        return None
+    return max(0, int((now - changed).total_seconds()))
+
+
+def next_safe_action(record: Mapping[str, Any]) -> str:
+    state = RolloverState(str(record.get("state")))
+    if state is RolloverState.PREPARED:
+        return "reconcile the exact packet, then request its native create action"
+    if state is RolloverState.AWAITING_NATIVE_CREATE:
+        return "run native-action --action create for this exact lineage and rollover"
+    if state is RolloverState.REPLACEMENT_CREATED:
+        return "resume-exact with the authoritative replacement task ID"
+    if state in {RolloverState.RESUMED, RolloverState.STRICT_RECALL_PASSED, RolloverState.CANARY_PASSED}:
+        return "complete strict recall and canary proof, then confirm this exact successor"
+    if state is RolloverState.CONFIRMED:
+        return "reconcile and archive only the exact confirmed predecessor"
+    if state is RolloverState.PREDECESSOR_ARCHIVED:
+        return "finish-cleanup exact after explicit heartbeat retirement authorization"
+    if state is RolloverState.HEARTBEAT_RETIRED:
+        return "none; confirmed successor owns the active lineage"
+    if state in TERMINAL_STATES:
+        return "none; terminal packet is excluded from live pending detection"
+    return "resolve the recorded blocker using exact reconciliation evidence"
+
+
+def candidate_summary(record: Mapping[str, Any], *, now: datetime | None = None) -> dict[str, Any]:
+    now = now or utc_now()
+    agent, lineage_id, rollover_id = _key(record)
+    identity, transition = _identity(record)
+    return {
+        "agent": agent,
+        "title": identity["visible_title"],
+        "semantic_title": identity["semantic_title"],
+        "visible_title": identity["visible_title"],
+        "issue": {
+            "number": identity["github_issue_number"],
+            "url": identity["github_issue_url"],
+        },
+        "epic": {
+            "number": identity["stream_epic"],
+            "url": identity["stream_epic_url"],
+        },
+        "lineage_id": lineage_id,
+        "rollover_id": rollover_id,
+        "source_thread_id": identity["predecessor_task_id"],
+        "replacement_thread_id": identity["replacement_task_id"],
+        "state": record.get("state"),
+        "identity_lifecycle_state": identity["lifecycle_state"],
+        "title_confirmation_state": transition["state"],
+        "identity_source": identity["migration"]["source"],
+        "age_seconds": _age_seconds(record, now=now),
+        "last_successful_boundary": record.get("last_successful_boundary"),
+        "blocking_reason": record.get("blocking_reason"),
+        "terminal_reason": record.get("terminal_reason"),
+        "next_safe_action": next_safe_action(record),
+    }
+
+
+def classify(record: Mapping[str, Any], *, now: datetime, stale_after: timedelta) -> AuditClassification:
+    state = RolloverState(str(record.get("state")))
+    age = _age_seconds(record, now=now)
+    if state in TERMINAL_STATES:
+        return AuditClassification.SUPERSEDED
+    if state is RolloverState.BLOCKED:
+        return AuditClassification.STALE_ADJUDICATION
+    if age is not None and age > int(stale_after.total_seconds()) and state in LIVE_PENDING_STATES:
+        return AuditClassification.STALE_ADJUDICATION
+    if state in {RolloverState.PREPARED, RolloverState.AWAITING_NATIVE_CREATE}:
+        return AuditClassification.AWAITING_NATIVE_ACTION
+    if state in {RolloverState.CONFIRMED, RolloverState.PREDECESSOR_ARCHIVED}:
+        return AuditClassification.CONFIRMED_INCOMPLETE_CLEANUP
+    if state is RolloverState.HEARTBEAT_RETIRED:
+        return AuditClassification.CONFIRMED_FULLY_CLEANED
+    return AuditClassification.ACTIVE_RESUMABLE
+
+
+def audit_fleet(
+    state_root: Path,
+    *,
+    stale_hours: float = DEFAULT_STALE_HOURS,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    now = now or utc_now()
+    records, errors = scan_records(state_root)
+    entries: list[dict[str, Any]] = []
+    matched_error_keys: set[tuple[object, object]] = set()
+    for record in records:
+        item = candidate_summary(record, now=now)
+        source_errors = record_source_errors(state_root, record, errors)
+        matched_error_keys.update((error.get("path"), error.get("error")) for error in source_errors)
+        item["classification"] = (
+            AuditClassification.INCONSISTENT_CORRUPT.value
+            if source_errors
+            else classify(record, now=now, stale_after=timedelta(hours=stale_hours)).value
+        )
+        item["live_pending"] = is_live_pending(record) and not source_errors
+        item["reconciliation"] = record.get("last_reconciliation")
+        item["source_errors"] = source_errors
+        entries.append(item)
+    unmatched_errors = [
+        error for error in errors if (error.get("path"), error.get("error")) not in matched_error_keys
+    ]
+    entries.extend(
+        {
+            "agent": None,
+            "title": None,
+            "issue": None,
+            "epic": None,
+            "lineage_id": None,
+            "rollover_id": None,
+            "source_thread_id": None,
+            "replacement_thread_id": None,
+            "state": None,
+            "age_seconds": None,
+            "last_successful_boundary": None,
+            "next_safe_action": "repair or adjudicate the corrupt packet; no mutation is authorized",
+            "classification": AuditClassification.INCONSISTENT_CORRUPT.value,
+            "live_pending": False,
+            "reconciliation": None,
+            "path": error.get("path"),
+            "error": error.get("error"),
+            "source_errors": [error],
+        }
+        for error in unmatched_errors
+    )
+    return {
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "generated_at": isoformat_z(now),
+        "mutation_allowed": False,
+        "entries": entries,
+        "errors": errors,
+        "counts": {
+            "total": len(entries),
+            "live_pending": sum(bool(item["live_pending"]) for item in entries),
+            "corrupt": sum(
+                item["classification"] == AuditClassification.INCONSISTENT_CORRUPT.value for item in entries
+            ),
+        },
+    }
+
+
+def migrate_existing(state_root: Path, *, apply: bool, evidence: str) -> dict[str, Any]:
+    legacy, errors = discover_legacy_records(state_root)
+    planned: list[dict[str, Any]] = []
+    for key, _record in sorted(legacy.items()):
+        path = record_path(state_root, agent=key[0], lineage_id=key[1], rollover_id=key[2])
+        planned.append({"key": list(key), "record_path": _relative(path, state_root), "exists": path.is_file()})
+    result = {
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "mode": "apply" if apply else "plan",
+        "mutation_allowed": apply,
+        "planned": planned,
+        "errors": errors,
+    }
+    if not apply:
+        return result
+    if errors:
+        raise ValueError("migration refuses to apply while legacy packets are inconsistent or corrupt")
+    if not evidence.strip():
+        raise ValueError("migration apply requires durable evidence")
+    written = 0
+    for key, record in sorted(legacy.items()):
+        path = record_path(state_root, agent=key[0], lineage_id=key[1], rollover_id=key[2])
+        with advisory_lock(lineage_lock_path(state_root, agent=key[0], lineage_id=key[1])):
+            if path.is_file():
+                current = validate_record(_load_json(path), path=path)
+                record = _merge_projection(current, record)
+            _append_history(
+                record,
+                _event(
+                    RolloverState(record["state"]),
+                    at=isoformat_z(utc_now()),
+                    reason=f"non-destructive registry migration: {evidence.strip()}",
+                    evidence_paths=record.get("evidence_paths", []),
+                ),
+            )
+            atomic_write_json(path, record)
+            written += 1
+    receipt_payload = {
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "kind": "rollover_registry_migration_receipt",
+        "evidence": evidence.strip(),
+        "written": written,
+        "keys": [list(key) for key in sorted(legacy)],
+    }
+    digest = sha256_digest(receipt_payload)
+    receipt_payload["digest"] = digest
+    atomic_write_json(registry_root(state_root) / "migrations" / digest[:24] / "receipt.json", receipt_payload)
+    return {**result, "written": written, "receipt_digest": digest}
+
+
+def _snapshot_key(snapshot: Mapping[str, Any]) -> tuple[str, str, str]:
+    return (
+        _clean_agent(snapshot.get("agent")),
+        normalize_lineage_id(str(snapshot.get("lineage_id") or "")),
+        normalize_rollover_id(str(snapshot.get("rollover_id") or "")),
+    )
+
+
+def reconcile_snapshot(record: Mapping[str, Any], snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    if _snapshot_key(snapshot) != _key(record):
+        raise ValueError("native reconciliation snapshot exact IDs do not match the selected registry record")
+    identity, title_transition = _identity(record)
+    evidence_paths = snapshot.get("evidence_paths")
+    if not isinstance(evidence_paths, list) or not _dedupe_strings(evidence_paths):
+        raise ValueError("native reconciliation snapshot requires evidence_paths")
+    captured_at = parse_timestamp(snapshot.get("captured_at"))
+    if captured_at is None:
+        raise ValueError("native reconciliation snapshot requires an authoritative UTC captured_at")
+    source = snapshot.get("source")
+    replacement = snapshot.get("replacement")
+    title_receipt = snapshot.get("title_receipt")
+    confirmation = snapshot.get("confirmation")
+    heartbeat = snapshot.get("heartbeat")
+    if not all(isinstance(item, Mapping) for item in (source, replacement, title_receipt, confirmation, heartbeat)):
+        raise ValueError(
+            "native reconciliation snapshot requires source, replacement, title_receipt, "
+            "confirmation, and heartbeat objects"
+        )
+    discrepancies: list[str] = []
+    transitions: list[str] = []
+    proposed_updates: dict[str, dict[str, Any]] = {}
+    receipt_paths: list[str] = []
+    if source.get("thread_id") != identity["predecessor_task_id"]:
+        discrepancies.append("source thread ID does not match the selected predecessor")
+    native_replacement_id = replacement.get("thread_id")
+    recorded_replacement_id = identity.get("replacement_task_id")
+    replacement_created = replacement.get("created")
+    if replacement_created is True:
+        if not isinstance(native_replacement_id, str) or not native_replacement_id:
+            discrepancies.append("snapshot says replacement exists but supplies no exact replacement thread ID")
+        elif recorded_replacement_id and native_replacement_id != recorded_replacement_id:
+            discrepancies.append("native replacement ID conflicts with the durable registry")
+        elif not recorded_replacement_id:
+            transitions.append(RolloverState.REPLACEMENT_CREATED.value)
+            try:
+                identity, title_transition = task_identity.bind_replacement(
+                    identity,
+                    title_transition,
+                    replacement_task_id=native_replacement_id,
+                    evidence=f"Authoritative exact native snapshot captured at {isoformat_z(captured_at)}.",
+                    now=isoformat_z(captured_at),
+                )
+            except ValueError as exc:
+                discrepancies.append(str(exc))
+    elif replacement_created is False:
+        if native_replacement_id is not None:
+            discrepancies.append("snapshot says replacement is absent but supplies a replacement thread ID")
+        if recorded_replacement_id:
+            discrepancies.append("authoritative native state cannot find the durable replacement task")
+    else:
+        discrepancies.append("native replacement creation state is unknown")
+    intended_title = identity["visible_title"]
+    title_replacement_id = title_receipt.get("replacement_thread_id")
+    if not isinstance(title_replacement_id, str) or title_replacement_id != native_replacement_id:
+        discrepancies.append("title receipt does not identify the exact native replacement")
+    if title_receipt.get("supported") is True:
+        if title_transition["native_title_supported"] is not True:
+            discrepancies.append("title snapshot overclaims support for the persisted harness")
+        if replacement_created is not True:
+            discrepancies.append("native title receipt cannot exist without an exact replacement task")
+        if replacement.get("title") != intended_title:
+            discrepancies.append("authoritative replacement title differs from the intended display title")
+        if title_receipt.get("readback_confirmed") is not True:
+            discrepancies.append("native title mutation lacks exact readback confirmation")
+        if title_receipt.get("intended_title") != intended_title:
+            discrepancies.append("title receipt intended title differs from the durable identity")
+        if title_receipt.get("readback_title") != intended_title:
+            discrepancies.append("title receipt readback differs from the durable identity")
+        if not isinstance(title_receipt.get("receipt_path"), str):
+            discrepancies.append("native title reconciliation receipt path is missing")
+        else:
+            receipt_paths.append(title_receipt["receipt_path"])
+            if isinstance(native_replacement_id, str) and title_transition["native_title_supported"] is True:
+                try:
+                    identity, title_transition = task_identity.record_title_acknowledgement(
+                        identity,
+                        title_transition,
+                        replacement_task_id=native_replacement_id,
+                        succeeded=True,
+                        evidence=title_receipt["receipt_path"],
+                        error="",
+                        now=isoformat_z(captured_at),
+                    )
+                    identity, title_transition = task_identity.record_title_readback(
+                        identity,
+                        title_transition,
+                        replacement_task_id=native_replacement_id,
+                        observed_title=str(title_receipt.get("readback_title") or ""),
+                        succeeded=title_receipt.get("readback_confirmed") is True,
+                        evidence=title_receipt["receipt_path"],
+                        error="exact native title readback failed",
+                        now=isoformat_z(captured_at),
+                    )
+                except ValueError as exc:
+                    discrepancies.append(str(exc))
+    elif title_receipt.get("supported") is False:
+        if title_transition["native_title_supported"] is not False:
+            discrepancies.append("title snapshot denies support for a harness with a native title adapter")
+        if replacement_created is not True:
+            discrepancies.append("title fallback receipt cannot exist without an exact replacement task")
+        if not isinstance(title_receipt.get("fallback_receipt_path"), str):
+            discrepancies.append("unsupported title adapter lacks an honest fallback receipt")
+        else:
+            receipt_paths.append(title_receipt["fallback_receipt_path"])
+    else:
+        discrepancies.append("title adapter support state is unknown")
+    last_boundary = RolloverState(str(record.get("last_successful_boundary")))
+    confirmation_active = confirmation.get("confirmed") is True
+    confirmation_replacement_id = confirmation.get("replacement_thread_id")
+    if confirmation_active:
+        if not isinstance(confirmation.get("proof_path"), str):
+            discrepancies.append("native confirmation lacks a durable proof path")
+        else:
+            receipt_paths.append(confirmation["proof_path"])
+        if not native_replacement_id or confirmation_replacement_id != native_replacement_id:
+            discrepancies.append("native confirmation does not identify the exact replacement")
+        if recorded_replacement_id and confirmation_replacement_id != recorded_replacement_id:
+            discrepancies.append("native confirmation conflicts with the durable replacement ID")
+        if SUCCESS_RANK.get(last_boundary, -1) < SUCCESS_RANK[RolloverState.CONFIRMED]:
+            if last_boundary is RolloverState.CANARY_PASSED:
+                transitions.append(RolloverState.CONFIRMED.value)
+            else:
+                discrepancies.append("native confirmation cannot skip strict-recall or canary boundaries")
+        if isinstance(confirmation_replacement_id, str):
+            try:
+                identity = task_identity.mark_confirmed(
+                    identity,
+                    title_transition,
+                    replacement_task_id=confirmation_replacement_id,
+                )
+            except ValueError as exc:
+                discrepancies.append(str(exc))
+    elif confirmation.get("confirmed") is False:
+        if SUCCESS_RANK.get(last_boundary, -1) >= SUCCESS_RANK[RolloverState.CONFIRMED]:
+            discrepancies.append("durable registry says confirmed but authoritative confirmation proof is absent")
+    else:
+        discrepancies.append("native confirmation state is unknown")
+    recorded_automation_id = (record.get("heartbeat") or {}).get("automation_id")
+    snapshot_automation_id = heartbeat.get("automation_id")
+    if recorded_automation_id and snapshot_automation_id != recorded_automation_id:
+        discrepancies.append("heartbeat automation ID does not match the durable registry")
+    elif not recorded_automation_id and isinstance(snapshot_automation_id, str) and snapshot_automation_id:
+        proposed_updates["heartbeat"] = {"automation_id": snapshot_automation_id}
+    confirmed_locally = SUCCESS_RANK.get(last_boundary, -1) >= SUCCESS_RANK[RolloverState.CONFIRMED]
+    confirmed_by_snapshot = confirmation_active and RolloverState.CONFIRMED.value in transitions
+    source_archived = source.get("archived")
+    if source_archived is True:
+        if not (confirmed_locally or confirmed_by_snapshot) or not confirmation_active:
+            discrepancies.append("predecessor archival lacks exact confirmed-successor proof")
+        elif not isinstance(source.get("archive_receipt_path"), str):
+            discrepancies.append("predecessor archival lacks a durable native receipt")
+        else:
+            receipt_paths.append(source["archive_receipt_path"])
+            if SUCCESS_RANK.get(last_boundary, -1) < SUCCESS_RANK[RolloverState.PREDECESSOR_ARCHIVED]:
+                transitions.append(RolloverState.PREDECESSOR_ARCHIVED.value)
+    elif source_archived is False:
+        if SUCCESS_RANK.get(last_boundary, -1) >= SUCCESS_RANK[RolloverState.PREDECESSOR_ARCHIVED]:
+            discrepancies.append("durable registry says predecessor archived but native state says active")
+    else:
+        discrepancies.append("native predecessor archival state is unknown")
+    heartbeat_retired = heartbeat.get("retired")
+    if heartbeat_retired is True:
+        if heartbeat.get("cleanup_authorized") is not True:
+            discrepancies.append("heartbeat retirement lacks explicit cleanup authorization")
+        elif not (confirmed_locally or confirmed_by_snapshot) or source_archived is not True:
+            discrepancies.append("heartbeat retirement requires an exact confirmed and archived predecessor")
+        elif not isinstance(heartbeat.get("retirement_receipt_path"), str):
+            discrepancies.append("heartbeat retirement lacks a durable native receipt")
+        else:
+            receipt_paths.append(heartbeat["retirement_receipt_path"])
+            if SUCCESS_RANK.get(last_boundary, -1) < SUCCESS_RANK[RolloverState.HEARTBEAT_RETIRED]:
+                transitions.append(RolloverState.HEARTBEAT_RETIRED.value)
+    elif heartbeat_retired is False:
+        if SUCCESS_RANK.get(last_boundary, -1) >= SUCCESS_RANK[RolloverState.HEARTBEAT_RETIRED]:
+            discrepancies.append("durable registry says heartbeat retired but authoritative automation is active")
+    else:
+        discrepancies.append("heartbeat retirement state is unknown")
+    if heartbeat.get("cleanup_authorized") is True:
+        if not (confirmed_locally or confirmed_by_snapshot):
+            discrepancies.append("heartbeat cleanup authorization precedes exact successor confirmation")
+        else:
+            proposed_updates.setdefault("heartbeat", {})["cleanup_authorized"] = True
+    proposed_updates["task_identity"] = identity
+    proposed_updates["title_transition"] = title_transition
+    return {
+        "consistent": not discrepancies,
+        "discrepancies": discrepancies,
+        "proposed_transitions": list(dict.fromkeys(transitions)),
+        "captured_at": isoformat_z(captured_at),
+        "evidence_paths": _dedupe_strings(evidence_paths),
+        "receipt_paths": _dedupe_strings(receipt_paths),
+        "proposed_updates": proposed_updates,
+        "snapshot_digest": hashlib.sha256(canonical_json(dict(snapshot)).encode()).hexdigest(),
+        "next_safe_action": "apply exact reconciliation"
+        if (transitions or proposed_updates) and not discrepancies
+        else next_safe_action(record),
+    }
+
+
+def apply_reconciliation(
+    state_root: Path,
+    *,
+    record: Mapping[str, Any],
+    snapshot: Mapping[str, Any],
+) -> dict[str, Any]:
+    reconciliation = reconcile_snapshot(record, snapshot)
+    if not reconciliation["consistent"]:
+        raise ValueError("reconciliation is inconsistent; no durable state was changed")
+    _require_durable_paths(
+        state_root,
+        [*reconciliation["evidence_paths"], *reconciliation["receipt_paths"]],
+        label="reconciliation evidence path",
+    )
+    agent, lineage_id, rollover_id = _key(record)
+    operation_id = reconciliation["snapshot_digest"]
+    receipt_path = (
+        record_path(state_root, agent=agent, lineage_id=lineage_id, rollover_id=rollover_id).parent
+        / "reconciliation"
+        / operation_id[:24]
+        / "receipt.json"
+    )
+
+    def existing_receipt() -> dict[str, Any] | None:
+        if not receipt_path.is_file():
+            return None
+        durable = _load_json(receipt_path)
+        if (
+            durable.get("kind") != "rollover_reconciliation_receipt"
+            or durable.get("key") != record.get("key")
+            or durable.get("snapshot_digest") != operation_id
+        ):
+            raise ValueError("durable reconciliation receipt conflicts with the exact snapshot")
+        return durable
+
+    if durable := existing_receipt():
+        return durable
+    with advisory_lock(lineage_lock_path(state_root, agent=agent, lineage_id=lineage_id)):
+        if durable := existing_receipt():
+            return durable
+        _require_durable_paths(
+            state_root,
+            [*reconciliation["evidence_paths"], *reconciliation["receipt_paths"]],
+            label="reconciliation evidence path",
+        )
+        current = load_record(state_root, agent=agent, lineage_id=lineage_id, rollover_id=rollover_id)
+        reconciliation = reconcile_snapshot(current, snapshot)
+        if not reconciliation["consistent"]:
+            raise ValueError("registry changed before reconciliation apply; no durable state was changed")
+        replacement = snapshot["replacement"]
+        native_id = replacement.get("thread_id")
+        for target_value in reconciliation["proposed_transitions"]:
+            target = RolloverState(target_value)
+            updates: dict[str, Any] = {
+                "task_identity": reconciliation["proposed_updates"]["task_identity"],
+                "title_transition": reconciliation["proposed_updates"]["title_transition"],
+            }
+            if target is RolloverState.REPLACEMENT_CREATED and isinstance(native_id, str):
+                updates["native_creation"] = {
+                    **current["native_creation"],
+                    "state": "authoritatively_reconciled",
+                    "snapshot_digest": operation_id,
+                }
+            current = transition(
+                state_root,
+                agent=agent,
+                lineage_id=lineage_id,
+                rollover_id=rollover_id,
+                state=target,
+                reason="authoritative exact native reconciliation",
+                evidence_paths=reconciliation["evidence_paths"],
+                operation_id=operation_id,
+                updates=updates,
+                already_locked=True,
+            )
+        for section, updates in reconciliation["proposed_updates"].items():
+            if section in {"task_identity", "title_transition"}:
+                current[section] = dict(updates)
+            else:
+                current[section] = {**(current.get(section) or {}), **updates}
+        current["receipts"] = _dedupe_strings([*current.get("receipts", []), *reconciliation["receipt_paths"]])
+        current["evidence_paths"] = _dedupe_strings(
+            [*current.get("evidence_paths", []), *reconciliation["evidence_paths"]]
+        )
+        current["last_reconciliation"] = reconciliation
+        path = record_path(state_root, agent=agent, lineage_id=lineage_id, rollover_id=rollover_id)
+        validate_record(current, path=path)
+        atomic_write_json(path, current)
+        receipt = {
+            "schema_version": REGISTRY_SCHEMA_VERSION,
+            "kind": "rollover_reconciliation_receipt",
+            "key": current["key"],
+            "snapshot_digest": operation_id,
+            "applied_transitions": reconciliation["proposed_transitions"],
+            "evidence_paths": _dedupe_strings([*reconciliation["evidence_paths"], *reconciliation["receipt_paths"]]),
+            "applied_at": isoformat_z(utc_now()),
+        }
+        atomic_write_json(receipt_path, receipt)
+    return receipt
+
+
+_DISPOSITION_ASSERTIONS = frozenset(
+    {
+        "not_confirmed_active",
+        "no_valid_replacement_owns_lineage",
+        "no_unrecorded_native_create",
+        "no_active_heartbeat_dependency",
+        "selected_exact_ids_match",
+    }
+)
+_CLEANUP_ASSERTIONS = frozenset(
+    {
+        "confirmed_successor_exact",
+        "predecessor_archived_exact",
+        "heartbeat_retirement_authorized",
+        "heartbeat_retired_exact",
+        "selected_exact_ids_match",
+    }
+)
+
+
+def _maintenance_target_states(action: MaintenanceAction) -> list[str]:
+    if action is MaintenanceAction.FINISH_CLEANUP:
+        return [
+            RolloverState.PREDECESSOR_ARCHIVED.value,
+            RolloverState.HEARTBEAT_RETIRED.value,
+        ]
+    return [
+        RolloverState.SUPERSEDED.value
+        if action is MaintenanceAction.SUPERSEDE
+        else RolloverState.ABANDONED_WITH_PROOF.value
+    ]
+
+
+def validate_maintenance_proof(
+    record: Mapping[str, Any],
+    *,
+    action: MaintenanceAction,
+    proof: Mapping[str, Any],
+) -> dict[str, Any]:
+    if _snapshot_key(proof) != _key(record):
+        raise ValueError("maintenance proof exact IDs do not match the selected registry record")
+    assertions = proof.get("assertions")
+    if not isinstance(assertions, Mapping):
+        raise ValueError("maintenance proof requires assertions")
+    required = _CLEANUP_ASSERTIONS if action is MaintenanceAction.FINISH_CLEANUP else _DISPOSITION_ASSERTIONS
+    missing = sorted(name for name in required if assertions.get(name) is not True)
+    if missing:
+        raise ValueError(f"maintenance proof lacks required true assertions: {', '.join(missing)}")
+    evidence_paths = proof.get("evidence_paths")
+    if not isinstance(evidence_paths, list) or not _dedupe_strings(evidence_paths):
+        raise ValueError("maintenance proof requires durable evidence_paths")
+    if parse_timestamp(proof.get("captured_at")) is None:
+        raise ValueError("maintenance proof requires an authoritative UTC captured_at")
+    state = RolloverState(str(record.get("state")))
+    if (
+        action in {MaintenanceAction.SUPERSEDE, MaintenanceAction.ABANDON}
+        and SUCCESS_RANK.get(RolloverState(str(record.get("last_successful_boundary"))), 0)
+        >= SUCCESS_RANK[RolloverState.CONFIRMED]
+    ):
+        raise ValueError("confirmed active rollover cannot be superseded or abandoned")
+    if action is MaintenanceAction.FINISH_CLEANUP and state not in {
+        RolloverState.CONFIRMED,
+        RolloverState.PREDECESSOR_ARCHIVED,
+        RolloverState.HEARTBEAT_RETIRED,
+    }:
+        raise ValueError("finish-cleanup requires an exact confirmed successor")
+    return {
+        "assertions": {name: True for name in sorted(required)},
+        "evidence_paths": _dedupe_strings(evidence_paths),
+        "captured_at": str(proof["captured_at"]),
+        "reason": str(proof.get("reason") or action.value),
+        "proof_digest": hashlib.sha256(canonical_json(dict(proof)).encode()).hexdigest(),
+    }
+
+
+def create_maintenance_plan(
+    state_root: Path,
+    *,
+    record: Mapping[str, Any],
+    action: MaintenanceAction,
+    proof: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_maintenance_proof(record, action=action, proof=proof)
+    _require_durable_paths(
+        state_root,
+        validated["evidence_paths"],
+        label="maintenance evidence path",
+    )
+    agent, lineage_id, rollover_id = _key(record)
+    payload = {
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "kind": "rollover_maintenance_plan",
+        "key": {"agent": agent, "lineage_id": lineage_id, "rollover_id": rollover_id},
+        "action": action.value,
+        "record_digest": sha256_digest(dict(record)),
+        "proof": validated,
+        "target_states": _maintenance_target_states(action),
+    }
+    digest = sha256_digest(payload)
+    payload["digest"] = digest
+    plan_path = (
+        record_path(state_root, agent=agent, lineage_id=lineage_id, rollover_id=rollover_id).parent
+        / "maintenance"
+        / action.value
+        / digest[:24]
+        / "plan.json"
+    )
+    with advisory_lock(lineage_lock_path(state_root, agent=agent, lineage_id=lineage_id)):
+        if plan_path.is_file() and _load_json(plan_path) != payload:
+            raise ValueError("immutable maintenance plan digest collision")
+        atomic_write_json(plan_path, payload)
+    return {**payload, "plan_path": _relative(plan_path, state_root)}
+
+
+def load_maintenance_plan(state_root: Path, *, plan_path: Path) -> tuple[Path, dict[str, Any]]:
+    """Load and validate an immutable plan without changing registry state."""
+    resolved = (state_root / plan_path).resolve() if not plan_path.is_absolute() else plan_path.resolve()
+    try:
+        resolved.relative_to(registry_root(state_root))
+    except ValueError as exc:
+        raise ValueError("maintenance plan must remain inside the canonical rollover registry") from exc
+    plan = _load_json(resolved)
+    if plan.get("schema_version") != REGISTRY_SCHEMA_VERSION or plan.get("kind") != "rollover_maintenance_plan":
+        raise ValueError("maintenance plan is malformed")
+    expected_plan_fields = {
+        "schema_version",
+        "kind",
+        "key",
+        "action",
+        "record_digest",
+        "proof",
+        "target_states",
+        "digest",
+    }
+    if set(plan) != expected_plan_fields:
+        raise ValueError("maintenance plan has missing or unexpected fields")
+    immutable = dict(plan)
+    digest = immutable.pop("digest", None)
+    if not isinstance(digest, str) or sha256_digest(immutable) != digest:
+        raise ValueError("maintenance plan digest mismatch")
+    key = plan.get("key")
+    if not isinstance(key, Mapping):
+        raise ValueError("maintenance plan key is missing")
+    agent, lineage_id, rollover_id = _snapshot_key(key)
+    try:
+        action = MaintenanceAction(str(plan.get("action")))
+    except ValueError as exc:
+        raise ValueError("maintenance plan action is malformed") from exc
+    if plan.get("target_states") != _maintenance_target_states(action):
+        raise ValueError("maintenance plan target states do not match its exact action")
+    record_digest = plan.get("record_digest")
+    if not isinstance(record_digest, str) or not re.fullmatch(r"[0-9a-f]{64}", record_digest):
+        raise ValueError("maintenance plan record digest is malformed")
+    proof = plan.get("proof")
+    if not isinstance(proof, Mapping):
+        raise ValueError("maintenance plan proof is missing")
+    if set(proof) != {"assertions", "evidence_paths", "captured_at", "reason", "proof_digest"}:
+        raise ValueError("maintenance plan proof has missing or unexpected fields")
+    assertions = proof.get("assertions")
+    required = _CLEANUP_ASSERTIONS if action is MaintenanceAction.FINISH_CLEANUP else _DISPOSITION_ASSERTIONS
+    if (
+        not isinstance(assertions, Mapping)
+        or set(assertions) != required
+        or not all(assertions.get(name) is True for name in required)
+    ):
+        raise ValueError("maintenance plan proof assertions do not match its exact action")
+    if not isinstance(proof.get("evidence_paths"), list) or not _dedupe_strings(proof["evidence_paths"]):
+        raise ValueError("maintenance plan proof has no durable evidence paths")
+    if parse_timestamp(proof.get("captured_at")) is None or not str(proof.get("reason") or "").strip():
+        raise ValueError("maintenance plan proof timestamp or reason is malformed")
+    proof_digest = proof.get("proof_digest")
+    if not isinstance(proof_digest, str) or not re.fullmatch(r"[0-9a-f]{64}", proof_digest):
+        raise ValueError("maintenance plan proof digest is malformed")
+    expected_path = (
+        record_path(
+            state_root,
+            agent=agent,
+            lineage_id=lineage_id,
+            rollover_id=rollover_id,
+        ).parent
+        / "maintenance"
+        / action.value
+        / digest[:24]
+        / "plan.json"
+    )
+    if resolved != expected_path:
+        raise ValueError("maintenance plan path does not match its exact key, action, and digest")
+    return resolved, plan
+
+
+def apply_maintenance_plan(state_root: Path, *, plan_path: Path) -> dict[str, Any]:
+    resolved, plan = load_maintenance_plan(state_root, plan_path=plan_path)
+    key = plan["key"]
+    agent, lineage_id, rollover_id = _snapshot_key(key)
+    receipt_path = resolved.parent / "receipt.json"
+    intent_path = resolved.parent / "apply-intent.json"
+
+    def existing_receipt() -> dict[str, Any] | None:
+        if not receipt_path.is_file():
+            return None
+        durable = _load_json(receipt_path)
+        if (
+            durable.get("kind") != "rollover_maintenance_receipt"
+            or durable.get("plan_digest") != plan.get("digest")
+            or durable.get("key") != key
+            or durable.get("action") != plan.get("action")
+        ):
+            raise ValueError("durable maintenance receipt conflicts with the exact plan")
+        return durable
+
+    if durable := existing_receipt():
+        return durable
+    with advisory_lock(lineage_lock_path(state_root, agent=agent, lineage_id=lineage_id)):
+        if durable := existing_receipt():
+            return durable
+        _, durable_plan = load_maintenance_plan(state_root, plan_path=resolved)
+        if durable_plan != plan:
+            raise ValueError("immutable maintenance plan changed before apply")
+        _require_durable_paths(
+            state_root,
+            plan["proof"]["evidence_paths"],
+            label="maintenance evidence path",
+        )
+        record = load_record(state_root, agent=agent, lineage_id=lineage_id, rollover_id=rollover_id)
+        operation_id = str(plan["digest"])
+        already_applied = any(event.get("operation_id") == operation_id for event in record.get("history", []))
+        if not already_applied and sha256_digest(record) != plan.get("record_digest"):
+            raise ValueError("registry record changed after maintenance planning; create a fresh exact plan")
+        intent = {
+            "schema_version": REGISTRY_SCHEMA_VERSION,
+            "kind": "rollover_maintenance_apply_intent",
+            "plan_digest": operation_id,
+            "key": dict(key),
+        }
+        if intent_path.is_file() and _load_json(intent_path) != intent:
+            raise ValueError("durable maintenance apply intent conflicts with the exact plan")
+        atomic_write_json(intent_path, intent)
+        for target_value in plan.get("target_states", []):
+            record = transition(
+                state_root,
+                agent=agent,
+                lineage_id=lineage_id,
+                rollover_id=rollover_id,
+                state=RolloverState(target_value),
+                reason=str(plan["proof"]["reason"]),
+                evidence_paths=plan["proof"]["evidence_paths"],
+                operation_id=operation_id,
+                already_locked=True,
+            )
+        receipt = {
+            "schema_version": REGISTRY_SCHEMA_VERSION,
+            "kind": "rollover_maintenance_receipt",
+            "plan_digest": operation_id,
+            "key": dict(key),
+            "action": plan["action"],
+            "final_state": record["state"],
+            "applied_at": isoformat_z(utc_now()),
+            "evidence_paths": plan["proof"]["evidence_paths"],
+        }
+        atomic_write_json(receipt_path, receipt)
+    return receipt
+
+
+def monitor_snapshot(state_root: Path) -> dict[str, Any]:
+    audit = audit_fleet(state_root)
+    return {
+        "schema_version": audit["schema_version"],
+        "generated_at": audit["generated_at"],
+        "counts": audit["counts"],
+        "entries": audit["entries"],
+        "errors": audit["errors"],
+    }

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -33,6 +33,7 @@ try:
     from scripts.orchestration import task_identity, thread_handoff_canary
     from scripts.orchestration.task_family import codex_state as task_family_codex_state
     from scripts.orchestration.task_family import rollover as task_family_rollover
+    from scripts.orchestration.task_family import rollover_registry as task_family_rollover_registry
     from scripts.orchestration.task_family.storage import advisory_lock as task_family_advisory_lock
 except ModuleNotFoundError as exc:
     if __package__ or exc.name != "scripts":
@@ -43,6 +44,7 @@ except ModuleNotFoundError as exc:
     import thread_handoff_canary
     from orchestration.task_family import codex_state as task_family_codex_state
     from orchestration.task_family import rollover as task_family_rollover
+    from orchestration.task_family import rollover_registry as task_family_rollover_registry
     from orchestration.task_family.storage import advisory_lock as task_family_advisory_lock
 
 SCHEMA_VERSION = 2
@@ -644,8 +646,14 @@ def normalize_identity_state(
     return normalized, migrated
 
 
-def write_rollover_state(state_path: Path, state_root: Path, state: dict[str, Any]) -> None:
-    """Persist the receipt first and the lease last as the transaction commit marker."""
+def write_rollover_state(
+    state_path: Path,
+    state_root: Path,
+    state: dict[str, Any],
+    *,
+    already_locked: bool = False,
+) -> None:
+    """Commit identity receipt and lease, then refresh the recoverable registry projection."""
     replacement = state.get("replacement") or {}
     receipt_value = replacement.get("identity_receipt_path")
     if not isinstance(receipt_value, str) or not receipt_value:
@@ -654,6 +662,12 @@ def write_rollover_state(state_path: Path, state_root: Path, state: dict[str, An
     receipt = task_identity.receipt_payload(state)
     write_json_atomic(receipt_path, receipt)
     write_json_atomic(state_path, state)
+    task_family_rollover_registry.sync_from_lease(
+        state_root,
+        state_path,
+        state,
+        already_locked=already_locked,
+    )
 
 
 def active_thread_id_from_env() -> str | None:
@@ -2200,7 +2214,7 @@ def _cmd_prepare_locked(args: argparse.Namespace) -> int:
             pending_native["supersedes"] = dict(supersedes)
             pending_replacement["native_lifecycle"] = pending_native
             pending_state["replacement"] = pending_replacement
-            write_rollover_state(state_path, state_root, pending_state)
+            write_rollover_state(state_path, state_root, pending_state, already_locked=True)
             task_family_rollover.supersede_unexecuted_transition(
                 repo_root=state_root,
                 family_id=supersedes["family_id"],
@@ -2221,7 +2235,7 @@ def _cmd_prepare_locked(args: argparse.Namespace) -> int:
             native_plan["supersedes"] = dict(supersedes)
             native_transition["status"] = "awaiting_native_create"
             native_transition["superseded"] = dict(supersedes)
-        write_rollover_state(state_path, state_root, prepared_state)
+        write_rollover_state(state_path, state_root, prepared_state, already_locked=True)
     except (OSError, ValueError) as exc:
         print(
             json.dumps(
@@ -2328,7 +2342,7 @@ def _native_command_context(
         raise ValueError(state_error["error"])
     state, migrated = normalize_identity_state(state, agent=agent, now=utc_now())
     if migrated:
-        write_rollover_state(state_path, state_root, state)
+        write_rollover_state(state_path, state_root, state, already_locked=True)
     replacement = state.get("replacement") or {}
     if replacement.get("rollover_id") != args.rollover_id:
         raise ValueError("--rollover-id does not match the isolated rollover")
@@ -2388,7 +2402,7 @@ def _identity_command_context(
     if replacement.get("rollover_id") != args.rollover_id:
         raise ValueError("--rollover-id does not match the isolated rollover")
     if migrated:
-        write_rollover_state(state_path, state_root, state)
+        write_rollover_state(state_path, state_root, state, already_locked=True)
     return repo_root, state_root, agent, state_path, state, replacement
 
 
@@ -2510,7 +2524,7 @@ def _cmd_repair_native_intent_locked(args: argparse.Namespace) -> int:
             supersedes=supersedes,
             task_identity_envelope=replacement["identity"],
         )
-        write_rollover_state(state_path, state_root, candidate_state)
+        write_rollover_state(state_path, state_root, candidate_state, already_locked=True)
         superseded = task_family_rollover.supersede_unexecuted_transition(
             repo_root=state_root,
             family_id=supersedes["family_id"],
@@ -2532,7 +2546,7 @@ def _cmd_repair_native_intent_locked(args: argparse.Namespace) -> int:
         candidate_replacement["native_lifecycle"] = candidate_native
         candidate_state["replacement"] = candidate_replacement
         candidate_state["updated_at"] = isoformat_z(utc_now())
-        write_rollover_state(state_path, state_root, candidate_state)
+        write_rollover_state(state_path, state_root, candidate_state, already_locked=True)
         _, final_error = validate_live_lease(candidate_state, agent=agent, state_path=state_path)
         if final_error:
             raise ValueError(f"persisted repaired lease failed validation: {final_error}")
@@ -2585,7 +2599,7 @@ def _write_native_status(
     replacement["native_lifecycle"] = native
     state["replacement"] = replacement
     state["updated_at"] = isoformat_z(utc_now())
-    write_rollover_state(state_path, state_root, state)
+    write_rollover_state(state_path, state_root, state, already_locked=True)
 
 
 def _record_identity_title_ack(
@@ -2659,7 +2673,7 @@ def _cmd_bind_replacement_locked(args: argparse.Namespace) -> int:
         updated_replacement["title_transition"] = bound_transition
         state["replacement"] = updated_replacement
         state["updated_at"] = isoformat_z(utc_now())
-        write_rollover_state(state_path, state_root, state)
+        write_rollover_state(state_path, state_root, state, already_locked=True)
     except (OSError, ValueError) as exc:
         print(json.dumps({"error": str(exc), "action": "bind-replacement"}, indent=2))
         return 2
@@ -2680,6 +2694,14 @@ def _cmd_bind_replacement_locked(args: argparse.Namespace) -> int:
 
 
 def cmd_register_created(args: argparse.Namespace) -> int:
+    lock_path = _rollover_mutation_lock_path(args)
+    if lock_path is None:
+        return _cmd_register_created_locked(args)
+    with task_family_advisory_lock(lock_path):
+        return _cmd_register_created_locked(args)
+
+
+def _cmd_register_created_locked(args: argparse.Namespace) -> int:
     state_root: Path | None = None
     native: dict[str, Any] | None = None
     try:
@@ -2755,8 +2777,6 @@ def cmd_register_created(args: argparse.Namespace) -> int:
 
 
 def cmd_native_action(args: argparse.Namespace) -> int:
-    if args.action != "create":
-        return _cmd_native_action_locked(args)
     lock_path = _rollover_mutation_lock_path(args)
     if lock_path is None:
         return _cmd_native_action_locked(args)
@@ -2829,6 +2849,14 @@ def _cmd_native_action_locked(args: argparse.Namespace) -> int:
 
 
 def cmd_record_native_result(args: argparse.Namespace) -> int:
+    lock_path = _rollover_mutation_lock_path(args)
+    if lock_path is None:
+        return _cmd_record_native_result_locked(args)
+    with task_family_advisory_lock(lock_path):
+        return _cmd_record_native_result_locked(args)
+
+
+def _cmd_record_native_result_locked(args: argparse.Namespace) -> int:
     try:
         _, state_root, _, state_path, state, native = _native_command_context(args)
         result = task_family_rollover.record_native_result(
@@ -2857,6 +2885,14 @@ def cmd_record_native_result(args: argparse.Namespace) -> int:
 
 
 def cmd_reconcile_native(args: argparse.Namespace) -> int:
+    lock_path = _rollover_mutation_lock_path(args)
+    if lock_path is None:
+        return _cmd_reconcile_native_locked(args)
+    with task_family_advisory_lock(lock_path):
+        return _cmd_reconcile_native_locked(args)
+
+
+def _cmd_reconcile_native_locked(args: argparse.Namespace) -> int:
     try:
         _, state_root, _, state_path, state, native = _native_command_context(args)
         db_path = task_family_rollover.resolve_db(args.db)
@@ -2921,7 +2957,7 @@ def _cmd_confirm_started_locked(args: argparse.Namespace) -> int:
     try:
         state, migrated = normalize_identity_state(state, agent=agent, now=utc_now())
         if migrated:
-            write_rollover_state(state_path, state_root, state)
+            write_rollover_state(state_path, state_root, state, already_locked=True)
     except (OSError, ValueError) as exc:
         print(json.dumps({"error": f"task identity migration failed: {exc}"}, indent=2))
         return 2
@@ -2963,7 +2999,7 @@ def _cmd_confirm_started_locked(args: argparse.Namespace) -> int:
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
         return 2
-    write_rollover_state(state_path, state_root, confirmed)
+    write_rollover_state(state_path, state_root, confirmed, already_locked=True)
     print(
         json.dumps(
             {
@@ -3025,7 +3061,7 @@ def _cmd_resume_locked(args: argparse.Namespace) -> int:
     try:
         state, migrated = normalize_identity_state(state, agent=agent, now=utc_now())
         if migrated:
-            write_rollover_state(state_path, state_root, state)
+            write_rollover_state(state_path, state_root, state, already_locked=True)
     except (OSError, ValueError) as exc:
         print(json.dumps({"error": f"task identity migration failed: {exc}"}, indent=2))
         return 2
@@ -3044,7 +3080,7 @@ def _cmd_resume_locked(args: argparse.Namespace) -> int:
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "state_file": rel(state_path, state_root)}, indent=2))
         return 2
-    write_rollover_state(state_path, state_root, resumed)
+    write_rollover_state(state_path, state_root, resumed, already_locked=True)
     replacement = resumed["replacement"]
     print(
         json.dumps(

--- a/tests/orchestration/task_family/test_rollover_registry.py
+++ b/tests/orchestration/task_family/test_rollover_registry.py
@@ -1,0 +1,1295 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration import rollover_registry_cli, task_identity
+from scripts.orchestration.task_family import rollover
+from scripts.orchestration.task_family import rollover_registry as registry
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _lease(
+    *,
+    agent: str = "codex",
+    lineage: str = "lineage-a1",
+    rollover_id: str = "rollover-r1",
+    source: str = "source-1",
+    replacement: str | None = None,
+    status: str = "pending_start",
+    prepared_at: str = "2026-07-16T09:00:00Z",
+) -> dict:
+    family_id, operation_id = rollover.transition_identity(
+        lineage_id=lineage,
+        generation=1,
+        rollover_id=rollover_id,
+    )
+    native_status = "awaiting_native_create"
+    if replacement:
+        native_status = "replacement_created_bound"
+    identity = task_identity.build_identity(
+        repository=task_identity.DEFAULT_REPOSITORY,
+        stream_epic=4707,
+        stream_epic_url=None,
+        github_issue_number=5296,
+        github_issue_url=None,
+        semantic_title=f"Registry test {lineage}",
+        task_family="thread-rollover",
+        role=agent,
+        predecessor_task_id=source,
+        replacement_task_id=None,
+        lineage_id=lineage,
+        generation=1,
+        terminal_goal="merge",
+    )
+    title_transition = task_identity.new_title_transition(
+        harness=task_identity.default_harness(agent),
+        visible_title_value=identity["visible_title"],
+        prepared_at=prepared_at,
+    )
+    if replacement:
+        identity, title_transition = task_identity.bind_replacement(
+            identity,
+            title_transition,
+            replacement_task_id=replacement,
+            evidence="Exact replacement binding fixture.",
+            now=prepared_at,
+        )
+        if title_transition["native_title_supported"]:
+            identity, title_transition = task_identity.record_title_acknowledgement(
+                identity,
+                title_transition,
+                replacement_task_id=replacement,
+                succeeded=True,
+                evidence="Exact native title acknowledgement fixture.",
+                error="",
+                now=prepared_at,
+            )
+            identity, title_transition = task_identity.record_title_readback(
+                identity,
+                title_transition,
+                replacement_task_id=replacement,
+                observed_title=identity["visible_title"],
+                succeeded=True,
+                evidence="Exact native title readback fixture.",
+                error="",
+                now=prepared_at,
+            )
+        if status == "resumed":
+            identity = task_identity.mark_resumed(
+                identity,
+                title_transition,
+                replacement_task_id=replacement,
+            )
+        elif status == "started":
+            identity = task_identity.mark_confirmed(
+                identity,
+                title_transition,
+                replacement_task_id=replacement,
+            )
+    result = {
+        "schema_version": 2,
+        "agent": agent,
+        "lineage_id": lineage,
+        "rollover_id": rollover_id,
+        "active": {
+            "thread_id": source,
+            "automation_id": "automation-1",
+            "generation": 0,
+            "lineage_id": lineage,
+            "started_at": prepared_at,
+            "last_seen_at": prepared_at,
+        },
+        "replacement": {
+            "rollover_id": rollover_id,
+            "lineage_id": lineage,
+            "generation": 1,
+            "status": status,
+            "prepared_at": prepared_at,
+            "thread_id": replacement if status == "started" else None,
+            "resumed_thread_id": replacement if status == "resumed" else None,
+            "display": {
+                "title": identity["visible_title"],
+                "title_source": "task_identity_v1",
+            },
+            "identity": identity,
+            "title_transition": title_transition,
+            "tracking": {"stream_epic": 4707, "github_issue": 5296},
+            "native_lifecycle": {
+                "family_id": family_id,
+                "operation_id": operation_id,
+                "source_thread_id": source,
+                "replacement_thread_id": replacement,
+                "status": native_status,
+            },
+            "runtime_path": f".agent/thread-rollovers/{agent}/{lineage}/generation-0001/{rollover_id}",
+            "handoff_path": f".agent/thread-rollovers/{agent}/{lineage}/generation-0001/{rollover_id}/handoff.md",
+            "bootstrap_prompt_path": f".agent/thread-rollovers/{agent}/{lineage}/generation-0001/{rollover_id}/bootstrap.md",
+            "semantic_snapshot_path": f".agent/thread-rollovers/{agent}/{lineage}/generation-0001/{rollover_id}/semantic-snapshot.json",
+            "strict_probe_path": f".agent/thread-rollovers/{agent}/{lineage}/generation-0001/{rollover_id}/strict-probe.json",
+            "strict_questions_path": f".agent/thread-rollovers/{agent}/{lineage}/generation-0001/{rollover_id}/strict-questions.json",
+            "strict_answers_path": f".agent/thread-rollovers/{agent}/{lineage}/generation-0001/{rollover_id}/strict-answers.json",
+            "strict_verdict_path": f".agent/thread-rollovers/{agent}/{lineage}/generation-0001/{rollover_id}/strict-verdict.json",
+            "canary_proof_path": f".agent/thread-rollovers/{agent}/{lineage}/generation-0001/{rollover_id}/canary-pass.json",
+        },
+        "cleanup": {
+            "old_automation_ready_to_delete": status == "started",
+            "reason": "test",
+        },
+        "updated_at": prepared_at,
+    }
+    if status == "started":
+        result["replacement"]["confirmed_at"] = prepared_at
+        result["replacement"]["strict_verdict"] = {"verdict": "PASS", "correct": 10, "k": 10}
+        result["replacement"]["canary_proof"] = {"status": "PASS"}
+    return result
+
+
+def _persist_lease(root: Path, lease: dict) -> Path:
+    path = root / ".agent" / "thread-rollovers" / lease["agent"] / lease["lineage_id"] / "lease.json"
+    _write_json(path, lease)
+    return path
+
+
+def _sync(root: Path, lease: dict) -> dict:
+    path = _persist_lease(root, lease)
+    return registry.sync_from_lease(root, path, lease)
+
+
+def _bound_identity_updates(record: dict, replacement_task_id: str) -> dict:
+    identity, title_transition = task_identity.bind_replacement(
+        record["task_identity"],
+        record["title_transition"],
+        replacement_task_id=replacement_task_id,
+        evidence="Exact native replacement fixture.",
+        now="2026-07-16T10:00:00Z",
+    )
+    if title_transition["native_title_supported"]:
+        identity, title_transition = task_identity.record_title_acknowledgement(
+            identity,
+            title_transition,
+            replacement_task_id=replacement_task_id,
+            succeeded=True,
+            evidence="Exact native title acknowledgement fixture.",
+            error="",
+            now="2026-07-16T10:00:00Z",
+        )
+        identity, title_transition = task_identity.record_title_readback(
+            identity,
+            title_transition,
+            replacement_task_id=replacement_task_id,
+            observed_title=identity["visible_title"],
+            succeeded=True,
+            evidence="Exact native title readback fixture.",
+            error="",
+            now="2026-07-16T10:00:00Z",
+        )
+    return {"task_identity": identity, "title_transition": title_transition}
+
+
+def _native_snapshot(record: dict, *, replacement_id: str | None, title: str | None = None) -> dict:
+    key = record["key"]
+    identity = record["task_identity"]
+    title_transition = record["title_transition"]
+    visible_title = identity["visible_title"]
+    confirmed = record["confirmation"]["state"] == "confirmed"
+    return {
+        "agent": key["agent"],
+        "lineage_id": key["lineage_id"],
+        "rollover_id": key["rollover_id"],
+        "captured_at": "2026-07-16T10:00:00Z",
+        "source": {
+            "thread_id": identity["predecessor_task_id"],
+            "archived": False,
+        },
+        "replacement": {
+            "created": replacement_id is not None,
+            "thread_id": replacement_id,
+            "title": title or visible_title,
+        },
+        "title_receipt": {
+            "supported": title_transition["native_title_supported"],
+            "replacement_thread_id": replacement_id,
+            "readback_confirmed": True,
+            "intended_title": visible_title,
+            "readback_title": visible_title,
+            **(
+                {"receipt_path": "evidence/title-readback.json"}
+                if title_transition["native_title_supported"]
+                else {"fallback_receipt_path": "evidence/title-fallback.json"}
+            ),
+        },
+        "confirmation": {
+            "confirmed": confirmed,
+            "replacement_thread_id": replacement_id if confirmed else None,
+            "proof_path": "evidence/confirmation.json" if confirmed else None,
+        },
+        "heartbeat": {
+            "automation_id": record["heartbeat"]["automation_id"],
+            "retired": False,
+            "cleanup_authorized": False,
+        },
+        "evidence_paths": ["evidence/native-app-snapshot.json"],
+    }
+
+
+def _disposition_proof(record: dict, *, reason: str = "operator adjudication") -> dict:
+    return {
+        **record["key"],
+        "captured_at": "2026-07-16T10:00:00Z",
+        "reason": reason,
+        "assertions": {
+            "not_confirmed_active": True,
+            "no_valid_replacement_owns_lineage": True,
+            "no_unrecorded_native_create": True,
+            "no_active_heartbeat_dependency": True,
+            "selected_exact_ids_match": True,
+        },
+        "evidence_paths": ["evidence/operator-adjudication.json"],
+    }
+
+
+def _cleanup_proof(record: dict) -> dict:
+    return {
+        **record["key"],
+        "captured_at": "2026-07-16T10:00:00Z",
+        "reason": "exact successor and native cleanup proved",
+        "assertions": {
+            "confirmed_successor_exact": True,
+            "predecessor_archived_exact": True,
+            "heartbeat_retirement_authorized": True,
+            "heartbeat_retired_exact": True,
+            "selected_exact_ids_match": True,
+        },
+        "evidence_paths": ["evidence/archive.json", "evidence/automation-retired.json"],
+    }
+
+
+def _persist_proof_evidence(root: Path, proof: dict) -> dict:
+    for path in proof["evidence_paths"]:
+        _write_json(root / path, {"kind": "test_evidence", "path": path})
+    return proof
+
+
+def _persist_snapshot_evidence(root: Path, snapshot: dict) -> dict:
+    paths = list(snapshot["evidence_paths"])
+    for container, key in (
+        (snapshot["title_receipt"], "receipt_path"),
+        (snapshot["title_receipt"], "fallback_receipt_path"),
+        (snapshot["confirmation"], "proof_path"),
+        (snapshot["source"], "archive_receipt_path"),
+        (snapshot["heartbeat"], "retirement_receipt_path"),
+    ):
+        value = container.get(key)
+        if isinstance(value, str):
+            paths.append(value)
+    for path in paths:
+        _write_json(root / path, {"kind": "test_evidence", "path": path})
+    return snapshot
+
+
+def test_four_pending_rollovers_allow_each_exact_selector(tmp_path: Path) -> None:
+    leases = [
+        _lease(lineage=f"lineage-a{index}", rollover_id=f"rollover-r{index}", source=f"source-{index}")
+        for index in range(1, 5)
+    ]
+    for lease in leases:
+        _sync(tmp_path, lease)
+
+    records, errors = registry.scan_records(tmp_path)
+    assert errors == []
+    assert len([record for record in records if registry.is_live_pending(record)]) == 4
+    selected = registry.select_exact(records, source_thread_id="source-3")
+    assert [record["key"]["rollover_id"] for record in selected] == ["rollover-r3"]
+    selected = registry.select_exact(records, lineage_id="lineage-a4", rollover_id="rollover-r4")
+    assert [record["task_identity"]["predecessor_task_id"] for record in selected] == ["source-4"]
+
+
+def test_cli_script_entrypoint_runs_from_repo_root(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    result = subprocess.run(
+        [
+            str(repo_root / ".venv/bin/python"),
+            str(repo_root / "scripts/orchestration/rollover_registry_cli.py"),
+            "--repo-root",
+            str(tmp_path),
+            "audit",
+        ],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["counts"]["total"] == 0
+
+
+@pytest.mark.parametrize("agent", ["codex", "claude", "gemini", "orchestrator"])
+def test_supported_agents_share_one_registry_contract(tmp_path: Path, agent: str) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(agent=agent, lineage=f"lineage-{agent}", rollover_id=f"rollover-{agent}"),
+    )
+
+    assert record["schema_version"] == registry.REGISTRY_SCHEMA_VERSION
+    assert record["key"] == {
+        "agent": agent,
+        "lineage_id": f"lineage-{agent}",
+        "rollover_id": f"rollover-{agent}",
+    }
+
+
+def test_generic_cli_is_fail_closed_with_actionable_candidates(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for index in range(1, 5):
+        _sync(
+            tmp_path,
+            _lease(lineage=f"lineage-c{index}", rollover_id=f"rollover-c{index}", source=f"source-c{index}"),
+        )
+
+    returncode = rollover_registry_cli.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert returncode == 2
+    assert payload["error"] == "multiple_live_pending_rollovers"
+    assert payload["mutation_allowed"] is False
+    assert len(payload["candidates"]) == 4
+    assert all(
+        {"title", "issue", "epic", "lineage_id", "rollover_id", "state", "age_seconds", "next_safe_action"}
+        <= candidate.keys()
+        for candidate in payload["candidates"]
+    )
+
+
+def test_generic_cli_refuses_single_candidate_when_another_source_is_corrupt(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _sync(tmp_path, _lease(lineage="lineage-only-visible", rollover_id="rollover-only-visible"))
+    corrupt = registry.registry_root(tmp_path) / "codex" / "lineage-hidden" / "rollover-hidden" / "record.json"
+    _write_json(corrupt, {"schema_version": 999})
+
+    returncode = rollover_registry_cli.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert returncode == 2
+    assert payload["error"] == "inconsistent_or_corrupt_rollover_sources"
+    assert payload["mutation_allowed"] is False
+    assert len(payload["candidates"]) == 1
+    assert payload["registry_errors"][0]["path"].endswith("record.json")
+
+
+def test_exact_cli_selector_ignores_unrelated_pending(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    for index in range(1, 5):
+        _sync(
+            tmp_path,
+            _lease(lineage=f"lineage-e{index}", rollover_id=f"rollover-e{index}", source=f"source-e{index}"),
+        )
+
+    returncode = rollover_registry_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "detect",
+            "--source-thread-id",
+            "source-e3",
+            "--lineage-id",
+            "lineage-e3",
+            "--rollover-id",
+            "rollover-e3",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert returncode == 0
+    assert payload["candidate"]["rollover_id"] == "rollover-e3"
+    assert payload["unrelated_live_pending"] == 3
+
+
+def test_wrong_lineage_rollover_pairing_finds_no_record(tmp_path: Path) -> None:
+    _sync(tmp_path, _lease(lineage="lineage-a1", rollover_id="rollover-r1", source="source-1"))
+    _sync(tmp_path, _lease(lineage="lineage-a2", rollover_id="rollover-r2", source="source-2"))
+    records, _ = registry.scan_records(tmp_path)
+
+    assert registry.select_exact(records, lineage_id="lineage-a1", rollover_id="rollover-r2") == []
+
+
+def test_confirmed_rollover_is_not_live_and_requires_cleanup(tmp_path: Path) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-f039",
+            rollover_id="rollover-f039",
+            source="source-f039",
+            replacement="replacement-f039",
+            status="started",
+        ),
+    )
+
+    assert record["state"] == registry.RolloverState.CONFIRMED.value
+    assert record["strict_recall"] == {
+        "state": "passed",
+        "score": 10,
+        "verdict_path": (
+            ".agent/thread-rollovers/codex/lineage-f039/generation-0001/"
+            "rollover-f039/strict-verdict.json"
+        ),
+    }
+    assert not registry.is_live_pending(record)
+    audit = registry.audit_fleet(tmp_path, now=datetime(2026, 7, 16, 10, tzinfo=UTC))
+    assert audit["entries"][0]["classification"] == "confirmed but incompletely cleaned"
+
+
+def test_incident_shape_allows_exact_aef219_and_leaves_unrelated_packets_untouched(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    confirmed = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-f039",
+            rollover_id="rollover-f039",
+            source="source-f039",
+            replacement="replacement-f039",
+            status="started",
+        ),
+    )
+    target = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-4ad435086af0f3a1111550d8",
+            rollover_id="rollover-aef219c119ed4141919c2e7fd90860a8",
+            source="source-aef219",
+        ),
+    )
+    unrelated = [
+        _sync(
+            tmp_path,
+            _lease(
+                lineage=f"lineage-unrelated-{index}",
+                rollover_id=f"rollover-unrelated-{index}",
+                source=f"source-unrelated-{index}",
+            ),
+        )
+        for index in range(1, 4)
+    ]
+
+    rc = rollover_registry_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "detect",
+            "--agent",
+            "codex",
+            "--source-thread-id",
+            "source-aef219",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    audit = registry.audit_fleet(tmp_path)
+
+    assert rc == 0
+    assert payload["candidate"]["rollover_id"] == target["key"]["rollover_id"]
+    assert audit["counts"]["live_pending"] == 4
+    assert not registry.is_live_pending(confirmed)
+    for packet in unrelated:
+        current = registry.load_record(tmp_path, **packet["key"])
+        assert current["state"] == registry.RolloverState.AWAITING_NATIVE_CREATE.value
+
+
+def test_stale_age_is_read_only_and_never_deletes_packet(tmp_path: Path) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-stale",
+            rollover_id="rollover-stale",
+            prepared_at="2026-07-01T00:00:00Z",
+        ),
+    )
+    path = registry.record_path(tmp_path, **record["key"])
+    before = path.read_bytes()
+
+    audit = registry.audit_fleet(
+        tmp_path,
+        stale_hours=12,
+        now=datetime(2026, 7, 16, 10, tzinfo=UTC),
+    )
+
+    assert audit["entries"][0]["classification"] == "stale and requiring operator adjudication"
+    assert path.read_bytes() == before
+
+
+def test_authoritative_reconciliation_records_unrecorded_successor_once(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-unrecorded", rollover_id="rollover-unrecorded"))
+    snapshot = _native_snapshot(record, replacement_id="replacement-authoritative")
+    _persist_snapshot_evidence(tmp_path, snapshot)
+    report = registry.reconcile_snapshot(record, snapshot)
+    assert report["proposed_transitions"] == [registry.RolloverState.REPLACEMENT_CREATED.value]
+
+    receipt = registry.apply_reconciliation(tmp_path, record=record, snapshot=snapshot)
+    repeated = registry.apply_reconciliation(tmp_path, record=record, snapshot=snapshot)
+    receipt_path = next(registry.record_path(tmp_path, **record["key"]).parent.glob("reconciliation/*/receipt.json"))
+    receipt_path.unlink()
+    crash_retry = registry.apply_reconciliation(tmp_path, record=record, snapshot=snapshot)
+    current = registry.load_record(tmp_path, **record["key"])
+
+    assert receipt == repeated
+    assert crash_retry["snapshot_digest"] == receipt["snapshot_digest"]
+    assert current["task_identity"]["replacement_task_id"] == "replacement-authoritative"
+    assert current["state"] == registry.RolloverState.REPLACEMENT_CREATED.value
+
+
+def test_reconciliation_never_infers_creation_from_title(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-title", rollover_id="rollover-title"))
+    snapshot = _native_snapshot(record, replacement_id=None, title=record["task_identity"]["visible_title"])
+
+    report = registry.reconcile_snapshot(record, snapshot)
+
+    assert report["proposed_transitions"] == []
+    assert report["consistent"] is False
+    assert "title receipt cannot exist" in " ".join(report["discrepancies"])
+    assert record["state"] == registry.RolloverState.AWAITING_NATIVE_CREATE.value
+
+
+def test_reconciliation_applies_exact_confirm_archive_and_retire_boundaries(tmp_path: Path) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-reconciled-cleanup",
+            rollover_id="rollover-reconciled-cleanup",
+            replacement="replacement-reconciled-cleanup",
+            status="resumed",
+        ),
+    )
+    for state in (registry.RolloverState.STRICT_RECALL_PASSED, registry.RolloverState.CANARY_PASSED):
+        record = registry.transition(tmp_path, **record["key"], state=state, reason="exact test proof")
+    snapshot = _native_snapshot(record, replacement_id=record["task_identity"]["replacement_task_id"])
+    snapshot["confirmation"] = {
+        "confirmed": True,
+        "replacement_thread_id": record["task_identity"]["replacement_task_id"],
+        "proof_path": "evidence/confirmation.json",
+    }
+    snapshot["source"] |= {
+        "archived": True,
+        "archive_receipt_path": "evidence/archive.json",
+    }
+    snapshot["heartbeat"] |= {
+        "retired": True,
+        "cleanup_authorized": True,
+        "retirement_receipt_path": "evidence/heartbeat-retirement.json",
+    }
+    _persist_snapshot_evidence(tmp_path, snapshot)
+
+    report = registry.reconcile_snapshot(record, snapshot)
+    receipt = registry.apply_reconciliation(tmp_path, record=record, snapshot=snapshot)
+    current = registry.load_record(tmp_path, **record["key"])
+
+    assert report["consistent"] is True
+    assert report["proposed_transitions"] == [
+        registry.RolloverState.CONFIRMED.value,
+        registry.RolloverState.PREDECESSOR_ARCHIVED.value,
+        registry.RolloverState.HEARTBEAT_RETIRED.value,
+    ]
+    assert receipt["applied_transitions"] == report["proposed_transitions"]
+    assert current["state"] == registry.RolloverState.HEARTBEAT_RETIRED.value
+    assert set(report["receipt_paths"]) <= set(current["receipts"])
+
+
+def test_reconciliation_rejects_missing_authoritative_confirmation(tmp_path: Path) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-confirmed-mismatch",
+            rollover_id="rollover-confirmed-mismatch",
+            replacement="replacement-confirmed-mismatch",
+            status="started",
+        ),
+    )
+    snapshot = _native_snapshot(record, replacement_id=record["task_identity"]["replacement_task_id"])
+    snapshot["confirmation"] = {
+        "confirmed": False,
+        "replacement_thread_id": None,
+        "proof_path": None,
+    }
+
+    report = registry.reconcile_snapshot(record, snapshot)
+
+    assert report["consistent"] is False
+    assert "authoritative confirmation proof is absent" in " ".join(report["discrepancies"])
+
+
+def test_reconciliation_rejects_cross_lineage_snapshot(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-one", rollover_id="rollover-one"))
+    snapshot = _native_snapshot(record, replacement_id="replacement-one")
+    snapshot["lineage_id"] = "lineage-other"
+
+    with pytest.raises(ValueError, match="exact IDs"):
+        registry.reconcile_snapshot(record, snapshot)
+
+
+def test_reconciliation_rejects_title_receipt_for_another_replacement(tmp_path: Path) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-title-receipt",
+            rollover_id="rollover-title-receipt",
+            replacement="replacement-title-receipt",
+            status="resumed",
+        ),
+    )
+    snapshot = _native_snapshot(record, replacement_id="replacement-title-receipt")
+    snapshot["title_receipt"]["replacement_thread_id"] = "replacement-other"
+
+    report = registry.reconcile_snapshot(record, snapshot)
+
+    assert report["consistent"] is False
+    assert "title receipt does not identify the exact native replacement" in report["discrepancies"]
+
+
+def test_reconciliation_rejects_archival_without_exact_confirmation(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-archive", rollover_id="rollover-archive"))
+    snapshot = _native_snapshot(record, replacement_id="replacement-archive")
+    snapshot["source"]["archived"] = True
+    snapshot["source"]["archive_receipt_path"] = "evidence/archive.json"
+
+    result = registry.reconcile_snapshot(record, snapshot)
+
+    assert result["consistent"] is False
+    assert "predecessor archival lacks exact confirmed-successor proof" in result["discrepancies"]
+
+
+def test_reconciliation_rejects_premature_heartbeat_cleanup_authorization(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-premature", rollover_id="rollover-premature"))
+    snapshot = _native_snapshot(record, replacement_id="replacement-premature")
+    snapshot["heartbeat"]["cleanup_authorized"] = True
+
+    result = registry.reconcile_snapshot(record, snapshot)
+
+    assert result["consistent"] is False
+    assert "cleanup authorization precedes" in " ".join(result["discrepancies"])
+
+
+def test_projection_rejects_duplicate_successor_for_exact_rollover(tmp_path: Path) -> None:
+    first = _lease(
+        lineage="lineage-duplicate",
+        rollover_id="rollover-duplicate",
+        replacement="replacement-one",
+        status="resumed",
+    )
+    _sync(tmp_path, first)
+    duplicate = _lease(
+        lineage="lineage-duplicate",
+        rollover_id="rollover-duplicate",
+        replacement="replacement-two",
+        status="resumed",
+    )
+
+    with pytest.raises(ValueError, match="replacement_task_id conflicts"):
+        _sync(tmp_path, duplicate)
+
+
+def test_supersede_requires_proof_plan_and_idempotent_apply(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-sup", rollover_id="rollover-sup"))
+    bad_proof = _disposition_proof(record)
+    bad_proof["assertions"]["no_unrecorded_native_create"] = False
+    with pytest.raises(ValueError, match="no_unrecorded_native_create"):
+        registry.create_maintenance_plan(
+            tmp_path,
+            record=record,
+            action=registry.MaintenanceAction.SUPERSEDE,
+            proof=bad_proof,
+        )
+
+    plan = registry.create_maintenance_plan(
+        tmp_path,
+        record=record,
+        action=registry.MaintenanceAction.SUPERSEDE,
+        proof=_persist_proof_evidence(tmp_path, _disposition_proof(record)),
+    )
+    receipt = registry.apply_maintenance_plan(tmp_path, plan_path=Path(plan["plan_path"]))
+    Path(tmp_path / plan["plan_path"]).parent.joinpath("receipt.json").unlink()
+    crash_retry = registry.apply_maintenance_plan(tmp_path, plan_path=Path(plan["plan_path"]))
+
+    assert receipt["final_state"] == registry.RolloverState.SUPERSEDED.value
+    assert crash_retry["final_state"] == registry.RolloverState.SUPERSEDED.value
+    assert not registry.is_live_pending(registry.load_record(tmp_path, **record["key"]))
+
+
+def test_maintenance_refuses_non_durable_evidence_paths(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-evidence", rollover_id="rollover-evidence"))
+
+    with pytest.raises(ValueError, match="does not exist as durable evidence"):
+        registry.create_maintenance_plan(
+            tmp_path,
+            record=record,
+            action=registry.MaintenanceAction.SUPERSEDE,
+            proof=_disposition_proof(record),
+        )
+
+
+def test_maintenance_apply_revalidates_action_target_semantics(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-forged", rollover_id="rollover-forged"))
+    plan = registry.create_maintenance_plan(
+        tmp_path,
+        record=record,
+        action=registry.MaintenanceAction.SUPERSEDE,
+        proof=_persist_proof_evidence(tmp_path, _disposition_proof(record)),
+    )
+    plan_path = tmp_path / plan["plan_path"]
+    forged = json.loads(plan_path.read_text(encoding="utf-8"))
+    forged["target_states"] = [registry.RolloverState.ABANDONED_WITH_PROOF.value]
+    unsigned = dict(forged)
+    unsigned.pop("digest")
+    forged["digest"] = registry.sha256_digest(unsigned)
+    _write_json(plan_path, forged)
+
+    with pytest.raises(ValueError, match="target states do not match"):
+        registry.apply_maintenance_plan(tmp_path, plan_path=plan_path)
+
+    assert registry.load_record(tmp_path, **record["key"])["state"] == record["state"]
+
+
+def test_blocked_packet_is_visible_but_not_mutation_authorized(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-blocked-resume",
+            rollover_id="rollover-blocked-resume",
+            replacement="replacement-blocked-resume",
+            status="resumed",
+        ),
+    )
+    registry.transition(
+        tmp_path,
+        **record["key"],
+        state=registry.RolloverState.BLOCKED,
+        reason="exact title proof missing",
+    )
+
+    detect_rc = rollover_registry_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "detect",
+            "--lineage-id",
+            record["key"]["lineage_id"],
+            "--rollover-id",
+            record["key"]["rollover_id"],
+        ]
+    )
+    detected = json.loads(capsys.readouterr().out)
+    resume_rc = rollover_registry_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "resume-exact",
+            "--lineage-id",
+            record["key"]["lineage_id"],
+            "--rollover-id",
+            record["key"]["rollover_id"],
+            "--replacement-thread-id",
+            "replacement-blocked-resume",
+        ]
+    )
+
+    assert detect_rc == 0
+    assert detected["mutation_allowed"] is False
+    assert resume_rc == 2
+    assert "requires reconciliation or maintenance" in capsys.readouterr().out
+
+
+def test_failed_native_boundary_projects_as_blocked(tmp_path: Path) -> None:
+    lease = _lease(lineage="lineage-native-failed", rollover_id="rollover-native-failed")
+    lease["replacement"]["native_lifecycle"]["status"] = "title_readback_failed"
+
+    record = _sync(tmp_path, lease)
+
+    assert record["state"] == registry.RolloverState.BLOCKED.value
+    assert record["last_successful_boundary"] == registry.RolloverState.AWAITING_NATIVE_CREATE.value
+    assert record["blocking_reason"] == "native rollover boundary blocked: title_readback_failed"
+    assert registry.allows_exact_progress(record) is False
+
+
+def test_existing_registry_projects_new_native_failure_as_blocked(tmp_path: Path) -> None:
+    lease = _lease(lineage="lineage-new-failure", rollover_id="rollover-new-failure")
+    _sync(tmp_path, lease)
+    lease["replacement"]["native_lifecycle"]["status"] = "native_create_failed"
+
+    blocked = _sync(tmp_path, lease)
+
+    assert blocked["state"] == registry.RolloverState.BLOCKED.value
+    assert blocked["last_successful_boundary"] == registry.RolloverState.AWAITING_NATIVE_CREATE.value
+    assert blocked["blocking_reason"] == "native rollover boundary blocked: native_create_failed"
+    assert registry.allows_exact_progress(blocked) is False
+
+
+def test_blocked_packet_cannot_be_cleared_at_the_same_boundary(tmp_path: Path) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-blocked-boundary",
+            rollover_id="rollover-blocked-boundary",
+            replacement="replacement-blocked-boundary",
+            status="resumed",
+        ),
+    )
+    registry.transition(
+        tmp_path,
+        **record["key"],
+        state=registry.RolloverState.BLOCKED,
+        reason="authoritative proof missing",
+    )
+
+    with pytest.raises(ValueError, match="authoritative proof beyond"):
+        registry.transition(
+            tmp_path,
+            **record["key"],
+            state=registry.RolloverState.RESUMED,
+            reason="unproved unblock",
+        )
+
+
+def test_cli_rejects_wrong_exact_plan_before_mutation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    selected = _sync(tmp_path, _lease(lineage="lineage-selected", rollover_id="rollover-selected"))
+    other = _sync(tmp_path, _lease(lineage="lineage-other", rollover_id="rollover-other"))
+    plan = registry.create_maintenance_plan(
+        tmp_path,
+        record=other,
+        action=registry.MaintenanceAction.SUPERSEDE,
+        proof=_persist_proof_evidence(tmp_path, _disposition_proof(other)),
+    )
+
+    rc = rollover_registry_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "supersede-exact",
+            "--lineage-id",
+            selected["key"]["lineage_id"],
+            "--rollover-id",
+            selected["key"]["rollover_id"],
+            "--apply",
+            "--plan-file",
+            plan["plan_path"],
+        ]
+    )
+
+    assert rc == 2
+    assert "exact IDs do not match the selected registry record" in capsys.readouterr().out
+    current = registry.load_record(tmp_path, **other["key"])
+    assert current["state"] == registry.RolloverState.AWAITING_NATIVE_CREATE.value
+
+
+def test_abandonment_refuses_confirmed_active_rollover(tmp_path: Path) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-confirmed",
+            rollover_id="rollover-confirmed",
+            replacement="replacement-confirmed",
+            status="started",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="confirmed active"):
+        registry.create_maintenance_plan(
+            tmp_path,
+            record=record,
+            action=registry.MaintenanceAction.ABANDON,
+            proof=_disposition_proof(record),
+        )
+
+
+def test_finish_cleanup_requires_exact_confirmation_and_heartbeat_proof(tmp_path: Path) -> None:
+    record = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-cleanup",
+            rollover_id="rollover-cleanup",
+            replacement="replacement-cleanup",
+            status="started",
+        ),
+    )
+    plan = registry.create_maintenance_plan(
+        tmp_path,
+        record=record,
+        action=registry.MaintenanceAction.FINISH_CLEANUP,
+        proof=_persist_proof_evidence(tmp_path, _cleanup_proof(record)),
+    )
+
+    receipt = registry.apply_maintenance_plan(tmp_path, plan_path=Path(plan["plan_path"]))
+    current = registry.load_record(tmp_path, **record["key"])
+
+    assert receipt["final_state"] == registry.RolloverState.HEARTBEAT_RETIRED.value
+    assert current["predecessor_archival"]["state"] == "archived"
+    assert current["heartbeat"]["state"] == "retired"
+    assert registry.classify(
+        current,
+        now=datetime(2026, 7, 16, 10, tzinfo=UTC),
+        stale_after=timedelta(hours=24),
+    ) is registry.AuditClassification.CONFIRMED_FULLY_CLEANED
+
+
+def test_one_lineage_confirmation_never_authorizes_another_cleanup(tmp_path: Path) -> None:
+    first = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-cleanup-one",
+            rollover_id="rollover-cleanup-one",
+            replacement="replacement-cleanup-one",
+            status="started",
+        ),
+    )
+    second = _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-cleanup-two",
+            rollover_id="rollover-cleanup-two",
+            replacement="replacement-cleanup-two",
+            status="started",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="exact IDs"):
+        registry.create_maintenance_plan(
+            tmp_path,
+            record=second,
+            action=registry.MaintenanceAction.FINISH_CLEANUP,
+            proof=_cleanup_proof(first),
+        )
+
+
+def test_migration_preserves_legacy_paths_and_proofs(tmp_path: Path) -> None:
+    lease = _lease(lineage="lineage-migrate", rollover_id="rollover-migrate")
+    lease_path = _persist_lease(tmp_path, lease)
+    proof_path = lease_path.parent / "generation-0001" / "rollover-migrate" / "legacy-proof.json"
+    _write_json(proof_path, {"status": "legacy-proof"})
+    lease["replacement"]["canary_proof_path"] = proof_path.relative_to(tmp_path).as_posix()
+    _write_json(lease_path, lease)
+
+    plan = registry.migrate_existing(tmp_path, apply=False, evidence="")
+    applied = registry.migrate_existing(tmp_path, apply=True, evidence="operator-approved non-destructive import")
+    record = registry.load_record(
+        tmp_path,
+        agent="codex",
+        lineage_id="lineage-migrate",
+        rollover_id="rollover-migrate",
+    )
+
+    assert plan["mode"] == "plan"
+    assert applied["written"] == 1
+    assert lease_path.relative_to(tmp_path).as_posix() in record["evidence_paths"]
+    assert proof_path.relative_to(tmp_path).as_posix() in record["evidence_paths"]
+    assert any("non-destructive registry migration" in event["reason"] for event in record["history"])
+
+
+def test_task_family_migration_preserves_blocked_state_after_exact_binding(tmp_path: Path) -> None:
+    operation_root = (
+        tmp_path
+        / ".agent"
+        / "task-families"
+        / "rollover-lineage-plan-blocked"
+        / "operations"
+        / "operation-plan-blocked"
+    )
+    plan_path = operation_root / "rollover-plan.json"
+    _write_json(
+        plan_path,
+        {
+            "agent": "codex",
+            "family_id": "rollover-lineage-plan-blocked",
+            "operation_id": "operation-plan-blocked",
+            "lineage_id": "lineage-plan-blocked",
+            "rollover_id": "rollover-plan-blocked",
+            "source_thread_id": "source-plan-blocked",
+            "generation": 1,
+            "intended_title": "INFRA #5296 — Fleet rollover registry",
+        },
+    )
+    _write_json(operation_root / "state.json", {"state": "blocked", "details": {"status": "title_failed"}})
+    _write_json(operation_root / "rollover-binding.json", {"replacement_thread_id": "replacement-plan-blocked"})
+
+    records, errors = registry.discover_legacy_records(tmp_path)
+    record = records[("codex", "lineage-plan-blocked", "rollover-plan-blocked")]
+
+    assert errors == []
+    assert record["state"] == registry.RolloverState.BLOCKED.value
+    assert record["last_successful_boundary"] == registry.RolloverState.REPLACEMENT_CREATED.value
+    assert record["task_identity"]["replacement_task_id"] == "replacement-plan-blocked"
+    assert registry.allows_exact_progress(record) is False
+
+
+def test_corrupt_registry_entry_is_classified_without_hiding_valid_entries(tmp_path: Path) -> None:
+    _sync(tmp_path, _lease(lineage="lineage-valid", rollover_id="rollover-valid"))
+    corrupt = registry.registry_root(tmp_path) / "codex" / "lineage-corrupt" / "rollover-corrupt" / "record.json"
+    _write_json(corrupt, {"schema_version": 999})
+
+    audit = registry.audit_fleet(tmp_path)
+
+    assert audit["counts"]["total"] == 2
+    assert audit["counts"]["corrupt"] == 1
+    assert any(
+        entry["classification"] == registry.AuditClassification.INCONSISTENT_CORRUPT.value for entry in audit["entries"]
+    )
+    assert audit["errors"][0]["path"].endswith("record.json")
+
+
+def test_audit_classifies_packet_with_corrupt_referenced_lease_once(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-corrupt-lease", rollover_id="rollover-corrupt-lease"))
+    (tmp_path / record["lease_path"]).write_text("{not-json\n", encoding="utf-8")
+
+    audit = registry.audit_fleet(tmp_path)
+
+    assert audit["counts"] == {"total": 1, "live_pending": 0, "corrupt": 1}
+    assert audit["entries"][0]["classification"] == registry.AuditClassification.INCONSISTENT_CORRUPT.value
+    assert audit["entries"][0]["source_errors"][0]["path"] == record["lease_path"]
+
+
+def test_audit_fails_closed_on_corrupt_referenced_task_family_receipt(tmp_path: Path) -> None:
+    lease = _lease(lineage="lineage-corrupt-receipt", rollover_id="rollover-corrupt-receipt")
+    record = _sync(tmp_path, lease)
+    native = lease["replacement"]["native_lifecycle"]
+    receipt_path = (
+        tmp_path
+        / ".agent"
+        / "task-families"
+        / native["family_id"]
+        / "operations"
+        / native["operation_id"]
+        / "receipt.json"
+    )
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text("{not-json\n", encoding="utf-8")
+
+    audit = registry.audit_fleet(tmp_path)
+
+    assert audit["counts"] == {"total": 1, "live_pending": 0, "corrupt": 1}
+    assert audit["entries"][0]["classification"] == registry.AuditClassification.INCONSISTENT_CORRUPT.value
+    assert audit["entries"][0]["source_errors"][0]["path"] == record["lease_path"]
+    assert "receipt.json" in audit["entries"][0]["source_errors"][0]["error"]
+
+
+def test_exact_selector_refuses_corrupt_authoritative_record(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-corrupt-exact", rollover_id="rollover-corrupt-exact"))
+    _write_json(registry.record_path(tmp_path, **record["key"]), {"schema_version": 999})
+
+    rc = rollover_registry_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "detect",
+            "--source-thread-id",
+            record["task_identity"]["predecessor_task_id"],
+        ]
+    )
+
+    assert rc == 2
+    assert "corrupt durable source" in capsys.readouterr().out
+
+
+def test_record_source_errors_includes_referenced_evidence_paths(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-source-error", rollover_id="rollover-source-error"))
+    record["evidence_paths"].append("evidence/corrupt-receipt.json")
+    source_error = {"path": "evidence/corrupt-receipt.json", "error": "invalid JSON"}
+
+    assert registry.record_source_errors(tmp_path, record, [source_error]) == [source_error]
+
+
+def test_transition_cannot_skip_required_boundaries(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-boundary", rollover_id="rollover-boundary"))
+
+    with pytest.raises(ValueError, match="cannot skip"):
+        registry.transition(
+            tmp_path,
+            **record["key"],
+            state=registry.RolloverState.CONFIRMED,
+            reason="invalid direct confirmation",
+        )
+
+
+def test_native_task_family_paths_reject_traversal(tmp_path: Path) -> None:
+    lease = _lease(lineage="lineage-path", rollover_id="rollover-path")
+    lease["replacement"]["native_lifecycle"]["operation_id"] = "../outside"
+    lease_path = _persist_lease(tmp_path, lease)
+
+    with pytest.raises(ValueError, match="path-safe component"):
+        registry.sync_from_lease(tmp_path, lease_path, lease)
+
+    assert not (tmp_path / ".agent" / "task-families" / "outside").exists()
+
+
+def test_registry_storage_rejects_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    agent_root = tmp_path / ".agent"
+    agent_root.mkdir()
+    (agent_root / "thread-rollover-registry").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="inside the repository state root"):
+        registry.record_path(
+            tmp_path,
+            agent="codex",
+            lineage_id="lineage-symlink",
+            rollover_id="rollover-symlink",
+        )
+
+
+def test_registry_record_rejects_absolute_evidence_path(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-path-proof", rollover_id="rollover-path-proof"))
+    record["evidence_paths"] = ["/tmp/untrusted-proof.json"]
+
+    with pytest.raises(ValueError, match="repository-relative"):
+        registry.validate_record(record)
+
+
+def test_stale_lease_projection_cannot_regress_a_blocked_boundary(tmp_path: Path) -> None:
+    lease = _lease(lineage="lineage-blocked", rollover_id="rollover-blocked")
+    record = _sync(tmp_path, lease)
+    created = registry.transition(
+        tmp_path,
+        **record["key"],
+        state=registry.RolloverState.REPLACEMENT_CREATED,
+        reason="native successor recorded",
+        updates=_bound_identity_updates(record, "replacement-blocked"),
+    )
+    blocked = registry.transition(
+        tmp_path,
+        **record["key"],
+        state=registry.RolloverState.BLOCKED,
+        reason="awaiting exact title proof",
+    )
+
+    projected = registry.sync_from_lease(
+        tmp_path,
+        tmp_path / blocked["lease_path"],
+        lease,
+    )
+
+    assert created["last_successful_boundary"] == registry.RolloverState.REPLACEMENT_CREATED.value
+    assert projected["state"] == registry.RolloverState.BLOCKED.value
+    assert projected["last_successful_boundary"] == registry.RolloverState.REPLACEMENT_CREATED.value
+    assert projected["native_creation"]["state"] == "replacement_created"
+
+
+def test_stale_terminal_projection_cannot_supersede_a_created_replacement(tmp_path: Path) -> None:
+    lease = _lease(lineage="lineage-stale-terminal", rollover_id="rollover-stale-terminal")
+    record = _sync(tmp_path, lease)
+    created = registry.transition(
+        tmp_path,
+        **record["key"],
+        state=registry.RolloverState.REPLACEMENT_CREATED,
+        reason="native successor recorded",
+        updates=_bound_identity_updates(record, "replacement-stale-terminal"),
+    )
+    native = lease["replacement"]["native_lifecycle"]
+    task_state_path = (
+        tmp_path
+        / ".agent"
+        / "task-families"
+        / native["family_id"]
+        / "operations"
+        / native["operation_id"]
+        / "state.json"
+    )
+    _write_json(task_state_path, {"state": "completed", "details": {"status": "superseded_before_native_create"}})
+
+    projected = registry.sync_from_lease(tmp_path, tmp_path / created["lease_path"], lease)
+
+    assert projected["state"] == registry.RolloverState.REPLACEMENT_CREATED.value
+    assert projected["last_successful_boundary"] == registry.RolloverState.REPLACEMENT_CREATED.value
+    assert not any(event["state"] == registry.RolloverState.SUPERSEDED.value for event in projected["history"])
+
+
+def test_cold_cleanup_failure_preserves_confirmed_non_live_state(tmp_path: Path) -> None:
+    lease = _lease(
+        lineage="lineage-cold-blocked",
+        rollover_id="rollover-cold-blocked",
+        replacement="replacement-cold-blocked",
+        status="started",
+    )
+    lease["replacement"]["native_lifecycle"]["status"] = "archive_authorization_blocked"
+
+    record = _sync(tmp_path, lease)
+
+    assert record["state"] == registry.RolloverState.CONFIRMED.value
+    assert record["last_successful_boundary"] == registry.RolloverState.CONFIRMED.value
+    assert record["blocking_reason"].startswith("native rollover boundary blocked")
+    assert registry.is_live_pending(record) is False
+
+
+def test_catchup_to_confirmed_preserves_cleanup_blocker_in_fleet_summary(tmp_path: Path) -> None:
+    _sync(
+        tmp_path,
+        _lease(
+            lineage="lineage-confirmed-catchup",
+            rollover_id="rollover-confirmed-catchup",
+            replacement="replacement-confirmed-catchup",
+            status="resumed",
+        ),
+    )
+    started = _lease(
+        lineage="lineage-confirmed-catchup",
+        rollover_id="rollover-confirmed-catchup",
+        replacement="replacement-confirmed-catchup",
+        status="started",
+    )
+    started["replacement"]["native_lifecycle"]["status"] = "archive_authorization_blocked"
+
+    record = _sync(tmp_path, started)
+    audit = registry.audit_fleet(tmp_path)
+
+    assert record["state"] == registry.RolloverState.CONFIRMED.value
+    assert registry.is_live_pending(record) is False
+    assert record["blocking_reason"] == "native rollover boundary blocked: archive_authorization_blocked"
+    assert audit["entries"][0]["blocking_reason"] == record["blocking_reason"]
+
+
+def test_every_success_boundary_is_idempotent_after_crash_retry(tmp_path: Path) -> None:
+    record = _sync(tmp_path, _lease(lineage="lineage-retry", rollover_id="rollover-retry"))
+    boundaries = (
+        registry.RolloverState.REPLACEMENT_CREATED,
+        registry.RolloverState.RESUMED,
+        registry.RolloverState.STRICT_RECALL_PASSED,
+        registry.RolloverState.CANARY_PASSED,
+        registry.RolloverState.CONFIRMED,
+        registry.RolloverState.PREDECESSOR_ARCHIVED,
+        registry.RolloverState.HEARTBEAT_RETIRED,
+    )
+
+    for boundary in boundaries:
+        operation_id = f"retry-{boundary.value.lower()}"
+        updates = (
+            _bound_identity_updates(record, "replacement-retry")
+            if boundary is registry.RolloverState.REPLACEMENT_CREATED
+            else None
+        )
+        first = registry.transition(
+            tmp_path,
+            **record["key"],
+            state=boundary,
+            reason="boundary crash retry",
+            operation_id=operation_id,
+            updates=updates,
+        )
+        second = registry.transition(
+            tmp_path,
+            **record["key"],
+            state=boundary,
+            reason="boundary crash retry",
+            operation_id=operation_id,
+        )
+
+        assert first == second
+        assert sum(event.get("operation_id") == operation_id for event in second["history"]) == 1

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -15,7 +15,7 @@ from scripts.orchestration import claudex_supervisor as cs
 from scripts.orchestration import task_identity
 from scripts.orchestration import thread_handoff as th
 from scripts.orchestration import thread_handoff_canary as canary
-from scripts.orchestration.task_family import rollover
+from scripts.orchestration.task_family import rollover, rollover_registry
 from scripts.orchestration.task_family.storage import TaskFamilyStorage
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -169,6 +169,59 @@ def test_rollover_state_missing_receipt_path_writes_nothing(
         th.write_rollover_state(tmp_path / "lease.json", tmp_path, state)
 
     assert writes == []
+
+
+def test_rollover_state_refreshes_canonical_registry_projection(tmp_path: Path) -> None:
+    state = prepared(agent="codex", thread_id="source-registry-sync")
+    lineage_id = state["lineage_id"]
+    rollover_id = state["replacement"]["rollover_id"]
+    state_path = tmp_path / th.default_state_path("codex", lineage_id)
+
+    th.write_rollover_state(state_path, tmp_path, state)
+
+    record = rollover_registry.load_record(
+        tmp_path,
+        agent="codex",
+        lineage_id=lineage_id,
+        rollover_id=rollover_id,
+    )
+    assert record["task_identity"] == state["replacement"]["identity"]
+    assert record["title_transition"] == state["replacement"]["title_transition"]
+    assert record["lease_path"] == state_path.relative_to(tmp_path).as_posix()
+
+
+@pytest.mark.parametrize(
+    ("command_name", "locked_name"),
+    [
+        ("cmd_register_created", "_cmd_register_created_locked"),
+        ("cmd_native_action", "_cmd_native_action_locked"),
+        ("cmd_record_native_result", "_cmd_record_native_result_locked"),
+        ("cmd_reconcile_native", "_cmd_reconcile_native_locked"),
+    ],
+)
+def test_every_native_mutation_runs_inside_the_lineage_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command_name: str,
+    locked_name: str,
+) -> None:
+    events: list[str] = []
+
+    class RecordingLock:
+        def __enter__(self) -> None:
+            events.append("lock-entered")
+
+        def __exit__(self, *_args: object) -> None:
+            events.append("lock-exited")
+
+    monkeypatch.setattr(th, "_rollover_mutation_lock_path", lambda _args: tmp_path / "lineage.lock")
+    monkeypatch.setattr(th, "task_family_advisory_lock", lambda _path: RecordingLock())
+    monkeypatch.setattr(th, locked_name, lambda _args: events.append("mutation") or 0)
+
+    returncode = getattr(th, command_name)(SimpleNamespace())
+
+    assert returncode == 0
+    assert events == ["lock-entered", "mutation", "lock-exited"]
 
 
 def bind_native_replacement(state: dict, thread_id: str) -> None:

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -86,6 +86,7 @@ def init_repo(tmp_path: Path, *, bootstrap_sources: bool = False) -> tuple[Path,
         "scripts/lib/session_record.py",
         "scripts/config/context_profiles.yaml",
         "agents_extensions/shared/schemas/task-identity.v1.schema.json",
+        "agents_extensions/shared/schemas/rollover-registry.v1.schema.json",
     ]
     sources.extend(
         str(path.relative_to(REPO_ROOT))

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -65,6 +65,11 @@ def _patch_orient_sources(monkeypatch) -> None:
     monkeypatch.setattr(api_main, "_collect_delegate_orient_data", lambda: {"active_count": 0, "recent": []})
     monkeypatch.setattr(api_main, "_collect_bridge_pending_orient_data", lambda: {})
     monkeypatch.setattr(
+        api_main,
+        "_collect_rollovers_orient_data",
+        lambda: {"counts": {"total": 0, "live_pending": 0}, "actionable": [], "errors": []},
+    )
+    monkeypatch.setattr(
         api_main, "_collect_wiki_orient_data", lambda: {"by_track": {"hist": {"compiled": 1, "total": 2, "pct": 50.0}}}
     )
     monkeypatch.setattr(
@@ -130,6 +135,7 @@ def test_orient_returns_all_top_level_keys(monkeypatch):
         "runtime",
         "delegate",
         "bridge_pending",
+        "rollovers",
         "wiki",
         "health",
         "session_hints",
@@ -144,7 +150,7 @@ def test_parse_orient_sections_lean_preset_excludes_heavy_sections():
     lean = api_main._parse_orient_sections(None, lean=True)
     assert lean == list(api_main.LEAN_ORIENT_SECTIONS)
     assert not ({"pipeline", "issues", "wiki"} & set(lean))
-    assert {"git", "delegate", "governance", "health", "session_hints"} <= set(lean)
+    assert {"git", "delegate", "rollovers", "governance", "health", "session_hints"} <= set(lean)
 
 
 def test_parse_orient_sections_explicit_list_overrides_lean():
@@ -244,6 +250,22 @@ def test_orient_includes_bridge_pending_field(monkeypatch):
     data = response.json()
     assert data["bridge_pending"] == {"claude": {"count": 1, "oldest_hours": 6.5}}
     assert "bridge_pending" in data["meta"]
+
+
+def test_orient_includes_actionable_rollovers(monkeypatch):
+    _patch_orient_sources(monkeypatch)
+    expected = {
+        "counts": {"total": 4, "live_pending": 3},
+        "actionable": [{"agent": "codex", "rollover_id": "rollover-a"}],
+        "errors": [],
+    }
+    monkeypatch.setattr(api_main, "_collect_rollovers_orient_data", lambda: expected)
+
+    response = client.get("/api/orient")
+
+    assert response.status_code == 200
+    assert response.json()["rollovers"] == expected
+    assert "rollovers" in response.json()["meta"]
 
 
 def test_orient_completes_within_500ms(monkeypatch):
@@ -589,6 +611,7 @@ def test_orient_default_sections_remain_full_payload(monkeypatch):
         "runtime",
         "delegate",
         "bridge_pending",
+        "rollovers",
         "wiki",
         "governance",
         "health",

--- a/tests/test_rollover_api.py
+++ b/tests/test_rollover_api.py
@@ -1,0 +1,184 @@
+"""Read-only API coverage for the fleet rollover registry."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import scripts.api.rollover_router as rollover_router
+from scripts.api.main import app
+from scripts.orchestration import task_identity
+from scripts.orchestration.task_family import rollover_registry as registry
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def _record(
+    *,
+    lineage_id: str = "lineage-api",
+    rollover_id: str = "rollover-api",
+    source_thread_id: str = "source-api",
+) -> dict:
+    identity = task_identity.build_identity(
+        repository=task_identity.DEFAULT_REPOSITORY,
+        stream_epic=4707,
+        stream_epic_url=None,
+        github_issue_number=5296,
+        github_issue_url=None,
+        semantic_title="Fleet rollover registry",
+        task_family="thread-rollover",
+        role="codex",
+        predecessor_task_id=source_thread_id,
+        replacement_task_id=None,
+        lineage_id=lineage_id,
+        generation=1,
+        terminal_goal="merge",
+    )
+    return {
+        "schema_version": registry.REGISTRY_SCHEMA_VERSION,
+        "key": {"agent": "codex", "lineage_id": lineage_id, "rollover_id": rollover_id},
+        "task_identity": identity,
+        "title_transition": task_identity.new_title_transition(
+            harness="codex-app",
+            visible_title_value=identity["visible_title"],
+            prepared_at="2026-07-16T09:00:00Z",
+        ),
+        "state": registry.RolloverState.AWAITING_NATIVE_CREATE.value,
+        "last_successful_boundary": registry.RolloverState.PREPARED.value,
+        "native_creation": {"state": "awaiting_native_create", "family_id": None, "operation_id": None},
+        "strict_recall": {"state": "pending", "score": None, "verdict_path": None},
+        "canary": {"state": "pending", "proof_path": None},
+        "confirmation": {"state": "pending", "confirmed_at": None, "confirmed_by": None},
+        "predecessor_archival": {"state": "pending"},
+        "heartbeat": {
+            "automation_id": "automation-api",
+            "state": "active_or_unknown",
+            "cleanup_authorized": False,
+        },
+        "timestamps": {
+            "prepared_at": "2026-07-16T09:00:00Z",
+            "updated_at": "2026-07-16T09:00:00Z",
+        },
+        "lease_path": None,
+        "packet_paths": {},
+        "evidence_paths": ["evidence/prepare.json"],
+        "receipts": [],
+        "history": [],
+        "blocking_reason": None,
+        "terminal_reason": None,
+        "last_reconciliation": None,
+    }
+
+
+def test_rollover_audit_route_is_read_only_and_uses_live_repo_root(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_audit(root, *, stale_hours=registry.DEFAULT_STALE_HOURS):
+        captured["root"] = root
+        captured["stale_hours"] = stale_hours
+        return {
+            "schema_version": 1,
+            "generated_at": "2026-07-16T10:00:00Z",
+            "counts": {"total": 1, "live_pending": 1, "corrupt": 0},
+            "entries": [registry.candidate_summary(_record())],
+            "errors": [],
+            "mutation_allowed": False,
+        }
+
+    monkeypatch.setattr(rollover_router, "LIVE_REPO_ROOT", tmp_path)
+    monkeypatch.setattr(rollover_router.registry, "audit_fleet", fake_audit)
+
+    response = client.get("/api/rollovers")
+
+    assert response.status_code == 200
+    assert response.json()["mutation_allowed"] is False
+    assert captured == {"root": tmp_path, "stale_hours": registry.DEFAULT_STALE_HOURS}
+
+
+def test_rollover_audit_rejects_invalid_agent_filter(monkeypatch):
+    monkeypatch.setattr(
+        rollover_router.registry,
+        "audit_fleet",
+        lambda _root, *, stale_hours: {
+            "counts": {"total": 0, "live_pending": 0, "corrupt": 0},
+            "entries": [],
+            "errors": [],
+        },
+    )
+
+    response = client.get("/api/rollovers?agent=../codex")
+
+    assert response.status_code == 400
+
+
+def test_rollover_exact_selector_ignores_unrelated_pending_records(monkeypatch):
+    selected = _record()
+    unrelated = _record(
+        lineage_id="lineage-other",
+        rollover_id="rollover-other",
+        source_thread_id="source-other",
+    )
+    monkeypatch.setattr(rollover_router.registry, "scan_records", lambda _root: ([selected, unrelated], []))
+
+    response = client.get("/api/rollovers?source_thread_id=source-api")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["entry"]["lineage_id"] == "lineage-api"
+    assert payload["classification"] == registry.AuditClassification.AWAITING_NATIVE_ACTION.value
+    assert payload["mutation_allowed"] is False
+
+
+def test_rollover_exact_selector_fails_closed_when_ambiguous(monkeypatch):
+    first = _record()
+    second = _record(
+        lineage_id="lineage-other",
+        rollover_id="rollover-other",
+        source_thread_id="source-api",
+    )
+    monkeypatch.setattr(rollover_router.registry, "scan_records", lambda _root: ([first, second], []))
+
+    response = client.get("/api/rollovers?source_thread_id=source-api")
+
+    assert response.status_code == 409
+    assert len(response.json()["detail"]["matches"]) == 2
+
+
+def test_rollover_exact_selector_surfaces_corrupt_authoritative_record(monkeypatch, tmp_path):
+    record = _record()
+    corrupt_path = registry.record_path(tmp_path, **record["key"]).relative_to(tmp_path).as_posix()
+    monkeypatch.setattr(rollover_router, "LIVE_REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        rollover_router.registry,
+        "scan_records",
+        lambda _root: ([record], [{"path": corrupt_path, "error": "malformed record"}]),
+    )
+
+    response = client.get("/api/rollovers?source_thread_id=source-api")
+
+    assert response.status_code == 409
+    assert "corrupt durable source" in response.json()["detail"]["error"]
+
+
+def test_rollover_orient_projection_exposes_only_actionable_entries(monkeypatch, tmp_path):
+    actionable = {
+        **registry.candidate_summary(_record()),
+        "live_pending": True,
+        "classification": registry.AuditClassification.AWAITING_NATIVE_ACTION.value,
+    }
+    finished = {**actionable, "live_pending": False, "classification": registry.AuditClassification.SUPERSEDED.value}
+    monkeypatch.setattr(rollover_router, "LIVE_REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        rollover_router.registry,
+        "audit_fleet",
+        lambda _root: {
+            "generated_at": "2026-07-16T10:00:00Z",
+            "counts": {"total": 2, "live_pending": 1, "corrupt": 0},
+            "entries": [actionable, finished],
+            "errors": [],
+        },
+    )
+
+    payload = rollover_router.collect_rollover_orient_data()
+
+    assert payload["actionable"] == [actionable]
+    assert payload["counts"]["total"] == 2


### PR DESCRIPTION
## Summary

- add the fleet-wide `(agent, lineage_id, rollover_id)` registry, canonical schema/contract, legacy migration, exact selectors, packet audit, authoritative reconciliation, and proof-gated plan/apply maintenance
- synchronize registry projection from every rollover lease mutation under the existing per-lineage native-intent lock
- expose read-only `/api/rollovers` and compact `/api/orient` rollover diagnostics with human-readable identity, lifecycle, corruption, blocking, and cleanup state
- deploy the shared contract and rollover skill to every supported agent/harness surface

## Safety and acceptance evidence

- generic ambiguity and corrupt sources remain non-mutating; exact AND selectors isolate unrelated pending work
- confirmed, superseded, abandoned, and fully cleaned packets are excluded from live pending
- native creation/title/confirmation/archive/heartbeat state requires exact authoritative IDs and durable receipts; age never deletes continuity
- maintenance revalidates immutable exact plans and evidence under the lineage lock and writes crash-idempotent receipts
- migration preserves lease/task-family evidence and blocked last-success boundaries without rewriting history

## Verification

- `413 passed` — full relevant orchestration + rollover/orient API suite
- `166 passed` — post-rebase focused registry, handoff, restart E2E, and API smoke suite
- Ruff, Python compilation, `git diff --check`, markdownlint: passed
- shared deploy + drift validation: passed on all supported surfaces
- live read-only fleet proof: 33 packets, 0 corrupt; generic Codex detection non-mutating with structured candidates
- independent cross-family closeout: Grok 4.5 PASS, confidence 0.86, zero findings after all prior findings were fixed and regression-tested

Fixes #5296
