### PR TITLE
test: align bio prep active hold expectation

### DIFF
--- a/tests/test_preparation_api.py
+++ b/tests/test_preparation_api.py
@@ -206,9 +206,7 @@ def test_module_projection_is_compact_canonical_and_has_no_ready_boolean() -> No
     assert response.headers["etag"].startswith('"')
     assert response.headers["x-source-identity"] == data["freshness"]["source_identity"]
 
-    expanded = CLIENT.get(
-        "/api/state/preparation/a1/sounds-letters-and-hello?evidence=expanded"
-    )
+    expanded = CLIENT.get("/api/state/preparation/a1/sounds-letters-and-hello?evidence=expanded")
     assert expanded.status_code == 200
     VALIDATOR.validate(expanded.json())
     assert expanded.json()["canonical"]["contract_version"] == "curriculum-preparation-result.v1"
@@ -223,8 +221,9 @@ def test_bio_uses_bio_profile_and_dossier_alone_never_means_build() -> None:
     assert data["authority"]["readiness"]["profile_id"] == "bio"
     assert data["module_state"] == "unbuilt"
     assert data["preparation_state"] == "missing"
-    assert data["next_action"] == "prepare"
+    assert data["next_action"] == "stop"
     assert data["next_action"] != "build"
+    assert "PREPARATION_HOLD_ACTIVE" in data["reason_codes"]
     assert data["reason_codes"]
 
 
@@ -363,9 +362,10 @@ def test_etag_changes_when_canonical_manifest_or_profile_sources_change(
         slug="demo",
         expanded=False,
     )
-    assert preparation_state.response_document(manifest_changed)[1] != preparation_state.response_document(
-        profile_changed
-    )[1]
+    assert (
+        preparation_state.response_document(manifest_changed)[1]
+        != preparation_state.response_document(profile_changed)[1]
+    )
 
 
 def test_count_disagreement_emits_finding(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
Closes #5461

- Issue: [#5461](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5461)
- Epic: [#4431](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4431)

Root cause: PR #5450 added an active reviewed hold for `bio/knyahynia-olha` in `curriculum/l2-uk-en/bio/promotion-evidence.yaml`, so the canonical API now correctly returns `next_action=stop`; this test still expected `prepare`.

Raw verification commands:
- .venv/bin/python -m pytest -q tests/test_preparation_api.py
- .venv/bin/python -m pytest -q tests/orchestration/test_curriculum_readiness.py -k reviewed_active_hold_is_a_terminal_stop_with_a_blocker_receipt
- .venv/bin/ruff check tests/test_preparation_api.py
- .venv/bin/ruff format --check tests/test_preparation_api.py
- .venv/bin/python scripts/audit/lint_agent_trailer.py
