### PR TITLE
test(site): assert inline etymology toggle in built output (#5342)

### DIFF
--- a/site/tests/unit/etymology-handler-built-output.test.ts
+++ b/site/tests/unit/etymology-handler-built-output.test.ts
@@ -17,10 +17,19 @@ import { articleProps } from "../helpers/word-atlas-record";
 type AstroComponent = Parameters<AstroContainer["renderToString"]>[0];
 
 const ETY_HANDLER_MARKERS = [
+  // The inline script must exist and be wired to click on etymology stages.
+  "<script",
+  "addEventListener('click'",
+  // Root scope + selector contract.
+  "[data-word-atlas]",
   "[data-ety-note]",
   "[data-ety-note-output]",
-  "data-ety-note",
+  // Output-target traversal contract.
+  "closest('.atlas-section')",
+  // Active-state + content swap contract.
   "classList.remove('active')",
+  "classList.add('active')",
+  "dataset.etyNote",
 ] as const;
 
 const stubRecord = articleProps({


### PR DESCRIPTION
Strengthen the built-output assertion for the lexicon etymology toggle so the handler cannot silently disappear while the route-parity shell comparison stays green.

- Verifies the inline `<script>` tag and `addEventListener('click', ...)` binding.
- Verifies selector hooks (`[data-word-atlas]`, `[data-ety-note]`, `[data-ety-note-output]`) and active-state contract.
- Fails when the handler is removed or the target id/attribute contract drifts.
- Contained to `site/tests/unit/etymology-handler-built-output.test.ts`.

Red/green demo:
- Removed the inline handler from `WordAtlasPageShell.astro` → `cd site && npx vitest run tests/unit/etymology-handler-built-output.test.ts` fails.
- Restored the handler → test passes.

Refs #5342
Refs #4387