### PR TITLE
fix(practice): weight practice selection by CEFR level

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: f84ed75a9c68b08ac614f2b627fc35fd192a1564dc6565cf683fbd362d1a9449
+  components_sha256: cb13611723173f08fd9ab53448230f54fc2a771f525772ed72323b23de4f0e4a
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/practice/cefr-difficulty-calibration.md
+++ b/docs/practice/cefr-difficulty-calibration.md
@@ -1,0 +1,54 @@
+# CEFR difficulty calibration — practice selection
+
+Issue: #5504 (related: #4700, #4387)
+
+## Current difficulty drivers
+
+1. **Shard filters / level cascade**
+   `LexiconPractice` loads every level up to the learner’s selected level via
+   `levelsUpTo()` and merges lower-level shards into the active deck for density
+   and SRS review coverage. This means a B1 session contains A1 and A2 items,
+   which can make the session feel too easy if they are not weighted.
+
+2. **Distractor pools**
+   `meaningDistractors()` already preferred same-CEFR distractors, but when a
+   level had too few eligible candidates it fell back to *any* other level.
+   A B1 answer could therefore be undermined by A1 distractors, or an A1 answer
+   could be ambushed by much harder vocabulary.
+
+3. **Cloze gaps**
+   Cloze items are only offered after the corresponding lemma reaches the
+   recognition-mastery threshold (`minRecognitionStability`). Until higher-level
+   recognition cards mature, lower-level cloze items dominate mixed sessions.
+
+4. **Synonym / paronym / heritage floors**
+   Drill-mode shards are sparser than core lexeme shards. In mixed mode this can
+   leave basic recognition items from lower levels over-represented.
+
+5. **Level bias only for new cards**
+   `selectNextPracticeItem()` previously applied a level preference only to
+   brand-new cards. Due and lapsed reviews from lower levels intermixed freely
+   with selected-level reviews.
+
+## Fixes
+
+- `rankCandidates()` now applies a **CEFR-distance penalty** to every candidate,
+  not just new cards. Within the same urgency bucket, items at the selected
+  learner level are preferred over lower-level items, while still preserving the
+  higher priority of due/lapsed cards and mode variety.
+
+- `meaningDistractors()` builds **concentric CEFR rings** around the answer.
+  It exhausts the closest ring before moving outward, keeping multiple-choice
+  options semantically comparable and preventing huge level leaps.
+
+- Existing mode eligibility is unchanged (index `modes` + recognition mastery
+  for cloze). Better item selection reduces the perceived dilution instead of
+  lowering quality bars by hiding valid reviews or easier modes.
+
+## Spot-check expectations
+
+- **A1**: only A1 items exist in the deck, so level bias is a no-op.
+- **A2**: A2 due reviews are preferred over same-urgency A1 reviews; a much
+  more overdue A1 card still wins because urgency is the primary sort key.
+- **B1**: B1 new cards and due reviews are preferred over A2/A1 ties; lower-
+  level cards still appear when they are genuinely due.

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -683,47 +683,61 @@ function orderedChoiceOptions(
   return options;
 }
 
