### PR TITLE
fix(tests): isolate _db.DB_PATH per test — xdist leak (#5247)

### DIFF
--- a/scripts/wiki/mlx_encoder.py
+++ b/scripts/wiki/mlx_encoder.py
@@ -24,8 +24,6 @@ from mlx_embeddings import load
 MODEL_NAME = "mlx-community/bge-m3-mlx-fp16"
 EMBEDDING_DIMS = 1024
 
-os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
-
 
 def _log(message: str) -> None:
     print(message, file=sys.stderr, flush=True)
@@ -99,6 +97,9 @@ class MLXEncoderWorker:
 
 
 def main() -> int:
+    # Must NOT run at import time — importing this module from tests must
+    # have zero process-env side effects (CI env-leak class #5247).
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
     try:
         _configure_memory_limit()
     except Exception as exc:  # pragma: no cover - startup diagnostics only

--- a/tests/ai_agent_bridge/test_ab_discuss_bugs.py
+++ b/tests/ai_agent_bridge/test_ab_discuss_bugs.py
@@ -31,7 +31,13 @@ def test_discuss_round_four_prompt_preserves_root_and_all_thread_replies(
     truncator entirely. So the truncation marker is no longer expected;
     instead we assert that all thread messages survive verbatim.
     """
-    monkeypatch.setattr(_db, "DB_PATH", tmp_path / "bridge.db")
+    # Patch both bindings — ``_db`` imports DB_PATH from ``_config`` by
+    # name, so they are independent (#5247 xdist leak class).
+    from ai_agent_bridge import _config
+
+    db_path = tmp_path / "bridge.db"
+    monkeypatch.setattr(_config, "DB_PATH", db_path)
+    monkeypatch.setattr(_db, "DB_PATH", db_path)
     monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
     monkeypatch.setattr(_channels, "context_sha256", lambda path: "")
     monkeypatch.setattr(

--- a/tests/test_ab_discuss_read_only.py
+++ b/tests/test_ab_discuss_read_only.py
@@ -55,7 +55,13 @@ def isolated_bridge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     repo.mkdir()
     _init_repo(repo)
 
-    monkeypatch.setattr(_db, "DB_PATH", tmp_path / "bridge.db")
+    # Patch both bindings — ``_db`` imports DB_PATH from ``_config`` by
+    # name, so they are independent (#5247 xdist leak class).
+    from ai_agent_bridge import _config
+
+    db_path = tmp_path / "bridge.db"
+    monkeypatch.setattr(_config, "DB_PATH", db_path)
+    monkeypatch.setattr(_db, "DB_PATH", db_path)
     monkeypatch.setattr(_channels_cli, "REPO_ROOT", repo)
     monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
     monkeypatch.setattr(_channels, "context_sha256", lambda path: "")

--- a/tests/test_agy_integration.py
+++ b/tests/test_agy_integration.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _VENV_PYTHON = _REPO_ROOT / ".venv" / "bin" / "python"
 
@@ -45,6 +47,51 @@ def _resolve_test_python() -> str:
 
 
 _TEST_PYTHON = _resolve_test_python()
+
+
+def _ensure_scripts_path() -> None:
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_bridge_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Per-test isolation for module-global bridge ``DB_PATH`` (#5247).
+
+    ``_db`` binds ``DB_PATH`` via ``from ._config import DB_PATH``, so the
+    two names are independent. Tests that only patch ``_db.DB_PATH`` leave
+    ``_config.DB_PATH`` pointing at the shared broker file; under xdist a
+    sibling worker/test can then make ``create_channel`` / ``get_channel``
+    disagree and ``ab discuss`` exits before ``runtime_invoke``.
+
+    Autouse so every test in this module — including future discuss
+    siblings — inherits isolation without reintroducing the leak.
+    """
+    _ensure_scripts_path()
+    from ai_agent_bridge import _config, _db
+
+    db_path = tmp_path / "bridge.db"
+    monkeypatch.setattr(_config, "DB_PATH", db_path)
+    monkeypatch.setattr(_db, "DB_PATH", db_path)
+    return db_path
+
+
+@pytest.fixture
+def discuss_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub channel I/O for discuss tests; relies on ``_isolate_bridge_db_path``."""
+    _ensure_scripts_path()
+    from ai_agent_bridge import _channels
+
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    monkeypatch.setattr(_channels, "context_sha256", lambda path: "")
+    monkeypatch.setattr(
+        _channels,
+        "load_channel_context",
+        lambda channel: {"body": "", "revs": {}, "missing": []},
+    )
+    _channels.create_channel("shared", exist_ok=True)
+    _channels.create_channel("agy-topic", exist_ok=True)
 
 
 def test_registry_exposes_agy():
@@ -108,28 +155,13 @@ def test_ab_channels_cli_marks_agy_cli_available():
 
 
 def test_ab_discuss_accepts_agy_in_with_list(
-    tmp_path, monkeypatch,
+    discuss_bridge, monkeypatch,
 ):
     """``ab discuss --with agy`` passes agent validation and invokes runtime."""
     from types import SimpleNamespace
 
-    scripts_dir = str(_REPO_ROOT / "scripts")
-    if scripts_dir not in sys.path:
-        sys.path.insert(0, scripts_dir)
-
-    from ai_agent_bridge import _channels, _channels_cli, _db
-
-    monkeypatch.setattr(_db, "DB_PATH", tmp_path / "bridge.db")
-    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
-    monkeypatch.setattr(_channels, "context_sha256", lambda path: "")
-    monkeypatch.setattr(
-        _channels,
-        "load_channel_context",
-        lambda channel: {"body": "", "revs": {}, "missing": []},
-    )
-
-    _channels.create_channel("shared", exist_ok=True)
-    _channels.create_channel("agy-topic", exist_ok=True)
+    _ensure_scripts_path()
+    from ai_agent_bridge import _channels_cli
 
     invoked: list[str] = []
     invoke_kwargs: list[dict] = []
@@ -160,27 +192,12 @@ def test_ab_discuss_accepts_agy_in_with_list(
     assert invoke_kwargs[0].get("model") is None
 
 
-def test_ab_discuss_passes_agy_pro_model_override(tmp_path, monkeypatch):
+def test_ab_discuss_passes_agy_pro_model_override(discuss_bridge, monkeypatch):
     """``--models agy:gemini-3.1-pro-high`` reaches runtime_invoke as model=."""
     from types import SimpleNamespace
 
-    scripts_dir = str(_REPO_ROOT / "scripts")
-    if scripts_dir not in sys.path:
-        sys.path.insert(0, scripts_dir)
-
-    from ai_agent_bridge import _channels, _channels_cli, _db
-
-    monkeypatch.setattr(_db, "DB_PATH", tmp_path / "bridge.db")
-    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
-    monkeypatch.setattr(_channels, "context_sha256", lambda path: "")
-    monkeypatch.setattr(
-        _channels,
-        "load_channel_context",
-        lambda channel: {"body": "", "revs": {}, "missing": []},
-    )
-
-    _channels.create_channel("shared", exist_ok=True)
-    _channels.create_channel("agy-topic", exist_ok=True)
+    _ensure_scripts_path()
+    from ai_agent_bridge import _channels_cli
 
     invoke_kwargs: list[dict] = []
 


### PR DESCRIPTION
## Summary
- Isolate bridge `DB_PATH` per test via an autouse fixture in `tests/test_agy_integration.py` that patches **both** `_config.DB_PATH` and `_db.DB_PATH` (independent bindings after `from ._config import DB_PATH`) so discuss siblings cannot leak shared broker state under pytest-xdist.
- Sweep sibling discuss modules (`test_ab_discuss_read_only.py`, `test_ab_discuss_bugs.py`) for the same incomplete single-binding patch pattern.
- Move `scripts/wiki/mlx_encoder.py` `TOKENIZERS_PARALLELISM` `setdefault` into `main()` (import-time env-leak class called out on #5247).

Refs #5247

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_agy_integration.py tests/test_ab_discuss_read_only.py tests/ai_agent_bridge/test_ab_discuss_bugs.py -q` — 14 passed
- [x] xdist repeat (`-n auto`, 3×) — all green (quoted below)
- [x] ruff on touched files — all checks passed (quoted below)
- [ ] CI green on this PR

### M-4 evidence — ruff

```
$ .venv/bin/ruff check tests/test_agy_integration.py tests/test_ab_discuss_read_only.py tests/ai_agent_bridge/test_ab_discuss_bugs.py scripts/wiki/mlx_encoder.py
All checks passed!
```

### M-4 evidence — xdist ×3 (`-n auto`)

```
=== xdist run 1 ===
created: 10/10 workers
10 workers [14 items]
..............                                                           [100%]
============================== 14 passed in 7.70s ==============================
=== xdist run 2 ===
created: 10/10 workers
10 workers [14 items]
..............                                                           [100%]
============================== 14 passed in 8.56s ==============================
=== xdist run 3 ===
created: 10/10 workers
10 workers [14 items]
..............                                                           [100%]
============================== 14 passed in 14.32s ==============================
=== all 3 xdist runs green ===
```