### PR TITLE
fix(atlas): browser-portable HttpAtlasDataSource (Sol F003/F004/F005)

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -20,7 +20,8 @@
     "test": "npm run hydrate && vitest run",
     "test:watch": "npm run hydrate && vitest --watch",
     "test:coverage": "npm run hydrate && vitest run --coverage",
-    "test:atlas-route-parity": "node --experimental-strip-types ./scripts/atlas-lexicon-route-parity.mjs"
+    "test:atlas-route-parity": "node --experimental-strip-types ./scripts/atlas-lexicon-route-parity.mjs",
+    "check:atlas-browser-bundle": "esbuild src/lib/lexicon/http-atlas-data-source.ts --bundle --platform=browser --external:astro* --outfile=/dev/null"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",

--- a/site/src/lib/lexicon/http-atlas-data-source.ts
+++ b/site/src/lib/lexicon/http-atlas-data-source.ts
@@ -1,13 +1,12 @@
 /**
- * HTTP/file Atlas data source — reads an exported runtime shard tree.
+ * HTTP Atlas data source — browser-portable reader for exported runtime shards.
  *
- * Used for parity tests against SqliteAtlasDataSource and as the browser/VPS
- * reader shape. R2AtlasDataSource (Worker binding + Cache API) is a later PR.
+ * Production serves dictionary shards as GitHub Release assets fetched on demand
+ * by the browser (client-rendered word pages). This module must stay free of
+ * `node:*` imports. Node-only helpers (file fetch, gunzipSync) live in
+ * `http-atlas-node.ts`.
  */
 
