### PR TITLE
fix(review): bind scored backlog evidence

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,6 +1,6 @@
 review_protocol_version: 6.0.4
 deterministic_contract_version: 2.0.0
-semantic_prompt_version: 6.0.5
+semantic_prompt_version: 6.0.6
 track_policy_version: 2.1.0
 
 score_calibration:

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Common semantic post-build review prompt
 
-Semantic prompt version: `6.0.5`
+Semantic prompt version: `6.0.6`
 
 ## Machine-response contract — read before any source or tool call
 
@@ -245,6 +245,12 @@ Apply the following anchored rubric within the bands:
   that dimension and its rationale must name the concrete gap to `10.0`.
   A `PASS` score may link only low/info findings; a score below `9.0` is never
   publication-ready and must use `REVISE` or `BLOCK` as its calibrated status.
+  At least one evidence entry for that dimension must repeat one linked
+  finding's exact primary locator: the identical repo-relative target path and
+  one-based line. Positive evidence elsewhere does not satisfy this relational
+  requirement. Before returning, compare each sub-`10.0` dimension's
+  `finding_ids` against the findings array and copy a linked finding's
+  `{location, line}` pair into that dimension's evidence.
 - Every semantic finding must be referenced by at least one quality dimension,
   contradicted/imprecise/unattested claim, or non-verified learner-evidence
   entry. A `10.0` attests that the dimension has no linked finding; it never
@@ -311,7 +317,7 @@ equal the statuses actually present in that array.
         {
           "location": "repo-relative target file",
           "line": 1,
-          "supports": "why this exact line supports the dimension assessment"
+          "supports": "why this linked finding line leaves bounded headroom below 10.0"
         }
       ],
       "finding_ids": ["example-bounded-headroom"]
@@ -320,28 +326,28 @@ equal the statuses actually present in that array.
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
       "score": 9.0,
       "score_rationale": "Publication-ready; the linked low-severity finding records bounded non-material headroom.",
-      "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this line supports naturalness"}],
+      "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this linked finding line leaves bounded naturalness headroom below 10.0"}],
       "finding_ids": ["example-bounded-headroom"]
     },
     "decolonization": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
       "score": 9.0,
       "score_rationale": "Publication-ready; the linked low-severity finding records bounded non-material headroom.",
-      "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this line supports decolonization"}],
+      "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this linked finding line leaves bounded decolonization headroom below 10.0"}],
       "finding_ids": ["example-bounded-headroom"]
     },
     "engagement": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
       "score": 9.0,
       "score_rationale": "Publication-ready; the linked low-severity finding records bounded non-material headroom.",
-      "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this line supports engagement"}],
+      "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this linked finding line leaves bounded engagement headroom below 10.0"}],
       "finding_ids": ["example-bounded-headroom"]
     },
     "tone": {
       "status": "PASS|REVISE|BLOCK|INCOMPLETE",
       "score": 9.0,
       "score_rationale": "Publication-ready; the linked low-severity finding records bounded non-material headroom.",
-      "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this line supports tone"}],
+      "evidence": [{"location": "repo-relative target file", "line": 1, "supports": "why this linked finding line leaves bounded tone headroom below 10.0"}],
       "finding_ids": ["example-bounded-headroom"]
     }
   },

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Core semantic post-build review prompt
 
-Semantic prompt version: `6.0.5`
+Semantic prompt version: `6.0.6`
 
 Apply this only to A1-C2 core tracks, after the common prompt.
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Seminar semantic post-build review prompt
 
