### PR TITLE
fix(review): constrain alignment status finding IDs

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,6 +1,6 @@
-review_protocol_version: 6.0.2
+review_protocol_version: 6.0.3
 deterministic_contract_version: 2.0.0
-semantic_prompt_version: 6.0.3
+semantic_prompt_version: 6.0.4
 track_policy_version: 2.0.0
 
 score_calibration:

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Common semantic post-build review prompt
 
-Semantic prompt version: `6.0.3`
+Semantic prompt version: `6.0.4`
 
 ## Machine-response contract — read before any source or tool call
 
@@ -178,6 +178,8 @@ class `CLEAR` only with exact cited evidence for the comparison, `FOUND` with
 every corresponding deterministic and semantic finding ID, or `INCOMPLETE`
 with an integrity finding. For mechanically supplied findings, reuse the exact
 IDs from the resolved context instead of emitting duplicate semantic findings.
+`CLEAR` requires an empty `finding_ids` array. `FOUND` and `INCOMPLETE` each
+require at least one finding ID; never attach a finding ID to a `CLEAR` class.
 Every `FOUND` class must own only medium, high, or blocker findings and makes
 semantic `PASS` impossible; return `REVISE`, `BLOCK`, or `INCOMPLETE` as the
 evidence requires.

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Core semantic post-build review prompt
 
-Semantic prompt version: `6.0.3`
+Semantic prompt version: `6.0.4`
 
 Apply this only to A1-C2 core tracks, after the common prompt.
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Seminar semantic post-build review prompt
 
-Semantic prompt version: `6.0.3`
+Semantic prompt version: `6.0.4`
 
 Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
 after the common prompt.

--- a/agents_extensions/shared/skills/post-build-review/schema/review-result.v6.schema.json
+++ b/agents_extensions/shared/skills/post-build-review/schema/review-result.v6.schema.json
@@ -330,13 +330,35 @@
       }
     },
     "alignmentAuditEntry": {
-      "type": "object", "additionalProperties": false,
-      "required": ["status", "evidence", "finding_ids"],
-      "properties": {
-        "status": {"enum": ["CLEAR", "FOUND", "INCOMPLETE"]},
-        "evidence": {"type": "array", "items": {"$ref": "#/$defs/dimensionEvidence"}},
-        "finding_ids": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/nonempty"}}
-      }
+      "oneOf": [
+        {
+          "type": "object", "additionalProperties": false,
+          "required": ["status", "evidence", "finding_ids"],
+          "properties": {
+            "status": {"const": "CLEAR"},
+            "evidence": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/dimensionEvidence"}},
+            "finding_ids": {"type": "array", "maxItems": 0, "items": {"$ref": "#/$defs/nonempty"}}
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false,
+          "required": ["status", "evidence", "finding_ids"],
+          "properties": {
+            "status": {"const": "FOUND"},
+            "evidence": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/dimensionEvidence"}},
+            "finding_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/nonempty"}}
+          }
+        },
+        {
+          "type": "object", "additionalProperties": false,
+          "required": ["status", "evidence", "finding_ids"],
+          "properties": {
+            "status": {"const": "INCOMPLETE"},
+            "evidence": {"type": "array", "items": {"$ref": "#/$defs/dimensionEvidence"}},
+            "finding_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/nonempty"}}
+          }
+        }
+      ]
     },
     "alignmentAudit": {
       "type": "object", "additionalProperties": false,

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -1231,6 +1231,34 @@ def test_provider_schema_rejects_prose_suffixed_vesum_mapping() -> None:
         Draft202012Validator(schema).validate(semantic)
 
 
+@pytest.mark.parametrize(
+    ("status", "finding_ids"),
+    [
+        ("CLEAR", ["misowned-finding"]),
+        ("FOUND", []),
+        ("INCOMPLETE", []),
+    ],
+)
+def test_provider_schema_enforces_alignment_status_finding_id_cardinality(
+    status: str,
+    finding_ids: list[str],
+) -> None:
+    packet = pbr.prepare_review("bio/andrii-malyshko", _reviewer())
+    schema = pbr.semantic_response_schema(packet)
+    semantic = _passing_semantic(packet)
+    Draft202012Validator(schema).validate(semantic)
+    entry = semantic["alignment_audit"]["PLAN_INSTRUCTION_LEAKAGE"]
+    entry["status"] = status
+    entry["finding_ids"] = finding_ids
+
+    with pytest.raises(ValidationError) as error:
+        Draft202012Validator(schema).validate(semantic)
+    assert list(error.value.absolute_path) == [
+        "alignment_audit",
+        "PLAN_INSTRUCTION_LEAKAGE",
+    ]
+
+
 def test_provider_schema_is_portable_and_finalizer_binds_vocabulary_order() -> None:
     packet = pbr.prepare_review("bio/andrii-malyshko", _reviewer())
     schema = pbr.semantic_response_schema(packet)
@@ -3502,8 +3530,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "6.0.3"
-    assert len(rows) == 69
+    assert catalog["catalog_version"] == "6.0.4"
+    assert len(rows) == 71
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -3543,6 +3571,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "6.0.1",
         "6.0.2",
         "6.0.3",
+        "6.0.4",
     }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 6.0.3
