### PR TITLE
fix(review): calibrate publication scores at nine

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/SKILL.md
+++ b/agents_extensions/shared/skills/post-build-review/SKILL.md
@@ -113,11 +113,17 @@ manually concatenate or substitute other review prompts.
   the repository.
 - Never let semantic `PASS` override a deterministic blocker/high finding.
 - Treat v6 dimension scores and `minimum_dimension_score` as diagnostic,
-  evidence-backed reporting only. Never use them as readiness thresholds,
-  disposition inputs, score sidecars, or retry-selection criteria.
-- Treat `10.0` as an attestation about findings linked to that dimension, not
-  as evidence that the whole result has no claim or learner-evidence findings.
-  The strict normalizer rejects any finding that has no dimension/ledger owner.
+  evidence-backed reporting. Never average them, use a score sidecar, demote a
+  categorical finding, or select retries from them. The versioned status bands
+  enforce the publication target: a categorical dimension `PASS` is `9.0+`;
+  anything below `9.0` is non-PASS.
+- Treat low/info findings linked to a `9.x` PASS dimension as the preserved,
+  non-blocking improvement backlog. They remain visible in the canonical
+  `findings` ledger and never authorize a material-finding downgrade.
+- Treat `10.0` as exceptional positive evidence, not an attestation inferred
+  from finding absence. It requires no linked findings, two distinct positive
+  evidence anchors, and a rationale that explains exceptional quality. The
+  strict normalizer rejects any finding that has no dimension/ledger owner.
 - Treat `alignment_audit` and `vocabulary_coverage` as required evidence
   ledgers. A prompt claim that a class was checked cannot replace the exact
   seven-class record or the source-order lemma enumeration.

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,17 +1,17 @@
-review_protocol_version: 6.0.3
+review_protocol_version: 6.0.4
 deterministic_contract_version: 2.0.0
-semantic_prompt_version: 6.0.4
-track_policy_version: 2.0.1
+semantic_prompt_version: 6.0.5
+track_policy_version: 2.1.0
 
 score_calibration:
   bands:
     PASS:
-      minimum: 8.0
+      minimum: 9.0
       maximum: 10.0
       includes_maximum: true
     REVISE:
       minimum: 6.0
-      maximum: 8.0
+      maximum: 9.0
       includes_maximum: false
     BLOCK:
       minimum: 0.0

--- a/agents_extensions/shared/skills/post-build-review/contracts/combined-disposition-policy.md
+++ b/agents_extensions/shared/skills/post-build-review/contracts/combined-disposition-policy.md
@@ -1,6 +1,6 @@
 # Combined disposition policy
 
-Review protocol version: `3.0.0`
+Review protocol version: `3.0.1`
 
 Apply disposition in this order:
 
@@ -16,8 +16,10 @@ Apply disposition in this order:
    non-mechanical medium finding.
 4. `PASS`: deterministic stages completed, all skips were policy-classified,
    semantic coverage completed or is correctly not applicable, all five
-   quality dimensions passed with target-backed evidence, and only low/info
-   findings remain.
+   quality dimensions passed at `9.0` or higher with target-backed evidence,
+   and only low/info improvement-backlog findings remain. A `10.0` dimension
+   additionally requires exceptional positive justification and at least two
+   distinct evidence anchors; absence of findings alone is not perfection.
 
 Semantic `PASS` never overrides deterministic or track-policy findings. A
 declared claim count never substitutes for its atomic ledger. Metadata never

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Common semantic post-build review prompt
 
-Semantic prompt version: `6.0.4`
+Semantic prompt version: `6.0.5`
 
 ## Machine-response contract — read before any source or tool call
 
@@ -202,7 +202,7 @@ those findings genuinely have the same exact locator.
 The review summary must name every material class found. A high-quality
 paragraph or activity never cancels a defect elsewhere. If any class was not
 actually compared, return `INCOMPLETE`. If a semantic dimension is `REVISE`,
-its score must be below `8.0`; `8.0` and above are valid only with `PASS`.
+its score must be below `9.0`; `9.0` and above are valid only with `PASS`.
 
 ## Required quality-dimension coverage
 
@@ -217,25 +217,34 @@ could not be inspected.
 
 For every quality dimension, return the exact raw keys `status`, `score`,
 `score_rationale`, `evidence`, and `finding_ids`. Scores are diagnostic evidence
-inside this result only: they never set readiness, demote a warning, change the
-categorical verdict, or authorize a release. `BLOCK` is this contract's name
+inside this result only: no average or standalone minimum can set readiness,
+demote a warning, change the categorical verdict, or authorize a release. The
+categorical status remains authoritative, and the validator rejects any status
+whose score falls outside its versioned band. `BLOCK` is this contract's name
 for the legacy standing-rule `REJECT`; the quality target remains 9+.
 
