### PR TITLE
data(atlas): publish textbook-curated bulk promote (#3934)

### DIFF
--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -1,14 +1,14 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-447e6bdf535b.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-e115e18a453e.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
   "manifest_fingerprint": "addd0590e765169cf09eb9a1a5255176160ec1889693bcf8bbefcb0d1a7dec77",
   "fingerprint_schema_version": 1,
   "generated_at": "2026-07-19T12:47:14+00:00",
-  "gz_sha256": "a18133ffb6d7a9340b54f2097c722400e9f17734d214fa1ea638faae488814ca",
-  "json_sha256": "447e6bdf535ba05a48c78fa5b4a99c37d338c3c649e9c09767d578c1a6085098",
-  "gz_bytes": 15553713,
-  "json_bytes": 115607824,
+  "gz_sha256": "568b7938dd23b6a5addcac3da5885fefc6ab1049f6055dc4b98e6378de2ee81a",
+  "json_sha256": "e115e18a453e3fdeef0beab6b75e6389fff9c978015048a31ab87a45abce6eb7",
+  "gz_bytes": 12591090,
+  "json_bytes": 72464289,
   "richness_gate": {
     "baseline": {
       "poc_thin_pages": 672,

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -1,14 +1,14 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-28f32e22c98f.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-447e6bdf535b.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
   "manifest_fingerprint": "addd0590e765169cf09eb9a1a5255176160ec1889693bcf8bbefcb0d1a7dec77",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-07-18T23:39:57+00:00",
-  "gz_sha256": "a9c21ac6da0f8d52c0b63d27b1072619969234e3b8185eb16897bc0180b6f878",
-  "json_sha256": "28f32e22c98f361a94b3269f06c6592c0f44ad2f9f4eec7df6844974ad95be37",
-  "gz_bytes": 12285733,
-  "json_bytes": 87388676,
+  "generated_at": "2026-07-19T12:47:14+00:00",
+  "gz_sha256": "a18133ffb6d7a9340b54f2097c722400e9f17734d214fa1ea638faae488814ca",
+  "json_sha256": "447e6bdf535ba05a48c78fa5b4a99c37d338c3c649e9c09767d578c1a6085098",
+  "gz_bytes": 15553713,
+  "json_bytes": 115607824,
   "richness_gate": {
     "baseline": {
       "poc_thin_pages": 672,

--- a/site/tests/unit/atlas-db-read.test.ts
+++ b/site/tests/unit/atlas-db-read.test.ts
@@ -4,7 +4,6 @@ import Database from 'better-sqlite3';
 import { describe, expect, test, vi, afterEach, beforeEach } from 'vitest';
 import { resolve } from 'node:path';
 import * as fs from 'node:fs';
-import manifest from '@site/src/data/lexicon-manifest.json';
 import {
   getAtlasPayloadCache,
   resetAtlasPayloadCacheForTests,
@@ -13,6 +12,16 @@ import {
 } from '@site/src/lib/lexicon/atlasDb';
 import { articleProps } from '../helpers/word-atlas-record';
 import { renderWordAtlasArticle } from '../helpers/render-word-atlas-article';
+
+// Static JSON import fails napi string conversion on large hydrated manifests
+// (~15k+ entries after textbook promote). Load with fs + JSON.parse instead.
+const manifest = JSON.parse(
+  fs.readFileSync(resolve(process.cwd(), 'src/data/lexicon-manifest.json'), 'utf8'),
+) as {
+  version: string;
+  generated_at: string;
+  entries: LexiconEntry[];
+};
 
 let mockExistsSync = (p: string): boolean => true;
 let mockReadFileSync = (p: string, encoding: any): string => '';


### PR DESCRIPTION
## Summary

Apply the already-committed textbook JSONL curated inventory + decisions to the **live** Word Atlas manifest and publish the release asset.

| Metric | Count |
| --- | ---: |
| Before (live) | **11,151** |
| Proposed additions | **17,251** |
| Skipped existing | **7,431** |
| **After** | **28,402** |
| Gloss coverage | **98.0%** |
| Richness gate (poc_thin / search_no_gloss / old_gate) | **672 / 43 / 43** (unchanged vs baseline) |

### Policy
- `source_family=textbook` curated auto-approve (POS+gloss via VESUM+SUM11)
- No AI row review
- Inventory + decisions already on main from the Ohoiko path commit; this PR is the **apply + publish** step

### Asset
- `lexicon-manifest-447e6bdf535b.json.gz` on `atlas-manifest` release
- Pointer + sizes updated

Closes #3934

## Test plan
- [x] `apply_plan` DELTA OK 17251
- [x] `audit_atlas_poc_richness --local` — no richness regression
- [x] `publish_manifest` succeeded
- [x] Remote asset entry count = 28402

X-Agent: grok/3934-textbook-promote