### PR TITLE
fix(hooks): guard-pr-merge judges the PR in the repo the merge runs in

### DIFF
--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -349,6 +349,30 @@ _MAX_SHELL_DEPTH = 8
 _UNREADABLE_MARKER = "--__guard_unreadable__"
 _UNPARSED = ["gh", "pr", "merge", _UNREADABLE_MARKER]
 
+# Sentinel: a `cd` whose target the guard cannot statically read (`cd -`, `cd "$DIR"`,
+# `cd $(...)`). Distinct from None ("this segment is not a cd").
+_CD_UNREADABLE = object()
+
+
+def _cd_target(seg: list[str]):
+    """The literal directory a `cd` segment changes into, expanded.
+
+    Returns None when the segment is not a cd; _CD_UNREADABLE when it is a cd the
+    guard cannot statically resolve (variable/substitution/`cd -`/flags-only). A
+    bare `cd` goes to $HOME, as the shell does. Relative paths resolve against the
+    hook process's cwd — the same base the real command's cd uses.
+    """
+    i = _skip_command_prefix(seg, 0)
+    if i >= len(seg) or seg[i] != "cd":
+        return None
+    rest = [a for a in seg[i + 1 :] if a not in {"-P", "-L", "-e", "-@"}]
+    if not rest:
+        return os.path.expanduser("~")
+    target = rest[0]
+    if target == "-" or "$" in target or "`" in target:
+        return _CD_UNREADABLE
+    return os.path.abspath(os.path.expanduser(target))
+
 
 def _judged_segments(command: str, depth: int = 0) -> list[list[str]]:
     """Every segment worth judging, including those nested in `bash -c` payloads."""
@@ -528,7 +552,7 @@ def _pr_selector(args: list[str]) -> str | None:
     return positionals[0] if positionals else None
 
 
-def _pr_ref(args: list[str], repo: str | None = None) -> str | None:
+def _pr_ref(args: list[str], repo: str | None = None, cwd: str | None = None) -> str | None:
     """The PR to judge: the explicit selector, else the current branch's PR number."""
     selector = _pr_selector(args)
     if selector:
@@ -538,6 +562,7 @@ def _pr_ref(args: list[str], repo: str | None = None) -> str | None:
             ["gh", "pr", "view", *_repo_args(repo), "--json", "number", "-q", ".number"],
             capture_output=True,
             env=_gh_env(),
+            cwd=cwd,
             text=True,
             timeout=10,
         )
@@ -559,7 +584,7 @@ def _owner_repo_from_url(url: str) -> str | None:
     return f"{m.group(1)}/{m.group(2)}" if m else None
 
 
