### PR TITLE
feat(orchestration): enforce fleet task lifecycle closeout

### DIFF
--- a/agents_extensions/shared/contracts/task-lifecycle-closeout.md
+++ b/agents_extensions/shared/contracts/task-lifecycle-closeout.md
@@ -1,0 +1,162 @@
+# Task lifecycle and GitHub closeout contract
+
+`task-lifecycle.v1` is the fleet-wide, provider-neutral state and evidence
+contract for non-trivial coding work. It wraps the canonical
+`task-identity.v1` envelope; it never replaces or weakens that identity.
+
+The implementation is `scripts/orchestration/task_lifecycle.py`. The operator
+entry point is:
+
+```bash
+.venv/bin/python -m scripts.orchestration.task_closeout --help
+```
+
+## Authority and storage
+
+- GitHub is authoritative for repository, issue, native parent epic, PR,
+  reviews, requested changes, checks, merge, deployments, comments, and issue
+  state.
+- Git and the filesystem are authoritative for the primary checkout,
+  dispatch worktree, commits, trailers, changed paths, branches, and cleanup.
+- The lifecycle ledger is an append-only projection of those observations. It
+  cannot overwrite contradictory authority facts.
+- Runtime ledgers live below the primary checkout's shared Git directory at
+  `.agent/task-lifecycle/<repository-digest>/issue-<number>.json`. The exact
+  `task-identity.v1` repository and issue deterministically locate the same
+  ledger after delegation, worktree changes, process crashes, or rollover.
+- Writes are locked and atomic. Replaying an identical observation returns the
+  existing receipt and performs no mutation.
+
+## States and terminal goals
+
+The lifecycle projection uses these typed states:
+
+`ISSUE_LINKED` → `ACS_FINALIZED` → `IMPLEMENTATION_READY` → `PR_OPEN` →
+`REVIEW_REQUESTED` / `CHANGES_REQUESTED` → `REVIEW_PASSED` → `CI_PASSED` →
+`MERGED` → optional `DEPLOYED` → optional `CERTIFIED` → `ISSUE_CLOSED` →
+`CLEANED_UP`.
+
+`BLOCKED_WITH_RECEIPT` is a recoverable fail-closed disposition for a material
+identity, evidence, review, check, scope, mutation, or cleanup failure. Every
+new observation receipt names the author-family owner and next action. Ordinary
+review/check waiting remains an actionable nonterminal state and is not called
+blocked.
+
+Terminal goals remain distinct:
+
+- `merge` requires verified merge, issue closure, and cleanup;
+- `deploy` additionally requires a successful deployment bound to the merge;
+- `certify` additionally requires typed certification evidence bound to the
+  deployment/merge.
+
+## Acceptance criteria and evidence
+
+Issue acceptance criteria use stable operator-visible IDs:
+
+```markdown
+- [ ] **AC-01** — A concrete, verifiable requirement.
+```
+
+Initialization snapshots the ID, canonical text, applicability, due state,
+and required typed evidence. A SHA-256 hash covers the ordered canonical
+snapshot. Reconciliation fails closed for missing, duplicate, reordered,
+removed, or text-drifted criteria. A checked box is a display projection, not
+proof.
+
+Every evidence record binds to the exact repository, issue, PR, and current PR
+head. Its type, summary, URL (when applicable), digest, timestamp, and optional
+details remain immutable. Review evidence additionally records author family,
+outside reviewer family, verdict, and reviewed commit. The referenced review
+receipt must exist in either the authoritative PR conversation comments or the
+native pull-request reviews endpoint, and requested changes must be absent on
+the current head.
+
+An AC policy marks a user-visible criterion with
+`behavior_proof_required: true` and includes the typed `behavior_proof`
+evidence requirement. That evidence never copies a prose status. Its
+`details.behavior_proof_receipt` references the canonical #5302
+`code-review-receipt.v1` JSON by absolute path and SHA-256 digest, records the
+receipt's target-input fingerprint, and binds the receipt's exact target SHA to
+the evidence subject/current PR head. Reconciliation reads the receipt and
+requires a clean outside-family closeout plus its target-bound
+`behavior-proof.v1` source-aware/source-blind surfaces. Prefer a shared
+`.agent/review-closeout/` receipt path so rollover and worktree cleanup do not
+discard the proof.
+
+Evidence due at `ISSUE_CLOSED` or `CLEANED_UP` may be derived from the
+post-action authoritative observation. This permits truthful staged closeout
+without pretending issue closure or cleanup happened before it did. The task is
+not terminal until those post-action criteria are also evidenced and checked.
+
+## Reconciliation and mutation
+
+`reconcile` is read-only. It observes GitHub and local Git, validates identity,
+AC drift/evidence, stream membership, review independence, checks, terminal
+goal, remaining scope, and cleanup, then emits a durable receipt plus a concise
+disposition.
+
+Remote mutation requires both an explicit action and `--authorize`. Supported
+actions are deliberately narrow:
+
+- `sync-acs`: check only criteria whose evidence is currently valid;
+- `arm-auto-merge`: require current-head outside-family review, clean local
+  readiness, and no material blocker before arming squash auto-merge;
+- `close-issue`: require the terminal goal's remote result, no untransferred
+  remaining scope, and every pre-close criterion evidenced and checked.
+
+Each action persists an intent before the remote call and performs authoritative
+readback afterward. If the process crashes after GitHub succeeds but before the
+local result receipt, retry observes the desired remote state, records recovery,
+and does not repeat the mutation. A missing `--authorize`, a rejected mutation
+gate, or a failed remote call writes a durable `BLOCKED_WITH_RECEIPT` mutation
+event with the actor, reason, and recovery instruction without broadening the
+allowed mutation surface.
+
+Auto-close keywords (`Fixes #N`) are intent only. They never count as proof.
+Post-merge reconciliation reads the real issue state; premature or failed close
+is `BLOCKED_WITH_RECEIPT` with an owner, reason, evidence, and next action.
+
+## Remaining scope
+
+`remaining_scope.status` is one of `none`, `open`, or `transferred`.
+
+- `open` always blocks closure.
+- `transferred` requires the follow-up issue, exactly one registered parent
+  stream epic, explicit transferred scope/evidence, and reciprocal issue links.
+- The original AC snapshot may change only through an explicit new snapshot
+  version; prior hashes and receipts remain immutable.
+
+## Git and review gates
+
+Readiness requires a dispatch worktree, a clean primary checkout, valid
+`X-Agent` trailers on every task commit, no protected/generated artifacts, a
+current-head independent outside-author-family review, no unresolved requested
+changes, and passing required checks. Auto-merge must not predate the verified
+review receipt and cannot be armed for a draft PR.
+
+The claimed dispatch worktree must exist in `git worktree list --porcelain`,
+must use the required dispatch subtree, and its Git-recorded branch must match
+the expected PR head branch. A caller-provided path or branch string is never
+accepted as proof by itself.
+
+Completion requires the PR's terminal state, actual issue closure, removal of
+the exact dispatch worktree, and absence of both local and remote task branches.
+An open/draft PR is nonterminal unless a durable blocker names the owner and next
+action.
+
+## Fleet carriers
+
+The validated carrier contains the full task identity and AC snapshot, terminal
+goal, PR binding, remaining scope, current projection, ledger path, and latest
+receipt digest. `delegate.py`, the agent ledger, and orchestrator run/inbox state
+carry this exact projection. Monitor coordination endpoints expose agent-ledger
+records unchanged.
+
+Rollover does not copy or fork lifecycle truth. The replacement's
+`task-identity.v1` envelope deterministically locates the same shared ledger,
+then validates the carrier before resuming. Harnesses therefore share one
+contract even when native title or task APIs differ.
+
+Legacy lifecycle data is migrated to an explicit `migration` record without
+rewriting evidence or receipt history. A legacy terminal goal of `unknown`
+cannot enter implementation readiness.

--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -314,13 +314,35 @@ Every OPEN issue belongs to **exactly one stream epic**. The registry is
 
 Every task follows this workflow. No exceptions for non-trivial changes.
 
-1. **Create GH issue** — describe the problem, draft a plan, **link it to its stream epic** (see Work intake above)
-2. **Adversarial review of plan** — send to Gemini, incorporate feedback
-3. **Finalize ACs** — update issue with concrete acceptance criteria
-4. **Implement** — work through ACs one by one
-5. **Verify all ACs** — every AC checked and documented on the issue
-6. **Adversarial review of implementation** — send code to Gemini, fix findings
-7. **Close** — only when all ACs pass and review is clean
+1. **Create GH issue** — describe the problem and link it to exactly one stream epic.
+2. **Review the plan** — obtain outside input and incorporate the disposition.
+3. **Finalize stable ACs** — use `- [ ] **AC-ID** — text`, then snapshot their
+   applicability, due state, evidence types, and content hash in
+   `task-lifecycle.v1`.
+4. **Implement in the dispatch worktree** — carry the lifecycle ledger with
+   `--lifecycle-file` through delegation, the agent ledger, and coordinator state.
+5. **Record typed AC evidence** — checkboxes are a display projection, never proof.
+   User-visible ACs require typed `behavior_proof` evidence referencing the
+   canonical #5302 receipt path/digest, target-input fingerprint, and exact
+   reviewed SHA; never copy a `behavior_proof_status` string.
+6. **Pass the independent review and CI gates** — review evidence must be from
+   outside the author model family and bound to the current PR head.
+7. **Reach the explicit terminal goal** — `merge`, `deploy`, and `certify` are
+   distinct and cannot substitute for one another.
+8. **Reconcile and close** — read actual GitHub state, transfer any remaining
+   scope first, close the issue explicitly, then remove the exact branch/worktree.
+
+The machine gate is:
+
+```bash
+.venv/bin/python -m scripts.orchestration.task_closeout --help
+```
+
+Read-only `reconcile` appends an idempotent observation receipt. Remote changes
+require `mutate`, an exact action, `--authorize`, and an actor. `Fixes #N`, a
+completed worker, or a merged PR never proves issue closeout by itself. The
+canonical contract is
+`agents_extensions/shared/contracts/task-lifecycle-closeout.md`.
 
 **Goal-Driven Execution (step 4)**: Transform imperative tasks into verifiable goals. For multi-step work, state a plan with explicit verification at each step:
 ```
@@ -332,11 +354,12 @@ Strong success criteria enable independent looping. Weak criteria ("make it work
 
 **Skip plan review** (step 2) only for trivial changes (< 50 lines, config/typo fixes).
 
-**Adversarial review command** (steps 2 & 6). Always use `--model gemini-3.1-pro-preview`. Document findings on the GH issue.
+**Adversarial review command** (steps 2 & 6). Use a current cross-family
+review lane and document findings on the GH issue.
 ```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini \
-  "Adversarial review for #NNN. Read {path}." \
-  --task-id issue-NNN --model gemini-3.1-pro-preview
+printf '%s\n' "Adversarial review for #NNN. Read {path}." | \
+  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - \
+    --task-id review-NNN --to-model gemini-3.1-pro-high --review
 ```
 
 ## Channel bridge (#1190, shipped 2026-04-12)
@@ -357,23 +380,27 @@ cross-agent discussions, anything that needs pinned context.
 **Not preferred for:** one-off drive-by questions — use `ask-*` for
 those.
 
-**Quick reference**:
+**Quick reference** (through the explicit project bridge; never run bare
+`ab`, which resolves to ApacheBench on the operator machine):
 ```bash
   # List / inspect
-ab channel list
-ab channel info pipeline
-ab channel tail reviews -n 20
-ab channel tail reviews --thread THREAD_ID
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel list
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel info pipeline
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel tail reviews -n 20
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel tail reviews --thread THREAD_ID
 
   # Post (short form — single recipient)
-ab p reviews gemini "quick question about module X"
+.venv/bin/python scripts/ai_agent_bridge/__main__.py p reviews gemini \
+  "quick question about module X"
 
   # Post (long form — multi-recipient, threading, parent/corr ids)
-ab post reviews "Review of #NNN" --to gemini,codex --parent MSG_ID
+.venv/bin/python scripts/ai_agent_bridge/__main__.py post reviews \
+  "Review of #NNN" --to gemini,codex --parent MSG_ID
 
   # Multi-agent bounded discussion
