### PR TITLE
feat(lexicon): offline reduce path for 20k ULIF network cache

### DIFF
--- a/scripts/lexicon/runner/__init__.py
+++ b/scripts/lexicon/runner/__init__.py
@@ -4,6 +4,7 @@ PR1: bounded lookup rewrite, sealed CEFR/relations, streaming I/O, hard caps.
 PR2: real-unit ledger, fencing/CAS, resume, attempt caps, operator retry.
 PR3: disconnected network cache, packets/bundles, fenced import.
 PR4: leaf sealing handoff, streaming finalization, publication gate.
+Offline reduce: consume ULIF network-cache raw envelopes → structured candidate.
 """
 
 from __future__ import annotations
@@ -13,6 +14,8 @@ from scripts.lexicon.runner.finalize import finalize_run
 from scripts.lexicon.runner.ledger import Ledger, compute_run_fingerprint
 from scripts.lexicon.runner.network_cache import NetworkCache, compute_request_key
 from scripts.lexicon.runner.offline_engine import enrich_offline_slice
+from scripts.lexicon.runner.offline_reduce import reduce_offline_slice
+from scripts.lexicon.runner.ulif_dictua_parse import parse_dictua_envelope
 
 __all__ = [
     "ENGINE_VERSION",
@@ -23,4 +26,6 @@ __all__ = [
     "compute_run_fingerprint",
     "enrich_offline_slice",
     "finalize_run",
+    "parse_dictua_envelope",
+    "reduce_offline_slice",
 ]

--- a/scripts/lexicon/runner/fetch_ulif_20k.py
+++ b/scripts/lexicon/runner/fetch_ulif_20k.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Durable, single-process ULIF DictUA fetch phase for Atlas 20k (#5230).
+
+This is intentionally fetch-only.  It never imports the enrichment engine or
+opens ``sources.db``: its durable state is the run ledger and network cache
+below ``--work-dir``.  A logical work unit is one DictUA lookup (the initial
+WebForms page, search postback, and any available relation-tab postbacks).
+The complete raw response envelope is content-addressed by ``NetworkCache``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+from bs4 import BeautifulSoup
+
+EXPECTED_COHORT_SHA256 = "858f0c7ce34d0d1e27c3519695073ea3e62bc0623010c03683137b7b730dcab4"
+EXPECTED_COHORT_COUNT = 20_323
+PHASE = "network_fetch"
+HOST = "lcorp.ulif.org.ua"
+ULIF_URL = "https://lcorp.ulif.org.ua/dictua/"
+ADAPTER_VERSION = "ulif-dictua-fetch-v1"
+POLITENESS_DELAY_SECONDS = 1.0
+REQUEST_TIMEOUT_SECONDS = 20
+COOLDOWN_SECONDS = 120.0
+LEASE_TTL_SECONDS = 60.0
+
+
+def _load_runner(repo: Path) -> None:
+    """Import runner modules only after the explicit repository path is known."""
+    sys.path.insert(0, str(repo))
+
+
+@dataclass(frozen=True, slots=True)
+class RetryableFetch(Exception):
+    error_code: str
+    cooldown_seconds: float
+
+
+class DictUAClient:
+    """One polite, sequential WebForms client; it holds no corpus/database handle."""
+
+    def __init__(self, *, delay_seconds: float, timeout_seconds: int) -> None:
+        self.session = requests.Session()
+        self.delay_seconds = delay_seconds
+        self.timeout_seconds = timeout_seconds
+        self.last_request_at = 0.0
+        self.session.headers.update(
+            {
+                "User-Agent": (
+                    "learn-ukrainian-atlas/1.0 "
+                    "(noncommercial educational ULIF per-lemma fetch; issue #5230)"
+                )
+            }
+        )
+
+    def _wait_turn(self) -> None:
+        elapsed = time.monotonic() - self.last_request_at
+        if self.last_request_at and elapsed < self.delay_seconds:
+            time.sleep(self.delay_seconds - elapsed)
+
+    @staticmethod
+    def _retry_after(response: requests.Response) -> float:
+        try:
+            return max(COOLDOWN_SECONDS, float(response.headers.get("Retry-After", "")))
+        except ValueError:
+            return COOLDOWN_SECONDS
+
+    @staticmethod
+    def _headers(response: requests.Response) -> dict[str, str]:
+        return {
+            key.lower(): value
+            for key, value in response.headers.items()
+            if key.lower() in {"content-type", "retry-after", "server", "date"}
+        }
+
+    def _request(self, method: str, **kwargs: Any) -> requests.Response:
+        self._wait_turn()
+        try:
+            response = self.session.request(method, ULIF_URL, timeout=self.timeout_seconds, **kwargs)
+        except requests.RequestException as exc:
+            raise RetryableFetch("network_error", COOLDOWN_SECONDS) from exc
+        finally:
+            self.last_request_at = time.monotonic()
+
+        if response.status_code in {403, 408, 425, 429} or response.status_code >= 500:
+            code = "http_429" if response.status_code == 429 else f"http_{response.status_code}"
+            raise RetryableFetch(code, self._retry_after(response))
+        return response
+
+    @staticmethod
+    def _tokens(html: str) -> dict[str, str] | None:
+        soup = BeautifulSoup(html, "html.parser")
+        values: dict[str, str] = {}
+        for name in ("__VIEWSTATE", "__VIEWSTATEGENERATOR", "__EVENTVALIDATION"):
+            node = soup.find("input", attrs={"name": name})
+            if node is not None and node.get("value") is not None:
+                values[name] = str(node.get("value"))
+        return values if values.get("__VIEWSTATE") and values.get("__EVENTVALIDATION") else None
+
+    @staticmethod
+    def _has_control(html: str, control_name: str) -> bool:
+        soup = BeautifulSoup(html, "html.parser")
+        return soup.find("input", attrs={"name": control_name}) is not None
+
+    @staticmethod
+    def _headword(html: str, requested_word: str) -> str:
+        soup = BeautifulSoup(html, "html.parser")
+        article = soup.find(id="ContentPlaceHolder1_article")
+        if article is not None:
+            article_text = " ".join(article.get_text(" ", strip=True).split())
+            for separator in (" – ", " — ", " - "):
+                if separator in article_text:
+                    candidate = article_text.split(separator, 1)[0].strip()
+                    if candidate:
+                        return candidate
+        input_control = soup.find("input", attrs={"name": "ctl00$ContentPlaceHolder1$tsearch"})
+        if input_control is None:
+            return requested_word
+        return str(input_control.get("value", requested_word)).strip() or requested_word
+
+    @staticmethod
+    def _search_result_matches(html: str, requested_word: str) -> bool | None:
+        """Distinguish a real DictUA match from its unrelated-article 200 miss."""
+        soup = BeautifulSoup(html, "html.parser")
+        result_list = soup.find(id="ContentPlaceHolder1_dgv")
+        if result_list is None:
+            return None
+        normalized_query = requested_word.replace("\u0301", "").casefold()
+        candidates = {
+            " ".join(link.get_text(" ", strip=True).split()).replace("\u0301", "").casefold()
+            for link in result_list.find_all("a")
+        }
+        return normalized_query in candidates
+
+    @classmethod
+    def _record(cls, stage: str, response: requests.Response) -> dict[str, Any]:
+        return {
+            "stage": stage,
+            "status_code": response.status_code,
+            "headers": cls._headers(response),
+            "html": response.text,
+        }
+
+    def fetch_lookup(self, lemma: str) -> dict[str, Any]:
+        """Return all raw WebForms pages for one lemma, or a durable parse marker."""
+        initial = self._request("GET")
+        tokens = self._tokens(initial.text)
+        if tokens is None:
+            return {"lemma": lemma, "status": "parse_error", "responses": [self._record("initial", initial)]}
+
+        search_data = {
+            **tokens,
+            "ctl00$ContentPlaceHolder1$tsearch": lemma,
+            "ctl00$ContentPlaceHolder1$search.x": "10",
+            "ctl00$ContentPlaceHolder1$search.y": "10",
+        }
+        search = self._request("POST", data=search_data)
+        responses = [self._record("initial", initial), self._record("paradigm", search)]
+        if search.status_code == 404:
+            return {"lemma": lemma, "status": "not_found", "responses": responses}
+        search_match = self._search_result_matches(search.text, lemma)
+        if search_match is None:
+            return {"lemma": lemma, "status": "parse_error", "responses": responses}
+        if not search_match:
+            return {"lemma": lemma, "status": "not_found", "responses": responses}
+
+        tab_tokens = self._tokens(search.text)
+        if tab_tokens is None:
+            return {"lemma": lemma, "status": "parse_error", "responses": responses}
+
+        headword = self._headword(search.text, lemma)
+        for section, control_name in (
+            ("synonyms", "ctl00$ContentPlaceHolder1$syn"),
+            ("phraseology", "ctl00$ContentPlaceHolder1$phras"),
+            ("antonyms", "ctl00$ContentPlaceHolder1$ant"),
+        ):
+            if not self._has_control(search.text, control_name):
+                continue
+            tab_data = {
+                **tab_tokens,
+                "ctl00$ContentPlaceHolder1$tsearch": headword,
+                f"{control_name}.x": "10",
+                f"{control_name}.y": "10",
+            }
+            tab = self._request("POST", data=tab_data)
+            responses.append(self._record(section, tab))
+            next_tokens = self._tokens(tab.text)
+            if next_tokens is None:
+                return {"lemma": lemma, "status": "parse_error", "responses": responses}
+            tab_tokens = next_tokens
+        return {"lemma": lemma, "status": "ok", "responses": responses}
+
+
+def _cohort(path: Path) -> tuple[list[str], str]:
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    lemmas = [line.strip() for line in raw.decode("utf-8").splitlines() if line.strip()]
+    if digest != EXPECTED_COHORT_SHA256:
+        raise RuntimeError(f"cohort sha mismatch: got {digest}, expected {EXPECTED_COHORT_SHA256}")
+    if len(lemmas) != EXPECTED_COHORT_COUNT:
+        raise RuntimeError(f"cohort count mismatch: got {len(lemmas)}, expected {EXPECTED_COHORT_COUNT}")
+    if len(set(lemmas)) != len(lemmas):
+        raise RuntimeError("cohort contains duplicate lemma identifiers")
+    return lemmas, digest
+
+
+def _event(name: str, **fields: Any) -> None:
+    print(json.dumps({"event": name, "at": time.time(), **fields}, ensure_ascii=False, sort_keys=True), flush=True)
+
+
+def _next_lemma(ledger: Any, run_id: str) -> str | None:
+    row = ledger._require().execute(  # coordinator-only query: no worker gets this ledger
+        "SELECT unit_id FROM work_units WHERE run_id = ? AND phase = ? "
+        "AND state IN ('pending', 'retry_scheduled') ORDER BY unit_id LIMIT 1",
+        (run_id, PHASE),
+    ).fetchone()
+    return None if row is None else str(row["unit_id"])
+
+
+def _counts(ledger: Any, run_id: str) -> dict[str, int]:
+    rows = ledger._require().execute(
+        "SELECT state, COUNT(*) AS n FROM work_units WHERE run_id = ? AND phase = ? GROUP BY state",
+        (run_id, PHASE),
+    ).fetchall()
+    return {str(row["state"]): int(row["n"]) for row in rows}
+
+
+def _parsed_payload(item: Any, body: bytes) -> tuple[dict[str, Any], str]:
+    envelope = json.loads(body.decode("utf-8"))
+    parsed = {
+        "lemma_id": item.lemma_id,
+        "request_key": item.request_key,
+        "status": str(envelope.get("status") or "parse_error"),
+        "response_count": len(envelope.get("responses") or []),
+    }
+    return parsed, json.dumps(parsed, ensure_ascii=False, sort_keys=True)
+
+
+def _process_lookup(cache: Any, item: Any, client: DictUAClient) -> Any:
+    """Network-cache equivalent of ``process_request`` for DictUA's multi-step lookup.
+
+    DictUA has a session-bound WebForms exchange, so the request-level cache
+    identity is the complete logical lookup for one lemma.  Every underlying
+    HTTP operation remains sequential and rate limited by ``DictUAClient``.
+    """
+    from scripts.lexicon.runner.network_cache import CacheCasStatus
+    from scripts.lexicon.runner.network_worker import FetchOutcome
+    from scripts.lexicon.runner.sources_guard import guard_network_worker
+    from scripts.lexicon.runner.transport import item_content_hash
+
+    with guard_network_worker():
+        claim = cache.claim_request(item.request_key, cache.owner_id, host=HOST)
+        if claim.status is CacheCasStatus.HOST_COOLDOWN:
+            return FetchOutcome(item.lemma_id, item.request_key, "retry_scheduled", error_code="host_cooldown")
+        if claim.status is CacheCasStatus.ATTEMPT_CAP_EXHAUSTED:
+            return FetchOutcome(item.lemma_id, item.request_key, "failed_terminal", error_code="attempt_cap_exhausted")
+        if not claim.ok:
+            return FetchOutcome(item.lemma_id, item.request_key, "failed_terminal", error_code=claim.status.value)
+
+        if claim.is_cache_hit:
+            assert claim.cached_body is not None and claim.body_sha256 is not None
+            parsed, parsed_json = _parsed_payload(item, claim.cached_body)
+            cache.put_parsed(
+                request_key=item.request_key,
+                body_sha256=claim.body_sha256,
+                parser_version=ADAPTER_VERSION,
+                normalizer_version="none",
+                schema_version="ulif-raw-envelope-v1",
+                parsed_payload=parsed_json,
+            )
+            result = {"lemma_id": item.lemma_id, "request_key": item.request_key, "result": parsed}
+            return FetchOutcome(
+                item.lemma_id,
+                item.request_key,
+                "cache_hit_parsed",
+                result=parsed,
+                result_hash=item_content_hash(result),
+                status_code=claim.status_code,
+            )
+
+        assert claim.lease_generation is not None
+        try:
+            cache.record_fetch_attempt()
+            envelope = client.fetch_lookup(item.lemma_id)
+        except RetryableFetch as exc:
+            next_allowed = time.time() + exc.cooldown_seconds
+            cache.commit_retry_scheduled(
+                item.request_key,
+                cache.owner_id,
+                claim.lease_generation,
+                host=HOST,
+                next_allowed_at=next_allowed,
+                error_code=exc.error_code,
+            )
+            return FetchOutcome(item.lemma_id, item.request_key, "retry_scheduled", error_code=exc.error_code)
+
+        body = (json.dumps(envelope, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+        raw = cache.commit_raw(
+            item.request_key,
+            cache.owner_id,
+            claim.lease_generation,
+            method=item.method,
+            url=item.url,
+            request_body=item.request_body,
+            response_affecting_headers=item.response_affecting_headers,
+            adapter_version=ADAPTER_VERSION,
+            status_code=200,
+            response_headers={"content-type": "application/json; charset=utf-8"},
+            body=body,
+            meta={"logical_request": "ulif_dictua_lookup", "lemma": item.lemma_id},
+        )
+        if not raw.ok:
+            return FetchOutcome(item.lemma_id, item.request_key, "failed_terminal", error_code=raw.status.value)
+        body_sha = hashlib.sha256(body).hexdigest()
+        parsed, parsed_json = _parsed_payload(item, body)
+        cache.put_parsed(
+            request_key=item.request_key,
+            body_sha256=body_sha,
+            parser_version=ADAPTER_VERSION,
+            normalizer_version="none",
+            schema_version="ulif-raw-envelope-v1",
+            parsed_payload=parsed_json,
+        )
+        result = {"lemma_id": item.lemma_id, "request_key": item.request_key, "result": parsed}
+        return FetchOutcome(
+            item.lemma_id,
+            item.request_key,
+            "done",
+            result=parsed,
+            result_hash=item_content_hash(result),
+            fetched=True,
+            status_code=200,
+        )
+
+
+def _run(args: argparse.Namespace) -> int:
+    repo = args.repo.resolve()
+    _load_runner(repo)
+    from scripts.lexicon.runner.ledger import CasStatus, Ledger
+    from scripts.lexicon.runner.memory import MemoryPolicy, apply_worker_memory_limit
+    from scripts.lexicon.runner.network_cache import NetworkCache
+    from scripts.lexicon.runner.network_worker import NetworkWorkItem
+
+    work_dir = args.work_dir.resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+    lemmas, cohort_digest = _cohort(args.cohort.resolve())
+    memory_policy = MemoryPolicy(high_bytes=1536 * 1024**2, max_bytes=2048 * 1024**2)
+    enforcement = apply_worker_memory_limit(memory_policy)
+    if enforcement == "none":
+        raise RuntimeError("MemoryPolicy could not enforce a hard cap")
+
+    config = {
+        "cohort_path": str(args.cohort.resolve()),
+        "cohort_sha256": cohort_digest,
+        "cohort_count": len(lemmas),
+        "fetch_adapter": ADAPTER_VERSION,
+        "source": ULIF_URL,
+        "request_delay_seconds": POLITENESS_DELAY_SECONDS,
+        "request_timeout_seconds": REQUEST_TIMEOUT_SECONDS,
+        "memory_high_bytes": memory_policy.high_bytes,
+        "memory_max_bytes": memory_policy.max_bytes,
+    }
+    from scripts.lexicon.runner.ledger import compute_run_fingerprint
+
+    fingerprint = compute_run_fingerprint(
+        cohort_digest=cohort_digest,
+        enrichment_config={"phase": PHASE, "fetch_adapter": ADAPTER_VERSION},
+        network_versions={"source": ULIF_URL, "policy": "sequential-1s-v1"},
+    )
+    client = DictUAClient(delay_seconds=POLITENESS_DELAY_SECONDS, timeout_seconds=REQUEST_TIMEOUT_SECONDS)
+
+    with Ledger(work_dir / "ledger.sqlite", lease_ttl_seconds=LEASE_TTL_SECONDS) as ledger, NetworkCache(
+        work_dir / "network-cache.sqlite", lease_ttl_seconds=LEASE_TTL_SECONDS
+    ) as cache:
+        existing = ledger.find_incomplete_by_fingerprint(fingerprint)
+        if existing:
+            resumed = ledger.resume_run(existing, fingerprint)
+            if not resumed.ok:
+                raise RuntimeError(f"cannot resume {existing}: {resumed.status.value} {resumed.detail}")
+            run_id = existing
+            lifecycle = "resumed"
+        else:
+            started = ledger.start_run(fingerprint, config=config)
+            if not started.ok or not started.run_id:
+                raise RuntimeError(f"cannot start run: {started.status.value} {started.detail}")
+            run_id = started.run_id
+            lifecycle = "started"
+        ledger.set_phase(run_id, PHASE, "running")
+        for lemma in lemmas:
+            ledger.register_work_unit(run_id, lemma, unit_kind="lemma", phase=PHASE)
+        _event("run_ready", lifecycle=lifecycle, run_id=run_id, fingerprint=fingerprint, memory_enforcement=enforcement, counts=_counts(ledger, run_id))
+
+        processed = 0
+        while True:
+            ledger.reclaim_expired(run_id)
+            cool = cache.host_cooldown_active(HOST)
+            if cool is not None:
+                _event("cooldown_wait", run_id=run_id, until=cool, seconds=max(0.0, cool - time.time()))
+                time.sleep(min(max(0.0, cool - time.time()), 60.0))
+                continue
+            lemma = _next_lemma(ledger, run_id)
+            if lemma is None:
+                counts = _counts(ledger, run_id)
+                if counts.get("leased", 0):
+                    time.sleep(1.0)
+                    continue
+                if not counts.get("failed_terminal", 0):
+                    ledger.set_phase(run_id, PHASE, "done")
+                    ledger.mark_run_completed(run_id)
+                    _event("run_completed", run_id=run_id, counts=counts)
+                    return 0
+                _event("run_terminal_failures", run_id=run_id, counts=counts)
+                return 2
+
+            item = NetworkWorkItem(
+                lemma_id=lemma,
+                method="POST",
+                url=ULIF_URL,
+                request_body=json.dumps({"adapter": ADAPTER_VERSION, "lemma": lemma}, ensure_ascii=False, sort_keys=True).encode("utf-8"),
+                response_affecting_headers={"user-agent": client.session.headers["User-Agent"]},
+                request_meta={"logical_request": "ulif_dictua_lookup"},
+            )
+            claim = ledger.claim_unit(run_id, lemma, ledger.owner_id, phase=PHASE, host=HOST)
+            if not claim.ok:
+                if claim.status is CasStatus.ATTEMPT_CAP_EXHAUSTED:
+                    _event("attempt_cap_exhausted", run_id=run_id, lemma=lemma)
+                continue
+            assert claim.lease_generation is not None
+            outcome = _process_lookup(cache, item, client)
+            if outcome.status in {"done", "cache_hit_parsed"}:
+                committed = ledger.commit_result(
+                    run_id, lemma, ledger.owner_id, claim.lease_generation, "done", result_hash=outcome.result_hash, phase=PHASE
+                )
+            elif outcome.status == "retry_scheduled":
+                deadline = cache.host_cooldown_active(HOST) or (time.time() + COOLDOWN_SECONDS)
+                if outcome.error_code == "http_429":
+                    committed = ledger.handle_http_429(
+                        run_id, lemma, ledger.owner_id, claim.lease_generation, host=HOST, next_allowed_at=deadline, phase=PHASE
+                    )
+                else:
+                    ledger.set_host_cooldown(HOST, deadline)
+                    committed = ledger.commit_result(
+                        run_id, lemma, ledger.owner_id, claim.lease_generation, "retry_scheduled", error_code=outcome.error_code, phase=PHASE
+                    )
+            else:
+                committed = ledger.commit_result(
+                    run_id, lemma, ledger.owner_id, claim.lease_generation, "failed_terminal", error_code=outcome.error_code, phase=PHASE
+                )
+            processed += 1
+            _event(
+                "lemma_processed", run_id=run_id, lemma=lemma, outcome=outcome.status,
+                error_code=outcome.error_code, committed=committed.status.value, counts=_counts(ledger, run_id),
+            )
+            if args.max_lemmas is not None and processed >= args.max_lemmas:
+                _event("invocation_limit_reached", run_id=run_id, processed=processed, counts=_counts(ledger, run_id))
+                return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--work-dir", type=Path, default=Path("/home/ops/atlas-runner/run-20k"))
+    parser.add_argument(
+        "--cohort",
+        type=Path,
+        default=Path("data/lexicon/cohort-20k-20260717.txt"),
+    )
+    parser.add_argument("--max-lemmas", type=int, default=None)
+    args = parser.parse_args()
+    return _run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/runner/launch_reduce.sh
+++ b/scripts/lexicon/runner/launch_reduce.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Detached, idempotent launcher for #5230 offline reduce (ULIF cache → candidate).
+# Mirrors run-20k/launch.sh resume pattern under MemoryHigh=1.5G MemoryMax=2.0G.
+set -euo pipefail
+
+RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
+REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
+WORK_DIR="${ATLAS_WORK_DIR:-$RUN_ROOT/run-20k}"
+UNIT="${ATLAS_REDUCE_UNIT:-atlas-20k-reduce.service}"
+LOG="$WORK_DIR/reduce.log"
+PID_FILE="$WORK_DIR/reduce-driver.pid"
+WRAPPER_PID_FILE="$WORK_DIR/reduce-systemd-run.pid"
+DRIVER="${ATLAS_REDUCE_DRIVER:-$REPO/scripts/lexicon/runner/reduce_ulif_20k.py}"
+
+mkdir -p "$WORK_DIR"
+cd "$REPO"
+
+if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+  printf 'pid=%s log=%s\n' "$(cat "$PID_FILE")" "$LOG"
+  exit 0
+fi
+
+# Prefer in-repo driver; fall back to work-dir copy if repo checkout is stale.
+if [[ ! -f "$DRIVER" ]]; then
+  DRIVER="$WORK_DIR/reduce_ulif_20k.py"
+fi
+if [[ ! -f "$DRIVER" ]]; then
+  echo "reduce driver not found: $DRIVER" >&2
+  exit 1
+fi
+
+EXTRA_ARGS=("$@")
+
+if systemctl --user is-system-running >/dev/null 2>&1 && command -v systemd-run >/dev/null 2>&1; then
+  rm -f "$PID_FILE" "$WRAPPER_PID_FILE"
+  nohup systemd-run --user --wait --collect --unit="${UNIT%.service}" \
+    --working-directory="$REPO" \
+    --property=MemoryHigh=1536M \
+    --property=MemoryMax=2048M \
+    --property=StandardOutput="append:$LOG" \
+    --property=StandardError="append:$LOG" \
+    /usr/bin/nice -n 10 /usr/bin/ionice -c3 "$REPO/.venv/bin/python" \
+    "$DRIVER" \
+    --repo "$REPO" \
+    --work-dir "$WORK_DIR" \
+    --network-cache "$WORK_DIR/network-cache.sqlite" \
+    --cohort "$REPO/data/lexicon/cohort-20k-20260717.txt" \
+    --require-memory-cap \
+    "${EXTRA_ARGS[@]}" >> "$LOG" 2>&1 &
+  wrapper_pid=$!
+  printf '%s\n' "$wrapper_pid" > "$WRAPPER_PID_FILE"
+  for _ in $(seq 1 50); do
+    driver_pid=$(systemctl --user show "$UNIT" --property=MainPID --value 2>/dev/null || true)
+    if [[ "$driver_pid" =~ ^[1-9][0-9]*$ ]]; then
+      printf '%s\n' "$driver_pid" > "$PID_FILE"
+      printf 'pid=%s wrapper_pid=%s unit=%s log=%s\n' "$driver_pid" "$wrapper_pid" "$UNIT" "$LOG"
+      exit 0
+    fi
+    if ! kill -0 "$wrapper_pid" 2>/dev/null; then
+      tail -n 80 "$LOG" || true
+      exit 1
+    fi
+    sleep 0.1
+  done
+  tail -n 80 "$LOG" || true
+  exit 1
+fi
+
+rm -f "$PID_FILE" "$WRAPPER_PID_FILE"
+nohup /usr/bin/nice -n 10 /usr/bin/ionice -c3 "$REPO/.venv/bin/python" \
+  "$DRIVER" \
+  --repo "$REPO" \
+  --work-dir "$WORK_DIR" \
+  --network-cache "$WORK_DIR/network-cache.sqlite" \
+  --cohort "$REPO/data/lexicon/cohort-20k-20260717.txt" \
+  --require-memory-cap \
+  "${EXTRA_ARGS[@]}" >> "$LOG" 2>&1 &
+printf '%s\n' "$!" > "$PID_FILE"
+printf 'pid=%s log=%s\n' "$(cat "$PID_FILE")" "$LOG"

--- a/scripts/lexicon/runner/offline_reduce.py
+++ b/scripts/lexicon/runner/offline_reduce.py
@@ -1,0 +1,620 @@
+"""Offline reduce: network-cache raw ULIF envelopes → structured candidate (#5230).
+
+Read-only against the durable network cache (no exclusive writer lock). Writes
+go to a separate reduce ledger + artifact tree so the completed ``network_fetch``
+run is never disturbed.
+
+Resume model matches the fetch driver: per-lemma work units under phase
+``offline_reduce``, claim → parse → atomic artifact write → commit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+import zlib
+from collections.abc import Iterable, Iterator, Sequence
+from pathlib import Path
+from typing import Any
+
+from scripts.lexicon.runner.contracts import canonical_json
+from scripts.lexicon.runner.ledger import CasStatus, Ledger, compute_run_fingerprint
+from scripts.lexicon.runner.stream_manifest import StreamingCandidateWriter
+from scripts.lexicon.runner.ulif_dictua_parse import (
+    ULIF_NORMALIZER_VERSION,
+    ULIF_PARSER_VERSION,
+    ULIF_STRUCTURED_SCHEMA_VERSION,
+    artifact_filename,
+    candidate_entry_from_artifact,
+    parse_dictua_envelope,
+    summarize_artifacts,
+)
+
+PHASE = "offline_reduce"
+DEFAULT_CHUNK_SIZE = 25
+# Match fetch-phase lease budget so kill -9 resume does not sit for the 300s
+# ledger default while a single orphaned lease blocks completion.
+DEFAULT_REDUCE_LEASE_TTL_SECONDS = 60.0
+
+
+def open_raw_cache_ro(path: Path) -> sqlite3.Connection:
+    """Open network-cache.sqlite read-only without the exclusive writer lock."""
+    resolved = Path(path).resolve()
+    if not resolved.is_file():
+        raise FileNotFoundError(resolved)
+    uri = f"file:{resolved.as_posix()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.execute("PRAGMA query_only = ON")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def build_lemma_request_index(conn: sqlite3.Connection) -> dict[str, str]:
+    """Map lemma → request_key from ``raw_cache.meta_json`` (no body decompress)."""
+    index: dict[str, str] = {}
+    for request_key, meta_json in conn.execute("SELECT request_key, meta_json FROM raw_cache"):
+        try:
+            meta = json.loads(str(meta_json or "{}"))
+        except json.JSONDecodeError:
+            continue
+        lemma = meta.get("lemma") if isinstance(meta, dict) else None
+        if lemma is None:
+            continue
+        index[str(lemma)] = str(request_key)
+    return index
+
+
+def load_raw_envelope(
+    conn: sqlite3.Connection,
+    request_key: str,
+) -> tuple[dict[str, Any], str]:
+    """Return (envelope_dict, body_sha256) for one request_key."""
+    row = conn.execute(
+        "SELECT body_zlib, body_sha256 FROM raw_cache WHERE request_key = ?",
+        (request_key,),
+    ).fetchone()
+    if row is None:
+        raise KeyError(request_key)
+    body = zlib.decompress(bytes(row["body_zlib"]))
+    envelope = json.loads(body.decode("utf-8"))
+    if not isinstance(envelope, dict):
+        raise ValueError(f"raw body for {request_key} is not a JSON object")
+    return envelope, str(row["body_sha256"])
+
+
+def cohort_lemmas(path: Path) -> tuple[list[str], str]:
+    raw = path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    lemmas = [line.strip() for line in raw.decode("utf-8").splitlines() if line.strip()]
+    if len(set(lemmas)) != len(lemmas):
+        raise RuntimeError("cohort contains duplicate lemma identifiers")
+    return lemmas, digest
+
+
+def _event(name: str, **fields: Any) -> None:
+    print(
+        json.dumps({"event": name, "at": time.time(), **fields}, ensure_ascii=False, sort_keys=True),
+        flush=True,
+    )
+
+
+def _counts(ledger: Ledger, run_id: str) -> dict[str, int]:
+    rows = (
+        ledger._require()
+        .execute(
+            "SELECT state, COUNT(*) AS n FROM work_units WHERE run_id = ? AND phase = ? GROUP BY state",
+            (run_id, PHASE),
+        )
+        .fetchall()
+    )
+    return {str(row["state"]): int(row["n"]) for row in rows}
+
+
+def _next_pending(ledger: Ledger, run_id: str) -> str | None:
+    row = (
+        ledger._require()
+        .execute(
+            "SELECT unit_id FROM work_units WHERE run_id = ? AND phase = ? "
+            "AND state IN ('pending', 'retry_scheduled') ORDER BY unit_id LIMIT 1",
+            (run_id, PHASE),
+        )
+        .fetchone()
+    )
+    return None if row is None else str(row["unit_id"])
+
+
+def _reclaim_foreign_leases(ledger: Ledger, run_id: str, owner_id: str) -> list[str]:
+    """Single-writer reduce: free leases held by a dead previous coordinator.
+
+    Only this process owns the reduce ledger, so foreign owners after kill -9
+    are safe to reclaim immediately (network cache is independent/read-only).
+    """
+    conn = ledger._require()
+    ts = time.time()
+    rows = conn.execute(
+        "SELECT unit_id, lease_generation FROM work_units "
+        "WHERE run_id = ? AND phase = ? AND state = 'leased' "
+        "AND (owner IS NULL OR owner != ?)",
+        (run_id, PHASE, owner_id),
+    ).fetchall()
+    reclaimed: list[str] = []
+    for row in rows:
+        cur = conn.execute(
+            "UPDATE work_units SET state = 'pending', owner = NULL, leased_until = NULL, "
+            "updated_at = ? WHERE run_id = ? AND unit_id = ? AND phase = ? "
+            "AND lease_generation = ? AND state = 'leased'",
+            (ts, run_id, row["unit_id"], PHASE, int(row["lease_generation"])),
+        )
+        if cur.rowcount == 1:
+            reclaimed.append(str(row["unit_id"]))
+    return reclaimed
+
+
+def _artifact_path(artifacts_root: Path, lemma: str) -> Path:
+    return artifacts_root / artifact_filename(lemma)
+
+
+def _write_artifact_atomic(path: Path, artifact: dict[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = canonical_json(artifact) + "\n"
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    tmp.replace(path)
+    return digest
+
+
+def reduce_lemma(
+    conn: sqlite3.Connection,
+    *,
+    lemma: str,
+    request_key: str | None,
+    artifacts_root: Path,
+    include_raw_html: bool = False,
+) -> tuple[dict[str, Any], str]:
+    """Parse one lemma from the raw cache and write its artifact."""
+    if not request_key:
+        artifact = {
+            "lemma": lemma,
+            "lemma_id": lemma,
+            "status": "not_found",
+            "source_status": "missing_raw",
+            "sections": {},
+            "stages": [],
+            "response_count": 0,
+            "parser_version": ULIF_PARSER_VERSION,
+            "normalizer_version": ULIF_NORMALIZER_VERSION,
+            "schema_version": ULIF_STRUCTURED_SCHEMA_VERSION,
+            "request_key": "",
+            "body_sha256": "",
+            "canonical_headword": lemma,
+            "source_id": "ulif_dictua",
+            "official_url": "https://lcorp.ulif.org.ua/dictua/",
+        }
+        digest = _write_artifact_atomic(_artifact_path(artifacts_root, lemma), artifact)
+        return artifact, digest
+
+    envelope, body_sha = load_raw_envelope(conn, request_key)
+    artifact = parse_dictua_envelope(
+        envelope,
+        request_key=request_key,
+        body_sha256=body_sha,
+        include_raw_html=include_raw_html,
+    )
+    # Ensure lemma_id matches the cohort key (fetch envelope lemma == query).
+    artifact["lemma_id"] = lemma
+    if not artifact.get("lemma"):
+        artifact["lemma"] = lemma
+    digest = _write_artifact_atomic(_artifact_path(artifacts_root, lemma), artifact)
+    return artifact, digest
+
+
+def iter_done_artifacts(
+    ledger: Ledger,
+    run_id: str,
+    artifacts_root: Path,
+    lemmas: Sequence[str],
+) -> Iterator[dict[str, Any]]:
+    for lemma in lemmas:
+        unit = ledger.get_work_unit(run_id, lemma, phase=PHASE)
+        if unit is None or str(unit.get("state")) != "done":
+            continue
+        path = _artifact_path(artifacts_root, lemma)
+        if not path.is_file():
+            continue
+        obj = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(obj, dict):
+            yield obj
+
+
+def write_candidate_export(
+    *,
+    output_path: Path,
+    artifacts: Iterable[dict[str, Any]],
+    meta: dict[str, Any],
+) -> dict[str, Any]:
+    count = 0
+    with StreamingCandidateWriter(output_path, meta=meta) as writer:
+        for artifact in artifacts:
+            writer.write_entry(candidate_entry_from_artifact(artifact))
+            count += 1
+    return {"output_path": str(output_path), "entry_count": count}
+
+
+def write_divergence_summary(
+    path: Path,
+    *,
+    ulif_summary: dict[str, Any],
+    baseline_path: Path | None,
+    baseline_summary: dict[str, Any] | None,
+    blocked_reason: str | None,
+) -> dict[str, Any]:
+    report = {
+        "kind": "atlas-ulif-offline-reduce-divergence",
+        "issue_refs": ["#5230", "#5331"],
+        "ulif": ulif_summary,
+        "baseline_path": str(baseline_path) if baseline_path else None,
+        "baseline": baseline_summary,
+        "blocked_reason": blocked_reason,
+        "note": (
+            "Aggregate CEFR/relations deltas require a live Atlas baseline manifest "
+            "or finalized offline_enrich candidate. ULIF section coverage is always "
+            "reported from reduce artifacts."
+        ),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def summarize_baseline_manifest(path: Path, *, lemma_filter: set[str] | None = None) -> dict[str, Any]:
+    """Cheap aggregate over a baseline manifest (JSON with entries or JSONL)."""
+    from scripts.lexicon.runner.stream_manifest import stream_manifest_entries_json
+
+    cefr_present = 0
+    relation_edges = {"synonym": 0, "antonym": 0, "homonym": 0, "paronym": 0}
+    ulif_present = 0
+    total = 0
+    for entry in stream_manifest_entries_json(path):
+        lemma = str(entry.get("lemma") or entry.get("url_slug") or "")
+        if lemma_filter is not None and lemma not in lemma_filter:
+            continue
+        total += 1
+        if entry.get("cefr") or entry.get("cefr_level") or entry.get("estimated_cefr"):
+            cefr_present += 1
+        if entry.get("ulif_dictua") or entry.get("ulif"):
+            ulif_present += 1
+        relations = entry.get("relations")
+        if isinstance(relations, list):
+            for rel in relations:
+                if not isinstance(rel, dict):
+                    continue
+                kind = str(rel.get("kind") or rel.get("type") or "").casefold()
+                if kind in relation_edges:
+                    relation_edges[kind] += 1
+        elif isinstance(relations, dict):
+            for kind, items in relations.items():
+                key = str(kind).casefold()
+                if key in relation_edges and isinstance(items, list):
+                    relation_edges[key] += len(items)
+    return {
+        "entry_count": total,
+        "cefr_present": cefr_present,
+        "ulif_present": ulif_present,
+        "relation_edge_counts": relation_edges,
+    }
+
+
+def reduce_offline_slice(
+    *,
+    network_cache: Path,
+    work_dir: Path,
+    cohort_path: Path | None = None,
+    lemmas: Sequence[str] | None = None,
+    cohort_digest: str | None = None,
+    output_path: Path | None = None,
+    divergence_path: Path | None = None,
+    baseline_path: Path | None = None,
+    ledger_path: Path | None = None,
+    run_id: str | None = None,
+    force_new_run: bool = False,
+    max_lemmas: int | None = None,
+    include_raw_html: bool = False,
+    owner_id: str | None = None,
+    expected_cohort_sha256: str | None = None,
+    expected_cohort_count: int | None = None,
+    lease_ttl_seconds: float = DEFAULT_REDUCE_LEASE_TTL_SECONDS,
+) -> dict[str, Any]:
+    """Resumable offline reduce over a cohort against the durable network cache."""
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    artifacts_root = work_dir / "artifacts" / "ulif_reduce"
+    artifacts_root.mkdir(parents=True, exist_ok=True)
+
+    if lemmas is None:
+        if cohort_path is None:
+            raise ValueError("cohort_path or lemmas is required")
+        lemma_list, digest = cohort_lemmas(Path(cohort_path))
+        if expected_cohort_sha256 and digest != expected_cohort_sha256:
+            raise RuntimeError(f"cohort sha mismatch: got {digest}, expected {expected_cohort_sha256}")
+        if expected_cohort_count is not None and len(lemma_list) != expected_cohort_count:
+            raise RuntimeError(f"cohort count mismatch: got {len(lemma_list)}, expected {expected_cohort_count}")
+    else:
+        lemma_list = [str(x) for x in lemmas]
+        digest = cohort_digest or hashlib.sha256("\n".join(lemma_list).encode("utf-8")).hexdigest()
+
+    fingerprint = compute_run_fingerprint(
+        cohort_digest=digest,
+        enrichment_config={
+            "phase": PHASE,
+            "parser_version": ULIF_PARSER_VERSION,
+            "schema_version": ULIF_STRUCTURED_SCHEMA_VERSION,
+            "normalizer_version": ULIF_NORMALIZER_VERSION,
+        },
+        network_versions={"cache": "raw_cache_ro", "source": "ulif_dictua"},
+    )
+
+    ledger_db = Path(ledger_path) if ledger_path else work_dir / "reduce-ledger.sqlite"
+    cache_conn = open_raw_cache_ro(network_cache)
+    try:
+        index = build_lemma_request_index(cache_conn)
+        ledger = Ledger(
+            ledger_db,
+            owner_id=owner_id,
+            lease_ttl_seconds=float(lease_ttl_seconds),
+        )
+        ledger.open()
+        try:
+            if run_id is not None:
+                resumed = ledger.resume_run(run_id, fingerprint)
+                if not resumed.ok:
+                    return {
+                        "error": resumed.status.value,
+                        "detail": resumed.detail,
+                        "run_id": run_id,
+                        "fingerprint": fingerprint,
+                    }
+                active_run_id = str(resumed.run_id)
+                lifecycle = "resumed"
+            else:
+                existing = ledger.find_incomplete_by_fingerprint(fingerprint)
+                if existing and not force_new_run:
+                    resumed = ledger.resume_run(existing, fingerprint)
+                    if not resumed.ok:
+                        return {
+                            "error": resumed.status.value,
+                            "detail": resumed.detail,
+                            "resumable_run_id": existing,
+                            "fingerprint": fingerprint,
+                        }
+                    active_run_id = existing
+                    lifecycle = "resumed"
+                else:
+                    started = ledger.start_run(
+                        fingerprint,
+                        force_new=force_new_run,
+                        config={
+                            "phase": PHASE,
+                            "cohort_sha256": digest,
+                            "cohort_count": len(lemma_list),
+                            "parser_version": ULIF_PARSER_VERSION,
+                            "schema_version": ULIF_STRUCTURED_SCHEMA_VERSION,
+                        },
+                    )
+                    if not started.ok or not started.run_id:
+                        return {
+                            "error": started.status.value,
+                            "detail": started.detail,
+                            "resumable_run_id": started.resumable_run_id,
+                            "fingerprint": fingerprint,
+                        }
+                    active_run_id = str(started.run_id)
+                    lifecycle = "started"
+
+            ledger.set_phase(active_run_id, PHASE, "running")
+            for lemma in lemma_list:
+                ledger.register_work_unit(active_run_id, lemma, unit_kind="lemma", phase=PHASE)
+            foreign = _reclaim_foreign_leases(ledger, active_run_id, ledger.owner_id)
+            expired = ledger.reclaim_expired(active_run_id)
+            if foreign or expired:
+                _event(
+                    "startup_reclaim",
+                    run_id=active_run_id,
+                    foreign=len(foreign),
+                    expired=len(expired),
+                )
+            _event(
+                "reduce_ready",
+                lifecycle=lifecycle,
+                run_id=active_run_id,
+                fingerprint=fingerprint,
+                cohort_count=len(lemma_list),
+                cache_index_size=len(index),
+                counts=_counts(ledger, active_run_id),
+            )
+
+            processed = 0
+            while True:
+                reclaimed = ledger.reclaim_expired(active_run_id)
+                if reclaimed:
+                    _event(
+                        "leases_reclaimed",
+                        run_id=active_run_id,
+                        count=len(reclaimed),
+                        units=reclaimed[:10],
+                    )
+                lemma = _next_pending(ledger, active_run_id)
+                if lemma is None:
+                    counts = _counts(ledger, active_run_id)
+                    if counts.get("leased", 0):
+                        # Wait for the soonest orphaned lease rather than spinning.
+                        row = (
+                            ledger._require()
+                            .execute(
+                                "SELECT MIN(leased_until) AS until FROM work_units "
+                                "WHERE run_id = ? AND phase = ? AND state = 'leased' "
+                                "AND leased_until IS NOT NULL",
+                                (active_run_id, PHASE),
+                            )
+                            .fetchone()
+                        )
+                        until = float(row["until"]) if row and row["until"] is not None else time.time()
+                        wait_s = max(0.05, min(until - time.time() + 0.05, 5.0))
+                        _event(
+                            "await_lease_expiry",
+                            run_id=active_run_id,
+                            wait_seconds=wait_s,
+                            leased=counts.get("leased", 0),
+                        )
+                        time.sleep(wait_s)
+                        continue
+                    if not counts.get("failed_terminal", 0):
+                        ledger.set_phase(active_run_id, PHASE, "done")
+                        ledger.mark_run_completed(active_run_id)
+                        _event("reduce_completed", run_id=active_run_id, counts=counts)
+                    else:
+                        _event(
+                            "reduce_terminal_failures",
+                            run_id=active_run_id,
+                            counts=counts,
+                        )
+                    break
+
+                claim = ledger.claim_unit(active_run_id, lemma, ledger.owner_id, phase=PHASE)
+                if not claim.ok:
+                    if claim.status is CasStatus.ATTEMPT_CAP_EXHAUSTED:
+                        _event(
+                            "attempt_cap_exhausted",
+                            run_id=active_run_id,
+                            lemma=lemma,
+                        )
+                    continue
+                assert claim.lease_generation is not None
+                try:
+                    _artifact, result_hash = reduce_lemma(
+                        cache_conn,
+                        lemma=lemma,
+                        request_key=index.get(lemma),
+                        artifacts_root=artifacts_root,
+                        include_raw_html=include_raw_html,
+                    )
+                    commit = ledger.commit_result(
+                        active_run_id,
+                        lemma,
+                        ledger.owner_id,
+                        claim.lease_generation,
+                        "done",
+                        result_hash=result_hash,
+                        phase=PHASE,
+                    )
+                    outcome = "done" if commit.ok else commit.status.value
+                except Exception as exc:
+                    commit = ledger.commit_result(
+                        active_run_id,
+                        lemma,
+                        ledger.owner_id,
+                        claim.lease_generation,
+                        "failed_terminal",
+                        error_code="reduce_error",
+                        phase=PHASE,
+                    )
+                    outcome = "failed_terminal"
+                    _event(
+                        "lemma_reduce_error",
+                        run_id=active_run_id,
+                        lemma=lemma,
+                        error=str(exc),
+                        committed=commit.status.value,
+                    )
+                processed += 1
+                _event(
+                    "lemma_reduced",
+                    run_id=active_run_id,
+                    lemma=lemma,
+                    outcome=outcome,
+                    counts=_counts(ledger, active_run_id),
+                )
+                if max_lemmas is not None and processed >= max_lemmas:
+                    _event(
+                        "invocation_limit_reached",
+                        run_id=active_run_id,
+                        processed=processed,
+                        counts=_counts(ledger, active_run_id),
+                    )
+                    break
+
+            # Export + summary only when every registered unit is done (or for slice tests).
+            counts = _counts(ledger, active_run_id)
+            all_done = counts.get("done", 0) == len(lemma_list) and not counts.get("failed_terminal", 0)
+            done_arts = list(iter_done_artifacts(ledger, active_run_id, artifacts_root, lemma_list))
+            ulif_summary = summarize_artifacts(done_arts)
+
+            out_candidate = output_path or (work_dir / "candidate-ulif-reduce.json")
+            export_meta = {
+                "enrichment_generated": False,
+                "phase": PHASE,
+                "parser_version": ULIF_PARSER_VERSION,
+                "schema_version": ULIF_STRUCTURED_SCHEMA_VERSION,
+                "cohort_digest": digest,
+                "ledger_run_id": active_run_id,
+                "ledger_fingerprint": fingerprint,
+                "network_cache": str(Path(network_cache).resolve()),
+                "ulif_summary": ulif_summary,
+                "complete": all_done,
+            }
+            export_info = write_candidate_export(
+                output_path=out_candidate,
+                artifacts=done_arts,
+                meta=export_meta,
+            )
+
+            baseline_summary = None
+            blocked_reason = None
+            if baseline_path is not None and Path(baseline_path).is_file():
+                baseline_summary = summarize_baseline_manifest(
+                    Path(baseline_path),
+                    lemma_filter=set(lemma_list),
+                )
+            else:
+                blocked_reason = (
+                    "no baseline manifest provided or path missing; "
+                    "ULIF section aggregates only (#5331 CEFR/relations deltas deferred)"
+                )
+
+            out_div = divergence_path or (work_dir / "divergence-summary.json")
+            div_report = write_divergence_summary(
+                out_div,
+                ulif_summary=ulif_summary,
+                baseline_path=Path(baseline_path) if baseline_path else None,
+                baseline_summary=baseline_summary,
+                blocked_reason=blocked_reason,
+            )
+
+            return {
+                "run_id": active_run_id,
+                "fingerprint": fingerprint,
+                "lifecycle": lifecycle,
+                "cohort_digest": digest,
+                "cohort_count": len(lemma_list),
+                "processed_this_invocation": processed,
+                "counts": counts,
+                "complete": all_done,
+                "ulif_summary": ulif_summary,
+                "candidate": export_info,
+                "divergence": {
+                    "path": str(out_div),
+                    "blocked_reason": blocked_reason,
+                    "summary": div_report,
+                },
+                "ledger_path": str(ledger_db),
+                "artifacts_root": str(artifacts_root),
+            }
+        finally:
+            ledger.close()
+    finally:
+        cache_conn.close()

--- a/scripts/lexicon/runner/reduce_ulif_20k.py
+++ b/scripts/lexicon/runner/reduce_ulif_20k.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Durable offline reduce for the Atlas 20k ULIF network cache (#5230).
+
+Consumes ``network-cache.sqlite`` raw envelopes (read-only) written by
+``fetch_ulif_20k.py``, parses DictUA HTML into structured lemma artifacts,
+stages a resumable ledger phase ``offline_reduce``, and emits a candidate
+export + aggregate divergence summary.  Stops before publish/pin-flip.
+
+Does not open ``sources.db`` unless ``--with-offline-enrich`` is passed (then
+delegates to :func:`scripts.lexicon.runner.offline_engine.enrich_offline_slice`
+for sealed CEFR/relations — memory-heavy; prefer VPS under 1.5/2.0 GiB caps).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+EXPECTED_COHORT_SHA256 = "858f0c7ce34d0d1e27c3519695073ea3e62bc0623010c03683137b7b730dcab4"
+EXPECTED_COHORT_COUNT = 20_323
+
+
+def _load_repo(repo: Path) -> None:
+    sys.path.insert(0, str(repo))
+
+
+def _event(name: str, **fields: Any) -> None:
+    print(
+        json.dumps({"event": name, "at": time.time(), **fields}, ensure_ascii=False, sort_keys=True),
+        flush=True,
+    )
+
+
+def _run(args: argparse.Namespace) -> int:
+    repo = args.repo.resolve()
+    _load_repo(repo)
+    from scripts.lexicon.runner.memory import MemoryPolicy, apply_worker_memory_limit
+    from scripts.lexicon.runner.offline_reduce import reduce_offline_slice
+
+    work_dir = args.work_dir.resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    memory_policy = MemoryPolicy(
+        high_bytes=int(args.memory_high_mib) * 1024**2,
+        max_bytes=int(args.memory_max_mib) * 1024**2,
+    )
+    enforcement = apply_worker_memory_limit(memory_policy)
+    _event(
+        "memory_policy",
+        enforcement=enforcement,
+        high_bytes=memory_policy.high_bytes,
+        max_bytes=memory_policy.max_bytes,
+    )
+    if args.require_memory_cap and enforcement == "none":
+        raise RuntimeError("MemoryPolicy could not enforce a hard cap")
+
+    lemmas: list[str] | None = None
+    expected_sha = EXPECTED_COHORT_SHA256 if not args.skip_cohort_pin else None
+    expected_count = EXPECTED_COHORT_COUNT if not args.skip_cohort_pin else None
+    if args.slice_file is not None:
+        lemmas = [
+            line.strip() for line in Path(args.slice_file).read_text(encoding="utf-8").splitlines() if line.strip()
+        ]
+        expected_sha = None
+        expected_count = None
+
+    result = reduce_offline_slice(
+        network_cache=args.network_cache.resolve(),
+        work_dir=work_dir,
+        cohort_path=None if lemmas is not None else args.cohort.resolve(),
+        lemmas=lemmas,
+        output_path=args.output.resolve() if args.output else None,
+        divergence_path=args.divergence.resolve() if args.divergence else None,
+        baseline_path=args.baseline.resolve() if args.baseline else None,
+        ledger_path=args.ledger.resolve() if args.ledger else None,
+        run_id=args.run_id,
+        force_new_run=args.force_new_run,
+        max_lemmas=args.max_lemmas,
+        include_raw_html=args.include_raw_html,
+        expected_cohort_sha256=expected_sha,
+        expected_cohort_count=expected_count,
+    )
+    if result.get("error"):
+        _event("reduce_failed", **result)
+        return 2
+    _event("reduce_summary", **{k: v for k, v in result.items() if k != "divergence"})
+    if args.with_offline_enrich:
+        return _maybe_enrich(args, repo, work_dir, result)
+    return 0
+
+
+def _maybe_enrich(
+    args: argparse.Namespace,
+    repo: Path,
+    work_dir: Path,
+    reduce_result: dict[str, Any],
+) -> int:
+    """Optional sealed offline enrich pass (CEFR + relations) on the candidate."""
+    sources = args.sources_db
+    kaikki = args.kaikki_json
+    if sources is None or not Path(sources).is_file():
+        _event(
+            "offline_enrich_blocked",
+            reason="sources.db missing",
+            sources=str(sources),
+        )
+        return 0
+    if kaikki is None or not Path(kaikki).is_file():
+        _event(
+            "offline_enrich_blocked",
+            reason="kaikki lookup missing",
+            kaikki=str(kaikki),
+        )
+        return 0
+    candidate = Path(reduce_result["candidate"]["output_path"])
+    if not candidate.is_file():
+        _event("offline_enrich_blocked", reason="candidate missing", path=str(candidate))
+        return 0
+
+    from scripts.lexicon.runner.memory import MemoryPolicy
+    from scripts.lexicon.runner.offline_engine import enrich_offline_slice
+
+    enrich_dir = work_dir / "offline_enrich"
+    enrich_dir.mkdir(parents=True, exist_ok=True)
+    out = enrich_dir / "candidate-enriched.json"
+    policy = MemoryPolicy(
+        high_bytes=int(args.memory_high_mib) * 1024**2,
+        max_bytes=int(args.memory_max_mib) * 1024**2,
+    )
+    _event("offline_enrich_start", candidate=str(candidate), sources=str(sources))
+    enrich_result = enrich_offline_slice(
+        manifest_path=candidate,
+        sources_db=Path(sources),
+        kaikki_json=Path(kaikki),
+        work_dir=enrich_dir,
+        output_path=out,
+        grac_cache={},
+        memory_policy=policy,
+        chunk_size=int(args.enrich_chunk_size),
+        require_memory_self_test=bool(args.require_memory_cap),
+        skip_workers=True,
+        stop_after_chunks=args.enrich_stop_after_chunks,
+    )
+    summary_keys = (
+        "run_id",
+        "completed",
+        "failed_terminal",
+        "interrupted",
+        "output_path",
+        "error",
+    )
+    _event(
+        "offline_enrich_summary",
+        **{key: enrich_result.get(key) for key in summary_keys},
+    )
+    if enrich_result.get("error"):
+        return 3
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=Path("/home/ops/atlas-runner/run-20k"),
+    )
+    parser.add_argument(
+        "--network-cache",
+        type=Path,
+        default=None,
+        help="Path to network-cache.sqlite (default: <work-dir>/network-cache.sqlite)",
+    )
+    parser.add_argument(
+        "--cohort",
+        type=Path,
+        default=Path("data/lexicon/cohort-20k-20260717.txt"),
+    )
+    parser.add_argument(
+        "--slice-file",
+        type=Path,
+        default=None,
+        help="Optional lemma list for dry-run slices (skips cohort pin)",
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--divergence", type=Path, default=None)
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help="Optional live Atlas baseline manifest for #5331 aggregate deltas",
+    )
+    parser.add_argument("--ledger", type=Path, default=None)
+    parser.add_argument("--run-id", type=str, default=None)
+    parser.add_argument("--force-new-run", action="store_true")
+    parser.add_argument("--max-lemmas", type=int, default=None)
+    parser.add_argument("--include-raw-html", action="store_true")
+    parser.add_argument("--skip-cohort-pin", action="store_true")
+    parser.add_argument("--memory-high-mib", type=int, default=1536)
+    parser.add_argument("--memory-max-mib", type=int, default=2048)
+    parser.add_argument(
+        "--require-memory-cap",
+        action="store_true",
+        help="Fail if OS cannot enforce MemoryPolicy (default on Linux VPS launch)",
+    )
+    parser.add_argument(
+        "--with-offline-enrich",
+        action="store_true",
+        help="After reduce, run sealed CEFR/relations offline_engine on the candidate",
+    )
+    parser.add_argument(
+        "--sources-db",
+        type=Path,
+        default=None,
+        help="sources.db for --with-offline-enrich",
+    )
+    parser.add_argument(
+        "--kaikki-json",
+        type=Path,
+        default=None,
+        help="kaikki_uk_lookup.json for --with-offline-enrich",
+    )
+    parser.add_argument("--enrich-chunk-size", type=int, default=25)
+    parser.add_argument("--enrich-stop-after-chunks", type=int, default=None)
+    args = parser.parse_args()
+    if args.network_cache is None:
+        args.network_cache = args.work_dir / "network-cache.sqlite"
+    if args.with_offline_enrich:
+        if args.sources_db is None:
+            args.sources_db = args.repo / "data" / "sources.db"
+        if args.kaikki_json is None:
+            args.kaikki_json = args.repo / "data" / "lexicon" / "kaikki_uk_lookup.json"
+    return _run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/runner/ulif_dictua_parse.py
+++ b/scripts/lexicon/runner/ulif_dictua_parse.py
@@ -1,0 +1,375 @@
+"""Offline ULIF DictUA envelope → structured lemma artifact (#5230 reduce).
+
+Consumes the durable network-cache raw body shape written by the fetch-only
+phase (``fetch_ulif_20k.py`` / ``scripts.lexicon.runner.fetch_ulif_20k``):
+
+```json
+{
+  "lemma": "<query>",
+  "status": "ok" | "not_found" | "parse_error",
+  "responses": [
+    {"stage": "initial"|"paradigm"|"synonyms"|"antonyms"|"phraseology",
+     "status_code": 200, "headers": {...}, "html": "..."}
+  ]
+}
+```
+
+HTML helpers mirror ``scripts.rag.source_query`` DictUA parsers so the reduce
+path stays free of the live-query / sources.db import graph (network + offline
+workers must not open sources.db).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from bs4 import BeautifulSoup, Tag
+
+# Structured reduce schema (independent of fetch status stubs).
+ULIF_STRUCTURED_SCHEMA_VERSION = "ulif-structured-v1"
+# Keep in lockstep with scripts.rag.source_query.ULIF_PARSER_VERSION.
+ULIF_PARSER_VERSION = "ulif-dictua-v1"
+ULIF_NORMALIZER_VERSION = "ulif-strip-raw-html-v1"
+ULIF_SOURCE_ID = "ulif_dictua"
+ULIF_OFFICIAL_URL = "https://lcorp.ulif.org.ua/dictua/"
+
+_ULIF_REGISTER_RE = re.compile(
+    r"\b(розм\.?|зах\.?|фам\.?|рідше|діал\.?|книжн\.?|заст\.?|жарт\.?|перев\.?)\b",
+    re.IGNORECASE,
+)
+_ULIF_CASE_LABELS = {
+    "називний",
+    "родовий",
+    "давальний",
+    "знахідний",
+    "орудний",
+    "місцевий",
+    "кличний",
+}
+_STAGE_SECTION = {
+    "paradigm": "paradigm",
+    "synonyms": "synonyms",
+    "antonyms": "antonyms",
+    "phraseology": "phraseology",
+}
+
+
+def strip_raw_html(obj: Any) -> Any:
+    """Drop ``raw_html`` leaves so 20k artifacts stay memory-friendly."""
+    if isinstance(obj, dict):
+        return {key: strip_raw_html(value) for key, value in obj.items() if key != "raw_html"}
+    if isinstance(obj, list):
+        return [strip_raw_html(item) for item in obj]
+    return obj
+
+
+def _ulif_text(node: Tag) -> str:
+    return re.sub(r"\s+", " ", node.get_text(" ", strip=True)).strip()
+
+
+def _ulif_register_labels(node: Tag) -> list[str]:
+    labels: list[str] = []
+    for italic in node.find_all("i"):
+        for match in _ULIF_REGISTER_RE.finditer(_ulif_text(italic)):
+            label = match.group(1)
+            base_label = label.rstrip(".")
+            if base_label.casefold() in {
+                "розм",
+                "зах",
+                "фам",
+                "діал",
+                "книжн",
+                "заст",
+                "жарт",
+                "перев",
+            }:
+                label = f"{base_label}."
+            if label not in labels:
+                labels.append(label)
+    return labels
+
+
+def _ulif_parentheticals(node: Tag) -> list[str]:
+    return [
+        re.sub(r"\s+", " ", value).strip() for value in re.findall(r"\(([^()]*)\)", _ulif_text(node)) if value.strip()
+    ]
+
+
+def _ulif_terms(node: Tag) -> list[dict[str, str]]:
+    terms: list[dict[str, str]] = []
+    for bold in node.find_all("b"):
+        text = _ulif_text(bold)
+        if text and any(char.isalpha() for char in text):
+            terms.append({"text": text, "raw_html": str(bold)})
+    return terms
+
+
+def parse_ulif_paradigm(html: str) -> dict[str, object] | None:
+    """Parse a noun/adjective or verb paradigm table from a DictUA response."""
+    soup = BeautifulSoup(html, "html.parser")
+    for table in soup.find_all("table"):
+        rows: list[list[str]] = []
+        for tr in table.find_all("tr", recursive=False):
+            cells = tr.find_all(["td", "th"], recursive=False)
+            row = [_ulif_text(cell) for cell in cells]
+            if row and any(row):
+                rows.append(row)
+        labels = {cell.casefold() for row in rows for cell in row}
+        if labels & _ULIF_CASE_LABELS or "інфінітив" in labels:
+            return {"rows": rows, "raw_html": str(table)}
+    return None
+
+
+def parse_ulif_relation_groups(html: str, kind: str) -> list[dict]:
+    """Parse ordered DictUA relation groups while retaining their source HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    panel = soup.select_one("div.p_cl")
+    if panel is None:
+        return []
+
+    if kind == "antonyms":
+        groups: list[dict] = []
+        for table_index, table in enumerate(panel.select("table.tab_ant"), start=1):
+            rows: list[dict] = []
+            for source_order, tr in enumerate(table.find_all("tr", recursive=False)):
+                cells = tr.find_all("td", recursive=False)
+                if len(cells) == 2:
+                    rows.append(
+                        {
+                            "source_order": source_order,
+                            "kind": "paired_sense",
+                            "left": {
+                                "text": _ulif_text(cells[0]),
+                                "terms": _ulif_terms(cells[0]),
+                                "register_labels": _ulif_register_labels(cells[0]),
+                                "citations": _ulif_parentheticals(cells[0]),
+                                "raw_html": str(cells[0]),
+                            },
+                            "right": {
+                                "text": _ulif_text(cells[1]),
+                                "terms": _ulif_terms(cells[1]),
+                                "register_labels": _ulif_register_labels(cells[1]),
+                                "citations": _ulif_parentheticals(cells[1]),
+                                "raw_html": str(cells[1]),
+                            },
+                        }
+                    )
+                elif len(cells) == 1:
+                    rows.append(
+                        {
+                            "source_order": source_order,
+                            "kind": "relation_note",
+                            "text": _ulif_text(cells[0]),
+                            "terms": _ulif_terms(cells[0]),
+                            "register_labels": _ulif_register_labels(cells[0]),
+                            "citations": _ulif_parentheticals(cells[0]),
+                            "raw_html": str(cells[0]),
+                        }
+                    )
+            if rows:
+                groups.append(
+                    {
+                        "sense_or_group_id": f"antonyms:{table_index}",
+                        "source_order": table_index - 1,
+                        "rows": rows,
+                        "raw_html": str(table),
+                    }
+                )
+        return groups
+
+    groups = []
+    for source_order, paragraph in enumerate(panel.find_all("p", recursive=False)):
+        text = _ulif_text(paragraph)
+        if not text:
+            continue
+        groups.append(
+            {
+                "sense_or_group_id": f"{kind}:{source_order + 1}",
+                "source_order": source_order,
+                "terms": _ulif_terms(paragraph),
+                "register_labels": _ulif_register_labels(paragraph),
+                "citations": _ulif_parentheticals(paragraph),
+                "text": text,
+                "raw_html": str(paragraph),
+            }
+        )
+    return groups
+
+
+def ulif_headword(html: str, requested_word: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    article = soup.find(id="ContentPlaceHolder1_article")
+    if article is not None:
+        article_text = _ulif_text(article)
+        match = re.match(r"^(.+?)\s+[–—-]\s+", article_text)
+        if match:
+            return match.group(1).strip()
+    input_control = soup.find("input", attrs={"name": "ctl00$ContentPlaceHolder1$tsearch"})
+    return str(input_control.get("value", requested_word)).strip() if input_control else requested_word
+
+
+def ulif_search_result_matches(html: str, requested_word: str) -> bool | None:
+    """Return whether DictUA's result list actually contains *requested_word*."""
+    soup = BeautifulSoup(html, "html.parser")
+    result_list = soup.find(id="ContentPlaceHolder1_dgv")
+    if result_list is None:
+        return None
+    normalized_query = requested_word.replace("\u0301", "").casefold()
+    candidates = {_ulif_text(link).replace("\u0301", "").casefold() for link in result_list.find_all("a")}
+    return normalized_query in candidates
+
+
+def _stage_html(responses: list[dict[str, Any]]) -> dict[str, str]:
+    by_stage: dict[str, str] = {}
+    for item in responses:
+        if not isinstance(item, dict):
+            continue
+        stage = str(item.get("stage") or "").strip()
+        html = item.get("html")
+        if stage and isinstance(html, str):
+            by_stage[stage] = html
+    return by_stage
+
+
+def _safe_status(value: Any) -> str:
+    text = str(value or "").strip().casefold()
+    if text in {"ok", "not_found", "parse_error"}:
+        return text
+    return "parse_error"
+
+
+def parse_dictua_envelope(
+    envelope: dict[str, Any],
+    *,
+    request_key: str | None = None,
+    body_sha256: str | None = None,
+    include_raw_html: bool = False,
+) -> dict[str, Any]:
+    """Parse one raw-cache envelope into a structured ULIF lemma artifact."""
+    lemma = str(envelope.get("lemma") or "").strip()
+    source_status = _safe_status(envelope.get("status"))
+    responses = envelope.get("responses") if isinstance(envelope.get("responses"), list) else []
+    by_stage = _stage_html([r for r in responses if isinstance(r, dict)])
+    stages = [str(r.get("stage") or "") for r in responses if isinstance(r, dict)]
+
+    sections: dict[str, Any] = {}
+    canonical_headword = lemma
+    status = source_status
+
+    paradigm_html = by_stage.get("paradigm") or by_stage.get("search")
+    if paradigm_html:
+        match = ulif_search_result_matches(paradigm_html, lemma) if lemma else None
+        if match is False:
+            status = "not_found"
+        elif match is None and source_status == "parse_error":
+            status = "parse_error"
+        elif match is True or source_status == "ok":
+            canonical_headword = ulif_headword(paradigm_html, lemma or "")
+            paradigm = parse_ulif_paradigm(paradigm_html)
+            if paradigm is not None:
+                sections["paradigm"] = paradigm if include_raw_html else strip_raw_html(paradigm)
+
+    for stage, section_name in _STAGE_SECTION.items():
+        if section_name == "paradigm":
+            continue
+        html = by_stage.get(stage)
+        if not html:
+            continue
+        groups = parse_ulif_relation_groups(html, section_name)
+        if groups:
+            sections[section_name] = groups if include_raw_html else strip_raw_html(groups)
+
+    if status == "ok":
+        if "paradigm" not in sections and source_status == "ok" and paradigm_html:
+            status = "parse_error"
+    elif status == "not_found":
+        sections = {}
+
+    # Antonyms-only / partial envelopes with source ok and no paradigm stage keep sections.
+    if status == "ok" and not paradigm_html and not sections:
+        status = "parse_error"
+
+    return {
+        "body_sha256": body_sha256 or "",
+        "canonical_headword": canonical_headword,
+        "lemma": lemma,
+        "lemma_id": lemma,
+        "official_url": ULIF_OFFICIAL_URL,
+        "parser_version": ULIF_PARSER_VERSION,
+        "normalizer_version": ULIF_NORMALIZER_VERSION,
+        "request_key": request_key or "",
+        "response_count": len(responses),
+        "schema_version": ULIF_STRUCTURED_SCHEMA_VERSION,
+        "sections": sections,
+        "source_id": ULIF_SOURCE_ID,
+        "source_status": source_status,
+        "stages": stages,
+        "status": status,
+    }
+
+
+def candidate_entry_from_artifact(artifact: dict[str, Any]) -> dict[str, Any]:
+    """Slim Atlas-oriented entry carrying the structured ULIF block only."""
+    lemma = str(artifact.get("lemma") or artifact.get("lemma_id") or "")
+    return {
+        "lemma": lemma,
+        "url_slug": lemma,
+        "ulif_dictua": {
+            "canonical_headword": artifact.get("canonical_headword") or lemma,
+            "official_url": artifact.get("official_url") or ULIF_OFFICIAL_URL,
+            "parser_version": artifact.get("parser_version") or ULIF_PARSER_VERSION,
+            "schema_version": artifact.get("schema_version") or ULIF_STRUCTURED_SCHEMA_VERSION,
+            "sections": artifact.get("sections") or {},
+            "source_id": artifact.get("source_id") or ULIF_SOURCE_ID,
+            "source_status": artifact.get("source_status"),
+            "stages": list(artifact.get("stages") or []),
+            "status": artifact.get("status") or "parse_error",
+        },
+    }
+
+
+def artifact_filename(lemma_id: str) -> str:
+    """Filesystem-safe artifact name (keeps Unicode; flattens path separators)."""
+    cleaned = re.sub(r"[/\\\\]+", "_", lemma_id.strip())
+    return f"{cleaned or 'empty'}.json"
+
+
+def summarize_artifacts(artifacts: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate ULIF field coverage for divergence-style reports (no row dumps)."""
+    status_counts: dict[str, int] = {}
+    section_counts = {
+        "paradigm": 0,
+        "synonyms": 0,
+        "antonyms": 0,
+        "phraseology": 0,
+    }
+    synonym_groups = 0
+    antonym_groups = 0
+    phraseology_groups = 0
+    for art in artifacts:
+        status = str(art.get("status") or "parse_error")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        sections = art.get("sections") if isinstance(art.get("sections"), dict) else {}
+        for name in section_counts:
+            if name in sections:
+                section_counts[name] += 1
+        syn = sections.get("synonyms")
+        if isinstance(syn, list):
+            synonym_groups += len(syn)
+        ant = sections.get("antonyms")
+        if isinstance(ant, list):
+            antonym_groups += len(ant)
+        phr = sections.get("phraseology")
+        if isinstance(phr, list):
+            phraseology_groups += len(phr)
+    return {
+        "artifact_count": len(artifacts),
+        "status_counts": status_counts,
+        "section_presence": section_counts,
+        "relation_group_totals": {
+            "synonyms": synonym_groups,
+            "antonyms": antonym_groups,
+            "phraseology": phraseology_groups,
+        },
+    }

--- a/tests/test_lexicon_runner_offline_reduce.py
+++ b/tests/test_lexicon_runner_offline_reduce.py
@@ -1,0 +1,280 @@
+"""Offline reduce: ULIF cache envelopes → structured candidate (#5230)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.lexicon.runner.network_cache import NetworkCache, compute_request_key
+from scripts.lexicon.runner.offline_reduce import (
+    PHASE,
+    build_lemma_request_index,
+    open_raw_cache_ro,
+    reduce_offline_slice,
+)
+from scripts.lexicon.runner.ulif_dictua_parse import (
+    ULIF_PARSER_VERSION,
+    ULIF_STRUCTURED_SCHEMA_VERSION,
+    parse_dictua_envelope,
+    strip_raw_html,
+    summarize_artifacts,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "ulif_dictua"
+USER_AGENT = "learn-ukrainian-atlas/1.0 (noncommercial educational ULIF per-lemma fetch; issue #5230)"
+
+
+def _html(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _envelope(lemma: str, status: str, stages: list[tuple[str, str]]) -> dict:
+    return {
+        "lemma": lemma,
+        "status": status,
+        "responses": [
+            {
+                "stage": stage,
+                "status_code": 200,
+                "headers": {"content-type": "text/html"},
+                "html": _html(html_name),
+            }
+            for stage, html_name in stages
+        ],
+    }
+
+
+def _seed_network_cache(path: Path, items: list[tuple[str, dict]]) -> dict[str, str]:
+    """Write fetch-shaped raw_cache rows; return lemma → request_key."""
+    cache = NetworkCache(path, owner_id="test-reduce-seed")
+    cache.open()
+    keys: dict[str, str] = {}
+    try:
+        for lemma, envelope in items:
+            body = (json.dumps(envelope, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+            request_body = json.dumps(
+                {"adapter": "ulif-dictua-fetch-v1", "lemma": lemma},
+                ensure_ascii=False,
+                sort_keys=True,
+            ).encode("utf-8")
+            headers = {"user-agent": USER_AGENT}
+            request_key = compute_request_key(
+                method="POST",
+                url="https://lcorp.ulif.org.ua/dictua/",
+                request_body=request_body,
+                response_affecting_headers=headers,
+            )
+            cache.ensure_claim_row(request_key)
+            claim = cache.claim_request(request_key, cache.owner_id)
+            assert claim.ok and claim.lease_generation is not None
+            result = cache.commit_raw(
+                request_key,
+                cache.owner_id,
+                claim.lease_generation,
+                method="POST",
+                url="https://lcorp.ulif.org.ua/dictua/",
+                request_body=request_body,
+                response_affecting_headers=headers,
+                adapter_version="ulif-dictua-fetch-v1",
+                status_code=200,
+                response_headers={"content-type": "application/json; charset=utf-8"},
+                body=body,
+                meta={"logical_request": "ulif_dictua_lookup", "lemma": lemma},
+            )
+            assert result.ok, result
+            # Status stub only — mirrors production fetch-only parsed_cache.
+            stub = {
+                "lemma_id": lemma,
+                "request_key": request_key,
+                "status": envelope["status"],
+                "response_count": len(envelope["responses"]),
+            }
+            cache.put_parsed(
+                request_key=request_key,
+                body_sha256=hashlib_sha256(body),
+                parser_version="ulif-dictua-fetch-v1",
+                normalizer_version="none",
+                schema_version="ulif-raw-envelope-v1",
+                parsed_payload=json.dumps(stub, ensure_ascii=False, sort_keys=True),
+            )
+            keys[lemma] = request_key
+    finally:
+        cache.close()
+    return keys
+
+
+def hashlib_sha256(body: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(body).hexdigest()
+
+
+@pytest.fixture
+def sample_envelopes() -> list[tuple[str, dict]]:
+    return [
+        (
+            "привіт",
+            _envelope(
+                "привіт",
+                "ok",
+                [
+                    ("initial", "privit-paradigm.html"),
+                    ("paradigm", "privit-paradigm.html"),
+                    ("synonyms", "privit-synonyms.html"),
+                    ("phraseology", "privit-phraseology.html"),
+                ],
+            ),
+        ),
+        (
+            "говорити",
+            _envelope(
+                "говорити",
+                "ok",
+                [
+                    ("initial", "hovoryty-paradigm.html"),
+                    ("paradigm", "hovoryty-paradigm.html"),
+                    ("synonyms", "hovoryty-synonyms.html"),
+                ],
+            ),
+        ),
+        (
+            "привіточок",
+            _envelope(
+                "привіточок",
+                "not_found",
+                [
+                    ("initial", "privit-paradigm.html"),
+                    ("paradigm", "privit-paradigm.html"),
+                ],
+            ),
+        ),
+        (
+            "добрий",
+            # No paradigm stage: antonyms-only envelope still yields structured groups.
+            _envelope(
+                "добрий",
+                "ok",
+                [
+                    ("initial", "privit-paradigm.html"),
+                    ("antonyms", "dobryi-antonyms.html"),
+                ],
+            ),
+        ),
+    ]
+
+
+def test_parse_dictua_envelope_ok_and_not_found(sample_envelopes):
+    by_lemma = dict(sample_envelopes)
+    ok = parse_dictua_envelope(by_lemma["привіт"], request_key="rk1")
+    assert ok["status"] == "ok"
+    assert ok["parser_version"] == ULIF_PARSER_VERSION
+    assert ok["schema_version"] == ULIF_STRUCTURED_SCHEMA_VERSION
+    assert "paradigm" in ok["sections"]
+    assert len(ok["sections"]["synonyms"]) >= 3
+    assert ok["sections"]["synonyms"][0]["terms"][0]["text"] == "ВІТА́ННЯ"
+    assert "raw_html" not in ok["sections"]["paradigm"]
+    assert "raw_html" not in ok["sections"]["synonyms"][0]
+
+    nf = parse_dictua_envelope(by_lemma["привіточок"], request_key="rk2")
+    assert nf["status"] == "not_found"
+    assert nf["sections"] == {}
+
+    ant = parse_dictua_envelope(by_lemma["добрий"], request_key="rk3")
+    assert "antonyms" in ant["sections"]
+    assert len(ant["sections"]["antonyms"]) >= 1
+
+
+def test_strip_raw_html_removes_nested_keys():
+    payload = {"rows": [[{"raw_html": "<b>x</b>", "text": "x"}]], "raw_html": "<table/>"}
+    cleaned = strip_raw_html(payload)
+    assert cleaned == {"rows": [[{"text": "x"}]]}
+
+
+def test_reduce_offline_slice_resumable_after_kill(tmp_path, sample_envelopes):
+    cache_path = tmp_path / "network-cache.sqlite"
+    keys = _seed_network_cache(cache_path, sample_envelopes)
+    assert len(keys) == 4
+
+    work = tmp_path / "work"
+    lemmas = [lemma for lemma, _ in sample_envelopes]
+    cohort = tmp_path / "slice.txt"
+    cohort.write_text("\n".join(lemmas) + "\n", encoding="utf-8")
+
+    # First pass: stop after 2 lemmas (simulates kill mid-run).
+    first = reduce_offline_slice(
+        network_cache=cache_path,
+        work_dir=work,
+        cohort_path=cohort,
+        max_lemmas=2,
+    )
+    assert first.get("error") is None
+    assert first["processed_this_invocation"] == 2
+    assert first["complete"] is False
+    counts = first["counts"]
+    assert counts.get("done", 0) == 2
+    assert counts.get("pending", 0) == 2
+
+    # Resume without force_new: finishes remaining units.
+    second = reduce_offline_slice(
+        network_cache=cache_path,
+        work_dir=work,
+        cohort_path=cohort,
+    )
+    assert second.get("error") is None
+    assert second["complete"] is True
+    assert second["counts"].get("done") == 4
+    assert second["ulif_summary"]["status_counts"].get("not_found") == 1
+    assert second["ulif_summary"]["status_counts"].get("ok", 0) >= 1
+    assert second["ulif_summary"]["section_presence"]["synonyms"] >= 1
+
+    candidate = Path(second["candidate"]["output_path"])
+    assert candidate.is_file()
+    data = json.loads(candidate.read_text(encoding="utf-8"))
+    assert data["phase"] == PHASE
+    assert len(data["entries"]) == 4
+    statuses = {e["lemma"]: e["ulif_dictua"]["status"] for e in data["entries"]}
+    assert statuses["привіточок"] == "not_found"
+    assert statuses["привіт"] == "ok"
+    assert "paradigm" in data["entries"][0]["ulif_dictua"]["sections"] or any(
+        e["ulif_dictua"]["sections"].get("paradigm") for e in data["entries"] if e["lemma"] == "привіт"
+    )
+
+    div = Path(second["divergence"]["path"])
+    assert div.is_file()
+    report = json.loads(div.read_text(encoding="utf-8"))
+    assert report["ulif"]["artifact_count"] == 4
+    assert report["blocked_reason"]  # no baseline in this test
+
+
+def test_raw_cache_ro_index_does_not_require_writer_lock(tmp_path, sample_envelopes):
+    cache_path = tmp_path / "network-cache.sqlite"
+    _seed_network_cache(cache_path, sample_envelopes[:1])
+    # Hold exclusive writer lock in another handle — RO index should still work.
+    writer = NetworkCache(cache_path, owner_id="writer-hold")
+    writer.open()
+    try:
+        conn = open_raw_cache_ro(cache_path)
+        try:
+            index = build_lemma_request_index(conn)
+            assert "привіт" in index
+        finally:
+            conn.close()
+    finally:
+        writer.close()
+
+
+def test_summarize_artifacts_aggregate_only():
+    arts = [
+        {"status": "ok", "sections": {"paradigm": {}, "synonyms": [{}, {}]}},
+        {"status": "not_found", "sections": {}},
+        {"status": "ok", "sections": {"paradigm": {}, "antonyms": [{}]}},
+    ]
+    summary = summarize_artifacts(arts)
+    assert summary["artifact_count"] == 3
+    assert summary["status_counts"] == {"ok": 2, "not_found": 1}
+    assert summary["section_presence"]["paradigm"] == 2
+    assert summary["relation_group_totals"]["synonyms"] == 2
+    assert summary["relation_group_totals"]["antonyms"] == 1


### PR DESCRIPTION
## Summary

Post-fetch **offline reduce** for the Atlas 20k ULIF DictUA run (#5230). The network_fetch phase stored full HTML envelopes in `raw_cache` and status stubs in `parsed_cache`; this PR consumes that durable cache and produces structured lemma artifacts + a candidate export, stopping **before** publish/pin-flip.

### What landed
- `scripts/lexicon/runner/ulif_dictua_parse.py` — DictUA HTML envelope → structured artifact (paradigm / synonyms / antonyms / phraseology), strips `raw_html` by default
- `scripts/lexicon/runner/offline_reduce.py` — resumable `offline_reduce` ledger phase (RO network cache; separate reduce ledger; foreign-lease reclaim after kill -9)
- `scripts/lexicon/runner/reduce_ulif_20k.py` — VPS/CLI driver under MemoryHigh=1.5G / MemoryMax=2.0G
- `scripts/lexicon/runner/launch_reduce.sh` — detached launcher mirroring `run-20k/launch.sh`
- `scripts/lexicon/runner/fetch_ulif_20k.py` — lands the previously VPS-only fetch driver in-repo
- Tests on real fixture HTML envelopes (incl. `not_found` + multi-tab lemmas)

### Measured on VPS (`ops@46.225.212.209`, `/home/ops/atlas-runner/run-20k/`)
- Network cache (tool-measured): **20,323 raw + 20,323 parsed**; parse stubs **ok 17,997 / not_found 2,326**
- Cohort pin: `data/lexicon/cohort-20k-20260717.txt` sha256 `858f0c7ce34d0d1e27c3519695073ea3e62bc0623010c03683137b7b730dcab4` (20,323 lines)
- **Dry-run 50** (includes `іти` + `pluralia tantum`): resume after partial pass → complete 50/50; `іти` status=ok with 31 synonym groups; `pluralia tantum`=not_found
- **kill -9**: mid-run leave partial done; resume after foreign-lease reclaim completes remaining units
- **Full 20k reduce**: launched detached (`atlas-20k-reduce.service`, cgroup_v2 1.5/2.0 GiB). Early progress ~1.5k done / ~64 MiB RSS (single-process, sequential)

### Divergence / #5331
- ULIF-side aggregate report written to `divergence-summary.json` (status + section presence + relation group totals)
- **Blocked on live Atlas baseline**: VPS has no `site/src/data/lexicon-manifest.json`; CEFR/relations deltas vs fill_local need a hydrated baseline or a completed `offline_enrich` candidate. Honest blocker recorded in the report (`blocked_reason`).
- Optional `--with-offline-enrich` wires `enrich_offline_slice` (CEFR/relations seals) when `sources.db` + kaikki are present — not required for this PR; heavy side-DB build left for post-review under the same memory caps.

### Publish gate (explicit non-goals)
- No `publish_manifest`, no release asset upload, no main push, no pin-flip
- PR4 finalize / seal sign-off (if still gated) remains the publish blocker; this PR only ships **reduce + measurement**

## Test plan
- [x] `pytest tests/test_lexicon_runner_offline_reduce.py` (5 passed)
- [x] VPS dry-run 50 with resume
- [x] VPS kill -9 resume
- [x] Full 20k reduce launched under memory caps (monitor `reduce.log`)
- [ ] CI green on this PR
- [ ] After full reduce: inspect `divergence-summary.json` aggregates; attach #5331 CEFR/relations numbers once baseline is available

Refs #5230
Refs #5331