### PR TITLE
feat(readiness): enforce preparation profile guarantees

### DIFF
--- a/agents_extensions/shared/curriculum-lifecycle/config/pilot-matrix.v1.yaml
+++ b/agents_extensions/shared/curriculum-lifecycle/config/pilot-matrix.v1.yaml
@@ -293,15 +293,15 @@ rows:
       forbidden: [FOLK seminar direction]
     expected:
       module_state: unbuilt
-      preparation_state: current
-      state: prepared-plan
-      next_action: build
-      disposition: build-required
+      preparation_state: missing
+      state: preparation-required
+      next_action: prepare
+      disposition: preparation-required
       cleanup_state: unchanged
     transitions:
-      - event: PREPARE_PASSED
-        from: prepared-plan
-        to: build-required
+      - event: PREPARATION_REQUIREMENTS_MISSING
+        from: preparation-required
+        to: preparation-required
     resume_evidence: test_prepared_unbuilt_bio_uses_real_validators_and_exact_sources
   - id: c1-unbuilt-shadow
     kind: repository
@@ -316,13 +316,13 @@ rows:
       module_state: unbuilt
       preparation_state: missing
       state: preparation-required
-      next_action: plan
-      disposition: plan-review-required
+      next_action: prepare
+      disposition: preparation-required
       cleanup_state: unchanged
     transitions:
-      - event: PLAN_MISSING
+      - event: PREPARATION_REQUIREMENTS_MISSING
         from: preparation-required
-        to: plan-review-required
+        to: preparation-required
     resume_evidence: test_unbuilt_core_and_generic_seminar_profile_seams
   - id: c2-unbuilt-shadow
     kind: repository
@@ -337,13 +337,13 @@ rows:
       module_state: unbuilt
       preparation_state: missing
       state: preparation-required
-      next_action: plan
-      disposition: plan-review-required
+      next_action: prepare
+      disposition: preparation-required
       cleanup_state: unchanged
     transitions:
-      - event: PLAN_MISSING
+      - event: PREPARATION_REQUIREMENTS_MISSING
         from: preparation-required
-        to: plan-review-required
+        to: preparation-required
     resume_evidence: test_unbuilt_core_and_generic_seminar_profile_seams
   - id: seminar-unbuilt-shadow
     kind: repository
@@ -356,15 +356,15 @@ rows:
       forbidden: ['BIO only: make the learner exposition a sourced life story', FOLK seminar direction]
     expected:
       module_state: unbuilt
-      preparation_state: current
-      state: prepared-plan
-      next_action: build
-      disposition: build-required
+      preparation_state: missing
+      state: preparation-required
+      next_action: prepare
+      disposition: preparation-required
       cleanup_state: unchanged
     transitions:
-      - event: PREPARE_PASSED
-        from: prepared-plan
-        to: build-required
+      - event: PREPARATION_REQUIREMENTS_MISSING
+        from: preparation-required
+        to: preparation-required
     resume_evidence: test_unbuilt_core_and_generic_seminar_profile_seams
   - id: partial-ambiguous-fixture
     kind: fixture

--- a/agents_extensions/shared/curriculum-lifecycle/config/readiness-profiles.v1.yaml
+++ b/agents_extensions/shared/curriculum-lifecycle/config/readiness-profiles.v1.yaml
@@ -8,7 +8,7 @@ selectors:
     track: seminar
 profiles:
   core:
-    version: 1.0.0
+    version: 1.1.0
     family: core
     prompt_profile: core
     requirements:
@@ -17,18 +17,33 @@ profiles:
         options:
           - artifact: plan
             validators: [exists, plan-check]
-  seminar:
-    version: 1.0.0
-    family: seminar
-    prompt_profile: seminar
-    requirements:
-      - id: plan
-        owner: plan
+      - id: research-evidence
+        owner: preparation
+        options:
+          - artifact: research
+            validators: [exists, research-quality]
+          - artifact: wiki-sources
+            validators: [exists, wiki-sources-registry]
+      - id: wiki-document
+        owner: preparation
+        options:
+          - artifact: wiki-document
+            validators: [exists, wiki-completeness]
+      - id: wiki-sources
+        owner: preparation
+        options:
+          - artifact: wiki-sources
+            validators: [exists, wiki-sources-registry]
+      - id: reading-or-rights
+        owner: preparation
         options:
           - artifact: plan
-            validators: [exists, plan-check, seminar-plan-language]
-  bio:
-    version: 1.0.0
+            validators: [exists, verified-reading-catalog]
+          - artifact: manual-registry
+            validators: [exists, manual-gate]
+            manual_gate: reading_rights
+  seminar:
+    version: 1.1.0
     family: seminar
     prompt_profile: seminar
     requirements:
@@ -36,7 +51,40 @@ profiles:
         owner: preparation
         options:
           - artifact: dossier
-            validators: [exists, bio-dossier-xref]
+            validators: [exists, research-quality]
+      - id: plan
+        owner: plan
+        options:
+          - artifact: plan
+            validators: [exists, plan-check, seminar-plan-language]
+      - id: wiki-document
+        owner: preparation
+        options:
+          - artifact: wiki-document
+            validators: [exists, wiki-completeness, seminar-wiki-language]
+      - id: wiki-sources
+        owner: preparation
+        options:
+          - artifact: wiki-sources
+            validators: [exists, wiki-sources-registry]
+      - id: reading-or-rights
+        owner: preparation
+        options:
+          - artifact: plan
+            validators: [exists, verified-reading-catalog]
+          - artifact: manual-registry
+            validators: [exists, manual-gate]
+            manual_gate: reading_rights
+  bio:
+    version: 1.1.0
+    family: seminar
+    prompt_profile: seminar
+    requirements:
+      - id: dossier
+        owner: preparation
+        options:
+          - artifact: dossier
+            validators: [exists, bio-dossier-xref, research-quality]
       - id: dossier-grounding
         owner: preparation
         options:
@@ -52,7 +100,7 @@ profiles:
         owner: preparation
         options:
           - artifact: plan
-            validators: [exists, readings-present]
+            validators: [exists, verified-reading-catalog, bio-reading-policy]
           - artifact: manual-registry
             validators: [exists, manual-gate]
             manual_gate: reading_rights
@@ -65,7 +113,7 @@ profiles:
         owner: preparation
         options:
           - artifact: wiki-sources
-            validators: [exists, yaml-mapping]
+            validators: [exists, wiki-sources-registry]
       - id: wiki-grounding
         owner: preparation
         options:

