### PR TITLE
feat(lexicon): runner PR2 — real-unit ledger, fencing, resume (spec §PR2)

### DIFF
--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -11,7 +11,7 @@ schema_version: 1
 streams:
   atlas-practice:
     title: "Word Atlas + Practice Hub product"
-    epics: [4387, 4700]        # umbrella + UX-quality-wave child board
+    epics: [4387, 4700, 5331]  # umbrella + UX-quality-wave + #5331 fill_local divergence
   atlas-intake:
     title: "Word Atlas full-corpus intake"
     epics: [4220, 4378, 5224]        # intake epic + entry-model DB epic

--- a/scripts/lexicon/runner/__init__.py
+++ b/scripts/lexicon/runner/__init__.py
@@ -1,17 +1,20 @@
-"""Chunked lexicon enrichment runner (#5230 PR1 — engine isolation).
+"""Chunked lexicon enrichment runner (#5230).
 
-PR1 ships the bounded lookup rewrite, sealed CEFR/relations phases, streaming
-I/O, and hard-capped worker subprocesses. Ledger/leases (PR2), network
-cache/packets (PR3), and sealing/assembly (PR4) are typed stubs only.
+PR1: bounded lookup rewrite, sealed CEFR/relations, streaming I/O, hard caps.
+PR2: real-unit ledger, fencing/CAS, resume, attempt caps, operator retry.
+PR3 network cache/packets and PR4 streaming assembly remain stubs.
 """
 
 from __future__ import annotations
 
 from scripts.lexicon.runner.contracts import ENGINE_VERSION, SERIALIZATION_VERSION
+from scripts.lexicon.runner.ledger import Ledger, compute_run_fingerprint
 from scripts.lexicon.runner.offline_engine import enrich_offline_slice
 
 __all__ = [
     "ENGINE_VERSION",
     "SERIALIZATION_VERSION",
+    "Ledger",
+    "compute_run_fingerprint",
     "enrich_offline_slice",
 ]

--- a/scripts/lexicon/runner/contracts.py
+++ b/scripts/lexicon/runner/contracts.py
@@ -6,11 +6,12 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Literal
 
-ENGINE_VERSION = "runner-pr1-v1"
+ENGINE_VERSION = "runner-pr2-v1"
 SERIALIZATION_VERSION = "lemma-artifact-v1"
 CEFR_ALGORITHM_VERSION = "grac-cohort-quantile-v1"
 RELATION_CLOSURE_VERSION = "reciprocal-closure-v1"
 SIDE_DB_SCHEMA_VERSION = "side-db-v1"
+LEDGER_SCHEMA_VERSION = "ledger-v1"
 
 # Host memory policy (16 GiB local host). Platform/VPS ceilings are selected
 # below physical RAM with explicit OS headroom — never copy 8/10 onto a smaller host.
@@ -19,19 +20,25 @@ DEFAULT_MEMORY_MAX_BYTES = 10 * 1024**3
 
 
 class ChunkState(StrEnum):
-    """Chunk lifecycle states used by PR1 splits (ledger vocabulary expands in PR2)."""
+    """Chunk lifecycle states (PR1 splits + PR2 ledger vocabulary)."""
 
     PENDING = "pending"
+    LEASED = "leased"
     RUNNING = "running"
     DONE = "done"
     SUPERSEDED = "superseded"
     FAILED_TERMINAL = "failed_terminal"
+    SEALED = "sealed"
+    RETRY_SCHEDULED = "retry_scheduled"
 
 
 class ErrorCode(StrEnum):
     FAILED_OOM = "failed_oom"
     FINGERPRINT_MISMATCH_REFUSED = "fingerprint_mismatch_refused"
     STALE_COMMIT_REJECTED = "stale_commit_rejected"
+    DUPLICATE_RUNNER_REFUSED = "duplicate_runner_refused"
+    ATTEMPT_CAP_EXHAUSTED = "attempt_cap_exhausted"
+    LEASE_RECLAIMED = "lease_reclaimed"
 
 
 PhaseOutcome = Literal["done", "no_data", "failed_terminal", "retry_scheduled"]
@@ -91,16 +98,19 @@ class OomSplitChildren:
     split_epoch: int
 
 
-# --- PR2/PR3/PR4 stubs (interfaces only; not implemented in PR1) ---
+# --- PR3/PR4 stubs (PR2 ledger is real — see scripts/lexicon/runner/ledger.py) ---
 
 
 @dataclass(frozen=True, slots=True)
 class LedgerStub:
-    """PR2: real-unit ledger, fencing, leases. PR1 does not open this for writing."""
+    """Compatibility handle pointing at a real PR2 ledger run.
+
+    Prefer :class:`scripts.lexicon.runner.ledger.Ledger` for all writes.
+    """
 
     run_id: str
     fingerprint: str
-    note: str = "PR2 stub — ledger/leases/fencing not implemented in PR1"
+    note: str = "PR2 real-unit ledger (see scripts.lexicon.runner.ledger.Ledger)"
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,15 +118,19 @@ class PacketStub:
     """PR3: content-addressed request packet (.tar.zst)."""
 
     packet_id: str
-    note: str = "PR3 stub — network cache/packets not implemented in PR1"
+    note: str = "PR3 stub — network cache/packets not implemented in PR1/PR2"
 
 
 @dataclass(frozen=True, slots=True)
 class SealStub:
-    """PR4: leaf seal transaction + streaming assembly."""
+    """PR4: full streaming assembly + publication gate.
+
+    Leaf seal *transactions* are implemented in PR2 (CAS + leaf-only rules);
+    final streaming assembly remains PR4.
+    """
 
     chunk_id: str
-    note: str = "PR4 stub — leaf sealing/assembly not implemented in PR1"
+    note: str = "PR4 stub — streaming assembly/publication not implemented in PR2"
 
 
 def canonical_json(obj: Any) -> str:

--- a/scripts/lexicon/runner/ledger.py
+++ b/scripts/lexicon/runner/ledger.py
@@ -1,0 +1,1679 @@
+"""Real-unit ledger, fencing, and resume (#5230 PR2).
+
+Implements the LOCKED design in ENRICH-RUNNER-SPEC-v2.md §2, §6–§8:
+
+- durable SQLite ledger with exclusive single-writer OS lock
+- transactional claims with monotonic ``lease_generation``
+- CAS on heartbeat / result / split / import / seal
+- state vocabulary + total attempt caps + operator retry records
+- fingerprint start/resume refusal and ``fingerprint_mismatch_refused``
+- deterministic OOM-split child IDs with ``superseded`` parents + leaf-only seals
+
+Workers never open this ledger for writing. Only the coordinator does.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import hashlib
+import json
+import sqlite3
+import time
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Literal
+
+from scripts.lexicon.runner.contracts import (
+    ENGINE_VERSION,
+    LEDGER_SCHEMA_VERSION,
+    SERIALIZATION_VERSION,
+    ErrorCode,
+    PhaseOutcome,
+    canonical_json,
+)
+from scripts.lexicon.runner.split import child_chunk_id, split_on_oom
+
+# Total automatic attempts per (run, unit, phase). Exhaustion → failed_terminal;
+# only an audited operator action may reopen (spec §6).
+DEFAULT_MAX_ATTEMPTS = 5
+
+# Active-computation lease wall-clock; heartbeats extend. Transport holds no lease.
+DEFAULT_LEASE_TTL_SECONDS = 300
+
+
+class RunStatus(StrEnum):
+    RUNNING = "running"
+    COMPLETED = "completed"
+    ABANDONED = "abandoned"
+
+
+class SchedulableState(StrEnum):
+    """Schedulable unit states (spec §6)."""
+
+    PENDING = "pending"
+    LEASED = "leased"
+
+
+class UnitOutcome(StrEnum):
+    """Terminal / phase outcomes (spec §6)."""
+
+    DONE = "done"
+    NO_DATA = "no_data"
+    FAILED_TERMINAL = "failed_terminal"
+    RETRY_SCHEDULED = "retry_scheduled"
+
+
+class ChunkLedgerState(StrEnum):
+    PENDING = "pending"
+    LEASED = "leased"
+    DONE = "done"
+    SUPERSEDED = "superseded"
+    FAILED_TERMINAL = "failed_terminal"
+    SEALED = "sealed"
+
+
+class CasStatus(StrEnum):
+    OK = "ok"
+    STALE_COMMIT_REJECTED = "stale_commit_rejected"
+    FINGERPRINT_MISMATCH_REFUSED = "fingerprint_mismatch_refused"
+    DUPLICATE_RUNNER_REFUSED = "duplicate_runner_refused"
+    ATTEMPT_CAP_EXHAUSTED = "attempt_cap_exhausted"
+    NOT_FOUND = "not_found"
+    INVALID_STATE = "invalid_state"
+    NOT_LEAF = "not_leaf"
+    LOCK_REQUIRED = "lock_required"
+
+
+class OperatorActionKind(StrEnum):
+    RETRY_FAILED = "retry_failed"
+    ABANDON_PACKET = "abandon_packet"
+    ACCEPT_FAILED = "accept_failed"
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS runs (
+    run_id TEXT PRIMARY KEY,
+    fingerprint TEXT NOT NULL,
+    status TEXT NOT NULL,
+    manual_retry_epoch INTEGER NOT NULL DEFAULT 0,
+    engine_version TEXT NOT NULL,
+    serialization_version TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    config_json TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_runs_fingerprint ON runs(fingerprint);
+
+CREATE TABLE IF NOT EXISTS run_phases (
+    run_id TEXT NOT NULL,
+    phase TEXT NOT NULL,
+    state TEXT NOT NULL,
+    seal_sha256 TEXT,
+    generation INTEGER NOT NULL DEFAULT 0,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (run_id, phase),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    run_id TEXT NOT NULL,
+    chunk_id TEXT NOT NULL,
+    parent_chunk_id TEXT,
+    split_epoch INTEGER NOT NULL DEFAULT 0,
+    lemma_ids_json TEXT NOT NULL,
+    state TEXT NOT NULL,
+    is_leaf INTEGER NOT NULL DEFAULT 1,
+    lease_generation INTEGER NOT NULL DEFAULT 0,
+    owner TEXT,
+    leased_until REAL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    result_hash TEXT,
+    error_code TEXT,
+    seal_sha256 TEXT,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (run_id, chunk_id),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_state ON chunks(run_id, state);
+
+CREATE TABLE IF NOT EXISTS work_units (
+    run_id TEXT NOT NULL,
+    unit_id TEXT NOT NULL,
+    unit_kind TEXT NOT NULL,
+    phase TEXT NOT NULL,
+    state TEXT NOT NULL,
+    lease_generation INTEGER NOT NULL DEFAULT 0,
+    owner TEXT,
+    leased_until REAL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    result_hash TEXT,
+    error_code TEXT,
+    packet_generation INTEGER NOT NULL DEFAULT 0,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (run_id, unit_id, phase),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_units_state ON work_units(run_id, phase, state);
+
+CREATE TABLE IF NOT EXISTS host_cooldowns (
+    host TEXT PRIMARY KEY,
+    next_allowed_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS packets (
+    run_id TEXT NOT NULL,
+    packet_id TEXT NOT NULL,
+    generation INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    content_hash TEXT,
+    created_at REAL NOT NULL,
+    abandoned_at REAL,
+    PRIMARY KEY (run_id, packet_id, generation),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE TABLE IF NOT EXISTS imports (
+    run_id TEXT NOT NULL,
+    lemma_id TEXT NOT NULL,
+    packet_generation INTEGER NOT NULL,
+    result_hash TEXT NOT NULL,
+    lease_generation INTEGER NOT NULL,
+    owner TEXT NOT NULL,
+    imported_at REAL NOT NULL,
+    PRIMARY KEY (run_id, lemma_id, packet_generation),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE TABLE IF NOT EXISTS seals (
+    run_id TEXT NOT NULL,
+    chunk_id TEXT NOT NULL,
+    seal_sha256 TEXT NOT NULL,
+    lemma_ids_json TEXT NOT NULL,
+    lease_generation INTEGER NOT NULL,
+    owner TEXT NOT NULL,
+    sealed_at REAL NOT NULL,
+    PRIMARY KEY (run_id, chunk_id),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE TABLE IF NOT EXISTS operator_actions (
+    action_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    unit_id TEXT,
+    phase TEXT,
+    created_at REAL NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT,
+    event TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}'
+);
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class CasResult:
+    status: CasStatus
+    detail: str = ""
+    lease_generation: int | None = None
+    run_id: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status is CasStatus.OK
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimResult:
+    status: CasStatus
+    unit_id: str
+    lease_generation: int | None = None
+    attempt_count: int | None = None
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status is CasStatus.OK
+
+
+@dataclass(frozen=True, slots=True)
+class StartRunResult:
+    status: CasStatus
+    run_id: str | None = None
+    resumable_run_id: str | None = None
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status is CasStatus.OK
+
+
+@dataclass(frozen=True, slots=True)
+class ResumeRunResult:
+    status: CasStatus
+    run_id: str | None = None
+    fingerprint: str | None = None
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status is CasStatus.OK
+
+
+def compute_run_fingerprint(
+    *,
+    cohort_digest: str,
+    engine_version: str = ENGINE_VERSION,
+    serialization_version: str = SERIALIZATION_VERSION,
+    enrichment_config: dict[str, Any] | None = None,
+    source_digests: dict[str, str] | None = None,
+    side_db_digests: dict[str, str] | None = None,
+    cefr_versions: dict[str, str] | None = None,
+    relation_versions: dict[str, str] | None = None,
+    network_versions: dict[str, str] | None = None,
+) -> str:
+    """Deterministic run fingerprint (spec §2)."""
+    payload = {
+        "cohort_digest": cohort_digest,
+        "engine_version": engine_version,
+        "serialization_version": serialization_version,
+        "enrichment_config": enrichment_config or {},
+        "source_digests": source_digests or {},
+        "side_db_digests": side_db_digests or {},
+        "cefr_versions": cefr_versions or {},
+        "relation_versions": relation_versions or {},
+        "network_versions": network_versions or {},
+        "ledger_schema": LEDGER_SCHEMA_VERSION,
+    }
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+class DuplicateRunnerError(RuntimeError):
+    """Raised when a second coordinator tries to open the same ledger for writing."""
+
+
+class Ledger:
+    """Single-writer durable ledger for real lemma/chunk units."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS,
+        owner_id: str | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.max_attempts = int(max_attempts)
+        self.lease_ttl_seconds = float(lease_ttl_seconds)
+        self.owner_id = owner_id or f"coord-{uuid.uuid4().hex[:12]}"
+        self._conn: sqlite3.Connection | None = None
+        self._lock_fh: Any | None = None
+        self._locked = False
+        # Crash-injection points for tests (no-ops in production).
+        self.crash_after_claim = False
+        self.crash_mid_split = False
+        self.crash_mid_seal = False
+        self.crash_after_result = False
+
+    # --- lock + open ---------------------------------------------------------
+
+    def open(self, *, create: bool = True) -> None:
+        """Open the ledger DB and acquire the exclusive single-writer OS lock."""
+        if self._conn is not None:
+            return
+        if create:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_fh = open(lock_path, "a+", encoding="utf-8")  # noqa: SIM115
+        try:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            lock_fh.close()
+            raise DuplicateRunnerError(
+                f"duplicate runner refused: ledger lock held on {lock_path}"
+            ) from exc
+        self._lock_fh = lock_fh
+        self._locked = True
+        lock_fh.seek(0)
+        lock_fh.truncate()
+        lock_fh.write(f"{self.owner_id}\n{time.time():.6f}\n")
+        lock_fh.flush()
+
+        self._conn = sqlite3.connect(self.path, isolation_level=None)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA synchronous = FULL")
+        self._conn.executescript(SCHEMA_SQL)
+        self._conn.execute(
+            "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+            ("schema_version", LEDGER_SCHEMA_VERSION),
+        )
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+        if self._lock_fh is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(self._lock_fh.fileno(), fcntl.LOCK_UN)
+            self._lock_fh.close()
+            self._lock_fh = None
+        self._locked = False
+
+    def __enter__(self) -> Ledger:
+        self.open()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def _require(self) -> sqlite3.Connection:
+        if self._conn is None or not self._locked:
+            raise RuntimeError("ledger not open under exclusive writer lock")
+        return self._conn
+
+    def _now(self, now: float | None = None) -> float:
+        return time.time() if now is None else float(now)
+
+    def _event(self, event: str, run_id: str | None = None, **payload: Any) -> None:
+        conn = self._require()
+        conn.execute(
+            "INSERT INTO events(run_id, event, created_at, payload_json) VALUES (?, ?, ?, ?)",
+            (run_id, event, self._now(), canonical_json(payload)),
+        )
+
+    # --- run lifecycle / fingerprint -----------------------------------------
+
+    def find_incomplete_by_fingerprint(self, fingerprint: str) -> str | None:
+        conn = self._require()
+        row = conn.execute(
+            "SELECT run_id FROM runs WHERE fingerprint = ? AND status = ? "
+            "ORDER BY created_at DESC LIMIT 1",
+            (fingerprint, RunStatus.RUNNING.value),
+        ).fetchone()
+        return None if row is None else str(row["run_id"])
+
+    def start_run(
+        self,
+        fingerprint: str,
+        *,
+        force_new: bool = False,
+        config: dict[str, Any] | None = None,
+        now: float | None = None,
+    ) -> StartRunResult:
+        """``start``: refuse duplication of an incomplete same-fingerprint run."""
+        conn = self._require()
+        ts = self._now(now)
+        if not force_new:
+            existing = self.find_incomplete_by_fingerprint(fingerprint)
+            if existing is not None:
+                self._event(
+                    "fingerprint_reuse_refused",
+                    existing,
+                    fingerprint=fingerprint,
+                    resumable_run_id=existing,
+                )
+                return StartRunResult(
+                    status=CasStatus.INVALID_STATE,
+                    resumable_run_id=existing,
+                    detail=(
+                        f"incomplete run already exists for fingerprint; "
+                        f"resume run_id={existing}"
+                    ),
+                )
+        run_id = f"run-{uuid.uuid4().hex}"
+        conn.execute(
+            "INSERT INTO runs("
+            "run_id, fingerprint, status, manual_retry_epoch, "
+            "engine_version, serialization_version, created_at, updated_at, config_json"
+            ") VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?)",
+            (
+                run_id,
+                fingerprint,
+                RunStatus.RUNNING.value,
+                ENGINE_VERSION,
+                SERIALIZATION_VERSION,
+                ts,
+                ts,
+                canonical_json(config or {}),
+            ),
+        )
+        self._event("run_started", run_id, fingerprint=fingerprint, force_new=force_new)
+        return StartRunResult(status=CasStatus.OK, run_id=run_id)
+
+    def resume_run(
+        self,
+        run_id: str,
+        fingerprint: str,
+        *,
+        now: float | None = None,
+    ) -> ResumeRunResult:
+        """``resume --run-id``: require exact fingerprint match."""
+        conn = self._require()
+        row = conn.execute(
+            "SELECT run_id, fingerprint, status FROM runs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            return ResumeRunResult(
+                status=CasStatus.NOT_FOUND,
+                detail=f"run_id {run_id!r} not found",
+            )
+        if str(row["fingerprint"]) != fingerprint:
+            self._event(
+                ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value,
+                run_id,
+                expected=str(row["fingerprint"]),
+                got=fingerprint,
+            )
+            return ResumeRunResult(
+                status=CasStatus.FINGERPRINT_MISMATCH_REFUSED,
+                run_id=run_id,
+                fingerprint=str(row["fingerprint"]),
+                detail="fingerprint_mismatch_refused",
+            )
+        if str(row["status"]) == RunStatus.ABANDONED.value:
+            return ResumeRunResult(
+                status=CasStatus.INVALID_STATE,
+                run_id=run_id,
+                fingerprint=fingerprint,
+                detail="run is abandoned",
+            )
+        ts = self._now(now)
+        conn.execute(
+            "UPDATE runs SET updated_at = ? WHERE run_id = ?",
+            (ts, run_id),
+        )
+        self._event("run_resumed", run_id, fingerprint=fingerprint)
+        return ResumeRunResult(
+            status=CasStatus.OK,
+            run_id=run_id,
+            fingerprint=fingerprint,
+        )
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        conn = self._require()
+        row = conn.execute("SELECT * FROM runs WHERE run_id = ?", (run_id,)).fetchone()
+        return None if row is None else dict(row)
+
+    def mark_run_completed(self, run_id: str, *, now: float | None = None) -> None:
+        conn = self._require()
+        conn.execute(
+            "UPDATE runs SET status = ?, updated_at = ? WHERE run_id = ?",
+            (RunStatus.COMPLETED.value, self._now(now), run_id),
+        )
+        self._event("run_completed", run_id)
+
+    # --- registration --------------------------------------------------------
+
+    def set_phase(
+        self,
+        run_id: str,
+        phase: str,
+        state: str,
+        *,
+        seal_sha256: str | None = None,
+        now: float | None = None,
+    ) -> None:
+        conn = self._require()
+        ts = self._now(now)
+        row = conn.execute(
+            "SELECT generation FROM run_phases WHERE run_id = ? AND phase = ?",
+            (run_id, phase),
+        ).fetchone()
+        gen = 0 if row is None else int(row["generation"]) + 1
+        conn.execute(
+            "INSERT INTO run_phases(run_id, phase, state, seal_sha256, generation, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(run_id, phase) DO UPDATE SET "
+            "state=excluded.state, seal_sha256=excluded.seal_sha256, "
+            "generation=excluded.generation, updated_at=excluded.updated_at",
+            (run_id, phase, state, seal_sha256, gen, ts),
+        )
+
+    def register_chunk(
+        self,
+        run_id: str,
+        chunk_id: str,
+        lemma_ids: Sequence[str],
+        *,
+        parent_chunk_id: str | None = None,
+        split_epoch: int = 0,
+        is_leaf: bool = True,
+        state: str = ChunkLedgerState.PENDING.value,
+        now: float | None = None,
+    ) -> None:
+        conn = self._require()
+        ts = self._now(now)
+        conn.execute(
+            "INSERT OR IGNORE INTO chunks("
+            "run_id, chunk_id, parent_chunk_id, split_epoch, lemma_ids_json, state, "
+            "is_leaf, lease_generation, owner, leased_until, attempt_count, updated_at"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, 0, ?)",
+            (
+                run_id,
+                chunk_id,
+                parent_chunk_id,
+                int(split_epoch),
+                canonical_json(list(lemma_ids)),
+                state,
+                1 if is_leaf else 0,
+                ts,
+            ),
+        )
+
+    def register_work_unit(
+        self,
+        run_id: str,
+        unit_id: str,
+        *,
+        unit_kind: Literal["lemma", "chunk"] = "lemma",
+        phase: str = "offline_enrich",
+        state: str = SchedulableState.PENDING.value,
+        now: float | None = None,
+    ) -> None:
+        conn = self._require()
+        ts = self._now(now)
+        conn.execute(
+            "INSERT OR IGNORE INTO work_units("
+            "run_id, unit_id, unit_kind, phase, state, lease_generation, owner, "
+            "leased_until, attempt_count, packet_generation, updated_at"
+            ") VALUES (?, ?, ?, ?, ?, 0, NULL, NULL, 0, 0, ?)",
+            (run_id, unit_id, unit_kind, phase, state, ts),
+        )
+
+    def register_chunk_work_units(
+        self,
+        run_id: str,
+        chunks: Sequence[tuple[str, Sequence[str]]],
+        *,
+        phase: str = "offline_enrich",
+        now: float | None = None,
+    ) -> None:
+        """Register chunk rows + one work unit per chunk (scheduling unit)."""
+        for chunk_id, lemma_ids in chunks:
+            self.register_chunk(run_id, chunk_id, lemma_ids, now=now)
+            self.register_work_unit(
+                run_id,
+                chunk_id,
+                unit_kind="chunk",
+                phase=phase,
+                now=now,
+            )
+            for lemma_id in lemma_ids:
+                self.register_work_unit(
+                    run_id,
+                    lemma_id,
+                    unit_kind="lemma",
+                    phase=phase,
+                    now=now,
+                )
+
+    # --- reclaim expired leases ----------------------------------------------
+
+    def reclaim_expired(
+        self,
+        run_id: str,
+        *,
+        now: float | None = None,
+    ) -> list[str]:
+        """Release expired leases to pending; next claim increments generation."""
+        conn = self._require()
+        ts = self._now(now)
+        reclaimed: list[str] = []
+        rows = conn.execute(
+            "SELECT unit_id, phase, lease_generation FROM work_units "
+            "WHERE run_id = ? AND state = ? AND leased_until IS NOT NULL AND leased_until < ?",
+            (run_id, SchedulableState.LEASED.value, ts),
+        ).fetchall()
+        for row in rows:
+            conn.execute(
+                "UPDATE work_units SET state = ?, owner = NULL, leased_until = NULL, "
+                "updated_at = ? WHERE run_id = ? AND unit_id = ? AND phase = ? "
+                "AND lease_generation = ? AND state = ?",
+                (
+                    SchedulableState.PENDING.value,
+                    ts,
+                    run_id,
+                    row["unit_id"],
+                    row["phase"],
+                    int(row["lease_generation"]),
+                    SchedulableState.LEASED.value,
+                ),
+            )
+            reclaimed.append(str(row["unit_id"]))
+            self._event(
+                "lease_reclaimed",
+                run_id,
+                unit_id=str(row["unit_id"]),
+                phase=str(row["phase"]),
+                lease_generation=int(row["lease_generation"]),
+            )
+        # Chunk rows mirror work-unit leases when used as scheduling units.
+        crows = conn.execute(
+            "SELECT chunk_id, lease_generation FROM chunks "
+            "WHERE run_id = ? AND state = ? AND leased_until IS NOT NULL AND leased_until < ?",
+            (run_id, ChunkLedgerState.LEASED.value, ts),
+        ).fetchall()
+        for row in crows:
+            conn.execute(
+                "UPDATE chunks SET state = ?, owner = NULL, leased_until = NULL, "
+                "updated_at = ? WHERE run_id = ? AND chunk_id = ? "
+                "AND lease_generation = ? AND state = ?",
+                (
+                    ChunkLedgerState.PENDING.value,
+                    ts,
+                    run_id,
+                    row["chunk_id"],
+                    int(row["lease_generation"]),
+                    ChunkLedgerState.LEASED.value,
+                ),
+            )
+            if str(row["chunk_id"]) not in reclaimed:
+                reclaimed.append(str(row["chunk_id"]))
+        return reclaimed
+
+    # --- claim / heartbeat / result ------------------------------------------
+
+    def claim_unit(
+        self,
+        run_id: str,
+        unit_id: str,
+        owner: str,
+        *,
+        phase: str = "offline_enrich",
+        now: float | None = None,
+        host: str | None = None,
+    ) -> ClaimResult:
+        """Transactional claim: increments monotonic lease_generation."""
+        conn = self._require()
+        ts = self._now(now)
+        if host is not None:
+            cool = conn.execute(
+                "SELECT next_allowed_at FROM host_cooldowns WHERE host = ?",
+                (host,),
+            ).fetchone()
+            if cool is not None and float(cool["next_allowed_at"]) > ts:
+                return ClaimResult(
+                    status=CasStatus.INVALID_STATE,
+                    unit_id=unit_id,
+                    detail=f"host cooldown until {cool['next_allowed_at']}",
+                )
+
+        self.reclaim_expired(run_id, now=ts)
+        row = conn.execute(
+            "SELECT * FROM work_units WHERE run_id = ? AND unit_id = ? AND phase = ?",
+            (run_id, unit_id, phase),
+        ).fetchone()
+        if row is None:
+            return ClaimResult(status=CasStatus.NOT_FOUND, unit_id=unit_id, detail="unit missing")
+
+        state = str(row["state"])
+        attempt_count = int(row["attempt_count"])
+        if state in {
+            UnitOutcome.DONE.value,
+            UnitOutcome.NO_DATA.value,
+            UnitOutcome.FAILED_TERMINAL.value,
+            ChunkLedgerState.SEALED.value,
+            ChunkLedgerState.SUPERSEDED.value,
+        }:
+            return ClaimResult(
+                status=CasStatus.INVALID_STATE,
+                unit_id=unit_id,
+                detail=f"unit not claimable in state={state}",
+            )
+        if state == SchedulableState.LEASED.value and float(row["leased_until"] or 0) >= ts:
+            return ClaimResult(
+                status=CasStatus.INVALID_STATE,
+                unit_id=unit_id,
+                detail="unit already leased",
+            )
+        if attempt_count >= self.max_attempts:
+            conn.execute(
+                "UPDATE work_units SET state = ?, error_code = ?, updated_at = ? "
+                "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+                (
+                    UnitOutcome.FAILED_TERMINAL.value,
+                    "attempt_cap_exhausted",
+                    ts,
+                    run_id,
+                    unit_id,
+                    phase,
+                ),
+            )
+            self._event(
+                "attempt_cap_exhausted",
+                run_id,
+                unit_id=unit_id,
+                phase=phase,
+                attempt_count=attempt_count,
+            )
+            return ClaimResult(
+                status=CasStatus.ATTEMPT_CAP_EXHAUSTED,
+                unit_id=unit_id,
+                attempt_count=attempt_count,
+                detail="total automatic attempts exhausted",
+            )
+
+        new_gen = int(row["lease_generation"]) + 1
+        new_attempts = attempt_count + 1
+        leased_until = ts + self.lease_ttl_seconds
+        cur = conn.execute(
+            "UPDATE work_units SET state = ?, lease_generation = ?, owner = ?, "
+            "leased_until = ?, attempt_count = ?, updated_at = ? "
+            "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+            "AND lease_generation = ? AND state IN (?, ?, ?)",
+            (
+                SchedulableState.LEASED.value,
+                new_gen,
+                owner,
+                leased_until,
+                new_attempts,
+                ts,
+                run_id,
+                unit_id,
+                phase,
+                int(row["lease_generation"]),
+                SchedulableState.PENDING.value,
+                UnitOutcome.RETRY_SCHEDULED.value,
+                SchedulableState.LEASED.value,
+            ),
+        )
+        if cur.rowcount != 1:
+            return ClaimResult(
+                status=CasStatus.STALE_COMMIT_REJECTED,
+                unit_id=unit_id,
+                detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+            )
+
+        # Keep chunk row in sync when unit is a chunk scheduling unit.
+        conn.execute(
+            "UPDATE chunks SET state = ?, lease_generation = ?, owner = ?, "
+            "leased_until = ?, attempt_count = ?, updated_at = ? "
+            "WHERE run_id = ? AND chunk_id = ? AND is_leaf = 1 "
+            "AND state IN (?, ?)",
+            (
+                ChunkLedgerState.LEASED.value,
+                new_gen,
+                owner,
+                leased_until,
+                new_attempts,
+                ts,
+                run_id,
+                unit_id,
+                ChunkLedgerState.PENDING.value,
+                ChunkLedgerState.LEASED.value,
+            ),
+        )
+        self._event(
+            "chunk_claimed" if str(row["unit_kind"]) == "chunk" else "unit_claimed",
+            run_id,
+            unit_id=unit_id,
+            phase=phase,
+            lease_generation=new_gen,
+            owner=owner,
+            attempt_count=new_attempts,
+        )
+        if self.crash_after_claim:
+            raise RuntimeError("injected crash: after_claim")
+        return ClaimResult(
+            status=CasStatus.OK,
+            unit_id=unit_id,
+            lease_generation=new_gen,
+            attempt_count=new_attempts,
+        )
+
+    def heartbeat(
+        self,
+        run_id: str,
+        unit_id: str,
+        owner: str,
+        lease_generation: int,
+        *,
+        phase: str = "offline_enrich",
+        now: float | None = None,
+    ) -> CasResult:
+        """CAS heartbeat: only the current owner+generation may extend the lease."""
+        conn = self._require()
+        ts = self._now(now)
+        leased_until = ts + self.lease_ttl_seconds
+        cur = conn.execute(
+            "UPDATE work_units SET leased_until = ?, updated_at = ? "
+            "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+            "AND owner = ? AND lease_generation = ? AND state = ?",
+            (
+                leased_until,
+                ts,
+                run_id,
+                unit_id,
+                phase,
+                owner,
+                int(lease_generation),
+                SchedulableState.LEASED.value,
+            ),
+        )
+        if cur.rowcount != 1:
+            self._event(
+                ErrorCode.STALE_COMMIT_REJECTED.value,
+                run_id,
+                unit_id=unit_id,
+                op="heartbeat",
+                lease_generation=lease_generation,
+                owner=owner,
+            )
+            return CasResult(
+                status=CasStatus.STALE_COMMIT_REJECTED,
+                detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                lease_generation=lease_generation,
+                run_id=run_id,
+            )
+        conn.execute(
+            "UPDATE chunks SET leased_until = ?, updated_at = ? "
+            "WHERE run_id = ? AND chunk_id = ? AND owner = ? AND lease_generation = ?",
+            (leased_until, ts, run_id, unit_id, owner, int(lease_generation)),
+        )
+        return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
+
+    def commit_result(
+        self,
+        run_id: str,
+        unit_id: str,
+        owner: str,
+        lease_generation: int,
+        outcome: PhaseOutcome | str,
+        *,
+        result_hash: str | None = None,
+        error_code: str | None = None,
+        phase: str = "offline_enrich",
+        now: float | None = None,
+    ) -> CasResult:
+        """CAS result commit for a work unit."""
+        conn = self._require()
+        ts = self._now(now)
+        outcome_s = str(outcome)
+        if outcome_s not in {
+            UnitOutcome.DONE.value,
+            UnitOutcome.NO_DATA.value,
+            UnitOutcome.FAILED_TERMINAL.value,
+            UnitOutcome.RETRY_SCHEDULED.value,
+        }:
+            return CasResult(
+                status=CasStatus.INVALID_STATE,
+                detail=f"invalid outcome {outcome_s!r}",
+            )
+        new_state = outcome_s
+        # All outcomes release the active lease; retry_scheduled returns to pending
+        # so the scheduler can reclaim after cooldown without holding owner.
+        cur = conn.execute(
+            "UPDATE work_units SET state = ?, result_hash = ?, error_code = ?, "
+            "owner = NULL, leased_until = NULL, updated_at = ? "
+            "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+            "AND owner = ? AND lease_generation = ? AND state = ?",
+            (
+                new_state,
+                result_hash,
+                error_code,
+                ts,
+                run_id,
+                unit_id,
+                phase,
+                owner,
+                int(lease_generation),
+                SchedulableState.LEASED.value,
+            ),
+        )
+        if cur.rowcount != 1:
+            self._event(
+                ErrorCode.STALE_COMMIT_REJECTED.value,
+                run_id,
+                unit_id=unit_id,
+                op="commit_result",
+                lease_generation=lease_generation,
+                owner=owner,
+            )
+            return CasResult(
+                status=CasStatus.STALE_COMMIT_REJECTED,
+                detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                lease_generation=lease_generation,
+                run_id=run_id,
+            )
+        # Mirror terminal outcomes onto chunk rows when unit is a chunk.
+        chunk_state = {
+            UnitOutcome.DONE.value: ChunkLedgerState.DONE.value,
+            UnitOutcome.NO_DATA.value: ChunkLedgerState.DONE.value,
+            UnitOutcome.FAILED_TERMINAL.value: ChunkLedgerState.FAILED_TERMINAL.value,
+            UnitOutcome.RETRY_SCHEDULED.value: ChunkLedgerState.PENDING.value,
+        }[new_state]
+        conn.execute(
+            "UPDATE chunks SET state = ?, result_hash = ?, error_code = ?, "
+            "owner = NULL, leased_until = NULL, updated_at = ? "
+            "WHERE run_id = ? AND chunk_id = ? AND lease_generation = ?",
+            (
+                chunk_state,
+                result_hash,
+                error_code,
+                ts,
+                run_id,
+                unit_id,
+                int(lease_generation),
+            ),
+        )
+        self._event(
+            "result_committed",
+            run_id,
+            unit_id=unit_id,
+            outcome=new_state,
+            result_hash=result_hash,
+            lease_generation=lease_generation,
+        )
+        if self.crash_after_result:
+            raise RuntimeError("injected crash: after_result")
+        return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
+
+    def set_host_cooldown(self, host: str, next_allowed_at: float) -> None:
+        conn = self._require()
+        conn.execute(
+            "INSERT INTO host_cooldowns(host, next_allowed_at) VALUES (?, ?) "
+            "ON CONFLICT(host) DO UPDATE SET next_allowed_at = excluded.next_allowed_at",
+            (host, float(next_allowed_at)),
+        )
+
+    # --- split (CAS) ---------------------------------------------------------
+
+    def commit_split(
+        self,
+        run_id: str,
+        parent_chunk_id: str,
+        owner: str,
+        lease_generation: int,
+        *,
+        phase: str = "offline_enrich",
+        now: float | None = None,
+    ) -> CasResult:
+        """CAS OOM split: create deterministic children; mark parent ``superseded``.
+
+        Crash mid-transaction leaves either the parent active or parent+both children
+        (SQLite single transaction). Retry recreates the same child IDs.
+        """
+        conn = self._require()
+        ts = self._now(now)
+        parent = conn.execute(
+            "SELECT * FROM chunks WHERE run_id = ? AND chunk_id = ?",
+            (run_id, parent_chunk_id),
+        ).fetchone()
+        if parent is None:
+            return CasResult(status=CasStatus.NOT_FOUND, detail="parent chunk missing")
+        if int(parent["is_leaf"]) != 1:
+            return CasResult(status=CasStatus.NOT_LEAF, detail="parent is not a leaf")
+        if (
+            str(parent["owner"]) != owner
+            or int(parent["lease_generation"]) != int(lease_generation)
+            or str(parent["state"]) != ChunkLedgerState.LEASED.value
+        ):
+            self._event(
+                ErrorCode.STALE_COMMIT_REJECTED.value,
+                run_id,
+                unit_id=parent_chunk_id,
+                op="commit_split",
+                lease_generation=lease_generation,
+            )
+            return CasResult(
+                status=CasStatus.STALE_COMMIT_REJECTED,
+                detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                lease_generation=lease_generation,
+                run_id=run_id,
+            )
+
+        lemma_ids = json.loads(str(parent["lemma_ids_json"]))
+        if not isinstance(lemma_ids, list) or not lemma_ids:
+            return CasResult(status=CasStatus.INVALID_STATE, detail="empty parent lemmas")
+
+        from scripts.lexicon.runner.contracts import ChunkSpec, ChunkState, OomSplitChildren
+
+        parent_spec = ChunkSpec(
+            chunk_id=parent_chunk_id,
+            lemma_ids=[str(x) for x in lemma_ids],
+            parent_chunk_id=parent["parent_chunk_id"],
+            split_epoch=int(parent["split_epoch"]),
+            state=ChunkState.PENDING,
+        )
+        split_result = split_on_oom(parent_spec)
+        if not isinstance(split_result, OomSplitChildren):
+            failed, code = split_result
+            # Single-lemma OOM: failed_terminal, never split.
+            cur = conn.execute(
+                "UPDATE chunks SET state = ?, error_code = ?, owner = NULL, "
+                "leased_until = NULL, updated_at = ? "
+                "WHERE run_id = ? AND chunk_id = ? AND owner = ? AND lease_generation = ?",
+                (
+                    ChunkLedgerState.FAILED_TERMINAL.value,
+                    code,
+                    ts,
+                    run_id,
+                    parent_chunk_id,
+                    owner,
+                    int(lease_generation),
+                ),
+            )
+            if cur.rowcount != 1:
+                return CasResult(
+                    status=CasStatus.STALE_COMMIT_REJECTED,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                )
+            conn.execute(
+                "UPDATE work_units SET state = ?, error_code = ?, owner = NULL, "
+                "leased_until = NULL, updated_at = ? "
+                "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+                "AND owner = ? AND lease_generation = ?",
+                (
+                    UnitOutcome.FAILED_TERMINAL.value,
+                    code,
+                    ts,
+                    run_id,
+                    parent_chunk_id,
+                    phase,
+                    owner,
+                    int(lease_generation),
+                ),
+            )
+            self._event(
+                "failed_oom",
+                run_id,
+                chunk_id=parent_chunk_id,
+                lemma_ids=failed.lemma_ids,
+            )
+            return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
+
+        if self.crash_mid_split:
+            # Simulate interruption after validation, before the write transaction commits.
+            raise RuntimeError("injected crash: mid_split")
+
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            cur = conn.execute(
+                "UPDATE chunks SET state = ?, is_leaf = 0, owner = NULL, "
+                "leased_until = NULL, updated_at = ? "
+                "WHERE run_id = ? AND chunk_id = ? AND owner = ? AND lease_generation = ? "
+                "AND state = ?",
+                (
+                    ChunkLedgerState.SUPERSEDED.value,
+                    ts,
+                    run_id,
+                    parent_chunk_id,
+                    owner,
+                    int(lease_generation),
+                    ChunkLedgerState.LEASED.value,
+                ),
+            )
+            if cur.rowcount != 1:
+                conn.execute("ROLLBACK")
+                return CasResult(
+                    status=CasStatus.STALE_COMMIT_REJECTED,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                )
+            conn.execute(
+                "UPDATE work_units SET state = ?, owner = NULL, leased_until = NULL, "
+                "updated_at = ? WHERE run_id = ? AND unit_id = ? AND phase = ?",
+                (
+                    ChunkLedgerState.SUPERSEDED.value,
+                    ts,
+                    run_id,
+                    parent_chunk_id,
+                    phase,
+                ),
+            )
+            for child in (split_result.left, split_result.right):
+                # INSERT OR IGNORE keeps child IDs stable across crash-retry.
+                conn.execute(
+                    "INSERT OR IGNORE INTO chunks("
+                    "run_id, chunk_id, parent_chunk_id, split_epoch, lemma_ids_json, "
+                    "state, is_leaf, lease_generation, attempt_count, updated_at"
+                    ") VALUES (?, ?, ?, ?, ?, ?, 1, 0, 0, ?)",
+                    (
+                        run_id,
+                        child.chunk_id,
+                        parent_chunk_id,
+                        int(split_result.split_epoch),
+                        canonical_json(list(child.lemma_ids)),
+                        ChunkLedgerState.PENDING.value,
+                        ts,
+                    ),
+                )
+                conn.execute(
+                    "INSERT OR IGNORE INTO work_units("
+                    "run_id, unit_id, unit_kind, phase, state, lease_generation, "
+                    "attempt_count, packet_generation, updated_at"
+                    ") VALUES (?, ?, 'chunk', ?, ?, 0, 0, 0, ?)",
+                    (
+                        run_id,
+                        child.chunk_id,
+                        phase,
+                        SchedulableState.PENDING.value,
+                        ts,
+                    ),
+                )
+                for lemma_id in child.lemma_ids:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO work_units("
+                        "run_id, unit_id, unit_kind, phase, state, lease_generation, "
+                        "attempt_count, packet_generation, updated_at"
+                        ") VALUES (?, ?, 'lemma', ?, ?, 0, 0, 0, ?)",
+                        (
+                            run_id,
+                            lemma_id,
+                            phase,
+                            SchedulableState.PENDING.value,
+                            ts,
+                        ),
+                    )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+        self._event(
+            "chunk_split",
+            run_id,
+            parent=parent_chunk_id,
+            left=split_result.left.chunk_id,
+            right=split_result.right.chunk_id,
+            split_epoch=split_result.split_epoch,
+        )
+        # Prove child_id formula matches split module.
+        assert split_result.left.chunk_id == child_chunk_id(
+            parent_chunk_id, split_result.split_epoch, split_result.left.lemma_ids
+        )
+        return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
+
+    # --- import (CAS, per-lemma atomic) --------------------------------------
+
+    def commit_import(
+        self,
+        run_id: str,
+        lemma_id: str,
+        owner: str,
+        lease_generation: int,
+        *,
+        packet_generation: int,
+        result_hash: str,
+        expected_fingerprint: str | None = None,
+        phase: str = "network_import",
+        now: float | None = None,
+    ) -> CasResult:
+        """CAS per-lemma import. Matching-hash re-import is a no-op success."""
+        conn = self._require()
+        ts = self._now(now)
+        run = self.get_run(run_id)
+        if run is None:
+            return CasResult(status=CasStatus.NOT_FOUND, detail="run missing")
+        if expected_fingerprint is not None and str(run["fingerprint"]) != expected_fingerprint:
+            self._event(
+                ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value,
+                run_id,
+                op="import",
+                lemma_id=lemma_id,
+            )
+            return CasResult(
+                status=CasStatus.FINGERPRINT_MISMATCH_REFUSED,
+                detail=ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value,
+                run_id=run_id,
+            )
+
+        existing = conn.execute(
+            "SELECT result_hash FROM imports "
+            "WHERE run_id = ? AND lemma_id = ? AND packet_generation = ?",
+            (run_id, lemma_id, int(packet_generation)),
+        ).fetchone()
+        if existing is not None:
+            if str(existing["result_hash"]) == result_hash:
+                return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
+            return CasResult(
+                status=CasStatus.INVALID_STATE,
+                detail="import hash conflict for same packet generation",
+                run_id=run_id,
+            )
+
+        # Optional work-unit fencing when a leased import unit exists.
+        unit = conn.execute(
+            "SELECT * FROM work_units WHERE run_id = ? AND unit_id = ? AND phase = ?",
+            (run_id, lemma_id, phase),
+        ).fetchone()
+        if (
+            unit is not None
+            and str(unit["state"]) == SchedulableState.LEASED.value
+            and (
+                str(unit["owner"]) != owner
+                or int(unit["lease_generation"]) != int(lease_generation)
+            )
+        ):
+            self._event(
+                ErrorCode.STALE_COMMIT_REJECTED.value,
+                run_id,
+                unit_id=lemma_id,
+                op="commit_import",
+                lease_generation=lease_generation,
+            )
+            return CasResult(
+                status=CasStatus.STALE_COMMIT_REJECTED,
+                detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                lease_generation=lease_generation,
+                run_id=run_id,
+            )
+
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            conn.execute(
+                "INSERT INTO imports("
+                "run_id, lemma_id, packet_generation, result_hash, "
+                "lease_generation, owner, imported_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    run_id,
+                    lemma_id,
+                    int(packet_generation),
+                    result_hash,
+                    int(lease_generation),
+                    owner,
+                    ts,
+                ),
+            )
+            if unit is not None:
+                cur = conn.execute(
+                    "UPDATE work_units SET state = ?, result_hash = ?, owner = NULL, "
+                    "leased_until = NULL, packet_generation = ?, updated_at = ? "
+                    "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+                    "AND owner = ? AND lease_generation = ?",
+                    (
+                        UnitOutcome.DONE.value,
+                        result_hash,
+                        int(packet_generation),
+                        ts,
+                        run_id,
+                        lemma_id,
+                        phase,
+                        owner,
+                        int(lease_generation),
+                    ),
+                )
+                if cur.rowcount != 1 and str(unit["state"]) == SchedulableState.LEASED.value:
+                    conn.execute("ROLLBACK")
+                    return CasResult(
+                        status=CasStatus.STALE_COMMIT_REJECTED,
+                        detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                    )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+        self._event(
+            "import_committed",
+            run_id,
+            lemma_id=lemma_id,
+            packet_generation=packet_generation,
+            result_hash=result_hash,
+        )
+        return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
+
+    # --- seal (CAS, leaf-only) -----------------------------------------------
+
+    def commit_seal(
+        self,
+        run_id: str,
+        chunk_id: str,
+        owner: str,
+        lease_generation: int,
+        *,
+        seal_sha256: str,
+        lemma_ids: Sequence[str] | None = None,
+        phase: str = "offline_enrich",
+        now: float | None = None,
+    ) -> CasResult:
+        """CAS leaf seal. Interrupted seal leaves no seal row (spec crash matrix)."""
+        conn = self._require()
+        ts = self._now(now)
+        chunk = conn.execute(
+            "SELECT * FROM chunks WHERE run_id = ? AND chunk_id = ?",
+            (run_id, chunk_id),
+        ).fetchone()
+        if chunk is None:
+            return CasResult(status=CasStatus.NOT_FOUND, detail="chunk missing")
+        if int(chunk["is_leaf"]) != 1:
+            return CasResult(
+                status=CasStatus.NOT_LEAF,
+                detail="only leaf chunks may seal; parents stay superseded",
+            )
+        if str(chunk["state"]) == ChunkLedgerState.SUPERSEDED.value:
+            return CasResult(
+                status=CasStatus.NOT_LEAF,
+                detail="superseded parents never seal",
+            )
+        # CAS: active lease owner+generation, OR a DONE leaf with matching generation
+        # after the coordinator already released the owner (seal pass).
+        owner_ok = str(chunk["owner"]) == owner and int(chunk["lease_generation"]) == int(
+            lease_generation
+        )
+        done_ok = (
+            str(chunk["state"]) == ChunkLedgerState.DONE.value
+            and int(chunk["lease_generation"]) == int(lease_generation)
+        )
+        if not owner_ok and not done_ok:
+            self._event(
+                ErrorCode.STALE_COMMIT_REJECTED.value,
+                run_id,
+                unit_id=chunk_id,
+                op="commit_seal",
+                lease_generation=lease_generation,
+            )
+            return CasResult(
+                status=CasStatus.STALE_COMMIT_REJECTED,
+                detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                lease_generation=lease_generation,
+                run_id=run_id,
+            )
+
+        if lemma_ids is None:
+            lemma_ids = json.loads(str(chunk["lemma_ids_json"]))
+        lemma_list = [str(x) for x in lemma_ids]
+
+        if self.crash_mid_seal:
+            raise RuntimeError("injected crash: mid_seal")
+
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            # Re-check leaf under the write transaction.
+            again = conn.execute(
+                "SELECT is_leaf, state, lease_generation, owner FROM chunks "
+                "WHERE run_id = ? AND chunk_id = ?",
+                (run_id, chunk_id),
+            ).fetchone()
+            if again is None or int(again["is_leaf"]) != 1:
+                conn.execute("ROLLBACK")
+                return CasResult(status=CasStatus.NOT_LEAF, detail="not a leaf at seal time")
+            if int(again["lease_generation"]) != int(lease_generation):
+                conn.execute("ROLLBACK")
+                return CasResult(
+                    status=CasStatus.STALE_COMMIT_REJECTED,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                )
+            conn.execute(
+                "INSERT INTO seals("
+                "run_id, chunk_id, seal_sha256, lemma_ids_json, "
+                "lease_generation, owner, sealed_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    run_id,
+                    chunk_id,
+                    seal_sha256,
+                    canonical_json(lemma_list),
+                    int(lease_generation),
+                    owner,
+                    ts,
+                ),
+            )
+            conn.execute(
+                "UPDATE chunks SET state = ?, seal_sha256 = ?, owner = NULL, "
+                "leased_until = NULL, updated_at = ? "
+                "WHERE run_id = ? AND chunk_id = ? AND lease_generation = ?",
+                (
+                    ChunkLedgerState.SEALED.value,
+                    seal_sha256,
+                    ts,
+                    run_id,
+                    chunk_id,
+                    int(lease_generation),
+                ),
+            )
+            conn.execute(
+                "UPDATE work_units SET state = ?, result_hash = ?, owner = NULL, "
+                "leased_until = NULL, updated_at = ? "
+                "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+                (
+                    ChunkLedgerState.SEALED.value,
+                    seal_sha256,
+                    ts,
+                    run_id,
+                    chunk_id,
+                    phase,
+                ),
+            )
+            conn.execute("COMMIT")
+        except sqlite3.IntegrityError:
+            conn.execute("ROLLBACK")
+            # Seal already exists — idempotent only if hash matches.
+            existing = conn.execute(
+                "SELECT seal_sha256 FROM seals WHERE run_id = ? AND chunk_id = ?",
+                (run_id, chunk_id),
+            ).fetchone()
+            if existing is not None and str(existing["seal_sha256"]) == seal_sha256:
+                return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
+            return CasResult(status=CasStatus.INVALID_STATE, detail="seal conflict")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+        self._event(
+            "chunk_sealed",
+            run_id,
+            chunk_id=chunk_id,
+            seal_sha256=seal_sha256,
+            lease_generation=lease_generation,
+        )
+        return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
+
+    # --- operator actions ----------------------------------------------------
+
+    def retry_failed(
+        self,
+        run_id: str,
+        unit_id: str,
+        reason: str,
+        *,
+        phase: str = "offline_enrich",
+        now: float | None = None,
+    ) -> CasResult:
+        """Only audited operator path to reopen terminal failures (spec §2, §6)."""
+        if not reason or not str(reason).strip():
+            return CasResult(status=CasStatus.INVALID_STATE, detail="reason required")
+        conn = self._require()
+        ts = self._now(now)
+        row = conn.execute(
+            "SELECT * FROM work_units WHERE run_id = ? AND unit_id = ? AND phase = ?",
+            (run_id, unit_id, phase),
+        ).fetchone()
+        if row is None:
+            return CasResult(status=CasStatus.NOT_FOUND, detail="unit missing")
+        if str(row["state"]) != UnitOutcome.FAILED_TERMINAL.value:
+            return CasResult(
+                status=CasStatus.INVALID_STATE,
+                detail=f"retry-failed only applies to failed_terminal, got {row['state']}",
+            )
+        conn.execute(
+            "UPDATE work_units SET state = ?, error_code = NULL, result_hash = NULL, "
+            "owner = NULL, leased_until = NULL, attempt_count = 0, updated_at = ? "
+            "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+            (SchedulableState.PENDING.value, ts, run_id, unit_id, phase),
+        )
+        conn.execute(
+            "UPDATE chunks SET state = ?, error_code = NULL, result_hash = NULL, "
+            "owner = NULL, leased_until = NULL, attempt_count = 0, updated_at = ? "
+            "WHERE run_id = ? AND chunk_id = ?",
+            (ChunkLedgerState.PENDING.value, ts, run_id, unit_id),
+        )
+        conn.execute(
+            "UPDATE runs SET manual_retry_epoch = manual_retry_epoch + 1, updated_at = ? "
+            "WHERE run_id = ?",
+            (ts, run_id),
+        )
+        conn.execute(
+            "INSERT INTO operator_actions("
+            "run_id, action, reason, unit_id, phase, created_at, payload_json"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                run_id,
+                OperatorActionKind.RETRY_FAILED.value,
+                reason,
+                unit_id,
+                phase,
+                ts,
+                canonical_json({"prior_lease_generation": int(row["lease_generation"])}),
+            ),
+        )
+        self._event(
+            "operator_retry_failed",
+            run_id,
+            unit_id=unit_id,
+            phase=phase,
+            reason=reason,
+        )
+        return CasResult(status=CasStatus.OK, run_id=run_id)
+
+    def abandon_packet(
+        self,
+        run_id: str,
+        packet_id: str,
+        generation: int,
+        reason: str,
+        *,
+        now: float | None = None,
+    ) -> CasResult:
+        """Explicitly invalidate an outstanding transport generation (spec §2)."""
+        if not reason or not str(reason).strip():
+            return CasResult(status=CasStatus.INVALID_STATE, detail="reason required")
+        conn = self._require()
+        ts = self._now(now)
+        conn.execute(
+            "INSERT INTO packets(run_id, packet_id, generation, state, created_at, abandoned_at) "
+            "VALUES (?, ?, ?, 'abandoned', ?, ?) "
+            "ON CONFLICT(run_id, packet_id, generation) DO UPDATE SET "
+            "state = 'abandoned', abandoned_at = excluded.abandoned_at",
+            (run_id, packet_id, int(generation), ts, ts),
+        )
+        conn.execute(
+            "INSERT INTO operator_actions("
+            "run_id, action, reason, unit_id, phase, created_at, payload_json"
+            ") VALUES (?, ?, ?, ?, NULL, ?, ?)",
+            (
+                run_id,
+                OperatorActionKind.ABANDON_PACKET.value,
+                reason,
+                packet_id,
+                ts,
+                canonical_json({"generation": int(generation)}),
+            ),
+        )
+        self._event(
+            "packet_abandoned",
+            run_id,
+            packet_id=packet_id,
+            generation=generation,
+            reason=reason,
+        )
+        return CasResult(status=CasStatus.OK, run_id=run_id)
+
+    # --- queries for resume --------------------------------------------------
+
+    def list_pending_chunk_ids(
+        self,
+        run_id: str,
+        *,
+        phase: str = "offline_enrich",
+    ) -> list[str]:
+        conn = self._require()
+        rows = conn.execute(
+            "SELECT unit_id FROM work_units "
+            "WHERE run_id = ? AND phase = ? AND unit_kind = 'chunk' "
+            "AND state IN (?, ?, ?) ORDER BY unit_id",
+            (
+                run_id,
+                phase,
+                SchedulableState.PENDING.value,
+                UnitOutcome.RETRY_SCHEDULED.value,
+                SchedulableState.LEASED.value,
+            ),
+        ).fetchall()
+        return [str(r["unit_id"]) for r in rows]
+
+    def list_completed_chunk_ids(self, run_id: str) -> list[str]:
+        conn = self._require()
+        rows = conn.execute(
+            "SELECT chunk_id FROM chunks WHERE run_id = ? AND state IN (?, ?) ORDER BY chunk_id",
+            (
+                run_id,
+                ChunkLedgerState.DONE.value,
+                ChunkLedgerState.SEALED.value,
+            ),
+        ).fetchall()
+        return [str(r["chunk_id"]) for r in rows]
+
+    def get_chunk(self, run_id: str, chunk_id: str) -> dict[str, Any] | None:
+        conn = self._require()
+        row = conn.execute(
+            "SELECT * FROM chunks WHERE run_id = ? AND chunk_id = ?",
+            (run_id, chunk_id),
+        ).fetchone()
+        return None if row is None else dict(row)
+
+    def get_work_unit(
+        self,
+        run_id: str,
+        unit_id: str,
+        *,
+        phase: str = "offline_enrich",
+    ) -> dict[str, Any] | None:
+        conn = self._require()
+        row = conn.execute(
+            "SELECT * FROM work_units WHERE run_id = ? AND unit_id = ? AND phase = ?",
+            (run_id, unit_id, phase),
+        ).fetchone()
+        return None if row is None else dict(row)
+
+    def count_operator_actions(self, run_id: str, action: str | None = None) -> int:
+        conn = self._require()
+        if action is None:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM operator_actions WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM operator_actions WHERE run_id = ? AND action = ?",
+                (run_id, action),
+            ).fetchone()
+        return int(row["n"]) if row else 0
+
+    def list_events(self, run_id: str | None = None, event: str | None = None) -> list[dict[str, Any]]:
+        conn = self._require()
+        sql = "SELECT * FROM events WHERE 1=1"
+        params: list[Any] = []
+        if run_id is not None:
+            sql += " AND run_id = ?"
+            params.append(run_id)
+        if event is not None:
+            sql += " AND event = ?"
+            params.append(event)
+        sql += " ORDER BY event_id"
+        return [dict(r) for r in conn.execute(sql, params).fetchall()]

--- a/scripts/lexicon/runner/ledger.py
+++ b/scripts/lexicon/runner/ledger.py
@@ -724,121 +724,151 @@ class Ledger:
                 )
 
         self.reclaim_expired(run_id, now=ts)
-        row = conn.execute(
-            "SELECT * FROM work_units WHERE run_id = ? AND unit_id = ? AND phase = ?",
-            (run_id, unit_id, phase),
-        ).fetchone()
-        if row is None:
-            return ClaimResult(status=CasStatus.NOT_FOUND, unit_id=unit_id, detail="unit missing")
 
-        state = str(row["state"])
-        attempt_count = int(row["attempt_count"])
-        if state in {
-            UnitOutcome.DONE.value,
-            UnitOutcome.NO_DATA.value,
-            UnitOutcome.FAILED_TERMINAL.value,
-            ChunkLedgerState.SEALED.value,
-            ChunkLedgerState.SUPERSEDED.value,
-        }:
-            return ClaimResult(
-                status=CasStatus.INVALID_STATE,
-                unit_id=unit_id,
-                detail=f"unit not claimable in state={state}",
-            )
-        if state == SchedulableState.LEASED.value and float(row["leased_until"] or 0) >= ts:
-            return ClaimResult(
-                status=CasStatus.INVALID_STATE,
-                unit_id=unit_id,
-                detail="unit already leased",
-            )
-        if attempt_count >= self.max_attempts:
-            conn.execute(
-                "UPDATE work_units SET state = ?, error_code = ?, updated_at = ? "
-                "WHERE run_id = ? AND unit_id = ? AND phase = ?",
-                (
-                    UnitOutcome.FAILED_TERMINAL.value,
+        # work_units + chunks must move atomically (review #5341 finding 1, 4).
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                "SELECT * FROM work_units WHERE run_id = ? AND unit_id = ? AND phase = ?",
+                (run_id, unit_id, phase),
+            ).fetchone()
+            if row is None:
+                conn.execute("ROLLBACK")
+                return ClaimResult(
+                    status=CasStatus.NOT_FOUND, unit_id=unit_id, detail="unit missing"
+                )
+
+            state = str(row["state"])
+            attempt_count = int(row["attempt_count"])
+            if state in {
+                UnitOutcome.DONE.value,
+                UnitOutcome.NO_DATA.value,
+                UnitOutcome.FAILED_TERMINAL.value,
+                ChunkLedgerState.SEALED.value,
+                ChunkLedgerState.SUPERSEDED.value,
+            }:
+                conn.execute("ROLLBACK")
+                return ClaimResult(
+                    status=CasStatus.INVALID_STATE,
+                    unit_id=unit_id,
+                    detail=f"unit not claimable in state={state}",
+                )
+            if state == SchedulableState.LEASED.value and float(row["leased_until"] or 0) >= ts:
+                conn.execute("ROLLBACK")
+                return ClaimResult(
+                    status=CasStatus.INVALID_STATE,
+                    unit_id=unit_id,
+                    detail="unit already leased",
+                )
+            if attempt_count >= self.max_attempts:
+                conn.execute(
+                    "UPDATE work_units SET state = ?, error_code = ?, updated_at = ? "
+                    "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+                    (
+                        UnitOutcome.FAILED_TERMINAL.value,
+                        "attempt_cap_exhausted",
+                        ts,
+                        run_id,
+                        unit_id,
+                        phase,
+                    ),
+                )
+                # Mirror terminal outcome onto chunk row when unit is a chunk.
+                conn.execute(
+                    "UPDATE chunks SET state = ?, error_code = ?, owner = NULL, "
+                    "leased_until = NULL, updated_at = ? "
+                    "WHERE run_id = ? AND chunk_id = ?",
+                    (
+                        ChunkLedgerState.FAILED_TERMINAL.value,
+                        "attempt_cap_exhausted",
+                        ts,
+                        run_id,
+                        unit_id,
+                    ),
+                )
+                self._event(
                     "attempt_cap_exhausted",
+                    run_id,
+                    unit_id=unit_id,
+                    phase=phase,
+                    attempt_count=attempt_count,
+                )
+                conn.execute("COMMIT")
+                return ClaimResult(
+                    status=CasStatus.ATTEMPT_CAP_EXHAUSTED,
+                    unit_id=unit_id,
+                    attempt_count=attempt_count,
+                    detail="total automatic attempts exhausted",
+                )
+
+            new_gen = int(row["lease_generation"]) + 1
+            new_attempts = attempt_count + 1
+            leased_until = ts + self.lease_ttl_seconds
+            cur = conn.execute(
+                "UPDATE work_units SET state = ?, lease_generation = ?, owner = ?, "
+                "leased_until = ?, attempt_count = ?, updated_at = ? "
+                "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+                "AND lease_generation = ? AND state IN (?, ?, ?)",
+                (
+                    SchedulableState.LEASED.value,
+                    new_gen,
+                    owner,
+                    leased_until,
+                    new_attempts,
                     ts,
                     run_id,
                     unit_id,
                     phase,
+                    int(row["lease_generation"]),
+                    SchedulableState.PENDING.value,
+                    UnitOutcome.RETRY_SCHEDULED.value,
+                    SchedulableState.LEASED.value,
+                ),
+            )
+            if cur.rowcount != 1:
+                conn.execute("ROLLBACK")
+                return ClaimResult(
+                    status=CasStatus.STALE_COMMIT_REJECTED,
+                    unit_id=unit_id,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                )
+
+            # Keep chunk row in sync when unit is a chunk scheduling unit.
+            conn.execute(
+                "UPDATE chunks SET state = ?, lease_generation = ?, owner = ?, "
+                "leased_until = ?, attempt_count = ?, updated_at = ? "
+                "WHERE run_id = ? AND chunk_id = ? AND is_leaf = 1 "
+                "AND state IN (?, ?)",
+                (
+                    ChunkLedgerState.LEASED.value,
+                    new_gen,
+                    owner,
+                    leased_until,
+                    new_attempts,
+                    ts,
+                    run_id,
+                    unit_id,
+                    ChunkLedgerState.PENDING.value,
+                    ChunkLedgerState.LEASED.value,
                 ),
             )
             self._event(
-                "attempt_cap_exhausted",
+                "chunk_claimed" if str(row["unit_kind"]) == "chunk" else "unit_claimed",
                 run_id,
                 unit_id=unit_id,
                 phase=phase,
-                attempt_count=attempt_count,
+                lease_generation=new_gen,
+                owner=owner,
+                attempt_count=new_attempts,
             )
-            return ClaimResult(
-                status=CasStatus.ATTEMPT_CAP_EXHAUSTED,
-                unit_id=unit_id,
-                attempt_count=attempt_count,
-                detail="total automatic attempts exhausted",
-            )
+            # Crash mid-transaction: both work_units and chunks roll back together.
+            if self.crash_after_claim:
+                raise RuntimeError("injected crash: after_claim")
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
 
-        new_gen = int(row["lease_generation"]) + 1
-        new_attempts = attempt_count + 1
-        leased_until = ts + self.lease_ttl_seconds
-        cur = conn.execute(
-            "UPDATE work_units SET state = ?, lease_generation = ?, owner = ?, "
-            "leased_until = ?, attempt_count = ?, updated_at = ? "
-            "WHERE run_id = ? AND unit_id = ? AND phase = ? "
-            "AND lease_generation = ? AND state IN (?, ?, ?)",
-            (
-                SchedulableState.LEASED.value,
-                new_gen,
-                owner,
-                leased_until,
-                new_attempts,
-                ts,
-                run_id,
-                unit_id,
-                phase,
-                int(row["lease_generation"]),
-                SchedulableState.PENDING.value,
-                UnitOutcome.RETRY_SCHEDULED.value,
-                SchedulableState.LEASED.value,
-            ),
-        )
-        if cur.rowcount != 1:
-            return ClaimResult(
-                status=CasStatus.STALE_COMMIT_REJECTED,
-                unit_id=unit_id,
-                detail=ErrorCode.STALE_COMMIT_REJECTED.value,
-            )
-
-        # Keep chunk row in sync when unit is a chunk scheduling unit.
-        conn.execute(
-            "UPDATE chunks SET state = ?, lease_generation = ?, owner = ?, "
-            "leased_until = ?, attempt_count = ?, updated_at = ? "
-            "WHERE run_id = ? AND chunk_id = ? AND is_leaf = 1 "
-            "AND state IN (?, ?)",
-            (
-                ChunkLedgerState.LEASED.value,
-                new_gen,
-                owner,
-                leased_until,
-                new_attempts,
-                ts,
-                run_id,
-                unit_id,
-                ChunkLedgerState.PENDING.value,
-                ChunkLedgerState.LEASED.value,
-            ),
-        )
-        self._event(
-            "chunk_claimed" if str(row["unit_kind"]) == "chunk" else "unit_claimed",
-            run_id,
-            unit_id=unit_id,
-            phase=phase,
-            lease_generation=new_gen,
-            owner=owner,
-            attempt_count=new_attempts,
-        )
-        if self.crash_after_claim:
-            raise RuntimeError("injected crash: after_claim")
         return ClaimResult(
             status=CasStatus.OK,
             unit_id=unit_id,
@@ -925,41 +955,6 @@ class Ledger:
                 detail=f"invalid outcome {outcome_s!r}",
             )
         new_state = outcome_s
-        # All outcomes release the active lease; retry_scheduled returns to pending
-        # so the scheduler can reclaim after cooldown without holding owner.
-        cur = conn.execute(
-            "UPDATE work_units SET state = ?, result_hash = ?, error_code = ?, "
-            "owner = NULL, leased_until = NULL, updated_at = ? "
-            "WHERE run_id = ? AND unit_id = ? AND phase = ? "
-            "AND owner = ? AND lease_generation = ? AND state = ?",
-            (
-                new_state,
-                result_hash,
-                error_code,
-                ts,
-                run_id,
-                unit_id,
-                phase,
-                owner,
-                int(lease_generation),
-                SchedulableState.LEASED.value,
-            ),
-        )
-        if cur.rowcount != 1:
-            self._event(
-                ErrorCode.STALE_COMMIT_REJECTED.value,
-                run_id,
-                unit_id=unit_id,
-                op="commit_result",
-                lease_generation=lease_generation,
-                owner=owner,
-            )
-            return CasResult(
-                status=CasStatus.STALE_COMMIT_REJECTED,
-                detail=ErrorCode.STALE_COMMIT_REJECTED.value,
-                lease_generation=lease_generation,
-                run_id=run_id,
-            )
         # Mirror terminal outcomes onto chunk rows when unit is a chunk.
         chunk_state = {
             UnitOutcome.DONE.value: ChunkLedgerState.DONE.value,
@@ -967,30 +962,74 @@ class Ledger:
             UnitOutcome.FAILED_TERMINAL.value: ChunkLedgerState.FAILED_TERMINAL.value,
             UnitOutcome.RETRY_SCHEDULED.value: ChunkLedgerState.PENDING.value,
         }[new_state]
-        conn.execute(
-            "UPDATE chunks SET state = ?, result_hash = ?, error_code = ?, "
-            "owner = NULL, leased_until = NULL, updated_at = ? "
-            "WHERE run_id = ? AND chunk_id = ? AND lease_generation = ?",
-            (
-                chunk_state,
-                result_hash,
-                error_code,
-                ts,
+        # work_units + chunks must move atomically (review #5341 finding 1).
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            # All outcomes release the active lease; retry_scheduled returns to pending
+            # so the scheduler can reclaim after cooldown without holding owner.
+            cur = conn.execute(
+                "UPDATE work_units SET state = ?, result_hash = ?, error_code = ?, "
+                "owner = NULL, leased_until = NULL, updated_at = ? "
+                "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+                "AND owner = ? AND lease_generation = ? AND state = ?",
+                (
+                    new_state,
+                    result_hash,
+                    error_code,
+                    ts,
+                    run_id,
+                    unit_id,
+                    phase,
+                    owner,
+                    int(lease_generation),
+                    SchedulableState.LEASED.value,
+                ),
+            )
+            if cur.rowcount != 1:
+                conn.execute("ROLLBACK")
+                self._event(
+                    ErrorCode.STALE_COMMIT_REJECTED.value,
+                    run_id,
+                    unit_id=unit_id,
+                    op="commit_result",
+                    lease_generation=lease_generation,
+                    owner=owner,
+                )
+                return CasResult(
+                    status=CasStatus.STALE_COMMIT_REJECTED,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                    lease_generation=lease_generation,
+                    run_id=run_id,
+                )
+            conn.execute(
+                "UPDATE chunks SET state = ?, result_hash = ?, error_code = ?, "
+                "owner = NULL, leased_until = NULL, updated_at = ? "
+                "WHERE run_id = ? AND chunk_id = ? AND lease_generation = ?",
+                (
+                    chunk_state,
+                    result_hash,
+                    error_code,
+                    ts,
+                    run_id,
+                    unit_id,
+                    int(lease_generation),
+                ),
+            )
+            self._event(
+                "result_committed",
                 run_id,
-                unit_id,
-                int(lease_generation),
-            ),
-        )
-        self._event(
-            "result_committed",
-            run_id,
-            unit_id=unit_id,
-            outcome=new_state,
-            result_hash=result_hash,
-            lease_generation=lease_generation,
-        )
-        if self.crash_after_result:
-            raise RuntimeError("injected crash: after_result")
+                unit_id=unit_id,
+                outcome=new_state,
+                result_hash=result_hash,
+                lease_generation=lease_generation,
+            )
+            # Crash mid-transaction: both work_units and chunks roll back together.
+            if self.crash_after_result:
+                raise RuntimeError("injected crash: after_result")
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
         return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
 
     def set_host_cooldown(self, host: str, next_allowed_at: float) -> None:
@@ -1061,58 +1100,64 @@ class Ledger:
             state=ChunkState.PENDING,
         )
         split_result = split_on_oom(parent_spec)
-        if not isinstance(split_result, OomSplitChildren):
-            failed, code = split_result
-            # Single-lemma OOM: failed_terminal, never split.
-            cur = conn.execute(
-                "UPDATE chunks SET state = ?, error_code = ?, owner = NULL, "
-                "leased_until = NULL, updated_at = ? "
-                "WHERE run_id = ? AND chunk_id = ? AND owner = ? AND lease_generation = ?",
-                (
-                    ChunkLedgerState.FAILED_TERMINAL.value,
-                    code,
-                    ts,
-                    run_id,
-                    parent_chunk_id,
-                    owner,
-                    int(lease_generation),
-                ),
-            )
-            if cur.rowcount != 1:
-                return CasResult(
-                    status=CasStatus.STALE_COMMIT_REJECTED,
-                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
-                )
-            conn.execute(
-                "UPDATE work_units SET state = ?, error_code = ?, owner = NULL, "
-                "leased_until = NULL, updated_at = ? "
-                "WHERE run_id = ? AND unit_id = ? AND phase = ? "
-                "AND owner = ? AND lease_generation = ?",
-                (
-                    UnitOutcome.FAILED_TERMINAL.value,
-                    code,
-                    ts,
-                    run_id,
-                    parent_chunk_id,
-                    phase,
-                    owner,
-                    int(lease_generation),
-                ),
-            )
-            self._event(
-                "failed_oom",
-                run_id,
-                chunk_id=parent_chunk_id,
-                lemma_ids=failed.lemma_ids,
-            )
-            return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
 
-        if self.crash_mid_split:
-            # Simulate interruption after validation, before the write transaction commits.
-            raise RuntimeError("injected crash: mid_split")
-
+        # Single-lemma and multi-lemma paths both need atomic work_units+chunks
+        # transitions (review #5341 findings 1, 3).
         conn.execute("BEGIN IMMEDIATE")
         try:
+            if not isinstance(split_result, OomSplitChildren):
+                failed, code = split_result
+                # Single-lemma OOM: failed_terminal, never split.
+                cur = conn.execute(
+                    "UPDATE chunks SET state = ?, error_code = ?, owner = NULL, "
+                    "leased_until = NULL, updated_at = ? "
+                    "WHERE run_id = ? AND chunk_id = ? AND owner = ? AND lease_generation = ?",
+                    (
+                        ChunkLedgerState.FAILED_TERMINAL.value,
+                        code,
+                        ts,
+                        run_id,
+                        parent_chunk_id,
+                        owner,
+                        int(lease_generation),
+                    ),
+                )
+                if cur.rowcount != 1:
+                    conn.execute("ROLLBACK")
+                    return CasResult(
+                        status=CasStatus.STALE_COMMIT_REJECTED,
+                        detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                    )
+                # Crash after first write, before work_units sync — exercises rollback.
+                if self.crash_mid_split:
+                    raise RuntimeError("injected crash: mid_split")
+                conn.execute(
+                    "UPDATE work_units SET state = ?, error_code = ?, owner = NULL, "
+                    "leased_until = NULL, updated_at = ? "
+                    "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+                    "AND owner = ? AND lease_generation = ?",
+                    (
+                        UnitOutcome.FAILED_TERMINAL.value,
+                        code,
+                        ts,
+                        run_id,
+                        parent_chunk_id,
+                        phase,
+                        owner,
+                        int(lease_generation),
+                    ),
+                )
+                self._event(
+                    "failed_oom",
+                    run_id,
+                    chunk_id=parent_chunk_id,
+                    lemma_ids=failed.lemma_ids,
+                )
+                conn.execute("COMMIT")
+                return CasResult(
+                    status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id
+                )
+
             cur = conn.execute(
                 "UPDATE chunks SET state = ?, is_leaf = 0, owner = NULL, "
                 "leased_until = NULL, updated_at = ? "
@@ -1134,17 +1179,30 @@ class Ledger:
                     status=CasStatus.STALE_COMMIT_REJECTED,
                     detail=ErrorCode.STALE_COMMIT_REJECTED.value,
                 )
-            conn.execute(
+            # Crash mid-transaction (after parent chunk write, before children).
+            if self.crash_mid_split:
+                raise RuntimeError("injected crash: mid_split")
+            # CAS fence on parent work unit (review #5341 finding 3).
+            cur_unit = conn.execute(
                 "UPDATE work_units SET state = ?, owner = NULL, leased_until = NULL, "
-                "updated_at = ? WHERE run_id = ? AND unit_id = ? AND phase = ?",
+                "updated_at = ? WHERE run_id = ? AND unit_id = ? AND phase = ? "
+                "AND owner = ? AND lease_generation = ?",
                 (
                     ChunkLedgerState.SUPERSEDED.value,
                     ts,
                     run_id,
                     parent_chunk_id,
                     phase,
+                    owner,
+                    int(lease_generation),
                 ),
             )
+            if cur_unit.rowcount != 1:
+                conn.execute("ROLLBACK")
+                return CasResult(
+                    status=CasStatus.STALE_COMMIT_REJECTED,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                )
             for child in (split_result.left, split_result.right):
                 # INSERT OR IGNORE keeps child IDs stable across crash-retry.
                 conn.execute(
@@ -1189,19 +1247,19 @@ class Ledger:
                             ts,
                         ),
                     )
+            self._event(
+                "chunk_split",
+                run_id,
+                parent=parent_chunk_id,
+                left=split_result.left.chunk_id,
+                right=split_result.right.chunk_id,
+                split_epoch=split_result.split_epoch,
+            )
             conn.execute("COMMIT")
         except Exception:
             conn.execute("ROLLBACK")
             raise
 
-        self._event(
-            "chunk_split",
-            run_id,
-            parent=parent_chunk_id,
-            left=split_result.left.chunk_id,
-            right=split_result.right.chunk_id,
-            split_epoch=split_result.split_epoch,
-        )
         # Prove child_id formula matches split module.
         assert split_result.left.chunk_id == child_chunk_id(
             parent_chunk_id, split_result.split_epoch, split_result.left.lemma_ids
@@ -1318,11 +1376,15 @@ class Ledger:
                         int(lease_generation),
                     ),
                 )
-                if cur.rowcount != 1 and str(unit["state"]) == SchedulableState.LEASED.value:
+                # Always reject when CAS misses — including reclaimed PENDING units
+                # (review #5341 finding 2: prior-state LEASED guard was a bypass).
+                if cur.rowcount != 1:
                     conn.execute("ROLLBACK")
                     return CasResult(
                         status=CasStatus.STALE_COMMIT_REJECTED,
                         detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                        lease_generation=lease_generation,
+                        run_id=run_id,
                     )
             conn.execute("COMMIT")
         except Exception:
@@ -1399,9 +1461,6 @@ class Ledger:
             lemma_ids = json.loads(str(chunk["lemma_ids_json"]))
         lemma_list = [str(x) for x in lemma_ids]
 
-        if self.crash_mid_seal:
-            raise RuntimeError("injected crash: mid_seal")
-
         conn.execute("BEGIN IMMEDIATE")
         try:
             # Re-check leaf under the write transaction.
@@ -1434,6 +1493,9 @@ class Ledger:
                     ts,
                 ),
             )
+            # Crash mid-transaction after seal insert — no half-seal rows survive.
+            if self.crash_mid_seal:
+                raise RuntimeError("injected crash: mid_seal")
             conn.execute(
                 "UPDATE chunks SET state = ?, seal_sha256 = ?, owner = NULL, "
                 "leased_until = NULL, updated_at = ? "
@@ -1511,44 +1573,52 @@ class Ledger:
                 status=CasStatus.INVALID_STATE,
                 detail=f"retry-failed only applies to failed_terminal, got {row['state']}",
             )
-        conn.execute(
-            "UPDATE work_units SET state = ?, error_code = NULL, result_hash = NULL, "
-            "owner = NULL, leased_until = NULL, attempt_count = 0, updated_at = ? "
-            "WHERE run_id = ? AND unit_id = ? AND phase = ?",
-            (SchedulableState.PENDING.value, ts, run_id, unit_id, phase),
-        )
-        conn.execute(
-            "UPDATE chunks SET state = ?, error_code = NULL, result_hash = NULL, "
-            "owner = NULL, leased_until = NULL, attempt_count = 0, updated_at = ? "
-            "WHERE run_id = ? AND chunk_id = ?",
-            (ChunkLedgerState.PENDING.value, ts, run_id, unit_id),
-        )
-        conn.execute(
-            "UPDATE runs SET manual_retry_epoch = manual_retry_epoch + 1, updated_at = ? "
-            "WHERE run_id = ?",
-            (ts, run_id),
-        )
-        conn.execute(
-            "INSERT INTO operator_actions("
-            "run_id, action, reason, unit_id, phase, created_at, payload_json"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
+        # work_units + chunks + run epoch + audit row must move atomically
+        # (review #5341 finding 1).
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            conn.execute(
+                "UPDATE work_units SET state = ?, error_code = NULL, result_hash = NULL, "
+                "owner = NULL, leased_until = NULL, attempt_count = 0, updated_at = ? "
+                "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+                (SchedulableState.PENDING.value, ts, run_id, unit_id, phase),
+            )
+            conn.execute(
+                "UPDATE chunks SET state = ?, error_code = NULL, result_hash = NULL, "
+                "owner = NULL, leased_until = NULL, attempt_count = 0, updated_at = ? "
+                "WHERE run_id = ? AND chunk_id = ?",
+                (ChunkLedgerState.PENDING.value, ts, run_id, unit_id),
+            )
+            conn.execute(
+                "UPDATE runs SET manual_retry_epoch = manual_retry_epoch + 1, updated_at = ? "
+                "WHERE run_id = ?",
+                (ts, run_id),
+            )
+            conn.execute(
+                "INSERT INTO operator_actions("
+                "run_id, action, reason, unit_id, phase, created_at, payload_json"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    run_id,
+                    OperatorActionKind.RETRY_FAILED.value,
+                    reason,
+                    unit_id,
+                    phase,
+                    ts,
+                    canonical_json({"prior_lease_generation": int(row["lease_generation"])}),
+                ),
+            )
+            self._event(
+                "operator_retry_failed",
                 run_id,
-                OperatorActionKind.RETRY_FAILED.value,
-                reason,
-                unit_id,
-                phase,
-                ts,
-                canonical_json({"prior_lease_generation": int(row["lease_generation"])}),
-            ),
-        )
-        self._event(
-            "operator_retry_failed",
-            run_id,
-            unit_id=unit_id,
-            phase=phase,
-            reason=reason,
-        )
+                unit_id=unit_id,
+                phase=phase,
+                reason=reason,
+            )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
         return CasResult(status=CasStatus.OK, run_id=run_id)
 
     def abandon_packet(

--- a/scripts/lexicon/runner/offline_engine.py
+++ b/scripts/lexicon/runner/offline_engine.py
@@ -1,20 +1,28 @@
-"""Offline enrichment coordinator for PR1 (streaming + sealed phases + capped workers)."""
+"""Offline enrichment coordinator (streaming + sealed phases + capped workers + ledger)."""
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from pathlib import Path
 from typing import Any
 
 from scripts.lexicon.runner.contracts import (
+    ENGINE_VERSION,
     ChunkSpec,
     ChunkState,
     ErrorCode,
     LedgerStub,
     OomSplitChildren,
     PacketStub,
-    SealStub,
+)
+from scripts.lexicon.runner.ledger import (
+    CasStatus,
+    ChunkLedgerState,
+    Ledger,
+    UnitOutcome,
+    compute_run_fingerprint,
 )
 from scripts.lexicon.runner.memory import (
     MemoryPolicy,
@@ -49,11 +57,16 @@ def enrich_offline_slice(
     chunk_size: int = 50,
     require_memory_self_test: bool = True,
     skip_workers: bool = False,
+    ledger_path: Path | None = None,
+    run_id: str | None = None,
+    force_new_run: bool = False,
+    stop_after_chunks: int | None = None,
+    owner_id: str | None = None,
 ) -> dict[str, Any]:
-    """Run PR1 offline pipeline on a staged cohort.
+    """Run offline pipeline on a staged cohort with PR2 ledger fencing + resume.
 
-    PR2 ledger / PR3 packets / PR4 seals remain stubs — this function performs
-    the engine isolation work and writes a streaming candidate.
+    PR3 packets remain stubs. Full streaming assembly/publication gate is PR4;
+    leaf seal CAS lives in the ledger.
     """
     from scripts.lexicon import enrich_manifest as em
 
@@ -154,141 +167,318 @@ def enrich_offline_slice(
     finally:
         sources.close()
 
-    # PR2/3/4 stubs recorded for fingerprint/docs — not functional.
-    ledger = LedgerStub(run_id="pr1-offline", fingerprint=str(staged["cohort_digest"]))
-    _packet = PacketStub(packet_id="pr1-no-network")
-    _seal = SealStub(chunk_id="pr1-coordinator")
+    side_digests = {
+        "balla": balla_art.sha256,
+        "dmklinger": dmk_art.sha256,
+        "kaikki": kaikki_art.sha256,
+    }
+    fingerprint = compute_run_fingerprint(
+        cohort_digest=str(staged["cohort_digest"]),
+        side_db_digests=side_digests,
+        cefr_versions={"seal": cefr_seal.seal_sha256, "algorithm": cefr_seal.algorithm_version},
+        relation_versions={
+            "seal": rel_seal.seal_sha256,
+            "algorithm": rel_seal.algorithm_version,
+        },
+        enrichment_config={"chunk_size": chunk_size, "mode": "offline_slice"},
+    )
 
-    lemma_ids = [str(e.get("url_slug") or e.get("lemma") or "") for e in entries]
-    chunks: list[ChunkSpec] = []
-    for i in range(0, len(lemma_ids), chunk_size):
-        part = lemma_ids[i : i + chunk_size]
-        chunks.append(
-            ChunkSpec(
-                chunk_id=f"chunk-{i // chunk_size:04d}",
-                lemma_ids=part,
-                state=ChunkState.PENDING,
+    ledger_db = Path(ledger_path) if ledger_path is not None else work_dir / "ledger.sqlite"
+    ledger = Ledger(ledger_db, owner_id=owner_id)
+    ledger.open()
+    try:
+        active_run_id: str
+        if run_id is not None:
+            resumed = ledger.resume_run(run_id, fingerprint)
+            if not resumed.ok:
+                return {
+                    "error": resumed.status.value,
+                    "detail": resumed.detail,
+                    "fingerprint": fingerprint,
+                    "run_id": run_id,
+                }
+            active_run_id = str(resumed.run_id)
+        else:
+            started = ledger.start_run(
+                fingerprint,
+                force_new=force_new_run,
+                config={"chunk_size": chunk_size},
             )
+            if not started.ok:
+                return {
+                    "error": started.status.value,
+                    "detail": started.detail,
+                    "resumable_run_id": started.resumable_run_id,
+                    "fingerprint": fingerprint,
+                }
+            active_run_id = str(started.run_id)
+
+        ledger.set_phase(
+            active_run_id,
+            "cefr",
+            "done",
+            seal_sha256=cefr_seal.seal_sha256,
+        )
+        ledger.set_phase(
+            active_run_id,
+            "relations",
+            "done",
+            seal_sha256=rel_seal.seal_sha256,
         )
 
-    artifacts_root = work_dir / "artifacts"
-    artifacts_root.mkdir(parents=True, exist_ok=True)
-    entry_by_id = {str(e.get("url_slug") or e.get("lemma") or ""): e for e in entries}
-    completed: dict[str, dict[str, Any]] = {}
-    failed_terminal: list[dict[str, Any]] = []
+        handle = LedgerStub(run_id=active_run_id, fingerprint=fingerprint)
+        _packet = PacketStub(packet_id="pr2-no-network")
 
-    pending = list(chunks)
-    while pending:
-        chunk = pending.pop(0)
-        if chunk.state == ChunkState.SUPERSEDED:
-            continue
-        chunk_entries = [entry_by_id[lid] for lid in chunk.lemma_ids if lid in entry_by_id]
-        entries_path = work_dir / "chunks" / f"{chunk.chunk_id}.json"
-        entries_path.parent.mkdir(parents=True, exist_ok=True)
-        entries_path.write_text(
-            json.dumps(chunk_entries, ensure_ascii=False, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        artifact_dir = artifacts_root / chunk.chunk_id
-        payload = {
-            "job": "enrich",
-            "chunk_id": chunk.chunk_id,
-            "entries_path": str(entries_path),
-            "sources_db": str(sources_db),
-            "cefr_seal_db": str(work_dir / "seals" / "cefr.sqlite"),
-            "relations_seal_db": str(work_dir / "seals" / "relations.sqlite"),
-            "balla_side_db": balla_art.path,
-            "dmklinger_side_db": dmk_art.path,
-            "kaikki_side_db": kaikki_art.path,
-            "artifact_dir": str(artifact_dir),
-            "memory_high_bytes": policy.high_bytes,
-            "memory_max_bytes": policy.max_bytes,
-        }
-        if skip_workers:
-            from scripts.lexicon.runner.worker_enrich import enrich_chunk_payload
-
-            # Still apply sealed phases + side DBs, but in-process (tests without
-            # spawning). Memory self-test already ran above.
-            arts = enrich_chunk_payload(payload)
-            for lemma_id, _digest in arts.items():
-                completed[lemma_id] = json.loads(
-                    (artifact_dir / f"{lemma_id}.json").read_text(encoding="utf-8")
+        lemma_ids = [str(e.get("url_slug") or e.get("lemma") or "") for e in entries]
+        chunks: list[ChunkSpec] = []
+        for i in range(0, len(lemma_ids), chunk_size):
+            part = lemma_ids[i : i + chunk_size]
+            chunks.append(
+                ChunkSpec(
+                    chunk_id=f"chunk-{i // chunk_size:04d}",
+                    lemma_ids=part,
+                    state=ChunkState.PENDING,
                 )
-            continue
+            )
 
-        result = run_capped_worker(
-            payload,
-            result_path=work_dir / "results" / f"{chunk.chunk_id}.json",
+        # Register units once; INSERT OR IGNORE keeps resume idempotent.
+        ledger.register_chunk_work_units(
+            active_run_id,
+            [(c.chunk_id, c.lemma_ids) for c in chunks],
         )
-        if result.error_code == ErrorCode.FAILED_OOM.value:
-            split_result = split_on_oom(chunk)
-            if isinstance(split_result, OomSplitChildren):
-                mark_parent_superseded(chunk)
-                pending.extend([split_result.left, split_result.right])
-            else:
-                failed_chunk, code = split_result
+
+        artifacts_root = work_dir / "artifacts"
+        artifacts_root.mkdir(parents=True, exist_ok=True)
+        entry_by_id = {str(e.get("url_slug") or e.get("lemma") or ""): e for e in entries}
+        completed: dict[str, dict[str, Any]] = {}
+        failed_terminal: list[dict[str, Any]] = []
+
+        # Reload already-done lemma artifacts on resume.
+        for chunk in chunks:
+            chunk_row = ledger.get_chunk(active_run_id, chunk.chunk_id)
+            if chunk_row is None:
+                continue
+            if str(chunk_row["state"]) in {
+                ChunkLedgerState.DONE.value,
+                ChunkLedgerState.SEALED.value,
+            }:
+                for lemma_id in chunk.lemma_ids:
+                    artifact_file = artifacts_root / chunk.chunk_id / f"{lemma_id}.json"
+                    if artifact_file.is_file():
+                        completed[lemma_id] = json.loads(
+                            artifact_file.read_text(encoding="utf-8")
+                        )
+
+        pending = list(chunks)
+        processed_this_invocation = 0
+        owner = ledger.owner_id
+
+        while pending:
+            if stop_after_chunks is not None and processed_this_invocation >= stop_after_chunks:
+                break
+            chunk = pending.pop(0)
+            if chunk.state == ChunkState.SUPERSEDED:
+                continue
+            existing = ledger.get_chunk(active_run_id, chunk.chunk_id)
+            if existing is not None and str(existing["state"]) in {
+                ChunkLedgerState.DONE.value,
+                ChunkLedgerState.SEALED.value,
+                ChunkLedgerState.SUPERSEDED.value,
+                ChunkLedgerState.FAILED_TERMINAL.value,
+            }:
+                continue
+
+            claim = ledger.claim_unit(active_run_id, chunk.chunk_id, owner)
+            if not claim.ok:
+                if claim.status is CasStatus.ATTEMPT_CAP_EXHAUSTED:
+                    failed_terminal.append(
+                        {
+                            "chunk_id": chunk.chunk_id,
+                            "error_code": ErrorCode.ATTEMPT_CAP_EXHAUSTED.value,
+                            "state": ChunkState.FAILED_TERMINAL.value,
+                        }
+                    )
+                continue
+            lease_gen = int(claim.lease_generation or 0)
+            hb = ledger.heartbeat(active_run_id, chunk.chunk_id, owner, lease_gen)
+            if not hb.ok:
+                continue
+
+            chunk_entries = [entry_by_id[lid] for lid in chunk.lemma_ids if lid in entry_by_id]
+            entries_path = work_dir / "chunks" / f"{chunk.chunk_id}.json"
+            entries_path.parent.mkdir(parents=True, exist_ok=True)
+            entries_path.write_text(
+                json.dumps(chunk_entries, ensure_ascii=False, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            artifact_dir = artifacts_root / chunk.chunk_id
+            payload = {
+                "job": "enrich",
+                "chunk_id": chunk.chunk_id,
+                "entries_path": str(entries_path),
+                "sources_db": str(sources_db),
+                "cefr_seal_db": str(work_dir / "seals" / "cefr.sqlite"),
+                "relations_seal_db": str(work_dir / "seals" / "relations.sqlite"),
+                "balla_side_db": balla_art.path,
+                "dmklinger_side_db": dmk_art.path,
+                "kaikki_side_db": kaikki_art.path,
+                "artifact_dir": str(artifact_dir),
+                "memory_high_bytes": policy.high_bytes,
+                "memory_max_bytes": policy.max_bytes,
+            }
+            if skip_workers:
+                from scripts.lexicon.runner.worker_enrich import enrich_chunk_payload
+
+                arts = enrich_chunk_payload(payload)
+                for lemma_id, _digest in arts.items():
+                    completed[lemma_id] = json.loads(
+                        (artifact_dir / f"{lemma_id}.json").read_text(encoding="utf-8")
+                    )
+                result_hash = hashlib.sha256(
+                    json.dumps(sorted(arts.items()), sort_keys=True).encode("utf-8")
+                ).hexdigest()
+                commit = ledger.commit_result(
+                    active_run_id,
+                    chunk.chunk_id,
+                    owner,
+                    lease_gen,
+                    "done",
+                    result_hash=result_hash,
+                )
+                if commit.ok:
+                    processed_this_invocation += 1
+                continue
+
+            result = run_capped_worker(
+                payload,
+                result_path=work_dir / "results" / f"{chunk.chunk_id}.json",
+            )
+            if result.error_code == ErrorCode.FAILED_OOM.value:
+                split_cas = ledger.commit_split(
+                    active_run_id,
+                    chunk.chunk_id,
+                    owner,
+                    lease_gen,
+                )
+                if not split_cas.ok:
+                    failed_terminal.append(
+                        {
+                            "chunk_id": chunk.chunk_id,
+                            "error_code": split_cas.status.value,
+                            "message": split_cas.detail,
+                        }
+                    )
+                    continue
+                split_result = split_on_oom(chunk)
+                if isinstance(split_result, OomSplitChildren):
+                    mark_parent_superseded(chunk)
+                    pending.extend([split_result.left, split_result.right])
+                else:
+                    failed_chunk, code = split_result
+                    failed_terminal.append(
+                        {
+                            "chunk_id": failed_chunk.chunk_id,
+                            "lemma_ids": failed_chunk.lemma_ids,
+                            "error_code": code,
+                            "state": ChunkState.FAILED_TERMINAL.value,
+                        }
+                    )
+                processed_this_invocation += 1
+                continue
+            if result.outcome != "done":
+                ledger.commit_result(
+                    active_run_id,
+                    chunk.chunk_id,
+                    owner,
+                    lease_gen,
+                    "failed_terminal",
+                    error_code=result.error_code,
+                )
                 failed_terminal.append(
                     {
-                        "chunk_id": failed_chunk.chunk_id,
-                        "lemma_ids": failed_chunk.lemma_ids,
-                        "error_code": code,
-                        "state": ChunkState.FAILED_TERMINAL.value,
+                        "chunk_id": chunk.chunk_id,
+                        "error_code": result.error_code,
+                        "message": result.message,
                     }
                 )
-            continue
-        if result.outcome != "done":
-            failed_terminal.append(
-                {
-                    "chunk_id": chunk.chunk_id,
-                    "error_code": result.error_code,
-                    "message": result.message,
-                }
+                processed_this_invocation += 1
+                continue
+            for lemma_id in chunk.lemma_ids:
+                artifact_file = artifact_dir / f"{lemma_id}.json"
+                if artifact_file.is_file():
+                    completed[lemma_id] = json.loads(artifact_file.read_text(encoding="utf-8"))
+            result_hash = hashlib.sha256(
+                json.dumps(sorted(result.lemma_artifacts.items()), sort_keys=True).encode("utf-8")
+            ).hexdigest()
+            ledger.commit_result(
+                active_run_id,
+                chunk.chunk_id,
+                owner,
+                lease_gen,
+                "done",
+                result_hash=result_hash,
             )
-            continue
-        for lemma_id in chunk.lemma_ids:
-            artifact_file = artifact_dir / f"{lemma_id}.json"
-            if artifact_file.is_file():
-                completed[lemma_id] = json.loads(artifact_file.read_text(encoding="utf-8"))
+            processed_this_invocation += 1
 
-    with StreamingCandidateWriter(
-        output_path,
-        meta={
-            "enrichment_generated": True,
-            "runner_engine_version": "runner-pr1-v1",
+        interrupted = stop_after_chunks is not None and any(
+            str((ledger.get_chunk(active_run_id, c.chunk_id) or {}).get("state"))
+            in {
+                ChunkLedgerState.PENDING.value,
+                ChunkLedgerState.LEASED.value,
+                UnitOutcome.RETRY_SCHEDULED.value,
+            }
+            for c in chunks
+        )
+        if not interrupted and not failed_terminal:
+            # All registered leaf chunks done/sealed?
+            pending_left = ledger.list_pending_chunk_ids(active_run_id)
+            if not pending_left:
+                ledger.mark_run_completed(active_run_id)
+
+        with StreamingCandidateWriter(
+            output_path,
+            meta={
+                "enrichment_generated": True,
+                "runner_engine_version": ENGINE_VERSION,
+                "cohort_digest": staged["cohort_digest"],
+                "cefr_seal": cefr_seal.seal_sha256,
+                "relations_seal": rel_seal.seal_sha256,
+                "ledger_run_id": handle.run_id,
+                "ledger_fingerprint": fingerprint,
+                "side_db_digests": side_digests,
+                "memory_self_test": {
+                    "kind": proof.kind,
+                    "enforced": proof.enforced,
+                    "detail": proof.detail,
+                },
+                "failed_terminal": failed_terminal,
+                "interrupted": interrupted,
+            },
+        ) as writer:
+            for lemma_id in lemma_ids:
+                if lemma_id in completed:
+                    writer.write_entry(completed[lemma_id])
+                elif lemma_id in entry_by_id:
+                    writer.write_entry(entry_by_id[lemma_id])
+
+        return {
             "cohort_digest": staged["cohort_digest"],
+            "entry_count": staged["entry_count"],
             "cefr_seal": cefr_seal.seal_sha256,
             "relations_seal": rel_seal.seal_sha256,
-            "ledger_stub_run_id": ledger.run_id,
-            "side_db_digests": {
-                "balla": balla_art.sha256,
-                "dmklinger": dmk_art.sha256,
-                "kaikki": kaikki_art.sha256,
-            },
-            "memory_self_test": {
+            "completed": len(completed),
+            "failed_terminal": failed_terminal,
+            "output_path": str(output_path),
+            "run_id": active_run_id,
+            "fingerprint": fingerprint,
+            "ledger_path": str(ledger_db),
+            "interrupted": interrupted,
+            "processed_this_invocation": processed_this_invocation,
+            "memory_proof": {
                 "kind": proof.kind,
                 "enforced": proof.enforced,
                 "detail": proof.detail,
             },
-            "failed_terminal": failed_terminal,
-        },
-    ) as writer:
-        for lemma_id in lemma_ids:
-            if lemma_id in completed:
-                writer.write_entry(completed[lemma_id])
-            elif lemma_id in entry_by_id:
-                writer.write_entry(entry_by_id[lemma_id])
-
-    return {
-        "cohort_digest": staged["cohort_digest"],
-        "entry_count": staged["entry_count"],
-        "cefr_seal": cefr_seal.seal_sha256,
-        "relations_seal": rel_seal.seal_sha256,
-        "completed": len(completed),
-        "failed_terminal": failed_terminal,
-        "output_path": str(output_path),
-        "memory_proof": {
-            "kind": proof.kind,
-            "enforced": proof.enforced,
-            "detail": proof.detail,
-        },
-    }
+        }
+    finally:
+        ledger.close()

--- a/tests/test_lexicon_runner_pr2_ledger.py
+++ b/tests/test_lexicon_runner_pr2_ledger.py
@@ -1,0 +1,506 @@
+"""Injected-crash + fencing tests for runner PR2 (real-unit ledger / resume)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.lexicon.runner.contracts import ErrorCode
+from scripts.lexicon.runner.ledger import (
+    CasStatus,
+    ChunkLedgerState,
+    DuplicateRunnerError,
+    Ledger,
+    OperatorActionKind,
+    SchedulableState,
+    UnitOutcome,
+    compute_run_fingerprint,
+)
+from scripts.lexicon.runner.split import child_chunk_id
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "lexicon" / "runner_pr1"
+
+
+def _ensure_fixture() -> None:
+    needed = (
+        FIXTURE / "baseline.sha256",
+        FIXTURE / "baseline_enriched.json",
+        FIXTURE / "sources_slice.sqlite",
+        FIXTURE / "slice_input.json",
+        FIXTURE / "grac_frequency_slice.json",
+        FIXTURE / "kaikki_slice.json",
+    )
+    if not all(path.is_file() for path in needed):
+        from scripts.lexicon.runner.generate_pr1_fixture import main as gen
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("LEXICON_SLOVNYK_OFFLINE", "1")
+            assert gen() == 0
+
+
+@pytest.fixture
+def ledger(tmp_path: Path) -> Ledger:
+    lg = Ledger(tmp_path / "run.ledger.sqlite", max_attempts=3, lease_ttl_seconds=60.0)
+    lg.open()
+    yield lg
+    lg.close()
+
+
+def test_duplicate_runner_os_lock_refused(tmp_path: Path) -> None:
+    path = tmp_path / "shared.ledger.sqlite"
+    a = Ledger(path, owner_id="writer-a")
+    a.open()
+    b = Ledger(path, owner_id="writer-b")
+    with pytest.raises(DuplicateRunnerError, match="duplicate runner refused"):
+        b.open()
+    a.close()
+    # After release, a second writer may acquire.
+    b.open()
+    b.close()
+
+
+def test_fingerprint_start_refuses_duplicate_incomplete(ledger: Ledger) -> None:
+    fp = compute_run_fingerprint(cohort_digest="cohort-a")
+    first = ledger.start_run(fp)
+    assert first.ok and first.run_id
+    second = ledger.start_run(fp)
+    assert not second.ok
+    assert second.resumable_run_id == first.run_id
+    # force_new creates a separate run without attaching old results.
+    forced = ledger.start_run(fp, force_new=True)
+    assert forced.ok
+    assert forced.run_id != first.run_id
+
+
+def test_resume_fingerprint_mismatch_refused(ledger: Ledger) -> None:
+    fp = compute_run_fingerprint(cohort_digest="cohort-b")
+    started = ledger.start_run(fp)
+    assert started.run_id
+    bad = ledger.resume_run(started.run_id, compute_run_fingerprint(cohort_digest="OTHER"))
+    assert bad.status is CasStatus.FINGERPRINT_MISMATCH_REFUSED
+    assert bad.detail == ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value
+    events = ledger.list_events(started.run_id, event=ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value)
+    assert events
+    good = ledger.resume_run(started.run_id, fp)
+    assert good.ok
+
+
+def test_claim_monotonic_generation_and_heartbeat_cas(ledger: Ledger) -> None:
+    fp = compute_run_fingerprint(cohort_digest="claim")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_chunk_work_units(run, [("chunk-0", ["a", "b"])])
+    c1 = ledger.claim_unit(run, "chunk-0", "owner-1", now=1000.0)
+    assert c1.ok
+    assert c1.lease_generation == 1
+    hb_ok = ledger.heartbeat(run, "chunk-0", "owner-1", 1, now=1010.0)
+    assert hb_ok.ok
+    # Stale writer heartbeat rejected.
+    hb_stale = ledger.heartbeat(run, "chunk-0", "owner-OLD", 1, now=1011.0)
+    assert hb_stale.status is CasStatus.STALE_COMMIT_REJECTED
+    hb_stale_gen = ledger.heartbeat(run, "chunk-0", "owner-1", 99, now=1012.0)
+    assert hb_stale_gen.status is CasStatus.STALE_COMMIT_REJECTED
+
+
+def test_stale_writer_result_commit_rejected(ledger: Ledger) -> None:
+    """Injected-crash suite: stale writers cannot commit after claim loss."""
+    fp = compute_run_fingerprint(cohort_digest="stale")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_chunk_work_units(run, [("chunk-0", ["x"])])
+    c1 = ledger.claim_unit(run, "chunk-0", "owner-A", now=1000.0)
+    assert c1.lease_generation == 1
+    # Lease expires; reclaim; new owner claims (generation 2).
+    reclaimed = ledger.reclaim_expired(run, now=2000.0)
+    assert "chunk-0" in reclaimed
+    events = ledger.list_events(run, event="lease_reclaimed")
+    assert events
+    c2 = ledger.claim_unit(run, "chunk-0", "owner-B", now=2001.0)
+    assert c2.ok and c2.lease_generation == 2
+    # Stale A commits with gen=1 → rejected; B commits with gen=2 → ok.
+    stale = ledger.commit_result(
+        run, "chunk-0", "owner-A", 1, "done", result_hash="hash-a", now=2002.0
+    )
+    assert stale.status is CasStatus.STALE_COMMIT_REJECTED
+    assert stale.detail == ErrorCode.STALE_COMMIT_REJECTED.value
+    good = ledger.commit_result(
+        run, "chunk-0", "owner-B", 2, "done", result_hash="hash-b", now=2003.0
+    )
+    assert good.ok
+    unit = ledger.get_work_unit(run, "chunk-0")
+    assert unit is not None
+    assert unit["result_hash"] == "hash-b"
+    assert unit["state"] == UnitOutcome.DONE.value
+
+
+def test_claim_loss_reclaim_increments_generation(ledger: Ledger) -> None:
+    fp = compute_run_fingerprint(cohort_digest="claim-loss")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_work_unit(run, "lemma-1", unit_kind="lemma")
+    c1 = ledger.claim_unit(run, "lemma-1", "w1", now=10.0)
+    assert c1.lease_generation == 1
+    ledger.reclaim_expired(run, now=9999.0)
+    c2 = ledger.claim_unit(run, "lemma-1", "w2", now=10000.0)
+    assert c2.lease_generation == 2
+    assert c2.attempt_count == 2
+
+
+def test_attempt_cap_exhaustion_and_operator_retry(ledger: Ledger) -> None:
+    ledger.max_attempts = 2
+    fp = compute_run_fingerprint(cohort_digest="cap")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_work_unit(run, "lemma-z", unit_kind="lemma")
+    t = 100.0
+    for owner in ("a", "b"):
+        c = ledger.claim_unit(run, "lemma-z", owner, now=t)
+        assert c.ok
+        ledger.commit_result(
+            run,
+            "lemma-z",
+            owner,
+            int(c.lease_generation or 0),
+            "retry_scheduled",
+            error_code="transient",
+            now=t + 1,
+        )
+        t += 10
+    # Third claim hits cap → failed_terminal.
+    exhausted = ledger.claim_unit(run, "lemma-z", "c", now=t)
+    assert exhausted.status is CasStatus.ATTEMPT_CAP_EXHAUSTED
+    unit = ledger.get_work_unit(run, "lemma-z")
+    assert unit is not None
+    assert unit["state"] == UnitOutcome.FAILED_TERMINAL.value
+    # Operator retry is the only reopen path.
+    bad = ledger.retry_failed(run, "lemma-z", "")
+    assert not bad.ok
+    ok = ledger.retry_failed(run, "lemma-z", "operator accepted transient exhaustion")
+    assert ok.ok
+    assert ledger.count_operator_actions(run, OperatorActionKind.RETRY_FAILED.value) == 1
+    unit2 = ledger.get_work_unit(run, "lemma-z")
+    assert unit2 is not None
+    assert unit2["state"] == SchedulableState.PENDING.value
+    assert int(unit2["attempt_count"]) == 0
+    run_row = ledger.get_run(run)
+    assert run_row is not None
+    assert int(run_row["manual_retry_epoch"]) == 1
+
+
+def test_split_interruption_and_deterministic_children(ledger: Ledger) -> None:
+    """Crash mid-split: parent remains active; retry creates same child IDs."""
+    fp = compute_run_fingerprint(cohort_digest="split")
+    run = ledger.start_run(fp).run_id
+    assert run
+    parent_id = "parent"
+    lemmas = ["a", "b", "c", "d"]
+    ledger.register_chunk_work_units(run, [(parent_id, lemmas)])
+    claim = ledger.claim_unit(run, parent_id, "coord", now=50.0)
+    assert claim.ok
+    gen = int(claim.lease_generation or 0)
+
+    ledger.crash_mid_split = True
+    with pytest.raises(RuntimeError, match="injected crash: mid_split"):
+        ledger.commit_split(run, parent_id, "coord", gen, now=51.0)
+    ledger.crash_mid_split = False
+
+    # Parent still leased (no partial children).
+    parent = ledger.get_chunk(run, parent_id)
+    assert parent is not None
+    assert parent["state"] == ChunkLedgerState.LEASED.value
+    assert int(parent["is_leaf"]) == 1
+
+    # Retry completes deterministically.
+    done = ledger.commit_split(run, parent_id, "coord", gen, now=52.0)
+    assert done.ok
+    parent2 = ledger.get_chunk(run, parent_id)
+    assert parent2 is not None
+    assert parent2["state"] == ChunkLedgerState.SUPERSEDED.value
+    assert int(parent2["is_leaf"]) == 0
+    left_id = child_chunk_id(parent_id, 1, ["a", "b"])
+    right_id = child_chunk_id(parent_id, 1, ["c", "d"])
+    left = ledger.get_chunk(run, left_id)
+    right = ledger.get_chunk(run, right_id)
+    assert left is not None and right is not None
+    assert left["state"] == ChunkLedgerState.PENDING.value
+    assert right["state"] == ChunkLedgerState.PENDING.value
+    # Re-split of a superseded (non-leaf) parent is refused.
+    again = ledger.commit_split(run, parent_id, "coord", gen, now=53.0)
+    assert again.status is CasStatus.NOT_LEAF
+
+
+def test_single_lemma_oom_failed_terminal_no_split(ledger: Ledger) -> None:
+    fp = compute_run_fingerprint(cohort_digest="oom1")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_chunk_work_units(run, [("leaf", ["only"])])
+    claim = ledger.claim_unit(run, "leaf", "coord", now=1.0)
+    assert claim.ok
+    res = ledger.commit_split(run, "leaf", "coord", int(claim.lease_generation or 0), now=2.0)
+    assert res.ok
+    leaf = ledger.get_chunk(run, "leaf")
+    assert leaf is not None
+    assert leaf["state"] == ChunkLedgerState.FAILED_TERMINAL.value
+    assert leaf["error_code"] == ErrorCode.FAILED_OOM.value
+
+
+def test_seal_interruption_and_leaf_only_rules(ledger: Ledger) -> None:
+    """Seal crash leaves no seal row; superseded parents never seal."""
+    fp = compute_run_fingerprint(cohort_digest="seal")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_chunk_work_units(run, [("parent", ["a", "b"])])
+    claim = ledger.claim_unit(run, "parent", "coord", now=10.0)
+    gen = int(claim.lease_generation or 0)
+    assert ledger.commit_split(run, "parent", "coord", gen, now=11.0).ok
+    left_id = child_chunk_id("parent", 1, ["a"])
+    # Parent is superseded — not sealable.
+    parent_seal = ledger.commit_seal(
+        run, "parent", "coord", gen, seal_sha256="dead", now=12.0
+    )
+    assert parent_seal.status is CasStatus.NOT_LEAF
+
+    # Claim leaf, mark done, then crash mid-seal.
+    c_left = ledger.claim_unit(run, left_id, "coord", now=13.0)
+    assert c_left.ok
+    lgen = int(c_left.lease_generation or 0)
+    assert ledger.commit_result(
+        run, left_id, "coord", lgen, "done", result_hash="r1", now=14.0
+    ).ok
+    # After result, owner released; seal uses matching generation on DONE leaf.
+    leaf = ledger.get_chunk(run, left_id)
+    assert leaf is not None
+    assert int(leaf["lease_generation"]) == lgen
+
+    ledger.crash_mid_seal = True
+    with pytest.raises(RuntimeError, match="injected crash: mid_seal"):
+        ledger.commit_seal(run, left_id, "coord", lgen, seal_sha256="seal-1", now=15.0)
+    ledger.crash_mid_seal = False
+    # No seal row after crash.
+    seals = ledger._require().execute(
+        "SELECT COUNT(*) AS n FROM seals WHERE run_id = ? AND chunk_id = ?",
+        (run, left_id),
+    ).fetchone()
+    assert int(seals["n"]) == 0
+    # Retry seal succeeds.
+    sealed = ledger.commit_seal(run, left_id, "coord", lgen, seal_sha256="seal-1", now=16.0)
+    assert sealed.ok
+    seals2 = ledger._require().execute(
+        "SELECT seal_sha256 FROM seals WHERE run_id = ? AND chunk_id = ?",
+        (run, left_id),
+    ).fetchone()
+    assert seals2 is not None
+    assert seals2["seal_sha256"] == "seal-1"
+    # Stale generation seal rejected.
+    stale = ledger.commit_seal(run, left_id, "coord", lgen - 1, seal_sha256="seal-x", now=17.0)
+    assert stale.status in {CasStatus.STALE_COMMIT_REJECTED, CasStatus.INVALID_STATE}
+
+
+def test_import_cas_and_stale_generation(ledger: Ledger) -> None:
+    fp = compute_run_fingerprint(cohort_digest="import")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_work_unit(run, "lemma-i", unit_kind="lemma", phase="network_import")
+    claim = ledger.claim_unit(run, "lemma-i", "imp", phase="network_import", now=1.0)
+    gen = int(claim.lease_generation or 0)
+    ok = ledger.commit_import(
+        run,
+        "lemma-i",
+        "imp",
+        gen,
+        packet_generation=1,
+        result_hash="body-1",
+        expected_fingerprint=fp,
+        now=2.0,
+    )
+    assert ok.ok
+    # Re-import matching hash is no-op success.
+    again = ledger.commit_import(
+        run,
+        "lemma-i",
+        "imp",
+        gen,
+        packet_generation=1,
+        result_hash="body-1",
+        expected_fingerprint=fp,
+        now=3.0,
+    )
+    assert again.ok
+    # Fingerprint mismatch refused.
+    bad_fp = ledger.commit_import(
+        run,
+        "lemma-j",
+        "imp",
+        1,
+        packet_generation=1,
+        result_hash="x",
+        expected_fingerprint="nope",
+        now=4.0,
+    )
+    assert bad_fp.status is CasStatus.FINGERPRINT_MISMATCH_REFUSED
+
+    # Stale owner/generation on a leased unit.
+    ledger.register_work_unit(run, "lemma-k", unit_kind="lemma", phase="network_import")
+    c2 = ledger.claim_unit(run, "lemma-k", "imp2", phase="network_import", now=5.0)
+    stale = ledger.commit_import(
+        run,
+        "lemma-k",
+        "wrong-owner",
+        int(c2.lease_generation or 0),
+        packet_generation=2,
+        result_hash="body-k",
+        expected_fingerprint=fp,
+        phase="network_import",
+        now=6.0,
+    )
+    assert stale.status is CasStatus.STALE_COMMIT_REJECTED
+
+
+def test_abandon_packet_operator_record(ledger: Ledger) -> None:
+    fp = compute_run_fingerprint(cohort_digest="pkt")
+    run = ledger.start_run(fp).run_id
+    assert run
+    res = ledger.abandon_packet(run, "pkt-1", 3, "operator abandoned stale transport")
+    assert res.ok
+    assert ledger.count_operator_actions(run, OperatorActionKind.ABANDON_PACKET.value) == 1
+
+
+def test_500_lemma_slice_resume_from_interrupted_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resume continues the frozen 500-lemma offline slice after interruption."""
+    _ensure_fixture()
+    from scripts.lexicon import enrich_manifest as em
+    from scripts.lexicon.runner.memory import EnforcementProof
+    from scripts.lexicon.runner.offline_engine import enrich_offline_slice
+
+    monkeypatch.setattr(em, "_vesum_valid_synonym", lambda term: bool(term))
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.offline_engine.run_startup_self_test",
+        lambda **_kwargs: EnforcementProof(
+            kind="rlimit_as",
+            enforced=True,
+            detail="test stub",
+            max_bytes=64 * 1024 * 1024,
+        ),
+    )
+
+    # In-process enrich stub: write tiny artifacts without full sources.
+    def _fake_enrich(payload: dict) -> dict[str, str]:
+        import hashlib
+
+        entries = json.loads(Path(payload["entries_path"]).read_text(encoding="utf-8"))
+        artifact_dir = Path(payload["artifact_dir"])
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        arts: dict[str, str] = {}
+        for entry in entries:
+            lemma_id = str(entry.get("url_slug") or entry.get("lemma") or "")
+            body = {"lemma": entry.get("lemma"), "url_slug": lemma_id, "enriched": True}
+            raw = json.dumps(body, ensure_ascii=False, sort_keys=True)
+            (artifact_dir / f"{lemma_id}.json").write_text(raw + "\n", encoding="utf-8")
+            arts[lemma_id] = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        return arts
+
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.worker_enrich.enrich_chunk_payload",
+        _fake_enrich,
+    )
+
+    grac = json.loads((FIXTURE / "grac_frequency_slice.json").read_text(encoding="utf-8"))
+    work = tmp_path / "runner_work"
+    out1 = tmp_path / "candidate1.json"
+    ledger_path = work / "ledger.sqlite"
+
+    first = enrich_offline_slice(
+        manifest_path=FIXTURE / "slice_input.json",
+        sources_db=FIXTURE / "sources_slice.sqlite",
+        kaikki_json=FIXTURE / "kaikki_slice.json",
+        work_dir=work,
+        output_path=out1,
+        grac_cache=dict(grac),
+        require_memory_self_test=False,
+        skip_workers=True,
+        chunk_size=50,
+        ledger_path=ledger_path,
+        stop_after_chunks=3,
+        owner_id="resume-test-1",
+    )
+    assert "error" not in first, first
+    assert first["interrupted"] is True
+    assert first["processed_this_invocation"] == 3
+    assert first["run_id"]
+    run_id = first["run_id"]
+    fingerprint = first["fingerprint"]
+
+    # Same fingerprint start must refuse and point at resumable run.
+    refuse = enrich_offline_slice(
+        manifest_path=FIXTURE / "slice_input.json",
+        sources_db=FIXTURE / "sources_slice.sqlite",
+        kaikki_json=FIXTURE / "kaikki_slice.json",
+        work_dir=work,
+        output_path=tmp_path / "should_refuse.json",
+        grac_cache=dict(grac),
+        require_memory_self_test=False,
+        skip_workers=True,
+        chunk_size=50,
+        ledger_path=ledger_path,
+        owner_id="resume-test-refuse",
+    )
+    assert refuse.get("error") == CasStatus.INVALID_STATE.value
+    assert refuse.get("resumable_run_id") == run_id
+
+    out2 = tmp_path / "candidate2.json"
+    second = enrich_offline_slice(
+        manifest_path=FIXTURE / "slice_input.json",
+        sources_db=FIXTURE / "sources_slice.sqlite",
+        kaikki_json=FIXTURE / "kaikki_slice.json",
+        work_dir=work,
+        output_path=out2,
+        grac_cache=dict(grac),
+        require_memory_self_test=False,
+        skip_workers=True,
+        chunk_size=50,
+        ledger_path=ledger_path,
+        run_id=run_id,
+        owner_id="resume-test-2",
+    )
+    assert "error" not in second, second
+    assert second["run_id"] == run_id
+    assert second["fingerprint"] == fingerprint
+    assert second["interrupted"] is False
+    # Resume must process remaining chunks (500/50=10 total; first did 3).
+    assert second["processed_this_invocation"] == 7
+    assert second["completed"] == 500
+
+    lg = Ledger(ledger_path, owner_id="verify")
+    lg.open()
+    try:
+        done = lg.list_completed_chunk_ids(run_id)
+        assert len(done) == 10
+        pending = lg.list_pending_chunk_ids(run_id)
+        assert pending == []
+        run_row = lg.get_run(run_id)
+        assert run_row is not None
+        assert run_row["status"] == "completed"
+    finally:
+        lg.close()
+
+    candidate = json.loads(out2.read_text(encoding="utf-8"))
+    assert candidate["ledger_run_id"] == run_id
+    assert len(candidate["entries"]) == 500
+
+
+def test_issue_streams_registers_5331_under_atlas_practice() -> None:
+    import yaml
+
+    doc = yaml.safe_load(
+        Path("scripts/config/issue_streams.yaml").read_text(encoding="utf-8")
+    )
+    epics = doc["streams"]["atlas-practice"]["epics"]
+    assert 5331 in epics
+    assert 4387 in epics
+    # Do not claim infra's issue.
+    infra = doc["streams"]["infra-harness"]["epics"]
+    assert 5331 not in infra

--- a/tests/test_lexicon_runner_pr2_ledger.py
+++ b/tests/test_lexicon_runner_pr2_ledger.py
@@ -189,8 +189,88 @@ def test_attempt_cap_exhaustion_and_operator_retry(ledger: Ledger) -> None:
     assert int(run_row["manual_retry_epoch"]) == 1
 
 
+def test_attempt_cap_syncs_chunk_row(ledger: Ledger) -> None:
+    """Attempt-cap terminal marking must update work_units AND chunks together."""
+    ledger.max_attempts = 1
+    fp = compute_run_fingerprint(cohort_digest="cap-chunk")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_chunk_work_units(run, [("chunk-cap", ["x", "y"])])
+    c1 = ledger.claim_unit(run, "chunk-cap", "owner-1", now=10.0)
+    assert c1.ok
+    assert ledger.commit_result(
+        run,
+        "chunk-cap",
+        "owner-1",
+        int(c1.lease_generation or 0),
+        "retry_scheduled",
+        error_code="transient",
+        now=11.0,
+    ).ok
+    exhausted = ledger.claim_unit(run, "chunk-cap", "owner-2", now=12.0)
+    assert exhausted.status is CasStatus.ATTEMPT_CAP_EXHAUSTED
+    unit = ledger.get_work_unit(run, "chunk-cap")
+    chunk = ledger.get_chunk(run, "chunk-cap")
+    assert unit is not None and chunk is not None
+    assert unit["state"] == UnitOutcome.FAILED_TERMINAL.value
+    assert chunk["state"] == ChunkLedgerState.FAILED_TERMINAL.value
+    assert chunk["error_code"] == "attempt_cap_exhausted"
+
+
+def test_claim_crash_mid_transaction_rolls_back_both_tables(ledger: Ledger) -> None:
+    """crash_after_claim fires inside the write txn so neither table commits."""
+    fp = compute_run_fingerprint(cohort_digest="claim-crash")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_chunk_work_units(run, [("chunk-c", ["a"])])
+    ledger.crash_after_claim = True
+    with pytest.raises(RuntimeError, match="injected crash: after_claim"):
+        ledger.claim_unit(run, "chunk-c", "owner", now=1.0)
+    ledger.crash_after_claim = False
+    unit = ledger.get_work_unit(run, "chunk-c")
+    chunk = ledger.get_chunk(run, "chunk-c")
+    assert unit is not None and chunk is not None
+    assert unit["state"] == SchedulableState.PENDING.value
+    assert int(unit["lease_generation"]) == 0
+    assert chunk["state"] == ChunkLedgerState.PENDING.value
+    assert int(chunk["lease_generation"]) == 0
+    # Retry claim succeeds after the crash flag is cleared.
+    ok = ledger.claim_unit(run, "chunk-c", "owner", now=2.0)
+    assert ok.ok and ok.lease_generation == 1
+
+
+def test_result_crash_mid_transaction_rolls_back_both_tables(ledger: Ledger) -> None:
+    """crash_after_result fires inside the write txn so neither table commits."""
+    fp = compute_run_fingerprint(cohort_digest="result-crash")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_chunk_work_units(run, [("chunk-r", ["a"])])
+    claim = ledger.claim_unit(run, "chunk-r", "owner", now=1.0)
+    gen = int(claim.lease_generation or 0)
+    ledger.crash_after_result = True
+    with pytest.raises(RuntimeError, match="injected crash: after_result"):
+        ledger.commit_result(
+            run, "chunk-r", "owner", gen, "done", result_hash="h1", now=2.0
+        )
+    ledger.crash_after_result = False
+    unit = ledger.get_work_unit(run, "chunk-r")
+    chunk = ledger.get_chunk(run, "chunk-r")
+    assert unit is not None and chunk is not None
+    assert unit["state"] == SchedulableState.LEASED.value
+    assert chunk["state"] == ChunkLedgerState.LEASED.value
+    assert unit["result_hash"] is None
+    # Retry commit succeeds.
+    assert ledger.commit_result(
+        run, "chunk-r", "owner", gen, "done", result_hash="h1", now=3.0
+    ).ok
+    unit2 = ledger.get_work_unit(run, "chunk-r")
+    assert unit2 is not None
+    assert unit2["state"] == UnitOutcome.DONE.value
+    assert unit2["result_hash"] == "h1"
+
+
 def test_split_interruption_and_deterministic_children(ledger: Ledger) -> None:
-    """Crash mid-split: parent remains active; retry creates same child IDs."""
+    """Crash mid-split (inside txn): parent remains active; retry creates same child IDs."""
     fp = compute_run_fingerprint(cohort_digest="split")
     run = ledger.start_run(fp).run_id
     assert run
@@ -206,11 +286,14 @@ def test_split_interruption_and_deterministic_children(ledger: Ledger) -> None:
         ledger.commit_split(run, parent_id, "coord", gen, now=51.0)
     ledger.crash_mid_split = False
 
-    # Parent still leased (no partial children).
+    # Parent still leased (no partial children) — crash rolled back mid-txn write.
     parent = ledger.get_chunk(run, parent_id)
     assert parent is not None
     assert parent["state"] == ChunkLedgerState.LEASED.value
     assert int(parent["is_leaf"]) == 1
+    parent_wu = ledger.get_work_unit(run, parent_id)
+    assert parent_wu is not None
+    assert parent_wu["state"] == SchedulableState.LEASED.value
 
     # Retry completes deterministically.
     done = ledger.commit_split(run, parent_id, "coord", gen, now=52.0)
@@ -232,18 +315,35 @@ def test_split_interruption_and_deterministic_children(ledger: Ledger) -> None:
 
 
 def test_single_lemma_oom_failed_terminal_no_split(ledger: Ledger) -> None:
+    """Single-lemma OOM marks chunks + work_units FAILED_TERMINAL atomically."""
     fp = compute_run_fingerprint(cohort_digest="oom1")
     run = ledger.start_run(fp).run_id
     assert run
     ledger.register_chunk_work_units(run, [("leaf", ["only"])])
     claim = ledger.claim_unit(run, "leaf", "coord", now=1.0)
     assert claim.ok
-    res = ledger.commit_split(run, "leaf", "coord", int(claim.lease_generation or 0), now=2.0)
+    gen = int(claim.lease_generation or 0)
+
+    # Mid-txn crash on single-lemma path: neither table advances.
+    ledger.crash_mid_split = True
+    with pytest.raises(RuntimeError, match="injected crash: mid_split"):
+        ledger.commit_split(run, "leaf", "coord", gen, now=2.0)
+    ledger.crash_mid_split = False
+    leaf_mid = ledger.get_chunk(run, "leaf")
+    wu_mid = ledger.get_work_unit(run, "leaf")
+    assert leaf_mid is not None and wu_mid is not None
+    assert leaf_mid["state"] == ChunkLedgerState.LEASED.value
+    assert wu_mid["state"] == SchedulableState.LEASED.value
+
+    res = ledger.commit_split(run, "leaf", "coord", gen, now=3.0)
     assert res.ok
     leaf = ledger.get_chunk(run, "leaf")
-    assert leaf is not None
+    wu = ledger.get_work_unit(run, "leaf")
+    assert leaf is not None and wu is not None
     assert leaf["state"] == ChunkLedgerState.FAILED_TERMINAL.value
     assert leaf["error_code"] == ErrorCode.FAILED_OOM.value
+    assert wu["state"] == UnitOutcome.FAILED_TERMINAL.value
+    assert wu["error_code"] == ErrorCode.FAILED_OOM.value
 
 
 def test_seal_interruption_and_leaf_only_rules(ledger: Ledger) -> None:
@@ -356,6 +456,63 @@ def test_import_cas_and_stale_generation(ledger: Ledger) -> None:
         now=6.0,
     )
     assert stale.status is CasStatus.STALE_COMMIT_REJECTED
+
+
+def test_import_reclaimed_lease_rejected(ledger: Ledger) -> None:
+    """After reclaim to PENDING, stale importer cannot commit_import (CAS bypass fix)."""
+    fp = compute_run_fingerprint(cohort_digest="import-reclaim")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_work_unit(run, "lemma-r", unit_kind="lemma", phase="network_import")
+    claim = ledger.claim_unit(run, "lemma-r", "imp-old", phase="network_import", now=100.0)
+    gen = int(claim.lease_generation or 0)
+    reclaimed = ledger.reclaim_expired(run, now=10_000.0)
+    assert "lemma-r" in reclaimed
+    unit = ledger.get_work_unit(run, "lemma-r", phase="network_import")
+    assert unit is not None
+    assert unit["state"] == SchedulableState.PENDING.value
+
+    stale = ledger.commit_import(
+        run,
+        "lemma-r",
+        "imp-old",
+        gen,
+        packet_generation=7,
+        result_hash="stale-body",
+        expected_fingerprint=fp,
+        phase="network_import",
+        now=10_001.0,
+    )
+    assert stale.status is CasStatus.STALE_COMMIT_REJECTED
+    # Import row must not exist after rejected stale commit.
+    imports = ledger._require().execute(
+        "SELECT COUNT(*) AS n FROM imports WHERE run_id = ? AND lemma_id = ?",
+        (run, "lemma-r"),
+    ).fetchone()
+    assert int(imports["n"]) == 0
+    unit2 = ledger.get_work_unit(run, "lemma-r", phase="network_import")
+    assert unit2 is not None
+    assert unit2["state"] == SchedulableState.PENDING.value
+
+    # Fresh claim + import still succeeds.
+    c2 = ledger.claim_unit(run, "lemma-r", "imp-new", phase="network_import", now=10_002.0)
+    assert c2.ok
+    ok = ledger.commit_import(
+        run,
+        "lemma-r",
+        "imp-new",
+        int(c2.lease_generation or 0),
+        packet_generation=7,
+        result_hash="fresh-body",
+        expected_fingerprint=fp,
+        phase="network_import",
+        now=10_003.0,
+    )
+    assert ok.ok
+    unit3 = ledger.get_work_unit(run, "lemma-r", phase="network_import")
+    assert unit3 is not None
+    assert unit3["state"] == UnitOutcome.DONE.value
+    assert unit3["result_hash"] == "fresh-body"
 
 
 def test_abandon_packet_operator_record(ledger: Ledger) -> None:


### PR DESCRIPTION
## Summary

**PR 2 of #5230** (LOCKED ENRICH-RUNNER-SPEC-v2 §PR2) — real-unit ledger, fencing, and resume on top of merged PR1 engine isolation.

### What changed
- **`scripts/lexicon/runner/ledger.py`** — durable single-writer SQLite ledger:
  - tables: `runs`, `run_phases`, `chunks`, `work_units`, `host_cooldowns`, `packets`, `imports`, `seals`, `operator_actions`, `events`
  - exclusive OS lock (`fcntl.LOCK_EX|LOCK_NB`) — duplicate runner refused
  - transactional claims with monotonic `lease_generation`
  - CAS on heartbeat, result, split, import, seal
  - state vocabulary: schedulable `pending|leased`; outcomes `done|no_data|failed_terminal|retry_scheduled`; chunk `superseded|sealed`
  - total attempt caps → `failed_terminal`; only `retry-failed` operator action reopens (increments `manual_retry_epoch`)
  - fingerprint `start` refuses incomplete same-fingerprint run; `resume` requires exact match (`fingerprint_mismatch_refused`); `start --new-fingerprint` via `force_new`
  - deterministic OOM split children + parent `superseded`; leaf-only seal; crash mid-split/mid-seal leaves no half-rows
- **`offline_engine.enrich_offline_slice`** — wires ledger claims/commits + resume (`run_id`, `stop_after_chunks`, `ledger_path`)
- **`contracts` / package exports** — PR2 vocabulary; `ENGINE_VERSION=runner-pr2-v1`
- **`scripts/config/issue_streams.yaml`** — register **#5331** under `atlas-practice` (umbrella **#4387**)

### Out of scope (later PRs)
- PR3: network/VPS transport, raw cache, packets/bundles
- PR4: streaming finalization + publication gate (leaf seal *CAS* is PR2)

## Acceptance criteria evidence

### 1–2 Transactional claims + CAS
`Ledger.claim_unit` increments `lease_generation`; heartbeat/result/split/import/seal all `WHERE owner=? AND lease_generation=?` (or DONE+gen for seal). Stale writers get `stale_commit_rejected`.

### 3 Single-writer OS locks
`test_duplicate_runner_os_lock_refused` — second `Ledger.open()` raises `DuplicateRunnerError`.

### 4 State vocabulary / attempt caps / operator retry / fingerprint
Covered by unit tests below (cap exhaustion + `retry_failed` audit row; start refuse + resume mismatch).

### 5 Deterministic children / superseded / leaf-only seal
`test_split_interruption_and_deterministic_children`, `test_seal_interruption_and_leaf_only_rules`, `test_single_lemma_oom_failed_terminal_no_split`.

### 6 Injected-crash suites
Stale writers, claim loss, split interruption, seal interruption, 500-lemma resume — all in `tests/test_lexicon_runner_pr2_ledger.py`.

## Verification preamble (raw tool output)

### tests pass (PR2 injected-crash + resume suite)
```
$ .venv/bin/python -m pytest tests/test_lexicon_runner_pr2_ledger.py -v --tb=line
============================= test session starts ==============================
...
tests/test_lexicon_runner_pr2_ledger.py::test_duplicate_runner_os_lock_refused PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_fingerprint_start_refuses_duplicate_incomplete PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_resume_fingerprint_mismatch_refused PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_claim_monotonic_generation_and_heartbeat_cas PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_stale_writer_result_commit_rejected PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_claim_loss_reclaim_increments_generation PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_attempt_cap_exhaustion_and_operator_retry PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_split_interruption_and_deterministic_children PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_single_lemma_oom_failed_terminal_no_split PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_seal_interruption_and_leaf_only_rules PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_import_cas_and_stale_generation PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_abandon_packet_operator_record PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_500_lemma_slice_resume_from_interrupted_run PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_issue_streams_registers_5331_under_atlas_practice PASSED
============================== 14 passed in 0.65s ==============================
```

### fencing holds (stale writer / claim loss)
```
tests/test_lexicon_runner_pr2_ledger.py::test_stale_writer_result_commit_rejected PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_claim_loss_reclaim_increments_generation PASSED
tests/test_lexicon_runner_pr2_ledger.py::test_claim_monotonic_generation_and_heartbeat_cas PASSED
```

### resume works (500-lemma frozen slice)
```
tests/test_lexicon_runner_pr2_ledger.py::test_500_lemma_slice_resume_from_interrupted_run PASSED
```
(Interrupts after 3/10 chunks → same-fingerprint start refused with resumable `run_id` → `resume --run-id` processes remaining 7 → `completed=500`, run `status=completed`.)

### lint clean
```
$ .venv/bin/ruff check scripts/lexicon/runner/ledger.py scripts/lexicon/runner/contracts.py \
    scripts/lexicon/runner/offline_engine.py scripts/lexicon/runner/__init__.py \
    tests/test_lexicon_runner_pr2_ledger.py
All checks passed!
```

### PR1 regression (not weakened)
```
$ .venv/bin/python -m pytest tests/test_lexicon_runner_pr1.py -q
11 passed, 1 skipped in 0.53s
```
(`test_injected_allocation_breach_classified_as_oom` skipped on Darwin — pre-existing.)

### agent trailer
```
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## What was NOT verified
- Full 20k production enrich run against live `sources.db` / network
- Linux cgroup memory path for ledger coordination (unchanged from PR1; Darwin RLIMIT skip remains)
- PR3 packet/bundle transport and VPS cache
- PR4 streaming assembly + verify-before-promote publication gate
- Live GH native sub-issue link of #5331 under #4387 (registry entry only, per brief)
- Cross-family independent review (orchestrator gate — author does not merge)

## Spec / PR1 conflict notes
None blocking. PR1 left `LedgerStub`; PR2 replaces it with a real writer while keeping the stub dataclass as a thin handle. Leaf seal *transaction* is PR2 (CAS + leaf-only); full assembly remains PR4 per resequenced plan.

Refs #5230
Refs #5331