### PR TITLE
docs(fleet): shared doctrine + living role scorecard

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -1,5 +1,10 @@
 # Agent Bridge — Channel Communication
 
+> **Fleet roles:** operator doctrine and living scorecard live in
+> [`fleet-shared-doctrine.md`](fleet-shared-doctrine.md) and
+> [`fleet-role-scorecard.md`](fleet-role-scorecard.md). Machine routing remains
+> `agents_extensions/shared/rules/model-assignment.md` (takes precedence on conflict).
+
 The agent bridge is how Claude, AGY, and Codex (and you, the
 human) communicate across invocations. The new **channel bridge**
 (added in #1190) replaces the old 1:1 `ask-*` pattern with topic-

--- a/docs/best-practices/fleet-role-scorecard.md
+++ b/docs/best-practices/fleet-role-scorecard.md
@@ -1,0 +1,172 @@
+# Fleet role scorecard — living model classification
+
+**Status:** living scorecard (**classification drafted** 2026-07-19 — not all cells fully bakeoff-validated)  
+**Doctrine:** [`fleet-shared-doctrine.md`](fleet-shared-doctrine.md)  
+**Machine routing:** `agents_extensions/shared/rules/model-assignment.md` (takes precedence on conflict)  
+**Evidence baseline:** public Jul 2026 model cards/roundups + project catalog + Sol advisories #3588 / #3593  
+**Owner:** accountable orchestrator (update after bakeoffs; operator approves role demotions/promotions for ceiling seats)
+
+---
+
+## 0. How to read this document
+
+- Rows are **role assignments**, not a global IQ ranking.  
+- Each assignment has a **confidence**: `provisional` | `validated` | `deprecated`.  
+- **Provisional** = operator intent + public priors + Sol review; needs local bakeoff.  
+- **Validated** = recorded local bakeoff with harness/effort/outcome.  
+- **Deprecated** = do not route except explicit exception.  
+- Benchmarks and press numbers are **priors**; harness × effort can invert order.
+
+---
+
+## 1. Role → models (operator 2026-07-19 + Sol amends)
+
+| Role | Primary | Secondary / volume | Effort | Confidence |
+|---|---|---|---|---|
+| Ceiling advisor/designer | Sol, Fable 5 | — | Sol ≥`high` (prefer `xhigh`/`max`); Fable prefer `xhigh` | provisional |
+| Accountable orchestrator | Opus 4.8, Terra | — | Opus `high`+; Terra `xhigh` when owning hard streams | provisional |
+| General implementer | Sonnet 5, Terra, Grok 4.5 | Gemini 3.5 Flash, K3, Cursor (**pin family**) | `high` default | provisional |
+| Hard implementer | Sol, Fable 5 | Prefer Sonnet/Terra first unless known ceiling task | `xhigh` | provisional |
+| UI / visual product design | K3 | Sol (systems UX adjudication only) | K3 `high`; Sol `xhigh` | provisional (K3 UI primacy needs bakeoffs) |
+| Code/security CF review | **Author-family-conditional** (see §3) | — | `high`+ | provisional |
+| Critical CF review | Sol ↔ Fable/Opus **cross-family** | — | `xhigh` | provisional |
+| Ukrainian language | Gemini 3.1 Pro (AGY) | LANGUAGE-LANES: codex/claude/grok-4.5 + sources | `high` | provisional (UA primacy AGY; morphology still VESUM-gated) |
+| Recon / triage | Luna, Gemini 3.5 Flash | — | `medium`–`high`; never sole release | provisional |
+
+**One orchestrator per stream.** Advisors recommend; orchestrator owns terminal disposition.
+
+---
+
+## 2. Model cards (strengths / weaknesses / project notes)
+
+| Model | Strengths | Weaknesses | Route / egress notes | Project seat |
+|---|---|---|---|---|
+| **Fable 5** | Ceiling coding; long hard tasks; architecture; lead grows with difficulty | ~2× Opus price; safety reroutes possible | Anthropic | Ceiling advisor + hard code |
+| **Sol** | Frontier coding/agent claims; synthesis; hard debug; design judgment; multi-agent `ultra` class capabilities in family docs | Expensive; OpenAI-family CF limits if author is OpenAI | OpenAI / Codex | Ceiling advisor; floor `high` |
+| **Opus 4.8** | Durable long agentic sessions; orchestration; architecture | Costly as bulk worker | Anthropic | Prefer orchestrator |
+| **Terra** | Balanced implementer/orchestrator; strong everyday agentic | Not Sol/Fable ceiling | OpenAI / Codex | Orchestrator + worker |
+| **Luna** | Fast recon, cheap mechanical checks | Never sole architecture/security/language/release authority | OpenAI / Codex | Recon |
+| **Sonnet 5** | Near-flagship coding at better cost; daily driver agentic | Escalate systemic ambiguity | Anthropic | Default worker |
+| **Grok 4.5** | Strong coding agent; token-efficient; good CF review value | Prefer worker/reviewer not sole orchestrator | xAI; SuperGrok Heavy = capacity entitlement (re-verify) | Worker + CF review |
+| **Gemini 3.5 Flash** | Fast agentic/coding volume | Not release authority | Google / AGY | Volume worker |
+| **Gemini 3.1 Pro** | Multilingual / designated UA language seat; semantic review | Not bulk CRUD default; language outputs need sources | Google / AGY | Language lane |
+| **K3** | Long-horizon coding; frontend/visual ideation | Maintainability ≠ demo; Moonshot route/egress | Moonshot | UI + long implement |
+| **GLM-5.2** | Deep bug/security; large-context code coherence | Weak UA pedagogy; **LOCAL-ONLY** China-egress | Zhipu / opencode local | Local CF code only; never CI |
+| **DeepSeek V4 Pro** | Economical coding and PR review | Not folk/UA cultural gate | Route-dependent (first-party vs openrouter) | Infra/code CF |
+| **Cursor Composer 2.5** | IDE-native implementation | **Harness**; pin backing **family** for CF | Cursor | Worker |
+
+---
+
+## 3. Author-family-conditional CF review (required)
+
+Never use a fixed unordered list that can pick the author’s family.
+
+| Author family | Prefer CF reviewers (code/infra) | Avoid as sole CF |
+|---|---|---|
+| Anthropic (Opus/Sonnet/Fable) | Grok, Sol/Terra (OpenAI), GLM local, DeepSeek, K3, Gemini | Sonnet/Opus/Fable self-family |
+| OpenAI (Sol/Terra/Luna) | Grok, Opus/Sonnet/Fable, GLM local, DeepSeek, K3, Gemini | Sol/Terra/Luna self-family |
+| xAI (Grok) | Opus/Sonnet/Fable, Sol/Terra, GLM local, DeepSeek, K3, Gemini | Grok self-family |
+| Google (Gemini via AGY) | Grok, OpenAI, Anthropic, GLM local, DeepSeek, K3 | Gemini self-family alone for CF of Gemini-authored infra |
+| Moonshot (K3) | Grok, OpenAI, Anthropic, GLM local, DeepSeek, Gemini | K3 self-family |
+| Zhipu (GLM) | Grok, OpenAI, Anthropic, DeepSeek, K3, Gemini | GLM self-family |
+
+**Task-family qualification overrides:** language CF must be LANGUAGE-LANES-qualified; FOLK remains GPT↔Claude per folk rubric.
+
+---
+
+## 4. Evidence ledger (promotion / demotion)
+
+### 4.1 Minimum fields per bakeoff cell
+
+| Field | Example |
+|---|---|
+| date | 2026-07-19 |
+| task_family | infra-fix / ui / language / cf-review / orchestrate |
+| model | `gpt-5.6-terra` |
+| family | OpenAI |
+| harness | codex |
+| effort | xhigh |
+| route | first-party / openrouter / … |
+| data_class | public-code |
+| corpus_ref | fixed fixture path or PR # |
+| outcome | pass/fail + notes |
+| cost_estimate | optional |
+| latency | optional |
+| adjudicator | other family or operator |
+
+### 4.2 Fixed evaluation corpus (minimum five cells)
+
+1. Thin orchestrator decision (route + stop/go)  
+2. 200–500 LOC infra fix with tests  
+3. UI component (Practice/Atlas chrome)  
+4. CF code review of a known PR (sealed `review-pr`)  
+5. UA lemma/stress sample with `sources` MCP  
+
+### 4.3 Thresholds (starting policy)
+
+| Event | Action |
+|---|---|
+| New major model release | Mark affected rows **provisional**; run ≥3 relevant cells |
+| New xAI ceiling model | Bakeoff vs Sol/Fable before **advisor** seat |
+| 2 consecutive fails on validated cell | Demote to provisional; consider deprecated for that task family |
+| Validated win on hard cell | May promote within role (not auto-orchestrator) |
+
+Store bakeoff notes under `docs/best-practices/fleet-bakeoffs/` (create when first probe is recorded) or link GH issue.
+
+---
+
+## 5. Escalation ladder (implementation)
+
+```
+Luna / Gemini 3.5 Flash recon
+  → Sonnet 5 / Grok 4.5 / Terra implement (worktree)
+    → escalate immediately if security / high blast radius / unclear invariants / multi-architecture
+    → otherwise escalate after evidence-backed root-cause attempts fail
+      → Sol or Fable (xhigh) advisory or hard implement
+        → orchestrator integrates
+        → CF review: other family + task-qualified
+```
+
+---
+
+## 6. SuperGrok Heavy and future xAI ceiling
+
+| Entitlement | Treat as | Do not treat as |
+|---|---|---|
+| SuperGrok Heavy | Verified **capacity** for longer/more parallel Grok workers | Automatic intelligence rank or orchestrator promotion |
+| Future xAI Fable/Sol-class | **Candidate** ceiling advisor + hard coder after bakeoff | Auto king of fleet / sole orchestrator |
+
+Re-verify capacity and routing when the subscription plan or API routing changes.
+
+---
+
+## 7. Fallback / substitution
+
+1. Prefer `scripts/config/agent_fallback_substitutions.yaml` + harness table in model-assignment.  
+2. Never silently lower quality floor on consequential work.  
+3. Always **NOTE** substitution (model, family, harness, reason) on PR or orchestration artifact.
+
+---
+
+## 8. Quick routing card
+
+```text
+Routine code/fix          → Sonnet 5 | Terra | Grok 4.5
+Hard code (ceiling)         → Sol | Fable 5 (after mid-tier wall or known ceiling)
+Orchestrate stream          → Opus 4.8 | Terra xhigh  (exactly one)
+UI / visual product         → K3 explore → Sonnet/Terra/Grok implement → Sol if systems-hard
+UA language                 → Gemini 3.1 Pro (AGY) + VESUM/sources
+Security/bug CF             → author-family-conditional (Grok/GLM/DeepSeek/Opus/…)
+Architecture decision       → Sol/Fable advisory → orchestrator decides
+Recon                       → Luna | Gemini 3.5 Flash
+```
+
+---
+
+## 9. Change log
+
+| Date | Change | Confidence note | By |
+|---|---|---|---|
+| 2026-07-19 | Initial scorecard from operator intent + web research + Sol #3588/#3593 | **drafted / provisional** — not full bakeoff-validated | grok/fleet-doctrine-scorecard |
+
+**Approval authority:** operator for ceiling-seat changes; orchestrator may update provisional notes and evidence ledger.

--- a/docs/best-practices/fleet-shared-doctrine.md
+++ b/docs/best-practices/fleet-shared-doctrine.md
@@ -1,0 +1,195 @@
+# Fleet shared doctrine — roles, cost discipline, living classification
+
+**Status:** operator doctrine (binding for routing judgment; see precedence)  
+**Classification state:** drafted 2026-07-19 (Sol draft review #3593 `APPROVE_WITH_AMENDS` applied)  
+**Maintains with:** [`fleet-role-scorecard.md`](fleet-role-scorecard.md)  
+**Complements:**
+
+- `agents_extensions/shared/rules/model-assignment.md` — machine routing / LANGUAGE-LANES  
+- [`agent-bridge.md`](agent-bridge.md) — review isolation, `review-pr`, worktree reaper  
+- `agents_extensions/shared/rules/operator-expectations.md` — operator contract  
+
+---
+
+## 0. Precedence (fail closed)
+
+When instructions conflict, apply **in this order**:
+
+1. Operator contract (`operator-expectations.md` and hard repo gates)  
+2. `model-assignment.md` / served `/api/rules` machine routing  
+3. **This doctrine** + scorecard  
+4. Session preference / ad-hoc “use the smartest model”  
+
+If a scorecard row conflicts with LANGUAGE-LANES, egress, or review-gate rules → **fail closed** (refuse the route; do not invent a silent substitution).
+
+---
+
+## 1. Terminology
+
+| Term | Meaning |
+|---|---|
+| **Family** | Independence unit for CF review (e.g. Anthropic, OpenAI, xAI, Google, Moonshot, Zhipu/GLM, DeepSeek, Cursor-backed-*pinned*). |
+| **Provider** | Who hosts the weights/API (OpenAI, Anthropic, xAI, Google, …). |
+| **Harness** | Runtime that invokes the model (native Claude CLI, Codex, Grok Build, AGY, Hermes, Cursor, opencode). **Cursor is a harness/product**, not automatically a family. |
+| **Route** | Concrete path: provider + intermediary (if any) + region/retention class. |
+| **Egress** | Where prompt/code data may leave (Western lab, China-route, local-only). |
+| **CF review** | Cross-**family** formal review of a change; discussion/panel alone does **not** satisfy the gate. |
+| **Consequential** | Work that can merge to `main`, change learner-facing Atlas/curriculum, alter security/CI gates, or spend non-trivial quota on multi-agent implementation. |
+| **Ceiling model** | Sol, Fable 5, and any future peer (e.g. expected xAI Fable/Sol-class) reserved for hard design/diagnostic/architecture. |
+| **Provisional / validated / deprecated** | Scorecard assignment confidence (see scorecard § evidence). |
+
+---
+
+## 2. Core principle
+
+**Roles beat models.** Models rotate on accelerated schedules; roles stay stable:
+
+`advisor · orchestrator · worker · CF reviewer · language · UI · recon`
+
+Assign by **role × task family × harness × route/egress**, not marketing rank or “newest frontier.”
+
+---
+
+## 3. Role definitions
+
+| Role | Job | Must not |
+|---|---|---|
+| **Ceiling advisor** | Architecture options, ambiguous multi-system failure, security/reliability disposition, hard curriculum **policy**, final **advisory** synthesis after evidence exists | Routine orchestration; first-pass implementation; recon; formatting; rubber-stamp “bless” without evidence |
+| **Accountable orchestrator** | **Exactly one per stream**: scope, sequence, dispatch, integration, review routing, **terminal disposition** (merge/close/handoff) | Be sole CF reviewer of own stream’s consequential PR; bulk worker coding in interactive session |
+| **Worker** | Implementation, tests, refactors, PR drafts in worktrees | Self-approve own formal review gate |
+| **Independent CF reviewer** | Outside author **family** and **qualified for task family** (code vs language vs folk) | Same family as author; unqualified lane (e.g. DeepSeek for folk); discuss-as-review |
+| **Language seat** | Ukrainian phrasing, morphology **hypotheses**, CEFR/pedagogy with `sources` MCP | China-egress cheap coders as UA cultural/factual authority |
+| **UI design seat** | Interaction/visual/frontend concepts | Skip maintainability/a11y because a demo looks pretty |
+| **Recon** | Search, logs, triage, evidence collection | Sole release authority |
+
+**Advisor vs orchestrator:** advisor “final synthesis” is **recommendation only**. The **accountable orchestrator alone** owns terminal disposition.
+
+**Advisor conflict:** if high-risk work was **materially designed** by an advisor, obtain dissent/review **outside** both that advisor’s family and the author’s family where practical.
+
+---
+
+## 4. Cost discipline (Sol / Fable / future xAI ceiling)
+
+- Use ceiling models **often** on *qualifying* hard work — not rarely, and not as free general labor.  
+- **Never** default ceiling models as orchestrator or first-pass implementer.  
+- **Escalation triggers (immediate):** security; high blast radius; unclear invariants; architectural ambiguity with multiple viable options; release-level uncertainty.  
+- **Escalation after evidence-backed attempts:** repeated failed **root-cause** fixes (not blind “retry 2×”).  
+- **Do not** escalate merely because the task is “important.”  
+- **SuperGrok Heavy** (and similar plans): **verified capacity entitlement** for longer/more parallel Grok worker runs — **not** a stable capability rank. Re-check when plan or routing changes.  
+- **Future xAI Fable/Sol-class:** candidate ceiling advisor/hard coder **after bakeoff**; do not auto-promote to orchestrator.
+
+### Effort guidance (per model)
+
+| Model | Effort |
+|---|---|
+| Sol | Floor **`high`**; prefer **`xhigh`/`max`** for qualifying hard decisions |
+| Fable 5 | Prefer **`xhigh`** for ceiling work |
+| Terra (orchestrating hard stream) | **`xhigh`** |
+| Terra (routine implement) | **`medium`–`high`**, escalate with risk |
+| Opus orchestrating | **`high`+** |
+| Luna recon | **`medium`** default; never sole authority |
+
+---
+
+## 5. Orchestration vs work vs review
+
+| Activity | Entry |
+|---|---|
+| Thin orchestration | Interactive Opus / Terra (one owner per stream) |
+| Implementation | `scripts/delegate.py dispatch --worktree` |
+| Formal code CF review | `scripts/ai_agent_bridge` **`review-pr`** (pointer-only; sealed when available) |
+| Advisory design | Bounded Sol/Fable ask with **explicit decision question** |
+| Multi-agent debate | `discuss` — **not** the merge gate |
+
+Interactive orchestrators stay **thin** (status, route, approve, merge). Workers hold bulk context in worktrees.
+
+---
+
+## 6. Cross-family review (necessary, not sufficient)
+
+For work in the **repository review-gate scope** (consequential PRs that must pass the operator CF gate before merge):
+
+1. Reviewer **family ≠ author family**.  
+2. Reviewer must be **qualified for the task family** (code/infra vs VESUM language vs folk).  
+3. Prefer `review-pr` / sealed isolation; never primary-checkout toolful review.  
+4. Record provenance on the PR (implementer + reviewer model/family/harness; note advisor if material).  
+5. **Conditional selection:** do not offer Terra as CF for OpenAI-authored PRs, or Sonnet as CF for Anthropic-authored PRs, etc.
+
+Authoritative CF quality ladder remains in `model-assignment.md`; this doctrine does not lower that floor.
+
+---
+
+## 7. Language + evidence
+
+- **LANGUAGE-LANES** for load-bearing Ukrainian judgment: `agy` / `codex` / `claude` / `grok-4.5` only (see model-assignment).  
+- **Gemini 3.1 Pro via AGY** is the designated UA specialist; outputs remain **hypotheses until VESUM/`sources`-backed**.  
+- VESUM validates **morphology/attestation** — not arbitrary cultural or historical claims.  
+- FOLK: GPT↔Claude cultural gate; **no DeepSeek** for folk culture.
+
+---
+
+## 8. Egress and data class (route-level)
+
+Before dispatch, classify **data class** and **route**:
+
+| Data class | Default |
+|---|---|
+| Public open-source code | Standard fleet routes OK |
+| Curriculum drafts / unreleased content | Prefer Western lab routes; record route |
+| Secrets, tokens, learner PII | **Default-deny** external routes |
+| Local-only policy lanes (GLM, some DeepSeek) | Never CI; never sensitive classes |
+
+Record when relevant: **provider, intermediary, region/retention, data class**. Brand labels (“China”) are insufficient without the concrete route.
+
+---
+
+## 9. Living classification
+
+Models improve on an accelerated schedule. Classification is a **maintenance duty**, not a one-time opinion.
+
+- After **every major release** (including SuperGrok Heavy changes / new xAI ceiling): re-probe scorecard cells.  
+- Else **quarterly** full re-score.  
+- Public benchmarks = **priors only**; local bakeoffs + evidence ledger drive promotion.  
+- Capability **peak is unknown**; **value** today is routing hygiene + harness + evidence, not waiting for AGI.
+
+See scorecard for provisional/validated/deprecated states and re-probe protocol.
+
+---
+
+## 10. Fallback and substitution
+
+When a preferred lane is at quota/outage:
+
+1. Use `scripts/config/agent_fallback_substitutions.yaml` + model-assignment harness table.  
+2. **Never** silently lower quality floor for consequential work.  
+3. **Always** record substitution (model/family/harness + reason) in the PR or orchestration note.
+
+---
+
+## 11. Anti-patterns
+
+- Sol/Fable for search, format, routine tests, first-pass CRUD.  
+- Sol/Fable only at the end to bless a design they never challenged.  
+- Any single model as sole orchestrator + implementer + CF reviewer on a consequential stream.  
+- Flash/Luna as release authority.  
+- Discuss/panel counted as CF review.  
+- Cursor “review” without **pinned** backing model family.  
+- Unqualified language/folk reviewers.  
+- China-egress / local-only routes on unclassified or sensitive data.  
+- Blind “fail twice then escalate” without root-cause evidence.
+
+---
+
+## 12. Change control
+
+| Field | Value |
+|---|---|
+| Approval authority | Operator; orchestrator may draft updates |
+| Sol review of this draft | Bridge ask `sol-fleet-docs-draft-review` reply #3593 |
+| Next action after major xAI ceiling ship | Bakeoff + scorecard bump before advisor promotion |
+
+**Changelog**
+
+| Date | Change | By |
+|---|---|---|
+| 2026-07-19 | Initial doctrine (research + Sol #3588/#3593 amends) | grok/fleet-doctrine-scorecard |


### PR DESCRIPTION
## Summary

Adds durable fleet classification docs after research + Sol review:

1. **`docs/best-practices/fleet-shared-doctrine.md`** — roles, cost discipline (Sol/Fable not routine orchestrators), CF/language/egress, living classification, anti-patterns, precedence fail-closed.
2. **`docs/best-practices/fleet-role-scorecard.md`** — living scorecard (provisional/validated/deprecated), model cards, author-family-conditional CF matrix, evidence ledger + re-probe checklist, SuperGrok Heavy / future xAI ceiling handling.
3. Pointer from **`agent-bridge.md`**.

### Process
- Web research (Fable/Opus/Sonnet, GPT-5.6 Sol/Terra/Luna, Grok 4.5, Gemini, K3, etc.)
- Operator intent (2026-07-19)
- Sol #3588 classification + Sol #3593 draft-doc review (`APPROVE_WITH_AMENDS` incorporated)

### Non-goals
- Does not rewrite `model-assignment.md` machine tables (complements; that file wins on conflict)
- Scorecard cells marked **provisional** until local bakeoffs

X-Agent: grok/fleet-doctrine-scorecard