### PR TITLE
fix(review): preserve fail-closed alignment scores

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,6 +1,6 @@
-review_protocol_version: 6.0.1
+review_protocol_version: 6.0.2
 deterministic_contract_version: 2.0.0
-semantic_prompt_version: 6.0.2
+semantic_prompt_version: 6.0.3
 track_policy_version: 2.0.0
 
 score_calibration:

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Common semantic post-build review prompt
 
-Semantic prompt version: `6.0.2`
+Semantic prompt version: `6.0.3`
 
 ## Machine-response contract — read before any source or tool call
 
@@ -25,8 +25,11 @@ Classify each statement as `claims` with all of its atomic claim IDs or as
 `source_attribution` is schema-bound to `claims` and cannot be dismissed. Every
 claim-ledger entry must name its owning `unit_id` and use that unit's exact
 packet location. Its `claim` text must be a verbatim contiguous substring of
-that unit after whitespace normalization; never replace the learner's words
-with a safer paraphrase. For a `universal_quantifier` unit, at least one owned
+that unit after whitespace normalization; copy the packet glyphs exactly when
+possible. The finalizer treats only `'`, `’`, and `ʼ` as equivalent Ukrainian
+apostrophe glyphs; it does not normalize any other punctuation or wording.
+Never replace the learner's words with a safer paraphrase. For a
+`universal_quantifier` unit, at least one owned
 claim must reproduce the full statement as a coverage anchor; an atomic split
 may accompany it, but a weaker quantifier or bare token cannot replace it. The
 inventory is exhaustive coverage scaffolding, not a claim that every heading
@@ -175,6 +178,9 @@ class `CLEAR` only with exact cited evidence for the comparison, `FOUND` with
 every corresponding deterministic and semantic finding ID, or `INCOMPLETE`
 with an integrity finding. For mechanically supplied findings, reuse the exact
 IDs from the resolved context instead of emitting duplicate semantic findings.
+Every `FOUND` class must own only medium, high, or blocker findings and makes
+semantic `PASS` impossible; return `REVISE`, `BLOCK`, or `INCOMPLETE` as the
+evidence requires.
 After finalizing the finding objects, audit each `FOUND` class against its
 `finding_ids`. Except for `VOCABULARY_INTEGRATION`, include at least one
 alignment evidence entry at every owned finding object's exact primary location and line.
@@ -428,6 +434,12 @@ Both `surface` and `verification` must be copied byte-for-byte from the
 source-order lemma's packet-bound candidate list. A candidate proves
 morphology and occurrence, not meaningful pedagogy; you must still judge
 whether its cited use integrates the term.
+An `INTEGRATED` ledger item proves that one meaningful learner-facing use
+exists; it does not force the broader `VOCABULARY_INTEGRATION` audit to
+`CLEAR`. When every target term has such a use but cross-bundle substitution,
+weak reinforcement, or inconsistent terminology still creates a material
+defect, keep the affected ledger item `INTEGRATED` and set the alignment audit
+to `FOUND` with the exact finding and evidence.
 The source-order vocabulary ledger is the exhaustive proof of individual
 absences: the `VOCABULARY_INTEGRATION` alignment entry must reference every
 matching finding but may cite representative comparison lines instead of an

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Core semantic post-build review prompt
 
-Semantic prompt version: `6.0.2`
+Semantic prompt version: `6.0.3`
 
 Apply this only to A1-C2 core tracks, after the common prompt.
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Seminar semantic post-build review prompt
 
-Semantic prompt version: `6.0.2`
+Semantic prompt version: `6.0.3`
 
 Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
 after the common prompt.

