### PR TITLE
Fix calibrated BLOCK score validation

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,6 +1,6 @@
-review_protocol_version: 6.0.4
+review_protocol_version: 6.0.5
 deterministic_contract_version: 2.0.0
-semantic_prompt_version: 6.0.6
+semantic_prompt_version: 6.0.7
 track_policy_version: 2.1.0
 
 score_calibration:

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Common semantic post-build review prompt
 
-Semantic prompt version: `6.0.6`
+Semantic prompt version: `6.0.7`
 
 ## Machine-response contract — read before any source or tool call
 
@@ -245,6 +245,8 @@ Apply the following anchored rubric within the bands:
   that dimension and its rationale must name the concrete gap to `10.0`.
   A `PASS` score may link only low/info findings; a score below `9.0` is never
   publication-ready and must use `REVISE` or `BLOCK` as its calibrated status.
+  A `BLOCK` score requires at least one linked high- or blocker-severity
+  finding. Medium-only findings cannot justify a score below `6.0`.
   At least one evidence entry for that dimension must repeat one linked
   finding's exact primary locator: the identical repo-relative target path and
   one-based line. Positive evidence elsewhere does not satisfy this relational
@@ -434,8 +436,9 @@ only supported claims.
 
 Every quality-dimension `finding_id` must reference a semantic finding. A
 dimension marked `REVISE` requires a medium/high finding, `BLOCK` requires a
-blocker, and `PASS` cannot reference a material finding. The overall verdict
-must fail closed when any dimension is not `PASS`. Do not repair, clamp,
+high/blocker finding, and `PASS` cannot reference a material finding. A
+medium-only finding cannot support `BLOCK` or a score below `6.0`. The overall
+verdict must fail closed when any dimension is not `PASS`. Do not repair, clamp,
 downgrade, round, reconcile, or otherwise change a score to fit a band.
 Do not emit an orphan semantic finding: every finding must be owned by a
 dimension, alignment-audit entry, vocabulary-coverage entry, claim-ledger,

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Core semantic post-build review prompt
 
-Semantic prompt version: `6.0.6`
+Semantic prompt version: `6.0.7`
 
 Apply this only to A1-C2 core tracks, after the common prompt.
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Seminar semantic post-build review prompt
 
