### PR TITLE
fix(qg): expire stale runtime authorization

### DIFF
--- a/agents_extensions/shared/skills/track-completion/scripts/certification_evidence.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/certification_evidence.py
@@ -189,6 +189,18 @@ def _qualification_route_is_current(route: Mapping[str, Any], identity: Mapping[
     )
 
 
+def runtime_authorization_is_current(
+    authorization: Mapping[str, Any], expected_identity: Mapping[str, str]
+) -> bool:
+    """Return whether a recorded authorization still binds the live QG contracts."""
+    route = authorization.get("route")
+    return bool(
+        isinstance(route, Mapping)
+        and set(expected_identity) == QG_IDENTITY_KEYS
+        and _qualification_route_is_current(route, expected_identity)
+    )
+
+
 def load_authorization(
     qg_profile: Mapping[str, Any],
     *,

--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -2441,9 +2441,17 @@ def certification_projection(
     try:
         if runtime_authorization is not None:
             # The runtime artifacts were schema-, identity-, and hash-validated before
-            # this immutable authorization was committed to the validated ledger.
-            # Projection must remain resumable after ephemeral evidence is cleaned up.
-            authorization = runtime_authorization
+            # this immutable authorization was committed to the validated ledger. Keep
+            # it resumable after ephemeral evidence is cleaned up, but never carry it
+            # across a changed prompt/gate/budget/circuit/resume contract.
+            if certification.runtime_authorization_is_current(
+                runtime_authorization, inputs["qg_identity"]
+            ):
+                authorization = runtime_authorization
+            else:
+                authorization_reason = (
+                    "recorded production-QG authorization does not bind the current QG contract"
+                )
         elif qg["mode"] == "armed-canary":
             authorization = certification.load_authorization(
                 qg,

--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -748,7 +748,8 @@ def resume_run(
     if prior is not None and prior.get("terminal_goal") is None:
         raise CompletionError("Existing ledger has no terminal goal; run migrate-terminal-goal")
     reopening_state: str | None = None
-    if prior is not None and prior.get("run", {}).get("run_id") == run_id and prior["run"].get("status") == "completed":
+    matching_prior = prior is not None and prior.get("run", {}).get("run_id") == run_id
+    if matching_prior and prior["run"].get("status") == "completed":
         projection = certification_projection(
             selector, repo_root=repo_root, config_path=config_path, ledger_root=ledger_root
         )
@@ -765,6 +766,16 @@ def resume_run(
             "AUDIT_TOOLING_REQUIRED",
         }:
             reopening_state = candidate
+    elif (
+        matching_prior
+        and prior["run"].get("status") == "active"
+        and prior["state"] == "PRODUCTION_QG_REQUIRED"
+    ):
+        projection = certification_projection(
+            selector, repo_root=repo_root, config_path=config_path, ledger_root=ledger_root
+        )
+        if projection["state"] == "AWAITING_PRODUCTION_QG_ARMING":
+            reopening_state = "AWAITING_PRODUCTION_QG_ARMING"
     try:
         with _with_lock(path):
             ledger = _read_ledger(path)
@@ -776,6 +787,12 @@ def resume_run(
                     raise CompletionError("Completed runs are non-authoritative; start a new run or resume after fresh certification evidence")
                 ledger["run"]["status"] = "active"
                 resumed_state = reopening_state
+            elif (
+                reopening_state == "AWAITING_PRODUCTION_QG_ARMING"
+                and ledger["state"] == "PRODUCTION_QG_REQUIRED"
+            ):
+                resumed_state = reopening_state
+                ledger["production_qg_authorization"] = None
             drifted = ledger["current_identity"]["sha256"] != identity["sha256"]
             if drifted and ledger["state"] not in MUTATING_STATES:
                 raise CompletionError("Unrecorded identity drift outside a mutation state; adjudicate stale evidence")

--- a/tests/test_certification_evidence.py
+++ b/tests/test_certification_evidence.py
@@ -919,6 +919,7 @@ def test_qg_only_drift_preserves_preparation_pbr_and_integration_bindings(
         {"path": "/outside/current.json", "sha256": current_sha, "value": current},
         {"path": "/outside/integration.json", "sha256": _sha("integration"), "value": integration},
     ]
+    ledger["state"] = "PRODUCTION_QG_REQUIRED"
     ledger["production_qg_authorization"] = {
         "approval_id": "qg-arm-stale-after-contract-drift",
         "qualification_path": "/outside/qualification.json",
@@ -945,6 +946,15 @@ def test_qg_only_drift_preserves_preparation_pbr_and_integration_bindings(
     assert projection["reason"] == (
         "recorded production-QG authorization does not bind the current QG contract"
     )
+    _, resumed = tc.resume_run(
+        inputs["target"],
+        run_id=ledger["run"]["run_id"],
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+    assert resumed["state"] == "AWAITING_PRODUCTION_QG_ARMING"
+    assert resumed["production_qg_authorization"] is None
 
 
 def test_actual_qg_policy_source_drift_changes_only_qg_identity(tmp_path: Path) -> None:

--- a/tests/test_certification_evidence.py
+++ b/tests/test_certification_evidence.py
@@ -908,7 +908,9 @@ def test_current_unresolved_independent_material_finding_blocks_a_pass(tmp_path:
     assert projection["independent_review"] == "unresolved"
 
 
-def test_qg_only_drift_preserves_preparation_pbr_and_integration_bindings(tmp_path: Path) -> None:
+def test_qg_only_drift_preserves_preparation_pbr_and_integration_bindings(
+    qg_capture: dict[str, Any], tmp_path: Path
+) -> None:
     repo, config_path, ledger_root, ledger, inputs = _completion_case(tmp_path)
     current = _independent_value(inputs)
     current_sha = _sha("current-independent")
@@ -917,6 +919,14 @@ def test_qg_only_drift_preserves_preparation_pbr_and_integration_bindings(tmp_pa
         {"path": "/outside/current.json", "sha256": current_sha, "value": current},
         {"path": "/outside/integration.json", "sha256": _sha("integration"), "value": integration},
     ]
+    ledger["production_qg_authorization"] = {
+        "approval_id": "qg-arm-stale-after-contract-drift",
+        "qualification_path": "/outside/qualification.json",
+        "qualification_sha256": _sha("qualification"),
+        "human_arming_path": "/outside/arming.json",
+        "human_arming_sha256": _sha("arming"),
+        "route": _route(inputs["qg_identity"], qg_capture["tier2"]),
+    }
     path = tc.ledger_path_for(tc.resolve_target(inputs["target"], repo_root=repo, config=tc.load_config(config_path)), repo_root=repo, config=tc.load_config(config_path), ledger_root=ledger_root)
     tc._atomic_write_json(path, ledger)
     before = tc.certification_inputs(inputs["target"], repo_root=repo, config_path=config_path, ledger=ledger)
@@ -930,7 +940,11 @@ def test_qg_only_drift_preserves_preparation_pbr_and_integration_bindings(tmp_pa
     projection = tc.certification_projection(inputs["target"], repo_root=repo, config_path=config_path, ledger_root=ledger_root)
     assert projection["post_build"] == "current"
     assert projection["integration"] == "current"
+    assert projection["state"] == "AWAITING_PRODUCTION_QG_ARMING"
     assert projection["production_qg"] == "awaiting-human-arming"
+    assert projection["reason"] == (
+        "recorded production-QG authorization does not bind the current QG contract"
+    )
 
 
 def test_actual_qg_policy_source_drift_changes_only_qg_identity(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- revalidate persisted runtime QG authorization against the live 13-class QG identity
- return the lifecycle to fail-closed human arming when prompt, gate, budget, circuit, or resume contracts drift
- preserve resumability when the exact authorization remains current

Follow-up to #5312 and #5313.

## Verification
- `.venv/bin/ruff check agents_extensions/shared/skills/track-completion/scripts/certification_evidence.py agents_extensions/shared/skills/track-completion/scripts/track_completion.py tests/test_certification_evidence.py`
- `.venv/bin/python -m pytest tests/test_certification_evidence.py tests/test_track_completion.py -q` (90 passed)
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check origin/main...HEAD`

## Review gate
Independent cross-family review will be attached before auto-merge is armed.