### PR TITLE
fix(api): wire kimi into CodexBar usage + honest error semantics (#5326)

### DIFF
--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -27,6 +27,7 @@ PROVIDER_TO_LANE = {
     "gemini": "gemini",
     "antigravity": "gemini",
     "grok": "grok",
+    "kimi": "kimi",
 }
 
 # In-memory storage for the last successfully fetched usage data (lasts the lifetime of the process)
@@ -90,7 +91,7 @@ def _fetch_single_provider(provider: str, timeout_s: float) -> dict[str, Any] | 
             timeout=timeout_s,
             check=False,
         )
-        if res.returncode != 0:
+        if res.returncode != 0 and not _stdout_has_provider_payload(res.stdout):
             # Fallback to codexbar in system path
             cmd = ["codexbar", "usage", "--json", "--provider", provider]
             res = subprocess.run(
@@ -100,7 +101,12 @@ def _fetch_single_provider(provider: str, timeout_s: float) -> dict[str, Any] | 
                 timeout=timeout_s,
                 check=False,
             )
-            if res.returncode != 0:
+            # The CLI exits NON-zero on provider/credential errors while still
+            # printing the error JSON on stdout (live-verified 2026-07-17: kimi
+            # expired credential → rc=1 + error payload). Bail only when there
+            # is no parseable payload at all — otherwise fall through so the
+            # error surfaces as status='unknown' instead of a silent None.
+            if res.returncode != 0 and not _stdout_has_provider_payload(res.stdout):
                 return None
 
         parsed = json.loads(res.stdout)
@@ -109,8 +115,9 @@ def _fetch_single_provider(provider: str, timeout_s: float) -> dict[str, Any] | 
 
         first_entry = parsed[0]
         if "error" in first_entry:
-            return None
-
+            # Provider/credential error (e.g. expired Kimi credentials): surface
+            # as status='unknown' with the message carried, never as zero usage.
+            return _normalize_provider_error(provider, first_entry["error"])
         return _normalize_provider_data(provider, first_entry)
     except Exception:
         return None
@@ -251,6 +258,53 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
     }
 
 
+def _stdout_has_provider_payload(stdout: str) -> bool:
+    """True when the CLI printed a parseable provider list despite rc != 0."""
+    try:
+        parsed = json.loads(stdout)
+    except (TypeError, ValueError):
+        return False
+    return isinstance(parsed, list) and bool(parsed)
+
+
+def _normalize_provider_error(provider: str, error: Any) -> dict[str, Any]:
+    """Normalize a codexbar provider-level error object.
+
+    The CLI can return an error instead of usage, e.g. expired Kimi credentials:
+        [{"source":"auto","provider":"kimi","error":{"code":1,"message":"...","kind":"provider"}}]
+
+    This MUST surface as status='unknown' with the message carried (auth_error),
+    NEVER as 0% remaining and never as a silently absent row for a subscription lane.
+    Mirrors _normalize_provider_data's shape so consumers see a uniform record.
+    """
+    lane = PROVIDER_TO_LANE.get(provider, provider)
+    message: str | None = None
+    code: Any = None
+    kind: str | None = None
+    if isinstance(error, dict):
+        message = error.get("message")
+        code = error.get("code")
+        kind = error.get("kind")
+
+    return {
+        "lane": lane,
+        "primary_used_pct": None,
+        "weekly_used_pct": None,
+        "monthly_cap_usd": None,
+        "monthly_used_usd": None,
+        "weekly_resets_at": None,
+        "weekly_pace_delta_pct": None,
+        "will_last_to_reset": None,
+        "pace_summary": None,
+        "source": "codexbar",
+        "fetched_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "status": "unknown",
+        "auth_error": message,
+        "error_kind": kind,
+        "error_code": code,
+    }
+
+
 def trigger_background_refresh() -> None:
     """Spawns a background thread to update the cache for all providers sequentially."""
     global _refresh_thread
@@ -263,7 +317,7 @@ def trigger_background_refresh() -> None:
 
 def _run_all_refreshes() -> None:
     # List of unique providers to refresh
-    providers = ["claude", "codex", "cursor", "gemini", "grok"]
+    providers = ["claude", "codex", "cursor", "gemini", "grok", "kimi"]
     for provider in providers:
         try:
             data = fetch_codexbar_usage(provider)
@@ -320,4 +374,5 @@ def get_provider_usage_data(provider: str) -> dict[str, Any]:
         "stale": False,
         "age_s": None,
         "status": "unknown",
+        "auth_error": None,
     }

