### PR TITLE
fix(atlas): align fill_local CEFR + closed pointer relations with enrich

### DIFF
--- a/scripts/atlas/fill_local.py
+++ b/scripts/atlas/fill_local.py
@@ -5,6 +5,12 @@ each attached field as a resumable row in ``enrichment``. Phase 1 is forced
 offline with ``LEXICON_SLOVNYK_OFFLINE=1``: existing local caches may be read,
 but cache misses must stay absent and never open a socket.
 
+Before the per-article loop, the fill cohort gets the same run-level
+precomputes as full ``enrich()`` / ``worker_enrich`` (#5331): CEFR quantile
+estimates via ``_prepare_cefr_estimates`` and closed
+``pointer_{synonym,antonym,homonym,paronym}_relations`` maps (reciprocal
+within the fill cohort).
+
 Absent-vs-uncovered rule:
 
 - Phase-2-fillable sections stay absent when Phase 1 has no payload:
@@ -347,6 +353,44 @@ def fill_local(
         )
 
 
+def _cohort_manifest(articles: list[sqlite3.Row]) -> dict[str, Any]:
+    """Build a mini-manifest for CEFR quantiles + closed pointer maps (#5331)."""
+    return {
+        "entries": [
+            {
+                "lemma": row["lemma"],
+                "url_slug": row["slug"],
+                "pos": row["pos"],
+                "gloss": row["gloss"],
+            }
+            for row in articles
+        ]
+    }
+
+
+def _pointer_relation_maps(
+    sources_conn: sqlite3.Connection,
+    cohort_manifest: dict[str, Any],
+    *,
+    has_sum11_flags: bool,
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Precompute reciprocal pointer maps over the fill cohort (mirror enrich())."""
+    return {
+        "synonym": enrich_manifest._definition_pointer_relations_by_headword(
+            sources_conn, cohort_manifest, has_sum11_flags=has_sum11_flags
+        ),
+        "antonym": enrich_manifest._definition_antonym_relations_by_headword(
+            sources_conn, cohort_manifest, has_sum11_flags=has_sum11_flags
+        ),
+        "homonym": enrich_manifest._homonym_relations_by_headword(
+            sources_conn, cohort_manifest
+        ),
+        "paronym": enrich_manifest._paronym_relations_by_headword(
+            sources_conn, cohort_manifest
+        ),
+    }
+
+
 def _fill_local(
     db_path: Path = DEFAULT_DB,
     sources_db_path: Path = DEFAULT_SOURCES_DB,
@@ -355,9 +399,6 @@ def _fill_local(
     slug: str | None = None,
     refresh: bool = False,
 ) -> FillResult:
-    if hasattr(enrich_manifest, "_CEFR_ESTIMATE_LEVEL_BY_KEY"):
-        enrich_manifest._CEFR_ESTIMATE_LEVEL_BY_KEY.clear()
-
     with _connect(db_path) as atlas_conn, sqlite3.connect(sources_db_path) as sources_conn:
         articles = _article_rows(atlas_conn, slug)
         if slug and not articles:
@@ -367,6 +408,17 @@ def _fill_local(
         before = _coverage(atlas_conn)
         kaikki_lookup = enrich_manifest._load_kaikki_lookup(kaikki_lookup_path)
         has_sum11_flags = enrich_manifest._sum11_has_flag_columns(sources_conn)
+
+        # Align with full enrich / worker_enrich (#5331): prepare cohort CEFR
+        # estimates and closed pointer maps before the per-article loop. Single-slug
+        # fills only close relations within that slug set; full-atlas fills get
+        # cohort-wide reciprocity. Sealed full-cohort maps remain the #5230 path.
+        cohort_manifest = _cohort_manifest(articles)
+        enrich_manifest._prepare_cefr_estimates(sources_conn, cohort_manifest)
+        pointer_maps = _pointer_relation_maps(
+            sources_conn, cohort_manifest, has_sum11_flags=has_sum11_flags
+        )
+
         filled_at = _iso_now()
         inserted = 0
         skipped_existing = 0
@@ -374,8 +426,18 @@ def _fill_local(
         for article in articles:
             entry = _entry_from_article(atlas_conn, article)
             existing_payloads = {} if refresh else _existing_payloads(atlas_conn, article["slug"])
+            entry_key = enrich_manifest._canonical_synonym_term(str(entry.get("lemma") or "")) or ""
             with _skip_existing_extractors(existing_payloads):
-                enrich_entry(entry, sources_conn, kaikki_lookup, has_sum11_flags=has_sum11_flags)
+                enrich_entry(
+                    entry,
+                    sources_conn,
+                    kaikki_lookup,
+                    has_sum11_flags=has_sum11_flags,
+                    pointer_synonym_relations=pointer_maps["synonym"].get(entry_key, []),
+                    pointer_antonym_relations=pointer_maps["antonym"].get(entry_key, []),
+                    pointer_homonym_relations=pointer_maps["homonym"].get(entry_key, []),
+                    pointer_paronym_relations=pointer_maps["paronym"].get(entry_key, []),
+                )
             payloads = entry_payloads(entry)
             uncovered = set(_uncovered_sections(payloads))
             for section in uncovered:

--- a/scripts/atlas/measure_fill_enrich_divergence.py
+++ b/scripts/atlas/measure_fill_enrich_divergence.py
@@ -1,36 +1,30 @@
 #!/usr/bin/env python3
-"""Measure fill_local vs full-enrich CEFR / relation divergence (#5331).
+"""Measure fill_local vs full-enrich CEFR / relation alignment (#5331).
 
-Two LIVE path divergences:
+Historical LIVE path divergences (pre-fix):
 
-1. **CEFR** — ``scripts/atlas/fill_local.py`` clears
-   ``enrich_manifest._CEFR_ESTIMATE_LEVEL_BY_KEY`` and never rebuilds it.
+1. **CEFR** — ``scripts/atlas/fill_local.py`` cleared
+   ``enrich_manifest._CEFR_ESTIMATE_LEVEL_BY_KEY`` and never rebuilt it.
    Full ``enrich()`` runs ``_prepare_cefr_estimates`` (or the sealed CEFR phase)
    over the cohort, so non-PULS lemmas get GRAC quantile bands.
 
 2. **Relations** — full ``enrich()`` precomputes pointer maps with reciprocal
-   closure and passes them into ``enrich_entry``. ``fill_local`` calls
+   closure and passes them into ``enrich_entry``. Pre-fix ``fill_local`` called
    ``enrich_entry`` without pointer args, so only per-lemma forward extractors
-   run (reciprocal edges onto other cohort headwords are absent).
+   ran (reciprocal edges onto other cohort headwords were absent).
+
+3. **Synonym kwarg** — ``enrich_entry`` accepted ``pointer_synonym_relations``
+   but did not merge them (mphdict-only) until the #5331 wire-up.
 
 This module measures those gaps **offline** on a fixed synthetic cohort (≤50
 lemmas by default) without rewriting the live gitignored manifest. Prefer the
 committed hermetic builder over live ``data/`` so CI stays OOM-safe.
 
-Fix shape for a follow-up (owned by the #5230 chunked-runner arc; do not partial-fix
-single-slug fills without a sealed full-cohort relation map):
-
-1. In ``fill_local._fill_local``, replace bare ``_CEFR_ESTIMATE_LEVEL_BY_KEY.clear()``
-   with ``_prepare_cefr_estimates(sources_conn, cohort_manifest)`` (or load a
-   sealed CEFR map) before the article loop.
-2. Precompute ``_*_relations_by_headword`` (or load sealed relations.sqlite) over
-   the fill cohort / full atlas headwords and pass
-   ``pointer_{synonym,antonym,homonym,paronym}_relations`` into each
-   ``enrich_entry`` call (mirror ``enrich()`` / ``worker_enrich``).
-3. Wire ``pointer_synonym_relations`` through ``_merge_synonym_relations`` inside
-   ``enrich_entry`` — the kwarg is currently accepted but unused (mphdict-only
-   synonyms), so even full enrich drops definition-pointer synonym edges from
-   the rendered section until that merge lands.
+After the fill_local + enrich_entry fix, the **fixed** path (prepare CEFR +
+closed pointer maps, matching live ``fill_local``) should report zero
+``missing_on_fill`` and zero ``only_on_enrich`` edge deltas for the synthetic
+cohort. The **legacy** path is retained so the pre-fix divergence remains
+reproducible for regression notes.
 
 Usage::
 
@@ -227,7 +221,7 @@ def fill_local_style_relations(
     *,
     has_sum11_flags: bool,
 ) -> dict[str, dict[str, list[dict[str, Any]]]]:
-    """Per-lemma extractors only — what ``enrich_entry`` uses when pointer_* is None."""
+    """Per-lemma extractors only — pre-fix fill_local / enrich_entry None-pointer path."""
     out: dict[str, dict[str, list[dict[str, Any]]]] = {kind: {} for kind in RELATION_KINDS}
     for entry in entries:
         lemma = str(entry.get("lemma") or "")
@@ -259,7 +253,7 @@ def enrich_style_relations(
     *,
     has_sum11_flags: bool,
 ) -> dict[str, dict[str, list[dict[str, Any]]]]:
-    """Run-level by_headword maps with reciprocal closure (full enrich path)."""
+    """Run-level by_headword maps with reciprocal closure (full enrich / fixed fill_local)."""
     return {
         "synonym": em._definition_pointer_relations_by_headword(
             conn, manifest, has_sum11_flags=has_sum11_flags
@@ -272,75 +266,35 @@ def enrich_style_relations(
     }
 
 
-def measure_divergence(
-    entries: list[dict[str, Any]],
-    sources_db: Path,
-    grac_cache: dict[str, Any],
+def _cefr_delta(
+    lemmas: list[str],
+    fill_cefr: dict[str, dict[str, str] | None],
+    enrich_cefr: dict[str, dict[str, str] | None],
     *,
-    open_conn: Callable[[Path], sqlite3.Connection] | None = None,
+    prepared_estimate_keys: int,
 ) -> dict[str, Any]:
-    """Compare fill_local-style vs full-enrich-style CEFR + relation precomputes.
-
-    Returns a JSON-serializable summary. Numbers come only from the executed paths.
-    """
-    if not entries:
-        raise ValueError("entries must be non-empty")
-    if len(entries) > 50:
-        raise ValueError("measure at most 50 lemmas (CI-safe cohort cap)")
-
-    manifest = {"entries": [dict(entry) for entry in entries]}
-    lemmas = [str(entry.get("lemma") or "") for entry in entries]
-    connect = open_conn or (lambda path: sqlite3.connect(f"file:{path.resolve().as_posix()}?mode=ro", uri=True))
-
-    with _engine_state(grac_cache):
-        conn = connect(sources_db)
-        try:
-            has_sum11 = em._sum11_has_flag_columns(conn)
-
-            # --- fill_local CEFR path: clear estimates, do not rebuild ---
-            em._CEFR_ESTIMATE_LEVEL_BY_KEY.clear()
-            fill_cefr: dict[str, dict[str, str] | None] = {}
-            for lemma in lemmas:
-                fill_cefr[lemma] = em._cefr(conn, lemma)
-
-            # --- full enrich CEFR path: prepare cohort quantiles ---
-            em._prepare_cefr_estimates(conn, manifest)
-            enrich_cefr: dict[str, dict[str, str] | None] = {}
-            for lemma in lemmas:
-                enrich_cefr[lemma] = em._cefr(conn, lemma)
-
-            fill_relations = fill_local_style_relations(
-                conn, entries, has_sum11_flags=has_sum11
-            )
-            enrich_relations = enrich_style_relations(
-                conn, manifest, has_sum11_flags=has_sum11
-            )
-            prepared_estimate_keys = len(em._CEFR_ESTIMATE_LEVEL_BY_KEY)
-        finally:
-            conn.close()
-
-    cefr_missing_on_fill: list[str] = []
-    cefr_level_divergent: list[dict[str, Any]] = []
-    cefr_fill_present = 0
-    cefr_enrich_present = 0
-    cefr_enrich_estimated = 0
+    missing_on_fill: list[str] = []
+    level_divergent: list[dict[str, Any]] = []
+    fill_present = 0
+    enrich_present = 0
+    enrich_estimated = 0
     for lemma in lemmas:
         fill_block = fill_cefr.get(lemma)
         enrich_block = enrich_cefr.get(lemma)
         if fill_block:
-            cefr_fill_present += 1
+            fill_present += 1
         if enrich_block:
-            cefr_enrich_present += 1
+            enrich_present += 1
             if str(enrich_block.get("source") or "") == em._CEFR_ESTIMATED_SOURCE:
-                cefr_enrich_estimated += 1
+                enrich_estimated += 1
         if enrich_block and not fill_block:
-            cefr_missing_on_fill.append(lemma)
+            missing_on_fill.append(lemma)
         elif (
             fill_block
             and enrich_block
             and str(fill_block.get("level") or "") != str(enrich_block.get("level") or "")
         ):
-            cefr_level_divergent.append(
+            level_divergent.append(
                 {
                     "lemma": lemma,
                     "fill_level": fill_block.get("level"),
@@ -349,7 +303,22 @@ def measure_divergence(
                     "enrich_source": enrich_block.get("source"),
                 }
             )
+    return {
+        "fill_present": fill_present,
+        "enrich_present": enrich_present,
+        "enrich_estimated": enrich_estimated,
+        "missing_on_fill_count": len(missing_on_fill),
+        "missing_on_fill_lemmas": missing_on_fill,
+        "level_divergent_count": len(level_divergent),
+        "level_divergent": level_divergent,
+        "prepared_estimate_keys": prepared_estimate_keys,
+    }
 
+
+def _relation_delta(
+    fill_relations: dict[str, dict[str, list[dict[str, Any]]]],
+    enrich_relations: dict[str, dict[str, list[dict[str, Any]]]],
+) -> dict[str, Any]:
     relation_delta: dict[str, Any] = {}
     for kind in RELATION_KINDS:
         fill_stats = _edge_stats(fill_relations.get(kind, {}))
@@ -366,47 +335,111 @@ def measure_divergence(
             "reciprocal_only_on_enrich": sum(
                 1 for _s, _t, direction in only_enrich if direction == "reciprocal"
             ),
-            # Sample keys for debugging (cap keeps JSON small).
             "sample_only_on_enrich": [
                 {"source": s, "target": t, "direction": d} for s, t, d in only_enrich[:8]
             ],
         }
+    return relation_delta
+
+
+def measure_divergence(
+    entries: list[dict[str, Any]],
+    sources_db: Path,
+    grac_cache: dict[str, Any],
+    *,
+    open_conn: Callable[[Path], sqlite3.Connection] | None = None,
+) -> dict[str, Any]:
+    """Compare fill_local paths vs full-enrich-style CEFR + relation precomputes.
+
+    Returns a JSON-serializable summary. Numbers come only from the executed paths.
+
+    ``fixed`` mirrors post-#5331 ``fill_local`` (prepare CEFR + closed pointer maps).
+    ``legacy`` mirrors the pre-fix clear-only / per-lemma-extractor path.
+    """
+    if not entries:
+        raise ValueError("entries must be non-empty")
+    if len(entries) > 50:
+        raise ValueError("measure at most 50 lemmas (CI-safe cohort cap)")
+
+    manifest = {"entries": [dict(entry) for entry in entries]}
+    lemmas = [str(entry.get("lemma") or "") for entry in entries]
+    connect = open_conn or (lambda path: sqlite3.connect(f"file:{path.resolve().as_posix()}?mode=ro", uri=True))
+
+    with _engine_state(grac_cache):
+        conn = connect(sources_db)
+        try:
+            has_sum11 = em._sum11_has_flag_columns(conn)
+
+            # --- legacy fill_local CEFR path: clear estimates, do not rebuild ---
+            em._CEFR_ESTIMATE_LEVEL_BY_KEY.clear()
+            legacy_fill_cefr: dict[str, dict[str, str] | None] = {}
+            for lemma in lemmas:
+                legacy_fill_cefr[lemma] = em._cefr(conn, lemma)
+
+            # --- fixed fill_local / full enrich CEFR path: prepare cohort quantiles ---
+            em._prepare_cefr_estimates(conn, manifest)
+            fixed_fill_cefr: dict[str, dict[str, str] | None] = {}
+            enrich_cefr: dict[str, dict[str, str] | None] = {}
+            for lemma in lemmas:
+                block = em._cefr(conn, lemma)
+                fixed_fill_cefr[lemma] = block
+                enrich_cefr[lemma] = block
+
+            legacy_fill_relations = fill_local_style_relations(
+                conn, entries, has_sum11_flags=has_sum11
+            )
+            fixed_fill_relations = enrich_style_relations(
+                conn, manifest, has_sum11_flags=has_sum11
+            )
+            enrich_relations = fixed_fill_relations
+            prepared_estimate_keys = len(em._CEFR_ESTIMATE_LEVEL_BY_KEY)
+        finally:
+            conn.close()
+
+    legacy_cefr = _cefr_delta(
+        lemmas,
+        legacy_fill_cefr,
+        enrich_cefr,
+        prepared_estimate_keys=0,
+    )
+    fixed_cefr = _cefr_delta(
+        lemmas,
+        fixed_fill_cefr,
+        enrich_cefr,
+        prepared_estimate_keys=prepared_estimate_keys,
+    )
+    legacy_relations = _relation_delta(legacy_fill_relations, enrich_relations)
+    fixed_relations = _relation_delta(fixed_fill_relations, enrich_relations)
 
     return {
-        "schema": "fill-enrich-divergence-v1",
+        "schema": "fill-enrich-divergence-v2",
         "issue": 5331,
         "lemmas_compared": len(lemmas),
         "lemmas": lemmas,
-        "cefr": {
-            "fill_present": cefr_fill_present,
-            "enrich_present": cefr_enrich_present,
-            "enrich_estimated": cefr_enrich_estimated,
-            "missing_on_fill_count": len(cefr_missing_on_fill),
-            "missing_on_fill_lemmas": cefr_missing_on_fill,
-            "level_divergent_count": len(cefr_level_divergent),
-            "level_divergent": cefr_level_divergent,
-            "prepared_estimate_keys": prepared_estimate_keys,
+        # Top-level keys keep the fixed path (post-#5331 fill_local) as primary.
+        "cefr": fixed_cefr,
+        "relations": fixed_relations,
+        "legacy": {
+            "cefr": legacy_cefr,
+            "relations": legacy_relations,
         },
-        "relations": relation_delta,
         "notes": {
-            "fill_local_cefr": (
-                "fill_local clears _CEFR_ESTIMATE_LEVEL_BY_KEY and never calls "
-                "_prepare_cefr_estimates; only PULS CEFR survives on the fill path."
+            "fixed_path": (
+                "Post-#5331 fill_local prepares _CEFR_ESTIMATE_LEVEL_BY_KEY via "
+                "_prepare_cefr_estimates and passes closed pointer maps into "
+                "enrich_entry; synonym pointers merge via _merge_synonym_relations. "
+                "On the same cohort as full enrich, missing_on_fill and "
+                "only_on_enrich should be zero."
             ),
-            "fill_local_relations": (
-                "fill_local calls enrich_entry without pointer_* maps; per-lemma "
-                "forward extractors run, reciprocal cohort edges do not."
+            "legacy_path": (
+                "Pre-fix fill_local cleared CEFR estimates without rebuild and "
+                "called enrich_entry without pointer_* maps (forward extractors only). "
+                "legacy.* preserves those pre-fix numbers for regression notes."
             ),
-            "pointer_synonym_dead_kwarg": (
-                "enrich_entry accepts pointer_synonym_relations but does not merge "
-                "them into sections (mphdict-only). Measurement still counts the "
-                "precompute-map delta; rendered synonym fix is a separate wire-up."
-            ),
-            "follow_up_fix_shape": (
-                "Prepare CEFR for the fill cohort (or load sealed CEFR); pass closed "
-                "pointer maps into enrich_entry; wire pointer_synonym_relations via "
-                "_merge_synonym_relations. Prefer #5230 sealed run-level phases over "
-                "ad-hoc single-slug reciprocity."
+            "single_slug_residual": (
+                "Single-slug fill_local only closes relations within the fill "
+                "cohort (that slug set). Full-atlas reciprocity still needs a "
+                "full-cohort or #5230 sealed relation map."
             ),
         },
     }
@@ -426,24 +459,39 @@ def run_default_measurement(cohort_size: int = DEFAULT_COHORT_SIZE) -> dict[str,
 def format_summary(result: dict[str, Any]) -> str:
     """Human-readable one-screen summary of a measurement result."""
     cefr = result["cefr"]
+    legacy_cefr = result.get("legacy", {}).get("cefr", {})
     lines = [
         f"lemmas_compared {result['lemmas_compared']}",
         (
-            f"cefr missing_on_fill={cefr['missing_on_fill_count']} "
+            f"cefr(fixed) missing_on_fill={cefr['missing_on_fill_count']} "
             f"fill_present={cefr['fill_present']} enrich_present={cefr['enrich_present']} "
             f"enrich_estimated={cefr['enrich_estimated']} "
             f"level_divergent={cefr['level_divergent_count']}"
         ),
     ]
+    if legacy_cefr:
+        lines.append(
+            f"cefr(legacy) missing_on_fill={legacy_cefr['missing_on_fill_count']} "
+            f"fill_present={legacy_cefr['fill_present']} "
+            f"enrich_present={legacy_cefr['enrich_present']}"
+        )
     for kind in RELATION_KINDS:
         rel = result["relations"][kind]
         lines.append(
-            f"relations.{kind} "
+            f"relations.{kind}(fixed) "
             f"fill_edges={rel['fill_local']['edges']} "
             f"enrich_edges={rel['enrich']['edges']} "
             f"only_on_enrich={rel['edges_only_on_enrich']} "
             f"reciprocal_only_on_enrich={rel['reciprocal_only_on_enrich']}"
         )
+        legacy_rel = result.get("legacy", {}).get("relations", {}).get(kind)
+        if legacy_rel:
+            lines.append(
+                f"relations.{kind}(legacy) "
+                f"fill_edges={legacy_rel['fill_local']['edges']} "
+                f"enrich_edges={legacy_rel['enrich']['edges']} "
+                f"only_on_enrich={legacy_rel['edges_only_on_enrich']}"
+            )
     return "\n".join(lines)
 
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -5901,6 +5901,20 @@ def enrich_entry(
         synonyms = _synonyms_mphdict(fallback_base)
         if synonyms:
             synonyms = _with_base_source_label(synonyms, fallback_base)
+    # Definition-pointer / closed-map synonyms (#5331): when the caller precomputed
+    # reciprocal maps (enrich / worker_enrich / fill_local), merge them; otherwise
+    # fall back to the per-lemma forward extractor (same contract as antonyms).
+    synonym_relations = (
+        pointer_synonym_relations
+        if pointer_synonym_relations is not None
+        else _definition_pointer_relations(
+            conn,
+            lemma,
+            has_sum11_flags=has_sum11_flags,
+            cache=slovnyk_cache,
+        )
+    )
+    synonyms = _merge_synonym_relations(synonyms, synonym_relations)
     _apply_section("synonyms", synonyms, gate_ran=synonyms_gate_ran)
     antonyms = _antonyms_wiktionary(conn, base, entry_pos=entry_pos)
     if not antonyms and fallback_base:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "addd0590e765169cf09eb9a1a5255176160ec1889693bcf8bbefcb0d1a7dec77",
+  "fingerprint": "d875d8b7b582e307b4de97d442bf5f2107be64c4af6c667505eda95d92d16daf",
   "inputs": {
     "lexicon_code": [
       {
@@ -76,7 +76,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "40f4f7e6ca6f6235787a6a8aa15c753b3b5f937a99be61968d0f9f2dfc501577"
+        "sha256": "599a5f1aa9e678e381efdf9b6cb77101e1bdb5350a23ed66cc1d3c9b5e74b938"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_atlas_fill_local.py
+++ b/tests/test_atlas_fill_local.py
@@ -5,14 +5,16 @@ import os
 import socket
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 from scripts.atlas import atlas_db, fill_local
+from scripts.atlas import measure_fill_enrich_divergence as measure
 from scripts.lexicon import enrich_manifest
 
 
-def _build_atlas_db(tmp_path: Path) -> Path:
-    manifest = {
-        "entries": [
+def _build_atlas_db(tmp_path: Path, entries: list[dict[str, Any]] | None = None) -> Path:
+    if entries is None:
+        entries = [
             {
                 "lemma": "прапор",
                 "url_slug": "прапор",
@@ -41,7 +43,7 @@ def _build_atlas_db(tmp_path: Path) -> Path:
                 "primary_source": "fixture",
             },
         ]
-    }
+    manifest = {"entries": entries}
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(manifest, ensure_ascii=False), encoding="utf-8")
     db_path = tmp_path / "atlas.db"
@@ -72,7 +74,7 @@ def test_section_mapping_writes_local_rows_and_honest_uncovered(tmp_path, monkey
     db_path = _build_atlas_db(tmp_path)
     sources_db_path = _empty_sources_db(tmp_path)
 
-    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags):
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags, **_kwargs):
         if entry["lemma"] == "прапор":
             entry["heritage_status"] = {
                 "classification": "standard",
@@ -118,7 +120,7 @@ def test_idempotent_rerun_skips_existing_sections(tmp_path, monkeypatch):
     db_path = _build_atlas_db(tmp_path)
     sources_db_path = _empty_sources_db(tmp_path)
 
-    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags):
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags, **_kwargs):
         entry["enrichment"] = {"stress": {"form": f"{entry['lemma']}́", "source": "stress fixture"}}
         entry["heritage_status"] = {"classification": "unknown"}
         return True
@@ -140,7 +142,7 @@ def test_refresh_replaces_existing_section_payload(tmp_path, monkeypatch):
     db_path = _build_atlas_db(tmp_path)
     sources_db_path = _empty_sources_db(tmp_path)
 
-    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags):
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags, **_kwargs):
         entry["enrichment"] = {"meaning": {"definitions": ["оновлено"], "source": "refresh fixture"}}
         entry["heritage_status"] = {"classification": "unknown"}
         return True
@@ -172,7 +174,7 @@ def test_phase1_offline_guard_blocks_slovnyk_wikipedia_and_grac_network(tmp_path
     monkeypatch.setattr(enrich_manifest, "_WIKI_REFERENCE_CACHE_DIRTY", False)
     enrich_manifest.query_wikipedia.cache_clear()
 
-    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags):
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags, **_kwargs):
         assert enrich_manifest._fetch_slovnyk_entry("немає", "немає", "vts") is None
         assert enrich_manifest._cached_wikipedia_summary("Тестова стаття без кешу") is None
         assert enrich_manifest._fetch_grac_frequency_batch(["немає"]) == {"немає": None}
@@ -184,3 +186,138 @@ def test_phase1_offline_guard_blocks_slovnyk_wikipedia_and_grac_network(tmp_path
 
     fill_local.fill_local(db_path, sources_db_path, tmp_path / "missing-kaikki.json", slug="бігти")
     assert os.environ["LEXICON_SLOVNYK_OFFLINE"] == "0"
+
+
+def test_fill_local_prepares_cefr_and_passes_closed_pointer_maps(tmp_path, monkeypatch):
+    """#5331: fill_local must prepare CEFR quantiles and pass reciprocal pointer maps."""
+    entries = measure.build_synthetic_entries(20)
+    db_path = _build_atlas_db(tmp_path, entries)
+    sources_db_path = tmp_path / "sources.db"
+    measure.build_synthetic_sources(sources_db_path, entries)
+    grac = measure.build_synthetic_grac(entries, puls_count=10)
+
+    previous_cefr = dict(enrich_manifest._CEFR_ESTIMATE_LEVEL_BY_KEY)
+    previous_grac = enrich_manifest._GRAC_FREQUENCY_CACHE_DATA
+    enrich_manifest._CEFR_ESTIMATE_LEVEL_BY_KEY.clear()
+    enrich_manifest._GRAC_FREQUENCY_CACHE_DATA = dict(grac)
+
+    seen: list[dict[str, Any]] = []
+
+    def fake_enrich_entry(
+        entry,
+        conn,
+        kaikki_lookup,
+        *,
+        has_sum11_flags,
+        pointer_synonym_relations=None,
+        pointer_antonym_relations=None,
+        pointer_homonym_relations=None,
+        pointer_paronym_relations=None,
+    ):
+        lemma = str(entry["lemma"])
+        seen.append(
+            {
+                "lemma": lemma,
+                "cefr": enrich_manifest._cefr(conn, lemma),
+                "syn": list(pointer_synonym_relations or []),
+                "ant": list(pointer_antonym_relations or []),
+            }
+        )
+        entry["heritage_status"] = {"classification": "unknown"}
+        return True
+
+    monkeypatch.setattr(fill_local, "enrich_entry", fake_enrich_entry)
+    monkeypatch.setattr(enrich_manifest, "_vesum_valid_synonym", lambda term: bool(term))
+    monkeypatch.setattr(enrich_manifest, "_vesum_word_analyses", lambda word: ((word, "noun"),))
+
+    try:
+        fill_local.fill_local(db_path, sources_db_path, tmp_path / "missing-kaikki.json")
+    finally:
+        enrich_manifest._CEFR_ESTIMATE_LEVEL_BY_KEY.clear()
+        enrich_manifest._CEFR_ESTIMATE_LEVEL_BY_KEY.update(previous_cefr)
+        enrich_manifest._GRAC_FREQUENCY_CACHE_DATA = previous_grac
+
+    assert len(seen) == 20
+    # Non-PULS lemmas (indices 10+) get estimated CEFR after prepare.
+    estimated = [
+        row
+        for row in seen
+        if row["cefr"] and row["cefr"].get("source") == enrich_manifest._CEFR_ESTIMATED_SOURCE
+    ]
+    assert len(estimated) == 10
+    assert sum(1 for row in seen if row["cefr"]) == 20
+
+    # Antonym pairs are one-way in fixtures; closed maps add reciprocal edges.
+    antonym_rows_with_edges = [row for row in seen if row["ant"]]
+    assert antonym_rows_with_edges
+    reciprocal_ants = [
+        rel
+        for row in seen
+        for rel in row["ant"]
+        if rel.get("direction") == "reciprocal"
+    ]
+    assert reciprocal_ants
+
+    # Synonym pairs are bidirectional; closed maps still pass non-empty lists.
+    synonym_rows_with_edges = [row for row in seen if row["syn"]]
+    assert synonym_rows_with_edges
+
+
+def test_enrich_entry_merges_pointer_synonym_relations(monkeypatch):
+    """#5331: pointer_synonym_relations must land in sections.synonyms."""
+    monkeypatch.setattr(enrich_manifest, "mphdict_synonyms_available", lambda: True)
+    monkeypatch.setattr(
+        enrich_manifest,
+        "_synonyms_mphdict",
+        lambda *args, **kwargs: {"items": ["mphdict-item"], "source": "mphdict"},
+    )
+    monkeypatch.setattr(enrich_manifest, "_antonyms_wiktionary", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_definition_antonym_relations", lambda *args, **kwargs: [])
+    monkeypatch.setattr(enrich_manifest, "_homonym_relations", lambda *args, **kwargs: [])
+    monkeypatch.setattr(enrich_manifest, "_paronym_relations", lambda *args, **kwargs: [])
+    monkeypatch.setattr(enrich_manifest, "_idioms", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+    monkeypatch.setattr(enrich_manifest, "_definition_cards", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        enrich_manifest,
+        "classify_lemma",
+        lambda lemma: {"classification": "standard", "is_russianism": False, "attestations": []},
+    )
+    monkeypatch.setattr(enrich_manifest, "_warning_slovnyk", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_curated_calque", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_reverse_calques", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_kaikki_pronunciation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_stress_display_form", lambda *args, **kwargs: "")
+    monkeypatch.setattr(enrich_manifest, "_kaikki_stress", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_cefr", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_morphology", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_meaning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_etymology", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_literary_attestation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_wiki_reference", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_vesum_valid_synonym", lambda term: bool(term))
+
+    entry = {"lemma": "тестслово", "pos": "noun"}
+    conn = sqlite3.connect(":memory:")
+    assert enrich_manifest.enrich_entry(
+        entry,
+        conn,
+        {},
+        has_sum11_flags=False,
+        pointer_synonym_relations=[
+            {
+                "item": "синонім-вказівник",
+                "source": "СУМ-11",
+                "pattern": "див.",
+                "vein": 1,
+                "direction": "reciprocal",
+            }
+        ],
+        pointer_antonym_relations=[],
+        pointer_homonym_relations=[],
+        pointer_paronym_relations=[],
+    )
+    items = entry["sections"]["synonyms"]["items"]
+    assert "mphdict-item" in items
+    assert "синонім-вказівник" in items

--- a/tests/test_measure_fill_enrich_divergence.py
+++ b/tests/test_measure_fill_enrich_divergence.py
@@ -1,4 +1,4 @@
-"""Fixture-backed measurement of fill_local vs enrich divergence (#5331)."""
+"""Fixture-backed measurement of fill_local vs enrich alignment (#5331)."""
 
 from __future__ import annotations
 
@@ -21,52 +21,59 @@ def cohort(tmp_path: Path) -> dict[str, object]:
     return {"entries": entries, "sources": sources, "grac": grac}
 
 
-def test_measure_reports_cefr_missing_on_fill(cohort: dict[str, object]) -> None:
+def test_fixed_path_reports_zero_cefr_and_relation_delta(cohort: dict[str, object]) -> None:
+    """Post-#5331 fill_local path must match full enrich on the synthetic cohort."""
     result = measure.measure_divergence(
         cohort["entries"],  # type: ignore[arg-type]
         cohort["sources"],  # type: ignore[arg-type]
         cohort["grac"],  # type: ignore[arg-type]
     )
 
+    assert result["schema"] == "fill-enrich-divergence-v2"
     assert result["lemmas_compared"] == 50
-    assert result["cefr"]["fill_present"] == 10  # PULS only after clear
-    assert result["cefr"]["enrich_estimated"] > 0
-    assert result["cefr"]["missing_on_fill_count"] == result["cefr"]["enrich_estimated"]
-    assert result["cefr"]["missing_on_fill_count"] == 40
-    assert result["cefr"]["prepared_estimate_keys"] == 40
+    assert result["cefr"]["fill_present"] == 50
+    assert result["cefr"]["enrich_present"] == 50
+    assert result["cefr"]["enrich_estimated"] == 40
+    assert result["cefr"]["missing_on_fill_count"] == 0
     assert result["cefr"]["level_divergent_count"] == 0
+    assert result["cefr"]["prepared_estimate_keys"] == 40
+
+    for kind in measure.RELATION_KINDS:
+        rel = result["relations"][kind]
+        assert rel["edges_only_on_enrich"] == 0, kind
+        assert rel["edges_only_on_fill"] == 0, kind
+        assert rel["reciprocal_only_on_enrich"] == 0, kind
+        assert rel["fill_local"]["edges"] == rel["enrich"]["edges"], kind
 
 
-def test_measure_reports_reciprocal_relation_delta(cohort: dict[str, object]) -> None:
+def test_legacy_path_still_shows_pre_fix_divergence(cohort: dict[str, object]) -> None:
+    """legacy.* preserves the pre-fix clear-only / forward-only numbers."""
     result = measure.measure_divergence(
         cohort["entries"],  # type: ignore[arg-type]
         cohort["sources"],  # type: ignore[arg-type]
         cohort["grac"],  # type: ignore[arg-type]
     )
 
-    syn = result["relations"]["synonym"]
-    ant = result["relations"]["antonym"]
+    legacy_cefr = result["legacy"]["cefr"]
+    assert legacy_cefr["fill_present"] == 10  # PULS only after clear
+    assert legacy_cefr["missing_on_fill_count"] == 40
+    assert legacy_cefr["enrich_estimated"] == 40
 
-    # Synonym pairs are bidirectional in sum11, so fill already has both directions
-    # as forward edges; by_headword adds explicit direction=reciprocal copies.
+    syn = result["legacy"]["relations"]["synonym"]
+    ant = result["legacy"]["relations"]["antonym"]
     assert syn["enrich"]["edges"] > syn["fill_local"]["edges"]
     assert syn["edges_only_on_enrich"] > 0
     assert syn["reciprocal_only_on_enrich"] > 0
-
-    # Antonym pointers are one-way in fixtures; enrich adds reciprocal edges.
     assert ant["fill_local"]["edges"] > 0
     assert ant["enrich"]["edges"] > ant["fill_local"]["edges"]
     assert ant["reciprocal_only_on_enrich"] == ant["fill_local"]["edges"]
     assert ant["edges_only_on_enrich"] == ant["reciprocal_only_on_enrich"]
 
-    for kind in ("homonym", "paronym"):
-        assert result["relations"][kind]["edges_only_on_enrich"] == 0
-
 
 def test_fill_local_style_matches_enrich_entry_none_pointer_fallback(
     cohort: dict[str, object], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """fill_local-style maps must equal per-lemma extractors enrich_entry uses."""
+    """Legacy per-lemma maps must equal extractors enrich_entry uses when pointer_* is None."""
     entries = cohort["entries"]
     sources = cohort["sources"]
     assert isinstance(entries, list)
@@ -98,12 +105,13 @@ def test_fill_local_style_matches_enrich_entry_none_pointer_fallback(
 def test_run_default_measurement_cli_path_is_deterministic() -> None:
     first = measure.run_default_measurement(50)
     second = measure.run_default_measurement(50)
-    # Drop non-semantic samples if present; full dict should match for hermetic run.
     assert first == second
     assert first["lemmas_compared"] == 50
     text = measure.format_summary(first)
-    assert "missing_on_fill=40" in text
-    assert "relations.antonym" in text
+    assert "missing_on_fill=0" in text
+    assert "relations.antonym(fixed)" in text
+    assert "only_on_enrich=0" in text
+    assert "cefr(legacy) missing_on_fill=40" in text
 
 
 def test_cohort_size_guards() -> None:
@@ -123,4 +131,5 @@ def test_json_roundtrip(tmp_path: Path, cohort: dict[str, object]) -> None:
     path.write_text(json.dumps(result, ensure_ascii=False, sort_keys=True), encoding="utf-8")
     loaded = json.loads(path.read_text(encoding="utf-8"))
     assert loaded["issue"] == 5331
-    assert loaded["cefr"]["missing_on_fill_count"] == 40
+    assert loaded["cefr"]["missing_on_fill_count"] == 0
+    assert loaded["legacy"]["cefr"]["missing_on_fill_count"] == 40


### PR DESCRIPTION
## Summary

Closes the live divergence between `fill_local` and full `enrich()` / `worker_enrich` tracked in #5331 (measurement in #5495).

**Measured pre-fix (synthetic n=50):** CEFR `missing_on_fill=40`; synonym `only_on_enrich=26` (all reciprocal); antonym `only_on_enrich=7`.

### Load-bearing fixes

1. **`fill_local._fill_local`** — after building the fill cohort, call `_prepare_cefr_estimates(sources_conn, cohort_manifest)` instead of bare `_CEFR_ESTIMATE_LEVEL_BY_KEY.clear()`.
2. **Pointer maps** — precompute closed `_*_relations_by_headword` over the fill cohort and pass `pointer_{synonym,antonym,homonym,paronym}_relations` into each `enrich_entry` (mirror `enrich()` / `worker_enrich`).
3. **`enrich_entry`** — wire `pointer_synonym_relations` through `_merge_synonym_relations` (kwarg was accepted but unused; mphdict-only path). When the kwarg is `None`, fall back to the per-lemma forward extractor (same contract as antonyms).

### Residual (documented)

Single-slug fills only close relations **within the fill cohort** (that slug set). Full-atlas reciprocity still wants a full-cohort or #5230 sealed relation map.

## Measurement (post-fix, n=50)

```
cefr(fixed) missing_on_fill=0 fill_present=50 enrich_present=50 enrich_estimated=40
relations.synonym(fixed) only_on_enrich=0
relations.antonym(fixed) only_on_enrich=0
cefr(legacy) missing_on_fill=40  # preserved for regression notes
relations.synonym(legacy) only_on_enrich=26
```

## Tests

- `tests/test_measure_fill_enrich_divergence.py` — fixed path zero delta; legacy path still shows pre-fix gap
- `tests/test_atlas_fill_local.py` — CEFR prepare + closed pointer kwargs on synthetic cohort; `enrich_entry` merges synonym pointers

## Refs

Refs #5331 #5230