### PR TITLE
fix(harness): canonical model-family vocabulary — one normalizer for the route-refusal chain (#5385)

### DIFF
--- a/scripts/audit/layerb_qualify.py
+++ b/scripts/audit/layerb_qualify.py
@@ -56,7 +56,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(project_root))
     sys.path.insert(0, str(project_root / "scripts"))
 
-from scripts.audit import layerb_shadow  # isort: skip
+from scripts.audit import layerb_shadow, model_families  # isort: skip
 
 
 REPORT_VERSION = "qg-layer-b-qualification-report.v4"
@@ -652,12 +652,14 @@ def route_eligibility(case: Mapping[str, Any], route: EffectiveRoute) -> dict[st
             "reason": "GEMINI_SAME_VENDOR_REVIEWER_EXCLUDED",
         }
     # The grok route's third-family status is GUARDED, not assumed: any case
-    # whose writer or reviewer normalizes into the grok/cursor/xai lineage
-    # ("grok-cursor" in layerb_shadow.normalize_lineage_family's domain) is
-    # self-judgment and fails closed. Today's labels contain no such rows, so
-    # this changes nothing operationally — it exists so future grok/cursor-
-    # authored content can never be judged by its own lineage silently.
-    if route.family == "grok" and "grok-cursor" in {writer, reviewer}:
+    # whose writer or reviewer normalizes into the xai lineage is
+    # self-judgment and fails closed. cursor-Auto is now UNKNOWN (separate
+    # from grok per the 2026-07-17 routing decision), so a cursor-reviewed row
+    # fails closed earlier via UNKNOWN_LINEAGE rather than this guard. Today's
+    # labels contain no xai rows, so this changes nothing operationally — it
+    # exists so future grok/xai-authored content can never be judged by its
+    # own lineage silently.
+    if route.family == "grok" and model_families.Family.XAI.value in {writer, reviewer}:
         return {
             "case_id": case_id,
             "writer_family": writer,

--- a/scripts/audit/layerb_shadow.py
+++ b/scripts/audit/layerb_shadow.py
@@ -42,7 +42,7 @@ from typing import Any, Protocol
 
 import yaml
 
-from scripts.audit import layerb_qualify
+from scripts.audit import layerb_qualify, model_families
 
 if __package__ in {None, ""}:
     project_root = Path(__file__).resolve().parents[2]
@@ -257,64 +257,26 @@ def normalize_seat_key(seat_arm: Any) -> tuple[str, Mapping[str, Any]]:
     return f"seat-{_sha256_text(_canonical_json(metadata))[:16]}", metadata
 
 
-_LINEAGE_METADATA_FIELDS = (
-    "family",
-    "vendor",
-    "provider",
-    "pin",
-    "pin_slug",
-    "resolved_model",
-    "model",
-    "model_id",
-    "reviewer_model_id",
-    "writer_model_id",
-)
-
 # ``fixture`` identifies human-authored or synthetic fixture content that has
-# no model lineage.  The longer marker is retained in adversarial artifact
-# metadata so it cannot be mistaken for a real judge family, then normalizes
-# to the same non-model lineage domain used for route exclusion.
-_FIXTURE_LINEAGE_MARKERS = frozenset({"fixture", "adversarial-fixture"})
+# no model lineage. The marker is retained in adversarial artifact metadata so
+# it cannot be mistaken for a real judge family; it normalizes to the
+# non-model lineage domain used for route exclusion. The token→family mapping
+# itself lives in ``scripts.audit.model_families`` (single source of truth).
 
 
 def normalize_lineage_family(metadata: Any) -> str | None:
-    """Map seat/pin metadata to a conservative Layer-B lineage family.
+    """Map seat/pin metadata to a Layer-B lineage family.
 
-    This intentionally differs from the live-reviewer dispatcher's broader
-    routing labels.  Layer B needs one stable equality domain: Google includes
-    Gemma and Gemini; GPT includes OpenAI and Codex; and Grok and Cursor share
-    one fleet-accounting family.  Values outside that domain are not guessed.
+    Thin compatibility wrapper over the canonical
+    ``scripts.audit.model_families.normalize_lineage_family`` vocabulary — the
+    single source of truth shared with the live reviewer dispatcher. Returns
+    the family string for recognized lineage and ``None`` for ``UNKNOWN``;
+    Layer-B turns ``None`` into an explicit ``failure_class=LINEAGE_OR_ROUTE``
+    refusal rather than acceptance.
     """
 
-    candidates: set[str] = set()
-
-    def add_text(value: str) -> None:
-        text = value.strip().casefold()
-        if not text:
-            return
-        if text in _FIXTURE_LINEAGE_MARKERS:
-            candidates.add("fixture")
-        if re.search(r"(?:^|[^a-z0-9])(google|gemma|gemini)(?:$|[^a-z0-9])", text):
-            candidates.add("google")
-        if re.search(r"(?:^|[^a-z0-9])deepseek(?:$|[^a-z0-9])", text):
-            candidates.add("deepseek")
-        if re.search(r"(?:^|[^a-z0-9])(openai|codex|gpt)(?:$|[^a-z0-9])", text):
-            candidates.add("gpt")
-        if re.search(r"(?:^|[^a-z0-9])(anthropic|claude)(?:$|[^a-z0-9])", text):
-            candidates.add("claude")
-        if re.search(r"(?:^|[^a-z0-9])(grok|cursor|xai)(?:$|[^a-z0-9])", text):
-            candidates.add("grok-cursor")
-
-    def visit(value: Any) -> None:
-        if isinstance(value, str):
-            add_text(value)
-        elif isinstance(value, Mapping):
-            for field in _LINEAGE_METADATA_FIELDS:
-                if field in value:
-                    visit(value[field])
-
-    visit(metadata)
-    return next(iter(candidates)) if len(candidates) == 1 else None
+    family = model_families.normalize_lineage_family(metadata)
+    return None if family is model_families.Family.UNKNOWN else family.value
 
 
 def _first_present(*values: Any) -> Any | None:
@@ -769,8 +731,10 @@ def _select_route(
     if norm_reviewer is not None and norm_reviewer != "fixture":
         excluded.add(norm_reviewer)
 
-    excluded.add("grok")
-    excluded.add("grok-cursor")
+    # grok/xai is never a QG judge seat (model-assignment rule). cursor routes
+    # are already unsatisfiable: ``normalize_lineage_family("cursor")`` is
+    # UNKNOWN (cursor-Auto), so the ``is not None`` route guard skips them.
+    excluded.add(model_families.Family.XAI.value)
 
     return next(
         (

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -25,7 +25,7 @@ from uuid import uuid4
 
 import yaml
 
-from scripts.audit import anchor_primitives, llm_qg_canaries, llm_reviewer, qg_schema
+from scripts.audit import anchor_primitives, llm_qg_canaries, llm_reviewer, model_families, qg_schema
 from scripts.audit.content_surface_gates import policy_for_level
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -385,29 +385,17 @@ _MEASURED_COST_PROFILES: dict[str, MeasuredCostProfile] = {
 
 
 def normalize_family(raw: Any) -> str | None:
-    """Normalize agent/model labels into cross-review family buckets."""
+    """Normalize agent/model labels into cross-review family buckets.
 
-    if raw is None:
-        return None
-    text = str(raw).strip().lower()
-    if not text:
-        return None
-    text = text.replace("_", "-")
-    if "deepseek" in text:
-        return "deepseek"
-    if any(marker in text for marker in ("gemma", "gemini", "agy", "google")):
-        return "google"
-    if any(marker in text for marker in ("codex", "openai", "gpt-")):
-        return "openai"
-    if any(marker in text for marker in ("claude", "anthropic", "opus", "sonnet")):
-        return "anthropic"
-    if any(marker in text for marker in ("cursor", "composer")):
-        return "cursor"
-    if any(marker in text for marker in ("grok", "xai")):
-        return "xai"
-    if "qwen" in text:
-        return "qwen"
-    return text.split()[0].split("(")[0].strip("-") or None
+    Thin compatibility wrapper over the canonical
+    ``scripts.audit.model_families`` vocabulary — the single source of truth
+    shared with Layer-B. Returns the family string for every recognized token
+    and ``None`` for ``UNKNOWN`` (which the live path turns into an explicit
+    ``ReviewerLineageError`` refusal via ``validate_cross_family``).
+    """
+
+    family = model_families.normalize_family(raw)
+    return None if family is model_families.Family.UNKNOWN else family.value
 
 
 def route_for_review(

--- a/scripts/audit/model_families.py
+++ b/scripts/audit/model_families.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Canonical model-family vocabulary and normalizers for the route-refusal chain.
+
+Single source of truth consumed by BOTH enforcement layers:
+
+* the live reviewer dispatcher (``scripts.audit.llm_reviewer_dispatch``)
+* the Layer-B shadow lineage path (``scripts.audit.layerb_shadow``)
+
+``Family.UNKNOWN`` is a first-class answer: an unrecognized lineage is UNKNOWN,
+never silently ``None`` and never a raw token smuggled past the gate. The
+compatibility wrappers in both consuming modules translate UNKNOWN to their
+existing refusal sentinel at the seam, so an unknown writer/reviewer always
+produces an explicit refusal (``ReviewerLineageError`` on the live path;
+``failure_class=LINEAGE_OR_ROUTE`` in Layer-B) rather than acceptance or a
+crash.
+
+Routing decisions codified here (2026-07-17, issue #5385):
+
+* ``grok`` → ``xai`` — a family of its own, SEPARATE from cursor. The old
+  Layer-B ``grok-cursor`` merge is gone.
+* ``cursor`` / ``composer`` / ``auto`` alone → ``UNKNOWN``. cursor-Auto is
+  never an acceptable formal-review identity
+  (``agents_extensions/shared/rules/model-assignment.md``); a cursor seat that
+  records a pinned model inherits the pin's family.
+* ``agy`` / ``gemma`` / ``gemini`` → ``google`` (restored in Layer-B, which
+  previously orphaned ``agy``).
+* ``codex`` / ``gpt`` / ``openai`` → ``openai`` (unified; Layer-B previously
+  used ``gpt``).
+* ``claude`` / ``anthropic`` / ``opus`` / ``sonnet`` → ``anthropic``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Any
+
+UNKNOWN_FAMILY = "unknown"
+FIXTURE_FAMILY = "fixture"
+
+
+class Family(StrEnum):
+    """Canonical model families. The one vocabulary for the whole chain.
+
+    Members are strings so ``Family.XAI == "xai"`` compares cleanly against
+    legacy string-typed call sites. ``UNKNOWN`` and ``FIXTURE`` are
+    first-class: UNKNOWN is the answer for any lineage the vocabulary cannot
+    classify, FIXTURE marks human/synthetic non-model content.
+    """
+
+    GOOGLE = "google"
+    ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+    DEEPSEEK = "deepseek"
+    XAI = "xai"
+    QWEN = "qwen"
+    FIXTURE = FIXTURE_FAMILY
+    UNKNOWN = UNKNOWN_FAMILY
+
+
+_FIXTURE_MARKERS = frozenset({"fixture", "adversarial-fixture"})
+
+# Lineage-metadata fields that may carry a model-family signal. A pinned model
+# (``pin`` / ``resolved_model`` / ``*_model_id``) is more specific than a coarse
+# ``family``/``vendor``/``provider`` label, so it can override a cursor seat.
+_LINEAGE_FIELDS: tuple[str, ...] = (
+    "family",
+    "vendor",
+    "provider",
+    "pin",
+    "pin_slug",
+    "resolved_model",
+    "model",
+    "model_id",
+    "reviewer_model_id",
+    "writer_model_id",
+)
+
+# Marker words → family. Matched as whole words (casefolded) so e.g. ``gemmate``
+# is NOT mistaken for ``gemma``. cursor/composer/auto are handled separately
+# because cursor-Auto is UNKNOWN unless a pin overrides it.
+_FAMILY_TOKEN_RULES: tuple[tuple[tuple[str, ...], Family], ...] = (
+    (("deepseek",), Family.DEEPSEEK),
+    (("gemma", "gemini", "agy", "google"), Family.GOOGLE),
+    (("codex", "openai", "gpt"), Family.OPENAI),
+    (("anthropic", "claude", "opus", "sonnet"), Family.ANTHROPIC),
+    (("grok", "xai"), Family.XAI),
+    (("qwen",), Family.QWEN),
+)
+
+
+def _compile_family_patterns() -> tuple[tuple[re.Pattern[str], Family], ...]:
+    compiled: list[tuple[re.Pattern[str], Family]] = []
+    for markers, family in _FAMILY_TOKEN_RULES:
+        alternation = "|".join(re.escape(marker) for marker in markers)
+        compiled.append((re.compile(rf"(?:^|[^a-z0-9])(?:{alternation})(?:$|[^a-z0-9])"), family))
+    return tuple(compiled)
+
+
+_FAMILY_PATTERNS = _compile_family_patterns()
+_CURSOR_PATTERN = re.compile(r"(?:^|[^a-z0-9])(?:cursor|composer|auto)(?:$|[^a-z0-9])")
+
+
+def normalize_family(value: Any) -> Family:
+    """Normalize a single token (string or stringifiable) to a ``Family``.
+
+    The one token→family mapping the whole route-refusal chain consumes.
+    Returns ``Family.UNKNOWN`` for empty/unrecognized input and for bare
+    cursor/composer/auto markers (cursor-Auto). Returns ``Family.FIXTURE`` for
+    the fixture sentinels.
+    """
+
+    if value is None:
+        return Family.UNKNOWN
+    text = str(value).strip().casefold()
+    if not text:
+        return Family.UNKNOWN
+    if text in _FIXTURE_MARKERS:
+        return Family.FIXTURE
+    if _CURSOR_PATTERN.search(text):
+        # cursor-Auto: identity not pinned, so it is not a usable formal-review
+        # family. A cursor seat that records a concrete pin resolves through
+        # the pin via ``normalize_lineage_family``.
+        return Family.UNKNOWN
+    for pattern, family in _FAMILY_PATTERNS:
+        if pattern.search(text):
+            return family
+    return Family.UNKNOWN
+
+
+def _visit(metadata: Any, concrete: set[Family], saw_fixture: list[bool]) -> None:
+    if isinstance(metadata, str):
+        family = normalize_family(metadata)
+        if family is Family.FIXTURE:
+            saw_fixture.append(True)
+        elif family is not Family.UNKNOWN:
+            concrete.add(family)
+    elif isinstance(metadata, Mapping):
+        for field in _LINEAGE_FIELDS:
+            if field in metadata:
+                _visit(metadata[field], concrete, saw_fixture)
+
+
+def normalize_lineage_family(metadata: Any) -> Family:
+    """Normalize lineage metadata to a single ``Family``.
+
+    Walks the lineage-metadata fields. A pinned model overrides a coarse
+    cursor seat, so ``{"family": "cursor", "pin": "grok-4"}`` resolves to
+    ``xai`` while ``{"family": "cursor"}`` (no pin) is ``UNKNOWN``. When two
+    or more distinct concrete families appear (e.g. a ``google`` family with a
+    ``deepseek`` pin) the signal is ambiguous and the result is ``UNKNOWN``
+    (fail closed). Fixture-only metadata is ``FIXTURE``.
+    """
+
+    if metadata is None:
+        return Family.UNKNOWN
+    if isinstance(metadata, str):
+        return normalize_family(metadata)
+    concrete: set[Family] = set()
+    saw_fixture: list[bool] = []
+    _visit(metadata, concrete, saw_fixture)
+    if len(concrete) == 1:
+        return next(iter(concrete))
+    if concrete:
+        # 2+ distinct concrete families: ambiguous, fail closed.
+        return Family.UNKNOWN
+    return Family.FIXTURE if saw_fixture else Family.UNKNOWN

--- a/tests/audit/test_qg_run_serializer.py
+++ b/tests/audit/test_qg_run_serializer.py
@@ -9,7 +9,11 @@ import pytest
 
 from scripts.audit import llm_reviewer_dispatch, qg_bakeoff
 
-PRE_EXTRACTION_ARTIFACT_SHA256 = "0b06f32e84f99d8e5949b70b3bdf90eb96710d9a411465830f4bee06ce589b20"
+# Under the unified model_families vocabulary (issue #5385) the synthetic
+# experiment pin ``openrouter/test/parity-model`` classifies as UNKNOWN and
+# bakeoff_route_for_model falls back to the FRONTIER_OPENCODE family
+# (``google``) instead of smuggling the raw pin through as a family label.
+PRE_EXTRACTION_ARTIFACT_SHA256 = "b3173cf527f505a9bb563c35bbc66590a2c25897067df45342ee3f81a785d1f5"
 
 
 def test_bakeoff_tooled_artifact_matches_pre_extraction_golden_hash(

--- a/tests/audit/test_qg_shadow_run.py
+++ b/tests/audit/test_qg_shadow_run.py
@@ -284,7 +284,10 @@ def test_shadow_driver_rejects_fixture_family_on_real_module(tmp_path: Path, fam
     module_dir = _module(tmp_path)
     (module_dir / "writer_meta.json").write_text(f'{{"writer_family": "{family}"}}\n', encoding="utf-8")
 
-    with pytest.raises(ValueError, match=f"writer lineage family '{family}' is classified as a fixture"):
+    # Both fixture markers normalize to the canonical ``fixture`` family under
+    # the unified model_families vocabulary, so the rejection always echoes the
+    # canonical family (issue #5385) rather than the raw input marker.
+    with pytest.raises(ValueError, match="writer lineage family 'fixture' is classified as a fixture"):
         qg_shadow_run.run_shadow_module(
             _target(module_dir),
             audit_dir=tmp_path / "audit",

--- a/tests/test_layerb_qualify.py
+++ b/tests/test_layerb_qualify.py
@@ -900,18 +900,28 @@ def test_grok_route_self_family_rows_fail_closed() -> None:
 
     xai_written = _case("xai-written-row", "raw")
     xai_written["lineage"] = {"writer_family": "xai", "qg_reviewer_family": "codex"}
-    cursor_reviewed = _case("cursor-reviewed-row", "raw")
-    cursor_reviewed["lineage"] = {"writer_family": "claude", "qg_reviewer_family": "cursor"}
     grok_reviewed = _case("grok-reviewed-row", "raw")
     grok_reviewed["lineage"] = {"writer_family": "claude", "qg_reviewer_family": "grok"}
 
-    for case in (xai_written, cursor_reviewed, grok_reviewed):
+    # xai writer / grok reviewer normalize into the xai lineage, which the
+    # grok route IS, so they are self-judgment and fail closed here.
+    for case in (xai_written, grok_reviewed):
         row = layerb_qualify.route_eligibility(case, grok)
         assert row["eligible"] is False, case["case_id"]
         assert row["reason"] == "GROK_SELF_FAMILY_EXCLUDED", case["case_id"]
         # The same rows stay eligible for a non-grok route: the exclusion is
         # self-judgment, not a blanket ban on grok-lineage content.
         assert layerb_qualify.route_eligibility(case, gpt)["eligible"] is True, case["case_id"]
+
+    # cursor-Auto is now UNKNOWN (separate from grok, 2026-07-17 routing
+    # decision): it fails closed via UNKNOWN_LINEAGE for EVERY route, not via
+    # the grok self-family guard, and is not eligible for gpt either.
+    cursor_reviewed = _case("cursor-reviewed-row", "raw")
+    cursor_reviewed["lineage"] = {"writer_family": "claude", "qg_reviewer_family": "cursor"}
+    for route in (grok, gpt):
+        row = layerb_qualify.route_eligibility(cursor_reviewed, route)
+        assert row["eligible"] is False, (route.family, row)
+        assert row["reason"] == "UNKNOWN_LINEAGE", (route.family, row)
 
 
 def test_unknown_route_family_still_refused() -> None:

--- a/tests/test_layerb_shadow.py
+++ b/tests/test_layerb_shadow.py
@@ -134,20 +134,30 @@ def test_seat_key_is_canonical_not_python_dict_order() -> None:
     assert first_metadata == second_metadata
 
 
-def test_normalize_lineage_family_uses_conservative_vendor_families() -> None:
+def test_normalize_lineage_family_uses_canonical_vendor_families() -> None:
+    # Single source of truth: layer-B now agrees with the live dispatcher on
+    # every token (see test_model_families for the cross-layer agreement
+    # table). grok/cursor are SEPARATE; cursor-Auto is UNKNOWN (None here).
     cases = (
         ({"family": "deepseek", "pin": "openrouter/deepseek/deepseek-v4-flash"}, "deepseek"),
         ({"family": "google", "pin": "openrouter/google/gemma-4-31b-it"}, "google"),
-        ({"family": "openai", "pin": "gpt-5.6-terra"}, "gpt"),
-        ({"family": "anthropic", "pin": "claude-opus-4-6"}, "claude"),
-        ({"family": "cursor", "pin": "grok-4"}, "grok-cursor"),
+        ({"family": "openai", "pin": "gpt-5.6-terra"}, "openai"),
+        ({"family": "anthropic", "pin": "claude-opus-4-6"}, "anthropic"),
+        ({"family": "agy", "pin": "gemini-3.1-pro"}, "google"),
+        ({"family": "qwen", "pin": "qwen-2.5"}, "qwen"),
+        ({"family": "grok", "pin": "grok-4"}, "xai"),
+        # cursor seat with a pinned model inherits the pin's family.
+        ({"family": "cursor", "pin": "grok-4"}, "xai"),
+        # cursor-Auto (no pin) is UNKNOWN -> None at the compatibility seam.
+        ({"family": "cursor"}, None),
         ("adversarial-fixture", "fixture"),
+        # Ambiguous concrete signals fail closed.
         ({"family": "google", "pin": "openrouter/deepseek/deepseek-v4-pro"}, None),
         ({"family": "unmapped", "pin": "local/mystery-model"}, None),
     )
 
     for metadata, expected in cases:
-        assert normalize_lineage_family(metadata) == expected
+        assert normalize_lineage_family(metadata) == expected, metadata
 
 
 def test_route_selection_treats_gemma_writer_and_gemini_judge_as_same_family() -> None:
@@ -177,7 +187,9 @@ def test_route_selection_ignores_adversarial_fixture_reviewer_marker() -> None:
     assert route == gemini
 
 
-def test_route_selection_excludes_grok_and_grok_cursor() -> None:
+def test_route_selection_excludes_grok_xai_and_cursor_routes() -> None:
+    # grok/xai is never a QG judge seat; cursor-Auto is UNKNOWN and thus
+    # unsatisfiable. Both drop out, leaving the cross-family claude route.
     grok = JudgeRoute("grok", "grok-2")
     cursor = JudgeRoute("cursor", "cursor-fast")
     claude = JudgeRoute("claude", "claude-opus-4-6")
@@ -207,11 +219,11 @@ def test_route_selection_refuses_when_lineage_unnormalized() -> None:
         ({}, ("fixture", "google")),
         (
             {"writer_family": "openai", "dispatch": {"reviewer_family": "deepseek"}},
-            ("gpt", "deepseek"),
+            ("openai", "deepseek"),
         ),
         (
             {"writer_seat": {"family": "anthropic", "pin": "claude-opus-4-6"}},
-            ("claude", "google"),
+            ("anthropic", "google"),
         ),
         (
             {"dispatch": {"reviewer_family": "adversarial-fixture"}},

--- a/tests/test_model_families.py
+++ b/tests/test_model_families.py
@@ -1,0 +1,152 @@
+"""Tests for the canonical model-family vocabulary (issue #5385).
+
+The route-refusal chain used to carry TWO divergent family vocabularies
+(live dispatcher vs Layer-B). They now both consume the single
+``scripts.audit.model_families`` module. These tests pin:
+
+* the canonical token→family mapping and the explicit UNKNOWN/FIXTURE members;
+* that both former call sites AGREE on every previously-recognized token;
+* that an UNKNOWN writer propagates to an explicit refusal, never acceptance
+  or a crash, on BOTH layers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.audit import layerb_shadow, llm_reviewer_dispatch, model_families
+
+# Every previously-recognized token, mapped to the unified family it must
+# normalize to in BOTH layers. "previously-recognized" = the union of tokens
+# the two old normalizers ever returned a non-raw answer for.
+_TOKEN_TO_FAMILY = {
+    # deepseek
+    "deepseek": "deepseek",
+    "deepseek-v4-pro": "deepseek",
+    "openrouter/deepseek/deepseek-v4-flash": "deepseek",
+    # google (gemma + gemini + agy)
+    "google": "google",
+    "gemma": "google",
+    "gemma-4-31b-it": "google",
+    "gemini": "google",
+    "gemini-3.1-pro": "google",
+    "agy": "google",
+    # openai (codex + gpt + openai)
+    "openai": "openai",
+    "gpt-5.6-terra": "openai",
+    "codex": "openai",
+    "gpt": "openai",
+    # anthropic (claude + opus + sonnet)
+    "anthropic": "anthropic",
+    "claude": "anthropic",
+    "claude-opus-4-6": "anthropic",
+    "opus": "anthropic",
+    "sonnet": "anthropic",
+    # xai (grok) — SEPARATE from cursor
+    "grok": "xai",
+    "grok-4": "xai",
+    "xai": "xai",
+    # qwen — restored in Layer-B (was orphaned/None)
+    "qwen": "qwen",
+    "qwen-2.5": "qwen",
+    # fixture sentinel
+    "fixture": "fixture",
+    "adversarial-fixture": "fixture",
+}
+
+# Tokens that are UNKNOWN under the unified vocabulary. cursor-Auto is the
+# routing decision (2026-07-17); glm/kimi/pool were raw-passthrough in the old
+# live normalizer and are now first-class UNKNOWN instead.
+_UNKNOWN_TOKENS = (
+    "cursor",
+    "composer",
+    "auto",
+    "cursor-fast",
+    "mystery-model",
+    "glm",
+    "kimi-k3",
+    "pool",
+)
+
+
+def test_canonical_normalize_family_maps_every_recognized_token() -> None:
+    for token, expected in _TOKEN_TO_FAMILY.items():
+        assert model_families.normalize_family(token).value == expected, token
+
+
+def test_canonical_normalize_family_unknown_is_first_class() -> None:
+    for token in _UNKNOWN_TOKENS:
+        assert model_families.normalize_family(token) is model_families.Family.UNKNOWN, token
+    assert model_families.normalize_family("") is model_families.Family.UNKNOWN
+    assert model_families.normalize_family(None) is model_families.Family.UNKNOWN
+
+
+def test_canonical_word_boundary_prevents_false_matches() -> None:
+    # "gemmate" must NOT be read as gemma; "openrouter" has no openai marker.
+    assert model_families.normalize_family("gemmate-thing") is model_families.Family.UNKNOWN
+    assert model_families.normalize_family("openrouter") is model_families.Family.UNKNOWN
+
+
+def test_canonical_lineage_prefers_pin_over_cursor_seat() -> None:
+    # cursor seat + pinned model -> the pin's family.
+    assert model_families.normalize_lineage_family({"family": "cursor", "pin": "grok-4"}) is model_families.Family.XAI
+    assert (
+        model_families.normalize_lineage_family({"family": "cursor", "pin": "claude-opus-4-6"})
+        is model_families.Family.ANTHROPIC
+    )
+    # cursor-Auto (no pin) is UNKNOWN.
+    assert model_families.normalize_lineage_family({"family": "cursor"}) is model_families.Family.UNKNOWN
+
+
+def test_canonical_lineage_ambiguous_concrete_signals_fail_closed() -> None:
+    assert (
+        model_families.normalize_lineage_family({"family": "google", "pin": "openrouter/deepseek/deepseek-v4-pro"})
+        is model_families.Family.UNKNOWN
+    )
+
+
+@pytest.mark.parametrize("token", sorted(_TOKEN_TO_FAMILY))
+def test_both_consumption_layers_agree_on_every_recognized_token(token: str) -> None:
+    expected = _TOKEN_TO_FAMILY[token]
+    live = llm_reviewer_dispatch.normalize_family(token)
+    layer_b = layerb_shadow.normalize_lineage_family(token)
+    assert live == expected, (token, "live", live)
+    assert layer_b == expected, (token, "layer-b", layer_b)
+
+
+@pytest.mark.parametrize("token", _UNKNOWN_TOKENS)
+def test_both_consumption_layers_agree_on_unknown(token: str) -> None:
+    # UNKNOWN collapses to None at the compatibility seam in BOTH layers.
+    assert llm_reviewer_dispatch.normalize_family(token) is None, token
+    assert layerb_shadow.normalize_lineage_family(token) is None, token
+
+
+def test_unknown_writer_refuses_in_layer_b_with_explicit_failure_class() -> None:
+    # An UNKNOWN writer cannot satisfy the third-family constraint: route
+    # selection returns None, which the runner turns into the explicit
+    # LINEAGE_OR_ROUTE failure_class (relation=AUDIT), never acceptance.
+    from scripts.audit.layerb_shadow import JudgeRoute, _select_route
+
+    gemini = JudgeRoute("gemini", "gemini-3.1-pro")
+    claude = JudgeRoute("claude", "claude-opus-4-6")
+
+    # cursor-Auto writer -> UNKNOWN -> no satisfiable route.
+    assert _select_route((gemini, claude), writer_family="cursor", reviewer_family="deepseek") is None
+    # arbitrary unrecognized writer -> UNKNOWN -> no satisfiable route.
+    assert _select_route((gemini, claude), writer_family="glm", reviewer_family="deepseek") is None
+
+
+def test_unknown_writer_refuses_on_live_path_with_lineage_error() -> None:
+    # On the live path an UNKNOWN family resolves to lineage.family=None, which
+    # validate_cross_family turns into an explicit ReviewerLineageError refusal
+    # (never acceptance, never a silent pass).
+    lineage = llm_reviewer_dispatch.AuthorLineage(family=None, source="test")
+    with pytest.raises(llm_reviewer_dispatch.ReviewerLineageError):
+        llm_reviewer_dispatch.validate_cross_family(llm_reviewer_dispatch.GEMMA_SURFACE_ROUTE, lineage)
+
+
+def test_self_review_still_blocks_when_families_match() -> None:
+    # Behavior preservation: equal families still raise ReviewerSelfReviewError.
+    lineage = llm_reviewer_dispatch.AuthorLineage(family="google", source="test")
+    with pytest.raises(llm_reviewer_dispatch.ReviewerSelfReviewError):
+        llm_reviewer_dispatch.validate_cross_family(llm_reviewer_dispatch.GEMMA_SURFACE_ROUTE, lineage)


### PR DESCRIPTION
Fixes the HIGH from the glm security audit (S2-1, #5385): the judge-safety chain classified families in two incompatible vocabularies — latent self-review gap (cursor≠grok at dispatch level, merged in Layer-B) and orphaned families (agy/qwen → None, accepted upstream, refused downstream with a cryptic class).

## What ships
- `scripts/audit/model_families.py` — ONE canonical vocabulary, `Family.UNKNOWN` first-class, pinned-model override for cursor seats, fixture markers incl. `adversarial-fixture`
- Both enforcement layers consume it via thin wrappers; UNKNOWN → explicit refusal at both seams
- Token decisions codified: grok=xai (separate from cursor) · cursor-Auto=UNKNOWN · agy/gemma=google · unified openai/anthropic
- Cross-layer agreement test over every previously-recognized token + UNKNOWN-propagation tests
- Scorer untouched (guard comment re-expressed only)

## Evidence (#M-4)
- `196 passed` across the six touched test files (incl. new `tests/test_model_families.py`)
- ruff clean
- Diff applied clean from glm's file-drop (`/tmp/glm-5385.diff` sha256 b93da3e7…; bridge-truncation workaround per #5392)

Authorship: glm (glm-5.2) authored; claude-infra applied/integrated. Cross-family review: non-Zhipu required.

Refs #5385

🤖 Generated with [Claude Code](https://claude.com/claude-code)