+catalog_version: 6.0.4
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -438,3 +438,23 @@ regressions:
     expected: >-
       Treat only the three Ukrainian apostrophe glyphs ', ’, and ʼ as
       equivalent while continuing to reject lexical or other punctuation drift.
+  - bug_id: clear-alignment-entry-carried-finding-id
+    responsible_layer: schema
+    fixed_in_version: 6.0.3
+    version_field: review_protocol_version
+    input: >-
+      A provider marks an alignment class CLEAR while attaching an unrelated
+      material finding ID, or marks FOUND or INCOMPLETE without any finding ID.
+    expected: >-
+      Reject the contradictory object at the provider schema boundary: CLEAR
+      owns no finding IDs, while FOUND and INCOMPLETE each own at least one.
+  - bug_id: prompt-left-alignment-status-cardinality-ambiguous
+    responsible_layer: semantic_prompt
+    fixed_in_version: 6.0.4
+    version_field: semantic_prompt_version
+    input: >-
+      A source-backed review discovers a SOURCE_TRACEABILITY defect but places
+      its ID under PLAN_INSTRUCTION_LEAKAGE while leaving that class CLEAR.
+    expected: >-
+      Tell the reviewer explicitly that CLEAR requires an empty finding_ids
+      array and FOUND or INCOMPLETE requires one or more correctly owned IDs.

--- a/tests/fixtures/post_build_review/score-calibration.v1.yaml
+++ b/tests/fixtures/post_build_review/score-calibration.v1.yaml
@@ -224,10 +224,10 @@ cases:
       documented_semantic_cap: 6.0
 comparability:
   - id: identical-review-identity-is-comparable
-    left: [6.0.3, fixture, fixture-model, high]
-    right: [6.0.3, fixture, fixture-model, high]
+    left: [6.0.4, fixture, fixture-model, high]
+    right: [6.0.4, fixture, fixture-model, high]
     expected: true
   - id: prompt-or-reviewer-identity-drift-is-not-comparable
-    left: [6.0.3, fixture, fixture-model, high]
-    right: [6.0.2, google, gemini-3.1-pro, high]
+    left: [6.0.4, fixture, fixture-model, high]
+    right: [6.0.3, google, gemini-3.1-pro, high]
     expected: false


### PR DESCRIPTION
## Summary
- make alignment-audit status/finding-ID cardinality provider-schema-enforced
- state the same contract explicitly in semantic prompt v6.0.4
- add packet-bound positive and negative regression coverage

## Verification
- 174/174 post-build review tests passed (including pre-commit rerun)
- Ruff, prompt lint, JSON Schema parsing, and git diff checks passed
- real CLI emitted review protocol 6.0.3 / prompt 6.0.4 with the expected three schema branches
- Claude Opus 4.8 max independent review: CLEAN, 0 findings, confidence 0.90
- deterministic closeout receipt: clean

No BIO content changes, score-threshold changes, deployment changes, or production QG arming.

Closes #5379