### PR TITLE
feat(activity-kit): carry rejected-draft answer keys

### DIFF
--- a/packages/activity-kit/src/fixtures/lu.lesson.v1.fixture.json
+++ b/packages/activity-kit/src/fixtures/lu.lesson.v1.fixture.json
@@ -426,6 +426,30 @@
         "provenance": { "source": "teacher-paste", "generator": "hramatka-poc-design", "gates": ["too-easy-for-level"] }
       },
       "reason": "занадто просте: відповідь стоїть у тексті поруч"
+    },
+    {
+      "type": "error-correction",
+      "activity": {
+        "id": "rejected-error-correction-schema-example",
+        "type": "error-correction",
+        "title": "Schema example",
+        "level": "b1",
+        "payload": {
+          "type": "error-correction",
+          "instruction": "Correct the example.",
+          "items": ["Example source sentence."]
+        },
+        "answer_key": { "items": ["Example corrected sentence."] },
+        "provenance": { "source": "teacher-paste", "generator": "schema-fixture", "gates": ["schema-contract"] }
+      },
+      "reason": "Synthetic schema fixture.",
+      "answer_key": {
+        "items": ["Example source sentence."],
+        "corrections": [
+          { "sentence": "Example source sentence.", "error": "source", "correction": "corrected" },
+          { "sentence": "Example source sentence.", "error": "source", "correction": "corrected" }
+        ]
+      }
     }
   ],
   "created_at": "2026-07-10T14:20:00+03:00",

--- a/packages/activity-kit/src/lu.lesson.v1.generated.ts
+++ b/packages/activity-kit/src/lu.lesson.v1.generated.ts
@@ -33,7 +33,19 @@ export type LuLessonBlock = {
 };
 
 export type LuRejectedDraft = {
-  type: "true-false" | "cloze" | "match-up" | "text-questions" | "multiple-choice" | "quiz" | "mark-the-words" | "fill-in" | "glossary" | "form-build" | "error-correction" | "paraphrase" | "continue-sentence" | "roleplay-dialog" | "short-writing";
+  type: "error-correction";
+  activity: LuActivityV1;
+  reason: string;
+  answer_key?: {
+    items: Array<string>;
+    corrections: Array<{
+      sentence: string;
+      error: string;
+      correction: string;
+    }>;
+  };
+} | {
+  type: "true-false" | "cloze" | "match-up" | "text-questions" | "multiple-choice" | "quiz" | "mark-the-words" | "fill-in" | "glossary" | "form-build" | "paraphrase" | "continue-sentence" | "roleplay-dialog" | "short-writing";
   activity: LuActivityV1;
   reason: string;
 };
@@ -73,7 +85,19 @@ export type LuLessonV1 = {
     };
   }>;
   rejected: Array<{
-    type: "true-false" | "cloze" | "match-up" | "text-questions" | "multiple-choice" | "quiz" | "mark-the-words" | "fill-in" | "glossary" | "form-build" | "error-correction" | "paraphrase" | "continue-sentence" | "roleplay-dialog" | "short-writing";
+    type: "error-correction";
+    activity: LuActivityV1;
+    reason: string;
+    answer_key?: {
+      items: Array<string>;
+      corrections: Array<{
+        sentence: string;
+        error: string;
+        correction: string;
+      }>;
+    };
+  } | {
+    type: "true-false" | "cloze" | "match-up" | "text-questions" | "multiple-choice" | "quiz" | "mark-the-words" | "fill-in" | "glossary" | "form-build" | "paraphrase" | "continue-sentence" | "roleplay-dialog" | "short-writing";
     activity: LuActivityV1;
     reason: string;
   }>;

--- a/packages/activity-kit/src/lu.lesson.v1.schema.json
+++ b/packages/activity-kit/src/lu.lesson.v1.schema.json
@@ -121,17 +121,78 @@
       ]
     },
     "rejectedDraft": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "activity", "reason"],
