### PR TITLE
fix(practice): stress mode uses character position contract (#5501)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 873dd59bced1611f97b1f07c5a217aa3485ca35c41c6f5a47c7fd4d53e4e94df
+  components_sha256: 18a580420d00ecb1e5a68065d3a0a742e5597d92edad27be7484619f3ee3d448
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1795,9 +1795,9 @@ components:
         type: PracticeStressItem
         description: item prop.
         ukrainian_text: 'false'
-      - name: selectedNucleusIndex
+      - name: selectedPosition
         type: number | null
-        description: selectedNucleusIndex prop.
+        description: selectedPosition prop.
         ukrainian_text: 'false'
       - name: answerLocked
         type: boolean
@@ -1807,7 +1807,7 @@ components:
     nested_types: {}
     example:
       item: <PracticeStressItem>
-      selectedNucleusIndex: <number | null>
+      selectedPosition: <number | null>
       answerLocked: false
     deprecated: false
     deprecation_reason: null

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1153,7 +1153,7 @@ function LexiconPracticeIsland({
   const [clozeAttemptRecorded, setClozeAttemptRecorded] = useState(false);
   const [heritageFeedback, setHeritageFeedback] = useState<HeritageFeedback | null>(null);
   const [paronymFeedback, setParonymFeedback] = useState<ParonymFeedback | null>(null);
-  const [stressSelectedIndex, setStressSelectedIndex] = useState<number | null>(null);
+  const [stressSelectedPosition, setStressSelectedPosition] = useState<number | null>(null);
   const [paradigmSelectedLabel, setParadigmSelectedLabel] = useState<string | null>(null);
   const [paronymSelectedLabel, setParonymSelectedLabel] = useState<string | null>(null);
   const [heritageSelectedLabel, setHeritageSelectedLabel] = useState<string | null>(null);
@@ -1215,7 +1215,7 @@ function LexiconPracticeIsland({
     setClozeAttemptRecorded(false);
     setHeritageFeedback(null);
     setParonymFeedback(null);
-    setStressSelectedIndex(null);
+    setStressSelectedPosition(null);
     setParadigmSelectedLabel(null);
     setParonymSelectedLabel(null);
     setHeritageSelectedLabel(null);
@@ -2253,10 +2253,10 @@ function LexiconPracticeIsland({
     completeSelection(selection, outcome);
   }
 
-  function handleStressSelect(nucleusIndex: number) {
+  function handleStressSelect(position: number) {
     if (!selection?.stress || answerLocked) return;
-    setStressSelectedIndex(nucleusIndex);
-    const correct = nucleusIndex === selection.stress.stressIndex;
+    setStressSelectedPosition(position);
+    const correct = position === selection.stress.stressIndex;
     const rating = correct ? 'good' : 'again';
     const outcome = recordReview(selection, rating);
     setFeedback({
@@ -2853,7 +2853,7 @@ function LexiconPracticeIsland({
                     clozeFeedback={clozeFeedback}
                     heritageFeedback={heritageFeedback}
                     paronymFeedback={paronymFeedback}
-                    stressSelectedIndex={stressSelectedIndex}
+                    stressSelectedPosition={stressSelectedPosition}
                     paradigmSelectedLabel={paradigmSelectedLabel}
                     paronymSelectedLabel={paronymSelectedLabel}
                     heritageSelectedLabel={heritageSelectedLabel}
@@ -2930,7 +2930,7 @@ function PracticeItem({
   clozeFeedback,
   heritageFeedback,
   paronymFeedback,
-  stressSelectedIndex,
+  stressSelectedPosition,
   paradigmSelectedLabel,
   paronymSelectedLabel,
   heritageSelectedLabel,
@@ -2954,14 +2954,14 @@ function PracticeItem({
   clozeFeedback: ClozeFeedback | null;
   heritageFeedback: HeritageFeedback | null;
   paronymFeedback: ParonymFeedback | null;
-  stressSelectedIndex: number | null;
+  stressSelectedPosition: number | null;
   paradigmSelectedLabel: string | null;
   paronymSelectedLabel: string | null;
   heritageSelectedLabel: string | null;
   onClozeInput(value: string): void;
   onFlashcardRating(rating: PracticeRating): void;
   onChoice(option: ChoiceOption): void;
-  onStressSelect(nucleusIndex: number): void;
+  onStressSelect(position: number): void;
   onMatchingComplete(): void;
   onMatchingMatch?: (pairIndex: number, rating: PracticeRating) => void;
   onClozeSubmit(value: string, source: 'typed' | 'chip'): void;
@@ -3025,7 +3025,7 @@ function PracticeItem({
         ) : null}
         <PracticeStress
           item={selection.stress}
-          selectedNucleusIndex={stressSelectedIndex}
+          selectedPosition={stressSelectedPosition}
           answerLocked={answerLocked}
           onSelect={onStressSelect}
         />

--- a/site/src/components/PracticeStress.tsx
+++ b/site/src/components/PracticeStress.tsx
@@ -3,9 +3,9 @@ import type { PracticeStressItem } from '../lib/lexicon/srs';
 
 export interface PracticeStressProps {
   item: PracticeStressItem;
-  selectedNucleusIndex: number | null;
+  selectedPosition: number | null;
   answerLocked: boolean;
-  onSelect(nucleusIndex: number): void;
+  onSelect(position: number): void;
 }
 
 interface NucleusInfo {
@@ -15,7 +15,7 @@ interface NucleusInfo {
 
 export default function PracticeStress({
   item,
-  selectedNucleusIndex,
+  selectedPosition,
   answerLocked,
   onSelect,
 }: PracticeStressProps) {
@@ -31,7 +31,7 @@ export default function PracticeStress({
   }, [item.nuclei]);
 
   const codePoints = Array.from(item.unstressed);
-  const isCorrect = selectedNucleusIndex === item.stressIndex;
+  const isCorrect = selectedPosition === item.stressIndex;
 
   return (
     <div className="practice-stress" data-testid="practice-stress" data-locked={answerLocked}>
@@ -39,7 +39,7 @@ export default function PracticeStress({
         {codePoints.map((char, position) => {
           const nucleus = nucleusByPosition.get(position);
           if (nucleus) {
-            const selected = selectedNucleusIndex === nucleus.nucleusIndex;
+            const selected = selectedPosition === position;
             const verdictClass = answerLocked
               ? selected
                 ? isCorrect
@@ -56,7 +56,7 @@ export default function PracticeStress({
                 data-position={position}
                 disabled={answerLocked}
                 aria-pressed={selected}
-                onClick={() => onSelect(nucleus.nucleusIndex)}
+                onClick={() => onSelect(position)}
               >
                 {char}
               </button>
@@ -69,7 +69,7 @@ export default function PracticeStress({
           );
         })}
       </p>
-      {answerLocked && selectedNucleusIndex !== null ? (
+      {answerLocked && selectedPosition !== null ? (
         <p
           className={`practice-stress-verdict ${isCorrect ? 'correct' : 'wrong'}`}
           role="status"

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -518,8 +518,8 @@ function stressDeck(): PracticeDeckData {
       unstressed: 'кава',
       stressIndex: 1,
       nuclei: [
-        { index: 0, label: 'а' },
         { index: 1, label: 'а' },
+        { index: 3, label: 'а' },
       ],
       source: 'fixture',
     }],
@@ -2774,7 +2774,9 @@ describe('LexiconPractice', () => {
         deck: stressDeck(),
         answer: async (user) => {
           const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button');
-          await user.click(buttons[1]!);
+          const target = buttons.find((button) => button.dataset.position === '1');
+          expect(target).toBeDefined();
+          await user.click(target!);
         },
       },
       {
@@ -2876,9 +2878,9 @@ describe('LexiconPractice', () => {
     }
 
     test.each([
-      { count: 2, word: 'кава', nuclei: [{ index: 0, label: 'а' }, { index: 2, label: 'а' }], stressIndex: 1 },
-      { count: 3, word: 'україна', nuclei: [{ index: 1, label: 'у' }, { index: 3, label: 'а' }, { index: 5, label: 'и' }], stressIndex: 2 },
-      { count: 5, word: 'автентифікація', nuclei: [{ index: 0, label: 'а' }, { index: 2, label: 'е' }, { index: 5, label: 'і' }, { index: 8, label: 'а' }, { index: 11, label: 'і' }], stressIndex: 3 },
+      { count: 2, word: 'кава', nuclei: [{ index: 0, label: 'а' }, { index: 2, label: 'а' }], stressIndex: 2 },
+      { count: 3, word: 'україна', nuclei: [{ index: 1, label: 'у' }, { index: 3, label: 'а' }, { index: 5, label: 'и' }], stressIndex: 5 },
+      { count: 5, word: 'автентифікація', nuclei: [{ index: 0, label: 'а' }, { index: 2, label: 'е' }, { index: 5, label: 'і' }, { index: 8, label: 'а' }, { index: 11, label: 'і' }], stressIndex: 8 },
     ])('renders $count vowel buttons preserving code-point positions', async ({ word, nuclei, stressIndex }) => {
       const user = userEvent.setup();
       render(<LexiconPractice initialDeck={stressDeckWithNuclei(word, nuclei, stressIndex)} autoStart initialMode="stress" />);
@@ -2886,7 +2888,9 @@ describe('LexiconPractice', () => {
       const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button');
       expect(buttons).toHaveLength(nuclei.length);
 
-      await user.click(buttons[stressIndex]!);
+      const target = buttons.find((button) => button.dataset.position === String(stressIndex));
+      expect(target).toBeDefined();
+      await user.click(target!);
 
       expect(screen.getByTestId('practice-stress-verdict')).toHaveTextContent('✓');
       expect(screen.queryByTestId('practice-form-rail')).not.toBeInTheDocument();
@@ -2898,7 +2902,7 @@ describe('LexiconPractice', () => {
         { index: 2, label: 'а' },
       ];
       const user = userEvent.setup();
-      render(<LexiconPractice initialDeck={stressDeckWithNuclei('кава', nuclei, 1)} autoStart initialMode="stress" />);
+      render(<LexiconPractice initialDeck={stressDeckWithNuclei('кава', nuclei, 2)} autoStart initialMode="stress" />);
 
       const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button');
       await user.click(buttons[0]!);
@@ -2931,7 +2935,7 @@ describe('LexiconPractice', () => {
         }
       } },
       { mode: 'choice', deck: sampleDeckWithOnlyMode('knyha', 'choice'), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /книга/ })); } },
-      { mode: 'stress', deck: stressDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button'); await user.click(buttons[1]!); } },
+      { mode: 'stress', deck: stressDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { const buttons = within(screen.getByTestId('practice-stress')).getAllByRole('button'); const target = buttons.find((button) => button.dataset.position === '1'); expect(target).toBeDefined(); await user.click(target!); } },
       { mode: 'classify', deck: classifyDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /жіночий/ })); } },
       { mode: 'synonym', deck: synonymDeck(), expectRail: false, action: async (user: ReturnType<typeof userEvent.setup>) => { await user.click(screen.getByRole('button', { name: /кава/ })); } },
     ])('$mode: rail is $expectRail', async ({ mode, deck, expectRail, action }) => {


### PR DESCRIPTION
## Root cause

The generator emits "stressIndex" as a code-point position equal to "nuclei[i].index", but the UI was passing and comparing the array ordinal of the nucleus. On real shards (e.g. "готель": stressIndex 3, nuclei at 1 and 3) clicking the correct vowel usually scored wrong.

## Changes

- "PracticeStress" now selects and reports character positions.
- "LexiconPractice.handleStressSelect" compares the clicked position to "stress.stressIndex".
- Unit fixtures updated: "stressIndex" is the char position and tests click the button whose "data-position" matches.

## Verification

- "cd site && npx vitest run tests/unit/LexiconPractice.test.tsx" → 94 passed.
- "npx vitest run tests/unit" → 799 passed, 4 skipped.
- No deck regeneration; shards left untouched.

## Links

Fixes #5501
Relates to #4700 #4387

X-Agent: kimi/5501-stress-mode-fix