### PR TITLE
feat(activity-kit): optional focus_status on lu.lesson.v1 (additive)

### DIFF
--- a/docs/projects/hramatka/lesson-document-v1.md
+++ b/docs/projects/hramatka/lesson-document-v1.md
@@ -26,7 +26,7 @@ the async bake API (build step 5) and the editor/player frontend (step 6).
                                         // they never reject the teacher's text for difficulty
   "method": "ttt",                      // v1: Тест→Навчання→Тест; phase set {1,2,3}
   "focus": "string|null",               // grammar focus, free text v1
-  "focus_status": "object|null",        // Outcome of the teacher's requested focus, optional
+  "focus_status": "object",             // optional (absent when no focus requested); never an explicit null
   "anchor": { "text": "string", "source": "teacher-paste|teacher-url", "chars": 1456 },
   "duration": 45 | 60 | 90,             // minutes; the ONLY sizing input a teacher gives
   "version": 1,                          // integer, for data migration (schema string is not parsed)

--- a/docs/projects/hramatka/lesson-document-v1.md
+++ b/docs/projects/hramatka/lesson-document-v1.md
@@ -26,6 +26,7 @@ the async bake API (build step 5) and the editor/player frontend (step 6).
                                         // they never reject the teacher's text for difficulty
   "method": "ttt",                      // v1: Тест→Навчання→Тест; phase set {1,2,3}
   "focus": "string|null",               // grammar focus, free text v1
+  "focus_status": "object|null",        // Outcome of the teacher's requested focus, optional
   "anchor": { "text": "string", "source": "teacher-paste|teacher-url", "chars": 1456 },
   "duration": 45 | 60 | 90,             // minutes; the ONLY sizing input a teacher gives
   "version": 1,                          // integer, for data migration (schema string is not parsed)

--- a/packages/activity-kit/src/lu.lesson.v1.generated.ts
+++ b/packages/activity-kit/src/lu.lesson.v1.generated.ts
@@ -79,4 +79,9 @@ export type LuLessonV1 = {
   }>;
   created_at: string;
   updated_at: string;
+  focus_status?: {
+    requested: string;
+    supported: boolean;
+    notice_uk: string | null;
+  };
 };

--- a/packages/activity-kit/src/lu.lesson.v1.schema.json
+++ b/packages/activity-kit/src/lu.lesson.v1.schema.json
@@ -45,7 +45,25 @@
       "items": { "$ref": "#/$defs/rejectedDraft" }
     },
     "created_at": { "type": "string", "format": "date-time" },
-    "updated_at": { "type": "string", "format": "date-time" }
+    "updated_at": { "type": "string", "format": "date-time" },
+    "focus_status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requested", "supported", "notice_uk"],
+      "properties": {
+        "requested": { "type": "string", "minLength": 1, "maxLength": 500 },
+        "supported": { "type": "boolean" },
+        "notice_uk": { "type": ["string", "null"], "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "supported": { "const": false } } },
+          "then": { "properties": { "notice_uk": { "type": "string" } } },
+          "else": { "properties": { "notice_uk": { "type": "null" } } }
+        }
+      ],
+      "description": "Outcome of the teacher's requested grammar/skill focus for this bake: whether the anchor text supports it, and (when unsupported) an honest learner-language notice explaining why. Absent when no focus was requested."
+    }
   },
   "allOf": [
     {

--- a/site/tests/unit/ActivityKit.contract.test.tsx
+++ b/site/tests/unit/ActivityKit.contract.test.tsx
@@ -264,4 +264,44 @@ describe('lesson document v1 contract', () => {
 
     expect(lessonSchemaErrors(malformed)).toContain("'answer_key' is a required property");
   });
+
+  test('validates focus_status supported:true with notice_uk:null', () => {
+    const doc = structuredClone(lessonFixture);
+    (doc as any).focus_status = {
+      requested: 'вищий ступінь прикметників',
+      supported: true,
+      notice_uk: null,
+    };
+    expect(lessonSchemaErrors(doc)).toBe('');
+  });
+
+  test('validates focus_status supported:false with the Ukrainian notice string', () => {
+    const doc = structuredClone(lessonFixture);
+    (doc as any).focus_status = {
+      requested: 'вищий ступінь прикметників',
+      supported: false,
+      notice_uk: 'Опора не містить достатньо перевіреного матеріалу для фокусу «вищий ступінь прикметників». Вправи спираються лише на текст-опору; додайте приклади або змініть фокус.',
+    };
+    expect(lessonSchemaErrors(doc)).toBe('');
+  });
+
+  test('rejects focus_status supported:true with a non-null notice_uk', () => {
+    const doc = structuredClone(lessonFixture);
+    (doc as any).focus_status = {
+      requested: 'вищий ступінь прикметників',
+      supported: true,
+      notice_uk: 'Опора не містить достатньо перевіреного матеріалу для фокусу «вищий ступінь прикметників». Вправи спираються лише на текст-опору; додайте приклади або змініть фокус.',
+    };
+    expect(lessonSchemaErrors(doc)).not.toBe('');
+  });
+
+  test('rejects focus_status supported:false with a null notice_uk', () => {
+    const doc = structuredClone(lessonFixture);
+    (doc as any).focus_status = {
+      requested: 'вищий ступінь прикметників',
+      supported: false,
+      notice_uk: null,
+    };
+    expect(lessonSchemaErrors(doc)).not.toBe('');
+  });
 });


### PR DESCRIPTION
# Verification Evidence

- **schema valid + fixtures pass**:
Ran vitest contract tests (`npx vitest run tests/unit/ActivityKit.contract.test.tsx` in `site` workspace):
```
 ✓ tests/unit/ActivityKit.contract.test.tsx (46 tests) 1922ms
 Test Files  1 passed (1)
      Tests  46 passed (46)
   Start at  18:59:09
   Duration  2.24s (transform 87ms, setup 29ms, import 132ms, tests 1.92s, environment 93ms)
```

- **types regenerated**:
Ran `npm run generate:types` in `packages/activity-kit` workspace:
```
git diff packages/activity-kit/src/lu.lesson.v1.generated.ts
diff --git a/packages/activity-kit/src/lu.lesson.v1.generated.ts b/packages/activity-kit/src/lu.lesson.v1.generated.ts
index e9d1d17b80..cfbe31c705 100644
--- a/packages/activity-kit/src/lu.lesson.v1.generated.ts
+++ b/packages/activity-kit/src/lu.lesson.v1.generated.ts
@@ -79,4 +79,9 @@ export type LuLessonV1 = {
   }>;
   created_at: string;
   updated_at: string;
+  focus_status?: {
+    requested: string;
+    supported: boolean;
+    notice_uk: string | null;
+  };
 };
```

- **old docs still valid**:
The existing canonical flagship fixture validated successfully, passing the schema checks unchanged:
`✓ tests/unit/ActivityKit.contract.test.tsx` passed, which contains the test validating the canonical fixture:
```typescript
  test('validates the canonical 12-block flagship fixture', () => {
    expect(lessonSchemaErrors(lessonFixture)).toBe('');
  });
```

---

## Description
This PR introduces the optional `focus_status` root property to the `lu.lesson.v1` schema to track focus outcome metadata.
