### PR TITLE
fix(codex): handle empty epic argument forwarding

### DIFF
--- a/start-codex.sh
+++ b/start-codex.sh
@@ -69,6 +69,7 @@ fi
 # ordering. An explicit epic gets a provider-specific handoff namespace; this
 # prevents unrelated Codex epic sessions from sharing one rollover queue.
 FORWARD_ARGS=("$@")
+FORWARD_ARG_COUNT=$#
 HANDOFF_IDENTITY_SH="$PROJECT_DIR/scripts/lib/handoff_identity.sh"
 if [ ! -f "$HANDOFF_IDENTITY_SH" ]; then
     printf 'Error: handoff identity helper is missing: %s\n' "$HANDOFF_IDENTITY_SH" >&2
@@ -96,14 +97,27 @@ if [ -n "$SELECTED_EPIC" ]; then
     export SESSION_EPIC="$SELECTED_EPIC"
     export SESSION_HANDOFF_AGENT="$HANDOFF_SLOT"
     FORWARD_ARGS=()
+    FORWARD_ARG_COUNT=0
     while IFS= read -r -d '' FORWARD_ARG; do
         FORWARD_ARGS+=("$FORWARD_ARG")
+        FORWARD_ARG_COUNT=$((FORWARD_ARG_COUNT + 1))
     done < <(strip_epic_from_argv "$@")
     unset FORWARD_ARG HANDOFF_SLOT
     printf 'Epic assignment: %s.epic\n' "$SESSION_EPIC"
     printf 'Handoff identity: %s\n' "$SESSION_HANDOFF_AGENT"
 fi
 unset HANDOFF_IDENTITY_SH SELECTED_EPIC
+
+# macOS ships Bash 3.2, where expanding an empty indexed array under `set -u`
+# fails even when the array was explicitly initialized. Move the filtered
+# values back into the special positional-parameter array, whose empty
+# expansion is nounset-safe, before any later loops or the final exec.
+if [ "$FORWARD_ARG_COUNT" -gt 0 ]; then
+    set -- "${FORWARD_ARGS[@]}"
+else
+    set --
+fi
+unset FORWARD_ARGS FORWARD_ARG_COUNT
 
 # Keep generated Codex config and the canonical rollover state ready before
 # replacing this wrapper process with the interactive CLI.
@@ -118,7 +132,7 @@ bootstrap_codex_checkout "$PROJECT_DIR" "$PROJECT_DIR" continue
 # reported by the CLI before trusting the profile.
 SELECTED_MODEL=""
 PREVIOUS_ARG=""
-for arg in "${FORWARD_ARGS[@]}"; do
+for arg in "$@"; do
     case "$arg" in
         --model=*)
             SELECTED_MODEL="${arg#--model=}"
@@ -157,4 +171,4 @@ exec codex \
     --search \
     --enable multi_agent \
     -C "$PROJECT_DIR" \
-    "${FORWARD_ARGS[@]}"
+    "$@"

--- a/tests/test_start_codex_profiles.py
+++ b/tests/test_start_codex_profiles.py
@@ -215,6 +215,25 @@ def test_launcher_binds_epic_and_strips_private_flag(tmp_path: Path) -> None:
     assert "Handoff identity: codex-hramatka" in result.stdout
 
 
+def test_launcher_binds_epic_when_no_codex_args_remain(tmp_path: Path) -> None:
+    values, forwarded, result, primary, _ = _launch(
+        tmp_path,
+        ["--epic=hramatka"],
+    )
+
+    assert values["epic"] == "hramatka"
+    assert values["handoff_agent"] == "codex-hramatka"
+    assert forwarded == [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--search",
+        "--enable",
+        "multi_agent",
+        "-C",
+        os.fspath(primary),
+    ]
+    assert "Epic assignment: hramatka.epic" in result.stdout
+
+
 def test_launcher_normalizes_equals_form_epic_suffix(tmp_path: Path) -> None:
     values, forwarded, _, _, _ = _launch(
         tmp_path,


### PR DESCRIPTION
## Summary

- make `./start-codex.sh --epic=hramatka` safe when stripping the launcher-only flag leaves no Codex arguments
- move filtered arguments into nounset-safe positional parameters before model parsing and `exec`
- add an end-to-end regression test for the exact equals-form invocation

## Root cause

macOS system Bash 3.2 treats an explicitly empty indexed-array expansion as unbound under `set -u`. The epic-only invocation produced `FORWARD_ARGS=()` and aborted before Codex could start.

## Verification

- `/bin/bash -n start-codex.sh`
- `shellcheck -x start-codex.sh`
- `.venv/bin/python -m pytest tests/test_start_codex_profiles.py -q` — 11 passed
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — PASS

Independent cross-family closeout: `claude-fable-5` via Cursor (Anthropic family) returned PASS with no findings. Strict `code-review-receipt.v1` disposition: `clean`; target fingerprint `eae6e6fc26505f3586f213d279396431212e5fa3a3de6d38938b4519219f15d3`.

Stream: #4542 (`hramatka`). Regression introduced by #5444; this PR does not close the stream epic.
