### PR TITLE
fix(harness): kimi adapter 0.27 — flagless danger/workspace-write, refuse read-only, surface instant-exit stderr (#5326)

### DIFF
--- a/scripts/agent_runtime/adapters/kimi.py
+++ b/scripts/agent_runtime/adapters/kimi.py
@@ -1,17 +1,15 @@
 """Native Kimi Code CLI adapter for the Kimi K3 subscription lane.
 
 The local Kimi Code installation exposes K3 as ``kimi-code/k3`` and emits
-newline-delimited events in ``--output-format stream-json`` mode.  OAuth
+newline-delimited events in ``--output-format stream-json`` mode. OAuth
 credentials stay in Kimi's own home directory; this adapter never reads or
 injects them.
 
-Permission mapping for non-interactive prompt mode:
-
-- ``read-only``: Kimi's default approval mode.  Reads execute headlessly;
-  mutations still require approval.  ``--plan`` cannot be combined with
-  ``--prompt`` in Kimi Code 0.26.0, so it is deliberately not used here.
-- ``workspace-write``: ``--auto``.
-- ``danger``: ``--yolo`` (only after delegate.py validates a worktree).
+Kimi Code 0.27.0 evidence (2026-07-17): ``kimi --yolo -p \"…\"`` exits with
+``error: Cannot combine --prompt with --yolo.`` Bare ``kimi -p`` also writes
+without an approval prompt. Consequently, headless workspace-write and danger
+must be flagless (delegate.py already verifies their worktrees), while
+read-only is refused because the CLI cannot guarantee it.
 """
 
 from __future__ import annotations
@@ -63,9 +61,14 @@ _RATE_LIMIT_RE = re.compile(
 )
 _MODE_FLAGS: dict[str, tuple[str, ...]] = {
     "read-only": (),
-    "workspace-write": ("--auto",),
-    "danger": ("--yolo",),
+    "workspace-write": (),
+    "danger": (),
 }
+
+_READ_ONLY_REFUSAL = (
+    "kimi headless auto-approves mutations; read-only cannot be guaranteed "
+    "on CLI 0.27 — use another agent"
+)
 
 
 class KimiAdapter:
@@ -93,6 +96,8 @@ class KimiAdapter:
                 f"KimiAdapter: unsupported mode {mode!r} "
                 f"(supported: {sorted(self.supported_modes)})"
             )
+        if mode == "read-only":
+            raise ValueError(_READ_ONLY_REFUSAL)
 
         requested_model = resolve_kimi_model(model)
 

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -230,12 +230,15 @@ def _spawn_pty_subprocess(
     env: Mapping[str, str],
     stdin: Any = subprocess.DEVNULL,
     pty_window: tuple[int, int] = (40, 200),
-) -> tuple[subprocess.Popen, int, int]:
-    """Spawn ``cmd`` in a PTY so stdout/stderr line-buffer naturally.
+    stderr_pipe: bool = False,
+) -> tuple[subprocess.Popen, int, int | None]:
+    """Spawn ``cmd`` with PTY stdout and optionally pipe-backed stderr.
 
-    Returns ``(proc, stdout_master_fd, stderr_master_fd)``. The slave
-    fds are closed in the parent immediately after spawn so EOF / EIO
-    propagates cleanly when the child closes its side.
+    Returns ``(proc, stdout_master_fd, stderr_master_fd)``. When
+    ``stderr_pipe`` is true, the final item is ``None`` and stderr is drained
+    from ``proc.stderr`` instead. The slave fds are closed in the parent
+    immediately after spawn so EOF / EIO propagates when the child closes its
+    side.
 
     PTY usage forces the child's libc to detect a TTY and switch from
     block-buffered to line-buffered stdout. Without this, agents that
