### PR TITLE
fix(codex): bind launcher to epic lanes

### DIFF
--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -532,14 +532,26 @@ fi
 # Epic assignment banner
 EPIC_BANNER=""
 if [ -n "${SESSION_EPIC:-}" ]; then
+  EPIC_HANDOFF_PATH=".claude/${SESSION_EPIC}-epic/CLAUDE-DRIVER-HANDOFF.md"
+  case "$HANDOFF_AGENT" in
+    codex|codex-*)
+      CODEX_EPIC_HANDOFF=".claude/${SESSION_EPIC}-epic/CODEX-DRIVER-HANDOFF.md"
+      if [ -f "$PROJECT_DIR/$CODEX_EPIC_HANDOFF" ]; then
+        EPIC_HANDOFF_PATH="$CODEX_EPIC_HANDOFF"
+      fi
+      unset CODEX_EPIC_HANDOFF
+      ;;
+  esac
   EPIC_BANNER="ASSIGNED EPIC: ${SESSION_EPIC}.epic (binding — from the launch command).
 You are the ${SESSION_EPIC} lane, NOT the main orchestrator. Do not claim or work
-other lanes' queues. Epic driver handoff (load AFTER the thread handoff below, it
-is the lane SSOT): .claude/${SESSION_EPIC}-epic/CLAUDE-DRIVER-HANDOFF.md"
-  if [ ! -f "$PROJECT_DIR/.claude/${SESSION_EPIC}-epic/CLAUDE-DRIVER-HANDOFF.md" ]; then
+other lanes' queues. Rollover namespace: ${HANDOFF_AGENT}.
+Epic driver handoff (load AFTER the thread handoff below, it
+is the lane SSOT): $EPIC_HANDOFF_PATH"
+  if [ ! -f "$PROJECT_DIR/$EPIC_HANDOFF_PATH" ]; then
     EPIC_BANNER="$EPIC_BANNER
 (No driver handoff exists yet for this epic — create it at first rollover.)"
   fi
+  unset EPIC_HANDOFF_PATH
 else
   EPIC_BANNER="NO EPIC ASSIGNED (launcher had no --epic flag).
 Do NOT default to 'main orchestrator'. Resolve your lane in this order:

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -60,6 +60,23 @@ or `luna` (and their full `gpt-5.6-*` model IDs).
   immediately and against the CLI-reported model at `SessionStart`
 - repo subprocess defaults unchanged unless you explicitly override env vars
 
