### PR TITLE
feat(ui): practice + atlas UI improvements (Kimi K3 review)

### DIFF
--- a/UI-REVIEW-FINDINGS.md
+++ b/UI-REVIEW-FINDINGS.md
@@ -1,0 +1,245 @@
+# UI Review — Practice hub + Atlas (dictionary) landing
+
+Reviewer: Kimi K3 · Branch: `kimi/atlas-ui-improve` · Date: 2026-07-16
+
+Scope reviewed (in-scope surfaces only; word-page article reviewed for findings only):
+
+- `site/src/pages/words-of-the-day/practice.astro` (+ its global practice styles)
+- `site/src/lexicon/LexiconPracticeMount.astro` → `site/src/components/LexiconPractice.tsx`,
+  `PracticeFlashcard.tsx`, `PracticeSessionSummary.tsx` (everything the mount mounts)
+- `site/src/pages/lexicon/index.astro` (atlas landing) → `site/src/lexicon/AtlasTypeahead.astro`,
+  `AtlasRuntimeStatus.astro`
+- `site/src/pages/lexicon/browse.astro` → `site/src/lexicon/AtlasFullIndex.astro` (browse UI)
+- Live pages cross-checked: `/lexicon/` , `/lexicon/practice/` (astro.config redirect →
+  `/words-of-the-day/practice/`), `/words-of-the-day/practice/`
+
+Standing rules applied: UI copy stays Ukrainian (English scaffolding is A1-only by design —
+`showEnglishSubtitles = learnerLevel === 'A1'` at `LexiconPractice.tsx:1136`); static hosting;
+focused diffs; accessibility/mobile = functionality.
+
+Legend: **[FIXED]** implemented in this PR · **[FILED]** finding only, not fixed here.
+
+---
+
+## HIGH
+
+### 1. Window-level key handlers hijack Enter/Space from focused controls [FIXED]
+
+- `site/src/components/PracticeFlashcard.tsx:44-70` — the window `keydown` flips the card on
+  Space/Enter and rates on `1–4`/`a/h/g/e` **regardless of where focus is**. While a card is
+  unflipped, pressing Enter/Space on the focused «← Додому» button (or any page control) flips the
+  card instead of activating the control, and calls `preventDefault()`.
+- `site/src/components/LexiconPractice.tsx:1431-1440` — during the wrong-answer dwell, a window
+  Enter handler `preventDefault()`s and advances even when focus is on the «Відкрити в Атласі →»
+  links (`:3047`, `:3132`, `:3273`) or «← Додому» (`:2612`). Keyboard-only learners cannot activate
+  those controls while `pendingOutcome` is set.
+- Minimal fix: bail when the event originates inside an interactive element
+  (`target.closest('button, a, input, textarea, select, [role="button"]')`) and only
+  `preventDefault()` when the handler actually acts.
+
+### 2. Number badges on choice options promise shortcuts that don't exist [FIXED]
+
+- `LexiconPractice.tsx:2869` (drill options) and `:2956` (choice options) render `.mc-key` badges
+  `1/2/3/4` styled as key caps (`practice.astro:907-919`), but no keydown listener maps digits for
+  these modes. Flashcards *do* support `1–4` (`PracticeFlashcard.tsx:54-63`), so learners trained
+  there press digits in choice/drill and nothing happens.
+- Minimal fix: window keydown listener in the drill/choice render paths mapping `1..n` →
+  `onChoice(options[n-1])` while `!answerLocked`, with the same interactive-target guard as #1.
+
+### 3. English leaks into the immersion UI for B1+ learners [FIXED]
+
+The component design is Ukrainian-only past A1 (`showEnglishSubtitles = learnerLevel === 'A1'`),
+but several strings bypass the gate:
+
+- `LexiconPractice.tsx:1019-1026` — `BilingualPracticeMessage` renders the English half
+  unconditionally; used for the load error (`:2587`) and pool-miss notice (`:2242`).
+- `LexiconPractice.tsx:2589-2592` — retry button always shows "Try again".
+- `LexiconPractice.tsx:3193` — `{cloze.clozeEn}` (English sentence translation) renders for every
+  level. It is currently the *only* cue for which word goes in the blank, so gating it requires
+  adding the Ukrainian lemma as the cue first.
+- `LexiconPractice.tsx:3196` — attribution starts with English "Sentences from".
+- `LexiconPractice.tsx:1442-1445` — `document.title` is always English
+  (`"Cloze Practice - Words of the Day"`) and is never restored after leaving the session.
+- `PracticeSessionSummary.tsx:45` — `<span lang="uk">З lapses</span>` (English word inside a
+  Ukrainian-tagged span; a Ukrainian TTS voice mangles it); `:65` — `<span lang="uk">Перейшли до
+  Review</span>`; `:88` — heading «повторимо наступного разу» starts lowercase, unlike siblings.
+- Minimal fix: gate every English fragment behind `showEnglishSubtitles`; show the cloze target
+  lemma in the Ukrainian task line («Поставте слово „валіза" у правильному відмінку») so the
+  exercise no longer depends on the English gloss; «Речення з» for attribution; Ukrainian
+  `document.title` restored on exit; «Помилки» / «Перейшли на повторення» / «Повторимо наступного
+  разу» in the summary.
+
+## MEDIUM
+
+### 4. Flashcard flip auto-focuses the «Добре» rating — races the flipping keystroke [FIXED]
+
+- `PracticeFlashcard.tsx:36-42` — on flip, focus is forced to `[data-rate="good"]`. Space activates
+  buttons on **keyup**: flipping with Space moves focus between keydown and keyup, so the keyup
+  lands on the just-focused «Добре» button and records an instant accidental rating. The hardcoded
+  target also biases the SRS rating.
+- Minimal fix: remove the auto-focus; ratings stay reachable via the documented `1–4`/`a/h/g/e`
+  keys and Tab.
+
+### 5. Focus lost when «Далі →» appears after a wrong answer [FIXED]
+
+- `LexiconPractice.tsx:2675-2689` — after a wrong pick the clicked option becomes `disabled`, so
+  focus drops to `<body>`; the «Далі →» button that appears is never focused. Keyboard/SR users
+  lose their place (the window Enter handler was the only recovery — undiscoverable, and see #1).
+- Minimal fix: focus the «Далі →» button when it renders (ref + effect on `pendingOutcome`).
+
+### 6. Stale 650 ms auto-advance timer mutates state after the learner leaves [FIXED]
+
+- `LexiconPractice.tsx:2055-2059` (choice) and `:2086-2090` (cloze) — the correct-answer
+  auto-advance `setTimeout` is never stored or cleared. Tapping «← Додому» within 650 ms of a
+  correct answer still lets `completeSelection` fire: it writes history, bumps counters, and can
+  call `openSummary()` — flipping the just-exited session back to the summary screen.
+- Minimal fix: keep the timer id in a ref; clear it in `finishPractice`, on unmount, and before
+  scheduling a new one.
+
+### 7. Cloze case-label phrasing is ungrammatical Ukrainian [FIXED]
+
+- `LexiconPractice.tsx:3219` — aria-label `Відповідь у знахідний` (bare adjective after «у»);
+  `:2101` — feedback «Тепер постав його у знахідний». `caseLabel` values are bare adjectives
+  (`знахідний`, `родовий`, … — generated at `scripts/audit/generate_practice_deck.py:724` with
+  `CASE_LABELS_UA` `:104-112`), so the two spots that use them with a preposition read wrong.
+- Minimal fix (UI-side, data untouched): derive «у знахідному відмінку» (locative) for the
+  aria-label and «у знахідний відмінок» (accusative) for the feedback from the bare label —
+  all seven case labels are regular hard-stem `-ий` adjectives, so the transformation is uniform.
+
+### 8. Next-due label lacks a unit; `uaPlural` imported but unused [FIXED]
+
+- `LexiconPractice.tsx:2736-2746` — `formatNextDueLabel` produces «ще 3 о 14:00» ("3 more *what*?");
+  `uaPlural` is imported (`:34`) and never used.
+- Minimal fix: `uaPlural(remaining, { one: 'година', few: 'години', many: 'годин' })` →
+  «ще 3 години о 14:00».
+
+### 9. Browse overflow message uses English "more" [FIXED]
+
+- `site/src/lexicon/AtlasFullIndex.astro:423` —
+  `` `+${state.overflow} more — звузьте запит` `` — English inside the Ukrainian browse UI.
+- Minimal fix: reuse the file's existing `atlasEntryCountLabel` → «ще 154 записи — звузьте запит».
+
+### 10. Typeahead active option doesn't scroll into view [FIXED]
+
+- `site/src/lexicon/AtlasTypeahead.astro:123-162` (`taRender`) — up to 12 results render in a
+  `max-height: 340px` scrollable list (`word-atlas.css:201-202`); ArrowUp/ArrowDown move
+  `aria-activedescendant` but the active option is never scrolled into view, so keyboard users
+  navigate blind past the fold.
+- Minimal fix: after render, `activeOption?.scrollIntoView({ block: 'nearest' })` when active ≥ 0.
+
+## LOW
+
+### 11. Small a11y/copy gaps in practice home & cloze [FIXED — batch]
+
+- `LexiconPractice.tsx:2231` — storage warning renders with no live-region role (the adjacent
+  pool-miss warning has `role="status"`). → `role="alert"`.
+- `LexiconPractice.tsx:2370-2387` — session-budget buttons announce as bare "10" / "20". →
+  Ukrainian `aria-label` («10 карток на сесію» / «20 карток на сесію»).
+- `LexiconPractice.tsx:2389-2402` — «Почати сесію» not disabled while loading; double-click fires
+  `startSession` twice. → `disabled={loading}`.
+- `LexiconPractice.tsx:3213-3221` — cloze input lacks mobile typing hints; iOS/Android keyboards
+  autocapitalize/autocorrect Ukrainian answers. → `autoCapitalize="off" autoCorrect="off"
+  spellCheck={false} lang="uk"` (16 px font already prevents iOS zoom — good).
+
+### 12. New-tab links don't say so [FILED]
+
+- «Відкрити в Атласі →» (`LexiconPractice.tsx:3047`, `:3132`, `:3273`) uses `target="_blank"`
+  with no indication to sighted or screen-reader users. Minimal fix: append «(нова вкладка)» to
+  the link's `aria-label`. Not fixed here (copy churn across three feedback panels; folded into a
+  later pass with the word-page work).
+
+### 13. Typeahead Escape clears the whole query [FILED]
+
+- `AtlasTypeahead.astro:310-315` — Escape wipes the input rather than just closing the listbox.
+  Common combobox behavior is close-first, clear-second. Low severity; the clear is at least
+  recoverable by retyping.
+
+### 14. `AtlasRuntimeStatus` byte formatting uses English "MB" [FILED]
+
+- `AtlasRuntimeStatus.astro:63` — `formatBytes` prints "MB"; Ukrainian convention is «МБ». Only
+  shown in the non-hydrated fallback detail line.
+
+### 15. `DailyWords` level group has an English aria-label [FILED — adjacent surface]
+
+- `site/src/lexicon/DailyWords.astro:34` — `aria-label="Learner level"` announced in English.
+  DailyWords is mounted only by the words-of-the-day hub (`pages/words-of-the-day.astro`), which
+  is outside this PR's enumerated scope. Minimal fix when touched: `aria-label="Рівень учня"`.
+
+### 16. Alphabet letter buttons are 36 px tap targets [FILED]
+
+- `AtlasFullIndex.astro:616-619` — `.atlas-letter-link` is 2.25 rem (36 px); passes WCAG 2.5.8 AA
+  (24 px) but below the 44 px platform guideline. Bumping to 2.5–2.75 rem keeps the sticky bar
+  reasonable (33 letters wrap anyway). Polish, not a blocker.
+
+---
+
+## OUT-OF-SCOPE-FOR-THIS-PR — word page (`[lemma].astro` / `WordAtlasArticle.astro`)
+
+These files are being reworked on another in-flight branch. Findings recorded for that branch's
+author; **not** fixed here.
+
+### W1 (high) — Etymology timeline stages are click-only
+
+`WordAtlasArticle.astro:801-804` + `:1184-1194` — `ety-stage` divs swap the etymology note on click
+but are plain `<div>`s: no `role="button"`, no `tabindex`, no keydown handler. Keyboard/switch
+users cannot reach per-stage notes. Minimal fix: real `<button type="button">` stages +
+`aria-live="polite"` on the note output.
+
+### W2 (med) — English UI strings on a Ukrainian-only page
+
+`WordAtlasArticle.astro:711` (`· keywords:`), `:1140` (`<h2>Wikipedia</h2>`), `:1169` (`manifest:`),
+plus raw Latin track codes (`HIST M03`, `ISTORIO`, `OES`, `RUTH`) in the «У курсі» module IDs
+(`:1114`, `:292-305`). Minimal fix: «ключові слова», «Вікіпедія», «маніфест»; map track codes to
+Ukrainian labels.
+
+### W3 (med) — `target="_blank"` links with no new-tab indication, inconsistent behavior
+
+Source pills (`:754`), synonym/antonym/homonym/paronym source links (`:964`, `:974`, `:1001`,
+`:1029`), literary attestation (`:1061`), wiki links (`:1147`, `:1154-1155`) open new tabs with no
+indicator; idiom sources (`:1046`) and external-material links (`:1099`) are external but open
+same-tab. Minimal fix: consistent «(нова вкладка) ↗» + aria-label; one behavior for external links.
+
+### W4 (med) — Paradigm tables lack header semantics
+
+`WordAtlasArticle.astro:821`, `:837`, `:851`, `:869`, `:888` — header rows are bare `<tr><th>`
+directly under `<table>` (implicit `<tbody>`), no `scope="col"`, no `<caption>`; verb tense tables
+are unidentifiable to screen readers. Minimal fix: `<thead>` + `scope="col"` + `<caption>`.
+
+### W5 (med) — English translation terms not marked `lang="en"`
+
+`WordAtlasArticle.astro:1130-1131` — `.en-side`/`.en-term` spans inherit the page's Ukrainian
+`lang`; TTS reads English glosses with Ukrainian rules. Minimal fix: `lang="en"` on the container.
+
+### W6 (low) — Heading levels skip `<h2>` → `<h4>`
+
+`WordAtlasArticle.astro:1043`, `:1083`, `:1099`, `:1144`, `:1151` — card titles under `<h2>`
+sections use `<h4>`. Minimal fix: `<h3>`.
+
+### W7 (low) — Overview-card ready/pending state is color + cryptic glyph only
+
+`WordAtlasArticle.astro:721-725` — `ready`/`pending` conveyed by color and an `aria-hidden`
+`✓`/`·`; the `·` is meaningless, AT gets no explicit state. Minimal fix: visually-hidden
+«готово»/«очікує» text + a real pending glyph.
+
+### W8 (low) — Synonym glosses exposed only via `title`
+
+`WordAtlasArticle.astro:936` — per-member gloss is hover-only (`title={member.gloss?.text}`),
+invisible to keyboard/touch. Minimal fix: visible small text or an accessible disclosure.
+
+Checked and intentionally not flagged: severity color boxes pair color with icons + text (not
+color-only); the `form_of` info box; `[lemma].astro` route frontmatter/description generation.
+
+---
+
+## What this PR implements (8 focused changes)
+
+| # | Change | Findings | Files |
+|---|--------|----------|-------|
+| 1 | Interactive-target guards on window key handlers | 1 | `PracticeFlashcard.tsx`, `LexiconPractice.tsx` |
+| 2 | Remove post-flip auto-focus to «Добре» | 4 | `PracticeFlashcard.tsx` |
+| 3 | Digit shortcuts (1–4) for drill/choice options | 2 | `LexiconPractice.tsx` |
+| 4 | Focus «Далі →» on wrong-answer dwell | 5 | `LexiconPractice.tsx` |
+| 5 | English-leak gating + Ukrainian copy (summary, title, attribution, cloze lemma cue) | 3 | `LexiconPractice.tsx`, `PracticeSessionSummary.tsx` |
+| 6 | Clear auto-advance timer on exit/unmount | 6 | `LexiconPractice.tsx` |
+| 7 | Cloze case-phrase grammar + next-due units + home/cloze a11y batch | 7, 8, 11 | `LexiconPractice.tsx` |
+| 8 | Atlas browse «ще N записів» + typeahead scroll-into-view | 9, 10 | `AtlasFullIndex.astro`, `AtlasTypeahead.astro` |

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -255,20 +255,6 @@ type VisiblePracticeModeFilter = Extract<
   | 'heritage'
 >;
 
-const MODE_LABELS: Record<VisiblePracticeModeFilter, string> = {
-  mixed: 'Mixed',
-  flashcards: 'Flashcards',
-  matching: 'Matching',
-  choice: 'Choice',
-  cloze: 'Cloze',
-  stress: 'Stress',
-  classify: 'Classify',
-  paradigm: 'Paradigm',
-  synonym: 'Synonym',
-  paronym: 'Пароніми',
-  heritage: 'Спадщина',
-};
-
 const MODE_CARD_ORDER: VisiblePracticeModeFilter[] = [
   'mixed',
   'flashcards',
@@ -1016,13 +1002,66 @@ function resolvePracticeIndexItem(
   );
 }
 
-function BilingualPracticeMessage({ uk, en }: { uk: string; en: string }) {
+function BilingualPracticeMessage({
+  uk,
+  en,
+  showEnglishSubtitles,
+}: {
+  uk: string;
+  en: string;
+  showEnglishSubtitles: boolean;
+}) {
   return (
     <>
-      <span lang="uk">{uk}</span>{' '}
-      <span lang="en">/ {en}</span>
+      <span lang="uk">{uk}</span>
+      {showEnglishSubtitles ? (
+        <>
+          {' '}
+          <span lang="en">/ {en}</span>
+        </>
+      ) : null}
     </>
   );
+}
+
+/** Bare hard-stem adjective case labels (`знахідний`) → «у знахідному відмінку». */
+function casePhraseLocative(caseLabel: string): string {
+  if (caseLabel.endsWith('ий')) {
+    return `у ${caseLabel.slice(0, -2)}ому відмінку`;
+  }
+  return `у ${caseLabel} відмінку`;
+}
+
+/** Bare hard-stem adjective case labels (`знахідний`) → «у знахідний відмінок». */
+function casePhraseAccusative(caseLabel: string): string {
+  return `у ${caseLabel} відмінок`;
+}
+
+/** Digit 1–n shortcuts for multiple-choice option lists (drill/choice). */
+function DigitChoiceShortcuts({
+  options,
+  answerLocked,
+  onChoice,
+}: {
+  options: ChoiceOption[];
+  answerLocked: boolean;
+  onChoice(option: ChoiceOption): void;
+}) {
+  useEffect(() => {
+    if (answerLocked || options.length === 0) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.altKey || event.ctrlKey || event.metaKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target?.closest?.('button, a, input, textarea, select, [role="button"]')) return;
+      const digit = Number.parseInt(event.key, 10);
+      if (!Number.isFinite(digit) || digit < 1 || digit > options.length) return;
+      event.preventDefault();
+      onChoice(options[digit - 1]!);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [answerLocked, onChoice, options]);
+  return null;
 }
 
 /** Deduped fetch for a practice shard JSON by URL. Concurrent or repeated callers share the promise. */
@@ -1126,6 +1165,10 @@ function LexiconPracticeIsland({
   // double-advance (double-Enter, or Enter+click) before React re-renders resolves to
   // exactly ONE `completeSelection` — the second call reads a null ref and no-ops.
   const pendingOutcomeRef = useRef<CompletionOutcome | null>(null);
+  // Correct-answer auto-advance timer — cleared on exit/unmount so a late fire cannot
+  // mutate state after «← Додому» (or remount) and bounce the learner into the summary.
+  const advanceTimerRef = useRef<number | null>(null);
+  const advanceButtonRef = useRef<HTMLButtonElement | null>(null);
   // Selection ref used to stabilize the in-flight item across live deck merges (pool growth from
   // background lower-level shards). While history length is unchanged we keep returning the
   // prior selection object so a B1 card is not yanked when an A1/A2 shard lands mid-item.
@@ -1427,11 +1470,14 @@ function LexiconPracticeIsland({
 
   // While a wrong answer dwells, Enter is a second way to advance (alongside the
   // «Далі →» button) — the disabled option buttons blur to <body>, so we listen at
-  // the window level rather than on the stage.
+  // the window level rather than on the stage. Bail when focus is already on an
+  // interactive control (Atlas links, «← Додому», the «Далі →» button itself).
   useEffect(() => {
     if (!pendingOutcome) return undefined;
     const handleEnter = (event: KeyboardEvent) => {
       if (event.key !== 'Enter') return;
+      const target = event.target as HTMLElement | null;
+      if (target?.closest?.('button, a, input, textarea, select, [role="button"]')) return;
       event.preventDefault();
       advancePending();
     };
@@ -1439,10 +1485,30 @@ function LexiconPracticeIsland({
     return () => window.removeEventListener('keydown', handleEnter);
   }, [pendingOutcome, selection]);
 
+  // Wrong-answer dwell: move focus to «Далі →» so keyboard/SR users keep their place
+  // after the clicked (now-disabled) option blurs to <body>.
+  useEffect(() => {
+    if (!pendingOutcome) return;
+    advanceButtonRef.current?.focus();
+  }, [pendingOutcome]);
+
   useEffect(() => {
     if (sessionPhase !== 'active') return;
-    document.title = `${MODE_LABELS[visiblePracticeMode(mode)]} Practice - Words of the Day`;
+    const previousTitle = document.title;
+    document.title = `${MODE_META[visiblePracticeMode(mode)].title} — Практика слів дня`;
+    return () => {
+      document.title = previousTitle;
+    };
   }, [mode, sessionPhase]);
+
+  useEffect(() => {
+    return () => {
+      if (advanceTimerRef.current != null) {
+        window.clearTimeout(advanceTimerRef.current);
+        advanceTimerRef.current = null;
+      }
+    };
+  }, []);
 
   async function ensureDeck(
     includeCloze = shouldLoadCloze(mode),
@@ -2052,7 +2118,11 @@ function LexiconPracticeIsland({
       en: option.correct ? `${selection.lemma.lemma}: Correct` : `${selection.lemma.lemma}: Again`,
     });
     if (option.correct) {
-      window.setTimeout(() => {
+      if (advanceTimerRef.current != null) {
+        window.clearTimeout(advanceTimerRef.current);
+      }
+      advanceTimerRef.current = window.setTimeout(() => {
+        advanceTimerRef.current = null;
         setAnswerLocked(false);
         completeSelection(selection, outcome);
       }, advanceDelayMs);
@@ -2083,7 +2153,11 @@ function LexiconPracticeIsland({
         textEn: `✓ ${cloze.form} (${translateGrammarTerm(cloze.caseRule.caseLabel)})`,
       });
       setAnswerLocked(true);
-      window.setTimeout(() => {
+      if (advanceTimerRef.current != null) {
+        window.clearTimeout(advanceTimerRef.current);
+      }
+      advanceTimerRef.current = window.setTimeout(() => {
+        advanceTimerRef.current = null;
         setAnswerLocked(false);
         completeSelection(selection, outcome);
       }, advanceDelayMs);
@@ -2098,7 +2172,7 @@ function LexiconPracticeIsland({
       setClozeInput('');
       setClozeFeedback({
         kind: 'case-miss',
-        textUk: `→ Правильне слово. Тепер постав його у ${cloze.caseRule.caseLabel}: ${cloze.caseRule.feedback}`,
+        textUk: `→ Правильне слово. Тепер постав його ${casePhraseAccusative(cloze.caseRule.caseLabel)}: ${cloze.caseRule.feedback}`,
         textEn: `→ Correct word. Now put it in the ${translateGrammarTerm(cloze.caseRule.caseLabel)}: ${cloze.caseRule.feedback}`,
       });
       return;
@@ -2184,6 +2258,10 @@ function LexiconPracticeIsland({
   };
 
   function finishPractice() {
+    if (advanceTimerRef.current != null) {
+      window.clearTimeout(advanceTimerRef.current);
+      advanceTimerRef.current = null;
+    }
     setSessionPhase('idle');
     setFocusWeakness(null);
     setHistory([]);
@@ -2228,7 +2306,7 @@ function LexiconPracticeIsland({
       {storageWarning && (() => {
         const warn = translateStorageWarning(storageWarning);
         return warn ? (
-          <p className="lexicon-practice-warning">
+          <p className="lexicon-practice-warning" role="alert">
             <span lang="uk">{warn.uk}</span>
             {showEnglishSubtitles && warn.en ? (
               <span className="btn-sub" lang="en">/ {warn.en}</span>
@@ -2239,7 +2317,11 @@ function LexiconPracticeIsland({
 
       {focusLookupMiss && (
         <p className="lexicon-practice-warning" role="status" data-testid="practice-lemma-missing">
-          <BilingualPracticeMessage uk={PRACTICE_POOL_MISS_UK} en={PRACTICE_POOL_MISS_EN} />
+          <BilingualPracticeMessage
+            uk={PRACTICE_POOL_MISS_UK}
+            en={PRACTICE_POOL_MISS_EN}
+            showEnglishSubtitles={showEnglishSubtitles}
+          />
         </p>
       )}
 
@@ -2373,6 +2455,13 @@ function LexiconPracticeIsland({
                   type="button"
                   className={sessionBudget === budget ? 'active' : ''}
                   aria-pressed={sessionBudget === budget}
+                  aria-label={
+                    budget === 10
+                      ? '10 карток на сесію'
+                      : budget === 20
+                        ? '20 карток на сесію'
+                        : undefined
+                  }
                   onClick={() => setSessionBudget(budget)}
                 >
                   {budget === 10 ? '10' : budget === 20 ? '20' : (
@@ -2390,6 +2479,7 @@ function LexiconPracticeIsland({
               type="button"
               className="btn btn-accent lexicon-session-primary"
               data-testid="practice-start-session"
+              disabled={loading}
               onClick={() => {
                 setFocusWeakness(null);
                 void startSession(sessionBudget, 'mixed');
@@ -2584,11 +2674,20 @@ function LexiconPracticeIsland({
       {error && !selection && (
         <div className="lexicon-practice-fallback" data-testid="practice-fetch-error">
           <p className="lexicon-practice-warning">
-            <BilingualPracticeMessage uk={error} en={PRACTICE_LOAD_ERROR_EN} />
+            <BilingualPracticeMessage
+              uk={error}
+              en={PRACTICE_LOAD_ERROR_EN}
+              showEnglishSubtitles={showEnglishSubtitles}
+            />
           </p>
           <button type="button" className="btn btn-accent" onClick={() => window.location.reload()}>
-            <span lang="uk">{PRACTICE_RETRY_UK}</span>{' '}
-            <span className="btn-sub" lang="en">{PRACTICE_RETRY_EN}</span>
+            <span lang="uk">{PRACTICE_RETRY_UK}</span>
+            {showEnglishSubtitles ? (
+              <>
+                {' '}
+                <span className="btn-sub" lang="en">{PRACTICE_RETRY_EN}</span>
+              </>
+            ) : null}
           </button>
         </div>
       )}
@@ -2675,6 +2774,7 @@ function LexiconPracticeIsland({
                   {pendingOutcome ? (
                     <div className="lexicon-practice-advance" data-testid="practice-advance">
                       <button
+                        ref={advanceButtonRef}
                         type="button"
                         className="btn btn-accent lexicon-practice-advance-btn"
                         data-testid="practice-advance-button"
@@ -2739,8 +2839,9 @@ function formatNextDueLabel(nextDue: Date | null): { uk: string; en: string } | 
   const minutes = nextDue.getMinutes().toString().padStart(2, '0');
   const remainingMs = nextDue.getTime() - Date.now();
   const remaining = Math.max(1, Math.ceil(remainingMs / (60 * 60 * 1000)));
+  const hoursWord = uaPlural(remaining, { one: 'година', few: 'години', many: 'годин' });
   return {
-    uk: `ще ${remaining} о ${hours}:${minutes}`,
+    uk: `ще ${remaining} ${hoursWord} о ${hours}:${minutes}`,
     en: `in ${remaining}h at ${hours}:${minutes}`,
   };
 }
@@ -2843,6 +2944,11 @@ function PracticeItem({
   if (drillOptions && drillPrompt) {
     return (
       <div className="lexicon-choice" data-testid={`practice-${selection.mode}`}>
+        <DigitChoiceShortcuts
+          options={drillOptions}
+          answerLocked={answerLocked}
+          onChoice={onChoice}
+        />
         <p className="lexicon-choice-prompt mc-q">
           <span lang="uk">{drillPrompt.promptUk}</span>
           {showEnglishSubtitles ? (
@@ -2930,6 +3036,11 @@ function PracticeItem({
   const prompt = choicePrompt(selection);
   return (
     <div className="lexicon-choice" data-testid={`practice-${selection.mode}`}>
+      <DigitChoiceShortcuts
+        options={options}
+        answerLocked={answerLocked}
+        onChoice={onChoice}
+      />
       <p className="lexicon-choice-prompt mc-q">
         <span lang="uk">{prompt.uk}</span>
         {showEnglishSubtitles ? (
@@ -3180,9 +3291,9 @@ function PracticeCloze({
   return (
     <div className="lexicon-cloze" data-testid="practice-cloze">
       <p className="cz-task">
-        <span lang="uk">Поставте пропущене слово у правильному відмінку.</span>
+        <span lang="uk">Поставте слово „{selection.lemma.lemma}” у правильному відмінку.</span>
         {showEnglishSubtitles ? (
-          <span className="btn-sub" lang="en">/ Put the missing word in the correct case.</span>
+          <span className="btn-sub" lang="en">/ Put the word „{selection.lemma.lemma}” in the correct case.</span>
         ) : null}
       </p>
       <p className="cz-sentence">
@@ -3190,17 +3301,24 @@ function PracticeCloze({
         <span className={blankClass}>{blankText}</span>
         <span>{after}</span>
       </p>
-      <p className="lexicon-cloze-translation cz-translate">{cloze.clozeEn}</p>
+      {showEnglishSubtitles ? (
+        <p className="lexicon-cloze-translation cz-translate" lang="en">{cloze.clozeEn}</p>
+      ) : null}
       {cloze.attribution ? (
         <p className="lexicon-cloze-attribution">
-          Sentences from{' '}
+          <span lang="uk">Речення з</span>{' '}
           {cloze.attribution.sourceUrl ? (
             <a href={cloze.attribution.sourceUrl}>{cloze.attribution.source}</a>
           ) : (
             cloze.attribution.source
           )}
-          : {cloze.attribution.uk.author} ({cloze.attribution.uk.license}) /{' '}
-          {cloze.attribution.en.author} ({cloze.attribution.en.license})
+          : {cloze.attribution.uk.author} ({cloze.attribution.uk.license})
+          {showEnglishSubtitles ? (
+            <>
+              {' '}
+              / {cloze.attribution.en.author} ({cloze.attribution.en.license})
+            </>
+          ) : null}
         </p>
       ) : null}
       <form
@@ -3216,7 +3334,15 @@ function PracticeCloze({
           disabled={answerLocked}
           placeholder={showEnglishSubtitles ? "наберіть слово у потрібній формі… / type the word in the correct form…" : "наберіть слово у потрібній формі…"}
           autoComplete="off"
-          aria-label={showEnglishSubtitles ? `Відповідь у ${cloze.caseRule.caseLabel} / Answer in ${translateGrammarTerm(cloze.caseRule.caseLabel)}` : `Відповідь у ${cloze.caseRule.caseLabel}`}
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          lang="uk"
+          aria-label={
+            showEnglishSubtitles
+              ? `Відповідь ${casePhraseLocative(cloze.caseRule.caseLabel)} / Answer in ${translateGrammarTerm(cloze.caseRule.caseLabel)}`
+              : `Відповідь ${casePhraseLocative(cloze.caseRule.caseLabel)}`
+          }
           onChange={(event) => onInput(event.currentTarget.value)}
         />
         <button className="btn btn-accent" type="submit" disabled={answerLocked}>

--- a/site/src/components/PracticeFlashcard.tsx
+++ b/site/src/components/PracticeFlashcard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { PracticeRating } from '../lib/lexicon/srs';
 
 export interface PracticeFlashcardData {
@@ -27,24 +27,22 @@ export default function PracticeFlashcard({
   showEnglishSubtitles,
 }: PracticeFlashcardProps) {
   const [flipped, setFlipped] = useState(false);
-  const ratingBarRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     setFlipped(false);
   }, [card.front, card.back]);
 
   useEffect(() => {
-    if (!flipped) return undefined;
-    const timer = window.setTimeout(() => {
-      ratingBarRef.current?.querySelector<HTMLButtonElement>('[data-rate="good"]')?.focus();
-    }, 0);
-    return () => window.clearTimeout(timer);
-  }, [flipped]);
-
-  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.altKey || event.ctrlKey || event.metaKey) return;
+      // Never steal keys from text-entry controls (typing 'a' must not rate).
+      const target = event.target as HTMLElement | null;
+      if (target?.closest?.('input, textarea, select, [contenteditable="true"]')) return;
       const key = event.key.toLowerCase();
+      // Space/Enter activate whatever control holds focus (button, link, the card
+      // itself) — let that native activation happen instead of double-handling it here.
+      const activatesControl = key === ' ' || key === 'enter';
+      if (activatesControl && target?.closest?.('button, a, [role="button"], [role="link"]')) return;
       if (!flipped && (key === ' ' || key === 'enter')) {
         event.preventDefault();
         setFlipped(true);
@@ -115,7 +113,6 @@ export default function PracticeFlashcard({
       </div>
       <div
         className="lexicon-rating-bar rating-bar"
-        ref={ratingBarRef}
         role="group"
         aria-label={showEnglishSubtitles ? "Оцініть, наскільки легко згадалось / Rate how easy it was to recall" : "Оцініть, наскільки легко згадалось"}
         data-revealed={flipped ? 'true' : 'false'}

--- a/site/src/components/PracticeSessionSummary.tsx
+++ b/site/src/components/PracticeSessionSummary.tsx
@@ -42,7 +42,7 @@ export default function PracticeSessionSummary({
         </div>
         <div>
           <dt>
-            <span lang="uk">З lapses</span>
+            <span lang="uk">Помилки</span>
             {showEnglishSubtitles ? (
               <span className="btn-sub" lang="en">/ Lapsed</span>
             ) : null}
@@ -62,7 +62,7 @@ export default function PracticeSessionSummary({
       {stats.advancedToReview.length > 0 ? (
         <section className="lexicon-session-advanced">
           <h3>
-            <span lang="uk">Перейшли до Review</span>
+            <span lang="uk">Перейшли на повторення</span>
             {showEnglishSubtitles ? (
               <span className="btn-sub" lang="en">/ Advanced to Review</span>
             ) : null}
@@ -85,7 +85,7 @@ export default function PracticeSessionSummary({
       {stats.deferredLemmas.length > 0 ? (
         <section className="lexicon-session-deferred" data-testid="practice-deferred-list">
           <h3>
-            <span lang="uk">повторимо наступного разу</span>
+            <span lang="uk">Повторимо наступного разу</span>
             {showEnglishSubtitles ? (
               <span className="btn-sub" lang="en">/ will repeat next time</span>
             ) : null}

--- a/site/src/lexicon/AtlasFullIndex.astro
+++ b/site/src/lexicon/AtlasFullIndex.astro
@@ -420,7 +420,7 @@ type BrowseRow = {
     const hasMore = rows.length > visibleRows.length;
     moreButton.hidden = !hasMore;
     overflow.hidden = state.overflow === 0 || hasMore;
-    overflow.textContent = state.overflow > 0 ? `+${state.overflow} more — звузьте запит` : "";
+    overflow.textContent = state.overflow > 0 ? `ще ${atlasEntryCountLabel(state.overflow)} — звузьте запит` : "";
     sentinel.hidden = !hasMore;
     setStatus(rows.length);
       focusHashTarget(rows);

--- a/site/src/lexicon/AtlasTypeahead.astro
+++ b/site/src/lexicon/AtlasTypeahead.astro
@@ -158,7 +158,10 @@ const listId = `${id}-list`;
         .join("");
       taList.hidden = false;
       taInput.setAttribute("aria-expanded", "true");
-      if (taActive >= 0) taInput.setAttribute("aria-activedescendant", taOptionId(taActive));
+      if (taActive >= 0) {
+        taInput.setAttribute("aria-activedescendant", taOptionId(taActive));
+        document.getElementById(taOptionId(taActive))?.scrollIntoView({ block: "nearest" });
+      }
     };
 
     const taLoadManifest = () => {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1250,7 +1250,7 @@ describe('LexiconPractice', () => {
     const status = screen.getByRole('status');
     expect(status).toHaveTextContent('Правильне слово');
     expect(status).toHaveClass('case-miss');
-    expect(screen.getByLabelText(/Відповідь у знахідний/)).toHaveValue('');
+    expect(screen.getByLabelText(/Відповідь у знахідному відмінку/)).toHaveValue('');
     expect(screen.getByRole('button', { name: 'книгу' })).not.toBeDisabled();
 
     await waitFor(() => {
@@ -1463,7 +1463,7 @@ describe('LexiconPractice', () => {
       expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument(),
     );
     expect(screen.getByTestId('practice-cloze')).toBeInTheDocument();
-    expect(screen.getByLabelText(/Відповідь у знахідний/)).toHaveValue('');
+    expect(screen.getByLabelText(/Відповідь у знахідному відмінку/)).toHaveValue('');
     expect(screen.getByRole('button', { name: 'книгу' })).not.toBeDisabled();
     expect(screen.queryByText('✗ Не те слово')).not.toBeInTheDocument();
   });
@@ -1504,7 +1504,7 @@ describe('LexiconPractice', () => {
     // Focus session is active and serving the accusative cloze — no other case leaks in.
     const cloze = await screen.findByTestId('practice-cloze');
     expect(cloze).toBeInTheDocument();
-    expect(screen.getByLabelText(/Відповідь у знахідний/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Відповідь у знахідному відмінку/)).toBeInTheDocument();
   });
 
   test('weak-area chip whose weakness yields no items shows a UA notice, clears focus, and never strands the learner', async () => {


### PR DESCRIPTION
## Summary

Implements the remaining **changes 3–8** from `UI-REVIEW-FINDINGS.md` (Kimi K3 web-dev review) on `kimi/atlas-ui-improve`, plus the LexiconPractice Enter interactive-target guard from finding 1 that change 1 only covered in `PracticeFlashcard.tsx`.

| # | Change | Findings | Files |
|---|--------|----------|-------|
| 1 | Interactive-target guards on window key handlers | 1 | `PracticeFlashcard.tsx` (prior), `LexiconPractice.tsx` (this PR) |
| 2 | Remove post-flip auto-focus to «Добре» | 4 | `PracticeFlashcard.tsx` (prior commit) |
| 3 | Digit shortcuts (1–4) for drill/choice options | 2 | `LexiconPractice.tsx` |
| 4 | Focus «Далі →» on wrong-answer dwell | 5 | `LexiconPractice.tsx` |
| 5 | English-leak gating + Ukrainian copy | 3 | `LexiconPractice.tsx`, `PracticeSessionSummary.tsx` |
| 6 | Clear auto-advance timer on exit/unmount | 6 | `LexiconPractice.tsx` |
| 7 | Cloze case-phrase grammar + next-due units + home/cloze a11y | 7, 8, 11 | `LexiconPractice.tsx` |
| 8 | Atlas browse «ще N записів» + typeahead scroll-into-view | 9, 10 | `AtlasFullIndex.astro`, `AtlasTypeahead.astro` |

### Per-change before → after

1. **Enter dwell guard** — Before: window Enter during wrong-answer dwell stole activation from Atlas links / «← Додому». After: bails when the event target is inside `button, a, input, textarea, select, [role="button"]`.
2. *(prior)* Flashcard auto-focus removed so Space keyup no longer accidental-rates «Добре».
3. **Digit shortcuts** — Before: `1–4` badges on drill/choice were decorative. After: digits select options while unlocked, with the same interactive-target guard.
4. **Далі focus** — Before: wrong pick disabled the option and dropped focus to `<body>`. After: «Далі →» is focused when the dwell control mounts.
5. **English-leak gating** — Before: bilingual load/pool messages, «Try again», cloze English gloss, «Sentences from», English `document.title`, and summary «З lapses» / «Review» leaked past A1. After: English only behind `showEnglishSubtitles`; cloze cues the Ukrainian lemma; attribution «Речення з»; title «{mode} — Практика слів дня» restored on exit; summary «Помилки» / «Перейшли на повторення» / «Повторимо наступного разу».
6. **Auto-advance timer** — Before: a 650 ms correct-answer timeout could fire after «← Додому» and reopen summary. After: timer id is stored and cleared in `finishPractice`, on unmount, and before rescheduling.
7. **Cloze/home polish** — Before: «у знахідний» bare adjective; «ще 3 о 14:00»; bare «10»/«20» announcements; start clickable while loading; cloze input autocorrected. After: «у знахідному відмінку» / «у знахідний відмінок»; «ще 3 години о 14:00»; `aria-label` «N карток на сесію»; start `disabled={loading}`; cloze `autoCapitalize/autoCorrect off` + `spellCheck={false}` + `lang="uk"`; storage warning `role="alert"`.
8. **Atlas browse/typeahead** — Before: `+N more — звузьте запит`; arrow keys moved active option off-screen. After: `ще N записів — звузьте запит`; active option `scrollIntoView({ block: 'nearest' })`.

## Failure diagnosis (pre-existing vs branch)

Reported 6 failing files on the pre-rebase tip were **environment / stale-base**, not caused by changes 1–2:

- Branch was behind `origin/main` (missing #5329/#5332/#5334 Atlas React/shell work).
- Worktree lacked hydrated `data/atlas.db`, `lexicon-manifest.json`, and practice shards until hydrate completed.
- After **rebase onto `origin/main`** + hydrate, those suites pass independently of the practice UI edits.
- No failure was caused by committed changes 1–2.

## Test plan / verification (raw)

```
$ cd site && npx vitest run
 Test Files  45 passed (45)
      Tests  693 passed | 4 skipped (697)

$ cd site && npm run build
 [build] 8973 page(s) built in 1m 24s
 [build] Complete!

$ npx tsc --noEmit  (filtered to touched files)
 tsc touched files: clean
```


Made with [Cursor](https://cursor.com)