### PR TITLE
fix(codex): refresh canonical launcher profile

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -56,6 +56,8 @@ or `luna` (and their full `gpt-5.6-*` model IDs).
 - `CODEX_SESSION=1` so repo scripts can detect an interactive Codex session
 - the canonical `main` checkout as its working root; the launcher does not create or refresh a detached interactive worktree
 - generated Codex config and rollover state bootstrapped before launch
+- an explicit native-Codex context profile, validated against `--model`/`-m`
+  immediately and against the CLI-reported model at `SessionStart`
 - repo subprocess defaults unchanged unless you explicitly override env vars
 
 Override before launch if needed:
@@ -63,6 +65,11 @@ Override before launch if needed:
 ```bash
 CODEX_DISPATCH_MODE=workspace-write CODEX_BRIDGE_MODE=safe ./start-codex.sh
 ```
+
+For a repository created with `--separate-git-dir`, Git cannot recover the
+primary checkout path from a linked worktree. In that uncommon layout, set
+`CODEX_CANONICAL_REPO_ROOT=/absolute/path/to/main`; the launcher verifies that
+the path is this repository's root on the `main` branch before using it.
 
 Implementation work still follows `AGENTS.md`: create a scoped dispatch
 worktree instead of editing or committing from the primary checkout. The

--- a/scripts/config/context_profiles.yaml
+++ b/scripts/config/context_profiles.yaml
@@ -1,5 +1,17 @@
 version: 1
 profiles:
+  native_codex:
+    profile_id: native_codex
+    transport: native_codex
+    main_model_id: gpt-5.6-sol
+    model_id_patterns:
+      - '^gpt-5\.6-sol$'
+    main_context_window_tokens: 372000
+    auto_compact_capacity_tokens: 353000
+    cold_start_profile: compact
+    cold_start_budget_tokens: 37200
+    rollover_warning_percentages: [75.0, 85.0, 92.0]
+
   sol_lead:
     profile_id: sol_lead
     transport: claudex

