### PR TITLE
feat(bridge): publish thin formal review verdicts

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -172,6 +172,24 @@ is the **canonical formal PR review entry** (Sol fleet-comms Phase 0–3):
   (GLM-5.2 is **LOCAL-ONLY** / China egress — never CI).
 - Do **not** identify the reviewer as “Hermes”; record model + family + harness.
 
+Formal reviews stay thin in both directions (Phase 4–5). Do not paste a review
+body over 4 KiB or attach evidence over 64 KiB to an `ask-*` review job; the
+bridge rejects it and points to `review-pr <N>`. Prefer a PR target over a
+manual review ask.
+
+After a reviewer writes a short verdict or findings JSON, publish exactly one
+PR comment without relaying the full body through the orchestrator:
+
+```bash
+.venv/bin/python scripts/ai_agent_bridge/__main__.py publish-review-verdict \
+  --pr 5458 --verdict-file /tmp/review-verdict.txt \
+  --model gpt-5.6-terra --family openai --harness codex
+```
+
+The comment contains only `VERDICT`, the PR head SHA, and reviewer provenance.
+The command prints a ≤2 KiB status summary; use `--findings-json` for a JSON
+file with a top-level `verdict`, and `--dry-run` to verify the payload locally.
+
 `.venv/bin/python scripts/ai_agent_bridge/__main__.py review-deep <PR-or-path> [--effort xhigh]` dispatches an
 adversarial Claude review run. It hardcodes `--agent claude --mode
 read-only --model claude-opus-4-7 --effort xhigh` unless an explicit

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -35,6 +35,11 @@ from ._config import _PARENT_ENV, CLAUDE_CMD, REPO_ROOT
 from ._db import get_db, get_session, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import build_claude_prompt
+from ._review_safety import (
+    ReviewSafetyError,
+    assert_formal_review_ask_payload,
+    warn_missing_review_target,
+)
 from ._review_worktree import (
     ReviewWorktreeError,
     append_review_prompt_evidence,
@@ -53,6 +58,20 @@ def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query"
                background: bool = False, review_branch: str | None = None,
                review_pr_number: int | None = None):
     """Send message to Claude AND invoke Claude to process it."""
