### PR TITLE
fix(track-completion): terminalize rejected rebuild preflight

### DIFF
--- a/agents_extensions/shared/skills/track-completion/schema/progress-ledger.v1.schema.json
+++ b/agents_extensions/shared/skills/track-completion/schema/progress-ledger.v1.schema.json
@@ -327,7 +327,7 @@
         "deferred_workflow_drift"
       ],
       "properties": {
-        "reason": {"enum": ["legacy-migration", "deferred-protocol-drift"]},
+        "reason": {"enum": ["legacy-migration", "deferred-protocol-drift", "preparation-remediated"]},
         "prior_run": {"$ref": "#/$defs/run"},
         "prior_state": {"type": "string", "minLength": 1},
         "prior_identity": {"$ref": "#/$defs/identity"},
@@ -345,6 +345,12 @@
         "deferred_workflow_drift": {
           "type": "array",
           "items": {"$ref": "#/$defs/deferredWorkflowDrift"}
+        },
+        "preparation_block": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref": "#/$defs/preparationBlock"}
+          ]
         }
       }
     },

--- a/agents_extensions/shared/skills/track-completion/schema/progress-ledger.v1.schema.json
+++ b/agents_extensions/shared/skills/track-completion/schema/progress-ledger.v1.schema.json
@@ -29,6 +29,7 @@
         "BUILD_REQUIRED",
         "PARTIAL_RECOVERY_REQUIRED",
         "POST_BUILD_REVIEW_REQUIRED",
+        "PREPARATION_BLOCKED",
         "REPAIR_REQUIRED",
         "BLOCKED_BUDGET_EXHAUSTED",
         "AUDIT_TOOLING_REQUIRED",
@@ -46,6 +47,7 @@
       ]
     },
     "current_identity": {"$ref": "#/$defs/identity"},
