### PR TITLE
fix(lexicon): seal verifies constituent lemmas + lemma retry resets parent chunk (#5370)

### DIFF
--- a/scripts/lexicon/runner/ledger.py
+++ b/scripts/lexicon/runner/ledger.py
@@ -367,9 +367,7 @@ class Ledger:
             fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError as exc:
             lock_fh.close()
-            raise DuplicateRunnerError(
-                f"duplicate runner refused: ledger lock held on {lock_path}"
-            ) from exc
+            raise DuplicateRunnerError(f"duplicate runner refused: ledger lock held on {lock_path}") from exc
         self._lock_fh = lock_fh
         self._locked = True
         lock_fh.seek(0)
@@ -426,8 +424,7 @@ class Ledger:
     def find_incomplete_by_fingerprint(self, fingerprint: str) -> str | None:
         conn = self._require()
         row = conn.execute(
-            "SELECT run_id FROM runs WHERE fingerprint = ? AND status = ? "
-            "ORDER BY created_at DESC LIMIT 1",
+            "SELECT run_id FROM runs WHERE fingerprint = ? AND status = ? ORDER BY created_at DESC LIMIT 1",
             (fingerprint, RunStatus.RUNNING.value),
         ).fetchone()
         return None if row is None else str(row["run_id"])
@@ -455,10 +452,7 @@ class Ledger:
                 return StartRunResult(
                     status=CasStatus.INVALID_STATE,
                     resumable_run_id=existing,
-                    detail=(
-                        f"incomplete run already exists for fingerprint; "
-                        f"resume run_id={existing}"
-                    ),
+                    detail=(f"incomplete run already exists for fingerprint; resume run_id={existing}"),
                 )
         run_id = f"run-{uuid.uuid4().hex}"
         conn.execute(
@@ -750,9 +744,7 @@ class Ledger:
             ).fetchone()
             if row is None:
                 conn.execute("ROLLBACK")
-                return ClaimResult(
-                    status=CasStatus.NOT_FOUND, unit_id=unit_id, detail="unit missing"
-                )
+                return ClaimResult(status=CasStatus.NOT_FOUND, unit_id=unit_id, detail="unit missing")
 
             state = str(row["state"])
             attempt_count = int(row["attempt_count"])
@@ -1170,9 +1162,7 @@ class Ledger:
                     lemma_ids=failed.lemma_ids,
                 )
                 conn.execute("COMMIT")