--- a/agents_extensions/shared/skills/post-build-review/schema/review-result.v6.schema.json
+++ b/agents_extensions/shared/skills/post-build-review/schema/review-result.v6.schema.json
@@ -271,7 +271,7 @@
         "unit_id": {"$ref": "#/$defs/nonempty"},
         "claim": {
           "$ref": "#/$defs/nonempty",
-          "description": "A verbatim contiguous substring of the owning statement unit after whitespace normalization; universal-quantifier units also require one full-statement coverage claim."
+          "description": "A verbatim contiguous substring of the owning statement unit after whitespace normalization and equivalence of the Ukrainian apostrophe glyphs ', ’, and ʼ; universal-quantifier units also require one full-statement coverage claim."
         },
         "location": {"$ref": "#/$defs/nonempty"},
         "status": {"enum": ["supported", "contradicted", "imprecise", "unattested", "unverifiable"]},

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -752,15 +752,17 @@ INSTRUCTION_OPEN_RE = re.compile(
     r"(?:\b[А-Яа-яІіЇїЄєҐґ][а-яіїєґ'’\-]{2,}(?:йте|іть|жте|чте)\b|"
     r"^[а-яіїєґ'’\-]{3,}ти\b)"
 )
+UKRAINIAN_APOSTROPHE_TRANSLATION = str.maketrans({"'": "ʼ", "’": "ʼ"})
 
 
 def _normalized_claim_surface(text: str) -> str:
-    """Normalize only whitespace; semantic paraphrases remain distinguishable."""
-    return re.sub(r"\s+", " ", text).strip()
+    """Normalize whitespace and Ukrainian apostrophe glyphs, never wording."""
+    apostrophe_normalized = text.translate(UKRAINIAN_APOSTROPHE_TRANSLATION)
+    return re.sub(r"\s+", " ", apostrophe_normalized).strip()
 
 
 def _claim_surface_is_bound(claim: str, statement: str) -> bool:
-    """Return whether a claim is a verbatim contiguous statement substring."""
+    """Return whether a claim is a contiguous statement substring."""
     return _normalized_claim_surface(claim) in _normalized_claim_surface(statement)
 
 
