### PR TITLE
ci(bio): route preparation data to focused gate

### DIFF
--- a/.github/actions/paths-filter-retry/action.yml
+++ b/.github/actions/paths-filter-retry/action.yml
@@ -35,6 +35,9 @@ outputs:
   postmortems:
     description: 'Whether postmortems files changed'
     value: ${{ steps.set-outputs.outputs.postmortems }}
+  preparation:
+    description: 'Whether BIO preparation data changed'
+    value: ${{ steps.set-outputs.outputs.preparation }}
 
 runs:
   using: 'composite'
@@ -90,6 +93,7 @@ runs:
         F1_LESSON_SCHEMA: ${{ steps.filter1.outputs.lesson_schema }}
         F1_ATLAS: ${{ steps.filter1.outputs.atlas }}
         F1_POSTMORTEMS: ${{ steps.filter1.outputs.postmortems }}
+        F1_PREPARATION: ${{ steps.filter1.outputs.preparation }}
         F2_CONTENT: ${{ steps.filter2.outputs.content }}
         F2_FRAMING: ${{ steps.filter2.outputs.framing }}
         F2_PROMOTE: ${{ steps.filter2.outputs.promote }}
@@ -100,6 +104,7 @@ runs:
         F2_LESSON_SCHEMA: ${{ steps.filter2.outputs.lesson_schema }}
         F2_ATLAS: ${{ steps.filter2.outputs.atlas }}
         F2_POSTMORTEMS: ${{ steps.filter2.outputs.postmortems }}
+        F2_PREPARATION: ${{ steps.filter2.outputs.preparation }}
         F3_CONTENT: ${{ steps.filter3.outputs.content }}
         F3_FRAMING: ${{ steps.filter3.outputs.framing }}
         F3_PROMOTE: ${{ steps.filter3.outputs.promote }}
@@ -110,6 +115,7 @@ runs:
         F3_LESSON_SCHEMA: ${{ steps.filter3.outputs.lesson_schema }}
         F3_ATLAS: ${{ steps.filter3.outputs.atlas }}
         F3_POSTMORTEMS: ${{ steps.filter3.outputs.postmortems }}
+        F3_PREPARATION: ${{ steps.filter3.outputs.preparation }}
       run: |
         emit() {
           {
@@ -123,19 +129,23 @@ runs:
             echo "lesson_schema=$8"
             echo "atlas=$9"
             echo "postmortems=${10}"
+            echo "preparation=${11}"
           } >> "$GITHUB_OUTPUT"
         }
         if [ "$FILTER1_OUTCOME" = "success" ]; then
           emit "$F1_CONTENT" "$F1_FRAMING" "$F1_PROMOTE" "$F1_CODE" "$F1_PYTHON" \
-            "$F1_FRONTEND" "$F1_AGENT_CONFIG" "$F1_LESSON_SCHEMA" "$F1_ATLAS" "$F1_POSTMORTEMS"
+            "$F1_FRONTEND" "$F1_AGENT_CONFIG" "$F1_LESSON_SCHEMA" "$F1_ATLAS" "$F1_POSTMORTEMS" \
+            "$F1_PREPARATION"
         elif [ "$FILTER2_OUTCOME" = "success" ]; then
           emit "$F2_CONTENT" "$F2_FRAMING" "$F2_PROMOTE" "$F2_CODE" "$F2_PYTHON" \
-            "$F2_FRONTEND" "$F2_AGENT_CONFIG" "$F2_LESSON_SCHEMA" "$F2_ATLAS" "$F2_POSTMORTEMS"
+            "$F2_FRONTEND" "$F2_AGENT_CONFIG" "$F2_LESSON_SCHEMA" "$F2_ATLAS" "$F2_POSTMORTEMS" \
+            "$F2_PREPARATION"
         elif [ "$FILTER3_OUTCOME" = "success" ]; then
           emit "$F3_CONTENT" "$F3_FRAMING" "$F3_PROMOTE" "$F3_CODE" "$F3_PYTHON" \
-            "$F3_FRONTEND" "$F3_AGENT_CONFIG" "$F3_LESSON_SCHEMA" "$F3_ATLAS" "$F3_POSTMORTEMS"
+            "$F3_FRONTEND" "$F3_AGENT_CONFIG" "$F3_LESSON_SCHEMA" "$F3_ATLAS" "$F3_POSTMORTEMS" \
+            "$F3_PREPARATION"
         else
           echo "::warning::path classification unavailable — running everything"
