### PR TITLE
feat(harness): Grok session canary (8/10 rot gate) + compact policy

### DIFF
--- a/docs/runbooks/grok-session-canary.md
+++ b/docs/runbooks/grok-session-canary.md
@@ -1,0 +1,74 @@
+# Grok session canary + auto-compact policy
+
+## Problem
+
+Grok auto-compacts at **85%** of the model context window by default (~**400k** tokens on large Grok coding windows). Compact is **lossy for working memory**. Disk session logs and stream dual-writes survive; the model’s live context is summarized.
+
+Ending a session *only because compact fired* is too early if recall is still sharp. Ending *only after* compact when dual-write is stale is too late. **Measured rot** is the end signal.
+
+## Policy
+
+| Signal | Meaning |
+| --- | --- |
+| Auto-compact | **Re-score** canary; keep driving only if PASS |
+| Canary **&lt; 8/10** (`pass-ratio` 0.8) | **FAIL-HANDOFF** → dual-write STATE AT HANDBACK, close stream, `/quit` |
+| Compact count / “compactions remaining” | **Not** an end criterion |
+| First compact | **Not** required before you may end; **not** a reason to delay a clean end |
+
+Production **thread rollover** still uses strict **10/10** via `scripts/context_canary.py mint --snapshot` (separate protocol).
+
+## Operator config (recommended)
+
+In `~/.grok/config.toml`:
+
+```toml
+[session]
+auto_compact_threshold_percent = 95
+```
+
+Default `85` leaves little runway for a deliberate close after the banner.
+
+## CLI
+
+```bash
+# Cold-start (after stream open + handoff load)
+.venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas --stream epic:4387
+.venv/bin/python -m scripts.session_canary.grok_lane questions --epic atlas
+
+# Mid-session / post-compact (answers FROM MEMORY — do not re-open probe.json)
+# Write .claude/atlas-epic/canary/answers.json as {"anchor-id": "your recall", ...}
+.venv/bin/python -m scripts.session_canary.grok_lane score \
+  --epic atlas \
+  --answers .claude/atlas-epic/canary/answers.json \
+  --context-tokens 250000 \
+  --model grok-4.5
+
+.venv/bin/python -m scripts.session_canary.grok_lane status --epic atlas
+.venv/bin/python -m scripts.session_canary.grok_lane protocol --epic atlas
+```
+
+Artifacts live under gitignored `.claude/<epic>-epic/canary/`.
+
+## Lifecycle
+
+```
+START  → open stream lease → dual-write handoff → mint canary
+DRIVE  → dual-write after each batch
+         at ~60–70% context OR after auto-compact → score from memory
+         FAIL → STATE AT HANDBACK + close stream + quit
+END    → optional clean close while canary still PASS (before forced compact if possible)
+```
+
+## SSOT
+
+| Store | Role |
+| --- | --- |
+| Session stream (`epic:N`) | Primary typed continuity |
+| INTERIM / CLAUDE driver handoff | Dual-write board |
+| Canary probe | Rot measurement only (not the board) |
+
+## Related
+
+- `scripts/context_canary.py` — shared mint/score engine
+- `docs/best-practices/codex-thread-handoff.md` — strict rollover canary
+- `start-grok.sh --epic <name>` — cold-start injects lane protocol pointer

--- a/scripts/session_canary/__init__.py
+++ b/scripts/session_canary/__init__.py
@@ -1,0 +1,10 @@
+"""Lane session canaries for long interactive sessions (Grok/Codex/Claude).
+
+Operational mid-session rot check reuses ``scripts.context_canary`` legacy
+scoring (pass-ratio, default 0.8 = 8/10). Production rollover still uses
+strict 10/10 snapshot mint via ``context_canary.py mint --snapshot``.
+"""
+
+__all__ = ["__version__"]
+
+__version__ = "1.0.0"

