### PR TITLE
feat(lexicon): deterministic needs_review triage for 2,316 held grow words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,6 +409,8 @@ data/lexicon/cache/
 #   .venv/bin/python -m scripts.lexicon.grow_lexicon_from_content (#3675 P2; promotion = P3)
 data/lexicon/grow_candidates.json
 data/lexicon/grow_needs_review.json
+data/lexicon/needs-review-triage.json
+data/lexicon/needs-review-triage-summary.md
 # Ohoiko corpus intake full source inventory (~31 MB, 111,200 rows): deterministic,
 # regenerable output of committed code over the private corpus (#4223). It does NOT
 # belong in git history — regenerate on demand into this path (main checkout only):

--- a/scripts/lexicon/triage_needs_review.py
+++ b/scripts/lexicon/triage_needs_review.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+"""Deterministic local-source triage for grow ``needs_review`` lemmas.
+
+For every held entry in ``data/lexicon/grow_candidates.json``, probe local
+dictionaries in ``data/sources.db`` (batched SQL, no per-word loops) and decide
+a machine action by code:
+
+* ``promote_with_gloss`` — ≥1 gloss-bearing source has a definition
+* ``truly_missing`` — no local gloss source has the lemma
+* ``heritage_flag`` — heritage/calque held reason (kept aside regardless of hits)
+
+When to use: answering "which dictionary are the 2,316 held grow words missing
+from?" with counts — never LLM judging. When NOT to use: linguistic sense
+disambiguation or promotion itself (this tool only triages).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.lexicon.lemma_normalization import strip_acute_stress
+from scripts.verification.vesum import verify_words
+from scripts.wiki import sources_db as sdb
+
+DEFAULT_CANDIDATES = PROJECT_ROOT / "data" / "lexicon" / "grow_candidates.json"
+DEFAULT_SOURCES_DB = PROJECT_ROOT / "data" / "sources.db"
+DEFAULT_OUT = PROJECT_ROOT / "data" / "lexicon" / "needs-review-triage.json"
+DEFAULT_SUMMARY = PROJECT_ROOT / "data" / "lexicon" / "needs-review-triage-summary.md"
+
+# Gloss priority for best_gloss / promote_with_gloss (user contract).
+GLOSS_SOURCE_PRIORITY: tuple[str, ...] = (
+    "sum11",
+    "dmklinger",
+    "grinchenko",
+    "slovnyk_me",
+    "balla",
+)
+# Full sources_hit key order (stable JSON / summary columns).
+SOURCE_HIT_KEYS: tuple[str, ...] = (
+    "sum11",
+    "dmklinger",
+    "grinchenko",
+    "slovnyk_me",
+    "balla",
+    "esum",
+    "puls_cefr",
+)
+
+MACHINE_PROMOTE = "promote_with_gloss"
+MACHINE_MISSING = "truly_missing"
+MACHINE_HERITAGE = "heritage_flag"
+SAMPLE_ROWS = 20
+_BATCH = 400
+
+LookupFn = Callable[[list[str]], dict[str, list[dict[str, Any]]]]
+VesumFn = Callable[[list[str]], dict[str, list[dict[str, Any]]]]
+
+
+@dataclass(frozen=True)
+class HeldEntry:
+    lemma: str
+    pos: str | None
+    held_reason: str
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class TriageResult:
+    entries: list[dict[str, Any]]
+    summary_md: str
+    counts_by_action: dict[str, int]
+    candidates_found: bool
+    written: bool
+    dry_run: bool
+
+
+def load_held_entries(candidates_path: Path) -> list[HeldEntry]:
+    """Parse ``needs_review`` rows from a grow_candidates payload."""
+    payload = json.loads(candidates_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"candidates payload must be a JSON object: {candidates_path}")
+    raw_items = payload.get("needs_review") or []
+    if not isinstance(raw_items, list):
+        raise ValueError(f"needs_review must be a list: {candidates_path}")
+
+    held: list[HeldEntry] = []
+    for item in raw_items:
+        if not isinstance(item, Mapping):
+            continue
+        entry = item.get("entry") if isinstance(item.get("entry"), Mapping) else item
+        if not isinstance(entry, Mapping):
+            continue
+        lemma = strip_acute_stress(str(entry.get("lemma") or "").strip())
+        if not lemma:
+            continue
+        pos_raw = entry.get("pos")
+        pos = str(pos_raw).strip() if pos_raw is not None and str(pos_raw).strip() else None
+        reason = str(item.get("reason") or entry.get("held_reason") or "").strip()
+        held.append(HeldEntry(lemma=lemma, pos=pos, held_reason=reason, raw=item))
+    return held
+
+
+def is_heritage_held(reason: str) -> bool:
+    """True when the hold reason is a heritage/calque carve-out."""
+    return "heritage_status" in (reason or "")
+
+
+def extract_gloss_text(source_key: str, hit: Mapping[str, Any]) -> str | None:
+    """Pull a non-empty definition/gloss string from one source row."""
+    if source_key == "dmklinger":
+        translations = hit.get("translations")
+        if isinstance(translations, str) and translations.strip():
+            try:
+                parsed = json.loads(translations)
+            except json.JSONDecodeError:
+                text = translations.strip()
+                return text or None
+            if isinstance(parsed, list):
+                for item in parsed:
+                    text = str(item or "").strip()
+                    if text:
+                        return text
+            text = str(parsed).strip()
+            return text or None
+        if isinstance(translations, list):
+            for item in translations:
+                text = str(item or "").strip()
+                if text:
+                    return text
+        text = str(hit.get("text") or "").strip()
+        return text or None
+
+    for field in ("definition", "text", "etymology_text"):
+        text = str(hit.get(field) or "").strip()
+        if text:
+            return text
+    return None
+
+
+def choose_best_gloss(
+    hits_by_source: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> dict[str, str] | None:
+    """First non-empty gloss in GLOSS_SOURCE_PRIORITY order."""
+    for source_key in GLOSS_SOURCE_PRIORITY:
+        for hit in hits_by_source.get(source_key) or []:
+            text = extract_gloss_text(source_key, hit)
+            if text:
+                return {"text": text, "source": source_key}
+    return None
+
+
+def decide_machine_action(
+    *,
+    held_reason: str,
+    best_gloss: Mapping[str, str] | None,
+) -> str:
+    """Code-only action bucket (no linguistic judgment)."""
+    if is_heritage_held(held_reason):
+        return MACHINE_HERITAGE
+    if best_gloss is not None:
+        return MACHINE_PROMOTE
+    return MACHINE_MISSING
+
+
+def _chunked(items: Sequence[str], size: int = _BATCH) -> list[list[str]]:
+    return [list(items[i : i + size]) for i in range(0, len(items), size)]
+
+
+def _merge_batch_lookup(
+    lemmas: Sequence[str],
+    lookup: LookupFn,
+) -> dict[str, list[dict[str, Any]]]:
+    out: dict[str, list[dict[str, Any]]] = {lemma: [] for lemma in lemmas}
+    if not lemmas:
+        return out
+    unique = list(dict.fromkeys(lemmas))
+    for chunk in _chunked(unique):
+        batch = lookup(chunk)
+        for lemma in chunk:
+            out[lemma] = list(batch.get(lemma) or [])
+    return out
+
+
+def probe_sources(
+    lemmas: Sequence[str],
+    *,
+    db_path: Path | None = None,
+    lookups: Mapping[str, LookupFn] | None = None,
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Batched local probes keyed by source then lemma."""
+    if lookups is not None:
+        return {key: _merge_batch_lookup(lemmas, fn) for key, fn in lookups.items()}
+
+    path = str(db_path) if db_path is not None else None
+
+    def _sum11(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+        return sdb.search_definitions_batch(words, db_path=path)
+
+    def _dmk(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+        return sdb.search_dmklinger_uk_en_batch(words, db_path=path)
+
+    def _grin(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+        return sdb.search_grinchenko_batch(words, db_path=path)
+
+    def _slov(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+        return sdb.search_slovnyk_me_entries_batch(words, db_path=path)
+
+    def _balla(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+        return sdb.search_balla_en_uk_batch(words, db_path=path)
+
+    def _esum(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+        return sdb.search_esum_batch(words, db_path=path)
+
+    def _cefr(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+        return sdb.query_cefr_levels(words, db_path=path)
+
+    default_lookups: dict[str, LookupFn] = {
+        "sum11": _sum11,
+        "dmklinger": _dmk,
+        "grinchenko": _grin,
+        "slovnyk_me": _slov,
+        "balla": _balla,
+        "esum": _esum,
+        "puls_cefr": _cefr,
+    }
+    return {key: _merge_batch_lookup(lemmas, fn) for key, fn in default_lookups.items()}
+
+
+def probe_vesum(
+    lemmas: Sequence[str],
+    *,
+    vesum_db: Path | None = None,
+    vesum_fn: VesumFn | None = None,
+) -> dict[str, bool]:
+    """Batch VESUM validity (chunked to stay under SQLite placeholder limits)."""
+    if not lemmas:
+        return {}
+    unique = list(dict.fromkeys(lemmas))
+    valid: dict[str, bool] = {lemma: False for lemma in unique}
+    checker = vesum_fn
+    if checker is None:
+
+        def checker(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+            return verify_words(words, db_path=vesum_db)
+
+    for chunk in _chunked(unique):
+        try:
+            batch = checker(chunk)
+        except FileNotFoundError:
+            # No VESUM DB in worktree/sparse checkout — report false, do not crash.
+            for lemma in chunk:
+                valid[lemma] = False
+            continue
+        for lemma in chunk:
+            valid[lemma] = bool(batch.get(lemma))
+    return valid
+
+
+def triage_held_entries(
+    held: Sequence[HeldEntry],
+    *,
+    db_path: Path | None = None,
+    vesum_db: Path | None = None,
+    lookups: Mapping[str, LookupFn] | None = None,
+    vesum_fn: VesumFn | None = None,
+) -> list[dict[str, Any]]:
+    """Return per-lemma triage records (deterministic, code-decided)."""
+    lemmas = [item.lemma for item in held]
+    by_source = probe_sources(lemmas, db_path=db_path, lookups=lookups)
+    vesum_valid = probe_vesum(lemmas, vesum_db=vesum_db, vesum_fn=vesum_fn)
+
+    records: list[dict[str, Any]] = []
+    for item in held:
+        hits: dict[str, list[dict[str, Any]]] = {}
+        sources_hit: dict[str, int] = {}
+        for key in SOURCE_HIT_KEYS:
+            source_map = by_source.get(key) or {}
+            row_hits = list(source_map.get(item.lemma) or [])
+            hits[key] = row_hits
+            sources_hit[key] = len(row_hits)
+
+        best_gloss = choose_best_gloss(hits)
+        cefr_hits = hits.get("puls_cefr") or []
+        cefr_level: str | None = None
+        if cefr_hits:
+            level = cefr_hits[0].get("level")
+            cefr_level = str(level).strip() if level is not None and str(level).strip() else None
+
+        action = decide_machine_action(held_reason=item.held_reason, best_gloss=best_gloss)
+        records.append(
+            {
+                "lemma": item.lemma,
+                "pos": item.pos,
+                "held_reason": item.held_reason,
+                "sources_hit": sources_hit,
+                "best_gloss": best_gloss,
+                "cefr": cefr_level,
+                "vesum_valid": bool(vesum_valid.get(item.lemma)),
+                "machine_action": action,
+            }
+        )
+    return records
+
+
+def build_summary_markdown(records: Sequence[Mapping[str, Any]]) -> str:
+    """Counts per action / source-hit combo / POS + 20-row samples."""
+    action_counts = Counter(str(r.get("machine_action") or "") for r in records)
+    pos_counts = Counter(str(r.get("pos") or "(none)") for r in records)
+
+    combo_counts: Counter[str] = Counter()
+    for record in records:
+        hits = record.get("sources_hit") if isinstance(record.get("sources_hit"), Mapping) else {}
+        present = [key for key in SOURCE_HIT_KEYS if int(hits.get(key) or 0) > 0]
+        label = "+".join(present) if present else "(none)"
+        combo_counts[label] += 1
+
+    lines: list[str] = [
+        "# Needs-review triage summary",
+        "",
+        "Deterministic local-source probe of grow `needs_review` lemmas.",
+        "No LLM judging — machine_action is decided by code.",
+        "",
+        f"Total held: **{len(records)}**",
+        "",
+        "## Counts by machine_action",
+        "",
+    ]
+    for action in (MACHINE_PROMOTE, MACHINE_MISSING, MACHINE_HERITAGE):
+        lines.append(f"- `{action}`: {action_counts.get(action, 0)}")
+    for action, count in sorted(action_counts.items()):
+        if action not in {MACHINE_PROMOTE, MACHINE_MISSING, MACHINE_HERITAGE}:
+            lines.append(f"- `{action}`: {count}")
+
+    lines.extend(["", "## Counts by POS", ""])
+    for pos, count in pos_counts.most_common():
+        lines.append(f"- `{pos}`: {count}")
+
+    lines.extend(
+        [
+            "",
+            "## Counts by source-hit combination",
+            "",
+            "Keys present (count > 0), joined with `+`. `(none)` = zero hits.",
+            "",
+        ]
+    )
+    for combo, count in combo_counts.most_common():
+        lines.append(f"- `{combo}`: {count}")
+
+    lines.extend(["", "## Per-source hit totals (lemma has ≥1 row)", ""])
+    for key in SOURCE_HIT_KEYS:
+        n = sum(
+            1
+            for record in records
+            if isinstance(record.get("sources_hit"), Mapping)
+            and int(record["sources_hit"].get(key) or 0) > 0
+        )
+        lines.append(f"- `{key}`: {n}")
+
+    for action in (MACHINE_PROMOTE, MACHINE_MISSING, MACHINE_HERITAGE):
+        bucket = [r for r in records if r.get("machine_action") == action]
+        lines.extend(
+            [
+                "",
+                f"## Sample ({SAMPLE_ROWS}) — `{action}` (n={len(bucket)})",
+                "",
+                "| lemma | pos | held_reason | sources_hit | best_gloss |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for record in bucket[:SAMPLE_ROWS]:
+            hits = record.get("sources_hit") if isinstance(record.get("sources_hit"), Mapping) else {}
+            hit_bits = ",".join(
+                f"{k}={hits.get(k, 0)}" for k in SOURCE_HIT_KEYS if int(hits.get(k) or 0) > 0
+            ) or "—"
+            gloss = record.get("best_gloss")
+            if isinstance(gloss, Mapping) and gloss.get("text"):
+                gloss_cell = f"{gloss.get('source')}: {_md_cell(str(gloss.get('text'))[:80])}"
+            else:
+                gloss_cell = "—"
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        _md_cell(str(record.get("lemma") or "")),
+                        _md_cell(str(record.get("pos") or "")),
+                        _md_cell(str(record.get("held_reason") or "")[:60]),
+                        _md_cell(hit_bits),
+                        gloss_cell,
+                    ]
+                )
+                + " |"
+            )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _md_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def run_triage(
+    *,
+    candidates_path: Path = DEFAULT_CANDIDATES,
+    db_path: Path | None = DEFAULT_SOURCES_DB,
+    vesum_db: Path | None = None,
+    out_path: Path = DEFAULT_OUT,
+    summary_path: Path = DEFAULT_SUMMARY,
+    write: bool = False,
+    limit: int | None = None,
+    lookups: Mapping[str, LookupFn] | None = None,
+    vesum_fn: VesumFn | None = None,
+) -> TriageResult:
+    """Load candidates, probe sources, optionally write artifacts."""
+    candidates_path = _resolve(candidates_path)
+    out_path = _resolve(out_path)
+    summary_path = _resolve(summary_path)
+    if db_path is not None:
+        db_path = _resolve(db_path)
+    if vesum_db is not None:
+        vesum_db = _resolve(vesum_db)
+
+    if not candidates_path.exists():
+        empty_summary = build_summary_markdown([])
+        return TriageResult(
+            entries=[],
+            summary_md=empty_summary,
+            counts_by_action={},
+            candidates_found=False,
+            written=False,
+            dry_run=not write,
+        )
+
+    held = load_held_entries(candidates_path)
+    if limit is not None:
+        held = held[: max(0, limit)]
+
+    records = triage_held_entries(
+        held,
+        db_path=db_path,
+        vesum_db=vesum_db,
+        lookups=lookups,
+        vesum_fn=vesum_fn,
+    )
+    summary_md = build_summary_markdown(records)
+    counts = dict(Counter(str(r["machine_action"]) for r in records))
+
+    written = False
+    if write:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "generated_by": "scripts/lexicon/triage_needs_review.py",
+            "candidates": str(candidates_path),
+            "sources_db": str(db_path) if db_path is not None else None,
+            "counts": {
+                "total": len(records),
+                **{f"action_{k}": v for k, v in sorted(counts.items())},
+            },
+            "entries": records,
+        }
+        out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(summary_md, encoding="utf-8")
+        written = True
+
+    return TriageResult(
+        entries=records,
+        summary_md=summary_md,
+        counts_by_action=counts,
+        candidates_found=True,
+        written=written,
+        dry_run=not write,
+    )
+
+
+def format_cli_summary(result: TriageResult) -> str:
+    lines = [
+        f"Mode: {'write' if result.written else 'probe (read-only)'}",
+        f"Candidates found: {str(result.candidates_found).lower()}",
+        f"Held triaged: {len(result.entries)}",
+        f"Written: {str(result.written).lower()}",
+    ]
+    for action in (MACHINE_PROMOTE, MACHINE_MISSING, MACHINE_HERITAGE):
+        lines.append(f"  {action}: {result.counts_by_action.get(action, 0)}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Deterministically triage grow needs_review lemmas against local "
+            "sources.db dictionaries (batched SQL + VESUM). "
+            "Use this when you need code-decided counts of which held words "
+            "already have a local gloss vs truly missing; do not use it for "
+            "LLM judging or for writing the live manifest."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Read-only probe (stdout counts; no files written)\n"
+            "  .venv/bin/python scripts/lexicon/triage_needs_review.py --probe\n"
+            "\n"
+            "  # Write JSON + markdown summary\n"
+            "  .venv/bin/python scripts/lexicon/triage_needs_review.py --write \\\n"
+            "    --db data/sources.db --candidates data/lexicon/grow_candidates.json\n"
+            "\n"
+            "  # Sparse worktree: pass absolute paths from the primary checkout\n"
+            "  .venv/bin/python scripts/lexicon/triage_needs_review.py --write \\\n"
+            "    --db /path/to/primary/data/sources.db \\\n"
+            "    --candidates /path/to/primary/data/lexicon/grow_candidates.json\n"
+            "\n"
+            "Outputs (only with --write):\n"
+            "  data/lexicon/needs-review-triage.json     per-lemma machine triage\n"
+            "  data/lexicon/needs-review-triage-summary.md  counts + samples\n"
+            "\n"
+            "Exit codes:\n"
+            "  0  success (--help, --probe, or successful --write)\n"
+            "  2  refused (no --write/--probe) or argparse/input error\n"
+            "\n"
+            "Related:\n"
+            "  scripts/lexicon/promote_grow_candidates.py  — promote auto_merge only\n"
+            "  scripts/wiki/sources_db.py                 — batched dictionary probes\n"
+            "  issue #5230                                — Atlas re-enrich arc\n"
+        ),
+    )
+    parser.add_argument(
+        "--candidates",
+        type=Path,
+        default=DEFAULT_CANDIDATES,
+        help=(
+            "Path to grow_candidates.json with needs_review[] "
+            f"(default: {DEFAULT_CANDIDATES})"
+        ),
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DEFAULT_SOURCES_DB,
+        help=f"Path to sources.db (default: {DEFAULT_SOURCES_DB})",
+    )
+    parser.add_argument(
+        "--vesum-db",
+        type=Path,
+        default=None,
+        help="Optional VESUM SQLite path override (default: project VESUM_DB_PATH)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"JSON triage output path (default: {DEFAULT_OUT})",
+    )
+    parser.add_argument(
+        "--summary-out",
+        type=Path,
+        default=DEFAULT_SUMMARY,
+        help=f"Markdown summary output path (default: {DEFAULT_SUMMARY})",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional cap on held entries processed (probe/debug; default: all)",
+    )
+    mode = parser.add_mutually_exclusive_group(required=False)
+    mode.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "Write needs-review-triage.json and the markdown summary. "
+            "Default without --write/--probe: refuse (exit 2)."
+        ),
+    )
+    mode.add_argument(
+        "--probe",
+        action="store_true",
+        help=(
+            "Read-only probe: run all batched lookups and print counts to stdout; "
+            "do not write files."
+        ),
+    )
+    parser.add_argument(
+        "--print-summary",
+        action="store_true",
+        help="Also print the full markdown summary to stdout after the count line.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not args.write and not args.probe:
+        parser.error(
+            "refusing to run without --write or --probe "
+            "(pass --probe for read-only counts, or --write to emit triage files)"
+        )
+
+    try:
+        result = run_triage(
+            candidates_path=args.candidates,
+            db_path=args.db,
+            vesum_db=args.vesum_db,
+            out_path=args.out,
+            summary_path=args.summary_out,
+            write=bool(args.write),
+            limit=args.limit,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(format_cli_summary(result))
+    if args.print_summary:
+        print()
+        print(result.summary_md)
+    return 0
+
+
+def _resolve(path: Path) -> Path:
+    path = Path(path)
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -1915,14 +1915,23 @@ def _batch_dict_lookup(
     return results
 
 
-def search_definitions(word: str, limit: int = 10) -> list[dict]:
+def search_definitions(
+    word: str,
+    limit: int = 10,
+    *,
+    db_path: str | Path | None = None,
+) -> list[dict]:
     """Look up word in СУМ-11 (Ukrainian explanatory dictionary)."""
-    return _dict_lookup("sum11", word, limit)
+    return _dict_lookup("sum11", word, limit, db_path=db_path)
 
 
-def search_definitions_batch(words: list[str]) -> dict[str, list[dict]]:
+def search_definitions_batch(
+    words: list[str],
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, list[dict]]:
     """Return the best СУМ-11 hit for each requested word in batched SQL."""
-    return _batch_dict_lookup("sum11", words, limit=1)
+    return _batch_dict_lookup("sum11", words, limit=1, db_path=db_path)
 
 
 def search_grinchenko_1907(
@@ -1933,6 +1942,247 @@ def search_grinchenko_1907(
 ) -> list[dict]:
     """Look up word in Грінченко (historical dictionary)."""
     return _dict_lookup("grinchenko", word, limit, db_path=db_path)
+
+
+def search_grinchenko_batch(
+    words: list[str],
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, list[dict]]:
+    """Return the best Грінченко hit for each requested word in batched SQL."""
+    return _batch_dict_lookup("grinchenko", words, limit=1, db_path=db_path)
+
+
+def search_balla_en_uk_batch(
+    words: list[str],
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, list[dict]]:
+    """Return the best Балла EN→UK hit for each requested English headword."""
+    return _batch_dict_lookup("balla_en_uk", words, limit=1, db_path=db_path)
+
+
+def search_dmklinger_uk_en_batch(
+    words: list[str],
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, list[dict]]:
+    """Batch-lookup dmklinger UK→EN by stress-normalized exact headword.
+
+    ``dmklinger_uk_en`` stores stressed headwords (e.g. ``робо́та``). Plain
+    equality therefore misses almost everything; strip U+0301 on both sides
+    and match case-insensitively in 400-row chunks (same budget as
+    :func:`_batch_dict_lookup`).
+    """
+    requested = list(dict.fromkeys(str(word) for word in words if str(word).strip()))
+    results: dict[str, list[dict]] = {word: [] for word in requested}
+    if not requested:
+        return results
+
+    conn = None
+    try:
+        conn = _get_conn_for(db_path)
+    except FileNotFoundError:
+        return results
+
+    try:
+        if not _table_columns("dmklinger_uk_en", db_path):
+            return results
+        for start in range(0, len(requested), 400):
+            chunk = requested[start:start + 400]
+            # Query keys are stress-stripped so callers can pass either form.
+            plain_keys = [_strip_combining_acute(word) for word in chunk]
+            values = ", ".join("(?)" for _ in plain_keys)
+            rows = conn.execute(
+                f"""
+                WITH requested(word) AS (VALUES {values}),
+                ranked AS (
+                    SELECT
+                        requested.word AS requested_word,
+                        dictionary.*,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY requested.word
+                            ORDER BY dictionary.word COLLATE NOCASE
+                        ) AS result_order
+                    FROM requested
+                    JOIN dmklinger_uk_en AS dictionary
+                      ON replace(dictionary.word, char(0x301), '')
+                         = requested.word COLLATE NOCASE
+                )
+                SELECT * FROM ranked
+                WHERE result_order <= 1
+                """,
+                plain_keys,
+            ).fetchall()
+            by_plain: dict[str, list[dict]] = {key: [] for key in plain_keys}
+            for row in rows:
+                item = dict(row)
+                plain = item.pop("requested_word")
+                item.pop("result_order", None)
+                by_plain.setdefault(plain, []).append(item)
+            for original, plain in zip(chunk, plain_keys, strict=True):
+                results[original] = list(by_plain.get(plain, []))
+    except sqlite3.OperationalError:
+        return results
+    finally:
+        _close_if_temporary(conn, db_path)
+
+    return results
+
+
+def search_esum_batch(
+    words: list[str],
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, list[dict]]:
+    """Exact-lemma ЕСУМ meta hits for many words (no FTS body scan)."""
+    requested = list(dict.fromkeys(str(word) for word in words if str(word).strip()))
+    results: dict[str, list[dict]] = {word: [] for word in requested}
+    if not requested:
+        return results
+
+    conn = None
+    try:
+        conn = _get_conn_for(db_path)
+    except FileNotFoundError:
+        return results
+
+    try:
+        if not _table_columns("esum_etymology_meta", db_path):
+            return results
+        for start in range(0, len(requested), 400):
+            chunk = requested[start:start + 400]
+            values = ", ".join("(?)" for _ in chunk)
+            rows = conn.execute(
+                f"""
+                WITH requested(word) AS (VALUES {values}),
+                ranked AS (
+                    SELECT
+                        requested.word AS requested_word,
+                        meta.id,
+                        meta.lemma,
+                        meta.etymology_text,
+                        meta.cognates,
+                        meta.vol,
+                        meta.page,
+                        meta.source,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY requested.word
+                            ORDER BY meta.vol, meta.page, meta.lemma
+                        ) AS result_order
+                    FROM requested
+                    JOIN esum_etymology_meta AS meta
+                      ON meta.lemma = requested.word COLLATE NOCASE
+                )
+                SELECT * FROM ranked
+                WHERE result_order <= 1
+                """,
+                chunk,
+            ).fetchall()
+            for row in rows:
+                item = dict(row)
+                requested_word = item.pop("requested_word")
+                item.pop("result_order", None)
+                results[requested_word].append(item)
+    except sqlite3.OperationalError:
+        return results
+    finally:
+        _close_if_temporary(conn, db_path)
+
+    return results
+
+
+def search_slovnyk_me_entries_batch(
+    words: list[str],
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, list[dict]]:
+    """Exact ``normalized_word`` hits on curated slovnyk.me entries (batched).
+
+    Missing table → empty hits (production sources.db may not ship the table).
+    Overlap-blocked dictionaries are excluded, matching single-word search.
+    """
+    requested = list(dict.fromkeys(str(word) for word in words if str(word).strip()))
+    results: dict[str, list[dict]] = {word: [] for word in requested}
+    if not requested:
+        return results
+
+    conn = None
+    try:
+        conn = _get_conn_for(db_path)
+    except FileNotFoundError:
+        return results
+
+    try:
+        if not _table_columns("slovnyk_me_entries", db_path):
+            return results
+        blocked = tuple(slovnyk_me.OVERLAP_BLOCKED_DICTS)
+        block_filter = ""
+        block_params: list[object] = []
+        if blocked:
+            block_filter = (
+                f" AND dictionary.dictionary_slug NOT IN "
+                f"({','.join('?' for _ in blocked)})"
+            )
+            block_params = list(blocked)
+
+        for start in range(0, len(requested), 400):
+            chunk = requested[start:start + 400]
+            normalized = [slovnyk_me.normalize_word(word) for word in chunk]
+            # Map normalized form back to original request keys (first wins).
+            originals_by_norm: dict[str, list[str]] = {}
+            for original, norm in zip(chunk, normalized, strict=True):
+                if not norm:
+                    continue
+                originals_by_norm.setdefault(norm, []).append(original)
+            norms = list(originals_by_norm)
+            if not norms:
+                continue
+            values = ", ".join("(?)" for _ in norms)
+            rows = conn.execute(
+                f"""
+                WITH requested(word) AS (VALUES {values}),
+                ranked AS (
+                    SELECT
+                        requested.word AS requested_word,
+                        dictionary.*,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY requested.word
+                            ORDER BY dictionary.id
+                        ) AS result_order
+                    FROM requested
+                    JOIN slovnyk_me_entries AS dictionary
+                      ON dictionary.normalized_word = requested.word
+                    WHERE 1=1{block_filter}
+                )
+                SELECT * FROM ranked
+                WHERE result_order <= 1
+                """,
+                (*norms, *block_params),
+            ).fetchall()
+            by_norm: dict[str, list[dict]] = {norm: [] for norm in norms}
+            for row in rows:
+                item = dict(row)
+                norm = item.pop("requested_word")
+                item.pop("result_order", None)
+                by_norm.setdefault(norm, []).append(
+                    _normalize_slovnyk_row(item, norm)
+                )
+            for norm, originals in originals_by_norm.items():
+                hits = by_norm.get(norm, [])
+                for original in originals:
+                    results[original] = list(hits)
+    except sqlite3.OperationalError:
+        return results
+    finally:
+        _close_if_temporary(conn, db_path)
+
+    return results
+
+
+def _strip_combining_acute(value: str) -> str:
+    """Remove U+0301 combining acute from a dictionary headword or query."""
+    return value.replace("\u0301", "")
 
 
 def _escape_fts5_phrase(term: str) -> str:
@@ -2090,9 +2340,14 @@ def search_esum(
         _close_if_temporary(conn, db_path)
 
 
-def translate_en_uk(word: str, limit: int = 10) -> list[dict]:
+def translate_en_uk(
+    word: str,
+    limit: int = 10,
+    *,
+    db_path: str | Path | None = None,
+) -> list[dict]:
     """Look up English→Ukrainian translation in Балла."""
-    return _dict_lookup("balla_en_uk", word, limit)
+    return _dict_lookup("balla_en_uk", word, limit, db_path=db_path)
 
 
 def search_idioms(word: str, limit: int = 10) -> list[dict]:
@@ -2121,14 +2376,23 @@ def search_synonyms(word: str, limit: int = 20) -> list[dict]:
     return (ulif_results + [dict(r) for r in rows])[:limit]
 
 
-def query_cefr_level(word: str, limit: int = 5) -> list[dict]:
+def query_cefr_level(
+    word: str,
+    limit: int = 5,
+    *,
+    db_path: str | Path | None = None,
+) -> list[dict]:
     """Look up CEFR level for a word in PULS vocabulary."""
-    return _dict_lookup("puls_cefr", word, limit=limit)
+    return _dict_lookup("puls_cefr", word, limit=limit, db_path=db_path)
 
 
-def query_cefr_levels(words: list[str]) -> dict[str, list[dict]]:
+def query_cefr_levels(
+    words: list[str],
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, list[dict]]:
     """Return the best PULS CEFR hit for each requested word in batched SQL."""
-    return _batch_dict_lookup("puls_cefr", words, limit=1)
+    return _batch_dict_lookup("puls_cefr", words, limit=1, db_path=db_path)
 
 
 def search_style_guide(

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "2ed8e1dd5513f94f8245bbdaedfde9da5e76e7ebd2cbe19e6dd1c423d169ee0b",
+  "fingerprint": "f1b11e6ef00173d5a961560befa0b80287b28088102534d22da2067111c6c49b",
   "inputs": {
     "lexicon_code": [
       {
@@ -183,6 +183,10 @@
         "sha256": "c999d218e5b95d28a8debe60dd093a0a90358ffb90419ca3cef317c3300e0431"
       },
       {
+        "path": "scripts/lexicon/triage_needs_review.py",
+        "sha256": "f9f954fdbebca4490702cf3bee46a774c87da23386a26c4634f7b81a7d4c2225"
+      },
+      {
         "path": "scripts/lexicon/verify_manifest.py",
         "sha256": "47df54386fda97fb7b372e8e68f89afb3ac5bd647c5a292a7380f14c5ae1f4b0"
       },
@@ -195,6 +199,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 47
+    "lexicon_code_files": 48
   }
 }

--- a/tests/test_triage_needs_review.py
+++ b/tests/test_triage_needs_review.py
@@ -1,0 +1,374 @@
+"""Tests for deterministic grow needs_review triage (#5230 arc)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.lexicon import triage_needs_review as triage
+from scripts.wiki import sources_db as sdb
+
+
+def _held(
+    lemma: str,
+    *,
+    pos: str | None = "noun",
+    reason: str = "missing dictionary definition",
+) -> triage.HeldEntry:
+    return triage.HeldEntry(lemma=lemma, pos=pos, held_reason=reason, raw={})
+
+
+def test_empty_input_returns_empty_records() -> None:
+    records = triage.triage_held_entries(
+        [],
+        lookups={key: (lambda words: {w: [] for w in words}) for key in triage.SOURCE_HIT_KEYS},
+        vesum_fn=lambda words: {w: [] for w in words},
+    )
+    assert records == []
+    summary = triage.build_summary_markdown([])
+    assert "Total held: **0**" in summary
+    assert f"`{triage.MACHINE_PROMOTE}`: 0" in summary
+
+
+def test_gloss_priority_order_sum11_over_dmklinger() -> None:
+    lookups = {
+        "sum11": lambda words: {
+            "хата": [{"definition": "СУМ gloss", "word": "хата"}],
+        },
+        "dmklinger": lambda words: {
+            "хата": [{"translations": json.dumps(["house"]), "word": "хата"}],
+        },
+        "grinchenko": lambda words: {"хата": [{"definition": "Грінченко"}]},
+        "slovnyk_me": lambda words: {"хата": []},
+        "balla": lambda words: {"хата": []},
+        "esum": lambda words: {"хата": []},
+        "puls_cefr": lambda words: {"хата": [{"level": "A1"}]},
+    }
+    records = triage.triage_held_entries(
+        [_held("хата")],
+        lookups=lookups,
+        vesum_fn=lambda words: {w: [{"lemma": w, "pos": "noun", "tags": ""}] for w in words},
+    )
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["best_gloss"] == {"text": "СУМ gloss", "source": "sum11"}
+    assert rec["machine_action"] == triage.MACHINE_PROMOTE
+    assert rec["cefr"] == "A1"
+    assert rec["vesum_valid"] is True
+    assert rec["sources_hit"]["sum11"] == 1
+    assert rec["sources_hit"]["dmklinger"] == 1
+
+
+def test_gloss_priority_falls_through_to_dmklinger() -> None:
+    lookups = {
+        "sum11": lambda words: {w: [] for w in words},
+        "dmklinger": lambda words: {
+            w: [{"translations": '["work", "job"]', "word": w}] for w in words
+        },
+        "grinchenko": lambda words: {w: [] for w in words},
+        "slovnyk_me": lambda words: {w: [] for w in words},
+        "balla": lambda words: {w: [] for w in words},
+        "esum": lambda words: {w: [] for w in words},
+        "puls_cefr": lambda words: {w: [] for w in words},
+    }
+    records = triage.triage_held_entries(
+        [_held("робота")],
+        lookups=lookups,
+        vesum_fn=lambda words: {w: [] for w in words},
+    )
+    assert records[0]["best_gloss"] == {"text": "work", "source": "dmklinger"}
+    assert records[0]["machine_action"] == triage.MACHINE_PROMOTE
+    assert records[0]["vesum_valid"] is False
+
+
+def test_truly_missing_when_no_gloss_sources() -> None:
+    empty = {key: (lambda words: {w: [] for w in words}) for key in triage.SOURCE_HIT_KEYS}
+    # esum alone must not promote — etymology is not a gloss source.
+    empty["esum"] = lambda words: {
+        w: [{"lemma": w, "etymology_text": "from X"}] for w in words
+    }
+    records = triage.triage_held_entries(
+        [_held("а-а-а")],
+        lookups=empty,
+        vesum_fn=lambda words: {w: [{"lemma": w}] for w in words},
+    )
+    assert records[0]["best_gloss"] is None
+    assert records[0]["machine_action"] == triage.MACHINE_MISSING
+    assert records[0]["sources_hit"]["esum"] == 1
+    assert records[0]["vesum_valid"] is True
+
+
+def test_heritage_carve_out_regardless_of_hits() -> None:
+    lookups = {
+        "sum11": lambda words: {
+            w: [{"definition": "still has a gloss", "word": w}] for w in words
+        },
+        "dmklinger": lambda words: {w: [] for w in words},
+        "grinchenko": lambda words: {w: [] for w in words},
+        "slovnyk_me": lambda words: {w: [] for w in words},
+        "balla": lambda words: {w: [] for w in words},
+        "esum": lambda words: {w: [] for w in words},
+        "puls_cefr": lambda words: {w: [] for w in words},
+    }
+    records = triage.triage_held_entries(
+        [
+            _held(
+                "верф",
+                reason="heritage_status flags russianism; heritage_status flags calque_warning",
+            )
+        ],
+        lookups=lookups,
+        vesum_fn=lambda words: {w: [] for w in words},
+    )
+    assert records[0]["best_gloss"] is not None
+    assert records[0]["machine_action"] == triage.MACHINE_HERITAGE
+
+
+def test_load_held_entries_from_grow_payload(tmp_path: Path) -> None:
+    path = tmp_path / "grow_candidates.json"
+    path.write_text(
+        json.dumps(
+            {
+                "needs_review": [
+                    {
+                        "entry": {"lemma": "те́ст", "pos": "noun"},
+                        "reason": "missing dictionary definition",
+                    },
+                    {
+                        "entry": {"lemma": "верф", "pos": "noun"},
+                        "reason": "heritage_status flags curated_calque",
+                    },
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    held = triage.load_held_entries(path)
+    assert [h.lemma for h in held] == ["тест", "верф"]  # stress stripped
+    assert held[1].held_reason.startswith("heritage_status")
+
+
+def test_dmklinger_batch_strips_u0301(tmp_path: Path) -> None:
+    """Plain-string equality misses stressed headwords; batch must strip U+0301."""
+    db = tmp_path / "sources.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """
+        CREATE TABLE dmklinger_uk_en (
+            id INTEGER PRIMARY KEY,
+            word TEXT NOT NULL,
+            pos TEXT,
+            translations TEXT,
+            text TEXT,
+            source TEXT
+        )
+        """
+    )
+    # Combining acute after о: роб + о + U+0301 + та
+    stressed = "роб" + "о\u0301" + "та"
+    conn.execute(
+        "INSERT INTO dmklinger_uk_en(word, pos, translations, text, source) VALUES (?,?,?,?,?)",
+        (stressed, "n", json.dumps(["work"]), f"{stressed}: work", "dmklinger"),
+    )
+    conn.commit()
+    conn.close()
+
+    plain = sdb.search_dmklinger_uk_en_batch(["робота"], db_path=db)
+    stressed_query = sdb.search_dmklinger_uk_en_batch([stressed], db_path=db)
+    # Control: exact equality batch on sum11-style would miss; dmklinger batch must hit.
+    assert len(plain["робота"]) == 1
+    assert "work" in plain["робота"][0]["translations"]
+    assert len(stressed_query[stressed]) == 1
+
+    # Sanity: replace-based match is required — naive equality fails.
+    conn = sqlite3.connect(db)
+    naive = conn.execute(
+        "SELECT word FROM dmklinger_uk_en WHERE word = ? COLLATE NOCASE",
+        ("робота",),
+    ).fetchall()
+    conn.close()
+    assert naive == []
+
+
+def test_batch_dict_siblings_with_fixture_db(tmp_path: Path) -> None:
+    db = tmp_path / "sources.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE sum11 (
+            id INTEGER PRIMARY KEY, word TEXT, definition TEXT,
+            text TEXT, source TEXT
+        );
+        CREATE TABLE grinchenko (
+            id INTEGER PRIMARY KEY, word TEXT, definition TEXT, source TEXT
+        );
+        CREATE TABLE balla_en_uk (
+            id INTEGER PRIMARY KEY, word TEXT, definition TEXT,
+            text TEXT, source TEXT
+        );
+        CREATE TABLE puls_cefr (
+            id INTEGER PRIMARY KEY, word TEXT, guideword TEXT, level TEXT,
+            pos TEXT, type TEXT, text TEXT, source TEXT
+        );
+        CREATE TABLE esum_etymology_meta (
+            id INTEGER PRIMARY KEY, lemma TEXT, vol INTEGER, page INTEGER,
+            entry_hash TEXT, etymology_text TEXT, cognates TEXT, source TEXT
+        );
+        CREATE TABLE slovnyk_me_entries (
+            id INTEGER PRIMARY KEY,
+            dictionary_slug TEXT,
+            word TEXT,
+            normalized_word TEXT,
+            definition TEXT,
+            text TEXT,
+            is_modern INTEGER DEFAULT 1,
+            is_dialect INTEGER DEFAULT 0,
+            is_russianism INTEGER DEFAULT 0,
+            sovietization_risk INTEGER DEFAULT 0
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO sum11(word, definition, text, source) VALUES (?,?,?,?)",
+        ("слово", "одиниця мови", "слово: одиниця", "СУМ-11"),
+    )
+    conn.execute(
+        "INSERT INTO grinchenko(word, definition, source) VALUES (?,?,?)",
+        ("слово", "мова", "Грінченко"),
+    )
+    conn.execute(
+        "INSERT INTO balla_en_uk(word, definition, text, source) VALUES (?,?,?,?)",
+        ("word", "слово", "word: слово", "Балла"),
+    )
+    conn.execute(
+        "INSERT INTO puls_cefr(word, guideword, level, pos, type, text, source) "
+        "VALUES (?,?,?,?,?,?,?)",
+        ("слово", "", "A1", "іменник", "значення", "слово (A1)", "PULS"),
+    )
+    conn.execute(
+        "INSERT INTO esum_etymology_meta"
+        "(lemma, vol, page, entry_hash, etymology_text, cognates, source) "
+        "VALUES (?,?,?,?,?,?,?)",
+        ("слово", 1, 1, "h", "etym", "[]", "ЕСУМ"),
+    )
+    conn.execute(
+        "INSERT INTO slovnyk_me_entries"
+        "(dictionary_slug, word, normalized_word, definition, text) "
+        "VALUES (?,?,?,?,?)",
+        ("ukreng", "слово", "слово", "word (en)", "слово — word"),
+    )
+    conn.commit()
+    conn.close()
+
+    assert sdb.search_definitions_batch(["слово"], db_path=db)["слово"][0]["definition"]
+    assert sdb.search_grinchenko_batch(["слово"], db_path=db)["слово"]
+    assert sdb.search_balla_en_uk_batch(["word"], db_path=db)["word"]
+    assert sdb.query_cefr_levels(["слово"], db_path=db)["слово"][0]["level"] == "A1"
+    assert sdb.search_esum_batch(["слово"], db_path=db)["слово"]
+    assert sdb.search_slovnyk_me_entries_batch(["слово"], db_path=db)["слово"]
+    # Missing lemmas stay empty (no KeyError).
+    assert sdb.search_definitions_batch(["відсутнє"], db_path=db)["відсутнє"] == []
+
+
+def test_run_triage_write_and_probe(tmp_path: Path) -> None:
+    candidates = tmp_path / "grow_candidates.json"
+    candidates.write_text(
+        json.dumps(
+            {
+                "needs_review": [
+                    {
+                        "entry": {"lemma": "alpha", "pos": "noun"},
+                        "reason": "missing dictionary definition",
+                    },
+                    {
+                        "entry": {"lemma": "beta", "pos": "verb"},
+                        "reason": "heritage_status flags curated_calque",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "needs-review-triage.json"
+    summary = tmp_path / "needs-review-triage-summary.md"
+
+    lookups = {
+        "sum11": lambda words: {
+            w: ([{"definition": "gloss"}] if w == "alpha" else []) for w in words
+        },
+        "dmklinger": lambda words: {w: [] for w in words},
+        "grinchenko": lambda words: {w: [] for w in words},
+        "slovnyk_me": lambda words: {w: [] for w in words},
+        "balla": lambda words: {w: [] for w in words},
+        "esum": lambda words: {w: [] for w in words},
+        "puls_cefr": lambda words: {w: [] for w in words},
+    }
+
+    probe = triage.run_triage(
+        candidates_path=candidates,
+        db_path=tmp_path / "missing.db",
+        out_path=out,
+        summary_path=summary,
+        write=False,
+        lookups=lookups,
+        vesum_fn=lambda words: {w: [] for w in words},
+    )
+    assert probe.written is False
+    assert not out.exists()
+    assert probe.counts_by_action[triage.MACHINE_PROMOTE] == 1
+    assert probe.counts_by_action[triage.MACHINE_HERITAGE] == 1
+
+    written = triage.run_triage(
+        candidates_path=candidates,
+        db_path=tmp_path / "missing.db",
+        out_path=out,
+        summary_path=summary,
+        write=True,
+        lookups=lookups,
+        vesum_fn=lambda words: {w: [] for w in words},
+    )
+    assert written.written is True
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["counts"]["total"] == 2
+    assert summary.exists()
+    assert "machine_action" in summary.read_text(encoding="utf-8")
+
+
+def test_cli_refuses_without_write_or_probe() -> None:
+    with pytest.raises(SystemExit) as exc:
+        triage.main([])
+    assert exc.value.code == 2
+
+
+def test_cli_help_is_clean() -> None:
+    with pytest.raises(SystemExit) as exc:
+        triage.main(["--help"])
+    assert exc.value.code == 0
+
+
+def test_cli_probe_with_injected_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    candidates = tmp_path / "grow_candidates.json"
+    candidates.write_text(json.dumps({"needs_review": []}), encoding="utf-8")
+
+    # Force empty probe path — no real DB required.
+    monkeypatch.setattr(
+        triage,
+        "run_triage",
+        lambda **kwargs: triage.TriageResult(
+            entries=[],
+            summary_md=triage.build_summary_markdown([]),
+            counts_by_action={},
+            candidates_found=True,
+            written=False,
+            dry_run=True,
+        ),
+    )
+    code = triage.main(["--probe", "--candidates", str(candidates)])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "probe (read-only)" in out
+    assert "Held triaged: 0" in out


### PR DESCRIPTION
## Summary

Adds a **code-only** triage tool for the 2,316 grow candidates held in `needs_review` (no LLM judging of why words are missing).

`scripts/lexicon/triage_needs_review.py` probes local sources in batches and decides `machine_action` per lemma:

| Action | Rule |
| --- | --- |
| `promote_with_gloss` | ≥1 gloss-bearing source has a definition (priority: sum11 > dmklinger > grinchenko > slovnyk_me > balla) |
| `truly_missing` | no gloss source hit |
| `heritage_flag` | held reason contains `heritage_status` (the 18 heritage/calque rows — kept aside regardless of dictionary hits) |

Per lemma also records `sources_hit` counts, `best_gloss`, `cefr`, and `vesum_valid`.

### What the tool decides (and how)

1. Load `needs_review[]` from `--candidates` (default `data/lexicon/grow_candidates.json`).
2. Stress-strip lemmas (`strip_acute_stress`); dmklinger matches via SQL `replace(word, char(0x301), '')` so plain queries do not miss stressed headwords.
3. Batched probes (400-row chunks, no per-word SQL loops) via `scripts/wiki/sources_db.py`:
   - sum11, grinchenko, balla_en_uk, puls_cefr — `_batch_dict_lookup` siblings
   - dmklinger_uk_en — stress-normalized exact
   - esum_etymology_meta — exact lemma
   - slovnyk_me_entries — `normalized_word` (empty if table absent)
   - VESUM — `verify_words` chunked
4. With `--write`: emit gitignored `needs-review-triage.json` + summary markdown (counts per action / source-hit combo / POS + 20-row samples).
5. `--probe` = read-only counts on stdout; bare invocation refuses (exit 2).

Worktrees without `data/` pass `--db` / `--candidates` absolute paths from the primary checkout. Orchestrator runs the full 2,316 pass on primary data.

## Verification

```
.venv/bin/python -m pytest tests/test_triage_needs_review.py -q
# 12 passed

.venv/bin/python -m pytest tests/test_sources_db.py -k batch_vocabulary -q
# 1 passed

.venv/bin/ruff check scripts/lexicon/triage_needs_review.py scripts/wiki/sources_db.py tests/test_triage_needs_review.py
# All checks passed!
```

CLI checks: `--help` clean; bare refuse exit 2; pre-commit ran full `test_sources_db` (24) + triage tests (12).

## Test plan

- [x] Unit tests: gloss priority, heritage carve-out, U+0301 stress strip, empty input, CLI refuse/help
- [ ] Orchestrator: full triage on primary with real `data/sources.db` + `grow_candidates.json`
- [ ] Confirm summary answers “which dictionary are they missing from?” with numbers

Refs #5230