### PR TITLE
fix(review): make v6 provider schema portable

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,4 +1,4 @@
-review_protocol_version: 6.0.0
+review_protocol_version: 6.0.1
 deterministic_contract_version: 2.0.0
 semantic_prompt_version: 6.0.0
 track_policy_version: 2.0.0

--- a/docs/runbooks/post-build-review.md
+++ b/docs/runbooks/post-build-review.md
@@ -89,6 +89,13 @@ seminars, curated named-source aliases are compared with learner-visible
 resources; an unmapped configured source produces a material deterministic
 finding, while incidental acronyms do not become extra source labels.
 
+The provider-facing v6 schema deliberately uses a portable strict-output
+subset. In particular, packet-bound arrays use ordinary `items` constraints
+rather than Draft 2020-12 `prefixItems`, which some supported providers reject
+before inference. This transport accommodation does not relax the canonical
+contract: finalization independently enforces exact vocabulary source order and
+exact source-resource sets, and any mismatch produces `INCOMPLETE`.
+
 Dimension scores preserve the accepted raw reviewer response after strict
 Decimal-based validation: `PASS` is `[8.0, 10.0]`, `REVISE` is `[6.0, 8.0)`,
 `BLOCK` is `[0.0, 6.0)`, and `INCOMPLETE` has a null score/rationale. The

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -3783,38 +3783,6 @@ def _provider_vocabulary_coverage_item_schema(
     }
 
 
