### PR TITLE
feat(lexicon): runner PR3 — disconnected network cache + transport (spec §PR3)

### DIFF
--- a/scripts/lexicon/runner/__init__.py
+++ b/scripts/lexicon/runner/__init__.py
@@ -2,19 +2,23 @@
 
 PR1: bounded lookup rewrite, sealed CEFR/relations, streaming I/O, hard caps.
 PR2: real-unit ledger, fencing/CAS, resume, attempt caps, operator retry.
-PR3 network cache/packets and PR4 streaming assembly remain stubs.
+PR3: disconnected network cache, packets/bundles, fenced import.
+PR4 streaming assembly remains a stub.
 """
 
 from __future__ import annotations
 
 from scripts.lexicon.runner.contracts import ENGINE_VERSION, SERIALIZATION_VERSION
 from scripts.lexicon.runner.ledger import Ledger, compute_run_fingerprint
+from scripts.lexicon.runner.network_cache import NetworkCache, compute_request_key
 from scripts.lexicon.runner.offline_engine import enrich_offline_slice
 
 __all__ = [
     "ENGINE_VERSION",
     "SERIALIZATION_VERSION",
     "Ledger",
+    "NetworkCache",
+    "compute_request_key",
     "compute_run_fingerprint",
     "enrich_offline_slice",
 ]

--- a/scripts/lexicon/runner/bundle_import.py
+++ b/scripts/lexicon/runner/bundle_import.py
@@ -1,0 +1,163 @@
+"""Phase 6 — bundle import (#5230 PR3).
+
+Verify the outer bundle hash and every item hash before state changes.
+Import is atomic per lemma; re-import of matching hashes is a no-op; stale
+packet generations are rejected cleanly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from scripts.lexicon.runner.ledger import CasResult, CasStatus, Ledger
+from scripts.lexicon.runner.transport import HashMismatchError, LoadedBundle, read_bundle
+
+
+@dataclass
+class BundleImportResult:
+    bundle_id: str
+    packet_generation: int
+    committed: list[str] = field(default_factory=list)
+    skipped_noop: list[str] = field(default_factory=list)
+    rejected: list[tuple[str, str]] = field(default_factory=list)  # (lemma_id, detail)
+    status: CasStatus = CasStatus.OK
+    detail: str = ""
+
+
+def import_bundle(
+    ledger: Ledger,
+    bundle_path: Path,
+    *,
+    owner: str,
+    expected_fingerprint: str | None = None,
+    expected_bundle_id: str | None = None,
+    claim_units: bool = True,
+    now: float | None = None,
+    crash_after_items: int | None = None,
+) -> BundleImportResult:
+    """Import a verified bundle. Per-lemma transactions; crash-safe at item k.
+
+    ``crash_after_items`` is a test hook: after successfully committing that many
+    new items, raise ``RuntimeError("injected crash: import_killed_at_k")``.
+    """
+    try:
+        loaded: LoadedBundle = read_bundle(bundle_path, expected_id=expected_bundle_id)
+    except HashMismatchError as exc:
+        return BundleImportResult(
+            bundle_id=expected_bundle_id or Path(bundle_path).name,
+            packet_generation=-1,
+            status=CasStatus.INVALID_STATE,
+            detail=f"hash verification failed: {exc}",
+        )
+
+    manifest = loaded.manifest
+    run_id = str(manifest["run_id"])
+    packet_generation = int(manifest["packet_generation"])
+    fingerprint = str(manifest["fingerprint"])
+    if expected_fingerprint is not None and fingerprint != expected_fingerprint:
+        return BundleImportResult(
+            bundle_id=loaded.artifact_id,
+            packet_generation=packet_generation,
+            status=CasStatus.FINGERPRINT_MISMATCH_REFUSED,
+            detail="fingerprint_mismatch_refused",
+        )
+
+    # Reject whole bundle early if the packet generation was abandoned.
+    if not ledger.packet_generation_active(run_id, packet_generation):
+        return BundleImportResult(
+            bundle_id=loaded.artifact_id,
+            packet_generation=packet_generation,
+            status=CasStatus.INVALID_STATE,
+            detail="stale_packet_generation",
+        )
+
+    result = BundleImportResult(
+        bundle_id=loaded.artifact_id,
+        packet_generation=packet_generation,
+    )
+    new_commits = 0
+    for item in loaded.items:
+        lemma_id = str(item["lemma_id"])
+        result_hash = str(item["result_hash"])
+        request_key = str(item["request_key"])
+        lease_generation = 0
+
+        if claim_units:
+            # Ensure unit exists then claim for fenced import.
+            ledger.register_work_unit(
+                run_id,
+                lemma_id,
+                unit_kind="lemma",
+                phase="network_import",
+                now=now,
+            )
+            claim = ledger.claim_unit(
+                run_id,
+                lemma_id,
+                owner,
+                phase="network_import",
+                now=now,
+            )
+            if not claim.ok:
+                # Already done with matching import is handled inside commit_import;
+                # if claim fails because unit is already done, try commit as no-op path.
+                unit = ledger.get_work_unit(run_id, lemma_id, phase="network_import")
+                if unit is not None and str(unit.get("state")) == "done":
+                    cas = ledger.commit_import(
+                        run_id,
+                        lemma_id,
+                        owner,
+                        int(unit.get("lease_generation") or 0),
+                        packet_generation=packet_generation,
+                        result_hash=result_hash,
+                        expected_fingerprint=fingerprint,
+                        expected_request_key=request_key,
+                        phase="network_import",
+                        now=now,
+                    )
+                    if cas.ok:
+                        result.skipped_noop.append(lemma_id)
+                        continue
+                result.rejected.append((lemma_id, claim.detail or claim.status.value))
+                continue
+            lease_generation = int(claim.lease_generation or 0)
+        else:
+            unit = ledger.get_work_unit(run_id, lemma_id, phase="network_import")
+            if unit is not None:
+                lease_generation = int(unit.get("lease_generation") or 0)
+                owner = str(unit.get("owner") or owner)
+
+        cas: CasResult = ledger.commit_import(
+            run_id,
+            lemma_id,
+            owner,
+            lease_generation,
+            packet_generation=packet_generation,
+            result_hash=result_hash,
+            expected_fingerprint=fingerprint,
+            expected_request_key=request_key,
+            phase="network_import",
+            now=now,
+        )
+        if cas.status is CasStatus.OK:
+            # Distinguish no-op re-import via events/import row age is unnecessary;
+            # if unit was already done before this call, count as noop when not newly claimed.
+            if lemma_id in result.committed or lemma_id in result.skipped_noop:
+                continue
+            # Check whether this was a first commit this pass.
+            if claim_units and lease_generation > 0:
+                result.committed.append(lemma_id)
+                new_commits += 1
+            else:
+                result.committed.append(lemma_id)
+                new_commits += 1
+            if crash_after_items is not None and new_commits >= int(crash_after_items):
+                raise RuntimeError("injected crash: import_killed_at_k")
+        else:
+            result.rejected.append((lemma_id, cas.detail or cas.status.value))
+
+    if result.rejected and not result.committed and not result.skipped_noop:
+        result.status = CasStatus.INVALID_STATE
+        result.detail = "all items rejected"
+    return result

--- a/scripts/lexicon/runner/contracts.py
+++ b/scripts/lexicon/runner/contracts.py
@@ -6,12 +6,20 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Literal
 
-ENGINE_VERSION = "runner-pr2-v1"
+ENGINE_VERSION = "runner-pr3-v1"
 SERIALIZATION_VERSION = "lemma-artifact-v1"
 CEFR_ALGORITHM_VERSION = "grac-cohort-quantile-v1"
 RELATION_CLOSURE_VERSION = "reciprocal-closure-v1"
 SIDE_DB_SCHEMA_VERSION = "side-db-v1"
 LEDGER_SCHEMA_VERSION = "ledger-v1"
+NETWORK_CACHE_SCHEMA_VERSION = "network-cache-v1"
+ADAPTER_VERSION = "http-adapter-v1"
+REQUEST_POLICY_VERSION = "request-policy-v1"
+PARSER_VERSION = "parser-v1"
+NORMALIZER_VERSION = "normalizer-v1"
+PARSED_SCHEMA_VERSION = "parsed-schema-v1"
+PACKET_SCHEMA_VERSION = "packet-v1"
+BUNDLE_SCHEMA_VERSION = "bundle-v1"
 
 # Host memory policy (16 GiB local host). Platform/VPS ceilings are selected
 # below physical RAM with explicit OS headroom — never copy 8/10 onto a smaller host.
@@ -98,27 +106,44 @@ class OomSplitChildren:
     split_epoch: int
 
 
-# --- PR3/PR4 stubs (PR2 ledger is real — see scripts/lexicon/runner/ledger.py) ---
+# --- PR4 stubs (PR3 network cache/transport is real — see network_cache/transport) ---
 
 
 @dataclass(frozen=True, slots=True)
 class LedgerStub:
-    """Compatibility handle pointing at a real PR2 ledger run.
+    """Compatibility handle pointing at a real PR2+ ledger run.
 
     Prefer :class:`scripts.lexicon.runner.ledger.Ledger` for all writes.
     """
 
     run_id: str
     fingerprint: str
-    note: str = "PR2 real-unit ledger (see scripts.lexicon.runner.ledger.Ledger)"
+    note: str = "PR2/PR3 real-unit ledger (see scripts.lexicon.runner.ledger.Ledger)"
 
 
 @dataclass(frozen=True, slots=True)
-class PacketStub:
-    """PR3: content-addressed request packet (.tar.zst)."""
+class PacketRef:
+    """Content-addressed request packet (.tar.zst) — PR3."""
 
     packet_id: str
-    note: str = "PR3 stub — network cache/packets not implemented in PR1/PR2"
+    generation: int = 0
+    path: str = ""
+    content_hash: str = ""
+
+
+# Back-compat alias used by offline_engine until callers switch to PacketRef.
+PacketStub = PacketRef
+
+
+@dataclass(frozen=True, slots=True)
+class BundleRef:
+    """Content-addressed result bundle (.tar.zst) — PR3."""
+
+    bundle_id: str
+    packet_id: str
+    packet_generation: int
+    path: str = ""
+    content_hash: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/scripts/lexicon/runner/ledger.py
+++ b/scripts/lexicon/runner/ledger.py
@@ -227,6 +227,17 @@ CREATE TABLE IF NOT EXISTS events (
     created_at REAL NOT NULL,
     payload_json TEXT NOT NULL DEFAULT '{}'
 );
+
+CREATE TABLE IF NOT EXISTS unit_request_keys (
+    run_id TEXT NOT NULL,
+    unit_id TEXT NOT NULL,
+    phase TEXT NOT NULL,
+    request_key TEXT NOT NULL,
+    packet_generation INTEGER NOT NULL,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (run_id, unit_id, phase),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
 """
 
 
@@ -335,6 +346,7 @@ class Ledger:
         self.crash_mid_split = False
         self.crash_mid_seal = False
         self.crash_after_result = False
+        self.crash_after_import = False
 
     # --- lock + open ---------------------------------------------------------
 
@@ -1278,10 +1290,15 @@ class Ledger:
         packet_generation: int,
         result_hash: str,
         expected_fingerprint: str | None = None,
+        expected_request_key: str | None = None,
         phase: str = "network_import",
         now: float | None = None,
     ) -> CasResult:
-        """CAS per-lemma import. Matching-hash re-import is a no-op success."""
+        """CAS per-lemma import. Matching-hash re-import is a no-op success.
+
+        Rejects abandoned/stale packet generations and optional request-key mismatch
+        (PR3 / spec §Phase 6).
+        """
         conn = self._require()
         ts = self._now(now)
         run = self.get_run(run_id)
@@ -1299,6 +1316,51 @@ class Ledger:
                 detail=ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value,
                 run_id=run_id,
             )
+
+        # Stale/abandoned packet generation: refuse before any state change.
+        if not self.packet_generation_active(run_id, int(packet_generation)):
+            # Allow no-op re-import of an already-committed matching hash even if
+            # the generation was later abandoned (artifacts already accepted).
+            existing_early = conn.execute(
+                "SELECT result_hash FROM imports "
+                "WHERE run_id = ? AND lemma_id = ? AND packet_generation = ?",
+                (run_id, lemma_id, int(packet_generation)),
+            ).fetchone()
+            if existing_early is not None and str(existing_early["result_hash"]) == result_hash:
+                return CasResult(
+                    status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id
+                )
+            self._event(
+                "stale_packet_generation_rejected",
+                run_id,
+                lemma_id=lemma_id,
+                packet_generation=int(packet_generation),
+            )
+            return CasResult(
+                status=CasStatus.INVALID_STATE,
+                detail="stale_packet_generation",
+                run_id=run_id,
+            )
+
+        if expected_request_key is not None:
+            key_row = conn.execute(
+                "SELECT request_key, packet_generation FROM unit_request_keys "
+                "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+                (run_id, lemma_id, phase),
+            ).fetchone()
+            if key_row is not None:
+                if str(key_row["request_key"]) != expected_request_key:
+                    return CasResult(
+                        status=CasStatus.INVALID_STATE,
+                        detail="request_key_mismatch",
+                        run_id=run_id,
+                    )
+                if int(key_row["packet_generation"]) != int(packet_generation):
+                    return CasResult(
+                        status=CasStatus.INVALID_STATE,
+                        detail="stale_packet_generation",
+                        run_id=run_id,
+                    )
 
         existing = conn.execute(
             "SELECT result_hash FROM imports "
@@ -1386,6 +1448,8 @@ class Ledger:
                         lease_generation=lease_generation,
                         run_id=run_id,
                     )
+            if self.crash_after_import:
+                raise RuntimeError("injected crash: after_import")
             conn.execute("COMMIT")
         except Exception:
             conn.execute("ROLLBACK")
@@ -1398,6 +1462,196 @@ class Ledger:
             packet_generation=packet_generation,
             result_hash=result_hash,
         )
