### PR TITLE
fix(lifecycle): refresh scorer after review

### DIFF
--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -162,6 +162,11 @@ reviewer family, exact evidence artifact, and `PASS`. Resolve requested changes,
 record `CHANGES_REQUESTED` with its deterministic `--owner-kind`, resolve the
 repair, and rerun post-build review before trying again.
 
+If only the versioned audit workflow changes while this gate is pending, record
+that exact `audit_tooling` change. The helper requires unchanged learner hashes
+and returns the module to `POST_BUILD_REVIEW_REQUIRED`; stale review evidence
+must never remain authoritative merely because it had already reached this gate.
+
 Record both the process receipt and the strict `independent-review`
 certification artifact. Only the strict current artifact advances to
 `PUBLISH_REQUIRED`.

--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -955,7 +955,11 @@ def record_change(
             }
             workflow_only_audit_refresh = (
                 ledger["state"]
-                in {"POST_BUILD_REVIEW_REQUIRED", "AWAITING_PRODUCTION_QG_ARMING"}
+                in {
+                    "POST_BUILD_REVIEW_REQUIRED",
+                    "INDEPENDENT_REVIEW_REQUIRED",
+                    "AWAITING_PRODUCTION_QG_ARMING",
+                }
                 and owner_kind == "audit_tooling"
             )
             if ledger["state"] not in allowed_states and not workflow_only_audit_refresh:

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -1192,16 +1192,67 @@ def test_legacy_qg_sidecar_cannot_advance_completion(fake_repo: tuple[Path, Path
     assert "llm_qg" not in snapshot.observed_files
 
 
-def test_pending_review_accepts_only_workflow_only_audit_tooling_refresh(
-    fake_repo: tuple[Path, Path, Path], monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def _advance_built_module_to_pending_review_state(
+    fake_repo: tuple[Path, Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pending_state: str,
+) -> tuple[str, dict[str, Any]]:
     repo, config_path, ledger_root = fake_repo
     _, ledger = _start(fake_repo, "bio/seminar-built")
     run_id = ledger["run"]["run_id"]
+    if pending_state == "INDEPENDENT_REVIEW_REQUIRED":
+        workflow = repo / "workflow.txt"
+        workflow.write_text("workflow-before-review\n", encoding="utf-8")
+        _, ledger = tc.record_change(
+            "bio/seminar-built",
+            run_id=run_id,
+            owner_kind="audit_tooling",
+            author_family="codex",
+            summary="Bind the authored module to the pre-review workflow.",
+            repo_root=repo,
+            config_path=config_path,
+            ledger_root=ledger_root,
+        )
+        snapshot = tc.resolve_target(
+            "bio/seminar-built",
+            repo_root=repo,
+            config=tc.load_config(config_path),
+        )
+        passing = _result(snapshot, repo, status="PASS")
+        passing["semantic_response"] = {"raw_sha256": "f" * 64}
+        result_path = _result_file(tmp_path, "pending-review-pass.json")
+        monkeypatch.setattr(tc, "_load_post_build_result", lambda _path: passing)
+        _, ledger = tc.record_review(
+            "bio/seminar-built",
+            run_id=run_id,
+            result_path=result_path,
+            repo_root=repo,
+            config_path=config_path,
+            ledger_root=ledger_root,
+        )
+    assert ledger["state"] == pending_state
+    return run_id, ledger
+
+
+@pytest.mark.parametrize(
+    "pending_state",
+    ["POST_BUILD_REVIEW_REQUIRED", "INDEPENDENT_REVIEW_REQUIRED"],
+)
+def test_pending_review_states_accept_workflow_only_audit_tooling_refresh(
+    fake_repo: tuple[Path, Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pending_state: str,
+) -> None:
+    repo, config_path, ledger_root = fake_repo
+    run_id, ledger = _advance_built_module_to_pending_review_state(
+        fake_repo, tmp_path, monkeypatch, pending_state
+    )
     original_target_hashes = ledger["current_identity"]["target_hashes"]
 
     workflow = repo / "workflow.txt"
-    workflow.write_text("workflow-v2\n", encoding="utf-8")
+    workflow.write_text("workflow-refresh\n", encoding="utf-8")
     _, refreshed = tc.record_change(
         "bio/seminar-built",
         run_id=run_id,
@@ -1220,39 +1271,61 @@ def test_pending_review_accepts_only_workflow_only_audit_tooling_refresh(
     ]
     assert refreshed["history"][-1]["details"]["owner_kind"] == "audit_tooling"
 
-    content = repo / "curriculum/l2-uk-en/bio/seminar-built/module.md"
-    content.write_text(content.read_text(encoding="utf-8") + "Незаписана зміна.\n", encoding="utf-8")
-    workflow.write_text("workflow-v3\n", encoding="utf-8")
 
-    with pytest.raises(tc.CompletionError, match="unchanged target hashes"):
-        tc.record_change(
-            "bio/seminar-built",
-            run_id=run_id,
-            owner_kind="audit_tooling",
-            author_family="codex",
-            summary="Must not disguise learner-surface drift as review tooling.",
-            repo_root=repo,
-            config_path=config_path,
-            ledger_root=ledger_root,
+@pytest.mark.parametrize(
+    "pending_state",
+    ["POST_BUILD_REVIEW_REQUIRED", "INDEPENDENT_REVIEW_REQUIRED"],
+)
+@pytest.mark.parametrize(
+    ("drift_kind", "error"),
+    [
+        ("target", "unchanged target hashes"),
+        ("layout", "unchanged module layout and state"),
+        ("module_state", "unchanged module layout and state"),
+    ],
+)
+def test_pending_review_audit_refresh_rejects_non_workflow_drift(
+    fake_repo: tuple[Path, Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pending_state: str,
+    drift_kind: str,
+    error: str,
+) -> None:
+    repo, config_path, ledger_root = fake_repo
+    run_id, _ledger = _advance_built_module_to_pending_review_state(
+        fake_repo, tmp_path, monkeypatch, pending_state
+    )
+    (repo / "workflow.txt").write_text("workflow-refresh\n", encoding="utf-8")
+    if drift_kind == "target":
+        content = repo / "curriculum/l2-uk-en/bio/seminar-built/module.md"
+        content.write_text(
+            content.read_text(encoding="utf-8") + "Незаписана зміна.\n",
+            encoding="utf-8",
         )
+    else:
+        changed_value = "flat" if drift_kind == "layout" else "PARTIAL"
+        real_build_identity = tc.build_identity
 
-    real_build_identity = tc.build_identity
+        def drifted_identity(*args: object, **kwargs: object) -> dict[str, Any]:
+            identity = real_build_identity(*args, **kwargs)
+            identity[drift_kind] = changed_value
+            payload = {
+                key: identity[key]
+                for key in ("module_state", "layout", "target_hashes", "workflow_hashes")
+            }
+            identity["sha256"] = tc.sha256_bytes(tc.stable_json(payload).encode("utf-8"))
+            return identity
 
-    def relocated_identity(*args: object, **kwargs: object) -> dict[str, Any]:
-        identity = real_build_identity(*args, **kwargs)
-        identity["layout"] = "flat"
-        payload = {key: identity[key] for key in ("module_state", "layout", "target_hashes", "workflow_hashes")}
-        identity["sha256"] = tc.sha256_bytes(tc.stable_json(payload).encode("utf-8"))
-        return identity
+        monkeypatch.setattr(tc, "build_identity", drifted_identity)
 
-    monkeypatch.setattr(tc, "build_identity", relocated_identity)
-    with pytest.raises(tc.CompletionError, match="unchanged module layout and state"):
+    with pytest.raises(tc.CompletionError, match=error):
         tc.record_change(
             "bio/seminar-built",
             run_id=run_id,
             owner_kind="audit_tooling",
             author_family="codex",
-            summary="Must not disguise a layout migration as review tooling.",
+            summary="Must not disguise non-workflow drift as review tooling.",
             repo_root=repo,
             config_path=config_path,
             ledger_root=ledger_root,


### PR DESCRIPTION
## Summary
- allows a workflow-only `audit_tooling` refresh when a module has already reached `INDEPENDENT_REVIEW_REQUIRED`
- requires unchanged learner hashes, layout, and module state, then routes the module back through `POST_BUILD_REVIEW_REQUIRED`
- prevents stale post-build and independent-review evidence from remaining authoritative after a scorer version change
- documents the transition and exercises a real authored PASS trajectory in regression tests

## Verification
- 30/30 `tests/test_track_completion.py` tests passed
- target, layout, and module-state drift rejection covered from both `POST_BUILD_REVIEW_REQUIRED` and `INDEPENDENT_REVIEW_REQUIRED`
- ruff passed
- `git diff --check` passed
- agent-trailer audit passed
- exact-commit independent Gemini 3.1 Pro High review: PASS, zero material findings

No learner content or generated artifacts are included.
