### PR TITLE
fix(harness): start-grok --epic auto-continues the lane

### DIFF
--- a/start-grok.sh
+++ b/start-grok.sh
@@ -20,6 +20,10 @@
 #   SESSION_STREAM_ID         epic:<n> from --stream or epic→number map
 #   LEARN_UKRAINIAN_GROK_LAUNCH=1
 #
+# Cold-start: with --epic and no free-text PROMPT, the launcher injects an
+# auto-continue prompt (Grok has no SessionStart hook like Claude). Pass an
+# explicit PROMPT to override. Use --no-always-approve to require tool confirms.
+#
 # Examples:
 #   ./start-grok.sh --epic atlas
 #   ./start-grok.sh --epic atlas --stream epic:4387 --effort high
@@ -254,7 +258,7 @@ if [ "$_always_approve" -eq 1 ]; then
   fi
 fi
 
-# Lane cold-start hint (printed, also useful as first prompt fragment if empty prompt)
+# Lane cold-start hint (printed always when epic is set)
 if [ -n "${SESSION_EPIC:-}" ]; then
   echo ""
   echo "Lane: ${SESSION_EPIC} (you are NOT the main orchestrator)."
@@ -276,6 +280,59 @@ if [ -n "${SESSION_EPIC:-}" ]; then
   echo "  Primary checkout is READ-ONLY for writes → worktrees via scripts/delegate.py"
   echo ""
 fi
