### PR TITLE
fix(review): bind alignment audits to finding locators

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,6 +1,6 @@
 review_protocol_version: 6.0.1
 deterministic_contract_version: 2.0.0
-semantic_prompt_version: 6.0.0
+semantic_prompt_version: 6.0.1
 track_policy_version: 2.0.0
 
 score_calibration:

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Common semantic post-build review prompt
 
-Semantic prompt version: `6.0.0`
+Semantic prompt version: `6.0.1`
 
 ## Machine-response contract — read before any source or tool call
 
@@ -175,6 +175,15 @@ class `CLEAR` only with exact cited evidence for the comparison, `FOUND` with
 every corresponding deterministic and semantic finding ID, or `INCOMPLETE`
 with an integrity finding. For mechanically supplied findings, reuse the exact
 IDs from the resolved context instead of emitting duplicate semantic findings.
+After finalizing the finding objects, audit each `FOUND` class against its
+`finding_ids`. Except for `VOCABULARY_INTEGRATION`, include at least one
+alignment evidence entry at every owned finding object's exact primary location and line.
+Copy that locator exactly from the finding object (or from
+the resolved supplied finding); do not substitute a related occurrence. You
+may add additional cross-cutting comparison evidence to show why a defect is
+redundant or misaligned, but it supplements rather than replaces the primary-
+locator entry. One primary-locator entry may cover multiple findings only when
+those findings genuinely have the same exact locator.
 The review summary must name every material class found. A high-quality
 paragraph or activity never cancels a defect elsewhere. If any class was not
 actually compared, return `INCOMPLETE`. If a semantic dimension is `REVISE`,

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Core semantic post-build review prompt
 
-Semantic prompt version: `6.0.0`
+Semantic prompt version: `6.0.1`
 
 Apply this only to A1-C2 core tracks, after the common prompt.
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Seminar semantic post-build review prompt
 
-Semantic prompt version: `6.0.0`
+Semantic prompt version: `6.0.1`
 
 Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
 after the common prompt.

--- a/docs/runbooks/post-build-review.md
+++ b/docs/runbooks/post-build-review.md
@@ -96,6 +96,12 @@ before inference. This transport accommodation does not relax the canonical
 contract: finalization independently enforces exact vocabulary source order and
 exact source-resource sets, and any mismatch produces `INCOMPLETE`.
 
+For every `FOUND` alignment class other than `VOCABULARY_INTEGRATION`, the
+audit evidence must include each owned finding's exact primary target-file
+locator. Related comparison lines may be added, but cannot replace the primary
+locator. This keeps the model-authored finding ledger and its alignment audit
+machine-checkable without repairing or deriving evidence after inference.
+
 Dimension scores preserve the accepted raw reviewer response after strict
 Decimal-based validation: `PASS` is `[8.0, 10.0]`, `REVISE` is `[6.0, 8.0)`,
 `BLOCK` is `[0.0, 6.0)`, and `INCOMPLETE` has a null score/rationale. The

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -2489,6 +2489,8 @@ def test_prompt_requires_exhaustive_learner_level_and_alignment_audit() -> None:
         "reuse each supplied finding's exact",
         "never emit a supplied finding object",
         "only genuinely new semantic defects",
+        "every owned finding object's exact primary location and line",
+        "additional cross-cutting comparison evidence",
     ):
         assert required in prompt_lower
 
@@ -2718,6 +2720,56 @@ def test_vocabulary_alignment_uses_coverage_ledger_for_absence_proof() -> None:
         "missing-2",
         "missing-3",
     ]
