### PR TITLE
fix(readiness): enforce active preparation holds

### DIFF
--- a/scripts/orchestration/curriculum_readiness.py
+++ b/scripts/orchestration/curriculum_readiness.py
@@ -740,6 +740,18 @@ def _lifecycle_decision(
     return LifecycleDecision("missing", "preparation-required", next_action), []
 
 
+def _active_preparation_hold(context: ValidationContext) -> Mapping[str, Any] | None:
+    """Return one strictly validated active hold, if the track registry has one."""
+    path = artifact_path("manual-registry", context.repo_root, context.track, context.slug)
+    if not path.is_file():
+        return None
+    try:
+        record = context.manual_evidence(path).get(context.slug, {}).get("hold")
+    except RegistryValidationError:
+        return None
+    return record if isinstance(record, Mapping) and record.get("active") is True else None
+
+
 def _evaluate_manifest_target(
     *,
     repo_root: Path,
@@ -774,6 +786,19 @@ def _evaluate_manifest_target(
         preparation_identity=preparation_identity,
         consumed_preparation_identity=consumed_preparation_identity,
     )
+    active_hold = _active_preparation_hold(context)
+    if active_hold is not None:
+        state_findings.append(
+            {
+                "id": "PREPARATION_HOLD_ACTIVE",
+                "category": "preparation",
+                "severity": "blocker",
+                "summary": f"Active reviewed preparation hold: {active_hold['reason']}",
+                "owner": "preparation",
+            }
+        )
+        if decision.next_action != "stop":
+            decision = LifecycleDecision("missing", "preparation-required", "stop")
     result = _result_document(
         track=track,
         slug=slug,

--- a/scripts/orchestration/preparation_evidence.py
+++ b/scripts/orchestration/preparation_evidence.py
@@ -119,6 +119,21 @@ def _validated_manual_record(slug: str, name: object, record: object) -> dict:
             or not clean["reason"].strip()
         ):
             raise RegistryValidationError(f"manual evidence {slug}.hold needs active boolean and reason")
+        if clean["active"] is True:
+            checked_evidence = clean.get("checked_evidence")
+            if (
+                not isinstance(clean.get("owner"), str)
+                or not clean["owner"].strip()
+                or not isinstance(clean.get("unblock_condition"), str)
+                or not clean["unblock_condition"].strip()
+                or not isinstance(checked_evidence, list)
+                or not checked_evidence
+                or not all(isinstance(item, str) and item.strip() for item in checked_evidence)
+            ):
+                raise RegistryValidationError(
+                    f"manual evidence {slug}.hold active record needs owner, "
+                    "checked_evidence, and unblock_condition"
+                )
     return clean
 
 

--- a/tests/audit/test_bio_readiness_ledger.py
+++ b/tests/audit/test_bio_readiness_ledger.py
@@ -276,6 +276,33 @@ entries:
         ledger.load_manual_evidence(off_manifest, {"known"})
 
 
+def test_registry_requires_closure_metadata_for_an_active_hold(tmp_path: Path) -> None:
+    path = tmp_path / "registry.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "entries": {
+                    "known": {
+                        "hold": {
+                            "status": "pass",
+                            "reviewer_family": "codex",
+                            "date": "2026-07-19",
+                            "evidence_url": "https://example.test/reviewed-hold",
+                            "active": True,
+                            "reason": "An authoritative source conflict remains unresolved.",
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ledger.RegistryValidationError, match="active record needs"):
+        ledger.load_manual_evidence(path, {"known"})
+
+
 @pytest.mark.parametrize(
     ("gate", "status", "disposition"),
     [

--- a/tests/orchestration/test_curriculum_readiness.py
+++ b/tests/orchestration/test_curriculum_readiness.py
@@ -217,6 +217,47 @@ def test_missing_bio_evidence_fails_closed_with_preparation_owner(tmp_path: Path
     assert finding["owner"] == "preparation"
 
 
+def test_reviewed_active_hold_is_a_terminal_stop_with_a_blocker_receipt(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    registry_path = repo_root / "curriculum/l2-uk-en/bio/promotion-evidence.yaml"
+    registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    registry["entries"][BIO_SLUG]["hold"] = {
+        "status": "pass",
+        "reviewer_family": "codex",
+        "date": "2026-07-19",
+        "evidence_url": "https://example.test/reviewed-hold",
+        "active": True,
+        "reason": "The terminal factual review found an unresolved source conflict.",
+        "owner": "bio-preparation-controller",
+        "checked_evidence": ["immutable packet review and adopted source set"],
+        "unblock_condition": "A stable authoritative source resolves the conflict.",
+    }
+    registry_path.write_text(yaml.safe_dump(registry, sort_keys=False), encoding="utf-8")
+
+    result = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+
+    assert result["preparation_state"] == "missing"
+    assert result["state"] == "preparation-required"
+    assert result["next_action"] == "stop"
+    assert "PREPARATION_HOLD_ACTIVE" in {item["id"] for item in result["findings"]}
+    readiness.validate_result(result, repo_root=repo_root)
+
+    _create_bundle(repo_root, "bio", BIO_SLUG)
+    built = readiness.evaluate_preparation(
+        "bio",
+        BIO_SLUG,
+        consumed_preparation_identity=result["preparation_identity"],
+        repo_root=repo_root,
+    )
+
+    assert built["module_state"] == "built"
+    assert built["preparation_state"] == "missing"
+    assert built["state"] == "preparation-required"
+    assert built["next_action"] == "stop"
+    assert "PREPARATION_HOLD_ACTIVE" in {item["id"] for item in built["findings"]}
+    readiness.validate_result(built, repo_root=repo_root)
+
+
 def test_missing_plan_routes_to_plan_owner(tmp_path: Path) -> None:
     repo_root = _bio_fixture(tmp_path)
     (repo_root / f"curriculum/l2-uk-en/plans/bio/{BIO_SLUG}.yaml").unlink()


### PR DESCRIPTION
## Summary

- strictly validate closure metadata on active preparation holds
- make the canonical readiness evaluator emit `next_action=stop` with `PREPARATION_HOLD_ACTIVE`
- cover both unbuilt and built-current/certify paths

## Verification

- 55 focused pytest tests passed
- Ruff passed on all four changed files
- Python bytecode compilation passed
- `git diff --check` passed
- agent trailer audit passed
- independent cross-family review: Claude Fable 5 via Cursor, PASS after CF5-001 was fixed
- final review result SHA-256: `946c858f359c1f59cd0858c375176bd6d71864e3e2377b563a797ba3245c9dd0`
- task-state SHA-256: `4a55ef1540194cf82701d00170810ac0495540bfdea58468fc1bb7473b4ecb23`

## Scope

No BIO capsules, readiness thresholds, generated artifacts, or learner modules are changed.

Refs #4431