### PR TITLE
feat(session-streams): PR-H inventory receipts + manifest CLI (#5512)

### DIFF
--- a/agents_extensions/shared/session_streams/cli.py
+++ b/agents_extensions/shared/session_streams/cli.py
@@ -19,8 +19,18 @@ from .dual_write import (
     resolve_handoff_path,
 )
 from .hooks import clean_exit_hook, heartbeat_hook, lease_from_environment
-from .inventory import epic_handoff_map, inventory_covers_issue_streams, load_stream_epic_inventory
+from .inventory import (
+    epic_handoff_map,
+    inventory_covers_issue_streams,
+    inventory_snapshot,
+    load_stream_epic_inventory,
+)
 from .model import entry_as_dict
+from .receipts import (
+    inventory_registration_summary,
+    list_migration_state,
+    register_manifest_inventory,
+)
 from .store import NotFoundError, SessionStreamError, SessionStreamStore
 
 
@@ -153,7 +163,8 @@ Related:
         help="Mirror any registered epic file handoff into its stream (dual-write, no cutover).",
         description=(
             "Append a stable legacy handoff image under the exact lease. "
-            "Uses EPIC_HANDOFF_CANDIDATES when --source is omitted. Never edits or deletes the file."
+            "Uses inventory-derived handoff candidates from issue_streams.yaml when "
+            "--source is omitted. Never edits or deletes the file."
         ),
     )
     mirror_handoff.add_argument(
@@ -192,6 +203,36 @@ Related:
         type=Path,
         default=Path.cwd(),
         help="Repository root. Default: current working directory.",
+    )
+
+    inventory = subparsers.add_parser(
+        "inventory",
+        help="List every epic from issue_streams.yaml (manifest authority; no hard-coded subset).",
+        description=(
+            "Print sorted unique epic numbers and the stream→epic map derived from "
+            "scripts/config/issue_streams.yaml. Optional --register writes inventory and "
+            "import receipts into the session-stream DB at mode=inventory without cutover."
+        ),
+    )
+    inventory.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root. Default: current working directory.",
+    )
+    inventory.add_argument(
+        "--format",
+        choices=("json", "table"),
+        default="json",
+        help="Output rendering. Default: json.",
+    )
+    inventory.add_argument(
+        "--register",
+        action="store_true",
+        help=(
+            "Register every manifest epic into the session-stream DB with inventory "
+            "and import receipts (mode stays inventory; cutover blocked)."
+        ),
     )
 
     handoff_status = subparsers.add_parser(
@@ -276,6 +317,8 @@ def main(argv: list[str] | None = None) -> int:
             return _mirror_handoff(store, args)
         if args.command == "dual-write-status":
             return _dual_write_status(args)
+        if args.command == "inventory":
+            return _inventory(store, args)
         if args.command == "handoff-status":
             return _handoff_status(store, args)
         if args.command == "handoff-claim":
@@ -471,6 +514,45 @@ def _dual_write_status(args: argparse.Namespace) -> int:
             sort_keys=True,
         )
     )
+    return 0
+
+
+def _inventory(store: SessionStreamStore, args: argparse.Namespace) -> int:
+    snap = inventory_snapshot(args.repo_root)
+    registration: dict[str, Any] | None = None
+    if args.register:
+        result = register_manifest_inventory(store, args.repo_root)
+        registration = {
+            "source": result.source,
+            "source_sha256": result.source_sha256,
+            "epic_count": result.epic_count,
+            "registered_stream_ids": list(result.registered_stream_ids),
+            "new_inventory_receipts": result.new_inventory_receipts,
+            "import_receipts_written": result.import_receipts_written,
+            "modes": result.modes,
+            "db_summary": inventory_registration_summary(store),
+            "migration_state": list_migration_state(store),
+        }
+    if args.format == "table":
+        print("stream_id\tstream_name\tepic\ttitle")
+        for rec in snap["records"]:
+            print(
+                f"{rec['stream_id']}\t{rec['stream_name']}\t"
+                f"{rec['epic_number']}\t{rec['title']}"
+            )
+        print(f"epic_count\t{snap['epic_count']}")
+        print(f"source\t{snap['source']}")
+        print(f"source_sha256\t{snap['source_sha256']}")
+        if registration is not None:
+            print(
+                f"registered_new_receipts\t{registration['new_inventory_receipts']}\t"
+                f"import_receipts_written\t{registration['import_receipts_written']}"
+            )
+        return 0
+    payload = dict(snap)
+    if registration is not None:
+        payload["registration"] = registration
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
     return 0
 
 

--- a/agents_extensions/shared/session_streams/inventory.py
+++ b/agents_extensions/shared/session_streams/inventory.py
@@ -7,6 +7,7 @@ participate in dual-write / cutover tracking without code edits per epic.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -98,6 +99,21 @@ def _handoff_candidates_for(stream_name: str, epic_number: int) -> tuple[str, ..
     )
 
 
