### PR TITLE
fix(review): ignore audiovisual descriptors in audio evidence gate

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,7 +1,7 @@
 review_protocol_version: 6.0.3
 deterministic_contract_version: 2.0.0
 semantic_prompt_version: 6.0.4
-track_policy_version: 2.0.0
+track_policy_version: 2.0.1
 
 score_calibration:
   bands:
@@ -75,7 +75,7 @@ defaults:
     evidence_requirements:
       - id: audio-dependent-task
         modality: audio
-        regex: '(?:прослух(?:ай(?:те)?|овуванн\w*|ати|овуй\w*|овуват\w*)|слухай(?:те)?|аудіо\w*|часов\w*\s+позначк\w*|(?:ви|де|що)\s+чуєте\b|виразно\s+почут\w*\s+(?:слов|звук|нот|фраз|акорд)\w*)'
+        regex: '(?:прослух(?:ай(?:те)?|овуванн\w*|ати|овуй\w*|овуват\w*)|слухай(?:те)?|аудіо(?!візуал)\w*|часов\w*\s+позначк\w*|(?:ви|де|що)\s+чуєте\b|виразно\s+почут\w*\s+(?:слов|звук|нот|фраз|акорд)\w*)'
         exclude_line_regex: '(?:необов''язков\w*|не\s+оціню\w*|не\s+використову\w*\s+в\s+оцінюван\w*\s+завданн\w*)'
       - id: video-dependent-task
         modality: video

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -3186,6 +3186,46 @@ def test_bilash_modality_vocabulary_does_not_create_evidence_requirements() -> N
     assert not [item for item in requirements if item["modality"] in {"audio", "video"}]
 
 
+def test_audiovisual_evidence_boundary_is_not_an_audio_requirement() -> None:
+    policy = pbr.resolve_track_policy("bio", pbr.load_track_policy())
+    texts = {
+        "module.md": (
+            "Кіно як аудіовізуальний медіум може додати сценічний контекст.\n"
+            "Без самого аудіовізуального твору цей контекст не перевірити.\n"
+            "Для аналізу потрібен сам фільм, а не лише довідка про нього.\n"
+        ),
+        "activities.yaml": (
+            "instruction: Розрізніть каталог і аудіовізуальний медіум.\n"
+            "answer: Без перегляду стрічки аналізувати її не можна.\n"
+        ),
+    }
+
+    requirements = pbr.inventory_evidence_requirements(
+        texts,
+        policy["mechanical_checks"]["evidence_requirements"],
+    )
+
+    assert not [item for item in requirements if item["modality"] == "audio"]
+
+
+def test_audio_record_compound_remains_an_audio_requirement() -> None:
+    policy = pbr.resolve_track_policy("bio", pbr.load_track_policy())
+    texts = {
+        "activities.yaml": "instruction: Порівняйте аудіозапис із текстом.\n",
+    }
+
+    requirements = pbr.inventory_evidence_requirements(
+        texts,
+        policy["mechanical_checks"]["evidence_requirements"],
+    )
+
+    assert [
+        (item["modality"], item["evidence"])
+        for item in requirements
+        if item["modality"] == "audio"
+    ] == [("audio", "аудіозапис")]
+
+
 def test_optional_ungraded_media_does_not_hide_required_listening() -> None:
     policy = pbr.resolve_track_policy("bio", pbr.load_track_policy())
     texts = {
@@ -3582,7 +3622,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
     assert catalog["catalog_version"] == "6.0.4"
-    assert len(rows) == 71
+    assert len(rows) == 72
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -155,6 +155,12 @@ regressions:
     version_field: track_policy_version
     input: Biographical prose mentions hearing/listeners and text tasks explain that catalog metadata cannot verify video.
     expected: Do not inventory audio or video unless learner-facing language actually requires listening, viewing, or perceptual evidence.
+  - bug_id: audiovisual-medium-misclassified-as-audio-task
+    responsible_layer: track_policy
+    fixed_in_version: 2.0.1
+    version_field: track_policy_version
+    input: Source-criticism prose describes film as an audiovisual medium while refusing analysis without direct access to the film.
+    expected: Do not inventory audio from the adjective audiovisual; genuine audio compounds and explicit listening cues remain inventoried.
   - bug_id: optional-ungraded-media-inventoried-as-required
     responsible_layer: deterministic_code
     fixed_in_version: 1.2.1


### PR DESCRIPTION
## Summary
- stop the audio evidence detector from treating `аудіовізуальний` as a listening requirement
- preserve genuine audio compounds such as `аудіозапис`
- bump `track_policy_version` to 2.0.1 and record the regression

## Verification
- `.venv/bin/python -m pytest tests/audit/test_post_build_review.py -q` — 177 passed
- exact BIO-371 learner text inventories zero audio evidence requirements
- `git diff --check`
- agent trailer lint

## Review evidence
- Grok 4.5 high read-only design review: PASS; suggested catalog hardening applied
- Gemini 3.1 Pro high request stalled beyond its 20-minute ceiling and was cancelled without a result

Related to #5294; does not close or recreate the already-completed BIO-371 work.