--- a/scripts/session_canary/__main__.py
+++ b/scripts/session_canary/__main__.py
@@ -1,0 +1,10 @@
+"""python -m scripts.session_canary → grok_lane CLI (default)."""
+
+from __future__ import annotations
+
+import sys
+
+from scripts.session_canary.grok_lane import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/session_canary/grok_lane.py
+++ b/scripts/session_canary/grok_lane.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""Grok epic-lane session canary — mint / questions / score / protocol.
+
+Purpose
+-------
+Auto-compact compresses **working context** (lossy for nuance). Disk logs and
+session-stream dual-writes survive; the model brain does not. This CLI freezes
+durable anchors at cold-start and scores recall later so we **end the session
+on measured rot**, not on compact count or a guessed token budget.
+
+Policy (operational, not production-rollover)
+---------------------------------------------
+- Mint **10** anchors from stream + handoff dual-write only (no git/PR scrape).
+- Score with legacy ``context_canary``: ``--pass-ratio`` default **0.8** (8/10).
+- FAIL-HANDOFF (rc 2) ⇒ write STATE AT HANDBACK, close stream lease, ``/quit``.
+- First auto-compact is a **re-score trigger**, not an end signal by itself.
+- Production identity rollover remains ``context_canary mint --snapshot`` (strict 10/10).
+
+Paths (gitignored local; under ``.claude/<epic>-epic/canary/``)
+---------------------------------------------------------------
+  probe.json       frozen ground truth (do not show answers to the scorer turn)
+  questions.json   id → question only (agent answers from memory)
+  answers.json     agent-written answers for score
+  log.csv          (context_tokens, score) time series
+  last_verdict.json  latest machine verdict
+
+Usage
+-----
+  .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas
+  .venv/bin/python -m scripts.session_canary.grok_lane questions
+  .venv/bin/python -m scripts.session_canary.grok_lane score \\
+      --answers .claude/atlas-epic/canary/answers.json \\
+      --context-tokens 250000 --model grok-4.5
+  .venv/bin/python -m scripts.session_canary.grok_lane protocol --epic atlas
+  .venv/bin/python -m scripts.session_canary.grok_lane status --epic atlas
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Epic slug → default stream id (aligned with start-grok.sh)
+EPIC_STREAM_DEFAULTS: dict[str, str] = {
+    "atlas": "epic:4387",
+    "practice": "epic:4387",
+    "practice-hub": "epic:4387",
+    "harness": "epic:4707",
+    "infra": "epic:4707",
+    "hramatka": "epic:4542",
+    "folk": "epic:2836",
+    "seminars-folk": "epic:2836",
+    "bio": "epic:4431",
+    "seminars-bio": "epic:4431",
+}
+
+DEFAULT_PASS_RATIO = 0.8
+DEFAULT_SIM_THRESHOLD = 0.75
+N_ANCHORS = 10
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _canary_dir(repo: Path, epic: str) -> Path:
+    return repo / ".claude" / f"{epic}-epic" / "canary"
+
+
+def _handoff_candidates(repo: Path, epic: str) -> list[Path]:
+    base = repo / ".claude" / f"{epic}-epic"
+    return [
+        base / "INTERIM-DRIVER-HANDOFF.md",
+        base / "CLAUDE-DRIVER-HANDOFF.md",
+        base / "CODEX-DRIVER-HANDOFF.md",
+    ]
+
+
+def _read_text(path: Path, limit: int = 120_000) -> str:
+    if not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")[:limit]
+
+
+def _clip(text: str, max_len: int = 220) -> str:
+    text = " ".join(text.split())
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1].rstrip() + "…"
+
+
+def _load_stream_entries(stream_id: str, *, limit: int = 40) -> list[dict[str, str]]:
+    """Return [{type, body}, ...] from session stream; empty if store unavailable."""
+    try:
+        from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+        from agents_extensions.shared.session_streams.store import SessionStreamStore
+
+        store = SessionStreamStore(SessionStreamDatabase())
+        digest = store.load_digest(stream_id, limit=limit)
+        out: list[dict[str, str]] = []
+        for entry in list(digest.pinned) + list(digest.recent):
+            body = (entry.body or "").strip()
+            if not body:
+                continue
+            out.append(
+                {
+                    "type": getattr(entry.type, "value", str(entry.type)),
+                    "body": body,
+                }
+            )
+        return out
+    except Exception as exc:
+        # Fail-open to handoff-only mint when stream DB is missing/unreadable.
+        print(f"warning: session stream unavailable ({type(exc).__name__}: {exc})", file=sys.stderr)
+        return []
+
+
+def _extract_handoff_bullets(md: str, *, heading_substrings: tuple[str, ...], limit: int = 12) -> list[str]:
+    """Pull bullet lines under headings whose title contains any substring (case-insensitive)."""
+    if not md:
+        return []
+    lines = md.splitlines()
+    bullets: list[str] = []
+    active = False
+    for line in lines:
+        if re.match(r"^#{1,4}\s+", line):
+            title = re.sub(r"^#{1,4}\s+", "", line).strip().lower()
+            active = any(s in title for s in heading_substrings)
+            continue
+        if not active:
+            continue
+        m = re.match(r"^\s*[-*]\s+(.+)$", line) or re.match(r"^\s*\d+\.\s+(.+)$", line)
+        if m:
+            item = m.group(1).strip()
+            # strip markdown bold/links lightly
+            item = re.sub(r"\*\*([^*]+)\*\*", r"\1", item)
+            item = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", item)
+            if item:
+                bullets.append(item)
+            if len(bullets) >= limit:
+                break
+    return bullets
+
+
+def _build_facts(
+    *,
+    epic: str,
+    stream_id: str,
+    stream_entries: list[dict[str, str]],
+    handoff_text: str,
+    handoff_rel: str,
+) -> list[dict[str, str]]:
+    """Build exactly 10 unique {id,q,a} facts from durable sources only."""
+    facts: list[dict[str, str]] = []
+    used_answers: set[str] = set()
+
+    def add(fid: str, q: str, a: str) -> None:
+        a_norm = _clip(a, 280)
+        if not a_norm or a_norm in used_answers:
+            return
+        if any(f["id"] == fid for f in facts):
+            return
+        used_answers.add(a_norm)
+        facts.append({"id": fid, "q": q, "a": a_norm})
+
+    # 1) Session identity (always)
+    add(
+        "lane-stream",
+        "What session stream id is this Grok lane driving?",
+        stream_id,
+    )
+    add(
+        "lane-epic",
+        "What epic slug is this Grok lane bound to?",
+        epic,
+    )
+
+    # 2) Pinned binding orders from stream
+    pinned_orders = [e for e in stream_entries if e["type"] == "binding_order"]
+    for i, entry in enumerate(pinned_orders[:4], start=1):
+        add(
+            f"bind-{i}",
+            f"What is binding order #{i} for this lane (plain paraphrase of the frozen stream pin)?",
+            entry["body"],
+        )
+
+    # 3) Negative constraints from stream
+    negs = [e for e in stream_entries if e["type"] == "negative_constraint"]
+    for i, entry in enumerate(negs[:2], start=1):
+        add(
+            f"neg-{i}",
+            f"What is negative constraint #{i} pinned on this stream?",
+            entry["body"],
+        )
+
+    # 4) Next actions from stream (prefer typed next_action)
+    nexts = [e for e in stream_entries if e["type"] == "next_action"]
+    for i, entry in enumerate(nexts[:3], start=1):
+        add(
+            f"next-stream-{i}",
+            f"What next-action entry #{i} was recorded on the stream?",
+            entry["body"],
+        )
+
+    # 5) Handoff dual-write: next drive / in-flight / hands-off
+    next_bullets = _extract_handoff_bullets(
+        handoff_text,
+        heading_substrings=("next drive", "next after", "next action", "in flight", "live session"),
+    )
+    for i, bullet in enumerate(next_bullets[:3], start=1):
+        add(
+            f"next-handoff-{i}",
+            f"According to the dual-write handoff ({handoff_rel}), what is next-item #{i}?",
+            bullet,
+        )
+
+    hands_off = _extract_handoff_bullets(
+        handoff_text,
+        heading_substrings=("hands-off", "handsoff", "do not", "out of scope"),
+    )
+    for i, bullet in enumerate(hands_off[:2], start=1):
+        add(
+            f"handsoff-{i}",
+            f"According to the dual-write handoff, what is hands-off rule #{i}?",
+            bullet,
+        )
+
+    # 6) Recent durable decisions from stream if still short
+    decisions = [e for e in stream_entries if e["type"] == "decision"]
+    for i, entry in enumerate(decisions[:3], start=1):
+        if len(facts) >= N_ANCHORS:
+            break
+        add(
+            f"decision-{i}",
+            f"What decision #{i} was recorded on the stream?",
+            entry["body"],
+        )
+
+    # 7) Recent state if still short (still dual-written stream entries — durable)
+    states = [e for e in stream_entries if e["type"] == "state"]
+    for i, entry in enumerate(reversed(states[-6:]), start=1):
+        if len(facts) >= N_ANCHORS:
+            break
+        add(
+            f"state-{i}",
+            f"What recent state note #{i} is on the stream (paraphrase the frozen text)?",
+            entry["body"],
+        )
+
+    if len(facts) < N_ANCHORS:
+        raise SystemExit(
+            f"error: could only derive {len(facts)}/{N_ANCHORS} durable anchors; "
+            "open a stream session and dual-write handoff next/hands-off sections, then re-mint"
+        )
+
+    # Exactly 10 — prefer earliest (highest-trust: identity + pins)
+    return facts[:N_ANCHORS]
+
+
+def cmd_mint(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    epic = args.epic.strip().lower()
+    stream_id = (args.stream or EPIC_STREAM_DEFAULTS.get(epic) or "").strip()
+    if not stream_id:
+        print(
+            f"error: no stream for epic {epic!r}; pass --stream epic:N",
+            file=sys.stderr,
+        )
+        return 1
+
+    handoff_path: Path | None = None
+    if args.handoff:
+        handoff_path = Path(args.handoff)
+        if not handoff_path.is_absolute():
+            handoff_path = repo / handoff_path
+    else:
+        for cand in _handoff_candidates(repo, epic):
+            if cand.is_file():
+                handoff_path = cand
+                break
+
+    handoff_text = _read_text(handoff_path) if handoff_path else ""
+    handoff_rel = (
+        str(handoff_path.relative_to(repo)) if handoff_path and handoff_path.is_relative_to(repo) else str(handoff_path or "")
+    )
+
+    stream_entries = _load_stream_entries(stream_id, limit=int(args.stream_limit))
+    try:
+        facts = _build_facts(
+            epic=epic,
+            stream_id=stream_id,
+            stream_entries=stream_entries,
+            handoff_text=handoff_text,
+            handoff_rel=handoff_rel or f".claude/{epic}-epic/",
+        )
+    except SystemExit as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    out_dir = Path(args.out_dir) if args.out_dir else _canary_dir(repo, epic)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    facts_path = out_dir / "facts.json"
+    probe_path = out_dir / "probe.json"
+    meta_path = out_dir / "mint_meta.json"
+
+    facts_path.write_text(json.dumps(facts, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    # Delegate freeze to context_canary (legacy path) so scoring stays shared.
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "scripts" / "context_canary.py"),
+            "mint",
+            "--facts",
+            str(facts_path),
+            "--out",
+            str(probe_path),
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        print(proc.stdout, end="")
+        print(proc.stderr, end="", file=sys.stderr)
+        return proc.returncode or 1
+    print(proc.stdout, end="")
+
+    meta = {
+        "minted_at": _utc_now(),
+        "epic": epic,
+        "stream_id": stream_id,
+        "handoff": handoff_rel,
+        "n_anchors": len(facts),
+        "pass_ratio_default": DEFAULT_PASS_RATIO,
+        "policy": "operational-8/10-legacy-facts-from-stream+handoff",
+        "probe": str(probe_path.relative_to(repo)) if probe_path.is_relative_to(repo) else str(probe_path),
+        "ids": [f["id"] for f in facts],
+    }
+    meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    # Always refresh questions view (no answers)
+    q_path = out_dir / "questions.json"
+    questions = {f["id"]: f["q"] for f in facts}
+    q_path.write_text(json.dumps(questions, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    print(f"canary dir: {out_dir}")
+    print(f"questions:  {q_path}")
+    print(f"policy: operational pass-ratio {DEFAULT_PASS_RATIO} (8/10); re-score after compact")
+    return 0
+
+
+def cmd_questions(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    epic = args.epic.strip().lower()
+    out_dir = Path(args.out_dir) if args.out_dir else _canary_dir(repo, epic)
+    probe_path = out_dir / "probe.json"
+    if not probe_path.is_file():
+        print(f"error: missing probe {probe_path}; run mint first", file=sys.stderr)
+        return 1
+    probe = json.loads(probe_path.read_text(encoding="utf-8"))
+    anchors = probe.get("anchors") or []
+    questions = {a["id"]: a["q"] for a in anchors if a.get("id") and a.get("q")}
+    out = Path(args.out) if args.out else out_dir / "questions.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(questions, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    # Also print a human checklist
+    for i, (aid, q) in enumerate(questions.items(), start=1):
+        print(f"{i:2d}. [{aid}] {q}")
+    print(f"wrote {out}")
+    return 0
+
+
+def cmd_score(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    epic = args.epic.strip().lower()
+    out_dir = Path(args.out_dir) if args.out_dir else _canary_dir(repo, epic)
+    probe_path = out_dir / "probe.json"
+    if not probe_path.is_file():
+        print(f"error: missing probe {probe_path}; run mint first", file=sys.stderr)
+        return 1
+
+    answers_path = Path(args.answers)
+    if not answers_path.is_absolute():
+        answers_path = repo / answers_path
+    if not answers_path.is_file():
+        print(f"error: answers file not found: {answers_path}", file=sys.stderr)
+        return 1
+
+    log_path = out_dir / "log.csv"
+    verdict_path = out_dir / "last_verdict.json"
+    pass_ratio = float(args.pass_ratio)
+    threshold = float(args.threshold)
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "scripts" / "context_canary.py"),
+            "score",
+            "--probe",
+            str(probe_path),
+            "--answers",
+            str(answers_path),
+            "--pass-ratio",
+            str(pass_ratio),
+            "--threshold",
+            str(threshold),
+            "--context-tokens",
+            str(int(args.context_tokens)),
+            "--model",
+            args.model,
+            "--log",
+            str(log_path),
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
+
+    # Parse SCORE line for machine verdict file
+    score_line = ""
+    for line in (proc.stdout or "").splitlines():
+        if line.startswith("SCORE "):
+            score_line = line
+    verdict = "PASS" if proc.returncode == 0 else "FAIL-HANDOFF"
+    payload = {
+        "scored_at": _utc_now(),
+        "epic": epic,
+        "verdict": verdict,
+        "pass_ratio": pass_ratio,
+        "context_tokens": int(args.context_tokens),
+        "model": args.model,
+        "score_line": score_line,
+        "rc": proc.returncode,
+        "policy": "operational-end-on-fail-handoff-not-on-compact-count",
+        "action_if_fail": [
+            "Append STATE AT HANDBACK to dual-write handoff",
+            "session_streams close / force-close expired then stop",
+            "Do NOT keep driving after FAIL-HANDOFF",
+            "/quit and start a new Grok session with --epic",
+        ],
+    }
+    verdict_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"verdict -> {verdict_path}")
+    if verdict == "FAIL-HANDOFF":
+        print("ACTION: FAIL-HANDOFF — dual-write STATE AT HANDBACK, close stream, end session now.")
+    return 0 if proc.returncode == 0 else (2 if proc.returncode == 2 else proc.returncode)
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    epic = args.epic.strip().lower()
+    out_dir = Path(args.out_dir) if args.out_dir else _canary_dir(repo, epic)
+    print(f"canary_dir: {out_dir}")
+    for name in ("probe.json", "questions.json", "mint_meta.json", "last_verdict.json", "log.csv"):
+        p = out_dir / name
+        print(f"  {'OK ' if p.is_file() else '—  '} {name}")
+    meta = out_dir / "mint_meta.json"
+    if meta.is_file():
+        print("mint_meta:", meta.read_text(encoding="utf-8").strip())
+    verdict = out_dir / "last_verdict.json"
+    if verdict.is_file():
+        print("last_verdict:", verdict.read_text(encoding="utf-8").strip())
+    return 0
+
+
+def cmd_protocol(args: argparse.Namespace) -> int:
+    """Print the agent-facing protocol (paste into cold-start / after compact)."""
+    epic = args.epic.strip().lower()
+    stream = args.stream or EPIC_STREAM_DEFAULTS.get(epic, "epic:N")
+    canary = f".claude/{epic}-epic/canary"
+    text = f"""## Grok lane session canary (operational)
+
+You are bound to epic **{epic}** / stream **{stream}**.
+
+### SSOT (survives compact)
+- Session stream dual-write (typed entries)
+- `{canary.replace('canary', 'INTERIM-DRIVER-HANDOFF.md')}` or CLAUDE-DRIVER-HANDOFF.md (read-only if not interim)
+
+### End signal = canary score, NOT compact count
+- Auto-compact is lossy for working memory. Disk logs ≠ model brain.
+- **First auto-compact ⇒ re-score**, do not auto-quit solely because compact fired.
+- **FAIL-HANDOFF (&lt; 8/10 at pass-ratio 0.8) ⇒ end now** regardless of token %.
+
+### Cold-start (after stream open + handoff load)
+```bash
+.venv/bin/python -m scripts.session_canary.grok_lane mint --epic {epic} --stream {stream}
+.venv/bin/python -m scripts.session_canary.grok_lane questions --epic {epic}
+```
+Do not open `probe.json` when later scoring from memory.
+
+### When to score
+1. After **any** auto-compact notification
+2. Around **60–70%** context (`/session-info` or `/context`)
+3. After a big merge/gate wave if still long-running
+
+### Score procedure (from memory — no re-read of probe answers)
+1. `.venv/bin/python -m scripts.session_canary.grok_lane questions --epic {epic}`
+2. Write answers **from memory only** to `{canary}/answers.json` as `{{"id": "answer", ...}}`
+3. Run:
+```bash
+.venv/bin/python -m scripts.session_canary.grok_lane score \\
+  --epic {epic} \\
+  --answers {canary}/answers.json \\
+  --context-tokens <N> --model grok-4.5
+```
+4. rc 0 = PASS (continue). rc 2 = FAIL-HANDOFF → dual-write STATE AT HANDBACK, close stream, `/quit`.
+
+### Operator compact config (optional)
+In `~/.grok/config.toml`:
+```toml
+[session]
+auto_compact_threshold_percent = 95
+```
+Default is 85% (~400k on large Grok windows). Higher leaves runway for a deliberate close.
+
+### Production rollover (different tool)
+Strict 10/10 identity rollover still uses:
+`scripts/context_canary.py mint --snapshot …` + score — not this operational lane canary.
+"""
+    print(text)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m scripts.session_canary.grok_lane",
+        description="Operational Grok epic-lane session canary (8/10 rot gate).",
+    )
+    p.add_argument("--repo", type=Path, default=ROOT, help="Repository root")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    mint = sub.add_parser("mint", help="Freeze 10 durable anchors from stream + handoff")
+    mint.add_argument("--epic", required=True, help="Epic slug (atlas, harness, …)")
+    mint.add_argument("--stream", default=None, help="Stream id (default from epic map)")
+    mint.add_argument("--handoff", default=None, help="Override dual-write handoff path")
+    mint.add_argument("--out-dir", default=None, help="Canary directory override")
+    mint.add_argument("--stream-limit", type=int, default=40)
+    mint.set_defaults(func=cmd_mint)
+
+    questions = sub.add_parser("questions", help="Print/write id→question map (no answers)")
+    questions.add_argument("--epic", default="atlas")
+    questions.add_argument("--out-dir", default=None)
+    questions.add_argument("--out", default=None, help="Questions JSON path")
+    questions.set_defaults(func=cmd_questions)
+
+    score = sub.add_parser("score", help="Score answers vs probe (rc 2 = FAIL-HANDOFF)")
+    score.add_argument("--epic", default="atlas")
+    score.add_argument("--out-dir", default=None)
+    score.add_argument("--answers", required=True, help="JSON map id→answer from memory")
+    score.add_argument("--context-tokens", type=int, default=0)
+    score.add_argument("--model", default="grok-4.5")
+    score.add_argument("--pass-ratio", type=float, default=DEFAULT_PASS_RATIO, help="Default 0.8 (8/10)")
+    score.add_argument("--threshold", type=float, default=DEFAULT_SIM_THRESHOLD, help="Per-anchor sim threshold")
+    score.set_defaults(func=cmd_score)
+
+    status = sub.add_parser("status", help="Show canary artifact presence + last verdict")
+    status.add_argument("--epic", default="atlas")
+    status.add_argument("--out-dir", default=None)
+    status.set_defaults(func=cmd_status)
+
+    protocol = sub.add_parser("protocol", help="Print agent-facing lifecycle protocol")
+    protocol.add_argument("--epic", default="atlas")
+    protocol.add_argument("--stream", default=None)
+    protocol.set_defaults(func=cmd_protocol)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/session_canary/grok_lane.py
+++ b/scripts/session_canary/grok_lane.py
@@ -42,7 +42,6 @@ import json
 import re
 import subprocess
 import sys
-import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -267,17 +267,22 @@ if [ -n "${SESSION_EPIC:-}" ]; then
       echo "  Stream SSOT: epic:4387  (session_streams tail --stream epic:4387)"
       echo "  File dual-write: .claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md (or CLAUDE-DRIVER-HANDOFF.md read-only)"
       echo "  TAKEOVER: .claude/atlas-epic/TAKEOVER-PROMPT.md"
+      echo "  Canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas"
+      echo "          docs/runbooks/grok-session-canary.md  (end on <8/10, not on compact count)"
       ;;
     harness|infra)
       echo "  Stream: ${SESSION_STREAM_ID:-epic:4707}"
       echo "  Infra handoff: docs/session-state/ + .agent/claude-infra-thread-handoff.md (read; write your own grok slot)"
+      echo "  Canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic harness"
       ;;
     *)
       echo "  Open stream if known: SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}"
       echo "  Epic dir (if any): .claude/${SESSION_EPIC}-epic/"
+      echo "  Canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic ${SESSION_EPIC}"
       ;;
   esac
   echo "  Primary checkout is READ-ONLY for writes → worktrees via scripts/delegate.py"
+  echo "  Session canary protocol: docs/runbooks/grok-session-canary.md"
   echo ""
 fi
 
@@ -316,16 +321,16 @@ done
 if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
   case "${SESSION_EPIC}" in
     atlas|practice|practice-hub)
