### PR TITLE
Fix Codex semantic output schema binding

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/SKILL.md
+++ b/agents_extensions/shared/skills/post-build-review/SKILL.md
@@ -70,6 +70,23 @@ artifacts. Report findings; do not fix the module during this invocation.
      --output <semantic_schema_path>
    ```
 
+   A Codex review dispatched through the project runtime must bind that exact
+   file at the provider boundary; omitting the flag is an orchestration defect
+   and must stop before inference:
+
+   ```bash
+   .venv/bin/python scripts/delegate.py dispatch \
+     --agent codex --task-id <unique_review_task_id> \
+     --prompt-file <semantic_prompt_path> --mode read-only \
+     --cwd <exact_review_checkout> --model <model> --effort <effort> \
+     --output-schema <semantic_schema_path>
+   ```
+
+   The dispatcher validates and hashes the schema before spawn, and the Codex
+   adapter validates it again before emitting `codex exec --output-schema`.
+   Preserve the task result file's exact bytes as the semantic response; do
+   not extract a JSON object from a provider envelope.
+
    Bind that schema at the provider boundary and redirect its structured text
    channel directly to `<semantic_response_path>`. The packet binding constrains
    cited evidence to valid target-file paths and one-based line numbers; the

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,4 +1,4 @@
-review_protocol_version: 6.0.5
+review_protocol_version: 6.0.6
 deterministic_contract_version: 2.0.0
 semantic_prompt_version: 6.0.7
 track_policy_version: 2.1.0

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -114,7 +114,9 @@ Read and follow `$post-build-review` completely for the same target. Allocate a
 new invocation directory every time. Do not repair, normalize, or retry inside
 that invocation. Use its emitted semantic schema when the provider supports
 structured output; prompt-only JSON compliance is not a reliable automation
-boundary. Record its exact result:
+boundary. For Codex dispatches, `--output-schema <semantic_schema_path>` is
+mandatory and its absence is `audit_tooling`, not a reason to retry the model.
+Record its exact result:
 
 ```bash
 .venv/bin/python \

--- a/docs/runbooks/post-build-review.md
+++ b/docs/runbooks/post-build-review.md
@@ -108,12 +108,18 @@ seven classes, so prompt guidance and exhaustive finalizer ownership cannot
 contradict one another.
 
 Dimension scores preserve the accepted raw reviewer response after strict
-Decimal-based validation: `PASS` is `[8.0, 10.0]`, `REVISE` is `[6.0, 8.0)`,
+Decimal-based validation: `PASS` is `[9.0, 10.0]`, `REVISE` is `[6.0, 9.0)`,
 `BLOCK` is `[0.0, 6.0)`, and `INCOMPLETE` has a null score/rationale. The
 normalizer never repairs, rounds, clamps, downgrades, or reconciles a score.
 `combine_disposition` consumes categorical semantic/deterministic evidence
 only. A score can be compared only for identical semantic prompt, reviewer
 family, reviewer model, and reviewer effort identities.
+
+Protocol 6.0.6 closes the Codex transport gap: `delegate.py dispatch
+--output-schema` validates and hashes the emitted schema before spawn, carries
+its absolute path through the detached worker, and binds it as `codex exec
+--output-schema`. Prompt-only Codex review is a fail-closed orchestration defect,
+not an acceptable substitute for structured output.
 
 ## Bug-fix workflow
 

--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -27,6 +27,7 @@ Issue: #1184
 
 from __future__ import annotations
 
+import hashlib
 import json as _json
 import logging
 import os
