### PR TITLE
feat(ui): dual-language chrome via data-chrome-locale + scout blockers/minors (K3 spec)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: b88d64e2ebef4decc59de438d4152124821426019ab9750e331f68caf78ceb93
+  components_sha256: 6de3f1336ed9e701a8dea2cf29b30b76d8aa625cc617860935af593f53fe0532
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1176,7 +1176,24 @@ function LexiconPracticeIsland({
   // Deduping cache for shard JSON fetches (by full URL) so index shards fetched by the eager
   // due-count effect are not re-fetched by ensure, and no shard is fetched twice.
   const shardJsonCacheRef = useRef(new Map<string, Promise<unknown>>());
-  const showEnglishSubtitles = learnerLevel === 'A1';
+  const [chromeLocale, setChromeLocale] = useState<'en' | 'uk'>(() =>
+    typeof document !== 'undefined'
+      ? ((document.documentElement.dataset.chromeLocale as 'en' | 'uk') || 'en')
+      : 'en',
+  );
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const el = document.documentElement;
+    setChromeLocale((el.dataset.chromeLocale as 'en' | 'uk') || 'en');
+    const obs = new MutationObserver(() =>
+      setChromeLocale((el.dataset.chromeLocale as 'en' | 'uk') || 'en'),
+    );
+    obs.observe(el, { attributes: true, attributeFilter: ['data-chrome-locale'] });
+    return () => obs.disconnect();
+  }, []);
+  // A1 scaffolding stays bilingual regardless of chrome locale; EN chrome also
+  // dual-labels practice chrome (K3 A1 / Sol-approved data-chrome-locale).
+  const showEnglishSubtitles = learnerLevel === 'A1' || chromeLocale === 'en';
 
   const matchedSelectedRatingRef = useRef<PracticeRating | null>(null);
   const matchingTargetOutcomeRef = useRef<CompletionOutcome | null>(null);