-Semantic prompt version: `6.0.6`
+Semantic prompt version: `6.0.7`
 
 Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
 after the common prompt.

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -2513,9 +2513,11 @@ def normalize_semantic_result(
             raise ReviewProtocolError(
                 f"Quality dimension {dimension} REVISE requires a high or medium finding"
             )
-        if dimension_status == "BLOCK" and "blocker" not in referenced_severities:
+        if dimension_status == "BLOCK" and not referenced_severities.intersection(
+            {"blocker", "high"}
+        ):
             raise ReviewProtocolError(
-                f"Quality dimension {dimension} BLOCK requires a blocker finding"
+                f"Quality dimension {dimension} BLOCK requires a high or blocker finding"
             )
         if dimension_status == "INCOMPLETE" and not dimension_finding_ids:
             raise ReviewProtocolError(
@@ -3177,9 +3179,9 @@ def _validate_normalized_quality_dimensions(
             raise ReviewProtocolError(
                 f"Quality dimension {dimension} REVISE requires a high or medium finding"
             )
-        if status == "BLOCK" and "blocker" not in severities:
+        if status == "BLOCK" and not severities.intersection({"blocker", "high"}):
             raise ReviewProtocolError(
-                f"Quality dimension {dimension} BLOCK requires a blocker finding"
+                f"Quality dimension {dimension} BLOCK requires a high or blocker finding"
             )
         if status == "INCOMPLETE" and not finding_ids:
             raise ReviewProtocolError(

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -1013,6 +1013,47 @@ def test_minimum_dimension_score_preserves_pass_backlog_without_averaging(
     assert result["combined_disposition"] == baseline["combined_disposition"]
 
 
+def test_block_score_accepts_high_finding_but_rejects_medium_only(
+    bilash_packet: dict,
+) -> None:
+    semantic = _passing_semantic(bilash_packet)
+    finding = {
+        "id": "high-blocking-gap",
+        "issue_id": "HIGH_BLOCKING_GAP",
+        "category": "pedagogy",
+        "severity": "high",
+        "message": "A high-severity defect blocks publication.",
+        "evidence": "Synthetic evidence-backed blocking gap.",
+        "location": _finding_location(semantic),
+    }
+    semantic["findings"].append(finding)
+    semantic["verdict"] = "BLOCK"
+    semantic["quality_dimensions"]["pedagogical"].update(
+        {
+            "status": "BLOCK",
+            "score": 5.5,
+            "score_rationale": "The high-severity defect blocks publication.",
+            "finding_ids": [finding["id"]],
+        }
+    )
+
+    result = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert result["semantic_response"]["contract_status"] == "valid"
+    assert result["minimum_dimension_score"] == 5.5
+    assert result["combined_disposition"]["status"] == "BLOCK"
+    pbr.validate_result(result)
+
+    finding["severity"] = "medium"
+    invalid = pbr.finalize_review(bilash_packet, _raw(semantic))
+
+    assert invalid["semantic_response"]["contract_status"] == "invalid"
+    assert "BLOCK requires a high or blocker finding" in invalid[
+        "semantic_response"
+    ]["error"]
+    assert invalid["combined_disposition"]["status"] == "INCOMPLETE"
+
+
 def test_subperfect_score_requires_linked_finding_locator_in_dimension_evidence(
     bilash_packet: dict,
 ) -> None:
@@ -3852,8 +3893,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "6.0.6"
-    assert len(rows) == 76
+    assert catalog["catalog_version"] == "6.0.7"
+    assert len(rows) == 77
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 6.0.6
+catalog_version: 6.0.7
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -506,3 +506,15 @@ regressions:
       Require the dimension evidence to repeat one linked finding's exact
       target path and line so the numeric gap remains auditable and the
       fail-closed validator can accept the response without repair.
+  - bug_id: high-finding-block-score-rejected-without-literal-blocker
+    responsible_layer: disposition
+    fixed_in_version: 6.0.5
+    version_field: review_protocol_version
+    input: >-
+      A reviewer assigns a dimension score below 6.0, marks the dimension
+      BLOCK, and links an evidence-backed high-severity finding, but no finding
+      uses the literal blocker severity.
+    expected: >-
+      Accept the calibrated BLOCK response and preserve its numeric score;
+      continue to reject a BLOCK dimension supported only by medium-or-lower
+      findings, and keep the categorical combined disposition fail-closed.

--- a/tests/fixtures/post_build_review/score-calibration.v1.yaml
+++ b/tests/fixtures/post_build_review/score-calibration.v1.yaml
@@ -224,10 +224,10 @@ cases:
       documented_semantic_cap: 6.0
 comparability:
   - id: identical-review-identity-is-comparable
-    left: [6.0.6, fixture, fixture-model, high]
-    right: [6.0.6, fixture, fixture-model, high]
+    left: [6.0.7, fixture, fixture-model, high]
+    right: [6.0.7, fixture, fixture-model, high]
     expected: true
   - id: prompt-or-reviewer-identity-drift-is-not-comparable
-    left: [6.0.6, fixture, fixture-model, high]
-    right: [6.0.4, google, gemini-3.1-pro, high]
+    left: [6.0.7, fixture, fixture-model, high]
+    right: [6.0.6, google, gemini-3.1-pro, high]
     expected: false


### PR DESCRIPTION
## Summary
- accept evidence-backed high-severity findings for calibrated dimension scores below 6.0
- keep medium-only BLOCK responses fail-closed
- version the review protocol at 6.0.5 and semantic prompt at 6.0.7
- add live/replay and regression-catalog coverage

## Verification
- `.venv/bin/python -m pytest tests/audit/test_post_build_review.py -q` — 192 passed
- `.venv/bin/ruff check scripts/audit/post_build_review.py tests/audit/test_post_build_review.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check`

Related: #5294