### PR TITLE
fix(orchestration): retire unsatisfiable legacy native plans at identity migration

### DIFF
--- a/scripts/orchestration/task_family/rollover_registry.py
+++ b/scripts/orchestration/task_family/rollover_registry.py
@@ -439,6 +439,19 @@ def _effective_state_from_lease(state_root: Path, lease: Mapping[str, Any]) -> t
         return RolloverState.RESUMED, None
     if isinstance(native.get("replacement_thread_id"), str) and native["replacement_thread_id"].strip():
         return RolloverState.REPLACEMENT_CREATED, None
+    if not native:
+        # Non-native lease: either prepared without a native plan (current
+        # prepare for a harness with no native adapter) or its unsatisfiable
+        # legacy plan was retired at identity migration and preserved under
+        # ``native_lifecycle_retired``. The replacement binds through the
+        # recorded fallback, never a native create — projecting
+        # AWAITING_NATIVE_CREATE here would tell operators and automation to
+        # attempt a native create that can never be authorized.
+        identity = replacement.get("identity")
+        bound_id = identity.get("replacement_task_id") if isinstance(identity, Mapping) else None
+        if isinstance(bound_id, str) and bound_id.strip():
+            return RolloverState.REPLACEMENT_CREATED, None
+        return RolloverState.PREPARED, None
     return RolloverState.AWAITING_NATIVE_CREATE, None
 
 

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -620,6 +620,45 @@ def write_text_atomic(path: Path, text: str) -> None:
     os.replace(tmp, path)
 
 
+def _retire_unsatisfiable_native_plan(state: dict[str, Any], *, now: datetime) -> bool:
+    """Retire a pristine legacy native plan that a non-native harness can never execute.
+
+    Leases prepared before the identity envelope carried an unconditional
+    ``native_lifecycle`` block. Deterministic legacy migration assigns the
+    ``<harness>-legacy`` slug, which is never native-capable, so a pristine
+    ``awaiting_native_create`` block is unsatisfiable: only ``register-created``
+    can bind it, and that path requires a native adapter the transition denies.
+    Converge the lease to the honest non-native fallback shape (what current
+    ``prepare`` emits for such a harness) and keep the retired block as durable
+    evidence. Touched plans (bound, failed, or supersession-pending) and
+    native-capable transitions are never retired here.
+    """
+    replacement = state.get("replacement")
+    if not isinstance(replacement, dict):
+        return False
+    native = replacement.get("native_lifecycle")
+    if not isinstance(native, dict):
+        return False
+    transition = replacement.get("title_transition")
+    if not isinstance(transition, dict) or transition.get("native_title_supported") is not False:
+        return False
+    if native.get("status") != "awaiting_native_create" or native.get("replacement_thread_id") is not None:
+        return False
+    updated_replacement = dict(replacement)
+    updated_replacement.pop("native_lifecycle")
+    updated_replacement["native_lifecycle_retired"] = {
+        **native,
+        "status": "retired_non_native_harness",
+        "retired_at": isoformat_z(now),
+        "reason": (
+            "legacy native plan is unsatisfiable on a harness without a native adapter; "
+            "converged to the recorded non-native fallback path"
+        ),
+    }
+    state["replacement"] = updated_replacement
+    return True
+
+
 def normalize_identity_state(
     state: dict[str, Any], *, agent: str, now: datetime
 ) -> tuple[dict[str, Any], bool]:
@@ -643,7 +682,8 @@ def normalize_identity_state(
             raise ValueError(f"legacy rollover cannot reserve its identity receipt: {exc}") from exc
         replacement.setdefault("identity_receipt_path", paths["identity_receipt_path"])
         normalized["replacement"] = replacement
-    return normalized, migrated
+    retired = _retire_unsatisfiable_native_plan(normalized, now=now)
+    return normalized, migrated or retired
 
 
 def write_rollover_state(

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -2471,7 +2471,9 @@ def _cmd_repair_native_intent_locked(args: argparse.Namespace) -> int:
         state_error = state_error_payload(state, state_path, state_root)
         if state_error:
             raise ValueError(state_error["error"])
-        state, _ = normalize_identity_state(state, agent=agent, now=utc_now())
+        state, changed = normalize_identity_state(state, agent=agent, now=utc_now())
+        if changed:
+            write_rollover_state(state_path, state_root, state, already_locked=True)
         replacement = dict(state.get("replacement") or {})
         if replacement.get("rollover_id") != args.rollover_id:
             raise ValueError("--rollover-id does not match the isolated rollover")
@@ -2483,6 +2485,11 @@ def _cmd_repair_native_intent_locked(args: argparse.Namespace) -> int:
         source_thread_id = active.get("thread_id")
         display = replacement.get("display")
         native = replacement.get("native_lifecycle")
+        if not isinstance(native, dict) and isinstance(replacement.get("native_lifecycle_retired"), dict):
+            raise ValueError(
+                "native plan was retired as unsatisfiable for a non-native harness; "
+                "no native-intent repair applies — bind the replacement and resume instead"
+            )
         if (
             not isinstance(lineage_id, str)
             or not isinstance(generation, int)

--- a/tests/orchestration/task_family/test_rollover_registry.py
+++ b/tests/orchestration/task_family/test_rollover_registry.py
@@ -505,6 +505,51 @@ def test_incident_shape_allows_exact_aef219_and_leaves_unrelated_packets_untouch
         assert current["state"] == registry.RolloverState.AWAITING_NATIVE_CREATE.value
 
 
+def _retire_native_plan(lease: dict) -> dict:
+    """Model a lease whose unsatisfiable legacy native plan was retired at migration."""
+    retired = lease["replacement"].pop("native_lifecycle")
+    lease["replacement"]["native_lifecycle_retired"] = {
+        **retired,
+        "status": "retired_non_native_harness",
+        "retired_at": "2026-07-16T12:00:00Z",
+        "reason": "legacy native plan is unsatisfiable on a harness without a native adapter",
+    }
+    return lease
+
+
+def test_retired_non_native_lease_projects_prepared_not_awaiting_native_create(tmp_path: Path) -> None:
+    lease = _retire_native_plan(
+        _lease(
+            agent="claude-infra",
+            lineage="lineage-retired-unbound",
+            rollover_id="rollover-retired-unbound",
+            source="source-retired-unbound",
+        )
+    )
+
+    record = _sync(tmp_path, lease)
+
+    assert lease["replacement"]["title_transition"]["native_title_supported"] is False
+    assert record["state"] == registry.RolloverState.PREPARED.value
+
+
+def test_retired_non_native_lease_with_bound_fallback_projects_replacement_created(tmp_path: Path) -> None:
+    lease = _retire_native_plan(
+        _lease(
+            agent="claude-infra",
+            lineage="lineage-retired-bound",
+            rollover_id="rollover-retired-bound",
+            source="source-retired-bound",
+            replacement="replacement-fallback-bound",
+        )
+    )
+
+    record = _sync(tmp_path, lease)
+
+    assert lease["replacement"]["title_transition"]["state"] == "fallback_recorded"
+    assert record["state"] == registry.RolloverState.REPLACEMENT_CREATED.value
+
+
 def test_stale_age_is_read_only_and_never_deletes_packet(tmp_path: Path) -> None:
     record = _sync(
         tmp_path,

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -900,6 +900,39 @@ def test_touched_legacy_native_plan_is_never_retired():
     assert "native_lifecycle_retired" not in normalized["replacement"]
 
 
+def test_repair_refuses_retired_native_plan_with_clear_error_and_persists_retirement(
+    tmp_path: Path, capsys
+) -> None:
+    state = _legacy_lease_with_unconditional_native_plan(agent="claude-infra")
+    lineage_id = state["lineage_id"]
+    rollover_id = state["replacement"]["rollover_id"]
+    state_path = th.default_state_path("claude-infra", lineage_id)
+    th.write_json_atomic(tmp_path / state_path, state)
+
+    command = [
+        "--repo-root",
+        str(tmp_path),
+        "repair-native-intent",
+        "--agent",
+        "claude-infra",
+        "--lineage-id",
+        lineage_id,
+        "--rollover-id",
+        rollover_id,
+        "--evidence",
+        "Legacy non-native packet; probing the repair path.",
+    ]
+    assert th.main(command) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert "retired as unsatisfiable" in payload["error"]
+
+    persisted = json.loads((tmp_path / state_path).read_text(encoding="utf-8"))
+    assert "native_lifecycle" not in persisted["replacement"]
+    assert persisted["replacement"]["native_lifecycle_retired"]["status"] == "retired_non_native_harness"
+    identity_receipt = tmp_path / persisted["replacement"]["identity_receipt_path"]
+    assert identity_receipt.exists()
+
+
 def test_prepare_rejects_dirty_source_checkout_without_writing_packet(tmp_path: Path, capsys, monkeypatch):
     dirty_snapshot = sample_snapshot(tmp_path)
     dirty_snapshot["git"]["modified_files"] = [{"status": "??", "path": "untracked.txt"}]

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -786,6 +786,120 @@ def test_live_lease_keeps_legacy_v2_pending_packet_compatible():
     assert replacement["identity"]["visible_title"] == "thread-rollover — Recover predecessor task context"
 
 
+def _legacy_lease_with_unconditional_native_plan(*, agent: str) -> dict:
+    """Model a pre-identity-envelope lease: no identity, native_lifecycle always present."""
+    state = prepared(agent=agent)
+    state["replacement"].pop("display")
+    state["replacement"].pop("identity")
+    state["replacement"].pop("title_transition")
+    state["replacement"].pop("identity_receipt_path")
+    assert state["replacement"]["native_lifecycle"]["status"] == "awaiting_native_create"
+    return state
+
+
+@pytest.mark.parametrize("agent", ["claude-infra", "codex"])
+def test_legacy_migration_retires_unsatisfiable_native_plan_and_unbricks_resume(agent: str):
+    state = _legacy_lease_with_unconditional_native_plan(agent=agent)
+    original_native = dict(state["replacement"]["native_lifecycle"])
+
+    normalized, changed = th.normalize_identity_state(state, agent=agent, now=datetime(2026, 7, 16, 12, 0, tzinfo=UTC))
+
+    assert changed is True
+    replacement = normalized["replacement"]
+    assert replacement["title_transition"]["native_title_supported"] is False
+    assert "native_lifecycle" not in replacement
+    retired = replacement["native_lifecycle_retired"]
+    assert retired["status"] == "retired_non_native_harness"
+    assert retired["family_id"] == original_native["family_id"]
+    assert retired["operation_id"] == original_native["operation_id"]
+    assert retired["replacement_thread_id"] is None
+    assert retired["retired_at"] == "2026-07-16T12:00:00Z"
+    assert "unsatisfiable" in retired["reason"]
+
+    identity, transition = task_identity.bind_replacement(
+        replacement["identity"],
+        replacement["title_transition"],
+        replacement_task_id="new-thread-1",
+        evidence="harness binding receipt for regression test",
+        now="2026-07-16T12:00:01Z",
+    )
+    replacement["identity"] = identity
+    replacement["title_transition"] = transition
+
+    resumed = th.resume_state(
+        normalized,
+        rollover_id=replacement["rollover_id"],
+        replacement_thread_id="new-thread-1",
+        now=datetime(2026, 7, 16, 12, 0, 2, tzinfo=UTC),
+    )
+    assert resumed["replacement"]["status"] == "resumed"
+    assert resumed["replacement"]["resumed_thread_id"] == "new-thread-1"
+
+
+def test_already_migrated_fallback_lease_still_retires_orphan_native_plan():
+    """A lease migrated+bound by pre-fix code keeps its orphan block; normalize must retire it."""
+    state = _legacy_lease_with_unconditional_native_plan(agent="claude-infra")
+    first, _ = th.normalize_identity_state(state, agent="claude-infra", now=datetime(2026, 7, 16, 12, 0, tzinfo=UTC))
+    replacement = first["replacement"]
+    # Simulate the pre-fix migration outcome: identity bound via fallback, orphan block intact.
+    identity, transition = task_identity.bind_replacement(
+        replacement["identity"],
+        replacement["title_transition"],
+        replacement_task_id="new-thread-2",
+        evidence="harness binding receipt recorded before the fix",
+        now="2026-07-16T12:00:01Z",
+    )
+    replacement["identity"] = identity
+    replacement["title_transition"] = transition
+    replacement["native_lifecycle"] = dict(replacement["native_lifecycle_retired"])
+    replacement["native_lifecycle"]["status"] = "awaiting_native_create"
+    del replacement["native_lifecycle_retired"]
+
+    normalized, changed = th.normalize_identity_state(
+        first, agent="claude-infra", now=datetime(2026, 7, 16, 12, 0, 3, tzinfo=UTC)
+    )
+
+    assert changed is True
+    assert "native_lifecycle" not in normalized["replacement"]
+    assert normalized["replacement"]["native_lifecycle_retired"]["status"] == "retired_non_native_harness"
+    resumed = th.resume_state(
+        normalized,
+        rollover_id=normalized["replacement"]["rollover_id"],
+        replacement_thread_id="new-thread-2",
+        now=datetime(2026, 7, 16, 12, 0, 4, tzinfo=UTC),
+    )
+    assert resumed["replacement"]["status"] == "resumed"
+
+
+def test_native_capable_packet_is_never_retired_and_resume_stays_gated():
+    state = prepared(agent="codex")  # current prepare: codex-app harness, native-capable
+
+    normalized, changed = th.normalize_identity_state(state, agent="codex", now=datetime(2026, 7, 16, 12, 0, tzinfo=UTC))
+
+    assert changed is False
+    replacement = normalized["replacement"]
+    assert replacement["title_transition"]["native_title_supported"] is True
+    assert replacement["native_lifecycle"]["status"] == "awaiting_native_create"
+    assert "native_lifecycle_retired" not in replacement
+    with pytest.raises(ValueError, match="must be registered before resume"):
+        th.resume_state(
+            normalized,
+            rollover_id=replacement["rollover_id"],
+            replacement_thread_id="new-thread-3",
+            now=datetime(2026, 7, 16, 12, 0, 1, tzinfo=UTC),
+        )
+
+
+def test_touched_legacy_native_plan_is_never_retired():
+    state = _legacy_lease_with_unconditional_native_plan(agent="claude-infra")
+    state["replacement"]["native_lifecycle"]["status"] = "supersession_pending"
+
+    normalized, _ = th.normalize_identity_state(state, agent="claude-infra", now=datetime(2026, 7, 16, 12, 0, tzinfo=UTC))
+
+    assert normalized["replacement"]["native_lifecycle"]["status"] == "supersession_pending"
+    assert "native_lifecycle_retired" not in normalized["replacement"]
+
+
 def test_prepare_rejects_dirty_source_checkout_without_writing_packet(tmp_path: Path, capsys, monkeypatch):
     dirty_snapshot = sample_snapshot(tmp_path)
     dirty_snapshot["git"]["modified_files"] = [{"status": "??", "path": "untracked.txt"}]


### PR DESCRIPTION
## What broke (plain language)

Every thread-rollover packet prepared before the task-identity envelope landed is stuck: the new `resume` command refuses it with *"native-created replacement must be registered before resume"*, and the register path it demands is impossible for those packets. All four live pending packets fleet-wide are affected (claude-infra, claude, and both codex ones — the migrated `codex-app-legacy` harness slug is not native-capable either). The claude-infra lane hit this today while claiming its own rollover.

## Root cause

- Old `prepare` (#5233 era) wrote a `native_lifecycle` block into **every** lease, regardless of harness.
- New code (#5301/#5307) writes that block only for native-capable harnesses, and `resume` treats its **presence** as proof the replacement was native-created → it demands `register-created`.
- Legacy identity migration assigns `<harness>-legacy`, which is never in `NATIVE_TITLE_HARNESSES`, so the honest `bind-replacement` fallback records correctly — but never clears the orphaned block. Resume then fail-closes forever. `repair-native-intent` explicitly refuses this case (same-rollover receipt).

## Fix (at the migration layer)

`normalize_identity_state` now retires a **pristine** legacy native plan (`awaiting_native_create`, never bound) when the validated transition says the harness has no native adapter — converging the lease to exactly the shape current `prepare` emits for non-native harnesses. The retired block is preserved verbatim under `native_lifecycle_retired` with a reason and timestamp (no receipt edited, deleted, or reused). The change rides the existing migration persistence flag, so every command context persists it the same way it persists identity backfill.

**Never retired:** touched plans (bound / failed / `supersession_pending`) and native-capable packets — genuine native packets keep the fail-closed resume gate (covered by a test).

## Tests

- Parametrized regression (claude-infra + codex): legacy lease → migrate → orphan retired → bind-replacement → resume succeeds.
- Already-migrated-but-unretired lease (the exact shape pre-fix code left behind in production) → retire fires on next normalize → resume succeeds.
- Native-capable new packet: never retired, resume stays gated.
- Touched (`supersession_pending`) plan: never retired.
- Full sweep green: `tests/orchestration/test_thread_handoff.py` (82), plus restart-e2e, task_identity, rollover API, task_family, context_canary (199).

## Verified vs not

- ✅ State-level unbrick proven by tests; full local suite for the touched modules green; ruff clean.
- ⏳ Not yet run against the live claude-infra lease — I will complete the real packet claim (resume → strict canary → confirm-started) from main after this merges and report the result.

Refs #5233 #5301 #5307

🤖 Generated with [Claude Code](https://claude.com/claude-code)