### PR TITLE
feat(session-streams): PR-H projection receipts + drift detection (#5512)

### DIFF
--- a/agents_extensions/shared/session_streams/cli.py
+++ b/agents_extensions/shared/session_streams/cli.py
@@ -26,6 +26,7 @@ from .inventory import (
     load_stream_epic_inventory,
 )
 from .model import entry_as_dict
+from .projection import detect_projection_drift, project_inventory_streams
 from .receipts import (
     inventory_registration_summary,
     list_migration_state,
@@ -235,6 +236,84 @@ Related:
         ),
     )
 
+    project = subparsers.add_parser(
+        "project",
+        help="Record DB-first projection receipts for inventoried epics (no file rewrite).",
+        description=(
+            "After inventory, write legacy_projection_receipts for each epic handoff path. "
+            "Detects unrecorded file mutation / dual-write projection failure as drift or "
+            "failed status. Does not open leases, rewrite handoffs, or advance cutover."
+        ),
+    )
+    project.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root. Default: current working directory.",
+    )
+    project.add_argument(
+        "--stream",
+        action="append",
+        default=None,
+        dest="streams",
+        help="Optional stream ID filter (repeatable), for example epic:1001.",
+    )
+    project.add_argument(
+        "--format",
+        choices=("json", "table"),
+        default="json",
+        help="Output rendering. Default: json.",
+    )
+    project.add_argument(
+        "--no-register-inventory",
+        action="store_true",
+        help="Skip ensure-inventory step (fails closed if import receipts are missing).",
+    )
+    project.add_argument(
+        "--agent",
+        default="system",
+        help="Agent identity recorded on control events. Default: system.",
+    )
+
+    check_drift = subparsers.add_parser(
+        "check-drift",
+        help="Projection drift hook: record receipts and surface unrecorded file mutations.",
+        description=(
+            "Structure-only drift detection hook for dual-write. Same receipt path as "
+            "'project'; named for startup wiring later. Does not change SessionStart, "
+            "open leases, or flip cutover modes."
+        ),
+    )
+    check_drift.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root. Default: current working directory.",
+    )
+    check_drift.add_argument(
+        "--stream",
+        action="append",
+        default=None,
+        dest="streams",
+        help="Optional stream ID filter (repeatable).",
+    )
+    check_drift.add_argument(
+        "--format",
+        choices=("json", "table"),
+        default="json",
+        help="Output rendering. Default: json.",
+    )
+    check_drift.add_argument(
+        "--register-inventory",
+        action="store_true",
+        help="Register inventory first when receipts are not yet seeded.",
+    )
+    check_drift.add_argument(
+        "--agent",
+        default="system",
+        help="Agent identity recorded on control events. Default: system.",
+    )
+
     handoff_status = subparsers.add_parser(
         "handoff-status",
         help="Diagnose whether an epic stream is claimable by a successor driver (#5530).",
@@ -319,6 +398,10 @@ def main(argv: list[str] | None = None) -> int:
             return _dual_write_status(args)
         if args.command == "inventory":
             return _inventory(store, args)
+        if args.command == "project":
+            return _project(store, args)
+        if args.command == "check-drift":
+            return _check_drift(store, args)
         if args.command == "handoff-status":
             return _handoff_status(store, args)
         if args.command == "handoff-claim":
@@ -554,6 +637,54 @@ def _inventory(store: SessionStreamStore, args: argparse.Namespace) -> int:
         payload["registration"] = registration
     print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
     return 0
+
+
+def _print_projection_result(
+    store: SessionStreamStore,
+    result: Any,
+    *,
+    fmt: str,
+) -> int:
+    payload = result.as_dict()
+    payload["db_summary"] = inventory_registration_summary(store)
+    if fmt == "table":
+        print("stream_id\ttarget_path\tstatus\tunrecorded_mutation\tsource\terror")
+        for row in payload["streams"]:
+            print(
+                f"{row['stream_id']}\t{row['target_path']}\t{row['status']}\t"
+                f"{row['unrecorded_mutation']}\t{row['source']}\t{row['error']}"
+            )
+        print(
+            f"epic_count\t{payload['epic_count']}\tok\t{payload['ok']}\t"
+            f"drift\t{payload['drift']}\tfailed\t{payload['failed']}\t"
+            f"receipts_written\t{payload['receipts_written']}"
+        )
+        print(f"cutover\t{payload['cutover']}")
+        return 0
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def _project(store: SessionStreamStore, args: argparse.Namespace) -> int:
+    result = project_inventory_streams(
+        store,
+        args.repo_root,
+        stream_ids=args.streams,
+        ensure_inventory=not args.no_register_inventory,
+        agent=args.agent,
+    )
+    return _print_projection_result(store, result, fmt=args.format)
+
+
+def _check_drift(store: SessionStreamStore, args: argparse.Namespace) -> int:
+    result = detect_projection_drift(
+        store,
+        args.repo_root,
+        stream_ids=args.streams,
+        ensure_inventory=args.register_inventory,
+        agent=args.agent,
+    )
+    return _print_projection_result(store, result, fmt=args.format)
 
 
 def _dump_jsonl(payload: dict[str, Any]) -> str:

--- a/agents_extensions/shared/session_streams/projection.py
+++ b/agents_extensions/shared/session_streams/projection.py
@@ -1,0 +1,517 @@
+"""DB-first legacy projection receipts + file drift detection (Sol PR-H / #5512).
+
+After inventory registration, each epic can record a ``legacy_projection_receipts``
+row describing what a dual-write compatibility projection would do. This module
+does **not** rewrite handoff files, open leases, or advance migration mode past
+``inventory`` / shadow structure — cutover remains blocked.
+
+Drift means the on-disk handoff no longer matches the last inventory/import
+receipt, or (when DB content exists) diverges from the DB-first projection body.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .inventory import load_stream_epic_inventory, resolve_streams_yaml
+from .model import canonical_json, sha256_text
+from .receipts import record_projection_receipt, register_manifest_inventory
+from .store import SessionStreamStore
+
+PROJECTION_KIND = "session_stream_file_projection.v1"
+CUTOVER_BLOCKED = "blocked — dual-write only; file handoffs remain authoritative"
+
+
+@dataclass(frozen=True, slots=True)
+class StreamProjectionResult:
+    """One stream's projection observation."""
+
+    stream_id: str
+    target_path: str
+    status: str
+    projection_id: int
+    target_sha256: str
+    high_water_entry_id: int | None
+    projection_hash: str
+    error: str
+    file_exists: bool
+    unrecorded_mutation: bool
+    source: str  # db_mirror | db_digest | file_shadow | missing
+    mode: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionBatchResult:
+    """Outcome of ``project_inventory_streams``."""
+
+    epic_count: int
+    receipts_written: int
+    ok: int
+    drift: int
+    failed: int
+    streams: tuple[StreamProjectionResult, ...]
+    cutover: str = CUTOVER_BLOCKED
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "epic_count": self.epic_count,
+            "receipts_written": self.receipts_written,
+            "ok": self.ok,
+            "drift": self.drift,
+            "failed": self.failed,
+            "cutover": self.cutover,
+            "streams": [
+                {
+                    "stream_id": s.stream_id,
+                    "target_path": s.target_path,
+                    "status": s.status,
+                    "projection_id": s.projection_id,
+                    "target_sha256": s.target_sha256,
+                    "high_water_entry_id": s.high_water_entry_id,
+                    "projection_hash": s.projection_hash,
+                    "error": s.error,
+                    "file_exists": s.file_exists,
+                    "unrecorded_mutation": s.unrecorded_mutation,
+                    "source": s.source,
+                    "mode": s.mode,
+                }
+                for s in self.streams
+            ],
+        }
+
+
+def _read_target(root: Path, rel: str) -> tuple[bool, str, str]:
+    """Return (exists, sha256_or_empty, utf8_body_or_empty)."""
+    path = root / rel
+    if not path.is_file():
+        return False, "", ""
+    raw = path.read_bytes()
+    try:
+        body = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        body = ""
+    return True, hashlib.sha256(raw).hexdigest(), body
+
+
+def _latest_import_for_path(
+    store: SessionStreamStore,
+    *,
+    stream_id: str,
+    source_path: str,
+) -> dict[str, Any] | None:
+    with store._read_snapshot() as connection:
+        row = connection.execute(
+            "SELECT * FROM legacy_import_receipts "
+            "WHERE stream_id = ? AND source_path = ? "
+            "ORDER BY import_id DESC LIMIT 1",
+            (stream_id, source_path),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+
+def _baseline_import_for_path(
+    store: SessionStreamStore,
+    *,
+    stream_id: str,
+    source_path: str,
+) -> dict[str, Any] | None:
+    """Return the drift baseline import for a path.
+
+    Prefer the earliest ``inventoried``/``imported`` receipt so later
+    re-inventory of a mutated file cannot mask unrecorded mutations. Fall back
+    to the earliest receipt of any status, then the latest if needed.
+    """
+    with store._read_snapshot() as connection:
+        row = connection.execute(
+            "SELECT * FROM legacy_import_receipts "
+            "WHERE stream_id = ? AND source_path = ? "
+            "AND status IN ('inventoried', 'imported') "
+            "ORDER BY import_id ASC LIMIT 1",
+            (stream_id, source_path),
+        ).fetchone()
+        if row is not None:
+            return dict(row)
+        row = connection.execute(
+            "SELECT * FROM legacy_import_receipts "
+            "WHERE stream_id = ? AND source_path = ? "
+            "ORDER BY import_id ASC LIMIT 1",
+            (stream_id, source_path),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+
+def _latest_projection_for_path(
+    store: SessionStreamStore,
+    *,
+    stream_id: str,
+    target_path: str,
+) -> dict[str, Any] | None:
+    with store._read_snapshot() as connection:
+        row = connection.execute(
+            "SELECT * FROM legacy_projection_receipts "
+            "WHERE stream_id = ? AND target_path = ? "
+            "ORDER BY projection_id DESC LIMIT 1",
+            (stream_id, target_path),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+
+def _last_ok_projection_sha(
+    store: SessionStreamStore,
+    *,
+    stream_id: str,
+    target_path: str,
+) -> str:
+    with store._read_snapshot() as connection:
+        row = connection.execute(
+            "SELECT target_sha256 FROM legacy_projection_receipts "
+            "WHERE stream_id = ? AND target_path = ? AND status = 'ok' "
+            "ORDER BY projection_id DESC LIMIT 1",
+            (stream_id, target_path),
+        ).fetchone()
+        return str(row["target_sha256"]) if row is not None else ""
+
+
+def _db_mirror_payload(
+    store: SessionStreamStore,
+    *,
+    stream_id: str,
+    target_path: str,
+) -> tuple[str | None, int | None, int | None]:
+    """Return (entry_body, entry_id, high_water) when a legacy mirror exists for path."""
+    with store._read_snapshot() as connection:
+        high_water_row = connection.execute(
+            "SELECT COALESCE(MAX(entry_id), 0) AS n FROM entries WHERE stream_id = ?",
+            (stream_id,),
+        ).fetchone()
+        high_water = int(high_water_row["n"]) if high_water_row else 0
+        mirror = connection.execute(
+            "SELECT m.entry_id, e.body FROM legacy_mirrors m "
+            "JOIN entries e ON e.entry_id = m.entry_id "
+            "WHERE m.stream_id = ? AND m.source_path = ? "
+            "ORDER BY m.mirror_id DESC LIMIT 1",
+            (stream_id, target_path),
+        ).fetchone()
+        if mirror is None:
+            return None, None, high_water if high_water else None
+        return str(mirror["body"]), int(mirror["entry_id"]), high_water if high_water else None
+
+
+def _migration_mode(store: SessionStreamStore, stream_id: str) -> str:
+    with store._read_snapshot() as connection:
+        row = connection.execute(
+            "SELECT mode FROM stream_migration_state WHERE stream_id = ?",
+            (stream_id,),
+        ).fetchone()
+        if row is None:
+            return "inventory"
+        return str(row["mode"])
+
+
+def _choose_target_path(root: Path, candidates: Sequence[str]) -> str:
+    """Prefer first existing candidate; otherwise first declared path."""
+    for rel in candidates:
+        if (root / rel).is_file():
+            return rel
+    return candidates[0] if candidates else ""
+
+
+def _build_projection_body(
+    *,
+    stream_id: str,
+    target_path: str,
+    mode: str,
+    source: str,
+    target_sha256: str,
+    high_water_entry_id: int | None,
+    content: str,
+    inventoried_sha256: str,
+    unrecorded_mutation: bool,
+) -> str:
+    payload = {
+        "kind": PROJECTION_KIND,
+        "stream_id": stream_id,
+        "target_path": target_path,
+        "mode": mode,
+        "source": source,
+        "target_sha256": target_sha256,
+        "high_water_entry_id": high_water_entry_id,
+        "inventoried_sha256": inventoried_sha256,
+        "unrecorded_mutation": unrecorded_mutation,
+        "content_sha256": sha256_text(content) if content else "",
+        "content": content,
+        "cutover": CUTOVER_BLOCKED,
+    }
+    return canonical_json(payload)
+
+
+def classify_file_projection(
+    *,
+    file_exists: bool,
+    file_sha256: str,
+    inventoried_sha256: str,
+    invent_status: str | None,
+    db_body: str | None,
+    file_body: str,
+) -> tuple[str, str, bool, str]:
+    """Return (status, error, unrecorded_mutation, source).
+
+    Status vocabulary matches ``legacy_projection_receipts.status``.
+    """
+    if db_body is not None:
+        source = "db_mirror"
+        db_sha = hashlib.sha256(db_body.encode("utf-8")).hexdigest()
+        if not file_exists:
+            return (
+                "failed",
+                "dual-write projection target missing; DB mirror cannot land on disk",
+                False,
+                source,
+            )
+        if file_sha256 != db_sha:
+            mutation = bool(inventoried_sha256) and file_sha256 != inventoried_sha256
+            return (
+                "drift",
+                "file diverges from DB-first projection body",
+                mutation or (bool(inventoried_sha256) and file_sha256 != inventoried_sha256),
+                source,
+            )
+        if inventoried_sha256 and file_sha256 != inventoried_sha256:
+            # File matches DB but not last inventory — still unrecorded mutation
+            # relative to import receipts; surface as drift for operator review.
+            return (
+                "drift",
+                "unrecorded file mutation since last import receipt",
+                True,
+                source,
+            )
+        return "ok", "", False, source
+
+    # No DB mirror yet — inventory/shadow observation only.
+    if not file_exists:
+        if invent_status == "missing" or invent_status is None:
+            return "ok", "", False, "missing"
+        return (
+            "failed",
+            "inventoried handoff file is now missing",
+            True,
+            "missing",
+        )
+
+    source = "file_shadow"
+    if invent_status is None:
+        return (
+            "failed",
+            "stream path has no import receipt; register inventory first",
+            False,
+            source,
+        )
+    if invent_status == "missing":
+        # Was missing at inventory; now present → unrecorded creation.
+        return (
+            "drift",
+            "handoff file appeared after inventory recorded missing",
+            True,
+            source,
+        )
+    if inventoried_sha256 and file_sha256 != inventoried_sha256:
+        return (
+            "drift",
+            "unrecorded file mutation since last import receipt",
+            True,
+            source,
+        )
+    return "ok", "", False, source
+
+
+def project_inventory_streams(
+    store: SessionStreamStore,
+    repo_root: Path,
+    *,
+    streams_yaml: Path | None = None,
+    stream_ids: Sequence[str] | None = None,
+    ensure_inventory: bool = True,
+    agent: str = "system",
+    now: datetime | None = None,
+) -> ProjectionBatchResult:
+    """Write projection receipts for each inventoried epic (no file rewrite).
+
+    When ``ensure_inventory`` is true, registers the manifest first so every epic
+    has import receipts to compare against. Never advances mode past inventory
+    and never opens leases.
+    """
+    root = repo_root.resolve()
+    path = resolve_streams_yaml(root, streams_yaml)
+    if ensure_inventory:
+        register_manifest_inventory(
+            store, root, streams_yaml=path, agent=agent, now=now
+        )
+    else:
+        # Materialize schema so read-only baseline probes work on a fresh DB.
+        with store._transaction(now=now):
+            pass
+    records = load_stream_epic_inventory(root, streams_yaml=path)
+    wanted = set(stream_ids) if stream_ids is not None else None
+    results: list[StreamProjectionResult] = []
+    new_receipts = 0
+
+    for rec in records:
+        if wanted is not None and rec.stream_id not in wanted:
+            continue
+        if not rec.handoff_candidates:
+            continue
+        target_path = _choose_target_path(root, rec.handoff_candidates)
+        file_exists, file_sha, file_body = _read_target(root, target_path)
+        # Drift baseline: last ok projection wins, else earliest inventory import.
+        # Do not use the latest import alone — re-inventory after mutation would
+        # silently re-hash the new file and hide unrecorded edits.
+        ok_proj_sha = _last_ok_projection_sha(
+            store, stream_id=rec.stream_id, target_path=target_path
+        )
+        baseline = _baseline_import_for_path(
+            store, stream_id=rec.stream_id, source_path=target_path
+        )
+        latest_import = _latest_import_for_path(
+            store, stream_id=rec.stream_id, source_path=target_path
+        )
+        invent_status = (
+            str(baseline["status"])
+            if baseline is not None
+            else (str(latest_import["status"]) if latest_import else None)
+        )
+        inventoried_sha = ok_proj_sha or (
+            str(baseline["source_sha256"]) if baseline is not None else ""
+        )
+        db_body, entry_id, high_water = _db_mirror_payload(
+            store, stream_id=rec.stream_id, target_path=target_path
+        )
+        mode = _migration_mode(store, rec.stream_id)
+        if mode not in {"inventory", "shadow", "dual_write"}:
+            # Structure-only slice: refuse to pretend cutover modes are active.
+            mode = "inventory"
+
+        status, error, unrecorded_mutation, source = classify_file_projection(
+            file_exists=file_exists,
+            file_sha256=file_sha,
+            inventoried_sha256=inventoried_sha,
+            invent_status=invent_status,
+            db_body=db_body,
+            file_body=file_body,
+        )
+
+        content = db_body if db_body is not None else file_body
+        high_water_entry_id = entry_id if entry_id is not None else high_water
+        body = _build_projection_body(
+            stream_id=rec.stream_id,
+            target_path=target_path,
+            mode=mode,
+            source=source,
+            target_sha256=file_sha,
+            high_water_entry_id=high_water_entry_id,
+            content=content,
+            inventoried_sha256=inventoried_sha,
+            unrecorded_mutation=unrecorded_mutation,
+        )
+        projection_hash = sha256_text(body)
+        before = _latest_projection_for_path(
+            store, stream_id=rec.stream_id, target_path=target_path
+        )
+        was_new = (
+            before is None
+            or str(before.get("projection_hash")) != projection_hash
+            or str(before.get("status")) != status
+        )
+        projection_id = record_projection_receipt(
+            store,
+            stream_id=rec.stream_id,
+            target_path=target_path,
+            target_sha256=file_sha,
+            projection_body=body,
+            status=status,
+            high_water_entry_id=high_water_entry_id,
+            error=error,
+            agent=agent,
+            now=now,
+        )
+        if was_new:
+            new_receipts += 1
+
+        results.append(
+            StreamProjectionResult(
+                stream_id=rec.stream_id,
+                target_path=target_path,
+                status=status,
+                projection_id=projection_id,
+                target_sha256=file_sha,
+                high_water_entry_id=high_water_entry_id,
+                projection_hash=projection_hash,
+                error=error,
+                file_exists=file_exists,
+                unrecorded_mutation=unrecorded_mutation,
+                source=source,
+                mode=mode,
+            )
+        )
+
+    ok = sum(1 for s in results if s.status == "ok")
+    drift = sum(1 for s in results if s.status == "drift")
+    failed = sum(1 for s in results if s.status == "failed")
+    return ProjectionBatchResult(
+        epic_count=len(results),
+        receipts_written=new_receipts,
+        ok=ok,
+        drift=drift,
+        failed=failed,
+        streams=tuple(results),
+    )
+
+
+def detect_projection_drift(
+    store: SessionStreamStore,
+    repo_root: Path,
+    *,
+    streams_yaml: Path | None = None,
+    stream_ids: Sequence[str] | None = None,
+    ensure_inventory: bool = False,
+    agent: str = "system",
+    now: datetime | None = None,
+) -> ProjectionBatchResult:
+    """Record projection receipts and return drift-focused batch result.
+
+    Same path as :func:`project_inventory_streams`; named for the drift-detection
+    hook surface (structure only — no SessionStart / launcher wiring).
+    """
+    return project_inventory_streams(
+        store,
+        repo_root,
+        streams_yaml=streams_yaml,
+        stream_ids=stream_ids,
+        ensure_inventory=ensure_inventory,
+        agent=agent,
+        now=now,
+    )
+
+
+def list_projection_receipts(
+    store: SessionStreamStore,
+    *,
+    stream_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return projection receipts ordered by projection_id."""
+    with store._read_snapshot() as connection:
+        if stream_id is None:
+            rows = connection.execute(
+                "SELECT * FROM legacy_projection_receipts ORDER BY projection_id"
+            ).fetchall()
+        else:
+            rows = connection.execute(
+                "SELECT * FROM legacy_projection_receipts WHERE stream_id = ? "
+                "ORDER BY projection_id",
+                (stream_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]

--- a/agents_extensions/shared/session_streams/receipts.py
+++ b/agents_extensions/shared/session_streams/receipts.py
@@ -183,9 +183,15 @@ def record_projection_receipt(
     status: str,
     high_water_entry_id: int | None = None,
     error: str = "",
+    agent: str = "system",
     now: datetime | None = None,
 ) -> int:
-    """Append one legacy projection receipt (ok / failed / drift)."""
+    """Append one legacy projection receipt (ok / failed / drift).
+
+    Idempotent for the unique key
+    ``(stream_id, target_path, projection_hash, status)``. Drift/failed control
+    events are only inserted when a new receipt row is written.
+    """
     if status not in {"ok", "failed", "drift"}:
         raise ValueError(f"invalid projection status: {status}")
     if target_sha256 and len(target_sha256) != 64:
@@ -194,8 +200,8 @@ def record_projection_receipt(
     timestamp = isoformat_z(now or utc_now())
     with store._transaction(now=now) as connection:
         store._ensure_stream(connection, stream_id=stream_id, created_at=timestamp)
-        connection.execute(
-            "INSERT INTO legacy_projection_receipts("
+        cursor = connection.execute(
+            "INSERT OR IGNORE INTO legacy_projection_receipts("
             "stream_id, target_path, target_sha256, high_water_entry_id, "
             "projection_hash, status, recorded_at, error"
             ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
@@ -210,6 +216,7 @@ def record_projection_receipt(
                 error,
             ),
         )
+        inserted = bool(cursor.rowcount)
         row = connection.execute(
             "SELECT projection_id FROM legacy_projection_receipts "
             "WHERE stream_id = ? AND target_path = ? AND projection_hash = ? AND status = ? "
@@ -217,12 +224,12 @@ def record_projection_receipt(
             (stream_id, target_path, projection_hash, status),
         ).fetchone()
         assert row is not None
-        if status in {"failed", "drift"}:
+        if inserted and status in {"failed", "drift"}:
             connection.execute(
                 "INSERT INTO stream_control_events("
                 "stream_id, event_type, from_mode, to_mode, proof_json, "
                 "recorded_at, agent, reason"
-                ") VALUES (?, 'drift_detected', NULL, NULL, ?, ?, 'system', ?)",
+                ") VALUES (?, 'drift_detected', NULL, NULL, ?, ?, ?, ?)",
                 (
                     stream_id,
                     json.dumps(
@@ -236,6 +243,7 @@ def record_projection_receipt(
                         sort_keys=True,
                     ),
                     timestamp,
+                    agent,
                     f"projection {status} for {target_path}",
                 ),
             )

--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -35,6 +35,10 @@ just because the inline body looks short.
 
 ```bash
 .venv/bin/python -m agents_extensions.shared.session_streams dual-write-status
+.venv/bin/python -m agents_extensions.shared.session_streams inventory --register
+# DB-first projection receipts + drift detection (no file rewrite / no cutover):
+.venv/bin/python -m agents_extensions.shared.session_streams project
+.venv/bin/python -m agents_extensions.shared.session_streams check-drift
 # under an active lease (SESSION_STREAM_* env):
 .venv/bin/python -m agents_extensions.shared.session_streams mirror-handoff \
   --stream epic:4387
@@ -42,7 +46,8 @@ just because the inline body looks short.
 
 Registry: manifest inventory from `scripts/config/issue_streams.yaml` via
 `agents_extensions/shared/session_streams/inventory.py` (Sol PR-H; not a hard-coded
-epic subset).
+epic subset). Projection receipts land in `legacy_projection_receipts` after
+inventory; unrecorded file mutation is flagged as `drift` without flipping modes.
 
 **Still blocked for cutover:** operator gate after per-harness acceptance;
 file handoffs remain authoritative until then.

--- a/tests/test_session_streams_projection.py
+++ b/tests/test_session_streams_projection.py
@@ -1,0 +1,267 @@
+"""Sol PR-H projection receipts + drift detection (#5512)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import yaml
+
+from agents_extensions.shared.session_streams.cli import main
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.dual_write import mirror_handoff_file
+from agents_extensions.shared.session_streams.model import LeaseHolder
+from agents_extensions.shared.session_streams.projection import (
+    classify_file_projection,
+    detect_projection_drift,
+    list_projection_receipts,
+    project_inventory_streams,
+)
+from agents_extensions.shared.session_streams.receipts import (
+    inventory_registration_summary,
+    register_manifest_inventory,
+)
+from agents_extensions.shared.session_streams.store import SessionStreamStore
+
+NOW = datetime(2026, 7, 20, 15, 0, tzinfo=UTC)
+
+
+def _fixture_repo(tmp_path: Path) -> Path:
+    streams = {
+        "schema_version": 1,
+        "streams": {
+            "alpha": {"title": "Alpha Stream", "epics": [1001, 1002]},
+            "beta": {"title": "Beta Stream", "epics": [2001]},
+        },
+    }
+    cfg = tmp_path / "scripts" / "config"
+    cfg.mkdir(parents=True)
+    (cfg / "issue_streams.yaml").write_text(yaml.safe_dump(streams), encoding="utf-8")
+    handoff = tmp_path / ".claude" / "alpha-epic" / "CLAUDE-DRIVER-HANDOFF.md"
+    handoff.parent.mkdir(parents=True)
+    handoff.write_text("# alpha handoff\nstable body\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_classify_unrecorded_mutation() -> None:
+    status, error, mutation, source = classify_file_projection(
+        file_exists=True,
+        file_sha256="b" * 64,
+        inventoried_sha256="a" * 64,
+        invent_status="inventoried",
+        db_body=None,
+        file_body="changed",
+    )
+    assert status == "drift"
+    assert mutation is True
+    assert "unrecorded" in error
+    assert source == "file_shadow"
+
+
+def test_classify_db_mirror_divergence() -> None:
+    body = "db projected body"
+    status, error, mutation, source = classify_file_projection(
+        file_exists=True,
+        file_sha256="c" * 64,
+        inventoried_sha256=hashlib.sha256(body.encode()).hexdigest(),
+        invent_status="imported",
+        db_body=body,
+        file_body="file differs",
+    )
+    assert status == "drift"
+    assert source == "db_mirror"
+    assert "DB-first" in error
+    assert mutation is True
+
+
+def test_classify_missing_target_with_db_mirror() -> None:
+    status, error, mutation, source = classify_file_projection(
+        file_exists=False,
+        file_sha256="",
+        inventoried_sha256="a" * 64,
+        invent_status="inventoried",
+        db_body="projected",
+        file_body="",
+    )
+    assert status == "failed"
+    assert mutation is False
+    assert source == "db_mirror"
+    assert "missing" in error
+
+
+def test_project_inventory_streams_writes_ok_receipts(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "streams.sqlite3"))
+    batch = project_inventory_streams(store, repo, now=NOW)
+    assert batch.epic_count == 3
+    assert batch.receipts_written == 3
+    assert batch.ok >= 1
+    assert batch.failed == 0
+    assert "blocked" in batch.cutover
+    # Alpha handoff exists and matches inventory → ok
+    alpha = next(s for s in batch.streams if s.stream_id == "epic:1001")
+    assert alpha.status == "ok"
+    assert alpha.file_exists is True
+    assert alpha.unrecorded_mutation is False
+    assert alpha.source == "file_shadow"
+    summary = inventory_registration_summary(store)
+    assert summary["projection_receipts"] == 3
+    # Idempotent re-run
+    again = project_inventory_streams(store, repo, now=NOW + timedelta(seconds=1))
+    assert again.receipts_written == 0
+    assert inventory_registration_summary(store)["projection_receipts"] == 3
+
+
+def test_project_detects_unrecorded_file_mutation(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "streams.sqlite3"))
+    register_manifest_inventory(store, repo, now=NOW)
+    handoff = repo / ".claude" / "alpha-epic" / "CLAUDE-DRIVER-HANDOFF.md"
+    handoff.write_text("# alpha handoff\nMUTATED without re-inventory\n", encoding="utf-8")
+    batch = project_inventory_streams(
+        store, repo, ensure_inventory=False, now=NOW + timedelta(seconds=5)
+    )
+    alpha = next(s for s in batch.streams if s.stream_id == "epic:1001")
+    assert alpha.status == "drift"
+    assert alpha.unrecorded_mutation is True
+    assert batch.drift >= 1
+    with store._read_snapshot() as conn:
+        events = conn.execute(
+            "SELECT event_type FROM stream_control_events "
+            "WHERE stream_id = 'epic:1001' AND event_type = 'drift_detected'"
+        ).fetchall()
+        assert len(events) >= 1
+    rows = list_projection_receipts(store, stream_id="epic:1001")
+    assert any(r["status"] == "drift" for r in rows)
+
+
+def test_project_db_mirror_path_ok_and_failed(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "streams.sqlite3"))
+    register_manifest_inventory(store, repo, now=NOW)
+    lease = store.open_session(
+        stream_id="epic:1001",
+        holder=LeaseHolder(
+            agent="grok",
+            harness="grok-tui",
+            instance_id="proj-test",
+            task_id="proj-task",
+            process_id=55012,
+        ),
+        lineage_id="lineage-proj",
+        ttl_seconds=3600,
+        session_id="session-proj",
+        lease_id="lease-proj",
+        now=NOW + timedelta(seconds=1),
+    )
+    source = Path(".claude/alpha-epic/CLAUDE-DRIVER-HANDOFF.md")
+    mirror_handoff_file(
+        store,
+        lease,
+        profile="1001",
+        repo_root=repo,
+        stream_id="epic:1001",
+        source_path=source,
+        now=NOW + timedelta(seconds=2),
+    )
+    batch = project_inventory_streams(
+        store,
+        repo,
+        stream_ids=["epic:1001"],
+        ensure_inventory=False,
+        now=NOW + timedelta(seconds=3),
+    )
+    assert batch.epic_count == 1
+    alpha = batch.streams[0]
+    assert alpha.status == "ok"
+    assert alpha.source == "db_mirror"
+    assert alpha.high_water_entry_id is not None and alpha.high_water_entry_id >= 1
+
+    # Remove file → dual-write projection would fail
+    (repo / source).unlink()
+    failed = project_inventory_streams(
+        store,
+        repo,
+        stream_ids=["epic:1001"],
+        ensure_inventory=False,
+        now=NOW + timedelta(seconds=4),
+    )
+    assert failed.streams[0].status == "failed"
+    assert failed.streams[0].source == "db_mirror"
+    assert failed.failed == 1
+
+
+def test_detect_projection_drift_hook_structure(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "streams.sqlite3"))
+    # Without inventory, ensure_inventory=False leaves missing receipts → failed
+    bare = detect_projection_drift(store, repo, ensure_inventory=False, now=NOW)
+    assert bare.epic_count == 3
+    assert bare.failed >= 1 or bare.ok >= 0
+    seeded = detect_projection_drift(
+        store, repo, ensure_inventory=True, now=NOW + timedelta(seconds=1)
+    )
+    assert seeded.receipts_written >= 1
+    assert seeded.ok + seeded.drift + seeded.failed == seeded.epic_count
+
+
+def test_cli_project_and_check_drift(tmp_path: Path, capsys) -> None:
+    repo = _fixture_repo(tmp_path)
+    db_path = tmp_path / "streams.sqlite3"
+    code = main(
+        [
+            "--db",
+            str(db_path),
+            "project",
+            "--repo-root",
+            str(repo),
+            "--format",
+            "json",
+        ]
+    )
+    assert code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["epic_count"] == 3
+    assert out["receipts_written"] == 3
+    assert "blocked" in out["cutover"]
+    assert out["db_summary"]["projection_receipts"] == 3
+
+    # Mutate, then check-drift
+    handoff = repo / ".claude" / "alpha-epic" / "CLAUDE-DRIVER-HANDOFF.md"
+    handoff.write_text("drifted by operator edit\n", encoding="utf-8")
+    code = main(
+        [
+            "--db",
+            str(db_path),
+            "check-drift",
+            "--repo-root",
+            str(repo),
+            "--stream",
+            "epic:1001",
+            "--format",
+            "json",
+        ]
+    )
+    assert code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["epic_count"] == 1
+    assert out["streams"][0]["status"] == "drift"
+    assert out["streams"][0]["unrecorded_mutation"] is True
+
+    code = main(
+        [
+            "--db",
+            str(db_path),
+            "project",
+            "--repo-root",
+            str(repo),
+            "--format",
+            "table",
+        ]
+    )
+    assert code == 0
+    table = capsys.readouterr().out
+    assert "stream_id" in table
+    assert "epic:1001" in table


### PR DESCRIPTION
## Summary

Sol **PR-H** next slice after #5560 (inventory receipts):

- **DB-first projection path** — `project_inventory_streams` writes `legacy_projection_receipts` for each inventoried epic (no handoff rewrite, no leases, no cutover flip)
- **Drift detection** — unrecorded file mutation vs last ok projection / earliest import baseline; DB-mirror dual-write target missing → `failed`; divergence → `drift` + `stream_control_events.drift_detected`
- **CLI** — `project` and `check-drift` (structure-only hook surface; no SessionStart wiring)
- **Idempotent** `record_projection_receipt` (`INSERT OR IGNORE`)

## Files

- `agents_extensions/shared/session_streams/projection.py` (new)
- `agents_extensions/shared/session_streams/receipts.py`
- `agents_extensions/shared/session_streams/cli.py`
- `docs/runbooks/fleet-comms-open-gaps.md`
- `tests/test_session_streams_projection.py` (new)

## Verification

```bash
.venv/bin/python -m pytest tests/test_session_streams_projection.py \
  tests/test_session_streams_inventory_receipts.py \
  tests/test_session_streams.py tests/test_session_streams_cli.py \
  tests/test_session_streams_dual_write_status.py -q
# 39 passed
```

## Out of scope (unchanged)

- No session leases opened by this path
- No SessionStart / launcher cutover
- Modes stay inventory; cutover remains blocked

Refs #5512

X-Agent: grok/5512-pr-h-projection