### PR TITLE
feat(review): enforce clause-backed behavior proof

### DIFF
--- a/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
+++ b/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
@@ -288,12 +288,14 @@ its clause claim from the frozen `intended_behavior`:
   --observation '<what happened>' --evidence-ref '<durable evidence reference>'
 ```
 
-Then pass `--behavior-proof-state-file "$STATE_FILE"` to
-`scripts/verify_review.py`. `source_blind` defaults to
-`blind_enforced: false`; its receipt is explicitly
+The recorder emits `behavior_proof.schema_version: behavior-proof.v1`; the
+verifier rejects unversioned proof. Then pass `--behavior-proof-state-file
+"$STATE_FILE"` to `scripts/verify_review.py`. A `source_blind` `pass` records
+an explicit `blind_enforced: false` by default; its receipt is explicitly
 `declared-blind/unenforced` unless a target-bound isolation attestation is
-validated by the isolation interface. Use `--status n/a --reason '<why>'` for
-a non-applicable surface.
+validated by the isolation interface. Any `blind_enforced: true` requires that
+attestation, including `n/a`; ordinary `n/a` has a non-empty reason and omits
+the field.
 
 - **Python CLI** (e.g. this closeout CLI itself): invoke the actual
   entry point from a shell with real arguments —

--- a/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
+++ b/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
@@ -273,6 +273,28 @@ happen. There is no repo-wide "verify" skill or tool that does this for
 you generically; do not invoke or reference one that doesn't exist. Use
 whatever real, product-specific surface applies:
 
+Record each surface through the canonical closeout state; do not hand-author
+`--behavior-proof-json`. This binds the proof to the frozen target and derives
+its clause claim from the frozen `intended_behavior`:
+
+```bash
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
+  behavior-proof record --surface source_aware --status pass \
+  --command '<actual command>' --cwd . --exit-code 0 \
+  --observation '<what happened>' --evidence-ref '<durable evidence reference>'
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
+  behavior-proof record --surface source_blind --status pass \
+  --command '<actual user-facing command>' --cwd . --exit-code 0 \
+  --observation '<what happened>' --evidence-ref '<durable evidence reference>'
+```
+
+Then pass `--behavior-proof-state-file "$STATE_FILE"` to
+`scripts/verify_review.py`. `source_blind` defaults to
+`blind_enforced: false`; its receipt is explicitly
+`declared-blind/unenforced` unless a target-bound isolation attestation is
+validated by the isolation interface. Use `--status n/a --reason '<why>'` for
+a non-applicable surface.
+
 - **Python CLI** (e.g. this closeout CLI itself): invoke the actual
   entry point from a shell with real arguments —
   `.venv/bin/python -m <module> <args>` — and read its stdout/stderr/exit

--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -105,7 +105,8 @@ Bind verification to one explicit mode from `scripts.review.target_resolution`
 deterministic SHA-256 over target metadata plus the exact patch bytes (and
 untracked file bytes in local mode) needed to reconstruct the reviewed
 surface. It **must** change when a local source, the changed-path set,
-base/head, or committed content changes.
+base/head, or committed content changes. Display-only target descriptions and
+equivalent ref spellings do not affect the fingerprint.
 
 Reviewer JSON is hashed separately as `reviewer_output_sha256`.
 

--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -132,7 +132,7 @@ Reviewer JSON is hashed separately as `reviewer_output_sha256`.
   --reviewer-model '...' --reviewer-family '...' --reviewer-harness '...' \
   --reviewer-selection-reason '...' \
   --tests-json '{"commands":["pytest ..."],"passed":true}' \
-  --behavior-proof-json '{"source_aware":{"status":"pass"},"source_blind":{"status":"pass"}}' \
+  --behavior-proof-state-file "$STATE_FILE" \
   --routing-lineage-json '{"implementation_agent":"...","accountable_advisor":"..."}' \
   --dispositions-json '{"F001":{"disposition":"in_scope_blocker","rationale":"..."}}' \
   --receipt-path /tmp/review-receipt.json
@@ -162,9 +162,16 @@ A valid **clean** or **actionable** receipt requires:
 - `tests` with concrete `commands` and `passed: true`, **or** explicitly
   supported `status: "n/a"` with a non-empty `reason`. `passed: false` /
   `status: "fail"` makes the receipt non-clean / `actionable` (never exit 0);
-- both `source_aware` and `source_blind` in `behavior_proof`, each with
-  `status: "pass"` or `status: "n/a"` + non-empty `reason`. `status: "fail"`
-  is non-clean / `actionable`; missing/invalid status is `incomplete`;
+- both `source_aware` and `source_blind` in `behavior_proof`. A `pass` needs
+  at least one complete clause: the frozen `intended_behavior` claim, a
+  command or manual step (and `cwd` for a command), exit/result, observation,
+  evidence reference, and the exact target-input fingerprint. Record it with
+  `closeout_cli behavior-proof record`; do not hand-author a competing surface
+  claim. `n/a` requires a non-empty `reason`; `fail` is non-clean / actionable;
+  missing or incomplete proof is `incomplete`;
+- `source_blind.blind_enforced` is `false` unless a target-bound isolation
+  attestation validates through the isolation interface. A false value is
+  rendered as `declared-blind/unenforced`, never as mechanically enforced;
 - explicit non-empty `routing_lineage` (supplied by the runner; not invented);
 - for every finding: disposition key present, disposition ∈
   `in_scope_blocker` | `follow_up` | `stop_and_escalate`, non-empty rationale;
@@ -184,6 +191,18 @@ Local / CI (no GitHub mutation) — full envelope example:
 TARGET_SHA=$(.venv/bin/python scripts/verify_review.py --emit-target-manifest \
   --mode local --repo-root . | .venv/bin/python -c 'import json,sys; print(json.load(sys.stdin)["input_sha256"])')
 
+# After `target` and `freeze`, record the proof against that frozen state.
+# The command derives `claim` from `--intended-behavior`; it does not accept a
+# separate behavior-surface field.
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
+  behavior-proof record --surface source_aware --status pass \
+  --command '.venv/bin/python scripts/verify_review.py --help' --cwd . \
+  --exit-code 0 --observation 'help rendered' --evidence-ref 'terminal:proof-aware'
+.venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
+  behavior-proof record --surface source_blind --status pass \
+  --command '.venv/bin/python scripts/verify_review.py --help' --cwd . \
+  --exit-code 0 --observation 'help rendered as a user' --evidence-ref 'terminal:proof-blind'
+
 .venv/bin/python scripts/verify_review.py --from-stdin --mode local \
   --expected-input-sha256 "$TARGET_SHA" \
   --issue-ref '#5284' \
@@ -193,7 +212,7 @@ TARGET_SHA=$(.venv/bin/python scripts/verify_review.py --emit-target-manifest \
   --reviewer-model 'grok-4.5' --reviewer-family xai --reviewer-harness grok-build \
   --reviewer-selection-reason 'cross-family-gate' \
   --tests-json '{"commands":["pytest tests/test_verify_review.py"],"passed":true}' \
-  --behavior-proof-json '{"source_aware":{"status":"pass"},"source_blind":{"status":"n/a","reason":"no user-visible surface"}}' \
+  --behavior-proof-state-file "$STATE_FILE" \
   --routing-lineage-json '{"implementation_agent":"runner-supplied","accountable_advisor":"runner-supplied"}' \
   --receipt-path /tmp/review-receipt.json
 ```

--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -162,16 +162,21 @@ A valid **clean** or **actionable** receipt requires:
 - `tests` with concrete `commands` and `passed: true`, **or** explicitly
   supported `status: "n/a"` with a non-empty `reason`. `passed: false` /
   `status: "fail"` makes the receipt non-clean / `actionable` (never exit 0);
-- both `source_aware` and `source_blind` in `behavior_proof`. A `pass` needs
+- `behavior_proof.schema_version: "behavior-proof.v1"`, emitted by
+  `closeout_cli behavior-proof record`; unversioned proof is not accepted as
+  legacy green evidence. Both `source_aware` and `source_blind` are required.
+  A `pass` needs
   at least one complete clause: the frozen `intended_behavior` claim, a
   command or manual step (and `cwd` for a command), exit/result, observation,
   evidence reference, and the exact target-input fingerprint. Record it with
   `closeout_cli behavior-proof record`; do not hand-author a competing surface
   claim. `n/a` requires a non-empty `reason`; `fail` is non-clean / actionable;
   missing or incomplete proof is `incomplete`;
-- `source_blind.blind_enforced` is `false` unless a target-bound isolation
-  attestation validates through the isolation interface. A false value is
-  rendered as `declared-blind/unenforced`, never as mechanically enforced;
+- `source_blind` `pass` records an explicit boolean `blind_enforced`. A true
+  value on any status requires a target-bound isolation attestation validated
+  through the isolation interface. Ordinary justified `n/a` does not carry the
+  field. A false value is rendered as `declared-blind/unenforced`, never as
+  mechanically enforced;
 - explicit non-empty `routing_lineage` (supplied by the runner; not invented);
 - for every finding: disposition key present, disposition ∈
   `in_scope_blocker` | `follow_up` | `stop_and_escalate`, non-empty rationale;
@@ -192,8 +197,9 @@ TARGET_SHA=$(.venv/bin/python scripts/verify_review.py --emit-target-manifest \
   --mode local --repo-root . | .venv/bin/python -c 'import json,sys; print(json.load(sys.stdin)["input_sha256"])')
 
 # After `target` and `freeze`, record the proof against that frozen state.
-# The command derives `claim` from `--intended-behavior`; it does not accept a
-# separate behavior-surface field.
+# The recorder emits behavior_proof.schema_version = behavior-proof.v1 and
+# derives `claim` from `--intended-behavior`; it does not accept a separate
+# behavior-surface field.
 .venv/bin/python -m scripts.review.closeout_cli --state-file "$STATE_FILE" \
   behavior-proof record --surface source_aware --status pass \
   --command '.venv/bin/python scripts/verify_review.py --help' --cwd . \

