### PR TITLE
feat(orchestration): deterministic archived-task cleanup

### DIFF
--- a/docs/runbooks/archived-thread-cleanup.md
+++ b/docs/runbooks/archived-thread-cleanup.md
@@ -1,0 +1,166 @@
+# Archived thread cleanup
+
+This runbook operates the deterministic cleanup for old Codex archived threads. It does not run a
+model, submit a prompt, or use a Codex automation. A per-user macOS `launchd` job runs the same Python
+command every week.
+
+## Safety policy
+
+The cleanup uses a 30-day retention period. A thread is only a deletion candidate when it is archived,
+older than the retention cutoff, unpinned, inactive, and free of protected lifecycle references. The
+cleanup engine revalidates eligibility before deletion.
+
+Apply mode does not delete a newly eligible candidate on first sight. It records the first weekly
+observation. The same candidate must remain eligible with an unchanged safety fingerprint on a second
+weekly run at least seven days later before it can be deleted. A changed or newly protected thread does
+not pass the second observation.
+
+Permanent deletion goes through the supported Codex CLI operation, equivalent to:
+
+```bash
+codex delete --force <thread-uuid>
+```
+
+The cleanup does not unlink session files or edit Codex's state database directly.
+
+## Manual dry run
+
+Run from the merged primary checkout with its project virtual environment:
+
+```bash
+.venv/bin/python scripts/orchestration/archived_thread_cleanup.py
+```
+
+The default performs no deletion, but it does persist observation state and a receipt. Review the JSON
+result and its receipt before enabling or invoking apply mode. To test another retention boundary
+explicitly:
+
+```bash
+.venv/bin/python scripts/orchestration/archived_thread_cleanup.py --retention-days 30
+```
+
+## Manual apply
+
+Apply the policy once with:
+
+```bash
+.venv/bin/python scripts/orchestration/archived_thread_cleanup.py --apply --repo-root "$PWD"
+```
+
+The first qualifying run records observations; only a later qualifying run at least seven days after
+the first observation can delete an unchanged candidate. The command remains non-interactive.
+
+Runtime state is stored at `~/.codex/thread-cleanup/state-v1.json`; versioned receipts are written under
+`~/.codex/thread-cleanup/receipts/v1/`. Standard output and standard error from scheduled runs are
+appended to:
+
+```text
+~/.codex/thread-cleanup/logs/stdout.log
+~/.codex/thread-cleanup/logs/stderr.log
+```
+
+Keep the receipts for both initial weekly observations. They are the audit record for why a thread was
+retained, advanced to its second observation, skipped, or deleted.
+
+## Inspect the launch agent without installing it
+
+Render the plist without disk writes or `launchctl` calls:
+
+```bash
+.venv/bin/python scripts/orchestration/install_archived_thread_cleanup_launchd.py render \
+  --repo-root "$PWD" \
+  --weekday sunday \
+  --hour 3
+```
+
+`install --dry-render` is an equivalent test-only path. Both forms are safe on non-macOS hosts and are
+useful for inspecting `ProgramArguments` in tests.
+
+## Install the weekly job
+
+Install only from the merged primary checkout. The absolute checkout path is persisted in the plist,
+so do not install from a disposable worktree. The default schedule is Sunday at 03:00 in the Mac's
+local time:
+
+```bash
+.venv/bin/python scripts/orchestration/install_archived_thread_cleanup_launchd.py install \
+  --repo-root "$PWD"
+```
+
+The installer atomically writes:
+
+```text
+~/Library/LaunchAgents/com.learn-ukrainian.codex-archived-thread-cleanup.plist
+```
+
+Its `ProgramArguments` use the checkout's explicit `.venv/bin/python` to run
+`scripts/orchestration/archived_thread_cleanup.py --apply --repo-root <checkout> --retention-days 30
+--observation-interval-days 7`. The installer also resolves the supported Codex CLI to an absolute,
+executable path and persists it through `--codex-binary`; the scheduled job does not depend on
+`launchd`'s minimal `PATH`. Installation is idempotent: an unchanged loaded job is left in place; a
+changed job is unloaded, rewritten, loaded, and verified through `launchctl print`.
+
+If `codex` is not on the interactive shell's `PATH`, provide its absolute path explicitly:
+
+```bash
+.venv/bin/python scripts/orchestration/install_archived_thread_cleanup_launchd.py install \
+  --repo-root "$PWD" \
+  --codex-binary "$HOME/.local/bin/codex"
+```
+
+To choose another weekly local schedule, pass a lowercase weekday name and an hour from 0 through 23:
+
+```bash
+.venv/bin/python scripts/orchestration/install_archived_thread_cleanup_launchd.py install \
+  --repo-root "$PWD" \
+  --weekday wednesday \
+  --hour 4
+```
+
+## Verify status and observe the first two runs
+
+Check both the plist and launchd's live service state:
+
+```bash
+.venv/bin/python scripts/orchestration/install_archived_thread_cleanup_launchd.py status
+```
+
+The command exits successfully only when the expected plist is installed, parses with the correct
+label, and the service is loaded. For lower-level readback:
+
+```bash
+launchctl print "gui/$(id -u)/com.learn-ukrainian.codex-archived-thread-cleanup"
+```
+
+After each of the first two scheduled runs:
+
+1. Run the status command and confirm the service remains loaded.
+2. Inspect `~/.codex/thread-cleanup/logs/stderr.log`; it should contain no unhandled error.
+3. Inspect the new receipt under `~/.codex/thread-cleanup/receipts/v1/` and reconcile its counts with the
+   JSON line in `stdout.log`.
+4. Confirm the first run only recorded observations. On the second run, confirm that only candidates
+   observed unchanged at least seven days apart were eligible for deletion.
+
+If the Mac is asleep at the scheduled time, `launchd` normally coalesces the missed calendar event and
+runs it after wake. The cleanup engine's minimum seven-day observation interval remains the controlling
+deletion gate.
+
+## Uninstall
+
+Unload the service and remove its plist:
+
+```bash
+.venv/bin/python scripts/orchestration/install_archived_thread_cleanup_launchd.py uninstall
+```
+
+Uninstall is idempotent. It intentionally preserves `~/.codex/thread-cleanup/`, including receipts and
+logs, so removing the schedule does not destroy its audit trail.
+
+## Residual race window
+
+The cleanup takes a fresh protected-state snapshot and revalidates each candidate immediately before it
+invokes `codex delete --force`. There is still an unavoidable time-of-check/time-of-use window: another
+process could pin, activate, restore, or otherwise reference the thread after the last validation but
+before the Codex CLI completes deletion. The two-observation gate and last-moment revalidation reduce
+that risk but cannot make multiple independent processes transactional. Uninstall the launch agent
+before performing bulk thread lifecycle changes, then run a fresh dry run before reinstalling it.

--- a/docs/runbooks/archived-thread-cleanup.md
+++ b/docs/runbooks/archived-thread-cleanup.md
@@ -52,7 +52,7 @@ the first observation can delete an unchanged candidate. The command remains non
 
 Runtime state is stored at `~/.codex/thread-cleanup/state-v1.json`; versioned receipts are written under
 `~/.codex/thread-cleanup/receipts/v1/`. Standard output and standard error from scheduled runs are
