### PR TITLE
feat(curriculum): bind coordination to bounded module results

### DIFF
--- a/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
@@ -17,6 +17,10 @@ This skill is the track-level entry point. It composes the deterministic
 coordinator with `$track-completion`; it does not reimplement readiness,
 building, certification, review, integration, or publication policy. Derive
 active tracks and order only from `curriculum/l2-uk-en/curriculum.yaml`.
+For a normal BIO request, this is one serial workflow: the coordinator owns
+manifest order, prerequisites, acquisition, deterministic resume, and the
+hash-bound receipt; the acquired module's `$track-completion` ledger is the
+only bounded-completion authority.
 
 ## Start or resume
 
@@ -50,6 +54,9 @@ active tracks and order only from `curriculum/l2-uk-en/curriculum.yaml`.
    adjudication path before starting a fresh run. Never migrate old state by
    hand.
 
+   The coordinator status includes this exact `resume_command`; use it rather
+   than reconstructing or replacing the run.
+
 ## Process one acquired module
 
 1. Acquire the next prerequisite-safe module. The coordinator pauses without
@@ -76,23 +83,24 @@ active tracks and order only from `curriculum/l2-uk-en/curriculum.yaml`.
    its exact ledger on resume. It owns plan review, build/recovery, read-only
    `$post-build-review`, repair routing, reviewer-instability handling,
    independent review, PR/CI/merge, publication evidence, and cleanup.
-4. Record the module outcome only after `$track-completion` reaches `COMPLETE`
-   with `terminal_satisfied=true` for the coordinator's exact goal:
+4. Record the module result from its authoritative ledger. A publishable result
+   is accepted only after `$track-completion` reaches `COMPLETE` for the
+   coordinator's exact goal; a terminal bounded-budget blocker is recorded as
+   blocked rather than left stale:
 
    ```bash
    .venv/bin/python scripts/orchestration/curriculum_coordinator.py record-module \
      --run-id <run-id> --owner <agent/task> --module <slug> \
-     --disposition <complete|no-change|blocked> \
-     --integration-json '<integration JSON including track_ledger and track_run_id>'
+     --track-ledger <track-completion-ledger> --track-run-id <module-run-id>
    ```
 
-   The coordinator reads and hashes the authoritative track ledger; a
-   free-form projection string is not evidence. `complete` requires issue,
-   aligned dispatch worktree/branch, PR, merge SHA, review/CI evidence, and
-   completed cleanup. `no-change` must not fabricate an issue or PR. `blocked`
-   must record the genuine owner and next action. A certification-only track
-   ledger cannot satisfy goal `deploy`, and a migrated historical module is
-   reacquired until its exact goal is proven.
+   Do not supply a coordinator disposition or repeat PR/worktree/cleanup
+   policy. The coordinator validates the bounded run, rejects semantic evidence
+   outside its model-call count, hashes the module ledger, and derives a concise
+   result with elapsed time, model-call count, repair count, disposition,
+   blocker, and next action. An incomplete module ledger cannot complete the
+   coordinator. A migrated historical module is reacquired until its exact goal
+   is proven.
 5. Repeat acquisition serially until the coordinator reports `complete`.
    Module-at-a-time mutation remains mandatory; a wave groups health and review
    capacity but does not authorize concurrent learner writes.

--- a/agents_extensions/shared/skills/local-code-review/SKILL.md
+++ b/agents_extensions/shared/skills/local-code-review/SKILL.md
@@ -1,10 +1,17 @@
 ---
 name: local-code-review
-description: Canonical closeout-review workflow — freezes scope, resolves the exact review target (local/commit/branch/PR), runs a non-mutating review, resolves a cross-family reviewer, and requires separate behavior proof for user-visible changes. Use before declaring any change done.
+description: Canonical code/infra closeout workflow — freezes scope, resolves the exact review target (local/commit/branch/PR), runs a non-mutating review, resolves a cross-family reviewer, and requires separate behavior proof for user-visible code or infrastructure changes. Never use as a learner-content semantic gate.
 argument-hint: "[local | commit <sha> | branch <branch> <base> | pr <number>]"
 ---
 
 # Closeout Review: $ARGUMENTS
+
+This skill supports only `code` and `infra` review profiles. A normal BIO
+learner-content request routes to `$curriculum-lifecycle` (or directly to
+`$track-completion` for one module), which owns the single bounded
+`$post-build-review` gate. `resolve-reviewer` fails before route selection for
+any learner-content semantic profile or domain. Do not duplicate post-build
+semantic review here.
 
 > **Scope**: this is the closeout gate for a change you (or another agent)
 > already made — not a PR-comment bot. For posting inline PR comments, use

--- a/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
+++ b/agents_extensions/shared/skills/local-code-review/local-code-review-checklist.md
@@ -60,7 +60,7 @@ never does it.
   --intended-behavior "<what this change is supposed to do>" \
   --non-goals "<what it explicitly does not do>" \
   --owner-boundary "<the paths/surfaces this change owns>" \
-  --review-profile "<code|infra|content|...>" \
+  --review-profile "<code|infra>" \
   --risk "<low|medium|high>"
 ```
 
@@ -70,6 +70,11 @@ non-test LOC count, with no file-extension allowlist: shell scripts,
 workflow YAML, config, schemas, and documentation are changed paths just
 as much as `.py`/`.ts` files, and none of them are silently excluded from
 scope or from review in the steps below.
+
+Learner-content semantic review is unsupported here. A normal BIO request uses
+`$curriculum-lifecycle` / `$track-completion`, with `$post-build-review` as its
+single bounded semantic gate; do not freeze or resolve a content profile in
+this code/infra closeout state.
 
 **Both `target` and `freeze` are one-shot per state file.** Once a baseline
 is frozen, `target` refuses to re-resolve (it would silently swap out what
@@ -112,7 +117,7 @@ curl -s 'http://localhost:8765/api/state/routing-budget?fresh_codexbar=true' \
   --author-model "<the author's actual model/seat, e.g. claude, codex, deepseek-v4-pro>" \
   --review-profile "<same profile as Step 2>" \
   --risk "<same risk as Step 2>" \
-  --domain "<code | folk_content | ... — only set non-default if it applies>" \
+  --domain "<code|infra>" \
   --data-egress-policy "<omit unless this run is genuinely local-interactive>" \
   --routing-snapshot-file /tmp/routing-snapshot.json
 ```
@@ -123,6 +128,10 @@ order alone decides) but **fail-closed on domain/data-egress**: leaving
 `--data-egress-policy` unset excludes any candidate that requires a
 specific egress policy (e.g. a China-hosted lane), it does not admit them
 by default.
+
+`resolve-reviewer` rejects any profile or domain outside `code`/`infra` before
+walking the candidate ladder. That failure is a routing boundary, not an
+invitation to dispatch a semantic reviewer manually.
 
 **Multi-model harnesses (e.g. Cursor) are fail-closed, not a synthetic
 family.** A harness that can run more than one underlying model (Cursor)

--- a/agents_extensions/shared/skills/post-build-review/SKILL.md
+++ b/agents_extensions/shared/skills/post-build-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: post-build-review
-description: Run the canonical read-only, versioned review of a built Ukrainian curriculum module by composing deterministic audit evidence, track policy, the correct core or seminar semantic prompt, and fail-closed combined disposition. Use for short requests such as "Use $post-build-review for bio/oleksandr-bilash", for post-build quality gates, for reproducing a prior versioned review, or before declaring a module ready.
+description: Run the canonical read-only, versioned semantic review authorized by one bounded track-completion ledger, or an explicitly diagnostic standalone review that cannot complete a module. A normal BIO completion request routes through track-completion, which owns call and repair budgets.
 ---
 
 # Post-build review
@@ -8,6 +8,21 @@ description: Run the canonical read-only, versioned review of a built Ukrainian 
 Keep all repository files unchanged. Write packets and results only under `/tmp`.
 Do not create curriculum `audit/`, `review/`, `status/`, telemetry, or published
 artifacts. Report findings; do not fix the module during this invocation.
+
+## Completion-bound entry
+
+A short normal BIO completion request routes through `$track-completion`; do
+not start an independent semantic closeout here. Before its provider call,
+`$track-completion` must run `prepare-semantic-review` and return the authorized
+phase and remaining bounded budget. This invocation consumes exactly that one
+authorized model call and returns its unchanged result to the same module
+ledger. No retry, stability check, repair, or second closeout review is hidden
+inside this skill.
+
+Run this skill standalone only when the operator explicitly requests a
+read-only diagnostic review that is not being represented as module
+completion. A standalone result cannot complete a curriculum coordinator or
+track-completion ledger.
 
 ## Workflow
 
@@ -57,10 +72,12 @@ artifacts. Report findings; do not fix the module during this invocation.
 6. Preserve the reviewer's exact response bytes at the emitted
    `<semantic_response_path>`. Do not extract, repair,
    normalize, merge, or reconcile malformed output. A malformed response ends
-   this review as `INCOMPLETE`; any retry is a distinct review with a new
-   packet/result and cannot replace the failed artifact. Allocate a new run
-   directory before every retry. Use `apply_patch`, not a shell heredoc, when
-   the current agent is the reviewer.
+   this review as `INCOMPLETE`. During bounded completion, return that outcome
+   without retrying; the module ledger alone decides whether any later
+   authorized call remains. For an explicit standalone diagnostic, any retry
+   is a distinct review with a new packet/result and cannot replace the failed
+   artifact. Use `apply_patch`, not a shell heredoc, when the current agent is
+   the reviewer.
    When the provider supports schema-constrained structured output, emit its
    provider-compatible transport schema before invoking it. For Codex, the
    provider selector is mandatory:

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -16,6 +16,11 @@ the only readiness gate; keep every post-build-review invocation read-only.
 Never run legacy LLM-QG, a separate deterministic audit, or a legacy content
 review as an operator completion gate.
 
+For a normal BIO module request, this ledger is the one authoritative bounded
+module workflow. `$curriculum-lifecycle` may order and acquire the module, but
+it must not reproduce this completion policy. `$local-code-review` is reserved
+for a code/infra diff and never repeats this learner-content semantic gate.
+
 ## Canonical entry paths
 
 New and existing modules use one lifecycle, not separate completion systems:
@@ -110,6 +115,13 @@ and identities into non-authoritative archival ledger storage.
    `migrate-terminal-goal` with the exact old run id and explicit intent; a
    `PBR_PASS_QG_PENDING` migration must also name its exact PR and 40-character
    merge SHA. Never infer a goal from historical cursor state.
+
+   The deterministic module resume command is:
+
+   ```bash
+   .venv/bin/python agents_extensions/shared/skills/track-completion/scripts/track_completion.py \
+     resume <track/slug> --run-id <id>
+   ```
 
 ## Follow the returned state
 
@@ -239,6 +251,11 @@ can merge.
 Do not reopen, retry, or silently replace the run. Preserve the terminal
 ledger and open a later run only after a separately adjudicated source or
 protocol change establishes new scope.
+
+Report the bounded ledger's `elapsed_time_ms`, `model_call_count`,
+`repair_count`, and `final_quality_disposition` with the blocker and next
+action. These counts are authoritative; do not add a hidden retry, stability
+check, semantic review, repair, or quality-gate call outside them.
 
 ### `PUBLISH_REQUIRED`
 

--- a/scripts/orchestration/curriculum_coordinator.py
+++ b/scripts/orchestration/curriculum_coordinator.py
@@ -1356,9 +1356,10 @@ def _record_module(
                     repo_root=repo_root,
                 )
             else:
-                if disposition is None:
+                if disposition != "no-change":
                     raise CoordinatorError(
-                        "legacy coordinator run must migrate-terminal-goal before recording a bounded result"
+                        "legacy coordinator run only permits no-change; run migrate-terminal-goal "
+                        "before recording complete or blocked results"
                     )
                 identity = _integration_record(integration)
                 _validate_legacy_integration(identity)

--- a/scripts/orchestration/curriculum_coordinator.py
+++ b/scripts/orchestration/curriculum_coordinator.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import sys
 from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
@@ -30,17 +31,17 @@ from scripts.orchestration.curriculum_readiness import (
     module_bundle_state,
 )
 
-DEFAULT_CONFIG_PATH = (
-    PROJECT_ROOT / "agents_extensions/shared/curriculum-lifecycle/config/coordinator.v1.yaml"
-)
+DEFAULT_CONFIG_PATH = PROJECT_ROOT / "agents_extensions/shared/curriculum-lifecycle/config/coordinator.v1.yaml"
 CONFIG_SCHEMA_PATH = (
     PROJECT_ROOT / "agents_extensions/shared/curriculum-lifecycle/schema/coordinator-config.v1.schema.json"
 )
 LEDGER_SCHEMA_PATH = (
     PROJECT_ROOT / "agents_extensions/shared/curriculum-lifecycle/schema/coordinator-ledger.v1.schema.json"
 )
+BOUNDED_RUN_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/skills/track-completion/schema/bounded-completion-run.v1.schema.json"
+)
 _TARGET_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
-_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _SCOPES = frozenset({"all", "built", "unbuilt", "stale", "one"})
 _TERMINAL_GOALS = frozenset({"merge", "certify", "deploy"})
 _TERMINAL_DISPOSITIONS = frozenset({"complete", "no-change"})
@@ -131,9 +132,7 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> dict[str, Any]:
         raise CoordinatorError("health capability group ids must be unique")
     for group in value["health"]["capability_groups"]:
         if group["minimum_available"] > len(group["lanes"]):
