### PR TITLE
fix(git): keep primary on main — block detach and gh pr checkout (#4857)

### DIFF
--- a/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
+++ b/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -49,8 +50,13 @@ SWITCH_VERBS = frozenset({"checkout", "switch"})
 
 # Branch names that are "safe" to switch to in the main worktree
 # (returning to the trunk). `master` kept for older repos; we use main here.
-SAFE_TARGETS = frozenset({"main", "master", "HEAD", "-", "--detach", "--orphan"})
+# NEVER list ``--detach`` / ``--orphan`` here — bare ``git checkout --detach``
+# leaves target=None and was previously allowed (#4857 recurrence class).
+SAFE_TARGETS = frozenset({"main", "master", "HEAD", "-"})
 
+# Full-length or abbreviated object names (SHA-1/SHA-256 hex) that would
+# detach HEAD when used as ``git checkout <sha>``.
+_HEX_OBJECT_RE = re.compile(r"^(?:[0-9a-f]{7,40}|[0-9a-f]{64})$")
 
 def _git_probe_env() -> dict[str, str]:
     """Return an environment that lets git discover the requested repo."""
@@ -482,6 +488,14 @@ def _segment_is_dangerous(
     if "--" in args or "--ours" in args or "--theirs" in args:
         return None
 
+    # Detach / orphan always forbidden on primary (#4857 recurrence: agents
+    # leave the tree on a raw SHA and every service silently reads wrong code).
+    if "--detach" in args or "--orphan" in args:
+        return (
+            f"git {verb} --detach/--orphan detaches HEAD in the main worktree "
+            "(primary must stay attached to main)"
+        )
+
     # Flags we treat as "definitely creates / switches to a new branch":
     if "-b" in args or "--create" in args:
         return f"git {verb} -b creates and switches to a new branch in the main worktree"
@@ -498,10 +512,9 @@ def _segment_is_dangerous(
             skip_next = False
             continue
         if a.startswith("-"):
-            # Switches like `--track`, `--detach` take no value; `-t` takes
-            # one (the upstream). Defensive: treat single-letter flags
-            # other than the known boolean ones as value-taking.
-            if a in {"--detach", "--quiet", "-q", "--force", "-f", "--orphan",
+            # Switches like `--track` take no value here; `-t` takes one.
+            # ``--detach`` / ``--orphan`` already blocked above.
+            if a in {"--quiet", "-q", "--force", "-f",
                      "--no-track", "--guess", "--no-guess", "--progress",
                      "--no-progress", "--merge", "--theirs", "--ours",
                      "--ignore-skip-worktree-bits", "--patch", "-p",
@@ -516,9 +529,58 @@ def _segment_is_dangerous(
         target = a
         break
 
-    if target is None or target in SAFE_TARGETS:
+    if target is None:
+        # e.g. bare `git checkout` (no-op / path help) — allow
         return None
+    if target in SAFE_TARGETS:
+        return None
+    if _HEX_OBJECT_RE.fullmatch(target.lower()):
+        return (
+            f"git {verb} {target} detaches HEAD onto a raw object in the main "
+            "worktree (use a worktree; primary must stay on main)"
+        )
+    # origin/main is a remote-tracking ref → detaches when checked out bare
+    if target.startswith("origin/") or target.startswith("refs/"):
+        return (
+            f"git {verb} {target} switches/detaches the main worktree "
+            "(stay on main; use worktrees for feature refs)"
+        )
     return f"git {verb} {target} switches branch in the main worktree"
+
+
+def _gh_pr_checkout_reason(seg: list[str], effective_cwd: Path) -> str | None:
+    """Block ``gh pr checkout`` in the protected primary (#4857).
+
+    That command moves the primary HEAD onto a PR branch (often ``pr-N``),
+    which is how read-only reviews silently poisoned every local service.
+    """
+    i = _skip_command_prefix(seg, 0)
+    if i >= len(seg) or seg[i] != "gh":
+        return None
+    # ``gh pr checkout <n>`` (with optional global flags before subcommand)
+    rest = seg[i + 1 :]
+    # Skip global gh flags that take a value
+    j = 0
+    while j < len(rest) and rest[j].startswith("-"):
+        flag = rest[j]
+        if flag in {"-R", "--repo", "-h", "--hostname", "--help"} and j + 1 < len(rest):
+            j += 2
+        else:
+            j += 1
+    if j + 1 < len(rest) and rest[j] == "pr" and rest[j + 1] == "checkout":
+        repo_root = _git_repo_root(effective_cwd)
+        if repo_root is None:
+            return None
+        protected_roots = {root.resolve() for root in PROTECTED_ROOTS}
+        if repo_root.resolve() not in protected_roots:
+            return None
+        if not _in_main_worktree(repo_root):
+            return None
+        return (
+            "gh pr checkout moves the primary checkout off main "
+            "(use a dispatch worktree or gh pr diff / review-pr instead)"
+        )
+    return None
 
 
 def _command_danger_reason(command: str, session_cwd: Path | None = None) -> str | None:
@@ -530,6 +592,10 @@ def _command_danger_reason(command: str, session_cwd: Path | None = None) -> str
         if cd_target is not None and following_operator == "&&":
             effective_cwd = cd_target
             continue
+
+        gh_reason = _gh_pr_checkout_reason(segment, effective_cwd)
+        if gh_reason:
+            return gh_reason
 
         invocation = _git_invocation(segment, effective_cwd)
         if invocation is None:

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -384,6 +384,22 @@ if [ "${LEARN_UKRAINIAN_COLD_START_PROFILE:-}" != "compact" ]; then
     elif [ "$DIRTY_NONEXEMPT" -gt "$HYGIENE_THRESHOLD_WARN" ]; then
       INFO+=("Git hygiene: $DIRTY_NONEXEMPT dirty files outside exempt paths. Under the issue threshold ($HYGIENE_THRESHOLD_ISSUE) but worth inspecting with \`git status --short | grep -vE ' (wiki/|data/corpus_audit/draft_tickets/)'\`. Policy: docs/best-practices/git-hygiene.md.")
     fi
+
+    # 12b. Primary must stay attached to main (#4857) — auto-heal when possible.
+    if [ -x "$PROJECT_DIR/.venv/bin/python" ] \
+        && [ -f "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" ]; then
+      if ! "$PROJECT_DIR/.venv/bin/python" \
+          "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
+          --cwd "$PROJECT_DIR" --quiet 2>/dev/null; then
+        if "$PROJECT_DIR/.venv/bin/python" \
+            "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
+            --cwd "$PROJECT_DIR" --heal 2>/dev/null; then
+          INFO+=("PRIMARY HEAD was off main/detached — auto-healed to main (#4857). Prefer worktrees for all branch work.")
+        else
+          ISSUES+=("PRIMARY HEAD is detached or not on main (#4857). Run: .venv/bin/python scripts/guardrails/assert_primary_on_main.py --heal. Never gh pr checkout / git checkout <sha> on primary.")
+        fi
+      fi
+    fi
   fi
 else
   # 9. Compact mode orientation link

--- a/scripts/guardrails/assert_primary_on_main.py
+++ b/scripts/guardrails/assert_primary_on_main.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Assert the protected primary checkout is attached to ``main`` (#4857).
+
+Use from launchers (start-*.sh) and SessionStart. Optionally **heal** a
+detached / wrong-branch primary with ``--heal`` (ff-only checkout of main).
+
+Exit codes:
+  0 — primary is on main (or not a protected primary / not a git repo)
+  1 — primary is detached or not on main (and --heal was not requested / failed)
+  2 — usage / environment error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Allow running as scripts/guardrails/*.py
+_REPO_CANDIDATE = Path(__file__).resolve().parents[2]
+if str(_REPO_CANDIDATE) not in sys.path:
+    sys.path.insert(0, str(_REPO_CANDIDATE))
+
+from scripts.guardrails.worktree_containment import (
+    is_primary_checkout,
+    resolve_main_root,
+)
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for name in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_PREFIX",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    ):
+        env.pop(name, None)
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def primary_head_state(cwd: Path | None = None) -> dict[str, object]:
+    """Return head diagnostics for the main worktree of this repo."""
+    start = (cwd or Path.cwd()).resolve()
+    main_root = resolve_main_root(start)
+    if main_root is None:
+        return {"ok": True, "reason": "not_a_git_repo", "path": str(start)}
+    if not is_primary_checkout(main_root):
+        # Called from inside an added worktree — primary state is a separate check.
+        return {
+            "ok": True,
+            "reason": "not_primary_checkout",
+            "path": str(main_root),
+            "cwd": str(start),
+        }
+
+    branch_p = _git(main_root, "symbolic-ref", "--quiet", "--short", "HEAD")
+    if branch_p.returncode != 0:
+        sha = _git(main_root, "rev-parse", "--short", "HEAD").stdout.strip()
+        return {
+            "ok": False,
+            "reason": "detached_head",
+            "path": str(main_root),
+            "head": sha,
+            "message": (
+                f"PRIMARY checkout is DETACHED at {sha or 'unknown'}. "
+                "It must stay on branch main (orientation only; writes go in worktrees)."
+            ),
+        }
+
+    branch = branch_p.stdout.strip()
+    if branch not in {"main", "master"}:
+        return {
+            "ok": False,
+            "reason": "wrong_branch",
+            "path": str(main_root),
+            "branch": branch,
+            "message": (
+                f"PRIMARY checkout is on '{branch}', not main. "
+                "Agents must not switch the primary branch (see #4857)."
+            ),
+        }
+
+    return {
+        "ok": True,
+        "reason": "on_main",
+        "path": str(main_root),
+        "branch": branch,
+    }
+
+
+def heal_primary_to_main(main_root: Path) -> tuple[bool, str]:
+    """Force primary back onto main (no force-reset of dirty files)."""
+    # Prefer local main; if missing, create tracking branch from origin/main.
+    show = _git(main_root, "show-ref", "--verify", "--quiet", "refs/heads/main")
+    if show.returncode != 0:
+        fetch = _git(main_root, "fetch", "origin", "main")
+        if fetch.returncode != 0:
+            return False, f"fetch origin main failed: {fetch.stderr.strip()}"
+        create = _git(main_root, "checkout", "-B", "main", "origin/main")
+        if create.returncode != 0:
+            return False, f"checkout -B main origin/main failed: {create.stderr.strip()}"
+        return True, "created/reset local main from origin/main"
+
+    co = _git(main_root, "checkout", "main")
+    if co.returncode != 0:
+        return False, f"git checkout main failed: {co.stderr.strip()}"
+    # Fast-forward if possible (never merge/rebase here).
+    pull = _git(main_root, "pull", "--ff-only", "origin", "main")
+    if pull.returncode != 0:
+        # Still on main; behind is acceptable for orientation.
+        return True, f"on main (ff-only pull skipped: {pull.stderr.strip() or 'not possible'})"
+    return True, "on main and fast-forwarded to origin/main"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=None,
+        help="Starting directory for repo discovery (default: process cwd)",
+    )
+    parser.add_argument(
+        "--heal",
+        action="store_true",
+        help="If primary is detached/wrong-branch, checkout main (+ optional ff-only)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="No stdout on success",
+    )
+    args = parser.parse_args(argv)
+
+    state = primary_head_state(args.cwd)
+    if state.get("ok"):
+        if not args.quiet:
+            print(f"OK primary on {state.get('branch', 'n/a')} ({state.get('path')})")
+        return 0
+
+    msg = str(state.get("message") or state.get("reason"))
+    print(f"ERROR: {msg}", file=sys.stderr)
+
+    if not args.heal:
+        print(
+            "Fix: cd <primary> && git checkout main && git pull --ff-only origin main\n"
+            "Or:  .venv/bin/python scripts/guardrails/assert_primary_on_main.py --heal",
+            file=sys.stderr,
+        )
+        return 1
+
+    main_root = Path(str(state["path"]))
+    ok, detail = heal_primary_to_main(main_root)
+    if not ok:
+        print(f"HEAL FAILED: {detail}", file=sys.stderr)
+        return 1
+    print(f"HEALED: {detail}")
+    # Re-check
+    again = primary_head_state(main_root)
+    if not again.get("ok"):
+        print(f"ERROR after heal: {again.get('message')}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/guardrails/primary_post_checkout_heal.sh
+++ b/scripts/guardrails/primary_post_checkout_heal.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Git post-checkout hook fragment: keep the PRIMARY worktree on main.
+#
+# Git has already moved HEAD when this runs. If the main worktree is detached
+# or on a non-main branch, heal immediately and warn. Added worktrees are
+# ignored (feature branches are expected there).
+#
+# Install via: .venv/bin/python scripts/guardrails/assert_primary_on_main.py
+# (or the primary_write_guard install-hooks path). Safe to re-run.
+
+set -euo pipefail
+
+# post-checkout args: previous HEAD, new HEAD, flag (1=branch checkout)
+# We do not use them beyond knowing a checkout happened.
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+# Only act in the main worktree (not .git/worktrees/*)
+GIT_DIR="$(git rev-parse --git-dir)"
+GIT_COMMON="$(git rev-parse --git-common-dir)"
+# Normalize relative paths
+GIT_DIR="$(cd "$(dirname "$GIT_DIR")" && pwd)/$(basename "$GIT_DIR")"
+GIT_COMMON="$(cd "$(dirname "$GIT_COMMON")" && pwd)/$(basename "$GIT_COMMON")"
+if [ "$GIT_DIR" != "$GIT_COMMON" ]; then
+  exit 0
+fi
+
+if [ ! -f "$ROOT/scripts/guardrails/assert_primary_on_main.py" ]; then
+  exit 0
+fi
+
+PY="${ROOT}/.venv/bin/python"
+if [ ! -x "$PY" ]; then
+  PY="python3"
+fi
+
+# Heal quietly if broken; always allow the checkout to complete (we already moved).
+if ! "$PY" "$ROOT/scripts/guardrails/assert_primary_on_main.py" --cwd "$ROOT" --quiet 2>/dev/null; then
+  echo "WARNING: primary left main/detached — auto-healing to main…" >&2
+  "$PY" "$ROOT/scripts/guardrails/assert_primary_on_main.py" --cwd "$ROOT" --heal || true
+fi
+
+exit 0

--- a/scripts/guardrails/primary_write_guard.py
+++ b/scripts/guardrails/primary_write_guard.py
@@ -245,21 +245,30 @@ def install_hooks() -> None:
             print(f"Error creating hooks directory: {e}", file=sys.stderr)
             sys.exit(1)
 
-    # post-merge ONLY (review #5399): `git pull`/merge is the one automation path
-    # that (re)creates tracked files with write bits, so re-apply there. post-commit
-    # never touches working-tree files, and post-checkout would add an O(tracked)
-    # lstat scan to every checkout for a path that branch-switch guards already
-    # cover in the primary. Opt-in manually via `apply` if ever needed.
-    hook_names = ["post-merge"]
-    hook_command = (
-        "\n# AGY_PRIMARY_WRITE_GUARD_START\n"
-        'if [ -f "scripts/guardrails/primary_write_guard.py" ]; then\n'
-        "    python3 scripts/guardrails/primary_write_guard.py apply --hook\n"
-        "fi\n"
-        "# AGY_PRIMARY_WRITE_GUARD_END\n"
-    )
+    # post-merge: re-apply write-bit guard after pull/merge (review #5399).
+    # post-checkout: heal detached/wrong-branch primary back to main (#4857).
+    fragments: list[tuple[str, str, str]] = [
+        (
+            "post-merge",
+            "AGY_PRIMARY_WRITE_GUARD_START",
+            "\n# AGY_PRIMARY_WRITE_GUARD_START\n"
+            'if [ -f "scripts/guardrails/primary_write_guard.py" ]; then\n'
+            "    python3 scripts/guardrails/primary_write_guard.py apply --hook\n"
+            "fi\n"
+            "# AGY_PRIMARY_WRITE_GUARD_END\n",
+        ),
+        (
+            "post-checkout",
+            "AGY_PRIMARY_STAY_ON_MAIN_START",
+            "\n# AGY_PRIMARY_STAY_ON_MAIN_START\n"
+            'if [ -f "scripts/guardrails/primary_post_checkout_heal.sh" ]; then\n'
+            '    sh "scripts/guardrails/primary_post_checkout_heal.sh" "$@"\n'
+            "fi\n"
+            "# AGY_PRIMARY_STAY_ON_MAIN_END\n",
+        ),
+    ]
 
-    for hook_name in hook_names:
+    for hook_name, marker, hook_command in fragments:
         hook_path = hooks_dir / hook_name
         content = ""
         if hook_path.exists():
@@ -269,8 +278,8 @@ def install_hooks() -> None:
                 print(f"Error reading existing hook {hook_name}: {e}", file=sys.stderr)
                 sys.exit(1)
 
-        if "# AGY_PRIMARY_WRITE_GUARD_START" in content:
-            print(f"Hook '{hook_name}' already has primary write guard installed.")
+        if marker in content:
+            print(f"Hook '{hook_name}' already has {marker} installed.")
             continue
 
         new_content = content
@@ -285,7 +294,7 @@ def install_hooks() -> None:
             hook_path.write_text(new_content, encoding="utf-8")
             current_mode = hook_path.stat().st_mode
             hook_path.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-            print(f"Successfully installed primary write guard in hook '{hook_name}'.")
+            print(f"Successfully installed primary guard fragment in hook '{hook_name}'.")
         except OSError as e:
             print(f"Error writing hook {hook_name}: {e}", file=sys.stderr)
             sys.exit(1)

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -59,7 +59,17 @@ if [ -z "$PROJECT_DIR" ]; then
     exit 1
 fi
 
-if [ "$(git -C "$PROJECT_DIR" branch --show-current)" != "main" ]; then
+# Primary must be *attached* to main (not detached SHA) — #4857.
+if [ -x "$PROJECT_DIR/.venv/bin/python" ] \
+    && [ -f "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" ]; then
+    if ! "$PROJECT_DIR/.venv/bin/python" \
+        "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
+        --cwd "$PROJECT_DIR" --heal; then
+        printf 'Error: primary checkout must be on main (heal failed): %s\n' \
+            "$PROJECT_DIR" >&2
+        exit 1
+    fi
+elif [ "$(git -C "$PROJECT_DIR" branch --show-current)" != "main" ]; then
     printf 'Error: canonical checkout must be on main: %s\n' "$PROJECT_DIR" >&2
     exit 1
 fi

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -78,6 +78,16 @@ cd "$PROJECT_DIR"
 
 if git rev-parse --git-dir >/dev/null 2>&1; then
   echo "Current branch: $(git branch --show-current 2>/dev/null || echo '?')"
+  # Heal detached/wrong-branch primary so agents never start on a raw SHA (#4857).
+  if [ -x "$PROJECT_DIR/.venv/bin/python" ] \
+      && [ -f "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" ]; then
+    if ! "$PROJECT_DIR/.venv/bin/python" \
+        "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
+        --cwd "$PROJECT_DIR" --heal; then
+      echo "Error: primary checkout is not on main and auto-heal failed." >&2
+      exit 1
+    fi
+  fi
   if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     echo "Uncommitted changes detected (primary checkout is orientation-only; write via worktrees)"
   fi

--- a/tests/test_assert_primary_on_main.py
+++ b/tests/test_assert_primary_on_main.py
@@ -1,0 +1,66 @@
+"""Tests for scripts/guardrails/assert_primary_on_main.py (#4857)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.guardrails.assert_primary_on_main import heal_primary_to_main, primary_head_state
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for name in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_PREFIX",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    ):
+        env.pop(name, None)
+    return subprocess.run(
+        list(args),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+@pytest.fixture
+def primary_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    assert _run(root, "git", "init", "-b", "main").returncode == 0
+    assert _run(root, "git", "config", "user.name", "Test").returncode == 0
+    assert _run(root, "git", "config", "user.email", "t@example.invalid").returncode == 0
+    assert _run(root, "git", "commit", "--allow-empty", "-m", "init").returncode == 0
+    return root
+
+
+def test_on_main_ok(primary_repo: Path) -> None:
+    state = primary_head_state(primary_repo)
+    assert state["ok"] is True
+    assert state["branch"] == "main"
+
+
+def test_detached_detected(primary_repo: Path) -> None:
+    r = _run(primary_repo, "git", "switch", "--detach", "HEAD")
+    assert r.returncode == 0, r.stderr
+    state = primary_head_state(primary_repo)
+    assert state["ok"] is False
+    assert state["reason"] == "detached_head"
+
+
+def test_heal_reattaches_main(primary_repo: Path) -> None:
+    assert _run(primary_repo, "git", "switch", "--detach", "HEAD").returncode == 0
+    ok, _detail = heal_primary_to_main(primary_repo)
+    assert ok is True
+    state = primary_head_state(primary_repo)
+    assert state["ok"] is True
+    assert state["branch"] == "main"

--- a/tests/test_guard_branch_switch_in_main.py
+++ b/tests/test_guard_branch_switch_in_main.py
@@ -132,6 +132,44 @@ def test_safe_ops_allowed(cmd):
     assert _dangerous(cmd) is None
 
 
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git checkout --detach",
+        "git switch --detach",
+        "git checkout --orphan tmp-orphan",
+        "git checkout abcdef0",
+        "git checkout 9265871162825c0c74a0b03cd2f2440d729b298f",
+        "git checkout origin/main",
+        "git checkout origin/feature",
+        "git checkout refs/heads/feature",
+    ],
+)
+def test_detach_and_raw_object_checkout_blocked(cmd):
+    """Primary must never detach (#4857 recurrence)."""
+    assert _dangerous(cmd) is not None
+
+
+def test_gh_pr_checkout_blocked_in_primary(repos, monkeypatch):
+    """#4857: gh pr checkout on primary is forbidden."""
+    monkeypatch.chdir(repos["public"])
+    reason = guard._command_danger_reason(
+        "gh pr checkout 4849",
+        session_cwd=repos["public"],
+    )
+    assert reason is not None
+    assert "gh pr checkout" in reason
+
+
+def test_gh_pr_checkout_allowed_in_worktree(repos, monkeypatch):
+    monkeypatch.chdir(repos["public_worktree"])
+    reason = guard._command_danger_reason(
+        "gh pr checkout 4849",
+        session_cwd=repos["public_worktree"],
+    )
+    assert reason is None
+
+
 # --- Force-delete / force-rename (new behavior) ----------------------------
 
 


### PR DESCRIPTION
## Summary

Primary checkout was repeatedly left **detached** or off `main` (agent `git checkout <sha>`, `git checkout --detach`, `gh pr checkout`). That is unacceptable: every service and orchestrator then reads the wrong tree.

### Root cause
`guard-branch-switch-in-main` treated bare `git checkout --detach` as **allowed** (target became `None` after skipping the flag) and never blocked **`gh pr checkout`**.

### Fix
1. **Block** `--detach` / `--orphan`, raw object SHAs, `origin/*` / `refs/*` checkouts on primary
2. **Block** `gh pr checkout` on primary (#4857)
3. **`assert_primary_on_main.py`** (+ `--heal`) for launchers / SessionStart
4. **post-checkout heal** fragment (install via `primary_write_guard.py install-hooks`)
5. **start-codex / start-grok** auto-heal before launch
6. **session-setup** auto-heal or surface ISSUE

### Tests
99 related tests green (including new detach / gh pr checkout cases).

Closes #4857

X-Agent: grok/primary-stay-on-main