### PR TITLE
fix(review): align alignment issue IDs

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,6 +1,6 @@
 review_protocol_version: 6.0.1
 deterministic_contract_version: 2.0.0
-semantic_prompt_version: 6.0.1
+semantic_prompt_version: 6.0.2
 track_policy_version: 2.0.0
 
 score_calibration:

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Common semantic post-build review prompt
 
-Semantic prompt version: `6.0.1`
+Semantic prompt version: `6.0.2`
 
 ## Machine-response contract — read before any source or tool call
 
@@ -178,6 +178,13 @@ IDs from the resolved context instead of emitting duplicate semantic findings.
 After finalizing the finding objects, audit each `FOUND` class against its
 `finding_ids`. Except for `VOCABULARY_INTEGRATION`, include at least one
 alignment evidence entry at every owned finding object's exact primary location and line.
+When a semantic finding belongs to one of these seven alignment classes:
+set its `issue_id` to that alignment class's exact uppercase name. The finding's
+specific defect name belongs in its unique `id`, not in a competing
+`issue_id`.
+Create a precise custom `issue_id` only for a finding outside all seven alignment classes.
+This exact class identity is how the finalizer proves
+that every matching finding is owned by the corresponding `FOUND` entry.
 Copy that locator exactly from the finding object (or from
 the resolved supplied finding); do not substitute a related occurrence. You
 may add additional cross-cutting comparison evidence to show why a defect is
@@ -240,7 +247,8 @@ numeric scores and `null` if and only if the status is `INCOMPLETE`.
 Before returning, verify every quality-dimension `location` is an exact target
 path and every `line` is the one-based line containing the cited evidence.
 
-Use stable uppercase-underscore `issue_id` values for semantic findings.
+Use stable uppercase-underscore `issue_id` values for semantic findings,
+subject to the exact seven-class ownership rule above.
 Known calibration classes include `ENGLISH_LEAKAGE`,
 `AWKWARD_PASSIVE_RESULT_STATE`, `UNNATURAL_ANTHROPOMORPHISM`,
 `UKRAINIAN_GRAMMAR_CALQUE`, `AI_LEAKAGE`, `PATH_LEAKAGE`,

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Core semantic post-build review prompt
 
-Semantic prompt version: `6.0.1`
+Semantic prompt version: `6.0.2`
 
 Apply this only to A1-C2 core tracks, after the common prompt.
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Seminar semantic post-build review prompt
 
-Semantic prompt version: `6.0.1`
+Semantic prompt version: `6.0.2`
 
 Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
 after the common prompt.

--- a/docs/runbooks/post-build-review.md
+++ b/docs/runbooks/post-build-review.md
@@ -101,6 +101,11 @@ audit evidence must include each owned finding's exact primary target-file
 locator. Related comparison lines may be added, but cannot replace the primary
 locator. This keeps the model-authored finding ledger and its alignment audit
 machine-checkable without repairing or deriving evidence after inference.
+Semantic findings owned by one of the seven alignment classes also use that
+class's exact uppercase name as `issue_id`; the more specific defect identity
+belongs in `id`. Custom `issue_id` values are reserved for findings outside all
+seven classes, so prompt guidance and exhaustive finalizer ownership cannot
+contradict one another.
 
 Dimension scores preserve the accepted raw reviewer response after strict
 Decimal-based validation: `PASS` is `[8.0, 10.0]`, `REVISE` is `[6.0, 8.0)`,

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -2491,6 +2491,8 @@ def test_prompt_requires_exhaustive_learner_level_and_alignment_audit() -> None:
         "only genuinely new semantic defects",
         "every owned finding object's exact primary location and line",
         "additional cross-cutting comparison evidence",
+        "set its `issue_id` to that alignment class's exact uppercase name",
+        "create a precise custom `issue_id` only for a finding outside all seven alignment classes",
     ):
         assert required in prompt_lower
 
