### PR TITLE
fix(qg): reconcile rearming workflow drift

### DIFF
--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -748,6 +748,7 @@ def resume_run(
     if prior is not None and prior.get("terminal_goal") is None:
         raise CompletionError("Existing ledger has no terminal goal; run migrate-terminal-goal")
     reopening_state: str | None = None
+    active_qg_rearming = False
     matching_prior = prior is not None and prior.get("run", {}).get("run_id") == run_id
     if matching_prior and prior["run"].get("status") == "completed":
         projection = certification_projection(
@@ -776,25 +777,32 @@ def resume_run(
         )
         if projection["state"] == "AWAITING_PRODUCTION_QG_ARMING":
             reopening_state = "AWAITING_PRODUCTION_QG_ARMING"
+            active_qg_rearming = True
     try:
         with _with_lock(path):
             ledger = _read_ledger(path)
             if ledger is None or ledger["run"]["run_id"] != run_id:
                 raise CompletionError("No matching completion run to resume")
             resumed_state = ledger["state"]
+            reconcile_qg_rearming = bool(
+                active_qg_rearming
+                and ledger["run"]["status"] == "active"
+                and ledger["state"] == "PRODUCTION_QG_REQUIRED"
+            )
             if ledger["run"]["status"] != "active":
                 if reopening_state is None:
                     raise CompletionError("Completed runs are non-authoritative; start a new run or resume after fresh certification evidence")
                 ledger["run"]["status"] = "active"
                 resumed_state = reopening_state
-            elif (
-                reopening_state == "AWAITING_PRODUCTION_QG_ARMING"
-                and ledger["state"] == "PRODUCTION_QG_REQUIRED"
-            ):
+            elif reconcile_qg_rearming:
                 resumed_state = reopening_state
                 ledger["production_qg_authorization"] = None
             drifted = ledger["current_identity"]["sha256"] != identity["sha256"]
-            if drifted and ledger["state"] not in MUTATING_STATES:
+            if (
+                drifted
+                and ledger["state"] not in MUTATING_STATES
+                and not reconcile_qg_rearming
+            ):
                 raise CompletionError("Unrecorded identity drift outside a mutation state; adjudicate stale evidence")
             _renew_lease(ledger, config)
             eid = _event_id(
@@ -807,8 +815,16 @@ def resume_run(
                     event_id=eid,
                     event="CERTIFICATION_RESUMED" if reopening_state else "RESUMED",
                     to_state=resumed_state,
-                    identity=ledger["current_identity"] if drifted else identity,
-                    details={"pending_identity_drift": drifted, "reopened_for_certification": reopening_state is not None},
+                    identity=(
+                        identity
+                        if reconcile_qg_rearming or not drifted
+                        else ledger["current_identity"]
+                    ),
+                    details={
+                        "pending_identity_drift": drifted and not reconcile_qg_rearming,
+                        "reconciled_qg_rearming": reconcile_qg_rearming,
+                        "reopened_for_certification": reopening_state is not None,
+                    },
                 )
             _validate(ledger, LEDGER_SCHEMA_PATH, "track-completion ledger")
             _atomic_write_json(path, ledger)

--- a/tests/test_certification_evidence.py
+++ b/tests/test_certification_evidence.py
@@ -933,11 +933,26 @@ def test_qg_only_drift_preserves_preparation_pbr_and_integration_bindings(
     before = tc.certification_inputs(inputs["target"], repo_root=repo, config_path=config_path, ledger=ledger)
     prompt_dependency = repo / "scripts/audit/prompts/reviewer_prompt.md"
     prompt_dependency.write_text(prompt_dependency.read_text(encoding="utf-8") + "\n<!-- qg-only drift -->\n", encoding="utf-8")
+    lifecycle_dependency = (
+        repo
+        / "agents_extensions/shared/skills/track-completion/scripts/track_completion.py"
+    )
+    lifecycle_dependency.write_text(
+        lifecycle_dependency.read_text(encoding="utf-8")
+        + "\n# lifecycle workflow identity drift\n",
+        encoding="utf-8",
+    )
     after = tc.certification_inputs(inputs["target"], repo_root=repo, config_path=config_path, ledger=ledger)
+    current_identity = tc.build_identity(
+        tc.resolve_target(inputs["target"], repo_root=repo, config=tc.load_config(config_path)),
+        repo_root=repo,
+        config=tc.load_config(config_path),
+    )
 
     assert after["preparation_identity"] == before["preparation_identity"]
     assert after["pbr_dependency_identity"] == before["pbr_dependency_identity"]
     assert after["qg_identity"] != before["qg_identity"]
+    assert current_identity["sha256"] != ledger["current_identity"]["sha256"]
     projection = tc.certification_projection(inputs["target"], repo_root=repo, config_path=config_path, ledger_root=ledger_root)
     assert projection["post_build"] == "current"
     assert projection["integration"] == "current"
@@ -955,6 +970,9 @@ def test_qg_only_drift_preserves_preparation_pbr_and_integration_bindings(
     )
     assert resumed["state"] == "AWAITING_PRODUCTION_QG_ARMING"
     assert resumed["production_qg_authorization"] is None
+    assert resumed["current_identity"]["sha256"] == current_identity["sha256"]
+    assert resumed["history"][-1]["details"]["pending_identity_drift"] is False
+    assert resumed["history"][-1]["details"]["reconciled_qg_rearming"] is True
 
 
 def test_actual_qg_policy_source_drift_changes_only_qg_identity(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- allow an active production-QG run to reconcile general workflow identity drift only when the live certification projection proves the sole transition is QG re-arming
- adopt the proven current workflow identity while clearing the stale authorization
- preserve the existing fail-closed drift error for every other non-mutation state

Follow-up to #5312, #5313, and #5314, discovered by replaying the real BIO-371 lifecycle ledger.

## Verification
- `.venv/bin/ruff check agents_extensions/shared/skills/track-completion/scripts/track_completion.py tests/test_certification_evidence.py`
- `.venv/bin/python -m pytest tests/test_certification_evidence.py tests/test_track_completion.py -q` (90 passed)
- `git diff --check`

## Review gate
Independent cross-family review will be attached before auto-merge is armed.