### PR TITLE
feat(agent-runtime): add phase-one SQLite session streams

### DIFF
--- a/agents_extensions/shared/session_streams/__init__.py
+++ b/agents_extensions/shared/session_streams/__init__.py
@@ -1,0 +1,28 @@
+"""Agent-agnostic, append-only epic session streams."""
+
+from .db import SessionStreamDatabase, default_database_path
+from .model import (
+    Entry,
+    EntryRef,
+    EntryType,
+    ForceCloseProof,
+    Lease,
+    LeaseHolder,
+    SessionState,
+    StreamDigest,
+)
+from .store import SessionStreamStore
+
+__all__ = [
+    "Entry",
+    "EntryRef",
+    "EntryType",
+    "ForceCloseProof",
+    "Lease",
+    "LeaseHolder",
+    "SessionState",
+    "SessionStreamDatabase",
+    "SessionStreamStore",
+    "StreamDigest",
+    "default_database_path",
+]

--- a/agents_extensions/shared/session_streams/__main__.py
+++ b/agents_extensions/shared/session_streams/__main__.py
@@ -1,0 +1,5 @@
+"""Run the session-stream CLI with ``python -m``."""
+
+from .cli import main
+
+raise SystemExit(main())

--- a/agents_extensions/shared/session_streams/cli.py
+++ b/agents_extensions/shared/session_streams/cli.py
@@ -1,0 +1,283 @@
+"""Operator and harness CLI for phase-one session streams."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .db import SessionStreamDatabase
+from .dual_write import ATLAS_HANDOFF_PATH, mirror_atlas_handoff
+from .hooks import clean_exit_hook, heartbeat_hook, lease_from_environment
+from .model import entry_as_dict
+from .store import NotFoundError, SessionStreamError, SessionStreamStore
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="session-streams",
+        description=(
+            "Read agent-agnostic epic session streams and invoke their harness hook surface.\n"
+            "Use during phase-one shadow/dual-write operation; do not use it to cut over or retire file handoffs."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Examples:
+  .venv/bin/python -m agents_extensions.shared.session_streams tail --stream epic:4707 --limit 20
+  .venv/bin/python -m agents_extensions.shared.session_streams dump --stream epic:4707 --format jsonl --output /tmp/stream.jsonl
+  .venv/bin/python -m agents_extensions.shared.session_streams hook heartbeat
+
+Outputs:
+  tail writes a bounded pinned-plus-recent view to stdout. dump writes complete stream history
+  to stdout or atomically to --output. hook mutates only the exact leased lifecycle projection.
+
+Exit codes:
+  0 success; 2 CLI usage; 3 exact stream not found; 4 lifecycle/lease/content refusal; 5 unexpected failure.
+
+Related:
+  agents_extensions/shared/docs/session-streams-design.md; tracking issue #5422; stream epic #4707.
+""",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help=(
+            "SQLite database path. Default: canonical primary-checkout "
+            ".agent/session-streams/v1/session-streams.sqlite3."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    tail = subparsers.add_parser(
+        "tail",
+        help="Print pinned entries followed by the last N non-pinned entries.",
+        description="Print the deterministic cold-start projection for one exact stream.",
+    )
+    tail.add_argument(
+        "--stream",
+        required=True,
+        help="Exact stream ID, for example epic:4707 or shared:fleet.",
+    )
+    tail.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Number of recent non-pinned entries to include. Default: 20; range: 0-10000.",
+    )
+    tail.add_argument(
+        "--format",
+        choices=("table", "json"),
+        default="table",
+        help="Output rendering. Default: table; json preserves full typed envelopes.",
+    )
+
+    dump = subparsers.add_parser(
+        "dump",
+        help="Export complete ordered history for one stream.",
+        description="Dump sessions, leases, events, entries, refs, migrations, and legacy mirror receipts.",
+    )
+    dump.add_argument(
+        "--stream",
+        required=True,
+        help="Exact stream ID, for example epic:4707 or shared:fleet.",
+    )
+    dump.add_argument(
+        "--format",
+        choices=("json", "jsonl"),
+        default="json",
+        help="Portable output encoding. Default: json; jsonl emits one typed record per line.",
+    )
+    dump.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Atomic output file path. Default: stdout; example: /tmp/epic-4707.jsonl.",
+    )
+
+    hook = subparsers.add_parser(
+        "hook",
+        help="Run the common harness-owned heartbeat or clean-exit hook.",
+        description=(
+            "Renew or close the exact lease from SESSION_STREAM_* environment fields. "
+            "This surface is provider-independent."
+        ),
+    )
+    hook.add_argument(
+        "action",
+        choices=("heartbeat", "close"),
+        help="Harness lifecycle action: heartbeat renews TTL; close performs idempotent clean-exit close.",
+    )
+
+    mirror = subparsers.add_parser(
+        "mirror-atlas",
+        help="Mirror the Atlas file handoff into an explicit stream without cutover.",
+        description=(
+            "Read a stable Atlas handoff file, append it as state under the exact lease, and record its hash. "
+            "The source file remains authoritative and is never edited or deleted."
+        ),
+    )
+    mirror.add_argument(
+        "--stream",
+        required=True,
+        help="Explicit Atlas stream ID, for example epic:4700; no Atlas epic is guessed.",
+    )
+    mirror.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root containing the legacy handoff. Default: current working directory.",
+    )
+    mirror.add_argument(
+        "--source",
+        type=Path,
+        default=ATLAS_HANDOFF_PATH,
+        help=(
+            "Atlas handoff path relative to --repo-root. "
+            "Default: .claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    store = SessionStreamStore(SessionStreamDatabase(args.db))
+    try:
+        if args.command == "tail":
+            return _tail(store, args)
+        if args.command == "dump":
+            return _dump(store, args)
+        if args.command == "hook":
+            return _hook(store, args)
+        if args.command == "mirror-atlas":
+            return _mirror_atlas(store, args)
+        parser.error(f"unsupported command: {args.command}")
+    except NotFoundError as exc:
+        print(f"session-streams: {exc}", file=sys.stderr)
+        return 3
+    except (SessionStreamError, ValueError) as exc:
+        print(f"session-streams: {exc}", file=sys.stderr)
+        return 4
+    except Exception as exc:  # pragma: no cover - final CLI safety net
+        print(f"session-streams: unexpected failure: {exc}", file=sys.stderr)
+        return 5
+    return 5
+
+
+def _tail(store: SessionStreamStore, args: argparse.Namespace) -> int:
+    digest = store.load_digest(args.stream, limit=args.limit)
+    if args.format == "json":
+        payload = {
+            "stream": digest.stream_id,
+            "limit": digest.limit,
+            "high_water_entry_id": digest.high_water_entry_id,
+            "digest_sha256": digest.digest_sha256,
+            "pinned": [entry_as_dict(entry) for entry in digest.pinned],
+            "recent": [entry_as_dict(entry) for entry in digest.recent],
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    print("section\tentry_id\ttype\tts\tagent\tharness\tbody")
+    for section, entries in (("PINNED", digest.pinned), ("RECENT", digest.recent)):
+        for entry in entries:
+            body = entry.body.replace("\t", "\\t").replace("\r", "\\r").replace("\n", "\\n")
+            print(
+                f"{section}\t{entry.entry_id}\t{entry.type.value}\t{entry.ts}\t"
+                f"{entry.agent}\t{entry.harness}\t{body}"
+            )
+    return 0
+
+
+def _dump(store: SessionStreamStore, args: argparse.Namespace) -> int:
+    payload = store.dump_stream(args.stream)
+    if args.format == "json":
+        rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    else:
+        rendered = _dump_jsonl(payload)
+    if args.output is None:
+        print(rendered, end="")
+    else:
+        _atomic_write(args.output, rendered)
+        print(str(args.output))
+    return 0
+
+
+def _hook(store: SessionStreamStore, args: argparse.Namespace) -> int:
+    lease = lease_from_environment()
+    result = heartbeat_hook(store, lease) if args.action == "heartbeat" else clean_exit_hook(store, lease)
+    print(json.dumps(result.__dict__, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+def _mirror_atlas(store: SessionStreamStore, args: argparse.Namespace) -> int:
+    lease = lease_from_environment()
+    result = mirror_atlas_handoff(
+        store,
+        lease,
+        repo_root=args.repo_root,
+        stream_id=args.stream,
+        source_path=args.source,
+    )
+    print(
+        json.dumps(
+            {
+                "profile": result.profile,
+                "source_path": result.source_path,
+                "source_sha256": result.source_sha256,
+                "source_bytes": result.source_bytes,
+                "entry_id": result.entry.entry_id,
+                "mirror_id": result.mirror_id,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _dump_jsonl(payload: dict[str, Any]) -> str:
+    lines: list[str] = []
+    for key, value in payload.items():
+        if isinstance(value, list):
+            lines.extend(
+                json.dumps({"record_type": key, "data": row}, ensure_ascii=False, sort_keys=True)
+                for row in value
+            )
+        elif value is not None:
+            lines.append(
+                json.dumps({"record_type": key, "data": value}, ensure_ascii=False, sort_keys=True)
+            )
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    target = path.resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_name = handle.name
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, target)
+        temporary_name = None
+        directory_fd = os.open(target.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)

--- a/agents_extensions/shared/session_streams/db.py
+++ b/agents_extensions/shared/session_streams/db.py
@@ -1,0 +1,224 @@
+"""SQLite connection, migration, and canonical-path management."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import subprocess
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from .model import isoformat_z, utc_now
+
+DEFAULT_RELATIVE_DATABASE = Path(".agent/session-streams/v1/session-streams.sqlite3")
+MIGRATIONS_DIR = Path(__file__).with_name("migrations")
+BUSY_TIMEOUT_MS = 5_000
+
+
+class SessionStreamDatabaseError(RuntimeError):
+    """Base error for a database that cannot safely serve session streams."""
+
+
+class MigrationError(SessionStreamDatabaseError):
+    """Raised when a schema receipt or migration is inconsistent."""
+
+
+@dataclass(frozen=True)
+class Migration:
+    version: int
+    name: str
+    sql: str
+    sha256: str
+
+
+def canonical_state_root(repo_root: Path | None = None) -> Path:
+    """Resolve the primary checkout shared by every linked worktree."""
+    active_root = (repo_root or Path.cwd()).resolve()
+    result = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=active_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    common_dir_text = result.stdout.strip()
+    if result.returncode != 0 or not common_dir_text:
+        detail = result.stderr.strip() or "git did not report a common directory"
+        raise SessionStreamDatabaseError(f"cannot resolve canonical state root: {detail}")
+    common_dir = Path(common_dir_text)
+    if not common_dir.is_absolute() or common_dir.name != ".git":
+        raise SessionStreamDatabaseError(
+            f"cannot derive primary checkout from Git common directory: {common_dir_text!r}"
+        )
+    return common_dir.parent.resolve()
+
+
+def default_database_path(repo_root: Path | None = None) -> Path:
+    return canonical_state_root(repo_root) / DEFAULT_RELATIVE_DATABASE
+
+
+def load_migrations() -> tuple[Migration, ...]:
+    migrations: list[Migration] = []
+    for path in sorted(MIGRATIONS_DIR.glob("[0-9][0-9][0-9][0-9]_*.sql")):
+        prefix, _, _ = path.name.partition("_")
+        version = int(prefix)
+        sql = path.read_text(encoding="utf-8")
+        migrations.append(
+            Migration(
+                version=version,
+                name=path.name,
+                sql=sql,
+                sha256=hashlib.sha256(sql.encode("utf-8")).hexdigest(),
+            )
+        )
+    if not migrations:
+        raise MigrationError(f"no session-stream migrations found under {MIGRATIONS_DIR}")
+    versions = [migration.version for migration in migrations]
+    if versions != list(range(1, len(versions) + 1)):
+        raise MigrationError(f"migration versions must be contiguous from 1; got {versions}")
+    return tuple(migrations)
+
+
+class SessionStreamDatabase:
+    """Open configured SQLite connections and verify forward-only migrations."""
+
+    def __init__(self, path: Path | str | None = None, *, repo_root: Path | None = None) -> None:
+        self.path = Path(path).resolve() if path is not None else default_database_path(repo_root)
+
+    def connect(self, *, read_only: bool = False, now: datetime | None = None) -> sqlite3.Connection:
+        if read_only:
+            if not self.path.is_file():
+                raise SessionStreamDatabaseError(f"session-stream database does not exist: {self.path}")
+            connection = sqlite3.connect(
+                f"file:{self.path}?mode=ro",
+                uri=True,
+                isolation_level=None,
+                timeout=BUSY_TIMEOUT_MS / 1000,
+            )
+        else:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            connection = sqlite3.connect(
+                self.path,
+                isolation_level=None,
+                timeout=BUSY_TIMEOUT_MS / 1000,
+            )
+        connection.row_factory = sqlite3.Row
+        try:
+            self._configure(connection, read_only=read_only)
+            if read_only:
+                self._verify_migrations(connection)
+                connection.execute("PRAGMA query_only = ON")
+            else:
+                self._apply_migrations(connection, now=now or utc_now())
+            return connection
+        except Exception:
+            connection.close()
+            raise
+
+    @staticmethod
+    def _configure(connection: sqlite3.Connection, *, read_only: bool) -> None:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
+        connection.execute("PRAGMA synchronous = FULL")
+        if not read_only:
+            journal_mode = str(connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]).lower()
+            if journal_mode != "wal":
+                raise SessionStreamDatabaseError(f"WAL mode required, SQLite returned {journal_mode!r}")
+        foreign_keys = int(connection.execute("PRAGMA foreign_keys").fetchone()[0])
+        synchronous = int(connection.execute("PRAGMA synchronous").fetchone()[0])
+        if foreign_keys != 1:
+            raise SessionStreamDatabaseError("foreign_keys pragma did not remain enabled")
+        if synchronous != 2:
+            raise SessionStreamDatabaseError(f"FULL synchronous mode required, SQLite returned {synchronous}")
+
+    @staticmethod
+    def _has_migration_table(connection: sqlite3.Connection) -> bool:
+        return (
+            connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'"
+            ).fetchone()
+            is not None
+        )
+
+    @staticmethod
+    def _non_internal_tables(connection: sqlite3.Connection) -> list[str]:
+        rows = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+        return [str(row[0]) for row in rows]
+
+    def _apply_migrations(self, connection: sqlite3.Connection, *, now: datetime) -> None:
+        migrations = load_migrations()
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            if not self._has_migration_table(connection):
+                unexpected_tables = self._non_internal_tables(connection)
+                if unexpected_tables:
+                    raise MigrationError(
+                        "refusing to initialize an unmanaged non-empty database: "
+                        + ", ".join(unexpected_tables)
+                    )
+                self._apply_one_locked(connection, migrations[0], now=now)
+            self._verify_migrations(connection)
+            applied_versions = {
+                int(row[0])
+                for row in connection.execute("SELECT version FROM schema_migrations").fetchall()
+            }
+            for migration in migrations:
+                if migration.version not in applied_versions:
+                    self._apply_one_locked(connection, migration, now=now)
+            self._verify_migrations(connection)
+            connection.execute("COMMIT")
+        except Exception:
+            with suppress(sqlite3.Error):
+                connection.execute("ROLLBACK")
+            raise
+
+    def _verify_migrations(self, connection: sqlite3.Connection) -> None:
+        if not self._has_migration_table(connection):
+            raise MigrationError("schema_migrations table is missing")
+        expected = {migration.version: migration for migration in load_migrations()}
+        rows = connection.execute(
+            "SELECT version, name, ddl_sha256 FROM schema_migrations ORDER BY version"
+        ).fetchall()
+        for row in rows:
+            version = int(row["version"])
+            migration = expected.get(version)
+            if migration is None:
+                raise MigrationError(f"database schema version {version} is newer than this runtime")
+            if row["name"] != migration.name or row["ddl_sha256"] != migration.sha256:
+                raise MigrationError(f"migration fingerprint mismatch at version {version}")
+        applied = [int(row["version"]) for row in rows]
+        if applied != list(range(1, len(applied) + 1)):
+            raise MigrationError(f"applied migration versions are not contiguous: {applied}")
+
+    @staticmethod
+    def _apply_one_locked(connection: sqlite3.Connection, migration: Migration, *, now: datetime) -> None:
+        try:
+            for statement in _split_sql_statements(migration.sql):
+                connection.execute(statement)
+            connection.execute(
+                "INSERT INTO schema_migrations(version, name, ddl_sha256, applied_at) VALUES (?, ?, ?, ?)",
+                (migration.version, migration.name, migration.sha256, isoformat_z(now)),
+            )
+        except sqlite3.Error as exc:
+            raise MigrationError(f"migration {migration.name} failed: {exc}") from exc
+
+
+def _split_sql_statements(sql: str) -> tuple[str, ...]:
+    """Split trusted migration SQL while preserving trigger BEGIN/END bodies."""
+    statements: list[str] = []
+    buffer = ""
+    for line in sql.splitlines(keepends=True):
+        buffer += line
+        if sqlite3.complete_statement(buffer):
+            statement = buffer.strip()
+            if statement:
+                statements.append(statement)
+            buffer = ""
+    if buffer.strip():
+        raise MigrationError("migration SQL ended with an incomplete statement")
+    return tuple(statements)

--- a/agents_extensions/shared/session_streams/db.py
+++ b/agents_extensions/shared/session_streams/db.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import random
 import sqlite3
 import subprocess
+import time
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
@@ -15,6 +17,10 @@ from .model import isoformat_z, utc_now
 DEFAULT_RELATIVE_DATABASE = Path(".agent/session-streams/v1/session-streams.sqlite3")
 MIGRATIONS_DIR = Path(__file__).with_name("migrations")
 BUSY_TIMEOUT_MS = 5_000
+# Bounded serialization for concurrent first-open/migration (see connect()).
+_LOCK_RETRY_ATTEMPTS = 6
+_LOCK_RETRY_BASE_S = 0.25
+_LOCK_RETRY_CAP_S = 4.0
 
 
 class SessionStreamDatabaseError(RuntimeError):
@@ -89,6 +95,35 @@ class SessionStreamDatabase:
         self.path = Path(path).resolve() if path is not None else default_database_path(repo_root)
 
     def connect(self, *, read_only: bool = False, now: datetime | None = None) -> sqlite3.Connection:
+        """Open a configured connection, serializing concurrent first-open.
+
+        Two processes racing to initialize/migrate the database must SERIALIZE,
+        never surface ``database is locked`` (design: concurrent first-open
+        contention resolves with the loser proceeding against the winner's
+        state). ``busy_timeout`` covers in-transaction waits; this bounded
+        retry covers lock windows that exceed it (slow CI disks under xdist,
+        FULL synchronous DDL application).
+        """
+        if read_only:
+            return self._connect_once(read_only=True, now=now)
+        last_error: sqlite3.OperationalError | None = None
+        for attempt in range(_LOCK_RETRY_ATTEMPTS):
+            try:
+                return self._connect_once(read_only=False, now=now)
+            except sqlite3.OperationalError as error:
+                message = str(error).lower()
+                if "locked" not in message and "busy" not in message:
+                    raise
+                last_error = error
+                if attempt == _LOCK_RETRY_ATTEMPTS - 1:
+                    break
+                delay = min(_LOCK_RETRY_BASE_S * (2**attempt), _LOCK_RETRY_CAP_S)
+                time.sleep(delay + random.uniform(0, delay / 2))
+        raise SessionStreamDatabaseError(
+            f"database stayed locked across {_LOCK_RETRY_ATTEMPTS} bounded retries: {self.path}"
+        ) from last_error
+
+    def _connect_once(self, *, read_only: bool, now: datetime | None) -> sqlite3.Connection:
         if read_only:
             if not self.path.is_file():
                 raise SessionStreamDatabaseError(f"session-stream database does not exist: {self.path}")

--- a/agents_extensions/shared/session_streams/dual_write.py
+++ b/agents_extensions/shared/session_streams/dual_write.py
@@ -1,0 +1,99 @@
+"""Non-destructive legacy-handoff mirroring for dual-write migration."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from .model import Entry, EntryRef, EntryType, Lease
+from .store import SessionStreamStore
+
+ATLAS_PROFILE = "atlas"
+ATLAS_HANDOFF_PATH = Path(".claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md")
+
+
+@dataclass(frozen=True)
+class MirrorResult:
+    profile: str
+    source_path: str
+    source_sha256: str
+    source_bytes: int
+    entry: Entry
+    mirror_id: int
+
+
+def mirror_atlas_handoff(
+    store: SessionStreamStore,
+    lease: Lease,
+    *,
+    repo_root: Path,
+    stream_id: str,
+    source_path: Path = ATLAS_HANDOFF_PATH,
+    now: datetime | None = None,
+) -> MirrorResult:
+    """Mirror the Atlas file handoff into an explicitly selected epic stream."""
+    return mirror_handoff_file(
+        store,
+        lease,
+        profile=ATLAS_PROFILE,
+        repo_root=repo_root,
+        stream_id=stream_id,
+        source_path=source_path,
+        now=now,
+    )
+
+
+def mirror_handoff_file(
+    store: SessionStreamStore,
+    lease: Lease,
+    *,
+    profile: str,
+    repo_root: Path,
+    stream_id: str,
+    source_path: Path,
+    now: datetime | None = None,
+) -> MirrorResult:
+    """Append one stable legacy file image without editing or retiring the file."""
+    if stream_id != lease.stream_id:
+        raise ValueError("explicit mirror stream must match the supplied lease")
+    root = repo_root.resolve()
+    candidate = source_path if source_path.is_absolute() else root / source_path
+    resolved = candidate.resolve(strict=True)
+    try:
+        relative = resolved.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ValueError("legacy handoff source must stay inside the selected repository root") from exc
+    first = resolved.read_bytes()
+    second = resolved.read_bytes()
+    if first != second:
+        raise RuntimeError("legacy handoff changed while it was being mirrored; retry the stable image")
+    body = first.decode("utf-8")
+    source_sha256 = hashlib.sha256(first).hexdigest()
+    idempotency_key = f"legacy-mirror:{profile}:{relative}:{source_sha256}"
+    entry = store.append_entry(
+        lease,
+        entry_type=EntryType.STATE,
+        body=body,
+        idempotency_key=idempotency_key,
+        refs=(EntryRef(kind="legacy_source", uri=f"legacy://{relative}?sha256={source_sha256}"),),
+        now=now,
+    )
+    mirror_id = store.record_legacy_mirror(
+        lease,
+        profile=profile,
+        source_path=relative,
+        source_sha256=source_sha256,
+        source_bytes=len(first),
+        entry=entry,
+        now=now,
+    )
+    return MirrorResult(
+        profile=profile,
+        source_path=relative,
+        source_sha256=source_sha256,
+        source_bytes=len(first),
+        entry=entry,
+        mirror_id=mirror_id,
+    )

--- a/agents_extensions/shared/session_streams/hooks.py
+++ b/agents_extensions/shared/session_streams/hooks.py
@@ -1,0 +1,87 @@
+"""Fleet-generic harness heartbeat and clean-exit hook surface."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+
+from .model import Lease, LeaseHolder
+from .store import SessionStreamStore
+
+ENV_PREFIX = "SESSION_STREAM_"
+
+
+@dataclass(frozen=True)
+class HookResult:
+    action: str
+    stream_id: str
+    session_id: str
+    state: str
+    expires_at: str | None = None
+
+
+def lease_from_environment(environment: Mapping[str, str] | None = None) -> Lease:
+    """Load the exact harness-owned lease envelope supplied at process start."""
+    values = environment or os.environ
+
+    def required(name: str) -> str:
+        value = values.get(f"{ENV_PREFIX}{name}", "").strip()
+        if not value:
+            raise ValueError(f"missing required hook environment: {ENV_PREFIX}{name}")
+        return value
+
+    holder = LeaseHolder(
+        agent=required("AGENT"),
+        harness=required("HARNESS"),
+        instance_id=required("INSTANCE_ID"),
+        task_id=values.get(f"{ENV_PREFIX}TASK_ID") or None,
+        process_id=int(required("PROCESS_ID")),
+    )
+    holder.validate()
+    return Lease(
+        stream_id=required("ID"),
+        session_id=required("SESSION_ID"),
+        lease_id=required("LEASE_ID"),
+        generation=int(required("GENERATION")),
+        fencing_token=int(required("FENCING_TOKEN")),
+        holder=holder,
+        heartbeat_at=values.get(f"{ENV_PREFIX}HEARTBEAT_AT", "1970-01-01T00:00:00Z"),
+        expires_at=values.get(f"{ENV_PREFIX}EXPIRES_AT", "1970-01-01T00:00:00Z"),
+        ttl_seconds=int(values.get(f"{ENV_PREFIX}TTL_SECONDS", "300")),
+        version=int(values.get(f"{ENV_PREFIX}VERSION", "1")),
+    )
+
+
+def heartbeat_hook(
+    store: SessionStreamStore,
+    lease: Lease,
+    *,
+    now: datetime | None = None,
+) -> HookResult:
+    """Renew the exact holder without relying on model-authored commands."""
+    renewed = store.heartbeat(lease, now=now)
+    return HookResult(
+        action="heartbeat",
+        stream_id=renewed.stream_id,
+        session_id=renewed.session_id,
+        state=store.session_state(renewed.stream_id, renewed.session_id).value,
+        expires_at=renewed.expires_at,
+    )
+
+
+def clean_exit_hook(
+    store: SessionStreamStore,
+    lease: Lease,
+    *,
+    now: datetime | None = None,
+) -> HookResult:
+    """Close the exact session idempotently when its harness exits cleanly."""
+    state = store.close_session(lease, now=now)
+    return HookResult(
+        action="close",
+        stream_id=lease.stream_id,
+        session_id=lease.session_id,
+        state=state.value,
+    )

--- a/agents_extensions/shared/session_streams/migrations/0001_initial.sql
+++ b/agents_extensions/shared/session_streams/migrations/0001_initial.sql
@@ -1,0 +1,433 @@
+CREATE TABLE schema_migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    ddl_sha256 TEXT NOT NULL CHECK (length(ddl_sha256) = 64),
+    applied_at TEXT NOT NULL
+) STRICT;
+
+CREATE TABLE streams (
+    stream_id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL CHECK (kind IN ('epic', 'shared')),
+    epic_number INTEGER,
+    created_at TEXT NOT NULL,
+    CHECK (
+        (kind = 'epic' AND epic_number > 0
+         AND stream_id = 'epic:' || epic_number)
+        OR
+        (kind = 'shared' AND epic_number IS NULL
+         AND stream_id LIKE 'shared:%')
+    )
+) STRICT;
+
+CREATE UNIQUE INDEX streams_one_row_per_epic
+    ON streams(epic_number) WHERE epic_number IS NOT NULL;
+
+CREATE TABLE sessions (
+    session_id TEXT PRIMARY KEY,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    state TEXT NOT NULL CHECK (state IN ('open', 'rolling', 'closed')),
+    lineage_id TEXT NOT NULL,
+    opened_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    closed_at TEXT,
+    state_version INTEGER NOT NULL DEFAULT 1 CHECK (state_version > 0),
+    CHECK (
+        (state = 'closed' AND closed_at IS NOT NULL)
+        OR
+        (state != 'closed' AND closed_at IS NULL)
+    ),
+    UNIQUE (session_id, stream_id)
+) STRICT;
+
+CREATE UNIQUE INDEX sessions_one_live_per_stream
+    ON sessions(stream_id) WHERE state IN ('open', 'rolling');
+
+CREATE TABLE session_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    session_id TEXT NOT NULL,
+    from_state TEXT CHECK (
+        from_state IS NULL OR from_state IN ('open', 'rolling', 'closed')
+    ),
+    to_state TEXT NOT NULL CHECK (to_state IN ('open', 'rolling', 'closed')),
+    ts TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    harness TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    proof_json TEXT NOT NULL DEFAULT '{}'
+        CHECK (json_valid(proof_json)),
+    FOREIGN KEY (session_id, stream_id)
+        REFERENCES sessions(session_id, stream_id)
+) STRICT;
+
+CREATE TABLE lease_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    session_id TEXT NOT NULL,
+    lease_id TEXT NOT NULL,
+    generation INTEGER NOT NULL CHECK (generation > 0),
+    fencing_token INTEGER NOT NULL CHECK (fencing_token > 0),
+    event_type TEXT NOT NULL CHECK (event_type IN (
+        'acquired', 'heartbeat', 'released', 'stale_observed', 'force_closed'
+    )),
+    holder_agent TEXT NOT NULL,
+    holder_harness TEXT NOT NULL,
+    holder_instance_id TEXT NOT NULL,
+    holder_task_id TEXT,
+    holder_process_id INTEGER NOT NULL CHECK (holder_process_id > 0),
+    ttl_seconds INTEGER NOT NULL CHECK (ttl_seconds > 0),
+    ts TEXT NOT NULL,
+    proof_json TEXT NOT NULL DEFAULT '{}'
+        CHECK (json_valid(proof_json)),
+    reason TEXT NOT NULL,
+    FOREIGN KEY (session_id, stream_id)
+        REFERENCES sessions(session_id, stream_id)
+) STRICT;
+
+CREATE TABLE stream_leases (
+    stream_id TEXT PRIMARY KEY REFERENCES streams(stream_id),
+    session_id TEXT NOT NULL,
+    lease_id TEXT NOT NULL UNIQUE,
+    generation INTEGER NOT NULL CHECK (generation > 0),
+    fencing_token INTEGER NOT NULL CHECK (fencing_token > 0),
+    state TEXT NOT NULL CHECK (state IN ('active', 'released')),
+    holder_agent TEXT NOT NULL,
+    holder_harness TEXT NOT NULL,
+    holder_instance_id TEXT NOT NULL,
+    holder_task_id TEXT,
+    holder_process_id INTEGER NOT NULL CHECK (holder_process_id > 0),
+    heartbeat_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    ttl_seconds INTEGER NOT NULL CHECK (ttl_seconds > 0),
+    version INTEGER NOT NULL CHECK (version > 0),
+    last_event_id INTEGER NOT NULL UNIQUE REFERENCES lease_events(event_id),
+    FOREIGN KEY (session_id, stream_id)
+        REFERENCES sessions(session_id, stream_id)
+) STRICT;
+
+CREATE TABLE entries (
+    entry_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    session_id TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    harness TEXT NOT NULL,
+    ts TEXT NOT NULL,
+    type TEXT NOT NULL CHECK (type IN (
+        'binding_order', 'negative_constraint', 'decision',
+        'state', 'next_action', 'note'
+    )),
+    body TEXT NOT NULL CHECK (
+        length(CAST(body AS BLOB)) BETWEEN 1 AND 65536
+    ),
+    body_sha256 TEXT NOT NULL CHECK (length(body_sha256) = 64),
+    origin TEXT NOT NULL CHECK (origin IN ('live', 'migration')),
+    writer_lease_id TEXT,
+    writer_instance_id TEXT,
+    fencing_token INTEGER,
+    idempotency_key TEXT NOT NULL,
+    FOREIGN KEY (session_id, stream_id)
+        REFERENCES sessions(session_id, stream_id),
+    CHECK (
+        (origin = 'live' AND writer_lease_id IS NOT NULL
+         AND writer_instance_id IS NOT NULL AND fencing_token > 0)
+        OR
+        (origin = 'migration' AND writer_lease_id IS NULL
+         AND writer_instance_id IS NULL AND fencing_token IS NULL)
+    ),
+    UNIQUE (stream_id, idempotency_key)
+) STRICT;
+
+CREATE TABLE entry_refs (
+    entry_id INTEGER NOT NULL REFERENCES entries(entry_id),
+    ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+    kind TEXT NOT NULL,
+    target_entry_id INTEGER REFERENCES entries(entry_id),
+    uri TEXT,
+    CHECK (
+        (target_entry_id IS NOT NULL AND uri IS NULL)
+        OR
+        (target_entry_id IS NULL AND uri IS NOT NULL)
+    ),
+    PRIMARY KEY (entry_id, ordinal)
+) STRICT;
+
+CREATE TABLE legacy_mirrors (
+    mirror_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    profile TEXT NOT NULL,
+    source_path TEXT NOT NULL,
+    source_sha256 TEXT NOT NULL CHECK (length(source_sha256) = 64),
+    source_bytes INTEGER NOT NULL CHECK (source_bytes > 0),
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    session_id TEXT NOT NULL,
+    entry_id INTEGER NOT NULL REFERENCES entries(entry_id),
+    mirrored_at TEXT NOT NULL,
+    FOREIGN KEY (session_id, stream_id)
+        REFERENCES sessions(session_id, stream_id),
+    UNIQUE (profile, source_path, source_sha256)
+) STRICT;
+
+CREATE INDEX entries_stream_order ON entries(stream_id, entry_id DESC);
+CREATE INDEX entries_stream_type_order
+    ON entries(stream_id, type, entry_id DESC);
+CREATE INDEX entries_session_order ON entries(session_id, entry_id DESC);
+CREATE INDEX entry_refs_target ON entry_refs(target_entry_id, kind);
+CREATE INDEX session_events_stream_order
+    ON session_events(stream_id, event_id DESC);
+CREATE INDEX lease_events_stream_order
+    ON lease_events(stream_id, event_id DESC);
+
+CREATE UNIQUE INDEX entry_refs_unique_target
+    ON entry_refs(entry_id, kind, target_entry_id)
+    WHERE target_entry_id IS NOT NULL;
+
+CREATE UNIQUE INDEX entry_refs_unique_uri
+    ON entry_refs(entry_id, kind, uri)
+    WHERE uri IS NOT NULL;
+
+CREATE TRIGGER sessions_valid_state_transition
+BEFORE UPDATE OF state ON sessions
+WHEN NEW.state != OLD.state AND NOT (
+    (OLD.state = 'open' AND NEW.state IN ('rolling', 'closed'))
+    OR
+    (OLD.state = 'rolling' AND NEW.state IN ('open', 'closed'))
+)
+BEGIN
+    SELECT RAISE(ABORT, 'invalid session state transition');
+END;
+
+CREATE TRIGGER sessions_closed_are_terminal
+BEFORE UPDATE ON sessions
+WHEN OLD.state = 'closed'
+BEGIN
+    SELECT RAISE(ABORT, 'closed sessions are terminal');
+END;
+
+CREATE TRIGGER sessions_close_requires_released_lease
+BEFORE UPDATE OF state ON sessions
+WHEN NEW.state = 'closed' AND EXISTS (
+    SELECT 1 FROM stream_leases AS lease
+    WHERE lease.stream_id = NEW.stream_id
+      AND lease.session_id = NEW.session_id
+      AND lease.state != 'released'
+)
+BEGIN
+    SELECT RAISE(ABORT, 'session close requires a released lease');
+END;
+
+CREATE TRIGGER sessions_no_delete
+BEFORE DELETE ON sessions
+BEGIN
+    SELECT RAISE(ABORT, 'sessions are never deleted');
+END;
+
+CREATE TRIGGER streams_no_update
+BEFORE UPDATE ON streams
+BEGIN
+    SELECT RAISE(ABORT, 'stream identity is immutable');
+END;
+
+CREATE TRIGGER streams_no_delete
+BEFORE DELETE ON streams
+BEGIN
+    SELECT RAISE(ABORT, 'streams are never deleted');
+END;
+
+CREATE TRIGGER leases_never_target_closed_session_insert
+BEFORE INSERT ON stream_leases
+WHEN NEW.state != 'released' AND EXISTS (
+    SELECT 1 FROM sessions AS session
+    WHERE session.session_id = NEW.session_id AND session.state = 'closed'
+)
+BEGIN
+    SELECT RAISE(ABORT, 'closed session cannot hold a lease');
+END;
+
+CREATE TRIGGER leases_never_target_closed_session_update
+BEFORE UPDATE ON stream_leases
+WHEN NEW.state != 'released' AND EXISTS (
+    SELECT 1 FROM sessions AS session
+    WHERE session.session_id = NEW.session_id AND session.state = 'closed'
+)
+BEGIN
+    SELECT RAISE(ABORT, 'closed session cannot hold or regain a lease');
+END;
+
+CREATE TRIGGER leases_projection_event_matches_insert
+BEFORE INSERT ON stream_leases
+WHEN NOT EXISTS (
+    SELECT 1 FROM lease_events AS event
+    WHERE event.event_id = NEW.last_event_id
+      AND event.stream_id = NEW.stream_id
+      AND event.session_id = NEW.session_id
+      AND event.lease_id = NEW.lease_id
+      AND event.generation = NEW.generation
+      AND event.fencing_token = NEW.fencing_token
+      AND event.holder_agent = NEW.holder_agent
+      AND event.holder_harness = NEW.holder_harness
+      AND event.holder_instance_id = NEW.holder_instance_id
+      AND event.holder_task_id IS NEW.holder_task_id
+      AND event.holder_process_id = NEW.holder_process_id
+      AND event.ttl_seconds = NEW.ttl_seconds
+)
+BEGIN
+    SELECT RAISE(ABORT, 'lease projection must match its lease event');
+END;
+
+CREATE TRIGGER leases_projection_event_matches_update
+BEFORE UPDATE ON stream_leases
+WHEN NOT EXISTS (
+    SELECT 1 FROM lease_events AS event
+    WHERE event.event_id = NEW.last_event_id
+      AND event.stream_id = NEW.stream_id
+      AND event.session_id = NEW.session_id
+      AND event.lease_id = NEW.lease_id
+      AND event.generation = NEW.generation
+      AND event.fencing_token = NEW.fencing_token
+      AND event.holder_agent = NEW.holder_agent
+      AND event.holder_harness = NEW.holder_harness
+      AND event.holder_instance_id = NEW.holder_instance_id
+      AND event.holder_task_id IS NEW.holder_task_id
+      AND event.holder_process_id = NEW.holder_process_id
+      AND event.ttl_seconds = NEW.ttl_seconds
+)
+BEGIN
+    SELECT RAISE(ABORT, 'lease projection must match its lease event');
+END;
+
+CREATE TRIGGER leases_projection_monotonic
+BEFORE UPDATE ON stream_leases
+WHEN NOT (
+    NEW.version > OLD.version
+    AND NEW.last_event_id > OLD.last_event_id
+    AND NEW.fencing_token >= OLD.fencing_token
+    AND NEW.generation >= OLD.generation
+    AND (
+        (
+            NEW.session_id = OLD.session_id
+            AND NEW.lease_id = OLD.lease_id
+            AND NEW.holder_agent = OLD.holder_agent
+            AND NEW.holder_harness = OLD.holder_harness
+            AND NEW.holder_instance_id = OLD.holder_instance_id
+            AND NEW.holder_process_id = OLD.holder_process_id
+        )
+        OR
+        (
+            NEW.fencing_token > OLD.fencing_token
+            AND NEW.generation > OLD.generation
+        )
+    )
+)
+BEGIN
+    SELECT RAISE(ABORT, 'lease projection counters must advance monotonically');
+END;
+
+CREATE TRIGGER leases_no_delete
+BEFORE DELETE ON stream_leases
+BEGIN
+    SELECT RAISE(ABORT, 'lease projections are never deleted');
+END;
+
+CREATE TRIGGER entries_no_update
+BEFORE UPDATE ON entries
+BEGIN
+    SELECT RAISE(ABORT, 'entries are append-only');
+END;
+
+CREATE TRIGGER entries_no_delete
+BEFORE DELETE ON entries
+BEGIN
+    SELECT RAISE(ABORT, 'entries are never deleted');
+END;
+
+CREATE TRIGGER entries_live_append_requires_current_lease
+BEFORE INSERT ON entries
+WHEN NEW.origin = 'live' AND NOT EXISTS (
+    SELECT 1
+    FROM stream_leases AS lease
+    JOIN sessions AS session
+      ON session.session_id = lease.session_id
+     AND session.stream_id = lease.stream_id
+    WHERE lease.stream_id = NEW.stream_id
+      AND lease.session_id = NEW.session_id
+      AND lease.lease_id = NEW.writer_lease_id
+      AND lease.fencing_token = NEW.fencing_token
+      AND lease.holder_agent = NEW.agent
+      AND lease.holder_harness = NEW.harness
+      AND lease.holder_instance_id = NEW.writer_instance_id
+      AND lease.state = 'active'
+      AND lease.expires_at > NEW.ts
+      AND session.state IN ('open', 'rolling')
+)
+BEGIN
+    SELECT RAISE(ABORT, 'live entry requires a valid current fenced lease');
+END;
+
+CREATE TRIGGER entry_refs_no_update
+BEFORE UPDATE ON entry_refs
+BEGIN
+    SELECT RAISE(ABORT, 'entry refs are append-only');
+END;
+
+CREATE TRIGGER entry_refs_no_delete
+BEFORE DELETE ON entry_refs
+BEGIN
+    SELECT RAISE(ABORT, 'entry refs are append-only');
+END;
+
+CREATE TRIGGER session_events_no_update
+BEFORE UPDATE ON session_events
+BEGIN
+    SELECT RAISE(ABORT, 'session events are append-only');
+END;
+
+CREATE TRIGGER session_events_no_delete
+BEFORE DELETE ON session_events
+BEGIN
+    SELECT RAISE(ABORT, 'session events are append-only');
+END;
+
+CREATE TRIGGER session_events_reject_closed_target
+BEFORE INSERT ON session_events
+WHEN EXISTS (
+    SELECT 1 FROM sessions AS session
+    WHERE session.session_id = NEW.session_id AND session.state = 'closed'
+)
+BEGIN
+    SELECT RAISE(ABORT, 'closed sessions accept no later events');
+END;
+
+CREATE TRIGGER lease_events_no_update
+BEFORE UPDATE ON lease_events
+BEGIN
+    SELECT RAISE(ABORT, 'lease events are append-only');
+END;
+
+CREATE TRIGGER lease_events_no_delete
+BEFORE DELETE ON lease_events
+BEGIN
+    SELECT RAISE(ABORT, 'lease events are append-only');
+END;
+
+CREATE TRIGGER schema_migrations_no_update
+BEFORE UPDATE ON schema_migrations
+BEGIN
+    SELECT RAISE(ABORT, 'schema migration receipts are immutable');
+END;
+
+CREATE TRIGGER schema_migrations_no_delete
+BEFORE DELETE ON schema_migrations
+BEGIN
+    SELECT RAISE(ABORT, 'schema migration receipts are never deleted');
+END;
+
+CREATE TRIGGER legacy_mirrors_no_update
+BEFORE UPDATE ON legacy_mirrors
+BEGIN
+    SELECT RAISE(ABORT, 'legacy mirror receipts are append-only');
+END;
+
+CREATE TRIGGER legacy_mirrors_no_delete
+BEFORE DELETE ON legacy_mirrors
+BEGIN
+    SELECT RAISE(ABORT, 'legacy mirror receipts are append-only');
+END;

--- a/agents_extensions/shared/session_streams/model.py
+++ b/agents_extensions/shared/session_streams/model.py
@@ -1,0 +1,226 @@
+"""Typed values shared by the session-stream storage and hook surfaces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+STREAM_ID_RE = re.compile(r"^(?:epic:[1-9][0-9]*|shared:[a-z][a-z0-9-]{0,63})$")
+IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$")
+
+
+class EntryType(StrEnum):
+    """The only entry types accepted by the append API."""
+
+    BINDING_ORDER = "binding_order"
+    NEGATIVE_CONSTRAINT = "negative_constraint"
+    DECISION = "decision"
+    STATE = "state"
+    NEXT_ACTION = "next_action"
+    NOTE = "note"
+
+
+PINNED_ENTRY_TYPES = frozenset({EntryType.BINDING_ORDER, EntryType.NEGATIVE_CONSTRAINT})
+
+
+class SessionState(StrEnum):
+    """Lifecycle states for one driver run."""
+
+    OPEN = "open"
+    ROLLING = "rolling"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True)
+class LeaseHolder:
+    """Exact harness-owned identity for one lease holder."""
+
+    agent: str
+    harness: str
+    instance_id: str
+    process_id: int
+    task_id: str | None = None
+
+    def validate(self) -> None:
+        for label, value in (
+            ("agent", self.agent),
+            ("harness", self.harness),
+            ("instance_id", self.instance_id),
+        ):
+            if not IDENTITY_RE.fullmatch(value):
+                raise ValueError(f"{label} must be a non-empty path-safe identity")
+        if self.task_id is not None and not IDENTITY_RE.fullmatch(self.task_id):
+            raise ValueError("task_id must be a path-safe identity when supplied")
+        if self.process_id <= 0:
+            raise ValueError("process_id must be a positive integer")
+
+
+@dataclass(frozen=True)
+class Lease:
+    """The exact fenced write authority returned by session open/heartbeat."""
+
+    stream_id: str
+    session_id: str
+    lease_id: str
+    generation: int
+    fencing_token: int
+    holder: LeaseHolder
+    heartbeat_at: str
+    expires_at: str
+    ttl_seconds: int
+    version: int
+
+
+@dataclass(frozen=True)
+class EntryRef:
+    """One normalized reference attached to an immutable entry."""
+
+    kind: str
+    uri: str | None = None
+    target_entry_id: int | None = None
+
+    def validate(self) -> None:
+        if not IDENTITY_RE.fullmatch(self.kind):
+            raise ValueError("reference kind must be a path-safe identity")
+        if (self.uri is None) == (self.target_entry_id is None):
+            raise ValueError("a reference must set exactly one of uri or target_entry_id")
+        if self.uri is not None and (not self.uri.strip() or "\x00" in self.uri):
+            raise ValueError("reference uri must be non-empty text without NUL")
+        if self.target_entry_id is not None and self.target_entry_id <= 0:
+            raise ValueError("target_entry_id must be positive")
+
+
+@dataclass(frozen=True)
+class Entry:
+    """One immutable semantic-memory entry."""
+
+    entry_id: int
+    stream_id: str
+    session_id: str
+    agent: str
+    harness: str
+    ts: str
+    type: EntryType
+    body: str
+    body_sha256: str
+    idempotency_key: str
+    refs: tuple[EntryRef, ...] = ()
+
+
+@dataclass(frozen=True)
+class StreamDigest:
+    """Pinned entries followed by a bounded recent non-pinned tail."""
+
+    stream_id: str
+    limit: int
+    pinned: tuple[Entry, ...]
+    recent: tuple[Entry, ...]
+    high_water_entry_id: int
+
+    @property
+    def entries(self) -> tuple[Entry, ...]:
+        return self.pinned + self.recent
+
+    @property
+    def digest_sha256(self) -> str:
+        payload = {
+            "stream_id": self.stream_id,
+            "limit": self.limit,
+            "high_water_entry_id": self.high_water_entry_id,
+            "pinned": [entry_as_dict(entry) for entry in self.pinned],
+            "recent": [entry_as_dict(entry) for entry in self.recent],
+        }
+        return sha256_text(canonical_json(payload))
+
+
+@dataclass(frozen=True)
+class ForceCloseProof:
+    """Recorded proof that an expired holder process was absent at apply time."""
+
+    stream_id: str
+    session_id: str
+    lease_id: str
+    holder_instance_id: str
+    holder_process_id: int
+    heartbeat_at: str
+    expires_at: str
+    observed_at: str
+    heartbeat_age_seconds: int
+    process_probe: str
+    candidate_agent: str
+    candidate_harness: str
+    candidate_instance_id: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "session_stream_force_close.v1",
+            "stream_id": self.stream_id,
+            "session_id": self.session_id,
+            "lease_id": self.lease_id,
+            "holder_instance_id": self.holder_instance_id,
+            "holder_process_id": self.holder_process_id,
+            "heartbeat_at": self.heartbeat_at,
+            "expires_at": self.expires_at,
+            "observed_at": self.observed_at,
+            "heartbeat_age_seconds": self.heartbeat_age_seconds,
+            "process_probe": self.process_probe,
+            "candidate_agent": self.candidate_agent,
+            "candidate_harness": self.candidate_harness,
+            "candidate_instance_id": self.candidate_instance_id,
+        }
+
+
+def validate_stream_id(stream_id: str) -> str:
+    """Return a canonical stream ID or fail closed."""
+    if not STREAM_ID_RE.fullmatch(stream_id):
+        raise ValueError("stream_id must be epic:<positive-number> or shared:<path-safe-name>")
+    return stream_id
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def isoformat_z(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise ValueError("timestamps must be timezone-aware")
+    return value.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("stored timestamps must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def entry_as_dict(entry: Entry) -> dict[str, Any]:
+    return {
+        "entry_id": entry.entry_id,
+        "stream": entry.stream_id,
+        "session_id": entry.session_id,
+        "agent": entry.agent,
+        "harness": entry.harness,
+        "ts": entry.ts,
+        "type": entry.type.value,
+        "body": entry.body,
+        "body_sha256": entry.body_sha256,
+        "idempotency_key": entry.idempotency_key,
+        "refs": [
+            {"kind": ref.kind, "uri": ref.uri, "target_entry_id": ref.target_entry_id}
+            for ref in entry.refs
+        ],
+    }

--- a/agents_extensions/shared/session_streams/store.py
+++ b/agents_extensions/shared/session_streams/store.py
@@ -1,0 +1,927 @@
+"""Transactional append, digest, and lifecycle API for session streams."""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+import uuid
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager, suppress
+from datetime import datetime, timedelta
+from typing import Any
+
+from .db import SessionStreamDatabase
+from .model import (
+    PINNED_ENTRY_TYPES,
+    Entry,
+    EntryRef,
+    EntryType,
+    ForceCloseProof,
+    Lease,
+    LeaseHolder,
+    SessionState,
+    StreamDigest,
+    canonical_json,
+    entry_as_dict,
+    isoformat_z,
+    parse_timestamp,
+    sha256_text,
+    utc_now,
+    validate_stream_id,
+)
+
+MAX_ENTRY_BYTES = 65_536
+MAX_TTL_SECONDS = 86_400
+SECRET_PATTERNS = (
+    ("private-key", re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC |PGP )?PRIVATE KEY-----")),
+    ("credential-token", re.compile(r"(?:sk-|gh[pousr]_|AIza)[A-Za-z0-9_-]{16,}")),
+    (
+        "credential-assignment",
+        re.compile(r"(?i)(?:api[_-]?key|access[_-]?token|secret|password)\s*[:=]\s*[^\s]{8,}"),
+    ),
+)
+EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
+PHONE_RE = re.compile(r"(?<!\w)\+[0-9][0-9 ()-]{7,}[0-9](?!\w)")
+
+
+class SessionStreamError(RuntimeError):
+    """Base runtime error for a refused session-stream operation."""
+
+
+class NotFoundError(SessionStreamError):
+    """Raised when an exact stream/session/lease identity is absent."""
+
+
+class LeaseConflictError(SessionStreamError):
+    """Raised when a mutation lacks the exact current valid lease."""
+
+
+class LifecycleError(SessionStreamError):
+    """Raised when a requested session state change is unsafe."""
+
+
+class ContentRejectedError(SessionStreamError):
+    """Raised without echoing body content when a hygiene rule rejects it."""
+
+
+def process_exists(process_id: int) -> bool:
+    """Return whether a local process currently owns this PID."""
+    try:
+        os.kill(process_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def validate_entry_body(body: str) -> None:
+    if not isinstance(body, str):
+        raise ContentRejectedError("entry body rejected by text-type rule")
+    encoded = body.encode("utf-8")
+    if not encoded:
+        raise ContentRejectedError("entry body rejected by non-empty rule")
+    if len(encoded) > MAX_ENTRY_BYTES:
+        raise ContentRejectedError("entry body rejected by 64-KiB rule")
+    if "\x00" in body or any(ord(char) < 32 and char not in "\n\r\t" for char in body):
+        raise ContentRejectedError("entry body rejected by control-character rule")
+    for rule, pattern in SECRET_PATTERNS:
+        if pattern.search(body):
+            raise ContentRejectedError(f"entry body rejected by {rule} rule")
+    if EMAIL_RE.search(body):
+        raise ContentRejectedError("entry body rejected by email-address rule")
+    if PHONE_RE.search(body):
+        raise ContentRejectedError("entry body rejected by phone-number rule")
+
+
+class SessionStreamStore:
+    """High-level API that keeps lifecycle projections fenced and auditable."""
+
+    def __init__(
+        self,
+        database: SessionStreamDatabase,
+        *,
+        _process_probe: Callable[[int], bool] = process_exists,
+    ) -> None:
+        self.database = database
+        self._process_probe = _process_probe
+
+    @contextmanager
+    def _transaction(self, *, now: datetime | None = None) -> Iterator[sqlite3.Connection]:
+        connection = self.database.connect(now=now)
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            yield connection
+            connection.execute("COMMIT")
+        except Exception:
+            with suppress(sqlite3.Error):
+                connection.execute("ROLLBACK")
+            raise
+        finally:
+            connection.close()
+
+    @contextmanager
+    def _read_snapshot(self) -> Iterator[sqlite3.Connection]:
+        """Hold one WAL snapshot across every query that forms a read response."""
+        connection = self.database.connect(read_only=True)
+        try:
+            connection.execute("BEGIN")
+            yield connection
+            connection.execute("COMMIT")
+        except Exception:
+            with suppress(sqlite3.Error):
+                connection.execute("ROLLBACK")
+            raise
+        finally:
+            connection.close()
+
+    def open_session(
+        self,
+        *,
+        stream_id: str,
+        holder: LeaseHolder,
+        lineage_id: str,
+        ttl_seconds: int,
+        session_id: str | None = None,
+        lease_id: str | None = None,
+        now: datetime | None = None,
+        reason: str = "harness session start",
+    ) -> Lease:
+        """Open a distinct driver-run session only when its stream has no live session."""
+        stream_id = validate_stream_id(stream_id)
+        holder.validate()
+        self._validate_identity("lineage_id", lineage_id)
+        session_id = session_id or f"session-{uuid.uuid4().hex}"
+        lease_id = lease_id or f"lease-{uuid.uuid4().hex}"
+        self._validate_identity("session_id", session_id)
+        self._validate_identity("lease_id", lease_id)
+        self._validate_ttl(ttl_seconds)
+        current_time = now or utc_now()
+        timestamp = isoformat_z(current_time)
+        expires_at = isoformat_z(current_time + timedelta(seconds=ttl_seconds))
+
+        with self._transaction(now=current_time) as connection:
+            self._ensure_stream(connection, stream_id=stream_id, created_at=timestamp)
+            live = connection.execute(
+                "SELECT session_id, state FROM sessions "
+                "WHERE stream_id = ? AND state IN ('open', 'rolling')",
+                (stream_id,),
+            ).fetchone()
+            if live is not None:
+                raise LifecycleError(
+                    f"stream {stream_id} already has live session {live['session_id']} ({live['state']})"
+                )
+            prior_lease = connection.execute(
+                "SELECT * FROM stream_leases WHERE stream_id = ?",
+                (stream_id,),
+            ).fetchone()
+            if prior_lease is not None and prior_lease["state"] != "released":
+                raise LifecycleError(f"stream {stream_id} retains an unreleased lease")
+            generation = 1 if prior_lease is None else int(prior_lease["generation"]) + 1
+            fencing_token = 1 if prior_lease is None else int(prior_lease["fencing_token"]) + 1
+
+            connection.execute(
+                "INSERT INTO sessions("
+                "session_id, stream_id, state, lineage_id, opened_at, updated_at, closed_at, state_version"
+                ") VALUES (?, ?, 'open', ?, ?, ?, NULL, 1)",
+                (session_id, stream_id, lineage_id, timestamp, timestamp),
+            )
+            connection.execute(
+                "INSERT INTO session_events("
+                "stream_id, session_id, from_state, to_state, ts, agent, harness, reason, proof_json"
+                ") VALUES (?, ?, NULL, 'open', ?, ?, ?, ?, '{}')",
+                (stream_id, session_id, timestamp, holder.agent, holder.harness, reason),
+            )
+            lease_event_id = self._insert_lease_event(
+                connection,
+                stream_id=stream_id,
+                session_id=session_id,
+                lease_id=lease_id,
+                generation=generation,
+                fencing_token=fencing_token,
+                event_type="acquired",
+                holder=holder,
+                ttl_seconds=ttl_seconds,
+                timestamp=timestamp,
+                proof={},
+                reason=reason,
+            )
+            if prior_lease is None:
+                connection.execute(
+                    "INSERT INTO stream_leases("
+                    "stream_id, session_id, lease_id, generation, fencing_token, state, "
+                    "holder_agent, holder_harness, holder_instance_id, holder_task_id, holder_process_id, "
+                    "heartbeat_at, expires_at, ttl_seconds, version, last_event_id"
+                    ") VALUES (?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)",
+                    (
+                        stream_id,
+                        session_id,
+                        lease_id,
+                        generation,
+                        fencing_token,
+                        holder.agent,
+                        holder.harness,
+                        holder.instance_id,
+                        holder.task_id,
+                        holder.process_id,
+                        timestamp,
+                        expires_at,
+                        ttl_seconds,
+                        lease_event_id,
+                    ),
+                )
+                version = 1
+            else:
+                version = int(prior_lease["version"]) + 1
+                connection.execute(
+                    "UPDATE stream_leases SET "
+                    "session_id = ?, lease_id = ?, generation = ?, fencing_token = ?, state = 'active', "
+                    "holder_agent = ?, holder_harness = ?, holder_instance_id = ?, holder_task_id = ?, "
+                    "holder_process_id = ?, heartbeat_at = ?, expires_at = ?, ttl_seconds = ?, "
+                    "version = ?, last_event_id = ? WHERE stream_id = ?",
+                    (
+                        session_id,
+                        lease_id,
+                        generation,
+                        fencing_token,
+                        holder.agent,
+                        holder.harness,
+                        holder.instance_id,
+                        holder.task_id,
+                        holder.process_id,
+                        timestamp,
+                        expires_at,
+                        ttl_seconds,
+                        version,
+                        lease_event_id,
+                        stream_id,
+                    ),
+                )
+        return Lease(
+            stream_id=stream_id,
+            session_id=session_id,
+            lease_id=lease_id,
+            generation=generation,
+            fencing_token=fencing_token,
+            holder=holder,
+            heartbeat_at=timestamp,
+            expires_at=expires_at,
+            ttl_seconds=ttl_seconds,
+            version=version,
+        )
+
+    def heartbeat(self, lease: Lease, *, now: datetime | None = None) -> Lease:
+        """Renew an exact holder's TTL; an expired holder may revive only itself."""
+        current_time = now or utc_now()
+        timestamp = isoformat_z(current_time)
+        with self._transaction(now=current_time) as connection:
+            row = self._require_current_lease(connection, lease)
+            if current_time < parse_timestamp(str(row["heartbeat_at"])):
+                raise LeaseConflictError("heartbeat time cannot move backwards")
+            expires_at = isoformat_z(current_time + timedelta(seconds=int(row["ttl_seconds"])))
+            event_id = self._insert_lease_event_from_row(
+                connection,
+                row=row,
+                event_type="heartbeat",
+                timestamp=timestamp,
+                proof={},
+                reason="harness heartbeat",
+            )
+            version = int(row["version"]) + 1
+            connection.execute(
+                "UPDATE stream_leases SET heartbeat_at = ?, expires_at = ?, version = ?, last_event_id = ? "
+                "WHERE stream_id = ?",
+                (timestamp, expires_at, version, event_id, lease.stream_id),
+            )
+        return Lease(
+            stream_id=lease.stream_id,
+            session_id=lease.session_id,
+            lease_id=lease.lease_id,
+            generation=lease.generation,
+            fencing_token=lease.fencing_token,
+            holder=lease.holder,
+            heartbeat_at=timestamp,
+            expires_at=expires_at,
+            ttl_seconds=lease.ttl_seconds,
+            version=version,
+        )
+
+    def transition_session(
+        self,
+        lease: Lease,
+        *,
+        to_state: SessionState,
+        reason: str,
+        now: datetime | None = None,
+    ) -> SessionState:
+        """Move open↔rolling under a currently valid lease."""
+        if to_state not in {SessionState.OPEN, SessionState.ROLLING}:
+            raise LifecycleError("transition_session only supports open and rolling")
+        current_time = now or utc_now()
+        timestamp = isoformat_z(current_time)
+        with self._transaction(now=current_time) as connection:
+            row = self._require_current_lease(connection, lease, require_valid_at=current_time)
+            session = self._session_row(connection, lease.stream_id, lease.session_id)
+            from_state = SessionState(str(session["state"]))
+            allowed = (from_state, to_state) in {
+                (SessionState.OPEN, SessionState.ROLLING),
+                (SessionState.ROLLING, SessionState.OPEN),
+            }
+            if not allowed:
+                raise LifecycleError(f"invalid session transition {from_state.value}->{to_state.value}")
+            connection.execute(
+                "INSERT INTO session_events("
+                "stream_id, session_id, from_state, to_state, ts, agent, harness, reason, proof_json"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}')",
+                (
+                    lease.stream_id,
+                    lease.session_id,
+                    from_state.value,
+                    to_state.value,
+                    timestamp,
+                    row["holder_agent"],
+                    row["holder_harness"],
+                    reason,
+                ),
+            )
+            connection.execute(
+                "UPDATE sessions SET state = ?, updated_at = ?, state_version = state_version + 1 "
+                "WHERE stream_id = ? AND session_id = ?",
+                (to_state.value, timestamp, lease.stream_id, lease.session_id),
+            )
+        return to_state
+
+    def close_session(
+        self,
+        lease: Lease,
+        *,
+        reason: str = "harness clean exit",
+        now: datetime | None = None,
+    ) -> SessionState:
+        """Idempotently close the exact holder's session; closed remains immutable."""
+        current_time = now or utc_now()
+        timestamp = isoformat_z(current_time)
+        with self._transaction(now=current_time) as connection:
+            session = self._session_row(connection, lease.stream_id, lease.session_id)
+            if session["state"] == SessionState.CLOSED.value:
+                historical_lease = connection.execute(
+                    "SELECT 1 FROM lease_events WHERE "
+                    "stream_id = ? AND session_id = ? AND lease_id = ? "
+                    "AND generation = ? AND fencing_token = ? "
+                    "AND holder_agent = ? AND holder_harness = ? AND holder_instance_id = ? "
+                    "AND holder_task_id IS ? AND holder_process_id = ? LIMIT 1",
+                    (
+                        lease.stream_id,
+                        lease.session_id,
+                        lease.lease_id,
+                        lease.generation,
+                        lease.fencing_token,
+                        lease.holder.agent,
+                        lease.holder.harness,
+                        lease.holder.instance_id,
+                        lease.holder.task_id,
+                        lease.holder.process_id,
+                    ),
+                ).fetchone()
+                if historical_lease is not None:
+                    return SessionState.CLOSED
+                raise LeaseConflictError("closed session does not match the supplied historical lease")
+            row = self._require_current_lease(connection, lease)
+            proof = {"kind": "session_stream_clean_exit.v1", "holder_instance_id": lease.holder.instance_id}
+            event_id = self._insert_lease_event_from_row(
+                connection,
+                row=row,
+                event_type="released",
+                timestamp=timestamp,
+                proof=proof,
+                reason=reason,
+            )
+            connection.execute(
+                "UPDATE stream_leases SET state = 'released', version = version + 1, last_event_id = ? "
+                "WHERE stream_id = ?",
+                (event_id, lease.stream_id),
+            )
+            connection.execute(
+                "INSERT INTO session_events("
+                "stream_id, session_id, from_state, to_state, ts, agent, harness, reason, proof_json"
+                ") VALUES (?, ?, ?, 'closed', ?, ?, ?, ?, ?)",
+                (
+                    lease.stream_id,
+                    lease.session_id,
+                    session["state"],
+                    timestamp,
+                    row["holder_agent"],
+                    row["holder_harness"],
+                    reason,
+                    canonical_json(proof),
+                ),
+            )
+            connection.execute(
+                "UPDATE sessions SET state = 'closed', closed_at = ?, updated_at = ?, "
+                "state_version = state_version + 1 WHERE stream_id = ? AND session_id = ?",
+                (timestamp, timestamp, lease.stream_id, lease.session_id),
+            )
+        return SessionState.CLOSED
+
+    def force_close_expired_session(
+        self,
+        *,
+        stream_id: str,
+        session_id: str,
+        candidate: LeaseHolder,
+        now: datetime | None = None,
+        reason: str = "proof-gated crashed-holder force close",
+    ) -> ForceCloseProof:
+        """Force-close only an expired session whose exact holder process is absent."""
+        stream_id = validate_stream_id(stream_id)
+        candidate.validate()
+        current_time = now or utc_now()
+        timestamp = isoformat_z(current_time)
+        with self._transaction(now=current_time) as connection:
+            session = self._session_row(connection, stream_id, session_id)
+            if session["state"] == SessionState.CLOSED.value:
+                raise LifecycleError("closed sessions are immutable and cannot be force-closed again")
+            row = connection.execute(
+                "SELECT * FROM stream_leases WHERE stream_id = ? AND session_id = ?",
+                (stream_id, session_id),
+            ).fetchone()
+            if row is None or row["state"] != "active":
+                raise LeaseConflictError("crashed session has no exact active lease to prove and close")
+            expires_at = parse_timestamp(str(row["expires_at"]))
+            if current_time < expires_at:
+                raise LeaseConflictError("valid live lease is untouchable until its TTL expires")
+            holder_pid = int(row["holder_process_id"])
+            if self._process_probe(holder_pid):
+                raise LeaseConflictError("expired lease holder process is still live; force-close refused")
+            if candidate.instance_id == row["holder_instance_id"]:
+                raise LeaseConflictError("force-close candidate must be a distinct runtime instance")
+            if not self._process_probe(candidate.process_id):
+                raise LeaseConflictError("force-close candidate process is not live; proof refused")
+            heartbeat_at = parse_timestamp(str(row["heartbeat_at"]))
+            proof = ForceCloseProof(
+                stream_id=stream_id,
+                session_id=session_id,
+                lease_id=str(row["lease_id"]),
+                holder_instance_id=str(row["holder_instance_id"]),
+                holder_process_id=holder_pid,
+                heartbeat_at=str(row["heartbeat_at"]),
+                expires_at=str(row["expires_at"]),
+                observed_at=timestamp,
+                heartbeat_age_seconds=max(0, int((current_time - heartbeat_at).total_seconds())),
+                process_probe="os.kill(pid, 0): ProcessLookupError",
+                candidate_agent=candidate.agent,
+                candidate_harness=candidate.harness,
+                candidate_instance_id=candidate.instance_id,
+            )
+            proof_payload = proof.as_dict()
+            self._insert_lease_event_from_row(
+                connection,
+                row=row,
+                event_type="stale_observed",
+                timestamp=timestamp,
+                proof=proof_payload,
+                reason="expired heartbeat and absent exact holder process observed",
+            )
+            force_event_id = self._insert_lease_event_from_row(
+                connection,
+                row=row,
+                event_type="force_closed",
+                timestamp=timestamp,
+                proof=proof_payload,
+                reason=reason,
+            )
+            connection.execute(
+                "UPDATE stream_leases SET state = 'released', version = version + 1, last_event_id = ? "
+                "WHERE stream_id = ? AND session_id = ?",
+                (force_event_id, stream_id, session_id),
+            )
+            connection.execute(
+                "INSERT INTO session_events("
+                "stream_id, session_id, from_state, to_state, ts, agent, harness, reason, proof_json"
+                ") VALUES (?, ?, ?, 'closed', ?, ?, ?, ?, ?)",
+                (
+                    stream_id,
+                    session_id,
+                    session["state"],
+                    timestamp,
+                    candidate.agent,
+                    candidate.harness,
+                    reason,
+                    canonical_json(proof_payload),
+                ),
+            )
+            connection.execute(
+                "UPDATE sessions SET state = 'closed', closed_at = ?, updated_at = ?, "
+                "state_version = state_version + 1 WHERE stream_id = ? AND session_id = ?",
+                (timestamp, timestamp, stream_id, session_id),
+            )
+        return proof
+
+    def append_entry(
+        self,
+        lease: Lease,
+        *,
+        entry_type: EntryType,
+        body: str,
+        idempotency_key: str,
+        refs: Sequence[EntryRef] = (),
+        now: datetime | None = None,
+    ) -> Entry:
+        """Append one typed entry under an exact, unexpired fenced lease."""
+        validate_entry_body(body)
+        if not isinstance(entry_type, EntryType):
+            entry_type = EntryType(entry_type)
+        self._validate_idempotency_key(idempotency_key)
+        ref_tuple = tuple(refs)
+        for ref in ref_tuple:
+            ref.validate()
+        current_time = now or utc_now()
+        timestamp = isoformat_z(current_time)
+        body_sha256 = sha256_text(body)
+        with self._transaction(now=current_time) as connection:
+            existing = connection.execute(
+                "SELECT * FROM entries WHERE stream_id = ? AND idempotency_key = ?",
+                (lease.stream_id, idempotency_key),
+            ).fetchone()
+            if existing is not None:
+                entry = self._entry_from_row(connection, existing)
+                if (
+                    entry.session_id != lease.session_id
+                    or entry.type != entry_type
+                    or entry.body_sha256 != body_sha256
+                    or entry.refs != ref_tuple
+                ):
+                    raise LeaseConflictError("idempotency key already binds different immutable content")
+                return entry
+            self._require_current_lease(connection, lease, require_valid_at=current_time)
+            cursor = connection.execute(
+                "INSERT INTO entries("
+                "stream_id, session_id, agent, harness, ts, type, body, body_sha256, origin, "
+                "writer_lease_id, writer_instance_id, fencing_token, idempotency_key"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'live', ?, ?, ?, ?)",
+                (
+                    lease.stream_id,
+                    lease.session_id,
+                    lease.holder.agent,
+                    lease.holder.harness,
+                    timestamp,
+                    entry_type.value,
+                    body,
+                    body_sha256,
+                    lease.lease_id,
+                    lease.holder.instance_id,
+                    lease.fencing_token,
+                    idempotency_key,
+                ),
+            )
+            entry_id = int(cursor.lastrowid)
+            for ordinal, ref in enumerate(ref_tuple):
+                connection.execute(
+                    "INSERT INTO entry_refs(entry_id, ordinal, kind, target_entry_id, uri) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (entry_id, ordinal, ref.kind, ref.target_entry_id, ref.uri),
+                )
+            row = connection.execute("SELECT * FROM entries WHERE entry_id = ?", (entry_id,)).fetchone()
+            if row is None:
+                raise SessionStreamError("entry insert did not produce a readable row")
+            return self._entry_from_row(connection, row)
+
+    def load_digest(self, stream_id: str, *, limit: int) -> StreamDigest:
+        """Load all pinned entries first, then the last N non-pinned entries."""
+        stream_id = validate_stream_id(stream_id)
+        if limit < 0 or limit > 10_000:
+            raise ValueError("limit must be between 0 and 10000")
+        with self._read_snapshot() as connection:
+            if connection.execute("SELECT 1 FROM streams WHERE stream_id = ?", (stream_id,)).fetchone() is None:
+                raise NotFoundError(f"stream not found: {stream_id}")
+            pinned_values = tuple(entry_type.value for entry_type in PINNED_ENTRY_TYPES)
+            placeholders = ",".join("?" for _ in pinned_values)
+            pinned_rows = connection.execute(
+                f"SELECT * FROM entries WHERE stream_id = ? AND type IN ({placeholders}) ORDER BY entry_id",
+                (stream_id, *pinned_values),
+            ).fetchall()
+            recent_rows = connection.execute(
+                f"SELECT * FROM entries WHERE stream_id = ? AND type NOT IN ({placeholders}) "
+                "ORDER BY entry_id DESC LIMIT ?",
+                (stream_id, *pinned_values, limit),
+            ).fetchall()
+            recent_rows = list(reversed(recent_rows))
+            high_water = int(
+                connection.execute(
+                    "SELECT COALESCE(MAX(entry_id), 0) FROM entries WHERE stream_id = ?",
+                    (stream_id,),
+                ).fetchone()[0]
+            )
+            return StreamDigest(
+                stream_id=stream_id,
+                limit=limit,
+                pinned=tuple(self._entry_from_row(connection, row) for row in pinned_rows),
+                recent=tuple(self._entry_from_row(connection, row) for row in recent_rows),
+                high_water_entry_id=high_water,
+            )
+
+    def dump_stream(self, stream_id: str) -> dict[str, Any]:
+        """Return complete ordered stream history for the operator dump surface."""
+        stream_id = validate_stream_id(stream_id)
+        with self._read_snapshot() as connection:
+            stream = connection.execute("SELECT * FROM streams WHERE stream_id = ?", (stream_id,)).fetchone()
+            if stream is None:
+                raise NotFoundError(f"stream not found: {stream_id}")
+            entry_rows = connection.execute(
+                "SELECT * FROM entries WHERE stream_id = ? ORDER BY entry_id",
+                (stream_id,),
+            ).fetchall()
+            return {
+                "schema_migrations": self._rows_as_dicts(
+                    connection.execute("SELECT * FROM schema_migrations ORDER BY version").fetchall()
+                ),
+                "stream": dict(stream),
+                "sessions": self._rows_as_dicts(
+                    connection.execute(
+                        "SELECT * FROM sessions WHERE stream_id = ? ORDER BY opened_at, session_id",
+                        (stream_id,),
+                    ).fetchall()
+                ),
+                "session_events": self._rows_as_dicts(
+                    connection.execute(
+                        "SELECT * FROM session_events WHERE stream_id = ? ORDER BY event_id",
+                        (stream_id,),
+                    ).fetchall()
+                ),
+                "lease_events": self._rows_as_dicts(
+                    connection.execute(
+                        "SELECT * FROM lease_events WHERE stream_id = ? ORDER BY event_id",
+                        (stream_id,),
+                    ).fetchall()
+                ),
+                "lease": self._row_as_dict(
+                    connection.execute("SELECT * FROM stream_leases WHERE stream_id = ?", (stream_id,)).fetchone()
+                ),
+                "entries": [entry_as_dict(self._entry_from_row(connection, row)) for row in entry_rows],
+                "legacy_mirrors": self._rows_as_dicts(
+                    connection.execute(
+                        "SELECT * FROM legacy_mirrors WHERE stream_id = ? ORDER BY mirror_id",
+                        (stream_id,),
+                    ).fetchall()
+                ),
+            }
+
+    def record_legacy_mirror(
+        self,
+        lease: Lease,
+        *,
+        profile: str,
+        source_path: str,
+        source_sha256: str,
+        source_bytes: int,
+        entry: Entry,
+        now: datetime | None = None,
+    ) -> int:
+        """Append an idempotent receipt after a legacy file was mirrored into an entry."""
+        self._validate_identity("profile", profile)
+        if not source_path or "\x00" in source_path:
+            raise ValueError("source_path must be non-empty text without NUL")
+        if len(source_sha256) != 64:
+            raise ValueError("source_sha256 must be a SHA-256 hex digest")
+        if source_bytes <= 0:
+            raise ValueError("source_bytes must be positive")
+        timestamp = isoformat_z(now or utc_now())
+        with self._transaction(now=now) as connection:
+            self._require_current_lease(
+                connection,
+                lease,
+                require_valid_at=parse_timestamp(timestamp),
+            )
+            if entry.stream_id != lease.stream_id or entry.session_id != lease.session_id:
+                raise LeaseConflictError("legacy mirror entry must belong to the exact current leased session")
+            connection.execute(
+                "INSERT OR IGNORE INTO legacy_mirrors("
+                "profile, source_path, source_sha256, source_bytes, stream_id, session_id, entry_id, mirrored_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    profile,
+                    source_path,
+                    source_sha256,
+                    source_bytes,
+                    entry.stream_id,
+                    entry.session_id,
+                    entry.entry_id,
+                    timestamp,
+                ),
+            )
+            row = connection.execute(
+                "SELECT mirror_id, entry_id FROM legacy_mirrors "
+                "WHERE profile = ? AND source_path = ? AND source_sha256 = ?",
+                (profile, source_path, source_sha256),
+            ).fetchone()
+            if row is None or int(row["entry_id"]) != entry.entry_id:
+                raise SessionStreamError("legacy mirror identity already binds a different entry")
+            return int(row["mirror_id"])
+
+    def session_state(self, stream_id: str, session_id: str) -> SessionState:
+        """Read the exact current state without inferring a session by recency."""
+        stream_id = validate_stream_id(stream_id)
+        with self._read_snapshot() as connection:
+            row = self._session_row(connection, stream_id, session_id)
+            return SessionState(str(row["state"]))
+
+    def audit(self) -> dict[str, Any]:
+        with self._read_snapshot() as connection:
+            integrity = str(connection.execute("PRAGMA integrity_check").fetchone()[0])
+            foreign_key_rows = connection.execute("PRAGMA foreign_key_check").fetchall()
+            return {
+                "integrity_check": integrity,
+                "foreign_key_violations": self._rows_as_dicts(foreign_key_rows),
+                "schema_versions": [
+                    int(row[0])
+                    for row in connection.execute(
+                        "SELECT version FROM schema_migrations ORDER BY version"
+                    ).fetchall()
+                ],
+            }
+
+    @staticmethod
+    def _ensure_stream(connection: sqlite3.Connection, *, stream_id: str, created_at: str) -> None:
+        if stream_id.startswith("epic:"):
+            kind = "epic"
+            epic_number: int | None = int(stream_id.removeprefix("epic:"))
+        else:
+            kind = "shared"
+            epic_number = None
+        connection.execute(
+            "INSERT OR IGNORE INTO streams(stream_id, kind, epic_number, created_at) VALUES (?, ?, ?, ?)",
+            (stream_id, kind, epic_number, created_at),
+        )
+        row = connection.execute(
+            "SELECT kind, epic_number FROM streams WHERE stream_id = ?",
+            (stream_id,),
+        ).fetchone()
+        if row is None or row["kind"] != kind or row["epic_number"] != epic_number:
+            raise LifecycleError(f"stream identity conflict for {stream_id}")
+
+    @staticmethod
+    def _validate_ttl(ttl_seconds: int) -> None:
+        if not isinstance(ttl_seconds, int) or not 0 < ttl_seconds <= MAX_TTL_SECONDS:
+            raise ValueError(f"ttl_seconds must be an integer between 1 and {MAX_TTL_SECONDS}")
+
+    @staticmethod
+    def _validate_identity(label: str, value: str) -> None:
+        if not value or len(value) > 256 or "\x00" in value or any(char.isspace() for char in value):
+            raise ValueError(f"{label} must be non-empty path-safe text up to 256 characters")
+
+    @staticmethod
+    def _validate_idempotency_key(value: str) -> None:
+        if not value or len(value) > 512 or "\x00" in value:
+            raise ValueError("idempotency_key must be non-empty text up to 512 characters without NUL")
+
+    @staticmethod
+    def _session_row(connection: sqlite3.Connection, stream_id: str, session_id: str) -> sqlite3.Row:
+        row = connection.execute(
+            "SELECT * FROM sessions WHERE stream_id = ? AND session_id = ?",
+            (stream_id, session_id),
+        ).fetchone()
+        if row is None:
+            raise NotFoundError(f"session not found: {stream_id}/{session_id}")
+        return row
+
+    @staticmethod
+    def _require_current_lease(
+        connection: sqlite3.Connection,
+        lease: Lease,
+        *,
+        require_valid_at: datetime | None = None,
+    ) -> sqlite3.Row:
+        row = connection.execute(
+            "SELECT lease.*, session.state AS session_state FROM stream_leases AS lease "
+            "JOIN sessions AS session ON session.stream_id = lease.stream_id "
+            "AND session.session_id = lease.session_id WHERE lease.stream_id = ?",
+            (lease.stream_id,),
+        ).fetchone()
+        if row is None:
+            raise NotFoundError(f"lease not found for stream {lease.stream_id}")
+        matches = (
+            row["session_id"] == lease.session_id
+            and row["lease_id"] == lease.lease_id
+            and int(row["generation"]) == lease.generation
+            and int(row["fencing_token"]) == lease.fencing_token
+            and row["holder_agent"] == lease.holder.agent
+            and row["holder_harness"] == lease.holder.harness
+            and row["holder_instance_id"] == lease.holder.instance_id
+            and row["holder_task_id"] == lease.holder.task_id
+            and int(row["holder_process_id"]) == lease.holder.process_id
+        )
+        if not matches or row["state"] != "active" or row["session_state"] == SessionState.CLOSED.value:
+            raise LeaseConflictError("supplied lease is not the exact current active fenced lease")
+        if require_valid_at is not None and require_valid_at >= parse_timestamp(str(row["expires_at"])):
+            raise LeaseConflictError("lease TTL has expired; live append/state mutation refused")
+        return row
+
+    @staticmethod
+    def _insert_lease_event(
+        connection: sqlite3.Connection,
+        *,
+        stream_id: str,
+        session_id: str,
+        lease_id: str,
+        generation: int,
+        fencing_token: int,
+        event_type: str,
+        holder: LeaseHolder,
+        ttl_seconds: int,
+        timestamp: str,
+        proof: dict[str, Any],
+        reason: str,
+    ) -> int:
+        cursor = connection.execute(
+            "INSERT INTO lease_events("
+            "stream_id, session_id, lease_id, generation, fencing_token, event_type, "
+            "holder_agent, holder_harness, holder_instance_id, holder_task_id, holder_process_id, "
+            "ttl_seconds, ts, proof_json, reason"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                stream_id,
+                session_id,
+                lease_id,
+                generation,
+                fencing_token,
+                event_type,
+                holder.agent,
+                holder.harness,
+                holder.instance_id,
+                holder.task_id,
+                holder.process_id,
+                ttl_seconds,
+                timestamp,
+                canonical_json(proof),
+                reason,
+            ),
+        )
+        return int(cursor.lastrowid)
+
+    def _insert_lease_event_from_row(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        row: sqlite3.Row,
+        event_type: str,
+        timestamp: str,
+        proof: dict[str, Any],
+        reason: str,
+    ) -> int:
+        holder = LeaseHolder(
+            agent=str(row["holder_agent"]),
+            harness=str(row["holder_harness"]),
+            instance_id=str(row["holder_instance_id"]),
+            task_id=str(row["holder_task_id"]) if row["holder_task_id"] is not None else None,
+            process_id=int(row["holder_process_id"]),
+        )
+        return self._insert_lease_event(
+            connection,
+            stream_id=str(row["stream_id"]),
+            session_id=str(row["session_id"]),
+            lease_id=str(row["lease_id"]),
+            generation=int(row["generation"]),
+            fencing_token=int(row["fencing_token"]),
+            event_type=event_type,
+            holder=holder,
+            ttl_seconds=int(row["ttl_seconds"]),
+            timestamp=timestamp,
+            proof=proof,
+            reason=reason,
+        )
+
+    @staticmethod
+    def _entry_from_row(connection: sqlite3.Connection, row: sqlite3.Row) -> Entry:
+        refs = tuple(
+            EntryRef(
+                kind=str(ref["kind"]),
+                target_entry_id=int(ref["target_entry_id"]) if ref["target_entry_id"] is not None else None,
+                uri=str(ref["uri"]) if ref["uri"] is not None else None,
+            )
+            for ref in connection.execute(
+                "SELECT kind, target_entry_id, uri FROM entry_refs WHERE entry_id = ? ORDER BY ordinal",
+                (row["entry_id"],),
+            ).fetchall()
+        )
+        return Entry(
+            entry_id=int(row["entry_id"]),
+            stream_id=str(row["stream_id"]),
+            session_id=str(row["session_id"]),
+            agent=str(row["agent"]),
+            harness=str(row["harness"]),
+            ts=str(row["ts"]),
+            type=EntryType(str(row["type"])),
+            body=str(row["body"]),
+            body_sha256=str(row["body_sha256"]),
+            idempotency_key=str(row["idempotency_key"]),
+            refs=refs,
+        )
+
+    @staticmethod
+    def _rows_as_dicts(rows: Sequence[sqlite3.Row]) -> list[dict[str, Any]]:
+        return [dict(row) for row in rows]
+
+    @staticmethod
+    def _row_as_dict(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        return dict(row) if row is not None else None

--- a/tests/test_session_streams.py
+++ b/tests/test_session_streams.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from threading import Barrier, Event
+from typing import Any
+
+import pytest
+
+from agents_extensions.shared.session_streams.db import MigrationError, SessionStreamDatabase, load_migrations
+from agents_extensions.shared.session_streams.dual_write import ATLAS_HANDOFF_PATH, mirror_atlas_handoff
+from agents_extensions.shared.session_streams.hooks import clean_exit_hook, heartbeat_hook
+from agents_extensions.shared.session_streams.model import EntryRef, EntryType, LeaseHolder, SessionState
+from agents_extensions.shared.session_streams.store import (
+    ContentRejectedError,
+    LeaseConflictError,
+    LifecycleError,
+    SessionStreamStore,
+)
+
+NOW = datetime(2026, 7, 18, 12, 0, tzinfo=UTC)
+
+
+def _holder(
+    *,
+    harness: str = "codex",
+    agent: str = "codex",
+    instance: str = "runtime-1",
+    process_id: int = 41001,
+) -> LeaseHolder:
+    return LeaseHolder(
+        agent=agent,
+        harness=harness,
+        instance_id=instance,
+        process_id=process_id,
+        task_id=f"task-{instance}",
+    )
+
+
+def _store(tmp_path: Path, process_state: dict[int, bool] | None = None) -> SessionStreamStore:
+    state = process_state if process_state is not None else {}
+    return SessionStreamStore(
+        SessionStreamDatabase(tmp_path / "streams.sqlite3"),
+        _process_probe=lambda process_id: state.get(process_id, False),
+    )
+
+
+def _open(store: SessionStreamStore, *, holder: LeaseHolder | None = None, stream: str = "epic:4707"):
+    return store.open_session(
+        stream_id=stream,
+        holder=holder or _holder(),
+        lineage_id="lineage-test",
+        ttl_seconds=30,
+        session_id="session-one",
+        lease_id="lease-one",
+        now=NOW,
+    )
+
+
+def test_schema_migration_wal_and_fingerprint(tmp_path: Path) -> None:
+    database = SessionStreamDatabase(tmp_path / "streams.sqlite3")
+    connection = database.connect(now=NOW)
+    try:
+        migration = load_migrations()[0]
+        receipt = connection.execute(
+            "SELECT version, name, ddl_sha256 FROM schema_migrations"
+        ).fetchone()
+        assert str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower() == "wal"
+        assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert connection.execute("PRAGMA synchronous").fetchone()[0] == 2
+        assert dict(receipt) == {
+            "version": 1,
+            "name": migration.name,
+            "ddl_sha256": migration.sha256,
+        }
+    finally:
+        connection.close()
+
+    assert SessionStreamStore(database).audit() == {
+        "integrity_check": "ok",
+        "foreign_key_violations": [],
+        "schema_versions": [1],
+    }
+
+
+def test_migration_fingerprint_drift_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "drift.sqlite3"
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "CREATE TABLE schema_migrations("
+            "version INTEGER PRIMARY KEY, name TEXT NOT NULL, ddl_sha256 TEXT NOT NULL, applied_at TEXT NOT NULL)"
+        )
+        connection.execute(
+            "INSERT INTO schema_migrations VALUES (1, '0001_initial.sql', ?, '2026-07-18T12:00:00Z')",
+            ("0" * 64,),
+        )
+
+    with pytest.raises(MigrationError, match="fingerprint mismatch"):
+        SessionStreamDatabase(path).connect()
+
+
+def test_concurrent_first_open_serializes_migration_and_session_contention(tmp_path: Path) -> None:
+    database_path = tmp_path / "shared-empty.sqlite3"
+    barrier = Barrier(8)
+
+    def attempt(index: int) -> str:
+        store = SessionStreamStore(
+            SessionStreamDatabase(database_path),
+            _process_probe=lambda _process_id: False,
+        )
+        barrier.wait(timeout=5)
+        try:
+            store.open_session(
+                stream_id="epic:4707",
+                holder=_holder(instance=f"runtime-{index}", process_id=45000 + index),
+                lineage_id=f"lineage-{index}",
+                ttl_seconds=30,
+                session_id=f"session-{index}",
+                lease_id=f"lease-{index}",
+                now=NOW,
+            )
+        except LifecycleError:
+            return "lifecycle-conflict"
+        return "opened"
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(attempt, range(8)))
+
+    assert results.count("opened") == 1
+    assert results.count("lifecycle-conflict") == 7
+    connection = SessionStreamDatabase(database_path).connect(read_only=True)
+    try:
+        assert connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 1
+    finally:
+        connection.close()
+
+
+def test_pinned_entries_precede_bounded_recent_tail(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    lease = _open(store)
+    order = store.append_entry(
+        lease,
+        entry_type=EntryType.BINDING_ORDER,
+        body="Operator order stays visible.",
+        idempotency_key="order-1",
+        refs=(EntryRef(kind="github", uri="https://github.com/example/issues/1"),),
+        now=NOW + timedelta(seconds=1),
+    )
+    constraint = store.append_entry(
+        lease,
+        entry_type=EntryType.NEGATIVE_CONSTRAINT,
+        body="Never mutate a closed session.",
+        idempotency_key="constraint-1",
+        now=NOW + timedelta(seconds=2),
+    )
+    notes = [
+        store.append_entry(
+            lease,
+            entry_type=EntryType.NOTE,
+            body=f"Recent note {index}",
+            idempotency_key=f"note-{index}",
+            now=NOW + timedelta(seconds=3 + index),
+        )
+        for index in range(5)
+    ]
+
+    digest = store.load_digest("epic:4707", limit=2)
+
+    assert [entry.entry_id for entry in digest.pinned] == [order.entry_id, constraint.entry_id]
+    assert [entry.entry_id for entry in digest.recent] == [notes[-2].entry_id, notes[-1].entry_id]
+    assert digest.entries == digest.pinned + digest.recent
+    assert len(digest.digest_sha256) == 64
+
+    repeated = store.append_entry(
+        lease,
+        entry_type=EntryType.BINDING_ORDER,
+        body="Operator order stays visible.",
+        idempotency_key="order-1",
+        refs=(EntryRef(kind="github", uri="https://github.com/example/issues/1"),),
+        now=NOW + timedelta(seconds=20),
+    )
+    assert repeated.entry_id == order.entry_id
+    with pytest.raises(LeaseConflictError, match="different immutable content"):
+        store.append_entry(
+            lease,
+            entry_type=EntryType.BINDING_ORDER,
+            body="Different body.",
+            idempotency_key="order-1",
+            now=NOW + timedelta(seconds=20),
+        )
+
+
+def test_digest_uses_one_wal_snapshot_during_concurrent_pinned_append(tmp_path: Path) -> None:
+    database_path = tmp_path / "snapshot.sqlite3"
+    write_store = SessionStreamStore(SessionStreamDatabase(database_path))
+    lease = _open(write_store)
+    note = write_store.append_entry(
+        lease,
+        entry_type=EntryType.NOTE,
+        body="Existing snapshot note.",
+        idempotency_key="snapshot-note",
+        now=NOW + timedelta(seconds=1),
+    )
+    pinned_query_started = Event()
+    writer_finished = Event()
+
+    class InterleavingConnection:
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            self.inner = inner
+            self.interleaved = False
+
+        def execute(self, sql: str, parameters: Any = ()):
+            cursor = self.inner.execute(sql, parameters)
+            if "FROM entries WHERE stream_id = ? AND type IN" in sql and not self.interleaved:
+                self.interleaved = True
+                pinned_query_started.set()
+                if not writer_finished.wait(timeout=5):
+                    raise RuntimeError("concurrent writer did not finish")
+            return cursor
+
+        def close(self) -> None:
+            self.inner.close()
+
+    class InterleavingDatabase(SessionStreamDatabase):
+        def __init__(self, path: Path) -> None:
+            super().__init__(path)
+            self.wrap_next_read = True
+
+        def connect(self, *, read_only: bool = False, now: datetime | None = None):
+            connection = super().connect(read_only=read_only, now=now)
+            if read_only and self.wrap_next_read:
+                self.wrap_next_read = False
+                return InterleavingConnection(connection)
+            return connection
+
+    def append_pinned() -> None:
+        assert pinned_query_started.wait(timeout=5)
+        write_store.append_entry(
+            lease,
+            entry_type=EntryType.BINDING_ORDER,
+            body="Concurrent binding order.",
+            idempotency_key="snapshot-order",
+            now=NOW + timedelta(seconds=2),
+        )
+        writer_finished.set()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(append_pinned)
+        snapshot = SessionStreamStore(InterleavingDatabase(database_path)).load_digest(
+            "epic:4707",
+            limit=10,
+        )
+        future.result(timeout=5)
+
+    assert snapshot.pinned == ()
+    assert [entry.entry_id for entry in snapshot.recent] == [note.entry_id]
+    assert snapshot.high_water_entry_id == note.entry_id
+    refreshed = write_store.load_digest("epic:4707", limit=10)
+    assert [entry.body for entry in refreshed.pinned] == ["Concurrent binding order."]
+    assert refreshed.high_water_entry_id > snapshot.high_water_entry_id
+
+
+@pytest.mark.parametrize(
+    "body,rule",
+    [
+        ("contact test@example.com", "email-address"),
+        ("api_key=secret-value-123", "credential-assignment"),
+        ("\x00binary", "control-character"),
+    ],
+)
+def test_append_rejects_sensitive_or_non_text_content(tmp_path: Path, body: str, rule: str) -> None:
+    store = _store(tmp_path)
+    lease = _open(store)
+    with pytest.raises(ContentRejectedError, match=rule):
+        store.append_entry(
+            lease,
+            entry_type=EntryType.NOTE,
+            body=body,
+            idempotency_key="rejected",
+            now=NOW + timedelta(seconds=1),
+        )
+
+
+def test_ttl_heartbeat_and_expired_write_fencing(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    lease = _open(store)
+
+    with pytest.raises(LeaseConflictError, match="TTL has expired"):
+        store.append_entry(
+            lease,
+            entry_type=EntryType.STATE,
+            body="Too late.",
+            idempotency_key="late",
+            now=NOW + timedelta(seconds=30),
+        )
+
+    renewed = store.heartbeat(lease, now=NOW + timedelta(seconds=31))
+    assert renewed.expires_at == "2026-07-18T12:01:01Z"
+    entry = store.append_entry(
+        lease,
+        entry_type=EntryType.STATE,
+        body="Holder process revived its own exact lease.",
+        idempotency_key="revived",
+        now=NOW + timedelta(seconds=32),
+    )
+    assert entry.entry_id > 0
+
+
+def test_valid_lease_untouchable_and_crash_force_close_opens_distinct_session(tmp_path: Path) -> None:
+    process_state = {41001: True, 42002: True}
+    store = _store(tmp_path, process_state)
+    original = _open(store)
+    candidate = _holder(harness="agy", agent="gemini", instance="runtime-2", process_id=42002)
+
+    with pytest.raises(LifecycleError, match="already has live session"):
+        store.open_session(
+            stream_id="epic:4707",
+            holder=candidate,
+            lineage_id="lineage-successor",
+            ttl_seconds=30,
+            session_id="session-two",
+            now=NOW + timedelta(seconds=1),
+        )
+    with pytest.raises(LeaseConflictError, match="untouchable"):
+        store.force_close_expired_session(
+            stream_id="epic:4707",
+            session_id="session-one",
+            candidate=candidate,
+            now=NOW + timedelta(seconds=29),
+        )
+    with pytest.raises(LeaseConflictError, match="still live"):
+        store.force_close_expired_session(
+            stream_id="epic:4707",
+            session_id="session-one",
+            candidate=candidate,
+            now=NOW + timedelta(seconds=31),
+        )
+
+    process_state[41001] = False
+    proof = store.force_close_expired_session(
+        stream_id="epic:4707",
+        session_id="session-one",
+        candidate=candidate,
+        now=NOW + timedelta(seconds=31),
+    )
+    assert proof.heartbeat_age_seconds == 31
+    assert proof.holder_process_id == 41001
+    assert proof.candidate_instance_id == "runtime-2"
+    with pytest.raises(LeaseConflictError):
+        store.heartbeat(original, now=NOW + timedelta(seconds=32))
+    with pytest.raises(LeaseConflictError):
+        store.append_entry(
+            original,
+            entry_type=EntryType.NOTE,
+            body="Old holder fenced.",
+            idempotency_key="old-holder",
+            now=NOW + timedelta(seconds=32),
+        )
+
+    successor = store.open_session(
+        stream_id="epic:4707",
+        holder=candidate,
+        lineage_id="lineage-successor",
+        ttl_seconds=30,
+        session_id="session-two",
+        lease_id="lease-two",
+        now=NOW + timedelta(seconds=32),
+    )
+    assert successor.session_id != original.session_id
+    assert successor.generation == original.generation + 1
+    assert successor.fencing_token == original.fencing_token + 1
+    history = store.dump_stream("epic:4707")
+    assert [session["state"] for session in history["sessions"]] == ["closed", "open"]
+    assert any(event["event_type"] == "stale_observed" for event in history["lease_events"])
+    assert any(event["event_type"] == "force_closed" for event in history["lease_events"])
+
+
+def test_open_rolling_closed_state_machine_and_sql_immutability(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    lease = _open(store)
+    assert store.transition_session(
+        lease,
+        to_state=SessionState.ROLLING,
+        reason="prepared exact rollover",
+        now=NOW + timedelta(seconds=1),
+    ) is SessionState.ROLLING
+    assert heartbeat_hook(store, lease, now=NOW + timedelta(seconds=1)).state == "rolling"
+    assert store.transition_session(
+        lease,
+        to_state=SessionState.OPEN,
+        reason="same live run resumed",
+        now=NOW + timedelta(seconds=2),
+    ) is SessionState.OPEN
+    entry = store.append_entry(
+        lease,
+        entry_type=EntryType.NEXT_ACTION,
+        body="Close cleanly.",
+        idempotency_key="before-close",
+        now=NOW + timedelta(seconds=3),
+    )
+    assert store.close_session(lease, now=NOW + timedelta(seconds=4)) is SessionState.CLOSED
+    assert store.close_session(lease, now=NOW + timedelta(seconds=5)) is SessionState.CLOSED
+    successor = store.open_session(
+        stream_id="epic:4707",
+        holder=_holder(instance="successor", process_id=43003),
+        lineage_id="lineage-successor",
+        ttl_seconds=30,
+        session_id="session-successor",
+        lease_id="lease-successor",
+        now=NOW + timedelta(seconds=6),
+    )
+    assert successor.session_id == "session-successor"
+    assert store.close_session(lease, now=NOW + timedelta(seconds=7)) is SessionState.CLOSED
+
+    connection = store.database.connect()
+    try:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            connection.execute("UPDATE entries SET body = 'rewritten' WHERE entry_id = ?", (entry.entry_id,))
+        with pytest.raises(sqlite3.IntegrityError, match="terminal"):
+            connection.execute("UPDATE sessions SET updated_at = ? WHERE session_id = ?", ("later", lease.session_id))
+        with pytest.raises(sqlite3.IntegrityError, match="never deleted"):
+            connection.execute("DELETE FROM sessions WHERE session_id = ?", (lease.session_id,))
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize(
+    ("agent", "harness"),
+    [
+        ("claude", "claude-code"),
+        ("codex", "codex"),
+        ("grok", "grok"),
+        ("gemini", "agy"),
+        ("kimi", "kimi"),
+        ("interim", "interim-driver"),
+    ],
+)
+def test_fleet_harnesses_share_heartbeat_and_exit_contract(
+    tmp_path: Path,
+    agent: str,
+    harness: str,
+) -> None:
+    store = _store(tmp_path)
+    holder = _holder(agent=agent, harness=harness, instance=f"{harness}-instance", process_id=os.getpid())
+    lease = _open(store, holder=holder)
+
+    heartbeat = heartbeat_hook(store, lease, now=NOW + timedelta(seconds=1))
+    closed = clean_exit_hook(store, lease, now=NOW + timedelta(seconds=2))
+
+    assert heartbeat.action == "heartbeat"
+    assert heartbeat.expires_at == "2026-07-18T12:00:31Z"
+    assert closed.state == "closed"
+
+
+def test_atlas_dual_write_mirrors_file_without_modifying_or_deleting_it(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    handoff = repo_root / ATLAS_HANDOFF_PATH
+    handoff.parent.mkdir(parents=True)
+    handoff.write_text("# Atlas handoff\n\nCurrent state.\n", encoding="utf-8")
+    store = _store(tmp_path / "runtime")
+    lease = _open(store, stream="epic:4700")
+
+    first = mirror_atlas_handoff(
+        store,
+        lease,
+        repo_root=repo_root,
+        stream_id="epic:4700",
+        now=NOW + timedelta(seconds=1),
+    )
+    repeated = mirror_atlas_handoff(
+        store,
+        lease,
+        repo_root=repo_root,
+        stream_id="epic:4700",
+        now=NOW + timedelta(seconds=2),
+    )
+
+    assert handoff.read_text(encoding="utf-8") == "# Atlas handoff\n\nCurrent state.\n"
+    assert first.entry.entry_id == repeated.entry.entry_id
+    assert first.mirror_id == repeated.mirror_id
+    assert handoff.exists()
+    history = store.dump_stream("epic:4700")
+    assert len(history["entries"]) == 1
+    assert len(history["legacy_mirrors"]) == 1
+    assert history["entries"][0]["refs"][0]["kind"] == "legacy_source"
+
+    handoff.write_text("# Atlas handoff\n\nUpdated state.\n", encoding="utf-8")
+    changed = mirror_atlas_handoff(
+        store,
+        lease,
+        repo_root=repo_root,
+        stream_id="epic:4700",
+        now=NOW + timedelta(seconds=3),
+    )
+    assert changed.entry.entry_id != first.entry.entry_id
+    assert len(store.dump_stream("epic:4700")["entries"]) == 2
+
+    with pytest.raises(ValueError, match="must match"):
+        mirror_atlas_handoff(
+            store,
+            lease,
+            repo_root=repo_root,
+            stream_id="epic:4220",
+            now=NOW + timedelta(seconds=4),
+        )
+
+    store.close_session(lease, now=NOW + timedelta(seconds=5))
+    with pytest.raises(LeaseConflictError, match="current active"):
+        mirror_atlas_handoff(
+            store,
+            lease,
+            repo_root=repo_root,
+            stream_id="epic:4700",
+            now=NOW + timedelta(seconds=6),
+        )

--- a/tests/test_session_streams_cli.py
+++ b/tests/test_session_streams_cli.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from agents_extensions.shared.session_streams.cli import build_parser, main
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.model import EntryType, LeaseHolder
+from agents_extensions.shared.session_streams.store import SessionStreamStore
+
+NOW = datetime(2026, 7, 18, 12, 0, tzinfo=UTC)
+
+
+def _populated_database(tmp_path: Path) -> Path:
+    path = tmp_path / "streams.sqlite3"
+    store = SessionStreamStore(SessionStreamDatabase(path))
+    lease = store.open_session(
+        stream_id="epic:4707",
+        holder=LeaseHolder(
+            agent="codex",
+            harness="codex",
+            instance_id="cli-test",
+            task_id="task-cli-test",
+            process_id=44004,
+        ),
+        lineage_id="lineage-cli",
+        ttl_seconds=60,
+        session_id="session-cli",
+        lease_id="lease-cli",
+        now=NOW,
+    )
+    store.append_entry(
+        lease,
+        entry_type=EntryType.BINDING_ORDER,
+        body="Pinned CLI order.",
+        idempotency_key="cli-order",
+        now=NOW + timedelta(seconds=1),
+    )
+    for index in range(3):
+        store.append_entry(
+            lease,
+            entry_type=EntryType.NOTE,
+            body=f"CLI note {index}",
+            idempotency_key=f"cli-note-{index}",
+            now=NOW + timedelta(seconds=2 + index),
+        )
+    return path
+
+
+def test_help_is_self_sufficient() -> None:
+    help_text = build_parser().format_help()
+    assert "Outputs:" in help_text
+    assert "Exit codes:" in help_text
+    assert "Related:" in help_text
+    assert "do not use it to cut over or retire file handoffs" in help_text
+
+
+def test_tail_json_preserves_pinned_plus_last_n(tmp_path: Path, capsys) -> None:
+    database = _populated_database(tmp_path)
+
+    exit_code = main(
+        ["--db", str(database), "tail", "--stream", "epic:4707", "--limit", "1", "--format", "json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [entry["body"] for entry in payload["pinned"]] == ["Pinned CLI order."]
+    assert [entry["body"] for entry in payload["recent"]] == ["CLI note 2"]
+    assert len(payload["digest_sha256"]) == 64
+
+
+def test_dump_jsonl_writes_atomically_complete_history(tmp_path: Path, capsys) -> None:
+    database = _populated_database(tmp_path)
+    output = tmp_path / "exports" / "epic-4707.jsonl"
+
+    exit_code = main(
+        [
+            "--db",
+            str(database),
+            "dump",
+            "--stream",
+            "epic:4707",
+            "--format",
+            "jsonl",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 0
+    assert capsys.readouterr().out.strip() == str(output)
+    records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    record_types = {record["record_type"] for record in records}
+    assert {"schema_migrations", "stream", "sessions", "session_events", "lease_events", "lease", "entries"} <= record_types
+    assert not list(output.parent.glob(f".{output.name}.*.tmp"))
+
+
+def test_tail_missing_stream_has_stable_exit_code(tmp_path: Path, capsys) -> None:
+    database = _populated_database(tmp_path)
+
+    exit_code = main(["--db", str(database), "tail", "--stream", "epic:9999"])
+
+    assert exit_code == 3
+    assert "stream not found" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- add a source-owned `agents_extensions.shared.session_streams` package with a checksummed v1 SQLite migration, WAL/FULL connection policy, immutable history triggers, retained fenced lease projection, and migration drift refusal
- add explicit typed append entries with idempotency, reference integrity, content hygiene, valid-TTL fencing, and deterministic pinned `binding_order`/`negative_constraint` entries followed by the last N non-pinned entries
- add open/rolling/closed lifecycle, harness-owned heartbeat renewal, idempotent clean-exit close, and proof-gated expired crash force-close that records heartbeat age and exact process absence before a distinct successor can open
- add provider-independent hook functions/environment contract for Claude, Codex, Grok, AGY/Gemini, Kimi, and interim drivers
- add argparse-standard operator `tail`/`dump` surfaces and an Atlas-first, explicit-stream dual-write shim that mirrors a stable legacy file image without modifying or deleting the file

## Scope and operator semantics

This is phase-one storage/lifecycle shadow infrastructure only. It does **not** mount Monitor routes, inject cold-start digests, change deploy targets, cut over database authority, retire/delete file handoffs, schedule backups, or merge itself.

A valid lease is untouchable. An expired crashed holder is never transferred: the exact holder PID must be absent, the successor process must be live, proof is recorded, the predecessor session is force-closed, and only then may a distinct successor session open with advanced generation/fencing counters.

The final design-semantic correction is in draft PR #5426; this implementation follows that pinned behavior and does not depend on its code changes.

## Independent review

Grok 4.5 High substituted for Claude because CodexBar reported the Claude weekly bucket at 98%.

- initial review message 3495 found four material issues: concurrent first-migration race, WAL snapshot tearing, delayed predecessor close idempotence, and missing concurrency regressions
- all four were fixed at root with one `BEGIN IMMEDIATE` migration transaction, statement-safe migration execution, explicit read snapshots, immutable lease-event identity checks, and two concurrency regressions
- follow-up message 3497: **APPROVE**, F001-F004 resolved, no new material blocker

## Validation

From `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/session-streams-impl-p1`:

```text
$ .venv/bin/python -m pytest tests/test_session_streams.py tests/test_session_streams_cli.py -q
collected 22 items
tests/test_session_streams.py ..................                         [ 81%]
tests/test_session_streams_cli.py ....                                   [100%]
============================== 22 passed in 0.28s ==============================

$ .venv/bin/ruff check agents_extensions/shared/session_streams tests/test_session_streams.py tests/test_session_streams_cli.py
All checks passed!

$ git diff --cached --check
<no output; exit 0>

$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:
  11efe9faec  PASS  X-Agent: codex/session-streams-impl-p1
All 1 non-skipped commit(s) carry an X-Agent trailer.
```

The commit hook independently reran Ruff plus the same 22 tests and reported `pre-commit passed`. The diff contains 11 directly related files; `.python-version`, `.yamllint`, `.markdownlint.json`, generated status/review/telemetry artifacts, `sys.executable`, and skip patterns are absent.

## Gate and disposition

Draft pending the orchestrator/interim-driver review gate. No merge or auto-merge is requested or armed.

Closes #5427. Refs #5426, #5422, #4707.
