### PR TITLE
feat(practice): Chunk 5 generalized form rail and N-vowel stress

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: f02c5f4b3e40d3f56b07dad41e0aaefd5e1baba47c5a41a48ecd2e864df9dbc0
+  components_sha256: a51f80e11aad25ba22c8814cea65f9ee7023902a8f375d4e63ff2f745dfaf006
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1691,6 +1691,47 @@ components:
       chromeLocale: <ChromeLocale>
     deprecated: false
     deprecation_reason: null
+  PracticeFormRail:
+    tab: lesson
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: source
+        type: PracticeFormRailEntry
+        description: source prop.
+        ukrainian_text: 'false'
+      - name: actual
+        type: PracticeFormRailEntry
+        description: actual prop.
+        ukrainian_text: 'false'
+      - name: verdict
+        type: FormRailVerdict
+        description: verdict prop.
+        ukrainian_text: 'false'
+      - name: chromeLocale
+        type: ChromeLocale
+        description: chromeLocale prop.
+        ukrainian_text: 'false'
+      optional: []
+    nested_types:
+      PracticeFormRailEntry:
+      - name: label
+        type: string
+        description: label prop.
+        ukrainian_text: 'false'
+      - name: value
+        type: string
+        description: value prop.
+        ukrainian_text: 'false'
+    example:
+      source: <PracticeFormRailEntry>
+      actual: <PracticeFormRailEntry>
+      verdict: <FormRailVerdict>
+      chromeLocale: <ChromeLocale>
+    deprecated: false
+    deprecation_reason: null
   PracticeSessionSummary:
     tab: lesson
     level_scope: *id001
@@ -1736,6 +1777,33 @@ components:
     example:
       stats: <SessionSummaryStats>
       showEnglishSubtitles: false
+    deprecated: false
+    deprecation_reason: null
+  PracticeStress:
+    tab: lesson
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: item
+        type: PracticeStressItem
+        description: item prop.
+        ukrainian_text: 'false'
+      - name: selectedNucleusIndex
+        type: number | null
+        description: selectedNucleusIndex prop.
+        ukrainian_text: 'false'
+      - name: answerLocked
+        type: boolean
+        description: answerLocked prop.
+        ukrainian_text: 'false'
+      optional: []
+    nested_types: {}
+    example:
+      item: <PracticeStressItem>
+      selectedNucleusIndex: <number | null>
+      answerLocked: false
     deprecated: false
     deprecation_reason: null
   PrimaryReading:

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -217,6 +217,21 @@ test('HARD-2: Ukrainian setup dashboard shows start and resume CTAs without scro
   await assertFirstViewportPracticeCTAs(page, 'uk');
 });
 