+
+
+def test_alignment_found_rejects_related_evidence_without_primary_finding_locators() -> None:
+    source_lookup = {
+        "module.md": (
+            "Нагорода не пояснює художньої форми.\n"
+            "Цю тезу повторено без нового доказу.\n"
+            "Завдання вже містить готову відповідь.\n"
+            "Порівняльний рядок стосується обох дефектів.\n"
+        )
+    }
+    findings = [
+        {
+            "id": "repeated-framing",
+            "issue_id": "SEMANTIC_REDUNDANCY",
+            "location": "module.md:2",
+        },
+        {
+            "id": "task-restates-answer",
+            "issue_id": "SEMANTIC_REDUNDANCY",
+            "location": "module.md:3",
+        },
+    ]
+    representative = [{
+        "location": "module.md:4",
+        "excerpt": "Порівняльний рядок стосується обох дефектів.",
+        "supports": "A related comparison line discusses both findings.",
+    }]
+    raw_audit = {
+        audit_class: {
+            "status": "FOUND" if audit_class == "SEMANTIC_REDUNDANCY" else "CLEAR",
+            "evidence": copy.deepcopy(representative),
+            "finding_ids": [finding["id"] for finding in findings]
+            if audit_class == "SEMANTIC_REDUNDANCY"
+            else [],
+        }
+        for audit_class in pbr.ALIGNMENT_AUDIT_CLASSES
+    }
+
+    with pytest.raises(
+        pbr.ReviewProtocolError,
+        match="must cite each finding's exact immutable locator",
+    ):
+        pbr._normalize_alignment_audit(
+            raw_audit,
+            verdict="REVISE",
+            semantic_findings=findings,
+            external_findings=[],
+            source_lookup=source_lookup,
+        )
 
 
 def test_finalize_accepts_representative_multi_missing_alignment_evidence(
@@ -3205,7 +3257,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
     assert catalog["catalog_version"] == "6.0.1"
-    assert len(rows) == 63
+    assert len(rows) == 64
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -371,3 +371,15 @@ regressions:
     version_field: review_protocol_version
     input: A canonical v6 packet is submitted to a strict structured-output provider that rejects Draft 2020-12 prefixItems before inference.
     expected: The provider-facing schema uses portable order-agnostic array constraints, while the canonical finalizer still rejects missing, duplicated, reordered, or unmapped vocabulary and source entries fail-closed.
+  - bug_id: alignment-evidence-omitted-semantic-finding-primary-locators
+    responsible_layer: semantic_prompt
+    fixed_in_version: 6.0.1
+    version_field: semantic_prompt_version
+    input: >-
+      A FOUND alignment class owns every semantic finding ID but cites only
+      related comparison lines, omitting each finding object's exact primary
+      location and line.
+    expected: >-
+      Require one alignment evidence entry at every owned non-vocabulary
+      finding's exact primary locator; additional cross-cutting comparison
+      evidence may supplement but never replace those entries.

--- a/tests/fixtures/post_build_review/score-calibration.v1.yaml
+++ b/tests/fixtures/post_build_review/score-calibration.v1.yaml
@@ -224,10 +224,10 @@ cases:
       documented_semantic_cap: 6.0
 comparability:
   - id: identical-review-identity-is-comparable
-    left: [6.0.0, fixture, fixture-model, high]
-    right: [6.0.0, fixture, fixture-model, high]
+    left: [6.0.1, fixture, fixture-model, high]
+    right: [6.0.1, fixture, fixture-model, high]
     expected: true
   - id: prompt-or-reviewer-identity-drift-is-not-comparable
-    left: [6.0.0, fixture, fixture-model, high]
-    right: [6.0.0, google, gemini-3.1-pro, high]
+    left: [6.0.1, fixture, fixture-model, high]
+    right: [6.0.1, google, gemini-3.1-pro, high]
     expected: false


### PR DESCRIPTION
## Summary

- bump semantic prompt protocol to 6.0.1
- require every FOUND non-vocabulary alignment audit to cite each owned finding exact primary locator
- preserve supplemental cross-cutting evidence, exact-response fail-closed validation, categorical gates, and diagnostic-only scores
- add the BIO-371-derived regression and update score-comparability identities

## Verification

- `.venv/bin/python -m pytest tests/audit/test_post_build_review.py -q` — 146 passed
- `scripts/deploy_prompts.sh --dry-run` — no deployment drift
- `scripts/check_rules_deployment.sh` — all checks passed
- Ruff, Markdown lint, YAML parse, and `git diff --check` passed
- canonical prepare smoke emitted semantic prompt 6.0.1 with both the primary-locator rule and exact-response preservation rule
- DeepSeek V4 Flash cross-family review: CLEAN (bridge message 3304)
- Grok 4.5 fallback review: correct, no findings (bridge message 3312)

Closes #5345