@@ -371,6 +372,11 @@ class CodexAdapter:
           (plus a symlink of the user's ``auth.json``) is the actual
           per-invocation isolation mechanism in codex-cli 0.133.0,
           confirmed via ``ab ask-codex`` 2026-05-22.
+        - ``output_schema_path`` plus ``output_schema_sha256``: absolute path
+          to a readable JSON object and its exact SHA-256 → ``--output-schema
+          <path>``. The adapter validates both again at invocation time so
+          direct runtime callers cannot bypass the dispatch boundary's
+          fail-closed schema checks or race different bytes into the provider.
         """
         flags: list[str] = []
         if not tool_config:
@@ -386,6 +392,30 @@ class CodexAdapter:
             for feature in disable_features:
                 if isinstance(feature, str) and feature:
                     flags.extend(["--disable", feature])
+
+        output_schema_path = tool_config.get("output_schema_path")
+        if output_schema_path is not None:
+            if not isinstance(output_schema_path, str) or not output_schema_path:
+                raise ValueError("CodexAdapter: output_schema_path must be a non-empty absolute path")
+            schema_path = Path(output_schema_path)
+            if not schema_path.is_absolute():
+                raise ValueError("CodexAdapter: output_schema_path must be absolute")
+            if not schema_path.is_file():
+                raise ValueError(f"CodexAdapter: output schema is not a readable file: {schema_path}")
+            expected_sha256 = tool_config.get("output_schema_sha256")
+            if not isinstance(expected_sha256, str) or not re.fullmatch(r"[0-9a-f]{64}", expected_sha256):
+                raise ValueError("CodexAdapter: output_schema_sha256 must be a lowercase SHA-256")
+            try:
+                payload = schema_path.read_bytes()
+                schema = _json.loads(payload.decode("utf-8"))
+            except (OSError, UnicodeDecodeError, _json.JSONDecodeError) as exc:
+                raise ValueError(f"CodexAdapter: invalid output schema JSON: {exc}") from exc
+            if not isinstance(schema, dict):
+                raise ValueError("CodexAdapter: output schema JSON must be an object")
+            actual_sha256 = hashlib.sha256(payload).hexdigest()
+            if actual_sha256 != expected_sha256:
+                raise ValueError("CodexAdapter: output schema SHA-256 changed after dispatch validation")
+            flags.extend(["--output-schema", str(schema_path)])
 
         return flags
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -87,6 +87,7 @@ Issue: #1184.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -297,6 +298,41 @@ def _normalize_worktree_path(raw_path: str) -> Path:
     if not path.is_absolute():
         path = _REPO_ROOT / path
     return path.resolve()
+
+
+def _resolve_output_schema(
+    raw_path: str | None,
+    *,
+    agent: str,
+) -> tuple[str | None, str | None]:
+    """Validate one provider output schema before any worker is spawned.
+
+    The Codex CLI is currently the only native dispatch adapter with a
+    file-backed structured-output flag. Returning an absolute path prevents
+    the detached worker from resolving a relative schema against a different
+    working directory. The SHA is persisted in task state as proof of the
+    exact schema bytes admitted at the dispatch boundary.
+    """
+    if raw_path is None:
+        return None, None
+    if agent != "codex":
+        raise ValueError("--output-schema is supported only with the effective codex agent")
+
+    candidate = Path(raw_path).expanduser()
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise ValueError(f"output schema does not exist: {candidate}") from exc
+    if not resolved.is_file():
+        raise ValueError(f"output schema is not a regular file: {resolved}")
+    try:
+        payload = resolved.read_bytes()
+        schema = json.loads(payload.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"output schema is not valid UTF-8 JSON: {exc}") from exc
+    if not isinstance(schema, dict):
+        raise ValueError("output schema JSON must be an object")
+    return str(resolved), hashlib.sha256(payload).hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -1983,6 +2019,8 @@ def _run_worker(
     initial_response_timeout: int = DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
     keep_worktree: bool = False,
     provider: str | None = None,
+    output_schema_path: str | None = None,
+    output_schema_sha256: str | None = None,
     runtime_tmp_root: str | None = None,
     runtime_tmp_namespace_root: str | None = None,
 ) -> int:
@@ -2052,6 +2090,9 @@ def _run_worker(
             tool_config["max_budget_usd"] = max_budget_usd
         if provider is not None:
             tool_config[RUNTIME_ROUTE_TOOL_CONFIG_KEY] = {"provider": provider}
+        if output_schema_path is not None:
+            tool_config["output_schema_path"] = output_schema_path
+            tool_config["output_schema_sha256"] = output_schema_sha256
         tool_config = tool_config or None
         result = runtime_invoke(
             agent,
@@ -2426,6 +2467,15 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     else:
         dispatch_agent = args.agent
 
+    try:
+        output_schema_path, output_schema_sha256 = _resolve_output_schema(
+            getattr(args, "output_schema", None),
+            agent=dispatch_agent,
+        )
+    except ValueError as exc:
+        print(f"❌ invalid --output-schema: {exc}", file=sys.stderr)
+        return 2
+
     if getattr(args, "dry_run", False):
         dry_run_worktree: Path | None = None
         dry_run_branch: str | None = None
@@ -2475,6 +2525,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             "worktree_branch": dry_run_branch,
             "worktree_base_sha": dry_run_worktree_telemetry.get("base_sha"),
             "runtime_tmp_root": str(runtime_tmp_root),
+            "output_schema_path": output_schema_path,
+            "output_schema_sha256": output_schema_sha256,
             "tmp_bytes_freed": None,
             "tmp_reap_error": None,
             "pid": None,
@@ -2619,6 +2671,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "silence_timeout": silence_timeout,
         "initial_response_timeout": initial_response_timeout,
         "max_budget_usd": max_budget_usd,
+        "output_schema_path": output_schema_path,
+        "output_schema_sha256": output_schema_sha256,
         "pid": None,  # worker fills this
         "status": "spawning",
         "started_at": datetime.now(UTC).isoformat(),
@@ -2700,6 +2754,15 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         cmd.append("--keep-worktree")
     if max_budget_usd is not None:
         cmd.extend(["--max-budget-usd", str(max_budget_usd)])
+    if output_schema_path is not None:
+        cmd.extend(
+            [
+                "--output-schema",
+                output_schema_path,
+                "--output-schema-sha256",
+                str(output_schema_sha256),
+            ]
+        )
     if args.model:
         cmd.extend(["--model", args.model])
     if getattr(args, "provider", None):
@@ -3239,6 +3302,8 @@ def cmd_worker(args: argparse.Namespace) -> int:
         model=args.model,
         hard_timeout=args.hard_timeout,
         provider=getattr(args, "provider", None),
+        output_schema_path=getattr(args, "output_schema", None),
+        output_schema_sha256=getattr(args, "output_schema_sha256", None),
         silence_timeout=args.silence_timeout,
         max_budget_usd=getattr(args, "max_budget_usd", None),
         effort=args.effort,
@@ -3499,6 +3564,17 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     d.add_argument(
+        "--output-schema",
+        default=None,
+        metavar="FILE",
+        help=(
+            "Bind a JSON Schema to the final response of an effective Codex "
+            "dispatch. The file is parsed before spawn, resolved to an "
+            "absolute path, hashed into task state, and revalidated by the "
+            "Codex adapter before it emits --output-schema."
+        ),
+    )
+    d.add_argument(
         "--research-role",
         default=None,
         metavar="ROLE",
@@ -3627,6 +3703,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     wk.add_argument("--keep-worktree", action="store_true")
     wk.add_argument("--max-budget-usd", type=float, default=None)
+    wk.add_argument("--output-schema", default=None)
+    wk.add_argument("--output-schema-sha256", default=None)
     wk.add_argument("--runtime-tmp-root", default=None)
     wk.add_argument("--runtime-tmp-namespace-root", default=None)
     wk.set_defaults(func=cmd_worker)

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -3887,14 +3887,15 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
     assert "--semantic-result" not in text
     assert "post_build_review.py allocate <track/slug>" in text
     assert "--output <packet_path>" in text
+    assert "--output-schema <semantic_schema_path>" in text
     assert "curriculum/l2-uk-en/{track}/audit" not in text
 
 
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "6.0.7"
-    assert len(rows) == 77
+    assert catalog["catalog_version"] == "6.0.8"
+    assert len(rows) == 78
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 6.0.7
+catalog_version: 6.0.8
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -518,3 +518,15 @@ regressions:
       Accept the calibrated BLOCK response and preserve its numeric score;
       continue to reject a BLOCK dimension supported only by medium-or-lower
       findings, and keep the categorical combined disposition fail-closed.
+  - bug_id: codex-dispatch-dropped-provider-output-schema
+    responsible_layer: orchestration
+    fixed_in_version: 6.0.6
+    version_field: review_protocol_version
+    input: >-
+      A canonical Codex semantic review emits a packet-bound JSON Schema, but
+      the detached dispatcher drops that schema before invoking the provider;
+      after a long review the model returns one valid object plus trailing data.
+    expected: >-
+      Validate and hash the schema before spawn, forward its absolute path
+      through worker tool configuration, bind codex exec --output-schema, and
+      fail closed before inference for a missing, malformed, or non-Codex use.

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -18,6 +18,8 @@ Issue: #1184
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
 import subprocess
@@ -627,6 +629,88 @@ def test_codex_adapter_disable_features_multiple(tmp_path):
     )
     disable_pairs = [plan.cmd[index + 1] for index, token in enumerate(plan.cmd[:-1]) if token == "--disable"]
     assert disable_pairs == ["shell_tool", "browser_use"]
+
+
+def test_codex_adapter_binds_valid_output_schema(tmp_path):
+    schema_path = tmp_path / "semantic-schema.json"
+    schema_path.write_text(
+        json.dumps({"type": "object", "properties": {"status": {"type": "string"}}}),
+        encoding="utf-8",
+    )
+    adapter = CodexAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config={
+            "output_schema_path": str(schema_path),
+            "output_schema_sha256": hashlib.sha256(schema_path.read_bytes()).hexdigest(),
+        },
+    )
+
+    schema_index = plan.cmd.index("--output-schema")
+    assert plan.cmd[schema_index + 1] == str(schema_path)
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("not-json", "invalid output schema JSON"),
+        ("[]", "must be an object"),
+    ],
+)
+def test_codex_adapter_rejects_invalid_output_schema(tmp_path, payload, expected):
+    schema_path = tmp_path / "semantic-schema.json"
+    schema_path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=expected):
+        CodexAdapter().build_invocation(
+            prompt="hello",
+            mode="read-only",
+            cwd=tmp_path,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config={
+                "output_schema_path": str(schema_path),
+                "output_schema_sha256": hashlib.sha256(schema_path.read_bytes()).hexdigest(),
+            },
+        )
+
+
+def test_codex_adapter_rejects_relative_output_schema_path(tmp_path):
+    with pytest.raises(ValueError, match="must be absolute"):
+        CodexAdapter().build_invocation(
+            prompt="hello",
+            mode="read-only",
+            cwd=tmp_path,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config={"output_schema_path": "semantic-schema.json"},
+        )
+
+
+def test_codex_adapter_rejects_output_schema_hash_drift(tmp_path):
+    schema_path = tmp_path / "semantic-schema.json"
+    schema_path.write_text('{"type": "object"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="changed after dispatch validation"):
+        CodexAdapter().build_invocation(
+            prompt="hello",
+            mode="read-only",
+            cwd=tmp_path,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config={
+                "output_schema_path": str(schema_path),
+                "output_schema_sha256": "0" * 64,
+            },
+        )
 
 
 def test_codex_adapter_disable_features_ignores_non_string_entries(tmp_path):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -700,6 +700,54 @@ def test_dispatch_parses_max_budget_usd_flag():
     assert args.max_budget_usd == 0.5
 
 
+def test_dispatch_parser_accepts_output_schema(tmp_path):
+    schema_path = tmp_path / "semantic-schema.json"
+    schema_path.write_text('{"type": "object"}', encoding="utf-8")
+    args = delegate.build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "schema-task",
+            "--prompt",
+            "hi",
+            "--output-schema",
+            str(schema_path),
+        ]
+    )
+
+    assert args.output_schema == str(schema_path)
+
+
+def test_resolve_output_schema_returns_absolute_path_and_hash(tmp_path):
+    schema_path = tmp_path / "semantic-schema.json"
+    payload = b'{"type":"object"}'
+    schema_path.write_bytes(payload)
+
+    resolved, digest = delegate._resolve_output_schema(str(schema_path), agent="codex")
+
+    assert resolved == str(schema_path.resolve())
+    assert digest == delegate.hashlib.sha256(payload).hexdigest()
+
+
+def test_resolve_output_schema_rejects_non_codex_agent(tmp_path):
+    schema_path = tmp_path / "semantic-schema.json"
+    schema_path.write_text('{"type": "object"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="only with the effective codex agent"):
+        delegate._resolve_output_schema(str(schema_path), agent="gemini")
+
+
+@pytest.mark.parametrize("payload", ["not-json", "[]"])
+def test_resolve_output_schema_rejects_invalid_json_object(tmp_path, payload):
+    schema_path = tmp_path / "semantic-schema.json"
+    schema_path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"valid UTF-8 JSON|must be an object"):
+        delegate._resolve_output_schema(str(schema_path), agent="codex")
+
+
 def test_worker_parser_accepts_max_budget_usd():
     parser = delegate.build_parser()
     args = parser.parse_args([
@@ -712,6 +760,27 @@ def test_worker_parser_accepts_max_budget_usd():
     ])
 
     assert args.max_budget_usd == 0.5
+
+
+def test_worker_parser_accepts_output_schema(tmp_path):
+    schema_path = tmp_path / "semantic-schema.json"
+    args = delegate.build_parser().parse_args(
+        [
+            "_worker",
+            "--task-id",
+            "schema-task",
+            "--agent",
+            "codex",
+            "--mode",
+            "read-only",
+            "--cwd",
+            "/tmp",
+            "--output-schema",
+            str(schema_path),
+        ]
+    )
+
+    assert args.output_schema == str(schema_path)
 
 
 def test_dispatch_persists_and_forwards_max_budget_usd(tmp_tasks_dir):
@@ -1587,6 +1656,48 @@ def test_run_worker_forwards_max_budget_usd_to_runtime(tmp_tasks_dir, tmp_path):
     assert state["max_budget_usd"] == 0.5
 
 
+def test_run_worker_forwards_output_schema_to_runtime(tmp_tasks_dir, tmp_path):
+    state_path = delegate._state_path("worker-schema")
+    delegate._write_state_atomic(state_path, {"task_id": "worker-schema"})
+    schema_path = tmp_path / "semantic-schema.json"
+    schema_path.write_text('{"type": "object"}', encoding="utf-8")
+    schema_sha256 = delegate.hashlib.sha256(schema_path.read_bytes()).hexdigest()
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "{}",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "gpt-5.6-sol",
+            "effort": "xhigh",
+            "cli_version": "fixture",
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result) as mock_invoke:
+        rc = delegate._run_worker(
+            task_id="worker-schema",
+            agent="codex",
+            prompt="hi",
+            mode="read-only",
+            cwd_str=str(tmp_path),
+            model="gpt-5.6-sol",
+            hard_timeout=60,
+            effort="xhigh",
+            output_schema_path=str(schema_path),
+            output_schema_sha256=schema_sha256,
+        )
+
+    assert rc == 0
+    assert mock_invoke.call_args.kwargs["tool_config"] == {
+        "output_schema_path": str(schema_path),
+        "output_schema_sha256": schema_sha256,
+    }
+
+
 def test_run_worker_silence_timeout_kills_silent_subprocess(
     tmp_tasks_dir,
     tmp_path,
@@ -2068,6 +2179,61 @@ def test_dispatch_records_runtime_tmp_lease_and_injects_worker_env(
     cmd = recorded["cmd"]
     assert isinstance(cmd, list)
     assert cmd[cmd.index("--runtime-tmp-root") + 1] == str(lease_root)
+
+
+def test_dispatch_persists_and_forwards_output_schema(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    recorded: dict[str, object] = {}
+    schema_path = tmp_path / "semantic-schema.json"
+    payload = b'{"type":"object"}'
+    schema_path.write_bytes(payload)
+
+    class _FakeStdin:
+        def write(self, _data):
+            pass
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        pid = 24682
+        stdin = _FakeStdin()
+
+    def fake_popen(cmd, **_kwargs):
+        recorded["cmd"] = cmd
+        return _FakeProc()
+
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(delegate.subprocess, "Popen", fake_popen)
+    args = delegate.build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "schema-dispatch",
+            "--prompt",
+            "test",
+            "--output-schema",
+            str(schema_path),
+        ]
+    )
+
+    assert delegate.cmd_dispatch(args) == 0
+
+    state = delegate._read_state(delegate._state_path("schema-dispatch"))
+    assert state is not None
+    assert state["output_schema_path"] == str(schema_path.resolve())
+    assert state["output_schema_sha256"] == delegate.hashlib.sha256(payload).hexdigest()
+    cmd = recorded["cmd"]
+    assert isinstance(cmd, list)
+    schema_index = cmd.index("--output-schema")
+    assert cmd[schema_index + 1] == str(schema_path.resolve())
+    hash_index = cmd.index("--output-schema-sha256")
+    assert cmd[hash_index + 1] == delegate.hashlib.sha256(payload).hexdigest()
 
 
 def test_dispatch_dry_run_records_and_reaps_runtime_tmp_lease(


### PR DESCRIPTION
## What changed

- Add `delegate.py dispatch --output-schema FILE` for effective Codex routes.
- Validate the schema as a UTF-8 JSON object before spawn, resolve it to an
  absolute path, and persist its SHA-256 in task state.
- Carry the path and hash through the detached worker, then revalidate both in
  `CodexAdapter` before emitting `codex exec --output-schema`.
- Make missing Codex schema binding an explicit `audit_tooling` lifecycle
  defect and bump the post-build review protocol to 6.0.6.
- Add regression coverage for invalid schemas, non-Codex use, hash drift,
  parent-to-worker propagation, adapter flag emission, versioning, and docs.

## Root cause

The canonical post-build review already emitted a packet-bound semantic JSON
Schema, and Codex CLI already supported `--output-schema`, but the project
dispatcher discarded that schema. BIO-371's long GPT-5.6 Sol review therefore
relied on prompt-only JSON compliance and returned one valid object plus
trailing data. The fail-closed finalizer correctly marked it `INCOMPLETE`, but
the transport gap made the expensive invocation avoidably fragile.

## Impact

Future Codex post-build reviews fail before inference when the schema is
missing or malformed and cannot race different schema bytes into the provider.
The categorical review gate remains authoritative; this change does not alter
BIO-371 learner content or arm production QG.

## Validation

- pre-commit affected suite: 492 passed
- `tests/test_agent_runtime.py`: 166 passed
- `tests/test_delegate.py`: 134 passed
- `tests/audit/test_post_build_review.py`: 192 passed
- `tests/test_deploy_script_idempotency.py`: 14 passed
- `tests/test_agent_runtime_effort.py`: 19 passed
- Ruff, Markdownlint, skill metadata/quick validation, deployment drift, agent
  trailer lint, and `git diff --check`: passed

Independent cross-family review: Gemini 3.1 Pro High reviewed frozen commit
`d778501e09caac70ee76fd6cb6bddfbd09978321` and returned
`PASS — no material findings`. Claude was not used, per operator instruction.

Related to #5294.