-def _pr_meta(pr: str, repo: str | None = None) -> dict | None:
+def _pr_meta(pr: str, repo: str | None = None, cwd: str | None = None) -> dict | None:
     """`{isDraft, baseRefName, url}` for the PR, or None if undeterminable (→ fail-closed).
 
     A payload without a boolean `isDraft` is undeterminable, not "not a draft" — `{}` or
@@ -570,6 +595,7 @@ def _pr_meta(pr: str, repo: str | None = None) -> dict | None:
             ["gh", "pr", "view", pr, *_repo_args(repo), "--json", "isDraft,baseRefName,url"],
             capture_output=True,
             env=_gh_env(),
+            cwd=cwd,
             text=True,
             timeout=8,
         )
@@ -586,13 +612,14 @@ def _pr_meta(pr: str, repo: str | None = None) -> dict | None:
     return data
 
 
-def _check_states(pr: str, repo: str | None = None) -> tuple[list[str], list[str]] | None:
+def _check_states(pr: str, repo: str | None = None, cwd: str | None = None) -> tuple[list[str], list[str]] | None:
     """(failing, pending) non-advisory check names, or None if undeterminable."""
     try:
         out = subprocess.run(
             ["gh", "pr", "checks", pr, *_repo_args(repo), "--json", "name,bucket,state"],
             capture_output=True,
             env=_gh_env(),
+            cwd=cwd,
             text=True,
             timeout=8,
         )
@@ -683,7 +710,7 @@ def _block_msg(reason: str, guidance: str) -> str:
     return f"BLOCKED by guard-pr-merge: {reason}.\n\n{guidance}\n\n{_FOOTER}"
 
 
-def _judge(args: list[str]) -> str | None:
+def _judge(args: list[str], cwd: str | None = None) -> str | None:
     """Block message for this `gh pr merge`, or None to allow."""
     if _UNREADABLE_MARKER in args:
         return _block_msg(
@@ -694,13 +721,13 @@ def _judge(args: list[str]) -> str | None:
             "named explicitly (`gh pr merge <number> ...`).",
         )
     repo = _repo_option(args)
-    pr = _pr_ref(args, repo)
+    pr = _pr_ref(args, repo, cwd=cwd)
     if not pr:
         return _block_msg(
             "could not determine which PR this merges",
             "Name the PR explicitly (`gh pr merge <number> ...`) so the merge can be verified.",
         )
-    meta = _pr_meta(pr, repo)
+    meta = _pr_meta(pr, repo, cwd=cwd)
     if meta is None:
         return _block_msg(
             f"could not verify PR {pr}'s draft status (gh error, timeout, or unexpected schema)",
@@ -714,7 +741,7 @@ def _judge(args: list[str]) -> str | None:
             "(the #189 incident: a draft was squash-merged before anyone reviewed it). Mark it\n"
             "ready (`gh pr ready`) and get the review gate first.",
         )
-    states = _check_states(pr, repo)
+    states = _check_states(pr, repo, cwd=cwd)
     if states is None:
         return _block_msg(
             f"could not verify PR {pr} check states (gh error, timeout, or an unrecognized check state)",
@@ -783,11 +810,34 @@ def main() -> int:
     probe = command.replace("\\", "").replace("'", "").replace('"', "")
     if "gh" not in probe or "pr" not in probe or "merge" not in probe:
         return 0
+    cwd: str | None = None
+    cwd_unreadable = False
     for seg in _judged_segments(command):
+        # Track `cd <target>` so PR numbers are judged in the repo the MERGE runs in,
+        # not the session's repo. `cd private-repo && gh pr merge 203` judged from the
+        # public repo resolves a DIFFERENT PR #203 — wrong verdict in BOTH directions
+        # (false block, or worse: false allow off a same-numbered green PR).
+        target = _cd_target(seg)
+        if target is _CD_UNREADABLE:
+            cwd_unreadable = True
+        elif target is not None:
+            cwd = target
+            cwd_unreadable = False
         args = _merge_args(seg)
         if args is None:
             continue
-        blocked = _judge(args)
+        if cwd_unreadable:
+            sys.stderr.write(
+                _block_msg(
+                    "this merge runs after a `cd` whose target cannot be read "
+                    "(variable, substitution, or `cd -`)",
+                    "The guard must judge the PR in the repo the merge actually runs in.\n"
+                    "Use a literal `cd /path && gh pr merge ...`, or name the repo with\n"
+                    "`-R owner/repo`.",
+                )
+            )
+            return 2
+        blocked = _judge(args, cwd=cwd)
         if blocked:
             sys.stderr.write(blocked)
             return 2

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -127,10 +127,17 @@ def _command(payload: dict) -> str:
 #
 # This copy alone splits the tokenizer into _scope_events() with _segments() derived from
 # it: only this hook cares WHERE a subshell begins and ends, because only this hook tracks
-# `cd` (#5333). _segments() still returns exactly what the siblings' version does — the
-# sync target is tokenizing semantics, not line count (guard-branch-switch-in-main.py likewise
-# grew _segments_with_following_operator for what it needed). Do NOT collapse the events
-# back into a flat list to "re-sync": that flattening WAS the bug.
+# `cd` (#5333). The sync target is tokenizing semantics, not line count
+# (guard-branch-switch-in-main.py likewise grew _segments_with_following_operator for what it
+# needed). Do NOT collapse the events back into a flat list to "re-sync": that flattening
+# WAS the bug.
+#
+# One deliberate semantic divergence (#5333 r2): the siblings read a QUOTED lone paren
+# (`echo ')'`) as an operator, because shlex strips the quotes before they see it. Here that
+# splits a subshell scope and judges a merge in the wrong repo, so this copy scans the raw
+# line for its parens (_split_scopes) and keeps quoted ones as argv. In the siblings the same
+# quirk only ever splits a segment that neither `git checkout` nor `gh pr merge` matches, so
+# it is harmless there and they are left alone rather than churned.
 
 
 def _strip_quotes(token: str) -> str:
@@ -218,10 +225,14 @@ def _join_line_continuations(text: str) -> str:
 
 
 _PUNCTUATION = ";|&()<>"
+# The parens are split out of the raw line by _split_scopes BEFORE a chunk is tokenized,
+# so any paren still inside a chunk is quoted or escaped text, never an operator (#5333 r2).
+_ARGV_PUNCTUATION = ";|&<>"
 
 
-def _is_operator(tok: str) -> bool:
-    return bool(tok) and all(c in _PUNCTUATION for c in tok)
+def _is_operator(tok: str, punctuation: str = _PUNCTUATION) -> bool:
+    """A token that is nothing but shell punctuation — a separator, not argv."""
+    return bool(tok) and all(c in punctuation for c in tok)
 
 
 def _tokenize(line: str) -> list[str] | None:
@@ -232,6 +243,53 @@ def _tokenize(line: str) -> list[str] | None:
         return list(lexer)
     except ValueError:
         return None
+
+
+def _split_scopes(line: str) -> list[tuple[str, str]]:
+    """One raw line as ("text"|"open"|"close", raw) pieces, split at its REAL parens.
+
+    A real paren is one the shell would act on: unquoted and unescaped. This scan runs on
+    the RAW line because that is the only place quote context still exists — shlex strips
+    quotes, so `echo ')'` and a bare `)` reach the token stream as the identical token `)`,
+    and the scope scanner read the quoted one as a real subshell close (#5333 r2). That was
+    not merely an over-block: in `(cd /a && echo ')' && gh pr merge 9)` the fake close
+    popped the REAL subshell and judged PR 9 in the session's repo instead of /a — a
+    wrong-repo judgment, the same false-ALLOW class the scope fix set out to close.
+
+    Pairing shlex's posix and non-posix token streams would be the obvious alternative, and
+    it is wrong: they diverge on backslashes (`cd /a\\ b` -> 2 posix tokens, 3 raw ones), so
+    the two streams cannot be zipped, and a misalignment silently mis-classifies a REAL
+    paren — reopening the leak. Splitting the raw text first needs no alignment at all.
+
+    Quote/escape state tracks posix shlex's own rules, so the pieces re-lex as shlex reads
+    them: `\\` escapes outside quotes and inside `"..."`, but is literal inside `'...'`.
+    """
+    pieces: list[tuple[str, str]] = []
+    buf: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for ch in line:
+        if escaped:
+            buf.append(ch)
+            escaped = False
+        elif ch == "\\" and quote != "'":
+            buf.append(ch)
+            escaped = True
+        elif quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+        elif ch in "'\"":
+            buf.append(ch)
+            quote = ch
+        elif ch in "()":
+            pieces.append(("text", "".join(buf)))
+            pieces.append(("open" if ch == "(" else "close", ch))
+            buf = []
+        else:
+            buf.append(ch)
+    pieces.append(("text", "".join(buf)))
+    return pieces
 
 
 def _scope_events(command: str) -> list[tuple[str, list[str]]]:
@@ -246,9 +304,14 @@ def _scope_events(command: str) -> list[tuple[str, list[str]]]:
     Events, rather than a flat segment list, because `(` and `)` are the only record of a
     SUBSHELL — and a subshell's `cd` dies at its `)` (#5333). Flattening them away made
     `(cd /inner && true) && gh pr merge 5` read as if the merge ran in /inner: a
-    false-ALLOW off whatever PR #5 is there. Parens arrive as their own tokens, but glue
-    (`&&(`, `)&&`) packs them WITH neighbouring operators, so each operator token is
-    scanned char by char, in order, to keep boundaries in sequence with the segments.
+    false-ALLOW off whatever PR #5 is there.
+
+    Boundaries come from _split_scopes' scan of the RAW line, which is the only reader that
+    still has quote context; the pieces between them are then tokenized. Glue (`&&(`, `)&&`)
+    needs no special handling — the raw split cuts at the paren, leaving `&&` in the
+    neighbouring chunk, so boundaries stay in sequence with the segments. A paren surviving
+    INSIDE a chunk is quoted or escaped text, so `_ARGV_PUNCTUATION` (parens excluded) is
+    what separates segments there: `echo ')'` keeps its `)` as the argument it is (#5333 r2).
 
     `(` also opens a command substitution (`cd $(cat f)`), which reads here as a subshell
     scope. That is not a coincidence to paper over: `$(...)` really does run in a
@@ -256,29 +319,34 @@ def _scope_events(command: str) -> list[tuple[str, list[str]]]:
 
     An `("unreadable", [])` event marks a line that does not lex (unbalanced quote —
     which the real shell rejects too). It cannot be scanned for `cd`, so it must not be
-    passed off as scope-neutral. Only a `segment` event carries argv; the rest carry [].
+    passed off as scope-neutral. It replaces the whole line's events rather than just the
+    offending chunk's: a half-scanned line could otherwise leave an `open` whose later
+    `close` RESTORES a readable cwd, laundering an unreadable line into a clean one.
+    Only a `segment` event carries argv; the rest carry [].
     """
     events: list[tuple[str, list[str]]] = []
     for line in _join_line_continuations(_strip_heredoc_bodies(command)).splitlines():
-        tokens = _tokenize(line)
-        if tokens is None:
-            events.append(("unreadable", []))
-            continue
-        cur: list[str] = []
-        for tok in tokens:
-            if not _is_operator(tok):
-                cur.append(tok)
+        line_events: list[tuple[str, list[str]]] = []
+        readable = True
+        for kind, raw in _split_scopes(line):
+            if kind != "text":
+                line_events.append((kind, []))
                 continue
+            tokens = _tokenize(raw)
+            if tokens is None:
+                readable = False
+                break
+            cur: list[str] = []
+            for tok in tokens:
+                if not _is_operator(tok, _ARGV_PUNCTUATION):
+                    cur.append(tok)
+                    continue
+                if cur:
+                    line_events.append(("segment", cur))
+                    cur = []
             if cur:
-                events.append(("segment", cur))
-                cur = []
-            for char in tok:
-                if char == "(":
-                    events.append(("open", []))
-                elif char == ")":
-                    events.append(("close", []))
-        if cur:
-            events.append(("segment", cur))
+                line_events.append(("segment", cur))
+        events.extend(line_events if readable else [("unreadable", [])])
     return events
 
 
@@ -946,18 +1014,27 @@ def main() -> int:
         args = _merge_args(seg.argv)
         if args is None:
             continue
-        if seg.cwd_unreadable:
+        # `-R owner/repo` names the repo outright, so this merge does not depend on the cwd
+        # it runs in — and an unreadable cwd has nothing left to fail closed about. Blocking
+        # anyway made the escape hatch this very message advertises a no-op (#5333 r2).
+        # Verified against real gh from /tmp, which is not a git repo at all:
+        # `gh pr view 9 --repo cli/cli --json number` -> rc=0 `{"number":9}`. Without a
+        # selector gh refuses (`argument required when using the --repo flag` -> rc=1), so
+        # `-R` alone cannot wave a merge through: _pr_ref reads that rc and fails closed.
+        if seg.cwd_unreadable and not _repo_option(args):
             sys.stderr.write(
                 _block_msg(
                     "this merge's working directory cannot be read (a `cd` to a variable, "
                     "a substitution, or `cd -`; or a shell nesting this guard cannot follow)",
                     "The guard must judge the PR in the repo the merge actually runs in.\n"
                     "Use a literal `cd /path && gh pr merge ...`, or name the repo with\n"
-                    "`-R owner/repo`.",
+                    "`-R owner/repo` (with the PR number: `gh pr merge 5 -R owner/repo`).",
                 )
             )
             return 2
-        blocked = _judge(args, cwd=seg.cwd)
+        # An unreadable cwd is a guess, not a location — `-R` got us here, so let gh resolve
+        # from the repo name in this hook's own cwd rather than hand it a stale directory.
+        blocked = _judge(args, cwd=None if seg.cwd_unreadable else seg.cwd)
         if blocked:
             sys.stderr.write(blocked)
             return 2

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -45,6 +45,7 @@ import re
 import shlex
 import subprocess
 import sys
+from typing import NamedTuple
 
 # Agent harnesses export CLICOLOR_FORCE/FORCE_COLOR, which beat NO_COLOR and make
 # `gh --json` emit ANSI-colorized JSON on pipes -> json.loads fails -> every merge
@@ -123,6 +124,13 @@ def _command(payload: dict) -> str:
 # so the helpers are copied, not imported. Keep the four copies in
 # guard-branch-switch-in-main.py, guard-admin-merge.py, guard-push-pytest.py,
 # and guard-pr-merge.py in sync.
+#
+# This copy alone splits the tokenizer into _scope_events() with _segments() derived from
+# it: only this hook cares WHERE a subshell begins and ends, because only this hook tracks
+# `cd` (#5333). _segments() still returns exactly what the siblings' version does — the
+# sync target is tokenizing semantics, not line count (guard-branch-switch-in-main.py likewise
+# grew _segments_with_following_operator for what it needed). Do NOT collapse the events
+# back into a flat list to "re-sync": that flattening WAS the bug.
 
 
 def _strip_quotes(token: str) -> str:
@@ -209,34 +217,74 @@ def _join_line_continuations(text: str) -> str:
     return text.replace("\\\n", "")
 
 
-def _segments(command: str) -> list[list[str]]:
-    """Quote-aware argv segments, robust to glued shell operators (#4876).
+_PUNCTUATION = ";|&()<>"
 
-    A `gh pr merge` inside a quoted commit body (`git commit -m "... gh pr merge ..."`)
-    stays one argv element — no false block. A `; gh pr merge 5` glued to a preceding
-    token is split into its own segment and inspected — no evasion. Heredoc bodies are
-    stripped (document text is not commands); `\\`-continuations are folded; each
-    logical line parses separately.
+
+def _is_operator(tok: str) -> bool:
+    return bool(tok) and all(c in _PUNCTUATION for c in tok)
+
+
+def _tokenize(line: str) -> list[str] | None:
+    """Quote-aware tokens of one logical line, or None when it does not lex."""
+    try:
+        lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        return list(lexer)
+    except ValueError:
+        return None
+
+
+def _scope_events(command: str) -> list[tuple[str, list[str]]]:
+    """The command as an ordered event stream: argv segments AND subshell boundaries.
+
+    Quote-aware and robust to glued shell operators (#4876). A `gh pr merge` inside a
+    quoted commit body (`git commit -m "... gh pr merge ..."`) stays one argv element —
+    no false block. A `; gh pr merge 5` glued to a preceding token becomes its own
+    segment and is inspected — no evasion. Heredoc bodies are stripped (document text is
+    not commands); `\\`-continuations are folded; each logical line lexes separately.
+
+    Events, rather than a flat segment list, because `(` and `)` are the only record of a
+    SUBSHELL — and a subshell's `cd` dies at its `)` (#5333). Flattening them away made
+    `(cd /inner && true) && gh pr merge 5` read as if the merge ran in /inner: a
+    false-ALLOW off whatever PR #5 is there. Parens arrive as their own tokens, but glue
+    (`&&(`, `)&&`) packs them WITH neighbouring operators, so each operator token is
+    scanned char by char, in order, to keep boundaries in sequence with the segments.
+
+    `(` also opens a command substitution (`cd $(cat f)`), which reads here as a subshell
+    scope. That is not a coincidence to paper over: `$(...)` really does run in a
+    subshell, so its `cd` really does die at the `)`. Same event, same truth.
+
+    An `("unreadable", [])` event marks a line that does not lex (unbalanced quote —
+    which the real shell rejects too). It cannot be scanned for `cd`, so it must not be
+    passed off as scope-neutral. Only a `segment` event carries argv; the rest carry [].
     """
-    segs: list[list[str]] = []
+    events: list[tuple[str, list[str]]] = []
     for line in _join_line_continuations(_strip_heredoc_bodies(command)).splitlines():
-        try:
-            lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
-            lexer.whitespace_split = True
-            tokens = list(lexer)
-        except ValueError:
+        tokens = _tokenize(line)
+        if tokens is None:
+            events.append(("unreadable", []))
             continue
         cur: list[str] = []
         for tok in tokens:
-            if tok and all(c in ";|&()<>" for c in tok):
-                if cur:
-                    segs.append(cur)
-                    cur = []
-            else:
+            if not _is_operator(tok):
                 cur.append(tok)
+                continue
+            if cur:
+                events.append(("segment", cur))
+                cur = []
+            for char in tok:
+                if char == "(":
+                    events.append(("open", []))
+                elif char == ")":
+                    events.append(("close", []))
         if cur:
-            segs.append(cur)
-    return segs
+            events.append(("segment", cur))
+    return events
+
+
+def _segments(command: str) -> list[list[str]]:
+    """Just the argv segments of `command`, scope boundaries discarded."""
+    return [argv for kind, argv in _scope_events(command) if kind == "segment" and argv]
 
 
 def _is_env_assignment(tok: str) -> bool:
@@ -354,18 +402,44 @@ _UNPARSED = ["gh", "pr", "merge", _UNREADABLE_MARKER]
 _CD_UNREADABLE = object()
 
 
+# bash's `cd` options (`cd -LP@ /x` is one legal cluster), minus `-` which is a TARGET.
+_CD_FLAG_CHARS = set("LPe@")
+
+
+def _is_cd_flag(tok: str) -> bool:
+    return len(tok) >= 2 and tok[0] == "-" and set(tok[1:]) <= _CD_FLAG_CHARS
+
+
 def _cd_target(seg: list[str]):
     """The literal directory a `cd` segment changes into, expanded.
 
     Returns None when the segment is not a cd; _CD_UNREADABLE when it is a cd the
-    guard cannot statically resolve (variable/substitution/`cd -`/flags-only). A
-    bare `cd` goes to $HOME, as the shell does. Relative paths resolve against the
-    hook process's cwd — the same base the real command's cd uses.
+    guard cannot statically resolve (variable/substitution/`cd -`). A bare `cd` goes
+    to $HOME, as the shell does. Relative paths resolve against the hook process's
+    cwd — the same base the real command's cd uses.
+
+    Options are stepped over rather than matched literally, and `--` ends them: reading
+    `cd -- /tmp`'s target as `--` (or `cd -LP /tmp`'s as `-LP`) would resolve a path that
+    does not exist, and a wrong path is not a safe one — gh would miss there and the
+    merge would fail closed on a command that is perfectly fine.
+
+    `--` does NOT demote `-` to a plain directory name, though it reads as if it should:
+    `cd -- -` still toggles to $OLDPWD (verified against bash with a real `./-` directory
+    in place, which only `cd -- ./-` reaches). So `-` stays unreadable in both spellings.
     """
     i = _skip_command_prefix(seg, 0)
     if i >= len(seg) or seg[i] != "cd":
         return None
-    rest = [a for a in seg[i + 1 :] if a not in {"-P", "-L", "-e", "-@"}]
+    rest: list[str] = []
+    options_done = False
+    for tok in seg[i + 1 :]:
+        if not options_done:
+            if tok == "--":
+                options_done = True
+                continue
+            if _is_cd_flag(tok):
+                continue
+        rest.append(tok)
     if not rest:
         return os.path.expanduser("~")
     target = rest[0]
@@ -374,19 +448,71 @@ def _cd_target(seg: list[str]):
     return os.path.abspath(os.path.expanduser(target))
 
 
-def _judged_segments(command: str, depth: int = 0) -> list[list[str]]:
-    """Every segment worth judging, including those nested in `bash -c` payloads."""
-    segs = _segments(command)
-    out: list[list[str]] = []
-    for seg in segs:
-        out.append(seg)
-        payload = _shell_c_payload(seg)
+class _JudgedSegment(NamedTuple):
+    """One argv segment, with the cwd it actually runs in already resolved."""
+
+    argv: list[str]
+    cwd: str | None
+    cwd_unreadable: bool
+
+
+def _judged_segments(
+    command: str,
+    depth: int = 0,
+    cwd: str | None = None,
+    cwd_unreadable: bool = False,
+) -> list[_JudgedSegment]:
+    """Every segment worth judging, each tagged with the cwd it runs in.
+
+    A `cd` is scoped to the shell level that runs it, so cwd is resolved HERE, during the
+    walk that knows the nesting — not by a caller reading a flattened list, which cannot
+    see where one shell ends and the next begins (#5333). Two boundaries close the leak:
+
+    * subshell `( ... )` — cwd is saved at `(` and restored at `)`.
+    * `bash -c '<payload>'` — the payload INHERITS the spawning shell's cwd (passed down),
+      but its own cds die with it (the recursion's final state is discarded).
+
+    Both leaked in both directions before: an inner `cd` was adopted by an outer merge
+    (`bash -c 'cd /inner && true' && gh pr merge 9` judged 9 in /inner), and an outer
+    merge inherited an inner one it never saw (`cd /outer && bash -c 'cd /inner &&
+    gh pr merge 1' && gh pr merge 2` judged BOTH in /inner, though 2 runs in /outer).
+    Judging a merge in the wrong repo is wrong in both directions, and the dangerous one
+    is the false ALLOW off a same-numbered green PR.
+
+    An unattributable boundary — a `)` with no `(` (a `case` arm, a stray paren) — desyncs
+    the model, so cwd is marked unreadable rather than guessed: the walk no longer knows
+    which shell it is standing in, and _judge never sees a cwd this function is unsure of.
+    """
+    out: list[_JudgedSegment] = []
+    stack: list[tuple[str | None, bool]] = []
+    for kind, argv in _scope_events(command):
+        if kind == "open":
+            stack.append((cwd, cwd_unreadable))
+            continue
+        if kind == "close":
+            if stack:
+                cwd, cwd_unreadable = stack.pop()
+            else:
+                cwd_unreadable = True
+            continue
+        if kind == "unreadable":
+            cwd_unreadable = True
+            continue
+        target = _cd_target(argv)
+        if target is _CD_UNREADABLE:
+            cwd_unreadable = True
+        elif target is not None:
+            # A literal cd RESOLVES the cwd — including after an unreadable one, whose
+            # target no longer matters now that a readable cd has overwritten it.
+            cwd, cwd_unreadable = target, False
+        out.append(_JudgedSegment(argv, cwd, cwd_unreadable))
+        payload = _shell_c_payload(argv)
         if not payload:
             continue
         if depth >= _MAX_SHELL_DEPTH:
-            out.append(list(_UNPARSED))
+            out.append(_JudgedSegment(list(_UNPARSED), cwd, cwd_unreadable))
             continue
-        out.extend(_judged_segments(payload, depth + 1))
+        out.extend(_judged_segments(payload, depth + 1, cwd, cwd_unreadable))
     return out
 
 
@@ -810,34 +936,28 @@ def main() -> int:
     probe = command.replace("\\", "").replace("'", "").replace('"', "")
     if "gh" not in probe or "pr" not in probe or "merge" not in probe:
         return 0
-    cwd: str | None = None
-    cwd_unreadable = False
+    # Each segment arrives carrying the cwd it runs in, so a PR number is judged in the
+    # repo the MERGE runs in, not the session's repo — `cd private-repo && gh pr merge 203`
+    # judged from the public repo resolves a DIFFERENT PR #203, wrong in BOTH directions
+    # (false block, or worse: false allow off a same-numbered green PR). Scoping that cwd
+    # to its own shell level is _judged_segments' job: it is the only reader that knows
+    # where a subshell or `bash -c` payload begins and ends.
     for seg in _judged_segments(command):
-        # Track `cd <target>` so PR numbers are judged in the repo the MERGE runs in,
-        # not the session's repo. `cd private-repo && gh pr merge 203` judged from the
-        # public repo resolves a DIFFERENT PR #203 — wrong verdict in BOTH directions
-        # (false block, or worse: false allow off a same-numbered green PR).
-        target = _cd_target(seg)
-        if target is _CD_UNREADABLE:
-            cwd_unreadable = True
-        elif target is not None:
-            cwd = target
-            cwd_unreadable = False
-        args = _merge_args(seg)
+        args = _merge_args(seg.argv)
         if args is None:
             continue
-        if cwd_unreadable:
+        if seg.cwd_unreadable:
             sys.stderr.write(
                 _block_msg(
-                    "this merge runs after a `cd` whose target cannot be read "
-                    "(variable, substitution, or `cd -`)",
+                    "this merge's working directory cannot be read (a `cd` to a variable, "
+                    "a substitution, or `cd -`; or a shell nesting this guard cannot follow)",
                     "The guard must judge the PR in the repo the merge actually runs in.\n"
                     "Use a literal `cd /path && gh pr merge ...`, or name the repo with\n"
                     "`-R owner/repo`.",
                 )
             )
             return 2
-        blocked = _judge(args, cwd=cwd)
+        blocked = _judge(args, cwd=seg.cwd)
         if blocked:
             sys.stderr.write(blocked)
             return 2

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -1078,3 +1078,103 @@ def test_multiline_merges_track_their_own_cwd(monkeypatch):
     assert _judged_cwds(
         monkeypatch, "cd /a\ngh pr merge 1\ncd /b\ngh pr merge 2"
     ) == [("1", "/a"), ("2", "/b")]
+
+
+# --- #5333 r2: the fail-closed path's own two bugs ----------------------------
+#
+# The scope fix above closed the leak, but its new fail-closed path shipped two of its
+# own defects (cross-family r2 review). Both are regression-locked here.
+
+
+def test_repo_option_is_honoured_when_cwd_is_unreadable(monkeypatch):
+    """B1: `-R owner/repo` is the remedy the block message advertises — so it must WORK.
+
+    An unreadable cwd is only a problem because the PR number is resolved relative to it.
+    `-R owner/repo` removes that dependency outright, so there is nothing left to fail
+    closed about. Verified against real gh, from /tmp (NOT a git repo at all):
+    `gh pr view 9 --repo cli/cli --json number` -> rc=0 `{"number":9}`. cwd is never
+    consulted once --repo names the repo.
+
+    The `case` arm's bare `)` is what makes the cwd unreadable here (see N1 below).
+    """
+    assert _judged_cwds(
+        monkeypatch, "case x in y) true;; esac; gh pr merge 9 --squash -R owner/repo"
+    ) == [("9", None)]
+
+
+def test_repo_option_under_unreadable_cwd_is_judged_not_waved_through(monkeypatch):
+    """B1 must not become a bypass: `-R` skips the cwd block, it does not skip _judge.
+
+    A draft PR named with `-R` is still a draft.
+    """
+    monkeypatch.setattr(guard, "_pr_meta", lambda pr, repo=None, cwd=None: {"isDraft": True})
+    payload = json.dumps(
+        {"tool_input": {"command": "case x in y) true;; esac; gh pr merge 9 -R owner/repo"}}
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert guard.main() == 2
+
+
+def test_unreadable_cwd_without_repo_option_still_fails_closed(monkeypatch):
+    """B1's fix is scoped to `-R`: without it, an unreadable cwd still blocks."""
+    payload = json.dumps({"tool_input": {"command": 'cd "$D" && gh pr merge 9 --squash'}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert guard.main() == 2
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo ')' && gh pr merge 9 --squash",
+        'echo ")" && gh pr merge 9 --squash',
+        "printf '%s' ')' ; gh pr merge 9 --squash",
+    ],
+)
+def test_quoted_paren_is_not_a_scope_boundary(monkeypatch, command):
+    """B2: a quoted `)` is an ARGUMENT, not a shell boundary.
+
+    shlex strips quotes, so `')'` and a bare `)` arrive as the same token — the scope scan
+    read the quoted one as a real close, desynced, and blocked a merge bash runs happily.
+    """
+    assert _judged_cwds(monkeypatch, command) == [("9", None)]
+
+
+def test_quoted_close_paren_does_not_pop_a_real_scope(monkeypatch):
+    """B2, the dangerous half: a fake `close` POPS a real subshell, and the merge after it
+    is judged in the wrong repo — the #5333 false-ALLOW class, re-entered by a new door.
+
+    Bash runs this merge inside the subshell, in /a. Reading `')'` as a real `)` restores
+    the session cwd early and judges PR 9 there instead — a different PR 9.
+    """
+    assert _judged_cwds(monkeypatch, "(cd /a && echo ')' && gh pr merge 9)") == [("9", "/a")]
+
+
+def test_quoted_open_paren_does_not_push_a_scope(monkeypatch):
+    """B2, mirror: a fake `open` swallows the real `)`, so a real subshell's `cd` leaks
+    out to the merge that follows it. Bash runs PR 9 in the session cwd."""
+    assert _judged_cwds(monkeypatch, "echo '(' && (cd /a && true) && gh pr merge 9") == [
+        ("9", None)
+    ]
+
+
+def test_quoted_paren_stays_in_argv():
+    """The root fix, at the tokenizer: a quoted paren is argv text, not an operator run —
+    so it neither splits the segment nor moves the scope. Multi-char quoted strings
+    already behaved (one token); single-char ones must now behave the same way."""
+    assert guard._segments("echo ')'") == [["echo", ")"]]
+    assert guard._segments("echo '(cd /X)'") == [["echo", "(cd /X)"]]
+
+
+def test_escaped_paren_is_not_a_scope_boundary(monkeypatch):
+    r"""`\)` is escaped, not a boundary — bash passes it to echo as a literal."""
+    assert _judged_cwds(monkeypatch, "cd /a && echo \\) && gh pr merge 9") == [("9", "/a")]
+
+
+def test_bare_unmatched_paren_still_fails_closed(monkeypatch):
+    """N1, accepted fail-closed: a GENUINELY bare `)` (a `case` arm) is still an
+    unattributable boundary. The r2 fix narrows what counts as bare — it does not make
+    the guard `case`-aware. Blocking a `case`-plus-merge one-liner is the accepted cost;
+    a literal `cd` (or `-R`, above) recovers."""
+    payload = json.dumps({"tool_input": {"command": "case x in y) true;; esac; gh pr merge 9"}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert guard.main() == 2

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -40,6 +41,11 @@ def _load_hook():
 
 
 guard = _load_hook()
+
+
+def _any_judged_merge(command: str) -> bool:
+    """Whether any segment of `command` — `bash -c` payloads included — is a judged merge."""
+    return any(guard._merge_args(s.argv) is not None for s in guard._judged_segments(command))
 
 
 def _run(
@@ -421,11 +427,11 @@ def test_repeated_auto_flags_on_unprotected_base_is_blocked(monkeypatch):
 )
 def test_shell_c_payload_is_judged(cmd):
     # A `bash -c` payload really executes the merge; the segment merely starts with `bash`.
-    assert any(guard._merge_args(s) is not None for s in guard._judged_segments(cmd))
+    assert _any_judged_merge(cmd)
 
 
 def test_shell_c_without_merge_is_not_judged():
-    assert not any(guard._merge_args(s) is not None for s in guard._judged_segments("bash -c 'git status'"))
+    assert not _any_judged_merge("bash -c 'git status'")
 
 
 def test_shell_c_merge_blocks_end_to_end(monkeypatch):
@@ -504,7 +510,7 @@ def test_pr_meta_requires_url_field(monkeypatch):
 def test_clustered_c_not_last_is_judged(cmd):
     # `bash -cx 'cmd'` runs cmd (verified: `bash -cx 'echo hi'` executes, exit 0), so
     # requiring the cluster to END in c missed a real merge.
-    assert any(guard._merge_args(s) is not None for s in guard._judged_segments(cmd))
+    assert _any_judged_merge(cmd)
 
 
 @pytest.mark.parametrize(
@@ -518,7 +524,7 @@ def test_dollar_quoted_shell_payload_is_judged(cmd):
     # Bash's $'...' (ANSI-C) and $"..." (locale) quoting run the command for real, but
     # survive tokenizing as a literal `$` glued to the payload — first token `$gh`,
     # matching nothing. Verified: `bash -c $'echo ansi-c-ran'` executes.
-    assert any(guard._merge_args(s) is not None for s in guard._judged_segments(cmd))
+    assert _any_judged_merge(cmd)
 
 
 def test_strip_dollar_quote():
@@ -527,10 +533,7 @@ def test_strip_dollar_quote():
 
 
 def test_valid_nested_shell_is_judged():
-    assert any(
-        guard._merge_args(s) is not None
-        for s in guard._judged_segments("""bash -c 'bash -c "gh pr merge 5 --squash"'""")
-    )
+    assert _any_judged_merge("""bash -c 'bash -c "gh pr merge 5 --squash"'""")
 
 
 def test_recursion_cap_fails_closed(monkeypatch):
@@ -546,7 +549,7 @@ def test_recursion_cap_fails_closed(monkeypatch):
 
 def test_deep_nesting_emits_unparsed_marker():
     segs = guard._judged_segments("bash -c 'gh pr merge 5 --squash'", guard._MAX_SHELL_DEPTH)
-    assert guard._UNPARSED in segs
+    assert guard._UNPARSED in [s.argv for s in segs]
 
 
 @pytest.mark.parametrize(
@@ -561,7 +564,7 @@ def test_flag_looking_values_do_not_suppress_judging(cmd):
     # pflag takes the next token as a string flag's VALUE even when it looks like a flag.
     # `--subject --disable-auto` is a normal merge whose subject is "--disable-auto";
     # reading that value as the flag skipped judging entirely — a fail-open.
-    assert any(guard._merge_args(s) is not None for s in guard._judged_segments(cmd))
+    assert _any_judged_merge(cmd)
 
 
 def test_flag_looking_value_does_not_force_auto_path():
@@ -711,10 +714,7 @@ def test_cluster_value():
 
 
 def test_xargs_shell_form_is_judged():
-    assert any(
-        guard._merge_args(s) is not None
-        for s in guard._judged_segments("printf '' | xargs sh -c 'gh pr merge 5 --auto'")
-    )
+    assert _any_judged_merge("printf '' | xargs sh -c 'gh pr merge 5 --auto'")
 
 
 # --- codex re-review round 5 (PR #5324): xargs is not a transparent prefix ----
@@ -892,7 +892,6 @@ def test_colorized_empty_required_checks_still_unprotected(monkeypatch):
 
 
 def test_cd_target_literal_and_home():
-    import os
     assert guard._cd_target(["cd", "/tmp"]) == "/tmp"
     assert guard._cd_target(["cd", "~/x"]) == os.path.expanduser("~/x")
     assert guard._cd_target(["cd"]) == os.path.expanduser("~")
@@ -943,3 +942,139 @@ def test_plain_merge_has_no_cwd(monkeypatch):
     monkeypatch.setattr(guard, "_judge", fake_judge)
     assert guard.main() == 0
     assert seen["cwd"] is None
+
+
+def test_cd_target_skips_options():
+    """`cd -- /tmp` targets /tmp, not `--`; `cd -LP /tmp` targets /tmp, not `-LP`.
+
+    A wrong path is not a safe one: gh misses there, and a fine command fails closed.
+    """
+    assert guard._cd_target(["cd", "--", "/tmp"]) == "/tmp"
+    assert guard._cd_target(["cd", "-LP", "/tmp"]) == "/tmp"
+    assert guard._cd_target(["cd", "-P", "-L", "/tmp"]) == "/tmp"
+    # `--` does NOT demote `-` to a literal directory: `cd -- -` still toggles to OLDPWD
+    # (verified against bash with a real ./- directory in place — only `cd -- ./-` reaches
+    # it). Unreadable either way, so the toggle keeps its meaning here too.
+    assert guard._cd_target(["cd", "--", "-"]) is guard._CD_UNREADABLE
+    assert guard._cd_target(["cd", "-"]) is guard._CD_UNREADABLE
+    assert guard._cd_target(["cd", "--", "./-"]) == os.path.abspath("./-")
+
+
+# --- #5333: `cd` scope must not leak across shell boundaries ------------------
+#
+# Verified against real bash before these were written: `bash -c 'cd /inner && true'`
+# and `(cd /inner && true)` both leave the CALLER's cwd untouched, while a `bash -c`
+# payload does INHERIT the spawning shell's cwd. The guard must model both halves —
+# reading a merge in the wrong repo is wrong in both directions, and the dangerous one
+# is the false ALLOW off a same-numbered green PR in the other repo.
+
+
+def _judged_cwds(monkeypatch, command: str) -> list[tuple[str, str | None]]:
+    """(PR selector, cwd) per merge main() judges — the scope decision, made visible."""
+    seen: list[tuple[str, str | None]] = []
+
+    def fake_judge(args, cwd=None):
+        seen.append((args[0], cwd))
+        return None
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"tool_input": {"command": command}})))
+    monkeypatch.setattr(guard, "_judge", fake_judge)
+    assert guard.main() == 0
+    return seen
+
+
+def test_shell_c_cd_does_not_leak_out(monkeypatch):
+    """LEAK, direction 1: an inner `cd` adopted by an OUTER merge (false-ALLOW).
+
+    `bash -c 'cd /inner && true'` ends with the outer shell still where it started, so
+    PR 9 is resolved there — not in /inner, whose PR 9 is a different PR entirely.
+    """
+    assert _judged_cwds(monkeypatch, "bash -c 'cd /inner && true' && gh pr merge 9") == [
+        ("9", None)
+    ]
+
+
+def test_subshell_cd_does_not_leak_out(monkeypatch):
+    """LEAK, direction 1 via `( ... )` — the subshell's cd dies at its `)`."""
+    assert _judged_cwds(monkeypatch, "(cd /inner && true) && gh pr merge 9") == [("9", None)]
+
+
+def test_shell_c_payload_inherits_cwd_but_does_not_export_it(monkeypatch):
+    """LEAK, direction 2: an OUTER merge inheriting an inner `cd` it never ran.
+
+    Both halves in one command: A really does run in /inner (the payload inherited
+    /outer, then cd'd), while B runs in /outer — the payload's cd died with it.
+    """
+    assert _judged_cwds(
+        monkeypatch,
+        "cd /outer && bash -c 'cd /inner && gh pr merge 1' && gh pr merge 2",
+    ) == [("1", "/inner"), ("2", "/outer")]
+
+
+def test_merge_inside_subshell_is_judged_in_the_subshell_cwd(monkeypatch):
+    """Scoping must not overshoot: a merge INSIDE the cd's scope is judged there."""
+    assert _judged_cwds(monkeypatch, "(cd /inner && gh pr merge 5)") == [("5", "/inner")]
+
+
+def test_merge_inside_shell_c_is_judged_in_the_payload_cwd(monkeypatch):
+    assert _judged_cwds(monkeypatch, 'bash -c "cd /inner && gh pr merge 5"') == [("5", "/inner")]
+
+
+def test_nested_subshells_restore_each_level(monkeypatch):
+    """Each `)` restores exactly one level — /b, then /a, then the session's cwd."""
+    assert _judged_cwds(
+        monkeypatch,
+        "(cd /a && (cd /b && gh pr merge 1) && gh pr merge 2) && gh pr merge 3",
+    ) == [("1", "/b"), ("2", "/a"), ("3", None)]
+
+
+def test_glued_subshell_operators_keep_scope(monkeypatch):
+    """`&&(` and `)&&` tokenize as one glued punctuation run (#4876) — the parens in
+    them still open and close scopes, in order."""
+    assert _judged_cwds(monkeypatch, "cd /a&&(cd /b&&gh pr merge 1)&&gh pr merge 2") == [
+        ("1", "/b"),
+        ("2", "/a"),
+    ]
+
+
+def test_command_substitution_cd_does_not_leak(monkeypatch):
+    """`$(...)` runs in a subshell, so its cd dies at the `)` — as bash does."""
+    assert _judged_cwds(monkeypatch, "cd /a && echo $(cd /b; pwd) && gh pr merge 1") == [
+        ("1", "/a")
+    ]
+
+
+def test_unreadable_cd_inside_payload_does_not_escape(monkeypatch):
+    """An unreadable cd is scoped too: it blocks the merge INSIDE the payload..."""
+    payload = json.dumps({"tool_input": {"command": "bash -c 'cd $D && gh pr merge 7'"}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert guard.main() == 2
+
+
+def test_unreadable_cd_in_subshell_does_not_block_outer_merge(monkeypatch):
+    """...but does NOT taint a merge outside it, which that cd never touched."""
+    assert _judged_cwds(monkeypatch, '(cd "$D" && true) && gh pr merge 7') == [("7", None)]
+
+
+def test_unattributable_scope_boundary_fails_closed(monkeypatch):
+    """A `)` with no `(` desyncs the scope model — block rather than guess a cwd."""
+    payload = json.dumps({"tool_input": {"command": "(cd /a)) && gh pr merge 7"}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert guard.main() == 2
+
+
+def test_cd_after_merge_does_not_apply_to_it(monkeypatch):
+    """A `cd` the merge never reached cannot move it: the merge already ran."""
+    assert _judged_cwds(monkeypatch, "gh pr merge 7 && cd /elsewhere") == [("7", None)]
+
+
+def test_cd_threads_across_lines(monkeypatch):
+    """cwd survives the line break, as it does in a real script — `cd` and merge on
+    separate lines are still the same shell."""
+    assert _judged_cwds(monkeypatch, "cd /repo\ngh pr merge 7 --squash") == [("7", "/repo")]
+
+
+def test_multiline_merges_track_their_own_cwd(monkeypatch):
+    assert _judged_cwds(
+        monkeypatch, "cd /a\ngh pr merge 1\ncd /b\ngh pr merge 2"
+    ) == [("1", "/a"), ("2", "/b")]

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -58,13 +58,13 @@ def _run(
     """
     payload = json.dumps({"tool_input": {"command": command}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
-    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: pr)
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None, cwd=None: pr)
     monkeypatch.setattr(
         guard,
         "_pr_meta",
-        lambda p, repo=None: ({"isDraft": False, "baseRefName": "main", "url": _URL} if meta is None else meta),
+        lambda p, repo=None, cwd=None: ({"isDraft": False, "baseRefName": "main", "url": _URL} if meta is None else meta),
     )
-    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None: checks)
+    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: checks)
     monkeypatch.setattr(guard, "_owner_repo_from_url", lambda u: owner_repo)
     monkeypatch.setattr(guard, "_base_protected", lambda o, b: protected)
     return guard.main()
@@ -168,10 +168,10 @@ def test_unknown_pr_fails_closed(monkeypatch):
 
 def test_undeterminable_pr_meta_fails_closed(monkeypatch):
     # _pr_meta returning None (gh error/timeout) → block, never "assume not a draft".
-    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None: None)
+    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None, cwd=None: None)
     payload = json.dumps({"tool_input": {"command": "gh pr merge 5 --squash"}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
-    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: "5")
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None, cwd=None: "5")
     assert guard.main() == 2
 
 
@@ -280,9 +280,9 @@ def test_auto_on_base_with_empty_required_checks_is_blocked(monkeypatch):
     monkeypatch.setattr(guard, "_base_protected", lambda o, b: False)
     payload = json.dumps({"tool_input": {"command": "gh pr merge 5 --auto --squash"}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
-    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: "5")
-    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None: {"isDraft": False, "baseRefName": "main", "url": _URL})
-    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None: ([], []))
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None, cwd=None: "5")
+    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": _URL})
+    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: ([], []))
     monkeypatch.setattr(guard, "_owner_repo_from_url", lambda u: "owner/repo")
     assert guard.main() == 2
 
@@ -473,13 +473,13 @@ def test_owner_repo_from_url(url, expected):
 def test_cross_repo_url_selector_uses_that_repo(monkeypatch):
     # The PR url decides which repo's protection is read, not the cwd.
     seen = {}
-    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: "https://github.com/other/repo/pull/9")
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None, cwd=None: "https://github.com/other/repo/pull/9")
     monkeypatch.setattr(
         guard,
         "_pr_meta",
-        lambda p, repo=None: {"isDraft": False, "baseRefName": "main", "url": "https://github.com/other/repo/pull/9"},
+        lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": "https://github.com/other/repo/pull/9"},
     )
-    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None: ([], []))
+    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: ([], []))
     monkeypatch.setattr(guard, "_base_protected", lambda o, b: seen.setdefault("repo", o) and True)
     payload = json.dumps({"tool_input": {"command": "gh pr merge https://github.com/other/repo/pull/9 --auto"}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
@@ -538,9 +538,9 @@ def test_recursion_cap_fails_closed(monkeypatch):
     # through. Regression for an inert sentinel: the marker segment carries no PR
     # selector, and _pr_ref falls back to the CURRENT BRANCH's PR — so without an
     # explicit marker check, a green current branch would approve an unread payload.
-    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None: "5")
-    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None: {"isDraft": False, "baseRefName": "main", "url": _URL})
-    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None: ([], []))  # all green
+    monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None, cwd=None: "5")
+    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": _URL})
+    monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: ([], []))  # all green
     assert guard._judge([guard._UNREADABLE_MARKER]) is not None
 
 
@@ -886,3 +886,60 @@ def test_colorized_empty_required_checks_still_unprotected(monkeypatch):
     completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=colorized, stderr="")
     monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
     assert guard._base_protected("owner/repo", "main") is False
+
+
+# --- cd-target resolution: judge the PR in the repo the merge RUNS in ---------
+
+
+def test_cd_target_literal_and_home():
+    import os
+    assert guard._cd_target(["cd", "/tmp"]) == "/tmp"
+    assert guard._cd_target(["cd", "~/x"]) == os.path.expanduser("~/x")
+    assert guard._cd_target(["cd"]) == os.path.expanduser("~")
+    assert guard._cd_target(["ls", "-la"]) is None
+
+
+def test_cd_target_unreadable_forms():
+    assert guard._cd_target(["cd", "-"]) is guard._CD_UNREADABLE
+    assert guard._cd_target(["cd", "$DIR"]) is guard._CD_UNREADABLE
+
+
+def test_cd_then_merge_threads_cwd(monkeypatch):
+    """`cd <repo> && gh pr merge N` must judge N in <repo> — captured via the cwd
+    handed to _judge. Wrong-repo judgment is dangerous BOTH ways (false block, or a
+    false ALLOW off a same-numbered green PR elsewhere)."""
+    seen = {}
+
+    def fake_judge(args, cwd=None):
+        seen["cwd"] = cwd
+        return None
+
+    payload = json.dumps(
+        {"tool_input": {"command": "cd /tmp && gh pr merge 7 --squash"}}
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setattr(guard, "_judge", fake_judge)
+    assert guard.main() == 0
+    assert seen["cwd"] == "/tmp"
+
+
+def test_unreadable_cd_before_merge_blocks(monkeypatch):
+    payload = json.dumps(
+        {"tool_input": {"command": 'cd "$WORKDIR" && gh pr merge 7 --squash'}}
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    assert guard.main() == 2
+
+
+def test_plain_merge_has_no_cwd(monkeypatch):
+    seen = {}
+
+    def fake_judge(args, cwd=None):
+        seen["cwd"] = cwd
+        return None
+
+    payload = json.dumps({"tool_input": {"command": "gh pr merge 7 --squash"}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setattr(guard, "_judge", fake_judge)
+    assert guard.main() == 0
+    assert seen["cwd"] is None


### PR DESCRIPTION
User-reported live failure: private-repo merges (`cd <private> && gh pr merge N`) were judged against the PUBLIC repo's PR N — the hook inherited the session cwd, not the command's target. Both failure directions possible; false-block hit live, false-ALLOW (same-numbered green PR elsewhere) latent.

Fix: literal-cd tracking across command segments threads the true cwd into every gh call; unreadable cd targets (variables, `cd -`) fail closed with guidance; `-R` unchanged. Evidence: 200 tests across both guard suites, ruff clean, live repro re-run yields the correct target-repo verdict.

**Operational note:** the fixed hook is hot-deployed locally ahead of merge (the deployed version's false-allow direction is the unsafe one); `npm run agents:deploy` reconciles after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)