### PR TITLE
feat(daily): publish source-backed sentence inventory

### DIFF
--- a/docs/practice/daily-sentence-inventory.md
+++ b/docs/practice/daily-sentence-inventory.md
@@ -1,0 +1,29 @@
+# Daily sentence inventory
+
+`site/src/data/lexicon-sentence-inventory.json` is the source-attested example
+layer for Daily Word. It is deliberately a sibling of
+`lexicon-practice-cloze-sources.json`: a daily example only needs a lemma-linked
+sentence, while a cloze row additionally needs a verified blank form, case rule,
+and distractor contract.
+
+Regenerate it from the current daily pool with:
+
+```bash
+.venv/bin/python -m scripts.audit.generate_sentence_inventory \
+  --daily-pool site/src/data/lexicon-daily-pool.json \
+  --sources-db data/sources.db \
+  --vesum-db data/vesum.db
+```
+
+The extractor searches textbook FTS for an exact daily-lemma surface, accepts
+only short sentence-shaped matches with a VESUM-attested verb, and records the
+source label, locator, and licence status for every row. The default inventory
+uses textbook matches. `--include-ulp` may add ULP fallback rows, but its
+provenance is intentionally only the safe source-family label — never a local
+file, transcript id, URL, or private locator.
+
+The daily generator overlays this inventory after its existing entry-enrichment
+example lookup and preserves `exampleProvenance` and `exampleLicense` in the
+published daily-pool row. The licence field records source status and use basis;
+it is not an assertion that a source is open-licensed. A future cloze reuse must
+separately select and VESUM-check its target inflected form.