-      _cold_prompt="You are the interim ATLAS lane driver (stream epic:4387). Immediately read and execute .claude/atlas-epic/TAKEOVER-PROMPT.md: tail the session stream, open or resume your lease, reconcile the board against gh/git/worktrees/task files, update INTERIM-DRIVER-HANDOFF.md as dual-write, and drive the next unblocked action without asking for a menu. Primary checkout is read-only — all writes via worktrees."
+      _cold_prompt="You are the interim ATLAS lane driver (stream epic:4387). Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, open/resume lease, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md; (2) mint the session canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas --stream epic:4387 (see docs/runbooks/grok-session-canary.md). Drive the next unblocked action without a menu. End session on canary FAIL-HANDOFF (<8/10), not on compact count; after any auto-compact re-score from memory. Primary checkout is read-only — writes via worktrees."
       ;;
     harness|infra)
-      _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). Cold-start from the infra handoff and stream tail; reconcile in-flight work; drive the next unblocked infra action. Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). Cold-start from the infra handoff and stream tail; mint canary (.venv/bin/python -m scripts.session_canary.grok_lane mint --epic harness); reconcile in-flight work; drive the next unblocked infra action. End on canary FAIL-HANDOFF not compact count (docs/runbooks/grok-session-canary.md). Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."
       ;;
     hramatka)
