### PR TITLE
feat(guardrails): primary-checkout write guard — tracked files read-only outside worktrees (#5389)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -478,9 +478,7 @@ def _reap_runtime_tmp_lease(
             os.close(namespace_fd)
         result["tmp_bytes_freed"] = bytes_freed
     except Exception as exc:
-        result["tmp_reap_error"] = (
-            f"{type(exc).__name__}: {exc}"
-        )[:500]
+        result["tmp_reap_error"] = (f"{type(exc).__name__}: {exc}")[:500]
     return result
 
 
@@ -557,6 +555,15 @@ def _load_worktree_containment():
     from scripts.guardrails import worktree_containment
 
     return worktree_containment
+
+
+def _load_primary_write_guard():
+    """Import the primary write guard logic (#5389), ensuring repo root on path."""
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    from scripts.guardrails import primary_write_guard
+
+    return primary_write_guard
 
 
 def _resolve_cwd_path(raw: str) -> Path:
@@ -688,6 +695,19 @@ def _resolve_dirty_primary_checkout_error(*, mode: str) -> str | None:
         return None
 
     entries = status.get("entries") or []
+
+    extra_diagnostic = ""
+    try:
+        pwg = _load_primary_write_guard()
+        writable = pwg.get_writable_tracked_files(_REPO_ROOT)
+        if writable:
+            offenders = [str(f.relative_to(_REPO_ROOT)) for f in writable]
+            extra_diagnostic = f"   writable tracked files (guard OFF): {', '.join(offenders)}\n"
+        else:
+            extra_diagnostic = "   writable tracked files (guard ON): (none)\n"
+    except Exception as exc:
+        extra_diagnostic = f"   could not check write guard status: {exc}\n"
+
     return (
         "❌ primary checkout is dirty; refusing write-capable dispatch before "
         "creating branch/worktree residue.\n"
@@ -695,6 +715,7 @@ def _resolve_dirty_primary_checkout_error(*, mode: str) -> str | None:
         f"   command: {status.get('checked_command')}\n"
         f"   branch: {status.get('branch')}\n"
         f"   dirty files: {_format_dirty_entries(entries)}\n"
+        f"{extra_diagnostic}"
         "   Clean/stash the primary checkout, or keep only gitignored local "
         "runtime state, then retry."
     )
@@ -736,16 +757,12 @@ def _validate_branch_reuse_name(branch: str) -> str:
     if not normalized:
         raise ValueError("--branch must name an existing non-protected branch")
     if normalized.startswith(("origin/", "refs/")):
-        raise ValueError(
-            "--branch must be a local branch name without origin/ or refs/ prefixes: "
-            f"got {branch!r}"
-        )
+        raise ValueError(f"--branch must be a local branch name without origin/ or refs/ prefixes: got {branch!r}")
 
     containment = _load_worktree_containment()
     if normalized in containment.PROTECTED_BRANCHES:
         raise ValueError(
-            f"refusing --branch {normalized!r}: protected branches may not be "
-            "attached to a dispatch worktree"
+            f"refusing --branch {normalized!r}: protected branches may not be attached to a dispatch worktree"
         )
     return normalized
 
@@ -761,9 +778,7 @@ def _fetch_existing_branch(branch: str) -> None:
         env=_sanitized_git_env(),
     )
     if proc.returncode != 0:
-        raise RuntimeError(
-            f"could not fetch existing branch {branch!r}: {_format_process_failure(proc)}"
-        )
+        raise RuntimeError(f"could not fetch existing branch {branch!r}: {_format_process_failure(proc)}")
     verify = subprocess.run(
         ["git", "rev-parse", "--verify", f"origin/{branch}"],
         cwd=_REPO_ROOT,
@@ -773,9 +788,7 @@ def _fetch_existing_branch(branch: str) -> None:
         env=_sanitized_git_env(),
     )
     if verify.returncode != 0:
-        raise RuntimeError(
-            f"origin/{branch} was not found after fetch; --branch requires an existing remote branch"
-        )
+        raise RuntimeError(f"origin/{branch} was not found after fetch; --branch requires an existing remote branch")
 
 
 def _branch_worktree_paths(branch: str) -> list[Path]:
@@ -1387,21 +1400,16 @@ def _normalize_sparse_include(raw: Sequence[str] | None) -> tuple[str, ...]:
         name = str(item).strip().strip("/")
         if not name or name in {".", ".."}:
             raise ValueError(
-                f"--sparse-include {item!r} is empty or invalid; "
-                f"pass a top-level name such as 'curriculum' or 'wiki'"
+                f"--sparse-include {item!r} is empty or invalid; pass a top-level name such as 'curriculum' or 'wiki'"
             )
         if "/" in name:
             top = name.split("/", 1)[0]
             raise ValueError(
-                f"--sparse-include {item!r} must be a top-level directory name "
-                f"(use {top!r}, not a nested path)"
+                f"--sparse-include {item!r} must be a top-level directory name (use {top!r}, not a nested path)"
             )
         if name not in _DISPATCH_SPARSE_EXCLUDE_DEFAULT:
             allowed = ", ".join(sorted(_DISPATCH_SPARSE_EXCLUDE_DEFAULT))
-            raise ValueError(
-                f"--sparse-include {name!r} is not a default-excluded tree; "
-                f"allowed: {allowed}"
-            )
+            raise ValueError(f"--sparse-include {name!r} is not a default-excluded tree; allowed: {allowed}")
         if name in seen:
             continue
         seen.add(name)
@@ -1459,9 +1467,7 @@ def _list_worktree_top_dirs(worktree_path: Path, *, at_ref: str = "HEAD") -> lis
     )
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or "git ls-tree failed").strip()
-        raise RuntimeError(
-            f"could not list top-level dirs in {worktree_path}: {detail}"
-        )
+        raise RuntimeError(f"could not list top-level dirs in {worktree_path}: {detail}")
     return [line.strip() for line in (proc.stdout or "").splitlines() if line.strip()]
 
 
@@ -1505,9 +1511,7 @@ def _apply_dispatch_sparse_checkout(
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout or "sparse-checkout disable failed").strip()
             telemetry["error"] = detail
-            raise RuntimeError(
-                f"failed to disable sparse-checkout in {worktree_path}: {detail}"
-            )
+            raise RuntimeError(f"failed to disable sparse-checkout in {worktree_path}: {detail}")
         telemetry["applied"] = True
         return telemetry
 
@@ -1525,9 +1529,7 @@ def _apply_dispatch_sparse_checkout(
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout or "sparse-checkout disable failed").strip()
             telemetry["error"] = detail
-            raise RuntimeError(
-                f"failed to disable sparse-checkout in {worktree_path}: {detail}"
-            )
+            raise RuntimeError(f"failed to disable sparse-checkout in {worktree_path}: {detail}")
         telemetry["applied"] = True
         return telemetry
 
@@ -1535,9 +1537,7 @@ def _apply_dispatch_sparse_checkout(
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or "sparse-checkout init failed").strip()
         telemetry["error"] = detail
-        raise RuntimeError(
-            f"failed to init sparse-checkout in {worktree_path}: {detail}"
-        )
+        raise RuntimeError(f"failed to init sparse-checkout in {worktree_path}: {detail}")
 
     proc = _run_git(["git", "sparse-checkout", "set", "--", *included])
     if proc.returncode != 0:
@@ -1636,8 +1636,7 @@ def _ensure_worktree(
 
     if dry_run:
         raise ValueError(
-            f"branch reuse dry-run found no existing worktree at {worktree_path}; "
-            "rerun without --dry-run to create one"
+            f"branch reuse dry-run found no existing worktree at {worktree_path}; rerun without --dry-run to create one"
         )
 
     # Fix 1 (#1476): fetch origin/{base} and branch from the remote ref,
@@ -1671,9 +1670,7 @@ def _ensure_worktree(
     if requested_branch and _resolve_sha(_REPO_ROOT, f"refs/heads/{requested_branch}"):
         add_command.extend([str(worktree_path), requested_branch])
     elif requested_branch:
-        add_command.extend(
-            ["--track", "-b", requested_branch, str(worktree_path), f"origin/{requested_branch}"]
-        )
+        add_command.extend(["--track", "-b", requested_branch, str(worktree_path), f"origin/{requested_branch}"])
     else:
         add_command.extend(["-b", worktree_branch, str(worktree_path), worktree_base_ref])
     proc = subprocess.run(
@@ -1770,14 +1767,10 @@ def _build_research_context(args: argparse.Namespace):
         if value is not None and len(value) > reg.MAX_QUERY_VALUE_LEN:
             raise ResearchContextError(f"{label} value too long (max {reg.MAX_QUERY_VALUE_LEN} chars)")
     if len(owned) > reg.MAX_OWNED_PATHS:
-        raise ResearchContextError(
-            f"too many --research-owned-path values ({len(owned)} > {reg.MAX_OWNED_PATHS})"
-        )
+        raise ResearchContextError(f"too many --research-owned-path values ({len(owned)} > {reg.MAX_OWNED_PATHS})")
     for path in owned:
         if len(path) > reg.MAX_OWNED_PATH_LEN:
-            raise ResearchContextError(
-                f"--research-owned-path value too long (max {reg.MAX_OWNED_PATH_LEN} chars)"
-            )
+            raise ResearchContextError(f"--research-owned-path value too long (max {reg.MAX_OWNED_PATH_LEN} chars)")
     return reg.normalize_context(role, family, track, owned)
 
 
@@ -1801,9 +1794,7 @@ def _render_research_prompt_block(pointers: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-def _with_optional_research_state(
-    state: dict[str, Any], research_state: dict[str, Any] | None
-) -> dict[str, Any]:
+def _with_optional_research_state(state: dict[str, Any], research_state: dict[str, Any] | None) -> dict[str, Any]:
     """Add ``"research"`` to ``state`` only when ``research_state`` is non-``None``.
 
     ADR-011 P3 default-compatibility: a no-flags dispatch, a disabled registry, or
@@ -2400,9 +2391,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         return 2
 
     try:
-        lifecycle_carrier, lifecycle_prompt = _load_task_lifecycle_carrier(
-            getattr(args, "lifecycle_file", None)
-        )
+        lifecycle_carrier, lifecycle_prompt = _load_task_lifecycle_carrier(getattr(args, "lifecycle_file", None))
     except (OSError, ValueError) as exc:
         print(f"❌ invalid --lifecycle-file: {exc}", file=sys.stderr)
         return 2
@@ -2442,11 +2431,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         dry_run_branch: str | None = None
         dry_run_worktree_telemetry: dict[str, Any] = {}
         if requested_branch:
-            resolved_raw = (
-                str(_auto_worktree_path(dispatch_agent, task_id))
-                if worktree_arg == "auto"
-                else worktree_arg
-            )
+            resolved_raw = str(_auto_worktree_path(dispatch_agent, task_id)) if worktree_arg == "auto" else worktree_arg
             assert resolved_raw is not None  # --branch above supplies the auto sentinel.
             try:
                 (

--- a/scripts/guardrails/primary_write_guard.py
+++ b/scripts/guardrails/primary_write_guard.py
@@ -33,10 +33,12 @@ except ImportError:
         from common.git_context import sanitized_git_env  # type: ignore[import-not-found]
     except ImportError:
         def sanitized_git_env() -> dict[str, str]:
+            # Mirror of scripts.common.git_context.GIT_REDIRECT_ENV_KEYS — keep in sync.
             _GIT_ENV = {
-                "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY",
-                "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES",
-                "GIT_DISCOVERY_ACROSS_FILESYSTEM", "GIT_COMMON_DIR"
+                "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX",
+                "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY",
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_NAMESPACE",
+                "GIT_CEILING_DIRECTORIES", "GIT_DISCOVERY_ACROSS_FILESYSTEM",
             }
             return {k: v for k, v in os.environ.items() if k not in _GIT_ENV}
 
@@ -111,7 +113,13 @@ def get_writable_tracked_files(main_root: Path) -> list[Path]:
 
 
 def apply_guard(hook_mode: bool = False) -> None:
-    """Make all tracked files read-only (chmod a-w)."""
+    """Make all tracked files read-only (chmod a-w).
+
+    Note the deliberate asymmetry with :func:`release_guard`: apply strips ALL
+    write bits (u,g,o), release restores only the owner bit (u+w). A file that
+    was group-writable before the first apply stays group-read-only after a
+    release — accepted metadata loss; only the owner needs write access here.
+    """
     main_root = check_primary_checkout_root(hook_mode=hook_mode)
 
     try:
@@ -152,7 +160,7 @@ def apply_guard(hook_mode: bool = False) -> None:
 
 
 def release_guard() -> None:
-    """Restore write permission on tracked files (chmod u+w)."""
+    """Restore write permission on tracked files (chmod u+w only — see apply_guard docstring)."""
     main_root = check_primary_checkout_root(hook_mode=False)
 
     try:
@@ -237,7 +245,12 @@ def install_hooks() -> None:
             print(f"Error creating hooks directory: {e}", file=sys.stderr)
             sys.exit(1)
 
-    hook_names = ["post-merge", "post-checkout", "post-commit"]
+    # post-merge ONLY (review #5399): `git pull`/merge is the one automation path
+    # that (re)creates tracked files with write bits, so re-apply there. post-commit
+    # never touches working-tree files, and post-checkout would add an O(tracked)
+    # lstat scan to every checkout for a path that branch-switch guards already
+    # cover in the primary. Opt-in manually via `apply` if ever needed.
+    hook_names = ["post-merge"]
     hook_command = (
         "\n# AGY_PRIMARY_WRITE_GUARD_START\n"
         'if [ -f "scripts/guardrails/primary_write_guard.py" ]; then\n'

--- a/scripts/guardrails/primary_write_guard.py
+++ b/scripts/guardrails/primary_write_guard.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Primary checkout write guard (issue #5389).
+
+Ensures that agents cannot write to tracked files in the primary checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+# Dual-flavor import support
+try:
+    from scripts.guardrails import worktree_containment as wc
+except ImportError:
+    try:
+        import worktree_containment as wc  # type: ignore[import-not-found]
+    except ImportError:
+        _root = Path(__file__).resolve().parent.parent.parent
+        if str(_root) not in sys.path:
+            sys.path.insert(0, str(_root))
+        from scripts.guardrails import worktree_containment as wc
+
+# Dual-flavor git environment sanitizer import
+try:
+    from scripts.common.git_context import sanitized_git_env
+except ImportError:
+    try:
+        from common.git_context import sanitized_git_env  # type: ignore[import-not-found]
+    except ImportError:
+        def sanitized_git_env() -> dict[str, str]:
+            _GIT_ENV = {
+                "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY",
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES",
+                "GIT_DISCOVERY_ACROSS_FILESYSTEM", "GIT_COMMON_DIR"
+            }
+            return {k: v for k, v in os.environ.items() if k not in _GIT_ENV}
+
+
+def check_primary_checkout_root(hook_mode: bool = False) -> Path:
+    """Verify that we are executing from the root of the primary checkout."""
+    try:
+        main_root = wc.resolve_main_root()
+    except Exception as e:
+        if hook_mode:
+            sys.exit(0)
+        print(f"Error: Not inside a git repository: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    cwd = Path.cwd().resolve()
+    if cwd != main_root:
+        if hook_mode:
+            sys.exit(0)
+        print(
+            f"Error: Must be run from the primary checkout root ({main_root}), current cwd is ({cwd})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    path_class = wc.classify_repo_path(cwd)
+    if path_class != "primary_checkout":
+        if hook_mode:
+            sys.exit(0)
+        print(
+            f"Error: Refusing to run inside a worktree (classification: {path_class})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return main_root
+
+
+def get_writable_tracked_files(main_root: Path) -> list[Path]:
+    """Get all regular tracked files in the repository that have write permissions."""
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=str(main_root),
+            capture_output=True,
+            text=True,
+            check=True,
+            env=sanitized_git_env(),
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error listing tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    tracked_files = proc.stdout.split("\0")
+    if tracked_files and not tracked_files[-1]:
+        tracked_files.pop()
+
+    writable_files = []
+    for rel_path_str in tracked_files:
+        if not rel_path_str:
+            continue
+        file_path = main_root / rel_path_str
+        try:
+            st = file_path.lstat()
+            # Must be a regular file, NOT a directory, NOT a symlink, and must have write permission (u, g, or o)
+            if stat.S_ISREG(st.st_mode) and not stat.S_ISLNK(st.st_mode) and (st.st_mode & 0o222):
+                writable_files.append(file_path)
+        except OSError:
+            # File might not exist (e.g. deleted or sparse checkout) or permission error
+            continue
+
+    return writable_files
+
+
+def apply_guard(hook_mode: bool = False) -> None:
+    """Make all tracked files read-only (chmod a-w)."""
+    main_root = check_primary_checkout_root(hook_mode=hook_mode)
+
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=str(main_root),
+            capture_output=True,
+            text=True,
+            check=True,
+            env=sanitized_git_env(),
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error listing tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    tracked_files = proc.stdout.split("\0")
+    if tracked_files and not tracked_files[-1]:
+        tracked_files.pop()
+
+    chmod_count = 0
+    for rel_path_str in tracked_files:
+        if not rel_path_str:
+            continue
+        file_path = main_root / rel_path_str
+        try:
+            st = file_path.lstat()
+            if stat.S_ISREG(st.st_mode) and not stat.S_ISLNK(st.st_mode):
+                current_mode = st.st_mode
+                new_mode = current_mode & ~0o222
+                if current_mode != new_mode:
+                    os.chmod(file_path, new_mode)
+                    chmod_count += 1
+        except OSError:
+            continue
+
+    if not hook_mode:
+        print(f"Guard applied: {chmod_count} tracked files made read-only.")
+
+
+def release_guard() -> None:
+    """Restore write permission on tracked files (chmod u+w)."""
+    main_root = check_primary_checkout_root(hook_mode=False)
+
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=str(main_root),
+            capture_output=True,
+            text=True,
+            check=True,
+            env=sanitized_git_env(),
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error listing tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    tracked_files = proc.stdout.split("\0")
+    if tracked_files and not tracked_files[-1]:
+        tracked_files.pop()
+
+    chmod_count = 0
+    for rel_path_str in tracked_files:
+        if not rel_path_str:
+            continue
+        file_path = main_root / rel_path_str
+        try:
+            st = file_path.lstat()
+            if stat.S_ISREG(st.st_mode) and not stat.S_ISLNK(st.st_mode):
+                current_mode = st.st_mode
+                new_mode = current_mode | 0o200
+                if current_mode != new_mode:
+                    os.chmod(file_path, new_mode)
+                    chmod_count += 1
+        except OSError:
+            continue
+
+    print(f"Guard released: restored write permissions on {chmod_count} tracked files.")
+    print("⚠️  LOUD REMINDER: Please remember to re-apply the write guard with 'apply' before dispatching agents!")
+
+
+def status_guard() -> None:
+    """Report whether the write guard is ON or OFF, plus offender count."""
+    try:
+        main_root = wc.resolve_main_root()
+    except Exception as e:
+        print(f"Error: Not inside a git repository: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    writable = get_writable_tracked_files(main_root)
+    state = "ON" if not writable else "OFF"
+    print(f"{state} ({len(writable)} writable tracked files)")
+
+
+def check_guard() -> None:
+    """Exit non-zero and name offenders if guard is expected ON but writable files exist."""
+    try:
+        main_root = wc.resolve_main_root()
+    except Exception as e:
+        print(f"Error: Not inside a git repository: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    writable = get_writable_tracked_files(main_root)
+    if writable:
+        print("Error: Primary write guard is OFF (writable tracked files exist).", file=sys.stderr)
+        print("Offending writable tracked files:", file=sys.stderr)
+        for f in writable:
+            print(f"  {f.relative_to(main_root)}", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("Primary write guard is ON. No writable tracked files.")
+        sys.exit(0)
+
+
+def install_hooks() -> None:
+    """Install the primary write guard logic into local git hooks."""
+    main_root = check_primary_checkout_root(hook_mode=False)
+    hooks_dir = main_root / ".git" / "hooks"
+
+    if not hooks_dir.exists():
+        try:
+            hooks_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            print(f"Error creating hooks directory: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    hook_names = ["post-merge", "post-checkout", "post-commit"]
+    hook_command = (
+        "\n# AGY_PRIMARY_WRITE_GUARD_START\n"
+        'if [ -f "scripts/guardrails/primary_write_guard.py" ]; then\n'
+        "    python3 scripts/guardrails/primary_write_guard.py apply --hook\n"
+        "fi\n"
+        "# AGY_PRIMARY_WRITE_GUARD_END\n"
+    )
+
+    for hook_name in hook_names:
+        hook_path = hooks_dir / hook_name
+        content = ""
+        if hook_path.exists():
+            try:
+                content = hook_path.read_text(encoding="utf-8")
+            except OSError as e:
+                print(f"Error reading existing hook {hook_name}: {e}", file=sys.stderr)
+                sys.exit(1)
+
+        if "# AGY_PRIMARY_WRITE_GUARD_START" in content:
+            print(f"Hook '{hook_name}' already has primary write guard installed.")
+            continue
+
+        new_content = content
+        if not new_content:
+            new_content = "#!/bin/sh\n"
+        elif not new_content.endswith("\n"):
+            new_content += "\n"
+
+        new_content += hook_command
+
+        try:
+            hook_path.write_text(new_content, encoding="utf-8")
+            current_mode = hook_path.stat().st_mode
+            hook_path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            print(f"Successfully installed primary write guard in hook '{hook_name}'.")
+        except OSError as e:
+            print(f"Error writing hook {hook_name}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Primary Checkout Write Guard")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    apply_parser = subparsers.add_parser("apply", help="Make tracked files read-only")
+    apply_parser.add_argument(
+        "--hook",
+        action="store_true",
+        help="Run in hook mode (graceful exit on worktree or non-root cwd)",
+    )
+
+    subparsers.add_parser("release", help="Restore write permissions on tracked files")
+    subparsers.add_parser("status", help="Report status of the write guard")
+    subparsers.add_parser("check", help="Verify write guard is ON and exit non-zero if not")
+    subparsers.add_parser("install-hooks", help="Install primary write guard into local git hooks")
+
+    args = parser.parse_args()
+
+    if args.command == "apply":
+        apply_guard(hook_mode=args.hook)
+    elif args.command == "release":
+        release_guard()
+    elif args.command == "status":
+        status_guard()
+    elif args.command == "check":
+        check_guard()
+    elif args.command == "install-hooks":
+        install_hooks()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_primary_write_guard.py
+++ b/tests/test_primary_write_guard.py
@@ -14,16 +14,18 @@ if str(REPO_ROOT) not in sys.path:
 
 from scripts.guardrails import primary_write_guard as pwg
 
+# Mirror of scripts.common.git_context.GIT_REDIRECT_ENV_KEYS — keep in sync.
 _GIT_ENV = {
     "GIT_DIR",
     "GIT_WORK_TREE",
     "GIT_INDEX_FILE",
+    "GIT_PREFIX",
+    "GIT_COMMON_DIR",
     "GIT_OBJECT_DIRECTORY",
     "GIT_ALTERNATE_OBJECT_DIRECTORIES",
     "GIT_NAMESPACE",
     "GIT_CEILING_DIRECTORIES",
     "GIT_DISCOVERY_ACROSS_FILESYSTEM",
-    "GIT_COMMON_DIR",
 }
 
 
@@ -243,10 +245,16 @@ def test_install_hooks(temp_git_repo, monkeypatch):
     pwg.install_hooks()
 
     hooks_dir = main_dir / ".git" / "hooks"
-    for hook_name in ["post-merge", "post-checkout", "post-commit"]:
+    for hook_name in ["post-merge"]:
         hook_path = hooks_dir / hook_name
         assert hook_path.exists()
         content = hook_path.read_text(encoding="utf-8")
         assert "# AGY_PRIMARY_WRITE_GUARD_START" in content
         assert "primary_write_guard.py apply --hook" in content
         assert os.access(hook_path, os.X_OK)
+    # Review #5399: post-checkout / post-commit deliberately NOT installed
+    # (per-operation O(tracked) scan; post-commit touches no working files).
+    for hook_name in ["post-checkout", "post-commit"]:
+        hook_path = hooks_dir / hook_name
+        if hook_path.exists():
+            assert "# AGY_PRIMARY_WRITE_GUARD_START" not in hook_path.read_text(encoding="utf-8")

--- a/tests/test_primary_write_guard.py
+++ b/tests/test_primary_write_guard.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add repo root to sys.path to resolve imports
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.guardrails import primary_write_guard as pwg
+
+_GIT_ENV = {
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_COMMON_DIR",
+}
+
+
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _GIT_ENV}
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    )
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path: Path) -> dict[str, Path]:
+    """Sets up a primary git repository and a clone for pulling."""
+    main_dir = tmp_path / "main"
+    main_dir.mkdir()
+    _git(main_dir, "init", "-q", "-b", "main")
+    _git(main_dir, "config", "user.email", "test@example.com")
+    _git(main_dir, "config", "user.name", "Test User")
+
+    # Create tracked files
+    (main_dir / "a.txt").write_text("Hello A\n", encoding="utf-8")
+    (main_dir / "b.txt").write_text("Hello B\n", encoding="utf-8")
+
+    # Create UTF-8 filename and file with spaces in name to verify handling
+    (main_dir / "українська книга.txt").write_text("Ukrainian Book\n", encoding="utf-8")
+    (main_dir / "space file.txt").write_text("Space File\n", encoding="utf-8")
+
+    # Create gitignore
+    (main_dir / ".gitignore").write_text("*.local\nignored_dir/\n", encoding="utf-8")
+
+    _git(main_dir, "add", "a.txt", "b.txt", "українська книга.txt", "space file.txt", ".gitignore")
+    _git(main_dir, "commit", "-q", "-m", "Initial commit")
+
+    # Setup worktree (needs directories created manually first)
+    (main_dir / ".worktrees" / "dispatch").mkdir(parents=True, exist_ok=True)
+    _git(main_dir, "worktree", "add", "-q", ".worktrees/dispatch/task1", "-b", "task1-branch")
+
+    # Setup a separate cloned repo to simulate pull
+    clone_dir = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(main_dir), "clone")
+    _git(clone_dir, "config", "user.email", "clone@example.com")
+    _git(clone_dir, "config", "user.name", "Clone User")
+
+    return {
+        "main": main_dir,
+        "clone": clone_dir,
+        "worktree": main_dir / ".worktrees" / "dispatch" / "task1",
+    }
+
+
+def test_apply_protects_tracked_files(temp_git_repo, monkeypatch):
+    main_dir = temp_git_repo["main"]
+    monkeypatch.chdir(main_dir)
+
+    # Apply guard
+    pwg.apply_guard(hook_mode=False)
+
+    # Trying to write to tracked file should raise PermissionError
+    a_file = main_dir / "a.txt"
+    with pytest.raises(PermissionError):
+        a_file.write_text("Modified\n", encoding="utf-8")
+
+    # Writing to untracked file should succeed
+    untracked_file = main_dir / "untracked.txt"
+    untracked_file.write_text("Untracked content\n", encoding="utf-8")
+    assert untracked_file.read_text(encoding="utf-8") == "Untracked content\n"
+
+    # Writing to gitignored file should succeed
+    ignored_file = main_dir / "test.local"
+    ignored_file.write_text("Ignored content\n", encoding="utf-8")
+    assert ignored_file.read_text(encoding="utf-8") == "Ignored content\n"
+
+
+def test_idempotent_release_and_status(temp_git_repo, monkeypatch, capsys):
+    main_dir = temp_git_repo["main"]
+    monkeypatch.chdir(main_dir)
+
+    # Initial state should be OFF
+    pwg.status_guard()
+    out, _ = capsys.readouterr()
+    assert "OFF" in out
+
+    # pwg.check_guard() should raise SystemExit(1)
+    with pytest.raises(SystemExit) as excinfo:
+        pwg.check_guard()
+    assert excinfo.value.code == 1
+
+    # Apply guard
+    pwg.apply_guard(hook_mode=False)
+
+    # Status should be ON
+    pwg.status_guard()
+    out, _ = capsys.readouterr()
+    assert "ON" in out
+    assert "0 writable tracked files" in out
+
+    # check_guard should pass with exit code 0
+    with pytest.raises(SystemExit) as excinfo:
+        pwg.check_guard()
+    assert excinfo.value.code == 0
+
+    # Apply again (idempotent)
+    pwg.apply_guard(hook_mode=False)
+
+    # Status still ON
+    pwg.status_guard()
+    out, _ = capsys.readouterr()
+    assert "ON" in out
+
+    # Release guard
+    pwg.release_guard()
+    out, _ = capsys.readouterr()
+    assert "Guard released" in out
+
+    # Status should be OFF
+    pwg.status_guard()
+    out, _ = capsys.readouterr()
+    assert "OFF" in out
+    assert "5 writable tracked files" in out
+
+    # check_guard should exit with 1
+    with pytest.raises(SystemExit) as excinfo:
+        pwg.check_guard()
+    assert excinfo.value.code == 1
+
+
+def test_git_pull_with_guard_on(temp_git_repo, monkeypatch):
+    main_dir = temp_git_repo["main"]
+    clone_dir = temp_git_repo["clone"]
+
+    # 1. Apply guard in clone_dir
+    monkeypatch.chdir(clone_dir)
+    pwg.apply_guard(hook_mode=False)
+
+    # Verify files in clone are read-only
+    with pytest.raises(PermissionError):
+        (clone_dir / "a.txt").write_text("Try write", encoding="utf-8")
+
+    # 2. Modify a.txt in main_dir and commit
+    (main_dir / "a.txt").write_text("Hello A modified\n", encoding="utf-8")
+    _git(main_dir, "add", "a.txt")
+    _git(main_dir, "commit", "-q", "-m", "Modify a.txt in main")
+
+    # 3. Pull in clone_dir. Pull should succeed despite files being read-only.
+    _git(clone_dir, "pull", "--ff-only")
+
+    # Pull should succeed and update a.txt content
+    assert (clone_dir / "a.txt").read_text(encoding="utf-8") == "Hello A modified\n"
+
+    # Simulate post-merge hook
+    pwg.apply_guard(hook_mode=True)
+
+    # Verify that a.txt is read-only again
+    with pytest.raises(PermissionError):
+        (clone_dir / "a.txt").write_text("Try write again", encoding="utf-8")
+
+
+def test_apply_refuses_outside_primary_root(temp_git_repo, monkeypatch):
+    main_dir = temp_git_repo["main"]
+    worktree_dir = temp_git_repo["worktree"]
+
+    # 1. From a subdirectory of main_dir
+    subdir = main_dir / "subdir"
+    subdir.mkdir(exist_ok=True)
+    monkeypatch.chdir(subdir)
+    with pytest.raises(SystemExit) as excinfo:
+        pwg.apply_guard(hook_mode=False)
+    assert excinfo.value.code == 1
+
+    # 2. From a worktree
+    monkeypatch.chdir(worktree_dir)
+    with pytest.raises(SystemExit) as excinfo:
+        pwg.apply_guard(hook_mode=False)
+    assert excinfo.value.code == 1
+
+    # With hook mode inside worktree it should exit 0 silently
+    with pytest.raises(SystemExit) as excinfo:
+        pwg.apply_guard(hook_mode=True)
+    assert excinfo.value.code == 0
+
+
+def test_unusual_filenames_handled(temp_git_repo, monkeypatch):
+    main_dir = temp_git_repo["main"]
+    monkeypatch.chdir(main_dir)
+
+    pwg.apply_guard(hook_mode=False)
+
+    utf8_file = main_dir / "українська книга.txt"
+    space_file = main_dir / "space file.txt"
+
+    with pytest.raises(PermissionError):
+        utf8_file.write_text("trying write", encoding="utf-8")
+
+    with pytest.raises(PermissionError):
+        space_file.write_text("trying write", encoding="utf-8")
+
+    pwg.release_guard()
+
+    utf8_file.write_text("Ukrainian Book modified\n", encoding="utf-8")
+    space_file.write_text("Space File modified\n", encoding="utf-8")
+
+    assert utf8_file.read_text(encoding="utf-8") == "Ukrainian Book modified\n"
+    assert space_file.read_text(encoding="utf-8") == "Space File modified\n"
+
+
+def test_install_hooks(temp_git_repo, monkeypatch):
+    main_dir = temp_git_repo["main"]
+    monkeypatch.chdir(main_dir)
+
+    pwg.install_hooks()
+
+    hooks_dir = main_dir / ".git" / "hooks"
+    for hook_name in ["post-merge", "post-checkout", "post-commit"]:
+        hook_path = hooks_dir / hook_name
+        assert hook_path.exists()
+        content = hook_path.read_text(encoding="utf-8")
+        assert "# AGY_PRIMARY_WRITE_GUARD_START" in content
+        assert "primary_write_guard.py apply --hook" in content
+        assert os.access(hook_path, os.X_OK)


### PR DESCRIPTION
## Overview
This PR implements the primary-checkout write guard (#5389). It prevents agent processes from modifying tracked files in the primary checkout by setting them to read-only (`chmod a-w`). This filesystem-level protection is harness-agnostic and enforces clean operator workspace boundaries.

## Key Features & Command Line Interface
The guard logic is implemented in `scripts/guardrails/primary_write_guard.py` with the following CLI commands:
- **`apply`**: Make all tracked repository files read-only (`chmod a-w`), leaving directories and untracked/ignored paths writable. Silently exits on worktrees/subdirectories if `--hook` is passed.
- **`release`**: Restore write permissions (`chmod u+w`) on tracked files to allow deliberate human editing. Prints a warning to re-apply the guard afterward.
- **`status`**: Report state (`ON` or `OFF`) and the count of writable tracked files.
- **`check`**: Verify the guard is `ON` (0 writable tracked files) and exit non-zero (with list of offending files) if not.
- **`install-hooks`**: Installs/appends the `apply --hook` guard command into local `.git/hooks/post-merge`, `post-checkout`, and `post-commit` hooks.

## Scope Constraints
1. **Primary Checkout Only**: Refuses to run `apply` anywhere except the primary checkout root (fails on subdirectories and worktrees under `.worktrees/`).
2. **Gitignored/Runtime state stays writable**: Only tracked files from `git ls-files` are made read-only. Local ignored assets like `.agent/`, `.venv/`, `.claude/`, logs, and `site/src/data/lexicon-manifest.json` remain fully writable.
3. **Safety**: Never auto-reverts or deletes files. Failures occur loudly.

## Activation
Once merged, to activate:
1. Run hook installation:
   `python3 scripts/guardrails/primary_write_guard.py install-hooks`
2. Apply the guard:
   `python3 scripts/guardrails/primary_write_guard.py apply`

## Validation & Test Execution
All 6 new tests under `tests/test_primary_write_guard.py` pass. They verify:
1. `apply` blocks writes on tracked files but allows writes to untracked/ignored files.
2. `apply` is idempotent, `release` restores write permission, and `status`/`check` are truthful in all states.
3. `git pull` succeeds in a checkout with read-only files (since git uses unlink+rename).
4. `apply` refuses to execute outside the primary checkout root or in worktrees.
5. Handling of files with special characters (spaces and Cyrillic UTF-8).
6. Hook installation.

Running tests locally:
```bash
pytest tests/test_primary_write_guard.py
```
Output:
```
tests/test_primary_write_guard.py ......                                 [100%]
============================== 6 passed in 2.01s ===============================
```

Additionally, the existing delegate test suite passes fully (132 tests in total):
```bash
pytest tests/test_delegate.py
```
Output:
```
============================= 132 passed in 12.21s =============================
```

refs #5389
