### PR TITLE
feat(canary): diary stamp/handback protocol for Grok lane recovery

### DIFF
--- a/docs/runbooks/grok-session-canary.md
+++ b/docs/runbooks/grok-session-canary.md
@@ -1,4 +1,4 @@
-# Grok session canary + auto-compact policy
+# Grok session canary + diary dual-write policy
 
 ## Problem
 
@@ -11,11 +11,67 @@ Ending a session *only because compact fired* is too early if recall is still sh
 | Signal | Meaning |
 | --- | --- |
 | Auto-compact | **Re-score** canary; keep driving only if PASS |
-| Canary **&lt; 8/10** (`pass-ratio` 0.8) | **FAIL-HANDOFF** → dual-write STATE AT HANDBACK, close stream, `/quit` |
+| Canary **&lt; 8/10** (`pass-ratio` 0.8) | **FAIL-HANDOFF** → auto **STATE AT HANDBACK** on diary + stream note → close stream → `/quit` |
 | Compact count / “compactions remaining” | **Not** an end criterion |
 | First compact | **Not** required before you may end; **not** a reason to delay a clean end |
 
 Production **thread rollover** still uses strict **10/10** via `scripts/context_canary.py mint --snapshot` (separate protocol).
+
+## Handoff = DIARY (required)
+
+The dual-write board under `.claude/<epic>-epic/*-DRIVER-HANDOFF.md` is a **diary**, not a one-shot close note.
+
+| When | Action |
+| --- | --- |
+| After each batch (merge, issue close, dispatch, advisor, block) | `stamp` |
+| After canary score PASS | auto stamp with `canary PASS … @ ~N tok` |
+| After canary FAIL or clean close | `handback` / auto FAIL template |
+| Cold-start | **Read diary + stream first**, then `mint` |
+
+### Mintable sections (keep short)
+
+Canary mint pulls bullets from headings matching **Next Drive** / **Hands-off** (see `scripts/session_canary/grok_lane.py`). Prefer:
+
+```markdown
+## Next Drive
+1. Concrete next action
+2. Another action
+
+## Hands-off
+- Foreign lanes
+- Primary checkout product writes
+```
+
+### No secrets
+
+Never put API keys, private teacher PII, or private-repo secrets in the diary.
+
+### CLI
+
+```bash
+# Mid-batch diary stamp + refresh Next Drive
+.venv/bin/python -m scripts.session_canary.grok_lane stamp --epic harness \
+  --title "merged continuity PRs" \
+  --bullet "#5532 MERGED" --bullet "#5533 MERGED" \
+  --next "Dispatch Terra B1" --next "Start Grok PR-C"
+
+# Clean close while canary still PASS
+.venv/bin/python -m scripts.session_canary.grok_lane handback --epic harness \
+  --reason "clean end" \
+  --canary-line "canary PASS 10/10 @ ~200k tok" \
+  --next "Resume Wave 1 B1" \
+  --pin "Sol SHIP memo binding" \
+  --open-pr "none"
+
+# FAIL-HANDOFF is automatic on score rc 2; optional overrides:
+.venv/bin/python -m scripts.session_canary.grok_lane score \
+  --epic harness --answers .claude/harness-epic/canary/answers.json \
+  --context-tokens 250000 \
+  --next-drive "Load STATE AT HANDBACK; mint; resume B1" \
+  --open-prs "PR #N still open"
+```
+
+Implementation: `scripts/session_canary/diary.py`.
 
 ## Operator config (recommended)
 
@@ -28,15 +84,14 @@ auto_compact_threshold_percent = 95
 
 Default `85` leaves little runway for a deliberate close after the banner.
 
-## CLI
+## CLI (canary)
 
 ```bash
-# Cold-start (after stream open + handoff load)
+# Cold-start (after stream open + diary load)
 .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas --stream epic:4387
 .venv/bin/python -m scripts.session_canary.grok_lane questions --epic atlas
 
 # Mid-session / post-compact (answers FROM MEMORY — do not re-open probe.json)
-# Write .claude/atlas-epic/canary/answers.json as {"anchor-id": "your recall", ...}
 .venv/bin/python -m scripts.session_canary.grok_lane score \
   --epic atlas \
   --answers .claude/atlas-epic/canary/answers.json \
@@ -52,11 +107,12 @@ Artifacts live under gitignored `.claude/<epic>-epic/canary/`.
 ## Lifecycle
 
 ```
-START  → open stream lease → dual-write handoff → mint canary
-DRIVE  → dual-write after each batch
+START  → open stream lease → load diary + stream → mint canary
+DRIVE  → stamp diary after each batch
          at ~60–70% context OR after auto-compact → score from memory
+         PASS → diary canary line; continue
          FAIL → STATE AT HANDBACK + close stream + quit