@@ -268,21 +271,25 @@ def _spawn_pty_subprocess(
         import termios
 
         stdout_master, stdout_slave = pty.openpty()
-        try:
-            stderr_master, stderr_slave = pty.openpty()
-        except (OSError, AttributeError):
-            with contextlib.suppress(OSError):
-                os.close(stdout_master)
-            with contextlib.suppress(OSError):
-                os.close(stdout_slave)
-            raise
+        stderr_master: int | None = None
+        stderr_slave: int | None = None
+        if not stderr_pipe:
+            try:
+                stderr_master, stderr_slave = pty.openpty()
+            except (OSError, AttributeError):
+                with contextlib.suppress(OSError):
+                    os.close(stdout_master)
+                with contextlib.suppress(OSError):
+                    os.close(stdout_slave)
+                raise
 
         # Disable OPOST on each slave so \n stays \n (no ONLCR rewrite).
         # Belt-and-suspenders: the streamer also strips \r\n → \n if a
         # platform somehow ignores the termios change. Suppression is
         # narrow — these calls are advisory; the spawn proceeds either
         # way.
-        for slave_fd in (stdout_slave, stderr_slave):
+        slave_fds = (stdout_slave,) if stderr_slave is None else (stdout_slave, stderr_slave)
+        for slave_fd in slave_fds:
             with contextlib.suppress(termios.error, OSError):
                 attrs = termios.tcgetattr(slave_fd)
                 attrs[1] &= ~termios.OPOST  # oflag
@@ -291,7 +298,7 @@ def _spawn_pty_subprocess(
         # Set sane window size so agents that query TIOCGWINSZ for output
         # formatting (e.g. ANSI tables) get reasonable defaults.
         winsize = struct.pack("HHHH", pty_window[0], pty_window[1], 0, 0)
-        for slave_fd in (stdout_slave, stderr_slave):
+        for slave_fd in slave_fds:
             with contextlib.suppress(OSError):
                 fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, winsize)
     except (OSError, AttributeError) as exc:
@@ -310,23 +317,25 @@ def _spawn_pty_subprocess(
             env=dict(env),
             stdin=stdin,
             stdout=stdout_slave,
-            stderr=stderr_slave,
+            stderr=subprocess.PIPE if stderr_pipe else stderr_slave,
             text=text_mode,
             bufsize=1 if text_mode else -1,
             start_new_session=True,
         )
     except BaseException:
         for fd in (stdout_master, stderr_master, stdout_slave, stderr_slave):
+            if fd is None:
+                continue
             with contextlib.suppress(OSError):
                 os.close(fd)
         raise
 
     # Parent does NOT need slave fds; close them so EOF arrives on
     # master when child closes its side.
-    with contextlib.suppress(OSError):
-        os.close(stdout_slave)
-    with contextlib.suppress(OSError):
-        os.close(stderr_slave)
+    for slave_fd in (stdout_slave, stderr_slave):
+        if slave_fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(slave_fd)
 
     return proc, stdout_master, stderr_master
 
@@ -367,6 +376,7 @@ def _spawn_subprocess(
     cwd: Path | str,
     env: Mapping[str, str],
     stdin: Any,
+    stderr_pipe: bool = False,
 ) -> tuple[subprocess.Popen, int | None, int | None]:
     """Spawn ``cmd`` using PTY mode by default; pipe mode on opt-out.
 
@@ -383,7 +393,13 @@ def _spawn_subprocess(
     if _pty_disabled_via_env():
         return _spawn_pipe_subprocess(cmd, cwd=cwd, env=env, stdin=stdin)
     try:
-        return _spawn_pty_subprocess(cmd, cwd=cwd, env=env, stdin=stdin)
+        return _spawn_pty_subprocess(
+            cmd,
+            cwd=cwd,
+            env=env,
+            stdin=stdin,
+            stderr_pipe=stderr_pipe,
+        )
     except _PTYUnavailableError as exc:
         import warnings
 
@@ -1126,6 +1142,11 @@ def _execute_invocation_plan(
                 cwd=review_cwd,
                 env=env,
                 stdin=stdin_handle,
+                # PTYs make stdout line-buffered, but macOS can discard bytes
+                # still waiting on a PTY master when an instantly failing
+                # child closes its slave. Keep stderr on a pipe so CLI errors
+                # survive every nonzero exit for task-state/log reporting.
+                stderr_pipe=True,
             )
         except (FileNotFoundError, PermissionError, OSError) as exc:
             record = _build_usage_record(

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1909,6 +1909,16 @@ def _classify_final_status(
     return "failed"
 
 
+def _first_error_line(stderr_excerpt: str | None) -> str | None:
+    """Return the first non-blank captured stderr line for task summaries."""
+    if not stderr_excerpt:
+        return None
+    return next(
+        (line.strip() for line in stderr_excerpt.splitlines() if line.strip()),
+        None,
+    )
+
+
 def _emit_terminal_dispatch_event(
     *,
     task_id: str,
@@ -2187,6 +2197,13 @@ def _run_worker(
     if needs_finalize:
         final_status = "needs_finalize"
 
+    last_error = _first_error_line(stderr_excerpt) if final_status != "done" else None
+    if last_error:
+        # Task logs capture this worker's stderr, while agent_runtime captures
+        # the CLI child's stderr internally. Re-emit the excerpt so an
+        # instant CLI failure is visible in both task state and its stderr log.
+        print(stderr_excerpt, file=sys.stderr, flush=True)
+
     worktree_reap: dict[str, Any] | None = None
     if (
         worktree_path
@@ -2219,6 +2236,8 @@ def _run_worker(
             "stderr_excerpt": stderr_excerpt,
             "returncode": returncode,
             "returncode_reason": returncode_reason,
+            "last_error": last_error,
+            "exit_code": returncode,
             "worktree_dirty_on_exit": dirty_on_exit,
             "commits_ahead": commits_ahead,
             "needs_finalize": needs_finalize,
@@ -2484,6 +2503,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             "stderr_excerpt": None,
             "returncode": None,
             "returncode_reason": None,
+            "last_error": None,
+            "exit_code": None,
             "substitution": None,
         }
         if lifecycle_carrier is not None:
@@ -2624,6 +2645,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "stderr_excerpt": None,
         "returncode": None,
         "returncode_reason": None,
+        "last_error": None,
+        "exit_code": None,
         "substitution": None,
     }
     if lifecycle_carrier is not None:
@@ -2737,14 +2760,17 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             # pid=None and no zombie detection could rescue it
             # (because zombie detection is gated on `pid and not alive`).
             # Codex 2026-04-10 audit finding.
+            spawn_error = f"Popen failed: {type(exc).__name__}: {exc}"[:500]
             failed_state = _read_state(state_path) or initial_state
             failed_state.update(
                 {
                     "status": "failed",
                     "finished_at": datetime.now(UTC).isoformat(),
-                    "stderr_excerpt": (f"Popen failed: {type(exc).__name__}: {exc}")[:500],
+                    "stderr_excerpt": spawn_error,
                     "returncode": None,
                     "returncode_reason": "worker process was not started",
+                    "last_error": _first_error_line(spawn_error),
+                    "exit_code": None,
                 }
             )
             failed_state.update(

--- a/tests/agent_runtime/adapters/test_kimi_adapter.py
+++ b/tests/agent_runtime/adapters/test_kimi_adapter.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from scripts.agent_runtime.adapters.kimi import (
+    _MODE_FLAGS,
+    _READ_ONLY_REFUSAL,
     KIMI_DEFAULT_EFFORT,
     KIMI_DEFAULT_MODEL,
     KIMI_MODEL_ALIASES,
@@ -25,7 +28,7 @@ def _build(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     *,
-    mode: str = "read-only",
+    mode: str = "workspace-write",
     model: str | None = None,
     effort: str | None = None,
 ):
@@ -45,22 +48,29 @@ def _build(
     )
 
 
-@pytest.mark.parametrize(
-    ("mode", "expected_flag"),
-    [
-        ("read-only", None),
-        ("workspace-write", "--auto"),
-        ("danger", "--yolo"),
-    ],
-)
-def test_build_invocation_maps_permission_modes(tmp_path, monkeypatch, mode, expected_flag):
+@pytest.mark.parametrize("mode", ["workspace-write", "danger"])
+def test_build_invocation_uses_flagless_write_modes(tmp_path, monkeypatch, mode):
     plan = _build(tmp_path, monkeypatch, mode=mode)
 
     assert plan.cmd[0] == str(tmp_path / "kimi")
     assert plan.cmd[plan.cmd.index("-m") + 1] == KIMI_MODEL_ALIASES[KIMI_DEFAULT_MODEL]
     assert plan.cmd[plan.cmd.index("--output-format") + 1] == "stream-json"
-    assert "--plan" not in plan.cmd  # Kimi rejects --prompt + --plan.
-    assert (expected_flag in plan.cmd) if expected_flag else not ({"--auto", "--yolo"} & set(plan.cmd))
+    assert not ({"--auto", "--yolo", "--plan"} & set(plan.cmd))
+
+
+def test_mode_flag_mapping_is_empty_for_all_headless_modes():
+    assert _MODE_FLAGS == {
+        "read-only": (),
+        "workspace-write": (),
+        "danger": (),
+    }
+
+
+def test_read_only_refuses_before_kimi_binary_resolution(tmp_path, monkeypatch):
+    with patch("scripts.agent_runtime.adapters.kimi._resolve_kimi_binary") as resolve_binary:
+        with pytest.raises(ValueError, match=re.escape(_READ_ONLY_REFUSAL)):
+            _build(tmp_path, monkeypatch, mode="read-only")
+    resolve_binary.assert_not_called()
 
 
 def test_short_names_and_full_aliases_resolve_and_unknown_models_reject(tmp_path, monkeypatch):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -9,6 +9,7 @@ Issue: #1184.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import signal
@@ -1075,6 +1076,53 @@ def test_run_worker_persists_runtime_telemetry(tmp_tasks_dir, tmp_path):
     assert state["cli_version"] == "2.1.89"
     assert state["returncode"] == 0
     assert state["returncode_reason"] is None
+
+
+def test_run_worker_surfaces_instant_exit_stderr_in_task_state_and_log(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """An instant Kimi CLI error must survive runtime and dispatch capture."""
+    from agent_runtime import runner as runtime_runner
+
+    kimi_bin = tmp_path / "kimi"
+    kimi_bin.write_text(
+        "#!/bin/sh\nprintf '%s\\n' 'error: Cannot combine --prompt with --yolo.' >&2\nexit 2\n",
+        encoding="utf-8",
+    )
+    kimi_bin.chmod(0o755)
+    monkeypatch.setenv("LEARN_UK_KIMI_BIN", str(kimi_bin))
+    monkeypatch.setattr(runtime_runner, "has_headroom", lambda *_args: (True, ""))
+    monkeypatch.setattr(runtime_runner, "write_record", lambda _record: None)
+    monkeypatch.setattr(runtime_runner, "_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(delegate, "_emit_terminal_dispatch_event", lambda **_kwargs: None)
+    runtime_runner._ADAPTER_CACHE.pop("kimi", None)
+
+    task_id = "kimi-instant-exit"
+    delegate._write_state_atomic(delegate._state_path(task_id), {"task_id": task_id})
+    stderr_log = tmp_path / "kimi-instant-exit.stderr.log"
+    with stderr_log.open("w", encoding="utf-8") as handle, contextlib.redirect_stderr(handle):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="kimi",
+            prompt="Inspect the target.",
+            mode="workspace-write",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+        )
+
+    state = delegate._read_state(delegate._state_path(task_id))
+    assert rc == 1
+    assert state is not None
+    assert state["returncode"] == 2
+    assert state["exit_code"] == 2
+    assert state["last_error"] == "error: Cannot combine --prompt with --yolo."
+    assert state["stderr_excerpt"] == state["last_error"]
+    assert stderr_log.read_text(encoding="utf-8") == (
+        "error: Cannot combine --prompt with --yolo.\n"
+    )
 
 
 def test_run_worker_emits_one_terminal_dispatch_event_with_cost_fields(
@@ -3443,4 +3491,3 @@ def test_apply_dispatch_sparse_checkout_real_git(tmp_path):
     assert meta3["full_checkout"] is True
     assert (worktree / "curriculum" / "f.txt").is_file()
     assert (worktree / "wiki" / "f.txt").is_file()
-

--- a/tests/test_kimi_integration.py
+++ b/tests/test_kimi_integration.py
@@ -7,11 +7,13 @@ from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from scripts.ai_agent_bridge import _channels, _cli, _kimi
 from scripts.ai_agent_bridge._channels_cli import _cli_available_agent
-from scripts.ai_agent_bridge._model import _build_kimi_probe_plan, check_model
+from scripts.ai_agent_bridge._model import _build_kimi_probe_plan
 
 
 def test_delegate_accepts_kimi_and_does_not_create_a_fallback_mapping():
@@ -146,25 +148,12 @@ def test_fetch_kimi_message_returns_none_for_an_unaddressed_row(monkeypatch, cap
     assert "not addressed to kimi" in capsys.readouterr().out
 
 
-def test_check_model_builds_read_only_native_kimi_probe_and_uses_agent_cache(monkeypatch, tmp_path):
-    # Stub the CLI binary (same pattern as test_kimi_adapter.py): plan building
-    # resolves it via _resolve_kimi_binary, and CI runners have no kimi install —
-    # unstubbed, this test only passes on machines with the real CLI (#5326).
-    binary = tmp_path / "kimi"
-    binary.write_text("#!/bin/sh\n", encoding="utf-8")
-    binary.chmod(0o755)
-    monkeypatch.setenv("LEARN_UK_KIMI_BIN", str(binary))
-
-    plan = _build_kimi_probe_plan("k3")
-    assert plan is not None
-    assert plan.cmd[plan.cmd.index("-m") + 1] == "kimi-code/k3"
-    assert "-y" not in plan.cmd
-
-    monkeypatch.setattr(
-        "scripts.ai_agent_bridge._model.subprocess.run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="MODEL_OK", stderr=""),
-    )
-    assert check_model("k3", agent="kimi", force=True) is True
+def test_check_model_refuses_read_only_native_kimi_probe():
+    with pytest.raises(
+        ValueError,
+        match=r"kimi headless auto-approves mutations; read-only cannot be guaranteed on CLI 0.27",
+    ):
+        _build_kimi_probe_plan("k3")
 
 
 def test_kimi_trailer_is_accepted():


### PR DESCRIPTION
## Summary
- Make Kimi 0.27 workspace-write and danger invocations flagless; refuse read-only before binary resolution because headless prompts auto-approve mutations.
- Preserve instant nonzero CLI stderr by keeping PTY stdout but piping stderr, then persist the exit code/first error line and re-emit stderr into the dispatch task log.
- Cover the Kimi flag mapping/refusal and an instant exit with stderr; update the Kimi probe expectation to the refusal contract.

## Validation
- `python -m pytest -q tests/agent_runtime/adapters/test_kimi_adapter.py tests/test_delegate.py tests/test_kimi_integration.py` — 152 passed (also passed in pre-commit).
- `ruff check` on all six changed files — passed.
- `pytest -q` — 12,716 passed; 175 failed and 56 errors from existing local service/fixture/configuration dependencies, outside this diff.
- `ruff check .` — 28 pre-existing violations in untouched `docs/reports/` and `plans/` files.
- Independent Claude Opus review — approved, no findings.

Refs #5326