-import { gunzipSync } from "node:zlib";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import {
   AtlasDataSourceError,
   isValidAtlasSlug,
@@ -26,6 +25,25 @@ import type { PracticeDeckData } from "./srs.ts";
 export interface AtlasFetch {
   (url: string): Promise<Uint8Array>;
 }
+
+/** Pluggable gzip decode — browsers use DecompressionStream; Node injects gunzipSync. */
+export type AtlasDecompress = (compressed: Uint8Array) => Promise<Uint8Array> | Uint8Array;
+
+export interface HttpAtlasDataSourceOptions {
+  assetBaseUrl?: string;
+  /**
+   * Max age for cached `current.json` / manifest pointer resolution.
+   * Default 60s. Set to 0 to re-resolve on every logical request (tests).
+   */
+  pointerTtlMs?: number;
+  /** Override gzip decode. Defaults to browser `DecompressionStream("gzip")`. */
+  decompress?: AtlasDecompress;
+  /** Clock for pointer TTL; injectable for tests. */
+  now?: () => number;
+}
+
+/** Default pointer TTL — short enough to observe release rollovers, long enough to amortize fetches. */
+export const DEFAULT_POINTER_TTL_MS = 60_000;
 
 interface CurrentPointer {
   schema: string;
@@ -88,8 +106,22 @@ interface SearchTreeNode {
   children?: Record<string, SearchTreeNode>;
 }
 
+/** Snapshot pinned for one logical request (getEntry / search / getDeck). */
+interface PinnedAtlasSession {
+  pointer: CurrentPointer;
+  manifest: RuntimeManifest;
+  versionDir: string;
+}
+
+/** Copy into a real ArrayBuffer-backed view (TS 5.7+/6 BufferSource strictness). */
+function toArrayBufferView(data: Uint8Array): Uint8Array<ArrayBuffer> {
+  const copy = new Uint8Array(data.byteLength);
+  copy.set(data);
+  return copy;
+}
+
 async function sha256Hex(data: Uint8Array): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", data);
+  const digest = await crypto.subtle.digest("SHA-256", toArrayBufferView(data));
   return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
@@ -97,30 +129,61 @@ function decodeJson<T>(raw: Uint8Array): T {
   return JSON.parse(new TextDecoder("utf-8").decode(raw)) as T;
 }
 
-export function createFileAtlasFetch(rootDir: string, basePath = "atlas"): AtlasFetch {
-  const root = resolve(rootDir, basePath);
-  return async (url: string) => {
-    const path = resolve(root, url);
-    if (!path.startsWith(root)) {
-      throw new AtlasDataSourceError("invalid_slug", `refusing path escape: ${url}`);
-    }
-    try {
-      return new Uint8Array(readFileSync(path));
-    } catch (error) {
-      throw new AtlasDataSourceError("unavailable", `failed to read ${url}: ${String(error)}`);
-    }
-  };
+/**
+ * Browser-default gzip decode via the Compression Streams API.
+ * Available in modern browsers and Node 20+.
+ */
+export async function gunzipWithDecompressionStream(compressed: Uint8Array): Promise<Uint8Array> {
+  if (typeof DecompressionStream === "undefined") {
+    throw new AtlasDataSourceError(
+      "unavailable",
+      "DecompressionStream is not available; inject options.decompress (e.g. Node gunzipSync)",
+    );
+  }
+  const copy = toArrayBufferView(compressed);
+  const stream = new Blob([copy]).stream().pipeThrough(new DecompressionStream("gzip"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/**
+ * Admit search article rows the ranker can score — lemma/roman exact·prefix and
+ * gloss substring (mirrors `matchTier` surfaces used by SqliteAtlasDataSource).
+ */
+export function admitsSearchArticle(row: SearchRow, normalizedQuery: string): boolean {
+  if (!normalizedQuery) return false;
+  const lemma = normalizeAtlasText(row.l);
+  const roman = row.r ? normalizeAtlasText(row.r) : "";
+  const gloss = row.g ? normalizeAtlasText(row.g) : "";
+  return (
+    lemma === normalizedQuery ||
+    lemma.startsWith(normalizedQuery) ||
+    lemma.includes(normalizedQuery) ||
+    (roman.length > 0 &&
+      (roman === normalizedQuery ||
+        roman.startsWith(normalizedQuery) ||
+        roman.includes(normalizedQuery))) ||
+    (gloss.length > 0 && gloss.includes(normalizedQuery))
+  );
 }
 
 export class HttpAtlasDataSource implements AtlasDataSource {
   private current: CurrentPointer | null = null;
+  private currentFetchedAt = 0;
   private manifest: RuntimeManifest | null = null;
+  private versionDir = "";
   private readonly assetCache = new Map<string, Uint8Array>();
+  private readonly pointerTtlMs: number;
+  private readonly decompress: AtlasDecompress;
+  private readonly now: () => number;
 
   constructor(
     private readonly fetchBytes: AtlasFetch,
-    private readonly options?: { assetBaseUrl?: string },
-  ) {}
+    private readonly options?: HttpAtlasDataSourceOptions,
+  ) {
+    this.pointerTtlMs = options?.pointerTtlMs ?? DEFAULT_POINTER_TTL_MS;
+    this.decompress = options?.decompress ?? gunzipWithDecompressionStream;
+    this.now = options?.now ?? (() => Date.now());
+  }
 
   private assetUrl(relative: string): string {
     const base = this.options?.assetBaseUrl ?? "";
@@ -128,46 +191,65 @@ export class HttpAtlasDataSource implements AtlasDataSource {
     return `${base.replace(/\/$/, "")}/${relative.replace(/^\//, "")}`;
   }
 
-  private async loadCurrent(force = false): Promise<CurrentPointer> {
-    if (this.current && !force) return this.current;
-    const raw = await this.fetchBytes(this.assetUrl("current.json"));
-    const pointer = decodeJson<CurrentPointer>(raw);
-    if (pointer.schema !== "atlas-current" || pointer.schemaVersion !== 1) {
-      throw new AtlasDataSourceError("unsupported_schema", "unsupported current.json schema");
-    }
-    this.current = pointer;
-    return pointer;
+  private pointerCacheFresh(force: boolean): boolean {
+    if (force || !this.current) return false;
+    return this.now() - this.currentFetchedAt < this.pointerTtlMs;
   }
 
-  private async loadManifest(force = false): Promise<RuntimeManifest> {
-    if (this.manifest && !force) return this.manifest;
-    const current = await this.loadCurrent(force);
-    const versionDir = current.manifestUrl.replace(/\/manifest\.json$/, "");
-    const raw = await this.fetchBytes(this.assetUrl(current.manifestUrl));
-    const manifest = decodeJson<RuntimeManifest>(raw);
-    if (manifest.schema !== "atlas-runtime-manifest" || manifest.schemaVersion !== 1) {
-      throw new AtlasDataSourceError("unsupported_schema", "unsupported manifest schema");
+  /**
+   * Resolve (or re-resolve) current.json + matching manifest, then return a
+   * request-pinned session so mid-request rollovers cannot tear shard URLs.
+   */
+  private async resolveSession(force = false): Promise<PinnedAtlasSession> {
+    let pointer = this.current;
+    if (!this.pointerCacheFresh(force)) {
+      const raw = await this.fetchBytes(this.assetUrl("current.json"));
+      pointer = decodeJson<CurrentPointer>(raw);
+      if (pointer.schema !== "atlas-current" || pointer.schemaVersion !== 1) {
+        throw new AtlasDataSourceError("unsupported_schema", "unsupported current.json schema");
+      }
+      this.current = pointer;
+      this.currentFetchedAt = this.now();
     }
-    if (manifest.dataVersion !== current.dataVersion) {
-      throw new AtlasDataSourceError(
-        "version_mismatch",
-        `current points to ${current.dataVersion} but manifest is ${manifest.dataVersion}`,
-      );
+    if (!pointer) {
+      throw new AtlasDataSourceError("unavailable", "current.json pointer missing after resolve");
     }
-    // Bind relative shard URLs against the version directory.
-    this.manifest = manifest;
-    this.manifestVersionDir = versionDir;
-    return manifest;
-  }
 
-  private manifestVersionDir = "";
+    const needsManifest =
+      force || !this.manifest || this.manifest.dataVersion !== pointer.dataVersion;
+    if (needsManifest) {
+      const versionDir = pointer.manifestUrl.replace(/\/manifest\.json$/, "");
+      const raw = await this.fetchBytes(this.assetUrl(pointer.manifestUrl));
+      const manifest = decodeJson<RuntimeManifest>(raw);
+      if (manifest.schema !== "atlas-runtime-manifest" || manifest.schemaVersion !== 1) {
+        throw new AtlasDataSourceError("unsupported_schema", "unsupported manifest schema");
+      }
+      if (manifest.dataVersion !== pointer.dataVersion) {
+        throw new AtlasDataSourceError(
+          "version_mismatch",
+          `current points to ${pointer.dataVersion} but manifest is ${manifest.dataVersion}`,
+        );
+      }
+      this.manifest = manifest;
+      this.versionDir = versionDir;
+    }
+
+    // Pin field copies for this request — concurrent resolveSession must not
+    // mutate the versionDir/manifest this request is already using.
+    return {
+      pointer,
+      manifest: this.manifest!,
+      versionDir: this.versionDir,
+    };
+  }
 
   private async readObject(
     descriptor: ObjectDescriptor,
     expectedVersion: string,
+    versionDir: string,
     options?: { kind?: "entry" | "search" | "deck" },
   ): Promise<unknown> {
-    const url = `${this.manifestVersionDir}/${descriptor.url}`.replace(/\/+/g, "/");
+    const url = `${versionDir}/${descriptor.url}`.replace(/\/+/g, "/");
     const cacheKey = `${expectedVersion}:${descriptor.id}:${descriptor.sha256}`;
     let compressed = this.assetCache.get(cacheKey);
     if (!compressed) {
@@ -186,8 +268,9 @@ export class HttpAtlasDataSource implements AtlasDataSource {
     }
     let raw: Uint8Array;
     try {
-      raw = gunzipSync(compressed);
+      raw = await this.decompress(compressed);
     } catch (error) {
+      if (error instanceof AtlasDataSourceError) throw error;
       throw new AtlasDataSourceError(
         "integrity_error",
         `gzip decode failed for ${descriptor.id}: ${String(error)}`,
@@ -221,17 +304,17 @@ export class HttpAtlasDataSource implements AtlasDataSource {
 
   private async withVersionRetry<T>(
     expectedVersion: string | undefined,
-    action: (manifest: RuntimeManifest) => Promise<T>,
+    action: (session: PinnedAtlasSession) => Promise<T>,
   ): Promise<T> {
-    const manifest = await this.loadManifest(false);
-    if (expectedVersion && expectedVersion !== manifest.dataVersion) {
+    const session = await this.resolveSession(false);
+    if (expectedVersion && expectedVersion !== session.manifest.dataVersion) {
       throw new AtlasDataSourceError(
         "version_mismatch",
-        `expected ${expectedVersion}, have ${manifest.dataVersion}`,
+        `expected ${expectedVersion}, have ${session.manifest.dataVersion}`,
       );
     }
     try {
-      return await action(manifest);
+      return await action(session);
     } catch (error) {
       if (!(error instanceof AtlasDataSourceError) || error.code !== "version_mismatch") {
         throw error;
@@ -239,9 +322,11 @@ export class HttpAtlasDataSource implements AtlasDataSource {
       // Discard partials, refresh current.json, retry once.
       this.assetCache.clear();
       this.current = null;
+      this.currentFetchedAt = 0;
       this.manifest = null;
-      const refreshed = await this.loadManifest(true);
-      if (expectedVersion && expectedVersion !== refreshed.dataVersion) {
+      this.versionDir = "";
+      const refreshed = await this.resolveSession(true);
+      if (expectedVersion && expectedVersion !== refreshed.manifest.dataVersion) {
         throw error;
       }
       return action(refreshed);
@@ -307,14 +392,15 @@ export class HttpAtlasDataSource implements AtlasDataSource {
     if (!isValidAtlasSlug(slug)) {
       throw new AtlasDataSourceError("invalid_slug", `invalid slug: ${JSON.stringify(slug)}`);
     }
-    return this.withVersionRetry(options?.expectedVersion, async (manifest) => {
+    return this.withVersionRetry(options?.expectedVersion, async (session) => {
+      const { manifest, versionDir } = session;
       const bits = await this.slugHashBits(slug);
       const shardId = this.resolveEntryShardId(manifest.entries.tree, bits);
       const descriptor = manifest.entries.shards[shardId];
       if (!descriptor) {
         throw new AtlasDataSourceError("integrity_error", `missing entry shard descriptor ${shardId}`);
       }
-      const payload = (await this.readObject(descriptor, manifest.dataVersion)) as {
+      const payload = (await this.readObject(descriptor, manifest.dataVersion, versionDir)) as {
         records: EntryRecord[];
       };
       const record = payload.records.find((item) => item.slug === slug);
@@ -327,7 +413,8 @@ export class HttpAtlasDataSource implements AtlasDataSource {
     query: string,
     options?: { limit?: number; expectedVersion?: string },
   ): Promise<SearchResponse> {
-    return this.withVersionRetry(options?.expectedVersion, async (manifest) => {
+    return this.withVersionRetry(options?.expectedVersion, async (session) => {
+      const { manifest, versionDir } = session;
       const normalizedQuery = normalizeAtlasText(query);
       const limit = options?.limit ?? 12;
       if (!normalizedQuery) {
@@ -354,7 +441,7 @@ export class HttpAtlasDataSource implements AtlasDataSource {
             if (!descriptor) {
               throw new AtlasDataSourceError("integrity_error", `missing article search shard ${id}`);
             }
-            return this.readObject(descriptor, manifest.dataVersion) as Promise<{
+            return this.readObject(descriptor, manifest.dataVersion, versionDir) as Promise<{
               records: SearchRow[];
             }>;
           }),
@@ -365,7 +452,7 @@ export class HttpAtlasDataSource implements AtlasDataSource {
             if (!descriptor) {
               throw new AtlasDataSourceError("integrity_error", `missing alias search shard ${id}`);
             }
-            return this.readObject(descriptor, manifest.dataVersion) as Promise<{
+            return this.readObject(descriptor, manifest.dataVersion, versionDir) as Promise<{
               records: SearchAlias[];
             }>;
           }),
@@ -375,13 +462,7 @@ export class HttpAtlasDataSource implements AtlasDataSource {
       const articlesBySlug = new Map<string, SearchRow>();
       for (const payload of articlePayloads) {
         for (const row of payload.records) {
-          const lemma = normalizeAtlasText(row.l);
-          const roman = row.r ? normalizeAtlasText(row.r) : "";
-          if (
-            lemma === normalizedQuery ||
-            lemma.startsWith(normalizedQuery) ||
-            roman.startsWith(normalizedQuery)
-          ) {
+          if (admitsSearchArticle(row, normalizedQuery)) {
             articlesBySlug.set(row.s, row);
           }
         }
@@ -391,7 +472,9 @@ export class HttpAtlasDataSource implements AtlasDataSource {
       for (const payload of aliasPayloads) {
         for (const row of payload.records) {
           const text = normalizeAtlasText(row.a);
-          if (!(text === normalizedQuery || text.startsWith(normalizedQuery))) continue;
+          if (!(text === normalizedQuery || text.startsWith(normalizedQuery) || text.includes(normalizedQuery))) {
+            continue;
+          }
           const key = `${row.a}\0${row.s}\0${row.k}`;
           if (seenAlias.has(key)) continue;
           seenAlias.add(key);
@@ -418,7 +501,8 @@ export class HttpAtlasDataSource implements AtlasDataSource {
     if (!PRACTICE_LEVELS.includes(level)) {
       throw new AtlasDataSourceError("invalid_slug", `invalid practice level ${level}`);
     }
-    return this.withVersionRetry(options?.expectedVersion, async (manifest) => {
+    return this.withVersionRetry(options?.expectedVersion, async (session) => {
+      const { manifest, versionDir } = session;
       const info = manifest.decks.levels[level];
       if (!info) return { kind: "missing", version: manifest.dataVersion, level };
       const parts = options?.parts ?? (["index", "lexemes", "cloze"] as DeckPart[]);
@@ -427,7 +511,7 @@ export class HttpAtlasDataSource implements AtlasDataSource {
       for (const part of parts) {
         const descriptor = info.parts[part];
         if (!descriptor) return { kind: "missing", version: manifest.dataVersion, level };
-        const payload = (await this.readObject(descriptor, manifest.dataVersion, {
+        const payload = (await this.readObject(descriptor, manifest.dataVersion, versionDir, {
           kind: "deck",
         })) as {
           deckVersion?: string;

--- a/site/src/lib/lexicon/http-atlas-node.ts
+++ b/site/src/lib/lexicon/http-atlas-node.ts
@@ -1,0 +1,50 @@
+/**
+ * Node-only helpers for HttpAtlasDataSource.
+ *
+ * Keep `node:*` imports here so the browser-portable core
+ * (`http-atlas-data-source.ts`) can load in client bundles.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { gunzipSync } from "node:zlib";
+import { AtlasDataSourceError } from "./atlas-data-source.ts";
+import {
+  HttpAtlasDataSource,
+  type AtlasDecompress,
+  type AtlasFetch,
+  type HttpAtlasDataSourceOptions,
+} from "./http-atlas-data-source.ts";
+
+/** Node gzip decode via zlib.gunzipSync. */
+export const nodeGunzip: AtlasDecompress = (compressed) => gunzipSync(compressed);
+
+/**
+ * Read an on-disk runtime shard tree (export root) as an AtlasFetch.
+ * Used by parity tests and local Node tooling — not for browser bundles.
+ */
+export function createFileAtlasFetch(rootDir: string, basePath = "atlas"): AtlasFetch {
+  const root = resolve(rootDir, basePath);
+  return async (url: string) => {
+    const path = resolve(root, url);
+    if (!path.startsWith(root)) {
+      throw new AtlasDataSourceError("invalid_slug", `refusing path escape: ${url}`);
+    }
+    try {
+      return new Uint8Array(readFileSync(path));
+    } catch (error) {
+      throw new AtlasDataSourceError("unavailable", `failed to read ${url}: ${String(error)}`);
+    }
+  };
+}
+
+/** Construct HttpAtlasDataSource with Node gunzip as the default decompress hook. */
+export function createNodeHttpAtlasDataSource(
+  fetchBytes: AtlasFetch,
+  options?: Omit<HttpAtlasDataSourceOptions, "decompress"> & { decompress?: AtlasDecompress },
+): HttpAtlasDataSource {
+  return new HttpAtlasDataSource(fetchBytes, {
+    ...options,
+    decompress: options?.decompress ?? nodeGunzip,
+  });
+}

--- a/site/tests/unit/atlas-runtime-shards.test.ts
+++ b/site/tests/unit/atlas-runtime-shards.test.ts
@@ -5,21 +5,29 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 import { normalizeAtlasText } from "@site/src/lib/lexicon/normalize";
 import {
-  createFileAtlasFetch,
-  HttpAtlasDataSource,
+  admitsSearchArticle,
+  type AtlasFetch,
 } from "@site/src/lib/lexicon/http-atlas-data-source";
+import {
+  createFileAtlasFetch,
+  createNodeHttpAtlasDataSource,
+} from "@site/src/lib/lexicon/http-atlas-node";
 import {
   resetSqliteAtlasDataSourceCachesForTests,
   SqliteAtlasDataSource,
 } from "@site/src/lib/lexicon/sqlite-atlas-data-source";
 import { AtlasDataSourceError } from "@site/src/lib/lexicon/atlas-data-source";
-import { rankSearchResults } from "@site/src/lib/lexicon/search";
+import { rankSearchResults, type SearchRow } from "@site/src/lib/lexicon/search";
 import reactRenderer from "@astrojs/react/server.js";
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import {
   getAtlasPayloadCache,
   resetAtlasPayloadCacheForTests,
 } from "@site/src/lib/lexicon/atlasDb";
+import { gzipSync } from "node:zlib";
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
 
 const vectorsPath = resolve(
   process.cwd(),
@@ -27,8 +35,17 @@ const vectorsPath = resolve(
 );
 const exportRoot = resolve(process.cwd(), "../build/atlas-runtime");
 const atlasDbPath = resolve(process.cwd(), "../data/atlas.db");
+const fixtureDbPath = resolve(
+  process.cwd(),
+  "../tests/fixtures/atlas/runtime_shards_fixture.db",
+);
 const hasAtlasDb = existsSync(atlasDbPath);
 const hasExportRoot = existsSync(resolve(exportRoot, "atlas/current.json"));
+const hasFixtureDb = existsSync(fixtureDbPath);
+
+function nodeHttp(fetchBytes: AtlasFetch, options?: { pointerTtlMs?: number; now?: () => number }) {
+  return createNodeHttpAtlasDataSource(fetchBytes, options);
+}
 
 const FIXTURE_SLUGS = [
   "прапор", // rich lemma
@@ -57,7 +74,7 @@ describe("AtlasDataSource runtime shards", () => {
       resetAtlasPayloadCacheForTests();
       resetSqliteAtlasDataSourceCachesForTests();
       const sqlite = new SqliteAtlasDataSource();
-      const http = new HttpAtlasDataSource(createFileAtlasFetch(exportRoot));
+      const http = nodeHttp(createFileAtlasFetch(exportRoot));
 
       for (const slug of FIXTURE_SLUGS) {
         const left = await sqlite.getEntry(slug);
@@ -81,7 +98,7 @@ describe("AtlasDataSource runtime shards", () => {
       resetSqliteAtlasDataSourceCachesForTests();
       const cache = getAtlasPayloadCache();
       const sqlite = new SqliteAtlasDataSource();
-      const http = new HttpAtlasDataSource(createFileAtlasFetch(exportRoot));
+      const http = nodeHttp(createFileAtlasFetch(exportRoot));
       const { default: WordAtlasArticle } = await import(
         "@site/src/lexicon/WordAtlasArticle.astro"
       );
@@ -135,7 +152,7 @@ describe("AtlasDataSource runtime shards", () => {
   test.skipIf(!hasExportRoot)(
     "search exact/prefix fixtures match legacy ranker and keep families separate",
     async () => {
-      const http = new HttpAtlasDataSource(createFileAtlasFetch(exportRoot));
+      const http = nodeHttp(createFileAtlasFetch(exportRoot));
       const articles = JSON.parse(
         readFileSync(resolve(process.cwd(), "src/data/lexicon-search-index.json"), "utf-8"),
       );
@@ -175,7 +192,7 @@ describe("AtlasDataSource runtime shards", () => {
   );
 
   test.skipIf(!hasExportRoot)("version mismatch never combines two manifests", async () => {
-    const http = new HttpAtlasDataSource(createFileAtlasFetch(exportRoot));
+    const http = nodeHttp(createFileAtlasFetch(exportRoot));
     await expect(http.getEntry("прапор", { expectedVersion: "atlas-v1-deadbeefdeadbeef" })).rejects.toBeInstanceOf(
       AtlasDataSourceError,
     );
@@ -188,7 +205,7 @@ describe("AtlasDataSource runtime shards", () => {
   });
 
   test.skipIf(!hasExportRoot)("deck parts share one deckVersion", async () => {
-    const http = new HttpAtlasDataSource(createFileAtlasFetch(exportRoot));
+    const http = nodeHttp(createFileAtlasFetch(exportRoot));
     const deck = await http.getDeck("A1");
     expect(deck.kind).toBe("deck");
     if (deck.kind !== "deck") return;
@@ -208,7 +225,7 @@ describe("AtlasDataSource runtime shards", () => {
     };
 
     // Locate the leaf that actually holds прапор, then corrupt that object.
-    const httpProbe = new HttpAtlasDataSource(createFileAtlasFetch(exportRoot));
+    const httpProbe = nodeHttp(createFileAtlasFetch(exportRoot));
     const before = await httpProbe.getEntry("прапор");
     expect(before.kind).toBe("entry");
 
@@ -235,13 +252,337 @@ describe("AtlasDataSource runtime shards", () => {
     const original = readFileSync(shardPath);
     const corrupted = Buffer.from(original);
     corrupted[0] = (corrupted[0] + 1) % 256;
-    const { writeFileSync } = await import("node:fs");
     writeFileSync(shardPath, corrupted);
-    const http = new HttpAtlasDataSource(createFileAtlasFetch(exportRoot));
+    const http = nodeHttp(createFileAtlasFetch(exportRoot));
     try {
       await expect(http.getEntry("прапор")).rejects.toBeInstanceOf(AtlasDataSourceError);
     } finally {
       writeFileSync(shardPath, original);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hermetic Sol F003 / F004 / F005 coverage (committed fixture export — always on)
+// ---------------------------------------------------------------------------
+
+async function sha256HexBuf(data: Uint8Array): Promise<string> {
+  const copy = new Uint8Array(data.byteLength);
+  copy.set(data);
+  const digest = await crypto.subtle.digest("SHA-256", copy);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+describe("HttpAtlasDataSource Sol F003/F004/F005 (hermetic)", () => {
+  test("admitsSearchArticle includes gloss-only hits (F005 unit)", () => {
+    const row: SearchRow = {
+      l: "достовірний",
+      s: "достовірний",
+      g: "reliable, trustworthy",
+      r: "dostovirnyy",
+    };
+    expect(admitsSearchArticle(row, normalizeAtlasText("trustworthy"))).toBe(true);
+    expect(admitsSearchArticle(row, normalizeAtlasText("достовірний"))).toBe(true);
+    expect(admitsSearchArticle(row, normalizeAtlasText("zzzz-nope"))).toBe(false);
+  });
+
+  test("pointer rollover v1→v2 on reused instance; in-flight request pins version (F003)", async () => {
+    const v1 = "atlas-v1-aaaaaaaaaaaaaaaa";
+    const v2 = "atlas-v1-bbbbbbbbbbbbbbbb";
+    const slug = "alpha";
+
+    const entryV1 = {
+      schema: "atlas-entry-shard",
+      schemaVersion: 1,
+      dataVersion: v1,
+      records: [
+        {
+          slug,
+          kind: "article",
+          entry: { lemma: "alpha-v1", url_slug: slug },
+          aliases: [],
+          relations: [],
+          provenance: [],
+          renderContext: { componentLinks: [], practiceLevels: [] },
+        },
+      ],
+    };
+    const entryV2 = {
+      ...entryV1,
+      dataVersion: v2,
+      records: [
+        {
+          ...entryV1.records[0],
+          entry: { lemma: "alpha-v2", url_slug: slug },
+        },
+      ],
+    };
+
+    async function entryObject(payload: typeof entryV1, id: string, url: string) {
+      const raw = Buffer.from(`${JSON.stringify(payload)}\n`, "utf-8");
+      const compressed = new Uint8Array(gzipSync(raw, { level: 9 }));
+      return {
+        descriptor: {
+          id,
+          url,
+          count: 1,
+          bytes: compressed.byteLength,
+          uncompressedBytes: raw.byteLength,
+          sha256: await sha256HexBuf(compressed),
+          jsonSha256: await sha256HexBuf(raw),
+          encoding: "gzip" as const,
+        },
+        bytes: compressed,
+      };
+    }
+
+    const shardV1 = await entryObject(entryV1, "e0", "entries/e0.json.gz");
+    const shardV2 = await entryObject(entryV2, "e0", "entries/e0.json.gz");
+
+    // Fixed hash leaf — any slug resolves to the single shard.
+    const entryTree = { shardId: "e0" };
+
+    function manifestFor(
+      version: string,
+      shard: { descriptor: Record<string, unknown> },
+    ) {
+      return {
+        schema: "atlas-runtime-manifest",
+        schemaVersion: 1,
+        dataVersion: version,
+        generatedAt: "2026-01-01T00:00:00+00:00",
+        entries: {
+          tree: entryTree,
+          shards: { e0: shard.descriptor },
+        },
+        search: {
+          articles: { tree: { shardId: "s0" }, shards: {} },
+          aliases: { tree: { shardId: "a0" }, shards: {} },
+        },
+        decks: { levels: {} },
+      };
+    }
+
+    const files = new Map<string, Uint8Array>([
+      [
+        "current.json",
+        new TextEncoder().encode(
+          JSON.stringify({
+            schema: "atlas-current",
+            schemaVersion: 1,
+            dataVersion: v1,
+            generatedAt: "2026-01-01T00:00:00+00:00",
+            manifestUrl: `versions/${v1}/manifest.json`,
+          }),
+        ),
+      ],
+      [
+        `versions/${v1}/manifest.json`,
+        new TextEncoder().encode(JSON.stringify(manifestFor(v1, shardV1))),
+      ],
+      [`versions/${v1}/entries/e0.json.gz`, shardV1.bytes],
+      [
+        `versions/${v2}/manifest.json`,
+        new TextEncoder().encode(JSON.stringify(manifestFor(v2, shardV2))),
+      ],
+      [`versions/${v2}/entries/e0.json.gz`, shardV2.bytes],
+    ]);
+
+    let clock = 1_000_000;
+
+    const fetchStub: AtlasFetch = async (url) => {
+      const bytes = files.get(url);
+      if (!bytes) throw new AtlasDataSourceError("unavailable", `missing ${url}`);
+      return bytes;
+    };
+
+    const http = nodeHttp(fetchStub, {
+      pointerTtlMs: 60_000,
+      now: () => clock,
+    });
+
+    const first = await http.getEntry(slug);
+    expect(first.kind).toBe("entry");
+    if (first.kind === "entry") {
+      expect(first.version).toBe(v1);
+      expect(first.record.entry.lemma).toBe("alpha-v1");
+    }
+
+    // Rollover current.json to v2; within TTL the instance would stay stale —
+    // advance clock past TTL so the next request re-resolves the pointer.
+    files.set(
+      "current.json",
+      new TextEncoder().encode(
+        JSON.stringify({
+          schema: "atlas-current",
+          schemaVersion: 1,
+          dataVersion: v2,
+          generatedAt: "2026-01-02T00:00:00+00:00",
+          manifestUrl: `versions/${v2}/manifest.json`,
+        }),
+      ),
+    );
+    clock += 60_001;
+
+    const second = await http.getEntry(slug);
+    expect(second.kind).toBe("entry");
+    if (second.kind === "entry") {
+      expect(second.version).toBe(v2);
+      expect(second.record.entry.lemma).toBe("alpha-v2");
+    }
+
+    // Concurrent pin: start a request on v2, flip pointer mid-flight to a fake v3
+    // that has no shards — the in-flight request must still finish on v2 URLs only.
+    let releaseShard!: () => void;
+    const shardGate = new Promise<void>((resolveGate) => {
+      releaseShard = resolveGate;
+    });
+    const fetchedDuringPin: string[] = [];
+    let v2ShardSeen = false;
+    const pinFetch: AtlasFetch = async (url) => {
+      fetchedDuringPin.push(url);
+      if (url === `versions/${v2}/entries/e0.json.gz` && !v2ShardSeen) {
+        v2ShardSeen = true;
+        await shardGate;
+      }
+      const bytes = files.get(url);
+      if (!bytes) throw new AtlasDataSourceError("unavailable", `missing ${url}`);
+      return bytes;
+    };
+    // pointerTtlMs: 0 re-resolves current every request; pin still holds for in-flight.
+    // Ensure current still points at v2 before the gated request starts.
+    files.set(
+      "current.json",
+      new TextEncoder().encode(
+        JSON.stringify({
+          schema: "atlas-current",
+          schemaVersion: 1,
+          dataVersion: v2,
+          generatedAt: "2026-01-02T00:00:00+00:00",
+          manifestUrl: `versions/${v2}/manifest.json`,
+        }),
+      ),
+    );
+    const pinned = nodeHttp(pinFetch, { pointerTtlMs: 0, now: () => clock });
+    const inflight = pinned.getEntry(slug);
+    // Wait until the gated shard fetch is in flight (session already pinned to v2).
+    for (let i = 0; i < 100 && !v2ShardSeen; i += 1) {
+      await new Promise((r) => setTimeout(r, 2));
+    }
+    expect(v2ShardSeen).toBe(true);
+
+    files.set(
+      "current.json",
+      new TextEncoder().encode(
+        JSON.stringify({
+          schema: "atlas-current",
+          schemaVersion: 1,
+          dataVersion: "atlas-v1-cccccccccccccccc",
+          generatedAt: "2026-01-03T00:00:00+00:00",
+          manifestUrl: "versions/atlas-v1-cccccccccccccccc/manifest.json",
+        }),
+      ),
+    );
+    releaseShard();
+    const pinnedResult = await inflight;
+    expect(pinnedResult.kind).toBe("entry");
+    if (pinnedResult.kind === "entry") {
+      expect(pinnedResult.version).toBe(v2);
+      expect(pinnedResult.record.entry.lemma).toBe("alpha-v2");
+    }
+    // In-flight must not have fetched any v3 asset.
+    expect(fetchedDuringPin.some((u) => u.includes("cccccccccccccccc"))).toBe(false);
+    expect(fetchedDuringPin.some((u) => u.includes(v2))).toBe(true);
+  });
+
+  test("gloss-only query matches SqliteAtlasDataSource over fixture export (F005)", async () => {
+    expect(hasFixtureDb).toBe(true);
+
+    const outDir = mkdtempSync(resolve(tmpdir(), "atlas-fixture-export-"));
+    try {
+      const pySnippet = [
+        "from pathlib import Path",
+        "from scripts.atlas.export_runtime_shards import export_runtime_shards",
+        `export_runtime_shards(db_path=Path(${JSON.stringify(fixtureDbPath)}), out_dir=Path(${JSON.stringify(outDir)}), include_decks=False, deck_dir=None, verify=True)`,
+      ].join("; ");
+      const exportResult = spawnSync(
+        resolve(process.cwd(), "../.venv/bin/python"),
+        ["-c", pySnippet],
+        {
+          cwd: resolve(process.cwd(), ".."),
+          encoding: "utf-8",
+          maxBuffer: 20 * 1024 * 1024,
+        },
+      );
+      if (exportResult.status !== 0) {
+        throw new Error(
+          `fixture export failed: ${exportResult.stderr || exportResult.stdout || exportResult.status}`,
+        );
+      }
+
+      const glossQuery = "trustworthy"; // distinctive: only in достовірний gloss, not lemma/roman
+      const http = nodeHttp(createFileAtlasFetch(outDir), { pointerTtlMs: 0 });
+
+      // Isolate Sqlite to fixture DB by temporarily hiding dual-publication search artifacts
+      // so it projects search rows from the same fixture DB the export used.
+      const searchIndex = resolve(process.cwd(), "src/data/lexicon-search-index.json");
+      const searchAliases = resolve(process.cwd(), "src/data/lexicon-search-aliases.json");
+      const bakIndex = `${searchIndex}.f005-bak`;
+      const bakAliases = `${searchAliases}.f005-bak`;
+      const prevAtlasDb = process.env.ATLAS_DB_PATH;
+      let movedIndex = false;
+      let movedAliases = false;
+      try {
+        if (existsSync(searchIndex)) {
+          renameSync(searchIndex, bakIndex);
+          movedIndex = true;
+        }
+        if (existsSync(searchAliases)) {
+          renameSync(searchAliases, bakAliases);
+          movedAliases = true;
+        }
+        process.env.ATLAS_DB_PATH = fixtureDbPath;
+        resetSqliteAtlasDataSourceCachesForTests();
+        resetAtlasPayloadCacheForTests();
+        const sqlite = new SqliteAtlasDataSource();
+
+        const left = await sqlite.search(glossQuery, { limit: 12 });
+        const right = await http.search(glossQuery, { limit: 12 });
+
+        expect(left.results.length).toBeGreaterThan(0);
+        expect(right.results.map((item) => item.article.s)).toEqual(
+          left.results.map((item) => item.article.s),
+        );
+        expect(right.results.map((item) => item.article.l)).toEqual(
+          left.results.map((item) => item.article.l),
+        );
+        // Gloss-only: lemma/roman must not be the admission path for the hit.
+        for (const item of right.results) {
+          const lemma = normalizeAtlasText(item.article.l);
+          const roman = item.article.r ? normalizeAtlasText(item.article.r) : "";
+          const nq = normalizeAtlasText(glossQuery);
+          expect(lemma === nq || lemma.startsWith(nq) || roman.startsWith(nq)).toBe(false);
+          expect(normalizeAtlasText(item.article.g ?? "").includes(nq)).toBe(true);
+        }
+      } finally {
+        if (movedIndex && existsSync(bakIndex)) renameSync(bakIndex, searchIndex);
+        if (movedAliases && existsSync(bakAliases)) renameSync(bakAliases, searchAliases);
+        if (prevAtlasDb === undefined) delete process.env.ATLAS_DB_PATH;
+        else process.env.ATLAS_DB_PATH = prevAtlasDb;
+        resetSqliteAtlasDataSourceCachesForTests();
+        resetAtlasPayloadCacheForTests();
+      }
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test("core module has no static node: imports (F004 source guard)", () => {
+    const src = readFileSync(
+      resolve(process.cwd(), "src/lib/lexicon/http-atlas-data-source.ts"),
+      "utf-8",
+    );
+    expect(src).not.toMatch(/from\s+["']node:/);
+    expect(src).not.toMatch(/require\(["']node:/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes three **CONFIRMED** Sol review findings in `HttpAtlasDataSource` (merged in PR #5282). Design target change: dictionary shards are **GitHub Release assets fetched on demand by the browser** — no edge worker, no Node in production. The reader must be browser-portable (F004 is required, not cosmetic).

### F003 — pointer/manifest cached forever → stale after release rollover (P1)

**Failure scenario:** A long-lived client instance memoized `current.json` + manifest unconditionally. After a new release flips the pointer to `v2`, the same instance kept serving `v1` forever (stale shards / wrong `dataVersion`).

**Fix:** Re-resolve `current.json` behind a short TTL (default **60s**, injectable). Reload the manifest when `dataVersion` changes. Within one logical request (`getEntry` / `search` / `getDeck`), pin a `PinnedAtlasSession` (`manifest` + `versionDir`) end-to-end so a mid-request rollover cannot mix v1/v2 shard URLs. Existing `version_mismatch` retry-once guard retained.

### F004 — static `node:*` imports → not browser-loadable (P1, required)

**Failure scenario:** Static `node:zlib` / `node:fs` / `node:path` imports made the module unloadable in the browser bundle for client-rendered word pages.

**Fix:**
- Core `http-atlas-data-source.ts`: **zero** `node:*` imports. Gzip via `DecompressionStream("gzip")` + pluggable `decompress` hook.
- New Node-only `http-atlas-node.ts`: `createFileAtlasFetch`, `nodeGunzip`, `createNodeHttpAtlasDataSource`.
- npm script `check:atlas-browser-bundle` for repeatable esbuild browser-bundle verification.
- Tests import Node helpers from `http-atlas-node` (no re-export of Node code from core).

### F005 — search drops gloss-only hits (P1)

**Failure scenario:** Article admission only allowed lemma exact/prefix or roman prefix. The exporter indexes glosses and `rankSearchResults` scores gloss hits — HTTP search silently lost gloss-only results that `SqliteAtlasDataSource` returns.

**Fix:** `admitsSearchArticle` admits lemma/roman exact·prefix·substring **and** gloss substring before ranking (mirrors ranker surfaces Sqlite uses).

## Files

| File | Change |
| --- | --- |
| `site/src/lib/lexicon/http-atlas-data-source.ts` | TTL pointer resolve, session pin, gloss admission, browser gzip |
| `site/src/lib/lexicon/http-atlas-node.ts` | **new** Node file fetch + gunzipSync wiring |
| `site/tests/unit/atlas-runtime-shards.test.ts` | hermetic F003/F005 tests; Node import path |
| `site/package.json` | `check:atlas-browser-bundle` script |

## Verification preamble (raw tool output)

### vitest green (incl. new tests)

```text
$ cd site && npx vitest run tests/unit/atlas-runtime-shards.test.ts

 RUN  v4.1.9
 ✓ tests/unit/atlas-runtime-shards.test.ts (11 tests | 6 skipped) 63ms

 Test Files  1 passed (1)
      Tests  5 passed | 6 skipped (11)
```

Unconditional new tests:
- F003: pointer rollover v1→v2 on reused instance + concurrent in-flight pin
- F005 unit: `admitsSearchArticle` gloss-only
- F005 parity: gloss query `trustworthy` → identical Sqlite vs Http over fixture export
- F004 source guard: core has no static `node:` imports

Existing real-DB/export `test.skipIf` gating left unchanged (F006 follow-up).

### type-safe (`npx tsc --noEmit`)

```text
$ cd site && npx tsc --noEmit 2>&1 | rg "src/lib/lexicon/http-atlas" || echo "PASS: zero tsc errors in http-atlas modules"
PASS: zero tsc errors in http-atlas modules
```

Repo-wide `tsc` still reports pre-existing errors outside this change (activity-kit react types, unrelated unit tests). **No errors** in `http-atlas-data-source.ts` / `http-atlas-node.ts`.

### browser-portable (F004)

```text
$ cd site && npx esbuild src/lib/lexicon/http-atlas-data-source.ts --bundle --platform=browser --external:astro* --outfile=/dev/null

  ../../../../../../../../../dev/null  18.6kb

⚡ Done in 9ms
```

```text
$ cd site && npm run check:atlas-browser-bundle

  ../../../../../../../../../dev/null  18.6kb

⚡ Done in 2ms
```

(Contrast: bundling `http-atlas-node.ts` for browser correctly fails on `node:fs` / `node:path` / `node:zlib` — Node-only by design.)

### rollover works (F003)

New vitest (always on): stub fetch serves v1 → exercise → flip `current.json` to v2 + advance clock past TTL → **same instance** returns v2 data. Concurrent in-flight request gated on v2 shard while pointer flips to missing v3 → finishes on v2 only; no v3 URLs fetched.

### gloss search parity (F005)

New vitest (always on): exports `tests/fixtures/atlas/runtime_shards_fixture.db` to a temp tree, isolates Sqlite to that DB (hides dual-publication search JSON for the test duration), query `"trustworthy"` (gloss-only for `достовірний`) — Sqlite and Http return the same result set + order; hit is not lemma/roman admitted.

## Out of scope

- F006 (`test.skipIf` gating of real-DB parity tests)
- Merge / auto-merge / self-review (orchestrator review gate)