### PR TITLE
feat(track-completion): add bounded module-completion contract

### DIFF
--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -37,6 +37,33 @@ artifact: record the owning source change and rerun a fresh canonical review.
 An unchanged existing module with a current PASS remains idempotent and must not
 be rebuilt or republished without a terminal-goal reason.
 
+## Bounded completion contract
+
+The canonical issue #5452 contract is
+`contracts/bounded-completion.v1.json`. Its strict contract and run schemas are
+`schema/bounded-completion-contract.v1.schema.json` and
+`schema/bounded-completion-run.v1.schema.json`. Validate them without invoking a
+provider:
+
+```bash
+.venv/bin/python \
+  agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py \
+  validate-contract
+```
+
+The standalone helper freezes the review protocol identity at run start and
+enforces one initial semantic review, at most one consolidated learner repair,
+and at most one final semantic review. A third review or second repair is
+rejected before mutation. A material learner-source change invalidates prior
+review evidence, and a final non-PASS exhausts the budget into terminal
+`BLOCKED_BUDGET_EXHAUSTED`. Publication requires every canonical quality
+dimension to remain at or above `9.0`.
+
+This contract slice is not wired into `scripts/track_completion.py`. Issue #5453
+owns production lifecycle integration. Use the helper's `replay` command only
+for deterministic contract fixtures. It has no provider transport and must
+never be treated as semantic review evidence.
+
 ## Start or resume
 
 1. Preserve the legacy parity boundary documented below. Post-build review v5

--- a/agents_extensions/shared/skills/track-completion/contracts/bounded-completion.v1.json
+++ b/agents_extensions/shared/skills/track-completion/contracts/bounded-completion.v1.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../schema/bounded-completion-contract.v1.schema.json",
+  "schema_version": "bounded-completion.contract.v1",
+  "contract_version": "1.0.0",
+  "run_schema_version": "bounded-completion.run.v1",
+  "states": [
+    "INSPECT",
+    "BUILD_REBUILD",
+    "DETERMINISTIC_VERIFICATION",
+    "SEMANTIC_REVIEW",
+    "CONSOLIDATED_REPAIR",
+    "FINAL_DISPOSITION",
+    "PUBLICATION"
+  ],
+  "transitions": {
+    "INSPECT": [
+      "BUILD_REBUILD",
+      "DETERMINISTIC_VERIFICATION"
+    ],
+    "BUILD_REBUILD": [
+      "DETERMINISTIC_VERIFICATION"
+    ],
+    "DETERMINISTIC_VERIFICATION": [
+      "SEMANTIC_REVIEW",
+      "FINAL_DISPOSITION"
+    ],
+    "SEMANTIC_REVIEW": [
+      "CONSOLIDATED_REPAIR",
+      "FINAL_DISPOSITION"
+    ],
+    "CONSOLIDATED_REPAIR": [
+      "DETERMINISTIC_VERIFICATION"
+    ],
+    "FINAL_DISPOSITION": [
+      "PUBLICATION"
+    ],
+    "PUBLICATION": []
+  },
+  "budgets": {
+    "initial_semantic_reviews": 1,
+    "consolidated_repairs": 1,
+    "final_semantic_reviews": 1,
+    "semantic_reviews_total": 2
+  },
+  "review_protocol_freeze": {
+    "pin_at_run_start": true,
+    "drift_policy": "REJECT_WITHOUT_MUTATION"
+  },
+  "learner_source_freshness": {
+    "material_change_invalidates_review_evidence": true,
+    "post_review_change_counts_as_repair": true
+  },
+  "publication_quality": {
+    "minimum_per_dimension": 9.0,
+    "dimensions": [
+      "engagement",
+      "pedagogical",
+      "naturalness",
+      "decolonization",
+      "tone"
+    ],
+    "aggregate_override_allowed": false,
+    "threshold_lowering_allowed": false
+  },
+  "budget_exhaustion": {
+    "disposition": "BLOCKED_BUDGET_EXHAUSTED",
+    "terminal": true,
+    "looping_allowed": false
+  },
+  "measurement_fields": [
+    "elapsed_time_ms",
+    "model_call_count",
+    "repair_count",
+    "prompt_bytes",
+    "schema_bytes",
+    "final_quality_disposition"
+  ]
+}

--- a/agents_extensions/shared/skills/track-completion/schema/bounded-completion-contract.v1.schema.json
+++ b/agents_extensions/shared/skills/track-completion/schema/bounded-completion-contract.v1.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "bounded-completion.contract.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "contract_version",
+    "run_schema_version",
+    "states",
+    "transitions",
+    "budgets",
+    "review_protocol_freeze",
+    "learner_source_freshness",
+    "publication_quality",
+    "budget_exhaustion",
+    "measurement_fields"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "../schema/bounded-completion-contract.v1.schema.json"
+    },
+    "schema_version": {
+      "const": "bounded-completion.contract.v1"
+    },
+    "contract_version": {
+      "const": "1.0.0"
+    },
+    "run_schema_version": {
+      "const": "bounded-completion.run.v1"
+    },
+    "states": {
+      "type": "array",
+      "prefixItems": [
+        {"const": "INSPECT"},
+        {"const": "BUILD_REBUILD"},
+        {"const": "DETERMINISTIC_VERIFICATION"},
+        {"const": "SEMANTIC_REVIEW"},
+        {"const": "CONSOLIDATED_REPAIR"},
+        {"const": "FINAL_DISPOSITION"},
+        {"const": "PUBLICATION"}
+      ],
+      "items": false,
+      "minItems": 7,
+      "maxItems": 7
+    },
+    "transitions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "INSPECT",
+        "BUILD_REBUILD",
+        "DETERMINISTIC_VERIFICATION",
+        "SEMANTIC_REVIEW",
+        "CONSOLIDATED_REPAIR",
+        "FINAL_DISPOSITION",
+        "PUBLICATION"
+      ],
+      "properties": {
+        "INSPECT": {
+          "const": ["BUILD_REBUILD", "DETERMINISTIC_VERIFICATION"]
+        },
+        "BUILD_REBUILD": {
+          "const": ["DETERMINISTIC_VERIFICATION"]
+        },
+        "DETERMINISTIC_VERIFICATION": {
+          "const": ["SEMANTIC_REVIEW", "FINAL_DISPOSITION"]
+        },
+        "SEMANTIC_REVIEW": {
+          "const": ["CONSOLIDATED_REPAIR", "FINAL_DISPOSITION"]
+        },
+        "CONSOLIDATED_REPAIR": {
+          "const": ["DETERMINISTIC_VERIFICATION"]
+        },
+        "FINAL_DISPOSITION": {
+          "const": ["PUBLICATION"]
+        },
+        "PUBLICATION": {
+          "const": []
+        }
+      }
+    },
+    "budgets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "initial_semantic_reviews",
+        "consolidated_repairs",
+        "final_semantic_reviews",
+        "semantic_reviews_total"
+      ],
+      "properties": {
+        "initial_semantic_reviews": {"const": 1},
+        "consolidated_repairs": {"const": 1},
+        "final_semantic_reviews": {"const": 1},
+        "semantic_reviews_total": {"const": 2}
+      }
+    },
+    "review_protocol_freeze": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pin_at_run_start", "drift_policy"],
+      "properties": {
+        "pin_at_run_start": {"const": true},
+        "drift_policy": {"const": "REJECT_WITHOUT_MUTATION"}
+      }
+    },
+    "learner_source_freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "material_change_invalidates_review_evidence",
+        "post_review_change_counts_as_repair"
+      ],
+      "properties": {
+        "material_change_invalidates_review_evidence": {"const": true},
+        "post_review_change_counts_as_repair": {"const": true}
+      }
+    },
+    "publication_quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "minimum_per_dimension",
+        "dimensions",
+        "aggregate_override_allowed",
+        "threshold_lowering_allowed"
+      ],
+      "properties": {
+        "minimum_per_dimension": {"const": 9.0},
+        "dimensions": {
+          "type": "array",
+          "prefixItems": [
+            {"const": "engagement"},
+            {"const": "pedagogical"},
+            {"const": "naturalness"},
+            {"const": "decolonization"},
+            {"const": "tone"}
+          ],
+          "items": false,
+          "minItems": 5,
+          "maxItems": 5
+        },
+        "aggregate_override_allowed": {"const": false},
+        "threshold_lowering_allowed": {"const": false}
+      }
+    },
+    "budget_exhaustion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["disposition", "terminal", "looping_allowed"],
+      "properties": {
+        "disposition": {"const": "BLOCKED_BUDGET_EXHAUSTED"},
+        "terminal": {"const": true},
+        "looping_allowed": {"const": false}
+      }
+    },
+    "measurement_fields": {
+      "type": "array",
+      "prefixItems": [
+        {"const": "elapsed_time_ms"},
+        {"const": "model_call_count"},
+        {"const": "repair_count"},
+        {"const": "prompt_bytes"},
+        {"const": "schema_bytes"},
+        {"const": "final_quality_disposition"}
+      ],
+      "items": false,
+      "minItems": 6,
+      "maxItems": 6
+    }
+  }
+}