+test('practice stress mode renders word-shaped vowel buttons for an N-vowel word', async ({ page }) => {
+  await page.goto('/words-of-the-day/practice/');
+
+  await page.locator('button[data-mode="stress"]').click();
+  const stress = page.locator('[data-testid="practice-stress"]');
+  await expect(stress).toBeVisible();
+  await expect.poll(() => stress.locator('.stress-vowel').count()).toBeGreaterThanOrEqual(2);
+
+  // Selecting a vowel locks the control and shows a verdict marker.
+  const firstVowel = stress.locator('.stress-vowel').first();
+  await firstVowel.click();
+  await expect(firstVowel).toBeDisabled();
+  await expect(stress.locator('[data-testid="practice-stress-verdict"]')).toBeVisible();
+});
+
 test('practice flashcard rating locks the card and waits for explicit next', async ({ page, context }) => {
   await context.clearCookies();
   await page.goto('/words-of-the-day/practice/');

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -3,7 +3,9 @@ import MatchUp from './MatchUp';
 import PracticeDailyDeck from './PracticeDailyDeck';
 import PracticeErrorBoundary from './PracticeErrorBoundary';
 import PracticeFlashcard from './PracticeFlashcard';
+import PracticeFormRail, { type FormRailVerdict } from './PracticeFormRail';
 import PracticeSessionSummary, { type SessionSummaryStats } from './PracticeSessionSummary';
+import PracticeStress from './PracticeStress';
 import ChromeText, { ChromeDual } from '../lib/i18n/ChromeText';
 import { CHROME_STRINGS } from '../lib/i18n/chrome';
 import {
@@ -712,12 +714,6 @@ function classifySet(selection: PracticeSelection): PracticeClassifySet | null {
 }
 
 function drillChoiceOptions(selection: PracticeSelection, showEnglishSubtitles: boolean): ChoiceOption[] | null {
-  if (selection.stress) {
-    return selection.stress.nuclei.map((nucleus) => ({
-      label: nucleus.label,
-      correct: nucleus.index === selection.stress?.stressIndex,
-    }));
-  }
   const selectedSet = classifySet(selection);
   if (selectedSet) {
     return selectedSet.options.map((option) => ({
@@ -1055,6 +1051,10 @@ function LexiconPracticeIsland({
   const [clozeAttemptRecorded, setClozeAttemptRecorded] = useState(false);
   const [heritageFeedback, setHeritageFeedback] = useState<HeritageFeedback | null>(null);
   const [paronymFeedback, setParonymFeedback] = useState<ParonymFeedback | null>(null);
+  const [stressSelectedIndex, setStressSelectedIndex] = useState<number | null>(null);
+  const [paradigmSelectedLabel, setParadigmSelectedLabel] = useState<string | null>(null);
+  const [paronymSelectedLabel, setParonymSelectedLabel] = useState<string | null>(null);
+  const [heritageSelectedLabel, setHeritageSelectedLabel] = useState<string | null>(null);
   const [dueIndex, setDueIndex] = useState<PracticeIndexItem[] | null>(null);
   const [dailySnapshot, setDailySnapshot] = useState<DailyPracticeDeckSnapshot | null>(null);
   const [dailyLexemes, setDailyLexemes] = useState<Map<string, PracticeLexeme>>(() => new Map());
@@ -1113,6 +1113,10 @@ function LexiconPracticeIsland({
     setClozeAttemptRecorded(false);
     setHeritageFeedback(null);
     setParonymFeedback(null);
+    setStressSelectedIndex(null);
+    setParadigmSelectedLabel(null);
+    setParonymSelectedLabel(null);
+    setHeritageSelectedLabel(null);
     setPendingOutcome(null);
     pendingOutcomeRef.current = null;
     matchedSelectedRatingRef.current = null;
@@ -2130,6 +2134,21 @@ function LexiconPracticeIsland({
     completeSelection(selection, outcome);
   }
 
+  function handleStressSelect(nucleusIndex: number) {
+    if (!selection?.stress || answerLocked) return;
+    setStressSelectedIndex(nucleusIndex);
+    const correct = nucleusIndex === selection.stress.stressIndex;
+    const rating = correct ? 'good' : 'again';
+    const outcome = recordReview(selection, rating);
+    setFeedback({
+      uk: `${selection.stress.unstressed}: ${correct ? 'Правильно' : 'Ще раз'}`,
+      en: `${selection.stress.unstressed}: ${correct ? 'Correct' : 'Again'}`,
+    });
+    setAnswerLocked(true);
+    pendingOutcomeRef.current = outcome;
+    setPendingOutcome(outcome);
+  }
+
   function handleChoice(option: ChoiceOption) {
     if (!selection || answerLocked) return;
     const rating = option.correct ? 'good' : 'again';
@@ -2141,6 +2160,9 @@ function LexiconPracticeIsland({
       ? paronymFeedbackFor(selection.paronym, option)
       : null;
     setAnswerLocked(true);
+    if (selection.paradigm) setParadigmSelectedLabel(option.label);
+    if (selection.paronym) setParonymSelectedLabel(option.label);
+    if (selection.heritage) setHeritageSelectedLabel(option.label);
     setHeritageFeedback(nextHeritageFeedback);
     setParonymFeedback(nextParonymFeedback);
     setFeedback({
@@ -2153,9 +2175,14 @@ function LexiconPracticeIsland({
   }
 
   function submitCloze(value: string, source: 'typed' | 'chip') {
-    if (!selection?.cloze || answerLocked) return;
+    if (!selection?.cloze) return;
     const answer = value.trim();
-    if (!answer) return;
+    if (source === 'chip') {
+      // Suggestions populate the input; only the explicit Check action commits.
+      if (!answerLocked) setClozeInput(answer);
+      return;
+    }
+    if (answerLocked || !answer) return;
     const cloze = selection.cloze;
     const correct = czNorm(answer) === czNorm(cloze.form);
     const caseMiss = isWrongCaseAnswer(answer, selection.lemma, cloze);
@@ -2197,13 +2224,9 @@ function LexiconPracticeIsland({
         textUk: '✗ Не те слово',
         textEn: '✗ Not that word',
       });
-      if (source === 'chip') {
-        // Wrong chip pick is a wrong answer: dwell rather than auto-advance so the
-        // learner can read the correction before «Далі →» / Enter.
-        setAnswerLocked(true);
-        pendingOutcomeRef.current = outcome;
-        setPendingOutcome(outcome);
-      }
+      setAnswerLocked(true);
+      pendingOutcomeRef.current = outcome;
+      setPendingOutcome(outcome);
       return;
     }
 
@@ -2212,15 +2235,7 @@ function LexiconPracticeIsland({
       textUk: '✗ Не те слово',
       textEn: '✗ Not that word',
     });
-    if (source === 'chip') {
-      setAnswerLocked(true);
-      const outcome = {
-        nextUnresolved: new Set(unresolvedCardKeys),
-        nextDeferred: [...deferredLemmas],
-      };
-      pendingOutcomeRef.current = outcome;
-      setPendingOutcome(outcome);
-    }
+    setAnswerLocked(true);
   }
 
   const dueReviews = useMemo(
@@ -2739,9 +2754,14 @@ function LexiconPracticeIsland({
                     clozeFeedback={clozeFeedback}
                     heritageFeedback={heritageFeedback}
                     paronymFeedback={paronymFeedback}
+                    stressSelectedIndex={stressSelectedIndex}
+                    paradigmSelectedLabel={paradigmSelectedLabel}
+                    paronymSelectedLabel={paronymSelectedLabel}
+                    heritageSelectedLabel={heritageSelectedLabel}
                     onClozeInput={setClozeInput}
                     onFlashcardRating={handleFlashcardRating}
                     onChoice={handleChoice}
+                    onStressSelect={handleStressSelect}
                     onMatchingComplete={handleMatchingComplete}
                     onMatchingMatch={handleMatchingMatch}
                     onClozeSubmit={submitCloze}
@@ -2833,9 +2853,14 @@ function PracticeItem({
   clozeFeedback,
   heritageFeedback,
   paronymFeedback,
+  stressSelectedIndex,
+  paradigmSelectedLabel,
+  paronymSelectedLabel,
+  heritageSelectedLabel,
   onClozeInput,
   onFlashcardRating,
   onChoice,
+  onStressSelect,
   onMatchingComplete,
   onMatchingMatch,
   onClozeSubmit,
@@ -2851,9 +2876,14 @@ function PracticeItem({
   clozeFeedback: ClozeFeedback | null;
   heritageFeedback: HeritageFeedback | null;
   paronymFeedback: ParonymFeedback | null;
+  stressSelectedIndex: number | null;
+  paradigmSelectedLabel: string | null;
+  paronymSelectedLabel: string | null;
+  heritageSelectedLabel: string | null;
   onClozeInput(value: string): void;
   onFlashcardRating(rating: PracticeRating): void;
   onChoice(option: ChoiceOption): void;
+  onStressSelect(nucleusIndex: number): void;
   onMatchingComplete(): void;
   onMatchingMatch?: (pairIndex: number, rating: PracticeRating) => void;
   onClozeSubmit(value: string, source: 'typed' | 'chip'): void;
@@ -2881,17 +2911,76 @@ function PracticeItem({
     );
   }
 
-  if (selection.mode === 'cloze' && selection.cloze) {
+  if (selection.mode === 'stress' && selection.stress) {
+    const drillPrompt = drillChoicePrompt(selection);
     return (
-      <PracticeCloze
-        selection={selection}
-        input={clozeInput}
-        feedback={clozeFeedback}
-        answerLocked={answerLocked}
-        onInput={onClozeInput}
-        onSubmit={onClozeSubmit}
-        showEnglishSubtitles={showEnglishSubtitles}
-      />
+      <div className="lexicon-stress" data-testid="practice-stress-stage">
+        {drillPrompt ? (
+          <p className="lexicon-choice-prompt mc-q" data-testid="practice-form-prompt">
+            <span lang="uk">
+              {drillPrompt.promptUk}
+              {drillPrompt.subtitleUk ? (
+                <>
+                  {' '}
+                  <span className="mc-descriptor">— {drillPrompt.subtitleUk}</span>
+                </>
+              ) : null}
+            </span>
+            {showEnglishSubtitles ? (
+              <span
+                className="btn-sub"
+                lang="en"
+                style={{
+                  display: 'inline',
+                  fontSize: '0.85em',
+                  fontWeight: 'normal',
+                  color: 'var(--lu-text-muted)',
+                }}
+              >
+                {' '}
+                / {drillPrompt.promptEn}
+                {drillPrompt.subtitleEn ? ` — ${drillPrompt.subtitleEn}` : ''}
+              </span>
+            ) : null}
+          </p>
+        ) : null}
+        <PracticeStress
+          item={selection.stress}
+          selectedNucleusIndex={stressSelectedIndex}
+          answerLocked={answerLocked}
+          onSelect={onStressSelect}
+        />
+      </div>
+    );
+  }
+
+  if (selection.mode === 'cloze' && selection.cloze) {
+    const cloze = selection.cloze;
+    const railVerdict: FormRailVerdict = !clozeFeedback
+      ? 'idle'
+      : clozeFeedback.kind === 'correct'
+        ? 'correct'
+        : 'wrong';
+    return (
+      <div className="lexicon-cloze-wrapper">
+        <PracticeCloze
+          selection={selection}
+          input={clozeInput}
+          feedback={clozeFeedback}
+          answerLocked={answerLocked}
+          onInput={onClozeInput}
+          onSubmit={onClozeSubmit}
+          showEnglishSubtitles={showEnglishSubtitles}
+        />
+        {answerLocked ? (
+          <PracticeFormRail
+            source={{ label: cloze.form, value: selection.lemma.lemma }}
+            actual={{ label: clozeInput, value: clozeInput }}
+            verdict={railVerdict}
+            chromeLocale={chromeLocale}
+          />
+        ) : null}
+      </div>
     );
   }
 
@@ -2901,6 +2990,8 @@ function PracticeItem({
         item={selection.heritage}
         feedback={heritageFeedback}
         answerLocked={answerLocked}
+        selectedLabel={heritageSelectedLabel}
+        chromeLocale={chromeLocale}
         onChoice={onChoice}
         showEnglishSubtitles={showEnglishSubtitles}
       />
@@ -2913,6 +3004,8 @@ function PracticeItem({
         item={selection.paronym}
         feedback={paronymFeedback}
         answerLocked={answerLocked}
+        selectedLabel={paronymSelectedLabel}
+        chromeLocale={chromeLocale}
         onChoice={onChoice}
         showEnglishSubtitles={showEnglishSubtitles}
       />
@@ -2971,6 +3064,14 @@ function PracticeItem({
             </li>
           ))}
         </ul>
+        {selection.mode === 'paradigm' && answerLocked && paradigmSelectedLabel !== null ? (
+          <PracticeFormRail
+            source={{ label: selection.lemma.lemma, value: selection.lemma.lemma }}
+            actual={{ label: paradigmSelectedLabel, value: paradigmSelectedLabel }}
+            verdict={drillOptions.some((o) => o.correct && o.label === paradigmSelectedLabel) ? 'correct' : 'wrong'}
+            chromeLocale={chromeLocale}
+          />
+        ) : null}
       </div>
     );
   }
@@ -3096,12 +3197,16 @@ function PracticeParonym({
   item,
   feedback,
   answerLocked,
+  selectedLabel,
+  chromeLocale,
   onChoice,
   showEnglishSubtitles,
 }: {
   item: PracticeParonymItem;
   feedback: ParonymFeedback | null;
   answerLocked: boolean;
+  selectedLabel: string | null;
+  chromeLocale: 'en' | 'uk';
   onChoice(option: ChoiceOption): void;
   showEnglishSubtitles: boolean;
 }) {
@@ -3150,6 +3255,12 @@ function PracticeParonym({
               <span className="btn-sub" lang="en">/ {feedback.textEn}</span>
             ) : null}
           </p>
+          <PracticeFormRail
+            source={{ label: `${item.lemma} / ${item.confusable}`, value: item.lemma }}
+            actual={{ label: selectedLabel ?? '', value: selectedLabel ?? '' }}
+            verdict={feedback.kind}
+            chromeLocale={chromeLocale}
+          />
           <div style={{ marginTop: '0.4rem' }}>
             <a
               href={atlasLemmaHref(item.lemmaId)}
@@ -3174,18 +3285,22 @@ function PracticeHeritage({
   item,
   feedback,
   answerLocked,
+  selectedLabel,
+  chromeLocale,
   onChoice,
   showEnglishSubtitles,
 }: {
   item: PracticeHeritageItem;
   feedback: HeritageFeedback | null;
   answerLocked: boolean;
+  selectedLabel: string | null;
+  chromeLocale: 'en' | 'uk';
   onChoice(option: ChoiceOption): void;
   showEnglishSubtitles: boolean;
 }) {
   const [before, after] = slotPromptParts(item.prompt);
   const options = heritageOptions(item);
-  const slotText = feedback?.kind === 'correct' ? item.answer : '___';
+  const slotText = feedback?.kind === 'correct' ? (selectedLabel ?? item.answer) : '___';
   return (
     <div className="lexicon-heritage" data-testid="practice-heritage">
       <p className="heritage-task">
@@ -3236,6 +3351,12 @@ function PracticeHeritage({
               ) : null}
             </p>
           ) : null}
+          <PracticeFormRail
+            source={{ label: item.nativeLemma ?? item.lemma ?? '', value: item.nativeLemma ?? item.lemma ?? '' }}
+            actual={{ label: item.answer, value: item.answer }}
+            verdict={feedback.kind}
+            chromeLocale={chromeLocale}
+          />
           <div style={{ marginTop: '0.4rem' }}>
             <a
               href={atlasLemmaHref(item.lemmaId)}

--- a/site/src/components/PracticeFormRail.tsx
+++ b/site/src/components/PracticeFormRail.tsx
@@ -1,0 +1,71 @@
+import ChromeText from '../lib/i18n/ChromeText';
+import type { ChromeLocale } from '../lib/i18n/chrome';
+
+export type FormRailVerdict = 'idle' | 'correct' | 'wrong' | 'calque';
+
+export interface PracticeFormRailEntry {
+  /** Accessible label for the value (not necessarily visible). */
+  label: string;
+  /** Visible value rendered in the rail cell. */
+  value: string;
+}
+
+export interface PracticeFormRailProps {
+  source: PracticeFormRailEntry;
+  actual: PracticeFormRailEntry;
+  verdict: FormRailVerdict;
+  chromeLocale: ChromeLocale;
+}
+
+export default function PracticeFormRail({
+  source,
+  actual,
+  verdict,
+  chromeLocale,
+}: PracticeFormRailProps) {
+  const verdictKey =
+    verdict === 'correct'
+      ? 'practice.verdict.correct'
+      : verdict === 'calque'
+        ? 'practice.verdict.calque'
+        : verdict === 'wrong'
+          ? 'practice.verdict.wrong'
+          : null;
+  return (
+    <div
+      className={`practice-form-rail verdict-${verdict}`}
+      role="status"
+      aria-live="polite"
+      data-testid="practice-form-rail"
+      data-verdict={verdict}
+      data-chrome-locale={chromeLocale}
+    >
+      <div className="practice-form-rail-row">
+        <div className="practice-form-rail-cell rail-source">
+          <span className="rail-cell-label">
+            <ChromeText k="practice.rail.source" />
+          </span>
+          <span className="rail-cell-value" lang="uk" aria-label={source.label}>
+            {source.value}
+          </span>
+        </div>
+        <div className="practice-form-rail-separator" aria-hidden="true">
+          →
+        </div>
+        <div className="practice-form-rail-cell rail-actual">
+          <span className="rail-cell-label">
+            <ChromeText k="practice.rail.actual" />
+          </span>
+          <span className="rail-cell-value" lang="uk" aria-label={actual.label}>
+            {actual.value}
+          </span>
+        </div>
+      </div>
+      {verdictKey ? (
+        <p className="practice-form-rail-status" data-testid="practice-form-rail-status">
+          <ChromeText k={verdictKey} />
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/site/src/components/PracticeStress.tsx
+++ b/site/src/components/PracticeStress.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from 'react';
+import type { PracticeStressItem } from '../lib/lexicon/srs';
+
+export interface PracticeStressProps {
+  item: PracticeStressItem;
+  selectedNucleusIndex: number | null;
+  answerLocked: boolean;
+  onSelect(nucleusIndex: number): void;
+}
+
+interface NucleusInfo {
+  nucleusIndex: number;
+  label: string;
+}
+
+export default function PracticeStress({
+  item,
+  selectedNucleusIndex,
+  answerLocked,
+  onSelect,
+}: PracticeStressProps) {
+  const nucleusByPosition = useMemo(() => {
+    const map = new Map<number, NucleusInfo>();
+    for (let index = 0; index < item.nuclei.length; index += 1) {
+      const nucleus = item.nuclei[index];
+      if (nucleus && !map.has(nucleus.index)) {
+        map.set(nucleus.index, { nucleusIndex: index, label: nucleus.label });
+      }
+    }
+    return map;
+  }, [item.nuclei]);
+
+  const codePoints = Array.from(item.unstressed);
+  const isCorrect = selectedNucleusIndex === item.stressIndex;
+
+  return (
+    <div className="practice-stress" data-testid="practice-stress" data-locked={answerLocked}>
+      <p className="practice-stress-word" lang="uk" aria-label={item.stressed}>
+        {codePoints.map((char, position) => {
+          const nucleus = nucleusByPosition.get(position);
+          if (nucleus) {
+            const selected = selectedNucleusIndex === nucleus.nucleusIndex;
+            const verdictClass = answerLocked
+              ? selected
+                ? isCorrect
+                  ? ' correct'
+                  : ' wrong'
+                : ''
+              : '';
+            return (
+              <button
+                key={`nucleus-${position}`}
+                type="button"
+                className={`stress-vowel${verdictClass}${selected ? ' selected' : ''}`}
+                data-nucleus-index={nucleus.nucleusIndex}
+                data-position={position}
+                disabled={answerLocked}
+                aria-pressed={selected}
+                onClick={() => onSelect(nucleus.nucleusIndex)}
+              >
+                {char}
+              </button>
+            );
+          }
+          return (
+            <span key={`char-${position}`} className="stress-consonant" aria-hidden="true">
+              {char}
+            </span>
+          );
+        })}
+      </p>
+      {answerLocked && selectedNucleusIndex !== null ? (
+        <p
+          className={`practice-stress-verdict ${isCorrect ? 'correct' : 'wrong'}`}
+          role="status"
+          aria-live="polite"
+          data-testid="practice-stress-verdict"
+        >
+          {isCorrect ? '✓' : '✗'}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -1369,4 +1369,158 @@ const frontmatter = {
     letter-spacing: 0.04em;
     text-transform: uppercase;
   }
+
+  /* Chunk 5 — generalized form rail and N-vowel stress */
+  :global(.practice-form-rail) {
+    display: grid;
+    gap: 0.6rem;
+    padding: 0.9rem 1rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 10px;
+    background: var(--lu-surface-raised);
+  }
+
+  :global(.practice-form-rail-row) {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  :global(.practice-form-rail-cell) {
+    display: grid;
+    gap: 0.15rem;
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  :global(.rail-cell-label) {
+    color: var(--lu-text-muted);
+    font-size: 0.72rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  :global(.rail-cell-value) {
+    color: var(--lu-text);
+    font-size: 1.15rem;
+    font-weight: 800;
+    line-height: 1.35;
+    word-break: break-word;
+  }
+
+  :global(.practice-form-rail-separator) {
+    color: var(--lu-text-muted);
+    font-size: 1.1rem;
+    font-weight: 900;
+  }
+
+  :global(.practice-form-rail-status) {
+    margin: 0;
+    font-weight: 900;
+  }
+
+  :global(.practice-form-rail.verdict-correct) {
+    border-color: var(--lu-green);
+    background: var(--lu-state-correct-bg);
+  }
+  :global(.practice-form-rail.verdict-correct .practice-form-rail-status),
+  :global(.practice-form-rail.verdict-correct .rail-cell-value) {
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.practice-form-rail.verdict-wrong) {
+    border-color: var(--lu-red);
+    background: var(--lu-state-wrong-bg);
+  }
+  :global(.practice-form-rail.verdict-wrong .practice-form-rail-status),
+  :global(.practice-form-rail.verdict-wrong .rail-cell-value) {
+    color: var(--lu-state-wrong-fg);
+  }
+
+  :global(.practice-form-rail.verdict-calque) {
+    border-color: color-mix(in srgb, var(--lu-orange) 50%, transparent);
+    background: var(--lu-orange-light);
+  }
+  :global(.practice-form-rail.verdict-calque .practice-form-rail-status),
+  :global(.practice-form-rail.verdict-calque .rail-cell-value) {
+    color: var(--lu-orange);
+  }
+
+  :global(.lexicon-stress) {
+    display: grid;
+    gap: 1rem;
+  }
+
+  :global(.practice-stress-word) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.1rem;
+    margin: 0;
+    padding: 1.25rem 1.5rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 14px;
+    background: var(--lu-surface-raised);
+    box-shadow: var(--lu-shadow);
+    color: var(--lu-text);
+    font-size: 1.8rem;
+    font-weight: 700;
+    line-height: 1.6;
+  }
+
+  :global(.stress-vowel) {
+    min-width: 2.2rem;
+    min-height: 2.6rem;
+    padding: 0 0.35rem;
+    border: 2px solid var(--lu-border);
+    border-radius: 8px;
+    background: var(--lu-surface);
+    color: var(--lu-primary);
+    font: inherit;
+    font-weight: 900;
+    cursor: pointer;
+  }
+
+  :global(.stress-vowel:hover:not(:disabled)) {
+    border-color: var(--lu-primary);
+    background: var(--lu-state-active);
+  }
+
+  :global(.stress-vowel:focus-visible) {
+    border-color: var(--lu-primary);
+    outline: 2px solid var(--lu-primary);
+    outline-offset: 2px;
+  }
+
+  :global(.stress-vowel.selected) {
+    border-color: var(--lu-primary);
+    background: var(--lu-primary);
+    color: var(--lu-on-primary);
+  }
+
+  :global(.stress-vowel.correct) {
+    border-color: var(--lu-green);
+    background: var(--lu-state-correct-bg);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.stress-vowel.wrong) {
+    border-color: var(--lu-red);
+    background: var(--lu-state-wrong-bg);
+    color: var(--lu-state-wrong-fg);
+  }
+
+  :global(.practice-stress-verdict) {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 900;
+    text-align: center;
+  }
+  :global(.practice-stress-verdict.correct) {
+    color: var(--lu-green);
+  }
+  :global(.practice-stress-verdict.wrong) {
+    color: var(--lu-red);
+  }
 </style>

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1018,7 +1018,8 @@ describe('LexiconPractice', () => {
     );
 
     const feedbackTextWithout = screen.getByTestId('practice-heritage-feedback').textContent;
-    expect(feedbackTextWithout).toBe('⚠️ калькаВідкрити в Атласі →');
+    expect(feedbackTextWithout).toContain('⚠️ калька');
+    expect(feedbackTextWithout).toContain('Відкрити в Атласі →');
     expect(feedbackTextWithout).not.toContain('english explanation');
   });
 
@@ -1433,8 +1434,9 @@ describe('LexiconPractice', () => {
 
     expect(screen.getByTestId('practice-cloze')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'книга' }));
+    await user.click(screen.getByRole('button', { name: /Перевірити/ }));
 
-    const status = screen.getByRole('status');
+    const status = within(screen.getByTestId('practice-cloze')).getByRole('status');
     expect(status).toHaveTextContent('Правильне слово');
     expect(status).toHaveClass('case-miss');
     expect(screen.getByLabelText(/Відповідь у знахідному відмінку/)).toHaveValue('');
@@ -1712,9 +1714,11 @@ describe('LexiconPractice', () => {
 
     expect(screen.getByTestId('practice-cloze')).toBeInTheDocument();
 
-    // A wrong CHIP pick (a different lemma — not a case-miss, not correct) parks in a
-    // dwell state with an explicit advance control instead of auto-advancing.
+    // A wrong CHIP pick (a different lemma — not a case-miss, not correct) populates
+    // the input; only Check commits it and parks in a dwell state with an explicit
+    // advance control instead of auto-advancing.
     await user.click(screen.getByRole('button', { name: 'робота' }));
+    await user.click(screen.getByRole('button', { name: /Перевірити/ }));
     expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
     expect(screen.getByText('✗ Не те слово')).toBeInTheDocument();
 
@@ -1741,8 +1745,9 @@ describe('LexiconPractice', () => {
     render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="cloze" />);
 
     await user.click(screen.getByRole('button', { name: 'книгу' }));
+    await user.click(screen.getByRole('button', { name: /Перевірити/ }));
     expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent('книгу');
+    expect(within(screen.getByTestId('practice-cloze')).getByRole('status')).toHaveTextContent('книгу');
 
     await new Promise((resolve) => setTimeout(resolve, 750));
     expect(screen.getByTestId('practice-cloze')).toBeInTheDocument();
@@ -2732,6 +2737,167 @@ describe('LexiconPractice', () => {
         expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument();
       });
     });
+  });
+
+  describe('PracticeStress N-vowel generality', () => {
+    function stressDeckWithNuclei(
+      word: string,
+      nuclei: { index: number; label: string }[],
+      stressIndex: number,
+    ): PracticeDeckData {
+      const entry = lexeme('stress-fixture', word, 'fixture', {
+        nominative: word,
+        accusative: word,
+        locative: word,
+      });
+      return {
+        deckVersion: 'test-stress-n',
+        level: 'A1',
+        lexemes: [entry],
+        index: [{
+          lemmaId: entry.lemmaId,
+          lemma: entry.lemma,
+          cefr: 'A1',
+          modes: ['stress'],
+          hasCloze: false,
+          clozeIds: [],
+          newOrder: 0,
+        }],
+        cloze: [],
+        stress: [{
+          stressId: 'stress-n',
+          lemmaId: 'stress-fixture',
+          lemma: word,
+          stressed: word,
+          unstressed: word,
+          stressIndex,
+          nuclei,
+          source: 'fixture',
+        }],
+        classify: [],
+        paradigm: [],
+        synonym: [],
+      };
+    }
+
+    test.each([
+      { count: 2, word: 'кава', nuclei: [{ index: 0, label: 'а' }, { index: 2, label: 'а' }], stressIndex: 1 },
+      { count: 3, word: 'україна', nuclei: [{ index: 1, label: 'у' }, { index: 3, label: 'а' }, { index: 5, label: 'и' }], stressIndex: 2 },
+      { count: 5, word: 'автентифікація', nuclei: [{ index: 0, label: 'а' }, { index: 2, label: 'е' }, { index: 5, label: 'і' }, { index: 8, label: 'а' }, { index: 11, label: 'і' }], stressIndex: 3 },
+    ])('renders $count vowel buttons preserving code-point positions', async ({ word, nuclei, stressIndex }) => {
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={stressDeckWithNuclei(word, nuclei, stressIndex)} autoStart initialMode="stress" />);
+
+      const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button');
+      expect(buttons).toHaveLength(nuclei.length);
+
+      await user.click(buttons[stressIndex]!);
+
+      expect(screen.getByTestId('practice-stress-verdict')).toHaveTextContent('✓');
+      expect(screen.queryByTestId('practice-form-rail')).not.toBeInTheDocument();
+    });
+
+    test('selecting the wrong nucleus records a wrong verdict and keeps the selected vowel highlighted', async () => {
+      const nuclei = [
+        { index: 0, label: 'а' },
+        { index: 2, label: 'а' },
+      ];
+      const user = userEvent.setup();
+      render(<LexiconPractice initialDeck={stressDeckWithNuclei('кава', nuclei, 1)} autoStart initialMode="stress" />);
+
+      const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button');
+      await user.click(buttons[0]!);
+
+      expect(screen.getByTestId('practice-stress-verdict')).toHaveTextContent('✗');
+      expect(screen.queryByTestId('practice-form-rail')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('PracticeFormRail presence', () => {
+    test.each([
+      { mode: 'cloze', deck: sampleDeck(), expectRail: true, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: 'книгу' })); await user.click(screen.getByRole('button', { name: /Перевірити/ })); } },
+      { mode: 'paradigm', deck: paradigmDeck(), expectRail: true, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /кави/ })); } },
+      { mode: 'paronym', deck: paronymDeck(), expectRail: true, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /бігає/ })); } },
+      { mode: 'heritage', deck: heritageDeck(), expectRail: true, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дім/ })); } },
+      { mode: 'flashcards', deck: sampleDeckWithOnlyMode('knyha', 'flashcards'), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>, container: HTMLElement) => { const card = container.querySelector<HTMLElement>('[data-activity="flashcard"]')!; await user.click(card); await user.click(container.querySelector<HTMLButtonElement>('[data-rate="good"]')!); } },
+      { mode: 'matching', deck: smallMatchingDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>, container: HTMLElement) => {
+        const leftCol = container.querySelector('[data-activity="match-left-column"]');
+        const rightCol = container.querySelector('[data-activity="match-right-column"]');
+        if (!leftCol || !rightCol) throw new Error('Matching columns not found');
+        const leftTiles = Array.from(leftCol.querySelectorAll('[data-activity="match-left-tile"]'));
+        const rightTiles = Array.from(rightCol.querySelectorAll('[data-activity="match-right-tile"]'));
+        for (const left of leftTiles) {
+          const pairId = left.getAttribute('data-pair-id');
+          const right = rightTiles.find((t) => t.getAttribute('data-pair-id') === pairId);
+          if (right) {
+            await user.click(left);
+            await user.click(right);
+          }
+        }
+      } },
+      { mode: 'choice', deck: sampleDeckWithOnlyMode('knyha', 'choice'), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /книга/ })); } },
+      { mode: 'stress', deck: stressDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button'); await user.click(buttons[1]!); } },
+      { mode: 'classify', deck: classifyDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /жіночий/ })); } },
+      { mode: 'synonym', deck: synonymDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /кава/ })); } },
+    ])('$mode: rail is $expectRail', async ({ mode, deck, expectRail, action }) => {
+      const user = userEvent.setup();
+      const { container } = render(<LexiconPractice initialDeck={deck} autoStart initialMode={mode as any} />);
+
+      await action(user, container);
+
+      if (expectRail) {
+        expect(screen.getByTestId('practice-form-rail')).toBeInTheDocument();
+      } else {
+        expect(screen.queryByTestId('practice-form-rail')).not.toBeInTheDocument();
+      }
+    });
+  });
+
+  test('heritage rail preserves source "день" and rail form "днями" while sentence keeps "Днями"', async () => {
+    const item: PracticeHeritageItem = {
+      ...heritagePracticeItem(),
+      heritageId: 'her-den-fixture',
+      lemmaId: 'den',
+      srsKey: cardKey('den', 'heritage'),
+      lemma: 'день',
+      nativeLemma: 'день',
+      calqueLabel: 'дом',
+      prompt: '___ я був у місті.',
+      answer: 'днями',
+      options: [
+        { label: 'Днями' },
+        { label: 'домами' },
+      ],
+      rationaleUk: 'питоме українське слово',
+    };
+    const deck: PracticeDeckData = {
+      ...heritageDeck(),
+      lexemes: [lexeme('den', 'день', 'day', { nominative: 'день', accusative: 'день', locative: 'дні' })],
+      index: [{
+        lemmaId: 'den',
+        lemma: 'день',
+        cefr: 'A2',
+        modes: ['heritage'],
+        hasCloze: false,
+        clozeIds: [],
+        newOrder: 0,
+      }],
+      heritage: [item],
+    };
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={deck} autoStart initialMode="heritage" />);
+
+    await user.click(within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /Днями/ }));
+
+    const rail = screen.getByTestId('practice-form-rail');
+    expect(rail).toHaveTextContent('день');
+    expect(rail).toHaveTextContent('днями');
+    expect(rail).not.toHaveTextContent('Днями');
+
+    const sentence = within(screen.getByTestId('practice-heritage')).getByText((_, element) =>
+      element?.classList.contains('heritage-slot') ?? false,
+    );
+    expect(sentence).toHaveTextContent('Днями');
   });
 
   test('summary renders score ratio and Ukrainian proverb', () => {


### PR DESCRIPTION
Chunk 5 of the K3 practice redesign: generalized form rail + N-vowel stress.

## What changed
- `site/src/components/PracticeFormRail.tsx` (new): typed source/actual entries and `idle | correct | wrong | calque` verdict states.
- `site/src/components/PracticeStress.tsx` (new): renders arbitrary-length stress choices by iterating `Array.from(item.unstressed)` and replacing only the code-point positions listed in `item.nuclei` with vowel buttons.
- `site/src/components/LexiconPractice.tsx`:
  - Threads selected labels / stress index through state and into `PracticeItem`.
  - Renders the form rail for **cloze, paradigm, paronym, and heritage** only (no rail for recognition-only modes).
  - Cloze chips now populate the input; only the explicit **Check** action commits and locks.
  - Heritage sentence slot preserves the selected option's capitalization while the rail shows the canonical `item.answer`.
- `site/src/pages/words-of-the-day/practice.astro`: route-local CSS for `.practice-form-rail`, `.lexicon-stress`, `.practice-stress-word`, `.stress-vowel`, and verdict states.
- `site/tests/unit/LexiconPractice.test.tsx`: N-vowel stress fixtures (2/3/5 nuclei), rail presence/absence matrix, heritage capitalization rail test, and updated cloze chip tests.
- `site/e2e/atlas-practice.spec.ts`: stress-mode smoke test.
- `docs/lesson-schema.yaml`: regenerated because site components changed.

## Verification
```bash
cd site && npx vitest run tests/unit/LexiconPractice.test.tsx tests/unit/k3-chrome-locale.test.ts
# Test Files  2 passed (2)
#      Tests  100 passed (100)

cd site && npx playwright test e2e/atlas-practice.spec.ts
# 15 passed (3.3s)

cd site && npx tsc --noEmit
# 0 errors in changed components (pre-existing errors are in packages/activity-kit)

.venv/bin/python scripts/build/generate_lesson_schema.py
.venv/bin/python -m pytest tests/test_lesson_schema.py tests/test_prompt_substitution.py -q
# 17 passed
.venv/bin/python -m ruff check scripts/build/generate_lesson_schema.py scripts/build/prompt_builder.py tests/test_lesson_schema.py tests/test_prompt_substitution.py
# All checks passed!

cd site && npm run build
# [build] 8973 page(s) built — complete
```

## Designer note — done-row AA contrast
The frozen `0.62` opacity over `--lu-surface-raised` produces composite contrast below WCAG AA 4.5:1 for done-row text in light mode and below 3:1 for markers in light mode:
- Light text (`--lu-text-muted` #676F7A @ 0.62 over #fff): **~2.45:1**
- Dark text (`--lu-text-muted` #A9B2BF @ 0.62 over #1D232B): **~3.75:1**
- Green marker (`--lu-green` #2E7D32 @ 0.62 over #fff): **~2.45:1**

Mathematically, no text color can reach 4.5:1 at 62% opacity over a white background (max possible with black is ~2.44:1). The opacity threshold was not weakened. A design decision is needed to either accept a non-white done-row background in light mode or raise the opacity. This PR leaves the frozen `0.62` value intact and surfaces the conflict rather than improvising.

Refs #5230
