### PR TITLE
feat(fleet-comms): PR-B2 remaining adapter conformance (#5512)

### DIFF
--- a/scripts/fleet_comms/adapter_conformance.py
+++ b/scripts/fleet_comms/adapter_conformance.py
@@ -5,14 +5,16 @@ only emit ``complete`` when their documented terminal contract is observed.
 Exit 0 + nonempty text alone is never enough.
 
 B1 primary adapters: codex, claude, agy.
-B2 remaining adapters start as stubs that return ``unknown`` until terminal
-evidence is proven (Sol: unknown → not formal-review eligible).
+B2 remaining adapters: grok, kimi, cursor, hermes (+ hermes-*), opencode —
+each implements a real harness-specific terminal contract. Missing terminal
+evidence yields ``unknown`` (formal-review ineligible).
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -20,8 +22,45 @@ from typing import Any
 from scripts.fleet_comms.contracts import AssistantSegment, CompletionState, ResponseEnvelope
 
 PRIMARY_ADAPTERS = frozenset({"codex", "claude", "agy"})
-# B2 targets — stubs until terminal evidence is wired.
-REMAINING_ADAPTERS = frozenset({"grok", "kimi", "cursor", "hermes", "opencode", "hermes-grok", "hermes-qwen", "hermes-deepseek"})
+REMAINING_ADAPTERS = frozenset(
+    {
+        "grok",
+        "grok-build",
+        "grok-hermes",
+        "kimi",
+        "cursor",
+        "hermes",
+        "hermes-grok",
+        "hermes-qwen",
+        "hermes-deepseek",
+        "opencode",
+    }
+)
+
+_LENGTH_REASONS = frozenset(
+    {
+        "length",
+        "max_tokens",
+        "max_output_tokens",
+        "maxtokens",
+        "max_token",
+        "length_limit",
+        "output_length",
+    }
+)
+_ERROR_REASONS = frozenset(
+    {
+        "error",
+        "failed",
+        "failure",
+        "aborted",
+        "abort",
+        "cancelled",
+        "canceled",
+        "refused",
+    }
+)
+_HERMES_HTTP_ERROR_RE = re.compile(r"^HTTP\s+[45]\d{2}\b")
 
 
 @dataclass(frozen=True, slots=True)
@@ -495,8 +534,547 @@ def conform_agy(capture: CaptureInput) -> ResponseEnvelope:
     )
 
 