--- a/agents_extensions/shared/skills/track-completion/schema/bounded-completion-run.v1.schema.json
+++ b/agents_extensions/shared/skills/track-completion/schema/bounded-completion-run.v1.schema.json
@@ -1,0 +1,239 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "bounded-completion.run.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "contract_version",
+    "run_id",
+    "target",
+    "state",
+    "terminal",
+    "review_protocol_identity",
+    "learner_source_sha256",
+    "deterministic_verification",
+    "reviews",
+    "repairs",
+    "publication",
+    "measurements",
+    "history"
+  ],
+  "properties": {
+    "schema_version": {"const": "bounded-completion.run.v1"},
+    "contract_version": {"const": "1.0.0"},
+    "run_id": {"type": "string", "pattern": "^[0-9a-f]{32}$"},
+    "target": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    },
+    "state": {"$ref": "#/$defs/state"},
+    "terminal": {"type": "boolean"},
+    "review_protocol_identity": {"$ref": "#/$defs/reviewProtocolIdentity"},
+    "learner_source_sha256": {
+      "oneOf": [
+        {"type": "null"},
+        {"$ref": "#/$defs/sha256"}
+      ]
+    },
+    "deterministic_verification": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["learner_source_sha256", "passed"],
+          "properties": {
+            "learner_source_sha256": {"$ref": "#/$defs/sha256"},
+            "passed": {"type": "boolean"}
+          }
+        }
+      ]
+    },
+    "reviews": {
+      "type": "array",
+      "maxItems": 2,
+      "items": {"$ref": "#/$defs/review"}
+    },
+    "repairs": {
+      "type": "array",
+      "maxItems": 1,
+      "items": {"$ref": "#/$defs/repair"}
+    },
+    "publication": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["reference", "learner_source_sha256"],
+          "properties": {
+            "reference": {"type": "string", "minLength": 1},
+            "learner_source_sha256": {"$ref": "#/$defs/sha256"}
+          }
+        }
+      ]
+    },
+    "measurements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "elapsed_time_ms",
+        "model_call_count",
+        "repair_count",
+        "prompt_bytes",
+        "schema_bytes",
+        "final_quality_disposition"
+      ],
+      "properties": {
+        "elapsed_time_ms": {"type": "integer", "minimum": 0},
+        "model_call_count": {"type": "integer", "minimum": 0, "maximum": 2},
+        "repair_count": {"type": "integer", "minimum": 0, "maximum": 1},
+        "prompt_bytes": {"type": "integer", "minimum": 0},
+        "schema_bytes": {"type": "integer", "minimum": 0},
+        "final_quality_disposition": {
+          "enum": [
+            "PENDING",
+            "PUBLISHABLE",
+            "BLOCKED_DETERMINISTIC",
+            "BLOCKED_BUDGET_EXHAUSTED"
+          ]
+        }
+      }
+    },
+    "history": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/event"}
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "state": {
+      "enum": [
+        "INSPECT",
+        "BUILD_REBUILD",
+        "DETERMINISTIC_VERIFICATION",
+        "SEMANTIC_REVIEW",
+        "CONSOLIDATED_REPAIR",
+        "FINAL_DISPOSITION",
+        "PUBLICATION"
+      ]
+    },
+    "reviewProtocolIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "protocol_version",
+        "tool_sha256",
+        "prompt_sha256",
+        "schema_sha256",
+        "reviewer_family",
+        "reviewer_model",
+        "identity_sha256"
+      ],
+      "properties": {
+        "protocol_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "tool_sha256": {"$ref": "#/$defs/sha256"},
+        "prompt_sha256": {"$ref": "#/$defs/sha256"},
+        "schema_sha256": {"$ref": "#/$defs/sha256"},
+        "reviewer_family": {"type": "string", "minLength": 1},
+        "reviewer_model": {"type": "string", "minLength": 1},
+        "identity_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "dimensionScores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "engagement",
+        "pedagogical",
+        "naturalness",
+        "decolonization",
+        "tone"
+      ],
+      "properties": {
+        "engagement": {"type": "number", "minimum": 0, "maximum": 10},
+        "pedagogical": {"type": "number", "minimum": 0, "maximum": 10},
+        "naturalness": {"type": "number", "minimum": 0, "maximum": 10},
+        "decolonization": {"type": "number", "minimum": 0, "maximum": 10},
+        "tone": {"type": "number", "minimum": 0, "maximum": 10}
+      }
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phase",
+        "evidence_id",
+        "review_protocol_identity_sha256",
+        "learner_source_sha256",
+        "reported_disposition",
+        "contract_disposition",
+        "dimension_scores",
+        "threshold_failures",
+        "valid",
+        "invalidated_reason"
+      ],
+      "properties": {
+        "phase": {"enum": ["INITIAL", "FINAL"]},
+        "evidence_id": {"type": "string", "minLength": 1},
+        "review_protocol_identity_sha256": {"$ref": "#/$defs/sha256"},
+        "learner_source_sha256": {"$ref": "#/$defs/sha256"},
+        "reported_disposition": {"enum": ["PASS", "REVISE", "BLOCK"]},
+        "contract_disposition": {"enum": ["PASS", "REVISE", "BLOCK"]},
+        "dimension_scores": {"$ref": "#/$defs/dimensionScores"},
+        "threshold_failures": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "engagement",
+              "pedagogical",
+              "naturalness",
+              "decolonization",
+              "tone"
+            ]
+          }
+        },
+        "valid": {"type": "boolean"},
+        "invalidated_reason": {
+          "enum": [null, "LEARNER_SOURCE_CHANGED"]
+        }
+      }
+    },
+    "repair": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_before_sha256",
+        "source_after_sha256",
+        "invalidated_evidence_ids"
+      ],
+      "properties": {
+        "source_before_sha256": {"$ref": "#/$defs/sha256"},
+        "source_after_sha256": {"$ref": "#/$defs/sha256"},
+        "invalidated_evidence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sequence", "action", "from_state", "to_state", "details"],
+      "properties": {
+        "sequence": {"type": "integer", "minimum": 1},
+        "action": {"type": "string", "minLength": 1},
+        "from_state": {"$ref": "#/$defs/state"},
+        "to_state": {"$ref": "#/$defs/state"},
+        "details": {"type": "object"}
+      }
+    }
+  }
+}

--- a/agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 from collections.abc import Mapping
 from copy import deepcopy
 from pathlib import Path
@@ -31,6 +32,7 @@ _PROTOCOL_FIELDS = (
     "reviewer_family",
     "reviewer_model",
 )
