### PR TITLE
fix(hooks): decolorize gh output in guard-admin-merge (#5324 review B1 class)

### DIFF
--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -23,9 +23,31 @@ substring (case-insensitive); erring toward "treat as blocking" is the safe dire
 from __future__ import annotations
 
 import json
+import os
+import re
 import shlex
 import subprocess
 import sys
+
+# Agent harnesses export CLICOLOR_FORCE/FORCE_COLOR, which beat NO_COLOR and make
+# `gh --json` emit ANSI-colorized JSON on pipes -> json.loads fails -> the guard reads
+# every check state as undeterminable and fail-closes, blocking the legitimate
+# advisory-only --admin merge it exists to permit (review B1, PR #5324). Every gh
+# subprocess below runs with the force vars REMOVED and NO_COLOR pinned; _decolorize()
+# strips any residual escapes. Kept identical to guard-pr-merge.py's copy.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _gh_env() -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k not in {"CLICOLOR_FORCE", "FORCE_COLOR"}}
+    env["NO_COLOR"] = "1"
+    env["CLICOLOR"] = "0"
+    return env
+
+
+def _decolorize(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
 
 # A check is treated as BLOCKING unless its name marks it explicitly advisory.
 # Rationale (anti-bypass safe direction): an allowlist of "known required" names would
@@ -215,10 +237,13 @@ def _pr_number(args: list[str]) -> str | None:
         out = subprocess.run(
             ["gh", "pr", "view", "--json", "number", "-q", ".number"],
             capture_output=True,
+            env=_gh_env(),
             text=True,
             timeout=10,
         )
-        return out.stdout.strip() or None
+        # Decolorized before use, not just before json.loads: a colorized "5" is passed
+        # straight to the next gh call as the PR selector, where the escapes break it.
+        return _decolorize(out.stdout or "").strip() or None
     except Exception:
         return None
 
@@ -229,8 +254,9 @@ def _failing_blocking_checks(pr: str) -> list[str] | None:
         out = subprocess.run(
             ["gh", "pr", "checks", pr, "--json", "name,bucket,state"],
             capture_output=True,
+            env=_gh_env(),
             text=True,
-            timeout=20,
+            timeout=8,
         )
     except Exception:
         return None
@@ -242,7 +268,7 @@ def _failing_blocking_checks(pr: str) -> list[str] | None:
         # failing checks" and lets the bypass through — the fail-open bug this closes.
         return [] if out.returncode == 0 else None
     try:
-        rows = json.loads(text)
+        rows = json.loads(_decolorize(text))
     except json.JSONDecodeError:
         return None
     if not isinstance(rows, list):

--- a/tests/test_guard_admin_merge.py
+++ b/tests/test_guard_admin_merge.py
@@ -201,3 +201,117 @@ def test_wrapper_assignment_brace_admin_detected(cmd):
 
 def test_unclosed_heredoc_does_not_hide_admin():
     assert _any_admin("cat <<'NOEND'\nnote\ngh pr merge 5 --admin")
+
+
+# --- colorized gh output (review B1, PR #5324) ------------------------------
+# Agent harnesses export CLICOLOR_FORCE/FORCE_COLOR (beating NO_COLOR), and gh then
+# colorizes piped --json output. The bare `json.loads` here raised JSONDecodeError ->
+# None -> "undeterminable" -> BLOCK, so the one legitimate use of --admin this hook
+# exists to permit (advisory-only failures, #M-0.5) was refused inside every agent
+# harness. Same bug class as the sibling's B1; the guard must scrub the env AND
+# tolerate residual ANSI.
+
+# Escapes sit OUTSIDE the string tokens, as gh's colorizer actually emits them.
+_COLORIZED_ROWS = (
+    '\x1b[1;37m[\x1b[m{\n'
+    '  \x1b[1;34m"name"\x1b[m: \x1b[32m"Test (pytest)"\x1b[m,\n'
+    '  \x1b[1;34m"bucket"\x1b[m: \x1b[32m"pass"\x1b[m,\n'
+    '  \x1b[1;34m"state"\x1b[m: \x1b[32m"SUCCESS"\x1b[m\n'
+    '}\x1b[1;37m]\x1b[m\n'
+)
+
+
+def _capture_gh(monkeypatch, *, returncode: int = 0, stdout: str = "[]"):
+    """Like _fake_gh, but records each call's argv + kwargs so the env can be asserted."""
+    import types
+
+    calls: list[tuple] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(guard.subprocess, "run", fake_run)
+    return calls
+
+
+def test_gh_env_scrubs_color_forcers(monkeypatch):
+    monkeypatch.setenv("CLICOLOR_FORCE", "1")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    env = guard._gh_env()
+    assert "CLICOLOR_FORCE" not in env
+    assert "FORCE_COLOR" not in env
+    assert env["NO_COLOR"] == "1"
+    assert env["CLICOLOR"] == "0"
+
+
+def test_decolorize_recovers_parseable_json():
+    assert json.loads(guard._decolorize(_COLORIZED_ROWS)) == [
+        {"name": "Test (pytest)", "bucket": "pass", "state": "SUCCESS"}
+    ]
+
+
+def test_colorized_check_rows_still_parse(monkeypatch):
+    """The B1 bug itself: colorized rows must not read as undeterminable (None), which
+    would fail-close and block a green PR's --admin merge."""
+    _fake_gh(monkeypatch, returncode=0, stdout=_COLORIZED_ROWS)
+    assert guard._failing_blocking_checks("5") == []
+
+
+def test_colorized_advisory_only_failure_still_allows(monkeypatch):
+    """End-to-end verdict, the user-level consequence: an advisory-only failure is the
+    ONE legitimate --admin case (#M-0.5). Colorized, it was blocked."""
+    rows = (
+        '\x1b[1;37m[\x1b[m{\x1b[1;34m"name"\x1b[m: \x1b[32m"pip-audit (advisory)"\x1b[m, '
+        '\x1b[1;34m"bucket"\x1b[m: \x1b[31m"fail"\x1b[m}\x1b[1;37m]\x1b[m'
+    )
+    _fake_gh(monkeypatch, returncode=0, stdout=rows)
+    monkeypatch.setattr(guard, "_pr_number", lambda args: "5")
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"tool_input": {"command": "gh pr merge 5 --admin"}})))
+    assert guard.main() == 0
+
+
+def test_colorized_blocking_failure_still_blocks(monkeypatch):
+    """Verdict unflipped in the anti-bypass direction: decolorizing must not lose the
+    `fail` bucket and let a red blocking check through."""
+    rows = (
+        '\x1b[1;37m[\x1b[m{\x1b[1;34m"name"\x1b[m: \x1b[32m"Test (pytest)"\x1b[m, '
+        '\x1b[1;34m"bucket"\x1b[m: \x1b[31m"fail"\x1b[m}\x1b[1;37m]\x1b[m'
+    )
+    _fake_gh(monkeypatch, returncode=0, stdout=rows)
+    assert guard._failing_blocking_checks("5") == ["Test (pytest)"]
+
+
+def test_colorized_pr_number_recovered(monkeypatch):
+    """`-q .number` output is passed to the NEXT gh call as the selector, so escapes
+    there break it just as surely as a failed parse."""
+    _fake_gh(monkeypatch, returncode=0, stdout="\x1b[32m5\x1b[m\n")
+    assert guard._pr_number(["--admin"]) == "5"
+
+
+def test_both_gh_sites_run_with_scrubbed_env(monkeypatch):
+    """Both subprocess sites, not just one: the sibling's B1 fix was partial exactly
+    because a second raw call site was missed."""
+    monkeypatch.setenv("CLICOLOR_FORCE", "1")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    calls = _capture_gh(monkeypatch, returncode=0, stdout="[]")
+    guard._pr_number(["--admin"])
+    guard._failing_blocking_checks("5")
+    assert len(calls) == 2
+    for cmd, kwargs in calls:
+        env = kwargs.get("env")
+        assert env is not None, f"{cmd} ran without a scrubbed env"
+        assert "CLICOLOR_FORCE" not in env and "FORCE_COLOR" not in env
+        assert env["NO_COLOR"] == "1" and env["CLICOLOR"] == "0"
+
+
+def test_gh_timeouts_stay_within_hook_budget(monkeypatch):
+    """Both gh calls can run in one main() pass; their timeouts must fit the hook's
+    registered 30s budget (settings.json) with headroom, else a slow gh is killed by the
+    harness mid-verdict rather than fail-closing cleanly."""
+    calls = _capture_gh(monkeypatch, returncode=0, stdout="[]")
+    guard._pr_number(["--admin"])
+    guard._failing_blocking_checks("5")
+    timeouts = [kwargs["timeout"] for _cmd, kwargs in calls]
+    assert all(t > 0 for t in timeouts)
+    assert sum(timeouts) < 30