-                return CasResult(
-                    status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id
-                )
+                return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
 
             cur = conn.execute(
                 "UPDATE chunks SET state = ?, is_leaf = 0, owner = NULL, "
@@ -1315,8 +1305,7 @@ class Ledger:
             # held but before validation — must still reject the import.
             if self.crash_import_concurrent_abandon:
                 conn.execute(
-                    "UPDATE packets SET state = 'abandoned', abandoned_at = ? "
-                    "WHERE run_id = ? AND generation = ?",
+                    "UPDATE packets SET state = 'abandoned', abandoned_at = ? WHERE run_id = ? AND generation = ?",
                     (ts, run_id, int(packet_generation)),
                 )
 
@@ -1343,15 +1332,12 @@ class Ledger:
                 # Allow no-op re-import of an already-committed matching hash even if
                 # the generation was later abandoned (artifacts already accepted).
                 existing_early = conn.execute(
-                    "SELECT result_hash FROM imports "
-                    "WHERE run_id = ? AND lemma_id = ? AND packet_generation = ?",
+                    "SELECT result_hash FROM imports WHERE run_id = ? AND lemma_id = ? AND packet_generation = ?",
                     (run_id, lemma_id, int(packet_generation)),
                 ).fetchone()
                 if existing_early is not None and str(existing_early["result_hash"]) == result_hash:
                     conn.execute("ROLLBACK")
-                    return CasResult(
-                        status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id
-                    )
+                    return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
                 conn.execute("ROLLBACK")
                 self._event(
                     "stale_packet_generation_rejected",
@@ -1388,16 +1374,13 @@ class Ledger:
                         )
 
             existing = conn.execute(
-                "SELECT result_hash FROM imports "
-                "WHERE run_id = ? AND lemma_id = ? AND packet_generation = ?",
+                "SELECT result_hash FROM imports WHERE run_id = ? AND lemma_id = ? AND packet_generation = ?",
                 (run_id, lemma_id, int(packet_generation)),
             ).fetchone()
             if existing is not None:
                 if str(existing["result_hash"]) == result_hash:
                     conn.execute("ROLLBACK")
-                    return CasResult(
-                        status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id
-                    )
+                    return CasResult(status=CasStatus.OK, lease_generation=lease_generation, run_id=run_id)
                 conn.execute("ROLLBACK")
                 return CasResult(
                     status=CasStatus.INVALID_STATE,
@@ -1413,10 +1396,7 @@ class Ledger:
             if (
                 unit is not None
                 and str(unit["state"]) == SchedulableState.LEASED.value
-                and (
-                    str(unit["owner"]) != owner
-                    or int(unit["lease_generation"]) != int(lease_generation)
-                )
+                and (str(unit["owner"]) != owner or int(unit["lease_generation"]) != int(lease_generation))
             ):
                 conn.execute("ROLLBACK")
                 self._event(
@@ -1578,9 +1558,7 @@ class Ledger:
             return False
         return any(str(r["state"]) != "abandoned" for r in rows)
 
-    def get_packet(
-        self, run_id: str, packet_id: str, generation: int
-    ) -> dict[str, Any] | None:
+    def get_packet(self, run_id: str, packet_id: str, generation: int) -> dict[str, Any] | None:
         conn = self._require()
         row = conn.execute(
             "SELECT * FROM packets WHERE run_id = ? AND packet_id = ? AND generation = ?",
@@ -1717,12 +1695,9 @@ class Ledger:
             )
         # CAS: active lease owner+generation, OR a DONE leaf with matching generation
         # after the coordinator already released the owner (seal pass).
-        owner_ok = str(chunk["owner"]) == owner and int(chunk["lease_generation"]) == int(
+        owner_ok = str(chunk["owner"]) == owner and int(chunk["lease_generation"]) == int(lease_generation)
+        done_ok = str(chunk["state"]) == ChunkLedgerState.DONE.value and int(chunk["lease_generation"]) == int(
             lease_generation
-        )
-        done_ok = (
-            str(chunk["state"]) == ChunkLedgerState.DONE.value
-            and int(chunk["lease_generation"]) == int(lease_generation)
         )
         if not owner_ok and not done_ok:
             self._event(
@@ -1747,8 +1722,7 @@ class Ledger:
         try:
             # Re-check leaf under the write transaction.
             again = conn.execute(
-                "SELECT is_leaf, state, lease_generation, owner FROM chunks "
-                "WHERE run_id = ? AND chunk_id = ?",
+                "SELECT is_leaf, state, lease_generation, owner FROM chunks WHERE run_id = ? AND chunk_id = ?",
                 (run_id, chunk_id),
             ).fetchone()
             if again is None or int(again["is_leaf"]) != 1:
@@ -1760,6 +1734,54 @@ class Ledger:
                     status=CasStatus.STALE_COMMIT_REJECTED,
                     detail=ErrorCode.STALE_COMMIT_REJECTED.value,
                 )
+
+            # Every constituent lemma must be terminal-successful (done/no_data)
+            # before a leaf seal is allowed — otherwise publish ships missing
+            # entries (issue #5370). Use a json_each join against the stored
+            # lemma_ids_json (bound param count stays O(1); no IN-list of ids).
+            bad_rows = conn.execute(
+                "SELECT CAST(je.value AS TEXT) AS lemma_id, "
+                "COALESCE(wu.state, 'missing') AS state "
+                "FROM chunks c "
+                "JOIN json_each(c.lemma_ids_json) AS je "
+                "LEFT JOIN work_units wu "
+                "  ON wu.run_id = c.run_id "
+                " AND wu.unit_id = CAST(je.value AS TEXT) "
+                " AND wu.phase = ? "
+                " AND wu.unit_kind = 'lemma' "
+                "WHERE c.run_id = ? AND c.chunk_id = ? "
+                "  AND COALESCE(wu.state, '') NOT IN (?, ?) "
+                "ORDER BY lemma_id",
+                (
+                    phase,
+                    run_id,
+                    chunk_id,
+                    UnitOutcome.DONE.value,
+                    UnitOutcome.NO_DATA.value,
+                ),
+            ).fetchall()
+            if bad_rows:
+                conn.execute("ROLLBACK")
+                offenders = [f"{r['lemma_id']} ({r['state']})" for r in bad_rows]
+                preview = ", ".join(offenders[:20])
+                if len(offenders) > 20:
+                    preview += f", ... (+{len(offenders) - 20} more)"
+                detail = "constituent lemmas not terminal-successful: " + preview
+                self._event(
+                    "seal_blocked_constituent_lemmas",
+                    run_id,
+                    chunk_id=chunk_id,
+                    offending_count=len(offenders),
+                    offending_lemma_ids=[str(r["lemma_id"]) for r in bad_rows[:50]],
+                    detail=detail,
+                )
+                return CasResult(
+                    status=CasStatus.INVALID_STATE,
+                    detail=detail,
+                    lease_generation=lease_generation,
+                    run_id=run_id,
+                )
+
             conn.execute(
                 "INSERT INTO seals("
                 "run_id, chunk_id, seal_sha256, lemma_ids_json, "
@@ -1855,8 +1877,9 @@ class Ledger:
                 status=CasStatus.INVALID_STATE,
                 detail=f"retry-failed only applies to failed_terminal, got {row['state']}",
             )
+        unit_kind = str(row["unit_kind"])
         # work_units + chunks + run epoch + audit row must move atomically
-        # (review #5341 finding 1).
+        # (review #5341 finding 1; issue #5370 parent-chunk reset for lemmas).
         conn.execute("BEGIN IMMEDIATE")
         try:
             conn.execute(
@@ -1865,17 +1888,92 @@ class Ledger:
                 "WHERE run_id = ? AND unit_id = ? AND phase = ?",
                 (SchedulableState.PENDING.value, ts, run_id, unit_id, phase),
             )
+            parent_chunk_id: str | None = None
+            if unit_kind == "chunk":
+                # Chunk unit: reset the matching chunk row (existing behaviour).
+                conn.execute(
+                    "UPDATE chunks SET state = ?, error_code = NULL, result_hash = NULL, "
+                    "owner = NULL, leased_until = NULL, attempt_count = 0, updated_at = ? "
+                    "WHERE run_id = ? AND chunk_id = ?",
+                    (ChunkLedgerState.PENDING.value, ts, run_id, unit_id),
+                )
+                parent_chunk_id = unit_id
+            elif unit_kind == "lemma":
+                # Constituent lemma: resolve parent leaf via json_each (not
+                # WHERE chunk_id = lemma_id — that never matches) and CAS-reset
+                # the parent to PENDING so the lemma reschedules with its chunk.
+                parent = conn.execute(
+                    "SELECT c.chunk_id AS chunk_id, c.lease_generation AS lease_generation, "
+                    "c.state AS state "
+                    "FROM chunks c "
+                    "JOIN json_each(c.lemma_ids_json) AS je "
+                    "  ON CAST(je.value AS TEXT) = ? "
+                    "WHERE c.run_id = ? "
+                    "  AND c.is_leaf = 1 "
+                    "  AND c.state != ? "
+                    "ORDER BY c.split_epoch DESC, c.chunk_id "
+                    "LIMIT 1",
+                    (unit_id, run_id, ChunkLedgerState.SUPERSEDED.value),
+                ).fetchone()
+                if parent is not None:
+                    parent_chunk_id = str(parent["chunk_id"])
+                    parent_gen = int(parent["lease_generation"])
+                    if str(parent["state"]) == ChunkLedgerState.SEALED.value:
+                        conn.execute("ROLLBACK")
+                        return CasResult(
+                            status=CasStatus.INVALID_STATE,
+                            detail=(f"parent chunk {parent_chunk_id} is sealed; cannot reopen via lemma retry"),
+                            run_id=run_id,
+                        )
+                    # Generation-guarded CAS: concurrent lease bump refuses the reset.
+                    cur = conn.execute(
+                        "UPDATE chunks SET state = ?, error_code = NULL, result_hash = NULL, "
+                        "owner = NULL, leased_until = NULL, attempt_count = 0, updated_at = ? "
+                        "WHERE run_id = ? AND chunk_id = ? AND lease_generation = ?",
+                        (
+                            ChunkLedgerState.PENDING.value,
+                            ts,
+                            run_id,
+                            parent_chunk_id,
+                            parent_gen,
+                        ),
+                    )
+                    if cur.rowcount != 1:
+                        conn.execute("ROLLBACK")
+                        return CasResult(
+                            status=CasStatus.STALE_COMMIT_REJECTED,
+                            detail=(
+                                f"parent chunk CAS miss while resetting for lemma retry (chunk_id={parent_chunk_id})"
+                            ),
+                            lease_generation=parent_gen,
+                            run_id=run_id,
+                        )
+                    # Reschedule the chunk work unit (list_pending_chunk_ids
+                    # only sees chunk-kind units).
+                    conn.execute(
+                        "UPDATE work_units SET state = ?, error_code = NULL, "
+                        "result_hash = NULL, owner = NULL, leased_until = NULL, "
+                        "attempt_count = 0, updated_at = ? "
+                        "WHERE run_id = ? AND unit_id = ? AND phase = ? "
+                        "AND unit_kind = 'chunk'",
+                        (
+                            SchedulableState.PENDING.value,
+                            ts,
+                            run_id,
+                            parent_chunk_id,
+                            phase,
+                        ),
+                    )
             conn.execute(
-                "UPDATE chunks SET state = ?, error_code = NULL, result_hash = NULL, "
-                "owner = NULL, leased_until = NULL, attempt_count = 0, updated_at = ? "
-                "WHERE run_id = ? AND chunk_id = ?",
-                (ChunkLedgerState.PENDING.value, ts, run_id, unit_id),
-            )
-            conn.execute(
-                "UPDATE runs SET manual_retry_epoch = manual_retry_epoch + 1, updated_at = ? "
-                "WHERE run_id = ?",
+                "UPDATE runs SET manual_retry_epoch = manual_retry_epoch + 1, updated_at = ? WHERE run_id = ?",
                 (ts, run_id),
             )
+            payload: dict[str, Any] = {
+                "prior_lease_generation": int(row["lease_generation"]),
+                "unit_kind": unit_kind,
+            }
+            if parent_chunk_id is not None and unit_kind == "lemma":
+                payload["parent_chunk_id"] = parent_chunk_id
             conn.execute(
                 "INSERT INTO operator_actions("
                 "run_id, action, reason, unit_id, phase, created_at, payload_json"
@@ -1887,7 +1985,7 @@ class Ledger:
                     unit_id,
                     phase,
                     ts,
-                    canonical_json({"prior_lease_generation": int(row["lease_generation"])}),
+                    canonical_json(payload),
                 ),
             )
             self._event(
@@ -1896,6 +1994,8 @@ class Ledger:
                 unit_id=unit_id,
                 phase=phase,
                 reason=reason,
+                unit_kind=unit_kind,
+                parent_chunk_id=parent_chunk_id,
             )
             conn.execute("COMMIT")
         except Exception:

--- a/tests/test_lexicon_runner_pr2_ledger.py
+++ b/tests/test_lexicon_runner_pr2_ledger.py
@@ -120,14 +120,10 @@ def test_stale_writer_result_commit_rejected(ledger: Ledger) -> None:
     c2 = ledger.claim_unit(run, "chunk-0", "owner-B", now=2001.0)
     assert c2.ok and c2.lease_generation == 2
     # Stale A commits with gen=1 → rejected; B commits with gen=2 → ok.
-    stale = ledger.commit_result(
-        run, "chunk-0", "owner-A", 1, "done", result_hash="hash-a", now=2002.0
-    )
+    stale = ledger.commit_result(run, "chunk-0", "owner-A", 1, "done", result_hash="hash-a", now=2002.0)
     assert stale.status is CasStatus.STALE_COMMIT_REJECTED
     assert stale.detail == ErrorCode.STALE_COMMIT_REJECTED.value
-    good = ledger.commit_result(
-        run, "chunk-0", "owner-B", 2, "done", result_hash="hash-b", now=2003.0
-    )
+    good = ledger.commit_result(run, "chunk-0", "owner-B", 2, "done", result_hash="hash-b", now=2003.0)
     assert good.ok
     unit = ledger.get_work_unit(run, "chunk-0")
     assert unit is not None
@@ -249,9 +245,7 @@ def test_result_crash_mid_transaction_rolls_back_both_tables(ledger: Ledger) -> 
     gen = int(claim.lease_generation or 0)
     ledger.crash_after_result = True
     with pytest.raises(RuntimeError, match="injected crash: after_result"):
-        ledger.commit_result(
-            run, "chunk-r", "owner", gen, "done", result_hash="h1", now=2.0
-        )
+        ledger.commit_result(run, "chunk-r", "owner", gen, "done", result_hash="h1", now=2.0)
     ledger.crash_after_result = False
     unit = ledger.get_work_unit(run, "chunk-r")
     chunk = ledger.get_chunk(run, "chunk-r")
@@ -260,9 +254,7 @@ def test_result_crash_mid_transaction_rolls_back_both_tables(ledger: Ledger) -> 
     assert chunk["state"] == ChunkLedgerState.LEASED.value
     assert unit["result_hash"] is None
     # Retry commit succeeds.
-    assert ledger.commit_result(
-        run, "chunk-r", "owner", gen, "done", result_hash="h1", now=3.0
-    ).ok
+    assert ledger.commit_result(run, "chunk-r", "owner", gen, "done", result_hash="h1", now=3.0).ok
     unit2 = ledger.get_work_unit(run, "chunk-r")
     assert unit2 is not None
     assert unit2["state"] == UnitOutcome.DONE.value
@@ -346,6 +338,29 @@ def test_single_lemma_oom_failed_terminal_no_split(ledger: Ledger) -> None:
     assert wu["error_code"] == ErrorCode.FAILED_OOM.value
 
 
+def _mark_lemma_terminal(
+    ledger: Ledger,
+    run_id: str,
+    lemma_id: str,
+    *,
+    owner: str = "coord",
+    now: float = 1.0,
+    outcome: str = "done",
+) -> None:
+    """Claim+commit a lemma work unit to a terminal-successful state."""
+    claim = ledger.claim_unit(run_id, lemma_id, owner, now=now)
+    assert claim.ok, claim.detail
+    assert ledger.commit_result(
+        run_id,
+        lemma_id,
+        owner,
+        int(claim.lease_generation or 0),
+        outcome,
+        result_hash=f"h-{lemma_id}",
+        now=now + 0.1,
+    ).ok
+
+
 def test_seal_interruption_and_leaf_only_rules(ledger: Ledger) -> None:
     """Seal crash leaves no seal row; superseded parents never seal."""
     fp = compute_run_fingerprint(cohort_digest="seal")
@@ -357,18 +372,16 @@ def test_seal_interruption_and_leaf_only_rules(ledger: Ledger) -> None:
     assert ledger.commit_split(run, "parent", "coord", gen, now=11.0).ok
     left_id = child_chunk_id("parent", 1, ["a"])
     # Parent is superseded — not sealable.
-    parent_seal = ledger.commit_seal(
-        run, "parent", "coord", gen, seal_sha256="dead", now=12.0
-    )
+    parent_seal = ledger.commit_seal(run, "parent", "coord", gen, seal_sha256="dead", now=12.0)
     assert parent_seal.status is CasStatus.NOT_LEAF
 
     # Claim leaf, mark done, then crash mid-seal.
     c_left = ledger.claim_unit(run, left_id, "coord", now=13.0)
     assert c_left.ok
     lgen = int(c_left.lease_generation or 0)
-    assert ledger.commit_result(
-        run, left_id, "coord", lgen, "done", result_hash="r1", now=14.0
-    ).ok
+    assert ledger.commit_result(run, left_id, "coord", lgen, "done", result_hash="r1", now=14.0).ok
+    # Constituent lemmas must be terminal-successful before seal (#5370).
+    _mark_lemma_terminal(ledger, run, "a", now=14.5)
     # After result, owner released; seal uses matching generation on DONE leaf.
     leaf = ledger.get_chunk(run, left_id)
     assert leaf is not None
@@ -379,23 +392,259 @@ def test_seal_interruption_and_leaf_only_rules(ledger: Ledger) -> None:
         ledger.commit_seal(run, left_id, "coord", lgen, seal_sha256="seal-1", now=15.0)
     ledger.crash_mid_seal = False
     # No seal row after crash.
-    seals = ledger._require().execute(
-        "SELECT COUNT(*) AS n FROM seals WHERE run_id = ? AND chunk_id = ?",
-        (run, left_id),
-    ).fetchone()
+    seals = (
+        ledger._require()
+        .execute(
+            "SELECT COUNT(*) AS n FROM seals WHERE run_id = ? AND chunk_id = ?",
+            (run, left_id),
+        )
+        .fetchone()
+    )
     assert int(seals["n"]) == 0
     # Retry seal succeeds.
     sealed = ledger.commit_seal(run, left_id, "coord", lgen, seal_sha256="seal-1", now=16.0)
     assert sealed.ok
-    seals2 = ledger._require().execute(
-        "SELECT seal_sha256 FROM seals WHERE run_id = ? AND chunk_id = ?",
-        (run, left_id),
-    ).fetchone()
+    seals2 = (
+        ledger._require()
+        .execute(
+            "SELECT seal_sha256 FROM seals WHERE run_id = ? AND chunk_id = ?",
+            (run, left_id),
+        )
+        .fetchone()
+    )
     assert seals2 is not None
     assert seals2["seal_sha256"] == "seal-1"
     # Stale generation seal rejected.
     stale = ledger.commit_seal(run, left_id, "coord", lgen - 1, seal_sha256="seal-x", now=17.0)
     assert stale.status in {CasStatus.STALE_COMMIT_REJECTED, CasStatus.INVALID_STATE}
+
+
+def test_seal_blocked_by_failed_constituent(ledger: Ledger) -> None:
+    """Seal refuses when any constituent lemma is failed_terminal (#5370)."""
+    fp = compute_run_fingerprint(cohort_digest="seal-fail-const")
+    run = ledger.start_run(fp).run_id
+    assert run
+    lemmas = ["good-a", "bad-b", "good-c"]
+    ledger.register_chunk_work_units(run, [("chunk-x", lemmas)])
+    claim = ledger.claim_unit(run, "chunk-x", "coord", now=1.0)
+    gen = int(claim.lease_generation or 0)
+    assert ledger.commit_result(run, "chunk-x", "coord", gen, "done", result_hash="chunk-h", now=2.0).ok
+    _mark_lemma_terminal(ledger, run, "good-a", now=3.0)
+    _mark_lemma_terminal(ledger, run, "good-c", now=4.0, outcome="no_data")
+    # Force failed_terminal on the remaining constituent without claim dance.
+    ledger._require().execute(
+        "UPDATE work_units SET state = ?, error_code = ?, updated_at = ? "
+        "WHERE run_id = ? AND unit_id = ? AND phase = ?",
+        (
+            UnitOutcome.FAILED_TERMINAL.value,
+            "inject_fail",
+            5.0,
+            run,
+            "bad-b",
+            "offline_enrich",
+        ),
+    )
+
+    blocked = ledger.commit_seal(run, "chunk-x", "coord", gen, seal_sha256="seal-blocked", now=6.0)
+    assert blocked.status is CasStatus.INVALID_STATE
+    assert "bad-b" in blocked.detail
+    assert "failed_terminal" in blocked.detail
+    assert "constituent lemmas not terminal-successful" in blocked.detail
+    seals = (
+        ledger._require()
+        .execute(
+            "SELECT COUNT(*) AS n FROM seals WHERE run_id = ? AND chunk_id = ?",
+            (run, "chunk-x"),
+        )
+        .fetchone()
+    )
+    assert int(seals["n"]) == 0
+    chunk = ledger.get_chunk(run, "chunk-x")
+    assert chunk is not None
+    assert chunk["state"] == ChunkLedgerState.DONE.value
+    events = ledger.list_events(run, event="seal_blocked_constituent_lemmas")
+    assert len(events) == 1
+
+
+def test_seal_blocked_by_pending_constituent(ledger: Ledger) -> None:
+    """Seal refuses when any constituent lemma is still pending (#5370)."""
+    fp = compute_run_fingerprint(cohort_digest="seal-pend-const")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_chunk_work_units(run, [("chunk-y", ["done-1", "still-pending"])])
+    claim = ledger.claim_unit(run, "chunk-y", "coord", now=1.0)
+    gen = int(claim.lease_generation or 0)
+    assert ledger.commit_result(run, "chunk-y", "coord", gen, "done", result_hash="cy", now=2.0).ok
+    _mark_lemma_terminal(ledger, run, "done-1", now=3.0)
+    # still-pending remains pending — seal must block.
+    blocked = ledger.commit_seal(run, "chunk-y", "coord", gen, seal_sha256="nope", now=4.0)
+    assert blocked.status is CasStatus.INVALID_STATE
+    assert "still-pending" in blocked.detail
+    assert "pending" in blocked.detail
+    seals = (
+        ledger._require()
+        .execute(
+            "SELECT COUNT(*) AS n FROM seals WHERE run_id = ? AND chunk_id = ?",
+            (run, "chunk-y"),
+        )
+        .fetchone()
+    )
+    assert int(seals["n"]) == 0
+
+    # Completing the last lemma unblocks seal; mid-seal crash still rolls back.
+    _mark_lemma_terminal(ledger, run, "still-pending", now=5.0)
+    ledger.crash_mid_seal = True
+    with pytest.raises(RuntimeError, match="injected crash: mid_seal"):
+        ledger.commit_seal(run, "chunk-y", "coord", gen, seal_sha256="seal-y", now=6.0)
+    ledger.crash_mid_seal = False
+    seals_mid = (
+        ledger._require()
+        .execute(
+            "SELECT COUNT(*) AS n FROM seals WHERE run_id = ? AND chunk_id = ?",
+            (run, "chunk-y"),
+        )
+        .fetchone()
+    )
+    assert int(seals_mid["n"]) == 0
+    sealed = ledger.commit_seal(run, "chunk-y", "coord", gen, seal_sha256="seal-y", now=7.0)
+    assert sealed.ok
+
+
+def test_lemma_retry_reschedules_parent_chunk(ledger: Ledger) -> None:
+    """retry_failed on a lemma CAS-resets the parent chunk to PENDING (#5370)."""
+    ledger.max_attempts = 1
+    fp = compute_run_fingerprint(cohort_digest="lemma-retry-parent")
+    run = ledger.start_run(fp).run_id
+    assert run
+    lemmas = ["L1", "L2", "L3"]
+    ledger.register_chunk_work_units(run, [("parent-chunk", lemmas)])
+
+    # Exhaust the lemma so it is failed_terminal.
+    c_lemma = ledger.claim_unit(run, "L2", "w1", now=10.0)
+    assert c_lemma.ok
+    assert ledger.commit_result(
+        run,
+        "L2",
+        "w1",
+        int(c_lemma.lease_generation or 0),
+        "retry_scheduled",
+        error_code="transient",
+        now=11.0,
+    ).ok
+    exhausted = ledger.claim_unit(run, "L2", "w2", now=12.0)
+    assert exhausted.status is CasStatus.ATTEMPT_CAP_EXHAUSTED
+    unit = ledger.get_work_unit(run, "L2")
+    assert unit is not None
+    assert unit["state"] == UnitOutcome.FAILED_TERMINAL.value
+
+    # Parent chunk completed while a constituent was still failing — the
+    # pre-#5370 orphanage path left the chunk DONE forever.
+    c_chunk = ledger.claim_unit(run, "parent-chunk", "coord", now=13.0)
+    assert c_chunk.ok
+    chunk_gen = int(c_chunk.lease_generation or 0)
+    assert ledger.commit_result(
+        run,
+        "parent-chunk",
+        "coord",
+        chunk_gen,
+        "done",
+        result_hash="partial",
+        now=14.0,
+    ).ok
+    parent_before = ledger.get_chunk(run, "parent-chunk")
+    assert parent_before is not None
+    assert parent_before["state"] == ChunkLedgerState.DONE.value
+    assert int(parent_before["lease_generation"]) == chunk_gen
+
+    ok = ledger.retry_failed(run, "L2", "operator reopening failed constituent lemma", now=15.0)
+    assert ok.ok
+
+    lemma_after = ledger.get_work_unit(run, "L2")
+    assert lemma_after is not None
+    assert lemma_after["state"] == SchedulableState.PENDING.value
+    assert int(lemma_after["attempt_count"]) == 0
+
+    parent_after = ledger.get_chunk(run, "parent-chunk")
+    assert parent_after is not None
+    assert parent_after["state"] == ChunkLedgerState.PENDING.value
+    assert parent_after["owner"] is None
+    assert parent_after["leased_until"] is None
+    # Generation preserved (CAS guard), owner cleared for reschedule.
+    assert int(parent_after["lease_generation"]) == chunk_gen
+
+    chunk_unit = ledger.get_work_unit(run, "parent-chunk")
+    assert chunk_unit is not None
+    assert chunk_unit["state"] == SchedulableState.PENDING.value
+    assert "parent-chunk" in ledger.list_pending_chunk_ids(run)
+
+    actions = (
+        ledger._require()
+        .execute(
+            "SELECT payload_json FROM operator_actions WHERE run_id = ? AND action = ? ORDER BY action_id DESC LIMIT 1",
+            (run, OperatorActionKind.RETRY_FAILED.value),
+        )
+        .fetchone()
+    )
+    assert actions is not None
+    payload = json.loads(str(actions["payload_json"]))
+    assert payload["unit_kind"] == "lemma"
+    assert payload["parent_chunk_id"] == "parent-chunk"
+
+
+def test_seal_large_chunk_no_sqlite_variable_limit(ledger: Ledger) -> None:
+    """1500-lemma chunk seals via json_each join (no IN-list var blowup) (#5370)."""
+    n = 1500
+    lemmas = [f"lem-{i:04d}" for i in range(n)]
+    fp = compute_run_fingerprint(cohort_digest="seal-1500")
+    run = ledger.start_run(fp).run_id
+    assert run
+    ledger.register_chunk_work_units(run, [("big-chunk", lemmas)])
+    claim = ledger.claim_unit(run, "big-chunk", "coord", now=1.0)
+    gen = int(claim.lease_generation or 0)
+    assert ledger.commit_result(run, "big-chunk", "coord", gen, "done", result_hash="big", now=2.0).ok
+    # Bulk-mark constituents terminal-successful (setup only; seal uses join).
+    conn = ledger._require()
+    conn.execute(
+        "UPDATE work_units SET state = ?, result_hash = 'bulk', updated_at = 3.0 "
+        "WHERE run_id = ? AND unit_kind = 'lemma' AND phase = ?",
+        (UnitOutcome.DONE.value, run, "offline_enrich"),
+    )
+    # Leave one pending to prove the aggregate still finds offenders at scale,
+    # then fix and seal cleanly.
+    conn.execute(
+        "UPDATE work_units SET state = ? WHERE run_id = ? AND unit_id = ?",
+        (SchedulableState.PENDING.value, run, lemmas[1234]),
+    )
+    blocked = ledger.commit_seal(run, "big-chunk", "coord", gen, seal_sha256="big-seal", now=4.0)
+    assert blocked.status is CasStatus.INVALID_STATE
+    assert lemmas[1234] in blocked.detail
+
+    conn.execute(
+        "UPDATE work_units SET state = ? WHERE run_id = ? AND unit_id = ?",
+        (UnitOutcome.DONE.value, run, lemmas[1234]),
+    )
+    sealed = ledger.commit_seal(run, "big-chunk", "coord", gen, seal_sha256="big-seal", now=5.0)
+    assert sealed.ok, sealed.detail
+    seal_row = conn.execute(
+        "SELECT seal_sha256 FROM seals WHERE run_id = ? AND chunk_id = ?",
+        (run, "big-chunk"),
+    ).fetchone()
+    assert seal_row is not None
+    assert seal_row["seal_sha256"] == "big-seal"
+    # Bound-parameter count stays O(1): re-run the same aggregate shape that
+    # seal uses and confirm SQLite accepts it (would raise if rewritten as IN).
+    rows = conn.execute(
+        "SELECT COUNT(*) AS n FROM chunks c "
+        "JOIN json_each(c.lemma_ids_json) AS je "
+        "LEFT JOIN work_units wu "
+        "  ON wu.run_id = c.run_id "
+        " AND wu.unit_id = CAST(je.value AS TEXT) "
+        " AND wu.phase = 'offline_enrich' "
+        " AND wu.unit_kind = 'lemma' "
+        "WHERE c.run_id = ? AND c.chunk_id = ?",
+        (run, "big-chunk"),
+    ).fetchone()
+    assert int(rows["n"]) == n
 
 
 def test_import_cas_and_stale_generation(ledger: Ledger) -> None:
@@ -485,10 +734,14 @@ def test_import_reclaimed_lease_rejected(ledger: Ledger) -> None:
     )
     assert stale.status is CasStatus.STALE_COMMIT_REJECTED
     # Import row must not exist after rejected stale commit.
-    imports = ledger._require().execute(
-        "SELECT COUNT(*) AS n FROM imports WHERE run_id = ? AND lemma_id = ?",
-        (run, "lemma-r"),
-    ).fetchone()
+    imports = (
+        ledger._require()
+        .execute(
+            "SELECT COUNT(*) AS n FROM imports WHERE run_id = ? AND lemma_id = ?",
+            (run, "lemma-r"),
+        )
+        .fetchone()
+    )
     assert int(imports["n"]) == 0
     unit2 = ledger.get_work_unit(run, "lemma-r", phase="network_import")
     assert unit2 is not None
@@ -524,9 +777,7 @@ def test_abandon_packet_operator_record(ledger: Ledger) -> None:
     assert ledger.count_operator_actions(run, OperatorActionKind.ABANDON_PACKET.value) == 1
 
 
-def test_500_lemma_slice_resume_from_interrupted_run(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_500_lemma_slice_resume_from_interrupted_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Resume continues the frozen 500-lemma offline slice after interruption."""
     _ensure_fixture()
     from scripts.lexicon import enrich_manifest as em
@@ -652,9 +903,7 @@ def test_500_lemma_slice_resume_from_interrupted_run(
 def test_issue_streams_registers_5331_under_atlas_practice() -> None:
     import yaml
 
-    doc = yaml.safe_load(
-        Path("scripts/config/issue_streams.yaml").read_text(encoding="utf-8")
-    )
+    doc = yaml.safe_load(Path("scripts/config/issue_streams.yaml").read_text(encoding="utf-8"))
     epics = doc["streams"]["atlas-practice"]["epics"]
     assert 5331 in epics
     assert 4387 in epics


### PR DESCRIPTION
## Summary

Fixes two publish-corruption-class ledger bugs from design review of PR #5341 (now on main), tracked as **#5370**:

1. **`commit_seal` constituent verification** — seal previously only checked the chunk row. Inside the `BEGIN IMMEDIATE` seal transaction it now aggregate-joins `json_each(chunks.lemma_ids_json)` to `work_units` and requires every constituent lemma to be `done`/`no_data`. Any `failed_terminal`/`pending`/`leased`/missing unit blocks the seal with an operator-visible detail listing offending lemma ids. Bind-parameter count is O(1) (no `IN (...)` list) so it holds at 20k lemmas.

2. **`retry_failed` parent-chunk reset for lemmas** — retrying a failed **lemma** previously only updated `work_units` and `UPDATE chunks WHERE chunk_id = <lemma-id>` (no match), orphaning the lemma under a DONE parent. Lemma retries now resolve the parent leaf via `json_each` and generation-guard CAS-reset the parent chunk (and its chunk work unit) to `PENDING` with owner cleared so the unit reschedules. Chunk-unit retries keep existing behaviour.

## Changes

- `scripts/lexicon/runner/ledger.py` — seal guard + lemma retry parent CAS
- `tests/test_lexicon_runner_pr2_ledger.py` — four regressions + seal fixture marks lemmas terminal-successful

## Test plan

- [x] `test_seal_blocked_by_failed_constituent`
- [x] `test_seal_blocked_by_pending_constituent` (incl. mid-seal crash after unblock)
- [x] `test_lemma_retry_reschedules_parent_chunk`
- [x] `test_seal_large_chunk_no_sqlite_variable_limit` (1500 lemmas)
- [x] Existing PR2 + PR3 suites still green (no weakened assertions)

## Verification (raw tool output)

### pytest

```
$ .venv/bin/python -m pytest tests/test_lexicon_runner_pr2_ledger.py tests/test_lexicon_runner_pr3_transport.py -v --tb=line
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/grok-build/atlas-5370-ledger-fixes/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/grok-build/atlas-5370-ledger-fixes
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.1.0, xdist-3.8.0, anyio-4.14.2
collecting ... collected 42 items

tests/test_lexicon_runner_pr2_ledger.py::test_duplicate_runner_os_lock_refused PASSED [  2%]
tests/test_lexicon_runner_pr2_ledger.py::test_fingerprint_start_refuses_duplicate_incomplete PASSED [  4%]
tests/test_lexicon_runner_pr2_ledger.py::test_resume_fingerprint_mismatch_refused PASSED [  7%]
tests/test_lexicon_runner_pr2_ledger.py::test_claim_monotonic_generation_and_heartbeat_cas PASSED [  9%]
tests/test_lexicon_runner_pr2_ledger.py::test_stale_writer_result_commit_rejected PASSED [ 11%]
tests/test_lexicon_runner_pr2_ledger.py::test_claim_loss_reclaim_increments_generation PASSED [ 14%]
tests/test_lexicon_runner_pr2_ledger.py::test_attempt_cap_exhaustion_and_operator_retry PASSED [ 16%]
tests/test_lexicon_runner_pr2_ledger.py::test_attempt_cap_syncs_chunk_row PASSED [ 19%]
tests/test_lexicon_runner_pr2_ledger.py::test_claim_crash_mid_transaction_rolls_back_both_tables PASSED [ 21%]
tests/test_lexicon_runner_pr2_ledger.py::test_result_crash_mid_transaction_rolls_back_both_tables PASSED [ 23%]
tests/test_lexicon_runner_pr2_ledger.py::test_split_interruption_and_deterministic_children PASSED [ 26%]
tests/test_lexicon_runner_pr2_ledger.py::test_single_lemma_oom_failed_terminal_no_split PASSED [ 28%]
tests/test_lexicon_runner_pr2_ledger.py::test_seal_interruption_and_leaf_only_rules PASSED [ 30%]
tests/test_lexicon_runner_pr2_ledger.py::test_seal_blocked_by_failed_constituent PASSED [ 33%]
tests/test_lexicon_runner_pr2_ledger.py::test_seal_blocked_by_pending_constituent PASSED [ 35%]
tests/test_lexicon_runner_pr2_ledger.py::test_lemma_retry_reschedules_parent_chunk PASSED [ 38%]
tests/test_lexicon_runner_pr2_ledger.py::test_seal_large_chunk_no_sqlite_variable_limit PASSED [ 40%]
tests/test_lexicon_runner_pr2_ledger.py::test_import_cas_and_stale_generation PASSED [ 42%]
tests/test_lexicon_runner_pr2_ledger.py::test_import_reclaimed_lease_rejected PASSED [ 45%]
tests/test_lexicon_runner_pr2_ledger.py::test_abandon_packet_operator_record PASSED [ 47%]
tests/test_lexicon_runner_pr2_ledger.py::test_500_lemma_slice_resume_from_interrupted_run PASSED [ 50%]
tests/test_lexicon_runner_pr2_ledger.py::test_issue_streams_registers_5331_under_atlas_practice PASSED [ 52%]
tests/test_lexicon_runner_pr3_transport.py::test_network_workers_cannot_open_sources_db PASSED [ 54%]
tests/test_lexicon_runner_pr3_transport.py::test_sources_guard_rejects_uri_query_forms PASSED [ 57%]
tests/test_lexicon_runner_pr3_transport.py::test_sources_guard_rejects_symlink_to_sources PASSED [ 59%]
tests/test_lexicon_runner_pr3_transport.py::test_open_immutable_ro_refuses_sources_db PASSED [ 61%]
tests/test_lexicon_runner_pr3_transport.py::test_commit_import_txn_fence_rejects_concurrent_abandon PASSED [ 64%]
tests/test_lexicon_runner_pr3_transport.py::test_network_cache_authorizer_denies_attach_sources PASSED [ 66%]
tests/test_lexicon_runner_pr3_transport.py::test_sources_guard_rejects_hardlink_via_inode PASSED [ 69%]
tests/test_lexicon_runner_pr3_transport.py::test_raw_cache_atomic_mid_write_crash_leaves_no_half_row PASSED [ 71%]
tests/test_lexicon_runner_pr3_transport.py::test_request_claim_fenced_stale_writer_rejected PASSED [ 73%]
tests/test_lexicon_runner_pr3_transport.py::test_duplicate_network_cache_runner_lock_refused PASSED [ 76%]
tests/test_lexicon_runner_pr3_transport.py::test_duplicate_ledger_runner_lock_refused PASSED [ 78%]
tests/test_lexicon_runner_pr3_transport.py::test_429_cooldown_retry_scheduled_does_not_expire_transport PASSED [ 80%]
tests/test_lexicon_runner_pr3_transport.py::test_packet_and_bundle_content_addressed_and_verified PASSED [ 83%]
tests/test_lexicon_runner_pr3_transport.py::test_bundle_bounded_split PASSED [ 85%]
tests/test_lexicon_runner_pr3_transport.py::test_retransmission_idempotent PASSED [ 88%]
tests/test_lexicon_runner_pr3_transport.py::test_import_atomic_per_lemma_and_rejects_stale_generation PASSED [ 90%]
tests/test_lexicon_runner_pr3_transport.py::test_cached_unparsed_recovery_without_refetch PASSED [ 92%]
tests/test_lexicon_runner_pr3_transport.py::test_retries_do_not_double_fetch_cached_request PASSED [ 95%]
tests/test_lexicon_runner_pr3_transport.py::test_end_to_end_packet_fetch_bundle_import PASSED [ 97%]
tests/test_lexicon_runner_pr3_transport.py::test_claim_after_claim_crash_rolls_back PASSED [100%]

============================== 42 passed in 0.92s ==============================
```

### ruff

```
$ .venv/bin/ruff check scripts/lexicon/runner/ledger.py tests/test_lexicon_runner_pr2_ledger.py
All checks passed!

$ .venv/bin/ruff format --check scripts/lexicon/runner/ledger.py tests/test_lexicon_runner_pr2_ledger.py
2 files already formatted
```

Refs #5370