-Semantic prompt version: `6.0.5`
+Semantic prompt version: `6.0.6`
 
 Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
 after the common prompt.

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -984,6 +984,43 @@ def test_minimum_dimension_score_preserves_pass_backlog_without_averaging(
     assert result["combined_disposition"] == baseline["combined_disposition"]
 
 
+def test_subperfect_score_requires_linked_finding_locator_in_dimension_evidence(
+    bilash_packet: dict,
+) -> None:
+    semantic = _passing_semantic(bilash_packet)
+    content = bilash_packet["target_materials"]["content"]
+    uncited_line = [
+        line for line in content["lines"] if len(line["text"].strip()) >= 8
+    ][2]
+    semantic["findings"].append(
+        {
+            "id": "unanchored-low-gap",
+            "issue_id": "UNANCHORED_LOW_GAP",
+            "category": "pedagogy",
+            "severity": "low",
+            "message": "A low-severity gap remains outside the cited positive anchors.",
+            "evidence": "Synthetic evidence-backed low gap.",
+            "location": {
+                "location": content["path"],
+                "line": uncited_line["line"],
+            },
+        }
+    )
+    semantic["quality_dimensions"]["pedagogical"].update(
+        {
+            "score": 9.0,
+            "score_rationale": "The linked gap prevents a 10.0 pedagogical score.",
+            "finding_ids": ["unanchored-low-gap"],
+        }
+    )
+
+    result = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert result["semantic_response"]["contract_status"] == "invalid"
+    assert "must share an exact locator" in result["semantic_response"]["error"]
+    assert result["combined_disposition"]["status"] == "INCOMPLETE"
+
+
 def test_perfect_score_requires_positive_exceptional_rationale(
     bilash_packet: dict,
 ) -> None:
@@ -2690,6 +2727,7 @@ def test_prompt_requires_exhaustive_learner_level_and_alignment_audit() -> None:
         "must be below `9.0`",
         "`10.0` is exceptional",
         "non-blocking improvement",
+        "identical repo-relative target path and",
         "return the exact repo-relative",
         "at least eight non-whitespace",
         "exact locator belongs to a supplied deterministic",
@@ -3733,8 +3771,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "6.0.5"
-    assert len(rows) == 75
+    assert catalog["catalog_version"] == "6.0.6"
+    assert len(rows) == 76
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -3777,6 +3815,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "6.0.3",
         "6.0.4",
         "6.0.5",
+        "6.0.6",
     }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 6.0.5
+catalog_version: 6.0.6
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -495,3 +495,14 @@ regressions:
       Reject the response unless the dimension has no linked findings, cites
       at least two distinct positive evidence anchors, and gives a positive
       exceptional-quality rationale.
+  - bug_id: subperfect-score-omitted-linked-finding-locator
+    responsible_layer: semantic_prompt
+    fixed_in_version: 6.0.6
+    version_field: semantic_prompt_version
+    input: >-
+      A reviewer assigns a 9.x score and links a low-severity finding, but the
+      dimension evidence cites only positive anchors elsewhere in the module.
+    expected: >-
+      Require the dimension evidence to repeat one linked finding's exact
+      target path and line so the numeric gap remains auditable and the
+      fail-closed validator can accept the response without repair.

--- a/tests/fixtures/post_build_review/score-calibration.v1.yaml
+++ b/tests/fixtures/post_build_review/score-calibration.v1.yaml
@@ -224,10 +224,10 @@ cases:
       documented_semantic_cap: 6.0
 comparability:
   - id: identical-review-identity-is-comparable
-    left: [6.0.5, fixture, fixture-model, high]
-    right: [6.0.5, fixture, fixture-model, high]
+    left: [6.0.6, fixture, fixture-model, high]
+    right: [6.0.6, fixture, fixture-model, high]
     expected: true
   - id: prompt-or-reviewer-identity-drift-is-not-comparable
-    left: [6.0.5, fixture, fixture-model, high]
+    left: [6.0.6, fixture, fixture-model, high]
     right: [6.0.4, google, gemini-3.1-pro, high]
     expected: false


### PR DESCRIPTION
## Summary\n- version semantic post-build prompt to 6.0.6\n- require every sub-10 quality dimension to reuse a linked finding's exact path:line locator\n- align all 9.x response examples with auditable backlog evidence\n- add a fail-closed regression fixture and packet-bound test\n\n## Why\nA real BIO-371 GPT-5.6 Sol response linked 9.x scores to low/info findings but cited only positive anchors in dimension evidence. The validator correctly returned INCOMPLETE; the prompt had omitted this relational constraint.\n\n## Verification\n- 182 tests passed: tests/audit/test_post_build_review.py\n- targeted amended-example tests: 2 passed\n- ruff passed\n- YAML parsing passed\n- git diff --check passed\n- exact predecessor review: Gemini 3.1 Pro High PASS, zero material findings; its one non-blocking consistency suggestion is implemented in the amended commit\n- amended exact-commit re-review is in progress and will gate auto-merge\n\nRelated: #5294