### PR TITLE
feat(bridge): fleet-comms Phase 4–5 residuals (#5485/#5486)

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -209,3 +209,17 @@ The cost economics above stand regardless: dispatched Claude is far pricier than
 The same table lives in `memory/MEMORY.md` rule #M0; this file is the deploy-rule mirror so it loads via `npm run agents:deploy` into `.claude/rules/`.
 
 </critical>
+
+## Formal PR CF review (fleet-comms Phase 4–5)
+
+For **GitHub PR formal cross-family review**, do **not** use fat `ask-* --review` with a pasted diff or PR URL body.
+
+```bash
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N>
+# after sealed review returns a short verdict file:
+.venv/bin/python scripts/ai_agent_bridge/__main__.py publish-review-verdict \
+  --pr <N> --verdict-file /tmp/verdict.txt --model <model> --family <family> --harness <harness>
+```
+
+Bridge refuse: `formal_pr_review_requires_review_pr` (#5486). See `docs/best-practices/agent-bridge.md`.
+

--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -182,6 +182,19 @@ body over 4 KiB or attach evidence over 64 KiB to an `ask-*` review job; the
 bridge rejects it and points to `review-pr <N>`. Prefer a PR target over a
 manual review ask.
 
+**Phase 5 fail-closed (#5486):** if an `ask-* --review` payload looks like a
+**formal CF PR review** (GitHub PR URL / `PR #N` / cross-family formal wording)
+and has **no** sealed `review_pr` / `review_branch` target, the bridge **refuses**
+with `formal_pr_review_requires_review_pr`. Use `review-pr <N>` then
+`publish-review-verdict`. Curriculum content reviews that use `--review` without
+a PR URL still work. Emergency escape only:
+`BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1`.
+
+**Phase 4 residual (#5485):** migrate runbooks and dispatch briefs that still say
+`ask-agy --review` / `ask-codex --review` for PR gates to `review-pr` +
+`publish-review-verdict`. `scripts/audit/llm_reviewer_dispatch.py` content-review
+routes remain `ask-* --review` (module QG, not PR CF).
+
 After a reviewer writes a short verdict or findings JSON, publish exactly one
 PR comment without relaying the full body through the orchestrator:
 

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -59,18 +59,20 @@ def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query"
                review_pr_number: int | None = None):
     """Send message to Claude AND invoke Claude to process it."""
     try:
+        has_target = review_branch is not None or review_pr_number is not None
         formal_review = assert_formal_review_ask_payload(
             content,
             msg_type=msg_type,
             task_id=task_id,
             attachment=data,
             review=review,
+            has_target=has_target,
         )
     except ReviewSafetyError as exc:
         raise SystemExit(f"ask-claude: {exc}") from exc
     warn_missing_review_target(
         formal_review=formal_review,
-        has_target=review_branch is not None or review_pr_number is not None,
+        has_target=has_target,
     )
     msg_id = send_message(
         content,

--- a/scripts/ai_agent_bridge/_codex.py
+++ b/scripts/ai_agent_bridge/_codex.py
@@ -120,18 +120,20 @@ def ask_codex(
 ):
     """Send message to Codex AND invoke Codex to process it."""
     try:
+        has_target = review_branch is not None or review_pr_number is not None
         formal_review = assert_formal_review_ask_payload(
             content,
             msg_type=msg_type,
             task_id=task_id,
             attachment=data,
             review=review,
+            has_target=has_target,
         )
     except ReviewSafetyError as exc:
         raise SystemExit(f"ask-codex: {exc}") from exc
     warn_missing_review_target(
         formal_review=formal_review,
-        has_target=review_branch is not None or review_pr_number is not None,
+        has_target=has_target,
     )
     from_llm = _resolve_codex_from_llm(from_llm)
     msg_id = send_message(

--- a/scripts/ai_agent_bridge/_hermes.py
+++ b/scripts/ai_agent_bridge/_hermes.py
@@ -180,6 +180,7 @@ def _preflight_hermes_payload(
         task_id=None,
         attachment=data,
         review=review,
+        has_target=False,
     )
     warn_missing_review_target(formal_review=formal_review, has_target=False)
     limit = MAX_REVIEW_REQUEST_BYTES if review else MAX_ASK_CONTENT_BYTES

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -328,6 +328,7 @@ def ask_glm(
             msg_type=msg_type,
             task_id=task_id,
             attachment=data,
+            has_target=False,
         )
     except ReviewSafetyError as exc:
         raise SystemExit(f"ask-glm: {exc}") from exc

--- a/scripts/ai_agent_bridge/_review_safety.py
+++ b/scripts/ai_agent_bridge/_review_safety.py
@@ -242,6 +242,7 @@ def assert_formal_review_ask_payload(
     task_id: str | None,
     attachment: str | Path | None = None,
     review: bool = False,
+    has_target: bool = False,
 ) -> bool:
     """Fail closed before a formal review ask can send a fat payload.
 
@@ -251,6 +252,10 @@ def assert_formal_review_ask_payload(
     formal_review = review or is_formal_review_ask(msg_type=msg_type, task_id=task_id)
     if not formal_review:
         return False
+
+    assert_pr_cf_review_uses_review_pr(
+        content, formal_review=True, has_target=has_target
+    )
 
     content_size = len(content.encode("utf-8"))
     if content_size > MAX_REVIEW_REQUEST_BYTES:
@@ -270,6 +275,28 @@ def assert_formal_review_ask_payload(
     return True
 
 
+_PR_CF_REVIEW_RE = re.compile(
+    r"github\.com/[^\s]+/pull/\d+|\breview-pr-\d+\b|\bPR\s*#?\d+\b|"
+    r"formal cross-family|cross-family formal|code-review-findings\.v1",
+    re.IGNORECASE,
+)
+
+
+def allow_legacy_review_ask_escape() -> bool:
+    """Emergency escape for non-PR formal asks that still need --review."""
+    return os.environ.get("BRIDGE_ALLOW_LEGACY_REVIEW_ASK", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def looks_like_pr_cf_review(content: str) -> bool:
+    """Heuristic: formal CF PR review should use review-pr, not fat ask-*."""
+    return bool(_PR_CF_REVIEW_RE.search(content[:4000]))
+
+
 def warn_missing_review_target(*, formal_review: bool, has_target: bool) -> None:
     """Steer manual formal-review asks to the PR-targeted entrypoint."""
     if formal_review and not has_target:
@@ -277,6 +304,31 @@ def warn_missing_review_target(*, formal_review: bool, has_target: bool) -> None
             "warning: formal review ask has no review target; prefer review-pr <N> "
             "for sealed, pointer-only review.",
             file=sys.stderr,
+        )
+
+
+def assert_pr_cf_review_uses_review_pr(
+    content: str,
+    *,
+    formal_review: bool,
+    has_target: bool,
+) -> None:
+    """Phase 5: formal CF PR review without a sealed target is refused.
+
+    Curriculum content reviews that pass --review without a PR URL continue to
+    work. Escape: BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1.
+    """
+    if not formal_review or has_target:
+        return
+    if allow_legacy_review_ask_escape():
+        return
+    if looks_like_pr_cf_review(content):
+        raise ReviewSafetyError(
+            "formal_pr_review_requires_review_pr: use "
+            "`scripts/ai_agent_bridge/__main__.py review-pr <N>` for sealed "
+            "pointer-only CF review, then `publish-review-verdict` for the thin "
+            "GH comment. Fat ask-* --review with a PR URL is refused (fleet-comms "
+            "Phase 5 / #5486). Escape only with BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1."
         )
 
 

--- a/tests/ai_agent_bridge/test_review_pr_required.py
+++ b/tests/ai_agent_bridge/test_review_pr_required.py
@@ -1,0 +1,71 @@
+"""Phase 5: formal PR CF review without sealed target is refused (#5486)."""
+
+from __future__ import annotations
+
+import pytest
+from ai_agent_bridge import _review_safety as safety
+
+
+def test_looks_like_pr_cf_review_detects_github_pr_url() -> None:
+    body = "Please review https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5480"
+    assert safety.looks_like_pr_cf_review(body) is True
+
+
+def test_assert_pr_cf_review_refuses_without_target() -> None:
+    body = (
+        "Formal cross-family PR review for "
+        "https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5480\n"
+        "VERDICT: APPROVED"
+    )
+    with pytest.raises(safety.ReviewSafetyError, match="formal_pr_review_requires_review_pr"):
+        safety.assert_formal_review_ask_payload(
+            body,
+            msg_type="review",
+            task_id="review-pr-5480-manual",
+            review=True,
+            has_target=False,
+        )
+
+
+def test_assert_pr_cf_review_allows_with_target() -> None:
+    body = "https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5480 thin pointer"
+    assert (
+        safety.assert_formal_review_ask_payload(
+            body,
+            msg_type="review",
+            task_id="review-pr-5480",
+            review=True,
+            has_target=True,
+        )
+        is True
+    )
+
+
+def test_content_review_without_pr_url_still_allowed() -> None:
+    body = "Please review this curriculum module for calques and naturalness."
+    assert (
+        safety.assert_formal_review_ask_payload(
+            body,
+            msg_type="review",
+            task_id="content-review-bio-1",
+            review=True,
+            has_target=False,
+        )
+        is True
+    )
+
+
+def test_legacy_escape_allows_pr_url_without_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BRIDGE_ALLOW_LEGACY_REVIEW_ASK", "1")
+    body = "https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/1"
+    assert (
+        safety.assert_formal_review_ask_payload(
+            body,
+            msg_type="review",
+            task_id="review-legacy",
+            review=True,
+            has_target=False,
+        )
+        is True
+    )
+    monkeypatch.delenv("BRIDGE_ALLOW_LEGACY_REVIEW_ASK", raising=False)


### PR DESCRIPTION
## Summary

Closes fleet-comms Phase **4 residual** (#5485) and Phase **5 residual** (#5486) under epic #5484.

### Phase 5
- Fail-closed: `ask-* --review` with PR-like payload and no sealed target → `formal_pr_review_requires_review_pr`
- Content reviews without PR URL still allowed
- Escape: `BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1`

### Phase 4
- Document migrate fat PR review callers → `review-pr` + `publish-review-verdict`
- Note `llm_reviewer_dispatch` content-review routes remain legitimate `ask-* --review`

### Tests
- `tests/ai_agent_bridge/test_review_pr_required.py` (5 cases)

Closes #5485
Closes #5486

X-Agent: grok/5485-5486-fleet-comms-finish