### PR TITLE
docs(fleet): add Claude Haiku to recon seat

### DIFF
--- a/docs/best-practices/fleet-role-scorecard.md
+++ b/docs/best-practices/fleet-role-scorecard.md
@@ -31,7 +31,7 @@
 | Code/security CF review | **Author-family-conditional** (see §3) | — | `high`+ | provisional |
 | Critical CF review | Sol ↔ Fable/Opus **cross-family** | — | `xhigh` | provisional |
 | Ukrainian language | Gemini 3.1 Pro (AGY) | LANGUAGE-LANES: codex/claude/grok-4.5 + sources | `high` | provisional (UA primacy AGY; morphology still VESUM-gated) |
-| Recon / triage | Luna, Gemini 3.5 Flash | — | `medium`–`high`; never sole release | provisional |
+| Recon / triage | Luna, Claude Haiku, Gemini 3.5 Flash | — | `medium`–`high`; never sole release | provisional |
 
 **One orchestrator per stream.** Advisors recommend; orchestrator owns terminal disposition.
 
@@ -46,6 +46,7 @@
 | **Opus 4.8** | Durable long agentic sessions; orchestration; architecture | Costly as bulk worker | Anthropic | Prefer orchestrator |
 | **Terra** | Balanced implementer/orchestrator; strong everyday agentic | Not Sol/Fable ceiling | OpenAI / Codex | Orchestrator + worker |
 | **Luna** | Fast recon, cheap mechanical checks | Never sole architecture/security/language/release authority | OpenAI / Codex | Recon |
+| **Claude Haiku** | Fast cheap recon/triage on Anthropic lane; good for log/search skim | Never sole architecture/security/language/release authority | Anthropic | Recon (with Luna / 3.5 Flash) |
 | **Sonnet 5** | Near-flagship coding at better cost; daily driver agentic | Escalate systemic ambiguity | Anthropic | Default worker |
 | **Grok 4.5** | Strong coding agent; token-efficient; good CF review value | Prefer worker/reviewer not sole orchestrator | xAI; SuperGrok Heavy = capacity entitlement (re-verify) | Worker + CF review |
 | **Gemini 3.5 Flash** | Fast agentic/coding volume | Not release authority | Google / AGY | Volume worker |
@@ -118,7 +119,7 @@ Store bakeoff notes under `docs/best-practices/fleet-bakeoffs/` (create when fir
 ## 5. Escalation ladder (implementation)
 
 ```
-Luna / Gemini 3.5 Flash recon
+Luna / Claude Haiku / Gemini 3.5 Flash recon
   → Sonnet 5 / Grok 4.5 / Terra implement (worktree)
     → escalate immediately if security / high blast radius / unclear invariants / multi-architecture
     → otherwise escalate after evidence-backed root-cause attempts fail
@@ -158,7 +159,7 @@ UI / visual product         → K3 explore → Sonnet/Terra/Grok implement → S
 UA language                 → Gemini 3.1 Pro (AGY) + VESUM/sources
 Security/bug CF             → author-family-conditional (Grok/GLM/DeepSeek/Opus/…)
 Architecture decision       → Sol/Fable advisory → orchestrator decides
-Recon                       → Luna | Gemini 3.5 Flash
+Recon                       → Luna | Claude Haiku | Gemini 3.5 Flash
 ```
 
 ---
@@ -168,5 +169,6 @@ Recon                       → Luna | Gemini 3.5 Flash
 | Date | Change | Confidence note | By |
 |---|---|---|---|
 | 2026-07-19 | Initial scorecard from operator intent + web research + Sol #3588/#3593 | **drafted / provisional** — not full bakeoff-validated | grok/fleet-doctrine-scorecard |
+| 2026-07-19 | Add Claude Haiku to recon seat (with Luna / Gemini 3.5 Flash) | provisional | grok/fleet-scorecard-haiku-recon |
 
 **Approval authority:** operator for ceiling-seat changes; orchestrator may update provisional notes and evidence ledger.

--- a/docs/best-practices/fleet-shared-doctrine.md
+++ b/docs/best-practices/fleet-shared-doctrine.md
@@ -87,7 +87,7 @@ Assign by **role × task family × harness × route/egress**, not marketing rank
 | Terra (orchestrating hard stream) | **`xhigh`** |
 | Terra (routine implement) | **`medium`–`high`**, escalate with risk |
 | Opus orchestrating | **`high`+** |
-| Luna recon | **`medium`** default; never sole authority |
+| Luna / Claude Haiku recon | **`medium`** default; never sole authority |
 
 ---
 
@@ -171,7 +171,7 @@ When a preferred lane is at quota/outage:
 - Sol/Fable for search, format, routine tests, first-pass CRUD.  
 - Sol/Fable only at the end to bless a design they never challenged.  
 - Any single model as sole orchestrator + implementer + CF reviewer on a consequential stream.  
-- Flash/Luna as release authority.  
+- Flash/Luna/Haiku as release authority.  
 - Discuss/panel counted as CF review.  
 - Cursor “review” without **pinned** backing model family.  
 - Unqualified language/folk reviewers.  
@@ -193,3 +193,4 @@ When a preferred lane is at quota/outage:
 | Date | Change | By |
 |---|---|---|
 | 2026-07-19 | Initial doctrine (research + Sol #3588/#3593 amends) | grok/fleet-doctrine-scorecard |
+| 2026-07-19 | Haiku listed with Luna for recon effort guidance / anti-patterns | grok/fleet-scorecard-haiku-recon |


### PR DESCRIPTION
## Summary

Operator direction: recon may use **Claude Haiku** as well as Luna and Gemini 3.5 Flash.

Updates:
- `docs/best-practices/fleet-role-scorecard.md` — recon row, model card, escalation ladder, quick routing
- `docs/best-practices/fleet-shared-doctrine.md` — effort guidance + anti-patterns

Haiku remains **never sole release authority** (same as Luna/Flash).

X-Agent: grok/fleet-scorecard-haiku-recon