### PR TITLE
feat(curriculum): define preparation handoff

### DIFF
--- a/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
@@ -76,26 +76,34 @@ only bounded-completion authority.
    | `next_action` | Exact next owner |
    | --- | --- |
    | `plan` | `$curriculum-preparation` |
-   | `prepare` | `$curriculum-preparation` |
+   | `prepare` | Requirement- and identity-sensitive; resolve from the full result |
    | `build` | `$track-completion` |
    | `certify` | `$track-completion` |
    | `stop` | Terminal reviewed HOLD |
 
-   For `plan` or `prepare`, call `$curriculum-preparation` once for the exact
-   acquired target and acquisition attempt. Its first canonical evaluation
-   becomes the typed handoff result. Stay inside that preparation scope until
-   it returns a fresh result whose action is `build`, `certify`, or `stop`;
-   preparation never calls lifecycle back. Use the result directly and do not
-   call `acquire-next` again.
+   For `plan` or `prepare`, run the canonical evaluator once for the exact
+   acquired target and use its full typed result to resolve ownership. If any
+   current failed requirement is owned by `plan` or `preparation`, route those
+   cells through `$curriculum-preparation`; accept its returned typed result
+   without calling lifecycle recursively.
+
+   When every current requirement passes but a built result remains `prepare`
+   solely because of `PREPARATION_IDENTITY_MISSING` or
+   `PREPARATION_IDENTITY_DRIFT`, hand the exact target to `$track-completion`.
+   Its authoritative ledger reruns readiness with the consumed identity from
+   `BUILD_RECORDED`, then either certifies or takes its existing explicit rebuild
+   transition. Do not reacquire, repeat the evaluator, or loop through
+   preparation. Fail closed on mixed or unknown combinations.
 
    For `stop`, run the canonical evaluator once to validate the full typed
    result. Accept it only with `PREPARATION_HOLD_ACTIVE`; preserve that reviewed
    HOLD evidence, leave the acquisition in place, report the terminal hold, and
    end. Do not record module completion or reacquire the target. Reject an
    unknown action or an unreviewed stop without mutation or an evaluation loop.
-3. For `build` or `certify`, resolve the acquired track's exact registered
-   semantic profile from the manifest. Put the typed context in a gitignored
-   runtime JSON file; never add free-form prompt prose to a profile:
+3. For `build`, `certify`, or an identity-only `prepare` exception, resolve the
+   acquired track's exact registered semantic profile from the manifest. Put
+   the typed context in a gitignored runtime JSON file; never add free-form
+   prompt prose to a profile:
 
    ```bash
    .venv/bin/python scripts/orchestration/prompt_contracts.py resolve-track \

--- a/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: curriculum-lifecycle
-description: Run or resume the manifest-derived curriculum lifecycle for one active track, using the coordinator for ordered waves and the canonical track-completion engine for exactly one acquired module at a time.
+description: Run or resume the manifest-derived curriculum lifecycle for one active track, using the coordinator for ordered waves and routing each acquired module through the canonical preparation or track-completion owner.
 ---
 
 # Curriculum lifecycle
@@ -14,9 +14,10 @@ Resume $curriculum-lifecycle for bio.
 ```
 
 This skill is the track-level entry point. It composes the deterministic
-coordinator with `$track-completion`; it does not reimplement readiness,
-building, certification, review, integration, or publication policy. Derive
-active tracks and order only from `curriculum/l2-uk-en/curriculum.yaml`.
+coordinator with `$curriculum-preparation` and `$track-completion`; it does not
+reimplement readiness, preparation, building, certification, review,
+integration, or publication policy. Derive active tracks and order only from
+`curriculum/l2-uk-en/curriculum.yaml`.
 For a normal BIO request, this is one serial workflow: the coordinator owns
 manifest order, prerequisites, acquisition, deterministic resume, and the
 hash-bound receipt; the acquired module's `$track-completion` ledger is the