-def _provider_vocabulary_prefix_item_schema(
-    lemma: str,
-    candidates: Sequence[tuple[str, str]],
-) -> dict[str, Any]:
-    allowed_pairs = [
-        {
-            "properties": {
-                "surface": {"const": surface},
-                "verification": {"const": verification},
-            },
-            "required": ["surface", "verification"],
-        }
-        for surface, verification in candidates
-    ]
-    return {
-        "allOf": [
-            {"$ref": "#/$defs/vocabularyCoverageItem"},
-            {
-                "properties": {"lemma": {"const": lemma}},
-                "required": ["lemma"],
-            },
-            {
-                "if": {
-                    "properties": {"status": {"const": "INTEGRATED"}},
-                    "required": ["status"],
-                },
-                "then": {"oneOf": allowed_pairs} if allowed_pairs else False,
-            },
-        ]
-    }
-
-
 def hydrate_provider_dimension_evidence(
     semantic: Mapping[str, Any],
     packet: Mapping[str, Any],
@@ -3927,19 +3895,26 @@ def semantic_response_schema(
     definitions["vocabularyEvidence"] = _provider_vocabulary_evidence_schema(packet)
     definitions["vocabularyCoverageItem"] = _provider_vocabulary_coverage_item_schema()
     if packet is not None:
-        candidate_pairs = _packet_vocabulary_candidates(packet)
-        vocabulary_items = [
-            _provider_vocabulary_prefix_item_schema(
-                lemma, candidate_pairs.get(lemma, [])
-            )
-            for lemma in _packet_vocabulary_lemmas(packet)
-        ]
+        vocabulary_lemmas = _packet_vocabulary_lemmas(packet)
         semantic["properties"]["vocabulary_coverage"] = {
             "type": "array",
-            "prefixItems": vocabulary_items,
-            "items": False,
-            "minItems": len(vocabulary_items),
-            "maxItems": len(vocabulary_items),
+            # Anthropic strict structured output accepts the portable `items`
+            # subset, but rejects Draft 2020-12 `prefixItems` before inference.
+            # Keep the transport schema order-agnostic and compact; the
+            # canonical normalizer independently enforces exact source order
+            # and packet-bound surface/verification pairs fail-closed.
+            "items": {
+                "allOf": [
+                    {"$ref": "#/$defs/vocabularyCoverageItem"},
+                    {
+                        "type": "object",
+                        "properties": {"lemma": {"enum": vocabulary_lemmas}},
+                        "required": ["lemma"],
+                    },
+                ]
+            },
+            "minItems": len(vocabulary_lemmas),
+            "maxItems": len(vocabulary_lemmas),
         }
         statement_units = packet["deterministic"]["statement_inventory"]["units"]
         statement_ids = [str(unit["id"]) for unit in statement_units]
@@ -3960,11 +3935,13 @@ def semantic_response_schema(
         if risk_statement_ids:
             statement_coverage_schema["allOf"] = [
                 {
+                    "type": "object",
                     "properties": {
                         unit_id: {
+                            "type": "object",
                             "properties": {
                                 "classification": {"const": "claims"},
-                                "claim_ids": {"minItems": 1},
+                                "claim_ids": {"type": "array", "minItems": 1},
                             }
                         }
                     }
@@ -4012,10 +3989,10 @@ def semantic_response_schema(
                         "status": {"const": "MAPPED"},
                         "resource_ids": {
                             "type": "array",
-                            "prefixItems": [{"const": item} for item in matched],
-                            "items": False,
+                            "items": {"enum": matched},
                             "minItems": len(matched),
                             "maxItems": len(matched),
+                            "uniqueItems": True,
                         },
                         "finding_id": {"type": "null"},
                     },
@@ -4048,8 +4025,29 @@ def semantic_response_schema(
         "$defs": definitions,
         **semantic,
     }
+    _normalize_provider_schema_types(provider_schema)
     Draft202012Validator.check_schema(provider_schema)
     return provider_schema
+
+
+def _normalize_provider_schema_types(value: object) -> None:
+    """Add strict-validator type annotations without changing constraints."""
+    if isinstance(value, list):
+        for item in value:
+            _normalize_provider_schema_types(item)
+        return
+    if not isinstance(value, dict):
+        return
+    for item in value.values():
+        _normalize_provider_schema_types(item)
+    if "type" in value:
+        return
+    if {"properties", "required", "minProperties", "maxProperties"}.intersection(
+        value
+    ):
+        value["type"] = "object"
+    elif {"items", "minItems", "maxItems", "uniqueItems"}.intersection(value):
+        value["type"] = "array"
 
 
 def write_semantic_prompt(

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -1231,7 +1231,7 @@ def test_provider_schema_rejects_prose_suffixed_vesum_mapping() -> None:
         Draft202012Validator(schema).validate(semantic)
 
 
-def test_provider_schema_binds_vocabulary_order_and_exact_surface() -> None:
+def test_provider_schema_is_portable_and_finalizer_binds_vocabulary_order() -> None:
     packet = pbr.prepare_review("bio/andrii-malyshko", _reviewer())
     schema = pbr.semantic_response_schema(packet)
     semantic = _passing_semantic(packet)
@@ -1240,7 +1240,32 @@ def test_provider_schema_binds_vocabulary_order_and_exact_surface() -> None:
 
     assert coverage_schema["minItems"] == len(expected_lemmas)
     assert coverage_schema["maxItems"] == len(expected_lemmas)
-    assert len(coverage_schema["prefixItems"]) == len(expected_lemmas)
+    assert "prefixItems" not in json.dumps(schema)
+    assert coverage_schema["items"]["allOf"][1]["properties"]["lemma"][
+        "enum"
+    ] == expected_lemmas
+    nested_schemas = []
+
+    def collect(value: object) -> None:
+        if isinstance(value, dict):
+            nested_schemas.append(value)
+            for item in value.values():
+                collect(item)
+        elif isinstance(value, list):
+            for item in value:
+                collect(item)
+
+    collect(schema)
+    assert all(
+        node.get("type") == "object"
+        for node in nested_schemas
+        if {"properties", "required"}.intersection(node)
+    )
+    assert all(
+        node.get("type") == "array"
+        for node in nested_schemas
+        if {"items", "minItems", "maxItems", "uniqueItems"}.intersection(node)
+    )
     Draft202012Validator(schema).validate(semantic)
 
     wrong_order = copy.deepcopy(semantic)
@@ -1248,8 +1273,13 @@ def test_provider_schema_binds_vocabulary_order_and_exact_surface() -> None:
         wrong_order["vocabulary_coverage"][1],
         wrong_order["vocabulary_coverage"][0],
     )
-    with pytest.raises(ValidationError):
-        Draft202012Validator(schema).validate(wrong_order)
+    # Provider portability may relax sequence enforcement, but the canonical
+    # boundary must still reject the exact raw response rather than repair it.
+    Draft202012Validator(schema).validate(wrong_order)
+    result = pbr.finalize_review(packet, _raw(wrong_order))
+    assert result["semantic_response"]["contract_status"] == "invalid"
+    assert "exactly once in source order" in result["semantic_response"]["error"]
+    assert result["combined_disposition"]["status"] == "INCOMPLETE"
 
     false_exact = copy.deepcopy(semantic)
     integrated = next(
@@ -1259,8 +1289,40 @@ def test_provider_schema_binds_vocabulary_order_and_exact_surface() -> None:
     )
     integrated["surface"] = "співтворчість"
     integrated["verification"] = "exact lemma surface"
+    Draft202012Validator(schema).validate(false_exact)
+    false_result = pbr.finalize_review(packet, _raw(false_exact))
+    assert false_result["semantic_response"]["contract_status"] == "invalid"
+    assert "not packet-bound candidates" in false_result[
+        "semantic_response"
+    ]["error"]
+    assert false_result["combined_disposition"]["status"] == "INCOMPLETE"
+
+
+def test_provider_schema_resource_arrays_use_portable_set_constraints() -> None:
+    packet = pbr.prepare_review("bio/oleksandr-bilash", _reviewer())
+    schema = pbr.semantic_response_schema(packet)
+    semantic = _passing_semantic(packet)
+
+    assert "prefixItems" not in json.dumps(schema)
+    Draft202012Validator(schema).validate(semantic)
+
+    mapped_unit_id, mapped_entry = next(
+        (unit_id, entry)
+        for unit_id, entry in semantic["source_traceability_coverage"].items()
+        if entry["status"] == "MAPPED" and entry["resource_ids"]
+    )
+    resource_schema = schema["properties"]["source_traceability_coverage"][
+        "properties"
+    ][mapped_unit_id]["properties"]["resource_ids"]
+    assert resource_schema["items"]["enum"] == mapped_entry["resource_ids"]
+    assert resource_schema["uniqueItems"] is True
+
+    wrong_resource = copy.deepcopy(semantic)
+    wrong_resource["source_traceability_coverage"][mapped_unit_id][
+        "resource_ids"
+    ] = ["resource-not-in-packet"]
     with pytest.raises(ValidationError):
-        Draft202012Validator(schema).validate(false_exact)
+        Draft202012Validator(schema).validate(wrong_resource)
 
 
 def test_provider_schema_excludes_vocabulary_file_from_integration_evidence() -> None:
@@ -3142,8 +3204,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "6.0.0"
-    assert len(rows) == 62
+    assert catalog["catalog_version"] == "6.0.1"
+    assert len(rows) == 63
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -3180,6 +3242,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "5.0.7",
         "5.0.8",
         "6.0.0",
+        "6.0.1",
     }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 6.0.0
+catalog_version: 6.0.1
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -365,3 +365,9 @@ regressions:
     version_field: track_policy_version
     input: Learner prose attributes a fact to ЦДАМЛМ while resources.yaml contains no matching archive resource.
     expected: Deterministic source attribution inventory emits material SOURCE_TRACEABILITY and the exact source ledger cannot return MAPPED or PASS.
+  - bug_id: provider-strict-schema-rejected-prefix-items
+    responsible_layer: schema
+    fixed_in_version: 6.0.1
+    version_field: review_protocol_version
+    input: A canonical v6 packet is submitted to a strict structured-output provider that rejects Draft 2020-12 prefixItems before inference.
+    expected: The provider-facing schema uses portable order-agnostic array constraints, while the canonical finalizer still rejects missing, duplicated, reordered, or unmapped vocabulary and source entries fail-closed.


### PR DESCRIPTION
## Summary

- replace provider-only `prefixItems` constraints with a strict-output-portable subset
- preserve exact vocabulary order, packet-bound surface mappings, and source-resource sets in the canonical fail-closed finalizer
- normalize missing nested schema types for strict providers and bump the review protocol to 6.0.1

## Root cause and boundary

Claude rejected the canonical v6 JSON Schema before content inference because its strict structured-output validator does not accept `prefixItems` and requires explicit nested `type` annotations. The provider-facing schema now constrains portable shape/membership; the canonical finalizer remains authoritative and returns `INCOMPLETE` for reordered vocabulary, unbound surfaces, or source-set mismatches. Numeric dimension scores remain diagnostic and unchanged; categorical evidence still controls disposition.

No BIO-371 content files or production-QG authorization are changed.

## Verification

- 159 post-build-review and deploy-idempotency tests passed
- Ruff and YAML parsing passed
- skill validation, prompt deployment, and deployment-drift checks passed
- Claude strict structured-output accepted the emitted BIO-371 schema with no schema diagnostics and proceeded to inference (intentionally stopped with a microscopic budget)
- canonical closeout receipt: clean, exit 0
- independent cross-family review: DeepSeek V4 Flash via Hermes, CLEAN, no findings (message 3302)

Fixes #5294