--- a/scripts/lib/context_profiles.py
+++ b/scripts/lib/context_profiles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Load and validate main-session context profiles for Claude Code routes."""
+"""Load and validate main-session context profiles for interactive routes."""
 
 from __future__ import annotations
 
@@ -53,8 +53,8 @@ def validate_profile(profile: dict[str, Any], *, key: str | None = None) -> list
     elif key is not None and profile_id != key:
         errors.append(f"profile_id {profile_id!r} does not match registry key {key!r}")
 
-    if profile["transport"] not in {"claudex", "native", "unknown"}:
-        errors.append("transport must be claudex, native, or unknown")
+    if profile["transport"] not in {"claudex", "native", "native_codex", "unknown"}:
+        errors.append("transport must be claudex, native, native_codex, or unknown")
     if not isinstance(profile["main_model_id"], str) or not profile["main_model_id"].strip():
         errors.append("main_model_id must be a non-empty string")
 

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -10,7 +10,54 @@ export GIT_OPTIONAL_LOCKS=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GIT_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir)"
-PROJECT_DIR="$(dirname "$GIT_COMMON_DIR")"
+PROJECT_DIR="${CODEX_CANONICAL_REPO_ROOT:-}"
+
+# Git cannot recover a primary working-tree path from a linked worktree when
+# the repository was created with --separate-git-dir. Allow that uncommon
+# layout to name the canonical checkout explicitly, but accept only the root
+# of this same repository; the main-branch check below still applies.
+if [ -n "$PROJECT_DIR" ]; then
+    REQUESTED_PROJECT_DIR="$PROJECT_DIR"
+    if ! PROJECT_DIR="$(cd "$PROJECT_DIR" 2>/dev/null && pwd)"; then
+        printf 'Error: CODEX_CANONICAL_REPO_ROOT is not a directory: %s\n' \
+            "$REQUESTED_PROJECT_DIR" >&2
+        exit 1
+    fi
+    if ! OVERRIDE_COMMON_DIR="$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+        || [ "$OVERRIDE_COMMON_DIR" != "$GIT_COMMON_DIR" ] \
+        || [ "$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null)" != "$PROJECT_DIR" ]; then
+        printf 'Error: CODEX_CANONICAL_REPO_ROOT is not a checkout of Git common dir: %s\n' \
+            "$GIT_COMMON_DIR" >&2
+        exit 1
+    fi
+fi
+
+if [ -z "$PROJECT_DIR" ]; then
+    CURRENT_WORKTREE=""
+    while IFS= read -r -d '' record; do
+        case "$record" in
+            worktree\ *)
+                CURRENT_WORKTREE="${record#worktree }"
+                ;;
+            "branch refs/heads/main")
+                if [ -d "$CURRENT_WORKTREE" ] \
+                    && [ "$(git -C "$CURRENT_WORKTREE" rev-parse --show-toplevel 2>/dev/null)" = "$CURRENT_WORKTREE" ]; then
+                    PROJECT_DIR="$CURRENT_WORKTREE"
+                    break
+                fi
+                ;;
+        esac
+    done < <(git -C "$SCRIPT_DIR" worktree list --porcelain -z)
+fi
+
+if [ -z "$PROJECT_DIR" ] && [ "$(git -C "$SCRIPT_DIR" branch --show-current)" = "main" ]; then
+    PROJECT_DIR="$SCRIPT_DIR"
+fi
+if [ -z "$PROJECT_DIR" ]; then
+    printf 'Error: could not resolve a canonical main checkout for Git common dir: %s\n' \
+        "$GIT_COMMON_DIR" >&2
+    exit 1
+fi
 
 if [ "$(git -C "$PROJECT_DIR" branch --show-current)" != "main" ]; then
     printf 'Error: canonical checkout must be on main: %s\n' "$PROJECT_DIR" >&2
@@ -24,9 +71,45 @@ fi
 source "$PROJECT_DIR/scripts/lib/thread_rollover_link.sh"
 bootstrap_codex_checkout "$PROJECT_DIR" "$PROJECT_DIR" continue
 
+# Resolve the native Codex route before SessionStart so context-budget hooks
+# receive an explicit, model-checked denominator. An explicit --model/-m is
+# validated now; when Codex uses config.toml, SessionStart validates the model
+# reported by the CLI before trusting the profile.
+SELECTED_MODEL=""
+PREVIOUS_ARG=""
+for arg in "$@"; do
+    case "$arg" in
+        --model=*)
+            SELECTED_MODEL="${arg#--model=}"
+            ;;
+    esac
+    if [ "$PREVIOUS_ARG" = "--model" ] || [ "$PREVIOUS_ARG" = "-m" ]; then
+        SELECTED_MODEL="$arg"
+    fi
+    PREVIOUS_ARG="$arg"
+done
+
+REQUESTED_PROFILE="native_codex"
+# shellcheck disable=SC1091
+source "$PROJECT_DIR/scripts/lib/profile_resolver.sh"
+if ! resolve_context_profile "$REQUESTED_PROFILE" "$SELECTED_MODEL"; then
+    printf 'Error: failed to resolve Codex context profile %s.\n' "$REQUESTED_PROFILE" >&2
+    exit 1
+fi
+if [ "$LEARN_UKRAINIAN_TRUSTED" != "1" ]; then
+    printf 'Warning: untrusted Codex route (%s); using compact fallback without a fabricated context window.\n' \
+        "$LEARN_UKRAINIAN_RESOLUTION_REASON" >&2
+fi
+
 export CODEX_SESSION=1
 export CODEX_CANONICAL_REPO_ROOT="$PROJECT_DIR"
 
+printf 'Context profile: id=%s model=%s window=%s budget=%s reason=%s\n' \
+    "$LEARN_UKRAINIAN_PROFILE_ID" \
+    "$LEARN_UKRAINIAN_MAIN_MODEL_ID" \
+    "$LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS" \
+    "$LEARN_UKRAINIAN_COLD_START_BUDGET_TOKENS" \
+    "$LEARN_UKRAINIAN_RESOLUTION_REASON"
 printf 'Starting Codex in %s\n' "$PROJECT_DIR"
 exec codex \
     --dangerously-bypass-approvals-and-sandbox \

--- a/tests/test_context_profiles.py
+++ b/tests/test_context_profiles.py
@@ -51,6 +51,17 @@ def _write_registry(tmp_path: Path, profiles: dict[str, dict[str, object]]) -> P
 def test_production_registry_separates_sol_capacity_values() -> None:
     profiles = load_registry(CONFIG_PATH)["profiles"]
 
+    assert profiles["native_codex"] == {
+        "profile_id": "native_codex",
+        "transport": "native_codex",
+        "main_model_id": "gpt-5.6-sol",
+        "model_id_patterns": [r"^gpt-5\.6-sol$"],
+        "main_context_window_tokens": 372_000,
+        "auto_compact_capacity_tokens": 353_000,
+        "cold_start_profile": "compact",
+        "cold_start_budget_tokens": 37_200,
+        "rollover_warning_percentages": [75.0, 85.0, 92.0],
+    }
     assert profiles["sol_lead"] == {
         "profile_id": "sol_lead",
         "transport": "claudex",
@@ -63,6 +74,19 @@ def test_production_registry_separates_sol_capacity_values() -> None:
         "rollover_warning_percentages": [75.0, 85.0, 92.0],
     }
     assert profiles["native_claude"]["auto_compact_capacity_tokens"] is None
+
+
+def test_native_codex_profile_accepts_sol_and_rejects_other_models() -> None:
+    trusted = resolve_profile("native_codex", "gpt-5.6-sol")
+    mismatch = resolve_profile("native_codex", "gpt-5.6-terra")
+
+    assert trusted["profile_id"] == "native_codex"
+    assert trusted["transport"] == "native_codex"
+    assert trusted["trusted"]
+    assert trusted["main_context_window_tokens"] == 372_000
+    assert mismatch["profile_id"] == "fallback"
+    assert mismatch["resolution_reason"] == "model-mismatch"
+    assert mismatch["expected_profile_id"] == "native_codex"
 
 
 def test_resolution_fails_closed_without_trusted_route_metadata() -> None:
@@ -163,6 +187,8 @@ def test_shell_resolver_exports_only_project_private_fields() -> None:
     command = f"""
         set -euo pipefail
         PROJECT_DIR={shlex.quote(os.fspath(PROJECT_ROOT))}
