### PR TITLE
test(curriculum): prove bounded preparation packets

### DIFF
--- a/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
@@ -96,6 +96,11 @@ packet.
 
 For model-assisted preparation, enforce one shared budget for the exact scope:
 
+Use `scripts/bounded_packet.py` for executable packet admission, exact PASS
+reuse, review-path selection, and compact receipt/HOLD projection only. Drive
+all review, repair, and verification transitions through the canonical
+`../track-completion/scripts/bounded_completion.py` helper.
+
 1. Before every review dispatch, persist conservative budget evidence in the
    invoking task or controller's existing durable progress ledger or issue
    receipt. Key it to the ordered exact scope and current

--- a/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
@@ -97,8 +97,8 @@ packet.
 For model-assisted preparation, enforce one shared budget for the exact scope:
 
 Use `scripts/bounded_packet.py` for executable packet admission, exact PASS
-reuse, review-path selection, and compact receipt/HOLD projection only. Drive
-all review, repair, and verification transitions through the canonical
+reuse, hash-derived review scope, and compact receipt/HOLD projection only.
+Drive all review, repair, and verification transitions through the canonical
 `../track-completion/scripts/bounded_completion.py` helper.
 
 1. Before every review dispatch, persist conservative budget evidence in the

--- a/agents_extensions/shared/skills/curriculum-preparation/scripts/bounded_packet.py
+++ b/agents_extensions/shared/skills/curriculum-preparation/scripts/bounded_packet.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Pure packet projections for bounded curriculum preparation.
+
+Review and repair transitions remain owned by the canonical bounded-completion
+helper.  This module has no transport, persistence, or controller loop.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+_HELPER = Path(__file__).resolve().parents[2] / "track-completion/scripts/bounded_completion.py"
+_SPEC = importlib.util.spec_from_file_location("preparation_bounded_completion", _HELPER)
+if _SPEC is None or _SPEC.loader is None:  # pragma: no cover - broken installation
+    raise RuntimeError(f"Cannot load bounded-completion helper: {_HELPER}")
+bounded_completion = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = bounded_completion
+_SPEC.loader.exec_module(bounded_completion)
+
+
+class PreparationPacketError(RuntimeError):
+    """Fail-closed packet rejection with an optional compact receipt."""
+
+    def __init__(self, code: str, message: str, receipt: Mapping[str, Any] | None = None) -> None:
+        self.code = code
+        self.receipt = deepcopy(dict(receipt)) if receipt else None
+        super().__init__(f"[{code}] {message}")
+
+
+def _fail(code: str, message: str, receipt: Mapping[str, Any] | None = None) -> None:
+    raise PreparationPacketError(code, message, receipt)
+
+
+def _sha(value: object, label: str) -> str:
+    if not (
+        isinstance(value, str) and len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+    ):
+        _fail("IDENTITY_INVALID", f"{label} must be a lowercase SHA-256")
+    return value
+
+
+def _target(target: Mapping[str, Any]) -> str:
+    return f"{target['track']}/{target['slug']}"
+
+
+def _cell_hashes(cells: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
+    return [
+        {
+            "path": cell["path"],
+            "source_sha256": cell["source_sha256"],
+            "preparation_identity": cell["preparation_identity"],
+        }
+        for cell in cells
+    ]
+
+
+def _rejection_receipt(targets: Sequence[Mapping[str, Any]], reason_codes: Sequence[str]) -> dict[str, Any]:
+    cells = [
+        {
+            "path": cell.get("path"),
+            "source_sha256": cell.get("source_sha256"),
+            "preparation_identity": target.get("preparation_identity"),
+        }
+        for target in targets
+        for cell in target.get("cells", [])
+    ]
+    return {
+        "paths": [cell["path"] for cell in cells],
+        "hashes": cells,
+        "reason_codes": list(reason_codes),
+        "counts": {"model_calls": 0, "repairs": 0},
+    }
+
+
+def admit_packet(
+    targets: Sequence[Mapping[str, Any]],
+    *,
+    limit: int,
+    prior_passes: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Admit one finite homogeneous packet and mark only exact PASS reuse."""
+
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+        _fail("PACKET_LIMIT_INVALID", "limit must be a positive integer")
+    if not targets:
+        _fail("PACKET_EMPTY", "packet requires at least one target")
+    if len(targets) > limit:
+        _fail(
+            "PACKET_LIMIT_EXCEEDED",
+            "packet exceeds its finite limit",
+            _rejection_receipt(targets, ["PACKET_LIMIT_EXCEEDED"]),
+        )
+
+    profiles: set[tuple[str, str, str, str]] = set()
+    target_ids: set[str] = set()
+    paths: set[str] = set()
+    for target in targets:
+        required = (
+            "track",
+            "slug",
+            "profile_id",
+            "profile_version",
+            "family",
+            "preparation_identity",
+            "deterministic",
+            "cells",
+        )
+        if not isinstance(target, Mapping) or any(field not in target for field in required):
+            _fail("PACKET_TARGET_INVALID", "target is missing required fields")
+        target_id = _target(target)
+        if target_id in target_ids:
+            _fail("PACKET_TARGET_DUPLICATE", f"duplicate target: {target_id}")
+        target_ids.add(target_id)
+        profiles.add(tuple(str(target[field]) for field in ("track", "profile_id", "profile_version", "family")))
+        _sha(target["preparation_identity"], f"{target_id} preparation_identity")
+        if not isinstance(target["deterministic"], Mapping) or not isinstance(
+            target["deterministic"].get("passed"), bool
+        ):
+            _fail("DETERMINISTIC_RESULT_INVALID", f"{target_id} requires a boolean passed result")
+        if not isinstance(target["cells"], list) or not target["cells"]:
+            _fail("PACKET_TARGET_INVALID", f"{target_id} requires a finite cell list")
+        for cell in target["cells"]:
+            if not isinstance(cell, Mapping):
+                _fail("PACKET_CELL_INVALID", f"{target_id} contains a non-object cell")
+            path = cell.get("path")
+            if not isinstance(path, str) or not path or path in paths:
+                _fail("PACKET_CELL_INVALID", f"invalid or duplicate cell path: {path}")
+            paths.add(path)
+            _sha(cell.get("source_sha256"), f"{path} source_sha256")
+    if len(profiles) != 1:
+        _fail(
+            "PACKET_HETEROGENEOUS",
+            "track/profile/version/family must match",
+            _rejection_receipt(targets, ["PACKET_HETEROGENEOUS"]),
+        )
+
+    deterministic_failures = [target for target in targets if target.get("deterministic", {}).get("passed") is not True]
+    if deterministic_failures:
+        codes = sorted(
+            {
+                str(code)
+                for target in deterministic_failures
+                for code in target.get("deterministic", {}).get("reason_codes", ["DETERMINISTIC_FAILURE"])
+            }
+        )
+        _fail(
+            "DETERMINISTIC_FAILURE",
+            "local failure rejects before packet/model admission",
+            _rejection_receipt(targets, codes),
+        )
+
+    prior = {(cell["target"], cell["path"]): cell for cell in prior_passes if cell.get("verdict") == "PASS"}
+    scope = [
+        {
+            "target": _target(target),
+            "profile_id": target["profile_id"],
+            "profile_version": target["profile_version"],
+            "family": target["family"],
+            "preparation_identity": target["preparation_identity"],
+        }
+        for target in targets
+    ]
+    cells = []
+    for target in targets:
+        target_id = _target(target)
+        for source in target["cells"]:
+            previous = prior.get((target_id, source["path"]))
+            reused = bool(
+                previous
+                and previous.get("source_sha256") == source["source_sha256"]
+                and previous.get("preparation_identity") == target["preparation_identity"]
+            )
+            cells.append(
+                {
+                    "target": target_id,
+                    "path": source["path"],
+                    "source_sha256": source["source_sha256"],
+                    "preparation_identity": target["preparation_identity"],
+                    "reused_pass": reused,
+                }
+            )
+    return {
+        "scope": scope,
+        "scope_sha256": bounded_completion.sha256_json(scope),
+        "paths": [cell["path"] for cell in cells],
+        "hashes": _cell_hashes(cells),
+        "reason_codes": ["EXACT_PASS_REUSED"] if any(cell["reused_pass"] for cell in cells) else [],
+        "counts": {
+            "model_calls": 0,
+            "repairs": 0,
+            "reused_pass_cells": sum(cell["reused_pass"] for cell in cells),
+        },
+        "cells": cells,
+    }
+
+
+def source_identity(packet: Mapping[str, Any]) -> str:
+    """Hash the packet's exact ordered source and preparation identities."""
+
+    return bounded_completion.sha256_json(
+        [
+            {key: cell[key] for key in ("target", "path", "source_sha256", "preparation_identity")}
+            for cell in packet["cells"]
+        ]
+    )
+
+
+def select_review_paths(
+    packet: Mapping[str, Any],
+    *,
+    phase: str,
+    failed_paths: Sequence[str] = (),
+    changed_paths: Sequence[str] = (),
+    pass_paths: Sequence[str] = (),
+    requested_paths: Sequence[str] | None = None,
+) -> list[str]:
+    """Select INITIAL non-reused or FINAL changed-and-failed cells exactly."""
+
+    if phase == "INITIAL":
+        eligible = [cell["path"] for cell in packet["cells"] if not cell["reused_pass"]]
+    elif phase == "FINAL":
+        failed = set(failed_paths)
+        changed = set(changed_paths)
+        eligible = [cell["path"] for cell in packet["cells"] if cell["path"] in failed & changed]
+    else:
+        _fail("REVIEW_PHASE_INVALID", f"unsupported review phase: {phase}")
+    selected = list(eligible if requested_paths is None else requested_paths)
+    if len(selected) == 1 and selected[0] in set(pass_paths) and selected[0] not in set(changed_paths):
+        _fail("UNCHANGED_PASS_SINGLETON_REVIEW", "unchanged PASS singleton re-review is forbidden")
+    if not selected or selected != eligible:
+        _fail("REVIEW_SCOPE_INVALID", f"{phase} review must use exact eligible paths")
+    return selected
+
+
+def pending_dispatch_receipt(
+    packet: Mapping[str, Any],
+    run: Mapping[str, Any],
+    *,
+    phase: str,
+    paths: Sequence[str],
+) -> dict[str, Any]:
+    """Project the compact receipt that callers persist before dispatch."""
+
+    if phase not in {"INITIAL", "FINAL"}:
+        _fail("REVIEW_PHASE_INVALID", f"unsupported review phase: {phase}")
+    selected = [cell for path in paths for cell in packet["cells"] if cell["path"] == path]
+    if len(selected) != len(paths):
+        _fail("REVIEW_SCOPE_INVALID", "pending receipt contains an unknown path")
+    return {
+        "phase": phase,
+        "paths": list(paths),
+        "hashes": _cell_hashes(selected),
+        "reason_codes": ["INITIAL_NON_REUSED_ONLY" if phase == "INITIAL" else "FINAL_CHANGED_FAILED_ONLY"],
+        "counts": {
+            "model_calls": run["measurements"]["model_call_count"] + 1,
+            "repairs": run["measurements"]["repair_count"],
+        },
+    }
+
+
+def terminal_hold_receipt(
+    packet: Mapping[str, Any],
+    run: Mapping[str, Any],
+    *,
+    failed_paths: Sequence[str],
+    blockers: Sequence[Mapping[str, str]],
+    date: str,
+    evidence_url: str,
+    token_count: int | None = None,
+    cost_usd: float | None = None,
+) -> dict[str, Any]:
+    """Project canonical per-target HOLD payloads after helper exhaustion."""
+
+    if not run["terminal"] or run["measurements"]["final_quality_disposition"] != "BLOCKED_BUDGET_EXHAUSTED":
+        _fail("HOLD_NOT_AUTHORIZED", "canonical helper has not exhausted the review budget")
+    fields = ("path", "reason_code", "reason", "owner", "evidence", "unblock_condition")
+    if [item.get("path") for item in blockers] != list(failed_paths) or any(
+        not all(item.get(field) for field in fields) for item in blockers
+    ):
+        _fail("BLOCKER_LEDGER_INCOMPLETE", "every failed path requires complete blocker evidence")
+    if not date or not evidence_url.startswith(("http://", "https://")):
+        _fail("HOLD_RECEIPT_INCOMPLETE", "date and HTTP(S) reviewed evidence URL are required")
+
+    by_path = {item["path"]: item for item in blockers}
+    failed_cells = [cell for cell in packet["cells"] if cell["path"] in failed_paths]
+    if [cell["path"] for cell in failed_cells] != list(failed_paths):
+        _fail("HOLD_RECEIPT_INCOMPLETE", "failed paths must be exact packet paths in order")
+    holds: dict[str, dict[str, Any]] = {}
+    for target in dict.fromkeys(cell["target"] for cell in failed_cells):
+        target_cells = [cell for cell in failed_cells if cell["target"] == target]
+        target_blockers = [by_path[cell["path"]] for cell in target_cells]
+        holds[target] = {
+            "status": "pass",
+            "reviewer_family": run["review_protocol_identity"]["reviewer_family"],
+            "date": date,
+            "evidence_url": evidence_url,
+            "active": True,
+            "reason": "; ".join(dict.fromkeys(item["reason"] for item in target_blockers)),
+            "owner": "; ".join(dict.fromkeys(item["owner"] for item in target_blockers)),
+            "checked_evidence": [
+                f"{by_path[cell['path']]['evidence']}; {cell['path']} sha256={cell['source_sha256']}"
+                for cell in target_cells
+            ],
+            "unblock_condition": "; ".join(dict.fromkeys(item["unblock_condition"] for item in target_blockers)),
+        }
+    receipt: dict[str, Any] = {
+        "next_action": "stop",
+        "paths": list(failed_paths),
+        "hashes": _cell_hashes(failed_cells),
+        "reason_codes": ["PREPARATION_REVIEW_BUDGET_EXHAUSTED", "PREPARATION_HOLD_ACTIVE"],
+        "counts": {
+            "model_calls": run["measurements"]["model_call_count"],
+            "repairs": run["measurements"]["repair_count"],
+        },
+        "holds": holds,
+    }
+    if token_count is not None:
+        receipt["token_count"] = token_count
+    if cost_usd is not None:
+        receipt["cost_usd"] = cost_usd
+    return receipt

--- a/agents_extensions/shared/skills/curriculum-preparation/scripts/bounded_packet.py
+++ b/agents_extensions/shared/skills/curriculum-preparation/scripts/bounded_packet.py
@@ -2,7 +2,7 @@
 """Pure packet projections for bounded curriculum preparation.
 
 Review and repair transitions remain owned by the canonical bounded-completion
-helper.  This module has no transport, persistence, or controller loop.
+helper. This module has no transport, persistence, or controller loop.
 """
 
 from __future__ import annotations
@@ -21,6 +21,9 @@ if _SPEC is None or _SPEC.loader is None:  # pragma: no cover - broken installat
 bounded_completion = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = bounded_completion
 _SPEC.loader.exec_module(bounded_completion)
+
+_SCOPE_FIELDS = ("target", "profile_id", "profile_version", "family", "manifest_sha256")
+_HASH_FIELDS = ("path", "source_sha256", "preparation_identity")
 
 
 class PreparationPacketError(RuntimeError):
@@ -49,14 +52,22 @@ def _target(target: Mapping[str, Any]) -> str:
 
 
 def _cell_hashes(cells: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
-    return [
+    return [{field: cell[field] for field in _HASH_FIELDS} for cell in cells]
+
+
+def _source_identity(scope: Sequence[Mapping[str, Any]], cells: Sequence[Mapping[str, Any]]) -> str:
+    return bounded_completion.sha256_json(
         {
-            "path": cell["path"],
-            "source_sha256": cell["source_sha256"],
-            "preparation_identity": cell["preparation_identity"],
+            "scope": list(scope),
+            "cells": [
+                {
+                    "target": cell["target"],
+                    **{field: cell[field] for field in _HASH_FIELDS},
+                }
+                for cell in cells
+            ],
         }
-        for cell in cells
-    ]
+    )
 
 
 def _rejection_receipt(targets: Sequence[Mapping[str, Any]], reason_codes: Sequence[str]) -> dict[str, Any]:
@@ -87,7 +98,7 @@ def admit_packet(
 
     if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
         _fail("PACKET_LIMIT_INVALID", "limit must be a positive integer")
-    if not targets:
+    if not targets or any(not isinstance(target, Mapping) for target in targets):
         _fail("PACKET_EMPTY", "packet requires at least one target")
     if len(targets) > limit:
         _fail(
@@ -96,58 +107,68 @@ def admit_packet(
             _rejection_receipt(targets, ["PACKET_LIMIT_EXCEEDED"]),
         )
 
-    profiles: set[tuple[str, str, str, str]] = set()
-    target_ids: set[str] = set()
-    paths: set[str] = set()
-    for target in targets:
-        required = (
-            "track",
-            "slug",
-            "profile_id",
-            "profile_version",
-            "family",
-            "preparation_identity",
-            "deterministic",
-            "cells",
-        )
-        if not isinstance(target, Mapping) or any(field not in target for field in required):
-            _fail("PACKET_TARGET_INVALID", "target is missing required fields")
-        target_id = _target(target)
-        if target_id in target_ids:
-            _fail("PACKET_TARGET_DUPLICATE", f"duplicate target: {target_id}")
-        target_ids.add(target_id)
-        profiles.add(tuple(str(target[field]) for field in ("track", "profile_id", "profile_version", "family")))
-        _sha(target["preparation_identity"], f"{target_id} preparation_identity")
-        if not isinstance(target["deterministic"], Mapping) or not isinstance(
-            target["deterministic"].get("passed"), bool
-        ):
-            _fail("DETERMINISTIC_RESULT_INVALID", f"{target_id} requires a boolean passed result")
-        if not isinstance(target["cells"], list) or not target["cells"]:
-            _fail("PACKET_TARGET_INVALID", f"{target_id} requires a finite cell list")
-        for cell in target["cells"]:
-            if not isinstance(cell, Mapping):
-                _fail("PACKET_CELL_INVALID", f"{target_id} contains a non-object cell")
-            path = cell.get("path")
-            if not isinstance(path, str) or not path or path in paths:
-                _fail("PACKET_CELL_INVALID", f"invalid or duplicate cell path: {path}")
-            paths.add(path)
-            _sha(cell.get("source_sha256"), f"{path} source_sha256")
-    if len(profiles) != 1:
+    scope: list[dict[str, str]] = []
+    cells: list[dict[str, Any]] = []
+    deterministic_failures: list[Mapping[str, Any]] = []
+    try:
+        for target in targets:
+            target_id = _target(target)
+            manifest = _sha(target["manifest_sha256"], f"{target_id} manifest_sha256")
+            preparation = _sha(target["preparation_identity"], f"{target_id} preparation_identity")
+            scope.append(
+                {
+                    "target": target_id,
+                    "profile_id": str(target["profile_id"]),
+                    "profile_version": str(target["profile_version"]),
+                    "family": str(target["family"]),
+                    "manifest_sha256": manifest,
+                }
+            )
+            deterministic = target["deterministic"]
+            if not isinstance(deterministic, Mapping) or not isinstance(deterministic.get("passed"), bool):
+                _fail("DETERMINISTIC_RESULT_INVALID", f"{target_id} requires a boolean passed result")
+            if not deterministic["passed"]:
+                deterministic_failures.append(target)
+            sources = target["cells"]
+            if not isinstance(sources, list) or not sources:
+                _fail("PACKET_TARGET_INVALID", f"{target_id} requires a finite cell list")
+            for source in sources:
+                path = source["path"]
+                cells.append(
+                    {
+                        "target": target_id,
+                        "path": path,
+                        "source_sha256": _sha(source["source_sha256"], f"{path} source_sha256"),
+                        "preparation_identity": preparation,
+                    }
+                )
+    except (KeyError, TypeError) as exc:
+        _fail("PACKET_TARGET_INVALID", f"packet target/cell is malformed: {exc}")
+
+    target_ids = [entry["target"] for entry in scope]
+    paths = [cell["path"] for cell in cells]
+    if len(set(target_ids)) != len(target_ids):
+        _fail("PACKET_TARGET_DUPLICATE", "packet targets must be unique")
+    if len(set(paths)) != len(paths) or any(not isinstance(path, str) or not path for path in paths):
+        _fail("PACKET_CELL_INVALID", "packet cell paths must be non-empty and unique")
+    if (
+        len({entry["target"].split("/", maxsplit=1)[0] for entry in scope}) != 1
+        or len({tuple(entry[field] for field in _SCOPE_FIELDS if field != "target") for entry in scope}) != 1
+    ):
         _fail(
             "PACKET_HETEROGENEOUS",
-            "track/profile/version/family must match",
+            "track/profile/version/family/manifest must match",
             _rejection_receipt(targets, ["PACKET_HETEROGENEOUS"]),
         )
 
-    deterministic_failures = [target for target in targets if target.get("deterministic", {}).get("passed") is not True]
     if deterministic_failures:
         codes = sorted(
             {
                 str(code)
                 for target in deterministic_failures
-                for code in target.get("deterministic", {}).get("reason_codes", ["DETERMINISTIC_FAILURE"])
+                for code in target["deterministic"].get("reason_codes", ["DETERMINISTIC_FAILURE"])
             }
-        )
+        ) or ["DETERMINISTIC_FAILURE"]
         _fail(
             "DETERMINISTIC_FAILURE",
             "local failure rejects before packet/model admission",
@@ -155,35 +176,11 @@ def admit_packet(
         )
 
     prior = {(cell["target"], cell["path"]): cell for cell in prior_passes if cell.get("verdict") == "PASS"}
-    scope = [
-        {
-            "target": _target(target),
-            "profile_id": target["profile_id"],
-            "profile_version": target["profile_version"],
-            "family": target["family"],
-            "preparation_identity": target["preparation_identity"],
-        }
-        for target in targets
-    ]
-    cells = []
-    for target in targets:
-        target_id = _target(target)
-        for source in target["cells"]:
-            previous = prior.get((target_id, source["path"]))
-            reused = bool(
-                previous
-                and previous.get("source_sha256") == source["source_sha256"]
-                and previous.get("preparation_identity") == target["preparation_identity"]
-            )
-            cells.append(
-                {
-                    "target": target_id,
-                    "path": source["path"],
-                    "source_sha256": source["source_sha256"],
-                    "preparation_identity": target["preparation_identity"],
-                    "reused_pass": reused,
-                }
-            )
+    scope_by_target = {entry["target"]: entry for entry in scope}
+    for cell in cells:
+        binding = {**scope_by_target[cell["target"]], **{field: cell[field] for field in _HASH_FIELDS}}
+        previous = prior.get((cell["target"], cell["path"]))
+        cell["reused_pass"] = bool(previous and all(previous.get(field) == value for field, value in binding.items()))
     return {
         "scope": scope,
         "scope_sha256": bounded_completion.sha256_json(scope),
@@ -200,62 +197,113 @@ def admit_packet(
 
 
 def source_identity(packet: Mapping[str, Any]) -> str:
-    """Hash the packet's exact ordered source and preparation identities."""
+    """Hash exact immutable scope plus ordered source/preparation cells."""
 
-    return bounded_completion.sha256_json(
-        [
-            {key: cell[key] for key in ("target", "path", "source_sha256", "preparation_identity")}
-            for cell in packet["cells"]
-        ]
-    )
+    return _source_identity(packet["scope"], packet["cells"])
 
 
-def select_review_paths(
-    packet: Mapping[str, Any],
-    *,
-    phase: str,
-    failed_paths: Sequence[str] = (),
-    changed_paths: Sequence[str] = (),
-    pass_paths: Sequence[str] = (),
-    requested_paths: Sequence[str] | None = None,
-) -> list[str]:
-    """Select INITIAL non-reused or FINAL changed-and-failed cells exactly."""
-
-    if phase == "INITIAL":
-        eligible = [cell["path"] for cell in packet["cells"] if not cell["reused_pass"]]
-    elif phase == "FINAL":
-        failed = set(failed_paths)
-        changed = set(changed_paths)
-        eligible = [cell["path"] for cell in packet["cells"] if cell["path"] in failed & changed]
-    else:
-        _fail("REVIEW_PHASE_INVALID", f"unsupported review phase: {phase}")
-    selected = list(eligible if requested_paths is None else requested_paths)
-    if len(selected) == 1 and selected[0] in set(pass_paths) and selected[0] not in set(changed_paths):
-        _fail("UNCHANGED_PASS_SINGLETON_REVIEW", "unchanged PASS singleton re-review is forbidden")
-    if not selected or selected != eligible:
-        _fail("REVIEW_SCOPE_INVALID", f"{phase} review must use exact eligible paths")
-    return selected
+def _receipt_cells(packet: Mapping[str, Any], receipt: Mapping[str, Any]) -> list[dict[str, str]]:
+    paths = receipt.get("paths")
+    hashes = receipt.get("hashes")
+    if (
+        not isinstance(paths, list)
+        or not isinstance(hashes, list)
+        or any(not isinstance(path, str) for path in paths)
+        or any(not isinstance(item, Mapping) for item in hashes)
+        or len(set(paths)) != len(paths)
+        or [item.get("path") for item in hashes] != paths
+    ):
+        _fail("PENDING_RECEIPT_INVALID", "pending paths and hashes must match exactly")
+    current = {cell["path"]: cell for cell in packet["cells"]}
+    if any(path not in current for path in paths):
+        _fail("PENDING_RECEIPT_INVALID", "pending receipt contains an unknown packet path")
+    return [
+        {
+            "target": current[item["path"]]["target"],
+            "path": item["path"],
+            "source_sha256": _sha(item.get("source_sha256"), "pending source_sha256"),
+            "preparation_identity": _sha(item.get("preparation_identity"), "pending preparation_identity"),
+        }
+        for item in hashes
+    ]
 
 
 def pending_dispatch_receipt(
     packet: Mapping[str, Any],
     run: Mapping[str, Any],
     *,
-    phase: str,
-    paths: Sequence[str],
+    initial_receipt: Mapping[str, Any] | None = None,
+    blocker_paths: Sequence[str] = (),
 ) -> dict[str, Any]:
-    """Project the compact receipt that callers persist before dispatch."""
+    """Derive phase and exact eligible paths, then project pre-dispatch proof."""
 
-    if phase not in {"INITIAL", "FINAL"}:
-        _fail("REVIEW_PHASE_INVALID", f"unsupported review phase: {phase}")
-    selected = [cell for path in paths for cell in packet["cells"] if cell["path"] == path]
-    if len(selected) != len(paths):
-        _fail("REVIEW_SCOPE_INVALID", "pending receipt contains an unknown path")
+    active_source = source_identity(packet)
+    if active_source != run.get("learner_source_sha256"):
+        _fail("PACKET_RUN_SOURCE_DRIFT", "packet identity differs from the canonical bounded run")
+    protocol = run.get("review_protocol_identity")
+    if not isinstance(protocol, Mapping):
+        _fail("PACKET_RUN_PROTOCOL_INVALID", "bounded run lacks a frozen protocol identity")
+    try:
+        phase = bounded_completion.semantic_review_phase(
+            run,
+            review_protocol_identity=protocol,
+            learner_source_sha256=active_source,
+        )
+    except bounded_completion.BoundedCompletionError as exc:
+        _fail(exc.code, str(exc))
+
+    if phase == "INITIAL":
+        if initial_receipt is not None or blocker_paths:
+            _fail("INITIAL_RECEIPT_UNEXPECTED", "INITIAL dispatch cannot consume prior review authority")
+        selected = [cell for cell in packet["cells"] if not cell["reused_pass"]]
+    else:
+        if initial_receipt is None or initial_receipt.get("phase") != "INITIAL":
+            _fail("INITIAL_RECEIPT_REQUIRED", "FINAL dispatch requires the persisted INITIAL receipt")
+        if initial_receipt.get("scope_sha256") != packet["scope_sha256"]:
+            _fail("INITIAL_RECEIPT_SCOPE_DRIFT", "INITIAL receipt scope differs from the current packet")
+        if initial_receipt.get("protocol_identity_sha256") != protocol["identity_sha256"]:
+            _fail("INITIAL_RECEIPT_PROTOCOL_DRIFT", "INITIAL receipt protocol differs from the bounded run")
+        if initial_receipt.get("paths") != [cell["path"] for cell in packet["cells"] if not cell["reused_pass"]]:
+            _fail("INITIAL_RECEIPT_SCOPE_DRIFT", "INITIAL receipt does not cover exact non-reused cells")
+        reviewed_cells = _receipt_cells(packet, initial_receipt)
+        prior_hashes = {cell["path"]: cell for cell in reviewed_cells}
+        initial_cells = [
+            {
+                **cell,
+                **{
+                    field: prior_hashes.get(cell["path"], cell)[field]
+                    for field in ("source_sha256", "preparation_identity")
+                },
+            }
+            for cell in packet["cells"]
+        ]
+        if _source_identity(packet["scope"], initial_cells) != initial_receipt.get("reviewed_source_identity"):
+            _fail("INITIAL_RECEIPT_IDENTITY_INVALID", "INITIAL receipt hashes do not reproduce its identity")
+        initial_review = run["reviews"][0] if run.get("reviews") else None
+        if not initial_review or initial_review["learner_source_sha256"] != initial_receipt["reviewed_source_identity"]:
+            _fail("INITIAL_RECEIPT_IDENTITY_INVALID", "INITIAL receipt is not bound to canonical review evidence")
+        expected_blockers = [path for path in initial_receipt["paths"] if path in set(blocker_paths)]
+        if not blocker_paths or list(blocker_paths) != expected_blockers:
+            _fail("BLOCKER_SCOPE_INVALID", "blocker paths must be an ordered subset of INITIAL paths")
+        selected = [
+            cell
+            for cell in packet["cells"]
+            if cell["path"] in blocker_paths
+            and any(
+                cell[field] != prior_hashes[cell["path"]][field] for field in ("source_sha256", "preparation_identity")
+            )
+        ]
+        if len(selected) != len(blocker_paths):
+            _fail("FINAL_REVIEW_NO_HASH_CHANGE", "every initially failed cell requires an exact hash change")
+
     return {
         "phase": phase,
-        "paths": list(paths),
+        "scope_sha256": packet["scope_sha256"],
+        "reviewed_source_identity": active_source,
+        "protocol_identity_sha256": protocol["identity_sha256"],
+        "paths": [cell["path"] for cell in selected],
         "hashes": _cell_hashes(selected),
-        "reason_codes": ["INITIAL_NON_REUSED_ONLY" if phase == "INITIAL" else "FINAL_CHANGED_FAILED_ONLY"],
+        "reason_codes": ["INITIAL_NON_REUSED_ONLY" if phase == "INITIAL" else "FINAL_HASH_CHANGED_BLOCKERS_ONLY"],
         "counts": {
             "model_calls": run["measurements"]["model_call_count"] + 1,
             "repairs": run["measurements"]["repair_count"],
@@ -267,29 +315,51 @@ def terminal_hold_receipt(
     packet: Mapping[str, Any],
     run: Mapping[str, Any],
     *,
-    failed_paths: Sequence[str],
+    final_receipt: Mapping[str, Any],
     blockers: Sequence[Mapping[str, str]],
     date: str,
     evidence_url: str,
+    still_failing_paths: Sequence[str] | None = None,
     token_count: int | None = None,
     cost_usd: float | None = None,
 ) -> dict[str, Any]:
-    """Project canonical per-target HOLD payloads after helper exhaustion."""
+    """Project per-target HOLDs only from the exact FINAL reviewed scope."""
 
     if not run["terminal"] or run["measurements"]["final_quality_disposition"] != "BLOCKED_BUDGET_EXHAUSTED":
         _fail("HOLD_NOT_AUTHORIZED", "canonical helper has not exhausted the review budget")
+    if final_receipt.get("phase") != "FINAL":
+        _fail("HOLD_SCOPE_INVALID", "terminal HOLD requires the FINAL pending receipt")
+    if (
+        final_receipt.get("scope_sha256") != packet["scope_sha256"]
+        or final_receipt.get("reviewed_source_identity") != source_identity(packet)
+        or final_receipt.get("reviewed_source_identity") != run["learner_source_sha256"]
+        or final_receipt.get("protocol_identity_sha256") != run["review_protocol_identity"]["identity_sha256"]
+        or final_receipt.get("counts")
+        != {
+            "model_calls": run["measurements"]["model_call_count"],
+            "repairs": run["measurements"]["repair_count"],
+        }
+    ):
+        _fail("PENDING_RECEIPT_STALE", "FINAL receipt is not bound to the terminal packet/run")
+    reviewed_cells = _receipt_cells(packet, final_receipt)
+    current = {cell["path"]: cell for cell in packet["cells"]}
+    if any(any(cell[field] != current[cell["path"]][field] for field in _HASH_FIELDS) for cell in reviewed_cells):
+        _fail("PENDING_RECEIPT_STALE", "FINAL receipt hashes differ from the terminal packet")
+    final_paths = final_receipt["paths"]
+    failed_paths = list(final_paths if still_failing_paths is None else still_failing_paths)
+    if not failed_paths or failed_paths != [path for path in final_paths if path in set(failed_paths)]:
+        _fail("HOLD_SCOPE_INVALID", "HOLD paths must be an ordered FINAL-reviewed subset")
+
     fields = ("path", "reason_code", "reason", "owner", "evidence", "unblock_condition")
-    if [item.get("path") for item in blockers] != list(failed_paths) or any(
+    if [item.get("path") for item in blockers] != failed_paths or any(
         not all(item.get(field) for field in fields) for item in blockers
     ):
-        _fail("BLOCKER_LEDGER_INCOMPLETE", "every failed path requires complete blocker evidence")
+        _fail("BLOCKER_LEDGER_INCOMPLETE", "blockers must match every HOLD path exactly")
     if not date or not evidence_url.startswith(("http://", "https://")):
         _fail("HOLD_RECEIPT_INCOMPLETE", "date and HTTP(S) reviewed evidence URL are required")
 
     by_path = {item["path"]: item for item in blockers}
-    failed_cells = [cell for cell in packet["cells"] if cell["path"] in failed_paths]
-    if [cell["path"] for cell in failed_cells] != list(failed_paths):
-        _fail("HOLD_RECEIPT_INCOMPLETE", "failed paths must be exact packet paths in order")
+    failed_cells = [current[path] for path in failed_paths]
     holds: dict[str, dict[str, Any]] = {}
     for target in dict.fromkeys(cell["target"] for cell in failed_cells):
         target_cells = [cell for cell in failed_cells if cell["target"] == target]
@@ -310,7 +380,7 @@ def terminal_hold_receipt(
         }
     receipt: dict[str, Any] = {
         "next_action": "stop",
-        "paths": list(failed_paths),
+        "paths": failed_paths,
         "hashes": _cell_hashes(failed_cells),
         "reason_codes": ["PREPARATION_REVIEW_BUDGET_EXHAUSTED", "PREPARATION_HOLD_ACTIVE"],
         "counts": {

--- a/tests/orchestration/test_curriculum_preparation_bounded_packet.py
+++ b/tests/orchestration/test_curriculum_preparation_bounded_packet.py
@@ -1,0 +1,398 @@
+"""Fixture proofs for bounded curriculum-preparation packets."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from collections.abc import Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "agents_extensions/shared/skills/curriculum-preparation/scripts/bounded_packet.py"
+SPEC = importlib.util.spec_from_file_location("curriculum_preparation_bounded_packet_tests", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+packet = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = packet
+SPEC.loader.exec_module(packet)
+bc = packet.bounded_completion
+
+PASS_SCORES = {
+    "engagement": 9.0,
+    "pedagogical": 9.0,
+    "naturalness": 9.0,
+    "decolonization": 9.0,
+    "tone": 9.0,
+}
+
+
+@pytest.fixture
+def preparation_fixture(tmp_path: Path) -> dict[str, Any]:
+    """Round-trip all synthetic inputs through tmp_path; touch no curriculum."""
+
+    value = {
+        "protocol": {
+            "protocol_version": "5.0.0",
+            "tool_sha256": "6" * 64,
+            "prompt_sha256": "7" * 64,
+            "schema_sha256": "8" * 64,
+            "reviewer_family": "fixture-cross-family",
+            "reviewer_model": "fixture-model",
+        },
+        "bio": [
+            {
+                "track": "bio",
+                "slug": "fixture-a",
+                "profile_id": "bio",
+                "profile_version": "1.1.0",
+                "family": "seminar",
+                "preparation_identity": "1" * 64,
+                "deterministic": {"passed": True, "reason_codes": []},
+                "cells": [
+                    {"path": "evidence/bio/fixture-a-plan.yaml", "source_sha256": "a" * 64},
+                    {"path": "evidence/bio/fixture-a-dossier.md", "source_sha256": "b" * 64},
+                ],
+            },
+            {
+                "track": "bio",
+                "slug": "fixture-b",
+                "profile_id": "bio",
+                "profile_version": "1.1.0",
+                "family": "seminar",
+                "preparation_identity": "2" * 64,
+                "deterministic": {"passed": True, "reason_codes": []},
+                "cells": [
+                    {"path": "evidence/bio/fixture-b-plan.yaml", "source_sha256": "c" * 64},
+                    {"path": "evidence/bio/fixture-b-dossier.md", "source_sha256": "d" * 64},
+                ],
+            },
+        ],
+        "core": [
+            {
+                "track": "core",
+                "slug": "fixture-c",
+                "profile_id": "core",
+                "profile_version": "1.1.0",
+                "family": "core-module",
+                "preparation_identity": "3" * 64,
+                "deterministic": {"passed": True, "reason_codes": []},
+                "cells": [{"path": "evidence/core/fixture-c-plan.yaml", "source_sha256": "f" * 64}],
+            },
+            {
+                "track": "core",
+                "slug": "fixture-d",
+                "profile_id": "core",
+                "profile_version": "1.1.0",
+                "family": "core-module",
+                "preparation_identity": "4" * 64,
+                "deterministic": {"passed": True, "reason_codes": []},
+                "cells": [{"path": "evidence/core/fixture-d-plan.yaml", "source_sha256": "9" * 64}],
+            },
+        ],
+    }
+    value["prior_passes"] = [
+        {
+            "target": "bio/fixture-a",
+            "path": "evidence/bio/fixture-a-plan.yaml",
+            "source_sha256": "a" * 64,
+            "preparation_identity": "1" * 64,
+            "verdict": "PASS",
+        },
+        {
+            "target": "bio/fixture-a",
+            "path": "evidence/bio/fixture-a-dossier.md",
+            "source_sha256": "b" * 64,
+            "preparation_identity": "1" * 64,
+            "verdict": "PASS",
+        },
+        {
+            "target": "bio/fixture-b",
+            "path": "evidence/bio/fixture-b-plan.yaml",
+            "source_sha256": "c" * 64,
+            "preparation_identity": "2" * 64,
+            "verdict": "PASS",
+        },
+    ]
+    path = tmp_path / "bounded-preparation-packets.json"
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _protocol(value: Mapping[str, Any]) -> dict[str, str]:
+    return bc.make_review_protocol_identity(**value["protocol"])
+
+
+def _admit_bio(value: Mapping[str, Any]) -> dict[str, Any]:
+    return packet.admit_packet(value["bio"], limit=2, prior_passes=value["prior_passes"])
+
+
+def test_admission_is_finite_homogeneous_and_exact_hash_bound(
+    preparation_fixture: dict[str, Any],
+) -> None:
+    value = preparation_fixture
+    admitted = _admit_bio(value)
+
+    assert [item["target"] for item in admitted["scope"]] == ["bio/fixture-a", "bio/fixture-b"]
+    assert admitted["counts"] == {"model_calls": 0, "repairs": 0, "reused_pass_cells": 3}
+    assert all(cell["reused_pass"] for cell in admitted["cells"] if cell["target"] == "bio/fixture-a")
+    assert packet.select_review_paths(admitted, phase="INITIAL") == ["evidence/bio/fixture-b-dossier.md"]
+
+    preparation_drift = deepcopy(value["bio"])
+    preparation_drift[0]["preparation_identity"] = "5" * 64
+    drifted = packet.admit_packet(preparation_drift, limit=2, prior_passes=value["prior_passes"])
+    assert [cell["path"] for cell in drifted["cells"] if not cell["reused_pass"]] == [
+        "evidence/bio/fixture-a-plan.yaml",
+        "evidence/bio/fixture-a-dossier.md",
+        "evidence/bio/fixture-b-dossier.md",
+    ]
+
+    with pytest.raises(packet.PreparationPacketError) as limited:
+        packet.admit_packet(value["bio"], limit=1)
+    assert limited.value.code == "PACKET_LIMIT_EXCEEDED"
+    assert limited.value.receipt["counts"]["model_calls"] == 0
+
+    with pytest.raises(packet.PreparationPacketError) as mixed:
+        packet.admit_packet([value["bio"][0], value["core"][0]], limit=2)
+    assert mixed.value.code == "PACKET_HETEROGENEOUS"
+    assert mixed.value.receipt["counts"]["model_calls"] == 0
+
+
+def test_deterministic_failure_rejects_before_packet_or_model_call(
+    preparation_fixture: dict[str, Any],
+) -> None:
+    targets = deepcopy(preparation_fixture["core"])
+    targets[0]["deterministic"] = {
+        "passed": False,
+        "reason_codes": ["MISSING_REQUIRED_SOURCE"],
+    }
+
+    with pytest.raises(packet.PreparationPacketError) as rejected:
+        packet.admit_packet(targets, limit=2)
+
+    assert rejected.value.code == "DETERMINISTIC_FAILURE"
+    assert rejected.value.receipt["reason_codes"] == ["MISSING_REQUIRED_SOURCE"]
+    assert rejected.value.receipt["counts"] == {"model_calls": 0, "repairs": 0}
+    assert rejected.value.receipt["paths"] == [
+        "evidence/core/fixture-c-plan.yaml",
+        "evidence/core/fixture-d-plan.yaml",
+    ]
+
+
+def test_bio_fixture_composes_one_repair_two_reviews_and_terminal_hold(
+    preparation_fixture: dict[str, Any],
+) -> None:
+    value = preparation_fixture
+    admitted = _admit_bio(value)
+    protocol = _protocol(value)
+    initial_source = packet.source_identity(admitted)
+    run = bc.start_run(
+        target=f"bio/packet-{admitted['scope_sha256'][:16]}",
+        run_id="a" * 32,
+        review_protocol_identity=protocol,
+        learner_source_sha256=initial_source,
+    )
+    run = bc.complete_inspection(run, needs_build=False)
+    run = bc.record_deterministic_verification(run, learner_source_sha256=initial_source, passed=True)
+
+    phase = bc.semantic_review_phase(
+        run,
+        review_protocol_identity=protocol,
+        learner_source_sha256=initial_source,
+    )
+    initial_paths = packet.select_review_paths(admitted, phase=phase)
+    initial_pending = packet.pending_dispatch_receipt(admitted, run, phase=phase, paths=initial_paths)
+    assert initial_pending == {
+        "phase": "INITIAL",
+        "paths": ["evidence/bio/fixture-b-dossier.md"],
+        "hashes": [
+            {
+                "path": "evidence/bio/fixture-b-dossier.md",
+                "source_sha256": "d" * 64,
+                "preparation_identity": "2" * 64,
+            }
+        ],
+        "reason_codes": ["INITIAL_NON_REUSED_ONLY"],
+        "counts": {"model_calls": 1, "repairs": 0},
+    }
+    assert run["measurements"]["model_call_count"] == 0
+
+    failed_path = initial_paths[0]
+    blockers = [
+        {
+            "path": failed_path,
+            "reason_code": "SOURCE_CONFLICT",
+            "reason": "The reviewed sources conflict on the bounded factual claim.",
+            "owner": "bio-preparation",
+            "evidence": "fixture packet review evidence",
+            "unblock_condition": "A stable authoritative source resolves the conflict.",
+        }
+    ]
+    run = bc.record_semantic_review(
+        run,
+        review_protocol_identity=protocol,
+        learner_source_sha256=initial_source,
+        evidence_id="1" * 64,
+        reported_disposition="REVISE",
+        dimension_scores=PASS_SCORES,
+        prompt_bytes=120,
+        schema_bytes=40,
+    )
+    assert run["state"] == "CONSOLIDATED_REPAIR"
+    assert len(blockers) == len(initial_paths) == 1
+
+    repaired = deepcopy(admitted)
+    next(cell for cell in repaired["cells"] if cell["path"] == failed_path)["source_sha256"] = "e" * 64
+    repaired["hashes"] = [
+        {
+            "path": cell["path"],
+            "source_sha256": cell["source_sha256"],
+            "preparation_identity": cell["preparation_identity"],
+        }
+        for cell in repaired["cells"]
+    ]
+    final_source = packet.source_identity(repaired)
+    run = bc.record_consolidated_repair(run, learner_source_sha256=final_source)
+    run = bc.record_deterministic_verification(run, learner_source_sha256=final_source, passed=True)
+
+    pass_paths = [cell["path"] for cell in repaired["cells"] if cell["path"] != failed_path]
+    before_singleton = deepcopy(run)
+    with pytest.raises(packet.PreparationPacketError) as singleton:
+        packet.select_review_paths(
+            repaired,
+            phase="FINAL",
+            failed_paths=[failed_path],
+            changed_paths=[failed_path],
+            pass_paths=pass_paths,
+            requested_paths=[pass_paths[0]],
+        )
+    assert singleton.value.code == "UNCHANGED_PASS_SINGLETON_REVIEW"
+    assert run == before_singleton
+
+    phase = bc.semantic_review_phase(
+        run,
+        review_protocol_identity=protocol,
+        learner_source_sha256=final_source,
+    )
+    final_paths = packet.select_review_paths(
+        repaired,
+        phase=phase,
+        failed_paths=[failed_path],
+        changed_paths=[failed_path],
+        pass_paths=pass_paths,
+    )
+    final_pending = packet.pending_dispatch_receipt(repaired, run, phase=phase, paths=final_paths)
+    assert final_pending["paths"] == [failed_path]
+    assert final_pending["hashes"][0]["source_sha256"] == "e" * 64
+    assert final_pending["reason_codes"] == ["FINAL_CHANGED_FAILED_ONLY"]
+    assert final_pending["counts"] == {"model_calls": 2, "repairs": 1}
+
+    run = bc.record_semantic_review(
+        run,
+        review_protocol_identity=protocol,
+        learner_source_sha256=final_source,
+        evidence_id="2" * 64,
+        reported_disposition="REVISE",
+        dimension_scores=PASS_SCORES,
+        prompt_bytes=100,
+        schema_bytes=40,
+    )
+    assert [review["phase"] for review in run["reviews"]] == ["INITIAL", "FINAL"]
+    assert run["measurements"]["model_call_count"] == 2
+    assert run["measurements"]["repair_count"] == 1
+
+    terminal = packet.terminal_hold_receipt(
+        repaired,
+        run,
+        failed_paths=[failed_path],
+        blockers=blockers,
+        date="2026-07-19",
+        evidence_url="https://example.test/reviews/bio-fixture-b",
+        token_count=83,
+        cost_usd=0.024,
+    )
+    assert terminal["next_action"] == "stop"
+    assert terminal["reason_codes"] == ["PREPARATION_REVIEW_BUDGET_EXHAUSTED", "PREPARATION_HOLD_ACTIVE"]
+    assert terminal["counts"] == {"model_calls": 2, "repairs": 1}
+    assert terminal["token_count"] == 83
+    assert terminal["cost_usd"] == 0.024
+    assert terminal["holds"] == {
+        "bio/fixture-b": {
+            "status": "pass",
+            "reviewer_family": "fixture-cross-family",
+            "date": "2026-07-19",
+            "evidence_url": "https://example.test/reviews/bio-fixture-b",
+            "active": True,
+            "reason": "The reviewed sources conflict on the bounded factual claim.",
+            "owner": "bio-preparation",
+            "checked_evidence": [f"fixture packet review evidence; {failed_path} sha256={'e' * 64}"],
+            "unblock_condition": "A stable authoritative source resolves the conflict.",
+        }
+    }
+    assert set(terminal) == {
+        "next_action",
+        "paths",
+        "hashes",
+        "reason_codes",
+        "counts",
+        "holds",
+        "token_count",
+        "cost_usd",
+    }
+
+    before_third = deepcopy(run)
+    with pytest.raises(bc.BoundedCompletionError) as third:
+        bc.semantic_review_phase(
+            run,
+            review_protocol_identity=protocol,
+            learner_source_sha256=final_source,
+        )
+    assert third.value.code == "SEMANTIC_REVIEW_BUDGET_EXHAUSTED"
+    assert run == before_third
+
+
+def test_non_bio_profile_forward_case_uses_the_same_pure_boundary(
+    preparation_fixture: dict[str, Any],
+) -> None:
+    value = preparation_fixture
+    admitted = packet.admit_packet(value["core"], limit=2)
+    protocol = _protocol(value)
+    source = packet.source_identity(admitted)
+    run = bc.start_run(
+        target=f"core/packet-{admitted['scope_sha256'][:16]}",
+        run_id="f" * 32,
+        review_protocol_identity=protocol,
+        learner_source_sha256=source,
+    )
+    run = bc.complete_inspection(run, needs_build=False)
+    run = bc.record_deterministic_verification(run, learner_source_sha256=source, passed=True)
+    phase = bc.semantic_review_phase(
+        run,
+        review_protocol_identity=protocol,
+        learner_source_sha256=source,
+    )
+    paths = packet.select_review_paths(admitted, phase=phase)
+    pending = packet.pending_dispatch_receipt(admitted, run, phase=phase, paths=paths)
+    run = bc.record_semantic_review(
+        run,
+        review_protocol_identity=protocol,
+        learner_source_sha256=source,
+        evidence_id="3" * 64,
+        reported_disposition="PASS",
+        dimension_scores=PASS_SCORES,
+        prompt_bytes=10,
+        schema_bytes=5,
+    )
+
+    assert [item["profile_id"] for item in admitted["scope"]] == ["core", "core"]
+    assert pending["paths"] == [
+        "evidence/core/fixture-c-plan.yaml",
+        "evidence/core/fixture-d-plan.yaml",
+    ]
+    assert set(pending) == {"phase", "paths", "hashes", "reason_codes", "counts"}
+    assert "provider" not in pending
+    assert run["measurements"]["final_quality_disposition"] == "PUBLISHABLE"
+    assert run["measurements"]["model_call_count"] == 1

--- a/tests/orchestration/test_curriculum_preparation_bounded_packet.py
+++ b/tests/orchestration/test_curriculum_preparation_bounded_packet.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -30,6 +30,43 @@ PASS_SCORES = {
 }
 
 
+def _target_fixture(
+    track: str,
+    slug: str,
+    profile: str,
+    family: str,
+    manifest: str,
+    preparation: str,
+    cells: Sequence[tuple[str, str]],
+) -> dict[str, Any]:
+    return {
+        "track": track,
+        "slug": slug,
+        "profile_id": profile,
+        "profile_version": "1.1.0",
+        "family": family,
+        "manifest_sha256": manifest * 64,
+        "preparation_identity": preparation * 64,
+        "deterministic": {"passed": True, "reason_codes": []},
+        "cells": [{"path": path, "source_sha256": digest * 64} for path, digest in cells],
+    }
+
+
+def _prior_pass(target: Mapping[str, Any], cell_index: int) -> dict[str, Any]:
+    cell = target["cells"][cell_index]
+    return {
+        "target": f"{target['track']}/{target['slug']}",
+        "profile_id": target["profile_id"],
+        "profile_version": target["profile_version"],
+        "family": target["family"],
+        "manifest_sha256": target["manifest_sha256"],
+        "path": cell["path"],
+        "source_sha256": cell["source_sha256"],
+        "preparation_identity": target["preparation_identity"],
+        "verdict": "PASS",
+    }
+
+
 @pytest.fixture
 def preparation_fixture(tmp_path: Path) -> dict[str, Any]:
     """Round-trip all synthetic inputs through tmp_path; touch no curriculum."""
@@ -44,78 +81,56 @@ def preparation_fixture(tmp_path: Path) -> dict[str, Any]:
             "reviewer_model": "fixture-model",
         },
         "bio": [
-            {
-                "track": "bio",
-                "slug": "fixture-a",
-                "profile_id": "bio",
-                "profile_version": "1.1.0",
-                "family": "seminar",
-                "preparation_identity": "1" * 64,
-                "deterministic": {"passed": True, "reason_codes": []},
-                "cells": [
-                    {"path": "evidence/bio/fixture-a-plan.yaml", "source_sha256": "a" * 64},
-                    {"path": "evidence/bio/fixture-a-dossier.md", "source_sha256": "b" * 64},
+            _target_fixture(
+                "bio",
+                "fixture-a",
+                "bio",
+                "seminar",
+                "0",
+                "1",
+                [
+                    ("evidence/bio/fixture-a-plan.yaml", "a"),
+                    ("evidence/bio/fixture-a-dossier.md", "b"),
                 ],
-            },
-            {
-                "track": "bio",
-                "slug": "fixture-b",
-                "profile_id": "bio",
-                "profile_version": "1.1.0",
-                "family": "seminar",
-                "preparation_identity": "2" * 64,
-                "deterministic": {"passed": True, "reason_codes": []},
-                "cells": [
-                    {"path": "evidence/bio/fixture-b-plan.yaml", "source_sha256": "c" * 64},
-                    {"path": "evidence/bio/fixture-b-dossier.md", "source_sha256": "d" * 64},
+            ),
+            _target_fixture(
+                "bio",
+                "fixture-b",
+                "bio",
+                "seminar",
+                "0",
+                "2",
+                [
+                    ("evidence/bio/fixture-b-plan.yaml", "c"),
+                    ("evidence/bio/fixture-b-dossier.md", "d"),
                 ],
-            },
+            ),
         ],
         "core": [
-            {
-                "track": "core",
-                "slug": "fixture-c",
-                "profile_id": "core",
-                "profile_version": "1.1.0",
-                "family": "core-module",
-                "preparation_identity": "3" * 64,
-                "deterministic": {"passed": True, "reason_codes": []},
-                "cells": [{"path": "evidence/core/fixture-c-plan.yaml", "source_sha256": "f" * 64}],
-            },
-            {
-                "track": "core",
-                "slug": "fixture-d",
-                "profile_id": "core",
-                "profile_version": "1.1.0",
-                "family": "core-module",
-                "preparation_identity": "4" * 64,
-                "deterministic": {"passed": True, "reason_codes": []},
-                "cells": [{"path": "evidence/core/fixture-d-plan.yaml", "source_sha256": "9" * 64}],
-            },
+            _target_fixture(
+                "core",
+                "fixture-c",
+                "core",
+                "core-module",
+                "5",
+                "3",
+                [("evidence/core/fixture-c-plan.yaml", "f")],
+            ),
+            _target_fixture(
+                "core",
+                "fixture-d",
+                "core",
+                "core-module",
+                "5",
+                "4",
+                [("evidence/core/fixture-d-plan.yaml", "9")],
+            ),
         ],
     }
     value["prior_passes"] = [
-        {
-            "target": "bio/fixture-a",
-            "path": "evidence/bio/fixture-a-plan.yaml",
-            "source_sha256": "a" * 64,
-            "preparation_identity": "1" * 64,
-            "verdict": "PASS",
-        },
-        {
-            "target": "bio/fixture-a",
-            "path": "evidence/bio/fixture-a-dossier.md",
-            "source_sha256": "b" * 64,
-            "preparation_identity": "1" * 64,
-            "verdict": "PASS",
-        },
-        {
-            "target": "bio/fixture-b",
-            "path": "evidence/bio/fixture-b-plan.yaml",
-            "source_sha256": "c" * 64,
-            "preparation_identity": "2" * 64,
-            "verdict": "PASS",
-        },
+        _prior_pass(value["bio"][0], 0),
+        _prior_pass(value["bio"][0], 1),
+        _prior_pass(value["bio"][1], 0),
     ]
     path = tmp_path / "bounded-preparation-packets.json"
     path.write_text(json.dumps(value), encoding="utf-8")
@@ -139,7 +154,9 @@ def test_admission_is_finite_homogeneous_and_exact_hash_bound(
     assert [item["target"] for item in admitted["scope"]] == ["bio/fixture-a", "bio/fixture-b"]
     assert admitted["counts"] == {"model_calls": 0, "repairs": 0, "reused_pass_cells": 3}
     assert all(cell["reused_pass"] for cell in admitted["cells"] if cell["target"] == "bio/fixture-a")
-    assert packet.select_review_paths(admitted, phase="INITIAL") == ["evidence/bio/fixture-b-dossier.md"]
+    assert [cell["path"] for cell in admitted["cells"] if not cell["reused_pass"]] == [
+        "evidence/bio/fixture-b-dossier.md"
+    ]
 
     preparation_drift = deepcopy(value["bio"])
     preparation_drift[0]["preparation_identity"] = "5" * 64
@@ -159,6 +176,35 @@ def test_admission_is_finite_homogeneous_and_exact_hash_bound(
         packet.admit_packet([value["bio"][0], value["core"][0]], limit=2)
     assert mixed.value.code == "PACKET_HETEROGENEOUS"
     assert mixed.value.receipt["counts"]["model_calls"] == 0
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("profile_id", "bio-v2"),
+        ("profile_version", "2.0.0"),
+        ("family", "seminar-v2"),
+        ("manifest_sha256", "6" * 64),
+    ],
+)
+def test_profile_and_manifest_drift_invalidate_exact_pass_reuse(
+    preparation_fixture: dict[str, Any],
+    field: str,
+    replacement: str,
+) -> None:
+    original = _admit_bio(preparation_fixture)
+    drifted_targets = deepcopy(preparation_fixture["bio"])
+    for target in drifted_targets:
+        target[field] = replacement
+
+    drifted = packet.admit_packet(
+        drifted_targets,
+        limit=2,
+        prior_passes=preparation_fixture["prior_passes"],
+    )
+
+    assert drifted["counts"]["reused_pass_cells"] == 0
+    assert packet.source_identity(drifted) != packet.source_identity(original)
 
 
 def test_deterministic_failure_rejects_before_packet_or_model_call(
@@ -198,29 +244,24 @@ def test_bio_fixture_composes_one_repair_two_reviews_and_terminal_hold(
     run = bc.complete_inspection(run, needs_build=False)
     run = bc.record_deterministic_verification(run, learner_source_sha256=initial_source, passed=True)
 
-    phase = bc.semantic_review_phase(
-        run,
-        review_protocol_identity=protocol,
-        learner_source_sha256=initial_source,
-    )
-    initial_paths = packet.select_review_paths(admitted, phase=phase)
-    initial_pending = packet.pending_dispatch_receipt(admitted, run, phase=phase, paths=initial_paths)
-    assert initial_pending == {
-        "phase": "INITIAL",
-        "paths": ["evidence/bio/fixture-b-dossier.md"],
-        "hashes": [
-            {
-                "path": "evidence/bio/fixture-b-dossier.md",
-                "source_sha256": "d" * 64,
-                "preparation_identity": "2" * 64,
-            }
-        ],
-        "reason_codes": ["INITIAL_NON_REUSED_ONLY"],
-        "counts": {"model_calls": 1, "repairs": 0},
-    }
+    initial_pending = packet.pending_dispatch_receipt(admitted, run)
+    assert initial_pending["phase"] == "INITIAL"
+    assert initial_pending["scope_sha256"] == admitted["scope_sha256"]
+    assert initial_pending["reviewed_source_identity"] == initial_source
+    assert initial_pending["protocol_identity_sha256"] == protocol["identity_sha256"]
+    assert initial_pending["paths"] == ["evidence/bio/fixture-b-dossier.md"]
+    assert initial_pending["hashes"] == [
+        {
+            "path": "evidence/bio/fixture-b-dossier.md",
+            "source_sha256": "d" * 64,
+            "preparation_identity": "2" * 64,
+        }
+    ]
+    assert initial_pending["reason_codes"] == ["INITIAL_NON_REUSED_ONLY"]
+    assert initial_pending["counts"] == {"model_calls": 1, "repairs": 0}
     assert run["measurements"]["model_call_count"] == 0
 
-    failed_path = initial_paths[0]
+    failed_path = initial_pending["paths"][0]
     blockers = [
         {
             "path": failed_path,
@@ -242,7 +283,29 @@ def test_bio_fixture_composes_one_repair_two_reviews_and_terminal_hold(
         schema_bytes=40,
     )
     assert run["state"] == "CONSOLIDATED_REPAIR"
-    assert len(blockers) == len(initial_paths) == 1
+    assert len(blockers) == len(initial_pending["paths"]) == 1
+
+    with pytest.raises(packet.PreparationPacketError) as wrong_phase:
+        packet.pending_dispatch_receipt(admitted, run)
+    assert wrong_phase.value.code == "STATE_INVALID"
+
+    forged = deepcopy(admitted)
+    forged["cells"][0]["source_sha256"] = "4" * 64
+    forged_source = packet.source_identity(forged)
+    forged_run = bc.record_consolidated_repair(run, learner_source_sha256=forged_source)
+    forged_run = bc.record_deterministic_verification(
+        forged_run,
+        learner_source_sha256=forged_source,
+        passed=True,
+    )
+    with pytest.raises(packet.PreparationPacketError) as forged_change:
+        packet.pending_dispatch_receipt(
+            forged,
+            forged_run,
+            initial_receipt=initial_pending,
+            blocker_paths=[failed_path],
+        )
+    assert forged_change.value.code == "INITIAL_RECEIPT_IDENTITY_INVALID"
 
     repaired = deepcopy(admitted)
     next(cell for cell in repaired["cells"] if cell["path"] == failed_path)["source_sha256"] = "e" * 64
@@ -258,36 +321,27 @@ def test_bio_fixture_composes_one_repair_two_reviews_and_terminal_hold(
     run = bc.record_consolidated_repair(run, learner_source_sha256=final_source)
     run = bc.record_deterministic_verification(run, learner_source_sha256=final_source, passed=True)
 
-    pass_paths = [cell["path"] for cell in repaired["cells"] if cell["path"] != failed_path]
     before_singleton = deepcopy(run)
     with pytest.raises(packet.PreparationPacketError) as singleton:
-        packet.select_review_paths(
+        packet.pending_dispatch_receipt(
             repaired,
-            phase="FINAL",
-            failed_paths=[failed_path],
-            changed_paths=[failed_path],
-            pass_paths=pass_paths,
-            requested_paths=[pass_paths[0]],
+            run,
+            initial_receipt=initial_pending,
+            blocker_paths=["evidence/bio/fixture-a-dossier.md"],
         )
-    assert singleton.value.code == "UNCHANGED_PASS_SINGLETON_REVIEW"
+    assert singleton.value.code == "BLOCKER_SCOPE_INVALID"
     assert run == before_singleton
 
-    phase = bc.semantic_review_phase(
-        run,
-        review_protocol_identity=protocol,
-        learner_source_sha256=final_source,
-    )
-    final_paths = packet.select_review_paths(
+    final_pending = packet.pending_dispatch_receipt(
         repaired,
-        phase=phase,
-        failed_paths=[failed_path],
-        changed_paths=[failed_path],
-        pass_paths=pass_paths,
+        run,
+        initial_receipt=initial_pending,
+        blocker_paths=[failed_path],
     )
-    final_pending = packet.pending_dispatch_receipt(repaired, run, phase=phase, paths=final_paths)
+    assert final_pending["phase"] == "FINAL"
     assert final_pending["paths"] == [failed_path]
     assert final_pending["hashes"][0]["source_sha256"] == "e" * 64
-    assert final_pending["reason_codes"] == ["FINAL_CHANGED_FAILED_ONLY"]
+    assert final_pending["reason_codes"] == ["FINAL_HASH_CHANGED_BLOCKERS_ONLY"]
     assert final_pending["counts"] == {"model_calls": 2, "repairs": 1}
 
     run = bc.record_semantic_review(
@@ -304,10 +358,37 @@ def test_bio_fixture_composes_one_repair_two_reviews_and_terminal_hold(
     assert run["measurements"]["model_call_count"] == 2
     assert run["measurements"]["repair_count"] == 1
 
+    stale_final = deepcopy(final_pending)
+    stale_final["hashes"][0]["source_sha256"] = "d" * 64
+    with pytest.raises(packet.PreparationPacketError) as stale_hold:
+        packet.terminal_hold_receipt(
+            repaired,
+            run,
+            final_receipt=stale_final,
+            blockers=blockers,
+            date="2026-07-19",
+            evidence_url="https://example.test/reviews/stale",
+        )
+    assert stale_hold.value.code == "PENDING_RECEIPT_STALE"
+
+    remapped_blockers = deepcopy(blockers)
+    remapped_blockers[0]["path"] = "evidence/bio/fixture-a-dossier.md"
+    with pytest.raises(packet.PreparationPacketError) as remapped_hold:
+        packet.terminal_hold_receipt(
+            repaired,
+            run,
+            final_receipt=final_pending,
+            still_failing_paths=["evidence/bio/fixture-a-dossier.md"],
+            blockers=remapped_blockers,
+            date="2026-07-19",
+            evidence_url="https://example.test/reviews/remapped",
+        )
+    assert remapped_hold.value.code == "HOLD_SCOPE_INVALID"
+
     terminal = packet.terminal_hold_receipt(
         repaired,
         run,
-        failed_paths=[failed_path],
+        final_receipt=final_pending,
         blockers=blockers,
         date="2026-07-19",
         evidence_url="https://example.test/reviews/bio-fixture-b",
@@ -369,13 +450,7 @@ def test_non_bio_profile_forward_case_uses_the_same_pure_boundary(
     )
     run = bc.complete_inspection(run, needs_build=False)
     run = bc.record_deterministic_verification(run, learner_source_sha256=source, passed=True)
-    phase = bc.semantic_review_phase(
-        run,
-        review_protocol_identity=protocol,
-        learner_source_sha256=source,
-    )
-    paths = packet.select_review_paths(admitted, phase=phase)
-    pending = packet.pending_dispatch_receipt(admitted, run, phase=phase, paths=paths)
+    pending = packet.pending_dispatch_receipt(admitted, run)
     run = bc.record_semantic_review(
         run,
         review_protocol_identity=protocol,
@@ -392,7 +467,16 @@ def test_non_bio_profile_forward_case_uses_the_same_pure_boundary(
         "evidence/core/fixture-c-plan.yaml",
         "evidence/core/fixture-d-plan.yaml",
     ]
-    assert set(pending) == {"phase", "paths", "hashes", "reason_codes", "counts"}
+    assert set(pending) == {
+        "phase",
+        "scope_sha256",
+        "reviewed_source_identity",
+        "protocol_identity_sha256",
+        "paths",
+        "hashes",
+        "reason_codes",
+        "counts",
+    }
     assert "provider" not in pending
     assert run["measurements"]["final_quality_disposition"] == "PUBLISHABLE"
     assert run["measurements"]["model_call_count"] == 1


### PR DESCRIPTION
## Summary

- add a pure, stateless curriculum-preparation packet boundary for homogeneous finite admission, deterministic pre-model rejection, and exact PASS reuse bound to target/profile/version/family/manifest/source/preparation identities
- derive INITIAL and FINAL pending scope from the canonical bounded run; FINAL eligibility comes only from persisted INITIAL hashes plus blocker paths whose exact source or preparation hash changed
- bind terminal reviewed HOLD projection to the exact current FINAL pending receipt and optional ordered still-failing subset
- exercise one BIO packet and one non-BIO profile entirely in tmp_path without learner edits or provider calls

## Independent review correction

- F001: forged FINAL change lists were removed; current hashes are compared to the canonical INITIAL reviewed identity
- F002: pending phase and eligibility are now derived internally through bounded_completion.semantic_review_phase with source/protocol binding
- F003: stale or remapped FINAL/HOLD receipts fail closed
- F004: PASS reuse and packet source identity include profile, family, manifest, target, source, and preparation bindings

## Validation

- .venv/bin/python -m pytest tests/orchestration/test_curriculum_preparation_bounded_packet.py tests/test_bounded_completion_contract.py tests/orchestration/test_prompt_contracts.py -q: 81 passed
- changed-file Ruff check and format check: passed
- skill metadata and Markdown lint: passed
- Python compilation, git diff, artifact, and X-Agent trailer fences: passed
- pre-commit focused packet proof: 8 passed

Closes #5472