### PR TITLE
fix(bridge): fleet-comms residuals — reply sidecars, dual-write status, hygiene

### DIFF
--- a/agents_extensions/shared/session_streams/cli.py
+++ b/agents_extensions/shared/session_streams/cli.py
@@ -11,7 +11,14 @@ from pathlib import Path
 from typing import Any
 
 from .db import SessionStreamDatabase
-from .dual_write import ATLAS_HANDOFF_PATH, mirror_atlas_handoff
+from .dual_write import (
+    ATLAS_HANDOFF_PATH,
+    EPIC_HANDOFF_CANDIDATES,
+    list_handoff_candidates,
+    mirror_atlas_handoff,
+    mirror_handoff_file,
+    resolve_handoff_path,
+)
 from .hooks import clean_exit_hook, heartbeat_hook, lease_from_environment
 from .model import entry_as_dict
 from .store import NotFoundError, SessionStreamError, SessionStreamStore
@@ -140,6 +147,52 @@ Related:
             "Default: .claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md."
         ),
     )
+
+    mirror_handoff = subparsers.add_parser(
+        "mirror-handoff",
+        help="Mirror any registered epic file handoff into its stream (dual-write, no cutover).",
+        description=(
+            "Append a stable legacy handoff image under the exact lease. "
+            "Uses EPIC_HANDOFF_CANDIDATES when --source is omitted. Never edits or deletes the file."
+        ),
+    )
+    mirror_handoff.add_argument(
+        "--stream",
+        required=True,
+        help="Stream ID, for example epic:4387.",
+    )
+    mirror_handoff.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root. Default: current working directory.",
+    )
+    mirror_handoff.add_argument(
+        "--source",
+        type=Path,
+        default=None,
+        help="Optional handoff path (relative to --repo-root). Default: first existing registry path.",
+    )
+    mirror_handoff.add_argument(
+        "--profile",
+        default=None,
+        help="Mirror profile label (default: stream id without epic: prefix).",
+    )
+
+    status = subparsers.add_parser(
+        "dual-write-status",
+        help="List registered epic handoff paths and whether each file exists (no cutover).",
+        description=(
+            "Phase-2 dual-write inventory: which streams have on-disk handoffs ready to mirror. "
+            "Does not mutate the database."
+        ),
+    )
+    status.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root. Default: current working directory.",
+    )
     return parser
 
 
@@ -156,6 +209,10 @@ def main(argv: list[str] | None = None) -> int:
             return _hook(store, args)
         if args.command == "mirror-atlas":
             return _mirror_atlas(store, args)
+        if args.command == "mirror-handoff":
+            return _mirror_handoff(store, args)
+        if args.command == "dual-write-status":
+            return _dual_write_status(args)
         parser.error(f"unsupported command: {args.command}")
     except NotFoundError as exc:
         print(f"session-streams: {exc}", file=sys.stderr)
@@ -232,6 +289,62 @@ def _mirror_atlas(store: SessionStreamStore, args: argparse.Namespace) -> int:
                 "source_bytes": result.source_bytes,
                 "entry_id": result.entry.entry_id,
                 "mirror_id": result.mirror_id,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _mirror_handoff(store: SessionStreamStore, args: argparse.Namespace) -> int:
+    lease = lease_from_environment()
+    source = args.source
+    if source is None:
+        resolved = resolve_handoff_path(args.stream, args.repo_root)
+        if resolved is None:
+            known = ", ".join(EPIC_HANDOFF_CANDIDATES.get(args.stream, ())) or "(none registered)"
+            raise ValueError(
+                f"no existing handoff for {args.stream}; candidates: {known}; pass --source explicitly"
+            )
+        source = resolved
+    profile = args.profile or args.stream.removeprefix("epic:")
+    result = mirror_handoff_file(
+        store,
+        lease,
+        profile=profile,
+        repo_root=args.repo_root,
+        stream_id=args.stream,
+        source_path=source,
+    )
+    print(
+        json.dumps(
+            {
+                "profile": result.profile,
+                "source_path": result.source_path,
+                "source_sha256": result.source_sha256,
+                "source_bytes": result.source_bytes,
+                "entry_id": result.entry.entry_id,
+                "mirror_id": result.mirror_id,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _dual_write_status(args: argparse.Namespace) -> int:
+    rows = list_handoff_candidates(args.repo_root)
+    print("stream\texists\tpath")
+    for row in rows:
+        print(f"{row.stream_id}\t{int(row.exists)}\t{row.path}")
+    registered = sorted(EPIC_HANDOFF_CANDIDATES)
+    present = sorted({r.stream_id for r in rows if r.exists})
+    print(
+        json.dumps(
+            {
+                "registered_streams": registered,
+                "streams_with_file": present,
+                "cutover": "blocked — dual-write only; file handoffs remain authoritative",
             },
             sort_keys=True,
         )

--- a/agents_extensions/shared/session_streams/dual_write.py
+++ b/agents_extensions/shared/session_streams/dual_write.py
@@ -13,6 +13,28 @@ from .store import SessionStreamStore
 ATLAS_PROFILE = "atlas"
 ATLAS_HANDOFF_PATH = Path(".claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md")
 
+# Registry of known epic streams → primary file handoff paths for dual-write.
+# Phase-2 migration: mirror these under an active lease without retiring files.
+# Paths are relative to the repository root. First existing path wins per epic.
+EPIC_HANDOFF_CANDIDATES: dict[str, tuple[str, ...]] = {
+    "epic:4387": (
+        ".claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md",
+        ".claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md",
+    ),
+    "epic:4707": (
+        ".claude/harness-epic/CLAUDE-DRIVER-HANDOFF.md",
+        "docs/session-state/current.claude-infra.md",
+    ),
+    "epic:4542": (
+        ".claude/hramatka-epic/CLAUDE-DRIVER-HANDOFF.md",
+        "docs/session-state/current.claude-hramatka.md",
+    ),
+    "epic:4706": (
+        ".claude/bio-epic/CLAUDE-DRIVER-HANDOFF.md",
+        "docs/session-state/current.claude-bio.md",
+    ),
+}
+
 
 @dataclass(frozen=True)
 class MirrorResult:
@@ -22,6 +44,34 @@ class MirrorResult:
     source_bytes: int
     entry: Entry
     mirror_id: int
+
+
+@dataclass(frozen=True)
+class HandoffCandidate:
+    stream_id: str
+    path: Path
+    exists: bool
+
+
+def list_handoff_candidates(repo_root: Path) -> list[HandoffCandidate]:
+    """List configured epic handoff paths and whether each file exists."""
+    root = repo_root.resolve()
+    out: list[HandoffCandidate] = []
+    for stream_id, paths in EPIC_HANDOFF_CANDIDATES.items():
+        for rel in paths:
+            path = root / rel
+            out.append(HandoffCandidate(stream_id=stream_id, path=path, exists=path.is_file()))
+    return out
+
+
+def resolve_handoff_path(stream_id: str, repo_root: Path) -> Path | None:
+    """Return the first existing handoff path for a stream, if any."""
+    root = repo_root.resolve()
+    for rel in EPIC_HANDOFF_CANDIDATES.get(stream_id, ()):
+        path = root / rel
+        if path.is_file():
+            return path
+    return None
 
 
 def mirror_atlas_handoff(

--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -1,0 +1,62 @@
+# Fleet communication open gaps — runbook
+
+Status board for the three residual fleet-comms problems after Sol phases 0–5.
+
+## 1. Large ask replies — #5392
+
+**Problem:** Big review/diff replies could land as a short SQLite body with no
+marker that transport clipped them.
+
+**Fix (code):** `scripts/ai_agent_bridge/_reply_sidecar.py` + `send_message`.
+
+- Responses over `AB_REPLY_INLINE_MAX_BYTES` (default **12 KiB**), or that match
+  mid-deliverable tail heuristics, write the **full** body to
+  `batch_state/asks/<task-id>/reply-<agent>-<sha16>.md` (gitignored).
+- The messages-table body becomes a head excerpt + explicit footer:
+
+  ```
+  TRUNCATED: full reply offloaded to sidecar …
+  path: …
+  sha256: …
+  bytes: …
+  ```
+
+- Metadata JSON also carries `reply_sidecar: {path, sha256, bytes, truncated}`.
+
+**Operator:** when you see `TRUNCATED`, open the path — do not re-run the model
+just because the inline body looks short.
+
+## 2. Session-stream dual-write (not full cutover)
+
+**Shipped:** SQLite streams + phase-one CLI; live streams include
+`epic:4387` (atlas), `epic:4707` (infra), `epic:4542`, `epic:4706`.
+
+**This PR:** dual-write inventory without retiring files:
+
+```bash
+.venv/bin/python -m agents_extensions.shared.session_streams dual-write-status
+# under an active lease (SESSION_STREAM_* env):
+.venv/bin/python -m agents_extensions.shared.session_streams mirror-handoff \
+  --stream epic:4387
+```
+
+Registry: `EPIC_HANDOFF_CANDIDATES` in
+`agents_extensions/shared/session_streams/dual_write.py`.
+
+**Still blocked for cutover:** operator gate after per-harness acceptance;
+file handoffs remain authoritative until then.
+
+## 3. Hygiene residuals
+
+| Issue | Fix |
+| --- | --- |
+| **#5113** dead `gemini` inbox nags | Backlog warnings skip `dead_lane_agents()`; expire via `ab cleanup --expire` (already bulk-expires dead lanes). |
+| **#4915** empty body on background process | `assert_ask_content_present` on process paths — empty DB body fails as **transport**, not model stall. |
+| **#4956** disk retention | Read-only scanner: `.venv/bin/python scripts/hygiene/lane_disk_retention.py [--include-home] [--json]` |
+
+## Closeout checklist
+
+- [ ] #5392 — green tests for sidecar + TRUNCATED footer
+- [ ] dual-write-status returns registered streams
+- [ ] backlog warning does not mention `gemini` when it is a dead lane
+- [ ] empty-body process-ask records `transport empty-ask-body`

--- a/scripts/ai_agent_bridge/_ask_lifecycle.py
+++ b/scripts/ai_agent_bridge/_ask_lifecycle.py
@@ -193,6 +193,24 @@ def maybe_print_timeout_notice() -> None:
         conn.close()
 
 
+def assert_ask_content_present(msg: dict[str, Any], *, message_id: int, target: str) -> str:
+    """Return non-empty ask content or record a transport-leg failure (#4915).
+
+    Background workers must feed the model from the *stored* message body,
+    never from inherited stdin. An empty body is a transport bug, not a model
+    stall — surface that distinction so failover logic does not misattribute.
+    """
+    content = msg.get("content") if isinstance(msg, dict) else None
+    if isinstance(content, str) and content.strip():
+        return content
+    reason = (
+        f"transport empty-ask-body: message #{message_id} target={target} "
+        f"has no stored content (stdin was not re-read; body must come from DB)"
+    )
+    record_ask_failure(message_id, reason)
+    raise ValueError(reason)
+
+
 def fetch_ask_message(message_id: int, target: str) -> dict[str, Any] | None:
     """Load the original ask payload for one-shot processors."""
     conn = get_db()

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -845,9 +845,15 @@ def _query_inbox_show(agent: str) -> dict[str, Any]:
 
 
 def _pending_backlog_rows() -> list[dict[str, Any]]:
-    """Return pending-delivery backlog rows used for the warning banner."""
+    """Return pending-delivery backlog rows used for the warning banner.
+
+    Dead lanes (e.g. retired ``gemini`` → ``agy``) are excluded: they never
+    get drained by ``ab inbox run``, and nagging every CLI invocation is
+    pure noise (#5113). Expire them via ``ab cleanup --expire`` instead.
+    """
     from ._db import get_db
 
+    dead = _channels.dead_lane_agents()
     conn = get_db()
     try:
         rows = conn.execute(
@@ -870,12 +876,12 @@ def _pending_backlog_rows() -> list[dict[str, Any]]:
             "oldest_created_at": str(row["oldest_created_at"]),
         }
         for row in rows
-        if row["oldest_created_at"]
+        if row["oldest_created_at"] and str(row["to_agent"]) not in dead
     ]
 
 
 def _maybe_print_backlog_warnings() -> None:
-    """Emit one stderr warning per agent with stale pending deliveries.
+    """Emit one stderr warning per *live* agent with stale pending deliveries.
 
     Intentionally read-only — see ``run_delivery_expiry_cleanup`` (``ab
     cleanup --expire``) and the Monitor API server's periodic sweep
@@ -885,6 +891,9 @@ def _maybe_print_backlog_warnings() -> None:
     including e.g. ``ab cleanup --dry-run`` — would be a surprising,
     hard-to-predict side effect and would break dry-run's no-mutation
     contract.
+
+    Dead-lane queues are never warned here (#5113); run
+    ``ab cleanup --expire`` (or the Monitor sweep) to bulk-expire them.
     """
     threshold = timedelta(hours=_parse_backlog_warn_hours())
     now = _now_utc()

--- a/scripts/ai_agent_bridge/_cursor.py
+++ b/scripts/ai_agent_bridge/_cursor.py
@@ -83,6 +83,10 @@ def ask_cursor(
 def process_for_cursor(message_id: int, *, no_timeout: bool = False) -> None:
     """Process an existing Cursor ask, shared by sync and detached paths."""
     msg = fetch_ask_message(message_id, "cursor")
+    if msg is not None:
+        from ._ask_lifecycle import assert_ask_content_present
+
+        assert_ask_content_present(msg, message_id=message_id, target="cursor")
     if not msg:
         return
     model = ask_target_model(msg) or CURSOR_DEFAULT_MODEL

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -130,6 +130,11 @@ def process_for_grok_build(
     if not msg:
         return
 
+    from ._ask_lifecycle import assert_ask_content_present
+
+    # #4915: background workers must use the DB-stored body, never empty stdin.
+    assert_ask_content_present(msg, message_id=message_id, target="grok")
+
     _ = new_session  # grok resume_policy="never"; bridge calls are fresh.
     timeout_val = _resolve_grok_build_bridge_timeout(no_timeout)
     model = _extract_target_model(msg) or GROK_BUILD_DEFAULT_MODEL

--- a/scripts/ai_agent_bridge/_hermes.py
+++ b/scripts/ai_agent_bridge/_hermes.py
@@ -133,6 +133,10 @@ def ask_hermes(
 def process_for_hermes(message_id: int, *, no_timeout: bool = False) -> None:
     """Process an existing Hermes ask, shared by sync and detached paths."""
     msg = fetch_ask_message(message_id, "hermes")
+    if msg is not None:
+        from ._ask_lifecycle import assert_ask_content_present
+
+        assert_ask_content_present(msg, message_id=message_id, target="hermes")
     if not msg:
         return
     model = ask_target_model(msg) or HERMES_DEFAULT_MODEL

--- a/scripts/ai_agent_bridge/_messaging.py
+++ b/scripts/ai_agent_bridge/_messaging.py
@@ -107,9 +107,28 @@ def send_message(content: str, task_id: str | None = None, msg_type: str = "resp
                  from_model: str | None = None, to_model: str | None = None,
                  review_target: dict | None = None,
                  quiet: bool = False):
-    """Send a message between agents."""
+    """Send a message between agents.
+
+    Large ``response`` / ``error`` bodies are offloaded to a gitignored sidecar
+    under ``batch_state/asks/`` (#5392). The SQLite row then carries a head
+    excerpt plus an explicit ``TRUNCATED`` footer (path + sha256 + bytes) so
+    consumers never mistake a transport clip for a short model reply.
+    """
     content = redact_text(content) or ""
     data = redact_text(data) if data is not None else None
+
+    # #5392: sidecar large/truncated replies before INSERT so the durable full
+    # body exists even if the row only keeps an excerpt.
+    from ._reply_sidecar import maybe_sidecare_response
+
+    sidecar = maybe_sidecare_response(
+        content,
+        task_id=task_id,
+        from_llm=from_llm,
+        msg_type=msg_type,
+    )
+    content = sidecar.content
+
     conn = get_db()
     cursor = conn.cursor()
 
@@ -128,6 +147,13 @@ def send_message(content: str, task_id: str | None = None, msg_type: str = "resp
         metadata["to_model"] = to_model
     if review_target is not None:
         metadata["review_target"] = review_target
+    if sidecar.truncated and sidecar.sidecar_path:
+        metadata["reply_sidecar"] = {
+            "path": sidecar.sidecar_path,
+            "sha256": sidecar.full_sha256,
+            "bytes": sidecar.full_bytes,
+            "truncated": True,
+        }
 
     metadata = redact_value(metadata)
     data_json = json.dumps(metadata) if metadata else None

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -470,16 +470,20 @@ def process_for_opencode(
     msg = fetch_ask_message(message_id, target)
     if not msg:
         return
+    from ._ask_lifecycle import assert_ask_content_present
+
+    # #4915: feed the model from the stored message body only (never inherited stdin).
+    content = assert_ask_content_present(msg, message_id=message_id, target=target)
     model = ask_target_model(msg)
     if not model:
         raise ValueError(f"ask #{message_id} has no target model")
 
     kwargs: dict[str, object] = {"data": ask_attachment(msg), "no_timeout": no_timeout}
     if target == "opencode":
-        response = _invoke_opencode(msg["content"], model, **kwargs)
+        response = _invoke_opencode(content, model, **kwargs)
     elif target == "pool":
         response = _invoke_opencode(
-            msg["content"],
+            content,
             model,
             variant=variant or POOL_DEFAULT_VARIANT,
             output_format="json",
@@ -489,7 +493,7 @@ def process_for_opencode(
     elif target == "glm":
         _assert_glm_egress_allowed("process background ask-glm")
         response = _invoke_opencode(
-            msg["content"],
+            content,
             model,
             output_format="json",
             default_timeout_s=GLM_DEFAULT_TIMEOUT_S,
@@ -498,7 +502,7 @@ def process_for_opencode(
     elif target == "gemma":
         response = _strip_gemma_thought(
             _invoke_opencode(
-                msg["content"],
+                content,
                 model,
                 output_format="json",
                 default_timeout_s=GEMMA_DEFAULT_TIMEOUT_S,

--- a/scripts/ai_agent_bridge/_reply_sidecar.py
+++ b/scripts/ai_agent_bridge/_reply_sidecar.py
@@ -1,0 +1,191 @@
+"""Large ask-reply sidecar storage (#5392).
+
+Bridge consumers historically could not tell a short model reply from a body
+that transport/store truncated. This module:
+
+1. Always persists the full reply body to a gitignored file sidecar when the
+   body exceeds the inline threshold (or looks truncated mid-stream).
+2. Returns an **inline** message body that is either the full content (small)
+   or a head excerpt plus an explicit ``TRUNCATED`` footer with path + sha256
+   + byte count so readers fail loudly and can open the sidecar.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from ._config import REPO_ROOT
+
+# Default: keep small reviews fully inline; large coding deliverables go to disk.
+DEFAULT_INLINE_MAX_BYTES = 12 * 1024
+# How much of the head to keep in the SQLite ``messages.content`` row.
+DEFAULT_INLINE_HEAD_BYTES = 4 * 1024
+
+_SIDECAR_ROOT = REPO_ROOT / "batch_state" / "asks"
+
+# Heuristics for "model hit a hard stop mid-deliverable".
+_TRUNCATION_TAIL_RE = re.compile(
+    r"(?:"
+    r"complete unified diff:\s*$"
+    r"|```\s*$"
+    r"|Now the complete\b"
+    r"|here is the (?:full|complete)\b[^\n]{0,40}:\s*$"
+    r")",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ReplySidecarResult:
+    """Result of maybe writing a reply sidecar."""
+
+    content: str
+    """Body to store in the messages table (full or excerpt+footer)."""
+
+    sidecar_path: str | None
+    """Repo-relative path to the full body, if written."""
+
+    full_bytes: int
+    full_sha256: str
+    truncated: bool
+
+
+def _inline_max_bytes() -> int:
+    raw = os.environ.get("AB_REPLY_INLINE_MAX_BYTES", "").strip()
+    if raw:
+        try:
+            value = int(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return DEFAULT_INLINE_MAX_BYTES
+
+
+def _inline_head_bytes() -> int:
+    raw = os.environ.get("AB_REPLY_INLINE_HEAD_BYTES", "").strip()
+    if raw:
+        try:
+            value = int(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return DEFAULT_INLINE_HEAD_BYTES
+
+
+def looks_truncated(content: str) -> bool:
+    """Return True when the body ends in a mid-deliverable pattern."""
+    tail = content.rstrip()[-400:] if content else ""
+    if not tail:
+        return False
+    if _TRUNCATION_TAIL_RE.search(tail):
+        return True
+    # Unclosed fenced code block is a strong signal of length death.
+    return tail.count("```") % 2 == 1
+
+
+def _safe_task_segment(task_id: str | None) -> str:
+    if not task_id:
+        return "no-task"
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", task_id.strip())[:80]
+    return cleaned or "no-task"
+
+
+def write_reply_sidecar(
+    content: str,
+    *,
+    task_id: str | None,
+    from_llm: str,
+    msg_type: str = "response",
+) -> Path:
+    """Write the full reply body and return the absolute path."""
+    raw = content.encode("utf-8")
+    digest = hashlib.sha256(raw).hexdigest()
+    task_seg = _safe_task_segment(task_id)
+    agent_seg = re.sub(r"[^A-Za-z0-9._-]+", "-", (from_llm or "agent"))[:40] or "agent"
+    directory = _SIDECAR_ROOT / task_seg
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"reply-{agent_seg}-{digest[:16]}.md"
+    # Idempotent: same body → same path; rewrite is fine.
+    path.write_bytes(raw)
+    # Touch a tiny pointer for humans grepping the task dir.
+    pointer = directory / f"latest-{agent_seg}.path"
+    with contextlib.suppress(OSError):
+        pointer.write_text(path.name + "\n", encoding="utf-8")
+    return path
+
+
+def maybe_sidecare_response(
+    content: str,
+    *,
+    task_id: str | None,
+    from_llm: str,
+    msg_type: str,
+) -> ReplySidecarResult:
+    """Return content + optional sidecar metadata for a bridge message.
+
+    Only ``response`` (and ``error``) messages are candidates — asks themselves
+    stay fully inline so process-ask always loads the complete request.
+    """
+    full = content if content is not None else ""
+    raw = full.encode("utf-8")
+    digest = hashlib.sha256(raw).hexdigest()
+    full_bytes = len(raw)
+
+    if msg_type not in {"response", "error"}:
+        return ReplySidecarResult(
+            content=full,
+            sidecar_path=None,
+            full_bytes=full_bytes,
+            full_sha256=digest,
+            truncated=False,
+        )
+
+    force = looks_truncated(full)
+    if full_bytes <= _inline_max_bytes() and not force:
+        return ReplySidecarResult(
+            content=full,
+            sidecar_path=None,
+            full_bytes=full_bytes,
+            full_sha256=digest,
+            truncated=False,
+        )
+
+    path = write_reply_sidecar(full, task_id=task_id, from_llm=from_llm, msg_type=msg_type)
+    try:
+        rel = path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        rel = str(path)
+
+    head_limit = _inline_head_bytes()
+    # Cut on a UTF-8-safe boundary.
+    head = full
+    if full_bytes > head_limit:
+        head = full.encode("utf-8")[:head_limit].decode("utf-8", errors="ignore")
+        # Prefer ending at a line boundary for readability.
+        nl = head.rfind("\n")
+        if nl > head_limit // 2:
+            head = head[: nl + 1]
+
+    reason = "heuristic mid-deliverable end" if force and full_bytes <= _inline_max_bytes() else "size"
+    footer = (
+        f"\n\n---\n"
+        f"TRUNCATED: full reply offloaded to sidecar (reason={reason}).\n"
+        f"path: {rel}\n"
+        f"sha256: {digest}\n"
+        f"bytes: {full_bytes}\n"
+        f"Read the sidecar for the complete body; do not treat this excerpt as complete.\n"
+    )
+    return ReplySidecarResult(
+        content=head + footer,
+        sidecar_path=rel,
+        full_bytes=full_bytes,
+        full_sha256=digest,
+        truncated=True,
+    )

--- a/scripts/hygiene/lane_disk_retention.py
+++ b/scripts/hygiene/lane_disk_retention.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Lane disk-retention scanner (#4956).
+
+Policy (operator 2026-07-11):
+- Each lane cleans **its own** session stores and dispatch worktrees.
+- Dispatch worktrees that are merged → reap.
+- Dirty/unpushed worktrees older than **72h** → push+PR or declare abandonable.
+- Sessions/logs older than **14d** → archive then delete (manual / Drive).
+
+This script is **read-only by default** (``--dry-run``). It never deletes
+another lane's uncommitted work. Use ``--json`` for machine-readable output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WORKTREE_STALE_HOURS = 72
+DEFAULT_SESSION_STALE_DAYS = 14
+
+
+@dataclass(frozen=True)
+class WorktreeReport:
+    path: str
+    branch: str
+    age_hours: float
+    dirty: bool
+    ahead_of_remote: bool
+    recommendation: str
+
+
+def _git(args: list[str], *, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return (result.stdout or "").strip()
+
+
+def scan_dispatch_worktrees(
+    *,
+    repo_root: Path = REPO_ROOT,
+    stale_hours: float = DEFAULT_WORKTREE_STALE_HOURS,
+    now: float | None = None,
+) -> list[WorktreeReport]:
+    """Scan ``.worktrees/dispatch/**`` for stale / dirty / merged candidates."""
+    root = repo_root / ".worktrees" / "dispatch"
+    if not root.is_dir():
+        return []
+    clock = now if now is not None else time.time()
+    reports: list[WorktreeReport] = []
+    for agent_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+        for task_dir in sorted(p for p in agent_dir.iterdir() if p.is_dir()):
+            git_dir = task_dir / ".git"
+            if not git_dir.exists():
+                continue
+            mtime = task_dir.stat().st_mtime
+            age_hours = max((clock - mtime) / 3600.0, 0.0)
+            branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=task_dir) or "(unknown)"
+            status = _git(["status", "--porcelain"], cwd=task_dir)
+            dirty = bool(status)
+            ahead = False
+            counts = _git(["rev-list", "--left-right", "--count", "@{u}...HEAD"], cwd=task_dir)
+            if counts and "\t" in counts:
+                _behind, ahead_s = counts.split("\t", 1)
+                try:
+                    ahead = int(ahead_s) > 0
+                except ValueError:
+                    ahead = False
+            if age_hours < stale_hours and not dirty:
+                rec = "ok"
+            elif dirty and age_hours >= stale_hours:
+                rec = "stale-dirty: push+PR or mark abandonable on tracking issue, then reap"
+            elif ahead and age_hours >= stale_hours:
+                rec = "stale-unpushed: push branch / open PR or abandon + worktree remove"
+            elif age_hours >= stale_hours:
+                rec = "stale-clean: candidate for worktree remove if PR merged"
+            else:
+                rec = "active-dirty: finish or checkpoint soon"
+            reports.append(
+                WorktreeReport(
+                    path=str(task_dir.relative_to(repo_root)),
+                    branch=branch,
+                    age_hours=round(age_hours, 1),
+                    dirty=dirty,
+                    ahead_of_remote=ahead,
+                    recommendation=rec,
+                )
+            )
+    return reports
+
+
+def scan_home_session_hints(
+    *,
+    stale_days: float = DEFAULT_SESSION_STALE_DAYS,
+) -> list[dict[str, object]]:
+    """Non-destructive size/age hints for known session roots (home only)."""
+    home = Path.home()
+    candidates = [
+        home / ".codex",
+        home / ".claude",
+        home / ".cursor",
+        home / ".grok",
+    ]
+    clock = time.time()
+    out: list[dict[str, object]] = []
+    for path in candidates:
+        if not path.exists():
+            continue
+        try:
+            size = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+        except OSError:
+            size = -1
+        mtime = path.stat().st_mtime
+        age_days = max((clock - mtime) / 86400.0, 0.0)
+        out.append(
+            {
+                "path": str(path),
+                "size_gb": round(size / (1024**3), 2) if size >= 0 else None,
+                "age_days": round(age_days, 1),
+                "recommendation": (
+                    f"archive sessions older than {stale_days:g}d to Drive, then delete locally"
+                    if age_days >= stale_days
+                    else "within retention window"
+                ),
+            }
+        )
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--stale-hours", type=float, default=DEFAULT_WORKTREE_STALE_HOURS)
+    parser.add_argument("--session-stale-days", type=float, default=DEFAULT_SESSION_STALE_DAYS)
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON report")
+    parser.add_argument(
+        "--include-home",
+        action="store_true",
+        help="Also scan ~/.codex ~/.claude ~/.cursor ~/.grok size hints (read-only)",
+    )
+    args = parser.parse_args(argv)
+
+    worktrees = scan_dispatch_worktrees(
+        repo_root=args.repo_root,
+        stale_hours=args.stale_hours,
+    )
+    home = scan_home_session_hints(stale_days=args.session_stale_days) if args.include_home else []
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "worktrees": [asdict(w) for w in worktrees],
+                    "home_sessions": home,
+                    "policy": {
+                        "worktree_stale_hours": args.stale_hours,
+                        "session_stale_days": args.session_stale_days,
+                        "mutate": False,
+                    },
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    print(f"Dispatch worktrees under {args.repo_root / '.worktrees' / 'dispatch'} "
+          f"(stale ≥ {args.stale_hours:g}h): {len(worktrees)}")
+    for w in worktrees:
+        flags = []
+        if w.dirty:
+            flags.append("dirty")
+        if w.ahead_of_remote:
+            flags.append("ahead")
+        flag_s = f" [{','.join(flags)}]" if flags else ""
+        print(f"  {w.path}  branch={w.branch}  age={w.age_hours}h{flag_s}")
+        print(f"    → {w.recommendation}")
+    if home:
+        print("\nHome session roots (hints only):")
+        for row in home:
+            print(f"  {row['path']}  ~{row['size_gb']} GiB  age={row['age_days']}d")
+            print(f"    → {row['recommendation']}")
+    print(
+        "\nNo files were deleted. Reap merged worktrees with "
+        "`git worktree remove …` after PR merge; archive sessions to Drive per #4956."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_lane_disk_retention.py
+++ b/tests/test_lane_disk_retention.py
@@ -1,0 +1,39 @@
+"""Tests for the read-only lane disk retention scanner (#4956)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from scripts.hygiene.lane_disk_retention import scan_dispatch_worktrees
+
+
+def test_scan_dispatch_worktrees_empty(tmp_path: Path) -> None:
+    assert scan_dispatch_worktrees(repo_root=tmp_path) == []
+
+
+def test_scan_dispatch_worktrees_reports_stale(tmp_path: Path, monkeypatch) -> None:
+    wt = tmp_path / ".worktrees" / "dispatch" / "grok" / "old-task"
+    wt.mkdir(parents=True)
+    (wt / ".git").mkdir()
+    # Pretend git commands
+    def fake_git(args, *, cwd):
+        if args[:2] == ["rev-parse", "--abbrev-ref"]:
+            return "grok/old-task"
+        if args[0] == "status":
+            return " M file.py"
+        if args[0] == "rev-list":
+            return "0\t2"
+        return ""
+
+    monkeypatch.setattr("scripts.hygiene.lane_disk_retention._git", fake_git)
+    old = time.time() - (80 * 3600)
+    # set mtime via os.utime
+    import os
+
+    os.utime(wt, (old, old))
+    reports = scan_dispatch_worktrees(repo_root=tmp_path, stale_hours=72)
+    assert len(reports) == 1
+    assert reports[0].dirty is True
+    assert reports[0].ahead_of_remote is True
+    assert "stale" in reports[0].recommendation

--- a/tests/test_reply_sidecar.py
+++ b/tests/test_reply_sidecar.py
@@ -1,0 +1,189 @@
+"""Tests for large ask-reply sidecars (#5392) and empty-body transport guard (#4915)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ai_agent_bridge import _reply_sidecar
+from scripts.ai_agent_bridge._ask_lifecycle import assert_ask_content_present
+
+
+def test_looks_truncated_detects_mid_diff_tail():
+    body = "Here is analysis.\n\nNow the complete unified diff:\n"
+    assert _reply_sidecar.looks_truncated(body) is True
+
+
+def test_small_response_stays_inline(tmp_path, monkeypatch):
+    monkeypatch.setattr(_reply_sidecar, "_SIDECAR_ROOT", tmp_path / "asks")
+    monkeypatch.setenv("AB_REPLY_INLINE_MAX_BYTES", "10000")
+    result = _reply_sidecar.maybe_sidecare_response(
+        "short ok",
+        task_id="t-small",
+        from_llm="glm",
+        msg_type="response",
+    )
+    assert result.truncated is False
+    assert result.sidecar_path is None
+    assert result.content == "short ok"
+
+
+def test_large_response_writes_sidecar_and_truncated_footer(tmp_path, monkeypatch):
+    monkeypatch.setattr(_reply_sidecar, "_SIDECAR_ROOT", tmp_path / "asks")
+    monkeypatch.setenv("AB_REPLY_INLINE_MAX_BYTES", "200")
+    monkeypatch.setenv("AB_REPLY_INLINE_HEAD_BYTES", "80")
+    body = "A" * 500 + "\n## VERDICT: APPROVED\n"
+    result = _reply_sidecar.maybe_sidecare_response(
+        body,
+        task_id="t-large",
+        from_llm="pool",
+        msg_type="response",
+    )
+    assert result.truncated is True
+    assert result.sidecar_path is not None
+    assert "TRUNCATED" in result.content
+    assert f"bytes: {result.full_bytes}" in result.content
+    assert result.full_sha256 in result.content
+    candidates = list((tmp_path / "asks").rglob("reply-*.md"))
+    assert len(candidates) == 1
+    assert candidates[0].read_text(encoding="utf-8") == body
+
+
+def test_ask_query_never_sidecared(tmp_path, monkeypatch):
+    monkeypatch.setattr(_reply_sidecar, "_SIDECAR_ROOT", tmp_path / "asks")
+    monkeypatch.setenv("AB_REPLY_INLINE_MAX_BYTES", "10")
+    body = "Q" * 500
+    result = _reply_sidecar.maybe_sidecare_response(
+        body,
+        task_id="t-query",
+        from_llm="claude",
+        msg_type="query",
+    )
+    assert result.truncated is False
+    assert result.content == body
+
+
+def test_send_message_large_response_records_sidecar_metadata(tmp_path, monkeypatch):
+    from scripts.ai_agent_bridge import _messaging
+
+    monkeypatch.setattr(_reply_sidecar, "_SIDECAR_ROOT", tmp_path / "asks")
+    monkeypatch.setenv("AB_REPLY_INLINE_MAX_BYTES", "100")
+    monkeypatch.setenv("AB_REPLY_INLINE_HEAD_BYTES", "40")
+
+    db_path = tmp_path / "msg.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT, from_llm TEXT NOT NULL, to_llm TEXT NOT NULL,
+            message_type TEXT DEFAULT 'message', content TEXT NOT NULL,
+            data TEXT, timestamp TEXT NOT NULL, acknowledged INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'pending'
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+    def _fresh_conn():
+        return sqlite3.connect(str(db_path))
+
+    body = "B" * 400
+    with (
+        patch("scripts.ai_agent_bridge._messaging.get_db", side_effect=_fresh_conn),
+        patch("subprocess.run"),
+    ):
+        msg_id = _messaging.send_message(
+            body,
+            task_id="t-meta",
+            msg_type="response",
+            from_llm="glm",
+            to_llm="claude",
+            quiet=True,
+        )
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute("SELECT content, data FROM messages WHERE id = ?", (msg_id,)).fetchone()
+    conn.close()
+    assert "TRUNCATED" in row[0]
+    meta = json.loads(row[1])
+    assert meta["reply_sidecar"]["truncated"] is True
+    assert meta["reply_sidecar"]["bytes"] == len(body.encode("utf-8"))
+
+
+def test_assert_ask_content_present_ok():
+    text = assert_ask_content_present(
+        {"content": "hello world"},
+        message_id=1,
+        target="grok",
+    )
+    assert text == "hello world"
+
+
+def test_assert_ask_content_present_empty_raises_transport(tmp_path):
+    db_path = tmp_path / "msg.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT, from_llm TEXT NOT NULL, to_llm TEXT NOT NULL,
+            message_type TEXT DEFAULT 'message', content TEXT NOT NULL,
+            data TEXT, timestamp TEXT NOT NULL, acknowledged INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'pending'
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO messages (task_id, from_llm, to_llm, message_type, content, timestamp, status) "
+        "VALUES ('t', 'claude', 'grok', 'query', '', '2026-07-19T00:00:00Z', 'processing')"
+    )
+    mid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.commit()
+    conn.close()
+
+    def _fresh_conn():
+        return sqlite3.connect(str(db_path))
+
+    with patch("scripts.ai_agent_bridge._ask_lifecycle.get_db", side_effect=_fresh_conn):
+        with pytest.raises(ValueError, match="transport empty-ask-body"):
+            assert_ask_content_present({"content": ""}, message_id=mid, target="grok")
+
+        conn = sqlite3.connect(str(db_path))
+        status = conn.execute("SELECT status FROM messages WHERE id = ?", (mid,)).fetchone()[0]
+        conn.close()
+        assert status.startswith("failed:")
+        assert "transport empty-ask-body" in status
+
+
+def test_pending_backlog_skips_dead_lane(monkeypatch):
+    """#5113: warnings must not nag retired gemini deliveries."""
+    from scripts.ai_agent_bridge import _channels_cli
+
+    monkeypatch.setenv("AB_DEAD_LANES", "gemini")
+
+    class _Row(dict):
+        def __getitem__(self, key):
+            return dict.__getitem__(self, key)
+
+    fake_rows = [
+        _Row(to_agent="gemini", count=7, oldest_created_at="2026-07-01T00:00:00+00:00"),
+        _Row(to_agent="claude", count=1, oldest_created_at="2026-07-01T00:00:00+00:00"),
+    ]
+
+    class _Conn:
+        def execute(self, *_a, **_k):
+            class _R:
+                def fetchall(self_inner):
+                    return fake_rows
+
+            return _R()
+
+        def close(self):
+            return None
+
+    with patch("scripts.ai_agent_bridge._db.get_db", return_value=_Conn()):
+        rows = _channels_cli._pending_backlog_rows()
+    agents = {r["agent"] for r in rows}
+    assert "gemini" not in agents
+    assert "claude" in agents

--- a/tests/test_session_streams_dual_write_status.py
+++ b/tests/test_session_streams_dual_write_status.py
@@ -1,0 +1,33 @@
+"""dual-write-status / registry inventory for session streams."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agents_extensions.shared.session_streams.dual_write import (
+    EPIC_HANDOFF_CANDIDATES,
+    list_handoff_candidates,
+    resolve_handoff_path,
+)
+
+
+def test_registry_includes_atlas_and_infra():
+    assert "epic:4387" in EPIC_HANDOFF_CANDIDATES
+    assert "epic:4707" in EPIC_HANDOFF_CANDIDATES
+
+
+def test_list_handoff_candidates_marks_missing(tmp_path: Path):
+    rows = list_handoff_candidates(tmp_path)
+    assert rows
+    assert all(r.exists is False for r in rows)
+
+
+def test_resolve_handoff_path_first_existing(tmp_path: Path):
+    stream = "epic:4387"
+    candidates = EPIC_HANDOFF_CANDIDATES[stream]
+    # Create second candidate only
+    second = tmp_path / candidates[1]
+    second.parent.mkdir(parents=True, exist_ok=True)
+    second.write_text("handoff\n", encoding="utf-8")
+    resolved = resolve_handoff_path(stream, tmp_path)
+    assert resolved == second.resolve()


### PR DESCRIPTION
## Summary

Closes the three residual fleet-comms open problems after Sol phases 0–5:

| Gap | Fix |
| --- | --- |
| **#5392** silent truncation of large ask replies | Full body → `batch_state/asks/<task>/reply-*.md`; SQLite row gets head + explicit `TRUNCATED` footer (`path` / `sha256` / `bytes`) + `reply_sidecar` metadata |
| **Session-stream dual-write incomplete** | `EPIC_HANDOFF_CANDIDATES` registry + `dual-write-status` / `mirror-handoff` CLI (no cutover / file retirement) |
| **#4707 hygiene** | Skip dead-lane (gemini) backlog nags (**#5113**); `assert_ask_content_present` on process-ask (**#4915**); read-only worktree/session scanner (**#4956**) |

Runbook: `docs/runbooks/fleet-comms-open-gaps.md`

## Verification

```bash
.venv/bin/python -m pytest tests/test_reply_sidecar.py tests/test_lane_disk_retention.py tests/test_session_streams_dual_write_status.py -q
# 13 passed
```

## Operator notes

- After merge, run `ab cleanup --expire` once to bulk-expire any remaining gemini pending deliveries.
- Dual-write cutover remains operator-gated; files stay authoritative.

Closes #5392
Closes #5113
Closes #4915
Refs #4956 #4707 #5422

X-Agent: grok/comms-open-gaps