+def _is_length_reason(reason: str | None) -> bool:
+    if not reason:
+        return False
+    normalized = reason.strip().lower().replace("-", "_")
+    return normalized in _LENGTH_REASONS
+
+
+def _is_error_reason(reason: str | None) -> bool:
+    if not reason:
+        return False
+    normalized = reason.strip().lower().replace("-", "_")
+    return normalized in _ERROR_REASONS
+
+
+def _with_session(
+    capture: CaptureInput,
+    *,
+    events: Sequence[dict[str, Any]] | None = None,
+    session_id: str | None = None,
+) -> CaptureInput:
+    return CaptureInput(
+        adapter=capture.adapter,
+        stdout=capture.stdout,
+        stderr=capture.stderr,
+        returncode=capture.returncode,
+        events=tuple(events) if events is not None else capture.events,
+        raw_bytes=capture.raw_bytes,
+        session_id=session_id if session_id is not None else capture.session_id,
+        transport_metadata=capture.transport_metadata,
+    )
+
+
+def _finish(
+    *,
+    segments: Sequence[AssistantSegment],
+    terminal: bool,
+    stop_reason: str | None,
+    capture: CaptureInput,
+    events: Sequence[dict[str, Any]] | None = None,
+    session_id: str | None = None,
+    extra_meta: Mapping[str, Any] | None = None,
+    error_terminal: bool = False,
+) -> ResponseEnvelope:
+    """Shared completion-state matrix used by B1/B2 conformers."""
+    bound = _with_session(capture, events=events, session_id=session_id)
+    length_limited = _is_length_reason(stop_reason)
+    if capture.returncode not in (None, 0) and not terminal:
+        state = CompletionState.FAILED if not segments else CompletionState.TRANSPORT_INCOMPLETE
+        return _envelope(
+            segments=segments,
+            state=state,
+            terminal=False,
+            capture=bound,
+            stop_reason=stop_reason or f"rc={capture.returncode}",
+            extra_meta=extra_meta,
+        )
+    if length_limited:
+        return _envelope(
+            segments=segments,
+            state=CompletionState.LENGTH_LIMITED,
+            terminal=terminal,
+            capture=bound,
+            stop_reason=stop_reason,
+            extra_meta=extra_meta,
+        )
+    if terminal and (error_terminal or _is_error_reason(stop_reason)):
+        return _envelope(
+            segments=segments,
+            state=CompletionState.FAILED,
+            terminal=True,
+            capture=bound,
+            stop_reason=stop_reason or "error",
+            extra_meta=extra_meta,
+        )
+    if terminal:
+        return _envelope(
+            segments=segments,
+            state=CompletionState.COMPLETE,
+            terminal=True,
+            capture=bound,
+            stop_reason=stop_reason or "terminal",
+            extra_meta=extra_meta,
+        )
+    if segments and capture.returncode in (None, 0):
+        return _envelope(
+            segments=segments,
+            state=CompletionState.UNKNOWN,
+            terminal=False,
+            capture=bound,
+            stop_reason=stop_reason or "missing_terminal_event",
+            extra_meta=extra_meta,
+        )
+    if not segments:
+        return _envelope(
+            segments=(),
+            state=CompletionState.TRANSPORT_INCOMPLETE,
+            terminal=False,
+            capture=bound,
+            stop_reason=stop_reason or "empty_capture",
+            extra_meta=extra_meta,
+        )
+    return _envelope(
+        segments=segments,
+        state=CompletionState.UNKNOWN,
+        terminal=False,
+        capture=bound,
+        stop_reason=stop_reason,
+        extra_meta=extra_meta,
+    )
+
+
+def _assistant_text_from_content(value: Any) -> str:
+    """Extract assistant prose from string / content-block shapes."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item:
+                parts.append(item)
+            elif isinstance(item, dict) and item.get("type") in {None, "text", "output_text"}:
+                text = item.get("text")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+        return "".join(parts)
+    return ""
+
+
+def _parse_json_object_tolerant(stdout: str) -> dict[str, Any] | None:
+    """Parse a single JSON object, tolerating leading/trailing log noise."""
+    text = (stdout or "").strip()
+    if not text:
+        return None
+    try:
+        value = json.loads(text)
+        return value if isinstance(value, dict) else None
+    except json.JSONDecodeError:
+        pass
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        try:
+            value = json.loads(text[start : end + 1])
+            return value if isinstance(value, dict) else None
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def conform_grok(capture: CaptureInput) -> ResponseEnvelope:
+    """Native grok headless JSON: terminal proof is a present ``stopReason``.
+
+    Documented shape (``GrokBuildAdapter``): ``{text, stopReason, sessionId}``.
+    Plain-text / JSON without ``stopReason`` is never ``complete``.
+    """
+    events = list(capture.events) if capture.events else _parse_jsonl(capture.stdout)
+    texts: list[str] = []
+    stop_reason: str | None = None
+    terminal = False
+    session_id = capture.session_id
+
+    def absorb_object(obj: Mapping[str, Any]) -> None:
+        nonlocal stop_reason, terminal, session_id
+        text = obj.get("text")
+        if isinstance(text, str) and text.strip():
+            texts.append(text.strip())
+        # Prefer documented camelCase; accept snake_case drift.
+        if "stopReason" in obj or "stop_reason" in obj:
+            terminal = True
+            raw = obj.get("stopReason", obj.get("stop_reason"))
+            if raw is not None:
+                stop_reason = str(raw)
+        sid = obj.get("sessionId") or obj.get("session_id")
+        if isinstance(sid, str) and sid:
+            session_id = sid
+
+    if events:
+        for event in events:
+            absorb_object(event)
+    else:
+        obj = _parse_json_object_tolerant(capture.stdout)
+        if obj is not None:
+            absorb_object(obj)
+        elif capture.stdout.strip():
+            # Plain-text fallback path used by the adapter — no terminal proof.
+            texts.append(capture.stdout.strip())
+
+    # Normalize: grok JSON text is stripped in the adapter on success.
+    segments = _ordered_segments(texts)
+    return _finish(
+        segments=segments,
+        terminal=terminal,
+        stop_reason=stop_reason,
+        capture=capture,
+        events=events,
+        session_id=session_id,
+        extra_meta={"terminal_contract": "stopReason"},
+    )
+
+
+def conform_kimi(capture: CaptureInput) -> ResponseEnvelope:
+    """Kimi stream-json: terminal proof is a completion meta event.
+
+    Documented terminal: ``role=meta`` + ``type=session.resume_hint`` (emitted
+    after a finished run; adapter already keys session resume on it). Optional
+    completion signals: meta ``status`` with a finished state, or explicit
+    ``result``/``done`` event types if the CLI adds them.
+    """
+    events = list(capture.events) if capture.events else _parse_jsonl(capture.stdout)
+    texts: list[str] = []
+    stop_reason: str | None = None
+    terminal = False
+    session_id = capture.session_id
+
+    for event in events:
+        role = str(event.get("role") or "")
+        etype = str(event.get("type") or event.get("event") or "")
+        if role == "assistant":
+            content = _assistant_text_from_content(event.get("content"))
+            if content:
+                texts.append(content)
+            reason = event.get("stop_reason") or event.get("finish_reason") or event.get("reason")
+            if isinstance(reason, str) and reason:
+                stop_reason = reason
+                if _is_length_reason(reason) or _is_error_reason(reason):
+                    # Explicit stop/finish reason on an assistant turn is terminal.
+                    terminal = True
+        if role == "meta" and etype == "session.resume_hint":
+            terminal = True
+            stop_reason = stop_reason or "session.resume_hint"
+            sid = event.get("session_id")
+            if isinstance(sid, str) and sid.strip():
+                session_id = sid.strip()
+        if role == "meta" and etype == "status":
+            state = str(event.get("state") or "").strip().lower()
+            if state in {"done", "completed", "finished", "idle", "ready"}:
+                terminal = True
+                stop_reason = stop_reason or f"status:{state}"
+            elif state in {"error", "failed"}:
+                terminal = True
+                stop_reason = "error"
+        if etype in {"result", "done", "task_complete", "RESULT"}:
+            terminal = True
+            stop_reason = stop_reason or etype
+            body = event.get("result") or event.get("content") or event.get("text")
+            if isinstance(body, str) and body.strip():
+                texts.append(body.strip())
+        reason = event.get("stop_reason") or event.get("finish_reason") or event.get("reason")
+        if isinstance(reason, str) and _is_length_reason(reason):
+            stop_reason = reason
+            terminal = True
+        sid = event.get("session_id")
+        if isinstance(sid, str) and sid.strip() and role == "meta":
+            session_id = sid.strip()
+
+    segments = _ordered_segments(texts)
+    if not segments and capture.stdout.strip() and not events:
+        segments = _ordered_segments([capture.stdout.strip()])
+
+    return _finish(
+        segments=segments,
+        terminal=terminal,
+        stop_reason=stop_reason,
+        capture=capture,
+        events=events,
+        session_id=session_id,
+        extra_meta={"terminal_contract": "session.resume_hint|status|result"},
+    )
+
+
+def conform_cursor(capture: CaptureInput) -> ResponseEnvelope:
+    """Cursor stream-json / transcript: terminal proof is ``turn_ended``.
+
+    Segments come from ordered ``text`` / assistant ``message`` events (not only
+    the last). ``turn_ended`` with error status → failed; length reasons map to
+    ``length_limited``.
+    """
+    events = list(capture.events) if capture.events else _parse_jsonl(capture.stdout)
+    texts: list[str] = []
+    stream_chunks: list[str] = []
+    stop_reason: str | None = None
+    terminal = False
+    session_id = capture.session_id
+    error_terminal = False
+
+    def flush_stream() -> None:
+        if stream_chunks:
+            texts.append("".join(stream_chunks))
+            stream_chunks.clear()
+
+    for event in events:
+        etype = str(event.get("type") or "")
+        sid = event.get("sessionId") or event.get("session_id")
+        if isinstance(sid, str) and sid:
+            session_id = sid
+
+        if etype == "text":
+            content = event.get("content")
+            if content is not None:
+                stream_chunks.append(str(content))
+        elif etype == "message" and event.get("role") == "assistant":
+            flush_stream()
+            text = _assistant_text_from_content(event.get("content"))
+            if text:
+                texts.append(text)
+        elif event.get("role") == "assistant" and isinstance(event.get("message"), dict):
+            flush_stream()
+            text = _assistant_text_from_content(event["message"].get("content"))
+            if text:
+                texts.append(text)
+        elif etype == "turn_ended":
+            flush_stream()
+            terminal = True
+            status = str(event.get("status") or event.get("reason") or "turn_ended")
+            stop_reason = status
+            if _is_error_reason(status) or status.lower() in {"error", "failed", "failure"}:
+                error_terminal = True
+            if _is_length_reason(status):
+                stop_reason = status
+        elif etype in {"result", "done", "task_complete"}:
+            flush_stream()
+            terminal = True
+            stop_reason = str(event.get("reason") or event.get("subtype") or etype)
+            body = event.get("result") or event.get("content") or event.get("text")
+            if isinstance(body, str) and body.strip():
+                texts.append(body.strip())
+            if event.get("is_error") is True:
+                error_terminal = True
+                stop_reason = "error"
+
+        reason = event.get("stop_reason") or event.get("reason")
+        if isinstance(reason, str) and _is_length_reason(reason):
+            stop_reason = reason
+
+    flush_stream()
+    segments = _ordered_segments(texts)
+    if not segments and capture.stdout.strip() and not events:
+        segments = _ordered_segments([capture.stdout.strip()])
+
+    return _finish(
+        segments=segments,
+        terminal=terminal,
+        stop_reason=stop_reason,
+        capture=capture,
+        events=events,
+        session_id=session_id,
+        error_terminal=error_terminal,
+        extra_meta={"terminal_contract": "turn_ended"},
+    )
+
+
+def conform_opencode(capture: CaptureInput) -> ResponseEnvelope:
+    """OpenCode ``--format json`` NDJSON: terminal proof is final ``step_finish``.
+
+    Intermediate ``step_finish`` with ``reason=tool-calls`` is NOT terminal.
+    Final ``reason=stop`` (and aliases) → complete; ``reason=length`` →
+    length_limited. Ordered text parts from every ``type=text`` event are kept
+    (Sol multi-turn NDJSON requirement — not last-message-only).
+    """
+    events = list(capture.events) if capture.events else _parse_jsonl(capture.stdout)
+    texts: list[str] = []
+    current_turn: list[str] = []
+    stop_reason: str | None = None
+    terminal = False
+    session_id = capture.session_id
+    error_terminal = False
+
+    terminal_success_reasons = frozenset(
+        {"stop", "end", "end_turn", "endturn", "done", "complete", "completed", "success"}
+    )
+
+    def commit_turn() -> None:
+        if current_turn:
+            msg = "".join(current_turn)
+            if msg:
+                texts.append(msg)
+            current_turn.clear()
+
+    for event in events:
+        etype = str(event.get("type") or "")
+        sid = event.get("sessionID") or event.get("sessionId") or event.get("session_id")
+        if isinstance(sid, str) and sid:
+            session_id = sid
+
+        if etype == "text":
+            part = event.get("part") if isinstance(event.get("part"), dict) else {}
+            text = part.get("text") if part else event.get("text") or event.get("content")
+            if isinstance(text, str) and text:
+                current_turn.append(text)
+            continue
+
+        if etype in {"tool", "tool_use", "step_start"}:
+            commit_turn()
+            continue
+
+        if etype == "step_finish":
+            commit_turn()
+            part = event.get("part") if isinstance(event.get("part"), dict) else {}
+            reason_raw = part.get("reason") if part else event.get("reason")
+            reason = str(reason_raw).strip() if reason_raw is not None else ""
+            reason_norm = reason.lower().replace("-", "_")
+            if reason_norm in {"tool_calls", "tool-calls", "toolcalls"}:
+                # Intermediate step boundary — not completion proof.
+                stop_reason = stop_reason or reason or "tool-calls"
+                continue
+            if _is_length_reason(reason_norm) or _is_length_reason(reason):
+                terminal = True
+                stop_reason = reason or "length"
+                continue
+            if _is_error_reason(reason_norm) or reason_norm in {"error", "fail", "failed"}:
+                terminal = True
+                error_terminal = True
+                stop_reason = reason or "error"
+                continue
+            if reason_norm in terminal_success_reasons or not reason:
+                # Empty reason on step_finish is still a finish boundary; treat
+                # only explicit success aliases / stop as complete. Bare empty
+                # is weaker — require a known success reason for complete.
+                if reason_norm in terminal_success_reasons:
+                    terminal = True
+                    stop_reason = reason or "stop"
+                else:
+                    stop_reason = stop_reason or "step_finish"
+                continue
+            # Unknown reason: observe the finish event but only mark terminal
+            # when the reason is a known success/length/error class.
+            stop_reason = reason
+
+        if etype in {"result", "done", "task_complete"}:
+            commit_turn()
+            terminal = True
+            stop_reason = str(event.get("reason") or etype)
+
+    commit_turn()
+    segments = _ordered_segments(texts)
+    if not segments and capture.stdout.strip() and not events:
+        segments = _ordered_segments([capture.stdout.strip()])
+
+    return _finish(
+        segments=segments,
+        terminal=terminal,
+        stop_reason=stop_reason,
+        capture=capture,
+        events=events,
+        session_id=session_id,
+        error_terminal=error_terminal,
+        extra_meta={"terminal_contract": "step_finish.reason"},
+    )
+
+
+def conform_hermes(capture: CaptureInput) -> ResponseEnvelope:
+    """Hermes ``-z`` one-shot: plain stdout has no documented terminal event.
+
+    Hermes adapters only see the final assistant message on stdout (no
+    stream-json). Without structured terminal evidence the envelope is
+    ``unknown`` — never ``complete`` on exit 0 + text alone.
+
+    If a capture *does* include structured events (result/done/task_complete)
+    or a grok-shaped ``stopReason`` object, those are honored. In-band
+    ``HTTP 4xx/5xx`` provider errors (documented Hermes failure shape) map to
+    ``failed``.
+    """
+    events = list(capture.events) if capture.events else _parse_jsonl(capture.stdout)
+    texts: list[str] = []
+    stop_reason: str | None = None
+    terminal = False
+    session_id = capture.session_id
+    error_terminal = False
+    extra: dict[str, Any] = {
+        "terminal_contract": "structured_only",
+        "formal_review_eligible": False,
+    }
+
+    if events:
+        for event in events:
+            etype = str(event.get("type") or event.get("event") or "")
+            if etype in {"assistant", "message", "text"}:
+                text = event.get("text") or event.get("content") or event.get("result")
+                if isinstance(text, str) and text:
+                    texts.append(text)
+            if etype in {"result", "done", "RESULT", "task_complete"}:
+                terminal = True
+                stop_reason = str(event.get("reason") or etype)
+                body = event.get("result") or event.get("content") or event.get("text")
+                if isinstance(body, str) and body.strip():
+                    texts.append(body.strip())
+            if "stopReason" in event or "stop_reason" in event:
+                terminal = True
+                raw = event.get("stopReason", event.get("stop_reason"))
+                if raw is not None:
+                    stop_reason = str(raw)
+                text = event.get("text")
+                if isinstance(text, str) and text.strip():
+                    texts.append(text.strip())
+            reason = event.get("stop_reason") or event.get("reason")
+            if isinstance(reason, str) and _is_length_reason(reason):
+                stop_reason = reason
+                terminal = True
+            sid = event.get("session_id")
+            if isinstance(sid, str) and sid:
+                session_id = sid
+    else:
+        obj = _parse_json_object_tolerant(capture.stdout)
+        if obj is not None and ("stopReason" in obj or "stop_reason" in obj):
+            terminal = True
+            raw = obj.get("stopReason", obj.get("stop_reason"))
+            stop_reason = str(raw) if raw is not None else "stopReason"
+            text = obj.get("text")
+            if isinstance(text, str) and text.strip():
+                texts.append(text.strip())
+            sid = obj.get("sessionId") or obj.get("session_id")
+            if isinstance(sid, str) and sid:
+                session_id = sid
+        else:
+            cleaned = (capture.stdout or "").strip()
+            # Strip ANSI the same way Hermes adapters do (minimal: control seq).
+            cleaned = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", cleaned).strip()
+            if cleaned and _HERMES_HTTP_ERROR_RE.match(cleaned.splitlines()[0].strip()):
+                # Documented in-band provider error as the final assistant line.
+                error_terminal = True
+                terminal = True
+                stop_reason = "inband_http_error"
+                # Do not promote the error string as a successful segment.
+            elif cleaned:
+                texts.append(cleaned)
+
+    segments = _ordered_segments(texts)
+    return _finish(
+        segments=segments,
+        terminal=terminal,
+        stop_reason=stop_reason,
+        capture=capture,
+        events=events,
+        session_id=session_id,
+        error_terminal=error_terminal,
+        extra_meta=extra,
+    )
+
+
 def conform_unknown_stub(capture: CaptureInput) -> ResponseEnvelope:
-    """B2 stub: transports without proven terminal evidence stay ``unknown``."""
+    """Fallback for unregistered transports: never invent ``complete``."""
     text = capture.stdout.strip()
     segments = _ordered_segments([text] if text else [])
     return _envelope(
@@ -513,26 +1091,39 @@ _CONFORMERS: dict[str, Callable[[CaptureInput], ResponseEnvelope]] = {
     "codex": conform_codex,
     "claude": conform_claude,
     "agy": conform_agy,
+    # B2 — native / remaining adapters
+    "grok": conform_grok,
+    "grok-build": conform_grok,
+    "kimi": conform_kimi,
+    "cursor": conform_cursor,
+    "opencode": conform_opencode,
+    "hermes": conform_hermes,
+    "hermes-grok": conform_hermes,
+    "hermes-qwen": conform_hermes,
+    "hermes-deepseek": conform_hermes,
+    "grok-hermes": conform_hermes,
 }
 
 
 def conform(capture: CaptureInput) -> ResponseEnvelope:
-    """Dispatch to the adapter-specific conformer (or B2 stub)."""
+    """Dispatch to the adapter-specific conformer (or unknown stub)."""
     name = capture.adapter.strip().lower()
     if name in _CONFORMERS:
         return _CONFORMERS[name](capture)
-    if name in REMAINING_ADAPTERS or name:
-        # Explicit stub path — never invent complete.
-        return conform_unknown_stub(CaptureInput(
-            adapter=name,
-            stdout=capture.stdout,
-            stderr=capture.stderr,
-            returncode=capture.returncode,
-            events=capture.events,
-            raw_bytes=capture.raw_bytes,
-            session_id=capture.session_id,
-            transport_metadata=capture.transport_metadata,
-        ))
+    if name:
+        # Unregistered transport — never invent complete.
+        return conform_unknown_stub(
+            CaptureInput(
+                adapter=name,
+                stdout=capture.stdout,
+                stderr=capture.stderr,
+                returncode=capture.returncode,
+                events=capture.events,
+                raw_bytes=capture.raw_bytes,
+                session_id=capture.session_id,
+                transport_metadata=capture.transport_metadata,
+            )
+        )
     raise ValueError(f"Unknown adapter for conformance: {capture.adapter!r}")
 
 

--- a/tests/test_fleet_comms_b2.py
+++ b/tests/test_fleet_comms_b2.py
@@ -1,0 +1,342 @@
+"""Fleet Comms PR-B2: remaining adapter conformance fixture matrix (#5512).
+
+Same acceptance matrix as B1 for each remaining adapter:
+complete · length_limited · missing terminal · nonzero exit with output ·
+multi-segment ordered. Exit 0 + text alone never yields ``complete``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from scripts.fleet_comms.adapter_conformance import (
+    REMAINING_ADAPTERS,
+    CaptureInput,
+    conform,
+    raw_capture_matches,
+)
+from scripts.fleet_comms.contracts import CompletionState
+
+B2_ADAPTERS = ("grok", "kimi", "cursor", "hermes", "opencode")
+HERMES_ALIASES = ("hermes", "hermes-grok", "hermes-qwen", "hermes-deepseek", "grok-hermes")
+
+
+def _lines(*events: dict[str, Any]) -> str:
+    return "\n".join(json.dumps(event) for event in events)
+
+
+# ── shared invariants ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", B2_ADAPTERS)
+def test_exit0_plain_text_without_terminal_is_unknown_not_complete(name: str) -> None:
+    env = conform(CaptureInput(adapter=name, stdout="looks fine", returncode=0))
+    assert env.completion_state is CompletionState.UNKNOWN
+    assert env.terminal_event_observed is False
+    assert env.is_formal_review_eligible is False
+
+
+@pytest.mark.parametrize("name", HERMES_ALIASES)
+def test_hermes_aliases_plain_stdout_unknown(name: str) -> None:
+    env = conform(CaptureInput(adapter=name, stdout="assistant final message", returncode=0))
+    assert env.completion_state is CompletionState.UNKNOWN
+    assert env.is_formal_review_eligible is False
+
+
+def test_remaining_adapters_set_covers_b2_targets() -> None:
+    for name in (*B2_ADAPTERS, "hermes-grok", "hermes-qwen", "hermes-deepseek", "grok-build"):
+        assert name in REMAINING_ADAPTERS or name in {"grok", "kimi", "cursor", "opencode"}
+
+
+# ── grok ─────────────────────────────────────────────────────────────────────
+
+
+def test_grok_complete_requires_stop_reason() -> None:
+    stdout = json.dumps(
+        {"text": "part-one part-two", "stopReason": "EndTurn", "sessionId": "g-1"}
+    )
+    raw = stdout.encode("utf-8")
+    env = conform(CaptureInput(adapter="grok", stdout=stdout, returncode=0, raw_bytes=raw))
+    assert env.completion_state is CompletionState.COMPLETE
+    assert env.terminal_event_observed is True
+    assert env.session_id == "g-1"
+    assert env.response_text == "part-one part-two"
+    assert env.is_formal_review_eligible is True
+    assert raw_capture_matches(env, raw)
+
+
+def test_grok_json_without_stop_reason_is_unknown() -> None:
+    stdout = json.dumps({"text": "partial answer", "sessionId": "g-2"})
+    env = conform(CaptureInput(adapter="grok", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.UNKNOWN
+    assert env.terminal_event_observed is False
+    assert "partial" in env.response_text
+    assert env.is_formal_review_eligible is False
+
+
+def test_grok_length_limited() -> None:
+    stdout = json.dumps({"text": "truncated…", "stopReason": "max_tokens"})
+    env = conform(CaptureInput(adapter="grok", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.LENGTH_LIMITED
+    assert "truncated" in env.response_text
+
+
+def test_grok_nonzero_exit_with_output_is_transport_incomplete() -> None:
+    stdout = json.dumps({"text": "partial"})
+    env = conform(CaptureInput(adapter="grok", stdout=stdout, returncode=1))
+    assert env.completion_state is CompletionState.TRANSPORT_INCOMPLETE
+    assert env.response_text == "partial"
+
+
+def test_grok_multi_segment_ordered_events() -> None:
+    events = (
+        {"text": "first ", "sessionId": "g-3"},
+        {"text": "second", "stopReason": "EndTurn", "sessionId": "g-3"},
+    )
+    env = conform(
+        CaptureInput(adapter="grok-build", events=events, returncode=0)
+    )
+    assert env.completion_state is CompletionState.COMPLETE
+    assert [s.text for s in env.segments] == ["first", "second"]
+    assert [s.sequence for s in env.segments] == [0, 1]
+
+
+# ── kimi ─────────────────────────────────────────────────────────────────────
+
+
+def test_kimi_complete_requires_session_resume_hint() -> None:
+    stdout = _lines(
+        {"role": "assistant", "content": "part-one "},
+        {"role": "assistant", "content": "part-two"},
+        {"role": "meta", "type": "session.resume_hint", "session_id": "k-1"},
+    )
+    raw = stdout.encode("utf-8")
+    env = conform(CaptureInput(adapter="kimi", stdout=stdout, returncode=0, raw_bytes=raw))
+    assert env.completion_state is CompletionState.COMPLETE
+    assert env.terminal_event_observed is True
+    assert env.session_id == "k-1"
+    assert env.response_text == "part-one part-two"
+    assert [s.sequence for s in env.segments] == [0, 1]
+    assert raw_capture_matches(env, raw)
+
+
+def test_kimi_assistant_only_without_terminal_is_unknown() -> None:
+    stdout = json.dumps({"role": "assistant", "content": "looks done"})
+    env = conform(CaptureInput(adapter="kimi", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.UNKNOWN
+    assert env.terminal_event_observed is False
+    assert env.is_formal_review_eligible is False
+
+
+def test_kimi_length_limited_via_finish_reason() -> None:
+    stdout = _lines(
+        {"role": "assistant", "content": "truncated…", "finish_reason": "length"},
+        {"role": "meta", "type": "session.resume_hint", "session_id": "k-2"},
+    )
+    env = conform(CaptureInput(adapter="kimi", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.LENGTH_LIMITED
+    assert "truncated" in env.response_text
+
+
+def test_kimi_nonzero_exit_with_output_is_transport_incomplete() -> None:
+    stdout = json.dumps({"role": "assistant", "content": "partial"})
+    env = conform(CaptureInput(adapter="kimi", stdout=stdout, returncode=2))
+    assert env.completion_state is CompletionState.TRANSPORT_INCOMPLETE
+    assert env.response_text == "partial"
+
+
+def test_kimi_status_done_is_terminal() -> None:
+    stdout = _lines(
+        {"role": "assistant", "content": "ok"},
+        {"role": "meta", "type": "status", "state": "done"},
+    )
+    env = conform(CaptureInput(adapter="kimi", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.COMPLETE
+
+
+# ── cursor ───────────────────────────────────────────────────────────────────
+
+
+def test_cursor_complete_requires_turn_ended() -> None:
+    stdout = _lines(
+        {"type": "system", "session_id": "c-1"},
+        {
+            "role": "assistant",
+            "message": {"content": [{"type": "text", "text": "first "}]},
+        },
+        {
+            "role": "assistant",
+            "message": {"content": [{"type": "text", "text": "second"}]},
+        },
+        {"type": "turn_ended", "status": "success"},
+    )
+    raw = stdout.encode("utf-8")
+    env = conform(CaptureInput(adapter="cursor", stdout=stdout, returncode=0, raw_bytes=raw))
+    assert env.completion_state is CompletionState.COMPLETE
+    assert env.terminal_event_observed is True
+    assert env.session_id == "c-1"
+    assert env.segments[0].text == "first "
+    assert env.segments[1].text == "second"
+    assert raw_capture_matches(env, raw)
+
+
+def test_cursor_message_stream_without_turn_ended_is_unknown() -> None:
+    stdout = json.dumps(
+        {"type": "message", "role": "assistant", "content": [{"type": "text", "text": "hi"}]}
+    )
+    env = conform(CaptureInput(adapter="cursor", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.UNKNOWN
+    assert env.is_formal_review_eligible is False
+
+
+def test_cursor_length_limited() -> None:
+    stdout = _lines(
+        {"type": "text", "content": "truncated…"},
+        {"type": "turn_ended", "status": "max_tokens"},
+    )
+    env = conform(CaptureInput(adapter="cursor", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.LENGTH_LIMITED
+
+
+def test_cursor_nonzero_exit_with_output_is_transport_incomplete() -> None:
+    stdout = json.dumps({"type": "text", "content": "partial"})
+    env = conform(CaptureInput(adapter="cursor", stdout=stdout, returncode=1))
+    assert env.completion_state is CompletionState.TRANSPORT_INCOMPLETE
+    assert env.response_text == "partial"
+
+
+def test_cursor_turn_ended_error_is_failed() -> None:
+    stdout = _lines(
+        {"type": "message", "role": "assistant", "content": "oops"},
+        {"type": "turn_ended", "status": "error"},
+    )
+    env = conform(CaptureInput(adapter="cursor", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.FAILED
+    assert env.terminal_event_observed is True
+
+
+def test_cursor_multi_segment_stream_chunks_ordered() -> None:
+    stdout = _lines(
+        {"type": "text", "content": "A"},
+        {"type": "text", "content": "B"},
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "C"}],
+        },
+        {"type": "turn_ended", "status": "success"},
+    )
+    env = conform(CaptureInput(adapter="cursor", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.COMPLETE
+    # stream chunks flush as one segment, then message segment
+    assert env.response_text == "ABC"
+    assert [s.sequence for s in env.segments] == [0, 1]
+
+
+# ── opencode ─────────────────────────────────────────────────────────────────
+
+
+def test_opencode_complete_requires_final_step_finish_stop() -> None:
+    stdout = _lines(
+        {"type": "text", "part": {"type": "text", "text": "preamble "}, "sessionID": "o-1"},
+        {"type": "step_finish", "part": {"reason": "tool-calls"}, "sessionID": "o-1"},
+        {"type": "text", "part": {"type": "text", "text": "final answer"}, "sessionID": "o-1"},
+        {"type": "step_finish", "part": {"reason": "stop"}, "sessionID": "o-1"},
+    )
+    raw = stdout.encode("utf-8")
+    env = conform(CaptureInput(adapter="opencode", stdout=stdout, returncode=0, raw_bytes=raw))
+    assert env.completion_state is CompletionState.COMPLETE
+    assert env.terminal_event_observed is True
+    assert env.session_id == "o-1"
+    # Ordered multi-turn segments retained (not last-message-only).
+    assert [s.text for s in env.segments] == ["preamble ", "final answer"]
+    assert raw_capture_matches(env, raw)
+
+
+def test_opencode_tool_calls_step_finish_alone_is_unknown() -> None:
+    stdout = _lines(
+        {"type": "text", "part": {"text": "thinking…"}},
+        {"type": "step_finish", "part": {"reason": "tool-calls"}},
+    )
+    env = conform(CaptureInput(adapter="opencode", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.UNKNOWN
+    assert env.terminal_event_observed is False
+    assert env.is_formal_review_eligible is False
+
+
+def test_opencode_length_limited() -> None:
+    stdout = _lines(
+        {"type": "text", "part": {"text": "truncated…"}},
+        {"type": "step_finish", "part": {"reason": "length"}},
+    )
+    env = conform(CaptureInput(adapter="opencode", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.LENGTH_LIMITED
+    assert "truncated" in env.response_text
+
+
+def test_opencode_nonzero_exit_with_output_is_transport_incomplete() -> None:
+    stdout = _lines({"type": "text", "part": {"text": "partial"}})
+    env = conform(CaptureInput(adapter="opencode", stdout=stdout, returncode=3))
+    assert env.completion_state is CompletionState.TRANSPORT_INCOMPLETE
+    assert env.response_text == "partial"
+
+
+def test_opencode_text_without_step_finish_is_unknown() -> None:
+    stdout = json.dumps({"type": "text", "part": {"text": "no finish"}})
+    env = conform(CaptureInput(adapter="opencode", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.UNKNOWN
+
+
+# ── hermes ───────────────────────────────────────────────────────────────────
+
+
+def test_hermes_structured_result_is_complete() -> None:
+    stdout = _lines(
+        {"type": "assistant", "text": "a"},
+        {"type": "done", "result": "a b"},
+    )
+    env = conform(CaptureInput(adapter="hermes", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.COMPLETE
+    assert env.terminal_event_observed is True
+
+
+def test_hermes_inband_http_error_is_failed() -> None:
+    env = conform(
+        CaptureInput(
+            adapter="hermes-deepseek",
+            stdout="HTTP 401: unauthorized provider",
+            returncode=0,
+        )
+    )
+    assert env.completion_state is CompletionState.FAILED
+    assert env.terminal_event_observed is True
+    assert env.response_text == ""
+
+
+def test_hermes_length_limited_structured() -> None:
+    stdout = json.dumps({"type": "result", "result": "cut", "reason": "max_tokens"})
+    env = conform(CaptureInput(adapter="hermes-qwen", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.LENGTH_LIMITED
+
+
+def test_hermes_nonzero_exit_with_output_is_transport_incomplete() -> None:
+    env = conform(
+        CaptureInput(adapter="hermes-grok", stdout="partial hermes", returncode=1)
+    )
+    assert env.completion_state is CompletionState.TRANSPORT_INCOMPLETE
+    assert env.response_text == "partial hermes"
+
+
+def test_hermes_empty_nonzero_is_failed() -> None:
+    env = conform(CaptureInput(adapter="hermes", stdout="", returncode=1))
+    assert env.completion_state is CompletionState.FAILED
+
+
+def test_hermes_stop_reason_json_object_is_complete() -> None:
+    stdout = json.dumps({"text": "via stopReason", "stopReason": "EndTurn"})
+    env = conform(CaptureInput(adapter="grok-hermes", stdout=stdout, returncode=0))
+    assert env.completion_state is CompletionState.COMPLETE
+    assert env.response_text == "via stopReason"

--- a/tests/test_fleet_comms_wave1.py
+++ b/tests/test_fleet_comms_wave1.py
@@ -188,7 +188,8 @@ def test_agy_json_done_event() -> None:
     assert env.completion_state is CompletionState.COMPLETE
 
 
-def test_b2_stub_adapters_are_unknown_not_review_eligible() -> None:
+def test_b2_adapters_plain_text_without_terminal_is_unknown_not_review_eligible() -> None:
+    """B2 real conformers still refuse complete on exit 0 + text alone."""
     for name in ("grok", "kimi", "cursor", "hermes", "opencode"):
         env = conform(CaptureInput(adapter=name, stdout="looks fine", returncode=0))
         assert env.completion_state is CompletionState.UNKNOWN


### PR DESCRIPTION
## Summary

Implements **Sol fleet-comms PR-B2** (parent #5512, stream #4707): real completion conformers for remaining adapters so exit 0 + text alone can never look complete.

| Adapter | Terminal contract (documented) |
|---|---|
| **grok** / grok-build | Headless JSON `stopReason` present |
| **kimi** | `role=meta` + `type=session.resume_hint` (or finished meta status / structured result) |
| **cursor** | `type=turn_ended` stream terminator |
| **opencode** | `step_finish` with final reason (`stop`, not intermediate `tool-calls`) |
| **hermes** (+ hermes-*, grok-hermes) | Structured result/done/stopReason only; plain `-z` stdout stays `unknown`; in-band `HTTP 4xx/5xx` → `failed` |

Missing terminal evidence → `CompletionState.UNKNOWN` → `formal_review_ineligible`.

Does **not** flip `FLEET_COMMS_MESSAGE_PLANE` defaults.

## Fixture matrix (per adapter, Sol B1/B2)

- complete (with terminal)
- length_limited
- missing terminal (exit 0 + text → unknown)
- nonzero exit with output → transport_incomplete
- multi-segment ordered retention

## Files

- `scripts/fleet_comms/adapter_conformance.py` — real B2 conformers
- `tests/test_fleet_comms_b2.py` — new matrix (38 tests)
- `tests/test_fleet_comms_wave1.py` — plain-text invariant rename/update

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_fleet_comms_b2.py tests/test_fleet_comms_wave1.py tests/test_fleet_comms_contracts.py -q` → **61 passed**
- [x] ruff clean
- [x] X-Agent trailer lint

## Refs

- Parent: #5512
- Stream: #4707
- Sol SHIP: `batch_state/tasks/sol-fleet-comms-full-arch-r2.result` PR-B2