### PR TITLE
fix(security): clear open CodeQL and zizmor alerts

### DIFF
--- a/.github/actions/paths-filter-retry/action.yml
+++ b/.github/actions/paths-filter-retry/action.yml
@@ -74,51 +74,68 @@ runs:
 
     - name: Set outputs and fail open if needed
       id: set-outputs
+      # Pass step outputs via env (not ${{ }} inside `run:`) to satisfy
+      # zizmor/template-injection. Values are boolean path-filter flags.
+      env:
+        FILTER1_OUTCOME: ${{ steps.filter1.outcome }}
+        FILTER2_OUTCOME: ${{ steps.filter2.outcome }}
+        FILTER3_OUTCOME: ${{ steps.filter3.outcome }}
+        F1_CONTENT: ${{ steps.filter1.outputs.content }}
+        F1_FRAMING: ${{ steps.filter1.outputs.framing }}
+        F1_PROMOTE: ${{ steps.filter1.outputs.promote }}
+        F1_CODE: ${{ steps.filter1.outputs.code }}
+        F1_PYTHON: ${{ steps.filter1.outputs.python }}
+        F1_FRONTEND: ${{ steps.filter1.outputs.frontend }}
+        F1_AGENT_CONFIG: ${{ steps.filter1.outputs.agent_config }}
+        F1_LESSON_SCHEMA: ${{ steps.filter1.outputs.lesson_schema }}
+        F1_ATLAS: ${{ steps.filter1.outputs.atlas }}
+        F1_POSTMORTEMS: ${{ steps.filter1.outputs.postmortems }}
+        F2_CONTENT: ${{ steps.filter2.outputs.content }}
+        F2_FRAMING: ${{ steps.filter2.outputs.framing }}
+        F2_PROMOTE: ${{ steps.filter2.outputs.promote }}
+        F2_CODE: ${{ steps.filter2.outputs.code }}
+        F2_PYTHON: ${{ steps.filter2.outputs.python }}
+        F2_FRONTEND: ${{ steps.filter2.outputs.frontend }}
+        F2_AGENT_CONFIG: ${{ steps.filter2.outputs.agent_config }}
+        F2_LESSON_SCHEMA: ${{ steps.filter2.outputs.lesson_schema }}
+        F2_ATLAS: ${{ steps.filter2.outputs.atlas }}
+        F2_POSTMORTEMS: ${{ steps.filter2.outputs.postmortems }}
+        F3_CONTENT: ${{ steps.filter3.outputs.content }}
+        F3_FRAMING: ${{ steps.filter3.outputs.framing }}
+        F3_PROMOTE: ${{ steps.filter3.outputs.promote }}
+        F3_CODE: ${{ steps.filter3.outputs.code }}
+        F3_PYTHON: ${{ steps.filter3.outputs.python }}
+        F3_FRONTEND: ${{ steps.filter3.outputs.frontend }}
+        F3_AGENT_CONFIG: ${{ steps.filter3.outputs.agent_config }}
+        F3_LESSON_SCHEMA: ${{ steps.filter3.outputs.lesson_schema }}
+        F3_ATLAS: ${{ steps.filter3.outputs.atlas }}
+        F3_POSTMORTEMS: ${{ steps.filter3.outputs.postmortems }}
       run: |
