### PR TITLE
feat(readiness): add deterministic inventory modes

### DIFF
--- a/scripts/orchestration/curriculum_readiness.py
+++ b/scripts/orchestration/curriculum_readiness.py
@@ -76,6 +76,7 @@ _BIO_DEPTH_TYPES = frozenset(
         "academic-article",
     }
 )
+_INVENTORY_PREPARATION_REASON_CODES = frozenset({"PREPARATION_HOLD_ACTIVE", "PREPARATION_IDENTITY_DRIFT"})
 
 
 class ReadinessError(ValueError):
@@ -175,19 +176,34 @@ def _load_json(path: Path) -> dict[str, Any]:
     return value
 
 
-def _validate(document: Mapping[str, Any], schema: Mapping[str, Any], label: str) -> None:
+def _compile_validator(
+    schema: Mapping[str, Any],
+    label: str,
+) -> Draft202012Validator:
     try:
         Draft202012Validator.check_schema(schema)
     except Exception as exc:  # jsonschema exposes multiple schema exception subclasses
         raise ReadinessError(f"invalid JSON schema for {label}: {exc}") from exc
+    return Draft202012Validator(schema)
+
+
+def _validate_with(
+    document: Mapping[str, Any],
+    validator: Draft202012Validator,
+    label: str,
+) -> None:
     errors = sorted(
-        Draft202012Validator(schema).iter_errors(document),
+        validator.iter_errors(document),
         key=lambda error: tuple(str(part) for part in error.path),
     )
     if errors:
         error = errors[0]
         location = ".".join(str(part) for part in error.absolute_path) or "<root>"
         raise ReadinessError(f"{label} failed schema validation at {location}: {error.message}")
+
+
+def _validate(document: Mapping[str, Any], schema: Mapping[str, Any], label: str) -> None:
+    _validate_with(document, _compile_validator(schema, label), label)
 
 
 def _source(role: str, path: Path, repo_root: Path) -> dict[str, Any]:
@@ -941,10 +957,17 @@ def _evaluate_manifest_target(
     files: ContractFiles,
     validators: Mapping[str, Validator],
     consumed_preparation_identity: str | None,
+    contract_sources: Sequence[Mapping[str, Any]] | None = None,
+    result_validator: Draft202012Validator | None = None,
 ) -> dict[str, Any]:
     context = ValidationContext(repo_root, track, slug, manifest_slugs)
     requirements, findings, artifact_sources = _evaluate_requirements(profile, context, validators)
