### PR TITLE
feat(api): serve fleet doctrine + role scorecard via /api/rules (#5529)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1982,10 +1982,22 @@ hashes against its local cache and only refetches what changed.
 
 ### `GET /api/rules?format={markdown,json}`
 
-Condensed rule text from `claude_extensions/rules/` (critical +
-non-negotiable + workflow, in that order). Source of truth is the
-checked-in files so a fresh clone or worktree that hasn't deployed
-to `.claude/rules/` still gets correct content.
+Condensed always-load rule text for agent cold-start. Source of truth is
+the checked-in paths in `scripts/api/rules_router.RULE_SOURCES` (not the
+deployed `.claude/rules/` copies), so a fresh clone or worktree that
+hasn't run `npm run agents:deploy` still gets correct content.
+
+Assembly order (stable; hash changes if this list or any file changes):
+
+1. Operator expectations + critical + non-negotiable + workflow
+2. Worktree / CLI hygiene rules
+3. **`model-assignment.md`** — machine routing + fleet topology ladder
+4. **`docs/best-practices/fleet-shared-doctrine.md`** — doctrine (#5474)
+5. **`docs/best-practices/fleet-role-scorecard.md`** — living role scoreboard (#5474 / #5529)
+
+Machine routing (`model-assignment.md`) wins on conflict with the living
+scorecard. Agents that previously only saw topology via rules now also
+receive the scoreboard without a second file read.
 
 - `format=markdown` (default) → `text/markdown; charset=utf-8` with
   an `X-Rules-Hash` header. Drop-in for a system prompt. With telemetry

--- a/scripts/api/rules_router.py
+++ b/scripts/api/rules_router.py
@@ -65,6 +65,10 @@ def _matches_etag(if_none_match: str | None, digest: str) -> bool:
 # then the mandatory workflow and remaining always-load rules. Changing
 # this order is a user-visible contract change — agents that cache the
 # concatenated blob by hash will see a new hash and refetch.
+#
+# Fleet doctrine + living role scorecard (#5529 / #5474) ship AFTER
+# model-assignment so machine routing remains earlier in the blob while
+# cold-start agents still receive the scoreboard without hunting docs/.
 RULE_SOURCES: tuple[str, ...] = (
     "agents_extensions/shared/rules/operator-expectations.md",
     "agents_extensions/shared/rules/critical-rules.md",
@@ -73,6 +77,8 @@ RULE_SOURCES: tuple[str, ...] = (
     "agents_extensions/shared/rules/delegate-must-use-worktree.md",
     "agents_extensions/shared/rules/cli-help-standard.md",
     "agents_extensions/shared/rules/model-assignment.md",
+    "docs/best-practices/fleet-shared-doctrine.md",
+    "docs/best-practices/fleet-role-scorecard.md",
 )
 
 # Separator between files. Explicit so the concatenation is stable

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -39,8 +39,28 @@ def test_rule_sources_includes_all_unscoped_files():
         "agents_extensions/shared/rules/delegate-must-use-worktree.md",
         "agents_extensions/shared/rules/cli-help-standard.md",
         "agents_extensions/shared/rules/model-assignment.md",
+        "docs/best-practices/fleet-shared-doctrine.md",
+        "docs/best-practices/fleet-role-scorecard.md",
     }
     assert set(rules_router.RULE_SOURCES) == expected
+    # Order: machine routing before living scorecard (#5529).
+    assert rules_router.RULE_SOURCES.index(
+        "agents_extensions/shared/rules/model-assignment.md"
+    ) < rules_router.RULE_SOURCES.index("docs/best-practices/fleet-role-scorecard.md")
+
+
+def test_rules_live_assembly_includes_fleet_scorecard():
+    """Live PROJECT_ROOT must serve doctrine + scorecard so cold-starts see them."""
+    resp = client.get("/api/rules?format=json")
+    assert resp.status_code == 200
+    body = resp.json()
+    sources = body["sources"]
+    assert "docs/best-practices/fleet-shared-doctrine.md" in sources
+    assert "docs/best-practices/fleet-role-scorecard.md" in sources
+    md = body["markdown"]
+    assert "Fleet role scorecard" in md
+    assert "Fleet topology" in md or "orchestrator" in md.lower()
+    assert body["hash"] == hashlib.sha256(md.encode("utf-8")).hexdigest()
 
 
 def test_rules_markdown_default(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Closes **#5529** (parent **#5531** continuity freeze).

Agents that only load `GET /api/rules` never saw the living fleet role scoreboard (#5474). This PR appends:

1. `docs/best-practices/fleet-shared-doctrine.md`
2. `docs/best-practices/fleet-role-scorecard.md`

after `model-assignment.md` so **machine routing stays first** and the scoreboard still lands in the same cold-start blob (hash/ETag updates when either file changes).

## Test plan

- [x] `pytest tests/test_manifest_api.py` (25 passed)
- [ ] CI green
- [ ] Cross-family review

## Follow-ups (not this PR)

- Structured `GET /api/fleet/topology` + `/scorecard` for CodexBar (optional PR2 on #5529)
- Epic-stream handoff CLI (#5530)
- Multi-packet detect (#5398)

Closes #5529