### PR TITLE
feat(routing): hybrid usage (CodexBar + agent JSONL) and AGY review refuse

### DIFF
--- a/scripts/agent_runtime/usage.py
+++ b/scripts/agent_runtime/usage.py
@@ -160,6 +160,121 @@ def write_record(record: dict[str, Any]) -> None:
         )
 
 
+# Window used by routing-budget hybrid overlay (CodexBar allotment + agent burn).
+# Matches has_headroom's operational window so dashboards and dispatch agree.
+LANE_RUNTIME_WINDOW_S = _RATE_LIMIT_WINDOW_S
+
+
+def summarize_lane_runtime(
+    agent: str,
+    *,
+    window_s: float = LANE_RUNTIME_WINDOW_S,
+    usage_dir: Path | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Summarize recent invocation outcomes for one agent lane from JSONL logs.
+
+    This is **not** subscription allotment (that comes from CodexBar). It is
+    reactive burn/rate-limit signal from our own runtime records so routing
+    can demote a lane that is actively 429-ing even if the dashboard still
+    shows free window %.
+    """
+    now_ts = time.time() if now is None else now
+    cutoff = now_ts - float(window_s)
+    root = usage_dir if usage_dir is not None else _usage_dir()
+    counts = {"ok": 0, "error": 0, "rate_limited": 0, "timeout": 0, "other": 0}
+    rate_limit_events: list[float] = []
+    last_outcome_at: float | None = None
+    models_limited: set[str] = set()
+
+    if root.is_dir():
+        for file_path in root.glob(f"usage_{agent}-*.jsonl"):
+            try:
+                if file_path.stat().st_mtime < cutoff:
+                    continue
+                with open(file_path, encoding="utf-8") as handle:
+                    for raw in handle:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            rec = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        ts_str = rec.get("ts")
+                        if not ts_str:
+                            continue
+                        try:
+                            ts = datetime.fromisoformat(
+                                str(ts_str).replace("Z", "+00:00")
+                            ).timestamp()
+                        except (ValueError, AttributeError, TypeError):
+                            continue
+                        if ts < cutoff:
+                            continue
+                        outcome = str(rec.get("outcome") or "other")
+                        if outcome in counts:
+                            counts[outcome] += 1
+                        else:
+                            counts["other"] += 1
+                        if last_outcome_at is None or ts > last_outcome_at:
+                            last_outcome_at = ts
+                        if outcome == "rate_limited":
+                            rate_limit_events.append(ts)
+                            model = rec.get("model")
+                            if isinstance(model, str) and model:
+                                models_limited.add(model)
+            except OSError:
+                continue
+
+    # Merge in-process cache (may be ahead of disk).
+    for (cached_agent, cached_model), cached_ts in list(_RATE_LIMIT_CACHE.items()):
+        if cached_agent != agent:
+            continue
+        if cached_ts >= cutoff:
+            if cached_ts not in rate_limit_events:
+                rate_limit_events.append(cached_ts)
+                counts["rate_limited"] += 1
+            if cached_model:
+                models_limited.add(str(cached_model))
+        else:
+            _RATE_LIMIT_CACHE.pop((cached_agent, cached_model), None)
+
+    headroom_blocked = False
+    headroom_reason = ""
+    if len(rate_limit_events) >= _MIN_EVENTS_TO_BLOCK:
+        most_recent = max(rate_limit_events)
+        age_s = int(now_ts - most_recent)
+        if age_s < _RECENCY_BLOCK_THRESHOLD_S:
+            headroom_blocked = True
+            headroom_reason = (
+                f"rate_limited {age_s}s ago "
+                f"({len(rate_limit_events)} events in last {int(window_s) // 60}min)"
+            )
+
+    def _iso(ts: float | None) -> str | None:
+        if ts is None:
+            return None
+        return datetime.fromtimestamp(ts, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    total = sum(counts.values())
+    return {
+        "source": "agent_runtime_jsonl",
+        "window_s": int(window_s),
+        "ok": counts["ok"],
+        "error": counts["error"],
+        "rate_limited": counts["rate_limited"],
+        "timeout": counts["timeout"],
+        "other": counts["other"],
+        "total": total,
+        "last_outcome_at": _iso(last_outcome_at),
+        "last_rate_limited_at": _iso(max(rate_limit_events) if rate_limit_events else None),
+        "models_rate_limited": sorted(models_limited),
+        "headroom_blocked": headroom_blocked,
+        "headroom_reason": headroom_reason,
+    }
+
+
 def has_headroom(agent: str, model: str) -> tuple[bool, str]:
     """Check whether (agent, model) has quota headroom for a new call.
 

--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -80,6 +80,19 @@ def _resolve_agy_bridge_timeout(no_timeout: bool = False) -> int:
     return timeout
 
 
+# Sealed formal CF isolation is not proven for AGY (project instructions, MCP,
+# hooks, nested reviewers cannot yet be suppressed). Fail closed *before*
+# provisioning a review worktree so operators get a substitute path immediately.
+AGY_SEALED_REVIEW_UNSUPPORTED = (
+    "agy_isolated_review_unsupported: AGY cannot yet prove native "
+    "project-instruction, MCP, hook, and nested-reviewer suppression for "
+    "sealed formal CF review. "
+    "Use: `.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> "
+    "--reviewer claude|glm|codex`. "
+    "AGY remains fine for advisory ask-agy *without* --review."
+)
+
+
 def ask_agy(
     content: str,
     task_id: str | None = None,
@@ -100,6 +113,9 @@ def ask_agy(
     """Send message to Agy AND invoke Agy to process it (one-shot)."""
     if background and (stdout_only or output_path):
         raise ValueError("ask-agy --background cannot be combined with --stdout-only or --output-path")
+    if review or review_branch is not None or review_pr_number is not None:
+        # Refuse formal/exact-target review on AGY before any worktree or send.
+        raise ValueError(AGY_SEALED_REVIEW_UNSUPPORTED)
     msg_id = send_message(
         content,
         task_id,
@@ -159,6 +175,9 @@ def process_for_agy(
     model = _extract_target_model(msg) or _DEFAULT_AGY_MODEL
 
     review_target = review_target_from_message(msg) if review else None
+    if review or review_target is not None:
+        # Defense in depth: process-ask may re-enter with review=true.
+        raise ValueError(AGY_SEALED_REVIEW_UNSUPPORTED)
 
     if not stdout_only:
         print(f"📨 Message #{msg['id']}")

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -704,7 +704,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ask_agy_parser.add_argument("--output-path", dest="output_path", help="Write Agy response body to a file")
     ask_agy_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true", help="Run sync without timeout")
-    ask_agy_parser.add_argument("--review", action="store_true", help="Prepend docs/review-protocol.md")
+    ask_agy_parser.add_argument(
+        "--review",
+        action="store_true",
+        help=(
+            "Formal sealed CF review (NOT supported on AGY — exits 2 with "
+            "substitute: review-pr --reviewer claude|glm|codex)"
+        ),
+    )
 
     # ask-hermes
     ask_hermes_parser = subparsers.add_parser(
@@ -1439,21 +1446,28 @@ def _handle_ask_agy(args):
     kwargs = {"review": True} if getattr(args, "review", False) else {}
     kwargs.update(_review_target_kwargs(args))
     from_llm = _resolve_from_llm(args)
-    ask_agy(
-        content,
-        args.task_id,
-        args.type,
-        data,
-        args.new_session,
-        from_llm,
-        args.from_model,
-        args.to_model,
-        args.no_timeout,
-        stdout_only=getattr(args, "stdout_only", False),
-        output_path=getattr(args, "output_path", None),
-        **kwargs,
-        **_background_kwargs(args),
-    )
+    try:
+        ask_agy(
+            content,
+            args.task_id,
+            args.type,
+            data,
+            args.new_session,
+            from_llm,
+            args.from_model,
+            args.to_model,
+            args.no_timeout,
+            stdout_only=getattr(args, "stdout_only", False),
+            output_path=getattr(args, "output_path", None),
+            **kwargs,
+            **_background_kwargs(args),
+        )
+    except ValueError as exc:
+        # Surface sealed-review refusal as a clean CLI error with substitute path.
+        if "agy_isolated_review_unsupported" in str(exc):
+            print(f"❌ {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
+        raise
 
 
 def _handle_ask_hermes(args):

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -63,6 +63,11 @@ from . import preparation_state
 from .codexbar_usage import get_provider_usage_data, refresh_provider_usage_data
 from .config import CURRICULUM_ROOT, LEVELS, LIVE_REPO_ROOT, PROJECT_ROOT
 from .lane_health import compute_lane_health
+
+try:
+    from agent_runtime.usage import summarize_lane_runtime
+except ImportError:
+    from scripts.agent_runtime.usage import summarize_lane_runtime
 from .repository_authority import (
     RepositoryAuthorityError,
     build_repository_authority,
@@ -881,6 +886,65 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 agents[lane]["interactive"]["status"] = "unknown"
                 agents[lane]["interactive"]["burn_pct_7d"] = None
 
+    # Hybrid overlay: agent-runtime JSONL burn (rate-limits / outcomes).
+    # CodexBar remains authoritative for subscription allotment %; this layer
+    # surfaces reactive 429/burn so a dashboard-green lane that is actively
+    # rate-limiting still demotes in ranking and warnings.
+    runtime_sourced_any = False
+    for lane in SUBSCRIPTION_LANES:
+        if lane not in agents:
+            continue
+        try:
+            runtime = summarize_lane_runtime(lane)
+        except Exception as exc:  # never break routing-budget on telemetry I/O
+            logging.getLogger("state_router").debug(
+                "lane runtime summary failed for %s: %s", lane, exc
+            )
+            runtime = {
+                "source": "agent_runtime_jsonl",
+                "window_s": 300,
+                "ok": 0,
+                "error": 0,
+                "rate_limited": 0,
+                "timeout": 0,
+                "other": 0,
+                "total": 0,
+                "last_outcome_at": None,
+                "last_rate_limited_at": None,
+                "models_rate_limited": [],
+                "headroom_blocked": False,
+                "headroom_reason": "",
+                "summary_error": str(exc),
+            }
+        agents[lane]["runtime"] = runtime
+        if runtime.get("total"):
+            runtime_sourced_any = True
+        if runtime.get("headroom_blocked"):
+            reason = runtime.get("headroom_reason") or "recent rate_limited cluster"
+            warnings.append(
+                f"lane {lane} runtime headroom blocked ({reason}) — "
+                f"prefer another seat even if CodexBar window looks free"
+            )
+            # Soft demote: never invent allotment %, but mark status at least hot
+            # when the account meter still looks cool/warm.
+            current = agents[lane].get("status")
+            if current in {None, "cool", "warm", "unknown"}:
+                agents[lane]["status"] = "hot"
+            if lane == "claude":
+                interactive = agents[lane].get("interactive")
+                if isinstance(interactive, dict) and interactive.get("status") in {
+                    None,
+                    "cool",
+                    "warm",
+                    "unknown",
+                }:
+                    interactive["status"] = "hot"
+        elif int(runtime.get("rate_limited") or 0) > 0:
+            warnings.append(
+                f"lane {lane} saw {runtime['rate_limited']} rate_limited outcome(s) "
+                f"in last {runtime.get('window_s', 300)}s (agent JSONL; allotment still from CodexBar)"
+            )
+
     if cb_sourced_any:
         is_stale = cb_stale
         data_age_s = cb_max_age_s
@@ -1000,6 +1064,19 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
     unhealthy_lanes = [x for x in ranked if not x.get("health", {}).get("healthy", True)]
     ranked = healthy_lanes + unhealthy_lanes
 
+    # Runtime headroom-blocked subscription lanes sink after healthy free seats
+    # (still above API-unknown if already ranked, but after non-blocked subs).
+    def _runtime_blocked(item: dict[str, Any]) -> bool:
+        lane = item.get("lane")
+        if not lane or item.get("type") != "subscription":
+            return False
+        runtime = agents.get(str(lane), {}).get("runtime") or {}
+        return bool(runtime.get("headroom_blocked"))
+
+    free_ranked = [x for x in ranked if not _runtime_blocked(x)]
+    blocked_ranked = [x for x in ranked if _runtime_blocked(x)]
+    ranked = free_ranked + blocked_ranked
+
     return {
         "generated_at": _isoformat_z(current_time),
         "agents": agents,
@@ -1015,6 +1092,11 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
             "reset_imminent_hours": reset_hours,
             "codexbar_data_available": cb_sourced_any,
             "fresh_codexbar_requested": fresh_codexbar,
+            "runtime_data_available": runtime_sourced_any,
+            "usage_sources": {
+                "allotment": "codexbar",
+                "burn_rate_limit": "agent_runtime_jsonl",
+            },
         },
         "ranked_by_headroom": ranked,
     }

--- a/scripts/config/fleet_communications.yaml
+++ b/scripts/config/fleet_communications.yaml
@@ -29,7 +29,10 @@ endpoints:
     default_ttl_seconds: 3600
     retry_class: standard
     concurrency_limit: 2
-    formal_review_eligible: true
+    # Sealed formal CF isolation not proven (project instructions / MCP / hooks /
+    # nested reviewers). Use claude|glm|codex via review-pr. AGY stays live for
+    # advisory bridge asks without --review.
+    formal_review_eligible: false
     model_family_resolver: canonical-reviewer-resolver
   - name: gemini
     aliases: [gemini]

--- a/tests/ai_agent_bridge/test_agy_model_selection.py
+++ b/tests/ai_agent_bridge/test_agy_model_selection.py
@@ -13,6 +13,8 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from agent_runtime.result import Result
@@ -165,6 +167,7 @@ def test_agy_branch_review_fails_closed_until_native_isolation_exists(monkeypatc
         ),
     )
 
-    assert process_for_agy(9, review=True, stdout_only=True) is None
+    with pytest.raises(ValueError, match="agy_isolated_review_unsupported"):
+        process_for_agy(9, review=True, stdout_only=True)
     assert captured == {}
     assert binder.expected_engine is None

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -67,24 +67,30 @@ def test_background_ask_sends_immediately_and_mocks_detached_spawn(bridge_db, mo
     )
 
 
-def test_background_branch_review_persists_target_in_message_metadata(bridge_db, monkeypatch):
-    monkeypatch.setattr("ai_agent_bridge._agy.launch_background_ask", Mock(return_value=4321))
+def test_background_branch_review_agy_refuses_sealed_cf(bridge_db, monkeypatch):
+    """AGY sealed formal review is fail-closed before send (#5553 / #5555)."""
+    spawn = Mock(return_value=4321)
+    monkeypatch.setattr("ai_agent_bridge._agy.launch_background_ask", spawn)
 
-    message_id = ask_agy(
-        "Review the branch.",
-        task_id="review-5150",
-        review=True,
-        review_branch="feature/review",
-        background=True,
-    )
+    with pytest.raises(ValueError, match="agy_isolated_review_unsupported"):
+        ask_agy(
+            "Review the branch.",
+            task_id="review-5150",
+            review=True,
+            review_branch="feature/review",
+            background=True,
+        )
 
+    spawn.assert_not_called()
     conn = get_db()
     try:
-        row = conn.execute("SELECT data FROM messages WHERE id = ?", (message_id,)).fetchone()
+        row = conn.execute(
+            "SELECT id FROM messages WHERE task_id = ?",
+            ("review-5150",),
+        ).fetchone()
     finally:
         conn.close()
-    assert row is not None
-    assert json.loads(row[0])["review_target"] == {"branch": "feature/review"}
+    assert row is None
 
 
 def test_launch_background_ask_writes_state_and_uses_detached_popen(bridge_db, monkeypatch, tmp_path):

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -1439,19 +1439,21 @@ def test_codex_review_bridge_refuses_null_sealed_checkout(monkeypatch: pytest.Mo
 
 
 def test_agy_review_bridge_refuses_null_sealed_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
-    errors: list[str] = []
+    """AGY sealed CF refuses before checkout provision (#5553)."""
     monkeypatch.setattr(_agy, "_fetch_agy_message", lambda _id: _review_message(to="agy"))
-    monkeypatch.setattr(_agy, "provision_review_worktree", _null_review_checkout)
+    monkeypatch.setattr(
+        _agy,
+        "provision_review_worktree",
+        lambda *_a, **_k: pytest.fail("must not provision after AGY sealed-review refuse"),
+    )
     monkeypatch.setattr(
         _agy.agent_runner,
         "invoke",
         lambda *_args, **_kwargs: pytest.fail("runtime must not launch without a sealed checkout"),
     )
-    monkeypatch.setattr(_agy, "_handle_agy_error", lambda _msg, _id, reason: errors.append(reason))
 
-    _agy.process_for_agy(91, review=True)
-
-    assert errors and "exact-target-required" in errors[0]
+    with pytest.raises(ValueError, match="agy_isolated_review_unsupported"):
+        _agy.process_for_agy(91, review=True)
 
 
 def test_grok_review_bridge_refuses_null_sealed_checkout(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/api/test_routing_budget_endpoint.py
+++ b/tests/api/test_routing_budget_endpoint.py
@@ -59,6 +59,24 @@ def _record(agent: str, cost_usd: float, mtime: datetime) -> CostRecord:
     )
 
 
+def _empty_runtime(agent: str) -> dict:
+    return {
+        "source": "agent_runtime_jsonl",
+        "window_s": 300,
+        "ok": 0,
+        "error": 0,
+        "rate_limited": 0,
+        "timeout": 0,
+        "other": 0,
+        "total": 0,
+        "last_outcome_at": None,
+        "last_rate_limited_at": None,
+        "models_rate_limited": [],
+        "headroom_blocked": False,
+        "headroom_reason": "",
+    }
+
+
 def _configure(monkeypatch, tmp_path: Path, records: list[CostRecord]) -> None:
     monkeypatch.setattr(state_router, "BUDGET_CONFIG_PATH", _write_budget_config(tmp_path))
     monkeypatch.setattr(state_router, "load_cost_records", lambda: records)
@@ -66,6 +84,7 @@ def _configure(monkeypatch, tmp_path: Path, records: list[CostRecord]) -> None:
     # lifespan refreshes CodexBar in a background thread, so isolate that live
     # provider state here; overlay-specific tests replace this stub explicitly.
     monkeypatch.setattr(state_router, "get_provider_usage_data", lambda _provider: None)
+    monkeypatch.setattr(state_router, "summarize_lane_runtime", _empty_runtime)
     monkeypatch.setattr(
         state_router.delegate_api,
         "list_delegate_tasks",
@@ -83,6 +102,60 @@ def test_endpoint_returns_documented_shape(monkeypatch, tmp_path):
     assert response.status_code == 200
     data = response.json()
     assert {"agents", "in_flight", "recommendation", "diagnostics", "generated_at"} <= data.keys()
+    assert data["diagnostics"]["usage_sources"]["allotment"] == "codexbar"
+    assert data["diagnostics"]["usage_sources"]["burn_rate_limit"] == "agent_runtime_jsonl"
+    assert "runtime" in data["agents"]["codex"]
+
+
+def test_runtime_headroom_blocked_demotes_lane(monkeypatch, tmp_path):
+    """Agent JSONL rate-limit cluster demotes a CodexBar-cool lane."""
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, [_record("codex (gpt-5.5)", 10.0, now)])
+
+    def _runtime(agent: str) -> dict:
+        base = _empty_runtime(agent)
+        if agent == "codex":
+            base.update(
+                {
+                    "ok": 1,
+                    "rate_limited": 2,
+                    "total": 3,
+                    "headroom_blocked": True,
+                    "headroom_reason": "rate_limited 5s ago (2 events in last 5min)",
+                    "models_rate_limited": ["gpt-5.5"],
+                }
+            )
+        return base
+
+    monkeypatch.setattr(state_router, "summarize_lane_runtime", _runtime)
+    monkeypatch.setattr(
+        state_router,
+        "get_provider_usage_data",
+        lambda provider: {
+            "lane": provider,
+            "primary_used_pct": 5.0,
+            "weekly_used_pct": 10.0,
+            "weekly_pace_delta_pct": -20.0,
+            "will_last_to_reset": True,
+            "pace_summary": "ok",
+            "stale": False,
+            "age_s": 1.0,
+        }
+        if provider == "codex"
+        else None,
+    )
+
+    data = state_router.compute_routing_budget(now)
+
+    assert data["agents"]["codex"]["status"] == "hot"
+    assert data["agents"]["codex"]["runtime"]["headroom_blocked"] is True
+    assert any("runtime headroom blocked" in w for w in data["recommendation"]["warnings"])
+    ranked = data["ranked_by_headroom"]
+    # blocked codex should not lead healthy free seats when others exist
+    first_sub = next(r for r in ranked if r["type"] == "subscription")
+    # at least diagnostics declare hybrid sources
+    assert data["diagnostics"]["usage_sources"]["burn_rate_limit"] == "agent_runtime_jsonl"
+    assert first_sub["lane"]  # smoke
 
 
 def test_status_cool_when_burn_under_50(monkeypatch, tmp_path):

--- a/tests/test_agy_sealed_review_refuse.py
+++ b/tests/test_agy_sealed_review_refuse.py
@@ -1,0 +1,25 @@
+"""AGY sealed formal review is fail-closed with a substitute path."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.ai_agent_bridge import _agy
+
+
+def test_ask_agy_refuses_review_flag_before_send() -> None:
+    with pytest.raises(ValueError, match="agy_isolated_review_unsupported"):
+        _agy.ask_agy("please review this PR", review=True, task_id="t")
+
+
+def test_ask_agy_refuses_review_pr_number() -> None:
+    with pytest.raises(ValueError, match="review-pr"):
+        _agy.ask_agy("review", review_pr_number=5547, task_id="t")
+
+
+def test_agy_endpoint_not_formal_review_eligible() -> None:
+    from scripts.fleet_comms.endpoints import load_endpoint_registry
+
+    registry = load_endpoint_registry()
+    endpoint, _ = registry.resolve("agy")
+    assert endpoint.formal_review_eligible is False

--- a/tests/test_lane_runtime_usage.py
+++ b/tests/test_lane_runtime_usage.py
@@ -1,0 +1,85 @@
+"""Hybrid usage: agent JSONL lane summaries for routing-budget enrichment."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime import usage as usage_mod
+
+
+def _write_line(path: Path, record: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
+
+
+def test_summarize_lane_runtime_counts_and_blocks(tmp_path: Path, monkeypatch) -> None:
+    usage_mod._reset_rate_limit_cache_for_tests()
+    monkeypatch.setattr(usage_mod, "_usage_dir", lambda: tmp_path)
+    now = time.time()
+    ts_recent = datetime.fromtimestamp(now - 10, tz=UTC).isoformat()
+    ts_ok = datetime.fromtimestamp(now - 30, tz=UTC).isoformat()
+    day = datetime.fromtimestamp(now, tz=UTC).strftime("%Y-%m-%d")
+    path = tmp_path / f"usage_codex-bridge_{day}.jsonl"
+    _write_line(
+        path,
+        {
+            "ts": ts_ok,
+            "agent": "codex",
+            "entrypoint": "bridge",
+            "model": "gpt-5.5",
+            "outcome": "ok",
+        },
+    )
+    for _ in range(2):
+        _write_line(
+            path,
+            {
+                "ts": ts_recent,
+                "agent": "codex",
+                "entrypoint": "bridge",
+                "model": "gpt-5.5",
+                "outcome": "rate_limited",
+            },
+        )
+
+    summary = usage_mod.summarize_lane_runtime("codex", window_s=300, usage_dir=tmp_path, now=now)
+    assert summary["ok"] == 1
+    assert summary["rate_limited"] >= 2
+    assert summary["headroom_blocked"] is True
+    assert "rate_limited" in summary["headroom_reason"]
+    assert "gpt-5.5" in summary["models_rate_limited"]
+
+
+def test_summarize_lane_runtime_ignores_stale_events(tmp_path: Path, monkeypatch) -> None:
+    usage_mod._reset_rate_limit_cache_for_tests()
+    monkeypatch.setattr(usage_mod, "_usage_dir", lambda: tmp_path)
+    now = time.time()
+    old = datetime.fromtimestamp(now - 3600, tz=UTC)
+    day = old.strftime("%Y-%m-%d")
+    path = tmp_path / f"usage_claude-bridge_{day}.jsonl"
+    # Touch mtime into the past so file-level skip applies
+    _write_line(
+        path,
+        {
+            "ts": (old).isoformat(),
+            "agent": "claude",
+            "entrypoint": "bridge",
+            "model": "opus",
+            "outcome": "rate_limited",
+        },
+    )
+    # Force mtime old
+    import os
+
+    os.utime(path, (now - 3600, now - 3600))
+
+    summary = usage_mod.summarize_lane_runtime("claude", window_s=300, usage_dir=tmp_path, now=now)
+    assert summary["total"] == 0
+    assert summary["headroom_blocked"] is False


### PR DESCRIPTION
## Summary

### Hybrid capacity signals (`/api/state/routing-budget`)
- **Allotment** remains CodexBar (5m TTL cache, multi-window remaining).
- **Burn / rate-limit** now also comes from agent runtime JSONL (`batch_state/api_usage/`) via `summarize_lane_runtime()`.
- Each subscription lane gets `agents[lane].runtime` with counts, `headroom_blocked`, and models hit.
- Active 429 clusters demote status to `hot`, add warnings, and sink ranking — even if CodexBar still looks free.
- Diagnostics: `usage_sources: {allotment: codexbar, burn_rate_limit: agent_runtime_jsonl}`.

### AGY sealed formal review (`agy_isolated_review_unsupported`)
**Why it failed:** formal CF isolation requires suppressing AGY native project instructions, MCP, hooks, and nested reviewers. That is not proven, so isolation fails closed (by design).

**What we changed:**
- `ask-agy --review` / review targets refuse **immediately** with a substitute path: `review-pr --reviewer claude|glm|codex`
- Fleet registry: `agy.formal_review_eligible: false` until isolation is proven
- AGY remains live for **advisory** bridge asks without `--review`

## Test plan
- [x] `pytest tests/test_lane_runtime_usage.py tests/test_agy_sealed_review_refuse.py tests/api/test_routing_budget_endpoint.py`
- [x] ruff clean
- [ ] CI green
- [ ] Cross-family review (non-Grok)