-ab discuss architecture "Should we extract the V6 god object?" \
-    --with claude,gemini,codex --max-rounds 2
+.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss architecture \
+  "Should we extract the V6 god object?" \
+  --with claude,gemini,codex --max-rounds 2
 ```
 
 `ab discuss` runs rounds in parallel via ThreadPoolExecutor,

--- a/agents_extensions/shared/schemas/task-lifecycle.v1.schema.json
+++ b/agents_extensions/shared/schemas/task-lifecycle.v1.schema.json
@@ -1,0 +1,279 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "task-lifecycle.v1",
+  "title": "Fleet task lifecycle and closeout ledger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "lifecycle_id",
+    "identity",
+    "terminal_goal",
+    "current_state",
+    "author_family",
+    "pr",
+    "ac_snapshot",
+    "evidence",
+    "required_checks",
+    "remaining_scope",
+    "observation_receipts",
+    "mutation_receipts",
+    "created_at",
+    "updated_at",
+    "migration"
+  ],
+  "properties": {
+    "schema_version": {"const": "task-lifecycle.v1"},
+    "lifecycle_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "identity": {"type": "object"},
+    "terminal_goal": {"enum": ["merge", "deploy", "certify"]},
+    "current_state": {
+      "enum": [
+        "ISSUE_LINKED",
+        "ACS_FINALIZED",
+        "IMPLEMENTATION_READY",
+        "PR_OPEN",
+        "REVIEW_REQUESTED",
+        "CHANGES_REQUESTED",
+        "REVIEW_PASSED",
+        "CI_PASSED",
+        "MERGED",
+        "DEPLOYED",
+        "CERTIFIED",
+        "ISSUE_CLOSED",
+        "CLEANED_UP",
+        "BLOCKED_WITH_RECEIPT"
+      ]
+    },
+    "author_family": {"type": "string", "minLength": 1, "maxLength": 100},
+    "pr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["number", "url"],
+      "properties": {
+        "number": {"type": ["integer", "null"], "minimum": 1},
+        "url": {"type": ["string", "null"], "format": "uri", "maxLength": 500}
+      }
+    },
+    "ac_snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "content_hash", "finalized_at", "criteria"],
+      "properties": {
+        "schema_version": {"const": "acceptance-criteria.v1"},
+        "content_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "finalized_at": {"type": "string", "format": "date-time"},
+        "criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "text",
+              "applicable",
+              "due_state",
+              "required_evidence",
+              "behavior_proof_required"
+            ],
+            "properties": {
+              "id": {"type": "string", "pattern": "^[A-Z][A-Z0-9_-]{1,31}$"},
+              "text": {"type": "string", "minLength": 1, "maxLength": 4000},
+              "applicable": {"type": "boolean"},
+              "due_state": {
+                "enum": [
+                  "IMPLEMENTATION_READY",
+                  "REVIEW_PASSED",
+                  "CI_PASSED",
+                  "MERGED",
+                  "DEPLOYED",
+                  "CERTIFIED",
+                  "ISSUE_CLOSED",
+                  "CLEANED_UP"
+                ]
+              },
+              "required_evidence": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "enum": [
+                    "command",
+                    "test",
+                    "review",
+                    "behavior_proof",
+                    "ci",
+                    "github",
+                    "deployment",
+                    "certification",
+                    "follow_up",
+                    "cleanup",
+                    "document"
+                  ]
+                }
+              },
+              "behavior_proof_required": {"type": "boolean"}
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/evidence"}
+    },
+    "required_checks": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1, "maxLength": 200}
+    },
+    "remaining_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "summary",
+        "follow_up_issue",
+        "follow_up_stream_epic",
+        "evidence_ids"
+      ],
+      "properties": {
+        "status": {"enum": ["none", "open", "transferred"]},
+        "summary": {"type": "string", "maxLength": 4000},
+        "follow_up_issue": {"type": ["integer", "null"], "minimum": 1},
+        "follow_up_stream_epic": {"type": ["integer", "null"], "minimum": 1},
+        "evidence_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+        }
+      }
+    },
+    "observation_receipts": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/observationReceipt"}
+    },
+    "mutation_receipts": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/mutationReceipt"}
+    },
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"},
+    "migration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "legacy", "migrated_at"],
+      "properties": {
+        "source": {"type": "string", "minLength": 1, "maxLength": 100},
+        "legacy": {"type": "boolean"},
+        "migrated_at": {"type": ["string", "null"], "format": "date-time"}
+      }
+    }
+  },
+  "$defs": {
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "issue", "pr", "commit"],
+      "properties": {
+        "repository": {"type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$"},
+        "issue": {"type": "integer", "minimum": 1},
+        "pr": {"type": ["integer", "null"], "minimum": 1},
+        "commit": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"}
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "ac_id",
+        "type",
+        "summary",
+        "url",
+        "subject",
+        "details",
+        "recorded_at"
+      ],
+      "properties": {
+        "id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "ac_id": {"type": "string", "pattern": "^[A-Z][A-Z0-9_-]{1,31}$"},
+        "type": {
+          "enum": [
+            "command",
+            "test",
+            "review",
+            "behavior_proof",
+            "ci",
+            "github",
+            "deployment",
+            "certification",
+            "follow_up",
+            "cleanup",
+            "document"
+          ]
+        },
+        "summary": {"type": "string", "minLength": 1, "maxLength": 4000},
+        "url": {"type": ["string", "null"], "format": "uri", "maxLength": 1000},
+        "subject": {"$ref": "#/$defs/subject"},
+        "details": {"type": "object"},
+        "recorded_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "observationReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "observation_digest",
+        "observed_at",
+        "state",
+        "disposition",
+        "hard_blockers",
+        "waiting",
+        "next_actions",
+        "observation"
+      ],
+      "properties": {
+        "id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "observation_digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "observed_at": {"type": "string", "format": "date-time"},
+        "owner": {"type": "string", "minLength": 1, "maxLength": 100},
+        "state": {"type": "string"},
+        "disposition": {"enum": ["waiting", "blocked", "ready", "complete"]},
+        "hard_blockers": {"type": "array", "items": {"type": "string"}},
+        "waiting": {"type": "array", "items": {"type": "string"}},
+        "next_actions": {"type": "array", "items": {"type": "string"}},
+        "observation": {"type": "object"}
+      }
+    },
+    "mutationReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "operation_id",
+        "action",
+        "status",
+        "authorized_by",
+        "requested_at",
+        "completed_at",
+        "remote_mutation_performed",
+        "detail"
+      ],
+      "properties": {
+        "id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "operation_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "action": {"enum": ["sync-acs", "arm-auto-merge", "close-issue"]},
+        "status": {"enum": ["intent", "complete", "failed"]},
+        "authorized_by": {"type": "string", "minLength": 1, "maxLength": 200},
+        "requested_at": {"type": "string", "format": "date-time"},
+        "completed_at": {"type": ["string", "null"], "format": "date-time"},
+        "remote_mutation_performed": {"type": "boolean"},
+        "detail": {"type": "string", "maxLength": 4000}
+      }
+    }
+  }
+}

--- a/agents_extensions/shared/skills/task-family-manager/SKILL.md
+++ b/agents_extensions/shared/skills/task-family-manager/SKILL.md
@@ -117,6 +117,25 @@ Choose the operation explicitly:
 - `preview-archive` is reversible and retains transcripts, worktrees, branches, and runtime resources.
 - `preview-cleanup` archives tasks and may remove only exact, verified, family-owned resources. Purge is not implemented.
 
+When the family belongs to non-trivial GitHub implementation work, task-family
+cleanup is only the final local/native part of the shared closeout contract. Load
+the exact `task-lifecycle.v1` ledger from its `task-identity.v1` repository/issue
+before previewing cleanup:
+
+```bash
+.venv/bin/python -m scripts.orchestration.task_closeout locate \
+  --identity-file /absolute/task-identity.json
+.venv/bin/python -m scripts.orchestration.task_closeout reconcile \
+  --state-file /absolute/.agent/task-lifecycle/.../issue-N.json \
+  --branch codex/N-topic --worktree /absolute/.worktrees/dispatch/codex/N-topic
+```
+
+Do not treat archived tasks, a completed worker, a merged PR, or a `Fixes #N`
+keyword as terminal proof. The lifecycle receipt must verify the explicit
+merge/deploy/certify goal, actual issue closure, and exact branch/worktree
+cleanup. A `BLOCKED_WITH_RECEIPT` disposition stops `preview-cleanup` until its
+owner, reason, evidence, and next action are resolved.
+
 ```bash
 .venv/bin/python -m scripts.orchestration.task_family preview-archive \
   --repo-root /absolute/project \

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1498,6 +1498,20 @@ def _augment_prompt_with_worktree(prompt: str, worktree_path: Path | None) -> st
     )
 
 
+def _load_task_lifecycle_carrier(raw_path: str | None) -> tuple[dict[str, Any] | None, str]:
+    """Validate one canonical lifecycle ledger before dispatch side effects."""
+    if not raw_path:
+        return None, ""
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    from scripts.orchestration import task_lifecycle
+
+    path = Path(raw_path).expanduser().resolve()
+    ledger = task_lifecycle.load_lifecycle(path)
+    carrier = task_lifecycle.carrier_projection(ledger, state_file=str(path))
+    return carrier, task_lifecycle.render_carrier_prompt(carrier)
+
+
 class ResearchContextError(ValueError):
     """A --research-* flag violated a request-side bound (mirrors the API 422s)."""
 
@@ -2120,6 +2134,15 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print("❌ --prompt or --prompt-file is required", file=sys.stderr)
         return 2
 
+    try:
+        lifecycle_carrier, lifecycle_prompt = _load_task_lifecycle_carrier(
+            getattr(args, "lifecycle_file", None)
+        )
+    except (OSError, ValueError) as exc:
+        print(f"❌ invalid --lifecycle-file: {exc}", file=sys.stderr)
+        return 2
+    prompt += lifecycle_prompt
+
     # ADR-011 P3 research context — explicit --research-* flags only. Validate the
     # request-side caps up front (fail fast, before any worktree side effect) so a
     # direct CLI caller is bounded exactly like the API query layer.
@@ -2215,6 +2238,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             "returncode_reason": None,
             "substitution": None,
         }
+        if lifecycle_carrier is not None:
+            dry_run_state["task_lifecycle"] = lifecycle_carrier
         dry_run_reap = _reap_runtime_tmp_lease(
             runtime_tmp_root,
             runtime_tmp_namespace_root,
@@ -2344,6 +2369,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "returncode_reason": None,
         "substitution": None,
     }
+    if lifecycle_carrier is not None:
+        initial_state["task_lifecycle"] = lifecycle_carrier
     initial_state = _with_optional_research_state(initial_state, research_state)
     _write_state_atomic(state_path, initial_state)
 
@@ -3012,6 +3039,13 @@ def build_parser() -> argparse.ArgumentParser:
     d.add_argument("--task-id", required=True, help="Stable task identifier used for state/log files, e.g. review-123.")
     d.add_argument("--prompt", help="Prompt text, or '-' to read the prompt from stdin.")
     d.add_argument("--prompt-file", help="Read the prompt body from this file path.")
+    d.add_argument(
+        "--lifecycle-file",
+        help=(
+            "Canonical task-lifecycle.v1 ledger to validate and carry in the worker prompt/state. "
+            "Invalid ledgers fail before worktree or worker side effects."
+        ),
+    )
     d.add_argument(
         "--mode",
         default="read-only",

--- a/scripts/orchestration/agent_ledger.py
+++ b/scripts/orchestration/agent_ledger.py
@@ -212,6 +212,18 @@ def task_event(
     }
 
 
+def lifecycle_carrier(path: str | Path) -> dict[str, Any]:
+    """Load the shared closeout projection exposed by coordination endpoints."""
+    from scripts.orchestration import task_lifecycle
+
+    resolved = Path(path).expanduser().resolve()
+    try:
+        ledger = task_lifecycle.load_lifecycle(resolved)
+    except task_lifecycle.LifecycleError as exc:
+        raise LedgerError(f"invalid task lifecycle ledger: {exc}") from exc
+    return task_lifecycle.carrier_projection(ledger, state_file=str(resolved))
+
+
 def upsert_task(
     repo_root: Path,
     *,
@@ -229,6 +241,7 @@ def upsert_task(
     owned_paths: list[str] | None = None,
     allow_conflicts: bool = False,
     metadata: dict[str, Any] | None = None,
+    lifecycle_file: str | Path | None = None,
 ) -> dict[str, Any]:
     with ledger_mutation_lock(repo_root):
         task_id = safe_id(task_id)
@@ -257,6 +270,11 @@ def upsert_task(
                 raise OwnershipConflictError(task_id, conflicts)
 
         now = isoformat_z(utc_now())
+        lifecycle = (
+            lifecycle_carrier(lifecycle_file)
+            if lifecycle_file is not None
+            else existing.get("task_lifecycle")
+        )
         events = list(existing.get("events") or [])
         if not existing:
             events.append(task_event(event_type="created", actor=effective_agent, message="task registered"))
@@ -289,6 +307,7 @@ def upsert_task(
             "ci": existing.get("ci") or {},
             "pr_url": existing.get("pr_url"),
             "metadata": {**(existing.get("metadata") or {}), **(metadata or {})},
+            "task_lifecycle": lifecycle,
             "events": events,
             "created_at": existing.get("created_at") or now,
             "updated_at": now,
@@ -383,6 +402,10 @@ def build_parser() -> argparse.ArgumentParser:
     upsert.add_argument("--owned-path", action="append")
     upsert.add_argument("--allow-conflicts", action="store_true")
     upsert.add_argument("--metadata")
+    upsert.add_argument(
+        "--lifecycle-file",
+        help="Validated task-lifecycle.v1 ledger carried into monitor-visible agent state.",
+    )
 
     event = sub.add_parser("event")
     event.add_argument("--task-id", required=True)
@@ -421,6 +444,7 @@ def main(argv: list[str] | None = None) -> int:
                 owned_paths=args.owned_path,
                 allow_conflicts=args.allow_conflicts,
                 metadata=_json_arg(args.metadata),
+                lifecycle_file=args.lifecycle_file,
             )
         elif args.command == "event":
             payload = append_event(

--- a/scripts/orchestration/orchestrator_control.py
+++ b/scripts/orchestration/orchestrator_control.py
@@ -152,10 +152,23 @@ def record_task(
     prompt_file: str | None = None,
     command: list[str] | None = None,
     note: str | None = None,
+    lifecycle_file: str | None = None,
 ) -> dict[str, Any]:
     state = ensure_run_state(repo_root, run_id)
     now = isoformat_z(utc_now())
+    previous = next(
+        (item for item in state.get("tasks", []) if item.get("task_id") == task_id),
+        None,
+    )
     tasks = [item for item in state.get("tasks", []) if item.get("task_id") != task_id]
+    lifecycle = (previous or {}).get("task_lifecycle")
+    if lifecycle_file:
+        from scripts.orchestration import task_lifecycle
+
+        lifecycle_path = Path(lifecycle_file).expanduser().resolve()
+        lifecycle = task_lifecycle.carrier_projection(
+            task_lifecycle.load_lifecycle(lifecycle_path), state_file=str(lifecycle_path)
+        )
     tasks.append(
         {
             "task_id": task_id,
@@ -163,6 +176,7 @@ def record_task(
             "prompt_file": prompt_file,
             "command": command,
             "note": note or "",
+            "task_lifecycle": lifecycle,
             "recorded_at": now,
         }
     )
@@ -289,6 +303,7 @@ def summarize_task(
         "stderr_log_excerpt": stderr_excerpt,
         "pr_urls": pr_urls,
         "attention": attention,
+        "task_lifecycle": task.get("task_lifecycle"),
     }
 
 
@@ -322,6 +337,7 @@ def collect_inbox(
                         "task_id": task_id,
                         "agent": record.get("agent"),
                         "status": "missing",
+                        "task_lifecycle": record.get("task_lifecycle"),
                     }
                 task_records.append(task)
     else:
@@ -390,6 +406,7 @@ def render_markdown_inbox(payload: dict[str, Any]) -> str:
                 str(task.get("duration_s") or task.get("age_s") or ""),
                 short_path(task.get("worktree_path"), repo_root),
                 prs,
+                str((task.get("task_lifecycle") or {}).get("current_state") or ""),
                 attention,
             ]
         )
@@ -417,7 +434,10 @@ def render_markdown_inbox(payload: dict[str, Any]) -> str:
         "",
         "## Tasks",
         "",
-        table(rows, ["Task", "Agent", "Status", "Age/Duration", "Worktree", "PR", "Attention"]),
+        table(
+            rows,
+            ["Task", "Agent", "Status", "Age/Duration", "Worktree", "PR", "Lifecycle", "Attention"],
+        ),
         "",
         "## Needs Orchestrator Attention",
         "",
@@ -512,6 +532,8 @@ def build_delegate_command(args: argparse.Namespace, prompt_file: Path) -> list[
         command.extend(["--initial-response-timeout", str(args.initial_response_timeout)])
     if args.max_budget_usd is not None:
         command.extend(["--max-budget-usd", str(args.max_budget_usd)])
+    if args.lifecycle_file:
+        command.extend(["--lifecycle-file", str(Path(args.lifecycle_file).expanduser().resolve())])
     return command
 
 
@@ -534,7 +556,14 @@ def cmd_add_task(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
     task = load_task_state(tasks_dir(repo_root), args.task_id)
     agent = args.agent or (task or {}).get("agent")
-    record_task(repo_root, args.run_id, task_id=args.task_id, agent=agent, note=args.note)
+    record_task(
+        repo_root,
+        args.run_id,
+        task_id=args.task_id,
+        agent=agent,
+        note=args.note,
+        lifecycle_file=args.lifecycle_file,
+    )
     print(json.dumps({"run_id": args.run_id, "task_id": args.task_id, "agent": agent}, indent=2))
     return 0
 
@@ -593,6 +622,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         prompt_file=str(prompt_file),
         command=command,
         note=args.note,
+        lifecycle_file=args.lifecycle_file,
     )
     print(
         json.dumps(
@@ -644,6 +674,7 @@ def build_parser() -> argparse.ArgumentParser:
     add.add_argument("--task-id", required=True)
     add.add_argument("--agent")
     add.add_argument("--note", default="")
+    add.add_argument("--lifecycle-file")
     add.set_defaults(func=cmd_add_task)
 
     dispatch = sub.add_parser("dispatch", help="Dispatch a delegate worker and record it in a run ledger.")
@@ -678,6 +709,10 @@ def build_parser() -> argparse.ArgumentParser:
     dispatch.add_argument("--silence-timeout", type=int, default=3600)
     dispatch.add_argument("--initial-response-timeout", type=int, default=180)
     dispatch.add_argument("--max-budget-usd", type=float)
+    dispatch.add_argument(
+        "--lifecycle-file",
+        help="Canonical task-lifecycle.v1 ledger forwarded to delegate state and the run ledger.",
+    )
     dispatch.add_argument("--dry-run", action="store_true")
     dispatch.set_defaults(func=cmd_dispatch)
 

--- a/scripts/orchestration/task_closeout.py
+++ b/scripts/orchestration/task_closeout.py
@@ -1,0 +1,981 @@
+#!/usr/bin/env python
+"""Observe, validate, and explicitly close out a task lifecycle ledger.
+
+Read-only reconciliation is the default.  Remote changes require the ``mutate``
+subcommand, an exact action, ``--authorize``, and an actor recorded in the
+append-only mutation receipt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Mapping
+from copy import deepcopy
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.orchestration import task_identity, task_lifecycle
+
+Runner = Callable[[list[str], str | None], str]
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def repo_root_from_file() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _json_file(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise task_lifecycle.LifecycleError(f"cannot read JSON file {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise task_lifecycle.LifecycleError(f"JSON file must contain an object: {path}")
+    return value
+
+
+def _default_runner(repo_root: Path) -> Runner:
+    def run(args: list[str], stdin: str | None = None) -> str:
+        completed = subprocess.run(
+            args,
+            cwd=repo_root,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout or "command failed").strip()
+            raise task_lifecycle.LifecycleError(f"{' '.join(args[:4])} failed: {detail[:1000]}")
+        return completed.stdout
+
+    return run
+
+
+class GhGitHubAdapter:
+    """Authoritative GitHub reads and the three explicitly allowed mutations."""
+
+    def __init__(self, repo_root: Path, *, runner: Runner | None = None) -> None:
+        self.repo_root = repo_root.resolve()
+        self._run = runner or _default_runner(self.repo_root)
+
+    def _json(self, args: list[str], stdin: str | None = None) -> Any:
+        raw = self._run(args, stdin)
+        try:
+            return json.loads(raw or "null")
+        except json.JSONDecodeError as exc:
+            raise task_lifecycle.LifecycleError(
+                f"GitHub command returned invalid JSON: {' '.join(args[:4])}"
+            ) from exc
+
+    def registered_stream_epics(self) -> list[int]:
+        try:
+            from scripts.orchestration import issue_stream_audit
+
+            registry = issue_stream_audit.load_registry(
+                self.repo_root / "scripts" / "config" / "issue_streams.yaml"
+            )
+        except (OSError, ValueError) as exc:
+            raise task_lifecycle.LifecycleError(
+                f"cannot load the issue-stream registry: {exc}"
+            ) from exc
+        return sorted({epic for epics in registry.values() for epic in epics})
+
+    @staticmethod
+    def _owner_name(repository: str) -> tuple[str, str]:
+        try:
+            owner, name = repository.split("/", 1)
+        except ValueError as exc:
+            raise task_lifecycle.LifecycleError("repository must be owner/name") from exc
+        return owner, name
+
+    def read_issue(self, repository: str, issue_number: int) -> dict[str, Any]:
+        issue = self._json(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue_number),
+                "--repo",
+                repository,
+                "--json",
+                "number,state,body,url,closedAt",
+            ]
+        )
+        owner, name = self._owner_name(repository)
+        parent_doc = self._json(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={issue_number}",
+                "-f",
+                "query=query($owner:String!,$name:String!,$number:Int!){"
+                "repository(owner:$owner,name:$name){nameWithOwner issue(number:$number){"
+                "number state url parent{number url}}}}",
+            ]
+        )
+        repository_doc = ((parent_doc or {}).get("data") or {}).get("repository") or {}
+        parent_issue = repository_doc.get("issue") or {}
+        parent = parent_issue.get("parent") or {}
+        return {
+            "number": issue.get("number"),
+            "state": str(issue.get("state") or "").upper(),
+            "body": issue.get("body") or "",
+            "url": issue.get("url"),
+            "closed_at": issue.get("closedAt"),
+            "parent_epic": parent.get("number"),
+        }
+
+    def _read_pr(self, repository: str, pr_number: int) -> dict[str, Any]:
+        pr = self._json(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repository,
+                "--json",
+                "number,url,state,isDraft,headRefOid,headRefName,mergeCommit,mergedAt,"
+                "autoMergeRequest,reviewDecision,reviews,statusCheckRollup,body",
+            ]
+        )
+        checks: list[dict[str, Any]] = []
+        for raw in pr.get("statusCheckRollup") or []:
+            typename = raw.get("__typename")
+            if typename == "CheckRun":
+                checks.append(
+                    {
+                        "name": raw.get("name"),
+                        "status": str(raw.get("status") or "").upper(),
+                        "conclusion": str(raw.get("conclusion") or "").upper(),
+                        "url": raw.get("detailsUrl"),
+                    }
+                )
+            else:
+                state = str(raw.get("state") or "").upper()
+                checks.append(
+                    {
+                        "name": raw.get("context") or raw.get("name"),
+                        "status": "COMPLETED" if state in {"SUCCESS", "FAILURE", "ERROR"} else "IN_PROGRESS",
+                        "conclusion": state,
+                        "url": raw.get("targetUrl"),
+                    }
+                )
+        auto = pr.get("autoMergeRequest") or {}
+        merge_commit = pr.get("mergeCommit") or {}
+        return {
+            "number": pr.get("number"),
+            "url": pr.get("url"),
+            "state": str(pr.get("state") or "").upper(),
+            "is_draft": bool(pr.get("isDraft")),
+            "head_sha": pr.get("headRefOid"),
+            "head_branch": pr.get("headRefName"),
+            "merge_sha": merge_commit.get("oid"),
+            "merged_at": pr.get("mergedAt"),
+            "auto_merge_enabled_at": auto.get("enabledAt"),
+            "review_decision": pr.get("reviewDecision"),
+            "requested_changes": pr.get("reviewDecision") == "CHANGES_REQUESTED",
+            "reviews": pr.get("reviews") or [],
+            "checks": checks,
+            "body": pr.get("body") or "",
+        }
+
+    def _comments(self, repository: str, pr_number: int) -> list[dict[str, Any]]:
+        issue_comments = self._json(
+            [
+                "gh",
+                "api",
+                f"repos/{repository}/issues/{pr_number}/comments",
+                "--paginate",
+            ]
+        )
+        native_reviews = self._json(
+            [
+                "gh",
+                "api",
+                f"repos/{repository}/pulls/{pr_number}/reviews",
+                "--paginate",
+            ]
+        )
+        if not isinstance(issue_comments, list) or not isinstance(native_reviews, list):
+            raise task_lifecycle.LifecycleError("GitHub PR comments response is not a list")
+        comments = [
+            {
+                "url": item.get("html_url"),
+                "body": item.get("body") or "",
+                "author": (item.get("user") or {}).get("login"),
+                "created_at": item.get("created_at"),
+                "kind": "issue_comment",
+            }
+            for item in issue_comments
+            if isinstance(item, dict)
+        ]
+        comments.extend(
+            {
+                "url": item.get("html_url"),
+                "body": item.get("body") or "",
+                "author": (item.get("user") or {}).get("login"),
+                "created_at": item.get("submitted_at"),
+                "kind": "pull_request_review",
+                "state": str(item.get("state") or "").upper(),
+                "commit_id": item.get("commit_id"),
+            }
+            for item in native_reviews
+            if isinstance(item, dict)
+        )
+        return comments
+
+    def _deployments(self, repository: str, sha: str | None) -> list[dict[str, Any]]:
+        if not sha:
+            return []
+        deployments = self._json(
+            [
+                "gh",
+                "api",
+                "--method",
+                "GET",
+                f"repos/{repository}/deployments",
+                "-f",
+                f"sha={sha}",
+            ]
+        )
+        result: list[dict[str, Any]] = []
+        for deployment in deployments or []:
+            deployment_id = deployment.get("id")
+            statuses = self._json(
+                ["gh", "api", f"repos/{repository}/deployments/{deployment_id}/statuses"]
+            )
+            latest = statuses[0] if statuses else {}
+            result.append(
+                {
+                    "id": deployment_id,
+                    "environment": deployment.get("environment"),
+                    "sha": deployment.get("sha"),
+                    "state": str(latest.get("state") or "").upper(),
+                    "url": latest.get("target_url") or latest.get("environment_url"),
+                }
+            )
+        return result
+
+    def _follow_up(
+        self,
+        repository: str,
+        original_issue: int,
+        original_body: str,
+        remaining_scope: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        follow_up_number = remaining_scope.get("follow_up_issue")
+        if remaining_scope.get("status") != "transferred" or not follow_up_number:
+            return None
+        follow_up = self.read_issue(repository, int(follow_up_number))
+        original_ref = f"#{original_issue}"
+        follow_up_ref = f"#{follow_up_number}"
+        follow_up["reciprocal_links_verified"] = (
+            follow_up_ref in original_body and original_ref in str(follow_up.get("body") or "")
+        )
+        return follow_up
+
+    def _github_observation(self, ledger: Mapping[str, Any]) -> dict[str, Any]:
+        identity = ledger["identity"]
+        repository = identity["repository"]
+        issue = self.read_issue(repository, identity["github_issue_number"])
+        pr_number = ledger["pr"]["number"]
+        pr: dict[str, Any] = {
+            "number": None,
+            "url": None,
+            "state": None,
+            "is_draft": False,
+            "head_sha": None,
+            "head_branch": None,
+            "merge_sha": None,
+            "merged_at": None,
+            "auto_merge_enabled_at": None,
+            "review_decision": None,
+            "requested_changes": False,
+            "reviews": [],
+            "checks": [],
+            "body": "",
+        }
+        comments: list[dict[str, Any]] = []
+        deployments: list[dict[str, Any]] = []
+        if pr_number is not None:
+            pr = self._read_pr(repository, pr_number)
+            comments = self._comments(repository, pr_number)
+            if ledger["terminal_goal"] in {"deploy", "certify"}:
+                deployments = self._deployments(repository, pr.get("merge_sha") or pr.get("head_sha"))
+        return {
+            "repository": repository,
+            "registered_stream_epics": self.registered_stream_epics(),
+            "issue": issue,
+            "pr": pr,
+            "comments": comments,
+            "deployments": deployments,
+            "follow_up": self._follow_up(
+                repository,
+                identity["github_issue_number"],
+                issue["body"],
+                ledger["remaining_scope"],
+            ),
+        }
+
+    def observe(
+        self,
+        ledger: Mapping[str, Any],
+        *,
+        now: str,
+        branch: str | None = None,
+        worktree: str | None = None,
+    ) -> dict[str, Any]:
+        canonical = task_lifecycle.validate_lifecycle(ledger)
+        try:
+            github = self._github_observation(canonical)
+        except task_lifecycle.LifecycleError as exc:
+            identity = canonical["identity"]
+            github = {
+                "repository": identity["repository"],
+                "registered_stream_epics": [],
+                "issue": {
+                    "number": identity["github_issue_number"],
+                    "state": None,
+                    "body": "",
+                    "url": identity["github_issue_url"],
+                    "closed_at": None,
+                    "parent_epic": None,
+                },
+                "pr": {
+                    "number": canonical["pr"]["number"],
+                    "url": canonical["pr"]["url"],
+                    "state": None,
+                    "head_sha": None,
+                    "head_branch": branch,
+                    "merge_sha": None,
+                    "checks": [],
+                    "requested_changes": False,
+                },
+                "comments": [],
+                "deployments": [],
+                "follow_up": None,
+                "error": str(exc),
+            }
+        pr = github["pr"]
+        local = task_lifecycle.observe_local_git(
+            self.repo_root,
+            head_sha=pr.get("head_sha"),
+            branch=branch or pr.get("head_branch"),
+            worktree=worktree or str(self.repo_root),
+        )
+        return {
+            "schema_version": task_lifecycle.OBSERVATION_SCHEMA_VERSION,
+            "observed_at": now,
+            "github": github,
+            "local": local,
+        }
+
+    def update_issue_body(self, repository: str, issue_number: int, body: str) -> None:
+        request = json.dumps({"body": body}, ensure_ascii=False)
+        self._run(
+            ["gh", "api", "-X", "PATCH", f"repos/{repository}/issues/{issue_number}", "--input", "-"],
+            request,
+        )
+
+    def arm_auto_merge(self, repository: str, pr_number: int) -> None:
+        self._run(
+            [
+                "gh",
+                "pr",
+                "merge",
+                str(pr_number),
+                "--repo",
+                repository,
+                "--auto",
+                "--squash",
+                "--delete-branch",
+            ],
+            None,
+        )
+
+    def close_issue(self, repository: str, issue_number: int) -> None:
+        self._run(
+            [
+                "gh",
+                "issue",
+                "close",
+                str(issue_number),
+                "--repo",
+                repository,
+                "--reason",
+                "completed",
+            ],
+            None,
+        )
+
+
+class StaticObservationAdapter:
+    """Hermetic injected observation adapter used by tests and offline replay."""
+
+    def __init__(self, observation: Mapping[str, Any]) -> None:
+        self.observation = deepcopy(dict(observation))
+
+    def observe(self, _ledger: Mapping[str, Any], **_kwargs: Any) -> dict[str, Any]:
+        return deepcopy(self.observation)
+
+
+def _replace_checkbox(body: str, ac_id: str) -> str:
+    lines = body.splitlines()
+    needle = f"**{ac_id}**"
+    for index, line in enumerate(lines):
+        if needle in line and line.lstrip().startswith("- ["):
+            prefix = line[: len(line) - len(line.lstrip())]
+            content = line.lstrip()
+            lines[index] = prefix + "- [x]" + content[5:]
+    suffix = "\n" if body.endswith("\n") else ""
+    return "\n".join(lines) + suffix
+
+
+def evidenced_issue_body(
+    ledger: Mapping[str, Any], observation: Mapping[str, Any]
+) -> tuple[str, list[str]]:
+    evaluation = task_lifecycle.evaluate(ledger, observation)
+    valid = {key: set(value) for key, value in evaluation["valid_evidence"].items()}
+    body = str(observation["github"]["issue"].get("body") or "")
+    checked_ids: list[str] = []
+    for criterion in ledger["ac_snapshot"]["criteria"]:
+        if not criterion["applicable"]:
+            continue
+        if set(criterion["required_evidence"]).issubset(valid.get(criterion["id"], set())):
+            body = _replace_checkbox(body, criterion["id"])
+            checked_ids.append(criterion["id"])
+    return body, checked_ids
+
+
+def _desired_remote_state(
+    action: str,
+    ledger: Mapping[str, Any],
+    observation: Mapping[str, Any],
+) -> bool:
+    issue = observation["github"]["issue"]
+    pr = observation["github"]["pr"]
+    if action == "close-issue":
+        return str(issue.get("state") or "").upper() == "CLOSED"
+    if action == "arm-auto-merge":
+        return bool(pr.get("auto_merge_enabled_at")) or str(pr.get("state") or "").upper() == "MERGED"
+    expected_body, _ = evidenced_issue_body(ledger, observation)
+    return expected_body == issue.get("body")
+
+
+def _assert_mutation_ready(
+    action: str,
+    ledger: Mapping[str, Any],
+    observation: Mapping[str, Any],
+) -> dict[str, Any]:
+    evaluation = task_lifecycle.evaluate(ledger, observation)
+    hard = evaluation["hard_blockers"]
+    if action == "sync-acs":
+        fatal_fragments = (
+            "repository does not match",
+            "issue does not match",
+            "issue URL does not match",
+            "stream epic",
+            "acceptance criteria drift",
+            "GitHub observation failed",
+            "authoritative PR does not match",
+        )
+        fatal = [item for item in hard if any(fragment in item for fragment in fatal_fragments)]
+        if fatal:
+            raise task_lifecycle.LifecycleError("AC sync blocked: " + "; ".join(fatal))
+    elif action == "arm-auto-merge":
+        if hard:
+            raise task_lifecycle.LifecycleError("auto-merge blocked: " + "; ".join(hard))
+        if task_lifecycle.STATE_RANK.get(evaluation["last_success_state"], -1) < task_lifecycle.STATE_RANK[
+            "REVIEW_PASSED"
+        ]:
+            raise task_lifecycle.LifecycleError("auto-merge requires verified current-head outside-family review")
+        if str(observation["github"]["pr"].get("state") or "").upper() != "OPEN":
+            raise task_lifecycle.LifecycleError("auto-merge requires an open PR")
+        if observation["github"]["pr"].get("is_draft"):
+            raise task_lifecycle.LifecycleError("auto-merge requires a ready-for-review PR")
+    else:
+        if hard:
+            raise task_lifecycle.LifecycleError("issue close blocked: " + "; ".join(hard))
+        if not evaluation["goal_reached"]:
+            raise task_lifecycle.LifecycleError("issue close requires the terminal goal's authoritative remote state")
+        if evaluation["preclose_missing_evidence"]:
+            raise task_lifecycle.LifecycleError("issue close has missing pre-close AC evidence")
+        if evaluation["preclose_unchecked"]:
+            raise task_lifecycle.LifecycleError(
+                "issue close requires evidenced AC checkboxes: "
+                + ", ".join(evaluation["preclose_unchecked"])
+            )
+        if ledger["remaining_scope"]["status"] == "open":
+            raise task_lifecycle.LifecycleError("issue close is blocked by untransferred remaining scope")
+    return evaluation
+
+
+def _record_failed_mutation(
+    state_file: Path,
+    ledger: Mapping[str, Any],
+    *,
+    operation_id: str,
+    action: str,
+    authorized_by: str,
+    requested_at: str,
+    detail: str,
+    remote_mutation_performed: bool = False,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    blocked = deepcopy(dict(ledger))
+    blocked["current_state"] = "BLOCKED_WITH_RECEIPT"
+    blocked, receipt, _ = task_lifecycle.append_mutation_event(
+        blocked,
+        operation_id=operation_id,
+        action=action,
+        status="failed",
+        authorized_by=authorized_by,
+        requested_at=requested_at,
+        completed_at=utc_now(),
+        remote_mutation_performed=remote_mutation_performed,
+        detail=detail,
+    )
+    task_lifecycle.write_lifecycle(state_file, blocked)
+    return blocked, receipt
+
+
+def record_unauthorized_mutation(
+    state_file: Path,
+    *,
+    action: str,
+    actor: str,
+    now: str,
+) -> dict[str, Any]:
+    """Persist a fail-closed receipt without performing any remote read or write."""
+    with task_lifecycle.lifecycle_lock(state_file):
+        ledger = task_lifecycle.load_lifecycle(state_file)
+        operation_id = task_lifecycle.mutation_operation_id(ledger, action)
+        _, receipt = _record_failed_mutation(
+            state_file,
+            ledger,
+            operation_id=operation_id,
+            action=action,
+            authorized_by=actor,
+            requested_at=now,
+            detail=(
+                "remote mutation denied: explicit --authorize was absent; "
+                "rerun the exact action with --authorize after reviewing its gate"
+            ),
+        )
+        return {
+            "action": action,
+            "operation_id": operation_id,
+            "disposition": "blocked",
+            "state": "BLOCKED_WITH_RECEIPT",
+            "mutation_receipt": receipt,
+            "remote_mutation_performed": False,
+        }
+
+
+def perform_mutation(
+    state_file: Path,
+    adapter: GhGitHubAdapter,
+    *,
+    action: str,
+    authorized_by: str,
+    branch: str | None,
+    worktree: str | None,
+    now: str,
+) -> dict[str, Any]:
+    with task_lifecycle.lifecycle_lock(state_file):
+        ledger = task_lifecycle.load_lifecycle(state_file)
+        before = adapter.observe(ledger, now=now, branch=branch, worktree=worktree)
+        ledger, before_receipt, _ = task_lifecycle.reconcile(ledger, before, now=now)
+        task_lifecycle.write_lifecycle(state_file, ledger)
+        operation_id = task_lifecycle.mutation_operation_id(ledger, action)
+        prior_status = task_lifecycle.mutation_status(ledger, operation_id)
+
+        if prior_status == "complete" and _desired_remote_state(
+            action, ledger, before
+        ):
+            return {
+                "action": action,
+                "operation_id": operation_id,
+                "replayed": True,
+                "remote_mutation_performed": False,
+                "observation_receipt": before_receipt,
+            }
+        if prior_status == "intent" and _desired_remote_state(action, ledger, before):
+            recovered_at = utc_now()
+            ledger, completed, _ = task_lifecycle.append_mutation_event(
+                ledger,
+                operation_id=operation_id,
+                action=action,
+                status="complete",
+                authorized_by=authorized_by,
+                requested_at=now,
+                completed_at=recovered_at,
+                remote_mutation_performed=False,
+                detail="recovered remote success after local receipt crash; no duplicate mutation",
+            )
+            task_lifecycle.write_lifecycle(state_file, ledger)
+            return {
+                "action": action,
+                "operation_id": operation_id,
+                "mutation_receipt": completed,
+                "observation_receipt": before_receipt,
+                "replayed": True,
+                "remote_mutation_performed": False,
+            }
+
+        try:
+            _assert_mutation_ready(action, ledger, before)
+        except task_lifecycle.LifecycleError as exc:
+            _, failed = _record_failed_mutation(
+                state_file,
+                ledger,
+                operation_id=operation_id,
+                action=action,
+                authorized_by=authorized_by,
+                requested_at=now,
+                detail=f"mutation gate rejected the action: {exc}",
+            )
+            raise task_lifecycle.LifecycleError(
+                f"mutation blocked with durable receipt {failed['id']}: {exc}"
+            ) from exc
+
+        ledger, intent, _ = task_lifecycle.append_mutation_event(
+            ledger,
+            operation_id=operation_id,
+            action=action,
+            status="intent",
+            authorized_by=authorized_by,
+            requested_at=now,
+            completed_at=None,
+            remote_mutation_performed=False,
+            detail="authorized mutation intent persisted before remote action",
+        )
+        task_lifecycle.write_lifecycle(state_file, ledger)
+        remote_performed = False
+        try:
+            if not _desired_remote_state(action, ledger, before):
+                identity = ledger["identity"]
+                if action == "sync-acs":
+                    body, _ = evidenced_issue_body(ledger, before)
+                    adapter.update_issue_body(
+                        identity["repository"], identity["github_issue_number"], body
+                    )
+                elif action == "arm-auto-merge":
+                    adapter.arm_auto_merge(identity["repository"], ledger["pr"]["number"])
+                else:
+                    adapter.close_issue(identity["repository"], identity["github_issue_number"])
+                remote_performed = True
+
+            after_time = utc_now()
+            after = adapter.observe(ledger, now=after_time, branch=branch, worktree=worktree)
+            if not _desired_remote_state(action, ledger, after):
+                raise task_lifecycle.LifecycleError("authoritative readback did not confirm the requested mutation")
+            ledger, after_receipt, _ = task_lifecycle.reconcile(ledger, after, now=after_time)
+            ledger, completed, _ = task_lifecycle.append_mutation_event(
+                ledger,
+                operation_id=operation_id,
+                action=action,
+                status="complete",
+                authorized_by=authorized_by,
+                requested_at=now,
+                completed_at=after_time,
+                remote_mutation_performed=remote_performed,
+                detail=(
+                    "remote mutation confirmed by readback"
+                    if remote_performed
+                    else "desired remote state already existed; recovered without duplicate mutation"
+                ),
+            )
+            task_lifecycle.write_lifecycle(state_file, ledger)
+            return {
+                "action": action,
+                "operation_id": operation_id,
+                "intent_receipt": intent,
+                "mutation_receipt": completed,
+                "observation_receipt": after_receipt,
+                "replayed": False,
+                "remote_mutation_performed": remote_performed,
+            }
+        except Exception as exc:
+            ledger = task_lifecycle.load_lifecycle(state_file)
+            _, failed = _record_failed_mutation(
+                state_file,
+                ledger,
+                operation_id=operation_id,
+                action=action,
+                authorized_by=authorized_by,
+                requested_at=now,
+                remote_mutation_performed=remote_performed,
+                detail=f"mutation/readback failed: {exc}",
+            )
+            raise task_lifecycle.LifecycleError(
+                f"mutation failed with durable receipt {failed['id']}: {exc}"
+            ) from exc
+
+
+def _state_file(args: argparse.Namespace, identity: Mapping[str, Any] | None = None) -> Path:
+    if args.state_file:
+        return Path(args.state_file).expanduser().resolve()
+    if identity is None:
+        raise task_lifecycle.LifecycleError("--state-file is required for this command")
+    return task_lifecycle.lifecycle_path(Path(args.repo_root), identity)
+
+
+def _load_policy(path: Path) -> dict[str, Mapping[str, Any]]:
+    policy = _json_file(path)
+    if not all(isinstance(key, str) and isinstance(value, dict) for key, value in policy.items()):
+        raise task_lifecycle.LifecycleError("AC policy must map stable IDs to policy objects")
+    return policy
+
+
+def _adapter(args: argparse.Namespace, ledger: Mapping[str, Any] | None = None):
+    if getattr(args, "observation_file", None):
+        return StaticObservationAdapter(_json_file(Path(args.observation_file)))
+    return GhGitHubAdapter(Path(args.repo_root))
+
+
+def _write_and_print(path: Path, ledger: Mapping[str, Any], extra: Mapping[str, Any] | None = None) -> int:
+    task_lifecycle.write_lifecycle(path, ledger)
+    payload = {
+        "state_file": str(path),
+        "lifecycle": task_lifecycle.carrier_projection(ledger, state_file=str(path)),
+        **dict(extra or {}),
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    identity = task_identity.validate_identity(_json_file(Path(args.identity_file)))
+    adapter = GhGitHubAdapter(Path(args.repo_root))
+    issue = adapter.read_issue(identity["repository"], identity["github_issue_number"])
+    if identity["stream_epic"] not in adapter.registered_stream_epics():
+        raise task_lifecycle.LifecycleError(
+            "task identity stream epic is absent from scripts/config/issue_streams.yaml"
+        )
+    if issue["parent_epic"] != identity["stream_epic"]:
+        raise task_lifecycle.LifecycleError("issue is not a native child of the identity's exact stream epic")
+    now = args.now or utc_now()
+    snapshot = task_lifecycle.build_ac_snapshot(
+        issue["body"], _load_policy(Path(args.ac_policy)), finalized_at=now
+    )
+    ledger = task_lifecycle.build_lifecycle(
+        identity,
+        author_family=args.author_family,
+        ac_snapshot=snapshot,
+        required_checks=args.required_check,
+        now=now,
+        pr_number=args.pr,
+    )
+    path = _state_file(args, identity)
+    if path.exists() and not args.reuse:
+        raise task_lifecycle.LifecycleError(f"lifecycle ledger already exists: {path}; use --reuse")
+    if path.exists():
+        existing = task_lifecycle.load_lifecycle(path)
+        if existing["lifecycle_id"] != ledger["lifecycle_id"]:
+            raise task_lifecycle.LifecycleError("existing lifecycle ledger belongs to another identity")
+        ledger = existing
+    return _write_and_print(path, ledger)
+
+
+def cmd_locate(args: argparse.Namespace) -> int:
+    identity = task_identity.validate_identity(_json_file(Path(args.identity_file)))
+    path = task_lifecycle.lifecycle_path(Path(args.repo_root), identity)
+    print(json.dumps({"state_file": str(path), "exists": path.exists()}, indent=2))
+    return 0 if path.exists() else 1
+
+
+def cmd_bind_pr(args: argparse.Namespace) -> int:
+    path = _state_file(args)
+    with task_lifecycle.lifecycle_lock(path):
+        ledger = task_lifecycle.bind_pr(
+            task_lifecycle.load_lifecycle(path), pr_number=args.pr, now=args.now or utc_now()
+        )
+        return _write_and_print(path, ledger)
+
+
+def cmd_evidence(args: argparse.Namespace) -> int:
+    path = _state_file(args)
+    details = json.loads(args.details) if args.details else {}
+    if not isinstance(details, dict):
+        raise task_lifecycle.LifecycleError("--details must be a JSON object")
+    with task_lifecycle.lifecycle_lock(path):
+        ledger, record = task_lifecycle.add_evidence(
+            task_lifecycle.load_lifecycle(path),
+            ac_id=args.ac_id,
+            evidence_type=args.type,
+            summary=args.summary,
+            url=args.url,
+            commit=args.commit,
+            details=details,
+            recorded_at=args.now or utc_now(),
+        )
+        return _write_and_print(path, ledger, {"evidence": record})
+
+
+def cmd_remaining_scope(args: argparse.Namespace) -> int:
+    path = _state_file(args)
+    with task_lifecycle.lifecycle_lock(path):
+        ledger = task_lifecycle.set_remaining_scope(
+            task_lifecycle.load_lifecycle(path),
+            status=args.status,
+            summary=args.summary,
+            follow_up_issue=args.follow_up_issue,
+            follow_up_stream_epic=args.follow_up_stream_epic,
+            evidence_ids=args.evidence_id,
+            now=args.now or utc_now(),
+        )
+        return _write_and_print(path, ledger)
+
+
+def cmd_reconcile(args: argparse.Namespace) -> int:
+    path = _state_file(args)
+    now = args.now or utc_now()
+    with task_lifecycle.lifecycle_lock(path):
+        ledger = task_lifecycle.load_lifecycle(path)
+        adapter = _adapter(args, ledger)
+        observation = adapter.observe(
+            ledger, now=now, branch=args.branch, worktree=args.worktree
+        )
+        ledger, receipt, replayed = task_lifecycle.reconcile(ledger, observation, now=now)
+        return _write_and_print(
+            path,
+            ledger,
+            {
+                "receipt": receipt,
+                "replayed": replayed,
+                "human": f"{receipt['disposition']}: {receipt['state']}",
+            },
+        )
+
+
+def cmd_mutate(args: argparse.Namespace) -> int:
+    if not args.authorize:
+        result = record_unauthorized_mutation(
+            _state_file(args),
+            action=args.action,
+            actor=args.actor,
+            now=args.now or utc_now(),
+        )
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 2
+    path = _state_file(args)
+    adapter = GhGitHubAdapter(Path(args.repo_root))
+    result = perform_mutation(
+        path,
+        adapter,
+        action=args.action,
+        authorized_by=args.actor,
+        branch=args.branch,
+        worktree=args.worktree,
+        now=args.now or utc_now(),
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_carrier(args: argparse.Namespace) -> int:
+    path = _state_file(args)
+    carrier = task_lifecycle.carrier_projection(
+        task_lifecycle.load_lifecycle(path), state_file=str(path)
+    )
+    print(json.dumps(carrier, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_file())
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    init = sub.add_parser("init", help="Snapshot authoritative issue ACs into a new lifecycle ledger.")
+    init.add_argument("--identity-file", required=True)
+    init.add_argument("--ac-policy", required=True)
+    init.add_argument("--author-family", required=True)
+    init.add_argument("--required-check", action="append", required=True)
+    init.add_argument("--pr", type=int)
+    init.add_argument("--state-file")
+    init.add_argument("--now")
+    init.add_argument("--reuse", action="store_true")
+    init.set_defaults(func=cmd_init)
+
+    locate = sub.add_parser("locate", help="Resolve the shared ledger path from task-identity.v1.")
+    locate.add_argument("--identity-file", required=True)
+    locate.set_defaults(func=cmd_locate, state_file=None)
+
+    bind = sub.add_parser("bind-pr", help="Bind the exact PR once; mismatched rebinding fails closed.")
+    bind.add_argument("--state-file", required=True)
+    bind.add_argument("--pr", type=int, required=True)
+    bind.add_argument("--now")
+    bind.set_defaults(func=cmd_bind_pr)
+
+    evidence = sub.add_parser("add-evidence", help="Append typed current-task AC evidence.")
+    evidence.add_argument("--state-file", required=True)
+    evidence.add_argument("--ac-id", required=True)
+    evidence.add_argument("--type", choices=sorted(task_lifecycle.EVIDENCE_TYPES), required=True)
+    evidence.add_argument("--summary", required=True)
+    evidence.add_argument("--url")
+    evidence.add_argument("--commit")
+    evidence.add_argument("--details", help="JSON object; review evidence records model families and verdict.")
+    evidence.add_argument("--now")
+    evidence.set_defaults(func=cmd_evidence)
+
+    remaining = sub.add_parser("remaining-scope", help="Record none/open/transferred remaining scope.")
+    remaining.add_argument("--state-file", required=True)
+    remaining.add_argument("--status", choices=["none", "open", "transferred"], required=True)
+    remaining.add_argument("--summary", default="")
+    remaining.add_argument("--follow-up-issue", type=int)
+    remaining.add_argument("--follow-up-stream-epic", type=int)
+    remaining.add_argument("--evidence-id", action="append")
+    remaining.add_argument("--now")
+    remaining.set_defaults(func=cmd_remaining_scope)
+
+    reconcile = sub.add_parser("reconcile", help="Read GitHub/Git authority and append an idempotent receipt.")
+    reconcile.add_argument("--state-file", required=True)
+    reconcile.add_argument("--branch")
+    reconcile.add_argument("--worktree")
+    reconcile.add_argument("--observation-file", help="Hermetic observation fixture; no live GitHub reads.")
+    reconcile.add_argument("--now")
+    reconcile.set_defaults(func=cmd_reconcile)
+
+    mutate = sub.add_parser("mutate", help="Explicitly authorize one narrow GitHub closeout mutation.")
+    mutate.add_argument("action", choices=["sync-acs", "arm-auto-merge", "close-issue"])
+    mutate.add_argument("--state-file", required=True)
+    mutate.add_argument("--authorize", action="store_true")
+    mutate.add_argument("--actor", required=True)
+    mutate.add_argument("--branch")
+    mutate.add_argument("--worktree")
+    mutate.add_argument("--now")
+    mutate.set_defaults(func=cmd_mutate)
+
+    carrier = sub.add_parser("carrier", help="Render the exact delegation/ledger/rollover carrier.")
+    carrier.add_argument("--state-file", required=True)
+    carrier.set_defaults(func=cmd_carrier)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except (task_lifecycle.LifecycleError, json.JSONDecodeError, OSError) as exc:
+        print(json.dumps({"error": str(exc)}, ensure_ascii=False, indent=2), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/task_lifecycle.py
+++ b/scripts/orchestration/task_lifecycle.py
@@ -1,0 +1,1338 @@
+"""Canonical fleet task lifecycle, evidence, and closeout projection.
+
+The module is deliberately split from the GitHub CLI adapter.  Everything here
+is deterministic over a validated task-identity envelope, an immutable AC/evidence
+ledger, and an injected observation.  Remote reads and explicitly authorized
+mutations live in :mod:`scripts.orchestration.task_closeout`.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import fnmatch
+import hashlib
+import json
+import os
+import re
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+from scripts.orchestration import task_identity
+
+SCHEMA_VERSION = "task-lifecycle.v1"
+AC_SCHEMA_VERSION = "acceptance-criteria.v1"
+OBSERVATION_SCHEMA_VERSION = "task-closeout-observation.v1"
+TERMINAL_GOALS = frozenset({"merge", "deploy", "certify"})
+STATES = (
+    "ISSUE_LINKED",
+    "ACS_FINALIZED",
+    "IMPLEMENTATION_READY",
+    "PR_OPEN",
+    "REVIEW_REQUESTED",
+    "CHANGES_REQUESTED",
+    "REVIEW_PASSED",
+    "CI_PASSED",
+    "MERGED",
+    "DEPLOYED",
+    "CERTIFIED",
+    "ISSUE_CLOSED",
+    "CLEANED_UP",
+    "BLOCKED_WITH_RECEIPT",
+)
+STATE_RANK = {state: index for index, state in enumerate(STATES[:-1])}
+EVIDENCE_TYPES = frozenset(
+    {
+        "command",
+        "test",
+        "review",
+        "behavior_proof",
+        "ci",
+        "github",
+        "deployment",
+        "certification",
+        "follow_up",
+        "cleanup",
+        "document",
+    }
+)
+CURRENT_HEAD_EVIDENCE = EVIDENCE_TYPES - {"follow_up", "cleanup"}
+PROTECTED_PATH_PATTERNS = (
+    ".python-version",
+    ".yamllint",
+    ".markdownlint.json",
+    "curriculum/l2-uk-en/**/status/*.json",
+    "curriculum/l2-uk-en/**/audit/*-review.md",
+    "curriculum/l2-uk-en/**/review/*-review.md",
+    "docs/*-STATUS.md",
+    "data/telemetry/**",
+)
+FORBIDDEN_RECEIPT_PATH_MARKERS = (
+    "/status/",
+    "/audit/",
+    "/review/",
+    "-review.md",
+    "/telemetry/",
+    "/data/telemetry/",
+)
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCHEMA_PATH = _ROOT / "agents_extensions" / "shared" / "schemas" / "task-lifecycle.v1.schema.json"
+_SCHEMA = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+_VALIDATOR = Draft202012Validator(_SCHEMA, format_checker=FormatChecker())
+_AC_RE = re.compile(
+    r"^- \[(?P<checked>[ xX])\] \*\*(?P<id>[A-Z][A-Z0-9_-]{1,31})\*\*\s+[—-]\s+(?P<text>.+?)\s*$"
+)
+_SAFE_FAMILY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,99}$")
+
+
+class LifecycleError(ValueError):
+    """The lifecycle ledger or requested transition violates the contract."""
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def digest(value: Any) -> str:
+    payload = value if isinstance(value, str) else canonical_json(value)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _clean_text(value: Any, label: str, *, maximum: int = 4000) -> str:
+    cleaned = " ".join(str(value or "").split())
+    if not cleaned:
+        raise LifecycleError(f"{label} must be non-empty")
+    if len(cleaned) > maximum:
+        raise LifecycleError(f"{label} exceeds {maximum} characters")
+    return cleaned
+
+
+def _issue_url(repository: str, number: int) -> str:
+    return f"https://github.com/{repository}/issues/{number}"
+
+
+def _pr_url(repository: str, number: int) -> str:
+    return f"https://github.com/{repository}/pull/{number}"
+
+
+def lifecycle_id(identity: Mapping[str, Any]) -> str:
+    canonical = task_identity.validate_identity(identity)
+    issue = canonical.get("github_issue_number")
+    if issue is None:
+        raise LifecycleError("non-trivial lifecycle work requires a GitHub issue")
+    return digest(
+        {
+            "repository": canonical["repository"],
+            "issue": issue,
+            "stream_epic": canonical["stream_epic"],
+        }
+    )
+
+
+def parse_issue_acceptance_criteria(body: str) -> list[dict[str, Any]]:
+    """Parse stable-ID issue checkboxes in their authoritative order."""
+    criteria: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw_line in str(body or "").splitlines():
+        match = _AC_RE.fullmatch(raw_line.strip())
+        if not match:
+            continue
+        ac_id = match.group("id")
+        if ac_id in seen:
+            raise LifecycleError(f"duplicate acceptance criterion ID in issue body: {ac_id}")
+        seen.add(ac_id)
+        criteria.append(
+            {
+                "id": ac_id,
+                "text": _clean_text(match.group("text"), f"acceptance criterion {ac_id}"),
+                "checked": match.group("checked").lower() == "x",
+            }
+        )
+    if not criteria:
+        raise LifecycleError("issue body has no stable-ID acceptance criteria")
+    return criteria
+
+
+def ac_content_hash(criteria: list[Mapping[str, Any]]) -> str:
+    projection = [
+        {
+            "id": item["id"],
+            "text": item["text"],
+            "applicable": item["applicable"],
+            "due_state": item["due_state"],
+            "required_evidence": list(item["required_evidence"]),
+            "behavior_proof_required": item["behavior_proof_required"],
+        }
+        for item in criteria
+    ]
+    return digest(projection)
+
+
+def build_ac_snapshot(
+    issue_body: str,
+    policy: Mapping[str, Mapping[str, Any]],
+    *,
+    finalized_at: str,
+) -> dict[str, Any]:
+    parsed = parse_issue_acceptance_criteria(issue_body)
+    parsed_ids = [item["id"] for item in parsed]
+    policy_ids = list(policy)
+    missing = [ac_id for ac_id in parsed_ids if ac_id not in policy]
+    extra = [ac_id for ac_id in policy_ids if ac_id not in parsed_ids]
+    if missing or extra:
+        raise LifecycleError(f"AC policy mismatch: missing={missing}, extra={extra}")
+
+    criteria: list[dict[str, Any]] = []
+    for item in parsed:
+        ac_id = item["id"]
+        spec = policy[ac_id]
+        due_state = str(spec.get("due_state") or "")
+        if due_state not in STATE_RANK or due_state in {
+            "ISSUE_LINKED",
+            "ACS_FINALIZED",
+            "PR_OPEN",
+            "REVIEW_REQUESTED",
+            "CHANGES_REQUESTED",
+        }:
+            raise LifecycleError(f"{ac_id}: invalid evidence due state {due_state!r}")
+        required = list(spec.get("required_evidence") or [])
+        if not required or any(kind not in EVIDENCE_TYPES for kind in required):
+            raise LifecycleError(f"{ac_id}: required_evidence must contain supported evidence types")
+        if len(required) != len(set(required)):
+            raise LifecycleError(f"{ac_id}: required_evidence contains duplicates")
+        criteria.append(
+            {
+                "id": ac_id,
+                "text": item["text"],
+                "applicable": bool(spec.get("applicable", True)),
+                "due_state": due_state,
+                "required_evidence": required,
+                "behavior_proof_required": bool(spec.get("behavior_proof_required", False)),
+            }
+        )
+    return {
+        "schema_version": AC_SCHEMA_VERSION,
+        "content_hash": ac_content_hash(criteria),
+        "finalized_at": finalized_at,
+        "criteria": criteria,
+    }
+
+
+def build_lifecycle(
+    identity: Mapping[str, Any],
+    *,
+    author_family: str,
+    ac_snapshot: Mapping[str, Any],
+    required_checks: list[str],
+    now: str,
+    pr_number: int | None = None,
+    migration_source: str = "explicit",
+    legacy: bool = False,
+) -> dict[str, Any]:
+    canonical_identity = task_identity.validate_identity(identity)
+    terminal_goal = canonical_identity["terminal_goal"]
+    if terminal_goal not in TERMINAL_GOALS:
+        raise LifecycleError("implementation lifecycle requires terminal goal merge, deploy, or certify")
+    issue = canonical_identity.get("github_issue_number")
+    epic = canonical_identity.get("stream_epic")
+    if issue is None or epic is None:
+        raise LifecycleError("implementation lifecycle requires an issue linked to one stream epic")
+    family = _clean_text(author_family, "author family", maximum=100)
+    if not _SAFE_FAMILY_RE.fullmatch(family):
+        raise LifecycleError("author family contains unsupported characters")
+    checks = [_clean_text(value, "required check", maximum=200) for value in required_checks]
+    if not checks or len(checks) != len(set(checks)):
+        raise LifecycleError("required checks must be a non-empty unique list")
+    snapshot = deepcopy(dict(ac_snapshot))
+    ledger = {
+        "schema_version": SCHEMA_VERSION,
+        "lifecycle_id": lifecycle_id(canonical_identity),
+        "identity": canonical_identity,
+        "terminal_goal": terminal_goal,
+        "current_state": "ISSUE_LINKED",
+        "author_family": family,
+        "pr": {
+            "number": pr_number,
+            "url": _pr_url(canonical_identity["repository"], pr_number) if pr_number else None,
+        },
+        "ac_snapshot": snapshot,
+        "evidence": [],
+        "required_checks": checks,
+        "remaining_scope": {
+            "status": "none",
+            "summary": "",
+            "follow_up_issue": None,
+            "follow_up_stream_epic": None,
+            "evidence_ids": [],
+        },
+        "observation_receipts": [],
+        "mutation_receipts": [],
+        "created_at": now,
+        "updated_at": now,
+        "migration": {
+            "source": _clean_text(migration_source, "migration source", maximum=100),
+            "legacy": legacy,
+            "migrated_at": now if legacy else None,
+        },
+    }
+    return validate_lifecycle(ledger)
+
+
+def _schema_errors(payload: Mapping[str, Any]) -> list[str]:
+    errors = sorted(_VALIDATOR.iter_errors(payload), key=lambda item: list(item.absolute_path))
+    rendered: list[str] = []
+    for error in errors:
+        location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        rendered.append(f"{location}: {error.message}")
+    return rendered
+
+
+def _evidence_payload(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: deepcopy(value) for key, value in record.items() if key != "id"}
+
+
+def _receipt_event_payload(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: deepcopy(value) for key, value in record.items() if key != "id"}
+
+
+def _validate_behavior_proof_reference_shape(details: Mapping[str, Any]) -> dict[str, str]:
+    reference = details.get("behavior_proof_receipt")
+    if not isinstance(reference, Mapping):
+        raise LifecycleError(
+            "behavior-proof evidence requires details.behavior_proof_receipt"
+        )
+    required = {"receipt_path", "receipt_sha256", "input_sha256", "target_sha"}
+    if set(reference) != required:
+        raise LifecycleError(
+            "behavior-proof receipt reference requires only receipt_path, receipt_sha256, "
+            "input_sha256, and target_sha"
+        )
+    normalized = {key: str(reference.get(key) or "") for key in sorted(required)}
+    receipt_path = Path(normalized["receipt_path"]).expanduser()
+    if not receipt_path.is_absolute():
+        raise LifecycleError("behavior-proof receipt path must be absolute")
+    slash_path = str(receipt_path).replace("\\", "/")
+    if any(marker in slash_path for marker in FORBIDDEN_RECEIPT_PATH_MARKERS):
+        raise LifecycleError("behavior-proof receipt path is a forbidden generated-artifact path")
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", normalized["receipt_sha256"]):
+        raise LifecycleError("behavior-proof receipt digest must be sha256:<64 lowercase hex>")
+    if not re.fullmatch(r"[0-9a-f]{64}", normalized["input_sha256"]):
+        raise LifecycleError("behavior-proof target-input fingerprint must be 64 lowercase hex")
+    if not re.fullmatch(r"[0-9a-f]{40}", normalized["target_sha"]):
+        raise LifecycleError("behavior-proof target SHA must be 40 lowercase hex")
+    return normalized
+
+
+def validate_lifecycle(payload: Mapping[str, Any]) -> dict[str, Any]:
+    errors = _schema_errors(payload)
+    if errors:
+        raise LifecycleError(f"task lifecycle schema violation at {errors[0]}")
+    ledger = deepcopy(dict(payload))
+    identity = task_identity.validate_identity(ledger["identity"])
+    if ledger["lifecycle_id"] != lifecycle_id(identity):
+        raise LifecycleError("lifecycle ID does not match the exact task identity")
+    if ledger["terminal_goal"] != identity["terminal_goal"]:
+        raise LifecycleError("lifecycle terminal goal does not match task identity")
+    if identity.get("github_issue_number") is None or identity.get("stream_epic") is None:
+        raise LifecycleError("task lifecycle identity requires issue and stream epic")
+    pr_number = ledger["pr"]["number"]
+    expected_pr_url = _pr_url(identity["repository"], pr_number) if pr_number else None
+    if ledger["pr"]["url"] != expected_pr_url:
+        raise LifecycleError("PR URL does not match repository and PR number")
+    snapshot = ledger["ac_snapshot"]
+    criteria = snapshot["criteria"]
+    ids = [item["id"] for item in criteria]
+    if len(ids) != len(set(ids)):
+        raise LifecycleError("AC snapshot contains duplicate stable IDs")
+    if snapshot["content_hash"] != ac_content_hash(criteria):
+        raise LifecycleError("AC snapshot content hash is stale or forged")
+    for criterion in criteria:
+        if criterion["behavior_proof_required"] and "behavior_proof" not in criterion[
+            "required_evidence"
+        ]:
+            raise LifecycleError(
+                f"{criterion['id']}: behavior-proof-required AC must require behavior_proof evidence"
+            )
+    criteria_by_id = {item["id"]: item for item in criteria}
+    evidence_ids: set[str] = set()
+    for record in ledger["evidence"]:
+        if record["id"] != digest(_evidence_payload(record)):
+            raise LifecycleError(f"evidence {record['id']} digest is invalid")
+        if record["id"] in evidence_ids:
+            raise LifecycleError(f"duplicate evidence record: {record['id']}")
+        evidence_ids.add(record["id"])
+        if record["ac_id"] not in criteria_by_id:
+            raise LifecycleError(f"evidence targets unknown AC: {record['ac_id']}")
+        subject = record["subject"]
+        if subject["repository"] != identity["repository"]:
+            raise LifecycleError("evidence repository does not match task identity")
+        if subject["issue"] != identity["github_issue_number"]:
+            raise LifecycleError("evidence issue does not match task identity")
+        if subject["pr"] != pr_number:
+            raise LifecycleError("evidence PR does not match lifecycle binding")
+        if record["type"] == "review":
+            details = record["details"]
+            required = {"author_family", "reviewer_family", "verdict"}
+            if not required.issubset(details):
+                raise LifecycleError("review evidence requires author_family, reviewer_family, and verdict")
+            if details["author_family"] != ledger["author_family"]:
+                raise LifecycleError("review evidence author family does not match lifecycle")
+            if details["reviewer_family"] == details["author_family"]:
+                raise LifecycleError("review evidence is not outside the author model family")
+            if details["verdict"] != "pass":
+                raise LifecycleError("review evidence verdict must be pass")
+        if record["type"] == "behavior_proof":
+            reference = _validate_behavior_proof_reference_shape(record["details"])
+            if subject["commit"] is None or reference["target_sha"] != subject["commit"]:
+                raise LifecycleError(
+                    "behavior-proof receipt target SHA does not match its evidence subject"
+                )
+    for evidence_id in ledger["remaining_scope"]["evidence_ids"]:
+        if evidence_id not in evidence_ids:
+            raise LifecycleError("remaining-scope evidence ID is not present in the evidence ledger")
+    remaining = ledger["remaining_scope"]
+    if remaining["status"] == "none":
+        if remaining["follow_up_issue"] is not None or remaining["follow_up_stream_epic"] is not None:
+            raise LifecycleError("remaining scope none cannot carry a follow-up issue")
+    elif remaining["status"] == "open":
+        if not remaining["summary"].strip():
+            raise LifecycleError("open remaining scope requires a summary")
+    else:
+        if not remaining["summary"].strip() or not remaining["follow_up_issue"]:
+            raise LifecycleError("transferred scope requires a summary and follow-up issue")
+        if not remaining["follow_up_stream_epic"] or not remaining["evidence_ids"]:
+            raise LifecycleError("transferred scope requires one stream epic and evidence")
+    observation_ids: set[str] = set()
+    for receipt in ledger["observation_receipts"]:
+        if receipt["id"] != digest(_receipt_event_payload(receipt)):
+            raise LifecycleError("observation receipt digest is invalid")
+        if receipt["id"] in observation_ids:
+            raise LifecycleError("duplicate observation receipt")
+        observation_ids.add(receipt["id"])
+    mutation_ids: set[str] = set()
+    for receipt in ledger["mutation_receipts"]:
+        if receipt["id"] != digest(_receipt_event_payload(receipt)):
+            raise LifecycleError("mutation receipt digest is invalid")
+        if receipt["id"] in mutation_ids:
+            raise LifecycleError("duplicate mutation receipt event")
+        mutation_ids.add(receipt["id"])
+    return ledger
+
+
+def bind_pr(payload: Mapping[str, Any], *, pr_number: int, now: str) -> dict[str, Any]:
+    ledger = validate_lifecycle(payload)
+    if pr_number < 1:
+        raise LifecycleError("PR number must be positive")
+    existing = ledger["pr"]["number"]
+    if existing is not None and existing != pr_number:
+        raise LifecycleError("lifecycle is already bound to a different PR")
+    if existing == pr_number:
+        return ledger
+    ledger["pr"] = {
+        "number": pr_number,
+        "url": _pr_url(ledger["identity"]["repository"], pr_number),
+    }
+    ledger["updated_at"] = now
+    return validate_lifecycle(ledger)
+
+
+def add_evidence(
+    payload: Mapping[str, Any],
+    *,
+    ac_id: str,
+    evidence_type: str,
+    summary: str,
+    url: str | None,
+    commit: str | None,
+    details: Mapping[str, Any] | None,
+    recorded_at: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    ledger = validate_lifecycle(payload)
+    if evidence_type not in EVIDENCE_TYPES:
+        raise LifecycleError(f"unsupported evidence type: {evidence_type}")
+    if ac_id not in {item["id"] for item in ledger["ac_snapshot"]["criteria"]}:
+        raise LifecycleError(f"unknown acceptance criterion: {ac_id}")
+    pr_number = ledger["pr"]["number"]
+    if pr_number is None:
+        raise LifecycleError("bind the lifecycle to a PR before recording evidence")
+    if commit is not None and not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise LifecycleError("evidence commit must be a full lowercase Git SHA")
+    record: dict[str, Any] = {
+        "ac_id": ac_id,
+        "type": evidence_type,
+        "summary": _clean_text(summary, "evidence summary"),
+        "url": url,
+        "subject": {
+            "repository": ledger["identity"]["repository"],
+            "issue": ledger["identity"]["github_issue_number"],
+            "pr": pr_number,
+            "commit": commit,
+        },
+        "details": deepcopy(dict(details or {})),
+        "recorded_at": recorded_at,
+    }
+    record["id"] = digest(record)
+    for existing in ledger["evidence"]:
+        if existing["id"] == record["id"]:
+            return ledger, existing
+    ledger["evidence"].append(record)
+    ledger["updated_at"] = recorded_at
+    return validate_lifecycle(ledger), record
+
+
+def set_remaining_scope(
+    payload: Mapping[str, Any],
+    *,
+    status: str,
+    summary: str = "",
+    follow_up_issue: int | None = None,
+    follow_up_stream_epic: int | None = None,
+    evidence_ids: list[str] | None = None,
+    now: str,
+) -> dict[str, Any]:
+    ledger = validate_lifecycle(payload)
+    if status not in {"none", "open", "transferred"}:
+        raise LifecycleError("remaining scope status must be none, open, or transferred")
+    ledger["remaining_scope"] = {
+        "status": status,
+        "summary": " ".join(summary.split()),
+        "follow_up_issue": follow_up_issue,
+        "follow_up_stream_epic": follow_up_stream_epic,
+        "evidence_ids": list(evidence_ids or []),
+    }
+    ledger["updated_at"] = now
+    return validate_lifecycle(ledger)
+
+
+def canonical_state_root(repo_root: Path) -> Path:
+    """Return the primary checkout shared by all linked worktrees."""
+    completed = _run_git(repo_root, ["rev-parse", "--path-format=absolute", "--git-common-dir"])
+    common = Path(completed.strip())
+    if not common.is_absolute():
+        common = (repo_root / common).resolve()
+    if common.name != ".git":
+        raise LifecycleError(f"cannot derive primary checkout from Git common directory: {common}")
+    return common.parent.resolve()
+
+
+def lifecycle_path(repo_root: Path, identity: Mapping[str, Any]) -> Path:
+    canonical = task_identity.validate_identity(identity)
+    issue = canonical.get("github_issue_number")
+    if issue is None:
+        raise LifecycleError("lifecycle path requires a GitHub issue")
+    repository_digest = hashlib.sha256(canonical["repository"].encode("utf-8")).hexdigest()[:16]
+    return canonical_state_root(repo_root) / ".agent" / "task-lifecycle" / repository_digest / f"issue-{issue}.json"
+
+
+def load_lifecycle(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise LifecycleError(f"lifecycle ledger not found: {path}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LifecycleError(f"cannot read lifecycle ledger {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise LifecycleError("lifecycle ledger must contain a JSON object")
+    return validate_lifecycle(payload)
+
+
+def write_lifecycle(path: Path, payload: Mapping[str, Any]) -> None:
+    ledger = validate_lifecycle(payload)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(ledger, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+@contextmanager
+def lifecycle_lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+def carrier_projection(payload: Mapping[str, Any], *, state_file: str | None = None) -> dict[str, Any]:
+    ledger = validate_lifecycle(payload)
+    receipts = ledger["observation_receipts"]
+    return {
+        "schema_version": "task-lifecycle-carrier.v1",
+        "lifecycle_id": ledger["lifecycle_id"],
+        "identity": ledger["identity"],
+        "terminal_goal": ledger["terminal_goal"],
+        "pr": ledger["pr"],
+        "ac_snapshot": ledger["ac_snapshot"],
+        "remaining_scope": ledger["remaining_scope"],
+        "current_state": ledger["current_state"],
+        "latest_receipt_id": receipts[-1]["id"] if receipts else None,
+        "state_file": state_file,
+    }
+
+
+def render_carrier_prompt(carrier: Mapping[str, Any]) -> str:
+    return (
+        "\n[task lifecycle — authoritative carrier]\n"
+        "This task is bound to the following shared lifecycle ledger. Preserve it through "
+        "delegation and final receipts; do not infer completion from worker status alone.\n"
+        f"{json.dumps(dict(carrier), ensure_ascii=False, sort_keys=True)}\n"
+    )
+
+
+def _run_git(repo_root: Path, args: list[str]) -> str:
+    import subprocess
+
+    completed = subprocess.run(
+        ["git", *args], cwd=repo_root, capture_output=True, text=True, check=False
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "git command failed").strip()
+        raise LifecycleError(f"git {' '.join(args)} failed: {detail}")
+    return completed.stdout.strip()
+
+
+def protected_paths(paths: list[str]) -> list[str]:
+    return sorted(
+        {
+            path
+            for path in paths
+            if any(fnmatch.fnmatch(path, pattern) for pattern in PROTECTED_PATH_PATTERNS)
+        }
+    )
+
+
+def observe_local_git(
+    repo_root: Path,
+    *,
+    head_sha: str | None,
+    branch: str | None,
+    worktree: str | None,
+) -> dict[str, Any]:
+    """Collect deterministic local Git/worktree closeout facts.
+
+    Missing post-merge refs are expected.  Pre-merge hygiene remains durable in
+    the earlier observation receipt; post-merge collection focuses on cleanup.
+    """
+    root = repo_root.resolve()
+    primary = canonical_state_root(root)
+    primary_clean = not bool(_run_git(primary, ["status", "--short"]))
+    worktree_rows = _run_git(primary, ["worktree", "list", "--porcelain"]).splitlines()
+    worktree_records: list[dict[str, str]] = []
+    current_record: dict[str, str] = {}
+    for line in [*worktree_rows, ""]:
+        if not line:
+            if current_record:
+                worktree_records.append(current_record)
+                current_record = {}
+            continue
+        key, _, value = line.partition(" ")
+        current_record[key] = value
+    resolved_worktree = str(Path(worktree).resolve()) if worktree else None
+    selected_worktree = next(
+        (
+            record
+            for record in worktree_records
+            if resolved_worktree
+            and str(Path(record.get("worktree", "")).resolve()) == resolved_worktree
+        ),
+        None,
+    )
+    worktree_present = selected_worktree is not None
+    actual_worktree_branch = (
+        str(selected_worktree.get("branch") or "").removeprefix("refs/heads/")
+        if selected_worktree
+        else None
+    ) or None
+    worktree_branch_matches = bool(
+        worktree_present
+        and actual_worktree_branch
+        and (not branch or actual_worktree_branch == branch)
+    )
+    dispatch_worktree_used = bool(
+        worktree_present
+        and resolved_worktree
+        and "/.worktrees/dispatch/" in resolved_worktree.replace("\\", "/")
+        and Path(resolved_worktree).resolve() != primary
+    )
+    local_branch_present = False
+    remote_branch_present = False
+    if branch:
+        local_branch_present = bool(
+            _run_git(primary, ["for-each-ref", "--format=%(refname)", f"refs/heads/{branch}"])
+        )
+        remote_branch_present = bool(
+            _run_git(primary, ["for-each-ref", "--format=%(refname)", f"refs/remotes/origin/{branch}"])
+        )
+
+    commits: list[dict[str, Any]] = []
+    changed_paths: list[str] = []
+    if head_sha:
+        try:
+            base = _run_git(root, ["merge-base", "origin/main", head_sha])
+            changed_raw = _run_git(root, ["diff", "--name-only", f"{base}..{head_sha}"])
+            changed_paths = [line for line in changed_raw.splitlines() if line]
+            log = _run_git(root, ["log", "--format=%H%x1f%B%x1e", f"{base}..{head_sha}"])
+            for record in log.split("\x1e"):
+                if not record.strip() or "\x1f" not in record:
+                    continue
+                sha, message = record.strip().split("\x1f", 1)
+                trailers = [
+                    line.strip()
+                    for line in message.splitlines()
+                    if line.strip().lower().startswith("x-agent:")
+                ]
+                commits.append({"sha": sha, "x_agent_trailers": trailers})
+        except LifecycleError:
+            # The immutable pre-merge receipt remains the authority for hygiene
+            # when squash merge/branch deletion makes the old comparison absent.
+            pass
+    return {
+        "primary_checkout": str(primary),
+        "primary_clean": primary_clean,
+        "dispatch_worktree_used": dispatch_worktree_used,
+        "worktree": resolved_worktree,
+        "worktree_present": worktree_present,
+        "actual_worktree_branch": actual_worktree_branch,
+        "worktree_branch_matches": worktree_branch_matches,
+        "branch": branch,
+        "local_branch_present": local_branch_present,
+        "remote_branch_present": remote_branch_present,
+        "commits": commits,
+        "changed_paths": changed_paths,
+        "forbidden_paths": protected_paths(changed_paths),
+    }
+
+
+def _observation_material(observation: Any) -> Any:
+    if isinstance(observation, dict):
+        return {
+            key: _observation_material(value)
+            for key, value in observation.items()
+            if key not in {"observed_at", "generated_at"}
+        }
+    if isinstance(observation, list):
+        return [_observation_material(value) for value in observation]
+    return observation
+
+
+def _ledger_projection_material(ledger: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "lifecycle_id": ledger["lifecycle_id"],
+        "terminal_goal": ledger["terminal_goal"],
+        "pr": ledger["pr"],
+        "ac_hash": ledger["ac_snapshot"]["content_hash"],
+        "evidence_ids": [item["id"] for item in ledger["evidence"]],
+        "remaining_scope": ledger["remaining_scope"],
+        "required_checks": ledger["required_checks"],
+    }
+
+
+def _behavior_proof_reference_error(
+    record: Mapping[str, Any], *, head_sha: str | None
+) -> str | None:
+    try:
+        reference = _validate_behavior_proof_reference_shape(record["details"])
+    except LifecycleError as exc:
+        return str(exc)
+    target_sha = reference["target_sha"]
+    if head_sha and target_sha != head_sha:
+        return "behavior-proof receipt is not bound to the current PR head"
+    path = Path(reference["receipt_path"]).expanduser()
+    try:
+        receipt_bytes = path.read_bytes()
+        receipt = json.loads(receipt_bytes)
+    except (OSError, json.JSONDecodeError) as exc:
+        return f"behavior-proof receipt is unreadable: {exc}"
+    actual_digest = "sha256:" + hashlib.sha256(receipt_bytes).hexdigest()
+    if actual_digest != reference["receipt_sha256"]:
+        return "behavior-proof receipt digest does not match the referenced file"
+    if not isinstance(receipt, dict) or receipt.get("schema_version") != "code-review-receipt.v1":
+        return "behavior-proof reference is not a canonical code-review receipt"
+    target = receipt.get("target")
+    if not isinstance(target, dict):
+        return "behavior-proof receipt has no canonical target"
+    if target.get("head_sha") != target_sha:
+        return "behavior-proof receipt target SHA does not match the evidence reference"
+    if target.get("input_sha256") != reference["input_sha256"]:
+        return "behavior-proof receipt target-input fingerprint does not match the reference"
+    if receipt.get("final_disposition") != "clean" or receipt.get("exit_code") != 0:
+        return "behavior-proof receipt is not a clean canonical closeout"
+    author = receipt.get("author") or {}
+    reviewer = receipt.get("reviewer") or {}
+    if not author.get("family") or not reviewer.get("family"):
+        return "behavior-proof receipt lacks concrete author/reviewer families"
+    if str(author["family"]).lower() == str(reviewer["family"]).lower():
+        return "behavior-proof receipt is not outside the author model family"
+    proof = receipt.get("behavior_proof")
+    if not isinstance(proof, dict) or proof.get("schema_version") != "behavior-proof.v1":
+        return "behavior-proof receipt lacks the canonical behavior-proof.v1 envelope"
+    for surface_name in ("source_aware", "source_blind"):
+        surface = proof.get(surface_name)
+        if not isinstance(surface, dict) or surface.get("status") not in {"pass", "n/a"}:
+            return f"behavior-proof receipt has no passing/applicable {surface_name} surface"
+        if surface["status"] == "n/a":
+            reason = str(surface.get("reason") or surface.get("rationale") or "").strip()
+            if not reason:
+                return f"behavior-proof receipt has an unexplained n/a {surface_name} surface"
+        if surface["status"] == "pass":
+            clauses = surface.get("clauses")
+            if not isinstance(clauses, list) or not any(
+                isinstance(clause, dict)
+                and clause.get("target_input_sha256") == reference["input_sha256"]
+                for clause in clauses
+            ):
+                return f"behavior-proof receipt {surface_name} clauses are not target-bound"
+    return None
+
+
+def _evidence_status(
+    ledger: Mapping[str, Any],
+    *,
+    head_sha: str | None,
+    comment_urls: set[str],
+) -> tuple[dict[str, set[str]], list[str]]:
+    valid: dict[str, set[str]] = {}
+    invalid: list[str] = []
+    for record in ledger["evidence"]:
+        kind = record["type"]
+        commit = record["subject"]["commit"]
+        if kind in CURRENT_HEAD_EVIDENCE and head_sha and commit != head_sha:
+            invalid.append(f"{record['ac_id']}: {kind} evidence is not bound to current PR head")
+            continue
+        if kind == "behavior_proof":
+            reference_error = _behavior_proof_reference_error(record, head_sha=head_sha)
+            if reference_error:
+                invalid.append(f"{record['ac_id']}: {reference_error}")
+                continue
+        if kind == "review" and (not record["url"] or record["url"] not in comment_urls):
+            invalid.append(f"{record['ac_id']}: review receipt URL is absent from authoritative PR comments")
+            continue
+        valid.setdefault(record["ac_id"], set()).add(kind)
+    return valid, invalid
+
+
+def _criteria_due_blockers(
+    ledger: Mapping[str, Any],
+    valid_evidence: Mapping[str, set[str]],
+    *,
+    target_state: str,
+) -> list[str]:
+    target_rank = STATE_RANK[target_state]
+    blockers: list[str] = []
+    for item in ledger["ac_snapshot"]["criteria"]:
+        if not item["applicable"] or STATE_RANK[item["due_state"]] > target_rank:
+            continue
+        missing = sorted(set(item["required_evidence"]) - valid_evidence.get(item["id"], set()))
+        if missing:
+            blockers.append(f"{item['id']}: missing typed evidence {', '.join(missing)}")
+    return blockers
+
+
+def _latest_premerge_local(ledger: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    for receipt in reversed(ledger["observation_receipts"]):
+        local = (receipt.get("observation") or {}).get("local")
+        if not isinstance(local, dict):
+            continue
+        if (
+            local.get("dispatch_worktree_used")
+            and local.get("worktree_present")
+            and local.get("worktree_branch_matches")
+            and local.get("commits")
+        ):
+            return local
+    return None
+
+
+def _local_readiness(local: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    if not local.get("primary_clean"):
+        blockers.append("primary checkout is not clean")
+    if not local.get("dispatch_worktree_used"):
+        blockers.append("implementation was not observed in a dispatch worktree")
+    if not local.get("worktree_present"):
+        blockers.append("the claimed dispatch worktree was absent from git worktree list")
+    if not local.get("worktree_branch_matches"):
+        blockers.append("the claimed dispatch worktree branch did not match Git authority")
+    commits = local.get("commits") or []
+    if not commits:
+        blockers.append("no task commits were available for X-Agent validation")
+    for commit in commits:
+        trailers = commit.get("x_agent_trailers") or []
+        if len(trailers) != 1 or not str(trailers[0]).split(":", 1)[-1].strip():
+            blockers.append(f"commit {commit.get('sha', 'unknown')} lacks exactly one valid X-Agent trailer")
+    forbidden = local.get("forbidden_paths") or []
+    if forbidden:
+        blockers.append(f"forbidden/generated paths changed: {', '.join(forbidden)}")
+    return blockers
+
+
+def _review_passed(ledger: Mapping[str, Any], valid_evidence: Mapping[str, set[str]]) -> bool:
+    review_records = [record for record in ledger["evidence"] if record["type"] == "review"]
+    return any("review" in valid_evidence.get(record["ac_id"], set()) for record in review_records)
+
+
+def _checks_status(required: list[str], checks: list[Mapping[str, Any]]) -> tuple[bool, bool, list[str]]:
+    by_name: dict[str, Mapping[str, Any]] = {}
+    for check in checks:
+        by_name[str(check.get("name") or "")] = check
+    missing = [name for name in required if name not in by_name]
+    pending = [name for name in required if name in by_name and by_name[name].get("status") != "COMPLETED"]
+    failed = [
+        name
+        for name in required
+        if name in by_name
+        and by_name[name].get("status") == "COMPLETED"
+        and by_name[name].get("conclusion") not in {"SUCCESS", "NEUTRAL", "SKIPPED"}
+    ]
+    return not (missing or pending or failed), bool(pending or missing), failed
+
+
+def evaluate(payload: Mapping[str, Any], observation: Mapping[str, Any]) -> dict[str, Any]:
+    ledger = validate_lifecycle(payload)
+    if observation.get("schema_version") != OBSERVATION_SCHEMA_VERSION:
+        raise LifecycleError("unsupported closeout observation schema")
+    github = observation.get("github")
+    local = observation.get("local")
+    if not isinstance(github, Mapping) or not isinstance(local, Mapping):
+        raise LifecycleError("observation requires github and local objects")
+    issue = github.get("issue") or {}
+    pr = github.get("pr") or {}
+    identity = ledger["identity"]
+    hard: list[str] = []
+    waiting: list[str] = []
+    actions: list[str] = []
+    last_success = "ISSUE_LINKED"
+
+    if github.get("error"):
+        hard.append(f"GitHub observation failed: {github['error']}")
+
+    if github.get("repository") != identity["repository"]:
+        hard.append("authoritative GitHub repository does not match task identity")
+    registered_epics = github.get("registered_stream_epics")
+    if not isinstance(registered_epics, list) or identity["stream_epic"] not in registered_epics:
+        hard.append("identity stream epic is absent from the registered issue-stream epics")
+    if issue.get("number") != identity["github_issue_number"]:
+        hard.append("authoritative GitHub issue does not match task identity")
+    if issue.get("url") != identity["github_issue_url"]:
+        hard.append("authoritative GitHub issue URL does not match task identity")
+    if issue.get("parent_epic") != identity["stream_epic"]:
+        hard.append("issue is not linked to the identity's exact registered stream epic")
+
+    issue_criteria: list[dict[str, Any]] = []
+    try:
+        issue_criteria = parse_issue_acceptance_criteria(str(issue.get("body") or ""))
+    except LifecycleError as exc:
+        hard.append(str(exc))
+    if issue_criteria:
+        snapshot_projection = [
+            {"id": item["id"], "text": item["text"]}
+            for item in ledger["ac_snapshot"]["criteria"]
+        ]
+        issue_projection = [{"id": item["id"], "text": item["text"]} for item in issue_criteria]
+        if issue_projection != snapshot_projection:
+            hard.append("issue acceptance criteria drift from the immutable AC snapshot")
+        else:
+            last_success = "ACS_FINALIZED"
+
+    expected_pr = ledger["pr"]["number"]
+    head_sha = pr.get("head_sha") if isinstance(pr, Mapping) else None
+    comment_urls = {
+        str(comment.get("url"))
+        for comment in github.get("comments") or []
+        if isinstance(comment, Mapping) and comment.get("url")
+    }
+    valid_evidence, invalid_evidence = _evidence_status(
+        ledger, head_sha=head_sha, comment_urls=comment_urls
+    )
+    hard.extend(invalid_evidence)
+
+    readiness_local = local
+    prior_local = _latest_premerge_local(ledger)
+    if prior_local is not None and (
+        not local.get("commits")
+        or not local.get("worktree_present")
+        or not local.get("worktree_branch_matches")
+    ):
+        readiness_local = prior_local
+    readiness_blockers = _local_readiness(readiness_local)
+    readiness_blockers.extend(
+        _criteria_due_blockers(ledger, valid_evidence, target_state="IMPLEMENTATION_READY")
+    )
+    if not readiness_blockers and last_success == "ACS_FINALIZED":
+        last_success = "IMPLEMENTATION_READY"
+    elif last_success == "ACS_FINALIZED":
+        hard.extend(readiness_blockers)
+
+    if expected_pr is None:
+        waiting.append("PR is not yet bound to the lifecycle ledger")
+        actions.append("bind the exact PR number")
+    elif pr.get("number") != expected_pr or pr.get("url") != ledger["pr"]["url"]:
+        hard.append("authoritative PR does not match the lifecycle binding")
+    else:
+        pr_state = str(pr.get("state") or "").upper()
+        if pr_state == "OPEN":
+            last_success = "PR_OPEN"
+            if pr.get("is_draft"):
+                waiting.append("PR remains a draft")
+                actions.append("mark the PR ready for review before requesting the gate")
+        requested_changes = bool(pr.get("requested_changes"))
+        if requested_changes:
+            last_success = "CHANGES_REQUESTED"
+            hard.append("unresolved requested changes remain on the PR")
+            actions.append("address requested changes and obtain fresh current-head review")
+        elif pr_state == "OPEN":
+            review_ok = _review_passed(ledger, valid_evidence)
+            if not review_ok:
+                last_success = "REVIEW_REQUESTED"
+                waiting.append("independent outside-author-family review is pending")
+                actions.append("record a current-head outside-family review receipt")
+            else:
+                review_due = _criteria_due_blockers(
+                    ledger, valid_evidence, target_state="REVIEW_PASSED"
+                )
+                if review_due:
+                    hard.extend(review_due)
+                else:
+                    last_success = "REVIEW_PASSED"
+                    auto_enabled = pr.get("auto_merge_enabled_at")
+                    review_times = [
+                        record["recorded_at"]
+                        for record in ledger["evidence"]
+                        if record["type"] == "review"
+                        and "review" in valid_evidence.get(record["ac_id"], set())
+                    ]
+                    if auto_enabled and review_times and auto_enabled < max(review_times):
+                        hard.append("auto-merge was armed before the verified review gate")
+                checks_ok, checks_waiting, checks_failed = _checks_status(
+                    ledger["required_checks"], list(pr.get("checks") or [])
+                )
+                if checks_failed:
+                    hard.append(f"required CI failed: {', '.join(checks_failed)}")
+                elif checks_waiting:
+                    waiting.append("required CI is pending")
+                elif checks_ok:
+                    ci_due = _criteria_due_blockers(
+                        ledger, valid_evidence, target_state="CI_PASSED"
+                    )
+                    if ci_due:
+                        hard.extend(ci_due)
+                    else:
+                        last_success = "CI_PASSED"
+                        waiting.append("reviewed green PR remains open")
+                        actions.append("arm or await auto-merge, then reconcile the merged PR")
+
+        if pr_state == "MERGED":
+            review_ok = _review_passed(ledger, valid_evidence)
+            checks_ok, checks_waiting, checks_failed = _checks_status(
+                ledger["required_checks"], list(pr.get("checks") or [])
+            )
+            if not review_ok:
+                hard.append("merged PR lacks verified current-head outside-family review")
+            else:
+                auto_enabled = pr.get("auto_merge_enabled_at")
+                review_times = [
+                    record["recorded_at"]
+                    for record in ledger["evidence"]
+                    if record["type"] == "review"
+                    and "review" in valid_evidence.get(record["ac_id"], set())
+                ]
+                if auto_enabled and review_times and auto_enabled < max(review_times):
+                    hard.append("auto-merge was armed before the verified review gate")
+            if checks_failed:
+                hard.append(f"merged PR has failed required CI: {', '.join(checks_failed)}")
+            elif checks_waiting:
+                waiting.append("merged PR still has pending required CI")
+            if not pr.get("merge_sha"):
+                hard.append("GitHub reports merged PR without a merge commit")
+            elif review_ok and checks_ok:
+                review_due = _criteria_due_blockers(
+                    ledger, valid_evidence, target_state="REVIEW_PASSED"
+                )
+                ci_due = _criteria_due_blockers(
+                    ledger, valid_evidence, target_state="CI_PASSED"
+                )
+                merged_due = _criteria_due_blockers(
+                    ledger, valid_evidence, target_state="MERGED"
+                )
+                boundary_due = list(dict.fromkeys([*review_due, *ci_due, *merged_due]))
+                if boundary_due:
+                    hard.extend(boundary_due)
+                else:
+                    last_success = "MERGED"
+        elif pr_state == "CLOSED":
+            hard.append("PR closed without merge")
+
+    goal = ledger["terminal_goal"]
+    deployments = github.get("deployments") or []
+    deployed = any(
+        item.get("state") == "SUCCESS" and item.get("sha") in {pr.get("merge_sha"), pr.get("head_sha")}
+        for item in deployments
+        if isinstance(item, Mapping)
+    )
+    if last_success == "MERGED" and goal in {"deploy", "certify"}:
+        if deployed:
+            deploy_due = _criteria_due_blockers(
+                ledger, valid_evidence, target_state="DEPLOYED"
+            )
+            if deploy_due:
+                hard.extend(deploy_due)
+            else:
+                last_success = "DEPLOYED"
+        else:
+            waiting.append("terminal goal requires deployment")
+            actions.append("deploy the merged commit and record authoritative evidence")
+    certified = any(
+        record["type"] == "certification"
+        and "certification" in valid_evidence.get(record["ac_id"], set())
+        for record in ledger["evidence"]
+    )
+    if last_success == "DEPLOYED" and goal == "certify":
+        if certified:
+            certify_due = _criteria_due_blockers(
+                ledger, valid_evidence, target_state="CERTIFIED"
+            )
+            if certify_due:
+                hard.extend(certify_due)
+            else:
+                last_success = "CERTIFIED"
+        else:
+            waiting.append("terminal goal requires certification")
+            actions.append("record certification evidence bound to the deployed commit")
+
+    remote_goal_state = {"merge": "MERGED", "deploy": "DEPLOYED", "certify": "CERTIFIED"}[goal]
+    goal_reached = STATE_RANK.get(last_success, -1) >= STATE_RANK[remote_goal_state]
+    remaining = ledger["remaining_scope"]
+    if remaining["status"] == "open":
+        hard.append("remaining scope is open and has not been transferred")
+        actions.append("create and reciprocally link a single-stream follow-up issue")
+    elif remaining["status"] == "transferred":
+        follow_up = github.get("follow_up") or {}
+        if follow_up.get("number") != remaining["follow_up_issue"]:
+            hard.append("authoritative follow-up issue does not match transferred scope")
+        if follow_up.get("parent_epic") != remaining["follow_up_stream_epic"]:
+            hard.append("follow-up issue does not have the exact transferred stream epic")
+        if remaining["follow_up_stream_epic"] not in (registered_epics or []):
+            hard.append("follow-up issue epic is absent from the registered issue-stream epics")
+        if not follow_up.get("reciprocal_links_verified"):
+            hard.append("original and follow-up issues are not reciprocally linked")
+
+    checked = {item["id"]: item["checked"] for item in issue_criteria}
+    preclose_missing = _criteria_due_blockers(
+        ledger, valid_evidence, target_state=remote_goal_state
+    )
+    preclose_unchecked = [
+        item["id"]
+        for item in ledger["ac_snapshot"]["criteria"]
+        if item["applicable"]
+        and STATE_RANK[item["due_state"]] <= STATE_RANK[remote_goal_state]
+        and not checked.get(item["id"], False)
+    ]
+    if str(issue.get("state") or "").upper() == "CLOSED":
+        if not goal_reached or preclose_missing or preclose_unchecked or remaining["status"] == "open":
+            hard.append("issue closed before terminal goal and pre-close AC proof were complete")
+        else:
+            last_success = "ISSUE_CLOSED"
+            close_due = _criteria_due_blockers(
+                ledger, valid_evidence, target_state="ISSUE_CLOSED"
+            )
+            if close_due:
+                hard.extend(close_due)
+    elif goal_reached:
+        waiting.append("merged/deployed work is not yet reconciled to an actually closed issue")
+        actions.append("sync evidenced AC checkboxes, then explicitly close the issue")
+
+    cleanup_ok = (
+        not local.get("worktree_present")
+        and not local.get("local_branch_present")
+        and not local.get("remote_branch_present")
+    )
+    if last_success == "ISSUE_CLOSED":
+        if cleanup_ok:
+            cleanup_due = _criteria_due_blockers(
+                ledger, valid_evidence, target_state="CLEANED_UP"
+            )
+            all_unchecked = [
+                item["id"]
+                for item in ledger["ac_snapshot"]["criteria"]
+                if item["applicable"] and not checked.get(item["id"], False)
+            ]
+            if cleanup_due:
+                hard.extend(cleanup_due)
+            if all_unchecked:
+                hard.append(f"applicable issue ACs remain unchecked: {', '.join(all_unchecked)}")
+            if not cleanup_due and not all_unchecked:
+                last_success = "CLEANED_UP"
+        else:
+            waiting.append("merged task branch or dispatch worktree still requires cleanup")
+            actions.append("remove the exact worktree and local/remote task branches")
+
+    if hard and not actions:
+        actions.append(
+            f"owner {ledger['author_family']}: resolve the listed hard blockers and reconcile again"
+        )
+    if hard:
+        state = "BLOCKED_WITH_RECEIPT"
+        disposition = "blocked"
+    else:
+        state = last_success
+        if state == "CLEANED_UP":
+            disposition = "complete"
+        elif waiting:
+            disposition = "waiting"
+        else:
+            disposition = "ready"
+    return {
+        "state": state,
+        "last_success_state": last_success,
+        "disposition": disposition,
+        "hard_blockers": list(dict.fromkeys(hard)),
+        "waiting": list(dict.fromkeys(waiting)),
+        "next_actions": list(dict.fromkeys(actions)),
+        "valid_evidence": {key: sorted(value) for key, value in valid_evidence.items()},
+        "preclose_missing_evidence": preclose_missing,
+        "preclose_unchecked": preclose_unchecked,
+        "goal_reached": goal_reached,
+    }
+
+
+def reconcile(
+    payload: Mapping[str, Any],
+    observation: Mapping[str, Any],
+    *,
+    now: str,
+) -> tuple[dict[str, Any], dict[str, Any], bool]:
+    ledger = validate_lifecycle(payload)
+    result = evaluate(ledger, observation)
+    observation_digest = digest(_observation_material(observation))
+    receipt_material = {
+        "observation_digest": observation_digest,
+        "observed_at": str(observation.get("observed_at") or now),
+        "owner": ledger["author_family"],
+        "state": result["state"],
+        "disposition": result["disposition"],
+        "hard_blockers": result["hard_blockers"],
+        "waiting": result["waiting"],
+        "next_actions": result["next_actions"],
+        "observation": {
+            **deepcopy(dict(observation)),
+            "projection": {
+                "last_success_state": result["last_success_state"],
+                "goal_reached": result["goal_reached"],
+                "valid_evidence": result["valid_evidence"],
+            },
+        },
+    }
+    replay_key = digest(
+        {
+            "observation": observation_digest,
+            "ledger": _ledger_projection_material(ledger),
+            "result": {
+                key: receipt_material[key]
+                for key in ("state", "disposition", "hard_blockers", "waiting", "next_actions")
+            },
+        }
+    )
+    for existing in ledger["observation_receipts"]:
+        existing_key = (existing.get("observation") or {}).get("replay_key")
+        if existing_key == replay_key:
+            return ledger, existing, True
+    receipt_material["observation"]["replay_key"] = replay_key
+    receipt = {"id": digest(receipt_material), **receipt_material}
+    ledger["observation_receipts"].append(receipt)
+    ledger["current_state"] = result["state"]
+    ledger["updated_at"] = now
+    return validate_lifecycle(ledger), receipt, False
+
+
+def mutation_operation_id(payload: Mapping[str, Any], action: str) -> str:
+    ledger = validate_lifecycle(payload)
+    if action not in {"sync-acs", "arm-auto-merge", "close-issue"}:
+        raise LifecycleError(f"unsupported mutation action: {action}")
+    return digest(
+        {
+            "lifecycle_id": ledger["lifecycle_id"],
+            "action": action,
+            "pr": ledger["pr"],
+            "ac_hash": ledger["ac_snapshot"]["content_hash"],
+            "evidence_ids": [item["id"] for item in ledger["evidence"]],
+            "remaining_scope": ledger["remaining_scope"],
+        }
+    )
+
+
+def mutation_status(payload: Mapping[str, Any], operation_id: str) -> str | None:
+    ledger = validate_lifecycle(payload)
+    events = [event for event in ledger["mutation_receipts"] if event["operation_id"] == operation_id]
+    return events[-1]["status"] if events else None
+
+
+def append_mutation_event(
+    payload: Mapping[str, Any],
+    *,
+    operation_id: str,
+    action: str,
+    status: str,
+    authorized_by: str,
+    requested_at: str,
+    completed_at: str | None,
+    remote_mutation_performed: bool,
+    detail: str,
+) -> tuple[dict[str, Any], dict[str, Any], bool]:
+    ledger = validate_lifecycle(payload)
+    event_material = {
+        "operation_id": operation_id,
+        "action": action,
+        "status": status,
+        "authorized_by": _clean_text(authorized_by, "mutation authorizer", maximum=200),
+        "requested_at": requested_at,
+        "completed_at": completed_at,
+        "remote_mutation_performed": remote_mutation_performed,
+        "detail": " ".join(detail.split()),
+    }
+    event = {"id": digest(event_material), **event_material}
+    for existing in ledger["mutation_receipts"]:
+        if existing["id"] == event["id"]:
+            return ledger, existing, True
+    ledger["mutation_receipts"].append(event)
+    ledger["updated_at"] = completed_at or requested_at
+    return validate_lifecycle(ledger), event, False
+
+
+def migrate_legacy(
+    payload: Mapping[str, Any],
+    *,
+    identity: Mapping[str, Any],
+    policy: Mapping[str, Mapping[str, Any]],
+    issue_body: str,
+    required_checks: list[str],
+    author_family: str,
+    now: str,
+) -> dict[str, Any]:
+    """Migrate an older unversioned ledger without rewriting proof history."""
+    if payload.get("schema_version") == SCHEMA_VERSION:
+        return validate_lifecycle(payload)
+    snapshot = build_ac_snapshot(issue_body, policy, finalized_at=now)
+    migrated = build_lifecycle(
+        identity,
+        author_family=author_family,
+        ac_snapshot=snapshot,
+        required_checks=required_checks,
+        now=now,
+        pr_number=payload.get("pr_number"),
+        migration_source=str(payload.get("schema_version") or "unversioned"),
+        legacy=True,
+    )
+    for key in ("evidence", "observation_receipts", "mutation_receipts"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            migrated[key] = deepcopy(value)
+    migrated["updated_at"] = now
+    return validate_lifecycle(migrated)

--- a/tests/orchestration/test_task_closeout.py
+++ b/tests/orchestration/test_task_closeout.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration import task_closeout, task_identity, task_lifecycle
+
+NOW = "2026-07-16T10:00:00Z"
+HEAD = "a" * 40
+MERGE = "b" * 40
+REVIEW_URL = "https://github.com/org/repo/pull/77#issuecomment-1"
+
+
+def _body(*, checked: bool = False) -> str:
+    mark = "x" if checked else " "
+    return "\n".join(
+        [
+            f"- [{mark}] **AC-IMPL** — Implementation is verified.",
+            f"- [{mark}] **AC-REVIEW** — Independent review passes.",
+            f"- [{mark}] **AC-MERGE** — The pull request merges.",
+            f"- [{mark}] **AC-CLOSE** — The issue is actually closed.",
+            f"- [{mark}] **AC-CLEAN** — Branch and worktree are cleaned.",
+            "",
+        ]
+    )
+
+
+def _ledger(tmp_path: Path, *, review: bool = True, merged: bool = False) -> tuple[Path, dict]:
+    identity = task_identity.build_identity(
+        repository="org/repo",
+        stream_epic=10,
+        stream_epic_url=None,
+        github_issue_number=42,
+        github_issue_url=None,
+        semantic_title="Enforce task closeout",
+        task_family="infrastructure",
+        role="implementer",
+        predecessor_task_id="thread-old",
+        replacement_task_id="thread-new",
+        lineage_id="lineage-closeout",
+        generation=2,
+        terminal_goal="merge",
+        lifecycle_state="confirmed",
+    )
+    policy = {
+        "AC-IMPL": {"due_state": "IMPLEMENTATION_READY", "required_evidence": ["test"]},
+        "AC-REVIEW": {"due_state": "REVIEW_PASSED", "required_evidence": ["review"]},
+        "AC-MERGE": {"due_state": "MERGED", "required_evidence": ["github"]},
+        "AC-CLOSE": {"due_state": "ISSUE_CLOSED", "required_evidence": ["github"]},
+        "AC-CLEAN": {"due_state": "CLEANED_UP", "required_evidence": ["cleanup"]},
+    }
+    ledger = task_lifecycle.build_lifecycle(
+        identity,
+        author_family="codex",
+        ac_snapshot=task_lifecycle.build_ac_snapshot(_body(), policy, finalized_at=NOW),
+        required_checks=["CI Gate"],
+        now=NOW,
+        pr_number=77,
+    )
+    ledger, _ = task_lifecycle.add_evidence(
+        ledger,
+        ac_id="AC-IMPL",
+        evidence_type="test",
+        summary="focused tests pass",
+        url=None,
+        commit=HEAD,
+        details={},
+        recorded_at=NOW,
+    )
+    if review:
+        ledger, _ = task_lifecycle.add_evidence(
+            ledger,
+            ac_id="AC-REVIEW",
+            evidence_type="review",
+            summary="outside-family review passes",
+            url=REVIEW_URL,
+            commit=HEAD,
+            details={
+                "author_family": "codex",
+                "reviewer_family": "gemini",
+                "verdict": "pass",
+            },
+            recorded_at=NOW,
+        )
+    if merged:
+        ledger, _ = task_lifecycle.add_evidence(
+            ledger,
+            ac_id="AC-MERGE",
+            evidence_type="github",
+            summary="PR merged",
+            url="https://github.com/org/repo/pull/77",
+            commit=HEAD,
+            details={},
+            recorded_at=NOW,
+        )
+    path = tmp_path / "lifecycle.json"
+    task_lifecycle.write_lifecycle(path, ledger)
+    return path, ledger
+
+
+def _observation(
+    *,
+    body: str | None = None,
+    issue_state: str = "OPEN",
+    pr_state: str = "OPEN",
+    pr_body: str = "Refs #42",
+) -> dict:
+    return {
+        "schema_version": task_lifecycle.OBSERVATION_SCHEMA_VERSION,
+        "observed_at": NOW,
+        "github": {
+            "repository": "org/repo",
+            "registered_stream_epics": [10],
+            "issue": {
+                "number": 42,
+                "state": issue_state,
+                "body": body if body is not None else _body(),
+                "url": "https://github.com/org/repo/issues/42",
+                "closed_at": NOW if issue_state == "CLOSED" else None,
+                "parent_epic": 10,
+            },
+            "pr": {
+                "number": 77,
+                "url": "https://github.com/org/repo/pull/77",
+                "state": pr_state,
+                "is_draft": False,
+                "head_sha": HEAD,
+                "head_branch": "codex/42-closeout",
+                "merge_sha": MERGE if pr_state == "MERGED" else None,
+                "merged_at": NOW if pr_state == "MERGED" else None,
+                "auto_merge_enabled_at": None,
+                "review_decision": "APPROVED",
+                "requested_changes": False,
+                "reviews": [],
+                "checks": [
+                    {"name": "CI Gate", "status": "COMPLETED", "conclusion": "SUCCESS"}
+                ],
+                "body": pr_body,
+            },
+            "comments": [{"url": REVIEW_URL, "body": "PASS", "created_at": NOW}],
+            "deployments": [],
+            "follow_up": None,
+        },
+        "local": {
+            "primary_checkout": "/repo",
+            "primary_clean": True,
+            "dispatch_worktree_used": True,
+            "worktree": "/repo/.worktrees/dispatch/codex/42-closeout",
+            "worktree_present": True,
+            "actual_worktree_branch": "codex/42-closeout",
+            "worktree_branch_matches": True,
+            "branch": "codex/42-closeout",
+            "local_branch_present": True,
+            "remote_branch_present": True,
+            "commits": [{"sha": HEAD, "x_agent_trailers": ["X-Agent: codex/42-closeout"]}],
+            "changed_paths": ["scripts/example.py"],
+            "forbidden_paths": [],
+        },
+    }
+
+
+class FakeAdapter:
+    def __init__(self, observation: dict) -> None:
+        self.observation = deepcopy(observation)
+        self.calls: list[str] = []
+
+    def observe(self, _ledger: dict, **_kwargs: object) -> dict:
+        return deepcopy(self.observation)
+
+    def update_issue_body(self, _repository: str, _issue_number: int, body: str) -> None:
+        self.calls.append("sync-acs")
+        self.observation["github"]["issue"]["body"] = body
+
+    def arm_auto_merge(self, _repository: str, _pr_number: int) -> None:
+        self.calls.append("arm-auto-merge")
+        self.observation["github"]["pr"]["auto_merge_enabled_at"] = NOW
+
+    def close_issue(self, _repository: str, _issue_number: int) -> None:
+        self.calls.append("close-issue")
+        self.observation["github"]["issue"]["state"] = "CLOSED"
+        self.observation["github"]["issue"]["closed_at"] = NOW
+
+
+def test_sync_acs_checks_only_evidenced_criteria_and_replays(tmp_path: Path) -> None:
+    path, _ = _ledger(tmp_path)
+    adapter = FakeAdapter(_observation())
+
+    first = task_closeout.perform_mutation(
+        path,
+        adapter,
+        action="sync-acs",
+        authorized_by="codex/5297",
+        branch="codex/42-closeout",
+        worktree="/repo/.worktrees/dispatch/codex/42-closeout",
+        now=NOW,
+    )
+    second = task_closeout.perform_mutation(
+        path,
+        adapter,
+        action="sync-acs",
+        authorized_by="codex/5297",
+        branch="codex/42-closeout",
+        worktree="/repo/.worktrees/dispatch/codex/42-closeout",
+        now=NOW,
+    )
+
+    body = adapter.observation["github"]["issue"]["body"]
+    assert adapter.calls == ["sync-acs"]
+    assert "- [x] **AC-IMPL**" in body
+    assert "- [x] **AC-REVIEW**" in body
+    assert "- [ ] **AC-MERGE**" in body
+    assert first["remote_mutation_performed"] is True
+    assert second["replayed"] is True
+    assert second["remote_mutation_performed"] is False
+
+
+def test_intent_recovery_does_not_repeat_remote_close(tmp_path: Path) -> None:
+    path, ledger = _ledger(tmp_path, merged=True)
+    operation_id = task_lifecycle.mutation_operation_id(ledger, "close-issue")
+    ledger, _, _ = task_lifecycle.append_mutation_event(
+        ledger,
+        operation_id=operation_id,
+        action="close-issue",
+        status="intent",
+        authorized_by="codex/5297",
+        requested_at=NOW,
+        completed_at=None,
+        remote_mutation_performed=False,
+        detail="intent persisted before simulated crash",
+    )
+    task_lifecycle.write_lifecycle(path, ledger)
+    adapter = FakeAdapter(
+        _observation(body=_body(checked=True), issue_state="CLOSED", pr_state="MERGED")
+    )
+
+    result = task_closeout.perform_mutation(
+        path,
+        adapter,
+        action="close-issue",
+        authorized_by="codex/5297",
+        branch="codex/42-closeout",
+        worktree="/repo/.worktrees/dispatch/codex/42-closeout",
+        now=NOW,
+    )
+
+    assert adapter.calls == []
+    assert result["replayed"] is True
+    assert result["remote_mutation_performed"] is False
+    assert task_lifecycle.mutation_status(
+        task_lifecycle.load_lifecycle(path), operation_id
+    ) == "complete"
+
+
+def test_verified_merge_permits_one_explicit_close(tmp_path: Path) -> None:
+    path, _ = _ledger(tmp_path, merged=True)
+    adapter = FakeAdapter(_observation(body=_body(checked=True), pr_state="MERGED"))
+
+    result = task_closeout.perform_mutation(
+        path,
+        adapter,
+        action="close-issue",
+        authorized_by="codex/5297",
+        branch="codex/42-closeout",
+        worktree="/repo/.worktrees/dispatch/codex/42-closeout",
+        now=NOW,
+    )
+
+    assert adapter.calls == ["close-issue"]
+    assert result["remote_mutation_performed"] is True
+    assert adapter.observation["github"]["issue"]["state"] == "CLOSED"
+
+
+def test_auto_merge_is_blocked_until_current_head_review(tmp_path: Path) -> None:
+    path, _ = _ledger(tmp_path, review=False)
+    adapter = FakeAdapter(_observation())
+
+    with pytest.raises(task_lifecycle.LifecycleError, match="outside-family review"):
+        task_closeout.perform_mutation(
+            path,
+            adapter,
+            action="arm-auto-merge",
+            authorized_by="codex/5297",
+            branch="codex/42-closeout",
+            worktree="/repo/.worktrees/dispatch/codex/42-closeout",
+            now=NOW,
+        )
+
+    assert adapter.calls == []
+    ledger = task_lifecycle.load_lifecycle(path)
+    assert ledger["current_state"] == "BLOCKED_WITH_RECEIPT"
+    assert ledger["mutation_receipts"][-1]["status"] == "failed"
+    assert "outside-family review" in ledger["mutation_receipts"][-1]["detail"]
+
+
+def test_missing_authorization_is_durable_and_nonmutating(tmp_path: Path) -> None:
+    path, _ = _ledger(tmp_path)
+
+    result = task_closeout.record_unauthorized_mutation(
+        path,
+        action="arm-auto-merge",
+        actor="codex/5297",
+        now=NOW,
+    )
+    ledger = task_lifecycle.load_lifecycle(path)
+
+    assert result["state"] == "BLOCKED_WITH_RECEIPT"
+    assert result["remote_mutation_performed"] is False
+    assert ledger["current_state"] == "BLOCKED_WITH_RECEIPT"
+    assert "--authorize" in ledger["mutation_receipts"][-1]["detail"]
+
+
+def test_github_adapter_normalizes_parent_pr_checks_and_deployments(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(args: list[str], _stdin: str | None) -> str:
+        calls.append(args)
+        command = " ".join(args)
+        if "issue view" in command:
+            return json.dumps(
+                {
+                    "number": 42,
+                    "state": "OPEN",
+                    "body": _body(),
+                    "url": "https://github.com/org/repo/issues/42",
+                    "closedAt": None,
+                }
+            )
+        if "api graphql" in command:
+            return json.dumps(
+                {"data": {"repository": {"issue": {"parent": {"number": 10}}}}}
+            )
+        if "pr view" in command:
+            return json.dumps(
+                {
+                    "number": 77,
+                    "url": "https://github.com/org/repo/pull/77",
+                    "state": "MERGED",
+                    "isDraft": False,
+                    "headRefOid": HEAD,
+                    "headRefName": "codex/42-closeout",
+                    "mergeCommit": {"oid": MERGE},
+                    "mergedAt": NOW,
+                    "autoMergeRequest": {"enabledAt": NOW},
+                    "reviewDecision": "APPROVED",
+                    "reviews": [],
+                    "statusCheckRollup": [
+                        {
+                            "__typename": "CheckRun",
+                            "name": "CI Gate",
+                            "status": "COMPLETED",
+                            "conclusion": "SUCCESS",
+                        }
+                    ],
+                    "body": "Refs #42",
+                }
+            )
+        if "issues/77/comments" in command:
+            return "[]"
+        if "pulls/77/reviews" in command:
+            return json.dumps(
+                [
+                    {
+                        "html_url": REVIEW_URL.replace("issuecomment-1", "pullrequestreview-5"),
+                        "body": "PASS",
+                        "user": {"login": "reviewer"},
+                        "submitted_at": NOW,
+                        "state": "APPROVED",
+                        "commit_id": HEAD,
+                    }
+                ]
+            )
+        if command.endswith("deployments -f sha=" + MERGE):
+            return json.dumps([{"id": 9, "environment": "production", "sha": MERGE}])
+        if "deployments/9/statuses" in command:
+            return json.dumps([{"state": "success", "environment_url": "https://prod"}])
+        raise AssertionError(f"unexpected command: {args}")
+
+    adapter = task_closeout.GhGitHubAdapter(tmp_path, runner=runner)
+    adapter.registered_stream_epics = lambda: [10]
+    _, ledger = _ledger(tmp_path)
+    ledger["terminal_goal"] = "deploy"
+    ledger["identity"]["terminal_goal"] = "deploy"
+    github = adapter._github_observation(task_lifecycle.validate_lifecycle(ledger))
+
+    assert github["issue"]["parent_epic"] == 10
+    assert github["pr"]["checks"][0]["conclusion"] == "SUCCESS"
+    assert github["comments"][0]["kind"] == "pull_request_review"
+    assert github["deployments"] == [
+        {
+            "id": 9,
+            "environment": "production",
+            "sha": MERGE,
+            "state": "SUCCESS",
+            "url": "https://prod",
+        }
+    ]
+    deployment_call = next(
+        args
+        for args in calls
+        if any(value.endswith("/deployments") for value in args) and "-f" in args
+    )
+    assert deployment_call[deployment_call.index("--method") + 1] == "GET"
+
+
+def test_github_read_failure_becomes_a_blocked_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path, ledger = _ledger(tmp_path)
+    adapter = task_closeout.GhGitHubAdapter(tmp_path)
+
+    def fail(_ledger: dict) -> dict:
+        raise task_lifecycle.LifecycleError("offline")
+
+    monkeypatch.setattr(adapter, "_github_observation", fail)
+    monkeypatch.setattr(task_lifecycle, "observe_local_git", lambda *_args, **_kwargs: {})
+    observation = adapter.observe(ledger, now=NOW)
+    updated, receipt, _ = task_lifecycle.reconcile(
+        task_lifecycle.load_lifecycle(path), observation, now=NOW
+    )
+
+    assert receipt["state"] == "BLOCKED_WITH_RECEIPT"
+    assert "GitHub observation failed" in " ".join(receipt["hard_blockers"])
+    assert updated["current_state"] == "BLOCKED_WITH_RECEIPT"

--- a/tests/orchestration/test_task_lifecycle.py
+++ b/tests/orchestration/test_task_lifecycle.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration import task_identity, task_lifecycle
+
+NOW = "2026-07-16T10:00:00Z"
+HEAD = "a" * 40
+MERGE = "b" * 40
+REVIEW_URL = "https://github.com/org/repo/pull/77#issuecomment-1"
+
+
+def _body(*, checked: bool = False, include_deploy: bool = False, include_certify: bool = False) -> str:
+    mark = "x" if checked else " "
+    lines = [
+        f"- [{mark}] **AC-IMPL** — Implementation is verified.",
+        f"- [{mark}] **AC-REVIEW** — Independent review passes.",
+        f"- [{mark}] **AC-MERGE** — The pull request merges.",
+    ]
+    if include_deploy:
+        lines.append(f"- [{mark}] **AC-DEPLOY** — The merged change deploys.")
+    if include_certify:
+        lines.append(f"- [{mark}] **AC-CERT** — The deployed change is certified.")
+    lines.extend(
+        [
+            f"- [{mark}] **AC-CLOSE** — The issue is actually closed.",
+            f"- [{mark}] **AC-CLEAN** — The task branch and worktree are cleaned.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _policy(
+    *,
+    include_deploy: bool = False,
+    include_certify: bool = False,
+    behavior_proof: bool = False,
+) -> dict:
+    policy = {
+        "AC-IMPL": {"due_state": "IMPLEMENTATION_READY", "required_evidence": ["test"]},
+        "AC-REVIEW": {"due_state": "REVIEW_PASSED", "required_evidence": ["review"]},
+        "AC-MERGE": {"due_state": "MERGED", "required_evidence": ["github"]},
+        "AC-CLOSE": {"due_state": "ISSUE_CLOSED", "required_evidence": ["github"]},
+        "AC-CLEAN": {"due_state": "CLEANED_UP", "required_evidence": ["cleanup"]},
+    }
+    if include_deploy:
+        policy["AC-DEPLOY"] = {"due_state": "DEPLOYED", "required_evidence": ["deployment"]}
+    if include_certify:
+        policy["AC-CERT"] = {"due_state": "CERTIFIED", "required_evidence": ["certification"]}
+    if behavior_proof:
+        policy["AC-IMPL"]["required_evidence"].append("behavior_proof")
+        policy["AC-IMPL"]["behavior_proof_required"] = True
+    return policy
+
+
+def _identity(goal: str = "merge") -> dict:
+    return task_identity.build_identity(
+        repository="org/repo",
+        stream_epic=10,
+        stream_epic_url=None,
+        github_issue_number=42,
+        github_issue_url=None,
+        semantic_title="Enforce task closeout",
+        task_family="infrastructure",
+        role="implementer",
+        predecessor_task_id="thread-old",
+        replacement_task_id="thread-new",
+        lineage_id="lineage-closeout",
+        generation=2,
+        terminal_goal=goal,
+        lifecycle_state="confirmed",
+    )
+
+
+def _ledger(goal: str = "merge", *, behavior_proof: bool = False) -> dict:
+    deploy = goal in {"deploy", "certify"}
+    certify = goal == "certify"
+    snapshot = task_lifecycle.build_ac_snapshot(
+        _body(include_deploy=deploy, include_certify=certify),
+        _policy(
+            include_deploy=deploy,
+            include_certify=certify,
+            behavior_proof=behavior_proof,
+        ),
+        finalized_at=NOW,
+    )
+    return task_lifecycle.build_lifecycle(
+        _identity(goal),
+        author_family="codex",
+        ac_snapshot=snapshot,
+        required_checks=["CI Gate"],
+        now=NOW,
+        pr_number=77,
+    )
+
+
+def _add(
+    ledger: dict,
+    ac_id: str,
+    kind: str,
+    *,
+    url: str | None = None,
+    details: dict | None = None,
+) -> dict:
+    updated, _ = task_lifecycle.add_evidence(
+        ledger,
+        ac_id=ac_id,
+        evidence_type=kind,
+        summary=f"verified {ac_id}",
+        url=url,
+        commit=None if kind in {"cleanup", "follow_up"} else HEAD,
+        details=details,
+        recorded_at=NOW,
+    )
+    return updated
+
+
+def _ready_evidence(ledger: dict) -> dict:
+    ledger = _add(ledger, "AC-IMPL", "test")
+    return _add(
+        ledger,
+        "AC-REVIEW",
+        "review",
+        url=REVIEW_URL,
+        details={"author_family": "codex", "reviewer_family": "gemini", "verdict": "pass"},
+    )
+
+
+def _behavior_receipt_reference(tmp_path: Path) -> dict:
+    input_sha256 = "c" * 64
+    receipt = {
+        "schema_version": "code-review-receipt.v1",
+        "author": {"family": "openai"},
+        "reviewer": {"family": "deepseek"},
+        "target": {"head_sha": HEAD, "input_sha256": input_sha256},
+        "behavior_proof": {
+            "schema_version": "behavior-proof.v1",
+            "source_aware": {
+                "status": "pass",
+                "clauses": [{"target_input_sha256": input_sha256}],
+            },
+            "source_blind": {
+                "status": "pass",
+                "blind_enforced": False,
+                "clauses": [{"target_input_sha256": input_sha256}],
+            },
+        },
+        "final_disposition": "clean",
+        "exit_code": 0,
+    }
+    path = (tmp_path / "behavior-proof-receipt.json").resolve()
+    receipt_bytes = (
+        json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    ).encode()
+    path.write_bytes(receipt_bytes)
+    return {
+        "behavior_proof_receipt": {
+            "receipt_path": str(path),
+            "receipt_sha256": "sha256:" + hashlib.sha256(receipt_bytes).hexdigest(),
+            "input_sha256": input_sha256,
+            "target_sha": HEAD,
+        }
+    }
+
+
+def _observation(
+    body: str,
+    *,
+    issue_state: str = "OPEN",
+    pr_state: str = "OPEN",
+    requested_changes: bool = False,
+    checks: str = "SUCCESS",
+    deployed: bool = False,
+    clean: bool = False,
+) -> dict:
+    return {
+        "schema_version": task_lifecycle.OBSERVATION_SCHEMA_VERSION,
+        "observed_at": NOW,
+        "github": {
+            "repository": "org/repo",
+            "registered_stream_epics": [10],
+            "issue": {
+                "number": 42,
+                "state": issue_state,
+                "body": body,
+                "url": "https://github.com/org/repo/issues/42",
+                "closed_at": NOW if issue_state == "CLOSED" else None,
+                "parent_epic": 10,
+            },
+            "pr": {
+                "number": 77,
+                "url": "https://github.com/org/repo/pull/77",
+                "state": pr_state,
+                "is_draft": False,
+                "head_sha": HEAD,
+                "head_branch": "codex/42-closeout",
+                "merge_sha": MERGE if pr_state == "MERGED" else None,
+                "merged_at": NOW if pr_state == "MERGED" else None,
+                "auto_merge_enabled_at": NOW,
+                "review_decision": "CHANGES_REQUESTED" if requested_changes else "APPROVED",
+                "requested_changes": requested_changes,
+                "reviews": [],
+                "checks": [
+                    {
+                        "name": "CI Gate",
+                        "status": "COMPLETED" if checks != "PENDING" else "IN_PROGRESS",
+                        "conclusion": checks if checks != "PENDING" else "",
+                    }
+                ],
+                "body": "Refs #42",
+            },
+            "comments": [{"url": REVIEW_URL, "body": "PASS", "created_at": NOW}],
+            "deployments": [
+                {"environment": "production", "state": "SUCCESS", "sha": MERGE}
+            ]
+            if deployed
+            else [],
+            "follow_up": None,
+        },
+        "local": {
+            "primary_checkout": "/repo",
+            "primary_clean": True,
+            "dispatch_worktree_used": True,
+            "worktree": "/repo/.worktrees/dispatch/codex/42-closeout",
+            "worktree_present": not clean,
+            "actual_worktree_branch": "codex/42-closeout" if not clean else None,
+            "worktree_branch_matches": not clean,
+            "branch": "codex/42-closeout",
+            "local_branch_present": not clean,
+            "remote_branch_present": not clean,
+            "commits": [{"sha": HEAD, "x_agent_trailers": ["X-Agent: codex/42-closeout"]}],
+            "changed_paths": ["scripts/example.py"],
+            "forbidden_paths": [],
+        },
+    }
+
+
+def test_snapshot_uses_stable_ids_and_rejects_text_drift() -> None:
+    ledger = _ready_evidence(_ledger())
+    observation = _observation(_body().replace("The pull request merges.", "The PR maybe merges."))
+
+    result = task_lifecycle.evaluate(ledger, observation)
+
+    assert result["state"] == "BLOCKED_WITH_RECEIPT"
+    assert any("drift" in blocker for blocker in result["hard_blockers"])
+    assert ledger["ac_snapshot"]["content_hash"].startswith("sha256:")
+
+
+def test_open_pr_reaches_ci_passed_but_is_not_terminal() -> None:
+    ledger = _ready_evidence(_ledger())
+
+    result = task_lifecycle.evaluate(ledger, _observation(_body()))
+
+    assert result["state"] == "CI_PASSED"
+    assert result["disposition"] == "waiting"
+    assert result["goal_reached"] is False
+
+
+def test_merged_pr_with_open_issue_is_nonterminal() -> None:
+    ledger = _add(_ready_evidence(_ledger()), "AC-MERGE", "github")
+
+    result = task_lifecycle.evaluate(
+        ledger,
+        _observation(_body(checked=True), pr_state="MERGED"),
+    )
+
+    assert result["state"] == "MERGED"
+    assert result["disposition"] == "waiting"
+    assert "actually closed issue" in " ".join(result["waiting"])
+
+
+def test_auto_close_keyword_is_not_treated_as_issue_closeout() -> None:
+    ledger = _add(_ready_evidence(_ledger()), "AC-MERGE", "github")
+    observation = _observation(_body(checked=True), pr_state="MERGED")
+    observation["github"]["pr"]["body"] = "Fixes #42"
+
+    result = task_lifecycle.evaluate(ledger, observation)
+
+    assert result["state"] == "MERGED"
+    assert result["goal_reached"] is True
+    assert "actually closed issue" in " ".join(result["waiting"])
+
+
+def test_closed_issue_with_unverified_postclose_acs_is_rejected() -> None:
+    ledger = _add(_ready_evidence(_ledger()), "AC-MERGE", "github")
+
+    result = task_lifecycle.evaluate(
+        ledger,
+        _observation(_body(checked=True), issue_state="CLOSED", pr_state="MERGED"),
+    )
+
+    assert result["state"] == "BLOCKED_WITH_RECEIPT"
+    assert any("AC-CLOSE" in blocker for blocker in result["hard_blockers"])
+
+
+def test_all_evidence_issue_close_and_cleanup_are_terminal() -> None:
+    ledger = _add(_ready_evidence(_ledger()), "AC-MERGE", "github")
+    ledger = _add(ledger, "AC-CLOSE", "github")
+    ledger = _add(ledger, "AC-CLEAN", "cleanup")
+    ledger, _, _ = task_lifecycle.reconcile(
+        ledger,
+        _observation(_body(checked=True), pr_state="MERGED"),
+        now=NOW,
+    )
+
+    result = task_lifecycle.evaluate(
+        ledger,
+        _observation(
+            _body(checked=True), issue_state="CLOSED", pr_state="MERGED", clean=True
+        ),
+    )
+
+    assert result["state"] == "CLEANED_UP"
+    assert result["disposition"] == "complete"
+
+
+def test_first_postmerge_reconcile_requires_retained_git_proof() -> None:
+    ledger = _add(_ready_evidence(_ledger()), "AC-MERGE", "github")
+    observation = _observation(_body(checked=True), pr_state="MERGED")
+    observation["local"].update(
+        {
+            "dispatch_worktree_used": False,
+            "worktree_present": False,
+            "actual_worktree_branch": None,
+            "worktree_branch_matches": False,
+            "commits": [],
+        }
+    )
+
+    result = task_lifecycle.evaluate(ledger, observation)
+
+    assert result["state"] == "BLOCKED_WITH_RECEIPT"
+    assert "dispatch worktree" in " ".join(result["hard_blockers"])
+
+
+@pytest.mark.parametrize(
+    ("goal", "deployment", "certification", "expected"),
+    [
+        ("deploy", False, False, "MERGED"),
+        ("certify", True, False, "DEPLOYED"),
+    ],
+)
+def test_terminal_goals_cannot_degrade(
+    goal: str, deployment: bool, certification: bool, expected: str
+) -> None:
+    ledger = _ready_evidence(_ledger(goal))
+    ledger = _add(ledger, "AC-MERGE", "github")
+    if deployment:
+        ledger = _add(ledger, "AC-DEPLOY", "deployment")
+    if certification:
+        ledger = _add(ledger, "AC-CERT", "certification")
+
+    result = task_lifecycle.evaluate(
+        ledger,
+        _observation(
+            _body(include_deploy=True, include_certify=goal == "certify"),
+            pr_state="MERGED",
+            deployed=deployment,
+        ),
+    )
+
+    assert result["last_success_state"] == expected
+    assert result["goal_reached"] is False
+
+
+def test_certify_goal_reaches_certified_only_with_typed_evidence() -> None:
+    ledger = _ready_evidence(_ledger("certify"))
+    for ac_id, kind in (
+        ("AC-MERGE", "github"),
+        ("AC-DEPLOY", "deployment"),
+        ("AC-CERT", "certification"),
+    ):
+        ledger = _add(ledger, ac_id, kind)
+
+    result = task_lifecycle.evaluate(
+        ledger,
+        _observation(
+            _body(include_deploy=True, include_certify=True),
+            pr_state="MERGED",
+            deployed=True,
+        ),
+    )
+
+    assert result["last_success_state"] == "CERTIFIED"
+    assert result["goal_reached"] is True
+
+
+def test_wrong_identity_requested_changes_and_git_hygiene_fail_closed() -> None:
+    ledger = _ready_evidence(_ledger())
+    observation = _observation(_body(), requested_changes=True)
+    observation["github"]["repository"] = "org/wrong"
+    observation["local"]["commits"][0]["x_agent_trailers"] = []
+    observation["local"]["forbidden_paths"] = [".python-version"]
+
+    result = task_lifecycle.evaluate(ledger, observation)
+
+    blockers = "\n".join(result["hard_blockers"])
+    assert result["state"] == "BLOCKED_WITH_RECEIPT"
+    assert "repository" in blockers
+    assert "requested changes" in blockers
+    assert "X-Agent" in blockers
+    assert ".python-version" in blockers
+
+
+def test_spoofed_dispatch_worktree_metadata_fails_closed() -> None:
+    ledger = _ready_evidence(_ledger())
+    observation = _observation(_body())
+    observation["local"].update(
+        {
+            "worktree_present": False,
+            "actual_worktree_branch": "codex/wrong",
+            "worktree_branch_matches": False,
+        }
+    )
+
+    result = task_lifecycle.evaluate(ledger, observation)
+
+    blockers = " ".join(result["hard_blockers"])
+    assert "absent from git worktree list" in blockers
+    assert "did not match Git authority" in blockers
+
+
+def test_unregistered_stream_epic_fails_closed() -> None:
+    ledger = _ready_evidence(_ledger())
+    observation = _observation(_body())
+    observation["github"]["registered_stream_epics"] = [99]
+
+    result = task_lifecycle.evaluate(ledger, observation)
+
+    assert result["state"] == "BLOCKED_WITH_RECEIPT"
+    assert "registered issue-stream" in " ".join(result["hard_blockers"])
+
+
+def test_remaining_scope_requires_exact_reciprocal_follow_up() -> None:
+    ledger = _ready_evidence(_ledger())
+    ledger = _add(ledger, "AC-MERGE", "github")
+    ledger = _add(ledger, "AC-CLOSE", "follow_up")
+    evidence_id = ledger["evidence"][-1]["id"]
+    ledger = task_lifecycle.set_remaining_scope(
+        ledger,
+        status="transferred",
+        summary="Move documentation follow-up.",
+        follow_up_issue=99,
+        follow_up_stream_epic=10,
+        evidence_ids=[evidence_id],
+        now=NOW,
+    )
+    observation = _observation(_body(checked=True), pr_state="MERGED")
+    observation["github"]["follow_up"] = {
+        "number": 99,
+        "parent_epic": 11,
+        "reciprocal_links_verified": False,
+    }
+
+    result = task_lifecycle.evaluate(ledger, observation)
+
+    assert result["state"] == "BLOCKED_WITH_RECEIPT"
+    assert "follow-up" in " ".join(result["hard_blockers"])
+
+
+def test_identical_reconcile_is_idempotent() -> None:
+    ledger = _ready_evidence(_ledger())
+    observation = _observation(_body())
+
+    once, receipt, replayed = task_lifecycle.reconcile(ledger, observation, now=NOW)
+    twice, replay_receipt, replayed_again = task_lifecycle.reconcile(
+        once, {**observation, "observed_at": "2026-07-16T10:01:00Z"}, now=NOW
+    )
+
+    assert replayed is False
+    assert replayed_again is True
+    assert replay_receipt["id"] == receipt["id"]
+    assert len(twice["observation_receipts"]) == 1
+
+
+def test_evidence_for_other_commit_is_stale() -> None:
+    ledger = _ready_evidence(_ledger())
+    ledger["evidence"][0]["subject"]["commit"] = "c" * 40
+    ledger["evidence"][0]["id"] = task_lifecycle.digest(
+        task_lifecycle._evidence_payload(ledger["evidence"][0])
+    )
+    ledger = task_lifecycle.validate_lifecycle(ledger)
+
+    result = task_lifecycle.evaluate(ledger, _observation(_body()))
+
+    assert any("current PR head" in blocker for blocker in result["hard_blockers"])
+
+
+def test_user_visible_ac_requires_canonical_target_bound_behavior_receipt(
+    tmp_path: Path,
+) -> None:
+    ledger = _ready_evidence(_ledger(behavior_proof=True))
+
+    missing = task_lifecycle.evaluate(ledger, _observation(_body()))
+    ledger = _add(
+        ledger,
+        "AC-IMPL",
+        "behavior_proof",
+        details=_behavior_receipt_reference(tmp_path),
+    )
+    valid = task_lifecycle.evaluate(ledger, _observation(_body()))
+
+    assert any("behavior_proof" in blocker for blocker in missing["hard_blockers"])
+    assert "behavior_proof" in valid["valid_evidence"]["AC-IMPL"]
+    assert valid["state"] == "CI_PASSED"
+
+
+def test_changed_behavior_receipt_fails_digest_validation(tmp_path: Path) -> None:
+    reference = _behavior_receipt_reference(tmp_path)
+    ledger = _ready_evidence(_ledger(behavior_proof=True))
+    ledger = _add(ledger, "AC-IMPL", "behavior_proof", details=reference)
+    receipt_path = Path(reference["behavior_proof_receipt"]["receipt_path"])
+    receipt_path.write_text("{}\n", encoding="utf-8")
+
+    result = task_lifecycle.evaluate(ledger, _observation(_body()))
+
+    assert result["state"] == "BLOCKED_WITH_RECEIPT"
+    assert "digest" in " ".join(result["hard_blockers"])
+
+
+def test_carrier_preserves_identity_ac_snapshot_and_remaining_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        monkeypatch.delenv(name, raising=False)
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    ledger = _ledger()
+    path = task_lifecycle.lifecycle_path(tmp_path, ledger["identity"])
+    task_lifecycle.write_lifecycle(path, ledger)
+
+    carrier = task_lifecycle.carrier_projection(ledger, state_file=str(path))
+
+    assert carrier["identity"] == ledger["identity"]
+    assert carrier["ac_snapshot"] == ledger["ac_snapshot"]
+    assert carrier["remaining_scope"] == ledger["remaining_scope"]
+    assert path.name == "issue-42.json"
+
+
+def test_local_git_observation_cross_checks_exact_worktree_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        monkeypatch.delenv(name, raising=False)
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    (repo / ".gitignore").write_text(".worktrees/\n", encoding="utf-8")
+    (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "base"], check=True)
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / "42-closeout"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "worktree",
+            "add",
+            "-qb",
+            "codex/42-closeout",
+            str(worktree),
+        ],
+        check=True,
+    )
+
+    observed = task_lifecycle.observe_local_git(
+        repo,
+        head_sha=None,
+        branch="codex/42-closeout",
+        worktree=str(worktree),
+    )
+    wrong = task_lifecycle.observe_local_git(
+        repo,
+        head_sha=None,
+        branch="codex/wrong",
+        worktree=str(worktree),
+    )
+
+    assert observed["worktree_present"] is True
+    assert observed["dispatch_worktree_used"] is True
+    assert observed["actual_worktree_branch"] == "codex/42-closeout"
+    assert observed["worktree_branch_matches"] is True
+    assert wrong["worktree_branch_matches"] is False
+
+
+def test_legacy_migration_preserves_proof_lists() -> None:
+    ledger = _ready_evidence(_ledger())
+    legacy = {
+        "schema_version": "task-lifecycle.legacy",
+        "pr_number": 77,
+        "evidence": deepcopy(ledger["evidence"]),
+        "observation_receipts": [],
+        "mutation_receipts": [],
+    }
+
+    migrated = task_lifecycle.migrate_legacy(
+        legacy,
+        identity=_identity(),
+        policy=_policy(),
+        issue_body=_body(),
+        required_checks=["CI Gate"],
+        author_family="codex",
+        now=NOW,
+    )
+
+    assert migrated["migration"]["legacy"] is True
+    assert migrated["evidence"] == legacy["evidence"]
+
+
+def test_schema_round_trip_is_strict() -> None:
+    ledger = _ledger()
+    schema = json.loads(
+        Path("agents_extensions/shared/schemas/task-lifecycle.v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert schema["additionalProperties"] is False
+    assert task_lifecycle.validate_lifecycle(ledger) == ledger
+
+
+@pytest.mark.parametrize("state", task_lifecycle.STATES)
+def test_every_lifecycle_boundary_survives_durable_resume(
+    tmp_path: Path, state: str
+) -> None:
+    ledger = _ledger()
+    ledger["current_state"] = state
+    path = tmp_path / f"{state.lower()}.json"
+
+    task_lifecycle.write_lifecycle(path, ledger)
+    resumed = task_lifecycle.load_lifecycle(path)
+
+    assert resumed == task_lifecycle.validate_lifecycle(ledger)
+    assert task_lifecycle.carrier_projection(resumed)["current_state"] == state

--- a/tests/orchestration/test_task_lifecycle_carriers.py
+++ b/tests/orchestration/test_task_lifecycle_carriers.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import delegate
+
+from scripts.api import coordination_router
+from scripts.orchestration import agent_ledger, orchestrator_control, task_identity, task_lifecycle
+
+NOW = "2026-07-16T10:00:00Z"
+
+
+def _lifecycle_file(tmp_path: Path) -> Path:
+    identity = task_identity.build_identity(
+        repository="org/repo",
+        stream_epic=10,
+        stream_epic_url=None,
+        github_issue_number=42,
+        github_issue_url=None,
+        semantic_title="Enforce task closeout",
+        task_family="infrastructure",
+        role="implementer",
+        predecessor_task_id="thread-old",
+        replacement_task_id="thread-new",
+        lineage_id="lineage-closeout",
+        generation=1,
+        terminal_goal="merge",
+        lifecycle_state="confirmed",
+    )
+    body = "- [ ] **AC-IMPL** — Implementation is verified.\n"
+    policy = {
+        "AC-IMPL": {
+            "due_state": "IMPLEMENTATION_READY",
+            "required_evidence": ["test"],
+        }
+    }
+    ledger = task_lifecycle.build_lifecycle(
+        identity,
+        author_family="codex",
+        ac_snapshot=task_lifecycle.build_ac_snapshot(body, policy, finalized_at=NOW),
+        required_checks=["CI Gate"],
+        now=NOW,
+    )
+    path = tmp_path / "task-lifecycle.json"
+    task_lifecycle.write_lifecycle(path, ledger)
+    return path
+
+
+def test_delegate_loads_validated_carrier_and_prompt(tmp_path: Path) -> None:
+    path = _lifecycle_file(tmp_path)
+
+    carrier, prompt = delegate._load_task_lifecycle_carrier(str(path))
+
+    assert carrier is not None
+    assert carrier["state_file"] == str(path.resolve())
+    assert carrier["identity"]["github_issue_number"] == 42
+    assert "authoritative carrier" in prompt
+    assert carrier["lifecycle_id"] in prompt
+
+
+def test_agent_ledger_persists_carrier_and_monitor_returns_it(
+    tmp_path: Path, monkeypatch
+) -> None:
+    path = _lifecycle_file(tmp_path)
+    task = agent_ledger.upsert_task(
+        tmp_path,
+        task_id="closeout-worker",
+        agent="codex",
+        status="running",
+        lifecycle_file=path,
+    )
+    monkeypatch.setattr(coordination_router, "PROJECT_ROOT", tmp_path)
+
+    monitored = asyncio.run(coordination_router.coordination_task("closeout-worker"))
+
+    assert task["task_lifecycle"]["state_file"] == str(path.resolve())
+    assert monitored["task_lifecycle"] == task["task_lifecycle"]
+
+
+def test_orchestrator_forwards_and_retains_lifecycle_carrier(
+    tmp_path: Path, capsys
+) -> None:
+    path = _lifecycle_file(tmp_path)
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("Do the worker task.", encoding="utf-8")
+
+    rc = orchestrator_control.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "dispatch",
+            "--run-id",
+            "closeout-run",
+            "--task-id",
+            "closeout-worker",
+            "--agent",
+            "codex",
+            "--prompt-file",
+            str(prompt),
+            "--lifecycle-file",
+            str(path),
+            "--dry-run",
+        ]
+    )
+    command = json.loads(capsys.readouterr().out)["command"]
+
+    assert rc == 0
+    assert command[command.index("--lifecycle-file") + 1] == str(path.resolve())
+
+    orchestrator_control.record_task(
+        tmp_path,
+        "closeout-run",
+        task_id="closeout-worker",
+        agent="codex",
+        lifecycle_file=str(path),
+    )
+    inbox = orchestrator_control.collect_inbox(
+        tmp_path,
+        run_id="closeout-run",
+        recent=20,
+        include_results=False,
+        include_logs=False,
+        max_result_chars=100,
+        max_log_chars=100,
+    )
+
+    assert inbox["tasks"][0]["status"] == "missing"
+    assert inbox["tasks"][0]["task_lifecycle"]["current_state"] == "ISSUE_LINKED"


### PR DESCRIPTION
## Summary

- add the canonical `task-lifecycle.v1` schema, contract, deterministic transition/evidence engine, and crash-safe closeout CLI
- enforce authoritative GitHub identity/stream/PR/review/CI/terminal-goal state plus local Git worktree/trailer/artifact/cleanup gates
- carry the exact lifecycle projection through delegation, agent-ledger/Monitor state, and orchestrator run/inbox state
- consume #5302 canonical target-bound behavior-proof receipts for user-visible AC evidence without duplicating its implementation
- deploy provider-neutral rules, schema, contract, and task-family closeout guidance from `agents_extensions/shared/`

## Verification

- `242 passed` across lifecycle/closeout/carrier tests and affected dispatch, ledger, orchestrator, identity, rollover, and deployment-contract suites
- Ruff, Python compilation, Markdown lint, JSON parsing, and `git diff --check` passed
- `npm run agents:deploy` completed and `scripts/check_rules_deployment.sh` reports zero drift across all supported surfaces
- X-Agent trailer audit passed
- independent outside-family review: DeepSeek V4 Flash PASS, bridge message `#3132`, against all 12 frozen paths and #5302 commit `65eea20a8fb8f9378659eaa1c3cf8921a9d0e4c9`
- live source-blind CLI smoke initialized the real #5297 ledger after verifying native parent epic #4707 and all 22 stable ACs

## Scope boundaries

- no learner content, generated curriculum artifacts, telemetry, linter config, or `.python-version` changes
- no `thread_handoff.py`, rollover registry/API, orient API, or `thread-rollover` skill changes; those remain owned by #5296
- no #5302-owned review implementation changes

Refs #5297