--- a/scripts/audit/generate_daily_pool.py
+++ b/scripts/audit/generate_daily_pool.py
@@ -35,6 +35,7 @@ from scripts.audit.lexeme_filter import (
 
 DEFAULT_MANIFEST = Path("site/src/data/lexicon-manifest.json")
 DEFAULT_OUT = Path("site/src/data/lexicon-daily-pool.json")
+DEFAULT_SENTENCE_INVENTORY = Path("site/src/data/lexicon-sentence-inventory.json")
 EARLY_CEFR = {"A1", "A2", "B1"}
 # Derived-form + surzhyk source tags live in scripts.audit.lexeme_filter (single source
 # of truth, shared with the search index, word-page routes, and the practice deck).
@@ -143,7 +144,34 @@ def _first_example(entry: dict[str, Any]) -> tuple[str | None, str | None]:
     return (None, None)
 
 
-def _pool_item(entry: dict[str, Any]) -> dict[str, Any] | None:
+def load_sentence_inventory(path: Path | None) -> dict[str, dict[str, Any]]:
+    """Load the public, provenance-bearing sentence inventory by lemma.
+
+    This is intentionally a sibling artifact rather than a cloze-source entry:
+    daily examples have no blanked form or case-rule contract.
+    """
+    if path is None or not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    rows = payload.get("rows", []) if isinstance(payload, dict) else []
+    if not isinstance(rows, list):
+        raise ValueError("sentence inventory rows must be a list")
+    inventory: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        lemma = row.get("lemma")
+        sentence = row.get("sentence")
+        provenance = row.get("provenance")
+        license_info = row.get("license")
+        if _has_text(lemma) and _has_text(sentence) and isinstance(provenance, dict) and isinstance(license_info, dict):
+            inventory[str(lemma)] = row
+    return inventory
+
+
+def _pool_item(
+    entry: dict[str, Any], sentence_inventory: dict[str, dict[str, Any]] | None = None
+) -> dict[str, Any] | None:
     lemma = entry.get("lemma")
     slug = entry.get("url_slug")
     if not _has_text(lemma) or not _has_text(slug):
@@ -164,14 +192,22 @@ def _pool_item(entry: dict[str, Any]) -> dict[str, Any] | None:
     if cefr is not None:
         item["cefr"] = cefr
     example, example_en = _first_example(entry)
+    inventory_row = (sentence_inventory or {}).get(str(lemma))
+    if inventory_row is not None:
+        example = str(inventory_row["sentence"]).strip()
     if example is not None:
         item["example"] = example
     if example_en is not None:
         item["exampleEn"] = example_en
+    if inventory_row is not None:
+        item["exampleProvenance"] = inventory_row["provenance"]
+        item["exampleLicense"] = inventory_row["license"]
     return item
 
 
-def build_pool(entries: list[dict[str, Any]], size: int = 300) -> list[dict[str, Any]]:
+def build_pool(
+    entries: list[dict[str, Any]], size: int = 300, sentence_inventory: dict[str, dict[str, Any]] | None = None
+) -> list[dict[str, Any]]:
     """Build the daily pool and return lemma-sorted JSON rows.
 
     Selection is deterministic but *representative*: within a weight tier we order by a
@@ -188,7 +224,7 @@ def build_pool(entries: list[dict[str, Any]], size: int = 300) -> list[dict[str,
     rest.sort(key=lambda e: (-compute_weight(e), _stable_hash(e["lemma"])))
 
     ordered = surzhyk + rest
-    selected = [item for entry in ordered[:size] if (item := _pool_item(entry)) is not None]
+    selected = [item for entry in ordered[:size] if (item := _pool_item(entry, sentence_inventory)) is not None]
     return sorted(selected, key=lambda item: item["lemma"])
 
 
@@ -237,6 +273,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Build the daily pool from atlas.db (entry-model SSOT) instead of the legacy manifest.",
     )
     parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--sentence-inventory", type=Path, default=DEFAULT_SENTENCE_INVENTORY)
     parser.add_argument("--size", type=int, default=300)
     args = parser.parse_args(argv)
 
@@ -247,7 +284,7 @@ def main(argv: list[str] | None = None) -> int:
         entries = manifest.get("entries", [])
         if not isinstance(entries, list):
             raise ValueError("manifest entries must be a list")
-    pool = build_pool(entries, args.size)
+    pool = build_pool(entries, args.size, load_sentence_inventory(args.sentence_inventory))
     write_pool(pool, args.out)
     return 0
 

--- a/scripts/audit/generate_sentence_inventory.py
+++ b/scripts/audit/generate_sentence_inventory.py
@@ -1,0 +1,266 @@
+"""Extract short, source-attested examples for the Word Atlas daily pool.
+
+The committed inventory contains only learner-facing sentences plus an
+attribution-safe provenance record.  It intentionally never copies a local
+ULP filename, transcript identifier, URL, or any other private locator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DAILY_POOL = Path("site/src/data/lexicon-daily-pool.json")
+DEFAULT_SOURCES_DB = Path("data/sources.db")
+DEFAULT_VESUM_DB = Path("data/vesum.db")
+DEFAULT_OUT = Path("site/src/data/lexicon-sentence-inventory.json")
+
+UK_TOKEN_RE = re.compile(r"[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]+(?:[ʼ'’-][А-ЩЬЮЯЄІЇҐа-щьюяєіїґ]+)*")
+SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+SPACE_RE = re.compile(r"\s+")
+
+TEXTBOOK_LICENSE = {
+    "status": "not_openly_licensed",
+    "useBasis": "short educational quotation with attribution",
+}
+ULP_LICENSE = {
+    "status": "copyrighted_source",
+    "useBasis": "short educational quotation with attribution",
+}
+
+
+def _text(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _normalise(text: str) -> str:
+    # OCR frequently breaks a word at the end of a visual line (``до-\nпомогу``).
+    text = re.sub(r"(?<=[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ])-\s+(?=[А-ЩЬЮЯЄІЇҐа-щьюяєіїґ])", "", text)
+    return SPACE_RE.sub(" ", text).strip()
+
+
+def _tokens(text: str) -> list[str]:
+    return UK_TOKEN_RE.findall(text)
+
+
+def _exact_target_present(sentence: str, lemma: str) -> bool:
+    target = lemma.casefold()
+    return any(token.casefold() == target for token in _tokens(sentence))
+
+
+class VesumSentenceVerifier:
+    """Small cached VESUM lookup used only for sentence-shape screening."""
+
+    def __init__(self, path: Path) -> None:
+        self.conn = sqlite3.connect(path)
+        self.cache: dict[str, bool] = {}
+
+    def has_verb(self, tokens: Iterable[str]) -> bool:
+        for token in tokens:
+            key = token.casefold()
+            known = self.cache.get(key)
+            if known is None:
+                known = (
+                    self.conn.execute(
+                        "SELECT 1 FROM forms WHERE word_form IN (?, ?) AND pos = 'verb' LIMIT 1",
+                        (token, key),
+                    ).fetchone()
+                    is not None
+                )
+                self.cache[key] = known
+            if known:
+                return True
+        return False
+
+    def close(self) -> None:
+        self.conn.close()
+
+
+def _candidate_sentences(text: str, lemma: str, *, vesum: VesumSentenceVerifier | None = None) -> Iterable[str]:
+    """Yield readable, short sentences containing the exact daily lemma.
+
+    We deliberately require the surface to equal the daily lemma.  This keeps
+    the initial inventory lemma-linked without making unverified morphology
+    claims; a later cloze workflow can VESUM-check a separately selected form.
+    """
+    for raw_sentence in SENTENCE_SPLIT_RE.split(_normalise(text)):
+        sentence = raw_sentence.strip(" \t\n—–")
+        tokens = _tokens(sentence)
+        if not (3 <= len(tokens) <= 18 and 15 <= len(sentence) <= 180):
+            continue
+        if sentence.isupper() or not sentence.endswith((".", "!", "?")):
+            continue
+        if not _exact_target_present(sentence, lemma):
+            continue
+        # OCR headings, web addresses, and mixed-language transcript noise are
+        # poor daily-practice examples even when the FTS match is exact.
+        if "http" in sentence.casefold() or sentence.count("*") > 1:
+            continue
+        if vesum is not None and not vesum.has_verb(tokens):
+            continue
+        yield sentence
+
+
+def _fts_rows(
+    conn: sqlite3.Connection,
+    *,
+    fts_table: str,
+    content_table: str,
+    lemma: str,
+    where_sql: str = "",
+) -> Iterable[sqlite3.Row]:
+    query = f'"{lemma.replace(chr(34), "")}"'
+    sql = f"""
+        SELECT source.text, source.title, source.chunk_id
+        FROM {fts_table} AS fts
+        JOIN {content_table} AS source ON source.id = fts.rowid
+        WHERE {fts_table} MATCH ? {where_sql}
+        ORDER BY bm25({fts_table})
+        LIMIT 20
+    """
+    yield from conn.execute(sql, (query,))
+
+
+def _first_source_sentence(
+    conn: sqlite3.Connection,
+    *,
+    target: dict[str, str],
+    source_kind: str,
+    vesum: VesumSentenceVerifier | None = None,
+) -> dict[str, Any] | None:
+    lemma = target["lemma"]
+    if source_kind == "textbook":
+        rows = _fts_rows(
+            conn,
+            fts_table="textbooks_fts",
+            content_table="textbooks",
+            lemma=lemma,
+        )
+        source_label = "Ukrainian school textbook"
+        license_info = TEXTBOOK_LICENSE
+    else:
+        rows = _fts_rows(
+            conn,
+            fts_table="external_fts",
+            content_table="external_articles",
+            lemma=lemma,
+            where_sql="AND source.source_file = 'ulp_youtube'",
+        )
+        # No local identifier is committed for this source family.
+        source_label = "Ukrainian Lessons Podcast"
+        license_info = ULP_LICENSE
+
+    for row in rows:
+        text = _text(row["text"])
+        if text is None:
+            continue
+        for sentence in _candidate_sentences(text, lemma, vesum=vesum):
+            provenance: dict[str, Any] = {
+                "source": source_kind,
+                "label": source_label,
+            }
+            if source_kind == "textbook":
+                # This is a public textbook chunk identifier, sufficient for
+                # attribution while keeping the inventory independent of DB ids.
+                provenance["locator"] = _text(row["chunk_id"])
+                provenance["title"] = _text(row["title"])
+            return {
+                "lemma": lemma,
+                "lemmaId": target["lemmaId"],
+                "sentence": sentence,
+                "targetForm": lemma,
+                "cefr": target.get("cefr"),
+                "uses": ["example"],
+                "provenance": provenance,
+                "license": dict(license_info),
+            }
+    return None
+
+
+def load_daily_lemmas(path: Path) -> list[str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("daily pool must be a JSON list")
+    lemmas = {_text(row.get("lemma")) for row in payload if isinstance(row, dict)}
+    return sorted(lemma for lemma in lemmas if lemma is not None)
+
+
+def load_daily_targets(path: Path) -> list[dict[str, str]]:
+    """Load daily lemma ids and CEFR labels without relying on a manifest checkout."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("daily pool must be a JSON list")
+    targets: dict[str, dict[str, str]] = {}
+    for row in payload:
+        if not isinstance(row, dict):
+            continue
+        lemma = _text(row.get("lemma"))
+        lemma_id = _text(row.get("slug"))
+        if lemma is None or lemma_id is None:
+            continue
+        target = {"lemma": lemma, "lemmaId": lemma_id}
+        cefr = _text(row.get("cefr"))
+        if cefr is not None:
+            target["cefr"] = cefr
+        targets[lemma] = target
+    return [targets[lemma] for lemma in sorted(targets)]
+
+
+def build_inventory(
+    targets: Iterable[dict[str, str]],
+    sources_db: Path,
+    *,
+    include_ulp: bool = False,
+    vesum_db: Path | None = None,
+) -> list[dict[str, Any]]:
+    conn = sqlite3.connect(sources_db)
+    conn.row_factory = sqlite3.Row
+    vesum = VesumSentenceVerifier(vesum_db) if vesum_db is not None and vesum_db.exists() else None
+    try:
+        rows: list[dict[str, Any]] = []
+        for target in sorted(targets, key=lambda row: row["lemma"]):
+            row = _first_source_sentence(conn, target=target, source_kind="textbook", vesum=vesum)
+            if row is None and include_ulp:
+                row = _first_source_sentence(conn, target=target, source_kind="ulp", vesum=vesum)
+            if row is not None:
+                rows.append(row)
+        return rows
+    finally:
+        conn.close()
+        if vesum is not None:
+            vesum.close()
+
+
+def write_inventory(rows: list[dict[str, Any]], out_path: Path) -> None:
+    payload = {
+        "schema": "atlas-sentence-inventory",
+        "schemaVersion": 1,
+        "rows": rows,
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--daily-pool", type=Path, default=DEFAULT_DAILY_POOL)
+    parser.add_argument("--sources-db", type=Path, default=DEFAULT_SOURCES_DB)
+    parser.add_argument("--vesum-db", type=Path, default=DEFAULT_VESUM_DB)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--include-ulp", action="store_true")
+    args = parser.parse_args(argv)
+    rows = build_inventory(
+        load_daily_targets(args.daily_pool), args.sources_db, include_ulp=args.include_ulp, vesum_db=args.vesum_db
+    )
+    write_inventory(rows, args.out)
+    print(f"sentence inventory: {len(rows)} rows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-daily-pool.json
+++ b/site/src/data/lexicon-daily-pool.json
@@ -6,7 +6,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Хмельницький був обраний для сюжету ікони «Покрова Богородиці»?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-istoria-ukr-galimov-2025_s0366",
+      "title": "Сторінка 225"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "США",
@@ -15,7 +26,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "США надають політичну підтримку та матеріально-технічну допомогу Україні у протистоянні російській агресії.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-geografija-bojko-2018_s0367",
+      "title": "Сторінка 200"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "Хрещатик",
@@ -24,7 +46,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Боно та Едж з U-2 виступають у київському метро на станції «Хрещатик».",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-istoriya-ukr-gisem-2024_s0514",
+      "title": "Сторінка 296"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "Як справи?",
@@ -42,7 +75,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Адміністратор: Сало́н краси́ «Верса́ль».",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-2-00-lesson-notes_l0068_w003",
+      "title": "Lesson 68: Запис до перукарні Дати та місцевий відмінок Making a hair appointment Dates & Locative case (part 3/11)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "аналогічно",
@@ -51,7 +95,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Вважатимемо, що x2 > x1 (випадок, коли x2 < x1, розглядається аналогічно).",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-heometriya-merzliak-2017_s0080",
+      "title": "Сторінка 79"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "апостроф",
@@ -60,7 +115,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Перепишіть слова, поставивши, де потрібно, апостроф.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0141",
+      "title": "Сторінка 91"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "аудиторія",
@@ -69,7 +135,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Витлумачте пряме й переносне значення слова аудиторія.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrmova-glazova-2018_s0087",
+      "title": "Сторінка 60"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "багаж",
@@ -78,7 +155,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Зберіть свій багаж знань.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-zdorovia-vorontsova-2022_s0031",
+      "title": "Сторінка 32"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "бажання",
@@ -87,7 +175,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "25 потреби та бажання Подумайте про те, чого ви дуже хочете.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-zdorovia-vorontsova-2022_s0024",
+      "title": "Сторінка 25"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "батьків",
@@ -96,7 +195,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Найбільше проблем може виникнути у ви­ падку, коли один з батьків проживає окремо від дитини.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0452",
+      "title": "Сторінка 235"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "бачення",
@@ -105,7 +215,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Спробуйте за допомоги ШІ створити образ майбутнього людства на основі вашого бачення.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-istoriya-vsesvit-schupak-2024_s0468",
+      "title": "Сторінка 252"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "безкоштовний",
@@ -114,7 +235,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Зазвичай компанія, що надає безкоштовний хостинг, заробляє шляхом показу реклами на сторінках, розміщених на ньому.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-informatyka-rudenko-2019_s0311",
+      "title": "Сторінка 205"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "бланк",
@@ -123,7 +255,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Дослідіть упаковку засобу побутової хімії та заповніть бланк.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-zdorovia-vorontsova-2023_s0136",
+      "title": "Сторінка 141"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "ближчий",
@@ -132,7 +275,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Рум’янець на українських іконах додавав образам теплішого, більш людяного вигляду, що відбивало ближчий зв’язок між святими й вірянами.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-mystetstvo-komarovska-2025_s0136",
+      "title": "Сторінка 138"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "варити / зварити",
@@ -150,7 +304,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Прийшло до мене втомлене поліття і роздуми достиглі принесло хвилина щастя варта півстоліття хвилина горя варта півстоліття (І.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0209",
+      "title": "Сторінка 150"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вартість",
@@ -159,7 +324,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "вартість виготовлення одного пенні розǸовна назва Ȃента сягала приǭлизно \u0014,\u001a Ȃента.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-finans-plastun-2025_s0021",
+      "title": "Сторінка 22"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "ведення",
@@ -168,7 +344,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "МГП обмежує законні засоби і методи ведення війни.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0045",
+      "title": "Сторінка 25"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "великий",
@@ -177,7 +364,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Іван Франко — Великий Каменяр Іван Якович Франко народився 27 серпня 1856 року на Галичині, в селі Нагуєвичі.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0158_w002",
+      "title": "Lesson 158: Іван Франко — Великий Каменяр (part 2/16)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "виглядати",
@@ -186,7 +384,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Інше слово, яке іноді вживають, це «виглядати».",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0128_w010",
+      "title": "Lesson 128: Рослини — символи України (part 10/19)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вийняти",
@@ -195,7 +404,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Відвести ручку затворної рами і, утримуючи її у задньому положенні, від’єднати магазин і вийняти патрон, що уткнувся.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-zakhyst-fuka-2023_s0320",
+      "title": "Сторінка 173"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "викладач",
@@ -213,7 +433,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Вивчила я її тоді, коли вперше почала використовувати англійську мову для конкретних цілей у моєму житті.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0122_w008",
+      "title": "Lesson 122: Як я вивчала і вивчила англійську мову (part 8/23)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вилетіти",
@@ -222,7 +453,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Серед молекул поверхневого шару рідини завжди є такі, що «намагаються» вилетіти з рідини.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-fizyka-bariakhtar-2025_s0143",
+      "title": "Сторінка 130"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вимикати",
@@ -231,7 +473,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Чому важливо вимикати електричну лампу, коли нею не користуєшся?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "1-klas-bukvar-bolshakova-2018-2_s0041",
+      "title": "Сторінка 42"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "виникати",
@@ -240,7 +493,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Які проблеми можуть виникати під час проведення штучного запліднення?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-biologija-i-ekologija-zadorozhnij-2018-stand_s0214",
+      "title": "Сторінка 187"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вирости",
@@ -249,7 +513,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Якось, реагуючи на людську нетерплячість, Блаженніший Любомир Гузар сказав: «Дайте людям вирости у свободі».",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrmova-glazova-2018_s0165",
+      "title": "Сторінка 117"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "витратити",
@@ -258,7 +533,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "А чи однакову кількість теплоти не­ обхідно витратити на плавлення різних речовин однакової маси?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-fizyka-bariakhtar-2025_s0135",
+      "title": "Сторінка 122"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вишитий",
@@ -267,7 +553,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Що символізує вишитий рушник в українській культурі?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-ukrlit-zabolotnyi-2024_s0135",
+      "title": "Сторінка 92"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вище",
@@ -276,7 +573,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Третє речення: День стає довший, сонце починає підніматися вище.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0173_w014",
+      "title": "Lesson 173: Зимовий цикл свят (part 14/22)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "волонтер / волонтерка",
@@ -294,7 +602,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Тому всередині джерела, крім електричних сил Fкл, діють ще й сторонні сили Fст.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0064",
+      "title": "Сторінка 38"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вчити",
@@ -303,7 +622,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "вивча́ти = вчи́ти = учи́ти, to learn, to study something ви́вчити (imperfective, perfective) Я вивча́ю (вчу) чудо́ву I am learning the wonderful Ukrainian украї́нську мо́ву.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "anna-ohoiko-1000-words-2nd-ed_e0090",
+      "title": "вивча́ти = вчи́ти = учи́ти,"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "відділ",
@@ -312,7 +642,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Позначений цифрою 1 відділ учень назвав стовбуром мозку.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-biolohiya-anderson-2025_s0292",
+      "title": "Сторінка 240"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "відкривати",
@@ -321,7 +662,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Ми любимо подорожувати і відкривати відкрива́ти — 1) to discover; 2) to open нові культури.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0164_w002",
+      "title": "Lesson 164: Інтерв’ю з Євгеном про життя в Америці (part 2/23)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "відлік",
@@ -330,7 +682,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Як ведуть відлік відстаней за паралелями і меридіанами.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-heohrafiya-hilberh-2024_s0020",
+      "title": "Сторінка 23"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "відповідно до",
@@ -348,7 +711,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Яка відстань буде між ними через 35 хв?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-matematyka-ister-2022_s0076",
+      "title": "Сторінка 78"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "відчинити",
@@ -357,7 +731,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Тому вирішив відчинити двері та перевірити, що сталося.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-zdorovia-vorontsova-2022_s0208",
+      "title": "Сторінка 209"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "відчуження",
@@ -366,7 +751,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Наступне п’яте речення: У Чорнобильській зоні відчуження сталась масштабна лісова пожежа.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0174_w016",
+      "title": "Lesson 174: Україна в 2020 році: головні новини (part 16/25)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "відчуття",
@@ -375,7 +771,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Через це серотонін і дофамін накопичуються в синаптичній щілині, викликаючи відчуття насолоди.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0394",
+      "title": "Сторінка 233"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "відійти",
@@ -384,7 +791,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Далі владу поступово перейняли більшовики й, на жаль, поступо́во ― gradually Грушевський змушений був відійти.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-6-00-lesson-notes_l0237_w014",
+      "title": "Lesson 237: Михайло Грушевський — великий історик України (part 14/28)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вінок",
@@ -393,7 +811,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Знаєте вінок, вінки?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0128_w007",
+      "title": "Lesson 128: Рослини — символи України (part 7/19)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вісім",
@@ -402,7 +831,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Вас було троє, — відповів суддя, — а коржи­ ків — вісім.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-etyka-martyniuk-2023_s0022",
+      "title": "Сторінка 23"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "вісімнадцять",
@@ -411,7 +851,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Потреба кохання гостро спалахнула в ньому, як тільки минуло йому вісімнадцять років.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-ukrajinska-literatura-avramenko-2017_s0206",
+      "title": "Сторінка 160"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "геть",
@@ -420,7 +871,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Леся Українка «Contra spem spero!» «Геть думи сумні», — у першій строфі Леся звертається до строфа́ ― strophe своїх думок, дум.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-6-00-lesson-notes_l0223_w008",
+      "title": "Lesson 223: Українська поезія. Леся Українка «Contra spem spero!» (part 8/36)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "голитися",
@@ -429,7 +891,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Коли потрібно починати голитися?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-zdorovia-guschyna-2024_s0120",
+      "title": "Сторінка 112"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "голосування",
@@ -438,7 +911,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Голосування проводиться в день вибо­ рів або в день повторного голосування.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-hromadianska-gisem-2018_s0136",
+      "title": "Сторінка 71"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "грамів",
@@ -447,7 +931,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": " ПРИКЛАД 4 Скільки грамів 3 %-го та скільки грамів 8 %-го розчинів солі треба взяти, щоб отримати 500 г 4 %-го розчину?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-algebra-merzliak-2024_s0299",
+      "title": "Сторінка 301"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "гривня",
@@ -456,7 +951,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Підбиваємо підсумки Офіційною грошовою одиницею в Україні є гривня.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-finans-plastun-2025_s0037",
+      "title": "Сторінка 38"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "громадський",
@@ -465,7 +971,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Публіцистика формує … думку (громадський, громадянський).",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-voron-2019_s0388",
+      "title": "Сторінка 252"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "грубий",
@@ -474,7 +991,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Те саме можна сказати й про слова грубий – товстий.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "antonenko-davydovych-yak-my-hovorymo_p138",
+      "title": "Antonenko-Davydovych «Як ми говоримо», p. 138"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дальший",
@@ -483,7 +1011,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "folk",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "У тритомному Російсько–українському словнику на першому місці стоїть слово дальший, на другому – подальший, Словник за редакцією А.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "antonenko-davydovych-yak-my-hovorymo_p053",
+      "title": "Antonenko-Davydovych «Як ми говоримо», p. 53"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дані",
@@ -492,7 +1031,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Складний запит для таблиць МАГАЗИНИ і КАДРИ, за яким формуються дані, наведено в табл.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-informatyka-rudenko-2019_s0046",
+      "title": "Сторінка 31"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дарувати",
@@ -501,7 +1051,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "дарувати буду дарувати, подарую подарувати даруватиму 2.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-3-00-lesson-notes_l0099_w019",
+      "title": "Lesson 99: План подорожі (Голосове повідомлення №4) Travel plan (Voice message №4) (part 19/21)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дата",
@@ -510,7 +1071,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Моволюбка Дата: Четвер, 25.10.2018, 14:48 | Повідомлення # 16 Група: Користувачі Повідомлень: 30 Статус: Offline Не бачу проблем.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrmova-glazova-2018_s0038",
+      "title": "Сторінка 29"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "два",
@@ -519,7 +1091,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "два two Два моро́зива, будь ла́ска.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "anna-ohoiko-1000-words-2nd-ed_e0192",
+      "title": "два"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дедалі",
@@ -528,7 +1111,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Слово «дедалі» вживайте з прикметником чи прислівником у формі вищого ви́щий сту́пінь порівня́ння — ступеня порівняння.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0136_w014",
+      "title": "Lesson 136: Екологічні тренди та екологічні традиції в Україні (part 14/19)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дешевий",
@@ -537,7 +1131,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Знання про хімічну рівновагу допомагає організувати більш дешевий і зручний технологічний процес одержання речовин.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-himia-grygorovych-2019_s0084",
+      "title": "Сторінка 61"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "деякий",
@@ -546,7 +1151,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Через деякий час це потепління зміниться похолоданням.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-geografija-pestushko-2019_s0052",
+      "title": "Сторінка 31"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "джерело",
@@ -555,7 +1171,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Вибрати джерело відеозапису.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-informatyka-ryvkind-2024_s0172",
+      "title": "Сторінка 149"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дивувати",
@@ -564,7 +1191,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "169 Мистецтво дивувати і радувати Цирк запрошує на свято .",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-mystetstvo-rublia-2022_s0003",
+      "title": "Сторінка 4"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "довкілля",
@@ -573,7 +1211,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "38 Що я знаю про еколог³ю Поміркуєте про вплив діяльності людини на стан довкілля, про Європейський зелений курс.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-zdorovia-vasylenko-2025_s0042",
+      "title": "Сторінка 38"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дозволяти",
@@ -582,7 +1231,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "5 пам’ятати — … відлітати — … руйнувати — … нагріватись — … вигравати — … дозволяти — … зустрічати — ...",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "3-klas-ukrainska-mova-ponomarova-2020-1_s0119",
+      "title": "Сторінка 120"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дозвілля",
@@ -591,7 +1251,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Як проводили дозвілля робітники й селяни?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-istoriya-ukr-hlibovska-2024_s0157",
+      "title": "Сторінка 90"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "доїхати",
@@ -600,7 +1271,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "А ви не підкажете, як ми можемо доїхати до Чигирина?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0185_w016",
+      "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 16/23)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "думати",
@@ -609,7 +1291,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Функція театру в тому, щоб збуджувати людей, змушувати їх думати… Бернард Шоу  Бургтеатр у Відні, де у 1913 р.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0403",
+      "title": "Сторінка 225"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "діаспора",
@@ -618,7 +1311,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Історично українська діаспора формувалася під впливом чотирьох основних міграційних хвиль (див.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-geografiia-boiko-2026_s0061",
+      "title": "Сторінка 33"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дівчина",
@@ -627,7 +1331,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "\u0003  Чому роман має назву «Дівчина з ведмедиком»?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrlit-borzenko-2019-prof_s0146",
+      "title": "Сторінка 80"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дідусь",
@@ -636,7 +1351,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Ще дідусь і не отримав твого листа, а може, і не зразу відповість.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-ukrlit-zabolotnyi-2025_s0060",
+      "title": "Сторінка 44"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "дім",
@@ -645,7 +1371,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Шевчука «Дім на горі» якраз і представляє життя людей у такому незвичайному поєднанні.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrlit-borzenko-2019-prof_s0401",
+      "title": "Сторінка 211"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "діюча",
@@ -654,7 +1391,18 @@
     "k": "avoid",
     "weight": 7,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Перша постійно діюча марксистська група на українських землях під назвою «Російська група соціал-демократів» виникла в 1893 р.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-istorija-ukrajini-gisem-2017_s0293",
+      "title": "Сторінка 162"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "забирати",
@@ -663,7 +1411,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Іду в садік забирати малу.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0135_w004",
+      "title": "Lesson 135: Суржик в українській мові (part 4/22)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "завгодно",
@@ -672,7 +1431,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "При необмеженому збільшенні кількості сторін правильного многокутника його периметр буде як завгодно мало відрізнятися від довжини кола.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-heometriya-merzliak-2017_s0063",
+      "title": "Сторінка 62"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "загадковий",
@@ -681,7 +1451,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Фільм розповідає про сучасного школяра Вітькà, який через загадковий портал часу потрапляє в минуле — на тисячу років назад.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "4-klas-ukrayinska-mova-savchenko-2021-2_s0054",
+      "title": "Сторінка 55"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "заздрість",
@@ -690,7 +1471,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "45 НАРОДНІ КАЗКИ Прийнято розрізняти заздрість злобну (чорну) і незлобну (білу).",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrlit-zabolotnyi-2022_s0051",
+      "title": "Сторінка 45"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "закривати / закрити",
@@ -708,7 +1500,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Зупинити запис вибором кнопки .",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-informatyka-ryvkind-2017_s0135",
+      "title": "Сторінка 86"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "затримка",
@@ -717,7 +1520,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Якщо затримка не усунулася, то необхідно з’ясувати причину її виникнення й усунути затримку.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-zakhyst-fuka-2023_s0319",
+      "title": "Сторінка 173"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "захист",
@@ -726,7 +1540,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Визнач­те, чи є в запропонованих ситуаціях порушення права на захист.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0194",
+      "title": "Сторінка 103"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "заява",
@@ -735,7 +1560,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Заява може містити перелік документів, що додають до неї.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-ukrajinska-mova-avramenko-2017_s0101",
+      "title": "Сторінка 70"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "зберігається",
@@ -744,7 +1580,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Подвоєння зберігається у всіх формах слова (п’ять тонн, сім ванн) .",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrmova-litvinova-2022_s0072",
+      "title": "Сторінка 67"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "звичайно",
@@ -753,7 +1600,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "навести́ при́клад ― to provide an example Олеся: Звичайно, звичайно.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0195_w007",
+      "title": "Lesson 195: Українці в ПАР: розмова з Олесею Лобшер (part 7/27)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "звідки",
@@ -762,7 +1620,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "У складнопідрядних реченнях з підрядними місця сполучні слова де, куди, звідки є прислівниками й виконують синтаксичну роль обставини.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0135",
+      "title": "Сторінка 98"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "згідно з",
@@ -780,7 +1649,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Тому великі міста країни мають, здебільшого, погану якість повітря.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0253",
+      "title": "Сторінка 150"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "здоровий",
@@ -789,7 +1669,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Пісня «Будь здоровий!» (музика і слова Сергія Дяченка).",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-mystetstvo-rublia-2022_s0198",
+      "title": "Сторінка 198"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "здійснено",
@@ -798,7 +1689,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Петлюри було здійснено низку заходів, покликаних викорінити в Армії УНР отаманщину та перетворити її на регулярне військо.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-istorija-ukrajiny-gisem-2018_s0125",
+      "title": "Сторінка 68"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "здійснювати",
@@ -807,7 +1709,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Суб’єкти господарювання можуть здійснювати свою діяльність не лише на основі права власності.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0330",
+      "title": "Сторінка 172"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "змінити",
@@ -816,7 +1729,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Створення закладки на відкриту сторінку: 1 – Панель закладок; 2 – Вікно 2 Закладку додано; 3 – Кнопка 3 Змінити закладку для цієї вкладки 1.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-informatyka-ryvkind-2024_s0012",
+      "title": "Сторінка 14"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "знищити",
@@ -825,7 +1749,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Радикали прагнули продовжити революцію та знищити самодержавство.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-istorija-ukrajini-gisem-2017_s0394",
+      "title": "Сторінка 218"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "кадр",
@@ -834,7 +1769,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "75 Кадр із фільму «Захар Беркут» Кадр із фільму-серіалу «Роксолана» З історичним жанром кіно часто поєднується пригодницький.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-mystetstvo-rublia-2023_s0076",
+      "title": "Сторінка 77"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "календарний",
@@ -843,7 +1789,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Чому важливо відрізняти історичний і календарний час?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-istoriya-schupak-2022_s0052",
+      "title": "Сторінка 54"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "камін",
@@ -852,7 +1809,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Коефіцієнт корисної дії нагрівника Багато людей вважають, що в приватному будинку обов’язково має бути камін.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-fizyka-bariakhtar-2025_s0160",
+      "title": "Сторінка 146"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "квасоля",
@@ -861,7 +1829,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "До продуктів з високим вмістом білків належать м’ясо, риба, молоко, квасоля, горох, соя.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0199",
+      "title": "Сторінка 200"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "керівний",
@@ -870,7 +1849,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Квіти щасливі, — сказав керівний робот корабля.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-ukrlit-avramenko-2024_s0317",
+      "title": "Сторінка 223"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "кислий",
@@ -879,7 +1869,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Червоний укаже на кислий ґрунт, синій – на слабокислий, а зелений – на нейтральний.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-heohrafiya-hilberh-2025_s0193",
+      "title": "Сторінка 139"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "клавіатура",
@@ -888,7 +1889,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "КЛАВІАТУРА Поміркуйте ● Значення яких властивостей користувач враховує під час вибору клавіатури для комп’ютера?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-informatyka-ryvkind-2025_s0085",
+      "title": "Сторінка 64"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "колего",
@@ -897,7 +1909,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Проте прізвище може набувати форми називного відмінка: колего Євгене Онищук, пане Коваль.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-ukrmova-avramenko-2025_s0180",
+      "title": "Сторінка 134"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "кольоровий",
@@ -906,7 +1929,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "folk",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Виберіть стиль SmartArt — Плоска сцена, кольорову гаму — Кольоровий діапазон — кольори акценту 5–6.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-informatyka-ryvkind-2017_s0116",
+      "title": "Сторінка 75"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "кома",
@@ -915,7 +1949,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "На місці крапок має стояти А кома Б тире В кома й тире Г крапка й тире 7.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0206",
+      "title": "Сторінка 147"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "коментар",
@@ -924,7 +1969,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Ваш коментар \u0007Прочитайте текст, укладіть пам’ятку «Як працювати над основною частиною виступу».",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-voron-2019_s0057",
+      "title": "Сторінка 40"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "контекст",
@@ -933,7 +1989,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Контекст Основним способом точної передачі значення слова є контекст.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0023",
+      "title": "Сторінка 18"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "контролювати",
@@ -942,7 +2009,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Вміння грати певні ролі важливе й під час конфліктів, коли важ­ ко контролювати свої емоції.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-zdorovia-vasylenko-2025_s0139",
+      "title": "Сторінка 122"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "кориця",
@@ -951,7 +2029,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "щеплення, гвоздика, кориця, імбир, перець Поєднайте числівники та іменники: 1.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0138_w019",
+      "title": "Lesson 138: Як пережити зиму в Україні? (part 19/20)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "космос",
@@ -960,7 +2049,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "folk",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Космічні апарати для польоту людей у космос називають кос­ мічними кораблями.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-piznaemo-pryrodu-korshevniuk-2023_s0138",
+      "title": "Сторінка 140"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "кошик",
@@ -969,7 +2069,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Отже, шинку і ковбасу кладуть у кошик, і також можна покласти ще будь-яку їжу, яку готували.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0190_w008",
+      "title": "Lesson 190: Великодній кошик (part 8/22)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "крайній",
@@ -978,7 +2089,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Пересуватися на скутері, мопеді дозволено тільки по крайній правій смузі, не дозволено на автомагістралях !",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-zdorovia-vasylenko-2025_s0040",
+      "title": "Сторінка 36"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "культура",
@@ -987,7 +2109,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "У широкому сенсі поняття ● культура означає все, що створене людиною, а не природою.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-hromadianska-osvita-vasylkiv-2025_s0006",
+      "title": "Сторінка 6"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "культурний",
@@ -996,7 +2129,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Чинники ЧИННИКИ, ЩО ВПЛИВАЛИ НА КУЛЬТУРНИЙ ПРОЦЕС НА УКРАЇНСЬКИХ ЗЕМЛЯХ у XIV—XV ст.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-istoria-ukr-galimov-2024_s0285",
+      "title": "Сторінка 193"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "купатися",
@@ -1005,7 +2149,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Купатися можна у вбиральні, на кухні, в кабінеті чи в конторі – за вибором.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-zarlit-voloschuk-2024_s0262",
+      "title": "Сторінка 185"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "кілька",
@@ -1014,7 +2169,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "кі́лька = де́кілька some У ме́не є кі́лька (де́кілька) I have some questions.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "anna-ohoiko-1000-words-2nd-ed_e0391",
+      "title": "кі́лька = де́кілька"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "лавка",
@@ -1023,7 +2189,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "У посадах поряд із будинком найчастіше розміщувалася реміснича майстерня або торговельна лавка.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-istoria-ukr-galimov-2024_s0112",
+      "title": "Сторінка 76"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "лагідний",
@@ -1032,7 +2209,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Кетчуп «Лагідний» доповнює будь-який гарнір і м’ясо.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0112",
+      "title": "Сторінка 70"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "лекція",
@@ -1041,7 +2229,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Це монологічний вид виступу, але погано, якщо лекція перетворюється тільки на монолог викладача без зворотного зв’язку з аудиторією.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-voron-2019_s0119",
+      "title": "Сторінка 82"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "листок",
@@ -1050,7 +2249,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Маргарита вирвала з блокнота листок, написала: «ЩО ВСЕ?» – склала його і кинула Флоріанові.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0136",
+      "title": "Сторінка 76"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "листя",
@@ -1059,7 +2269,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Також заборонено спалювати опале листя через небезпеку виникнення пожеж і забруднення повітря.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-zdorovia-vorontsova-2022_s0192",
+      "title": "Сторінка 193"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "лице",
@@ -1068,7 +2289,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Запалене лице було гарне, але дуже молоде.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-ukrlit-avramenko-2025_s0239",
+      "title": "Сторінка 139"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "ловити / піймати",
@@ -1086,7 +2318,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Тобі знадобляться: помірно гаряча вода, чашка, секундомір, металева ложка.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0077",
+      "title": "Сторінка 78"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "люблять",
@@ -1095,7 +2338,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "І це сва́рка — quarrel прислів’я говорить про те, що українці не люблять суперечки, не люблять конфлікти.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0133_w008",
+      "title": "Lesson 133: Прислів’я та приказки Частина 2 (part 8/17)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "літр",
@@ -1104,7 +2358,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Потрібно одержати в одній із цих посудин 1 літр рідини.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-informatyka-ryvkind-2022_s0186",
+      "title": "Сторінка 185"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "лічильник",
@@ -1113,7 +2378,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Найчастіше первинний ключ складається з одного поля, а в ролі первинного ключа використовується поле типу Лічильник.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-informatika-rudenko-2018-stand_s0104",
+      "title": "Сторінка 99"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "м'яз",
@@ -1131,7 +2407,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Були ми всі тоді трудящі чи малі.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrlit-borzenko-2019-prof_s0271",
+      "title": "Сторінка 140"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "мандрівник",
@@ -1140,7 +2427,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Знайдіть інформацію, на що витрачає кошти мандрівник, готуючись до підйому на найвищу вершину світу.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-heohrafiya-hilberh-2024_s0048",
+      "title": "Сторінка 50"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "маршрут",
@@ -1149,7 +2447,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Вам потрібно прокласти маршрут подорожі.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-istoriya-schupak-2022_s0081",
+      "title": "Сторінка 83"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "мед",
@@ -1158,7 +2467,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "ДЛЯ ДОПИТЛИВИХ Виявлення глюкози в мед\u0003 Глюкозу виявляють у мед\u0003 так.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-khimiya-popel-2017_s0191",
+      "title": "Сторінка 192"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "методологія",
@@ -1167,7 +2487,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Методологія — принципи, сукупність ідей, методів і засобів, які визначають підхід до розробки програмного забезпечення.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-informatyka-rudenko-2019_s0394",
+      "title": "Сторінка 252"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "мешканець",
@@ -1176,7 +2507,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Плекаймо слово і ЖИТЕЛЬ ЧИ МЕШКАНЕЦЬ?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-ukrajinska-mova-voron-2017_s0272",
+      "title": "Сторінка 210"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "мило",
@@ -1185,7 +2527,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Що таке собаче мило?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0049",
+      "title": "Сторінка 51"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "миритися",
@@ -1194,7 +2547,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Прийшов битися чи миритися?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "3-klas-ukrainska-mova-savchenko-2020-2_s0043",
+      "title": "Сторінка 44"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "мислити",
@@ -1203,7 +2567,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Це здатність мислити вільно, знаходити свіжі ідеї та оригінальні рішення, швидко пристосовуватися до змін і нових обставин.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-zdorovia-vorontsova-2023_s0178",
+      "title": "Сторінка 183"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "мох",
@@ -1212,7 +2587,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Вербинка обережно підважила мох.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrlit-avramenko-2022_s0094",
+      "title": "Сторінка 90"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "музей",
@@ -1221,14 +2607,36 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Пригадай, що таке музей.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "4-klas-ukrayinska-mova-savchenko-2021-2_s0045",
+      "title": "Сторінка 46"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "міроприємство",
     "slug": "міроприємство",
     "gloss": "avoid: захід",
     "k": "avoid",
-    "weight": 2
+    "weight": 2,
+    "example": "Помилку допущено в рядку А ухвалити рішення Б запобігти помилці В здійснити контроль Г відвідати міроприємство 5.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0028",
+      "title": "Сторінка 21"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "місяць",
@@ -1237,7 +2645,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Шляхом тривалих спостережень вони визначили надійні одиниці часу: добу, рік, місяць.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-fizyka-bariakhtar-2024_s0093",
+      "title": "Сторінка 92"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "мішати",
@@ -1246,7 +2665,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Складіть і запишіть по одному реченню з такими словами: пощастить, повезе, заважати, мішати.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrmova-zabolotnyi-2023_s0035",
+      "title": "Сторінка 37"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "наближення",
@@ -1255,7 +2685,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Чому глобалізацію розглядають як «скорочення світу» і «наближення речей»?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-geografiia-boiko-2026_s0163",
+      "title": "Сторінка 87"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "набрати",
@@ -1264,7 +2705,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Набрати з колодязя повне відро води.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-informatyka-ryvkind-2022_s0214",
+      "title": "Сторінка 213"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "наведено",
@@ -1273,7 +2725,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Програму мовою Python обчислення чисел Фібоначчі на основі рекурентного підходу наведено на рис.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-informatyka-rudenko-2019_s0172",
+      "title": "Сторінка 115"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "нагода",
@@ -1282,7 +2745,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "І одного разу йому випала нагода поїхати до Петербурга і працювати там при царському дворі.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0155_w008",
+      "title": "Lesson 155: Григорій Сковорода — мандрівний філософ (part 8/16)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "надіслано",
@@ -1291,7 +2765,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "У діловому листуванні трапляється читати: \"Книжки надіслано накладною платою\".",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "antonenko-davydovych-yak-my-hovorymo_p032",
+      "title": "Antonenko-Davydovych «Як ми говоримо», p. 32"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "називний",
@@ -1300,7 +2785,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "три, третій Відмінок Кількісні числівники Порядкові числівники Однина Множина Називний скільки?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrmova-avramenko-2023_s0241",
+      "title": "Сторінка 225"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "найвищий",
@@ -1309,7 +2805,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "137 Прикметник Н Найвищий ступінь порівняння вказує, що певний предмет переважає всі інші за якою-небудь ознакою.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrmova-zabolotnyi-2020_s0139",
+      "title": "Сторінка 137"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "найняти",
@@ -1318,7 +2825,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "folk",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Скільки ж необхідно найняти робітників на кухню?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ekonomika-krupska-2018_s0143",
+      "title": "Сторінка 76"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "наліво",
@@ -1327,7 +2845,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Поверніть ліворуч (наліво), ідіть прямо по вулиці Зеленій.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-1-00-lesson-notes_l0019_w005",
+      "title": "Lesson 19: Asking for a phone number in Ukrainian (part 5/7)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "намалювати",
@@ -1336,7 +2865,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Операції класу: + намалювати (фігура Прямокутник = квадрат, колірФарбування Соlоr = (255,0,0)) Приклад 5.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-informatyka-rudenko-2019_s0370",
+      "title": "Сторінка 238"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "напруження",
@@ -1345,7 +2885,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Саме із цієї миті відбувається перелом у сюжеті та спадає напруження, яке збільшувалося постійно впродовж усього твору.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrlit-avramenko-2023_s0248",
+      "title": "Сторінка 188"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "народити",
@@ -1354,7 +2905,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Сніг, щука, юнак, берег, рік, книга, радити, Оленка, допомога, їздити, народити, могти.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrmova-avramenko-2022_s0117",
+      "title": "Сторінка 114"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "наскільки",
@@ -1363,7 +2925,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "взаємовідно́шення — relationship Наскільки часто ви будете слухати подкаст, настільки добре будете розуміти українську мову.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0145_w013",
+      "title": "Lesson 145: Українські народні музичні інструменти (part 13/17)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "наступний",
@@ -1372,7 +2945,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Максим: _________________________ (Наступний п’ятниця) ми поїдемо на фестиваль ____________________ (борщ) в Тернопільській області.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-2-00-lesson-notes_l0047_w007",
+      "title": "Lesson 47: Гастрономічні фестивалі Родовий відмінок Food festivals Genitive case (part 7/9)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "натуральний",
@@ -1381,7 +2965,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Натуральний каучук був уперше описаний французьким астрономом та мандрівником Шарлем Марі де ла Кондоміном 1751 року.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-himija-grygorovych-2018_s0231",
+      "title": "Сторінка 205"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "недостатньо",
@@ -1390,7 +2985,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Цього недостатньо — це особлива структура речення, тому що недоста́тньо — insufficient, not enough ми вживаємо слово «це» в родовому відмінку — цього.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0178_w020",
+      "title": "Lesson 178: Як ефективніше вчитися? (part 20/26)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "неістота",
@@ -1399,7 +3005,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Визначте групу за значенням істота/неістота.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrmova-litvinova-2023_s0129",
+      "title": "Сторінка 122"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "нижчий",
@@ -1408,7 +3025,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "З територій, де тиск вищий, повітря переміщується на території, де він нижчий.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0114",
+      "title": "Сторінка 115"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "низько",
@@ -1417,7 +3045,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Карпо ненавидів тих, хто панові дуже низько кланявся, до землі нагинався.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrlit-avramenko-2022_s0012",
+      "title": "Сторінка 12"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "ніби",
@@ -1426,7 +3065,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Працюй так, ніби тобі не потрібні не можна повернути: час, слово і гроші… Танцюй так, ніби можливість.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-3-00-lesson-notes_l0106_w012",
+      "title": "Lesson 106: Події на вихідних Weekend events Negative adverbs and pronouns in Ukrainian (part 12/17)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "ніхто",
@@ -1435,7 +3085,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "ніхто́ nobody, no one Ніхто́ мене́ не зупи́нить.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "anna-ohoiko-1000-words-2nd-ed_e0518",
+      "title": "ніхто́"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "обманювати",
@@ -1444,7 +3105,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Вішати на вуха ло5кшину — обманювати, відволікати від суті розмови, вводити в оману.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-glazova-2019_s0319",
+      "title": "Сторінка 218"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "обов'язковий",
@@ -1462,7 +3134,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Під склерою розташована судинна оболонка, де проходять кровоносні судини.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-biolohiya-anderson-2025_s0208",
+      "title": "Сторінка 168"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "овес",
@@ -1471,7 +3154,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "folk",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Зеленеє жито ще й овес — Тут зібрався рід наш увесь.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-mystetstvo-komarovska-2025_s0014",
+      "title": "Сторінка 16"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "одягатися",
@@ -1480,7 +3174,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Завоювавши Персію, Александр почав одягатися як перський шахиншах та одружився із двома персіянками.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-istoriya-gisem-2023_s0187",
+      "title": "Сторінка 140"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "ой",
@@ -1489,7 +3194,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Ой радуйся, земле, Син Божий народився.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrlit-avramenko-2023_s0014",
+      "title": "Сторінка 14"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "опонент",
@@ -1498,7 +3214,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Домашнє завдання 737 Яким повинен бути ідеальний опонент у дискусії?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrmova-karaman-2018_s0476",
+      "title": "Сторінка 265"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "орендар",
@@ -1507,7 +3234,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Отже, слова орендар, дипломант, касир мають чоловічий рід, але так можна називати й чоловіків, і жінок.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0256",
+      "title": "Сторінка 181"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "основа",
@@ -1516,7 +3254,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "У якому слові основа закінчується на м’який приголосний?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0051",
+      "title": "Сторінка 53"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "основний",
@@ -1525,7 +3274,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Це визначає основний метод правового регулювання, який використовує фінансове право, — імперативний метод, або метод субординації, владних приписів.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0043",
+      "title": "Сторінка 24"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "офіс",
@@ -1534,7 +3294,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Ми маєм офіс в Києві і офіс в Торонто.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0199_w013",
+      "title": "Lesson 199: Українці в Канаді: розмова з Оксаною Грициною (part 13/33)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "п'ятдесят",
@@ -1561,7 +3332,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "У складі апеляційного суду можуть утворю­ ватися судові палати з розгляду окремих ка­ тегорій справ.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0506",
+      "title": "Сторінка 225"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "перевантаження",
@@ -1570,7 +3352,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "12.11 і зробіть висновки: куди напрямлене прискорення руху тіла, коли тіло зазнає перевантаження?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-fizyka-barjakhtar-2018_s0120",
+      "title": "Сторінка 76"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "переглянути",
@@ -1579,7 +3372,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Звертаємо увагу, що результати заповнення форми можуть переглянути тільки автор/ авторка і користувачі, яким надано доступ редагування форми.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-informatyka-ryvkind-2024_s0280",
+      "title": "Сторінка 244"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "повідомлення",
@@ -1588,7 +3392,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Як людина сприймає повідомлення?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-informatyka-ryvkind-2022_s0012",
+      "title": "Сторінка 14"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "покращення",
@@ -1597,7 +3412,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "5 порад для покращення української мови Добре, отже, ви розумієте, що я кажу українською на подкасті.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0137_w002",
+      "title": "Lesson 137: 5 порад для покращення української мови (part 2/19)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "полуничний",
@@ -1606,7 +3432,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Беатріс купила в сільському магазині морозиво і зробила полуничний полуни́чний — strawberry (adjective) коктейль.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0185_w011",
+      "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 11/23)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "поліція",
@@ -1615,7 +3452,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "У роки революції російські чорносотенні організації вчинили єврейські погроми, причому поліція трималася ­осторонь цих подій.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-istorija-ukrajini-gisem-2017_s0421",
+      "title": "Сторінка 233"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "порівнювати",
@@ -1624,7 +3472,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Чи потрібно постійно порівнювати себе з іншими?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrlit-zabolotnyi-2022_s0051",
+      "title": "Сторінка 45"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "постійно",
@@ -1633,7 +3492,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Після евакуації пораненого в укриття потрібно постійно дбати про власну безпеку і безпеку пораненого.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0197",
+      "title": "Сторінка 105"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "початися",
@@ -1642,7 +3512,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Причин ритмічності кілька: по-перше, процес не може початися знову, доки не завершено попередній.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0118",
+      "title": "Сторінка 72"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "починати",
@@ -1651,7 +3532,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "У якому віці можна починати фарбувати волосся?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-zdorovia-guschyna-2024_s0120",
+      "title": "Сторінка 112"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "поширити",
@@ -1660,7 +3552,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Із метою відволікти населення від боротьби проти самодержавства царський уряд намагався поширити на українські землі антисемітські настрої.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-istorija-ukrajini-gisem-2017_s0421",
+      "title": "Сторінка 233"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "поїду",
@@ -1669,7 +3572,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Запряжу я козу в віз Та й поїду по рогіз.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-mystetstvo-rublia-2023_s0056",
+      "title": "Сторінка 57"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "правопис",
@@ -1678,7 +3592,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Перевірити правопис слова можна в орфографічному словнику .",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrmova-litvinova-2022_s0122",
+      "title": "Сторінка 117"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "працюємо",
@@ -1687,7 +3612,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Працюємо в малих групах.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-istoria-ukr-galimov-2025_s0408",
+      "title": "Сторінка 248"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "препарат",
@@ -1696,7 +3632,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Тривимірне зобра­ ження того, як наночастинки, що містять протипухлинний препарат, оточують ракову клітину та вбивають пухлину 111 § 18.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-fizyka-bariakhtar-2025_s0125",
+      "title": "Сторінка 114"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "привезти",
@@ -1705,7 +3652,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Які сувеніри привезти з України?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0130_w016",
+      "title": "Lesson 130: Які сувеніри привезти з України? (part 16/23)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "привітання",
@@ -1714,7 +3672,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Прочитайте фрагмент привітання Президента України з нагоди Дня Соборності.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-ukrmova-zabolotnyi-2025_s0341",
+      "title": "Сторінка 275"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "прийняти",
@@ -1723,7 +3692,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Для цього їй довелося прийняти іслам.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0152_w009",
+      "title": "Lesson 152: Роксолана — La Sultana Rossa (part 9/15)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "прикраса",
@@ -1732,7 +3712,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Д Різдвяна прикраса на палиці, сповіщає про народження Ісуса Христа.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-6-00-lesson-notes_l0214_w021",
+      "title": "Lesson 214: Символи Різдва в Україні (part 21/24)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "приспів",
@@ -1741,7 +3732,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "folk",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "(Приспів) Та кладіть калачі з ярої пшениці.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrlit-zabolotnyi-2023_s0026",
+      "title": "Сторінка 27"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "приховати",
@@ -1750,7 +3752,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Коли потрібно приховати деякі поля, їх слід виділити й у групі Записи виконати команду Додатково → Приховати поля.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-informatyka-rudenko-2019_s0039",
+      "title": "Сторінка 26"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "приєднати",
@@ -1759,7 +3772,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Приєднати газову трубку.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-zakhyst-fuka-2023_s0326",
+      "title": "Сторінка 177"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "приєднатися",
@@ -1768,7 +3792,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Приєднатися до такого народу — це гірше, ніж скочити живим у вогонь.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-istoria-ukr-galimov-2025_s0230",
+      "title": "Сторінка 140"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "про",
@@ -1777,7 +3812,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Нузет Умеров ПРО КНИЖКУ Дбайливо тонесеньку книжку гортаю, рядок за рядочком уважно читаю.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "2-klas-ukrmova-vashulenko-2019-2_s0018",
+      "title": "Сторінка 20"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "провідник",
@@ -1786,7 +3832,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "сила аМпЕра Із матеріалу § 1 ви дізналися, що магнітне поле діє на провідник зі струмом із де­ якою силою.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-fizyka-bariakhtar-2022_s0029",
+      "title": "Сторінка 20"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "програвати",
@@ -1795,7 +3852,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Ті не перемагають, хто не вміють програвати.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-fizyka-bariakhtar-2022_s0340",
+      "title": "Сторінка 226"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "продавати",
@@ -1804,7 +3872,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Її не можна було передавати в спадок, продавати тощо.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-istoria-ukr-galimov-2024_s0106",
+      "title": "Сторінка 73"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "продовжувати",
@@ -1813,7 +3892,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Однак я досить довго не могла зрозуміти, як (imperfective, perfective) продовжувати подкаст саме в умовах війни.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-6-00-lesson-notes_l0201_w005",
+      "title": "Lesson 201: Про шостий сезон подкасту (part 5/21)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "проза",
@@ -1822,7 +3912,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "­Ораторсько-проповідницька проза включала твори з тлумаченням євангельських текстів і моралістичними повчаннями.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-istoriya-ukr-gisem-2021_s0077",
+      "title": "Сторінка 41"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "простір",
@@ -1831,7 +3932,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Що таке особистий простір та якими є його складники.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-etyka-martyniuk-2023_s0042",
+      "title": "Сторінка 43"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "професія",
@@ -1840,7 +3952,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Можна стати по-справжньому щасливим, коли характер і професія перебувають у гармонії.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0272",
+      "title": "Сторінка 190"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "психологічний",
@@ -1849,7 +3972,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Думаю скласти психологічний портрет людини можна за кількістю і якістю прочитаних і зібраних нею книжок.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-glazova-2019_s0221",
+      "title": "Сторінка 157"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "птаха",
@@ -1858,7 +3992,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Персонаж «Синього птаха», якого в українському перекладі названо Душею Світла, в оригіналі – просто Світло.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-zarubizhna-literatura-voloshhuk-2018_s0342",
+      "title": "Сторінка 198"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "півострів",
@@ -1867,7 +4012,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "yy Балканський півострів омивається ________________ морями.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-istoriia-shchupak-2023_s0128",
+      "title": "Сторінка 126"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "підліток",
@@ -1876,7 +4032,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "В Підліток може висловити свої скарги вчителю, шкільному адміністратору чи батькам.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-zdorovia-guschyna-2024_s0077",
+      "title": "Сторінка 72"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "підряд",
@@ -1885,7 +4052,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Розкажіть про особливості складнопідрядних речень із з’ясувальними підряд ними частинами.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0182",
+      "title": "Сторінка 131"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "підсилити",
@@ -1894,7 +4072,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Його потужність, колір, напрям допомагають зробити декорації виразнішими, виділити головне, підсилити враження глядачів/глядачок.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-mystetstvo-rublia-2023_s0184",
+      "title": "Сторінка 185"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "підтвердження",
@@ -1903,7 +4092,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Доберіть історичні факти на підтвердження тези «Самвидав» — зброя в руках дисидентів».",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-istoriya-ukr-hlibovska-2024_s0320",
+      "title": "Сторінка 175"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "пізно",
@@ -1912,7 +4112,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Мілкіше, мало, довше, дешево, пізно, більше, світло, сумно, близько.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "4-klas-ukrayinska-mova-zaharijchuk-2021-1_s0125",
+      "title": "Сторінка 127"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "разом",
@@ -1921,7 +4132,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Далі вона розповідає: Ми далі будемо рухатися по життю разом.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0195_w017",
+      "title": "Lesson 195: Українці в ПАР: розмова з Олесею Лобшер (part 17/27)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "рекорд",
@@ -1930,7 +4152,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Номер 5 ― побити світовий рекорд.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0141_w012",
+      "title": "Lesson 141: Україна в 2019: головні новини (part 12/20)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "референт",
@@ -1948,7 +4181,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Уявіть, що хтось із ваших знайомих уперше створює електронну пошту чи реєструється в соціальній мережі.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrmova-zabolotnyi-2023_s0019",
+      "title": "Сторінка 21"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "риса",
@@ -1957,7 +4201,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "(imperfective, perfective) торту́ри ― torture Очевидно, ця риса — риса стоїцизму — не може бути здава́тися, зда́тися ― to give up притаманною усім людям.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-6-00-lesson-notes_l0229_w002",
+      "title": "Lesson 229: Українська поезія. Василь Стус «Господи, гніву пречистого…» (part 2/30)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "родич",
@@ -1966,7 +4221,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Моєму родичу випала неймовірна можливість (Мій родич отримав неймовірну можливість) навчатися (вчитися) безкоштовно.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0189_w026",
+      "title": "Lesson 189: Вища освіта в Україні та США (part 26/26)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "розмова",
@@ -1975,7 +4241,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "за кордо́ном ― abroad Шотла́ндія ― Scotland Ця розмова буде особлива і трошки інша, ніж попередні дві.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0194_w001",
+      "title": "Lesson 194: Українці в Шотландії: розмова з Олексою Курилюком (part 1/21)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "розповісти",
@@ -1984,7 +4261,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "☆☆☆ Я можу розповісти про причини виникнення пожеж.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-zdorovia-vorontsova-2023_s0163",
+      "title": "Сторінка 168"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "розпорядження",
@@ -1993,7 +4281,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "\u0007Поясніть поняття «власність», «користування», «володіння», «розпорядження», «сервітут», «суперфіцій», «емфітевзис».",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0240",
+      "title": "Сторінка 127"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "розум",
@@ -2002,7 +4301,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Маруся не знайшла в собі сили пережити цю зраду і тому вона зовсім втратила розум.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0153_w011",
+      "title": "Lesson 153: Маруся Чурай — дівчина з легенди (part 11/17)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "розширювати",
@@ -2011,7 +4321,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "для тих, хто вже добре розуміє українську мову, але хоче розширювати словниковий запас».",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0128_w010",
+      "title": "Lesson 128: Рослини — символи України (part 10/19)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "роль",
@@ -2020,7 +4341,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Далі я казала, що Ярослав Мудрий відіграв важливу роль в історії.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0151_w010",
+      "title": "Lesson 151: Ярослав Мудрий — «тесть Європи» (part 10/16)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "рости",
@@ -2029,7 +4361,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "і заспівала: «Плавай, плавай, леб;едонько, По синьому морю – Рости, рости, топ;оленько, Все вгору та вгору!",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-ukrlit-zabolotnyi-2024_s0211",
+      "title": "Сторінка 144"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "рушник",
@@ -2038,7 +4381,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "І в дорогу далеку ти мене на зорі проводжала, І рушник вишиваний на щастя, на долю дала.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-ukrlit-mishhenko-2015_s0407",
+      "title": "Сторінка 246"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "рідко",
@@ -2047,7 +4401,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "У формі називного відмінка іменник, яким виражено звертання, уживають рідко — зазвичай у поетичних творах.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-glazova-2019_s0149",
+      "title": "Сторінка 104"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "різдвяний",
@@ -2056,7 +4421,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Узвар, український різдвяний напій, готується із 5.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-6-00-lesson-notes_l0214_w022",
+      "title": "Lesson 214: Символи Різдва в Україні (part 22/24)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "сад",
@@ -2065,7 +4441,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Пагутяк «Потрапити в сад» за родовою ознакою — епічний.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-literatura-avramenko-2019_s0403",
+      "title": "Сторінка 248"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "садівництво",
@@ -2074,7 +4461,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Крім землеробства, розвивалися скотарство, городництво, садівництво, бджільництво, рибальство й мисливство.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-istoria-ukr-galimov-2025_s0027",
+      "title": "Сторінка 20"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "салат",
@@ -2083,7 +4481,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Ще був салат мімоза — з вареними мімо́за — mimosa salad яйцями і рибними консервами.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0181_w010",
+      "title": "Lesson 181: Українська кухня в радянські часи (part 10/22)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "самостійно",
@@ -2092,7 +4501,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Початкові значення властивостей напису виберіть самостійно.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-informatyka-ryvkind-2025_s0167",
+      "title": "Сторінка 120"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "свята",
@@ -2101,7 +4521,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Речення номер один: Деякі свята потрохи відходять в історію.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0173_w013",
+      "title": "Lesson 173: Зимовий цикл свят (part 13/22)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "свідомість",
@@ -2110,7 +4541,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Свідомість Прагнення пізнання себе є одним з головних рушіїв розвитку людства.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-biolohiya-anderson-2025_s0250",
+      "title": "Сторінка 202"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "свіжий",
@@ -2119,7 +4561,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Взагалі, свіжоспечений ми говоримо про хліб, тобто хліб, який спекли спекти́ — to bake щойно, недавно, цей хліб свіжий, він свіжоспечений.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-4-00-lesson-notes_l0133_w010",
+      "title": "Lesson 133: Прислів’я та приказки Частина 2 (part 10/17)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "середній",
@@ -2128,7 +4581,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Це така відстань, з якої середній радіус земної орбіти видно під кутом 1″ (секунда дуги).",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0387",
+      "title": "Сторінка 240"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "символічно",
@@ -2137,7 +4601,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "folk",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "символічно це показало, що від заходу до сходу Україна одна, символі́чно — symbolically єдина, неподільна, або соборна.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0177_w010",
+      "title": "Lesson 177: День Соборності України (part 10/21)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "скарб",
@@ -2146,7 +4621,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "folk",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Люди – дуже цікаві створіння!» – думає персонаж твору А «Скарб» В «Мишка» Б «Кольорові миші» Г «Чайка на крижині» 6.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-ukrlit-mishhenko-2015_s0345",
+      "title": "Сторінка 209"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "слюсар",
@@ -2155,7 +4641,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Учитель, лікар чи геолог, письменник, слюсар чи кресляр — всі називають головною одну професію — школяр!",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "2-klas-ukrmova-vashulenko-2019-2_s0002",
+      "title": "Сторінка 4"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "слідуючий",
@@ -2163,7 +4660,18 @@
     "gloss": "avoid: наступний",
     "k": "avoid",
     "weight": 5,
-    "lessonTag": "b1"
+    "lessonTag": "b1",
+    "example": "Студенти сіли в потяг, слідуючий до Рівного.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrmova-zabolotnyi-2019_s0079",
+      "title": "Сторінка 58"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "сніг",
@@ -2172,7 +4680,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "\u0007Якими фарбами зображено на картині сніг, небо, дерева?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0067",
+      "title": "Сторінка 69"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "соломка",
@@ -2181,7 +4700,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Так і посипалось на сніг, а соломка й пір’ячко за вітром полетіли.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "2-klas-ukrmova-kravcova-2019-2_s0052",
+      "title": "Сторінка 54"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "сорок",
@@ -2190,7 +4720,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Зверніть увагу на відмінкові закінчення числівника сорок.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrmova-golub-2023_s0164",
+      "title": "Сторінка 161"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "спитати",
@@ -2199,7 +4740,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Міжбанківський валютний ринок (міжбанк) Можете спитати в батьків чи в дорослих, яким довіряєте, як вам купити 100 доларів.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-finans-plastun-2025_s0058",
+      "title": "Сторінка 57"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "споживач",
@@ -2208,7 +4760,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Споживач в економіці 51 кожного додаткового літра значно зменшу­ ється, а кожний додатковий карат алмаза збільшує корисність коштовностей.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ekonomika-krupska-2018_s0098",
+      "title": "Сторінка 51"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "спортивний",
@@ -2217,7 +4780,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Підготуйте твір-опис приміщення в художньому стилі на одну з тем: «Наш клас», «Моя кімната», «Улюблений спортивний зал» (усно).",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrmova-avramenko-2023_s0127",
+      "title": "Сторінка 119"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "спостереження",
@@ -2226,7 +4800,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Пост радіаційного та хімічного спостереження встановлюють на території об’єкта недалеко від пункту управління.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0326",
+      "title": "Сторінка 176"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "стадіон",
@@ -2235,7 +4820,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "На стадіон прийшли хлопці, бажаючі грати у футбол.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-ukrmova-zabolotnyi-2024_s0233",
+      "title": "Сторінка 233"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "стажування",
@@ -2244,7 +4840,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Учасники наукового стажування отримали престижну премію.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-6-00-lesson-notes_l0210_w027",
+      "title": "Lesson 210: Питання-відповіді: частина друга (part 27/27)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "стілець",
@@ -2253,7 +4860,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "НУМО ДОСЛІДЖУВАТИ ЯК ОЧІ ОЦІНЮЮТЬ ВІДСТАНЬ Тобі знадобляться: аркуш паперу, олівець, стілець.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-piznaemo-pryrodu-korshevniuk-2023_s0199",
+      "title": "Сторінка 201"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "сума",
@@ -2262,7 +4880,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Знайдіть ймовірність того, що: 1) його куб менший за 8000; 2) сума квадратів його цифр менша за 20.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-algebra-ister-2019-prof_s0251",
+      "title": "Сторінка 243"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "сумка",
@@ -2271,7 +4900,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Для ваших однокласників у задоволенні цієї по­ треби товарами-субститутами можуть бути портфель, спортивна сумка, сумка-пакет, рюкзак.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ekonomika-krupska-2018_s0091",
+      "title": "Сторінка 47"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "сумніватися",
@@ -2280,7 +4920,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "(сумніватися) в тому, що я кажу правду?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-3-00-lesson-notes_l0109_w015",
+      "title": "Lesson 109: На побаченні On a date Reflexive verbs (part 15/18)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "суспільство",
@@ -2289,7 +4940,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Сутність громадянського суспільства та його інститути Чим відрізняється громадянське суспільство від суспільства?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-hromadianska-osvita-vasylkiv-2025_s0071",
+      "title": "Сторінка 34"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "сусід",
@@ -2298,7 +4960,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Було тій Анні, може, десять рочків, її привів розлючений сусід.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-ukrlit-mishhenko-2015_s0262",
+      "title": "Сторінка 164"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "схвалено",
@@ -2307,7 +4980,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Верховною Радою схвалено «Основні напрями зовнішньої політики України»; – 5 грудня 1994 р.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-istoriya-ukr-hlibovska-2024_s0479",
+      "title": "Сторінка 262"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "схильний",
@@ -2316,7 +5000,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Схильний, охочий що-небудь робити; готовий до певних учинків; згоден на певну дію, стан.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-ukrmova-avramenko-2025_s0253",
+      "title": "Сторінка 180"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "сцена",
@@ -2325,7 +5020,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "(Лиховісно сміється.) СЦЕНА 3 Покої в королівському палаці.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0060",
+      "title": "Сторінка 62"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "сценарій",
@@ -2334,7 +5040,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "З якою метою створюється режисерський сценарій під час створення фільму за певним літературним твором?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-informatyka-ryvkind-2024_s0206",
+      "title": "Сторінка 181"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "телебачення",
@@ -2343,7 +5060,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "До яких жанрів телебачення вони належать?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-mystetstvo-masol-2017_s0184",
+      "title": "Сторінка 163"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "телефонувати",
@@ -2352,7 +5080,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "дзвіно́к — call Ви можете зідзвонюватись, тобто телефонувати одне одному, телефонува́ти = дзвони́ти — to call дзвонити одне одному.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0165_w013",
+      "title": "Lesson 165: Як використовувати смартфон для вивчення мов (part 13/19)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "тема",
@@ -2361,7 +5100,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "ПОВЕРНЕННЯ ДО ІДЕАЛІВ КРАСИ МИНУЛОГО Тема 1 5 -1 6 .",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-mystetstvo-masol-2017_s0002",
+      "title": "Сторінка 4"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "тест",
@@ -2370,7 +5120,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Тест — це слово, яке часто має негативну конотацію.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0178_w007",
+      "title": "Lesson 178: Як ефективніше вчитися? (part 7/26)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "тестувати",
@@ -2379,7 +5140,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "У процесі здійснення тест-дизайну тест-аналітик визначає, ЩО тестувати, а тест-дизайнер — ЯК тестувати.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-informatyka-rudenko-2019_s0388",
+      "title": "Сторінка 249"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "тисяча",
@@ -2388,7 +5160,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "(на) тисяча дев’ятсот сьомому Кожен компонент складеного числівника відмінюється за своїм правилом.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0054",
+      "title": "Сторінка 38"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "тихо",
@@ -2397,7 +5180,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Ярослав Грицак зазначав: «Можу сказати, що комунізм упав напрочуд тихо.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-istoriya-ukr-gisem-2024_s0310",
+      "title": "Сторінка 173"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "тканина",
@@ -2406,7 +5200,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Скелетна м’язова тканина утворює скелетні м’язи, язик тощо.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-biolohiya-anderson-2025_s0014",
+      "title": "Сторінка 13"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "товариський",
@@ -2415,7 +5220,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Використайте синоніми приятельський, приязний, дружній, товариський.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-ukrmova-avramenko-2022_s0047",
+      "title": "Сторінка 45"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "точний",
@@ -2424,7 +5240,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Визначити точний час певної події, тобто її дату, допомагає хронологія.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "5-klas-istoriya-schupak-2022_s0053",
+      "title": "Сторінка 55"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "трава",
@@ -2433,7 +5260,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "трава́ grass Ми лежимо́ на траві́ в па́рку.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "anna-ohoiko-1000-words-2nd-ed_e0880",
+      "title": "трава́"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "традиція",
@@ -2442,7 +5280,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "А от традиція купання в боягу́з — coward холодній воді не для боягузів, не для тих, хто боїться, так?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0173_w017",
+      "title": "Lesson 173: Зимовий цикл свят (part 17/22)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "тричі",
@@ -2451,7 +5300,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Його тричі обирали до Верховної Ради України (1990, 1994, 1998 рр.).",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-istoriya-ukr-gisem-2024_s0283",
+      "title": "Сторінка 157"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "тротуар",
@@ -2460,7 +5320,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "УÑÅ заметено снігом: тротуар, дорога, стадіон.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-ukrmova-zabolotnyi-2025_s0192",
+      "title": "Сторінка 163"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "трохи",
@@ -2469,7 +5340,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Зобрази його м’язистим, але трохи пере­ більшено кремезним — наче він щойно зліз із коня після десятиліття боїв.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-vsesvitnia-istoriia-pometun-2026_s0121",
+      "title": "Сторінка 87"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "туалет",
@@ -2478,7 +5360,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Туалет • Не куріть, не шуміть, не запалюйте свічки без дозволу відповідальної особи.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-zdorovia-vasylenko-2025_s0024",
+      "title": "Сторінка 22"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "тістечко",
@@ -2487,7 +5380,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Чоловік ламає те тістечко навпіл, підсовує їй одну частинку, другу з’їдає сам і йде геть.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrmova-golub-2023_s0200",
+      "title": "Сторінка 197"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "удома",
@@ -2496,7 +5400,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Бояри та представники знаті винаймали для своїх дітей приватних учителів, які навчали їх удома.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-istoria-ukr-pometun-2024_s0175",
+      "title": "Сторінка 144"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "узимку",
@@ -2505,7 +5420,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Узимку – пом’якшує морози, приносить снігопади, відлиги.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-heohrafiya-hilberh-2025_s0114",
+      "title": "Сторінка 82"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "фінал",
@@ -2514,7 +5440,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "У першому виданні твір мав відкритий фінал: груша розросталася, а сварки не припинялись.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrlit-borzenko-2018-prof_s0051",
+      "title": "Сторінка 29"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "фінальний",
@@ -2523,7 +5460,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Етап 2 На етапі проектування структури інтерфейсу створюють прототип інтерфейсу — зазвичай два: чорновий та фінальний.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-informatyka-rudenko-2019_s0379",
+      "title": "Сторінка 244"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "ходить",
@@ -2532,7 +5480,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Ходить сон стежками лісовими.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0140",
+      "title": "Сторінка 101"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "цвісти",
@@ -2541,7 +5500,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Цвісти або процвітати можуть квіти, коли вони розкриваються, цвісти́ — to bloom, to blossom квіти стають такі гарні квіти.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0199_w023",
+      "title": "Lesson 199: Українці в Канаді: розмова з Оксаною Грициною (part 23/33)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "часовий",
@@ -2550,7 +5520,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Позаду був часовий стрибок у ранок сьогоднішнього дня.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrlit-avramenko-2023_s0243",
+      "title": "Сторінка 185"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "червень",
@@ -2559,7 +5540,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Послухайте ще один уривочок про червень в Україні.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0185_w010",
+      "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 10/23)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "чомусь",
@@ -2568,7 +5560,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Знатися на чомусь.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "ulp-5-00-lesson-notes_l0184_w014",
+      "title": "Lesson 184: Кавова культура України (part 14/22)"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "чорна",
@@ -2577,7 +5580,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "ПІДНЯТИСЯ НАД БУДЕННІСТЮ здивувати», – повідомляли губи світу, доки Чорна Пані мовчки роздивлялася Софійку.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-ukrlit-zabolotnyi-2024_s0372",
+      "title": "Сторінка 250"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "чорні",
@@ -2586,7 +5600,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Чорні клобуки часом повставали або відходили в степ, відмовляючись нести службу.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "7-klas-istoria-ukr-pometun-2024_s0128",
+      "title": "Сторінка 107"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "чіпати",
@@ -2595,7 +5620,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b2",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Чіпати і їсти їх не (дозволятися).",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0113",
+      "title": "Сторінка 115"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "швидкий",
@@ -2604,7 +5640,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Згодом розпочався «промисловий» бум – швидкий розвиток вторинного сектору економіки: металургії, машинобудування, хімічної промисловості.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-geografiia-boiko-2026_s0548",
+      "title": "Сторінка 289"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "швидко",
@@ -2613,7 +5660,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Б Троянці, в човни посідавши, і швидко їх поодпихавши, по вітру гарно попливли.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0179",
+      "title": "Сторінка 127"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "шум",
@@ -2622,7 +5680,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Вони в захваті від ритмів пісні «Шум», яку український гурт «Go A» прославив на співочому конкурсі «Євробачення» у 2021 р.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-ukrlit-avramenko-2023_s0008",
+      "title": "Сторінка 8"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "щодо",
@@ -2631,7 +5700,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Які заходи щодо подолання дискримінації жінок у суспільно-політичній сфері передбачала Конвенція?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-hromadianska-gisem-2018_s0126",
+      "title": "Сторінка 66"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "якось",
@@ -2640,7 +5720,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "Якось враз знялася курява й завертівся перед­ грозовий вихор.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "9-klas-ukrajinska-mova-voron-2017_s0047",
+      "title": "Сторінка 40"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "інвалідність",
@@ -2649,7 +5740,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Альтруїзм та егоїзм у поведінці людини 139 Зараз в Україні живе понад 2,7 млн осіб, які мають інвалідність.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "6-klas-etyka-martyniuk-2023_s0140",
+      "title": "Сторінка 141"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "індивідуально",
@@ -2658,7 +5760,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "Узагалі одяг добирають індивідуально, охопити всі нюанси і тонкощі тих чи інших видів одягу неможливо.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-zakhyst-fuka-2023_s0482",
+      "title": "Сторінка 264"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "інтенсивний",
@@ -2667,7 +5780,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a2",
-    "cefr": "B1"
+    "cefr": "B1",
+    "example": "У природному русі населення розрізняють також традиційний (екстенсивний) та сучасний (інтенсивний) типи відтворення населення.",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "11-klas-geografija-pestushko-2019_s0144",
+      "title": "Сторінка 80"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "інтернет",
@@ -2676,7 +5800,18 @@
     "k": "vyv",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Використавши мережу Skype, організуйте та проведіть інтернет-дискусію на тему «Інтернет у житті сучасного школяра».",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-ukrmova-glazova-2018_s0058",
+      "title": "Сторінка 43"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "інформація",
@@ -2685,7 +5820,18 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "a1",
-    "cefr": "A1"
+    "cefr": "A1",
+    "example": "Із розвитком суспільства інформація стає універсальним ресурсом, який уже не поступається традиційним матеріальним ресурсам (нафта, газ та ін.).",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "10-klas-informatika-rudenko-2018-stand_s0002",
+      "title": "Сторінка 4"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   },
   {
     "lemma": "інформувати",
@@ -2694,6 +5840,17 @@
     "k": "other",
     "weight": 5,
     "lessonTag": "b1",
-    "cefr": "A2"
+    "cefr": "A2",
+    "example": "• Що робить держава для того, щоб інформувати людей про НС та ліквідувати її наслідки?",
+    "exampleProvenance": {
+      "source": "textbook",
+      "label": "Ukrainian school textbook",
+      "locator": "8-klas-zdorovia-vasylenko-2025_s0023",
+      "title": "Сторінка 21"
+    },
+    "exampleLicense": {
+      "status": "not_openly_licensed",
+      "useBasis": "short educational quotation with attribution"
+    }
   }
 ]

--- a/site/src/data/lexicon-sentence-inventory.json
+++ b/site/src/data/lexicon-sentence-inventory.json
@@ -1,0 +1,5746 @@
+{
+  "schema": "atlas-sentence-inventory",
+  "schemaVersion": 1,
+  "rows": [
+    {
+      "lemma": "Покрова",
+      "lemmaId": "покрова",
+      "sentence": "Хмельницький був обраний для сюжету ікони «Покрова Богородиці»?",
+      "targetForm": "Покрова",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoria-ukr-galimov-2025_s0366",
+        "title": "Сторінка 225"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "США",
+      "lemmaId": "сша",
+      "sentence": "США надають політичну підтримку та матеріально-технічну допомогу Україні у протистоянні російській агресії.",
+      "targetForm": "США",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-geografija-bojko-2018_s0367",
+        "title": "Сторінка 200"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "Хрещатик",
+      "lemmaId": "хрещатик",
+      "sentence": "Боно та Едж з U-2 виступають у київському метро на станції «Хрещатик».",
+      "targetForm": "Хрещатик",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-gisem-2024_s0514",
+        "title": "Сторінка 296"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "адміністратор",
+      "lemmaId": "адміністратор",
+      "sentence": "Адміністратор: Сало́н краси́ «Верса́ль».",
+      "targetForm": "адміністратор",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-2-00-lesson-notes_l0068_w003",
+        "title": "Lesson 68: Запис до перукарні Дати та місцевий відмінок Making a hair appointment Dates & Locative case (part 3/11)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "аналогічно",
+      "lemmaId": "аналогічно",
+      "sentence": "Вважатимемо, що x2 > x1 (випадок, коли x2 < x1, розглядається аналогічно).",
+      "targetForm": "аналогічно",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-heometriya-merzliak-2017_s0080",
+        "title": "Сторінка 79"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "апостроф",
+      "lemmaId": "апостроф",
+      "sentence": "Перепишіть слова, поставивши, де потрібно, апостроф.",
+      "targetForm": "апостроф",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0141",
+        "title": "Сторінка 91"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "аудиторія",
+      "lemmaId": "аудиторія",
+      "sentence": "Витлумачте пряме й переносне значення слова аудиторія.",
+      "targetForm": "аудиторія",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0087",
+        "title": "Сторінка 60"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "багаж",
+      "lemmaId": "багаж",
+      "sentence": "Зберіть свій багаж знань.",
+      "targetForm": "багаж",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0031",
+        "title": "Сторінка 32"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "бажання",
+      "lemmaId": "бажання",
+      "sentence": "25 потреби та бажання Подумайте про те, чого ви дуже хочете.",
+      "targetForm": "бажання",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0024",
+        "title": "Сторінка 25"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "батьків",
+      "lemmaId": "батьків",
+      "sentence": "Найбільше проблем може виникнути у ви­ падку, коли один з батьків проживає окремо від дитини.",
+      "targetForm": "батьків",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0452",
+        "title": "Сторінка 235"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "бачення",
+      "lemmaId": "бачення",
+      "sentence": "Спробуйте за допомоги ШІ створити образ майбутнього людства на основі вашого бачення.",
+      "targetForm": "бачення",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-vsesvit-schupak-2024_s0468",
+        "title": "Сторінка 252"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "безкоштовний",
+      "lemmaId": "безкоштовний",
+      "sentence": "Зазвичай компанія, що надає безкоштовний хостинг, заробляє шляхом показу реклами на сторінках, розміщених на ньому.",
+      "targetForm": "безкоштовний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0311",
+        "title": "Сторінка 205"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "бланк",
+      "lemmaId": "бланк",
+      "sentence": "Дослідіть упаковку засобу побутової хімії та заповніть бланк.",
+      "targetForm": "бланк",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-zdorovia-vorontsova-2023_s0136",
+        "title": "Сторінка 141"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ближчий",
+      "lemmaId": "ближчий",
+      "sentence": "Рум’янець на українських іконах додавав образам теплішого, більш людяного вигляду, що відбивало ближчий зв’язок між святими й вірянами.",
+      "targetForm": "ближчий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-mystetstvo-komarovska-2025_s0136",
+        "title": "Сторінка 138"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "варта",
+      "lemmaId": "варта",
+      "sentence": "Прийшло до мене втомлене поліття і роздуми достиглі принесло хвилина щастя варта півстоліття хвилина горя варта півстоліття (І.",
+      "targetForm": "варта",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0209",
+        "title": "Сторінка 150"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вартість",
+      "lemmaId": "вартість",
+      "sentence": "вартість виготовлення одного пенні розǸовна назва Ȃента сягала приǭлизно \u0014,\u001a Ȃента.",
+      "targetForm": "вартість",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-finans-plastun-2025_s0021",
+        "title": "Сторінка 22"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ведення",
+      "lemmaId": "ведення",
+      "sentence": "МГП обмежує законні засоби і методи ведення війни.",
+      "targetForm": "ведення",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0045",
+        "title": "Сторінка 25"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "великий",
+      "lemmaId": "великий",
+      "sentence": "Іван Франко — Великий Каменяр Іван Якович Франко народився 27 серпня 1856 року на Галичині, в селі Нагуєвичі.",
+      "targetForm": "великий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0158_w002",
+        "title": "Lesson 158: Іван Франко — Великий Каменяр (part 2/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "виглядати",
+      "lemmaId": "виглядати",
+      "sentence": "Інше слово, яке іноді вживають, це «виглядати».",
+      "targetForm": "виглядати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0128_w010",
+        "title": "Lesson 128: Рослини — символи України (part 10/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вийняти",
+      "lemmaId": "вийняти",
+      "sentence": "Відвести ручку затворної рами і, утримуючи її у задньому положенні, від’єднати магазин і вийняти патрон, що уткнувся.",
+      "targetForm": "вийняти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0320",
+        "title": "Сторінка 173"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "використовувати",
+      "lemmaId": "використовувати",
+      "sentence": "Вивчила я її тоді, коли вперше почала використовувати англійську мову для конкретних цілей у моєму житті.",
+      "targetForm": "використовувати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0122_w008",
+        "title": "Lesson 122: Як я вивчала і вивчила англійську мову (part 8/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вилетіти",
+      "lemmaId": "вилетіти",
+      "sentence": "Серед молекул поверхневого шару рідини завжди є такі, що «намагаються» вилетіти з рідини.",
+      "targetForm": "вилетіти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-fizyka-bariakhtar-2025_s0143",
+        "title": "Сторінка 130"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вимикати",
+      "lemmaId": "вимикати",
+      "sentence": "Чому важливо вимикати електричну лампу, коли нею не користуєшся?",
+      "targetForm": "вимикати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "1-klas-bukvar-bolshakova-2018-2_s0041",
+        "title": "Сторінка 42"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "виникати",
+      "lemmaId": "виникати",
+      "sentence": "Які проблеми можуть виникати під час проведення штучного запліднення?",
+      "targetForm": "виникати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-biologija-i-ekologija-zadorozhnij-2018-stand_s0214",
+        "title": "Сторінка 187"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вирости",
+      "lemmaId": "вирости",
+      "sentence": "Якось, реагуючи на людську нетерплячість, Блаженніший Любомир Гузар сказав: «Дайте людям вирости у свободі».",
+      "targetForm": "вирости",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0165",
+        "title": "Сторінка 117"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "витратити",
+      "lemmaId": "витратити",
+      "sentence": "А чи однакову кількість теплоти не­ обхідно витратити на плавлення різних речовин однакової маси?",
+      "targetForm": "витратити",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-fizyka-bariakhtar-2025_s0135",
+        "title": "Сторінка 122"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вишитий",
+      "lemmaId": "вишитий",
+      "sentence": "Що символізує вишитий рушник в українській культурі?",
+      "targetForm": "вишитий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-zabolotnyi-2024_s0135",
+        "title": "Сторінка 92"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вище",
+      "lemmaId": "вище",
+      "sentence": "Третє речення: День стає довший, сонце починає підніматися вище.",
+      "targetForm": "вище",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0173_w014",
+        "title": "Lesson 173: Зимовий цикл свят (part 14/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "всередині",
+      "lemmaId": "всередині",
+      "sentence": "Тому всередині джерела, крім електричних сил Fкл, діють ще й сторонні сили Fст.",
+      "targetForm": "всередині",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0064",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вчити",
+      "lemmaId": "вчити",
+      "sentence": "вивча́ти = вчи́ти = учи́ти, to learn, to study something ви́вчити (imperfective, perfective) Я вивча́ю (вчу) чудо́ву I am learning the wonderful Ukrainian украї́нську мо́ву.",
+      "targetForm": "вчити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "anna-ohoiko-1000-words-2nd-ed_e0090",
+        "title": "вивча́ти = вчи́ти = учи́ти,"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відділ",
+      "lemmaId": "відділ",
+      "sentence": "Позначений цифрою 1 відділ учень назвав стовбуром мозку.",
+      "targetForm": "відділ",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0292",
+        "title": "Сторінка 240"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відкривати",
+      "lemmaId": "відкривати",
+      "sentence": "Ми любимо подорожувати і відкривати відкрива́ти — 1) to discover; 2) to open нові культури.",
+      "targetForm": "відкривати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0164_w002",
+        "title": "Lesson 164: Інтерв’ю з Євгеном про життя в Америці (part 2/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відлік",
+      "lemmaId": "відлік",
+      "sentence": "Як ведуть відлік відстаней за паралелями і меридіанами.",
+      "targetForm": "відлік",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-heohrafiya-hilberh-2024_s0020",
+        "title": "Сторінка 23"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відстань",
+      "lemmaId": "відстань",
+      "sentence": "Яка відстань буде між ними через 35 хв?",
+      "targetForm": "відстань",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-matematyka-ister-2022_s0076",
+        "title": "Сторінка 78"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відчинити",
+      "lemmaId": "відчинити",
+      "sentence": "Тому вирішив відчинити двері та перевірити, що сталося.",
+      "targetForm": "відчинити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0208",
+        "title": "Сторінка 209"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відчуження",
+      "lemmaId": "відчуження",
+      "sentence": "Наступне п’яте речення: У Чорнобильській зоні відчуження сталась масштабна лісова пожежа.",
+      "targetForm": "відчуження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0174_w016",
+        "title": "Lesson 174: Україна в 2020 році: головні новини (part 16/25)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відчуття",
+      "lemmaId": "відчуття",
+      "sentence": "Через це серотонін і дофамін накопичуються в синаптичній щілині, викликаючи відчуття насолоди.",
+      "targetForm": "відчуття",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0394",
+        "title": "Сторінка 233"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "відійти",
+      "lemmaId": "відійти",
+      "sentence": "Далі владу поступово перейняли більшовики й, на жаль, поступо́во ― gradually Грушевський змушений був відійти.",
+      "targetForm": "відійти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0237_w014",
+        "title": "Lesson 237: Михайло Грушевський — великий історик України (part 14/28)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вінок",
+      "lemmaId": "вінок",
+      "sentence": "Знаєте вінок, вінки?",
+      "targetForm": "вінок",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0128_w007",
+        "title": "Lesson 128: Рослини — символи України (part 7/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вісім",
+      "lemmaId": "вісім",
+      "sentence": "Вас було троє, — відповів суддя, — а коржи­ ків — вісім.",
+      "targetForm": "вісім",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-etyka-martyniuk-2023_s0022",
+        "title": "Сторінка 23"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "вісімнадцять",
+      "lemmaId": "вісімнадцять",
+      "sentence": "Потреба кохання гостро спалахнула в ньому, як тільки минуло йому вісімнадцять років.",
+      "targetForm": "вісімнадцять",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-literatura-avramenko-2017_s0206",
+        "title": "Сторінка 160"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "геть",
+      "lemmaId": "геть",
+      "sentence": "Леся Українка «Contra spem spero!» «Геть думи сумні», — у першій строфі Леся звертається до строфа́ ― strophe своїх думок, дум.",
+      "targetForm": "геть",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0223_w008",
+        "title": "Lesson 223: Українська поезія. Леся Українка «Contra spem spero!» (part 8/36)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "голитися",
+      "lemmaId": "голитися",
+      "sentence": "Коли потрібно починати голитися?",
+      "targetForm": "голитися",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0120",
+        "title": "Сторінка 112"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "голосування",
+      "lemmaId": "голосування",
+      "sentence": "Голосування проводиться в день вибо­ рів або в день повторного голосування.",
+      "targetForm": "голосування",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-hromadianska-gisem-2018_s0136",
+        "title": "Сторінка 71"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "грамів",
+      "lemmaId": "грамів",
+      "sentence": " ПРИКЛАД 4 Скільки грамів 3 %-го та скільки грамів 8 %-го розчинів солі треба взяти, щоб отримати 500 г 4 %-го розчину?",
+      "targetForm": "грамів",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-algebra-merzliak-2024_s0299",
+        "title": "Сторінка 301"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "гривня",
+      "lemmaId": "гривня",
+      "sentence": "Підбиваємо підсумки Офіційною грошовою одиницею в Україні є гривня.",
+      "targetForm": "гривня",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-finans-plastun-2025_s0037",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "громадський",
+      "lemmaId": "громадський",
+      "sentence": "Публіцистика формує … думку (громадський, громадянський).",
+      "targetForm": "громадський",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-voron-2019_s0388",
+        "title": "Сторінка 252"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "грубий",
+      "lemmaId": "грубий",
+      "sentence": "Те саме можна сказати й про слова грубий – товстий.",
+      "targetForm": "грубий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "antonenko-davydovych-yak-my-hovorymo_p138",
+        "title": "Antonenko-Davydovych «Як ми говоримо», p. 138"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дальший",
+      "lemmaId": "дальший",
+      "sentence": "У тритомному Російсько–українському словнику на першому місці стоїть слово дальший, на другому – подальший, Словник за редакцією А.",
+      "targetForm": "дальший",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "antonenko-davydovych-yak-my-hovorymo_p053",
+        "title": "Antonenko-Davydovych «Як ми говоримо», p. 53"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дані",
+      "lemmaId": "дані",
+      "sentence": "Складний запит для таблиць МАГАЗИНИ і КАДРИ, за яким формуються дані, наведено в табл.",
+      "targetForm": "дані",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0046",
+        "title": "Сторінка 31"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дарувати",
+      "lemmaId": "дарувати",
+      "sentence": "дарувати буду дарувати, подарую подарувати даруватиму 2.",
+      "targetForm": "дарувати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0099_w019",
+        "title": "Lesson 99: План подорожі (Голосове повідомлення №4) Travel plan (Voice message №4) (part 19/21)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дата",
+      "lemmaId": "дата",
+      "sentence": "Моволюбка Дата: Четвер, 25.10.2018, 14:48 | Повідомлення # 16 Група: Користувачі Повідомлень: 30 Статус: Offline Не бачу проблем.",
+      "targetForm": "дата",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0038",
+        "title": "Сторінка 29"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "два",
+      "lemmaId": "два",
+      "sentence": "два two Два моро́зива, будь ла́ска.",
+      "targetForm": "два",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "anna-ohoiko-1000-words-2nd-ed_e0192",
+        "title": "два"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дедалі",
+      "lemmaId": "дедалі",
+      "sentence": "Слово «дедалі» вживайте з прикметником чи прислівником у формі вищого ви́щий сту́пінь порівня́ння — ступеня порівняння.",
+      "targetForm": "дедалі",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0136_w014",
+        "title": "Lesson 136: Екологічні тренди та екологічні традиції в Україні (part 14/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дешевий",
+      "lemmaId": "дешевий",
+      "sentence": "Знання про хімічну рівновагу допомагає організувати більш дешевий і зручний технологічний процес одержання речовин.",
+      "targetForm": "дешевий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-himia-grygorovych-2019_s0084",
+        "title": "Сторінка 61"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "деякий",
+      "lemmaId": "деякий",
+      "sentence": "Через деякий час це потепління зміниться похолоданням.",
+      "targetForm": "деякий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-geografija-pestushko-2019_s0052",
+        "title": "Сторінка 31"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "джерело",
+      "lemmaId": "джерело",
+      "sentence": "Вибрати джерело відеозапису.",
+      "targetForm": "джерело",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0172",
+        "title": "Сторінка 149"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дивувати",
+      "lemmaId": "дивувати",
+      "sentence": "169 Мистецтво дивувати і радувати Цирк запрошує на свято .",
+      "targetForm": "дивувати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-mystetstvo-rublia-2022_s0003",
+        "title": "Сторінка 4"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "довкілля",
+      "lemmaId": "довкілля",
+      "sentence": "38 Що я знаю про еколог³ю Поміркуєте про вплив діяльності людини на стан довкілля, про Європейський зелений курс.",
+      "targetForm": "довкілля",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-zdorovia-vasylenko-2025_s0042",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дозволяти",
+      "lemmaId": "дозволяти",
+      "sentence": "5 пам’ятати — … відлітати — … руйнувати — … нагріватись — … вигравати — … дозволяти — … зустрічати — ...",
+      "targetForm": "дозволяти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-ponomarova-2020-1_s0119",
+        "title": "Сторінка 120"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дозвілля",
+      "lemmaId": "дозвілля",
+      "sentence": "Як проводили дозвілля робітники й селяни?",
+      "targetForm": "дозвілля",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-hlibovska-2024_s0157",
+        "title": "Сторінка 90"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "доїхати",
+      "lemmaId": "доїхати",
+      "sentence": "А ви не підкажете, як ми можемо доїхати до Чигирина?",
+      "targetForm": "доїхати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0185_w016",
+        "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 16/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "думати",
+      "lemmaId": "думати",
+      "sentence": "Функція театру в тому, щоб збуджувати людей, змушувати їх думати… Бернард Шоу  Бургтеатр у Відні, де у 1913 р.",
+      "targetForm": "думати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0403",
+        "title": "Сторінка 225"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "діаспора",
+      "lemmaId": "діаспора",
+      "sentence": "Історично українська діаспора формувалася під впливом чотирьох основних міграційних хвиль (див.",
+      "targetForm": "діаспора",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-geografiia-boiko-2026_s0061",
+        "title": "Сторінка 33"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дівчина",
+      "lemmaId": "дівчина",
+      "sentence": "\u0003  Чому роман має назву «Дівчина з ведмедиком»?",
+      "targetForm": "дівчина",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrlit-borzenko-2019-prof_s0146",
+        "title": "Сторінка 80"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дідусь",
+      "lemmaId": "дідусь",
+      "sentence": "Ще дідусь і не отримав твого листа, а може, і не зразу відповість.",
+      "targetForm": "дідусь",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-zabolotnyi-2025_s0060",
+        "title": "Сторінка 44"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "дім",
+      "lemmaId": "дім",
+      "sentence": "Шевчука «Дім на горі» якраз і представляє життя людей у такому незвичайному поєднанні.",
+      "targetForm": "дім",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrlit-borzenko-2019-prof_s0401",
+        "title": "Сторінка 211"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "діюча",
+      "lemmaId": "діюча",
+      "sentence": "Перша постійно діюча марксистська група на українських землях під назвою «Російська група соціал-демократів» виникла в 1893 р.",
+      "targetForm": "діюча",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-gisem-2017_s0293",
+        "title": "Сторінка 162"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "забирати",
+      "lemmaId": "забирати",
+      "sentence": "Іду в садік забирати малу.",
+      "targetForm": "забирати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0135_w004",
+        "title": "Lesson 135: Суржик в українській мові (part 4/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "завгодно",
+      "lemmaId": "завгодно",
+      "sentence": "При необмеженому збільшенні кількості сторін правильного многокутника його периметр буде як завгодно мало відрізнятися від довжини кола.",
+      "targetForm": "завгодно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-heometriya-merzliak-2017_s0063",
+        "title": "Сторінка 62"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "загадковий",
+      "lemmaId": "загадковий",
+      "sentence": "Фільм розповідає про сучасного школяра Вітькà, який через загадковий портал часу потрапляє в минуле — на тисячу років назад.",
+      "targetForm": "загадковий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-savchenko-2021-2_s0054",
+        "title": "Сторінка 55"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "заздрість",
+      "lemmaId": "заздрість",
+      "sentence": "45 НАРОДНІ КАЗКИ Прийнято розрізняти заздрість злобну (чорну) і незлобну (білу).",
+      "targetForm": "заздрість",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-zabolotnyi-2022_s0051",
+        "title": "Сторінка 45"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "запис",
+      "lemmaId": "запис",
+      "sentence": "Зупинити запис вибором кнопки .",
+      "targetForm": "запис",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-informatyka-ryvkind-2017_s0135",
+        "title": "Сторінка 86"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "затримка",
+      "lemmaId": "затримка",
+      "sentence": "Якщо затримка не усунулася, то необхідно з’ясувати причину її виникнення й усунути затримку.",
+      "targetForm": "затримка",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0319",
+        "title": "Сторінка 173"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "захист",
+      "lemmaId": "захист",
+      "sentence": "Визнач­те, чи є в запропонованих ситуаціях порушення права на захист.",
+      "targetForm": "захист",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0194",
+        "title": "Сторінка 103"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "заява",
+      "lemmaId": "заява",
+      "sentence": "Заява може містити перелік документів, що додають до неї.",
+      "targetForm": "заява",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-avramenko-2017_s0101",
+        "title": "Сторінка 70"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "зберігається",
+      "lemmaId": "зберігається",
+      "sentence": "Подвоєння зберігається у всіх формах слова (п’ять тонн, сім ванн) .",
+      "targetForm": "зберігається",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-litvinova-2022_s0072",
+        "title": "Сторінка 67"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "звичайно",
+      "lemmaId": "звичайно",
+      "sentence": "навести́ при́клад ― to provide an example Олеся: Звичайно, звичайно.",
+      "targetForm": "звичайно",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0195_w007",
+        "title": "Lesson 195: Українці в ПАР: розмова з Олесею Лобшер (part 7/27)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "звідки",
+      "lemmaId": "звідки",
+      "sentence": "У складнопідрядних реченнях з підрядними місця сполучні слова де, куди, звідки є прислівниками й виконують синтаксичну роль обставини.",
+      "targetForm": "звідки",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0135",
+        "title": "Сторінка 98"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здебільшого",
+      "lemmaId": "здебільшого",
+      "sentence": "Тому великі міста країни мають, здебільшого, погану якість повітря.",
+      "targetForm": "здебільшого",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0253",
+        "title": "Сторінка 150"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здоровий",
+      "lemmaId": "здоровий",
+      "sentence": "Пісня «Будь здоровий!» (музика і слова Сергія Дяченка).",
+      "targetForm": "здоровий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-mystetstvo-rublia-2022_s0198",
+        "title": "Сторінка 198"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здійснено",
+      "lemmaId": "здійснено",
+      "sentence": "Петлюри було здійснено низку заходів, покликаних викорінити в Армії УНР отаманщину та перетворити її на регулярне військо.",
+      "targetForm": "здійснено",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-istorija-ukrajiny-gisem-2018_s0125",
+        "title": "Сторінка 68"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "здійснювати",
+      "lemmaId": "здійснювати",
+      "sentence": "Суб’єкти господарювання можуть здійснювати свою діяльність не лише на основі права власності.",
+      "targetForm": "здійснювати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0330",
+        "title": "Сторінка 172"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "змінити",
+      "lemmaId": "змінити",
+      "sentence": "Створення закладки на відкриту сторінку: 1 – Панель закладок; 2 – Вікно 2 Закладку додано; 3 – Кнопка 3 Змінити закладку для цієї вкладки 1.",
+      "targetForm": "змінити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0012",
+        "title": "Сторінка 14"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "знищити",
+      "lemmaId": "знищити",
+      "sentence": "Радикали прагнули продовжити революцію та знищити самодержавство.",
+      "targetForm": "знищити",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-gisem-2017_s0394",
+        "title": "Сторінка 218"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кадр",
+      "lemmaId": "кадр",
+      "sentence": "75 Кадр із фільму «Захар Беркут» Кадр із фільму-серіалу «Роксолана» З історичним жанром кіно часто поєднується пригодницький.",
+      "targetForm": "кадр",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-mystetstvo-rublia-2023_s0076",
+        "title": "Сторінка 77"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "календарний",
+      "lemmaId": "календарний",
+      "sentence": "Чому важливо відрізняти історичний і календарний час?",
+      "targetForm": "календарний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-istoriya-schupak-2022_s0052",
+        "title": "Сторінка 54"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "камін",
+      "lemmaId": "камін",
+      "sentence": "Коефіцієнт корисної дії нагрівника Багато людей вважають, що в приватному будинку обов’язково має бути камін.",
+      "targetForm": "камін",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-fizyka-bariakhtar-2025_s0160",
+        "title": "Сторінка 146"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "квасоля",
+      "lemmaId": "квасоля",
+      "sentence": "До продуктів з високим вмістом білків належать м’ясо, риба, молоко, квасоля, горох, соя.",
+      "targetForm": "квасоля",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0199",
+        "title": "Сторінка 200"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "керівний",
+      "lemmaId": "керівний",
+      "sentence": "Квіти щасливі, — сказав керівний робот корабля.",
+      "targetForm": "керівний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-avramenko-2024_s0317",
+        "title": "Сторінка 223"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кислий",
+      "lemmaId": "кислий",
+      "sentence": "Червоний укаже на кислий ґрунт, синій – на слабокислий, а зелений – на нейтральний.",
+      "targetForm": "кислий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-heohrafiya-hilberh-2025_s0193",
+        "title": "Сторінка 139"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "клавіатура",
+      "lemmaId": "клавіатура",
+      "sentence": "КЛАВІАТУРА Поміркуйте ● Значення яких властивостей користувач враховує під час вибору клавіатури для комп’ютера?",
+      "targetForm": "клавіатура",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-informatyka-ryvkind-2025_s0085",
+        "title": "Сторінка 64"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "колего",
+      "lemmaId": "колего",
+      "sentence": "Проте прізвище може набувати форми називного відмінка: колего Євгене Онищук, пане Коваль.",
+      "targetForm": "колего",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrmova-avramenko-2025_s0180",
+        "title": "Сторінка 134"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кольоровий",
+      "lemmaId": "кольоровий",
+      "sentence": "Виберіть стиль SmartArt — Плоска сцена, кольорову гаму — Кольоровий діапазон — кольори акценту 5–6.",
+      "targetForm": "кольоровий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-informatyka-ryvkind-2017_s0116",
+        "title": "Сторінка 75"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кома",
+      "lemmaId": "кома",
+      "sentence": "На місці крапок має стояти А кома Б тире В кома й тире Г крапка й тире 7.",
+      "targetForm": "кома",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0206",
+        "title": "Сторінка 147"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "коментар",
+      "lemmaId": "коментар",
+      "sentence": "Ваш коментар \u0007Прочитайте текст, укладіть пам’ятку «Як працювати над основною частиною виступу».",
+      "targetForm": "коментар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-voron-2019_s0057",
+        "title": "Сторінка 40"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "контекст",
+      "lemmaId": "контекст",
+      "sentence": "Контекст Основним способом точної передачі значення слова є контекст.",
+      "targetForm": "контекст",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-zabolotnij-2018_s0023",
+        "title": "Сторінка 18"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "контролювати",
+      "lemmaId": "контролювати",
+      "sentence": "Вміння грати певні ролі важливе й під час конфліктів, коли важ­ ко контролювати свої емоції.",
+      "targetForm": "контролювати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-zdorovia-vasylenko-2025_s0139",
+        "title": "Сторінка 122"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кориця",
+      "lemmaId": "кориця",
+      "sentence": "щеплення, гвоздика, кориця, імбир, перець Поєднайте числівники та іменники: 1.",
+      "targetForm": "кориця",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0138_w019",
+        "title": "Lesson 138: Як пережити зиму в Україні? (part 19/20)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "космос",
+      "lemmaId": "космос",
+      "sentence": "Космічні апарати для польоту людей у космос називають кос­ мічними кораблями.",
+      "targetForm": "космос",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-piznaemo-pryrodu-korshevniuk-2023_s0138",
+        "title": "Сторінка 140"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кошик",
+      "lemmaId": "кошик",
+      "sentence": "Отже, шинку і ковбасу кладуть у кошик, і також можна покласти ще будь-яку їжу, яку готували.",
+      "targetForm": "кошик",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0190_w008",
+        "title": "Lesson 190: Великодній кошик (part 8/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "крайній",
+      "lemmaId": "крайній",
+      "sentence": "Пересуватися на скутері, мопеді дозволено тільки по крайній правій смузі, не дозволено на автомагістралях !",
+      "targetForm": "крайній",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-zdorovia-vasylenko-2025_s0040",
+        "title": "Сторінка 36"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "культура",
+      "lemmaId": "культура",
+      "sentence": "У широкому сенсі поняття ● культура означає все, що створене людиною, а не природою.",
+      "targetForm": "культура",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-hromadianska-osvita-vasylkiv-2025_s0006",
+        "title": "Сторінка 6"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "культурний",
+      "lemmaId": "культурний",
+      "sentence": "Чинники ЧИННИКИ, ЩО ВПЛИВАЛИ НА КУЛЬТУРНИЙ ПРОЦЕС НА УКРАЇНСЬКИХ ЗЕМЛЯХ у XIV—XV ст.",
+      "targetForm": "культурний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-istoria-ukr-galimov-2024_s0285",
+        "title": "Сторінка 193"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "купатися",
+      "lemmaId": "купатися",
+      "sentence": "Купатися можна у вбиральні, на кухні, в кабінеті чи в конторі – за вибором.",
+      "targetForm": "купатися",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zarlit-voloschuk-2024_s0262",
+        "title": "Сторінка 185"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "кілька",
+      "lemmaId": "кілька",
+      "sentence": "кі́лька = де́кілька some У ме́не є кі́лька (де́кілька) I have some questions.",
+      "targetForm": "кілька",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "anna-ohoiko-1000-words-2nd-ed_e0391",
+        "title": "кі́лька = де́кілька"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лавка",
+      "lemmaId": "лавка",
+      "sentence": "У посадах поряд із будинком найчастіше розміщувалася реміснича майстерня або торговельна лавка.",
+      "targetForm": "лавка",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-istoria-ukr-galimov-2024_s0112",
+        "title": "Сторінка 76"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лагідний",
+      "lemmaId": "лагідний",
+      "sentence": "Кетчуп «Лагідний» доповнює будь-який гарнір і м’ясо.",
+      "targetForm": "лагідний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0112",
+        "title": "Сторінка 70"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лекція",
+      "lemmaId": "лекція",
+      "sentence": "Це монологічний вид виступу, але погано, якщо лекція перетворюється тільки на монолог викладача без зворотного зв’язку з аудиторією.",
+      "targetForm": "лекція",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-voron-2019_s0119",
+        "title": "Сторінка 82"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "листок",
+      "lemmaId": "листок",
+      "sentence": "Маргарита вирвала з блокнота листок, написала: «ЩО ВСЕ?» – склала його і кинула Флоріанові.",
+      "targetForm": "листок",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-zarubizhna-literatura-kovbasenko-2026_s0136",
+        "title": "Сторінка 76"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "листя",
+      "lemmaId": "листя",
+      "sentence": "Також заборонено спалювати опале листя через небезпеку виникнення пожеж і забруднення повітря.",
+      "targetForm": "листя",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-zdorovia-vorontsova-2022_s0192",
+        "title": "Сторінка 193"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лице",
+      "lemmaId": "лице",
+      "sentence": "Запалене лице було гарне, але дуже молоде.",
+      "targetForm": "лице",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrlit-avramenko-2025_s0239",
+        "title": "Сторінка 139"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ложка",
+      "lemmaId": "ложка",
+      "sentence": "Тобі знадобляться: помірно гаряча вода, чашка, секундомір, металева ложка.",
+      "targetForm": "ложка",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0077",
+        "title": "Сторінка 78"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "люблять",
+      "lemmaId": "люблять",
+      "sentence": "І це сва́рка — quarrel прислів’я говорить про те, що українці не люблять суперечки, не люблять конфлікти.",
+      "targetForm": "люблять",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0133_w008",
+        "title": "Lesson 133: Прислів’я та приказки Частина 2 (part 8/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "літр",
+      "lemmaId": "літр",
+      "sentence": "Потрібно одержати в одній із цих посудин 1 літр рідини.",
+      "targetForm": "літр",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-informatyka-ryvkind-2022_s0186",
+        "title": "Сторінка 185"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "лічильник",
+      "lemmaId": "лічильник",
+      "sentence": "Найчастіше первинний ключ складається з одного поля, а в ролі первинного ключа використовується поле типу Лічильник.",
+      "targetForm": "лічильник",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-informatika-rudenko-2018-stand_s0104",
+        "title": "Сторінка 99"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "малі",
+      "lemmaId": "малі",
+      "sentence": "Були ми всі тоді трудящі чи малі.",
+      "targetForm": "малі",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrlit-borzenko-2019-prof_s0271",
+        "title": "Сторінка 140"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мандрівник",
+      "lemmaId": "мандрівник",
+      "sentence": "Знайдіть інформацію, на що витрачає кошти мандрівник, готуючись до підйому на найвищу вершину світу.",
+      "targetForm": "мандрівник",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-heohrafiya-hilberh-2024_s0048",
+        "title": "Сторінка 50"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "маршрут",
+      "lemmaId": "маршрут",
+      "sentence": "Вам потрібно прокласти маршрут подорожі.",
+      "targetForm": "маршрут",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-istoriya-schupak-2022_s0081",
+        "title": "Сторінка 83"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мед",
+      "lemmaId": "мед",
+      "sentence": "ДЛЯ ДОПИТЛИВИХ Виявлення глюкози в мед\u0003 Глюкозу виявляють у мед\u0003 так.",
+      "targetForm": "мед",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-khimiya-popel-2017_s0191",
+        "title": "Сторінка 192"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "методологія",
+      "lemmaId": "методологія",
+      "sentence": "Методологія — принципи, сукупність ідей, методів і засобів, які визначають підхід до розробки програмного забезпечення.",
+      "targetForm": "методологія",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0394",
+        "title": "Сторінка 252"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мешканець",
+      "lemmaId": "мешканець",
+      "sentence": "Плекаймо слово і ЖИТЕЛЬ ЧИ МЕШКАНЕЦЬ?",
+      "targetForm": "мешканець",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-voron-2017_s0272",
+        "title": "Сторінка 210"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мило",
+      "lemmaId": "мило",
+      "sentence": "Що таке собаче мило?",
+      "targetForm": "мило",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-kravtsova-2020-1_s0049",
+        "title": "Сторінка 51"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "миритися",
+      "lemmaId": "миритися",
+      "sentence": "Прийшов битися чи миритися?",
+      "targetForm": "миритися",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-savchenko-2020-2_s0043",
+        "title": "Сторінка 44"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мислити",
+      "lemmaId": "мислити",
+      "sentence": "Це здатність мислити вільно, знаходити свіжі ідеї та оригінальні рішення, швидко пристосовуватися до змін і нових обставин.",
+      "targetForm": "мислити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-zdorovia-vorontsova-2023_s0178",
+        "title": "Сторінка 183"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мох",
+      "lemmaId": "мох",
+      "sentence": "Вербинка обережно підважила мох.",
+      "targetForm": "мох",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-avramenko-2022_s0094",
+        "title": "Сторінка 90"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "музей",
+      "lemmaId": "музей",
+      "sentence": "Пригадай, що таке музей.",
+      "targetForm": "музей",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-savchenko-2021-2_s0045",
+        "title": "Сторінка 46"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "міроприємство",
+      "lemmaId": "міроприємство",
+      "sentence": "Помилку допущено в рядку А ухвалити рішення Б запобігти помилці В здійснити контроль Г відвідати міроприємство 5.",
+      "targetForm": "міроприємство",
+      "cefr": null,
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrajinska-mova-avramenko-2018_s0028",
+        "title": "Сторінка 21"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "місяць",
+      "lemmaId": "місяць",
+      "sentence": "Шляхом тривалих спостережень вони визначили надійні одиниці часу: добу, рік, місяць.",
+      "targetForm": "місяць",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-fizyka-bariakhtar-2024_s0093",
+        "title": "Сторінка 92"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "мішати",
+      "lemmaId": "мішати",
+      "sentence": "Складіть і запишіть по одному реченню з такими словами: пощастить, повезе, заважати, мішати.",
+      "targetForm": "мішати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-zabolotnyi-2023_s0035",
+        "title": "Сторінка 37"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наближення",
+      "lemmaId": "наближення",
+      "sentence": "Чому глобалізацію розглядають як «скорочення світу» і «наближення речей»?",
+      "targetForm": "наближення",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-geografiia-boiko-2026_s0163",
+        "title": "Сторінка 87"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "набрати",
+      "lemmaId": "набрати",
+      "sentence": "Набрати з колодязя повне відро води.",
+      "targetForm": "набрати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-informatyka-ryvkind-2022_s0214",
+        "title": "Сторінка 213"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наведено",
+      "lemmaId": "наведено",
+      "sentence": "Програму мовою Python обчислення чисел Фібоначчі на основі рекурентного підходу наведено на рис.",
+      "targetForm": "наведено",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0172",
+        "title": "Сторінка 115"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "нагода",
+      "lemmaId": "нагода",
+      "sentence": "І одного разу йому випала нагода поїхати до Петербурга і працювати там при царському дворі.",
+      "targetForm": "нагода",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0155_w008",
+        "title": "Lesson 155: Григорій Сковорода — мандрівний філософ (part 8/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "надіслано",
+      "lemmaId": "надіслано",
+      "sentence": "У діловому листуванні трапляється читати: \"Книжки надіслано накладною платою\".",
+      "targetForm": "надіслано",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "antonenko-davydovych-yak-my-hovorymo_p032",
+        "title": "Antonenko-Davydovych «Як ми говоримо», p. 32"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "називний",
+      "lemmaId": "називний",
+      "sentence": "три, третій Відмінок Кількісні числівники Порядкові числівники Однина Множина Називний скільки?",
+      "targetForm": "називний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-avramenko-2023_s0241",
+        "title": "Сторінка 225"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "найвищий",
+      "lemmaId": "найвищий",
+      "sentence": "137 Прикметник Н Найвищий ступінь порівняння вказує, що певний предмет переважає всі інші за якою-небудь ознакою.",
+      "targetForm": "найвищий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-zabolotnyi-2020_s0139",
+        "title": "Сторінка 137"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "найняти",
+      "lemmaId": "найняти",
+      "sentence": "Скільки ж необхідно найняти робітників на кухню?",
+      "targetForm": "найняти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ekonomika-krupska-2018_s0143",
+        "title": "Сторінка 76"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наліво",
+      "lemmaId": "наліво",
+      "sentence": "Поверніть ліворуч (наліво), ідіть прямо по вулиці Зеленій.",
+      "targetForm": "наліво",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-1-00-lesson-notes_l0019_w005",
+        "title": "Lesson 19: Asking for a phone number in Ukrainian (part 5/7)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "намалювати",
+      "lemmaId": "намалювати",
+      "sentence": "Операції класу: + намалювати (фігура Прямокутник = квадрат, колірФарбування Соlоr = (255,0,0)) Приклад 5.",
+      "targetForm": "намалювати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0370",
+        "title": "Сторінка 238"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "напруження",
+      "lemmaId": "напруження",
+      "sentence": "Саме із цієї миті відбувається перелом у сюжеті та спадає напруження, яке збільшувалося постійно впродовж усього твору.",
+      "targetForm": "напруження",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0248",
+        "title": "Сторінка 188"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "народити",
+      "lemmaId": "народити",
+      "sentence": "Сніг, щука, юнак, берег, рік, книга, радити, Оленка, допомога, їздити, народити, могти.",
+      "targetForm": "народити",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-avramenko-2022_s0117",
+        "title": "Сторінка 114"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наскільки",
+      "lemmaId": "наскільки",
+      "sentence": "взаємовідно́шення — relationship Наскільки часто ви будете слухати подкаст, настільки добре будете розуміти українську мову.",
+      "targetForm": "наскільки",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0145_w013",
+        "title": "Lesson 145: Українські народні музичні інструменти (part 13/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "наступний",
+      "lemmaId": "наступний",
+      "sentence": "Максим: _________________________ (Наступний п’ятниця) ми поїдемо на фестиваль ____________________ (борщ) в Тернопільській області.",
+      "targetForm": "наступний",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-2-00-lesson-notes_l0047_w007",
+        "title": "Lesson 47: Гастрономічні фестивалі Родовий відмінок Food festivals Genitive case (part 7/9)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "натуральний",
+      "lemmaId": "натуральний",
+      "sentence": "Натуральний каучук був уперше описаний французьким астрономом та мандрівником Шарлем Марі де ла Кондоміном 1751 року.",
+      "targetForm": "натуральний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-himija-grygorovych-2018_s0231",
+        "title": "Сторінка 205"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "недостатньо",
+      "lemmaId": "недостатньо",
+      "sentence": "Цього недостатньо — це особлива структура речення, тому що недоста́тньо — insufficient, not enough ми вживаємо слово «це» в родовому відмінку — цього.",
+      "targetForm": "недостатньо",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0178_w020",
+        "title": "Lesson 178: Як ефективніше вчитися? (part 20/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "неістота",
+      "lemmaId": "неістота",
+      "sentence": "Визначте групу за значенням істота/неістота.",
+      "targetForm": "неістота",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-litvinova-2023_s0129",
+        "title": "Сторінка 122"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "нижчий",
+      "lemmaId": "нижчий",
+      "sentence": "З територій, де тиск вищий, повітря переміщується на території, де він нижчий.",
+      "targetForm": "нижчий",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-piznaiemo-pryrodu-korshevniuk-2022_s0114",
+        "title": "Сторінка 115"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "низько",
+      "lemmaId": "низько",
+      "sentence": "Карпо ненавидів тих, хто панові дуже низько кланявся, до землі нагинався.",
+      "targetForm": "низько",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-avramenko-2022_s0012",
+        "title": "Сторінка 12"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ніби",
+      "lemmaId": "ніби",
+      "sentence": "Працюй так, ніби тобі не потрібні не можна повернути: час, слово і гроші… Танцюй так, ніби можливість.",
+      "targetForm": "ніби",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0106_w012",
+        "title": "Lesson 106: Події на вихідних Weekend events Negative adverbs and pronouns in Ukrainian (part 12/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ніхто",
+      "lemmaId": "ніхто",
+      "sentence": "ніхто́ nobody, no one Ніхто́ мене́ не зупи́нить.",
+      "targetForm": "ніхто",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "anna-ohoiko-1000-words-2nd-ed_e0518",
+        "title": "ніхто́"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "обманювати",
+      "lemmaId": "обманювати",
+      "sentence": "Вішати на вуха ло5кшину — обманювати, відволікати від суті розмови, вводити в оману.",
+      "targetForm": "обманювати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-glazova-2019_s0319",
+        "title": "Сторінка 218"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "оболонка",
+      "lemmaId": "оболонка",
+      "sentence": "Під склерою розташована судинна оболонка, де проходять кровоносні судини.",
+      "targetForm": "оболонка",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0208",
+        "title": "Сторінка 168"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "овес",
+      "lemmaId": "овес",
+      "sentence": "Зеленеє жито ще й овес — Тут зібрався рід наш увесь.",
+      "targetForm": "овес",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-mystetstvo-komarovska-2025_s0014",
+        "title": "Сторінка 16"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "одягатися",
+      "lemmaId": "одягатися",
+      "sentence": "Завоювавши Персію, Александр почав одягатися як перський шахиншах та одружився із двома персіянками.",
+      "targetForm": "одягатися",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-istoriya-gisem-2023_s0187",
+        "title": "Сторінка 140"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ой",
+      "lemmaId": "ой",
+      "sentence": "Ой радуйся, земле, Син Божий народився.",
+      "targetForm": "ой",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0014",
+        "title": "Сторінка 14"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "опонент",
+      "lemmaId": "опонент",
+      "sentence": "Домашнє завдання 737 Яким повинен бути ідеальний опонент у дискусії?",
+      "targetForm": "опонент",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-karaman-2018_s0476",
+        "title": "Сторінка 265"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "орендар",
+      "lemmaId": "орендар",
+      "sentence": "Отже, слова орендар, дипломант, касир мають чоловічий рід, але так можна називати й чоловіків, і жінок.",
+      "targetForm": "орендар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0256",
+        "title": "Сторінка 181"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "основа",
+      "lemmaId": "основа",
+      "sentence": "У якому слові основа закінчується на м’який приголосний?",
+      "targetForm": "основа",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0051",
+        "title": "Сторінка 53"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "основний",
+      "lemmaId": "основний",
+      "sentence": "Це визначає основний метод правового регулювання, який використовує фінансове право, — імперативний метод, або метод субординації, владних приписів.",
+      "targetForm": "основний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0043",
+        "title": "Сторінка 24"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "офіс",
+      "lemmaId": "офіс",
+      "sentence": "Ми маєм офіс в Києві і офіс в Торонто.",
+      "targetForm": "офіс",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0199_w013",
+        "title": "Lesson 199: Українці в Канаді: розмова з Оксаною Грициною (part 13/33)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "палати",
+      "lemmaId": "палати",
+      "sentence": "У складі апеляційного суду можуть утворю­ ватися судові палати з розгляду окремих ка­ тегорій справ.",
+      "targetForm": "палати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-pravoznavstvo-lukianchykov-2018_s0506",
+        "title": "Сторінка 225"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "перевантаження",
+      "lemmaId": "перевантаження",
+      "sentence": "12.11 і зробіть висновки: куди напрямлене прискорення руху тіла, коли тіло зазнає перевантаження?",
+      "targetForm": "перевантаження",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-fizyka-barjakhtar-2018_s0120",
+        "title": "Сторінка 76"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "переглянути",
+      "lemmaId": "переглянути",
+      "sentence": "Звертаємо увагу, що результати заповнення форми можуть переглянути тільки автор/ авторка і користувачі, яким надано доступ редагування форми.",
+      "targetForm": "переглянути",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0280",
+        "title": "Сторінка 244"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "повідомлення",
+      "lemmaId": "повідомлення",
+      "sentence": "Як людина сприймає повідомлення?",
+      "targetForm": "повідомлення",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-informatyka-ryvkind-2022_s0012",
+        "title": "Сторінка 14"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "покращення",
+      "lemmaId": "покращення",
+      "sentence": "5 порад для покращення української мови Добре, отже, ви розумієте, що я кажу українською на подкасті.",
+      "targetForm": "покращення",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0137_w002",
+        "title": "Lesson 137: 5 порад для покращення української мови (part 2/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "полуничний",
+      "lemmaId": "полуничний",
+      "sentence": "Беатріс купила в сільському магазині морозиво і зробила полуничний полуни́чний — strawberry (adjective) коктейль.",
+      "targetForm": "полуничний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0185_w011",
+        "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 11/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "поліція",
+      "lemmaId": "поліція",
+      "sentence": "У роки революції російські чорносотенні організації вчинили єврейські погроми, причому поліція трималася ­осторонь цих подій.",
+      "targetForm": "поліція",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-gisem-2017_s0421",
+        "title": "Сторінка 233"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "порівнювати",
+      "lemmaId": "порівнювати",
+      "sentence": "Чи потрібно постійно порівнювати себе з іншими?",
+      "targetForm": "порівнювати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrlit-zabolotnyi-2022_s0051",
+        "title": "Сторінка 45"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "постійно",
+      "lemmaId": "постійно",
+      "sentence": "Після евакуації пораненого в укриття потрібно постійно дбати про власну безпеку і безпеку пораненого.",
+      "targetForm": "постійно",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0197",
+        "title": "Сторінка 105"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "початися",
+      "lemmaId": "початися",
+      "sentence": "Причин ритмічності кілька: по-перше, процес не може початися знову, доки не завершено попередній.",
+      "targetForm": "початися",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-biologiia-i-ekologia-shalamov-2019_s0118",
+        "title": "Сторінка 72"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "починати",
+      "lemmaId": "починати",
+      "sentence": "У якому віці можна починати фарбувати волосся?",
+      "targetForm": "починати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0120",
+        "title": "Сторінка 112"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "поширити",
+      "lemmaId": "поширити",
+      "sentence": "Із метою відволікти населення від боротьби проти самодержавства царський уряд намагався поширити на українські землі антисемітські настрої.",
+      "targetForm": "поширити",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-istorija-ukrajini-gisem-2017_s0421",
+        "title": "Сторінка 233"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "поїду",
+      "lemmaId": "поїду",
+      "sentence": "Запряжу я козу в віз Та й поїду по рогіз.",
+      "targetForm": "поїду",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-mystetstvo-rublia-2023_s0056",
+        "title": "Сторінка 57"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "правопис",
+      "lemmaId": "правопис",
+      "sentence": "Перевірити правопис слова можна в орфографічному словнику .",
+      "targetForm": "правопис",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-litvinova-2022_s0122",
+        "title": "Сторінка 117"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "працюємо",
+      "lemmaId": "працюємо",
+      "sentence": "Працюємо в малих групах.",
+      "targetForm": "працюємо",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoria-ukr-galimov-2025_s0408",
+        "title": "Сторінка 248"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "препарат",
+      "lemmaId": "препарат",
+      "sentence": "Тривимірне зобра­ ження того, як наночастинки, що містять протипухлинний препарат, оточують ракову клітину та вбивають пухлину 111 § 18.",
+      "targetForm": "препарат",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-fizyka-bariakhtar-2025_s0125",
+        "title": "Сторінка 114"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "привезти",
+      "lemmaId": "привезти",
+      "sentence": "Які сувеніри привезти з України?",
+      "targetForm": "привезти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0130_w016",
+        "title": "Lesson 130: Які сувеніри привезти з України? (part 16/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "привітання",
+      "lemmaId": "привітання",
+      "sentence": "Прочитайте фрагмент привітання Президента України з нагоди Дня Соборності.",
+      "targetForm": "привітання",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrmova-zabolotnyi-2025_s0341",
+        "title": "Сторінка 275"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "прийняти",
+      "lemmaId": "прийняти",
+      "sentence": "Для цього їй довелося прийняти іслам.",
+      "targetForm": "прийняти",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0152_w009",
+        "title": "Lesson 152: Роксолана — La Sultana Rossa (part 9/15)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "прикраса",
+      "lemmaId": "прикраса",
+      "sentence": "Д Різдвяна прикраса на палиці, сповіщає про народження Ісуса Христа.",
+      "targetForm": "прикраса",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0214_w021",
+        "title": "Lesson 214: Символи Різдва в Україні (part 21/24)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приспів",
+      "lemmaId": "приспів",
+      "sentence": "(Приспів) Та кладіть калачі з ярої пшениці.",
+      "targetForm": "приспів",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-zabolotnyi-2023_s0026",
+        "title": "Сторінка 27"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приховати",
+      "lemmaId": "приховати",
+      "sentence": "Коли потрібно приховати деякі поля, їх слід виділити й у групі Записи виконати команду Додатково → Приховати поля.",
+      "targetForm": "приховати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0039",
+        "title": "Сторінка 26"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приєднати",
+      "lemmaId": "приєднати",
+      "sentence": "Приєднати газову трубку.",
+      "targetForm": "приєднати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0326",
+        "title": "Сторінка 177"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "приєднатися",
+      "lemmaId": "приєднатися",
+      "sentence": "Приєднатися до такого народу — це гірше, ніж скочити живим у вогонь.",
+      "targetForm": "приєднатися",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoria-ukr-galimov-2025_s0230",
+        "title": "Сторінка 140"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "про",
+      "lemmaId": "про",
+      "sentence": "Нузет Умеров ПРО КНИЖКУ Дбайливо тонесеньку книжку гортаю, рядок за рядочком уважно читаю.",
+      "targetForm": "про",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-vashulenko-2019-2_s0018",
+        "title": "Сторінка 20"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "провідник",
+      "lemmaId": "провідник",
+      "sentence": "сила аМпЕра Із матеріалу § 1 ви дізналися, що магнітне поле діє на провідник зі струмом із де­ якою силою.",
+      "targetForm": "провідник",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-fizyka-bariakhtar-2022_s0029",
+        "title": "Сторінка 20"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "програвати",
+      "lemmaId": "програвати",
+      "sentence": "Ті не перемагають, хто не вміють програвати.",
+      "targetForm": "програвати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-fizyka-bariakhtar-2022_s0340",
+        "title": "Сторінка 226"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "продавати",
+      "lemmaId": "продавати",
+      "sentence": "Її не можна було передавати в спадок, продавати тощо.",
+      "targetForm": "продавати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-istoria-ukr-galimov-2024_s0106",
+        "title": "Сторінка 73"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "продовжувати",
+      "lemmaId": "продовжувати",
+      "sentence": "Однак я досить довго не могла зрозуміти, як (imperfective, perfective) продовжувати подкаст саме в умовах війни.",
+      "targetForm": "продовжувати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0201_w005",
+        "title": "Lesson 201: Про шостий сезон подкасту (part 5/21)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "проза",
+      "lemmaId": "проза",
+      "sentence": "­Ораторсько-проповідницька проза включала твори з тлумаченням євангельських текстів і моралістичними повчаннями.",
+      "targetForm": "проза",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoriya-ukr-gisem-2021_s0077",
+        "title": "Сторінка 41"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "простір",
+      "lemmaId": "простір",
+      "sentence": "Що таке особистий простір та якими є його складники.",
+      "targetForm": "простір",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-etyka-martyniuk-2023_s0042",
+        "title": "Сторінка 43"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "професія",
+      "lemmaId": "професія",
+      "sentence": "Можна стати по-справжньому щасливим, коли характер і професія перебувають у гармонії.",
+      "targetForm": "професія",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0272",
+        "title": "Сторінка 190"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "психологічний",
+      "lemmaId": "психологічний",
+      "sentence": "Думаю скласти психологічний портрет людини можна за кількістю і якістю прочитаних і зібраних нею книжок.",
+      "targetForm": "психологічний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-glazova-2019_s0221",
+        "title": "Сторінка 157"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "птаха",
+      "lemmaId": "птаха",
+      "sentence": "Персонаж «Синього птаха», якого в українському перекладі названо Душею Світла, в оригіналі – просто Світло.",
+      "targetForm": "птаха",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zarubizhna-literatura-voloshhuk-2018_s0342",
+        "title": "Сторінка 198"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "півострів",
+      "lemmaId": "півострів",
+      "sentence": "yy Балканський півострів омивається ________________ морями.",
+      "targetForm": "півострів",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-istoriia-shchupak-2023_s0128",
+        "title": "Сторінка 126"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підліток",
+      "lemmaId": "підліток",
+      "sentence": "В Підліток може висловити свої скарги вчителю, шкільному адміністратору чи батькам.",
+      "targetForm": "підліток",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-zdorovia-guschyna-2024_s0077",
+        "title": "Сторінка 72"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підряд",
+      "lemmaId": "підряд",
+      "sentence": "Розкажіть про особливості складнопідрядних речень із з’ясувальними підряд ними частинами.",
+      "targetForm": "підряд",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0182",
+        "title": "Сторінка 131"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підсилити",
+      "lemmaId": "підсилити",
+      "sentence": "Його потужність, колір, напрям допомагають зробити декорації виразнішими, виділити головне, підсилити враження глядачів/глядачок.",
+      "targetForm": "підсилити",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-mystetstvo-rublia-2023_s0184",
+        "title": "Сторінка 185"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "підтвердження",
+      "lemmaId": "підтвердження",
+      "sentence": "Доберіть історичні факти на підтвердження тези «Самвидав» — зброя в руках дисидентів».",
+      "targetForm": "підтвердження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-hlibovska-2024_s0320",
+        "title": "Сторінка 175"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "пізно",
+      "lemmaId": "пізно",
+      "sentence": "Мілкіше, мало, довше, дешево, пізно, більше, світло, сумно, близько.",
+      "targetForm": "пізно",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-zaharijchuk-2021-1_s0125",
+        "title": "Сторінка 127"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "разом",
+      "lemmaId": "разом",
+      "sentence": "Далі вона розповідає: Ми далі будемо рухатися по життю разом.",
+      "targetForm": "разом",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0195_w017",
+        "title": "Lesson 195: Українці в ПАР: розмова з Олесею Лобшер (part 17/27)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рекорд",
+      "lemmaId": "рекорд",
+      "sentence": "Номер 5 ― побити світовий рекорд.",
+      "targetForm": "рекорд",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0141_w012",
+        "title": "Lesson 141: Україна в 2019: головні новини (part 12/20)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "реєструється",
+      "lemmaId": "реєструється",
+      "sentence": "Уявіть, що хтось із ваших знайомих уперше створює електронну пошту чи реєструється в соціальній мережі.",
+      "targetForm": "реєструється",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-zabolotnyi-2023_s0019",
+        "title": "Сторінка 21"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "риса",
+      "lemmaId": "риса",
+      "sentence": "(imperfective, perfective) торту́ри ― torture Очевидно, ця риса — риса стоїцизму — не може бути здава́тися, зда́тися ― to give up притаманною усім людям.",
+      "targetForm": "риса",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0229_w002",
+        "title": "Lesson 229: Українська поезія. Василь Стус «Господи, гніву пречистого…» (part 2/30)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "родич",
+      "lemmaId": "родич",
+      "sentence": "Моєму родичу випала неймовірна можливість (Мій родич отримав неймовірну можливість) навчатися (вчитися) безкоштовно.",
+      "targetForm": "родич",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0189_w026",
+        "title": "Lesson 189: Вища освіта в Україні та США (part 26/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розмова",
+      "lemmaId": "розмова",
+      "sentence": "за кордо́ном ― abroad Шотла́ндія ― Scotland Ця розмова буде особлива і трошки інша, ніж попередні дві.",
+      "targetForm": "розмова",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0194_w001",
+        "title": "Lesson 194: Українці в Шотландії: розмова з Олексою Курилюком (part 1/21)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розповісти",
+      "lemmaId": "розповісти",
+      "sentence": "☆☆☆ Я можу розповісти про причини виникнення пожеж.",
+      "targetForm": "розповісти",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-zdorovia-vorontsova-2023_s0163",
+        "title": "Сторінка 168"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розпорядження",
+      "lemmaId": "розпорядження",
+      "sentence": "\u0007Поясніть поняття «власність», «користування», «володіння», «розпорядження», «сервітут», «суперфіцій», «емфітевзис».",
+      "targetForm": "розпорядження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-pravoznavstvo-narovlianskyi-2019_s0240",
+        "title": "Сторінка 127"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розум",
+      "lemmaId": "розум",
+      "sentence": "Маруся не знайшла в собі сили пережити цю зраду і тому вона зовсім втратила розум.",
+      "targetForm": "розум",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0153_w011",
+        "title": "Lesson 153: Маруся Чурай — дівчина з легенди (part 11/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "розширювати",
+      "lemmaId": "розширювати",
+      "sentence": "для тих, хто вже добре розуміє українську мову, але хоче розширювати словниковий запас».",
+      "targetForm": "розширювати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0128_w010",
+        "title": "Lesson 128: Рослини — символи України (part 10/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "роль",
+      "lemmaId": "роль",
+      "sentence": "Далі я казала, що Ярослав Мудрий відіграв важливу роль в історії.",
+      "targetForm": "роль",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0151_w010",
+        "title": "Lesson 151: Ярослав Мудрий — «тесть Європи» (part 10/16)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рости",
+      "lemmaId": "рости",
+      "sentence": "і заспівала: «Плавай, плавай, леб;едонько, По синьому морю – Рости, рости, топ;оленько, Все вгору та вгору!",
+      "targetForm": "рости",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-zabolotnyi-2024_s0211",
+        "title": "Сторінка 144"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рушник",
+      "lemmaId": "рушник",
+      "sentence": "І в дорогу далеку ти мене на зорі проводжала, І рушник вишиваний на щастя, на долю дала.",
+      "targetForm": "рушник",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0407",
+        "title": "Сторінка 246"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "рідко",
+      "lemmaId": "рідко",
+      "sentence": "У формі називного відмінка іменник, яким виражено звертання, уживають рідко — зазвичай у поетичних творах.",
+      "targetForm": "рідко",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-glazova-2019_s0149",
+        "title": "Сторінка 104"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "різдвяний",
+      "lemmaId": "різдвяний",
+      "sentence": "Узвар, український різдвяний напій, готується із 5.",
+      "targetForm": "різдвяний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0214_w022",
+        "title": "Lesson 214: Символи Різдва в Україні (part 22/24)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сад",
+      "lemmaId": "сад",
+      "sentence": "Пагутяк «Потрапити в сад» за родовою ознакою — епічний.",
+      "targetForm": "сад",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-literatura-avramenko-2019_s0403",
+        "title": "Сторінка 248"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "садівництво",
+      "lemmaId": "садівництво",
+      "sentence": "Крім землеробства, розвивалися скотарство, городництво, садівництво, бджільництво, рибальство й мисливство.",
+      "targetForm": "садівництво",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-istoria-ukr-galimov-2025_s0027",
+        "title": "Сторінка 20"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "салат",
+      "lemmaId": "салат",
+      "sentence": "Ще був салат мімоза — з вареними мімо́за — mimosa salad яйцями і рибними консервами.",
+      "targetForm": "салат",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0181_w010",
+        "title": "Lesson 181: Українська кухня в радянські часи (part 10/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "самостійно",
+      "lemmaId": "самостійно",
+      "sentence": "Початкові значення властивостей напису виберіть самостійно.",
+      "targetForm": "самостійно",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-informatyka-ryvkind-2025_s0167",
+        "title": "Сторінка 120"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "свята",
+      "lemmaId": "свята",
+      "sentence": "Речення номер один: Деякі свята потрохи відходять в історію.",
+      "targetForm": "свята",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0173_w013",
+        "title": "Lesson 173: Зимовий цикл свят (part 13/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "свідомість",
+      "lemmaId": "свідомість",
+      "sentence": "Свідомість Прагнення пізнання себе є одним з головних рушіїв розвитку людства.",
+      "targetForm": "свідомість",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0250",
+        "title": "Сторінка 202"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "свіжий",
+      "lemmaId": "свіжий",
+      "sentence": "Взагалі, свіжоспечений ми говоримо про хліб, тобто хліб, який спекли спекти́ — to bake щойно, недавно, цей хліб свіжий, він свіжоспечений.",
+      "targetForm": "свіжий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-4-00-lesson-notes_l0133_w010",
+        "title": "Lesson 133: Прислів’я та приказки Частина 2 (part 10/17)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "середній",
+      "lemmaId": "середній",
+      "sentence": "Це така відстань, з якої середній радіус земної орбіти видно під кутом 1″ (секунда дуги).",
+      "targetForm": "середній",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-fizika-astronomiia-zasekina-2019-standart_s0387",
+        "title": "Сторінка 240"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "символічно",
+      "lemmaId": "символічно",
+      "sentence": "символічно це показало, що від заходу до сходу Україна одна, символі́чно — symbolically єдина, неподільна, або соборна.",
+      "targetForm": "символічно",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0177_w010",
+        "title": "Lesson 177: День Соборності України (part 10/21)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "скарб",
+      "lemmaId": "скарб",
+      "sentence": "Люди – дуже цікаві створіння!» – думає персонаж твору А «Скарб» В «Мишка» Б «Кольорові миші» Г «Чайка на крижині» 6.",
+      "targetForm": "скарб",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0345",
+        "title": "Сторінка 209"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "слюсар",
+      "lemmaId": "слюсар",
+      "sentence": "Учитель, лікар чи геолог, письменник, слюсар чи кресляр — всі називають головною одну професію — школяр!",
+      "targetForm": "слюсар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-vashulenko-2019-2_s0002",
+        "title": "Сторінка 4"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "слідуючий",
+      "lemmaId": "слідуючий",
+      "sentence": "Студенти сіли в потяг, слідуючий до Рівного.",
+      "targetForm": "слідуючий",
+      "cefr": null,
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrmova-zabolotnyi-2019_s0079",
+        "title": "Сторінка 58"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сніг",
+      "lemmaId": "сніг",
+      "sentence": "\u0007Якими фарбами зображено на картині сніг, небо, дерева?",
+      "targetForm": "сніг",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0067",
+        "title": "Сторінка 69"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "соломка",
+      "lemmaId": "соломка",
+      "sentence": "Так і посипалось на сніг, а соломка й пір’ячко за вітром полетіли.",
+      "targetForm": "соломка",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "2-klas-ukrmova-kravcova-2019-2_s0052",
+        "title": "Сторінка 54"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сорок",
+      "lemmaId": "сорок",
+      "sentence": "Зверніть увагу на відмінкові закінчення числівника сорок.",
+      "targetForm": "сорок",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-golub-2023_s0164",
+        "title": "Сторінка 161"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "спитати",
+      "lemmaId": "спитати",
+      "sentence": "Міжбанківський валютний ринок (міжбанк) Можете спитати в батьків чи в дорослих, яким довіряєте, як вам купити 100 доларів.",
+      "targetForm": "спитати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-finans-plastun-2025_s0058",
+        "title": "Сторінка 57"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "споживач",
+      "lemmaId": "споживач",
+      "sentence": "Споживач в економіці 51 кожного додаткового літра значно зменшу­ ється, а кожний додатковий карат алмаза збільшує корисність коштовностей.",
+      "targetForm": "споживач",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ekonomika-krupska-2018_s0098",
+        "title": "Сторінка 51"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "спортивний",
+      "lemmaId": "спортивний",
+      "sentence": "Підготуйте твір-опис приміщення в художньому стилі на одну з тем: «Наш клас», «Моя кімната», «Улюблений спортивний зал» (усно).",
+      "targetForm": "спортивний",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-avramenko-2023_s0127",
+        "title": "Сторінка 119"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "спостереження",
+      "lemmaId": "спостереження",
+      "sentence": "Пост радіаційного та хімічного спостереження встановлюють на території об’єкта недалеко від пункту управління.",
+      "targetForm": "спостереження",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-zakhist-vitchizni-gudima-2019-med_s0326",
+        "title": "Сторінка 176"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "стадіон",
+      "lemmaId": "стадіон",
+      "sentence": "На стадіон прийшли хлопці, бажаючі грати у футбол.",
+      "targetForm": "стадіон",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrmova-zabolotnyi-2024_s0233",
+        "title": "Сторінка 233"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "стажування",
+      "lemmaId": "стажування",
+      "sentence": "Учасники наукового стажування отримали престижну премію.",
+      "targetForm": "стажування",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-6-00-lesson-notes_l0210_w027",
+        "title": "Lesson 210: Питання-відповіді: частина друга (part 27/27)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "стілець",
+      "lemmaId": "стілець",
+      "sentence": "НУМО ДОСЛІДЖУВАТИ ЯК ОЧІ ОЦІНЮЮТЬ ВІДСТАНЬ Тобі знадобляться: аркуш паперу, олівець, стілець.",
+      "targetForm": "стілець",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-piznaemo-pryrodu-korshevniuk-2023_s0199",
+        "title": "Сторінка 201"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сума",
+      "lemmaId": "сума",
+      "sentence": "Знайдіть ймовірність того, що: 1) його куб менший за 8000; 2) сума квадратів його цифр менша за 20.",
+      "targetForm": "сума",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-algebra-ister-2019-prof_s0251",
+        "title": "Сторінка 243"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сумка",
+      "lemmaId": "сумка",
+      "sentence": "Для ваших однокласників у задоволенні цієї по­ треби товарами-субститутами можуть бути портфель, спортивна сумка, сумка-пакет, рюкзак.",
+      "targetForm": "сумка",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ekonomika-krupska-2018_s0091",
+        "title": "Сторінка 47"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сумніватися",
+      "lemmaId": "сумніватися",
+      "sentence": "(сумніватися) в тому, що я кажу правду?",
+      "targetForm": "сумніватися",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-3-00-lesson-notes_l0109_w015",
+        "title": "Lesson 109: На побаченні On a date Reflexive verbs (part 15/18)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "суспільство",
+      "lemmaId": "суспільство",
+      "sentence": "Сутність громадянського суспільства та його інститути Чим відрізняється громадянське суспільство від суспільства?",
+      "targetForm": "суспільство",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-hromadianska-osvita-vasylkiv-2025_s0071",
+        "title": "Сторінка 34"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сусід",
+      "lemmaId": "сусід",
+      "sentence": "Було тій Анні, може, десять рочків, її привів розлючений сусід.",
+      "targetForm": "сусід",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-mishhenko-2015_s0262",
+        "title": "Сторінка 164"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "схвалено",
+      "lemmaId": "схвалено",
+      "sentence": "Верховною Радою схвалено «Основні напрями зовнішньої політики України»; – 5 грудня 1994 р.",
+      "targetForm": "схвалено",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-hlibovska-2024_s0479",
+        "title": "Сторінка 262"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "схильний",
+      "lemmaId": "схильний",
+      "sentence": "Схильний, охочий що-небудь робити; готовий до певних учинків; згоден на певну дію, стан.",
+      "targetForm": "схильний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrmova-avramenko-2025_s0253",
+        "title": "Сторінка 180"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сцена",
+      "lemmaId": "сцена",
+      "sentence": "(Лиховісно сміється.) СЦЕНА 3 Покої в королівському палаці.",
+      "targetForm": "сцена",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "3-klas-ukrainska-mova-vashulenko-2020-2_s0060",
+        "title": "Сторінка 62"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "сценарій",
+      "lemmaId": "сценарій",
+      "sentence": "З якою метою створюється режисерський сценарій під час створення фільму за певним літературним твором?",
+      "targetForm": "сценарій",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-informatyka-ryvkind-2024_s0206",
+        "title": "Сторінка 181"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "телебачення",
+      "lemmaId": "телебачення",
+      "sentence": "До яких жанрів телебачення вони належать?",
+      "targetForm": "телебачення",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-mystetstvo-masol-2017_s0184",
+        "title": "Сторінка 163"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "телефонувати",
+      "lemmaId": "телефонувати",
+      "sentence": "дзвіно́к — call Ви можете зідзвонюватись, тобто телефонувати одне одному, телефонува́ти = дзвони́ти — to call дзвонити одне одному.",
+      "targetForm": "телефонувати",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0165_w013",
+        "title": "Lesson 165: Як використовувати смартфон для вивчення мов (part 13/19)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тема",
+      "lemmaId": "тема",
+      "sentence": "ПОВЕРНЕННЯ ДО ІДЕАЛІВ КРАСИ МИНУЛОГО Тема 1 5 -1 6 .",
+      "targetForm": "тема",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-mystetstvo-masol-2017_s0002",
+        "title": "Сторінка 4"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тест",
+      "lemmaId": "тест",
+      "sentence": "Тест — це слово, яке часто має негативну конотацію.",
+      "targetForm": "тест",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0178_w007",
+        "title": "Lesson 178: Як ефективніше вчитися? (part 7/26)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тестувати",
+      "lemmaId": "тестувати",
+      "sentence": "У процесі здійснення тест-дизайну тест-аналітик визначає, ЩО тестувати, а тест-дизайнер — ЯК тестувати.",
+      "targetForm": "тестувати",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0388",
+        "title": "Сторінка 249"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тисяча",
+      "lemmaId": "тисяча",
+      "sentence": "(на) тисяча дев’ятсот сьомому Кожен компонент складеного числівника відмінюється за своїм правилом.",
+      "targetForm": "тисяча",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0054",
+        "title": "Сторінка 38"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тихо",
+      "lemmaId": "тихо",
+      "sentence": "Ярослав Грицак зазначав: «Можу сказати, що комунізм упав напрочуд тихо.",
+      "targetForm": "тихо",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-gisem-2024_s0310",
+        "title": "Сторінка 173"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тканина",
+      "lemmaId": "тканина",
+      "sentence": "Скелетна м’язова тканина утворює скелетні м’язи, язик тощо.",
+      "targetForm": "тканина",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-biolohiya-anderson-2025_s0014",
+        "title": "Сторінка 13"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "товариський",
+      "lemmaId": "товариський",
+      "sentence": "Використайте синоніми приятельський, приязний, дружній, товариський.",
+      "targetForm": "товариський",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-ukrmova-avramenko-2022_s0047",
+        "title": "Сторінка 45"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "точний",
+      "lemmaId": "точний",
+      "sentence": "Визначити точний час певної події, тобто її дату, допомагає хронологія.",
+      "targetForm": "точний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "5-klas-istoriya-schupak-2022_s0053",
+        "title": "Сторінка 55"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "трава",
+      "lemmaId": "трава",
+      "sentence": "трава́ grass Ми лежимо́ на траві́ в па́рку.",
+      "targetForm": "трава",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "anna-ohoiko-1000-words-2nd-ed_e0880",
+        "title": "трава́"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "традиція",
+      "lemmaId": "традиція",
+      "sentence": "А от традиція купання в боягу́з — coward холодній воді не для боягузів, не для тих, хто боїться, так?",
+      "targetForm": "традиція",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0173_w017",
+        "title": "Lesson 173: Зимовий цикл свят (part 17/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тричі",
+      "lemmaId": "тричі",
+      "sentence": "Його тричі обирали до Верховної Ради України (1990, 1994, 1998 рр.).",
+      "targetForm": "тричі",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-istoriya-ukr-gisem-2024_s0283",
+        "title": "Сторінка 157"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тротуар",
+      "lemmaId": "тротуар",
+      "sentence": "УÑÅ заметено снігом: тротуар, дорога, стадіон.",
+      "targetForm": "тротуар",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-ukrmova-zabolotnyi-2025_s0192",
+        "title": "Сторінка 163"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "трохи",
+      "lemmaId": "трохи",
+      "sentence": "Зобрази його м’язистим, але трохи пере­ більшено кремезним — наче він щойно зліз із коня після десятиліття боїв.",
+      "targetForm": "трохи",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-vsesvitnia-istoriia-pometun-2026_s0121",
+        "title": "Сторінка 87"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "туалет",
+      "lemmaId": "туалет",
+      "sentence": "Туалет • Не куріть, не шуміть, не запалюйте свічки без дозволу відповідальної особи.",
+      "targetForm": "туалет",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-zdorovia-vasylenko-2025_s0024",
+        "title": "Сторінка 22"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "тістечко",
+      "lemmaId": "тістечко",
+      "sentence": "Чоловік ламає те тістечко навпіл, підсовує їй одну частинку, другу з’їдає сам і йде геть.",
+      "targetForm": "тістечко",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrmova-golub-2023_s0200",
+        "title": "Сторінка 197"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "удома",
+      "lemmaId": "удома",
+      "sentence": "Бояри та представники знаті винаймали для своїх дітей приватних учителів, які навчали їх удома.",
+      "targetForm": "удома",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-istoria-ukr-pometun-2024_s0175",
+        "title": "Сторінка 144"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "узимку",
+      "lemmaId": "узимку",
+      "sentence": "Узимку – пом’якшує морози, приносить снігопади, відлиги.",
+      "targetForm": "узимку",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-heohrafiya-hilberh-2025_s0114",
+        "title": "Сторінка 82"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "фінал",
+      "lemmaId": "фінал",
+      "sentence": "У першому виданні твір мав відкритий фінал: груша розросталася, а сварки не припинялись.",
+      "targetForm": "фінал",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrlit-borzenko-2018-prof_s0051",
+        "title": "Сторінка 29"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "фінальний",
+      "lemmaId": "фінальний",
+      "sentence": "Етап 2 На етапі проектування структури інтерфейсу створюють прототип інтерфейсу — зазвичай два: чорновий та фінальний.",
+      "targetForm": "фінальний",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-informatyka-rudenko-2019_s0379",
+        "title": "Сторінка 244"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "ходить",
+      "lemmaId": "ходить",
+      "sentence": "Ходить сон стежками лісовими.",
+      "targetForm": "ходить",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-zabolotnij-2017_s0140",
+        "title": "Сторінка 101"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "цвісти",
+      "lemmaId": "цвісти",
+      "sentence": "Цвісти або процвітати можуть квіти, коли вони розкриваються, цвісти́ — to bloom, to blossom квіти стають такі гарні квіти.",
+      "targetForm": "цвісти",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0199_w023",
+        "title": "Lesson 199: Українці в Канаді: розмова з Оксаною Грициною (part 23/33)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "часовий",
+      "lemmaId": "часовий",
+      "sentence": "Позаду був часовий стрибок у ранок сьогоднішнього дня.",
+      "targetForm": "часовий",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0243",
+        "title": "Сторінка 185"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "червень",
+      "lemmaId": "червень",
+      "sentence": "Послухайте ще один уривочок про червень в Україні.",
+      "targetForm": "червень",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0185_w010",
+        "title": "Lesson 185: «Як іноземці козака рятували» — нова книга від Ukrainian Lessons (part 10/23)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "чомусь",
+      "lemmaId": "чомусь",
+      "sentence": "Знатися на чомусь.",
+      "targetForm": "чомусь",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "ulp-5-00-lesson-notes_l0184_w014",
+        "title": "Lesson 184: Кавова культура України (part 14/22)"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "чорна",
+      "lemmaId": "чорна",
+      "sentence": "ПІДНЯТИСЯ НАД БУДЕННІСТЮ здивувати», – повідомляли губи світу, доки Чорна Пані мовчки роздивлялася Софійку.",
+      "targetForm": "чорна",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-ukrlit-zabolotnyi-2024_s0372",
+        "title": "Сторінка 250"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "чорні",
+      "lemmaId": "чорні",
+      "sentence": "Чорні клобуки часом повставали або відходили в степ, відмовляючись нести службу.",
+      "targetForm": "чорні",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "7-klas-istoria-ukr-pometun-2024_s0128",
+        "title": "Сторінка 107"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "чіпати",
+      "lemmaId": "чіпати",
+      "sentence": "Чіпати і їсти їх не (дозволятися).",
+      "targetForm": "чіпати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "4-klas-ukrayinska-mova-ponomarova-2021-1_s0113",
+        "title": "Сторінка 115"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "швидкий",
+      "lemmaId": "швидкий",
+      "sentence": "Згодом розпочався «промисловий» бум – швидкий розвиток вторинного сектору економіки: металургії, машинобудування, хімічної промисловості.",
+      "targetForm": "швидкий",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-geografiia-boiko-2026_s0548",
+        "title": "Сторінка 289"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "швидко",
+      "lemmaId": "швидко",
+      "sentence": "Б Троянці, в човни посідавши, і швидко їх поодпихавши, по вітру гарно попливли.",
+      "targetForm": "швидко",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-ukrajinska-mova-avramenko-2019_s0179",
+        "title": "Сторінка 127"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "шум",
+      "lemmaId": "шум",
+      "sentence": "Вони в захваті від ритмів пісні «Шум», яку український гурт «Go A» прославив на співочому конкурсі «Євробачення» у 2021 р.",
+      "targetForm": "шум",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-ukrlit-avramenko-2023_s0008",
+        "title": "Сторінка 8"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "щодо",
+      "lemmaId": "щодо",
+      "sentence": "Які заходи щодо подолання дискримінації жінок у суспільно-політичній сфері передбачала Конвенція?",
+      "targetForm": "щодо",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-hromadianska-gisem-2018_s0126",
+        "title": "Сторінка 66"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "якось",
+      "lemmaId": "якось",
+      "sentence": "Якось враз знялася курява й завертівся перед­ грозовий вихор.",
+      "targetForm": "якось",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "9-klas-ukrajinska-mova-voron-2017_s0047",
+        "title": "Сторінка 40"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інвалідність",
+      "lemmaId": "інвалідність",
+      "sentence": "Альтруїзм та егоїзм у поведінці людини 139 Зараз в Україні живе понад 2,7 млн осіб, які мають інвалідність.",
+      "targetForm": "інвалідність",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "6-klas-etyka-martyniuk-2023_s0140",
+        "title": "Сторінка 141"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "індивідуально",
+      "lemmaId": "індивідуально",
+      "sentence": "Узагалі одяг добирають індивідуально, охопити всі нюанси і тонкощі тих чи інших видів одягу неможливо.",
+      "targetForm": "індивідуально",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-zakhyst-fuka-2023_s0482",
+        "title": "Сторінка 264"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інтенсивний",
+      "lemmaId": "інтенсивний",
+      "sentence": "У природному русі населення розрізняють також традиційний (екстенсивний) та сучасний (інтенсивний) типи відтворення населення.",
+      "targetForm": "інтенсивний",
+      "cefr": "B1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "11-klas-geografija-pestushko-2019_s0144",
+        "title": "Сторінка 80"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інтернет",
+      "lemmaId": "інтернет",
+      "sentence": "Використавши мережу Skype, організуйте та проведіть інтернет-дискусію на тему «Інтернет у житті сучасного школяра».",
+      "targetForm": "інтернет",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-ukrmova-glazova-2018_s0058",
+        "title": "Сторінка 43"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інформація",
+      "lemmaId": "інформація",
+      "sentence": "Із розвитком суспільства інформація стає універсальним ресурсом, який уже не поступається традиційним матеріальним ресурсам (нафта, газ та ін.).",
+      "targetForm": "інформація",
+      "cefr": "A1",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "10-klas-informatika-rudenko-2018-stand_s0002",
+        "title": "Сторінка 4"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    },
+    {
+      "lemma": "інформувати",
+      "lemmaId": "інформувати",
+      "sentence": "• Що робить держава для того, щоб інформувати людей про НС та ліквідувати її наслідки?",
+      "targetForm": "інформувати",
+      "cefr": "A2",
+      "uses": [
+        "example"
+      ],
+      "provenance": {
+        "source": "textbook",
+        "label": "Ukrainian school textbook",
+        "locator": "8-klas-zdorovia-vasylenko-2025_s0023",
+        "title": "Сторінка 21"
+      },
+      "license": {
+        "status": "not_openly_licensed",
+        "useBasis": "short educational quotation with attribution"
+      }
+    }
+  ]
+}

--- a/site/src/lib/lexicon/daily.ts
+++ b/site/src/lib/lexicon/daily.ts
@@ -15,6 +15,18 @@ export interface DailyWord {
   example?: string | null;
   /** English rendering of `example` (A1 scaffolding only). */
   exampleEn?: string | null;
+  /** Source attribution preserved with an inventory-backed daily example. */
+  exampleProvenance?: {
+    source: "textbook" | "ulp";
+    label: string;
+    locator?: string;
+    title?: string;
+  };
+  /** Rights status and the documented educational-use basis for that example. */
+  exampleLicense?: {
+    status: string;
+    useBasis?: string;
+  };
 }
 
 export function dateSeed(d: Date): number {

--- a/tests/test_daily_sentence_inventory.py
+++ b/tests/test_daily_sentence_inventory.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INVENTORY = ROOT / "site/src/data/lexicon-sentence-inventory.json"
+DAILY_POOL = ROOT / "site/src/data/lexicon-daily-pool.json"
+
+
+def test_daily_pool_examples_are_inventory_backed_and_cover_the_ship_floor() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    pool = json.loads(DAILY_POOL.read_text(encoding="utf-8"))
+
+    assert inventory["schema"] == "atlas-sentence-inventory"
+    rows = inventory["rows"]
+    assert rows
+    assert all(row["lemmaId"] and row["uses"] == ["example"] and row["provenance"] and row["license"] for row in rows)
+    assert all(row["provenance"]["source"] in {"textbook", "ulp"} for row in rows)
+
+    examples = [row for row in pool if row.get("example")]
+    assert len(examples) / len(pool) >= 0.40
+    assert all(row.get("exampleProvenance") and row.get("exampleLicense") for row in examples)
+    assert all("clozemaster" not in json.dumps(row, ensure_ascii=False).casefold() for row in rows)
+
+
+def test_ulp_inventory_rows_have_only_the_safe_provenance_shape() -> None:
+    rows = json.loads(INVENTORY.read_text(encoding="utf-8"))["rows"]
+    for row in rows:
+        if row["provenance"]["source"] == "ulp":
+            assert set(row["provenance"]) == {"source", "label"}

--- a/tests/test_generate_daily_pool.py
+++ b/tests/test_generate_daily_pool.py
@@ -99,6 +99,23 @@ def test_build_pool_schema_sorting_and_filters() -> None:
     assert set(by_lemma["добрий день"]) == {"lemma", "slug", "gloss", "k", "weight"}
 
 
+def test_build_pool_prefers_inventory_example_with_provenance() -> None:
+    inventory = {
+        "баба": {
+            "lemma": "баба",
+            "sentence": "Баба читає книжку.",
+            "provenance": {"source": "textbook", "label": "Ukrainian school textbook"},
+            "license": {"status": "not_openly_licensed"},
+        }
+    }
+
+    row = next(item for item in build_pool(fixture_entries(), sentence_inventory=inventory) if item["lemma"] == "баба")
+
+    assert row["example"] == "Баба читає книжку."
+    assert row["exampleProvenance"] == inventory["баба"]["provenance"]
+    assert row["exampleLicense"] == inventory["баба"]["license"]
+
+
 def test_build_pool_top_n_uses_weight_then_lemma() -> None:
     pool = build_pool(fixture_entries(), size=2)
 
@@ -155,7 +172,6 @@ def test_main_writes_deterministic_json_bytes(tmp_path) -> None:
     assert out_one.read_text(encoding="utf-8").endswith("\n")
 
 
-
 def _daily_atlas_db(tmp_path: Path) -> Path:
     """Materialize a fixture atlas.db from a small manifest via the real migrator.
 
@@ -173,9 +189,7 @@ def _daily_atlas_db(tmp_path: Path) -> Path:
                         "url_slug": "baba",
                         "gloss": "grandmother",
                         "primary_source": "course",
-                        "course_usage": [
-                            {"track": "a1", "module_num": 1, "slug": "family", "context": "x"}
-                        ],
+                        "course_usage": [{"track": "a1", "module_num": 1, "slug": "family", "context": "x"}],
                         "enrichment": {"cefr": {"level": "A1", "source": "est", "text": "A1"}},
                     },
                     {

--- a/tests/test_generate_sentence_inventory.py
+++ b/tests/test_generate_sentence_inventory.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from scripts.audit.generate_sentence_inventory import (
+    build_inventory,
+    load_daily_lemmas,
+    load_daily_targets,
+    write_inventory,
+)
+
+
+def _sources_db(tmp_path):
+    db = tmp_path / "sources.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE textbooks (id INTEGER PRIMARY KEY, chunk_id TEXT, title TEXT, text TEXT);
+        CREATE VIRTUAL TABLE textbooks_fts USING fts5(title, text, content='textbooks', content_rowid='id');
+        CREATE TABLE external_articles (id INTEGER PRIMARY KEY, chunk_id TEXT, title TEXT, text TEXT, source_file TEXT);
+        CREATE VIRTUAL TABLE external_fts USING fts5(title, text, content='external_articles', content_rowid='id');
+        INSERT INTO textbooks VALUES (1, 'grade-1-p-4', 'Grade 1', 'Ми живемо в Україні. Наша мова — українська.');
+        INSERT INTO textbooks_fts(rowid, title, text) VALUES (1, 'Grade 1', 'Ми живемо в Україні. Наша мова — українська.');
+        INSERT INTO external_articles VALUES (1, 'private-local-id', 'Private title', 'Я читаю українською щодня.', 'ulp_youtube');
+        INSERT INTO external_fts(rowid, title, text) VALUES (1, 'Private title', 'Я читаю українською щодня.');
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_extracts_attributed_textbook_sentence(tmp_path) -> None:
+    rows = build_inventory([{"lemma": "Україні", "lemmaId": "ukraini", "cefr": "A1"}], _sources_db(tmp_path))
+
+    assert rows == [
+        {
+            "lemma": "Україні",
+            "lemmaId": "ukraini",
+            "sentence": "Ми живемо в Україні.",
+            "targetForm": "Україні",
+            "cefr": "A1",
+            "uses": ["example"],
+            "provenance": {
+                "source": "textbook",
+                "label": "Ukrainian school textbook",
+                "locator": "grade-1-p-4",
+                "title": "Grade 1",
+            },
+            "license": {
+                "status": "not_openly_licensed",
+                "useBasis": "short educational quotation with attribution",
+            },
+        }
+    ]
+
+
+def test_ulp_provenance_never_exposes_private_locator(tmp_path) -> None:
+    rows = build_inventory(
+        [{"lemma": "українською", "lemmaId": "ukrainskoiu"}], _sources_db(tmp_path), include_ulp=True
+    )
+
+    assert rows[0]["provenance"] == {"source": "ulp", "label": "Ukrainian Lessons Podcast"}
+    assert "private-local-id" not in json.dumps(rows, ensure_ascii=False)
+    assert "Private title" not in json.dumps(rows, ensure_ascii=False)
+
+
+def test_daily_lemmas_and_written_schema(tmp_path) -> None:
+    pool = tmp_path / "daily.json"
+    pool.write_text(
+        json.dumps([{"lemma": "дім", "slug": "dim", "cefr": "A1"}, {"lemma": "дім"}, {"lemma": ""}]),
+        encoding="utf-8",
+    )
+    assert load_daily_lemmas(pool) == ["дім"]
+    assert load_daily_targets(pool) == [{"lemma": "дім", "lemmaId": "dim", "cefr": "A1"}]
+    out = tmp_path / "inventory.json"
+    write_inventory([], out)
+    assert json.loads(out.read_text(encoding="utf-8")) == {
+        "schema": "atlas-sentence-inventory",
+        "schemaVersion": 1,
+        "rows": [],
+    }


### PR DESCRIPTION
## Summary

Publishes source-attested, lemma-linked examples into the Daily Word pool through a dedicated sibling inventory. The sibling schema was chosen over the cloze allowlist because daily examples have no blank-form, case-rule, or distractor contract.

- Extracts exact daily-lemma matches from `sources.db` textbook FTS, repairs OCR line-break hyphens, rejects fragments, and requires a VESUM-attested verb.
- Preserves `lemmaId`, CEFR when available, `uses: ["example"]`, provenance, and licence-status/use-basis metadata on every inventory row.
- Overlays inventory sentences onto the DB-backed daily-pool build and preserves example provenance/licence metadata in the published row.
- Keeps ULP as an explicit opt-in fallback with only an opaque safe source-family label; no ULP raw locator is committed.

## Published counts

| Artifact | Rows | With examples | Coverage |
| --- | ---: | ---: | ---: |
| Sentence inventory | 287 | 287 | 100% provenance + licence metadata |
| Daily pool | 300 | 287 | 95.67% |

All currently published inventory rows are textbook FTS rows. Their `not_openly_licensed` status is deliberately retained with an attributed short-educational-quotation use basis; no source is represented as open-licensed.

## Verification

- `.venv/bin/python -m pytest tests/test_generate_sentence_inventory.py tests/test_generate_daily_pool.py tests/test_daily_sentence_inventory.py tests/test_check_static_practice_assets.py -q` (30 passed)
- `.venv/bin/ruff check scripts/audit/generate_sentence_inventory.py scripts/audit/generate_daily_pool.py tests/test_generate_sentence_inventory.py tests/test_generate_daily_pool.py tests/test_daily_sentence_inventory.py`
- Regenerated inventory and DB-backed daily pool to byte-identical `/tmp` outputs.
- `npm --prefix site exec vitest run tests/unit/daily-words-example.test.ts` could not start: this sparse worktree lacks the local `happy-dom` package; the Python generation and static-asset tests passed.

## Review routing

AGY and sealed Claude/Grok advisory routes rejected the sparse-worktree `.venv` symlink; direct Claude was at its weekly limit. This is recorded as the required lane substitution. A formal independent cross-family PR review is requested before auto-merge.

Closes #5483
Refs #4387 #4700 #3797 #5434