-            raise CoordinatorError(
-                f"health group {group['id']} requires more lanes than it declares"
-            )
+            raise CoordinatorError(f"health group {group['id']} requires more lanes than it declares")
     return value
 
 
@@ -290,9 +289,7 @@ def _validate_ledger(ledger: Mapping[str, Any]) -> None:
         "request": ledger["request"],
         "authority": ledger["authority"],
     }
-    migrated = any(
-        event["event"] == "TERMINAL_GOAL_MIGRATED" for event in ledger["history"]
-    )
+    migrated = any(event["event"] == "TERMINAL_GOAL_MIGRATED" for event in ledger["history"])
     if ledger.get("terminal_goal") is not None and not migrated:
         identity_payload["terminal_goal"] = ledger["terminal_goal"]
     expected_request_sha = _sha256(identity_payload)
@@ -379,8 +376,7 @@ def _validate_event_transitions(ledger: Mapping[str, Any]) -> None:
                 or details["attempt"]
                 != 1
                 + sum(
-                    prior["event"] == "MODULE_ACQUIRED"
-                    and prior["details"].get("slug") == details["slug"]
+                    prior["event"] == "MODULE_ACQUIRED" and prior["details"].get("slug") == details["slug"]
                     for prior in history
                 )
                 or details["wave"] not in state["accepted_waves"]
@@ -392,8 +388,7 @@ def _validate_event_transitions(ledger: Mapping[str, Any]) -> None:
                 (
                     prior
                     for prior in reversed(history)
-                    if prior["event"] == "MODULE_ACQUIRED"
-                    and prior["details"]["slug"] == details["slug"]
+                    if prior["event"] == "MODULE_ACQUIRED" and prior["details"]["slug"] == details["slug"]
                 ),
                 None,
             )