@@ -67,9 +68,34 @@ only bounded-completion authority.
      --run-id <run-id> --owner <agent/task>
    ```
 
-2. Resolve the acquired track's exact registered semantic profile from the
-   manifest. Put the typed context in a gitignored runtime JSON file; never add
-   free-form prompt prose to a profile:
+2. Read the canonical readiness routing snapshot from the latest matching
+   `MODULE_ACQUIRED` event in the returned ledger. Bind it to that event's
+   track, slug, and attempt. Route its exact `next_action` uniformly for CORE,
+   seminar, and BIO targets:
+
+   | `next_action` | Exact next owner |
+   | --- | --- |
+   | `plan` | `$curriculum-preparation` |
+   | `prepare` | `$curriculum-preparation` |
+   | `build` | `$track-completion` |
+   | `certify` | `$track-completion` |
+   | `stop` | Terminal reviewed HOLD |
+
+   For `plan` or `prepare`, call `$curriculum-preparation` once for the exact
+   acquired target and acquisition attempt. Its first canonical evaluation
+   becomes the typed handoff result. Stay inside that preparation scope until
+   it returns a fresh result whose action is `build`, `certify`, or `stop`;
+   preparation never calls lifecycle back. Use the result directly and do not
+   call `acquire-next` again.
+
+   For `stop`, run the canonical evaluator once to validate the full typed
+   result. Accept it only with `PREPARATION_HOLD_ACTIVE`; preserve that reviewed
+   HOLD evidence, leave the acquisition in place, report the terminal hold, and
+   end. Do not record module completion or reacquire the target. Reject an
+   unknown action or an unreviewed stop without mutation or an evaluation loop.
+3. For `build` or `certify`, resolve the acquired track's exact registered
+   semantic profile from the manifest. Put the typed context in a gitignored
+   runtime JSON file; never add free-form prompt prose to a profile:
 
    ```bash
    .venv/bin/python scripts/orchestration/prompt_contracts.py resolve-track \
@@ -79,11 +105,11 @@ only bounded-completion authority.
    Preserve the returned prompt/source identity with the phase evidence. A
    retired or unknown track, stale selector, family mismatch, missing fragment,
    or unresolved input is a fail-closed configuration defect.
-3. Follow `$track-completion` completely for the acquired `track/slug`. Reuse
+4. Follow `$track-completion` completely for the acquired `track/slug`. Reuse
    its exact ledger on resume. It owns plan review, build/recovery, read-only
    `$post-build-review`, repair routing, reviewer-instability handling,
    independent review, PR/CI/merge, publication evidence, and cleanup.
-4. Record the module result from its authoritative ledger. A publishable result
+5. Record the module result from its authoritative ledger. A publishable result
    is accepted only after `$track-completion` reaches `COMPLETE` for the
    coordinator's exact goal; a terminal bounded-budget blocker is recorded as
    blocked rather than left stale:
@@ -101,7 +127,7 @@ only bounded-completion authority.
    blocker, and next action. An incomplete module ledger cannot complete the
    coordinator. A migrated historical module is reacquired until its exact goal
    is proven.
-5. Repeat acquisition serially until the coordinator reports `complete`.
+6. Repeat acquisition serially until the coordinator reports `complete`.
    Module-at-a-time mutation remains mandatory; a wave groups health and review
    capacity but does not authorize concurrent learner writes.
 

--- a/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
@@ -79,7 +79,7 @@ only bounded-completion authority.
    | `prepare` | Requirement- and identity-sensitive; resolve from the full result |
    | `build` | `$track-completion` |
    | `certify` | `$track-completion` |
-   | `stop` | Terminal reviewed HOLD |
+   | `stop` | State- and owner-sensitive; reviewed HOLD or partial recovery |
 
    For `plan` or `prepare`, run the canonical evaluator once for the exact
    acquired target and use its full typed result to resolve ownership. If any
@@ -96,14 +96,18 @@ only bounded-completion authority.
    preparation. Fail closed on mixed or unknown combinations.
 
    For `stop`, run the canonical evaluator once to validate the full typed
