### PR TITLE
test(rollover): freeze API fixture clock

### DIFF
--- a/tests/test_rollover_api.py
+++ b/tests/test_rollover_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from fastapi.testclient import TestClient
 
 import scripts.api.rollover_router as rollover_router
@@ -118,6 +120,11 @@ def test_rollover_exact_selector_ignores_unrelated_pending_records(monkeypatch):
         source_thread_id="source-other",
     )
     monkeypatch.setattr(rollover_router.registry, "scan_records", lambda _root: ([selected, unrelated], []))
+    monkeypatch.setattr(
+        rollover_router.registry,
+        "utc_now",
+        lambda: datetime(2026, 7, 16, 10, tzinfo=UTC),
+    )
 
     response = client.get("/api/rollovers?source_thread_id=source-api")
 


### PR DESCRIPTION
## Root cause

The exact-selector rollover API test used fixed July 16 timestamps but called the live clock. Once the fixture exceeded the production 24-hour stale threshold, the assertion changed from `awaiting native action` to `stale and requiring operator adjudication`, breaking every full CI run. This reproduced on current `main` and blocked #5353.

## Fix

Freeze `registry.utc_now()` inside that one test at 10:00 UTC, one hour after the fixture timestamp. Production rollover behavior and thresholds are unchanged.

## Verification

- isolated formerly failing test: 1 passed
- full rollover API test file: 6 passed
- Ruff and diff checks passed
- Claude Opus 4.8 independent cross-family review: CLEAN (bridge message 3326)

Closes #5358