-Use these bands exactly: `PASS` `[8.0, 10.0]`, `REVISE` `[6.0, 8.0)`,
+Use these bands exactly: `PASS` `[9.0, 10.0]`, `REVISE` `[6.0, 9.0)`,
 `BLOCK` `[0.0, 6.0)`, and `INCOMPLETE` `null`. Use at most one decimal place.
 Apply the following anchored rubric within the bands:
 
-- Return `10.0` if and only if that dimension has no findings.
-- `9.0`–`9.9` meets the quality target with only bounded, low-severity
-  headroom; `8.0`–`8.9` is release-safe but has a more consequential,
-  concrete low-severity improvement.
-- `7.0`–`7.9` needs one focused material revision while most of the dimension
-  remains strong; `6.0`–`6.9` has a substantial material defect that requires
-  broader revision.
+- `10.0` is exceptional, not the default result of finding nothing. It requires
+  no linked findings, at least two distinct positive evidence anchors, and a
+  positive rationale explaining what makes the dimension exceptional. A
+  rationale based only on the absence of findings or gaps is invalid.
+- `9.0`–`9.9` meets the publication-quality target with only bounded,
+  low-severity or informational headroom. Record that headroom as linked
+  evidence-backed findings; those findings are the non-blocking improvement
+  backlog preserved by a categorical `PASS`.
+- `8.0`–`8.9` remains strong in parts but has a material revision before it is
+  publication-ready. `7.0`–`7.9` needs a focused material revision while most
+  of the dimension remains usable; `6.0`–`6.9` has a substantial material
+  defect that requires broader revision.
 - `4.0`–`5.9` has a blocking defect despite some usable evidence; `0.0`–`3.9`
   is fundamentally unusable, unsafe, or unsupported for that dimension.
 - Every score below `10.0` must link to at least one evidence-backed finding in
   that dimension and its rationale must name the concrete gap to `10.0`.
+  A `PASS` score may link only low/info findings; a score below `9.0` is never
+  publication-ready and must use `REVISE` or `BLOCK` as its calibrated status.
 - Every semantic finding must be referenced by at least one quality dimension,
   contradicted/imprecise/unattested claim, or non-verified learner-evidence
   entry. A `10.0` attests that the dimension has no linked finding; it never
@@ -296,8 +305,8 @@ equal the statuses actually present in that array.
   "quality_dimensions": {
     "pedagogical": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
-      "score": 10.0,
-      "score_rationale": "No pedagogical finding identifies a gap to 10.0.",
+      "score": 9.0,
+      "score_rationale": "Publication-ready; the linked low-severity finding records bounded non-material headroom.",
       "evidence": [
         {
           "location": "repo-relative target file",
@@ -305,35 +314,35 @@ equal the statuses actually present in that array.
           "supports": "why this exact line supports the dimension assessment"
         }
       ],
-      "finding_ids": []
+      "finding_ids": ["example-bounded-headroom"]
     },
     "naturalness": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
-      "score": 10.0,
-      "score_rationale": "No naturalness finding identifies a gap to 10.0.",
+      "score": 9.0,
+      "score_rationale": "Publication-ready; the linked low-severity finding records bounded non-material headroom.",
       "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this line supports naturalness"}],
-      "finding_ids": []
+      "finding_ids": ["example-bounded-headroom"]
     },
     "decolonization": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
-      "score": 10.0,
-      "score_rationale": "No decolonization finding identifies a gap to 10.0.",
+      "score": 9.0,
+      "score_rationale": "Publication-ready; the linked low-severity finding records bounded non-material headroom.",
       "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this line supports decolonization"}],
-      "finding_ids": []
+      "finding_ids": ["example-bounded-headroom"]
     },
     "engagement": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
-      "score": 10.0,
-      "score_rationale": "No engagement finding identifies a gap to 10.0.",
+      "score": 9.0,
+      "score_rationale": "Publication-ready; the linked low-severity finding records bounded non-material headroom.",
       "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this line supports engagement"}],
-      "finding_ids": []
+      "finding_ids": ["example-bounded-headroom"]
     },
     "tone": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
-      "score": 10.0,
-      "score_rationale": "No tone finding identifies a gap to 10.0.",
+      "score": 9.0,
+      "score_rationale": "Publication-ready; the linked low-severity finding records bounded non-material headroom.",
       "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this line supports tone"}],
-      "finding_ids": []
+      "finding_ids": ["example-bounded-headroom"]
     }
   },
   "alignment_audit": {
@@ -399,12 +408,12 @@ equal the statuses actually present in that array.
   ],
   "findings": [
     {
-      "id": "stable-kebab-id",
-      "issue_id": "STABLE_UPPERCASE_ISSUE_CLASS",
-      "category": "pedagogy|language|activity|factuality|grounding|decolonization|engagement|tone|rights|size|other",
-      "severity": "blocker|high|medium|low|info",
-      "message": "what is wrong and why it matters",
-      "evidence": "exact text plus source/tool support",
+      "id": "example-bounded-headroom",
+      "issue_id": "BOUNDED_NON_MATERIAL_HEADROOM",
+      "category": "other",
+      "severity": "low",
+      "message": "bounded improvement that does not block publication",
+      "evidence": "exact learner-visible text explaining the remaining headroom",
       "location": {"location": "repo-relative target file", "line": 1}
     }
   ]

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Core semantic post-build review prompt
 