+          "properties": {
+            "type": { "const": "error-correction" },
+            "activity": {
+              "$ref": "https://learn-ukrainian.github.io/packages/activity-kit/lu.activity.v1.schema.json"
+            },
+            "reason": { "type": "string", "minLength": 1 },
+            "answer_key": { "$ref": "#/$defs/rejectedDraftAnswerKey" }
+          },
+          "allOf": [{ "$ref": "#/$defs/typeMatchesActivity" }]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "activity", "reason"],
+          "properties": {
+            "type": {
+              "enum": [
+                "true-false",
+                "cloze",
+                "match-up",
+                "text-questions",
+                "multiple-choice",
+                "quiz",
+                "mark-the-words",
+                "fill-in",
+                "glossary",
+                "form-build",
+                "paraphrase",
+                "continue-sentence",
+                "roleplay-dialog",
+                "short-writing"
+              ]
+            },
+            "activity": {
+              "$ref": "https://learn-ukrainian.github.io/packages/activity-kit/lu.activity.v1.schema.json"
+            },
+            "reason": { "type": "string", "minLength": 1 }
+          },
+          "allOf": [{ "$ref": "#/$defs/typeMatchesActivity" }]
+        }
+      ]
+    },
+    "rejectedDraftAnswerKey": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "activity", "reason"],
+      "required": ["items", "corrections"],
       "properties": {
-        "type": { "$ref": "#/$defs/activityType" },
-        "activity": {
-          "$ref": "https://learn-ukrainian.github.io/packages/activity-kit/lu.activity.v1.schema.json"
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
         },
-        "reason": { "type": "string", "minLength": 1 }
-      },
-      "allOf": [{ "$ref": "#/$defs/typeMatchesActivity" }]
+        "corrections": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["sentence", "error", "correction"],
+            "properties": {
+              "sentence": { "type": "string", "minLength": 1, "pattern": "\\S" },
+              "error": { "type": "string", "minLength": 1, "pattern": "\\S" },
+              "correction": { "type": "string", "minLength": 1, "pattern": "\\S" }
+            }
+          }
+        }
+      }
     },
     "activityType": {
       "enum": [

--- a/site/tests/unit/ActivityKit.contract.test.tsx
+++ b/site/tests/unit/ActivityKit.contract.test.tsx
@@ -6,7 +6,7 @@ import { describe, expect, test, vi } from 'vitest';
 import fixtures from '../../../packages/activity-kit/src/fixtures/lu.activity.v1.fixtures.json';
 import lessonFixture from '../../../packages/activity-kit/src/fixtures/lu.lesson.v1.fixture.json';
 import { ActivityPlayer } from '../../../packages/activity-kit/src/ActivityPlayer';
-import type { ActivityEditOperation, LuActivityV1, LuLessonV1 } from '../../../packages/activity-kit/src';
+import type { ActivityEditOperation, LuActivityV1, LuLessonV1, LuRejectedDraft } from '../../../packages/activity-kit/src';
 
 const repoRoot = resolve(process.cwd(), '..');
 const kitRoot = join(repoRoot, 'packages/activity-kit');
@@ -80,6 +80,25 @@ function lessonSchemaErrors(fixture: unknown): string {
 
   if (result.error) throw result.error;
   return result.stdout.trim();
+}
+
+type RejectedDraftFixture = {
+  type: string;
+  activity: { answer_key: Record<string, unknown> };
+  reason: string;
+  answer_key?: {
+    items?: string[];
+    corrections?: Array<Record<string, string>>;
+  };
+};
+
+function rejectedDraft(document: { rejected: unknown[] }, type: string): RejectedDraftFixture {
+  const draft = document.rejected.find((candidate) => (
+    typeof candidate === 'object' && candidate !== null && 'type' in candidate && candidate.type === type
+  ));
+
+  expect(draft).toBeDefined();
+  return draft as RejectedDraftFixture;
 }
 
 function sourceFiles(directory: string): string[] {
@@ -207,6 +226,59 @@ describe('lesson document v1 contract', () => {
     expect(lessonSchemaErrors(lessonFixture)).toBe('');
   });
 
+  test('keeps legacy rejected drafts valid without a teacher-only answer key', () => {
+    const document = structuredClone(lessonFixture);
+    const legacyDraft = rejectedDraft(document, 'true-false');
+
+    expect(legacyDraft.answer_key).toBeUndefined();
+    expect(lessonSchemaErrors(document)).toBe('');
+  });
+
+  test('validates an error-correction rejected-draft carrier and preserves duplicate corrections', () => {
+    const document = structuredClone(lessonFixture);
+    const draft = rejectedDraft(document, 'error-correction') as unknown as Extract<LuRejectedDraft, { type: 'error-correction' }>;
+
+    expect(draft.answer_key?.corrections).toHaveLength(2);
+    expect(draft.answer_key?.corrections[0]).toEqual(draft.answer_key?.corrections[1]);
+    expect(lessonSchemaErrors(document)).toBe('');
+  });
+
+  test.each([
+    ['missing items', (draft: RejectedDraftFixture) => delete draft.answer_key?.items],
+    ['missing corrections', (draft: RejectedDraftFixture) => delete draft.answer_key?.corrections],
+    ['missing correction field', (draft: RejectedDraftFixture) => delete draft.answer_key?.corrections?.[0].error],
+    ['blank correction text', (draft: RejectedDraftFixture) => { draft.answer_key!.corrections![0].correction = '   '; }],
+    ['extra correction property', (draft: RejectedDraftFixture) => { draft.answer_key!.corrections![0].extra = 'not allowed'; }],
+    ['empty items', (draft: RejectedDraftFixture) => { draft.answer_key!.items = []; }],
+    ['empty corrections', (draft: RejectedDraftFixture) => { draft.answer_key!.corrections = []; }],
+  ])('rejects an error-correction carrier with %s', (_, mutate) => {
+    const document = structuredClone(lessonFixture);
+    mutate(rejectedDraft(document, 'error-correction'));
+
+    expect(lessonSchemaErrors(document)).not.toBe('');
+  });
+
+  test('rejects a teacher-only carrier on a non-error-correction rejected draft', () => {
+    const document = structuredClone(lessonFixture);
+    const draft = rejectedDraft(document, 'true-false');
+    draft.answer_key = {
+      items: ['Example source sentence.'],
+      corrections: [{ sentence: 'Example source sentence.', error: 'source', correction: 'corrected' }],
+    };
+
+    expect(lessonSchemaErrors(document)).not.toBe('');
+  });
+
+  test('rejects teacher-only correction metadata inside the activity answer key', () => {
+    const document = structuredClone(lessonFixture);
+    const draft = rejectedDraft(document, 'error-correction');
+    draft.activity.answer_key.corrections = [
+      { sentence: 'Example source sentence.', error: 'source', correction: 'corrected' },
+    ];
+
+    expect(lessonSchemaErrors(document)).not.toBe('');
+  });
+
   test('keeps the 90-minute 4·5·3 phase plan', () => {
     const document = lessonFixture as LuLessonV1;
 
@@ -266,8 +338,8 @@ describe('lesson document v1 contract', () => {
   });
 
   test('validates focus_status supported:true with notice_uk:null', () => {
-    const doc = structuredClone(lessonFixture);
-    (doc as any).focus_status = {
+    const doc = structuredClone(lessonFixture) as unknown as LuLessonV1;
+    doc.focus_status = {
       requested: 'вищий ступінь прикметників',
       supported: true,
       notice_uk: null,
@@ -276,8 +348,8 @@ describe('lesson document v1 contract', () => {
   });
 
   test('validates focus_status supported:false with the Ukrainian notice string', () => {
-    const doc = structuredClone(lessonFixture);
-    (doc as any).focus_status = {
+    const doc = structuredClone(lessonFixture) as unknown as LuLessonV1;
+    doc.focus_status = {
       requested: 'вищий ступінь прикметників',
       supported: false,
       notice_uk: 'Опора не містить достатньо перевіреного матеріалу для фокусу «вищий ступінь прикметників». Вправи спираються лише на текст-опору; додайте приклади або змініть фокус.',
@@ -286,8 +358,8 @@ describe('lesson document v1 contract', () => {
   });
 
   test('rejects focus_status supported:true with a non-null notice_uk', () => {
-    const doc = structuredClone(lessonFixture);
-    (doc as any).focus_status = {
+    const doc = structuredClone(lessonFixture) as unknown as LuLessonV1;
+    doc.focus_status = {
       requested: 'вищий ступінь прикметників',
       supported: true,
       notice_uk: 'Опора не містить достатньо перевіреного матеріалу для фокусу «вищий ступінь прикметників». Вправи спираються лише на текст-опору; додайте приклади або змініть фокус.',
@@ -296,8 +368,8 @@ describe('lesson document v1 contract', () => {
   });
 
   test('rejects focus_status supported:false with a null notice_uk', () => {
-    const doc = structuredClone(lessonFixture);
-    (doc as any).focus_status = {
+    const doc = structuredClone(lessonFixture) as unknown as LuLessonV1;
+    doc.focus_status = {
       requested: 'вищий ступінь прикметників',
       supported: false,
       notice_uk: null,


### PR DESCRIPTION
Fixes #5447

Parent stream: #4542
Private consumer: learn-ukrainian/learn-ukrainian-infra-private#239

## Summary
- add an optional rejected-draft answer-key carrier for deliberate error-correction activities
- keep old drafts valid
- preserve correction order and multiplicity
- regenerate the TypeScript contract and add compatibility/validation coverage

## Verification
- activity-kit contract test: 57 passed
- ESLint on changed test: passed
- generated contract stability: passed
- git diff --check: passed
- X-Agent trailer audit: passed

Astro check remains blocked by pre-existing AtlasRuntimeStatus/generated-lexicon errors unrelated to this change.