+    "preparation_block": {"$ref": "#/$defs/preparationBlock"},
     "author_families": {
       "type": "array",
       "uniqueItems": true,
@@ -165,7 +167,42 @@
         "status": {"enum": ["active", "completed"]},
         "started_at": {"$ref": "#/$defs/timestamp"},
         "updated_at": {"$ref": "#/$defs/timestamp"},
-        "lease_expires_at": {"$ref": "#/$defs/timestamp"}
+        "lease_expires_at": {"$ref": "#/$defs/timestamp"},
+        "lease_released_at": {"$ref": "#/$defs/timestamp"}
+      }
+    },
+    "preparationBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "disposition",
+        "reason_code",
+        "owner",
+        "reason",
+        "finding_ids",
+        "evidence_ids",
+        "unblock_condition",
+        "next_action"
+      ],
+      "properties": {
+        "disposition": {"const": "HOLD"},
+        "reason_code": {"const": "PREPARATION_REBUILD_PRECHECK_INCOMPLETE"},
+        "owner": {"const": "preparation"},
+        "reason": {"type": "string", "minLength": 1},
+        "finding_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "evidence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "unblock_condition": {"type": "string", "minLength": 1},
+        "next_action": {"const": "stop"}
       }
     },
     "identity": {

--- a/agents_extensions/shared/skills/track-completion/schema/progress-ledger.v1.schema.json
+++ b/agents_extensions/shared/skills/track-completion/schema/progress-ledger.v1.schema.json
@@ -143,6 +143,16 @@
       ]
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"state": {"const": "PREPARATION_BLOCKED"}},
+        "required": ["state"]
+      },
+      "then": {"required": ["preparation_block"]},
+      "else": {"not": {"required": ["preparation_block"]}}
+    }
+  ],
   "$defs": {
     "timestamp": {"type": "string", "format": "date-time"},
     "sha": {"type": "string", "pattern": "^[0-9a-f]{64}$"},

--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -65,6 +65,8 @@ BOUNDED_CONTRACT_PATH = SKILL_ROOT / "contracts" / "bounded-completion.v1.json"
 SELECTOR_RE = re.compile(r"^(?P<track>[a-z0-9-]+)/(?P<slug>[a-z0-9-]+)$")
 MATERIAL_SEVERITIES = frozenset({"blocker", "high", "medium"})
 TERMINAL_GOALS = frozenset({"merge", "certify", "deploy"})
+PREPARATION_BLOCKED_STATE = "PREPARATION_BLOCKED"
+PREPARATION_BLOCK_REASON_CODE = "PREPARATION_REBUILD_PRECHECK_INCOMPLETE"
 MUTATING_STATES = frozenset(
     {
         "PLAN_REPAIR_REQUIRED",
@@ -1013,6 +1015,69 @@ def _renew_lease(ledger: dict[str, Any], config: Mapping[str, Any]) -> None:
     ledger["run"]["lease_expires_at"] = _iso(now + timedelta(seconds=int(config["lease_seconds"])))
 
 
+def _preparation_block_record(readiness: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the durable HOLD record from one canonical readiness result."""
+    finding_ids = sorted(
+        {
+            str(finding["id"])
+            for finding in readiness["findings"]
+            if isinstance(finding, Mapping) and isinstance(finding.get("id"), str)
+        }
+    )
+    evidence_ids = sorted(
+        {
+            f"{source['role']}:{source['path']}:{source['sha256'] or 'missing'}"
+            for source in readiness["sources"]
+            if isinstance(source, Mapping)
+            and isinstance(source.get("role"), str)
+            and isinstance(source.get("path"), str)
+            and (isinstance(source.get("sha256"), str) or source.get("sha256") is None)
+        }
+    )
+    if not finding_ids or not evidence_ids:
+        raise CompletionError("Incomplete preparation has no canonical finding or evidence identity")
+    return {
+        "disposition": "HOLD",
+        "reason_code": PREPARATION_BLOCK_REASON_CODE,
+        "owner": "preparation",
+        "reason": "Preparation requirements are incomplete; do not rebuild or begin post-build review.",
+        "finding_ids": finding_ids,
+        "evidence_ids": evidence_ids,
+        "unblock_condition": (
+            "Resolve every failed preparation requirement and clear any active reviewed preparation hold "
+            "before starting a new completion run."
+        ),
+        "next_action": "stop",
+    }
+
+
+def _terminalize_preparation_block(
+    ledger: dict[str, Any],
+    *,
+    event_id: str,
+    identity: Mapping[str, Any],
+    block: Mapping[str, Any],
+) -> None:
+    """Persist one terminal preparation HOLD and release its completion lease."""
+    _append_event(
+        ledger,
+        event_id=event_id,
+        event="PREPARATION_REBUILD_BLOCKED",
+        to_state=PREPARATION_BLOCKED_STATE,
+        identity=identity,
+        details={"preparation_block": dict(block)},
+    )
+    now = _iso(_now())
+    ledger["preparation_block"] = dict(block)
+    ledger["routing"] = None
+    ledger["publication"] = None
+    ledger["production_qg_authorization"] = None
+    ledger["run"]["status"] = "completed"
+    ledger["run"]["updated_at"] = now
+    ledger["run"]["lease_expires_at"] = now
+    ledger["run"]["lease_released_at"] = now
+
+
 def _require_run(ledger: dict[str, Any], run_id: str, config: Mapping[str, Any]) -> None:
     run = ledger["run"]
     if run["run_id"] != run_id:
@@ -1507,6 +1572,15 @@ def request_preparation_rebuild(
     path = ledger_path_for(snapshot, repo_root=repo_root, config=config, ledger_root=ledger_root)
     try:
         with _with_lock(path):
+            existing = _read_ledger(path)
+            if (
+                existing is not None
+                and existing.get("run", {}).get("run_id") == run_id
+                and existing.get("state") == PREPARATION_BLOCKED_STATE
+                and existing.get("run", {}).get("status") == "completed"
+                and isinstance(existing.get("preparation_block"), Mapping)
+            ):
+                return path, existing
             config, snapshot, identity, path, ledger = _load_for_update(
                 selector, run_id, repo_root=repo_root, config_path=config_path, ledger_root=ledger_root
             )
@@ -1549,7 +1623,17 @@ def request_preparation_rebuild(
             if readiness["state"] != "built-preparation-drift":
                 raise CompletionError("Current preparation does not require a rebuild")
             if not current_preparation_identity or not all(item["passed"] for item in readiness["requirements"]):
-                raise CompletionError("Preparation requirements must pass before routing the bundle to rebuild")
+                block = _preparation_block_record(readiness)
+                eid = _event_id("PREPARATION_REBUILD_BLOCKED", block)
+                _terminalize_preparation_block(
+                    ledger,
+                    event_id=eid,
+                    identity=identity,
+                    block=block,
+                )
+                _validate(ledger, LEDGER_SCHEMA_PATH, "track-completion ledger")
+                _atomic_write_json(path, ledger)
+                return path, ledger
             _append_event(
                 ledger,
                 event_id=eid,
@@ -2849,6 +2933,18 @@ def certification_projection(
             deployment="unknown",
             final="not-certified",
             reason="ledger has no explicit terminal goal",
+        )
+    preparation_block = ledger.get("preparation_block")
+    if ledger["state"] == PREPARATION_BLOCKED_STATE and isinstance(preparation_block, Mapping):
+        return result(
+            PREPARATION_BLOCKED_STATE,
+            post_build="preparation-blocked",
+            independent_review="not-applicable",
+            integration="not-applicable",
+            production_qg="not-applicable",
+            deployment="not-applicable",
+            final="preparation-blocked",
+            reason=str(preparation_block["reason"]),
         )
     bounded = _bounded_record(ledger)
     if (

--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -1059,15 +1059,26 @@ def _terminalize_preparation_block(
     block: Mapping[str, Any],
 ) -> None:
     """Persist one terminal preparation HOLD and release its completion lease."""
-    _append_event(
-        ledger,
-        event_id=event_id,
-        event="PREPARATION_REBUILD_BLOCKED",
-        to_state=PREPARATION_BLOCKED_STATE,
-        identity=identity,
-        details={"preparation_block": dict(block)},
-    )
+    existing_event = next((event for event in ledger["history"] if event["event_id"] == event_id), None)
+    if existing_event is not None:
+        if (
+            existing_event["event"] != "PREPARATION_REBUILD_BLOCKED"
+            or existing_event["to_state"] != PREPARATION_BLOCKED_STATE
+            or existing_event["details"] != {"preparation_block": dict(block)}
+        ):
+            raise CompletionError("Preparation-block terminal event conflicts with existing history")
+    else:
+        _append_event(
+            ledger,
+            event_id=event_id,
+            event="PREPARATION_REBUILD_BLOCKED",
+            to_state=PREPARATION_BLOCKED_STATE,
+            identity=identity,
+            details={"preparation_block": dict(block)},
+        )
     now = _iso(_now())
+    ledger["state"] = PREPARATION_BLOCKED_STATE
+    ledger["current_identity"] = dict(identity)
     ledger["preparation_block"] = dict(block)
     ledger["routing"] = None
     ledger["publication"] = None
@@ -1718,7 +1729,9 @@ def request_preparation_rebuild(
                 raise CompletionError("Current preparation does not require a rebuild")
             if not current_preparation_identity or not all(item["passed"] for item in readiness["requirements"]):
                 block = _preparation_block_record(readiness)
-                eid = _event_id("PREPARATION_REBUILD_BLOCKED", block)
+                eid = _event_id(
+                    "PREPARATION_REBUILD_BLOCKED", {"run_id": ledger["run"]["run_id"], "block": block}
+                )
                 _terminalize_preparation_block(
                     ledger,
                     event_id=eid,

--- a/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
+++ b/agents_extensions/shared/skills/track-completion/scripts/track_completion.py
@@ -1147,6 +1147,84 @@ def _with_lock(path: Path) -> FileLock:
     return FileLock(str(path.with_suffix(path.suffix + ".lock")), timeout=0)
 
 
+def _restart_remediated_preparation_block(
+    ledger: dict[str, Any],
+    *,
+    owner: str,
+    snapshot: TargetSnapshot,
+    identity: Mapping[str, Any],
+    config: Mapping[str, Any],
+    repo_root: Path,
+) -> None:
+    """Archive one remediated preparation HOLD and open its fresh completion run."""
+    try:
+        readiness = curriculum_readiness.evaluate_preparation(
+            snapshot.track,
+            snapshot.slug,
+            consumed_preparation_identity=_consumed_preparation_identity(ledger),
+            repo_root=repo_root,
+        )
+    except curriculum_readiness.ReadinessError as exc:
+        raise CompletionError(f"Current preparation cannot be evaluated: {exc}") from exc
+    if (
+        not readiness["preparation_identity"]
+        or not all(item["passed"] for item in readiness["requirements"])
+        or readiness["next_action"] == "stop"
+    ):
+        raise CompletionError(
+            "Preparation-blocked run remains terminal until canonical preparation is complete and unheld"
+        )
+    prior_run = dict(ledger["run"])
+    archive = {
+        "reason": "preparation-remediated",
+        "prior_run": prior_run,
+        "prior_state": ledger["state"],
+        "prior_identity": dict(ledger["current_identity"]),
+        "reviews": list(ledger["reviews"]),
+        "certification_evidence": list(ledger.get("certification_evidence", [])),
+        "routing": ledger.get("routing"),
+        "publication": ledger.get("publication"),
+        "production_qg_authorization": ledger.get("production_qg_authorization"),
+        "bounded_completion": _bounded_record(ledger),
+        "deferred_workflow_drift": list(ledger.get("deferred_workflow_drift", [])),
+        "preparation_block": dict(ledger["preparation_block"]),
+    }
+    now = _now()
+    fresh_run_id = uuid.uuid4().hex
+    ledger["run"] = {
+        "run_id": fresh_run_id,
+        "owner": owner,
+        "status": "active",
+        "started_at": _iso(now),
+        "updated_at": _iso(now),
+        "lease_expires_at": _iso(now + timedelta(seconds=int(config["lease_seconds"]))),
+    }
+    ledger.setdefault("archived_authority", []).append(archive)
+    ledger["author_families"] = []
+    ledger["reviews"] = []
+    ledger["certification_evidence"] = []
+    ledger["routing"] = None
+    ledger["publication"] = None
+    ledger["production_qg_authorization"] = None
+    ledger["bounded_completion"] = None
+    ledger["deferred_workflow_drift"] = []
+    ledger.pop("preparation_block")
+    _append_event(
+        ledger,
+        event_id=_event_id(
+            "PREPARATION_BLOCK_REMEDIATED", {"prior_run_id": prior_run["run_id"], "run_id": fresh_run_id}
+        ),
+        event="PREPARATION_BLOCK_REMEDIATED",
+        to_state=_initial_state(snapshot.module_state),
+        identity=identity,
+        details={
+            "prior_run_id": prior_run["run_id"],
+            "fresh_run_id": fresh_run_id,
+            "readiness_preparation_identity": readiness["preparation_identity"],
+        },
+    )
+
+
 def start_run(
     selector: str,
     *,
@@ -1176,6 +1254,22 @@ def start_run(
                         f"Existing ledger terminal goal is {existing['terminal_goal']}; refusing {terminal_goal}"
                     )
                 run = existing["run"]
+                if (
+                    run["status"] == "completed"
+                    and existing["state"] == PREPARATION_BLOCKED_STATE
+                    and isinstance(existing.get("preparation_block"), Mapping)
+                ):
+                    _restart_remediated_preparation_block(
+                        existing,
+                        owner=owner,
+                        snapshot=snapshot,
+                        identity=identity,
+                        config=config,
+                        repo_root=repo_root,
+                    )
+                    _validate(existing, LEDGER_SCHEMA_PATH, "track-completion ledger")
+                    _atomic_write_json(path, existing)
+                    return path, existing
                 if run["status"] == "completed" and existing["current_identity"]["sha256"] == identity["sha256"]:
                     return path, existing
                 if run["status"] == "active" and _parse_time(run["lease_expires_at"]) > _now():

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -306,6 +306,48 @@ def _prepare_review(
     )
 
 
+def _set_bio_manual_preparation_gate(repo: Path) -> None:
+    """Keep the remediable BIO preflight fixture independent of learner files."""
+    path = repo / "agents_extensions/shared/curriculum-lifecycle/config/readiness-profiles.v1.yaml"
+    profiles = yaml.safe_load(path.read_text(encoding="utf-8"))
+    profiles["profiles"]["bio"]["requirements"] = [
+        {
+            "id": "dossier-grounding",
+            "owner": "preparation",
+            "options": [
+                {
+                    "artifact": "manual-registry",
+                    "validators": ["exists", "manual-gate"],
+                    "manual_gate": "dossier_grounding",
+                }
+            ],
+        }
+    ]
+    path.write_text(yaml.safe_dump(profiles, sort_keys=False), encoding="utf-8")
+
+
+def _write_bio_dossier_grounding(repo: Path) -> None:
+    _write(
+        repo / "curriculum/l2-uk-en/bio/promotion-evidence.yaml",
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "entries": {
+                    "seminar-built": {
+                        "dossier_grounding": {
+                            "status": "pass",
+                            "reviewer_family": "gemini",
+                            "evidence_url": "https://example.test/bio/dossier-grounding",
+                            "date": "2026-07-19",
+                        }
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+    )
+
+
 def test_current_certification_profiles_require_post_build_review_v5() -> None:
     path = ROOT / "agents_extensions/shared/curriculum-lifecycle/config/certification-profiles.v1.yaml"
     config = yaml.safe_load(path.read_text(encoding="utf-8"))
@@ -736,6 +778,7 @@ def test_preparation_rebuild_terminalizes_incomplete_inputs_and_preserves_learne
     fake_repo: tuple[Path, Path, Path],
 ) -> None:
     repo, config_path, ledger_root = fake_repo
+    _set_bio_manual_preparation_gate(repo)
     path, bio_ledger = _start(fake_repo, "bio/seminar-built")
     # Regression shape for #5455: a built BIO run began but had only STARTED,
     # leaving no final event or released lease when its rebuild preflight failed.
@@ -771,6 +814,9 @@ def test_preparation_rebuild_terminalizes_incomplete_inputs_and_preserves_learne
     assert blocked["bounded_completion"] is None
     tc._validate(blocked, tc.LEDGER_SCHEMA_PATH, "track-completion ledger")
 
+    with pytest.raises(tc.CompletionError, match="remains terminal"):
+        _start(fake_repo, "bio/seminar-built", owner="codex/remediation")
+
     _, replayed = tc.request_preparation_rebuild(
         "bio/seminar-built",
         run_id=bio_ledger["run"]["run_id"],
@@ -785,6 +831,23 @@ def test_preparation_rebuild_terminalizes_incomplete_inputs_and_preserves_learne
     )
     assert projection["state"] == "PREPARATION_BLOCKED"
     assert projection["final"] == "preparation-blocked"
+
+    blocked_identity = blocked["current_identity"]["sha256"]
+    _write_bio_dossier_grounding(repo)
+    snapshot = tc.resolve_target("bio/seminar-built", repo_root=repo, config=tc.load_config(config_path))
+    assert tc.build_identity(snapshot, repo_root=repo, config=tc.load_config(config_path))["sha256"] == blocked_identity
+
+    _, remediated = _start(fake_repo, "bio/seminar-built", owner="codex/remediation")
+    assert remediated["run"]["run_id"] != bio_ledger["run"]["run_id"]
+    assert remediated["run"]["status"] == "active"
+    assert remediated["state"] == "POST_BUILD_REVIEW_REQUIRED"
+    assert "preparation_block" not in remediated
+    assert remediated["archived_authority"][-1]["reason"] == "preparation-remediated"
+    assert remediated["archived_authority"][-1]["preparation_block"] == block
+    history = list(remediated["history"])
+    _, resumed = _start(fake_repo, "bio/seminar-built", owner="codex/remediation")
+    assert resumed["run"]["run_id"] == remediated["run"]["run_id"]
+    assert resumed["history"] == history
 
     _, core_ledger = _start(fake_repo, "a1/core-built")
     content = repo / "curriculum/l2-uk-en/a1/core-built/module.md"

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -732,22 +732,59 @@ def test_certification_rejects_built_bundle_without_consumed_preparation_identit
     assert len(inputs["preparation_identity"]) == 64
 
 
-def test_preparation_rebuild_routing_rejects_incomplete_inputs_and_learner_drift(
+def test_preparation_rebuild_terminalizes_incomplete_inputs_and_preserves_learner_drift_rejection(
     fake_repo: tuple[Path, Path, Path],
 ) -> None:
     repo, config_path, ledger_root = fake_repo
-    _, bio_ledger = _start(fake_repo, "bio/seminar-built")
-    with pytest.raises(
-        tc.CompletionError,
-        match="Preparation requirements must pass before routing the bundle to rebuild",
-    ):
-        tc.request_preparation_rebuild(
-            "bio/seminar-built",
-            run_id=bio_ledger["run"]["run_id"],
-            repo_root=repo,
-            config_path=config_path,
-            ledger_root=ledger_root,
-        )
+    path, bio_ledger = _start(fake_repo, "bio/seminar-built")
+    # Regression shape for #5455: a built BIO run began but had only STARTED,
+    # leaving no final event or released lease when its rebuild preflight failed.
+    assert bio_ledger["state"] == "POST_BUILD_REVIEW_REQUIRED"
+    assert [event["event"] for event in bio_ledger["history"]] == ["STARTED"]
+    # The terminal record is optional so pre-existing ledgers remain schema-valid.
+    assert "preparation_block" not in bio_ledger
+    tc._validate(bio_ledger, tc.LEDGER_SCHEMA_PATH, "track-completion legacy ledger")
+
+    _, blocked = tc.request_preparation_rebuild(
+        "bio/seminar-built",
+        run_id=bio_ledger["run"]["run_id"],
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+
+    assert blocked["state"] == "PREPARATION_BLOCKED"
+    assert blocked["run"]["status"] == "completed"
+    assert blocked["run"]["lease_released_at"] == blocked["run"]["lease_expires_at"]
+    assert tc._parse_time(blocked["run"]["lease_expires_at"]) <= tc._now()
+    assert [event["event"] for event in blocked["history"]] == [
+        "STARTED",
+        "PREPARATION_REBUILD_BLOCKED",
+    ]
+    block = blocked["preparation_block"]
+    assert block["disposition"] == "HOLD"
+    assert block["reason_code"] == "PREPARATION_REBUILD_PRECHECK_INCOMPLETE"
+    assert block["owner"] == "preparation"
+    assert block["next_action"] == "stop"
+    assert block["finding_ids"] == sorted(block["finding_ids"])
+    assert block["evidence_ids"] == sorted(block["evidence_ids"])
+    assert blocked["bounded_completion"] is None
+    tc._validate(blocked, tc.LEDGER_SCHEMA_PATH, "track-completion ledger")
+
+    _, replayed = tc.request_preparation_rebuild(
+        "bio/seminar-built",
+        run_id=bio_ledger["run"]["run_id"],
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+    assert replayed == blocked
+    assert json.loads(path.read_text(encoding="utf-8")) == blocked
+    projection = tc.certification_projection(
+        "bio/seminar-built", repo_root=repo, config_path=config_path, ledger_root=ledger_root
+    )
+    assert projection["state"] == "PREPARATION_BLOCKED"
+    assert projection["final"] == "preparation-blocked"
 
     _, core_ledger = _start(fake_repo, "a1/core-built")
     content = repo / "curriculum/l2-uk-en/a1/core-built/module.md"

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -849,6 +849,27 @@ def test_preparation_rebuild_terminalizes_incomplete_inputs_and_preserves_learne
     assert resumed["run"]["run_id"] == remediated["run"]["run_id"]
     assert resumed["history"] == history
 
+    (repo / "curriculum/l2-uk-en/bio/promotion-evidence.yaml").unlink()
+    _, blocked_again = tc.request_preparation_rebuild(
+        "bio/seminar-built",
+        run_id=remediated["run"]["run_id"],
+        repo_root=repo,
+        config_path=config_path,
+        ledger_root=ledger_root,
+    )
+    terminal_events = [event for event in blocked_again["history"] if event["event"] == "PREPARATION_REBUILD_BLOCKED"]
+    assert len(terminal_events) == 2
+    assert terminal_events[0]["event_id"] != terminal_events[1]["event_id"]
+    assert blocked_again["state"] == "PREPARATION_BLOCKED"
+    assert blocked_again["run"]["status"] == "completed"
+    assert blocked_again["run"]["lease_released_at"] == blocked_again["run"]["lease_expires_at"]
+
+    _write_bio_dossier_grounding(repo)
+    _, remediated_again = _start(fake_repo, "bio/seminar-built", owner="codex/remediation-2")
+    assert remediated_again["run"]["run_id"] != remediated["run"]["run_id"]
+    assert remediated_again["run"]["status"] == "active"
+    assert remediated_again["state"] == "POST_BUILD_REVIEW_REQUIRED"
+
     _, core_ledger = _start(fake_repo, "a1/core-built")
     content = repo / "curriculum/l2-uk-en/a1/core-built/module.md"
     content.write_text(content.read_text(encoding="utf-8") + "Незаписана зміна.\n", encoding="utf-8")
@@ -863,6 +884,41 @@ def test_preparation_rebuild_terminalizes_incomplete_inputs_and_preserves_learne
             config_path=config_path,
             ledger_root=ledger_root,
         )
+
+
+def test_preparation_block_state_pair_is_schema_enforced_and_consumers_fail_closed(
+    fake_repo: tuple[Path, Path, Path],
+) -> None:
+    repo, config_path, ledger_root = fake_repo
+    path, ledger = _start(fake_repo, "a1/core-built")
+    ledger["state"] = "PREPARATION_BLOCKED"
+    tc._atomic_write_json(path, ledger)
+
+    with pytest.raises(tc.CompletionError, match="Invalid track-completion ledger"):
+        tc.certification_projection(
+            "a1/core-built", repo_root=repo, config_path=config_path, ledger_root=ledger_root
+        )
+    with pytest.raises(tc.CompletionError, match="Invalid track-completion ledger"):
+        _start(fake_repo, "a1/core-built")
+
+    ledger["state"] = "POST_BUILD_REVIEW_REQUIRED"
+    ledger["preparation_block"] = {
+        "disposition": "HOLD",
+        "reason_code": "PREPARATION_REBUILD_PRECHECK_INCOMPLETE",
+        "owner": "preparation",
+        "reason": "fixture",
+        "finding_ids": ["PREPARATION_FIXTURE"],
+        "evidence_ids": ["fixture:evidence:missing"],
+        "unblock_condition": "fixture",
+        "next_action": "stop",
+    }
+    tc._atomic_write_json(path, ledger)
+    with pytest.raises(tc.CompletionError, match="Invalid track-completion ledger"):
+        tc.certification_projection(
+            "a1/core-built", repo_root=repo, config_path=config_path, ledger_root=ledger_root
+        )
+    with pytest.raises(tc.CompletionError, match="Invalid track-completion ledger"):
+        _start(fake_repo, "a1/core-built")
 
 
 def test_preparation_rebuild_from_awaiting_production_qg_arming_clears_stale_fields(


### PR DESCRIPTION
Closes #5509

## Summary
- terminalize rejected preparation-rebuild preflights in the authoritative ledger with a schema-valid HOLD
- release the run lease, make replay idempotent, and restart only after canonical preparation remediation
- enforce preparation-block state/record coupling and cover a second reblock cycle

## Verification
- `.venv/bin/python -m pytest -q tests/test_track_completion.py tests/test_bounded_completion_contract.py` — 60 passed
- `.venv/bin/ruff check agents_extensions/shared/skills/track-completion/scripts/track_completion.py tests/test_track_completion.py`
- `git diff --check origin/main...HEAD`
- X-Agent trailer audit — 3 commits passed

## Independent review
Claude Fable 5 was selected but unavailable due to its usage limit. Supported fallback Grok 4.5 completed the formal cross-family review; it raised two material lifecycle findings, both fixed in `84edb0a`, then returned PASS on the final head.