-END    → optional clean close while canary still PASS (before forced compact if possible)
+END    → handback while PASS (optional) before forced compact
 ```
 
 ## SSOT
@@ -64,11 +120,13 @@ END    → optional clean close while canary still PASS (before forced compact i
 | Store | Role |
 | --- | --- |
 | Session stream (`epic:N`) | Primary typed continuity |
-| INTERIM / CLAUDE driver handoff | Dual-write board |
+| INTERIM / CLAUDE / CODEX driver handoff | Dual-write **diary** board |
 | Canary probe | Rot measurement only (not the board) |
 
 ## Related
 
+- `scripts/session_canary/diary.py` — stamp / handback helpers
+- `docs/runbooks/epic-stream-handoff.md` — cross-agent stream claim
 - `scripts/context_canary.py` — shared mint/score engine
 - `docs/best-practices/codex-thread-handoff.md` — strict rollover canary
 - `start-grok.sh --epic <name>` — cold-start injects lane protocol pointer

--- a/scripts/session_canary/diary.py
+++ b/scripts/session_canary/diary.py
@@ -1,0 +1,317 @@
+"""Driver-handoff diary helpers for Grok lane canary recovery.
+
+The dual-write handoff file is the human SSOT that survives compact/rot.
+This module keeps stamps mintable (Next Drive / Hands-off bullets) and
+emits a fixed STATE AT HANDBACK block on FAIL or clean close.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+DIARY_MARKER = "## 📔 Diary — reverse chrono (newest first)"
+NEXT_DRIVE_MARKER = "## Next Drive"
+HANDS_OFF_MARKER = "## Hands-off"
+HANDBACK_MARKER = "## STATE AT HANDBACK"
+
+_LAST_STAMP_RE = re.compile(
+    r"^(\*\*Last diary stamp:\*\*)\s*.+$",
+    re.MULTILINE,
+)
+
+
+def utc_stamp() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%MZ")
+
+
+def resolve_handoff_path(repo: Path, epic: str, override: str | Path | None = None) -> Path:
+    if override:
+        p = Path(override)
+        return p if p.is_absolute() else (repo / p)
+    base = repo / ".claude" / f"{epic}-epic"
+    for name in (
+        "INTERIM-DRIVER-HANDOFF.md",
+        "CLAUDE-DRIVER-HANDOFF.md",
+        "CODEX-DRIVER-HANDOFF.md",
+    ):
+        cand = base / name
+        if cand.is_file():
+            return cand
+    # Prefer INTERIM as write target for Grok interim drivers.
+    return base / "INTERIM-DRIVER-HANDOFF.md"
+
+
+def _ensure_section(text: str, heading: str, default_body: str) -> str:
+    title = heading.lstrip("#").strip()
+    if heading in text or re.search(
+        rf"^##\s+.*{re.escape(title)}", text, re.MULTILINE | re.IGNORECASE
+    ):
+        return text
+    return text.rstrip() + "\n\n" + heading + "\n" + default_body.rstrip() + "\n"
+
+
+def ensure_diary_skeleton(text: str, *, epic: str, stream_id: str) -> str:
+    """Ensure mintable sections exist (idempotent)."""
+    if not text.strip():
+        text = (
+            f"# Driver handoff — epic `{epic}` / stream `{stream_id}`\n\n"
+            f"> **Handoff = DIARY.** Stamp after every batch. Mint canary only after load.\n\n"
+            f"**Last diary stamp:** never\n\n"
+        )
+    if "**Last diary stamp:**" not in text:
+        # Insert after first heading
+        lines = text.splitlines()
+        if lines and lines[0].startswith("#"):
+            lines.insert(1, "")
+            lines.insert(2, "**Last diary stamp:** never")
+            text = "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+        else:
+            text = "**Last diary stamp:** never\n\n" + text
+
+    text = _ensure_section(
+        text,
+        NEXT_DRIVE_MARKER,
+        "1. (update after each batch — short bullets only; canary mints these)\n",
+    )
+    # Accept either "## Hands-off" or "## Hands-off / Out of scope"
+    if not re.search(r"^##\s+Hands-off", text, re.MULTILINE | re.IGNORECASE):
+        text = text.rstrip() + f"\n\n{HANDS_OFF_MARKER}\n- (lane boundaries)\n"
+    if DIARY_MARKER not in text and not re.search(r"^##\s+.*Diary", text, re.MULTILINE | re.IGNORECASE):
+        text = text.rstrip() + f"\n\n{DIARY_MARKER}\n\n"
+    if "No secrets" not in text and "no secrets" not in text.lower():
+        # Insert once near top (after title / stamp).
+        lines = text.splitlines()
+        insert_at = 0
+        for i, line in enumerate(lines[:12]):
+            if line.startswith("#"):
+                insert_at = i + 1
+                break
+        banner = "> **No secrets / private teacher PII / API keys** in this file."
+        lines.insert(insert_at, "")
+        lines.insert(insert_at + 1, banner)
+        text = "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+    return text
+
+
+def append_diary_stamp(
+    path: Path,
+    *,
+    title: str,
+    bullets: Sequence[str],
+    next_drive: Sequence[str] | None = None,
+    stamp: str | None = None,
+) -> str:
+    """Prepend a diary entry; optionally replace Next Drive bullets. Returns stamp used."""
+    stamp = stamp or utc_stamp()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = path.read_text(encoding="utf-8", errors="replace") if path.is_file() else ""
+    text = ensure_diary_skeleton(text, epic=path.parent.name.replace("-epic", ""), stream_id="epic:?")
+
+    # Update last stamp
+    if _LAST_STAMP_RE.search(text):
+        text = _LAST_STAMP_RE.sub(rf"\1 {stamp}", text, count=1)
+
+    bullet_lines = "\n".join(f"- {b.strip()}" for b in bullets if b and b.strip())
+    entry = f"### {stamp} — {title.strip()}\n{bullet_lines}\n\n"
+
+    # Insert under diary marker
+    diary_re = re.compile(
+        r"^(##\s+.*Diary[^\n]*\n\n)",
+        re.MULTILINE | re.IGNORECASE,
+    )
+    m = diary_re.search(text)
+    text = (
+        text[: m.end()] + entry + text[m.end() :]
+        if m
+        else text.rstrip() + f"\n\n{DIARY_MARKER}\n\n" + entry
+    )
+
+    if next_drive is not None:
+        text = replace_next_drive_bullets(text, next_drive)
+
+    path.write_text(text if text.endswith("\n") else text + "\n", encoding="utf-8")
+    return stamp
+
+
+def replace_next_drive_bullets(text: str, bullets: Sequence[str]) -> str:
+    """Replace content under ## Next Drive until next ## heading."""
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        out.append(lines[i])
+        if re.match(r"^##\s+Next Drive\b", lines[i], re.IGNORECASE):
+            i += 1
+            # skip old body until next ##
+            while i < len(lines) and not re.match(r"^##\s+", lines[i]):
+                i += 1
+            for n, b in enumerate(bullets, start=1):
+                b = b.strip()
+                if not b:
+                    continue
+                # Prefer numbered list for mint friendliness
+                if re.match(r"^\d+\.", b):
+                    out.append(b + "\n")
+                else:
+                    out.append(f"{n}. {b}\n")
+            out.append("\n")
+            continue
+        i += 1
+    return "".join(out)
+
+
+def format_canary_score_line(
+    *,
+    verdict: str,
+    score_line: str,
+    context_tokens: int,
+    pass_ratio: float,
+) -> str:
+    tok = f"~{context_tokens} tok" if context_tokens else "tok=n/a"
+    # SCORE line from context_canary is like: SCORE 9/10 pass=...
+    short = score_line.replace("SCORE ", "").strip() if score_line else verdict
+    return f"canary {verdict} {short} @ {tok} (pass-ratio {pass_ratio})"
+
+
+def format_handback_block(
+    *,
+    stamp: str,
+    epic: str,
+    stream_id: str,
+    reason: str,
+    pins: Sequence[str],
+    open_prs: Sequence[str],
+    next_drive: Sequence[str],
+    hands_off: Sequence[str],
+    pending_user: Sequence[str],
+    worktrees: Sequence[str],
+    canary_line: str,
+    notes: Sequence[str] = (),
+) -> str:
+    def bullets(items: Sequence[str]) -> str:
+        items = [i.strip() for i in items if i and i.strip()]
+        if not items:
+            return "- (none)\n"
+        return "".join(f"- {i}\n" for i in items)
+
+    def numbered(items: Sequence[str]) -> str:
+        items = [i.strip() for i in items if i and i.strip()]
+        if not items:
+            return "1. (none)\n"
+        out = []
+        for n, i in enumerate(items, start=1):
+            if re.match(r"^\d+\.", i):
+                out.append(i + "\n")
+            else:
+                out.append(f"{n}. {i}\n")
+        return "".join(out)
+
+    return (
+        f"{HANDBACK_MARKER} — {stamp}\n\n"
+        f"**Epic / stream:** `{epic}` / `{stream_id}`\n"
+        f"**Reason:** {reason.strip()}\n"
+        f"**Canary:** {canary_line.strip()}\n\n"
+        f"### Pins\n{bullets(pins)}"
+        f"\n### Open PRs / in flight\n{bullets(open_prs)}"
+        f"\n### Next Drive (mintable)\n{numbered(next_drive)}"
+        f"\n### Hands-off\n{bullets(hands_off)}"
+        f"\n### Pending user\n{bullets(pending_user)}"
+        f"\n### Worktrees\n{bullets(worktrees)}"
+        f"\n### Notes\n{bullets(notes)}"
+        f"\n> Successor: load this block + stream tail, then "
+        f"`.venv/bin/python -m scripts.session_canary.grok_lane mint --epic {epic}`.\n"
+        f"> Do **not** invent the queue from chat memory alone.\n"
+    )
+
+
+def append_handback(
+    path: Path,
+    *,
+    epic: str,
+    stream_id: str,
+    reason: str,
+    pins: Sequence[str],
+    open_prs: Sequence[str],
+    next_drive: Sequence[str],
+    hands_off: Sequence[str],
+    pending_user: Sequence[str],
+    worktrees: Sequence[str],
+    canary_line: str,
+    notes: Sequence[str] = (),
+    stamp: str | None = None,
+) -> str:
+    """Append STATE AT HANDBACK and a diary stamp. Sync Next Drive bullets."""
+    stamp = stamp or utc_stamp()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = path.read_text(encoding="utf-8", errors="replace") if path.is_file() else ""
+    text = ensure_diary_skeleton(text, epic=epic, stream_id=stream_id)
+    if _LAST_STAMP_RE.search(text):
+        text = _LAST_STAMP_RE.sub(rf"\1 {stamp}", text, count=1)
+
+    block = format_handback_block(
+        stamp=stamp,
+        epic=epic,
+        stream_id=stream_id,
+        reason=reason,
+        pins=pins,
+        open_prs=open_prs,
+        next_drive=next_drive,
+        hands_off=hands_off,
+        pending_user=pending_user,
+        worktrees=worktrees,
+        canary_line=canary_line,
+        notes=notes,
+    )
+
+    # Keep history: always append a new handback block (never delete prior ones).
+    text = text.rstrip() + "\n\n" + block
+
+    text = replace_next_drive_bullets(text, next_drive)
+
+    # Diary stamp pointing at handback
+    diary_entry = (
+        f"### {stamp} — STATE AT HANDBACK ({reason.strip()})\n"
+        f"- {canary_line.strip()}\n"
+        f"- Full block under `{HANDBACK_MARKER}` below/above.\n"
+        f"- Successor must mint canary after loading this file + stream.\n\n"
+    )
+    diary_re = re.compile(r"^(##\s+.*Diary[^\n]*\n\n)", re.MULTILINE | re.IGNORECASE)
+    m = diary_re.search(text)
+    if m:
+        text = text[: m.end()] + diary_entry + text[m.end() :]
+    else:
+        text = text.rstrip() + f"\n\n{DIARY_MARKER}\n\n" + diary_entry
+
+    path.write_text(text if text.endswith("\n") else text + "\n", encoding="utf-8")
+    return stamp
+
+
+def try_stream_state_note(stream_id: str, body: str, *, idempotency_key: str) -> bool:
+    """Best-effort append stream state under active env lease. Fail-open."""
+    try:
+        import os
+
+        from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+        from agents_extensions.shared.session_streams.hooks import lease_from_environment
+        from agents_extensions.shared.session_streams.model import EntryType
+        from agents_extensions.shared.session_streams.store import SessionStreamStore
+
+        if not os.environ.get("SESSION_STREAM_LEASE_ID"):
+            return False
+        store = SessionStreamStore(SessionStreamDatabase())
+        lease = lease_from_environment()
+        if lease.stream_id != stream_id:
+            return False
+        store.heartbeat(lease)
+        store.append_entry(
+            lease,
+            entry_type=EntryType.STATE,
+            body=body,
+            idempotency_key=idempotency_key[:200],
+        )
+        return True
+    except Exception:
+        return False

--- a/scripts/session_canary/grok_lane.py
+++ b/scripts/session_canary/grok_lane.py
@@ -457,9 +457,82 @@ def cmd_score(args: argparse.Namespace) -> int:
     }
     verdict_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     print(f"verdict -> {verdict_path}")
-    if verdict == "FAIL-HANDOFF":
-        print("ACTION: FAIL-HANDOFF — dual-write STATE AT HANDBACK, close stream, end session now.")
+
+    # Diary dual-write: always stamp canary line; on FAIL write STATE AT HANDBACK template.
+    try:
+        from scripts.session_canary import diary as diary_mod
+
+        handoff_path = diary_mod.resolve_handoff_path(repo, epic, getattr(args, "handoff", None))
+        canary_line = diary_mod.format_canary_score_line(
+            verdict=verdict,
+            score_line=score_line,
+            context_tokens=int(args.context_tokens),
+            pass_ratio=pass_ratio,
+        )
+        stream_id = EPIC_STREAM_DEFAULTS.get(epic, "epic:N")
+        meta_path = out_dir / "mint_meta.json"
+        if meta_path.is_file():
+            import contextlib
+            with contextlib.suppress(json.JSONDecodeError, OSError):
+                stream_id = json.loads(meta_path.read_text(encoding="utf-8")).get("stream_id") or stream_id
+
+        if verdict == "FAIL-HANDOFF":
+            next_drive = _split_csv_lines(getattr(args, "next_drive", "") or "")
+            if not next_drive:
+                next_drive = [
+                    "Load STATE AT HANDBACK + stream tail; re-mint canary",
+                    "Resume only from dual-write Next Drive bullets",
+                ]
+            diary_mod.append_handback(
+                handoff_path,
+                epic=epic,
+                stream_id=stream_id,
+                reason="canary FAIL-HANDOFF",
+                pins=_split_csv_lines(getattr(args, "pins", "") or ""),
+                open_prs=_split_csv_lines(getattr(args, "open_prs", "") or ""),
+                next_drive=next_drive,
+                hands_off=_split_csv_lines(getattr(args, "hands_off", "") or "")
+                or ["Foreign lanes", "Primary checkout product writes"],
+                pending_user=_split_csv_lines(getattr(args, "pending_user", "") or ""),
+                worktrees=_split_csv_lines(getattr(args, "worktrees", "") or ""),
+                canary_line=canary_line,
+                notes=["Auto-written by grok_lane score on FAIL-HANDOFF"],
+            )
+            print(f"diary handback -> {handoff_path}")
+            diary_mod.try_stream_state_note(
+                stream_id,
+                f"STATE AT HANDBACK (canary FAIL-HANDOFF): {canary_line}",
+                idempotency_key=f"handback-{_utc_now()}",
+            )
+            print("ACTION: FAIL-HANDOFF — STATE AT HANDBACK written; close stream lease; /quit now.")
+        else:
+            diary_mod.append_diary_stamp(
+                handoff_path,
+                title="canary score PASS",
+                bullets=[canary_line, "Continue drive; dual-write after next batch."],
+            )
+            print(f"diary stamp -> {handoff_path}")
+            diary_mod.try_stream_state_note(
+                stream_id,
+                f"Canary PASS: {canary_line}",
+                idempotency_key=f"canary-pass-{_utc_now()}",
+            )
+    except Exception as exc:  # fail-open: never block score exit codes
+        print(f"warning: diary dual-write skipped ({type(exc).__name__}: {exc})", file=sys.stderr)
+
     return 0 if proc.returncode == 0 else (2 if proc.returncode == 2 else proc.returncode)
+
+
+def _split_csv_lines(raw: str) -> list[str]:
+    """Split ';' or newline separated bullets from CLI flags."""
+    if not raw or not raw.strip():
+        return []
+    parts: list[str] = []
+    for chunk in raw.replace("\n", ";").split(";"):
+        chunk = chunk.strip()
+        if chunk:
+            parts.append(chunk)
+    return parts
 
 
 def cmd_status(args: argparse.Namespace) -> int:
@@ -484,20 +557,35 @@ def cmd_protocol(args: argparse.Namespace) -> int:
     epic = args.epic.strip().lower()
     stream = args.stream or EPIC_STREAM_DEFAULTS.get(epic, "epic:N")
     canary = f".claude/{epic}-epic/canary"
-    text = f"""## Grok lane session canary (operational)
+    handoff = f".claude/{epic}-epic/INTERIM-DRIVER-HANDOFF.md"
+    text = f"""## Grok lane session canary + diary (operational)
 
 You are bound to epic **{epic}** / stream **{stream}**.
 
-### SSOT (survives compact)
+### SSOT (survives compact) — chat does not
 - Session stream dual-write (typed entries)
-- `{canary.replace('canary', 'INTERIM-DRIVER-HANDOFF.md')}` or CLAUDE-DRIVER-HANDOFF.md (read-only if not interim)
+- Dual-write **diary handoff** (prefer `{handoff}` / CLAUDE-DRIVER-HANDOFF.md)
+- Canary probe under `{canary}/` — rot measurement only, **not** the board
+
+### Handoff = DIARY (required)
+After every real batch (merge, issue close, dispatch start, advisor note, block):
+```bash
+.venv/bin/python -m scripts.session_canary.grok_lane stamp --epic {epic} \\
+  --title "short what changed" \\
+  --bullet "fact 1" --bullet "fact 2" \\
+  --next "next action 1" --next "next action 2"
+```
+Keep **## Next Drive** as short numbered bullets (canary mints these). No secrets/PII.
 
 ### End signal = canary score, NOT compact count
 - Auto-compact is lossy for working memory. Disk logs ≠ model brain.
 - **First auto-compact ⇒ re-score**, do not auto-quit solely because compact fired.
 - **FAIL-HANDOFF (&lt; 8/10 at pass-ratio 0.8) ⇒ end now** regardless of token %.
 
-### Cold-start (after stream open + handoff load)
+### Cold-start (order is load-bearing)
+1. Open/claim stream lease for `{stream}`
+2. **Read diary handoff + stream tail first** (do not invent queue from chat)
+3. Only then mint:
 ```bash
 .venv/bin/python -m scripts.session_canary.grok_lane mint --epic {epic} --stream {stream}
 .venv/bin/python -m scripts.session_canary.grok_lane questions --epic {epic}
