### PR TITLE
feat(atlas): slice 3 — deploy vendoring + generation retention + scale gates (spec v2 R1/R7)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -93,8 +93,23 @@ jobs:
           mkdir -p dist/.well-known
           printf '%s\n' "$GITHUB_SHA" > "dist/.well-known/learn-ukrainian-deployment-${GITHUB_SHA}.txt"
 
+      # PR3 D1/R1/R7: vendor pinned atlas runtime tree into dist/atlas/ (same-origin).
+      # Feature-flagged: unset ATLAS_TREE_ASSET_ID + ATLAS_TREE_SHA256 → skip (deploy
+      # stays green until the 20k publish arc supplies the first immutable pin).
+      # Pin is asset id + sha256 digest — never a mutable release tag name.
+      # Runs AFTER build, BEFORE the size gate so the vendored tree counts.
+      - name: Vendor Atlas runtime tree
+        working-directory: .
+        env:
+          ATLAS_TREE_ASSET_ID: ${{ vars.ATLAS_TREE_ASSET_ID }}
+          ATLAS_TREE_SHA256: ${{ vars.ATLAS_TREE_SHA256 }}
+          ATLAS_TREE_METRICS_PATH: ${{ runner.temp }}/atlas-vendor-metrics.json
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .venv/bin/python scripts/deploy/vendor_atlas_tree.py site/dist
+
       # #5274: fail-closed size gate (replaces advisory 70% warn-only). Runs after
-      # build, before upload-pages-artifact — unknown profile or ≥80% of 1 GiB fails.
+      # build (+ optional atlas vendoring), before upload-pages-artifact — unknown
+      # profile or ≥80% of 1 GiB fails.
       - name: Check published-site size (fail-closed)
         working-directory: .
         env:

--- a/scripts/deploy/vendor_atlas_tree.py
+++ b/scripts/deploy/vendor_atlas_tree.py
@@ -159,7 +159,14 @@ def download_release_asset(
             "Accept: application/octet-stream",
         ]
         try:
