### PR TITLE
feat(fleet-comms): PR-F formal review jobs skeleton (#5512)

### DIFF
--- a/scripts/fleet_comms/__init__.py
+++ b/scripts/fleet_comms/__init__.py
@@ -3,6 +3,13 @@
 from scripts.fleet_comms.adapter_conformance import CaptureInput, conform
 from scripts.fleet_comms.artifacts import ArtifactRecord, ArtifactStore
 from scripts.fleet_comms.contracts import AssistantSegment, CompletionState, ResponseEnvelope, new_id
+from scripts.fleet_comms.formal_review_jobs import (
+    FormalReviewAttempt,
+    FormalReviewJob,
+    FormalReviewJobsError,
+    FormalReviewJobService,
+    open_formal_review_jobs,
+)
 from scripts.fleet_comms.message_plane import (
     MessagePlane,
     open_message_plane,
@@ -17,12 +24,17 @@ __all__ = [
     "AssistantSegment",
     "CaptureInput",
     "CompletionState",
+    "FormalReviewAttempt",
+    "FormalReviewJob",
+    "FormalReviewJobService",
+    "FormalReviewJobsError",
     "MessagePlane",
     "RequestExecutor",
     "RequestRecord",
     "ResponseEnvelope",
     "conform",
     "new_id",
+    "open_formal_review_jobs",
     "open_message_plane",
     "read_plane_status",
     "resolve_plane_mode",

--- a/scripts/fleet_comms/formal_review_jobs.py
+++ b/scripts/fleet_comms/formal_review_jobs.py
@@ -1,7 +1,7 @@
 """Formal review job skeleton (Fleet Comms Sol PR-F first slice / #5512).
 
 Durable SQLite usage of ``formal_review_jobs`` / ``formal_review_attempts``
-(schema from fleet_comms migrations). Unique active key:
+(schema from fleet_comms migrations). Unique key (one job per head; attempts accumulate):
 
     (repository, pr_number, head_sha, gate_kind)
 
@@ -131,7 +131,7 @@ class FormalReviewJobService:
         state: str = "open",
         review_id: str | None = None,
     ) -> FormalReviewJob:
-        """Create a formal review job under the unique active key.
+        """Create a formal review job under the unique key (one job per head).
 
         Parameters
         ----------
@@ -159,7 +159,7 @@ class FormalReviewJobService:
         if existing is not None:
             raise FormalReviewJobsError(
                 "concurrent duplicate formal review job rejected: "
-                f"active key {(repo, pr_number, sha, gate)} already held by "
+                f"unique job key {(repo, pr_number, sha, gate)} already held by "
                 f"{existing.review_id} (state={existing.state})"
             )
 
@@ -181,7 +181,7 @@ class FormalReviewJobService:
             if raced is not None:
                 raise FormalReviewJobsError(
                     "concurrent duplicate formal review job rejected: "
-                    f"active key {(repo, pr_number, sha, gate)} already held by "
+                    f"unique job key {(repo, pr_number, sha, gate)} already held by "
                     f"{raced.review_id} (state={raced.state})"
                 ) from exc
             raise FormalReviewJobsError(f"failed to create formal review job: {exc}") from exc
@@ -322,7 +322,7 @@ class FormalReviewJobService:
         *,
         include_attempts: bool = True,
     ) -> FormalReviewJob | None:
-        """Lookup by unique active key; ``None`` if no job exists."""
+        """Lookup by unique key (one job per head); ``None`` if no job exists."""
         return self._find_by_key(
             self._require_nonempty(repository, "repository"),
             self._require_pr(pr),

--- a/scripts/fleet_comms/formal_review_jobs.py
+++ b/scripts/fleet_comms/formal_review_jobs.py
@@ -1,0 +1,442 @@
+"""Formal review job skeleton (Fleet Comms Sol PR-F first slice / #5512).
+
+Durable SQLite usage of ``formal_review_jobs`` / ``formal_review_attempts``
+(schema from fleet_comms migrations). Unique active key:
+
+    (repository, pr_number, head_sha, gate_kind)
+
+Concurrent duplicate creates are rejected. This module does **not** cut over
+``review-pr``, seal snapshots, resolve reviewers, validate verdicts, or publish
+to GitHub (those are later PR-F / PR-G slices).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.fleet_comms.artifacts import ArtifactStore
+from scripts.fleet_comms.contracts import CompletionState, new_id
+from scripts.fleet_comms.migrations import apply_migrations
+
+# Job lifecycle for this skeleton. Publication / sealed verdict acceptance land later.
+JOB_STATES = frozenset({"open", "running", "complete", "failed", "blocked"})
+ACTIVE_JOB_STATES = frozenset({"open", "running"})
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _normalize_completion_state(completion_state: CompletionState | str) -> str:
+    if isinstance(completion_state, CompletionState):
+        return completion_state.value
+    value = str(completion_state).strip().lower()
+    try:
+        return CompletionState(value).value
+    except ValueError as exc:
+        raise FormalReviewJobsError(
+            f"invalid completion_state: {completion_state!r}; "
+            f"expected one of {[s.value for s in CompletionState]}"
+        ) from exc
+
+
+@dataclass(frozen=True, slots=True)
+class FormalReviewAttempt:
+    review_attempt_id: str
+    review_id: str
+    attempt_number: int
+    completion_state: str
+    raw_capture_artifact_id: str | None
+    created_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "review_attempt_id": self.review_attempt_id,
+            "review_id": self.review_id,
+            "attempt_number": self.attempt_number,
+            "completion_state": self.completion_state,
+            "raw_capture_artifact_id": self.raw_capture_artifact_id,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FormalReviewJob:
+    review_id: str
+    repository: str
+    pr_number: int
+    head_sha: str
+    gate_kind: str
+    state: str
+    snapshot_artifact_id: str | None
+    created_at: str
+    attempts: tuple[FormalReviewAttempt, ...] = field(default_factory=tuple)
+
+    @property
+    def unique_key(self) -> tuple[str, int, str, str]:
+        return (self.repository, self.pr_number, self.head_sha, self.gate_kind)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "review_id": self.review_id,
+            "repository": self.repository,
+            "pr_number": self.pr_number,
+            "head_sha": self.head_sha,
+            "gate_kind": self.gate_kind,
+            "state": self.state,
+            "snapshot_artifact_id": self.snapshot_artifact_id,
+            "created_at": self.created_at,
+            "attempts": [attempt.to_dict() for attempt in self.attempts],
+        }
+
+
+class FormalReviewJobsError(RuntimeError):
+    """Formal review job service refused an operation."""
+
+
+class FormalReviewJobService:
+    """SQLite writers/readers for formal review jobs and attempts (no GitHub)."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore | None = None,
+        root: Path | None = None,
+    ) -> None:
+        self.store = store or ArtifactStore(root=root)
+        self._conn = self.store.connection
+        apply_migrations(self._conn)
+
+    def close(self) -> None:
+        self.store.close()
+
+    def __enter__(self) -> FormalReviewJobService:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def create_job(
+        self,
+        repository: str,
+        pr: int,
+        head_sha: str,
+        gate_kind: str,
+        *,
+        snapshot_artifact_id: str | None = None,
+        state: str = "open",
+        review_id: str | None = None,
+    ) -> FormalReviewJob:
+        """Create a formal review job under the unique active key.
+
+        Parameters
+        ----------
+        repository:
+            ``owner/repo`` style identifier.
+        pr:
+            Pull request number (positive integer).
+        head_sha:
+            Immutable commit SHA under review.
+        gate_kind:
+            Gate discriminator (e.g. ``cross-family``).
+        """
+        repo = self._require_nonempty(repository, "repository")
+        pr_number = self._require_pr(pr)
+        sha = self._require_nonempty(head_sha, "head_sha").lower()
+        gate = self._require_nonempty(gate_kind, "gate_kind")
+        if state not in JOB_STATES:
+            raise FormalReviewJobsError(
+                f"invalid job state: {state!r}; expected one of {sorted(JOB_STATES)}"
+            )
+        if snapshot_artifact_id is not None:
+            self._require_artifact(snapshot_artifact_id)
+
+        existing = self._find_by_key(repo, pr_number, sha, gate)
+        if existing is not None:
+            raise FormalReviewJobsError(
+                "concurrent duplicate formal review job rejected: "
+                f"active key {(repo, pr_number, sha, gate)} already held by "
+                f"{existing.review_id} (state={existing.state})"
+            )
+
+        rid = review_id or new_id("review")
+        created = _utc_now()
+        try:
+            self._conn.execute(
+                """INSERT INTO formal_review_jobs(
+                    review_id, repository, pr_number, head_sha, gate_kind,
+                    state, snapshot_artifact_id, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (rid, repo, pr_number, sha, gate, state, snapshot_artifact_id, created),
+            )
+            self._conn.commit()
+        except sqlite3.IntegrityError as exc:
+            self._conn.rollback()
+            # Race: another writer inserted the same unique key between SELECT and INSERT.
+            raced = self._find_by_key(repo, pr_number, sha, gate)
+            if raced is not None:
+                raise FormalReviewJobsError(
+                    "concurrent duplicate formal review job rejected: "
+                    f"active key {(repo, pr_number, sha, gate)} already held by "
+                    f"{raced.review_id} (state={raced.state})"
+                ) from exc
+            raise FormalReviewJobsError(f"failed to create formal review job: {exc}") from exc
+        return self.get_job(rid)
+
+    def record_attempt(
+        self,
+        review_id: str,
+        *,
+        completion_state: CompletionState | str,
+        raw_capture_artifact_id: str | None = None,
+        review_attempt_id: str | None = None,
+    ) -> FormalReviewAttempt:
+        """Append one attempt row for an existing job.
+
+        ``raw_capture_artifact_id`` is optional; when provided it must exist in
+        the artifact store (FK is not enforced by schema, but the skeleton
+        fails closed so callers cannot invent IDs).
+        """
+        job = self.get_job(review_id, include_attempts=False)
+        state_value = _normalize_completion_state(completion_state)
+        if raw_capture_artifact_id is not None:
+            self._require_artifact(raw_capture_artifact_id)
+
+        row = self._conn.execute(
+            "SELECT COALESCE(MAX(attempt_number), 0) FROM formal_review_attempts WHERE review_id = ?",
+            (job.review_id,),
+        ).fetchone()
+        next_number = int(row[0]) + 1 if row is not None else 1
+        attempt_id = review_attempt_id or new_id("review-attempt")
+        created = _utc_now()
+        try:
+            self._conn.execute(
+                """INSERT INTO formal_review_attempts(
+                    review_attempt_id, review_id, attempt_number,
+                    completion_state, raw_capture_artifact_id, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    attempt_id,
+                    job.review_id,
+                    next_number,
+                    state_value,
+                    raw_capture_artifact_id,
+                    created,
+                ),
+            )
+            # Keep job state in step with the latest attempt (skeleton mapping only).
+            new_job_state = self._map_completion_to_job_state(state_value, job.state)
+            if new_job_state != job.state:
+                self._conn.execute(
+                    "UPDATE formal_review_jobs SET state = ? WHERE review_id = ?",
+                    (new_job_state, job.review_id),
+                )
+            self._conn.commit()
+        except sqlite3.IntegrityError as exc:
+            self._conn.rollback()
+            raise FormalReviewJobsError(
+                f"failed to record attempt for {job.review_id}: {exc}"
+            ) from exc
+
+        return FormalReviewAttempt(
+            review_attempt_id=attempt_id,
+            review_id=job.review_id,
+            attempt_number=next_number,
+            completion_state=state_value,
+            raw_capture_artifact_id=raw_capture_artifact_id,
+            created_at=created,
+        )
+
+    def get_job(self, review_id: str, *, include_attempts: bool = True) -> FormalReviewJob:
+        rid = self._require_nonempty(review_id, "review_id")
+        row = self._conn.execute(
+            "SELECT * FROM formal_review_jobs WHERE review_id = ?", (rid,)
+        ).fetchone()
+        if row is None:
+            raise FormalReviewJobsError(f"formal review job not found: {rid}")
+        attempts: tuple[FormalReviewAttempt, ...] = ()
+        if include_attempts:
+            attempts = self._load_attempts(rid)
+        return self._row_to_job(row, attempts=attempts)
+
+    def list_jobs(
+        self,
+        *,
+        repository: str | None = None,
+        pr: int | None = None,
+        head_sha: str | None = None,
+        gate_kind: str | None = None,
+        state: str | None = None,
+        include_attempts: bool = False,
+    ) -> list[FormalReviewJob]:
+        """List jobs matching optional filters (``list_job`` API surface)."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if repository is not None:
+            clauses.append("repository = ?")
+            params.append(self._require_nonempty(repository, "repository"))
+        if pr is not None:
+            clauses.append("pr_number = ?")
+            params.append(self._require_pr(pr))
+        if head_sha is not None:
+            clauses.append("head_sha = ?")
+            params.append(self._require_nonempty(head_sha, "head_sha").lower())
+        if gate_kind is not None:
+            clauses.append("gate_kind = ?")
+            params.append(self._require_nonempty(gate_kind, "gate_kind"))
+        if state is not None:
+            if state not in JOB_STATES:
+                raise FormalReviewJobsError(
+                    f"invalid job state filter: {state!r}; expected one of {sorted(JOB_STATES)}"
+                )
+            clauses.append("state = ?")
+            params.append(state)
+
+        sql = "SELECT * FROM formal_review_jobs"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY created_at ASC, review_id ASC"
+
+        rows = self._conn.execute(sql, params).fetchall()
+        jobs: list[FormalReviewJob] = []
+        for row in rows:
+            attempts: tuple[FormalReviewAttempt, ...] = ()
+            if include_attempts:
+                attempts = self._load_attempts(str(row["review_id"]))
+            jobs.append(self._row_to_job(row, attempts=attempts))
+        return jobs
+
+    # Alias matching the brief's ``list_job`` naming.
+    list_job = list_jobs
+
+    def find_job(
+        self,
+        repository: str,
+        pr: int,
+        head_sha: str,
+        gate_kind: str,
+        *,
+        include_attempts: bool = True,
+    ) -> FormalReviewJob | None:
+        """Lookup by unique active key; ``None`` if no job exists."""
+        return self._find_by_key(
+            self._require_nonempty(repository, "repository"),
+            self._require_pr(pr),
+            self._require_nonempty(head_sha, "head_sha").lower(),
+            self._require_nonempty(gate_kind, "gate_kind"),
+            include_attempts=include_attempts,
+        )
+
+    def _find_by_key(
+        self,
+        repository: str,
+        pr_number: int,
+        head_sha: str,
+        gate_kind: str,
+        *,
+        include_attempts: bool = False,
+    ) -> FormalReviewJob | None:
+        row = self._conn.execute(
+            """SELECT * FROM formal_review_jobs
+               WHERE repository = ? AND pr_number = ? AND head_sha = ? AND gate_kind = ?""",
+            (repository, pr_number, head_sha, gate_kind),
+        ).fetchone()
+        if row is None:
+            return None
+        attempts: tuple[FormalReviewAttempt, ...] = ()
+        if include_attempts:
+            attempts = self._load_attempts(str(row["review_id"]))
+        return self._row_to_job(row, attempts=attempts)
+
+    def _load_attempts(self, review_id: str) -> tuple[FormalReviewAttempt, ...]:
+        rows = self._conn.execute(
+            """SELECT * FROM formal_review_attempts
+               WHERE review_id = ?
+               ORDER BY attempt_number ASC""",
+            (review_id,),
+        ).fetchall()
+        return tuple(
+            FormalReviewAttempt(
+                review_attempt_id=str(row["review_attempt_id"]),
+                review_id=str(row["review_id"]),
+                attempt_number=int(row["attempt_number"]),
+                completion_state=str(row["completion_state"]),
+                raw_capture_artifact_id=(
+                    str(row["raw_capture_artifact_id"])
+                    if row["raw_capture_artifact_id"] is not None
+                    else None
+                ),
+                created_at=str(row["created_at"]),
+            )
+            for row in rows
+        )
+
+    @staticmethod
+    def _row_to_job(
+        row: sqlite3.Row,
+        *,
+        attempts: tuple[FormalReviewAttempt, ...],
+    ) -> FormalReviewJob:
+        return FormalReviewJob(
+            review_id=str(row["review_id"]),
+            repository=str(row["repository"]),
+            pr_number=int(row["pr_number"]),
+            head_sha=str(row["head_sha"]),
+            gate_kind=str(row["gate_kind"]),
+            state=str(row["state"]),
+            snapshot_artifact_id=(
+                str(row["snapshot_artifact_id"]) if row["snapshot_artifact_id"] is not None else None
+            ),
+            created_at=str(row["created_at"]),
+            attempts=attempts,
+        )
+
+    def _require_artifact(self, artifact_id: str) -> None:
+        aid = self._require_nonempty(artifact_id, "artifact_id")
+        row = self._conn.execute(
+            "SELECT 1 FROM artifacts WHERE artifact_id = ?", (aid,)
+        ).fetchone()
+        if row is None:
+            raise FormalReviewJobsError(f"artifact not found: {aid}")
+
+    @staticmethod
+    def _require_nonempty(value: str, field_name: str) -> str:
+        if value is None or not str(value).strip():
+            raise FormalReviewJobsError(f"{field_name} is required")
+        return str(value).strip()
+
+    @staticmethod
+    def _require_pr(pr: int) -> int:
+        try:
+            number = int(pr)
+        except (TypeError, ValueError) as exc:
+            raise FormalReviewJobsError(f"pr must be a positive integer, got {pr!r}") from exc
+        if number < 1:
+            raise FormalReviewJobsError(f"pr must be a positive integer, got {number}")
+        return number
+
+    @staticmethod
+    def _map_completion_to_job_state(completion_state: str, current: str) -> str:
+        if completion_state == CompletionState.COMPLETE.value:
+            return "complete"
+        if completion_state == CompletionState.FAILED.value:
+            return "failed"
+        if completion_state in {
+            CompletionState.LENGTH_LIMITED.value,
+            CompletionState.TRANSPORT_INCOMPLETE.value,
+            CompletionState.UNKNOWN.value,
+        }:
+            # Keep open jobs runnable for retries; otherwise leave terminal alone.
+            if current in ACTIVE_JOB_STATES:
+                return "running"
+            return current
+        return current
+
+
+def open_formal_review_jobs(root: Path | None = None) -> FormalReviewJobService:
+    """Factory used by CLI/tests."""
+    return FormalReviewJobService(root=root)

--- a/tests/test_fleet_comms_formal_review_jobs.py
+++ b/tests/test_fleet_comms_formal_review_jobs.py
@@ -1,0 +1,166 @@
+"""Unit tests for Fleet Comms PR-F formal review job skeleton (#5512)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.fleet_comms.artifacts import ArtifactStore
+from scripts.fleet_comms.contracts import CompletionState
+from scripts.fleet_comms.formal_review_jobs import (
+    FormalReviewJobsError,
+    FormalReviewJobService,
+    open_formal_review_jobs,
+)
+
+REPO = "learn-ukrainian/learn-ukrainian.github.io"
+HEAD = "a" * 40
+GATE = "cross-family"
+
+
+def _service(tmp_path: Path) -> FormalReviewJobService:
+    return FormalReviewJobService(root=tmp_path / "fleet-comms-v1")
+
+
+def test_create_job_get_job_round_trip(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, HEAD, GATE)
+        assert job.repository == REPO
+        assert job.pr_number == 5512
+        assert job.head_sha == HEAD
+        assert job.gate_kind == GATE
+        assert job.state == "open"
+        assert job.snapshot_artifact_id is None
+        assert job.review_id.startswith("review_")
+        assert job.attempts == ()
+
+        loaded = svc.get_job(job.review_id)
+        assert loaded.to_dict() == job.to_dict()
+        assert loaded.unique_key == (REPO, 5512, HEAD, GATE)
+
+        by_key = svc.find_job(REPO, 5512, HEAD, GATE)
+        assert by_key is not None
+        assert by_key.review_id == job.review_id
+
+
+def test_create_job_rejects_concurrent_duplicate(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        first = svc.create_job(REPO, 100, HEAD, GATE)
+        with pytest.raises(FormalReviewJobsError, match=r"concurrent duplicate"):
+            svc.create_job(REPO, 100, HEAD, GATE)
+        # Same PR different head is allowed (new commit).
+        other = svc.create_job(REPO, 100, "b" * 40, GATE)
+        assert other.review_id != first.review_id
+        # Same head different gate is allowed.
+        other_gate = svc.create_job(REPO, 100, HEAD, "advisory")
+        assert other_gate.gate_kind == "advisory"
+
+
+def test_record_attempt_with_and_without_raw_capture(tmp_path: Path) -> None:
+    root = tmp_path / "fleet-comms-v1"
+    with ArtifactStore(root=root) as store:
+        capture = store.store_bytes(
+            b'{"type":"task_complete"}',
+            producer="test-formal-review",
+            retention_class="raw-capture",
+            logical_filename="attempt.capture",
+        )
+        with FormalReviewJobService(store=store) as svc:
+            job = svc.create_job(REPO, 42, HEAD, GATE)
+            a1 = svc.record_attempt(
+                job.review_id,
+                completion_state=CompletionState.TRANSPORT_INCOMPLETE,
+            )
+            assert a1.attempt_number == 1
+            assert a1.raw_capture_artifact_id is None
+            assert a1.completion_state == "transport_incomplete"
+
+            a2 = svc.record_attempt(
+                job.review_id,
+                completion_state="complete",
+                raw_capture_artifact_id=capture.artifact_id,
+            )
+            assert a2.attempt_number == 2
+            assert a2.raw_capture_artifact_id == capture.artifact_id
+            assert a2.completion_state == CompletionState.COMPLETE.value
+
+            full = svc.get_job(job.review_id)
+            assert [a.attempt_number for a in full.attempts] == [1, 2]
+            assert full.state == "complete"
+
+            with pytest.raises(FormalReviewJobsError, match=r"artifact not found"):
+                svc.record_attempt(
+                    job.review_id,
+                    completion_state=CompletionState.FAILED,
+                    raw_capture_artifact_id="artifact_does_not_exist",
+                )
+
+
+def test_list_jobs_filters_and_alias(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        j1 = svc.create_job(REPO, 1, HEAD, GATE)
+        j2 = svc.create_job(REPO, 2, HEAD, GATE)
+        j3 = svc.create_job("other/repo", 1, HEAD, GATE)
+
+        all_jobs = svc.list_jobs()
+        assert {j.review_id for j in all_jobs} == {j1.review_id, j2.review_id, j3.review_id}
+
+        only_repo = svc.list_job(repository=REPO)
+        assert {j.review_id for j in only_repo} == {j1.review_id, j2.review_id}
+
+        only_pr = svc.list_jobs(repository=REPO, pr=2)
+        assert [j.review_id for j in only_pr] == [j2.review_id]
+
+        only_open = svc.list_jobs(state="open")
+        assert len(only_open) == 3
+
+        svc.record_attempt(j1.review_id, completion_state=CompletionState.FAILED)
+        failed = svc.list_jobs(state="failed")
+        assert [j.review_id for j in failed] == [j1.review_id]
+
+
+def test_get_job_missing_and_validation(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        with pytest.raises(FormalReviewJobsError, match=r"not found"):
+            svc.get_job("review_missing")
+        with pytest.raises(FormalReviewJobsError, match=r"repository is required"):
+            svc.create_job("  ", 1, HEAD, GATE)
+        with pytest.raises(FormalReviewJobsError, match=r"positive integer"):
+            svc.create_job(REPO, 0, HEAD, GATE)
+        with pytest.raises(FormalReviewJobsError, match=r"invalid completion_state"):
+            job = svc.create_job(REPO, 9, HEAD, GATE)
+            svc.record_attempt(job.review_id, completion_state="not-a-state")
+
+
+def test_open_formal_review_jobs_factory(tmp_path: Path) -> None:
+    root = tmp_path / "v1"
+    svc = open_formal_review_jobs(root)
+    try:
+        job = svc.create_job(REPO, 7, HEAD, GATE)
+        assert svc.get_job(job.review_id).pr_number == 7
+    finally:
+        svc.close()
+
+
+def test_snapshot_artifact_id_must_exist(tmp_path: Path) -> None:
+    root = tmp_path / "v1"
+    with ArtifactStore(root=root) as store:
+        snap = store.store_text("sealed-snapshot", producer="test", logical_filename="snap.md")
+        with FormalReviewJobService(store=store) as svc:
+            job = svc.create_job(
+                REPO,
+                3,
+                HEAD,
+                GATE,
+                snapshot_artifact_id=snap.artifact_id,
+            )
+            assert job.snapshot_artifact_id == snap.artifact_id
+            with pytest.raises(FormalReviewJobsError, match=r"artifact not found"):
+                svc.create_job(
+                    REPO,
+                    4,
+                    HEAD,
+                    GATE,
+                    snapshot_artifact_id="artifact_nope",
+                )


### PR DESCRIPTION
## Summary

First skeleton slice of Sol fleet-comms **PR-F** (sealed formal-review jobs) under #5512.

Adds durable SQLite usage of migration tables `formal_review_jobs` / `formal_review_attempts` — **no live `review-pr` cutover**, **no GitHub publication**, **no Sol involvement**.

### What landed

- `scripts/fleet_comms/formal_review_jobs.py`
  - `create_job(repository, pr, head_sha, gate_kind)` with unique active key `(repository, pr_number, head_sha, gate_kind)`
  - Concurrent duplicate creates fail closed (`FormalReviewJobsError`)
  - `record_attempt(review_id, completion_state=..., raw_capture_artifact_id=optional)`
  - `get_job` / `list_jobs` (`list_job` alias) + `find_job` by unique key
  - Optional snapshot / raw-capture artifact IDs validated against `ArtifactStore`
- Unit tests: `tests/test_fleet_comms_formal_review_jobs.py` (tmp root, 7 cases)
- Public exports via `scripts/fleet_comms/__init__.py`

### Explicit non-goals

- No sealed snapshot creation / reviewer resolver / verdict schema validation (later PR-F)
- No default switch of `review-pr` onto these tables
- No GitHub status/comment publish (PR-G #5566 pure helpers remain separate)

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_fleet_comms_formal_review_jobs.py -q`
- [x] `.venv/bin/ruff check` on touched files
- [x] `git diff --check`

Closes nothing (epic slice under #5512).