-        if [ "${{ steps.filter1.outcome }}" = "success" ]; then
-          echo "content=${{ steps.filter1.outputs.content }}" >> "$GITHUB_OUTPUT"
-          echo "framing=${{ steps.filter1.outputs.framing }}" >> "$GITHUB_OUTPUT"
-          echo "promote=${{ steps.filter1.outputs.promote }}" >> "$GITHUB_OUTPUT"
-          echo "code=${{ steps.filter1.outputs.code }}" >> "$GITHUB_OUTPUT"
-          echo "python=${{ steps.filter1.outputs.python }}" >> "$GITHUB_OUTPUT"
-          echo "frontend=${{ steps.filter1.outputs.frontend }}" >> "$GITHUB_OUTPUT"
-          echo "agent_config=${{ steps.filter1.outputs.agent_config }}" >> "$GITHUB_OUTPUT"
-          echo "lesson_schema=${{ steps.filter1.outputs.lesson_schema }}" >> "$GITHUB_OUTPUT"
-          echo "atlas=${{ steps.filter1.outputs.atlas }}" >> "$GITHUB_OUTPUT"
-          echo "postmortems=${{ steps.filter1.outputs.postmortems }}" >> "$GITHUB_OUTPUT"
-        elif [ "${{ steps.filter2.outcome }}" = "success" ]; then
-          echo "content=${{ steps.filter2.outputs.content }}" >> "$GITHUB_OUTPUT"
-          echo "framing=${{ steps.filter2.outputs.framing }}" >> "$GITHUB_OUTPUT"
-          echo "promote=${{ steps.filter2.outputs.promote }}" >> "$GITHUB_OUTPUT"
-          echo "code=${{ steps.filter2.outputs.code }}" >> "$GITHUB_OUTPUT"
-          echo "python=${{ steps.filter2.outputs.python }}" >> "$GITHUB_OUTPUT"
-          echo "frontend=${{ steps.filter2.outputs.frontend }}" >> "$GITHUB_OUTPUT"
-          echo "agent_config=${{ steps.filter2.outputs.agent_config }}" >> "$GITHUB_OUTPUT"
-          echo "lesson_schema=${{ steps.filter2.outputs.lesson_schema }}" >> "$GITHUB_OUTPUT"
-          echo "atlas=${{ steps.filter2.outputs.atlas }}" >> "$GITHUB_OUTPUT"
-          echo "postmortems=${{ steps.filter2.outputs.postmortems }}" >> "$GITHUB_OUTPUT"
-        elif [ "${{ steps.filter3.outcome }}" = "success" ]; then
-          echo "content=${{ steps.filter3.outputs.content }}" >> "$GITHUB_OUTPUT"
-          echo "framing=${{ steps.filter3.outputs.framing }}" >> "$GITHUB_OUTPUT"
-          echo "promote=${{ steps.filter3.outputs.promote }}" >> "$GITHUB_OUTPUT"
-          echo "code=${{ steps.filter3.outputs.code }}" >> "$GITHUB_OUTPUT"
-          echo "python=${{ steps.filter3.outputs.python }}" >> "$GITHUB_OUTPUT"
-          echo "frontend=${{ steps.filter3.outputs.frontend }}" >> "$GITHUB_OUTPUT"
-          echo "agent_config=${{ steps.filter3.outputs.agent_config }}" >> "$GITHUB_OUTPUT"
-          echo "lesson_schema=${{ steps.filter3.outputs.lesson_schema }}" >> "$GITHUB_OUTPUT"
-          echo "atlas=${{ steps.filter3.outputs.atlas }}" >> "$GITHUB_OUTPUT"
-          echo "postmortems=${{ steps.filter3.outputs.postmortems }}" >> "$GITHUB_OUTPUT"
+        emit() {
+          {
+            echo "content=$1"
+            echo "framing=$2"
+            echo "promote=$3"
+            echo "code=$4"
+            echo "python=$5"
+            echo "frontend=$6"
+            echo "agent_config=$7"
+            echo "lesson_schema=$8"
+            echo "atlas=$9"
+            echo "postmortems=${10}"
+          } >> "$GITHUB_OUTPUT"
+        }
+        if [ "$FILTER1_OUTCOME" = "success" ]; then
+          emit "$F1_CONTENT" "$F1_FRAMING" "$F1_PROMOTE" "$F1_CODE" "$F1_PYTHON" \
+            "$F1_FRONTEND" "$F1_AGENT_CONFIG" "$F1_LESSON_SCHEMA" "$F1_ATLAS" "$F1_POSTMORTEMS"
+        elif [ "$FILTER2_OUTCOME" = "success" ]; then
+          emit "$F2_CONTENT" "$F2_FRAMING" "$F2_PROMOTE" "$F2_CODE" "$F2_PYTHON" \
+            "$F2_FRONTEND" "$F2_AGENT_CONFIG" "$F2_LESSON_SCHEMA" "$F2_ATLAS" "$F2_POSTMORTEMS"
+        elif [ "$FILTER3_OUTCOME" = "success" ]; then
+          emit "$F3_CONTENT" "$F3_FRAMING" "$F3_PROMOTE" "$F3_CODE" "$F3_PYTHON" \
+            "$F3_FRONTEND" "$F3_AGENT_CONFIG" "$F3_LESSON_SCHEMA" "$F3_ATLAS" "$F3_POSTMORTEMS"
         else
           echo "::warning::path classification unavailable — running everything"
-          echo "content=true" >> "$GITHUB_OUTPUT"
-          echo "framing=true" >> "$GITHUB_OUTPUT"
-          echo "promote=true" >> "$GITHUB_OUTPUT"
-          echo "code=true" >> "$GITHUB_OUTPUT"
-          echo "python=true" >> "$GITHUB_OUTPUT"
-          echo "frontend=true" >> "$GITHUB_OUTPUT"
-          echo "agent_config=true" >> "$GITHUB_OUTPUT"
-          echo "lesson_schema=true" >> "$GITHUB_OUTPUT"
-          echo "atlas=true" >> "$GITHUB_OUTPUT"
-          echo "postmortems=true" >> "$GITHUB_OUTPUT"
+          emit true true true true true true true true true true
         fi
       shell: bash

