### PR TITLE
fix(qg): retry missing seminar fact sweeps

### DIFF
--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -60,6 +60,7 @@ INVALID_TOOL_THEATRE = "INVALID_TOOL_THEATRE"
 RETRY_EXHAUSTED = "RETRY_EXHAUSTED"
 UNGROUNDED_FINDINGS = "ungrounded_findings"
 DEEP_READ_REQUIRED = "deep_read_required"
+FACTUAL_SWEEP_REQUIRED = "factual_sweep_required"
 
 _TOKEN_DIVISOR = 3.5
 _TOKEN_RE = re.compile(r"[\w’'-]+", re.UNICODE)
@@ -106,6 +107,21 @@ _DEEP_READ_RETRY_REMINDER = """
 ## Reviewer Retry: Deep Read Required
 
 The prior response used wiki summary-mode evidence where summary-only evidence is inadmissible for any verdict. Re-run the relevant wiki query in section/extract mode before deciding the verdict, then return only the required JSON object.
+"""
+
+_FACTUAL_SWEEP_RETRY_REMINDER = """
+
+---
+
+## Reviewer Retry: Factual Sweep Required
+
+The prior seminar response omitted the mandatory top-level `fact_checks` sweep
+or returned it empty. Re-read the target module, call the sources MCP tools for
+the factual claims, and return one JSON object containing all three top-level
+arrays: `findings`, `fact_checks`, and `evidence_gaps`. Enumerate every factual
+claim. When the source protocol or tool budget cannot verify a claim, preserve
+it as `UNVERIFIED_INSUFFICIENT_SEARCH` with `budget_exhausted: true`; never
+silently omit it.
 """
 
 
@@ -1289,6 +1305,8 @@ def reviewer_retry_prompt(prompt: str, reason: str) -> str:
     """Append a deterministic retry reminder to the reviewer prompt."""
     if reason == DEEP_READ_REQUIRED:
         return f"{prompt}{_DEEP_READ_RETRY_REMINDER}"
+    if reason == FACTUAL_SWEEP_REQUIRED:
+        return f"{prompt}{_FACTUAL_SWEEP_RETRY_REMINDER}"
     return f"{prompt}{_THEATRE_RETRY_REMINDER}"
 
 

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -6,7 +6,8 @@ one canonical ``qg_schema`` evidence record per module. Live reviewer dispatch
 is intentionally absent until #4370 calibrates the prompt and canary runbook;
 callers must inject a reviewer response or reuse a composite cache hit. The
 live Tier-2 retry composition is capped at three reviewer calls per module:
-initial response, at most one theatre retry, and at most one deep-read retry.
+one initial response plus at most two one-time retries selected from theatre,
+deep-read, and a missing seminar factual sweep.
 """
 
 from __future__ import annotations

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -53,6 +53,7 @@ DEFAULT_REVIEWER_MODEL_ID = "llm-reviewer-disabled-until-4370"
 DEFAULT_REVIEWER_FAMILY = "qg_workflow"
 LLM_POLICY_FAMILIES = frozenset({"b1_plus", "seminar"})
 CONTENT_HASH_BASIS = "llm_qg_store.CONTENT_FILES"
+MAX_TIER2_REVIEWER_CALLS = 3
 
 Reviewer = Callable[["ReviewTarget", str], Any]
 
@@ -831,6 +832,7 @@ def _run_tier2(
                     policy_family=policy_family,
                     theatre_retry_available=True,
                     deep_read_retry_available=True,
+                    factual_sweep_retry_available=True,
                     retry_unavailable_fails=True,
                 )
             except ValueError:
@@ -984,6 +986,7 @@ def _run_tier2(
     attempt_prompt = prompt
     theatre_retried = False
     deep_read_retried = False
+    factual_sweep_retried = False
     payload: dict[str, Any]
     findings: list[dict[str, Any]]
     dispatch_meta: dict[str, Any]
@@ -1200,12 +1203,16 @@ def _run_tier2(
                 "reviewer_family": reviewer_family,
             }
 
+        retry_slot_available = len(capture_attempts) < MAX_TIER2_REVIEWER_CALLS and (
+            options.max_llm_calls is None or budget.llm_calls < options.max_llm_calls
+        )
         gate_outcome = _run_reviewer_gate_sequence(
             payload,
             dispatch_meta,
             policy_family=policy_family,
-            theatre_retry_available=not theatre_retried,
-            deep_read_retry_available=not deep_read_retried,
+            theatre_retry_available=not theatre_retried and retry_slot_available,
+            deep_read_retry_available=not deep_read_retried and retry_slot_available,
+            factual_sweep_retry_available=not factual_sweep_retried and retry_slot_available,
         )
         if gate_outcome.retry_reason == llm_reviewer_dispatch.INVALID_TOOL_THEATRE:
             theatre_retried = True
@@ -1219,6 +1226,13 @@ def _run_tier2(
             attempt_prompt = llm_reviewer_dispatch.reviewer_retry_prompt(
                 prompt,
                 llm_reviewer_dispatch.DEEP_READ_REQUIRED,
+            )
+            continue
+        if gate_outcome.retry_reason == llm_reviewer_dispatch.FACTUAL_SWEEP_REQUIRED:
+            factual_sweep_retried = True
+            attempt_prompt = llm_reviewer_dispatch.reviewer_retry_prompt(
+                attempt_prompt,
+                llm_reviewer_dispatch.FACTUAL_SWEEP_REQUIRED,
             )
             continue
         if gate_outcome.status == llm_reviewer_dispatch.RETRY_EXHAUSTED:
@@ -1272,6 +1286,7 @@ def _run_tier2(
         workflow_override=workflow_override,
         theatre_retried=theatre_retried,
         deep_read_retried=deep_read_retried,
+        factual_sweep_retried=factual_sweep_retried,
         grounding_gate=grounding_gate,
     )
     if options.persist_llm_qg:
@@ -1453,6 +1468,7 @@ def _capture_gate_outcomes(
     workflow_override: str | None,
     theatre_retried: bool,
     deep_read_retried: bool,
+    factual_sweep_retried: bool,
     grounding_gate: llm_reviewer_dispatch.GroundingGateResult,
 ) -> dict[str, Any]:
     """Build the strict replay-grade record of the gates that actually ran."""
@@ -1461,6 +1477,7 @@ def _capture_gate_outcomes(
         "workflow_override": workflow_override,
         "theatre_retried": theatre_retried,
         "deep_read_retried": deep_read_retried,
+        "factual_sweep_retried": factual_sweep_retried,
         "grounding": {
             "ungrounded_findings": grounding_gate.ungrounded_findings,
             "required_ungrounded_findings": grounding_gate.required_ungrounded_findings,
@@ -1525,6 +1542,7 @@ def _complete_cached_capture(
             workflow_override=cache_gate.workflow_override,
             theatre_retried=bool(gate.get("theatre_retried")),
             deep_read_retried=bool(gate.get("deep_read_retried")),
+            factual_sweep_retried=bool(gate.get("factual_sweep_retried")),
             grounding_gate=grounding_gate,
         ),
     }
@@ -1610,6 +1628,7 @@ def _run_reviewer_gate_sequence(
     policy_family: str,
     theatre_retry_available: bool,
     deep_read_retry_available: bool,
+    factual_sweep_retry_available: bool,
     retry_unavailable_fails: bool = False,
 ) -> _ReviewerGateOutcome:
     """Apply the canonical theatre/deep-read/grounding/factual-sweep gates."""
@@ -1656,6 +1675,17 @@ def _run_reviewer_gate_sequence(
         policy_family=policy_family,
         invalid_fact_checks=grounding_gate.invalid_fact_checks,
     )
+    fact_checks = working_payload.get("fact_checks")
+    sweep_missing = policy_family.strip().lower() == "seminar" and (
+        not isinstance(fact_checks, list) or not fact_checks
+    )
+    if sweep_missing and (factual_sweep_retry_available or retry_unavailable_fails):
+        return _ReviewerGateOutcome(
+            payload=working_payload,
+            findings=[],
+            retry_reason=llm_reviewer_dispatch.FACTUAL_SWEEP_REQUIRED,
+            grounding_gate=grounding_gate,
+        )
     if grounding_gate.inadmissible_positive_verdicts:
         working_payload["inadmissible_positive_verdicts"] = grounding_gate.inadmissible_positive_verdicts
     if (

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -820,20 +820,24 @@ def _run_tier2(
     if cached is not None:
         cached_payload = dict(cached.payload)
         cached_meta = dict(cached.dispatch_metadata or {})
+        cached_gate_outcomes = dict(cached.gate_outcomes or {})
         cached_meta.setdefault("tool_call_count", cached.tool_call_count)
         cached_meta.setdefault("tools_used", list(cached.tools_used))
         cached_meta.setdefault("route_name", cached.route_name)
         if cached.tool_events is not None:
             cached_meta.setdefault("tool_events", [dict(event) for event in cached.tool_events])
             try:
-                llm_reviewer.validate_reviewer_payload(cached_payload, policy_family)
+                cached_gate_payload = _cached_reviewer_payload_for_regate(cached, texts=texts)
+                llm_reviewer.validate_reviewer_payload(cached_gate_payload, policy_family)
                 cache_gate = _run_reviewer_gate_sequence(
-                    cached_payload,
+                    cached_gate_payload,
                     cached_meta,
                     policy_family=policy_family,
                     theatre_retry_available=True,
                     deep_read_retry_available=True,
-                    factual_sweep_retry_available=True,
+                    factual_sweep_retry_available=not bool(
+                        cached_gate_outcomes.get("factual_sweep_retried")
+                    ),
                     retry_unavailable_fails=True,
                 )
             except ValueError:
@@ -1549,6 +1553,34 @@ def _complete_cached_capture(
     }
 
 
+def _cached_reviewer_payload_for_regate(
+    cached: llm_qg_store.StoredQG,
+    *,
+    texts: Mapping[str, str],
+) -> dict[str, Any]:
+    """Recover the original reviewer payload before replaying deterministic gates."""
+    raw_response = cached.raw_response
+    raw_sha256 = cached.raw_response_sha256
+    if (
+        not isinstance(raw_response, str)
+        or not raw_response
+        or not isinstance(raw_sha256, str)
+        or raw_sha256 != llm_qg_store._sha256_bytes(raw_response.encode("utf-8"))
+    ):
+        return dict(cached.payload)
+    parsed_payload = llm_reviewer.parse_and_evaluate_llm_response(
+        raw_response,
+        module_md=texts.get("module.md", ""),
+        activities_yaml=texts.get("activities.yaml", ""),
+        vocabulary_yaml=texts.get("vocabulary.yaml", ""),
+        resources_yaml=texts.get("resources.yaml", ""),
+        return_payload=True,
+    )
+    if not isinstance(parsed_payload, Mapping):
+        raise ValueError("cached reviewer payload must be a mapping")
+    return _payload_from_reviewer_payload(parsed_payload)
+
+
 def _observed_cost(dispatch_meta: Mapping[str, Any]) -> float | None:
     value = dispatch_meta.get("observed_cost_usd")
     if value is None:
@@ -1680,7 +1712,7 @@ def _run_reviewer_gate_sequence(
     sweep_missing = policy_family.strip().lower() == "seminar" and (
         not isinstance(fact_checks, list) or not fact_checks
     )
-    if sweep_missing and (factual_sweep_retry_available or retry_unavailable_fails):
+    if sweep_missing and factual_sweep_retry_available:
         return _ReviewerGateOutcome(
             payload=working_payload,
             findings=[],

--- a/tests/test_qg_workflow.py
+++ b/tests/test_qg_workflow.py
@@ -658,6 +658,7 @@ def test_live_and_cache_paths_use_shared_reviewer_gate_helper(tmp_path: Path, mo
         policy_family: str,
         theatre_retry_available: bool,
         deep_read_retry_available: bool,
+        factual_sweep_retry_available: bool,
         retry_unavailable_fails: bool = False,
     ) -> qg_workflow._ReviewerGateOutcome:
         calls.append(retry_unavailable_fails)
@@ -697,6 +698,145 @@ def test_live_and_cache_paths_use_shared_reviewer_gate_helper(tmp_path: Path, mo
     assert _tier(first, 2)["status"] == "ran"
     assert _tier(second, 2)["status"] == "cache_hit"
     assert calls == [False, True]
+
+
+def test_missing_fact_sweep_retries_once_and_recovers(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="fact-sweep-recovery",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    section_event = _wiki_event(mode="section")
+    calls: list[str] = []
+
+    def reviewer(_target: qg_workflow.ReviewTarget, prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(prompt)
+        response = json.dumps({"findings": []}) if len(calls) == 1 else _seminar_response()
+        return _seminar_dispatch(response_text=response, events=(section_event,))
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="fact-sweep-recovery"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            capture_tier2=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    tier = _tier(record, 2)
+    assert tier["status"] == "ran"
+    assert record["terminal_verdict"] == "PASS"
+    assert len(calls) == 2
+    assert "Factual Sweep Required" in calls[1]
+    assert len(tier["retry_history"]) == 2
+    assert tier["gate_outcomes"]["factual_sweep_retried"] is True
+
+
+def test_missing_fact_sweep_retry_exhausts_fail_closed(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="fact-sweep-exhausted",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    section_event = _wiki_event(mode="section")
+    calls: list[str] = []
+
+    def reviewer(_target: qg_workflow.ReviewTarget, prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(prompt)
+        return _seminar_dispatch(
+            response_text=json.dumps({"findings": []}),
+            events=(section_event,),
+        )
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="fact-sweep-exhausted"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    assert _tier(record, 2)["status"] == "factual_sweep_incomplete"
+    assert record["terminal_verdict"] == "FAIL"
+    assert len(calls) == 2
+    assert "Factual Sweep Required" in calls[1]
+
+
+def test_missing_fact_sweep_retry_honors_lower_call_limit(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="fact-sweep-call-limit",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    calls: list[str] = []
+
+    def reviewer(_target: qg_workflow.ReviewTarget, prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(prompt)
+        return _seminar_dispatch(
+            response_text=json.dumps({"findings": []}),
+            events=(_wiki_event(mode="section"),),
+        )
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="fact-sweep-call-limit"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            max_llm_calls=1,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    assert _tier(record, 2)["status"] == "factual_sweep_incomplete"
+    assert record["terminal_verdict"] == "FAIL"
+    assert len(calls) == 1
+
+
+def test_theatre_then_missing_fact_sweep_recovers_within_three_calls(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="theatre-fact-sweep",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    section_event = _wiki_event(mode="section")
+    calls: list[str] = []
+
+    def reviewer(_target: qg_workflow.ReviewTarget, prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(prompt)
+        if len(calls) == 1:
+            return _seminar_dispatch(response_text=json.dumps({"findings": []}), tool_call_count=0)
+        response = json.dumps({"findings": []}) if len(calls) == 2 else _seminar_response()
+        return _seminar_dispatch(response_text=response, events=(section_event,))
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="theatre-fact-sweep"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    assert _tier(record, 2)["status"] == "ran"
+    assert record["terminal_verdict"] == "PASS"
+    assert len(calls) == qg_workflow.MAX_TIER2_REVIEWER_CALLS
+    assert "Tools Required" in calls[1]
+    assert "Tools Required" in calls[2]
+    assert "Factual Sweep Required" in calls[2]
 
 
 def test_tier2_threads_tool_telemetry_into_store(tmp_path: Path) -> None:

--- a/tests/test_qg_workflow.py
+++ b/tests/test_qg_workflow.py
@@ -770,6 +770,56 @@ def test_missing_fact_sweep_retry_exhausts_fail_closed(tmp_path: Path) -> None:
     assert "Factual Sweep Required" in calls[1]
 
 
+def test_exhausted_fact_sweep_replays_fail_closed_from_cache(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="fact-sweep-cache-exhausted",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    db_path = tmp_path / "qg.db"
+    calls: list[str] = []
+
+    def reviewer(_target: qg_workflow.ReviewTarget, prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(prompt)
+        return _seminar_dispatch(
+            response_text=json.dumps({"findings": []}),
+            events=(_wiki_event(mode="section"),),
+        )
+
+    options = qg_workflow.WorkflowOptions(
+        enable_llm=True,
+        reviewer_model_id="test-reviewer",
+        reviewer_family="test-family",
+    )
+    target = _target(seminar_dir, level="folk", slug="fact-sweep-cache-exhausted")
+    first = qg_workflow.review_module(
+        target,
+        options=options,
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+    stored = llm_qg_store.latest_llm_qg(
+        "folk", "fact-sweep-cache-exhausted", path=db_path
+    )
+    assert stored is not None
+    assert stored.gate_outcomes is not None
+    assert stored.gate_outcomes["factual_sweep_retried"] is True
+    second = qg_workflow.review_module(
+        target,
+        options=options,
+        reviewer=None,
+        store_path=db_path,
+    )
+
+    assert _tier(first, 2)["status"] == "factual_sweep_incomplete"
+    assert first["terminal_verdict"] == "FAIL"
+    assert _tier(second, 2)["status"] == "factual_sweep_incomplete"
+    assert _tier(second, 2)["cache_regate"] == "replayed"
+    assert second["terminal_verdict"] == "FAIL"
+    assert len(calls) == 2
+
+
 def test_missing_fact_sweep_retry_honors_lower_call_limit(tmp_path: Path) -> None:
     seminar_dir = _write_module(
         tmp_path,


### PR DESCRIPTION
## Summary

- retry an otherwise grounded seminar response once when its mandatory fact-check sweep is missing or empty
- retain the fail-closed disposition after retry exhaustion or a lower operator call limit
- cap a Tier-2 review at three total calls and preserve retry provenance for cache replay

## Validation

- `.venv/bin/ruff check scripts/audit/llm_reviewer_dispatch.py scripts/audit/qg_workflow.py tests/test_qg_workflow.py`
- `.venv/bin/python -m pytest -q tests/test_qg_workflow.py tests/test_llm_reviewer_dispatch.py tests/test_certification_evidence.py tests/audit/test_llm_qg_store.py` (180 passed)
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check`

Closes #5312