### PR TITLE
feat(fleet-comms): PR-G pure verdict publisher prep (#5512)

### DIFF
--- a/scripts/ai_agent_bridge/_review_verdict.py
+++ b/scripts/ai_agent_bridge/_review_verdict.py
@@ -1,4 +1,11 @@
-"""Publish a deliberately thin formal-review verdict to one GitHub PR comment."""
+"""Publish a deliberately thin formal-review verdict to one GitHub PR comment.
+
+PR-G cutover note: the eventual ``publish-review-verdict --review-id`` path
+(sealed job reload, stale-head check, idempotent status/comment) is prepared in
+``scripts/fleet_comms/review_publication.py``. Full default cutover waits for
+PR-F formal-jobs table writers; this CLI remains the temporary file/flag-based
+poster and must not switch defaults until then.
+"""
 
 from __future__ import annotations
 

--- a/scripts/fleet_comms/review_publication.py
+++ b/scripts/fleet_comms/review_publication.py
@@ -1,0 +1,439 @@
+"""PR-G prep: pure helpers for formal-review verdict publication (GitHub gate).
+
+Sol fleet-comms architecture (#5512, sol-fleet-comms-full-arch-r2) assigns PR-G
+to the verdict publisher: stale-head protection, idempotent comment + commit
+status publication, and auto-merge-compatible context
+``fleet/cross-family-review``.
+
+This module is intentionally pure and dry-run-first:
+
+* parse sealed verdict payloads (APPROVED / CHANGES_REQUESTED / BLOCKED)
+* compare expected head SHA against the current PR head (fail closed on drift)
+* derive a stable idempotency key from ``(repository, pr, head_sha, gate_kind)``
+* plan publication (comment body + status state) without calling GitHub
+
+Live GitHub mutation is **not** performed here. The existing bridge command
+``publish-review-verdict`` remains the temporary poster; full
+``publish-review-verdict --review-id`` cutover waits for PR-F formal-jobs table
+writers and must not become the default until those land.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+VALID_VERDICTS = frozenset({"APPROVED", "CHANGES_REQUESTED", "BLOCKED"})
+DEFAULT_GATE_KIND = "cross-family-review"
+DEFAULT_STATUS_CONTEXT = "fleet/cross-family-review"
+# GitHub commit status states used for the merge gate.
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
+STATUS_ERROR = "error"
+STATUS_PENDING = "pending"
+
+_SHA_RE = re.compile(r"^[0-9a-f]{7,64}$", re.IGNORECASE)
+_VERDICT_LINE_RE = re.compile(
+    r"\bVERDICT\s*:\s*(APPROVED|CHANGES_REQUESTED|BLOCKED)\b",
+    re.IGNORECASE,
+)
+
+PublicationAction = Literal["publish", "skip_idempotent", "refuse_stale"]
+CommitStatusState = Literal["success", "failure", "error", "pending"]
+
+
+class ReviewPublicationError(ValueError):
+    """Sealed payload or publication plan failed closed."""
+
+
+@dataclass(frozen=True, slots=True)
+class SealedVerdict:
+    """Minimal sealed formal-review verdict needed to plan a GitHub gate post.
+
+    Provenance fields (model/family/harness) are required so the thin PR comment
+    never invents CLI-supplied identity after PR-G cutover. PR-F owns job
+    storage; this structure is the in-memory view the publisher consumes.
+    """
+
+    review_id: str
+    repository: str
+    pr_number: int
+    head_sha: str
+    gate_kind: str
+    verdict: str
+    model: str
+    family: str
+    harness: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "review_id": self.review_id,
+            "repository": self.repository,
+            "pr_number": self.pr_number,
+            "head_sha": self.head_sha,
+            "gate_kind": self.gate_kind,
+            "verdict": self.verdict,
+            "model": self.model,
+            "family": self.family,
+            "harness": self.harness,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HeadFreshness:
+    """Result of comparing the sealed job head to the live PR head."""
+
+    expected_sha: str
+    current_sha: str
+    is_fresh: bool
+
+    @property
+    def is_stale(self) -> bool:
+        return not self.is_fresh
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationPlan:
+    """Dry-run-first publication decision; never posts to GitHub by itself."""
+
+    action: PublicationAction
+    idempotency_key: str
+    review_id: str
+    repository: str
+    pr_number: int
+    head_sha: str
+    gate_kind: str
+    verdict: str
+    status_context: str
+    status_state: CommitStatusState | None
+    comment_body: str | None
+    mutate: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "idempotency_key": self.idempotency_key,
+            "review_id": self.review_id,
+            "repository": self.repository,
+            "pr_number": self.pr_number,
+            "head_sha": self.head_sha,
+            "gate_kind": self.gate_kind,
+            "verdict": self.verdict,
+            "status_context": self.status_context,
+            "status_state": self.status_state,
+            "comment_body": self.comment_body,
+            "mutate": self.mutate,
+            "reason": self.reason,
+        }
+
+
+def _require_nonempty_str(value: Any, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise ReviewPublicationError(f"missing_{field}: expected non-empty string")
+    normalized = " ".join(value.split())
+    if not normalized:
+        raise ReviewPublicationError(f"missing_{field}: expected non-empty string")
+    return normalized
+
+
+def _normalize_sha(value: Any, *, field: str = "head_sha") -> str:
+    sha = _require_nonempty_str(value, field=field).lower()
+    if not _SHA_RE.fullmatch(sha):
+        raise ReviewPublicationError(f"invalid_{field}: {sha!r}")
+    return sha
+
+
+def _normalize_pr_number(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ReviewPublicationError(f"invalid_pr_number: {value!r}")
+    if value <= 0:
+        raise ReviewPublicationError(f"invalid_pr_number: {value}")
+    return value
+
+
+def normalize_verdict(raw: Any) -> str:
+    """Return a canonical APPROVED|CHANGES_REQUESTED|BLOCKED verdict."""
+    if not isinstance(raw, str):
+        raise ReviewPublicationError(
+            "invalid_verdict: expected APPROVED|CHANGES_REQUESTED|BLOCKED"
+        )
+    verdict = raw.strip().upper()
+    if verdict not in VALID_VERDICTS:
+        raise ReviewPublicationError(
+            f"invalid_verdict: {raw!r} "
+            "(expected APPROVED|CHANGES_REQUESTED|BLOCKED)"
+        )
+    return verdict
+
+
+def parse_verdict_token(text: str) -> str:
+    """Extract a VERDICT line from free text without retaining the body."""
+    if not isinstance(text, str) or not text.strip():
+        raise ReviewPublicationError("verdict_missing: empty payload")
+    match = _VERDICT_LINE_RE.search(text)
+    if not match:
+        raise ReviewPublicationError(
+            "verdict_missing: expected VERDICT: APPROVED|CHANGES_REQUESTED|BLOCKED"
+        )
+    return normalize_verdict(match.group(1))
+
+
+def parse_sealed_verdict_payload(payload: Mapping[str, Any] | str | bytes) -> SealedVerdict:
+    """Parse a sealed formal-review verdict payload (dict or JSON object).
+
+    Accepts either:
+
+    * a mapping / JSON object with explicit fields, or
+    * JSON text that decodes to that object.
+
+    The ``verdict`` field is required. A free-text ``verdict_text`` with a
+    ``VERDICT:`` line is accepted only when ``verdict`` is absent (bridge
+    compatibility while PR-F jobs land).
+    """
+    data: Mapping[str, Any]
+    if isinstance(payload, (str, bytes)):
+        raw = payload.decode("utf-8") if isinstance(payload, bytes) else payload
+        try:
+            loaded = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ReviewPublicationError(f"sealed_payload_invalid_json: {exc.msg}") from exc
+        if not isinstance(loaded, dict):
+            raise ReviewPublicationError("sealed_payload_invalid: expected a JSON object")
+        data = loaded
+    elif isinstance(payload, Mapping):
+        data = payload
+    else:
+        raise ReviewPublicationError(
+            f"sealed_payload_invalid: unsupported type {type(payload).__name__}"
+        )
+
+    if "verdict" in data and data["verdict"] is not None:
+        verdict = normalize_verdict(data["verdict"])
+    elif data.get("verdict_text"):
+        verdict = parse_verdict_token(str(data["verdict_text"]))
+    else:
+        raise ReviewPublicationError(
+            "sealed_payload_missing_verdict: expected verdict field"
+        )
+
+    gate_kind = (
+        _require_nonempty_str(data["gate_kind"], field="gate_kind")
+        if data.get("gate_kind") is not None
+        else DEFAULT_GATE_KIND
+    )
+
+    return SealedVerdict(
+        review_id=_require_nonempty_str(data.get("review_id"), field="review_id"),
+        repository=_require_nonempty_str(data.get("repository"), field="repository"),
+        pr_number=_normalize_pr_number(data.get("pr_number", data.get("pr"))),
+        head_sha=_normalize_sha(data.get("head_sha"), field="head_sha"),
+        gate_kind=gate_kind,
+        verdict=verdict,
+        model=_require_nonempty_str(data.get("model"), field="model"),
+        family=_require_nonempty_str(data.get("family"), field="family"),
+        harness=_require_nonempty_str(data.get("harness"), field="harness"),
+    )
+
+
+def check_head_freshness(*, expected_sha: str, current_sha: str) -> HeadFreshness:
+    """Compare sealed job head against live PR head (case-insensitive full match).
+
+    Publisher head drift must fail closed without posting success (Sol PR-G).
+    Short prefixes are not accepted — both sides must be normalized SHAs.
+    """
+    expected = _normalize_sha(expected_sha, field="expected_sha")
+    current = _normalize_sha(current_sha, field="current_sha")
+    return HeadFreshness(
+        expected_sha=expected,
+        current_sha=current,
+        is_fresh=expected == current,
+    )
+
+
+def assert_head_fresh(*, expected_sha: str, current_sha: str) -> HeadFreshness:
+    """Like :func:`check_head_freshness` but raises on stale head."""
+    result = check_head_freshness(expected_sha=expected_sha, current_sha=current_sha)
+    if result.is_stale:
+        raise ReviewPublicationError(
+            f"stale_head: expected={result.expected_sha} current={result.current_sha}"
+        )
+    return result
+
+
+def publication_idempotency_key(
+    *,
+    repository: str,
+    pr_number: int,
+    head_sha: str,
+    gate_kind: str = DEFAULT_GATE_KIND,
+) -> str:
+    """Stable key for unique formal-review jobs / publication receipts.
+
+    Matches the formal_review_jobs uniqueness constraint::
+
+        UNIQUE (repository, pr_number, head_sha, gate_kind)
+
+    The digest is hex SHA-256 over a canonical encoding so callers can store a
+    compact key without delimiter ambiguity.
+    """
+    repo = _require_nonempty_str(repository, field="repository").lower()
+    pr = _normalize_pr_number(pr_number)
+    sha = _normalize_sha(head_sha, field="head_sha")
+    gate = _require_nonempty_str(gate_kind, field="gate_kind").lower()
+    canonical = f"{repo}\n{pr}\n{sha}\n{gate}".encode()
+    digest = hashlib.sha256(canonical).hexdigest()
+    return f"fleet-pub:{digest}"
+
+
+def map_verdict_to_commit_status(verdict: str) -> CommitStatusState:
+    """Map sealed verdict → GitHub commit status state for the merge gate.
+
+    Sol formal-review service::
+
+        APPROVED            → success
+        CHANGES_REQUESTED   → failure
+        BLOCKED             → error  (terminal infrastructure / policy block)
+    """
+    normalized = normalize_verdict(verdict)
+    if normalized == "APPROVED":
+        return STATUS_SUCCESS
+    if normalized == "CHANGES_REQUESTED":
+        return STATUS_FAILURE
+    return STATUS_ERROR
+
+
+def build_thin_verdict_comment(sealed: SealedVerdict) -> str:
+    """Build the thin PR comment body (no findings, provenance from sealed job)."""
+    return "\n".join(
+        (
+            f"VERDICT: {sealed.verdict}",
+            f"Head SHA: {sealed.head_sha}",
+            f"Review ID: {sealed.review_id}",
+            "Reviewer provenance: "
+            f"model={sealed.model}; "
+            f"family={sealed.family}; "
+            f"harness={sealed.harness}",
+        )
+    )
+
+
+def plan_publication(
+    sealed: SealedVerdict,
+    *,
+    current_head_sha: str,
+    already_published_key: str | None = None,
+    mutate: bool = False,
+    status_context: str = DEFAULT_STATUS_CONTEXT,
+) -> PublicationPlan:
+    """Plan comment + commit-status publication for a sealed verdict.
+
+    Default path is dry-run (``mutate=False``): the plan describes what would be
+    posted but performs no GitHub I/O. Callers that intend live mutation must
+    pass ``mutate=True`` **and** implement the actual ``gh``/API calls outside
+    this module — this function still never talks to GitHub.
+
+    Idempotency: if ``already_published_key`` equals the planned key, action is
+    ``skip_idempotent`` (exactly one effective status/comment per job).
+    """
+    if not isinstance(sealed, SealedVerdict):
+        raise ReviewPublicationError("sealed_verdict_invalid: expected SealedVerdict")
+
+    context = _require_nonempty_str(status_context, field="status_context")
+    key = publication_idempotency_key(
+        repository=sealed.repository,
+        pr_number=sealed.pr_number,
+        head_sha=sealed.head_sha,
+        gate_kind=sealed.gate_kind,
+    )
+
+    freshness = check_head_freshness(
+        expected_sha=sealed.head_sha,
+        current_sha=current_head_sha,
+    )
+    if freshness.is_stale:
+        return PublicationPlan(
+            action="refuse_stale",
+            idempotency_key=key,
+            review_id=sealed.review_id,
+            repository=sealed.repository,
+            pr_number=sealed.pr_number,
+            head_sha=sealed.head_sha,
+            gate_kind=sealed.gate_kind,
+            verdict=sealed.verdict,
+            status_context=context,
+            status_state=None,
+            comment_body=None,
+            mutate=False,
+            reason=(
+                f"stale_head: expected={freshness.expected_sha} "
+                f"current={freshness.current_sha}"
+            ),
+        )
+
+    if already_published_key is not None and already_published_key == key:
+        return PublicationPlan(
+            action="skip_idempotent",
+            idempotency_key=key,
+            review_id=sealed.review_id,
+            repository=sealed.repository,
+            pr_number=sealed.pr_number,
+            head_sha=sealed.head_sha,
+            gate_kind=sealed.gate_kind,
+            verdict=sealed.verdict,
+            status_context=context,
+            status_state=None,
+            comment_body=None,
+            mutate=False,
+            reason="already_published: matching idempotency key",
+        )
+
+    return PublicationPlan(
+        action="publish",
+        idempotency_key=key,
+        review_id=sealed.review_id,
+        repository=sealed.repository,
+        pr_number=sealed.pr_number,
+        head_sha=sealed.head_sha,
+        gate_kind=sealed.gate_kind,
+        verdict=sealed.verdict,
+        status_context=context,
+        status_state=map_verdict_to_commit_status(sealed.verdict),
+        comment_body=build_thin_verdict_comment(sealed),
+        mutate=bool(mutate),
+        reason=(
+            "ready_to_publish"
+            if mutate
+            else "dry_run: no GitHub mutation (pass mutate=True only from an explicit live publisher)"
+        ),
+    )
+
+
+__all__ = [
+    "DEFAULT_GATE_KIND",
+    "DEFAULT_STATUS_CONTEXT",
+    "STATUS_ERROR",
+    "STATUS_FAILURE",
+    "STATUS_PENDING",
+    "STATUS_SUCCESS",
+    "VALID_VERDICTS",
+    "CommitStatusState",
+    "HeadFreshness",
+    "PublicationAction",
+    "PublicationPlan",
+    "ReviewPublicationError",
+    "SealedVerdict",
+    "assert_head_fresh",
+    "build_thin_verdict_comment",
+    "check_head_freshness",
+    "map_verdict_to_commit_status",
+    "normalize_verdict",
+    "parse_sealed_verdict_payload",
+    "parse_verdict_token",
+    "plan_publication",
+    "publication_idempotency_key",
+]

--- a/tests/test_fleet_comms_review_publication.py
+++ b/tests/test_fleet_comms_review_publication.py
@@ -1,0 +1,300 @@
+"""Unit tests for Fleet Comms PR-G verdict publisher prep (pure, no GitHub I/O)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.fleet_comms.review_publication import (
+    DEFAULT_GATE_KIND,
+    DEFAULT_STATUS_CONTEXT,
+    STATUS_ERROR,
+    STATUS_FAILURE,
+    STATUS_SUCCESS,
+    HeadFreshness,
+    ReviewPublicationError,
+    SealedVerdict,
+    assert_head_fresh,
+    build_thin_verdict_comment,
+    check_head_freshness,
+    map_verdict_to_commit_status,
+    normalize_verdict,
+    parse_sealed_verdict_payload,
+    parse_verdict_token,
+    plan_publication,
+    publication_idempotency_key,
+)
+
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+
+
+def _sealed(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "review_id": "review_deadbeef",
+        "repository": "learn-ukrainian/learn-ukrainian.github.io",
+        "pr_number": 5512,
+        "head_sha": _SHA_A,
+        "gate_kind": DEFAULT_GATE_KIND,
+        "verdict": "APPROVED",
+        "model": "claude-opus-4-6",
+        "family": "anthropic",
+        "harness": "claude",
+    }
+    base.update(overrides)
+    return base
+
+
+# ── verdict parsing ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("APPROVED", "APPROVED"),
+        ("approved", "APPROVED"),
+        ("CHANGES_REQUESTED", "CHANGES_REQUESTED"),
+        ("changes_requested", "CHANGES_REQUESTED"),
+        ("BLOCKED", "BLOCKED"),
+        ("  blocked  ", "BLOCKED"),
+    ],
+)
+def test_normalize_verdict_accepts_canonical_states(raw: str, expected: str) -> None:
+    assert normalize_verdict(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["", "PASS", "correct", "APPROVE", None, 1])
+def test_normalize_verdict_rejects_unknown(raw: object) -> None:
+    with pytest.raises(ReviewPublicationError, match="invalid_verdict"):
+        normalize_verdict(raw)  # type: ignore[arg-type]
+
+
+def test_parse_verdict_token_from_text() -> None:
+    body = "notes...\nVERDICT: CHANGES_REQUESTED\nmore"
+    assert parse_verdict_token(body) == "CHANGES_REQUESTED"
+
+
+def test_parse_verdict_token_missing() -> None:
+    with pytest.raises(ReviewPublicationError, match="verdict_missing"):
+        parse_verdict_token("no formal marker here")
+
+
+def test_parse_sealed_verdict_payload_from_mapping() -> None:
+    sealed = parse_sealed_verdict_payload(_sealed())
+    assert isinstance(sealed, SealedVerdict)
+    assert sealed.verdict == "APPROVED"
+    assert sealed.pr_number == 5512
+    assert sealed.head_sha == _SHA_A
+    assert sealed.gate_kind == DEFAULT_GATE_KIND
+
+
+def test_parse_sealed_verdict_payload_from_json_bytes() -> None:
+    sealed = parse_sealed_verdict_payload(json.dumps(_sealed(verdict="BLOCKED")).encode())
+    assert sealed.verdict == "BLOCKED"
+    assert sealed.to_dict()["review_id"] == "review_deadbeef"
+
+
+def test_parse_sealed_verdict_accepts_pr_alias_and_verdict_text() -> None:
+    payload = _sealed()
+    del payload["pr_number"]
+    del payload["verdict"]
+    payload["pr"] = 99
+    payload["verdict_text"] = "Summary\nVERDICT: CHANGES_REQUESTED\n"
+    sealed = parse_sealed_verdict_payload(payload)
+    assert sealed.pr_number == 99
+    assert sealed.verdict == "CHANGES_REQUESTED"
+
+
+def test_parse_sealed_verdict_defaults_gate_kind() -> None:
+    payload = _sealed()
+    del payload["gate_kind"]
+    sealed = parse_sealed_verdict_payload(payload)
+    assert sealed.gate_kind == DEFAULT_GATE_KIND
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"review_id": ""}, "missing_review_id"),
+        ({"head_sha": "not-a-sha"}, "invalid_head_sha"),
+        ({"pr_number": 0}, "invalid_pr_number"),
+        ({"pr_number": True}, "invalid_pr_number"),
+        ({"verdict": "PASS"}, "invalid_verdict"),
+        ({"model": "  "}, "missing_model"),
+    ],
+)
+def test_parse_sealed_verdict_fail_closed(overrides: dict[str, object], match: str) -> None:
+    with pytest.raises(ReviewPublicationError, match=match):
+        parse_sealed_verdict_payload(_sealed(**overrides))
+
+
+def test_parse_sealed_verdict_rejects_non_object_json() -> None:
+    with pytest.raises(ReviewPublicationError, match="JSON object"):
+        parse_sealed_verdict_payload("[1, 2]")
+
+
+# ── stale-head check ─────────────────────────────────────────────────────────
+
+
+def test_check_head_freshness_fresh() -> None:
+    result = check_head_freshness(expected_sha=_SHA_A, current_sha=_SHA_A.upper())
+    assert result == HeadFreshness(expected_sha=_SHA_A, current_sha=_SHA_A, is_fresh=True)
+    assert result.is_stale is False
+
+
+def test_check_head_freshness_stale() -> None:
+    result = check_head_freshness(expected_sha=_SHA_A, current_sha=_SHA_B)
+    assert result.is_fresh is False
+    assert result.is_stale is True
+
+
+def test_assert_head_fresh_raises_on_drift() -> None:
+    with pytest.raises(ReviewPublicationError, match="stale_head"):
+        assert_head_fresh(expected_sha=_SHA_A, current_sha=_SHA_B)
+
+
+def test_assert_head_fresh_ok() -> None:
+    result = assert_head_fresh(expected_sha=_SHA_A, current_sha=_SHA_A)
+    assert result.is_fresh is True
+
+
+# ── idempotency key ──────────────────────────────────────────────────────────
+
+
+def test_publication_idempotency_key_stable_and_sensitive() -> None:
+    key1 = publication_idempotency_key(
+        repository="learn-ukrainian/learn-ukrainian.github.io",
+        pr_number=5512,
+        head_sha=_SHA_A,
+        gate_kind=DEFAULT_GATE_KIND,
+    )
+    key2 = publication_idempotency_key(
+        repository="Learn-Ukrainian/learn-ukrainian.github.io",
+        pr_number=5512,
+        head_sha=_SHA_A.upper(),
+        gate_kind=DEFAULT_GATE_KIND,
+    )
+    assert key1 == key2
+    assert key1.startswith("fleet-pub:")
+    assert len(key1) == len("fleet-pub:") + 64
+
+    different_sha = publication_idempotency_key(
+        repository="learn-ukrainian/learn-ukrainian.github.io",
+        pr_number=5512,
+        head_sha=_SHA_B,
+        gate_kind=DEFAULT_GATE_KIND,
+    )
+    different_pr = publication_idempotency_key(
+        repository="learn-ukrainian/learn-ukrainian.github.io",
+        pr_number=5513,
+        head_sha=_SHA_A,
+        gate_kind=DEFAULT_GATE_KIND,
+    )
+    different_gate = publication_idempotency_key(
+        repository="learn-ukrainian/learn-ukrainian.github.io",
+        pr_number=5512,
+        head_sha=_SHA_A,
+        gate_kind="advisory-review",
+    )
+    assert len({key1, different_sha, different_pr, different_gate}) == 4
+
+
+# ── status mapping + thin comment ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("verdict", "state"),
+    [
+        ("APPROVED", STATUS_SUCCESS),
+        ("CHANGES_REQUESTED", STATUS_FAILURE),
+        ("BLOCKED", STATUS_ERROR),
+    ],
+)
+def test_map_verdict_to_commit_status(verdict: str, state: str) -> None:
+    assert map_verdict_to_commit_status(verdict) == state
+
+
+def test_build_thin_verdict_comment_has_no_findings() -> None:
+    sealed = parse_sealed_verdict_payload(_sealed(verdict="CHANGES_REQUESTED"))
+    body = build_thin_verdict_comment(sealed)
+    assert "VERDICT: CHANGES_REQUESTED" in body
+    assert f"Head SHA: {_SHA_A}" in body
+    assert "Review ID: review_deadbeef" in body
+    assert "model=claude-opus-4-6" in body
+    assert "findings" not in body.lower()
+
+
+# ── publication plan (dry-run default, no live mutation) ─────────────────────
+
+
+def test_plan_publication_dry_run_default_ready() -> None:
+    sealed = parse_sealed_verdict_payload(_sealed())
+    plan = plan_publication(sealed, current_head_sha=_SHA_A)
+    assert plan.action == "publish"
+    assert plan.mutate is False
+    assert plan.status_context == DEFAULT_STATUS_CONTEXT
+    assert plan.status_state == STATUS_SUCCESS
+    assert plan.comment_body is not None
+    assert "VERDICT: APPROVED" in plan.comment_body
+    assert "dry_run" in plan.reason
+    assert plan.idempotency_key == publication_idempotency_key(
+        repository=sealed.repository,
+        pr_number=sealed.pr_number,
+        head_sha=sealed.head_sha,
+        gate_kind=sealed.gate_kind,
+    )
+
+
+def test_plan_publication_mutate_flag_only_marks_intent() -> None:
+    """mutate=True records intent; this helper still performs zero I/O."""
+    sealed = parse_sealed_verdict_payload(_sealed(verdict="BLOCKED"))
+    plan = plan_publication(sealed, current_head_sha=_SHA_A, mutate=True)
+    assert plan.action == "publish"
+    assert plan.mutate is True
+    assert plan.status_state == STATUS_ERROR
+    assert plan.reason == "ready_to_publish"
+
+
+def test_plan_publication_refuses_stale_head_without_posting() -> None:
+    sealed = parse_sealed_verdict_payload(_sealed())
+    plan = plan_publication(sealed, current_head_sha=_SHA_B, mutate=True)
+    assert plan.action == "refuse_stale"
+    assert plan.mutate is False  # never mutate on stale
+    assert plan.comment_body is None
+    assert plan.status_state is None
+    assert "stale_head" in plan.reason
+
+
+def test_plan_publication_idempotent_skip_on_repeat() -> None:
+    sealed = parse_sealed_verdict_payload(_sealed())
+    key = publication_idempotency_key(
+        repository=sealed.repository,
+        pr_number=sealed.pr_number,
+        head_sha=sealed.head_sha,
+        gate_kind=sealed.gate_kind,
+    )
+    plan = plan_publication(
+        sealed,
+        current_head_sha=_SHA_A,
+        already_published_key=key,
+        mutate=True,
+    )
+    assert plan.action == "skip_idempotent"
+    assert plan.mutate is False
+    assert plan.comment_body is None
+    assert "already_published" in plan.reason
+
+
+def test_plan_publication_all_verdicts_for_fake_github_matrix() -> None:
+    """PR-G acceptance matrix (approved / changes / blocked) without live GH."""
+    for verdict, status in (
+        ("APPROVED", STATUS_SUCCESS),
+        ("CHANGES_REQUESTED", STATUS_FAILURE),
+        ("BLOCKED", STATUS_ERROR),
+    ):
+        sealed = parse_sealed_verdict_payload(_sealed(verdict=verdict))
+        plan = plan_publication(sealed, current_head_sha=_SHA_A)
+        assert plan.action == "publish"
+        assert plan.status_state == status
+        assert plan.to_dict()["verdict"] == verdict