-          emit true true true true true true true true true true
+          emit true true true true true true true true true true true
         fi
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,13 +299,29 @@ jobs:
               ).strip()
           changed = set(
               subprocess.check_output(
-                  ["git", "diff", "--name-only", "--diff-filter=AMR", base_sha, head_sha],
+                  [
+                      "git",
+                      "diff",
+                      "--no-renames",
+                      "--name-only",
+                      "--diff-filter=AM",
+                      base_sha,
+                      head_sha,
+                  ],
                   text=True,
               ).splitlines()
           )
           deleted = set(
               subprocess.check_output(
-                  ["git", "diff", "--name-only", "--diff-filter=D", base_sha, head_sha],
+                  [
+                      "git",
+                      "diff",
+                      "--no-renames",
+                      "--name-only",
+                      "--diff-filter=D",
+                      base_sha,
+                      head_sha,
+                  ],
                   text=True,
               ).splitlines()
           )
@@ -356,6 +372,35 @@ jobs:
                   slug = path.name.removesuffix(".sources.yaml") if raw_path.endswith(".sources.yaml") else path.stem
               if slug in manifest_set:
                   changed_slugs.add(slug)
+
+          if "curriculum/l2-uk-en/bio/promotion-evidence.yaml" in changed:
+              from scripts.orchestration.preparation_evidence import UniqueKeyLoader
+              import yaml
+
+              registry_rel = "curriculum/l2-uk-en/bio/promotion-evidence.yaml"
+              try:
+                  base_registry_text = subprocess.check_output(
+                      ["git", "show", f"{base_sha}:{registry_rel}"],
+                      text=True,
+                      stderr=subprocess.DEVNULL,
+                  )
+              except subprocess.CalledProcessError:
+                  base_registry_text = "version: 1\nentries: {}\n"
+              base_registry = yaml.load(base_registry_text, Loader=UniqueKeyLoader)
+              head_registry = yaml.load(registry_path.read_text(encoding="utf-8"), Loader=UniqueKeyLoader)
+              base_entries = base_registry.get("entries", {})
+              head_entries = head_registry.get("entries", {})
+              registry_changed_slugs = {
+                  slug
+                  for slug in set(base_entries) | set(head_entries)
+                  if base_entries.get(slug) != head_entries.get(slug)
+              }
+              off_manifest_changes = registry_changed_slugs - manifest_set
+              if off_manifest_changes:
+                  raise SystemExit(
+                      f"promotion evidence changed off-manifest slugs: {sorted(off_manifest_changes)}"
+                  )
+              changed_slugs.update(registry_changed_slugs)
 
           targets = active_holds | changed_slugs
           for slug in sorted(targets, key=manifest_slugs.index):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,14 @@ jobs:
     outputs:
       # code = any high-signal source/config change. Used by the broad secret scan.
       code: ${{ steps.filter.outputs.code }}
-      # python = Python/test paths PLUS the curriculum/site content that tests
-      # read at runtime. Gates pytest + ruff/radon/root guards. curriculum/l2-uk-en/**
+      # python = Python/test paths PLUS learner curriculum/site content that tests
+      # read at runtime. Gates pytest + ruff/radon/root guards. Learner bundles
       # and site/src/content/** are INCLUDED because content-reading tests
       # (citation_resolve, llm_qg_api, reading_coverage, reading_links, parity, ...)
       # load those files at runtime — excluding them let a content-deletion PR
       # (#3867) skip pytest entirely and ship a regression to main (root cause: #3873).
+      # BIO preparation-only data is excluded and routed to the focused preparation
+      # gate below; mixed PRs still match their Python or learner-content paths.
       python: ${{ steps.filter.outputs.python }}
       # frontend = generated site inputs/outputs. Gates the build/vitest job plus
       # MDX source/drift checks, so curriculum source edits cannot leave stale
@@ -77,6 +79,9 @@ jobs:
       # postmortems = bug-autopsy docs + the checker. Gates the postmortem
       # hygiene job so a malformed autopsy or stale INDEX cannot merge (#3725).
       postmortems: ${{ steps.filter.outputs.postmortems }}