### PR DESCRIPTION
## Why

Agent harnesses export `CLICOLOR_FORCE`/`FORCE_COLOR`. Those **beat `NO_COLOR`**, so `gh --json` colorizes even when its output is a pipe. `guard-admin-merge.py` parsed `gh pr checks --json` with a bare `json.loads` — inside every agent harness the parse raised, check states read as undeterminable, and the hook **fail-closed**.

Fail-closed is the right default here, but this fired on the *wrong* case: it refused the **one legitimate use of `--admin`** the hook exists to permit — advisory-only failures (#M-0.5). And it blamed a `gh error/timeout` that never happened. gh exited **0**; the colorization was the entire cause, so the message sent you looking for a network fault that wasn't there.

This is the follow-up flagged in [PR #5324's review trail](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5324) — same bug class as its **review B1**, left out of that PR to keep its diff matching its title.

## What changed

The sibling's exact pattern, ported:

| Change | Why |
| --- | --- |
| `_gh_env()` — drop `CLICOLOR_FORCE`/`FORCE_COLOR`, pin `NO_COLOR=1` / `CLICOLOR=0` | on **both** gh subprocess sites (`_pr_number`, `_failing_blocking_checks`). B1's first fix was **partial** because a second call site was missed — a named test now covers both. |
| `_decolorize()` before every parse | incl. `_pr_number`'s `-q .number`: that value is handed to the next gh call as the **PR selector**, where escapes break it just as surely as a failed parse. |
| `gh pr checks` timeout 20 → 8 | both calls can run in one `main()` pass, and **10+20 sat exactly at the hook's registered 30s budget** (`settings.json`) — a slow gh was killed mid-verdict by the harness instead of fail-closing cleanly. Now 18, with headroom. |

**Verdicts unchanged in the anti-bypass direction**, which is the direction that matters: a colorized **red blocking check still blocks** (decolorizing must not lose the `fail` bucket), and empty output with a non-zero rc still fail-closes.

## Proof: red → green by revert

Not "my diff applied" — the tests were held against the **pre-fix** hook to confirm they actually catch it:

```
$ git stash push agents_extensions/shared/hooks/guard-admin-merge.py   # tests kept
$ .venv/bin/python -m pytest tests/test_guard_admin_merge.py -q
8 failed, 30 passed        # all 8 new tests red; no pre-existing test disturbed
E   assert 30 < 30
E    +  where 30 = sum([10, 20])     # the timeout budget, caught by its own test

$ git stash pop
38 passed
```

### End-to-end through the real subprocess path

A stub `gh` on `PATH` colorizing by the **real mechanism** — only when the force vars are present — under a harness-like `CLICOLOR_FORCE=1 FORCE_COLOR=1`, driving the hook as an actual subprocess with a real stdin payload:

```
PRE-FIX:  advisory-only -> exit 2  BLOCKED "could not verify PR #5 check states (gh error/timeout)"
          blocking red  -> exit 2  BLOCKED
FIXED:    advisory-only -> exit 0  ALLOWED     <- the bug, gone
          blocking red  -> exit 2  BLOCKED     <- guard still does its job
```

The pre-fix hook blocked **both** cases, so it *looked* safe while being wrong on the legitimate one — with a diagnostic pointing at the wrong cause.

## Verification

```
$ .venv/bin/python -m pytest tests/test_guard_admin_merge.py tests/test_guard_branch_switch_in_main.py \
    tests/test_guard_push_pytest.py tests/test_guard_secret_print.py tests/test_guard_primary_checkout_write.py -q
208 passed in 13.18s
$ .venv/bin/ruff check agents_extensions/shared/hooks/guard-admin-merge.py tests/test_guard_admin_merge.py
All checks passed!
```

8 new tests: env scrubbing · decolorize round-trip · colorized rows parse · **advisory-only colorized still ALLOWS** (end-to-end `main()`) · **colorized blocking failure still BLOCKS** · colorized PR number recovered · both sites scrubbed · timeouts within budget.

`tests/test_guard_pr_merge.py` is **not** run here — it lives on the unmerged #5324 branch, not on `main`.

## Note for the reviewer

#5324 is still open and touches the same bug class. The two diffs don't overlap (different files), but its `_gh_env`/`_decolorize` helpers are a **deliberate copy** — hooks are standalone by design, per the existing keep-in-sync note. Kept byte-identical to the sibling's so the copies stay diffable.

Not merging, not arming auto-merge.

Refs #5324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