-   result. Accept it only with `PREPARATION_HOLD_ACTIVE`; preserve that reviewed
-   HOLD evidence, leave the acquisition in place, report the terminal hold, and
-   end. Do not record module completion or reacquire the target. Reject an
-   unknown action or an unreviewed stop without mutation or an evaluation loop.
-3. For `build`, `certify`, or an identity-only `prepare` exception, resolve the
-   acquired track's exact registered semantic profile from the manifest. Put
-   the typed context in a gitignored runtime JSON file; never add free-form
-   prompt prose to a profile:
+   result. `PREPARATION_HOLD_ACTIVE` without a partial-bundle finding is a
+   terminal reviewed HOLD: preserve its evidence, leave the acquisition in
+   place, report the hold, and do not record module completion or reacquire. A
+   result whose state is `partial-bundle`, contains `PARTIAL_LEARNER_BUNDLE`
+   owned by `built_artifact`, and has no active HOLD goes once to
+   `$track-completion` for its existing forensic recovery. Do not reacquire.
+   Reject a result containing both routes, or any unknown stop combination,
+   without mutation or an evaluation loop.
+3. For `build`, `certify`, an identity-only `prepare` exception, or the exact
+   partial-bundle `stop` exception, resolve the acquired track's registered
+   semantic profile from the manifest. Put the typed context in a gitignored
+   runtime JSON file; never add free-form prompt prose to a profile:
 
    ```bash
    .venv/bin/python scripts/orchestration/prompt_contracts.py resolve-track \

--- a/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
@@ -11,11 +11,12 @@ never invoke `$curriculum-lifecycle`; that skill may call this one, and this one
 returns its typed result to the caller.
 
 When `$curriculum-lifecycle` delegates an acquired target whose canonical
-`next_action` is `plan` or `prepare`, accept its exact target and acquisition
-binding, run canonical readiness before mutation, and remain inside this
-preparation scope. Never start, resume, or reacquire lifecycle. Rerun canonical
-readiness after each preparation mutation, then return the first fresh `build`,
-`certify`, or reviewed `stop` result to the caller.
+`next_action` is `plan` or `prepare`, accept and validate its exact full typed
+result bound to the target and acquisition. Remain inside this preparation
+scope. Never start, resume, or reacquire lifecycle. Rerun canonical readiness
+after each preparation mutation, then return the fresh typed result to the
+caller. This may be `build`, `certify`, reviewed `stop`, or the unchanged
+identity-only `prepare` exception described below.
 This lets a standalone preparation campaign stop with a build-authorized queue
 without starting lifecycle or building learner modules.
 
@@ -65,16 +66,18 @@ actions, but each failed requirement keeps its declared owner:
 - Route a failed `plan` requirement through the registered plan owner,
   then resume this exact preparation scope; do not absorb or duplicate its
   plan-review and approval policy.
-- Act directly only on a failed `requirements[]` item owned by `preparation`, or
-  on the preparation-owned `PREPARATION_IDENTITY_DRIFT` finding.
-- When a built result has `next_action: prepare` only because
-  `PREPARATION_IDENTITY_MISSING` is owned by `audit_tooling`, return the typed
-  result unchanged. Do not regenerate preparation evidence.
+- Act directly only on a failed `requirements[]` item owned by `preparation`.
+- When every current requirement passes but a built result has
+  `next_action: prepare` solely because of `PREPARATION_IDENTITY_MISSING` or
+  `PREPARATION_IDENTITY_DRIFT`, return the fresh typed result unchanged to
+  lifecycle. Only `$track-completion` can derive the consumed build identity or
+  record its explicit rebuild. Do not regenerate preparation evidence, loop, or
+  treat this handoff as unfinished preparation work.
 - Leave passing requirements unchanged. Treat an alternative option as
   complete as soon as the evaluator marks its requirement passed.
-- Return `build`, `certify`, or `stop` results without performing that work. A
-  partial bundle, off-manifest target, or active hold is not preparation
-  authority.
+- Return `build`, `certify`, `stop`, or an identity-only `prepare` exception
+  without performing that work. A partial bundle, off-manifest target, or
+  active hold is not preparation authority.
 - Skip current cells during a missing-only scan. Do not rebuild or recertify a
   learner bundle from this skill.
 

--- a/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
@@ -10,6 +10,15 @@ engine. Prepare prerequisite evidence only. Produce no learner module bundle and
 never invoke `$curriculum-lifecycle`; that skill may call this one, and this one
 returns its typed result to the caller.
 
+When `$curriculum-lifecycle` delegates an acquired target whose canonical
+`next_action` is `plan` or `prepare`, accept its exact target and acquisition
+binding, run canonical readiness before mutation, and remain inside this
+preparation scope. Never start, resume, or reacquire lifecycle. Rerun canonical
+readiness after each preparation mutation, then return the first fresh `build`,
+`certify`, or reviewed `stop` result to the caller.
+This lets a standalone preparation campaign stop with a build-authorized queue
+without starting lifecycle or building learner modules.
+
 ## Accept one exact scope
 
 Accept exactly one of these operator forms:
@@ -50,17 +59,21 @@ The command emits the schema-validated
 standalone use, omit that option unless the operator supplied an authoritative
 identity; never infer one.
 
-Use the result cell by cell:
+Use the result cell by cell. `plan` and `prepare` are both preparation-scope
+actions, but each failed requirement keeps its declared owner:
 
-- Act only on a failed `requirements[]` item owned by `preparation`, or on the
-  preparation-owned `PREPARATION_IDENTITY_DRIFT` finding.
+- Route a failed `plan` requirement through the registered plan owner,
+  then resume this exact preparation scope; do not absorb or duplicate its
+  plan-review and approval policy.
+- Act directly only on a failed `requirements[]` item owned by `preparation`, or
+  on the preparation-owned `PREPARATION_IDENTITY_DRIFT` finding.
 - When a built result has `next_action: prepare` only because
   `PREPARATION_IDENTITY_MISSING` is owned by `audit_tooling`, return the typed
   result unchanged. Do not regenerate preparation evidence.
 - Leave passing requirements unchanged. Treat an alternative option as
   complete as soon as the evaluator marks its requirement passed.
-- Return `plan`, `build`, `certify`, or `stop` results without performing that
-  work. A partial bundle, off-manifest target, or active hold is not preparation
+- Return `build`, `certify`, or `stop` results without performing that work. A
+  partial bundle, off-manifest target, or active hold is not preparation
   authority.
 - Skip current cells during a missing-only scan. Do not rebuild or recertify a
   learner bundle from this skill.
@@ -117,8 +130,8 @@ result schema.
 
 In standalone use, report the exact result and end at its `next_action`. When
 called by `$curriculum-lifecycle`, return the same result and action to that
-caller, which owns the next transition. Preparation never calls lifecycle in
-either mode.
+caller, which owns the next transition without reacquisition. Preparation never
+calls lifecycle in either mode.
 
 On resume, reuse the exact target scope, typed results, identities, hashes, and
 durable review receipt. Run canonical readiness first, discard stale cells, and

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -25,9 +25,13 @@ for a code/infra diff and never repeats this learner-content semantic gate.
 `build` or `certify`, plus one narrow class of `prepare` result: the bundle is
 built, every current requirement passes, and the only remaining reason is
 `PREPARATION_IDENTITY_MISSING` or `PREPARATION_IDENTITY_DRIFT`. `plan`, any
-`prepare` with a failed plan/preparation requirement, and `stop` remain outside
-this skill. Treat every incoming result only as owner routing, never as
-caller-supplied build or certification authority.
+`prepare` with a failed plan/preparation requirement, and reviewed HOLD `stop`
+remain outside this skill. One `stop` exception enters here: canonical state
+`partial-bundle` with `PARTIAL_LEARNER_BUNDLE` owned by `built_artifact` and no
+`PREPARATION_HOLD_ACTIVE`. It follows the existing `PARTIAL_RECOVERY_REQUIRED`
+forensic path. Treat every incoming result only as owner routing, never as
+caller-supplied build or certification authority. A mixed or unknown stop fails
+closed.
 
 For the exception, derive the consumed preparation identity from the latest
 `BUILD_RECORDED` event in this authoritative ledger and rerun canonical

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -21,6 +21,16 @@ module workflow. `$curriculum-lifecycle` may order and acquire the module, but
 it must not reproduce this completion policy. `$local-code-review` is reserved
 for a code/infra diff and never repeats this learner-content semantic gate.
 
+`$curriculum-lifecycle` hands a target here only when the latest canonical
+preparation result says `next_action: build` or `next_action: certify`; `plan`,
+`prepare`, and `stop` remain outside this skill. Treat that result only as owner
+routing, never as caller-supplied build or certification authority. Before
+consuming a build, the engine reruns canonical readiness, derives the consumed
+preparation identity from the latest `BUILD_RECORDED` event, and requires every
+current preparation requirement to pass. Missing, incomplete, or stale
+preparation therefore fails closed in standalone use as well; do not weaken or
+bypass this identity-consumption gate.
+
 ## Canonical entry paths
 
 New and existing modules use one lifecycle, not separate completion systems:

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -21,15 +21,20 @@ module workflow. `$curriculum-lifecycle` may order and acquire the module, but
 it must not reproduce this completion policy. `$local-code-review` is reserved
 for a code/infra diff and never repeats this learner-content semantic gate.
 
-`$curriculum-lifecycle` hands a target here only when the latest canonical
-preparation result says `next_action: build` or `next_action: certify`; `plan`,
-`prepare`, and `stop` remain outside this skill. Treat that result only as owner
-routing, never as caller-supplied build or certification authority. Before
-consuming a build, the engine reruns canonical readiness, derives the consumed
-preparation identity from the latest `BUILD_RECORDED` event, and requires every
-current preparation requirement to pass. Missing, incomplete, or stale
-preparation therefore fails closed in standalone use as well; do not weaken or
-bypass this identity-consumption gate.
+`$curriculum-lifecycle` hands a target here when the latest canonical result is
+`build` or `certify`, plus one narrow class of `prepare` result: the bundle is
+built, every current requirement passes, and the only remaining reason is
+`PREPARATION_IDENTITY_MISSING` or `PREPARATION_IDENTITY_DRIFT`. `plan`, any
+`prepare` with a failed plan/preparation requirement, and `stop` remain outside
+this skill. Treat every incoming result only as owner routing, never as
+caller-supplied build or certification authority.
+
+For the exception, derive the consumed preparation identity from the latest
+`BUILD_RECORDED` event in this authoritative ledger and rerun canonical
+readiness with it. Continue only from that fresh result: certify when current,
+or take the existing explicit preparation-rebuild transition when the identity
+differs. A failed requirement or mixed/unknown combination fails closed. Do not
+weaken or bypass this identity-consumption gate.
 
 ## Canonical entry paths
 

--- a/tests/orchestration/test_prompt_contracts.py
+++ b/tests/orchestration/test_prompt_contracts.py
@@ -709,3 +709,37 @@ def test_four_skill_entrypoints_route_normal_bio_work_to_one_bounded_ledger() ->
     assert "without retrying" in post_build
     assert "supports only `code` and `infra`" in code_review
     assert "Do not duplicate post-build semantic review" in normalized_code_review
+
+
+def test_curriculum_skills_define_one_non_recursive_preparation_handoff() -> None:
+    skill_root = REPO_ROOT / "agents_extensions/shared/skills"
+    lifecycle = (skill_root / "curriculum-lifecycle/SKILL.md").read_text(encoding="utf-8")
+    preparation = (skill_root / "curriculum-preparation/SKILL.md").read_text(encoding="utf-8")
+    completion = (skill_root / "track-completion/SKILL.md").read_text(encoding="utf-8")
+    normalized_lifecycle = " ".join(lifecycle.split())
+    normalized_preparation = " ".join(preparation.split())
+    normalized_completion = " ".join(completion.split())
+
+    for family in ("CORE", "seminar", "BIO"):
+        assert family in lifecycle
+    for action, owner in (
+        ("`plan`", "`$curriculum-preparation`"),
+        ("`prepare`", "`$curriculum-preparation`"),
+        ("`build`", "`$track-completion`"),
+        ("`certify`", "`$track-completion`"),
+        ("`stop`", "Terminal reviewed HOLD"),
+    ):
+        assert f"| {action} | {owner} |" in lifecycle
+
+    assert "readiness routing snapshot from the latest matching `MODULE_ACQUIRED` event" in normalized_lifecycle
+    assert "do not call `acquire-next` again" in normalized_lifecycle
+    assert "PREPARATION_HOLD_ACTIVE" in normalized_lifecycle
+    assert "Do not record module completion or reacquire" in normalized_lifecycle
+    assert "without mutation or an evaluation loop" in normalized_lifecycle
+    assert "Never start, resume, or reacquire lifecycle" in normalized_preparation
+    assert "failed `plan` requirement" in normalized_preparation
+    assert "build-authorized queue" in normalized_preparation
+    assert "Preparation never calls lifecycle" in normalized_preparation
+    assert "only when the latest canonical preparation result says" in normalized_completion
+    assert "latest `BUILD_RECORDED` event" in normalized_completion
+    assert "identity-consumption gate" in normalized_completion

--- a/tests/orchestration/test_prompt_contracts.py
+++ b/tests/orchestration/test_prompt_contracts.py
@@ -727,7 +727,7 @@ def test_curriculum_skills_define_one_non_recursive_preparation_handoff() -> Non
         ("`prepare`", "Requirement- and identity-sensitive; resolve from the full result"),
         ("`build`", "`$track-completion`"),
         ("`certify`", "`$track-completion`"),
-        ("`stop`", "Terminal reviewed HOLD"),
+        ("`stop`", "State- and owner-sensitive; reviewed HOLD or partial recovery"),
     ):
         assert f"| {action} | {owner} |" in lifecycle
 
@@ -740,8 +740,13 @@ def test_curriculum_skills_define_one_non_recursive_preparation_handoff() -> Non
     assert "hand the exact target to `$track-completion`" in normalized_lifecycle
     assert "Do not reacquire, repeat the evaluator, or loop through preparation" in normalized_lifecycle
     assert "PREPARATION_HOLD_ACTIVE" in normalized_lifecycle
-    assert "Do not record module completion or reacquire" in normalized_lifecycle
-    assert "without mutation or an evaluation loop" in normalized_lifecycle
+    assert "without a partial-bundle finding is a terminal reviewed HOLD" in normalized_lifecycle
+    assert "do not record module completion or reacquire" in normalized_lifecycle
+    assert "state is `partial-bundle`" in normalized_lifecycle
+    assert "PARTIAL_LEARNER_BUNDLE" in normalized_lifecycle
+    assert "has no active HOLD" in normalized_lifecycle
+    assert "goes once to `$track-completion`" in normalized_lifecycle
+    assert "Reject a result containing both routes" in normalized_lifecycle
     assert "accept and validate its exact full typed result" in normalized_preparation
     assert "Never start, resume, or reacquire lifecycle" in normalized_preparation
     assert "failed `plan` requirement" in normalized_preparation
@@ -761,3 +766,9 @@ def test_curriculum_skills_define_one_non_recursive_preparation_handoff() -> Non
     assert "latest `BUILD_RECORDED` event" in normalized_completion
     assert "identity-consumption gate" in normalized_completion
     assert "`plan`, `prepare`, and `stop` remain outside this skill" not in normalized_completion
+    assert "reviewed HOLD `stop` remain outside this skill" in normalized_completion
+    assert "canonical state `partial-bundle`" in normalized_completion
+    assert "PARTIAL_LEARNER_BUNDLE" in normalized_completion
+    assert "and no `PREPARATION_HOLD_ACTIVE`" in normalized_completion
+    assert "existing `PARTIAL_RECOVERY_REQUIRED` forensic path" in normalized_completion
+    assert "A mixed or unknown stop fails closed" in normalized_completion

--- a/tests/orchestration/test_prompt_contracts.py
+++ b/tests/orchestration/test_prompt_contracts.py
@@ -724,7 +724,7 @@ def test_curriculum_skills_define_one_non_recursive_preparation_handoff() -> Non
         assert family in lifecycle
     for action, owner in (
         ("`plan`", "`$curriculum-preparation`"),
-        ("`prepare`", "`$curriculum-preparation`"),
+        ("`prepare`", "Requirement- and identity-sensitive; resolve from the full result"),
         ("`build`", "`$track-completion`"),
         ("`certify`", "`$track-completion`"),
         ("`stop`", "Terminal reviewed HOLD"),
@@ -732,14 +732,32 @@ def test_curriculum_skills_define_one_non_recursive_preparation_handoff() -> Non
         assert f"| {action} | {owner} |" in lifecycle
 
     assert "readiness routing snapshot from the latest matching `MODULE_ACQUIRED` event" in normalized_lifecycle
-    assert "do not call `acquire-next` again" in normalized_lifecycle
+    assert "use its full typed result to resolve ownership" in normalized_lifecycle
+    assert "If any current failed requirement is owned by `plan` or `preparation`" in normalized_lifecycle
+    assert "every current requirement passes but a built result remains `prepare`" in normalized_lifecycle
+    assert "PREPARATION_IDENTITY_MISSING" in normalized_lifecycle
+    assert "PREPARATION_IDENTITY_DRIFT" in normalized_lifecycle
+    assert "hand the exact target to `$track-completion`" in normalized_lifecycle
+    assert "Do not reacquire, repeat the evaluator, or loop through preparation" in normalized_lifecycle
     assert "PREPARATION_HOLD_ACTIVE" in normalized_lifecycle
     assert "Do not record module completion or reacquire" in normalized_lifecycle
     assert "without mutation or an evaluation loop" in normalized_lifecycle
+    assert "accept and validate its exact full typed result" in normalized_preparation
     assert "Never start, resume, or reacquire lifecycle" in normalized_preparation
     assert "failed `plan` requirement" in normalized_preparation
     assert "build-authorized queue" in normalized_preparation
+    assert "return the fresh typed result unchanged to lifecycle" in normalized_preparation
+    assert "PREPARATION_IDENTITY_MISSING" in normalized_preparation
+    assert "PREPARATION_IDENTITY_DRIFT" in normalized_preparation
+    assert "Only `$track-completion` can derive the consumed build identity" in normalized_preparation
+    assert "treat this handoff as unfinished preparation work" in normalized_preparation
     assert "Preparation never calls lifecycle" in normalized_preparation
-    assert "only when the latest canonical preparation result says" in normalized_completion
+    assert "plus one narrow class of `prepare` result" in normalized_completion
+    assert "PREPARATION_IDENTITY_MISSING" in normalized_completion
+    assert "PREPARATION_IDENTITY_DRIFT" in normalized_completion
+    assert "any `prepare` with a failed plan/preparation requirement" in normalized_completion
+    assert "rerun canonical readiness with it" in normalized_completion
+    assert "existing explicit preparation-rebuild transition" in normalized_completion
     assert "latest `BUILD_RECORDED` event" in normalized_completion
     assert "identity-consumption gate" in normalized_completion
+    assert "`plan`, `prepare`, and `stop` remain outside this skill" not in normalized_completion


### PR DESCRIPTION
## Summary

- route acquired readiness by full typed ownership: failed `plan`/`preparation` requirements stay in `$curriculum-preparation`, while built identity-only `prepare` results hand off once to `$track-completion`
- cover both identity-only cases—`PREPARATION_IDENTITY_MISSING` and `PREPARATION_IDENTITY_DRIFT`—so the authoritative completion ledger reruns readiness from `BUILD_RECORDED` and either certifies or uses its existing rebuild transition
- make `stop` state/owner-sensitive: `PREPARATION_HOLD_ACTIVE` remains a terminal reviewed HOLD, while exact `partial-bundle` + `PARTIAL_LEARNER_BUNDLE:built_artifact` hands off once to track-completion forensic recovery
- reject mixed/unknown stop combinations, preserve non-recursion/no-reacquisition, and pin the uniform CORE/seminar/BIO boundary in focused contract tests

The merged #5481 coordinator already persists the routing snapshot in the matching `MODULE_ACQUIRED` event, so no coordinator code change or second controller was needed.

## Review correction

- resolves Grok F001 on corrected head `b7b37f32`: partial learner bundles no longer dead-end as reviewed HOLD stops

## Validation

- `.venv/bin/python -m pytest -q -n 0 tests/orchestration/test_prompt_contracts.py tests/test_track_completion.py::test_certification_rejects_built_bundle_without_consumed_preparation_identity` — 52 passed
- `.venv/bin/python scripts/lint/lint_agent_skills.py` — 16 skills valid
- `.venv/bin/ruff check tests/orchestration/test_prompt_contracts.py` — passed
- `.venv/bin/ruff format --check tests/orchestration/test_prompt_contracts.py` — passed
- `markdownlint-cli2` on changed skill files — 0 errors
- `git diff --check` and protected/generated-artifact guard — passed; PR remains exactly 4 scoped files
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — all 3 commits passed

No learner modules, plans, dossiers, wikis, readings, generated artifacts, or coordinator code changed. No additional review was requested.

Parent stream epic: #4431

Closes #5471