+_SEMANTIC_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 _EXPECTED_TRANSITIONS = {
     "INSPECT": ["BUILD_REBUILD", "DETERMINISTIC_VERIFICATION"],
     "BUILD_REBUILD": ["DETERMINISTIC_VERIFICATION"],
@@ -125,8 +127,11 @@ def make_review_protocol_identity(
 ) -> dict[str, str]:
     """Build the full review-tooling identity pinned at run start."""
 
-    if not isinstance(protocol_version, str) or not protocol_version:
-        raise BoundedCompletionError("PROTOCOL_IDENTITY_INVALID", "protocol_version is required")
+    if not isinstance(protocol_version, str) or _SEMANTIC_VERSION_RE.fullmatch(protocol_version) is None:
+        raise BoundedCompletionError(
+            "PROTOCOL_IDENTITY_INVALID",
+            "protocol_version must use X.Y.Z numeric semantic-version syntax",
+        )
     payload = {
         "protocol_version": protocol_version,
         "tool_sha256": _require_sha256(tool_sha256, "tool_sha256"),
@@ -185,12 +190,48 @@ def _assert_invariants(run: Mapping[str, Any], contract: Mapping[str, Any]) -> N
     disposition = measurements["final_quality_disposition"]
     state = run["state"]
     terminal = run["terminal"]
+    if terminal and state not in {"FINAL_DISPOSITION", "PUBLICATION"}:
+        raise BoundedCompletionError(
+            "RUN_INVARIANT",
+            "Terminal runs must be in FINAL_DISPOSITION or PUBLICATION",
+        )
+    if terminal and disposition == "PENDING":
+        raise BoundedCompletionError(
+            "RUN_INVARIANT",
+            "Terminal runs cannot retain a PENDING quality disposition",
+        )
     if state == "PUBLICATION" and (publication is None or not terminal or disposition != "PUBLISHABLE"):
         raise BoundedCompletionError("RUN_INVARIANT", "Publication must be terminal and publishable")
     if disposition.startswith("BLOCKED_") and (state != "FINAL_DISPOSITION" or not terminal):
         raise BoundedCompletionError("RUN_INVARIANT", "Blocked disposition must be terminal")
     if disposition == "PUBLISHABLE" and state not in {"FINAL_DISPOSITION", "PUBLICATION"}:
         raise BoundedCompletionError("RUN_INVARIANT", "Publishable disposition is in the wrong state")
+    if disposition == "PUBLISHABLE" or state == "PUBLICATION":
+        if (
+            verification is None
+            or not verification["passed"]
+            or verification["learner_source_sha256"] != current_source
+        ):
+            raise BoundedCompletionError(
+                "RUN_INVARIANT",
+                "Publishable runs require a current deterministic PASS",
+            )
+        if not reviews:
+            raise BoundedCompletionError(
+                "RUN_INVARIANT",
+                "Publishable runs require current semantic review evidence",
+            )
+        final_review = reviews[-1]
+        if (
+            not final_review["valid"]
+            or final_review["contract_disposition"] != "PASS"
+            or final_review["learner_source_sha256"] != current_source
+            or final_review["review_protocol_identity_sha256"] != run["review_protocol_identity"]["identity_sha256"]
+        ):
+            raise BoundedCompletionError(
+                "RUN_INVARIANT",
+                "Publishable runs require a current PASS review bound to the active source and protocol",
+            )
     if state == "SEMANTIC_REVIEW" and (verification is None or not verification["passed"]):
         raise BoundedCompletionError("RUN_INVARIANT", "Semantic review requires current deterministic PASS")
 

--- a/agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+"""Pure, bounded state machine for one module-completion run.
+
+This helper intentionally has no provider transport and is not imported by the
+production track-completion lifecycle. It makes the issue #5452 contract
+executable without triggering semantic review calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONTRACT_PATH = SKILL_ROOT / "contracts" / "bounded-completion.v1.json"
+CONTRACT_SCHEMA_PATH = SKILL_ROOT / "schema" / "bounded-completion-contract.v1.schema.json"
+RUN_SCHEMA_PATH = SKILL_ROOT / "schema" / "bounded-completion-run.v1.schema.json"
+
+_PROTOCOL_FIELDS = (
+    "protocol_version",
+    "tool_sha256",
+    "prompt_sha256",
+    "schema_sha256",
+    "reviewer_family",
+    "reviewer_model",
+)
+_EXPECTED_TRANSITIONS = {
+    "INSPECT": ["BUILD_REBUILD", "DETERMINISTIC_VERIFICATION"],
+    "BUILD_REBUILD": ["DETERMINISTIC_VERIFICATION"],
+    "DETERMINISTIC_VERIFICATION": ["SEMANTIC_REVIEW", "FINAL_DISPOSITION"],
+    "SEMANTIC_REVIEW": ["CONSOLIDATED_REPAIR", "FINAL_DISPOSITION"],
+    "CONSOLIDATED_REPAIR": ["DETERMINISTIC_VERIFICATION"],
+    "FINAL_DISPOSITION": ["PUBLICATION"],
+    "PUBLICATION": [],
+}
+
+
+class BoundedCompletionError(RuntimeError):
+    """Raised when the bounded contract rejects an input or transition."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"[{code}] {message}")
+
+
+def stable_json(value: object) -> str:
+    """Return the canonical JSON representation used for identity hashes."""
+
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_json(value: object) -> str:
+    """Hash a JSON-compatible value using the canonical representation."""
+
+    return hashlib.sha256(stable_json(value).encode("utf-8")).hexdigest()
+
+
+def read_json(path: Path) -> Any:
+    """Read one UTF-8 JSON document."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate(value: object, schema_path: Path, label: str) -> None:
+    schema = read_json(schema_path)
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(value),
+        key=lambda error: [str(part) for part in error.absolute_path],
+    )
+    if not errors:
+        return
+    details = "; ".join(
+        f"{'.'.join(str(part) for part in error.absolute_path) or '<root>'}: {error.message}" for error in errors[:8]
+    )
+    raise BoundedCompletionError("SCHEMA_INVALID", f"Invalid {label}: {details}")
+
+
+def load_contract(path: Path = DEFAULT_CONTRACT_PATH) -> dict[str, Any]:
+    """Load and validate the canonical bounded-completion contract."""
+
+    value = read_json(path)
+    if not isinstance(value, dict):
+        raise BoundedCompletionError("CONTRACT_INVALID", "Contract root must be an object")
+    _validate(value, CONTRACT_SCHEMA_PATH, "bounded-completion contract")
+    if value["transitions"] != _EXPECTED_TRANSITIONS:
+        raise BoundedCompletionError(
+            "CONTRACT_INVALID",
+            "Version 1 transition graph differs from the fail-closed canonical graph",
+        )
+    return value
+
+
+def _is_sha256(value: object) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+
+
+def _require_sha256(value: object, label: str) -> str:
+    if not _is_sha256(value):
+        raise BoundedCompletionError("IDENTITY_INVALID", f"{label} must be a lowercase SHA-256")
+    return str(value)
+
+
+def _require_nonnegative_int(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BoundedCompletionError("MEASUREMENT_INVALID", f"{label} must be a non-negative integer")
+    return value
+
+
+def make_review_protocol_identity(
+    *,
+    protocol_version: str,
+    tool_sha256: str,
+    prompt_sha256: str,
+    schema_sha256: str,
+    reviewer_family: str,
+    reviewer_model: str,
+) -> dict[str, str]:
+    """Build the full review-tooling identity pinned at run start."""
+
+    if not isinstance(protocol_version, str) or not protocol_version:
+        raise BoundedCompletionError("PROTOCOL_IDENTITY_INVALID", "protocol_version is required")
+    payload = {
+        "protocol_version": protocol_version,
+        "tool_sha256": _require_sha256(tool_sha256, "tool_sha256"),
+        "prompt_sha256": _require_sha256(prompt_sha256, "prompt_sha256"),
+        "schema_sha256": _require_sha256(schema_sha256, "schema_sha256"),
+        "reviewer_family": reviewer_family,
+        "reviewer_model": reviewer_model,
+    }
+    for field in ("reviewer_family", "reviewer_model"):
+        if not isinstance(payload[field], str) or not payload[field].strip():
+            raise BoundedCompletionError("PROTOCOL_IDENTITY_INVALID", f"{field} is required")
+    return {**payload, "identity_sha256": sha256_json(payload)}
+
+
+def _validate_protocol_identity(identity: Mapping[str, object]) -> dict[str, str]:
+    if set(identity) != {*_PROTOCOL_FIELDS, "identity_sha256"}:
+        raise BoundedCompletionError(
+            "PROTOCOL_IDENTITY_INVALID",
+            "Review protocol identity has missing or unexpected fields",
+        )
+    rebuilt = make_review_protocol_identity(**{field: identity[field] for field in _PROTOCOL_FIELDS})  # type: ignore[arg-type]
+    if rebuilt != dict(identity):
+        raise BoundedCompletionError(
+            "PROTOCOL_IDENTITY_INVALID",
+            "Review protocol identity digest does not match its fields",
+        )
+    return rebuilt
+
+
+def _assert_invariants(run: Mapping[str, Any], contract: Mapping[str, Any]) -> None:
+    reviews = run["reviews"]
+    repairs = run["repairs"]
+    measurements = run["measurements"]
+    if len(reviews) != measurements["model_call_count"]:
+        raise BoundedCompletionError("RUN_INVARIANT", "model_call_count must equal recorded reviews")
+    if len(repairs) != measurements["repair_count"]:
+        raise BoundedCompletionError("RUN_INVARIANT", "repair_count must equal recorded repairs")
+    if len(reviews) > contract["budgets"]["semantic_reviews_total"]:
+        raise BoundedCompletionError("RUN_INVARIANT", "Semantic-review budget is exceeded")
+    if len(repairs) > contract["budgets"]["consolidated_repairs"]:
+        raise BoundedCompletionError("RUN_INVARIANT", "Consolidated-repair budget is exceeded")
+    expected_phases = ["INITIAL", "FINAL"][: len(reviews)]
+    if [review["phase"] for review in reviews] != expected_phases:
+        raise BoundedCompletionError("RUN_INVARIANT", "Review phases must be INITIAL then FINAL")
+    current_source = run["learner_source_sha256"]
+    for review in reviews:
+        if review["valid"] and review["learner_source_sha256"] != current_source:
+            raise BoundedCompletionError("RUN_INVARIANT", "Valid review evidence is stale")
+    verification = run["deterministic_verification"]
+    if verification is not None and verification["passed"] and verification["learner_source_sha256"] != current_source:
+        raise BoundedCompletionError("RUN_INVARIANT", "Deterministic evidence is stale")
+    publication = run["publication"]
+    if publication is not None and publication["learner_source_sha256"] != current_source:
+        raise BoundedCompletionError("RUN_INVARIANT", "Publication identity is stale")
+
+    disposition = measurements["final_quality_disposition"]
+    state = run["state"]
+    terminal = run["terminal"]
+    if state == "PUBLICATION" and (publication is None or not terminal or disposition != "PUBLISHABLE"):
+        raise BoundedCompletionError("RUN_INVARIANT", "Publication must be terminal and publishable")
+    if disposition.startswith("BLOCKED_") and (state != "FINAL_DISPOSITION" or not terminal):
+        raise BoundedCompletionError("RUN_INVARIANT", "Blocked disposition must be terminal")
+    if disposition == "PUBLISHABLE" and state not in {"FINAL_DISPOSITION", "PUBLICATION"}:
+        raise BoundedCompletionError("RUN_INVARIANT", "Publishable disposition is in the wrong state")
+    if state == "SEMANTIC_REVIEW" and (verification is None or not verification["passed"]):
+        raise BoundedCompletionError("RUN_INVARIANT", "Semantic review requires current deterministic PASS")
+
+
+def validate_run(
+    run: Mapping[str, Any],
+    *,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> None:
+    """Validate a run against both JSON Schema and cross-field invariants."""
+
+    contract = load_contract(contract_path)
+    _validate(run, RUN_SCHEMA_PATH, "bounded-completion run")
+    _validate_protocol_identity(run["review_protocol_identity"])
+    if run["contract_version"] != contract["contract_version"]:
+        raise BoundedCompletionError("CONTRACT_DRIFT", "Run contract version is no longer active")
+    _assert_invariants(run, contract)
+
+
+def start_run(
+    *,
+    target: str,
+    run_id: str,
+    review_protocol_identity: Mapping[str, object],
+    learner_source_sha256: str | None,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> dict[str, Any]:
+    """Create a new run with a frozen review protocol identity."""
+
+    contract = load_contract(contract_path)
+    protocol = _validate_protocol_identity(review_protocol_identity)
+    if learner_source_sha256 is not None:
+        learner_source_sha256 = _require_sha256(learner_source_sha256, "learner_source_sha256")
+    run: dict[str, Any] = {
+        "schema_version": contract["run_schema_version"],
+        "contract_version": contract["contract_version"],
+        "run_id": run_id,
+        "target": target,
+        "state": "INSPECT",
+        "terminal": False,
+        "review_protocol_identity": protocol,
+        "learner_source_sha256": learner_source_sha256,
+        "deterministic_verification": None,
+        "reviews": [],
+        "repairs": [],
+        "publication": None,
+        "measurements": {
+            "elapsed_time_ms": 0,
+            "model_call_count": 0,
+            "repair_count": 0,
+            "prompt_bytes": 0,
+            "schema_bytes": 0,
+            "final_quality_disposition": "PENDING",
+        },
+        "history": [],
+    }
+    validate_run(run, contract_path=contract_path)
+    return run
+
+
+def _copy_run(run: Mapping[str, Any], contract_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    validate_run(run, contract_path=contract_path)
+    return deepcopy(dict(run)), load_contract(contract_path)
+
+
+def _require_state(run: Mapping[str, Any], expected: str) -> None:
+    if run["state"] != expected:
+        raise BoundedCompletionError(
+            "STATE_INVALID",
+            f"Expected state {expected}, found {run['state']}",
+        )
+
+
+def _add_elapsed(run: dict[str, Any], elapsed_time_ms: int) -> None:
+    run["measurements"]["elapsed_time_ms"] += _require_nonnegative_int(
+        elapsed_time_ms,
+        "elapsed_time_ms",
+    )
+
+
+def _transition(
+    run: dict[str, Any],
+    contract: Mapping[str, Any],
+    *,
+    to_state: str,
+    action: str,
+    details: Mapping[str, Any] | None = None,
+) -> None:
+    from_state = run["state"]
+    if to_state not in contract["transitions"][from_state]:
+        raise BoundedCompletionError(
+            "TRANSITION_INVALID",
+            f"Contract forbids {from_state} -> {to_state}",
+        )
+    run["state"] = to_state
+    run["history"].append(
+        {
+            "sequence": len(run["history"]) + 1,
+            "action": action,
+            "from_state": from_state,
+            "to_state": to_state,
+            "details": dict(details or {}),
+        }
+    )
+
+
+def complete_inspection(
+    run: Mapping[str, Any],
+    *,
+    needs_build: bool,
+    elapsed_time_ms: int = 0,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> dict[str, Any]:
+    """Record inspection and choose build/rebuild or direct verification."""
+
+    updated, contract = _copy_run(run, contract_path)
+    _require_state(updated, "INSPECT")
+    if not isinstance(needs_build, bool):
+        raise BoundedCompletionError("INPUT_INVALID", "needs_build must be boolean")
+    if not needs_build and updated["learner_source_sha256"] is None:
+        raise BoundedCompletionError("IDENTITY_INVALID", "A built source identity is required")
+    _add_elapsed(updated, elapsed_time_ms)
+    _transition(
+        updated,
+        contract,
+        to_state="BUILD_REBUILD" if needs_build else "DETERMINISTIC_VERIFICATION",
+        action="inspection_completed",
+        details={"needs_build": needs_build},
+    )
+    validate_run(updated, contract_path=contract_path)
+    return updated
+
+
+def complete_build(
+    run: Mapping[str, Any],
+    *,
+    learner_source_sha256: str,
+    elapsed_time_ms: int = 0,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> dict[str, Any]:
+    """Record one build or rebuild before semantic evidence exists."""
+
+    updated, contract = _copy_run(run, contract_path)
+    _require_state(updated, "BUILD_REBUILD")
+    source = _require_sha256(learner_source_sha256, "learner_source_sha256")
+    _add_elapsed(updated, elapsed_time_ms)
+    updated["learner_source_sha256"] = source
+    updated["deterministic_verification"] = None
+    _transition(
+        updated,
+        contract,
+        to_state="DETERMINISTIC_VERIFICATION",
+        action="build_completed",
+        details={"learner_source_sha256": source},
+    )
+    validate_run(updated, contract_path=contract_path)
+    return updated
+
+
+def record_deterministic_verification(
+    run: Mapping[str, Any],
+    *,
+    learner_source_sha256: str,
+    passed: bool,
+    elapsed_time_ms: int = 0,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> dict[str, Any]:
+    """Bind deterministic evidence to the exact current learner source."""
+
+    updated, contract = _copy_run(run, contract_path)
+    _require_state(updated, "DETERMINISTIC_VERIFICATION")
+    source = _require_sha256(learner_source_sha256, "learner_source_sha256")
+    if source != updated["learner_source_sha256"]:
+        raise BoundedCompletionError(
+            "LEARNER_SOURCE_DRIFT",
+            "Deterministic evidence does not match the active learner source",
+        )
+    if not isinstance(passed, bool):
+        raise BoundedCompletionError("INPUT_INVALID", "passed must be boolean")
+    _add_elapsed(updated, elapsed_time_ms)
+    updated["deterministic_verification"] = {
+        "learner_source_sha256": source,
+        "passed": passed,
+    }
+    if passed:
+        next_state = "SEMANTIC_REVIEW"
+    else:
+        next_state = "FINAL_DISPOSITION"
+        updated["terminal"] = True
+        updated["measurements"]["final_quality_disposition"] = "BLOCKED_DETERMINISTIC"
+    _transition(
+        updated,
+        contract,
+        to_state=next_state,
+        action="deterministic_verification_recorded",
+        details={"passed": passed, "learner_source_sha256": source},
+    )
+    validate_run(updated, contract_path=contract_path)
+    return updated
+
+
+def semantic_review_phase(
+    run: Mapping[str, Any],
+    *,
+    review_protocol_identity: Mapping[str, object],
+    learner_source_sha256: str,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> str:
+    """Fail-closed preflight to run before making a semantic model call."""
+
+    validate_run(run, contract_path=contract_path)
+    contract = load_contract(contract_path)
+    if len(run["reviews"]) >= contract["budgets"]["semantic_reviews_total"]:
+        raise BoundedCompletionError(
+            "SEMANTIC_REVIEW_BUDGET_EXHAUSTED",
+            "A third semantic review is forbidden",
+        )
+    _require_state(run, "SEMANTIC_REVIEW")
+    observed_protocol = _validate_protocol_identity(review_protocol_identity)
+    if observed_protocol != run["review_protocol_identity"]:
+        raise BoundedCompletionError(
+            "REVIEW_PROTOCOL_DRIFT",
+            "Active review tooling differs from the run-start identity",
+        )
+    source = _require_sha256(learner_source_sha256, "learner_source_sha256")
+    if source != run["learner_source_sha256"]:
+        raise BoundedCompletionError(
+            "LEARNER_SOURCE_DRIFT",
+            "Semantic review input differs from the active learner source",
+        )
+    verification = run["deterministic_verification"]
+    if verification is None or not verification["passed"] or verification["learner_source_sha256"] != source:
+        raise BoundedCompletionError(
+            "DETERMINISTIC_EVIDENCE_STALE",
+            "Current deterministic PASS is required before semantic review",
+        )
+    if not run["reviews"]:
+        if run["repairs"]:
+            raise BoundedCompletionError("RUN_INVARIANT", "Initial review cannot follow a repair")
+        return "INITIAL"
+    if len(run["reviews"]) == 1 and len(run["repairs"]) == 1:
+        return "FINAL"
+    raise BoundedCompletionError(
+        "RUN_INVARIANT",
+        "Final review requires exactly one initial review and one consolidated repair",
+    )
+
+
+def _normalize_dimension_scores(
+    scores: Mapping[str, object],
+    contract: Mapping[str, Any],
+) -> dict[str, float]:
+    dimensions = contract["publication_quality"]["dimensions"]
+    if set(scores) != set(dimensions):
+        raise BoundedCompletionError(
+            "QUALITY_DIMENSIONS_INVALID",
+            "Scores must cover exactly the canonical publication dimensions",
+        )
+    normalized: dict[str, float] = {}
+    for dimension in dimensions:
+        score = scores[dimension]
+        if isinstance(score, bool) or not isinstance(score, (int, float)) or not 0 <= score <= 10:
+            raise BoundedCompletionError(
+                "QUALITY_SCORE_INVALID",
+                f"{dimension} must be a number from 0 through 10",
+            )
+        normalized[dimension] = float(score)
+    return normalized
+
+
+def record_semantic_review(
+    run: Mapping[str, Any],
+    *,
+    review_protocol_identity: Mapping[str, object],
+    learner_source_sha256: str,
+    evidence_id: str,
+    reported_disposition: str,
+    dimension_scores: Mapping[str, object],
+    prompt_bytes: int,
+    schema_bytes: int,
+    elapsed_time_ms: int = 0,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> dict[str, Any]:
+    """Record one allowed semantic result and apply the 9.0 hard threshold."""
+
+    phase = semantic_review_phase(
+        run,
+        review_protocol_identity=review_protocol_identity,
+        learner_source_sha256=learner_source_sha256,
+        contract_path=contract_path,
+    )
+    updated, contract = _copy_run(run, contract_path)
+    if not isinstance(evidence_id, str) or not evidence_id.strip():
+        raise BoundedCompletionError("EVIDENCE_INVALID", "evidence_id is required")
+    if reported_disposition not in {"PASS", "REVISE", "BLOCK"}:
+        raise BoundedCompletionError("DISPOSITION_INVALID", "Unknown semantic disposition")
+    scores = _normalize_dimension_scores(dimension_scores, contract)
+    minimum = contract["publication_quality"]["minimum_per_dimension"]
+    threshold_failures = [
+        dimension for dimension in contract["publication_quality"]["dimensions"] if scores[dimension] < minimum
+    ]
+    contract_disposition = "BLOCK" if reported_disposition == "PASS" and threshold_failures else reported_disposition
+    prompt_size = _require_nonnegative_int(prompt_bytes, "prompt_bytes")
+    schema_size = _require_nonnegative_int(schema_bytes, "schema_bytes")
+    _add_elapsed(updated, elapsed_time_ms)
+    updated["measurements"]["model_call_count"] += 1
+    updated["measurements"]["prompt_bytes"] += prompt_size
+    updated["measurements"]["schema_bytes"] += schema_size
+    updated["reviews"].append(
+        {
+            "phase": phase,
+            "evidence_id": evidence_id,
+            "review_protocol_identity_sha256": updated["review_protocol_identity"]["identity_sha256"],
+            "learner_source_sha256": learner_source_sha256,
+            "reported_disposition": reported_disposition,
+            "contract_disposition": contract_disposition,
+            "dimension_scores": scores,
+            "threshold_failures": threshold_failures,
+            "valid": True,
+            "invalidated_reason": None,
+        }
+    )
+
+    if contract_disposition == "PASS":
+        updated["measurements"]["final_quality_disposition"] = "PUBLISHABLE"
+        next_state = "FINAL_DISPOSITION"
+    elif phase == "INITIAL":
+        next_state = "CONSOLIDATED_REPAIR"
+    else:
+        updated["measurements"]["final_quality_disposition"] = contract["budget_exhaustion"]["disposition"]
+        updated["terminal"] = True
+        next_state = "FINAL_DISPOSITION"
+    _transition(
+        updated,
+        contract,
+        to_state=next_state,
+        action="semantic_review_recorded",
+        details={
+            "phase": phase,
+            "evidence_id": evidence_id,
+            "reported_disposition": reported_disposition,
+            "contract_disposition": contract_disposition,
+            "threshold_failures": threshold_failures,
+        },
+    )
+    validate_run(updated, contract_path=contract_path)
+    return updated
+
+
+def record_consolidated_repair(
+    run: Mapping[str, Any],
+    *,
+    learner_source_sha256: str,
+    elapsed_time_ms: int = 0,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> dict[str, Any]:
+    """Record the only allowed learner repair and invalidate old evidence."""
+
+    updated, contract = _copy_run(run, contract_path)
+    if len(updated["repairs"]) >= contract["budgets"]["consolidated_repairs"]:
+        raise BoundedCompletionError(
+            "REPAIR_BUDGET_EXHAUSTED",
+            "A second consolidated learner repair is forbidden",
+        )
+    _require_state(updated, "CONSOLIDATED_REPAIR")
+    previous_source = updated["learner_source_sha256"]
+    if previous_source is None:
+        raise BoundedCompletionError("IDENTITY_INVALID", "Repair requires an existing learner source")
+    new_source = _require_sha256(learner_source_sha256, "learner_source_sha256")
+    if new_source == previous_source:
+        raise BoundedCompletionError(
+            "NON_MATERIAL_REPAIR",
+            "A consolidated learner repair must change the learner-source identity",
+        )
+    invalidated: list[str] = []
+    for review in updated["reviews"]:
+        if review["valid"]:
+            review["valid"] = False
+            review["invalidated_reason"] = "LEARNER_SOURCE_CHANGED"
+            invalidated.append(review["evidence_id"])
+    if not invalidated:
+        raise BoundedCompletionError("RUN_INVARIANT", "Repair must invalidate prior review evidence")
+    updated["repairs"].append(
+        {
+            "source_before_sha256": previous_source,
+            "source_after_sha256": new_source,
+            "invalidated_evidence_ids": invalidated,
+        }
+    )
+    updated["learner_source_sha256"] = new_source
+    updated["deterministic_verification"] = None
+    updated["measurements"]["repair_count"] += 1
+    _add_elapsed(updated, elapsed_time_ms)
+    _transition(
+        updated,
+        contract,
+        to_state="DETERMINISTIC_VERIFICATION",
+        action="consolidated_repair_recorded",
+        details={
+            "source_before_sha256": previous_source,
+            "source_after_sha256": new_source,
+            "invalidated_evidence_ids": invalidated,
+        },
+    )
+    validate_run(updated, contract_path=contract_path)
+    return updated
+
+
+def record_publication(
+    run: Mapping[str, Any],
+    *,
+    reference: str,
+    elapsed_time_ms: int = 0,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> dict[str, Any]:
+    """Record publication only after a current publishable disposition."""
+
+    updated, contract = _copy_run(run, contract_path)
+    _require_state(updated, "FINAL_DISPOSITION")
+    if updated["terminal"] or updated["measurements"]["final_quality_disposition"] != "PUBLISHABLE":
+        raise BoundedCompletionError(
+            "PUBLICATION_BLOCKED",
+            "Only a non-terminal PUBLISHABLE disposition may publish",
+        )
+    if not isinstance(reference, str) or not reference.strip():
+        raise BoundedCompletionError("PUBLICATION_INVALID", "Publication reference is required")
+    source = updated["learner_source_sha256"]
+    if source is None:
+        raise BoundedCompletionError("IDENTITY_INVALID", "Publication requires a learner source")
+    _add_elapsed(updated, elapsed_time_ms)
+    updated["publication"] = {
+        "reference": reference,
+        "learner_source_sha256": source,
+    }
+    updated["terminal"] = True
+    _transition(
+        updated,
+        contract,
+        to_state="PUBLICATION",
+        action="publication_recorded",
+        details={"reference": reference, "learner_source_sha256": source},
+    )
+    validate_run(updated, contract_path=contract_path)
+    return updated
+
+
+def _fixture_protocol(
+    run: Mapping[str, Any],
+    override: Mapping[str, object] | None,
+) -> dict[str, str]:
+    fields = {field: run["review_protocol_identity"][field] for field in _PROTOCOL_FIELDS}
+    if override:
+        fields.update(override)
+    return make_review_protocol_identity(**fields)  # type: ignore[arg-type]
+
+
+def replay_fixture(
+    fixture: Path | Mapping[str, Any],
+    *,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> dict[str, Any]:
+    """Execute one deterministic regression fixture with fail-closed assertions."""
+
+    value = read_json(fixture) if isinstance(fixture, Path) else deepcopy(dict(fixture))
+    if value.get("fixture_version") != "bounded-completion.fixture.v1":
+        raise BoundedCompletionError("FIXTURE_INVALID", "Unknown fixture version")
+    start = value.get("start")
+    steps = value.get("steps")
+    if not isinstance(start, dict) or not isinstance(steps, list):
+        raise BoundedCompletionError("FIXTURE_INVALID", "Fixture requires start and steps")
+    protocol_data = start.get("review_protocol")
+    if not isinstance(protocol_data, dict):
+        raise BoundedCompletionError("FIXTURE_INVALID", "Fixture review_protocol must be an object")
+    run = start_run(
+        target=start["target"],
+        run_id=start["run_id"],
+        review_protocol_identity=make_review_protocol_identity(**protocol_data),
+        learner_source_sha256=start.get("learner_source_sha256"),
+        contract_path=contract_path,
+    )
+    expected_errors: list[dict[str, Any]] = []
+    for sequence, raw_step in enumerate(steps, start=1):
+        if not isinstance(raw_step, dict):
+            raise BoundedCompletionError("FIXTURE_INVALID", f"Step {sequence} must be an object")
+        step = deepcopy(raw_step)
+        action = step.pop("action", None)
+        expected_error = step.pop("expect_error", None)
+        protocol_override = step.pop("review_protocol_override", None)
+        before = deepcopy(run)
+        try:
+            if action == "complete_inspection":
+                candidate = complete_inspection(run, contract_path=contract_path, **step)
+            elif action == "complete_build":
+                candidate = complete_build(run, contract_path=contract_path, **step)
+            elif action == "record_deterministic_verification":
+                candidate = record_deterministic_verification(run, contract_path=contract_path, **step)
+            elif action == "record_semantic_review":
+                candidate = record_semantic_review(
+                    run,
+                    review_protocol_identity=_fixture_protocol(run, protocol_override),
+                    contract_path=contract_path,
+                    **step,
+                )
+            elif action == "record_consolidated_repair":
+                candidate = record_consolidated_repair(run, contract_path=contract_path, **step)
+            elif action == "record_publication":
+                candidate = record_publication(run, contract_path=contract_path, **step)
+            else:
+                raise BoundedCompletionError("FIXTURE_INVALID", f"Unknown fixture action: {action}")
+        except BoundedCompletionError as exc:
+            if exc.code != expected_error:
+                raise
+            if run != before:
+                raise BoundedCompletionError(
+                    "FAIL_CLOSED_MUTATION",
+                    f"Rejected fixture step {sequence} mutated the active run",
+                ) from exc
+            expected_errors.append({"step": sequence, "code": exc.code, "unchanged": True})
+            continue
+        if expected_error is not None:
+            raise BoundedCompletionError(
+                "FIXTURE_EXPECTATION_FAILED",
+                f"Step {sequence} expected {expected_error} but succeeded",
+            )
+        run = candidate
+    validate_run(run, contract_path=contract_path)
+    return {"run": run, "expected_errors": expected_errors}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("validate-contract", help="validate the canonical contract and schemas")
+    replay = subparsers.add_parser("replay", help="execute one deterministic JSON fixture")
+    replay.add_argument("fixture", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for contract validation and fixture replay."""
+
+    args = _build_parser().parse_args(argv)
+    if args.command == "validate-contract":
+        contract = load_contract()
+        Draft202012Validator.check_schema(read_json(RUN_SCHEMA_PATH))
+        print(
+            json.dumps(
+                {
+                    "status": "PASS",
+                    "contract_version": contract["contract_version"],
+                    "run_schema_version": contract["run_schema_version"],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    result = replay_fixture(args.fixture)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/bounded_completion/budget-exhaustion.json
+++ b/tests/fixtures/bounded_completion/budget-exhaustion.json
@@ -90,6 +90,12 @@
       "learner_source_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
       "elapsed_time_ms": 1,
       "expect_error": "REPAIR_BUDGET_EXHAUSTED"
+    },
+    {
+      "action": "record_publication",
+      "reference": "forbidden-budget-publication",
+      "elapsed_time_ms": 1,
+      "expect_error": "PUBLICATION_BLOCKED"
     }
   ]
 }

--- a/tests/fixtures/bounded_completion/budget-exhaustion.json
+++ b/tests/fixtures/bounded_completion/budget-exhaustion.json
@@ -1,0 +1,95 @@
+{
+  "fixture_version": "bounded-completion.fixture.v1",
+  "start": {
+    "target": "bio/budget-exhaustion",
+    "run_id": "22222222222222222222222222222222",
+    "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "review_protocol": {
+      "protocol_version": "5.0.0",
+      "tool_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "prompt_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "schema_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+      "reviewer_family": "fixture-family",
+      "reviewer_model": "fixture-model"
+    }
+  },
+  "steps": [
+    {
+      "action": "complete_inspection",
+      "needs_build": false,
+      "elapsed_time_ms": 4
+    },
+    {
+      "action": "record_deterministic_verification",
+      "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "passed": true,
+      "elapsed_time_ms": 6
+    },
+    {
+      "action": "record_semantic_review",
+      "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "evidence_id": "initial-review",
+      "reported_disposition": "REVISE",
+      "dimension_scores": {
+        "engagement": 8.0,
+        "pedagogical": 8.1,
+        "naturalness": 8.2,
+        "decolonization": 9.0,
+        "tone": 8.5
+      },
+      "prompt_bytes": 1000,
+      "schema_bytes": 350,
+      "elapsed_time_ms": 10
+    },
+    {
+      "action": "record_consolidated_repair",
+      "learner_source_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "elapsed_time_ms": 12
+    },
+    {
+      "action": "record_deterministic_verification",
+      "learner_source_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "passed": true,
+      "elapsed_time_ms": 6
+    },
+    {
+      "action": "record_semantic_review",
+      "learner_source_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "evidence_id": "final-review",
+      "reported_disposition": "REVISE",
+      "dimension_scores": {
+        "engagement": 8.8,
+        "pedagogical": 8.9,
+        "naturalness": 8.7,
+        "decolonization": 9.2,
+        "tone": 8.9
+      },
+      "prompt_bytes": 1100,
+      "schema_bytes": 350,
+      "elapsed_time_ms": 10
+    },
+    {
+      "action": "record_semantic_review",
+      "learner_source_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "evidence_id": "forbidden-third-review",
+      "reported_disposition": "PASS",
+      "dimension_scores": {
+        "engagement": 10.0,
+        "pedagogical": 10.0,
+        "naturalness": 10.0,
+        "decolonization": 10.0,
+        "tone": 10.0
+      },
+      "prompt_bytes": 1,
+      "schema_bytes": 1,
+      "elapsed_time_ms": 1,
+      "expect_error": "SEMANTIC_REVIEW_BUDGET_EXHAUSTED"
+    },
+    {
+      "action": "record_consolidated_repair",
+      "learner_source_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "elapsed_time_ms": 1,
+      "expect_error": "REPAIR_BUDGET_EXHAUSTED"
+    }
+  ]
+}

--- a/tests/fixtures/bounded_completion/protocol-drift.json
+++ b/tests/fixtures/bounded_completion/protocol-drift.json
@@ -1,0 +1,49 @@
+{
+  "fixture_version": "bounded-completion.fixture.v1",
+  "start": {
+    "target": "bio/protocol-drift",
+    "run_id": "33333333333333333333333333333333",
+    "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "review_protocol": {
+      "protocol_version": "5.0.0",
+      "tool_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "prompt_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "schema_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+      "reviewer_family": "fixture-family",
+      "reviewer_model": "fixture-model"
+    }
+  },
+  "steps": [
+    {
+      "action": "complete_inspection",
+      "needs_build": false,
+      "elapsed_time_ms": 2
+    },
+    {
+      "action": "record_deterministic_verification",
+      "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "passed": true,
+      "elapsed_time_ms": 3
+    },
+    {
+      "action": "record_semantic_review",
+      "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "evidence_id": "drifted-review",
+      "reported_disposition": "PASS",
+      "dimension_scores": {
+        "engagement": 10.0,
+        "pedagogical": 10.0,
+        "naturalness": 10.0,
+        "decolonization": 10.0,
+        "tone": 10.0
+      },
+      "prompt_bytes": 999,
+      "schema_bytes": 999,
+      "elapsed_time_ms": 99,
+      "review_protocol_override": {
+        "prompt_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      "expect_error": "REVIEW_PROTOCOL_DRIFT"
+    }
+  ]
+}

--- a/tests/fixtures/bounded_completion/quality-floor.json
+++ b/tests/fixtures/bounded_completion/quality-floor.json
@@ -1,0 +1,45 @@
+{
+  "fixture_version": "bounded-completion.fixture.v1",
+  "start": {
+    "target": "bio/quality-floor",
+    "run_id": "44444444444444444444444444444444",
+    "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "review_protocol": {
+      "protocol_version": "5.0.0",
+      "tool_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "prompt_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "schema_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+      "reviewer_family": "fixture-family",
+      "reviewer_model": "fixture-model"
+    }
+  },
+  "steps": [
+    {
+      "action": "complete_inspection",
+      "needs_build": false,
+      "elapsed_time_ms": 1
+    },
+    {
+      "action": "record_deterministic_verification",
+      "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "passed": true,
+      "elapsed_time_ms": 1
+    },
+    {
+      "action": "record_semantic_review",
+      "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "evidence_id": "below-floor-pass",
+      "reported_disposition": "PASS",
+      "dimension_scores": {
+        "engagement": 9.0,
+        "pedagogical": 9.0,
+        "naturalness": 9.0,
+        "decolonization": 9.0,
+        "tone": 8.99
+      },
+      "prompt_bytes": 100,
+      "schema_bytes": 50,
+      "elapsed_time_ms": 2
+    }
+  ]
+}