--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -83,14 +83,20 @@ def fetch_codexbar_usage(provider: str, *, timeout_s: float = 45.0) -> dict[str,
 def _fetch_single_provider(provider: str, timeout_s: float) -> dict[str, Any] | None:
     try:
         # Run codexbar usage --json --provider <provider>
-        cmd = ["/opt/homebrew/bin/codexbar", "usage", "--json", "--provider", provider]
-        res = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout_s,
-            check=False,
-        )
+        try:
+            cmd = ["/opt/homebrew/bin/codexbar", "usage", "--json", "--provider", provider]
+            res = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                check=False,
+            )
+        except FileNotFoundError:
+            # Homebrew path absent (Intel mac /usr/local, CI, Linux) — the
+            # PATH-fallback below must still get its chance (review-5386 F1:
+            # letting this reach the outer handler bypassed the fallback).
+            res = subprocess.CompletedProcess(cmd, returncode=127, stdout="", stderr="")
         if res.returncode != 0 and not _stdout_has_provider_payload(res.stdout):
             # Fallback to codexbar in system path
             cmd = ["codexbar", "usage", "--json", "--provider", provider]
@@ -253,6 +259,12 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
         "weekly_pace_delta_pct": weekly_pace_delta_pct,
         "will_last_to_reset": will_last_to_reset,
         "pace_summary": pace_summary,
+        # Same key shape as _normalize_provider_error so consumers can use
+        # bracket access on either record (review-5386 F2).
+        "status": "healthy",
+        "auth_error": None,
+        "error_kind": None,
+        "error_code": None,
         "source": "codexbar",
         "fetched_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
     }

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -792,6 +792,36 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 if cb_data.get("weekly_resets_at"):
                     agents[lane]["resets_at"] = cb_data["weekly_resets_at"]
 
+        elif cb_data and cb_data.get("auth_error"):
+            # Provider/credential error from codexbar (e.g. Kimi CLI credentials
+            # expired — 2026-07-17 incident). The CLI positively reported the lane
+            # is unavailable, so override any ledger-derived "cool"/0%-burn verdict
+            # (an empty ledger with a cap would otherwise render the seat as 100%
+            # available, or a stale ledger as 0%). Surface status='unknown' with
+            # the error message carried; NEVER 0% remaining, never an absent row.
+            agents[lane]["status"] = "unknown"
+            agents[lane]["burn_pct_7d"] = None
+            agents[lane]["remaining_pct"] = None
+            agents[lane]["codexbar"] = {
+                "primary_used_pct": None,
+                "weekly_used_pct": None,
+                "monthly_cap_usd": None,
+                "monthly_used_usd": None,
+                "weekly_resets_at": None,
+                "weekly_pace_delta_pct": None,
+                "will_last_to_reset": None,
+                "pace_summary": None,
+                "stale": cb_data.get("stale", False),
+                "fetched_at": cb_data.get("fetched_at"),
+                "status": "unknown",
+                "auth_error": cb_data.get("auth_error"),
+                "error_kind": cb_data.get("error_kind"),
+                "error_code": cb_data.get("error_code"),
+            }
+            if lane == "claude":
+                agents[lane]["interactive"]["status"] = "unknown"
+                agents[lane]["interactive"]["burn_pct_7d"] = None
+
     if cb_sourced_any:
         is_stale = cb_stale
         data_age_s = cb_max_age_s

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -426,3 +426,35 @@ def test_kimi_provider_error_with_nonzero_exit_still_surfaces(monkeypatch):
     assert res is not None
     assert res["status"] == "unknown"
     assert "credential is expired" in res["auth_error"]
+
+
+def test_healthy_record_carries_error_shape_defaults():
+    """Healthy and error records share one key shape (review-5386 F2)."""
+    raw_list = json.loads(KIMI_HEALTHY_FIXTURE)
+    res = _normalize_provider_data("kimi", raw_list[0])
+    assert res["status"] == "healthy"
+    assert res["auth_error"] is None
+    assert res["error_kind"] is None
+    assert res["error_code"] is None
+
+
+def test_missing_homebrew_binary_reaches_path_fallback(monkeypatch):
+    """FileNotFoundError on the homebrew path must not bypass the PATH fallback (review-5386 F1)."""
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd[0])
+        if cmd[0].startswith("/opt/homebrew"):
+            raise FileNotFoundError(cmd[0])
+
+        class _R:
+            returncode = 0
+            stdout = KIMI_HEALTHY_FIXTURE
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(codexbar_usage_mod.subprocess, "run", fake_run)
+    res = codexbar_usage_mod.fetch_codexbar_usage("kimi", timeout_s=1.0)
+    assert calls == ["/opt/homebrew/bin/codexbar", "codexbar"]
+    assert res is not None and res["lane"] == "kimi" and res["status"] == "healthy"

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 
+from scripts.api import codexbar_usage as codexbar_usage_mod
 from scripts.api import state_router
 from scripts.api.codexbar_usage import _normalize_provider_data
 
@@ -325,3 +326,103 @@ def test_monthly_window_only_does_not_mislabel_weekly_used_pct():
     assert res["primary_used_pct"] == 10.0
     assert res["weekly_used_pct"] != 75.0
     assert res["weekly_used_pct"] == 10.0