-            result = subprocess.run(cmd, check=False, capture_output=True)
+            result = subprocess.run(
+                cmd, check=False, capture_output=True, timeout=300
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise VendorError(
+                f"gh api timed out downloading release asset {asset_id} "
+                f"from {repo}: {exc}"
+            ) from exc
         except OSError as exc:
             raise VendorError(f"failed to invoke gh for asset {asset_id}: {exc}") from exc
         if result.returncode != 0:
@@ -555,9 +562,17 @@ def vendor_atlas_tree(
         extract_root = Path(tmp)
         extract_zip(archive_bytes, extract_root)
         packaging_manifest = load_tree_manifest(extract_root)
-        verify_tree_manifest(extract_root, packaging_manifest)
+        listed_file_count = verify_tree_manifest(extract_root, packaging_manifest)
         data_version, priors = verify_generation_retention(extract_root)
         extracted_bytes, object_count = measure_tree(extract_root)
+        # Fail closed: packaging manifest is the allowlist. Extra archive members
+        # (not listed in atlas/tree-manifest.json) would otherwise install unverified.
+        # The packaging manifest lists itself, so object_count must equal listed count.
+        if object_count != listed_file_count:
+            raise VendorError(
+                f"archive contains files not listed in packaging manifest: "
+                f"object_count={object_count} != listed_file_count={listed_file_count}"
+            )
         warnings = apply_scale_gates(
             archive_bytes=len(archive_bytes),
             extracted_bytes=extracted_bytes,

--- a/scripts/deploy/vendor_atlas_tree.py
+++ b/scripts/deploy/vendor_atlas_tree.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Vendor a pinned Atlas runtime-shard tree into the Pages dist (PR3 D1 / R1 / R7).
+
+Downloads a GitHub Release asset pinned by **immutable asset id + sha256** (never a
+mutable tag name), verifies archive checksum + internal packaging manifest, enforces
+generation retention (CURRENT + PRIOR version dirs), applies scale gates, then
+byte-preserves the tree into ``<dist>/atlas/``.
+
+Feature flag: when ``ATLAS_TREE_ASSET_ID`` / ``ATLAS_TREE_SHA256`` are unset (and no
+``--archive`` is supplied), the script logs a skip message and exits 0 so deploys
+stay green until the 20k publish arc supplies the first real pin.
+
+Usage::
+
+    # Offline / tests (local archive + digest pin)
+    ATLAS_TREE_SHA256=<hex> .venv/bin/python scripts/deploy/vendor_atlas_tree.py \\
+        site/dist --archive /tmp/atlas-tree.zip
+
+    # CI (asset id pin + digest; requires network + token)
+    ATLAS_TREE_ASSET_ID=123 ATLAS_TREE_SHA256=<hex> \\
+      .venv/bin/python scripts/deploy/vendor_atlas_tree.py site/dist
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Scale gates (R7) — fail before the 1 GiB GitHub Pages hard cap is at risk.
+# Overridable via env; defaults are constants.
+# ---------------------------------------------------------------------------
+MIB = 1024 * 1024
+DEFAULT_WARN_EXTRACTED_BYTES = 512 * MIB  # 512 MiB
+DEFAULT_FAIL_EXTRACTED_BYTES = 800 * MIB  # 800 MiB
+DEFAULT_FAIL_ARCHIVE_BYTES = 900 * MIB
+DEFAULT_FAIL_OBJECT_COUNT = 200_000
+
+TREE_MANIFEST_SCHEMA = "atlas-tree-archive-manifest"
+TREE_MANIFEST_SCHEMA_VERSION = 1
+TREE_MANIFEST_REL = "atlas/tree-manifest.json"
+CURRENT_REL = "atlas/current.json"
+VERSIONS_REL = "atlas/versions"
+
+SKIP_MESSAGE = "atlas vendoring: no pin configured, skipping"
+
+DEFAULT_REPO = "learn-ukrainian/learn-ukrainian.github.io"
+
+
+class VendorError(RuntimeError):
+    """Hard vendoring failure — deploy must abort (old site stays live)."""
+
+
+@dataclass
+class VendorMetrics:
+    """R7 metrics emitted to stdout + optional JSON file."""
+
+    archive_bytes: int
+    extracted_bytes: int
+    object_count: int
+    vendor_duration_ms: int
+    data_version: str
+    prior_versions: list[str] = field(default_factory=list)
+    archive_sha256: str = ""
+    asset_id: str | None = None
+    warnings: list[str] = field(default_factory=list)
+    skipped: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not str(raw).strip():
+        return default
+    try:
+        value = int(str(raw).strip(), 10)
+    except ValueError as exc:
+        raise VendorError(f"{name} must be an integer, got {raw!r}") from exc
+    if value < 0:
+        raise VendorError(f"{name} must be non-negative, got {value}")
+    return value
+
+
+def resolve_thresholds() -> dict[str, int]:
+    """Return warn/fail thresholds (env overrides constants)."""
+    return {
+        "warn_extracted_bytes": _env_int(
+            "ATLAS_TREE_WARN_EXTRACTED_BYTES", DEFAULT_WARN_EXTRACTED_BYTES
+        ),
+        "fail_extracted_bytes": _env_int(
+            "ATLAS_TREE_FAIL_EXTRACTED_BYTES", DEFAULT_FAIL_EXTRACTED_BYTES
+        ),
+        "fail_archive_bytes": _env_int(
+            "ATLAS_TREE_FAIL_ARCHIVE_BYTES", DEFAULT_FAIL_ARCHIVE_BYTES
+        ),
+        "fail_object_count": _env_int(
+            "ATLAS_TREE_FAIL_OBJECT_COUNT", DEFAULT_FAIL_OBJECT_COUNT
+        ),
+    }
+
+
+def pin_configured(
+    *,
+    asset_id: str | None,
+    sha256: str | None,
+    archive_path: Path | None,
+) -> bool:
+    """True when enough pin inputs exist to attempt vendoring (not skip)."""
+    has_digest = bool(sha256 and str(sha256).strip())
+    has_source = bool(archive_path) or bool(asset_id and str(asset_id).strip())
+    return has_digest and has_source
+
+
+def download_release_asset(
+    asset_id: str,
+    *,
+    repo: str,
+    token: str | None = None,
+) -> bytes:
+    """Download a release asset by immutable numeric id (GitHub API).
+
+    Uses ``gh api`` when available (inherits ``GH_TOKEN`` / ``GITHUB_TOKEN``),
+    otherwise falls back to ``urllib`` with an Authorization header.
+    """
+    asset_id = str(asset_id).strip()
+    if not asset_id.isdigit():
+        raise VendorError(
+            f"ATLAS_TREE_ASSET_ID must be a numeric GitHub asset id, got {asset_id!r}"
+        )
+
+    # Prefer gh: handles redirects + auth for private/public assets uniformly.
+    gh = shutil.which("gh")
+    if gh:
+        cmd = [
+            gh,
+            "api",
+            f"repos/{repo}/releases/assets/{asset_id}",
+            "-H",
+            "Accept: application/octet-stream",
+        ]
+        try:
+            result = subprocess.run(cmd, check=False, capture_output=True)
+        except OSError as exc:
+            raise VendorError(f"failed to invoke gh for asset {asset_id}: {exc}") from exc
+        if result.returncode != 0:
+            err = result.stderr.decode("utf-8", errors="replace").strip()
+            raise VendorError(
+                f"gh api failed downloading release asset {asset_id} "
+                f"from {repo}: {err or f'exit {result.returncode}'}"
+            )
+        return result.stdout
+
+    url = f"https://api.github.com/repos/{repo}/releases/assets/{asset_id}"
+    headers = {
+        "Accept": "application/octet-stream",
+        "User-Agent": "learn-ukrainian-atlas-tree-vendor/1.0",
+    }
+    tok = token or os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=300) as response:
+            return response.read()
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+        raise VendorError(
+            f"failed to download release asset {asset_id} from {repo}: {exc}"
+        ) from exc
+
+
+def verify_archive_digest(archive_bytes: bytes, expected_sha256: str) -> str:
+    """Return digest if it matches; raise VendorError on mismatch (fail closed)."""
+    expected = expected_sha256.strip().lower()
+    if len(expected) != 64 or any(c not in "0123456789abcdef" for c in expected):
+        raise VendorError(
+            f"ATLAS_TREE_SHA256 must be a 64-char hex digest, got {expected_sha256!r}"
+        )
+    actual = sha256_hex(archive_bytes)
+    if actual != expected:
+        raise VendorError(
+            f"archive sha256 mismatch: expected {expected}, got {actual}"
+        )
+    return actual
+
+
+def _safe_member_path(name: str) -> Path:
+    """Reject absolute paths and ``..`` traversal in zip members."""
+    # Zip members use forward slashes; normalize without resolving against host FS.
+    cleaned = name.replace("\\", "/").lstrip("/")
+    if not cleaned or cleaned.endswith("/"):
+        raise VendorError(f"unsafe or empty zip member path: {name!r}")
+    parts = Path(cleaned).parts
+    if any(part in ("", ".", "..") for part in parts):
+        raise VendorError(f"unsafe zip member path: {name!r}")
+    if parts[0] != "atlas":
+        raise VendorError(
+            f"archive member must be under atlas/: got {name!r}"
+        )
+    return Path(*parts)
+
+
+def extract_zip(archive_bytes: bytes, dest: Path) -> None:
+    """Extract a zip archive into ``dest`` with path-safety checks."""
+    dest.mkdir(parents=True, exist_ok=True)
+    try:
+        with zipfile.ZipFile(io_bytes_zip(archive_bytes)) as zf:
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                rel = _safe_member_path(info.filename)
+                target = dest / rel
+                target.parent.mkdir(parents=True, exist_ok=True)
+                # Byte-preserving copy (R10) — write raw member bytes as-is.
+                with zf.open(info, "r") as src, open(target, "wb") as out:
+                    shutil.copyfileobj(src, out)
+    except zipfile.BadZipFile as exc:
+        raise VendorError(f"archive is not a valid zip: {exc}") from exc
+
+
+def io_bytes_zip(archive_bytes: bytes) -> Any:
+    """Return a BytesIO suitable for ZipFile (kept as function for tests/mocks)."""
+    import io
+
+    return io.BytesIO(archive_bytes)
+
+
+def load_tree_manifest(extract_root: Path) -> dict[str, Any]:
+    """Load and schema-check the internal packaging manifest."""
+    path = extract_root / TREE_MANIFEST_REL
+    if not path.is_file():
+        raise VendorError(f"internal manifest missing: {TREE_MANIFEST_REL}")
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise VendorError(f"internal manifest unreadable: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise VendorError("internal manifest must be a JSON object")
+    if manifest.get("schema") != TREE_MANIFEST_SCHEMA:
+        raise VendorError(
+            f"internal manifest schema must be {TREE_MANIFEST_SCHEMA!r}, "
+            f"got {manifest.get('schema')!r}"
+        )
+    if manifest.get("schemaVersion") != TREE_MANIFEST_SCHEMA_VERSION:
+        raise VendorError(
+            f"internal manifest schemaVersion must be {TREE_MANIFEST_SCHEMA_VERSION}, "
+            f"got {manifest.get('schemaVersion')!r}"
+        )
+    files = manifest.get("files")
+    if not isinstance(files, list) or not files:
+        raise VendorError("internal manifest.files must be a non-empty list")
+    return manifest
+
+
+def verify_tree_manifest(extract_root: Path, manifest: Mapping[str, Any]) -> int:
+    """Ensure every listed file exists and sizes match. Return listed file count."""
+    seen: set[str] = set()
+    for index, entry in enumerate(manifest["files"]):
+        if not isinstance(entry, dict):
+            raise VendorError(f"internal manifest.files[{index}] must be an object")
+        rel = entry.get("path")
+        size = entry.get("bytes")
+        if not isinstance(rel, str) or not rel:
+            raise VendorError(f"internal manifest.files[{index}].path must be a string")
+        if not isinstance(size, int) or size < 0:
+            raise VendorError(
+                f"internal manifest.files[{index}].bytes must be a non-negative int"
+            )
+        # Paths in the packaging manifest are archive-relative (atlas/...).
+        try:
+            safe = _safe_member_path(rel)
+        except VendorError:
+            # _safe_member_path rejects trailing slashes; re-raise with context.
+            raise
+        if rel in seen:
+            raise VendorError(f"internal manifest lists duplicate path: {rel}")
+        seen.add(rel)
+        path = extract_root / safe
+        if not path.is_file():
+            raise VendorError(f"manifest lists missing file: {rel}")
+        actual = path.stat().st_size
+        if actual != size:
+            raise VendorError(
+                f"size mismatch for {rel}: manifest={size}, actual={actual}"
+            )
+    return len(seen)
+
+
+def list_version_dirs(extract_root: Path) -> list[str]:
+    """Return sorted dataVersion directory names under atlas/versions/."""
+    versions_root = extract_root / VERSIONS_REL
+    if not versions_root.is_dir():
+        raise VendorError(f"missing version tree: {VERSIONS_REL}/")
+    names: list[str] = []
+    for child in versions_root.iterdir():
+        if child.is_dir() and not child.name.startswith("."):
+            names.append(child.name)
+    return sorted(names)
+
+
+def verify_generation_retention(extract_root: Path) -> tuple[str, list[str]]:
+    """R1: CURRENT + ≥1 PRIOR generation; current.json must point at a vendored dir.
+
+    Returns ``(current_data_version, prior_versions)``.
+    """
+    current_path = extract_root / CURRENT_REL
+    if not current_path.is_file():
+        raise VendorError(f"missing {CURRENT_REL}")
+    try:
+        current = json.loads(current_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise VendorError(f"current.json unreadable: {exc}") from exc
+    if not isinstance(current, dict):
+        raise VendorError("current.json must be a JSON object")
+    if current.get("schema") != "atlas-current" or current.get("schemaVersion") != 1:
+        raise VendorError("current.json has unsupported schema")
+    data_version = current.get("dataVersion")
+    if not isinstance(data_version, str) or not data_version.strip():
+        raise VendorError("current.json missing dataVersion")
+    manifest_url = current.get("manifestUrl")
+    if not isinstance(manifest_url, str) or not manifest_url.startswith("versions/"):
+        raise VendorError("current.json.manifestUrl must start with versions/")
+
+    version_dirs = list_version_dirs(extract_root)
+    if data_version not in version_dirs:
+        raise VendorError(
+            f"current.json points at non-vendored generation {data_version!r}; "
+            f"vendored: {version_dirs}"
+        )
+    expected_manifest = extract_root / "atlas" / manifest_url
+    if not expected_manifest.is_file():
+        raise VendorError(f"current.json manifestUrl missing on disk: {manifest_url}")
+
+    # Path inside versions/<dataVersion>/ must match the pointer's dataVersion.
+    # manifestUrl form: versions/<dataVersion>/manifest.json
+    parts = Path(manifest_url).parts
+    if len(parts) < 3 or parts[0] != "versions" or parts[1] != data_version:
+        raise VendorError(
+            f"current.json manifestUrl {manifest_url!r} does not match "
+            f"dataVersion {data_version!r}"
+        )
+
+    priors = [name for name in version_dirs if name != data_version]
+    if not priors:
+        raise VendorError(
+            "generation retention failed: archive must vendor CURRENT and at least "
+            f"one PRIOR generation under {VERSIONS_REL}/; only found {version_dirs}"
+        )
+    return data_version, priors
+
+
+def measure_tree(extract_root: Path) -> tuple[int, int]:
+    """Return ``(extracted_bytes, object_count)`` for files under extract_root."""
+    total = 0
+    count = 0
+    atlas_root = extract_root / "atlas"
+    if not atlas_root.is_dir():
+        raise VendorError("extracted tree missing atlas/ root")
+    for path in atlas_root.rglob("*"):
+        if path.is_file():
+            count += 1
+            total += path.stat().st_size
+    return total, count
+
+
+def apply_scale_gates(
+    *,
+    archive_bytes: int,
+    extracted_bytes: int,
+    object_count: int,
+    thresholds: Mapping[str, int],
+) -> list[str]:
+    """Return warnings; raise VendorError when a fail threshold is crossed."""
+    warnings: list[str] = []
+    warn_ex = thresholds["warn_extracted_bytes"]
+    fail_ex = thresholds["fail_extracted_bytes"]
+    fail_arch = thresholds["fail_archive_bytes"]
+    fail_obj = thresholds["fail_object_count"]
+
+    if extracted_bytes >= warn_ex and extracted_bytes < fail_ex:
+        warnings.append(
+            f"extracted size {extracted_bytes:,} bytes ≥ warn {warn_ex:,}"
+        )
+    if extracted_bytes >= fail_ex:
+        raise VendorError(
+            f"scale gate: extracted size {extracted_bytes:,} bytes ≥ fail "
+            f"{fail_ex:,} (Pages hard-cap headroom)"
+        )
+    if archive_bytes >= fail_arch:
+        raise VendorError(
+            f"scale gate: archive size {archive_bytes:,} bytes ≥ fail {fail_arch:,}"
+        )
+    if object_count >= fail_obj:
+        raise VendorError(
+            f"scale gate: object count {object_count:,} ≥ fail {fail_obj:,}"
+        )
+    return warnings
+
+
+def install_atlas_tree(extract_root: Path, dist: Path) -> Path:
+    """Byte-preserve ``extract_root/atlas`` into ``dist/atlas`` (R10).
+
+    Replaces any previous ``dist/atlas`` entirely so a pin flip is atomic from
+    the deploy job's perspective (failure before this leaves the old artifact
+    unuploaded).
+    """
+    src = extract_root / "atlas"
+    if not src.is_dir():
+        raise VendorError("nothing to install: extracted atlas/ missing")
+    dest = dist / "atlas"
+    if dest.exists():
+        shutil.rmtree(dest)
+    # copytree preserves file bytes; no rewrite/rename inside versions/.
+    shutil.copytree(src, dest)
+    return dest
+
+
+def _serialize_tree_manifest(files: list[dict[str, Any]]) -> bytes:
+    """Serialize packaging manifest JSON (UTF-8, trailing newline)."""
+    body = {
+        "schema": TREE_MANIFEST_SCHEMA,
+        "schemaVersion": TREE_MANIFEST_SCHEMA_VERSION,
+        "files": files,
+    }
+    return (json.dumps(body, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+
+def build_archive_from_tree(tree_root: Path, archive_path: Path) -> str:
+    """Test helper: zip an on-disk ``atlas/`` tree + write tree-manifest, return sha256.
+
+    ``tree_root`` must contain an ``atlas/`` directory (e.g. a mini runtime tree).
+    The packaging manifest lists every file under ``atlas/`` with sizes.
+    """
+    atlas = tree_root / "atlas"
+    if not atlas.is_dir():
+        raise VendorError(f"build_archive_from_tree: missing {atlas}")
+
+    files: list[dict[str, Any]] = []
+    for path in sorted(atlas.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(tree_root).as_posix()
+        if rel == TREE_MANIFEST_REL:
+            continue  # rewritten below
+        files.append({"path": rel, "bytes": path.stat().st_size})
+
+    # Self-size fixed-point: listed bytes for tree-manifest must match payload.
+    self_entry: dict[str, Any] = {"path": TREE_MANIFEST_REL, "bytes": 0}
+    files_with_self = [*files, self_entry]
+    manifest_bytes = b""
+    for _ in range(8):
+        manifest_bytes = _serialize_tree_manifest(files_with_self)
+        if self_entry["bytes"] == len(manifest_bytes):
+            break
+        self_entry["bytes"] = len(manifest_bytes)
+    else:
+        raise VendorError("failed to stabilize tree-manifest self size")
+
+    manifest_path = tree_root / TREE_MANIFEST_REL
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_bytes(manifest_bytes)
+
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(atlas.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(tree_root).as_posix()
+            # write stores exact file bytes (R10 source side).
+            zf.write(path, arcname=rel)
+    return sha256_hex(archive_path.read_bytes())
+
+
+def vendor_atlas_tree(
+    dist: Path,
+    *,
+    asset_id: str | None = None,
+    sha256: str | None = None,
+    archive_path: Path | None = None,
+    repo: str | None = None,
+    token: str | None = None,
+    metrics_path: Path | None = None,
+    thresholds: Mapping[str, int] | None = None,
+) -> VendorMetrics:
+    """Download (or load), verify, and install the atlas tree into ``dist``.
+
+    Raises :class:`VendorError` on any integrity / retention / scale failure.
+    When no pin is configured, returns a skipped metrics object (exit 0 path).
+    """
+    started = time.perf_counter()
+    asset_id = (asset_id if asset_id is not None else os.environ.get("ATLAS_TREE_ASSET_ID") or "").strip() or None
+    sha256 = (sha256 if sha256 is not None else os.environ.get("ATLAS_TREE_SHA256") or "").strip() or None
+    if archive_path is None:
+        env_archive = os.environ.get("ATLAS_TREE_ARCHIVE_PATH")
+        if env_archive and str(env_archive).strip():
+            archive_path = Path(str(env_archive).strip())
+
+    if not pin_configured(asset_id=asset_id, sha256=sha256, archive_path=archive_path):
+        metrics = VendorMetrics(
+            archive_bytes=0,
+            extracted_bytes=0,
+            object_count=0,
+            vendor_duration_ms=int((time.perf_counter() - started) * 1000),
+            data_version="",
+            skipped=True,
+        )
+        print(SKIP_MESSAGE)
+        _write_metrics(metrics, metrics_path)
+        return metrics
+
+    if not sha256:
+        raise VendorError("ATLAS_TREE_SHA256 is required when vendoring is enabled")
+
+    if archive_path is not None:
+        try:
+            archive_bytes = archive_path.read_bytes()
+        except OSError as exc:
+            raise VendorError(f"failed to read archive {archive_path}: {exc}") from exc
+    else:
+        if not asset_id:
+            raise VendorError("ATLAS_TREE_ASSET_ID is required when --archive is omitted")
+        resolved_repo = (
+            repo
+            or os.environ.get("ATLAS_TREE_REPO")
+            or os.environ.get("GITHUB_REPOSITORY")
+            or DEFAULT_REPO
+        )
+        archive_bytes = download_release_asset(
+            asset_id, repo=resolved_repo, token=token
+        )
+
+    digest = verify_archive_digest(archive_bytes, sha256)
+    thr = dict(thresholds) if thresholds is not None else resolve_thresholds()
+
+    with tempfile.TemporaryDirectory(prefix="atlas-vendor-") as tmp:
+        extract_root = Path(tmp)
+        extract_zip(archive_bytes, extract_root)
+        packaging_manifest = load_tree_manifest(extract_root)
+        verify_tree_manifest(extract_root, packaging_manifest)
+        data_version, priors = verify_generation_retention(extract_root)
+        extracted_bytes, object_count = measure_tree(extract_root)
+        warnings = apply_scale_gates(
+            archive_bytes=len(archive_bytes),
+            extracted_bytes=extracted_bytes,
+            object_count=object_count,
+            thresholds=thr,
+        )
+        dist.mkdir(parents=True, exist_ok=True)
+        install_atlas_tree(extract_root, dist)
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    metrics = VendorMetrics(
+        archive_bytes=len(archive_bytes),
+        extracted_bytes=extracted_bytes,
+        object_count=object_count,
+        vendor_duration_ms=duration_ms,
+        data_version=data_version,
+        prior_versions=priors,
+        archive_sha256=digest,
+        asset_id=asset_id,
+        warnings=warnings,
+        skipped=False,
+    )
+    _emit_metrics(metrics)
+    _write_metrics(metrics, metrics_path)
+    return metrics
+
+
+def _emit_metrics(metrics: VendorMetrics) -> None:
+    print("## Atlas tree vendoring metrics (R7)")
+    print(f"archive_bytes={metrics.archive_bytes}")
+    print(f"extracted_bytes={metrics.extracted_bytes}")
+    print(f"object_count={metrics.object_count}")
+    print(f"vendor_duration_ms={metrics.vendor_duration_ms}")
+    print(f"data_version={metrics.data_version}")
+    print(f"prior_versions={','.join(metrics.prior_versions)}")
+    print(f"archive_sha256={metrics.archive_sha256}")
+    if metrics.asset_id:
+        print(f"asset_id={metrics.asset_id}")
+    for warning in metrics.warnings:
+        print(f"::warning title=Atlas tree scale::{warning}")
+        print(f"WARNING: {warning}")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        lines = [
+            "## Atlas tree vendoring (R1/R7)",
+            "",
+            f"- archive_bytes: **{metrics.archive_bytes:,}**",
+            f"- extracted_bytes: **{metrics.extracted_bytes:,}**",
+            f"- object_count: **{metrics.object_count:,}**",
+            f"- vendor_duration_ms: **{metrics.vendor_duration_ms}**",
+            f"- data_version: `{metrics.data_version}`",
+            f"- prior_versions: `{', '.join(metrics.prior_versions)}`",
+            f"- archive_sha256: `{metrics.archive_sha256}`",
+            "",
+        ]
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines))
+
+
+def _write_metrics(metrics: VendorMetrics, metrics_path: Path | None) -> None:
+    if metrics_path is None:
+        return
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.write_text(
+        json.dumps(metrics.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "dist",
+        type=Path,
+        nargs="?",
+        default=Path("site/dist"),
+        help="Site dist directory (default: site/dist); installs into <dist>/atlas/",
+    )
+    parser.add_argument(
+        "--archive",
+        type=Path,
+        default=None,
+        help="Local zip path (skips GitHub download; still requires ATLAS_TREE_SHA256)",
+    )
+    parser.add_argument(
+        "--asset-id",
+        default=None,
+        help="Immutable GitHub release asset id (default: $ATLAS_TREE_ASSET_ID)",
+    )
+    parser.add_argument(
+        "--sha256",
+        default=None,
+        help="Expected archive sha256 hex digest (default: $ATLAS_TREE_SHA256)",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="owner/repo for the release asset (default: $ATLAS_TREE_REPO / $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument(
+        "--metrics-out",
+        type=Path,
+        default=None,
+        help="Write JSON metrics to this path (also set via ATLAS_TREE_METRICS_PATH)",
+    )
+    args = parser.parse_args(argv)
+
+    metrics_path = args.metrics_out
+    if metrics_path is None:
+        env_metrics = os.environ.get("ATLAS_TREE_METRICS_PATH")
+        if env_metrics and str(env_metrics).strip():
+            metrics_path = Path(str(env_metrics).strip())
+    # Metrics are opt-in via --metrics-out / ATLAS_TREE_METRICS_PATH so they
+    # never land inside the Pages artifact by accident.
+
+    try:
+        vendor_atlas_tree(
+            args.dist,
+            asset_id=args.asset_id,
+            sha256=args.sha256,
+            archive_path=args.archive,
+            repo=args.repo,
+            metrics_path=metrics_path,
+        )
+    except VendorError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        print(f"::error title=Atlas tree vendoring::{exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/lib/lexicon/http-atlas-data-source.ts
+++ b/site/src/lib/lexicon/http-atlas-data-source.ts
@@ -90,8 +90,9 @@ export function resolveAtlasAssetBaseUrl(options?: {
 }
 
 /**
- * Constructor-time base resolution: env override when set, else explicit option,
- * else empty string (backward-compatible for Node fixture fetchers).
+ * Constructor-time base resolution: explicit option when provided (including empty),
+ * else env override when set, else empty string (backward-compatible for Node
+ * fixture fetchers).
  * Product same-origin default `/atlas` is applied by the app shell / 404 page
  * (or by calling {@link resolveAtlasAssetBaseUrl} without an explicit base).
  */

--- a/site/src/lib/lexicon/http-atlas-data-source.ts
+++ b/site/src/lib/lexicon/http-atlas-data-source.ts
@@ -29,8 +29,24 @@ export interface AtlasFetch {
 /** Pluggable gzip decode — browsers use DecompressionStream; Node injects gunzipSync. */
 export type AtlasDecompress = (compressed: Uint8Array) => Promise<Uint8Array> | Uint8Array;
 
+export interface AtlasAssetBaseEnv {
+  /** Vite public env: immutable raw.githubusercontent.com/.../<sha>/… overflow base (R7). */
+  PUBLIC_ATLAS_ASSET_BASE_URL?: string;
+}
+
 export interface HttpAtlasDataSourceOptions {
+  /**
+   * Atlas asset root. Production default is same-origin `/atlas` (PR3 D1).
+   * Overflow escape (R7, design-in): set `PUBLIC_ATLAS_ASSET_BASE_URL` at build
+   * time to an immutable commit-SHA `raw.githubusercontent.com` URL — never a
+   * branch name. Explicit option wins over env.
+   */
   assetBaseUrl?: string;
+  /**
+   * Inject build-time env for tests / Node. Defaults to `import.meta.env` when
+   * available. Only `PUBLIC_ATLAS_ASSET_BASE_URL` is read.
+   */
+  env?: AtlasAssetBaseEnv;
   /**
    * Max age for cached `current.json` / manifest pointer resolution.
    * Default 60s. Set to 0 to re-resolve on every logical request (tests).
@@ -44,6 +60,62 @@ export interface HttpAtlasDataSourceOptions {
 
 /** Default pointer TTL — short enough to observe release rollovers, long enough to amortize fetches. */
 export const DEFAULT_POINTER_TTL_MS = 60_000;
+
+/** Same-origin Pages-vendored tree root (PR3 D1). */
+export const DEFAULT_ATLAS_ASSET_BASE_URL = "/atlas";
+
+/**
+ * Resolve the Atlas asset base URL (R7 overflow hook).
+ *
+ * Precedence: explicit `assetBaseUrl` → `PUBLIC_ATLAS_ASSET_BASE_URL` →
+ * `DEFAULT_ATLAS_ASSET_BASE_URL` (`/atlas`).
+ *
+ * For on-disk fixture fetchers that root at the `atlas/` directory, pass
+ * `assetBaseUrl: ""` so relative paths stay unprefixed.
+ */
+export function resolveAtlasAssetBaseUrl(options?: {
+  assetBaseUrl?: string;
+  env?: AtlasAssetBaseEnv;
+}): string {
+  if (options && Object.prototype.hasOwnProperty.call(options, "assetBaseUrl")) {
+    const explicit = options.assetBaseUrl ?? "";
+    return explicit.replace(/\/$/, "");
+  }
+  const env = options?.env ?? readImportMetaEnv();
+  const fromEnv = env?.PUBLIC_ATLAS_ASSET_BASE_URL?.trim();
+  if (fromEnv) {
+    return fromEnv.replace(/\/$/, "");
+  }
+  return DEFAULT_ATLAS_ASSET_BASE_URL;
+}
+
+/**
+ * Constructor-time base resolution: env override when set, else explicit option,
+ * else empty string (backward-compatible for Node fixture fetchers).
+ * Product same-origin default `/atlas` is applied by the app shell / 404 page
+ * (or by calling {@link resolveAtlasAssetBaseUrl} without an explicit base).
+ */
+function resolveConstructorAssetBaseUrl(options?: HttpAtlasDataSourceOptions): string {
+  if (options && Object.prototype.hasOwnProperty.call(options, "assetBaseUrl")) {
+    return (options.assetBaseUrl ?? "").replace(/\/$/, "");
+  }
+  const env = options?.env ?? readImportMetaEnv();
+  const fromEnv = env?.PUBLIC_ATLAS_ASSET_BASE_URL?.trim();
+  if (fromEnv) {
+    return fromEnv.replace(/\/$/, "");
+  }
+  return "";
+}
+
+function readImportMetaEnv(): AtlasAssetBaseEnv | undefined {
+  try {
+    // Vite injects import.meta.env; guard for non-Vite Node unit contexts.
+    const meta = import.meta as ImportMeta & { env?: AtlasAssetBaseEnv };
+    return meta.env;
+  } catch {
+    return undefined;
+  }
+}
 
 interface CurrentPointer {
   schema: string;
@@ -172,6 +244,7 @@ export class HttpAtlasDataSource implements AtlasDataSource {
   private manifest: RuntimeManifest | null = null;
   private versionDir = "";
   private readonly assetCache = new Map<string, Uint8Array>();
+  private readonly assetBaseUrl: string;
   private readonly pointerTtlMs: number;
   private readonly decompress: AtlasDecompress;
   private readonly now: () => number;
@@ -180,13 +253,15 @@ export class HttpAtlasDataSource implements AtlasDataSource {
     private readonly fetchBytes: AtlasFetch,
     private readonly options?: HttpAtlasDataSourceOptions,
   ) {
+    // Env overflow hook (R7) when assetBaseUrl is omitted; explicit option wins.
+    this.assetBaseUrl = resolveConstructorAssetBaseUrl(options);
     this.pointerTtlMs = options?.pointerTtlMs ?? DEFAULT_POINTER_TTL_MS;
     this.decompress = options?.decompress ?? gunzipWithDecompressionStream;
     this.now = options?.now ?? (() => Date.now());
   }
 
   private assetUrl(relative: string): string {
-    const base = this.options?.assetBaseUrl ?? "";
+    const base = this.assetBaseUrl;
     if (!base) return relative;
     return `${base.replace(/\/$/, "")}/${relative.replace(/^\//, "")}`;
   }

--- a/site/tests/unit/http-atlas-asset-base-url.test.ts
+++ b/site/tests/unit/http-atlas-asset-base-url.test.ts
@@ -1,0 +1,85 @@
+/**
+ * R7 overflow escape hook: PUBLIC_ATLAS_ASSET_BASE_URL / assetBaseUrl override.
+ * Design-in only — proves resolve + HttpAtlasDataSource honor the override.
+ */
+import { describe, expect, test } from "vitest";
+import {
+  DEFAULT_ATLAS_ASSET_BASE_URL,
+  HttpAtlasDataSource,
+  resolveAtlasAssetBaseUrl,
+  type AtlasFetch,
+} from "@site/src/lib/lexicon/http-atlas-data-source";
+
+describe("resolveAtlasAssetBaseUrl (R7 overflow hook)", () => {
+  test("defaults to same-origin /atlas when nothing is set", () => {
+    expect(resolveAtlasAssetBaseUrl({ env: {} })).toBe(DEFAULT_ATLAS_ASSET_BASE_URL);
+    expect(DEFAULT_ATLAS_ASSET_BASE_URL).toBe("/atlas");
+  });
+
+  test("honors immutable raw.githubusercontent.com commit-SHA override via env", () => {
+    const overflow =
+      "https://raw.githubusercontent.com/learn-ukrainian/learn-ukrainian.github.io/0123456789abcdef0123456789abcdef01234567/atlas";
+    expect(
+      resolveAtlasAssetBaseUrl({
+        env: { PUBLIC_ATLAS_ASSET_BASE_URL: overflow },
+      }),
+    ).toBe(overflow);
+  });
+
+  test("explicit assetBaseUrl wins over env", () => {
+    expect(
+      resolveAtlasAssetBaseUrl({
+        assetBaseUrl: "/atlas",
+        env: {
+          PUBLIC_ATLAS_ASSET_BASE_URL:
+            "https://raw.githubusercontent.com/org/repo/deadbeef/atlas",
+        },
+      }),
+    ).toBe("/atlas");
+  });
+
+  test("strips trailing slash from override", () => {
+    expect(
+      resolveAtlasAssetBaseUrl({
+        env: {
+          PUBLIC_ATLAS_ASSET_BASE_URL:
+            "https://raw.githubusercontent.com/org/repo/abc123def456/atlas/",
+        },
+      }),
+    ).toBe("https://raw.githubusercontent.com/org/repo/abc123def456/atlas");
+  });
+});
+
+describe("HttpAtlasDataSource assetBaseUrl env override smoke", () => {
+  test("constructor env override prefixes fetch URLs (overflow path)", async () => {
+    const overflow =
+      "https://raw.githubusercontent.com/learn-ukrainian/learn-ukrainian.github.io/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/atlas";
+    const seen: string[] = [];
+    const fetchBytes: AtlasFetch = async (url) => {
+      seen.push(url);
+      // Minimal valid current.json so resolveSession gets past the first fetch.
+      const body = new TextEncoder().encode(
+        JSON.stringify({
+          schema: "atlas-current",
+          schemaVersion: 1,
+          dataVersion: "v-test",
+          generatedAt: "2026-07-17T00:00:00+00:00",
+          manifestUrl: "versions/v-test/manifest.json",
+        }),
+      );
+      return body;
+    };
+
+    const source = new HttpAtlasDataSource(fetchBytes, {
+      env: { PUBLIC_ATLAS_ASSET_BASE_URL: overflow },
+      pointerTtlMs: 0,
+      // Force decompress not to run — getEntry will fail later; we only need pointer fetch.
+      decompress: (data) => data,
+    });
+
+    // getEntry triggers current.json fetch with the overflow base.
+    await expect(source.getEntry("test-slug")).rejects.toThrow();
+    expect(seen.length).toBeGreaterThanOrEqual(1);
+    expect(seen[0]).toBe(`${overflow}/current.json`);
+  });
+});

--- a/tests/test_deploy_pages_workflow.py
+++ b/tests/test_deploy_pages_workflow.py
@@ -42,3 +42,27 @@ def test_pages_deploy_uses_normal_build_and_fail_closed_size_gate() -> None:
     upload = by_name["Upload artifact"]
     assert steps.index(size_gate) < steps.index(upload)
     assert steps.index(build_site) < steps.index(size_gate)
+
+
+def test_pages_deploy_vendors_atlas_tree_after_build_before_size_gate() -> None:
+    """PR3 D1/R1/R7: feature-flagged atlas vendoring between build and size gate."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["deploy"]["steps"]
+    by_name = {step.get("name"): step for step in steps}
+
+    build_site = by_name["Build Site"]
+    vendor = by_name["Vendor Atlas runtime tree"]
+    size_gate = by_name["Check published-site size (fail-closed)"]
+    upload = by_name["Upload artifact"]
+
+    assert "scripts/deploy/vendor_atlas_tree.py" in vendor["run"]
+    assert vendor["env"]["ATLAS_TREE_ASSET_ID"] == "${{ vars.ATLAS_TREE_ASSET_ID }}"
+    assert vendor["env"]["ATLAS_TREE_SHA256"] == "${{ vars.ATLAS_TREE_SHA256 }}"
+    # Pin is asset id + digest — never a mutable release tag env.
+    env_blob = yaml.safe_dump(vendor.get("env") or {})
+    assert "ATLAS_TREE_TAG" not in env_blob
+    assert "release_tag" not in env_blob
+
+    assert steps.index(build_site) < steps.index(vendor)
+    assert steps.index(vendor) < steps.index(size_gate)
+    assert steps.index(size_gate) < steps.index(upload)

--- a/tests/test_vendor_atlas_tree.py
+++ b/tests/test_vendor_atlas_tree.py
@@ -211,6 +211,36 @@ def test_missing_file_in_manifest_fails_closed(tmp_path: Path) -> None:
         vendor_atlas_tree(tmp_path / "dist", sha256=digest, archive_path=bad)
 
 
+def test_extra_unlisted_file_fails_closed(tmp_path: Path) -> None:
+    """Archive member not in tree-manifest must fail closed (object_count gate)."""
+    tree_root = _build_two_gen_tree(tmp_path)
+    archive, _digest = _archive_for(tree_root, tmp_path)
+    with zipfile.ZipFile(archive, "r") as zf:
+        members = {
+            name: zf.read(name) for name in zf.namelist() if not name.endswith("/")
+        }
+    # Inject a payload under atlas/ that packaging manifest does not list.
+    members["atlas/versions/v-current/sneaky-extra.bin"] = b"unlisted-payload"
+    bad = tmp_path / "extra-unlisted.zip"
+    with zipfile.ZipFile(bad, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    digest = sha256_hex(bad.read_bytes())
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    sentinel = dist / "keep-me.txt"
+    sentinel.write_text("pre-existing", encoding="utf-8")
+
+    with pytest.raises(
+        VendorError,
+        match=r"files not listed in packaging manifest.*object_count=.*listed_file_count=",
+    ):
+        vendor_atlas_tree(dist, sha256=digest, archive_path=bad)
+
+    assert not (dist / "atlas").exists()
+    assert sentinel.read_text(encoding="utf-8") == "pre-existing"
+
+
 def test_missing_prior_generation_fails(tmp_path: Path) -> None:
     tree_root = tmp_path / "tree"
     _mini_generation(tree_root, "v-only", payload=b"solo")

--- a/tests/test_vendor_atlas_tree.py
+++ b/tests/test_vendor_atlas_tree.py
@@ -1,0 +1,318 @@
+"""Tests for deploy-time Atlas tree vendoring (PR3 D1 / R1 / R7)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.deploy.vendor_atlas_tree import (
+    SKIP_MESSAGE,
+    TREE_MANIFEST_REL,
+    VendorError,
+    build_archive_from_tree,
+    main,
+    sha256_hex,
+    vendor_atlas_tree,
+    verify_archive_digest,
+)
+
+
+def _write(path: Path, data: bytes | str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(data, str):
+        path.write_text(data, encoding="utf-8")
+    else:
+        path.write_bytes(data)
+
+
+def _mini_generation(root: Path, data_version: str, *, payload: bytes) -> None:
+    """Write a minimal versions/<dataVersion>/ tree (manifest + one shard)."""
+    version_root = root / "atlas" / "versions" / data_version
+    shard_rel = "entries/p00-0.json.gz"
+    _write(version_root / shard_rel, payload)
+    manifest = {
+        "schema": "atlas-runtime-manifest",
+        "schemaVersion": 1,
+        "dataVersion": data_version,
+        "generatedAt": "2026-07-17T00:00:00+00:00",
+        "entries": {
+            "tree": {"shardId": "p00-0"},
+            "shards": {
+                "p00-0": {
+                    "id": "p00-0",
+                    "url": shard_rel,
+                    "count": 1,
+                    "bytes": len(payload),
+                    "uncompressedBytes": len(payload),
+                    "sha256": sha256_hex(payload),
+                    "jsonSha256": sha256_hex(payload),
+                    "encoding": "gzip",
+                }
+            },
+        },
+        "search": {"articles": {"tree": {}, "shards": {}}, "aliases": {"tree": {}, "shards": {}}},
+        "decks": {"levels": {}},
+        "counts": {"entryShards": 1},
+    }
+    _write(
+        version_root / "manifest.json",
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+    )
+
+
+def _build_two_gen_tree(tmp: Path, *, current: str = "v-current", prior: str = "v-prior") -> Path:
+    """Create tree_root with atlas/current.json + two version dirs."""
+    tree_root = tmp / "tree"
+    _mini_generation(tree_root, prior, payload=b"prior-shard-bytes")
+    _mini_generation(tree_root, current, payload=b"current-shard-bytes")
+    current_doc = {
+        "schema": "atlas-current",
+        "schemaVersion": 1,
+        "dataVersion": current,
+        "generatedAt": "2026-07-17T00:00:00+00:00",
+        "manifestUrl": f"versions/{current}/manifest.json",
+    }
+    _write(
+        tree_root / "atlas" / "current.json",
+        json.dumps(current_doc, ensure_ascii=False, indent=2) + "\n",
+    )
+    return tree_root
+
+
+def _archive_for(tree_root: Path, tmp: Path) -> tuple[Path, str]:
+    archive = tmp / "atlas-tree.zip"
+    digest = build_archive_from_tree(tree_root, archive)
+    return archive, digest
+
+
+def test_happy_path_vendors_current_and_prior(tmp_path: Path) -> None:
+    tree_root = _build_two_gen_tree(tmp_path)
+    archive, digest = _archive_for(tree_root, tmp_path)
+    dist = tmp_path / "dist"
+    metrics_path = tmp_path / "metrics.json"
+
+    # Capture original bytes of a versioned shard for R10 byte-preservation.
+    original_shard = (
+        tree_root / "atlas" / "versions" / "v-current" / "entries" / "p00-0.json.gz"
+    ).read_bytes()
+
+    metrics = vendor_atlas_tree(
+        dist,
+        sha256=digest,
+        archive_path=archive,
+        metrics_path=metrics_path,
+    )
+
+    assert metrics.skipped is False
+    assert metrics.data_version == "v-current"
+    assert "v-prior" in metrics.prior_versions
+    assert metrics.archive_bytes == archive.stat().st_size
+    assert metrics.object_count >= 4
+    assert metrics.extracted_bytes > 0
+    assert metrics.archive_sha256 == digest
+
+    installed_shard = dist / "atlas" / "versions" / "v-current" / "entries" / "p00-0.json.gz"
+    assert installed_shard.read_bytes() == original_shard
+    assert (dist / "atlas" / "versions" / "v-prior" / "manifest.json").is_file()
+    assert (dist / "atlas" / "current.json").is_file()
+    assert (dist / "atlas" / "tree-manifest.json").is_file()
+
+    saved = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert saved["data_version"] == "v-current"
+    assert saved["archive_sha256"] == digest
+
+
+def test_corrupt_archive_sha256_fails_closed(tmp_path: Path) -> None:
+    tree_root = _build_two_gen_tree(tmp_path)
+    archive, digest = _archive_for(tree_root, tmp_path)
+    # Flip one byte after digest pin — checksum gate must abort before install.
+    blob = bytearray(archive.read_bytes())
+    blob[0] = (blob[0] + 1) % 256
+    corrupt = tmp_path / "corrupt.zip"
+    corrupt.write_bytes(bytes(blob))
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    sentinel = dist / "keep-me.txt"
+    sentinel.write_text("pre-existing", encoding="utf-8")
+
+    with pytest.raises(VendorError, match="archive sha256 mismatch"):
+        vendor_atlas_tree(dist, sha256=digest, archive_path=corrupt)
+
+    assert not (dist / "atlas").exists()
+    assert sentinel.read_text(encoding="utf-8") == "pre-existing"
+
+
+def test_verify_archive_digest_direct() -> None:
+    data = b"abc"
+    digest = hashlib.sha256(data).hexdigest()
+    assert verify_archive_digest(data, digest) == digest
+    with pytest.raises(VendorError, match="sha256 mismatch"):
+        verify_archive_digest(data, "0" * 64)
+
+
+def test_manifest_inconsistency_fails_closed(tmp_path: Path) -> None:
+    tree_root = _build_two_gen_tree(tmp_path)
+    archive, _digest = _archive_for(tree_root, tmp_path)
+
+    # Rebuild zip with a size lie in tree-manifest.
+    with zipfile.ZipFile(archive, "r") as zf:
+        members = {name: zf.read(name) for name in zf.namelist() if not name.endswith("/")}
+    manifest = json.loads(members[TREE_MANIFEST_REL].decode("utf-8"))
+    # Point at a real file but claim wrong size.
+    for entry in manifest["files"]:
+        if entry["path"].endswith("p00-0.json.gz"):
+            entry["bytes"] = entry["bytes"] + 99
+            break
+    members[TREE_MANIFEST_REL] = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+    # Also fix the self-size entry for tree-manifest so only the shard size is wrong.
+    for entry in manifest["files"]:
+        if entry["path"] == TREE_MANIFEST_REL:
+            entry["bytes"] = len(members[TREE_MANIFEST_REL])
+    members[TREE_MANIFEST_REL] = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+    for entry in manifest["files"]:
+        if entry["path"] == TREE_MANIFEST_REL:
+            entry["bytes"] = len(members[TREE_MANIFEST_REL])
+    members[TREE_MANIFEST_REL] = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+
+    bad = tmp_path / "bad-manifest.zip"
+    with zipfile.ZipFile(bad, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    bad_digest = sha256_hex(bad.read_bytes())
+
+    with pytest.raises(VendorError, match="size mismatch"):
+        vendor_atlas_tree(tmp_path / "dist", sha256=bad_digest, archive_path=bad)
+
+
+def test_missing_file_in_manifest_fails_closed(tmp_path: Path) -> None:
+    tree_root = _build_two_gen_tree(tmp_path)
+    archive, _digest = _archive_for(tree_root, tmp_path)
+    with zipfile.ZipFile(archive, "r") as zf:
+        members = {name: zf.read(name) for name in zf.namelist() if not name.endswith("/")}
+    manifest = json.loads(members[TREE_MANIFEST_REL].decode("utf-8"))
+    manifest["files"].append({"path": "atlas/versions/v-current/missing.bin", "bytes": 1})
+    members[TREE_MANIFEST_REL] = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+    for entry in manifest["files"]:
+        if entry["path"] == TREE_MANIFEST_REL:
+            entry["bytes"] = len(members[TREE_MANIFEST_REL])
+    members[TREE_MANIFEST_REL] = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+
+    bad = tmp_path / "missing-file.zip"
+    with zipfile.ZipFile(bad, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    digest = sha256_hex(bad.read_bytes())
+
+    with pytest.raises(VendorError, match="missing file"):
+        vendor_atlas_tree(tmp_path / "dist", sha256=digest, archive_path=bad)
+
+
+def test_missing_prior_generation_fails(tmp_path: Path) -> None:
+    tree_root = tmp_path / "tree"
+    _mini_generation(tree_root, "v-only", payload=b"solo")
+    current_doc = {
+        "schema": "atlas-current",
+        "schemaVersion": 1,
+        "dataVersion": "v-only",
+        "generatedAt": "2026-07-17T00:00:00+00:00",
+        "manifestUrl": "versions/v-only/manifest.json",
+    }
+    _write(
+        tree_root / "atlas" / "current.json",
+        json.dumps(current_doc, indent=2) + "\n",
+    )
+    archive, digest = _archive_for(tree_root, tmp_path)
+
+    with pytest.raises(VendorError, match="PRIOR generation"):
+        vendor_atlas_tree(tmp_path / "dist", sha256=digest, archive_path=archive)
+
+
+def test_current_json_pointing_outside_vendored_set_fails(tmp_path: Path) -> None:
+    tree_root = _build_two_gen_tree(tmp_path)
+    # Point current at a generation that is not present under versions/.
+    current_doc = {
+        "schema": "atlas-current",
+        "schemaVersion": 1,
+        "dataVersion": "v-ghost",
+        "generatedAt": "2026-07-17T00:00:00+00:00",
+        "manifestUrl": "versions/v-ghost/manifest.json",
+    }
+    _write(
+        tree_root / "atlas" / "current.json",
+        json.dumps(current_doc, indent=2) + "\n",
+    )
+    archive, digest = _archive_for(tree_root, tmp_path)
+
+    with pytest.raises(VendorError, match="non-vendored generation"):
+        vendor_atlas_tree(tmp_path / "dist", sha256=digest, archive_path=archive)
+
+
+def test_scale_threshold_extracted_fails(tmp_path: Path) -> None:
+    tree_root = _build_two_gen_tree(tmp_path)
+    archive, digest = _archive_for(tree_root, tmp_path)
+    # Fail threshold of 1 byte forces gate trip on any real extract.
+    with pytest.raises(VendorError, match="scale gate: extracted size"):
+        vendor_atlas_tree(
+            tmp_path / "dist",
+            sha256=digest,
+            archive_path=archive,
+            thresholds={
+                "warn_extracted_bytes": 0,
+                "fail_extracted_bytes": 1,
+                "fail_archive_bytes": 10**12,
+                "fail_object_count": 10**9,
+            },
+        )
+
+
+def test_scale_threshold_object_count_fails(tmp_path: Path) -> None:
+    tree_root = _build_two_gen_tree(tmp_path)
+    archive, digest = _archive_for(tree_root, tmp_path)
+    with pytest.raises(VendorError, match="scale gate: object count"):
+        vendor_atlas_tree(
+            tmp_path / "dist",
+            sha256=digest,
+            archive_path=archive,
+            thresholds={
+                "warn_extracted_bytes": 10**12,
+                "fail_extracted_bytes": 10**12,
+                "fail_archive_bytes": 10**12,
+                "fail_object_count": 1,
+            },
+        )
+
+
+def test_skip_when_no_pin_configured(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    dist = tmp_path / "dist"
+    metrics = vendor_atlas_tree(dist, asset_id=None, sha256=None, archive_path=None)
+    assert metrics.skipped is True
+    assert not (dist / "atlas").exists()
+    captured = capsys.readouterr()
+    assert SKIP_MESSAGE in captured.out
+
+
+def test_main_skip_exit_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_TREE_ASSET_ID", raising=False)
+    monkeypatch.delenv("ATLAS_TREE_SHA256", raising=False)
+    monkeypatch.delenv("ATLAS_TREE_ARCHIVE_PATH", raising=False)
+    assert main([str(tmp_path / "dist")]) == 0
+
+
+def test_main_bad_sha_exit_one(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tree_root = _build_two_gen_tree(tmp_path)
+    archive, _digest = _archive_for(tree_root, tmp_path)
+    monkeypatch.delenv("ATLAS_TREE_ASSET_ID", raising=False)
+    assert main([str(tmp_path / "dist"), "--archive", str(archive), "--sha256", "0" * 64]) == 1
+
+
+def test_partial_pin_without_source_skips(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Digest alone without asset id / archive is incomplete → skip (feature flag off).
+    metrics = vendor_atlas_tree(tmp_path / "dist", sha256="ab" * 32, archive_path=None, asset_id=None)
+    assert metrics.skipped is True
+    assert SKIP_MESSAGE in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Atlas migration **slice 3** (spec v2 **R1 / R7 / R10 / D1**): deploy-side vendoring of the Atlas runtime shard tree into the Pages artifact, with integrity gates, generation retention, and scale metrics/thresholds.

Spec: `.claude/atlas-epic/PR3-SPEC-client-word-pages.md` (LOCKED v2).  
Refs #5230

### What changed

1. **`scripts/deploy/vendor_atlas_tree.py`** (new)
   - Downloads a release asset pinned by **immutable asset id + sha256** (`ATLAS_TREE_ASSET_ID` + `ATLAS_TREE_SHA256`) — never a mutable tag name.
   - Fail-closed before install: archive sha256, internal packaging manifest (`atlas/tree-manifest.json` — every listed path exists, sizes match), path-safety on zip members.
   - **R1 generation retention**: requires CURRENT + ≥1 PRIOR under `atlas/versions/`; `current.json` must point at a vendored generation.
   - Installs byte-preserving copy into `<dist>/atlas/` (**R10**).
   - **R7 scale gates**: emits archive/extracted size, object count, vendor duration (stdout + optional JSON metrics); defaults warn ≥512 MiB extracted, fail ≥800 MiB extracted (env-overridable).
   - **Feature flag**: when pin unset → logs `atlas vendoring: no pin configured, skipping` and exits 0 (deploy stays green until 20k publish arc supplies the first pin).

2. **`.github/workflows/deploy-pages.yml`**
   - New step **Vendor Atlas runtime tree** after build / deployment marker, **before** `check_site_size.py` (vendored tree counts against site budget).
   - Pin from repo vars; metrics to `${{ runner.temp }}/atlas-vendor-metrics.json`.

3. **Overflow escape hook (R7, design-in only)**
   - `resolveAtlasAssetBaseUrl` + `PUBLIC_ATLAS_ASSET_BASE_URL` on `HttpAtlasDataSource` for immutable `raw.githubusercontent.com/.../<commit-sha>/…` base. Default product path remains same-origin `/atlas` via app shell. No new transport.

4. **Tests**
   - pytest: happy path, corrupt sha256 fail-closed, manifest inconsistency, missing prior, current outside vendored set, scale thresholds, skip-when-unpinned, workflow ordering.
   - vitest: env override smoke.

### Out of scope (unchanged)

- Publish/enrich pipeline (`scripts/lexicon/…`)
- Shard formats / `current.json` schema
- Real Pages E2E deploy (slice 4)
- Building out the raw.githubusercontent transport

---

## Verification evidence (raw tool output)

### tests pass — pytest

```
.venv/bin/python -m pytest tests/test_vendor_atlas_tree.py tests/test_deploy_pages_workflow.py -v --tb=line

============================= test session starts ==============================
collected 16 items

tests/test_vendor_atlas_tree.py::test_happy_path_vendors_current_and_prior PASSED
tests/test_vendor_atlas_tree.py::test_corrupt_archive_sha256_fails_closed PASSED
tests/test_vendor_atlas_tree.py::test_verify_archive_digest_direct PASSED
tests/test_vendor_atlas_tree.py::test_manifest_inconsistency_fails_closed PASSED
tests/test_vendor_atlas_tree.py::test_missing_file_in_manifest_fails_closed PASSED
tests/test_vendor_atlas_tree.py::test_missing_prior_generation_fails PASSED
tests/test_vendor_atlas_tree.py::test_current_json_pointing_outside_vendored_set_fails PASSED
tests/test_vendor_atlas_tree.py::test_scale_threshold_extracted_fails PASSED
tests/test_vendor_atlas_tree.py::test_scale_threshold_object_count_fails PASSED
tests/test_vendor_atlas_tree.py::test_skip_when_no_pin_configured PASSED
tests/test_vendor_atlas_tree.py::test_main_skip_exit_zero PASSED
tests/test_vendor_atlas_tree.py::test_main_bad_sha_exit_one PASSED
tests/test_vendor_atlas_tree.py::test_partial_pin_without_source_skips PASSED
tests/test_deploy_pages_workflow.py::test_pages_build_installs_atlas_python_dependencies PASSED
tests/test_deploy_pages_workflow.py::test_pages_deploy_uses_normal_build_and_fail_closed_size_gate PASSED
tests/test_deploy_pages_workflow.py::test_pages_deploy_vendors_atlas_tree_after_build_before_size_gate PASSED

============================== 16 passed in 0.21s ==============================
```

### tests pass — vitest (from `site/`)

```
npx vitest run tests/unit/http-atlas-asset-base-url.test.ts

 ✓ tests/unit/http-atlas-asset-base-url.test.ts (5 tests) 3ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### lint clean — ruff

```
.venv/bin/ruff check scripts/deploy/vendor_atlas_tree.py tests/test_vendor_atlas_tree.py tests/test_deploy_pages_workflow.py

All checks passed!
```

### workflow valid — actionlint

```
actionlint not available locally
```

(Binary not installed in this worktree environment; CI may still run actionlint if configured. Workflow YAML also covered by `tests/test_deploy_pages_workflow.py` structure assertions.)

### checksum gate fails closed

```
.venv/bin/python -m pytest tests/test_vendor_atlas_tree.py::test_corrupt_archive_sha256_fails_closed -v --tb=short

tests/test_vendor_atlas_tree.py::test_corrupt_archive_sha256_fails_closed PASSED

============================== 1 passed in 0.09s ===============================
```

(Corrupt zip after pin → `VendorError: archive sha256 mismatch`; `dist/atlas/` not created; pre-existing dist files untouched.)

---

## What was NOT verified

- **Real GitHub Pages deploy** with a live release-asset pin (slice 4 E2E scope; pin not configured yet by design).
- **Network download** of a real asset id in CI (tests use local fixture zips only).
- **`actionlint`** binary (absent locally — stated above).
- Full `atlas-runtime-shards` vitest suite in this worktree (needs native `better-sqlite3` build; unrelated to this diff; our new smoke file passed).

## Spec / reality notes

- Existing deploy-pages.yml already had an atlas **manifest** hydrate/cache path (`lexicon-manifest.json`) for build-time prerender. Slice 3 adds a **separate** runtime-tree vendor step for client-side `/atlas` shards (D1). No conflict requiring a stop: both serve different contracts.
- Packaging archive format introduced here for the pin: zip rooted at `atlas/`, plus internal `atlas/tree-manifest.json` (`schema: atlas-tree-archive-manifest`). Publish arc that emits the release asset must produce this layout (out of scope for this PR).

## Review / merge

- Do **not** enable auto-merge from this worker; independent cross-family review gate first.