@@ -2141,6 +2143,33 @@ def _normalize_alignment_audit(
     return normalized
 
 
+def _validate_found_alignment_disposition(
+    alignment_audit: Mapping[str, Mapping[str, Any]],
+    *,
+    verdict: str,
+    known_findings: Mapping[str, Mapping[str, Any]],
+) -> None:
+    """Keep every categorical FOUND audit material and non-PASS."""
+    for audit_class, entry in alignment_audit.items():
+        if entry["status"] != "FOUND":
+            continue
+        if verdict == "PASS":
+            raise ReviewProtocolError(
+                f"{audit_class} FOUND requires semantic REVISE, BLOCK, or INCOMPLETE"
+            )
+        nonmaterial = sorted(
+            finding_id
+            for finding_id in entry["finding_ids"]
+            if known_findings[finding_id].get("severity")
+            not in {"blocker", "high", "medium"}
+        )
+        if nonmaterial:
+            raise ReviewProtocolError(
+                f"{audit_class} FOUND requires medium-or-higher findings: "
+                + ", ".join(nonmaterial)
+            )
+
+
 def _normalize_vocabulary_coverage(
     raw_coverage: object,
     *,
@@ -2481,6 +2510,14 @@ def normalize_semantic_result(
         external_findings=alignment_findings,
         source_lookup=source_lookup,
     )
+    _validate_found_alignment_disposition(
+        alignment_audit,
+        verdict=verdict,
+        known_findings={
+            str(finding["id"]): finding
+            for finding in [*alignment_findings, *findings]
+        },
+    )
     vocabulary_coverage = _normalize_vocabulary_coverage(
         value["vocabulary_coverage"],
         expected_lemmas=expected_vocabulary_lemmas,
@@ -2500,11 +2537,10 @@ def normalize_semantic_result(
         raise ReviewProtocolError(
             "Missing vocabulary coverage requires VOCABULARY_INTEGRATION audit FOUND"
         )
-    coverage_complete = bool(vocabulary_statuses) and vocabulary_statuses <= {"INTEGRATED"}
     empty_not_incomplete = not vocabulary_statuses and verdict != "INCOMPLETE"
-    if (coverage_complete or empty_not_incomplete) and vocabulary_audit["status"] != "CLEAR":
+    if empty_not_incomplete and vocabulary_audit["status"] != "CLEAR":
         raise ReviewProtocolError(
-            "Fully integrated vocabulary coverage requires VOCABULARY_INTEGRATION audit CLEAR"
+            "Empty vocabulary coverage requires VOCABULARY_INTEGRATION audit CLEAR"
         )
 
     coverage = value["claim_coverage"]
@@ -3018,7 +3054,16 @@ def combine_disposition(
     )
     if deterministic_high:
         return {"status": "BLOCK", "reasons": ["high-severity mechanical finding is unresolved"]}
-    if semantic["verdict"] == "REVISE" or severities.intersection({"high", "medium"}):
+    found_alignment = any(
+        entry.get("status") == "FOUND"
+        for entry in semantic.get("alignment_audit", {}).values()
+        if isinstance(entry, Mapping)
+    )
+    if (
+        semantic["verdict"] == "REVISE"
+        or severities.intersection({"high", "medium"})
+        or found_alignment
+    ):
         return {"status": "REVISE", "reasons": ["actionable finding is unresolved"]}
     if "MISSING" in vocabulary_statuses:
         return {"status": "REVISE", "reasons": ["vocabulary integration is incomplete"]}
@@ -3163,6 +3208,11 @@ def _validate_normalized_alignment_vocabulary(
                 f"Alignment audit {audit_class} INCOMPLETE requires a finding and semantic INCOMPLETE"
             )
 
+    _validate_found_alignment_disposition(
+        alignment,
+        verdict=str(semantic["verdict"]),
+        known_findings=known,
+    )
     findings_by_id = {
         str(finding["id"]): finding for finding in semantic_findings
     }
@@ -3216,11 +3266,10 @@ def _validate_normalized_alignment_vocabulary(
         raise ReviewProtocolError(
             "Missing vocabulary coverage requires VOCABULARY_INTEGRATION audit FOUND"
         )
-    coverage_complete = bool(vocabulary_statuses) and vocabulary_statuses <= {"INTEGRATED"}
     empty_not_incomplete = not vocabulary_statuses and semantic["verdict"] != "INCOMPLETE"
-    if (coverage_complete or empty_not_incomplete) and vocabulary_audit["status"] != "CLEAR":
+    if empty_not_incomplete and vocabulary_audit["status"] != "CLEAR":
         raise ReviewProtocolError(
-            "Fully integrated vocabulary coverage requires VOCABULARY_INTEGRATION audit CLEAR"
+            "Empty vocabulary coverage requires VOCABULARY_INTEGRATION audit CLEAR"
         )
 
 

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -1499,6 +1499,31 @@ def test_risk_claim_surface_substitution_fails_closed(
     assert result["combined_disposition"]["status"] == "INCOMPLETE"
 
 
+@pytest.mark.parametrize("provider_apostrophe", ["'", "’", "ʼ"])
+def test_claim_surface_accepts_ukrainian_apostrophe_glyph_equivalence(
+    provider_apostrophe: str,
+) -> None:
+    statement = "Київ стає місцем освіти та літературної кар’єри."
+    claim = f"місцем освіти та літературної кар{provider_apostrophe}єри"
+
+    assert pbr._claim_surface_is_bound(claim, statement) is True
+
+
+@pytest.mark.parametrize(
+    "claim",
+    [
+        "місцем освіти та успішної літературної кар'єри",
+        "місцем освіти та літературної кар’єри!",
+        "місцем навчання та літературної кар'єри",
+        "місцем освіти та літературної кар`єри",
+    ],
+)
+def test_claim_surface_rejects_non_apostrophe_drift(claim: str) -> None:
+    statement = "Київ стає місцем освіти та літературної кар’єри."
+
+    assert pbr._claim_surface_is_bound(claim, statement) is False
+
+
 @pytest.mark.parametrize(
     ("statement", "substituted_claim"),
     [
@@ -2830,8 +2855,189 @@ def test_finalize_accepts_representative_multi_missing_alignment_evidence(
     pbr.validate_result(result)
 
 
+def _single_integrated_vocabulary_semantic(
+    packet: dict,
+    *,
+    severity: str,
+    verdict: str,
+) -> tuple[dict, dict]:
+    semantic = _passing_semantic(packet)
+    coverage = copy.deepcopy(
+        next(
+            item
+            for item in semantic["vocabulary_coverage"]
+            if item["status"] == "INTEGRATED"
+        )
+    )
+    semantic["vocabulary_coverage"] = [coverage]
+    semantic["findings"] = [
+        finding
+        for finding in semantic["findings"]
+        if finding.get("issue_id") != "VOCABULARY_INTEGRATION"
+    ]
+    finding_id = "fixture-vocabulary-substitution"
+    location = coverage["evidence"][0]
+    semantic["findings"].append({
+        "id": finding_id,
+        "issue_id": "VOCABULARY_INTEGRATION",
+        "category": "vocabulary",
+        "severity": severity,
+        "message": "A target term appears once but is substituted across activities.",
+        "evidence": (
+            "The occurrence ledger and cross-bundle audit serve distinct purposes."
+        ),
+        "location": {
+            "location": location["location"],
+            "line": location["line"],
+        },
+    })
+    semantic["alignment_audit"]["VOCABULARY_INTEGRATION"].update(
+        {
+            "status": "FOUND",
+            "evidence": copy.deepcopy(coverage["evidence"]),
+            "finding_ids": [finding_id],
+        }
+    )
+    semantic["verdict"] = verdict
+    return semantic, coverage
+
+
+def _patch_single_vocabulary_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    coverage: dict,
+) -> None:
+    monkeypatch.setattr(
+        pbr,
+        "_packet_vocabulary_lemmas",
+        lambda _packet: [coverage["lemma"]],
+    )
+    monkeypatch.setattr(
+        pbr,
+        "_packet_vocabulary_candidates",
+        lambda _packet: {
+            coverage["lemma"]: [
+                (coverage["surface"], coverage["verification"])
+            ]
+        },
+    )
+
+
+def test_finalize_accepts_integrated_vocabulary_with_broader_alignment_finding(
+    bilash_packet: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    semantic, coverage = _single_integrated_vocabulary_semantic(
+        bilash_packet,
+        severity="medium",
+        verdict="REVISE",
+    )
+    _patch_single_vocabulary_contract(monkeypatch, coverage)
+
+    result = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert result["semantic_response"]["contract_status"] == "valid"
+    assert result["semantic"]["vocabulary_coverage"][0]["status"] == "INTEGRATED"
+    assert result["semantic"]["alignment_audit"]["VOCABULARY_INTEGRATION"][
+        "status"
+    ] == "FOUND"
+    assert result["combined_disposition"]["status"] != "PASS"
+    pbr.validate_result(result)
+
+
+@pytest.mark.parametrize(
+    ("verdict", "severity", "error_fragment"),
+    [
+        ("PASS", "medium", "FOUND requires semantic REVISE"),
+        ("REVISE", "low", "FOUND requires medium-or-higher findings"),
+    ],
+)
+def test_finalize_rejects_fail_open_integrated_vocabulary_finding(
+    bilash_packet: dict,
+    monkeypatch: pytest.MonkeyPatch,
+    verdict: str,
+    severity: str,
+    error_fragment: str,
+) -> None:
+    semantic, coverage = _single_integrated_vocabulary_semantic(
+        bilash_packet,
+        severity=severity,
+        verdict=verdict,
+    )
+    _patch_single_vocabulary_contract(monkeypatch, coverage)
+
+    result = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert result["semantic_response"]["contract_status"] == "invalid"
+    assert error_fragment in result["semantic_response"]["error"]
+    assert result["combined_disposition"]["status"] == "INCOMPLETE"
+
+
+@pytest.mark.parametrize("audit_class", pbr.ALIGNMENT_AUDIT_CLASSES)
+def test_combined_disposition_defends_against_found_alignment_pass(
+    audit_class: str,
+) -> None:
+    deterministic = {
+        "track_audit": {"status": "complete"},
+        "size_policy": {"status": "complete"},
+        "policy_findings": [],
+        "skip_assessments": [],
+    }
+    deterministic["aggregate"] = pbr.aggregate_deterministic(deterministic)
+    semantic = {
+        "verdict": "PASS",
+        "claim_coverage": {
+            "status": "complete",
+            "claims_total": 0,
+            "claims_checked": 0,
+            "claims_supported": 0,
+        },
+        "learner_evidence_ledger": [],
+        "vocabulary_coverage": [{"status": "INTEGRATED"}],
+        "quality_dimensions": {},
+        "alignment_audit": {audit_class: {"status": "FOUND"}},
+    }
+    findings = [{"source": "semantic", "severity": "low"}]
+
+    disposition = pbr.combine_disposition(deterministic, semantic, findings)
+
+    assert disposition["status"] == "REVISE"
+
+
+@pytest.mark.parametrize("audit_class", pbr.ALIGNMENT_AUDIT_CLASSES)
+def test_found_alignment_contract_rejects_pass_and_nonmaterial_finding(
+    audit_class: str,
+) -> None:
+    finding_id = "fixture-alignment-finding"
+    alignment = {
+        audit_class: {
+            "status": "FOUND",
+            "finding_ids": [finding_id],
+        }
+    }
+
+    with pytest.raises(
+        pbr.ReviewProtocolError,
+        match=rf"{audit_class} FOUND requires semantic REVISE",
+    ):
+        pbr._validate_found_alignment_disposition(
+            alignment,
+            verdict="PASS",
+            known_findings={finding_id: {"severity": "medium"}},
+        )
+
+    with pytest.raises(
+        pbr.ReviewProtocolError,
+        match=rf"{audit_class} FOUND requires medium-or-higher findings",
+    ):
+        pbr._validate_found_alignment_disposition(
+            alignment,
+            verdict="REVISE",
+            known_findings={finding_id: {"severity": "low"}},
+        )
+
+
 @pytest.mark.parametrize("severity", ["low", "info"])
-def test_missing_vocabulary_rejects_nonmaterial_severity_and_semantic_pass(
+def test_missing_vocabulary_rejects_nonmaterial_severity(
     malyshko_packet: dict,
     severity: str,
 ) -> None:
@@ -2846,12 +3052,10 @@ def test_missing_vocabulary_rejects_nonmaterial_severity_and_semantic_pass(
     for finding in semantic["findings"]:
         if finding["id"] in missing_ids:
             finding["severity"] = severity
-    semantic["verdict"] = "PASS"
-
     result = pbr.finalize_review(malyshko_packet, _raw(semantic))
 
     assert result["semantic_response"]["contract_status"] == "invalid"
-    assert "MISSING requires a medium-or-higher finding" in result[
+    assert "VOCABULARY_INTEGRATION FOUND requires medium-or-higher findings" in result[
         "semantic_response"
     ]["error"]
     assert result["combined_disposition"]["status"] == "INCOMPLETE"
@@ -3298,8 +3502,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "6.0.2"
-    assert len(rows) == 65
+    assert catalog["catalog_version"] == "6.0.3"
+    assert len(rows) == 69
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -3338,6 +3542,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "6.0.0",
         "6.0.1",
         "6.0.2",
+        "6.0.3",
     }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 6.0.2
+catalog_version: 6.0.3
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -395,3 +395,46 @@ regressions:
       class's exact uppercase name as issue_id; keep the specific defect name
       in id and reserve custom issue_id values for findings outside all seven
       classes.
+  - bug_id: integrated-vocabulary-suppressed-cross-bundle-finding
+    responsible_layer: disposition
+    fixed_in_version: 6.0.2
+    version_field: review_protocol_version
+    input: >-
+      Every target lemma has one meaningful learner-facing surface, while the
+      lesson and activities materially substitute or under-reinforce one target
+      term elsewhere in the bundle.
+    expected: >-
+      Keep the occurrence ledger INTEGRATED, accept VOCABULARY_INTEGRATION
+      FOUND with exact evidence, and preserve the fail-closed REVISE verdict.
+  - bug_id: provider-conflated-occurrence-ledger-with-bundle-integration
+    responsible_layer: semantic_prompt
+    fixed_in_version: 6.0.3
+    version_field: semantic_prompt_version
+    input: >-
+      A target term has one meaningful learner-facing occurrence but is
+      materially substituted or under-reinforced elsewhere in the bundle.
+    expected: >-
+      Keep the term INTEGRATED in the occurrence ledger, emit a
+      medium-or-higher VOCABULARY_INTEGRATION finding, and return a non-PASS
+      semantic verdict.
+  - bug_id: non-vocabulary-alignment-found-passed-on-low-severity
+    responsible_layer: disposition
+    fixed_in_version: 6.0.2
+    version_field: review_protocol_version
+    input: >-
+      Any non-vocabulary alignment class is FOUND with a low-severity finding
+      while the semantic reviewer returns PASS.
+    expected: >-
+      Reject the semantic response because every categorical FOUND class
+      requires a medium-or-higher finding and a non-PASS semantic verdict;
+      combine_disposition independently returns REVISE for every class.
+  - bug_id: ukrainian-apostrophe-glyph-broke-exact-claim-binding
+    responsible_layer: deterministic_code
+    fixed_in_version: 6.0.2
+    version_field: review_protocol_version
+    input: >-
+      A claim is an exact contiguous statement substring except that the
+      provider emits ASCII apostrophe where the packet uses right single quote.
+    expected: >-
+      Treat only the three Ukrainian apostrophe glyphs ', ’, and ʼ as
+      equivalent while continuing to reject lexical or other punctuation drift.

--- a/tests/fixtures/post_build_review/score-calibration.v1.yaml
+++ b/tests/fixtures/post_build_review/score-calibration.v1.yaml
@@ -224,10 +224,10 @@ cases:
       documented_semantic_cap: 6.0
 comparability:
   - id: identical-review-identity-is-comparable
-    left: [6.0.2, fixture, fixture-model, high]
-    right: [6.0.2, fixture, fixture-model, high]
+    left: [6.0.3, fixture, fixture-model, high]
+    right: [6.0.3, fixture, fixture-model, high]
     expected: true
   - id: prompt-or-reviewer-identity-drift-is-not-comparable
-    left: [6.0.2, fixture, fixture-model, high]
+    left: [6.0.3, fixture, fixture-model, high]
     right: [6.0.2, google, gemini-3.1-pro, high]
     expected: false


### PR DESCRIPTION
## Summary

- bump the canonical review protocol to 6.0.2 and semantic prompt to 6.0.3
- preserve numeric dimension scores while making all seven categorical alignment classes fail closed
- distinguish complete vocabulary occurrence coverage from broader integration defects
- accept only the three Ukrainian apostrophe glyphs for exact claim binding
- add end-to-end positive/negative finalizer coverage and all-class disposition defenses

## Verification

- `.venv/bin/ruff check scripts/audit/post_build_review.py tests/audit/test_post_build_review.py`
- `.venv/bin/python -m pytest tests/audit/test_post_build_review.py -q` — 171 passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- canonical closeout receipt: clean, Claude Opus 4.8, exact commit fingerprint
- source-blind BIO-371 proof: v6.0.3 preserved scores 6.5 / 9.0 / 7.0 / 7.5 / 10.0 and 11 findings while returning REVISE

## Review

Authoritative independent cross-family review: Claude Opus 4.8 at max effort — CLEAN after two finding/fix cycles. The automatic cheap resolver was not used as authority.

## Follow-ups

- #5374 tracks latent apostrophe normalization in vocabulary surface resolution
- #5375 tracks combining-stress normalization for A1 vocabulary candidates

Closes #5369