-    sources = [*_contract_sources(files, repo_root), *artifact_sources]
+    base_sources = (
+        [dict(source) for source in contract_sources]
+        if contract_sources is not None
+        else _contract_sources(files, repo_root)
+    )
+    sources = [*base_sources, *artifact_sources]
     manifest_index = manifest_slugs.index(slug)
     preparation_identity = _preparation_identity(
         track=track,
@@ -991,7 +1014,7 @@ def _evaluate_manifest_target(
         preparation_identity=preparation_identity,
         consumed_preparation_identity=consumed_preparation_identity,
     )
-    validate_result(result, repo_root=repo_root)
+    validate_result(result, repo_root=repo_root, validator=result_validator)
     return result
 
 
@@ -1048,9 +1071,162 @@ def evaluate_preparation(
     )
 
 
-def validate_result(result: Mapping[str, Any], *, repo_root: Path = PROJECT_ROOT) -> None:
-    schema = _load_json(_repo_file(repo_root, RESULT_SCHEMA_PATH))
-    _validate(result, schema, "preparation result")
+def validate_result(
+    result: Mapping[str, Any],
+    *,
+    repo_root: Path = PROJECT_ROOT,
+    validator: Draft202012Validator | None = None,
+) -> None:
+    if validator is None:
+        schema = _load_json(_repo_file(repo_root, RESULT_SCHEMA_PATH))
+        _validate(result, schema, "preparation result")
+        return
+    _validate_with(result, validator, "preparation result")
+
+
+def _inventory_missing_row(result: Mapping[str, Any]) -> dict[str, Any] | None:
+    if result["preparation_state"] == "current":
+        return None
+    failed_requirements = [
+        {"id": requirement["id"], "owner": requirement["owner"]}
+        for requirement in result["requirements"]
+        if not requirement["passed"]
+    ]
+    preparation_reason_codes = [
+        finding["id"]
+        for finding in result["findings"]
+        if finding["owner"] == "preparation" and finding["id"] in _INVENTORY_PREPARATION_REASON_CODES
+    ]
+    if not failed_requirements and not preparation_reason_codes:
+        return None
+    return {
+        "track": result["track"],
+        "slug": result["slug"],
+        "profile_id": result["profile_id"],
+        "profile_version": result["profile_version"],
+        "module_state": result["module_state"],
+        "preparation_state": result["preparation_state"],
+        "state": result["state"],
+        "next_action": result["next_action"],
+        "failed_requirements": failed_requirements,
+        "preparation_reason_codes": preparation_reason_codes,
+    }
+
+
+def evaluate_inventory(
+    *,
+    mode: str,
+    track: str | None = None,
+    repo_root: Path = PROJECT_ROOT,
+    validators: Mapping[str, Validator] = VALIDATORS,
+) -> dict[str, Any]:
+    """Evaluate a deterministic compact view over active manifest results."""
+    if mode not in {"summary", "missing-only"}:
+        raise ReadinessError(f"unsupported readiness inventory mode: {mode}")
+    if track is not None:
+        track = track.lower()
+        if not _TARGET_RE.fullmatch(track):
+            raise ReadinessError("track must be a lowercase repository identifier")
+
+    manifest = load_active_manifest(repo_root)
+    selected_tracks = tuple(manifest["tracks"]) if track is None else (track,)
+    if track is not None and track not in manifest["tracks"]:
+        raise ReadinessError(f"curriculum manifest has no active track: {track}")
+    config = load_config(
+        repo_root=repo_root,
+        active_tracks={track_id: str(record["type"]) for track_id, record in manifest["tracks"].items()},
+    )
+    files = _contract_files(repo_root, manifest["path"])
+    contract_sources = _contract_sources(files, repo_root)
+    result_schema = _load_json(_repo_file(repo_root, RESULT_SCHEMA_PATH))
+    result_validator = _compile_validator(result_schema, "preparation result")
+
+    track_counts: dict[str, int] = {}
+    profile_counts: dict[tuple[str, str], int] = {}
+    requirement_counts: dict[tuple[str, str], dict[str, Any]] = {}
+    next_action_counts: dict[str, int] = {}
+    module_state_counts: dict[str, int] = {}
+    missing_rows: list[dict[str, Any]] = []
+    module_count = 0
+
+    for track_id in selected_tracks:
+        manifest_record, manifest_slugs = manifest_track(manifest, track_id)
+        profile_id, profile = _select_profile(config, track_id, str(manifest_record["type"]))
+        profile_version = str(profile["version"])
+        track_counts[track_id] = 0
+        profile_counts.setdefault((profile_id, profile_version), 0)
+        for requirement in profile["requirements"]:
+            requirement_counts.setdefault(
+                (str(requirement["id"]), str(requirement["owner"])),
+                {
+                    "requirement_id": str(requirement["id"]),
+                    "owner": str(requirement["owner"]),
+                    "passed": 0,
+                    "failed": 0,
+                },
+            )
+        for slug in manifest_slugs:
+            result = _evaluate_manifest_target(
+                repo_root=repo_root,
+                track=track_id,
+                slug=slug,
+                profile_id=profile_id,
+                profile=profile,
+                manifest_slugs=manifest_slugs,
+                files=files,
+                validators=validators,
+                consumed_preparation_identity=None,
+                contract_sources=contract_sources,
+                result_validator=result_validator,
+            )
+            module_count += 1
+            track_counts[track_id] += 1
+            profile_counts[(profile_id, profile_version)] += 1
+            next_action = str(result["next_action"])
+            next_action_counts[next_action] = next_action_counts.get(next_action, 0) + 1
+            module_state = str(result["module_state"])
+            module_state_counts[module_state] = module_state_counts.get(module_state, 0) + 1
+            for requirement in result["requirements"]:
+                key = (str(requirement["id"]), str(requirement["owner"]))
+                counts = requirement_counts[key]
+                outcome = "passed" if requirement["passed"] else "failed"
+                counts[outcome] += 1
+            if mode == "missing-only":
+                row = _inventory_missing_row(result)
+                if row is not None:
+                    missing_rows.append(row)
+
+    scope = {"all": True} if track is None else {"track": track}
+    if mode == "missing-only":
+        return {
+            "mode": mode,
+            "scope": scope,
+            "candidate_count": len(missing_rows),
+            "rows": missing_rows,
+        }
+    return {
+        "mode": mode,
+        "scope": scope,
+        "module_count": module_count,
+        "counts": {
+            "track": [{"track": track_id, "count": count} for track_id, count in track_counts.items()],
+            "profile": [
+                {
+                    "profile_id": profile_id,
+                    "profile_version": profile_version,
+                    "count": count,
+                }
+                for (profile_id, profile_version), count in profile_counts.items()
+            ],
+            "requirement": list(requirement_counts.values()),
+            "next_action": [
+                {"next_action": next_action, "count": count} for next_action, count in next_action_counts.items()
+            ],
+            "module_state": [
+                {"module_state": module_state, "count": count} for module_state, count in module_state_counts.items()
+            ],
+        },
+    }
 
 
 def dependent_evidence_identity(
@@ -1075,24 +1251,52 @@ def dependent_evidence_identity(
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--track", required=True)
-    parser.add_argument("--slug", required=True)
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--all", dest="all_tracks", action="store_true")
+    scope.add_argument("--track")
+    inventory_mode = parser.add_mutually_exclusive_group()
+    inventory_mode.add_argument("--summary", action="store_true")
+    inventory_mode.add_argument("--missing-only", action="store_true")
+    parser.add_argument("--slug")
     parser.add_argument("--consumed-preparation-identity")
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    inventory_mode = "summary" if args.summary else "missing-only" if args.missing_only else None
+    if args.all_tracks:
+        if inventory_mode is None:
+            parser.error("--all requires exactly one of --summary or --missing-only")
+        if args.slug is not None or args.consumed_preparation_identity is not None:
+            parser.error("--all inventory cannot be combined with target-only arguments")
+    elif args.slug is None and inventory_mode is None:
+        parser.error("--track requires --slug, --summary, or --missing-only")
+    elif args.slug is not None and inventory_mode is not None:
+        parser.error("--slug cannot be combined with an inventory mode")
+    elif args.slug is None and args.consumed_preparation_identity is not None:
+        parser.error("--consumed-preparation-identity requires --slug")
+
     try:
-        result = evaluate_preparation(
-            args.track,
-            args.slug,
-            consumed_preparation_identity=args.consumed_preparation_identity,
-        )
+        if inventory_mode is not None:
+            result = evaluate_inventory(
+                mode=inventory_mode,
+                track=None if args.all_tracks else args.track,
+            )
+        else:
+            result = evaluate_preparation(
+                args.track,
+                args.slug,
+                consumed_preparation_identity=args.consumed_preparation_identity,
+            )
     except (ReadinessError, RegistryValidationError, OSError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    if inventory_mode is not None:
+        print(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
+    else:
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
     return 0
 
 

--- a/tests/orchestration/test_curriculum_readiness.py
+++ b/tests/orchestration/test_curriculum_readiness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 from collections.abc import Mapping
 from pathlib import Path
@@ -122,6 +123,75 @@ def _write_manifest(repo_root: Path, track: str, manifest_type: str, slug: str) 
     readiness_path.write_text(yaml.safe_dump(readiness_config, sort_keys=False), encoding="utf-8")
 
 
+def _inventory_fixture(tmp_path: Path) -> tuple[Path, dict[str, dict]]:
+    repo_root = tmp_path / "repo"
+    _copy_contracts(repo_root)
+    levels = {
+        "bio": {
+            "type": "track",
+            "modules": ["bio-missing", "bio-current", "bio-drift", "bio-hold"],
+        },
+        "a1": {"type": "core", "modules": ["a1-audit", "a1-plan"]},
+    }
+    manifest_path = repo_root / readiness.MANIFEST_PATH
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        yaml.safe_dump({"version": "1.0", "levels": levels}, sort_keys=False),
+        encoding="utf-8",
+    )
+    for relative in (
+        readiness.CONFIG_PATH,
+        Path("agents_extensions/shared/prompt-contracts/profiles/curriculum-lifecycle.v1.yaml"),
+    ):
+        config_path = repo_root / relative
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        config["selectors"]["tracks"] = {
+            track: profile for track, profile in config["selectors"]["tracks"].items() if track in levels
+        }
+        config["selectors"]["manifest_types"] = {
+            manifest_type: profile
+            for manifest_type, profile in config["selectors"]["manifest_types"].items()
+            if manifest_type in {level["type"] for level in levels.values()}
+        }
+        config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return repo_root, levels
+
+
+def _fake_inventory_result(
+    *,
+    track: str,
+    slug: str,
+    profile_id: str,
+    profile: Mapping,
+    failed: set[str] | None = None,
+    module_state: str = "unbuilt",
+    preparation_state: str = "missing",
+    state: str = "preparation-required",
+    next_action: str = "prepare",
+    findings: list[dict] | None = None,
+) -> dict:
+    failed = failed or set()
+    return {
+        "track": track,
+        "slug": slug,
+        "profile_id": profile_id,
+        "profile_version": str(profile["version"]),
+        "module_state": module_state,
+        "preparation_state": preparation_state,
+        "state": state,
+        "next_action": next_action,
+        "requirements": [
+            {
+                "id": requirement["id"],
+                "owner": requirement["owner"],
+                "passed": requirement["id"] not in failed,
+            }
+            for requirement in profile["requirements"]
+        ],
+        "findings": findings or [],
+    }
+
+
 def _create_bundle(repo_root: Path, track: str, slug: str) -> None:
     directory = repo_root / "curriculum" / "l2-uk-en" / track / slug
     directory.mkdir(parents=True, exist_ok=True)
@@ -235,6 +305,380 @@ def test_all_active_tracks_resolve_readiness_certification_and_prompt_profiles()
     assert certification_profiles["bio"] == "bio-pending"
     assert semantic_profiles["a1"] == "core-a1"
     assert semantic_profiles["folk"] == "seminar-folk"
+
+
+def test_all_manifest_inventory_resolves_tracks_once_in_manifest_order(monkeypatch) -> None:
+    manifest = readiness.load_active_manifest(REPO_ROOT)
+    expected_targets = [(track, slug) for track, record in manifest["tracks"].items() for slug in record["modules"]]
+    profile_tracks: list[str] = []
+    seen: list[tuple[str, str]] = []
+    original_select_profile = readiness._select_profile
+
+    def select_profile(config: Mapping, track: str, manifest_type: str):
+        profile_tracks.append(track)
+        return original_select_profile(config, track, manifest_type)
+
+    def evaluate(**kwargs):
+        seen.append((kwargs["track"], kwargs["slug"]))
+        return _fake_inventory_result(
+            track=kwargs["track"],
+            slug=kwargs["slug"],
+            profile_id=kwargs["profile_id"],
+            profile=kwargs["profile"],
+            preparation_state="current",
+            state="prepared-plan",
+            next_action="build",
+        )
+
+    monkeypatch.setattr(readiness, "_select_profile", select_profile)
+    monkeypatch.setattr(readiness, "_evaluate_manifest_target", evaluate)
+
+    summary = readiness.evaluate_inventory(mode="summary", repo_root=REPO_ROOT)
+
+    assert profile_tracks == list(manifest["tracks"])
+    assert seen == expected_targets
+    assert summary["module_count"] == len(expected_targets) == 1932
+    assert summary["counts"]["track"] == [
+        {"track": track, "count": len(record["modules"])} for track, record in manifest["tracks"].items()
+    ]
+
+
+def test_single_target_cli_json_remains_byte_and_shape_compatible(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    expected = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+
+    def evaluate(track: str, slug: str, *, consumed_preparation_identity=None):
+        assert (track, slug, consumed_preparation_identity) == ("bio", BIO_SLUG, None)
+        return expected
+
+    monkeypatch.setattr(readiness, "evaluate_preparation", evaluate)
+
+    assert readiness.main(["--track", "bio", "--slug", BIO_SLUG]) == 0
+    output = capsys.readouterr().out
+
+    assert output == json.dumps(expected, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    assert json.loads(output) == expected
+    readiness.validate_result(expected, repo_root=repo_root)
+
+
+def test_inventory_summary_counts_every_required_dimension(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root, _levels = _inventory_fixture(tmp_path)
+    specs = {
+        ("bio", "bio-missing"): {
+            "failed": {"dossier"},
+            "findings": [
+                {
+                    "id": "PREPARATION_DOSSIER",
+                    "owner": "preparation",
+                }
+            ],
+        },
+        ("bio", "bio-current"): {
+            "preparation_state": "current",
+            "state": "prepared-plan",
+            "next_action": "build",
+        },
+        ("bio", "bio-drift"): {
+            "module_state": "built",
+            "preparation_state": "stale",
+            "state": "built-preparation-drift",
+            "findings": [
+                {
+                    "id": "PREPARATION_IDENTITY_DRIFT",
+                    "owner": "preparation",
+                }
+            ],
+        },
+        ("bio", "bio-hold"): {
+            "state": "preparation-required",
+            "next_action": "stop",
+            "findings": [
+                {
+                    "id": "PREPARATION_HOLD_ACTIVE",
+                    "owner": "preparation",
+                }
+            ],
+        },
+        ("a1", "a1-audit"): {
+            "module_state": "built",
+            "preparation_state": "stale",
+            "state": "built-preparation-drift",
+            "findings": [
+                {
+                    "id": "PREPARATION_IDENTITY_MISSING",
+                    "owner": "audit_tooling",
+                }
+            ],
+        },
+        ("a1", "a1-plan"): {
+            "failed": {"plan"},
+            "state": "missing-plan",
+            "next_action": "plan",
+            "findings": [{"id": "PREPARATION_PLAN", "owner": "plan"}],
+        },
+    }
+    seen: list[tuple[str, str]] = []
+
+    def evaluate(**kwargs):
+        key = (kwargs["track"], kwargs["slug"])
+        seen.append(key)
+        return _fake_inventory_result(
+            track=kwargs["track"],
+            slug=kwargs["slug"],
+            profile_id=kwargs["profile_id"],
+            profile=kwargs["profile"],
+            **specs[key],
+        )
+
+    monkeypatch.setattr(readiness, "_evaluate_manifest_target", evaluate)
+
+    summary = readiness.evaluate_inventory(mode="summary", repo_root=repo_root)
+
+    assert seen == [
+        ("bio", "bio-missing"),
+        ("bio", "bio-current"),
+        ("bio", "bio-drift"),
+        ("bio", "bio-hold"),
+        ("a1", "a1-audit"),
+        ("a1", "a1-plan"),
+    ]
+    assert summary["module_count"] == 6
+    assert summary["counts"]["track"] == [
+        {"track": "bio", "count": 4},
+        {"track": "a1", "count": 2},
+    ]
+    assert summary["counts"]["profile"] == [
+        {"profile_id": "bio", "profile_version": "1.1.0", "count": 4},
+        {"profile_id": "core", "profile_version": "1.1.0", "count": 2},
+    ]
+    requirements = {
+        (item["requirement_id"], item["owner"]): (item["passed"], item["failed"])
+        for item in summary["counts"]["requirement"]
+    }
+    assert requirements[("dossier", "preparation")] == (3, 1)
+    assert requirements[("plan", "plan")] == (5, 1)
+    assert requirements[("research-evidence", "preparation")] == (2, 0)
+    assert summary["counts"]["next_action"] == [
+        {"next_action": "prepare", "count": 3},
+        {"next_action": "build", "count": 1},
+        {"next_action": "stop", "count": 1},
+        {"next_action": "plan", "count": 1},
+    ]
+    assert summary["counts"]["module_state"] == [
+        {"module_state": "unbuilt", "count": 4},
+        {"module_state": "built", "count": 2},
+    ]
+
+
+def test_missing_only_is_manifest_ordered_and_preparation_safe(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root, _levels = _inventory_fixture(tmp_path)
+    specs = {
+        ("bio", "bio-missing"): {
+            "failed": {"dossier"},
+            "findings": [{"id": "PREPARATION_DOSSIER", "owner": "preparation"}],
+        },
+        ("bio", "bio-current"): {
+            "preparation_state": "current",
+            "state": "prepared-plan",
+            "next_action": "build",
+        },
+        ("bio", "bio-drift"): {
+            "module_state": "built",
+            "preparation_state": "stale",
+            "state": "built-preparation-drift",
+            "findings": [{"id": "PREPARATION_IDENTITY_DRIFT", "owner": "preparation"}],
+        },
+        ("bio", "bio-hold"): {
+            "next_action": "stop",
+            "findings": [{"id": "PREPARATION_HOLD_ACTIVE", "owner": "preparation"}],
+        },
+        ("a1", "a1-audit"): {
+            "module_state": "built",
+            "preparation_state": "stale",
+            "state": "built-preparation-drift",
+            "findings": [{"id": "PREPARATION_IDENTITY_MISSING", "owner": "audit_tooling"}],
+        },
+        ("a1", "a1-plan"): {
+            "failed": {"plan"},
+            "state": "missing-plan",
+            "next_action": "plan",
+            "findings": [{"id": "PREPARATION_PLAN", "owner": "plan"}],
+        },
+    }
+
+    def evaluate(**kwargs):
+        return _fake_inventory_result(
+            track=kwargs["track"],
+            slug=kwargs["slug"],
+            profile_id=kwargs["profile_id"],
+            profile=kwargs["profile"],
+            **specs[(kwargs["track"], kwargs["slug"])],
+        )
+
+    monkeypatch.setattr(readiness, "_evaluate_manifest_target", evaluate)
+
+    inventory = readiness.evaluate_inventory(mode="missing-only", repo_root=repo_root)
+
+    assert inventory["candidate_count"] == 4
+    assert [(row["track"], row["slug"]) for row in inventory["rows"]] == [
+        ("bio", "bio-missing"),
+        ("bio", "bio-drift"),
+        ("bio", "bio-hold"),
+        ("a1", "a1-plan"),
+    ]
+    rows = {row["slug"]: row for row in inventory["rows"]}
+    assert rows["bio-missing"]["failed_requirements"] == [{"id": "dossier", "owner": "preparation"}]
+    assert rows["bio-drift"]["preparation_reason_codes"] == ["PREPARATION_IDENTITY_DRIFT"]
+    assert rows["bio-hold"]["preparation_reason_codes"] == ["PREPARATION_HOLD_ACTIVE"]
+    assert rows["a1-plan"]["failed_requirements"] == [{"id": "plan", "owner": "plan"}]
+    assert "bio-current" not in rows
+    assert "a1-audit" not in rows
+
+
+def test_one_track_inventory_never_scans_another_track(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root, levels = _inventory_fixture(tmp_path)
+    seen: list[tuple[str, str]] = []
+
+    def evaluate(**kwargs):
+        seen.append((kwargs["track"], kwargs["slug"]))
+        return _fake_inventory_result(
+            track=kwargs["track"],
+            slug=kwargs["slug"],
+            profile_id=kwargs["profile_id"],
+            profile=kwargs["profile"],
+            failed={"dossier"},
+        )
+
+    monkeypatch.setattr(readiness, "_evaluate_manifest_target", evaluate)
+
+    result = readiness.evaluate_inventory(
+        mode="missing-only",
+        track="bio",
+        repo_root=repo_root,
+    )
+
+    assert seen == [("bio", slug) for slug in levels["bio"]["modules"]]
+    assert {row["track"] for row in result["rows"]} == {"bio"}
+
+
+def test_inventory_loads_global_contracts_once_and_never_writes_repository(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root, _levels = _inventory_fixture(tmp_path)
+    calls = {"manifest": 0, "config": 0, "contract_sources": 0}
+    json_paths: list[Path] = []
+    profile_tracks: list[str] = []
+    original_manifest = readiness.load_active_manifest
+    original_config = readiness.load_config
+    original_contract_sources = readiness._contract_sources
+    original_load_json = readiness._load_json
+    original_select_profile = readiness._select_profile
+
+    def load_manifest(*args, **kwargs):
+        calls["manifest"] += 1
+        return original_manifest(*args, **kwargs)
+
+    def load_config(*args, **kwargs):
+        calls["config"] += 1
+        return original_config(*args, **kwargs)
+
+    def contract_sources(*args, **kwargs):
+        calls["contract_sources"] += 1
+        return original_contract_sources(*args, **kwargs)
+
+    def load_json(path: Path):
+        json_paths.append(path)
+        return original_load_json(path)
+
+    def select_profile(config: Mapping, track: str, manifest_type: str):
+        profile_tracks.append(track)
+        return original_select_profile(config, track, manifest_type)
+
+    monkeypatch.setattr(readiness, "load_active_manifest", load_manifest)
+    monkeypatch.setattr(readiness, "load_config", load_config)
+    monkeypatch.setattr(readiness, "_contract_sources", contract_sources)
+    monkeypatch.setattr(readiness, "_load_json", load_json)
+    monkeypatch.setattr(readiness, "_select_profile", select_profile)
+    passing_validators = {
+        validator_id: lambda _path, _option, _context: readiness.ValidationResult(True, "fixture")
+        for validator_id in readiness.VALIDATORS
+    }
+    before = {path.relative_to(repo_root): path.read_bytes() for path in repo_root.rglob("*") if path.is_file()}
+
+    summary = readiness.evaluate_inventory(
+        mode="summary",
+        repo_root=repo_root,
+        validators=passing_validators,
+    )
+
+    after = {path.relative_to(repo_root): path.read_bytes() for path in repo_root.rglob("*") if path.is_file()}
+    assert summary["module_count"] == 6
+    assert calls == {"manifest": 1, "config": 1, "contract_sources": 1}
+    assert profile_tracks == ["bio", "a1"]
+    assert json_paths.count(repo_root / readiness.CONFIG_SCHEMA_PATH) == 1
+    assert json_paths.count(repo_root / readiness.RESULT_SCHEMA_PATH) == 1
+    assert after == before
+
+
+def test_inventory_invalid_inputs_and_cli_combinations_fail_closed(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo_root, _levels = _inventory_fixture(tmp_path)
+    with pytest.raises(readiness.ReadinessError, match="no active track"):
+        readiness.evaluate_inventory(
+            mode="summary",
+            track="not-active",
+            repo_root=repo_root,
+        )
+
+    config_path = repo_root / readiness.CONFIG_PATH
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["selectors"]["tracks"]["bio"] = "missing-profile"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    with pytest.raises(readiness.ReadinessError, match="unknown profile"):
+        readiness.evaluate_inventory(mode="summary", repo_root=repo_root)
+
+    def evaluation_error(**_kwargs):
+        raise readiness.ReadinessError("fixture evaluation failure")
+
+    monkeypatch.setattr(readiness, "evaluate_inventory", evaluation_error)
+    assert readiness.main(["--all", "--summary"]) == 2
+    assert "fixture evaluation failure" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--all"],
+        ["--all", "--summary", "--slug", "demo"],
+        ["--track", "bio"],
+        ["--track", "bio", "--slug", "demo", "--summary"],
+        ["--track", "bio", "--summary", "--consumed-preparation-identity", "a" * 64],
+        ["--track", "bio", "--summary", "--missing-only"],
+        ["--all", "--track", "bio", "--summary"],
+    ],
+)
+def test_inventory_selector_contradictions_exit_two(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        readiness.main(argv)
+
+    assert exc_info.value.code == 2
 
 
 def test_prepared_unbuilt_bio_uses_real_validators_and_exact_sources(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add compact deterministic readiness inventory views over the canonical evaluator
- preserve the existing single-target command and typed JSON byte shape unchanged
- load the active manifest, readiness profile config, result schema validator, and contract-source snapshot once per inventory run
- exclude current cells and audit-tooling-only `PREPARATION_IDENTITY_MISSING` from preparation candidates while retaining exact preparation drift/hold reason codes

## CLI contract

```text
--all --summary
--track TRACK --summary
--all --missing-only
--track TRACK --missing-only
```

Single-target use remains:

```text
--track TRACK --slug SLUG [--consumed-preparation-identity SHA256]
```

Illegal combinations, unknown/inactive tracks, invalid profile configuration, and evaluation failures exit 2 without partial inventory output.

## Changes

- `scripts/orchestration/curriculum_readiness.py`
  - reuse `_evaluate_manifest_target` for manifest-ordered inventory evaluation
  - emit summary counts by track, profile id/version, requirement pass/fail + owner, next action, and module state
  - emit compact missing-only rows with exact target/profile/state fields, failed requirement IDs + owners, and preparation-owned drift/hold codes
  - compile and reuse the preparation-result validator and contract sources across the run
- `tests/orchestration/test_curriculum_readiness.py`
  - cover all 20 active tracks / 1,932 manifest targets in manifest order
  - cover all summary dimensions, missing-only safety, one-track isolation, invalid selectors/config, no repository writes, and once-only global loading
  - prove single-target JSON serialization remains byte/shape compatible

## Testing

- [x] `.venv/bin/python -m pytest tests/orchestration/test_curriculum_readiness.py tests/test_preparation_api.py -q` — 57 passed
- [x] `.venv/bin/ruff check scripts/orchestration/curriculum_readiness.py tests/orchestration/test_curriculum_readiness.py`
- [x] `.venv/bin/python -m py_compile scripts/orchestration/curriculum_readiness.py tests/orchestration/test_curriculum_readiness.py tests/test_preparation_api.py`
- [x] `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- [x] `git diff --check origin/main..HEAD`
- [x] protected/generated-artifact fences empty; exactly 2 changed files
- [x] real `--track bio --summary` — 410 targets
- [x] real `--track bio --missing-only` — 410 deterministic candidates, first `knyahynia-olha`, last `marusia-churai`
- [x] pre/post single-target SHA-256 identical: `687fbeebf6d7df9885bd5988264878c735b179ac09a33c418c45369cd71dca7c`
- [ ] learner module audit/build/Ukrainian review — not applicable; this PR changes orchestration code only and the issue explicitly excludes learner builds

## Related issues

Fixes #5470

Parent stream epic: #4431