### PR DESCRIPTION
## Summary

Small first slice of Sol fleet-comms **PR-G** (verdict publisher / GitHub gate prep) under #5512.

Adds pure, dry-run-first helpers only — **no live GitHub mutation** and **no production cutover** of `publish-review-verdict`.

### What landed

- `scripts/fleet_comms/review_publication.py`
  - Parse sealed verdict payloads (`APPROVED` / `CHANGES_REQUESTED` / `BLOCKED`)
  - Stale-head check (`expected_sha` vs current; fail closed)
  - Idempotency key from `(repository, pr, head_sha, gate_kind)` (matches `formal_review_jobs` uniqueness)
  - Map verdict → commit status (`success` / `failure` / `error`) for context `fleet/cross-family-review`
  - `plan_publication(...)` dry-run default (`mutate=False`); `mutate=True` only records intent — this module never calls `gh`/API
- Unit tests: `tests/test_fleet_comms_review_publication.py` (39 cases covering approved / changes / blocked / stale / repeat-publish)
- Doc note on existing `publish-review-verdict`: full `--review-id` cutover **waits for PR-F** formal-jobs table writers

### Explicit non-goals

- No default switch of bridge `publish-review-verdict` to `--review-id`
- No Sol involvement
- No live GitHub status/comment posting in this path

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_fleet_comms_review_publication.py -q`
- [x] `.venv/bin/ruff check` on touched files
- [x] `git diff --check`

Closes nothing (epic slice under #5512).