--- a/tests/fixtures/bounded_completion/success.json
+++ b/tests/fixtures/bounded_completion/success.json
@@ -1,0 +1,77 @@
+{
+  "fixture_version": "bounded-completion.fixture.v1",
+  "start": {
+    "target": "bio/bounded-success",
+    "run_id": "11111111111111111111111111111111",
+    "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "review_protocol": {
+      "protocol_version": "5.0.0",
+      "tool_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "prompt_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "schema_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+      "reviewer_family": "fixture-family",
+      "reviewer_model": "fixture-model"
+    }
+  },
+  "steps": [
+    {
+      "action": "complete_inspection",
+      "needs_build": false,
+      "elapsed_time_ms": 5
+    },
+    {
+      "action": "record_deterministic_verification",
+      "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "passed": true,
+      "elapsed_time_ms": 7
+    },
+    {
+      "action": "record_semantic_review",
+      "learner_source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "evidence_id": "initial-review",
+      "reported_disposition": "REVISE",
+      "dimension_scores": {
+        "engagement": 8.5,
+        "pedagogical": 8.5,
+        "naturalness": 8.5,
+        "decolonization": 9.2,
+        "tone": 9.0
+      },
+      "prompt_bytes": 1200,
+      "schema_bytes": 400,
+      "elapsed_time_ms": 20
+    },
+    {
+      "action": "record_consolidated_repair",
+      "learner_source_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "elapsed_time_ms": 30
+    },
+    {
+      "action": "record_deterministic_verification",
+      "learner_source_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "passed": true,
+      "elapsed_time_ms": 8
+    },
+    {
+      "action": "record_semantic_review",
+      "learner_source_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "evidence_id": "final-review",
+      "reported_disposition": "PASS",
+      "dimension_scores": {
+        "engagement": 9.1,
+        "pedagogical": 9.3,
+        "naturalness": 9.2,
+        "decolonization": 9.4,
+        "tone": 9.0
+      },
+      "prompt_bytes": 1300,
+      "schema_bytes": 400,
+      "elapsed_time_ms": 22
+    },
+    {
+      "action": "record_publication",
+      "reference": "fixture-publication",
+      "elapsed_time_ms": 6
+    }
+  ]
+}

