### PR TITLE
fix(ci): cover MDX + atlas gate inputs in path filters (#5354)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,14 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'site/**'
               - 'curriculum/l2-uk-en/**'
+              # MDX generator entry + package (mdx-generation-drift invokes
+              # scripts/generate_mdx.py; mdx-source-parity treats package edits
+              # as generator changes). Missing these let generator-only PRs skip
+              # both drift/parity gates (#5354; class: #5351/#3873/#4888/#4936).
+              # tests/test_mdx_atlas_filter_coverage.py enforces coverage.
+              - 'scripts/generate_mdx.py'
+              - 'scripts/generate_mdx/**'
+              - 'scripts/yaml_activities.py'
             agent_config:
               - '.github/workflows/ci.yml'
               - '.mcp.json'
@@ -203,8 +211,14 @@ jobs:
               - 'site/src/data/lexicon-daily-pool.json'
               - 'site/src/data/lexicon-manifest.json'
               - 'site/src/data/lexicon-manifest.fingerprint.json'
+              # hashFiles + load_manifest read the pointer; missing it let
+              # pointer-only edits skip atlas-freshness (#5354; class: #5351).
+              # tests/test_mdx_atlas_filter_coverage.py enforces coverage.
+              - 'site/src/data/lexicon-manifest.pointer.json'
               - 'site/src/data/lexicon-practice-deck.pointer.json'
               - 'site/src/data/lexicon-practice-reviewed-sources.json'
+              # check_static_practice_assets.py DEFAULT_PRACTICE_DIR
+              - 'site/public/lexicon/**'
               - 'site/scripts/hydrate-practice-deck.mjs'
               - 'site/scripts/hydrate-lexicon-api-shards.ts'
             postmortems:

--- a/tests/test_mdx_atlas_filter_coverage.py
+++ b/tests/test_mdx_atlas_filter_coverage.py
@@ -1,0 +1,141 @@
+"""Guards for MDX drift/parity + atlas path-filter coverage (#5354).
+
+Sibling of ``tests/test_lesson_schema_filter_coverage.py`` (#5352): conditional
+CI gates must trigger on every path the gated check actually consumes.
+Otherwise drift/staleness accumulates silently on main and reds an unrelated
+ci.yml-touching PR later (class: #3873 / #4888 / #4936 / #5351).
+
+1. ``frontend`` must cover MDX generator entry + package (+ generator deps
+   enumerated by ``check_mdx_source_parity``), else generator-only PRs skip
+   ``mdx-generation-drift`` / ``mdx-source-parity``.
+2. ``atlas`` must cover the manifest pointer (``hashFiles`` +
+   ``load_manifest``) and the static practice asset paths read by
+   ``check_static_practice_assets``, else pointer-only / asset-only edits
+   skip ``atlas-freshness``.
+
+Expectations are derived FROM the gate scripts / workflow expressions, so a
+new input without a matching glob fails pytest.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+sys.path.insert(0, str(_REPO_ROOT))
+from scripts.audit import check_mdx_source_parity as mdx_parity
+from scripts.audit import check_static_practice_assets as practice_assets
+from scripts.lexicon import manifest_io
+
+
+def _filter_globs(name: str) -> list[str]:
+    workflow = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["changes"]["steps"]
+    filter_step = next(s for s in steps if s.get("id") == "filter")
+    filters = yaml.safe_load(filter_step["with"]["filters"])
+    return filters[name]
+
+
+def _covered(rel_path: str, globs: list[str]) -> bool:
+    # fnmatch's ``*`` crosses ``/`` — intentionally permissive: we assert
+    # representative concrete paths are matched (coverage), never exclusion.
+    return any(fnmatch.fnmatch(rel_path, g) for g in globs)
+
+
+def _assert_filter_covers(filter_name: str, inputs: list[Path], *, hint: str) -> None:
+    globs = _filter_globs(filter_name)
+    assert globs, f"{filter_name} filter missing from ci.yml"
+    uncovered = [
+        str(p.relative_to(_REPO_ROOT))
+        for p in inputs
+        if not _covered(str(p.relative_to(_REPO_ROOT)), globs)
+    ]
+    assert not uncovered, (
+        f"{filter_name} path filter does not cover gate inputs {uncovered}; "
+        f"{hint} Extend the {filter_name} globs in .github/workflows/ci.yml."
+    )
+
+
+def _mdx_generator_inputs() -> list[Path]:
+    """Paths whose edits must fire the MDX drift/parity gates.
+
+    Derived from ``check_mdx_source_parity`` (generator change detection) and
+    ``check_mdx_generation_drift`` (subprocess to ``scripts/generate_mdx.py``).
+    """
+    package_files = sorted(mdx_parity.GENERATOR_PACKAGE.rglob("*.py"))
+    assert package_files, "generate_mdx package empty or moved?"
+    inputs = [
+        mdx_parity.GENERATOR_ENTRYPOINT,
+        package_files[0],  # representative proves scripts/generate_mdx/**
+        *sorted(mdx_parity.GENERATOR_DEPENDENCIES),
+    ]
+    return inputs
+
+
+def _atlas_freshness_inputs() -> list[Path]:
+    """Paths consumed by atlas-freshness (workflow + static practice check).
+
+    - ``lexicon-manifest.pointer.json``: ``hashFiles(...)`` cache key and
+      ``manifest_io.load_manifest`` / ``_load_pointer``.
+    - practice asset defaults from ``check_static_practice_assets``.
+    """
+    workflow_text = _CI_WORKFLOW.read_text(encoding="utf-8")
+    # Confirm the workflow still hashes the pointer (regression if expression moves).
+    assert "lexicon-manifest.pointer.json" in workflow_text, (
+        "ci.yml no longer hashFiles the atlas pointer — update this test"
+    )
+    pointer = manifest_io.DEFAULT_POINTER
+    assert pointer.is_relative_to(_REPO_ROOT)
+
+    practice_dir = _REPO_ROOT / practice_assets.DEFAULT_PRACTICE_DIR
+    # One representative file under public/lexicon proves the directory glob.
+    practice_files = sorted(p for p in practice_dir.rglob("*.json") if p.is_file())[:1]
+    assert practice_files, (
+        f"no practice assets under {practice_assets.DEFAULT_PRACTICE_DIR} — path moved?"
+    )
+
+    return [
+        pointer,
+        _REPO_ROOT / practice_assets.DEFAULT_DAILY_POOL,
+        _REPO_ROOT / practice_assets.DEFAULT_REVIEWED_SOURCES,
+        practice_files[0],
+    ]
+
+
+def test_frontend_filter_covers_mdx_generator_inputs() -> None:
+    _assert_filter_covers(
+        "frontend",
+        _mdx_generator_inputs(),
+        hint=(
+            "mdx-generation-drift / mdx-source-parity will not fire on "
+            "generator-only changes."
+        ),
+    )
+
+
+def test_atlas_filter_covers_freshness_inputs() -> None:
+    _assert_filter_covers(
+        "atlas",
+        _atlas_freshness_inputs(),
+        hint="atlas-freshness will not fire when those inputs change.",
+    )
+
+
+def test_atlas_freshness_hashfiles_includes_pointer() -> None:
+    """Workflow expression must still key the cache on the pointer file."""
+    text = _CI_WORKFLOW.read_text(encoding="utf-8")
+    # Match the dorny/actions expression used by atlas-freshness (and peers).
+    pattern = re.compile(
+        r"hashFiles\(\s*['\"]site/src/data/lexicon-manifest\.pointer\.json['\"]\s*\)"
+    )
+    assert pattern.search(text), (
+        "ci.yml atlas cache key no longer hashFiles "
+        "site/src/data/lexicon-manifest.pointer.json"
+    )


### PR DESCRIPTION
## Summary

Closes sibling trigger≠inputs filter gaps found in the #5352 cross-family review (same class as #5351 / autopsy `docs/bug-autopsies/path-filter-gate-coverage.md`).

**Filter WIDENING only** — no job `if:` changes, no gate logic changes, no paths-filter-retry composite interaction.

1. **`frontend` filter** — add MDX generator entry + package (+ `yaml_activities.py` dep) so `mdx-generation-drift` / `mdx-source-parity` fire on generator-only PRs.
2. **`atlas` filter** — add `lexicon-manifest.pointer.json` (workflow `hashFiles` + `load_manifest`) and `site/public/lexicon/**` (`check_static_practice_assets` `DEFAULT_PRACTICE_DIR`).
3. **Load-bearing test** — `tests/test_mdx_atlas_filter_coverage.py` derives each gate’s input set from the gate scripts and asserts filter coverage (fnmatch-permissive-for-coverage, same semantics as #5352).

Refs #5354

## Inputs enumerated (tool-backed)

### MDX gates (`mdx-generation-drift` / `mdx-source-parity`)

`scripts/audit/check_mdx_generation_drift.py` invokes the generator entrypoint:

```python
subprocess.run(
    [
        str(VENV_PYTHON),
        "scripts/generate_mdx.py",
        ...
    ],
```

`scripts/audit/check_mdx_source_parity.py` treats these as generator changes:

```python
GENERATOR_ENTRYPOINT = PROJECT_ROOT / "scripts/generate_mdx.py"
GENERATOR_PACKAGE = PROJECT_ROOT / "scripts/generate_mdx"
GENERATOR_DEPENDENCIES = {
    PROJECT_ROOT / "scripts/yaml_activities.py",
}
```

### Atlas freshness

`ci.yml` cache key (both restore + save):

```yaml
key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
```

`scripts/lexicon/manifest_io.py`:

```python
DEFAULT_POINTER = ROOT / "site" / "src" / "data" / "lexicon-manifest.pointer.json"
# load_manifest → _load_pointer() reads DEFAULT_POINTER
```

`scripts/audit/check_static_practice_assets.py` read set:

```python
DEFAULT_DAILY_POOL = Path("site/src/data/lexicon-daily-pool.json")          # already in atlas
DEFAULT_PRACTICE_DIR = Path("site/public/lexicon")                          # NEW: site/public/lexicon/**
DEFAULT_REVIEWED_SOURCES = Path("site/src/data/lexicon-practice-reviewed-sources.json")  # already in atlas
```

(Hydrate path already covered via `scripts/practice_deck/**` + `lexicon-practice-deck.pointer.json`.)

## Negative verify (unwidened main filters)

Temporarily replaced `ci.yml` with `origin/main` version; new tests failed as expected:

```
FAILED tests/test_mdx_atlas_filter_coverage.py::test_frontend_filter_covers_mdx_generator_inputs
AssertionError: frontend path filter does not cover gate inputs
  ['scripts/generate_mdx.py', 'scripts/generate_mdx/__init__.py', 'scripts/yaml_activities.py'];
  mdx-generation-drift / mdx-source-parity will not fire on generator-only changes.
  Extend the frontend globs in .github/workflows/ci.yml.

FAILED tests/test_mdx_atlas_filter_coverage.py::test_atlas_filter_covers_freshness_inputs
AssertionError: atlas path filter does not cover gate inputs
  ['site/src/data/lexicon-manifest.pointer.json', 'site/public/lexicon/browse/Є.json'];
  atlas-freshness will not fire when those inputs change.
  Extend the atlas globs in .github/workflows/ci.yml.
```

After restoring widened filters: **3 passed**.

## Verification

### pytest (targeted)

```
tests/test_mdx_atlas_filter_coverage.py::test_frontend_filter_covers_mdx_generator_inputs PASSED
tests/test_mdx_atlas_filter_coverage.py::test_atlas_filter_covers_freshness_inputs PASSED
tests/test_mdx_atlas_filter_coverage.py::test_atlas_freshness_hashfiles_includes_pointer PASSED
============================== 3 passed in 0.21s ===============================
```

### ruff

```
.venv/bin/ruff check tests/test_mdx_atlas_filter_coverage.py
All checks passed!
```

### actionlint

```
bash scripts/audit/check_workflows.sh
→ actionlint 1.7.12 on 9 workflow file(s)
✅ actionlint: all workflow files valid
```

## Test plan

- [x] Negative verify: tests fail against main’s filters
- [x] Positive verify: tests pass with widened filters
- [x] actionlint green
- [x] ruff clean on new test
- [ ] CI paths-filter: generator-only / pointer-only PRs should now enable frontend / atlas jobs (orchestrator review gate)