### PR TITLE
fix(practice): owner UX orders — full-switch locale, selected states, one-line form, no auto-advance

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 6de3f1336ed9e701a8dea2cf29b30b76d8aa625cc617860935af593f53fe0532
+  components_sha256: 54959816e895db8c8db437bf803695f507b33f81df7a270018a4ea802e160ee2
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1104,10 +1104,6 @@ components:
       - name: autoStart
         type: boolean
         description: autoStart prop.
-        ukrainian_text: 'false'
-      - name: advanceDelayMs
-        type: number
-        description: advanceDelayMs prop.
         ukrainian_text: 'false'
     nested_types: {}
     example: {}

--- a/packages/activity-kit/src/components/MatchUp.tsx
+++ b/packages/activity-kit/src/components/MatchUp.tsx
@@ -161,6 +161,7 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, o
               data-matched={matched.has(index) ? 'true' : 'false'}
               data-pair-color={matched.has(index) ? index % MATCH_PAIR_COLOR_COUNT : undefined}
               data-selected={selectedLeft === index ? 'true' : 'false'}
+              aria-pressed={selectedLeft === index}
               style={getMatchedPairStyle(index, matched.has(index))}
               onClick={() => handleLeftClick(index)}
               disabled={matched.has(index)}

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -76,7 +76,6 @@ interface LexiconPracticeProps {
   initialDeck?: PracticeDeckData | PracticeLexeme[];
   initialMode?: PracticeModeFilter;
   autoStart?: boolean;
-  advanceDelayMs?: number;
 }
 
 interface StreakState {
@@ -1096,7 +1095,6 @@ function LexiconPracticeIsland({
   initialDeck,
   initialMode = 'mixed',
   autoStart = false,
-  advanceDelayMs = 650,
 }: LexiconPracticeProps) {
   const [deck, setDeck] = useState<PracticeDeckData | null>(() => normalizeInitialDeck(initialDeck));
   const [clozeLoaded, setClozeLoaded] = useState(() => {
@@ -1134,9 +1132,8 @@ function LexiconPracticeIsland({
   const [revision, setRevision] = useState(0);
   const [history, setHistory] = useState<SelectionHistoryItem[]>([]);
   const [answerLocked, setAnswerLocked] = useState(false);
-  // A WRONG answer parks its scored outcome here instead of auto-advancing, so the
-  // feedback panel (e.g. the §9.5 cited calque correction) dwells until the learner
-  // explicitly moves on via «Далі →» or Enter. Correct answers never set this.
+  // After ANY answer (correct or wrong), park the scored outcome here instead of
+  // auto-advancing so the learner explicitly continues via «Далі →» or Enter.
   const [pendingOutcome, setPendingOutcome] = useState<CompletionOutcome | null>(null);
   const [streak, setStreak] = useState<StreakState>({
     version: 1,
@@ -1160,14 +1157,11 @@ function LexiconPracticeIsland({
   const deckRequestId = useRef(0);
   const sessionStartedAtRef = useRef(Date.now());
   const didInitRef = useRef(false);
-  // Consumption source of truth for the parked wrong-answer outcome. `advancePending`
+  // Consumption source of truth for the parked answer outcome. `advancePending`
   // claims it via this ref (not the closed-over `pendingOutcome` state) so a rapid
   // double-advance (double-Enter, or Enter+click) before React re-renders resolves to
   // exactly ONE `completeSelection` — the second call reads a null ref and no-ops.
   const pendingOutcomeRef = useRef<CompletionOutcome | null>(null);
-  // Correct-answer auto-advance timer — cleared on exit/unmount so a late fire cannot
-  // mutate state after «← Додому» (or remount) and bounce the learner into the summary.
-  const advanceTimerRef = useRef<number | null>(null);
   const advanceButtonRef = useRef<HTMLButtonElement | null>(null);
   // Selection ref used to stabilize the in-flight item across live deck merges (pool growth from
   // background lower-level shards). While history length is unchanged we keep returning the
@@ -1485,7 +1479,7 @@ function LexiconPracticeIsland({
     }
   }, [pairs, selection, sessionCompleted]);
 
-  // While a wrong answer dwells, Enter is a second way to advance (alongside the
+  // While an answer dwells, Enter is a second way to advance (alongside the
   // «Далі →» button) — the disabled option buttons blur to <body>, so we listen at
   // the window level rather than on the stage. Bail when focus is already on an
   // interactive control (Atlas links, «← Додому», the «Далі →» button itself).
@@ -1502,7 +1496,7 @@ function LexiconPracticeIsland({
     return () => window.removeEventListener('keydown', handleEnter);
   }, [pendingOutcome, selection]);
 
-  // Wrong-answer dwell: move focus to «Далі →» so keyboard/SR users keep their place
+  // Answer dwell: move focus to «Далі →» so keyboard/SR users keep their place
   // after the clicked (now-disabled) option blurs to <body>.
   useEffect(() => {
     if (!pendingOutcome) return;
@@ -1517,15 +1511,6 @@ function LexiconPracticeIsland({
       document.title = previousTitle;
     };
   }, [mode, sessionPhase]);
-
-  useEffect(() => {
-    return () => {
-      if (advanceTimerRef.current != null) {
-        window.clearTimeout(advanceTimerRef.current);
-        advanceTimerRef.current = null;
-      }
-    };
-  }, []);
 
   async function ensureDeck(
     includeCloze = shouldLoadCloze(mode),
@@ -2105,7 +2090,7 @@ function LexiconPracticeIsland({
     completeSelection(current, outcome);
   }
 
-  /** Complete the parked (wrong-answer) selection once the learner chooses to advance. */
+  /** Complete the parked selection once the learner chooses to advance. */
   function advancePending() {
     // Claim the outcome via the ref FIRST so a second synchronous invocation (a rapid
     // double-Enter, or Enter racing a «Далі» click) reads null and no-ops — the closed-over
@@ -2134,20 +2119,7 @@ function LexiconPracticeIsland({
       uk: option.correct ? `${selection.lemma.lemma}: Правильно` : `${selection.lemma.lemma}: Ще раз`,
       en: option.correct ? `${selection.lemma.lemma}: Correct` : `${selection.lemma.lemma}: Again`,
     });
-    if (option.correct) {
-      if (advanceTimerRef.current != null) {
-        window.clearTimeout(advanceTimerRef.current);
-      }
-      advanceTimerRef.current = window.setTimeout(() => {
-        advanceTimerRef.current = null;
-        setAnswerLocked(false);
-        completeSelection(selection, outcome);
-      }, advanceDelayMs);
-      return;
-    }
-    // WRONG answer: dwell so the cited correction stays readable; the learner
-    // advances explicitly via «Далі →» / Enter (see advancePending). The ref mirrors
-    // the state so advancePending can claim the outcome race-free.
+    // Correct and wrong both dwell — never auto-advance; learner continues via «Далі →» / Enter.
     pendingOutcomeRef.current = outcome;
     setPendingOutcome(outcome);
   }
@@ -2170,14 +2142,8 @@ function LexiconPracticeIsland({
         textEn: `✓ ${cloze.form} (${translateGrammarTerm(cloze.caseRule.caseLabel)})`,
       });
       setAnswerLocked(true);
-      if (advanceTimerRef.current != null) {
-        window.clearTimeout(advanceTimerRef.current);
-      }
-      advanceTimerRef.current = window.setTimeout(() => {
-        advanceTimerRef.current = null;
-        setAnswerLocked(false);
-        completeSelection(selection, outcome);
-      }, advanceDelayMs);
+      pendingOutcomeRef.current = outcome;
+      setPendingOutcome(outcome);
       return;
     }
 
@@ -2275,10 +2241,6 @@ function LexiconPracticeIsland({
   };
 
   function finishPractice() {
-    if (advanceTimerRef.current != null) {
-      window.clearTimeout(advanceTimerRef.current);
-      advanceTimerRef.current = null;
-    }
     setSessionPhase('idle');
     setFocusWeakness(null);
     setHistory([]);
@@ -2472,12 +2434,13 @@ function LexiconPracticeIsland({
                   type="button"
                   className={sessionBudget === budget ? 'active' : ''}
                   aria-pressed={sessionBudget === budget}
+                  data-testid={`practice-session-budget-${budget === 'until-zero' ? 'until-zero' : budget}`}
                   aria-label={
                     budget === 10
-                      ? '10 карток на сесію'
+                      ? (showEnglishSubtitles ? '10 карток на сесію / 10 cards per session' : '10 карток на сесію')
                       : budget === 20
-                        ? '20 карток на сесію'
-                        : undefined
+                        ? (showEnglishSubtitles ? '20 карток на сесію / 20 cards per session' : '20 карток на сесію')
+                        : (showEnglishSubtitles ? 'до нуля / Until clear' : 'до нуля')
                   }
                   onClick={() => setSessionBudget(budget)}
                 >
@@ -2966,18 +2929,31 @@ function PracticeItem({
           answerLocked={answerLocked}
           onChoice={onChoice}
         />
-        <p className="lexicon-choice-prompt mc-q">
-          <span lang="uk">{drillPrompt.promptUk}</span>
+        <p className="lexicon-choice-prompt mc-q" data-testid="practice-form-prompt">
+          <span lang="uk">
+            {drillPrompt.promptUk}
+            {drillPrompt.subtitleUk ? (
+              <>
+                {' '}
+                <span className="mc-descriptor">— {drillPrompt.subtitleUk}</span>
+              </>
+            ) : null}
+          </span>
           {showEnglishSubtitles ? (
-            <span className="btn-sub" lang="en" style={{ display: 'block', fontSize: '0.85em', fontWeight: 'normal', color: 'var(--lu-text-muted)', marginTop: '0.25rem' }}>
+            <span
+              className="btn-sub"
+              lang="en"
+              style={{
+                display: 'inline',
+                fontSize: '0.85em',
+                fontWeight: 'normal',
+                color: 'var(--lu-text-muted)',
+              }}
+            >
+              {' '}
               / {drillPrompt.promptEn}
+              {drillPrompt.subtitleEn ? ` — ${drillPrompt.subtitleEn}` : ''}
             </span>
-          ) : null}
-        </p>
-        <p className="mc-sub">
-          <span lang="uk">{drillPrompt.subtitleUk}</span>
-          {showEnglishSubtitles && drillPrompt.subtitleEn ? (
-            <span className="btn-sub" lang="en">/ {drillPrompt.subtitleEn}</span>
           ) : null}
         </p>
         <ul className="lexicon-option-list mc-options">

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -20,18 +20,18 @@ const frontmatter = {
     <section class="lexicon-practice-intro" aria-labelledby="lexicon-practice-page-title">
       <a class="lexicon-practice-back" href="/words-of-the-day/">
         <span class="lu-i18n">
-          <span data-loc="en">← Слова дня / Words of the Day</span>
+          <span data-loc="en">← Words of the Day</span>
           <span data-loc="uk">← Слова дня</span>
         </span>
       </a>
       <span class="lexicon-practice-badge">
         <span class="lu-i18n">
-          <span data-loc="en">СЛОВА ДНЯ · ПРАКТИКА / WORDS OF THE DAY · PRACTICE</span>
+          <span data-loc="en">WORDS OF THE DAY · PRACTICE</span>
           <span data-loc="uk">СЛОВА ДНЯ · ПРАКТИКА</span>
         </span>
       </span>
       <h1 id="lexicon-practice-page-title" class="lu-i18n-block">
-        <span data-loc="en">Практика / Practice</span>
+        <span data-loc="en">Practice</span>
         <span data-loc="uk">Практика</span>
       </h1>
       <p>
@@ -186,10 +186,18 @@ const frontmatter = {
   }
 
   :global(.lexicon-practice-modes button.active),
-  :global(.lexicon-practice-levels-row button.active) {
+  :global(.lexicon-practice-levels-row button.active),
+  :global(.lexicon-session-budgets button.active) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
     color: var(--lu-on-primary);
+  }
+
+  /* Selection fills the control; focus ring must stay distinct from that fill. */
+  :global(.lexicon-session-budgets button.active:focus-visible) {
+    outline: 2px solid var(--lu-text);
+    outline-offset: 3px;
+    box-shadow: 0 0 0 3px var(--lu-state-active);
   }
 
   :global(.lexicon-practice-progress) {
@@ -900,6 +908,12 @@ const frontmatter = {
     font-weight: 900;
   }
 
+  /* Form/drill prompt: question + grammatical descriptor in one text flow. */
+  :global(.mc-q .mc-descriptor) {
+    font-weight: 700;
+    color: var(--lu-text-muted);
+  }
+
   :global(.mc-sub) {
     margin: 0 0 0.3rem;
     color: var(--lu-text-muted);
@@ -1089,10 +1103,12 @@ const frontmatter = {
     font-weight: 900;
   }
 
-  :global(.lexicon-practice-stage [data-selected="true"]) {
+  :global(.lexicon-practice-stage [data-selected="true"]),
+  :global(.lexicon-practice-stage .matchItem.selected) {
     border-color: var(--lu-primary);
-    background: var(--lu-state-active);
-    box-shadow: 0 0 0 2px var(--lu-state-active);
+    background: var(--lu-primary);
+    color: var(--lu-on-primary);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--lu-primary) 35%, transparent);
   }
 
   :global(.lexicon-practice-stage [data-matched="true"]) {

--- a/site/src/styles/match-up.css
+++ b/site/src/styles/match-up.css
@@ -40,8 +40,10 @@
 }
 
 .matchItem.selected {
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 0 0 2px var(--lu-state-active);
+  border-color: var(--lu-primary, var(--ifm-color-primary));
+  background: var(--lu-primary, var(--ifm-color-primary));
+  color: var(--lu-on-primary, #fff);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--lu-primary, var(--ifm-color-primary)) 35%, transparent);
 }
 
 .matchItem.matched {
@@ -108,9 +110,14 @@
 }
 
 /* Dark Mode Overrides */
-[data-theme='dark'] .matchColumn:first-child .matchItem,
-[data-theme='dark'] .matchItem.selected {
+[data-theme='dark'] .matchColumn:first-child .matchItem {
   background: var(--lu-state-active);
+}
+
+[data-theme='dark'] .matchItem.selected {
+  border-color: var(--lu-primary, var(--ifm-color-primary));
+  background: var(--lu-primary, var(--ifm-color-primary));
+  color: var(--lu-on-primary, #fff);
 }
 
 [data-theme='dark'] .matchColumn:last-child .matchItem {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -673,7 +673,7 @@ describe('LexiconPractice', () => {
         initialDeck={heritageDeck()}
         autoStart
         initialMode="mixed"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -682,7 +682,7 @@ describe('LexiconPractice', () => {
     expect(screen.getByText(/Я бачу/)).toBeInTheDocument();
 
     mixedRender.unmount();
-    const { container } = render(<LexiconPractice initialDeck={heritageDeck()} advanceDelayMs={10_000} />);
+    const { container } = render(<LexiconPractice initialDeck={heritageDeck()} />);
     expect(screen.getByText('Спадщина')).toBeInTheDocument();
 
     await user.click(container.querySelector<HTMLButtonElement>('[data-mode="heritage"]')!);
@@ -697,7 +697,7 @@ describe('LexiconPractice', () => {
         initialDeck={heritageDeck()}
         autoStart
         initialMode="heritage"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -725,7 +725,7 @@ describe('LexiconPractice', () => {
         initialDeck={heritageDeck()}
         autoStart
         initialMode="heritage"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -754,7 +754,7 @@ describe('LexiconPractice', () => {
         initialDeck={heritageDeck()}
         autoStart
         initialMode="heritage"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -796,7 +796,7 @@ describe('LexiconPractice', () => {
         initialDeck={deckWithRationale}
         autoStart
         initialMode="heritage"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -823,7 +823,7 @@ describe('LexiconPractice', () => {
         initialDeck={deckWithoutRationale}
         autoStart
         initialMode="heritage"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -843,7 +843,7 @@ describe('LexiconPractice', () => {
         initialDeck={heritageDeck()}
         autoStart
         initialMode="heritage"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -918,7 +918,7 @@ describe('LexiconPractice', () => {
         initialDeck={paronymDeck()}
         autoStart
         initialMode="mixed"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -927,7 +927,7 @@ describe('LexiconPractice', () => {
     expect(screen.getByText(/Вранці він/)).toBeInTheDocument();
 
     mixedRender.unmount();
-    const { container } = render(<LexiconPractice initialDeck={paronymDeck()} advanceDelayMs={10_000} />);
+    const { container } = render(<LexiconPractice initialDeck={paronymDeck()} />);
     expect(screen.getByText('Пароніми')).toBeInTheDocument();
 
     await user.click(container.querySelector<HTMLButtonElement>('[data-mode="paronym"]')!);
@@ -942,7 +942,7 @@ describe('LexiconPractice', () => {
         initialDeck={paronymDeck()}
         autoStart
         initialMode="paronym"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -969,7 +969,7 @@ describe('LexiconPractice', () => {
         initialDeck={paronymDeck()}
         autoStart
         initialMode="paronym"
-        advanceDelayMs={10_000}
+
       />,
     );
 
@@ -1415,9 +1415,8 @@ describe('LexiconPractice', () => {
     expect(good?.textContent).toMatch(/‹.+›/);
   });
 
-  test('wrong answer dwells: feedback stays and it never auto-advances past 650ms', async () => {
+  test('wrong answer dwells: feedback stays and never auto-advances', async () => {
     const user = userEvent.setup();
-    // Default 650ms auto-advance window; a wrong answer must ignore it entirely.
     render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" />);
 
     await user.click(
@@ -1428,7 +1427,7 @@ describe('LexiconPractice', () => {
     expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
     expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('калька');
 
-    // Wait well past the 650ms correct-answer window — the item must still be here.
+    // Wait — the item must still be here with no timer-driven advance.
     await new Promise((resolve) => setTimeout(resolve, 750));
     expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
     expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('калька');
@@ -1437,7 +1436,7 @@ describe('LexiconPractice', () => {
   test('wrong answer advances on «Далі» click and on Enter', async () => {
     const clickUser = userEvent.setup();
     const clicked = render(
-      <LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />,
+      <LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" />,
     );
     await clickUser.click(
       within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дом/ }),
@@ -1451,7 +1450,7 @@ describe('LexiconPractice', () => {
 
     const enterUser = userEvent.setup();
     render(
-      <LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />,
+      <LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" />,
     );
     await enterUser.click(
       within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дом/ }),
@@ -1463,19 +1462,25 @@ describe('LexiconPractice', () => {
     );
   });
 
-  test('correct answer still auto-advances (never enters dwell)', async () => {
+  test('correct answer never auto-advances: next card waits for «Далі»', async () => {
     const user = userEvent.setup();
-    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />);
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" />);
 
     await user.click(
       within(screen.getByTestId('practice-heritage')).getByRole('button', { name: 'дім' }),
     );
 
-    // Correct answers keep the snappy auto-advance: no dwell control ever appears.
-    expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument();
+    // Correct answers dwell identically to wrong ones — «Далі →» is required.
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
     expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('Правильно');
+    expect(document.activeElement).toBe(screen.getByTestId('practice-advance-button'));
 
-    // The snappy timer fires and moves off the item on its own — no «Далі» needed.
+    // Still on the same card after a dwell window — no timer advance.
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('Правильно');
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('practice-advance-button'));
     await waitFor(() =>
       expect(screen.queryByTestId('practice-heritage-feedback')).not.toBeInTheDocument(),
     );
@@ -1483,8 +1488,7 @@ describe('LexiconPractice', () => {
 
   test('heritage calque citation stays visible until «Далі»', async () => {
     const user = userEvent.setup();
-    // Tiny auto-advance window — the cited correction must still outlast it.
-    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />);
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" />);
 
     await user.click(
       within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дом/ }),
@@ -1494,7 +1498,6 @@ describe('LexiconPractice', () => {
       'Джерело: Антоненко-Давидович: fixture',
     );
 
-    // The cited §9.5 correction is the teaching moment — the 20ms timer must not erase it.
     await new Promise((resolve) => setTimeout(resolve, 200));
     expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent(
       'Джерело: Антоненко-Давидович: fixture',
@@ -1506,10 +1509,9 @@ describe('LexiconPractice', () => {
     );
   });
 
-  test('cloze wrong chip dwells (no auto-advance past 650ms) and «Далі» resets to a clean item', async () => {
+  test('cloze wrong chip dwells (no auto-advance) and «Далі» resets to a clean item', async () => {
     seedRecognitionMastery('knyha');
     const user = userEvent.setup();
-    // Default 650ms auto-advance window; a wrong chip pick must ignore it entirely.
     render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="cloze" />);
 
     expect(screen.getByTestId('practice-cloze')).toBeInTheDocument();
@@ -1520,7 +1522,6 @@ describe('LexiconPractice', () => {
     expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
     expect(screen.getByText('✗ Не те слово')).toBeInTheDocument();
 
-    // Wait well past the 650ms correct-answer window — the wrong chip must still dwell.
     await new Promise((resolve) => setTimeout(resolve, 750));
     expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
     expect(screen.getByText('✗ Не те слово')).toBeInTheDocument();
@@ -1536,6 +1537,97 @@ describe('LexiconPractice', () => {
     expect(screen.getByLabelText(/Відповідь у знахідному відмінку/)).toHaveValue('');
     expect(screen.getByRole('button', { name: 'книгу' })).not.toBeDisabled();
     expect(screen.queryByText('✗ Не те слово')).not.toBeInTheDocument();
+  });
+
+  test('cloze correct answer also requires «Далі» before the next card', async () => {
+    seedRecognitionMastery('knyha');
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="cloze" />);
+
+    await user.click(screen.getByRole('button', { name: 'книгу' }));
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('книгу');
+
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    expect(screen.getByTestId('practice-cloze')).toBeInTheDocument();
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('practice-advance-button'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument(),
+    );
+  });
+
+  test('session-size buttons expose aria-pressed and active class for the selection', async () => {
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={sampleDeck()} />);
+
+    const twenty = screen.getByTestId('practice-session-budget-20');
+    const ten = screen.getByTestId('practice-session-budget-10');
+    expect(twenty).toHaveAttribute('aria-pressed', 'true');
+    expect(twenty).toHaveClass('active');
+    expect(ten).toHaveAttribute('aria-pressed', 'false');
+    expect(ten).not.toHaveClass('active');
+
+    await user.click(ten);
+    expect(ten).toHaveAttribute('aria-pressed', 'true');
+    expect(ten).toHaveClass('active');
+    expect(twenty).toHaveAttribute('aria-pressed', 'false');
+    expect(twenty).not.toHaveClass('active');
+  });
+
+  test('paradigm form question renders prompt + descriptor on one line', () => {
+    const entry = lexeme('semantyka', 'семантика', 'semantics', {
+      nominative: 'семантика',
+      accusative: 'семантику',
+      locative: 'семантиці',
+    });
+    const deck: PracticeDeckData = {
+      deckVersion: 'test-paradigm-oneline',
+      level: 'A1',
+      lexemes: [entry],
+      index: [
+        {
+          lemmaId: entry.lemmaId,
+          lemma: entry.lemma,
+          cefr: 'A1',
+          modes: ['paradigm'],
+          hasCloze: false,
+          clozeIds: [],
+          newOrder: 0,
+        },
+      ],
+      cloze: [],
+      paradigm: [
+        {
+          paradigmId: 'semantyka:paradigm:1',
+          lemmaId: 'semantyka',
+          lemma: 'семантика',
+          slot: {
+            case: 'орудний',
+            number: 'singular',
+            labelUk: 'орудний відмінок, однина',
+            labelEn: 'instrumental case, singular',
+          },
+          form: 'семантикою',
+          options: [
+            { label: 'семантикою', kind: 'answer' },
+            { label: 'семантика', kind: 'same-paradigm' },
+            { label: 'семантиці', kind: 'same-paradigm' },
+            { label: 'семантику', kind: 'same-paradigm' },
+          ],
+        },
+      ],
+    };
+
+    render(<LexiconPractice initialDeck={deck} autoStart initialMode="paradigm" />);
+    const prompt = screen.getByTestId('practice-form-prompt');
+    expect(prompt).toHaveTextContent('Яка форма від «семантика»?');
+    expect(prompt).toHaveTextContent('— орудний відмінок, однина');
+    // One text-flow node — not a stacked mc-q + mc-sub pair.
+    expect(prompt.querySelectorAll('p')).toHaveLength(0);
+    expect(screen.queryByText('орудний відмінок, однина', { selector: '.mc-sub' })).not.toBeInTheDocument();
+    expect(prompt).toMatchSnapshot();
   });
 
   test('weak-area chips: renders a UA case chip from a weak review log', async () => {
@@ -1674,7 +1766,7 @@ describe('LexiconPractice', () => {
     const { fn } = mockShardFetch({});
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
     const user = userEvent.setup();
-    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />);
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" />);
 
     // Wrong (calque) pick parks in a dwell state with an explicit advance control.
     await user.click(

--- a/site/tests/unit/MatchUp.test.tsx
+++ b/site/tests/unit/MatchUp.test.tsx
@@ -138,10 +138,34 @@ describe('MatchUp', () => {
 
     await user.click(leftTiles(container)[0]);
     expect(leftTiles(container)[0].getAttribute('data-selected')).toBe('true');
+    expect(leftTiles(container)[0]).toHaveAttribute('aria-pressed', 'true');
+    expect(leftTiles(container)[0]).toHaveClass('selected');
 
     await user.click(leftTiles(container)[1]);
     expect(leftTiles(container)[0].getAttribute('data-selected')).toBe('false');
+    expect(leftTiles(container)[0]).toHaveAttribute('aria-pressed', 'false');
+    expect(leftTiles(container)[0]).not.toHaveClass('selected');
     expect(leftTiles(container)[1].getAttribute('data-selected')).toBe('true');
+    expect(leftTiles(container)[1]).toHaveAttribute('aria-pressed', 'true');
+    expect(leftTiles(container)[1]).toHaveClass('selected');
+  });
+
+  test('selected left tile stays visibly marked until its pair is chosen', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<MatchUp pairs={pairs} />);
+
+    await user.click(leftTiles(container)[0]);
+    const selected = leftTiles(container)[0];
+    expect(selected).toHaveClass('selected');
+    expect(selected).toHaveAttribute('aria-pressed', 'true');
+    expect(selected).toHaveAttribute('data-selected', 'true');
+
+    // Still selected before the right tile is chosen.
+    expect(leftTiles(container)[0]).toHaveClass('selected');
+
+    await user.click(findRightByText(container, 'Meow'));
+    expect(leftTiles(container)[0]).not.toHaveClass('selected');
+    expect(leftTiles(container)[0]).toHaveAttribute('aria-pressed', 'false');
   });
 
   test('clicking a right tile without a left selection is a no-op', async () => {

--- a/site/tests/unit/__snapshots__/LexiconPractice.test.tsx.snap
+++ b/site/tests/unit/__snapshots__/LexiconPractice.test.tsx.snap
@@ -1,0 +1,31 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`LexiconPractice > paradigm form question renders prompt + descriptor on one line 1`] = `
+<p
+  class="lexicon-choice-prompt mc-q"
+  data-testid="practice-form-prompt"
+>
+  <span
+    lang="uk"
+  >
+    Яка форма від «семантика»?
+     
+    <span
+      class="mc-descriptor"
+    >
+      — 
+      орудний відмінок, однина
+    </span>
+  </span>
+  <span
+    class="btn-sub"
+    lang="en"
+    style="display: inline; font-size: 0.85em; font-weight: normal; color: var(--lu-text-muted);"
+  >
+     
+    / 
+    Which form is from «семантика»?
+     — instrumental case, singular
+  </span>
+</p>
+`;


### PR DESCRIPTION
## Summary

Owner-ordered practice-hub UX fixes (2026-07-17). Surfaces: `/words-of-the-day/practice/` + MatchUp pairing.

### Per-item checklist

- [x] **(1) LOCALE = FULL SWITCH** — stripped stuffed bilingual strings from `data-loc=en` in `practice.astro` (`← Words of the Day`, `WORDS OF THE DAY · PRACTICE`, `Practice`). Existing `.lu-i18n` CSS full-switch mechanism unchanged.
- [x] **(2) SESSION-SIZE BUTTONS** — size choices keep `aria-pressed`; `.lexicon-session-budgets button.active` now fills with primary background; focus ring remains distinct from selection.
- [x] **(3) ONE-LINE QUESTION** — paradigm/form prompt + grammatical descriptor render in one text flow (`Яка форма…? — орудний відмінок, однина`); natural wrap OK, no stacked `mc-q`/`mc-sub` blocks.
- [x] **(4) NEVER AUTO-ADVANCE** — removed correct-answer `setTimeout` auto-advance in `LexiconPractice.tsx`; correct and wrong both park on «Далі →» with focus moved to that control. No auto-advance path in `PracticeFlashcard.tsx`.
- [x] **(5) PAIRING SELECTED STATE** — MatchUp left tile exposes `aria-pressed` + stronger filled selected styling until the pair is chosen.

Does not touch exercise content, A1 scaffolding logic, or the locale switching mechanism beyond item 1.

Refs #5355

## Test plan

- [x] `cd site && npx vitest run` — full suite green
- [x] Critical: correct answer does **not** advance until «Далі» is activated
- [x] Session-size `aria-pressed` / `.active` assertions
- [x] MatchUp selected `aria-pressed` / `.selected` assertions
- [x] One-line form prompt structure + snapshot

### Quoted vitest output

```
 Test Files  48 passed (48)
      Tests  720 passed | 4 skipped (724)
   Start at  14:27:19
   Duration  155.52s (transform 12.89s, setup 1.38s, import 44.56s, tests 100.55s, environment 5.18s)
```


Made with [Cursor](https://cursor.com)