-      _cold_prompt="You are the hramatka lane driver (stream ${SESSION_STREAM_ID:-epic:4542}). Cold-start from the epic handoff and stream if present; reconcile and drive the next unblocked action. Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the hramatka lane driver (stream ${SESSION_STREAM_ID:-epic:4542}). Cold-start from the epic handoff and stream if present; mint canary (.venv/bin/python -m scripts.session_canary.grok_lane mint --epic hramatka); reconcile and drive the next unblocked action. End on canary FAIL-HANDOFF (docs/runbooks/grok-session-canary.md). Primary checkout is read-only — writes via worktrees."
       ;;
     *)
-      _cold_prompt="You are the ${SESSION_EPIC} lane driver (SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}). You are NOT the main orchestrator. Cold-start: load the epic handoff under .claude/${SESSION_EPIC}-epic/ (or stream tail if SESSION_STREAM_ID is set), reconcile reality, and drive the next unblocked action without a menu. Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the ${SESSION_EPIC} lane driver (SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}). You are NOT the main orchestrator. Cold-start: load the epic handoff under .claude/${SESSION_EPIC}-epic/ (or stream tail if SESSION_STREAM_ID is set), mint canary via .venv/bin/python -m scripts.session_canary.grok_lane mint --epic ${SESSION_EPIC}, reconcile reality, and drive the next unblocked action without a menu. End on canary FAIL-HANDOFF not compact count (docs/runbooks/grok-session-canary.md). Primary checkout is read-only — writes via worktrees."
       ;;
   esac
   echo "Cold-start: injecting epic auto-continue prompt (no user PROMPT given)."