-Semantic prompt version: `6.0.4`
+Semantic prompt version: `6.0.5`
 
 Apply this only to A1-C2 core tracks, after the common prompt.
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Seminar semantic post-build review prompt
 
-Semantic prompt version: `6.0.4`
+Semantic prompt version: `6.0.5`
 
 Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
 after the common prompt.

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -16,6 +16,27 @@ the only readiness gate; keep every post-build-review invocation read-only.
 Never run legacy LLM-QG, a separate deterministic audit, or a legacy content
 review as an operator completion gate.
 
+## Canonical entry paths
+
+New and existing modules use one lifecycle, not separate completion systems:
+
+- An `UNBUILT` module enters at `PLAN_REVIEW_REQUIRED`, advances through the
+  versioned plan/build stages, and then reaches `POST_BUILD_REVIEW_REQUIRED`.
+- A complete existing `BUILT` module enters directly at
+  `POST_BUILD_REVIEW_REQUIRED`; do not rebuild it merely because it already
+  exists. A stale preparation identity routes through the explicit rebuild
+  transition before returning to that same gate.
+- A `PARTIAL` module enters forensic recovery, records one complete build, and
+  then reaches the same post-build gate.
+
+From `POST_BUILD_REVIEW_REQUIRED` onward, every entry path uses the same
+versioned scorer, fail-closed categorical disposition, source-hash invalidation,
+automated repair loop, independent cross-family review, publication, and
+rendered deployment verification. A repair never patches only the review
+artifact: record the owning source change and rerun a fresh canonical review.
+An unchanged existing module with a current PASS remains idempotent and must not
+be rebuilt or republished without a terminal-goal reason.
+
 ## Start or resume
 
 1. Preserve the legacy parity boundary documented below. Post-build review v5
@@ -225,8 +246,8 @@ The repository-backed feature audit has these binding dispositions:
 | Pedagogical, naturalness, decolonization, engagement, tone; scaffolding/leakage canaries; Ukrainian/factual/decolonization/media evidence | ABSORB into post-build prompt v4, schema, strict normalizer, and regression tests |
 | Deterministic surface/activity/vocabulary/resource/route/size checks | ABSORB through post-build preparation; never invoke separately |
 | Author lineage, repairability, freshness, bounded correction, and stability | REPLACE with ledger identities, deterministic owners, fresh review, and `REVIEWER_INSTABILITY` |
-| Schema-bound, evidence-backed in-result diagnostic dimension scores and a reporting-only minimum | ACCEPT; categorical semantic and deterministic gates remain authoritative |
-| Numeric score authority, numeric readiness thresholds, score sidecars, score-based disposition, warning demotion, parser salvage, merged retries, DB/mtime readiness, same-route median independence | REJECT |
+| Schema-bound, evidence-backed in-result diagnostic dimension scores and a reporting-only minimum | ACCEPT; categorical semantic and deterministic gates remain authoritative, with `PASS` calibrated to `9.0+` per dimension |
+| Numeric averages, score sidecars, a minimum-score shortcut around categorical evidence, warning demotion, parser salvage, merged retries, DB/mtime readiness, same-route median independence | REJECT |
 | Canary calibration, cost/circuit experiments, deep-read evaluation, and V7's internal LLM-QG while it remains | RETAIN-EVAL only; none can complete the outer state machine |
 
 Before deprecating separate operator invocation, tests must prove current and

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -1656,6 +1656,7 @@ def _validate_quality_dimension_score(
     status: str,
     score: object,
     score_rationale: object,
+    dimension_evidence: Sequence[Mapping[str, Any]],
     referenced_findings: Sequence[Mapping[str, Any]],
 ) -> None:
     """Enforce score/status calibration from structure, never by repairing text."""
@@ -1671,7 +1672,9 @@ def _validate_quality_dimension_score(
             f"{label} and score_rationale are required when the status is {status}"
         )
     decimal_score = _decimal_score(score, label)