+Bind a Codex session to one epic at launch so SessionStart loads only that
+lane's handoff and rollover namespace:
+
+```bash
+./start-codex.sh --epic hramatka
+./start-codex.sh --epic atlas
+./start-codex.sh --epic harness
+```
+
+`--epic` is launcher-only and is not forwarded to the Codex CLI. It exports the
+binding `SESSION_EPIC` and a provider-specific handoff identity such as
+`codex-hramatka`. SessionStart selects that epic's `CODEX-DRIVER-HANDOFF.md`
+when present and otherwise uses (or initializes) its shared
+`CLAUDE-DRIVER-HANDOFF.md`. Without `--epic`, the existing cold-start rule still
+requires the first user message or lane-assignment fallback to identify the
+session before it touches a queue.
+
 Override before launch if needed:
 
 ```bash

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -59,6 +59,13 @@ eq "$(handoff_identity_for_epic harness)" "claude-infra" "epic harness → claud
 eq "$(handoff_identity_for_epic infra)" "claude-infra" "epic infra → claude-infra alias"
 eq "$(handoff_identity_for_epic)" "" "no epic → empty slot"
 
+# Codex uses provider-specific per-epic slots; harness/infra share one alias.
+eq "$(handoff_identity_for_codex_epic atlas)" "codex-atlas" "Codex atlas → codex-atlas"
+eq "$(handoff_identity_for_codex_epic hramatka)" "codex-hramatka" "Codex hramatka → codex-hramatka"
+eq "$(handoff_identity_for_codex_epic harness)" "codex-infra" "Codex harness → codex-infra"
+eq "$(handoff_identity_for_codex_epic infra)" "codex-infra" "Codex infra → codex-infra alias"
+eq "$(handoff_identity_for_codex_epic)" "" "Codex no epic → empty slot"
+
 # --- e2e: --epic harness resolves the infra lane slot (not phantom claude-harness) ---
 epic="$(handoff_epic_from_argv --epic harness --agent infra-orchestrator)"
 eq "$(handoff_identity_for_epic "$epic")" "claude-infra" "e2e: --epic harness → claude-infra"

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -82,6 +82,7 @@ run_hook() {
   local requested_profile="${6:-native_claude}"
   local supervisor_run_id="${7:-}"
   local supervisor_generation="${8:-}"
+  local session_epic="${9:-}"
 
   printf '%s' "$hook_json" | \
     HOME="$TMP_ROOT/home" XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" XDG_DATA_HOME="$TMP_ROOT/xdg-data" XDG_STATE_HOME="$TMP_ROOT/xdg-state" GH_CONFIG_DIR="$TMP_ROOT/gh" PATH="/usr/bin:/bin" \
@@ -103,6 +104,7 @@ run_hook() {
     THREAD_ROLLOVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
     THREAD_ROLLOVER_SCRIPT="$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     SESSION_HANDOFF_AGENT="$handoff_agent" \
+    SESSION_EPIC="$session_epic" \
     SESSION_HANDOFF_ALLOW_GIT_ROUTER="$allow_git_router" \
     "$HOOK"
 }
@@ -240,6 +242,35 @@ EOF
 output="$(run_hook "$fixture_root")"
 assert_not_contains "$output" "DEFAULT ROUTER BODY SHOULD NOT APPEAR" "router ignored by default"
 assert_not_contains "$output" "WARN: Could not locate latest brief in current.md" "router ignored by default"
+
+# 2b. A Codex epic launch points to its provider-specific driver handoff when
+# present; it must not send the Codex lane to Claude's parallel delta.
+setup_fixture "$fixture_root"
+mkdir -p "$fixture_root/.claude/hramatka-epic"
+printf '# Codex driver handoff\n' > "$fixture_root/.claude/hramatka-epic/CODEX-DRIVER-HANDOFF.md"
+printf '# Claude driver handoff\n' > "$fixture_root/.claude/hramatka-epic/CLAUDE-DRIVER-HANDOFF.md"
+output="$(run_hook "$fixture_root" 0 codex-hramatka "" "" native_codex "" "" hramatka)"
+assert_contains "$output" "ASSIGNED EPIC: hramatka.epic" "Codex epic assignment"
+assert_contains "$output" "Rollover namespace: codex-hramatka" "Codex epic namespace"
+assert_contains "$output" ".claude/hramatka-epic/CODEX-DRIVER-HANDOFF.md" "Codex epic handoff"
+assert_not_contains "$output" ".claude/hramatka-epic/CLAUDE-DRIVER-HANDOFF.md" "Codex epic handoff"
+
+# 2c. A Codex epic without a provider-specific delta retains the existing
+# shared Claude handoff rather than claiming that no lane state exists.
+setup_fixture "$fixture_root"
+mkdir -p "$fixture_root/.claude/atlas-epic"
+printf '# Shared driver handoff\n' > "$fixture_root/.claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md"
+output="$(run_hook "$fixture_root" 0 codex-atlas "" "" native_codex "" "" atlas)"
+assert_contains "$output" ".claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md" "Codex shared epic fallback"
+assert_not_contains "$output" ".claude/atlas-epic/CODEX-DRIVER-HANDOFF.md" "Codex shared epic fallback"
+
+# 2d. A brand-new Codex epic initializes the shared lane handoff path rather
+# than creating a provider-only fork that Claude cannot discover.
+setup_fixture "$fixture_root"
+output="$(run_hook "$fixture_root" 0 codex-new-lane "" "" native_codex "" "" new-lane)"
+assert_contains "$output" ".claude/new-lane-epic/CLAUDE-DRIVER-HANDOFF.md" "Codex new epic fallback"
+assert_not_contains "$output" ".claude/new-lane-epic/CODEX-DRIVER-HANDOFF.md" "Codex new epic fallback"
+assert_contains "$output" "No driver handoff exists yet" "Codex new epic fallback"
 
 # 3. Marker path is used when legacy router is explicitly enabled.
 setup_fixture "$fixture_root"

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Map a Claude Code `--agent` selection to its cold-start handoff identity
+# Map interactive launcher selections to their cold-start handoff identity
 # (SESSION_HANDOFF_AGENT).
 #
 # WHY: every Claude session launched as plain `claude` defaults to agent
@@ -139,5 +139,19 @@ handoff_identity_for_epic() {
   case "$epic" in
     harness|infra) printf '%s' 'claude-infra' ;;
     *) printf 'claude-%s' "$epic" ;;
+  esac
+}
+
+# handoff_identity_for_codex_epic "<epic-name>"
+# Echo the per-epic Codex rollover slot. Codex needs the same lane separation
+# as Claude, but its namespaces must remain provider-specific so a Codex launch
+# never adopts a Claude packet. The infra alias mirrors the canonical
+# claude-infra convention and avoids inventing parallel harness/infra slots.
+handoff_identity_for_codex_epic() {
+  local epic="${1:-}"
+  [ -n "$epic" ] || return 0
+  case "$epic" in
+    harness|infra) printf '%s' 'codex-infra' ;;
+    *) printf 'codex-%s' "$epic" ;;
   esac
 }

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -64,6 +64,47 @@ if [ "$(git -C "$PROJECT_DIR" branch --show-current)" != "main" ]; then
     exit 1
 fi
 
+# `--epic` is a launcher-only lane binding. Codex itself does not know this
+# flag, so consume it before exec while preserving all other argv bytes and
+# ordering. An explicit epic gets a provider-specific handoff namespace; this
+# prevents unrelated Codex epic sessions from sharing one rollover queue.
+FORWARD_ARGS=("$@")
+HANDOFF_IDENTITY_SH="$PROJECT_DIR/scripts/lib/handoff_identity.sh"
+if [ ! -f "$HANDOFF_IDENTITY_SH" ]; then
+    printf 'Error: handoff identity helper is missing: %s\n' "$HANDOFF_IDENTITY_SH" >&2
+    exit 1
+fi
+# shellcheck source=scripts/lib/handoff_identity.sh
+source "$HANDOFF_IDENTITY_SH"
+
+SELECTED_EPIC="$(handoff_epic_from_argv "$@")"
+if [ -z "$SELECTED_EPIC" ] && epic_flag_present "$@"; then
+    printf 'Error: --epic requires a non-empty value (for example: --epic hramatka).\n' >&2
+    exit 1
+fi
+if [ -n "$SELECTED_EPIC" ]; then
+    if ! epic_name_valid "$SELECTED_EPIC"; then
+        printf "Error: invalid --epic name '%s' (use lowercase letters, digits, and inner hyphens).\n" \
+            "$SELECTED_EPIC" >&2
+        exit 1
+    fi
+    HANDOFF_SLOT="$(handoff_identity_for_codex_epic "$SELECTED_EPIC")"
+    if [ -z "$HANDOFF_SLOT" ]; then
+        printf "Error: could not derive a Codex handoff slot for epic '%s'.\n" "$SELECTED_EPIC" >&2
+        exit 1
+    fi
+    export SESSION_EPIC="$SELECTED_EPIC"
+    export SESSION_HANDOFF_AGENT="$HANDOFF_SLOT"
+    FORWARD_ARGS=()
+    while IFS= read -r -d '' FORWARD_ARG; do
+        FORWARD_ARGS+=("$FORWARD_ARG")
+    done < <(strip_epic_from_argv "$@")
+    unset FORWARD_ARG HANDOFF_SLOT
+    printf 'Epic assignment: %s.epic\n' "$SESSION_EPIC"
+    printf 'Handoff identity: %s\n' "$SESSION_HANDOFF_AGENT"
+fi
+unset HANDOFF_IDENTITY_SH SELECTED_EPIC
+
 # Keep generated Codex config and the canonical rollover state ready before
 # replacing this wrapper process with the interactive CLI.
 # PROJECT_DIR is resolved dynamically.
@@ -77,7 +118,7 @@ bootstrap_codex_checkout "$PROJECT_DIR" "$PROJECT_DIR" continue
 # reported by the CLI before trusting the profile.
 SELECTED_MODEL=""
 PREVIOUS_ARG=""
-for arg in "$@"; do
+for arg in "${FORWARD_ARGS[@]}"; do
     case "$arg" in
         --model=*)
             SELECTED_MODEL="${arg#--model=}"
@@ -116,4 +157,4 @@ exec codex \
     --search \
     --enable multi_agent \
     -C "$PROJECT_DIR" \
-    "$@"
+    "${FORWARD_ARGS[@]}"

--- a/tests/test_start_codex_profiles.py
+++ b/tests/test_start_codex_profiles.py
@@ -7,6 +7,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PROJECT_PYTHON = _REPO_ROOT / ".venv" / "bin" / "python"
 _LAUNCHER_FILES = (
@@ -14,6 +16,7 @@ _LAUNCHER_FILES = (
     Path("scripts/config/context_profiles.yaml"),
     Path("scripts/lib/context_profiles.py"),
     Path("scripts/lib/deploy_extensions.sh"),
+    Path("scripts/lib/handoff_identity.sh"),
     Path("scripts/lib/profile_resolver.sh"),
     Path("scripts/lib/thread_rollover_link.sh"),
 )
@@ -117,6 +120,8 @@ def _launch(
     printf 'main_window=%s\n' "$LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS"
     printf 'reason=%s\n' "$LEARN_UKRAINIAN_RESOLUTION_REASON"
     printf 'trusted=%s\n' "$LEARN_UKRAINIAN_TRUSTED"
+    printf 'epic=%s\n' "${SESSION_EPIC:-}"
+    printf 'handoff_agent=%s\n' "${SESSION_HANDOFF_AGENT:-}"
     printf 'arg=%s\n' "$@"
 } > "$CODEX_LAUNCHER_TEST_CAPTURE"
 """,
@@ -127,6 +132,8 @@ def _launch(
         if name.startswith("LEARN_UKRAINIAN_") or name in {
             "CODEX_CANONICAL_REPO_ROOT",
             "CODEX_SESSION",
+            "SESSION_EPIC",
+            "SESSION_HANDOFF_AGENT",
         }:
             env.pop(name, None)
     env.update(
@@ -176,6 +183,8 @@ def test_launcher_targets_canonical_main_without_creating_worktree(tmp_path: Pat
         "main_window": "372000",
         "reason": "explicit-profile",
         "trusted": "1",
+        "epic": "",
+        "handoff_agent": "",
     }
     assert forwarded == [
         "--dangerously-bypass-approvals-and-sandbox",
@@ -190,6 +199,60 @@ def test_launcher_targets_canonical_main_without_creating_worktree(tmp_path: Pat
         "thread-id",
     ]
     assert f"Starting Codex in {primary}" in result.stdout
+
+
+def test_launcher_binds_epic_and_strips_private_flag(tmp_path: Path) -> None:
+    values, forwarded, result, _, _ = _launch(
+        tmp_path,
+        ["--epic", "hramatka", "orchestrate this epic"],
+    )
+
+    assert values["epic"] == "hramatka"
+    assert values["handoff_agent"] == "codex-hramatka"
+    assert forwarded[-1] == "orchestrate this epic"
+    assert "--epic" not in forwarded
+    assert "Epic assignment: hramatka.epic" in result.stdout
+    assert "Handoff identity: codex-hramatka" in result.stdout
+
+
+def test_launcher_normalizes_equals_form_epic_suffix(tmp_path: Path) -> None:
+    values, forwarded, _, _, _ = _launch(
+        tmp_path,
+        ["--epic=atlas.epic", "--model", "gpt-5.6-sol"],
+    )
+
+    assert values["epic"] == "atlas"
+    assert values["handoff_agent"] == "codex-atlas"
+    assert "--epic=atlas.epic" not in forwarded
+
+
+@pytest.mark.parametrize("epic_args", [["--epic"], ["--epic="], ["--epic", "Atlas"]])
+def test_launcher_rejects_missing_or_invalid_epic_before_codex_starts(
+    tmp_path: Path,
+    epic_args: list[str],
+) -> None:
+    primary, linked = _prepare_repo(tmp_path)
+    home_bin = tmp_path / "home" / ".local" / "bin"
+    started = tmp_path / "codex-started"
+    _write_executable(
+        home_bin / "codex",
+        f"#!/usr/bin/env bash\ntouch {os.fspath(started)!r}\n",
+    )
+    env = os.environ.copy()
+    env.update({"HOME": os.fspath(tmp_path / "home")})
+    for name in (
+        "CODEX_CANONICAL_REPO_ROOT",
+        "SESSION_EPIC",
+        "SESSION_HANDOFF_AGENT",
+    ):
+        env.pop(name, None)
+
+    result = _run([os.fspath(linked / "start-codex.sh"), *epic_args], linked, env=env)
+
+    assert result.returncode != 0
+    assert not started.exists()
+    assert os.fspath(primary) not in result.stdout
+    assert "--epic" in result.stderr
 
 
 def test_launcher_model_mismatch_fails_closed_but_still_starts(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #5442

## Summary
- add a launcher-only `--epic` flag to `start-codex.sh`
- isolate Codex rollover identities per epic, with the canonical infra alias
- point SessionStart at a Codex-specific epic handoff when present and the shared Claude handoff otherwise
- cover argv forwarding, validation, namespace mapping, handoff selection, and new-epic fallback

## Verification
- `bash -n` on all touched shell files
- `shellcheck -S warning` on all touched shell files
- `.venv/bin/ruff check tests/test_start_codex_profiles.py`
- `npx --no-install markdownlint-cli2 docs/SCRIPTS.md`
- `.venv/bin/python -m pytest -q tests/test_start_codex_profiles.py tests/test_handoff_identity.py tests/test_session_setup_hook.py` (14 passed)
- `bash scripts/audit/test_session_setup_hook.sh`
- `bash scripts/audit/test_handoff_identity.sh`
- `bash scripts/audit/test_deploy_extensions.sh`
- `scripts/check_rules_deployment.sh`
- independent Google-family closeout review: CLEAN

## Review routing
The resolver selected Claude Fable through Cursor, but that task and the eligible native Claude fallback produced no output and were cancelled. The healthy Google-family fallback returned CLEAN after identifying and verifying the fix for the brand-new-epic handoff fork risk.