--- a/tests/test_grok_lane_session_canary.py
+++ b/tests/test_grok_lane_session_canary.py
@@ -1,0 +1,187 @@
+"""Operational Grok lane session canary (mint / score via context_canary)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.session_canary import grok_lane as gl
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def _py() -> str:
+    venv = _REPO / ".venv" / "bin" / "python"
+    return str(venv) if venv.is_file() else sys.executable
+
+
+def test_build_facts_exactly_ten_from_stream_and_handoff() -> None:
+    stream = [
+        {"type": "binding_order", "body": f"Binding order number {i} about quality and no shortcuts."}
+        for i in range(1, 5)
+    ]
+    stream += [
+        {"type": "negative_constraint", "body": "Never commit directly to main."},
+        {"type": "negative_constraint", "body": "Never merge drafts."},
+        {"type": "next_action", "body": "Merge offline enrich when CI green."},
+        {"type": "next_action", "body": "Run VPS launch_enrich after merge."},
+        {"type": "decision", "body": "Sol is the designer for practice setup."},
+        {"type": "state", "body": "PR 5496 waiting on pytest."},
+    ]
+    handoff = """
+# Handoff
+## Next drive order
+1. Ship start-grok canary mint at cold-start
+2. Score after auto-compact
+3. End on FAIL-HANDOFF only
+## Hands-off
+- Other lanes' queues
+- Primary checkout writes for product code
+"""
+    facts = gl._build_facts(
+        epic="atlas",
+        stream_id="epic:4387",
+        stream_entries=stream,
+        handoff_text=handoff,
+        handoff_rel=".claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md",
+    )
+    assert len(facts) == 10
+    ids = [f["id"] for f in facts]
+    assert len(set(ids)) == 10
+    assert "lane-stream" in ids
+    assert facts[0]["a"] == "epic:4387"
+    assert all(f["q"] and f["a"] for f in facts)
+
+
+def test_build_facts_fails_when_insufficient(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="could only derive"):
+        gl._build_facts(
+            epic="atlas",
+            stream_id="epic:4387",
+            stream_entries=[{"type": "state", "body": "only one"}],
+            handoff_text="",
+            handoff_rel="",
+        )
+
+
+def test_mint_score_roundtrip_pass_and_fail(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Avoid depending on live session DB
+    monkeypatch.setattr(gl, "_load_stream_entries", lambda *a, **k: [
+        {"type": "binding_order", "body": f"Pinned binding order text {i} with enough content."}
+        for i in range(1, 6)
+    ] + [
+        {"type": "negative_constraint", "body": "Do not lower quality gates."},
+        {"type": "negative_constraint", "body": "Do not bypass CI."},
+        {"type": "next_action", "body": "Dual-write handoff after each batch."},
+        {"type": "next_action", "body": "Re-score canary after auto-compact."},
+        {"type": "decision", "body": "Canary end signal is score not compact count."},
+    ])
+
+    canary_dir = tmp_path / "canary"
+    handoff = tmp_path / "handoff.md"
+    handoff.write_text(
+        "## Next drive order\n- Keep dual-write current\n- Score canary after compact\n"
+        "## Hands-off\n- Foreign lanes\n",
+        encoding="utf-8",
+    )
+
+    rc = gl.main(
+        [
+            "--repo",
+            str(_REPO),
+            "mint",
+            "--epic",
+            "atlas",
+            "--stream",
+            "epic:4387",
+            "--handoff",
+            str(handoff),
+            "--out-dir",
+            str(canary_dir),
+        ]
+    )
+    assert rc == 0
+    probe = json.loads((canary_dir / "probe.json").read_text(encoding="utf-8"))
+    anchors = probe["anchors"]
+    assert len(anchors) == 10
+
+    # Perfect recall
+    answers = {a["id"]: a["a"] for a in anchors}
+    answers_path = canary_dir / "answers-ok.json"
+    answers_path.write_text(json.dumps(answers), encoding="utf-8")
+    rc = gl.main(
+        [
+            "--repo",
+            str(_REPO),
+            "score",
+            "--epic",
+            "atlas",
+            "--out-dir",
+            str(canary_dir),
+            "--answers",
+            str(answers_path),
+            "--context-tokens",
+            "100000",
+            "--model",
+            "test-model",
+            "--pass-ratio",
+            "0.8",
+        ]
+    )
+    assert rc == 0
+    verdict = json.loads((canary_dir / "last_verdict.json").read_text(encoding="utf-8"))
+    assert verdict["verdict"] == "PASS"
+
+    # Drop 3 answers → 7/10 < 0.8
+    broken = dict(answers)
+    for aid in list(broken)[:3]:
+        broken[aid] = "I forgot this entirely"
+    answers_path2 = canary_dir / "answers-bad.json"
+    answers_path2.write_text(json.dumps(broken), encoding="utf-8")
+    rc = gl.main(
+        [
+            "--repo",
+            str(_REPO),
+            "score",
+            "--epic",
+            "atlas",
+            "--out-dir",
+            str(canary_dir),
+            "--answers",
+            str(answers_path2),
+            "--context-tokens",
+            "300000",
+            "--model",
+            "test-model",
+            "--pass-ratio",
+            "0.8",
+        ]
+    )
+    assert rc == 2
+    verdict2 = json.loads((canary_dir / "last_verdict.json").read_text(encoding="utf-8"))
+    assert verdict2["verdict"] == "FAIL-HANDOFF"
+
+
+def test_protocol_prints_epic(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = gl.main(["protocol", "--epic", "atlas"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "epic:4387" in out
+    assert "0.8" in out or "8/10" in out
+    assert "FAIL-HANDOFF" in out
+
+
+def test_cli_module_help() -> None:
+    proc = subprocess.run(
+        [_py(), "-m", "scripts.session_canary.grok_lane", "--help"],
+        cwd=_REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "mint" in proc.stdout


### PR DESCRIPTION
## Summary

Long Grok sessions auto-compact (~85% of window ≈ 400k). Compact is **lossy for working memory**; compact **count** is a bad end signal. This PR wires the same *kind* of gate Claude/Codex already use: **measure recall**, end when it fails.

### What landed
- `scripts/session_canary/` — `mint` / `questions` / `score` / `status` / `protocol` for epic lanes
  - Freezes **10** durable anchors from **session stream + dual-write handoff** (no git scrape)
  - Scores via existing `scripts/context_canary.py` with default **pass-ratio 0.8 (8/10)**
  - **rc 2 FAIL-HANDOFF** → handoff + close stream + quit
- `docs/runbooks/grok-session-canary.md` — lifecycle + operator compact config
- `start-grok.sh` — banner + cold-start prompt require mint + re-score after compact
- Tests: `tests/test_grok_lane_session_canary.py` (5 passed)

### Policy
| Signal | Action |
| --- | --- |
| Auto-compact | Re-score (not auto-quit) |
| Score &lt; 8/10 | End session now |
| Compact count | Ignore as end criterion |

### Operator machine (not in this PR)
`~/.grok/config.toml` → `[session] auto_compact_threshold_percent = 95` (already applied on this host).

## Test plan
- [x] `pytest tests/test_grok_lane_session_canary.py` (5 passed)
- [x] `ruff check scripts/session_canary …`
- [x] Smoke mint against live `epic:4387`
- [ ] Next atlas session: mint at cold-start; score after compact

Refs #4387 (atlas driver ergonomics). Complements #5494 start-grok cold-start.