+    try:
+        formal_review = assert_formal_review_ask_payload(
+            content,
+            msg_type=msg_type,
+            task_id=task_id,
+            attachment=data,
+            review=review,
+        )
+    except ReviewSafetyError as exc:
+        raise SystemExit(f"ask-claude: {exc}") from exc
+    warn_missing_review_target(
+        formal_review=formal_review,
+        has_target=review_branch is not None or review_pr_number is not None,
+    )
     msg_id = send_message(
         content,
         task_id,

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -979,8 +979,10 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     from ._review_pr import register_review_pr_parser
+    from ._review_verdict import register_publish_review_verdict_parser
 
     register_review_pr_parser(subparsers)
+    register_publish_review_verdict_parser(subparsers)
 
     review_deep_parser = subparsers.add_parser(
         "review-deep",
@@ -1260,6 +1262,10 @@ def _dispatch_command(args):
         from ._review_pr import handle_review_pr
 
         sys.exit(handle_review_pr(args))
+    elif args.command == "publish-review-verdict":
+        from ._review_verdict import handle_publish_review_verdict
+
+        sys.exit(handle_publish_review_verdict(args))
     elif args.command == "review-deep":
         sys.exit(handle_review_deep(args))
     elif args.command == "check-model":

--- a/scripts/ai_agent_bridge/_codex.py
+++ b/scripts/ai_agent_bridge/_codex.py
@@ -22,6 +22,11 @@ from ._config import REPO_ROOT
 from ._db import get_db, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import build_codex_prompt
+from ._review_safety import (
+    ReviewSafetyError,
+    assert_formal_review_ask_payload,
+    warn_missing_review_target,
+)
 from ._review_worktree import (
     ReviewWorktreeError,
     append_review_prompt_evidence,
@@ -114,6 +119,20 @@ def ask_codex(
     review_pr_number: int | None = None,
 ):
     """Send message to Codex AND invoke Codex to process it."""
+    try:
+        formal_review = assert_formal_review_ask_payload(
+            content,
+            msg_type=msg_type,
+            task_id=task_id,
+            attachment=data,
+            review=review,
+        )
+    except ReviewSafetyError as exc:
+        raise SystemExit(f"ask-codex: {exc}") from exc
+    warn_missing_review_target(
+        formal_review=formal_review,
+        has_target=review_branch is not None or review_pr_number is not None,
+    )
     from_llm = _resolve_codex_from_llm(from_llm)
     msg_id = send_message(
         content,

--- a/scripts/ai_agent_bridge/_hermes.py
+++ b/scripts/ai_agent_bridge/_hermes.py
@@ -43,11 +43,13 @@ from ._review_safety import (
     ReviewSafetyError,
     assert_attachment_size,
     assert_content_size,
+    assert_formal_review_ask_payload,
     assert_review_cwd_safe,
     hermes_must_use_neutral_cwd,
     is_review_class_ask,
     neutral_review_scratch,
     prepend_read_only_contract,
+    warn_missing_review_target,
 )
 from .routing_guard import assert_model_routing_allowed
 
@@ -172,6 +174,14 @@ def _preflight_hermes_payload(
     data: str | None,
     review: bool,
 ) -> None:
+    formal_review = assert_formal_review_ask_payload(
+        content,
+        msg_type="review" if review else None,
+        task_id=None,
+        attachment=data,
+        review=review,
+    )
+    warn_missing_review_target(formal_review=formal_review, has_target=False)
     limit = MAX_REVIEW_REQUEST_BYTES if review else MAX_ASK_CONTENT_BYTES
     assert_content_size(content, limit=limit, label="ask_content")
     if data:

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -53,6 +53,11 @@ from ._ask_lifecycle import (
     register_ask,
 )
 from ._messaging import acknowledge, send_message
+from ._review_safety import (
+    ReviewSafetyError,
+    assert_formal_review_ask_payload,
+    warn_missing_review_target,
+)
 
 # Default was qwen3.7-max (EXPENSIVE) until 2026-07-05 — a silent money trap
 # for every ask-opencode call without --model. Since 2026-07-07 (user order:
@@ -317,6 +322,16 @@ def ask_glm(
     ``openrouter/z-ai/glm-5.2``). Any override MUST still be a GLM model — the
     China-egress guard above is unconditional.
     """
+    try:
+        formal_review = assert_formal_review_ask_payload(
+            content,
+            msg_type=msg_type,
+            task_id=task_id,
+            attachment=data,
+        )
+    except ReviewSafetyError as exc:
+        raise SystemExit(f"ask-glm: {exc}") from exc
+    warn_missing_review_target(formal_review=formal_review, has_target=False)
     _assert_glm_egress_allowed()
     effective_model = model or GLM_MODEL
     msg_id = send_message(

--- a/scripts/ai_agent_bridge/_review_safety.py
+++ b/scripts/ai_agent_bridge/_review_safety.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -214,6 +215,68 @@ def assert_attachment_size(path: Path) -> None:
         raise ReviewSafetyError(
             f"attachment_exceeds_cap: path={path} bytes={size} "
             f"limit={MAX_ASK_ATTACHMENT_BYTES}. Do not attach multi-MB inventory/YAML."
+        )
+
+
+def is_formal_review_ask(*, msg_type: str | None, task_id: str | None) -> bool:
+    """Return whether an ask is formal review work without prompt heuristics."""
+    return is_review_class_ask(msg_type=msg_type, task_id=task_id)
+
+
+def _attachment_bytes(attachment: str | Path) -> int:
+    """Measure an inline attachment or a file-backed attachment safely."""
+    value = str(attachment)
+    inline_size = len(value.encode("utf-8"))
+    path = Path(value)
+    try:
+        file_size = path.stat().st_size if path.exists() else 0
+    except (OSError, ValueError):
+        file_size = 0
+    return max(inline_size, file_size)
+
+
+def assert_formal_review_ask_payload(
+    content: str,
+    *,
+    msg_type: str | None,
+    task_id: str | None,
+    attachment: str | Path | None = None,
+    review: bool = False,
+) -> bool:
+    """Fail closed before a formal review ask can send a fat payload.
+
+    Returns whether the ask is review-class so callers can share the same
+    classification for the missing-target warning.
+    """
+    formal_review = review or is_formal_review_ask(msg_type=msg_type, task_id=task_id)
+    if not formal_review:
+        return False
+
+    content_size = len(content.encode("utf-8"))
+    if content_size > MAX_REVIEW_REQUEST_BYTES:
+        raise ReviewSafetyError(
+            "review_ask_content_exceeds_cap: "
+            f"bytes={content_size} limit={MAX_REVIEW_REQUEST_BYTES}. "
+            "Use review-pr <N>; it pulls PR evidence instead of accepting pasted review bodies."
+        )
+    if attachment is not None:
+        attachment_size = _attachment_bytes(attachment)
+        if attachment_size > MAX_ASK_ATTACHMENT_BYTES:
+            raise ReviewSafetyError(
+                "review_ask_attachment_exceeds_cap: "
+                f"bytes={attachment_size} limit={MAX_ASK_ATTACHMENT_BYTES}. "
+                "Use review-pr <N>; it pulls PR evidence instead of accepting attachments."
+            )
+    return True
+
+
+def warn_missing_review_target(*, formal_review: bool, has_target: bool) -> None:
+    """Steer manual formal-review asks to the PR-targeted entrypoint."""
+    if formal_review and not has_target:
+        print(
+            "warning: formal review ask has no review target; prefer review-pr <N> "
+            "for sealed, pointer-only review.",
+            file=sys.stderr,
         )
 
 

--- a/scripts/ai_agent_bridge/_review_verdict.py
+++ b/scripts/ai_agent_bridge/_review_verdict.py
@@ -1,0 +1,171 @@
+"""Publish a deliberately thin formal-review verdict to one GitHub PR comment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ._review_safety import MAX_VERDICT_SUMMARY_BYTES, ReviewSafetyError
+
+_VERDICT_RE = re.compile(
+    r"\bVERDICT\s*:\s*(APPROVED|CHANGES_REQUESTED|BLOCKED)\b", re.IGNORECASE
+)
+_MAX_INPUT_BYTES = 64 * 1024
+_VALID_VERDICTS = frozenset({"APPROVED", "CHANGES_REQUESTED", "BLOCKED"})
+
+
+def _single_line(value: str, *, label: str) -> str:
+    normalized = " ".join(value.split())
+    if not normalized:
+        raise ReviewSafetyError(f"missing_{label}")
+    return normalized
+
+
+def _read_small_file(path: Path) -> str:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ReviewSafetyError(f"verdict_file_unreadable: {path}") from exc
+    if size > _MAX_INPUT_BYTES:
+        raise ReviewSafetyError(
+            f"verdict_file_exceeds_cap: bytes={size} limit={_MAX_INPUT_BYTES}. "
+            "Publish only a verdict or findings JSON, never a full review body."
+        )
+    return path.read_text(encoding="utf-8")
+
+
+def verdict_from_text(text: str) -> str:
+    """Extract the required verdict without retaining the review body."""
+    match = _VERDICT_RE.search(text)
+    if not match:
+        raise ReviewSafetyError("verdict_missing: expected VERDICT: APPROVED|CHANGES_REQUESTED|BLOCKED")
+    return match.group(1).upper()
+
+
+def verdict_from_findings_json(path: Path) -> str:
+    """Read a findings JSON document and extract its top-level verdict field."""
+    try:
+        payload = json.loads(_read_small_file(path))
+    except json.JSONDecodeError as exc:
+        raise ReviewSafetyError(f"findings_json_invalid: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ReviewSafetyError("findings_json_invalid: expected an object with a verdict field")
+    raw = payload.get("verdict")
+    if not isinstance(raw, str) or raw.upper() not in _VALID_VERDICTS:
+        raise ReviewSafetyError("findings_json_missing_verdict: expected APPROVED|CHANGES_REQUESTED|BLOCKED")
+    return raw.upper()
+
+
+def build_verdict_comment(*, verdict: str, head_sha: str, model: str, family: str, harness: str) -> str:
+    """Build the complete comment body; it intentionally has no review findings."""
+    normalized_verdict = _single_line(verdict, label="verdict").upper()
+    if normalized_verdict not in _VALID_VERDICTS:
+        raise ReviewSafetyError(f"invalid_verdict: {normalized_verdict!r}")
+    return "\n".join(
+        (
+            f"VERDICT: {normalized_verdict}",
+            f"Head SHA: {_single_line(head_sha, label='head_sha')}",
+            "Reviewer provenance: "
+            f"model={_single_line(model, label='model')}; "
+            f"family={_single_line(family, label='family')}; "
+            f"harness={_single_line(harness, label='harness')}",
+        )
+    )
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def publish_review_verdict(
+    *,
+    pr: int,
+    verdict: str,
+    model: str,
+    family: str,
+    harness: str,
+    dry_run: bool = False,
+    runner: Runner = subprocess.run,
+) -> str:
+    """Post one comment and return a bounded, body-free orchestrator summary."""
+    if pr <= 0:
+        raise ReviewSafetyError(f"invalid_pr: {pr}")
+    head = runner(
+        ["gh", "pr", "view", str(pr), "--json", "headRefOid", "--jq", ".headRefOid"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if head.returncode != 0:
+        raise ReviewSafetyError(f"gh_pr_head_lookup_failed: pr={pr} exit={head.returncode}")
+    head_sha = _single_line(head.stdout, label="head_sha")
+    comment = build_verdict_comment(
+        verdict=verdict,
+        head_sha=head_sha,
+        model=model,
+        family=family,
+        harness=harness,
+    )
+    if not dry_run:
+        posted = runner(
+            ["gh", "pr", "comment", str(pr), "--body", comment],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if posted.returncode != 0:
+            raise ReviewSafetyError(f"gh_pr_comment_failed: pr={pr} exit={posted.returncode}")
+    summary = (
+        f"publish-review-verdict: pr={pr} verdict={verdict.upper()} "
+        f"head_sha={head_sha} model={_single_line(model, label='model')} "
+        f"family={_single_line(family, label='family')} "
+        f"harness={_single_line(harness, label='harness')} "
+        f"posted={'false (dry-run)' if dry_run else 'true'}"
+    )
+    if len(summary.encode("utf-8")) > MAX_VERDICT_SUMMARY_BYTES:
+        raise ReviewSafetyError("verdict_summary_exceeds_cap")
+    return summary
+
+
+def handle_publish_review_verdict(args: argparse.Namespace) -> int:
+    """CLI handler for ``publish-review-verdict``."""
+    try:
+        verdict = (
+            verdict_from_findings_json(Path(args.findings_json))
+            if args.findings_json
+            else verdict_from_text(_read_small_file(Path(args.verdict_file)))
+        )
+        print(
+            publish_review_verdict(
+                pr=args.pr,
+                verdict=verdict,
+                model=args.model,
+                family=args.family,
+                harness=args.harness,
+                dry_run=args.dry_run,
+            )
+        )
+    except ReviewSafetyError as exc:
+        print(f"publish-review-verdict: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def register_publish_review_verdict_parser(subparsers: Any) -> None:
+    parser = subparsers.add_parser(
+        "publish-review-verdict",
+        help="Post one thin formal-review verdict comment to a PR",
+    )
+    parser.add_argument("--pr", type=int, required=True, help="Pull request number")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--verdict-file", help="Short text containing a VERDICT line")
+    source.add_argument("--findings-json", help="Findings JSON with a top-level verdict field")
+    parser.add_argument("--model", required=True, help="Exact reviewer model ID")
+    parser.add_argument("--family", required=True, help="Reviewer model family")
+    parser.add_argument("--harness", required=True, help="Reviewer harness")
+    parser.add_argument("--dry-run", action="store_true", help="Resolve head SHA without posting")

--- a/tests/ai_agent_bridge/test_review_ask_caps.py
+++ b/tests/ai_agent_bridge/test_review_ask_caps.py
@@ -1,0 +1,60 @@
+"""Formal review asks fail before broker delivery when their payload is fat."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from ai_agent_bridge import _claude, _codex, _hermes, _opencode
+from ai_agent_bridge import _review_safety as safety
+
+
+@pytest.mark.parametrize(
+    ("ask", "kwargs"),
+    (
+        (_codex.ask_codex, {"from_llm": "test"}),
+        (_claude.ask_claude, {"from_llm": "test"}),
+        (_opencode.ask_glm, {"from_llm": "test"}),
+        (_hermes.ask_hermes, {"model": "deepseek-v4-flash", "from_llm": "test"}),
+    ),
+)
+def test_named_transports_reject_fat_formal_review_body(ask, kwargs: dict[str, str]) -> None:
+    with pytest.raises(SystemExit, match=r"review-pr.*exceeds_cap|exceeds_cap.*review-pr"):
+        ask(
+            "x" * (safety.MAX_REVIEW_REQUEST_BYTES + 1),
+            task_id="review-fat",
+            msg_type="review",
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize(
+    ("ask", "kwargs"),
+    (
+        (_codex.ask_codex, {"from_llm": "test"}),
+        (_claude.ask_claude, {"from_llm": "test"}),
+        (_opencode.ask_glm, {"from_llm": "test"}),
+        (_hermes.ask_hermes, {"model": "deepseek-v4-flash", "from_llm": "test"}),
+    ),
+)
+def test_named_transports_reject_fat_formal_review_attachment(
+    ask,
+    kwargs: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    attachment = tmp_path / "fat-evidence.txt"
+    attachment.write_bytes(b"x" * (safety.MAX_ASK_ATTACHMENT_BYTES + 1))
+
+    with pytest.raises(SystemExit, match=r"review-pr.*attachment_exceeds_cap|attachment_exceeds_cap.*review-pr"):
+        ask(
+            "thin pointer only",
+            task_id="review-attachment",
+            msg_type="review",
+            data=str(attachment),
+            **kwargs,
+        )
+
+
+def test_formal_review_without_target_warns(capsys: pytest.CaptureFixture[str]) -> None:
+    safety.warn_missing_review_target(formal_review=True, has_target=False)
+    assert "prefer review-pr <N>" in capsys.readouterr().err

--- a/tests/ai_agent_bridge/test_review_verdict.py
+++ b/tests/ai_agent_bridge/test_review_verdict.py
@@ -1,0 +1,73 @@
+"""Thin GitHub verdict publisher tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+from ai_agent_bridge import _review_verdict as publisher
+from ai_agent_bridge._review_safety import ReviewSafetyError
+
+
+def test_publish_review_verdict_dry_run_is_thin_and_does_not_post() -> None:
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="deadbeef\n", stderr="")
+
+    summary = publisher.publish_review_verdict(
+        pr=5458,
+        verdict="APPROVED",
+        model="gpt-5.6-terra",
+        family="openai",
+        harness="codex",
+        dry_run=True,
+        runner=fake_runner,
+    )
+
+    assert calls == [["gh", "pr", "view", "5458", "--json", "headRefOid", "--jq", ".headRefOid"]]
+    assert "pr=5458" in summary
+    assert "head_sha=deadbeef" in summary
+    assert len(summary.encode("utf-8")) <= publisher.MAX_VERDICT_SUMMARY_BYTES
+
+
+def test_publish_review_verdict_posts_one_comment_without_findings() -> None:
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[2] == "view":
+            return subprocess.CompletedProcess(command, 0, stdout="abc123\n", stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    publisher.publish_review_verdict(
+        pr=99,
+        verdict="CHANGES_REQUESTED",
+        model="glm-5.2",
+        family="zhipu",
+        harness="opencode",
+        runner=fake_runner,
+    )
+
+    assert len(calls) == 2
+    assert calls[1][:4] == ["gh", "pr", "comment", "99"]
+    comment = calls[1][5]
+    assert "VERDICT: CHANGES_REQUESTED" in comment
+    assert "Head SHA: abc123" in comment
+    assert "model=glm-5.2" in comment
+    assert "findings" not in comment.lower()
+
+
+def test_verdict_from_findings_json_requires_explicit_verdict(tmp_path) -> None:
+    findings = tmp_path / "findings.json"
+    findings.write_text(
+        json.dumps({"verdict": "BLOCKED", "findings": ["long body"]}),
+        encoding="utf-8",
+    )
+    assert publisher.verdict_from_findings_json(findings) == "BLOCKED"
+
+    findings.write_text('{"findings": []}', encoding="utf-8")
+    with pytest.raises(ReviewSafetyError, match="missing_verdict"):
+        publisher.verdict_from_findings_json(findings)


### PR DESCRIPTION
## Summary
- add a bounded `publish-review-verdict` CLI that posts one verdict/provenance/head-SHA comment
- reject oversized formal review asks before delivery across Codex, Claude, GLM, and Hermes
- document the Phase 4–5 pointer-only workflow

## Verification
- `PYTHONPATH=scripts .venv/bin/python -m pytest tests/ai_agent_bridge/test_review_ask_caps.py tests/ai_agent_bridge/test_review_verdict.py tests/ai_agent_bridge/test_review_pr.py tests/ai_agent_bridge/test_hermes_review_isolation.py tests/ai_agent_bridge/test_claude_review_worktree.py tests/ai_agent_bridge/test_ask_lifecycle.py -q`
- `PYTHONPATH=scripts .venv/bin/python -m ruff check ...`
- `npx --no-install markdownlint-cli2 docs/best-practices/agent-bridge.md`

## Review routing
- Cross-family review: `review-pr 5465 --reviewer glm` (GLM / Zhipu / opencode) is in progress.
- Claude fallback was unavailable due its weekly limit; GLM remains the active independent reviewer.

Swarm used: false — solo run; no swarm used.