+      # preparation = BIO source-preparation surfaces. These are plans/research
+      # evidence, not application code or learner bundles.
+      preparation: ${{ steps.filter.outputs.preparation }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -121,11 +126,17 @@ jobs:
               - 'pyproject.toml'
               - 'scripts/**/*.py'
               - 'tests/**/*.py'
-              # Content that python tests read at runtime — a deletion/edit here
-              # must run pytest, else a content regression reaches main unguarded
+              # Learner content that python tests read at runtime — a deletion/edit
+              # here must run pytest, else a content regression reaches main unguarded
               # (this is the #3873 root cause: #3867 deleted curriculum files,
               # python filter was false, pytest skipped, 4 tests broke on main).
-              - 'curriculum/l2-uk-en/**'
+              # BIO plans/discovery/promotion evidence are preparation data and
+              # take the focused `preparation` lane instead. Picomatch extglobs
+              # preserve broad coverage for all other tracks and BIO learner data.
+              - 'curriculum/l2-uk-en/curriculum.yaml'
+              - 'curriculum/l2-uk-en/!(plans|bio)/**'
+              - 'curriculum/l2-uk-en/plans/!(bio)/**'
+              - 'curriculum/l2-uk-en/bio/!(*promotion-evidence.yaml|discovery)/**'
               - 'site/src/content/**'
               # Schema-validated committed data: pytest validates every file in
               # this directory (test_source_inventory_review_decisions). A
@@ -153,7 +164,12 @@ jobs:
             frontend:
               - '.github/workflows/ci.yml'
               - 'site/**'
-              - 'curriculum/l2-uk-en/**'
+              # BIO preparation data does not feed generated MDX or frontend code.
+              # Keep learner bundles and every non-BIO preparation surface covered.
+              - 'curriculum/l2-uk-en/curriculum.yaml'
+              - 'curriculum/l2-uk-en/!(plans|bio)/**'
+              - 'curriculum/l2-uk-en/plans/!(bio)/**'
+              - 'curriculum/l2-uk-en/bio/!(*promotion-evidence.yaml|discovery)/**'
               # MDX generator entry + package (mdx-generation-drift invokes
               # scripts/generate_mdx.py; mdx-source-parity treats package edits
               # as generator changes). Missing these let generator-only PRs skip
@@ -225,6 +241,139 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'docs/bug-autopsies/**'
               - 'scripts/audit/check_postmortems.py'
+            preparation:
+              - '.github/workflows/ci.yml'
+              - 'curriculum/l2-uk-en/plans/bio/*.yaml'
+              - 'curriculum/l2-uk-en/bio/discovery/*.yaml'
+              - 'curriculum/l2-uk-en/bio/promotion-evidence.yaml'
+              - 'docs/research/bio/*.md'
+              - 'wiki/figures/*.md'
+              - 'wiki/figures/*.sources.yaml'
+
+  bio-preparation-data:
+    name: BIO Preparation Data
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.preparation == 'true'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install preparation validator dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install PyYAML jsonschema
+
+      - name: Check changed BIO dossier word-count floor
+        run: |
+          git fetch --no-tags --prune origin '+refs/heads/main:refs/remotes/origin/main'
+          .venv/bin/python scripts/audit/check_dossier_wordcount.py --changed
+
+      - name: Validate BIO preparation capsules and active holds
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          .venv/bin/python - <<'PY'
+          from pathlib import Path
+          import os
+          import subprocess
+
+          from scripts.orchestration import curriculum_readiness as readiness
+          from scripts.orchestration.preparation_evidence import load_manual_evidence
+
+          root = Path.cwd()
+          base_sha = os.environ.get("BASE_SHA", "")
+          head_sha = os.environ.get("HEAD_SHA", "HEAD") or "HEAD"
+          if not base_sha or set(base_sha) == {"0"}:
+              base_sha = subprocess.check_output(
+                  ["git", "merge-base", "origin/main", head_sha],
+                  text=True,
+              ).strip()
+          changed = set(
+              subprocess.check_output(
+                  ["git", "diff", "--name-only", "--diff-filter=AMR", base_sha, head_sha],
+                  text=True,
+              ).splitlines()
+          )
+          deleted = set(
+              subprocess.check_output(
+                  ["git", "diff", "--name-only", "--diff-filter=D", base_sha, head_sha],
+                  text=True,
+              ).splitlines()
+          )
+
+          _, manifest_slugs = readiness.load_manifest_track(root, "bio")
+          manifest_set = set(manifest_slugs)
+
+          def is_bio_preparation_path(raw_path: str) -> bool:
+              path = Path(raw_path)
+              parts = path.parts
+              wiki_slug = (
+                  path.name.removesuffix(".sources.yaml")
+                  if raw_path.endswith(".sources.yaml")
+                  else path.stem
+              )
+              return (
+                  parts[:4] == ("curriculum", "l2-uk-en", "plans", "bio")
+                  or parts[:4] == ("curriculum", "l2-uk-en", "bio", "discovery")
+                  or raw_path == "curriculum/l2-uk-en/bio/promotion-evidence.yaml"
+                  or parts[:3] == ("docs", "research", "bio")
+                  or (parts[:2] == ("wiki", "figures") and wiki_slug in manifest_set)
+              )
+
+          deleted_preparation = sorted(path for path in deleted if is_bio_preparation_path(path))
+          if deleted_preparation:
+              raise SystemExit(f"BIO preparation files may not be deleted: {deleted_preparation}")
+
+          registry_path = root / "curriculum/l2-uk-en/bio/promotion-evidence.yaml"
+          evidence = load_manual_evidence(registry_path, manifest_set)
+          active_holds = {
+              slug
+              for slug, gates in evidence.items()
+              if gates.get("hold", {}).get("active") is True
+          }
+
+          changed_slugs = set()
+          for raw_path in changed:
+              path = Path(raw_path)
+              parts = path.parts
+              slug = None
+              if parts[:4] == ("curriculum", "l2-uk-en", "plans", "bio"):
+                  slug = path.stem
+              elif parts[:4] == ("curriculum", "l2-uk-en", "bio", "discovery"):
+                  slug = path.stem
+              elif parts[:3] == ("docs", "research", "bio"):
+                  slug = path.stem
+              elif parts[:2] == ("wiki", "figures"):
+                  slug = path.name.removesuffix(".sources.yaml") if raw_path.endswith(".sources.yaml") else path.stem
+              if slug in manifest_set:
+                  changed_slugs.add(slug)
+
+          targets = active_holds | changed_slugs
+          for slug in sorted(targets, key=manifest_slugs.index):
+              result = readiness.evaluate_preparation("bio", slug, repo_root=root)
+              finding_ids = {finding["id"] for finding in result["findings"]}
+              if slug in active_holds:
+                  if result["next_action"] != "stop" or "PREPARATION_HOLD_ACTIVE" not in finding_ids:
+                      raise SystemExit(f"active hold does not fail closed for {slug}")
+                  continue
+              failed = [item["id"] for item in result["requirements"] if not item["passed"]]
+              if failed:
+                  raise SystemExit(f"changed BIO capsule is not preparation-ready: {slug}: {failed}")
+
+          print(
+              f"BIO preparation PASS: entries={len(evidence)} "
+              f"changed_slugs={len(changed_slugs)} active_holds={len(active_holds)}"
+          )
+          PY
 
   atlas-freshness:
     name: Atlas Manifest Freshness
@@ -1036,6 +1185,7 @@ jobs:
     if: always()
     needs:
       - changes
+      - bio-preparation-data   # BIO Preparation Data
       - test                  # Test (pytest)
       - lint                  # Lint (ruff)
       - quality-gates         # Quality Gates (radon)

--- a/tests/test_bio_preparation_ci_routing.py
+++ b/tests/test_bio_preparation_ci_routing.py
@@ -1,0 +1,71 @@
+"""Regression coverage for the BIO preparation-only CI lane (#4431)."""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
+FILTER_ACTION = REPO_ROOT / ".github/actions/paths-filter-retry/action.yml"
+
+BIO_PREPARATION_PATHS = (
+    "curriculum/l2-uk-en/plans/bio/knyahynia-olha.yaml",
+    "curriculum/l2-uk-en/bio/discovery/knyahynia-olha.yaml",
+    "curriculum/l2-uk-en/bio/promotion-evidence.yaml",
+    "docs/research/bio/knyahynia-olha.md",
+    "wiki/figures/knyahynia-olha.md",
+    "wiki/figures/knyahynia-olha.sources.yaml",
+)
+
+RUNTIME_CURRICULUM_GLOBS = {
+    "curriculum/l2-uk-en/curriculum.yaml",
+    "curriculum/l2-uk-en/!(plans|bio)/**",
+    "curriculum/l2-uk-en/plans/!(bio)/**",
+    "curriculum/l2-uk-en/bio/!(*promotion-evidence.yaml|discovery)/**",
+}
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _filters() -> dict[str, list[str]]:
+    workflow = _workflow()
+    filter_step = next(
+        step for step in workflow["jobs"]["changes"]["steps"] if step.get("id") == "filter"
+    )
+    return yaml.safe_load(filter_step["with"]["filters"])
+
+
+def test_preparation_filter_covers_every_bio_capsule_surface() -> None:
+    globs = _filters()["preparation"]
+    uncovered = [
+        path for path in BIO_PREPARATION_PATHS if not any(fnmatch.fnmatch(path, glob) for glob in globs)
+    ]
+    assert not uncovered
+
+
+def test_bio_preparation_is_removed_from_broad_python_and_frontend_routes() -> None:
+    filters = _filters()
+    for route in ("python", "frontend"):
+        globs = set(filters[route])
+        assert "curriculum/l2-uk-en/**" not in globs
+        assert globs >= RUNTIME_CURRICULUM_GLOBS
+
+    # Mixed PRs remain fail-open: application/test paths still select Python,
+    # and BIO learner bundles still select both broad runtime routes.
+    assert "scripts/**/*.py" in filters["python"]
+    assert "tests/**/*.py" in filters["python"]
+
+
+def test_preparation_output_and_required_gate_are_wired_end_to_end() -> None:
+    action = yaml.safe_load(FILTER_ACTION.read_text(encoding="utf-8"))
+    assert "preparation" in action["outputs"]
+
+    jobs = _workflow()["jobs"]
+    assert jobs["changes"]["outputs"]["preparation"] == "${{ steps.filter.outputs.preparation }}"
+    assert jobs["bio-preparation-data"]["if"] == "needs.changes.outputs.preparation == 'true'"
+    assert "bio-preparation-data" in jobs["ci-gate"]["needs"]

--- a/tests/test_bio_preparation_ci_routing.py
+++ b/tests/test_bio_preparation_ci_routing.py
@@ -69,3 +69,14 @@ def test_preparation_output_and_required_gate_are_wired_end_to_end() -> None:
     assert jobs["changes"]["outputs"]["preparation"] == "${{ steps.filter.outputs.preparation }}"
     assert jobs["bio-preparation-data"]["if"] == "needs.changes.outputs.preparation == 'true'"
     assert "bio-preparation-data" in jobs["ci-gate"]["needs"]
+
+
+def test_preparation_gate_tracks_registry_entry_changes_and_decomposes_renames() -> None:
+    steps = _workflow()["jobs"]["bio-preparation-data"]["steps"]
+    validator = next(step for step in steps if step.get("name") == "Validate BIO preparation capsules and active holds")
+    script = validator["run"]
+
+    assert script.count('"--no-renames"') == 2
+    assert '"git", "show", f"{base_sha}:{registry_rel}"' in script
+    assert "registry_changed_slugs" in script
+    assert "changed_slugs.update(registry_changed_slugs)" in script


### PR DESCRIPTION
Supports #4431. This is a CI/process-only change; it does not modify BIO preparation or learner content.

## Outcome

- Routes BIO plans, dossiers, discovery, wiki/source registries, and promotion evidence to a required focused readiness gate.
- Keeps the required Test (pytest) context emitted, but skips its body for preparation-only diffs.
- Skips frontend build/vitest for preparation-only diffs.
- Preserves broad Python/frontend gates for mixed diffs and learner module bundles.
- Fails closed on deleted/renamed preparation files, malformed manual evidence, non-ready changed capsules, active holds that do not resolve to stop, and registry hold removals/deactivations that are not preparation-ready.

## Verification

- 76 focused workflow/readiness tests passed.
- actionlint passed for all workflows.
- ruff and git diff --check passed.
- Picomatch path matrix: registry-only and five-file capsule => preparation only; mixed script+preparation => Python + preparation; learner bundle => Python + frontend.
- Advisory Codex-fleet review: PASS.
- Independent cross-family review: Gemini 3.1 Pro (High), exact commit 3ba7c97edc, PASS after both initial findings were fixed.

X-Agent: codex/4431-content-ci-routing