@@ -2820,7 +2837,7 @@ function LexiconPracticeIsland({
                   <span lang="uk">Усі картки на зараз повторено.</span>
                   {showEnglishSubtitles ? (
                     <span className="btn-sub" lang="en" style={{ display: 'block', fontSize: '0.85em', marginTop: '4px' }}>
-                      / All cards have been reviewed for now.
+                      / All cards are reviewed for now.
                     </span>
                   ) : null}
                 </p>
@@ -3159,6 +3176,7 @@ function PracticeParonym({
               href={`/lexicon/${item.lemmaId}/`}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="Відкрити в Атласі (нова вкладка)"
               style={{ fontSize: '0.85rem', textDecoration: 'underline', color: 'inherit', fontWeight: 'bold' }}
             >
               <span lang="uk">Відкрити в Атласі →</span>
@@ -3244,6 +3262,7 @@ function PracticeHeritage({
               href={`/lexicon/${item.lemmaId}/`}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="Відкрити в Атласі (нова вкладка)"
               style={{ fontSize: '0.85rem', textDecoration: 'underline', color: 'inherit', fontWeight: 'bold' }}
             >
               <span lang="uk">Відкрити в Атласі →</span>
@@ -3332,7 +3351,7 @@ function PracticeCloze({
           className="cz-input"
           value={input}
           disabled={answerLocked}
-          placeholder={showEnglishSubtitles ? "наберіть слово у потрібній формі… / type the word in the correct form…" : "наберіть слово у потрібній формі…"}
+          placeholder={showEnglishSubtitles ? 'введіть слово / type the word' : 'введіть слово'}
           autoComplete="off"
           autoCapitalize="off"
           autoCorrect="off"
@@ -3400,6 +3419,7 @@ function PracticeCloze({
               href={`/lexicon/${selection.lemma.lemmaId}/`}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="Відкрити в Атласі (нова вкладка)"
               style={{ fontSize: '0.85rem', textDecoration: 'underline', color: 'inherit', fontWeight: 'bold' }}
             >
               <span lang="uk">Відкрити в Атласі →</span>

--- a/site/src/layouts/CourseLayout.astro
+++ b/site/src/layouts/CourseLayout.astro
@@ -206,6 +206,11 @@ const isActive = (href: string) => {
       html[data-chrome-locale='uk'] .lu-i18n [data-loc='uk'] { display: inline; }
       html[data-chrome-locale='uk'] .lu-i18n [data-loc='en'] { display: none; }
 
+      /* Block-level sibling (headings, paragraphs) — same locale rule as .lu-i18n. */
+      .lu-i18n-block [data-loc='uk'] { display: none; }
+      html[data-chrome-locale='uk'] .lu-i18n-block [data-loc='uk'] { display: block; }
+      html[data-chrome-locale='uk'] .lu-i18n-block [data-loc='en'] { display: none; }
+
       .lu-locale-toggle {
         display: inline-flex;
         align-items: center;

--- a/site/src/lexicon/AtlasFullIndex.astro
+++ b/site/src/lexicon/AtlasFullIndex.astro
@@ -29,7 +29,11 @@ const atlasEntryNoun = (count: number): string => {
   return "записів";
 };
 const totalCount = browseMeta.total ?? 0;
-const totalLabel = `${totalCount} ${atlasEntryNoun(totalCount)} Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
+const alphabetWithEntries = UKRAINIAN_ALPHABET.filter(
+  (letter) => (letterCounts[letter] ?? 0) > 0,
+);
+const totalLabelUk = `${totalCount} ${atlasEntryNoun(totalCount)} Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
+const totalLabelEn = `${totalCount.toLocaleString("en-US")} atlas entries · ${UKRAINIAN_ALPHABET.length} letters`;
 ---
 
 <section
@@ -37,25 +41,31 @@ const totalLabel = `${totalCount} ${atlasEntryNoun(totalCount)} Атласу · 
   data-atlas-index
   data-browse-meta={JSON.stringify(browseMeta)}
   data-flagged-rows={JSON.stringify(flaggedRows)}
-  data-total-label={totalLabel}
+  data-total-label-uk={totalLabelUk}
+  data-total-label-en={totalLabelEn}
 >
   <div class="atlas-index-heading">
-    <h2>Перегляд Атласу А–Я</h2>
-    <p>Алфавітний покажчик відкриває слова по одній літері.</p>
+    <h2 class="lu-i18n-block">
+      <span data-loc="en">Browse the Atlas A–Z</span>
+      <span data-loc="uk">Перегляд Атласу А–Я</span>
+    </h2>
+    <p class="lu-i18n-block">
+      <span data-loc="en">The alphabetical index opens words one letter at a time.</span>
+      <span data-loc="uk">Алфавітний покажчик відкриває слова по одній літері.</span>
+    </p>
   </div>
 
   <nav class="atlas-letter-nav" aria-label="Літери українського алфавіту">
     {
-      UKRAINIAN_ALPHABET.map((letter) => {
+      alphabetWithEntries.map((letter) => {
         const count = letterCounts[letter] ?? 0;
         return (
           <button
             type="button"
-            class:list={["atlas-letter-link", count === 0 && "is-empty"]}
+            class="atlas-letter-link"
             data-letter={letter}
             data-base-count={count}
             aria-pressed="false"
-            disabled={count === 0}
           >
             {letter}
           </button>
@@ -63,6 +73,10 @@ const totalLabel = `${totalCount} ${atlasEntryNoun(totalCount)} Атласу · 
       })
     }
   </nav>
+  <p class="atlas-letter-nav-note lu-i18n-block">
+    <span data-loc="en">Showing letters that have Atlas entries.</span>
+    <span data-loc="uk">Показано літери, для яких є записи в Атласі.</span>
+  </p>
 
   {
     chips.length > 0 && (
@@ -92,11 +106,12 @@ const totalLabel = `${totalCount} ${atlasEntryNoun(totalCount)} Атласу · 
 </label>
 
   <p
-    class="atlas-index-status"
+    class="atlas-index-status lu-i18n-block"
     data-index-status
     aria-live="polite"
   >
-    {totalLabel}
+    <span data-loc="uk">{totalLabelUk}</span>
+    <span data-loc="en">{totalLabelEn}</span>
   </p>
 
   <section class="atlas-letter-section" data-letter-section hidden>
@@ -173,8 +188,22 @@ type BrowseRow = {
   const meta = JSON.parse(root.dataset.browseMeta ?? "{}") as BrowseMeta;
   const flaggedRows = JSON.parse(root.dataset.flaggedRows ?? "[]") as BrowseRow[];
   const totalCount = meta.total ?? 0;
-  const totalLabel = root.dataset.totalLabel
-    ?? `${atlasEntryCountLabel(totalCount)} Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
+  const totalLabelUk =
+    root.dataset.totalLabelUk ??
+    `${atlasEntryCountLabel(totalCount)} Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
+  const totalLabelEn =
+    root.dataset.totalLabelEn ??
+    `${totalCount.toLocaleString("en-US")} atlas entries · ${UKRAINIAN_ALPHABET.length} letters`;
+  const setStatusBilingual = (uk: string, en: string): void => {
+    if (!status) return;
+    status.classList.add("lu-i18n-block");
+    status.innerHTML = `<span data-loc="uk">${escapeHtml(uk)}</span><span data-loc="en">${escapeHtml(en)}</span>`;
+  };
+  const setStatusText = (value: string): void => {
+    if (!status) return;
+    status.classList.remove("lu-i18n-block");
+    status.textContent = value;
+  };
     const searchInput = root.querySelector<HTMLInputElement>("[data-index-search]");
     const status = root.querySelector<HTMLElement>("[data-index-status]");
     const section = root.querySelector<HTMLElement>("[data-letter-section]");
@@ -285,33 +314,33 @@ type BrowseRow = {
       if (!status) return;
     if (!state.letter) {
       if (state.loading) {
-        status.textContent = "Шукаємо…";
+        setStatusText("Шукаємо…");
         return;
       }
       if (state.error) {
-        status.textContent = state.error;
+        setStatusText(state.error);
         return;
       }
       if (state.q.trim()) {
-        status.textContent = `${state.cls ? `${CLS_LABELS[state.cls] ?? state.cls}: ` : ""}${filteredCount} збігів`;
+        setStatusText(`${state.cls ? `${CLS_LABELS[state.cls] ?? state.cls}: ` : ""}${filteredCount} збігів`);
         return;
       }
       if (state.cls) {
-        status.textContent = `${CLS_LABELS[state.cls] ?? state.cls}: ${atlasEntryCountLabel(filteredCount)}`;
+        setStatusText(`${CLS_LABELS[state.cls] ?? state.cls}: ${atlasEntryCountLabel(filteredCount)}`);
         return;
       }
-      status.textContent = totalLabel;
+      setStatusBilingual(totalLabelUk, totalLabelEn);
       return;
     }
       if (state.loading) {
-        status.textContent = `Завантажуємо ${state.letter}…`;
+        setStatusText(`Завантажуємо ${state.letter}…`);
         return;
       }
       if (state.error) {
-        status.textContent = state.error;
+        setStatusText(state.error);
         return;
       }
-      status.textContent = `${state.letter}: ${atlasEntryCountLabel(filteredCount)}`;
+      setStatusText(`${state.letter}: ${atlasEntryCountLabel(filteredCount)}`);
     };
 
     const updateControls = (): void => {
@@ -589,11 +618,18 @@ type BrowseRow = {
     gap: 0.35rem;
   }
 
+  .atlas-letter-nav-note {
+    margin: 0;
+    color: var(--lu-text-muted);
+    font-size: 0.85rem;
+    line-height: 1.45;
+  }
+
   .atlas-letter-nav {
     position: sticky;
     top: 0.25rem;
     z-index: 2;
-    padding: 0.6rem;
+    padding: 0.45rem;
     border: 1px solid var(--lu-border);
     border-radius: 8px;
     background: var(--lu-surface);
@@ -603,7 +639,7 @@ type BrowseRow = {
   .atlas-letter-link,
   .atlas-chip,
   .atlas-more-button {
-    min-height: 2.25rem;
+    min-height: 2.75rem;
     border: 1px solid var(--lu-border);
     border-radius: 8px;
     background: var(--lu-surface);
@@ -614,7 +650,8 @@ type BrowseRow = {
   }
 
   .atlas-letter-link {
-    width: 2.25rem;
+    width: 2.75rem;
+    min-width: 2.75rem;
     padding: 0;
   }
 

--- a/site/src/lexicon/AtlasRuntimeStatus.astro
+++ b/site/src/lexicon/AtlasRuntimeStatus.astro
@@ -9,46 +9,99 @@ const statusUrl = "/api/lexicon/status.json";
   data-status-url={statusUrl}
 >
   <div class="atlas-runtime-heading">
-    <span class="atlas-runtime-badge">Дані</span>
-    <h2 id="atlas-runtime-title">Покриття Атласу</h2>
-    <p data-runtime-status>Завантажуємо поточний стан...</p>
+    <span class="atlas-runtime-badge">
+      <span class="lu-i18n">
+        <span data-loc="en">Data</span>
+        <span data-loc="uk">Дані</span>
+      </span>
+    </span>
+    <h2 id="atlas-runtime-title" class="lu-i18n-block">
+      <span data-loc="en">Atlas coverage</span>
+      <span data-loc="uk">Покриття Атласу</span>
+    </h2>
+    <p data-runtime-status class="lu-i18n-block">
+      <span data-loc="en">Loading current status…</span>
+      <span data-loc="uk">Завантажуємо поточний стан...</span>
+    </p>
   </div>
 
   <dl class="atlas-runtime-grid" aria-live="polite">
     <div class="atlas-runtime-card">
-      <dt>Публічний Атлас</dt>
+      <dt class="lu-i18n">
+        <span data-loc="en">Public Atlas</span>
+        <span data-loc="uk">Публічний Атлас</span>
+      </dt>
       <dd data-runtime-value="publicAtlas">-</dd>
-      <p data-runtime-detail="publicAtlas">Пошук і перегляд</p>
+      <p data-runtime-detail="publicAtlas" class="lu-i18n-block">
+        <span data-loc="en">Search and browse</span>
+        <span data-loc="uk">Пошук і перегляд</span>
+      </p>
     </div>
     <div class="atlas-runtime-card">
-      <dt>Маніфест</dt>
+      <dt class="lu-i18n">
+        <span data-loc="en">Manifest</span>
+        <span data-loc="uk">Маніфест</span>
+      </dt>
       <dd data-runtime-value="manifest">-</dd>
-      <p data-runtime-detail="manifest">Маніфест релізу</p>
+      <p data-runtime-detail="manifest" class="lu-i18n-block">
+        <span data-loc="en">Release manifest</span>
+        <span data-loc="uk">Маніфест релізу</span>
+      </p>
     </div>
     <div class="atlas-runtime-card">
-      <dt>API</dt>
+      <dt class="lu-i18n">
+        <span data-loc="en">API</span>
+        <span data-loc="uk">API</span>
+      </dt>
       <dd data-runtime-value="api">-</dd>
-      <p data-runtime-detail="api">Контракт даних</p>
+      <p data-runtime-detail="api" class="lu-i18n-block">
+        <span data-loc="en">Data contract</span>
+        <span data-loc="uk">Контракт даних</span>
+      </p>
     </div>
     <div class="atlas-runtime-card">
-      <dt>Слова дня</dt>
+      <dt class="lu-i18n">
+        <span data-loc="en">Words of the Day</span>
+        <span data-loc="uk">Слова дня</span>
+      </dt>
       <dd data-runtime-value="daily">-</dd>
-      <p data-runtime-detail="daily">Рівні A1-B1</p>
+      <p data-runtime-detail="daily" class="lu-i18n-block">
+        <span data-loc="en">Levels A1–B1</span>
+        <span data-loc="uk">Рівні A1-B1</span>
+      </p>
     </div>
     <div class="atlas-runtime-card">
-      <dt>Практика</dt>
+      <dt class="lu-i18n">
+        <span data-loc="en">Practice</span>
+        <span data-loc="uk">Практика</span>
+      </dt>
       <dd data-runtime-value="practice">-</dd>
-      <p data-runtime-detail="practice">Лексеми в деці</p>
+      <p data-runtime-detail="practice" class="lu-i18n-block">
+        <span data-loc="en">Lexemes in the deck</span>
+        <span data-loc="uk">Лексеми в деці</span>
+      </p>
     </div>
     <div class="atlas-runtime-card">
-      <dt>Пропуски</dt>
+      <dt class="lu-i18n">
+        <span data-loc="en">Cloze</span>
+        <span data-loc="uk">Пропуски</span>
+      </dt>
       <dd data-runtime-value="cloze">-</dd>
-      <p data-runtime-detail="cloze">Перевірені речення</p>
+      <p data-runtime-detail="cloze" class="lu-i18n-block">
+        <span data-loc="en">Reviewed sentences</span>
+        <span data-loc="uk">Перевірені речення</span>
+      </p>
     </div>
     <div class="atlas-runtime-card">
-      <dt>Джерела</dt>
+      <dt class="lu-i18n">
+        <span data-loc="en">Sources</span>
+        <span data-loc="uk">Джерела</span>
+      </dt>
       <dd data-runtime-value="sourceInventory">-</dd>
-      <p data-runtime-detail="sourceInventory">Слова дня / практика / пропуски</p>
+      <p data-runtime-detail="sourceInventory" class="lu-i18n-block">
+        <span data-loc="en">Words of the Day / practice / cloze</span>
+        <span data-loc="uk">Слова дня / практика / пропуски</span>
+      </p>
     </div>
   </dl>
 </section>
@@ -59,17 +112,34 @@ const statusUrl = "/api/lexicon/status.json";
   const numberFormatter = new Intl.NumberFormat("uk-UA");
   const formatCount = (value) =>
     typeof value === "number" ? numberFormatter.format(value) : "-";
-  const formatBytes = (value) =>
+  const formatBytesUk = (value) =>
+    typeof value === "number" ? `${(value / (1024 * 1024)).toFixed(1)} МБ` : "-";
+  const formatBytesEn = (value) =>
     typeof value === "number" ? `${(value / (1024 * 1024)).toFixed(1)} MB` : "-";
+  const escapeHtml = (value) =>
+    String(value ?? "").replace(
+      /[&<>"']/g,
+      (c) =>
+        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c,
+    );
 
   function setRuntimeText(root, key, value) {
     const node = root.querySelector(`[data-runtime-value="${key}"]`);
     if (node) node.textContent = value;
   }
 
-  function setRuntimeDetail(root, key, value) {
+  function setRuntimeDetailHtml(root, key, uk, en) {
     const node = root.querySelector(`[data-runtime-detail="${key}"]`);
-    if (node) node.textContent = value;
+    if (!node) return;
+    node.innerHTML = `<span data-loc="uk">${escapeHtml(uk)}</span><span data-loc="en">${escapeHtml(en)}</span>`;
+    node.classList.add("lu-i18n-block");
+  }
+
+  function setRuntimeStatusHtml(root, uk, en) {
+    const statusNode = root.querySelector("[data-runtime-status]");
+    if (!statusNode) return;
+    statusNode.innerHTML = `<span data-loc="uk">${escapeHtml(uk)}</span><span data-loc="en">${escapeHtml(en)}</span>`;
+    statusNode.classList.add("lu-i18n-block");
   }
 
   function renderRuntimeStatus(root, status) {
@@ -81,10 +151,11 @@ const statusUrl = "/api/lexicon/status.json";
     const shardCount = status.publicAtlas.searchShards ?? 0;
     const shardLabel = pluralizeUk(shardCount, ["сегмент пошуку", "сегменти пошуку", "сегментів пошуку"]);
 
-    setRuntimeDetail(
+    setRuntimeDetailHtml(
       root,
       "publicAtlas",
       `${formatCount(aliasCount)} ${aliasLabel} · ${formatCount(shardCount)} ${shardLabel}`,
+      `${formatCount(aliasCount)} search wordforms · ${formatCount(shardCount)} search shards`,
     );
 
     setRuntimeText(root, "manifest", formatCount(status.manifest.records));
@@ -95,53 +166,71 @@ const statusUrl = "/api/lexicon/status.json";
     const grammarCount = status.manifest.grammarTermRecords ?? 0;
     const grammarLabel = pluralizeUk(grammarCount, ["внутрішній", "внутрішні", "внутрішніх"]);
 
-    setRuntimeDetail(
+    setRuntimeDetailHtml(
       root,
       "manifest",
       status.manifest.hydrated
         ? `${formatCount(publicCount)} ${publicLabel} · ${formatCount(grammarCount)} ${grammarLabel}`
-        : `${formatBytes(status.manifest.jsonBytes)} pinned`,
+        : `${formatBytesUk(status.manifest.jsonBytes)} закріплено`,
+      status.manifest.hydrated
+        ? `${formatCount(publicCount)} public records · ${formatCount(grammarCount)} internal`
+        : `${formatBytesEn(status.manifest.jsonBytes)} pinned`,
     );
 
     setRuntimeText(root, "api", "4");
-    setRuntimeDetail(root, "api", status.endpoints.contract);
+    setRuntimeDetailHtml(root, "api", status.endpoints.contract, status.endpoints.contract);
 
     setRuntimeText(root, "daily", formatCount(status.daily.poolEntries));
-    setRuntimeDetail(root, "daily", "Навчальна добірка");
+    setRuntimeDetailHtml(root, "daily", "Навчальна добірка", "Learning selection");
 
     setRuntimeText(root, "practice", formatCount(status.practice.totalLexemes));
-    setRuntimeDetail(
+    setRuntimeDetailHtml(
       root,
       "practice",
       status.practice.deckVersions.length
         ? status.practice.deckVersions.join(", ")
         : "Без версії",
+      status.practice.deckVersions.length
+        ? status.practice.deckVersions.join(", ")
+        : "No version",
     );
 
     setRuntimeText(root, "cloze", formatCount(status.cloze.totalItems));
-    setRuntimeDetail(
+    setRuntimeDetailHtml(
       root,
       "cloze",
       `${formatCount(status.cloze.sourceRows)} джерел · ${formatCount(
         status.cloze.reviewedSourceRows,
       )} дозволено`,
+      `${formatCount(status.cloze.sourceRows)} sources · ${formatCount(
+        status.cloze.reviewedSourceRows,
+      )} allowed`,
     );
 
     setRuntimeText(root, "sourceInventory", formatCount(status.sourceInventory.atlasRows));
-    setRuntimeDetail(
+    setRuntimeDetailHtml(
       root,
       "sourceInventory",
       `${formatCount(status.sourceInventory.dailyAdmitted)} / ${formatCount(
         status.sourceInventory.practiceAdmitted,
       )} / ${formatCount(status.sourceInventory.clozeAdmitted)}`,
+      `${formatCount(status.sourceInventory.dailyAdmitted)} / ${formatCount(
+        status.sourceInventory.practiceAdmitted,
+      )} / ${formatCount(status.sourceInventory.clozeAdmitted)}`,
     );
 
-    const statusNode = root.querySelector("[data-runtime-status]");
-    if (statusNode) {
-      statusNode.textContent =
-        status.status === "ok"
-          ? "Дані узгоджені: пошук, перегляд, Слова дня і практика синхронізовані."
-          : "Дані потребують перевірки: одна з поверхонь Атласу не збігається.";
+    if (status.status === "ok") {
+      setRuntimeStatusHtml(
+        root,
+        "Дані узгоджені: пошук, перегляд, Слова дня і практика синхронізовані.",
+        "Data aligned: search, browse, Words of the Day, and practice are in sync.",
+      );
+    } else {
+      setRuntimeStatusHtml(
+        root,
+        "Дані потребують перевірки: одна з поверхонь Атласу не збігається.",
+        "Data needs review: one Atlas surface is out of sync.",
+      );
     }
     root.dataset.runtimeLoaded = "true";
   }
@@ -155,8 +244,11 @@ const statusUrl = "/api/lexicon/status.json";
       })
       .then((status) => renderRuntimeStatus(root, status))
       .catch(() => {
-        const statusNode = root.querySelector("[data-runtime-status]");
-        if (statusNode) statusNode.textContent = "Стан Атласу зараз недоступний.";
+        setRuntimeStatusHtml(
+          root,
+          "Стан Атласу зараз недоступний.",
+          "Atlas status is unavailable right now.",
+        );
         root.dataset.runtimeLoaded = "false";
       });
   }

--- a/site/src/lexicon/AtlasTypeahead.astro
+++ b/site/src/lexicon/AtlasTypeahead.astro
@@ -56,6 +56,10 @@ const listId = `${id}-list`;
     type SearchRow,
     type SearchShardManifest,
   } from "../lib/lexicon/search";
+  import {
+    resolveTypeaheadEnterSelection,
+    resolveTypeaheadEscapeAction,
+  } from "../lib/lexicon/atlas-typeahead-keys";
 
   const EMPTY_MESSAGE = "Нічого не знайдено — спробуйте українською, латиницею або англійською";
   const LOADING_MESSAGE = "Завантажуємо…";
@@ -270,7 +274,9 @@ const listId = `${id}-list`;
           if (request !== taRequest) return;
         }
         taItems = matches;
-        taActive = taItems.length ? 0 : -1;
+        // No auto-highlight — Enter prefers an exact lemma match until the
+        // learner arrows to a suggestion (scout #7 / K3 B1).
+        taActive = -1;
         taState = taItems.length ? null : "empty";
         taRender();
       });
@@ -279,6 +285,8 @@ const listId = `${id}-list`;
     const taGo = (slug: string | null) => {
       if (slug) window.location.assign(`/lexicon/${encodeURIComponent(slug)}/`);
     };
+
+    const taListboxOpen = () => !taList.hidden;
 
     taInput.addEventListener("focus", () => {
       void taLoadManifest().catch(() => taLoadFull()).then(() => taSearch(taInput.value));
@@ -296,24 +304,46 @@ const listId = `${id}-list`;
       if (ev.key === "ArrowDown") {
         ev.preventDefault();
         if (taItems.length) {
-          taActive = (taActive + 1) % taItems.length;
+          taActive = taActive < 0 ? 0 : (taActive + 1) % taItems.length;
           taRender();
         }
       } else if (ev.key === "ArrowUp") {
         ev.preventDefault();
         if (taItems.length) {
-          taActive = (taActive - 1 + taItems.length) % taItems.length;
+          taActive =
+            taActive < 0
+              ? taItems.length - 1
+              : (taActive - 1 + taItems.length) % taItems.length;
           taRender();
         }
       } else if (ev.key === "Enter") {
-        if (taItems[taActive]) {
+        const chosen = resolveTypeaheadEnterSelection(
+          taInput.value,
+          taItems.map((item) => ({
+            lemma: item.article.l,
+            slug: item.article.s,
+            item,
+          })),
+          taActive,
+        );
+        if (chosen) {
           ev.preventDefault();
-          taGo(taItems[taActive].article.s);
+          taGo(chosen.slug);
         }
       } else if (ev.key === "Escape") {
+        ev.preventDefault();
+        const action = resolveTypeaheadEscapeAction(taListboxOpen() && (taItems.length > 0 || taState !== null));
+        if (action === "close-listbox") {
+          taItems = [];
+          taState = null;
+          taActive = -1;
+          taRender();
+          return;
+        }
         taInput.value = "";
         taItems = [];
         taState = null;
+        taActive = -1;
         taRender();
       }
     });

--- a/site/src/lexicon/WordAtlasClientShell.tsx
+++ b/site/src/lexicon/WordAtlasClientShell.tsx
@@ -26,6 +26,7 @@ import { absoluteSitePath } from "../lib/lexicon/site-base";
 import {
   analyticsClassForState,
   loadAtlasClientShellEntry,
+  preflightAtlasSlugInSearchIndex,
   type AtlasClientShellState,
 } from "../lib/lexicon/word-atlas-client-shell";
 
@@ -126,19 +127,29 @@ export default function WordAtlasClientShell({
     let cancelled = false;
     setState({ status: "loading", slug });
 
-    const source = new HttpAtlasDataSource(createBrowserAtlasFetch(fetchImpl), {
-      assetBaseUrl: atlasBase,
-      pointerTtlMs: 0,
-    });
+    const run = async () => {
+      const fetchFn = fetchImpl ?? fetch.bind(globalThis);
+      const preflight = await preflightAtlasSlugInSearchIndex(slug, fetchFn, resolvedBase);
+      if (cancelled) return;
+      if (preflight === "missing") {
+        setState({ status: "not_found", slug });
+        return;
+      }
 
-    void loadAtlasClientShellEntry(slug, source).then((next) => {
+      const source = new HttpAtlasDataSource(createBrowserAtlasFetch(fetchImpl), {
+        assetBaseUrl: atlasBase,
+        pointerTtlMs: 0,
+      });
+      const next = await loadAtlasClientShellEntry(slug, source);
       if (!cancelled) setState(next);
-    });
+    };
+
+    void run();
 
     return () => {
       cancelled = true;
     };
-  }, [slug, atlasBase, fetchImpl, retryToken]);
+  }, [slug, atlasBase, fetchImpl, retryToken, resolvedBase]);
 
   useEffect(() => {
     if (!state || state.status === "loading") return;
@@ -174,15 +185,27 @@ export default function WordAtlasClientShell({
         data-http-status="404"
         className="atlas-client-shell-state"
       >
-        <h1>Слово не знайдено</h1>
-        <p>
-          Немає публічної статті для «{state.slug}».
+        <h1 className="lu-i18n-block">
+          <span data-loc="en">Word not found</span>
+          <span data-loc="uk">Слово не знайдено</span>
+        </h1>
+        <p className="lu-i18n-block">
+          <span data-loc="en">No public article for «{state.slug}».</span>
+          <span data-loc="uk">Немає публічної статті для «{state.slug}».</span>
         </p>
         <p>
-          <a href={absoluteSitePath("/lexicon/", resolvedBase)}>До Атласу</a>
+          <a href={absoluteSitePath("/lexicon/", resolvedBase)}>
+            <span className="lu-i18n">
+              <span data-loc="en">Back to Atlas</span>
+              <span data-loc="uk">До Атласу</span>
+            </span>
+          </a>
           {" · "}
           <a href={absoluteSitePath("/lexicon/", resolvedBase) + "#lexicon-landing-search"}>
-            Пошук
+            <span className="lu-i18n">
+              <span data-loc="en">Search</span>
+              <span data-loc="uk">Пошук</span>
+            </span>
           </a>
         </p>
       </div>

--- a/site/src/lexicon/WordAtlasPageShell.astro
+++ b/site/src/lexicon/WordAtlasPageShell.astro
@@ -54,13 +54,30 @@ const { state } = Astro.props as Props;
   </div>
 ) : state.status === "missing" ? (
   <div role="alert" data-word-atlas-state="missing" data-http-status="404">
-    <h1>Статтю не знайдено</h1>
-    <p>Немає публічної статті для «{state.slug}».</p>
-    <p>
-      <a href="/lexicon/">До Атласу</a>
-      {" · "}
-      <a href="/lexicon/#lexicon-landing-search">Пошук</a>
+    <h1 class="lu-i18n-block">
+      <span data-loc="en">Word not found</span>
+      <span data-loc="uk">Слово не знайдено</span>
+    </h1>
+    <p class="lu-i18n-block">
+      <span data-loc="en">No public article for «{state.slug}».</span>
+      <span data-loc="uk">Немає публічної статті для «{state.slug}».</span>
     </p>
+    <p>
+      <a href="/lexicon/">
+        <span class="lu-i18n">
+          <span data-loc="en">Back to Atlas</span>
+          <span data-loc="uk">До Атласу</span>
+        </span>
+      </a>
+      {" · "}
+      <a href="/lexicon/#lexicon-landing-search">
+        <span class="lu-i18n">
+          <span data-loc="en">Search</span>
+          <span data-loc="uk">Пошук</span>
+        </span>
+      </a>
+    </p>
+    <AtlasTypeahead id="atlas-missing-search" label="Шукати слово в Лексиконі" />
   </div>
 ) : state.status === "offline" ? (
   <div role="alert" data-word-atlas-state="offline" data-http-status="503">

--- a/site/src/lib/lexicon/atlas-typeahead-keys.ts
+++ b/site/src/lib/lexicon/atlas-typeahead-keys.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure keyboard helpers for Atlas typeahead (Enter exact-match + Escape dismiss).
+ */
+
+import { normalize } from "./search";
+
+export interface TypeaheadNavItem {
+  lemma: string;
+  slug: string;
+}
+
+/**
+ * Enter with no Arrow selection prefers an exact lemma/slug match; otherwise
+ * the first suggestion. When activeIndex >= 0, the highlighted item wins.
+ */
+export function resolveTypeaheadEnterSelection<T extends TypeaheadNavItem>(
+  query: string,
+  items: readonly T[],
+  activeIndex: number,
+): T | null {
+  if (!items.length) return null;
+  if (activeIndex >= 0 && activeIndex < items.length) {
+    return items[activeIndex] ?? null;
+  }
+  const trimmed = query.trim();
+  if (!trimmed) return items[0] ?? null;
+  const needle = normalize(trimmed);
+  const exact =
+    items.find((item) => item.lemma === trimmed || item.slug === trimmed) ??
+    items.find(
+      (item) => normalize(item.lemma) === needle || normalize(item.slug) === needle,
+    );
+  return exact ?? items[0] ?? null;
+}
+
+/** First Escape closes an open listbox; second Escape clears the input. */
+export function resolveTypeaheadEscapeAction(
+  listboxOpen: boolean,
+): "close-listbox" | "clear-input" {
+  return listboxOpen ? "close-listbox" : "clear-input";
+}

--- a/site/src/lib/lexicon/word-atlas-client-shell.ts
+++ b/site/src/lib/lexicon/word-atlas-client-shell.ts
@@ -9,6 +9,7 @@ import {
   type AtlasDataSource,
   type EntryRecord,
 } from "./atlas-data-source.ts";
+import { absoluteSitePath } from "./site-base.ts";
 
 export type AtlasClientShellState =
   | { status: "loading"; slug: string }
@@ -63,6 +64,38 @@ function mapError(
     slug,
     message: error instanceof Error ? error.message : String(error),
   };
+}
+
+/**
+ * Preflight against the public search index so unknown lemma 404 surfaces
+ * never request `/atlas/current.json` (K3 B2).
+ *
+ * Returns `missing` when the index loads and the slug is absent; `unknown`
+ * when the index is unavailable (caller falls through to HttpAtlasDataSource).
+ */
+export async function preflightAtlasSlugInSearchIndex(
+  slug: string,
+  fetchImpl: typeof fetch,
+  baseUrl = "/",
+): Promise<"found" | "missing" | "unknown"> {
+  const url = absoluteSitePath("/lexicon/search-index.json", baseUrl);
+  try {
+    const response = await fetchImpl(url);
+    if (!response.ok) return "unknown";
+    const data: unknown = await response.json();
+    if (!Array.isArray(data)) return "unknown";
+    const hit = data.some(
+      (row) =>
+        row &&
+        typeof row === "object" &&
+        "s" in row &&
+        typeof (row as { s: unknown }).s === "string" &&
+        (row as { s: string }).s === slug,
+    );
+    return hit ? "found" : "missing";
+  } catch {
+    return "unknown";
+  }
 }
 
 /**

--- a/site/src/pages/lexicon/browse.astro
+++ b/site/src/pages/lexicon/browse.astro
@@ -22,8 +22,18 @@ const frontmatter = {
 >
   <div class="word-atlas lexicon-browse-page" data-word-atlas>
     <nav class="atlas-view-nav" aria-label="Навігація Атласу">
-      <a href="/lexicon/">Пошук</a>
-      <a href="/lexicon/browse/" aria-current="page">Перегляд А–Я</a>
+      <a href="/lexicon/">
+        <span class="lu-i18n">
+          <span data-loc="en">Search</span>
+          <span data-loc="uk">Пошук</span>
+        </span>
+      </a>
+      <a href="/lexicon/browse/" aria-current="page">
+        <span class="lu-i18n">
+          <span data-loc="en">Browse A–Z</span>
+          <span data-loc="uk">Перегляд А–Я</span>
+        </span>
+      </a>
     </nav>
 
     <AtlasFullIndex />

--- a/site/src/pages/lexicon/index.astro
+++ b/site/src/pages/lexicon/index.astro
@@ -5,11 +5,15 @@
 import CourseLayout from "../../layouts/CourseLayout.astro";
 import AtlasRuntimeStatus from "../../lexicon/AtlasRuntimeStatus.astro";
 import AtlasTypeahead from "../../lexicon/AtlasTypeahead.astro";
+import browseMeta from "../../data/lexicon-browse-meta.json";
 
 const frontmatter = {
   title: "Атлас слів",
   description: "Пошук і А-Я перегляд українських слів курсу з джерелами, морфологією та місцями появи.",
 };
+const atlasWordCount = browseMeta.total ?? 0;
+const atlasWordsUk = `${atlasWordCount.toLocaleString("uk-UA")} слів`;
+const atlasWordsEn = `${atlasWordCount.toLocaleString("en-US")} words`;
 ---
 
 <CourseLayout
@@ -22,10 +26,19 @@ const frontmatter = {
 >
   <div class="word-atlas lexicon-landing" data-word-atlas>
     <section class="lexicon-landing-hero" aria-labelledby="lexicon-landing-title">
-      <span class="lexicon-badge">Лексикон</span>
-      <h1 id="lexicon-landing-title">Атлас слів</h1>
-      <p>
-        Шукайте курсові слова з джерелами, морфологією та місцями появи в модулях.
+      <span class="lexicon-badge">
+        <span class="lu-i18n">
+          <span data-loc="en">Lexicon</span>
+          <span data-loc="uk">Лексикон</span>
+        </span>
+      </span>
+      <h1 id="lexicon-landing-title" class="lu-i18n-block">
+        <span data-loc="en">Word Atlas</span>
+        <span data-loc="uk">Атлас слів</span>
+      </h1>
+      <p class="lu-i18n-block">
+        <span data-loc="en">Search course words with sources, morphology, and where they appear in modules.</span>
+        <span data-loc="uk">Шукайте курсові слова з джерелами, морфологією та місцями появи в модулях.</span>
       </p>
       <AtlasTypeahead
         id="lexicon-landing-search"
@@ -34,7 +47,16 @@ const frontmatter = {
         containerClass="atlas-typeahead-landing"
         labelClass="atlas-typeahead-label"
       />
-      <a class="lexicon-browse-link" href="/lexicon/browse/">Перегляд А–Я →</a>
+      <p class="lexicon-atlas-size lu-i18n-block" data-testid="atlas-dictionary-size">
+        <span data-loc="en">{atlasWordsEn}</span>
+        <span data-loc="uk">{atlasWordsUk}</span>
+      </p>
+      <a class="lexicon-browse-link" href="/lexicon/browse/">
+        <span class="lu-i18n">
+          <span data-loc="en">Browse A–Z →</span>
+          <span data-loc="uk">Перегляд А–Я →</span>
+        </span>
+      </a>
     </section>
 
     <AtlasRuntimeStatus />
@@ -80,6 +102,15 @@ const frontmatter = {
   color: var(--lu-text-muted);
   font-size: 1.1rem;
   line-height: 1.65;
+}
+
+.lexicon-atlas-size {
+  margin: 1.35rem auto 0;
+  color: var(--lu-text);
+  font-size: clamp(1.55rem, 2.4vw, 2rem);
+  font-weight: 900;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
 }
 
 /* `.word-atlas.lexicon-landing` (0,3,0) deterministically beats the global

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -18,12 +18,33 @@ const frontmatter = {
 >
   <main class="word-atlas lexicon-practice-page" data-word-atlas>
     <section class="lexicon-practice-intro" aria-labelledby="lexicon-practice-page-title">
-      <a class="lexicon-practice-back" href="/words-of-the-day/">← Слова дня</a>
-      <span class="lexicon-practice-badge">СЛОВА ДНЯ · ПРАКТИКА</span>
-      <h1 id="lexicon-practice-page-title">Практика</h1>
+      <a class="lexicon-practice-back" href="/words-of-the-day/">
+        <span class="lu-i18n">
+          <span data-loc="en">← Слова дня / Words of the Day</span>
+          <span data-loc="uk">← Слова дня</span>
+        </span>
+      </a>
+      <span class="lexicon-practice-badge">
+        <span class="lu-i18n">
+          <span data-loc="en">СЛОВА ДНЯ · ПРАКТИКА / WORDS OF THE DAY · PRACTICE</span>
+          <span data-loc="uk">СЛОВА ДНЯ · ПРАКТИКА</span>
+        </span>
+      </span>
+      <h1 id="lexicon-practice-page-title" class="lu-i18n-block">
+        <span data-loc="en">Практика / Practice</span>
+        <span data-loc="uk">Практика</span>
+      </h1>
       <p>
-        Інтервальне повторення слів вашого рівня (CEFR, накопичувально) — картки,
-        добір, вибір і пропуски. Прогрес зберігається локально у цьому браузері.
+        <span lang="uk">
+          Інтервальне повторення слів вашого рівня (CEFR, накопичувально) — картки,
+          добір, вибір і пропуски. Прогрес зберігається локально у цьому браузері.
+        </span>
+      </p>
+      <p class="lexicon-practice-intro-en lu-i18n-block" lang="en">
+        <span data-loc="en">
+          Spaced repetition for your level (CEFR, cumulative) — cards, matching,
+          choice, and cloze. Progress stays locally in this browser.
+        </span>
       </p>
     </section>
 
@@ -70,6 +91,10 @@ const frontmatter = {
     color: var(--lu-text-muted);
     font-size: 1.05rem;
     line-height: 1.65;
+  }
+
+  :global(html[data-chrome-locale='uk']) .lexicon-practice-intro-en {
+    display: none;
   }
 
   :global(.lexicon-practice) {

--- a/site/src/styles/course.css
+++ b/site/src/styles/course.css
@@ -174,7 +174,13 @@ body {
   transform: translateY(-160%);
 }
 
-.lu-skip-link:focus {
+/* Visible only for keyboard focus; mouse/:focus without :focus-visible stays hidden
+   so Space/Enter practice keys never leave the skip link stuck on screen. */
+.lu-skip-link:focus:not(:focus-visible) {
+  transform: translateY(-160%);
+}
+
+.lu-skip-link:focus-visible {
   transform: translateY(0);
 }
 

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -467,6 +467,8 @@ beforeEach(() => {
   localStorage.clear();
   loadState(localStorage, NOW);
   vi.restoreAllMocks();
+  // Preserve prior A2+/uk-only chrome expectations unless a test opts into EN.
+  document.documentElement.dataset.chromeLocale = 'uk';
 });
 
 describe('LexiconPractice', () => {
@@ -1304,15 +1306,83 @@ describe('LexiconPractice', () => {
     expect(denominator).toBeLessThan(1150);
   });
 
-  test('A1 renders English subtitles on session labels; A2 does not', async () => {
-    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
+  test("A1 renders English subtitles on session labels; A2 does not when chrome locale is uk", async () => {
+    document.documentElement.dataset.chromeLocale = "uk";
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A1");
     const { unmount } = render(<LexiconPractice />);
-    expect(screen.getByText('Start session')).toBeInTheDocument();
+    expect(screen.getByText("Start session")).toBeInTheDocument();
     unmount();
 
-    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A2');
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A2");
     render(<LexiconPractice />);
-    expect(screen.queryByText('Start session')).not.toBeInTheDocument();
+    expect(screen.queryByText("Start session")).not.toBeInTheDocument();
+  });
+
+  test("A2 shows English chrome when data-chrome-locale is en", async () => {
+    document.documentElement.dataset.chromeLocale = "en";
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A2");
+    render(<LexiconPractice />);
+    expect(screen.getByText("Start session")).toBeInTheDocument();
+  });
+
+  test("toggling data-chrome-locale updates practice chrome without remount", async () => {
+    document.documentElement.dataset.chromeLocale = "uk";
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "B1");
+    render(<LexiconPractice />);
+    expect(screen.queryByText("Start session")).not.toBeInTheDocument();
+
+    await act(async () => {
+      document.documentElement.dataset.chromeLocale = "en";
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Start session")).toBeInTheDocument();
+    });
+  });
+
+  test("heritage empty state is dual-language when chrome locale is en", async () => {
+    document.documentElement.dataset.chromeLocale = "en";
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A2");
+    render(
+      <LexiconPractice
+        initialDeck={heritageDeck({ includeItems: false })}
+        autoStart
+        initialMode="heritage"
+      />,
+    );
+    expect(await screen.findByTestId("practice-heritage-empty")).toHaveTextContent(
+      /Heritage exercises for this level are still being prepared/,
+    );
+  });
+
+  test("synonyms empty catch-all is dual-language when chrome locale is en", async () => {
+    document.documentElement.dataset.chromeLocale = "en";
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A2");
+    const deck = sampleDeckWithOnlyMode("knyha", "synonym");
+    deck.synonym = [];
+    render(<LexiconPractice initialDeck={deck} autoStart initialMode="synonym" />);
+    await waitFor(() => {
+      expect(screen.getByText(/All cards are reviewed for now/)).toBeInTheDocument();
+    });
+  });
+
+  test("cloze placeholder is short and bilingual when chrome locale is en", async () => {
+    document.documentElement.dataset.chromeLocale = "en";
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A2");
+    const clozeDeck = sampleDeck();
+    render(<LexiconPractice initialDeck={clozeDeck} autoStart initialMode="cloze" />);
+    const input = await screen.findByRole("textbox");
+    expect(input.getAttribute("placeholder")).toBe("введіть слово / type the word");
+  });
+
+  test("atlas links announce нова вкладка for screen readers", async () => {
+    document.documentElement.dataset.chromeLocale = "en";
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" />);
+    await user.click(
+      within(screen.getByTestId("practice-heritage")).getByRole("button", { name: /дом/ }),
+    );
+    const link = await screen.findByRole("link", { name: /нова вкладка/i });
+    expect(link).toHaveAttribute("target", "_blank");
   });
 
   test('unpublished C2 level button is disabled with «скоро»', () => {

--- a/site/tests/unit/atlas-typeahead-keys.test.ts
+++ b/site/tests/unit/atlas-typeahead-keys.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import {
+  resolveTypeaheadEnterSelection,
+  resolveTypeaheadEscapeAction,
+} from "@site/src/lib/lexicon/atlas-typeahead-keys";
+
+describe("resolveTypeaheadEnterSelection", () => {
+  const items = [
+    { lemma: "гаряча вода", slug: "гаряча-вода" },
+    { lemma: "вода", slug: "вода" },
+    { lemma: "водний", slug: "водний" },
+  ];
+
+  test("Enter with no highlight prefers the exact typed lemma", () => {
+    const chosen = resolveTypeaheadEnterSelection("вода", items, -1);
+    expect(chosen?.slug).toBe("вода");
+  });
+
+  test("Enter with no highlight prefers an exact multiword lemma", () => {
+    const chosen = resolveTypeaheadEnterSelection("гаряча вода", items, -1);
+    expect(chosen?.slug).toBe("гаряча-вода");
+  });
+
+  test("Enter with highlight selects the highlighted item", () => {
+    const chosen = resolveTypeaheadEnterSelection("вода", items, 0);
+    expect(chosen?.slug).toBe("гаряча-вода");
+  });
+
+  test("Enter without an exact match falls back to the first suggestion", () => {
+    const chosen = resolveTypeaheadEnterSelection("вод", items, -1);
+    expect(chosen?.slug).toBe("гаряча-вода");
+  });
+
+  test("empty suggestion list returns null", () => {
+    expect(resolveTypeaheadEnterSelection("вода", [], -1)).toBeNull();
+  });
+});
+
+describe("resolveTypeaheadEscapeAction", () => {
+  test("first Escape closes an open listbox", () => {
+    expect(resolveTypeaheadEscapeAction(true)).toBe("close-listbox");
+  });
+
+  test("second Escape clears the input when the listbox is closed", () => {
+    expect(resolveTypeaheadEscapeAction(false)).toBe("clear-input");
+  });
+});

--- a/site/tests/unit/k3-chrome-locale.test.ts
+++ b/site/tests/unit/k3-chrome-locale.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+describe("skip-link focus-visible dismissal (K3 B3)", () => {
+  test("course.css hides skip link except on :focus-visible", () => {
+    const css = readFileSync(resolve(process.cwd(), "src/styles/course.css"), "utf8");
+    expect(css).toMatch(/\.lu-skip-link:focus:not\(:focus-visible\)/);
+    expect(css).toMatch(/\.lu-skip-link:focus-visible/);
+    expect(css).not.toMatch(/\.lu-skip-link:focus\s*\{[^}]*transform:\s*translateY\(0\)/);
+  });
+});
+
+describe("chrome locale block CSS (K3 A2)", () => {
+  test("CourseLayout defines .lu-i18n-block show/hide rules", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/layouts/CourseLayout.astro"),
+      "utf8",
+    );
+    expect(source).toContain(".lu-i18n-block [data-loc='uk'] { display: none; }");
+    expect(source).toContain(
+      "html[data-chrome-locale='uk'] .lu-i18n-block [data-loc='uk'] { display: block; }",
+    );
+    expect(source).toContain(
+      "html[data-chrome-locale='uk'] .lu-i18n-block [data-loc='en'] { display: none; }",
+    );
+  });
+});
+
+describe("atlas alphabet tap targets + empty-letter filter (K3 B6/C4)", () => {
+  test("AtlasFullIndex hides zero-count letters and uses 2.75rem targets", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/lexicon/AtlasFullIndex.astro"),
+      "utf8",
+    );
+    expect(source).toContain("alphabetWithEntries");
+    expect(source).toContain("(letterCounts[letter] ?? 0) > 0");
+    expect(source).toContain("Showing letters that have Atlas entries.");
+    expect(source).toContain("Показано літери, для яких є записи в Атласі.");
+    expect(source).toMatch(/min-height:\s*2\.75rem/);
+    expect(source).toMatch(/width:\s*2\.75rem/);
+  });
+});
+
+describe("atlas dictionary size headline (K3 A2)", () => {
+  test("lexicon landing exposes bilingual 8,206 words headline", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/pages/lexicon/index.astro"),
+      "utf8",
+    );
+    expect(source).toContain('data-testid="atlas-dictionary-size"');
+    expect(source).toContain("atlasWordsEn");
+    expect(source).toContain("atlasWordsUk");
+    expect(source).toContain("words");
+    expect(source).toContain("слів");
+  });
+});

--- a/site/tests/unit/word-atlas-client-shell.test.tsx
+++ b/site/tests/unit/word-atlas-client-shell.test.tsx
@@ -242,4 +242,33 @@ describe("WordAtlasClientShell React mount", () => {
       expect(document.querySelector("[data-word-atlas]")).toBeTruthy();
     });
   });
+
+  test("not_found via search-index preflight never requests current.json", async () => {
+    const requested: string[] = [];
+    const fetchImpl = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      if (url.includes("search-index.json")) {
+        return new Response(JSON.stringify([{ l: "прапор", s: "прапор", g: "flag" }]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("should-not-fetch", { status: 500 });
+    }) as typeof fetch;
+
+    render(
+      createElement(WordAtlasClientShell, {
+        pathname: "/lexicon/неіснуючесловоxyzqqq/",
+        assetBaseUrl: "/atlas",
+        fetchImpl,
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveAttribute("data-word-atlas-state", "not_found");
+    });
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toMatch(/Word not found|Слово не знайдено/);
+    expect(requested.some((url) => url.includes("current.json"))).toBe(false);
+    expect(requested.some((url) => url.includes("search-index.json"))).toBe(true);
+  });
 });

--- a/site/tests/unit/word-atlas-page-shell.test.ts
+++ b/site/tests/unit/word-atlas-page-shell.test.ts
@@ -60,6 +60,8 @@ describe("WordAtlasPageShell dormant states", () => {
     expect(html).toContain('data-http-status="404"');
     expect(html).toContain("немає");
     expect(html).toContain('href="/lexicon/"');
+    expect(html).toContain("Слово не знайдено");
+    expect(html).toContain("Word not found");
     expect(html).not.toContain("data-word-atlas=");
   });
 


### PR DESCRIPTION
## Summary

Implements the Sol-approved **K3 UI/UX Improvement Spec** on #5355 (groups A–C; D skipped). Practice + Atlas chrome now follow the existing `data-chrome-locale` toggle (no second language switch). Curriculum content immersion stays Ukrainian.

Refs #5355 #4700

## Spec checklist

### A. Dual-language + locale correctness (P0)

- [x] **A1** Practice chrome observes `data-chrome-locale`; `showEnglishSubtitles = A1 || chromeLocale === 'en'`; hub back/eyebrow/H1/intro dual via `.lu-i18n` / `.lu-i18n-block`
  - Quoted: `✓ … > A2 shows English chrome when data-chrome-locale is en`
  - Quoted: `✓ … > toggling data-chrome-locale updates practice chrome without remount`
- [x] **A2** `.lu-i18n-block` CSS; Atlas landing “8,206 words / 8 206 слів”; runtime card titles bilingual; browse header bilingual
  - Quoted: `✓ k3-chrome-locale > CourseLayout defines .lu-i18n-block show/hide rules`
  - Quoted: `✓ k3-chrome-locale > lexicon landing exposes bilingual 8,206 words headline`

### B. Blockers / majors (P1)

- [x] **B1** Typeahead Enter prefers exact lemma when no Arrow highlight
  - Quoted: `✓ resolveTypeaheadEnterSelection > Enter with no highlight prefers the exact typed lemma`
- [x] **B2** Missing lemma shows bilingual “Word not found / Слово не знайдено”; search-index preflight skips `/atlas/current.json`
  - Quoted: `✓ WordAtlasClientShell > not_found via search-index preflight never requests current.json`
- [x] **B3** Skip-to-content only on `:focus-visible`
  - Quoted: `✓ skip-link focus-visible dismissal > course.css hides skip link except on :focus-visible`
- [x] **B4** Synonyms / Heritage empty states dual when locale=en (via A1 flag)
  - Quoted: `✓ heritage empty state is dual-language when chrome locale is en`
  - Quoted: `✓ synonyms empty catch-all is dual-language when chrome locale is en`
- [x] **B5** Cloze placeholder shortened + bilingual
  - Quoted: `✓ cloze placeholder is short and bilingual when chrome locale is en`
- [x] **B6** Alphabet strip hides И/Ь (zero entries) + explanation line
  - Quoted: `✓ AtlasFullIndex hides zero-count letters and uses 2.75rem targets`

### C. Minors (P2)

- [x] **C1** Escape closes listbox first, clears on second
  - Quoted: `✓ first Escape closes an open listbox` / `✓ second Escape clears the input when the listbox is closed`
- [x] **C2** `target="_blank"` atlas links `aria-label` includes `(нова вкладка)`
  - Quoted: `✓ atlas links announce нова вкладка for screen readers`
- [x] **C3** Runtime bytes use `МБ` / `MB` via locale spans
- [x] **C4** Letter buttons ≥ `2.75rem` (44px)

### D. Rejected

- Skipped per Sol approval / spec table.

## Verification

```text
cd site && npx vitest run
# Test Files  48 passed (48)
# Tests  716 passed | 4 skipped (720)

cd site && npm run build
# [build] 8973 page(s) built … Complete!

# Focused K3 suites also green:
# Test Files  4 passed (4) / Tests  84 passed (84)
# atlas-typeahead-keys + k3-chrome-locale: 11 passed
```

No Python touched → ruff N/A.

## Not verified (live deploy = later)

- Live GH Pages walkthrough of locale toggle / typeahead Enter / skip-link after keyboard practice
- Visual QA of 44px letter targets in a real browser box model
- Production `/atlas/current.json` availability for known tail lemmas (preflight only short-circuits when search-index loads)

## Test plan

- [ ] Toggle `#lu-locale-toggle` on `/lexicon/` and `/words-of-the-day/practice/` — EN shows dual chrome; UK Ukrainian-only
- [ ] Type `вода` → Enter → `/lexicon/вода/`; Escape once keeps query / closes list
- [ ] Open unknown `/lexicon/неіснуючесловоxyzqqq/` → bilingual not-found, no stuck “Loading…”
- [ ] Browse alphabet: no И/Ь; letter buttons ≥ 44px
- [ ] Practice cloze placeholder fully readable; blank Atlas links announce нова вкладка


Made with [Cursor](https://cursor.com)