### PR TITLE
feat(practice): example sentence on today's word list (#5434)

### DIFF
--- a/scripts/audit/generate_daily_pool.py
+++ b/scripts/audit/generate_daily_pool.py
@@ -111,6 +111,38 @@ def _stable_hash(text: str) -> str:
     return hashlib.sha1(text.encode("utf-8")).hexdigest()
 
 
+def _first_example(entry: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Return the first verified example sentence and optional English gloss.
+
+    Looks in common manifest/article payload shapes so the daily pool can carry
+    one short example per word without a second large shard. Returns (None, None)
+    when no usable sentence is present.
+    """
+    enrichment = entry.get("enrichment") if isinstance(entry.get("enrichment"), dict) else {}
+
+    # Prefer a single verified example with English scaffolding.
+    single = enrichment.get("example") or entry.get("example")
+    if isinstance(single, dict):
+        uk = single.get("uk") or single.get("sentence") or single.get("text")
+        en = single.get("en") or single.get("translation") or single.get("gloss")
+        if _has_text(uk):
+            return (str(uk).strip(), str(en).strip() if _has_text(en) else None)
+
+    # Fall back to an array of examples.
+    examples = enrichment.get("examples") or entry.get("examples") or []
+    if isinstance(examples, list) and examples:
+        first = examples[0]
+        if isinstance(first, dict):
+            uk = first.get("uk") or first.get("sentence") or first.get("text")
+            en = first.get("en") or first.get("translation") or first.get("gloss")
+            if _has_text(uk):
+                return (str(uk).strip(), str(en).strip() if _has_text(en) else None)
+        if _has_text(first):
+            return (str(first).strip(), None)
+
+    return (None, None)
+
+
 def _pool_item(entry: dict[str, Any]) -> dict[str, Any] | None:
     lemma = entry.get("lemma")
     slug = entry.get("url_slug")
@@ -131,6 +163,11 @@ def _pool_item(entry: dict[str, Any]) -> dict[str, Any] | None:
     cefr = _early_cefr(entry)
     if cefr is not None:
         item["cefr"] = cefr
+    example, example_en = _first_example(entry)
+    if example is not None:
+        item["example"] = example
+    if example_en is not None:
+        item["exampleEn"] = example_en
     return item
 
 

--- a/site/src/lexicon/DailyWords.astro
+++ b/site/src/lexicon/DailyWords.astro
@@ -94,12 +94,22 @@ const dailyCount = Math.max(1, Math.floor(count));
     return chips.length > 0 ? `<span class="lexicon-daily-chips">${chips.join("")}</span>` : "";
   };
 
+  const renderExample = (word: DailyWord): string => {
+    const example = word.example?.trim();
+    if (!example) return "";
+    const exampleEn = word.exampleEn?.trim();
+    return `<span class="lexicon-daily-example" data-testid="daily-example-${dwEsc(word.slug)}" lang="uk">
+      ${dwEsc(example)}${exampleEn ? `<span class="lexicon-daily-example-en" lang="en">${dwEsc(exampleEn)}</span>` : ""}
+    </span>`;
+  };
+
   const renderCard = (word: DailyWord): string => {
     const href = `/lexicon/${encodeURIComponent(String(word.slug))}/`;
     return `<li class="lexicon-daily-item">
       <a class="lexicon-daily-card" href="${href}">
         <span class="lexicon-daily-lemma">${dwEsc(word.lemma)}</span>
         ${word.gloss ? `<span class="lexicon-daily-gloss">${dwEsc(word.gloss)}</span>` : ""}
+        ${renderExample(word)}
         ${renderChips(word)}
       </a>
     </li>`;
@@ -329,6 +339,23 @@ const dailyCount = Math.max(1, Math.floor(count));
     color: var(--lu-text-muted);
     font-size: 0.92rem;
     line-height: 1.45;
+  }
+
+  :global(.lexicon-daily-example) {
+    display: block;
+    margin-top: 0.25rem;
+    color: var(--lu-text);
+    font-size: 0.95rem;
+    font-style: italic;
+    line-height: 1.5;
+  }
+
+  :global(.lexicon-daily-example-en) {
+    display: block;
+    margin-top: 0.15rem;
+    color: var(--lu-text-muted);
+    font-size: 0.85rem;
+    font-style: normal;
   }
 
   :global(.lexicon-daily-chips) {

--- a/site/src/lib/lexicon/daily.ts
+++ b/site/src/lib/lexicon/daily.ts
@@ -8,6 +8,13 @@ export interface DailyWord {
   lessonTag?: string;
   cefr?: string;
   weight?: number;
+  /**
+   * #5434 verified example sentence for the word of the day.
+   * Absent until the sentence corpus lands — the UI omits the slot quietly.
+   */
+  example?: string | null;
+  /** English rendering of `example` (A1 scaffolding only). */
+  exampleEn?: string | null;
 }
 
 export function dateSeed(d: Date): number {

--- a/site/tests/unit/daily-words-example.test.ts
+++ b/site/tests/unit/daily-words-example.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import { GET as getDailyPool } from "@site/src/pages/api/lexicon/daily-pool.json";
+import type { DailyWord } from "@site/src/lib/lexicon/daily";
+
+const dailyWordsSource = readFileSync(
+  resolve(process.cwd(), "src/lexicon/DailyWords.astro"),
+  "utf8",
+);
+
+describe("DailyWords list example sentence (GH #5434)", () => {
+  test("DailyWords Astro renders an example slot with bilingual scaffolding", () => {
+    expect(dailyWordsSource).toContain("word.example?.trim()");
+    expect(dailyWordsSource).toContain('data-testid="daily-example-');
+    expect(dailyWordsSource).toContain('class="lexicon-daily-example"');
+    expect(dailyWordsSource).toContain('class="lexicon-daily-example-en"');
+    expect(dailyWordsSource).toContain('lang="uk"');
+    expect(dailyWordsSource).toContain('lang="en"');
+  });
+
+  test("DailyWords card omits example markup when no example is present", () => {
+    // renderExample returns an empty string for missing data, so the card does
+    // not create an empty element.
+    expect(dailyWordsSource).toContain("if (!example) return \"\";");
+  });
+
+  test("daily pool API route exposes optional example fields", async () => {
+    const response = await getDailyPool({} as Parameters<typeof getDailyPool>[0]);
+    const pool = (await response.json()) as DailyWord[];
+
+    expect(Array.isArray(pool)).toBe(true);
+    expect(pool.length).toBeGreaterThan(0);
+
+    // Schema is permissive: examples may not be populated yet, but every row
+    // must remain a valid DailyWord with the new optional fields.
+    for (const row of pool) {
+      expect(row).toHaveProperty("lemma");
+      expect(row).toHaveProperty("slug");
+      expect(row).toHaveProperty("gloss");
+      if (row.example !== undefined && row.example !== null) {
+        expect(typeof row.example).toBe("string");
+        expect(row.example.trim()).toBe(row.example);
+      }
+      if (row.exampleEn !== undefined && row.exampleEn !== null) {
+        expect(typeof row.exampleEn).toBe("string");
+        expect(row.exampleEn.trim()).toBe(row.exampleEn);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #5434

## What changed
- Added optional `example` / `exampleEn` fields to the `DailyWord` type.
- Updated `DailyWords.astro` list cards to render a verified example sentence (with bilingual A1 scaffolding) and omit the slot quietly when no example is present.
- Wired `scripts/audit/generate_daily_pool.py` to extract the first example into the daily pool JSON, supporting dict and array shapes, so future manifest data can surface without another UI change.
- Added `site/tests/unit/daily-words-example.test.ts` covering markup, missing-data behavior, and the daily-pool API schema.

## Out of scope
- This PR intentionally does not add new Ukrainian sentence content; it wires rendering and the daily-pool extraction path so the language-lane data work can populate verified examples in the manifest / daily pool.
- The companion change to carry `example` / `examples` from `vocabulary.yaml` into manifest entries is left for the data lane, because it requires regenerating and committing the Atlas manifest + fingerprint.

## Verification
- `.venv/bin/python -m ruff check scripts/audit/generate_daily_pool.py` ✅
- `cd site && ./node_modules/.bin/vitest run tests/unit/daily-words-example.test.ts tests/unit/lexicon-api-routes.test.ts tests/unit/LexiconPractice.test.tsx tests/unit/k3-chrome-locale.test.ts` ✅
- Pre-commit (ruff + pytest on affected files) ✅
- `astro check` reports no errors in changed files.

## Notes
- No changes to `site/src/data/lexicon-manifest.pointer.json`, bulk inventory, or auto-generated status/audit files.