+def resolve_streams_yaml(repo_root: Path, streams_yaml: Path | None = None) -> Path:
+    """Resolve the issue_streams.yaml path under ``repo_root``."""
+    root = repo_root.resolve()
+    path = streams_yaml if streams_yaml is not None else root / DEFAULT_STREAMS_YAML
+    if not path.is_absolute():
+        path = root / path
+    return path
+
+
+def streams_yaml_sha256(repo_root: Path, *, streams_yaml: Path | None = None) -> str:
+    """Content hash of the authoritative stream manifest."""
+    path = resolve_streams_yaml(repo_root, streams_yaml)
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
 def load_stream_epic_inventory(
     repo_root: Path,
     *,
@@ -108,10 +124,7 @@ def load_stream_epic_inventory(
     Deduplicates epic numbers (an epic listed under multiple stream names keeps
     the first registration order from the YAML file).
     """
-    root = repo_root.resolve()
-    path = streams_yaml if streams_yaml is not None else root / DEFAULT_STREAMS_YAML
-    if not path.is_absolute():
-        path = root / path
+    path = resolve_streams_yaml(repo_root, streams_yaml)
     streams = _load_streams_doc(path)
     seen: set[int] = set()
     out: list[StreamEpicRecord] = []
@@ -142,6 +155,80 @@ def load_stream_epic_inventory(
     return tuple(out)
 
 
+def sorted_epic_numbers(
+    repo_root: Path,
+    *,
+    streams_yaml: Path | None = None,
+) -> list[int]:
+    """Sorted unique epic numbers from issue_streams.yaml (manifest authority)."""
+    return sorted({r.epic_number for r in load_stream_epic_inventory(repo_root, streams_yaml=streams_yaml)})
+
+
+def stream_map(
+    repo_root: Path,
+    *,
+    streams_yaml: Path | None = None,
+) -> dict[str, list[int]]:
+    """Map stream name → sorted unique epic numbers from issue_streams.yaml.
+
+    Unlike :func:`load_stream_epic_inventory`, this does not collapse an epic
+    that appears under multiple stream names — each stream lists its own epics.
+    """
+    path = resolve_streams_yaml(repo_root, streams_yaml)
+    streams = _load_streams_doc(path)
+    result: dict[str, list[int]] = {}
+    for stream_name, body in streams.items():
+        if not isinstance(body, dict):
+            continue
+        epics = body.get("epics") or []
+        if not isinstance(epics, list):
+            continue
+        numbers: set[int] = set()
+        for raw in epics:
+            try:
+                numbers.add(int(raw))
+            except (TypeError, ValueError):
+                continue
+        result[str(stream_name)] = sorted(numbers)
+    return result
+
+
+def inventory_snapshot(
+    repo_root: Path,
+    *,
+    streams_yaml: Path | None = None,
+) -> dict[str, Any]:
+    """Machine-readable inventory: sorted epics, stream map, source hash."""
+    path = resolve_streams_yaml(repo_root, streams_yaml)
+    records = load_stream_epic_inventory(repo_root, streams_yaml=path)
+    mapping = stream_map(repo_root, streams_yaml=path)
+    epics = sorted({r.epic_number for r in records})
+    try:
+        source_rel = path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        source_rel = str(path)
+    return {
+        "source": source_rel,
+        "source_sha256": streams_yaml_sha256(repo_root, streams_yaml=path),
+        "epic_count": len(epics),
+        "epics": epics,
+        "stream_ids": [f"epic:{n}" for n in epics],
+        "stream_map": mapping,
+        "records": [
+            {
+                "stream_id": r.stream_id,
+                "epic_number": r.epic_number,
+                "stream_name": r.stream_name,
+                "title": r.title,
+                "handoff_candidates": list(r.handoff_candidates),
+            }
+            for r in records
+        ],
+        "authority": "scripts/config/issue_streams.yaml",
+        "hard_coded_subset_authoritative": False,
+    }
+
+
 def epic_handoff_map(
     repo_root: Path,
     *,
@@ -162,10 +249,7 @@ def inventory_covers_issue_streams(
     """Return (ok, missing_stream_ids) vs issue_streams.yaml epic numbers."""
     records = load_stream_epic_inventory(repo_root, streams_yaml=streams_yaml)
     present = {r.epic_number for r in records}
-    root = repo_root.resolve()
-    path = streams_yaml if streams_yaml is not None else root / DEFAULT_STREAMS_YAML
-    if not path.is_absolute():
-        path = root / path
+    path = resolve_streams_yaml(repo_root, streams_yaml)
     streams = _load_streams_doc(path)
     expected: set[int] = set()
     for body in streams.values():

--- a/agents_extensions/shared/session_streams/migrations/0002_inventory_receipts.sql
+++ b/agents_extensions/shared/session_streams/migrations/0002_inventory_receipts.sql
@@ -1,0 +1,138 @@
+-- Sol PR-H / #5512: inventory + import/projection receipt structures.
+-- Migration modes progress inventory → shadow → dual_write → db_primary → legacy_retired.
+-- This migration does NOT flip cutover defaults; registration starts at inventory.
+
+CREATE TABLE stream_migration_state (
+    stream_id TEXT PRIMARY KEY REFERENCES streams(stream_id),
+    mode TEXT NOT NULL CHECK (mode IN (
+        'inventory', 'shadow', 'dual_write', 'db_primary', 'legacy_retired'
+    )),
+    stream_name TEXT NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    inventoried_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    inventory_source TEXT NOT NULL DEFAULT 'scripts/config/issue_streams.yaml',
+    version INTEGER NOT NULL DEFAULT 1 CHECK (version > 0)
+) STRICT;
+
+CREATE TABLE stream_inventory_receipts (
+    receipt_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    stream_name TEXT NOT NULL,
+    epic_number INTEGER NOT NULL CHECK (epic_number > 0),
+    title TEXT NOT NULL DEFAULT '',
+    source_path TEXT NOT NULL,
+    source_sha256 TEXT NOT NULL CHECK (length(source_sha256) = 64),
+    handoff_candidates_json TEXT NOT NULL CHECK (json_valid(handoff_candidates_json)),
+    recorded_at TEXT NOT NULL,
+    UNIQUE (stream_id, source_sha256)
+) STRICT;
+
+CREATE INDEX stream_inventory_receipts_stream_order
+    ON stream_inventory_receipts(stream_id, receipt_id DESC);
+
+-- File presence / content inventory without requiring a session entry yet.
+CREATE TABLE legacy_import_receipts (
+    import_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    source_path TEXT NOT NULL,
+    source_sha256 TEXT NOT NULL CHECK (length(source_sha256) = 64 OR source_sha256 = ''),
+    source_bytes INTEGER NOT NULL CHECK (source_bytes >= 0),
+    status TEXT NOT NULL CHECK (status IN (
+        'missing', 'inventoried', 'imported', 'review_required'
+    )),
+    recorded_at TEXT NOT NULL,
+    entry_id INTEGER REFERENCES entries(entry_id),
+    UNIQUE (stream_id, source_path, source_sha256, status)
+) STRICT;
+
+CREATE INDEX legacy_import_receipts_stream_order
+    ON legacy_import_receipts(stream_id, import_id DESC);
+
+-- DB → legacy file projection receipts (append-only; failure is visible drift).
+CREATE TABLE legacy_projection_receipts (
+    projection_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    target_path TEXT NOT NULL,
+    target_sha256 TEXT NOT NULL CHECK (length(target_sha256) = 64 OR target_sha256 = ''),
+    high_water_entry_id INTEGER,
+    projection_hash TEXT NOT NULL CHECK (length(projection_hash) = 64),
+    status TEXT NOT NULL CHECK (status IN ('ok', 'failed', 'drift')),
+    recorded_at TEXT NOT NULL,
+    error TEXT NOT NULL DEFAULT '',
+    UNIQUE (stream_id, target_path, projection_hash, status)
+) STRICT;
+
+CREATE INDEX legacy_projection_receipts_stream_order
+    ON legacy_projection_receipts(stream_id, projection_id DESC);
+
+CREATE TABLE stream_control_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id TEXT NOT NULL REFERENCES streams(stream_id),
+    event_type TEXT NOT NULL CHECK (event_type IN (
+        'inventory_registered',
+        'mode_transition',
+        'cutover_proposed',
+        'cutover_applied',
+        'cutover_refused',
+        'drift_detected',
+        'drift_cleared'
+    )),
+    from_mode TEXT,
+    to_mode TEXT,
+    proof_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(proof_json)),
+    recorded_at TEXT NOT NULL,
+    agent TEXT NOT NULL DEFAULT 'system',
+    reason TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE INDEX stream_control_events_stream_order
+    ON stream_control_events(stream_id, event_id DESC);
+
+CREATE TRIGGER stream_inventory_receipts_no_update
+BEFORE UPDATE ON stream_inventory_receipts
+BEGIN
+    SELECT RAISE(ABORT, 'stream inventory receipts are append-only');
+END;
+
+CREATE TRIGGER stream_inventory_receipts_no_delete
+BEFORE DELETE ON stream_inventory_receipts
+BEGIN
+    SELECT RAISE(ABORT, 'stream inventory receipts are never deleted');
+END;
+
+CREATE TRIGGER legacy_import_receipts_no_update
+BEFORE UPDATE ON legacy_import_receipts
+BEGIN
+    SELECT RAISE(ABORT, 'legacy import receipts are append-only');
+END;
+
+CREATE TRIGGER legacy_import_receipts_no_delete
+BEFORE DELETE ON legacy_import_receipts
+BEGIN
+    SELECT RAISE(ABORT, 'legacy import receipts are never deleted');
+END;
+
+CREATE TRIGGER legacy_projection_receipts_no_update
+BEFORE UPDATE ON legacy_projection_receipts
+BEGIN
+    SELECT RAISE(ABORT, 'legacy projection receipts are append-only');
+END;
+
+CREATE TRIGGER legacy_projection_receipts_no_delete
+BEFORE DELETE ON legacy_projection_receipts
+BEGIN
+    SELECT RAISE(ABORT, 'legacy projection receipts are never deleted');
+END;
+
+CREATE TRIGGER stream_control_events_no_update
+BEFORE UPDATE ON stream_control_events
+BEGIN
+    SELECT RAISE(ABORT, 'stream control events are append-only');
+END;
+
+CREATE TRIGGER stream_control_events_no_delete
+BEFORE DELETE ON stream_control_events
+BEGIN
+    SELECT RAISE(ABORT, 'stream control events are never deleted');
+END;

--- a/agents_extensions/shared/session_streams/receipts.py
+++ b/agents_extensions/shared/session_streams/receipts.py
@@ -1,0 +1,272 @@
+"""Import / projection / inventory receipt registration (Sol PR-H / #5512).
+
+Registers every epic from ``issue_streams.yaml`` into the session-stream DB at
+migration mode ``inventory``. Does not open leases, flip cutover defaults, or
+touch launchers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .inventory import (
+    DEFAULT_STREAMS_YAML,
+    load_stream_epic_inventory,
+    resolve_streams_yaml,
+    streams_yaml_sha256,
+)
+from .model import isoformat_z, sha256_text, utc_now
+from .store import SessionStreamStore
+
+
+@dataclass(frozen=True, slots=True)
+class InventoryRegistrationResult:
+    """Outcome of one ``register_manifest_inventory`` call."""
+
+    source: str
+    source_sha256: str
+    epic_count: int
+    registered_stream_ids: tuple[str, ...]
+    new_inventory_receipts: int
+    import_receipts_written: int
+    modes: dict[str, str]
+
+
+def register_manifest_inventory(
+    store: SessionStreamStore,
+    repo_root: Path,
+    *,
+    streams_yaml: Path | None = None,
+    agent: str = "system",
+    now: datetime | None = None,
+) -> InventoryRegistrationResult:
+    """Ensure every manifest epic is registered with inventory receipts.
+
+    Idempotent for the same manifest content hash. Never advances mode past
+    ``inventory`` (cutover remains blocked).
+    """
+    root = repo_root.resolve()
+    path = resolve_streams_yaml(root, streams_yaml)
+    source_sha = streams_yaml_sha256(root, streams_yaml=path)
+    try:
+        source_rel = path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        source_rel = str(path)
+    records = load_stream_epic_inventory(root, streams_yaml=path)
+    timestamp = isoformat_z(now or utc_now())
+    new_inventory = 0
+    import_written = 0
+    modes: dict[str, str] = {}
+    registered: list[str] = []
+
+    with store._transaction(now=now) as connection:
+        for rec in records:
+            store._ensure_stream(
+                connection, stream_id=rec.stream_id, created_at=timestamp
+            )
+            registered.append(rec.stream_id)
+            handoff_json = json.dumps(list(rec.handoff_candidates), ensure_ascii=False, sort_keys=True)
+            cursor = connection.execute(
+                "INSERT OR IGNORE INTO stream_inventory_receipts("
+                "stream_id, stream_name, epic_number, title, source_path, "
+                "source_sha256, handoff_candidates_json, recorded_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    rec.stream_id,
+                    rec.stream_name,
+                    rec.epic_number,
+                    rec.title,
+                    source_rel,
+                    source_sha,
+                    handoff_json,
+                    timestamp,
+                ),
+            )
+            if cursor.rowcount:
+                new_inventory += 1
+                connection.execute(
+                    "INSERT INTO stream_control_events("
+                    "stream_id, event_type, from_mode, to_mode, proof_json, "
+                    "recorded_at, agent, reason"
+                    ") VALUES (?, 'inventory_registered', NULL, 'inventory', ?, ?, ?, ?)",
+                    (
+                        rec.stream_id,
+                        json.dumps(
+                            {
+                                "source": source_rel,
+                                "source_sha256": source_sha,
+                                "stream_name": rec.stream_name,
+                                "epic_number": rec.epic_number,
+                            },
+                            ensure_ascii=False,
+                            sort_keys=True,
+                        ),
+                        timestamp,
+                        agent,
+                        f"registered {rec.stream_id} from issue_streams.yaml",
+                    ),
+                )
+
+            existing = connection.execute(
+                "SELECT mode, version FROM stream_migration_state WHERE stream_id = ?",
+                (rec.stream_id,),
+            ).fetchone()
+            if existing is None:
+                connection.execute(
+                    "INSERT INTO stream_migration_state("
+                    "stream_id, mode, stream_name, title, inventoried_at, updated_at, "
+                    "inventory_source, version"
+                    ") VALUES (?, 'inventory', ?, ?, ?, ?, ?, 1)",
+                    (
+                        rec.stream_id,
+                        rec.stream_name,
+                        rec.title,
+                        timestamp,
+                        timestamp,
+                        source_rel,
+                    ),
+                )
+                modes[rec.stream_id] = "inventory"
+            else:
+                modes[rec.stream_id] = str(existing["mode"])
+                connection.execute(
+                    "UPDATE stream_migration_state SET stream_name = ?, title = ?, "
+                    "updated_at = ?, inventory_source = ?, version = version + 1 "
+                    "WHERE stream_id = ?",
+                    (rec.stream_name, rec.title, timestamp, source_rel, rec.stream_id),
+                )
+
+            for rel in rec.handoff_candidates:
+                file_path = root / rel
+                if file_path.is_file():
+                    raw = file_path.read_bytes()
+                    status = "inventoried"
+                    file_sha = hashlib.sha256(raw).hexdigest()
+                    source_bytes = len(raw)
+                else:
+                    status = "missing"
+                    file_sha = ""
+                    source_bytes = 0
+                cursor = connection.execute(
+                    "INSERT OR IGNORE INTO legacy_import_receipts("
+                    "stream_id, source_path, source_sha256, source_bytes, status, "
+                    "recorded_at, entry_id"
+                    ") VALUES (?, ?, ?, ?, ?, ?, NULL)",
+                    (rec.stream_id, rel, file_sha, source_bytes, status, timestamp),
+                )
+                if cursor.rowcount:
+                    import_written += 1
+
+    return InventoryRegistrationResult(
+        source=source_rel,
+        source_sha256=source_sha,
+        epic_count=len(records),
+        registered_stream_ids=tuple(registered),
+        new_inventory_receipts=new_inventory,
+        import_receipts_written=import_written,
+        modes=modes,
+    )
+
+
+def record_projection_receipt(
+    store: SessionStreamStore,
+    *,
+    stream_id: str,
+    target_path: str,
+    target_sha256: str,
+    projection_body: str,
+    status: str,
+    high_water_entry_id: int | None = None,
+    error: str = "",
+    now: datetime | None = None,
+) -> int:
+    """Append one legacy projection receipt (ok / failed / drift)."""
+    if status not in {"ok", "failed", "drift"}:
+        raise ValueError(f"invalid projection status: {status}")
+    if target_sha256 and len(target_sha256) != 64:
+        raise ValueError("target_sha256 must be empty or a SHA-256 hex digest")
+    projection_hash = sha256_text(projection_body)
+    timestamp = isoformat_z(now or utc_now())
+    with store._transaction(now=now) as connection:
+        store._ensure_stream(connection, stream_id=stream_id, created_at=timestamp)
+        connection.execute(
+            "INSERT INTO legacy_projection_receipts("
+            "stream_id, target_path, target_sha256, high_water_entry_id, "
+            "projection_hash, status, recorded_at, error"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                stream_id,
+                target_path,
+                target_sha256,
+                high_water_entry_id,
+                projection_hash,
+                status,
+                timestamp,
+                error,
+            ),
+        )
+        row = connection.execute(
+            "SELECT projection_id FROM legacy_projection_receipts "
+            "WHERE stream_id = ? AND target_path = ? AND projection_hash = ? AND status = ? "
+            "ORDER BY projection_id DESC LIMIT 1",
+            (stream_id, target_path, projection_hash, status),
+        ).fetchone()
+        assert row is not None
+        if status in {"failed", "drift"}:
+            connection.execute(
+                "INSERT INTO stream_control_events("
+                "stream_id, event_type, from_mode, to_mode, proof_json, "
+                "recorded_at, agent, reason"
+                ") VALUES (?, 'drift_detected', NULL, NULL, ?, ?, 'system', ?)",
+                (
+                    stream_id,
+                    json.dumps(
+                        {
+                            "target_path": target_path,
+                            "status": status,
+                            "projection_hash": projection_hash,
+                            "error": error,
+                        },
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    ),
+                    timestamp,
+                    f"projection {status} for {target_path}",
+                ),
+            )
+        return int(row["projection_id"])
+
+
+def list_migration_state(store: SessionStreamStore) -> list[dict[str, Any]]:
+    """Return current migration mode rows for all registered streams."""
+    with store._read_snapshot() as connection:
+        rows = connection.execute(
+            "SELECT stream_id, mode, stream_name, title, inventoried_at, "
+            "updated_at, inventory_source, version "
+            "FROM stream_migration_state ORDER BY stream_id"
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+
+def inventory_registration_summary(store: SessionStreamStore) -> dict[str, Any]:
+    """Counts of inventory / import / projection receipts and modes."""
+    with store._read_snapshot() as connection:
+        inv = connection.execute("SELECT COUNT(*) AS n FROM stream_inventory_receipts").fetchone()
+        imp = connection.execute("SELECT COUNT(*) AS n FROM legacy_import_receipts").fetchone()
+        proj = connection.execute("SELECT COUNT(*) AS n FROM legacy_projection_receipts").fetchone()
+        modes = connection.execute(
+            "SELECT mode, COUNT(*) AS n FROM stream_migration_state GROUP BY mode ORDER BY mode"
+        ).fetchall()
+        return {
+            "inventory_receipts": int(inv["n"]) if inv else 0,
+            "import_receipts": int(imp["n"]) if imp else 0,
+            "projection_receipts": int(proj["n"]) if proj else 0,
+            "modes": {str(row["mode"]): int(row["n"]) for row in modes},
+            "default_source": str(DEFAULT_STREAMS_YAML),
+            "cutover": "blocked — dual-write only; file handoffs remain authoritative",
+        }

--- a/agents_extensions/shared/session_streams/store.py
+++ b/agents_extensions/shared/session_streams/store.py
@@ -665,6 +665,40 @@ class SessionStreamStore:
                         (stream_id,),
                     ).fetchall()
                 ),
