### PR TITLE
fix(bridge): warn not reject PR CF ask without review-pr target

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -221,5 +221,7 @@ For **GitHub PR formal cross-family review**, do **not** use fat `ask-* --review
   --pr <N> --verdict-file /tmp/verdict.txt --model <model> --family <family> --harness <harness>
 ```
 
-Bridge refuse: `formal_pr_review_requires_review_pr` (#5486). See `docs/best-practices/agent-bridge.md`.
+Bridge steers with a **warning** (not refuse) if `ask-* --review` looks like PR CF
+without a sealed target — so agent work is not discarded (#5486 warn-not-reject).
+Size caps still fail closed. See `docs/best-practices/agent-bridge.md`.
 

--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -182,13 +182,14 @@ body over 4 KiB or attach evidence over 64 KiB to an `ask-*` review job; the
 bridge rejects it and points to `review-pr <N>`. Prefer a PR target over a
 manual review ask.
 
-**Phase 5 fail-closed (#5486):** if an `ask-* --review` payload looks like a
-**formal CF PR review** (GitHub PR URL / `PR #N` / cross-family formal wording)
-and has **no** sealed `review_pr` / `review_branch` target, the bridge **refuses**
-with `formal_pr_review_requires_review_pr`. Use `review-pr <N>` then
-`publish-review-verdict`. Curriculum content reviews that use `--review` without
-a PR URL still work. Emergency escape only:
-`BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1`.
+**Phase 5 steer (warn-not-reject, #5486):** if an `ask-* --review` payload looks
+like a **formal CF PR review** (GitHub PR URL / `PR #N` / cross-family formal
+wording) and has **no** sealed `review_pr` / `review_branch` target, the bridge
+prints a **warning** and still delivers the ask — rejecting after the agent
+already wrote a formal review wastes work when the agent did not know to use
+`review-pr`. Prefer `review-pr <N>` then `publish-review-verdict` for new work.
+**Size caps remain fail-closed** for oversized bodies/attachments. Silence the
+steering warning with `BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1`.
 
 **Phase 4 residual (#5485):** migrate runbooks and dispatch briefs that still say
 `ask-agy --review` / `ask-codex --review` for PR gates to `review-pr` +

--- a/scripts/ai_agent_bridge/_review_safety.py
+++ b/scripts/ai_agent_bridge/_review_safety.py
@@ -253,7 +253,7 @@ def assert_formal_review_ask_payload(
     if not formal_review:
         return False
 
-    assert_pr_cf_review_uses_review_pr(
+    warn_pr_cf_review_prefer_review_pr(
         content, formal_review=True, has_target=has_target
     )
 
@@ -307,29 +307,35 @@ def warn_missing_review_target(*, formal_review: bool, has_target: bool) -> None
         )
 
 
-def assert_pr_cf_review_uses_review_pr(
+def warn_pr_cf_review_prefer_review_pr(
     content: str,
     *,
     formal_review: bool,
     has_target: bool,
 ) -> None:
-    """Phase 5: formal CF PR review without a sealed target is refused.
+    """Phase 5: steer PR CF reviews to review-pr without discarding agent work.
 
-    Curriculum content reviews that pass --review without a PR URL continue to
-    work. Escape: BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1.
+    Rejecting after a model already generated a formal PR review is wasteful when
+    the agent did not know to use review-pr. Emit a strong warning instead; size
+    caps still fail closed for oversized bodies/attachments.
     """
     if not formal_review or has_target:
         return
     if allow_legacy_review_ask_escape():
         return
     if looks_like_pr_cf_review(content):
-        raise ReviewSafetyError(
-            "formal_pr_review_requires_review_pr: use "
-            "`scripts/ai_agent_bridge/__main__.py review-pr <N>` for sealed "
-            "pointer-only CF review, then `publish-review-verdict` for the thin "
-            "GH comment. Fat ask-* --review with a PR URL is refused (fleet-comms "
-            "Phase 5 / #5486). Escape only with BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1."
+        print(
+            "warning: formal CF PR review via ask-* without a sealed target — "
+            "prefer `scripts/ai_agent_bridge/__main__.py review-pr <N>` (pointer-only) "
+            "then `publish-review-verdict`. This ask is allowed so work is not discarded "
+            "(fleet-comms Phase 5 / #5486; warn-not-reject). "
+            "Silence with BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1.",
+            file=sys.stderr,
         )
+
+
+# Back-compat alias used by older call sites / tests.
+assert_pr_cf_review_uses_review_pr = warn_pr_cf_review_prefer_review_pr
 
 
 def allow_primary_hermes_escape() -> bool:

--- a/tests/ai_agent_bridge/test_review_pr_required.py
+++ b/tests/ai_agent_bridge/test_review_pr_required.py
@@ -1,4 +1,4 @@
-"""Phase 5: formal PR CF review without sealed target is refused (#5486)."""
+"""Phase 5: formal PR CF review without sealed target warns (not reject) (#5486)."""
 
 from __future__ import annotations
 
@@ -11,13 +11,14 @@ def test_looks_like_pr_cf_review_detects_github_pr_url() -> None:
     assert safety.looks_like_pr_cf_review(body) is True
 
 
-def test_assert_pr_cf_review_refuses_without_target() -> None:
+def test_assert_pr_cf_review_warns_without_target(capsys: pytest.CaptureFixture[str]) -> None:
     body = (
         "Formal cross-family PR review for "
         "https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5480\n"
         "VERDICT: APPROVED"
     )
-    with pytest.raises(safety.ReviewSafetyError, match="formal_pr_review_requires_review_pr"):
+    # Warn-not-reject: agent work is not discarded.
+    assert (
         safety.assert_formal_review_ask_payload(
             body,
             msg_type="review",
@@ -25,9 +26,14 @@ def test_assert_pr_cf_review_refuses_without_target() -> None:
             review=True,
             has_target=False,
         )
+        is True
+    )
+    err = capsys.readouterr().err
+    assert "prefer" in err and "review-pr" in err
+    assert "warn-not-reject" in err or "not discarded" in err
 
 
-def test_assert_pr_cf_review_allows_with_target() -> None:
+def test_assert_pr_cf_review_allows_with_target(capsys: pytest.CaptureFixture[str]) -> None:
     body = "https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5480 thin pointer"
     assert (
         safety.assert_formal_review_ask_payload(
@@ -39,9 +45,10 @@ def test_assert_pr_cf_review_allows_with_target() -> None:
         )
         is True
     )
+    assert "prefer" not in capsys.readouterr().err
 
 
-def test_content_review_without_pr_url_still_allowed() -> None:
+def test_content_review_without_pr_url_still_allowed(capsys: pytest.CaptureFixture[str]) -> None:
     body = "Please review this curriculum module for calques and naturalness."
     assert (
         safety.assert_formal_review_ask_payload(
@@ -53,9 +60,12 @@ def test_content_review_without_pr_url_still_allowed() -> None:
         )
         is True
     )
+    assert "prefer" not in capsys.readouterr().err
 
 
-def test_legacy_escape_allows_pr_url_without_target(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_legacy_escape_silences_pr_url_warning(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     monkeypatch.setenv("BRIDGE_ALLOW_LEGACY_REVIEW_ASK", "1")
     body = "https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/1"
     assert (
@@ -68,4 +78,5 @@ def test_legacy_escape_allows_pr_url_without_target(monkeypatch: pytest.MonkeyPa
         )
         is True
     )
+    assert "prefer" not in capsys.readouterr().err
     monkeypatch.delenv("BRIDGE_ALLOW_LEGACY_REVIEW_ASK", raising=False)


### PR DESCRIPTION
## Summary

Operator feedback: hard-refusing formal CF PR reviews via `ask-*` is wasteful when the agent already generated the review and did not know to use `review-pr`.

**Change:** `formal_pr_review_requires_review_pr` path is now **warn-not-reject** (stderr steering to `review-pr` + `publish-review-verdict`). **Size caps stay fail-closed.**

## Tests
- Updated `tests/ai_agent_bridge/test_review_pr_required.py`

X-Agent: grok/5486-warn-not-reject