+
+
+# Kimi healthy usage snapshot (weekly + primary windows present)
+KIMI_HEALTHY_FIXTURE = """[
+  {
+    "provider": "kimi",
+    "source": "oauth",
+    "usage": {
+      "primary": {
+        "windowMinutes": 300,
+        "usedPercent": 12,
+        "resetsAt": "2026-07-17T18:00:00Z"
+      },
+      "secondary": {
+        "windowMinutes": 10080,
+        "usedPercent": 40,
+        "resetsAt": "2026-07-20T18:00:00Z"
+      }
+    },
+    "pace": {
+      "secondary": {
+        "deltaPercent": -5,
+        "willLastToReset": true,
+        "summary": "5% in reserve | Expected 45% used"
+      }
+    }
+  }
+]"""
+
+
+# Kimi credential/provider error snapshot (the 2026-07-17 incident shape)
+KIMI_ERROR_FIXTURE = """[
+  {
+    "source": "auto",
+    "provider": "kimi",
+    "error": {
+      "code": 1,
+      "message": "Kimi Code CLI credential is expired, please re-authenticate",
+      "kind": "provider"
+    }
+  }
+]"""
+
+
+
+
+def test_normalize_kimi_healthy_shape():
+    """Healthy kimi payload yields a lane row with window numbers."""
+    raw = json.loads(KIMI_HEALTHY_FIXTURE)[0]
+    res = _normalize_provider_data("kimi", raw)
+
+    assert res["lane"] == "kimi"
+    assert res["primary_used_pct"] == 12.0
+    assert res["weekly_used_pct"] == 40.0
+    assert res["weekly_resets_at"] == "2026-07-20T18:00:00Z"
+    assert res["will_last_to_reset"] is True
+    assert res["source"] == "codexbar"
+
+
+def test_kimi_provider_error_surfaces_unknown(monkeypatch):
+    """Credential/provider error -> status='unknown' + auth_error, never zero usage."""
+
+    class _FakeResult:
+        returncode = 0
+        stdout = KIMI_ERROR_FIXTURE
+        stderr = ""
+
+    monkeypatch.setattr(codexbar_usage_mod.subprocess, "run", lambda cmd, **kw: _FakeResult())
+    # Never fall back to last-good data
+    codexbar_usage_mod._last_good_data.pop("kimi", None)
+
+    res = codexbar_usage_mod.fetch_codexbar_usage("kimi", timeout_s=1.0)
+
+    assert res is not None
+    assert res["lane"] == "kimi"
+    assert res["status"] == "unknown"
+    assert res["weekly_used_pct"] is None
+    assert res["primary_used_pct"] is None
+    assert "credential is expired" in res["auth_error"]
+    assert res["error_kind"] == "provider"
+    assert res["error_code"] == 1
+
+
+def test_kimi_provider_error_with_nonzero_exit_still_surfaces(monkeypatch):
+    """LIVE-verified gap (2026-07-17): the CLI exits rc=1 on credential errors
+    while printing the error JSON — rc alone must not swallow the payload."""
+
+    class _FakeResult:
+        returncode = 1
+        stdout = KIMI_ERROR_FIXTURE
+        stderr = ""
+
+    monkeypatch.setattr(codexbar_usage_mod.subprocess, "run", lambda cmd, **kw: _FakeResult())
+    codexbar_usage_mod._last_good_data.pop("kimi", None)
+
+    res = codexbar_usage_mod.fetch_codexbar_usage("kimi", timeout_s=1.0)
+
+    assert res is not None
+    assert res["status"] == "unknown"
+    assert "credential is expired" in res["auth_error"]


### PR DESCRIPTION
## Incident
CodexBar showed kimi at ZERO availability while the seat was at full capacity (user report 2026-07-17).

## Root causes + fix
1. Our fetcher never polled kimi — `PROVIDER_TO_LANE` lacked the entry → no row → consumers rendered zero/absent. Wired in (fetch + background refresh; `SUBSCRIPTION_LANES` already listed it).
2. Provider/credential errors (the live state: *"Kimi Code CLI credential is expired…"*) must surface as `status=unknown` + `auth_error`, never as 0% available. Normalizer + state_router overlay added.
3. **Live-verify catch**: the codexbar CLI exits rc=1 on credential errors while still printing the error JSON — the original code bailed on rc before parsing. Fixed + regression test.

## Evidence (#M-4)
- pytest: `8 passed` (healthy / error rc=0 / error rc=1 fixtures)
- ruff: clean
- LIVE end-to-end against the real expired credential: `{'lane': 'kimi', 'status': 'unknown', 'auth_error': 'Kimi Code CLI credential is expired…', 'error_kind': 'provider'}` (was `null` pre-fix)

## Authorship
Base diff written by **glm** (glm-5.2 — first coding task in the fleet, per user order); applied, integrated, and rc-gap fixed by claude-infra. Cross-family review: non-Zhipu reviewer required.

Refs #5326

🤖 Generated with [Claude Code](https://claude.com/claude-code)