### PR TITLE
feat(fleet-comms): register grok/kimi/cursor fail-closed formal CF flags

### DIFF
--- a/scripts/config/fleet_communications.yaml
+++ b/scripts/config/fleet_communications.yaml
@@ -1,5 +1,9 @@
 ---
 version: 1
+# formal_review_eligible is fail-closed until sealed CF isolation is proven and
+# the matching isolation issue closes (#5555 AGY, #5556 Kimi, #5557 Grok). Only
+# claude|codex are proven formal CF seats today; unproven live lanes stay
+# eligible for advisory/implement work with formal_review_eligible: false.
 endpoints:
   - name: claude
     aliases: [claude]
@@ -31,7 +35,44 @@ endpoints:
     concurrency_limit: 2
     # Sealed formal CF isolation not proven (project instructions / MCP / hooks /
     # nested reviewers). Use claude|glm|codex via review-pr. AGY stays live for
-    # advisory bridge asks without --review.
+    # advisory bridge asks without --review. See #5555.
+    formal_review_eligible: false
+    model_family_resolver: canonical-reviewer-resolver
+  - name: grok
+    aliases: [grok]
+    state: live
+    transports: [native_cli]
+    completion_evidence: [terminal_event]
+    default_ttl_seconds: 3600
+    retry_class: standard
+    concurrency_limit: 1
+    # Sealed formal CF isolation not proven (OAuth / tool credential surface).
+    # Live for implement/advisory work; formal CF via review-pr claude|glm|codex.
+    # See #5557.
+    formal_review_eligible: false
+    model_family_resolver: canonical-reviewer-resolver
+  - name: kimi
+    aliases: [kimi]
+    state: live
+    transports: [project_bridge]
+    completion_evidence: [terminal_event]
+    default_ttl_seconds: 3600
+    retry_class: standard
+    concurrency_limit: 1
+    # Sealed formal CF isolation not proven. Live for implement/advisory bridge
+    # asks; formal CF via review-pr claude|glm|codex. See #5556.
+    formal_review_eligible: false
+    model_family_resolver: canonical-reviewer-resolver
+  - name: cursor
+    aliases: [cursor]
+    state: live
+    transports: [native_cli]
+    completion_evidence: [terminal_event]
+    default_ttl_seconds: 3600
+    retry_class: standard
+    concurrency_limit: 1
+    # Harness multi-model seat; not a sealed formal CF identity. Cursor auto is
+    # never a model identity for formal review (model_catalog policy).
     formal_review_eligible: false
     model_family_resolver: canonical-reviewer-resolver
   - name: gemini

--- a/tests/test_fleet_comms_contracts.py
+++ b/tests/test_fleet_comms_contracts.py
@@ -44,6 +44,25 @@ def test_endpoint_registry_retires_gemini_to_agy() -> None:
     assert endpoint.state == "live"
 
 
+def test_endpoint_registry_formal_review_eligibility_is_fail_closed() -> None:
+    """Sealed CF only for proven seats; unproven live lanes stay false until isolation issues close."""
+    registry = load_endpoint_registry()
+    by_name = {endpoint.name: endpoint for endpoint in registry.endpoints}
+
+    assert by_name["claude"].formal_review_eligible is True
+    assert by_name["codex"].formal_review_eligible is True
+
+    for name in ("agy", "grok", "kimi", "cursor", "gemini", "glm-local"):
+        assert name in by_name, f"missing registry endpoint: {name}"
+        assert by_name[name].formal_review_eligible is False, name
+
+    for name in ("grok", "kimi", "agy", "cursor"):
+        endpoint, resolved = registry.resolve(name)
+        assert resolved == name
+        assert endpoint.state == "live"
+        assert endpoint.formal_review_eligible is False
+
+
 def test_endpoint_registry_rejects_duplicate_aliases(tmp_path: Path) -> None:
     path = tmp_path / "fleet.yaml"
     path.write_text(


### PR DESCRIPTION
## Summary

Registers first-class fleet-comms endpoints for **grok**, **kimi**, and **cursor** with `formal_review_eligible: false` (fail-closed until sealed CF isolation is proven). Keeps proven seats and existing policy intact.

Closes a registry gap called out by #5556 / #5557 (and mirrors #5555/#5553 for AGY): unproven lanes must appear in `fleet_communications.yaml` as not formal-eligible rather than being absent.

Parent: #5512

## Changes

- `scripts/config/fleet_communications.yaml`
  - Add live `grok`, `kimi`, `cursor` with `formal_review_eligible: false`
  - Keep `claude`/`codex` true; `agy` false; `gemini` retired; `glm-local` false
  - Header comment: fail-closed until isolation issues close (#5555 / #5556 / #5557)
- `tests/test_fleet_comms_contracts.py`
  - Assert registry loads and grok/kimi/agy/cursor (plus gemini/glm-local) are not formal-eligible; claude/codex remain true

## Verification

```bash
.venv/bin/python -m pytest tests/test_fleet_comms_contracts.py tests/test_agy_sealed_review_refuse.py -q
# 10 passed
```

## Non-goals

- Does not flip any unproven lane to formal-eligible
- Does not implement isolation for Grok/Kimi/AGY (#5555–#5557 remain open)
- No Sol advisory path on this slice

## X-Agent

`grok/5512-registry-formal-cf-flags`