### PR TITLE
fix(review): make Codex semantic schema provider-compatible

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/SKILL.md
+++ b/agents_extensions/shared/skills/post-build-review/SKILL.md
@@ -61,12 +61,14 @@ artifacts. Report findings; do not fix the module during this invocation.
    packet/result and cannot replace the failed artifact. Allocate a new run
    directory before every retry. Use `apply_patch`, not a shell heredoc, when
    the current agent is the reviewer.
-   When the provider supports schema-constrained structured output, emit the
-   canonical raw-response schema before invoking it:
+   When the provider supports schema-constrained structured output, emit its
+   provider-compatible transport schema before invoking it. For Codex, the
+   provider selector is mandatory:
 
    ```bash
    .venv/bin/python scripts/audit/post_build_review.py semantic-schema \
      --packet <packet_path> \
+     --provider codex \
      --output <semantic_schema_path>
    ```
 
@@ -82,18 +84,23 @@ artifacts. Report findings; do not fix the module during this invocation.
      --output-schema <semantic_schema_path>
    ```
 
-   The dispatcher validates and hashes the schema before spawn, and the Codex
-   adapter validates it again before emitting `codex exec --output-schema`.
+   The generator rejects Codex schemas that exceed OpenAI Structured Outputs
+   limits or use unsupported keywords. The dispatcher validates and hashes the
+   schema before spawn, and the Codex adapter validates it again before
+   emitting `codex exec --output-schema`.
    Preserve the task result file's exact bytes as the semantic response; do
    not extract a JSON object from a provider envelope.
 
    Bind that schema at the provider boundary and redirect its structured text
-   channel directly to `<semantic_response_path>`. The packet binding constrains
-   cited evidence to valid target-file paths and one-based line numbers; the
-   finalizer hydrates the exact Unicode line from the immutable packet. The v6
-   schema also requires all seven alignment classes, every vocabulary lemma,
-   every learner statement, and every detected seminar source attribution, so omitted
-   audit work fails closed instead of disappearing. Keep
+   channel directly to `<semantic_response_path>`. The Codex transport schema
+   constrains cited evidence to target-file paths and valid one-based ranges,
+   while the canonical packet-bound validator rejects short/ineligible lines,
+   wrong claim ownership, and every other relaxed transport-only constraint
+   before hydration. The finalizer then hydrates the exact Unicode line from
+   the immutable packet. The v6 schema also requires all seven alignment
+   classes, every vocabulary lemma, every learner statement, and every detected
+   seminar source attribution, so omitted audit work fails closed instead of
+   disappearing. Keep
    provider envelopes and stderr separate. Schema enforcement is preferred over prompt-only JSON
    compliance; it does not authorize extracting an embedded object from an
    unconstrained prose response.

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,4 +1,4 @@
-review_protocol_version: 6.0.6
+review_protocol_version: 6.0.7
 deterministic_contract_version: 2.0.0
 semantic_prompt_version: 6.0.7
 track_policy_version: 2.1.0

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -114,8 +114,10 @@ Read and follow `$post-build-review` completely for the same target. Allocate a
 new invocation directory every time. Do not repair, normalize, or retry inside
 that invocation. Use its emitted semantic schema when the provider supports
 structured output; prompt-only JSON compliance is not a reliable automation
-boundary. For Codex dispatches, `--output-schema <semantic_schema_path>` is
-mandatory and its absence is `audit_tooling`, not a reason to retry the model.
+boundary. For Codex dispatches, emit the schema with `semantic-schema
+--provider codex`; then `--output-schema <semantic_schema_path>` is mandatory.
+An absent or provider-incompatible schema is `audit_tooling`, not a reason to
+retry the model.
 Record its exact result:
 
 ```bash

--- a/docs/runbooks/post-build-review.md
+++ b/docs/runbooks/post-build-review.md
@@ -89,12 +89,15 @@ seminars, curated named-source aliases are compared with learner-visible
 resources; an unmapped configured source produces a material deterministic
 finding, while incidental acronyms do not become extra source labels.
 
