### PR TITLE
feat(atlas): client word-page app shell via 404 fallback (spec v2 D2/R9)

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -22,6 +22,8 @@
     "test:coverage": "npm run hydrate && vitest run --coverage",
     "test:atlas-route-parity": "node --experimental-strip-types ./scripts/atlas-lexicon-route-parity.mjs",
     "test:atlas-release-gate": "ATLAS_RELEASE_GATE=1 vitest run tests/unit/atlas-runtime-shards.test.ts -t \"full-catalog Sqlite\"",
+    "test:atlas-client-shell-e2e": "node ./scripts/e2e-atlas-client-shell.mjs",
+    "serve:gh-pages-404": "node ./scripts/serve-gh-pages-404.mjs --root dist --port 4177",
     "check:atlas-browser-bundle": "esbuild src/lib/lexicon/http-atlas-data-source.ts --bundle --platform=browser --external:astro* --outfile=/dev/null"
   },
   "dependencies": {

--- a/site/scripts/e2e-atlas-client-shell.mjs
+++ b/site/scripts/e2e-atlas-client-shell.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Deploy-realistic E2E for the atlas 404 client shell (PR3 R4).
+ *
+ * 1. Expects `site/dist/` from `npm run build`
+ * 2. Vendors the F006 fixture runtime tree at `dist/atlas/` (slice 3 owns real deploy vendoring)
+ * 3. Serves with true HTTP 404 → 404.html (not astro preview)
+ * 4. Asserts: fixture tail slug renders via shell; prerendered slug has no shell boot;
+ *    trailing-slash + Cyrillic-encoded slugs work.
+ *
+ * Usage (from site/):
+ *   node ./scripts/e2e-atlas-client-shell.mjs
+ */
+
+import { cpSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+import { createGhPages404Server } from "./serve-gh-pages-404.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SITE = resolve(__dirname, "..");
+const REPO = resolve(SITE, "..");
+const DIST = resolve(SITE, "dist");
+const FIXTURE_ATLAS = resolve(REPO, "tests/fixtures/atlas/runtime-tree/atlas");
+const DIST_ATLAS = resolve(DIST, "atlas");
+
+const TAIL_SLUG = "fixture-expression";
+const TAIL_LEMMA = "на добраніч";
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exitCode = 1;
+}
+
+function ok(msg) {
+  console.log(`OK: ${msg}`);
+}
+
+function pickPrerenderedSlug() {
+  const candidates = ["прапор", "кава", "дім", "я", "іван", "вид"];
+  for (const slug of candidates) {
+    if (existsSync(resolve(DIST, "lexicon", slug, "index.html"))) return slug;
+  }
+  for (const ent of readdirSync(resolve(DIST, "lexicon"), { withFileTypes: true })) {
+    if (!ent.isDirectory()) continue;
+    if (["browse", "practice"].includes(ent.name)) continue;
+    if (existsSync(resolve(DIST, "lexicon", ent.name, "index.html"))) return ent.name;
+  }
+  return null;
+}
+
+async function main() {
+  if (!existsSync(resolve(DIST, "404.html"))) {
+    fail("site/dist/404.html missing — run `npm run build` first");
+    return;
+  }
+  if (!existsSync(FIXTURE_ATLAS)) {
+    fail(`fixture atlas tree missing: ${FIXTURE_ATLAS}`);
+    return;
+  }
+
+  rmSync(DIST_ATLAS, { recursive: true, force: true });
+  cpSync(FIXTURE_ATLAS, DIST_ATLAS, { recursive: true });
+  ok(`vendored fixture atlas → ${DIST_ATLAS}`);
+
+  const prerendered = pickPrerenderedSlug();
+  if (!prerendered) {
+    fail("no prerendered lexicon article found under dist/lexicon/");
+    return;
+  }
+  ok(`prerendered slug: ${prerendered}`);
+
+  if (existsSync(resolve(DIST, "lexicon", TAIL_SLUG, "index.html"))) {
+    fail(`tail slug ${TAIL_SLUG} is unexpectedly prerendered`);
+    return;
+  }
+  ok(`tail slug ${TAIL_SLUG} is not prerendered (will hit 404 shell)`);
+
+  const server = createGhPages404Server({ root: DIST, host: "127.0.0.1", port: 4177 });
+  const { baseUrl } = await server.listen();
+  ok(`server ${baseUrl}`);
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on("pageerror", (err) => errors.push(String(err)));
+
+  try {
+    const statusProbe = await page.request.get(`${baseUrl}/lexicon/${TAIL_SLUG}/`);
+    if (statusProbe.status() !== 404) {
+      fail(`expected HTTP 404 for tail slug, got ${statusProbe.status()}`);
+    } else {
+      ok(`HTTP 404 for /lexicon/${TAIL_SLUG}/`);
+    }
+
+    await page.goto(`${baseUrl}/lexicon/${TAIL_SLUG}/`, { waitUntil: "networkidle" });
+    await page.waitForSelector("[data-word-atlas]", { timeout: 20_000 });
+    const articleText = await page.locator("[data-word-atlas]").innerText();
+    if (!articleText.includes(TAIL_LEMMA) && !articleText.includes(TAIL_SLUG)) {
+      fail(`tail article missing lemma/slug; got snippet: ${articleText.slice(0, 200)}`);
+    } else {
+      ok("tail slug rendered article via shell (lemma/slug present)");
+    }
+    const genericHidden = await page.locator("[data-generic-404][hidden]").count();
+    if (genericHidden < 1) {
+      fail("generic 404 section should be hidden on lexicon shell path");
+    } else {
+      ok("generic 404 hidden while shell active");
+    }
+    const clientWrapped = await page.locator("[data-atlas-client-article]").count();
+    if (clientWrapped < 1) {
+      fail("expected [data-atlas-client-article] wrapper from client shell");
+    } else {
+      ok("client shell article wrapper present");
+    }
+
+    // Encoded Cyrillic of a fixture slug that is also commonly prerendered
+    const encoded = encodeURIComponent("прапор");
+    const praporPrerendered = existsSync(resolve(DIST, "lexicon", "прапор", "index.html"));
+    await page.goto(`${baseUrl}/lexicon/${encoded}/`, { waitUntil: "networkidle" });
+    await page.waitForSelector("[data-word-atlas]", { timeout: 15_000 });
+    if (praporPrerendered) {
+      const hasClientShellAttr = await page.locator("[data-atlas-client-article]").count();
+      if (hasClientShellAttr > 0) {
+        fail("prerendered /lexicon/прапор/ unexpectedly mounted client shell article wrapper");
+      } else {
+        ok("encoded Cyrillic prerendered slug serves static HTML (no client article wrapper)");
+      }
+    } else {
+      ok("encoded Cyrillic slug rendered via shell");
+    }
+
+    // No trailing slash → still resolves (server index fallback or shell)
+    await page.goto(`${baseUrl}/lexicon/${TAIL_SLUG}`, { waitUntil: "networkidle" });
+    await page.waitForSelector("[data-word-atlas]", { timeout: 20_000 });
+    ok("tail slug without trailing slash still renders article");
+
+    const preStatus = await page.request.get(`${baseUrl}/lexicon/${prerendered}/`);
+    if (preStatus.status() !== 200) {
+      fail(`prerendered slug expected 200, got ${preStatus.status()}`);
+    } else {
+      ok(`HTTP 200 for prerendered /lexicon/${prerendered}/`);
+    }
+    await page.goto(`${baseUrl}/lexicon/${prerendered}/`, { waitUntil: "networkidle" });
+    await page.waitForSelector("[data-word-atlas]", { timeout: 10_000 });
+    const clientArticle = await page.locator("[data-atlas-client-article]").count();
+    const atlasShellPending = await page.evaluate(
+      () => document.documentElement.dataset.atlasShell || "",
+    );
+    if (clientArticle > 0 || atlasShellPending === "active" || atlasShellPending === "pending") {
+      fail(
+        `prerendered page should not boot atlas shell (clientArticle=${clientArticle}, dataset=${atlasShellPending})`,
+      );
+    } else {
+      ok("prerendered page has no atlas shell boot");
+    }
+
+    await page.goto(`${baseUrl}/this-route-does-not-exist-xyz/`, { waitUntil: "networkidle" });
+    const genericVisible = await page.locator("[data-generic-404]:not([hidden])").count();
+    if (genericVisible < 1) {
+      fail("generic 404 should remain visible for non-lexicon paths");
+    } else {
+      ok("non-lexicon 404 keeps generic recovery UI");
+    }
+
+    if (errors.length) {
+      fail(`page errors: ${errors.join(" | ")}`);
+    }
+  } finally {
+    await browser.close();
+    await server.close();
+  }
+
+  if (process.exitCode && process.exitCode !== 0) {
+    console.error("\nE2E FAILED");
+  } else {
+    console.log("\nE2E PASSED");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/site/scripts/serve-gh-pages-404.mjs
+++ b/site/scripts/serve-gh-pages-404.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Tiny static server with GitHub Pages 404 semantics.
+ *
+ * Unknown paths return `404.html` with HTTP status 404 (astro preview does not).
+ *
+ * Usage:
+ *   node ./scripts/serve-gh-pages-404.mjs --root dist --port 4177
+ */
+
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { createServer } from "node:http";
+import { extname, join, normalize, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".woff2": "font/woff2",
+  ".gz": "application/gzip",
+  ".map": "application/json",
+  ".txt": "text/plain; charset=utf-8",
+  ".xml": "application/xml; charset=utf-8",
+};
+
+function parseArgs(argv) {
+  const out = { root: "dist", port: 4177, host: "127.0.0.1" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--root") out.root = argv[++i];
+    else if (arg === "--port") out.port = Number(argv[++i]);
+    else if (arg === "--host") out.host = argv[++i];
+  }
+  return out;
+}
+
+function safeJoin(root, requestPath) {
+  const decoded = decodeURIComponent(requestPath.split("?")[0] || "/");
+  const cleaned = normalize(decoded).replace(/^(\.\.[/\\])+/, "");
+  const full = resolve(root, "." + (cleaned.startsWith("/") ? cleaned : `/${cleaned}`));
+  if (!full.startsWith(root)) return null;
+  return full;
+}
+
+function sendFile(res, status, filePath) {
+  const type = MIME[extname(filePath).toLowerCase()] || "application/octet-stream";
+  res.writeHead(status, { "content-type": type, "cache-control": "no-store" });
+  createReadStream(filePath).pipe(res);
+}
+
+export function createGhPages404Server(options) {
+  const root = resolve(options.root);
+  const notFound = join(root, "404.html");
+  if (!existsSync(notFound)) {
+    throw new Error(`404.html missing under ${root}`);
+  }
+
+  const server = createServer((req, res) => {
+    const urlPath = req.url || "/";
+    let target = safeJoin(root, urlPath);
+    if (!target) {
+      res.writeHead(400).end("bad path");
+      return;
+    }
+
+    if (existsSync(target) && statSync(target).isDirectory()) {
+      target = join(target, "index.html");
+    }
+
+    if (existsSync(target) && statSync(target).isFile()) {
+      sendFile(res, 200, target);
+      return;
+    }
+
+    // Trailing-slash index fallback for `/lexicon/slug` without slash
+    if (!urlPath.endsWith("/") && !extname(urlPath.split("?")[0] || "")) {
+      const withIndex = safeJoin(root, `${urlPath.replace(/\?.*$/, "")}/index.html`);
+      if (withIndex && existsSync(withIndex)) {
+        sendFile(res, 200, withIndex);
+        return;
+      }
+    }
+
+    sendFile(res, 404, notFound);
+  });
+
+  return {
+    server,
+    root,
+    listen: () =>
+      new Promise((resolveListen) => {
+        server.listen(options.port, options.host, () => {
+          resolveListen({
+            host: options.host,
+            port: options.port,
+            baseUrl: `http://${options.host}:${options.port}`,
+          });
+        });
+      }),
+    close: () =>
+      new Promise((resolveClose, reject) => {
+        server.close((err) => (err ? reject(err) : resolveClose()));
+      }),
+  };
+}
+
+const isMain =
+  process.argv[1] &&
+  resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1]);
+
+if (isMain) {
+  const args = parseArgs(process.argv.slice(2));
+  const app = createGhPages404Server(args);
+  const info = await app.listen();
+  console.log(`GH-Pages 404 server at ${info.baseUrl} (root=${app.root})`);
+}

--- a/site/src/layouts/CourseLayout.astro
+++ b/site/src/layouts/CourseLayout.astro
@@ -88,6 +88,7 @@ const isActive = (href: string) => {
     <title>{title} · Learn Ukrainian</title>
     {description && <meta name="description" content={description} />}
     <link rel="icon" href="/favicon.svg" />
+    <slot name="head" />
     <script is:inline>
       (() => {
         const query = window.matchMedia('(prefers-color-scheme: dark)');

--- a/site/src/lexicon/WordAtlasClientShell.tsx
+++ b/site/src/lexicon/WordAtlasClientShell.tsx
@@ -1,0 +1,246 @@
+/**
+ * Client-mounted Word Atlas shell for GH Pages 404 fallback (PR3 D2/R9).
+ *
+ * When `location.pathname` is `/lexicon/<slug>/`, fetches the entry via
+ * `HttpAtlasDataSource` and mounts `WordAtlasArticle`. Non-lexicon paths
+ * render nothing so the generic 404 stays visible.
+ *
+ * Do not edit WordAtlasArticle internals here — mount as-is.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import WordAtlasArticle from "./WordAtlasArticle";
+import {
+  parseLexiconArticleSlug,
+} from "../lib/lexicon/atlas-lexicon-path";
+import {
+  reportAtlasShellAnalytics,
+  suppressGoatcounterAutoload,
+} from "../lib/lexicon/atlas-shell-analytics";
+import {
+  createBrowserAtlasFetch,
+  DEFAULT_ATLAS_ASSET_BASE,
+} from "../lib/lexicon/browser-atlas-fetch";
+import { HttpAtlasDataSource } from "../lib/lexicon/http-atlas-data-source";
+import { absoluteSitePath } from "../lib/lexicon/site-base";
+import {
+  analyticsClassForState,
+  loadAtlasClientShellEntry,
+  type AtlasClientShellState,
+} from "../lib/lexicon/word-atlas-client-shell";
+
+export interface WordAtlasClientShellProps {
+  /** Same-origin atlas root; default `/atlas` (base-aware absolute). */
+  assetBaseUrl?: string;
+  /** Site base URL (`import.meta.env.BASE_URL`). */
+  baseUrl?: string;
+  /** Override pathname (tests). */
+  pathname?: string;
+  /** Inject fetch for hermetic tests. */
+  fetchImpl?: typeof fetch;
+}
+
+function bindEtymologyHandlers(root: ParentNode | null): () => void {
+  if (!root) return () => {};
+  const stages = root.querySelectorAll<HTMLElement>("[data-ety-note]");
+  const listeners: Array<{ el: HTMLElement; fn: () => void }> = [];
+  stages.forEach((stage) => {
+    const fn = () => {
+      root.querySelectorAll("[data-ety-note]").forEach((item) => {
+        item.classList.remove("active");
+      });
+      stage.classList.add("active");
+      const output = stage
+        .closest(".atlas-section")
+        ?.querySelector<HTMLElement>("[data-ety-note-output]");
+      if (output) {
+        output.textContent = stage.dataset.etyNote || output.textContent;
+        output.style.background = "var(--teal-light)";
+      }
+    };
+    stage.addEventListener("click", fn);
+    listeners.push({ el: stage, fn });
+  });
+  return () => {
+    for (const { el, fn } of listeners) el.removeEventListener("click", fn);
+  };
+}
+
+function ShellSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      data-word-atlas-state="loading"
+      className="atlas-client-shell-state atlas-client-shell-loading"
+    >
+      <div className="atlas-client-shell-skeleton" aria-hidden="true">
+        <div className="atlas-client-shell-skel-line wide" />
+        <div className="atlas-client-shell-skel-line" />
+        <div className="atlas-client-shell-skel-line mid" />
+        <div className="atlas-client-shell-skel-block" />
+      </div>
+      <p>Завантаження статті Атласу…</p>
+    </div>
+  );
+}
+
+export default function WordAtlasClientShell({
+  assetBaseUrl,
+  baseUrl = "/",
+  pathname,
+  fetchImpl,
+}: WordAtlasClientShellProps) {
+  const resolvedBase = baseUrl;
+  const atlasBase =
+    assetBaseUrl ??
+    (absoluteSitePath(DEFAULT_ATLAS_ASSET_BASE, resolvedBase).replace(/\/$/, "") ||
+      DEFAULT_ATLAS_ASSET_BASE);
+
+  const path =
+    pathname ??
+    (typeof window !== "undefined" ? window.location.pathname : "");
+  const slug = parseLexiconArticleSlug(path, resolvedBase);
+
+  const [state, setState] = useState<AtlasClientShellState | null>(() =>
+    slug ? { status: "loading", slug } : null,
+  );
+  const [retryToken, setRetryToken] = useState(0);
+  const articleHostRef = useRef<HTMLDivElement | null>(null);
+  const reportedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) return;
+    suppressGoatcounterAutoload();
+    document.documentElement.dataset.atlasShell = "active";
+    document.querySelectorAll("[data-generic-404]").forEach((el) => {
+      el.setAttribute("hidden", "");
+    });
+    document.querySelectorAll("[data-atlas-shell-boot]").forEach((el) => {
+      el.setAttribute("hidden", "");
+    });
+  }, [slug]);
+
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+    setState({ status: "loading", slug });
+
+    const source = new HttpAtlasDataSource(createBrowserAtlasFetch(fetchImpl), {
+      assetBaseUrl: atlasBase,
+      pointerTtlMs: 0,
+    });
+
+    void loadAtlasClientShellEntry(slug, source).then((next) => {
+      if (!cancelled) setState(next);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, atlasBase, fetchImpl, retryToken]);
+
+  useEffect(() => {
+    if (!state || state.status === "loading") return;
+    const classification = analyticsClassForState(state);
+    if (!classification) return;
+    const reportKey = `${classification}:${state.slug}:${state.status === "ready" ? state.record.entry.lemma : ""}`;
+    if (reportedRef.current === reportKey) return;
+    reportedRef.current = reportKey;
+    reportAtlasShellAnalytics({
+      classification,
+      slug: state.slug,
+      lemma: state.status === "ready" ? state.record.entry.lemma : undefined,
+      baseUrl: resolvedBase,
+    });
+  }, [state, resolvedBase]);
+
+  useEffect(() => {
+    if (!state || state.status !== "ready") return;
+    return bindEtymologyHandlers(articleHostRef.current);
+  }, [state]);
+
+  if (!slug || !state) return null;
+
+  if (state.status === "loading") {
+    return <ShellSkeleton />;
+  }
+
+  if (state.status === "not_found") {
+    return (
+      <div
+        role="alert"
+        data-word-atlas-state="not_found"
+        data-http-status="404"
+        className="atlas-client-shell-state"
+      >
+        <h1>Слово не знайдено</h1>
+        <p>
+          Немає публічної статті для «{state.slug}».
+        </p>
+        <p>
+          <a href={absoluteSitePath("/lexicon/", resolvedBase)}>До Атласу</a>
+          {" · "}
+          <a href={absoluteSitePath("/lexicon/", resolvedBase) + "#lexicon-landing-search"}>
+            Пошук
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  if (state.status === "corrupt") {
+    return (
+      <div
+        role="alert"
+        data-word-atlas-state="corrupt"
+        data-http-status="503"
+        className="atlas-client-shell-state"
+      >
+        <h1>Дані статті пошкоджені</h1>
+        <p>Не вдалося прочитати словникові дані для «{state.slug}».</p>
+        <p className="atlas-client-shell-detail">{state.message}</p>
+        <p>
+          <a href={absoluteSitePath("/lexicon/", resolvedBase)}>До Атласу</a>
+        </p>
+      </div>
+    );
+  }
+
+  if (state.status === "network_error") {
+    return (
+      <div
+        role="alert"
+        data-word-atlas-state="network_error"
+        data-http-status="503"
+        className="atlas-client-shell-state"
+      >
+        <h1>Не вдалося завантажити</h1>
+        <p>Мережева помилка під час завантаження «{state.slug}».</p>
+        <p className="atlas-client-shell-detail">{state.message}</p>
+        <p>
+          <button
+            type="button"
+            data-word-atlas-retry
+            onClick={() => {
+              reportedRef.current = null;
+              setRetryToken((n) => n + 1);
+            }}
+          >
+            Спробувати знову
+          </button>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={articleHostRef} data-atlas-client-article>
+      <WordAtlasArticle
+        record={state.record}
+        generatedAt={state.generatedAt}
+        manifestVersion={state.manifestVersion}
+      />
+    </div>
+  );
+}

--- a/site/src/lib/lexicon/atlas-lexicon-path.ts
+++ b/site/src/lib/lexicon/atlas-lexicon-path.ts
@@ -1,0 +1,38 @@
+/**
+ * Lexicon article path helpers for the 404-fallback client shell (PR3 D2).
+ */
+
+import { isValidAtlasSlug } from "./atlas-data-source.ts";
+import { stripSiteBase } from "./site-base.ts";
+
+const LEXICON_ARTICLE_RE = /^\/lexicon\/([^/]+)\/?$/;
+
+/**
+ * If `pathname` is a lexicon article URL (`/lexicon/<slug>/`), return the
+ * decoded NFC slug. Otherwise null (generic 404 / non-article lexicon routes).
+ */
+export function parseLexiconArticleSlug(
+  pathname: string,
+  baseUrl: string | undefined | null = "/",
+): string | null {
+  const path = stripSiteBase(pathname, baseUrl);
+  const match = path.match(LEXICON_ARTICLE_RE);
+  if (!match) return null;
+  let slug: string;
+  try {
+    slug = decodeURIComponent(match[1]!).normalize("NFC");
+  } catch {
+    return null;
+  }
+  if (!isValidAtlasSlug(slug)) return null;
+  return slug;
+}
+
+/** Canonical article path for a slug (trailing slash, base-aware). */
+export function lexiconArticlePath(
+  slug: string,
+  baseUrl: string | undefined | null = "/",
+): string {
+  const base = baseUrl && baseUrl !== "/" ? String(baseUrl).replace(/\/$/, "") : "";
+  return `${base}/lexicon/${slug}/`;
+}

--- a/site/src/lib/lexicon/atlas-shell-analytics.ts
+++ b/site/src/lib/lexicon/atlas-shell-analytics.ts
@@ -1,0 +1,64 @@
+/**
+ * GoatCounter classification for atlas 404-fallback pages (spec R2).
+ *
+ * Call after the shell settles. Suppresses the automatic /404/ pageview via
+ * `goatcounter.no_onload` (set early on lexicon paths) so we emit exactly one
+ * classified hit — never a double pageview.
+ */
+
+import type { AtlasAnalyticsClass } from "./word-atlas-client-shell.ts";
+import { lexiconArticlePath } from "./atlas-lexicon-path.ts";
+
+export type GoatCounterLike = {
+  count?: (vars?: {
+    path?: string;
+    title?: string;
+    event?: boolean;
+  }) => void;
+  no_onload?: boolean;
+};
+
+declare global {
+  interface Window {
+    goatcounter?: GoatCounterLike;
+  }
+}
+
+export function suppressGoatcounterAutoload(): void {
+  const existing = window.goatcounter ?? {};
+  window.goatcounter = { ...existing, no_onload: true };
+}
+
+export function reportAtlasShellAnalytics(options: {
+  classification: AtlasAnalyticsClass;
+  slug: string;
+  lemma?: string;
+  baseUrl?: string;
+  goatcounter?: GoatCounterLike | null;
+  setDocumentTitle?: boolean;
+}): void {
+  const {
+    classification,
+    slug,
+    lemma,
+    baseUrl = "/",
+    setDocumentTitle = true,
+  } = options;
+  const gc = options.goatcounter ?? window.goatcounter;
+  const path = lexiconArticlePath(slug, baseUrl);
+  const title = lemma ?? slug;
+
+  if (classification === "atlas_tail_rendered") {
+    if (setDocumentTitle) {
+      document.title = `${title} · Learn Ukrainian`;
+    }
+    // One pageview with overridden path+title (not the generic /404/).
+    gc?.count?.({ path, title });
+    // Classification event (not a second pageview).
+    gc?.count?.({ path: classification, title, event: true });
+    return;
+  }
+
+  // Failures: classify as event only — still no /404/ pageview.
+  gc?.count?.({ path: classification, title: slug, event: true });
+}

--- a/site/src/lib/lexicon/browser-atlas-fetch.ts
+++ b/site/src/lib/lexicon/browser-atlas-fetch.ts
@@ -1,0 +1,36 @@
+/**
+ * Browser `AtlasFetch` for same-origin runtime shards.
+ *
+ * `HttpAtlasDataSource` already prefixes `assetBaseUrl` (e.g. `/atlas/current.json`);
+ * this fetch only performs the network read.
+ */
+
+import { AtlasDataSourceError } from "./atlas-data-source.ts";
+import type { AtlasFetch } from "./http-atlas-data-source.ts";
+
+export function createBrowserAtlasFetch(
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
+): AtlasFetch {
+  return async (url: string) => {
+    let response: Response;
+    try {
+      response = await fetchImpl(url);
+    } catch (error) {
+      throw new AtlasDataSourceError(
+        "unavailable",
+        `network error fetching ${url}: ${String(error)}`,
+      );
+    }
+    if (!response.ok) {
+      throw new AtlasDataSourceError(
+        "unavailable",
+        `HTTP ${response.status} fetching ${url}`,
+      );
+    }
+    const buffer = await response.arrayBuffer();
+    return new Uint8Array(buffer);
+  };
+}
+
+/** Default same-origin atlas asset root (Pages-vendored tree; slice 3). */
+export const DEFAULT_ATLAS_ASSET_BASE = "/atlas";

--- a/site/src/lib/lexicon/site-base.ts
+++ b/site/src/lib/lexicon/site-base.ts
@@ -1,0 +1,33 @@
+/**
+ * Base-aware absolute site paths (spec R4).
+ * Astro `BASE_URL` is `/` on the production Pages root deploy.
+ */
+
+export function normalizeBaseUrl(baseUrl: string | undefined | null): string {
+  if (!baseUrl || baseUrl === "/") return "/";
+  const withSlash = baseUrl.startsWith("/") ? baseUrl : `/${baseUrl}`;
+  return withSlash.endsWith("/") ? withSlash.slice(0, -1) || "/" : withSlash;
+}
+
+/** Join site base with a root-absolute path (`/lexicon/…`, `/atlas`). */
+export function absoluteSitePath(
+  path: string,
+  baseUrl: string | undefined | null = "/",
+): string {
+  const base = normalizeBaseUrl(baseUrl);
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  if (base === "/") return normalizedPath;
+  return `${base}${normalizedPath}`;
+}
+
+/** Strip the site base prefix from a location pathname. */
+export function stripSiteBase(
+  pathname: string,
+  baseUrl: string | undefined | null = "/",
+): string {
+  const base = normalizeBaseUrl(baseUrl);
+  if (base === "/") return pathname || "/";
+  if (pathname === base) return "/";
+  if (pathname.startsWith(`${base}/`)) return pathname.slice(base.length) || "/";
+  return pathname || "/";
+}

--- a/site/src/lib/lexicon/word-atlas-client-shell.ts
+++ b/site/src/lib/lexicon/word-atlas-client-shell.ts
@@ -1,0 +1,92 @@
+/**
+ * Client word-page shell load/state machine (PR3 D2 + R9).
+ *
+ * Pure async helpers — hermetic tests stub `AtlasDataSource` / fetch.
+ */
+
+import {
+  AtlasDataSourceError,
+  type AtlasDataSource,
+  type EntryRecord,
+} from "./atlas-data-source.ts";
+
+export type AtlasClientShellState =
+  | { status: "loading"; slug: string }
+  | {
+      status: "ready";
+      slug: string;
+      record: EntryRecord;
+      generatedAt: string;
+      manifestVersion: string;
+    }
+  | { status: "not_found"; slug: string }
+  | { status: "corrupt"; slug: string; message: string }
+  | { status: "network_error"; slug: string; message: string };
+
+export type AtlasAnalyticsClass =
+  | "atlas_tail_rendered"
+  | "atlas_not_found"
+  | "atlas_fetch_failed";
+
+export function analyticsClassForState(
+  state: AtlasClientShellState,
+): AtlasAnalyticsClass | null {
+  switch (state.status) {
+    case "ready":
+      return "atlas_tail_rendered";
+    case "not_found":
+      return "atlas_not_found";
+    case "corrupt":
+    case "network_error":
+      return "atlas_fetch_failed";
+    case "loading":
+      return null;
+  }
+}
+
+function mapError(
+  slug: string,
+  error: unknown,
+): Exclude<AtlasClientShellState, { status: "loading" }> {
+  if (error instanceof AtlasDataSourceError) {
+    if (error.code === "integrity_error" || error.code === "unsupported_schema") {
+      return { status: "corrupt", slug, message: error.message };
+    }
+    if (error.code === "invalid_slug") {
+      return { status: "not_found", slug };
+    }
+    // unavailable + version_mismatch → retryable network/fetch failure UI
+    return { status: "network_error", slug, message: error.message };
+  }
+  return {
+    status: "network_error",
+    slug,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+/**
+ * Resolve a slug through any `AtlasDataSource` into a terminal shell state
+ * (or throw never — all failures become typed states).
+ */
+export async function loadAtlasClientShellEntry(
+  slug: string,
+  source: AtlasDataSource,
+  options?: { generatedAt?: string },
+): Promise<Exclude<AtlasClientShellState, { status: "loading" }>> {
+  try {
+    const result = await source.getEntry(slug);
+    if (result.kind === "missing") {
+      return { status: "not_found", slug };
+    }
+    return {
+      status: "ready",
+      slug,
+      record: result.record,
+      manifestVersion: result.version,
+      generatedAt: options?.generatedAt ?? result.version,
+    };
+  } catch (error) {
+    return mapError(slug, error);
+  }
+}

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -1,6 +1,23 @@
 ---
+/**
+ * Site 404 + Atlas client word-page shell (PR3 D2).
+ *
+ * GitHub Pages serves this document with HTTP 404 for unknown paths. When the
+ * path is `/lexicon/<slug>/`, the client shell boots, fetches the entry from
+ * same-origin `/atlas` shards, and mounts WordAtlasArticle. Other 404s keep
+ * the generic learner recovery UI.
+ */
 import CourseLayout from '../layouts/CourseLayout.astro';
 import ChromeText from '../components/chrome/ChromeText.astro';
+import WordAtlasClientShell from '../lexicon/WordAtlasClientShell';
+
+const siteUrl = Astro.site ? new URL(Astro.site).origin : 'https://learn-ukrainian.github.io';
+const ogTitle = 'Learn Ukrainian';
+const ogDescription =
+  'Free open-source Ukrainian curriculum — lessons, readings, and the Word Atlas.';
+const ogImage = `${siteUrl}/favicon.svg`;
+const baseUrl = import.meta.env.BASE_URL || '/';
+const atlasAssetBase = `${baseUrl === '/' ? '' : baseUrl.replace(/\/$/, '')}/atlas`;
 ---
 
 <CourseLayout
@@ -12,7 +29,59 @@ import ChromeText from '../components/chrome/ChromeText.astro';
   heroVariant="unavailable"
   wide
 >
-  <section class="route-state-card big">
+  {/* Generic site-wide OpenGraph on 404 (spec R2 — tail lemmas share these tags). */}
+  <meta slot="head" property="og:type" content="website" />
+  <meta slot="head" property="og:site_name" content="Learn Ukrainian" />
+  <meta slot="head" property="og:title" content={ogTitle} />
+  <meta slot="head" property="og:description" content={ogDescription} />
+  <meta slot="head" property="og:url" content={siteUrl} />
+  <meta slot="head" property="og:image" content={ogImage} />
+  <meta slot="head" name="twitter:card" content="summary" />
+  <meta slot="head" name="twitter:title" content={ogTitle} />
+  <meta slot="head" name="twitter:description" content={ogDescription} />
+
+  <script is:inline define:vars={{ baseUrl }}>
+    (() => {
+      const base = baseUrl === '/' ? '' : String(baseUrl).replace(/\/$/, '');
+      const path = location.pathname;
+      const stripped = base && path.startsWith(base) ? path.slice(base.length) || '/' : path;
+      const isLexiconArticle = /^\/lexicon\/[^/]+\/?$/.test(stripped);
+      if (!isLexiconArticle) return;
+      window.goatcounter = Object.assign(window.goatcounter || {}, { no_onload: true });
+      document.documentElement.dataset.atlasShell = 'pending';
+      document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('[data-generic-404]').forEach((el) => {
+          el.setAttribute('hidden', '');
+        });
+        document.querySelectorAll('[data-atlas-shell-boot]').forEach((el) => {
+          el.removeAttribute('hidden');
+        });
+      });
+    })();
+  </script>
+
+  <div data-atlas-shell-boot hidden>
+    <div
+      role="status"
+      aria-busy="true"
+      data-word-atlas-state="loading"
+      class="atlas-client-shell-state atlas-client-shell-loading"
+    >
+      <div class="atlas-client-shell-skeleton" aria-hidden="true">
+        <div class="atlas-client-shell-skel-line wide"></div>
+        <div class="atlas-client-shell-skel-line"></div>
+        <div class="atlas-client-shell-skel-line mid"></div>
+        <div class="atlas-client-shell-skel-block"></div>
+      </div>
+      <p>Завантаження статті Атласу…</p>
+    </div>
+  </div>
+
+  <div data-atlas-client-shell>
+    <WordAtlasClientShell client:only="react" baseUrl={baseUrl} assetBaseUrl={atlasAssetBase} />
+  </div>
+
+  <section class="route-state-card big" data-generic-404>
     <p class="state-code">404</p>
     <h2><ChromeText k="state.notFoundTitle" /></h2>
     <p><ChromeText k="state.notFoundBody" /></p>
@@ -24,3 +93,81 @@ import ChromeText from '../components/chrome/ChromeText.astro';
     </div>
   </section>
 </CourseLayout>
+
+<style is:global>
+  .atlas-client-shell-state {
+    display: grid;
+    gap: 0.75rem;
+    padding: 1.25rem 0 2rem;
+    max-width: 42rem;
+  }
+  .atlas-client-shell-state h1 {
+    margin: 0;
+    font-size: 1.75rem;
+    line-height: 1.25;
+  }
+  .atlas-client-shell-state p {
+    margin: 0;
+    line-height: 1.5;
+  }
+  .atlas-client-shell-detail {
+    font-size: 0.9rem;
+    opacity: 0.8;
+    word-break: break-word;
+  }
+  .atlas-client-shell-state a {
+    font-weight: 700;
+  }
+  .atlas-client-shell-state button[data-word-atlas-retry] {
+    min-height: 44px;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--lu-border, #ccc);
+    border-radius: 6px;
+    background: var(--lu-surface, #fff);
+    color: var(--lu-text, inherit);
+    font: inherit;
+    font-weight: 800;
+    cursor: pointer;
+  }
+  .atlas-client-shell-skeleton {
+    display: grid;
+    gap: 0.65rem;
+    margin-bottom: 0.5rem;
+  }
+  .atlas-client-shell-skel-line,
+  .atlas-client-shell-skel-block {
+    border-radius: 6px;
+    background: linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--lu-border, #ddd) 65%, transparent),
+      color-mix(in srgb, var(--lu-border, #ddd) 35%, transparent),
+      color-mix(in srgb, var(--lu-border, #ddd) 65%, transparent)
+    );
+    background-size: 200% 100%;
+    animation: atlas-shell-shimmer 1.2s ease-in-out infinite;
+  }
+  .atlas-client-shell-skel-line {
+    height: 0.9rem;
+    width: 70%;
+  }
+  .atlas-client-shell-skel-line.wide {
+    width: 92%;
+    height: 1.4rem;
+  }
+  .atlas-client-shell-skel-line.mid {
+    width: 55%;
+  }
+  .atlas-client-shell-skel-block {
+    height: 6rem;
+    width: 100%;
+    margin-top: 0.5rem;
+  }
+  @keyframes atlas-shell-shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: -100% 0;
+    }
+  }
+</style>

--- a/site/tests/unit/etymology-handler-built-output.test.ts
+++ b/site/tests/unit/etymology-handler-built-output.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+
+/**
+ * Built-output / shell-render assertion: prerendered lexicon pages must keep
+ * the inline etymology-anchor click handler (follow-up from #5329 — route-parity
+ * strips scripts, so this gate covers them explicitly).
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import reactRenderer from "@astrojs/react/server.js";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { beforeAll, describe, expect, test } from "vitest";
+import type { EntryRecord } from "@site/src/lib/lexicon/atlas-data-source";
+import { articleProps } from "../helpers/word-atlas-record";
+
+type AstroComponent = Parameters<AstroContainer["renderToString"]>[0];
+
+const ETY_HANDLER_MARKERS = [
+  "[data-ety-note]",
+  "[data-ety-note-output]",
+  "data-ety-note",
+  "classList.remove('active')",
+] as const;
+
+const stubRecord = articleProps({
+  lemma: "прапор",
+  url_slug: "прапор",
+  gloss: "flag",
+  entry_type: "lemma",
+  pos: "noun",
+  ipa: null,
+  primary_source: "fixture",
+  course_usage: [],
+}).record as EntryRecord;
+
+describe("etymology inline handler on prerendered lexicon pages", () => {
+  let container: AstroContainer;
+  let WordAtlasPageShell: AstroComponent;
+
+  beforeAll(async () => {
+    const mod = await import("@site/src/lexicon/WordAtlasPageShell.astro");
+    WordAtlasPageShell = mod.default as AstroComponent;
+    container = await AstroContainer.create();
+    container.addServerRenderer({ renderer: reactRenderer });
+  });
+
+  test("WordAtlasPageShell ready state embeds the etymology click handler script", async () => {
+    const html = await container.renderToString(WordAtlasPageShell, {
+      props: {
+        state: {
+          status: "ready",
+          record: stubRecord,
+          generatedAt: "test",
+          manifestVersion: "0.1",
+        },
+      },
+    });
+    for (const marker of ETY_HANDLER_MARKERS) {
+      expect(html, `missing marker ${marker}`).toContain(marker);
+    }
+  });
+
+  test("built dist lexicon HTML keeps the etymology handler when dist/ is present", () => {
+    const distLexicon = resolve(process.cwd(), "dist/lexicon");
+    if (!existsSync(distLexicon)) {
+      // Hermetic unit runs without a prior build still cover the shell render above.
+      expect(true).toBe(true);
+      return;
+    }
+    const articleDirs = readdirSync(distLexicon, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .filter((name) => !["browse", "practice"].includes(name) && !name.startsWith("."));
+    expect(articleDirs.length).toBeGreaterThan(0);
+    let checked = 0;
+    for (const name of articleDirs.slice(0, 5)) {
+      const indexPath = join(distLexicon, name, "index.html");
+      if (!existsSync(indexPath)) continue;
+      const html = readFileSync(indexPath, "utf8");
+      for (const marker of ETY_HANDLER_MARKERS) {
+        expect(html, `${name} missing ${marker}`).toContain(marker);
+      }
+      checked += 1;
+    }
+    expect(checked).toBeGreaterThan(0);
+  });
+});

--- a/site/tests/unit/word-atlas-client-shell.test.tsx
+++ b/site/tests/unit/word-atlas-client-shell.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement } from "react";
+import {
+  createFileAtlasFetch,
+  createNodeHttpAtlasDataSource,
+} from "@site/src/lib/lexicon/http-atlas-node";
+import { parseLexiconArticleSlug } from "@site/src/lib/lexicon/atlas-lexicon-path";
+import {
+  analyticsClassForState,
+  loadAtlasClientShellEntry,
+} from "@site/src/lib/lexicon/word-atlas-client-shell";
+import { reportAtlasShellAnalytics } from "@site/src/lib/lexicon/atlas-shell-analytics";
+import { AtlasDataSourceError } from "@site/src/lib/lexicon/atlas-data-source";
+import WordAtlasClientShell from "@site/src/lexicon/WordAtlasClientShell";
+
+const fixtureRuntimeTree = resolve(
+  process.cwd(),
+  "../tests/fixtures/atlas/runtime-tree",
+);
+const assetRoot = resolve(fixtureRuntimeTree, "atlas");
+
+function fixtureHttpSource() {
+  // File fetch already roots at runtime-tree/atlas/; leave assetBaseUrl empty
+  // so HttpAtlasDataSource requests `current.json` not `atlas/current.json`.
+  return createNodeHttpAtlasDataSource(createFileAtlasFetch(fixtureRuntimeTree), {
+    pointerTtlMs: 0,
+  });
+}
+
+/** Browser-shaped fetch over the committed F006 fixture tree. */
+function fixtureFetchImpl(overrides?: {
+  corruptShard?: boolean;
+  failUrls?: RegExp;
+  failOnceUrls?: RegExp;
+}): typeof fetch {
+  let failOnceTripped = false;
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const path = url.replace(/^https?:\/\/[^/]+/, "");
+    if (overrides?.failUrls?.test(path)) {
+      throw new TypeError(`network down: ${path}`);
+    }
+    if (overrides?.failOnceUrls?.test(path) && !failOnceTripped) {
+      failOnceTripped = true;
+      throw new TypeError(`transient network: ${path}`);
+    }
+    const relative = path.replace(/^\/atlas\//, "");
+    const filePath = resolve(assetRoot, relative);
+    let body: Buffer;
+    try {
+      body = readFileSync(filePath);
+    } catch {
+      return new Response("missing", { status: 404 });
+    }
+    if (overrides?.corruptShard && relative.includes("/entries/") && relative.endsWith(".json.gz")) {
+      // Truncate so gunzip / integrity checks fail.
+      body = body.subarray(0, Math.min(32, body.length));
+    }
+    return new Response(new Uint8Array(body), {
+      status: 200,
+      headers: { "content-type": "application/octet-stream" },
+    });
+  }) as typeof fetch;
+}
+
+afterEach(() => {
+  cleanup();
+  document.title = "";
+  delete document.documentElement.dataset.atlasShell;
+});
+
+describe("parseLexiconArticleSlug", () => {
+  test("matches trailing-slash and Cyrillic-encoded forms", () => {
+    expect(parseLexiconArticleSlug("/lexicon/прапор/")).toBe("прапор");
+    expect(parseLexiconArticleSlug("/lexicon/%D0%BF%D1%80%D0%B0%D0%BF%D0%BE%D1%80/")).toBe(
+      "прапор",
+    );
+    expect(parseLexiconArticleSlug("/lexicon/прапор")).toBe("прапор");
+    expect(parseLexiconArticleSlug("/base/lexicon/прапор/", "/base/")).toBe("прапор");
+  });
+
+  test("rejects non-article lexicon paths", () => {
+    expect(parseLexiconArticleSlug("/lexicon/")).toBeNull();
+    expect(parseLexiconArticleSlug("/lexicon/browse/")).toBe("browse"); // article-shaped; real browse is prerendered
+    expect(parseLexiconArticleSlug("/a1/")).toBeNull();
+    expect(parseLexiconArticleSlug("/404/")).toBeNull();
+  });
+});
+
+describe("loadAtlasClientShellEntry (fixture tree)", () => {
+  test("loading→ready for a known fixture slug", async () => {
+    const source = fixtureHttpSource();
+    const state = await loadAtlasClientShellEntry("прапор", source);
+    expect(state.status).toBe("ready");
+    if (state.status === "ready") {
+      expect(state.record.entry.lemma).toBe("прапор");
+      expect(analyticsClassForState(state)).toBe("atlas_tail_rendered");
+    }
+  });
+
+  test("not_found for an unknown slug", async () => {
+    const source = fixtureHttpSource();
+    const state = await loadAtlasClientShellEntry("немає-такого-слова-xyz", source);
+    expect(state).toEqual({ status: "not_found", slug: "немає-такого-слова-xyz" });
+    expect(analyticsClassForState(state)).toBe("atlas_not_found");
+  });
+
+  test("corrupt when shard integrity fails", async () => {
+    const fetchBytes = createFileAtlasFetch(fixtureRuntimeTree);
+    const wrapping: typeof fetchBytes = async (url) => {
+      const bytes = await fetchBytes(url);
+      if (url.includes("/entries/") && url.endsWith(".json.gz")) {
+        return bytes.subarray(0, 24);
+      }
+      return bytes;
+    };
+    const source = createNodeHttpAtlasDataSource(wrapping, {
+      pointerTtlMs: 0,
+    });
+    const state = await loadAtlasClientShellEntry("прапор", source);
+    expect(state.status).toBe("corrupt");
+    expect(analyticsClassForState(state)).toBe("atlas_fetch_failed");
+  });
+
+  test("network_error maps unavailable failures", async () => {
+    const source = {
+      async getEntry() {
+        throw new AtlasDataSourceError("unavailable", "offline");
+      },
+      async search() {
+        throw new Error("unused");
+      },
+      async getDeck() {
+        throw new Error("unused");
+      },
+    };
+    const state = await loadAtlasClientShellEntry("прапор", source);
+    expect(state.status).toBe("network_error");
+    expect(analyticsClassForState(state)).toBe("atlas_fetch_failed");
+  });
+});
+
+describe("reportAtlasShellAnalytics", () => {
+  test("success overrides path+title once and emits classification event", () => {
+    const calls: unknown[] = [];
+    reportAtlasShellAnalytics({
+      classification: "atlas_tail_rendered",
+      slug: "прапор",
+      lemma: "прапор",
+      goatcounter: {
+        count: (vars) => {
+          calls.push(vars);
+        },
+      },
+    });
+    expect(document.title).toContain("прапор");
+    expect(calls).toEqual([
+      { path: "/lexicon/прапор/", title: "прапор" },
+      { path: "atlas_tail_rendered", title: "прапор", event: true },
+    ]);
+  });
+
+  test("failures emit classification event only", () => {
+    const calls: unknown[] = [];
+    reportAtlasShellAnalytics({
+      classification: "atlas_not_found",
+      slug: "немає",
+      goatcounter: {
+        count: (vars) => {
+          calls.push(vars);
+        },
+      },
+    });
+    expect(calls).toEqual([{ path: "atlas_not_found", title: "немає", event: true }]);
+  });
+});
+
+describe("WordAtlasClientShell React mount", () => {
+  test("renders fixture article via stubbed fetch", async () => {
+    render(
+      createElement(WordAtlasClientShell, {
+        pathname: "/lexicon/прапор/",
+        assetBaseUrl: "/atlas",
+        fetchImpl: fixtureFetchImpl(),
+      }),
+    );
+    expect(screen.getByRole("status")).toHaveAttribute("data-word-atlas-state", "loading");
+    await waitFor(() => {
+      expect(document.querySelector("[data-word-atlas]")).toBeTruthy();
+    });
+    expect(document.body.textContent).toContain("прапор");
+  });
+
+  test("shows слово не знайдено for missing slug", async () => {
+    render(
+      createElement(WordAtlasClientShell, {
+        pathname: "/lexicon/немає-такого-xyz/",
+        assetBaseUrl: "/atlas",
+        fetchImpl: fixtureFetchImpl(),
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveAttribute("data-word-atlas-state", "not_found");
+    });
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toMatch(/Слово не знайдено/i);
+  });
+
+  test("shows corrupt state for truncated shard", async () => {
+    render(
+      createElement(WordAtlasClientShell, {
+        pathname: "/lexicon/прапор/",
+        assetBaseUrl: "/atlas",
+        fetchImpl: fixtureFetchImpl({ corruptShard: true }),
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveAttribute("data-word-atlas-state", "corrupt");
+    });
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toMatch(/пошкоджен/i);
+  });
+
+  test("network fail → retry recovers", async () => {
+    const user = userEvent.setup();
+    render(
+      createElement(WordAtlasClientShell, {
+        pathname: "/lexicon/прапор/",
+        assetBaseUrl: "/atlas",
+        fetchImpl: fixtureFetchImpl({ failOnceUrls: /current\.json$/ }),
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveAttribute("data-word-atlas-state", "network_error");
+    });
+    await user.click(screen.getByRole("button", { name: /Спробувати знову/i }));
+    await waitFor(() => {
+      expect(document.querySelector("[data-word-atlas]")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extends `404.astro` so `/lexicon/<slug>/` boots a client shell: same-origin `HttpAtlasDataSource` (`assetBaseUrl: /atlas`) + `client:only` mount of React `WordAtlasArticle` (untouched internals).
- R9 UA states: loading skeleton · «Слово не знайдено» · corrupt data · retryable network error; R2 GoatCounter `no_onload` + post-render `atlas_tail_rendered` / `atlas_not_found` / `atlas_fetch_failed` (path+title override on success; generic OG on 404).
- Hermetic vitest over F006 fixture tree; etymology inline-handler built-output assert; `serve-gh-pages-404.mjs` + `e2e-atlas-client-shell.mjs` (true HTTP 404, not astro preview). **No deploy-workflow changes** (slice 3).

## Per-state DOM snippets

**Loading**
```html
<div role="status" aria-busy="true" data-word-atlas-state="loading" class="atlas-client-shell-state atlas-client-shell-loading">
  …skeleton…
  <p>Завантаження статті Атласу…</p>
</div>
```

**Not found**
```html
<div role="alert" data-word-atlas-state="not_found" data-http-status="404">
  <h1>Слово не знайдено</h1>
  <p>Немає публічної статті для «немає-такого-xyz».</p>
</div>
```

**Corrupt**
```html
<div role="alert" data-word-atlas-state="corrupt" data-http-status="503">
  <h1>Дані статті пошкоджені</h1>
</div>
```

**Network + retry**
```html
<div role="alert" data-word-atlas-state="network_error" data-http-status="503">
  <h1>Не вдалося завантажити</h1>
  <button type="button" data-word-atlas-retry>Спробувати знову</button>
</div>
```

**Ready (client mount)**
```html
<div data-atlas-client-article>
  <div class="… word-atlas" data-word-atlas>…</div>
</div>
```

**404 OpenGraph (generic site-wide)**
```html
<meta property="og:type" content="website" />
<meta property="og:site_name" content="Learn Ukrainian" />
<meta property="og:title" content="Learn Ukrainian" />
```

## Test plan / raw outputs

### `npx vitest run` (after hydrate)
```
 Test Files  45 passed (45)
      Tests  693 passed | 4 skipped (697)
   Duration  382.40s
```

### `npm run build`
```
[build] 8973 page(s) built in 3m 29s
[build] Complete!
```

### `npx tsc --noEmit` (touched files)
```
NO_ERRORS_IN_TOUCHED
```

### E2E (`node ./scripts/e2e-atlas-client-shell.mjs`)
```
OK: vendored fixture atlas → …/site/dist/atlas
OK: prerendered slug: прапор
OK: tail slug fixture-expression is not prerendered (will hit 404 shell)
OK: server http://127.0.0.1:4177
OK: HTTP 404 for /lexicon/fixture-expression/
OK: tail slug rendered article via shell (lemma/slug present)
OK: generic 404 hidden while shell active
OK: client shell article wrapper present
OK: encoded Cyrillic prerendered slug serves static HTML (no client article wrapper)
OK: tail slug without trailing slash still renders article
OK: HTTP 200 for prerendered /lexicon/прапор/
OK: prerendered page has no atlas shell boot
OK: non-lexicon 404 keeps generic recovery UI

E2E PASSED
```

## Notes
- Runtime deps: none new (uses existing React / Playwright).
- `WordAtlasArticle.tsx` not modified (parallel a11y PR owns it).
- Fixture `/atlas` tree is E2E-vendored only; production Pages vendoring is slice 3.
- Spec R2 owner acceptance of HTTP-404 unfurl consequence remains pending for cutover.


Made with [Cursor](https://cursor.com)