@@ -2762,6 +2764,46 @@ def test_alignment_found_rejects_related_evidence_without_primary_finding_locato
     with pytest.raises(
         pbr.ReviewProtocolError,
         match="must cite each finding's exact immutable locator",
+    ):
+        pbr._normalize_alignment_audit(
+            raw_audit,
+            verdict="REVISE",
+            semantic_findings=findings,
+            external_findings=[],
+            source_lookup=source_lookup,
+        )
+
+
+def test_alignment_found_rejects_custom_issue_id_for_owned_finding() -> None:
+    source_lookup = {
+        "activities.yaml": "Завдання безпідставно узагальнює кожне звернення.\n"
+    }
+    findings = [
+        {
+            "id": "every-petition-overreach",
+            "issue_id": "UNIVERSAL_QUANTIFIER_OVERREACH",
+            "location": "activities.yaml:1",
+        }
+    ]
+    evidence = [{
+        "location": "activities.yaml:1",
+        "excerpt": "Завдання безпідставно узагальнює кожне звернення.",
+        "supports": "The task-validity finding's exact primary locator.",
+    }]
+    raw_audit = {
+        audit_class: {
+            "status": "FOUND" if audit_class == "TASK_VALIDITY" else "CLEAR",
+            "evidence": copy.deepcopy(evidence),
+            "finding_ids": ["every-petition-overreach"]
+            if audit_class == "TASK_VALIDITY"
+            else [],
+        }
+        for audit_class in pbr.ALIGNMENT_AUDIT_CLASSES
+    }
+
+    with pytest.raises(
+        pbr.ReviewProtocolError,
+        match="TASK_VALIDITY FOUND must reference every matching finding",
     ):
         pbr._normalize_alignment_audit(
             raw_audit,
@@ -3256,8 +3298,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "6.0.1"
-    assert len(rows) == 64
+    assert catalog["catalog_version"] == "6.0.2"
+    assert len(rows) == 65
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -3295,6 +3337,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "5.0.8",
         "6.0.0",
         "6.0.1",
+        "6.0.2",
     }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 6.0.1
+catalog_version: 6.0.2
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -383,3 +383,15 @@ regressions:
       Require one alignment evidence entry at every owned non-vocabulary
       finding's exact primary locator; additional cross-cutting comparison
       evidence may supplement but never replace those entries.
+  - bug_id: alignment-finding-custom-issue-id-breaks-class-ownership
+    responsible_layer: semantic_prompt
+    fixed_in_version: 6.0.2
+    version_field: semantic_prompt_version
+    input: >-
+      A TASK_VALIDITY defect uses a precise custom uppercase issue_id while
+      the TASK_VALIDITY alignment entry references the finding's stable id.
+    expected: >-
+      Require findings owned by any seven-class alignment audit to use that
+      class's exact uppercase name as issue_id; keep the specific defect name
+      in id and reserve custom issue_id values for findings outside all seven
+      classes.

--- a/tests/fixtures/post_build_review/score-calibration.v1.yaml
+++ b/tests/fixtures/post_build_review/score-calibration.v1.yaml
@@ -224,10 +224,10 @@ cases:
       documented_semantic_cap: 6.0
 comparability:
   - id: identical-review-identity-is-comparable
-    left: [6.0.1, fixture, fixture-model, high]
-    right: [6.0.1, fixture, fixture-model, high]
+    left: [6.0.2, fixture, fixture-model, high]
+    right: [6.0.2, fixture, fixture-model, high]
     expected: true
   - id: prompt-or-reviewer-identity-drift-is-not-comparable
-    left: [6.0.1, fixture, fixture-model, high]
-    right: [6.0.1, google, gemini-3.1-pro, high]
+    left: [6.0.2, fixture, fixture-model, high]
+    right: [6.0.2, google, gemini-3.1-pro, high]
     expected: false


### PR DESCRIPTION
## Summary

- bump the semantic prompt to 6.0.2
- require findings owned by the seven exhaustive alignment classes to use the exact class name as issue_id
- keep the specific defect identity in id and reserve custom issue IDs for findings outside those classes
- preserve the fail-closed categorical gate and calibrated diagnostic score contract
- add the BIO-371-derived prompt regression and a dedicated finalizer-path rejection test

## Verification

- post-build review suite: 147 passed
- pre-commit affected suite: 147 passed
- generated semantic-prompt behavior proof emitted version 6.0.2 with both ownership constraints
- prompt deployment + mirror checks passed
- Ruff, Markdown lint, YAML parsing, protected-file checks, and git diff --check passed
- Claude Opus 4.8 authoritative cross-family review: CLEAN after source-backed follow-up (bridge messages 3318 and 3322)
- DeepSeek V4 Flash supplementary cross-family review: CLEAN (bridge message 3316)

No BIO-371 learner content is changed in this PR.

Closes #5349