--- a/tests/test_bounded_completion_contract.py
+++ b/tests/test_bounded_completion_contract.py
@@ -1,0 +1,269 @@
+"""Executable contract tests for the issue #5452 bounded completion slice."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_ROOT = ROOT / "agents_extensions" / "shared" / "skills" / "track-completion"
+SCRIPT = SKILL_ROOT / "scripts" / "bounded_completion.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "bounded_completion"
+SPEC = importlib.util.spec_from_file_location("bounded_completion_for_tests", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+bc = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = bc
+SPEC.loader.exec_module(bc)
+
+SOURCE_A = "a" * 64
+SOURCE_B = "b" * 64
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    return bc.replay_fixture(FIXTURES / name)["run"]
+
+
+def _protocol() -> dict[str, str]:
+    return bc.make_review_protocol_identity(
+        protocol_version="5.0.0",
+        tool_sha256="1" * 64,
+        prompt_sha256="2" * 64,
+        schema_sha256="3" * 64,
+        reviewer_family="fixture-family",
+        reviewer_model="fixture-model",
+    )
+
+
+def test_canonical_contract_pins_states_budgets_quality_and_measurements() -> None:
+    contract = bc.load_contract()
+
+    assert contract["contract_version"] == "1.0.0"
+    assert contract["states"] == [
+        "INSPECT",
+        "BUILD_REBUILD",
+        "DETERMINISTIC_VERIFICATION",
+        "SEMANTIC_REVIEW",
+        "CONSOLIDATED_REPAIR",
+        "FINAL_DISPOSITION",
+        "PUBLICATION",
+    ]
+    assert contract["budgets"] == {
+        "initial_semantic_reviews": 1,
+        "consolidated_repairs": 1,
+        "final_semantic_reviews": 1,
+        "semantic_reviews_total": 2,
+    }
+    assert contract["review_protocol_freeze"] == {
+        "pin_at_run_start": True,
+        "drift_policy": "REJECT_WITHOUT_MUTATION",
+    }
+    assert contract["publication_quality"] == {
+        "minimum_per_dimension": 9.0,
+        "dimensions": [
+            "engagement",
+            "pedagogical",
+            "naturalness",
+            "decolonization",
+            "tone",
+        ],
+        "aggregate_override_allowed": False,
+        "threshold_lowering_allowed": False,
+    }
+    assert contract["measurement_fields"] == [
+        "elapsed_time_ms",
+        "model_call_count",
+        "repair_count",
+        "prompt_bytes",
+        "schema_bytes",
+        "final_quality_disposition",
+    ]
+
+
+def test_contract_schema_rejects_threshold_lowering() -> None:
+    contract = bc.load_contract()
+    schema = json.loads(bc.CONTRACT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    lowered = deepcopy(contract)
+    lowered["publication_quality"]["minimum_per_dimension"] = 8.99
+
+    errors = list(Draft202012Validator(schema).iter_errors(lowered))
+
+    assert errors
+    assert any("9.0 was expected" in error.message for error in errors)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "success.json",
+        "budget-exhaustion.json",
+        "protocol-drift.json",
+        "quality-floor.json",
+    ],
+)
+def test_every_regression_fixture_replays_to_a_schema_valid_run(
+    fixture_name: str,
+) -> None:
+    result = bc.replay_fixture(FIXTURES / fixture_name)
+
+    bc.validate_run(result["run"])
+
+
+def test_success_fixture_covers_measurements_and_publication() -> None:
+    run = _fixture("success.json")
+
+    assert run["state"] == "PUBLICATION"
+    assert run["terminal"] is True
+    assert run["measurements"] == {
+        "elapsed_time_ms": 98,
+        "model_call_count": 2,
+        "repair_count": 1,
+        "prompt_bytes": 2500,
+        "schema_bytes": 800,
+        "final_quality_disposition": "PUBLISHABLE",
+    }
+    assert run["publication"] == {
+        "reference": "fixture-publication",
+        "learner_source_sha256": SOURCE_B,
+    }
+
+
+def test_material_learner_repair_invalidates_prior_review_evidence() -> None:
+    run = _fixture("success.json")
+    initial, final = run["reviews"]
+
+    assert initial["learner_source_sha256"] == SOURCE_A
+    assert initial["valid"] is False
+    assert initial["invalidated_reason"] == "LEARNER_SOURCE_CHANGED"
+    assert final["learner_source_sha256"] == SOURCE_B
+    assert final["valid"] is True
+    assert final["invalidated_reason"] is None
+    assert run["repairs"] == [
+        {
+            "source_before_sha256": SOURCE_A,
+            "source_after_sha256": SOURCE_B,
+            "invalidated_evidence_ids": ["initial-review"],
+        }
+    ]
+
+
+def test_third_review_and_second_repair_fail_closed_after_terminal_stop() -> None:
+    result = bc.replay_fixture(FIXTURES / "budget-exhaustion.json")
+    run = result["run"]
+
+    assert result["expected_errors"] == [
+        {
+            "step": 7,
+            "code": "SEMANTIC_REVIEW_BUDGET_EXHAUSTED",
+            "unchanged": True,
+        },
+        {
+            "step": 8,
+            "code": "REPAIR_BUDGET_EXHAUSTED",
+            "unchanged": True,
+        },
+    ]
+    assert run["state"] == "FINAL_DISPOSITION"
+    assert run["terminal"] is True
+    assert run["measurements"] == {
+        "elapsed_time_ms": 48,
+        "model_call_count": 2,
+        "repair_count": 1,
+        "prompt_bytes": 2100,
+        "schema_bytes": 700,
+        "final_quality_disposition": "BLOCKED_BUDGET_EXHAUSTED",
+    }
+    assert len(run["reviews"]) == 2
+    assert len(run["repairs"]) == 1
+    assert run["publication"] is None
+
+
+def test_protocol_drift_rejection_does_not_reopen_or_mutate_active_run() -> None:
+    result = bc.replay_fixture(FIXTURES / "protocol-drift.json")
+    run = result["run"]
+
+    assert result["expected_errors"] == [{"step": 3, "code": "REVIEW_PROTOCOL_DRIFT", "unchanged": True}]
+    assert run["state"] == "SEMANTIC_REVIEW"
+    assert run["terminal"] is False
+    assert run["reviews"] == []
+    assert run["measurements"] == {
+        "elapsed_time_ms": 5,
+        "model_call_count": 0,
+        "repair_count": 0,
+        "prompt_bytes": 0,
+        "schema_bytes": 0,
+        "final_quality_disposition": "PENDING",
+    }
+
+
+def test_reported_pass_below_any_9_point_dimension_fails_closed() -> None:
+    run = _fixture("quality-floor.json")
+    review = run["reviews"][0]
+
+    assert review["reported_disposition"] == "PASS"
+    assert review["contract_disposition"] == "BLOCK"
+    assert review["threshold_failures"] == ["tone"]
+    assert run["state"] == "CONSOLIDATED_REPAIR"
+    assert run["measurements"]["final_quality_disposition"] == "PENDING"
+    assert run["publication"] is None
+
+
+def test_build_rebuild_path_rejoins_deterministic_verification() -> None:
+    run = bc.start_run(
+        target="bio/unbuilt-fixture",
+        run_id="5" * 32,
+        review_protocol_identity=_protocol(),
+        learner_source_sha256=None,
+    )
+
+    run = bc.complete_inspection(run, needs_build=True, elapsed_time_ms=2)
+    assert run["state"] == "BUILD_REBUILD"
+
+    run = bc.complete_build(
+        run,
+        learner_source_sha256=SOURCE_A,
+        elapsed_time_ms=3,
+    )
+    assert run["state"] == "DETERMINISTIC_VERIFICATION"
+    assert run["learner_source_sha256"] == SOURCE_A
+    assert run["measurements"]["elapsed_time_ms"] == 5
+
+
+def test_deterministic_failure_is_a_terminal_non_publication_disposition() -> None:
+    run = bc.start_run(
+        target="bio/deterministic-block",
+        run_id="6" * 32,
+        review_protocol_identity=_protocol(),
+        learner_source_sha256=SOURCE_A,
+    )
+    run = bc.complete_inspection(run, needs_build=False)
+    run = bc.record_deterministic_verification(
+        run,
+        learner_source_sha256=SOURCE_A,
+        passed=False,
+    )
+
+    assert run["state"] == "FINAL_DISPOSITION"
+    assert run["terminal"] is True
+    assert run["measurements"]["final_quality_disposition"] == "BLOCKED_DETERMINISTIC"
+    assert run["measurements"]["model_call_count"] == 0
+    assert run["publication"] is None
+
+
+def test_tampered_protocol_identity_is_rejected_at_run_start() -> None:
+    protocol = _protocol()
+    protocol["identity_sha256"] = "f" * 64
+
+    with pytest.raises(bc.BoundedCompletionError, match="PROTOCOL_IDENTITY_INVALID"):
+        bc.start_run(
+            target="bio/tampered-protocol",
+            run_id="7" * 32,
+            review_protocol_identity=protocol,
+            learner_source_sha256=SOURCE_A,
+        )

--- a/tests/test_bounded_completion_contract.py
+++ b/tests/test_bounded_completion_contract.py
@@ -41,6 +41,21 @@ def _protocol() -> dict[str, str]:
     )
 
 
+def _semantic_review_ready_run() -> dict[str, Any]:
+    run = bc.start_run(
+        target="bio/semantic-ready",
+        run_id="8" * 32,
+        review_protocol_identity=_protocol(),
+        learner_source_sha256=SOURCE_A,
+    )
+    run = bc.complete_inspection(run, needs_build=False)
+    return bc.record_deterministic_verification(
+        run,
+        learner_source_sha256=SOURCE_A,
+        passed=True,
+    )
+
+
 def test_canonical_contract_pins_states_budgets_quality_and_measurements() -> None:
     contract = bc.load_contract()
 
@@ -153,7 +168,7 @@ def test_material_learner_repair_invalidates_prior_review_evidence() -> None:
     ]
 
 
-def test_third_review_and_second_repair_fail_closed_after_terminal_stop() -> None:
+def test_budget_exhaustion_rejects_review_repair_and_publication_without_mutation() -> None:
     result = bc.replay_fixture(FIXTURES / "budget-exhaustion.json")
     run = result["run"]
 
@@ -166,6 +181,11 @@ def test_third_review_and_second_repair_fail_closed_after_terminal_stop() -> Non
         {
             "step": 8,
             "code": "REPAIR_BUDGET_EXHAUSTED",
+            "unchanged": True,
+        },
+        {
+            "step": 9,
+            "code": "PUBLICATION_BLOCKED",
             "unchanged": True,
         },
     ]
@@ -254,6 +274,105 @@ def test_deterministic_failure_is_a_terminal_non_publication_disposition() -> No
     assert run["measurements"]["final_quality_disposition"] == "BLOCKED_DETERMINISTIC"
     assert run["measurements"]["model_call_count"] == 0
     assert run["publication"] is None
+
+    before = deepcopy(run)
+    with pytest.raises(bc.BoundedCompletionError, match="PUBLICATION_BLOCKED"):
+        bc.record_publication(run, reference="forbidden-deterministic-publication")
+    assert run == before
+
+
+@pytest.mark.parametrize(
+    ("state", "terminal", "publication"),
+    [
+        ("FINAL_DISPOSITION", False, None),
+        (
+            "PUBLICATION",
+            True,
+            {
+                "reference": "forged-publication",
+                "learner_source_sha256": SOURCE_A,
+            },
+        ),
+    ],
+)
+def test_forged_publishable_run_without_current_review_evidence_is_rejected(
+    state: str,
+    terminal: bool,
+    publication: dict[str, str] | None,
+) -> None:
+    forged = bc.start_run(
+        target="bio/forged-publishable",
+        run_id="9" * 32,
+        review_protocol_identity=_protocol(),
+        learner_source_sha256=SOURCE_A,
+    )
+    forged["state"] = state
+    forged["terminal"] = terminal
+    forged["publication"] = publication
+    forged["measurements"]["final_quality_disposition"] = "PUBLISHABLE"
+    before = deepcopy(forged)
+
+    with pytest.raises(bc.BoundedCompletionError, match="RUN_INVARIANT"):
+        bc.validate_run(forged)
+    with pytest.raises(bc.BoundedCompletionError, match="RUN_INVARIANT"):
+        bc.record_publication(forged, reference="forged-publication-attempt")
+    assert forged == before
+
+
+def test_terminal_semantic_review_run_rejects_further_action_without_mutation() -> None:
+    forged = _semantic_review_ready_run()
+    forged["terminal"] = True
+    before = deepcopy(forged)
+
+    with pytest.raises(bc.BoundedCompletionError, match="RUN_INVARIANT"):
+        bc.record_semantic_review(
+            forged,
+            review_protocol_identity=_protocol(),
+            learner_source_sha256=SOURCE_A,
+            evidence_id="forbidden-terminal-review",
+            reported_disposition="PASS",
+            dimension_scores={
+                "engagement": 9.0,
+                "pedagogical": 9.0,
+                "naturalness": 9.0,
+                "decolonization": 9.0,
+                "tone": 9.0,
+            },
+            prompt_bytes=1,
+            schema_bytes=1,
+        )
+    assert forged == before
+
+
+def test_terminal_final_disposition_cannot_remain_pending() -> None:
+    forged = bc.start_run(
+        target="bio/terminal-pending",
+        run_id="a" * 32,
+        review_protocol_identity=_protocol(),
+        learner_source_sha256=SOURCE_A,
+    )
+    forged["state"] = "FINAL_DISPOSITION"
+    forged["terminal"] = True
+    before = deepcopy(forged)
+
+    with pytest.raises(bc.BoundedCompletionError, match="RUN_INVARIANT"):
+        bc.validate_run(forged)
+    assert forged == before
+
+
+@pytest.mark.parametrize("protocol_version", ["5", "5.0", "v5.0.0", "5.0.0.1"])
+def test_malformed_semantic_protocol_version_is_rejected_at_identity_boundary(
+    protocol_version: str,
+) -> None:
+    with pytest.raises(bc.BoundedCompletionError, match="PROTOCOL_IDENTITY_INVALID"):
+        bc.make_review_protocol_identity(
+            protocol_version=protocol_version,
+            tool_sha256="1" * 64,
+            prompt_sha256="2" * 64,
+            schema_sha256="3" * 64,
+            reviewer_family="fixture-family",
+            reviewer_model="fixture-model",
+        )
 
 
 def test_tampered_protocol_identity_is_rejected_at_run_start() -> None:


### PR DESCRIPTION
## Summary

- add the versioned canonical `bounded-completion.v1` contract and strict contract/run schemas
- add a pure, copy-on-write helper with deterministic fixture replay and no provider transport
- pin review protocol identity at run start; enforce one initial review, one repair, and one final review
- invalidate stale review evidence on material learner-source repair and preserve the 9.0 per-dimension publication floor
- document the standalone boundary; production lifecycle integration remains assigned to #5453

## Acceptance evidence

- canonical states cover inspect, build/rebuild, deterministic verification, semantic review, consolidated repair, final disposition, and publication
- `budget-exhaustion.json` proves a third semantic review and second repair are rejected without mutation, after terminal `BLOCKED_BUDGET_EXHAUSTED`
- `protocol-drift.json` proves review-tooling drift is rejected without reopening or mutating the active run
- `success.json` proves material learner-source repair invalidates prior review evidence before the final review
- `quality-floor.json` proves a reported PASS at 8.99 in any dimension is contract-classified as BLOCK
- measurements cover elapsed time, model-call count, repair count, prompt bytes, schema bytes, and final quality disposition
- no curriculum, generated artifact, protected config, provider transport, or production `track_completion.py` change is present
- no semantic/provider call was triggered by implementation or tests

## Validation

- `.venv/bin/python -m pytest tests/test_bounded_completion_contract.py -q` — 14 passed
- `.venv/bin/ruff check agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py tests/test_bounded_completion_contract.py` — passed
- `.venv/bin/ruff format --check agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py tests/test_bounded_completion_contract.py` — passed
- `.venv/bin/python agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py validate-contract` — PASS
- all four deterministic JSON fixtures replayed successfully
- Markdown lint and JSON parse checks passed
- `git diff --check origin/main...HEAD` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- protected-config, forbidden-artifact, learner-file, owned-path, test-weakening, and `<20` file-count audits passed

Closes #5452