### PR TITLE
feat(fleet-comms): read-only plane-status Monitor API (#5512)

### DIFF
--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -11,6 +11,7 @@ Endpoints:
   GET /api/comms/zombies               Stuck patterns
   GET /api/comms/stats                 Rate, latency, error %
   GET /api/comms/health                Broker DB health
+  GET /api/comms/v1/plane-status       Message-plane mode + schema + parity (read-only)
   GET /api/comms/agent-activity        Compact channel activity by agent
   GET /api/comms/batch-progress        Live preseed/batch progress per track
   POST /api/comms/cleanup              Force-ack zombies
@@ -42,6 +43,7 @@ except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
 from pydantic import BaseModel
 
+from scripts.fleet_comms.message_plane import read_plane_status
 from scripts.fleet_comms.migrations import apply_migrations
 
 from .config import CURRICULUM_ROOT, MESSAGE_DB, PROJECT_ROOT
@@ -770,6 +772,18 @@ async def broker_health():
                 pass
 
     return health
+
+
+@router.get("/v1/plane-status")
+async def message_plane_status():
+    """Read-only fleet message-plane status (PR-K-ish / #5512 parity surface).
+
+    Reports ``FLEET_COMMS_MESSAGE_PLANE`` mode (default off), schema migration
+    version when ``batch_state/fleet-comms/v1/comms.sqlite3`` exists, and a
+    recent parity telemetry summary when the optional JSONL file is present.
+    Never writes or migrates.
+    """
+    return read_plane_status(repo_root=PROJECT_ROOT)
 
 
 # ==================== BATCH PROGRESS ====================

--- a/scripts/fleet_comms/__init__.py
+++ b/scripts/fleet_comms/__init__.py
@@ -3,7 +3,12 @@
 from scripts.fleet_comms.adapter_conformance import CaptureInput, conform
 from scripts.fleet_comms.artifacts import ArtifactRecord, ArtifactStore
 from scripts.fleet_comms.contracts import AssistantSegment, CompletionState, ResponseEnvelope, new_id
-from scripts.fleet_comms.message_plane import MessagePlane, open_message_plane, resolve_plane_mode
+from scripts.fleet_comms.message_plane import (
+    MessagePlane,
+    open_message_plane,
+    read_plane_status,
+    resolve_plane_mode,
+)
 from scripts.fleet_comms.request_executor import RequestExecutor, RequestRecord
 
 __all__ = [
@@ -19,5 +24,6 @@ __all__ = [
     "conform",
     "new_id",
     "open_message_plane",
+    "read_plane_status",
     "resolve_plane_mode",
 ]

--- a/scripts/fleet_comms/message_plane.py
+++ b/scripts/fleet_comms/message_plane.py
@@ -30,8 +30,14 @@ from scripts.fleet_comms.request_executor import RequestExecutor, RequestRecord
 
 PlaneMode = Literal["off", "shadow", "dual_write"]
 ENV_MODE = "FLEET_COMMS_MESSAGE_PLANE"
+ENV_ROOT = "FLEET_COMMS_ROOT"
+ENV_TELEMETRY = "FLEET_COMMS_PLANE_TELEMETRY"
 # Max centrally configured continuation segments for length_limited (Sol).
 MAX_CONTINUATIONS = 2
+# Conventional relative layout under the plane root (batch_state/fleet-comms/v1).
+DEFAULT_ROOT_REL = Path("batch_state") / "fleet-comms" / "v1"
+DEFAULT_TELEMETRY_NAME = Path("telemetry") / "plane-parity.jsonl"
+_TELEMETRY_SUMMARY_LIMIT = 50
 
 
 def resolve_plane_mode(raw: str | None = None) -> PlaneMode:
@@ -43,6 +49,24 @@ def resolve_plane_mode(raw: str | None = None) -> PlaneMode:
     if value in {"dual-write", "dualwrite"}:
         return "dual_write"
     raise ValueError(f"invalid FLEET_COMMS_MESSAGE_PLANE={value!r} (use off|shadow|dual_write)")
+
+
+def default_plane_root(*, repo_root: Path | None = None) -> Path:
+    """Resolve plane storage root (env override or batch_state/fleet-comms/v1)."""
+    env = os.environ.get(ENV_ROOT)
+    if env:
+        return Path(env).expanduser()
+    base = repo_root if repo_root is not None else Path.cwd()
+    return (base / DEFAULT_ROOT_REL).resolve()
+
+
+def default_parity_telemetry_path(root: Path | None = None) -> Path:
+    """Optional parity JSONL path under the plane root (or env override)."""
+    env = os.environ.get(ENV_TELEMETRY)
+    if env:
+        return Path(env).expanduser()
+    base = root if root is not None else default_plane_root()
+    return Path(base) / DEFAULT_TELEMETRY_NAME
 
 
 def _utc_now() -> str:
@@ -424,3 +448,122 @@ def open_message_plane(
         legacy_db=legacy_db,
         telemetry_path=telemetry_path,
     )
+
+
+def _read_applied_schema_version(db_path: Path) -> dict[str, Any]:
+    """Read comms_schema_migrations without writing or migrating."""
+    from scripts.fleet_comms.migrations import MIGRATIONS
+
+    known = MIGRATIONS[-1].version if MIGRATIONS else 0
+    payload: dict[str, Any] = {
+        "known_version": known,
+        "applied_version": None,
+        "applied_name": None,
+        "db_path": str(db_path),
+        "db_exists": db_path.is_file(),
+    }
+    if not db_path.is_file():
+        return payload
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = conn.execute(
+                "SELECT version, name FROM comms_schema_migrations ORDER BY version DESC LIMIT 1"
+            ).fetchone()
+            if row is not None:
+                payload["applied_version"] = int(row[0])
+                payload["applied_name"] = str(row[1]) if row[1] is not None else None
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        payload["db_error"] = str(exc)
+    return payload
+
+
+def _summarize_parity_telemetry(
+    path: Path,
+    *,
+    limit: int = _TELEMETRY_SUMMARY_LIMIT,
+) -> dict[str, Any]:
+    """Read-only tail summary of plane parity JSONL (missing file is fine)."""
+    summary: dict[str, Any] = {
+        "path": str(path),
+        "exists": path.is_file(),
+        "event_count": 0,
+        "parity_ok_count": 0,
+        "parity_fail_count": 0,
+        "recent": [],
+        "summary_window": limit,
+    }
+    if not path.is_file():
+        return summary
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        summary["read_error"] = str(exc)
+        return summary
+    events: list[dict[str, Any]] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            loaded = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(loaded, dict):
+            events.append(loaded)
+    summary["event_count"] = len(events)
+    ok = 0
+    fail = 0
+    for event in events:
+        flag = event.get("parity_ok")
+        if flag is True:
+            ok += 1
+        elif flag is False:
+            fail += 1
+    summary["parity_ok_count"] = ok
+    summary["parity_fail_count"] = fail
+    summary["recent"] = events[-limit:]
+    return summary
+
+
+def read_plane_status(
+    *,
+    repo_root: Path | None = None,
+    root: Path | None = None,
+    telemetry_path: Path | None = None,
+    recent_limit: int = _TELEMETRY_SUMMARY_LIMIT,
+) -> dict[str, Any]:
+    """Read-only message-plane status for Monitor API (no writer side effects).
+
+    Returns mode from ``FLEET_COMMS_MESSAGE_PLANE`` (default ``off``), schema
+    migration version when the plane DB exists, and an optional parity telemetry
+    summary when the JSONL file is present under batch_state (or env override).
+    """
+    mode_error: str | None = None
+    try:
+        mode: PlaneMode | str = resolve_plane_mode()
+    except ValueError as exc:
+        mode = "invalid"
+        mode_error = str(exc)
+
+    plane_root = Path(root) if root is not None else default_plane_root(repo_root=repo_root)
+    db_path = plane_root / "comms.sqlite3"
+    tele_path = (
+        Path(telemetry_path)
+        if telemetry_path is not None
+        else default_parity_telemetry_path(plane_root)
+    )
+
+    payload: dict[str, Any] = {
+        "mode": mode,
+        "enabled": mode not in {"off", "invalid"},
+        "read_only": True,
+        "plane_root": str(plane_root),
+        "schema": _read_applied_schema_version(db_path),
+        "parity_telemetry": _summarize_parity_telemetry(tele_path, limit=recent_limit),
+    }
+    if mode_error is not None:
+        payload["mode_error"] = mode_error
+    return payload

--- a/tests/test_comms_plane_status_api.py
+++ b/tests/test_comms_plane_status_api.py
@@ -1,0 +1,105 @@
+"""Monitor API plane-status surface (read-only; Sol PR-K-ish / #5512)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from scripts.fleet_comms.message_plane import read_plane_status
+from scripts.fleet_comms.migrations import apply_migrations
+
+
+def _client() -> TestClient:
+    from scripts.api.comms_router import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/comms")
+    return TestClient(app)
+
+
+def test_read_plane_status_defaults_off(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("FLEET_COMMS_MESSAGE_PLANE", raising=False)
+    monkeypatch.delenv("FLEET_COMMS_ROOT", raising=False)
+    monkeypatch.delenv("FLEET_COMMS_PLANE_TELEMETRY", raising=False)
+    status = read_plane_status(repo_root=tmp_path)
+    assert status["mode"] == "off"
+    assert status["enabled"] is False
+    assert status["read_only"] is True
+    assert status["schema"]["known_version"] == 1
+    assert status["schema"]["applied_version"] is None
+    assert status["schema"]["db_exists"] is False
+    assert status["parity_telemetry"]["exists"] is False
+    assert status["parity_telemetry"]["event_count"] == 0
+
+
+def test_read_plane_status_with_schema_and_telemetry(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "fleet-comms" / "v1"
+    root.mkdir(parents=True)
+    db_path = root / "comms.sqlite3"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        applied = apply_migrations(conn)
+        assert applied == 1
+    finally:
+        conn.close()
+
+    tele = root / "telemetry" / "plane-parity.jsonl"
+    tele.parent.mkdir(parents=True)
+    events = [
+        {"event": "plane_complete", "parity_ok": True, "request_id": "a"},
+        {"event": "plane_complete", "parity_ok": False, "request_id": "b"},
+        {"event": "plane_refuse_legacy_replied", "request_id": "c"},
+    ]
+    tele.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "shadow")
+    status = read_plane_status(root=root, telemetry_path=tele)
+    assert status["mode"] == "shadow"
+    assert status["enabled"] is True
+    assert status["schema"]["db_exists"] is True
+    assert status["schema"]["applied_version"] == 1
+    assert status["schema"]["applied_name"] == "fleet-comms-v1-contracts"
+    assert status["parity_telemetry"]["exists"] is True
+    assert status["parity_telemetry"]["event_count"] == 3
+    assert status["parity_telemetry"]["parity_ok_count"] == 1
+    assert status["parity_telemetry"]["parity_fail_count"] == 1
+    assert len(status["parity_telemetry"]["recent"]) == 3
+
+
+def test_api_plane_status_endpoint(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "dual_write")
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(tmp_path / "plane"))
+    tele = tmp_path / "tele.jsonl"
+    tele.write_text(
+        json.dumps({"event": "plane_complete", "parity_ok": True}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FLEET_COMMS_PLANE_TELEMETRY", str(tele))
+
+    # Endpoint uses PROJECT_ROOT for repo_root; plane root/telemetry come from env.
+    client = _client()
+    response = client.get("/api/comms/v1/plane-status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "dual_write"
+    assert data["enabled"] is True
+    assert data["read_only"] is True
+    assert data["plane_root"] == str(tmp_path / "plane")
+    assert data["parity_telemetry"]["exists"] is True
+    assert data["parity_telemetry"]["event_count"] == 1
+    assert data["schema"]["known_version"] == 1
+
+
+def test_api_plane_status_invalid_mode(monkeypatch) -> None:
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "production")
+    client = _client()
+    response = client.get("/api/comms/v1/plane-status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "invalid"
+    assert data["enabled"] is False
+    assert "mode_error" in data


### PR DESCRIPTION
## Summary
- Add **GET `/api/comms/v1/plane-status`** — read-only message-plane status for fleet-comms parity after PR-E (#5558/#5559).
- Reports `FLEET_COMMS_MESSAGE_PLANE` mode (default `off`), schema/migration version from plane DB when present, and recent parity telemetry summary when the optional JSONL under `batch_state/fleet-comms/v1` exists.
- **Not a second writer** — no migrations, no cutover, no production flip.

## Endpoint
`GET /api/comms/v1/plane-status`

Example fields:
- `mode` / `enabled` / `read_only`
- `schema.known_version` / `schema.applied_version` (from `comms.sqlite3` if present)
- `parity_telemetry` (exists, counts, recent events; missing file is fine)

Optional env:
- `FLEET_COMMS_MESSAGE_PLANE` — `off`|`shadow`|`dual_write`
- `FLEET_COMMS_ROOT` — plane root override
- `FLEET_COMMS_PLANE_TELEMETRY` — JSONL path override

## Test plan
- [x] `pytest tests/test_comms_plane_status_api.py` (TestClient)
- [x] existing `tests/test_fleet_comms_message_plane.py` still green

## Notes
- Parent: #5512 (fleet-comms full solution)
- Sol PR-K-ish partial only — no Sol, no production cutover
- Cross-family review: Claude (requested)