-function meaningDistractors(
+function cefrRank(level: string): number {
+  return CEFR_LEVELS.indexOf(level as CefrLevel);
+}
+
+export function meaningDistractors(
   answer: PracticeLexeme,
   deck: PracticeDeckData,
   limit: number,
 ): PracticeLexeme[] {
   const answerHeadword = glossHeadword(answer);
   const answerLength = glossLabel(answer).length;
+  const answerRank = cefrRank(answer.cefr ?? 'A1');
   const candidatePool = deck.lexemes.filter(
     (candidate) =>
       candidate.lemmaId !== answer.lemmaId &&
       isMeaningMcEligible(candidate) &&
       glossHeadword(candidate) !== answerHeadword,
   );
-  const sameLevel = candidatePool.filter((candidate) => candidate.cefr === answer.cefr);
-  const candidates =
-    sameLevel.length >= limit
-      ? sameLevel
-      : [
-        ...sameLevel,
-        ...candidatePool.filter((candidate) => candidate.cefr !== answer.cefr),
-      ];
-  // PRIORITIZE same-POS + comparable gloss length via sort keys — never hard-filter
-  // the candidate pool down to a subset, which would starve distractors when a word
-  // has fewer than 3 same-POS peers even though hundreds of valid candidates exist.
+
+  // Build concentric CEFR rings around the answer. Distractors stay
+  // semantically comparable because we exhaust the closest ring before
+  // moving outward; this prevents a B1 answer from being undermined by A1
+  // distractors or an A1 answer from being ambushed by C1 vocabulary.
+  const rings = new Map<number, PracticeLexeme[]>();
+  for (const candidate of candidatePool) {
+    const gap = Math.abs(cefrRank(candidate.cefr ?? 'A1') - answerRank);
+    const bucket = rings.get(gap) ?? [];
+    bucket.push(candidate);
+    rings.set(gap, bucket);
+  }
+  const sortedGaps = [...rings.keys()].sort((left, right) => left - right);
+
   const seenLabels = new Set<string>();
-  return candidates
-    .sort((left, right) => {
-      const leftPos = left.pos === answer.pos ? 0 : 1;
-      const rightPos = right.pos === answer.pos ? 0 : 1;
-      if (leftPos !== rightPos) return leftPos - rightPos;
-      const leftLen = Math.abs(glossLabel(left).length - answerLength);
-      const rightLen = Math.abs(glossLabel(right).length - answerLength);
-      return leftLen - rightLen || left.lemmaId.localeCompare(right.lemmaId);
-    })
-    .filter((entry) => {
-      const key = glossLabel(entry).toLocaleLowerCase('en-US');
-      if (seenLabels.has(key)) return false;
-      seenLabels.add(key);
-      return true;
-    })
-    .slice(0, limit);
+  const result: PracticeLexeme[] = [];
+  for (const gap of sortedGaps) {
+    const ring = rings.get(gap) ?? [];
+    const picked = ring
+      .sort((left, right) => {
+        const leftPos = left.pos === answer.pos ? 0 : 1;
+        const rightPos = right.pos === answer.pos ? 0 : 1;
+        if (leftPos !== rightPos) return leftPos - rightPos;
+        const leftLen = Math.abs(glossLabel(left).length - answerLength);
+        const rightLen = Math.abs(glossLabel(right).length - answerLength);
+        return leftLen - rightLen || left.lemmaId.localeCompare(right.lemmaId);
+      })
+      .filter((entry) => {
+        const key = glossLabel(entry).toLocaleLowerCase('en-US');
+        if (seenLabels.has(key)) return false;
+        seenLabels.add(key);
+        return true;
+      });
+    result.push(...picked);
+    if (result.length >= limit) break;
+  }
+  return result.slice(0, limit);
 }
 
 function matchingPairs(selection: PracticeSelection, deck: PracticeDeckData, learnerLevel: CefrLevel) {

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -1487,9 +1487,18 @@ function urgencyBucket(candidate: PracticeSelection, nowTime: number): number {
   return Math.floor((candidate.due - nowTime) / HOUR_MS);
 }
 
+/**
+ * Prefer items at the selected learner level. The penalty is one rank per CEFR
+ * step below the selected level, so B1 sessions prefer B1 over A2 and A2 over A1
+ * when urgency and variety are otherwise tied. It never applies to items above
+ * the selected level because `levelsUpTo` never loads them, and it is a tiebreak
+ * only — a genuinely more-due lower-level card still wins.
+ */
 function levelMatchBias(candidate: PracticeSelection, deckLevel: string): number {
-  if (candidate.cardState) return 0;
-  return candidate.indexItem.cefr === deckLevel ? 0 : 1;
+  const deckRank = cefrRank(deckLevel);
+  const itemRank = cefrRank(candidate.indexItem.cefr);
+  if (deckRank < 0 || itemRank < 0) return 0;
+  return Math.max(0, deckRank - itemRank);
 }
 
 function applyPoolFilter(

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -1034,6 +1034,62 @@ describe('lexicon SRS facade', () => {
     );
   });
 
+  test('B1 sessions prefer B1 due reviews over same-urgency lower-level reviews', () => {
+    const state = loadState(localStorage, NOW);
+    state.cards.set(cardKey('a1-word', 'flashcards'), stateCard({ due: NOW.getTime() - HOUR_MS }));
+    state.cards.set(cardKey('b1-word', 'flashcards'), stateCard({ due: NOW.getTime() - HOUR_MS }));
+    saveState(state, localStorage, NOW.getTime());
+
+    const testDeck = flashcardDeck(
+      [
+        { id: 'a1-word', cefr: 'A1' },
+        { id: 'b1-word', cefr: 'B1' },
+      ],
+      'B1',
+    );
+    const selection = selectNextPracticeItem(testDeck, { now: NOW, modeFilter: 'flashcards' });
+
+    expect(selection?.lemma.lemmaId).toBe('b1-word');
+    expect(selection?.indexItem.cefr).toBe('B1');
+  });
+
+  test('A2 sessions prefer A2 due reviews over same-urgency A1 reviews', () => {
+    const state = loadState(localStorage, NOW);
+    state.cards.set(cardKey('a1-word', 'flashcards'), stateCard({ due: NOW.getTime() - HOUR_MS }));
+    state.cards.set(cardKey('a2-word', 'flashcards'), stateCard({ due: NOW.getTime() - HOUR_MS }));
+    saveState(state, localStorage, NOW.getTime());
+
+    const testDeck = flashcardDeck(
+      [
+        { id: 'a1-word', cefr: 'A1' },
+        { id: 'a2-word', cefr: 'A2' },
+      ],
+      'A2',
+    );
+    const selection = selectNextPracticeItem(testDeck, { now: NOW, modeFilter: 'flashcards' });
+
+    expect(selection?.lemma.lemmaId).toBe('a2-word');
+    expect(selection?.indexItem.cefr).toBe('A2');
+  });
+
+  test('urgency still beats level bias for lower-level overdue cards', () => {
+    const state = loadState(localStorage, NOW);
+    state.cards.set(cardKey('a1-word', 'flashcards'), stateCard({ due: NOW.getTime() - 3 * HOUR_MS }));
+    state.cards.set(cardKey('b1-word', 'flashcards'), stateCard({ due: NOW.getTime() }));
+    saveState(state, localStorage, NOW.getTime());
+
+    const testDeck = flashcardDeck(
+      [
+        { id: 'a1-word', cefr: 'A1' },
+        { id: 'b1-word', cefr: 'B1' },
+      ],
+      'B1',
+    );
+    const selection = selectNextPracticeItem(testDeck, { now: NOW, modeFilter: 'flashcards' });
+
+    expect(selection?.lemma.lemmaId).toBe('a1-word');
+  });
+
   test('seeded answer placement varies correct-answer positions across a session', () => {
     const positions = new Set(
       Array.from({ length: 20 }, (_, index) =>

--- a/site/tests/unit/practice-distractors.test.ts
+++ b/site/tests/unit/practice-distractors.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { meaningDistractors } from '@site/src/components/LexiconPractice';
+import { loadState } from '@site/src/lib/lexicon/srs';
+import type { PracticeDeckData, PracticeLexeme } from '@site/src/lib/lexicon/srs';
+
+const NOW = new Date('2026-06-23T12:00:00.000Z');
+
+function lexeme(lemmaId: string, cefr: string): PracticeLexeme {
+  return {
+    lemmaId,
+    lemma: lemmaId,
+    lemmaPlain: lemmaId,
+    gloss: `${lemmaId} gloss`,
+    ipa: null,
+    pos: 'noun',
+    cefr,
+    heritage: null,
+    severity: null,
+    paradigm: { cases: { nominative: { singular: lemmaId } } },
+  };
+}
+
+function deck(rows: { id: string; cefr: string }[]): PracticeDeckData {
+  return {
+    deckVersion: 'distractor-test',
+    level: rows[0]?.cefr ?? 'A1',
+    lexemes: rows.map((row) => lexeme(row.id, row.cefr)),
+    cloze: [],
+    stress: [],
+    classify: [],
+    paradigm: [],
+    synonym: [],
+    heritage: [],
+    index: rows.map((row, index) => ({
+      lemmaId: row.id,
+      lemma: row.id,
+      cefr: row.cefr,
+      modes: ['flashcards', 'choice'],
+      hasCloze: false,
+      clozeIds: [],
+      newOrder: index,
+    })),
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  loadState(localStorage, NOW);
+});
+
+describe('meaningDistractors', () => {
+  test('prefers same-CEFR distractors when enough exist', () => {
+    const rows = [
+      { id: 'answer', cefr: 'B1' },
+      ...Array.from({ length: 5 }, (_, index) => ({ id: `b1-${index}`, cefr: 'B1' })),
+      ...Array.from({ length: 5 }, (_, index) => ({ id: `a1-${index}`, cefr: 'A1' })),
+    ];
+    const testDeck = deck(rows);
+    const answer = testDeck.lexemes[0]!;
+
+    const distractors = meaningDistractors(answer, testDeck, 3);
+
+    expect(distractors).toHaveLength(3);
+    expect(distractors.every((candidate) => candidate.cefr === 'B1')).toBe(true);
+    expect(distractors.some((candidate) => candidate.lemmaId === 'answer')).toBe(false);
+  });
+
+  test('falls back to the next CEFR ring when same-level is exhausted', () => {
+    const rows = [
+      { id: 'answer', cefr: 'B1' },
+      { id: 'b1-peer', cefr: 'B1' },
+      ...Array.from({ length: 5 }, (_, index) => ({ id: `a2-${index}`, cefr: 'A2' })),
+    ];
+    const testDeck = deck(rows);
+    const answer = testDeck.lexemes[0]!;
+
+    const distractors = meaningDistractors(answer, testDeck, 3);
+
+    expect(distractors).toHaveLength(3);
+    expect(distractors[0]?.cefr).toBe('B1');
+    expect(distractors[1]?.cefr).toBe('A2');
+    expect(distractors[2]?.cefr).toBe('A2');
+  });
+
+  test('never returns the answer or a candidate with the same headword', () => {
+    const rows = [
+      { id: 'answer', cefr: 'A1' },
+      { id: 'answer-clone', cefr: 'A1' },
+      ...Array.from({ length: 5 }, (_, index) => ({ id: `peer-${index}`, cefr: 'A1' })),
+    ];
+    const testDeck = deck(rows);
+    // Force answer-clone to share the answer's headword by giving it the same gloss.
+    testDeck.lexemes[1] = { ...testDeck.lexemes[1]!, gloss: 'answer gloss' };
+    const answer = testDeck.lexemes[0]!;
+
+    const distractors = meaningDistractors(answer, testDeck, 3);
+
+    expect(distractors).toHaveLength(3);
+    expect(distractors.some((candidate) => candidate.lemmaId === 'answer')).toBe(false);
+    expect(distractors.some((candidate) => candidate.lemmaId === 'answer-clone')).toBe(false);
+  });
+
+  test('returns at most the requested limit', () => {
+    const rows = [
+      { id: 'answer', cefr: 'A2' },
+      ...Array.from({ length: 20 }, (_, index) => ({ id: `peer-${index}`, cefr: 'A2' })),
+    ];
+    const testDeck = deck(rows);
+    const answer = testDeck.lexemes[0]!;
+
+    const distractors = meaningDistractors(answer, testDeck, 3);
+
+    expect(distractors).toHaveLength(3);
+  });
+
+  test('returns fewer than limit when the pool is small', () => {
+    const rows = [
+      { id: 'answer', cefr: 'A1' },
+      { id: 'only-peer', cefr: 'A1' },
+    ];
+    const testDeck = deck(rows);
+    const answer = testDeck.lexemes[0]!;
+
+    const distractors = meaningDistractors(answer, testDeck, 3);
+
+    expect(distractors).toHaveLength(1);
+    expect(distractors[0]?.lemmaId).toBe('only-peer');
+  });
+});


### PR DESCRIPTION
## Root cause

Practice sessions merge every lower CEFR shard into the selected-level deck for density and SRS review coverage. The selector only preferred the selected level for *new* cards, so lower-level due reviews and distractors could make B1 sessions feel too easy.

## What changed

- `site/src/lib/lexicon/srs.ts`: `rankCandidates()` now applies a CEFR-distance penalty to **every** candidate (due/new/lapsed), making the selected learner level the preferred tiebreak within the same urgency bucket while keeping due/lapsed cards first.
- `site/src/components/LexiconPractice.tsx`: `meaningDistractors()` now builds concentric CEFR rings around the answer, exhausting the closest ring before moving outward so multiple-choice options stay semantically comparable.
- `docs/practice/cefr-difficulty-calibration.md`: documents the five difficulty drivers (shard filters, distractor pools, cloze gaps, synonym floors, level cascade) and the calibration fixes.
- Added/updated unit tests for A1/A2/B1 level bias and distractor pools.

## Tests

- `npx vitest run tests/unit/lexicon-srs.test.ts tests/unit/practice-session.test.ts tests/unit/practice-distractors.test.ts tests/unit/LexiconPractice.test.tsx` → **165 passed**.
- `scripts/audit/lint_agent_trailer.py` → PASS.
- `markdownlint-cli2` on the new doc → 0 errors.

Closes #5504. Related #4700, #4387.
