### PR TITLE
feat(lexicon): needs_review re-entry machinery (#5230)

### DIFF
--- a/scripts/lexicon/generate_needs_review_ledger.py
+++ b/scripts/lexicon/generate_needs_review_ledger.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Generate a sha-bound needs_review re-entry ledger from deterministic triage.
+
+Reads grow ``needs_review`` candidates plus ``needs-review-triage.json`` and emits
+a fail-closed ``atlas_grow_needs_review_decisions`` YAML ledger: one decision per
+held entry, bound to both file SHA digests. CODE maps triage actions only —
+``promote_with_gloss`` → approve (+ approved_gloss), ``truly_missing`` /
+``heritage_flag`` → deferred (heritage rows carry ``heritage: true``).
+
+When to use: after triage has ranked held grow lemmas and before
+``promote_grow_candidates.py --needs-review-ledger`` promotes the approve set.
+When NOT to use: inventing glosses, partial human spot-check ledgers outside
+this code path, or writing the live manifest (promotion is a separate step).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.lexicon.promote_grow_candidates import (
+    NEEDS_REVIEW_LEDGER_KIND,
+    _held_rows,
+    index_by_decision_key,
+    require_exact_decision_coverage,
+)
+from scripts.lexicon.triage_needs_review import (
+    MACHINE_HERITAGE,
+    MACHINE_MISSING,
+    MACHINE_PROMOTE,
+)
+
+DEFAULT_CANDIDATES = PROJECT_ROOT / "data" / "lexicon" / "grow_candidates.json"
+DEFAULT_TRIAGE = PROJECT_ROOT / "data" / "lexicon" / "needs-review-triage.json"
+DEFAULT_DECISIONS_DIR = PROJECT_ROOT / "data" / "lexicon" / "source-inventory-review-decisions"
+BATCH_SLUG = "grow-needs-review-batch-01"
+
+
+@dataclass(frozen=True)
+class GenerateResult:
+    ledger: dict[str, Any]
+    out_path: Path
+    written: bool
+    dry_run: bool
+    approve_count: int
+    deferred_count: int
+    heritage_count: int
+    total: int
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_triage_entries(triage_path: Path) -> list[Mapping[str, Any]]:
+    payload = json.loads(triage_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"triage payload must be a JSON object: {triage_path}")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError(f"triage entries must be a list: {triage_path}")
+    return [row for row in entries if isinstance(row, Mapping)]
+
+
+def load_candidates_payload(candidates_path: Path) -> dict[str, Any]:
+    payload = json.loads(candidates_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"candidates payload must be a JSON object: {candidates_path}")
+    return payload
+
+
+def decision_from_triage(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Map one triage record to a ledger decision row (code-only)."""
+    lemma = str(row.get("lemma") or "").strip()
+    pos = str(row.get("pos") or "").strip()
+    if not lemma:
+        raise ValueError("triage row lacks lemma")
+    if not pos:
+        raise ValueError(f"triage row lacks pos: {lemma!r}")
+
+    action = str(row.get("machine_action") or "").strip()
+    base: dict[str, Any] = {"lemma": lemma, "pos": pos}
+
+    if action == MACHINE_PROMOTE:
+        gloss = row.get("best_gloss")
+        if not isinstance(gloss, Mapping):
+            raise ValueError(f"promote_with_gloss row lacks best_gloss: {lemma!r}")
+        text = str(gloss.get("text") or "").strip()
+        source = str(gloss.get("source") or "").strip()
+        if not text or not source:
+            raise ValueError(f"promote_with_gloss best_gloss incomplete: {lemma!r}")
+        base["decision"] = "approve"
+        base["approved_gloss"] = {"text": text, "source": source}
+        return base
+
+    if action == MACHINE_MISSING:
+        base["decision"] = "deferred"
+        base["reason"] = "truly_missing"
+        return base
+
+    if action == MACHINE_HERITAGE:
+        base["decision"] = "deferred"
+        base["heritage"] = True
+        base["reason"] = "heritage_flag"
+        held = str(row.get("held_reason") or "").strip()
+        if held:
+            base["held_reason"] = held
+        return base
+
+    raise ValueError(f"unknown machine_action for {lemma!r}: {action!r}")
+
+
+def build_needs_review_ledger(
+    *,
+    candidates_path: Path,
+    triage_path: Path,
+    reviewed_at: str | None = None,
+    batch_id: str | None = None,
+) -> dict[str, Any]:
+    """Build the full ledger mapping; exact-covers needs_review vs triage."""
+    candidates_path = _resolve(candidates_path)
+    triage_path = _resolve(triage_path)
+    if not candidates_path.exists():
+        raise ValueError(f"candidates file not found: {candidates_path}")
+    if not triage_path.exists():
+        raise ValueError(f"triage file not found: {triage_path}")
+
+    candidates_payload = load_candidates_payload(candidates_path)
+    held_rows = _held_rows(candidates_payload.get("needs_review", []))
+    held_entries = [row.entry for row in held_rows]
+    held_by_key = index_by_decision_key(held_entries, label="needs_review candidate")
+
+    triage_entries = load_triage_entries(triage_path)
+    triage_by_key = index_by_decision_key(triage_entries, label="triage entry")
+    require_exact_decision_coverage(
+        set(held_by_key),
+        set(triage_by_key),
+        scope_label="needs_review candidates",
+        ledger_label="triage JSON",
+    )
+
+    # Emit decisions in candidates needs_review order (stable, fail-closed coverage).
+    decisions: list[dict[str, Any]] = []
+    for key in held_by_key:
+        decisions.append(decision_from_triage(triage_by_key[key]))
+
+    approve_count = sum(1 for row in decisions if row.get("decision") == "approve")
+    deferred_count = sum(1 for row in decisions if row.get("decision") == "deferred")
+    heritage_count = sum(1 for row in decisions if row.get("heritage") is True)
+
+    day = reviewed_at or datetime.now(UTC).date().isoformat()
+    resolved_batch_id = batch_id or f"{BATCH_SLUG}-{day}"
+
+    return {
+        "version": 1,
+        "kind": NEEDS_REVIEW_LEDGER_KIND,
+        "batch_id": resolved_batch_id,
+        "batch_label": BATCH_SLUG,
+        "reviewed_at": day,
+        "generated_by": "scripts/lexicon/generate_needs_review_ledger.py",
+        "epic": "#5230 needs_review re-entry (code-decided promote_with_gloss batch)",
+        "scope": (
+            "Full needs_review set from grow_candidates.json; decisions mapped "
+            "from needs-review-triage.json machine_action only (no LLM judging)."
+        ),
+        "provenance": {
+            "candidates_sha256": file_sha256(candidates_path),
+            "triage_sha256": file_sha256(triage_path),
+            "candidates": _display_path(candidates_path),
+            "triage": _display_path(triage_path),
+        },
+        "decision_counts": {
+            "approve": approve_count,
+            "deferred": deferred_count,
+            "heritage_flag": heritage_count,
+            "total": len(decisions),
+        },
+        "decisions": decisions,
+    }
+
+
+def default_out_path(*, reviewed_at: str | None = None, out_dir: Path | None = None) -> Path:
+    day = reviewed_at or datetime.now(UTC).date().isoformat()
+    directory = _resolve(out_dir) if out_dir is not None else DEFAULT_DECISIONS_DIR
+    return directory / f"{day}-{BATCH_SLUG}.yaml"
+
+
+def generate_needs_review_ledger(
+    *,
+    candidates_path: Path = DEFAULT_CANDIDATES,
+    triage_path: Path = DEFAULT_TRIAGE,
+    out_path: Path | None = None,
+    write: bool = False,
+    reviewed_at: str | None = None,
+) -> GenerateResult:
+    """Build (and optionally write) the needs_review decisions ledger."""
+    ledger = build_needs_review_ledger(
+        candidates_path=candidates_path,
+        triage_path=triage_path,
+        reviewed_at=reviewed_at,
+    )
+    day = str(ledger.get("reviewed_at") or datetime.now(UTC).date().isoformat())
+    resolved_out = _resolve(out_path) if out_path is not None else default_out_path(reviewed_at=day)
+    counts = ledger.get("decision_counts") if isinstance(ledger.get("decision_counts"), Mapping) else {}
+    approve_count = int(counts.get("approve") or 0)
+    deferred_count = int(counts.get("deferred") or 0)
+    heritage_count = int(counts.get("heritage_flag") or 0)
+    total = int(counts.get("total") or len(ledger.get("decisions") or []))
+
+    written = False
+    if write:
+        resolved_out.parent.mkdir(parents=True, exist_ok=True)
+        resolved_out.write_text(
+            yaml.safe_dump(ledger, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+        written = True
+
+    return GenerateResult(
+        ledger=ledger,
+        out_path=resolved_out,
+        written=written,
+        dry_run=not write,
+        approve_count=approve_count,
+        deferred_count=deferred_count,
+        heritage_count=heritage_count,
+        total=total,
+    )
+
+
+def format_cli_summary(result: GenerateResult) -> str:
+    return "\n".join(
+        [
+            f"Mode: {'write' if result.written else 'dry-run (not written)'}",
+            f"Out: {_display_path(result.out_path)}",
+            f"Written: {str(result.written).lower()}",
+            f"Total decisions: {result.total}",
+            f"  approve: {result.approve_count}",
+            f"  deferred: {result.deferred_count}",
+            f"  heritage_flag (subset of deferred): {result.heritage_count}",
+            f"kind: {NEEDS_REVIEW_LEDGER_KIND}",
+            f"candidates_sha256: {result.ledger['provenance']['candidates_sha256']}",
+            f"triage_sha256: {result.ledger['provenance']['triage_sha256']}",
+        ]
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a sha-bound atlas_grow_needs_review_decisions ledger from "
+            "deterministic needs-review triage. Use this after triage_needs_review.py "
+            "and before promote_grow_candidates.py --needs-review-ledger; do not use it "
+            "to write the live manifest or to invent glosses."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Dry-run counts (no files written)\n"
+            "  .venv/bin/python scripts/lexicon/generate_needs_review_ledger.py --dry-run \\\n"
+            "    --candidates data/lexicon/grow_candidates.json \\\n"
+            "    --triage data/lexicon/needs-review-triage.json\n"
+            "\n"
+            "  # Write the dated batch ledger (orchestrator on primary)\n"
+            "  .venv/bin/python scripts/lexicon/generate_needs_review_ledger.py --write \\\n"
+            "    --candidates data/lexicon/grow_candidates.json \\\n"
+            "    --triage data/lexicon/needs-review-triage.json\n"
+            "\n"
+            "Outputs (only with --write):\n"
+            "  data/lexicon/source-inventory-review-decisions/"
+            "<date>-grow-needs-review-batch-01.yaml\n"
+            "\n"
+            "Exit codes:\n"
+            "  0  success (--help, --dry-run, or successful --write)\n"
+            "  2  refused (no --write/--dry-run) or validation/input error\n"
+            "\n"
+            "Related:\n"
+            "  scripts/lexicon/triage_needs_review.py       — produces triage JSON\n"
+            "  scripts/lexicon/promote_grow_candidates.py   — consumes this ledger\n"
+            "  issue #5230                                 — needs_review re-entry arc\n"
+        ),
+    )
+    parser.add_argument(
+        "--candidates",
+        type=Path,
+        default=DEFAULT_CANDIDATES,
+        help=f"Path to grow_candidates.json (default: {DEFAULT_CANDIDATES})",
+    )
+    parser.add_argument(
+        "--triage",
+        type=Path,
+        default=DEFAULT_TRIAGE,
+        help=f"Path to needs-review-triage.json (default: {DEFAULT_TRIAGE})",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=(
+            "Output YAML path (default: "
+            "data/lexicon/source-inventory-review-decisions/<UTC-date>-"
+            f"{BATCH_SLUG}.yaml)"
+        ),
+    )
+    parser.add_argument(
+        "--reviewed-at",
+        type=str,
+        default=None,
+        help="Optional ISO date for batch filename/metadata (default: UTC today)",
+    )
+    mode = parser.add_mutually_exclusive_group(required=False)
+    mode.add_argument(
+        "--write",
+        action="store_true",
+        help="Write the ledger YAML. Default without --write/--dry-run: refuse (exit 2).",
+    )
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and print decision counts without writing files.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not args.write and not args.dry_run:
+        parser.error(
+            "refusing to run without --write or --dry-run "
+            "(pass --dry-run for counts only, or --write to emit the ledger YAML)"
+        )
+
+    try:
+        result = generate_needs_review_ledger(
+            candidates_path=args.candidates,
+            triage_path=args.triage,
+            out_path=args.out,
+            write=bool(args.write),
+            reviewed_at=args.reviewed_at,
+        )
+    except (OSError, ValueError, json.JSONDecodeError, KeyError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(format_cli_summary(result))
+    return 0
+
+
+def _resolve(path: Path) -> Path:
+    path = Path(path)
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def _display_path(path: Path) -> str:
+    path = _resolve(path)
+    try:
+        return path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/promote_grow_candidates.py
+++ b/scripts/lexicon/promote_grow_candidates.py
@@ -3,12 +3,19 @@
 
 Phase 2 writes ``data/lexicon/grow_candidates.json`` with a confidence split:
 ``auto_merge`` entries are dictionary-grounded and safe to promote, while
-``needs_review`` entries are held for a human. This script promotes only the
-clean bucket, validates the prospective manifest before writing it, and leaves
-the held set as a local PR-body artifact.  Entries still lacking a learner-English
-anchor remain visible promotion debt: the curation ledger records it, while the
-#5138 publish gate enforces the downstream ``old_gate_no_english_anchor``
-richness-regression backstop against the live baseline.
+``needs_review`` entries are held unless a checksum-bound needs-review ledger
+explicitly approves them (``--needs-review-ledger``). This script promotes the
+clean auto_merge bucket (optionally filtered by ``--approval-ledger``) and any
+ledger-approved held entries with their approved gloss injected as the learner
+anchor.  Entries still lacking a learner-English anchor remain visible promotion
+debt: the curation ledger records it, while the #5138 publish gate enforces the
+downstream ``old_gate_no_english_anchor`` richness-regression backstop against
+the live baseline.
+
+When to use: applying a reviewed grow promotion (auto_merge and/or needs_review
+re-entry) into the live manifest after ledger validation.
+When NOT to use: generating triage decisions (``triage_needs_review.py``) or
+emitting the needs-review decision ledger (``generate_needs_review_ledger.py``).
 """
 
 from __future__ import annotations
@@ -55,6 +62,8 @@ DEFAULT_MANIFEST = PROJECT_ROOT / "site" / "src" / "data" / "lexicon-manifest.js
 DEFAULT_NEEDS_REVIEW = PROJECT_ROOT / "data" / "lexicon" / "grow_needs_review.json"
 PRIMARY_SOURCE = "content_lexicon_grow"
 APPROVAL_LEDGER_KIND = "atlas_grow_promotion_ledger"
+NEEDS_REVIEW_LEDGER_KIND = "atlas_grow_needs_review_decisions"
+ALLOWED_LEDGER_DECISIONS = frozenset({"approve", "deferred", "reject"})
 _OPTIONAL_CANDIDATE_FIELDS = (
     "heritage_status",
     "enrichment",
@@ -81,6 +90,15 @@ class HeldLemma:
 
 
 @dataclass(frozen=True)
+class HeldRow:
+    """One needs_review row with its candidate entry payload."""
+
+    lemma: str
+    reason: str
+    entry: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
 class PromotionResult:
     candidates_found: bool
     promoted: tuple[str, ...]
@@ -94,6 +112,8 @@ class PromotionResult:
     fingerprint_written: bool
     needs_review_written: bool
     dry_run: bool
+    needs_review_approved: int = 0
+    needs_review_deferred: int = 0
 
 
 class SelfCheckError(RuntimeError):
@@ -111,6 +131,7 @@ def promote_grow_candidates(
     needs_review_path: Path = DEFAULT_NEEDS_REVIEW,
     fingerprint_path: Path = DEFAULT_FINGERPRINT,
     approval_ledger_path: Path | None = None,
+    needs_review_ledger_path: Path | None = None,
     write: bool = False,
     self_check: SelfCheck | None = None,
     fingerprint_writer: FingerprintWriter | None = None,
@@ -122,6 +143,8 @@ def promote_grow_candidates(
     fingerprint_path = _resolve_path(fingerprint_path)
     if approval_ledger_path is not None:
         approval_ledger_path = _resolve_path(approval_ledger_path)
+    if needs_review_ledger_path is not None:
+        needs_review_ledger_path = _resolve_path(needs_review_ledger_path)
     self_check = self_check or verify_prospective_manifest
     fingerprint_writer = fingerprint_writer or _write_fingerprint_sidecar
 
@@ -141,7 +164,8 @@ def promote_grow_candidates(
         )
 
     candidates = _load_candidates(candidates_path)
-    held = tuple(_held_lemmas(candidates.get("needs_review", [])))
+    needs_review_raw = candidates.get("needs_review", [])
+    held_rows = _held_rows(needs_review_raw)
     auto_merge = _candidate_entries(candidates.get("auto_merge", []))
     if approval_ledger_path is not None:
         auto_merge = _approved_candidate_entries(
@@ -149,6 +173,23 @@ def promote_grow_candidates(
             candidates_path=candidates_path,
             approval_ledger_path=approval_ledger_path,
         )
+
+    needs_review_to_promote: list[Mapping[str, Any]] = []
+    needs_review_approved = 0
+    needs_review_deferred = 0
+    if needs_review_ledger_path is not None:
+        approved_entries, held_rows, needs_review_approved, needs_review_deferred = (
+            _approved_needs_review_entries(
+                held_rows,
+                candidates_path=candidates_path,
+                needs_review_ledger_path=needs_review_ledger_path,
+            )
+        )
+        needs_review_to_promote = approved_entries
+    held = tuple(HeldLemma(lemma=row.lemma, reason=row.reason) for row in held_rows)
+
+    promote_queue: list[Mapping[str, Any]] = list(auto_merge) + list(needs_review_to_promote)
+
     manifest = _load_manifest(manifest_path)
     entries = manifest["entries"]
     existing_keys = _manifest_lemma_keys(entries)
@@ -157,7 +198,7 @@ def promote_grow_candidates(
     promoted: list[str] = []
     skipped_existing: list[str] = []
     newly_promoted_entries: list[dict[str, Any]] = []
-    for candidate in auto_merge:
+    for candidate in promote_queue:
         lemma = strip_acute_stress(_candidate_lemma(candidate))
         key = _lemma_key(lemma)
         if key in existing_keys:
@@ -205,6 +246,8 @@ def promote_grow_candidates(
         fingerprint_written=fingerprint_written,
         needs_review_written=needs_review_written,
         dry_run=not write,
+        needs_review_approved=needs_review_approved,
+        needs_review_deferred=needs_review_deferred,
     )
 
 
@@ -262,6 +305,8 @@ def format_summary(result: PromotionResult, *, report: bool = False, candidates_
             f"Promoted: {len(result.promoted)}",
             f"Skipped existing: {len(result.skipped_existing)}",
             f"Held for review: {len(result.held)}",
+            f"Needs-review ledger approve: {result.needs_review_approved}",
+            f"Needs-review ledger deferred: {result.needs_review_deferred}",
             f"Cached learner-English anchors filled: {len(result.cached_anchor_fills)}",
             f"Promoted entries still without learner-English anchor: {len(result.anchorless_promoted)}",
             f"New lemmas_total: {result.lemmas_total}",
@@ -292,20 +337,98 @@ def format_summary(result: PromotionResult, *, report: bool = False, candidates_
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--candidates", type=Path, default=DEFAULT_CANDIDATES)
-    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
-    parser.add_argument("--needs-review", type=Path, default=DEFAULT_NEEDS_REVIEW)
-    parser.add_argument("--fingerprint", type=Path, default=DEFAULT_FINGERPRINT)
+    parser = argparse.ArgumentParser(
+        description=(
+            "Promote Atlas grow candidates into the live lexicon manifest. "
+            "Use this after a reviewed auto_merge and/or needs_review ledger is "
+            "ready; do not use it to invent glosses or triage held lemmas."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Dry-run auto_merge promotion\n"
+            "  .venv/bin/python scripts/lexicon/promote_grow_candidates.py --dry-run\n"
+            "\n"
+            "  # Promote only ledger-approved auto_merge rows\n"
+            "  .venv/bin/python scripts/lexicon/promote_grow_candidates.py --write \\\n"
+            "    --approval-ledger data/lexicon/grow-triage-ledgers/…-ledger.yaml\n"
+            "\n"
+            "  # Re-enter needs_review via a sha-bound decisions ledger (#5230)\n"
+            "  .venv/bin/python scripts/lexicon/promote_grow_candidates.py --write \\\n"
+            "    --needs-review-ledger data/lexicon/source-inventory-review-decisions/"
+            "…-grow-needs-review-batch-01.yaml\n"
+            "\n"
+            "Outputs (only with --write):\n"
+            "  site/src/data/lexicon-manifest.json           updated when promotions land\n"
+            "  site/src/data/lexicon-manifest.fingerprint.json  refreshed sidecar\n"
+            "  data/lexicon/grow_needs_review.json           remaining held rows\n"
+            "\n"
+            "Exit codes:\n"
+            "  0  success (dry-run or write)\n"
+            "  2  validation/self-check failure; no files written\n"
+            "\n"
+            "Related:\n"
+            "  scripts/lexicon/generate_needs_review_ledger.py  — build needs-review ledger\n"
+            "  scripts/lexicon/triage_needs_review.py           — deterministic held triage\n"
+            "  issue #5230                                     — needs_review re-entry arc\n"
+        ),
+    )
+    parser.add_argument(
+        "--candidates",
+        type=Path,
+        default=DEFAULT_CANDIDATES,
+        help=f"Path to grow_candidates.json (default: {DEFAULT_CANDIDATES})",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help=f"Path to lexicon-manifest.json (default: {DEFAULT_MANIFEST})",
+    )
+    parser.add_argument(
+        "--needs-review",
+        type=Path,
+        default=DEFAULT_NEEDS_REVIEW,
+        help=f"Path for remaining held-review JSON report (default: {DEFAULT_NEEDS_REVIEW})",
+    )
+    parser.add_argument(
+        "--fingerprint",
+        type=Path,
+        default=DEFAULT_FINGERPRINT,
+        help=f"Fingerprint sidecar path (default: {DEFAULT_FINGERPRINT})",
+    )
     parser.add_argument(
         "--approval-ledger",
         type=Path,
-        help=("Require an exact, checksum-bound atlas_grow_promotion_ledger; only its approve decisions are promoted"),
+        help=(
+            "Optional exact, checksum-bound atlas_grow_promotion_ledger; "
+            "only its approve decisions are promoted from auto_merge"
+        ),
+    )
+    parser.add_argument(
+        "--needs-review-ledger",
+        type=Path,
+        help=(
+            "Optional exact, dual-sha-bound atlas_grow_needs_review_decisions ledger; "
+            "only its approve rows are promoted from needs_review (with approved_gloss)"
+        ),
     )
     mode = parser.add_mutually_exclusive_group()
-    mode.add_argument("--write", action="store_true", help="Write the manifest and held-review report")
-    mode.add_argument("--dry-run", action="store_true", help="Report what would change without writing")
-    parser.add_argument("--report", action="store_true", help="Print promoted and held lemma details")
+    mode.add_argument(
+        "--write",
+        action="store_true",
+        help="Write the manifest, fingerprint sidecar, and held-review report",
+    )
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing (default behaviour)",
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Print promoted and held lemma details",
+    )
     return parser
 
 
@@ -319,6 +442,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             needs_review_path=args.needs_review,
             fingerprint_path=args.fingerprint,
             approval_ledger_path=args.approval_ledger,
+            needs_review_ledger_path=args.needs_review_ledger,
             write=args.write,
         )
     except (SelfCheckError, ValueError) as exc:
@@ -360,61 +484,261 @@ def _approved_candidate_entries(
     file by SHA-256.  A stale, partial, or mismatched ledger cannot silently
     broaden promotion.
     """
-    try:
-        payload = yaml.safe_load(approval_ledger_path.read_text(encoding="utf-8"))
-    except OSError as exc:
-        raise ValueError(f"could not read approval ledger: {approval_ledger_path}") from exc
-    except yaml.YAMLError as exc:
-        raise ValueError(f"approval ledger is not valid YAML: {approval_ledger_path}") from exc
-    if not isinstance(payload, Mapping):
-        raise ValueError(f"approval ledger must be a mapping: {approval_ledger_path}")
-    if payload.get("kind") != APPROVAL_LEDGER_KIND:
-        raise ValueError(f"approval ledger kind must be {APPROVAL_LEDGER_KIND!r}: {approval_ledger_path}")
+    payload = load_ledger_mapping(approval_ledger_path, label="approval ledger")
+    require_ledger_kind(payload, APPROVAL_LEDGER_KIND, label="approval ledger")
+    provenance = require_ledger_provenance(payload, label="approval ledger")
+    require_file_sha256(
+        candidates_path,
+        provenance.get("candidates_sha256"),
+        label="approval ledger candidates_sha256",
+        mismatch_message="approval ledger candidate SHA-256 does not match the supplied candidates file",
+    )
+    decision_rows = parse_ledger_decision_rows(
+        payload.get("decisions"),
+        label="approval ledger",
+        allowed_decisions=ALLOWED_LEDGER_DECISIONS,
+    )
+    candidate_by_key = index_by_decision_key(candidates, label="auto-merge candidate")
+    require_exact_decision_coverage(
+        set(candidate_by_key),
+        set(decision_rows),
+        scope_label="auto-merge candidates",
+        ledger_label="approval ledger",
+    )
+    return [
+        candidate
+        for candidate in candidates
+        if decision_rows[_candidate_decision_key(candidate)]["decision"] == "approve"
+    ]
 
+
+def _approved_needs_review_entries(
+    held_rows: Sequence[HeldRow],
+    *,
+    candidates_path: Path,
+    needs_review_ledger_path: Path,
+) -> tuple[list[Mapping[str, Any]], list[HeldRow], int, int]:
+    """Return gloss-injected approve entries + remaining held rows from a bound ledger.
+
+    Fail-closed: kind, candidates_sha256, triage_sha256 presence, exact coverage of
+    the full needs_review set, and decision vocabulary must all validate before any
+    promotion is considered.
+    """
+    payload = load_ledger_mapping(needs_review_ledger_path, label="needs-review ledger")
+    require_ledger_kind(payload, NEEDS_REVIEW_LEDGER_KIND, label="needs-review ledger")
+    provenance = require_ledger_provenance(payload, label="needs-review ledger")
+    require_file_sha256(
+        candidates_path,
+        provenance.get("candidates_sha256"),
+        label="needs-review ledger candidates_sha256",
+        mismatch_message=(
+            "needs-review ledger candidates_sha256 does not match the supplied candidates file"
+        ),
+    )
+    triage_sha = str(provenance.get("triage_sha256") or "").strip()
+    if not triage_sha:
+        raise ValueError("needs-review ledger provenance lacks triage_sha256")
+    if len(triage_sha) != 64 or any(ch not in "0123456789abcdef" for ch in triage_sha.casefold()):
+        raise ValueError("needs-review ledger triage_sha256 must be a 64-char hex digest")
+
+    decision_rows = parse_ledger_decision_rows(
+        payload.get("decisions"),
+        label="needs-review ledger",
+        allowed_decisions=ALLOWED_LEDGER_DECISIONS,
+    )
+    held_by_key = index_held_rows_by_decision_key(held_rows)
+    require_exact_decision_coverage(
+        set(held_by_key),
+        set(decision_rows),
+        scope_label="needs_review candidates",
+        ledger_label="needs-review ledger",
+    )
+
+    approved: list[Mapping[str, Any]] = []
+    remaining_held: list[HeldRow] = []
+    approve_count = 0
+    deferred_count = 0
+    for key, row in held_by_key.items():
+        decision_row = decision_rows[key]
+        decision = decision_row["decision"]
+        if decision == "approve":
+            if decision_row.get("heritage") is True:
+                raise ValueError(f"needs-review ledger approve row must not set heritage=true: {key!r}")
+            gloss = decision_row.get("approved_gloss")
+            if not isinstance(gloss, Mapping):
+                raise ValueError(f"needs-review ledger approve row lacks approved_gloss: {key!r}")
+            text = str(gloss.get("text") or "").strip()
+            source = str(gloss.get("source") or "").strip()
+            if not text:
+                raise ValueError(f"needs-review ledger approved_gloss.text is empty: {key!r}")
+            if not source:
+                raise ValueError(f"needs-review ledger approved_gloss.source is empty: {key!r}")
+            approved.append(inject_approved_gloss(row.entry, {"text": text, "source": source}))
+            approve_count += 1
+        else:
+            # deferred / reject stay held; heritage rows are always deferred by generator.
+            deferred_count += 1
+            remaining_held.append(row)
+
+    # Preserve original needs_review order for held report stability.
+    remaining_keys = {_candidate_decision_key(row.entry) for row in remaining_held}
+    ordered_held = [row for row in held_rows if _candidate_decision_key(row.entry) in remaining_keys]
+    return approved, ordered_held, approve_count, deferred_count
+
+
+def load_ledger_mapping(path: Path, *, label: str) -> Mapping[str, Any]:
+    """Load a YAML ledger as a mapping (shared auto_merge / needs_review helper)."""
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"could not read {label}: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{label} is not valid YAML: {path}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"{label} must be a mapping: {path}")
+    return payload
+
+
+def require_ledger_kind(payload: Mapping[str, Any], kind: str, *, label: str) -> None:
+    if payload.get("kind") != kind:
+        raise ValueError(f"{label} kind must be {kind!r}")
+
+
+def require_ledger_provenance(payload: Mapping[str, Any], *, label: str) -> Mapping[str, Any]:
     provenance = payload.get("provenance")
     if not isinstance(provenance, Mapping):
-        raise ValueError("approval ledger lacks provenance")
-    expected_sha256 = str(provenance.get("candidates_sha256") or "").strip()
-    actual_sha256 = hashlib.sha256(candidates_path.read_bytes()).hexdigest()
-    if expected_sha256 != actual_sha256:
-        raise ValueError("approval ledger candidate SHA-256 does not match the supplied candidates file")
+        raise ValueError(f"{label} lacks provenance")
+    return provenance
 
-    raw_decisions = payload.get("decisions")
+
+def require_file_sha256(
+    path: Path,
+    expected: object,
+    *,
+    label: str,
+    mismatch_message: str,
+) -> str:
+    """Compare path bytes to an expected hex digest; return the actual digest."""
+    expected_sha = str(expected or "").strip()
+    actual_sha = hashlib.sha256(path.read_bytes()).hexdigest()
+    if not expected_sha:
+        raise ValueError(f"{label} is missing")
+    if expected_sha != actual_sha:
+        raise ValueError(mismatch_message)
+    return actual_sha
+
+
+def parse_ledger_decision_rows(
+    raw_decisions: object,
+    *,
+    label: str,
+    allowed_decisions: frozenset[str] = ALLOWED_LEDGER_DECISIONS,
+) -> dict[tuple[str, str], dict[str, Any]]:
+    """Parse decision rows keyed by (lemma_key, pos); fail on duplicates/invalid vocab."""
     if not isinstance(raw_decisions, list):
-        raise ValueError("approval ledger decisions must be a list")
-
-    candidate_by_key: dict[tuple[str, str], Mapping[str, Any]] = {}
-    for candidate in candidates:
-        key = _candidate_decision_key(candidate)
-        if key in candidate_by_key:
-            raise ValueError(f"duplicate auto-merge candidate decision key: {key!r}")
-        candidate_by_key[key] = candidate
-
-    decision_by_key: dict[tuple[str, str], str] = {}
+        raise ValueError(f"{label} decisions must be a list")
+    decision_by_key: dict[tuple[str, str], dict[str, Any]] = {}
     for row in raw_decisions:
         if not isinstance(row, Mapping):
-            raise ValueError("approval ledger decision must be a mapping")
+            raise ValueError(f"{label} decision must be a mapping")
         key = _candidate_decision_key(row)
         if key in decision_by_key:
-            raise ValueError(f"duplicate approval ledger decision key: {key!r}")
+            raise ValueError(f"duplicate {label} decision key: {key!r}")
         decision = str(row.get("decision") or "").strip()
-        if decision not in {"approve", "deferred", "reject"}:
-            raise ValueError(f"invalid approval ledger decision for {key!r}: {decision!r}")
-        decision_by_key[key] = decision
+        if decision not in allowed_decisions:
+            raise ValueError(f"invalid {label} decision for {key!r}: {decision!r}")
+        normalized = dict(row)
+        normalized["decision"] = decision
+        decision_by_key[key] = normalized
+    return decision_by_key
 
-    candidate_keys = set(candidate_by_key)
-    decision_keys = set(decision_by_key)
-    if candidate_keys != decision_keys:
-        missing = sorted(candidate_keys - decision_keys)
-        unexpected = sorted(decision_keys - candidate_keys)
-        details: list[str] = []
-        if missing:
-            details.append(f"missing decisions={len(missing)}")
-        if unexpected:
-            details.append(f"unexpected decisions={len(unexpected)}")
-        raise ValueError(f"approval ledger does not exactly cover auto-merge candidates ({', '.join(details)})")
 
-    return [candidate for candidate in candidates if decision_by_key[_candidate_decision_key(candidate)] == "approve"]
+def index_by_decision_key(
+    candidates: Sequence[Mapping[str, Any]],
+    *,
+    label: str,
+) -> dict[tuple[str, str], Mapping[str, Any]]:
+    by_key: dict[tuple[str, str], Mapping[str, Any]] = {}
+    for candidate in candidates:
+        key = _candidate_decision_key(candidate)
+        if key in by_key:
+            raise ValueError(f"duplicate {label} decision key: {key!r}")
+        by_key[key] = candidate
+    return by_key
+
+
+def index_held_rows_by_decision_key(held_rows: Sequence[HeldRow]) -> dict[tuple[str, str], HeldRow]:
+    by_key: dict[tuple[str, str], HeldRow] = {}
+    for row in held_rows:
+        key = _candidate_decision_key(row.entry)
+        if key in by_key:
+            raise ValueError(f"duplicate needs_review candidate decision key: {key!r}")
+        by_key[key] = row
+    return by_key
+
+
+def require_exact_decision_coverage(
+    candidate_keys: set[tuple[str, str]],
+    decision_keys: set[tuple[str, str]],
+    *,
+    scope_label: str,
+    ledger_label: str,
+) -> None:
+    if candidate_keys == decision_keys:
+        return
+    missing = sorted(candidate_keys - decision_keys)
+    unexpected = sorted(decision_keys - candidate_keys)
+    details: list[str] = []
+    if missing:
+        details.append(f"missing decisions={len(missing)}")
+    if unexpected:
+        details.append(f"unexpected decisions={len(unexpected)}")
+    raise ValueError(f"{ledger_label} does not exactly cover {scope_label} ({', '.join(details)})")
+
+
+def inject_approved_gloss(
+    candidate: Mapping[str, Any],
+    approved_gloss: Mapping[str, str],
+) -> dict[str, Any]:
+    """Inject ledger-approved gloss as definition/anchor on a needs_review entry.
+
+    Sets top-level ``gloss`` (satisfies the learner-English anchor check) and
+    seeds ``enrichment.meaning`` / ``enrichment.translation`` so the existing
+    anchor-fill short-circuit and attribution pass see a grounded definition.
+    """
+    text = str(approved_gloss.get("text") or "").strip()
+    source = str(approved_gloss.get("source") or "").strip()
+    if not text:
+        raise ValueError("approved_gloss.text must be non-empty")
+    entry = dict(candidate)
+    entry["gloss"] = text
+    enrichment_raw = entry.get("enrichment")
+    enrichment: dict[str, Any] = dict(enrichment_raw) if isinstance(enrichment_raw, Mapping) else {}
+
+    meaning_raw = enrichment.get("meaning")
+    meaning: dict[str, Any] = dict(meaning_raw) if isinstance(meaning_raw, Mapping) else {}
+    definitions = meaning.get("definitions")
+    if not (isinstance(definitions, list) and any(str(item or "").strip() for item in definitions)):
+        meaning["definitions"] = [text]
+        if source:
+            meaning["source"] = source
+        enrichment["meaning"] = meaning
+
+    translation_raw = enrichment.get("translation")
+    translation: dict[str, Any] = dict(translation_raw) if isinstance(translation_raw, Mapping) else {}
+    en_terms = translation.get("en")
+    if not (isinstance(en_terms, list) and any(isinstance(t, str) and t.strip() for t in en_terms)):
+        translation["en"] = [text]
+        if source:
+            translation["source"] = source
+        enrichment["translation"] = translation
+
+    sources = list(enrichment.get("sources") or []) if isinstance(enrichment.get("sources"), list) else []
+    if source and source not in sources:
+        sources.append(source)
+    enrichment["sources"] = sources
+    entry["enrichment"] = enrichment
+    return entry
 
 
 def _candidate_decision_key(candidate: Mapping[str, Any]) -> tuple[str, str]:
@@ -617,18 +941,28 @@ def _json_bytes(payload: object) -> bytes:
 
 
 def _held_lemmas(raw_items: object) -> list[HeldLemma]:
+    return [HeldLemma(lemma=row.lemma, reason=row.reason) for row in _held_rows(raw_items)]
+
+
+def _held_rows(raw_items: object) -> list[HeldRow]:
+    """Parse needs_review payload rows into HeldRow values (entry + reason)."""
     if not isinstance(raw_items, list):
         return []
-    held: list[HeldLemma] = []
+    held: list[HeldRow] = []
     for item in raw_items:
         if not isinstance(item, Mapping):
             continue
-        entry = item.get("entry")
-        lemma = ""
-        if isinstance(entry, Mapping):
-            lemma = str(entry.get("lemma") or "").strip()
-        reason = str(item.get("reason") or "").strip()
-        held.append(HeldLemma(lemma=lemma, reason=reason))
+        entry_raw = item.get("entry")
+        if isinstance(entry_raw, Mapping):
+            entry: Mapping[str, Any] = entry_raw
+        else:
+            # Tolerate bare entry objects (tests / alternate emitters).
+            entry = item
+        lemma = str(entry.get("lemma") or "").strip()
+        if not lemma:
+            continue
+        reason = str(item.get("reason") or entry.get("held_reason") or "").strip()
+        held.append(HeldRow(lemma=lemma, reason=reason, entry=entry))
     return held
 
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "f1b11e6ef00173d5a961560befa0b80287b28088102534d22da2067111c6c49b",
+  "fingerprint": "4406cb72333c70b3d69ade0aa262dbfb9636809fe3956706bc166501e4cbe978",
   "inputs": {
     "lexicon_code": [
       {
@@ -99,6 +99,10 @@
         "sha256": "4d424621a014a85ea67b8f123e6e0d1fed5726eeea76c0afe0d3d5cd359bebef"
       },
       {
+        "path": "scripts/lexicon/generate_needs_review_ledger.py",
+        "sha256": "6bc9a7fb4977a57e5d39a5a11af13842b8efd1b42ea203c9c0b5647b91079663"
+      },
+      {
         "path": "scripts/lexicon/generate_vesum_aliases.py",
         "sha256": "583f2cfd82892779321bdd91e7127212750f0be7ac430c2bec9512cef71e1084"
       },
@@ -156,7 +160,7 @@
       },
       {
         "path": "scripts/lexicon/promote_grow_candidates.py",
-        "sha256": "de3e8f0081b37f5210147825147dca6a6236de1c05e6ee361ddce38419552d12"
+        "sha256": "197d9a8c4791be86899a6b35357e97732bb58657222bc01e50598c92a2f6c5cf"
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
@@ -199,6 +203,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 48
+    "lexicon_code_files": 49
   }
 }

--- a/tests/test_generate_needs_review_ledger.py
+++ b/tests/test_generate_needs_review_ledger.py
@@ -1,0 +1,475 @@
+"""Tests for needs_review re-entry ledger generation + promotion (#5230)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.lexicon import generate_needs_review_ledger as gen
+from scripts.lexicon import promote_grow_candidates as promote
+
+
+def test_cli_refuses_without_write_or_dry_run() -> None:
+    with pytest.raises(SystemExit) as exc:
+        gen.main([])
+    assert exc.value.code == 2
+
+
+def test_generator_round_trip_maps_actions(tmp_path: Path) -> None:
+    candidates_path, triage_path = _write_fixture_pair(tmp_path)
+    out = tmp_path / "ledger.yaml"
+
+    result = gen.generate_needs_review_ledger(
+        candidates_path=candidates_path,
+        triage_path=triage_path,
+        out_path=out,
+        write=True,
+        reviewed_at="2026-07-18",
+    )
+
+    assert result.written is True
+    assert result.approve_count == 1
+    assert result.deferred_count == 2
+    assert result.heritage_count == 1
+    assert result.total == 3
+    assert out.exists()
+
+    payload = yaml.safe_load(out.read_text(encoding="utf-8"))
+    assert payload["kind"] == promote.NEEDS_REVIEW_LEDGER_KIND
+    assert payload["provenance"]["candidates_sha256"] == hashlib.sha256(
+        candidates_path.read_bytes()
+    ).hexdigest()
+    assert payload["provenance"]["triage_sha256"] == hashlib.sha256(
+        triage_path.read_bytes()
+    ).hexdigest()
+
+    by_lemma = {row["lemma"]: row for row in payload["decisions"]}
+    assert by_lemma["хата"]["decision"] == "approve"
+    assert by_lemma["хата"]["approved_gloss"] == {"text": "house; home", "source": "dmklinger"}
+    assert by_lemma["абонплата"]["decision"] == "deferred"
+    assert by_lemma["абонплата"]["reason"] == "truly_missing"
+    assert by_lemma["верф"]["decision"] == "deferred"
+    assert by_lemma["верф"]["heritage"] is True
+    assert by_lemma["верф"]["reason"] == "heritage_flag"
+
+    # Round-trip: re-read path is loadable by promote helpers.
+    rows = promote.parse_ledger_decision_rows(
+        payload["decisions"],
+        label="needs-review ledger",
+    )
+    assert set(rows) == {
+        promote._candidate_decision_key({"lemma": "хата", "pos": "noun"}),
+        promote._candidate_decision_key({"lemma": "абонплата", "pos": "noun"}),
+        promote._candidate_decision_key({"lemma": "верф", "pos": "noun"}),
+    }
+
+
+def test_generator_fails_on_coverage_mismatch(tmp_path: Path) -> None:
+    candidates_path, triage_path = _write_fixture_pair(tmp_path)
+    triage = json.loads(triage_path.read_text(encoding="utf-8"))
+    triage["entries"] = triage["entries"][:1]
+    triage_path.write_text(json.dumps(triage, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not exactly cover"):
+        gen.generate_needs_review_ledger(
+            candidates_path=candidates_path,
+            triage_path=triage_path,
+            out_path=tmp_path / "ledger.yaml",
+            write=False,
+        )
+
+
+def test_promote_needs_review_ledger_promotes_only_approve_with_gloss(tmp_path: Path) -> None:
+    candidates_path, triage_path = _write_fixture_pair(tmp_path)
+    ledger_path = tmp_path / "nr-ledger.yaml"
+    gen.generate_needs_review_ledger(
+        candidates_path=candidates_path,
+        triage_path=triage_path,
+        out_path=ledger_path,
+        write=True,
+        reviewed_at="2026-07-18",
+    )
+
+    manifest_path = _write_manifest(tmp_path, [_entry("авто")])
+    result = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=tmp_path / "grow_needs_review.json",
+        fingerprint_path=tmp_path / "lexicon-manifest.fingerprint.json",
+        needs_review_ledger_path=ledger_path,
+        write=True,
+        self_check=lambda _path: 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    lemmas = [entry["lemma"] for entry in _read_json(manifest_path)["entries"]]
+    assert lemmas == ["авто", "хата"]
+    assert result.promoted == ("хата",)
+    assert result.needs_review_approved == 1
+    assert result.needs_review_deferred == 2
+    assert {item.lemma for item in result.held} == {"абонплата", "верф"}
+
+    promoted = next(e for e in _read_json(manifest_path)["entries"] if e["lemma"] == "хата")
+    assert promoted["gloss"] == "house; home"
+    assert promoted["enrichment"]["meaning"]["definitions"] == ["house; home"]
+    assert promoted["enrichment"]["translation"]["en"] == ["house; home"]
+    assert "dmklinger" in promoted["enrichment"]["sources"]
+
+
+def test_promote_needs_review_deferred_and_heritage_never_promoted(tmp_path: Path) -> None:
+    candidates_path, triage_path = _write_fixture_pair(tmp_path)
+    # Force only deferred/heritage actions.
+    triage = json.loads(triage_path.read_text(encoding="utf-8"))
+    for row in triage["entries"]:
+        if row["machine_action"] == "promote_with_gloss":
+            row["machine_action"] = "truly_missing"
+            row["best_gloss"] = None
+    triage_path.write_text(json.dumps(triage, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    ledger_path = tmp_path / "nr-ledger.yaml"
+    gen.generate_needs_review_ledger(
+        candidates_path=candidates_path,
+        triage_path=triage_path,
+        out_path=ledger_path,
+        write=True,
+    )
+
+    manifest_path = _write_manifest(tmp_path, [_entry("авто")])
+    result = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=tmp_path / "grow_needs_review.json",
+        fingerprint_path=tmp_path / "fp.json",
+        needs_review_ledger_path=ledger_path,
+        write=True,
+        self_check=lambda _path: 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    assert result.promoted == ()
+    assert result.needs_review_approved == 0
+    assert result.needs_review_deferred == 3
+    assert [e["lemma"] for e in _read_json(manifest_path)["entries"]] == ["авто"]
+
+
+def test_promote_needs_review_fails_on_candidates_sha_mismatch(tmp_path: Path) -> None:
+    candidates_path, triage_path = _write_fixture_pair(tmp_path)
+    ledger_path = tmp_path / "nr-ledger.yaml"
+    gen.generate_needs_review_ledger(
+        candidates_path=candidates_path,
+        triage_path=triage_path,
+        out_path=ledger_path,
+        write=True,
+    )
+    candidates_path.write_text(candidates_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="candidates_sha256"):
+        promote.promote_grow_candidates(
+            candidates_path=candidates_path,
+            manifest_path=_write_manifest(tmp_path, [_entry("авто")]),
+            needs_review_ledger_path=ledger_path,
+            self_check=lambda _path: 0,
+            fingerprint_writer=_fingerprint_writer,
+        )
+
+
+def test_promote_needs_review_fails_on_coverage_mismatch(tmp_path: Path) -> None:
+    candidates_path, triage_path = _write_fixture_pair(tmp_path)
+    ledger_path = tmp_path / "nr-ledger.yaml"
+    gen.generate_needs_review_ledger(
+        candidates_path=candidates_path,
+        triage_path=triage_path,
+        out_path=ledger_path,
+        write=True,
+    )
+    payload = yaml.safe_load(ledger_path.read_text(encoding="utf-8"))
+    payload["decisions"] = payload["decisions"][:1]
+    # Keep sha valid so coverage is the failure mode under test.
+    payload["provenance"]["candidates_sha256"] = hashlib.sha256(
+        candidates_path.read_bytes()
+    ).hexdigest()
+    ledger_path.write_text(yaml.safe_dump(payload, allow_unicode=True, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not exactly cover"):
+        promote.promote_grow_candidates(
+            candidates_path=candidates_path,
+            manifest_path=_write_manifest(tmp_path, [_entry("авто")]),
+            needs_review_ledger_path=ledger_path,
+            self_check=lambda _path: 0,
+            fingerprint_writer=_fingerprint_writer,
+        )
+
+
+def test_promote_needs_review_fails_when_triage_sha_missing(tmp_path: Path) -> None:
+    candidates_path, triage_path = _write_fixture_pair(tmp_path)
+    ledger_path = tmp_path / "nr-ledger.yaml"
+    gen.generate_needs_review_ledger(
+        candidates_path=candidates_path,
+        triage_path=triage_path,
+        out_path=ledger_path,
+        write=True,
+    )
+    payload = yaml.safe_load(ledger_path.read_text(encoding="utf-8"))
+    del payload["provenance"]["triage_sha256"]
+    ledger_path.write_text(yaml.safe_dump(payload, allow_unicode=True, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="triage_sha256"):
+        promote.promote_grow_candidates(
+            candidates_path=candidates_path,
+            manifest_path=_write_manifest(tmp_path, [_entry("авто")]),
+            needs_review_ledger_path=ledger_path,
+            self_check=lambda _path: 0,
+            fingerprint_writer=_fingerprint_writer,
+        )
+
+
+def test_inject_approved_gloss_sets_anchor_fields() -> None:
+    candidate = {
+        "lemma": "хата",
+        "pos": "noun",
+        "enrichment": {"sources": ["VESUM"], "cefr": {"level": "A1"}},
+    }
+    injected = promote.inject_approved_gloss(
+        candidate,
+        {"text": "house", "source": "sum11"},
+    )
+    assert injected["gloss"] == "house"
+    assert injected["enrichment"]["meaning"]["definitions"] == ["house"]
+    assert injected["enrichment"]["meaning"]["source"] == "sum11"
+    assert injected["enrichment"]["translation"]["en"] == ["house"]
+    assert "sum11" in injected["enrichment"]["sources"]
+    assert injected["enrichment"]["cefr"] == {"level": "A1"}
+
+
+def test_needs_review_and_auto_merge_ledgers_compose(tmp_path: Path) -> None:
+    auto = _candidate("мама")
+    held = [
+        {
+            "entry": _candidate("хата", enrichment={"sources": ["fixture"]}),
+            "reason": "missing dictionary definition",
+        }
+    ]
+    candidates_path = _write_candidates(tmp_path, [auto], held)
+    triage_path = tmp_path / "triage.json"
+    triage_path.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "lemma": "хата",
+                        "pos": "noun",
+                        "held_reason": "missing dictionary definition",
+                        "best_gloss": {"text": "house", "source": "sum11"},
+                        "machine_action": "promote_with_gloss",
+                    }
+                ]
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    nr_ledger = tmp_path / "nr.yaml"
+    gen.generate_needs_review_ledger(
+        candidates_path=candidates_path,
+        triage_path=triage_path,
+        out_path=nr_ledger,
+        write=True,
+    )
+    approval = tmp_path / "auto.yaml"
+    approval.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "kind": promote.APPROVAL_LEDGER_KIND,
+                "provenance": {
+                    "candidates_sha256": hashlib.sha256(candidates_path.read_bytes()).hexdigest(),
+                },
+                "decisions": [
+                    {"lemma": "мама", "pos": "noun", "decision": "approve"},
+                ],
+            },
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=_write_manifest(tmp_path, [_entry("авто")]),
+        needs_review_path=tmp_path / "held.json",
+        fingerprint_path=tmp_path / "fp.json",
+        approval_ledger_path=approval,
+        needs_review_ledger_path=nr_ledger,
+        write=True,
+        self_check=lambda _path: 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    assert set(result.promoted) == {"мама", "хата"}
+    assert result.needs_review_approved == 1
+    assert result.needs_review_deferred == 0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_fixture_pair(tmp_path: Path) -> tuple[Path, Path]:
+    held = [
+        {
+            "entry": _candidate("хата", enrichment={"sources": ["VESUM"]}),
+            "reason": "missing dictionary definition",
+        },
+        {
+            "entry": _candidate("абонплата", enrichment={"sources": ["VESUM"]}),
+            "reason": "missing dictionary definition",
+        },
+        {
+            "entry": _candidate(
+                "верф",
+                enrichment={"sources": ["VESUM"]},
+                heritage_status={
+                    "classification": "russianism",
+                    "is_russianism": True,
+                    "russian_shadow": False,
+                    "calque_warning": "calque",
+                },
+            ),
+            "reason": "heritage_status flags russianism; heritage_status flags calque_warning",
+        },
+    ]
+    candidates_path = _write_candidates(tmp_path, [], held)
+    triage_path = tmp_path / "needs-review-triage.json"
+    triage_path.write_text(
+        json.dumps(
+            {
+                "generated_by": "scripts/lexicon/triage_needs_review.py",
+                "counts": {"total": 3},
+                "entries": [
+                    {
+                        "lemma": "хата",
+                        "pos": "noun",
+                        "held_reason": "missing dictionary definition",
+                        "best_gloss": {"text": "house; home", "source": "dmklinger"},
+                        "machine_action": "promote_with_gloss",
+                    },
+                    {
+                        "lemma": "абонплата",
+                        "pos": "noun",
+                        "held_reason": "missing dictionary definition",
+                        "best_gloss": None,
+                        "machine_action": "truly_missing",
+                    },
+                    {
+                        "lemma": "верф",
+                        "pos": "noun",
+                        "held_reason": (
+                            "heritage_status flags russianism; heritage_status flags calque_warning"
+                        ),
+                        "best_gloss": {"text": "shipyard", "source": "sum11"},
+                        "machine_action": "heritage_flag",
+                    },
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return candidates_path, triage_path
+
+
+def _candidate(lemma: str = "мама", **overrides: object) -> dict[str, object]:
+    candidate: dict[str, object] = {
+        "lemma": lemma,
+        "pos": "noun",
+        "heritage_status": {
+            "classification": "standard",
+            "attestations": [],
+            "is_russianism": False,
+            "russian_shadow": False,
+            "calque_warning": None,
+        },
+        "enrichment": {
+            "sources": ["fixture"],
+        },
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _entry(lemma: str) -> dict[str, object]:
+    return {
+        "lemma": lemma,
+        "url_slug": lemma.casefold(),
+        "gloss": lemma,
+        "pos": "noun",
+        "ipa": None,
+        "primary_source": "built_vocabulary",
+        "course_usage": [],
+        "heritage_status": {
+            "classification": "standard",
+            "attestations": [],
+            "is_russianism": False,
+            "russian_shadow": False,
+            "calque_warning": None,
+        },
+        "enrichment": {
+            "meaning": {"definitions": [lemma], "source": "fixture"},
+            "sources": ["fixture"],
+        },
+    }
+
+
+def _write_manifest(tmp_path: Path, entries: list[dict[str, object]]) -> Path:
+    path = tmp_path / "lexicon-manifest.json"
+    payload = {
+        "version": "0.1",
+        "generated_at": "2026-06-22T00:00:00+00:00",
+        "stats": {
+            "lemmas_total": len(entries),
+            "enriched_count": sum(1 for entry in entries if entry.get("enrichment")),
+        },
+        "modules": [],
+        "seed_groups": [],
+        "entries": entries,
+        "enrichment_generated": True,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_candidates(
+    tmp_path: Path,
+    auto_merge: list[dict[str, object]],
+    needs_review: list[dict[str, object]],
+) -> Path:
+    path = tmp_path / "grow_candidates.json"
+    payload = {
+        "counts": {
+            "total_delta": len(auto_merge) + len(needs_review),
+            "processed": len(auto_merge) + len(needs_review),
+            "auto_merge": len(auto_merge),
+            "needs_review": len(needs_review),
+        },
+        "auto_merge": auto_merge,
+        "needs_review": needs_review,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _fingerprint_writer(path: Path) -> None:
+    path.write_text('{"fingerprint": "fixture"}\n', encoding="utf-8")


### PR DESCRIPTION
## Summary

Implements the **needs_review re-entry path** for the #5230 arc (task #2): code-decided promotion of triaged held grow lemmas, without LLM judging.

- **Ledger generator** `scripts/lexicon/generate_needs_review_ledger.py` — reads mini/fixture triage + candidates, emits sha-bound `atlas_grow_needs_review_decisions` YAML (`candidates_sha256` + `triage_sha256`). Maps:
  - `promote_with_gloss` → `approve` + `approved_gloss`
  - `truly_missing` → `deferred`
  - `heritage_flag` → `deferred` + `heritage: true`
  - Bare CLI refuses; `--write` / `--dry-run` only (cli-help-standard).
- **Promote flag** `promote_grow_candidates.py --needs-review-ledger` — usable with or without `--approval-ledger`. Validates kind, both SHA bindings, exact needs_review coverage, decision vocab; promotes only `approve` rows with gloss injected into definition/anchor via the existing fill/attribution path. Summary reports approve/deferred counts.
- **Shared validation helpers** extracted from the auto_merge ledger path (no copy-paste).
- **Tests** with fixture mini-candidates + mini-triage (never real data): coverage/sha mismatch fail-closed, deferred/heritage never promoted, gloss lands on promoted entry, generator round-trip.

**Not in this PR (orchestrator on primary after merge):** running the real generator against the 838/1460/18 triage, or the real promote write.

Refs #5230

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_generate_needs_review_ledger.py tests/test_promote_grow_candidates.py -q` → 29 passed
- [x] `.venv/bin/ruff check` on touched scripts/tests → clean
- [x] Fingerprint sidecar refreshed on branch
- [x] `scripts/audit/lint_agent_trailer.py` → PASS
- [ ] Orchestrator: generate real ledger on primary from `needs-review-triage.json` + `grow_candidates.json`
- [ ] Orchestrator: promote with `--needs-review-ledger` (838 approve expected) after review gate