### PR TITLE
fix(guards): catch checkout without -- and git mv/rm on primary (#5517)

### DIFF
--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -31,13 +31,13 @@ Covered write surfaces
   in-place editors (``sed -i`` / ``perl -i``). Quote-aware tokenization keeps a
   ``>`` inside a quoted string (e.g. a commit message) from reading as a
   redirect.
-* ``Bash`` git-mediated working-tree writes (issue #5396) — ``git apply`` /
-  ``git am``, ``git add``, ``git stash pop|apply``, and
-  ``git checkout <ref> -- <path>`` / ``git restore --source=…`` when the
-  effective git worktree (payload cwd or ``git -C``) is the protected primary
-  checkout. Rescue clean forms ``git checkout -- <path>`` and plain
-  ``git restore <path>`` (no ``--source``) remain allowed so operators can
-  discard accidental dirt.
+* ``Bash`` git-mediated working-tree writes (issues #5396 / #5517) — ``git apply`` /
+  ``git am``, ``git add``, ``git stash pop|apply``, ``git mv`` / ``git rm``,
+  ``git checkout <ref> -- <path>``, ``git checkout <ref> <path>`` (no ``--``),
+  and ``git restore --source=…`` when the effective git worktree (payload cwd
+  or ``git -C``) is the protected primary checkout. Rescue clean forms
+  ``git checkout -- <path>`` and plain ``git restore <path>`` (no ``--source``)
+  remain allowed so operators can discard accidental dirt.
 
 Coverage limitations (documented, by design)
 --------------------------------------------
@@ -577,12 +577,14 @@ def bash_git_write_intents(command: str) -> list[dict[str, object]]:
 
         if sub == "checkout":
             # Allowlist: `git checkout -- <paths>` (restore from index/HEAD).
-            # Block: `git checkout <tree-ish> -- <paths>` (writes tree content).
+            # Block: `git checkout <tree-ish> -- <paths>` and the no-dashdash
+            # form `git checkout <tree-ish> <path>…` (#5517).
+            # Branch-only checkouts (single non-flag arg, no paths) stay out —
+            # other guards own branch switches.
             if "--" in sub_args:
                 dd = sub_args.index("--")
                 before = sub_args[:dd]
                 after = sub_args[dd + 1 :]
-                # Drop flags from `before`.
                 treeish = [t for t in before if not t.startswith("-")]
                 if not treeish:
                     intents.append(
@@ -604,7 +606,22 @@ def bash_git_write_intents(command: str) -> list[dict[str, object]]:
                             "allowlisted": False,
                         }
                     )
-            # Branch switches / plain checkout have no pathspecs → other guards.
+            else:
+                positionals = [t for t in sub_args if not t.startswith("-")]
+                if len(positionals) >= 2:
+                    # tree-ish + one or more pathspecs (no `--` separator).
+                    intents.append(
+                        {
+                            "kind": "path_checkout",
+                            "c_path": c_path,
+                            "paths": positionals[1:],
+                            "summary": (
+                                f"git checkout {positionals[0]} "
+                                + " ".join(positionals[1:])
+                            ),
+                            "allowlisted": False,
+                        }
+                    )
             continue
 
         if sub == "restore":
@@ -649,6 +666,31 @@ def bash_git_write_intents(command: str) -> list[dict[str, object]]:
                         "allowlisted": False,
                     }
                 )
