### PR TITLE
feat(practice): Chunk 4 practice-only matching pair coding

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: b54868bbd39a28b9884b3aaa5d9707dc94c9e93e5c670a154295e688b0f2b96d
+  components_sha256: f02c5f4b3e40d3f56b07dad41e0aaefd5e1baba47c5a41a48ecd2e864df9dbc0
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1164,7 +1164,7 @@ components:
         ukrainian_text: 'true'
       optional:
       - name: instruction
-        type: string
+        type: jsx
         description: Instruction shown to the learner above the activity.
         ukrainian_text: 'true'
       - name: isUkrainian
@@ -1172,6 +1172,10 @@ components:
         description: UI language flag for Ukrainian labels and feedback.
         ukrainian_text: 'false'
         default: false
+      - name: matchedPairCoding
+        type: '''semantic-four'''
+        description: Optional practice-only pair-coding mode.
+        ukrainian_text: 'false'
       - name: onComplete
         type: () => void
         description: onComplete prop.
@@ -1197,7 +1201,7 @@ components:
     example:
       pairs:
       - <MatchPair>
-      instruction: Приклад
+      instruction: <p>Приклад вмісту.</p>
     deprecated: false
     deprecation_reason: null
   MotifFormula:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2800,6 +2800,16 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/showdown": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.6.tgz",
@@ -4385,6 +4395,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -10487,6 +10504,9 @@
     "packages/activity-kit": {
       "name": "@learn-ukrainian/activity-kit",
       "version": "0.1.0",
+      "devDependencies": {
+        "@types/react": "^19.2.15"
+      },
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"

--- a/packages/activity-kit/package.json
+++ b/packages/activity-kit/package.json
@@ -21,6 +21,9 @@
     "react": ">=18",
     "react-dom": ">=18"
   },
+  "devDependencies": {
+    "@types/react": "^19.2.15"
+  },
   "scripts": {
     "generate:types": "node scripts/generate-types.mjs"
   }

--- a/packages/activity-kit/src/components/MatchUp.tsx
+++ b/packages/activity-kit/src/components/MatchUp.tsx
@@ -27,12 +27,17 @@ export interface MatchUpProps {
    * @schemaDescription Instruction shown to the learner above the activity.
    * @ukrainianText true
    */
-  instruction?: string;
+  instruction?: React.ReactNode;
   /**
    * @schemaDescription UI language flag for Ukrainian labels and feedback.
    * @ukrainianText false
    */
   isUkrainian?: boolean;
+  /**
+   * @schemaDescription Optional practice-only pair-coding mode.
+   * @ukrainianText false
+   */
+  matchedPairCoding?: 'semantic-four';
   onComplete?: () => void;
   onMatch?: (pairIndex: number, rating: 'again' | 'hard' | 'good') => void;
 }
@@ -45,6 +50,25 @@ const MATCH_PAIR_HUES = [
 ] as const;
 const MATCH_PAIR_COLOR_COUNT = MATCH_PAIR_HUES.length;
 
+const SEMANTIC_FOUR_TOKENS = [
+  { name: 'teal' },
+  { name: 'orange' },
+  { name: 'purple' },
+  { name: 'yellow' },
+] as const;
+
+const PAIR_CODING_CLASS = 'match-pair-coded';
+
+const MISSHAKE_TIMEOUT_MS = 240;
+
+/** Convert a 1-based match order to a circled digit string. Supports 1–50. */
+function circledNumber(n: number): string {
+  if (n >= 1 && n <= 20) return String.fromCodePoint(0x245f + n);
+  if (n >= 21 && n <= 35) return String.fromCodePoint(0x3250 + n);
+  if (n >= 36 && n <= 50) return String.fromCodePoint(0x32a0 + n);
+  return String(n);
+}
+
 type MatchPairStyle = React.CSSProperties & {
   '--match-pair-hue': string;
 };
@@ -54,10 +78,27 @@ const getMatchedPairStyle = (index: number, isMatched: boolean): MatchPairStyle 
   return { '--match-pair-hue': String(MATCH_PAIR_HUES[index % MATCH_PAIR_COLOR_COUNT]) };
 };
 