-The provider-facing v6 schema deliberately uses a portable strict-output
-subset. In particular, packet-bound arrays use ordinary `items` constraints
-rather than Draft 2020-12 `prefixItems`, which some supported providers reject
-before inference. This transport accommodation does not relax the canonical
-contract: finalization independently enforces exact vocabulary source order and
-exact source-resource sets, and any mismatch produces `INCOMPLETE`.
+The provider-facing v6 schema has explicit transport variants. Codex uses
+`semantic-schema --provider codex`, which stays inside OpenAI Structured Outputs
+limits and supported keywords. It binds the stable object shape, exhaustive
+statement keys, target paths, and valid line ranges without repeating hundreds
+of packet line numbers as enum values. The canonical packet-bound schema still
+revalidates the exact raw bytes before hydration and independently enforces
+eligible evidence lines, exact claim ownership, vocabulary source order, and
+source-resource sets. Any mismatch produces `INCOMPLETE`; transport
+compatibility never weakens the release gate.
 
 For every `FOUND` alignment class other than `VOCABULARY_INTEGRATION`, the
 audit evidence must include each owned finding's exact primary target-file
@@ -120,6 +123,11 @@ Protocol 6.0.6 closes the Codex transport gap: `delegate.py dispatch
 its absolute path through the detached worker, and binds it as `codex exec
 --output-schema`. Prompt-only Codex review is a fail-closed orchestration defect,
 not an acceptable substitute for structured output.
+
+Protocol 6.0.7 closes the provider-compatibility gap exposed by BIO-371. The
+Codex schema generator rejects unsupported composition/property keywords and
+the documented OpenAI limits before inference, prunes unused definitions, and
+keeps packet-sized line and claim enumerations in the canonical local validator.
 
 ## Bug-fix workflow
 

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -4156,6 +4156,357 @@ def semantic_response_schema(
     return provider_schema
 
 
+OPENAI_STRUCTURED_OUTPUT_FORBIDDEN_KEYWORDS = frozenset(
+    {
+        "allOf",
+        "oneOf",
+        "not",
+        "if",
+        "then",
+        "else",
+        "dependentRequired",
+        "dependentSchemas",
+        "propertyNames",
+        "patternProperties",
+        "minProperties",
+        "maxProperties",
+        "uniqueItems",
+    }
+)
+
+
+def _codex_provider_locator_schema(
+    packet: Mapping[str, Any] | None,
+    *,
+    allowed_paths: set[str] | None = None,
+) -> dict[str, Any]:
+    """Bind target paths and line ranges without packet-sized line enums."""
+    if packet is None:
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["location", "line"],
+            "properties": {
+                "location": {"type": "string", "minLength": 1},
+                "line": {"type": "integer", "minimum": 1},
+            },
+        }
+    choices: list[dict[str, Any]] = []
+    for path, material in _packet_materials_by_path(packet).items():
+        if allowed_paths is not None and path not in allowed_paths:
+            continue
+        line_count = len(material["lines"])
+        if not line_count:
+            continue
+        choices.append(
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["location", "line"],
+                "properties": {
+                    "location": {"const": path},
+                    "line": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": line_count,
+                    },
+                },
+            }
+        )
+    if not choices:
+        raise ReviewProtocolError("No target-file evidence locators were found")
+    return {"anyOf": choices}
+
+
+def _codex_provider_dimension_evidence_schema(
+    packet: Mapping[str, Any] | None,
+    *,
+    allowed_paths: set[str] | None = None,
+) -> dict[str, Any]:
+    locator = _codex_provider_locator_schema(packet, allowed_paths=allowed_paths)
+    choices = locator.get("anyOf")
+    if isinstance(choices, list):
+        enriched: list[dict[str, Any]] = []
+        for choice in choices:
+            item = deepcopy(choice)
+            item["required"].append("supports")
+            item["properties"]["supports"] = {"type": "string", "minLength": 8}
+            enriched.append(item)
+        return {"anyOf": enriched}
+    locator["required"].append("supports")
+    locator["properties"]["supports"] = {"type": "string", "minLength": 8}
+    return locator
+
+
+def _codex_provider_vocabulary_evidence_schema(
+    packet: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if packet is None:
+        return _codex_provider_dimension_evidence_schema(packet)
+    target = packet.get("target")
+    files = target.get("files") if isinstance(target, Mapping) else None
+    if not isinstance(files, Mapping):
+        raise ReviewProtocolError("Semantic packet target must contain files")
+    allowed_paths = {
+        str(files[name]) for name in ("content", "activities") if name in files
+    }
+    if not allowed_paths:
+        raise ReviewProtocolError(
+            "Semantic packet has no learner content or activities for vocabulary evidence"
+        )
+    return _codex_provider_dimension_evidence_schema(
+        packet, allowed_paths=allowed_paths
+    )
+
+
+def _schema_definition_refs(value: object) -> set[str]:
+    refs: set[str] = set()
+    if isinstance(value, list):
+        for item in value:
+            refs.update(_schema_definition_refs(item))
+    elif isinstance(value, Mapping):
+        ref = value.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/$defs/"):
+            refs.add(ref.removeprefix("#/$defs/"))
+        for key, item in value.items():
+            if key != "$defs":
+                refs.update(_schema_definition_refs(item))
+    return refs
+
+
+def _prune_unused_schema_definitions(schema: dict[str, Any]) -> None:
+    definitions = schema.get("$defs")
+    if not isinstance(definitions, Mapping):
+        return
+    required = _schema_definition_refs(schema)
+    pending = list(required)
+    while pending:
+        name = pending.pop()
+        definition = definitions.get(name)
+        if definition is None:
+            raise ReviewProtocolError(f"Structured-output schema has unknown $ref: {name}")
+        for nested in _schema_definition_refs(definition) - required:
+            required.add(nested)
+            pending.append(nested)
+    schema["$defs"] = {
+        name: deepcopy(definition)
+        for name, definition in definitions.items()
+        if name in required
+    }
+
+
+def _normalize_codex_schema_subset(value: object) -> None:
+    """Translate the canonical transport schema to OpenAI's strict subset."""
+    if isinstance(value, list):
+        for item in value:
+            _normalize_codex_schema_subset(item)
+        return
+    if not isinstance(value, dict):
+        return
+    if "oneOf" in value and "anyOf" not in value:
+        value["anyOf"] = value.pop("oneOf")
+    for keyword in OPENAI_STRUCTURED_OUTPUT_FORBIDDEN_KEYWORDS:
+        value.pop(keyword, None)
+    if value.get("type") == "object":
+        properties = value.get("properties")
+        if not isinstance(properties, Mapping):
+            raise ReviewProtocolError(
+                "Codex structured-output objects must declare explicit properties"
+            )
+        value["additionalProperties"] = False
+        value["required"] = list(properties)
+    for item in value.values():
+        _normalize_codex_schema_subset(item)
+
+
+def _openai_schema_metrics(schema: Mapping[str, Any]) -> dict[str, int]:
+    properties = 0
+    enum_values = 0
+    total_strings = 0
+    largest_enum_strings = 0
+    definitions = schema.get("$defs")
+    if isinstance(definitions, Mapping):
+        total_strings += sum(len(str(name)) for name in definitions)
+    stack: list[object] = [schema]
+    while stack:
+        value = stack.pop()
+        if isinstance(value, Mapping):
+            raw_properties = value.get("properties")
+            if isinstance(raw_properties, Mapping):
+                properties += len(raw_properties)
+                total_strings += sum(len(str(name)) for name in raw_properties)
+            raw_enum = value.get("enum")
+            if isinstance(raw_enum, list):
+                enum_values += len(raw_enum)
+                enum_string_size = sum(
+                    len(item) for item in raw_enum if isinstance(item, str)
+                )
+                total_strings += enum_string_size
+                if len(raw_enum) > 250:
+                    largest_enum_strings = max(
+                        largest_enum_strings, enum_string_size
+                    )
+            raw_const = value.get("const")
+            if isinstance(raw_const, str):
+                total_strings += len(raw_const)
+            stack.extend(value.values())
+        elif isinstance(value, list):
+            stack.extend(value)
+    return {
+        "properties": properties,
+        "enum_values": enum_values,
+        "total_strings": total_strings,
+        "largest_enum_strings": largest_enum_strings,
+    }
+
+
+def _openai_schema_nesting_depth(schema: Mapping[str, Any]) -> int:
+    definitions = schema.get("$defs")
+
+    def visit(value: object, depth: int, refs: frozenset[str]) -> int:
+        if isinstance(value, list):
+            return max((visit(item, depth, refs) for item in value), default=depth)
+        if not isinstance(value, Mapping):
+            return depth
+        ref = value.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/$defs/"):
+            name = ref.removeprefix("#/$defs/")
+            if name in refs or not isinstance(definitions, Mapping):
+                return depth
+            target = definitions.get(name)
+            if target is None:
+                raise ReviewProtocolError(f"Structured-output schema has unknown $ref: {name}")
+            return visit(target, depth, refs | {name})
+        schema_type = value.get("type")
+        next_depth = depth + (
+            1 if isinstance(schema_type, str) and schema_type in {"object", "array"} else 0
+        )
+        children = [
+            item for key, item in value.items() if key not in {"$defs", "$ref"}
+        ]
+        return max(
+            (visit(item, next_depth, refs) for item in children),
+            default=next_depth,
+        )
+
+    return visit(schema, 0, frozenset())
+
+
+def validate_codex_output_schema(schema: Mapping[str, Any]) -> None:
+    """Fail locally when a schema exceeds OpenAI Structured Outputs limits."""
+    Draft202012Validator.check_schema(schema)
+    forbidden: set[str] = set()
+    stack: list[object] = [schema]
+    while stack:
+        value = stack.pop()
+        if isinstance(value, Mapping):
+            forbidden.update(OPENAI_STRUCTURED_OUTPUT_FORBIDDEN_KEYWORDS & value.keys())
+            if value.get("type") == "object":
+                properties = value.get("properties")
+                if not isinstance(properties, Mapping):
+                    raise ReviewProtocolError(
+                        "Codex structured-output objects must declare explicit properties"
+                    )
+                if value.get("additionalProperties") is not False:
+                    raise ReviewProtocolError(
+                        "Codex structured-output objects require additionalProperties=false"
+                    )
+                if set(value.get("required") or []) != set(properties):
+                    raise ReviewProtocolError(
+                        "Codex structured-output object properties must all be required"
+                    )
+            stack.extend(value.values())
+        elif isinstance(value, list):
+            stack.extend(value)
+    if forbidden:
+        raise ReviewProtocolError(
+            "Codex structured-output schema uses unsupported keywords: "
+            + ", ".join(sorted(forbidden))
+        )
+    metrics = _openai_schema_metrics(schema)
+    if metrics["properties"] > 5_000:
+        raise ReviewProtocolError("Codex structured-output schema exceeds 5000 properties")
+    if metrics["enum_values"] > 1_000:
+        raise ReviewProtocolError("Codex structured-output schema exceeds 1000 enum values")
+    if metrics["total_strings"] > 120_000:
+        raise ReviewProtocolError(
+            "Codex structured-output schema exceeds 120000 schema-string characters"
+        )
+    if metrics["largest_enum_strings"] > 15_000:
+        raise ReviewProtocolError(
+            "Codex structured-output schema exceeds the per-enum string limit"
+        )
+    if _openai_schema_nesting_depth(schema) > 10:
+        raise ReviewProtocolError(
+            "Codex structured-output schema exceeds 10 levels of nesting"
+        )
+
+
+def codex_semantic_response_schema(
+    packet: Mapping[str, Any] | None = None,
+    *,
+    repo_root: Path = PROJECT_ROOT,
+) -> dict[str, Any]:
+    """Return an OpenAI-compatible transport schema for the canonical response."""
+    if packet is None:
+        raise ReviewProtocolError("Codex semantic output schema requires a packet")
+    schema = semantic_response_schema(packet, repo_root=repo_root)
+    definitions = schema["$defs"]
+    definitions["dimensionEvidence"] = _codex_provider_dimension_evidence_schema(packet)
+    definitions["vocabularyEvidence"] = _codex_provider_vocabulary_evidence_schema(packet)
+    if "issue_id" not in definitions["finding"]["required"]:
+        definitions["finding"]["required"].append("issue_id")
+    definitions["finding"]["properties"]["location"] = {
+        "anyOf": [{"type": "null"}, _codex_provider_locator_schema(packet)]
+    }
+    vocabulary_lemmas = _packet_vocabulary_lemmas(packet)
+    schema["properties"]["vocabulary_coverage"] = {
+        "type": "array",
+        "items": {"$ref": "#/$defs/vocabularyCoverageItem"},
+        "minItems": len(vocabulary_lemmas),
+        "maxItems": len(vocabulary_lemmas),
+    }
+    statement_units = packet["deterministic"]["statement_inventory"]["units"]
+    statement_properties: dict[str, Any] = {}
+    for unit in statement_units:
+        unit_id = str(unit["id"])
+        if _statement_requires_claim(unit):
+            statement_properties[unit_id] = {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["classification", "claim_ids"],
+                "properties": {
+                    "classification": {"const": "claims"},
+                    "claim_ids": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/nonempty"},
+                        "minItems": 1,
+                    },
+                },
+            }
+        else:
+            statement_properties[unit_id] = {
+                "$ref": "#/$defs/statementCoverageEntry"
+            }
+    schema["properties"]["statement_coverage"] = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": list(statement_properties),
+        "properties": statement_properties,
+    }
+    definitions["claim"]["properties"]["unit_id"] = {
+        "$ref": "#/$defs/nonempty"
+    }
+    definitions["claim"]["properties"]["location"] = {
+        "$ref": "#/$defs/nonempty"
+    }
+    _prune_unused_schema_definitions(schema)
+    _normalize_provider_schema_types(schema)
+    _normalize_codex_schema_subset(schema)
+    validate_codex_output_schema(schema)
+    return schema
+
+
 def _normalize_provider_schema_types(value: object) -> None:
     """Add strict-validator type annotations without changing constraints."""
     if isinstance(value, list):
@@ -4237,6 +4588,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     semantic_schema.add_argument("--packet", type=Path)
     semantic_schema.add_argument("--output", type=Path)
+    semantic_schema.add_argument(
+        "--provider",
+        choices=("generic", "codex"),
+        default="generic",
+        help="Emit the canonical generic schema or the OpenAI Codex strict subset.",
+    )
 
     semantic_prompt = subparsers.add_parser(
         "semantic-prompt",
@@ -4281,8 +4638,13 @@ def main(argv: list[str] | None = None) -> int:
             if args.packet is not None
             else None
         )
+        schema = (
+            codex_semantic_response_schema(packet)
+            if args.provider == "codex"
+            else semantic_response_schema(packet)
+        )
         _write_or_print(
-            semantic_response_schema(packet),
+            schema,
             args.output,
             repo_root=PROJECT_ROOT,
         )

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -4315,7 +4315,11 @@ def _normalize_codex_schema_subset(value: object) -> None:
             )
         value["additionalProperties"] = False
         value["required"] = list(properties)
-    for item in value.values():
+    for key, item in value.items():
+        if key in {"properties", "$defs"} and isinstance(item, Mapping):
+            for subschema in item.values():
+                _normalize_codex_schema_subset(subschema)
+            continue
         _normalize_codex_schema_subset(item)
 
 

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -1457,6 +1457,25 @@ def test_codex_schema_fits_openai_strict_subset_and_preserves_raw_contract() -> 
     Draft202012Validator(schema).validate(semantic)
 
 
+def test_codex_schema_normalizer_preserves_property_and_definition_names() -> None:
+    schema = {
+        "$defs": {"if": {"type": "string"}},
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["not", "oneOf"],
+        "properties": {
+            "not": {"type": "string"},
+            "oneOf": {"$ref": "#/$defs/if"},
+        },
+    }
+
+    pbr._normalize_codex_schema_subset(schema)
+
+    assert set(schema["properties"]) == {"not", "oneOf"}
+    assert set(schema["$defs"]) == {"if"}
+    assert schema["required"] == ["not", "oneOf"]
+
+
 def test_codex_schema_keeps_statement_exhaustiveness_and_local_line_binding() -> None:
     packet = pbr.prepare_review("bio/andrii-malyshko", _reviewer())
     schema = pbr.codex_semantic_response_schema(packet)

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -1423,6 +1423,82 @@ def test_semantic_response_schema_matches_raw_contract() -> None:
     Draft202012Validator(schema).validate(exemplar)
 
 
+def test_codex_schema_fits_openai_strict_subset_and_preserves_raw_contract() -> None:
+    with pytest.raises(pbr.ReviewProtocolError, match="requires a packet"):
+        pbr.codex_semantic_response_schema()
+
+    packet = pbr.prepare_review("bio/andrii-malyshko", _reviewer())
+    generic = pbr.semantic_response_schema(packet)
+
+    with pytest.raises(
+        pbr.ReviewProtocolError,
+        match="Codex structured-output",
+    ):
+        pbr.validate_codex_output_schema(generic)
+
+    schema = pbr.codex_semantic_response_schema(packet)
+    semantic = _passing_semantic(packet)
+    metrics = pbr._openai_schema_metrics(schema)
+
+    assert metrics["properties"] <= 5_000
+    assert metrics["enum_values"] <= 1_000
+    assert metrics["total_strings"] <= 120_000
+    assert metrics["largest_enum_strings"] <= 15_000
+    assert pbr._openai_schema_nesting_depth(schema) <= 10
+    serialized = json.dumps(schema)
+    assert all(
+        f'"{keyword}"' not in serialized
+        for keyword in pbr.OPENAI_STRUCTURED_OUTPUT_FORBIDDEN_KEYWORDS
+    )
+    assert schema["required"] == list(schema["properties"])
+    assert schema["properties"]["vocabulary_coverage"]["items"] == {
+        "$ref": "#/$defs/vocabularyCoverageItem"
+    }
+    Draft202012Validator(schema).validate(semantic)
+
+
+def test_codex_schema_keeps_statement_exhaustiveness_and_local_line_binding() -> None:
+    packet = pbr.prepare_review("bio/andrii-malyshko", _reviewer())
+    schema = pbr.codex_semantic_response_schema(packet)
+    semantic = _passing_semantic(packet)
+    statement_schema = schema["properties"]["statement_coverage"]
+    units = packet["deterministic"]["statement_inventory"]["units"]
+
+    assert statement_schema["required"] == [unit["id"] for unit in units]
+    risk_unit = next(unit for unit in units if pbr._statement_requires_claim(unit))
+    assert statement_schema["properties"][risk_unit["id"]]["properties"][
+        "classification"
+    ] == {"const": "claims"}
+
+    missing = copy.deepcopy(semantic)
+    missing["statement_coverage"].pop(units[0]["id"])
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(missing)
+
+    content_path = packet["target"]["files"]["content"]
+    content_choice = next(
+        choice
+        for choice in schema["$defs"]["dimensionEvidence"]["anyOf"]
+        if choice["properties"]["location"]["const"] == content_path
+    )
+    assert content_choice["properties"]["line"] == {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": len(packet["target_materials"]["content"]["lines"]),
+    }
+
+    insufficient = copy.deepcopy(semantic)
+    insufficient["quality_dimensions"]["pedagogical"]["evidence"][0] = {
+        "location": content_path,
+        "line": 86,
+        "supports": "This deliberately targets a short structural line.",
+    }
+    Draft202012Validator(schema).validate(insufficient)
+    result = pbr.finalize_review(packet, _raw(insufficient))
+    assert result["semantic_response"]["contract_status"] == "invalid"
+    assert "packet-bound schema" in result["semantic_response"]["error"]
+
+
 def test_provider_schema_rejects_prose_suffixed_vesum_mapping() -> None:
     packet = pbr.prepare_review("bio/andrii-malyshko", _reviewer())
     schema = pbr.semantic_response_schema(packet)
@@ -3895,7 +3971,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
     assert catalog["catalog_version"] == "6.0.8"
-    assert len(rows) == 78
+    assert len(rows) == 79
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -3939,6 +4015,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "6.0.4",
         "6.0.5",
         "6.0.6",
+        "6.0.7",
     }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -530,3 +530,16 @@ regressions:
       Validate and hash the schema before spawn, forward its absolute path
       through worker tool configuration, bind codex exec --output-schema, and
       fail closed before inference for a missing, malformed, or non-Codex use.
+  - bug_id: codex-provider-schema-exceeded-structured-output-subset
+    responsible_layer: schema
+    fixed_in_version: 6.0.7
+    version_field: review_protocol_version
+    input: >-
+      A packet-bound BIO schema reaches Codex with 3,167 enum values plus
+      unsupported composition and dynamic-property keywords, so the provider
+      completes without an assistant message before semantic review begins.
+    expected: >-
+      Emit a Codex-specific strict transport schema that passes OpenAI limits
+      before inference while the canonical packet-bound finalizer continues to
+      reject ineligible lines, wrong claim ownership, and every relaxed
+      transport-only constraint without repair.


### PR DESCRIPTION
## Summary

- emit a Codex-specific semantic response schema that stays inside the current OpenAI Structured Outputs subset and limits
- preserve the generic packet-bound schema and canonical fail-closed finalizer for exact evidence-line, claim, vocabulary-order, and source-set enforcement
- require `semantic-schema --provider codex` for Codex post-build reviews and bump the review protocol to 6.0.7

## Root cause

BIO-371's schema-bound Sol launch stopped before inference because the generic packet schema had 3,167 enum values plus provider-unsupported composition and dynamic-property keywords. The provider-specific transport schema now removes that compilation barrier without weakening the canonical local validator.

## Official contract checked

Validated against the current [OpenAI Structured Outputs supported-schema documentation](https://developers.openai.com/api/docs/guides/structured-outputs#supported-schemas) on 2026-07-18: root object, required object fields, `additionalProperties: false`, 5,000-property / 10-level / 120,000-string-character limits, enum limits, and unsupported keywords.

## Behavior proof at exact head

Head: `f3eb226708592c11352135174b43a65daa1fd619`

- exact BIO schema: 659 properties, 39 enum values, 5 nesting levels, 5,458 counted schema-string characters, 79,325 pretty-printed bytes
- root: object; root `anyOf`: absent; nested object-rule violations: 0
- schema SHA-256: `555caba4edd3c65f70c7c60aa01f9e48a436b4485484f3dec481b105524a99ba`
- focused post-build suite: 195 passed
- Ruff: PASS
- YAML parse: PASS; targeted yamllint reports only inherited long-line debt and the new regression row adds none
- Markdown lint: PASS
- skill metadata + deployment mirror drift: PASS
- protected configs, forbidden generated artifacts, `sys.executable`, commit trailers, and `git diff --check`: PASS
- GitHub CI / CodeQL / security / deploy-idempotency checks: PASS

## Independent review

One fresh read-only Gemini 3.1 Pro High review ran against the exact head under task `bio371-pr5436-gemini-final-20260718`.

Raw verdict: `CHANGES_REQUESTED` with two claimed blockers. Both were adjudicated as stale-read false positives:

1. “schema emission and CLI support absent” — disproven by `codex_semantic_response_schema`, `validate_codex_output_schema`, the `semantic-schema --provider codex` CLI path, and a successful exact BIO invocation.
2. “OpenAI constraint tests absent” — disproven by `test_codex_schema_fits_openai_strict_subset_and_preserves_raw_contract`, nested object validation, limit assertions, and canonical-finalizer regression coverage.

No substantiated blocking finding remained; no speculative patch was applied. Review gate: **PASS after evidence-backed adjudication**.

Supports #5294.