### PR TITLE
feat(fleet-comms): thin CLI for plane-status + formal-job get (#5512)

### DIFF
--- a/scripts/fleet_comms/__main__.py
+++ b/scripts/fleet_comms/__main__.py
@@ -1,0 +1,7 @@
+"""``python -m scripts.fleet_comms`` entry point."""
+
+from __future__ import annotations
+
+from scripts.fleet_comms.cli import main
+
+raise SystemExit(main())

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -1,0 +1,222 @@
+"""Thin read-only CLI for fleet-comms plane status and formal review jobs.
+
+Usage::
+
+    .venv/bin/python -m scripts.fleet_comms plane-status
+    .venv/bin/python -m scripts.fleet_comms formal-job get <review_id>
+
+No writers, no GitHub, no review-pr cutover. Dumps JSON to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NOT_FOUND = 1
+EXIT_ERROR = 3
+
+
+class FleetCommsCliError(RuntimeError):
+    """CLI refused a read-only operation."""
+
+
+def _json_dump(payload: Any, *, indent: int | None = 2) -> str:
+    return json.dumps(payload, indent=indent, sort_keys=True, default=str) + "\n"
+
+
+def cmd_plane_status(args: argparse.Namespace) -> int:
+    """Dump ``read_plane_status`` JSON (same surface as Monitor API)."""
+    root = Path(args.root).expanduser() if args.root else None
+    repo_root = Path(args.repo_root).expanduser() if args.repo_root else None
+    telemetry = Path(args.telemetry).expanduser() if args.telemetry else None
+    status = read_plane_status(
+        repo_root=repo_root,
+        root=root,
+        telemetry_path=telemetry,
+        recent_limit=args.recent_limit,
+    )
+    sys.stdout.write(_json_dump(status))
+    return EXIT_OK
+
+
+def _open_plane_db_ro(root: Path) -> sqlite3.Connection:
+    db_path = root / "comms.sqlite3"
+    if not db_path.is_file():
+        raise FleetCommsCliError(f"plane DB not found: {db_path}")
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    return dict(row)
+
+
+def get_formal_review_job(
+    review_id: str,
+    *,
+    root: Path | None = None,
+    repo_root: Path | None = None,
+    include_attempts: bool = True,
+) -> dict[str, Any]:
+    """Read-only formal-job dump from the plane SQLite (no PR-F service required).
+
+    Tables are created by fleet-comms migrations (schema v1). This helper does
+    **not** call writers, migrations, or GitHub.
+    """
+    rid = (review_id or "").strip()
+    if not rid:
+        raise FleetCommsCliError("review_id is required")
+
+    plane_root = Path(root) if root is not None else default_plane_root(repo_root=repo_root)
+    conn = _open_plane_db_ro(plane_root)
+    try:
+        if not _table_exists(conn, "formal_review_jobs"):
+            raise FleetCommsCliError(
+                f"formal_review_jobs table missing under {plane_root} "
+                "(run fleet-comms migrations first)"
+            )
+        row = conn.execute(
+            "SELECT * FROM formal_review_jobs WHERE review_id = ?",
+            (rid,),
+        ).fetchone()
+        if row is None:
+            raise FleetCommsCliError(f"formal review job not found: {rid}")
+
+        payload = _row_to_dict(row)
+        payload["attempts"] = []
+        if include_attempts and _table_exists(conn, "formal_review_attempts"):
+            attempts = conn.execute(
+                """SELECT * FROM formal_review_attempts
+                   WHERE review_id = ?
+                   ORDER BY attempt_number ASC""",
+                (rid,),
+            ).fetchall()
+            payload["attempts"] = [_row_to_dict(a) for a in attempts]
+        return payload
+    finally:
+        conn.close()
+
+
+def cmd_formal_job_get(args: argparse.Namespace) -> int:
+    """Dump one formal review job (+ attempts) as JSON."""
+    root = Path(args.root).expanduser() if args.root else None
+    repo_root = Path(args.repo_root).expanduser() if args.repo_root else None
+    try:
+        payload = get_formal_review_job(
+            args.review_id,
+            root=root,
+            repo_root=repo_root,
+            include_attempts=not args.no_attempts,
+        )
+    except FleetCommsCliError as exc:
+        message = str(exc)
+        sys.stderr.write(message + "\n")
+        if message.startswith("formal review job not found:"):
+            return EXIT_NOT_FOUND
+        return EXIT_ERROR
+    sys.stdout.write(_json_dump(payload))
+    return EXIT_OK
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.fleet_comms",
+        description=(
+            "Thin read-only fleet-comms CLI: plane-status dump and formal-job get. "
+            "No GitHub mutation, no review-pr cutover."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    plane = sub.add_parser(
+        "plane-status",
+        help="Dump message-plane mode/schema/parity telemetry as JSON",
+    )
+    plane.add_argument(
+        "--root",
+        default=None,
+        help="Plane storage root (default: FLEET_COMMS_ROOT or batch_state/fleet-comms/v1)",
+    )
+    plane.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root used to resolve default plane path (default: cwd)",
+    )
+    plane.add_argument(
+        "--telemetry",
+        default=None,
+        help="Parity telemetry JSONL path (default: FLEET_COMMS_PLANE_TELEMETRY or under plane root)",
+    )
+    plane.add_argument(
+        "--recent-limit",
+        type=int,
+        default=50,
+        help="Max recent parity events to include (default: 50)",
+    )
+    plane.set_defaults(func=cmd_plane_status)
+
+    formal = sub.add_parser(
+        "formal-job",
+        help="Read-only formal review job queries (plane SQLite)",
+    )
+    formal_sub = formal.add_subparsers(dest="formal_command", required=True)
+
+    formal_get = formal_sub.add_parser(
+        "get",
+        help="Dump one formal_review_jobs row (+ attempts) by review_id",
+    )
+    formal_get.add_argument("review_id", help="Primary key of formal_review_jobs")
+    formal_get.add_argument(
+        "--root",
+        default=None,
+        help="Plane storage root (default: FLEET_COMMS_ROOT or batch_state/fleet-comms/v1)",
+    )
+    formal_get.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root used to resolve default plane path (default: cwd)",
+    )
+    formal_get.add_argument(
+        "--no-attempts",
+        action="store_true",
+        help="Omit formal_review_attempts rows",
+    )
+    formal_get.set_defaults(func=cmd_formal_job_get)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func = getattr(args, "func", None)
+    if func is None:
+        parser.print_help(sys.stderr)
+        return EXIT_USAGE
+    try:
+        return int(func(args))
+    except FleetCommsCliError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_ERROR
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fleet_comms_cli.py
+++ b/tests/test_fleet_comms_cli.py
@@ -1,0 +1,145 @@
+"""Unit tests for thin fleet-comms CLI (plane-status + formal-job get)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.fleet_comms.cli import (
+    EXIT_ERROR,
+    EXIT_NOT_FOUND,
+    EXIT_OK,
+    FleetCommsCliError,
+    get_formal_review_job,
+    main,
+)
+from scripts.fleet_comms.migrations import apply_migrations
+
+
+def _seed_plane_db(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    db_path = root / "comms.sqlite3"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert apply_migrations(conn) == 1
+        conn.execute(
+            """INSERT INTO formal_review_jobs(
+                review_id, repository, pr_number, head_sha, gate_kind,
+                state, snapshot_artifact_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "rev-abc",
+                "learn-ukrainian/learn-ukrainian.github.io",
+                5512,
+                "deadbeefcafebabe0123456789abcdef01234567",
+                "cross-family-review",
+                "open",
+                None,
+                "2026-07-20T12:00:00Z",
+            ),
+        )
+        conn.execute(
+            """INSERT INTO formal_review_attempts(
+                review_attempt_id, review_id, attempt_number,
+                completion_state, raw_capture_artifact_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                "att-1",
+                "rev-abc",
+                1,
+                "incomplete",
+                None,
+                "2026-07-20T12:01:00Z",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def test_plane_status_cli_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "shadow")
+    monkeypatch.setenv("FLEET_COMMS_ROOT", str(tmp_path / "plane"))
+    tele = tmp_path / "tele.jsonl"
+    tele.write_text(
+        json.dumps({"event": "plane_complete", "parity_ok": True}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FLEET_COMMS_PLANE_TELEMETRY", str(tele))
+
+    rc = main(["plane-status"])
+    assert rc == EXIT_OK
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["mode"] == "shadow"
+    assert data["enabled"] is True
+    assert data["read_only"] is True
+    assert data["plane_root"] == str(tmp_path / "plane")
+    assert data["parity_telemetry"]["event_count"] == 1
+
+
+def test_plane_status_cli_root_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.delenv("FLEET_COMMS_MESSAGE_PLANE", raising=False)
+    monkeypatch.delenv("FLEET_COMMS_ROOT", raising=False)
+    root = tmp_path / "custom-root"
+    root.mkdir()
+    rc = main(["plane-status", "--root", str(root)])
+    assert rc == EXIT_OK
+    data = json.loads(capsys.readouterr().out)
+    assert data["mode"] == "off"
+    assert data["plane_root"] == str(root)
+
+
+def test_get_formal_review_job_helper(tmp_path: Path) -> None:
+    root = tmp_path / "plane"
+    _seed_plane_db(root)
+    job = get_formal_review_job("rev-abc", root=root)
+    assert job["review_id"] == "rev-abc"
+    assert job["pr_number"] == 5512
+    assert job["gate_kind"] == "cross-family-review"
+    assert len(job["attempts"]) == 1
+    assert job["attempts"][0]["review_attempt_id"] == "att-1"
+
+
+def test_formal_job_get_cli(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "plane"
+    _seed_plane_db(root)
+    rc = main(["formal-job", "get", "rev-abc", "--root", str(root)])
+    assert rc == EXIT_OK
+    data = json.loads(capsys.readouterr().out)
+    assert data["review_id"] == "rev-abc"
+    assert data["repository"] == "learn-ukrainian/learn-ukrainian.github.io"
+    assert data["attempts"][0]["completion_state"] == "incomplete"
+
+
+def test_formal_job_get_no_attempts(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "plane"
+    _seed_plane_db(root)
+    rc = main(["formal-job", "get", "rev-abc", "--root", str(root), "--no-attempts"])
+    assert rc == EXIT_OK
+    data = json.loads(capsys.readouterr().out)
+    assert data["attempts"] == []
+
+
+def test_formal_job_get_not_found(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "plane"
+    _seed_plane_db(root)
+    rc = main(["formal-job", "get", "missing", "--root", str(root)])
+    assert rc == EXIT_NOT_FOUND
+    err = capsys.readouterr().err
+    assert "not found" in err
+
+
+def test_formal_job_get_missing_db(tmp_path: Path, capsys) -> None:
+    rc = main(["formal-job", "get", "rev-abc", "--root", str(tmp_path / "empty")])
+    assert rc == EXIT_ERROR
+    assert "plane DB not found" in capsys.readouterr().err
+
+
+def test_get_formal_review_job_empty_id(tmp_path: Path) -> None:
+    with pytest.raises(FleetCommsCliError, match="review_id is required"):
+        get_formal_review_job("  ", root=tmp_path)


### PR DESCRIPTION
## Summary

Thin operator CLI for fleet-comms under #5512 (option B next slice after PR-E / B2 / plane-status / PR-G / H).

```bash
.venv/bin/python -m scripts.fleet_comms plane-status
.venv/bin/python -m scripts.fleet_comms formal-job get <review_id>
```

### What landed

- `scripts/fleet_comms/cli.py` + `__main__.py`
  - **plane-status** — dumps `read_plane_status` JSON (mode / schema / parity telemetry); same surface as Monitor `GET /api/comms/v1/plane-status`
  - **formal-job get** — read-only SQLite dump of `formal_review_jobs` (+ `formal_review_attempts`) by `review_id` from the plane DB (no PR-F service import; schema already on main)
- Unit tests: `tests/test_fleet_comms_cli.py` (8 cases)

### Explicit non-goals

- No Sol advisory
- No production cutover / no `review-pr` wiring
- No GitHub mutation / no formal-job writers (PR-F #5567 remains separate)
- No dual_write default flip

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_fleet_comms_cli.py -q`
- [x] `.venv/bin/ruff check` on touched files
- [x] `scripts/audit/lint_agent_trailer.py`
- [x] `git diff --check`

Related: #5512 · parent stream epic #4707