-export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, onMatch }: MatchUpProps) {
+const getSemanticTokenStyle = (pairIndex: number): React.CSSProperties | undefined => {
+  const token = SEMANTIC_FOUR_TOKENS[pairIndex % SEMANTIC_FOUR_TOKENS.length];
+  if (!token) return undefined;
+  return {
+    '--match-pair-token': token.name,
+  } as React.CSSProperties;
+};
+
+export default function MatchUp({
+  pairs,
+  instruction,
+  isUkrainian,
+  matchedPairCoding,
+  onComplete,
+  onMatch,
+}: MatchUpProps) {
   const [selectedLeft, setSelectedLeft] = useState<number | null>(null);
   const [matched, setMatched] = useState<Set<number>>(new Set());
   const matchedRef = useRef<Set<number>>(new Set());
+  const [matchedOrder, setMatchedOrder] = useState<Map<number, number>>(new Map());
+  const matchedOrderRef = useRef<Map<number, number>>(new Map());
   const [wrongPair, setWrongPair] = useState<{ left: number; right: number } | null>(null);
   const [misses, setMisses] = useState<Record<number, number>>({});
   const completedRef = useRef(false);
@@ -67,6 +108,8 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, o
     setSelectedLeft(null);
     setMatched(new Set());
     matchedRef.current = new Set();
+    setMatchedOrder(new Map());
+    matchedOrderRef.current = new Map();
     setWrongPair(null);
     setMisses({});
     completedRef.current = false;
@@ -90,11 +133,15 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, o
     if (selectedLeft === originalIndex) {
       // Correct match
       matchedRef.current.add(originalIndex);
+      const nextOrder = matchedRef.current.size;
+      matchedOrderRef.current = new Map(matchedOrderRef.current).set(originalIndex, nextOrder);
+
       const currentMisses = misses[selectedLeft] || 0;
       const rating = currentMisses === 0 ? 'good' : currentMisses === 1 ? 'hard' : 'again';
       onMatch?.(selectedLeft, rating);
 
       setMatched(new Set(matchedRef.current));
+      setMatchedOrder(new Map(matchedOrderRef.current));
       setSelectedLeft(null);
     } else {
       // Wrong match
@@ -106,7 +153,7 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, o
       setTimeout(() => {
         setWrongPair(null);
         setSelectedLeft(null);
-      }, 800);
+      }, MISSHAKE_TIMEOUT_MS);
     }
   };
 
@@ -120,6 +167,30 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, o
     }
     if (!allMatched) completedRef.current = false;
   }, [allMatched, onComplete]);