+        env | LC_ALL=C sort
+        printf '%s\n' '__AFTER_PROFILE_RESOLUTION__'
         source {shlex.quote(os.fspath(SHELL_RESOLVER))}
         resolve_context_profile sol_lead gpt-5.6-sol
         env | LC_ALL=C sort
@@ -178,12 +204,26 @@ def test_shell_resolver_exports_only_project_private_fields() -> None:
             "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
         },
     )
-    exported = dict(
-        line.split("=", 1)
-        for line in result.stdout.splitlines()
-        if line.startswith("LEARN_UKRAINIAN_")
+    before_output, after_output = result.stdout.split(
+        "__AFTER_PROFILE_RESOLUTION__\n", 1
     )
+    before = dict(
+        line.split("=", 1)
+        for line in before_output.splitlines()
+        if "=" in line
+    )
+    after = dict(
+        line.split("=", 1)
+        for line in after_output.splitlines()
+        if "=" in line
+    )
+    exported = {
+        key: value
+        for key, value in after.items()
+        if key.startswith("LEARN_UKRAINIAN_")
+    }
 
+    assert set(after) - set(before) == set(exported)
     assert set(exported) == {f"LEARN_UKRAINIAN_{key}" for key in EXPECTED_ENV0_KEYS}
     assert exported["LEARN_UKRAINIAN_PROFILE_ID"] == "sol_lead"
     assert exported["LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS"] == "372000"

--- a/tests/test_start_codex_profiles.py
+++ b/tests/test_start_codex_profiles.py
@@ -1,0 +1,254 @@
+"""Canonical-checkout and context-profile behavior for start-codex.sh."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PROJECT_PYTHON = _REPO_ROOT / ".venv" / "bin" / "python"
+_LAUNCHER_FILES = (
+    Path("start-codex.sh"),
+    Path("scripts/config/context_profiles.yaml"),
+    Path("scripts/lib/context_profiles.py"),
+    Path("scripts/lib/deploy_extensions.sh"),
+    Path("scripts/lib/profile_resolver.sh"),
+    Path("scripts/lib/thread_rollover_link.sh"),
+)
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run(command: list[str], cwd: Path, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    run_env = (env if env is not None else os.environ).copy()
+    for name in (
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_PREFIX",
+        "GIT_WORK_TREE",
+    ):
+        run_env.pop(name, None)
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=run_env,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+
+def _prepare_repo(
+    tmp_path: Path, *, separate_git_dir: bool = False
+) -> tuple[Path, Path]:
+    primary = tmp_path / "repo"
+    primary.mkdir()
+    for relative in _LAUNCHER_FILES:
+        destination = primary / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(_REPO_ROOT / relative, destination)
+
+    venv_bin = primary / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    _write_executable(
+        venv_bin / "python",
+        f'#!/usr/bin/env bash\nexec {os.fspath(_PROJECT_PYTHON)!r} "$@"\n',
+    )
+
+    init_command = ["git", "init", "-b", "main"]
+    if separate_git_dir:
+        init_command.extend(
+            ["--separate-git-dir", os.fspath(tmp_path / "separate-git-dir")]
+        )
+    assert _run(init_command, primary).returncode == 0
+    assert _run(["git", "add", "."], primary).returncode == 0
+    commit = _run(
+        [
+            "git",
+            "-c",
+            "user.name=Codex Launcher Test",
+            "-c",
+            "user.email=codex-launcher@example.invalid",
+            "commit",
+            "-m",
+            "launcher fixture",
+        ],
+        primary,
+    )
+    assert commit.returncode == 0, commit.stderr
+
+    linked = tmp_path / "linked"
+    worktree = _run(["git", "worktree", "add", "--detach", os.fspath(linked), "HEAD"], primary)
+    assert worktree.returncode == 0, worktree.stderr
+    return primary, linked
+
+
+def _launch(
+    tmp_path: Path,
+    arguments: list[str],
+    *,
+    separate_git_dir: bool = False,
+    provide_canonical_root: bool = False,
+    ambient_profile: tuple[str, str] | None = None,
+) -> tuple[dict[str, str], list[str], subprocess.CompletedProcess[str], Path, Path]:
+    primary, linked = _prepare_repo(tmp_path, separate_git_dir=separate_git_dir)
+    home_bin = tmp_path / "home" / ".local" / "bin"
+    capture = tmp_path / "capture.txt"
+    _write_executable(
+        home_bin / "codex",
+        """#!/usr/bin/env bash
+{
+    printf 'canonical=%s\n' "$CODEX_CANONICAL_REPO_ROOT"
+    printf 'session=%s\n' "$CODEX_SESSION"
+    printf 'profile=%s\n' "$LEARN_UKRAINIAN_PROFILE_ID"
+    printf 'requested_profile=%s\n' "$LEARN_UKRAINIAN_REQUESTED_PROFILE_ID"
+    printf 'transport=%s\n' "$LEARN_UKRAINIAN_TRANSPORT"
+    printf 'main_model=%s\n' "$LEARN_UKRAINIAN_MAIN_MODEL_ID"
+    printf 'main_window=%s\n' "$LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS"
+    printf 'reason=%s\n' "$LEARN_UKRAINIAN_RESOLUTION_REASON"
+    printf 'trusted=%s\n' "$LEARN_UKRAINIAN_TRUSTED"
+    printf 'arg=%s\n' "$@"
+} > "$CODEX_LAUNCHER_TEST_CAPTURE"
+""",
+    )
+
+    env = os.environ.copy()
+    for name in tuple(env):
+        if name.startswith("LEARN_UKRAINIAN_") or name in {
+            "CODEX_CANONICAL_REPO_ROOT",
+            "CODEX_SESSION",
+        }:
+            env.pop(name, None)
+    env.update(
+        {
+            "HOME": os.fspath(tmp_path / "home"),
+            "CODEX_LAUNCHER_TEST_CAPTURE": os.fspath(capture),
+        }
+    )
+    if provide_canonical_root:
+        env["CODEX_CANONICAL_REPO_ROOT"] = os.fspath(primary)
+    if ambient_profile is not None:
+        profile_id, transport = ambient_profile
+        env["LEARN_UKRAINIAN_REQUESTED_PROFILE_ID"] = profile_id
+        env["LEARN_UKRAINIAN_TRANSPORT"] = transport
+
+    before = _run(["git", "worktree", "list", "--porcelain"], primary)
+    result = _run(
+        [os.fspath(linked / "start-codex.sh"), *arguments],
+        linked,
+        env=env,
+    )
+    after = _run(["git", "worktree", "list", "--porcelain"], primary)
+    assert result.returncode == 0, result.stderr
+    assert before.stdout == after.stdout
+    assert not (primary / ".worktrees" / "codex-interactive").exists()
+
+    lines = capture.read_text(encoding="utf-8").splitlines()
+    values = dict(line.split("=", 1) for line in lines if not line.startswith("arg="))
+    forwarded = [line.removeprefix("arg=") for line in lines if line.startswith("arg=")]
+    return values, forwarded, result, primary, linked
+
+
+def test_launcher_targets_canonical_main_without_creating_worktree(tmp_path: Path) -> None:
+    values, forwarded, result, primary, linked = _launch(
+        tmp_path,
+        ["--model", "gpt-5.6-sol", "resume", "thread-id"],
+    )
+
+    assert linked != primary
+    assert values == {
+        "canonical": os.fspath(primary),
+        "session": "1",
+        "profile": "native_codex",
+        "requested_profile": "native_codex",
+        "transport": "native_codex",
+        "main_model": "gpt-5.6-sol",
+        "main_window": "372000",
+        "reason": "explicit-profile",
+        "trusted": "1",
+    }
+    assert forwarded == [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--search",
+        "--enable",
+        "multi_agent",
+        "-C",
+        os.fspath(primary),
+        "--model",
+        "gpt-5.6-sol",
+        "resume",
+        "thread-id",
+    ]
+    assert f"Starting Codex in {primary}" in result.stdout
+
+
+def test_launcher_model_mismatch_fails_closed_but_still_starts(tmp_path: Path) -> None:
+    values, forwarded, result, primary, _ = _launch(
+        tmp_path,
+        ["-m", "gpt-5.6-terra"],
+    )
+
+    assert values["canonical"] == os.fspath(primary)
+    assert values["profile"] == "fallback"
+    assert values["transport"] == "unknown"
+    assert values["main_window"] == "0"
+    assert values["reason"] == "model-mismatch"
+    assert values["trusted"] == "0"
+    assert forwarded[-2:] == ["-m", "gpt-5.6-terra"]
+    assert "without a fabricated context window" in result.stderr
+
+
+def test_launcher_does_not_inherit_foreign_route_profile(tmp_path: Path) -> None:
+    values, _, _, _, _ = _launch(
+        tmp_path,
+        ["--model", "gpt-5.6-sol"],
+        ambient_profile=("sol_lead", "claudex"),
+    )
+
+    assert values["profile"] == "native_codex"
+    assert values["requested_profile"] == "native_codex"
+    assert values["transport"] == "native_codex"
+    assert values["trusted"] == "1"
+
+
+def test_launcher_accepts_validated_main_checkout_with_separate_git_dir(
+    tmp_path: Path,
+) -> None:
+    values, forwarded, _, primary, _ = _launch(
+        tmp_path,
+        ["--model=gpt-5.6-sol"],
+        separate_git_dir=True,
+        provide_canonical_root=True,
+    )
+
+    assert values["canonical"] == os.fspath(primary)
+    cd_index = forwarded.index("-C")
+    assert forwarded[cd_index + 1] == os.fspath(primary)
+    assert values["profile"] == "native_codex"
+
+
+def test_launcher_rejects_canonical_root_from_another_repository(
+    tmp_path: Path,
+) -> None:
+    primary, linked = _prepare_repo(tmp_path)
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    assert _run(["git", "init", "-b", "main"], unrelated).returncode == 0
+
+    env = os.environ.copy()
+    env["CODEX_CANONICAL_REPO_ROOT"] = os.fspath(unrelated)
+    result = _run([os.fspath(linked / "start-codex.sh")], linked, env=env)
+
+    assert result.returncode != 0
+    assert "is not a checkout of Git common dir" in result.stderr
+    assert os.fspath(primary) not in result.stdout


### PR DESCRIPTION
## Summary

- keep `start-codex.sh` anchored to the canonical `main` checkout without creating or refreshing an interactive worktree
- add a model-validated `native_codex` context profile so SessionStart/context hooks receive trusted capacity metadata
- validate the unusual `--separate-git-dir` override and reject unrelated repositories
- add black-box launcher coverage for worktree count, forwarded arguments, profile mismatch, ambient profile isolation, and canonical-root validation

## Why

The no-interactive-worktree launcher behavior was already present, but it had no direct regression coverage and inferred the checkout from the Git common-directory layout. That inference is not valid for every Git layout. Native Codex sessions also reached the shared context hooks without an explicit route profile, so the hooks could only report `missing-profile` instead of validated context capacity.

The launcher now discovers a registered `main` worktree, uses a narrowly validated override for repositories created with `--separate-git-dir`, fails honestly if canonical `main` cannot be proven, and always certifies the native Codex route rather than inheriting a foreign parent-process profile.

## Validation

- `62 passed`: context profiles, black-box launcher behavior, deployment, primary-checkout guard, and SessionStart hook tests
- real pre-commit hook: Ruff plus all 16 affected tests passed
- `shellcheck start-codex.sh` and `bash -n start-codex.sh`
- Ruff, Markdown lint, YAML lint (existing document-start warning only), and `git diff --check`
- `npm run agents:deploy` plus `scripts/check_rules_deployment.sh`
- Codex Doctor 0.144.6: 17 ok, 1 idle, 0 warnings, 0 failures
- live Codex hook probe: Bash and `apply_patch` allow/deny cases all intercepted correctly
- independent cross-family review: Gemini 3.1 Pro High via AGY returned `APPROVE`; the initially selected Claude/Fable route was cancelled after producing no result, and native Claude was at 98% weekly quota
