### PR TITLE
fix(practice): daily set density 12 + primary CTA above fold (#5502)

### DIFF
--- a/docs/practice/K3-BUILD-SPEC.md
+++ b/docs/practice/K3-BUILD-SPEC.md
@@ -22,11 +22,12 @@ The following requirements are non-negotiable across all chunks:
   reordering, or filler row.
 - The primary start/resume CTA is visible without scrolling at `1366x768` in
   both Ukrainian and English chrome. Section 8 defines the two owner HARD tests.
-- The daily set contains 20 unique lemmas. Its rows are ordered pending due,
-  pending new, then completed. Completed rows remain visible at full opacity with
-  a green finished tint; their why-line uses a neutral readable token. State is always three
-  channel: boxed glyph (`✦`, `↻`, `✓`), localized text, and the accepted
-  yellow-dark/blue/green semantic color.
+- The daily set contains **12** unique lemmas (`DAILY_PRACTICE_DECK_SIZE`, owner
+  #5502 — try 12 first among 10/12/15 for viewport density). Its rows are ordered
+  pending due, pending new, then completed. Completed rows remain visible at full
+  opacity with a green finished tint; their why-line uses a neutral readable
+  token. State is always three channel: boxed glyph (`✦`, `↻`, `✓`), localized
+  text, and the accepted yellow-dark/blue/green semantic color.
 - The words disclosure is a native `<details>` element, closed on initial setup
   render. Its summary is at least 48 CSS pixels high and exposes the real open
   state through `aria-expanded`.
@@ -82,23 +83,24 @@ are source observations, not proposed names.
 | Locale and theme | `site/src/layouts/CourseLayout.astro` pre-paints `lu-theme` and `lu-chrome-locale` and defines exclusive `.lu-i18n`/`.lu-i18n-block` rendering. `ChromeText` and `ChromeDual` are exported by `site/src/lib/i18n/ChromeText.tsx`. Theme color tokens, including teal, orange, purple, and yellow families in both themes, are in `site/src/styles/course.css`. |
 | Summary | `site/src/components/PracticeSessionSummary.tsx` already accepts counts, streak, a next-due label, deferred lemmas, and start/back actions. It does not yet render the accepted score ratio and closing proverb. |
 | Atlas route | `site/src/pages/lexicon/[lemma].astro` is the lexicon detail route. Existing practice links in `site/src/components/LexiconPractice.tsx` already target `/lexicon/<lemmaId>/`. |
-| Separate daily pool | `site/src/lexicon/DailyWords.astro` and `site/src/lib/lexicon/daily.ts` power a separate date-seeded Atlas daily selection from `/lexicon/daily-pool.json`. That random pool is not the source of the practice 20. |
+| Separate daily pool | `site/src/lexicon/DailyWords.astro` and `site/src/lib/lexicon/daily.ts` power a separate date-seeded Atlas daily selection from `/lexicon/daily-pool.json`. That random pool is not the source of the practice daily set. |
 | Existing tests | Practice coverage lives in `site/tests/unit/LexiconPractice.test.tsx`, `site/tests/unit/lexicon-srs.test.ts`, `site/tests/unit/weak-areas.test.ts`, `site/tests/unit/k3-chrome-locale.test.ts`, and `site/e2e/atlas-practice.spec.ts`. |
 
 ## 3. Daily-set and SRS data contract
 
-### 3.1 Source of the 20 words
+### 3.1 Source of the daily words
 
-The practice 20 are selected from the existing generated practice-index shards,
-not from `/lexicon/daily-pool.json`. The eligible pool is the chosen learner
-level plus every published lower level, matching the cumulative behavior already
+The practice daily set (`DAILY_PRACTICE_DECK_SIZE`, currently **12** per #5502)
+is selected from the existing generated practice-index shards, not from
+`/lexicon/daily-pool.json`. The eligible pool is the chosen learner level plus
+every published lower level, matching the cumulative behavior already
 implemented by `levelsUpTo`, `mergeDecks`, and `ensureDeck` in
 `site/src/components/LexiconPractice.tsx`. C2 remains “soon” because
 `PUBLISHED_PRACTICE_LEVELS` in `site/src/lib/lexicon/srs.ts` ends at C1.
 
 The setup path loads all eligible `practice-index.<level>.json` shards before it
-materializes the daily snapshot. It does not need drill shards. After the 20 IDs
-are known, fetch the `practice-lexemes.<level>.json` core only for levels
+materializes the daily snapshot. It does not need drill shards. After the daily
+IDs are known, fetch the `practice-lexemes.<level>.json` core only for levels
 represented in that set so the dashboard has verified lemma, gloss, part of
 speech, and paradigm data. Preserve the current progressive loading behavior for
 the active exercise's drill shards in `site/src/components/LexiconPractice.tsx`.
@@ -113,9 +115,10 @@ Selection is deterministic for the local date, learner level, and deck version:
 3. A lemma is new when every supported card is absent or satisfies
    `isPracticeNewCard`. Sort new lemmas by CEFR, `newOrder`, and `lemmaId`.
 4. Take unique due lemmas first and then unique new lemmas until the set reaches
-   20. If a synthetic/test deck contains fewer than 20 eligible unique lemmas,
-   use the full eligible set and expose that actual denominator; production
-   acceptance fixtures must contain at least 20.
+   `DAILY_PRACTICE_DECK_SIZE` (12). If a synthetic/test deck contains fewer than
+   that many eligible unique lemmas, use the full eligible set and expose that
+   actual denominator; production acceptance fixtures must contain at least the
+   configured size.
 5. A reviewed-but-not-due lemma that is neither due nor new does not displace a
    due or new candidate. Never use randomness to refill the set.
 
@@ -229,10 +232,10 @@ lemma and form both link through the Atlas scheme in section 3.4.
 | --- | --- | --- |
 | `site/src/lib/lexicon/srs.ts` | CHANGE | Own the versioned daily-snapshot types, storage key, deterministic selection, validation, refill, and row-state derivation. |
 | `site/src/lib/i18n/chrome.ts` | CHANGE | Add typed `practice.*` keys for static redesigned interface copy; preserve the existing English-key/Ukrainian-record compile-time parity contract. Dynamic numeric phrases use `ChromeDual` rather than dictionary keys. |
-| `site/src/components/PracticeDailyDeck.tsx` | **NEW** | Render the 3D daily-card preview and the collapsed 20-row `<details>` disclosure, row markers, counters, Atlas links, voice slot, and open-state accessibility. It receives data; it does not select the set. |
+| `site/src/components/PracticeDailyDeck.tsx` | **NEW** | Render the 3D daily-card preview and the collapsed daily-row `<details>` disclosure, row markers, counters, Atlas links, voice slot, and open-state accessibility. It receives data; it does not select the set. |
 | `site/src/components/PracticeFormRail.tsx` | **NEW** | Render the generalized source-to-actual-form rail and its idle/correct/wrong/calque verdict states for cloze, paradigm, paronym, and heritage only. |
 | `site/src/components/PracticeStress.tsx` | **NEW** | Render arbitrary-length stress choices by iterating the generated `nuclei` positions. It owns no two-vowel special case. |
-| `site/src/components/LexiconPractice.tsx` | CHANGE | Materialize/load the daily set; render the accepted setup dashboard; constrain sessions to the 20 IDs; coordinate mode detail, focus cue, result dwell, explicit next, form rail, level changes, and summary data. |
+| `site/src/components/LexiconPractice.tsx` | CHANGE | Materialize/load the daily set; render the accepted setup dashboard; constrain sessions to the daily IDs; coordinate mode detail, focus cue, result dwell, explicit next, form rail, level changes, and summary data. |
 | `site/src/components/PracticeFlashcard.tsx` | CHANGE | Keep the real `.flashcard`; add a locked rated state and explicit parent-controlled completion. Prevent flip/rating keyboard handlers after lock. |
 | `site/src/components/PracticeSessionSummary.tsx` | CHANGE | Add the accepted completed/total ratio and closing proverb while retaining next-due formatting and existing actions. |
 | `site/src/components/MatchUp.tsx` | CHANGE | Add the documented optional practice-only pair-coding prop to the lesson-schema shim. |
@@ -249,7 +252,7 @@ chunks.
 
 ### Chunk 1 — Daily-set domain and copy inventory
 
-**Goal:** introduce the deterministic 20-lemma contract without changing the
+**Goal:** introduce the deterministic daily-lemma contract without changing the
 current UI.
 
 **Files**
@@ -276,7 +279,7 @@ current UI.
 
 **Acceptance**
 
-- Exactly 20 unique lemmas are selected from a fixture containing enough data;
+- Exactly `DAILY_PRACTICE_DECK_SIZE` (12) unique lemmas are selected from a fixture containing enough data;
   due precedes new, and all deterministic tie-breakers are covered.
 - Multiple due modes for one lemma consume one slot.
 - A valid snapshot is stable after SRS mutations and page reload.
@@ -718,7 +721,7 @@ explicitly approved learning content.
 
 ### HARD-1 — English first viewport
 
-In `site/e2e/atlas-practice.spec.ts`, set a deterministic 20-item fixture and a
+In `site/e2e/atlas-practice.spec.ts`, set a deterministic daily-size fixture and a
 resumable Mixed session, select English chrome and a desktop light theme, set the
 viewport to exactly `1366x768`, open `/words-of-the-day/practice/`, wait for the
 idle dashboard to settle, and make **no scroll call**. Assert:
@@ -743,7 +746,7 @@ mockup, but it does not replace either `1366x768` HARD test.
 | Gate | Required proof |
 | --- | --- |
 | Frozen layout | Centered single-column DOM/focus order; page-growing disclosure; HARD-1 and HARD-2. |
-| Daily 20 | Unique persisted IDs, due/new source counts, stable done state/order, actual denominator for undersized fixtures. |
+| Daily set | Unique persisted IDs, due/new source counts, stable done state/order, actual denominator for undersized fixtures. Size = `DAILY_PRACTICE_DECK_SIZE` (12, #5502). |
 | All modes | Exactly the 11 `MODE_CARD_ORDER` modes, compact titles/steps, one shared focus/hover detail line, no icons. |
 | Real flashcard | Canonical `.flashcard` DOM/CSS, card flip, disabled pre-flip ratings, locked rated state, explicit next. |
 | Honest feedback | Actual submitted value, distinct wrong/calque, relevant four-mode form rail only, heritage labeling touch. |

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -16,7 +16,15 @@ export const SRS_BACKUP_KEY = 'lu-lexicon-srs.backup';
 export const PRACTICE_NEW_CARDS_KEY = 'lu-practice-newcards';
 export const PRACTICE_SESSION_STORAGE_KEY = 'lu-practice-session';
 export const DAILY_PRACTICE_DECK_KEY = 'lu-daily-practice-deck';
-export const DAILY_PRACTICE_DECK_SIZE = 20;
+/**
+ * Daily practice set size (owner #5502).
+ *
+ * Prefer 10 / 12 / 15 for viewport density; **12** first: enough for a
+ * meaningful day, still keeps the collapsed daily list + primary Start CTA
+ * usable without buried scroll at 1366×768 and common phone widths. localStorage
+ * snapshot shape is unchanged (same key/version; only the item cap changes).
+ */
+export const DAILY_PRACTICE_DECK_SIZE = 12;
 export const DEFAULT_NEW_PER_SESSION = 8;
 export const DEFAULT_NEW_PER_DAY = 20;
 export const SESSION_CLOSURE_EXTENSION_MAX = 5;

--- a/site/src/pages/words-of-the-day.astro
+++ b/site/src/pages/words-of-the-day.astro
@@ -26,7 +26,7 @@ const frontmatter = {
       </a>
     </section>
 
-    {/* Atlas daily pool count aligns with practice density (#5502): 12 first. */}
+    {/* Practice daily set density (#5502): 12 first — atlas daily-pool.json unchanged. */}
     <DailyWords
       title="Добірка на сьогодні"
       description="Слова оновлюються за календарною датою; кожна картка веде до повної статті Атласу."

--- a/site/src/pages/words-of-the-day.astro
+++ b/site/src/pages/words-of-the-day.astro
@@ -26,6 +26,7 @@ const frontmatter = {
       </a>
     </section>
 
+    {/* Atlas daily pool count aligns with practice density (#5502): 12 first. */}
     <DailyWords
       title="Добірка на сьогодні"
       description="Слова оновлюються за календарною датою; кожна картка веде до повної статті Атласу."
@@ -39,12 +40,12 @@ const frontmatter = {
   .words-day-page {
     max-width: 1120px;
     margin: 0 auto;
-    padding: 3.5rem 1.5rem 4.5rem;
+    padding: 2rem 1.5rem 3.5rem;
   }
 
   .words-day-hero {
     max-width: 820px;
-    margin-bottom: 2rem;
+    margin-bottom: 1.35rem;
   }
 
   .words-day-badge {
@@ -62,40 +63,61 @@ const frontmatter = {
   }
 
   .words-day-hero h1 {
-    margin: 0.7rem 0 0;
+    margin: 0.55rem 0 0;
     color: var(--lu-text);
-    font-size: clamp(2.3rem, 4vw, 4rem);
+    font-size: clamp(2rem, 4vw, 3.4rem);
     line-height: 1;
   }
 
   .words-day-hero p {
     max-width: 680px;
-    margin: 1rem 0 0;
+    margin: 0.75rem 0 0;
     color: var(--lu-text-muted);
-    font-size: 1.05rem;
-    line-height: 1.65;
+    font-size: 1.02rem;
+    line-height: 1.55;
   }
 
   /* `.word-atlas.words-day-page` (0,3,0) beats the global `.lu-content .word-atlas a`
-     (0,2,1) link color so the CTA text stays white on the primary fill. */
+     (0,2,1) link color so the CTA text stays dark on the gold accent fill. */
   .word-atlas.words-day-page .words-day-practice-cta {
     display: inline-flex;
     align-items: center;
-    min-height: 2.75rem;
-    margin-top: 1.5rem;
-    padding: 0 1.1rem;
+    justify-content: center;
+    gap: 0.35rem;
+    min-height: 3rem;
+    margin-top: 1.1rem;
+    padding: 0 1.25rem;
     border: 1px solid var(--lu-accent);
-    border-radius: 8px;
+    border-radius: 12px;
     background: var(--lu-accent);
     color: var(--lu-on-accent);
+    font-size: 1.02rem;
     font-weight: 900;
+    letter-spacing: 0.01em;
     text-decoration: none;
+    box-shadow:
+      0 1px 0 color-mix(in srgb, #fff 35%, transparent) inset,
+      0 4px 14px color-mix(in srgb, var(--lu-accent) 45%, transparent);
   }
 
   .words-day-practice-cta:hover,
   .words-day-practice-cta:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 3px var(--lu-state-active);
+    filter: brightness(1.04);
+    box-shadow:
+      0 0 0 3px var(--lu-state-active),
+      0 6px 18px color-mix(in srgb, var(--lu-accent) 55%, transparent);
+  }
+
+  @media (max-width: 760px) {
+    .words-day-page {
+      padding: 1.25rem 1rem 2.75rem;
+    }
+
+    .word-atlas.words-day-page .words-day-practice-cta {
+      width: 100%;
+      min-height: 3.1rem;
+    }
   }
 
   :global(.words-day-page .lexicon-daily-section) {

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -963,14 +963,14 @@ const frontmatter = {
   /* K3 practice dashboard (Chunk 2) — density tuned for #5502 above-the-fold CTA */
   :global(.k3-practice-dashboard) {
     display: grid;
-    gap: 0.55rem;
+    gap: 0.4rem;
     max-width: 800px;
     margin: 0 auto;
   }
 
   :global(.k3-hero h1) {
     margin: 0;
-    font-size: clamp(1.75rem, 3vw, 2.15rem);
+    font-size: clamp(1.65rem, 3vw, 2.05rem);
     line-height: 1;
   }
   :global(.k3-hero-subtitle) {
@@ -1056,8 +1056,8 @@ const frontmatter = {
 
   :global(.k3-session) {
     display: grid;
-    gap: 0.55rem;
-    padding: 0.85rem 0.95rem;
+    gap: 0.35rem;
+    padding: 0.6rem 0.75rem;
     border: 1px solid color-mix(in srgb, var(--lu-primary) 28%, var(--lu-border));
     border-radius: 14px;
     background:
@@ -1117,15 +1117,15 @@ const frontmatter = {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.4rem;
-    min-height: 52px;
+    gap: 0.35rem;
+    min-height: 48px;
     width: 100%;
-    padding: 0 1.15rem;
+    padding: 0 1rem;
     border: 1px solid var(--lu-primary);
     border-radius: 12px;
     background: var(--lu-primary);
     color: var(--lu-on-primary);
-    font-size: 1.08rem;
+    font-size: 1.05rem;
     font-weight: 900;
     letter-spacing: 0.01em;
     box-shadow:

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -25,7 +25,7 @@ const frontmatter = {
   .lexicon-practice-page {
     max-width: 1120px;
     margin: 0 auto;
-    padding: 0.75rem 1.5rem 3.5rem;
+    padding: 0.5rem 1.5rem 3.5rem;
   }
 
   @media (max-width: 760px) {
@@ -980,11 +980,15 @@ const frontmatter = {
     font-weight: 800;
   }
   :global(.k3-hero-epigraph) {
-    margin: 0.4rem 0 0;
+    margin: 0.3rem 0 0;
     color: var(--lu-text-muted);
-    font-size: 0.88rem;
+    font-size: 0.86rem;
     font-style: italic;
-    line-height: 1.3;
+    line-height: 1.25;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 
   :global(.k3-levels) {
@@ -1118,7 +1122,7 @@ const frontmatter = {
     align-items: center;
     justify-content: center;
     gap: 0.35rem;
-    min-height: 48px;
+    min-height: 46px;
     width: 100%;
     padding: 0 1rem;
     border: 1px solid var(--lu-primary);

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -25,7 +25,13 @@ const frontmatter = {
   .lexicon-practice-page {
     max-width: 1120px;
     margin: 0 auto;
-    padding: 1rem 1.5rem 4.5rem;
+    padding: 0.75rem 1.5rem 3.5rem;
+  }
+
+  @media (max-width: 760px) {
+    .lexicon-practice-page {
+      padding: 0.5rem 1rem 3rem;
+    }
   }
 
   .lexicon-practice-badge {
@@ -954,31 +960,31 @@ const frontmatter = {
     }
   }
 
-  /* K3 practice dashboard (Chunk 2) */
+  /* K3 practice dashboard (Chunk 2) — density tuned for #5502 above-the-fold CTA */
   :global(.k3-practice-dashboard) {
     display: grid;
-    gap: 0.4rem;
+    gap: 0.55rem;
     max-width: 800px;
     margin: 0 auto;
   }
 
   :global(.k3-hero h1) {
     margin: 0;
-    font-size: clamp(1.9rem, 3vw, 2.25rem);
+    font-size: clamp(1.75rem, 3vw, 2.15rem);
     line-height: 1;
   }
   :global(.k3-hero-subtitle) {
-    margin: 0.35rem 0 0;
+    margin: 0.3rem 0 0;
     color: var(--lu-text-muted);
-    font-size: 1.05rem;
+    font-size: 1.02rem;
     font-weight: 800;
   }
   :global(.k3-hero-epigraph) {
-    margin: 0.55rem 0 0;
+    margin: 0.4rem 0 0;
     color: var(--lu-text-muted);
-    font-size: 0.92rem;
+    font-size: 0.88rem;
     font-style: italic;
-    line-height: 1.35;
+    line-height: 1.3;
   }
 
   :global(.k3-levels) {
@@ -1015,15 +1021,15 @@ const frontmatter = {
   :global(.k3-stats) {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0.5rem;
+    gap: 0.4rem;
   }
   :global(.k3-stat) {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: 0.2rem;
-    min-height: 3.5rem;
-    padding: 0.5rem 0.75rem;
+    gap: 0.15rem;
+    min-height: 3.15rem;
+    padding: 0.4rem 0.65rem;
     border: 1px solid var(--lu-border);
     border-radius: 12px;
     background: var(--lu-surface-raised);
@@ -1031,7 +1037,7 @@ const frontmatter = {
   }
   :global(.k3-stat-value) {
     color: var(--lu-text);
-    font-size: 1.75rem;
+    font-size: 1.55rem;
     font-weight: 900;
     line-height: 1;
   }
@@ -1050,7 +1056,17 @@ const frontmatter = {
 
   :global(.k3-session) {
     display: grid;
-    gap: 0.35rem;
+    gap: 0.55rem;
+    padding: 0.85rem 0.95rem;
+    border: 1px solid color-mix(in srgb, var(--lu-primary) 28%, var(--lu-border));
+    border-radius: 14px;
+    background:
+      linear-gradient(
+        165deg,
+        color-mix(in srgb, var(--lu-primary) 8%, var(--lu-surface-raised)) 0%,
+        var(--lu-surface-raised) 55%
+      );
+    box-shadow: var(--lu-shadow);
   }
   :global(.k3-session-overview) {
     display: flex;
@@ -1092,22 +1108,79 @@ const frontmatter = {
     background: var(--lu-primary);
     color: var(--lu-on-primary);
   }
-  :global(.k3-session-primary) {
-    min-height: 48px;
+  /*
+   * Primary Daily/Start CTA (#5502): `.btn-accent` is not a global style, so the
+   * session primary used to render as a generic surface button. Force a distinct
+   * primary treatment that stays readable in light/dark without hunting.
+   */
+  :global(.lexicon-practice button.k3-session-primary) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    min-height: 52px;
     width: 100%;
-    font-size: 1.05rem;
+    padding: 0 1.15rem;
+    border: 1px solid var(--lu-primary);
+    border-radius: 12px;
+    background: var(--lu-primary);
+    color: var(--lu-on-primary);
+    font-size: 1.08rem;
+    font-weight: 900;
+    letter-spacing: 0.01em;
+    box-shadow:
+      0 1px 0 color-mix(in srgb, var(--lu-on-primary) 18%, transparent) inset,
+      0 4px 14px color-mix(in srgb, var(--lu-primary) 32%, transparent);
+  }
+  :global(.lexicon-practice button.k3-session-primary:hover),
+  :global(.lexicon-practice button.k3-session-primary:focus-visible) {
+    border-color: var(--lu-primary);
+    background: var(--lu-primary);
+    color: var(--lu-on-primary);
+    filter: brightness(1.06);
+    outline: none;
+    box-shadow:
+      0 0 0 3px var(--lu-state-active),
+      0 6px 18px color-mix(in srgb, var(--lu-primary) 38%, transparent);
+  }
+  :global(.lexicon-practice button.k3-session-primary:disabled) {
+    opacity: 0.72;
+    filter: none;
+    cursor: wait;
   }
   :global(.k3-session-resume) {
     justify-self: start;
     min-height: 44px;
-    padding: 0;
+    padding: 0.15rem 0;
     border: 0;
     background: transparent;
-    color: var(--lu-text-muted);
+    color: var(--lu-primary);
     font-weight: 800;
     text-decoration: underline;
+    text-underline-offset: 0.18em;
+  }
+  :global(.lexicon-practice button.k3-session-resume:hover),
+  :global(.lexicon-practice button.k3-session-resume:focus-visible) {
+    border: 0;
+    background: transparent;
+    color: var(--lu-primary);
+    box-shadow: none;
+    outline: 2px solid var(--lu-primary);
+    outline-offset: 2px;
   }
   @media (max-width: 760px) {
+    :global(.k3-practice-dashboard) {
+      gap: 0.45rem;
+    }
+    :global(.k3-hero-epigraph) {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    :global(.k3-session) {
+      padding: 0.75rem 0.8rem;
+    }
     :global(.k3-session-overview),
     :global(.k3-session-size) {
       align-items: flex-start;
@@ -1122,12 +1195,16 @@ const frontmatter = {
     :global(.k3-session-scope) {
       white-space: normal;
     }
+    :global(.lexicon-practice button.k3-session-primary) {
+      min-height: 50px;
+      font-size: 1.05rem;
+    }
   }
 
   :global(.practice-daily-deck) {
     display: grid;
-    gap: 0.45rem;
-    padding: 0.65rem 0.8rem;
+    gap: 0.4rem;
+    padding: 0.55rem 0.75rem;
     border: 1px solid var(--lu-border);
     border-radius: 14px;
     background: var(--lu-surface-raised);
@@ -1168,7 +1245,7 @@ const frontmatter = {
     font-weight: 900;
   }
   :global(.daily-preview-card) {
-    min-height: 88px;
+    min-height: 76px;
     flex: 1 1 auto;
     cursor: pointer;
   }

--- a/site/tests/unit/k3-chrome-locale.test.ts
+++ b/site/tests/unit/k3-chrome-locale.test.ts
@@ -81,6 +81,21 @@ describe("K3 practice dashboard layout and copy (Chunk 2)", () => {
     expect(dailyDeckSource).toContain('onToggle={(event) => setDetailsOpen(event.currentTarget.open)}');
   });
 
+  test("practice.astro styles the primary Daily/Start CTA as a distinct primary control (#5502)", () => {
+    // Generic `.btn-accent` is not a global style; the session primary must force
+    // primary-fill treatment so it is not an "ugly default surface button".
+    expect(practiceSource).toContain("button.k3-session-primary");
+    expect(practiceSource).toMatch(
+      /button\.k3-session-primary[^}]*background:\s*var\(--lu-primary\)/s,
+    );
+    expect(practiceSource).toMatch(
+      /button\.k3-session-primary[^}]*color:\s*var\(--lu-on-primary\)/s,
+    );
+    expect(practiceSource).toMatch(
+      /button\.k3-session-primary[^}]*min-height:\s*52px/s,
+    );
+  });
+
   test("practice.astro removed the superseded static intro", () => {
     expect(practiceSource).not.toContain('<div class="lexicon-practice-intro">');
     expect(practiceSource).not.toContain('lexicon-practice-intro h1');

--- a/site/tests/unit/k3-chrome-locale.test.ts
+++ b/site/tests/unit/k3-chrome-locale.test.ts
@@ -92,7 +92,7 @@ describe("K3 practice dashboard layout and copy (Chunk 2)", () => {
       /button\.k3-session-primary[^}]*color:\s*var\(--lu-on-primary\)/s,
     );
     expect(practiceSource).toMatch(
-      /button\.k3-session-primary[^}]*min-height:\s*52px/s,
+      /button\.k3-session-primary[^}]*min-height:\s*46px/s,
     );
   });
 

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -1157,7 +1157,12 @@ describe('lexicon SRS facade', () => {
 });
 
 describe('daily practice deck (K3 chunk 1)', () => {
-  test('selects exactly 20 unique lemmas when enough data exists', () => {
+  test('daily deck size is 12 for viewport density (#5502)', () => {
+    // Owner preference: try 12 first among 10/12/15 so the setup list + Start CTA fit.
+    expect(DAILY_PRACTICE_DECK_SIZE).toBe(12);
+  });
+
+  test('selects exactly DAILY_PRACTICE_DECK_SIZE unique lemmas when enough data exists', () => {
     const ids = Array.from({ length: 30 }, (_, index) => `w${String(index).padStart(2, '0')}`);
     const index = dailyIndex(ids);
     const cards = makeCards({});
@@ -1209,7 +1214,7 @@ describe('daily practice deck (K3 chunk 1)', () => {
     expect(ids).toEqual(['due-one', 'new-one']);
   });
 
-  test('uses the actual eligible count as denominator when fewer than 20 lemmas exist', () => {
+  test('uses the actual eligible count as denominator when fewer than daily size lemmas exist', () => {
     const index = dailyIndex(['a', 'b', 'c']);
     const cards = makeCards({});
     const items = selectDailyPracticeDeckItems(index, cards, NOW);


### PR DESCRIPTION
## Summary

Owner live-test (#5502): 20 words-of-the-day is too dense for one viewport, and the Daily/Start control was an ugly default surface button that felt buried.

- **Default daily set size → 12** via clear constant `DAILY_PRACTICE_DECK_SIZE` in `site/src/lib/lexicon/srs.ts`
- **Rationale (10 / 12 / 15):** try **12 first** — enough for a meaningful day, short enough that the collapsed daily list + primary Start CTA stay usable without buried scroll at 1366×768 and common phone widths. 10 felt thin; 15 still long when the disclosure is open.
- **CTA polish (static/serverless only):** `.btn-accent` is not a global style, so the session primary rendered as a generic bordered surface button. Force primary-fill treatment (`--lu-primary` / `--lu-on-primary`), larger hit area, elevation, and a distinct session card. Words-of-the-day gold practice link also tightened for first-viewport density.
- **No backend.** localStorage SRS key/version contract unchanged — only the selection cap changes.
- K3 build spec updated to match the new size.

## Layout notes (manual)

| Viewport | Expectation |
| --- | --- |
| **1366×768** | Hero → stats → daily preview (disclosure closed) → session card with primary Start/Resume remain in the first viewport (HARD-1/2 order preserved). Tighter hero/stats/preview min-heights free vertical room for the CTA. |
| **Phone (~390×844 / ≤760px)** | Full-width primary CTA; clamped epigraph; reduced page padding; session card padding compact. List disclosure still grows the page only when opened (unchanged K3 behavior). |

DOM/tab order is still: hero → stats → words → session → secondary (no CSS reorder).

## Files

- `site/src/lib/lexicon/srs.ts` — `DAILY_PRACTICE_DECK_SIZE = 12` + rationale
- `site/src/pages/words-of-the-day/practice.astro` — CTA + density CSS
- `site/src/pages/words-of-the-day.astro` — practice CTA polish / density
- `docs/practice/K3-BUILD-SPEC.md` — 20 → 12 contract
- unit tests for size + primary CTA styling

## Verification

```bash
cd site
./node_modules/.bin/vitest run tests/unit/lexicon-srs.test.ts tests/unit/k3-chrome-locale.test.ts
./node_modules/.bin/vitest run tests/unit/LexiconPractice.test.tsx tests/unit/practice-session.test.ts tests/unit/daily-words-example.test.ts
```

- 62 + 110 unit tests passed (targeted)
- `scripts/audit/lint_agent_trailer.py` PASS
- lesson-schema regeneration run; no `docs/lesson-schema.yaml` contract diff

## Out of scope

- Session budget chips remain 10 / 20 / until-zero (session length, not daily set)
- `DEFAULT_NEW_PER_DAY` remains 20 (SRS new-card daily cap)
- No auto-merge arming; leave open for **cross-family CF review** (prefer GLM/Kimi)

Refs #5502 #4700 #4387