### PR TITLE
feat(lexicon): offline enrich CLI driver for 20k ULIF path

### DIFF
--- a/scripts/lexicon/runner/README-offline-enrich.md
+++ b/scripts/lexicon/runner/README-offline-enrich.md
@@ -1,0 +1,79 @@
+# Offline enrich driver (20k ULIF path)
+
+CLI: `enrich_offline_20k.py`  
+Launcher: `launch_enrich.sh`
+
+Consumes the **reduce** candidate (`candidate-ulif-reduce.json` from
+`reduce_ulif_20k.py` / `offline_reduce.py`) and runs sealed offline enrich
+phases (CEFR → relations → leaf chunks) with a resumable ledger.
+
+**Stops before** finalize / publish / pin-flip.
+
+## Local dry-run (fixture / ≤50 lemmas)
+
+```bash
+# Plan only — no enrich, no sources.db open beyond path checks
+.venv/bin/python scripts/lexicon/runner/enrich_offline_20k.py \
+  --dry-run \
+  --work-dir /tmp/enrich-dry \
+  --candidate tests/fixtures/lexicon/runner_pr1/slice_input.json \
+  --sources-db tests/fixtures/lexicon/runner_pr1/sources_slice.sqlite \
+  --kaikki-json tests/fixtures/lexicon/runner_pr1/kaikki_slice.json \
+  --max-lemmas 50
+
+# Small in-process slice (tests / smoke)
+.venv/bin/python scripts/lexicon/runner/enrich_offline_20k.py \
+  --work-dir /tmp/enrich-smoke \
+  --candidate tests/fixtures/lexicon/runner_pr1/slice_input.json \
+  --sources-db tests/fixtures/lexicon/runner_pr1/sources_slice.sqlite \
+  --kaikki-json tests/fixtures/lexicon/runner_pr1/kaikki_slice.json \
+  --grac-cache tests/fixtures/lexicon/runner_pr1/grac_frequency_slice.json \
+  --max-lemmas 50 \
+  --chunk-size 25 \
+  --stop-after-chunks 1 \
+  --in-process
+```
+
+Bare invocation and `--help` never start a multi-hour run (#5393 class).
+
+## VPS recipe (run-20k, post-reduce)
+
+Assumes fetch + reduce already completed under `/home/ops/atlas-runner/run-20k`:
+
+| Artifact | Path |
+| --- | --- |
+| Network cache | `$WORK_DIR/network-cache.sqlite` |
+| Reduce candidate | `$WORK_DIR/candidate-ulif-reduce.json` |
+| Enrich work dir | `$WORK_DIR/offline_enrich/` |
+| Enriched output | `$WORK_DIR/offline_enrich/candidate-enriched.json` |
+| Log | `$WORK_DIR/enrich.log` |
+
+```bash
+# Optional: plan against live reduce artifact
+.venv/bin/python scripts/lexicon/runner/enrich_offline_20k.py \
+  --dry-run \
+  --repo /home/ops/atlas-runner/repo \
+  --work-dir /home/ops/atlas-runner/run-20k/offline_enrich \
+  --candidate /home/ops/atlas-runner/run-20k/candidate-ulif-reduce.json
+
+# Detached under MemoryHigh=1.5G MemoryMax=2.0G (idempotent)
+scripts/lexicon/runner/launch_enrich.sh
+
+# Resume after kill / reboot (same work-dir; ledger resumes)
+scripts/lexicon/runner/launch_enrich.sh
+
+# Smoke: one chunk then exit (resume later)
+scripts/lexicon/runner/launch_enrich.sh --stop-after-chunks 1
+```
+
+Tail progress:
+
+```bash
+tail -f /home/ops/atlas-runner/run-20k/enrich.log | grep --line-buffered '"event"'
+```
+
+## Out of scope for this driver
+
+- `finalize.py` (publication archive)
+- Live Atlas pin-flip / publish
+- Re-fetching ULIF / re-running reduce

--- a/scripts/lexicon/runner/enrich_offline_20k.py
+++ b/scripts/lexicon/runner/enrich_offline_20k.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Durable offline enrich driver for the Atlas 20k ULIF path (#5230 / #5331).
+
+Consumes a reduce candidate (``candidate-ulif-reduce.json``) or any Atlas-style
+entries manifest, runs sealed CEFR + relations + per-chunk leaf enrichment via
+:func:`scripts.lexicon.runner.offline_engine.enrich_offline_slice`, and stages a
+resumable ledger under ``--work-dir``.
+
+**Stops before** finalize / publication archive / pin-flip.  Those are separate
+operator steps (``finalize.py`` + publish gate) and are intentionally out of
+scope for this driver.
+
+#5393 class: bare invocation and ``--help`` never start a multi-hour enrich run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+# VPS defaults (MemoryHigh=1.5G MemoryMax=2.0G); local tests override.
+DEFAULT_MEMORY_HIGH_MIB = 1536
+DEFAULT_MEMORY_MAX_MIB = 2048
+DEFAULT_CHUNK_SIZE = 25
+
+
+def _load_repo(repo: Path) -> None:
+    sys.path.insert(0, str(repo))
+
+
+def _event(name: str, **fields: Any) -> None:
+    print(
+        json.dumps({"event": name, "at": time.time(), **fields}, ensure_ascii=False, sort_keys=True),
+        flush=True,
+    )
+
+
+def _resolve_input(args: argparse.Namespace) -> Path | None:
+    """Return the candidate/manifest path (``--candidate`` wins over ``--manifest``)."""
+    if args.candidate is not None:
+        return Path(args.candidate)
+    if args.manifest is not None:
+        return Path(args.manifest)
+    return None
+
+
+def _count_entries(path: Path) -> int:
+    """Count entries without building a full in-memory list when ijson is available."""
+    try:
+        import ijson  # type: ignore[import-untyped]
+    except ModuleNotFoundError:
+        ijson = None  # type: ignore[assignment]
+
+    if ijson is None:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        entries = data.get("entries") if isinstance(data, dict) else None
+        if not isinstance(entries, list):
+            raise ValueError(f"{path} missing entries list")
+        return len(entries)
+
+    count = 0
+    with path.open("rb") as handle:
+        for _ in ijson.items(handle, "entries.item"):
+            count += 1
+    return count
+
+
+def _slice_candidate(
+    source: Path,
+    dest: Path,
+    *,
+    max_lemmas: int,
+) -> dict[str, Any]:
+    """Write a truncated Atlas-style candidate with the first ``max_lemmas`` entries."""
+    data = json.loads(source.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{source} must contain a JSON object")
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError(f"{source} missing entries list")
+    sliced = entries[: max(0, int(max_lemmas))]
+    out = {**data, "entries": sliced}
+    # Preserve reduce phase markers when present; mark slice for operators.
+    out["offline_enrich_slice"] = {
+        "max_lemmas": int(max_lemmas),
+        "source_entry_count": len(entries),
+        "sliced_entry_count": len(sliced),
+        "source_path": str(source),
+    }
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(
+        json.dumps(out, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "path": str(dest),
+        "source_entry_count": len(entries),
+        "sliced_entry_count": len(sliced),
+    }
+
+
+def _load_grac_cache(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object (lemma_key → rank payload)")
+    return data
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=None,
+        help="Working directory for ledger, seals, side DBs, artifacts (required to run)",
+    )
+    parser.add_argument(
+        "--candidate",
+        type=Path,
+        default=None,
+        help="Reduce candidate JSON (e.g. candidate-ulif-reduce.json)",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Alias for --candidate: any Atlas-style {entries:[...]} manifest",
+    )
+    parser.add_argument(
+        "--sources-db",
+        type=Path,
+        default=None,
+        help="sources.db (default: <repo>/data/sources.db)",
+    )
+    parser.add_argument(
+        "--kaikki-json",
+        type=Path,
+        default=None,
+        help="kaikki_uk_lookup.json (default: <repo>/data/lexicon/kaikki_uk_lookup.json)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Enriched candidate JSON (default: <work-dir>/candidate-enriched.json)",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=DEFAULT_CHUNK_SIZE,
+        help=f"Lemmas per leaf chunk (default {DEFAULT_CHUNK_SIZE})",
+    )
+    parser.add_argument(
+        "--stop-after-chunks",
+        type=int,
+        default=None,
+        help="Process at most N pending chunks this invocation (resume-friendly)",
+    )
+    parser.add_argument(
+        "--max-lemmas",
+        type=int,
+        default=None,
+        help="Truncate input to first N lemmas before enrich (fixture / dry-run slices)",
+    )
+    parser.add_argument("--ledger", type=Path, default=None, help="Ledger path (default: <work-dir>/ledger.sqlite)")
+    parser.add_argument("--run-id", type=str, default=None, help="Resume this ledger run_id")
+    parser.add_argument("--force-new-run", action="store_true")
+    parser.add_argument(
+        "--grac-cache",
+        type=Path,
+        default=None,
+        help="Optional pre-seeded GRAC frequency JSON (tests / offline hosts)",
+    )
+    parser.add_argument("--memory-high-mib", type=int, default=DEFAULT_MEMORY_HIGH_MIB)
+    parser.add_argument("--memory-max-mib", type=int, default=DEFAULT_MEMORY_MAX_MIB)
+    parser.add_argument(
+        "--require-memory-cap",
+        action="store_true",
+        help="Fail if OS cannot enforce MemoryPolicy (default on Linux VPS launch)",
+    )
+    parser.add_argument(
+        "--in-process",
+        action="store_true",
+        help="Run leaf enrich in-process (skip capped worker spawn; tests / tiny slices)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and print plan only; do not open sources.db or enrich",
+    )
+    parser.add_argument(
+        "--owner-id",
+        type=str,
+        default=None,
+        help="Ledger owner id (default: process-local auto)",
+    )
+    return parser
+
+
+def _refuse_bare(parser: argparse.ArgumentParser) -> int:
+    parser.print_usage(sys.stderr)
+    print(
+        "refusing: bare invocation would start offline enrich. "
+        "Pass --candidate/--manifest and --work-dir (or --help / --dry-run).",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def dry_run_plan(args: argparse.Namespace) -> int:
+    """Emit a dry-run plan event without starting enrichment."""
+    repo = args.repo.resolve()
+    input_path = _resolve_input(args)
+    work_dir = args.work_dir.resolve() if args.work_dir is not None else None
+    sources = (
+        Path(args.sources_db).resolve()
+        if args.sources_db is not None
+        else (repo / "data" / "sources.db")
+    )
+    kaikki = (
+        Path(args.kaikki_json).resolve()
+        if args.kaikki_json is not None
+        else (repo / "data" / "lexicon" / "kaikki_uk_lookup.json")
+    )
+    output = (
+        Path(args.output).resolve()
+        if args.output is not None
+        else ((work_dir / "candidate-enriched.json") if work_dir is not None else None)
+    )
+
+    entry_count: int | None = None
+    missing: list[str] = []
+    if input_path is None:
+        missing.append("candidate/manifest")
+    else:
+        if not input_path.is_file():
+            missing.append(f"input missing: {input_path}")
+        else:
+            try:
+                entry_count = _count_entries(input_path)
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                missing.append(f"input unreadable: {exc}")
+
+    if work_dir is None:
+        missing.append("work-dir")
+    if not sources.is_file():
+        missing.append(f"sources-db missing: {sources}")
+    if not kaikki.is_file():
+        missing.append(f"kaikki-json missing: {kaikki}")
+
+    effective_count = entry_count
+    if entry_count is not None and args.max_lemmas is not None:
+        effective_count = min(entry_count, max(0, int(args.max_lemmas)))
+    chunk_size = max(1, int(args.chunk_size))
+    planned_chunks = (
+        (effective_count + chunk_size - 1) // chunk_size if effective_count is not None else None
+    )
+
+    plan = {
+        "kind": "atlas-offline-enrich-dry-run",
+        "issue_refs": ["#5230", "#5331"],
+        "repo": str(repo),
+        "work_dir": str(work_dir) if work_dir else None,
+        "input": str(input_path) if input_path else None,
+        "sources_db": str(sources),
+        "kaikki_json": str(kaikki),
+        "output": str(output) if output else None,
+        "entry_count": entry_count,
+        "effective_entry_count": effective_count,
+        "chunk_size": chunk_size,
+        "planned_chunks": planned_chunks,
+        "stop_after_chunks": args.stop_after_chunks,
+        "max_lemmas": args.max_lemmas,
+        "memory_high_mib": args.memory_high_mib,
+        "memory_max_mib": args.memory_max_mib,
+        "in_process": bool(args.in_process),
+        "stops_before": ["finalize", "publish", "pin_flip"],
+        "missing": missing,
+        "ok": not missing,
+    }
+    _event("offline_enrich_dry_run", **plan)
+    return 0 if not missing else 2
+
+
+def _run(args: argparse.Namespace) -> int:
+    if args.dry_run:
+        return dry_run_plan(args)
+
+    input_path = _resolve_input(args)
+    if input_path is None or args.work_dir is None:
+        return _refuse_bare(build_parser())
+
+    repo = args.repo.resolve()
+    _load_repo(repo)
+    from scripts.lexicon.runner.memory import MemoryPolicy, apply_worker_memory_limit
+    from scripts.lexicon.runner.offline_engine import enrich_offline_slice
+
+    work_dir = args.work_dir.resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+    input_path = input_path.resolve()
+    if not input_path.is_file():
+        _event("offline_enrich_failed", error="input_missing", path=str(input_path))
+        return 2
+
+    sources = (
+        Path(args.sources_db).resolve()
+        if args.sources_db is not None
+        else (repo / "data" / "sources.db")
+    )
+    kaikki = (
+        Path(args.kaikki_json).resolve()
+        if args.kaikki_json is not None
+        else (repo / "data" / "lexicon" / "kaikki_uk_lookup.json")
+    )
+    if not sources.is_file():
+        _event("offline_enrich_failed", error="sources_db_missing", path=str(sources))
+        return 2
+    if not kaikki.is_file():
+        _event("offline_enrich_failed", error="kaikki_json_missing", path=str(kaikki))
+        return 2
+
+    memory_policy = MemoryPolicy(
+        high_bytes=int(args.memory_high_mib) * 1024**2,
+        max_bytes=int(args.memory_max_mib) * 1024**2,
+    )
+    enforcement = apply_worker_memory_limit(memory_policy)
+    _event(
+        "memory_policy",
+        enforcement=enforcement,
+        high_bytes=memory_policy.high_bytes,
+        max_bytes=memory_policy.max_bytes,
+    )
+    if args.require_memory_cap and enforcement == "none":
+        raise RuntimeError("MemoryPolicy could not enforce a hard cap")
+
+    manifest_for_engine = input_path
+    if args.max_lemmas is not None:
+        slice_path = work_dir / "candidate-slice.json"
+        slice_meta = _slice_candidate(input_path, slice_path, max_lemmas=int(args.max_lemmas))
+        _event("offline_enrich_slice", **slice_meta)
+        manifest_for_engine = slice_path
+
+    output = (
+        Path(args.output).resolve()
+        if args.output is not None
+        else (work_dir / "candidate-enriched.json")
+    )
+    ledger_path = Path(args.ledger).resolve() if args.ledger is not None else None
+    grac_cache = _load_grac_cache(Path(args.grac_cache) if args.grac_cache else None)
+
+    _event(
+        "offline_enrich_start",
+        candidate=str(manifest_for_engine),
+        sources=str(sources),
+        kaikki=str(kaikki),
+        work_dir=str(work_dir),
+        output=str(output),
+        chunk_size=int(args.chunk_size),
+        stop_after_chunks=args.stop_after_chunks,
+        in_process=bool(args.in_process),
+    )
+
+    result = enrich_offline_slice(
+        manifest_path=manifest_for_engine,
+        sources_db=sources,
+        kaikki_json=kaikki,
+        work_dir=work_dir,
+        output_path=output,
+        grac_cache=grac_cache,
+        memory_policy=memory_policy,
+        chunk_size=max(1, int(args.chunk_size)),
+        require_memory_self_test=bool(args.require_memory_cap),
+        skip_workers=bool(args.in_process),
+        ledger_path=ledger_path,
+        run_id=args.run_id,
+        force_new_run=bool(args.force_new_run),
+        stop_after_chunks=args.stop_after_chunks,
+        owner_id=args.owner_id,
+    )
+
+    summary_keys = (
+        "run_id",
+        "fingerprint",
+        "completed",
+        "failed_terminal",
+        "interrupted",
+        "processed_this_invocation",
+        "entry_count",
+        "output_path",
+        "ledger_path",
+        "cefr_seal",
+        "relations_seal",
+        "error",
+        "detail",
+        "resumable_run_id",
+    )
+    _event(
+        "offline_enrich_summary",
+        **{key: result.get(key) for key in summary_keys if key in result or key == "error"},
+        stops_before=["finalize", "publish", "pin_flip"],
+    )
+    if result.get("error"):
+        return 3
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    raw = list(sys.argv[1:] if argv is None else argv)
+    # #5393: bare invocation must not start multi-hour enrich.
+    if not raw:
+        return _refuse_bare(parser)
+    args = parser.parse_args(raw)
+    # --help is handled by argparse (SystemExit 0) before we get here.
+    return _run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/runner/launch_enrich.sh
+++ b/scripts/lexicon/runner/launch_enrich.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Detached, idempotent launcher for #5230 offline enrich (reduce candidate → enriched).
+# Mirrors launch_reduce.sh under MemoryHigh=1.5G MemoryMax=2.0G.
+#
+# Prerequisites (on VPS run-20k):
+#   - network-cache.sqlite populated (fetch done)
+#   - candidate-ulif-reduce.json present (reduce complete)
+#   - data/sources.db + data/lexicon/kaikki_uk_lookup.json available in $REPO
+#
+# Does NOT finalize, publish, or pin-flip. After enrich completes, operators
+# run finalize.py separately under the #5138 / #5331 publish gate.
+#
+# Usage:
+#   scripts/lexicon/runner/launch_enrich.sh
+#   scripts/lexicon/runner/launch_enrich.sh --stop-after-chunks 2   # smoke
+#   scripts/lexicon/runner/launch_enrich.sh --force-new-run
+#
+# Env overrides:
+#   ATLAS_RUN_ROOT, ATLAS_REPO, ATLAS_WORK_DIR, ATLAS_ENRICH_UNIT,
+#   ATLAS_ENRICH_DRIVER, ATLAS_CANDIDATE, ATLAS_SOURCES_DB, ATLAS_KAIKKI_JSON
+set -euo pipefail
+
+RUN_ROOT="${ATLAS_RUN_ROOT:-/home/ops/atlas-runner}"
+REPO="${ATLAS_REPO:-$RUN_ROOT/repo}"
+WORK_DIR="${ATLAS_WORK_DIR:-$RUN_ROOT/run-20k}"
+UNIT="${ATLAS_ENRICH_UNIT:-atlas-20k-enrich.service}"
+LOG="$WORK_DIR/enrich.log"
+PID_FILE="$WORK_DIR/enrich-driver.pid"
+WRAPPER_PID_FILE="$WORK_DIR/enrich-systemd-run.pid"
+DRIVER="${ATLAS_ENRICH_DRIVER:-$REPO/scripts/lexicon/runner/enrich_offline_20k.py}"
+CANDIDATE="${ATLAS_CANDIDATE:-$WORK_DIR/candidate-ulif-reduce.json}"
+SOURCES_DB="${ATLAS_SOURCES_DB:-$REPO/data/sources.db}"
+KAIKKI_JSON="${ATLAS_KAIKKI_JSON:-$REPO/data/lexicon/kaikki_uk_lookup.json}"
+ENRICH_WORK="${ATLAS_ENRICH_WORK_DIR:-$WORK_DIR/offline_enrich}"
+
+mkdir -p "$WORK_DIR" "$ENRICH_WORK"
+cd "$REPO"
+
+if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+  printf 'pid=%s log=%s\n' "$(cat "$PID_FILE")" "$LOG"
+  exit 0
+fi
+
+# Prefer in-repo driver; fall back to work-dir copy if repo checkout is stale.
+if [[ ! -f "$DRIVER" ]]; then
+  DRIVER="$WORK_DIR/enrich_offline_20k.py"
+fi
+if [[ ! -f "$DRIVER" ]]; then
+  echo "enrich driver not found: $DRIVER" >&2
+  exit 1
+fi
+if [[ ! -f "$CANDIDATE" ]]; then
+  echo "reduce candidate not found: $CANDIDATE (run reduce first)" >&2
+  exit 1
+fi
+if [[ ! -f "$SOURCES_DB" ]]; then
+  echo "sources.db not found: $SOURCES_DB" >&2
+  exit 1
+fi
+if [[ ! -f "$KAIKKI_JSON" ]]; then
+  echo "kaikki lookup not found: $KAIKKI_JSON" >&2
+  exit 1
+fi
+
+EXTRA_ARGS=("$@")
+
+COMMON_ARGS=(
+  --repo "$REPO"
+  --work-dir "$ENRICH_WORK"
+  --candidate "$CANDIDATE"
+  --sources-db "$SOURCES_DB"
+  --kaikki-json "$KAIKKI_JSON"
+  --output "$ENRICH_WORK/candidate-enriched.json"
+  --chunk-size 25
+  --require-memory-cap
+)
+
+if systemctl --user is-system-running >/dev/null 2>&1 && command -v systemd-run >/dev/null 2>&1; then
+  rm -f "$PID_FILE" "$WRAPPER_PID_FILE"
+  nohup systemd-run --user --wait --collect --unit="${UNIT%.service}" \
+    --working-directory="$REPO" \
+    --property=MemoryHigh=1536M \
+    --property=MemoryMax=2048M \
+    --property=StandardOutput="append:$LOG" \
+    --property=StandardError="append:$LOG" \
+    /usr/bin/nice -n 10 /usr/bin/ionice -c3 "$REPO/.venv/bin/python" \
+    "$DRIVER" \
+    "${COMMON_ARGS[@]}" \
+    "${EXTRA_ARGS[@]}" >> "$LOG" 2>&1 &
+  wrapper_pid=$!
+  printf '%s\n' "$wrapper_pid" > "$WRAPPER_PID_FILE"
+  for _ in $(seq 1 50); do
+    driver_pid=$(systemctl --user show "$UNIT" --property=MainPID --value 2>/dev/null || true)
+    if [[ "$driver_pid" =~ ^[1-9][0-9]*$ ]]; then
+      printf '%s\n' "$driver_pid" > "$PID_FILE"
+      printf 'pid=%s wrapper_pid=%s unit=%s log=%s\n' "$driver_pid" "$wrapper_pid" "$UNIT" "$LOG"
+      exit 0
+    fi
+    if ! kill -0 "$wrapper_pid" 2>/dev/null; then
+      tail -n 80 "$LOG" || true
+      exit 1
+    fi
+    sleep 0.1
+  done
+  tail -n 80 "$LOG" || true
+  exit 1
+fi
+
+rm -f "$PID_FILE" "$WRAPPER_PID_FILE"
+nohup /usr/bin/nice -n 10 /usr/bin/ionice -c3 "$REPO/.venv/bin/python" \
+  "$DRIVER" \
+  "${COMMON_ARGS[@]}" \
+  "${EXTRA_ARGS[@]}" >> "$LOG" 2>&1 &
+printf '%s\n' "$!" > "$PID_FILE"
+printf 'pid=%s log=%s\n' "$(cat "$PID_FILE")" "$LOG"

--- a/tests/test_lexicon_runner_enrich_offline_20k.py
+++ b/tests/test_lexicon_runner_enrich_offline_20k.py
@@ -1,0 +1,308 @@
+"""CLI driver for offline enrich (20k ULIF path) — #5230 / #5331 post-reduce."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON = str(ROOT / ".venv" / "bin" / "python")
+DRIVER = ROOT / "scripts" / "lexicon" / "runner" / "enrich_offline_20k.py"
+FIXTURE = ROOT / "tests" / "fixtures" / "lexicon" / "runner_pr1"
+MAX_FIXTURE_LEMMAS = 50
+
+
+def _ensure_fixture() -> None:
+    needed = (
+        FIXTURE / "slice_input.json",
+        FIXTURE / "sources_slice.sqlite",
+        FIXTURE / "kaikki_slice.json",
+        FIXTURE / "grac_frequency_slice.json",
+    )
+    if all(path.is_file() for path in needed):
+        return
+    from scripts.lexicon.runner.generate_pr1_fixture import main as gen
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("LEXICON_SLOVNYK_OFFLINE", "1")
+        assert gen() == 0
+    assert all(path.is_file() for path in needed)
+
+
+def _run_driver(*args: str, timeout: int = 120) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [PYTHON, str(DRIVER), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _events(stdout: str) -> list[dict]:
+    out: list[dict] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "event" in obj:
+            out.append(obj)
+    return out
+
+
+def test_help_exits_zero_without_side_effects(tmp_path: Path) -> None:
+    """#5393 class: --help must not start enrich or write work artifacts."""
+    work = tmp_path / "work"
+    proc = _run_driver("--help")
+    assert proc.returncode == 0, proc.stderr
+    help_text = (proc.stdout + proc.stderr).lower()
+    assert "usage:" in help_text
+    assert "--candidate" in help_text or "--manifest" in help_text
+    assert "--work-dir" in help_text
+    assert "--dry-run" in help_text
+    assert "--stop-after-chunks" in help_text
+    assert not work.exists()
+
+
+def test_bare_invocation_refuses_without_running() -> None:
+    """#5393 class: bare argv must refuse (nonzero) and not open a long run."""
+    proc = _run_driver()
+    assert proc.returncode != 0
+    combined = (proc.stdout + proc.stderr).lower()
+    assert "refusing" in combined or "usage:" in combined
+    assert "offline_enrich_start" not in proc.stdout
+
+
+def test_dry_run_plan_fixture_slice(tmp_path: Path) -> None:
+    _ensure_fixture()
+    work = tmp_path / "enrich_work"
+    proc = _run_driver(
+        "--dry-run",
+        "--work-dir",
+        str(work),
+        "--candidate",
+        str(FIXTURE / "slice_input.json"),
+        "--sources-db",
+        str(FIXTURE / "sources_slice.sqlite"),
+        "--kaikki-json",
+        str(FIXTURE / "kaikki_slice.json"),
+        "--max-lemmas",
+        str(MAX_FIXTURE_LEMMAS),
+        "--chunk-size",
+        "25",
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    events = _events(proc.stdout)
+    assert any(e.get("event") == "offline_enrich_dry_run" for e in events)
+    plan = next(e for e in events if e.get("event") == "offline_enrich_dry_run")
+    assert plan["ok"] is True
+    assert plan["entry_count"] == 500
+    assert plan["effective_entry_count"] == MAX_FIXTURE_LEMMAS
+    assert plan["planned_chunks"] == 2  # 50 / 25
+    assert "finalize" in plan["stops_before"]
+    assert "publish" in plan["stops_before"]
+    # Dry-run must not create ledger / seals under work-dir.
+    assert not (work / "ledger.sqlite").exists()
+    assert not (work / "seals").exists()
+
+
+def test_dry_run_missing_candidate_reports_not_ok(tmp_path: Path) -> None:
+    work = tmp_path / "enrich_work"
+    proc = _run_driver(
+        "--dry-run",
+        "--work-dir",
+        str(work),
+        "--candidate",
+        str(tmp_path / "missing-candidate.json"),
+        "--sources-db",
+        str(FIXTURE / "sources_slice.sqlite") if (FIXTURE / "sources_slice.sqlite").is_file() else str(tmp_path / "no-sources"),
+        "--kaikki-json",
+        str(tmp_path / "no-kaikki.json"),
+    )
+    assert proc.returncode != 0
+    events = _events(proc.stdout)
+    plan = next(e for e in events if e.get("event") == "offline_enrich_dry_run")
+    assert plan["ok"] is False
+    assert plan["missing"]
+
+
+def test_in_process_slice_stop_after_chunks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """≤50-lemma fixture dry-run of the full driver path (resumable, no finalize)."""
+    _ensure_fixture()
+    from scripts.lexicon import enrich_manifest as em
+    from scripts.lexicon.runner.enrich_offline_20k import main as enrich_main
+    from scripts.lexicon.runner.memory import EnforcementProof
+
+    monkeypatch.setattr(em, "_vesum_valid_synonym", lambda term: bool(term))
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.offline_engine.run_startup_self_test",
+        lambda **_kwargs: EnforcementProof(
+            kind="rlimit_as",
+            enforced=True,
+            detail="test stub",
+            max_bytes=64 * 1024 * 1024,
+        ),
+    )
+
+    def _fake_enrich(payload: dict) -> dict[str, str]:
+        import hashlib
+
+        entries = json.loads(Path(payload["entries_path"]).read_text(encoding="utf-8"))
+        artifact_dir = Path(payload["artifact_dir"])
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        arts: dict[str, str] = {}
+        for entry in entries:
+            lemma_id = str(entry.get("url_slug") or entry.get("lemma") or "")
+            body = {
+                "lemma": entry.get("lemma"),
+                "url_slug": lemma_id,
+                "enriched": True,
+                "offline_enrich_driver": True,
+            }
+            raw = json.dumps(body, ensure_ascii=False, sort_keys=True)
+            (artifact_dir / f"{lemma_id}.json").write_text(raw + "\n", encoding="utf-8")
+            arts[lemma_id] = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        return arts
+
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.worker_enrich.enrich_chunk_payload",
+        _fake_enrich,
+    )
+
+    work = tmp_path / "enrich_work"
+    out = work / "candidate-enriched.json"
+    code = enrich_main(
+        [
+            "--repo",
+            str(ROOT),
+            "--work-dir",
+            str(work),
+            "--candidate",
+            str(FIXTURE / "slice_input.json"),
+            "--sources-db",
+            str(FIXTURE / "sources_slice.sqlite"),
+            "--kaikki-json",
+            str(FIXTURE / "kaikki_slice.json"),
+            "--grac-cache",
+            str(FIXTURE / "grac_frequency_slice.json"),
+            "--output",
+            str(out),
+            "--max-lemmas",
+            str(MAX_FIXTURE_LEMMAS),
+            "--chunk-size",
+            "25",
+            "--stop-after-chunks",
+            "1",
+            "--in-process",
+        ]
+    )
+    assert code == 0
+    assert out.is_file()
+    candidate = json.loads(out.read_text(encoding="utf-8"))
+    assert candidate.get("enrichment_generated") is True
+    assert candidate.get("interrupted") is True
+    assert len(candidate["entries"]) == MAX_FIXTURE_LEMMAS
+    # First chunk only enriched under the stub; rest passthrough.
+    enriched = [e for e in candidate["entries"] if e.get("enriched") is True]
+    assert len(enriched) == 25
+    assert (work / "ledger.sqlite").is_file()
+    # Must not have invoked finalize / publication tree.
+    assert not (work / "tree").exists()
+    assert not list(work.glob("**/atlas-tree.zip"))
+
+
+def test_resume_after_stop_after_chunks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _ensure_fixture()
+    from scripts.lexicon import enrich_manifest as em
+    from scripts.lexicon.runner.enrich_offline_20k import main as enrich_main
+    from scripts.lexicon.runner.memory import EnforcementProof
+
+    monkeypatch.setattr(em, "_vesum_valid_synonym", lambda term: bool(term))
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.offline_engine.run_startup_self_test",
+        lambda **_kwargs: EnforcementProof(
+            kind="rlimit_as",
+            enforced=True,
+            detail="test stub",
+            max_bytes=64 * 1024 * 1024,
+        ),
+    )
+
+    def _fake_enrich(payload: dict) -> dict[str, str]:
+        import hashlib
+
+        entries = json.loads(Path(payload["entries_path"]).read_text(encoding="utf-8"))
+        artifact_dir = Path(payload["artifact_dir"])
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        arts: dict[str, str] = {}
+        for entry in entries:
+            lemma_id = str(entry.get("url_slug") or entry.get("lemma") or "")
+            body = {"lemma": entry.get("lemma"), "url_slug": lemma_id, "enriched": True}
+            raw = json.dumps(body, ensure_ascii=False, sort_keys=True)
+            (artifact_dir / f"{lemma_id}.json").write_text(raw + "\n", encoding="utf-8")
+            arts[lemma_id] = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        return arts
+
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.worker_enrich.enrich_chunk_payload",
+        _fake_enrich,
+    )
+
+    work = tmp_path / "enrich_work"
+    out1 = work / "out1.json"
+    common = [
+        "--repo",
+        str(ROOT),
+        "--work-dir",
+        str(work),
+        "--candidate",
+        str(FIXTURE / "slice_input.json"),
+        "--sources-db",
+        str(FIXTURE / "sources_slice.sqlite"),
+        "--kaikki-json",
+        str(FIXTURE / "kaikki_slice.json"),
+        "--grac-cache",
+        str(FIXTURE / "grac_frequency_slice.json"),
+        "--max-lemmas",
+        str(MAX_FIXTURE_LEMMAS),
+        "--chunk-size",
+        "25",
+        "--in-process",
+        "--owner-id",
+        "enrich-driver-test",
+    ]
+    code1 = enrich_main([*common, "--output", str(out1), "--stop-after-chunks", "1"])
+    assert code1 == 0
+    first = json.loads(out1.read_text(encoding="utf-8"))
+    run_id = first["ledger_run_id"]
+    assert first.get("interrupted") is True
+
+    out2 = work / "out2.json"
+    code2 = enrich_main([*common, "--output", str(out2), "--run-id", run_id])
+    assert code2 == 0
+    second = json.loads(out2.read_text(encoding="utf-8"))
+    assert second["ledger_run_id"] == run_id
+    assert second.get("interrupted") is False
+    assert sum(1 for e in second["entries"] if e.get("enriched") is True) == MAX_FIXTURE_LEMMAS
+
+
+def test_launch_enrich_sh_is_executable_and_documents_caps() -> None:
+    path = ROOT / "scripts" / "lexicon" / "runner" / "launch_enrich.sh"
+    assert path.is_file()
+    text = path.read_text(encoding="utf-8")
+    assert "MemoryHigh=1536M" in text
+    assert "MemoryMax=2048M" in text
+    assert "enrich_offline_20k.py" in text
+    assert "candidate-ulif-reduce.json" in text
+    assert "finalize" in text.lower() or "pin-flip" in text.lower()
+    # Shell syntax check
+    proc = subprocess.run(["bash", "-n", str(path)], capture_output=True, text=True, check=False)
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
## Summary

Ships an in-repo **CLI driver + tests + VPS launcher** for the post-reduce offline enrich path on the 20k ULIF cohort.

- Consumes `candidate-ulif-reduce.json` (or any Atlas-style `{entries:[…]}` fixture/manifest)
- Runs sealed CEFR → relations → leaf chunk enrich via `offline_engine.enrich_offline_slice`
- Resumable ledger under `--work-dir`
- **Stops before** finalize / publish / pin-flip (out of scope)
- `#5393` class: bare invocation and `--help` never start a multi-hour run

Refs #5230 #5331

## Files

| Path | Role |
| --- | --- |
| `scripts/lexicon/runner/enrich_offline_20k.py` | CLI driver (`argparse`) |
| `scripts/lexicon/runner/launch_enrich.sh` | Detached VPS launcher (mirrors `launch_reduce.sh`) |
| `scripts/lexicon/runner/README-offline-enrich.md` | Operator recipe |
| `tests/test_lexicon_runner_enrich_offline_20k.py` | ≤50-lemma fixture + bare/help + resume tests |

## CLI surface

```text
--work-dir --candidate|--manifest --sources-db --kaikki-json --output
--chunk-size --stop-after-chunks --max-lemmas --ledger --run-id
--force-new-run --grac-cache --memory-high-mib --memory-max-mib
--require-memory-cap --in-process --dry-run --owner-id
```

## VPS launch recipe (post-reduce, run-20k)

Prerequisites already on VPS:

- `network-cache.sqlite` (fetch done, ~20,323 units)
- `candidate-ulif-reduce.json` (reduce complete)
- `data/sources.db` + `data/lexicon/kaikki_uk_lookup.json` in repo checkout
- Memory caps: MemoryHigh=1.5G MemoryMax=2.0G

```bash
# Plan only (no enrich)
.venv/bin/python scripts/lexicon/runner/enrich_offline_20k.py \
  --dry-run \
  --repo /home/ops/atlas-runner/repo \
  --work-dir /home/ops/atlas-runner/run-20k/offline_enrich \
  --candidate /home/ops/atlas-runner/run-20k/candidate-ulif-reduce.json

# Detached enrich under systemd-run memory caps (idempotent)
scripts/lexicon/runner/launch_enrich.sh

# Smoke one chunk then exit (resume later)
scripts/lexicon/runner/launch_enrich.sh --stop-after-chunks 1

# Resume after kill/reboot (same work-dir; ledger continues)
scripts/lexicon/runner/launch_enrich.sh

# Tail events
tail -f /home/ops/atlas-runner/run-20k/enrich.log | grep --line-buffered '"event"'
```

Outputs under `$WORK_DIR/offline_enrich/`:

- `ledger.sqlite` — resumable run state
- `seals/cefr.sqlite`, `seals/relations.sqlite`
- `artifacts/` — per-chunk lemma JSON
- `candidate-enriched.json` — streaming candidate (not published)

**Not done by this driver:** `finalize.py`, publication archive, pin-flip.

## Local smoke (fixture ≤50 lemmas)

```bash
.venv/bin/python -m pytest tests/test_lexicon_runner_enrich_offline_20k.py -q
```

## Test plan

- [x] `pytest tests/test_lexicon_runner_enrich_offline_20k.py` (7 passed)
- [x] `--help` exits 0; bare refuses (exit 2)
- [x] dry-run ≤50 lemmas plans 2 chunks, no ledger writes
- [x] in-process slice + `--stop-after-chunks 1` + resume
- [x] `bash -n launch_enrich.sh`
- [x] `lint_agent_trailer.py` PASS
- [ ] Operator VPS dry-run against live reduce artifact (post-merge / after review)
- [ ] Full VPS enrich (operator-gated; not in this PR)

## Out of scope

- Publishing Atlas to live site
- #5411 838 promote
- Re-running full VPS enrich in CI