+                "stream_migration_state": self._row_as_dict(
+                    connection.execute(
+                        "SELECT * FROM stream_migration_state WHERE stream_id = ?",
+                        (stream_id,),
+                    ).fetchone()
+                ),
+                "stream_inventory_receipts": self._rows_as_dicts(
+                    connection.execute(
+                        "SELECT * FROM stream_inventory_receipts WHERE stream_id = ? "
+                        "ORDER BY receipt_id",
+                        (stream_id,),
+                    ).fetchall()
+                ),
+                "legacy_import_receipts": self._rows_as_dicts(
+                    connection.execute(
+                        "SELECT * FROM legacy_import_receipts WHERE stream_id = ? "
+                        "ORDER BY import_id",
+                        (stream_id,),
+                    ).fetchall()
+                ),
+                "legacy_projection_receipts": self._rows_as_dicts(
+                    connection.execute(
+                        "SELECT * FROM legacy_projection_receipts WHERE stream_id = ? "
+                        "ORDER BY projection_id",
+                        (stream_id,),
+                    ).fetchall()
+                ),
+                "stream_control_events": self._rows_as_dicts(
+                    connection.execute(
+                        "SELECT * FROM stream_control_events WHERE stream_id = ? "
+                        "ORDER BY event_id",
+                        (stream_id,),
+                    ).fetchall()
+                ),
             }
 
     def record_legacy_mirror(

--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -40,8 +40,9 @@ just because the inline body looks short.
   --stream epic:4387
 ```
 
-Registry: `EPIC_HANDOFF_CANDIDATES` in
-`agents_extensions/shared/session_streams/dual_write.py`.
+Registry: manifest inventory from `scripts/config/issue_streams.yaml` via
+`agents_extensions/shared/session_streams/inventory.py` (Sol PR-H; not a hard-coded
+epic subset).
 
 **Still blocked for cutover:** operator gate after per-harness acceptance;
 file handoffs remain authoritative until then.

--- a/tests/test_session_streams.py
+++ b/tests/test_session_streams.py
@@ -64,10 +64,18 @@ def test_schema_migration_wal_and_fingerprint(tmp_path: Path) -> None:
     database = SessionStreamDatabase(tmp_path / "streams.sqlite3")
     connection = database.connect(now=NOW)
     try:
-        migration = load_migrations()[0]
+        migrations = load_migrations()
+        migration = migrations[0]
         receipt = connection.execute(
-            "SELECT version, name, ddl_sha256 FROM schema_migrations"
+            "SELECT version, name, ddl_sha256 FROM schema_migrations WHERE version = 1"
         ).fetchone()
+        versions = [
+            int(row[0])
+            for row in connection.execute(
+                "SELECT version FROM schema_migrations ORDER BY version"
+            ).fetchall()
+        ]
+        assert versions == [m.version for m in migrations]
         assert str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower() == "wal"
         assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert connection.execute("PRAGMA synchronous").fetchone()[0] == 2
@@ -82,7 +90,7 @@ def test_schema_migration_wal_and_fingerprint(tmp_path: Path) -> None:
     assert SessionStreamStore(database).audit() == {
         "integrity_check": "ok",
         "foreign_key_violations": [],
-        "schema_versions": [1],
+        "schema_versions": [m.version for m in load_migrations()],
     }
 
 
@@ -133,7 +141,9 @@ def test_concurrent_first_open_serializes_migration_and_session_contention(tmp_p
     assert results.count("lifecycle-conflict") == 7
     connection = SessionStreamDatabase(database_path).connect(read_only=True)
     try:
-        assert connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 1
+        assert connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == len(
+            load_migrations()
+        )
     finally:
         connection.close()
 

--- a/tests/test_session_streams_inventory_receipts.py
+++ b/tests/test_session_streams_inventory_receipts.py
@@ -1,0 +1,209 @@
+"""Sol PR-H inventory + import/projection receipts (#5512)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from agents_extensions.shared.session_streams.cli import main
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase, load_migrations
+from agents_extensions.shared.session_streams.inventory import (
+    inventory_snapshot,
+    load_stream_epic_inventory,
+    sorted_epic_numbers,
+    stream_map,
+)
+from agents_extensions.shared.session_streams.receipts import (
+    inventory_registration_summary,
+    list_migration_state,
+    record_projection_receipt,
+    register_manifest_inventory,
+)
+from agents_extensions.shared.session_streams.store import SessionStreamStore
+
+
+def _fixture_repo(tmp_path: Path) -> Path:
+    """Write a multi-stream issue_streams.yaml under a fake repo root."""
+    streams = {
+        "schema_version": 1,
+        "streams": {
+            "alpha": {"title": "Alpha Stream", "epics": [1001, 1002]},
+            "beta": {"title": "Beta Stream", "epics": [2001, 1002]},  # 1002 shared name only once in inventory
+            "gamma": {"title": "Gamma Stream", "epics": [3001]},
+        },
+    }
+    cfg = tmp_path / "scripts" / "config"
+    cfg.mkdir(parents=True)
+    (cfg / "issue_streams.yaml").write_text(yaml.safe_dump(streams), encoding="utf-8")
+    # One existing handoff for alpha epic 1001 default path pattern.
+    handoff = tmp_path / ".claude" / "alpha-epic" / "CLAUDE-DRIVER-HANDOFF.md"
+    handoff.parent.mkdir(parents=True)
+    handoff.write_text("# alpha handoff\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_sorted_epics_and_stream_map_from_multi_stream_fixture(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    epics = sorted_epic_numbers(repo)
+    assert epics == [1001, 1002, 2001, 3001]
+    mapping = stream_map(repo)
+    assert mapping == {
+        "alpha": [1001, 1002],
+        "beta": [1002, 2001],
+        "gamma": [3001],
+    }
+    records = load_stream_epic_inventory(repo)
+    # Dedup: epic 1002 kept under first stream (alpha)
+    assert [r.epic_number for r in records] == [1001, 1002, 2001, 3001]
+    assert {r.stream_id for r in records} == {
+        "epic:1001",
+        "epic:1002",
+        "epic:2001",
+        "epic:3001",
+    }
+    snap = inventory_snapshot(repo)
+    assert snap["epic_count"] == 4
+    assert snap["epics"] == [1001, 1002, 2001, 3001]
+    assert snap["hard_coded_subset_authoritative"] is False
+    assert snap["authority"] == "scripts/config/issue_streams.yaml"
+    assert len(snap["source_sha256"]) == 64
+
+
+def test_inventory_does_not_use_hard_coded_exclusive_list(tmp_path: Path) -> None:
+    """Fixture epics are the sole authority — not the old four-epic production set."""
+    repo = _fixture_repo(tmp_path)
+    epics = set(sorted_epic_numbers(repo))
+    # Classic four-epic subset from pre-PR-H dual-write code must not appear.
+    hard_coded_four = {4387, 4707, 4542, 4706}
+    assert epics.isdisjoint(hard_coded_four)
+    assert epics == {1001, 1002, 2001, 3001}
+
+
+def test_schema_applies_inventory_receipts_migration(tmp_path: Path) -> None:
+    migrations = load_migrations()
+    assert [m.version for m in migrations] == [1, 2]
+    assert "inventory_receipts" in migrations[1].name
+    db = SessionStreamDatabase(tmp_path / "streams.sqlite3")
+    conn = db.connect()
+    try:
+        versions = [int(r[0]) for r in conn.execute("SELECT version FROM schema_migrations ORDER BY 1")]
+        assert versions == [1, 2]
+        for table in (
+            "stream_migration_state",
+            "stream_inventory_receipts",
+            "legacy_import_receipts",
+            "legacy_projection_receipts",
+            "stream_control_events",
+        ):
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                (table,),
+            ).fetchone()
+            assert row is not None, table
+    finally:
+        conn.close()
+
+
+def test_register_manifest_inventory_writes_receipts(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "streams.sqlite3"))
+    result = register_manifest_inventory(store, repo)
+    assert result.epic_count == 4
+    assert set(result.registered_stream_ids) == {
+        "epic:1001",
+        "epic:1002",
+        "epic:2001",
+        "epic:3001",
+    }
+    assert result.new_inventory_receipts == 4
+    assert result.import_receipts_written >= 4  # at least one candidate per epic
+    assert all(mode == "inventory" for mode in result.modes.values())
+
+    # Idempotent for same manifest hash
+    again = register_manifest_inventory(store, repo)
+    assert again.new_inventory_receipts == 0
+
+    summary = inventory_registration_summary(store)
+    assert summary["inventory_receipts"] == 4
+    assert summary["import_receipts"] >= 4
+    assert summary["modes"] == {"inventory": 4}
+    assert "blocked" in summary["cutover"]
+
+    states = list_migration_state(store)
+    assert {s["stream_id"] for s in states} == set(result.registered_stream_ids)
+    assert all(s["mode"] == "inventory" for s in states)
+
+    # Existing handoff file recorded as inventoried
+    with store._read_snapshot() as conn:
+        inv_rows = conn.execute(
+            "SELECT status, source_path FROM legacy_import_receipts WHERE stream_id = 'epic:1001'"
+        ).fetchall()
+        statuses = {str(r["status"]) for r in inv_rows}
+        assert "inventoried" in statuses
+        assert "missing" in statuses
+
+
+def test_projection_receipt_records_drift(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "streams.sqlite3"))
+    register_manifest_inventory(store, repo)
+    pid = record_projection_receipt(
+        store,
+        stream_id="epic:1001",
+        target_path=".claude/alpha-epic/CLAUDE-DRIVER-HANDOFF.md",
+        target_sha256="a" * 64,
+        projection_body="projected body",
+        status="drift",
+        error="file hash diverged",
+    )
+    assert pid >= 1
+    summary = inventory_registration_summary(store)
+    assert summary["projection_receipts"] == 1
+    with store._read_snapshot() as conn:
+        events = conn.execute(
+            "SELECT event_type FROM stream_control_events "
+            "WHERE stream_id = 'epic:1001' AND event_type = 'drift_detected'"
+        ).fetchall()
+        assert len(events) == 1
+
+
+def test_cli_inventory_json_and_register(tmp_path: Path, capsys) -> None:
+    repo = _fixture_repo(tmp_path)
+    db_path = tmp_path / "streams.sqlite3"
+    # Read-only inventory (no register)
+    code = main(
+        [
+            "--db",
+            str(db_path),
+            "inventory",
+            "--repo-root",
+            str(repo),
+            "--format",
+            "json",
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert '"epic_count": 4' in out
+    assert "1001" in out and "3001" in out
+    assert "hard_coded_subset_authoritative" in out
+
+    code = main(
+        [
+            "--db",
+            str(db_path),
+            "inventory",
+            "--repo-root",
+            str(repo),
+            "--register",
+            "--format",
+            "json",
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "registration" in out
+    assert "new_inventory_receipts" in out
+    summary = inventory_registration_summary(SessionStreamStore(SessionStreamDatabase(db_path)))
+    assert summary["inventory_receipts"] == 4


### PR DESCRIPTION
## Summary

Sol **PR-H** first-slice completion for #5512 (after #5515 inventory map):

- Manifest-derived **sorted epic list** + **stream map** + `inventory_snapshot` from `scripts/config/issue_streams.yaml`
- Migration **0002**: inventory / import / projection receipts + stream control events + migration mode state (`inventory` only; **no cutover**)
- `register_manifest_inventory` seeds every epic with receipts at `mode=inventory`
- CLI: `.venv/bin/python -m agents_extensions.shared.session_streams inventory [--register]`
- Multi-stream fixture tests prove fixture epics are sole authority (not a hard-coded four-epic list)
- No launcher changes; no message-plane default flips

## Files

- `agents_extensions/shared/session_streams/inventory.py`
- `agents_extensions/shared/session_streams/receipts.py` (new)
- `agents_extensions/shared/session_streams/migrations/0002_inventory_receipts.sql` (new)
- `agents_extensions/shared/session_streams/cli.py`
- `agents_extensions/shared/session_streams/store.py`
- `docs/runbooks/fleet-comms-open-gaps.md` (stale registry pointer)
- `tests/test_session_streams_inventory_receipts.py` (new)
- `tests/test_session_streams.py`

## Verification

```bash
.venv/bin/python -m pytest tests/test_session_streams_inventory_receipts.py \
  tests/test_session_streams.py tests/test_session_streams_cli.py \
  tests/test_session_streams_dual_write_status.py -q
# 31 passed
```

Refs #5512

X-Agent: grok/5512-pr-h-stream-inventory