### PR TITLE
feat(session-streams): inventory from issue_streams.yaml (Sol PR-H / #5512)

### DIFF
--- a/agents_extensions/shared/session_streams/cli.py
+++ b/agents_extensions/shared/session_streams/cli.py
@@ -13,13 +13,13 @@ from typing import Any
 from .db import SessionStreamDatabase
 from .dual_write import (
     ATLAS_HANDOFF_PATH,
-    EPIC_HANDOFF_CANDIDATES,
     list_handoff_candidates,
     mirror_atlas_handoff,
     mirror_handoff_file,
     resolve_handoff_path,
 )
 from .hooks import clean_exit_hook, heartbeat_hook, lease_from_environment
+from .inventory import epic_handoff_map, inventory_covers_issue_streams, load_stream_epic_inventory
 from .model import entry_as_dict
 from .store import NotFoundError, SessionStreamError, SessionStreamStore
 
@@ -302,7 +302,7 @@ def _mirror_handoff(store: SessionStreamStore, args: argparse.Namespace) -> int:
     if source is None:
         resolved = resolve_handoff_path(args.stream, args.repo_root)
         if resolved is None:
-            known = ", ".join(EPIC_HANDOFF_CANDIDATES.get(args.stream, ())) or "(none registered)"
+            known = ", ".join(epic_handoff_map(args.repo_root).get(args.stream, ())) or "(none registered)"
             raise ValueError(
                 f"no existing handoff for {args.stream}; candidates: {known}; pass --source explicitly"
             )
@@ -334,16 +334,22 @@ def _mirror_handoff(store: SessionStreamStore, args: argparse.Namespace) -> int:
 
 def _dual_write_status(args: argparse.Namespace) -> int:
     rows = list_handoff_candidates(args.repo_root)
-    print("stream\texists\tpath")
+    print("stream\tname\texists\tpath")
     for row in rows:
-        print(f"{row.stream_id}\t{int(row.exists)}\t{row.path}")
-    registered = sorted(EPIC_HANDOFF_CANDIDATES)
+        print(f"{row.stream_id}\t{row.stream_name}\t{int(row.exists)}\t{row.path}")
+    inventory = load_stream_epic_inventory(args.repo_root)
+    registered = sorted(r.stream_id for r in inventory)
     present = sorted({r.stream_id for r in rows if r.exists})
+    ok, missing = inventory_covers_issue_streams(args.repo_root)
     print(
         json.dumps(
             {
                 "registered_streams": registered,
+                "epic_count": len(inventory),
                 "streams_with_file": present,
+                "inventory_covers_issue_streams": ok,
+                "missing_epics": missing,
+                "source": "scripts/config/issue_streams.yaml",
                 "cutover": "blocked — dual-write only; file handoffs remain authoritative",
             },
             sort_keys=True,

--- a/agents_extensions/shared/session_streams/dual_write.py
+++ b/agents_extensions/shared/session_streams/dual_write.py
@@ -7,33 +7,12 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from .inventory import epic_handoff_map, load_stream_epic_inventory
 from .model import Entry, EntryRef, EntryType, Lease
 from .store import SessionStreamStore
 
 ATLAS_PROFILE = "atlas"
 ATLAS_HANDOFF_PATH = Path(".claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md")
-
-# Registry of known epic streams → primary file handoff paths for dual-write.
-# Phase-2 migration: mirror these under an active lease without retiring files.
-# Paths are relative to the repository root. First existing path wins per epic.
-EPIC_HANDOFF_CANDIDATES: dict[str, tuple[str, ...]] = {
-    "epic:4387": (
-        ".claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md",
-        ".claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md",
-    ),
-    "epic:4707": (
-        ".claude/harness-epic/CLAUDE-DRIVER-HANDOFF.md",
-        "docs/session-state/current.claude-infra.md",
-    ),
-    "epic:4542": (
-        ".claude/hramatka-epic/CLAUDE-DRIVER-HANDOFF.md",
-        "docs/session-state/current.claude-hramatka.md",
-    ),
-    "epic:4706": (
-        ".claude/bio-epic/CLAUDE-DRIVER-HANDOFF.md",
-        "docs/session-state/current.claude-bio.md",
-    ),
-}
 
 
 @dataclass(frozen=True)
@@ -51,23 +30,38 @@ class HandoffCandidate:
     stream_id: str
     path: Path
     exists: bool
+    stream_name: str = ""
+    title: str = ""
 
 
 def list_handoff_candidates(repo_root: Path) -> list[HandoffCandidate]:
-    """List configured epic handoff paths and whether each file exists."""
+    """List inventory-derived handoff paths and whether each file exists.
+
+    Inventory covers every epic in ``scripts/config/issue_streams.yaml``
+    (Sol PR-H). No hard-coded four-epic subset remains authoritative.
+    """
     root = repo_root.resolve()
     out: list[HandoffCandidate] = []
-    for stream_id, paths in EPIC_HANDOFF_CANDIDATES.items():
-        for rel in paths:
+    for rec in load_stream_epic_inventory(root):
+        for rel in rec.handoff_candidates:
             path = root / rel
-            out.append(HandoffCandidate(stream_id=stream_id, path=path, exists=path.is_file()))
+            out.append(
+                HandoffCandidate(
+                    stream_id=rec.stream_id,
+                    path=path,
+                    exists=path.is_file(),
+                    stream_name=rec.stream_name,
+                    title=rec.title,
+                )
+            )
     return out
 
 
 def resolve_handoff_path(stream_id: str, repo_root: Path) -> Path | None:
     """Return the first existing handoff path for a stream, if any."""
     root = repo_root.resolve()
-    for rel in EPIC_HANDOFF_CANDIDATES.get(stream_id, ()):
+    candidates = epic_handoff_map(root).get(stream_id, ())
+    for rel in candidates:
         path = root / rel
         if path.is_file():
             return path

--- a/agents_extensions/shared/session_streams/inventory.py
+++ b/agents_extensions/shared/session_streams/inventory.py
@@ -1,0 +1,180 @@
+"""Manifest-derived session-stream inventory (Sol PR-H / #5512).
+
+The hard-coded four-epic list must not remain authoritative. Inventory is
+derived from ``scripts/config/issue_streams.yaml`` so every stream epic can
+participate in dual-write / cutover tracking without code edits per epic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_STREAMS_YAML = Path("scripts/config/issue_streams.yaml")
+
+# Optional explicit handoff path overrides (relative to repo root).
+# First existing path wins when resolving a live mirror source.
+# Keys are stream ids ``epic:<number>``.
+HANDOFF_PATH_OVERRIDES: dict[str, tuple[str, ...]] = {
+    "epic:4387": (
+        ".claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md",
+        ".claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md",
+    ),
+    "epic:4700": (
+        ".claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md",
+        ".claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md",
+    ),
+    "epic:4707": (
+        ".claude/harness-epic/CLAUDE-DRIVER-HANDOFF.md",
+        "docs/session-state/current.claude-infra.md",
+    ),
+    "epic:4542": (
+        ".claude/hramatka-epic/CLAUDE-DRIVER-HANDOFF.md",
+        "docs/session-state/current.claude-hramatka.md",
+    ),
+    "epic:4706": (
+        ".claude/bio-epic/CLAUDE-DRIVER-HANDOFF.md",
+        "docs/session-state/current.claude-bio.md",
+    ),
+    "epic:2836": (
+        ".claude/folk-epic/CLAUDE-DRIVER-HANDOFF.md",
+        "docs/session-state/current.claude-folk.md",
+    ),
+    "epic:4431": (
+        ".claude/bio-epic/CLAUDE-DRIVER-HANDOFF.md",
+        "docs/session-state/current.claude-bio.md",
+    ),
+}
+
+# Map issue-stream *names* → conventional .claude/<slug>-epic/ directories.
+_STREAM_NAME_TO_CLAUDE_DIR: dict[str, str] = {
+    "atlas-practice": "atlas",
+    "atlas-intake": "atlas",
+    "infra-harness": "harness",
+    "hramatka": "hramatka",
+    "seminars-folk": "folk",
+    "seminars-bio": "bio",
+    "corpus-channels": "bio",
+    "core-quality": "core",
+    "eval-harness": "harness",
+    "benchmark-2156": "harness",
+    "seminars-cross": "folk",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class StreamEpicRecord:
+    """One epic that may host a session stream."""
+
+    stream_id: str  # epic:4387
+    epic_number: int
+    stream_name: str  # atlas-practice
+    title: str
+    handoff_candidates: tuple[str, ...]
+
+
+def _load_streams_doc(path: Path) -> dict[str, Any]:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"issue_streams.yaml must be a mapping: {path}")
+    streams = raw.get("streams")
+    if not isinstance(streams, dict):
+        raise ValueError(f"issue_streams.yaml missing streams map: {path}")
+    return streams
+
+
+def _handoff_candidates_for(stream_name: str, epic_number: int) -> tuple[str, ...]:
+    stream_id = f"epic:{epic_number}"
+    if stream_id in HANDOFF_PATH_OVERRIDES:
+        return HANDOFF_PATH_OVERRIDES[stream_id]
+    slug = _STREAM_NAME_TO_CLAUDE_DIR.get(stream_name, stream_name.replace("_", "-"))
+    return (
+        f".claude/{slug}-epic/CLAUDE-DRIVER-HANDOFF.md",
+        f".claude/{slug}-epic/INTERIM-DRIVER-HANDOFF.md",
+        f"docs/session-state/current.claude-{slug}.md",
+    )
+
+
+def load_stream_epic_inventory(
+    repo_root: Path,
+    *,
+    streams_yaml: Path | None = None,
+) -> tuple[StreamEpicRecord, ...]:
+    """Return every epic registered in issue_streams.yaml as a stream candidate.
+
+    Deduplicates epic numbers (an epic listed under multiple stream names keeps
+    the first registration order from the YAML file).
+    """
+    root = repo_root.resolve()
+    path = streams_yaml if streams_yaml is not None else root / DEFAULT_STREAMS_YAML
+    if not path.is_absolute():
+        path = root / path
+    streams = _load_streams_doc(path)
+    seen: set[int] = set()
+    out: list[StreamEpicRecord] = []
+    for stream_name, body in streams.items():
+        if not isinstance(body, dict):
+            continue
+        title = str(body.get("title") or stream_name)
+        epics = body.get("epics") or []
+        if not isinstance(epics, list):
+            continue
+        for raw in epics:
+            try:
+                num = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if num in seen:
+                continue
+            seen.add(num)
+            out.append(
+                StreamEpicRecord(
+                    stream_id=f"epic:{num}",
+                    epic_number=num,
+                    stream_name=str(stream_name),
+                    title=title,
+                    handoff_candidates=_handoff_candidates_for(str(stream_name), num),
+                )
+            )
+    return tuple(out)
+
+
+def epic_handoff_map(
+    repo_root: Path,
+    *,
+    streams_yaml: Path | None = None,
+) -> dict[str, tuple[str, ...]]:
+    """Map ``epic:<n>`` → handoff candidate paths (replaces hard-coded four-epic dict)."""
+    return {
+        rec.stream_id: rec.handoff_candidates
+        for rec in load_stream_epic_inventory(repo_root, streams_yaml=streams_yaml)
+    }
+
+
+def inventory_covers_issue_streams(
+    repo_root: Path,
+    *,
+    streams_yaml: Path | None = None,
+) -> tuple[bool, list[str]]:
+    """Return (ok, missing_stream_ids) vs issue_streams.yaml epic numbers."""
+    records = load_stream_epic_inventory(repo_root, streams_yaml=streams_yaml)
+    present = {r.epic_number for r in records}
+    root = repo_root.resolve()
+    path = streams_yaml if streams_yaml is not None else root / DEFAULT_STREAMS_YAML
+    if not path.is_absolute():
+        path = root / path
+    streams = _load_streams_doc(path)
+    expected: set[int] = set()
+    for body in streams.values():
+        if not isinstance(body, dict):
+            continue
+        for raw in body.get("epics") or []:
+            try:
+                expected.add(int(raw))
+            except (TypeError, ValueError):
+                continue
+    missing = sorted(f"epic:{n}" for n in expected - present)
+    return (not missing, missing)

--- a/tests/test_session_streams_dual_write_status.py
+++ b/tests/test_session_streams_dual_write_status.py
@@ -1,31 +1,71 @@
-"""dual-write-status / registry inventory for session streams."""
+"""dual-write-status / inventory-derived session stream registry (Sol PR-H)."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 from agents_extensions.shared.session_streams.dual_write import (
-    EPIC_HANDOFF_CANDIDATES,
     list_handoff_candidates,
     resolve_handoff_path,
 )
+from agents_extensions.shared.session_streams.inventory import (
+    epic_handoff_map,
+    inventory_covers_issue_streams,
+    load_stream_epic_inventory,
+)
 
 
-def test_registry_includes_atlas_and_infra():
-    assert "epic:4387" in EPIC_HANDOFF_CANDIDATES
-    assert "epic:4707" in EPIC_HANDOFF_CANDIDATES
+def test_inventory_covers_repo_issue_streams():
+    repo = Path(__file__).resolve().parents[1]
+    ok, missing = inventory_covers_issue_streams(repo)
+    assert ok is True
+    assert missing == []
+    records = load_stream_epic_inventory(repo)
+    # issue_streams.yaml has more than the old hard-coded four epics
+    assert len(records) >= 10
+    ids = {r.stream_id for r in records}
+    assert "epic:4387" in ids
+    assert "epic:4707" in ids
+    assert "epic:4542" in ids
+    assert "epic:2836" in ids  # folk — was not in the hard-coded four
 
 
 def test_list_handoff_candidates_marks_missing(tmp_path: Path):
+    # Minimal issue_streams fixture
+    streams = {
+        "schema_version": 1,
+        "streams": {
+            "demo": {"title": "Demo", "epics": [9999]},
+        },
+    }
+    yml = tmp_path / "issue_streams.yaml"
+    yml.write_text(yaml.safe_dump(streams), encoding="utf-8")
+    # Point inventory at fixture via writing under scripts/config path structure
+    cfg = tmp_path / "scripts" / "config"
+    cfg.mkdir(parents=True)
+    (cfg / "issue_streams.yaml").write_text(yaml.safe_dump(streams), encoding="utf-8")
     rows = list_handoff_candidates(tmp_path)
     assert rows
     assert all(r.exists is False for r in rows)
+    assert any(r.stream_id == "epic:9999" for r in rows)
 
 
 def test_resolve_handoff_path_first_existing(tmp_path: Path):
+    cfg = tmp_path / "scripts" / "config"
+    cfg.mkdir(parents=True)
+    (cfg / "issue_streams.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "streams": {"atlas-practice": {"title": "Atlas", "epics": [4387]}},
+            }
+        ),
+        encoding="utf-8",
+    )
     stream = "epic:4387"
-    candidates = EPIC_HANDOFF_CANDIDATES[stream]
-    # Create second candidate only
+    candidates = epic_handoff_map(tmp_path)[stream]
     second = tmp_path / candidates[1]
     second.parent.mkdir(parents=True, exist_ok=True)
     second.write_text("handoff\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Sol **PR-H** slice for #5512:

- Inventory from `scripts/config/issue_streams.yaml` (not a hard-coded 4-epic list)
- `dual-write-status` reports epic count + coverage
- No launcher / cutover changes

## Verification

25 session-stream tests green.

Refs #5512

X-Agent: grok/5512-pr-h-stream-inventory