### PR TITLE
fix(practice): pure EN|UK chrome locale — no mixed dual labels (#5503)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: b3162b24212f8947a32c6b6ff9e88624e2a363678df3732fc1565d777f7250b8
+  components_sha256: f84ed75a9c68b08ac614f2b627fc35fd192a1564dc6565cf683fbd362d1a9449
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 18a580420d00ecb1e5a68065d3a0a742e5597d92edad27be7484619f3ee3d448
+  components_sha256: b3162b24212f8947a32c6b6ff9e88624e2a363678df3732fc1565d777f7250b8
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1657,10 +1657,6 @@ components:
         type: Record<PracticeRating, string>
         description: intervalPreviews prop.
         ukrainian_text: 'false'
-      - name: showEnglishSubtitles
-        type: boolean
-        description: showEnglishSubtitles prop.
-        ukrainian_text: 'false'
       - name: chromeLocale
         type: ChromeLocale
         description: chromeLocale prop.
@@ -1692,7 +1688,6 @@ components:
       card: <PracticeFlashcardData>
       ratingLabels: '<Record<PracticeRating, { uk: string; en: string }>>'
       intervalPreviews: <Record<PracticeRating, string>>
-      showEnglishSubtitles: false
       chromeLocale: <ChromeLocale>
     deprecated: false
     deprecation_reason: null
@@ -1748,9 +1743,9 @@ components:
         type: SessionSummaryStats
         description: stats prop.
         ukrainian_text: 'false'
-      - name: showEnglishSubtitles
-        type: boolean
-        description: showEnglishSubtitles prop.
+      - name: chromeLocale
+        type: ChromeLocale
+        description: chromeLocale prop.
         ukrainian_text: 'false'
       optional: []
     nested_types:
@@ -1781,7 +1776,7 @@ components:
         ukrainian_text: 'false'
     example:
       stats: <SessionSummaryStats>
-      showEnglishSubtitles: false
+      chromeLocale: <ChromeLocale>
     deprecated: false
     deprecation_reason: null
   PracticeStress:

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -63,7 +63,7 @@ test('practice mode switch starts the selected mode without inheriting the unfin
 
   await page.locator('button[data-mode="matching"]').click();
   await expect(page.locator('[data-testid="practice-matching"]')).toBeVisible();
-  await page.getByRole('button', { name: /Додому/ }).click();
+  await page.getByRole('button', { name: /Додому|Home/ }).click();
 
   // The K3 dashboard preserves mode snapshots but exposes only the primary mixed resume CTA.
   // Switching to a different mode starts fresh instead of inheriting the unfinished session.

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -85,46 +85,16 @@ import {
 } from '../lib/lexicon/levels';
 
 
-/** A1 always bilingual; otherwise pure chrome-locale via CSS (owner #5355 full-switch). */
-function PracticeChromeLabel({
-  k,
-  a1Bilingual,
-}: {
-  k: ChromeKey;
-  a1Bilingual: boolean;
-}): ReactElement {
-  if (a1Bilingual) {
-    return (
-      <>
-        <span lang="uk">{CHROME_STRINGS.uk[k]}</span>
-        <span className="btn-sub" lang="en">
-          / {CHROME_STRINGS.en[k]}
-        </span>
-      </>
-    );
-  }
+/**
+ * Practice chrome labels — pure locale via ChromeText CSS (data-chrome-locale).
+ * A1 English scaffolding is for item content glosses only (#5503), never dual chrome.
+ */
+function PracticeChromeLabel({ k }: { k: ChromeKey }): ReactElement {
   return <ChromeText k={k} />;
 }
 
-function PracticeChromeDual({
-  uk,
-  en,
-  a1Bilingual,
-}: {
-  uk: string;
-  en: string;
-  a1Bilingual: boolean;
-}): ReactElement {
-  if (a1Bilingual) {
-    return (
-      <>
-        <span lang="uk">{uk}</span>
-        <span className="btn-sub" lang="en">
-          / {en}
-        </span>
-      </>
-    );
-  }
+/** Dynamic chrome phrases (interpolated numbers) — pure locale via CSS, never slash-dual. */
+function PracticeChromeDual({ uk, en }: { uk: string; en: string }): ReactElement {
   return <ChromeDual en={en} uk={uk} />;
 }
 
@@ -178,12 +148,7 @@ const STREAK_KEY = 'lu-lexicon-practice-streak';
 const MASTERED_THRESHOLD = 21;
 type SessionPhase = 'idle' | 'active' | 'summary';
 
-const PRACTICE_LOAD_ERROR_UK = 'Не вдалося завантажити практику.';
-const PRACTICE_LOAD_ERROR_EN = 'We couldn’t load practice.';
-const PRACTICE_RETRY_UK = 'Спробувати ще раз';
-const PRACTICE_RETRY_EN = 'Try again';
-const PRACTICE_POOL_MISS_UK = 'Це слово ще не в тренажері.';
-const PRACTICE_POOL_MISS_EN = 'This word is not in the practice pool yet.';
+// Load/error chrome strings live in CHROME_STRINGS (practice.loadError / retry / poolMiss).
 
 function makePracticeSessionSeed(): number {
   return (Date.now() ^ Math.floor(Math.random() * 4294967296)) >>> 0;
@@ -220,7 +185,6 @@ function translateGrammarTerm(ukLabel: string): string {
   if (!ukLabel) return '';
   const norm = ukLabel.toLowerCase().trim();
   const parts = norm.split(/[\s,]+/);
-  
   if (norm.includes('відмінок')) {
     const caseName = parts.find(p => p !== 'відмінок' && p !== 'і' && CASE_GLOSSES[p]);
     const caseEn = caseName ? CASE_GLOSSES[caseName] : '';
@@ -1005,26 +969,9 @@ function resolvePracticeIndexItem(
   );
 }
 
-function BilingualPracticeMessage({
-  uk,
-  en,
-  showEnglishSubtitles,
-}: {
-  uk: string;
-  en: string;
-  showEnglishSubtitles: boolean;
-}) {
-  return (
-    <>
-      <span lang="uk">{uk}</span>
-      {showEnglishSubtitles ? (
-        <>
-          {' '}
-          <span lang="en">/ {en}</span>
-        </>
-      ) : null}
-    </>
-  );
+/** Pure-locale practice chrome message (both locales in DOM; CSS shows one). */
+function PureLocalePracticeMessage({ uk, en }: { uk: string; en: string }) {
+  return <ChromeDual uk={uk} en={en} />;
 }
 
 /** Bare hard-stem adjective case labels (`знахідний`) → «у знахідному відмінку». */
@@ -1197,8 +1144,8 @@ function LexiconPracticeIsland({
     obs.observe(el, { attributes: true, attributeFilter: ['data-chrome-locale'] });
     return () => obs.disconnect();
   }, []);
-  // A1 scaffolding stays bilingual regardless of chrome locale; EN chrome also
-  // dual-labels practice chrome (K3 A1 / Sol-approved data-chrome-locale).
+  // Content glosses only (A1 pedagogy + EN chrome). Practice chrome is pure
+  // chromeLocale via ChromeText/ChromeDual — never slash-dual (#5503).
   const showEnglishSubtitles = learnerLevel === 'A1' || chromeLocale === 'en';
 
   const matchedSelectedRatingRef = useRef<PracticeRating | null>(null);
@@ -1803,7 +1750,7 @@ function LexiconPracticeIsland({
       return nextDeck!;
     } catch {
       if (deckRequestId.current === requestId) {
-        setError(PRACTICE_LOAD_ERROR_UK);
+        setError(CHROME_STRINGS.uk['practice.loadError']);
       }
       return null;
     } finally {
@@ -1861,7 +1808,7 @@ function LexiconPracticeIsland({
       if (!resolvedItem) {
         // An index/lexeme deploy mismatch is a real data-load fault, not a word that
         // simply is not in the learner's available practice pool.
-        setError(PRACTICE_LOAD_ERROR_UK);
+        setError(CHROME_STRINGS.uk['practice.loadError']);
         setSessionPhase('idle');
         return;
       }
@@ -1874,7 +1821,7 @@ function LexiconPracticeIsland({
     } catch {
       // Only request failures reach the load fallback. A completed lookup miss remains
       // a usable hub with a concise bilingual notice.
-      setError(PRACTICE_LOAD_ERROR_UK);
+      setError(CHROME_STRINGS.uk['practice.loadError']);
       setSessionPhase('idle');
     } finally {
       setLoading(false);
@@ -2461,23 +2408,18 @@ function LexiconPracticeIsland({
   }
 
   return (
-    <section className="lexicon-practice" aria-label={showEnglishSubtitles ? "Практика слів дня / Words of the Day Practice" : "Практика слів дня"}>
+    <section className="lexicon-practice" aria-label={CHROME_STRINGS[chromeLocale]['practice.ariaLabel']}>
       {sessionPhase !== 'idle' || feedback ? (
       <p className="lexicon-practice-status" aria-live="polite">
         {feedback ? (
-          <>
-            <span lang="uk">{feedback.uk}</span>
-            {showEnglishSubtitles && feedback.en ? (
-              <span className="btn-sub" lang="en">/ {feedback.en}</span>
-            ) : null}
-          </>
+          <PureLocalePracticeMessage uk={feedback.uk} en={feedback.en ?? feedback.uk} />
         ) : sessionPhase === 'active' ? (
           <>
-            <PracticeChromeDual uk={`Сесія ${progressLabel}`} en={`Session ${progressLabel}`} a1Bilingual={learnerLevel === 'A1'} />
+            <PracticeChromeDual uk={`Сесія ${progressLabel}`} en={`Session ${progressLabel}`} />
           </>
         ) : (
           <>
-            <PracticeChromeLabel k="practice.sessionComplete" a1Bilingual={learnerLevel === 'A1'} />
+            <PracticeChromeLabel k="practice.sessionComplete" />
           </>
         )}
       </p>
@@ -2487,20 +2429,16 @@ function LexiconPracticeIsland({
         const warn = translateStorageWarning(storageWarning);
         return warn ? (
           <p className="lexicon-practice-warning" role="alert">
-            <span lang="uk">{warn.uk}</span>
-            {showEnglishSubtitles && warn.en ? (
-              <span className="btn-sub" lang="en">/ {warn.en}</span>
-            ) : null}
+            <PureLocalePracticeMessage uk={warn.uk} en={warn.en ?? warn.uk} />
           </p>
         ) : null;
       })()}
 
       {focusLookupMiss && (
         <p className="lexicon-practice-warning" role="status" data-testid="practice-lemma-missing">
-          <BilingualPracticeMessage
-            uk={PRACTICE_POOL_MISS_UK}
-            en={PRACTICE_POOL_MISS_EN}
-            showEnglishSubtitles={showEnglishSubtitles}
+          <PureLocalePracticeMessage
+            uk={CHROME_STRINGS.uk['practice.poolMiss']}
+            en={CHROME_STRINGS.en['practice.poolMiss']}
           />
         </p>
       )}
@@ -2524,7 +2462,7 @@ function LexiconPracticeIsland({
             >
               <span>
                 🎯 <strong>
-                  <PracticeChromeLabel k="practice.focusPractice" a1Bilingual={learnerLevel === 'A1'} />
+                  <PracticeChromeLabel k="practice.focusPractice" />
                 </strong> «{focusedLemmaId}»
               </span>
               <button
@@ -2540,7 +2478,7 @@ function LexiconPracticeIsland({
                   cursor: 'pointer'
                 }}
               >
-                <PracticeChromeLabel k="practice.clearFocus" a1Bilingual={learnerLevel === 'A1'} />
+                <PracticeChromeLabel k="practice.clearFocus" />
               </button>
             </div>
           )}
@@ -2774,26 +2712,19 @@ function LexiconPracticeIsland({
       )}
       {loading && (
         <p className="lexicon-practice-muted">
-          <PracticeChromeLabel k="practice.loading" a1Bilingual={learnerLevel === 'A1'} />
+          <PracticeChromeLabel k="practice.loading" />
         </p>
       )}
       {error && !selection && (
         <div className="lexicon-practice-fallback" data-testid="practice-fetch-error">
           <p className="lexicon-practice-warning">
-            <BilingualPracticeMessage
+            <PureLocalePracticeMessage
               uk={error}
-              en={PRACTICE_LOAD_ERROR_EN}
-              showEnglishSubtitles={showEnglishSubtitles}
+              en={CHROME_STRINGS.en['practice.loadError']}
             />
           </p>
           <button type="button" className="btn btn-accent" onClick={() => window.location.reload()}>
-            <span lang="uk">{PRACTICE_RETRY_UK}</span>
-            {showEnglishSubtitles ? (
-              <>
-                {' '}
-                <span className="btn-sub" lang="en">{PRACTICE_RETRY_EN}</span>
-              </>
-            ) : null}
+            <ChromeText k="practice.retry" />
           </button>
         </div>
       )}
@@ -2801,7 +2732,7 @@ function LexiconPracticeIsland({
       {sessionPhase === 'summary' && (
         <PracticeSessionSummary
           stats={summaryStats}
-          showEnglishSubtitles={showEnglishSubtitles}
+          chromeLocale={chromeLocale}
           onAnotherSession={() => {
             // A fresh «another session» is never a focus session — startSession(focus=null)
             // clears any weakness so the next session is the full pool for `mode`.
@@ -2815,17 +2746,14 @@ function LexiconPracticeIsland({
         <div className="lexicon-practice-stage-shell">
           <div className="lexicon-practice-stage-bar">
             <button type="button" className="stage-back" onClick={finishPractice}>
-              <PracticeChromeLabel k="practice.home" a1Bilingual={learnerLevel === 'A1'} />
+              <PracticeChromeLabel k="practice.home" />
             </button>
             <h2>
-              <span lang="uk">{stageTitleUk}</span>
-              {showEnglishSubtitles ? (
-                <span className="btn-sub" lang="en" style={{ fontSize: '0.65em', marginLeft: '8px' }}>/ {stageTitleEn}</span>
-              ) : null}
+              <PracticeChromeDual uk={stageTitleUk} en={stageTitleEn} />
             </h2>
             <span
               className="queue-pill"
-              aria-label={showEnglishSubtitles ? `Прогрес ${progressLabel} / Progress ${progressLabel}` : `Прогрес ${progressLabel}`}
+              aria-label={`${CHROME_STRINGS[chromeLocale]['practice.progress']} ${progressLabel}`}
               data-testid="practice-session-progress"
             >
               {progressLabel}
@@ -2834,7 +2762,7 @@ function LexiconPracticeIsland({
 
           {deck && deck.index.length === 0 && (
             <p className="lexicon-practice-muted">
-              <PracticeChromeLabel k="practice.noCards" a1Bilingual={learnerLevel === 'A1'} />
+              <PracticeChromeLabel k="practice.noCards" />
             </p>
           )}
 
@@ -2877,26 +2805,26 @@ function LexiconPracticeIsland({
                         data-testid="practice-advance-button"
                         onClick={advancePending}
                       >
-                        <PracticeChromeLabel k="practice.nextArrow" a1Bilingual={learnerLevel === 'A1'} />
+                        <PracticeChromeLabel k="practice.nextArrow" />
                       </button>
                     </div>
                   ) : null}
                 </>
               ) : mode === 'cloze' && deck.cloze.length === 0 ? (
                 <p className="lexicon-practice-muted" data-testid="practice-cloze-empty">
-                  <PracticeChromeLabel k="practice.clozePreparing" a1Bilingual={learnerLevel === 'A1'} />
+                  <PracticeChromeLabel k="practice.clozePreparing" />
                 </p>
               ) : mode === 'heritage' && (deck.heritage?.length ?? 0) === 0 ? (
                 <p className="lexicon-practice-muted" data-testid="practice-heritage-empty">
-                  <PracticeChromeLabel k="practice.heritagePreparing" a1Bilingual={learnerLevel === 'A1'} />
+                  <PracticeChromeLabel k="practice.heritagePreparing" />
                 </p>
               ) : mode === 'paronym' && (deck.paronym?.length ?? 0) === 0 ? (
                 <p className="lexicon-practice-muted" data-testid="practice-paronym-empty">
-                  <PracticeChromeLabel k="practice.paronymPreparing" a1Bilingual={learnerLevel === 'A1'} />
+                  <PracticeChromeLabel k="practice.paronymPreparing" />
                 </p>
               ) : (
                 <p className="lexicon-practice-muted">
-                  <PracticeChromeLabel k="practice.allCaughtUp" a1Bilingual={learnerLevel === 'A1'} />
+                  <PracticeChromeLabel k="practice.allCaughtUp" />
                 </p>
               )}
             </div>
@@ -2984,7 +2912,6 @@ function PracticeItem({
         ratingLabels={RATING_LABELS}
         intervalPreviews={intervalPreviews}
         onRate={onFlashcardRating}
-        showEnglishSubtitles={showEnglishSubtitles}
         chromeLocale={chromeLocale}
       />
     );
@@ -3175,7 +3102,7 @@ function PracticeItem({
     if (!pairs.length) {
       return (
         <p className="lexicon-practice-muted">
-          <PracticeChromeLabel k="practice.noMatchCards" a1Bilingual={learnerLevel === 'A1'} />
+          <PracticeChromeLabel k="practice.noMatchCards" />
         </p>
       );
     }
@@ -3192,7 +3119,7 @@ function PracticeItem({
               en={`Match pairs · ${matchedCount} of ${totalPairs}`}
             />
           )}
-          isUkrainian={!showEnglishSubtitles}
+          isUkrainian={chromeLocale === 'uk'}
           matchedPairCoding="semantic-four"
           onComplete={onMatchingComplete}
           onMatch={(pairIndex, rating) => {
@@ -3215,7 +3142,7 @@ function PracticeItem({
   if (!options.length) {
     return (
       <p className="lexicon-practice-muted">
-        <PracticeChromeLabel k="practice.noChoiceCards" a1Bilingual={learnerLevel === 'A1'} />
+        <PracticeChromeLabel k="practice.noChoiceCards" />
       </p>
     );
   }
@@ -3236,7 +3163,7 @@ function PracticeItem({
         ) : null}
       </p>
       <p className="mc-sub">
-        <PracticeChromeLabel k="practice.chooseCorrect" a1Bilingual={learnerLevel === 'A1'} />
+        <PracticeChromeLabel k="practice.chooseCorrect" />
       </p>
       <ul className="lexicon-option-list mc-options">
         {options.map((option, index) => (
@@ -3304,7 +3231,7 @@ function PracticeParonym({
   return (
     <div className="lexicon-paronym" data-testid="practice-paronym">
       <p className="paronym-task">
-        <PracticeChromeLabel k="practice.chooseParonym" a1Bilingual={learnerLevel === 'A1'} />
+        <PracticeChromeLabel k="practice.chooseParonym" />
       </p>
       <p className="paronym-sentence">
         <span>{before}</span>
@@ -3360,7 +3287,7 @@ function PracticeParonym({
               aria-label={CHROME_STRINGS[chromeLocale]['practice.openInAtlasTab']}
               style={{ fontSize: '0.85rem', textDecoration: 'underline', color: 'inherit', fontWeight: 'bold' }}
             >
-              <PracticeChromeLabel k="practice.openInAtlasArrow" a1Bilingual={learnerLevel === 'A1'} />
+              <PracticeChromeLabel k="practice.openInAtlasArrow" />
             </a>
           </div>
         </div>
@@ -3396,7 +3323,7 @@ function PracticeHeritage({
   return (
     <div className="lexicon-heritage" data-testid="practice-heritage">
       <p className="heritage-task">
-        <PracticeChromeLabel k="practice.chooseNative" a1Bilingual={learnerLevel === 'A1'} />
+        <PracticeChromeLabel k="practice.chooseNative" />
       </p>
       <p className="heritage-sentence">
         <span>{before}</span>
@@ -3437,7 +3364,7 @@ function PracticeHeritage({
               <PracticeChromeDual
                 uk={`Джерело: ${feedback.citations.join('; ')}`}
                 en={`Source: ${feedback.citations.join('; ')}`}
-                a1Bilingual={learnerLevel === 'A1'}
+               
               />
             </p>
           ) : null}
@@ -3461,7 +3388,7 @@ function PracticeHeritage({
               aria-label={CHROME_STRINGS[chromeLocale]['practice.openInAtlasTab']}
               style={{ fontSize: '0.85rem', textDecoration: 'underline', color: 'inherit', fontWeight: 'bold' }}
             >
-              <PracticeChromeLabel k="practice.openInAtlasArrow" a1Bilingual={learnerLevel === 'A1'} />
+              <PracticeChromeLabel k="practice.openInAtlasArrow" />
             </a>
           </div>
         </div>
@@ -3511,7 +3438,7 @@ function PracticeCloze({
         <PracticeChromeDual
           uk={`Поставте слово „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” у правильному відмінку.`}
           en={`Put the word „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” in the correct case.`}
-          a1Bilingual={learnerLevel === 'A1'}
+         
         />
       </p>
       <p className="cz-sentence">
@@ -3524,7 +3451,7 @@ function PracticeCloze({
       ) : null}
       {cloze.attribution ? (
         <p className="lexicon-cloze-attribution">
-          <PracticeChromeLabel k="practice.sentenceWith" a1Bilingual={learnerLevel === 'A1'} />{' '}
+          <PracticeChromeLabel k="practice.sentenceWith" />{' '}
           {cloze.attribution.sourceUrl ? (
             <a href={cloze.attribution.sourceUrl}>{cloze.attribution.source}</a>
           ) : (
@@ -3550,31 +3477,31 @@ function PracticeCloze({
           className="cz-input"
           value={input}
           disabled={answerLocked}
-          placeholder={showEnglishSubtitles ? 'введіть слово / type the word' : 'введіть слово'}
+          placeholder={CHROME_STRINGS[chromeLocale]['practice.typeWord']}
           autoComplete="off"
           autoCapitalize="off"
           autoCorrect="off"
           spellCheck={false}
           lang="uk"
           aria-label={
-            showEnglishSubtitles
-              ? `Відповідь ${casePhraseLocative(cloze.caseRule.caseLabel)} / Answer in ${translateGrammarTerm(cloze.caseRule.caseLabel)}`
+            chromeLocale === 'en'
+              ? `Answer in ${translateGrammarTerm(cloze.caseRule.caseLabel)}`
               : `Відповідь ${casePhraseLocative(cloze.caseRule.caseLabel)}`
           }
           onChange={(event) => onInput(event.currentTarget.value)}
         />
         <button className="btn btn-accent" type="submit" disabled={answerLocked}>
-          <PracticeChromeLabel k="practice.check" a1Bilingual={learnerLevel === 'A1'} />
+          <PracticeChromeLabel k="practice.check" />
         </button>
       </form>
       {optionErrors.length > 0 ? (
         <p className="lexicon-practice-warning">
-          <PracticeChromeLabel k="practice.clozeOptionsFailed" a1Bilingual={learnerLevel === 'A1'} />
+          <PracticeChromeLabel k="practice.clozeOptionsFailed" />
         </p>
       ) : (
         <>
           <div className="cz-or">
-            <PracticeChromeLabel k="practice.orChoose" a1Bilingual={learnerLevel === 'A1'} />
+            <PracticeChromeLabel k="practice.orChoose" />
           </div>
           <ul className="lexicon-option-list lexicon-cloze-options cz-options">
           {cloze.options.map((option) => (
@@ -3612,7 +3539,7 @@ function PracticeCloze({
               aria-label={CHROME_STRINGS[chromeLocale]['practice.openInAtlasTab']}
               style={{ fontSize: '0.85rem', textDecoration: 'underline', color: 'inherit', fontWeight: 'bold' }}
             >
-              <PracticeChromeLabel k="practice.openInAtlasArrow" a1Bilingual={learnerLevel === 'A1'} />
+              <PracticeChromeLabel k="practice.openInAtlasArrow" />
             </a>
           </div>
         </div>

--- a/site/src/components/PracticeErrorBoundary.tsx
+++ b/site/src/components/PracticeErrorBoundary.tsx
@@ -1,4 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import ChromeText, { ChromeDual } from '../lib/i18n/ChromeText';
+import { CHROME_STRINGS } from '../lib/i18n/chrome';
 
 interface PracticeErrorBoundaryProps {
   children: ReactNode;
@@ -27,12 +29,13 @@ export default class PracticeErrorBoundary extends Component<
       return (
         <div className="lexicon-practice-fallback" role="alert" data-testid="practice-error-fallback">
           <p className="lexicon-practice-warning">
-            <span lang="uk">Не вдалося завантажити практику. Спробуйте оновити сторінку.</span>{' '}
-            <span lang="en">/ We couldn’t load practice. Try reloading the page.</span>
+            <ChromeDual
+              uk={CHROME_STRINGS.uk['practice.loadErrorReload']}
+              en={CHROME_STRINGS.en['practice.loadErrorReload']}
+            />
           </p>
           <button type="button" className="btn btn-accent" onClick={() => window.location.reload()}>
-            <span lang="uk">Спробувати ще раз</span>{' '}
-            <span className="btn-sub" lang="en">Try again</span>
+            <ChromeText k="practice.retry" />
           </button>
         </div>
       );

--- a/site/src/components/PracticeFlashcard.tsx
+++ b/site/src/components/PracticeFlashcard.tsx
@@ -16,7 +16,7 @@ interface PracticeFlashcardProps {
   ratingLabels: Record<PracticeRating, { uk: string; en: string }>;
   intervalPreviews: Record<PracticeRating, string>;
   onRate(rating: PracticeRating): void;
-  showEnglishSubtitles: boolean;
+  /** Pure chrome locale for rating-button labels (#5503). */
   chromeLocale: ChromeLocale;
 }
 
@@ -27,7 +27,6 @@ export default function PracticeFlashcard({
   ratingLabels,
   intervalPreviews,
   onRate,
-  showEnglishSubtitles,
   chromeLocale,
 }: PracticeFlashcardProps) {
   const [flipped, setFlipped] = useState(false);
@@ -146,11 +145,8 @@ export default function PracticeFlashcard({
             onClick={() => handleRate(rating)}
           >
             <span className="rk">{index + 1}</span>
-            <span className="rt">
-              <span lang="uk">{ratingLabels[rating].uk}</span>
-              {showEnglishSubtitles ? (
-                <span className="btn-sub" lang="en">{ratingLabels[rating].en}</span>
-              ) : null}
+            <span className="rt" lang={chromeLocale}>
+              {ratingLabels[rating][chromeLocale]}
             </span>
             {flipped ? <span className="ri">‹{intervalPreviews[rating]}›</span> : null}
           </button>

--- a/site/src/components/PracticeSessionSummary.tsx
+++ b/site/src/components/PracticeSessionSummary.tsx
@@ -1,4 +1,5 @@
-import ChromeText from '../lib/i18n/ChromeText';
+import ChromeText, { ChromeDual } from '../lib/i18n/ChromeText';
+import type { ChromeLocale } from '../lib/i18n/chrome';
 import type { PracticeLexeme } from '../lib/lexicon/srs';
 
 export interface SessionSummaryStats {
@@ -12,51 +13,43 @@ export interface SessionSummaryStats {
 
 interface PracticeSessionSummaryProps {
   stats: SessionSummaryStats;
-  showEnglishSubtitles: boolean;
+  /** Pure chrome locale — summary UI never slash-duals (#5503). */
+  chromeLocale: ChromeLocale;
   onAnotherSession(): void;
   onDone(): void;
 }
 
 export default function PracticeSessionSummary({
   stats,
-  showEnglishSubtitles,
+  chromeLocale,
   onAnotherSession,
   onDone,
 }: PracticeSessionSummaryProps) {
+  // chromeLocale is the caller's pure-locale contract; ChromeText/ChromeDual
+  // render both locales and CSS on html[data-chrome-locale] shows one.
+  void chromeLocale;
   const total = stats.correct + stats.lapsed;
   return (
     <div className="lexicon-session-summary" data-testid="practice-session-summary">
       <h2 className="lexicon-session-summary-title">
-        <span lang="uk">Сесія завершена</span>
+        <ChromeText k="practice.sessionComplete" />
       </h2>
-      {showEnglishSubtitles ? (
-        <p className="lexicon-session-summary-sub" lang="en">Session complete</p>
-      ) : null}
       <dl className="lexicon-session-summary-stats">
         <div>
           <dt>
-            <span lang="uk">Правильно</span>
-            {showEnglishSubtitles ? (
-              <span className="btn-sub" lang="en">/ Correct</span>
-            ) : null}
+            <ChromeText k="practice.correctCount" />
           </dt>
           <dd>{stats.correct}</dd>
         </div>
         <div>
           <dt>
-            <span lang="uk">Помилки</span>
-            {showEnglishSubtitles ? (
-              <span className="btn-sub" lang="en">/ Lapsed</span>
-            ) : null}
+            <ChromeText k="practice.lapsedCount" />
           </dt>
           <dd>{stats.lapsed}</dd>
         </div>
         <div>
           <dt>
-            <span lang="uk">Серія</span>
-            {showEnglishSubtitles ? (
-              <span className="btn-sub" lang="en">/ Streak</span>
-            ) : null}
+            <ChromeText k="practice.streak" />
           </dt>
           <dd>🔥 {stats.streak}</dd>
         </div>
@@ -64,16 +57,15 @@ export default function PracticeSessionSummary({
           <dt>
             <ChromeText k="practice.score" />
           </dt>
-          <dd>{stats.correct}/{total}</dd>
+          <dd>
+            {stats.correct}/{total}
+          </dd>
         </div>
       </dl>
       {stats.advancedToReview.length > 0 ? (
         <section className="lexicon-session-advanced">
           <h3>
-            <span lang="uk">Перейшли на повторення</span>
-            {showEnglishSubtitles ? (
-              <span className="btn-sub" lang="en">/ Advanced to Review</span>
-            ) : null}
+            <ChromeText k="practice.advancedToReview" />
           </h3>
           <ul>
             {stats.advancedToReview.map((lemma) => (
@@ -84,19 +76,13 @@ export default function PracticeSessionSummary({
       ) : null}
       {stats.nextDueLabel ? (
         <p className="lexicon-session-next-due" data-testid="practice-next-due">
-          <span lang="uk">{stats.nextDueLabel.uk}</span>
-          {showEnglishSubtitles ? (
-            <span className="btn-sub" lang="en">/ {stats.nextDueLabel.en}</span>
-          ) : null}
+          <ChromeDual uk={stats.nextDueLabel.uk} en={stats.nextDueLabel.en} />
         </p>
       ) : null}
       {stats.deferredLemmas.length > 0 ? (
         <section className="lexicon-session-deferred" data-testid="practice-deferred-list">
           <h3>
-            <span lang="uk">Повторимо наступного разу</span>
-            {showEnglishSubtitles ? (
-              <span className="btn-sub" lang="en">/ will repeat next time</span>
-            ) : null}
+            <ChromeText k="practice.willRepeatNext" />
           </h3>
           <ul>
             {stats.deferredLemmas.map((lemma) => (
@@ -107,17 +93,15 @@ export default function PracticeSessionSummary({
       ) : null}
       <div className="lexicon-session-summary-actions">
         <button type="button" className="btn btn-accent" onClick={onAnotherSession}>
-          <span lang="uk">Ще одна сесія</span>
-          {showEnglishSubtitles ? <span className="btn-sub" lang="en">Another session</span> : null}
+          <ChromeText k="practice.anotherSession" />
         </button>
         <button type="button" className="btn" onClick={onDone}>
-          <span lang="uk">Готово</span>
-          {showEnglishSubtitles ? <span className="btn-sub" lang="en">Done</span> : null}
+          <ChromeText k="practice.done" />
         </button>
       </div>
       <figure className="lexicon-session-proverb">
         <blockquote lang="uk">«Терпи, козаче — отаманом будеш.»</blockquote>
-        <figcaption lang="uk">Українське прислів'я</figcaption>
+        <figcaption lang="uk">Українське прислів&apos;я</figcaption>
       </figure>
     </div>
   );

--- a/site/src/lib/i18n/chrome.ts
+++ b/site/src/lib/i18n/chrome.ts
@@ -311,6 +311,21 @@ const en = {
   'practice.sourcePrefix': 'Source:',
   'practice.orChoose': 'Or choose',
 
+  // Pure-locale chrome residuals (#5503) — one locale at a time, never slash-dual
+  'practice.ariaLabel': 'Words of the Day Practice',
+  'practice.typeWord': 'type the word',
+  'practice.anotherSession': 'Another session',
+  'practice.done': 'Done',
+  'practice.correctCount': 'Correct',
+  'practice.lapsedCount': 'Lapsed',
+  'practice.advancedToReview': 'Advanced to Review',
+  'practice.willRepeatNext': 'will repeat next time',
+  'practice.retry': 'Try again',
+  'practice.loadError': 'We couldn’t load practice.',
+  'practice.loadErrorReload': 'We couldn’t load practice. Try reloading the page.',
+  'practice.poolMiss': 'This word is not in the practice pool yet.',
+  'practice.progress': 'Progress',
+
   // Word Atlas entry chrome (#5435 reverse habit loop)
   'atlas.practiceThisWord': 'Practice this word →',
   'atlas.practiceUnavailable': 'Not in the practice pool yet',
@@ -593,6 +608,21 @@ const uk: Record<ChromeKey, string> = {
   'practice.clozeOptionsFailed': 'Варіанти для пропуску не пройшли перевірку.',
   'practice.sourcePrefix': 'Джерело:',
   'practice.orChoose': 'Або оберіть',
+
+  // Pure-locale chrome residuals (#5503) — one locale at a time, never slash-dual
+  'practice.ariaLabel': 'Практика слів дня',
+  'practice.typeWord': 'введіть слово',
+  'practice.anotherSession': 'Ще одна сесія',
+  'practice.done': 'Готово',
+  'practice.correctCount': 'Правильно',
+  'practice.lapsedCount': 'Помилки',
+  'practice.advancedToReview': 'Перейшли на повторення',
+  'practice.willRepeatNext': 'Повторимо наступного разу',
+  'practice.retry': 'Спробувати ще раз',
+  'practice.loadError': 'Не вдалося завантажити практику.',
+  'practice.loadErrorReload': 'Не вдалося завантажити практику. Спробуйте оновити сторінку.',
+  'practice.poolMiss': 'Це слово ще не в тренажері.',
+  'practice.progress': 'Прогрес',
 
   // Word Atlas entry chrome (#5435 reverse habit loop)
   'atlas.practiceThisWord': 'Практикувати це слово →',

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -740,7 +740,7 @@ describe('LexiconPractice', () => {
     expect(enriched.get(clozeOnly.lemmaId)?.exampleEn).toBe('I am reading a book.');
   });
 
-  test('practice render fallback is bilingual', () => {
+  test('practice render fallback dual-renders pure locale chrome (ChromeText/ChromeDual)', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     render(
@@ -750,9 +750,13 @@ describe('LexiconPractice', () => {
     );
 
     const fallback = screen.getByTestId('practice-error-fallback');
+    // Both locales in DOM; CSS on data-chrome-locale shows exactly one (#5503).
     expect(fallback).toHaveTextContent('Не вдалося завантажити практику. Спробуйте оновити сторінку.');
     expect(fallback).toHaveTextContent('We couldn’t load practice. Try reloading the page.');
-    expect(screen.getByRole('button', { name: /Спробувати ще раз\s*Try again/ })).toBeInTheDocument();
+    const retry = screen.getByRole('button', { name: /Try again|Спробувати ще раз/ });
+    expect(retry).toBeInTheDocument();
+    // No slash-dual button chrome.
+    expect(retry.textContent ?? '').not.toMatch(/\/\s*Try again|\/\s*Спробувати/);
   });
 
   test('eager-loads only the index (not lexemes/cloze) before a mode starts', async () => {
@@ -1490,7 +1494,7 @@ describe('LexiconPractice', () => {
     }
   });
 
-  test('a real deep-link fetch failure renders bilingual practice fallback', async () => {
+  test('a real deep-link fetch failure renders pure dual-locale practice fallback', async () => {
     const originalSearch = window.location.search;
     delete (window as any).location;
     window.location = new URL('http://localhost/words-of-the-day/practice/?lemmaId=%D0%BA%D0%B0%D1%84%D0%B5') as any;
@@ -1501,9 +1505,12 @@ describe('LexiconPractice', () => {
       render(<LexiconPractice />);
 
       const fallback = await screen.findByTestId('practice-fetch-error');
+      // ChromeDual/ChromeText put both locales in DOM; CSS shows one (#5503).
       expect(fallback).toHaveTextContent('Не вдалося завантажити практику.');
       expect(fallback).toHaveTextContent('We couldn’t load practice.');
-      expect(screen.getByRole('button', { name: /Спробувати ще раз\s*Try again/ })).toBeInTheDocument();
+      const retry = screen.getByRole('button', { name: /Try again|Спробувати ще раз/ });
+      expect(retry).toBeInTheDocument();
+      expect(retry.textContent ?? '').not.toMatch(/\/\s*Try again|\/\s*Спробувати/);
     } finally {
       window.location = new URL(originalSearch ? `http://localhost${originalSearch}` : 'http://localhost/') as any;
       vi.restoreAllMocks();
@@ -1579,21 +1586,31 @@ describe('LexiconPractice', () => {
     expect(denominator).toBeLessThan(1150);
   });
 
-  test("A1 renders English subtitles on chrome labels; A2 does not when chrome locale is uk", async () => {
+  test("A1 and A2 chrome aria-labels follow pure data-chrome-locale (no slash-dual)", async () => {
     document.documentElement.dataset.chromeLocale = "uk";
     localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A1");
     const { unmount } = render(<LexiconPractice />);
+    // #5503: A1 chrome is pure UK when locale is uk — English only in item content.
     expect(screen.getByRole("region")).toHaveAttribute(
       "aria-label",
-      "Практика слів дня / Words of the Day Practice",
+      "Практика слів дня",
     );
     unmount();
 
     localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A2");
-    render(<LexiconPractice />);
+    const { unmount: unmountA2 } = render(<LexiconPractice />);
     expect(screen.getByRole("region")).toHaveAttribute(
       "aria-label",
       "Практика слів дня",
+    );
+    unmountA2();
+
+    document.documentElement.dataset.chromeLocale = "en";
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A1");
+    render(<LexiconPractice />);
+    expect(screen.getByRole("region")).toHaveAttribute(
+      "aria-label",
+      "Words of the Day Practice",
     );
   });
 
@@ -1646,13 +1663,22 @@ describe('LexiconPractice', () => {
     });
   });
 
-  test("cloze placeholder is short and bilingual when chrome locale is en", async () => {
+  test("cloze placeholder is pure EN when chrome locale is en", async () => {
     document.documentElement.dataset.chromeLocale = "en";
     localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A2");
     const clozeDeck = sampleDeck();
     render(<LexiconPractice initialDeck={clozeDeck} autoStart initialMode="cloze" />);
     const input = await screen.findByRole("textbox");
-    expect(input.getAttribute("placeholder")).toBe("введіть слово / type the word");
+    expect(input.getAttribute("placeholder")).toBe("type the word");
+  });
+
+  test("cloze placeholder is pure UK when chrome locale is uk (including A1)", async () => {
+    document.documentElement.dataset.chromeLocale = "uk";
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, "A1");
+    const clozeDeck = sampleDeck();
+    render(<LexiconPractice initialDeck={clozeDeck} autoStart initialMode="cloze" />);
+    const input = await screen.findByRole("textbox");
+    expect(input.getAttribute("placeholder")).toBe("введіть слово");
   });
 
   test("atlas links announce new tab for screen readers in EN chrome", async () => {
@@ -3011,7 +3037,7 @@ describe('LexiconPractice', () => {
     const { container } = render(
       <PracticeSessionSummary
         stats={stats}
-        showEnglishSubtitles={false}
+        chromeLocale="uk"
         onAnotherSession={() => undefined}
         onDone={() => undefined}
       />,

--- a/site/tests/unit/practice-locale-purity.test.ts
+++ b/site/tests/unit/practice-locale-purity.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+/**
+ * Practice chrome locale purity (#5503 / #5376 family).
+ *
+ * Chrome must be one locale at a time (en | uk). A1 may keep English glosses
+ * inside activity item content, but never slash-dual chrome labels.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { CHROME_STRINGS, type ChromeKey } from '@site/src/lib/i18n/chrome';
+
+const ROOT = process.cwd();
+
+function readSrc(rel: string): string {
+  return readFileSync(resolve(ROOT, rel), 'utf8');
+}
+
+const PRACTICE_SOURCES = [
+  'src/components/LexiconPractice.tsx',
+  'src/components/PracticeSessionSummary.tsx',
+  'src/components/PracticeFlashcard.tsx',
+  'src/components/PracticeDailyDeck.tsx',
+  'src/components/PracticeErrorBoundary.tsx',
+  'src/components/PracticeFormRail.tsx',
+] as const;
+
+describe('practice chrome locale purity (#5503)', () => {
+  test('no a1Bilingual dual-chrome helpers remain', () => {
+    for (const rel of PRACTICE_SOURCES) {
+      const src = readSrc(rel);
+      expect(src, rel).not.toMatch(/a1Bilingual/);
+      expect(src, rel).not.toMatch(/PracticeChromeLabel[\s\S]{0,80}btn-sub/);
+    }
+  });
+
+  test('LexiconPractice does not force dual chrome via A1 || chromeLocale for chrome aria/placeholders', () => {
+    const src = readSrc('src/components/LexiconPractice.tsx');
+    // Region aria must key off chromeLocale, not showEnglishSubtitles dual slash.
+    expect(src).toContain("CHROME_STRINGS[chromeLocale]['practice.ariaLabel']");
+    expect(src).not.toMatch(
+      /aria-label=\{showEnglishSubtitles \? ["']Практика слів дня \/ Words/,
+    );
+    // Cloze chrome placeholder is pure locale-keyed, not slash-dual.
+    expect(src).toContain("CHROME_STRINGS[chromeLocale]['practice.typeWord']");
+    expect(src).not.toMatch(/введіть слово \/ type the word/);
+    // Progress aria is pure locale-keyed.
+    expect(src).toContain("CHROME_STRINGS[chromeLocale]['practice.progress']");
+    expect(src).not.toMatch(/Прогрес \$\{progressLabel\} \/ Progress/);
+  });
+
+  test('showEnglishSubtitles is documented as content-only (A1 item glosses)', () => {
+    const src = readSrc('src/components/LexiconPractice.tsx');
+    expect(src).toMatch(/Content glosses only/);
+    expect(src).toMatch(
+      /const showEnglishSubtitles = learnerLevel === 'A1' \|\| chromeLocale === 'en'/,
+    );
+  });
+
+  test('session summary and error boundary use ChromeText/ChromeDual, not slash duals', () => {
+    const summary = readSrc('src/components/PracticeSessionSummary.tsx');
+    expect(summary).toContain('ChromeText');
+    expect(summary).not.toMatch(/btn-sub/);
+    expect(summary).not.toMatch(/\/ Correct/);
+    expect(summary).not.toMatch(/showEnglishSubtitles/);
+
+    const boundary = readSrc('src/components/PracticeErrorBoundary.tsx');
+    expect(boundary).toContain('ChromeDual');
+    expect(boundary).toContain('ChromeText');
+    expect(boundary).not.toMatch(/btn-sub/);
+    expect(boundary).not.toMatch(/\/ We could/);
+  });
+
+  test('flashcard rating labels are pure chromeLocale (no dual EN subtitle under UK)', () => {
+    const src = readSrc('src/components/PracticeFlashcard.tsx');
+    expect(src).toContain('ratingLabels[rating][chromeLocale]');
+    expect(src).not.toMatch(/btn-sub/);
+    expect(src).not.toMatch(/showEnglishSubtitles/);
+  });
+
+  test('pure-locale practice.* keys exist in both en and uk', () => {
+    const purityKeys: ChromeKey[] = [
+      'practice.ariaLabel',
+      'practice.typeWord',
+      'practice.anotherSession',
+      'practice.done',
+      'practice.correctCount',
+      'practice.lapsedCount',
+      'practice.advancedToReview',
+      'practice.willRepeatNext',
+      'practice.retry',
+      'practice.loadError',
+      'practice.loadErrorReload',
+      'practice.poolMiss',
+      'practice.progress',
+    ];
+    for (const key of purityKeys) {
+      expect(CHROME_STRINGS.en[key].trim().length).toBeGreaterThan(0);
+      expect(CHROME_STRINGS.uk[key].trim().length).toBeGreaterThan(0);
+      // Values must not themselves be slash-dual strings.
+      expect(CHROME_STRINGS.en[key]).not.toMatch(/ \/ /);
+      expect(CHROME_STRINGS.uk[key]).not.toMatch(/ \/ /);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Practice UI chrome is now **one locale at a time** (`en` | `uk` via `html[data-chrome-locale]`), not mixed dual/slash labels.

After #5355 / #5479 the living site still showed hybrid chrome because A1 forced bilingual chrome labels (`a1Bilingual` / `showEnglishSubtitles` on chrome). Owner expects pure EN or pure UK chrome; A1 English scaffolding stays only for **item content** glosses.

### Changes
- Remove A1 slash-dual `PracticeChromeLabel` / `PracticeChromeDual` path
- Setup, session, summary, errors, placeholders, aria-labels, flashcard rating labels → pure `ChromeText` / `ChromeDual` / `CHROME_STRINGS[chromeLocale]`
- Keep `showEnglishSubtitles = A1 || chromeLocale === 'en'` for **item content only** (cloze EN, feedback glosses, drill prompts)
- Add pure-locale `practice.*` keys + `practice-locale-purity.test.ts` (#5376 family)
- Refresh `docs/lesson-schema.yaml` component hash/props

### Manual check note
No screenshots captured in this agent run (headless). Verify on `/words-of-the-day/practice/`:
1. Site locale toggle **EN** → pure English chrome (buttons, stage bar, summary, errors)
2. Site locale toggle **UK** → pure Ukrainian chrome even at **A1**
3. A1 still shows English **inside** cloze/choice item content when UK chrome is selected

## Test plan
- [x] `vitest` `practice-locale-purity.test.ts` (6)
- [x] `vitest` `practice-chrome-copy.test.ts` (2)
- [x] `vitest` `LexiconPractice.test.tsx` (95)
- [ ] CF review (GLM/Kimi preferred)
- [ ] Manual pure-EN and pure-UK pass on practice hub

Closes #5503
Refs #4700 #4387 #5355 #5376