--- a/scripts/review/closeout_cli.py
+++ b/scripts/review/closeout_cli.py
@@ -36,6 +36,12 @@ from scripts.review.target_resolution import (
     rev_parse,
 )
 
+BEHAVIOR_PROOF_SCHEMA_VERSION = "behavior-proof.v1"
+
+
+class CloseoutStateError(RuntimeError):
+    """The canonical closeout state is malformed or cannot be read."""
+
 
 def _load_state(state_file: Path) -> dict:
     if not state_file.exists():
@@ -47,7 +53,15 @@ def _load_state(state_file: Path) -> dict:
             "cycle_outstanding_counts": [],
             "findings": [],
         }
-    return json.loads(state_file.read_text(encoding="utf-8"))
+    try:
+        state = json.loads(state_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError) as exc:
+        raise CloseoutStateError(f"state_unreadable:{exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise CloseoutStateError(f"state_invalid_json:{exc.msg}") from exc
+    if not isinstance(state, dict):
+        raise CloseoutStateError("state_must_be_object")
+    return state
 
 
 def _save_state(state_file: Path, state: dict) -> None:
@@ -55,15 +69,38 @@ def _save_state(state_file: Path, state: dict) -> None:
     state_file.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
 
 
-def _target_from_dict(data: dict) -> ReviewTarget:
+def _target_from_dict(data: object) -> ReviewTarget:
+    if not isinstance(data, dict):
+        raise CloseoutStateError("target_must_be_object")
+    mode = data.get("mode")
+    base_sha = data.get("base_sha")
+    head_sha = data.get("head_sha")
+    changed_paths = data.get("changed_paths")
+    non_test_loc = data.get("non_test_loc")
+    clean_tree = data.get("clean_tree")
+    description = data.get("description")
+    if mode not in {"local", "commit", "branch", "pr"}:
+        raise CloseoutStateError("target_mode_invalid")
+    if not all(value is None or isinstance(value, str) for value in (base_sha, head_sha)):
+        raise CloseoutStateError("target_sha_invalid")
+    if not isinstance(changed_paths, list) or not all(
+        isinstance(path, str) and path for path in changed_paths
+    ):
+        raise CloseoutStateError("target_changed_paths_invalid")
+    if not isinstance(non_test_loc, int) or isinstance(non_test_loc, bool) or non_test_loc < 0:
+        raise CloseoutStateError("target_non_test_loc_invalid")
+    if not isinstance(clean_tree, bool):
+        raise CloseoutStateError("target_clean_tree_invalid")
+    if not isinstance(description, str) or not description.strip():
+        raise CloseoutStateError("target_description_invalid")
     return ReviewTarget(
-        mode=data["mode"],
-        base_sha=data["base_sha"],
-        head_sha=data["head_sha"],
-        changed_paths=tuple(data["changed_paths"]),
-        non_test_loc=data["non_test_loc"],
-        clean_tree=data["clean_tree"],
-        description=data["description"],
+        mode=mode,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        changed_paths=tuple(changed_paths),
+        non_test_loc=non_test_loc,
+        clean_tree=clean_tree,
+        description=description,
     )
 
 
@@ -128,7 +165,7 @@ def _cmd_freeze(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    if not state.get("target"):
+    if state.get("target") is None:
         print(json.dumps({"error": "no target resolved yet — run the `target` subcommand first"}), file=sys.stderr)
         return 1
 
@@ -160,7 +197,33 @@ def _cmd_freeze(args: argparse.Namespace) -> int:
 
 
 def _baseline_from_state(state: dict) -> ScopeBaseline:
-    data = state["baseline"]
+    data = state.get("baseline")
+    if not isinstance(data, dict):
+        raise CloseoutStateError("baseline_must_be_object")
+    required_strings = (
+        "issue_ref",
+        "intended_behavior",
+        "non_goals",
+        "owner_boundary",
+        "review_profile",
+        "risk",
+    )
+    for key in required_strings:
+        value = data.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise CloseoutStateError(f"baseline_{key}_invalid")
+    frozen_files = data.get("frozen_files")
+    frozen_non_test_loc = data.get("frozen_non_test_loc")
+    if not isinstance(frozen_files, list) or not all(
+        isinstance(path, str) and path for path in frozen_files
+    ):
+        raise CloseoutStateError("baseline_frozen_files_invalid")
+    if (
+        not isinstance(frozen_non_test_loc, int)
+        or isinstance(frozen_non_test_loc, bool)
+        or frozen_non_test_loc < 0
+    ):
+        raise CloseoutStateError("baseline_frozen_non_test_loc_invalid")
     return ScopeBaseline(
         issue_ref=data["issue_ref"],
         intended_behavior=data["intended_behavior"],
@@ -169,8 +232,8 @@ def _baseline_from_state(state: dict) -> ScopeBaseline:
         target=_target_from_dict(data["target"]),
         review_profile=data["review_profile"],
         risk=data["risk"],
-        frozen_files=frozenset(data["frozen_files"]),
-        frozen_non_test_loc=data["frozen_non_test_loc"],
+        frozen_files=frozenset(frozen_files),
+        frozen_non_test_loc=frozen_non_test_loc,
     )
 
 
@@ -188,7 +251,7 @@ def _cmd_check_expansion(args: argparse.Namespace) -> int:
     mode the baseline was actually frozen under.
     """
     state = _load_state(args.state_file)
-    if not state.get("baseline"):
+    if state.get("baseline") is None:
         print(json.dumps({"error": "no frozen baseline yet — run `freeze` first"}), file=sys.stderr)
         return 1
     baseline = _baseline_from_state(state)
@@ -238,7 +301,7 @@ def _cmd_check_expansion(args: argparse.Namespace) -> int:
 
 def _cmd_record_cycle(args: argparse.Namespace) -> int:
     state = _load_state(args.state_file)
-    if not state.get("baseline"):
+    if state.get("baseline") is None:
         print(json.dumps({"error": "no frozen baseline yet — run `freeze` first"}), file=sys.stderr)
         return 1
     if args.outstanding_count < 0:
@@ -313,7 +376,7 @@ def _cmd_finding(args: argparse.Namespace) -> int:
 def _cmd_behavior_proof(args: argparse.Namespace) -> int:
     """Record target-bound behavior proof from the frozen closeout state."""
     state = _load_state(args.state_file)
-    if not state.get("baseline"):
+    if state.get("baseline") is None:
         print(json.dumps({"error": "no frozen baseline yet — run `freeze` first"}), file=sys.stderr)
         return 1
     baseline = _baseline_from_state(state)
@@ -328,19 +391,27 @@ def _cmd_behavior_proof(args: argparse.Namespace) -> int:
         print(json.dumps({"error": f"target_fingerprint_unavailable:{exc}"}), file=sys.stderr)
         return 1
 
-    proof = state.setdefault("behavior_proof", {})
+    proof = state.get("behavior_proof", {})
+    if not isinstance(proof, dict):
+        raise CloseoutStateError("behavior_proof_must_be_object")
+    if proof and proof.get("schema_version") != BEHAVIOR_PROOF_SCHEMA_VERSION:
+        raise CloseoutStateError("behavior_proof_schema_version_invalid")
     if args.behavior_action == "emit":
-        if not proof:
+        if not any(key in proof for key in ("source_aware", "source_blind")):
             print(json.dumps({"error": "no behavior proof recorded yet"}), file=sys.stderr)
             return 1
         print(json.dumps(proof, indent=2, sort_keys=True))
         return 0
 
     if args.status == "pass":
-        if args.command is None and args.step is None:
+        command = args.command.strip() if isinstance(args.command, str) else None
+        step = args.step.strip() if isinstance(args.step, str) else None
+        has_command = bool(command)
+        has_step = bool(step)
+        if has_command == has_step:
             print(json.dumps({"error": "passing proof requires --command or --step"}), file=sys.stderr)
             return 1
-        if args.command is not None and (not isinstance(args.cwd, str) or not args.cwd.strip()):
+        if has_command and (not isinstance(args.cwd, str) or not args.cwd.strip()):
             print(json.dumps({"error": "command proof requires --cwd"}), file=sys.stderr)
             return 1
         if args.exit_code is None and (not isinstance(args.result, str) or not args.result.strip()):
@@ -360,11 +431,11 @@ def _cmd_behavior_proof(args: argparse.Namespace) -> int:
             "observation": args.observation,
             "evidence_ref": args.evidence_ref,
         }
-        if args.command is not None:
-            clause["command"] = args.command
+        if has_command:
+            clause["command"] = command
             clause["cwd"] = args.cwd
         else:
-            clause["step"] = args.step
+            clause["step"] = step
         if args.exit_code is not None:
             clause["exit_code"] = args.exit_code
         else:
@@ -376,9 +447,11 @@ def _cmd_behavior_proof(args: argparse.Namespace) -> int:
             return 1
         surface = {"status": args.status, "reason": args.reason}
 
-    if args.surface == "source_blind":
+    proof["schema_version"] = BEHAVIOR_PROOF_SCHEMA_VERSION
+    if args.surface == "source_blind" and args.status == "pass":
         surface["blind_enforced"] = args.blind_enforced
     proof[args.surface] = surface
+    state["behavior_proof"] = proof
     _save_state(args.state_file, state)
     print(json.dumps(proof, indent=2, sort_keys=True))
     return 0
@@ -500,7 +573,11 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
-    return args.func(args)
+    try:
+        return args.func(args)
+    except CloseoutStateError as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/review/closeout_cli.py
+++ b/scripts/review/closeout_cli.py
@@ -19,6 +19,7 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
+from scripts.review.evidence import compute_target_input_fingerprint
 from scripts.review.findings import FindingEvent, FindingsLedger, FindingsLedgerError
 from scripts.review.reviewer_resolver import ResolverInputs, resolve_reviewer
 from scripts.review.scope_baseline import (
@@ -38,7 +39,14 @@ from scripts.review.target_resolution import (
 
 def _load_state(state_file: Path) -> dict:
     if not state_file.exists():
-        return {"target": None, "target_args": None, "baseline": None, "cycle_outstanding_counts": [], "findings": []}
+        return {
+            "target": None,
+            "target_args": None,
+            "baseline": None,
+            "behavior_proof": {},
+            "cycle_outstanding_counts": [],
+            "findings": [],
+        }
     return json.loads(state_file.read_text(encoding="utf-8"))
 
 
@@ -302,6 +310,80 @@ def _cmd_finding(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_behavior_proof(args: argparse.Namespace) -> int:
+    """Record target-bound behavior proof from the frozen closeout state."""
+    state = _load_state(args.state_file)
+    if not state.get("baseline"):
+        print(json.dumps({"error": "no frozen baseline yet — run `freeze` first"}), file=sys.stderr)
+        return 1
+    baseline = _baseline_from_state(state)
+    target_args = state.get("target_args") or {}
+    repo_root_raw = target_args.get("repo_root")
+    if not isinstance(repo_root_raw, str) or not repo_root_raw:
+        print(json.dumps({"error": "frozen target has no repository root"}), file=sys.stderr)
+        return 1
+    try:
+        target_input_sha256 = compute_target_input_fingerprint(Path(repo_root_raw), baseline.target)
+    except Exception as exc:
+        print(json.dumps({"error": f"target_fingerprint_unavailable:{exc}"}), file=sys.stderr)
+        return 1
+
+    proof = state.setdefault("behavior_proof", {})
+    if args.behavior_action == "emit":
+        if not proof:
+            print(json.dumps({"error": "no behavior proof recorded yet"}), file=sys.stderr)
+            return 1
+        print(json.dumps(proof, indent=2, sort_keys=True))
+        return 0
+
+    if args.status == "pass":
+        if args.command is None and args.step is None:
+            print(json.dumps({"error": "passing proof requires --command or --step"}), file=sys.stderr)
+            return 1
+        if args.command is not None and (not isinstance(args.cwd, str) or not args.cwd.strip()):
+            print(json.dumps({"error": "command proof requires --cwd"}), file=sys.stderr)
+            return 1
+        if args.exit_code is None and (not isinstance(args.result, str) or not args.result.strip()):
+            print(json.dumps({"error": "passing proof requires --exit-code or --result"}), file=sys.stderr)
+            return 1
+        if not isinstance(args.observation, str) or not args.observation.strip():
+            print(json.dumps({"error": "passing proof requires --observation"}), file=sys.stderr)
+            return 1
+        if not isinstance(args.evidence_ref, str) or not args.evidence_ref.strip():
+            print(json.dumps({"error": "passing proof requires --evidence-ref"}), file=sys.stderr)
+            return 1
+        clause: dict[str, object] = {
+            # The claim is derived from the frozen baseline; callers cannot
+            # provide a competing behavior-surface string.
+            "claim": baseline.intended_behavior,
+            "target_input_sha256": target_input_sha256,
+            "observation": args.observation,
+            "evidence_ref": args.evidence_ref,
+        }
+        if args.command is not None:
+            clause["command"] = args.command
+            clause["cwd"] = args.cwd
+        else:
+            clause["step"] = args.step
+        if args.exit_code is not None:
+            clause["exit_code"] = args.exit_code
+        else:
+            clause["result"] = args.result
+        surface: dict[str, object] = {"status": "pass", "clauses": [clause]}
+    else:
+        if args.status == "n/a" and (not isinstance(args.reason, str) or not args.reason.strip()):
+            print(json.dumps({"error": "n/a proof requires --reason"}), file=sys.stderr)
+            return 1
+        surface = {"status": args.status, "reason": args.reason}
+
+    if args.surface == "source_blind":
+        surface["blind_enforced"] = args.blind_enforced
+    proof[args.surface] = surface
+    _save_state(args.state_file, state)
+    print(json.dumps(proof, indent=2, sort_keys=True))
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--state-file", required=True, type=Path)
@@ -388,6 +470,29 @@ def _build_parser() -> argparse.ArgumentParser:
     frep = finding_sub.add_parser("report")
     frep.add_argument("--id", required=False, default=None, help="unused, present for CLI symmetry")
     p_finding.set_defaults(func=_cmd_finding)
+
+    p_behavior = sub.add_parser(
+        "behavior-proof",
+        help="Record or emit behavior proof bound to the frozen target",
+    )
+    behavior_sub = p_behavior.add_subparsers(dest="behavior_action", required=True)
+    behavior_record = behavior_sub.add_parser("record", help="Record one source-aware or source-blind proof surface")
+    behavior_record.add_argument("--surface", required=True, choices=["source_aware", "source_blind"])
+    behavior_record.add_argument("--status", required=True, choices=["pass", "fail", "n/a"])
+    command_or_step = behavior_record.add_mutually_exclusive_group()
+    command_or_step.add_argument("--command")
+    command_or_step.add_argument("--step")
+    behavior_record.add_argument("--cwd")
+    result = behavior_record.add_mutually_exclusive_group()
+    result.add_argument("--exit-code", type=int)
+    result.add_argument("--result")
+    behavior_record.add_argument("--observation")
+    behavior_record.add_argument("--evidence-ref")
+    behavior_record.add_argument("--reason")
+    behavior_record.add_argument("--blind-enforced", action="store_true")
+    behavior_record.set_defaults(func=_cmd_behavior_proof)
+    behavior_emit = behavior_sub.add_parser("emit", help="Print recorded proof JSON for verify_review")
+    behavior_emit.set_defaults(func=_cmd_behavior_proof)
 
     return parser
 

--- a/scripts/review/closeout_cli.py
+++ b/scripts/review/closeout_cli.py
@@ -104,6 +104,15 @@ def _target_from_dict(data: object) -> ReviewTarget:
     )
 
 
+def _target_args_from_state(state: dict) -> dict:
+    target_args = state.get("target_args")
+    if target_args is None:
+        return {}
+    if not isinstance(target_args, dict):
+        raise CloseoutStateError("target_args_must_be_object")
+    return target_args
+
+
 def _ledger_from_state(state: dict) -> FindingsLedger:
     return FindingsLedger.from_events(FindingEvent(**raw) for raw in state.get("findings", []))
 
@@ -224,12 +233,15 @@ def _baseline_from_state(state: dict) -> ScopeBaseline:
         or frozen_non_test_loc < 0
     ):
         raise CloseoutStateError("baseline_frozen_non_test_loc_invalid")
+    target = data.get("target")
+    if not isinstance(target, dict):
+        raise CloseoutStateError("baseline_target_invalid")
     return ScopeBaseline(
         issue_ref=data["issue_ref"],
         intended_behavior=data["intended_behavior"],
         non_goals=data["non_goals"],
         owner_boundary=data["owner_boundary"],
-        target=_target_from_dict(data["target"]),
+        target=_target_from_dict(target),
         review_profile=data["review_profile"],
         risk=data["risk"],
         frozen_files=frozenset(frozen_files),
@@ -256,7 +268,7 @@ def _cmd_check_expansion(args: argparse.Namespace) -> int:
         return 1
     baseline = _baseline_from_state(state)
     repo_root = Path(args.repo_root).resolve()
-    target_args = state.get("target_args") or {}
+    target_args = _target_args_from_state(state)
     mode = target_args.get("mode") or baseline.target.mode
 
     try:
@@ -380,7 +392,7 @@ def _cmd_behavior_proof(args: argparse.Namespace) -> int:
         print(json.dumps({"error": "no frozen baseline yet — run `freeze` first"}), file=sys.stderr)
         return 1
     baseline = _baseline_from_state(state)
-    target_args = state.get("target_args") or {}
+    target_args = _target_args_from_state(state)
     repo_root_raw = target_args.get("repo_root")
     if not isinstance(repo_root_raw, str) or not repo_root_raw:
         print(json.dumps({"error": "frozen target has no repository root"}), file=sys.stderr)

--- a/scripts/review/closeout_cli.py
+++ b/scripts/review/closeout_cli.py
@@ -460,7 +460,7 @@ def _cmd_behavior_proof(args: argparse.Namespace) -> int:
         surface = {"status": args.status, "reason": args.reason}
 
     proof["schema_version"] = BEHAVIOR_PROOF_SCHEMA_VERSION
-    if args.surface == "source_blind" and args.status == "pass":
+    if args.surface == "source_blind" and (args.status == "pass" or args.blind_enforced):
         surface["blind_enforced"] = args.blind_enforced
     proof[args.surface] = surface
     state["behavior_proof"] = proof

--- a/scripts/review/evidence.py
+++ b/scripts/review/evidence.py
@@ -39,7 +39,7 @@ EVIDENCE_OUTCOMES = frozenset(
 _DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:")
 _HUNK_RE = re.compile(r"^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@")
 
-TARGET_INPUT_FINGERPRINT_VERSION = "target-input-v1"
+TARGET_INPUT_FINGERPRINT_VERSION = "target-input-v2"
 
 # Stable git-diff flags for target-input fingerprint surfaces. Avoid default
 # abbreviated index lines, external diff drivers, textconv filters, and rename
@@ -303,6 +303,10 @@ def compute_target_input_fingerprint(repo_root: Path, target: ReviewTarget) -> s
         if head_proc.returncode == 0:
             working_tree_head = (head_proc.stdout or "").strip()
 
+    # ``description`` is display-only and may contain the caller's ref spelling
+    # (for example ``HEAD`` versus a branch name).  Binding it would give the
+    # same immutable target different fingerprints depending on how it was
+    # addressed, so only stable target identity belongs in the hash.
     meta = {
         "fingerprint_version": TARGET_INPUT_FINGERPRINT_VERSION,
         "mode": target.mode,
@@ -312,7 +316,6 @@ def compute_target_input_fingerprint(repo_root: Path, target: ReviewTarget) -> s
         "changed_paths": list(target.changed_paths),
         "non_test_loc": target.non_test_loc,
         "clean_tree": target.clean_tree,
-        "description": target.description,
     }
     hasher = hashlib.sha256()
     hasher.update(TARGET_INPUT_FINGERPRINT_VERSION.encode("utf-8"))

--- a/scripts/review/review_contract.py
+++ b/scripts/review/review_contract.py
@@ -32,6 +32,7 @@ from scripts.review.target_resolution import ReviewTarget
 
 SCHEMA_VERSION = "code-review-findings.v1"
 RECEIPT_SCHEMA_VERSION = "code-review-receipt.v1"
+BEHAVIOR_PROOF_SCHEMA_VERSION = "behavior-proof.v1"
 SCHEMA_RELATIVE_PATH = "schemas/code-review-findings.v1.schema.json"
 
 # Stable exit classes (documented in docs/review-protocol.md).
@@ -352,6 +353,8 @@ def _behavior_proof_envelope_status(
     failures: list[str] = []
     if not isinstance(behavior_proof, dict):
         return ["behavior_proof_invalid"], failures
+    if behavior_proof.get("schema_version") != BEHAVIOR_PROOF_SCHEMA_VERSION:
+        incomplete.append("behavior_proof_schema_version_invalid")
 
     for key in ("source_aware", "source_blind"):
         proof = behavior_proof.get(key)
@@ -363,6 +366,27 @@ def _behavior_proof_envelope_status(
             incomplete.append(f"behavior_proof.{key}_status_missing")
             continue
         status = status_raw.strip().lower()
+        if key == "source_blind":
+            blind_enforced = proof.get("blind_enforced")
+            if blind_enforced is not None and not isinstance(blind_enforced, bool):
+                incomplete.append("behavior_proof.source_blind_blind_enforced_invalid")
+            if status == "pass" and not isinstance(blind_enforced, bool):
+                incomplete.append("behavior_proof.source_blind_blind_enforced_missing")
+            if blind_enforced is True:
+                attestation = proof.get("isolation_attestation")
+                if not isinstance(attestation, dict) or not attestation:
+                    incomplete.append("behavior_proof.source_blind_enforced_without_attestation")
+                elif attestation.get("target_input_sha256") != target_input_sha256:
+                    incomplete.append("behavior_proof.source_blind_attestation_target_mismatch")
+                elif isolation_attestation_validator is None:
+                    incomplete.append("behavior_proof.source_blind_attestation_unvalidated")
+                else:
+                    try:
+                        valid_attestation = isolation_attestation_validator(attestation, target)
+                    except Exception:
+                        valid_attestation = False
+                    if valid_attestation is not True:
+                        incomplete.append("behavior_proof.source_blind_attestation_invalid")
         if status == "fail":
             failures.append(f"behavior_proof.{key}_failed")
             continue
@@ -421,25 +445,6 @@ def _behavior_proof_envelope_status(
                 ):
                     incomplete.append(f"behavior_proof.{key}_claim_mismatch")
                 continue
-            if key == "source_blind":
-                blind_enforced = proof.get("blind_enforced")
-                if not isinstance(blind_enforced, bool):
-                    incomplete.append("behavior_proof.source_blind_blind_enforced_missing")
-                elif blind_enforced:
-                    attestation = proof.get("isolation_attestation")
-                    if not isinstance(attestation, dict) or not attestation:
-                        incomplete.append("behavior_proof.source_blind_enforced_without_attestation")
-                    elif attestation.get("target_input_sha256") != target_input_sha256:
-                        incomplete.append("behavior_proof.source_blind_attestation_target_mismatch")
-                    elif isolation_attestation_validator is None:
-                        incomplete.append("behavior_proof.source_blind_attestation_unvalidated")
-                    else:
-                        try:
-                            valid_attestation = isolation_attestation_validator(attestation, target)
-                        except Exception:
-                            valid_attestation = False
-                        if valid_attestation is not True:
-                            incomplete.append("behavior_proof.source_blind_attestation_invalid")
             continue
         if status in {"n/a", "na"}:
             reason = proof.get("reason")

--- a/scripts/review/review_contract.py
+++ b/scripts/review/review_contract.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections.abc import Callable
+from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -258,6 +260,12 @@ class VerifyContext:
     expected_input_sha256: str | None = None
     tests: dict[str, Any] = field(default_factory=dict)
     behavior_proof: dict[str, Any] = field(default_factory=dict)
+    # Supplied only by the frozen closeout state. A passing clause must use
+    # this exact claim; callers must not substitute a free-text surface.
+    frozen_intended_behavior: str = ""
+    # #5285 owns actual isolation verification. This narrow boundary lets its
+    # attestation interface plug in without duplicating isolation logic here.
+    isolation_attestation_validator: Callable[[dict[str, Any], ReviewTarget], bool] | None = None
     dispositions: dict[str, dict[str, str]] = field(default_factory=dict)
     routing_lineage: dict[str, str] = field(default_factory=dict)
 
@@ -326,12 +334,19 @@ def _tests_envelope_status(tests: dict[str, Any]) -> tuple[list[str], list[str]]
 
 def _behavior_proof_envelope_status(
     behavior_proof: Any,
+    *,
+    target_input_sha256: str,
+    frozen_intended_behavior: str,
+    isolation_attestation_validator: Callable[[dict[str, Any], ReviewTarget], bool] | None,
+    target: ReviewTarget,
 ) -> tuple[list[str], list[str]]:
     """Validate source-aware / source-blind proof semantics.
 
-    Each side must be ``status: pass`` or ``status: n/a`` with a non-empty
-    reason. Explicit ``fail`` is a proof failure (non-clean/actionable).
-    Missing or invalid status remains incomplete.
+    Each side must be ``status: pass`` backed by a complete, target-bound
+    clause, or ``status: n/a`` with a non-empty reason. The clause claim is
+    the frozen intended behavior, never a separate free-text behavior-surface
+    field. Explicit ``fail`` is a proof failure (non-clean/actionable).
+    Missing or invalid evidence remains incomplete.
     """
     incomplete: list[str] = []
     failures: list[str] = []
@@ -352,6 +367,79 @@ def _behavior_proof_envelope_status(
             failures.append(f"behavior_proof.{key}_failed")
             continue
         if status == "pass":
+            if not isinstance(frozen_intended_behavior, str) or not frozen_intended_behavior.strip():
+                incomplete.append(f"behavior_proof.{key}_frozen_intended_behavior_missing")
+                continue
+            clauses = proof.get("clauses")
+            if not isinstance(clauses, list) or not clauses:
+                incomplete.append(f"behavior_proof.{key}_clauses_missing")
+                continue
+
+            complete_clause_found = False
+            for clause in clauses:
+                if not isinstance(clause, dict):
+                    continue
+                claim = clause.get("claim")
+                binding = clause.get("target_input_sha256")
+                command = clause.get("command")
+                step = clause.get("step")
+                has_command = isinstance(command, str) and bool(command.strip())
+                has_step = isinstance(step, str) and bool(step.strip())
+                has_cwd = isinstance(clause.get("cwd"), str) and bool(clause["cwd"].strip())
+                exit_code = clause.get("exit_code")
+                has_exit = isinstance(exit_code, int) and not isinstance(exit_code, bool)
+                result = clause.get("result")
+                has_result = isinstance(result, str) and bool(result.strip())
+                observation = clause.get("observation")
+                evidence_ref = clause.get("evidence_ref")
+                complete = (
+                    claim == frozen_intended_behavior
+                    and binding == target_input_sha256
+                    and (has_command ^ has_step)
+                    and (not has_command or has_cwd)
+                    and (has_exit or has_result)
+                    and isinstance(observation, str)
+                    and bool(observation.strip())
+                    and isinstance(evidence_ref, str)
+                    and bool(evidence_ref.strip())
+                )
+                if complete:
+                    complete_clause_found = True
+                    break
+            if not complete_clause_found:
+                incomplete.append(f"behavior_proof.{key}_complete_clause_missing")
+                if not any(
+                    isinstance(clause, dict)
+                    and clause.get("target_input_sha256") == target_input_sha256
+                    for clause in clauses
+                ):
+                    incomplete.append(f"behavior_proof.{key}_target_binding_mismatch")
+                if not any(
+                    isinstance(clause, dict)
+                    and clause.get("claim") == frozen_intended_behavior
+                    for clause in clauses
+                ):
+                    incomplete.append(f"behavior_proof.{key}_claim_mismatch")
+                continue
+            if key == "source_blind":
+                blind_enforced = proof.get("blind_enforced")
+                if not isinstance(blind_enforced, bool):
+                    incomplete.append("behavior_proof.source_blind_blind_enforced_missing")
+                elif blind_enforced:
+                    attestation = proof.get("isolation_attestation")
+                    if not isinstance(attestation, dict) or not attestation:
+                        incomplete.append("behavior_proof.source_blind_enforced_without_attestation")
+                    elif attestation.get("target_input_sha256") != target_input_sha256:
+                        incomplete.append("behavior_proof.source_blind_attestation_target_mismatch")
+                    elif isolation_attestation_validator is None:
+                        incomplete.append("behavior_proof.source_blind_attestation_unvalidated")
+                    else:
+                        try:
+                            valid_attestation = isolation_attestation_validator(attestation, target)
+                        except Exception:
+                            valid_attestation = False
+                        if valid_attestation is not True:
+                            incomplete.append("behavior_proof.source_blind_attestation_invalid")
             continue
         if status in {"n/a", "na"}:
             reason = proof.get("reason")
@@ -425,7 +513,13 @@ def validate_closeout_envelope(
     incomplete.extend(t_incomplete)
     proof_failures.extend(t_failures)
 
-    b_incomplete, b_failures = _behavior_proof_envelope_status(ctx.behavior_proof)
+    b_incomplete, b_failures = _behavior_proof_envelope_status(
+        ctx.behavior_proof,
+        target_input_sha256=ctx.input_sha256,
+        frozen_intended_behavior=ctx.frozen_intended_behavior,
+        isolation_attestation_validator=ctx.isolation_attestation_validator,
+        target=ctx.target,
+    )
     incomplete.extend(b_incomplete)
     proof_failures.extend(b_failures)
 
@@ -558,7 +652,7 @@ def build_receipt(
         "reviewer_output_sha256": ctx.reviewer_output_sha256,
         "findings": [v.to_dict() for v in validations],
         "tests": ctx.tests,
-        "behavior_proof": ctx.behavior_proof,
+        "behavior_proof": _render_behavior_proof(ctx.behavior_proof),
         "final_disposition": final_disposition,
         "exit_code": exit_code,
         "error": error,
@@ -572,6 +666,15 @@ def build_receipt(
             "finding_ids": [f["id"] for f in payload.get("findings", [])],
         }
     return receipt
+
+
+def _render_behavior_proof(behavior_proof: dict[str, Any]) -> dict[str, Any]:
+    """Make declared-but-unenforced source-blind proof explicit in receipts."""
+    rendered = deepcopy(behavior_proof)
+    source_blind = rendered.get("source_blind")
+    if isinstance(source_blind, dict) and source_blind.get("blind_enforced") is False:
+        source_blind["blind_enforcement"] = "declared-blind/unenforced"
+    return rendered
 
 
 def verify_review(

--- a/scripts/verify_review.py
+++ b/scripts/verify_review.py
@@ -47,6 +47,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from scripts.review.evidence import build_target_manifest
 from scripts.review.review_contract import (
+    BEHAVIOR_PROOF_SCHEMA_VERSION,
     EXIT_INVALID,
     AgentIdentity,
     ContractError,
@@ -139,7 +140,7 @@ def _load_behavior_proof_state(
     """Load proof and its claim from the canonical frozen closeout state."""
     try:
         state = json.loads(state_file.read_text(encoding="utf-8"))
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         raise ContractError(
             f"behavior_proof_state_unreadable:{exc}", exit_code=EXIT_INVALID
         ) from exc
@@ -153,22 +154,28 @@ def _load_behavior_proof_state(
     proof = state.get("behavior_proof")
     if not isinstance(baseline, dict) or not isinstance(proof, dict):
         raise ContractError("behavior_proof_state_incomplete", exit_code=EXIT_INVALID)
+    if proof.get("schema_version") != BEHAVIOR_PROOF_SCHEMA_VERSION:
+        raise ContractError("behavior_proof_state_schema_version_invalid", exit_code=EXIT_INVALID)
     intended_behavior = baseline.get("intended_behavior")
     saved_target = baseline.get("target")
     if not isinstance(intended_behavior, str) or not intended_behavior.strip():
         raise ContractError("behavior_proof_state_intended_behavior_missing", exit_code=EXIT_INVALID)
     if not isinstance(saved_target, dict):
         raise ContractError("behavior_proof_state_target_missing", exit_code=EXIT_INVALID)
-    expected_target = {
+    stable_target_fields = {
         "mode": target.mode,
         "base_sha": target.base_sha,
         "head_sha": target.head_sha,
         "changed_paths": list(target.changed_paths),
         "non_test_loc": target.non_test_loc,
         "clean_tree": target.clean_tree,
-        "description": target.description,
     }
-    if saved_target != expected_target:
+    if any(field not in saved_target for field in stable_target_fields):
+        raise ContractError("behavior_proof_state_target_invalid", exit_code=EXIT_INVALID)
+    if any(
+        saved_target[field] != expected_value
+        for field, expected_value in stable_target_fields.items()
+    ):
         raise ContractError("behavior_proof_state_target_mismatch", exit_code=EXIT_INVALID)
     return proof, intended_behavior
 

--- a/scripts/verify_review.py
+++ b/scripts/verify_review.py
@@ -131,6 +131,48 @@ def _receipt_path_allowed(path: Path) -> bool:
     return "telemetry" not in parts
 
 
+def _load_behavior_proof_state(
+    state_file: Path,
+    *,
+    target,
+) -> tuple[dict, str]:
+    """Load proof and its claim from the canonical frozen closeout state."""
+    try:
+        state = json.loads(state_file.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ContractError(
+            f"behavior_proof_state_unreadable:{exc}", exit_code=EXIT_INVALID
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise ContractError(
+            f"behavior_proof_state_invalid_json:{exc.msg}", exit_code=EXIT_INVALID
+        ) from exc
+    if not isinstance(state, dict):
+        raise ContractError("behavior_proof_state_must_be_object", exit_code=EXIT_INVALID)
+    baseline = state.get("baseline")
+    proof = state.get("behavior_proof")
+    if not isinstance(baseline, dict) or not isinstance(proof, dict):
+        raise ContractError("behavior_proof_state_incomplete", exit_code=EXIT_INVALID)
+    intended_behavior = baseline.get("intended_behavior")
+    saved_target = baseline.get("target")
+    if not isinstance(intended_behavior, str) or not intended_behavior.strip():
+        raise ContractError("behavior_proof_state_intended_behavior_missing", exit_code=EXIT_INVALID)
+    if not isinstance(saved_target, dict):
+        raise ContractError("behavior_proof_state_target_missing", exit_code=EXIT_INVALID)
+    expected_target = {
+        "mode": target.mode,
+        "base_sha": target.base_sha,
+        "head_sha": target.head_sha,
+        "changed_paths": list(target.changed_paths),
+        "non_test_loc": target.non_test_loc,
+        "clean_tree": target.clean_tree,
+        "description": target.description,
+    }
+    if saved_target != expected_target:
+        raise ContractError("behavior_proof_state_target_mismatch", exit_code=EXIT_INVALID)
+    return proof, intended_behavior
+
+
 def _post_summary(issue: int, receipt: dict) -> None:
     counts: dict[str, int] = {}
     for item in receipt.get("findings") or []:
@@ -231,7 +273,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--behavior-proof-json",
         default="",
-        help="JSON object with source_aware / source_blind proof fields",
+        help="Legacy JSON object; passing proof needs --behavior-proof-state-file for its frozen claim",
+    )
+    parser.add_argument(
+        "--behavior-proof-state-file",
+        type=Path,
+        help=(
+            "Canonical closeout state from `closeout_cli behavior-proof record`; "
+            "loads target-bound proof and frozen intended behavior without hand-authored JSON"
+        ),
     )
     parser.add_argument(
         "--dispositions-json",
@@ -325,9 +375,6 @@ def main(argv: list[str] | None = None) -> int:
     try:
         scope = _load_json_arg(args.scope_json or None, label="--scope-json")
         tests = _load_json_arg(args.tests_json or None, label="--tests-json")
-        behavior_proof = _load_json_arg(
-            args.behavior_proof_json or None, label="--behavior-proof-json"
-        )
         dispositions = _load_json_arg(
             args.dispositions_json or None, label="--dispositions-json"
         )
@@ -360,6 +407,36 @@ def main(argv: list[str] | None = None) -> int:
         )
         return EXIT_INVALID
 
+    try:
+        if args.behavior_proof_state_file is not None:
+            if args.behavior_proof_json:
+                raise ContractError(
+                    "behavior_proof_source_conflict: use exactly one of --behavior-proof-json or --behavior-proof-state-file",
+                    exit_code=EXIT_INVALID,
+                )
+            behavior_proof, frozen_intended_behavior = _load_behavior_proof_state(
+                args.behavior_proof_state_file,
+                target=target,
+            )
+        else:
+            behavior_proof = _load_json_arg(
+                args.behavior_proof_json or None, label="--behavior-proof-json"
+            )
+            frozen_intended_behavior = ""
+    except ContractError as exc:
+        print(
+            json.dumps(
+                {
+                    "error": str(exc),
+                    "final_disposition": "invalid",
+                    "exit_code": EXIT_INVALID,
+                },
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+        )
+        return EXIT_INVALID
+
     ctx = VerifyContext(
         issue_ref=issue_ref,
         scope=scope,
@@ -383,6 +460,7 @@ def main(argv: list[str] | None = None) -> int:
         expected_input_sha256=args.expected_input_sha256 or None,
         tests=tests,
         behavior_proof=behavior_proof,
+        frozen_intended_behavior=frozen_intended_behavior,
         dispositions={
             str(k): v if isinstance(v, dict) else {"disposition": str(v)}
             for k, v in dispositions.items()

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -146,6 +146,7 @@ def test_behavior_proof_recording_round_trips_into_receipt(tmp_path):
     assert blind.returncode == 0, blind.stderr
 
     recorded = json.loads(_run_cli(state_file, "behavior-proof", "emit").stdout)
+    assert recorded["schema_version"] == "behavior-proof.v1"
     assert recorded["source_aware"]["clauses"][0]["claim"] == "add feature"
     assert recorded["source_blind"]["blind_enforced"] is False
 
@@ -208,6 +209,85 @@ def test_behavior_proof_recording_round_trips_into_receipt(tmp_path):
     receipt = json.loads(verify.stdout)
     assert receipt["behavior_proof"]["source_aware"] == recorded["source_aware"]
     assert receipt["behavior_proof"]["source_blind"]["blind_enforcement"] == "declared-blind/unenforced"
+
+
+def test_behavior_proof_record_rejects_malformed_proof_and_baseline_before_mutation(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    state_file = tmp_path / "state.json"
+    assert _run_cli(state_file, "target", "--mode", "local", "--repo-root", str(repo)).returncode == 0
+    assert _run_cli(state_file, *_freeze_kwargs()).returncode == 0
+
+    record_args = (
+        "behavior-proof", "record", "--surface", "source_aware", "--status", "pass",
+        "--step", "open the feature", "--result", "feature opened", "--observation", "visible",
+        "--evidence-ref", "test:manual",
+    )
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    for malformed in (None, [], "not-an-object"):
+        state["behavior_proof"] = malformed
+        state_file.write_text(json.dumps(state), encoding="utf-8")
+        before = state_file.read_bytes()
+        proc = _run_cli(state_file, *record_args)
+        assert proc.returncode != 0
+        assert json.loads(proc.stderr)["error"] == "behavior_proof_must_be_object"
+        assert state_file.read_bytes() == before
+
+    state_file.write_text(json.dumps({"baseline": {"intended_behavior": "partial"}}), encoding="utf-8")
+    proc = _run_cli(state_file, *record_args)
+    assert proc.returncode != 0
+    assert json.loads(proc.stderr)["error"] == "baseline_issue_ref_invalid"
+
+
+def test_behavior_proof_record_rejects_empty_steps_and_emit_before_record(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    state_file = tmp_path / "state.json"
+    assert _run_cli(state_file, "target", "--mode", "local", "--repo-root", str(repo)).returncode == 0
+    assert _run_cli(state_file, *_freeze_kwargs()).returncode == 0
+
+    emit = _run_cli(state_file, "behavior-proof", "emit")
+    assert emit.returncode != 0
+    assert json.loads(emit.stderr)["error"] == "no behavior proof recorded yet"
+
+    common = (
+        "behavior-proof", "record", "--surface", "source_aware", "--status", "pass",
+        "--result", "done", "--observation", "visible", "--evidence-ref", "test:manual",
+    )
+    for flag in ("--command", "--step"):
+        proc = _run_cli(state_file, *common, flag, "   ")
+        assert proc.returncode != 0
+        assert json.loads(proc.stderr)["error"] == "passing proof requires --command or --step"
+
+
+def test_behavior_proof_na_is_versioned_and_does_not_add_blind_enforcement(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    state_file = tmp_path / "state.json"
+    assert _run_cli(state_file, "target", "--mode", "local", "--repo-root", str(repo)).returncode == 0
+    assert _run_cli(state_file, *_freeze_kwargs()).returncode == 0
+
+    missing_reason = _run_cli(
+        state_file, "behavior-proof", "record", "--surface", "source_blind", "--status", "n/a"
+    )
+    assert missing_reason.returncode != 0
+    assert json.loads(missing_reason.stderr)["error"] == "n/a proof requires --reason"
+    recorded = _run_cli(
+        state_file, "behavior-proof", "record", "--surface", "source_blind", "--status", "n/a",
+        "--reason", "no user-visible surface",
+    )
+    assert recorded.returncode == 0, recorded.stderr
+    proof = json.loads(recorded.stdout)
+    assert proof["schema_version"] == "behavior-proof.v1"
+    assert "blind_enforced" not in proof["source_blind"]
+
+
+def test_closeout_cli_invalid_json_state_is_structured(tmp_path):
+    state_file = tmp_path / "state.json"
+    state_file.write_text("{not-json", encoding="utf-8")
+    proc = _run_cli(state_file, "target", "--mode", "local")
+    assert proc.returncode != 0
+    assert "state_invalid_json" in json.loads(proc.stderr)["error"]
 
 
 def test_check_expansion_commit_mode_measures_committed_fixes_not_clean_tree(tmp_path):

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -119,6 +119,97 @@ def test_full_flow_target_freeze_expansion_cycle_reviewer_findings(tmp_path):
     assert len(state["findings"]) == 3  # raised, adjudicated, applied
 
 
+def test_behavior_proof_recording_round_trips_into_receipt(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    state_file = tmp_path / "state.json"
+    assert _run_cli(state_file, "target", "--mode", "local", "--repo-root", str(repo)).returncode == 0
+    assert _run_cli(state_file, *_freeze_kwargs("#5302")).returncode == 0
+
+    common = (
+        "--status",
+        "pass",
+        "--command",
+        ".venv/bin/python -m scripts.review.closeout_cli --help",
+        "--cwd",
+        str(repo),
+        "--exit-code",
+        "0",
+        "--observation",
+        "command completed and printed help",
+        "--evidence-ref",
+        "test:closeout-cli-help",
+    )
+    aware = _run_cli(state_file, "behavior-proof", "record", "--surface", "source_aware", *common)
+    blind = _run_cli(state_file, "behavior-proof", "record", "--surface", "source_blind", *common)
+    assert aware.returncode == 0, aware.stderr
+    assert blind.returncode == 0, blind.stderr
+
+    recorded = json.loads(_run_cli(state_file, "behavior-proof", "emit").stdout)
+    assert recorded["source_aware"]["clauses"][0]["claim"] == "add feature"
+    assert recorded["source_blind"]["blind_enforced"] is False
+
+    review_file = tmp_path / "review.json"
+    review_file.write_text(
+        json.dumps(
+            {
+                "schema_version": "code-review-findings.v1",
+                "overall": {"correctness": "correct", "explanation": "clean", "confidence": 0.9},
+                "findings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    project_root = Path(__file__).resolve().parent.parent
+    verify = subprocess.run(
+        [
+            ".venv/bin/python",
+            "scripts/verify_review.py",
+            "--review-file",
+            str(review_file),
+            "--mode",
+            "local",
+            "--repo-root",
+            str(repo),
+            "--expected-input-sha256",
+            recorded["source_aware"]["clauses"][0]["target_input_sha256"],
+            "--issue-ref",
+            "#5302",
+            "--scope-json",
+            '{"owner_boundary":"repo root"}',
+            "--author-model",
+            "author-model",
+            "--author-family",
+            "openai",
+            "--author-harness",
+            "codex",
+            "--author-selection-reason",
+            "implementation",
+            "--reviewer-model",
+            "reviewer-model",
+            "--reviewer-family",
+            "xai",
+            "--reviewer-harness",
+            "grok",
+            "--reviewer-selection-reason",
+            "cross-family-review",
+            "--tests-json",
+            '{"commands":["pytest"],"passed":true}',
+            "--behavior-proof-state-file",
+            str(state_file),
+            "--routing-lineage-json",
+            '{"implementation_agent":"test","accountable_advisor":"test"}',
+        ],
+        cwd=str(project_root),
+        capture_output=True,
+        text=True,
+    )
+    assert verify.returncode == 0, verify.stderr
+    receipt = json.loads(verify.stdout)
+    assert receipt["behavior_proof"]["source_aware"] == recorded["source_aware"]
+    assert receipt["behavior_proof"]["source_blind"]["blind_enforcement"] == "declared-blind/unenforced"
+
+
 def test_check_expansion_commit_mode_measures_committed_fixes_not_clean_tree(tmp_path):
     """A commit/branch/pr-mode baseline must be re-measured against the
     committed post-fix head, not the (always-clean) local working tree.

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -223,8 +223,9 @@ def test_behavior_proof_record_rejects_malformed_proof_and_baseline_before_mutat
         "--step", "open the feature", "--result", "feature opened", "--observation", "visible",
         "--evidence-ref", "test:manual",
     )
-    state = json.loads(state_file.read_text(encoding="utf-8"))
+    valid_state = json.loads(state_file.read_text(encoding="utf-8"))
     for malformed in (None, [], "not-an-object"):
+        state = json.loads(json.dumps(valid_state))
         state["behavior_proof"] = malformed
         state_file.write_text(json.dumps(state), encoding="utf-8")
         before = state_file.read_bytes()
@@ -232,6 +233,24 @@ def test_behavior_proof_record_rejects_malformed_proof_and_baseline_before_mutat
         assert proc.returncode != 0
         assert json.loads(proc.stderr)["error"] == "behavior_proof_must_be_object"
         assert state_file.read_bytes() == before
+
+    state = json.loads(json.dumps(valid_state))
+    state["target_args"] = ["not", "an", "object"]
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+    before = state_file.read_bytes()
+    proc = _run_cli(state_file, *record_args)
+    assert proc.returncode != 0
+    assert json.loads(proc.stderr)["error"] == "target_args_must_be_object"
+    assert state_file.read_bytes() == before
+
+    state = json.loads(json.dumps(valid_state))
+    state["baseline"].pop("target")
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+    before = state_file.read_bytes()
+    proc = _run_cli(state_file, *record_args)
+    assert proc.returncode != 0
+    assert json.loads(proc.stderr)["error"] == "baseline_target_invalid"
+    assert state_file.read_bytes() == before
 
     state_file.write_text(json.dumps({"baseline": {"intended_behavior": "partial"}}), encoding="utf-8")
     proc = _run_cli(state_file, *record_args)

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -279,7 +279,7 @@ def test_behavior_proof_record_rejects_empty_steps_and_emit_before_record(tmp_pa
         assert json.loads(proc.stderr)["error"] == "passing proof requires --command or --step"
 
 
-def test_behavior_proof_na_is_versioned_and_does_not_add_blind_enforcement(tmp_path):
+def test_behavior_proof_na_is_versioned_and_preserves_explicit_blind_enforcement(tmp_path):
     repo = _init_repo(tmp_path)
     (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
     state_file = tmp_path / "state.json"
@@ -299,6 +299,13 @@ def test_behavior_proof_na_is_versioned_and_does_not_add_blind_enforcement(tmp_p
     proof = json.loads(recorded.stdout)
     assert proof["schema_version"] == "behavior-proof.v1"
     assert "blind_enforced" not in proof["source_blind"]
+
+    explicit = _run_cli(
+        state_file, "behavior-proof", "record", "--surface", "source_blind", "--status", "n/a",
+        "--reason", "isolation unavailable", "--blind-enforced",
+    )
+    assert explicit.returncode == 0, explicit.stderr
+    assert json.loads(explicit.stdout)["source_blind"]["blind_enforced"] is True
 
 
 def test_closeout_cli_invalid_json_state_is_structured(tmp_path):

--- a/tests/test_verify_review.py
+++ b/tests/test_verify_review.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from pathlib import Path
 
 import pytest
@@ -794,6 +794,19 @@ def test_target_fingerprint_changes_after_local_mutation(tmp_path):
     fp2 = compute_target_input_fingerprint(repo, target2)
     assert fp1 != fp2
     assert len(fp1) == 64
+
+
+def test_target_fingerprint_ignores_equivalent_ref_description(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(repo, "commit", "-q", "-m", "feature")
+    target = resolve_commit_target(repo, "HEAD")
+    equivalent_ref = replace(target, description="same commit via branch name")
+
+    assert compute_target_input_fingerprint(
+        repo, target
+    ) == compute_target_input_fingerprint(repo, equivalent_ref)
 
 
 def test_missing_expected_fingerprint_cannot_exit_clean(tmp_path):

--- a/tests/test_verify_review.py
+++ b/tests/test_verify_review.py
@@ -32,6 +32,7 @@ from scripts.review.evidence import (
     split_lines_preserve_content,
 )
 from scripts.review.review_contract import (
+    BEHAVIOR_PROOF_SCHEMA_VERSION,
     EXIT_ACTIONABLE,
     EXIT_CLEAN,
     EXIT_INCOMPLETE,
@@ -162,6 +163,7 @@ def _full_envelope_kwargs(repo: Path, target, **overrides):
         ),
         "tests": {"commands": ["pytest"], "passed": True},
         "behavior_proof": {
+            "schema_version": BEHAVIOR_PROOF_SCHEMA_VERSION,
             "source_aware": {"status": "pass", "clauses": [clause("source-aware")]},
             "source_blind": {
                 "status": "pass",
@@ -232,6 +234,7 @@ def _cli_envelope_args(repo: Path, *, dispositions: dict | None = None) -> list[
                     "target": asdict(target),
                 },
                 "behavior_proof": {
+                    "schema_version": BEHAVIOR_PROOF_SCHEMA_VERSION,
                     "source_aware": {"status": "pass", "clauses": [clause("source-aware")]},
                     "source_blind": {
                         "status": "pass",
@@ -1309,6 +1312,7 @@ def test_failed_behavior_proof_cannot_exit_clean(tmp_path):
             target,
             raw,
             behavior_proof={
+                "schema_version": BEHAVIOR_PROOF_SCHEMA_VERSION,
                 "source_aware": {"status": "fail"},
                 "source_blind": {"status": "fail"},
             },
@@ -1331,6 +1335,7 @@ def test_bare_passing_behavior_proof_is_incomplete(tmp_path):
             target,
             raw,
             behavior_proof={
+                "schema_version": BEHAVIOR_PROOF_SCHEMA_VERSION,
                 "source_aware": {"status": "pass"},
                 "source_blind": {"status": "pass", "blind_enforced": False},
             },
@@ -1382,6 +1387,49 @@ def test_blind_enforcement_requires_attestation_and_unenforced_is_rendered(tmp_p
     enforced = verify_review(raw, _ctx(repo, target, raw, behavior_proof=enforced_proof))
     assert enforced.exit_code == EXIT_INCOMPLETE
     assert "behavior_proof.source_blind_enforced_without_attestation" in (enforced.error or "")
+
+
+def test_na_blind_proof_requires_reason_but_not_blind_enforced(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    proof = _full_envelope_kwargs(repo, target)["behavior_proof"]
+    del proof["source_blind"]["blind_enforced"]
+    missing_pass_boolean = verify_review(raw, _ctx(repo, target, raw, behavior_proof=proof))
+    assert missing_pass_boolean.exit_code == EXIT_INCOMPLETE
+    assert "behavior_proof.source_blind_blind_enforced_missing" in (
+        missing_pass_boolean.error or ""
+    )
+
+    proof = _full_envelope_kwargs(repo, target)["behavior_proof"]
+    proof["source_blind"] = {"status": "n/a"}
+    missing_reason = verify_review(raw, _ctx(repo, target, raw, behavior_proof=proof))
+    assert missing_reason.exit_code == EXIT_INCOMPLETE
+    assert "behavior_proof.source_blind_na_reason_empty" in (missing_reason.error or "")
+
+    proof["source_blind"] = {
+        "status": "n/a",
+        "reason": "no user-visible surface",
+        "blind_enforced": True,
+    }
+    unjustified_enforcement = verify_review(raw, _ctx(repo, target, raw, behavior_proof=proof))
+    assert unjustified_enforcement.exit_code == EXIT_INCOMPLETE
+    assert "behavior_proof.source_blind_enforced_without_attestation" in (
+        unjustified_enforcement.error or ""
+    )
+
+
+def test_unversioned_green_behavior_proof_cannot_exit_clean(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    proof = _full_envelope_kwargs(repo, target)["behavior_proof"]
+    del proof["schema_version"]
+    result = verify_review(raw, _ctx(repo, target, raw, behavior_proof=proof))
+    assert result.exit_code == EXIT_INCOMPLETE
+    assert "behavior_proof_schema_version_invalid" in (result.error or "")
 
 
 def test_blind_enforcement_uses_optional_target_bound_attestation_validator(tmp_path):
@@ -1466,6 +1514,7 @@ def test_missing_behavior_status_is_incomplete(tmp_path):
             target,
             raw,
             behavior_proof={
+                "schema_version": BEHAVIOR_PROOF_SCHEMA_VERSION,
                 "source_aware": {"note": "present without status"},
                 "source_blind": {"status": "pass"},
             },
@@ -1621,6 +1670,78 @@ def test_cli_malformed_envelope_json_exits_invalid(tmp_path, capsys):
         assert "invalid_json" in data["error"]
 
 
+def test_behavior_proof_state_rejects_invalid_shapes_and_bytes(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    state_file = tmp_path / "state.json"
+
+    state_file.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(ContractError, match="behavior_proof_state_invalid_json") as exc:
+        verify_review_cli._load_behavior_proof_state(state_file, target=target)
+    assert exc.value.exit_code == EXIT_INVALID
+
+    state_file.write_bytes(b"\xff")
+    with pytest.raises(ContractError, match="behavior_proof_state_unreadable") as exc:
+        verify_review_cli._load_behavior_proof_state(state_file, target=target)
+    assert exc.value.exit_code == EXIT_INVALID
+
+    state_file.write_text(json.dumps({"baseline": {"intended_behavior": "x"}, "behavior_proof": None}), encoding="utf-8")
+    with pytest.raises(ContractError, match="behavior_proof_state_incomplete"):
+        verify_review_cli._load_behavior_proof_state(state_file, target=target)
+
+
+def test_behavior_proof_state_checks_stable_target_identity_not_description(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(repo, "commit", "-q", "-m", "feature")
+    target = resolve_commit_target(repo, "HEAD")
+    proof = _full_envelope_kwargs(repo, target)["behavior_proof"]
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "baseline": {
+                    "intended_behavior": "test intended behavior",
+                    "target": {**asdict(target), "description": "equivalent ref display"},
+                },
+                "behavior_proof": proof,
+            }
+        ),
+        encoding="utf-8",
+    )
+    loaded_proof, claim = verify_review_cli._load_behavior_proof_state(state_file, target=target)
+    assert loaded_proof == proof
+    assert claim == "test intended behavior"
+
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    state["baseline"]["target"]["changed_paths"] = ["different.py"]
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+    with pytest.raises(ContractError, match="behavior_proof_state_target_mismatch"):
+        verify_review_cli._load_behavior_proof_state(state_file, target=target)
+
+    state["baseline"]["target"] = asdict(target)
+    state["behavior_proof"] = {key: value for key, value in proof.items() if key != "schema_version"}
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+    with pytest.raises(ContractError, match="behavior_proof_state_schema_version_invalid"):
+        verify_review_cli._load_behavior_proof_state(state_file, target=target)
+
+
+def test_cli_rejects_dual_behavior_proof_sources(tmp_path, capsys):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    review = tmp_path / "review.json"
+    review.write_text(json.dumps(_clean_payload()), encoding="utf-8")
+    args = _cli_envelope_args(repo)
+    code = verify_review_cli.main(
+        ["--review-file", str(review), *args, "--behavior-proof-json", json.dumps({})]
+    )
+    assert code == EXIT_INVALID
+    data = json.loads(capsys.readouterr().err)
+    assert data["error"] == "behavior_proof_source_conflict: use exactly one of --behavior-proof-json or --behavior-proof-state-file"
+
+
 def test_cli_failed_proof_and_same_family_non_clean(tmp_path, capsys):
     repo = _init_repo(tmp_path)
     (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
@@ -1670,6 +1791,7 @@ def test_cli_failed_proof_and_same_family_non_clean(tmp_path, capsys):
             "--behavior-proof-json",
             json.dumps(
                 {
+                    "schema_version": BEHAVIOR_PROOF_SCHEMA_VERSION,
                     "source_aware": {"status": "fail"},
                     "source_blind": {"status": "fail"},
                 }
@@ -1693,6 +1815,7 @@ def test_cli_failed_proof_and_same_family_non_clean(tmp_path, capsys):
             "--behavior-proof-json",
             json.dumps(
                 {
+                    "schema_version": BEHAVIOR_PROOF_SCHEMA_VERSION,
                     "source_aware": {"status": "n/a", "reason": "not exercised"},
                     "source_blind": {"status": "n/a", "reason": "not exercised"},
                 }

--- a/tests/test_verify_review.py
+++ b/tests/test_verify_review.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
 import pytest
@@ -136,6 +137,19 @@ def _finding(
 def _full_envelope_kwargs(repo: Path, target, **overrides):
     """Runner envelope sufficient for clean/actionable closeout."""
     fp = compute_target_input_fingerprint(repo, target)
+    intended_behavior = "test intended behavior"
+
+    def clause(surface: str) -> dict:
+        return {
+            "claim": intended_behavior,
+            "target_input_sha256": fp,
+            "command": f"prove {surface}",
+            "cwd": str(repo),
+            "exit_code": 0,
+            "observation": f"{surface} observed",
+            "evidence_ref": f"test:{surface}",
+        }
+
     base = {
         "issue_ref": "#5284",
         "scope": {"owner_boundary": "scripts/verify_review.py"},
@@ -148,9 +162,14 @@ def _full_envelope_kwargs(repo: Path, target, **overrides):
         ),
         "tests": {"commands": ["pytest"], "passed": True},
         "behavior_proof": {
-            "source_aware": {"status": "pass"},
-            "source_blind": {"status": "pass", "note": "cli-proof"},
+            "source_aware": {"status": "pass", "clauses": [clause("source-aware")]},
+            "source_blind": {
+                "status": "pass",
+                "clauses": [clause("source-blind")],
+                "blind_enforced": False,
+            },
         },
+        "frozen_intended_behavior": intended_behavior,
         "routing_lineage": {
             "implementation_agent": "test-impl",
             "accountable_advisor": "test-advisor",
@@ -182,6 +201,7 @@ def _ctx(
         expected_input_sha256=env.get("expected_input_sha256"),
         tests=env["tests"],
         behavior_proof=env["behavior_proof"],
+        frozen_intended_behavior=env["frozen_intended_behavior"],
         dispositions=env["dispositions"],
         routing_lineage=env["routing_lineage"],
     )
@@ -190,6 +210,39 @@ def _ctx(
 def _cli_envelope_args(repo: Path, *, dispositions: dict | None = None) -> list[str]:
     target = resolve_local_target(repo)
     fp = compute_target_input_fingerprint(repo, target)
+    intended_behavior = "test intended behavior"
+    state_file = repo.parent / "behavior-proof-state.json"
+
+    def clause(surface: str) -> dict:
+        return {
+            "claim": intended_behavior,
+            "target_input_sha256": fp,
+            "command": f"prove {surface}",
+            "cwd": str(repo),
+            "exit_code": 0,
+            "observation": f"{surface} observed",
+            "evidence_ref": f"test:{surface}",
+        }
+
+    state_file.write_text(
+        json.dumps(
+            {
+                "baseline": {
+                    "intended_behavior": intended_behavior,
+                    "target": asdict(target),
+                },
+                "behavior_proof": {
+                    "source_aware": {"status": "pass", "clauses": [clause("source-aware")]},
+                    "source_blind": {
+                        "status": "pass",
+                        "clauses": [clause("source-blind")],
+                        "blind_enforced": False,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
     args = [
         "--mode",
         "local",
@@ -219,13 +272,8 @@ def _cli_envelope_args(repo: Path, *, dispositions: dict | None = None) -> list[
         "cross-family-gate",
         "--tests-json",
         json.dumps({"commands": ["pytest"], "passed": True}),
-        "--behavior-proof-json",
-        json.dumps(
-            {
-                "source_aware": {"status": "pass"},
-                "source_blind": {"status": "pass"},
-            }
-        ),
+        "--behavior-proof-state-file",
+        str(state_file),
         "--routing-lineage-json",
         json.dumps(
             {
@@ -1271,6 +1319,90 @@ def test_failed_behavior_proof_cannot_exit_clean(tmp_path):
     assert "behavior_proof.source_blind_failed" in (result.error or "")
 
 
+def test_bare_passing_behavior_proof_is_incomplete(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    result = verify_review(
+        raw,
+        _ctx(
+            repo,
+            target,
+            raw,
+            behavior_proof={
+                "source_aware": {"status": "pass"},
+                "source_blind": {"status": "pass", "blind_enforced": False},
+            },
+        ),
+    )
+    assert result.exit_code == EXIT_INCOMPLETE
+    assert "behavior_proof.source_aware_clauses_missing" in (result.error or "")
+    assert "behavior_proof.source_blind_clauses_missing" in (result.error or "")
+
+
+def test_mismatched_behavior_proof_target_binding_is_incomplete(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    proof = _full_envelope_kwargs(repo, target)["behavior_proof"]
+    proof["source_aware"]["clauses"][0]["target_input_sha256"] = "wrong-target"
+    result = verify_review(raw, _ctx(repo, target, raw, behavior_proof=proof))
+    assert result.exit_code == EXIT_INCOMPLETE
+    assert "behavior_proof.source_aware_target_binding_mismatch" in (result.error or "")
+
+
+def test_missing_behavior_proof_target_binding_is_incomplete(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    proof = _full_envelope_kwargs(repo, target)["behavior_proof"]
+    del proof["source_aware"]["clauses"][0]["target_input_sha256"]
+    result = verify_review(raw, _ctx(repo, target, raw, behavior_proof=proof))
+    assert result.exit_code == EXIT_INCOMPLETE
+    assert "behavior_proof.source_aware_target_binding_mismatch" in (result.error or "")
+
+
+def test_blind_enforcement_requires_attestation_and_unenforced_is_rendered(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    unenforced = verify_review(raw, _ctx(repo, target, raw))
+    assert unenforced.exit_code == EXIT_CLEAN
+    assert (
+        unenforced.receipt["behavior_proof"]["source_blind"]["blind_enforcement"]
+        == "declared-blind/unenforced"
+    )
+
+    enforced_proof = _full_envelope_kwargs(repo, target)["behavior_proof"]
+    enforced_proof["source_blind"]["blind_enforced"] = True
+    enforced = verify_review(raw, _ctx(repo, target, raw, behavior_proof=enforced_proof))
+    assert enforced.exit_code == EXIT_INCOMPLETE
+    assert "behavior_proof.source_blind_enforced_without_attestation" in (enforced.error or "")
+
+
+def test_blind_enforcement_uses_optional_target_bound_attestation_validator(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
+    target = resolve_local_target(repo)
+    raw = json.dumps(_clean_payload())
+    proof = _full_envelope_kwargs(repo, target)["behavior_proof"]
+    proof["source_blind"]["blind_enforced"] = True
+    proof["source_blind"]["isolation_attestation"] = {
+        "target_input_sha256": compute_target_input_fingerprint(repo, target),
+        "attestation_id": "provided-by-5285",
+    }
+    ctx = _ctx(repo, target, raw, behavior_proof=proof)
+    ctx.isolation_attestation_validator = lambda attestation, reviewed_target: (
+        attestation["attestation_id"] == "provided-by-5285" and reviewed_target == target
+    )
+    result = verify_review(raw, ctx)
+    assert result.exit_code == EXIT_CLEAN
+
+
 def test_same_family_lineage_cannot_exit_clean(tmp_path):
     repo = _init_repo(tmp_path)
     (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
@@ -1300,6 +1432,11 @@ def test_justified_na_tests_and_behavior_proof_can_exit_clean(tmp_path):
     (repo / "app.py").write_text("print('v2')\n", encoding="utf-8")
     target = resolve_local_target(repo)
     raw = json.dumps(_clean_payload())
+    behavior_proof = _full_envelope_kwargs(repo, target)["behavior_proof"]
+    behavior_proof["source_blind"] = {
+        "status": "n/a",
+        "reason": "no user-visible surface",
+    }
     result = verify_review(
         raw,
         _ctx(
@@ -1310,13 +1447,7 @@ def test_justified_na_tests_and_behavior_proof_can_exit_clean(tmp_path):
                 "status": "n/a",
                 "reason": "no automated suite for docs-only surface",
             },
-            behavior_proof={
-                "source_aware": {"status": "pass"},
-                "source_blind": {
-                    "status": "n/a",
-                    "reason": "no user-visible surface",
-                },
-            },
+            behavior_proof=behavior_proof,
         ),
     )
     assert result.exit_code == EXIT_CLEAN
@@ -1562,8 +1693,8 @@ def test_cli_failed_proof_and_same_family_non_clean(tmp_path, capsys):
             "--behavior-proof-json",
             json.dumps(
                 {
-                    "source_aware": {"status": "pass"},
-                    "source_blind": {"status": "pass"},
+                    "source_aware": {"status": "n/a", "reason": "not exercised"},
+                    "source_blind": {"status": "n/a", "reason": "not exercised"},
                 }
             ),
         ]


### PR DESCRIPTION
## Summary

- Add `behavior-proof.v1` to canonical closeout state and reject bare or unbound passing proof.
- Add `closeout_cli behavior-proof record|emit`; let `verify_review` consume the frozen state.
- Render source-blind evidence honestly as declared-blind/unenforced unless a validated #5285 attestation exists.
- Add `target-input-v2`, so equivalent ref spellings share a fingerprint while stable target metadata and patch bytes remain bound.
- Fail closed on malformed closeout state and preserve explicit enforcement claims for every proof status.

## Decision

Keep the existing `local-code-review` skill. Do not add a new skill or handoff status field. Handoffs should reference the durable review receipt identity/path plus target SHA instead of duplicating proof state.

## Review evidence

- Final target: `002f5b758d9c47be9b57350910c6c707e17d415d..715955deef402771466a0574eacc95efaea62375`
- Target-input fingerprint: `8c928d41f4ad6c51503382f41091d952d54d29c661771c608278643e34a16cf0`
- Formal cross-family receipt: clean, Claude Opus 4.8, no findings.
- Gemini and Claude findings were fixed and re-reviewed; Grok independently reported the final behavior correct but its prose-prefixed response was advisory-only.

## Validation

- `80 passed`: `tests/test_review_closeout_cli.py` + `tests/test_verify_review.py`
- Ruff: changed Python/tests clean
- Skill metadata + all local-code-review mirror parity: pass
- `git diff --check`: pass
- Agent trailer audit: all five commits pass
- Pre-submit artifact/config/test-weakening checks: pass

Fixes #5302
Parent: #5281
Infra stream: #4707