-appended to:
+written to:
 
 ```text
 ~/.codex/thread-cleanup/logs/stdout.log

--- a/scripts/orchestration/archived_thread_cleanup.py
+++ b/scripts/orchestration/archived_thread_cleanup.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""Deterministically age, protect, and delete archived Codex threads."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import fcntl
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import tomllib
+import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, TextIO
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.orchestration.task_family import codex_state, rollover_registry
+
+STATE_SCHEMA_VERSION = "archived-thread-cleanup-state.v1"
+RECEIPT_SCHEMA_VERSION = "archived-thread-cleanup-receipt.v1"
+RETENTION_DAYS = 30
+OBSERVATION_INTERVAL_DAYS = 7
+CURRENT_THREAD_ENV_VARS = (
+    "LEARN_UKRAINIAN_SESSION_ID",
+    "CODEX_THREAD_ID",
+    "CODEX_SESSION_ID",
+    "CODEX_SESSION",
+)
+UUID_PATTERN = re.compile(
+    r"(?<![0-9A-Fa-f])"
+    r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+    r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+    r"(?![0-9A-Fa-f])"
+)
+
+DeleteRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+Sleep = Callable[[float], None]
+
+
+class CleanupError(RuntimeError):
+    """Base error for deterministic cleanup failures."""
+
+
+class CleanupBusyError(CleanupError):
+    """Another cleanup process owns the exclusive lock."""
+
+
+class CleanupStateError(CleanupError):
+    """Persisted observation state is missing required structure."""
+
+
+@dataclass(frozen=True)
+class ProtectionSnapshot:
+    pinned_ids: frozenset[str]
+    current_ids: frozenset[str]
+    automation_ids: frozenset[str]
+    rollover_ids: frozenset[str]
+    relevant_roots: tuple[Path, ...]
+    errors: tuple[str, ...]
+
+    def reasons_for(self, thread_id: str) -> list[str]:
+        reasons: list[str] = []
+        if thread_id in self.pinned_ids:
+            reasons.append("pinned")
+        if thread_id in self.current_ids:
+            reasons.append("current_thread")
+        if thread_id in self.automation_ids:
+            reasons.append("automation_reference")
+        if thread_id in self.rollover_ids:
+            reasons.append("live_rollover_reference")
+        if self.errors:
+            reasons.append("protection_registry_unavailable")
+        return reasons
+
+
+def _now_utc(now: datetime | None) -> datetime:
+    value = now or datetime.now(UTC)
+    if value.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    return value.astimezone(UTC)
+
+
+def _isoformat(value: datetime) -> str:
+    return value.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_time(value: Any, *, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise CleanupStateError(f"{field} must be a non-empty timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise CleanupStateError(f"{field} is not an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise CleanupStateError(f"{field} must be timezone-aware")
+    return parsed.astimezone(UTC)
+
+
+def _normalize_uuid(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError("thread id must be a string UUID")
+    return str(uuid.UUID(value.strip()))
+
+
+def _uuid_strings(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            found.update(_uuid_strings(key))
+            found.update(_uuid_strings(child))
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            found.update(_uuid_strings(child))
+    elif isinstance(value, str):
+        for match in UUID_PATTERN.finditer(value):
+            found.add(str(uuid.UUID(match.group(0))))
+    return found
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise CleanupError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise CleanupError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(path.parent, 0o700)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+@contextmanager
+def cleanup_lock(state_dir: Path) -> Iterable[TextIO]:
+    state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(state_dir, 0o700)
+    lock_path = state_dir / "cleanup-v1.lock"
+    handle = lock_path.open("a+", encoding="utf-8")
+    try:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise CleanupBusyError(f"cleanup lock is already held: {lock_path}") from exc
+        yield handle
+    finally:
+        handle.close()
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"schema_version": STATE_SCHEMA_VERSION, "observations": {}}
+    payload = _read_json_object(path, label="cleanup state")
+    if payload.get("schema_version") != STATE_SCHEMA_VERSION:
+        raise CleanupStateError(f"unsupported cleanup state version in {path}")
+    observations = payload.get("observations")
+    if not isinstance(observations, dict):
+        raise CleanupStateError(f"cleanup state observations must be an object: {path}")
+    for raw_id, observation in observations.items():
+        try:
+            normalized = _normalize_uuid(raw_id)
+        except (ValueError, AttributeError) as exc:
+            raise CleanupStateError(f"cleanup state has invalid thread id: {raw_id!r}") from exc
+        if normalized != raw_id or not isinstance(observation, dict):
+            raise CleanupStateError(f"cleanup state has malformed observation for {raw_id!r}")
+        fingerprint = observation.get("fingerprint")
+        count = observation.get("observation_count")
+        if not isinstance(fingerprint, str) or len(fingerprint) != 64:
+            raise CleanupStateError(f"cleanup state fingerprint is invalid for {raw_id}")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 1:
+            raise CleanupStateError(f"cleanup state observation count is invalid for {raw_id}")
+        _parse_time(observation.get("first_observed_at"), field="first_observed_at")
+        _parse_time(observation.get("last_observed_at"), field="last_observed_at")
+    return payload
+
+
+def _thread_fingerprint(record: codex_state.CleanupThreadRecord) -> str:
+    serialized = json.dumps(
+        dataclasses.asdict(record),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _load_global_state(codex_home: Path) -> tuple[set[str], set[Path], list[str]]:
+    path = codex_home / ".codex-global-state.json"
+    errors: list[str] = []
+    try:
+        payload = _read_json_object(path, label="Codex global state")
+    except CleanupError as exc:
+        return set(), set(), [str(exc)]
+
+    pinned: set[str] = set()
+    raw_pinned = payload.get("pinned-thread-ids")
+    if not isinstance(raw_pinned, list):
+        errors.append(f"pin registry is missing or malformed: {path}")
+    else:
+        for raw_id in raw_pinned:
+            try:
+                pinned.add(_normalize_uuid(raw_id))
+            except (ValueError, AttributeError):
+                errors.append(f"pin registry contains a non-UUID value: {raw_id!r}")
+
+    roots: set[Path] = set()
+    raw_roots = payload.get("active-workspace-roots", [])
+    if not isinstance(raw_roots, list) or any(not isinstance(item, str) for item in raw_roots):
+        errors.append(f"active workspace root registry is malformed: {path}")
+    else:
+        roots.update(Path(item).expanduser() for item in raw_roots)
+    return pinned, roots, errors
+
+
+def _load_automation_references(codex_home: Path) -> tuple[set[str], set[Path], list[str]]:
+    automation_ids: set[str] = set()
+    roots: set[Path] = set()
+    errors: list[str] = []
+    automations_dir = codex_home / "automations"
+    if not automations_dir.exists():
+        return automation_ids, roots, errors
+    if not automations_dir.is_dir():
+        return automation_ids, roots, [f"automation registry is not a directory: {automations_dir}"]
+    for path in sorted(automations_dir.glob("**/automation.toml")):
+        try:
+            with path.open("rb") as handle:
+                payload = tomllib.load(handle)
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            errors.append(f"cannot read automation {path}: {exc}")
+            continue
+        automation_ids.update(_uuid_strings(payload))
+        cwds = payload.get("cwds", [])
+        if isinstance(cwds, list) and all(isinstance(item, str) for item in cwds):
+            roots.update(Path(item).expanduser() for item in cwds)
+        elif "cwds" in payload:
+            errors.append(f"automation cwds is malformed: {path}")
+    return automation_ids, roots, errors
+
+
+def _relevant_rollover_roots(paths: Iterable[Path]) -> tuple[Path, ...]:
+    roots: set[Path] = set()
+    for raw_path in paths:
+        path = raw_path.expanduser()
+        for candidate in (path, *path.parents):
+            if (candidate / ".agent" / "thread-rollovers").is_dir():
+                roots.add(candidate.resolve())
+                break
+    return tuple(sorted(roots))
+
+
+def _load_live_rollover_references(roots: Iterable[Path]) -> tuple[set[str], list[str]]:
+    protected: set[str] = set()
+    errors: list[str] = []
+    for root in roots:
+        rollover_root = root / ".agent" / "thread-rollovers"
+        for path in sorted(rollover_root.glob("*/*/lease.json")):
+            try:
+                payload = _read_json_object(path, label="rollover lease")
+                record = rollover_registry.record_from_lease(root, path, payload)
+                if rollover_registry.is_live_pending(record):
+                    protected.update(_uuid_strings(payload))
+            except (CleanupError, OSError, ValueError) as exc:
+                errors.append(f"cannot classify rollover lease {path}: {exc}")
+    return protected, errors
+
+
+def load_protections(
+    *,
+    codex_home: Path,
+    records: Iterable[codex_state.CleanupThreadRecord],
+    environ: Mapping[str, str] | None = None,
+    current_cwd: Path | None = None,
+) -> ProtectionSnapshot:
+    """Load all fail-closed protection registries for one cleanup observation."""
+    environment = environ if environ is not None else os.environ
+    pinned, global_roots, global_errors = _load_global_state(codex_home)
+    automation_ids, automation_roots, automation_errors = _load_automation_references(codex_home)
+    current_ids: set[str] = set()
+    for name in CURRENT_THREAD_ENV_VARS:
+        value = environment.get(name)
+        if not value:
+            continue
+        try:
+            current_ids.add(_normalize_uuid(value))
+        except ValueError:
+            # CODEX_SESSION is also used as a boolean marker by legacy scripts.
+            if name != "CODEX_SESSION":
+                global_errors.append(f"{name} does not contain an exact UUID")
+
+    search_roots = {Path(record.cwd).expanduser() for record in records if record.cwd}
+    search_roots.update(global_roots)
+    search_roots.update(automation_roots)
+    search_roots.add((current_cwd or Path.cwd()).expanduser())
+    relevant_roots = _relevant_rollover_roots(search_roots)
+    rollover_ids, rollover_errors = _load_live_rollover_references(relevant_roots)
+    return ProtectionSnapshot(
+        pinned_ids=frozenset(pinned),
+        current_ids=frozenset(current_ids),
+        automation_ids=frozenset(automation_ids),
+        rollover_ids=frozenset(rollover_ids),
+        relevant_roots=relevant_roots,
+        errors=tuple(sorted({*global_errors, *automation_errors, *rollover_errors})),
+    )
+
+
+def _allocated_bytes(path_value: str) -> int:
+    if not path_value:
+        return 0
+    path = Path(path_value).expanduser()
+    try:
+        stat = path.stat()
+    except OSError:
+        return 0
+    blocks = getattr(stat, "st_blocks", 0)
+    return int(blocks * 512) if blocks else int(stat.st_size)
+
+
+def _default_runner(codex_home: Path) -> DeleteRunner:
+    def run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["CODEX_HOME"] = str(codex_home)
+        return subprocess.run(
+            list(command),
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+            timeout=120,
+        )
+
+    return run
+
+
+def _reconcile_absent(
+    db_path: Path,
+    thread_id: str,
+    *,
+    attempts: int = 5,
+    sleep: Sleep = time.sleep,
+) -> bool:
+    for attempt in range(attempts):
+        try:
+            codex_state.read_cleanup_thread_record(
+                db_path,
+                thread_id=thread_id,
+                read_window_seconds=0.25,
+            )
+        except codex_state.CodexStateMissingTaskError:
+            return True
+        if attempt + 1 < attempts:
+            sleep(0.1)
+    return False
+
+
+def _observe(
+    previous: Mapping[str, Any] | None,
+    *,
+    fingerprint: str,
+    now: datetime,
+    observation_interval_days: int,
+) -> tuple[dict[str, Any], bool]:
+    now_text = _isoformat(now)
+    if previous is None or previous.get("fingerprint") != fingerprint:
+        return (
+            {
+                "fingerprint": fingerprint,
+                "first_observed_at": now_text,
+                "last_observed_at": now_text,
+                "observation_count": 1,
+            },
+            False,
+        )
+    first = _parse_time(previous.get("first_observed_at"), field="first_observed_at")
+    count = int(previous.get("observation_count", 0)) + 1
+    observation = {
+        "fingerprint": fingerprint,
+        "first_observed_at": _isoformat(first),
+        "last_observed_at": now_text,
+        "observation_count": count,
+    }
+    mature = count >= 2 and now - first >= timedelta(days=observation_interval_days)
+    return observation, mature
+
+
+def _receipt_path(state_dir: Path, now: datetime) -> Path:
+    stamp = now.strftime("%Y%m%dT%H%M%SZ")
+    return state_dir / "receipts" / "v1" / f"{stamp}-{os.getpid()}-{uuid.uuid4().hex[:12]}.json"
+
+
+def run_cleanup(
+    *,
+    apply: bool = False,
+    codex_home: Path | None = None,
+    db_path: Path | None = None,
+    state_dir: Path | None = None,
+    now: datetime | None = None,
+    runner: DeleteRunner | None = None,
+    sleep: Sleep = time.sleep,
+    codex_binary: str = "codex",
+    environ: Mapping[str, str] | None = None,
+    current_cwd: Path | None = None,
+    retention_days: int = RETENTION_DAYS,
+    observation_interval_days: int = OBSERVATION_INTERVAL_DAYS,
+) -> dict[str, Any]:
+    """Run one locked cleanup observation and optionally apply mature deletions."""
+    clock = _now_utc(now)
+    if retention_days < 1:
+        raise ValueError("retention_days must be at least 1")
+    if observation_interval_days < 1:
+        raise ValueError("observation_interval_days must be at least 1")
+    home = (codex_home or Path.home() / ".codex").expanduser()
+    cleanup_dir = (state_dir or home / "thread-cleanup").expanduser()
+    database = db_path or codex_state.discover_state_database(codex_home=home)
+    delete_runner = runner or _default_runner(home)
+    state_path = cleanup_dir / "state-v1.json"
+
+    with cleanup_lock(cleanup_dir):
+        state = _load_state(state_path)
+        previous_observations = state["observations"]
+        records = codex_state.list_archived_cleanup_threads(database)
+        protections = load_protections(
+            codex_home=home,
+            records=records,
+            environ=environ,
+            current_cwd=current_cwd,
+        )
+        cutoff = int((clock - timedelta(days=retention_days)).timestamp())
+        observations: dict[str, Any] = {}
+        outcomes: list[dict[str, Any]] = []
+        mature_ids: list[str] = []
+
+        for record in records:
+            fingerprint = _thread_fingerprint(record)
+            entry: dict[str, Any] = {
+                "thread_id": record.thread_id,
+                "title": record.title,
+                "archived_at": record.archived_at,
+                "updated_at": record.updated_at,
+                "fingerprint": fingerprint,
+                "bytes_before": _allocated_bytes(record.rollout_path),
+            }
+            reasons = protections.reasons_for(record.thread_id)
+            if record.archived_at is None:
+                entry.update(outcome="protected", reasons=["invalid_archive_state", *reasons])
+            elif record.archived_at > cutoff:
+                entry.update(outcome="retained", reasons=["retention_period", *reasons])
+            elif reasons:
+                entry.update(outcome="protected", reasons=reasons)
+            else:
+                observation, mature = _observe(
+                    previous_observations.get(record.thread_id),
+                    fingerprint=fingerprint,
+                    now=clock,
+                    observation_interval_days=observation_interval_days,
+                )
+                observations[record.thread_id] = observation
+                if mature:
+                    mature_ids.append(record.thread_id)
+                    entry.update(outcome="ready", reasons=[])
+                else:
+                    entry.update(outcome="observing", reasons=["two_observations_seven_days_apart"])
+                entry["observation"] = observation
+            outcomes.append(entry)
+
+        state = {
+            "schema_version": STATE_SCHEMA_VERSION,
+            "updated_at": _isoformat(clock),
+            "observations": observations if not protections.errors else {},
+        }
+        _write_json(state_path, state)
+
+        outcome_by_id = {entry["thread_id"]: entry for entry in outcomes}
+        if apply and not protections.errors:
+            for thread_id in mature_ids:
+                entry = outcome_by_id[thread_id]
+                try:
+                    refreshed = codex_state.read_cleanup_thread_record(database, thread_id=thread_id)
+                except codex_state.CodexStateError as exc:
+                    entry.update(outcome="refresh_failed", error=str(exc))
+                    continue
+                refreshed_fingerprint = _thread_fingerprint(refreshed)
+                if (
+                    refreshed_fingerprint != entry["fingerprint"]
+                    or not refreshed.archived
+                    or refreshed.archived_at is None
+                    or refreshed.archived_at > cutoff
+                ):
+                    observations[thread_id], _ = _observe(
+                        None,
+                        fingerprint=refreshed_fingerprint,
+                        now=clock,
+                        observation_interval_days=observation_interval_days,
+                    )
+                    entry.update(outcome="changed_before_delete", refreshed_fingerprint=refreshed_fingerprint)
+                    continue
+
+                refreshed_protections = load_protections(
+                    codex_home=home,
+                    records=records,
+                    environ=environ,
+                    current_cwd=current_cwd,
+                )
+                refreshed_reasons = refreshed_protections.reasons_for(thread_id)
+                if refreshed_reasons:
+                    observations.pop(thread_id, None)
+                    entry.update(outcome="protected_before_delete", reasons=refreshed_reasons)
+                    continue
+
+                bytes_before = _allocated_bytes(refreshed.rollout_path)
+                command = (codex_binary, "delete", "--force", thread_id)
+                try:
+                    result = delete_runner(command)
+                    returncode = int(result.returncode)
+                    stderr = (result.stderr or "").strip()[-500:]
+                except Exception as exc:
+                    entry.update(outcome="delete_failed", error=f"runner failure: {exc}")
+                    continue
+                try:
+                    absent = _reconcile_absent(database, thread_id, sleep=sleep)
+                except codex_state.CodexStateError as exc:
+                    entry.update(
+                        command=list(command),
+                        command_returncode=returncode,
+                        stderr=stderr,
+                        outcome="reconciliation_failed",
+                        error=str(exc),
+                    )
+                    continue
+                bytes_after = _allocated_bytes(refreshed.rollout_path)
+                entry.update(
+                    command=list(command),
+                    command_returncode=returncode,
+                    stderr=stderr,
+                    bytes_before=bytes_before,
+                    bytes_after=bytes_after,
+                    reclaimed_bytes=max(0, bytes_before - bytes_after),
+                    outcome=(
+                        "deleted"
+                        if absent and returncode == 0
+                        else "deleted_with_cli_error"
+                        if absent
+                        else "reconciliation_failed"
+                        if returncode == 0
+                        else "delete_failed"
+                    ),
+                )
+                if absent:
+                    observations.pop(thread_id, None)
+
+            state["observations"] = observations
+            _write_json(state_path, state)
+        elif apply:
+            for thread_id in mature_ids:
+                outcome_by_id[thread_id].update(
+                    outcome="apply_blocked",
+                    reasons=["protection_registry_unavailable"],
+                )
+        else:
+            for thread_id in mature_ids:
+                outcome_by_id[thread_id]["outcome"] = "ready_dry_run"
+
+        summary: dict[str, int] = {}
+        for entry in outcomes:
+            outcome = str(entry["outcome"])
+            summary[outcome] = summary.get(outcome, 0) + 1
+        summary["archived_threads"] = len(records)
+        summary["reclaimed_bytes"] = sum(int(entry.get("reclaimed_bytes", 0)) for entry in outcomes)
+        receipt = {
+            "schema_version": RECEIPT_SCHEMA_VERSION,
+            "mode": "apply" if apply else "dry-run",
+            "started_at": _isoformat(clock),
+            "policy": {
+                "retention_days": retention_days,
+                "observation_interval_days": observation_interval_days,
+                "required_unchanged_observations": 2,
+            },
+            "codex_home": str(home),
+            "database": str(database),
+            "state_path": str(state_path),
+            "protection_errors": list(protections.errors),
+            "relevant_rollover_roots": [str(path) for path in protections.relevant_roots],
+            "summary": summary,
+            "outcomes": outcomes,
+        }
+        receipt_path = _receipt_path(cleanup_dir, clock)
+        receipt["receipt_path"] = str(receipt_path)
+        _write_json(receipt_path, receipt)
+        return receipt
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="apply mature deletions (default is a stateful dry-run observation)",
+    )
+    parser.add_argument("--codex-home", type=Path, default=Path.home() / ".codex")
+    parser.add_argument("--db", type=Path, help="explicit Codex state_*.sqlite path")
+    parser.add_argument("--state-dir", type=Path, help="override versioned state/receipt directory")
+    parser.add_argument("--codex-binary", default="codex")
+    parser.add_argument("--repo-root", type=Path, help="repository root used for rollover protection")
+    parser.add_argument("--retention-days", type=int, default=RETENTION_DAYS)
+    parser.add_argument(
+        "--observation-interval-days",
+        type=int,
+        default=OBSERVATION_INTERVAL_DAYS,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        receipt = run_cleanup(
+            apply=args.apply,
+            codex_home=args.codex_home,
+            db_path=args.db,
+            state_dir=args.state_dir,
+            codex_binary=args.codex_binary,
+            current_cwd=args.repo_root,
+            retention_days=args.retention_days,
+            observation_interval_days=args.observation_interval_days,
+        )
+    except (CleanupError, codex_state.CodexStateError, OSError, ValueError) as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}, sort_keys=True))
+        return 2
+    print(
+        json.dumps(
+            {
+                "status": "blocked" if args.apply and receipt["protection_errors"] else "ok",
+                "mode": receipt["mode"],
+                "receipt_path": receipt["receipt_path"],
+                "summary": receipt["summary"],
+                "protection_errors": receipt["protection_errors"],
+            },
+            sort_keys=True,
+        )
+    )
+    failed = sum(
+        count
+        for outcome, count in receipt["summary"].items()
+        if outcome in {"apply_blocked", "delete_failed", "reconciliation_failed", "refresh_failed"}
+    )
+    return 2 if failed or (args.apply and receipt["protection_errors"]) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/install_archived_thread_cleanup_launchd.py
+++ b/scripts/orchestration/install_archived_thread_cleanup_launchd.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Install the deterministic archived-thread cleanup launchd job on macOS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+LABEL = "com.learn-ukrainian.codex-archived-thread-cleanup"
+DEFAULT_WEEKDAY = "sunday"
+DEFAULT_HOUR = 3
+WEEKDAYS = {
+    "sunday": 0,
+    "monday": 1,
+    "tuesday": 2,
+    "wednesday": 3,
+    "thursday": 4,
+    "friday": 5,
+    "saturday": 6,
+}
+
+
+class LaunchdError(RuntimeError):
+    """Raised when launchd cannot reach the requested final state."""
+
+
+def default_repo_root() -> Path:
+    """Return the checkout containing this installer."""
+    return Path(__file__).resolve().parents[2]
+
+
+def default_home() -> Path:
+    """Return the current user's home without consulting shell expansion."""
+    return Path.home()
+
+
+def valid_hour(value: str) -> int:
+    """Parse and validate a launch hour in local time."""
+    try:
+        hour = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("hour must be an integer from 0 through 23") from exc
+    if not 0 <= hour <= 23:
+        raise argparse.ArgumentTypeError("hour must be an integer from 0 through 23")
+    return hour
+
+
+def plist_path(home: Path) -> Path:
+    """Return the per-user launch agent path."""
+    return home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def state_dir(home: Path) -> Path:
+    """Return the durable scheduler log and cleanup-state directory."""
+    return home / ".codex" / "thread-cleanup"
+
+
+def resolve_codex_binary(configured: Path | None) -> Path:
+    """Resolve and validate the supported Codex CLI before persisting its path."""
+    if configured is None:
+        discovered = shutil.which("codex")
+        if discovered is None:
+            raise LaunchdError("codex is not on PATH; pass --codex-binary with its absolute path")
+        candidate = Path(discovered)
+    else:
+        candidate = configured.expanduser()
+
+    absolute = candidate.absolute()
+    if not absolute.is_file() or not os.access(absolute, os.X_OK):
+        raise LaunchdError(f"Codex CLI is missing or not executable: {absolute}")
+    return absolute
+
+
+def build_plist(
+    *, repo_root: Path, home: Path, codex_binary: Path, weekday: str, hour: int
+) -> dict[str, object]:
+    """Build the launchd configuration without touching disk or launchd."""
+    cleanup_script = repo_root / "scripts" / "orchestration" / "archived_thread_cleanup.py"
+    interpreter = repo_root / ".venv" / "bin" / "python"
+    log_dir = state_dir(home) / "logs"
+    return {
+        "Label": LABEL,
+        "LowPriorityIO": True,
+        "ProcessType": "Background",
+        "ProgramArguments": [
+            str(interpreter),
+            str(cleanup_script),
+            "--apply",
+            "--repo-root",
+            str(repo_root),
+            "--retention-days",
+            "30",
+            "--observation-interval-days",
+            "7",
+            "--codex-binary",
+            str(codex_binary),
+        ],
+        "RunAtLoad": False,
+        "StandardErrorPath": str(log_dir / "stderr.log"),
+        "StandardOutPath": str(log_dir / "stdout.log"),
+        "StartCalendarInterval": {
+            "Hour": hour,
+            "Minute": 0,
+            "Weekday": WEEKDAYS[weekday],
+        },
+        "WorkingDirectory": str(repo_root),
+    }
+
+
+def render_plist(
+    *, repo_root: Path, home: Path, codex_binary: Path, weekday: str, hour: int
+) -> bytes:
+    """Render a stable XML plist for inspection and tests."""
+    payload = build_plist(
+        repo_root=repo_root,
+        home=home,
+        codex_binary=codex_binary,
+        weekday=weekday,
+        hour=hour,
+    )
+    return plistlib.dumps(payload, fmt=plistlib.FMT_XML, sort_keys=True)
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def atomic_write(path: Path, content: bytes, *, mode: int = 0o644) -> bool:
+    """Atomically replace path and report whether its contents changed."""
+    if path.is_file() and path.read_bytes() == content:
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_path, mode)
+        os.replace(temporary_path, path)
+        _fsync_directory(path.parent)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+    return True
+
+
+def _launchctl(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["/bin/launchctl", *command],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise LaunchdError("/bin/launchctl is unavailable; this installer requires macOS") from exc
+
+
+def _domain() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _service_target() -> str:
+    return f"{_domain()}/{LABEL}"
+
+
+def _loaded_readback() -> subprocess.CompletedProcess[str]:
+    return _launchctl(["print", _service_target()])
+
+
+def _failure(action: str, result: subprocess.CompletedProcess[str]) -> LaunchdError:
+    detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+    return LaunchdError(f"launchctl {action} failed: {detail}")
+
+
+def _validate_runtime(repo_root: Path, codex_binary: Path) -> None:
+    interpreter = repo_root / ".venv" / "bin" / "python"
+    cleanup_script = repo_root / "scripts" / "orchestration" / "archived_thread_cleanup.py"
+    if not interpreter.is_file() or not os.access(interpreter, os.X_OK):
+        raise LaunchdError(f"required interpreter is missing or not executable: {interpreter}")
+    if not cleanup_script.is_file():
+        raise LaunchdError(f"cleanup script is missing: {cleanup_script}")
+    if not codex_binary.is_file() or not os.access(codex_binary, os.X_OK):
+        raise LaunchdError(f"Codex CLI is missing or not executable: {codex_binary}")
+
+
+def install(
+    *, repo_root: Path, home: Path, codex_binary: Path, weekday: str, hour: int
+) -> dict[str, object]:
+    """Install or reconcile the launch agent, then verify launchd readback."""
+    _validate_runtime(repo_root, codex_binary)
+    destination = plist_path(home)
+    content = render_plist(
+        repo_root=repo_root,
+        home=home,
+        codex_binary=codex_binary,
+        weekday=weekday,
+        hour=hour,
+    )
+    runtime_state = state_dir(home)
+    runtime_state.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(runtime_state, 0o700)
+    logs = runtime_state / "logs"
+    logs.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(logs, 0o700)
+
+    before = _loaded_readback()
+    was_loaded = before.returncode == 0
+    changed = not destination.is_file() or destination.read_bytes() != content
+
+    if changed and was_loaded:
+        bootout = _launchctl(["bootout", _service_target()])
+        if bootout.returncode != 0:
+            raise _failure("bootout", bootout)
+
+    wrote_plist = atomic_write(destination, content)
+    if changed or not was_loaded:
+        bootstrap = _launchctl(["bootstrap", _domain(), str(destination)])
+        if bootstrap.returncode != 0:
+            raise _failure("bootstrap", bootstrap)
+
+    readback = _loaded_readback()
+    if readback.returncode != 0:
+        raise _failure("print", readback)
+
+    return {
+        "action": "install",
+        "changed": changed,
+        "codex_binary": str(codex_binary),
+        "hour": hour,
+        "label": LABEL,
+        "loaded": True,
+        "plist_path": str(destination),
+        "repo_root": str(repo_root),
+        "weekday": weekday,
+        "wrote_plist": wrote_plist,
+    }
+
+
+def status(*, home: Path) -> tuple[dict[str, object], int]:
+    """Read both the persisted plist and launchd's current service state."""
+    destination = plist_path(home)
+    readback = _loaded_readback()
+    installed = destination.is_file()
+    loaded = readback.returncode == 0
+    valid_plist = False
+    configuration: dict[str, object] = {}
+    parse_error: str | None = None
+
+    if installed:
+        try:
+            parsed = plistlib.loads(destination.read_bytes())
+            if not isinstance(parsed, dict):
+                raise ValueError("top-level plist value is not a dictionary")
+            configuration = {
+                "label": parsed.get("Label"),
+                "program_arguments": parsed.get("ProgramArguments"),
+                "schedule": parsed.get("StartCalendarInterval"),
+                "working_directory": parsed.get("WorkingDirectory"),
+            }
+            arguments = parsed.get("ProgramArguments")
+            schedule = parsed.get("StartCalendarInterval")
+            valid_plist = (
+                parsed.get("Label") == LABEL
+                and isinstance(arguments, list)
+                and len(arguments) >= 3
+                and all(isinstance(argument, str) for argument in arguments)
+                and Path(arguments[1]).name == "archived_thread_cleanup.py"
+                and "--apply" in arguments
+                and isinstance(schedule, dict)
+                and isinstance(schedule.get("Weekday"), int)
+            )
+        except (OSError, ValueError, plistlib.InvalidFileException) as exc:
+            parse_error = str(exc)
+
+    payload: dict[str, object] = {
+        "action": "status",
+        "configuration": configuration,
+        "installed": installed,
+        "label": LABEL,
+        "launchctl_error": None if loaded else (readback.stderr.strip() or readback.stdout.strip()),
+        "loaded": loaded,
+        "parse_error": parse_error,
+        "plist_path": str(destination),
+        "valid_plist": valid_plist,
+    }
+    return payload, 0 if installed and loaded and valid_plist else 1
+
+
+def uninstall(*, home: Path) -> dict[str, object]:
+    """Idempotently unload and remove the plist while preserving audit state."""
+    destination = plist_path(home)
+    before = _loaded_readback()
+    was_loaded = before.returncode == 0
+    existed = destination.exists()
+
+    if was_loaded:
+        bootout = _launchctl(["bootout", _service_target()])
+        if bootout.returncode != 0:
+            raise _failure("bootout", bootout)
+
+    if existed:
+        destination.unlink()
+        _fsync_directory(destination.parent)
+
+    readback = _loaded_readback()
+    if readback.returncode == 0:
+        raise LaunchdError(f"launchd service remains loaded after bootout: {_service_target()}")
+
+    return {
+        "action": "uninstall",
+        "label": LABEL,
+        "loaded": False,
+        "logs_and_state_preserved": str(state_dir(home)),
+        "plist_existed": existed,
+        "plist_path": str(destination),
+        "was_loaded": was_loaded,
+    }
+
+
+def _add_schedule_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--weekday",
+        choices=tuple(WEEKDAYS),
+        default=DEFAULT_WEEKDAY,
+        help=f"local weekday for the cleanup (default: {DEFAULT_WEEKDAY})",
+    )
+    parser.add_argument(
+        "--hour",
+        type=valid_hour,
+        default=DEFAULT_HOUR,
+        help=f"local hour from 0 through 23 (default: {DEFAULT_HOUR})",
+    )
+
+
+def _add_path_options(parser: argparse.ArgumentParser, *, include_repo: bool) -> None:
+    if include_repo:
+        parser.add_argument(
+            "--repo-root",
+            type=Path,
+            default=default_repo_root(),
+            help="merged repository checkout to execute",
+        )
+        parser.add_argument(
+            "--codex-binary",
+            type=Path,
+            help="absolute Codex CLI path (default: resolve codex from the installer's PATH)",
+        )
+    parser.add_argument(
+        "--home",
+        type=Path,
+        default=default_home(),
+        help=argparse.SUPPRESS,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    install_parser = subparsers.add_parser("install", help="install or reconcile the launch agent")
+    _add_schedule_options(install_parser)
+    _add_path_options(install_parser, include_repo=True)
+    install_parser.add_argument(
+        "--dry-render",
+        action="store_true",
+        help="render the plist to stdout without disk writes or launchctl calls",
+    )
+
+    render_parser = subparsers.add_parser("render", help="render the plist without side effects")
+    _add_schedule_options(render_parser)
+    _add_path_options(render_parser, include_repo=True)
+
+    status_parser = subparsers.add_parser("status", help="show persisted and launchd state")
+    _add_path_options(status_parser, include_repo=False)
+
+    uninstall_parser = subparsers.add_parser("uninstall", help="unload and remove the launch agent")
+    _add_path_options(uninstall_parser, include_repo=False)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    home = args.home.expanduser().resolve()
+
+    try:
+        if args.command in {"install", "render"}:
+            repo_root = args.repo_root.expanduser().resolve()
+            codex_binary = resolve_codex_binary(args.codex_binary)
+            if args.command == "render" or args.dry_render:
+                rendered = render_plist(
+                    repo_root=repo_root,
+                    home=home,
+                    codex_binary=codex_binary,
+                    weekday=args.weekday,
+                    hour=args.hour,
+                )
+                print(rendered.decode("utf-8"), end="")
+                return 0
+            payload = install(
+                repo_root=repo_root,
+                home=home,
+                codex_binary=codex_binary,
+                weekday=args.weekday,
+                hour=args.hour,
+            )
+            return_code = 0
+        elif args.command == "status":
+            payload, return_code = status(home=home)
+        else:
+            payload = uninstall(home=home)
+            return_code = 0
+    except LaunchdError as exc:
+        print(json.dumps({"error": str(exc), "label": LABEL}, sort_keys=True))
+        return 1
+
+    print(json.dumps(payload, sort_keys=True))
+    return return_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/install_archived_thread_cleanup_launchd.py
+++ b/scripts/orchestration/install_archived_thread_cleanup_launchd.py
@@ -139,7 +139,7 @@ def _fsync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
-def atomic_write(path: Path, content: bytes, *, mode: int = 0o644) -> bool:
+def atomic_write(path: Path, content: bytes, *, mode: int = 0o600) -> bool:
     """Atomically replace path and report whether its contents changed."""
     if path.is_file() and path.read_bytes() == content:
         return False

--- a/scripts/orchestration/task_family/codex_state.py
+++ b/scripts/orchestration/task_family/codex_state.py
@@ -62,6 +62,20 @@ class ThreadRecord:
     host: str | None
 
 
+@dataclass(frozen=True)
+class CleanupThreadRecord:
+    """Stable read model for deterministic saved-thread cleanup."""
+
+    thread_id: str
+    title: str
+    cwd: str
+    rollout_path: str
+    created_at: int
+    updated_at: int
+    archived: bool
+    archived_at: int | None
+
+
 def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -98,6 +112,20 @@ def _coerce_task_id(raw: Any) -> str:
         raise CodexStateContextError(f"task id must be a UUID: {candidate!r}") from exc
 
 
+def _coerce_timestamp(raw: Any, *, field: str, optional: bool = False) -> int | None:
+    if raw is None and optional:
+        return None
+    if isinstance(raw, bool):
+        raise CodexStateContextError(f"{field} must be an integer timestamp")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise CodexStateContextError(f"{field} must be an integer timestamp: {raw!r}") from exc
+    if value < 0:
+        raise CodexStateContextError(f"{field} must be non-negative: {value}")
+    return value
+
+
 def _row_to_record(row: sqlite3.Row, *, has_host: bool) -> ThreadRecord:
     archived = _coerce_bool(row["archived"])
     archived_at = _to_text(row["archived_at"])
@@ -109,6 +137,19 @@ def _row_to_record(row: sqlite3.Row, *, has_host: bool) -> ThreadRecord:
         archived=archived,
         archived_at=archived_at,
         host=_to_text(host),
+    )
+
+
+def _row_to_cleanup_record(row: sqlite3.Row) -> CleanupThreadRecord:
+    return CleanupThreadRecord(
+        thread_id=_coerce_task_id(row["id"]),
+        title=_to_text(row["title"]) or "",
+        cwd=_to_text(row["cwd"]) or "",
+        rollout_path=_to_text(row["rollout_path"]) or "",
+        created_at=int(_coerce_timestamp(row["created_at"], field="created_at")),
+        updated_at=int(_coerce_timestamp(row["updated_at"], field="updated_at")),
+        archived=_coerce_bool(row["archived"]),
+        archived_at=_coerce_timestamp(row["archived_at"], field="archived_at", optional=True),
     )
 
 
@@ -304,6 +345,123 @@ def read_thread_record(
                 f"thread {task} state raced during bounded read window: {db_path}"
             )
         time.sleep(0.05)
+
+
+_CLEANUP_REQUIRED_COLUMNS = frozenset(
+    {
+        "id",
+        "title",
+        "cwd",
+        "rollout_path",
+        "created_at",
+        "updated_at",
+        "archived",
+        "archived_at",
+    }
+)
+
+
+def _read_cleanup_records_once(
+    db_path: Path,
+    *,
+    thread_id: str | None,
+    archived_only: bool,
+    timeout_seconds: float,
+) -> tuple[CleanupThreadRecord, ...]:
+    with open_state_db(db_path, timeout_seconds=timeout_seconds, mode="ro") as connection:
+        columns = _thread_columns(connection)
+        missing = sorted(_CLEANUP_REQUIRED_COLUMNS - columns)
+        if missing:
+            raise CodexStateSchemaError(f"missing cleanup thread columns: {', '.join(missing)}")
+        predicates: list[str] = []
+        values: list[Any] = []
+        if thread_id is not None:
+            predicates.append("id = ?")
+            values.append(_coerce_task_id(thread_id))
+        if archived_only:
+            predicates.append("archived = 1")
+        where = f" where {' and '.join(predicates)}" if predicates else ""
+        rows = connection.execute(
+            "select id, title, cwd, rollout_path, created_at, updated_at, archived, archived_at "
+            f"from {THREADS_TABLE}{where} order by id",
+            values,
+        ).fetchall()
+    return tuple(_row_to_cleanup_record(row) for row in rows)
+
+
+def _stable_cleanup_records(
+    db_path: Path,
+    *,
+    thread_id: str | None,
+    archived_only: bool,
+    timeout_seconds: float,
+    read_window_seconds: float,
+) -> tuple[CleanupThreadRecord, ...]:
+    deadline = time.monotonic() + max(0.0, read_window_seconds)
+    stable_sample: tuple[CleanupThreadRecord, ...] | None = None
+    stable_count = 0
+    while True:
+        current = _read_cleanup_records_once(
+            db_path,
+            thread_id=thread_id,
+            archived_only=archived_only,
+            timeout_seconds=timeout_seconds,
+        )
+        if current == stable_sample:
+            stable_count += 1
+            if stable_count >= 3:
+                return current
+        else:
+            stable_sample = current
+            stable_count = 1
+        if time.monotonic() >= deadline:
+            target = thread_id or "cleanup inventory"
+            raise CodexStateConflictError(
+                f"{target} state raced during bounded read window: {db_path}"
+            )
+        time.sleep(0.05)
+
+
+def list_archived_cleanup_threads(
+    db_path: Path | str,
+    *,
+    timeout_seconds: float = 5.0,
+    read_window_seconds: float = 0.75,
+) -> tuple[CleanupThreadRecord, ...]:
+    """List archived threads through a bounded, stable, read-only sample."""
+    path = Path(db_path)
+    if not path.exists():
+        raise CodexStateDiscoveryError(f"codex DB not found: {path}")
+    return _stable_cleanup_records(
+        path,
+        thread_id=None,
+        archived_only=True,
+        timeout_seconds=timeout_seconds,
+        read_window_seconds=read_window_seconds,
+    )
+
+
+def read_cleanup_thread_record(
+    db_path: Path | str,
+    *,
+    thread_id: str,
+    timeout_seconds: float = 5.0,
+    read_window_seconds: float = 0.75,
+) -> CleanupThreadRecord:
+    """Read one exact cleanup row through the same stable read-only bridge."""
+    path = Path(db_path)
+    if not path.exists():
+        raise CodexStateMissingTaskError(f"missing task {thread_id} in {path}")
+    records = _stable_cleanup_records(
+        path,
+        thread_id=_coerce_task_id(thread_id),
+        archived_only=False,
+        timeout_seconds=timeout_seconds,
+        read_window_seconds=read_window_seconds,
+    )
+    if not records:
+        raise CodexStateMissingTaskError(f"missing task {thread_id} in {path}")
+    return records[0]
 
 
 def _ensure_archive_shape(record: ThreadRecord, *, archived: bool) -> bool:

--- a/tests/orchestration/test_archived_thread_cleanup.py
+++ b/tests/orchestration/test_archived_thread_cleanup.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from scripts.orchestration import archived_thread_cleanup as cleanup
+from scripts.orchestration import task_identity
 
 NOW = datetime(2026, 7, 16, 18, 0, tzinfo=UTC)
 THREAD_A = "00000000-0000-4000-8000-000000000001"
@@ -82,6 +83,57 @@ def _codex_home(path: Path, *, pinned: list[str] | None = None) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def _write_live_rollover_lease(root: Path, *, source_thread_id: str) -> None:
+    prepared_at = "2026-07-16T09:00:00Z"
+    lineage_id = "cleanup-protection"
+    rollover_id = "rollover-cleanup-protection"
+    identity = task_identity.build_identity(
+        repository=task_identity.DEFAULT_REPOSITORY,
+        stream_epic=None,
+        stream_epic_url=None,
+        github_issue_number=None,
+        github_issue_url=None,
+        semantic_title="Cleanup protection fixture",
+        task_family="thread-rollover",
+        role="codex",
+        predecessor_task_id=source_thread_id,
+        replacement_task_id=None,
+        lineage_id=lineage_id,
+        generation=1,
+        terminal_goal="merge",
+    )
+    lease = {
+        "schema_version": 2,
+        "agent": "codex",
+        "lineage_id": lineage_id,
+        "rollover_id": rollover_id,
+        "active": {
+            "thread_id": source_thread_id,
+            "generation": 0,
+            "lineage_id": lineage_id,
+            "started_at": prepared_at,
+            "last_seen_at": prepared_at,
+        },
+        "replacement": {
+            "rollover_id": rollover_id,
+            "lineage_id": lineage_id,
+            "generation": 1,
+            "status": "pending_start",
+            "prepared_at": prepared_at,
+            "identity": identity,
+            "title_transition": task_identity.new_title_transition(
+                harness="codex-app",
+                visible_title_value=identity["visible_title"],
+                prepared_at=prepared_at,
+            ),
+        },
+        "updated_at": prepared_at,
+    }
+    path = root / ".agent" / "thread-rollovers" / "codex" / lineage_id / "lease.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(lease), encoding="utf-8")
 
 
 def _runner(db: Path, transcript_by_id: dict[str, Path], *, fail: set[str] | None = None):
@@ -243,7 +295,7 @@ def test_malformed_pin_registry_blocks_apply_and_clears_observations(tmp_path: P
 
 
 def test_automation_and_rollover_references_are_protected(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
     home = _codex_home(tmp_path / "codex")
     automation_dir = home / "automations" / "weekly"
@@ -263,11 +315,7 @@ def test_automation_and_rollover_references_are_protected(
             _row(THREAD_B, second, archived_at=NOW - timedelta(days=100)),
         ],
     )
-    monkeypatch.setattr(
-        cleanup,
-        "_load_live_rollover_references",
-        lambda roots: ({THREAD_B}, []),
-    )
+    _write_live_rollover_lease(tmp_path, source_thread_id=THREAD_B)
 
     receipt = cleanup.run_cleanup(
         codex_home=home,

--- a/tests/orchestration/test_archived_thread_cleanup.py
+++ b/tests/orchestration/test_archived_thread_cleanup.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import stat
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestration import archived_thread_cleanup as cleanup
+
+NOW = datetime(2026, 7, 16, 18, 0, tzinfo=UTC)
+THREAD_A = "00000000-0000-4000-8000-000000000001"
+THREAD_B = "00000000-0000-4000-8000-000000000002"
+THREAD_C = "00000000-0000-4000-8000-000000000003"
+
+
+def _database(path: Path, rows: list[tuple[object, ...]]) -> Path:
+    connection = sqlite3.connect(path)
+    connection.execute(
+        """
+        create table threads (
+            id text primary key,
+            rollout_path text not null,
+            created_at integer not null,
+            updated_at integer not null,
+            source text not null default '',
+            model_provider text not null default '',
+            cwd text not null,
+            title text not null,
+            sandbox_policy text not null default '',
+            approval_mode text not null default '',
+            archived integer not null default 0,
+            archived_at integer
+        )
+        """
+    )
+    connection.executemany(
+        """
+        insert into threads (
+            id, rollout_path, created_at, updated_at, cwd, title, archived, archived_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        rows,
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+def _row(
+    thread_id: str,
+    transcript: Path,
+    *,
+    archived_at: datetime,
+    title: str = "Archived task",
+) -> tuple[object, ...]:
+    timestamp = int(archived_at.timestamp())
+    return (
+        thread_id,
+        str(transcript),
+        timestamp - 100,
+        timestamp,
+        str(transcript.parent),
+        title,
+        1,
+        timestamp,
+    )
+
+
+def _codex_home(path: Path, *, pinned: list[str] | None = None) -> Path:
+    path.mkdir()
+    (path / ".codex-global-state.json").write_text(
+        json.dumps(
+            {
+                "pinned-thread-ids": pinned or [],
+                "active-workspace-roots": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _runner(db: Path, transcript_by_id: dict[str, Path], *, fail: set[str] | None = None):
+    commands: list[tuple[str, ...]] = []
+    failures = fail or set()
+
+    def run(command):
+        normalized = tuple(command)
+        commands.append(normalized)
+        thread_id = normalized[-1]
+        if thread_id in failures:
+            return subprocess.CompletedProcess(normalized, 9, "", "synthetic failure")
+        connection = sqlite3.connect(db)
+        connection.execute("delete from threads where id = ?", (thread_id,))
+        connection.commit()
+        connection.close()
+        transcript_by_id[thread_id].unlink()
+        return subprocess.CompletedProcess(normalized, 0, "deleted", "")
+
+    return run, commands
+
+
+def test_dry_run_observes_old_thread_and_protects_pinned(tmp_path: Path) -> None:
+    home = _codex_home(tmp_path / "codex", pinned=[THREAD_B])
+    state_dir = tmp_path / "cleanup"
+    first = tmp_path / "first.jsonl"
+    second = tmp_path / "second.jsonl"
+    first.write_bytes(b"a" * 4096)
+    second.write_bytes(b"b" * 2048)
+    db = _database(
+        tmp_path / "state_5.sqlite",
+        [
+            _row(THREAD_A, first, archived_at=NOW - timedelta(days=31)),
+            _row(THREAD_B, second, archived_at=NOW - timedelta(days=90)),
+        ],
+    )
+
+    receipt = cleanup.run_cleanup(
+        codex_home=home,
+        db_path=db,
+        state_dir=state_dir,
+        now=NOW,
+        current_cwd=tmp_path,
+    )
+
+    by_id = {item["thread_id"]: item for item in receipt["outcomes"]}
+    assert receipt["mode"] == "dry-run"
+    assert by_id[THREAD_A]["outcome"] == "observing"
+    assert by_id[THREAD_B]["outcome"] == "protected"
+    assert by_id[THREAD_B]["reasons"] == ["pinned"]
+    assert first.exists() and second.exists()
+    state = json.loads((state_dir / "state-v1.json").read_text(encoding="utf-8"))
+    assert list(state["observations"]) == [THREAD_A]
+    assert Path(receipt["receipt_path"]).is_file()
+
+
+def test_second_unchanged_observation_deletes_through_exact_cli(tmp_path: Path) -> None:
+    home = _codex_home(tmp_path / "codex")
+    state_dir = tmp_path / "cleanup"
+    transcript = tmp_path / "thread.jsonl"
+    transcript.write_bytes(b"payload" * 1000)
+    db = _database(
+        tmp_path / "state_5.sqlite",
+        [_row(THREAD_A, transcript, archived_at=NOW - timedelta(days=40))],
+    )
+    cleanup.run_cleanup(
+        apply=True,
+        codex_home=home,
+        db_path=db,
+        state_dir=state_dir,
+        now=NOW,
+        current_cwd=tmp_path,
+    )
+    runner, commands = _runner(db, {THREAD_A: transcript})
+
+    receipt = cleanup.run_cleanup(
+        apply=True,
+        codex_home=home,
+        db_path=db,
+        state_dir=state_dir,
+        now=NOW + timedelta(days=8),
+        runner=runner,
+        sleep=lambda _: None,
+        codex_binary="/opt/codex/bin/codex",
+        current_cwd=tmp_path,
+    )
+
+    assert commands == [("/opt/codex/bin/codex", "delete", "--force", THREAD_A)]
+    outcome = receipt["outcomes"][0]
+    assert outcome["outcome"] == "deleted"
+    assert outcome["reclaimed_bytes"] > 0
+    assert not transcript.exists()
+    state = json.loads((state_dir / "state-v1.json").read_text(encoding="utf-8"))
+    assert state["observations"] == {}
+
+
+def test_changed_fingerprint_restarts_observation(tmp_path: Path) -> None:
+    home = _codex_home(tmp_path / "codex")
+    state_dir = tmp_path / "cleanup"
+    transcript = tmp_path / "thread.jsonl"
+    transcript.write_text("original", encoding="utf-8")
+    db = _database(
+        tmp_path / "state_5.sqlite",
+        [_row(THREAD_A, transcript, archived_at=NOW - timedelta(days=45))],
+    )
+    cleanup.run_cleanup(
+        codex_home=home,
+        db_path=db,
+        state_dir=state_dir,
+        now=NOW,
+        current_cwd=tmp_path,
+    )
+    connection = sqlite3.connect(db)
+    connection.execute("update threads set title = ? where id = ?", ("changed", THREAD_A))
+    connection.commit()
+    connection.close()
+    runner, commands = _runner(db, {THREAD_A: transcript})
+
+    receipt = cleanup.run_cleanup(
+        apply=True,
+        codex_home=home,
+        db_path=db,
+        state_dir=state_dir,
+        now=NOW + timedelta(days=8),
+        runner=runner,
+        current_cwd=tmp_path,
+    )
+
+    assert commands == []
+    assert receipt["outcomes"][0]["outcome"] == "observing"
+    assert transcript.exists()
+
+
+def test_malformed_pin_registry_blocks_apply_and_clears_observations(tmp_path: Path) -> None:
+    home = _codex_home(tmp_path / "codex")
+    (home / ".codex-global-state.json").write_text("{}", encoding="utf-8")
+    transcript = tmp_path / "thread.jsonl"
+    transcript.write_text("payload", encoding="utf-8")
+    db = _database(
+        tmp_path / "state_5.sqlite",
+        [_row(THREAD_A, transcript, archived_at=NOW - timedelta(days=100))],
+    )
+    runner, commands = _runner(db, {THREAD_A: transcript})
+
+    receipt = cleanup.run_cleanup(
+        apply=True,
+        codex_home=home,
+        db_path=db,
+        state_dir=tmp_path / "cleanup",
+        now=NOW,
+        runner=runner,
+        current_cwd=tmp_path,
+    )
+
+    assert commands == []
+    assert receipt["protection_errors"]
+    assert receipt["outcomes"][0]["outcome"] == "protected"
+    assert "protection_registry_unavailable" in receipt["outcomes"][0]["reasons"]
+
+
+def test_automation_and_rollover_references_are_protected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = _codex_home(tmp_path / "codex")
+    automation_dir = home / "automations" / "weekly"
+    automation_dir.mkdir(parents=True)
+    (automation_dir / "automation.toml").write_text(
+        f'prompt = "inspect {THREAD_A}"\ncwds = []\n',
+        encoding="utf-8",
+    )
+    first = tmp_path / "a.jsonl"
+    second = tmp_path / "b.jsonl"
+    first.write_text("a", encoding="utf-8")
+    second.write_text("b", encoding="utf-8")
+    db = _database(
+        tmp_path / "state_5.sqlite",
+        [
+            _row(THREAD_A, first, archived_at=NOW - timedelta(days=100)),
+            _row(THREAD_B, second, archived_at=NOW - timedelta(days=100)),
+        ],
+    )
+    monkeypatch.setattr(
+        cleanup,
+        "_load_live_rollover_references",
+        lambda roots: ({THREAD_B}, []),
+    )
+
+    receipt = cleanup.run_cleanup(
+        codex_home=home,
+        db_path=db,
+        state_dir=tmp_path / "cleanup",
+        now=NOW,
+        current_cwd=tmp_path,
+    )
+
+    by_id = {item["thread_id"]: item for item in receipt["outcomes"]}
+    assert by_id[THREAD_A]["reasons"] == ["automation_reference"]
+    assert by_id[THREAD_B]["reasons"] == ["live_rollover_reference"]
+
+
+def test_delete_failure_does_not_prevent_later_candidate(tmp_path: Path) -> None:
+    home = _codex_home(tmp_path / "codex")
+    state_dir = tmp_path / "cleanup"
+    first = tmp_path / "a.jsonl"
+    second = tmp_path / "b.jsonl"
+    first.write_bytes(b"a" * 100)
+    second.write_bytes(b"b" * 100)
+    db = _database(
+        tmp_path / "state_5.sqlite",
+        [
+            _row(THREAD_A, first, archived_at=NOW - timedelta(days=100)),
+            _row(THREAD_B, second, archived_at=NOW - timedelta(days=100)),
+        ],
+    )
+    cleanup.run_cleanup(
+        codex_home=home,
+        db_path=db,
+        state_dir=state_dir,
+        now=NOW,
+        current_cwd=tmp_path,
+    )
+    runner, commands = _runner(
+        db,
+        {THREAD_A: first, THREAD_B: second},
+        fail={THREAD_A},
+    )
+
+    receipt = cleanup.run_cleanup(
+        apply=True,
+        codex_home=home,
+        db_path=db,
+        state_dir=state_dir,
+        now=NOW + timedelta(days=8),
+        runner=runner,
+        sleep=lambda _: None,
+        current_cwd=tmp_path,
+    )
+
+    assert [command[-1] for command in commands] == [THREAD_A, THREAD_B]
+    by_id = {item["thread_id"]: item for item in receipt["outcomes"]}
+    assert by_id[THREAD_A]["outcome"] == "delete_failed"
+    assert by_id[THREAD_B]["outcome"] == "deleted"
+    assert first.exists() and not second.exists()
+
+
+def test_cleanup_lock_refuses_concurrent_run(tmp_path: Path) -> None:
+    state_dir = tmp_path / "cleanup"
+    with cleanup.cleanup_lock(state_dir):
+        assert stat.S_IMODE(state_dir.stat().st_mode) == 0o700
+        with pytest.raises(cleanup.CleanupBusyError):
+            with cleanup.cleanup_lock(state_dir):
+                pass
+
+
+def test_receipt_writer_restricts_directory_and_file_permissions(tmp_path: Path) -> None:
+    destination = tmp_path / "receipts" / "v1" / "receipt.json"
+
+    cleanup._write_json(destination, {"status": "ok"})
+
+    assert stat.S_IMODE(destination.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o600

--- a/tests/orchestration/test_install_archived_thread_cleanup_launchd.py
+++ b/tests/orchestration/test_install_archived_thread_cleanup_launchd.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+from scripts.orchestration import install_archived_thread_cleanup_launchd as launchd
+
+
+def test_rendered_plist_invokes_code_directly_once_per_week(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    codex_binary = tmp_path / "bin" / "codex"
+    codex_binary.parent.mkdir()
+    codex_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    codex_binary.chmod(0o755)
+
+    payload = plistlib.loads(
+        launchd.render_plist(
+            repo_root=repo,
+            home=home,
+            codex_binary=codex_binary,
+            weekday="sunday",
+            hour=3,
+        )
+    )
+
+    assert payload["Label"] == launchd.LABEL
+    assert payload["ProgramArguments"] == [
+        str(repo / ".venv" / "bin" / "python"),
+        str(repo / "scripts" / "orchestration" / "archived_thread_cleanup.py"),
+        "--apply",
+        "--repo-root",
+        str(repo),
+        "--retention-days",
+        "30",
+        "--observation-interval-days",
+        "7",
+        "--codex-binary",
+        str(codex_binary),
+    ]
+    assert payload["StartCalendarInterval"] == {"Hour": 3, "Minute": 0, "Weekday": 0}
+    assert "prompt" not in str(payload).lower()
+
+
+def test_atomic_write_is_idempotent(tmp_path: Path) -> None:
+    destination = tmp_path / "LaunchAgents" / "job.plist"
+
+    assert launchd.atomic_write(destination, b"first") is True
+    assert launchd.atomic_write(destination, b"first") is False
+    assert launchd.atomic_write(destination, b"second") is True
+    assert destination.read_bytes() == b"second"
+
+
+def test_uninstall_preserves_cleanup_receipts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"plist")
+    receipts = launchd.state_dir(home) / "receipts" / "v1"
+    receipts.mkdir(parents=True)
+    receipt = receipts / "receipt.json"
+    receipt.write_text("{}", encoding="utf-8")
+
+    class Result:
+        returncode = 1
+        stdout = ""
+        stderr = "not loaded"
+
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: Result())
+
+    result = launchd.uninstall(home=home)
+
+    assert result["loaded"] is False
+    assert not destination.exists()
+    assert receipt.exists()
+
+
+def test_status_rejects_loaded_plist_that_does_not_run_cleanup_code(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    payload = launchd.build_plist(
+        repo_root=tmp_path / "repo",
+        home=home,
+        codex_binary=tmp_path / "bin" / "codex",
+        weekday="sunday",
+        hour=3,
+    )
+    payload["ProgramArguments"] = ["/bin/sh", "-c", "echo prompt"]
+    destination.write_bytes(plistlib.dumps(payload))
+
+    class Result:
+        returncode = 0
+        stdout = "loaded"
+        stderr = ""
+
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: Result())
+
+    status, return_code = launchd.status(home=home)
+
+    assert return_code == 1
+    assert status["loaded"] is True
+    assert status["valid_plist"] is False

--- a/tests/orchestration/test_install_archived_thread_cleanup_launchd.py
+++ b/tests/orchestration/test_install_archived_thread_cleanup_launchd.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import plistlib
+import stat
 from pathlib import Path
 
 from scripts.orchestration import install_archived_thread_cleanup_launchd as launchd
@@ -49,6 +50,7 @@ def test_atomic_write_is_idempotent(tmp_path: Path) -> None:
     assert launchd.atomic_write(destination, b"first") is False
     assert launchd.atomic_write(destination, b"second") is True
     assert destination.read_bytes() == b"second"
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o600
 
 
 def test_uninstall_preserves_cleanup_receipts(


### PR DESCRIPTION
## Summary

- add a deterministic archived Codex task cleanup CLI with a 30-day retention period and two unchanged observations at least seven days apart
- fail closed for pinned, current, automation-referenced, or live-rollover-referenced tasks and delete only through `codex delete --force`
- add durable receipts, an exclusive lock, and a native weekly macOS launchd installer (Sunday 03:00 local) that runs code directly without prompts or models

## Verification

- 111 focused cleanup, scheduler, Codex-state, rollover, and rollover-registry tests passed
- Ruff, py_compile, markdownlint, plutil, and git diff checks passed
- real-state dry run: 152 archived tasks, 152 retained, 0 protection errors, 0 deletions
- canonical strict review verification: clean
- independent cross-family final review: DeepSeek v4 Flash, unconditional PASS (bridge message 3204)

Refs #5322
Epic #4707

The issue remains open through post-merge installation/readback of the weekly launch agent.