### PR TITLE
docs(session-state): 2026-07-19 orchestrator finish-wave handoff

### DIFF
--- a/docs/session-state/2026-07-19-orchestrator-practice-atlas-fleet-comms-finish-brief.md
+++ b/docs/session-state/2026-07-19-orchestrator-practice-atlas-fleet-comms-finish-brief.md
@@ -1,0 +1,104 @@
+---
+date: 2026-07-19
+session: "Grok orchestrator: practice chrome + paronyms + sentence inventory + textbook atlas promote + fleet-comms Sol phases 0–5 finish + warn-not-reject PR CF policy. Session ended clean; durable handoff written after chat wrap-up."
+status: finish-wave-closed-session-handoff
+main_sha: b845eb95b5
+main_green: yes (wave PRs merged with CF review + CI)
+working_tree_dirty: no (this brief ships via PR)
+session_close: 2026-07-19
+driver: grok (orchestrator seat)
+---
+
+# 2026-07-19 — Practice + atlas + fleet-comms finish wave
+
+**THE ONE NEXT ACTION:** resume product queue on practice/atlas depth — do **not** re-open closed finish work. Preferred order: (1) spot-check live daily examples after #5487 inventory, (2) #5478 textbook re-enrich backlog when product capacity returns, (3) standing atlas/practice epics #4387 / #4700 / #4707, (4) deeper multi-surface sentences (#3797) only if daily still thin.
+
+## TL;DR
+
+This session closed a coordinated **finish wave** across practice UI, atlas textbook promotion, shared sentence inventory for daily practice, and fleet-comms isolation (Sol phases 0–5 + policy fix). User priority: activity/practice over textbook re-enrich; finish everything; always run cross-family `review-pr` before merge; end session with a durable handoff (this file — chat wrap-up alone was not enough).
+
+## ✅ Merged this session (finish wave)
+
+| PR | What landed |
+| --- | --- |
+| **#5474 / #5475** | Fleet doctrine + living role scorecard; Haiku recon seat documented |
+| **#5477** | Textbook-curated bulk promote (#3934): promote then prune unenriched so richness floor stays ≥40% (~17.7k published / ~42% enrichment). Unenriched held heads → backlog **#5478** |
+| **#5479** | Practice full-locale session chrome residuals (#5355): dual chrome (`data-chrome-locale`), A1 bilingual vs full EN/UK switch, ChromeText / PracticeChromeLabel |
+| **#5480 / #5489** | Paronym pairs expanded (#4506) 7→20; Ukrainian apostrophe fix `пам’ятка` (not `пам-ятка`) |
+| **#5487** | Source-backed sentence inventory for daily practice — generator + `lexicon-sentence-inventory.json`; corpus/ULP/textbook-first (not Clozemaster import); ~287/300 example coverage on daily pool overlay |
+| **#5488** | Fleet-comms Phase 4–5 residuals: formal PR CF review requires `review-pr` / target (#5485/#5486) |
+| **#5491** | Policy fix: fat formal PR CF ask without `review-pr` target is **warn-not-reject** (size caps still fail-closed) |
+
+Also on main near session close (adjacent lanes / prep track, not this driver’s exclusive work): #5463 track-completion bound repair, #5464 practice CTA, #5465 thin review verdicts, #5466 daily example sentences UI, #5473/#5476/#5481/#5482/#5490 curriculum preparation / readiness stack.
+
+## ✅ Issues closed this session
+
+- **#5483** — sentence inventory ASAP task (shipped via #5487)
+- **#5484** — [EPIC] fleet-comms isolation & thin-review program Sol phases 0–5 (CLOSED)
+- **#5485 / #5486** — formal PR CF + review-pr residuals (shipped #5488)
+- **#4506** — paronym expansion (shipped #5480 + apostrophe #5489)
+
+## Product / architecture decisions (carry forward)
+
+1. **Sentences:** multi-surface inventory, not Clozemaster product import. Prefer textbooks, ULP, Tatoeba/corpus already in repo. Daily practice consumes `example` / `exampleEn` from inventory overlay.
+2. **Textbook atlas:** publish only enrichment-safe slice; never lower richness floor. Re-enrich is a separate tracked backlog (#5478), not a silent republish of thin heads.
+3. **Practice chrome:** A1 keeps English scaffolding by design; full-locale switch must not double-English or leave residual EN chrome.
+4. **Fleet-comms:** pointer-only / caps / `review-pr` / `publish-review-verdict` path. Formal PR CF asks that skip `review-pr` **warn** (steer agents) rather than hard-reject wasteful work; absolute size caps remain hard fail-closed.
+5. **Reviews:** discussion/panels do **not** satisfy the merge gate. Cross-family `review-pr` every merge. Arm auto-merge after CF gate pass.
+6. **Orchestrator posture:** drive, don’t babysit; ask only when blocked; prefer activity/practice product work over textbook re-enrich unless user reprioritizes.
+
+## Key paths (if resuming code)
+
+| Area | Paths |
+| --- | --- |
+| Practice chrome | `src/…/LexiconPractice.tsx`, practice chrome helpers (`chrome.ts` / labels) |
+| Sentence inventory | `scripts/…/generate_sentence_inventory.py`, published `lexicon-sentence-inventory.json` (or site data path from #5487) |
+| Paronyms | `paronym_pairs.yaml` (apostrophe-correct slugs) |
+| Fleet review safety | `scripts/ai_agent_bridge/_review_safety.py`, `_review_pr.py`, `_review_verdict.py` |
+| Fleet docs | `docs/…/fleet-shared-doctrine.md`, role scorecard |
+| Textbook promote | atlas promote + prune-to-floor pattern from #5477 |
+
+Exact filenames: verify on main with `git show` / PR files if paths drifted — do not invent.
+
+## ▶ NEXT QUEUE
+
+### Do soon (product)
+
+1. **Live spot-check** daily practice examples after #5487 inventory (UI already takes examples; confirm variety/quality on a few heads).
+2. **#5478** — re-enrich ~10.7k held textbook heads when enrichment capacity is intentional (do not rush into another bulk promote).
+3. **Atlas/practice depth** — #4387 practice hub, #4700 / #4707 standing epics; #5411 needs_review glosses (838) via enrich/anchor-fill, not raw inject.
+4. **#3797** — deeper Tatoeba / multi-surface only if daily still under-served after inventory.
+
+### Infra / fleet (when free, not session-critical)
+
+- #5392 large ask reply truncation (file-side channel)
+- #5400 worktree base_sha race
+- #5366 rollover exact-selector CI flake
+- #5326 Kimi lane onboard (if still open)
+- Curriculum preparation residual: #5472 prove bounded packets / hash reuse / no singleton review loops
+
+### Hygiene
+
+- Leftover dispatch worktrees from finish wave (k3 design, etc.) — reap when idle
+- No open finish-wave PRs expected; if any draft limbo appears, close or finish — do not leave limbo
+
+## Operating rules (unchanged, re-asserted)
+
+- Implementation only in `.worktrees/dispatch/<agent>/<task>/`
+- `.venv/bin/python`; never `sys.executable`
+- No `.python-version` / linter config edits; no status/audit artifact dumps in code PRs
+- `X-Agent` trailer on every commit
+- CF review before merge; auto-merge arm after gate
+
+## Handoff layers
+
+| Layer | Path | Notes |
+| --- | --- | --- |
+| **This brief** | `docs/session-state/2026-07-19-orchestrator-practice-atlas-fleet-comms-finish-brief.md` | Durable cross-agent record (MD only) |
+| **Codex orchestrator pointer** | `docs/session-state/codex-orchestrator-handoff.md` | Updated to point here + next focus |
+| **Thin pointer** | `docs/session-state/current.orchestrator.md` | Still points at codex-orchestrator-handoff.md |
+| **Local machine state** | `.agent/*-thread-handoff.md` | Gitignored; not authoritative across machines |
+
+## Session close note
+
+User asked to end the session; first reply was chat-only wrap-up. User correctly asked whether the durable handoff was written — it was **not**. This brief + orchestrator pointer update close that gap.

--- a/docs/session-state/codex-orchestrator-handoff.md
+++ b/docs/session-state/codex-orchestrator-handoff.md
@@ -1,76 +1,63 @@
-# Current - Codex Orchestrator Handoff (2026-06-06)
+# Current - Codex / Grok Orchestrator Handoff (2026-07-19)
 
-Latest-Brief: docs/session-state/codex-orchestrator-handoff.md
+Latest-Brief: docs/session-state/2026-07-19-orchestrator-practice-atlas-fleet-comms-finish-brief.md
 
 ## Role
 
-Codex is the A1/A2 retrofit PR gate and orchestrator. Workers open draft PRs
-and stop; the orchestrator checks the queue, reviews, assigns independent
-review, merges only when clean, and cleans up branches/worktrees.
+Orchestrator seat (Codex / Grok / Claude-infra as assigned): drive the product and
+infra queue, keep main clean, open PRs from worktrees only, require cross-family
+`review-pr` before merge, arm auto-merge after the gate, clean worktrees after merge.
+Do not babysit idle green PRs; do not leave draft limbo.
 
-Do not use `docs/session-state/current.md` as scratch space. It is the shared
-router. If it is dirty at startup, restore it from `origin/main` and stop to
-report. Durable orchestrator state lives in this file. Thread rollover packets
-live under `.agent/<agent>-thread-handoff.md`.
+Do not use `docs/session-state/current.md` as scratch space. Durable state lives in
+the Latest-Brief above and this file. Thread rollover packets live under
+`.agent/<agent>-thread-handoff.md` (machine-local).
 
-## Current State
+## Current State (session close 2026-07-19)
 
-- #2717 merged: neutral A1/A2 standards.
-- #2728 merged: A1/A2 retrofit audit protocol and evidence packet template.
-- #2734 merged: A1 M1-M7 retrofit audit/classification report.
-- #2736 merged: A1 M1-M7 plan/wiki/prompt repair.
-- #2736 merge commit: `7ebac72745a0a1dc12c97ee841e1e6c7869570d7`.
-- #2747 cleanup work is complete and merged, including the related cleanup PRs
-  #2767, #2765, #2770, #2771, #2772, and #2773.
-- #2774 merged: worker inbox control plane for orchestrator/delegate results.
+Finish wave **closed**. Main at ~`b845eb95b5` (and successors once this handoff PR merges).
 
-The A1 M1 pilot is still struggling. The current blocker is not "rebuild from
-scratch"; it is that early A1 gates/prompts are asking for mature error
-correction material too early, especially decolonization bad-form pairs. The
-likely direction is pure Ukrainian learner-facing A1 content first, then
-introduce Russianism/Anglicism contrast work later when students have enough
-Ukrainian to benefit from it.
+### Shipped / closed
+
+- Practice chrome dual-locale residuals: **#5479** (#5355)
+- Paronym expansion + apostrophe fix: **#5480**, **#5489** (#4506)
+- Source-backed sentence inventory for daily: **#5487** (#5483 closed)
+- Textbook bulk promote with enrichment floor: **#5477** (#3934); backlog **#5478** open
+- Fleet doctrine + Haiku recon: **#5474**, **#5475**
+- Fleet-comms Sol phases 0–5 epic **#5484** closed via **#5488** (#5485/#5486)
+- Warn-not-reject fat formal PR CF ask (prefer `review-pr`): **#5491**
+
+### Explicit non-goals for next cold-start
+
+- Do not re-litigate closed fleet-comms phases 0–5
+- Do not re-promote unenriched textbook heads without #5478 enrichment work
+- Do not import Clozemaster as a product; inventory is multi-surface / corpus-first
 
 ## Operating Rules
 
-- One active A1/A2 PR maximum.
-- Before dispatching or reviewing, check open PRs and active delegates.
-- Do not start duplicate work if a worker is already running.
-- Do not create a new branch/worktree unless fixing the PR under review.
-- Do not touch generated status/audit/review artifacts unless explicitly in
-  scope.
-- Do not modify `.python-version`, `.yamllint`, or `.markdownlint.json`.
-- Do not use third-party workbook/product/trademark names in repo files,
-  branch names, PR titles/bodies, issue comments, or internal handles.
-- Do not copy, quote, summarize, store, extract, embed, or derive from paid
-  commercial materials.
-- Use `.worktrees/dispatch/<agent>/<task>/` for implementation work.
-- Every commit must carry an `X-Agent` trailer.
-- Use `.venv/bin/python`, not `sys.executable` or system Python.
-
-## Review Policy
-
-Use deterministic checks first. Use Gemini for independent review when required
-by the gate. Add DeepSeek, Claude, or Cursor review when there is meaningful
-language/register/pedagogy/build risk. The orchestrator remains responsible for
-rejecting false positives and fixing or routing valid findings.
+- Implementation only under `.worktrees/dispatch/<agent>/<task>/`
+- Every commit: `X-Agent` trailer
+- Use `.venv/bin/python`, never `sys.executable`
+- Never touch `.python-version`, `.yamllint`, `.markdownlint.json`
+- No status/audit/review artifact dumps in code PRs
+- CF review gate = independent cross-family `review-pr` (discuss ≠ review)
+- Prefer activity/practice product work over textbook re-enrich unless reprioritized
 
 ## Startup Checks
 
 ```bash
 cd /Users/krisztiankoos/projects/learn-ukrainian
 git fetch origin main --prune
-git status --short -- docs/session-state/current.md
-gh pr list --state open --json number,title,isDraft,mergeStateStatus,headRefName,url --limit 50
-gh pr list --search 'A1 A2 in:title,body is:open repo:learn-ukrainian/learn-ukrainian.github.io' --json number,title,isDraft,mergeStateStatus,headRefName,url --limit 50
-curl -sS http://127.0.0.1:8765/api/delegate/active
-.venv/bin/python scripts/orchestration/orchestrator_control.py inbox --recent 20 --include-results
+git status --short --branch
+gh pr list --state open --json number,title,isDraft,mergeStateStatus,headRefName,url --limit 30
+curl -sS --max-time 2 "http://127.0.0.1:8765/api/orient?lean=true" || true
+# Read latest brief:
+# docs/session-state/2026-07-19-orchestrator-practice-atlas-fleet-comms-finish-brief.md
 ```
 
 ## Next Focus
 
-After the handoff split lands, prepare the next worker prompt to adjust the A1
-plan/wiki/gate assumptions so the beginning of A1 teaches clean Ukrainian
-directly and does not require decolonization bad-form contrast inventory in M1.
-The worker should not run a content rebuild until the gating expectation is
-fixed.
+1. Spot-check live daily practice examples (inventory #5487 already merged).
+2. When enrichment capacity is intentional: **#5478** re-enrich held textbook heads.
+3. Atlas/practice depth: #4387, #4700, #4707, #5411 (glosses via enrich, not raw inject).
+4. Infra backlog only when free: #5392, #5400, #5366, #5472 (prep prove-out).

--- a/docs/session-state/current.orchestrator.md
+++ b/docs/session-state/current.orchestrator.md
@@ -1,8 +1,12 @@
 # Current Orchestrator Handoff Pointer
 
-The durable Codex orchestrator handoff now lives at:
+The durable orchestrator handoff lives at:
 
 `docs/session-state/codex-orchestrator-handoff.md`
+
+**Latest session brief (2026-07-19 finish wave):**
+
+`docs/session-state/2026-07-19-orchestrator-practice-atlas-fleet-comms-finish-brief.md`
 
 `docs/session-state/current.md` may still point here for compatibility with
 older cold-start hooks. Do not write detailed session state into this pointer.


### PR DESCRIPTION
## Summary

- Adds durable session brief for the 2026-07-19 finish wave (practice chrome #5479, paronyms #5480/#5489, sentence inventory #5487, textbook promote #5477, fleet-comms #5488/#5491).
- Updates `codex-orchestrator-handoff.md` and thin `current.orchestrator.md` pointer for next cold-start.
- Chat wrap-up alone was incomplete; user asked for the written handoff.

## Test plan

- [x] Paths under `docs/session-state/` only
- [x] No code/config/artifact churn
- [ ] Skim brief for accuracy vs merged PR list