### PR TITLE
fix(runtime): kimi version probe resolves the binary like the adapter (#5326)

### DIFF
--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -368,7 +368,15 @@ def _resolve_cli_version(agent_name: str, plan: InvocationPlan | None = None) ->
         prefix = _cursor_version_prefix(plan.cmd) if plan is not None else ("cursor-agent",)
         return cursor_cli_version(prefix)
     if agent_name == "kimi":
-        prefix = (plan.cmd[0],) if plan is not None and plan.cmd else ("kimi",)
+        if plan is not None and plan.cmd:
+            bin_path = plan.cmd[0]
+        else:
+            try:
+                from .adapters.kimi import _resolve_kimi_binary
+                bin_path = _resolve_kimi_binary()
+            except Exception:
+                bin_path = "kimi"
+        prefix = (bin_path,)
         return kimi_cli_version(prefix)
     from .agent_identity import is_hermes_grok_seat, is_native_grok_seat
 

--- a/tests/test_dispatch_telemetry.py
+++ b/tests/test_dispatch_telemetry.py
@@ -310,6 +310,34 @@ def test_runner_usage_record_includes_correlation_ids_without_prompt_change(
     assert captured_env["LU_SESSION_ID"] == "session-456"
 
 
+def test_resolve_dispatch_start_telemetry_kimi_resolves_binary(tmp_path, monkeypatch):
+    """The Kimi version probe must reuse the adapter's binary resolution logic,
+    so that if kimi lives in ~/.kimi-code/bin/kimi or LEARN_UK_KIMI_BIN, it finds it.
+    """
+    kimi_bin = tmp_path / "mock_kimi"
+    kimi_bin.write_text("#!/bin/sh\necho 'kimi version v0.42.1'\n", encoding="utf-8")
+    kimi_bin.chmod(0o755)
+
+    monkeypatch.setenv("LEARN_UK_KIMI_BIN", str(kimi_bin))
+
+    telemetry = resolve_dispatch_start_telemetry(
+        agent_name="kimi",
+        requested_model=None,
+        requested_effort=None,
+    )
+    assert telemetry.cli_version == "0.42.1"
+
+    # Also test with a plan to ensure it resolves successfully
+    plan = InvocationPlan(cmd=[str(kimi_bin), "-p", "hello"], cwd=tmp_path)
+    telemetry_with_plan = resolve_invocation_telemetry(
+        agent_name="kimi",
+        plan=plan,
+        requested_model=None,
+        requested_effort=None,
+    )
+    assert telemetry_with_plan.cli_version == "0.42.1"
+
+
 def setup_function() -> None:
     _reset_rate_limit_cache_for_tests()
     _reset_version_cache_for_tests()


### PR DESCRIPTION
Refs #5326

Telemetry version probe for the Kimi CLI now correctly resolves the binary path using the same resolution order as the adapter (supporting `LEARN_UK_KIMI_BIN` env var, `PATH`, and `~/.kimi-code/bin/kimi` fallback) rather than using a bare `kimi` string.

### Test Results

```
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.3, pluggy-1.6.0 -- /Users/krisztiankoos/.pyenv/versions/3.12.8/bin/python
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/kimi-version-probe
configfile: pyproject.toml
plugins: anyio-4.13.0
collecting ... collected 8 items

tests/test_dispatch_telemetry.py::test_resolve_dispatch_start_telemetry_codex_model_from_registry_effort_from_config PASSED [ 12%]
tests/test_dispatch_telemetry.py::test_resolve_dispatch_start_telemetry_codex_explicit_model_wins PASSED [ 25%]
tests/test_dispatch_telemetry.py::test_resolve_invocation_telemetry_reads_claude_plan_flags PASSED [ 37%]
tests/test_dispatch_telemetry.py::test_expected_effort_markers_and_version_probes_do_not_warn PASSED [ 50%]
tests/test_dispatch_telemetry.py::test_unexpected_version_probe_failure_still_warns PASSED [ 62%]
tests/test_dispatch_telemetry.py::test_runner_invoke_preserves_observed_terminal_returncode_and_telemetry PASSED [ 75%]
tests/test_dispatch_telemetry.py::test_runner_usage_record_includes_correlation_ids_without_prompt_change PASSED [ 87%]
tests/test_dispatch_telemetry.py::test_resolve_dispatch_start_telemetry_kimi_resolves_binary PASSED [100%]

============================== 8 passed in 0.29s ===============================
```

### Lint Results

```
All checks passed!
```
