### PR TITLE
fix(audit): verbatim gate meta counts post-dedup + dedupe scope-note (#5106)

### DIFF
--- a/scripts/audit/verbatim_overlap_gate.py
+++ b/scripts/audit/verbatim_overlap_gate.py
@@ -51,6 +51,11 @@ EXTRACTION_SPEC_VERSION: str = "2026-07-v1-ua-learner-activities"
 K_DEFAULT: int = 8
 DF_N_DEFAULT: int = 5  # tuned post-baseline with user; report the value used
 
+SCOPED_CORPUS_WARNING: str = (
+    "WARNING: DF counts and the verify_quote allowlist are computed over the scoped corpus only. "
+    "Ratios are NOT comparable to full-index runs and MUST NOT set enforcement thresholds without a full-index delta check."
+)
+
 # Corpus tables we index at full strength (RIGHT side). Order matters for fingerprints.
 FULL_CORPORA: list[tuple[str, str, str, str]] = [
     ("textbooks", "chunk_id", "text", "textbooks"),
@@ -620,7 +625,8 @@ class ShingleIndex:
         self.conn.commit()
 
         shingle_to_chunks: dict[str, set[tuple[str, str]]] = defaultdict(set)
-        total_shingles = 0
+        total_shingles = 0  # post-deduplication count (number of actual postings inserted)
+        total_shingles_pre_dedup = 0  # pre-deduplication raw occurrence count
 
         for table, id_col, text_col, corpus_label in corpora:
             try:
@@ -637,11 +643,12 @@ class ShingleIndex:
                 shs = make_shingles(toks, self.k)
                 for sh in shs:
                     shingle_to_chunks[sh].add((corpus_label, cid))
-                total_shingles += len(shs)
+                total_shingles_pre_dedup += len(shs)
                 # insert postings (char_offset 0 is sufficient; LCS recovers exact)
                 # deduplicate postings to unique (shingle_key, corpus, chunk_id) before insert
                 if shs:
                     unique_shs = list(dict.fromkeys(shs))
+                    total_shingles += len(unique_shs)
                     self.conn.executemany(
                         "INSERT INTO postings (shingle_key, corpus, chunk_id, char_offset) VALUES (?, ?, ?, 0)",
                         [(sh, corpus_label, cid) for sh in unique_shs],
@@ -658,11 +665,14 @@ class ShingleIndex:
         self.set_meta("k", str(self.k))
         self.set_meta("extraction_spec", EXTRACTION_SPEC_VERSION)
         self.set_meta("total_shingles", str(total_shingles))
+        self.set_meta("total_shingles_pre_dedup", str(total_shingles_pre_dedup))
         self.set_meta("indexed_corpora", json.dumps([c[3] for c in corpora]))
         self.conn.commit()
 
         if progress:
-            print(f"Index built. fingerprint={fp} shingles~{total_shingles}")
+            print(
+                f"Index built. fingerprint={fp} shingles~{total_shingles} (pre-dedup~{total_shingles_pre_dedup})"
+            )
         return fp
 
     def _compute_fingerprint(self, conn: sqlite3.Connection, corpora: list) -> str:
@@ -752,10 +762,7 @@ def compute_metrics(
     default_labels = {c[3] for c in default_corpora}
     scope_note = None
     if set(indexed_corpora) != default_labels:
-        scope_note = (
-            "WARNING: DF counts and the verify_quote allowlist are computed over the scoped corpus only. "
-            "Ratios are NOT comparable to full-index runs and MUST NOT set enforcement thresholds without a full-index delta check."
-        )
+        scope_note = SCOPED_CORPUS_WARNING
 
     if verify_quote_fn is None:
 
@@ -1121,10 +1128,7 @@ def cmd_baseline_sweep(args: argparse.Namespace) -> int:
     default_corpora = FULL_CORPORA + SELF_CORPORA
     default_labels = {c[3] for c in default_corpora}
     if set(indexed_corpora) != default_labels:
-        out["scope_note"] = (
-            "WARNING: DF counts and the verify_quote allowlist are computed over the scoped corpus only. "
-            "Ratios are NOT comparable to full-index runs and MUST NOT set enforcement thresholds without a full-index delta check."
-        )
+        out["scope_note"] = SCOPED_CORPUS_WARNING
 
     print(json.dumps(out, indent=2, ensure_ascii=False))
     sources_conn.close()

--- a/tests/test_verbatim_overlap_gate.py
+++ b/tests/test_verbatim_overlap_gate.py
@@ -809,3 +809,38 @@ def test_cross_scope_df_exclusion_warning(tmp_path: Path):
     conn.close()
     idx_full.close()
     idx_scoped.close()
+
+
+def test_total_shingles_meta_counts(tmp_path: Path):
+    """Test that total_shingles records post-dedup occurrences count, and
+    total_shingles_pre_dedup records the raw occurrences count before deduplication.
+    """
+    conn, _ = _tiny_sources_db()
+    # A single chunk with duplicated shingles within the chunk:
+    # "один два три один два три" (k=3 shingles: 4 raw, 3 unique)
+    _seed_corpus(
+        conn,
+        [{"table": "textbooks", "chunk_id": "c-meta", "text": "один два три один два три"}],
+    )
+
+    idx = ShingleIndex(tmp_path / "idx_meta.db", k=3)
+    idx.build(conn)
+
+    post_dedup = idx.get_meta("total_shingles")
+    pre_dedup = idx.get_meta("total_shingles_pre_dedup")
+
+    # Raw shingles:
+    # 1. один два три
+    # 2. два три один
+    # 3. три один два
+    # 4. один два три
+    # Unique:
+    # 1. один два три
+    # 2. два три один
+    # 3. три один два
+    assert post_dedup == "3"
+    assert pre_dedup == "4"
+
+    conn.close()
+    idx.close()
+


### PR DESCRIPTION
Refs #5106

## Description
- Updates the `total_shingles` metadata in `ShingleIndex.build` to record post-deduplication shingle counts (actual postings inserted), while keeping raw/pre-deduplication occurrence counts available as a new metadata key `total_shingles_pre_dedup`.
- Removes duplication of the scope warning string by hoisting it to a single module-level constant `SCOPED_CORPUS_WARNING` in `scripts/audit/verbatim_overlap_gate.py`.
- Added hermetic tests to verify correct metadata counts.

## Test & Lint Output

### pytest
```
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/5106-verbatim-polish/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/5106-verbatim-polish
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.1.0, xdist-3.8.0, anyio-4.14.2
collecting ... collected 26 items / 4 deselected / 22 selected

tests/test_verbatim_overlap_gate.py::test_normalize_and_tokenize_deterministic_and_ua_aware PASSED [  4%]
tests/test_verbatim_overlap_gate.py::test_extraction_spec_version_is_stable PASSED [  9%]
tests/test_verbatim_overlap_gate.py::test_hermetic_verbatim_copy_flagged PASSED [ 13%]
tests/test_verbatim_overlap_gate.py::test_paraphrase_is_clean PASSED     [ 18%]
tests/test_verbatim_overlap_gate.py::test_attributed_quote_allowlisted_in_ratio PASSED [ 22%]
tests/test_verbatim_overlap_gate.py::test_df_gaming_long_run_still_flagged_by_max_contiguous PASSED [ 27%]
tests/test_verbatim_overlap_gate.py::test_copied_activity_is_flagged PASSED [ 31%]
tests/test_verbatim_overlap_gate.py::test_index_build_is_deterministic PASSED [ 36%]
tests/test_verbatim_overlap_gate.py::test_chained_run_and_lcs_recovery PASSED [ 40%]
tests/test_verbatim_overlap_gate.py::test_L544_postings_and_reports_deterministic_across_insert_order PASSED [ 45%]
tests/test_verbatim_overlap_gate.py::test_L584_fingerprint_content_based_on_text_change PASSED [ 50%]
tests/test_verbatim_overlap_gate.py::test_L698_overlap_ratio_zero_when_no_matches PASSED [ 54%]
tests/test_verbatim_overlap_gate.py::test_L741_verify_quote_excludes_from_ratio_truthfully PASSED [ 59%]
tests/test_verbatim_overlap_gate.py::test_L686_max_contiguous_run_per_chunk_not_summed PASSED [ 63%]
tests/test_verbatim_overlap_gate.py::test_multiline_html_comment_not_leaked_into_extraction PASSED [ 68%]
tests/test_verbatim_overlap_gate.py::test_normalize_L79_strips_only_stress_preserves_uk_letters PASSED [ 72%]
tests/test_verbatim_overlap_gate.py::test_postings_deduplication_metrics_identical PASSED [ 77%]
tests/test_verbatim_overlap_gate.py::test_cli_corpus_scoping_options PASSED [ 81%]
tests/test_verbatim_overlap_gate.py::test_index_db_filename_scoping PASSED [ 86%]
tests/test_verbatim_overlap_gate.py::test_missing_indexed_corpora_raises_hard_error PASSED [ 90%]
tests/test_verbatim_overlap_gate.py::test_cross_scope_df_exclusion_warning PASSED [ 95%]
tests/test_verbatim_overlap_gate.py::test_total_shingles_meta_counts PASSED [100%]

======================= 22 passed, 4 deselected in 0.32s =======================
```

### ruff check
```
All checks passed!
```