+            continue
+
+        if sub in {"mv", "rm"}:
+            # Both mutate the index and the working tree (#5517).
+            paths: list[str] = []
+            i = 0
+            while i < len(sub_args):
+                tok = sub_args[i]
+                if tok == "--":
+                    paths.extend(sub_args[i + 1 :])
+                    break
+                if tok.startswith("-"):
+                    i += 1
+                    continue
+                paths.append(tok)
+                i += 1
+            intents.append(
+                {
+                    "kind": "mv" if sub == "mv" else "rm",
+                    "c_path": c_path,
+                    "paths": paths,
+                    "summary": f"git {sub}" + (f" {' '.join(paths)}" if paths else ""),
+                    "allowlisted": False,
+                }
+            )
             continue
 
     return intents

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -44,8 +44,8 @@ exits 2 and tells the agent to create/`cd` into
   editors (`sed -i` / `perl -i`). Read-only preflight (`git status`, `git log`,
   `rg`, `cat`, …) exposes no write target and is never blocked.
 - `Bash` git-mediated working-tree writes (**#5396**): `git apply` / `git am`,
-  `git add`, `git stash pop|apply`, and `git checkout <ref> -- <path>` /
-  `git restore --source=…` when the effective worktree (payload cwd or
+  `git add`, `git stash pop|apply`, and `git checkout <ref> -- <path>` / `git checkout <ref> <path>` /
+  `git mv` / `git rm` / `git restore --source=…` (#5517) when the effective worktree (payload cwd or
   `git -C`) is the protected primary checkout. Honors `git -C <worktree>` so
   apply-from-primary-shell into a worktree stays allowed. Rescue clean forms
   `git checkout -- <path>` and plain `git restore <path>` remain allowed.

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -492,3 +492,76 @@ def test_git_apply_override_env_allows(repo: Path, monkeypatch: pytest.MonkeyPat
         env=env,
     )
     assert result.returncode == 0, result.stderr
+
+
+# --- #5517: checkout without -- ; git mv / git rm -------------------------
+
+
+def test_bash_git_write_intents_checkout_no_dashdash():
+    intents = hook.bash_git_write_intents("git checkout HEAD~1 curriculum/tracked.md")
+    assert len(intents) == 1
+    assert intents[0]["kind"] == "path_checkout"
+    assert intents[0]["allowlisted"] is False
+    assert intents[0]["paths"] == ["curriculum/tracked.md"]
+
+
+def test_bash_git_write_intents_mv_rm():
+    mv = hook.bash_git_write_intents("git mv a.py b.py")
+    assert len(mv) == 1 and mv[0]["kind"] == "mv" and mv[0]["paths"] == ["a.py", "b.py"]
+    rm = hook.bash_git_write_intents("git rm -f curriculum/tracked.md")
+    assert len(rm) == 1 and rm[0]["kind"] == "rm" and rm[0]["paths"] == ["curriculum/tracked.md"]
+
+
+def test_git_checkout_treeish_path_no_dashdash_blocked(repo: Path):
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {"command": "git checkout HEAD~1 curriculum/tracked.md"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 2, result.stderr
+
+
+def test_git_mv_on_primary_blocked(repo: Path):
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {"command": "git mv curriculum/tracked.md curriculum/renamed.md"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 2, result.stderr
+
+
+def test_git_rm_on_primary_blocked(repo: Path):
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {"command": "git rm curriculum/tracked.md"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 2, result.stderr
+
+
+def test_git_mv_via_dash_c_worktree_allowed(repo: Path):
+    worktree = repo / ".worktrees/dispatch/claude/task-1"
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {
+            "command": f"git -C {worktree} mv curriculum/tracked.md curriculum/renamed.md"
+        },
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 0, result.stderr
+
+
+def test_git_checkout_branch_only_not_blocked_by_git_guard(repo: Path):
+    """Branch switch has no pathspecs — left to the branch-switch guard."""
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {"command": "git checkout -b feature-x"},
+    }
+    result = _run(repo, payload)
+    # No git-mediated path intent → this hook allows (other hooks may still fire).
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Follow-up to #5516 / #5396 from GLM cross-family review (non-blocking findings, now closed as #5517).

Extends the primary-checkout git-mediated guard to also block:

- `git checkout <tree-ish> <path>` **without** `--` (was a bypass)
- `git mv` / `git rm` (mutate worktree + index)

Worktree targeting via `git -C` / cwd still allowed. Rescue `git checkout -- path` unchanged. Branch-only checkout left to the branch-switch guard.

## Test plan

- [x] 72 tests in `tests/test_guard_primary_checkout_write.py` pass
- [ ] CI green
- [ ] Cross-family review (non-Grok)

Closes #5517