### PR TITLE
ci(dependabot): ignore typescript >=7 until @astrojs/check peers allow it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,12 @@ updates:
           - "@astrojs/*"
     # Only security updates — we don't want churn on minor bumps
     open-pull-requests-limit: 5
+    ignore:
+      # @astrojs/check@0.9.9 peers typescript@"^5.0.0 || ^6.0.0"; typescript 7
+      # fails npm ci with ERESOLVE. Block >=7 until @astrojs/check accepts it —
+      # REMOVE this entry then. Closed PR: #5527.
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
 
   # pip (Python scripts)
   - package-ecosystem: "pip"


### PR DESCRIPTION
## Summary
- Closes the reopen loop for Dependabot typescript 7.x after #5527 failed CI
- Root cause: `@astrojs/check@0.9.9` peers `typescript@"^5.0.0 || ^6.0.0"`; `npm ci` ERESOLVE on 7.0.2
- Adds npm ignore for `typescript >=7.0.0` (remove when `@astrojs/check` accepts TS 7)

Parent stream: infra-harness epic #4707

## Test plan
- [ ] Confirm `#5527` stays closed
- [ ] Next Dependabot npm run does not open a typescript 7.x PR
- [ ] Remove this ignore when `@astrojs/check` (or successor) peers include `^7`


Made with [Cursor](https://cursor.com)