--- a/agents_extensions/shared/curriculum-lifecycle/schema/readiness-profiles.v1.schema.json
+++ b/agents_extensions/shared/curriculum-lifecycle/schema/readiness-profiles.v1.schema.json
@@ -67,7 +67,7 @@
       "required": ["artifact", "validators"],
       "properties": {
         "artifact": {
-          "enum": ["dossier", "plan", "manual-registry", "wiki-document", "wiki-sources", "discovery"]
+          "enum": ["research", "dossier", "plan", "manual-registry", "wiki-document", "wiki-sources", "discovery"]
         },
         "validators": {
           "type": "array",
@@ -79,7 +79,10 @@
               "yaml-mapping",
               "plan-check",
               "seminar-plan-language",
-              "readings-present",
+              "research-quality",
+              "wiki-sources-registry",
+              "verified-reading-catalog",
+              "bio-reading-policy",
               "bio-dossier-xref",
               "manual-gate",
               "wiki-completeness",

--- a/scripts/orchestration/curriculum_readiness.py
+++ b/scripts/orchestration/curriculum_readiness.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from jsonschema import Draft202012Validator
 
@@ -28,8 +29,10 @@ from scripts.orchestration.preparation_evidence import (
     load_manual_evidence,
     load_yaml_mapping,
 )
+from scripts.research import research_quality
 from scripts.validate import check_discovery_integrity, check_wiki_subject, lint_seminar_quality
 from scripts.wiki.domains import resolve_write_domain
+from scripts.wiki.sources_schema import load_sources_registry, validate_sources_registry
 
 CONFIG_PATH = Path("agents_extensions/shared/curriculum-lifecycle/config/readiness-profiles.v1.yaml")
 CONFIG_SCHEMA_PATH = Path(
@@ -43,6 +46,36 @@ MODULE_BUNDLE_FILES = ("module.md", "activities.yaml", "vocabulary.yaml", "resou
 DEPENDENT_EVIDENCE_CLASSES = frozenset({"build", "post-build", "production-qg"})
 _TARGET_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 _HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_RESEARCH_PASS_QUALITIES = frozenset({"solid", "exemplary"})
+_READING_PLACEHOLDERS = frozenset({"needed", "reading-needed", "tbd", "todo"})
+_READING_URL_FIELDS = ("url", "source_url", "source")
+_READING_INTERNAL_FIELDS = (
+    "source_locator",
+    "corpus_id",
+    "internal_source",
+    "internal_source_id",
+)
+_BIO_REFERENCE_ROLES = frozenset({"reference", "context", "source-critical"})
+_BIO_REFERENCE_TYPES = frozenset(
+    {"reference", "encyclopedia", "scholarly", "institutional", "wikipedia"}
+)
+_BIO_DEPTH_ROLES = frozenset({"required-reading", "primary-voice", "primary"})
+_BIO_DEPTH_TYPES = frozenset(
+    {
+        "primary",
+        "near-primary",
+        "primary-source",
+        "primary-text",
+        "textbook",
+        "scholarly",
+        "institutional",
+        "archive",
+        "museum",
+        "media",
+        "article",
+        "academic-article",
+    }
+)
 
 
 class ReadinessError(ValueError):
@@ -167,10 +200,23 @@ def _source(role: str, path: Path, repo_root: Path) -> dict[str, Any]:
     }
 
 
+def _research_path(repo_root: Path, track: str, slug: str) -> Path:
+    """Resolve the existing research/knowledge-packet path shapes deterministically."""
+    candidates = (
+        repo_root / "curriculum" / "l2-uk-en" / track / "research" / f"{slug}-research.md",
+        repo_root / "curriculum" / "l2-uk-en" / track / "research" / f"{slug}-knowledge-packet.md",
+        repo_root / "docs" / "research" / track / f"{slug}.md",
+        repo_root / "docs" / "research" / track / f"{slug}-research.md",
+        repo_root / "docs" / "research" / track / f"{slug}-knowledge-packet.md",
+    )
+    return next((path for path in candidates if path.is_file()), candidates[0])
+
+
 def artifact_path(artifact: str, repo_root: Path, track: str, slug: str) -> Path:
     """Resolve a registered artifact ID without track-name branches."""
     curriculum = repo_root / "curriculum" / "l2-uk-en"
     resolvers: dict[str, Callable[[], Path]] = {
+        "research": lambda: _research_path(repo_root, track, slug),
         "dossier": lambda: repo_root / "docs" / "research" / track / f"{slug}.md",
         "plan": lambda: curriculum / "plans" / track / f"{slug}.yaml",
         "manual-registry": lambda: curriculum / track / "promotion-evidence.yaml",
@@ -218,14 +264,143 @@ def _seminar_plan_language(
     return ValidationResult(not findings, f"{len(findings)} high seminar-language finding(s)")
 
 
-def _readings_present(path: Path, _option: Mapping[str, Any], _context: ValidationContext) -> ValidationResult:
+def _research_quality(
+    path: Path,
+    _option: Mapping[str, Any],
+    context: ValidationContext,
+) -> ValidationResult:
+    discovery_path = artifact_path("discovery", context.repo_root, context.track, context.slug)
+    assessment = research_quality.assess_research_compat(
+        path,
+        context.track,
+        discovery_path=discovery_path if discovery_path.is_file() else None,
+    )
+    if not isinstance(assessment, Mapping):
+        return ValidationResult(False, "research quality assessment is unavailable")
+    quality = assessment.get("quality")
+    score = assessment.get("score")
+    passed = (
+        quality in _RESEARCH_PASS_QUALITIES
+        and isinstance(score, (int, float))
+        and not isinstance(score, bool)
+        and score >= 7
+    )
+    return ValidationResult(
+        passed,
+        f"research quality {quality or 'unrated'} ({score if score is not None else 'unrated'}/10)",
+    )
+
+
+def _wiki_sources_registry(
+    path: Path,
+    _option: Mapping[str, Any],
+    context: ValidationContext,
+) -> ValidationResult:
+    try:
+        raw = load_yaml_mapping(path)
+        raw_sources = raw.get("sources")
+        if not isinstance(raw_sources, list) or not raw_sources:
+            return ValidationResult(False, "wiki source registry needs a non-empty sources list")
+        if not all(isinstance(item, Mapping) for item in raw_sources):
+            return ValidationResult(False, "wiki source registry entries must be mappings")
+        registry = load_sources_registry(path)
+        if not registry.sources:
+            return ValidationResult(False, "wiki source registry has no valid entries")
+        article_path = artifact_path("wiki-document", context.repo_root, context.track, context.slug)
+        article_text = article_path.read_text(encoding="utf-8", errors="strict")
+        issues = validate_sources_registry(article_text, registry)
+    except (KeyError, OSError, TypeError, UnicodeDecodeError, ValueError) as exc:
+        return ValidationResult(False, f"invalid wiki source registry: {exc}")
+    if issues:
+        return ValidationResult(False, issues[0])
+    return ValidationResult(True, f"valid source-backed wiki registry ({len(registry.sources)} entries)")
+
+
+def _normalized_category(value: object) -> str:
+    return re.sub(r"[_\s]+", "-", str(value or "").strip().casefold())
+
+
+def _usable_reading_value(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    normalized = value.strip().casefold()
+    return normalized not in _READING_PLACEHOLDERS and "reading-needed" not in normalized
+
+
+def _http_url(value: object) -> bool:
+    if not _usable_reading_value(value):
+        return False
+    parsed = urlparse(str(value).strip())
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _reading_catalog(path: Path) -> tuple[list[Mapping[str, Any]] | None, str]:
     try:
         plan = load_yaml_mapping(path)
     except RegistryValidationError as exc:
-        return ValidationResult(False, str(exc))
+        return None, str(exc)
     readings = plan.get("readings")
-    passed = isinstance(readings, list) and bool(readings)
-    return ValidationResult(passed, "plan reading packet is present" if passed else "plan has no reading packet")
+    if not isinstance(readings, list) or not readings:
+        return None, "plan needs a non-empty readings list"
+    entries: list[Mapping[str, Any]] = []
+    for index, raw_entry in enumerate(readings, start=1):
+        if not isinstance(raw_entry, Mapping):
+            return None, f"reading {index} must be a mapping"
+        if not any(
+            _usable_reading_value(raw_entry.get(field))
+            for field in ("title", "name", "source_name")
+        ):
+            return None, f"reading {index} needs a usable title, name, or source_name"
+        has_url = any(_http_url(raw_entry.get(field)) for field in _READING_URL_FIELDS)
+        has_internal = any(
+            _usable_reading_value(raw_entry.get(field)) for field in _READING_INTERNAL_FIELDS
+        )
+        if not has_url and not has_internal:
+            return None, f"reading {index} needs an HTTP(S) URL or explicit internal source locator"
+        entries.append(raw_entry)
+    return entries, f"verified reading catalog ({len(entries)} entries)"
+
+
+def _verified_reading_catalog(
+    path: Path,
+    _option: Mapping[str, Any],
+    _context: ValidationContext,
+) -> ValidationResult:
+    entries, detail = _reading_catalog(path)
+    return ValidationResult(entries is not None, detail)
+
+
+def _bio_reading_policy(
+    path: Path,
+    _option: Mapping[str, Any],
+    _context: ValidationContext,
+) -> ValidationResult:
+    entries, detail = _reading_catalog(path)
+    if entries is None:
+        return ValidationResult(False, detail)
+    non_ukrainian = [
+        index
+        for index, entry in enumerate(entries, start=1)
+        if _normalized_category(entry.get("language")) != "uk"
+    ]
+    if non_ukrainian:
+        return ValidationResult(False, f"BIO readings must all use language: uk; invalid: {non_ukrainian}")
+
+    reference_indexes: set[int] = set()
+    depth_indexes: set[int] = set()
+    for index, entry in enumerate(entries):
+        role = _normalized_category(entry.get("role"))
+        source_type = _normalized_category(entry.get("source_type", entry.get("type")))
+        if role in _BIO_REFERENCE_ROLES or source_type in _BIO_REFERENCE_TYPES:
+            reference_indexes.add(index)
+        if role in _BIO_DEPTH_ROLES or source_type in _BIO_DEPTH_TYPES:
+            depth_indexes.add(index)
+    if not any(reference != depth for reference in reference_indexes for depth in depth_indexes):
+        return ValidationResult(
+            False,
+            "BIO readings need distinct reference/context and primary/near-primary/textbook/article entries",
+        )
+    return ValidationResult(True, f"Ukrainian-only BIO reading minimum passed ({len(entries)} entries)")
 
 
 def _bio_dossier_xref(
@@ -294,7 +469,10 @@ VALIDATORS: dict[str, Validator] = {
     "yaml-mapping": _yaml_mapping,
     "plan-check": _plan_check,
     "seminar-plan-language": _seminar_plan_language,
-    "readings-present": _readings_present,
+    "research-quality": _research_quality,
+    "wiki-sources-registry": _wiki_sources_registry,
+    "verified-reading-catalog": _verified_reading_catalog,
+    "bio-reading-policy": _bio_reading_policy,
     "bio-dossier-xref": _bio_dossier_xref,
     "manual-gate": _manual_gate,
     "wiki-completeness": _wiki_completeness,

--- a/tests/orchestration/test_curriculum_readiness.py
+++ b/tests/orchestration/test_curriculum_readiness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,45 @@ def _bio_fixture(tmp_path: Path) -> Path:
         f"wiki/figures/{BIO_SLUG}.sources.yaml",
     ):
         _copy(repo_root, relative)
+    dossier = repo_root / f"docs/research/bio/{BIO_SLUG}.md"
+    dossier.write_text(
+        dossier.read_text(encoding="utf-8")
+        + """
+
+## Використані джерела
+
+1. https://history.org.ua/fixture-one
+2. https://uk.wikipedia.org/wiki/Fixture_two
+3. https://esu.com.ua/fixture-three
+4. https://litopys.org.ua/fixture-four
+
+## Хронологія
+
+- 1900 — fixture event.
+- 1910 — fixture event.
+
+## Engagement Hooks
+
+- [!history] Fixture hook one.
+- [!context] Fixture hook two.
+- [!analysis] Fixture hook three.
+
+## Section-Mapped Research Notes
+
+### Section one
+
+Fixture note.
+
+### Section two
+
+Fixture note.
+
+### Section three
+
+Fixture note.
+""",
+        encoding="utf-8",
+    )
     return repo_root
 
 
@@ -89,6 +129,18 @@ def _create_bundle(repo_root: Path, track: str, slug: str) -> None:
         (directory / filename).write_text(f"fixture: {filename}\n", encoding="utf-8")
 
 
+def _requirement(result: Mapping, requirement_id: str) -> Mapping:
+    return next(item for item in result["requirements"] if item["id"] == requirement_id)
+
+
+def _write_readings(repo_root: Path, track: str, slug: str, readings: list[dict]) -> Path:
+    path = repo_root / f"curriculum/l2-uk-en/plans/{track}/{slug}.yaml"
+    plan = yaml.safe_load(path.read_text(encoding="utf-8"))
+    plan["readings"] = readings
+    path.write_text(yaml.safe_dump(plan, allow_unicode=True, sort_keys=False), encoding="utf-8")
+    return path
+
+
 def test_bio_profile_expresses_complete_preparation_without_track_branches() -> None:
     config = readiness.load_config(repo_root=REPO_ROOT)
     bio = config["profiles"]["bio"]
@@ -115,13 +167,31 @@ def test_bio_profile_expresses_complete_preparation_without_track_branches() -> 
     assert {
         "bio-dossier-xref",
         "plan-check",
-        "readings-present",
+        "research-quality",
+        "verified-reading-catalog",
+        "bio-reading-policy",
+        "wiki-sources-registry",
         "manual-gate",
         "wiki-completeness",
         "bio-wiki-subject",
         "bio-discovery-integrity",
     } <= validators
     assert set(config["profiles"]) == {"core", "seminar", "bio"}
+    assert {profile["version"] for profile in config["profiles"].values()} == {"1.1.0"}
+    assert {item["id"] for item in config["profiles"]["core"]["requirements"]} == {
+        "plan",
+        "research-evidence",
+        "wiki-document",
+        "wiki-sources",
+        "reading-or-rights",
+    }
+    assert {item["id"] for item in config["profiles"]["seminar"]["requirements"]} == {
+        "dossier",
+        "plan",
+        "wiki-document",
+        "wiki-sources",
+        "reading-or-rights",
+    }
     assert all("certification" not in profile for profile in config["profiles"].values())
     engine_source = (REPO_ROOT / "scripts/orchestration/curriculum_readiness.py").read_text(encoding="utf-8")
     assert 'track == "bio"' not in engine_source
@@ -161,6 +231,7 @@ def test_all_active_tracks_resolve_readiness_certification_and_prompt_profiles()
     assert set(certification_profiles) == set(active)
     assert set(semantic_profiles) == set(active)
     assert readiness_profiles["bio"] == "bio"
+    assert all(readiness_config["profiles"][profile_id]["version"] == "1.1.0" for profile_id in readiness_profiles.values())
     assert certification_profiles["bio"] == "bio-pending"
     assert semantic_profiles["a1"] == "core-a1"
     assert semantic_profiles["folk"] == "seminar-folk"
@@ -334,7 +405,7 @@ def test_preparation_change_invalidates_build_pbr_and_qg_identities(tmp_path: Pa
         ("hist", "track", "trypillian-civilization", "plans/hist/trypillian-civilization.yaml", "seminar"),
     ],
 )
-def test_unbuilt_core_and_generic_seminar_profile_seams(
+def test_unbuilt_core_and_generic_seminar_cannot_pass_from_plan_alone(
     tmp_path: Path,
     track: str,
     manifest_type: str,
@@ -351,8 +422,203 @@ def test_unbuilt_core_and_generic_seminar_profile_seams(
 
     assert result["profile_id"] == expected_profile
     assert result["module_state"] == "unbuilt"
-    assert result["state"] == "prepared-plan"
-    assert result["next_action"] == "build"
+    assert result["state"] == "preparation-required"
+    assert result["next_action"] == "prepare"
+    assert _requirement(result, "reading-or-rights")["passed"] is False
+    assert _requirement(result, "wiki-document")["passed"] is False
+    assert _requirement(result, "wiki-sources")["passed"] is False
+    research_id = "research-evidence" if expected_profile == "core" else "dossier"
+    assert _requirement(result, research_id)["passed"] is False
+
+
+def test_core_research_requirement_accepts_explicit_packet_or_wiki_registry(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    track = "a1"
+    slug = "sounds-letters-and-hello"
+
+    packet_root = tmp_path / "packet"
+    _copy_contracts(packet_root)
+    _write_manifest(packet_root, track, "core", slug)
+    _copy(packet_root, f"curriculum/l2-uk-en/plans/{track}/{slug}.yaml")
+    packet_path = packet_root / f"curriculum/l2-uk-en/{track}/research/{slug}-research.md"
+    packet_path.parent.mkdir(parents=True, exist_ok=True)
+    packet_path.write_text("# Deterministic research packet\n", encoding="utf-8")
+    monkeypatch.setattr(
+        readiness.research_quality,
+        "assess_research_compat",
+        lambda *_args, **_kwargs: {"quality": "solid", "score": 7},
+    )
+
+    packet_result = readiness.evaluate_preparation(track, slug, repo_root=packet_root)
+    packet_requirement = _requirement(packet_result, "research-evidence")
+    assert packet_requirement["passed"] is True
+    assert [option["passed"] for option in packet_requirement["options"]] == [True, False]
+
+    registry_root = tmp_path / "registry"
+    _copy_contracts(registry_root)
+    _write_manifest(registry_root, track, "core", slug)
+    for relative in (
+        f"curriculum/l2-uk-en/plans/{track}/{slug}.yaml",
+        f"wiki/pedagogy/{track}/{slug}.md",
+        f"wiki/pedagogy/{track}/{slug}.sources.yaml",
+    ):
+        _copy(registry_root, relative)
+
+    registry_result = readiness.evaluate_preparation(track, slug, repo_root=registry_root)
+    registry_requirement = _requirement(registry_result, "research-evidence")
+    assert registry_requirement["passed"] is True
+    assert [option["passed"] for option in registry_requirement["options"]] == [False, True]
+
+
+@pytest.mark.parametrize(
+    ("score", "quality", "expected"),
+    [(6, "adequate", False), (7, "solid", True)],
+)
+def test_research_quality_uses_existing_solid_score_floor(
+    tmp_path: Path,
+    monkeypatch,
+    score: int,
+    quality: str,
+    expected: bool,
+) -> None:
+    repo_root = tmp_path / "repo"
+    path = repo_root / "docs/research/hist/demo.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# Research fixture\n", encoding="utf-8")
+    context = readiness.ValidationContext(repo_root, "hist", "demo", ("demo",))
+    monkeypatch.setattr(
+        readiness.research_quality,
+        "assess_research_compat",
+        lambda *_args, **_kwargs: {"quality": quality, "score": score},
+    )
+
+    result = readiness._research_quality(path, {}, context)
+
+    assert result.passed is expected
+    assert f"({score}/10)" in result.detail
+
+
+@pytest.mark.parametrize(
+    ("registry_text", "expected_detail"),
+    [
+        ("sources: []\n", "non-empty sources list"),
+        ("plain: mapping\n", "non-empty sources list"),
+        ("sources:\n  - id: S1\n", "invalid wiki source registry"),
+    ],
+)
+def test_wiki_source_registry_fails_closed_when_empty_or_malformed(
+    tmp_path: Path,
+    registry_text: str,
+    expected_detail: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+    article = repo_root / "wiki/pedagogy/a1/demo.md"
+    registry = article.with_suffix(".sources.yaml")
+    article.parent.mkdir(parents=True)
+    article.write_text("# Demo\n\nGrounded claim [S1].\n", encoding="utf-8")
+    registry.write_text(registry_text, encoding="utf-8")
+    context = readiness.ValidationContext(repo_root, "a1", "demo", ("demo",))
+
+    result = readiness._wiki_sources_registry(registry, {}, context)
+
+    assert result.passed is False
+    assert expected_detail in result.detail
+
+
+def test_verified_reading_catalog_and_reviewed_rights_are_explicit_alternatives(tmp_path: Path) -> None:
+    track = "a1"
+    slug = "sounds-letters-and-hello"
+    repo_root = tmp_path / "repo"
+    _copy_contracts(repo_root)
+    _write_manifest(repo_root, track, "core", slug)
+    _copy(repo_root, f"curriculum/l2-uk-en/plans/{track}/{slug}.yaml")
+    plan_path = _write_readings(
+        repo_root,
+        track,
+        slug,
+        [{"title": "Internal packet", "source_locator": "corpus:fixture-a1"}],
+    )
+    context = readiness.ValidationContext(repo_root, track, slug, (slug,))
+
+    verified = readiness._verified_reading_catalog(plan_path, {}, context)
+    assert verified.passed is True
+
+    _write_readings(
+        repo_root,
+        track,
+        slug,
+        [{"source_name": "External packet", "source": "https://example.test/reading"}],
+    )
+    source_alias = readiness._verified_reading_catalog(plan_path, {}, context)
+    assert source_alias.passed is True
+
+    _write_readings(
+        repo_root,
+        track,
+        slug,
+        [{"source_name": "Provider label", "source": "Archive provider prose"}],
+    )
+    provider_prose = readiness._verified_reading_catalog(plan_path, {}, context)
+    assert provider_prose.passed is False
+    assert "HTTP(S) URL or explicit internal source locator" in provider_prose.detail
+
+    _write_readings(
+        repo_root,
+        track,
+        slug,
+        [{"title": "Placeholder", "source_url": "reading-needed"}],
+    )
+    registry_path = repo_root / f"curriculum/l2-uk-en/{track}/promotion-evidence.yaml"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        """version: 1
+entries:
+  sounds-letters-and-hello:
+    reading_rights:
+      status: pass
+      reviewer_family: human
+      date: 2026-07-19
+      evidence_url: https://example.test/reviewed-rights
+      disposition: link-only-approved
+""",
+        encoding="utf-8",
+    )
+
+    result = readiness.evaluate_preparation(track, slug, repo_root=repo_root)
+    requirement = _requirement(result, "reading-or-rights")
+    assert requirement["passed"] is True
+    assert [option["passed"] for option in requirement["options"]] == [False, True]
+
+
+def test_bio_reading_policy_is_ukrainian_only_and_requires_two_candidate_roles(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    plan_path = repo_root / f"curriculum/l2-uk-en/plans/bio/{BIO_SLUG}.yaml"
+    context = readiness.ValidationContext(repo_root, "bio", BIO_SLUG, (BIO_SLUG,))
+
+    passing = readiness._bio_reading_policy(plan_path, {}, context)
+    assert passing.passed is True
+
+    plan = yaml.safe_load(plan_path.read_text(encoding="utf-8"))
+    plan["readings"][0]["language"] = "en"
+    plan_path.write_text(yaml.safe_dump(plan, allow_unicode=True, sort_keys=False), encoding="utf-8")
+    non_ukrainian = readiness._bio_reading_policy(plan_path, {}, context)
+    assert non_ukrainian.passed is False
+    assert "language: uk" in non_ukrainian.detail
+
+    plan["readings"] = [
+        {
+            "title": "Context only",
+            "language": "uk",
+            "source_type": "encyclopedia",
+            "source_url": "https://example.test/context",
+        }
+    ]
+    plan_path.write_text(yaml.safe_dump(plan, allow_unicode=True, sort_keys=False), encoding="utf-8")
+    incomplete = readiness._bio_reading_policy(plan_path, {}, context)
+    assert incomplete.passed is False
+    assert "distinct reference/context" in incomplete.detail
 
 
 def test_off_manifest_target_fails_with_authority_owner(tmp_path: Path) -> None:

--- a/tests/orchestration/test_curriculum_readiness.py
+++ b/tests/orchestration/test_curriculum_readiness.py
@@ -405,7 +405,7 @@ def test_preparation_change_invalidates_build_pbr_and_qg_identities(tmp_path: Pa
         ("hist", "track", "trypillian-civilization", "plans/hist/trypillian-civilization.yaml", "seminar"),
     ],
 )
-def test_unbuilt_core_and_generic_seminar_cannot_pass_from_plan_alone(
+def test_unbuilt_core_and_generic_seminar_profile_seams(
     tmp_path: Path,
     track: str,
     manifest_type: str,

--- a/tests/test_certification_evidence.py
+++ b/tests/test_certification_evidence.py
@@ -379,6 +379,23 @@ def _completion_case(tmp_path: Path) -> tuple[Path, Path, Path, dict[str, Any], 
     slug = "adjectives-comparative"
     (repo / "curriculum/l2-uk-en/plans/b1").mkdir(parents=True)
     shutil.copy2(ROOT / f"curriculum/l2-uk-en/plans/b1/{slug}.yaml", repo / f"curriculum/l2-uk-en/plans/b1/{slug}.yaml")
+    plan_path = repo / f"curriculum/l2-uk-en/plans/b1/{slug}.yaml"
+    plan = yaml.safe_load(plan_path.read_text(encoding="utf-8"))
+    plan["readings"] = [
+        {
+            "title": "Перевірене тестове читання",
+            "url": "https://example.test/b1/adjectives-comparative",
+        }
+    ]
+    plan_path.write_text(
+        yaml.safe_dump(plan, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    wiki_fixture = ROOT / "wiki/grammar/b1/aspect-future-tense.md"
+    wiki_target = repo / f"wiki/grammar/b1/{slug}.md"
+    wiki_target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(wiki_fixture, wiki_target)
+    shutil.copy2(wiki_fixture.with_suffix(".sources.yaml"), wiki_target.with_suffix(".sources.yaml"))
     manifest = {"levels": {"b1": {"type": "core", "modules": [slug]}}}
     (repo / "curriculum/l2-uk-en/curriculum.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
     for relative in (

--- a/tests/test_preparation_api.py
+++ b/tests/test_preparation_api.py
@@ -201,6 +201,7 @@ def test_module_projection_is_compact_canonical_and_has_no_ready_boolean() -> No
     assert data["preparation_state"] == "stale"
     assert data["next_action"] == "prepare"
     assert data["authority"]["readiness"]["profile_id"] == "core"
+    assert "PREPARATION_READING_OR_RIGHTS" in data["reason_codes"]
     assert data["field_authority"]["orchestration_telemetry"] == "not-included"
     assert "ready" not in _all_keys(data)
     assert response.headers["etag"].startswith('"')

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -175,10 +175,29 @@ def fake_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
                             }
                         ],
                         "references": [{"title": "Тестове джерело"}],
+                        **(
+                            {
+                                "readings": [
+                                    {
+                                        "title": "Перевірене тестове читання",
+                                        "url": f"https://example.test/{track}/{slug}",
+                                    }
+                                ]
+                            }
+                            if track == "a1"
+                            else {}
+                        ),
                     },
                     sort_keys=False,
                 ),
             )
+    wiki_fixture = ROOT / "wiki/pedagogy/a1/my-morning.md"
+    wiki_sources_fixture = wiki_fixture.with_suffix(".sources.yaml")
+    for slug in ("core-built", "core-unbuilt"):
+        wiki_target = repo / f"wiki/pedagogy/a1/{slug}.md"
+        wiki_target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(wiki_fixture, wiki_target)
+        shutil.copy2(wiki_sources_fixture, wiki_target.with_suffix(".sources.yaml"))
     for track, slug in (("a1", "core-built"), ("bio", "seminar-built"), ("folk", "folk-built")):
         _write_bundle(
             repo,


### PR DESCRIPTION
## Summary

- version the existing three readiness profiles at 1.1.0 and require plan, research, wiki/source, and reading/rights evidence for every profile
- keep CORE research alternatives explicit (solid-or-better research packet or the same valid non-empty wiki source registry), require a dedicated solid-or-better seminar dossier, and preserve BIO's stricter gates
- add fail-closed adapters for canonical research-quality scoring, wiki source-registry validation, deterministic reading catalogs, and BIO Ukrainian-only/minimum-shape policy
- preserve the existing `curriculum-preparation-result.v1` schema unchanged
- align four lifecycle pilot rows with the truthful missing-preparation outcomes and give downstream track-completion/certification fixtures profile-complete prerequisite evidence

## Behavior impact

CORE and seminar targets no longer become prepared from a valid plan alone. Reading evidence is accepted only as a non-empty catalog of mapping entries with a usable title/name/source_name and a real HTTP(S) URL (including a URL-valued `source`) or explicit internal locator, or through the reviewed `reading_rights` gate. BIO catalogs additionally require `language: uk` throughout and distinct reference/context plus primary/near-primary/textbook/article candidates. Active reviewed HOLD records still force `next_action: stop`.

The pilot matrix now reports `preparation-required` for the four unbuilt rows whose profile-v1.1.0 prerequisites are missing; it does not fabricate prepared/build-ready outcomes.

## Validation

- `.venv/bin/python -m pytest -q tests/orchestration/test_curriculum_lifecycle_pilot.py` — 14 passed
- `.venv/bin/python -m pytest -q tests/test_track_completion.py tests/test_certification_evidence.py tests/orchestration/test_curriculum_lifecycle_pilot.py` — 116 passed
- `.venv/bin/python -m pytest -q tests/orchestration/test_curriculum_readiness.py tests/test_preparation_api.py` — 43 passed, 1 deprecation warning
- pre-commit affected-file selection — 129 passed
- `.venv/bin/ruff check` on all five cumulatively changed Python files — passed
- readiness and pilot YAML parsed and validated against their existing JSON Schemas; canonical loaders accepted all profiles and the 22-row matrix
- `.venv/bin/yamllint` on both changed YAML configs — passed
- `npm run agents:deploy -- --dry-run` — prompt/skill lint passed before implementation
- `npm run agents:deploy` — passed for the readiness config/schema; deployed provider copies were byte-identical
- `git diff --check`, exact eight-path scope allowlist, protected-file checks, generated-artifact fence, and file-count check — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — both PR commits passed

Fixes #5469
Part of #4431