@@ -519,7 +607,14 @@ Do not open `probe.json` when later scoring from memory.
   --answers {canary}/answers.json \\
   --context-tokens <N> --model grok-4.5
 ```
-4. rc 0 = PASS (continue). rc 2 = FAIL-HANDOFF → dual-write STATE AT HANDBACK, close stream, `/quit`.
+4. rc 0 = PASS → auto diary stamp with canary line.
+   rc 2 = FAIL-HANDOFF → auto **STATE AT HANDBACK** block; close stream; `/quit`.
+
+### Clean close (optional while still PASS)
+```bash
+.venv/bin/python -m scripts.session_canary.grok_lane handback --epic {epic} \\
+  --reason "clean end" --next "..." --bullet "..."
+```
 
 ### Operator compact config (optional)
 In `~/.grok/config.toml`:
@@ -534,6 +629,67 @@ Strict 10/10 identity rollover still uses:
 `scripts/context_canary.py mint --snapshot …` + score — not this operational lane canary.
 """
     print(text)
+    return 0
+
+
+def cmd_stamp(args: argparse.Namespace) -> int:
+    """Append a diary stamp + optional Next Drive refresh."""
+    from scripts.session_canary import diary as diary_mod
+
+    repo = Path(args.repo).resolve()
+    epic = args.epic.strip().lower()
+    stream = args.stream or EPIC_STREAM_DEFAULTS.get(epic, "epic:N")
+    path = diary_mod.resolve_handoff_path(repo, epic, args.handoff)
+    bullets = list(args.bullet or [])
+    if args.title and not bullets:
+        bullets = [args.title]
+    if not bullets:
+        print("error: provide --bullet at least once (or a meaningful --title)", file=sys.stderr)
+        return 2
+    next_drive = list(args.next) if args.next else None
+    stamp = diary_mod.append_diary_stamp(
+        path,
+        title=args.title or "batch",
+        bullets=bullets,
+        next_drive=next_drive,
+    )
+    print(f"diary stamp {stamp} -> {path}")
+    note = f"DIARY {stamp}: {args.title or 'batch'}; " + "; ".join(bullets[:5])
+    if diary_mod.try_stream_state_note(stream, note[:500], idempotency_key=f"diary-{stamp}-{epic}"):
+        print(f"stream state noted on {stream}")
+    return 0
+
+
+def cmd_handback(args: argparse.Namespace) -> int:
+    """Write STATE AT HANDBACK (clean close or manual FAIL close)."""
+    from scripts.session_canary import diary as diary_mod
+
+    repo = Path(args.repo).resolve()
+    epic = args.epic.strip().lower()
+    stream = args.stream or EPIC_STREAM_DEFAULTS.get(epic, "epic:N")
+    path = diary_mod.resolve_handoff_path(repo, epic, args.handoff)
+    next_drive = list(args.next or []) or ["Load STATE AT HANDBACK + stream; mint canary; resume"]
+    canary_line = args.canary_line or "canary not scored this close"
+    stamp = diary_mod.append_handback(
+        path,
+        epic=epic,
+        stream_id=stream,
+        reason=args.reason or "clean close",
+        pins=list(args.pin or []),
+        open_prs=list(args.open_pr or []),
+        next_drive=next_drive,
+        hands_off=list(args.hands_off or []) or ["Foreign lanes"],
+        pending_user=list(args.pending_user or []),
+        worktrees=list(args.worktree or []),
+        canary_line=canary_line,
+        notes=list(args.note or []),
+    )
+    print(f"STATE AT HANDBACK {stamp} -> {path}")
+    diary_mod.try_stream_state_note(
+        stream,
+        f"STATE AT HANDBACK ({args.reason or 'clean close'}): {canary_line}",
+        idempotency_key=f"handback-cmd-{stamp}",
+    )
     return 0
 
 
@@ -567,6 +723,13 @@ def build_parser() -> argparse.ArgumentParser:
     score.add_argument("--model", default="grok-4.5")
     score.add_argument("--pass-ratio", type=float, default=DEFAULT_PASS_RATIO, help="Default 0.8 (8/10)")
     score.add_argument("--threshold", type=float, default=DEFAULT_SIM_THRESHOLD, help="Per-anchor sim threshold")
+    score.add_argument("--handoff", default=None, help="Dual-write diary path override")
+    score.add_argument("--next-drive", default="", help="On FAIL: Next Drive bullets separated by ';'")
+    score.add_argument("--pins", default="", help="On FAIL: pin bullets separated by ';'")
+    score.add_argument("--open-prs", default="", help="On FAIL: open PR bullets separated by ';'")
+    score.add_argument("--hands-off", default="", help="On FAIL: hands-off bullets separated by ';'")
+    score.add_argument("--pending-user", default="", help="On FAIL: pending-user bullets separated by ';'")
+    score.add_argument("--worktrees", default="", help="On FAIL: worktree bullets separated by ';'")
     score.set_defaults(func=cmd_score)
 
     status = sub.add_parser("status", help="Show canary artifact presence + last verdict")
@@ -578,6 +741,30 @@ def build_parser() -> argparse.ArgumentParser:
     protocol.add_argument("--epic", default="atlas")
     protocol.add_argument("--stream", default=None)
     protocol.set_defaults(func=cmd_protocol)
+
+    stamp = sub.add_parser("stamp", help="Append diary stamp (+ optional Next Drive refresh)")
+    stamp.add_argument("--epic", required=True)
+    stamp.add_argument("--stream", default=None)
+    stamp.add_argument("--handoff", default=None)
+    stamp.add_argument("--title", default="batch", help="Diary entry title")
+    stamp.add_argument("--bullet", action="append", default=[], help="Diary bullet (repeatable)")
+    stamp.add_argument("--next", action="append", default=[], help="Replace Next Drive bullets (repeatable)")
+    stamp.set_defaults(func=cmd_stamp)
+
+    handback = sub.add_parser("handback", help="Write STATE AT HANDBACK (clean close or manual fail)")
+    handback.add_argument("--epic", required=True)
+    handback.add_argument("--stream", default=None)
+    handback.add_argument("--handoff", default=None)
+    handback.add_argument("--reason", default="clean close")
+    handback.add_argument("--canary-line", default="")
+    handback.add_argument("--pin", action="append", default=[])
+    handback.add_argument("--open-pr", action="append", default=[])
+    handback.add_argument("--next", action="append", default=[])
+    handback.add_argument("--hands-off", action="append", default=[])
+    handback.add_argument("--pending-user", action="append", default=[])
+    handback.add_argument("--worktree", action="append", default=[])
+    handback.add_argument("--note", action="append", default=[])
+    handback.set_defaults(func=cmd_handback)
 
     return p
 

--- a/tests/test_session_canary_diary.py
+++ b/tests/test_session_canary_diary.py
@@ -1,0 +1,165 @@
+"""Diary dual-write helpers for Grok lane canary recovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.session_canary import diary as d
+from scripts.session_canary import grok_lane as gl
+
+
+def test_append_diary_stamp_and_next_drive(tmp_path: Path) -> None:
+    path = tmp_path / "INTERIM-DRIVER-HANDOFF.md"
+    d.append_diary_stamp(
+        path,
+        title="merged PR",
+        bullets=["#5532 MERGED", "scorecard on /api/rules"],
+        next_drive=["Dispatch Terra B1", "Start Grok PR-C"],
+        stamp="2026-07-20T12:00Z",
+    )
+    text = path.read_text(encoding="utf-8")
+    assert "**Last diary stamp:** 2026-07-20T12:00Z" in text
+    assert "### 2026-07-20T12:00Z — merged PR" in text
+    assert "#5532 MERGED" in text
+    assert "## Next Drive" in text
+    assert "1. Dispatch Terra B1" in text
+    assert "2. Start Grok PR-C" in text
+    assert "No secrets" in text
+
+
+def test_handback_block_and_next_drive(tmp_path: Path) -> None:
+    path = tmp_path / "CLAUDE-DRIVER-HANDOFF.md"
+    d.append_handback(
+        path,
+        epic="harness",
+        stream_id="epic:4707",
+        reason="canary FAIL-HANDOFF",
+        pins=["Sol SHIP binding"],
+        open_prs=["none"],
+        next_drive=["Load handback", "Mint canary"],
+        hands_off=["Atlas #5496"],
+        pending_user=["lift hold"],
+        worktrees=[".worktrees/dispatch/grok/x"],
+        canary_line="canary FAIL-HANDOFF 7/10 @ ~300000 tok",
+        stamp="2026-07-20T13:00Z",
+    )
+    text = path.read_text(encoding="utf-8")
+    assert "## STATE AT HANDBACK — 2026-07-20T13:00Z" in text
+    assert "canary FAIL-HANDOFF 7/10" in text
+    assert "1. Load handback" in text
+    assert "### 2026-07-20T13:00Z — STATE AT HANDBACK" in text
+    assert "Successor: load this block" in text
+
+
+def test_format_canary_score_line() -> None:
+    line = d.format_canary_score_line(
+        verdict="PASS",
+        score_line="SCORE 9/10 pass_ratio=0.8",
+        context_tokens=250_000,
+        pass_ratio=0.8,
+    )
+    assert "PASS" in line
+    assert "9/10" in line
+    assert "250000" in line
+
+
+def test_stamp_cli(tmp_path: Path) -> None:
+    handoff = tmp_path / "INTERIM-DRIVER-HANDOFF.md"
+    # epic dir layout not required — pass --handoff
+    rc = gl.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "stamp",
+            "--epic",
+            "harness",
+            "--handoff",
+            str(handoff),
+            "--title",
+            "batch",
+            "--bullet",
+            "did X",
+            "--next",
+            "do Y",
+        ]
+    )
+    assert rc == 0
+    text = handoff.read_text(encoding="utf-8")
+    assert "did X" in text
+    assert "1. do Y" in text
+
+
+def test_handback_cli(tmp_path: Path) -> None:
+    handoff = tmp_path / "INTERIM-DRIVER-HANDOFF.md"
+    rc = gl.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "handback",
+            "--epic",
+            "harness",
+            "--stream",
+            "epic:4707",
+            "--handoff",
+            str(handoff),
+            "--reason",
+            "clean end",
+            "--next",
+            "resume B1",
+            "--canary-line",
+            "canary PASS 10/10 @ ~100k tok",
+        ]
+    )
+    assert rc == 0
+    text = handoff.read_text(encoding="utf-8")
+    assert "STATE AT HANDBACK" in text
+    assert "clean end" in text
+    assert "resume B1" in text
+
+
+def test_score_fail_writes_handback(tmp_path: Path, monkeypatch) -> None:
+    """score FAIL path should write STATE AT HANDBACK even if context_canary is mocked."""
+    canary = tmp_path / "canary"
+    canary.mkdir()
+    (canary / "probe.json").write_text("{}", encoding="utf-8")
+    answers = canary / "answers.json"
+    answers.write_text("{}", encoding="utf-8")
+    handoff = tmp_path / "INTERIM-DRIVER-HANDOFF.md"
+    handoff.write_text("## Next Drive\n1. x\n## Hands-off\n- y\n", encoding="utf-8")
+
+    class FakeProc:
+        returncode = 2
+        stdout = "SCORE 6/10 (failed)\n"
+        stderr = ""
+
+    monkeypatch.setattr(gl.subprocess, "run", lambda *a, **k: FakeProc())
+    monkeypatch.setattr(
+        "scripts.session_canary.diary.resolve_handoff_path",
+        lambda repo, epic, override=None: handoff,
+    )
+    rc = gl.main(
+        [
+            "--repo",
+            str(tmp_path),
+            "score",
+            "--epic",
+            "harness",
+            "--out-dir",
+            str(canary),
+            "--answers",
+            str(answers),
+            "--context-tokens",
+            "999",
+            "--handoff",
+            str(handoff),
+            "--next-drive",
+            "Load handback; mint",
+        ]
+    )
+    assert rc == 2
+    text = handoff.read_text(encoding="utf-8")
+    assert "STATE AT HANDBACK" in text
+    assert "FAIL-HANDOFF" in text or "canary" in text.lower()
+    verdict = json.loads((canary / "last_verdict.json").read_text(encoding="utf-8"))
+    assert verdict["verdict"] == "FAIL-HANDOFF"


### PR DESCRIPTION
## Summary

Implements the **handoff-as-diary** improvements for Grok canary recovery:

| Improvement | How |
| --- | --- |
| Stamp after batches | `grok_lane stamp --bullet … --next …` |
| Mid-session canary line | `score` PASS auto-stamps `canary PASS … @ ~N tok` |
| Fixed STATE AT HANDBACK | auto on FAIL-HANDOFF; manual `handback` for clean close |
| Mintable Next Drive | stamp/handback refresh numbered bullets |
| No secrets | skeleton banner on diary files |
| Cold-start order | protocol: load diary+stream **then** mint |
| Stream note | best-effort state append when lease env present |

## Files
- `scripts/session_canary/diary.py` (new)
- `scripts/session_canary/grok_lane.py` — stamp/handback commands + score dual-write
- `docs/runbooks/grok-session-canary.md` — full policy
- tests

## Test plan
- [x] `pytest tests/test_session_canary_diary.py` + existing canary tests
- [ ] CI green
- [ ] CF review