+        return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
+
+    # --- packets (PR3 transport) ---------------------------------------------
+
+    def next_packet_generation(self, run_id: str) -> int:
+        """Monotonic packet generation for a run (1-based)."""
+        conn = self._require()
+        row = conn.execute(
+            "SELECT COALESCE(MAX(generation), 0) AS g FROM packets WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        return int(row["g"]) + 1
+
+    def record_packet_exported(
+        self,
+        run_id: str,
+        packet_id: str,
+        generation: int,
+        *,
+        content_hash: str | None = None,
+        now: float | None = None,
+    ) -> CasResult:
+        """Durable ``packet_exported`` — transport holds no lease (spec §Phase 4)."""
+        conn = self._require()
+        ts = self._now(now)
+        existing = conn.execute(
+            "SELECT state FROM packets WHERE run_id = ? AND packet_id = ? AND generation = ?",
+            (run_id, packet_id, int(generation)),
+        ).fetchone()
+        if existing is not None and str(existing["state"]) == "abandoned":
+            return CasResult(
+                status=CasStatus.INVALID_STATE,
+                detail="packet generation already abandoned",
+                run_id=run_id,
+            )
+        conn.execute(
+            "INSERT INTO packets("
+            "run_id, packet_id, generation, state, content_hash, created_at, abandoned_at"
+            ") VALUES (?, ?, ?, 'packet_exported', ?, ?, NULL) "
+            "ON CONFLICT(run_id, packet_id, generation) DO UPDATE SET "
+            "state = CASE WHEN packets.state = 'abandoned' THEN packets.state "
+            "ELSE 'packet_exported' END, "
+            "content_hash = COALESCE(excluded.content_hash, packets.content_hash)",
+            (run_id, packet_id, int(generation), content_hash or packet_id, ts),
+        )
+        # Re-check abandoned race.
+        row = conn.execute(
+            "SELECT state FROM packets WHERE run_id = ? AND packet_id = ? AND generation = ?",
+            (run_id, packet_id, int(generation)),
+        ).fetchone()
+        if row is not None and str(row["state"]) == "abandoned":
+            return CasResult(
+                status=CasStatus.INVALID_STATE,
+                detail="packet generation already abandoned",
+                run_id=run_id,
+            )
+        self._event(
+            "packet_exported",
+            run_id,
+            packet_id=packet_id,
+            generation=int(generation),
+            content_hash=content_hash or packet_id,
+        )
+        return CasResult(status=CasStatus.OK, run_id=run_id)
+
+    def packet_generation_active(self, run_id: str, generation: int) -> bool:
+        """True when generation is importable.
+
+        - No packets recorded for the run → allow (direct/PR2 import paths).
+        - Generation has a non-abandoned row → allow.
+        - Generation missing while other packets exist, or only abandoned → refuse.
+        Active transport is never expired by wall-clock alone (spec §2).
+        """
+        conn = self._require()
+        any_packets = conn.execute(
+            "SELECT 1 FROM packets WHERE run_id = ? LIMIT 1",
+            (run_id,),
+        ).fetchone()
+        if any_packets is None:
+            return True
+        rows = conn.execute(
+            "SELECT state FROM packets WHERE run_id = ? AND generation = ?",
+            (run_id, int(generation)),
+        ).fetchall()
+        if not rows:
+            return False
+        return any(str(r["state"]) != "abandoned" for r in rows)
+
+    def get_packet(
+        self, run_id: str, packet_id: str, generation: int
+    ) -> dict[str, Any] | None:
+        conn = self._require()
+        row = conn.execute(
+            "SELECT * FROM packets WHERE run_id = ? AND packet_id = ? AND generation = ?",
+            (run_id, packet_id, int(generation)),
+        ).fetchone()
+        return None if row is None else dict(row)
+
+    def set_work_unit_packet_generation(
+        self,
+        run_id: str,
+        unit_id: str,
+        packet_generation: int,
+        *,
+        phase: str = "network_import",
+        request_key: str | None = None,
+        now: float | None = None,
+    ) -> None:
+        """Bind a work unit to the active packet generation (and optional request key)."""
+        conn = self._require()
+        ts = self._now(now)
+        conn.execute(
+            "UPDATE work_units SET packet_generation = ?, updated_at = ? "
+            "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+            (int(packet_generation), ts, run_id, unit_id, phase),
+        )
+        if request_key is not None:
+            conn.execute(
+                "INSERT INTO unit_request_keys("
+                "run_id, unit_id, phase, request_key, packet_generation, updated_at"
+                ") VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(run_id, unit_id, phase) DO UPDATE SET "
+                "request_key = excluded.request_key, "
+                "packet_generation = excluded.packet_generation, "
+                "updated_at = excluded.updated_at",
+                (run_id, unit_id, phase, request_key, int(packet_generation), ts),
+            )
+
+    def handle_http_429(
+        self,
+        run_id: str,
+        unit_id: str,
+        owner: str,
+        lease_generation: int,
+        *,
+        host: str,
+        next_allowed_at: float,
+        phase: str = "network_fetch",
+        now: float | None = None,
+    ) -> CasResult:
+        """429 → ``retry_scheduled`` + host cooldown; does not abandon packets.
+
+        Active transport (``packet_exported`` rows) is intentionally untouched.
+        """
+        conn = self._require()
+        ts = self._now(now)
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            cur = conn.execute(
+                "UPDATE work_units SET state = ?, error_code = ?, owner = NULL, "
+                "leased_until = NULL, updated_at = ? "
+                "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+                "AND owner = ? AND lease_generation = ? AND state = ?",
+                (
+                    UnitOutcome.RETRY_SCHEDULED.value,
+                    "http_429",
+                    ts,
+                    run_id,
+                    unit_id,
+                    phase,
+                    owner,
+                    int(lease_generation),
+                    SchedulableState.LEASED.value,
+                ),
+            )
+            if cur.rowcount != 1:
+                conn.execute("ROLLBACK")
+                return CasResult(
+                    status=CasStatus.STALE_COMMIT_REJECTED,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                    lease_generation=lease_generation,
+                    run_id=run_id,
+                )
+            conn.execute(
+                "INSERT INTO host_cooldowns(host, next_allowed_at) VALUES (?, ?) "
+                "ON CONFLICT(host) DO UPDATE SET next_allowed_at = excluded.next_allowed_at",
+                (host, float(next_allowed_at)),
+            )
+            self._event(
+                "http_429_retry_scheduled",
+                run_id,
+                unit_id=unit_id,
+                host=host,
+                next_allowed_at=float(next_allowed_at),
+                lease_generation=int(lease_generation),
+            )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
         return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
 
     # --- seal (CAS, leaf-only) -----------------------------------------------

--- a/scripts/lexicon/runner/ledger.py
+++ b/scripts/lexicon/runner/ledger.py
@@ -347,6 +347,10 @@ class Ledger:
         self.crash_mid_seal = False
         self.crash_after_result = False
         self.crash_after_import = False
+        # When True, marks the target packet generation abandoned inside the
+        # commit_import write fence (before validation) to prove concurrent
+        # abandon cannot slip past pre-txn reads (PR #5365 review finding 4).
+        self.crash_import_concurrent_abandon = False
 
     # --- lock + open ---------------------------------------------------------
 
@@ -1298,113 +1302,137 @@ class Ledger:
 
         Rejects abandoned/stale packet generations and optional request-key mismatch
         (PR3 / spec §Phase 6).
+
+        All validation reads run under ``BEGIN IMMEDIATE`` so a concurrent
+        abandon cannot race past stale pre-txn checks (PR #5365 review finding 4).
         """
         conn = self._require()
         ts = self._now(now)
-        run = self.get_run(run_id)
-        if run is None:
-            return CasResult(status=CasStatus.NOT_FOUND, detail="run missing")
-        if expected_fingerprint is not None and str(run["fingerprint"]) != expected_fingerprint:
-            self._event(
-                ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value,
-                run_id,
-                op="import",
-                lemma_id=lemma_id,
-            )
-            return CasResult(
-                status=CasStatus.FINGERPRINT_MISMATCH_REFUSED,
-                detail=ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value,
-                run_id=run_id,
-            )
+        # Fence first: every validation read below is inside this transaction.
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            # Test hook: simulate concurrent abandon after the write fence is
+            # held but before validation — must still reject the import.
+            if self.crash_import_concurrent_abandon:
+                conn.execute(
+                    "UPDATE packets SET state = 'abandoned', abandoned_at = ? "
+                    "WHERE run_id = ? AND generation = ?",
+                    (ts, run_id, int(packet_generation)),
+                )
 
-        # Stale/abandoned packet generation: refuse before any state change.
-        if not self.packet_generation_active(run_id, int(packet_generation)):
-            # Allow no-op re-import of an already-committed matching hash even if
-            # the generation was later abandoned (artifacts already accepted).
-            existing_early = conn.execute(
+            run = self.get_run(run_id)
+            if run is None:
+                conn.execute("ROLLBACK")
+                return CasResult(status=CasStatus.NOT_FOUND, detail="run missing")
+            if expected_fingerprint is not None and str(run["fingerprint"]) != expected_fingerprint:
+                conn.execute("ROLLBACK")
+                self._event(
+                    ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value,
+                    run_id,
+                    op="import",
+                    lemma_id=lemma_id,
+                )
+                return CasResult(
+                    status=CasStatus.FINGERPRINT_MISMATCH_REFUSED,
+                    detail=ErrorCode.FINGERPRINT_MISMATCH_REFUSED.value,
+                    run_id=run_id,
+                )
+
+            # Stale/abandoned packet generation: refuse before any state change.
+            if not self.packet_generation_active(run_id, int(packet_generation)):
+                # Allow no-op re-import of an already-committed matching hash even if
+                # the generation was later abandoned (artifacts already accepted).
+                existing_early = conn.execute(
+                    "SELECT result_hash FROM imports "
+                    "WHERE run_id = ? AND lemma_id = ? AND packet_generation = ?",
+                    (run_id, lemma_id, int(packet_generation)),
+                ).fetchone()
+                if existing_early is not None and str(existing_early["result_hash"]) == result_hash:
+                    conn.execute("ROLLBACK")
+                    return CasResult(
+                        status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id
+                    )
+                conn.execute("ROLLBACK")
+                self._event(
+                    "stale_packet_generation_rejected",
+                    run_id,
+                    lemma_id=lemma_id,
+                    packet_generation=int(packet_generation),
+                )
+                return CasResult(
+                    status=CasStatus.INVALID_STATE,
+                    detail="stale_packet_generation",
+                    run_id=run_id,
+                )
+
+            if expected_request_key is not None:
+                key_row = conn.execute(
+                    "SELECT request_key, packet_generation FROM unit_request_keys "
+                    "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+                    (run_id, lemma_id, phase),
+                ).fetchone()
+                if key_row is not None:
+                    if str(key_row["request_key"]) != expected_request_key:
+                        conn.execute("ROLLBACK")
+                        return CasResult(
+                            status=CasStatus.INVALID_STATE,
+                            detail="request_key_mismatch",
+                            run_id=run_id,
+                        )
+                    if int(key_row["packet_generation"]) != int(packet_generation):
+                        conn.execute("ROLLBACK")
+                        return CasResult(
+                            status=CasStatus.INVALID_STATE,
+                            detail="stale_packet_generation",
+                            run_id=run_id,
+                        )
+
+            existing = conn.execute(
                 "SELECT result_hash FROM imports "
                 "WHERE run_id = ? AND lemma_id = ? AND packet_generation = ?",
                 (run_id, lemma_id, int(packet_generation)),
             ).fetchone()
-            if existing_early is not None and str(existing_early["result_hash"]) == result_hash:
+            if existing is not None:
+                if str(existing["result_hash"]) == result_hash:
+                    conn.execute("ROLLBACK")
+                    return CasResult(
+                        status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id
+                    )
+                conn.execute("ROLLBACK")
                 return CasResult(
-                    status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id
+                    status=CasStatus.INVALID_STATE,
+                    detail="import hash conflict for same packet generation",
+                    run_id=run_id,
                 )
-            self._event(
-                "stale_packet_generation_rejected",
-                run_id,
-                lemma_id=lemma_id,
-                packet_generation=int(packet_generation),
-            )
-            return CasResult(
-                status=CasStatus.INVALID_STATE,
-                detail="stale_packet_generation",
-                run_id=run_id,
-            )
 
-        if expected_request_key is not None:
-            key_row = conn.execute(
-                "SELECT request_key, packet_generation FROM unit_request_keys "
-                "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+            # Optional work-unit fencing when a leased import unit exists.
+            unit = conn.execute(
+                "SELECT * FROM work_units WHERE run_id = ? AND unit_id = ? AND phase = ?",
                 (run_id, lemma_id, phase),
             ).fetchone()
-            if key_row is not None:
-                if str(key_row["request_key"]) != expected_request_key:
-                    return CasResult(
-                        status=CasStatus.INVALID_STATE,
-                        detail="request_key_mismatch",
-                        run_id=run_id,
-                    )
-                if int(key_row["packet_generation"]) != int(packet_generation):
-                    return CasResult(
-                        status=CasStatus.INVALID_STATE,
-                        detail="stale_packet_generation",
-                        run_id=run_id,
-                    )
+            if (
+                unit is not None
+                and str(unit["state"]) == SchedulableState.LEASED.value
+                and (
+                    str(unit["owner"]) != owner
+                    or int(unit["lease_generation"]) != int(lease_generation)
+                )
+            ):
+                conn.execute("ROLLBACK")
+                self._event(
+                    ErrorCode.STALE_COMMIT_REJECTED.value,
+                    run_id,
+                    unit_id=lemma_id,
+                    op="commit_import",
+                    lease_generation=lease_generation,
+                )
+                return CasResult(
+                    status=CasStatus.STALE_COMMIT_REJECTED,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                    lease_generation=lease_generation,
+                    run_id=run_id,
+                )
 
-        existing = conn.execute(
-            "SELECT result_hash FROM imports "
-            "WHERE run_id = ? AND lemma_id = ? AND packet_generation = ?",
-            (run_id, lemma_id, int(packet_generation)),
-        ).fetchone()
-        if existing is not None:
-            if str(existing["result_hash"]) == result_hash:
-                return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
-            return CasResult(
-                status=CasStatus.INVALID_STATE,
-                detail="import hash conflict for same packet generation",
-                run_id=run_id,
-            )
-
-        # Optional work-unit fencing when a leased import unit exists.
-        unit = conn.execute(
-            "SELECT * FROM work_units WHERE run_id = ? AND unit_id = ? AND phase = ?",
-            (run_id, lemma_id, phase),
-        ).fetchone()
-        if (
-            unit is not None
-            and str(unit["state"]) == SchedulableState.LEASED.value
-            and (
-                str(unit["owner"]) != owner
-                or int(unit["lease_generation"]) != int(lease_generation)
-            )
-        ):
-            self._event(
-                ErrorCode.STALE_COMMIT_REJECTED.value,
-                run_id,
-                unit_id=lemma_id,
-                op="commit_import",
-                lease_generation=lease_generation,
-            )
-            return CasResult(
-                status=CasStatus.STALE_COMMIT_REJECTED,
-                detail=ErrorCode.STALE_COMMIT_REJECTED.value,
-                lease_generation=lease_generation,
-                run_id=run_id,
-            )
-
-        conn.execute("BEGIN IMMEDIATE")
-        try:
             conn.execute(
                 "INSERT INTO imports("
                 "run_id, lemma_id, packet_generation, result_hash, "

--- a/scripts/lexicon/runner/network_cache.py
+++ b/scripts/lexicon/runner/network_cache.py
@@ -1,0 +1,815 @@
+"""VPS/network host durable write-through cache (#5230 PR3).
+
+Independent of the local run ledger (spec §6): exclusive OS lock, request-level
+fenced claims reusing PR2 CAS/generation machinery, and atomic raw cache rows
+(metadata + compressed body in one SQLite transaction).
+
+Network workers that open this cache must never construct or open ``sources.db``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import hashlib
+import sqlite3
+import time
+import uuid
+import zlib
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from scripts.lexicon.runner.contracts import (
+    ADAPTER_VERSION,
+    NETWORK_CACHE_SCHEMA_VERSION,
+    REQUEST_POLICY_VERSION,
+    ErrorCode,
+    canonical_json,
+)
+from scripts.lexicon.runner.sources_guard import (
+    SourcesDbForbiddenError,
+    assert_not_sources_db,
+    guard_network_worker,
+)
+
+# Active-computation lease for in-flight fetches (transport itself holds no lease).
+DEFAULT_REQUEST_LEASE_TTL_SECONDS = 300
+DEFAULT_MAX_FETCH_ATTEMPTS = 5
+
+
+class RequestClaimState(StrEnum):
+    PENDING = "pending"
+    LEASED = "leased"
+    DONE = "done"
+    RETRY_SCHEDULED = "retry_scheduled"
+    FAILED_TERMINAL = "failed_terminal"
+
+
+class CacheCasStatus(StrEnum):
+    OK = "ok"
+    STALE_COMMIT_REJECTED = "stale_commit_rejected"
+    DUPLICATE_RUNNER_REFUSED = "duplicate_runner_refused"
+    NOT_FOUND = "not_found"
+    INVALID_STATE = "invalid_state"
+    CACHE_HIT = "cache_hit"
+    ATTEMPT_CAP_EXHAUSTED = "attempt_cap_exhausted"
+    HOST_COOLDOWN = "host_cooldown"
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS raw_cache (
+    request_key TEXT PRIMARY KEY,
+    method TEXT NOT NULL,
+    url TEXT NOT NULL,
+    request_body_hash TEXT NOT NULL,
+    headers_json TEXT NOT NULL,
+    adapter_version TEXT NOT NULL,
+    request_policy_version TEXT NOT NULL,
+    status_code INTEGER NOT NULL,
+    response_headers_json TEXT NOT NULL,
+    body_sha256 TEXT NOT NULL,
+    body_zlib BLOB NOT NULL,
+    freshness_policy TEXT NOT NULL DEFAULT '',
+    fetched_at REAL NOT NULL,
+    meta_json TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS request_claims (
+    request_key TEXT PRIMARY KEY,
+    state TEXT NOT NULL,
+    lease_generation INTEGER NOT NULL DEFAULT 0,
+    owner TEXT,
+    leased_until REAL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    error_code TEXT,
+    updated_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS parsed_cache (
+    parsed_key TEXT PRIMARY KEY,
+    request_key TEXT NOT NULL,
+    body_sha256 TEXT NOT NULL,
+    parser_version TEXT NOT NULL,
+    normalizer_version TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    parsed_sha256 TEXT NOT NULL,
+    parsed_zlib BLOB NOT NULL,
+    created_at REAL NOT NULL,
+    FOREIGN KEY (request_key) REFERENCES raw_cache(request_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_parsed_request ON parsed_cache(request_key);
+
+CREATE TABLE IF NOT EXISTS host_cooldowns (
+    host TEXT PRIMARY KEY,
+    next_allowed_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS fetch_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event TEXT NOT NULL,
+    request_key TEXT,
+    created_at REAL NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}'
+);
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class CacheCasResult:
+    status: CacheCasStatus
+    detail: str = ""
+    lease_generation: int | None = None
+    request_key: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status is CacheCasStatus.OK
+
+
+@dataclass(frozen=True, slots=True)
+class RequestClaimResult:
+    status: CacheCasStatus
+    request_key: str
+    lease_generation: int | None = None
+    attempt_count: int | None = None
+    detail: str = ""
+    cached_body: bytes | None = None
+    body_sha256: str | None = None
+    status_code: int | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status in {CacheCasStatus.OK, CacheCasStatus.CACHE_HIT}
+
+    @property
+    def is_cache_hit(self) -> bool:
+        return self.status is CacheCasStatus.CACHE_HIT
+
+
+@dataclass(frozen=True, slots=True)
+class RawCacheEntry:
+    request_key: str
+    method: str
+    url: str
+    request_body_hash: str
+    headers_json: str
+    adapter_version: str
+    request_policy_version: str
+    status_code: int
+    response_headers_json: str
+    body_sha256: str
+    body: bytes
+    freshness_policy: str
+    fetched_at: float
+    meta_json: str
+
+
+class DuplicateCacheRunnerError(RuntimeError):
+    """Second process tried to open the same network cache for writing."""
+
+
+def compute_request_key(
+    *,
+    method: str,
+    url: str,
+    request_body: bytes | str | None = None,
+    response_affecting_headers: dict[str, str] | None = None,
+    adapter_version: str = ADAPTER_VERSION,
+    request_policy_version: str = REQUEST_POLICY_VERSION,
+) -> str:
+    """Canonical raw request key (spec §5)."""
+    if request_body is None:
+        body_repr = ""
+    elif isinstance(request_body, bytes):
+        body_repr = hashlib.sha256(request_body).hexdigest()
+    else:
+        body_repr = hashlib.sha256(request_body.encode("utf-8")).hexdigest()
+    payload = {
+        "adapter_version": adapter_version,
+        "method": method.upper(),
+        "request_body": body_repr,
+        "request_policy_version": request_policy_version,
+        "response_affecting_headers": {
+            str(k).lower(): str(v)
+            for k, v in sorted((response_affecting_headers or {}).items(), key=lambda kv: kv[0].lower())
+        },
+        "url": url,
+    }
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def compute_parsed_key(
+    *,
+    request_key: str,
+    body_sha256: str,
+    parser_version: str,
+    normalizer_version: str,
+    schema_version: str,
+) -> str:
+    payload = {
+        "body_sha256": body_sha256,
+        "normalizer_version": normalizer_version,
+        "parser_version": parser_version,
+        "request_key": request_key,
+        "schema_version": schema_version,
+    }
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+class NetworkCache:
+    """Single-writer durable network cache (VPS-side, independent of local ledger)."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        max_attempts: int = DEFAULT_MAX_FETCH_ATTEMPTS,
+        lease_ttl_seconds: float = DEFAULT_REQUEST_LEASE_TTL_SECONDS,
+        owner_id: str | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.max_attempts = int(max_attempts)
+        self.lease_ttl_seconds = float(lease_ttl_seconds)
+        self.owner_id = owner_id or f"net-{uuid.uuid4().hex[:12]}"
+        self._conn: sqlite3.Connection | None = None
+        self._lock_fh: Any | None = None
+        self._locked = False
+        # Crash-injection points (tests only).
+        self.crash_after_claim = False
+        self.crash_mid_cache_write = False
+        self.crash_after_cache_write = False
+        self.fetch_count = 0  # instrumentation: real network/fetch attempts
+
+    def open(self, *, create: bool = True) -> None:
+        if self._conn is not None:
+            return
+        # Hard guard: never point the cache path at sources.db.
+        assert_not_sources_db(self.path)
+        if create:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_fh = open(lock_path, "a+", encoding="utf-8")  # noqa: SIM115
+        try:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            lock_fh.close()
+            raise DuplicateCacheRunnerError(
+                f"duplicate runner refused: network cache lock held on {lock_path}"
+            ) from exc
+        self._lock_fh = lock_fh
+        self._locked = True
+        lock_fh.seek(0)
+        lock_fh.truncate()
+        lock_fh.write(f"{self.owner_id}\n{time.time():.6f}\n")
+        lock_fh.flush()
+
+        self._conn = sqlite3.connect(self.path, isolation_level=None)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA synchronous = FULL")
+        self._conn.executescript(SCHEMA_SQL)
+        self._conn.execute(
+            "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+            ("schema_version", NETWORK_CACHE_SCHEMA_VERSION),
+        )
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+        if self._lock_fh is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(self._lock_fh.fileno(), fcntl.LOCK_UN)
+            self._lock_fh.close()
+            self._lock_fh = None
+        self._locked = False
+
+    def __enter__(self) -> NetworkCache:
+        self.open()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def _require(self) -> sqlite3.Connection:
+        if self._conn is None or not self._locked:
+            raise RuntimeError("network cache not open under exclusive writer lock")
+        return self._conn
+
+    def _now(self, now: float | None = None) -> float:
+        return time.time() if now is None else float(now)
+
+    def _event(self, event: str, request_key: str | None = None, **payload: Any) -> None:
+        conn = self._require()
+        conn.execute(
+            "INSERT INTO fetch_events(event, request_key, created_at, payload_json) "
+            "VALUES (?, ?, ?, ?)",
+            (event, request_key, self._now(), canonical_json(payload)),
+        )
+
+    def set_host_cooldown(self, host: str, next_allowed_at: float) -> None:
+        conn = self._require()
+        conn.execute(
+            "INSERT INTO host_cooldowns(host, next_allowed_at) VALUES (?, ?) "
+            "ON CONFLICT(host) DO UPDATE SET next_allowed_at = excluded.next_allowed_at",
+            (host, float(next_allowed_at)),
+        )
+
+    def host_cooldown_active(self, host: str, *, now: float | None = None) -> float | None:
+        """Return next_allowed_at if host is still cooling down, else None."""
+        conn = self._require()
+        ts = self._now(now)
+        row = conn.execute(
+            "SELECT next_allowed_at FROM host_cooldowns WHERE host = ?",
+            (host,),
+        ).fetchone()
+        if row is None:
+            return None
+        until = float(row["next_allowed_at"])
+        return until if until > ts else None
+
+    def get_raw(self, request_key: str) -> RawCacheEntry | None:
+        conn = self._require()
+        row = conn.execute(
+            "SELECT * FROM raw_cache WHERE request_key = ?",
+            (request_key,),
+        ).fetchone()
+        if row is None:
+            return None
+        body = zlib.decompress(bytes(row["body_zlib"]))
+        return RawCacheEntry(
+            request_key=str(row["request_key"]),
+            method=str(row["method"]),
+            url=str(row["url"]),
+            request_body_hash=str(row["request_body_hash"]),
+            headers_json=str(row["headers_json"]),
+            adapter_version=str(row["adapter_version"]),
+            request_policy_version=str(row["request_policy_version"]),
+            status_code=int(row["status_code"]),
+            response_headers_json=str(row["response_headers_json"]),
+            body_sha256=str(row["body_sha256"]),
+            body=body,
+            freshness_policy=str(row["freshness_policy"] or ""),
+            fetched_at=float(row["fetched_at"]),
+            meta_json=str(row["meta_json"] or "{}"),
+        )
+
+    def ensure_claim_row(self, request_key: str, *, now: float | None = None) -> None:
+        conn = self._require()
+        ts = self._now(now)
+        conn.execute(
+            "INSERT OR IGNORE INTO request_claims("
+            "request_key, state, lease_generation, owner, leased_until, "
+            "attempt_count, updated_at"
+            ") VALUES (?, ?, 0, NULL, NULL, 0, ?)",
+            (request_key, RequestClaimState.PENDING.value, ts),
+        )
+
+    def claim_request(
+        self,
+        request_key: str,
+        owner: str,
+        *,
+        now: float | None = None,
+        host: str | None = None,
+    ) -> RequestClaimResult:
+        """Fenced claim. Cache hits return CACHE_HIT without incrementing fetch_count."""
+        conn = self._require()
+        ts = self._now(now)
+        if host is not None:
+            cool = self.host_cooldown_active(host, now=ts)
+            if cool is not None:
+                return RequestClaimResult(
+                    status=CacheCasStatus.HOST_COOLDOWN,
+                    request_key=request_key,
+                    detail=f"host cooldown until {cool}",
+                )
+
+        # Cache hit: no fetch, no lease needed for reparse-from-cache path.
+        cached = self.get_raw(request_key)
+        if cached is not None:
+            self.ensure_claim_row(request_key, now=ts)
+            self._event("cache_hit", request_key, body_sha256=cached.body_sha256)
+            return RequestClaimResult(
+                status=CacheCasStatus.CACHE_HIT,
+                request_key=request_key,
+                cached_body=cached.body,
+                body_sha256=cached.body_sha256,
+                status_code=cached.status_code,
+                detail="raw cache hit; parse without fetch",
+            )
+
+        self.ensure_claim_row(request_key, now=ts)
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                "SELECT * FROM request_claims WHERE request_key = ?",
+                (request_key,),
+            ).fetchone()
+            assert row is not None
+            state = str(row["state"])
+            if state in {
+                RequestClaimState.DONE.value,
+                RequestClaimState.FAILED_TERMINAL.value,
+            }:
+                # Race: another writer may have committed raw since we checked.
+                again = conn.execute(
+                    "SELECT body_sha256, body_zlib, status_code FROM raw_cache "
+                    "WHERE request_key = ?",
+                    (request_key,),
+                ).fetchone()
+                if again is not None:
+                    conn.execute("COMMIT")
+                    body = zlib.decompress(bytes(again["body_zlib"]))
+                    return RequestClaimResult(
+                        status=CacheCasStatus.CACHE_HIT,
+                        request_key=request_key,
+                        cached_body=body,
+                        body_sha256=str(again["body_sha256"]),
+                        status_code=int(again["status_code"]),
+                    )
+                conn.execute("ROLLBACK")
+                return RequestClaimResult(
+                    status=CacheCasStatus.INVALID_STATE,
+                    request_key=request_key,
+                    detail=f"not claimable in state={state}",
+                )
+            if state == RequestClaimState.LEASED.value and float(row["leased_until"] or 0) >= ts:
+                conn.execute("ROLLBACK")
+                return RequestClaimResult(
+                    status=CacheCasStatus.INVALID_STATE,
+                    request_key=request_key,
+                    detail="request already leased",
+                )
+            attempt_count = int(row["attempt_count"])
+            if attempt_count >= self.max_attempts:
+                conn.execute(
+                    "UPDATE request_claims SET state = ?, error_code = ?, updated_at = ? "
+                    "WHERE request_key = ?",
+                    (
+                        RequestClaimState.FAILED_TERMINAL.value,
+                        "attempt_cap_exhausted",
+                        ts,
+                        request_key,
+                    ),
+                )
+                conn.execute("COMMIT")
+                return RequestClaimResult(
+                    status=CacheCasStatus.ATTEMPT_CAP_EXHAUSTED,
+                    request_key=request_key,
+                    attempt_count=attempt_count,
+                    detail="total automatic fetch attempts exhausted",
+                )
+
+            new_gen = int(row["lease_generation"]) + 1
+            new_attempts = attempt_count + 1
+            leased_until = ts + self.lease_ttl_seconds
+            cur = conn.execute(
+                "UPDATE request_claims SET state = ?, lease_generation = ?, owner = ?, "
+                "leased_until = ?, attempt_count = ?, updated_at = ? "
+                "WHERE request_key = ? AND lease_generation = ? AND state IN (?, ?, ?)",
+                (
+                    RequestClaimState.LEASED.value,
+                    new_gen,
+                    owner,
+                    leased_until,
+                    new_attempts,
+                    ts,
+                    request_key,
+                    int(row["lease_generation"]),
+                    RequestClaimState.PENDING.value,
+                    RequestClaimState.RETRY_SCHEDULED.value,
+                    RequestClaimState.LEASED.value,
+                ),
+            )
+            if cur.rowcount != 1:
+                conn.execute("ROLLBACK")
+                return RequestClaimResult(
+                    status=CacheCasStatus.STALE_COMMIT_REJECTED,
+                    request_key=request_key,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                )
+            self._event(
+                "request_claimed",
+                request_key,
+                lease_generation=new_gen,
+                owner=owner,
+                attempt_count=new_attempts,
+            )
+            if self.crash_after_claim:
+                raise RuntimeError("injected crash: after_claim")
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+        return RequestClaimResult(
+            status=CacheCasStatus.OK,
+            request_key=request_key,
+            lease_generation=new_gen,
+            attempt_count=new_attempts,
+        )
+
+    def commit_raw(
+        self,
+        request_key: str,
+        owner: str,
+        lease_generation: int,
+        *,
+        method: str,
+        url: str,
+        request_body: bytes | str | None = None,
+        response_affecting_headers: dict[str, str] | None = None,
+        adapter_version: str = ADAPTER_VERSION,
+        request_policy_version: str = REQUEST_POLICY_VERSION,
+        status_code: int,
+        response_headers: dict[str, str] | None = None,
+        body: bytes,
+        freshness_policy: str = "",
+        meta: dict[str, Any] | None = None,
+        now: float | None = None,
+    ) -> CacheCasResult:
+        """Atomic raw cache write (metadata + compressed body) under CAS claim."""
+        conn = self._require()
+        ts = self._now(now)
+        if isinstance(request_body, str):
+            body_bytes_req = request_body.encode("utf-8")
+        elif request_body is None:
+            body_bytes_req = b""
+        else:
+            body_bytes_req = request_body
+        req_body_hash = hashlib.sha256(body_bytes_req).hexdigest()
+        body_sha = hashlib.sha256(body).hexdigest()
+        body_z = zlib.compress(body, level=9)
+
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                "SELECT * FROM request_claims WHERE request_key = ?",
+                (request_key,),
+            ).fetchone()
+            if row is None:
+                conn.execute("ROLLBACK")
+                return CacheCasResult(status=CacheCasStatus.NOT_FOUND, detail="claim missing")
+            if (
+                str(row["owner"]) != owner
+                or int(row["lease_generation"]) != int(lease_generation)
+                or str(row["state"]) != RequestClaimState.LEASED.value
+            ):
+                conn.execute("ROLLBACK")
+                self._event(
+                    ErrorCode.STALE_COMMIT_REJECTED.value,
+                    request_key,
+                    op="commit_raw",
+                    lease_generation=lease_generation,
+                    owner=owner,
+                )
+                return CacheCasResult(
+                    status=CacheCasStatus.STALE_COMMIT_REJECTED,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                    lease_generation=lease_generation,
+                    request_key=request_key,
+                )
+
+            # Idempotent: identical raw body already present.
+            existing = conn.execute(
+                "SELECT body_sha256 FROM raw_cache WHERE request_key = ?",
+                (request_key,),
+            ).fetchone()
+            if existing is not None and str(existing["body_sha256"]) == body_sha:
+                conn.execute(
+                    "UPDATE request_claims SET state = ?, owner = NULL, leased_until = NULL, "
+                    "updated_at = ? WHERE request_key = ? AND lease_generation = ?",
+                    (RequestClaimState.DONE.value, ts, request_key, int(lease_generation)),
+                )
+                conn.execute("COMMIT")
+                return CacheCasResult(
+                    status=CacheCasStatus.OK,
+                    lease_generation=lease_generation,
+                    request_key=request_key,
+                    detail="raw already cached",
+                )
+            if existing is not None:
+                conn.execute("ROLLBACK")
+                return CacheCasResult(
+                    status=CacheCasStatus.INVALID_STATE,
+                    detail="raw cache hash conflict",
+                    request_key=request_key,
+                )
+
+            if self.crash_mid_cache_write:
+                raise RuntimeError("injected crash: mid_cache_write")
+
+            conn.execute(
+                "INSERT INTO raw_cache("
+                "request_key, method, url, request_body_hash, headers_json, "
+                "adapter_version, request_policy_version, status_code, "
+                "response_headers_json, body_sha256, body_zlib, freshness_policy, "
+                "fetched_at, meta_json"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    request_key,
+                    method.upper(),
+                    url,
+                    req_body_hash,
+                    canonical_json(
+                        {
+                            str(k).lower(): str(v)
+                            for k, v in (response_affecting_headers or {}).items()
+                        }
+                    ),
+                    adapter_version,
+                    request_policy_version,
+                    int(status_code),
+                    canonical_json(
+                        {str(k).lower(): str(v) for k, v in (response_headers or {}).items()}
+                    ),
+                    body_sha,
+                    body_z,
+                    freshness_policy,
+                    ts,
+                    canonical_json(meta or {}),
+                ),
+            )
+            conn.execute(
+                "UPDATE request_claims SET state = ?, owner = NULL, leased_until = NULL, "
+                "updated_at = ? WHERE request_key = ? AND lease_generation = ?",
+                (RequestClaimState.DONE.value, ts, request_key, int(lease_generation)),
+            )
+            self._event(
+                "raw_cache_committed",
+                request_key,
+                body_sha256=body_sha,
+                status_code=status_code,
+                lease_generation=lease_generation,
+            )
+            if self.crash_after_cache_write:
+                raise RuntimeError("injected crash: after_cache_write")
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+        return CacheCasResult(
+            status=CacheCasStatus.OK,
+            lease_generation=lease_generation,
+            request_key=request_key,
+        )
+
+    def commit_retry_scheduled(
+        self,
+        request_key: str,
+        owner: str,
+        lease_generation: int,
+        *,
+        host: str | None = None,
+        next_allowed_at: float | None = None,
+        error_code: str = "http_429",
+        now: float | None = None,
+    ) -> CacheCasResult:
+        """Release claim to retry_scheduled; optionally advance host-wide cooldown."""
+        conn = self._require()
+        ts = self._now(now)
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            cur = conn.execute(
+                "UPDATE request_claims SET state = ?, owner = NULL, leased_until = NULL, "
+                "error_code = ?, updated_at = ? "
+                "WHERE request_key = ? AND owner = ? AND lease_generation = ? AND state = ?",
+                (
+                    RequestClaimState.RETRY_SCHEDULED.value,
+                    error_code,
+                    ts,
+                    request_key,
+                    owner,
+                    int(lease_generation),
+                    RequestClaimState.LEASED.value,
+                ),
+            )
+            if cur.rowcount != 1:
+                conn.execute("ROLLBACK")
+                return CacheCasResult(
+                    status=CacheCasStatus.STALE_COMMIT_REJECTED,
+                    detail=ErrorCode.STALE_COMMIT_REJECTED.value,
+                    lease_generation=lease_generation,
+                    request_key=request_key,
+                )
+            if host is not None and next_allowed_at is not None:
+                conn.execute(
+                    "INSERT INTO host_cooldowns(host, next_allowed_at) VALUES (?, ?) "
+                    "ON CONFLICT(host) DO UPDATE SET "
+                    "next_allowed_at = excluded.next_allowed_at",
+                    (host, float(next_allowed_at)),
+                )
+            self._event(
+                "retry_scheduled",
+                request_key,
+                error_code=error_code,
+                host=host,
+                next_allowed_at=next_allowed_at,
+                lease_generation=lease_generation,
+            )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        return CacheCasResult(
+            status=CacheCasStatus.OK,
+            lease_generation=lease_generation,
+            request_key=request_key,
+        )
+
+    def put_parsed(
+        self,
+        *,
+        request_key: str,
+        body_sha256: str,
+        parser_version: str,
+        normalizer_version: str,
+        schema_version: str,
+        parsed_payload: bytes | str,
+        now: float | None = None,
+    ) -> str:
+        """Store parsed artifact keyed by raw body + parser/normalizer/schema versions."""
+        conn = self._require()
+        ts = self._now(now)
+        parsed_bytes = (
+            parsed_payload.encode("utf-8") if isinstance(parsed_payload, str) else parsed_payload
+        )
+        parsed_sha = hashlib.sha256(parsed_bytes).hexdigest()
+        parsed_key = compute_parsed_key(
+            request_key=request_key,
+            body_sha256=body_sha256,
+            parser_version=parser_version,
+            normalizer_version=normalizer_version,
+            schema_version=schema_version,
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO parsed_cache("
+            "parsed_key, request_key, body_sha256, parser_version, normalizer_version, "
+            "schema_version, parsed_sha256, parsed_zlib, created_at"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                parsed_key,
+                request_key,
+                body_sha256,
+                parser_version,
+                normalizer_version,
+                schema_version,
+                parsed_sha,
+                zlib.compress(parsed_bytes, level=9),
+                ts,
+            ),
+        )
+        return parsed_key
+
+    def get_parsed(self, parsed_key: str) -> bytes | None:
+        conn = self._require()
+        row = conn.execute(
+            "SELECT parsed_zlib FROM parsed_cache WHERE parsed_key = ?",
+            (parsed_key,),
+        ).fetchone()
+        if row is None:
+            return None
+        return zlib.decompress(bytes(row["parsed_zlib"]))
+
+    def record_fetch_attempt(self) -> None:
+        """Instrumentation: count a real network/fetch side-effect."""
+        self.fetch_count += 1
+
+    def list_events(self, event: str | None = None) -> list[dict[str, Any]]:
+        conn = self._require()
+        if event is None:
+            rows = conn.execute(
+                "SELECT * FROM fetch_events ORDER BY event_id"
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM fetch_events WHERE event = ? ORDER BY event_id",
+                (event,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+
+def open_network_cache(path: Path, **kwargs: Any) -> NetworkCache:
+    """Open a network cache under the network-worker sources.db guard."""
+    with guard_network_worker():
+        # Refuse accidental sources.db path and any open attempt.
+        if path.name == "sources.db" or path.resolve().name == "sources.db":
+            raise SourcesDbForbiddenError(
+                f"network workers cannot open sources.db (refused path={path})"
+            )
+        cache = NetworkCache(path, **kwargs)
+        cache.open()
+        return cache

--- a/scripts/lexicon/runner/network_cache.py
+++ b/scripts/lexicon/runner/network_cache.py
@@ -29,7 +29,7 @@ from scripts.lexicon.runner.contracts import (
     canonical_json,
 )
 from scripts.lexicon.runner.sources_guard import (
-    SourcesDbForbiddenError,
+    apply_network_connection_guards,
     assert_not_sources_db,
     guard_network_worker,
 )
@@ -274,6 +274,8 @@ class NetworkCache:
         lock_fh.flush()
 
         self._conn = sqlite3.connect(self.path, isolation_level=None)
+        # Network-side factory: always install ATTACH authorizer (PR #5365 review).
+        apply_network_connection_guards(self._conn, self.path, force_authorizer=True)
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA foreign_keys = ON")
         self._conn.execute("PRAGMA journal_mode = WAL")
@@ -805,11 +807,9 @@ class NetworkCache:
 def open_network_cache(path: Path, **kwargs: Any) -> NetworkCache:
     """Open a network cache under the network-worker sources.db guard."""
     with guard_network_worker():
-        # Refuse accidental sources.db path and any open attempt.
-        if path.name == "sources.db" or path.resolve().name == "sources.db":
-            raise SourcesDbForbiddenError(
-                f"network workers cannot open sources.db (refused path={path})"
-            )
+        # Refuse accidental sources.db path (URI/inode-aware) before connect.
+        assert_not_sources_db(path)
         cache = NetworkCache(path, **kwargs)
         cache.open()
         return cache
+

--- a/scripts/lexicon/runner/network_worker.py
+++ b/scripts/lexicon/runner/network_worker.py
@@ -1,0 +1,334 @@
+"""Network fetch/parse worker (#5230 PR3).
+
+Operates only against the durable network cache. Never opens ``sources.db``.
+Uses request-level fenced claims; 429 releases to ``retry_scheduled`` and sets a
+host-wide cooldown without touching packet transport state.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.lexicon.runner.contracts import (
+    ADAPTER_VERSION,
+    NORMALIZER_VERSION,
+    PARSED_SCHEMA_VERSION,
+    PARSER_VERSION,
+    REQUEST_POLICY_VERSION,
+)
+from scripts.lexicon.runner.network_cache import (
+    CacheCasStatus,
+    NetworkCache,
+    compute_request_key,
+)
+from scripts.lexicon.runner.sources_guard import (
+    SourcesDbForbiddenError,
+    guard_network_worker,
+    open_sources_db_refused,
+)
+from scripts.lexicon.runner.transport import (
+    BundleItem,
+    PacketItem,
+    build_bundle,
+    item_content_hash,
+    read_packet,
+)
+
+FetchFn = Callable[[str, str, bytes | None, dict[str, str]], tuple[int, dict[str, str], bytes]]
+ParseFn = Callable[[bytes, Mapping[str, Any]], dict[str, Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class NetworkWorkItem:
+    lemma_id: str
+    method: str
+    url: str
+    request_body: bytes | None = None
+    response_affecting_headers: dict[str, str] | None = None
+    request_meta: dict[str, Any] | None = None
+
+    @property
+    def request_key(self) -> str:
+        return compute_request_key(
+            method=self.method,
+            url=self.url,
+            request_body=self.request_body,
+            response_affecting_headers=self.response_affecting_headers,
+        )
+
+    def as_packet_item(self) -> PacketItem:
+        request = {
+            "adapter_version": ADAPTER_VERSION,
+            "method": self.method.upper(),
+            "request_body_b64": None
+            if self.request_body is None
+            else base64.b64encode(self.request_body).decode("ascii"),
+            "request_policy_version": REQUEST_POLICY_VERSION,
+            "response_affecting_headers": dict(self.response_affecting_headers or {}),
+            "url": self.url,
+            **dict(self.request_meta or {}),
+        }
+        return PacketItem.from_request(self.lemma_id, self.request_key, request)
+
+
+@dataclass(slots=True)
+class FetchOutcome:
+    lemma_id: str
+    request_key: str
+    status: str  # done | retry_scheduled | failed_terminal | cache_hit_parsed
+    result: dict[str, Any] | None = None
+    result_hash: str | None = None
+    error_code: str | None = None
+    fetched: bool = False
+    status_code: int | None = None
+
+
+def refuse_sources_db(path: Path | str) -> None:
+    """Public hard guard used by network worker entry points and tests."""
+    open_sources_db_refused(path)
+
+
+def default_parse(body: bytes, request: Mapping[str, Any]) -> dict[str, Any]:
+    """Minimal deterministic parser: JSON if possible, else text envelope."""
+    text = body.decode("utf-8", errors="replace")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = {"text": text}
+    return {
+        "lemma_id": request.get("lemma_id"),
+        "parser_version": PARSER_VERSION,
+        "payload": parsed,
+        "request_key": request.get("request_key"),
+        "url": request.get("url"),
+    }
+
+
+def process_request(
+    cache: NetworkCache,
+    item: NetworkWorkItem,
+    *,
+    owner: str,
+    fetch: FetchFn,
+    parse: ParseFn = default_parse,
+    host: str = "default",
+    now: float | None = None,
+    cooldown_seconds: float = 60.0,
+) -> FetchOutcome:
+    """Claim → (cache hit | fetch+atomic cache) → parse. Never opens sources.db."""
+    with guard_network_worker():
+        request_key = item.request_key
+        claim = cache.claim_request(request_key, owner, now=now, host=host)
+        if claim.status is CacheCasStatus.HOST_COOLDOWN:
+            return FetchOutcome(
+                lemma_id=item.lemma_id,
+                request_key=request_key,
+                status="retry_scheduled",
+                error_code="host_cooldown",
+            )
+        if claim.status is CacheCasStatus.ATTEMPT_CAP_EXHAUSTED:
+            return FetchOutcome(
+                lemma_id=item.lemma_id,
+                request_key=request_key,
+                status="failed_terminal",
+                error_code="attempt_cap_exhausted",
+            )
+        if not claim.ok:
+            return FetchOutcome(
+                lemma_id=item.lemma_id,
+                request_key=request_key,
+                status="failed_terminal",
+                error_code=claim.status.value,
+            )
+
+        body: bytes
+        body_sha: str
+        status_code: int
+        fetched = False
+
+        if claim.is_cache_hit:
+            assert claim.cached_body is not None and claim.body_sha256 is not None
+            body = claim.cached_body
+            body_sha = claim.body_sha256
+            status_code = int(claim.status_code or 200)
+        else:
+            assert claim.lease_generation is not None
+            cache.record_fetch_attempt()
+            status_code, resp_headers, body = fetch(
+                item.method,
+                item.url,
+                item.request_body,
+                dict(item.response_affecting_headers or {}),
+            )
+            fetched = True
+            if status_code == 429:
+                ts = time.time() if now is None else float(now)
+                cache.commit_retry_scheduled(
+                    request_key,
+                    owner,
+                    claim.lease_generation,
+                    host=host,
+                    next_allowed_at=ts + float(cooldown_seconds),
+                    error_code="http_429",
+                    now=ts,
+                )
+                return FetchOutcome(
+                    lemma_id=item.lemma_id,
+                    request_key=request_key,
+                    status="retry_scheduled",
+                    error_code="http_429",
+                    fetched=True,
+                    status_code=429,
+                )
+            raw = cache.commit_raw(
+                request_key,
+                owner,
+                claim.lease_generation,
+                method=item.method,
+                url=item.url,
+                request_body=item.request_body,
+                response_affecting_headers=item.response_affecting_headers,
+                status_code=status_code,
+                response_headers=resp_headers,
+                body=body,
+                now=now,
+            )
+            if not raw.ok:
+                return FetchOutcome(
+                    lemma_id=item.lemma_id,
+                    request_key=request_key,
+                    status="failed_terminal",
+                    error_code=raw.status.value,
+                    fetched=True,
+                    status_code=status_code,
+                )
+            body_sha = hashlib.sha256(body).hexdigest()
+
+        request_ctx = {
+            "lemma_id": item.lemma_id,
+            "request_key": request_key,
+            "url": item.url,
+            "method": item.method.upper(),
+        }
+        parsed = parse(body, request_ctx)
+        cache.put_parsed(
+            request_key=request_key,
+            body_sha256=body_sha,
+            parser_version=PARSER_VERSION,
+            normalizer_version=NORMALIZER_VERSION,
+            schema_version=PARSED_SCHEMA_VERSION,
+            parsed_payload=json.dumps(parsed, ensure_ascii=False, sort_keys=True),
+            now=now,
+        )
+        result_body = {
+            "lemma_id": item.lemma_id,
+            "request_key": request_key,
+            "result": parsed,
+        }
+        return FetchOutcome(
+            lemma_id=item.lemma_id,
+            request_key=request_key,
+            status="done" if not claim.is_cache_hit else "cache_hit_parsed",
+            result=parsed,
+            result_hash=item_content_hash(result_body),
+            fetched=fetched,
+            status_code=status_code,
+        )
+
+
+def process_packet_to_bundle(
+    cache: NetworkCache,
+    packet_path: Path,
+    *,
+    owner: str,
+    fetch: FetchFn,
+    output_dir: Path,
+    host: str = "default",
+    parse: ParseFn = default_parse,
+    now: float | None = None,
+    cooldown_seconds: float = 60.0,
+) -> tuple[Path | None, list[FetchOutcome]]:
+    """Fetch/parse every packet item via the cache; emit one result bundle when all done.
+
+    Items that land in ``retry_scheduled`` do not enter the bundle. Returns
+    ``(bundle_path_or_None, outcomes)``.
+    """
+    with guard_network_worker():
+        packet = read_packet(packet_path)
+        outcomes: list[FetchOutcome] = []
+        bundle_items: list[BundleItem] = []
+        for entry in packet.items:
+            body_b64 = entry["request"].get("request_body_b64")
+            req_body = None
+            if body_b64:
+                req_body = base64.b64decode(body_b64)
+            work = NetworkWorkItem(
+                lemma_id=entry["lemma_id"],
+                method=str(entry["request"].get("method") or "GET"),
+                url=str(entry["request"]["url"]),
+                request_body=req_body,
+                response_affecting_headers=dict(
+                    entry["request"].get("response_affecting_headers") or {}
+                ),
+            )
+            # Prefer packet's request_key identity; recompute must match.
+            if work.request_key != entry["request_key"]:
+                outcomes.append(
+                    FetchOutcome(
+                        lemma_id=entry["lemma_id"],
+                        request_key=entry["request_key"],
+                        status="failed_terminal",
+                        error_code="request_key_mismatch",
+                    )
+                )
+                continue
+            out = process_request(
+                cache,
+                work,
+                owner=owner,
+                fetch=fetch,
+                parse=parse,
+                host=host,
+                now=now,
+                cooldown_seconds=cooldown_seconds,
+            )
+            outcomes.append(out)
+            if out.result is not None and out.status in {
+                "done",
+                "cache_hit_parsed",
+            }:
+                bundle_items.append(
+                    BundleItem.from_result(
+                        out.lemma_id,
+                        out.request_key,
+                        out.result,
+                    )
+                )
+        if not bundle_items:
+            return None, outcomes
+        ref = build_bundle(
+            run_id=str(packet.manifest["run_id"]),
+            fingerprint=str(packet.manifest["fingerprint"]),
+            packet_id=packet.artifact_id,
+            packet_generation=int(packet.manifest["generation"]),
+            items=bundle_items,
+            output_dir=output_dir,
+        )
+        return ref.path, outcomes
+
+
+def assert_network_worker_cannot_open_sources(path: Path | str = "sources.db") -> None:
+    """Test helper / startup check: always raises for sources.db."""
+    try:
+        with guard_network_worker():
+            refuse_sources_db(path)
+    except SourcesDbForbiddenError:
+        raise
+    raise AssertionError("sources.db guard did not fire")

--- a/scripts/lexicon/runner/packet_export.py
+++ b/scripts/lexicon/runner/packet_export.py
@@ -1,0 +1,93 @@
+"""Phase 4 — request packet export (#5230 PR3).
+
+Exports only unresolved network requests as a content-addressed ``.tar.zst``.
+After export, transport is durable ``packet_exported`` (no live lease).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.lexicon.runner.ledger import CasResult, CasStatus, Ledger
+from scripts.lexicon.runner.network_worker import NetworkWorkItem
+from scripts.lexicon.runner.transport import ArtifactRef, PacketItem, build_packet
+
+
+@dataclass(frozen=True, slots=True)
+class PacketExportResult:
+    artifact: ArtifactRef
+    generation: int
+    lemma_ids: list[str]
+    ledger_status: CasStatus
+
+
+def export_request_packet(
+    ledger: Ledger,
+    *,
+    run_id: str,
+    fingerprint: str,
+    items: Sequence[NetworkWorkItem | PacketItem],
+    output_dir: Path,
+    generation: int | None = None,
+    now: float | None = None,
+) -> PacketExportResult:
+    """Build packet, write content-addressed artifact, record ``packet_exported``."""
+    packet_items: list[PacketItem] = []
+    for item in items:
+        if isinstance(item, PacketItem):
+            packet_items.append(item)
+        else:
+            packet_items.append(item.as_packet_item())
+    packet_items = sorted(packet_items, key=lambda p: p.lemma_id)
+
+    gen = (
+        int(generation)
+        if generation is not None
+        else ledger.next_packet_generation(run_id)
+    )
+    artifact = build_packet(
+        run_id=run_id,
+        fingerprint=fingerprint,
+        generation=gen,
+        items=packet_items,
+        output_dir=output_dir,
+    )
+    rec = ledger.record_packet_exported(
+        run_id,
+        artifact.artifact_id,
+        gen,
+        content_hash=artifact.artifact_id,
+        now=now,
+    )
+    if not rec.ok:
+        return PacketExportResult(
+            artifact=artifact,
+            generation=gen,
+            lemma_ids=[p.lemma_id for p in packet_items],
+            ledger_status=rec.status,
+        )
+    # Register import work units (pending) so later bundle import can CAS-fence.
+    for pkt in packet_items:
+        ledger.register_work_unit(
+            run_id,
+            pkt.lemma_id,
+            unit_kind="lemma",
+            phase="network_import",
+            now=now,
+        )
+        ledger.set_work_unit_packet_generation(
+            run_id,
+            pkt.lemma_id,
+            gen,
+            phase="network_import",
+            request_key=pkt.request_key,
+            now=now,
+        )
+    return PacketExportResult(
+        artifact=artifact,
+        generation=gen,
+        lemma_ids=[p.lemma_id for p in packet_items],
+        ledger_status=CasStatus.OK,
+    )

--- a/scripts/lexicon/runner/sources_guard.py
+++ b/scripts/lexicon/runner/sources_guard.py
@@ -2,17 +2,27 @@
 
 Spec §Phase 5: the VPS runner cannot construct or open sources.db. This module
 provides a process-local flag plus path refusal used by network-side entry points.
+
+Hardening (PR #5365 review delta):
+- SQLite URI / query-string forms are parsed with URI semantics before checks
+- Case-insensitive substring match on the resolved path target
+- Inode comparison against the configured ``sources.db`` path (hardlink defense)
+- SQLite authorizer denying ``ATTACH`` of any sources.db on network connections
 """
 
 from __future__ import annotations
 
 import contextlib
 import os
+import sqlite3
 import threading
 from collections.abc import Iterator
 from pathlib import Path
+from urllib.parse import unquote
 
 _ENV_FLAG = "LEXICON_RUNNER_NETWORK_WORKER"
+_SOURCES_DB_ENV = "LEXICON_SOURCES_DB"
+_SOURCES_DB_NAME = "sources.db"
 _tls = threading.local()
 
 
@@ -30,23 +40,164 @@ def is_network_worker() -> bool:
     return _flag_active()
 
 
+def configured_sources_db_path() -> Path:
+    """Return the configured corpus ``sources.db`` path.
+
+    Honours ``LEXICON_SOURCES_DB`` when set; otherwise the repo-default
+    ``data/sources.db`` (resolved against the process cwd).
+    """
+    override = os.environ.get(_SOURCES_DB_ENV, "").strip()
+    if override:
+        return Path(override)
+    return Path("data") / _SOURCES_DB_NAME
+
+
+def _sqlite_uri_path_target(path: Path | str) -> str:
+    """Extract the filesystem path SQLite would open from a URI or plain path.
+
+    Implements the subset of SQLite URI filename semantics needed for the guard
+    (https://www.sqlite.org/uri.html): ``file:`` scheme, authority forms, and
+    stripping of query string / fragment. Non-``file:`` strings are treated as
+    ordinary filenames; a bare ``?…`` suffix (common accidental URI form) is
+    still stripped so ``sources.db?mode=ro`` resolves to ``sources.db``.
+    """
+    raw = str(path)
+    lower = raw.lower()
+    if lower.startswith("file:"):
+        rest = raw[5:]
+        if rest.startswith("//"):
+            # file:///abs, file://localhost/abs, file://host/path
+            without = rest[2:]
+            if without.startswith("/"):
+                path_part = without
+            else:
+                slash = without.find("/")
+                path_part = without[slash:] if slash >= 0 else without
+        else:
+            # file:/abs or file:relative
+            path_part = rest
+        for sep in ("?", "#"):
+            if sep in path_part:
+                path_part = path_part.split(sep, 1)[0]
+        return unquote(path_part)
+
+    # Ordinary filename. Strip accidental query/fragment suffixes so
+    # ``sources.db?mode=ro`` is recognized even without a file: scheme.
+    plain = raw
+    for sep in ("?", "#"):
+        if sep in plain:
+            plain = plain.split(sep, 1)[0]
+    return plain
+
+
+def _looks_like_sources_db(path: Path | str) -> bool:
+    """True when *path* names sources.db (URI-aware, case-insensitive)."""
+    target = _sqlite_uri_path_target(path)
+    target_lower = target.lower().replace("\\", "/")
+    if _SOURCES_DB_NAME in target_lower:
+        return True
+    # Basename of the stripped target (handles empty/edge URI forms).
+    name = Path(target).name.lower()
+    if name == _SOURCES_DB_NAME:
+        return True
+    # Resolved absolute path (follows symlinks when the path exists).
+    try:
+        candidate = Path(target)
+        # Only resolve when it doesn't invent a non-existent absolute path for
+        # pure URI strings that are already absolute after unquote.
+        resolved = candidate.resolve()
+        resolved_s = str(resolved).lower().replace("\\", "/")
+        if _SOURCES_DB_NAME in resolved_s or resolved.name.lower() == _SOURCES_DB_NAME:
+            return True
+    except OSError:
+        pass
+    return False
+
+
+def _same_inode(a: Path, b: Path) -> bool:
+    try:
+        if not a.is_file() or not b.is_file():
+            return False
+        sa = a.stat()
+        sb = b.stat()
+        return sa.st_ino == sb.st_ino and sa.st_dev == sb.st_dev
+    except OSError:
+        return False
+
+
+def _inode_matches_configured_sources(path: Path | str) -> bool:
+    """True when *path* is a hardlink (same inode) to the configured sources.db."""
+    target = _sqlite_uri_path_target(path)
+    try:
+        candidate = Path(target).resolve()
+    except OSError:
+        return False
+    configured = configured_sources_db_path()
+    try:
+        configured_resolved = configured.resolve()
+    except OSError:
+        return False
+    return _same_inode(candidate, configured_resolved)
+
+
 def assert_not_sources_db(path: Path | str) -> None:
     """Refuse any path that is or ends with sources.db when the guard is active.
 
-    Always refuses an explicit ``sources.db`` basename under the network-worker
-    role. When the guard is inactive this is a no-op so offline workers may open
+    Always refuses an explicit ``sources.db`` basename (including URI/query forms
+    and hardlinks to the configured sources.db) under the network-worker role.
+    When the guard is inactive this is a no-op so offline workers may open
     sources for Map/Reduce enrichment.
     """
     if not _flag_active():
         return
-    resolved = Path(path)
-    name = resolved.name
-    # Also catch URI forms like file:/.../sources.db?mode=ro
-    s = str(path)
-    if name == "sources.db" or s.rstrip("/").endswith("sources.db") or "/sources.db?" in s:
+    if _looks_like_sources_db(path) or _inode_matches_configured_sources(path):
         raise SourcesDbForbiddenError(
             f"network workers cannot open sources.db (refused path={path})"
         )
+
+
+def install_network_authorizer(
+    conn: sqlite3.Connection,
+    *,
+    force: bool = False,
+) -> None:
+    """Deny ATTACH of sources.db on a network-side SQLite connection.
+
+    Applied by every network-side connection factory after ``sqlite3.connect``.
+    When *force* is False (default), installs only while the network-worker
+    guard is active so offline openers are unaffected. Network-only factories
+    (e.g. ``NetworkCache``) pass ``force=True``.
+    """
+    if not force and not _flag_active():
+        return
+
+    def _authorizer(
+        action: int,
+        arg1: str | None,
+        _arg2: str | None,
+        _dbname: str | None,
+        _source: str | None,
+    ) -> int:
+        if action == sqlite3.SQLITE_ATTACH:
+            target = arg1 if arg1 is not None else ""
+            if _looks_like_sources_db(target) or _inode_matches_configured_sources(target):
+                return sqlite3.SQLITE_DENY
+        return sqlite3.SQLITE_OK
+
+    conn.set_authorizer(_authorizer)
+
+
+def apply_network_connection_guards(
+    conn: sqlite3.Connection,
+    path: Path | str | None = None,
+    *,
+    force_authorizer: bool = False,
+) -> sqlite3.Connection:
+    """Path assert (optional) + ATTACH authorizer for a network-side connection."""
+    if path is not None:
+        assert_not_sources_db(path)
+    install_network_authorizer(conn, force=force_authorizer)
+    return conn
 
 
 @contextlib.contextmanager
@@ -69,16 +220,11 @@ def guard_network_worker() -> Iterator[None]:
 def open_sources_db_refused(path: Path | str) -> None:
     """Explicit entry used by network workers / tests to prove the hard guard.
 
-    Always raises when path names sources.db, regardless of ambient flag — the
-    network worker must call this before any SQLite open of corpus sources.
+    Always raises when path names sources.db (URI/inode-aware), regardless of
+    ambient flag — the network worker must call this before any SQLite open of
+    corpus sources.
     """
-    resolved = Path(path)
-    s = str(path)
-    if (
-        resolved.name == "sources.db"
-        or s.rstrip("/").endswith("sources.db")
-        or "/sources.db?" in s
-    ):
+    if _looks_like_sources_db(path) or _inode_matches_configured_sources(path):
         raise SourcesDbForbiddenError(
             f"network workers cannot open sources.db (refused path={path})"
         )

--- a/scripts/lexicon/runner/sources_guard.py
+++ b/scripts/lexicon/runner/sources_guard.py
@@ -1,0 +1,89 @@
+"""Hard guard: network workers cannot open ``sources.db`` (#5230 PR3).
+
+Spec §Phase 5: the VPS runner cannot construct or open sources.db. This module
+provides a process-local flag plus path refusal used by network-side entry points.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+
+_ENV_FLAG = "LEXICON_RUNNER_NETWORK_WORKER"
+_tls = threading.local()
+
+
+class SourcesDbForbiddenError(RuntimeError):
+    """Raised when a network worker attempts to open or construct sources.db."""
+
+
+def _flag_active() -> bool:
+    if getattr(_tls, "active", False):
+        return True
+    return os.environ.get(_ENV_FLAG, "").strip() in {"1", "true", "TRUE", "yes", "YES"}
+
+
+def is_network_worker() -> bool:
+    return _flag_active()
+
+
+def assert_not_sources_db(path: Path | str) -> None:
+    """Refuse any path that is or ends with sources.db when the guard is active.
+
+    Always refuses an explicit ``sources.db`` basename under the network-worker
+    role. When the guard is inactive this is a no-op so offline workers may open
+    sources for Map/Reduce enrichment.
+    """
+    if not _flag_active():
+        return
+    resolved = Path(path)
+    name = resolved.name
+    # Also catch URI forms like file:/.../sources.db?mode=ro
+    s = str(path)
+    if name == "sources.db" or s.rstrip("/").endswith("sources.db") or "/sources.db?" in s:
+        raise SourcesDbForbiddenError(
+            f"network workers cannot open sources.db (refused path={path})"
+        )
+
+
+@contextlib.contextmanager
+def guard_network_worker() -> Iterator[None]:
+    """Activate the process/thread-local network-worker sources.db ban."""
+    prev_tls = getattr(_tls, "active", False)
+    prev_env = os.environ.get(_ENV_FLAG)
+    _tls.active = True
+    os.environ[_ENV_FLAG] = "1"
+    try:
+        yield
+    finally:
+        _tls.active = prev_tls
+        if prev_env is None:
+            os.environ.pop(_ENV_FLAG, None)
+        else:
+            os.environ[_ENV_FLAG] = prev_env
+
+
+def open_sources_db_refused(path: Path | str) -> None:
+    """Explicit entry used by network workers / tests to prove the hard guard.
+
+    Always raises when path names sources.db, regardless of ambient flag — the
+    network worker must call this before any SQLite open of corpus sources.
+    """
+    resolved = Path(path)
+    s = str(path)
+    if (
+        resolved.name == "sources.db"
+        or s.rstrip("/").endswith("sources.db")
+        or "/sources.db?" in s
+    ):
+        raise SourcesDbForbiddenError(
+            f"network workers cannot open sources.db (refused path={path})"
+        )
+    # Non-sources paths are still blocked when the ambient network role is set
+    # and something tries the open_sources_ro helper — that helper consults the flag.
+    if _flag_active():
+        # Allow non-sources opens only through explicit network-cache APIs.
+        return

--- a/scripts/lexicon/runner/sqlite_ro.py
+++ b/scripts/lexicon/runner/sqlite_ro.py
@@ -27,12 +27,21 @@ def open_immutable_ro(
     """Open a completed side DB for workers: mode=ro, immutable, query_only.
 
     Bounded page cache; large mmap disabled so workers do not pin giant mappings.
+    Network workers are hard-refused for sources.db (PR3 review delta).
     """
-    resolved = path.resolve()
+    from scripts.lexicon.runner.sources_guard import (
+        apply_network_connection_guards,
+        assert_not_sources_db,
+    )
+
+    # Resolve symlinks first so the guard sees the real target (review finding 2/3).
+    resolved = Path(path).resolve()
+    assert_not_sources_db(resolved)
     if not resolved.is_file():
         raise FileNotFoundError(resolved)
     uri = f"file:{resolved.as_posix()}?mode=ro&immutable=1"
     conn = sqlite3.connect(uri, uri=True)
+    apply_network_connection_guards(conn, resolved)
     conn.execute("PRAGMA query_only = ON")
     conn.execute(f"PRAGMA cache_size = -{int(cache_kib)}")
     conn.execute(f"PRAGMA mmap_size = {int(mmap_size)}")
@@ -45,12 +54,17 @@ def open_sources_ro(path: Path) -> sqlite3.Connection:
 
     Network workers are hard-refused (PR3 / spec §Phase 5).
     """
-    from scripts.lexicon.runner.sources_guard import assert_not_sources_db
+    from scripts.lexicon.runner.sources_guard import (
+        apply_network_connection_guards,
+        assert_not_sources_db,
+    )
 
-    assert_not_sources_db(path)
-    resolved = path.resolve()
+    # Resolve symlinks BEFORE asserting (review finding 2).
+    resolved = Path(path).resolve()
+    assert_not_sources_db(resolved)
     uri = f"file:{resolved.as_posix()}?mode=ro"
     conn = sqlite3.connect(uri, uri=True)
+    apply_network_connection_guards(conn, resolved)
     conn.execute("PRAGMA query_only = ON")
     conn.row_factory = sqlite3.Row
     return conn

--- a/scripts/lexicon/runner/sqlite_ro.py
+++ b/scripts/lexicon/runner/sqlite_ro.py
@@ -41,7 +41,13 @@ def open_immutable_ro(
 
 
 def open_sources_ro(path: Path) -> sqlite3.Connection:
-    """Open sources.db read-only (mutable file; no immutable=1)."""
+    """Open sources.db read-only (mutable file; no immutable=1).
+
+    Network workers are hard-refused (PR3 / spec §Phase 5).
+    """
+    from scripts.lexicon.runner.sources_guard import assert_not_sources_db
+
+    assert_not_sources_db(path)
     resolved = path.resolve()
     uri = f"file:{resolved.as_posix()}?mode=ro"
     conn = sqlite3.connect(uri, uri=True)

--- a/scripts/lexicon/runner/transport.py
+++ b/scripts/lexicon/runner/transport.py
@@ -1,0 +1,551 @@
+"""Content-addressed packet/bundle transport (#5230 PR3).
+
+Packets and return bundles are immutable ``.tar.zst`` objects named by SHA-256
+(spec §9). Writes are rsync-resumable: content is staged to a ``.partial`` file
+and atomically renamed only after the outer content hash verifies.
+
+Host-agnostic: no VPS provisioning. Compression uses the ``zstandard`` module
+when installed, otherwise the ``zstd`` CLI (same framing either way).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.lexicon.runner.contracts import (
+    BUNDLE_SCHEMA_VERSION,
+    PACKET_SCHEMA_VERSION,
+    canonical_json,
+)
+
+# Soft bound so one changed item never requires retransmitting multi-GB archives.
+DEFAULT_MAX_BUNDLE_ITEMS = 500
+DEFAULT_MAX_BUNDLE_UNCOMPRESSED_BYTES = 64 * 1024 * 1024  # 64 MiB
+
+
+class TransportError(RuntimeError):
+    """Invalid packet/bundle construction or verification failure."""
+
+
+class HashMismatchError(TransportError):
+    """Outer or per-item content hash did not match."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            block = handle.read(chunk_size)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def zstd_compress(data: bytes, *, level: int = 3) -> bytes:
+    """Compress bytes to zstd framing."""
+    try:
+        import zstandard as zstd  # type: ignore[import-not-found]
+
+        return zstd.ZstdCompressor(level=level).compress(data)
+    except ImportError:
+        pass
+    if shutil.which("zstd") is None:
+        raise TransportError(
+            "zstd compression requires the 'zstandard' package or a 'zstd' binary on PATH"
+        )
+    proc = subprocess.run(
+        ["zstd", f"-{int(level)}", "-c", "-"],
+        input=data,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise TransportError(f"zstd compress failed: {proc.stderr[:200]!r}")
+    return proc.stdout
+
+
+def zstd_decompress(data: bytes) -> bytes:
+    """Decompress zstd-framed bytes."""
+    try:
+        import zstandard as zstd  # type: ignore[import-not-found]
+
+        return zstd.ZstdDecompressor().decompress(data)
+    except ImportError:
+        pass
+    if shutil.which("zstd") is None:
+        raise TransportError(
+            "zstd decompression requires the 'zstandard' package or a 'zstd' binary on PATH"
+        )
+    proc = subprocess.run(
+        ["zstd", "-d", "-c", "-"],
+        input=data,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise TransportError(f"zstd decompress failed: {proc.stderr[:200]!r}")
+    return proc.stdout
+
+
+def item_content_hash(payload: Mapping[str, Any] | bytes | str) -> str:
+    if isinstance(payload, bytes):
+        return _sha256_bytes(payload)
+    if isinstance(payload, str):
+        return _sha256_bytes(payload.encode("utf-8"))
+    return _sha256_bytes(canonical_json(dict(payload)).encode("utf-8"))
+
+
+@dataclass(frozen=True, slots=True)
+class PacketItem:
+    lemma_id: str
+    request_key: str
+    request: dict[str, Any]
+    item_hash: str
+
+    @staticmethod
+    def from_request(
+        lemma_id: str,
+        request_key: str,
+        request: Mapping[str, Any],
+    ) -> PacketItem:
+        body = {
+            "lemma_id": lemma_id,
+            "request": dict(request),
+            "request_key": request_key,
+        }
+        return PacketItem(
+            lemma_id=lemma_id,
+            request_key=request_key,
+            request=dict(request),
+            item_hash=item_content_hash(body),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BundleItem:
+    lemma_id: str
+    request_key: str
+    result: dict[str, Any]
+    result_hash: str
+
+    @staticmethod
+    def from_result(
+        lemma_id: str,
+        request_key: str,
+        result: Mapping[str, Any],
+    ) -> BundleItem:
+        body = {
+            "lemma_id": lemma_id,
+            "request_key": request_key,
+            "result": dict(result),
+        }
+        return BundleItem(
+            lemma_id=lemma_id,
+            request_key=request_key,
+            result=dict(result),
+            result_hash=item_content_hash(body),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactRef:
+    """Content-addressed artifact on disk."""
+
+    artifact_id: str
+    path: Path
+    kind: str  # "packet" | "bundle"
+    item_count: int
+    uncompressed_bytes: int
+
+
+def _build_tar_bytes(members: Mapping[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name in sorted(members):
+            data = members[name]
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _extract_tar_bytes(tar_bytes: bytes) -> dict[str, bytes]:
+    out: dict[str, bytes] = {}
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:") as tar:
+        for member in tar.getmembers():
+            if not member.isfile():
+                continue
+            handle = tar.extractfile(member)
+            if handle is None:
+                continue
+            out[member.name] = handle.read()
+    return out
+
+
+def atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Rsync-resumable durable write: ``.partial`` then fsync + atomic rename."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    partial = path.with_name(path.name + ".partial")
+    # If a prior partial exists, overwrite from start (rsync-style resume at app layer
+    # is: rewrite partial until final hash matches, then rename).
+    fd = os.open(str(partial), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except Exception:
+        # Leave partial for resume; re-raise.
+        raise
+    os.replace(partial, path)
+    # Best-effort directory fsync for durability on crash after rename.
+    try:
+        dir_fd = os.open(str(path.parent), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass
+
+
+def write_content_addressed(
+    directory: Path,
+    tar_bytes: bytes,
+    *,
+    kind: str,
+    item_count: int,
+) -> ArtifactRef:
+    """Compress, hash, and write ``{sha256}.tar.zst`` under *directory*."""
+    compressed = zstd_compress(tar_bytes)
+    artifact_id = _sha256_bytes(compressed)
+    path = Path(directory) / f"{artifact_id}.tar.zst"
+    if path.is_file():
+        # Idempotent retransmission: same object, same path.
+        if _sha256_file(path) != artifact_id:
+            raise HashMismatchError(f"existing artifact corrupted: {path}")
+        return ArtifactRef(
+            artifact_id=artifact_id,
+            path=path,
+            kind=kind,
+            item_count=item_count,
+            uncompressed_bytes=len(tar_bytes),
+        )
+    atomic_write_bytes(path, compressed)
+    # Verify outer hash after write (receiving-side contract also uses this).
+    if _sha256_file(path) != artifact_id:
+        path.unlink(missing_ok=True)
+        raise HashMismatchError(f"outer hash mismatch after write: {path}")
+    return ArtifactRef(
+        artifact_id=artifact_id,
+        path=path,
+        kind=kind,
+        item_count=item_count,
+        uncompressed_bytes=len(tar_bytes),
+    )
+
+
+def verify_artifact_file(path: Path, *, expected_id: str | None = None) -> str:
+    """Verify outer content address before extraction. Returns artifact id."""
+    path = Path(path)
+    if not path.is_file():
+        raise TransportError(f"artifact missing: {path}")
+    # Ignore incomplete partials.
+    if path.name.endswith(".partial"):
+        raise TransportError(f"partial transfer not final: {path}")
+    digest = _sha256_file(path)
+    name_id = path.name.removesuffix(".tar.zst")
+    if path.name.endswith(".tar.zst") and name_id != digest:
+        raise HashMismatchError(
+            f"filename content-address mismatch: name={name_id} file={digest}"
+        )
+    if expected_id is not None and digest != expected_id:
+        raise HashMismatchError(
+            f"expected artifact id {expected_id}, got {digest}"
+        )
+    return digest
+
+
+def load_tar_zst(path: Path, *, expected_id: str | None = None) -> dict[str, bytes]:
+    verify_artifact_file(path, expected_id=expected_id)
+    compressed = Path(path).read_bytes()
+    return _extract_tar_bytes(zstd_decompress(compressed))
+
+
+def build_packet(
+    *,
+    run_id: str,
+    fingerprint: str,
+    generation: int,
+    items: Sequence[PacketItem],
+    output_dir: Path,
+    extra_manifest: Mapping[str, Any] | None = None,
+) -> ArtifactRef:
+    """Build a content-addressed request packet (.tar.zst)."""
+    if not items:
+        raise TransportError("packet requires at least one item")
+    item_entries = []
+    members: dict[str, bytes] = {}
+    for item in items:
+        body = {
+            "lemma_id": item.lemma_id,
+            "request": item.request,
+            "request_key": item.request_key,
+        }
+        raw = canonical_json(body).encode("utf-8")
+        digest = _sha256_bytes(raw)
+        if digest != item.item_hash:
+            raise HashMismatchError(
+                f"item hash mismatch for lemma {item.lemma_id}: "
+                f"declared={item.item_hash} actual={digest}"
+            )
+        rel = f"items/{item.lemma_id}.json"
+        members[rel] = raw
+        item_entries.append(
+            {
+                "item_hash": item.item_hash,
+                "lemma_id": item.lemma_id,
+                "path": rel,
+                "request_key": item.request_key,
+            }
+        )
+    manifest = {
+        "fingerprint": fingerprint,
+        "generation": int(generation),
+        "items": sorted(item_entries, key=lambda x: x["lemma_id"]),
+        "kind": "packet",
+        "run_id": run_id,
+        "schema_version": PACKET_SCHEMA_VERSION,
+        **dict(extra_manifest or {}),
+    }
+    members["manifest.json"] = canonical_json(manifest).encode("utf-8")
+    tar_bytes = _build_tar_bytes(members)
+    return write_content_addressed(
+        output_dir, tar_bytes, kind="packet", item_count=len(items)
+    )
+
+
+def build_bundle(
+    *,
+    run_id: str,
+    fingerprint: str,
+    packet_id: str,
+    packet_generation: int,
+    items: Sequence[BundleItem],
+    output_dir: Path,
+    max_items: int = DEFAULT_MAX_BUNDLE_ITEMS,
+    max_uncompressed_bytes: int = DEFAULT_MAX_BUNDLE_UNCOMPRESSED_BYTES,
+    extra_manifest: Mapping[str, Any] | None = None,
+) -> ArtifactRef:
+    """Build a bounded content-addressed result bundle (.tar.zst)."""
+    if not items:
+        raise TransportError("bundle requires at least one item")
+    if len(items) > int(max_items):
+        raise TransportError(
+            f"bundle item count {len(items)} exceeds bound {max_items}; split the bundle"
+        )
+    item_entries = []
+    members: dict[str, bytes] = {}
+    for item in items:
+        body = {
+            "lemma_id": item.lemma_id,
+            "request_key": item.request_key,
+            "result": item.result,
+        }
+        raw = canonical_json(body).encode("utf-8")
+        digest = _sha256_bytes(raw)
+        if digest != item.result_hash:
+            raise HashMismatchError(
+                f"result hash mismatch for lemma {item.lemma_id}: "
+                f"declared={item.result_hash} actual={digest}"
+            )
+        rel = f"items/{item.lemma_id}.json"
+        members[rel] = raw
+        item_entries.append(
+            {
+                "lemma_id": item.lemma_id,
+                "path": rel,
+                "request_key": item.request_key,
+                "result_hash": item.result_hash,
+            }
+        )
+    manifest = {
+        "fingerprint": fingerprint,
+        "items": sorted(item_entries, key=lambda x: x["lemma_id"]),
+        "kind": "bundle",
+        "packet_generation": int(packet_generation),
+        "packet_id": packet_id,
+        "run_id": run_id,
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        **dict(extra_manifest or {}),
+    }
+    members["manifest.json"] = canonical_json(manifest).encode("utf-8")
+    tar_bytes = _build_tar_bytes(members)
+    if len(tar_bytes) > int(max_uncompressed_bytes):
+        raise TransportError(
+            f"bundle uncompressed size {len(tar_bytes)} exceeds bound "
+            f"{max_uncompressed_bytes}; split the bundle"
+        )
+    return write_content_addressed(
+        output_dir, tar_bytes, kind="bundle", item_count=len(items)
+    )
+
+
+def split_bundle_items(
+    items: Sequence[BundleItem],
+    *,
+    max_items: int = DEFAULT_MAX_BUNDLE_ITEMS,
+) -> list[list[BundleItem]]:
+    """Split items into bounded groups (stable lemma order)."""
+    ordered = sorted(items, key=lambda it: it.lemma_id)
+    groups: list[list[BundleItem]] = []
+    for i in range(0, len(ordered), int(max_items)):
+        groups.append(list(ordered[i : i + int(max_items)]))
+    return groups
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedPacket:
+    artifact_id: str
+    path: Path
+    manifest: dict[str, Any]
+    items: list[dict[str, Any]]  # each has lemma_id, request_key, request, item_hash
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedBundle:
+    artifact_id: str
+    path: Path
+    manifest: dict[str, Any]
+    items: list[dict[str, Any]]  # each has lemma_id, request_key, result, result_hash
+
+
+def _load_json_member(members: Mapping[str, bytes], name: str) -> dict[str, Any]:
+    if name not in members:
+        raise TransportError(f"missing member {name!r}")
+    data = json.loads(members[name].decode("utf-8"))
+    if not isinstance(data, dict):
+        raise TransportError(f"{name} must be a JSON object")
+    return data
+
+
+def read_packet(path: Path, *, expected_id: str | None = None) -> LoadedPacket:
+    """Verify outer hash and every per-item hash; return loaded packet."""
+    path = Path(path)
+    artifact_id = verify_artifact_file(path, expected_id=expected_id)
+    members = load_tar_zst(path, expected_id=artifact_id)
+    manifest = _load_json_member(members, "manifest.json")
+    if manifest.get("kind") != "packet":
+        raise TransportError(f"not a packet artifact: kind={manifest.get('kind')!r}")
+    items: list[dict[str, Any]] = []
+    for entry in manifest.get("items") or []:
+        rel = str(entry["path"])
+        raw = members.get(rel)
+        if raw is None:
+            raise TransportError(f"missing packet item file {rel}")
+        actual = _sha256_bytes(raw)
+        declared = str(entry["item_hash"])
+        if actual != declared:
+            raise HashMismatchError(
+                f"per-item hash mismatch for {entry.get('lemma_id')}: "
+                f"declared={declared} actual={actual}"
+            )
+        body = json.loads(raw.decode("utf-8"))
+        items.append(
+            {
+                "item_hash": declared,
+                "lemma_id": str(body["lemma_id"]),
+                "request": dict(body["request"]),
+                "request_key": str(body["request_key"]),
+            }
+        )
+    items.sort(key=lambda x: x["lemma_id"])
+    return LoadedPacket(
+        artifact_id=artifact_id,
+        path=path,
+        manifest=manifest,
+        items=items,
+    )
+
+
+def read_bundle(path: Path, *, expected_id: str | None = None) -> LoadedBundle:
+    """Verify outer hash and every per-item hash; return loaded bundle."""
+    path = Path(path)
+    artifact_id = verify_artifact_file(path, expected_id=expected_id)
+    members = load_tar_zst(path, expected_id=artifact_id)
+    manifest = _load_json_member(members, "manifest.json")
+    if manifest.get("kind") != "bundle":
+        raise TransportError(f"not a bundle artifact: kind={manifest.get('kind')!r}")
+    items: list[dict[str, Any]] = []
+    for entry in manifest.get("items") or []:
+        rel = str(entry["path"])
+        raw = members.get(rel)
+        if raw is None:
+            raise TransportError(f"missing bundle item file {rel}")
+        actual = _sha256_bytes(raw)
+        declared = str(entry["result_hash"])
+        if actual != declared:
+            raise HashMismatchError(
+                f"per-item hash mismatch for {entry.get('lemma_id')}: "
+                f"declared={declared} actual={actual}"
+            )
+        body = json.loads(raw.decode("utf-8"))
+        items.append(
+            {
+                "lemma_id": str(body["lemma_id"]),
+                "request_key": str(body["request_key"]),
+                "result": dict(body["result"]),
+                "result_hash": declared,
+            }
+        )
+    items.sort(key=lambda x: x["lemma_id"])
+    return LoadedBundle(
+        artifact_id=artifact_id,
+        path=path,
+        manifest=manifest,
+        items=items,
+    )
+
+
+def retransmit_copy(src: Path, dest_dir: Path) -> Path:
+    """Idempotent retransmission of the same content-addressed object."""
+    artifact_id = verify_artifact_file(src)
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / f"{artifact_id}.tar.zst"
+    if dest.is_file() and _sha256_file(dest) == artifact_id:
+        return dest
+    # Stage via partial then rename (same contract as initial write).
+    atomic_write_bytes(dest, Path(src).read_bytes())
+    if _sha256_file(dest) != artifact_id:
+        dest.unlink(missing_ok=True)
+        raise HashMismatchError(f"retransmit hash mismatch: {dest}")
+    return dest
+
+
+def stage_directory(prefix: str = "runner-transport-") -> Path:
+    return Path(tempfile.mkdtemp(prefix=prefix))
+
+
+def iter_packet_paths(directory: Path) -> Iterable[Path]:
+    for path in sorted(Path(directory).glob("*.tar.zst")):
+        if path.name.endswith(".partial"):
+            continue
+        yield path

--- a/tests/test_lexicon_runner_pr3_transport.py
+++ b/tests/test_lexicon_runner_pr3_transport.py
@@ -13,6 +13,8 @@ Spec §PR3 / crash matrix:
 
 from __future__ import annotations
 
+import os
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -43,10 +45,12 @@ from scripts.lexicon.runner.network_worker import (
 from scripts.lexicon.runner.packet_export import export_request_packet
 from scripts.lexicon.runner.sources_guard import (
     SourcesDbForbiddenError,
+    assert_not_sources_db,
     guard_network_worker,
+    install_network_authorizer,
     is_network_worker,
 )
-from scripts.lexicon.runner.sqlite_ro import open_sources_ro
+from scripts.lexicon.runner.sqlite_ro import open_immutable_ro, open_sources_ro
 from scripts.lexicon.runner.transport import (
     BundleItem,
     HashMismatchError,
@@ -107,7 +111,6 @@ def test_network_workers_cannot_open_sources_db(tmp_path: Path) -> None:
     assert not is_network_worker()
     # empty file still opens as sqlite (creates schema on connect for non-uri? mode=ro needs file)
     # We only assert the guard path; offline open of a non-db may error — use a real sqlite.
-    import sqlite3
 
     conn = sqlite3.connect(sources)
     conn.execute("CREATE TABLE t(x)")
@@ -115,6 +118,180 @@ def test_network_workers_cannot_open_sources_db(tmp_path: Path) -> None:
     conn.close()
     ro = open_sources_ro(sources)
     ro.close()
+
+
+def test_sources_guard_rejects_uri_query_forms(tmp_path: Path) -> None:
+    """Finding 1: URI / query forms must not bypass basename checks."""
+    sources = tmp_path / "sources.db"
+    conn = sqlite3.connect(sources)
+    conn.execute("CREATE TABLE t(x)")
+    conn.commit()
+    conn.close()
+
+    uri_forms = [
+        "sources.db?mode=ro",
+        "file:sources.db?mode=ro",
+        f"file:{sources.as_posix()}?mode=ro",
+        f"file:///{sources.as_posix().lstrip('/')}?mode=ro&immutable=1",
+        "SOURCES.DB?mode=ro",
+        f"file:{sources.as_posix().upper()}?mode=RO",
+    ]
+    with guard_network_worker():
+        for form in uri_forms:
+            with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+                assert_not_sources_db(form)
+            with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+                refuse_sources_db(form)
+
+
+def test_sources_guard_rejects_symlink_to_sources(tmp_path: Path) -> None:
+    """Finding 2: resolve symlinks before asserting — alias path must refuse."""
+    sources = tmp_path / "sources.db"
+    conn = sqlite3.connect(sources)
+    conn.execute("CREATE TABLE t(x)")
+    conn.commit()
+    conn.close()
+    alias = tmp_path / "not_sources.db"
+    alias.symlink_to(sources)
+
+    with guard_network_worker():
+        with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+            open_sources_ro(alias)
+        with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+            assert_not_sources_db(alias)
+
+
+def test_open_immutable_ro_refuses_sources_db(tmp_path: Path) -> None:
+    """Finding 3: open_immutable_ro must apply the sources guard."""
+    sources = tmp_path / "sources.db"
+    conn = sqlite3.connect(sources)
+    conn.execute("CREATE TABLE t(x)")
+    conn.commit()
+    conn.close()
+    alias = tmp_path / "side_alias.db"
+    alias.symlink_to(sources)
+
+    with guard_network_worker():
+        with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+            open_immutable_ro(sources)
+        with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+            open_immutable_ro(alias)
+
+
+def test_commit_import_txn_fence_rejects_concurrent_abandon(
+    ledger: Ledger, tmp_path: Path
+) -> None:
+    """Finding 4: BEGIN IMMEDIATE before validation — abandon race rejects import.
+
+    Crash hook marks the packet generation abandoned inside the write fence
+    (after BEGIN, before validation reads). Pre-txn validation would have
+    seen the generation as active; the fenced path must still refuse.
+    """
+    fp = compute_run_fingerprint(cohort_digest="import-fence")
+    run = ledger.start_run(fp).run_id
+    assert run
+    work = [NetworkWorkItem(lemma_id="fence-a", method="GET", url="https://example.test/fence")]
+    exported = export_request_packet(
+        ledger,
+        run_id=run,
+        fingerprint=fp,
+        items=work,
+        output_dir=tmp_path / "packets-fence",
+        now=1.0,
+    )
+    gen = exported.generation
+    assert ledger.packet_generation_active(run, gen)
+
+    ledger.crash_import_concurrent_abandon = True
+    result = ledger.commit_import(
+        run,
+        "fence-a",
+        "imp",
+        1,
+        packet_generation=gen,
+        result_hash="body-fence",
+        expected_fingerprint=fp,
+        now=2.0,
+    )
+    ledger.crash_import_concurrent_abandon = False
+
+    assert result.status is CasStatus.INVALID_STATE
+    assert result.detail == "stale_packet_generation"
+    n = ledger._require().execute(
+        "SELECT COUNT(*) AS n FROM imports WHERE run_id = ? AND lemma_id = ?",
+        (run, "fence-a"),
+    ).fetchone()
+    assert int(n["n"]) == 0
+
+
+def test_network_cache_authorizer_denies_attach_sources(tmp_path: Path, monkeypatch) -> None:
+    """Finding 5: ATTACH of sources.db denied on network-side connections."""
+    sources = tmp_path / "sources.db"
+    conn = sqlite3.connect(sources)
+    conn.execute("CREATE TABLE secret(x)")
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("LEXICON_SOURCES_DB", str(sources))
+
+    # Hardlink with a non-sources basename — path string alone is not enough.
+    hardlink = tmp_path / "innocent_hardlink.db"
+    try:
+        os.link(sources, hardlink)
+    except OSError:
+        hardlink = None  # some FS (e.g. some network mounts) disallow hardlinks
+
+    cache = NetworkCache(tmp_path / "net.cache.sqlite")
+    cache.open()
+    try:
+        with pytest.raises(sqlite3.DatabaseError, match=r"not authorized|prohibited"):
+            cache._require().execute(f"ATTACH DATABASE '{sources.as_posix()}' AS sources")
+        with pytest.raises(sqlite3.DatabaseError, match=r"not authorized|prohibited"):
+            cache._require().execute(
+                f"ATTACH DATABASE 'file:{sources.as_posix()}?mode=ro' AS sources"
+            )
+        if hardlink is not None:
+            with pytest.raises(sqlite3.DatabaseError, match=r"not authorized|prohibited"):
+                cache._require().execute(
+                    f"ATTACH DATABASE '{hardlink.as_posix()}' AS sources"
+                )
+    finally:
+        cache.close()
+
+    # Direct factory helper also installs the authorizer under the network role.
+    side = tmp_path / "allowed.db"
+    c2 = sqlite3.connect(side)
+    c2.execute("CREATE TABLE t(x)")
+    c2.commit()
+    c2.close()
+    with guard_network_worker():
+        ro = open_immutable_ro(side)
+        try:
+            install_network_authorizer(ro, force=True)
+            with pytest.raises(sqlite3.DatabaseError, match=r"not authorized|prohibited"):
+                ro.execute(f"ATTACH DATABASE '{sources.as_posix()}' AS sources")
+        finally:
+            ro.close()
+
+
+def test_sources_guard_rejects_hardlink_via_inode(tmp_path: Path, monkeypatch) -> None:
+    """Finding 5 (inode): hardlink to configured sources.db is refused by path."""
+    sources = tmp_path / "sources.db"
+    conn = sqlite3.connect(sources)
+    conn.execute("CREATE TABLE t(x)")
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("LEXICON_SOURCES_DB", str(sources))
+    hardlink = tmp_path / "alias_inode.db"
+    try:
+        os.link(sources, hardlink)
+    except OSError:
+        pytest.skip("filesystem does not support hardlinks")
+
+    with guard_network_worker():
+        with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+            assert_not_sources_db(hardlink)
+        with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+            open_sources_ro(hardlink)
 
 
 # --- 2. atomic raw cache + fenced claims -------------------------------------

--- a/tests/test_lexicon_runner_pr3_transport.py
+++ b/tests/test_lexicon_runner_pr3_transport.py
@@ -1,0 +1,634 @@
+"""Crash + acceptance tests for runner PR3 (network cache + transport).
+
+Spec §PR3 / crash matrix:
+- network workers cannot open sources.db
+- atomic raw cache + fenced request claims (PR2 CAS generations)
+- 429 → retry_scheduled + host cooldown without expiring transport
+- packets/bundles content-addressed, compressed, bounded, rsync-resumable
+- outer + per-item hash verification
+- per-lemma atomic import; stale packet generations rejected
+- cached-unparsed recovery, duplicate runner lock, import killed at k,
+  retransmission, no double-fetch on retry
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.lexicon.runner.bundle_import import import_bundle
+from scripts.lexicon.runner.ledger import (
+    CasStatus,
+    DuplicateRunnerError,
+    Ledger,
+    OperatorActionKind,
+    SchedulableState,
+    UnitOutcome,
+    compute_run_fingerprint,
+)
+from scripts.lexicon.runner.network_cache import (
+    CacheCasStatus,
+    DuplicateCacheRunnerError,
+    NetworkCache,
+    compute_request_key,
+)
+from scripts.lexicon.runner.network_worker import (
+    NetworkWorkItem,
+    assert_network_worker_cannot_open_sources,
+    process_packet_to_bundle,
+    process_request,
+    refuse_sources_db,
+)
+from scripts.lexicon.runner.packet_export import export_request_packet
+from scripts.lexicon.runner.sources_guard import (
+    SourcesDbForbiddenError,
+    guard_network_worker,
+    is_network_worker,
+)
+from scripts.lexicon.runner.sqlite_ro import open_sources_ro
+from scripts.lexicon.runner.transport import (
+    BundleItem,
+    HashMismatchError,
+    PacketItem,
+    build_bundle,
+    build_packet,
+    read_bundle,
+    read_packet,
+    retransmit_copy,
+    split_bundle_items,
+    verify_artifact_file,
+)
+
+
+@pytest.fixture
+def ledger(tmp_path: Path) -> Ledger:
+    lg = Ledger(tmp_path / "run.ledger.sqlite", max_attempts=5, lease_ttl_seconds=60.0)
+    lg.open()
+    yield lg
+    lg.close()
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> NetworkCache:
+    c = NetworkCache(tmp_path / "net.cache.sqlite", max_attempts=5, lease_ttl_seconds=60.0)
+    c.open()
+    yield c
+    c.close()
+
+
+def _fake_fetch_factory(bodies: dict[str, tuple[int, dict[str, str], bytes]], counter: list[int]):
+    def _fetch(
+        method: str, url: str, body: bytes | None, headers: dict[str, str]
+    ) -> tuple[int, dict[str, str], bytes]:
+        counter[0] += 1
+        if url not in bodies:
+            raise AssertionError(f"unexpected fetch url={url}")
+        return bodies[url]
+
+    return _fetch
+
+
+# --- 1. sources.db hard guard ------------------------------------------------
+
+
+def test_network_workers_cannot_open_sources_db(tmp_path: Path) -> None:
+    sources = tmp_path / "sources.db"
+    sources.write_bytes(b"")  # presence is enough; open must refuse first
+    with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+        refuse_sources_db(sources)
+    with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+        assert_network_worker_cannot_open_sources(sources)
+    with pytest.raises(SourcesDbForbiddenError, match=r"cannot open sources\.db"):
+        with guard_network_worker():
+            open_sources_ro(sources)
+    # Guard is inactive outside network role — open may proceed (file is empty/invalid,
+    # but path refusal must not fire).
+    assert not is_network_worker()
+    # empty file still opens as sqlite (creates schema on connect for non-uri? mode=ro needs file)
+    # We only assert the guard path; offline open of a non-db may error — use a real sqlite.
+    import sqlite3
+
+    conn = sqlite3.connect(sources)
+    conn.execute("CREATE TABLE t(x)")
+    conn.commit()
+    conn.close()
+    ro = open_sources_ro(sources)
+    ro.close()
+
+
+# --- 2. atomic raw cache + fenced claims -------------------------------------
+
+
+def test_raw_cache_atomic_mid_write_crash_leaves_no_half_row(cache: NetworkCache) -> None:
+    key = compute_request_key(method="GET", url="https://example.test/a")
+    claim = cache.claim_request(key, "w1", now=1.0)
+    assert claim.ok and claim.lease_generation == 1
+    cache.crash_mid_cache_write = True
+    with pytest.raises(RuntimeError, match="injected crash: mid_cache_write"):
+        cache.commit_raw(
+            key,
+            "w1",
+            1,
+            method="GET",
+            url="https://example.test/a",
+            status_code=200,
+            body=b'{"ok":true}',
+            now=2.0,
+        )
+    cache.crash_mid_cache_write = False
+    assert cache.get_raw(key) is None
+    # Retry with same generation is stale (txn rolled back claim? — claim commit already done).
+    # Claim row stays leased; re-claim after expiry or commit with same gen after clearing crash.
+    ok = cache.commit_raw(
+        key,
+        "w1",
+        1,
+        method="GET",
+        url="https://example.test/a",
+        status_code=200,
+        body=b'{"ok":true}',
+        now=3.0,
+    )
+    assert ok.ok
+    entry = cache.get_raw(key)
+    assert entry is not None
+    assert entry.body == b'{"ok":true}'
+
+
+def test_request_claim_fenced_stale_writer_rejected(cache: NetworkCache) -> None:
+    key = compute_request_key(method="GET", url="https://example.test/b")
+    c1 = cache.claim_request(key, "owner-a", now=10.0)
+    assert c1.ok and c1.lease_generation == 1
+    # Second claim while leased fails.
+    c2 = cache.claim_request(key, "owner-b", now=11.0)
+    assert c2.status is CacheCasStatus.INVALID_STATE
+    # Stale commit rejected.
+    stale = cache.commit_raw(
+        key,
+        "owner-b",
+        1,
+        method="GET",
+        url="https://example.test/b",
+        status_code=200,
+        body=b"nope",
+        now=12.0,
+    )
+    assert stale.status is CacheCasStatus.STALE_COMMIT_REJECTED
+    assert cache.get_raw(key) is None
+
+
+def test_duplicate_network_cache_runner_lock_refused(tmp_path: Path) -> None:
+    path = tmp_path / "shared.cache.sqlite"
+    a = NetworkCache(path, owner_id="cache-a")
+    a.open()
+    b = NetworkCache(path, owner_id="cache-b")
+    with pytest.raises(DuplicateCacheRunnerError, match="duplicate runner refused"):
+        b.open()
+    a.close()
+    b.open()
+    b.close()
+
+
+def test_duplicate_ledger_runner_lock_refused(tmp_path: Path) -> None:
+    """PR3 crash suite also re-proves coordinator OS lock (shared with PR2)."""
+    path = tmp_path / "shared.ledger.sqlite"
+    a = Ledger(path, owner_id="coord-a")
+    a.open()
+    b = Ledger(path, owner_id="coord-b")
+    with pytest.raises(DuplicateRunnerError, match="duplicate runner refused"):
+        b.open()
+    a.close()
+
+
+# --- 3. 429 cooldown without expiring transport ------------------------------
+
+
+def test_429_cooldown_retry_scheduled_does_not_expire_transport(
+    ledger: Ledger, cache: NetworkCache, tmp_path: Path
+) -> None:
+    fp = compute_run_fingerprint(cohort_digest="cooldown-429")
+    run = ledger.start_run(fp).run_id
+    assert run
+    items = [
+        NetworkWorkItem(lemma_id="l1", method="GET", url="https://example.test/429"),
+    ]
+    exported = export_request_packet(
+        ledger,
+        run_id=run,
+        fingerprint=fp,
+        items=items,
+        output_dir=tmp_path / "packets",
+        now=1.0,
+    )
+    assert exported.ledger_status is CasStatus.OK
+    pkt_row = ledger.get_packet(run, exported.artifact.artifact_id, exported.generation)
+    assert pkt_row is not None
+    assert pkt_row["state"] == "packet_exported"
+
+    # Local ledger unit for network fetch phase.
+    ledger.register_work_unit(run, "l1", unit_kind="lemma", phase="network_fetch", now=2.0)
+    claim = ledger.claim_unit(run, "l1", "fetcher", phase="network_fetch", now=3.0)
+    assert claim.ok
+    gen = int(claim.lease_generation or 0)
+    res = ledger.handle_http_429(
+        run,
+        "l1",
+        "fetcher",
+        gen,
+        host="vps-1",
+        next_allowed_at=1000.0,
+        phase="network_fetch",
+        now=4.0,
+    )
+    assert res.ok
+    unit = ledger.get_work_unit(run, "l1", phase="network_fetch")
+    assert unit is not None
+    assert unit["state"] == UnitOutcome.RETRY_SCHEDULED.value
+    # Transport still live.
+    pkt_row2 = ledger.get_packet(run, exported.artifact.artifact_id, exported.generation)
+    assert pkt_row2 is not None
+    assert pkt_row2["state"] == "packet_exported"
+    assert ledger.packet_generation_active(run, exported.generation)
+
+    # Host cooldown gates new claims.
+    ledger.register_work_unit(run, "l2", unit_kind="lemma", phase="network_fetch", now=5.0)
+    blocked = ledger.claim_unit(
+        run, "l2", "fetcher2", phase="network_fetch", host="vps-1", now=10.0
+    )
+    assert not blocked.ok
+    assert "cooldown" in blocked.detail
+    # After cooldown, claim works.
+    ok = ledger.claim_unit(
+        run, "l2", "fetcher2", phase="network_fetch", host="vps-1", now=1001.0
+    )
+    assert ok.ok
+
+    # Network cache 429 path mirrors the same semantics.
+    counter = [0]
+    fetch = _fake_fetch_factory(
+        {"https://example.test/429": (429, {}, b"slow down")},
+        counter,
+    )
+    out = process_request(
+        cache,
+        items[0],
+        owner="nw",
+        fetch=fetch,
+        host="vps-1",
+        now=50.0,
+        cooldown_seconds=100.0,
+    )
+    assert out.status == "retry_scheduled"
+    assert out.error_code == "http_429"
+    assert cache.host_cooldown_active("vps-1", now=51.0) is not None
+    blocked_c = cache.claim_request(
+        compute_request_key(method="GET", url="https://example.test/other"),
+        "nw2",
+        host="vps-1",
+        now=52.0,
+    )
+    assert blocked_c.status is CacheCasStatus.HOST_COOLDOWN
+
+
+# --- 4–5. packets/bundles compressed, content-addressed, hashed -------------
+
+
+def test_packet_and_bundle_content_addressed_and_verified(tmp_path: Path) -> None:
+    items = [
+        PacketItem.from_request(
+            "alpha",
+            compute_request_key(method="GET", url="https://example.test/alpha"),
+            {"method": "GET", "url": "https://example.test/alpha"},
+        ),
+        PacketItem.from_request(
+            "beta",
+            compute_request_key(method="GET", url="https://example.test/beta"),
+            {"method": "GET", "url": "https://example.test/beta"},
+        ),
+    ]
+    pkt = build_packet(
+        run_id="run-x",
+        fingerprint="fp-x",
+        generation=1,
+        items=items,
+        output_dir=tmp_path / "out",
+    )
+    assert pkt.path.name == f"{pkt.artifact_id}.tar.zst"
+    assert pkt.path.suffixes[-2:] == [".tar", ".zst"] or pkt.path.name.endswith(".tar.zst")
+    verify_artifact_file(pkt.path, expected_id=pkt.artifact_id)
+    loaded = read_packet(pkt.path)
+    assert len(loaded.items) == 2
+    assert loaded.manifest["generation"] == 1
+
+    b_items = [
+        BundleItem.from_result(
+            "alpha",
+            items[0].request_key,
+            {"gloss": "a"},
+        ),
+        BundleItem.from_result(
+            "beta",
+            items[1].request_key,
+            {"gloss": "b"},
+        ),
+    ]
+    bundle = build_bundle(
+        run_id="run-x",
+        fingerprint="fp-x",
+        packet_id=pkt.artifact_id,
+        packet_generation=1,
+        items=b_items,
+        output_dir=tmp_path / "out",
+    )
+    loaded_b = read_bundle(bundle.path, expected_id=bundle.artifact_id)
+    assert {i["lemma_id"] for i in loaded_b.items} == {"alpha", "beta"}
+
+    # Corrupt per-item hash detection: rewrite file with wrong payload under same name.
+    # Easier: declare wrong hash at build time.
+    bad = BundleItem(
+        lemma_id="gamma",
+        request_key="rk",
+        result={"x": 1},
+        result_hash="0" * 64,
+    )
+    with pytest.raises(HashMismatchError):
+        build_bundle(
+            run_id="run-x",
+            fingerprint="fp-x",
+            packet_id=pkt.artifact_id,
+            packet_generation=1,
+            items=[bad],
+            output_dir=tmp_path / "bad",
+        )
+
+
+def test_bundle_bounded_split(tmp_path: Path) -> None:
+    items = [
+        BundleItem.from_result(f"l{i:03d}", f"rk{i}", {"i": i}) for i in range(10)
+    ]
+    groups = split_bundle_items(items, max_items=3)
+    assert len(groups) == 4
+    assert all(len(g) <= 3 for g in groups)
+    with pytest.raises(Exception, match="exceeds bound"):
+        build_bundle(
+            run_id="r",
+            fingerprint="f",
+            packet_id="p",
+            packet_generation=1,
+            items=items,
+            output_dir=tmp_path / "b",
+            max_items=3,
+        )
+
+
+def test_retransmission_idempotent(tmp_path: Path) -> None:
+    item = PacketItem.from_request(
+        "one",
+        compute_request_key(method="GET", url="https://example.test/one"),
+        {"method": "GET", "url": "https://example.test/one"},
+    )
+    pkt = build_packet(
+        run_id="r",
+        fingerprint="f",
+        generation=1,
+        items=[item],
+        output_dir=tmp_path / "src",
+    )
+    dest = retransmit_copy(pkt.path, tmp_path / "dest")
+    assert dest.name == pkt.path.name
+    assert dest.read_bytes() == pkt.path.read_bytes()
+    # Second retransmit is a no-op success.
+    dest2 = retransmit_copy(pkt.path, tmp_path / "dest")
+    assert dest2 == dest
+    # Writing the same packet again to src is idempotent.
+    pkt2 = build_packet(
+        run_id="r",
+        fingerprint="f",
+        generation=1,
+        items=[item],
+        output_dir=tmp_path / "src",
+    )
+    assert pkt2.artifact_id == pkt.artifact_id
+
+
+# --- 6. import atomic per lemma + stale generation --------------------------
+
+
+def test_import_atomic_per_lemma_and_rejects_stale_generation(
+    ledger: Ledger, tmp_path: Path
+) -> None:
+    fp = compute_run_fingerprint(cohort_digest="import-atomic")
+    run = ledger.start_run(fp).run_id
+    assert run
+    work = [
+        NetworkWorkItem(lemma_id="a", method="GET", url="https://example.test/a"),
+        NetworkWorkItem(lemma_id="b", method="GET", url="https://example.test/b"),
+        NetworkWorkItem(lemma_id="c", method="GET", url="https://example.test/c"),
+    ]
+    exported = export_request_packet(
+        ledger,
+        run_id=run,
+        fingerprint=fp,
+        items=work,
+        output_dir=tmp_path / "packets",
+        now=1.0,
+    )
+    gen = exported.generation
+    bundle_items = [
+        BundleItem.from_result(w.lemma_id, w.request_key, {"lemma": w.lemma_id}) for w in work
+    ]
+    bundle = build_bundle(
+        run_id=run,
+        fingerprint=fp,
+        packet_id=exported.artifact.artifact_id,
+        packet_generation=gen,
+        items=bundle_items,
+        output_dir=tmp_path / "bundles",
+    )
+
+    # Kill import after 2 commits.
+    with pytest.raises(RuntimeError, match="injected crash: import_killed_at_k"):
+        import_bundle(
+            ledger,
+            bundle.path,
+            owner="imp",
+            expected_fingerprint=fp,
+            now=10.0,
+            crash_after_items=2,
+        )
+    # Exactly 2 imports committed.
+    n = ledger._require().execute(
+        "SELECT COUNT(*) AS n FROM imports WHERE run_id = ?",
+        (run,),
+    ).fetchone()
+    assert int(n["n"]) == 2
+
+    # Resume import: remaining + no-op on already imported.
+    result = import_bundle(
+        ledger,
+        bundle.path,
+        owner="imp",
+        expected_fingerprint=fp,
+        now=20.0,
+    )
+    n2 = ledger._require().execute(
+        "SELECT COUNT(*) AS n FROM imports WHERE run_id = ?",
+        (run,),
+    ).fetchone()
+    assert int(n2["n"]) == 3
+    assert len(result.committed) + len(result.skipped_noop) >= 1
+
+    # Abandon generation → further new imports of a different lemma with same gen fail.
+    ledger.abandon_packet(
+        run, exported.artifact.artifact_id, gen, "operator abandoned stale transport"
+    )
+    assert ledger.count_operator_actions(run, OperatorActionKind.ABANDON_PACKET.value) == 1
+    extra = BundleItem.from_result("d", "rk-d", {"lemma": "d"})
+    stale_bundle = build_bundle(
+        run_id=run,
+        fingerprint=fp,
+        packet_id=exported.artifact.artifact_id,
+        packet_generation=gen,
+        items=[extra],
+        output_dir=tmp_path / "bundles2",
+    )
+    stale = import_bundle(
+        ledger,
+        stale_bundle.path,
+        owner="imp",
+        expected_fingerprint=fp,
+        now=30.0,
+    )
+    assert stale.status is CasStatus.INVALID_STATE
+    assert stale.detail == "stale_packet_generation"
+
+
+# --- 7. crash suite: cached-unparsed, no double-fetch -----------------------
+
+
+def test_cached_unparsed_recovery_without_refetch(cache: NetworkCache) -> None:
+    """Cached but unparsed → resume parses the cached body without fetching."""
+    url = "https://example.test/parse-me"
+    key = compute_request_key(method="GET", url=url)
+    counter = [0]
+    body = '{"lemma":"кіт","gloss":"cat"}'.encode()
+    fetch = _fake_fetch_factory({url: (200, {"content-type": "application/json"}, body)}, counter)
+
+    item = NetworkWorkItem(lemma_id="кіт", method="GET", url=url)
+    first = process_request(cache, item, owner="w", fetch=fetch, now=1.0)
+    assert first.fetched is True
+    assert counter[0] == 1
+    assert cache.fetch_count == 1
+    assert first.result is not None
+
+    # Drop parsed cache rows to simulate "cached but unparsed".
+    cache._require().execute("DELETE FROM parsed_cache")
+    second = process_request(cache, item, owner="w2", fetch=fetch, now=2.0)
+    assert second.fetched is False
+    assert counter[0] == 1  # no second network fetch
+    assert cache.fetch_count == 1
+    assert second.status == "cache_hit_parsed"
+    assert second.result is not None
+    assert second.result["payload"]["lemma"] == "кіт"
+
+
+def test_retries_do_not_double_fetch_cached_request(cache: NetworkCache) -> None:
+    """PROOF: retries after a successful cache commit never re-hit the network."""
+    url = "https://example.test/once"
+    counter = [0]
+    body = b'{"ok":1}'
+    fetch = _fake_fetch_factory({url: (200, {}, body)}, counter)
+    item = NetworkWorkItem(lemma_id="once", method="GET", url=url)
+
+    for i in range(5):
+        out = process_request(cache, item, owner=f"w{i}", fetch=fetch, now=float(i + 1))
+        assert out.result is not None
+
+    assert counter[0] == 1, f"expected single fetch, got {counter[0]}"
+    assert cache.fetch_count == 1
+    hits = cache.list_events(event="cache_hit")
+    assert len(hits) >= 4
+
+
+def test_end_to_end_packet_fetch_bundle_import(
+    ledger: Ledger, cache: NetworkCache, tmp_path: Path
+) -> None:
+    fp = compute_run_fingerprint(cohort_digest="e2e-net")
+    run = ledger.start_run(fp).run_id
+    assert run
+    work = [
+        NetworkWorkItem(lemma_id="x", method="GET", url="https://example.test/x"),
+        NetworkWorkItem(lemma_id="y", method="GET", url="https://example.test/y"),
+    ]
+    exported = export_request_packet(
+        ledger,
+        run_id=run,
+        fingerprint=fp,
+        items=work,
+        output_dir=tmp_path / "packets",
+    )
+    counter = [0]
+    fetch = _fake_fetch_factory(
+        {
+            "https://example.test/x": (200, {}, b'{"lemma":"x"}'),
+            "https://example.test/y": (200, {}, b'{"lemma":"y"}'),
+        },
+        counter,
+    )
+    bundle_path, outcomes = process_packet_to_bundle(
+        cache,
+        exported.artifact.path,
+        owner="net",
+        fetch=fetch,
+        output_dir=tmp_path / "bundles",
+        now=5.0,
+    )
+    assert bundle_path is not None
+    assert counter[0] == 2
+    assert all(o.result is not None for o in outcomes)
+
+    # Second pass over same packet: zero new fetches (cache hits).
+    bundle_path2, outcomes2 = process_packet_to_bundle(
+        cache,
+        exported.artifact.path,
+        owner="net2",
+        fetch=fetch,
+        output_dir=tmp_path / "bundles2",
+        now=6.0,
+    )
+    assert bundle_path2 is not None
+    assert counter[0] == 2
+    assert all(o.fetched is False for o in outcomes2)
+
+    imp = import_bundle(
+        ledger,
+        bundle_path,
+        owner="importer",
+        expected_fingerprint=fp,
+        now=7.0,
+    )
+    assert imp.status is CasStatus.OK
+    assert len(imp.committed) == 2
+    for lemma in ("x", "y"):
+        unit = ledger.get_work_unit(run, lemma, phase="network_import")
+        assert unit is not None
+        assert unit["state"] == UnitOutcome.DONE.value
+
+
+def test_claim_after_claim_crash_rolls_back(cache: NetworkCache) -> None:
+    key = compute_request_key(method="GET", url="https://example.test/crash-claim")
+    cache.crash_after_claim = True
+    with pytest.raises(RuntimeError, match="injected crash: after_claim"):
+        cache.claim_request(key, "w", now=1.0)
+    cache.crash_after_claim = False
+    row = cache._require().execute(
+        "SELECT state, lease_generation FROM request_claims WHERE request_key = ?",
+        (key,),
+    ).fetchone()
+    # Either no row or still pending gen 0 — never half-leased.
+    if row is not None:
+        assert str(row["state"]) == SchedulableState.PENDING.value
+        assert int(row["lease_generation"]) == 0
+    claim = cache.claim_request(key, "w", now=2.0)
+    assert claim.ok and claim.lease_generation == 1


### PR DESCRIPTION
## Summary

Implements **PR 3** of the chunked enrich-runner (LOCKED spec `ENRICH-RUNNER-SPEC-v2.md` §PR3 / Phases 4–6 / §§6–9): disconnected network cache and host-agnostic packet/bundle transport on top of merged PR1 (engine isolation) + PR2 (ledger/fencing/resume).

### What landed

| Area | Implementation |
| --- | --- |
| **Network cache** | `scripts/lexicon/runner/network_cache.py` — independent SQLite + exclusive OS lock; atomic raw rows (metadata + zlib body in one txn); request claims with monotonic `lease_generation` CAS (same fencing model as PR2, not a parallel scheme) |
| **sources.db hard guard** | `sources_guard.py` + `open_sources_ro` refusal under network-worker role |
| **Transport** | `transport.py` — content-addressed `{sha256}.tar.zst` packets/bundles; outer + per-item hash verify; `.partial` → fsync → atomic rename (rsync-resumable); bounded bundle split |
| **Packet export** | `packet_export.py` + ledger `record_packet_exported` (durable transport, no lease) |
| **Bundle import** | `bundle_import.py` — verify hashes first; atomic per-lemma `commit_import`; reject abandoned/stale packet generations |
| **429 cooldown** | ledger `handle_http_429` + cache `commit_retry_scheduled` → `retry_scheduled` + host `next_allowed_at`; **does not** abandon `packet_exported` rows |
| **Network worker** | `network_worker.py` — claim → cache-hit reparse **or** fetch+atomic commit → parse; never opens sources |

### Files

- **New:** `network_cache.py`, `network_worker.py`, `transport.py`, `packet_export.py`, `bundle_import.py`, `sources_guard.py`, `tests/test_lexicon_runner_pr3_transport.py`
- **Extended:** `ledger.py` (packet export/import generation guards, `handle_http_429`, `unit_request_keys`), `contracts.py` (network version pins), `sqlite_ro.py` (guard hook), `__init__.py`

### Not in this PR (by design)

- PR4 leaf seal streaming assembly / publication gate
- Shard format changes
- VPS provisioning / host-specific code (spec §10 qualification is a separate decision)
- Real network HTTP adapters (fetch is injected; host-agnostic)

Refs #5230

---

## Verification (raw tool output)

### tests pass (PR3 crash suite + acceptance)

```text
$ .venv/bin/python -m pytest tests/test_lexicon_runner_pr3_transport.py -v --tb=line
============================= test session starts ==============================
...
collected 14 items

tests/test_lexicon_runner_pr3_transport.py::test_network_workers_cannot_open_sources_db PASSED
tests/test_lexicon_runner_pr3_transport.py::test_raw_cache_atomic_mid_write_crash_leaves_no_half_row PASSED
tests/test_lexicon_runner_pr3_transport.py::test_request_claim_fenced_stale_writer_rejected PASSED
tests/test_lexicon_runner_pr3_transport.py::test_duplicate_network_cache_runner_lock_refused PASSED
tests/test_lexicon_runner_pr3_transport.py::test_duplicate_ledger_runner_lock_refused PASSED
tests/test_lexicon_runner_pr3_transport.py::test_429_cooldown_retry_scheduled_does_not_expire_transport PASSED
tests/test_lexicon_runner_pr3_transport.py::test_packet_and_bundle_content_addressed_and_verified PASSED
tests/test_lexicon_runner_pr3_transport.py::test_bundle_bounded_split PASSED
tests/test_lexicon_runner_pr3_transport.py::test_retransmission_idempotent PASSED
tests/test_lexicon_runner_pr3_transport.py::test_import_atomic_per_lemma_and_rejects_stale_generation PASSED
tests/test_lexicon_runner_pr3_transport.py::test_cached_unparsed_recovery_without_refetch PASSED
tests/test_lexicon_runner_pr3_transport.py::test_retries_do_not_double_fetch_cached_request PASSED
tests/test_lexicon_runner_pr3_transport.py::test_end_to_end_packet_fetch_bundle_import PASSED
tests/test_lexicon_runner_pr3_transport.py::test_claim_after_claim_crash_rolls_back PASSED

============================== 14 passed in 0.24s ==============================
```

PR2 regression (no breakage of ledger/CAS):

```text
$ .venv/bin/python -m pytest tests/test_lexicon_runner_pr2_ledger.py tests/test_lexicon_runner_pr3_transport.py -q
...
collected 32 items
tests/test_lexicon_runner_pr2_ledger.py .................. 
tests/test_lexicon_runner_pr3_transport.py ..............
======================== 32 passed ========================
```

PR1 regression: `11 passed, 1 skipped`.

### lint clean

```text
$ .venv/bin/ruff check scripts/lexicon/runner/network_cache.py \
    scripts/lexicon/runner/network_worker.py \
    scripts/lexicon/runner/transport.py \
    scripts/lexicon/runner/packet_export.py \
    scripts/lexicon/runner/bundle_import.py \
    scripts/lexicon/runner/sources_guard.py \
    scripts/lexicon/runner/ledger.py \
    scripts/lexicon/runner/contracts.py \
    scripts/lexicon/runner/sqlite_ro.py \
    scripts/lexicon/runner/__init__.py \
    tests/test_lexicon_runner_pr3_transport.py
All checks passed!
```

### no sources.db access from network workers

```text
$ .venv/bin/python -m pytest tests/test_lexicon_runner_pr3_transport.py::test_network_workers_cannot_open_sources_db -v
...
tests/test_lexicon_runner_pr3_transport.py::test_network_workers_cannot_open_sources_db PASSED
============================== 1 passed in 0.12s ===============================
```

Guard raises `SourcesDbForbiddenError: network workers cannot open sources.db` for `refuse_sources_db`, `assert_network_worker_cannot_open_sources`, and `open_sources_ro` under `guard_network_worker()`.

### no double-fetch

```text
$ .venv/bin/python -m pytest tests/test_lexicon_runner_pr3_transport.py::test_retries_do_not_double_fetch_cached_request -v
...
tests/test_lexicon_runner_pr3_transport.py::test_retries_do_not_double_fetch_cached_request PASSED
============================== 1 passed in 0.09s ===============================
```

Proof assertion in test: five `process_request` retries → `counter[0] == 1` and `cache.fetch_count == 1`. Companion `test_cached_unparsed_recovery_without_refetch` proves cache-hit reparse after dropping parsed rows without a second fetch.

### Crash matrix covered

| Spec boundary | Test |
| --- | --- |
| Cached but unparsed | `test_cached_unparsed_recovery_without_refetch` |
| Duplicate runner lock | `test_duplicate_network_cache_runner_lock_refused`, `test_duplicate_ledger_runner_lock_refused` |
| Import killed at item k | `test_import_atomic_per_lemma_and_rejects_stale_generation` (crash after 2; resume completes) |
| Retransmission idempotent | `test_retransmission_idempotent` |
| No double-fetch | `test_retries_do_not_double_fetch_cached_request` |
| Mid-write atomic raw cache | `test_raw_cache_atomic_mid_write_crash_leaves_no_half_row` |
| Claim mid-txn rollback | `test_claim_after_claim_crash_rolls_back` |

---

## Explicitly NOT verified

- **Real VPS / SSH / rsync over a network** — transport is design-in (content-addressed files + partial→rename); no live remote transfer test.
- **Live HTTP against external dictionaries** — fetch is injected via callable; no production adapter yet.
- **zstandard Python package** — compression uses `zstd` CLI when `zstandard` is absent (present on this host via Homebrew); CI hosts need `zstd` on PATH or the `zstandard` module.
- **PR4 seal/assembly/publication** — out of scope.
- **End-to-end 20k run** — unit/crash suites only.

## Acceptance criteria checklist (spec §PR3)

- [x] Network workers cannot open `sources.db` (hard guard + test)
- [x] Raw cache entries atomic; request claims fenced via PR2 CAS/generation
- [x] 429 → `retry_scheduled` + host cooldown; active transport not expired
- [x] Packets/bundles compressed, content-addressed, bounded, rsync-resumable
- [x] Bundle hashes and per-item hashes verified
- [x] Import atomic per lemma; rejects stale packet generations
- [x] Crash tests: cached-unparsed, duplicate lock, import@k, retransmission, no double-fetch

## Test plan

- [x] Targeted pytest PR3 + PR2 + PR1
- [x] ruff on changed files
- [ ] Independent cross-family review gate (orchestrator)
- [ ] CI green; auto-merge armed by orchestrator only (not by this agent)