### PR TITLE
fix(rollover): epic task-family filter for multi-packet detect (#5398)

### DIFF
--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -462,20 +462,44 @@ Do not dump or rewrite docs/session-state/current.md. For thread rollover, run:
 EOF
 }
 
+# Optional task-family filter from launcher epic (#5398). SESSION_EPIC is the
+# epic name (hramatka, atlas, harness); task_family on packets usually matches.
+TASK_FAMILY_ARGS=()
+if [ -n "${SESSION_EPIC:-}" ]; then
+  case "${SESSION_EPIC}" in
+    harness|infra) : ;; # do not over-filter infra packets
+    *) TASK_FAMILY_ARGS=(--task-family "$SESSION_EPIC") ;;
+  esac
+fi
+
 if ! DETECT_OUTPUT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
   --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
-  --current-thread-id "$CURRENT_THREAD_ID" --format json 2>&1); then
-  HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.
+  --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" --format json 2>&1); then
+  # Exit 2 may be multi-packet ambiguity (#5398) — surface candidates, never cold-start.
+  DETECT_ERR_CODE=$(printf '%s' "$DETECT_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
+try:
+  d=json.loads(sys.stdin.read()); print(d.get("error_code") or "")
+except Exception:
+  print("")' 2>/dev/null || true)
+  if [ "$DETECT_ERR_CODE" = "MULTIPLE_LIVE_PENDING_ROLLOVERS" ]; then
+    HANDOFF_CONTEXT="ERROR: MULTIPLE live pending rollovers — do not cold-start; bind one exact candidate.
+$DETECT_OUTPUT"
+  else
+    HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.
 Output:
 $DETECT_OUTPUT"
+  fi
 elif ! DETECT_STATUS=$(printf '%s' "$DETECT_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("status", ""), end="")'); then
   HANDOFF_CONTEXT="ERROR: thread_handoff.py detect output could not be parsed. Stop.
 Output:
 $DETECT_OUTPUT"
+elif [ "$DETECT_STATUS" = "ambiguous" ]; then
+  HANDOFF_CONTEXT="ERROR: MULTIPLE live pending rollovers — do not cold-start; bind one exact candidate.
+$DETECT_OUTPUT"
 elif [ "$DETECT_STATUS" = "pending_start" ] || [ "$DETECT_STATUS" = "resumed" ]; then
   if ! HANDOFF_CONTEXT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
     --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
-    --current-thread-id "$CURRENT_THREAD_ID" --format session-start 2>&1); then
+    --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" --format session-start 2>&1); then
     HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.
 Output:
 $HANDOFF_CONTEXT"

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -3308,6 +3308,73 @@ def render_session_start_context(candidate: dict[str, Any] | None, *, agent: str
     return "\n".join(lines)
 
 
+def _candidate_task_family(state: dict[str, Any], replacement: dict[str, Any]) -> str:
+    """Extract task_family from lease state / replacement identity blobs."""
+    for blob in (replacement, state):
+        if not isinstance(blob, dict):
+            continue
+        identity = blob.get("identity") or blob.get("task_identity") or {}
+        if isinstance(identity, dict):
+            family = str(identity.get("task_family") or "").strip().lower()
+            if family:
+                return family
+        family = str(blob.get("task_family") or "").strip().lower()
+        if family:
+            return family
+    return ""
+
+
+def _filter_live_leases_by_task_family(
+    live_leases: list[tuple[Path, dict[str, Any], dict[str, Any]]],
+    task_family: str,
+) -> list[tuple[Path, dict[str, Any], dict[str, Any]]]:
+    wanted = task_family.strip().lower()
+    if not wanted:
+        return live_leases
+    matched = [
+        item
+        for item in live_leases
+        if _candidate_task_family(item[1], item[2]) == wanted
+    ]
+    return matched
+
+
+def _render_multiple_pending_session_start(
+    *,
+    agent: str,
+    candidates: list[dict[str, Any]],
+    task_family_filter: str,
+) -> str:
+    lines = [
+        f"MULTIPLE LIVE PENDING ROLLOVERS for agent `{agent}` (#5398 class).",
+        "Do NOT cold-start. Do NOT pick by title or filesystem order.",
+        f"Candidate count: {len(candidates)}.",
+    ]
+    if task_family_filter:
+        lines.append(f"Task-family filter applied: `{task_family_filter}` (still ambiguous).")
+    lines.append("")
+    for i, cand in enumerate(candidates, start=1):
+        lines.append(
+            f"{i}. lineage_id={cand.get('lineage_id')} rollover_id={cand.get('rollover_id')} "
+            f"family={cand.get('task_family')} title={cand.get('visible_title')!r}"
+        )
+        issue = cand.get("issue") or {}
+        if isinstance(issue, dict) and issue.get("number"):
+            lines.append(f"   issue=#{issue.get('number')} {issue.get('url') or ''}".rstrip())
+        lines.append(
+            f"   bind: .venv/bin/python scripts/orchestration/thread_handoff.py bind-replacement "
+            f"--agent {agent} --lineage-id {cand.get('lineage_id')} "
+            f"--rollover-id {cand.get('rollover_id')} "
+            f"--replacement-task-id <this-thread-id> --evidence <harness-binding>"
+        )
+        lines.append("")
+    lines.append(
+        "Resolution: bind the exact candidate for THIS lane (or re-run detect with "
+        "`--task-family <family>` / launch with `--epic <name>`)."
+    )
+    return "\n".join(lines)
+
+
 def cmd_detect(args: argparse.Namespace) -> int:
     try:
         _, state_root = resolve_roots(args.repo_root)
@@ -3315,9 +3382,34 @@ def cmd_detect(args: argparse.Namespace) -> int:
         print(json.dumps({"error": str(exc)}, indent=2))
         return 2
     agent = normalize_agent_name(args.agent)
+    task_family_filter = str(getattr(args, "task_family", "") or "").strip().lower()
 
-    agent_dir = state_root / ".agent" / "thread-rollovers" / agent
-    if not agent_dir.exists():
+    # Agent directories to scan. Epic slots like claude-hramatka often have packets
+    # prepared under the bare `claude` namespace (#5398 / hramatka interim).
+    scan_agents = [agent]
+    # Epic slots (claude-hramatka, codex-folk, …) often have packets prepared under
+    # the bare provider namespace — scan both (#5398 slot trap).
+    if agent.startswith("claude-") and agent not in {"claude-infra", "claude-atlas"}:
+        scan_agents.append("claude")
+    elif agent.startswith("codex-") and agent not in {"codex-infra"}:
+        scan_agents.append("codex")
+
+    live_leases: list[tuple[Path, dict[str, Any], dict[str, Any], str]] = []
+
+    for scan_agent in scan_agents:
+        agent_dir = state_root / ".agent" / "thread-rollovers" / scan_agent
+        if not agent_dir.exists():
+            continue
+        for path in sorted(agent_dir.glob("*/lease.json")):
+            state = load_state(path)
+            replacement, error = validate_live_lease(state, agent=scan_agent, state_path=path)
+            if error:
+                print(json.dumps({"error": f"invalid rollover lease {rel(path, state_root)}: {error}"}, indent=2))
+                return 2
+            if replacement is not None and replacement["status"] in {"pending_start", "resumed"}:
+                live_leases.append((path, state, replacement, scan_agent))
+
+    if not live_leases:
         output: dict[str, Any] = {"agent": agent, "status": "none"}
         print(
             render_session_start_context(None, agent=agent, current_thread_id=args.current_thread_id)
@@ -3326,25 +3418,20 @@ def cmd_detect(args: argparse.Namespace) -> int:
         )
         return 0
 
-    live_leases: list[tuple[Path, dict[str, Any], dict[str, Any]]] = []
-
-    for path in sorted(agent_dir.glob("*/lease.json")):
-        state = load_state(path)
-        replacement, error = validate_live_lease(state, agent=agent, state_path=path)
-        if error:
-            print(json.dumps({"error": f"invalid rollover lease {rel(path, state_root)}: {error}"}, indent=2))
-            return 2
-        if replacement is not None and replacement["status"] in {"pending_start", "resumed"}:
-            live_leases.append((path, state, replacement))
-
-    if not live_leases:
-        output = {"agent": agent, "status": "none"}
-        print(
-            render_session_start_context(None, agent=agent, current_thread_id=args.current_thread_id)
-            if args.format == "session-start"
-            else json.dumps(output, indent=2)
-        )
-        return 0
+    # Narrow multi-packet sets by task family when the launcher knows the epic (#5398).
+    if task_family_filter and len(live_leases) > 1:
+        filtered = [
+            item
+            for item in live_leases
+            if _candidate_task_family(item[1], item[2]) == task_family_filter
+            or (
+                # Epic name often matches task_family (hramatka, folk, atlas, …).
+                task_family_filter in str(item[2].get("role") or "").lower()
+            )
+        ]
+        if len(filtered) == 1 or len(filtered) > 1:
+            live_leases = filtered
+        # If filter matches zero, keep full list so the operator sees everything.
 
     if len(live_leases) > 1:
         candidates = [
@@ -3353,24 +3440,35 @@ def cmd_detect(args: argparse.Namespace) -> int:
                 replacement,
                 state_file=rel(path, state_root),
             )
-            for path, state, replacement in live_leases
+            for path, state, replacement, _scan_agent in live_leases
         ]
-        print(
-            json.dumps(
-                {
-                    "error_code": "MULTIPLE_LIVE_PENDING_ROLLOVERS",
-                    "error": f"Multiple live pending rollovers found for agent {agent}.",
-                    "agent": agent,
-                    "candidate_count": len(candidates),
-                    "candidates": candidates,
-                    "resolution_policy": "Use exact candidate identifiers and receipts; never select by filesystem order, visible title, or automatic supersession.",
-                },
-                indent=2,
+        payload = {
+            "error_code": "MULTIPLE_LIVE_PENDING_ROLLOVERS",
+            "error": f"Multiple live pending rollovers found for agent {agent}.",
+            "agent": agent,
+            "status": "ambiguous",
+            "candidate_count": len(candidates),
+            "candidates": candidates,
+            "task_family_filter": task_family_filter or None,
+            "resolution_policy": (
+                "Use exact candidate identifiers and receipts; never select by filesystem "
+                "order, visible title, or automatic supersession. Prefer --task-family / "
+                "--epic launch filter when the lane is known."
+            ),
+        }
+        if args.format == "session-start":
+            print(
+                _render_multiple_pending_session_start(
+                    agent=agent,
+                    candidates=candidates,
+                    task_family_filter=task_family_filter,
+                )
             )
-        )
+        else:
+            print(json.dumps(payload, indent=2))
         return 2
 
-    path, state, replacement = live_leases[0]
+    path, state, replacement, scan_agent = live_leases[0]
     if (
         replacement["status"] == "resumed"
         and args.current_thread_id
@@ -3389,6 +3487,7 @@ def cmd_detect(args: argparse.Namespace) -> int:
 
     output = {
         "agent": agent,
+        "packet_agent": scan_agent,
         "lineage_id": state.get("lineage_id"),
         "rollover_id": replacement.get("rollover_id"),
         "status": replacement.get("status"),
@@ -3408,6 +3507,7 @@ def cmd_detect(args: argparse.Namespace) -> int:
         "identity_receipt_path": replacement.get("identity_receipt_path"),
         "identity": replacement.get("identity"),
         "title_transition": replacement.get("title_transition"),
+        "task_family_filter": task_family_filter or None,
     }
     print(
         render_session_start_context(output, agent=agent, current_thread_id=args.current_thread_id)
@@ -3614,6 +3714,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     detect.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
     detect.add_argument("--current-thread-id", default="")
+    detect.add_argument(
+        "--task-family",
+        default="",
+        help=(
+            "When multiple live packets exist, keep only candidates whose task_family "
+            "matches this value (e.g. hramatka). Prefer launching with --epic so "
+            "SessionStart can pass SESSION_EPIC here (#5398)."
+        ),
+    )
     detect.add_argument("--format", choices=("json", "session-start"), default="json")
     detect.set_defaults(func=cmd_detect)
     return parser

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -2328,6 +2328,7 @@ def test_detect_rejects_bad_or_ambiguous_engine_leases(tmp_path: Path, capsys, m
     payload = json.loads(capsys.readouterr().out)
     if mutation == "ambiguous":
         assert payload["error_code"] == "MULTIPLE_LIVE_PENDING_ROLLOVERS"
+        assert payload["status"] == "ambiguous"
         assert payload["candidate_count"] == 2
         assert "filesystem order" in payload["resolution_policy"]
         for candidate in payload["candidates"]:
@@ -2346,6 +2347,84 @@ def test_detect_rejects_bad_or_ambiguous_engine_leases(tmp_path: Path, capsys, m
                 "title_confirmation_state",
                 "safe_recommended_resolution",
             }
+
+
+def test_detect_task_family_filter_selects_one_of_many(tmp_path: Path, capsys, monkeypatch) -> None:
+    """#5398: --task-family must disambiguate multi-packet detect to one lane."""
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    for thread_id, family, title in (
+        ("old-a", "hramatka", "Ship hramatka lessons"),
+        ("old-b", "thread-rollover", "Repair infra PR"),
+    ):
+        assert (
+            th.main(
+                [
+                    "--repo-root",
+                    str(tmp_path),
+                    "prepare",
+                    "--agent",
+                    "claude",
+                    "--active-thread-id",
+                    thread_id,
+                    "--task-family",
+                    family,
+                    "--semantic-title",
+                    title,
+                    "--terminal-goal",
+                    "merge",
+                    "--role",
+                    f"{family} driver",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+    # Without filter: ambiguous exit 2.
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "claude"]) == 2
+    multi = json.loads(capsys.readouterr().out)
+    assert multi["error_code"] == "MULTIPLE_LIVE_PENDING_ROLLOVERS"
+    assert multi["candidate_count"] == 2
+
+    # With filter: single hramatka packet selected.
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "detect",
+                "--agent",
+                "claude",
+                "--task-family",
+                "hramatka",
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(capsys.readouterr().out)
+    assert selected["status"] == "pending_start"
+    assert selected["task_family_filter"] == "hramatka"
+    identity = selected.get("identity") or {}
+    assert identity.get("task_family") == "hramatka" or "hramatka" in str(selected).lower()
+
+    # Epic slot claude-hramatka scans bare claude namespace with filter (#5398 slot trap).
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "detect",
+                "--agent",
+                "claude-hramatka",
+                "--task-family",
+                "hramatka",
+            ]
+        )
+        == 0
+    )
+    epic_slot = json.loads(capsys.readouterr().out)
+    assert epic_slot["status"] == "pending_start"
+    assert epic_slot.get("packet_agent") == "claude"
 
 
 def test_epic_harness_session_start_surfaces_claude_infra_pending_packet(tmp_path: Path, capsys, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Closes **#5398** (parent continuity freeze **#5531**).

### Root cause (current main)
`thread_handoff.py detect` already returns exit 2 + candidates on multi-packet, but:
1. SessionStart treated exit 2 only as generic "detect failed" (easy to read as cold-start dead-end).
2. No **task-family / epic** filter — two `claude` packets always block even when launcher knows the lane.
3. Epic slots (`claude-hramatka`) did not scan bare `claude/` where interim packets live.

### Fix
- `--task-family` on detect; SessionStart passes `SESSION_EPIC` as family filter
- Epic agent slots also scan bare provider namespace (`claude-hramatka` → also `claude/`)
- Multi-packet JSON has `status: ambiguous`; session-start renders bind commands
- Hook: MULTIPLE error surfaces candidates, never "NO LIVE THREAD ROLLOVER"

### Live proof
```
detect --agent claude --task-family hramatka  → pending_start (Tetiana packet)
detect --agent claude-hramatka --task-family hramatka → same via packet_agent=claude
detect --agent claude (no filter) → exit 2 ambiguous ×2
```

## Test plan
- [x] focused unit tests for multi + family filter (84 thread_handoff tests in pre-commit)
- [ ] CI green
- [ ] CF review

Closes #5398