--- a/scripts/api/rollover_router.py
+++ b/scripts/api/rollover_router.py
@@ -14,6 +14,19 @@ from .config import LIVE_REPO_ROOT
 router = APIRouter(tags=["rollovers"])
 
 
+def _client_registry_errors(errors: list | None) -> list[dict[str, str]]:
+    """Return path-only registry errors for HTTP clients (no exception text)."""
+    out: list[dict[str, str]] = []
+    for err in errors or []:
+        if not isinstance(err, dict):
+            continue
+        path = err.get("path")
+        if path is None:
+            continue
+        out.append({"path": str(path), "error": "invalid or unreadable durable source"})
+    return out
+
+
 def collect_rollover_orient_data() -> dict:
     """Compact cold-start projection; full evidence remains on this router."""
     audit = registry.audit_fleet(LIVE_REPO_ROOT)
@@ -28,7 +41,7 @@ def collect_rollover_orient_data() -> dict:
         "generated_at": audit["generated_at"],
         "counts": audit["counts"],
         "actionable": actionable,
-        "errors": audit["errors"],
+        "errors": _client_registry_errors(audit["errors"]),
         "task_identity": {
             "schema_version": identity_snapshot["schema_version"],
             "candidate_count": identity_snapshot["candidate_count"],
@@ -62,7 +75,7 @@ def rollover_audit(
         if not selected:
             raise HTTPException(
                 status_code=404,
-                detail={"error": "exact rollover selector matched no registry entry", "registry_errors": errors},
+                detail={"error": "exact rollover selector matched no registry entry", "registry_errors": _client_registry_errors(errors)},
             )
         if len(selected) > 1:
             raise HTTPException(
@@ -70,7 +83,7 @@ def rollover_audit(
                 detail={
                     "error": "exact rollover selector remains ambiguous",
                     "matches": [registry.candidate_summary(record) for record in selected],
-                    "registry_errors": errors,
+                    "registry_errors": _client_registry_errors(errors),
                 },
             )
         record = selected[0]
@@ -81,7 +94,7 @@ def rollover_audit(
                 detail={
                     "error": "exact rollover selector matched a corrupt durable source",
                     "candidate": registry.candidate_summary(record),
-                    "registry_errors": selected_errors,
+                    "registry_errors": _client_registry_errors(selected_errors),
                 },
             )
         return {
@@ -98,7 +111,7 @@ def rollover_audit(
             "evidence_paths": record.get("evidence_paths", []),
             "blocking_reason": record.get("blocking_reason"),
             "terminal_reason": record.get("terminal_reason"),
-            "registry_errors": errors,
+            "registry_errors": _client_registry_errors(errors),
         }
     audit = registry.audit_fleet(LIVE_REPO_ROOT, stale_hours=stale_hours)
     if agent is not None:
@@ -115,4 +128,5 @@ def rollover_audit(
                 for entry in audit["entries"]
             ),
         }
+    audit = {**audit, "errors": _client_registry_errors(audit.get("errors"))}
     return audit

--- a/scripts/lexicon/runner/transport.py
+++ b/scripts/lexicon/runner/transport.py
@@ -205,7 +205,7 @@ def atomic_write_bytes(path: Path, data: bytes) -> None:
     partial = path.with_name(path.name + ".partial")
     # If a prior partial exists, overwrite from start (rsync-style resume at app layer
     # is: rewrite partial until final hash matches, then rename).
-    fd = os.open(str(partial), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    fd = os.open(str(partial), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         with os.fdopen(fd, "wb") as handle:
             handle.write(data)

--- a/site/scripts/atlas-lexicon-route-parity.mjs
+++ b/site/scripts/atlas-lexicon-route-parity.mjs
@@ -217,25 +217,23 @@ function prepareSiteCopy({ label, sourceSite, lemmaFilesFrom, outDir, nodeModule
     "curriculum-stats.json",
   ]) {
     const dest = join(dataDir, name);
-    if (!existsSync(dest)) {
-      const fallback =
-        name === "lexicon-manifest.json"
-          ? JSON.stringify({ version: "0.1", generated_at: "test", entries: [] })
-          : name.includes("browse-meta")
-            ? JSON.stringify({ total: 0, letterCounts: {}, chipCounts: {} })
-            : name.includes("stats")
-              ? "{}"
-              : "[]";
-      try {
-        // wx: create-only — closes the existsSync→writeFileSync TOCTOU race.
-        writeFileSync(dest, fallback, { flag: "wx" });
-      } catch (err) {
-        if (err && typeof err === "object" && "code" in err && err.code === "EEXIST") {
-          // Another writer created the fixture between existsSync and write.
-          continue;
-        }
-        throw err;
+    const fallback =
+      name === "lexicon-manifest.json"
+        ? JSON.stringify({ version: "0.1", generated_at: "test", entries: [] })
+        : name.includes("browse-meta")
+          ? JSON.stringify({ total: 0, letterCounts: {}, chipCounts: {} })
+          : name.includes("stats")
+            ? "{}"
+            : "[]";
+    try {
+      // Exclusive create — no existsSync→write TOCTOU (CodeQL js/file-system-race).
+      writeFileSync(dest, fallback, { flag: "wx" });
+    } catch (err) {
+      if (err && typeof err === "object" && "code" in err && err.code === "EEXIST") {
+        // Fixture already present — leave it.
+        continue;
       }
+      throw err;
     }
   }
 

--- a/site/scripts/atlas-lexicon-route-parity.mjs
+++ b/site/scripts/atlas-lexicon-route-parity.mjs
@@ -226,7 +226,16 @@ function prepareSiteCopy({ label, sourceSite, lemmaFilesFrom, outDir, nodeModule
             : name.includes("stats")
               ? "{}"
               : "[]";
-      writeFileSync(dest, fallback);
+      try {
+        // wx: create-only — closes the existsSync→writeFileSync TOCTOU race.
+        writeFileSync(dest, fallback, { flag: "wx" });
+      } catch (err) {
+        if (err && typeof err === "object" && "code" in err && err.code === "EEXIST") {
+          // Another writer created the fixture between existsSync and write.
+          continue;
+        }
+        throw err;
+      }
     }
   }
 

--- a/site/tests/helpers/normalize-article-dom.ts
+++ b/site/tests/helpers/normalize-article-dom.ts
@@ -48,14 +48,15 @@ const PRESENCE_DATA_ATTRS = new Set([
 ]);
 
 function decodeEntities(text: string): string {
+  // Decode &amp; last so sequences like &amp;lt; are not double-unescaped.
   return text
     .replace(/&#x27;/gi, "'")
     .replace(/&#39;/g, "'")
     .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
-    .replace(/&nbsp;/g, " ");
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&");
 }
 
 function normalizeClassList(value: string | null): string | null {

--- a/tests/test_paths_filter_fail_open.py
+++ b/tests/test_paths_filter_fail_open.py
@@ -64,12 +64,22 @@ def test_fail_open_sets_all_declared_outputs_to_true() -> None:
         "Fallback block must emit warning annotation"
     )
 
-    # Check that every declared output is explicitly set to true in the fallback block
-    for output in outputs:
-        pattern = rf'echo "{output}=true"\s+>>\s+"?\$GITHUB_OUTPUT"?'
-        assert re.search(pattern, fallback_content), (
-            f"Fallback block must set '{output}=true' to run everything on failure"
-        )
+    # Fail-open must set every declared output to true. Accept either per-key
+    # `echo "key=true"` lines or a single `emit true ...` call with one true per output
+    # (env-indirection hardening for zizmor/template-injection).
+    ordered = list(action_data.get("outputs", {}).keys())
+    per_key_ok = all(
+        re.search(rf'echo "{output}=true"\s+>>\s+"?\$GITHUB_OUTPUT"?', fallback_content)
+        for output in outputs
+    )
+    emit_trues = re.search(
+        r"emit\s+" + r"\s+".join(["true"] * len(ordered)),
+        fallback_content,
+    )
+    assert per_key_ok or emit_trues, (
+        "Fallback block must set every declared output to true "
+        f"(outputs={sorted(outputs)})"
+    )
 
 
 def test_workflows_only_consume_valid_action_outputs() -> None:


### PR DESCRIPTION
## Summary
- `py/overly-permissive-file` (#311): write `.partial` files as `0o600`.
- `zizmor/template-injection` (#278–#310): pass paths-filter outputs via `env:` instead of `${{ }}` inside `run:`.
- `py/stack-trace-exposure` (#273/#274): sanitize registry exception text before HTTP responses.
- `js/double-escaping` (#276): decode `&amp;` last.
- `js/file-system-race` (#271): exclusive `wx` create for atlas fixtures.

## Test plan
- [ ] `pytest tests/test_rollover_api.py` (local: 6 passed)
- [ ] Code scanning / zizmor clean on the PR
- [ ] CI green


Made with [Cursor](https://cursor.com)