-    _nonempty_string(score_rationale, f"Quality dimension {dimension} score_rationale")
+    rationale = _nonempty_string(
+        score_rationale, f"Quality dimension {dimension} score_rationale"
+    )
     lower, upper, includes_upper = QUALITY_DIMENSION_SCORE_BANDS[status]
     if decimal_score < lower or decimal_score > upper or (
         decimal_score == upper and not includes_upper
@@ -1680,10 +1683,24 @@ def _validate_quality_dimension_score(
         raise ReviewProtocolError(
             f"{label} {decimal_score} is inconsistent with {status}; expected [{lower}, {upper}{upper_marker}"
         )
-    if decimal_score == Decimal("10.0") and referenced_findings:
-        raise ReviewProtocolError(
-            f"Quality dimension {dimension} score 10.0 requires no dimension findings"
-        )
+    if decimal_score == Decimal("10.0"):
+        if referenced_findings:
+            raise ReviewProtocolError(
+                f"Quality dimension {dimension} score 10.0 requires no dimension findings"
+            )
+        distinct_locations = {
+            str(item.get("location") or "").strip()
+            for item in dimension_evidence
+            if str(item.get("location") or "").strip()
+        }
+        if len(distinct_locations) < 2:
+            raise ReviewProtocolError(
+                f"Quality dimension {dimension} score 10.0 requires two distinct positive evidence anchors"
+            )
+        if re.search(r"\b(exceptional|винятков\w*)\b", rationale, re.IGNORECASE) is None:
+            raise ReviewProtocolError(
+                f"Quality dimension {dimension} score 10.0 requires a positive exceptional-quality rationale"
+            )
     if decimal_score < Decimal("10.0"):
         if not referenced_findings:
             raise ReviewProtocolError(
@@ -2462,6 +2479,7 @@ def normalize_semantic_result(
             status=dimension_status,
             score=raw["score"],
             score_rationale=raw["score_rationale"],
+            dimension_evidence=dimension_evidence,
             referenced_findings=referenced_findings,
         )
         if raw["score"] is not None and Decimal(str(raw["score"])) < Decimal("10.0"):
@@ -3125,6 +3143,7 @@ def _validate_normalized_quality_dimensions(
                 status=status,
                 score=assessment["score"],
                 score_rationale=assessment["score_rationale"],
+                dimension_evidence=assessment["evidence"],
                 referenced_findings=[findings_by_id[finding_id] for finding_id in finding_ids],
             )
         if status != "PASS":
@@ -3470,10 +3489,22 @@ def validate_result(
     validated_versions = {"post-build-review.result.v3", *scored_versions}
     if schema_version not in validated_versions:
         return
+    current_policy = load_track_policy(
+        repo_root / POLICY_PATH.relative_to(PROJECT_ROOT), repo_root=repo_root
+    )
+    current_score_contract = schema_version == CURRENT_RESULT_SCHEMA_VERSION and all(
+        str(result.get(field)) == str(current_policy[field])
+        for field in (
+            "review_protocol_version",
+            "deterministic_contract_version",
+            "semantic_prompt_version",
+            "track_policy_version",
+        )
+    )
     deterministic_findings = _deterministic_findings(result)
     _validate_normalized_quality_dimensions(
         result["semantic"],
-        scores_required=schema_version in scored_versions,
+        scores_required=current_score_contract,
         ownership_required=schema_version in scored_versions,
         external_findings=(
             deterministic_findings

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -24,7 +24,10 @@ REGRESSIONS = FIXTURES / "regressions.v1.yaml"
 CORE_EXEMPLAR = FIXTURES / "core-semantic-exemplar.v1.json"
 SCORE_CALIBRATION = FIXTURES / "score-calibration.v1.yaml"
 SYNTHETIC_PATH = "tests/fixtures/post_build_review.md"
-SYNTHETIC_TEXT = "Synthetic quality-dimension evidence for the review contract.\n"
+SYNTHETIC_TEXT = (
+    "Synthetic quality-dimension evidence for the review contract.\n"
+    "A second independent anchor supports exceptional-score validation.\n"
+)
 
 
 def _synthetic_statement_inventory() -> dict:
@@ -94,36 +97,52 @@ def _finding_location(semantic: dict, dimension: str = "pedagogical") -> object:
 
 
 def _quality_dimensions(packet: dict | None = None) -> dict[str, dict[str, object]]:
-    location = f"{SYNTHETIC_PATH}:1"
-    excerpt = SYNTHETIC_TEXT.rstrip("\n")
+    evidence_rows = [
+        {
+            "location": SYNTHETIC_PATH,
+            "line": line_number,
+            "excerpt": text,
+        }
+        for line_number, text in enumerate(SYNTHETIC_TEXT.splitlines(), start=1)
+    ]
     materials = (packet or {}).get("target_materials", {})
     content_material = materials.get("content") if isinstance(materials, dict) else None
     if isinstance(content_material, dict):
         content_path = content_material["path"]
-        line = next(
-            item for item in content_material["lines"] if len(item["text"].strip()) >= 8
-        )
-        excerpt = line["text"]
-        location = f"{content_path}:{line['line']}"
+        lines = [item for item in content_material["lines"] if len(item["text"].strip()) >= 8][
+            :2
+        ]
+        assert len(lines) == 2
+        evidence_rows = [
+            {
+                "location": content_path,
+                "line": line["line"],
+                "excerpt": line["text"],
+            }
+            for line in lines
+        ]
     packet_bound = isinstance(content_material, dict)
     return {
         dimension: {
             "status": "PASS",
             "score": 10.0,
-            "score_rationale": "No evidence-backed finding identifies a gap to 10.0.",
-            "evidence": ([
+            "score_rationale": (
+                f"Two independent anchors demonstrate exceptional {dimension} quality."
+            ),
+            "evidence": [
                 {
-                    "location": location.rsplit(":", 1)[0],
-                    "line": int(location.rsplit(":", 1)[1]),
+                    **(
+                        {"location": row["location"], "line": row["line"]}
+                        if packet_bound
+                        else {
+                            "location": f"{row['location']}:{row['line']}",
+                            "excerpt": row["excerpt"],
+                        }
+                    ),
                     "supports": f"This line supports the {dimension} assessment.",
                 }
-            ] if packet_bound else [
-                {
-                    "location": location,
-                    "excerpt": excerpt,
-                    "supports": f"This line supports the {dimension} assessment.",
-                }
-            ]),
+                for row in evidence_rows
+            ],
             "finding_ids": [],
         }
         for dimension in pbr.QUALITY_DIMENSIONS
@@ -732,9 +751,9 @@ def test_score_calibration_fixture_validates_anchored_cases_and_comparability(
         "INCOMPLETE": None,
     }
     assert calibration["score_anchors"] == {
-        "10.0": "no dimension findings",
-        "[9.0, 10.0)": "quality target with bounded low-severity headroom",
-        "[8.0, 9.0)": "release-safe with a concrete low-severity improvement",
+        "10.0": "exceptional positive quality with two independent evidence anchors and no findings",
+        "[9.0, 10.0)": "publication target with bounded low-severity improvement backlog",
+        "[8.0, 9.0)": "strong base with a material revision before publication",
         "[7.0, 8.0)": "focused material revision while most of the dimension remains strong",
         "[6.0, 7.0)": "substantial material defect requiring broader revision",
         "[4.0, 6.0)": "blocking defect with some usable evidence",
@@ -795,10 +814,12 @@ def test_effective_prompt_names_the_closed_pass_band_without_half_open_claim(
 ) -> None:
     prompt = bilash_packet["semantic_prompt"]
 
-    assert "`PASS` `[8.0, 10.0]`" in prompt
-    assert "`REVISE` `[6.0, 8.0)`" in prompt
+    assert "`PASS` `[9.0, 10.0]`" in prompt
+    assert "`REVISE` `[6.0, 9.0)`" in prompt
     assert "`BLOCK` `[0.0, 6.0)`" in prompt
     assert "half-open bands" not in prompt
+    assert prompt.count('"score": 9.0') == len(pbr.QUALITY_DIMENSIONS)
+    assert '"score": 10.0' not in prompt
 
 
 @pytest.mark.parametrize(
@@ -820,7 +841,7 @@ def test_effective_prompt_names_the_closed_pass_band_without_half_open_claim(
                     },
                 ),
                 semantic["quality_dimensions"]["pedagogical"].update(
-                    {"status": "REVISE", "score": 8.0, "finding_ids": ["band-mismatch"]}
+                    {"status": "REVISE", "score": 9.0, "finding_ids": ["band-mismatch"]}
                 ),
             ),
             "inconsistent with REVISE",
@@ -867,6 +888,31 @@ def test_effective_prompt_names_the_closed_pass_band_without_half_open_claim(
             "score 10.0 requires no dimension findings",
         ),
         (
+            "below-publication-floor pass",
+            lambda semantic: (
+                _append_finding(
+                    semantic,
+                    {
+                        "id": "below-publication-floor",
+                        "issue_id": "BELOW_PUBLICATION_FLOOR",
+                        "category": "pedagogy",
+                        "severity": "low",
+                        "message": "The dimension remains below the publication target.",
+                        "evidence": "Synthetic evidence-backed headroom.",
+                        "location": _finding_location(semantic),
+                    },
+                ),
+                semantic["quality_dimensions"]["pedagogical"].update(
+                    {
+                        "score": 8.9,
+                        "score_rationale": "The linked gap leaves the dimension below 9.0.",
+                        "finding_ids": ["below-publication-floor"],
+                    }
+                ),
+            ),
+            "inconsistent with PASS",
+        ),
+        (
             "orphan material finding",
             lambda semantic: _append_finding(
                 semantic,
@@ -906,7 +952,7 @@ def test_invalid_dimension_scores_fail_closed_without_repair(
     )
 
 
-def test_minimum_dimension_score_is_reporting_only_not_a_disposition_input(
+def test_minimum_dimension_score_preserves_pass_backlog_without_averaging(
     bilash_packet: dict,
 ) -> None:
     baseline = pbr.finalize_review(
@@ -926,7 +972,7 @@ def test_minimum_dimension_score_is_reporting_only_not_a_disposition_input(
     )
     semantic["quality_dimensions"]["pedagogical"].update(
         {
-            "score": 8.0,
+            "score": 9.0,
             "score_rationale": "The low-severity gap prevents a 10.0 pedagogical score.",
             "finding_ids": ["reporting-only-low-gap"],
         }
@@ -934,8 +980,38 @@ def test_minimum_dimension_score_is_reporting_only_not_a_disposition_input(
 
     result = pbr.finalize_review(bilash_packet, _raw(semantic))
 
-    assert result["minimum_dimension_score"] == 8.0
+    assert result["minimum_dimension_score"] == 9.0
     assert result["combined_disposition"] == baseline["combined_disposition"]
+
+
+def test_perfect_score_requires_positive_exceptional_rationale(
+    bilash_packet: dict,
+) -> None:
+    semantic = _passing_semantic(bilash_packet)
+    semantic["quality_dimensions"]["pedagogical"]["score_rationale"] = (
+        "No pedagogical finding identifies a gap to 10.0."
+    )
+
+    result = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert result["semantic_response"]["contract_status"] == "invalid"
+    assert "positive exceptional-quality rationale" in result["semantic_response"]["error"]
+    assert result["combined_disposition"]["status"] == "INCOMPLETE"
+
+
+def test_perfect_score_requires_two_distinct_positive_evidence_anchors(
+    bilash_packet: dict,
+) -> None:
+    semantic = _passing_semantic(bilash_packet)
+    semantic["quality_dimensions"]["pedagogical"]["evidence"] = semantic[
+        "quality_dimensions"
+    ]["pedagogical"]["evidence"][:1]
+
+    result = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert result["semantic_response"]["contract_status"] == "invalid"
+    assert "two distinct positive evidence anchors" in result["semantic_response"]["error"]
+    assert result["combined_disposition"]["status"] == "INCOMPLETE"
 
 
 def test_minimum_dimension_score_mismatch_fails_even_with_recomputed_key(
@@ -954,6 +1030,32 @@ def test_minimum_dimension_score_mismatch_fails_even_with_recomputed_key(
 
     with pytest.raises(pbr.ReviewProtocolError, match="minimum_dimension_score"):
         pbr.validate_result(result)
+
+
+def test_historical_scored_result_does_not_reapply_current_calibration(
+    bilash_packet: dict,
+) -> None:
+    result = pbr.finalize_review(
+        bilash_packet, _raw(_passing_semantic(bilash_packet))
+    )
+    result.update(
+        {
+            "review_protocol_version": "6.0.3",
+            "semantic_prompt_version": "6.0.4",
+            "track_policy_version": "2.0.1",
+        }
+    )
+    dimension = result["semantic"]["quality_dimensions"]["pedagogical"]
+    dimension["score_rationale"] = "No pedagogical finding identifies a gap to 10.0."
+    dimension["evidence"] = dimension["evidence"][:1]
+    reproducible = {
+        key: copy.deepcopy(result[key]) for key in pbr.REPRODUCIBILITY_FIELDS
+    }
+    result["reproducibility_key"] = pbr.sha256_text(
+        pbr._stable_json(reproducible)
+    )
+
+    pbr.validate_result(result)
 
 
 def test_claim_only_owned_finding_preserves_perfect_dimension_vector(
@@ -1748,12 +1850,16 @@ def test_provider_line_locator_hydrates_exact_unicode_excerpt() -> None:
         if "пам’яті опору" in text
     )
     for dimension in semantic["quality_dimensions"].values():
+        second_anchor = next(
+            item for item in dimension["evidence"] if item["line"] != line
+        )
         dimension["evidence"] = [
             {
                 "location": content_path,
                 "line": line,
                 "supports": "This exact line supports the dimension assessment.",
-            }
+            },
+            second_anchor,
         ]
 
     hydrated = pbr.hydrate_provider_dimension_evidence(semantic, packet)
@@ -1778,12 +1884,16 @@ def test_finalize_accepts_provider_line_locators_and_preserves_exact_excerpt() -
         if "пам’яті опору" in text
     )
     for dimension in semantic["quality_dimensions"].values():
+        second_anchor = next(
+            item for item in dimension["evidence"] if item["line"] != line
+        )
         dimension["evidence"] = [
             {
                 "location": content_path,
                 "line": line,
                 "supports": "This exact line supports the dimension assessment.",
-            }
+            },
+            second_anchor,
         ]
 
     result = pbr.finalize_review(packet, _raw(semantic))
@@ -2577,7 +2687,9 @@ def test_prompt_requires_exhaustive_learner_level_and_alignment_audit() -> None:
         "VOCABULARY_INTEGRATION",
         "Mandatory seven-class alignment audit",
         "A synonym, reversed phrase, or",
-        "must be below `8.0`",
+        "must be below `9.0`",
+        "`10.0` is exceptional",
+        "non-blocking improvement",
         "return the exact repo-relative",
         "at least eight non-whitespace",
         "exact locator belongs to a supplied deterministic",
@@ -3621,8 +3733,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "6.0.4"
-    assert len(rows) == 72
+    assert catalog["catalog_version"] == "6.0.5"
+    assert len(rows) == 75
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -3644,6 +3756,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "1.9.0",
         "2.0.0",
         "2.0.1",
+        "2.1.0",
         "3.0.0",
         "4.0.0",
         "4.1.2",
@@ -3663,6 +3776,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "6.0.2",
         "6.0.3",
         "6.0.4",
+        "6.0.5",
     }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 6.0.4
+catalog_version: 6.0.5
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -464,3 +464,34 @@ regressions:
     expected: >-
       Tell the reviewer explicitly that CLEAR requires an empty finding_ids
       array and FOUND or INCOMPLETE requires one or more correctly owned IDs.
+  - bug_id: pass-band-admitted-score-below-publication-target
+    responsible_layer: track_policy
+    fixed_in_version: 2.1.0
+    version_field: track_policy_version
+    input: >-
+      A dimension receives 8.0–8.9 while its categorical status remains PASS,
+      even though the documented publication-quality target is 9.0.
+    expected: >-
+      Calibrate PASS to [9.0, 10.0] and REVISE to [6.0, 9.0), preserving the
+      categorical fail-closed disposition rather than introducing an average.
+  - bug_id: no-findings-defaulted-every-dimension-to-perfect
+    responsible_layer: semantic_prompt
+    fixed_in_version: 6.0.5
+    version_field: semantic_prompt_version
+    input: >-
+      The reviewer finds no material defect and copies five 10.0 scores from
+      the response example without identifying exceptional positive evidence.
+    expected: >-
+      Use 9.x PASS examples with a bounded low/info improvement backlog, and
+      reserve 10.0 for explicitly justified exceptional quality.
+  - bug_id: perfect-score-lacked-independent-positive-anchors
+    responsible_layer: disposition
+    fixed_in_version: 6.0.4
+    version_field: review_protocol_version
+    input: >-
+      A dimension claims 10.0 from one generic compliment or from the absence
+      of linked findings.
+    expected: >-
+      Reject the response unless the dimension has no linked findings, cites
+      at least two distinct positive evidence anchors, and gives a positive
+      exceptional-quality rationale.

--- a/tests/fixtures/post_build_review/score-calibration.v1.yaml
+++ b/tests/fixtures/post_build_review/score-calibration.v1.yaml
@@ -1,31 +1,31 @@
 fixture_version: score-calibration.v1
 score_bands:
-  PASS: "[8.0, 10.0]"
-  REVISE: "[6.0, 8.0)"
+  PASS: "[9.0, 10.0]"
+  REVISE: "[6.0, 9.0)"
   BLOCK: "[0.0, 6.0)"
   INCOMPLETE: null
 score_anchors:
-  "10.0": no dimension findings
-  "[9.0, 10.0)": quality target with bounded low-severity headroom
-  "[8.0, 9.0)": release-safe with a concrete low-severity improvement
+  "10.0": exceptional positive quality with two independent evidence anchors and no findings
+  "[9.0, 10.0)": publication target with bounded low-severity improvement backlog
+  "[8.0, 9.0)": strong base with a material revision before publication
   "[7.0, 8.0)": focused material revision while most of the dimension remains strong
   "[6.0, 7.0)": substantial material defect requiring broader revision
   "[4.0, 6.0)": blocking defect with some usable evidence
   "[0.0, 4.0)": fundamentally unusable, unsafe, or unsupported
 cases:
-  - id: pass-lower-bound-backed-backlog
+  - id: revise-strong-but-below-publication-floor
     dimension: pedagogical
-    verdict: PASS
+    verdict: REVISE
     assessment:
-      status: PASS
+      status: REVISE
       score: 8.0
-      score_rationale: A low-severity pedagogical finding leaves a concrete gap to 10.0.
+      score_rationale: A material pedagogical finding leaves a concrete gap before publication.
     finding:
-      id: low-pedagogy-gap
+      id: material-pedagogy-gap
       issue_id: PEDAGOGICAL_CLARITY_GAP
       category: pedagogy
-      severity: low
-      message: One instruction could clarify its next learner action.
+      severity: medium
+      message: One instruction omits the next learner action required for completion.
       evidence: The task omits an explicit next action.
       location: tests/fixtures/post_build_review:1
     expected:
@@ -55,7 +55,7 @@ cases:
     assessment:
       status: PASS
       score: 10.0
-      score_rationale: No naturalness finding identifies a gap to 10.0.
+      score_rationale: Two independent anchors demonstrate exceptional naturalness across exposition and instructions.
     finding: null
     expected:
       valid: true
@@ -83,8 +83,8 @@ cases:
     verdict: REVISE
     assessment:
       status: REVISE
-      score: 7.9
-      score_rationale: A medium tone finding leaves a narrow but concrete gap to 10.0.
+      score: 8.9
+      score_rationale: A medium tone finding leaves a narrow but material gap before publication.
     finding:
       id: tone-revision
       issue_id: TONE_REGISTER_GAP
@@ -95,7 +95,7 @@ cases:
       location: tests/fixtures/post_build_review:1
     expected:
       valid: true
-      minimum_dimension_score: 7.9
+      minimum_dimension_score: 8.9
   - id: revise-focused-anchor
     dimension: naturalness
     verdict: REVISE
@@ -224,10 +224,10 @@ cases:
       documented_semantic_cap: 6.0
 comparability:
   - id: identical-review-identity-is-comparable
-    left: [6.0.4, fixture, fixture-model, high]
-    right: [6.0.4, fixture, fixture-model, high]
+    left: [6.0.5, fixture, fixture-model, high]
+    right: [6.0.5, fixture, fixture-model, high]
     expected: true
   - id: prompt-or-reviewer-identity-drift-is-not-comparable
-    left: [6.0.4, fixture, fixture-model, high]
-    right: [6.0.3, google, gemini-3.1-pro, high]
+    left: [6.0.5, fixture, fixture-model, high]
+    right: [6.0.4, google, gemini-3.1-pro, high]
     expected: false

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -257,6 +257,7 @@ def _result(
             "effort": "high",
             "capabilities": ["text"],
         },
+        "semantic_response": {"raw_sha256": "3" * 64},
         "findings": findings,
         "combined_disposition": {"status": status},
     }
@@ -381,6 +382,82 @@ def test_resolution_covers_core_and_seminar_built_unbuilt_partial(
     assert not ledger_root.exists()
     with pytest.raises(tc.CompletionError, match="not active"):
         tc.inspect_target("retired/ghost", repo_root=repo, config_path=config_path)
+
+
+def test_new_and_existing_modules_converge_on_the_same_post_build_gate(
+    fake_repo: tuple[Path, Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, config_path, ledger_root = fake_repo
+    _, existing = _start(fake_repo, "a1/core-built")
+    _, new = _start(fake_repo, "a1/core-unbuilt")
+    assert existing["state"] == "POST_BUILD_REVIEW_REQUIRED"
+    assert new["state"] == "PLAN_REVIEW_REQUIRED"
+
+    plan_evidence = tmp_path / "new-plan-review.json"
+    plan_evidence.write_text('{"verdict":"PASS"}\n', encoding="utf-8")
+    _, new = tc.record_plan_review(
+        "a1/core-unbuilt",
+        run_id=new["run"]["run_id"],
+        verdict="PASS",
+        evidence=plan_evidence,
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+    _write_bundle(
+        repo,
+        "a1",
+        "core-unbuilt",
+        "# Новий модуль\n\nЗавершений навчальний текст.\n",
+    )
+    _, new = tc.record_build(
+        "a1/core-unbuilt",
+        run_id=new["run"]["run_id"],
+        author_family="codex",
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+    assert new["state"] == "POST_BUILD_REVIEW_REQUIRED"
+
+    existing_snapshot = tc.resolve_target(
+        "a1/core-built", repo_root=repo, config=tc.load_config(config_path)
+    )
+    new_snapshot = tc.resolve_target(
+        "a1/core-unbuilt", repo_root=repo, config=tc.load_config(config_path)
+    )
+    existing_result_path = _result_file(tmp_path, "existing-post-build-pass.json")
+    new_result_path = _result_file(tmp_path, "new-post-build-pass.json")
+    results = {
+        existing_result_path: _result(existing_snapshot, repo, status="PASS"),
+        new_result_path: _result(new_snapshot, repo, status="PASS"),
+    }
+    monkeypatch.setattr(tc, "_load_post_build_result", lambda path: results[path])
+
+    _, existing = tc.record_review(
+        "a1/core-built",
+        run_id=existing["run"]["run_id"],
+        result_path=existing_result_path,
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+    _, new = tc.record_review(
+        "a1/core-unbuilt",
+        run_id=new["run"]["run_id"],
+        result_path=new_result_path,
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+
+    assert existing["reviews"][-1]["status"] == "PASS"
+    assert new["reviews"][-1]["status"] == "PASS"
+    assert existing["state"] == "AWAITING_PRODUCTION_QG_ARMING"
+    assert new["state"] == "INDEPENDENT_REVIEW_REQUIRED"
+    assert new["author_families"] == ["codex"]
 
 
 def test_certification_config_rejects_retired_track_selector(


### PR DESCRIPTION
## Summary
- raises the canonical per-dimension publication floor to 9.0 while preserving the categorical fail-closed gate
- makes 10.0 exceptional: it requires zero linked findings, at least two distinct positive evidence anchors, and an explicit exceptional-quality rationale
- preserves evidence-backed low/info findings as the improvement backlog for 9.x PASS scores
- documents and tests one canonical post-build gate for both existing/built and new/unbuilt modules
- keeps historical review artifacts reproducible but prevents stale versions from becoming current lifecycle authority

## Versioned contract
- review protocol: 6.0.4
- semantic prompt: 6.0.5
- track policy: 2.1.0

## Verification
- 212 post-build review, track-completion, and threshold-source tests passed
- ruff passed
- YAML parsing passed
- git diff --check passed
- agent-trailer audit passed
- exact-commit independent Gemini 3.1 Pro High review: PASS, no material findings

No generated status, audit, review, or telemetry artifacts are included.
