### PR TITLE
feat(sources): add composite vocabulary vet tool

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -15,7 +15,7 @@ with imports; rename there is a follow-up.
 
 Tools:
     - search_sources, search_text, search_literary, search_external, search_images, get_chunk_context
-    - verify_word, verify_words, verify_lemma (VESUM)
+    - verify_word, verify_words, verify_lemma, vet_vocabulary (VESUM)
     - query_wikipedia, query_pravopys, query_e2u, query_r2u, query_ulif
     - search_definitions, search_grinchenko_1907, search_esum, search_idioms, search_synonyms
     - search_slovnyk_me, search_heritage
@@ -453,6 +453,31 @@ async def list_tools() -> list[Tool]:
                     },
                 },
                 "required": ["words"]
+            },
+        ),
+        Tool(
+            name="vet_vocabulary",
+            description=(
+                "Vet up to 500 Ukrainian vocabulary items in one compact report. "
+                "Batches VESUM validity, PULS CEFR lookup, and Russian-shadow "
+                "suspicion checks; optionally includes the best СУМ-11 gloss. "
+                "A Russian-shadow result is a suspicion signal, not a verdict."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "words": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Ukrainian words to vet. Requests over 500 are truncated with a response note.",
+                    },
+                    "include_definitions": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Include the best available one-line СУМ-11 gloss for each word.",
+                    },
+                },
+                "required": ["words"],
             },
         ),
         Tool(
@@ -1284,6 +1309,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             "verify_word": lambda: handle_verify_word(arguments),
             "verify_source_attribution": lambda: handle_verify_source_attribution(arguments),
             "verify_words": lambda: handle_verify_words(arguments),
+            "vet_vocabulary": lambda: handle_vet_vocabulary(arguments),
             "verify_lemma": lambda: handle_verify_lemma(arguments),
             "query_wikipedia": lambda: handle_query_wikipedia(arguments),
             "query_grac": lambda: handle_query_grac(arguments),
@@ -1599,6 +1625,104 @@ async def handle_verify_words(args: dict) -> list[TextContent]:
             lines.append(f"- **{word}** — NOT FOUND")
 
     lines.insert(1, f"Found: {found}/{len(words)}\n")
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+def _compact_vocabulary_value(value: object, *, max_chars: int | None = None) -> str:
+    """Keep a vocabulary-vetting field on one safe, parser-friendly line."""
+    text = re.sub(r"\s+", " ", str(value)).strip()
+    if max_chars is not None and len(text) > max_chars:
+        text = f"{text[:max_chars - 1].rstrip()}…"
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("`", "\\`")
+
+
+def _preferred_vocabulary_lookup(word: str, matches: list[dict]) -> str:
+    """Prefer the submitted form, then its matching VESUM lemma for dictionaries."""
+    for match in matches:
+        lemma = str(match.get("lemma") or "")
+        if lemma == word:
+            return word
+    for match in matches:
+        lemma = str(match.get("lemma") or "")
+        if lemma:
+            return lemma
+    return word
+
+
+def _format_vocabulary_vesum(matches: list[dict]) -> str:
+    if not matches:
+        return "not found"
+    details = "; ".join(
+        "lemma={lemma}, pos={pos}, tags={tags}".format(
+            lemma=_compact_vocabulary_value(match.get("lemma") or ""),
+            pos=_compact_vocabulary_value(match.get("pos") or ""),
+            tags=_compact_vocabulary_value(match.get("tags") or ""),
+        )
+        for match in matches
+    )
+    return f"valid ({details})"
+
+
+def _format_vocabulary_shadow(result: dict) -> str:
+    if not result.get("matches_russian"):
+        return "not flagged (suspicion only, not a verdict)"
+    lemma = result.get("russian_lemma") or "unknown"
+    confidence = float(result.get("confidence") or 0.0)
+    return (
+        "suspected (suspicion only, not a verdict; "
+        f"russian_lemma={_compact_vocabulary_value(lemma)}, confidence={confidence:.2f})"
+    )
+
+
+async def handle_vet_vocabulary(args: dict) -> list[TextContent]:
+    """Combine the existing vocabulary checks without per-word SQL round trips."""
+    submitted_words = args["words"]
+    words = submitted_words[:500]
+    include_definitions = bool(args.get("include_definitions", False))
+
+    from scripts.verification.check_ru_morph import check_russian_patterns_batch
+    from scripts.verification.vesum import verify_words
+    from wiki import sources_db as sdb
+
+    vesum_results = await asyncio.to_thread(verify_words, words)
+    lookup_terms = list(dict.fromkeys(
+        _preferred_vocabulary_lookup(word, vesum_results.get(word, []))
+        for word in words
+    ))
+    cefr_results = await asyncio.to_thread(sdb.query_cefr_levels, lookup_terms)
+    definition_results = (
+        await asyncio.to_thread(sdb.search_definitions_batch, lookup_terms)
+        if include_definitions else {}
+    )
+    verified_words = {word for word in words if vesum_results.get(word)}
+    shadow_results = await asyncio.to_thread(
+        check_russian_patterns_batch,
+        words,
+        verified_words=verified_words,
+    )
+
+    lines = []
+    if len(submitted_words) > len(words):
+        lines.append(
+            f"Note: received {len(submitted_words)} words; processed the first 500 (hard cap)."
+        )
+
+    for word in words:
+        matches = vesum_results.get(word, [])
+        lookup_term = _preferred_vocabulary_lookup(word, matches)
+        cefr_hit = (cefr_results.get(lookup_term) or [{}])[0]
+        fields = [
+            f"**{_compact_vocabulary_value(word)}**",
+            f"VESUM: {_format_vocabulary_vesum(matches)}",
+            f"CEFR: {_compact_vocabulary_value(cefr_hit.get('level') or 'not listed')}",
+            f"Russian-shadow: {_format_vocabulary_shadow(shadow_results.get(word, {}))}",
+        ]
+        if include_definitions:
+            definition_hit = (definition_results.get(lookup_term) or [{}])[0]
+            gloss = definition_hit.get("definition") or "not found"
+            fields.append(f"Gloss: {_compact_vocabulary_value(gloss, max_chars=240)}")
+        lines.append("- " + " | ".join(fields))
+
     return [TextContent(type="text", text="\n".join(lines))]
 
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -461,6 +461,7 @@ of a second server:
 Full list: [`.claude/rules/rag-and-dictionaries.md`](../.claude/rules/rag-and-dictionaries.md). Core tools used daily:
 
 - `mcp__rag__verify_word` - VESUM morphological check
+- `mcp__sources__vet_vocabulary` - batched VESUM/CEFR/Russian-shadow vocabulary vetting (optional SUM-11 gloss)
 - `mcp__rag__search_text` - textbook content search
 - `mcp__rag__search_definitions` - SUM-11 explanatory dictionary
 - `mcp__rag__search_style_guide` - Antonenko-Davydovych style guidance

--- a/scripts/verification/check_ru_morph.py
+++ b/scripts/verification/check_ru_morph.py
@@ -91,3 +91,38 @@ def is_russian_pattern(
         "ukrainian_alternative": None,  # Without translation dict, we can't reliably guess the UK alt
         "confidence": conf
     }
+
+
+def check_russian_patterns_batch(
+    words: list[str],
+    threshold: float = 0.7,
+    *,
+    verified_words: set[str],
+) -> dict[str, dict]:
+    """Apply the Russian-shadow heuristic using already-batched VESUM results.
+
+    ``is_russian_pattern`` verifies VESUM for each call. Composite vocabulary
+    vetting has already completed that check in one SQL query, so this helper
+    preserves the same VESUM short-circuit without N extra database lookups.
+    """
+    normalized_verified = {word.lower().strip() for word in verified_words}
+    results: dict[str, dict] = {}
+    for raw_word in words:
+        word = raw_word.lower().strip()
+        if not word or word in normalized_verified:
+            results[raw_word] = {
+                "matches_russian": False,
+                "russian_lemma": None,
+                "ukrainian_alternative": None,
+                "confidence": 0.0,
+            }
+            continue
+
+        confidence, russian_lemma = get_ru_confidence(word)
+        results[raw_word] = {
+            "matches_russian": confidence >= threshold,
+            "russian_lemma": russian_lemma,
+            "ukrainian_alternative": None,
+            "confidence": confidence,
+        }
+    return results

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -1826,9 +1826,103 @@ def _dict_lookup(
         _close_if_temporary(conn, db_path)
 
 
+def _batch_dict_lookup(
+    table: str,
+    words: list[str],
+    limit: int = 1,
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, list[dict]]:
+    """Look up many dictionary headwords without issuing one query per word.
+
+    This is the batch counterpart to :func:`_dict_lookup`: exact headwords
+    take precedence and unmatched requests then use its prefix fallback.  A
+    chunk is deliberately much smaller than SQLite's conservative 999
+    placeholder limit, so callers can batch the MCP tool's 500-word cap
+    safely on older SQLite builds too.
+    """
+    requested = list(dict.fromkeys(str(word) for word in words if str(word).strip()))
+    results: dict[str, list[dict]] = {word: [] for word in requested}
+    if not requested:
+        return results
+
+    conn = None
+    try:
+        conn = _get_conn_for(db_path)
+    except FileNotFoundError:
+        return results
+
+    try:
+        for start in range(0, len(requested), 400):
+            chunk = requested[start:start + 400]
+            values = ", ".join("(?)" for _ in chunk)
+            rows = conn.execute(
+                f"""
+                WITH requested(word) AS (VALUES {values}),
+                ranked AS (
+                    SELECT
+                        requested.word AS requested_word,
+                        dictionary.*,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY requested.word
+                            ORDER BY dictionary.word COLLATE NOCASE
+                        ) AS result_order
+                    FROM requested
+                    JOIN {table} AS dictionary
+                      ON dictionary.word = requested.word COLLATE NOCASE
+                )
+                SELECT * FROM ranked
+                WHERE result_order <= ?
+                """,
+                (*chunk, limit),
+            ).fetchall()
+            for row in rows:
+                item = dict(row)
+                requested_word = item.pop("requested_word")
+                item.pop("result_order", None)
+                results[requested_word].append(item)
+
+            missing = [word for word in chunk if not results[word]]
+            if not missing:
+                continue
+
+            prefix_values = ", ".join("(?)" for _ in missing)
+            rows = conn.execute(
+                f"""
+                WITH requested(word) AS (VALUES {prefix_values})
+                SELECT requested.word AS requested_word, dictionary.*
+                FROM requested
+                JOIN {table} AS dictionary
+                  ON dictionary.id = (
+                    SELECT candidate.id
+                    FROM {table} AS candidate
+                    WHERE candidate.word LIKE requested.word || '%' COLLATE NOCASE
+                    ORDER BY candidate.word COLLATE NOCASE
+                    LIMIT 1
+                  )
+                """,
+                missing,
+            ).fetchall()
+            for row in rows:
+                item = dict(row)
+                requested_word = item.pop("requested_word")
+                results[requested_word].append(item)
+    except sqlite3.OperationalError:
+        return results
+    finally:
+        _close_if_temporary(conn, db_path)
+
+    return results
+
+
 def search_definitions(word: str, limit: int = 10) -> list[dict]:
     """Look up word in СУМ-11 (Ukrainian explanatory dictionary)."""
     return _dict_lookup("sum11", word, limit)
+
+
+def search_definitions_batch(words: list[str]) -> dict[str, list[dict]]:
+    """Return the best СУМ-11 hit for each requested word in batched SQL."""
+    return _batch_dict_lookup("sum11", words, limit=1)
 
 
 def search_grinchenko_1907(
@@ -2030,6 +2124,11 @@ def search_synonyms(word: str, limit: int = 20) -> list[dict]:
 def query_cefr_level(word: str, limit: int = 5) -> list[dict]:
     """Look up CEFR level for a word in PULS vocabulary."""
     return _dict_lookup("puls_cefr", word, limit=limit)
+
+
+def query_cefr_levels(words: list[str]) -> dict[str, list[dict]]:
+    """Return the best PULS CEFR hit for each requested word in batched SQL."""
+    return _batch_dict_lookup("puls_cefr", words, limit=1)
 
 
 def search_style_guide(

--- a/tests/test_check_ru_morph.py
+++ b/tests/test_check_ru_morph.py
@@ -1,6 +1,10 @@
 from unittest.mock import patch
 
-from scripts.verification.check_ru_morph import get_ru_confidence, is_russian_pattern
+from scripts.verification.check_ru_morph import (
+    check_russian_patterns_batch,
+    get_ru_confidence,
+    is_russian_pattern,
+)
 
 
 def test_get_ru_confidence():
@@ -42,3 +46,20 @@ def test_smoke_cases(mock_verify_word):
     # 4. котрий
     res = is_russian_pattern("котрий")
     assert res["matches_russian"] is False
+
+
+@patch("scripts.verification.vesum.verify_word")
+@patch("scripts.verification.check_ru_morph.get_ru_confidence")
+def test_batch_reuses_preverified_vesum_results(mock_confidence, mock_verify_word):
+    mock_confidence.return_value = (0.91, "выдуманный")
+
+    results = check_russian_patterns_batch(
+        ["привіт", "вигадане"],
+        verified_words={"привіт"},
+    )
+
+    assert results["привіт"]["matches_russian"] is False
+    assert results["вигадане"]["matches_russian"] is True
+    assert results["вигадане"]["russian_lemma"] == "выдуманный"
+    mock_confidence.assert_called_once_with("вигадане")
+    mock_verify_word.assert_not_called()

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -49,7 +49,7 @@ class TestListTools:
         expected = {
             "search_sources", "search_text", "search_images", "search_literary", "search_external",
             "get_full_text", "get_chunk_context", "collection_stats",
-            "verify_word", "verify_source_attribution", "verify_words", "verify_lemma", "verify_quote", "check_modern_form",
+            "verify_word", "verify_source_attribution", "verify_words", "vet_vocabulary", "verify_lemma", "verify_quote", "check_modern_form",
             "query_wikipedia", "query_grac", "query_ulif", "query_ulif_synonyms",
             "query_ulif_antonyms", "query_ulif_phraseology",
             "query_r2u", "query_e2u", "query_sum20", "query_slovnyk_me",
@@ -147,6 +147,13 @@ class TestUlifHandlers:
         assert props["type"] == "array"
         assert props["items"]["type"] == "string"
 
+    def test_vet_vocabulary_schema(self, server_module):
+        tools = _run(server_module.list_tools())
+        tool = next(tool for tool in tools if tool.name == "vet_vocabulary")
+        assert tool.inputSchema["required"] == ["words"]
+        assert tool.inputSchema["properties"]["words"]["type"] == "array"
+        assert tool.inputSchema["properties"]["include_definitions"]["default"] is False
+
     def test_verify_quote_schema(self, server_module):
         tools = _run(server_module.list_tools())
         vq = next(t for t in tools if t.name == "verify_quote")
@@ -195,6 +202,13 @@ class TestCallToolDispatch:
             mock.return_value = [MagicMock(text="ok")]
             _run(server_module.call_tool("verify_words", {"words": ["тест"]}))
             mock.assert_called_once_with({"words": ["тест"]})
+
+    def test_vet_vocabulary_dispatches(self, server_module):
+        with patch.object(server_module, "handle_vet_vocabulary", new_callable=AsyncMock) as mock:
+            mock.return_value = [MagicMock(text="ok")]
+            args = {"words": ["тест"], "include_definitions": True}
+            _run(server_module.call_tool("vet_vocabulary", args))
+            mock.assert_called_once_with(args)
 
     def test_verify_quote_dispatches(self, server_module):
         with patch.object(server_module, "handle_verify_quote", new_callable=AsyncMock) as mock:
@@ -342,6 +356,109 @@ class TestVerifyWordsHandler:
             assert "Found: 1/2" in text
             assert "**стій** — FOUND" in text
             assert "**взяйте** — NOT FOUND" in text
+
+
+@pytest.fixture
+def vocabulary_vet_fixtures():
+    """One fixture payload for each source that composite vocabulary vetting uses."""
+    return {
+        "vesum": {
+            "кіт": [{"lemma": "кіт", "pos": "noun", "tags": "noun:anim:m:v_naz"}],
+            "вигадане": [],
+        },
+        "cefr": {"кіт": [{"level": "A1"}], "вигадане": []},
+        "shadow": {
+            "кіт": {
+                "matches_russian": False,
+                "russian_lemma": None,
+                "confidence": 0.0,
+            },
+            "вигадане": {
+                "matches_russian": True,
+                "russian_lemma": "выдуманный",
+                "confidence": 0.91,
+            },
+        },
+        "definitions": {
+            "кіт": [{"definition": "КІТ, кота, ч. Свійська тварина родини котячих."}],
+            "вигадане": [],
+        },
+    }
+
+
+class TestVetVocabularyHandler:
+    def test_reports_all_sources_and_missing_word(self, server_module, vocabulary_vet_fixtures):
+        fixtures = vocabulary_vet_fixtures
+        with (
+            patch("scripts.verification.vesum.verify_words", return_value=fixtures["vesum"]) as verify_words,
+            patch("wiki.sources_db.query_cefr_levels", return_value=fixtures["cefr"]) as query_cefr,
+            patch(
+                "scripts.verification.check_ru_morph.check_russian_patterns_batch",
+                return_value=fixtures["shadow"],
+            ) as check_shadow,
+            patch(
+                "wiki.sources_db.search_definitions_batch",
+                return_value=fixtures["definitions"],
+            ) as search_definitions,
+        ):
+            result = _run(
+                server_module.handle_vet_vocabulary(
+                    {"words": ["кіт", "вигадане"], "include_definitions": True}
+                )
+            )
+
+        text = result[0].text
+        assert text.splitlines()[0] == (
+            "- **кіт** | VESUM: valid (lemma=кіт, pos=noun, tags=noun:anim:m:v_naz) "
+            "| CEFR: A1 | Russian-shadow: not flagged (suspicion only, not a verdict) "
+            "| Gloss: КІТ, кота, ч. Свійська тварина родини котячих."
+        )
+        assert "**вигадане** | VESUM: not found" in text
+        assert "Russian-shadow: suspected (suspicion only, not a verdict; russian_lemma=выдуманный" in text
+        assert "Gloss: КІТ, кота, ч. Свійська тварина родини котячих." in text
+        assert "Gloss: not found" in text
+        verify_words.assert_called_once_with(["кіт", "вигадане"])
+        query_cefr.assert_called_once_with(["кіт", "вигадане"])
+        search_definitions.assert_called_once_with(["кіт", "вигадане"])
+        check_shadow.assert_called_once_with(
+            ["кіт", "вигадане"], verified_words={"кіт"}
+        )
+
+    def test_omits_gloss_without_definitions_toggle(self, server_module, vocabulary_vet_fixtures):
+        fixtures = vocabulary_vet_fixtures
+        with (
+            patch("scripts.verification.vesum.verify_words", return_value=fixtures["vesum"]),
+            patch("wiki.sources_db.query_cefr_levels", return_value=fixtures["cefr"]),
+            patch(
+                "scripts.verification.check_ru_morph.check_russian_patterns_batch",
+                return_value=fixtures["shadow"],
+            ),
+            patch("wiki.sources_db.search_definitions_batch") as search_definitions,
+        ):
+            result = _run(server_module.handle_vet_vocabulary({"words": ["кіт"]}))
+
+        assert "Gloss:" not in result[0].text
+        assert "Russian-shadow: not flagged (suspicion only, not a verdict)" in result[0].text
+        search_definitions.assert_not_called()
+
+    def test_honestly_truncates_after_500_words(self, server_module):
+        words = [f"слово-{index}" for index in range(501)]
+        first_500 = words[:500]
+        with (
+            patch("scripts.verification.vesum.verify_words", return_value={word: [] for word in first_500}) as verify_words,
+            patch("wiki.sources_db.query_cefr_levels", return_value={}),
+            patch(
+                "scripts.verification.check_ru_morph.check_russian_patterns_batch",
+                return_value={word: {"matches_russian": False} for word in first_500},
+            ),
+        ):
+            result = _run(server_module.handle_vet_vocabulary({"words": words}))
+
+        text = result[0].text
+        assert text.startswith("Note: received 501 words; processed the first 500 (hard cap).")
+        assert "**слово-499**" in text
+        assert "**слово-500**" not in text
+        verify_words.assert_called_once_with(first_500)
 
 
 def _shevchenko_quote_hits():

--- a/tests/test_mcp_sources_streamable_http.py
+++ b/tests/test_mcp_sources_streamable_http.py
@@ -82,7 +82,7 @@ def test_streamable_http_initialize_returns_capabilities(sources_http_url):
     assert "capabilities" in body["result"]
 
 
-def test_streamable_http_tools_list_contains_verify_words(sources_http_url):
+def test_streamable_http_tools_list_contains_vocabulary_vetting_tools(sources_http_url):
     response = httpx.post(
         f"{sources_http_url}/mcp",
         json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
@@ -93,6 +93,7 @@ def test_streamable_http_tools_list_contains_verify_words(sources_http_url):
     body = response.json()
     tool_names = {tool["name"] for tool in body["result"]["tools"]}
     assert "verify_words" in tool_names
+    assert "vet_vocabulary" in tool_names
 
 
 def test_streamable_http_tool_call_returns_valid_response(sources_http_url):

--- a/tests/test_sources_db.py
+++ b/tests/test_sources_db.py
@@ -315,6 +315,19 @@ class TestSourcesDb:
         assert len(results) >= 1
         assert results[0]["level"] == "A1"
 
+    def test_batch_vocabulary_lookups(self, sample_data, monkeypatch):
+        self._build_and_patch(sample_data, monkeypatch)
+        from wiki.sources_db import query_cefr_levels, search_definitions_batch
+
+        cefr = query_cefr_levels(["добре", "відсутнє"])
+        definitions = search_definitions_batch(["слово", "слов", "відсутнє"])
+
+        assert cefr["добре"][0]["level"] == "A1"
+        assert cefr["відсутнє"] == []
+        assert "Одиниця мови" in definitions["слово"][0]["definition"]
+        assert "Одиниця мови" in definitions["слов"][0]["definition"]
+        assert definitions["відсутнє"] == []
+
     def test_search_style_guide(self, sample_data, monkeypatch):
         self._build_and_patch(sample_data, monkeypatch)
         from wiki.sources_db import search_style_guide


### PR DESCRIPTION
## Summary

- Adds `mcp__sources__vet_vocabulary`, a compact one-line-per-word composite report for VESUM validity, PULS CEFR, Russian-shadow suspicion, and optional best-hit SUM-11 glosses.
- Batches VESUM and dictionary SQL, and reuses the batched VESUM result for the Russian-shadow short-circuit rather than adding per-word database lookups.
- Caps requests at 500 words with an explicit truncation note; existing MCP tool behavior is unchanged.

Refs #5368.

## Validation

From `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/composite-vet-tool`:

```text
.venv/bin/ruff check <8 changed Python/test paths>
All checks passed!

.venv/bin/python -m pytest -q tests/test_check_ru_morph.py tests/test_mcp_sources_server.py tests/test_mcp_sources_streamable_http.py tests/test_sources_db.py
82 passed, 5 skipped in 2.46s

.venv/bin/python scripts/lint/lint_prompts.py
All prompts clean — no violations found.

npx --no-install markdownlint-cli2 docs/SCRIPTS.md
Summary: 0 error(s)
```

Live MCP measurement against `http://127.0.0.1:8766/mcp` (200 distinct PULS words, `include_definitions=true`):

```text
live vet_vocabulary: words=200 definitions=true status=200 elapsed_ms=980.0 lines=200
```

Independent Claude Opus 4.8 review (bridge message #3449) found no issues and reported the change correct (0.72 confidence). AGY was unavailable because its OAuth credential probe failed; Kimi and Grok read-only review routes refused isolation, so Claude was the documented cross-family fallback.
