### PR TITLE
feat(hooks): guard-pr-merge — block draft/red/unprotected-auto merges

### DIFF
--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -43,6 +43,12 @@
           },
           {
             "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-pr-merge.py\"",
+            "timeout": 30,
+            "statusMessage": "Checking PR merge safety"
+          },
+          {
+            "type": "command",
             "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-push-pytest.py\"",
             "timeout": 10,
             "statusMessage": "Checking push safety"

--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -58,9 +58,9 @@ def _command(payload: dict) -> str:
 
 # --- Command segmentation hardened against glued shell operators (#4876). ---
 # Pattern lifted from guard-secret-print.py. Hooks are standalone by design,
-# so the helpers are copied, not imported. Keep the three copies in
-# guard-branch-switch-in-main.py, guard-admin-merge.py, and
-# guard-push-pytest.py in sync.
+# so the helpers are copied, not imported. Keep the four copies in
+# guard-branch-switch-in-main.py, guard-admin-merge.py, guard-push-pytest.py,
+# and guard-pr-merge.py in sync.
 
 
 def _strip_quotes(token: str) -> str:

--- a/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
+++ b/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
@@ -136,8 +136,8 @@ def _in_main_worktree(project_root: Path) -> bool:
 # --- Command segmentation hardened against glued shell operators (#4876). ---
 # Pattern lifted from guard-secret-print.py (the reference parser among the
 # Bash guards). Hooks are standalone by design, so the helpers are copied,
-# not imported. Keep the three copies in guard-branch-switch-in-main.py,
-# guard-admin-merge.py, and guard-push-pytest.py in sync.
+# not imported. Keep the four copies in guard-branch-switch-in-main.py,
+# guard-admin-merge.py, guard-push-pytest.py, and guard-pr-merge.py in sync.
 
 
 def _strip_quotes(token: str) -> str:

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python3
+"""PreToolUse guard — block `gh pr merge` (no `--admin`) that GitHub itself cannot refuse.
+
+Reads the Claude Code hook payload on stdin (JSON with `tool_input.command`) and exits
+2 (block) when the command is a `gh pr merge ...` whose target PR is a draft, has red
+checks, has checks still running, or arms `--auto` on a branch that enforces nothing.
+
+Division of labor with guard-admin-merge.py: that hook owns `gh pr merge --admin`
+(the deliberate branch-protection bypass, #M-0.5); this hook owns every OTHER
+`gh pr merge`. Segments carrying `--admin` are skipped here so a merge is never
+double-judged.
+
+Why a hook: branch protection is a paid feature for private repos, so on the free-plan
+private repo the protection API answers 403 and NOTHING is a "required" check. Two
+consequences bit us in one day: a draft PR was squash-merged before review (#189 class),
+and two merges landed with the boundary-and-tests job RED because `--auto` only ever
+waits for *required* checks — of which that repo has none. The fleet works across repos
+with and without protection (this public repo's `main` does have it), so the guard
+decides per-repo rather than assuming either.
+
+FAIL-CLOSED: if the PR, its draft flag, its check states, or the base branch's
+protection can't be determined (gh error/timeout, no PR number), BLOCK. A merge gate
+must not let an *unverifiable* merge through; a human can always run the merge directly,
+outside the agent harness.
+
+A red check blocks regardless of whether GitHub calls it required: "required" is a
+config accident, red is red. So EVERY check counts unless its name marks it advisory.
+`--auto` is the one verdict that consults protection, because it is the one thing
+protection actually changes.
+
+SCOPE, stated honestly: this is a discipline gate, not a sandbox. It matches the shapes a
+careless merge actually takes — direct, wrapper-prefixed, `bash -c` wrapped, and xargs-fed
+`gh pr merge`, in gh's real flag spellings — and fails closed on what it cannot read. It
+cannot stop an agent that sets out to evade it: `gh api -X PUT repos/{o}/{r}/pulls/{n}/merge`
+never says "gh pr merge" at all, and neither does a Python script hitting the REST API.
+Nothing matching on Bash commands can close that, so the job is to make the CARELESS path
+refuse, not the deliberate path impossible. A shell here-string (`sh <<< '<cmd>'`) is
+likewise unread — a deliberate-only shape, documented rather than papered over.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import subprocess
+import sys
+
+# A check is treated as merge-blocking unless its name marks it explicitly advisory.
+# Same inversion as guard-admin-merge.py, and it matters more here: an allowlist of
+# "known required" names would UNDER-block, and on a repo where GitHub marks nothing
+# required, under-blocking is the entire failure mode this hook exists to close.
+ADVISORY_NAME_MARKERS = ("advisory",)
+
+_FAIL_BUCKETS = {"fail", "failure", "error", "cancel", "canceled", "cancelled", "timed_out", "action_required"}
+_PENDING_BUCKETS = {"pending", "queued", "in_progress", "waiting", "expected"}
+# Only these mean "done and fine". A non-advisory check in ANY other state — including a
+# bucket gh grows later, or a row with no bucket at all — is undeterminable, not green.
+_PASS_BUCKETS = {"pass", "success", "skipping", "skipped", "neutral"}
+
+# strconv.ParseBool's false spellings (lowercased). gh is cobra/pflag, so every boolean
+# flag also accepts `--flag=value`: `gh pr list --draft=notabool` fails with
+# "strconv.ParseBool: parsing \"notabool\": invalid syntax", which proves the =value path
+# is real and must be parsed here too — `--auto` and `--auto=true` are the same flag.
+_FALSE_VALUES = {"false", "f", "0"}
+
+
+def _flag_enabled(args: list[str], name: str) -> bool:
+    """Whether a gh boolean flag is on, in either spelling (`--auto` / `--auto=true`).
+
+    LAST occurrence wins, as pflag applies repeated flags in argument order — verified:
+    `gh pr list --draft=false --draft=true` returns draft PRs. Returning on the FIRST
+    match would read `--auto=false --auto` as off and wave through the very auto-merge
+    gh is about to arm.
+
+    A malformed value (`--auto=maybe`) makes gh itself exit non-zero, so reading it as ON
+    is the fail-closed direction: the guard judges a command that could never merge anyway.
+    """
+    enabled = False
+    for a in args:
+        if a == f"--{name}":
+            enabled = True
+        elif a.startswith(f"--{name}="):
+            enabled = a.split("=", 1)[1].strip().lower() not in _FALSE_VALUES
+    return enabled
+
+
+def _is_advisory(name: str) -> bool:
+    low = name.lower()
+    return any(m in low for m in ADVISORY_NAME_MARKERS)
+
+
+def _read_payload() -> dict:
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def _command(payload: dict) -> str:
+    return ((payload.get("tool_input") or {}).get("command") or "").strip()
+
+
+# --- Command segmentation hardened against glued shell operators (#4876). ---
+# Pattern lifted from guard-secret-print.py. Hooks are standalone by design,
+# so the helpers are copied, not imported. Keep the four copies in
+# guard-branch-switch-in-main.py, guard-admin-merge.py, guard-push-pytest.py,
+# and guard-pr-merge.py in sync.
+
+
+def _strip_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {"'", '"'}:
+        return token[1:-1]
+    return token
+
+
+def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
+    """Return (delimiter, strip_tabs) per heredoc opener; handles spaced
+    ``<< EOF`` / ``<< - EOF`` and attached ``<<-EOF`` / ``<<-'EOF'`` (#4877)."""
+    try:
+        lexer = shlex.shlex(line, posix=False, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return []
+
+    delimiters: list[tuple[str, bool]] = []
+    i = 0
+    while i < len(tokens):
+        if tokens[i] != "<<":
+            i += 1
+            continue
+        strip_tabs = False
+        j = i + 1
+        delim_tok = ""
+        if j < len(tokens):
+            nxt = tokens[j]
+            if nxt == "-":
+                strip_tabs = True
+                j += 1
+                if j < len(tokens):
+                    delim_tok = tokens[j]
+            elif nxt.startswith("-") and len(nxt) > 1:
+                strip_tabs = True
+                delim_tok = nxt[1:]
+            else:
+                delim_tok = nxt
+        delimiter = _strip_quotes(delim_tok)
+        if delimiter:
+            delimiters.append((delimiter, strip_tabs))
+        i = j + 1
+    return delimiters
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Drop heredoc BODY lines — document text is data, not commands.
+
+    Fail-CLOSED on an unclosed heredoc (#4877): a never-closing / mis-parsed
+    opener must not make a trailing real `gh pr merge` vanish. Only a heredoc
+    that actually closes has its body + closer dropped.
+    """
+    if "<<" not in command:
+        return command
+
+    lines = command.splitlines()
+    kept: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        kept.append(lines[i])
+        i += 1
+        pending = _heredoc_delimiters(lines[i - 1])
+        if not pending:
+            continue
+        body_start = i
+        while i < n and pending:
+            delimiter, strip_tabs = pending[0]
+            candidate = lines[i].lstrip("\t") if strip_tabs else lines[i]
+            if candidate == delimiter:
+                pending.pop(0)
+            i += 1
+        if pending:
+            kept.extend(lines[body_start:i])
+    return "\n".join(kept)
+
+
+def _join_line_continuations(text: str) -> str:
+    r"""Fold `\<newline>` into one logical line, as the shell does — so a
+    `\`-continued `gh pr merge` is not split across physical lines and missed.
+    Over-folding a quoted literal `\` only merges argv text."""
+    return text.replace("\\\n", "")
+
+
+def _segments(command: str) -> list[list[str]]:
+    """Quote-aware argv segments, robust to glued shell operators (#4876).
+
+    A `gh pr merge` inside a quoted commit body (`git commit -m "... gh pr merge ..."`)
+    stays one argv element — no false block. A `; gh pr merge 5` glued to a preceding
+    token is split into its own segment and inspected — no evasion. Heredoc bodies are
+    stripped (document text is not commands); `\\`-continuations are folded; each
+    logical line parses separately.
+    """
+    segs: list[list[str]] = []
+    for line in _join_line_continuations(_strip_heredoc_bodies(command)).splitlines():
+        try:
+            lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+            lexer.whitespace_split = True
+            tokens = list(lexer)
+        except ValueError:
+            continue
+        cur: list[str] = []
+        for tok in tokens:
+            if tok and all(c in ";|&()<>" for c in tok):
+                if cur:
+                    segs.append(cur)
+                    cur = []
+            else:
+                cur.append(tok)
+        if cur:
+            segs.append(cur)
+    return segs
+
+
+def _is_env_assignment(tok: str) -> bool:
+    return "=" in tok and not tok.startswith("-") and tok.split("=", 1)[0].isidentifier()
+
+
+def _skip_command_prefix(seg: list[str], i: int) -> int:
+    """Advance past wrappers / env-assignments / brace-group open so a
+    `env FOO=1 gh pr merge` or `{ gh pr merge; }` is not missed (#4877)."""
+    while i < len(seg):
+        tok = seg[i]
+        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(
+            tok
+        ):
+            i += 1
+        else:
+            break
+    return i
+
+
+_SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "fish", "busybox"}
+
+
+def _find_merge(seg: list[str], start: int) -> int | None:
+    """Index of the `gh pr merge` token run at or after `start`, else None."""
+    for j in range(start, len(seg) - 2):
+        if seg[j : j + 3] == ["gh", "pr", "merge"]:
+            return j
+    return None
+
+
+# xargs options that consume a value; everything else short is a switch.
+_XARGS_VALUE_OPTS = {"-n", "-P", "-I", "-i", "-L", "-l", "-s", "-d", "-E", "-e", "-a", "--max-args",
+                     "--max-procs", "--replace", "--max-lines", "--max-chars", "--delimiter",
+                     "--eof", "--arg-file"}
+
+
+def _invoked_start(seg: list[str]) -> tuple[int, bool]:
+    """Index where the actually-executed command begins → (index, reached_via_xargs).
+
+    `xargs` is NOT a transparent prefix: it appends stdin items to the command it runs.
+    Its own options must be stepped over, and the command boundary respected — otherwise
+    `xargs echo gh pr merge 5` (which runs `echo`) reads as a merge, while
+    `printf '5' | xargs gh pr merge --squash` (which really does merge PR 5) hides its
+    selector on stdin.
+    """
+    i = _skip_command_prefix(seg, 0)
+    if i >= len(seg) or seg[i] != "xargs":
+        return i, False
+    i += 1
+    while i < len(seg):
+        tok = seg[i]
+        if not tok.startswith("-"):
+            break
+        if tok in _XARGS_VALUE_OPTS:
+            i += 2
+            continue
+        if "=" in tok and tok.startswith("--"):
+            i += 1
+            continue
+        i += 1
+    return _skip_command_prefix(seg, i), True
+
+
+def _strip_dollar_quote(payload: str) -> str:
+    """Drop the `$` that `$'...'` / `$"..."` leave glued to a payload after tokenizing."""
+    return payload[1:] if payload.startswith("$") else payload
+
+
+def _shell_c_payload(seg: list[str]) -> str | None:
+    """The command string of a `bash -c '<cmd>'` segment, else None.
+
+    `bash -c 'gh pr merge 5 --squash'` really does merge, but the segment starts with
+    `bash`, so a direct-command match alone never sees it. The payload is a command
+    string and must be parsed as one.
+
+    Bash's `$'...'` (ANSI-C) and `$"..."` (locale) quoting survive shlex as a literal
+    `$` glued to the front — `bash -c $'gh pr merge 5'` yields `$gh pr merge 5`, whose
+    first token is `$gh`, matching nothing. Bash runs that command for real (verified),
+    so the marker is stripped rather than left to hide the merge.
+    """
+    i, _ = _invoked_start(seg)
+    if i >= len(seg):
+        return None
+    if seg[i].rsplit("/", 1)[-1] not in _SHELLS:
+        return None
+    for j in range(i + 1, len(seg) - 1):
+        tok = seg[j]
+        # `-c`, and any short cluster CONTAINING c — `bash -cx 'cmd'` runs cmd just as
+        # `-c` does, so requiring c to be last would miss a real merge (verified:
+        # `bash -cx 'echo hi'` executes and exits 0).
+        if tok.startswith("-") and not tok.startswith("--") and "c" in tok[1:]:
+            return _strip_dollar_quote(seg[j + 1])
+        if tok == "--command":
+            return _strip_dollar_quote(seg[j + 1])
+        if tok.startswith("--command="):
+            return _strip_dollar_quote(tok.split("=", 1)[1])
+    return None
+
+
+_MAX_SHELL_DEPTH = 8
+
+# Stand-in segment for a shell payload left uninspected at the recursion cap. _judge()
+# recognizes the marker and refuses outright — the cap costs a refusal, never a free
+# pass. Bounding the work must not bound the guarantee.
+#
+# It must be matched EXPLICITLY: relying on "no PR selector → block" would be wrong,
+# because _pr_ref falls back to the CURRENT BRANCH's PR, so a green current branch would
+# silently approve the payload nobody read.
+_UNREADABLE_MARKER = "--__guard_unreadable__"
+_UNPARSED = ["gh", "pr", "merge", _UNREADABLE_MARKER]
+
+
+def _judged_segments(command: str, depth: int = 0) -> list[list[str]]:
+    """Every segment worth judging, including those nested in `bash -c` payloads."""
+    segs = _segments(command)
+    out: list[list[str]] = []
+    for seg in segs:
+        out.append(seg)
+        payload = _shell_c_payload(seg)
+        if not payload:
+            continue
+        if depth >= _MAX_SHELL_DEPTH:
+            out.append(list(_UNPARSED))
+            continue
+        out.extend(_judged_segments(payload, depth + 1))
+    return out
+
+
+def _merge_args(seg: list[str]) -> list[str] | None:
+    """Return the args of a `gh pr merge ...` segment this hook judges, else None.
+
+    Skipped: `--disable-auto` (any spelling), which disarms auto-merge rather than
+    merging anything and is exactly the remedy this hook's --auto verdict asks for.
+
+    Also skipped: a bare `--admin`, which is guard-admin-merge.py's job — but ONLY that
+    exact spelling, because that is precisely what the sibling matches. `--admin=true` is
+    a real admin merge the sibling misses, so it is judged HERE rather than falling
+    between the two hooks. Judging it cannot double-judge: the sibling never sees it.
+    """
+    i, via_xargs = _invoked_start(seg)
+    if seg[i : i + 3] == ["gh", "pr", "merge"]:
+        args = seg[i + 3 :]
+    elif i > 0 and not via_xargs:
+        # A known wrapper brought its own options/operands (`sudo -u bot gh pr merge`,
+        # `env -i gh pr merge`), so the command does not begin at `i`. Find it instead of
+        # letting the merge through unjudged. Only wrapper-prefixed segments are scanned,
+        # so an unwrapped `echo gh pr merge 5` is still not treated as a merge — and the
+        # scan is skipped for xargs, whose trailing tokens are DATA for another command
+        # (`xargs echo gh pr merge 5` runs echo).
+        j = _find_merge(seg, i)
+        if j is None:
+            return None
+        args = seg[j + 3 :]
+    else:
+        return None
+    if via_xargs and _pr_selector(args) is None:
+        # xargs appends stdin items, so the real selector is not in this command at all.
+        # Falling back to the current branch's PR would judge one PR while gh merges
+        # another; refuse instead.
+        args = [*args, _UNREADABLE_MARKER]
+    flags, _ = _classify(args)
+    # `gh pr merge --help` prints help and merges nothing — reading the manual is not
+    # the offence this guard is for. --help is a bool like any other, so it gets the same
+    # spelling treatment (`--help=true`) rather than a bare-token check.
+    if _flag_enabled(flags, "help") or "-h" in flags:
+        return None
+    if "--admin" in flags or _flag_enabled(flags, "disable-auto"):
+        return None
+    return args
+
+
+# Options of `gh pr merge` that consume the NEXT argv token as their value. Their values
+# must never be mistaken for the PR selector: in `gh pr merge --subject 5`, the 5 is the
+# commit subject and the real target is the current branch's PR. Judging the wrong PR is a
+# fail-open (green PR #5 waves through a red current branch), not a cosmetic slip.
+_VALUE_FLAGS = {
+    "--subject", "-t",
+    "--body", "-b",
+    "--body-file", "-F",
+    "--match-head-commit",
+    "--author-email", "-A",
+    # Inherited by every `gh pr` subcommand: `-R, --repo [HOST/]OWNER/REPO`.
+    "--repo", "-R",
+}
+
+
+# Value-taking SHORTHANDS, by letter → canonical long name. pflag allows these inside a
+# cluster (`-st subj` = squash + subject), with the value attached (`-tsubj`, `-Rowner/repo`
+# — both verified against real gh), `=`-joined (`-t=subj`), or in the next token.
+_VALUE_SHORTS = {"t": "--subject", "b": "--body", "F": "--body-file", "A": "--author-email", "R": "--repo"}
+
+_LONG_VALUE_FLAGS = {"--subject", "--body", "--body-file", "--match-head-commit", "--author-email", "--repo"}
+
+
+def _cluster_value(tok: str) -> tuple[str | None, str | None, bool]:
+    """Inspect a shorthand cluster: → (canonical long name, attached value, needs_next).
+
+    pflag scans a cluster left to right; the first value-taking letter consumes the rest
+    of the token as its value, or the next token when nothing is attached. So in
+    `-st green-subject`, `green-subject` is the SUBJECT — treating it as the PR selector
+    would judge some other PR entirely.
+    """
+    j = 1
+    while j < len(tok):
+        ch = tok[j]
+        if ch in _VALUE_SHORTS:
+            name = _VALUE_SHORTS[ch]
+            rest = tok[j + 1 :]
+            if rest.startswith("="):
+                return name, rest[1:], False
+            if rest:
+                return name, rest, False
+            return name, None, True
+        j += 1
+    return None, None, False
+
+
+def _parse_args(args: list[str]) -> tuple[list[str], list[str], dict[str, str]]:
+    """Split argv into (flag tokens, positionals, option values keyed by long name).
+
+    pflag takes the NEXT token as a string flag's value even when it looks like a flag,
+    so `gh pr merge 5 --subject --disable-auto` is a normal merge whose subject happens
+    to be "--disable-auto". Scanning raw argv would read that value as the flag and skip
+    judging the merge entirely — a fail-open. Only tokens in FLAG position count.
+    """
+    flags: list[str] = []
+    positionals: list[str] = []
+    values: dict[str, str] = {}
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a.startswith("--"):
+            flags.append(a)
+            name, _, value = a.partition("=")
+            if value:
+                if name in _LONG_VALUE_FLAGS:
+                    values[name] = value
+                i += 1
+                continue
+            if a in _LONG_VALUE_FLAGS and i + 1 < len(args):
+                values[a] = args[i + 1]
+                i += 2
+                continue
+            i += 1
+            continue
+        if a.startswith("-") and len(a) > 1:
+            flags.append(a)
+            name, attached, needs_next = _cluster_value(a)
+            if name and attached is not None:
+                values[name] = attached
+                i += 1
+                continue
+            if name and needs_next and i + 1 < len(args):
+                values[name] = args[i + 1]
+                i += 2
+                continue
+            i += 1
+            continue
+        positionals.append(a)
+        i += 1
+    return flags, positionals, values
+
+
+def _classify(args: list[str]) -> tuple[list[str], list[str]]:
+    """(flags, positionals) — see _parse_args."""
+    flags, positionals, _ = _parse_args(args)
+    return flags, positionals
+
+
+def _repo_option(args: list[str]) -> str | None:
+    """The `-R/--repo` value, which retargets the whole command at another repo."""
+    return _parse_args(args)[2].get("--repo")
+
+
+def _repo_args(repo: str | None) -> list[str]:
+    """`--repo X` argv for gh, so every lookup targets the repo the MERGE targets."""
+    return ["--repo", repo] if repo else []
+
+
+def _pr_selector(args: list[str]) -> str | None:
+    """The `<number|url|branch>` selector of `gh pr merge`, or None for the current branch.
+
+    gh accepts all three forms, so the selector is passed through verbatim rather than
+    forced to a number — a URL selector names a PR in a possibly different repo, and
+    resolving it as "whatever PR the cwd is on" would judge a different PR than gh merges.
+    """
+    _, positionals = _classify(args)
+    return positionals[0] if positionals else None
+
+
+def _pr_ref(args: list[str], repo: str | None = None) -> str | None:
+    """The PR to judge: the explicit selector, else the current branch's PR number."""
+    selector = _pr_selector(args)
+    if selector:
+        return selector
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", *_repo_args(repo), "--json", "number", "-q", ".number"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip() or None
+
+
+def _owner_repo_from_url(url: str) -> str | None:
+    """`owner/repo` from a PR URL — the PR's BASE repo, which is what protection guards.
+
+    Taken from the PR's own `url` rather than `gh repo view` in cwd: the cwd can be a
+    different repo entirely (a URL selector), and it is the base repo — not the fork a PR
+    may come from — whose branch protection decides what `--auto` waits for.
+    """
+    m = re.match(r"https?://[^/]+/([^/]+)/([^/]+)/pull/\d+", url.strip())
+    return f"{m.group(1)}/{m.group(2)}" if m else None
+
+
+def _pr_meta(pr: str, repo: str | None = None) -> dict | None:
+    """`{isDraft, baseRefName, url}` for the PR, or None if undeterminable (→ fail-closed).
+
+    A payload without a boolean `isDraft` is undeterminable, not "not a draft" — `{}` or
+    `isDraft: null` must never read as a green light.
+    """
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", pr, *_repo_args(repo), "--json", "isDraft,baseRefName,url"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    try:
+        data = json.loads((out.stdout or "").strip() or "{}")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or not isinstance(data.get("isDraft"), bool):
+        return None
+    return data
+
+
+def _check_states(pr: str, repo: str | None = None) -> tuple[list[str], list[str]] | None:
+    """(failing, pending) non-advisory check names, or None if undeterminable."""
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "checks", pr, *_repo_args(repo), "--json", "name,bucket,state"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except Exception:
+        return None
+    text = (out.stdout or "").strip()
+    if not text:
+        # Empty output is ambiguous: a PR with zero checks (rc 0 → nothing to wait for)
+        # vs a gh error / non-existent PR (rc != 0 → fail-CLOSED block). Reading an
+        # *error* as "no failing checks" is the fail-open bug guard-admin-merge closed.
+        return ([], []) if out.returncode == 0 else None
+    try:
+        rows = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(rows, list):
+        return None
+    failing: list[str] = []
+    pending: list[str] = []
+    for r in rows:
+        if not isinstance(r, dict):
+            return None
+        name = str(r.get("name") or "")
+        if _is_advisory(name):
+            continue
+        bucket = str(r.get("bucket") or r.get("state") or "").lower()
+        if bucket in _FAIL_BUCKETS:
+            failing.append(name)
+        elif bucket in _PENDING_BUCKETS:
+            pending.append(name)
+        elif bucket not in _PASS_BUCKETS:
+            # Schema drift or a partial row on a non-advisory check. "I don't recognize
+            # this state" must never fall through to green — that is the fail-open bug
+            # this hook exists to prevent, arriving by a different door.
+            return None
+    return failing, pending
+
+
+def _base_protected(owner_repo: str, base: str) -> bool | None:
+    """True = protection with at least one required status check, False = the branch
+    enforces nothing (403 on a free plan, 404 unprotected, protection without required
+    checks, or an EMPTY required-checks list), None = undeterminable (→ fail-closed).
+
+    The empty list matters: `required_status_checks` can be present with `contexts: []`
+    and `checks: []`, which is truthy but requires nothing — auto-merge would wait for
+    nothing and merge red, exactly as on an unprotected branch. Only a non-empty list
+    gives `--auto` something to wait on.
+    """
+    try:
+        out = subprocess.run(
+            ["gh", "api", f"repos/{owner_repo}/branches/{base}/protection"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        err = f"{out.stderr or ''}{out.stdout or ''}"
+        if "HTTP 403" in err or "HTTP 404" in err or "Branch not protected" in err:
+            return False
+        return None
+    try:
+        data = json.loads((out.stdout or "").strip() or "{}")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    required = data.get("required_status_checks")
+    if not isinstance(required, dict):
+        return False
+    contexts = required.get("contexts") or []
+    checks = required.get("checks") or []
+    return bool(contexts or checks)
+
+
+_FOOTER = (
+    "GitHub will merge a draft or a red PR without complaint — branch protection stops only\n"
+    "what it was configured to require, and on a free-plan private repo it cannot be configured\n"
+    "at all. That is the gap this hook covers. If the merge is genuinely intended, a human can\n"
+    "run it directly, outside the agent harness.\n\n"
+    "Hook source: .claude/hooks/guard-pr-merge.py\n"
+)
+
+
+def _block_msg(reason: str, guidance: str) -> str:
+    return f"BLOCKED by guard-pr-merge: {reason}.\n\n{guidance}\n\n{_FOOTER}"
+
+
+def _judge(args: list[str]) -> str | None:
+    """Block message for this `gh pr merge`, or None to allow."""
+    if _UNREADABLE_MARKER in args:
+        return _block_msg(
+            "this merge's target cannot be read from the command itself",
+            "The PR is not named here — it arrives on stdin (`xargs`), or is buried under more\n"
+            "layers of `bash -c` than this guard unwraps. Judging the current branch's PR\n"
+            "instead would verify one PR while gh merges another. Run the merge with the PR\n"
+            "named explicitly (`gh pr merge <number> ...`).",
+        )
+    repo = _repo_option(args)
+    pr = _pr_ref(args, repo)
+    if not pr:
+        return _block_msg(
+            "could not determine which PR this merges",
+            "Name the PR explicitly (`gh pr merge <number> ...`) so the merge can be verified.",
+        )
+    meta = _pr_meta(pr, repo)
+    if meta is None:
+        return _block_msg(
+            f"could not verify PR {pr}'s draft status (gh error, timeout, or unexpected schema)",
+            "An unverifiable merge is refused, not assumed safe. Re-check the PR with\n"
+            "`gh pr view` and retry once gh answers.",
+        )
+    if meta.get("isDraft"):
+        return _block_msg(
+            f"PR {pr} is a DRAFT",
+            "Draft PRs are never merged or armed — a draft is by definition not review-ready\n"
+            "(the #189 incident: a draft was squash-merged before anyone reviewed it). Mark it\n"
+            "ready (`gh pr ready`) and get the review gate first.",
+        )
+    states = _check_states(pr, repo)
+    if states is None:
+        return _block_msg(
+            f"could not verify PR {pr} check states (gh error, timeout, or an unrecognized check state)",
+            "An unverifiable merge is refused, not assumed safe. Re-read the checks with\n"
+            "`gh pr checks` and retry once gh answers.",
+        )
+    failing, pending = states
+    if failing:
+        return _block_msg(
+            f"PR {pr} has FAILING checks: {', '.join(failing)}",
+            "Every non-advisory check counts, whether or not GitHub marks it required —\n"
+            "'required' is a config accident, red is red. Fix the failures and re-run;\n"
+            "do not merge over them.",
+        )
+    if _flag_enabled(_classify(args)[0], "auto"):
+        base = str(meta.get("baseRefName") or "")
+        if not base:
+            return _block_msg(
+                f"could not determine PR {pr}'s base branch",
+                "--auto can only be verified against a known base branch.",
+            )
+        owner_repo = _owner_repo_from_url(str(meta.get("url") or ""))
+        if not owner_repo:
+            return _block_msg(
+                f"could not determine which repo owns PR {pr} (no usable PR url)",
+                "--auto is refused while its safety is unverifiable.",
+            )
+        protected = _base_protected(owner_repo, base)
+        if protected is None:
+            return _block_msg(
+                f"could not determine whether {owner_repo}@{base} is protected (gh error/timeout)",
+                "--auto is refused while its safety is unverifiable.",
+            )
+        if not protected:
+            return _block_msg(
+                f"--auto on {owner_repo}@{base}, which has no required status checks",
+                "auto-merge fires regardless of checks here — merge manually after an explicit\n"
+                "all-green read. Auto-merge only ever waits for REQUIRED checks, and this branch\n"
+                "has none, so arming it merges the moment the PR is mergeable (two merges landed\n"
+                "red this way).",
+            )
+        # Protected base with required checks: --auto is what it claims to be, so
+        # still-running checks are exactly what it will wait for.
+        return None
+    if pending:
+        return _block_msg(
+            f"PR {pr} has checks still running: {', '.join(pending)}",
+            "Wait for them to finish and read the result, or re-run with --auto — which this\n"
+            "guard allows once it confirms the base branch really does have required checks\n"
+            "for auto-merge to wait on. Merging now merges an unknown result.",
+        )
+    return None
+
+
+def main() -> int:
+    payload = _read_payload()
+    command = _command(payload)
+    # Fast path: only engage on `gh ... pr ... merge` (leave every other command untouched).
+    # Quote/backslash marks are dropped first, because the shell drops them BEFORE running
+    # the command: `g\h pr merge 5` and `g'h' pr merge 5` both execute gh (verified:
+    # `bash -c 'g\h --version'` prints gh's version). Testing the raw source would let a
+    # merge past this early return before the real parser ever sees it. Normalizing only
+    # ever sends MORE commands to the full parse — never fewer.
+    if not command:
+        return 0
+    probe = command.replace("\\", "").replace("'", "").replace('"', "")
+    if "gh" not in probe or "pr" not in probe or "merge" not in probe:
+        return 0
+    for seg in _judged_segments(command):
+        args = _merge_args(seg)
+        if args is None:
+            continue
+        blocked = _judge(args)
+        if blocked:
+            sys.stderr.write(blocked)
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -578,7 +578,7 @@ def _pr_meta(pr: str, repo: str | None = None) -> dict | None:
     if out.returncode != 0:
         return None
     try:
-        data = json.loads((out.stdout or "").strip() or "{}")
+        data = json.loads(_decolorize(out.stdout or "").strip() or "{}")
     except json.JSONDecodeError:
         return None
     if not isinstance(data, dict) or not isinstance(data.get("isDraft"), bool):
@@ -657,7 +657,7 @@ def _base_protected(owner_repo: str, base: str) -> bool | None:
             return False
         return None
     try:
-        data = json.loads((out.stdout or "").strip() or "{}")
+        data = json.loads(_decolorize(out.stdout or "").strip() or "{}")
     except json.JSONDecodeError:
         return None
     if not isinstance(data, dict):

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -40,10 +40,28 @@ likewise unread — a deliberate-only shape, documented rather than papered over
 from __future__ import annotations
 
 import json
+import os
 import re
 import shlex
 import subprocess
 import sys
+
+# Agent harnesses export CLICOLOR_FORCE/FORCE_COLOR, which beat NO_COLOR and make
+# `gh --json` emit ANSI-colorized JSON on pipes -> json.loads fails -> every merge
+# fail-closes (review B1, PR #5324). Every gh subprocess below runs with the force
+# vars REMOVED and NO_COLOR pinned; _decolorize() strips any residual escapes.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _gh_env() -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k not in {"CLICOLOR_FORCE", "FORCE_COLOR"}}
+    env["NO_COLOR"] = "1"
+    env["CLICOLOR"] = "0"
+    return env
+
+
+def _decolorize(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 # A check is treated as merge-blocking unless its name marks it explicitly advisory.
 # Same inversion as guard-admin-merge.py, and it matters more here: an allowlist of
@@ -519,6 +537,7 @@ def _pr_ref(args: list[str], repo: str | None = None) -> str | None:
         out = subprocess.run(
             ["gh", "pr", "view", *_repo_args(repo), "--json", "number", "-q", ".number"],
             capture_output=True,
+            env=_gh_env(),
             text=True,
             timeout=10,
         )
@@ -550,8 +569,9 @@ def _pr_meta(pr: str, repo: str | None = None) -> dict | None:
         out = subprocess.run(
             ["gh", "pr", "view", pr, *_repo_args(repo), "--json", "isDraft,baseRefName,url"],
             capture_output=True,
+            env=_gh_env(),
             text=True,
-            timeout=20,
+            timeout=8,
         )
     except Exception:
         return None
@@ -572,8 +592,9 @@ def _check_states(pr: str, repo: str | None = None) -> tuple[list[str], list[str
         out = subprocess.run(
             ["gh", "pr", "checks", pr, *_repo_args(repo), "--json", "name,bucket,state"],
             capture_output=True,
+            env=_gh_env(),
             text=True,
-            timeout=20,
+            timeout=8,
         )
     except Exception:
         return None
@@ -584,7 +605,7 @@ def _check_states(pr: str, repo: str | None = None) -> tuple[list[str], list[str
         # *error* as "no failing checks" is the fail-open bug guard-admin-merge closed.
         return ([], []) if out.returncode == 0 else None
     try:
-        rows = json.loads(text)
+        rows = json.loads(_decolorize(text))
     except json.JSONDecodeError:
         return None
     if not isinstance(rows, list):
@@ -624,8 +645,9 @@ def _base_protected(owner_repo: str, base: str) -> bool | None:
         out = subprocess.run(
             ["gh", "api", f"repos/{owner_repo}/branches/{base}/protection"],
             capture_output=True,
+            env=_gh_env(),
             text=True,
-            timeout=20,
+            timeout=8,
         )
     except Exception:
         return None

--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -42,9 +42,9 @@ def _command(payload: dict) -> str:
 
 # --- Command segmentation hardened against glued shell operators (#4876). ---
 # Pattern lifted from guard-secret-print.py. Hooks are standalone by design,
-# so the helpers are copied, not imported. Keep the three copies in
-# guard-branch-switch-in-main.py, guard-admin-merge.py, and
-# guard-push-pytest.py in sync.
+# so the helpers are copied, not imported. Keep the four copies in
+# guard-branch-switch-in-main.py, guard-admin-merge.py, guard-push-pytest.py,
+# and guard-pr-merge.py in sync.
 
 
 def _strip_quotes(token: str) -> str:

--- a/agents_extensions/shared/settings.json
+++ b/agents_extensions/shared/settings.json
@@ -661,6 +661,11 @@
           },
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-pr-merge.py",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-push-pytest.py",
             "timeout": 10
           },

--- a/docs/best-practices/gitflow.md
+++ b/docs/best-practices/gitflow.md
@@ -220,6 +220,44 @@ it accordingly.
 - Worktree branches that never land on `main` get cleaned by
   `scripts/wt.sh clean {issue}`.
 
+### Merge guards (the hook layer, where GitHub can't enforce)
+
+Branch protection is a paid feature for **private** repos: on a free-plan private
+repo the protection API answers 403, so **no check is ever "required"** there.
+That gap is not theoretical — it cost us a draft PR squash-merged before review,
+plus two merges that landed with the test job red, because `--auto` only ever
+waits for *required* checks and there were none. (This public repo is the lucky
+case: `main` is protected, with `CI Gate` required. The fleet works across both,
+so the guards decide per-repo rather than assuming either.) Two PreToolUse hooks
+close the gap:
+
+| Hook | Owns | Blocks |
+| --- | --- | --- |
+| `guard-admin-merge.py` | `gh pr merge --admin` | a blocking check is red (#M-0.5) |
+| `guard-pr-merge.py` | every other `gh pr merge` | draft PR · any red non-advisory check · checks still running without `--auto` · `--auto` on a base branch with no required status checks |
+
+The two never judge the same command — `guard-pr-merge.py` skips `--admin`
+segments. Both fail **closed**: if the PR, its checks, or the base branch's
+protection can't be read (gh error/timeout), the merge is refused rather than
+assumed safe.
+
+A red check blocks whether or not GitHub calls it required: "required" is a
+config accident (absent entirely on the private repo), while red is red. So every
+check counts unless its name says `advisory` — which is why the two advisory
+jobs, `pip-audit (advisory)` and `npm-audit (advisory)`, carry that word.
+
+`--auto` is the one verdict that does consult protection, because it is the one
+thing protection actually changes: auto-merge waits for *required* checks, so
+with none configured it merges the moment the PR is mergeable, red or not. The
+guard reads `repos/{owner}/{repo}/branches/{base}/protection` per merge — allowed
+against a base with required checks (this repo's `main`), refused where the API
+403s or lists none (the private repo). There, read the checks green yourself and
+merge manually. `gh pr merge --disable-auto` is never blocked; disarming
+auto-merge is the remedy, not the offence.
+
+**Escape hatch:** a human runs the merge outside the agent harness. The hooks
+gate the agent fleet, not the maintainer — but see the override log below.
+
 ### When a hook or check blocks you
 
 Fix the underlying issue — never bypass with `--no-verify`,

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -838,3 +838,51 @@ def test_colorized_check_rows_still_judged(monkeypatch):
     monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
     failing, pending = guard._check_states("5")
     assert failing == [] and pending == []
+
+
+def test_colorized_pr_meta_still_parses(monkeypatch):
+    """_check_states was decolorized but _pr_meta was not (review B1 follow-up). Raw
+    parsing here raises JSONDecodeError -> None -> undeterminable -> every merge blocked,
+    draft or not. The payload must survive ANSI and keep isDraft a real boolean."""
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=_COLORIZED_JSON, stderr="")
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
+    assert guard._pr_meta("5") == {
+        "baseRefName": "main",
+        "isDraft": False,
+        "url": "https://github.com/owner/repo/pull/5",
+    }
+
+
+def test_colorized_pr_meta_honors_draft(monkeypatch):
+    """The draft bit must be read THROUGH the colorization, not lost to it: a colorized
+    draft payload has to still block."""
+    colorized_draft = '\x1b[1;37m{\x1b[m\x1b[1;34m"isDraft"\x1b[m: \x1b[35mtrue\x1b[m, \x1b[1;34m"baseRefName"\x1b[m: \x1b[32m"main"\x1b[m\x1b[1;37m}\x1b[m'
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=colorized_draft, stderr="")
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
+    meta = guard._pr_meta("5")
+    assert meta is not None and meta["isDraft"] is True
+
+
+def test_colorized_base_protection_still_classified(monkeypatch):
+    """_base_protected's parse was raw too. Colorized protection JSON must classify as
+    protected — reading it as undeterminable blocks legitimate --auto on a guarded base."""
+    colorized = (
+        '\x1b[1;37m{\x1b[m\n'
+        '  \x1b[1;34m"required_status_checks"\x1b[m: \x1b[1;37m{\x1b[m\n'
+        '    \x1b[1;34m"contexts"\x1b[m: [\x1b[32m"Test (pytest)"\x1b[m],\n'
+        '    \x1b[1;34m"strict"\x1b[m: \x1b[35mtrue\x1b[m\n'
+        '  \x1b[1;37m}\x1b[m\n'
+        '\x1b[1;37m}\x1b[m\n'
+    )
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=colorized, stderr="")
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
+    assert guard._base_protected("owner/repo", "main") is True
+
+
+def test_colorized_empty_required_checks_still_unprotected(monkeypatch):
+    """Decolorizing must not flip the empty-required-checks verdict: protection that
+    requires NOTHING is still False (auto-merge would wait for nothing and merge red)."""
+    colorized = '\x1b[1;37m{\x1b[m\x1b[1;34m"required_status_checks"\x1b[m: \x1b[1;37m{\x1b[m\x1b[1;34m"contexts"\x1b[m: [], \x1b[1;34m"checks"\x1b[m: []\x1b[1;37m}\x1b[m\x1b[1;37m}\x1b[m'
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=colorized, stderr="")
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
+    assert guard._base_protected("owner/repo", "main") is False

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -1,0 +1,794 @@
+"""Unit tests for the PR-merge guard hook (#189 class / free-plan protection gap).
+
+Exercises the pure decision logic in
+``agents_extensions/shared/hooks/guard-pr-merge.py``:
+
+  * `gh pr merge` detection (incl. wrappers, a positional PR number, and the
+    `--admin` / `--disable-auto` segments this hook deliberately leaves alone),
+  * the quote-aware tokenizer (a `gh pr merge` inside a quoted commit body is NOT a merge),
+  * failing/pending check classification against the advisory allowlist,
+  * the fail-CLOSED `main()` decision (block on draft, red checks, pending-without-auto,
+    --auto on an unprotected base, and on anything undeterminable; allow on green).
+
+The hook filename has hyphens, so it is loaded by path via importlib. `main()` is guarded
+by `__name__ == "__main__"`, so import has no side effects. Network functions
+(`_pr_ref`, `_pr_meta`, `_check_states`, `_base_protected`) are monkeypatched — no
+`gh`/network in tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_PATH = REPO_ROOT / "agents_extensions/shared" / "hooks" / "guard-pr-merge.py"
+_URL = "https://github.com/owner/repo/pull/5"
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location("guard_pr_merge", HOOK_PATH)
+    assert spec and spec.loader, f"could not load hook at {HOOK_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_hook()
+
+
+def _run(
+    monkeypatch,
+    command: str,
+    *,
+    pr: str | None = "5",
+    meta: dict | None = None,
+    checks: tuple[list[str], list[str]] | None = ([], []),
+    owner_repo: str | None = "owner/repo",
+    protected: bool | None = False,
+) -> int:
+    """Drive main() with a simulated stdin payload + monkeypatched network calls.
+
+    Defaults describe this repo today: a ready PR, all checks green, unprotected base.
+    """
+    payload = json.dumps({"tool_input": {"command": command}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: pr)
+    monkeypatch.setattr(
+        guard,
+        "_pr_meta",
+        lambda p, repo=None: ({"isDraft": False, "baseRefName": "main", "url": _URL} if meta is None else meta),
+    )
+    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None: checks)
+    monkeypatch.setattr(guard, "_owner_repo_from_url", lambda u: owner_repo)
+    monkeypatch.setattr(guard, "_base_protected", lambda o, b: protected)
+    return guard.main()
+
+
+# --- detection (pure, no network) ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "seg,judged",
+    [
+        (["gh", "pr", "merge"], True),
+        (["gh", "pr", "merge", "123", "--squash", "--delete-branch"], True),
+        (["gh", "pr", "merge", "--auto", "--squash"], True),
+        (["sudo", "gh", "pr", "merge", "5"], True),
+        # guard-admin-merge.py's job — never double-judge.
+        (["gh", "pr", "merge", "5", "--admin"], False),
+        # Disarms auto-merge rather than merging; it is the remedy, not the offence.
+        (["gh", "pr", "merge", "5", "--disable-auto"], False),
+        (["gh", "pr", "view", "5"], False),
+        (["gh", "pr", "create"], False),
+        (["git", "push"], False),
+    ],
+)
+def test_merge_detection(seg, judged):
+    assert (guard._merge_args(seg) is not None) is judged
+
+
+def test_quoted_merge_not_detected():
+    # `gh pr merge` inside a quoted commit body must NOT be seen as a merge command.
+    segs = guard._segments('git commit -m "docs: never run gh pr merge 5 on a draft"')
+    assert all(guard._merge_args(s) is None for s in segs)
+
+
+def test_is_advisory():
+    assert guard._is_advisory("pip-audit (advisory)")
+    assert not guard._is_advisory("boundary-and-tests")
+    assert not guard._is_advisory("Test (pytest)")
+
+
+# --- main() decision (fail-closed) -----------------------------------------
+
+
+def test_non_merge_command_is_untouched(monkeypatch):
+    assert _run(monkeypatch, "gh pr view 5 --json state") == 0
+
+
+def test_unrelated_command_is_untouched(monkeypatch):
+    assert _run(monkeypatch, "git push origin main") == 0
+
+
+def test_admin_merge_is_other_guards_job(monkeypatch):
+    # Red checks + --admin → still 0 from THIS hook; guard-admin-merge.py judges it.
+    assert _run(monkeypatch, "gh pr merge 5 --admin", checks=(["Test (pytest)"], [])) == 0
+
+
+def test_disable_auto_is_not_a_merge(monkeypatch):
+    # Disarming auto-merge on a draft is the remedy this guard asks for — never block it.
+    assert _run(
+        monkeypatch, "gh pr merge 5 --disable-auto", meta={"isDraft": True, "baseRefName": "main", "url": _URL}
+    ) == 0
+
+
+def test_draft_is_blocked(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --squash", meta={"isDraft": True, "baseRefName": "main", "url": _URL}) == 2
+
+
+def test_red_non_advisory_check_is_blocked(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --squash", checks=(["boundary-and-tests"], [])) == 2
+
+
+def test_green_is_allowed(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --squash --delete-branch") == 0
+
+
+def test_pending_without_auto_is_blocked(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --squash", checks=([], ["Test (pytest)"])) == 2
+
+
+def test_auto_on_protected_base_is_allowed(monkeypatch):
+    # Protection with required status checks → --auto waits for them, as advertised.
+    assert _run(monkeypatch, "gh pr merge 5 --auto --squash", checks=([], ["Test (pytest)"]), protected=True) == 0
+
+
+def test_auto_on_unprotected_base_is_blocked(monkeypatch):
+    # 403/404 → the repo enforces nothing → auto-merge fires regardless of checks.
+    assert _run(monkeypatch, "gh pr merge 5 --auto --squash", protected=False) == 2
+
+
+def test_auto_with_undeterminable_protection_fails_closed(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --auto --squash", protected=None) == 2
+
+
+def test_auto_with_unknown_repo_fails_closed(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --auto --squash", owner_repo=None) == 2
+
+
+def test_unknown_pr_fails_closed(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge --squash", pr=None) == 2
+
+
+def test_undeterminable_pr_meta_fails_closed(monkeypatch):
+    # _pr_meta returning None (gh error/timeout) → block, never "assume not a draft".
+    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None: None)
+    payload = json.dumps({"tool_input": {"command": "gh pr merge 5 --squash"}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: "5")
+    assert guard.main() == 2
+
+
+def test_undeterminable_checks_fails_closed(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --squash", checks=None) == 2
+
+
+# --- _pr_meta / _check_states: gh-output handling (fail-open regression) -----
+
+
+def _fake_gh(monkeypatch, *, returncode: int, stdout: str, stderr: str = ""):
+    import types
+
+    def fake_run(*_a, **_k):
+        return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr(guard.subprocess, "run", fake_run)
+
+
+def test_pr_meta_parses_draft(monkeypatch):
+    _fake_gh(monkeypatch, returncode=0, stdout='{"isDraft":true,"baseRefName":"main"}')
+    assert guard._pr_meta("5") == {"isDraft": True, "baseRefName": "main"}
+
+
+def test_pr_meta_error_rc_is_failclosed(monkeypatch):
+    _fake_gh(monkeypatch, returncode=1, stdout="")
+    assert guard._pr_meta("99999") is None
+
+
+def test_pr_meta_without_isdraft_is_failclosed(monkeypatch):
+    # An empty/partial payload must not read as "not a draft".
+    _fake_gh(monkeypatch, returncode=0, stdout="{}")
+    assert guard._pr_meta("5") is None
+
+
+def test_pr_meta_garbage_output_is_failclosed(monkeypatch):
+    _fake_gh(monkeypatch, returncode=0, stdout="not json")
+    assert guard._pr_meta("5") is None
+
+
+def test_check_states_empty_output_with_error_rc_is_failclosed(monkeypatch):
+    # Bogus/non-existent PR → gh errors with EMPTY stdout. Must be None (fail-closed),
+    # not ([], []) — reading an error as "all green" is the fail-open bug.
+    _fake_gh(monkeypatch, returncode=1, stdout="")
+    assert guard._check_states("99999") is None
+
+
+def test_check_states_empty_output_with_ok_rc_is_no_checks(monkeypatch):
+    _fake_gh(monkeypatch, returncode=0, stdout="")
+    assert guard._check_states("5") == ([], [])
+
+
+def test_check_states_splits_failing_and_pending(monkeypatch):
+    rows = (
+        '[{"name":"boundary-and-tests","bucket":"fail"},'
+        '{"name":"Test (pytest)","bucket":"pending"},'
+        '{"name":"Lint (ruff)","bucket":"pass"},'
+        '{"name":"pip-audit (advisory)","bucket":"fail"}]'
+    )
+    _fake_gh(monkeypatch, returncode=8, stdout=rows)
+    assert guard._check_states("5") == (["boundary-and-tests"], ["Test (pytest)"])
+
+
+def test_check_states_garbage_output_is_failclosed(monkeypatch):
+    _fake_gh(monkeypatch, returncode=0, stdout="not json")
+    assert guard._check_states("5") is None
+
+
+def test_base_protected_true_only_with_required_checks(monkeypatch):
+    _fake_gh(monkeypatch, returncode=0, stdout='{"required_status_checks":{"contexts":["Test (pytest)"]}}')
+    assert guard._base_protected("owner/repo", "main") is True
+
+
+def test_base_protected_without_required_checks_is_false(monkeypatch):
+    # Protected, but nothing required → --auto still merges regardless of checks.
+    _fake_gh(monkeypatch, returncode=0, stdout='{"allow_force_pushes":{"enabled":false}}')
+    assert guard._base_protected("owner/repo", "main") is False
+
+
+def test_base_protected_with_empty_required_checks_is_false(monkeypatch):
+    # required_status_checks can exist while requiring NOTHING: a truthy dict whose
+    # contexts and checks are both empty. Auto-merge would then wait for nothing and
+    # merge red — the same hole as an unprotected branch, wearing protection's clothes.
+    _fake_gh(monkeypatch, returncode=0, stdout='{"required_status_checks":{"contexts":[],"checks":[],"strict":false}}')
+    assert guard._base_protected("owner/repo", "main") is False
+
+
+def test_base_protected_with_checks_but_no_contexts_is_true(monkeypatch):
+    # The modern shape: `checks` populated, legacy `contexts` empty. Still enforcing.
+    _fake_gh(
+        monkeypatch,
+        returncode=0,
+        stdout='{"required_status_checks":{"contexts":[],"checks":[{"context":"CI Gate","app_id":15368}]}}',
+    )
+    assert guard._base_protected("owner/repo", "main") is True
+
+
+def test_base_protected_with_non_dict_required_checks_is_false(monkeypatch):
+    _fake_gh(monkeypatch, returncode=0, stdout='{"required_status_checks":"weird"}')
+    assert guard._base_protected("owner/repo", "main") is False
+
+
+def test_auto_on_base_with_empty_required_checks_is_blocked(monkeypatch):
+    # End-to-end: the empty-required-checks branch must refuse --auto like any other
+    # base that enforces nothing.
+    monkeypatch.setattr(guard, "_base_protected", lambda o, b: False)
+    payload = json.dumps({"tool_input": {"command": "gh pr merge 5 --auto --squash"}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: "5")
+    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None: {"isDraft": False, "baseRefName": "main", "url": _URL})
+    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None: ([], []))
+    monkeypatch.setattr(guard, "_owner_repo_from_url", lambda u: "owner/repo")
+    assert guard.main() == 2
+
+
+@pytest.mark.parametrize("err", ["HTTP 403: Upgrade to GitHub Pro", "HTTP 404: Branch not protected"])
+def test_base_protected_403_404_is_false(monkeypatch, err):
+    _fake_gh(monkeypatch, returncode=1, stdout="", stderr=err)
+    assert guard._base_protected("owner/repo", "main") is False
+
+
+def test_base_protected_other_error_is_undeterminable(monkeypatch):
+    _fake_gh(monkeypatch, returncode=1, stdout="", stderr="HTTP 500: Internal Server Error")
+    assert guard._base_protected("owner/repo", "main") is None
+
+
+# --- codex adversarial round (PR #5324): confirmed fail-open holes -----------
+#
+# Every case below was a REAL hole, reproduced against the code before the fix.
+# gh is cobra/pflag, so `--auto=true` is the same flag as `--auto` — verified live:
+# `gh pr list --draft=notabool` errors with "strconv.ParseBool: invalid syntax",
+# proving the =value spelling parses.
+
+
+def test_flag_enabled_spellings():
+    assert guard._flag_enabled(["--auto"], "auto")
+    assert guard._flag_enabled(["--auto=true"], "auto")
+    assert guard._flag_enabled(["--auto=1"], "auto")
+    assert guard._flag_enabled(["--auto=T"], "auto")
+    assert not guard._flag_enabled(["--auto=false"], "auto")
+    assert not guard._flag_enabled(["--auto=0"], "auto")
+    assert not guard._flag_enabled(["--squash"], "auto")
+    # Malformed → gh itself would exit non-zero; reading it as ON is fail-closed.
+    assert guard._flag_enabled(["--auto=maybe"], "auto")
+
+
+def test_auto_equals_true_on_unprotected_base_is_blocked(monkeypatch):
+    # F001: `--auto=true` skipped the protection check entirely and armed auto-merge
+    # on a base that enforces nothing — the exact incident this hook exists to stop.
+    assert _run(monkeypatch, "gh pr merge 5 --auto=true --squash", protected=False) == 2
+
+
+def test_auto_equals_false_is_a_normal_merge(monkeypatch):
+    # Not an auto-merge → judged as a manual merge: green passes, pending blocks.
+    assert _run(monkeypatch, "gh pr merge 5 --auto=false --squash", protected=False) == 0
+    assert _run(monkeypatch, "gh pr merge 5 --auto=false --squash", checks=([], ["Test (pytest)"])) == 2
+
+
+def test_disable_auto_equals_true_is_not_a_merge(monkeypatch):
+    # F005: the safe disarm was judged (and blocked) in its `=true` spelling.
+    assert _run(
+        monkeypatch, "gh pr merge 5 --disable-auto=true", meta={"isDraft": True, "baseRefName": "main", "url": _URL}
+    ) == 0
+
+
+def test_admin_equals_true_is_judged_here(monkeypatch):
+    # guard-admin-merge.py matches the exact token "--admin" only, so `--admin=true`
+    # is invisible to it. Judging it here closes the gap between the two hooks rather
+    # than letting a red admin merge fall between them. (Bare --admin stays its job.)
+    assert _run(monkeypatch, "gh pr merge 5 --admin=true", checks=(["Test (pytest)"], [])) == 2
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "sudo -u bot gh pr merge 5 --squash",
+        "env -i gh pr merge 5 --squash",
+        "env -u FOO gh pr merge 5 --auto",
+    ],
+)
+def test_wrapper_with_options_is_still_judged(cmd):
+    # F002: _skip_command_prefix consumed the wrapper but not its options, so the
+    # `['gh','pr','merge']` match failed and the merge was never judged.
+    assert _any_merge(cmd)
+
+
+def test_unwrapped_mention_is_not_a_merge():
+    # The wrapper scan must not turn any stray token run into a merge.
+    assert not _any_merge("echo gh pr merge 5")
+
+
+def test_unknown_check_bucket_fails_closed(monkeypatch):
+    # F003: an unrecognized (or future) bucket fell through as neither failing nor
+    # pending — i.e. green. Schema drift must block, not merge.
+    _fake_gh(monkeypatch, returncode=0, stdout='[{"name":"CI Gate","bucket":"mystery","state":"mystery"}]')
+    assert guard._check_states("5") is None
+
+
+def test_missing_check_bucket_fails_closed(monkeypatch):
+    _fake_gh(monkeypatch, returncode=0, stdout='[{"name":"CI Gate"}]')
+    assert guard._check_states("5") is None
+
+
+def test_known_pass_buckets_are_green(monkeypatch):
+    rows = '[{"name":"CI Gate","bucket":"pass"},{"name":"Flaky","bucket":"skipping"},{"name":"N","bucket":"neutral"}]'
+    _fake_gh(monkeypatch, returncode=0, stdout=rows)
+    assert guard._check_states("5") == ([], [])
+
+
+@pytest.mark.parametrize("draft", ["null", '"false"', "0"])
+def test_non_bool_isdraft_fails_closed(monkeypatch, draft):
+    # F004: `isDraft: null` is falsey → was read as a confirmed non-draft and allowed.
+    _fake_gh(monkeypatch, returncode=0, stdout=f'{{"isDraft":{draft},"baseRefName":"main"}}')
+    assert guard._pr_meta("5") is None
+
+
+# --- codex re-review round 2 (PR #5324): three more confirmed holes ----------
+
+
+def test_flag_enabled_last_occurrence_wins():
+    # pflag applies repeated flags in order, so `--auto=false --auto` IS auto-merge.
+    # Verified live: `gh pr list --draft=false --draft=true` returns draft PRs.
+    # Returning on the first match read this as "off" and waved the merge through.
+    assert guard._flag_enabled(["--auto=false", "--auto"], "auto")
+    assert guard._flag_enabled(["--auto", "--auto=true"], "auto")
+    assert not guard._flag_enabled(["--auto", "--auto=false"], "auto")
+    assert not guard._flag_enabled(["--auto=true", "--auto=false"], "auto")
+
+
+def test_repeated_auto_flags_on_unprotected_base_is_blocked(monkeypatch):
+    # The fail-open: green checks + `--auto=false --auto` → gh arms auto-merge on a base
+    # that requires nothing, and a later red check does not stop it.
+    assert _run(monkeypatch, "gh pr merge 5 --auto=false --auto --squash", protected=False) == 2
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "bash -c 'gh pr merge 5 --squash'",
+        'sh -c "gh pr merge 5 --auto"',
+        "/bin/bash -c 'gh pr merge 5 --squash'",
+        "bash -lc 'gh pr merge 5 --squash'",
+        "zsh -c 'true; gh pr merge 5 --squash'",
+        # Nested one level deeper.
+        "bash -c \"bash -c 'gh pr merge 5 --squash'\"",
+    ],
+)
+def test_shell_c_payload_is_judged(cmd):
+    # A `bash -c` payload really executes the merge; the segment merely starts with `bash`.
+    assert any(guard._merge_args(s) is not None for s in guard._judged_segments(cmd))
+
+
+def test_shell_c_without_merge_is_not_judged():
+    assert not any(guard._merge_args(s) is not None for s in guard._judged_segments("bash -c 'git status'"))
+
+
+def test_shell_c_merge_blocks_end_to_end(monkeypatch):
+    assert _run(monkeypatch, "bash -c 'gh pr merge 5 --squash'", checks=(["boundary-and-tests"], [])) == 2
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["5", "--squash"], "5"),
+        (["--squash", "5"], "5"),
+        # The value of a value-taking flag is NOT the PR: judging PR #5 here while gh
+        # merges the current branch's PR is a fail-open.
+        (["--subject", "5", "--squash"], None),
+        (["-t", "5", "--squash"], None),
+        (["--body", "5"], None),
+        (["--match-head-commit", "1234567", "--squash"], None),
+        (["--subject=5", "--squash"], None),
+        # gh accepts url and branch selectors too — pass them through verbatim.
+        (["https://github.com/other/repo/pull/9", "--squash"], "https://github.com/other/repo/pull/9"),
+        (["some-branch", "--squash"], "some-branch"),
+        (["--squash", "--delete-branch"], None),
+    ],
+)
+def test_pr_selector(args, expected):
+    assert guard._pr_selector(args) == expected
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5324", "learn-ukrainian/learn-ukrainian.github.io"),
+        ("https://github.com/other/repo/pull/9", "other/repo"),
+        ("https://ghe.example.com/o/r/pull/1", "o/r"),
+        ("not a url", None),
+        ("", None),
+    ],
+)
+def test_owner_repo_from_url(url, expected):
+    # Identity comes from the PR's own url — the BASE repo, fork-safe, and correct even
+    # when cwd is a different repo entirely (a URL selector).
+    assert guard._owner_repo_from_url(url) == expected
+
+
+def test_cross_repo_url_selector_uses_that_repo(monkeypatch):
+    # The PR url decides which repo's protection is read, not the cwd.
+    seen = {}
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: "https://github.com/other/repo/pull/9")
+    monkeypatch.setattr(
+        guard,
+        "_pr_meta",
+        lambda p, repo=None: {"isDraft": False, "baseRefName": "main", "url": "https://github.com/other/repo/pull/9"},
+    )
+    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None: ([], []))
+    monkeypatch.setattr(guard, "_base_protected", lambda o, b: seen.setdefault("repo", o) and True)
+    payload = json.dumps({"tool_input": {"command": "gh pr merge https://github.com/other/repo/pull/9 --auto"}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    guard.main()
+    assert seen["repo"] == "other/repo"
+
+
+def test_pr_meta_requires_url_field(monkeypatch):
+    # url is load-bearing for the protection lookup; gh must actually return it.
+    _fake_gh(monkeypatch, returncode=0, stdout='{"isDraft":false,"baseRefName":"main","url":"https://github.com/o/r/pull/5"}')
+    assert guard._pr_meta("5") == {
+        "isDraft": False,
+        "baseRefName": "main",
+        "url": "https://github.com/o/r/pull/5",
+    }
+
+
+# --- codex re-review round 3 (PR #5324): four more confirmed holes -----------
+
+
+@pytest.mark.parametrize("cmd", ["bash -cx 'gh pr merge 5 --squash'", 'sh -cx "gh pr merge 5"'])
+def test_clustered_c_not_last_is_judged(cmd):
+    # `bash -cx 'cmd'` runs cmd (verified: `bash -cx 'echo hi'` executes, exit 0), so
+    # requiring the cluster to END in c missed a real merge.
+    assert any(guard._merge_args(s) is not None for s in guard._judged_segments(cmd))
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "bash -c $'gh pr merge 5 --squash'",
+        'bash -c $"gh pr merge 5"',
+    ],
+)
+def test_dollar_quoted_shell_payload_is_judged(cmd):
+    # Bash's $'...' (ANSI-C) and $"..." (locale) quoting run the command for real, but
+    # survive tokenizing as a literal `$` glued to the payload — first token `$gh`,
+    # matching nothing. Verified: `bash -c $'echo ansi-c-ran'` executes.
+    assert any(guard._merge_args(s) is not None for s in guard._judged_segments(cmd))
+
+
+def test_strip_dollar_quote():
+    assert guard._strip_dollar_quote("$gh pr merge 5") == "gh pr merge 5"
+    assert guard._strip_dollar_quote("gh pr merge 5") == "gh pr merge 5"
+
+
+def test_valid_nested_shell_is_judged():
+    assert any(
+        guard._merge_args(s) is not None
+        for s in guard._judged_segments("""bash -c 'bash -c "gh pr merge 5 --squash"'""")
+    )
+
+
+def test_recursion_cap_fails_closed(monkeypatch):
+    # At the cap the payload is NOT inspected, so it must be refused rather than passed
+    # through. Regression for an inert sentinel: the marker segment carries no PR
+    # selector, and _pr_ref falls back to the CURRENT BRANCH's PR — so without an
+    # explicit marker check, a green current branch would approve an unread payload.
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: "5")
+    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None: {"isDraft": False, "baseRefName": "main", "url": _URL})
+    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None: ([], []))  # all green
+    assert guard._judge([guard._UNREADABLE_MARKER]) is not None
+
+
+def test_deep_nesting_emits_unparsed_marker():
+    segs = guard._judged_segments("bash -c 'gh pr merge 5 --squash'", guard._MAX_SHELL_DEPTH)
+    assert guard._UNPARSED in segs
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "gh pr merge 5 --subject --disable-auto",
+        "gh pr merge 5 --subject --admin",
+        "gh pr merge 5 --body --disable-auto --squash",
+    ],
+)
+def test_flag_looking_values_do_not_suppress_judging(cmd):
+    # pflag takes the next token as a string flag's VALUE even when it looks like a flag.
+    # `--subject --disable-auto` is a normal merge whose subject is "--disable-auto";
+    # reading that value as the flag skipped judging entirely — a fail-open.
+    assert any(guard._merge_args(s) is not None for s in guard._judged_segments(cmd))
+
+
+def test_flag_looking_value_does_not_force_auto_path():
+    # The mirror image: `--subject --auto` must not be read as arming auto-merge.
+    flags, _ = guard._classify(["5", "--subject", "--auto"])
+    assert not guard._flag_enabled(flags, "auto")
+
+
+def test_real_control_flags_still_recognized():
+    assert guard._merge_args(["gh", "pr", "merge", "5", "--disable-auto"]) is None
+    assert guard._merge_args(["gh", "pr", "merge", "5", "--admin"]) is None
+    assert guard._flag_enabled(guard._classify(["5", "--auto"])[0], "auto")
+
+
+@pytest.mark.parametrize(
+    "args,repo",
+    [
+        (["--repo", "other/repo", "9"], "other/repo"),
+        (["--repo=other/repo", "9"], "other/repo"),
+        (["-R", "o/r", "9"], "o/r"),
+        (["9", "--squash"], None),
+        # A VALUE that looks like --repo is not a repo selector.
+        (["5", "--subject", "--repo"], None),
+    ],
+)
+def test_repo_option(args, repo):
+    assert guard._repo_option(args) == repo
+
+
+def test_repo_option_value_is_not_the_pr_selector():
+    # `gh pr merge --repo other/repo 9` targets PR 9 — not a PR named "other/repo".
+    assert guard._pr_selector(["--repo", "other/repo", "9", "--auto"]) == "9"
+
+
+def test_repo_is_propagated_to_every_gh_lookup(monkeypatch):
+    # `gh pr merge --repo other/repo 9` merges other/repo#9. If the guard reads THIS
+    # repo's #9 instead, it judges a different PR than the one being merged.
+    calls = []
+
+    def fake_run(argv, *_a, **_k):
+        import types
+
+        calls.append(argv)
+        if argv[:3] == ["gh", "pr", "view"]:
+            return types.SimpleNamespace(
+                returncode=0, stdout='{"isDraft":false,"baseRefName":"main","url":"https://github.com/other/repo/pull/9"}', stderr=""
+            )
+        return types.SimpleNamespace(returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(guard.subprocess, "run", fake_run)
+    guard._judge(["--repo", "other/repo", "9", "--squash"])
+    assert all("--repo" in c and "other/repo" in c for c in calls), calls
+
+
+# --- codex re-review round 4 (PR #5324): pflag shorthands + shell escaping ---
+
+
+def test_escaped_gh_still_reaches_the_parser(monkeypatch):
+    # The shell strips the backslash BEFORE running the command: `bash -c 'g\h --version'`
+    # prints gh's version. A fast path over raw source let `g\h pr merge` past the early
+    # return entirely. Normalizing quotes/backslashes first closes it.
+    assert _run(monkeypatch, r"g\h pr merge 5 --squash", checks=(["boundary-and-tests"], [])) == 2
+    assert _run(monkeypatch, "g'h' pr merge 5 --squash", checks=(["boundary-and-tests"], [])) == 2
+
+
+def test_fast_path_still_ignores_unrelated_commands(monkeypatch):
+    assert _run(monkeypatch, "git push origin main") == 0
+    assert _run(monkeypatch, "echo 'nothing to see'") == 0
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "gh pr merge --help",
+        "gh pr merge -h",
+        "gh pr merge 5 --help",
+        # --help is a bool like any other, so it has the =value spelling too.
+        "gh pr merge --help=true",
+    ],
+)
+def test_help_is_not_a_merge(monkeypatch, cmd):
+    # Reading the manual merges nothing. Blocking it (on a draft, say) would just teach
+    # people the guard is noise.
+    assert _run(monkeypatch, cmd, meta={"isDraft": True, "baseRefName": "main", "url": _URL}) == 0
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git commit -m 'fix: pr merge notes'",
+        "gh pr create --title x --body y",
+        "gh pr view 5 --json state",
+        "gh pr checks 5",
+        "gh pr ready 5",
+        "grep -r 'gh pr merge' docs/",
+        "python scripts/merge_data.py --pr 5",
+        "git merge origin/main",
+    ],
+)
+def test_ordinary_commands_are_untouched(monkeypatch, cmd):
+    # The guard must be invisible in normal use; a red PR is the harshest setting here.
+    assert _run(monkeypatch, cmd, checks=(["boundary-and-tests"], [])) == 0
+
+
+@pytest.mark.parametrize(
+    "args,repo",
+    [
+        # Attached short value — verified against real gh: `gh pr view -R<owner>/<repo> N`.
+        (["-Rother/repo", "9"], "other/repo"),
+        (["-R=other/repo", "9"], "other/repo"),
+        (["-R", "other/repo", "9"], "other/repo"),
+        (["--repo=other/repo", "9"], "other/repo"),
+        # -R as the last letter of a cluster, value in the next token.
+        (["-sR", "other/repo", "9"], "other/repo"),
+        (["9", "--squash"], None),
+    ],
+)
+def test_repo_option_all_spellings(args, repo):
+    assert guard._repo_option(args) == repo
+
+
+@pytest.mark.parametrize(
+    "args,selector",
+    [
+        # `-st green-subject`: -s is squash, -t consumes the subject → target is the
+        # CURRENT branch's PR, not a PR called "green-subject".
+        (["-st", "green-subject", "--auto"], None),
+        (["-tgreen-subject", "--auto"], None),
+        (["-t=green-subject"], None),
+        (["-Rother/repo", "9"], "9"),
+        (["-sR", "other/repo", "9"], "9"),
+        # A non-value shorthand must NOT swallow the selector.
+        (["-s", "9"], "9"),
+        (["-d", "branch-name"], "branch-name"),
+    ],
+)
+def test_pr_selector_with_shorthand_clusters(args, selector):
+    assert guard._pr_selector(args) == selector
+
+
+def test_cluster_value():
+    assert guard._cluster_value("-st") == ("--subject", None, True)
+    assert guard._cluster_value("-tsubj") == ("--subject", "subj", False)
+    assert guard._cluster_value("-t=subj") == ("--subject", "subj", False)
+    assert guard._cluster_value("-Rowner/repo") == ("--repo", "owner/repo", False)
+    assert guard._cluster_value("-sd") == (None, None, False)
+
+
+def test_xargs_shell_form_is_judged():
+    assert any(
+        guard._merge_args(s) is not None
+        for s in guard._judged_segments("printf '' | xargs sh -c 'gh pr merge 5 --auto'")
+    )
+
+
+# --- codex re-review round 5 (PR #5324): xargs is not a transparent prefix ----
+
+
+def test_xargs_fed_selector_fails_closed(monkeypatch):
+    # `printf '5' | xargs gh pr merge --squash` runs `gh pr merge --squash 5`, but 5 is
+    # on stdin. Falling back to the current branch's PR would verify one PR while gh
+    # merges another — so refuse. Green current branch must NOT rescue it.
+    assert _run(monkeypatch, "printf '5' | xargs gh pr merge --squash", checks=([], [])) == 2
+
+
+def test_xargs_with_explicit_selector_is_judged_normally(monkeypatch):
+    assert _run(monkeypatch, "printf '' | xargs gh pr merge 5 --squash", checks=(["boundary-and-tests"], [])) == 2
+    assert _run(monkeypatch, "printf '' | xargs gh pr merge 5 --squash", checks=([], [])) == 0
+
+
+def test_xargs_options_are_stepped_over(monkeypatch):
+    # -n1 / -I{} carry their own values; the invoked command still starts at gh.
+    assert _run(monkeypatch, "printf '' | xargs -n1 gh pr merge 5 --squash", checks=(["x"], [])) == 2
+    assert _run(monkeypatch, "printf '' | xargs -t -n 1 gh pr merge 5", checks=(["x"], [])) == 2
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # `xargs echo gh pr merge 5` runs ECHO with data appended — not a merge. Treating
+        # xargs' operands as an invoked command blocked a plain logging line.
+        "printf 'x' | xargs echo gh pr merge 5",
+        "printf 'x' | xargs -n1 echo gh pr merge 5",
+    ],
+)
+def test_xargs_operands_are_not_a_merge(monkeypatch, cmd):
+    assert _run(monkeypatch, cmd, meta={"isDraft": True, "baseRefName": "main", "url": _URL}) == 0
+
+
+def test_invoked_start():
+    assert guard._invoked_start(["gh", "pr", "merge", "5"]) == (0, False)
+    assert guard._invoked_start(["xargs", "gh", "pr", "merge"]) == (1, True)
+    assert guard._invoked_start(["xargs", "-n", "1", "gh", "pr", "merge"]) == (3, True)
+    assert guard._invoked_start(["xargs", "-t", "gh", "pr", "merge"]) == (2, True)
+    assert guard._invoked_start(["sudo", "gh", "pr", "merge"]) == (1, False)
+
+
+# --- #4876: glued-operator evasion class ------------------------------------
+
+
+def _any_merge(command: str) -> bool:
+    return any(guard._merge_args(s) is not None for s in guard._segments(command))
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "true 2>&1 | head -1; gh pr merge 5 --squash",
+        "gh pr view 5 --jq '{state}'; gh pr merge 5 --auto --squash",
+        "echo hi\ngh pr merge 5 --squash",
+        "true;gh pr merge 5",
+        "env FOO=1 gh pr merge 5 --squash",
+        "FOO=1 gh pr merge 5 --squash",
+        "{ gh pr merge 5 --squash; }",
+    ],
+)
+def test_glued_operator_merge_detected(cmd):
+    assert _any_merge(cmd)
+
+
+def test_heredoc_merge_mention_not_detected():
+    cmd = "cat > /tmp/n.md <<'EOF'\nrun gh pr merge 5 --squash manually\nEOF"
+    assert not _any_merge(cmd)
+
+
+def test_unclosed_heredoc_does_not_hide_merge():
+    assert _any_merge("cat <<'NOEND'\nnote\ngh pr merge 5 --squash")
+
+
+def test_backslash_continuation_merge_detected():
+    assert _any_merge("gh pr merge 5 \\\n  --auto --squash")

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -792,3 +793,48 @@ def test_unclosed_heredoc_does_not_hide_merge():
 
 def test_backslash_continuation_merge_detected():
     assert _any_merge("gh pr merge 5 \\\n  --auto --squash")
+
+
+# --- colorized gh output (review B1, PR #5324) ------------------------------
+# Agent harnesses export CLICOLOR_FORCE/FORCE_COLOR (beating NO_COLOR), and gh
+# then colorizes piped --json output — raw json.loads fails and every merge
+# fail-closes. The guard must scrub the env AND tolerate residual ANSI.
+
+_COLORIZED_JSON = (
+    '\x1b[1;37m{\x1b[m\n'
+    '  \x1b[1;34m"baseRefName"\x1b[m: \x1b[32m"main"\x1b[m,\n'
+    '  \x1b[1;34m"isDraft"\x1b[m: \x1b[35mfalse\x1b[m,\n'
+    '  \x1b[1;34m"url"\x1b[m: \x1b[32m"https://github.com/owner/repo/pull/5"\x1b[m\n'
+    '\x1b[1;37m}\x1b[m\n'
+)
+
+
+def test_gh_env_scrubs_color_forcers(monkeypatch):
+    monkeypatch.setenv("CLICOLOR_FORCE", "1")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setenv("NO_COLOR", "1")
+    env = guard._gh_env()
+    assert "CLICOLOR_FORCE" not in env
+    assert "FORCE_COLOR" not in env
+    assert env["NO_COLOR"] == "1"
+    assert env["CLICOLOR"] == "0"
+
+
+def test_decolorize_recovers_parseable_json():
+    cleaned = guard._decolorize(_COLORIZED_JSON)
+    parsed = json.loads(cleaned)
+    assert parsed == {
+        "baseRefName": "main",
+        "isDraft": False,
+        "url": "https://github.com/owner/repo/pull/5",
+    }
+
+
+def test_colorized_check_rows_still_judged(monkeypatch):
+    """End-to-end through _check_states' parser: colorized rows must not read as
+    undeterminable (which would block every green merge)."""
+    rows = '\x1b[1;37m[{"name": "pytest", "bucket": "pass", "state": "SUCCESS"}]\x1b[m'
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=rows, stderr="")
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
+    failing, pending = guard._check_states("5")
+    assert failing == [] and pending == []


### PR DESCRIPTION
## Why

Branch protection is a paid feature **for private repos**. On the free-plan private repo the protection API answers **403**, so **no check is ever \"required\"** there — and everything downstream breaks quietly:

- a **draft PR was squash-merged before review** (#189 class);
- **two merges landed with the boundary-and-tests job RED**, because `gh pr merge --auto` only ever waits for *required* checks, and there were none to wait on.

This public repo is the lucky case — `main` **is** protected, with `CI Gate` required (verified live). The fleet works across both, so the guard decides **per-repo** instead of assuming either. That's why `--auto` is *allowed* on this PR and refused on the private one.

## What it enforces

`guard-pr-merge.py`, a PreToolUse (Bash) guard owning every `gh pr merge` without a bare `--admin`:

| # | Verdict | Why |
| --- | --- | --- |
| 1 | **draft PR** | a draft is by definition not review-ready (#189) |
| 2 | **any red non-advisory check** | red is red — \"required\" is a config accident, absent entirely on the private repo |
| 3 | **`--auto` on a base with no required status checks** | auto-merge fires regardless of checks; the 2-red-merges incident |
| 4 | **pending checks without `--auto`** | merging now merges an unknown result |
| 5 | all green | → allow |

**Fail-closed throughout.** An unverifiable PR, check state, base, or protection read is *refused*. `--auto` is the one verdict that consults protection, because it's the one thing protection actually changes.

**Division of labor**: a bare `--admin` stays `guard-admin-merge.py`'s job (#M-0.5) — skipped here, never double-judged.

**Scope, written into the docstring rather than implied**: this is a *discipline gate, not a sandbox*. `gh api -X PUT repos/{o}/{r}/pulls/{n}/merge` never says \"gh pr merge\", so no Bash matcher can see it. The job is to make the **careless** path refuse, not the deliberate path impossible.

## Cross-family review: 6 rounds, 21 real defects

Codex reviewed this five times and returned **\"incorrect\" every time**. I reproduced **every finding with tools before fixing** and re-probed after. Eighteen were codex's; three I found myself — including **two of my own fixes that were themselves broken**. A guard that fails open is worse than no guard, so each is now a named regression test.

**Fail-open — the guard never fired:**

| Command | Why it slipped |
| --- | --- |
| `bash -c 'gh pr merge 5'`, `bash -cx '...'`, `bash -c $'...'` | segment starts with `bash`; `c` needn't end the cluster; ANSI-C quoting survives tokenizing as a literal `$`, making the first token `$gh` |
| `sudo -u bot gh pr merge`, `env -i gh pr merge`, `xargs sh -c '...'` | the wrapper skipper ate the wrapper but **not its options** |
| `g\h pr merge 5` | the shell strips the backslash before running gh; the **raw-text fast path** never saw \"gh\" and returned 0 before the parser ran |
| `gh pr merge 5 --subject --disable-auto` | a normal merge whose **subject** is \"--disable-auto\"; pflag takes the next token as a value even when it looks like a flag |
| deeply nested `bash -c` | the recursion cap returned payloads **uninspected**. My first fix was **inert** — the marker carried no selector, and `_pr_ref` falls back to the current branch's PR, so a green branch would have approved an unread payload |

**Fail-open — the guard fired but read the wrong thing:**

| Command | Why it was wrong |
| --- | --- |
| `--auto=true` | **skipped the protection check** and armed auto-merge on an unprotected base — the incident itself |
| `--auto=false --auto` | read as OFF; pflag is **last-wins**, so that IS auto-merge |
| `--subject 5`, `-st green-subject` | judged PR #5 / a PR named \"green-subject\" — those are **subject values** |
| `gh pr merge -R other/repo 9` | `--repo` (inherited by every `gh pr` subcommand) was read as the **PR selector** and never propagated → judged THIS repo's #9 |
| `printf '5' \| xargs gh pr merge` | selector arrives on **stdin**; the guard judged the current branch instead |
| a URL selector | judged whatever PR **cwd** was on; identity now comes from the PR's own `url` (base repo, fork-safe) |
| unknown check bucket · `isDraft:null` · `required_status_checks` with `contexts:[]`+`checks:[]` | each read as green / not-a-draft / protected while requiring nothing |

**False blocks** (a guard that cries wolf teaches people to ignore it): `gh pr merge --help` and `--help=true`; `--disable-auto=true` (the safe disarm, and the remedy verdict 3 asks for); `printf 'x' \| xargs echo gh pr merge 5` (runs echo, not gh).

### Verified against real gh, not memory

gh is cobra/pflag — `--auto`/`--auto=true` are one flag, repeated flags are last-wins, and `-c` needn't end a cluster:

\`\`\`
$ gh pr list --draft=notabool --limit 1
invalid argument "notabool" for "-d, --draft" flag: strconv.ParseBool: parsing "notabool": invalid syntax
$ gh pr list --draft=false --draft=true --limit 2      # last-wins → returns a DRAFT row
5244  chore(dispatch): finalize grok-build task ...  DRAFT
$ bash -c 'g\h --version'        → gh version 2.96.0     # escaped gh still runs
$ bash -cx 'echo hi-from-cx'     → hi-from-cx            # c not last in cluster
$ gh pr view --help | grep -A3 'INHERITED FLAGS'
  -R, --repo [HOST/]OWNER/REPO   Select another repository
\`\`\`

**Two of my own probes were wrong, and codex was right both times.** My first `--auto=true` check used `gh pr merge --auto=true --help` and appeared to *disprove* the finding — but a repo shim intercepts every agent `gh pr merge` (`AGENT_NO_MERGE=1`, INCIDENT #1403), so it never reached gh's parser. The read-only commands above are the honest test.

## Verification

**180 targeted tests** (one per finding; the prior art's 30 unregressed) · **ruff clean** on every touched file.

\`\`\`
$ .venv/bin/python -m pytest tests/test_guard_pr_merge.py tests/test_guard_admin_merge.py -q
============================= 180 passed in 0.87s ==============================
\`\`\`

**Every verdict class through the real subprocess path** (stub `gh` on PATH):

\`\`\`
block-draft            → exit 2   BLOCKED ... PR 5 is a DRAFT.
block-red              → exit 2   BLOCKED ... PR 5 has FAILING checks: boundary-and-tests.
block-pending-no-auto  → exit 2   BLOCKED ... PR 5 has checks still running: Test (pytest).
block-auto-unprotected → exit 2   BLOCKED ... --auto on owner/repo@main, which has no required status checks.
block-undeterminable   → exit 2   BLOCKED ... could not determine whether owner/repo@main is protected.
ALLOW-green / ALLOW-admin / ALLOW-quoted-mention → exit 0
\`\`\`

**End-to-end against this very PR** (real `gh`, no stubs) — the guard judging itself:

\`\`\`
_base_protected('learn-ukrainian/learn-ukrainian.github.io','main') -> True   # CI Gate required
_base_protected(..., 'no-such-branch-xyz')                          -> False  # 404 path
_pr_meta('5324')  -> {'baseRefName': 'main', 'isDraft': False, 'url': '.../pull/5324'}
gh pr checks 5324 -> 31 checks: {'pass': 20, 'skipping': 11}  → verdict: ALLOWED (correct)
--auto=true on this PR -> ALLOWED (base IS protected — the per-repo decision working)
\`\`\`

**False-block sweep** — 15 ordinary commands (`git push`, `gh pr create/view/checks/ready`, `grep 'gh pr merge' docs/`, `git merge`, `python merge_data.py --pr 5`, `echo ...`), all exit 0 against a **red** PR. This sweep is what caught the `--help` false block.

**Zero regressions, measured not assumed.** Full-suite failure-set diff vs a clean `origin/main` worktree: baseline 44 failures, this branch 45. The 2 deltas (`test_citation_resolution_invariant`, `test_grow_lexicon_from_content`) **fail identically with this diff stashed in the same worktree** — pre-existing sparse-checkout artifacts. No guard/hook test fails in either run.

Repo-wide `ruff check .` reports 28 errors — **pre-existing on origin/main**, confirmed by stash (identical count). Worktree caveat for re-runners: many tests shell out to `.venv/bin/python` relative to the repo root and worktrees have no `.venv`; symlinking it cuts \"failures\" from 160 to ~45.

### Two blind spots in the sibling (follow-ups, not touched here)

The brief says don't change `guard-admin-merge.py`'s behavior, so I didn't — but the same review applies to it:

1. **`--admin=true` is invisible to it** (exact-token match). Rather than let that fall between the hooks, this guard judges `--admin=true` itself — no double-judging, since the sibling never sees it.
2. **The wrapper-option, `bash -c`, and escaped-`gh` evasions exist there too**: `sudo -u bot gh pr merge 5 --admin` is judged by neither hook. Fixes here live in this hook's own helpers, leaving the copied segmentation helpers byte-identical per the keep-in-sync note. Worth a follow-up PR.

**Deviation from the brief, flagged:** it specified a raw-text fast path (`return 0 unless the command contains gh+pr+merge`). That is itself a fail-open — `g\h pr merge` never matches. The probe now strips quotes/backslashes first, which only ever sends *more* commands to the full parse.

## Registration & docs

- `agents_extensions/shared/settings.json` — same PreToolUse Bash matcher block, right after `guard-admin-merge`, mirroring its entry (timeout 30).
- `agents_extensions/codex/hooks.json` — mirrored per the sibling pattern.
- `.claude/` / `.codex/` untouched (gitignored; deploy rsyncs the whole `agents_extensions/shared/` tree, so the hook rides along — no manifest to update).
- Keep-in-sync note now reads **four copies** in all siblings.
- `docs/best-practices/gitflow.md` gains a *Merge guards* section: the two-hook division of labor, why the platform can't enforce it (and why this repo is the exception), and the escape hatch — a human merging outside the agent harness.

## Review

Not merging, not arming auto-merge — the orchestrator merges after review. (`--auto` would in fact be *allowed* here since `main` is protected, but a guard against careless auto-merge shouldn't arm auto-merge on itself.)

Refs #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)