+
+# Auto-continue the epic stream when --epic is set and the user did not pass a PROMPT.
+# Grok has no SessionStart hook (Claude does) — without an initial prompt the TUI idles
+# even though SESSION_EPIC / SESSION_STREAM_ID are exported. Root cause of the 2026-07-19
+# "start-grok.sh --epic=atlas did not auto-continue" failure.
+_has_prompt=0
+_expect_value=0
+for a in "${_forward[@]+"${_forward[@]}"}"; do
+  if [ "$_expect_value" -eq 1 ]; then
+    _expect_value=0
+    continue
+  fi
+  case "$a" in
+    --)
+      # everything after -- is prompt material; treat next non-empty as prompt
+      _expect_value=0
+      ;;
+    --*=*)
+      ;;
+    --model|--effort|--cwd|--agent|--agents|--allow|--deny|--disallowed-tools|--debug-file|--json-schema|--leader-socket|--max-turns|--session-id|--resume|--worktree|--output-format|--permission-mode)
+      _expect_value=1
+      ;;
+    -c|--continue|--always-approve|--debug|--disable-web-search|--experimental-memory|--fork-session|--fullscreen|--minimal|--no-alt-screen|--no-memory|--no-plan|--no-subagents|--check|--help|-h)
+      ;;
+    -*)
+      # unknown flag: next token may be its value; do not treat as prompt
+      ;;
+    *)
+      _has_prompt=1
+      ;;
+  esac
+done
+
+if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
+  case "${SESSION_EPIC}" in
+    atlas|practice|practice-hub)
+      _cold_prompt="You are the interim ATLAS lane driver (stream epic:4387). Immediately read and execute .claude/atlas-epic/TAKEOVER-PROMPT.md: tail the session stream, open or resume your lease, reconcile the board against gh/git/worktrees/task files, update INTERIM-DRIVER-HANDOFF.md as dual-write, and drive the next unblocked action without asking for a menu. Primary checkout is read-only — all writes via worktrees."
+      ;;
+    harness|infra)
+      _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). Cold-start from the infra handoff and stream tail; reconcile in-flight work; drive the next unblocked infra action. Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."
+      ;;
+    hramatka)
+      _cold_prompt="You are the hramatka lane driver (stream ${SESSION_STREAM_ID:-epic:4542}). Cold-start from the epic handoff and stream if present; reconcile and drive the next unblocked action. Primary checkout is read-only — writes via worktrees."
+      ;;
+    *)
+      _cold_prompt="You are the ${SESSION_EPIC} lane driver (SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}). You are NOT the main orchestrator. Cold-start: load the epic handoff under .claude/${SESSION_EPIC}-epic/ (or stream tail if SESSION_STREAM_ID is set), reconcile reality, and drive the next unblocked action without a menu. Primary checkout is read-only — writes via worktrees."
+      ;;
+  esac
+  echo "Cold-start: injecting epic auto-continue prompt (no user PROMPT given)."
+  _forward+=("$_cold_prompt")
+  unset _cold_prompt
+fi
+unset _has_prompt _expect_value
 
 echo "Launching Grok Build TUI..."
 exec "$GROK_BIN" "${_defaults[@]}" "${_forward[@]+"${_forward[@]}"}"

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -1,0 +1,117 @@
+"""start-grok.sh launcher: --epic env export + cold-start auto-continue prompt."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LAUNCHER = _REPO_ROOT / "start-grok.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_launcher(
+    tmp_path: Path,
+    arguments: list[str],
+) -> tuple[dict[str, str], str, subprocess.CompletedProcess[str]]:
+    """Run start-grok.sh with a fake grok binary that captures env + argv."""
+    home = tmp_path / "home"
+    grok_bin_dir = home / ".grok" / "bin"
+    grok_bin_dir.mkdir(parents=True)
+    capture = tmp_path / "capture.txt"
+
+    _write_executable(
+        grok_bin_dir / "grok",
+        f"""#!/usr/bin/env bash
+if [[ "${{1:-}}" == "--version" ]]; then
+  echo "test-grok 0.0.0"
+  exit 0
+fi
+{{
+  printf 'session_epic=%s\\n' "${{SESSION_EPIC-unset}}"
+  printf 'session_stream=%s\\n' "${{SESSION_STREAM_ID-unset}}"
+  printf 'handoff=%s\\n' "${{SESSION_HANDOFF_AGENT-unset}}"
+  printf 'launch=%s\\n' "${{LEARN_UKRAINIAN_GROK_LAUNCH-unset}}"
+  printf 'argv='
+  printf '%s\\0' "$@"
+  printf '\\n'
+}} > "{capture}"
+""",
+    )
+
+    env = os.environ.copy()
+    for name in (
+        "SESSION_EPIC",
+        "SESSION_STREAM_ID",
+        "SESSION_HANDOFF_AGENT",
+        "LEARN_UKRAINIAN_GROK_LAUNCH",
+    ):
+        env.pop(name, None)
+    env["HOME"] = os.fspath(home)
+    env["PATH"] = f"{grok_bin_dir}:{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        [os.fspath(_LAUNCHER), *arguments],
+        cwd=_REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    raw = capture.read_text(encoding="utf-8") if capture.exists() else ""
+    values: dict[str, str] = {}
+    argv_blob = ""
+    for line in raw.splitlines():
+        if line.startswith("argv="):
+            argv_blob = line[len("argv=") :]
+            continue
+        if "=" in line:
+            k, _, v = line.partition("=")
+            values[k] = v
+    return values, argv_blob, result
+
+
+def test_epic_atlas_exports_env_and_injects_cold_start_prompt(tmp_path: Path) -> None:
+    values, argv_blob, result = _run_launcher(tmp_path, ["--epic", "atlas"])
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "atlas"
+    assert values["session_stream"] == "epic:4387"
+    assert values["handoff"] == "grok-atlas"
+    assert values["launch"] == "1"
+    # Null-separated argv from fake grok; last non-empty token is the prompt.
+    parts = [p for p in argv_blob.split("\0") if p]
+    assert parts, "expected grok argv"
+    prompt = parts[-1]
+    assert "ATLAS" in prompt or "atlas" in prompt.lower()
+    assert "TAKEOVER-PROMPT.md" in prompt
+    assert "epic:4387" in prompt
+    assert "--model" in parts
+    assert "grok-4.5" in parts
+    assert "--always-approve" in parts
+
+
+def test_epic_equals_form_and_explicit_prompt_skips_inject(tmp_path: Path) -> None:
+    values, argv_blob, result = _run_launcher(
+        tmp_path,
+        ["--epic=atlas", "only do the cloze batch"],
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "atlas"
+    parts = [p for p in argv_blob.split("\0") if p]
+    assert parts[-1] == "only do the cloze batch"
+    assert "TAKEOVER-PROMPT.md" not in parts[-1]
+
+
+def test_no_epic_no_cold_start_prompt(tmp_path: Path) -> None:
+    values, argv_blob, result = _run_launcher(tmp_path, [])
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "unset"
+    parts = [p for p in argv_blob.split("\0") if p]
+    # Flags only — no free-text cold-start prompt.
+    assert all(p.startswith("-") or p in {"grok-4.5", "high"} or Path(p).is_absolute() for p in parts)


### PR DESCRIPTION
## Summary
`./start-grok.sh --epic atlas` exported `SESSION_EPIC` / stream / handoff env and printed a cold-start banner, but **did not pass an initial PROMPT** to the Grok TUI. Unlike Claude (SessionStart capsule), Grok has no hook surface — so the session idled until a human typed "continue".

### Fix
When `--epic` is set and no free-text PROMPT remains on the argv after stripping launcher flags, inject a lane-specific auto-continue prompt:
- **atlas** → execute `TAKEOVER-PROMPT.md`, tail `epic:4387`, drive next action
- **harness/infra**, **hramatka**, generic epic → analogous cold-start
- Explicit PROMPT always wins (no inject)

### Tests
`tests/test_start_grok_launcher.py` — env export, inject, skip-on-explicit-prompt, no-epic baseline (3 passed).

## Test plan
- [x] `bash -n start-grok.sh`
- [x] `pytest tests/test_start_grok_launcher.py` (3 passed)
- [ ] Manual: `./start-grok.sh --epic atlas` starts TUI already driving (no empty chat)

Refs #4387 (atlas driver ergonomics). Follow-up to #5437.