### PR TITLE
fix(lifecycle): prefer category routing

### DIFF
--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -1256,15 +1256,20 @@ def route_findings(
         location = str(finding.get("location") or "")
         finding_id = str(finding.get("id") or "")
         source = str(finding.get("source") or "")
-        if location.startswith("curriculum/l2-uk-en/plans/") or category in plan_categories:
+        if category in plan_categories:
             owner = "plan_workflow"
         elif (
             category in tooling_categories
             or finding_id.startswith(tooling_prefixes)
-            or location.startswith(("scripts/", "agents_extensions/", ".codex/", ".claude/"))
         ):
             owner = "audit_tooling"
-        elif category in built_categories or location.startswith("curriculum/l2-uk-en/"):
+        elif category in built_categories:
+            owner = "built_artifact"
+        elif location.startswith("curriculum/l2-uk-en/plans/"):
+            owner = "plan_workflow"
+        elif location.startswith(("scripts/", "agents_extensions/", ".codex/", ".claude/")):
+            owner = "audit_tooling"
+        elif location.startswith("curriculum/l2-uk-en/"):
             owner = "built_artifact"
         elif source in {"deterministic", "track_policy"}:
             owner = "audit_tooling"

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -784,6 +784,36 @@ def test_learner_level_meta_policy_finding_routes_to_built_artifact() -> None:
     }
 
 
+def test_assessment_gap_uses_category_owner_before_plan_evidence_location() -> None:
+    result = {
+        "combined_disposition": {"status": "REVISE"},
+        "findings": [
+            {
+                "id": "objective-two-subskills-unelicited",
+                "issue_id": "OBJECTIVE_ASSESSMENT_GAP",
+                "source": "semantic",
+                "category": "pedagogy",
+                "severity": "high",
+                "location": "curriculum/l2-uk-en/plans/bio/example.yaml:148",
+            }
+        ],
+    }
+
+    routing = tc.route_findings(result, config=_config())
+
+    assert routing == {
+        "owners": ["built_artifact"],
+        "findings": [
+            {
+                "finding_id": "objective-two-subskills-unelicited",
+                "category": "pedagogy",
+                "location": "curriculum/l2-uk-en/plans/bio/example.yaml:148",
+                "owner": "built_artifact",
+            }
+        ],
+    }
+
+
 def _fresh_fixture_from(tmp_path: Path) -> tuple[Path, Path, Path]:
     """Create the same fixture without depending on pytest fixture internals."""
     repo = tmp_path / "repo"


### PR DESCRIPTION
Closes #5347

## Root cause

Lifecycle routing treated a plan evidence locator as proof that the plan itself needed repair. For OBJECTIVE_ASSESSMENT_GAP, that could weaken an immutable objective instead of adding the missing built assessment.

## Change

- Make configured category ownership authoritative.
- Use file location only as a fallback for unknown categories.
- Add the BIO-371 regression while preserving genuine plan_adherence routing.

## Verification

- Full tests/test_track_completion.py: 22 passed.
- Ruff: clean.
- git diff --check: clean.
- Cross-family review: DeepSeek V4 Flash, CLEAN, no blocking findings.
- Scope breaker: not triggered; zero outstanding findings.

No BIO-371 learner content is changed in this PR.