+
+  const pairTag = (originalIndex: number): string | null => {
+    if (matchedPairCoding !== 'semantic-four') return null;
+    const order = matchedOrder.get(originalIndex);
+    if (order === undefined) return null;
+    return circledNumber(order);
+  };
+
+  const pairAccessibleName = (originalIndex: number, side: 'left' | 'right'): string | undefined => {
+    if (matchedPairCoding !== 'semantic-four' || !matched.has(originalIndex)) return undefined;
+    const pair = pairs[originalIndex];
+    if (!pair) return undefined;
+    const order = matchedOrder.get(originalIndex);
+    const tag = order ? circledNumber(order) : '';
+    const partner = side === 'left' ? pair.right : pair.left;
+    if (isUkrainian) {
+      return `${pair.left} — ${pair.right}, пара ${tag}, з’єднано з ${partner}`;
+    }
+    return `${pair.left} — ${pair.right}, pair ${tag}, matched with ${partner}`;
+  };
+
+  const instructionId = `match-up-instruction-${Math.random().toString(36).slice(2)}`;
+  const progressRegionId = `match-up-progress-${Math.random().toString(36).slice(2)}`;
+
   const headerLabel = isUkrainian ? (
     <span lang="uk">Знайдіть пару</span>
   ) : (
@@ -147,26 +218,66 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, o
         <ActivityHelp activityType="match-up" isUkrainian={isUkrainian} />
       </div>
       {instruction && (
-        <p className={styles.instruction}><strong>{instruction}</strong></p>
+        <p
+          id={instructionId}
+          className={styles.instruction}
+          aria-live={matchedPairCoding === 'semantic-four' ? 'polite' : undefined}
+        >
+          <strong>{instruction}</strong>
+        </p>
       )}
-      <div className="matchUpContainer">
+      {matchedPairCoding === 'semantic-four' && (
+        <div
+          id={progressRegionId}
+          aria-live="polite"
+          style={{
+            position: 'absolute',
+            width: '1px',
+            height: '1px',
+            padding: 0,
+            margin: '-1px',
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            border: 0,
+          }}
+        >
+          {isUkrainian
+            ? `З’єднано ${matched.size} з ${pairs.length}`
+            : `Matched ${matched.size} of ${pairs.length}`}
+        </div>
+      )}
+      <div className="matchUpContainer" data-pair-coding={matchedPairCoding}>
         <div className="matchColumn" data-activity="match-left-column">
           {pairs.map((pair, index) => (
             <button
               key={`left-${index}`}
               className={`matchItem ${matched.has(index) ? 'matched' : ''} ${
                 selectedLeft === index ? 'selected' : ''
-              } ${wrongPair?.left === index ? 'wrong' : ''}`}
+              } ${wrongPair?.left === index ? 'wrong' : ''} ${
+                matchedPairCoding === 'semantic-four' && matched.has(index) ? PAIR_CODING_CLASS : ''
+              }`}
               data-activity="match-left-tile"
               data-matched={matched.has(index) ? 'true' : 'false'}
               data-pair-color={matched.has(index) ? index % MATCH_PAIR_COLOR_COUNT : undefined}
+              data-pair-coding={matchedPairCoding}
+              data-pair-token={matchedPairCoding === 'semantic-four' ? index % SEMANTIC_FOUR_TOKENS.length : undefined}
               data-selected={selectedLeft === index ? 'true' : 'false'}
+              data-original-index={index}
               aria-pressed={selectedLeft === index}
-              style={getMatchedPairStyle(index, matched.has(index))}
+              aria-label={pairAccessibleName(index, 'left')}
+              style={
+                matchedPairCoding === 'semantic-four'
+                  ? getSemanticTokenStyle(index)
+                  : getMatchedPairStyle(index, matched.has(index))
+              }
               onClick={() => handleLeftClick(index)}
               disabled={matched.has(index)}
             >
               {parseMarkdown(pair.left)}
+              {matchedPairCoding === 'semantic-four' && pairTag(index) ? (
+                <span className="matchPairTag" aria-hidden="true">{pairTag(index)}</span>
+              ) : null}
             </button>
           ))}
         </div>
@@ -176,16 +287,28 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, o
               key={`right-${displayIndex}`}
               className={`matchItem ${matched.has(originalIndex) ? 'matched' : ''} ${
                 wrongPair?.right === originalIndex ? 'wrong' : ''
+              } ${
+                matchedPairCoding === 'semantic-four' && matched.has(originalIndex) ? PAIR_CODING_CLASS : ''
               }`}
               data-activity="match-right-tile"
               data-matched={matched.has(originalIndex) ? 'true' : 'false'}
               data-original-index={originalIndex}
               data-pair-color={matched.has(originalIndex) ? originalIndex % MATCH_PAIR_COLOR_COUNT : undefined}
-              style={getMatchedPairStyle(originalIndex, matched.has(originalIndex))}
+              data-pair-coding={matchedPairCoding}
+              data-pair-token={matchedPairCoding === 'semantic-four' ? originalIndex % SEMANTIC_FOUR_TOKENS.length : undefined}
+              style={
+                matchedPairCoding === 'semantic-four'
+                  ? getSemanticTokenStyle(originalIndex)
+                  : getMatchedPairStyle(originalIndex, matched.has(originalIndex))
+              }
+              aria-label={pairAccessibleName(originalIndex, 'right')}
               onClick={() => handleRightClick(originalIndex)}
               disabled={matched.has(originalIndex)}
             >
               {parseMarkdown(pairs[originalIndex].right)}
+              {matchedPairCoding === 'semantic-four' && pairTag(originalIndex) ? (
+                <span className="matchPairTag" aria-hidden="true">{pairTag(originalIndex)}</span>
+              ) : null}
             </button>
           ))}
         </div>

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -2986,18 +2986,21 @@ function PracticeItem({
         </p>
       );
     }
-    const promptedPair = matchingPromptIndex === null ? null : pairs[matchingPromptIndex] ?? null;
+    const matchedCount = matchedPairIndexesRef.current.size;
+    const totalPairs = pairs.length;
     return (
       <div data-testid="practice-matching">
         <MatchUp
           key={selection.cardKey}
           pairs={pairs}
-          instruction={promptedPair ? (
-            showEnglishSubtitles
-              ? `Доберіть пару для «${promptedPair.left}» / Match the pair for «${promptedPair.left}»`
-              : `Доберіть пару для «${promptedPair.left}»`
-          ) : undefined}
+          instruction={(
+            <ChromeDual
+              uk={`Доберіть пари · ${matchedCount} з ${totalPairs}`}
+              en={`Match pairs · ${matchedCount} of ${totalPairs}`}
+            />
+          )}
           isUkrainian={!showEnglishSubtitles}
+          matchedPairCoding="semantic-four"
           onComplete={onMatchingComplete}
           onMatch={(pairIndex, rating) => {
             matchedPairIndexesRef.current.add(pairIndex);

--- a/site/src/components/MatchUp.tsx
+++ b/site/src/components/MatchUp.tsx
@@ -26,12 +26,17 @@ export interface MatchUpProps {
    * @schemaDescription Instruction shown to the learner above the activity.
    * @ukrainianText true
    */
-  instruction?: string;
+  instruction?: React.ReactNode;
   /**
    * @schemaDescription UI language flag for Ukrainian labels and feedback.
    * @ukrainianText false
    */
   isUkrainian?: boolean;
+  /**
+   * @schemaDescription Optional practice-only pair-coding mode.
+   * @ukrainianText false
+   */
+  matchedPairCoding?: 'semantic-four';
   onComplete?: () => void;
   onMatch?: (pairIndex: number, rating: 'again' | 'hard' | 'good') => void;
 }

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -796,12 +796,6 @@ const frontmatter = {
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--lu-primary) 35%, transparent);
   }
 
-  :global(.lexicon-practice-stage [data-matched="true"]) {
-    border-color: var(--lu-green);
-    background: var(--lu-state-correct-bg);
-    color: var(--lu-state-correct-fg);
-  }
-
   @media (max-width: 560px) {
     :global(.lexicon-practice-stage-bar) {
       align-items: stretch;

--- a/site/src/styles/match-up.css
+++ b/site/src/styles/match-up.css
@@ -73,10 +73,67 @@
   content: '';
 }
 
+/* Practice-only semantic-four pair coding.
+   Color families identify a pair, but the visible circled tag is the
+   non-color identity signal (WCAG 1.4.1). */
+.matchUpContainer[data-pair-coding='semantic-four'] .matchItem.matched {
+  --match-pair-bg: var(--lu-state-correct-bg);
+  --match-pair-border: var(--lu-green);
+  --match-pair-fg: var(--lu-text);
+
+  border-color: var(--match-pair-border);
+  background: var(--match-pair-bg);
+  color: var(--match-pair-fg);
+}
+
+.matchUpContainer[data-pair-coding='semantic-four'] .matchItem.matched[data-pair-token='0'] {
+  --match-pair-bg: var(--lu-teal-light);
+  --match-pair-border: var(--lu-teal);
+}
+
+.matchUpContainer[data-pair-coding='semantic-four'] .matchItem.matched[data-pair-token='1'] {
+  --match-pair-bg: var(--lu-orange-light);
+  --match-pair-border: var(--lu-orange);
+}
+
+.matchUpContainer[data-pair-coding='semantic-four'] .matchItem.matched[data-pair-token='2'] {
+  --match-pair-bg: var(--lu-purple-light);
+  --match-pair-border: var(--lu-purple);
+}
+
+.matchUpContainer[data-pair-coding='semantic-four'] .matchItem.matched[data-pair-token='3'] {
+  --match-pair-bg: var(--lu-yellow-light);
+  --match-pair-border: var(--lu-yellow-dark);
+}
+
+.matchColumn:first-child .matchItem.matched.match-pair-coded {
+  box-shadow: inset -4px 0 0 var(--match-pair-border);
+}
+
+.matchColumn:last-child .matchItem.matched.match-pair-coded {
+  box-shadow: inset 4px 0 0 var(--match-pair-border);
+}
+
+.matchPairTag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.45em;
+  height: 1.45em;
+  margin-inline-start: 0.5em;
+  border: 1.5px solid var(--match-pair-border);
+  border-radius: 999px;
+  background: var(--lu-surface-raised);
+  color: var(--match-pair-border);
+  font-size: 0.82em;
+  font-weight: 900;
+  line-height: 1;
+}
+
 .matchItem.wrong {
   border-color: var(--lu-state-wrong-fg);
   background: var(--lu-state-wrong-bg);
-  animation: shake 0.5s ease;
+  animation: shake 0.24s ease;
 }
 
 @keyframes shake {
@@ -85,20 +142,18 @@
     transform: translateX(0);
   }
 
-  20% {
-    transform: translateX(-8px);
-  }
-
-  40% {
-    transform: translateX(8px);
-  }
-
-  60% {
+  25% {
     transform: translateX(-6px);
   }
 
-  80% {
+  75% {
     transform: translateX(6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .matchItem.wrong {
+    animation: none;
   }
 }
 

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { State } from 'ts-fsrs';
 import { act, render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import LexiconPractice, { nextMatchingPromptIndex } from '@site/src/components/LexiconPractice';
+import LexiconPractice from '@site/src/components/LexiconPractice';
 import PracticeSessionSummary, { type SessionSummaryStats } from '@site/src/components/PracticeSessionSummary';
 import PracticeErrorBoundary from '@site/src/components/PracticeErrorBoundary';
 import {
@@ -2123,7 +2123,7 @@ describe('LexiconPractice', () => {
     };
   }
 
-  test('matching prompt advances in board order and clears after the final match', async () => {
+  test('matching progress updates after each match', async () => {
     const user = userEvent.setup();
     const deck = matchingDeck();
     const { container } = render(<LexiconPractice initialDeck={deck} autoStart initialMode="matching" />);
@@ -2140,17 +2140,78 @@ describe('LexiconPractice', () => {
       return { left, right };
     });
 
-    const initialPrompt = screen.getByText(/Доберіть пару для/);
-    expect(initialPrompt).toHaveTextContent(`«${pairs[0].left}»`);
+    const initialProgress = screen.getByText(/Доберіть пари/);
+    expect(initialProgress).toHaveTextContent('0 з 6');
 
     await user.click(within(leftColumn as HTMLElement).getByRole('button', { name: pairs[0].left }));
     await user.click(pairs[0].right!);
 
     await waitFor(() => {
-      expect(screen.getByText(/Доберіть пару для/)).toHaveTextContent(`«${pairs[1].left}»`);
+      expect(screen.getByText(/Доберіть пари/)).toHaveTextContent('1 з 6');
     });
+  });
 
-    expect(nextMatchingPromptIndex(2, new Set([0, 1, 2]), 3)).toBeNull();
+  test('matching practice opts into semantic-four pair coding', async () => {
+    const user = userEvent.setup();
+    const deck = matchingDeck();
+    const { container } = render(<LexiconPractice initialDeck={deck} autoStart initialMode="matching" />);
+
+    const leftCol = container.querySelector('[data-activity="match-left-column"]');
+    const rightCol = container.querySelector('[data-activity="match-right-column"]');
+    expect(leftCol).toBeInTheDocument();
+    expect(rightCol).toBeInTheDocument();
+
+    const findLeft = (text: string) => {
+      const btn = within(leftCol as HTMLElement).getAllByRole('button').find((b) => {
+        const tag = b.querySelector('.matchPairTag');
+        const content = tag ? b.textContent?.replace(tag.textContent ?? '', '') : b.textContent;
+        return content?.trim() === text;
+      });
+      if (!btn) throw new Error(`Left tile "${text}" not found`);
+      return btn;
+    };
+    const findRight = (text: string) => {
+      const btn = within(rightCol as HTMLElement).getAllByRole('button').find((b) => {
+        const tag = b.querySelector('.matchPairTag');
+        const content = tag ? b.textContent?.replace(tag.textContent ?? '', '') : b.textContent;
+        return content?.trim() === text;
+      });
+      if (!btn) throw new Error(`Right tile "${text}" not found`);
+      return btn;
+    };
+
+    const firstLeft = within(leftCol as HTMLElement).getAllByRole('button')[0];
+    const selectedLemmaText = firstLeft?.textContent?.replace(firstLeft.querySelector('.matchPairTag')?.textContent ?? '', '').trim() ?? '';
+    const textToGloss: Record<string, string> = {
+      'книга': 'book',
+      'робота': 'work',
+      'місто': 'city',
+      'школа': 'school',
+      'сад': 'garden',
+      'дім': 'house',
+    };
+    const selectedGloss = textToGloss[selectedLemmaText];
+
+    // Match the first distractor and verify the semantic-four tag and token appear.
+    const distractorWords = Object.keys(textToGloss).filter(w => w !== selectedLemmaText);
+    await user.click(findLeft(distractorWords[0]));
+    await user.click(findRight(textToGloss[distractorWords[0]]));
+
+    const matchedLeft = findLeft(distractorWords[0]);
+    const matchedRight = findRight(textToGloss[distractorWords[0]]);
+    expect(matchedLeft).toHaveAttribute('data-pair-coding', 'semantic-four');
+    expect(matchedRight).toHaveAttribute('data-pair-coding', 'semantic-four');
+    expect(matchedLeft.querySelector('.matchPairTag')).toBeInTheDocument();
+    expect(matchedRight.querySelector('.matchPairTag')).toBeInTheDocument();
+    expect(matchedLeft.querySelector('.matchPairTag')).toHaveTextContent('①');
+    expect(matchedRight.querySelector('.matchPairTag')).toHaveTextContent('①');
+
+    // Matching the selected lemma produces the second tag.
+    await user.click(findLeft(selectedLemmaText));
+    await user.click(findRight(selectedGloss));
+    await waitFor(() => {
+      expect(findLeft(selectedLemmaText).querySelector('.matchPairTag')).toHaveTextContent('②');
+    });
   });
 
   test('matching mode rates every matched pair with proper ratings', async () => {
@@ -2176,9 +2237,7 @@ describe('LexiconPractice', () => {
       return btn;
     };
 
-    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
-    const match = instructionText.match(/«([^»]+)»/);
-    const selectedLemmaText = match ? match[1] : '';
+    const selectedLemmaText = within(leftCol as HTMLElement).getAllByRole('button')[0]?.textContent?.trim() ?? '';
 
     const textToLemmaId: Record<string, string> = {
       'книга': 'knyha',
@@ -2288,9 +2347,7 @@ describe('LexiconPractice', () => {
       return btn;
     };
 
-    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
-    const match = instructionText.match(/«([^»]+)»/);
-    const selectedLemmaText = match ? match[1] : '';
+    const selectedLemmaText = within(leftCol as HTMLElement).getAllByRole('button')[0]?.textContent?.trim() ?? '';
 
     const textToLemmaId: Record<string, string> = {
       'книга': 'knyha',
@@ -2360,9 +2417,7 @@ describe('LexiconPractice', () => {
       return btn;
     };
 
-    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
-    const match = instructionText.match(/«([^»]+)»/);
-    const selectedLemmaText = match ? match[1] : '';
+    const selectedLemmaText = within(leftCol as HTMLElement).getAllByRole('button')[0]?.textContent?.trim() ?? '';
 
     const textToLemmaId: Record<string, string> = {
       'книга': 'knyha',
@@ -2461,9 +2516,7 @@ describe('LexiconPractice', () => {
       return btn;
     };
 
-    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
-    const match = instructionText.match(/«([^»]+)»/);
-    const selectedLemmaText = match ? match[1] : '';
+    const selectedLemmaText = within(leftCol as HTMLElement).getAllByRole('button')[0]?.textContent?.trim() ?? '';
 
     const textToLemmaId: Record<string, string> = {
       'книга': 'knyha',
@@ -2522,9 +2575,7 @@ describe('LexiconPractice', () => {
       return btn;
     };
 
-    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
-    const match = instructionText.match(/«([^»]+)»/);
-    const selectedLemmaText = match ? match[1] : '';
+    const selectedLemmaText = within(leftCol as HTMLElement).getAllByRole('button')[0]?.textContent?.trim() ?? '';
 
     const textToLemmaId: Record<string, string> = {
       'книга': 'knyha',

--- a/site/tests/unit/MatchUp.test.tsx
+++ b/site/tests/unit/MatchUp.test.tsx
@@ -1,5 +1,5 @@
-import { describe, test, expect } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MatchUp from '@site/src/components/MatchUp';
 
@@ -21,7 +21,11 @@ function rightTiles(container: HTMLElement) {
 }
 
 function findRightByText(container: HTMLElement, text: string) {
-  const btn = rightTiles(container).find(b => b.textContent?.trim() === text);
+  const btn = rightTiles(container).find((b) => {
+    const tag = b.querySelector('.matchPairTag');
+    const content = tag ? b.textContent?.replace(tag.textContent ?? '', '') : b.textContent;
+    return content?.trim() === text;
+  });
   if (!btn) throw new Error(`right tile "${text}" not found`);
   return btn;
 }
@@ -246,5 +250,155 @@ describe('MatchUp', () => {
 
     const rightTextContents = rightTiles(container).map((b) => b.textContent?.trim());
     expect(new Set(rightTextContents)).toEqual(new Set(['table', 'book', 'window']));
+  });
+
+  describe('practice-only matchedPairCoding="semantic-four"', () => {
+    test('omitted prop leaves default DOM and pair-color attributes', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<MatchUp pairs={pairs} />);
+
+      await user.click(leftTiles(container)[0]);
+      await user.click(findRightByText(container, 'Meow'));
+
+      const catTile = leftTiles(container)[0];
+      const meowTile = findRightByText(container, 'Meow');
+      expect(catTile).not.toHaveAttribute('data-pair-coding');
+      expect(meowTile).not.toHaveAttribute('data-pair-coding');
+      expect(catTile.querySelector('.matchPairTag')).not.toBeInTheDocument();
+      expect(meowTile.querySelector('.matchPairTag')).not.toBeInTheDocument();
+    });
+
+    test('opted-in board exposes data-pair-coding and visible tags after match', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<MatchUp pairs={pairs} matchedPairCoding="semantic-four" />);
+
+      await user.click(leftTiles(container)[0]);
+      await user.click(findRightByText(container, 'Meow'));
+
+      const catTile = leftTiles(container)[0];
+      const meowTile = findRightByText(container, 'Meow');
+      expect(catTile).toHaveAttribute('data-pair-coding', 'semantic-four');
+      expect(meowTile).toHaveAttribute('data-pair-coding', 'semantic-four');
+      expect(catTile).toHaveAttribute('data-pair-token', '0');
+      expect(meowTile).toHaveAttribute('data-pair-token', '0');
+      expect(catTile.querySelector('.matchPairTag')).toHaveTextContent('①');
+      expect(meowTile.querySelector('.matchPairTag')).toHaveTextContent('①');
+    });
+
+    test('four-pair board produces four token families and four unique tags', async () => {
+      const user = userEvent.setup();
+      const fourPairs = [
+        { left: 'A', right: 'a' },
+        { left: 'B', right: 'b' },
+        { left: 'C', right: 'c' },
+        { left: 'D', right: 'd' },
+      ];
+      const { container } = render(<MatchUp pairs={fourPairs} matchedPairCoding="semantic-four" />);
+
+      // Match in the order 2, 0, 3, 1 so tag order differs from original index order.
+      await user.click(leftTiles(container)[2]);
+      await user.click(findRightByText(container, 'c'));
+      await user.click(leftTiles(container)[0]);
+      await user.click(findRightByText(container, 'a'));
+      await user.click(leftTiles(container)[3]);
+      await user.click(findRightByText(container, 'd'));
+      await user.click(leftTiles(container)[1]);
+      await user.click(findRightByText(container, 'b'));
+
+      const tags = new Set<string>();
+      const tokens = new Set<string>();
+      for (const tile of [...leftTiles(container), ...rightTiles(container)]) {
+        const tag = tile.querySelector('.matchPairTag');
+        expect(tag).toBeInTheDocument();
+        tags.add(tag!.textContent ?? '');
+        tokens.add(tile.getAttribute('data-pair-token') ?? '');
+      }
+      expect(Array.from(tags).sort()).toEqual(['①', '②', '③', '④']);
+      expect(tokens).toEqual(new Set(['0', '1', '2', '3']));
+    });
+
+    test('board above four pairs cycles colors but keeps unique tags', async () => {
+      const user = userEvent.setup();
+      const sixPairs = [
+        { left: 'A', right: 'a' },
+        { left: 'B', right: 'b' },
+        { left: 'C', right: 'c' },
+        { left: 'D', right: 'd' },
+        { left: 'E', right: 'e' },
+        { left: 'F', right: 'f' },
+      ];
+      const { container } = render(<MatchUp pairs={sixPairs} matchedPairCoding="semantic-four" />);
+
+      for (let i = 0; i < sixPairs.length; i += 1) {
+        await user.click(leftTiles(container)[i]);
+        await user.click(findRightByText(container, sixPairs[i].right));
+      }
+
+      const tags = new Set<string>();
+      for (const tile of [...leftTiles(container), ...rightTiles(container)]) {
+        const tag = tile.querySelector('.matchPairTag');
+        expect(tag).toBeInTheDocument();
+        tags.add(tag!.textContent ?? '');
+      }
+      expect(tags.size).toBe(6);
+      expect(Array.from(tags).sort()).toEqual(['①', '②', '③', '④', '⑤', '⑥']);
+    });
+
+    test('shuffle does not change original pair identity or rating attribution', async () => {
+      const user = userEvent.setup();
+      const onMatch = vi.fn();
+      const { container } = render(
+        <MatchUp pairs={pairs} matchedPairCoding="semantic-four" onMatch={onMatch} />,
+      );
+
+      await user.click(leftTiles(container)[0]);
+      const meowTile = findRightByText(container, 'Meow');
+      expect(meowTile).toHaveAttribute('data-original-index', '0');
+      await user.click(meowTile);
+
+      expect(onMatch).toHaveBeenCalledTimes(1);
+      expect(onMatch).toHaveBeenCalledWith(0, 'good');
+    });
+
+    test('matched tiles announce pair identity and tag in accessible name', async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <MatchUp pairs={pairs} matchedPairCoding="semantic-four" isUkrainian />,
+      );
+
+      await user.click(leftTiles(container)[0]);
+      await user.click(findRightByText(container, 'Meow'));
+
+      const catTile = leftTiles(container)[0];
+      const meowTile = findRightByText(container, 'Meow');
+      expect(catTile).toHaveAttribute('aria-label', expect.stringContaining('пара ①'));
+      expect(catTile).toHaveAttribute('aria-label', expect.stringContaining('Meow'));
+      expect(meowTile).toHaveAttribute('aria-label', expect.stringContaining('пара ①'));
+      expect(meowTile).toHaveAttribute('aria-label', expect.stringContaining('Cat'));
+    });
+
+    test('wrong match clears after 240ms and never advances the board', async () => {
+      const user = userEvent.setup();
+      const onMatch = vi.fn();
+      const { container } = render(
+        <MatchUp pairs={pairs} matchedPairCoding="semantic-four" onMatch={onMatch} />,
+      );
+
+      await user.click(leftTiles(container)[0]); // Cat
+      await user.click(findRightByText(container, 'Bark')); // wrong
+
+      const catTile = leftTiles(container)[0];
+      const barkTile = findRightByText(container, 'Bark');
+      expect(catTile).toHaveClass('wrong');
+      expect(barkTile).toHaveClass('wrong');
+      expect(onMatch).not.toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(catTile).not.toHaveClass('wrong');
+        expect(barkTile).not.toHaveClass('wrong');
+      }, { timeout: 500 });
+
+      expect(onMatch).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Refs #5230

## Summary

Implements **Chunk 4 — Practice-only matching pair coding** from `docs/practice/K3-BUILD-SPEC.md` §4.

- Adds optional `matchedPairCoding?: 'semantic-four'` to `packages/activity-kit/src/components/MatchUp.tsx` and the site shim `site/src/components/MatchUp.tsx`. Omitted leaves existing lesson DOM/behavior unchanged.
- In practice matching mode, each original pair gets a stable token index `pairIndex % 4` using the existing teal/orange/purple/yellow theme families, plus a circled tag (①–㊿) on both partners.
- `LexiconPractice` opts in only for matching mode and renders the progress prompt `Доберіть пари · n з N` / `Match pairs · n of N` via `ChromeDual`.
- Removes the route-local single-green `[data-matched="true"]` override from `site/src/pages/words-of-the-day/practice.astro`.
- Keeps the accepted mismatch behavior: red border + 240 ms shake when motion is allowed; omitted under `prefers-reduced-motion`.
- Updates unit tests for pair coding and the new progress prompt.
- Adds `@types/react` to `packages/activity-kit/package.json` devDependencies so the workspace package type-checks; `package-lock.json` updated accordingly.
- Regenerates `docs/lesson-schema.yaml` because site components changed (real MatchUp contract change: new `matchedPairCoding` prop and corrected `instruction` type mapping).

## Verification

Unit tests:
```bash
cd site && npx vitest run tests/unit/LexiconPractice.test.tsx tests/unit/MatchUp.test.tsx
# Test Files  2 passed (2)
# Tests       102 passed (102)
```

Playwright e2e:
```bash
cd site && npx playwright test e2e/atlas-practice.spec.ts
# 14 passed (4.3s)
```

Astro build:
```bash
cd site && npm run build
# ✓ astro build produced dist/
```

Lesson-schema regeneration:
```bash
.venv/bin/python scripts/build/generate_lesson_schema.py
.venv/bin/python -m pytest tests/test_lesson_schema.py tests/test_prompt_substitution.py -v
# 17 passed in 0.37s
.venv/bin/ruff check scripts/build/generate_lesson_schema.py scripts/build/prompt_builder.py tests/test_lesson_schema.py tests/test_prompt_substitution.py
# All checks passed!
```

Type-check:
```bash
cd site && npx tsc --noEmit
# 3 pre-existing errors in unchanged test files:
# tests/unit/atlas-runtime-shards.test.ts(342,9) recursive type mismatch
# tests/unit/hydrate-practice-deck.test.ts(157,22) missing .counts
# tests/unit/word-atlas-page-shell.test.ts(28,17) AstroComponentFactory assignability
# No TS errors in any changed TS/TSX files.
```

## Notes for reviewers

- The three `tsc --noEmit` failures are in pre-existing, untouched test files and are unrelated to this chunk. They are quoted above for transparency per the deterministic-claims preamble.
- This PR does not enable auto-merge per chunk instructions; the orchestrator gates the review.
