### PR TITLE
fix(harness): surface Tier-2 skip reason + guard canary level→route trap

### DIFF
--- a/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
+++ b/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
@@ -82,6 +82,9 @@ the tool-disabled judge does not. A judged invocation instead requires the
 attested judge command, exact route identity, attestation, labels, and frozen
 qualification manifests; `layerb_shadow` verifies all of them.
 
+> [!WARNING]
+> When minting the canary artifact for a seminar-level run, always run the canary generator with the specific target level (e.g. `folk` or `hist`), not the literal string `seminar`. Using `seminar` maps to the `b1_plus` policy family and `gemma_surface` route instead of `opencode_frontier`, which will fail validation.
+
 ```bash
 .venv/bin/python scripts/audit/qg_shadow_run.py \
   --module-dir curriculum/l2-uk-en/folk/vesnianky-hayivky \

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -842,7 +842,32 @@ def run_canary(
     author_family: str,
     runner: ProviderRunner | None = None,
 ) -> dict[str, Any]:
-    """Run a live canary through the same dispatcher route used by a batch."""
+    """Run a live canary through the same dispatcher route used by a batch.
+
+    Route mapping details:
+    - Levels starting with 'a1' map to family 'a1' -> GEMMA_SURFACE_ROUTE (gemma_surface)
+    - Levels starting with 'a2' map to family 'a2' -> GEMMA_SURFACE_ROUTE (gemma_surface)
+    - Levels starting with 'b1', 'b2', 'c1', 'c2' map to family 'b1_plus' -> GEMMA_SURFACE_ROUTE (gemma_surface)
+    - Seminar levels (e.g. 'folk', 'hist', 'bio', etc.) map to family 'seminar' -> FRONTIER_OPENCODE_ROUTE (opencode_frontier)
+    """
+
+    clean = level.strip().lower()
+    from scripts.audit.content_surface_gates import SEMINAR_LEVELS
+    is_valid_cefr = (
+        clean.startswith("a1")
+        or clean.startswith("a2")
+        or clean.startswith("b1")
+        or clean.startswith("b2")
+        or clean.startswith("c1")
+        or clean.startswith("c2")
+    )
+    is_valid_seminar = clean in SEMINAR_LEVELS
+    if not (is_valid_cefr or is_valid_seminar):
+        raise ValueError(
+            f"Level {level!r} is not a valid curriculum level or seminar track level. "
+            "To mint a canary, you must use a specific target level (e.g., 'folk', 'hist', 'b1', etc.) "
+            "so it maps to the correct reviewer route family."
+        )
 
     policy = policy_for_level(level)
     prompt = build_canary_prompt(level)

--- a/scripts/audit/qg_shadow_run.py
+++ b/scripts/audit/qg_shadow_run.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import logging
 import sys
 from collections.abc import Mapping, Sequence
 from contextlib import suppress
@@ -32,6 +33,9 @@ from scripts.audit import layerb_shadow, llm_qg_shadow_store, llm_reviewer_dispa
 from scripts.audit.content_surface_gates import policy_for_level
 from scripts.audit.qg_run_serializer import RUN_SCHEMA_VERSION, serialize_qg_run_v2
 from scripts.common.repo_root import resolve_repo_root
+
+_LOGGER = logging.getLogger("qg_shadow_run")
+
 
 SHADOW_ARTIFACT_ARM = "production_shadow"
 
@@ -115,7 +119,14 @@ def _artifact_for_capture(
     payload = tier2.get("payload")
     tier2_run_id = tier2.get("tier2_run_id")
     if not isinstance(dispatch, Mapping) or not isinstance(payload, Mapping) or not isinstance(tier2_run_id, str):
-        raise ValueError("Tier-2 capture is unavailable; shadow runs require a fresh captured live dispatch")
+        status = tier2.get("status")
+        reason = tier2.get("reason")
+        err_msg = (
+            f"Tier-2 capture is unavailable; shadow runs require a fresh captured live dispatch "
+            f"(status={status}, reason={reason})"
+        )
+        _LOGGER.error(err_msg)
+        raise ValueError(err_msg)
     qg_workflow_meta = record.get("qg_workflow") if isinstance(record.get("qg_workflow"), Mapping) else {}
     reviewer_family = dispatch.get("reviewer_family") or tier2.get("reviewer_family")
     if not isinstance(reviewer_family, str) or not reviewer_family:

--- a/tests/audit/test_qg_run_serializer.py
+++ b/tests/audit/test_qg_run_serializer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -76,3 +77,44 @@ def test_bakeoff_tooled_artifact_matches_pre_extraction_golden_hash(
     artifact = qg_bakeoff.run_one(route, fixture, output_dir=tmp_path, runner=runner)
 
     assert hashlib.sha256(artifact.artifact_path.read_bytes()).hexdigest() == PRE_EXTRACTION_ARTIFACT_SHA256
+
+
+def test_run_canary_guards_against_invalid_level_trap() -> None:
+    with pytest.raises(ValueError, match="not a valid curriculum level or seminar track level"):
+        llm_reviewer_dispatch.run_canary(
+            level="seminar",
+            gate_version="test.v1",
+            author_family="openai",
+        )
+
+    # A valid level (e.g. 'folk' or 'b1') should not raise the validation ValueError,
+    # though it will fail later if we don't mock the dispatcher or evaluate_canaries.
+    # We can mock the dispatcher/evaluate_canaries or pass a mock runner to verify this.
+    def mock_runner(selected_route: llm_reviewer_dispatch.ReviewerRoute, *args: Any, **kwargs: Any) -> llm_reviewer_dispatch.DispatchResult:
+        import json
+        return llm_reviewer_dispatch.DispatchResult(
+            response_text=json.dumps({"findings": [], "fact_checks": [], "evidence_gaps": []}),
+            reviewer_model_id=selected_route.reviewer_model_id,
+            reviewer_family=selected_route.reviewer_family,
+            route_name=selected_route.route_name,
+            tool_call_count=0,
+            tools_used=(),
+            tool_events=(),
+        )
+
+    # Let's mock llm_qg_canaries.evaluate_canaries to avoid actual execution / file lookups
+    from scripts.audit import llm_qg_canaries
+    original_evaluate = llm_qg_canaries.evaluate_canaries
+    llm_qg_canaries.evaluate_canaries = lambda payload, level: {"passed": True}
+    try:
+        res = llm_reviewer_dispatch.run_canary(
+            level="folk",
+            gate_version="test.v1",
+            author_family="openai",
+            runner=mock_runner,
+        )
+        assert res["passed"] is True
+        assert res["level"] == "seminar"  # canonical level for folk
+    finally:
+        llm_qg_canaries.evaluate_canaries = original_evaluate
+

--- a/tests/audit/test_qg_shadow_run.py
+++ b/tests/audit/test_qg_shadow_run.py
@@ -277,3 +277,24 @@ def test_main_exits_4_when_evidence_vanishes(tmp_path: Path, monkeypatch: pytest
     )
 
     assert rc == 4
+
+
+def test_shadow_driver_surfaces_skip_reason(tmp_path: Path) -> None:
+    module_dir = _module(tmp_path)
+
+    with pytest.raises(ValueError) as excinfo:
+        qg_shadow_run.run_shadow_module(
+            _target(module_dir),
+            audit_dir=tmp_path / "audit",
+            shadow_db=tmp_path / "shadow.db",
+            author_family="openai",
+            reviewer=_dispatch,
+            live_reviewer=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+            max_cost_usd=1.0,
+            layerb_dry_run=True,
+        )
+    assert "skipped_canary_required" in str(excinfo.value)
+    assert "exact_canary_required" in str(excinfo.value)
+


### PR DESCRIPTION
Refs #5195

### Preamble
- **tests green**:
```
tests/audit/test_qg_run_serializer.py ..                                 [  2%]
tests/audit/test_qg_shadow_run.py .........                              [ 13%]
tests/test_llm_reviewer_dispatch.py .................................... [ 57%]
...................................                                      [100%]

============================== 82 passed in 1.69s ==============================
```
- **ruff clean**:
```
All checks passed!
```
- **error now carries the reason**:
```
ValueError: Tier-2 capture is unavailable; shadow runs require a fresh captured live dispatch (status=skipped_canary_required, reason=exact_canary_required)
```

### Changes
1. **Swallowed skip reason**: Modified `_artifact_for_capture` in `scripts/audit/qg_shadow_run.py` to extract `status` and `reason` from the `tier2` mapping and include them in the raised `ValueError` and the logged error. Added `test_shadow_driver_surfaces_skip_reason` in `tests/audit/test_qg_shadow_run.py`.
2. **Canary level→route trap**: Added level string whitelist validation in `run_canary` in `scripts/audit/llm_reviewer_dispatch.py` to reject level strings that do not map to real CEFR or seminar levels (like `'seminar'`), raising a `ValueError`. Documented route mapping in the `run_canary` docstring. Added `test_run_canary_guards_against_invalid_level_trap` in `tests/audit/test_qg_run_serializer.py`. Updated runbook docs in `docs/projects/ua-eval-harness/cost-aware-qg-workflow.md`.