### PR TITLE
docs(rules): grok = grok-4.5 only (effort low/mid/high); cursor composer-2.5-fast retired

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -25,6 +25,13 @@ that tier → cost among equivalent fits**. Cost never lowers the quality floor.
 is unavailable; `degraded` and `near_cap` only break ties inside a quality rung. `cursor:auto` is
 never an acceptable formal-review identity.
 
+**Lane updates (user-reported 2026-07-18):**
+- **grok**: the lane now offers **grok-4.5 only**, with selectable reasoning effort
+  (`low`/`mid`/`high`) — set effort explicitly per dispatch; authoring/review seats run `high`.
+- **cursor**: **composer-2.5-fast is retired** — cursor has no cheap-fast tier; route quick
+  mechanical edits to agy/glm instead. Composer 2.5 (standard) remains the pinned-model choice
+  where family independence matters.
+
 | Task | Tool + model |
 | --- | --- |
 | Inline code edit ≤5 LOC, fixing a CI failure I just caused | Me, current model |


### PR DESCRIPTION
Two-row lane update to the canonical routing rule, user-reported 2026-07-18.

- grok lane offers only grok-4.5 now, with selectable reasoning effort (low/mid/high) — dispatches must set effort explicitly; authoring/review = high.
- cursor composer-2.5-fast is retired — no cheap-fast cursor tier; quick mechanical edits route to agy/glm. Composer 2.5 standard remains for pinned-model independence.

Docs-only (rules file); cross-family review requested via bridge (agy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)