@@ -499,9 +494,7 @@ def _build_queue(
             preparation_identity = readiness["preparation_identity"]
             if preparation_state != "stale":
                 continue
-        elif (scope == "built" and bundle_state != "built") or (
-            scope == "unbuilt" and bundle_state != "unbuilt"
-        ):
+        elif (scope == "built" and bundle_state != "built") or (scope == "unbuilt" and bundle_state != "unbuilt"):
             continue
         selected.append((slug, bundle_state, preparation_state, preparation_identity))
     if not selected:
@@ -563,19 +556,12 @@ def derive_state(ledger: Mapping[str, Any]) -> dict[str, Any]:
             slug = str(details["slug"])
             disposition = str(details["disposition"])
             terminal = details.get("integration", {}).get("track_terminal")
-            terminal_satisfied = (
-                ledger.get("terminal_goal") is None
-                or (
-                    isinstance(terminal, Mapping)
-                    and terminal.get("satisfied") is True
-                    and terminal.get("goal") == ledger.get("terminal_goal")
-                )
+            terminal_satisfied = ledger.get("terminal_goal") is None or (
+                isinstance(terminal, Mapping)
+                and terminal.get("satisfied") is True
+                and terminal.get("goal") == ledger.get("terminal_goal")
             )
-            modules[slug] = (
-                "complete"
-                if disposition in _TERMINAL_DISPOSITIONS and terminal_satisfied
-                else "blocked"
-            )
+            modules[slug] = "complete" if disposition in _TERMINAL_DISPOSITIONS and terminal_satisfied else "blocked"
             if current_module == slug:
                 current_module = None
         elif event["event"] == "WAVE_COMPLETED":
@@ -636,6 +622,11 @@ def compact_status(ledger: Mapping[str, Any]) -> dict[str, Any]:
         "completed_waves": state["completed_waves"],
         "last_event": ledger["history"][-1]["event"],
         "event_count": len(ledger["history"]),
+        "resume_command": (
+            ".venv/bin/python scripts/orchestration/curriculum_coordinator.py resume "
+            f"--run-id {shlex.quote(str(ledger['run_id']))} "
+            f"--owner {shlex.quote(str(ledger['owner']))}"
+        ),
     }
 
 
@@ -732,13 +723,9 @@ def start_run(
     if terminal_goal is not None and terminal_goal not in _TERMINAL_GOALS:
         raise CoordinatorError("terminal goal must be one of merge, certify, or deploy")
     config = load_config(config_path)
-    selected_wave_size = (
-        wave_size if wave_size is not None else int(config["default_wave_size"])
-    )
+    selected_wave_size = wave_size if wave_size is not None else int(config["default_wave_size"])
     if selected_wave_size < 1 or selected_wave_size > int(config["maximum_wave_size"]):
-        raise CoordinatorError(
-            f"wave size must be within 1..{config['maximum_wave_size']}"
-        )
+        raise CoordinatorError(f"wave size must be within 1..{config['maximum_wave_size']}")
     request = {
         "track": track,
         "scope": scope,
@@ -761,9 +748,7 @@ def start_run(
         with _locked(root):
             existing = _read_optional_json(path)
             if existing is not None:
-                _path, existing = _load_owned_run(
-                    root=root, run_id=run_id, owner=owner, repo_root=repo_root
-                )
+                _path, existing = _load_owned_run(root=root, run_id=run_id, owner=owner, repo_root=repo_root)
                 if existing["owner"] != owner or existing["request_sha256"] != request_sha:
                     raise CoordinatorError("run identity collision with a different request")
                 if derive_state(existing)["status"] == "complete":
@@ -780,9 +765,7 @@ def start_run(
                 )
                 state = derive_state(existing)
                 if state["current_module"] is not None:
-                    item = next(
-                        row for row in existing["queue"] if row["slug"] == state["current_module"]
-                    )
+                    item = next(row for row in existing["queue"] if row["slug"] == state["current_module"])
                     _renew_active_module_leases(root, existing, item, config)
                 assert lease["run_id"] == run_id
                 return path, existing
@@ -895,18 +878,12 @@ def resume_run(
     root = _runtime_root(repo_root, config, runtime_root)
     try:
         with _locked(root):
-            path, ledger = _load_owned_run(
-                root=root, run_id=run_id, owner=owner, repo_root=repo_root
-            )
+            path, ledger = _load_owned_run(root=root, run_id=run_id, owner=owner, repo_root=repo_root)
             if ledger.get("terminal_goal") is None and derive_state(ledger)["status"] == "complete":
-                raise CoordinatorError(
-                    "coordinator ledger has no terminal goal; run migrate-terminal-goal"
-                )
+                raise CoordinatorError("coordinator ledger has no terminal goal; run migrate-terminal-goal")
             state = derive_state(ledger)
             if state["status"] == "complete":
-                _release_owned_lease(
-                    _lease_path(root, "track", ledger["request"]["track"]), run_id
-                )
+                _release_owned_lease(_lease_path(root, "track", ledger["request"]["track"]), run_id)
                 return path, ledger
             track = ledger["request"]["track"]
             _claim_lease(
@@ -974,9 +951,7 @@ def migrate_terminal_goal(
             existing = ledger.get("terminal_goal")
             if existing is not None:
                 if existing != terminal_goal:
-                    raise CoordinatorError(
-                        f"coordinator terminal goal is already {existing}; refusing {terminal_goal}"
-                    )
+                    raise CoordinatorError(f"coordinator terminal goal is already {existing}; refusing {terminal_goal}")
                 return path, ledger
             ledger["terminal_goal"] = terminal_goal
             _append_event(
@@ -986,9 +961,7 @@ def migrate_terminal_goal(
                     "terminal_goal": terminal_goal,
                     "legacy_run_id": run_id,
                     "reopened_modules": [
-                        slug
-                        for slug, state in derive_state(ledger)["modules"].items()
-                        if state != "complete"
+                        slug for slug, state in derive_state(ledger)["modules"].items() if state != "complete"
                     ],
                 },
             )
@@ -996,9 +969,7 @@ def migrate_terminal_goal(
             _atomic_write_json(path, ledger)
             return path, ledger
     except Timeout as exc:
-        raise CoordinatorError(
-            "curriculum coordinator is busy; retry the exact terminal-goal migration"
-        ) from exc
+        raise CoordinatorError("curriculum coordinator is busy; retry the exact terminal-goal migration") from exc
 
 
 def adjudicate_run(
@@ -1030,23 +1001,15 @@ def adjudicate_run(
                 return path, ledger
             track = ledger["request"]["track"]
             if state["status"] == "abandoned":
-                abandonment = next(
-                    event for event in reversed(ledger["history"]) if event["event"] == "RUN_ABANDONED"
-                )
+                abandonment = next(event for event in reversed(ledger["history"]) if event["event"] == "RUN_ABANDONED")
                 abandoned_module = abandonment["details"]["current_module"]
                 if abandoned_module is not None:
-                    _release_owned_lease(
-                        _lease_path(root, "module", f"{track}--{abandoned_module}"), run_id
-                    )
+                    _release_owned_lease(_lease_path(root, "module", f"{track}--{abandoned_module}"), run_id)
                 _release_owned_lease(_lease_path(root, "global"), run_id)
                 _release_owned_lease(_lease_path(root, "track", track), run_id)
                 return path, ledger
             manifest_path = _repo_relative_path(repo_root, ledger["authority"]["manifest_path"])
-            current_sha = (
-                hashlib.sha256(manifest_path.read_bytes()).hexdigest()
-                if manifest_path.is_file()
-                else None
-            )
+            current_sha = hashlib.sha256(manifest_path.read_bytes()).hexdigest() if manifest_path.is_file() else None
             manifest_changed = current_sha != ledger["authority"]["manifest_sha256"]
             track_lease_path = _lease_path(root, "track", track)
             track_lease = _read_optional_json(track_lease_path)
@@ -1075,9 +1038,7 @@ def adjudicate_run(
             _validate_ledger(ledger)
             _atomic_write_json(path, ledger)
             if state["current_module"] is not None:
-                _release_owned_lease(
-                    _lease_path(root, "module", f"{track}--{state['current_module']}"), run_id
-                )
+                _release_owned_lease(_lease_path(root, "module", f"{track}--{state['current_module']}"), run_id)
             _release_owned_lease(_lease_path(root, "global"), run_id)
             _release_owned_lease(track_lease_path, run_id)
             return path, ledger
@@ -1111,9 +1072,7 @@ def acquire_next(
     evaluator = readiness_evaluator or _default_readiness(repo_root)
     try:
         with _locked(root):
-            path, ledger = _load_owned_run(
-                root=root, run_id=run_id, owner=owner, repo_root=repo_root
-            )
+            path, ledger = _load_owned_run(root=root, run_id=run_id, owner=owner, repo_root=repo_root)
             state = derive_state(ledger)
             if state["status"] == "complete":
                 return path, ledger, None
@@ -1136,14 +1095,10 @@ def acquire_next(
         assessment: dict[str, Any] | None = None
         if needs_health:
             passed, assessment = _probe_health(health_probe, config)
-        readiness = (
-            _readiness_snapshot(track, planned_item["slug"], evaluator) if passed else None
-        )
+        readiness = _readiness_snapshot(track, planned_item["slug"], evaluator) if passed else None
 
         with _locked(root):
-            path, ledger = _load_owned_run(
-                root=root, run_id=run_id, owner=owner, repo_root=repo_root
-            )
+            path, ledger = _load_owned_run(root=root, run_id=run_id, owner=owner, repo_root=repo_root)
             state = derive_state(ledger)
             if state["status"] == "complete":
                 return path, ledger, None
@@ -1211,8 +1166,7 @@ def acquire_next(
                     "wave": wave,
                     "attempt": 1
                     + sum(
-                        event["event"] == "MODULE_ACQUIRED"
-                        and event["details"].get("slug") == item["slug"]
+                        event["event"] == "MODULE_ACQUIRED" and event["details"].get("slug") == item["slug"]
                         for event in ledger["history"]
                     ),
                     "readiness": readiness,
@@ -1247,55 +1201,28 @@ def _integration_record(integration: Mapping[str, Any] | None) -> dict[str, Any]
     return record
 
 
-def _validate_integration(disposition: str, integration: Mapping[str, Any]) -> None:
+def _validate_legacy_integration(integration: Mapping[str, Any]) -> None:
+    """Keep pre-goal ledgers readable without retaining completion policy here."""
+
     evidence = integration["evidence"]
     if not isinstance(evidence, str) or not evidence.strip():
         raise CoordinatorError("every module disposition requires a non-empty evidence identity")
-    if disposition == "no-change":
-        identity_keys = ("issue", "worktree", "branch", "pr", "merge_sha")
-        if any(integration[key] is not None for key in identity_keys) or integration["cleanup"] != "not-required":
-            raise CoordinatorError("no-change disposition must not fabricate issue, branch, PR, or cleanup work")
-    elif disposition == "complete":
-        if not isinstance(integration["issue"], int) or integration["issue"] < 1:
-            raise CoordinatorError("completed repair requires an issue number")
-        if not isinstance(integration["pr"], int) or integration["pr"] < 1:
-            raise CoordinatorError("completed repair requires a PR number")
-        _validate_dispatch_identity(integration, label="completed repair")
-        if not isinstance(integration["merge_sha"], str) or not _SHA_RE.fullmatch(integration["merge_sha"]):
-            raise CoordinatorError("completed repair requires a 40-character merge SHA")
-        if integration["cleanup"] != "complete":
-            raise CoordinatorError("completed repair requires proof of post-merge cleanup")
-    elif disposition == "blocked":
-        if any(integration[key] is not None for key in ("track_ledger", "track_run_id")):
-            raise CoordinatorError("blocked disposition cannot claim track terminal evidence")
-        if integration["cleanup"] not in {"not-required", "pending"}:
-            raise CoordinatorError("blocked disposition cleanup must be not-required or pending")
-        if integration["merge_sha"] is not None:
-            raise CoordinatorError("blocked disposition cannot claim a merge SHA")
-        identity_keys = ("issue", "worktree", "branch", "pr", "merge_sha")
-        if integration["cleanup"] == "not-required":
-            if any(integration[key] is not None for key in identity_keys):
-                raise CoordinatorError("blocked no-repair disposition must not claim integration identities")
-        else:
-            if not isinstance(integration["issue"], int) or integration["issue"] < 1:
-                raise CoordinatorError("blocked repair with pending cleanup requires an issue number")
-            _validate_dispatch_identity(integration, label="blocked repair")
 
 
-def _track_terminal_proof(
+def _bounded_module_result(
     integration: Mapping[str, Any],
     *,
     track: str,
     slug: str,
     terminal_goal: str,
     repo_root: Path,
-) -> dict[str, Any]:
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    """Derive the coordinator receipt only from one bounded module ledger."""
+
     raw_path = integration.get("track_ledger")
     run_id = integration.get("track_run_id")
     if not isinstance(raw_path, str) or not raw_path.strip() or not isinstance(run_id, str):
-        raise CoordinatorError(
-            "terminal module disposition requires track_ledger and track_run_id"
-        )
+        raise CoordinatorError("terminal module disposition requires track_ledger and track_run_id")
     ledger_path = Path(raw_path)
     if not ledger_path.is_absolute():
         ledger_path = repo_root / ledger_path
@@ -1313,48 +1240,75 @@ def _track_terminal_proof(
         or target.get("selector") != f"{track}/{slug}"
         or not isinstance(run, Mapping)
         or run.get("run_id") != run_id
-        or run.get("status") != "completed"
         or ledger.get("terminal_goal") != terminal_goal
-        or ledger.get("state") != "COMPLETE"
     ):
+        raise CoordinatorError("track-completion ledger does not match the acquired module, run, and terminal goal")
+
+    bounded = ledger.get("bounded_completion")
+    bounded_run = bounded.get("run") if isinstance(bounded, Mapping) else None
+    if not isinstance(bounded_run, Mapping):
+        raise CoordinatorError("track-completion ledger has no authoritative bounded-completion run")
+    _validate(bounded_run, BOUNDED_RUN_SCHEMA_PATH, "bounded module run")
+    if bounded_run.get("run_id") != run_id or bounded_run.get("target") != f"{track}/{slug}":
+        raise CoordinatorError("bounded module run identity does not match the track ledger")
+    measurements = bounded_run["measurements"]
+    model_call_count = int(measurements["model_call_count"])
+    repair_count = int(measurements["repair_count"])
+    if model_call_count != len(bounded_run["reviews"]) or repair_count != len(bounded_run["repairs"]):
+        raise CoordinatorError("bounded module measurements do not match recorded calls and repairs")
+    track_reviews = ledger.get("reviews")
+    if not isinstance(track_reviews, list) or len(track_reviews) != model_call_count:
+        raise CoordinatorError("track-completion ledger contains semantic review evidence outside the bounded budget")
+
+    final_disposition = str(measurements["final_quality_disposition"])
+    if bounded_run.get("terminal") is not True or final_disposition == "PENDING":
+        raise CoordinatorError("track-completion module ledger is incomplete")
+    outer_state = ledger.get("state")
+    if final_disposition == "PUBLISHABLE":
+        if run.get("status") != "completed" or outer_state != "COMPLETE":
+            raise CoordinatorError("track-completion module ledger is incomplete for the coordinator terminal goal")
+        coordinator_disposition = "complete"
+        blocker = None
+        next_action = "acquire-next"
+    elif final_disposition == "BLOCKED_BUDGET_EXHAUSTED":
+        if outer_state != "BLOCKED_BUDGET_EXHAUSTED":
+            raise CoordinatorError("bounded terminal blocker is stale relative to the track-completion ledger")
+        coordinator_disposition = "blocked"
+        blocker = "canonical semantic-review/repair budget exhausted"
+        next_action = "adjudicate blocker before reacquiring the same module"
+    else:
         raise CoordinatorError(
-            "track-completion ledger has not satisfied the coordinator terminal goal"
+            f"unsupported bounded terminal disposition for coordinator closeout: {final_disposition}"
         )
-    if terminal_goal == "deploy":
-        evidence = ledger.get("certification_evidence")
-        if not isinstance(evidence, list) or not any(
-            isinstance(item, Mapping)
-            and isinstance(item.get("value"), Mapping)
-            and item["value"].get("kind") == "deployment"
-            for item in evidence
-        ):
-            raise CoordinatorError("deploy terminal requires a deployment receipt")
-    return {
+
+    ledger_sha256 = hashlib.sha256(raw).hexdigest()
+    terminal = {
         "ledger": str(ledger_path.resolve()),
-        "sha256": hashlib.sha256(raw).hexdigest(),
+        "sha256": ledger_sha256,
         "run_id": run_id,
         "goal": terminal_goal,
-        "state": "COMPLETE",
-        "satisfied": True,
+        "state": outer_state,
+        "satisfied": coordinator_disposition == "complete",
     }
-
-
-def _validate_dispatch_identity(integration: Mapping[str, Any], *, label: str) -> None:
-    for key in ("worktree", "branch"):
-        if not isinstance(integration[key], str) or not integration[key].strip():
-            raise CoordinatorError(f"{label} requires {key} identity")
-    worktree = Path(integration["worktree"])
-    if (
-        worktree.is_absolute()
-        or len(worktree.parts) != 4
-        or worktree.parts[:2] != (".worktrees", "dispatch")
-        or not _TARGET_RE.fullmatch(worktree.parts[2])
-        or not _TARGET_RE.fullmatch(worktree.parts[3])
-    ):
-        raise CoordinatorError(f"{label} worktree must use .worktrees/dispatch/<agent>/<task>")
-    expected_branch = f"{worktree.parts[2]}/{worktree.parts[3]}"
-    if integration["branch"] != expected_branch:
-        raise CoordinatorError(f"{label} branch must align with its dispatch worktree")
+    if coordinator_disposition == "blocked":
+        terminal = None
+    receipt = _integration_record(
+        {
+            "evidence": f"track-completion:{ledger_sha256}",
+            "track_ledger": str(ledger_path.resolve()),
+            "track_run_id": run_id,
+        }
+    )
+    receipt["track_terminal"] = terminal
+    operator_result = {
+        "elapsed_time_ms": int(measurements["elapsed_time_ms"]),
+        "model_call_count": model_call_count,
+        "repair_count": repair_count,
+        "disposition": final_disposition,
+        "blocker": blocker,
+        "next_action": next_action,
+    }
+    return coordinator_disposition, receipt, operator_result
 
 
 def _finish_events(ledger: dict[str, Any], item: Mapping[str, Any]) -> None:
@@ -1368,42 +1322,46 @@ def _finish_events(ledger: dict[str, Any], item: Mapping[str, Any]) -> None:
         _append_event(ledger, "RUN_COMPLETED", {"module_count": len(ledger["queue"])})
 
 
-def record_module(
+def _record_module(
     run_id: str,
     *,
     owner: str,
     slug: str,
-    disposition: str,
+    disposition: str | None,
     integration: Mapping[str, Any] | None,
     repo_root: Path = PROJECT_ROOT,
     config_path: Path = DEFAULT_CONFIG_PATH,
     runtime_root: Path | None = None,
-) -> tuple[Path, dict[str, Any]]:
-    """Persist a module outcome exactly once and release only its owned leases."""
-    disposition = disposition.strip().lower()
+) -> tuple[Path, dict[str, Any], dict[str, Any] | None]:
+    """Persist one derived bounded result, retaining only a legacy adapter."""
+    disposition = disposition.strip().lower() if disposition is not None else None
     slug = slug.strip().lower()
     if not _TARGET_RE.fullmatch(slug):
         raise CoordinatorError("module result requires one repository slug")
-    if disposition not in {"complete", "no-change", "blocked"}:
+    if disposition is not None and disposition not in {"complete", "no-change", "blocked"}:
         raise CoordinatorError(f"unsupported module disposition: {disposition}")
-    identity = _integration_record(integration)
-    _validate_integration(disposition, identity)
     config = load_config(config_path)
     root = _runtime_root(repo_root, config, runtime_root)
     try:
         with _locked(root):
-            path, ledger = _load_owned_run(
-                root=root, run_id=run_id, owner=owner, repo_root=repo_root
-            )
+            path, ledger = _load_owned_run(root=root, run_id=run_id, owner=owner, repo_root=repo_root)
             track = ledger["request"]["track"]
-            if ledger.get("terminal_goal") is not None and disposition in _TERMINAL_DISPOSITIONS:
-                identity["track_terminal"] = _track_terminal_proof(
-                    identity,
+            operator_result: dict[str, Any] | None = None
+            if ledger.get("terminal_goal") is not None:
+                disposition, identity, operator_result = _bounded_module_result(
+                    _integration_record(integration),
                     track=track,
                     slug=slug,
                     terminal_goal=str(ledger["terminal_goal"]),
                     repo_root=repo_root,
                 )
+            else:
+                if disposition is None:
+                    raise CoordinatorError(
+                        "legacy coordinator run must migrate-terminal-goal before recording a bounded result"
+                    )
+                identity = _integration_record(integration)
+                _validate_legacy_integration(identity)
             state = derive_state(ledger)
             details: dict[str, Any]
             if state["current_module"] is None:
@@ -1421,11 +1379,9 @@ def record_module(
                 _release_owned_lease(_lease_path(root, "global"), run_id)
                 if derive_state(ledger)["status"] == "complete":
                     _release_owned_lease(_lease_path(root, "track", track), run_id)
-                return path, ledger
+                return path, ledger, operator_result
             if state["current_module"] != slug:
-                raise CoordinatorError(
-                    f"acquired module is {state['current_module']}; refusing result for {slug}"
-                )
+                raise CoordinatorError(f"acquired module is {state['current_module']}; refusing result for {slug}")
             item = next(row for row in ledger["queue"] if row["slug"] == slug)
             acquisition = next(
                 event
@@ -1451,9 +1407,62 @@ def record_module(
             _release_owned_lease(_lease_path(root, "global"), run_id)
             if derive_state(ledger)["status"] == "complete":
                 _release_owned_lease(_lease_path(root, "track", track), run_id)
-            return path, ledger
+            return path, ledger, operator_result
     except Timeout as exc:
         raise CoordinatorError("curriculum coordinator is busy; retry the exact module result") from exc
+
+
+def record_module(
+    run_id: str,
+    *,
+    owner: str,
+    slug: str,
+    disposition: str,
+    integration: Mapping[str, Any] | None,
+    repo_root: Path = PROJECT_ROOT,
+    config_path: Path = DEFAULT_CONFIG_PATH,
+    runtime_root: Path | None = None,
+) -> tuple[Path, dict[str, Any]]:
+    """Compatibility adapter for provisional ledgers and existing Python callers."""
+
+    path, ledger, _operator_result = _record_module(
+        run_id,
+        owner=owner,
+        slug=slug,
+        disposition=disposition,
+        integration=integration,
+        repo_root=repo_root,
+        config_path=config_path,
+        runtime_root=runtime_root,
+    )
+    return path, ledger
+
+
+def record_bounded_module_result(
+    run_id: str,
+    *,
+    owner: str,
+    slug: str,
+    track_ledger: str,
+    track_run_id: str,
+    repo_root: Path = PROJECT_ROOT,
+    config_path: Path = DEFAULT_CONFIG_PATH,
+    runtime_root: Path | None = None,
+) -> tuple[Path, dict[str, Any], dict[str, Any]]:
+    """Record the terminal result of the one authoritative bounded module ledger."""
+
+    path, ledger, operator_result = _record_module(
+        run_id,
+        owner=owner,
+        slug=slug,
+        disposition=None,
+        integration={"track_ledger": track_ledger, "track_run_id": track_run_id},
+        repo_root=repo_root,
+        config_path=config_path,
+        runtime_root=runtime_root,
+    )
+    assert operator_result is not None
+    return path, ledger, operator_result
 
 
 def status_run(
@@ -1494,9 +1503,7 @@ def _parser() -> argparse.ArgumentParser:
     start_parser.add_argument("--start")
     start_parser.add_argument("--end")
     start_parser.add_argument("--wave-size", type=int)
-    start_parser.add_argument(
-        "--terminal-goal", required=True, choices=sorted(_TERMINAL_GOALS)
-    )
+    start_parser.add_argument("--terminal-goal", required=True, choices=sorted(_TERMINAL_GOALS))
 
     for command in ("resume", "acquire-next", "status"):
         command_parser = subparsers.add_parser(command)
@@ -1511,16 +1518,14 @@ def _parser() -> argparse.ArgumentParser:
     migrate_parser = subparsers.add_parser("migrate-terminal-goal")
     migrate_parser.add_argument("--run-id", required=True)
     migrate_parser.add_argument("--owner", required=True)
-    migrate_parser.add_argument(
-        "--terminal-goal", required=True, choices=sorted(_TERMINAL_GOALS)
-    )
+    migrate_parser.add_argument("--terminal-goal", required=True, choices=sorted(_TERMINAL_GOALS))
 
     record_parser = subparsers.add_parser("record-module")
     record_parser.add_argument("--run-id", required=True)
     record_parser.add_argument("--owner", required=True)
     record_parser.add_argument("--module", required=True)
-    record_parser.add_argument("--disposition", choices=["complete", "no-change", "blocked"], required=True)
-    record_parser.add_argument("--integration-json", required=True)
+    record_parser.add_argument("--track-ledger", required=True)
+    record_parser.add_argument("--track-run-id", required=True)
     return parser
 
 
@@ -1552,18 +1557,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             path, ledger, item = acquire_next(args.run_id, owner=args.owner, **common)
             result = {"ledger": str(path), "status": compact_status(ledger), "acquired": item}
         elif args.command == "record-module":
-            integration = json.loads(args.integration_json)
-            if not isinstance(integration, dict):
-                raise CoordinatorError("--integration-json must be a JSON object")
-            path, ledger = record_module(
+            path, ledger, module_result = record_bounded_module_result(
                 args.run_id,
                 owner=args.owner,
                 slug=args.module,
-                disposition=args.disposition,
-                integration=integration,
+                track_ledger=args.track_ledger,
+                track_run_id=args.track_run_id,
                 **common,
             )
-            result = {"ledger": str(path), "status": compact_status(ledger)}
+            result = {
+                "ledger": str(path),
+                "status": compact_status(ledger),
+                "module_result": module_result,
+            }
         elif args.command == "adjudicate-run":
             path, ledger = adjudicate_run(
                 args.run_id,
@@ -1571,6 +1577,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 reason=args.reason,
                 **common,
             )
+            result = {"ledger": str(path), "status": compact_status(ledger)}
         elif args.command == "migrate-terminal-goal":
             path, ledger = migrate_terminal_goal(
                 args.run_id,
@@ -1578,7 +1585,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 terminal_goal=args.terminal_goal,
                 **common,
             )
-            result = {"ledger": str(path), "status": compact_status(ledger)}
             result = {"ledger": str(path), "status": compact_status(ledger)}
         else:
             result = status_run(args.run_id, owner=args.owner, **common)

--- a/scripts/review/closeout_cli.py
+++ b/scripts/review/closeout_cli.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from scripts.review.evidence import compute_target_input_fingerprint
 from scripts.review.findings import FindingEvent, FindingsLedger, FindingsLedgerError
-from scripts.review.model_catalog import VALID_RISKS
+from scripts.review.model_catalog import VALID_REVIEW_PROFILES, VALID_RISKS
 from scripts.review.reviewer_resolver import ResolverInputs, resolve_reviewer
 from scripts.review.scope_baseline import (
     ScopeBaseline,
@@ -84,9 +84,7 @@ def _target_from_dict(data: object) -> ReviewTarget:
         raise CloseoutStateError("target_mode_invalid")
     if not all(value is None or isinstance(value, str) for value in (base_sha, head_sha)):
         raise CloseoutStateError("target_sha_invalid")
-    if not isinstance(changed_paths, list) or not all(
-        isinstance(path, str) and path for path in changed_paths
-    ):
+    if not isinstance(changed_paths, list) or not all(isinstance(path, str) and path for path in changed_paths):
         raise CloseoutStateError("target_changed_paths_invalid")
     if not isinstance(non_test_loc, int) or isinstance(non_test_loc, bool) or non_test_loc < 0:
         raise CloseoutStateError("target_non_test_loc_invalid")
@@ -161,6 +159,20 @@ def _cmd_target(args: argparse.Namespace) -> int:
 
 
 def _cmd_freeze(args: argparse.Namespace) -> int:
+    if args.review_profile.strip().casefold() not in VALID_REVIEW_PROFILES:
+        print(
+            json.dumps(
+                {
+                    "error": (
+                        f"unsupported local-code-review profile {args.review_profile!r}; "
+                        "learner-content semantic review belongs to track-completion via "
+                        "post-build-review"
+                    )
+                }
+            ),
+            file=sys.stderr,
+        )
+        return 1
     state = _load_state(args.state_file)
     if state.get("baseline"):
         print(
@@ -224,15 +236,9 @@ def _baseline_from_state(state: dict) -> ScopeBaseline:
             raise CloseoutStateError(f"baseline_{key}_invalid")
     frozen_files = data.get("frozen_files")
     frozen_non_test_loc = data.get("frozen_non_test_loc")
-    if not isinstance(frozen_files, list) or not all(
-        isinstance(path, str) and path for path in frozen_files
-    ):
+    if not isinstance(frozen_files, list) or not all(isinstance(path, str) and path for path in frozen_files):
         raise CloseoutStateError("baseline_frozen_files_invalid")
-    if (
-        not isinstance(frozen_non_test_loc, int)
-        or isinstance(frozen_non_test_loc, bool)
-        or frozen_non_test_loc < 0
-    ):
+    if not isinstance(frozen_non_test_loc, int) or isinstance(frozen_non_test_loc, bool) or frozen_non_test_loc < 0:
         raise CloseoutStateError("baseline_frozen_non_test_loc_invalid")
     target = data.get("target")
     if not isinstance(target, dict):
@@ -326,11 +332,30 @@ def _cmd_record_cycle(args: argparse.Namespace) -> int:
     state.setdefault("cycle_outstanding_counts", []).append(args.outstanding_count)
     result = check_cycle_convergence_breaker(state["cycle_outstanding_counts"])
     _save_state(args.state_file, state)
-    print(json.dumps({"triggered": result.triggered, "reason": result.reason, "history": state["cycle_outstanding_counts"]}, indent=2))
+    print(
+        json.dumps(
+            {"triggered": result.triggered, "reason": result.reason, "history": state["cycle_outstanding_counts"]},
+            indent=2,
+        )
+    )
     return 0
 
 
 def _cmd_resolve_reviewer(args: argparse.Namespace) -> int:
+    if args.domain.strip().casefold() not in VALID_REVIEW_PROFILES:
+        print(
+            json.dumps(
+                {
+                    "selected": None,
+                    "fail_closed_reason": (
+                        f"unsupported local-code-review domain {args.domain!r}; learner-content "
+                        "semantic review belongs to track-completion via post-build-review"
+                    ),
+                },
+                indent=2,
+            )
+        )
+        return 1
     routing_snapshot = None
     if args.routing_snapshot_file:
         routing_snapshot = json.loads(Path(args.routing_snapshot_file).read_text(encoding="utf-8"))

--- a/scripts/review/model_catalog.py
+++ b/scripts/review/model_catalog.py
@@ -13,6 +13,7 @@ CATALOG_PATH = Path(__file__).resolve().parents[1] / "config" / "model_catalog.y
 EXPECTED_SCHEMA_VERSION = "model-catalog.v1"
 VALID_LIFECYCLES = frozenset({"active", "fallback", "hold", "retired"})
 VALID_RISKS = frozenset({"low", "medium", "high", "critical"})
+VALID_REVIEW_PROFILES = frozenset({"code", "infra"})
 EXPECTED_SELECTION_ORDER = [
     "independence_and_hard_gates",
     "review_quality_tier",
@@ -38,9 +39,7 @@ def _require_string(value: Any, label: str) -> str:
 
 
 def _require_string_list(value: Any, label: str) -> list[str]:
-    if not isinstance(value, list) or not value or not all(
-        isinstance(item, str) and item.strip() for item in value
-    ):
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item.strip() for item in value):
         raise ModelCatalogError(f"{label} must be a non-empty list of strings")
     return [item.strip() for item in value]
 
@@ -53,8 +52,7 @@ def validate_catalog(data: Any) -> dict[str, Any]:
     catalog = _require_mapping(data, "catalog").copy()
     if catalog.get("schema_version") != EXPECTED_SCHEMA_VERSION:
         raise ModelCatalogError(
-            f"schema_version must be {EXPECTED_SCHEMA_VERSION!r}, "
-            f"got {catalog.get('schema_version')!r}"
+            f"schema_version must be {EXPECTED_SCHEMA_VERSION!r}, got {catalog.get('schema_version')!r}"
         )
 
     reviewed_on = catalog.get("reviewed_on")
@@ -79,8 +77,7 @@ def validate_catalog(data: Any) -> dict[str, Any]:
 
     tiers = _require_mapping(catalog.get("quality_tiers"), "quality_tiers")
     if not tiers or not all(
-        isinstance(rank, int) and not isinstance(rank, bool) and rank > 0
-        for rank in tiers.values()
+        isinstance(rank, int) and not isinstance(rank, bool) and rank > 0 for rank in tiers.values()
     ):
         raise ModelCatalogError("quality_tiers must map names to positive integer ranks")
     if len(set(tiers.values())) != len(tiers):
@@ -90,21 +87,13 @@ def validate_catalog(data: Any) -> dict[str, Any]:
     if policy.get("quality_first") is not True:
         raise ModelCatalogError("policy.quality_first must be true")
     if policy.get("selection_order") != EXPECTED_SELECTION_ORDER:
-        raise ModelCatalogError(
-            f"policy.selection_order must be exactly {EXPECTED_SELECTION_ORDER!r}"
-        )
-    risk_floor = _require_mapping(
-        policy.get("risk_quality_floor"), "policy.risk_quality_floor"
-    )
+        raise ModelCatalogError(f"policy.selection_order must be exactly {EXPECTED_SELECTION_ORDER!r}")
+    risk_floor = _require_mapping(policy.get("risk_quality_floor"), "policy.risk_quality_floor")
     if set(risk_floor) != VALID_RISKS:
-        raise ModelCatalogError(
-            f"policy.risk_quality_floor must define exactly {sorted(VALID_RISKS)}"
-        )
+        raise ModelCatalogError(f"policy.risk_quality_floor must define exactly {sorted(VALID_RISKS)}")
     for risk, tier in risk_floor.items():
         if tier not in tiers:
-            raise ModelCatalogError(
-                f"policy.risk_quality_floor.{risk} references unknown tier {tier!r}"
-            )
+            raise ModelCatalogError(f"policy.risk_quality_floor.{risk} references unknown tier {tier!r}")
 
     models = _require_mapping(catalog.get("models"), "models")
     if not models:
@@ -117,25 +106,17 @@ def validate_catalog(data: Any) -> dict[str, Any]:
         tier = _require_string(model.get("tier"), f"models.{model_id}.tier")
         if tier not in tiers:
             raise ModelCatalogError(f"models.{model_id}.tier references unknown tier {tier!r}")
-        lifecycle = _require_string(
-            model.get("lifecycle"), f"models.{model_id}.lifecycle"
-        )
+        lifecycle = _require_string(model.get("lifecycle"), f"models.{model_id}.lifecycle")
         if lifecycle not in VALID_LIFECYCLES:
-            raise ModelCatalogError(
-                f"models.{model_id}.lifecycle must be one of {sorted(VALID_LIFECYCLES)}"
-            )
+            raise ModelCatalogError(f"models.{model_id}.lifecycle must be one of {sorted(VALID_LIFECYCLES)}")
         for field in ("roles", "transports", "strengths", "weaknesses", "sources"):
             values = _require_string_list(model.get(field), f"models.{model_id}.{field}")
             if field == "sources" and any(not source.startswith("https://") for source in values):
                 raise ModelCatalogError(f"models.{model_id}.sources must use https URLs")
         if model["family"] in {"openai", "xai"} and "hermes" in model["transports"]:
-            raise ModelCatalogError(
-                f"models.{model_id}.transports must not route GPT/Grok families through Hermes"
-            )
+            raise ModelCatalogError(f"models.{model_id}.transports must not route GPT/Grok families through Hermes")
         aliases = model.get("aliases", [])
-        if not isinstance(aliases, list) or not all(
-            isinstance(alias, str) and alias.strip() for alias in aliases
-        ):
+        if not isinstance(aliases, list) or not all(isinstance(alias, str) and alias.strip() for alias in aliases):
             raise ModelCatalogError(f"models.{model_id}.aliases must be a list of strings")
         for alias in aliases:
             if alias in models or alias in alias_owner:
@@ -145,55 +126,36 @@ def validate_catalog(data: Any) -> dict[str, Any]:
     candidates = _require_mapping(catalog.get("review_candidates"), "review_candidates")
     for name, raw in candidates.items():
         candidate = _require_mapping(raw, f"review_candidates.{name}")
-        model_id = _require_string(
-            candidate.get("model_id"), f"review_candidates.{name}.model_id"
-        )
+        model_id = _require_string(candidate.get("model_id"), f"review_candidates.{name}.model_id")
         if model_id not in models:
-            raise ModelCatalogError(
-                f"review_candidates.{name}.model_id references unknown model {model_id!r}"
-            )
+            raise ModelCatalogError(f"review_candidates.{name}.model_id references unknown model {model_id!r}")
         if models[model_id]["lifecycle"] != "active":
-            raise ModelCatalogError(
-                f"review candidate {name!r} must reference an active model"
-            )
+            raise ModelCatalogError(f"review candidate {name!r} must reference an active model")
         _require_string(candidate.get("route"), f"review_candidates.{name}.route")
-        transport = _require_string(
-            candidate.get("transport"), f"review_candidates.{name}.transport"
-        )
+        transport = _require_string(candidate.get("transport"), f"review_candidates.{name}.transport")
         if transport not in models[model_id]["transports"]:
             raise ModelCatalogError(
-                f"review_candidates.{name}.transport {transport!r} is not listed in "
-                f"models.{model_id}.transports"
+                f"review_candidates.{name}.transport {transport!r} is not listed in models.{model_id}.transports"
             )
-        _require_string(
-            candidate.get("invocation"), f"review_candidates.{name}.invocation"
-        )
-        profiles = _require_string_list(
-            candidate.get("review_profiles"), f"review_candidates.{name}.review_profiles"
-        )
+        _require_string(candidate.get("invocation"), f"review_candidates.{name}.invocation")
+        profiles = _require_string_list(candidate.get("review_profiles"), f"review_candidates.{name}.review_profiles")
         if any(profile != profile.casefold() for profile in profiles):
+            raise ModelCatalogError(f"review_candidates.{name}.review_profiles must use lowercase profile names")
+        unsupported_profiles = sorted(set(profiles) - VALID_REVIEW_PROFILES)
+        if unsupported_profiles:
             raise ModelCatalogError(
-                f"review_candidates.{name}.review_profiles must use lowercase profile names"
+                f"review_candidates.{name}.review_profiles contains unsupported code-closeout "
+                f"profiles {unsupported_profiles}; expected only {sorted(VALID_REVIEW_PROFILES)}"
             )
         if transport == "cursor" and model_id.casefold() in {"auto", "cursor", "composer"}:
-            raise ModelCatalogError(
-                f"review_candidates.{name} requires a concrete Cursor model id, not {model_id!r}"
-            )
+            raise ModelCatalogError(f"review_candidates.{name} requires a concrete Cursor model id, not {model_id!r}")
         health_keys = candidate.get("health_keys", [])
-        if not isinstance(health_keys, list) or not all(
-            isinstance(item, str) and item.strip() for item in health_keys
-        ):
-            raise ModelCatalogError(
-                f"review_candidates.{name}.health_keys must be a list of strings"
-            )
-        _require_string_list(
-            candidate.get("capabilities"), f"review_candidates.{name}.capabilities"
-        )
+        if not isinstance(health_keys, list) or not all(isinstance(item, str) and item.strip() for item in health_keys):
+            raise ModelCatalogError(f"review_candidates.{name}.health_keys must be a list of strings")
+        _require_string_list(candidate.get("capabilities"), f"review_candidates.{name}.capabilities")
         silence_timeout = candidate.get("requires_silence_timeout", False)
         if not isinstance(silence_timeout, bool):
-            raise ModelCatalogError(
-                f"review_candidates.{name}.requires_silence_timeout must be a boolean"
-            )
+            raise ModelCatalogError(f"review_candidates.{name}.requires_silence_timeout must be a boolean")
         egress_policy = candidate.get("requires_data_egress_policy")
         if egress_policy is not None:
             _require_string(
@@ -202,18 +164,12 @@ def validate_catalog(data: Any) -> dict[str, Any]:
             )
         for field in ("domain_excluded_from", "advisory_only_for_author_families"):
             values = candidate.get(field, [])
-            if not isinstance(values, list) or not all(
-                isinstance(item, str) and item.strip() for item in values
-            ):
-                raise ModelCatalogError(
-                    f"review_candidates.{name}.{field} must be a list of strings"
-                )
+            if not isinstance(values, list) or not all(isinstance(item, str) and item.strip() for item in values):
+                raise ModelCatalogError(f"review_candidates.{name}.{field} must be a list of strings")
 
     ladders = _require_mapping(catalog.get("review_ladders"), "review_ladders")
     if set(ladders) != VALID_RISKS:
-        raise ModelCatalogError(
-            f"review_ladders must define exactly {sorted(VALID_RISKS)}, got {sorted(ladders)}"
-        )
+        raise ModelCatalogError(f"review_ladders must define exactly {sorted(VALID_RISKS)}, got {sorted(ladders)}")
     for risk, rungs in ladders.items():
         if not isinstance(rungs, list) or not rungs:
             raise ModelCatalogError(f"review_ladders.{risk} must be a non-empty list")
@@ -222,35 +178,23 @@ def validate_catalog(data: Any) -> dict[str, Any]:
         floor_rank = tiers[risk_floor[risk]]
         for rung in rungs:
             if not isinstance(rung, list) or not rung:
-                raise ModelCatalogError(
-                    f"review_ladders.{risk} rungs must be non-empty lists"
-                )
+                raise ModelCatalogError(f"review_ladders.{risk} rungs must be non-empty lists")
             rung_ranks: set[int] = set()
             for candidate_name in rung:
                 if candidate_name not in candidates:
-                    raise ModelCatalogError(
-                        f"review_ladders.{risk} references unknown candidate {candidate_name!r}"
-                    )
+                    raise ModelCatalogError(f"review_ladders.{risk} references unknown candidate {candidate_name!r}")
                 if candidate_name in seen:
-                    raise ModelCatalogError(
-                        f"review_ladders.{risk} repeats candidate {candidate_name!r}"
-                    )
+                    raise ModelCatalogError(f"review_ladders.{risk} repeats candidate {candidate_name!r}")
                 seen.add(candidate_name)
                 model_id = candidates[candidate_name]["model_id"]
                 rung_ranks.add(tiers[models[model_id]["tier"]])
             if len(rung_ranks) != 1:
-                raise ModelCatalogError(
-                    f"review_ladders.{risk} mixes quality tiers in one rung"
-                )
+                raise ModelCatalogError(f"review_ladders.{risk} mixes quality tiers in one rung")
             rung_rank = next(iter(rung_ranks))
             if rung_rank < previous_rank:
-                raise ModelCatalogError(
-                    f"review_ladders.{risk} improves quality in a later rung"
-                )
+                raise ModelCatalogError(f"review_ladders.{risk} improves quality in a later rung")
             if rung_rank > floor_rank:
-                raise ModelCatalogError(
-                    f"review_ladders.{risk} falls below its {risk_floor[risk]!r} quality floor"
-                )
+                raise ModelCatalogError(f"review_ladders.{risk} falls below its {risk_floor[risk]!r} quality floor")
             previous_rank = rung_rank
     return catalog
 
@@ -273,9 +217,7 @@ def catalog_age_days(catalog: dict[str, Any], *, as_of: date | None = None) -> i
     reviewed = date.fromisoformat(str(catalog["reviewed_on"]))
     age = (today - reviewed).days
     if age < 0:
-        raise ModelCatalogError(
-            f"reviewed_on {reviewed.isoformat()} is in the future relative to {today.isoformat()}"
-        )
+        raise ModelCatalogError(f"reviewed_on {reviewed.isoformat()} is in the future relative to {today.isoformat()}")
     return age
 
 

--- a/scripts/review/reviewer_resolver.py
+++ b/scripts/review/reviewer_resolver.py
@@ -25,11 +25,12 @@ from typing import Literal
 
 from scripts.agent_runtime.agent_identity import normalize_seat, tools_writer_runtime_agent
 from scripts.audit import model_families
-from scripts.review.model_catalog import VALID_RISKS, load_model_catalog
+from scripts.review.model_catalog import VALID_REVIEW_PROFILES, VALID_RISKS, load_model_catalog
 
 CandidateStatus = Literal["eligible", "selected", "advisory_only", "excluded"]
 
 # --- family resolution -------------------------------------------------------
+
 
 def resolve_family(seat_or_model: str) -> str:
     """Resolve a seat/CLI-alias/model-id string to its model family.
@@ -135,6 +136,7 @@ def resolve_author_family(author_model: str, author_family: str | None = None) -
 
 # --- candidates ---------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class ReviewerCandidate:
     name: str
@@ -183,9 +185,7 @@ def _catalog_candidate(name: str) -> ReviewerCandidate:
         review_profiles=frozenset(raw.get("review_profiles", [])),
         capabilities=frozenset(raw.get("capabilities", [])),
         domain_excluded_from=frozenset(raw.get("domain_excluded_from", [])),
-        advisory_only_for_author_families=frozenset(
-            raw.get("advisory_only_for_author_families", [])
-        ),
+        advisory_only_for_author_families=frozenset(raw.get("advisory_only_for_author_families", [])),
     )
 
 
@@ -195,10 +195,7 @@ REVIEW_CANDIDATES: dict[str, ReviewerCandidate] = {
 
 
 def _catalog_ladder(risk: str) -> tuple[tuple[ReviewerCandidate, ...], ...]:
-    return tuple(
-        tuple(REVIEW_CANDIDATES[name] for name in rung)
-        for rung in _MODEL_CATALOG["review_ladders"][risk]
-    )
+    return tuple(tuple(REVIEW_CANDIDATES[name] for name in rung) for rung in _MODEL_CATALOG["review_ladders"][risk])
 
 
 REVIEW_LADDERS: dict[str, tuple[tuple[ReviewerCandidate, ...], ...]] = {
@@ -261,10 +258,7 @@ def _normalize_health_status(value: object, *, label: str) -> str | None:
         raise ValueError(f"{label} health status must be a non-empty string")
     token = value.strip().lower()
     if token not in _HEALTH_ALIASES:
-        raise ValueError(
-            f"{label} has unsupported health status {value!r}; "
-            f"expected one of {sorted(_HEALTH_ALIASES)}"
-        )
+        raise ValueError(f"{label} has unsupported health status {value!r}; expected one of {sorted(_HEALTH_ALIASES)}")
     return _HEALTH_ALIASES[token]
 
 
@@ -297,9 +291,7 @@ def normalize_routing_snapshot(snapshot: Mapping[str, object] | None) -> dict[st
         if status is None and isinstance(health, Mapping) and health.get("healthy") is True:
             normalized[str(route)] = "healthy"
             continue
-        normalized_status = _normalize_health_status(
-            status, label=f"agents.{route}"
-        )
+        normalized_status = _normalize_health_status(status, label=f"agents.{route}")
         if normalized_status is not None:
             normalized[str(route)] = normalized_status
     return normalized
@@ -420,9 +412,7 @@ def evaluate_candidate(
     candidates that aren't in the default ladder (e.g. ``GLM``, ``QWEN``).
     """
     family = (
-        author_family
-        if author_family is not None
-        else resolve_author_family(inputs.author_model, inputs.author_family)
+        author_family if author_family is not None else resolve_author_family(inputs.author_model, inputs.author_family)
     )
     normalized_snapshot = normalize_routing_snapshot(inputs.routing_snapshot)
     health = _health_of(candidate, normalized_snapshot)
@@ -518,7 +508,8 @@ def resolve_reviewer(
     :func:`resolve_author_family`.
     """
     risk = (inputs.risk or "").strip().lower()
-    if ladder is None and risk not in VALID_RISKS:
+    review_profile = (inputs.review_profile or "").strip().casefold()
+    if review_profile not in VALID_REVIEW_PROFILES:
         return ReviewerResolution(
             selected=None,
             advisory=(),
@@ -528,8 +519,22 @@ def resolve_reviewer(
             catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
             resolved_risk=risk,
             fail_closed_reason=(
-                f"unsupported review risk {inputs.risk!r}; expected one of {sorted(VALID_RISKS)}"
+                f"unsupported local-code-review profile {inputs.review_profile!r}; "
+                f"expected one of {sorted(VALID_REVIEW_PROFILES)}. Learner-content semantic "
+                "review belongs to track-completion via post-build-review."
             ),
+        )
+    inputs = replace(inputs, review_profile=review_profile)
+    if ladder is None and risk not in VALID_RISKS:
+        return ReviewerResolution(
+            selected=None,
+            advisory=(),
+            trace=(),
+            substitution_note=None,
+            policy_version=_MODEL_CATALOG["schema_version"],
+            catalog_reviewed_on=_MODEL_CATALOG["reviewed_on"],
+            resolved_risk=risk,
+            fail_closed_reason=(f"unsupported review risk {inputs.risk!r}; expected one of {sorted(VALID_RISKS)}"),
         )
     active_ladder = ladder if ladder is not None else REVIEW_LADDERS[risk]
     try:
@@ -551,8 +556,7 @@ def resolve_reviewer(
     if author_family in UNRESOLVED_AUTHOR_FAMILIES:
         reason = {
             UNKNOWN_AUTHOR_FAMILY: (
-                f"author identity unknown — cannot resolve a model family from "
-                f"author_model={inputs.author_model!r}"
+                f"author identity unknown — cannot resolve a model family from author_model={inputs.author_model!r}"
             ),
             AMBIGUOUS_AUTHOR_FAMILY: (
                 f"author harness is multi-model and ambiguous (author_model={inputs.author_model!r}) — "
@@ -633,8 +637,7 @@ def resolve_reviewer(
         ]
         if unavailable:
             substitution_notes.append(
-                f"selected {selected.name}: same-quality route(s) unavailable by health: "
-                f"{', '.join(unavailable)}"
+                f"selected {selected.name}: same-quality route(s) unavailable by health: {', '.join(unavailable)}"
             )
         if better_health_than:
             substitution_notes.append(

--- a/tests/orchestration/test_curriculum_coordinator.py
+++ b/tests/orchestration/test_curriculum_coordinator.py
@@ -372,27 +372,7 @@ def test_global_mutation_lease_blocks_cross_track_work(repo: Path, tmp_path: Pat
     with pytest.raises(coordinator.CoordinatorError, match="lease belongs"):
         _acquire(repo, runtime, bio["run_id"])
 
-    coordinator.record_module(
-        folk["run_id"],
-        owner="sol",
-        slug="alpha",
-        disposition="blocked",
-        integration={"evidence": "blocker:source-rights"},
-        repo_root=repo,
-        runtime_root=runtime,
-    )
-    _path, retried, item = _acquire(repo, runtime, folk["run_id"])
-    assert item and item["slug"] == "alpha"
-    assert coordinator.derive_state(retried)["modules"]["alpha"] == "active"
-    coordinator.record_module(
-        folk["run_id"],
-        owner="sol",
-        slug="alpha",
-        disposition="blocked",
-        integration={"evidence": "blocker:source-rights"},
-        repo_root=repo,
-        runtime_root=runtime,
-    )
+    _no_change(repo, runtime, folk["run_id"])
     _path, _ledger, item = _acquire(repo, runtime, bio["run_id"])
     assert item and item["slug"] == "echo"
 
@@ -849,6 +829,41 @@ def test_bio_deploy_goal_waits_for_bounded_terminal_then_records_authoritative_r
 def test_pages_deploy_installs_audit_import_dependencies() -> None:
     workflow = (coordinator.PROJECT_ROOT / ".github/workflows/deploy-pages.yml").read_text(encoding="utf-8")
     assert "PyYAML==6.0.3 jsonschema==4.26.0" in workflow
+
+
+@pytest.mark.parametrize("disposition", ["complete", "blocked"])
+def test_legacy_run_requires_terminal_goal_migration_for_policy_dispositions(
+    repo: Path, tmp_path: Path, disposition: str
+) -> None:
+    runtime = tmp_path / "runtime"
+    path, ledger = _start(repo, runtime, scope="one", module="alpha")
+    _acquire(repo, runtime, ledger["run_id"])
+    before = path.read_bytes()
+
+    with pytest.raises(coordinator.CoordinatorError, match="migrate-terminal-goal"):
+        coordinator.record_module(
+            ledger["run_id"],
+            owner="sol",
+            slug="alpha",
+            disposition=disposition,
+            integration={"evidence": f"legacy:{disposition}"},
+            repo_root=repo,
+            runtime_root=runtime,
+        )
+
+    assert path.read_bytes() == before
+
+
+def test_legacy_no_change_with_evidence_remains_replayable(repo: Path, tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    _path, ledger = _start(repo, runtime, scope="one", module="alpha")
+    _acquire(repo, runtime, ledger["run_id"])
+
+    _path, completed = _no_change(repo, runtime, ledger["run_id"], evidence="legacy:pbr-v1")
+    _path, replayed = _no_change(repo, runtime, ledger["run_id"], evidence="legacy:pbr-v1")
+
+    assert coordinator.compact_status(completed)["status"] == "complete"
+    assert replayed == completed
 
 
 def test_legacy_completed_run_migration_reopens_unproven_module(repo: Path, tmp_path: Path) -> None:

--- a/tests/orchestration/test_curriculum_coordinator.py
+++ b/tests/orchestration/test_curriculum_coordinator.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +14,14 @@ import yaml
 from scripts.orchestration import curriculum_coordinator as coordinator
 
 BUNDLE_FILES = ("module.md", "activities.yaml", "vocabulary.yaml", "resources.yaml")
+ROOT = Path(__file__).resolve().parents[2]
+BOUNDED_SCRIPT = ROOT / "agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py"
+BOUNDED_FIXTURES = ROOT / "tests/fixtures/bounded_completion"
+BOUNDED_SPEC = importlib.util.spec_from_file_location("bounded_completion_for_coordinator_tests", BOUNDED_SCRIPT)
+assert BOUNDED_SPEC is not None and BOUNDED_SPEC.loader is not None
+bounded_completion = importlib.util.module_from_spec(BOUNDED_SPEC)
+sys.modules[BOUNDED_SPEC.name] = bounded_completion
+BOUNDED_SPEC.loader.exec_module(bounded_completion)
 
 
 @pytest.fixture
@@ -19,6 +29,10 @@ def repo(tmp_path: Path) -> Path:
     root = tmp_path / "repo"
     manifest = {
         "levels": {
+            "a1": {
+                "type": "core",
+                "modules": ["introductions", "family", "daily-routine"],
+            },
             "folk": {"type": "track", "modules": ["alpha", "bravo", "charlie", "delta"]},
             "bio": {
                 "type": "track",
@@ -122,9 +136,7 @@ def _no_change(repo: Path, runtime: Path, run_id: str, evidence: str = "pbr:v1")
     slug = coordinator.derive_state(ledger)["current_module"]
     if slug is None:
         slug = next(
-            event["details"]["slug"]
-            for event in reversed(ledger["history"])
-            if event["event"] == "MODULE_FINISHED"
+            event["details"]["slug"] for event in reversed(ledger["history"]) if event["event"] == "MODULE_FINISHED"
         )
     return coordinator.record_module(
         run_id,
@@ -135,6 +147,64 @@ def _no_change(repo: Path, runtime: Path, run_id: str, evidence: str = "pbr:v1")
         repo_root=repo,
         runtime_root=runtime,
     )
+
+
+def _bounded_protocol() -> dict[str, str]:
+    return bounded_completion.make_review_protocol_identity(
+        protocol_version="5.0.0",
+        tool_sha256="1" * 64,
+        prompt_sha256="2" * 64,
+        schema_sha256="3" * 64,
+        reviewer_family="fixture-family",
+        reviewer_model="fixture-model",
+    )
+
+
+def _incomplete_bounded_run(selector: str, run_id: str) -> dict[str, Any]:
+    run = bounded_completion.start_run(
+        target=selector,
+        run_id=run_id,
+        review_protocol_identity=_bounded_protocol(),
+        learner_source_sha256="a" * 64,
+    )
+    run = bounded_completion.complete_inspection(run, needs_build=False, elapsed_time_ms=5)
+    return bounded_completion.record_deterministic_verification(
+        run,
+        learner_source_sha256="a" * 64,
+        passed=True,
+        elapsed_time_ms=7,
+    )
+
+
+def _terminal_bounded_run(selector: str, run_id: str, fixture: str) -> dict[str, Any]:
+    run = bounded_completion.replay_fixture(BOUNDED_FIXTURES / fixture)["run"]
+    run["target"] = selector
+    run["run_id"] = run_id
+    bounded_completion.validate_run(run)
+    return run
+
+
+def _write_track_ledger(
+    path: Path,
+    *,
+    selector: str,
+    run_id: str,
+    terminal_goal: str,
+    bounded_run: dict[str, Any],
+    outer_state: str,
+    outer_status: str,
+    extra_reviews: int = 0,
+) -> None:
+    model_calls = int(bounded_run["measurements"]["model_call_count"])
+    value = {
+        "target": {"selector": selector},
+        "run": {"run_id": run_id, "status": outer_status},
+        "terminal_goal": terminal_goal,
+        "state": outer_state,
+        "bounded_completion": {"run": bounded_run},
+        "reviews": [{"evidence": f"semantic-{index + 1}"} for index in range(model_calls + extra_reviews)],
+    }
+    path.write_text(json.dumps(value), encoding="utf-8")
 
 
 def test_versioned_config_and_schemas_are_strict() -> None:
@@ -186,6 +256,26 @@ def test_manifest_selectors_ranges_and_prerequisites(repo: Path, tmp_path: Path)
     _path, one = _start(repo, tmp_path / "one", scope="one", module="bravo")
     assert [item["slug"] for item in one["queue"]] == ["bravo"]
 
+    _path, core = _start(
+        repo,
+        tmp_path / "core-order",
+        track="a1",
+        start="introductions",
+        end="daily-routine",
+        wave_size=2,
+    )
+    assert [item["slug"] for item in core["queue"]] == [
+        "introductions",
+        "family",
+        "daily-routine",
+    ]
+    assert [item["prerequisites"] for item in core["queue"]] == [
+        [],
+        ["introductions"],
+        ["family"],
+    ]
+    assert [item["wave"] for item in core["queue"]] == [1, 1, 2]
+
 
 @pytest.mark.parametrize(
     ("kwargs", "message"),
@@ -233,15 +323,11 @@ def test_health_pause_resume_serial_waves_and_no_change(repo: Path, tmp_path: Pa
         snapshot["generated_at"] = f"2026-07-14T12:00:0{polls}Z"
         return snapshot
 
-    _path, paused, item = _acquire(
-        repo, runtime, run_id, health_probe=changing_unhealthy_probe
-    )
+    _path, paused, item = _acquire(repo, runtime, run_id, health_probe=changing_unhealthy_probe)
     assert item is None
     assert coordinator.compact_status(paused)["status"] == "paused"
     pause_count = len(paused["history"])
-    _path, retried, item = _acquire(
-        repo, runtime, run_id, health_probe=changing_unhealthy_probe
-    )
+    _path, retried, item = _acquire(repo, runtime, run_id, health_probe=changing_unhealthy_probe)
     assert item is None
     assert len(retried["history"]) == pause_count
 
@@ -264,8 +350,7 @@ def test_health_pause_resume_serial_waves_and_no_change(repo: Path, tmp_path: Pa
     assert item and item["slug"] == "delta"
     current = json.loads(_path.read_text(encoding="utf-8"))
     assert any(
-        event["event"] == "RUN_RESUMED"
-        and event["details"]["reason"] == "wave-health-restored"
+        event["event"] == "RUN_RESUMED" and event["details"]["reason"] == "wave-health-restored"
         for event in current["history"]
     )
     _no_change(repo, runtime, run_id, evidence="pbr:delta")
@@ -325,9 +410,7 @@ def test_expired_lease_requires_exact_resume_and_is_never_stolen(repo: Path, tmp
     with pytest.raises(coordinator.CoordinatorError, match="stale lease belongs"):
         _start(repo, runtime, owner="terra", scope="one", module="bravo")
 
-    coordinator.resume_run(
-        ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime
-    )
+    coordinator.resume_run(ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime)
     _path, _ledger, item = _acquire(repo, runtime, ledger["run_id"])
     assert item and item["slug"] == "alpha"
 
@@ -378,73 +461,104 @@ def test_finish_retry_heals_cleanup_after_crash(repo: Path, tmp_path: Path, monk
     assert duplicate == healed
 
 
-def test_conflicting_replay_and_incomplete_repair_identity_fail(repo: Path, tmp_path: Path) -> None:
+def test_bounded_module_ledger_is_authoritative_and_terminal_result_clears_stale_state(
+    repo: Path, tmp_path: Path
+) -> None:
     runtime = tmp_path / "runtime"
-    _path, ledger = _start(repo, runtime, scope="one", module="alpha")
+    _path, ledger = _start(repo, runtime, scope="one", module="alpha", terminal_goal="merge")
     run_id = ledger["run_id"]
     _acquire(repo, runtime, run_id)
-    with pytest.raises(coordinator.CoordinatorError, match="PR number"):
-        coordinator.record_module(
+    track_run_id = "1" * 32
+    track_path = tmp_path / "track-completion.json"
+    incomplete = _incomplete_bounded_run("folk/alpha", track_run_id)
+    _write_track_ledger(
+        track_path,
+        selector="folk/alpha",
+        run_id=track_run_id,
+        terminal_goal="merge",
+        bounded_run=incomplete,
+        outer_state="POST_BUILD_REVIEW_REQUIRED",
+        outer_status="active",
+    )
+
+    with pytest.raises(coordinator.CoordinatorError, match="incomplete"):
+        coordinator.record_bounded_module_result(
             run_id,
             owner="sol",
             slug="alpha",
-            disposition="complete",
-            integration={"issue": 5158, "evidence": "repair:test"},
+            track_ledger=str(track_path),
+            track_run_id=track_run_id,
             repo_root=repo,
             runtime_root=runtime,
         )
-    _no_change(repo, runtime, run_id, evidence="pbr:pass")
-    with pytest.raises(coordinator.CoordinatorError, match="conflicting replay"):
-        _no_change(repo, runtime, run_id, evidence="pbr:different")
+    unchanged = json.loads((runtime / "runs" / f"{run_id}.json").read_text(encoding="utf-8"))
+    assert coordinator.derive_state(unchanged)["current_module"] == "alpha"
 
-
-def test_completed_repair_requires_full_merge_and_cleanup_identity(repo: Path, tmp_path: Path) -> None:
-    runtime = tmp_path / "runtime"
-    _path, ledger = _start(repo, runtime, scope="one", module="alpha")
-    run_id = ledger["run_id"]
-    _acquire(repo, runtime, run_id)
-    _path, complete = coordinator.record_module(
+    terminal = _terminal_bounded_run("folk/alpha", track_run_id, "success.json")
+    _write_track_ledger(
+        track_path,
+        selector="folk/alpha",
+        run_id=track_run_id,
+        terminal_goal="merge",
+        bounded_run=terminal,
+        outer_state="COMPLETE",
+        outer_status="completed",
+    )
+    _path, complete, result = coordinator.record_bounded_module_result(
         run_id,
         owner="sol",
         slug="alpha",
-        disposition="complete",
-        integration={
-            "issue": 6001,
-            "worktree": ".worktrees/dispatch/codex/6001-alpha",
-            "branch": "codex/6001-alpha",
-            "pr": 6002,
-            "merge_sha": "a" * 40,
-            "cleanup": "complete",
-            "evidence": "review:claude-opus",
-        },
+        track_ledger=str(track_path),
+        track_run_id=track_run_id,
         repo_root=repo,
         runtime_root=runtime,
     )
+    assert result == {
+        "elapsed_time_ms": 98,
+        "model_call_count": 2,
+        "repair_count": 1,
+        "disposition": "PUBLISHABLE",
+        "blocker": None,
+        "next_action": "acquire-next",
+    }
     assert coordinator.compact_status(complete)["counts"]["complete"] == 1
+    finished = next(event for event in complete["history"] if event["event"] == "MODULE_FINISHED")
+    integration = finished["details"]["integration"]
+    assert integration["issue"] is None
+    assert integration["pr"] is None
+    assert integration["track_terminal"]["sha256"] in integration["evidence"]
 
 
-def test_completed_repair_rejects_misaligned_branch_identity(repo: Path, tmp_path: Path) -> None:
+def test_unbounded_semantic_evidence_is_rejected_without_coordinator_mutation(repo: Path, tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
-    _path, ledger = _start(repo, runtime, scope="one", module="alpha")
+    _path, ledger = _start(repo, runtime, scope="one", module="alpha", terminal_goal="merge")
     _acquire(repo, runtime, ledger["run_id"])
-    with pytest.raises(coordinator.CoordinatorError, match="align"):
-        coordinator.record_module(
+    track_run_id = "2" * 32
+    track_path = tmp_path / "track-completion.json"
+    terminal = _terminal_bounded_run("folk/alpha", track_run_id, "success.json")
+    _write_track_ledger(
+        track_path,
+        selector="folk/alpha",
+        run_id=track_run_id,
+        terminal_goal="merge",
+        bounded_run=terminal,
+        outer_state="COMPLETE",
+        outer_status="completed",
+        extra_reviews=1,
+    )
+    coordinator_path = runtime / "runs" / f"{ledger['run_id']}.json"
+    before = coordinator_path.read_bytes()
+    with pytest.raises(coordinator.CoordinatorError, match="outside the bounded budget"):
+        coordinator.record_bounded_module_result(
             ledger["run_id"],
             owner="sol",
             slug="alpha",
-            disposition="complete",
-            integration={
-                "issue": 6001,
-                "worktree": ".worktrees/dispatch/codex/6001-alpha",
-                "branch": "codex/different",
-                "pr": 6002,
-                "merge_sha": "a" * 40,
-                "cleanup": "complete",
-                "evidence": "review:claude-opus",
-            },
+            track_ledger=str(track_path),
+            track_run_id=track_run_id,
             repo_root=repo,
             runtime_root=runtime,
         )
+    assert coordinator_path.read_bytes() == before
 
 
 def test_ledger_tampering_is_detected_by_replay_validation(repo: Path, tmp_path: Path) -> None:
@@ -453,9 +567,7 @@ def test_ledger_tampering_is_detected_by_replay_validation(repo: Path, tmp_path:
     ledger["history"][0]["details"]["request_sha256"] = "0" * 64
     path.write_text(json.dumps(ledger), encoding="utf-8")
     with pytest.raises(coordinator.CoordinatorError, match="identity does not match"):
-        coordinator.status_run(
-            ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime
-        )
+        coordinator.status_run(ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime)
 
 
 def test_manifest_drift_invalidates_the_durable_queue(repo: Path, tmp_path: Path) -> None:
@@ -466,14 +578,10 @@ def test_manifest_drift_invalidates_the_durable_queue(repo: Path, tmp_path: Path
     manifest["levels"]["folk"]["modules"].append("golf")
     manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
 
-    status = coordinator.status_run(
-        ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime
-    )
+    status = coordinator.status_run(ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime)
     assert status["manifest_current"] is False
     with pytest.raises(coordinator.CoordinatorError, match="manifest changed"):
-        coordinator.resume_run(
-            ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime
-        )
+        coordinator.resume_run(ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime)
     with pytest.raises(coordinator.CoordinatorError, match="lease belongs"):
         _start(repo, runtime, scope="one", module="bravo")
     _path, abandoned = coordinator.adjudicate_run(
@@ -549,36 +657,39 @@ def test_adjudication_retry_heals_leases_after_crash(
     assert replacement["run_id"] != ledger["run_id"]
 
 
-def test_blocked_integration_identity_is_consistent(repo: Path, tmp_path: Path) -> None:
+def test_terminal_bounded_blocker_updates_coordinator_and_preserves_reacquisition(repo: Path, tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
-    _path, ledger = _start(repo, runtime, scope="one", module="alpha")
+    _path, ledger = _start(repo, runtime, scope="one", module="alpha", terminal_goal="merge")
     _acquire(repo, runtime, ledger["run_id"])
-    with pytest.raises(coordinator.CoordinatorError, match="must not claim"):
-        coordinator.record_module(
-            ledger["run_id"],
-            owner="sol",
-            slug="alpha",
-            disposition="blocked",
-            integration={"issue": 5158, "evidence": "blocker:test"},
-            repo_root=repo,
-            runtime_root=runtime,
-        )
-    _path, blocked = coordinator.record_module(
+    track_run_id = "3" * 32
+    track_path = tmp_path / "track-completion.json"
+    terminal = _terminal_bounded_run("folk/alpha", track_run_id, "budget-exhaustion.json")
+    _write_track_ledger(
+        track_path,
+        selector="folk/alpha",
+        run_id=track_run_id,
+        terminal_goal="merge",
+        bounded_run=terminal,
+        outer_state="BLOCKED_BUDGET_EXHAUSTED",
+        outer_status="active",
+    )
+    _path, blocked, result = coordinator.record_bounded_module_result(
         ledger["run_id"],
         owner="sol",
         slug="alpha",
-        disposition="blocked",
-        integration={
-            "issue": 5158,
-            "worktree": ".worktrees/dispatch/codex/5158-track-coordinator",
-            "branch": "codex/5158-track-coordinator",
-            "cleanup": "pending",
-            "evidence": "blocker:test",
-        },
+        track_ledger=str(track_path),
+        track_run_id=track_run_id,
         repo_root=repo,
         runtime_root=runtime,
     )
     assert coordinator.compact_status(blocked)["status"] == "blocked"
+    assert result["disposition"] == "BLOCKED_BUDGET_EXHAUSTED"
+    assert result["model_call_count"] == len(terminal["reviews"])
+    assert result["repair_count"] == len(terminal["repairs"])
+    assert result["blocker"] is not None
+    _path, reacquired, item = _acquire(repo, runtime, ledger["run_id"])
+    assert item is not None and item["slug"] == "alpha"
+    assert coordinator.derive_state(reacquired)["current_module"] == "alpha"
 
 
 def test_partial_module_lease_claim_rolls_back_global_lease(repo: Path, tmp_path: Path) -> None:
@@ -615,9 +726,7 @@ def test_recomputed_but_impossible_event_is_rejected(repo: Path, tmp_path: Path)
     )
     path.write_text(json.dumps(ledger), encoding="utf-8")
     with pytest.raises(coordinator.CoordinatorError, match="completion is premature"):
-        coordinator.status_run(
-            ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime
-        )
+        coordinator.status_run(ledger["run_id"], owner="sol", repo_root=repo, runtime_root=runtime)
 
 
 def test_one_line_cli_start_and_status_use_compact_contract(
@@ -667,15 +776,9 @@ def test_one_line_cli_start_and_status_use_compact_contract(
     assert status["event_count"] == 1
 
 
-def test_bio_371_deploy_goal_rejects_pending_and_certification_only_track_ledger(
+def test_bio_deploy_goal_waits_for_bounded_terminal_then_records_authoritative_result(
     repo: Path, tmp_path: Path
 ) -> None:
-    incident = {
-        "track_run_id": "0b4b92fcc5ca4653a33fb89b68c7cfc8",
-        "coordinator_run_id": "clc-d571995205b4c2773fc9c2a1",
-        "pr": 5255,
-        "merge_sha": "ba5e43d42922d6c08ec3f4b5e0f558e18ac74041",
-    }
     runtime = tmp_path / "runtime"
     _path, ledger = _start(
         repo,
@@ -687,84 +790,68 @@ def test_bio_371_deploy_goal_rejects_pending_and_certification_only_track_ledger
     )
     run_id = ledger["run_id"]
     _acquire(repo, runtime, run_id)
-    track_run_id = incident["track_run_id"]
+    track_run_id = "0b4b92fcc5ca4653a33fb89b68c7cfc8"
     track_path = tmp_path / "track-completion.json"
-    track_ledger = {
-        "target": {"selector": "bio/andrii-malyshko"},
-        "run": {"run_id": track_run_id, "status": "active"},
-        "terminal_goal": "deploy",
-        "state": "PBR_PASS_QG_PENDING",
-        "publication": {
-            "pr": incident["pr"],
-            "merge_sha": incident["merge_sha"],
-        },
-        "certification_evidence": [],
-    }
-    track_path.write_text(json.dumps(track_ledger), encoding="utf-8")
-    integration = {
-        "evidence": f"BIO-371 coordinator:{incident['coordinator_run_id']}",
-        "track_ledger": str(track_path),
-        "track_run_id": track_run_id,
-    }
-    with pytest.raises(coordinator.CoordinatorError, match="not satisfied"):
-        coordinator.record_module(
+    incomplete = _incomplete_bounded_run("bio/andrii-malyshko", track_run_id)
+    _write_track_ledger(
+        track_path,
+        selector="bio/andrii-malyshko",
+        run_id=track_run_id,
+        terminal_goal="deploy",
+        bounded_run=incomplete,
+        outer_state="AWAITING_PRODUCTION_QG_ARMING",
+        outer_status="active",
+    )
+    with pytest.raises(coordinator.CoordinatorError, match="incomplete"):
+        coordinator.record_bounded_module_result(
             run_id,
             owner="sol",
             slug="andrii-malyshko",
-            disposition="no-change",
-            integration=integration,
+            track_ledger=str(track_path),
+            track_run_id=track_run_id,
             repo_root=repo,
             runtime_root=runtime,
         )
-    track_ledger["run"]["status"] = "completed"
-    track_ledger["state"] = "COMPLETE"
-    track_path.write_text(json.dumps(track_ledger), encoding="utf-8")
-    with pytest.raises(coordinator.CoordinatorError, match="deployment receipt"):
-        coordinator.record_module(
-            run_id,
-            owner="sol",
-            slug="andrii-malyshko",
-            disposition="no-change",
-            integration=integration,
-            repo_root=repo,
-            runtime_root=runtime,
-        )
-    track_ledger["certification_evidence"] = [
-        {"value": {"kind": "deployment"}}
-    ]
-    track_path.write_text(json.dumps(track_ledger), encoding="utf-8")
-    _path, complete = coordinator.record_module(
+
+    terminal = _terminal_bounded_run("bio/andrii-malyshko", track_run_id, "success.json")
+    _write_track_ledger(
+        track_path,
+        selector="bio/andrii-malyshko",
+        run_id=track_run_id,
+        terminal_goal="deploy",
+        bounded_run=terminal,
+        outer_state="COMPLETE",
+        outer_status="completed",
+    )
+    _path, complete, result = coordinator.record_bounded_module_result(
         run_id,
         owner="sol",
         slug="andrii-malyshko",
-        disposition="no-change",
-        integration=integration,
+        track_ledger=str(track_path),
+        track_run_id=track_run_id,
         repo_root=repo,
         runtime_root=runtime,
     )
-    _path, replayed = coordinator.record_module(
+    _path, replayed, replayed_result = coordinator.record_bounded_module_result(
         run_id,
         owner="sol",
         slug="andrii-malyshko",
-        disposition="no-change",
-        integration=integration,
+        track_ledger=str(track_path),
+        track_run_id=track_run_id,
         repo_root=repo,
         runtime_root=runtime,
     )
     assert coordinator.compact_status(complete)["terminal_satisfied"] is True
     assert replayed == complete
+    assert replayed_result == result
 
 
 def test_pages_deploy_installs_audit_import_dependencies() -> None:
-    workflow = (coordinator.PROJECT_ROOT / ".github/workflows/deploy-pages.yml").read_text(
-        encoding="utf-8"
-    )
+    workflow = (coordinator.PROJECT_ROOT / ".github/workflows/deploy-pages.yml").read_text(encoding="utf-8")
     assert "PyYAML==6.0.3 jsonschema==4.26.0" in workflow
 
 
-def test_legacy_completed_run_migration_reopens_unproven_module(
-    repo: Path, tmp_path: Path
-) -> None:
+def test_legacy_completed_run_migration_reopens_unproven_module(repo: Path, tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
     _path, ledger = _start(repo, runtime, scope="one", module="alpha")
     run_id = ledger["run_id"]

--- a/tests/orchestration/test_prompt_contracts.py
+++ b/tests/orchestration/test_prompt_contracts.py
@@ -440,11 +440,7 @@ def test_seminar_profiles_compose_shared_and_exact_direction_without_bio_leakage
     assert all(marker in resolved.rendered_prompt for marker in SHARED_SEMINAR_MARKERS)
     assert direction_marker in resolved.rendered_prompt
     assert discipline_marker in resolved.rendered_prompt
-    other_direction_markers = {
-        profile[2]
-        for profile in SEMINAR_PROFILES
-        if profile[0] != profile_id
-    }
+    other_direction_markers = {profile[2] for profile in SEMINAR_PROFILES if profile[0] != profile_id}
     assert all(marker not in resolved.rendered_prompt for marker in other_direction_markers)
     assert resolved.fragment_ids == (
         "contract.base",
@@ -691,3 +687,25 @@ def test_explicit_historical_version_survives_current_version_change(tmp_path: P
     assert historical.version == "1.0.0"
     assert current.version == "1.1.0"
     assert current.identity_sha256 != historical.identity_sha256
+
+
+def test_four_skill_entrypoints_route_normal_bio_work_to_one_bounded_ledger() -> None:
+    skill_root = REPO_ROOT / "agents_extensions/shared/skills"
+    lifecycle = (skill_root / "curriculum-lifecycle/SKILL.md").read_text(encoding="utf-8")
+    completion = (skill_root / "track-completion/SKILL.md").read_text(encoding="utf-8")
+    post_build = (skill_root / "post-build-review/SKILL.md").read_text(encoding="utf-8")
+    code_review = (skill_root / "local-code-review/SKILL.md").read_text(encoding="utf-8")
+    normalized_code_review = " ".join(code_review.split())
+
+    assert "one serial workflow" in lifecycle
+    assert "--track-ledger <track-completion-ledger>" in lifecycle
+    assert "--disposition <complete|no-change|blocked>" not in lifecycle
+    assert "resume_command" in lifecycle
+    assert "one authoritative bounded" in completion
+    assert "model_call_count" in completion
+    assert "hidden retry" in completion
+    assert "routes through `$track-completion`" in post_build
+    assert "prepare-semantic-review" in post_build
+    assert "without retrying" in post_build
+    assert "supports only `code` and `infra`" in code_review
+    assert "Do not duplicate post-build semantic review" in normalized_code_review

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -9,6 +9,7 @@ import pytest
 
 from scripts.agent_runtime.registry import AGENTS
 from scripts.review.model_catalog import (
+    VALID_REVIEW_PROFILES,
     ModelCatalogError,
     catalog_age_days,
     catalog_is_stale,
@@ -58,8 +59,7 @@ def test_runtime_registry_defaults_resolve_to_catalog_model_or_alias():
     unresolved = {
         agent: entry["default_model"]
         for agent, entry in AGENTS.items()
-        if entry["default_model"] not in {None, "auto"}
-        and entry["default_model"] not in known
+        if entry["default_model"] not in {None, "auto"} and entry["default_model"] not in known
     }
     assert unresolved == {}
 
@@ -86,8 +86,16 @@ def test_bridge_only_reviewers_expose_executable_invocations():
 
 def test_formal_review_candidates_declare_supported_profiles_and_concrete_cursor_model():
     candidates = load_model_catalog()["review_candidates"]
-    assert all(candidate["review_profiles"] == ["code", "infra"] for candidate in candidates.values())
+    assert {"code", "infra"} == VALID_REVIEW_PROFILES
+    assert all(set(candidate["review_profiles"]) == VALID_REVIEW_PROFILES for candidate in candidates.values())
     assert candidates["composer-2.5"]["model_id"] == "composer-2.5"
+
+
+def test_catalog_rejects_learner_content_as_a_code_closeout_profile():
+    broken = deepcopy(load_model_catalog())
+    broken["review_candidates"]["openai_frontier"]["review_profiles"].append("content")
+    with pytest.raises(ModelCatalogError, match="unsupported code-closeout profiles"):
+        validate_catalog(broken)
 
 
 def test_catalog_rejects_unknown_candidate_model_reference():

--- a/tests/test_review_closeout_cli.py
+++ b/tests/test_review_closeout_cli.py
@@ -99,13 +99,23 @@ def test_full_flow_target_freeze_expansion_cycle_reviewer_findings(tmp_path):
     assert resolution["policy_version"] == "model-catalog.v1"
     assert resolution["resolved_risk"] == "medium"
 
-    raise_proc = _run_cli(state_file, "finding", "raise", "--id", "F1", "--summary", "issue", "--source", "reviewer:grok")
+    raise_proc = _run_cli(
+        state_file, "finding", "raise", "--id", "F1", "--summary", "issue", "--source", "reviewer:grok"
+    )
     assert raise_proc.returncode == 0, raise_proc.stderr
     apply_before_adjudicate = _run_cli(state_file, "finding", "apply", "--id", "F1")
     assert apply_before_adjudicate.returncode != 0
 
     adjudicate_proc = _run_cli(
-        state_file, "finding", "adjudicate", "--id", "F1", "--disposition", "in_scope_blocker", "--rationale", "real bug"
+        state_file,
+        "finding",
+        "adjudicate",
+        "--id",
+        "F1",
+        "--disposition",
+        "in_scope_blocker",
+        "--rationale",
+        "real bug",
     )
     assert adjudicate_proc.returncode == 0, adjudicate_proc.stderr
     apply_proc = _run_cli(state_file, "finding", "apply", "--id", "F1")
@@ -142,6 +152,25 @@ def test_resolve_reviewer_cli_rejects_invalid_risk_and_fail_closed_identity(tmp_
     )
     assert unknown_author.returncode != 0
     assert json.loads(unknown_author.stdout)["selected"] is None
+
+
+def test_resolve_reviewer_cli_rejects_learner_semantic_profile_before_dispatch(tmp_path):
+    state_file = tmp_path / "state.json"
+    unsupported = _run_cli(
+        state_file,
+        "resolve-reviewer",
+        "--author-model",
+        "claude",
+        "--review-profile",
+        "content",
+    )
+
+    assert unsupported.returncode != 0
+    payload = json.loads(unsupported.stdout)
+    assert payload["selected"] is None
+    assert payload["trace"] == []
+    assert "unsupported local-code-review profile" in payload["fail_closed_reason"]
+    assert "post-build-review" in payload["fail_closed_reason"]
 
 
 def test_behavior_proof_recording_round_trips_into_receipt(tmp_path):
@@ -244,9 +273,20 @@ def test_behavior_proof_record_rejects_malformed_proof_and_baseline_before_mutat
     assert _run_cli(state_file, *_freeze_kwargs()).returncode == 0
 
     record_args = (
-        "behavior-proof", "record", "--surface", "source_aware", "--status", "pass",
-        "--step", "open the feature", "--result", "feature opened", "--observation", "visible",
-        "--evidence-ref", "test:manual",
+        "behavior-proof",
+        "record",
+        "--surface",
+        "source_aware",
+        "--status",
+        "pass",
+        "--step",
+        "open the feature",
+        "--result",
+        "feature opened",
+        "--observation",
+        "visible",
+        "--evidence-ref",
+        "test:manual",
     )
     valid_state = json.loads(state_file.read_text(encoding="utf-8"))
     for malformed in (None, [], "not-an-object"):
@@ -295,8 +335,18 @@ def test_behavior_proof_record_rejects_empty_steps_and_emit_before_record(tmp_pa
     assert json.loads(emit.stderr)["error"] == "no behavior proof recorded yet"
 
     common = (
-        "behavior-proof", "record", "--surface", "source_aware", "--status", "pass",
-        "--result", "done", "--observation", "visible", "--evidence-ref", "test:manual",
+        "behavior-proof",
+        "record",
+        "--surface",
+        "source_aware",
+        "--status",
+        "pass",
+        "--result",
+        "done",
+        "--observation",
+        "visible",
+        "--evidence-ref",
+        "test:manual",
     )
     for flag in ("--command", "--step"):
         proc = _run_cli(state_file, *common, flag, "   ")
@@ -311,14 +361,19 @@ def test_behavior_proof_na_is_versioned_and_preserves_explicit_blind_enforcement
     assert _run_cli(state_file, "target", "--mode", "local", "--repo-root", str(repo)).returncode == 0
     assert _run_cli(state_file, *_freeze_kwargs()).returncode == 0
 
-    missing_reason = _run_cli(
-        state_file, "behavior-proof", "record", "--surface", "source_blind", "--status", "n/a"
-    )
+    missing_reason = _run_cli(state_file, "behavior-proof", "record", "--surface", "source_blind", "--status", "n/a")
     assert missing_reason.returncode != 0
     assert json.loads(missing_reason.stderr)["error"] == "n/a proof requires --reason"
     recorded = _run_cli(
-        state_file, "behavior-proof", "record", "--surface", "source_blind", "--status", "n/a",
-        "--reason", "no user-visible surface",
+        state_file,
+        "behavior-proof",
+        "record",
+        "--surface",
+        "source_blind",
+        "--status",
+        "n/a",
+        "--reason",
+        "no user-visible surface",
     )
     assert recorded.returncode == 0, recorded.stderr
     proof = json.loads(recorded.stdout)
@@ -326,8 +381,16 @@ def test_behavior_proof_na_is_versioned_and_preserves_explicit_blind_enforcement
     assert "blind_enforced" not in proof["source_blind"]
 
     explicit = _run_cli(
-        state_file, "behavior-proof", "record", "--surface", "source_blind", "--status", "n/a",
-        "--reason", "isolation unavailable", "--blind-enforced",
+        state_file,
+        "behavior-proof",
+        "record",
+        "--surface",
+        "source_blind",
+        "--status",
+        "n/a",
+        "--reason",
+        "isolation unavailable",
+        "--blind-enforced",
     )
     assert explicit.returncode == 0, explicit.stderr
     assert json.loads(explicit.stdout)["source_blind"]["blind_enforced"] is True

--- a/tests/test_review_reviewer_resolver.py
+++ b/tests/test_review_reviewer_resolver.py
@@ -81,10 +81,7 @@ def test_cursor_requires_concrete_model_identity():
 def test_invalid_or_conflicting_author_identity_fails_closed():
     assert resolve_author_family("") == UNKNOWN_AUTHOR_FAMILY
     assert resolve_author_family("unknown-seat") == UNKNOWN_AUTHOR_FAMILY
-    assert (
-        resolve_author_family("cursor:gpt-5.6-sol", author_family="anthropic")
-        == CONFLICTING_AUTHOR_FAMILY
-    )
+    assert resolve_author_family("cursor:gpt-5.6-sol", author_family="anthropic") == CONFLICTING_AUTHOR_FAMILY
     for inputs in (
         ResolverInputs(author_model="cursor"),
         ResolverInputs(author_model="unknown-seat"),
@@ -179,9 +176,7 @@ def test_real_routing_budget_payload_is_normalized_without_crashing():
             "claude": {"status": "warm", "health": {"healthy": True}},
         },
     }
-    resolution = resolve_reviewer(
-        ResolverInputs(author_model="codex", risk="medium", routing_snapshot=snapshot)
-    )
+    resolution = resolve_reviewer(ResolverInputs(author_model="codex", risk="medium", routing_snapshot=snapshot))
     assert resolution.selected.name == "claude-fable-5"
     assert resolution.selected.health is None
 
@@ -193,9 +188,7 @@ def test_real_gemini_lane_outage_excludes_agy_candidates():
             "grok": {"status": "cool", "health": {"healthy": True}},
         }
     }
-    resolution = resolve_reviewer(
-        ResolverInputs(author_model="codex", risk="medium", routing_snapshot=snapshot)
-    )
+    resolution = resolve_reviewer(ResolverInputs(author_model="codex", risk="medium", routing_snapshot=snapshot))
     assert resolution.selected.name == "claude-fable-5"
     gemini = next(entry for entry in resolution.trace if entry.name == "gemini-3.1-pro")
     assert gemini.health == "unhealthy"
@@ -274,12 +267,8 @@ def test_all_top_tier_routes_unavailable_fall_to_next_quality_tier():
 
 
 def test_missing_health_signal_is_fail_open():
-    empty = resolve_reviewer(
-        ResolverInputs(author_model="codex", risk="low", routing_snapshot={})
-    )
-    absent = resolve_reviewer(
-        ResolverInputs(author_model="codex", risk="low", routing_snapshot=None)
-    )
+    empty = resolve_reviewer(ResolverInputs(author_model="codex", risk="low", routing_snapshot={}))
+    absent = resolve_reviewer(ResolverInputs(author_model="codex", risk="low", routing_snapshot=None))
     assert empty.selected.name == absent.selected.name == "claude-fable-5"
 
 
@@ -394,6 +383,16 @@ def test_review_profile_is_a_hard_eligibility_filter():
     )
     assert result.status == "excluded"
     assert "profile exclusion" in result.reason
+
+
+def test_learner_content_profile_fails_before_reviewer_ladder_resolution():
+    resolution = resolve_reviewer(ResolverInputs(author_model="claude", review_profile="content"))
+
+    assert resolution.selected is None
+    assert resolution.trace == ()
+    assert resolution.advisory == ()
+    assert "unsupported local-code-review profile" in resolution.fail_closed_reason
+    assert "post-build-review" in resolution.fail_closed_reason
 
 
 def test_custom_ladder_still_supported_for_focused_callers():


### PR DESCRIPTION
## Summary

- make the acquired module's bounded track-completion ledger the coordinator's only completion authority
- reject incomplete, stale, mismatched, or out-of-budget semantic evidence before coordinator completion
- keep local-code-review limited to code/infra profiles and route BIO semantic completion through track-completion/post-build-review
- document one normal BIO workflow with deterministic resume and a concise bounded operator result

Parent stream epic: #4431

Closes #5454

## Acceptance evidence

- initial full issue batch at `04225c4f7b107c702cb31b5329b9cb620fa48855` — 213 passed in 740.33s
- current-head correction batch: `.venv/bin/python -m pytest -q -n 0 tests/orchestration/test_curriculum_coordinator.py tests/orchestration/test_curriculum_lifecycle_pilot.py tests/orchestration/test_prompt_contracts.py tests/test_bounded_completion_contract.py tests/test_track_completion.py tests/test_review_closeout_cli.py tests/test_review_reviewer_resolver.py` — 199 passed in 147.69s
- focused legacy-ledger regression command — 4 passed in 1.36s; `complete` and `blocked` fail before mutation, while exact `no-change` replay remains valid
- coordinator tests include explicit CORE ordering/prerequisite preservation, BIO/seminar ordering, incomplete-ledger rejection, terminal-ledger synchronization, bounded blocker handling, and hidden semantic-evidence rejection
- `.venv/bin/python scripts/lint/lint_agent_skills.py` — skill metadata OK for 16 skills
- `.venv/bin/ruff check <9 changed Python files>` — all checks passed
- `.venv/bin/ruff format --check <9 changed Python files>` — 9 files already formatted
- `git diff --check origin/main...HEAD` — passed
- protected-file/forbidden-artifact/allowlist fence — 14 changed files; all allowlisted; protected files and forbidden artifacts unchanged; `.python-version` remains 3.12.8; no forbidden additions
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — 2 commits passed with `X-Agent: codex/5454-curriculum-coordination`

No paid semantic/provider/model review was run.
