### PR TITLE
feat(fleet-comms): Wave 1 B1/B2/C/D artifact store, conformance, executor

### DIFF
--- a/scripts/fleet_comms/__init__.py
+++ b/scripts/fleet_comms/__init__.py
@@ -1,1 +1,19 @@
-"""Fleet Communications System v1 contracts and storage migrations."""
+"""Fleet Communications System v1 contracts, storage, and request plane."""
+
+from scripts.fleet_comms.adapter_conformance import CaptureInput, conform
+from scripts.fleet_comms.artifacts import ArtifactRecord, ArtifactStore
+from scripts.fleet_comms.contracts import AssistantSegment, CompletionState, ResponseEnvelope, new_id
+from scripts.fleet_comms.request_executor import RequestExecutor, RequestRecord
+
+__all__ = [
+    "ArtifactRecord",
+    "ArtifactStore",
+    "AssistantSegment",
+    "CaptureInput",
+    "CompletionState",
+    "RequestExecutor",
+    "RequestRecord",
+    "ResponseEnvelope",
+    "conform",
+    "new_id",
+]

--- a/scripts/fleet_comms/adapter_conformance.py
+++ b/scripts/fleet_comms/adapter_conformance.py
@@ -1,0 +1,543 @@
+"""Adapter completion-conformance harness (Fleet Comms PR-B1/B2 / #5512).
+
+Maps harness-specific captures into a typed ``ResponseEnvelope``. Adapters may
+only emit ``complete`` when their documented terminal contract is observed.
+Exit 0 + nonempty text alone is never enough.
+
+B1 primary adapters: codex, claude, agy.
+B2 remaining adapters start as stubs that return ``unknown`` until terminal
+evidence is proven (Sol: unknown → not formal-review eligible).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from scripts.fleet_comms.contracts import AssistantSegment, CompletionState, ResponseEnvelope
+
+PRIMARY_ADAPTERS = frozenset({"codex", "claude", "agy"})
+# B2 targets — stubs until terminal evidence is wired.
+REMAINING_ADAPTERS = frozenset({"grok", "kimi", "cursor", "hermes", "opencode", "hermes-grok", "hermes-qwen", "hermes-deepseek"})
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureInput:
+    """Raw transport capture fed into the conformance harness."""
+
+    adapter: str
+    stdout: str = ""
+    stderr: str = ""
+    returncode: int | None = None
+    events: tuple[dict[str, Any], ...] = ()
+    raw_bytes: bytes | None = None
+    session_id: str | None = None
+    transport_metadata: Mapping[str, Any] | None = None
+
+
+def _parse_jsonl(text: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events
+
+
+def _ordered_segments(texts: Iterable[str]) -> tuple[AssistantSegment, ...]:
+    segments: list[AssistantSegment] = []
+    for index, text in enumerate(texts):
+        if text is None:
+            continue
+        value = str(text)
+        if not value:
+            continue
+        segments.append(AssistantSegment(text=value, sequence=index))
+    return tuple(segments)
+
+
+def _raw_hash(capture: CaptureInput) -> tuple[str | None, str | None]:
+    raw = capture.raw_bytes
+    if raw is None:
+        # Deterministic capture of the inputs we observed.
+        raw = "\n".join(
+            [
+                capture.stdout or "",
+                "---stderr---",
+                capture.stderr or "",
+                f"---rc={capture.returncode}---",
+            ]
+        ).encode("utf-8")
+    digest = hashlib.sha256(raw).hexdigest()
+    # Artifact ID is content-addressed preview; store layer assigns real IDs.
+    return f"artifact_raw_{digest[:16]}", digest
+
+
+def _envelope(
+    *,
+    segments: Sequence[AssistantSegment],
+    state: CompletionState,
+    terminal: bool,
+    capture: CaptureInput,
+    stop_reason: str | None,
+    extra_meta: Mapping[str, Any] | None = None,
+) -> ResponseEnvelope:
+    art_id, digest = _raw_hash(capture)
+    meta = dict(capture.transport_metadata or {})
+    meta["adapter"] = capture.adapter
+    if extra_meta:
+        meta.update(extra_meta)
+    return ResponseEnvelope(
+        segments=tuple(segments),
+        completion_state=state,
+        provider_stop_reason=stop_reason,
+        terminal_event_observed=terminal,
+        process_returncode=capture.returncode,
+        transport_metadata=meta,
+        raw_capture_artifact_id=art_id,
+        raw_capture_sha256=digest,
+        session_id=capture.session_id,
+    )
+
+
+def conform_codex(capture: CaptureInput) -> ResponseEnvelope:
+    """Codex: terminal proof is a ``task_complete`` event (or equivalent).
+
+    Segments come from ordered ``agent_message`` / ``message`` assistant texts.
+    ``reason=length`` maps to length_limited even when text is present.
+    """
+    events = list(capture.events) if capture.events else _parse_jsonl(capture.stdout)
+    texts: list[str] = []
+    stop_reason: str | None = None
+    terminal = False
+    session_id = capture.session_id
+
+    for event in events:
+        etype = str(event.get("type") or event.get("event") or "")
+        if etype in {"agent_message", "message", "item.completed"}:
+            item = event.get("item") if isinstance(event.get("item"), dict) else event
+            text = item.get("text") if isinstance(item, dict) else None
+            if text is None and isinstance(item, dict):
+                content = item.get("content")
+                if isinstance(content, str):
+                    text = content
+                elif isinstance(content, list):
+                    parts = [
+                        str(part.get("text", ""))
+                        for part in content
+                        if isinstance(part, dict) and part.get("type") in {None, "text", "output_text"}
+                    ]
+                    text = "".join(parts)
+            if isinstance(text, str) and text:
+                texts.append(text)
+        if etype == "task_complete":
+            terminal = True
+            stop_reason = str(event.get("reason") or event.get("stop_reason") or "task_complete")
+        if etype in {"turn.completed", "response.completed"}:
+            # Weaker signal — not terminal alone without task_complete.
+            stop_reason = stop_reason or str(event.get("reason") or etype)
+        reason = event.get("reason") or event.get("stop_reason")
+        if isinstance(reason, str) and reason in {"length", "max_tokens", "max_output_tokens"}:
+            stop_reason = reason
+        sid = event.get("session_id") or event.get("thread_id")
+        if isinstance(sid, str) and sid:
+            session_id = sid
+
+    segments = _ordered_segments(texts)
+    if not segments and capture.stdout.strip() and not events:
+        # Plain text fallback — never complete without terminal evidence.
+        segments = _ordered_segments([capture.stdout.strip()])
+
+    length_limited = stop_reason in {"length", "max_tokens", "max_output_tokens"}
+    if capture.returncode not in (None, 0) and not terminal:
+        state = CompletionState.FAILED if not segments else CompletionState.TRANSPORT_INCOMPLETE
+        return _envelope(
+            segments=segments,
+            state=state,
+            terminal=False,
+            capture=capture,
+            stop_reason=stop_reason or f"rc={capture.returncode}",
+            extra_meta={"session_id_resolved": session_id},
+        )
+    if length_limited:
+        return _envelope(
+            segments=segments,
+            state=CompletionState.LENGTH_LIMITED,
+            terminal=terminal,
+            capture=CaptureInput(
+                adapter=capture.adapter,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=tuple(events),
+                raw_bytes=capture.raw_bytes,
+                session_id=session_id,
+                transport_metadata=capture.transport_metadata,
+            ),
+            stop_reason=stop_reason,
+        )
+    if terminal:
+        return _envelope(
+            segments=segments,
+            state=CompletionState.COMPLETE,
+            terminal=True,
+            capture=CaptureInput(
+                adapter=capture.adapter,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=tuple(events),
+                raw_bytes=capture.raw_bytes,
+                session_id=session_id,
+                transport_metadata=capture.transport_metadata,
+            ),
+            stop_reason=stop_reason or "task_complete",
+        )
+    if segments and capture.returncode in (None, 0):
+        # Nonempty + exit 0 without terminal → unknown (never complete).
+        return _envelope(
+            segments=segments,
+            state=CompletionState.UNKNOWN,
+            terminal=False,
+            capture=CaptureInput(
+                adapter=capture.adapter,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=tuple(events),
+                raw_bytes=capture.raw_bytes,
+                session_id=session_id,
+                transport_metadata=capture.transport_metadata,
+            ),
+            stop_reason=stop_reason or "missing_terminal_event",
+        )
+    if not segments:
+        return _envelope(
+            segments=(),
+            state=CompletionState.TRANSPORT_INCOMPLETE,
+            terminal=False,
+            capture=capture,
+            stop_reason=stop_reason or "empty_capture",
+        )
+    return _envelope(
+        segments=segments,
+        state=CompletionState.UNKNOWN,
+        terminal=False,
+        capture=capture,
+        stop_reason=stop_reason,
+    )
+
+
+def conform_claude(capture: CaptureInput) -> ResponseEnvelope:
+    """Claude stream-json: terminal proof is a final ``result`` event type.
+
+    Ordered assistant text segments are retained from every text item, not only
+    the last event (Sol multi-turn NDJSON requirement).
+    """
+    events = list(capture.events) if capture.events else _parse_jsonl(capture.stdout)
+    texts: list[str] = []
+    stop_reason: str | None = None
+    terminal = False
+    session_id = capture.session_id
+
+    for event in events:
+        etype = str(event.get("type") or "")
+        sid = event.get("session_id") or event.get("sessionId")
+        if isinstance(sid, str) and sid:
+            session_id = sid
+        if etype in {"assistant", "content_block_delta", "text"}:
+            content = event.get("content") or event.get("message", {}).get("content") if isinstance(event.get("message"), dict) else event.get("content")
+            if isinstance(content, str) and content:
+                texts.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str):
+                        texts.append(part["text"])
+            delta = event.get("delta")
+            if isinstance(delta, dict) and isinstance(delta.get("text"), str):
+                texts.append(delta["text"])
+        if etype == "result":
+            terminal = True
+            result_text = event.get("result")
+            if isinstance(result_text, str) and result_text.strip():
+                texts.append(result_text.strip())
+            stop_reason = str(event.get("subtype") or event.get("stop_reason") or "result")
+            if event.get("is_error") is True:
+                stop_reason = "error"
+        reason = event.get("stop_reason") or event.get("reason")
+        if isinstance(reason, str) and reason in {"max_tokens", "length"}:
+            stop_reason = reason
+
+    segments = _ordered_segments(texts)
+    if not segments and capture.stdout.strip() and not events:
+        segments = _ordered_segments([capture.stdout.strip()])
+
+    length_limited = stop_reason in {"max_tokens", "length"}
+    if capture.returncode not in (None, 0) and not terminal:
+        state = CompletionState.FAILED if not segments else CompletionState.TRANSPORT_INCOMPLETE
+        return _envelope(
+            segments=segments,
+            state=state,
+            terminal=False,
+            capture=capture,
+            stop_reason=stop_reason or f"rc={capture.returncode}",
+        )
+    if length_limited:
+        return _envelope(
+            segments=segments,
+            state=CompletionState.LENGTH_LIMITED,
+            terminal=terminal,
+            capture=CaptureInput(
+                adapter=capture.adapter,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=tuple(events),
+                raw_bytes=capture.raw_bytes,
+                session_id=session_id,
+                transport_metadata=capture.transport_metadata,
+            ),
+            stop_reason=stop_reason,
+        )
+    if terminal and stop_reason != "error":
+        return _envelope(
+            segments=segments,
+            state=CompletionState.COMPLETE,
+            terminal=True,
+            capture=CaptureInput(
+                adapter=capture.adapter,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=tuple(events),
+                raw_bytes=capture.raw_bytes,
+                session_id=session_id,
+                transport_metadata=capture.transport_metadata,
+            ),
+            stop_reason=stop_reason or "result",
+        )
+    if terminal and stop_reason == "error":
+        return _envelope(
+            segments=segments,
+            state=CompletionState.FAILED,
+            terminal=True,
+            capture=capture,
+            stop_reason="error",
+        )
+    if segments and capture.returncode in (None, 0):
+        return _envelope(
+            segments=segments,
+            state=CompletionState.UNKNOWN,
+            terminal=False,
+            capture=CaptureInput(
+                adapter=capture.adapter,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=tuple(events),
+                raw_bytes=capture.raw_bytes,
+                session_id=session_id,
+                transport_metadata=capture.transport_metadata,
+            ),
+            stop_reason=stop_reason or "missing_terminal_event",
+        )
+    if not segments:
+        return _envelope(
+            segments=(),
+            state=CompletionState.TRANSPORT_INCOMPLETE,
+            terminal=False,
+            capture=capture,
+            stop_reason=stop_reason or "empty_capture",
+        )
+    return _envelope(
+        segments=segments,
+        state=CompletionState.UNKNOWN,
+        terminal=False,
+        capture=capture,
+        stop_reason=stop_reason,
+    )
+
+
+def conform_agy(capture: CaptureInput) -> ResponseEnvelope:
+    """AGY bridge: terminal proof is a final RESULT marker / done event.
+
+    Multi-line RESULT bodies are ordered segments; missing RESULT → unknown.
+    """
+    events = list(capture.events) if capture.events else _parse_jsonl(capture.stdout)
+    texts: list[str] = []
+    stop_reason: str | None = None
+    terminal = False
+    session_id = capture.session_id
+
+    for event in events:
+        etype = str(event.get("type") or event.get("event") or "")
+        if etype in {"assistant", "message", "text"}:
+            text = event.get("text") or event.get("content") or event.get("result")
+            if isinstance(text, str) and text:
+                texts.append(text)
+        if etype in {"result", "done", "RESULT", "task_complete"}:
+            terminal = True
+            stop_reason = str(event.get("reason") or etype)
+            body = event.get("result") or event.get("content") or event.get("text")
+            if isinstance(body, str) and body.strip():
+                texts.append(body.strip())
+        reason = event.get("stop_reason") or event.get("reason")
+        if isinstance(reason, str) and reason in {"length", "max_tokens"}:
+            stop_reason = reason
+        sid = event.get("session_id")
+        if isinstance(sid, str) and sid:
+            session_id = sid
+
+    if not events and capture.stdout:
+        # Text RESULT: prefix protocol used by some bridge paths.
+        lines = capture.stdout.splitlines()
+        collecting = False
+        body: list[str] = []
+        for line in lines:
+            if line.lstrip().startswith("RESULT:"):
+                collecting = True
+                terminal = True
+                stop_reason = "RESULT"
+                rest = line.split("RESULT:", 1)[1].strip()
+                if rest:
+                    body.append(rest)
+                continue
+            if collecting:
+                body.append(line)
+        if body:
+            texts.append("\n".join(body).strip())
+
+    segments = _ordered_segments(texts)
+    length_limited = stop_reason in {"length", "max_tokens"}
+    if capture.returncode not in (None, 0) and not terminal:
+        state = CompletionState.FAILED if not segments else CompletionState.TRANSPORT_INCOMPLETE
+        return _envelope(
+            segments=segments,
+            state=state,
+            terminal=False,
+            capture=capture,
+            stop_reason=stop_reason or f"rc={capture.returncode}",
+        )
+    if length_limited:
+        return _envelope(
+            segments=segments,
+            state=CompletionState.LENGTH_LIMITED,
+            terminal=terminal,
+            capture=CaptureInput(
+                adapter=capture.adapter,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=tuple(events),
+                raw_bytes=capture.raw_bytes,
+                session_id=session_id,
+                transport_metadata=capture.transport_metadata,
+            ),
+            stop_reason=stop_reason,
+        )
+    if terminal:
+        return _envelope(
+            segments=segments,
+            state=CompletionState.COMPLETE,
+            terminal=True,
+            capture=CaptureInput(
+                adapter=capture.adapter,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=tuple(events),
+                raw_bytes=capture.raw_bytes,
+                session_id=session_id,
+                transport_metadata=capture.transport_metadata,
+            ),
+            stop_reason=stop_reason or "result",
+        )
+    if segments and capture.returncode in (None, 0):
+        return _envelope(
+            segments=segments,
+            state=CompletionState.UNKNOWN,
+            terminal=False,
+            capture=CaptureInput(
+                adapter=capture.adapter,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=tuple(events),
+                raw_bytes=capture.raw_bytes,
+                session_id=session_id,
+                transport_metadata=capture.transport_metadata,
+            ),
+            stop_reason=stop_reason or "missing_terminal_event",
+        )
+    if not segments:
+        return _envelope(
+            segments=(),
+            state=CompletionState.TRANSPORT_INCOMPLETE,
+            terminal=False,
+            capture=capture,
+            stop_reason=stop_reason or "empty_capture",
+        )
+    return _envelope(
+        segments=segments,
+        state=CompletionState.UNKNOWN,
+        terminal=False,
+        capture=capture,
+        stop_reason=stop_reason,
+    )
+
+
+def conform_unknown_stub(capture: CaptureInput) -> ResponseEnvelope:
+    """B2 stub: transports without proven terminal evidence stay ``unknown``."""
+    text = capture.stdout.strip()
+    segments = _ordered_segments([text] if text else [])
+    return _envelope(
+        segments=segments,
+        state=CompletionState.UNKNOWN,
+        terminal=False,
+        capture=capture,
+        stop_reason="adapter_conformance_stub",
+        extra_meta={"formal_review_eligible": False, "b2_status": "stub"},
+    )
+
+
+_CONFORMERS: dict[str, Callable[[CaptureInput], ResponseEnvelope]] = {
+    "codex": conform_codex,
+    "claude": conform_claude,
+    "agy": conform_agy,
+}
+
+
+def conform(capture: CaptureInput) -> ResponseEnvelope:
+    """Dispatch to the adapter-specific conformer (or B2 stub)."""
+    name = capture.adapter.strip().lower()
+    if name in _CONFORMERS:
+        return _CONFORMERS[name](capture)
+    if name in REMAINING_ADAPTERS or name:
+        # Explicit stub path — never invent complete.
+        return conform_unknown_stub(CaptureInput(
+            adapter=name,
+            stdout=capture.stdout,
+            stderr=capture.stderr,
+            returncode=capture.returncode,
+            events=capture.events,
+            raw_bytes=capture.raw_bytes,
+            session_id=capture.session_id,
+            transport_metadata=capture.transport_metadata,
+        ))
+    raise ValueError(f"Unknown adapter for conformance: {capture.adapter!r}")
+
+
+def raw_capture_matches(envelope: ResponseEnvelope, raw: bytes) -> bool:
+    """Prove raw-capture hash matches bytes (Sol B1 acceptance)."""
+    if not envelope.raw_capture_sha256:
+        return False
+    return hashlib.sha256(raw).hexdigest() == envelope.raw_capture_sha256

--- a/scripts/fleet_comms/artifacts.py
+++ b/scripts/fleet_comms/artifacts.py
@@ -1,0 +1,359 @@
+"""Content-addressed artifact / file-drop service (Fleet Comms PR-C / #5512).
+
+Store immutable payloads at::
+
+    batch_state/fleet-comms/v1/blobs/sha256/<aa>/<digest>
+
+Creation is temp → fsync → hash → atomic rename → SQLite commit so a crash
+never leaves a DB row pointing at a missing blob.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import mimetypes
+import os
+import re
+import shutil
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from scripts.fleet_comms.contracts import new_id
+from scripts.fleet_comms.migrations import apply_migrations
+
+DEFAULT_ROOT = Path("batch_state/fleet-comms/v1")
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9._@+=,-][A-Za-z0-9._@+=, -]{0,200}$")
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactRecord:
+    artifact_id: str
+    sha256: str
+    bytes: int
+    mime_type: str | None
+    logical_filename: str | None
+    producer: str
+    retention_class: str
+    created_at: str
+    blob_path: Path
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "sha256": self.sha256,
+            "bytes": self.bytes,
+            "mime_type": self.mime_type,
+            "logical_filename": self.logical_filename,
+            "producer": self.producer,
+            "retention_class": self.retention_class,
+            "created_at": self.created_at,
+            "blob_path": str(self.blob_path),
+        }
+
+
+class ArtifactStoreError(RuntimeError):
+    """Artifact store refused an operation."""
+
+
+class ArtifactStore:
+    """SQLite metadata + content-addressed blob store."""
+
+    def __init__(self, root: Path | None = None, *, repo_root: Path | None = None) -> None:
+        base = repo_root or Path.cwd()
+        self.root = (root if root is not None else base / DEFAULT_ROOT).resolve()
+        self.blob_root = self.root / "blobs" / "sha256"
+        self.db_path = self.root / "comms.sqlite3"
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.blob_root.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        apply_migrations(self._conn)
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> ArtifactStore:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return self._conn
+
+    def blob_path_for(self, digest: str) -> Path:
+        digest = digest.lower()
+        if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+            raise ArtifactStoreError("sha256 digest must be 64 lowercase hex chars")
+        return self.blob_root / digest[:2] / digest
+
+    def store_bytes(
+        self,
+        data: bytes,
+        *,
+        producer: str,
+        retention_class: str = "default",
+        mime_type: str | None = None,
+        logical_filename: str | None = None,
+        artifact_id: str | None = None,
+    ) -> ArtifactRecord:
+        if not producer or not producer.strip():
+            raise ArtifactStoreError("producer is required")
+        if logical_filename is not None:
+            logical_filename = self._validate_filename(logical_filename)
+        digest = hashlib.sha256(data).hexdigest()
+        dest = self.blob_path_for(digest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        existing = self._conn.execute(
+            "SELECT * FROM artifacts WHERE sha256 = ?", (digest,)
+        ).fetchone()
+        if existing is not None:
+            if not dest.exists():
+                self._write_blob_atomic(dest, data)
+            return self._row_to_record(existing)
+
+        if not dest.exists():
+            self._write_blob_atomic(dest, data)
+
+        aid = artifact_id or new_id("artifact")
+        created = _utc_now()
+        mime = mime_type
+        if mime is None and logical_filename:
+            mime, _ = mimetypes.guess_type(logical_filename)
+        try:
+            self._conn.execute(
+                """INSERT INTO artifacts(
+                    artifact_id, sha256, bytes, mime_type, logical_filename,
+                    producer, retention_class, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (aid, digest, len(data), mime, logical_filename, producer, retention_class, created),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+        row = self._conn.execute(
+            "SELECT * FROM artifacts WHERE artifact_id = ?", (aid,)
+        ).fetchone()
+        if row is None:
+            raise ArtifactStoreError(f"failed to persist artifact metadata for {aid}")
+        return self._row_to_record(row)
+
+    def store_text(
+        self,
+        text: str,
+        *,
+        producer: str,
+        retention_class: str = "default",
+        logical_filename: str | None = None,
+        mime_type: str = "text/plain; charset=utf-8",
+    ) -> ArtifactRecord:
+        return self.store_bytes(
+            text.encode("utf-8"),
+            producer=producer,
+            retention_class=retention_class,
+            logical_filename=logical_filename,
+            mime_type=mime_type,
+        )
+
+    def import_path(
+        self,
+        path: Path,
+        *,
+        producer: str,
+        retention_class: str = "default",
+        mime_type: str | None = None,
+        logical_filename: str | None = None,
+    ) -> ArtifactRecord:
+        """Import a local file into the store (never hand caller paths to providers)."""
+        candidate = path.expanduser()
+        # Check symlink on the caller path before resolve() follows it.
+        if candidate.is_symlink() or path.is_symlink():
+            raise ArtifactStoreError("import refuses symlink paths")
+        resolved = candidate.resolve()
+        if not resolved.is_file():
+            raise ArtifactStoreError(f"import path is not a file: {path}")
+        if resolved.is_symlink():
+            raise ArtifactStoreError("import refuses symlink paths")
+        name = logical_filename or resolved.name
+        data = resolved.read_bytes()
+        return self.store_bytes(
+            data,
+            producer=producer,
+            retention_class=retention_class,
+            mime_type=mime_type,
+            logical_filename=name,
+        )
+
+    def materialize(
+        self,
+        artifact_id: str,
+        dest_dir: Path,
+        *,
+        filename: str | None = None,
+        readonly: bool = True,
+    ) -> Path:
+        """Copy blob into an invocation scratch directory as a real file."""
+        rec = self.get(artifact_id)
+        dest_dir = dest_dir.resolve()
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        name = filename or rec.logical_filename or f"{rec.sha256[:16]}.bin"
+        name = self._validate_filename(name)
+        dest = dest_dir / name
+        if dest.exists():
+            raise ArtifactStoreError(f"materialize target already exists: {dest}")
+        shutil.copyfile(rec.blob_path, dest)
+        if readonly:
+            dest.chmod(0o444)
+        return dest
+
+    def get(self, artifact_id: str) -> ArtifactRecord:
+        row = self._conn.execute(
+            "SELECT * FROM artifacts WHERE artifact_id = ?", (artifact_id,)
+        ).fetchone()
+        if row is None:
+            raise ArtifactStoreError(f"artifact not found: {artifact_id}")
+        return self._row_to_record(row)
+
+    def get_by_sha256(self, digest: str) -> ArtifactRecord | None:
+        row = self._conn.execute(
+            "SELECT * FROM artifacts WHERE sha256 = ?", (digest.lower(),)
+        ).fetchone()
+        return self._row_to_record(row) if row else None
+
+    def read_bytes(self, artifact_id: str) -> bytes:
+        rec = self.get(artifact_id)
+        if not rec.blob_path.is_file():
+            raise ArtifactStoreError(
+                f"missing blob for {artifact_id} (sha256={rec.sha256}) — integrity failure"
+            )
+        data = rec.blob_path.read_bytes()
+        if hashlib.sha256(data).hexdigest() != rec.sha256:
+            raise ArtifactStoreError(f"blob digest mismatch for {artifact_id}")
+        return data
+
+    def reference(self, message_id: str, artifact_id: str, relation: str = "body") -> None:
+        """Link artifact to a message so GC will not delete it."""
+        if not message_id or not artifact_id:
+            raise ArtifactStoreError("message_id and artifact_id required")
+        self.get(artifact_id)  # ensure exists
+        self._ensure_message_stub(message_id)
+        self._conn.execute(
+            """INSERT OR IGNORE INTO message_artifacts(message_id, artifact_id, relation)
+               VALUES (?, ?, ?)""",
+            (message_id, artifact_id, relation),
+        )
+        self._conn.commit()
+
+    def is_referenced(self, artifact_id: str) -> bool:
+        row = self._conn.execute(
+            "SELECT 1 FROM message_artifacts WHERE artifact_id = ? LIMIT 1",
+            (artifact_id,),
+        ).fetchone()
+        if row:
+            return True
+        row = self._conn.execute(
+            "SELECT 1 FROM delivery_attempts WHERE raw_capture_artifact_id = ? LIMIT 1",
+            (artifact_id,),
+        ).fetchone()
+        return row is not None
+
+    def garbage_collect_unreferenced(self, *, grace_seconds: int = 3600) -> list[str]:
+        """Delete unreferenced artifacts older than grace. Returns deleted artifact_ids."""
+        cutoff = (datetime.now(UTC) - timedelta(seconds=grace_seconds)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        rows = self._conn.execute(
+            "SELECT artifact_id, sha256, created_at FROM artifacts"
+        ).fetchall()
+        deleted: list[str] = []
+        for row in rows:
+            aid = str(row["artifact_id"])
+            if self.is_referenced(aid):
+                continue
+            if str(row["created_at"]) > cutoff:
+                continue
+            digest = str(row["sha256"])
+            path = self.blob_path_for(digest)
+            self._conn.execute("DELETE FROM artifacts WHERE artifact_id = ?", (aid,))
+            if path.is_file():
+                # Only remove blob if no other artifact row shares the digest.
+                still = self._conn.execute(
+                    "SELECT 1 FROM artifacts WHERE sha256 = ? LIMIT 1", (digest,)
+                ).fetchone()
+                if still is None:
+                    path.unlink()
+            deleted.append(aid)
+        self._conn.commit()
+        return deleted
+
+    def _write_blob_atomic(self, dest: Path, data: bytes) -> None:
+        fd, tmp_name = tempfile.mkstemp(prefix=".art-", dir=str(dest.parent))
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, dest)
+        except Exception:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
+            raise
+
+    def _row_to_record(self, row: sqlite3.Row) -> ArtifactRecord:
+        digest = str(row["sha256"])
+        return ArtifactRecord(
+            artifact_id=str(row["artifact_id"]),
+            sha256=digest,
+            bytes=int(row["bytes"]),
+            mime_type=row["mime_type"],
+            logical_filename=row["logical_filename"],
+            producer=str(row["producer"]),
+            retention_class=str(row["retention_class"]),
+            created_at=str(row["created_at"]),
+            blob_path=self.blob_path_for(digest),
+        )
+
+    def _validate_filename(self, name: str) -> str:
+        name = name.strip().replace("\\", "/")
+        if ".." in name or name.startswith("/") or "\x00" in name:
+            raise ArtifactStoreError("logical_filename rejects traversal/absolute/NUL")
+        base = name.rsplit("/", 1)[-1]
+        if not base or not _SAFE_NAME.match(base):
+            raise ArtifactStoreError(f"unsafe logical_filename: {name!r}")
+        if base in {".", ".."}:
+            raise ArtifactStoreError("invalid logical_filename")
+        return base
+
+    def _ensure_message_stub(self, message_id: str) -> None:
+        row = self._conn.execute(
+            "SELECT 1 FROM comms_messages WHERE message_id = ?", (message_id,)
+        ).fetchone()
+        if row:
+            return
+        conv = new_id("conversation")
+        now = _utc_now()
+        self._conn.execute(
+            "INSERT OR IGNORE INTO conversations(conversation_id, created_at, source) VALUES (?, ?, ?)",
+            (conv, now, "artifact-store"),
+        )
+        self._conn.execute(
+            """INSERT OR IGNORE INTO comms_messages(
+                message_id, conversation_id, kind, sender, body_inline, created_at
+            ) VALUES (?, ?, 'note', 'artifact-store', '', ?)""",
+            (message_id, conv, now),
+        )
+        self._conn.commit()

--- a/scripts/fleet_comms/request_executor.py
+++ b/scripts/fleet_comms/request_executor.py
@@ -1,0 +1,352 @@
+"""Request / delivery executor skeleton (Fleet Comms PR-D / #5512).
+
+One path for foreground and background work: create a durable request, resolve
+endpoint (incl. permanent Gemini→AGY retirement), run adapter conformance on a
+raw capture, store the raw artifact, and advance request state only on proven
+completion.
+
+This is not production cutover — bridge still uses legacy ask paths until PR-E.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from scripts.fleet_comms.adapter_conformance import CaptureInput, conform
+from scripts.fleet_comms.artifacts import ArtifactStore
+from scripts.fleet_comms.contracts import CompletionState, ResponseEnvelope, new_id
+from scripts.fleet_comms.endpoints import EndpointRegistry, load_endpoint_registry
+from scripts.fleet_comms.migrations import apply_migrations
+
+REQUEST_STATES = frozenset(
+    {"queued", "running", "complete", "incomplete", "failed", "expired", "dead_lettered"}
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True, slots=True)
+class RequestRecord:
+    request_id: str
+    request_message_id: str
+    requested_recipient: str
+    resolved_recipient: str
+    state: str
+    expires_at: str
+    completion_state: str
+    created_at: str
+    updated_at: str
+    envelope: ResponseEnvelope | None = None
+    raw_capture_artifact_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "request_id": self.request_id,
+            "request_message_id": self.request_message_id,
+            "requested_recipient": self.requested_recipient,
+            "resolved_recipient": self.resolved_recipient,
+            "state": self.state,
+            "expires_at": self.expires_at,
+            "completion_state": self.completion_state,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "raw_capture_artifact_id": self.raw_capture_artifact_id,
+        }
+        if self.envelope is not None:
+            payload["envelope"] = self.envelope.to_dict()
+        return payload
+
+
+class RequestExecutorError(RuntimeError):
+    """Request executor refused an operation."""
+
+
+class RequestExecutor:
+    """Durable request lifecycle over communications SQLite + artifact store."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore | None = None,
+        registry: EndpointRegistry | None = None,
+        root: Path | None = None,
+        default_ttl_seconds: int | None = None,
+    ) -> None:
+        self.store = store or ArtifactStore(root=root)
+        self.registry = registry or load_endpoint_registry()
+        self.default_ttl_seconds = default_ttl_seconds
+        self._conn = self.store.connection
+        apply_migrations(self._conn)
+
+    def close(self) -> None:
+        self.store.close()
+
+    def __enter__(self) -> RequestExecutor:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def create_request(
+        self,
+        *,
+        recipient: str,
+        body: str,
+        sender: str = "request-executor",
+        ttl_seconds: int | None = None,
+        conversation_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> RequestRecord:
+        endpoint, matched_name = self.registry.resolve(recipient)
+        # resolve(): live → (endpoint, endpoint.name); retired → (successor, retired_name).
+        requested = matched_name
+        resolved = endpoint.name
+        ttl = ttl_seconds
+        if ttl is None:
+            ttl = self.default_ttl_seconds if self.default_ttl_seconds is not None else endpoint.default_ttl_seconds
+        now = _utc_now()
+        expires = now + timedelta(seconds=int(ttl))
+        conv = conversation_id or new_id("conversation")
+        msg_id = new_id("message")
+        req_id = new_id("request")
+        now_s = _iso(now)
+        expires_s = _iso(expires)
+
+        self._conn.execute(
+            "INSERT OR IGNORE INTO conversations(conversation_id, created_at, source, title) VALUES (?, ?, ?, ?)",
+            (conv, now_s, "request-executor", None),
+        )
+        self._conn.execute(
+            """INSERT INTO comms_messages(
+                message_id, conversation_id, kind, sender, recipient, body_inline,
+                content_sha256, metadata_json, created_at
+            ) VALUES (?, ?, 'request', ?, ?, ?, ?, ?, ?)""",
+            (
+                msg_id,
+                conv,
+                sender,
+                resolved,
+                body,
+                None,
+                json.dumps(metadata or {}, sort_keys=True),
+                now_s,
+            ),
+        )
+        self._conn.execute(
+            """INSERT INTO requests(
+                request_id, request_message_id, requested_recipient, resolved_recipient,
+                state, expires_at, completion_state, invocation_spec_json, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, 'queued', ?, 'unknown', ?, ?, ?)""",
+            (
+                req_id,
+                msg_id,
+                requested,
+                resolved,
+                expires_s,
+                json.dumps(
+                    {
+                        "recipient": recipient,
+                        "requested_recipient": requested,
+                        "resolved_recipient": resolved,
+                        "ttl_seconds": ttl,
+                    },
+                    sort_keys=True,
+                ),
+                now_s,
+                now_s,
+            ),
+        )
+        self._conn.commit()
+        return self.get_request(req_id)
+
+    def get_request(self, request_id: str) -> RequestRecord:
+        row = self._conn.execute(
+            "SELECT * FROM requests WHERE request_id = ?", (request_id,)
+        ).fetchone()
+        if row is None:
+            raise RequestExecutorError(f"request not found: {request_id}")
+        return RequestRecord(
+            request_id=str(row["request_id"]),
+            request_message_id=str(row["request_message_id"]),
+            requested_recipient=str(row["requested_recipient"]),
+            resolved_recipient=str(row["resolved_recipient"]),
+            state=str(row["state"]),
+            expires_at=str(row["expires_at"]),
+            completion_state=str(row["completion_state"]),
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
+        )
+
+    def execute_capture(
+        self,
+        request_id: str,
+        *,
+        adapter: str | None = None,
+        stdout: str = "",
+        stderr: str = "",
+        returncode: int | None = 0,
+        events: tuple[dict[str, Any], ...] = (),
+        raw_bytes: bytes | None = None,
+        session_id: str | None = None,
+    ) -> RequestRecord:
+        """Run adapter conformance on a capture and persist the outcome.
+
+        Production adapters will stream into the artifact store then call this
+        with the same bytes. Tests inject fixtures directly.
+        """
+        req = self.get_request(request_id)
+        if req.state not in {"queued", "running"}:
+            raise RequestExecutorError(f"request {request_id} is not executable (state={req.state})")
+        if req.expires_at < _iso(_utc_now()):
+            self._set_state(request_id, "expired", CompletionState.UNKNOWN)
+            raise RequestExecutorError(f"request {request_id} expired")
+
+        self._set_state(request_id, "running", CompletionState.UNKNOWN)
+        adapter_name = (adapter or req.resolved_recipient).lower()
+        capture = CaptureInput(
+            adapter=adapter_name,
+            stdout=stdout,
+            stderr=stderr,
+            returncode=returncode,
+            events=events,
+            raw_bytes=raw_bytes,
+            session_id=session_id,
+            transport_metadata={"request_id": request_id},
+        )
+        raw = raw_bytes
+        if raw is None:
+            raw = "\n".join(
+                [stdout or "", "---stderr---", stderr or "", f"---rc={returncode}---"]
+            ).encode("utf-8")
+        art = self.store.store_bytes(
+            raw,
+            producer=f"adapter:{adapter_name}",
+            retention_class="raw-capture",
+            mime_type="application/x-ndjson" if events or stdout.lstrip().startswith("{") else "text/plain",
+            logical_filename=f"{request_id}.capture",
+        )
+        envelope = conform(capture)
+        # Rebind envelope to the real artifact id/digest from the store.
+        envelope = ResponseEnvelope(
+            segments=envelope.segments,
+            completion_state=envelope.completion_state,
+            provider_stop_reason=envelope.provider_stop_reason,
+            terminal_event_observed=envelope.terminal_event_observed,
+            process_returncode=envelope.process_returncode,
+            transport_metadata={**envelope.transport_metadata, "artifact_store_id": art.artifact_id},
+            raw_capture_artifact_id=art.artifact_id,
+            raw_capture_sha256=art.sha256,
+            session_id=envelope.session_id or session_id,
+            token_metadata=envelope.token_metadata,
+            tool_call_metadata=envelope.tool_call_metadata,
+        )
+        self.store.reference(req.request_message_id, art.artifact_id, relation="raw_capture")
+
+        request_state = self._map_completion_to_request_state(envelope.completion_state)
+        now_s = _iso(_utc_now())
+        row = self._conn.execute(
+            "SELECT invocation_spec_json FROM requests WHERE request_id = ?",
+            (request_id,),
+        ).fetchone()
+        spec: dict[str, Any] = {}
+        if row and row[0]:
+            try:
+                loaded = json.loads(str(row[0]))
+                if isinstance(loaded, dict):
+                    spec = loaded
+            except json.JSONDecodeError:
+                spec = {}
+        spec["raw_capture_artifact_id"] = art.artifact_id
+        spec["completion_state"] = envelope.completion_state.value
+        self._conn.execute(
+            """UPDATE requests SET state = ?, completion_state = ?, updated_at = ?,
+               invocation_spec_json = ?
+               WHERE request_id = ?""",
+            (
+                request_state,
+                envelope.completion_state.value,
+                now_s,
+                json.dumps(spec, sort_keys=True),
+                request_id,
+            ),
+        )
+        # Reply message when we have text (even incomplete).
+        if envelope.response_text:
+            reply_id = new_id("message")
+            preview = envelope.response_text[:500]
+            self._conn.execute(
+                """INSERT INTO comms_messages(
+                    message_id, conversation_id, in_reply_to, kind, sender, recipient,
+                    body_inline, body_artifact_id, content_sha256, metadata_json, created_at
+                ) VALUES (
+                    ?,
+                    (SELECT conversation_id FROM comms_messages WHERE message_id = ?),
+                    ?, 'reply', ?, ?, ?, ?, ?, ?, ?
+                )""",
+                (
+                    reply_id,
+                    req.request_message_id,
+                    req.request_message_id,
+                    req.resolved_recipient,
+                    "request-executor",
+                    preview,
+                    art.artifact_id,
+                    art.sha256,
+                    json.dumps({"completion_state": envelope.completion_state.value}, sort_keys=True),
+                    now_s,
+                ),
+            )
+            self.store.reference(reply_id, art.artifact_id, relation="body")
+        self._conn.commit()
+        record = self.get_request(request_id)
+        return RequestRecord(
+            request_id=record.request_id,
+            request_message_id=record.request_message_id,
+            requested_recipient=record.requested_recipient,
+            resolved_recipient=record.resolved_recipient,
+            state=record.state,
+            expires_at=record.expires_at,
+            completion_state=record.completion_state,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+            envelope=envelope,
+            raw_capture_artifact_id=art.artifact_id,
+        )
+
+    @staticmethod
+    def _map_completion_to_request_state(state: CompletionState) -> str:
+        if state is CompletionState.COMPLETE:
+            return "complete"
+        if state is CompletionState.FAILED:
+            return "failed"
+        if state in {
+            CompletionState.LENGTH_LIMITED,
+            CompletionState.TRANSPORT_INCOMPLETE,
+            CompletionState.UNKNOWN,
+        }:
+            return "incomplete"
+        return "incomplete"
+
+    def _set_state(self, request_id: str, state: str, completion: CompletionState) -> None:
+        if state not in REQUEST_STATES:
+            raise RequestExecutorError(f"invalid request state: {state}")
+        self._conn.execute(
+            "UPDATE requests SET state = ?, completion_state = ?, updated_at = ? WHERE request_id = ?",
+            (state, completion.value, _iso(_utc_now()), request_id),
+        )
+        self._conn.commit()
+
+
+def open_executor(root: Path | None = None) -> RequestExecutor:
+    """Factory used by CLI/tests."""
+    return RequestExecutor(root=root)

--- a/tests/test_fleet_comms_wave1.py
+++ b/tests/test_fleet_comms_wave1.py
@@ -1,0 +1,243 @@
+"""Wave 1 fleet: PR-B1 adapter conformance, PR-C artifacts, PR-D request executor."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.fleet_comms.adapter_conformance import (
+    CaptureInput,
+    conform,
+    raw_capture_matches,
+)
+from scripts.fleet_comms.artifacts import ArtifactStore, ArtifactStoreError
+from scripts.fleet_comms.contracts import CompletionState
+from scripts.fleet_comms.request_executor import RequestExecutor
+
+# ── PR-C: artifact store ────────────────────────────────────────────────────
+
+
+def test_artifact_store_round_trip_and_dedup(tmp_path: Path) -> None:
+    with ArtifactStore(root=tmp_path / "v1") as store:
+        a = store.store_text("hello fleet", producer="test", logical_filename="hello.txt")
+        assert a.bytes == len(b"hello fleet")
+        assert a.sha256 == hashlib.sha256(b"hello fleet").hexdigest()
+        assert a.blob_path.is_file()
+        assert store.read_bytes(a.artifact_id) == b"hello fleet"
+        b = store.store_bytes(b"hello fleet", producer="other")
+        assert b.artifact_id == a.artifact_id  # content-addressed reuse
+        assert b.sha256 == a.sha256
+
+
+def test_artifact_store_rejects_traversal_filename(tmp_path: Path) -> None:
+    with ArtifactStore(root=tmp_path / "v1") as store:
+        with pytest.raises(ArtifactStoreError, match=r"traversal|unsafe"):
+            store.store_text("x", producer="t", logical_filename="../etc/passwd")
+        with pytest.raises(ArtifactStoreError, match=r"traversal|unsafe"):
+            store.store_text("x", producer="t", logical_filename="/abs/name.txt")
+
+
+def test_artifact_import_materialize_and_gc(tmp_path: Path) -> None:
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload-bytes")
+    with ArtifactStore(root=tmp_path / "v1") as store:
+        rec = store.import_path(src, producer="import-test")
+        scratch = tmp_path / "scratch"
+        out = store.materialize(rec.artifact_id, scratch, filename="payload.bin")
+        assert out.read_bytes() == b"payload-bytes"
+        assert out.stat().st_mode & 0o222 == 0  # readonly
+
+        # Unreferenced + zero grace → GC deletes
+        deleted = store.garbage_collect_unreferenced(grace_seconds=0)
+        assert rec.artifact_id in deleted
+        with pytest.raises(ArtifactStoreError, match="not found"):
+            store.get(rec.artifact_id)
+
+        # Re-store and reference → GC spares it
+        rec2 = store.store_bytes(b"kept", producer="t")
+        store.reference("message_keep_1", rec2.artifact_id)
+        deleted2 = store.garbage_collect_unreferenced(grace_seconds=0)
+        assert rec2.artifact_id not in deleted2
+        assert store.get(rec2.artifact_id).sha256 == hashlib.sha256(b"kept").hexdigest()
+
+
+def test_artifact_missing_blob_is_integrity_failure(tmp_path: Path) -> None:
+    with ArtifactStore(root=tmp_path / "v1") as store:
+        rec = store.store_bytes(b"gone", producer="t")
+        rec.blob_path.unlink()
+        with pytest.raises(ArtifactStoreError, match=r"missing blob|integrity"):
+            store.read_bytes(rec.artifact_id)
+
+
+def test_artifact_import_refuses_symlink(tmp_path: Path) -> None:
+    real = tmp_path / "real.txt"
+    real.write_text("x", encoding="utf-8")
+    link = tmp_path / "link.txt"
+    link.symlink_to(real)
+    with ArtifactStore(root=tmp_path / "v1") as store:
+        with pytest.raises(ArtifactStoreError, match="symlink"):
+            store.import_path(link, producer="t")
+
+
+# ── PR-B1: adapter conformance ──────────────────────────────────────────────
+
+
+def _codex_complete_jsonl() -> str:
+    return "\n".join(
+        [
+            json.dumps({"type": "agent_message", "text": "part-one "}),
+            json.dumps({"type": "agent_message", "text": "part-two"}),
+            json.dumps({"type": "task_complete", "reason": "stop"}),
+        ]
+    )
+
+
+def test_codex_complete_requires_task_complete_and_keeps_order() -> None:
+    raw = _codex_complete_jsonl().encode("utf-8")
+    env = conform(
+        CaptureInput(adapter="codex", stdout=_codex_complete_jsonl(), returncode=0, raw_bytes=raw)
+    )
+    assert env.completion_state is CompletionState.COMPLETE
+    assert env.terminal_event_observed is True
+    assert env.response_text == "part-one part-two"
+    assert [s.sequence for s in env.segments] == [0, 1]
+    assert raw_capture_matches(env, raw)
+
+
+def test_codex_exit0_text_without_terminal_is_unknown_not_complete() -> None:
+    stdout = json.dumps({"type": "agent_message", "text": "looks done"})
+    env = conform(CaptureInput(adapter="codex", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.UNKNOWN
+    assert env.terminal_event_observed is False
+    assert env.is_formal_review_eligible is False
+
+
+def test_codex_length_limited() -> None:
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "agent_message", "text": "truncated..."}),
+            json.dumps({"type": "task_complete", "reason": "length"}),
+        ]
+    )
+    env = conform(CaptureInput(adapter="codex", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.LENGTH_LIMITED
+    assert "truncated" in env.response_text
+
+
+def test_codex_nonzero_exit_with_output_is_transport_incomplete() -> None:
+    stdout = json.dumps({"type": "agent_message", "text": "partial"})
+    env = conform(CaptureInput(adapter="codex", stdout=stdout, returncode=1))
+    assert env.completion_state is CompletionState.TRANSPORT_INCOMPLETE
+    assert env.response_text == "partial"
+
+
+def test_claude_result_event_is_complete_multi_segment() -> None:
+    lines = [
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "first "}]},
+                "session_id": "sess-1",
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "second"}]},
+            }
+        ),
+        json.dumps({"type": "result", "result": "first second", "subtype": "success"}),
+    ]
+    stdout = "\n".join(lines)
+    raw = stdout.encode("utf-8")
+    env = conform(CaptureInput(adapter="claude", stdout=stdout, returncode=0, raw_bytes=raw))
+    assert env.completion_state is CompletionState.COMPLETE
+    assert env.session_id == "sess-1"
+    # ordered segments retained (assistant texts + final result)
+    assert env.segments[0].text == "first "
+    assert env.segments[1].text == "second"
+    assert raw_capture_matches(env, raw)
+
+
+def test_claude_missing_result_is_unknown() -> None:
+    stdout = json.dumps(
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}}
+    )
+    env = conform(CaptureInput(adapter="claude", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.UNKNOWN
+
+
+def test_agy_result_marker_complete() -> None:
+    stdout = "RESULT: hello from agy\nline2"
+    env = conform(CaptureInput(adapter="agy", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.COMPLETE
+    assert "hello from agy" in env.response_text
+
+
+def test_agy_json_done_event() -> None:
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "assistant", "text": "a"}),
+            json.dumps({"type": "done", "result": "a b"}),
+        ]
+    )
+    env = conform(CaptureInput(adapter="agy", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.COMPLETE
+
+
+def test_b2_stub_adapters_are_unknown_not_review_eligible() -> None:
+    for name in ("grok", "kimi", "cursor", "hermes", "opencode"):
+        env = conform(CaptureInput(adapter=name, stdout="looks fine", returncode=0))
+        assert env.completion_state is CompletionState.UNKNOWN
+        assert env.is_formal_review_eligible is False
+
+
+# ── PR-D: request executor ──────────────────────────────────────────────────
+
+
+def test_request_executor_gemini_retires_to_agy_and_completes(tmp_path: Path) -> None:
+    with RequestExecutor(root=tmp_path / "v1") as ex:
+        req = ex.create_request(recipient="gemini", body="ping")
+        assert req.requested_recipient == "gemini"
+        assert req.resolved_recipient == "agy"
+        assert req.state == "queued"
+
+        stdout = _codex_complete_jsonl()  # use codex-shaped complete for adapter override
+        # Resolve path is agy — feed agy RESULT capture
+        done = ex.execute_capture(
+            req.request_id,
+            adapter="agy",
+            stdout="RESULT: pong",
+            returncode=0,
+        )
+        assert done.state == "complete"
+        assert done.completion_state == CompletionState.COMPLETE.value
+        assert done.envelope is not None
+        assert done.envelope.response_text.startswith("pong")
+        assert done.raw_capture_artifact_id
+        # artifact readable
+        body = ex.store.read_bytes(done.raw_capture_artifact_id)
+        assert b"pong" in body or b"RESULT" in body
+
+
+def test_request_executor_unknown_stays_incomplete(tmp_path: Path) -> None:
+    with RequestExecutor(root=tmp_path / "v1") as ex:
+        req = ex.create_request(recipient="codex", body="x")
+        # exit 0 + text, no terminal
+        stdout = json.dumps({"type": "agent_message", "text": "not proven"})
+        done = ex.execute_capture(req.request_id, adapter="codex", stdout=stdout, returncode=0)
+        assert done.state == "incomplete"
+        assert done.completion_state == CompletionState.UNKNOWN.value
+        assert done.envelope is not None
+        assert done.envelope.is_formal_review_eligible is False
+
+
+def test_request_executor_failed_on_nonzero_empty(tmp_path: Path) -> None:
+    with RequestExecutor(root=tmp_path / "v1") as ex:
+        req = ex.create_request(recipient="claude", body="x")
+        done = ex.execute_capture(req.request_id, adapter="claude", stdout="", returncode=2)
+        assert done.state == "failed"
+        assert done.completion_state == CompletionState.FAILED.value


### PR DESCRIPTION
## Summary

Wave 1 of Fleet Communications System v1 (Sol SHIP memo, epic #5512) — **no production cutover**.

| Slice | What shipped |
| --- | --- |
| **PR-C** | `ArtifactStore` — content-addressed blobs under `batch_state/fleet-comms/v1/blobs/sha256/…`, atomic temp→fsync→rename→SQLite, import/materialize, message references, GC of unreferenced, traversal/symlink rejection |
| **PR-B1** | Adapter conformance for **codex / claude / agy** → typed `ResponseEnvelope`. `complete` only with harness terminal evidence (`task_complete` / stream-json `result` / AGY RESULT). Exit 0 + text alone → `unknown` |
| **PR-B2** | Stubs for grok/kimi/cursor/hermes/opencode → always `unknown` (not formal-review eligible) |
| **PR-D** | `RequestExecutor` skeleton: create durable request, Gemini→AGY retirement, `execute_capture` stores raw artifact + advances request state |

Bridge/legacy ask paths unchanged until PR-E.

## Test plan

- [x] `pytest tests/test_fleet_comms_wave1.py tests/test_fleet_comms_contracts.py` (23 passed)
- [x] ruff clean on `scripts/fleet_comms/`
- [ ] CI green
- [ ] Cross-family review (non-Grok)

Closes nothing alone — parent epic #5512.