### PR TITLE
feat(fleet-comms): PR-G live verdict publisher + sealed CLI path (#5512)

### DIFF
--- a/scripts/ai_agent_bridge/_review_verdict.py
+++ b/scripts/ai_agent_bridge/_review_verdict.py
@@ -1,10 +1,18 @@
 """Publish a deliberately thin formal-review verdict to one GitHub PR comment.
 
-PR-G cutover note: the eventual ``publish-review-verdict --review-id`` path
-(sealed job reload, stale-head check, idempotent status/comment) is prepared in
-``scripts/fleet_comms/review_publication.py``. Full default cutover waits for
-PR-F formal-jobs table writers; this CLI remains the temporary file/flag-based
-poster and must not switch defaults until then.
+Two paths:
+
+1. **Legacy (temporary)** — ``--pr`` + ``--verdict-file``/``--findings-json`` + CLI
+   provenance flags. Posts a comment only (no commit status, no receipts).
+
+2. **PR-G sealed path** — ``--sealed-payload`` (JSON matching
+   ``scripts.fleet_comms.review_publication.SealedVerdict``). Optionally bind
+   ``--review-id`` to a durable formal-job row (identity check only; PR-F still
+   owns sealed-job writers). Posts thin comment + ``fleet/cross-family-review``
+   commit status, with stale-head / idempotent receipt handling.
+
+Full default cutover of all formal CF to ``--review-id`` alone waits for PR-F
+to store sealed verdict provenance on the job. Do not invent that as landed.
 """
 
 from __future__ import annotations
@@ -99,7 +107,7 @@ def publish_review_verdict(
     dry_run: bool = False,
     runner: Runner = subprocess.run,
 ) -> str:
-    """Post one comment and return a bounded, body-free orchestrator summary."""
+    """Legacy path: post one comment and return a bounded, body-free summary."""
     if pr <= 0:
         raise ReviewSafetyError(f"invalid_pr: {pr}")
     head = runner(
@@ -139,8 +147,112 @@ def publish_review_verdict(
     return summary
 
 
+def _handle_sealed_path(args: argparse.Namespace) -> int:
+    """PR-G sealed path: pure plan + optional GitHub mutate + receipts."""
+    from scripts.fleet_comms.artifacts import ArtifactStore
+    from scripts.fleet_comms.formal_review_jobs import (
+        FormalReviewJobsError,
+        FormalReviewJobService,
+    )
+    from scripts.fleet_comms.review_publisher import (
+        ReviewPublisherError,
+        load_sealed_payload_file,
+        publish_sealed_verdict,
+        sealed_matches_job,
+    )
+
+    payload_path = Path(args.sealed_payload)
+    try:
+        sealed = load_sealed_payload_file(payload_path)
+    except ReviewPublisherError as exc:
+        print(f"publish-review-verdict: {exc}", file=sys.stderr)
+        return 2
+
+    plane_root = Path(args.plane_root).expanduser() if args.plane_root else None
+    store: ArtifactStore | None = None
+    service: FormalReviewJobService | None = None
+
+    try:
+        if args.review_id:
+            # Bind sealed payload identity to durable job row (fail closed).
+            try:
+                service = FormalReviewJobService(root=plane_root)
+                job = service.get_job(args.review_id, include_attempts=False)
+            except FormalReviewJobsError as exc:
+                print(f"publish-review-verdict: {exc}", file=sys.stderr)
+                return 2
+            try:
+                sealed_matches_job(
+                    sealed,
+                    review_id=job.review_id,
+                    repository=job.repository,
+                    pr_number=job.pr_number,
+                    head_sha=job.head_sha,
+                    gate_kind=job.gate_kind,
+                )
+            except ReviewPublisherError as exc:
+                print(f"publish-review-verdict: {exc}", file=sys.stderr)
+                return 2
+            store = service.store
+        elif plane_root is not None or args.require_receipt:
+            store = ArtifactStore(root=plane_root)
+
+        result = publish_sealed_verdict(
+            sealed,
+            mutate=not args.dry_run,
+            require_receipt=bool(args.require_receipt),
+            store=store,
+        )
+    except ReviewPublisherError as exc:
+        print(f"publish-review-verdict: {exc}", file=sys.stderr)
+        return 2
+    finally:
+        if service is not None:
+            service.close()
+        elif store is not None:
+            store.close()
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        summary = result.summary
+        if len(summary.encode("utf-8")) > MAX_VERDICT_SUMMARY_BYTES:
+            print("publish-review-verdict: verdict_summary_exceeds_cap", file=sys.stderr)
+            return 2
+        print(summary)
+
+    # Non-zero when plan refused to publish (stale head) so orchestrators fail closed.
+    if result.plan.action == "refuse_stale":
+        return 3
+    return 0
+
+
 def handle_publish_review_verdict(args: argparse.Namespace) -> int:
     """CLI handler for ``publish-review-verdict``."""
+    if getattr(args, "sealed_payload", None):
+        return _handle_sealed_path(args)
+
+    # Legacy path: require CLI provenance flags.
+    missing = [
+        name
+        for name in ("pr", "model", "family", "harness")
+        if getattr(args, name, None) in (None, "")
+    ]
+    if missing:
+        print(
+            "publish-review-verdict: legacy path requires "
+            + ", ".join(f"--{m}" for m in missing)
+            + " (or use --sealed-payload)",
+            file=sys.stderr,
+        )
+        return 2
+    if not args.verdict_file and not args.findings_json:
+        print(
+            "publish-review-verdict: provide --verdict-file, --findings-json, or --sealed-payload",
+            file=sys.stderr,
+        )
+        return 2
+
     try:
         verdict = (
             verdict_from_findings_json(Path(args.findings_json))
@@ -149,7 +261,7 @@ def handle_publish_review_verdict(args: argparse.Namespace) -> int:
         )
         print(
             publish_review_verdict(
-                pr=args.pr,
+                pr=int(args.pr),
                 verdict=verdict,
                 model=args.model,
                 family=args.family,
@@ -166,13 +278,53 @@ def handle_publish_review_verdict(args: argparse.Namespace) -> int:
 def register_publish_review_verdict_parser(subparsers: Any) -> None:
     parser = subparsers.add_parser(
         "publish-review-verdict",
-        help="Post one thin formal-review verdict comment to a PR",
+        help=(
+            "Post one thin formal-review verdict (legacy file path, or PR-G "
+            "--sealed-payload with commit status + receipts)"
+        ),
     )
-    parser.add_argument("--pr", type=int, required=True, help="Pull request number")
     source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument("--verdict-file", help="Short text containing a VERDICT line")
-    source.add_argument("--findings-json", help="Findings JSON with a top-level verdict field")
-    parser.add_argument("--model", required=True, help="Exact reviewer model ID")
-    parser.add_argument("--family", required=True, help="Reviewer model family")
-    parser.add_argument("--harness", required=True, help="Reviewer harness")
-    parser.add_argument("--dry-run", action="store_true", help="Resolve head SHA without posting")
+    source.add_argument("--verdict-file", help="Short text containing a VERDICT line (legacy)")
+    source.add_argument(
+        "--findings-json",
+        help="Findings JSON with a top-level verdict field (legacy)",
+    )
+    source.add_argument(
+        "--sealed-payload",
+        help=(
+            "PR-G sealed verdict JSON (review_id, repository, pr_number, head_sha, "
+            "gate_kind, verdict, model, family, harness). Provenance is never taken "
+            "from CLI flags on this path."
+        ),
+    )
+    parser.add_argument(
+        "--review-id",
+        help=(
+            "Optional durable formal-job id to bind against --sealed-payload "
+            "(identity check + publication receipt). Job must already exist (PR-F)."
+        ),
+    )
+    parser.add_argument(
+        "--plane-root",
+        help="Fleet-comms ArtifactStore root for receipts / formal jobs (optional)",
+    )
+    parser.add_argument(
+        "--require-receipt",
+        action="store_true",
+        help="Refuse live sealed publish when no plane DB is available for receipts",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="On sealed path, emit full PublicationResult JSON",
+    )
+    # Legacy-only flags (optional at parse time; validated in handler).
+    parser.add_argument("--pr", type=int, help="Pull request number (legacy path)")
+    parser.add_argument("--model", help="Exact reviewer model ID (legacy path)")
+    parser.add_argument("--family", help="Reviewer model family (legacy path)")
+    parser.add_argument("--harness", help="Reviewer harness (legacy path)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan / resolve head without posting comment or commit status",
+    )

--- a/scripts/fleet_comms/review_publisher.py
+++ b/scripts/fleet_comms/review_publisher.py
@@ -1,0 +1,565 @@
+"""PR-G live verdict publisher: execute planned GitHub gate posts + receipts.
+
+Sol fleet-comms (#5512) PR-G owns the GitHub side of formal review publication:
+
+* resolve current PR head (fail closed on lookup failure)
+* plan via pure ``review_publication.plan_publication`` (stale / idempotent / ready)
+* when mutate is requested and the plan says ``publish``: post one thin PR comment
+  and one commit status under ``fleet/cross-family-review``
+* record a durable row in ``github_publications`` (schema v1)
+
+This module still does **not** create formal jobs, seal snapshots, or cut over
+``review-pr``. Those remain PR-F / later wiring. Callers that only have a sealed
+payload (not a stored job) can publish without a plane DB; receipt recording
+requires an open plane store.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import subprocess
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.fleet_comms.artifacts import ArtifactStore
+from scripts.fleet_comms.contracts import new_id
+from scripts.fleet_comms.migrations import apply_migrations
+from scripts.fleet_comms.review_publication import (
+    DEFAULT_STATUS_CONTEXT,
+    PublicationPlan,
+    ReviewPublicationError,
+    SealedVerdict,
+    parse_sealed_verdict_payload,
+    plan_publication,
+    publication_idempotency_key,
+)
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+_SHA_RE = re.compile(r"^[0-9a-f]{7,64}$", re.IGNORECASE)
+
+
+class ReviewPublisherError(RuntimeError):
+    """Live GitHub publication or receipt recording failed closed."""
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationResult:
+    """Outcome of planning and optionally executing a GitHub gate post."""
+
+    plan: PublicationPlan
+    publication_id: str | None
+    comment_url: str | None
+    status_posted: bool
+    summary: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "plan": self.plan.to_dict(),
+            "publication_id": self.publication_id,
+            "comment_url": self.comment_url,
+            "status_posted": self.status_posted,
+            "summary": self.summary,
+        }
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _single_line(value: str, *, label: str) -> str:
+    normalized = " ".join(value.split())
+    if not normalized:
+        raise ReviewPublisherError(f"missing_{label}")
+    return normalized
+
+
+def split_repository(repository: str) -> tuple[str, str]:
+    """Parse ``owner/repo``; refuse other shapes."""
+    text = _single_line(repository, label="repository")
+    if text.count("/") != 1:
+        raise ReviewPublisherError(
+            f"invalid_repository: expected owner/repo, got {repository!r}"
+        )
+    owner, repo = text.split("/", 1)
+    if not owner or not repo:
+        raise ReviewPublisherError(
+            f"invalid_repository: expected owner/repo, got {repository!r}"
+        )
+    return owner, repo
+
+
+def fetch_pr_head_sha(
+    *,
+    repository: str,
+    pr_number: int,
+    runner: Runner = subprocess.run,
+) -> str:
+    """Return the live PR head OID via ``gh`` (injectable for tests)."""
+    if pr_number <= 0:
+        raise ReviewPublisherError(f"invalid_pr: {pr_number}")
+    owner, repo = split_repository(repository)
+    completed = runner(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            f"{owner}/{repo}",
+            "--json",
+            "headRefOid",
+            "--jq",
+            ".headRefOid",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        raise ReviewPublisherError(
+            f"gh_pr_head_lookup_failed: pr={pr_number} repo={owner}/{repo} "
+            f"exit={completed.returncode}"
+            + (f" stderr={stderr[:200]}" if stderr else "")
+        )
+    head = _single_line(completed.stdout or "", label="head_sha")
+    if not _SHA_RE.match(head):
+        raise ReviewPublisherError(f"gh_pr_head_invalid: {head!r}")
+    return head.lower() if len(head) == 40 else head
+
+
+def post_pr_comment(
+    *,
+    repository: str,
+    pr_number: int,
+    body: str,
+    runner: Runner = subprocess.run,
+) -> str:
+    """Post one PR comment; return the comment URL when gh prints it."""
+    owner, repo = split_repository(repository)
+    completed = runner(
+        [
+            "gh",
+            "pr",
+            "comment",
+            str(pr_number),
+            "--repo",
+            f"{owner}/{repo}",
+            "--body",
+            body,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        raise ReviewPublisherError(
+            f"gh_pr_comment_failed: pr={pr_number} exit={completed.returncode}"
+            + (f" stderr={stderr[:200]}" if stderr else "")
+        )
+    return _single_line(completed.stdout or "(posted)", label="comment_url")
+
+
+def post_commit_status(
+    *,
+    repository: str,
+    head_sha: str,
+    state: str,
+    context: str,
+    description: str,
+    runner: Runner = subprocess.run,
+) -> None:
+    """Create a commit status on the exact reviewed SHA."""
+    owner, repo = split_repository(repository)
+    if state not in {"success", "failure", "error", "pending"}:
+        raise ReviewPublisherError(f"invalid_status_state: {state!r}")
+    completed = runner(
+        [
+            "gh",
+            "api",
+            f"repos/{owner}/{repo}/statuses/{head_sha}",
+            "-f",
+            f"state={state}",
+            "-f",
+            f"context={context}",
+            "-f",
+            f"description={description[:140]}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        raise ReviewPublisherError(
+            f"gh_commit_status_failed: sha={head_sha} state={state} "
+            f"exit={completed.returncode}"
+            + (f" stderr={stderr[:200]}" if stderr else "")
+        )
+
+
+def lookup_publication_receipt(
+    conn: sqlite3.Connection,
+    *,
+    review_id: str,
+    status_context: str = DEFAULT_STATUS_CONTEXT,
+) -> dict[str, Any] | None:
+    """Return the durable publication row when one already exists."""
+    rid = _single_line(review_id, label="review_id")
+    ctx = _single_line(status_context, label="status_context")
+    row = conn.execute(
+        """SELECT publication_id, review_id, head_sha, status_context, published_at
+           FROM github_publications
+           WHERE review_id = ? AND status_context = ?""",
+        (rid, ctx),
+    ).fetchone()
+    if row is None:
+        return None
+    if isinstance(row, sqlite3.Row):
+        return dict(row)
+    keys = ("publication_id", "review_id", "head_sha", "status_context", "published_at")
+    return dict(zip(keys, row, strict=True))
+
+
+def record_publication_receipt(
+    conn: sqlite3.Connection,
+    *,
+    review_id: str,
+    head_sha: str,
+    status_context: str = DEFAULT_STATUS_CONTEXT,
+    publication_id: str | None = None,
+) -> str:
+    """Insert one ``github_publications`` row; refuse duplicates."""
+    rid = _single_line(review_id, label="review_id")
+    sha = _single_line(head_sha, label="head_sha").lower()
+    ctx = _single_line(status_context, label="status_context")
+    existing = lookup_publication_receipt(conn, review_id=rid, status_context=ctx)
+    if existing is not None:
+        return str(existing["publication_id"])
+    pid = publication_id or new_id("publication")
+    try:
+        conn.execute(
+            """INSERT INTO github_publications(
+                publication_id, review_id, head_sha, status_context, published_at
+            ) VALUES (?, ?, ?, ?, ?)""",
+            (pid, rid, sha, ctx, _utc_now()),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError as exc:
+        conn.rollback()
+        raced = lookup_publication_receipt(conn, review_id=rid, status_context=ctx)
+        if raced is not None:
+            return str(raced["publication_id"])
+        raise ReviewPublisherError(
+            f"failed to record publication receipt for {rid}: {exc}"
+        ) from exc
+    return pid
+
+
+def already_published_key_for_job(
+    conn: sqlite3.Connection,
+    sealed: SealedVerdict,
+    *,
+    status_context: str = DEFAULT_STATUS_CONTEXT,
+) -> str | None:
+    """If a receipt exists for this review, return the pure-module idempotency key."""
+    receipt = lookup_publication_receipt(
+        conn, review_id=sealed.review_id, status_context=status_context
+    )
+    if receipt is None:
+        return None
+    # Receipt proves one effective post for this review_id+context.
+    return publication_idempotency_key(
+        repository=sealed.repository,
+        pr_number=sealed.pr_number,
+        head_sha=sealed.head_sha,
+        gate_kind=sealed.gate_kind,
+    )
+
+
+def _summary_for(plan: PublicationPlan, *, posted: bool, publication_id: str | None) -> str:
+    parts = [
+        f"publish-review-verdict: action={plan.action}",
+        f"review_id={plan.review_id}",
+        f"pr={plan.pr_number}",
+        f"verdict={plan.verdict}",
+        f"head_sha={plan.head_sha}",
+        f"status_context={plan.status_context}",
+        f"status_state={plan.status_state or 'none'}",
+        f"posted={'true' if posted else 'false'}",
+        f"reason={plan.reason}",
+    ]
+    if publication_id:
+        parts.append(f"publication_id={publication_id}")
+    return " ".join(parts)
+
+
+def execute_publication(
+    plan: PublicationPlan,
+    *,
+    runner: Runner = subprocess.run,
+    conn: sqlite3.Connection | None = None,
+    require_receipt: bool = False,
+) -> PublicationResult:
+    """Execute a planned publication (or no-op for refuse/skip/dry-run).
+
+    Parameters
+    ----------
+    plan:
+        Output of ``plan_publication`` (never talks to GitHub itself).
+    runner:
+        Injectable subprocess runner (``gh`` CLI).
+    conn:
+        Optional plane SQLite connection for ``github_publications`` receipts.
+    require_receipt:
+        When True and mutate publishes, refuse if ``conn`` is missing so we never
+        post without a durable receipt path.
+    """
+    if plan.action in {"refuse_stale", "skip_idempotent"}:
+        return PublicationResult(
+            plan=plan,
+            publication_id=None,
+            comment_url=None,
+            status_posted=False,
+            summary=_summary_for(plan, posted=False, publication_id=None),
+        )
+
+    if plan.action != "publish":
+        raise ReviewPublisherError(f"unsupported_plan_action: {plan.action!r}")
+
+    if not plan.mutate:
+        return PublicationResult(
+            plan=plan,
+            publication_id=None,
+            comment_url=None,
+            status_posted=False,
+            summary=_summary_for(plan, posted=False, publication_id=None),
+        )
+
+    if plan.comment_body is None or plan.status_state is None:
+        raise ReviewPublisherError("publish_plan_incomplete: missing comment or status")
+
+    if require_receipt and conn is None:
+        raise ReviewPublisherError(
+            "receipt_required: refuse live publish without plane DB connection"
+        )
+
+    comment_url = post_pr_comment(
+        repository=plan.repository,
+        pr_number=plan.pr_number,
+        body=plan.comment_body,
+        runner=runner,
+    )
+    description = f"VERDICT: {plan.verdict} review_id={plan.review_id}"
+    post_commit_status(
+        repository=plan.repository,
+        head_sha=plan.head_sha,
+        state=plan.status_state,
+        context=plan.status_context,
+        description=description,
+        runner=runner,
+    )
+
+    publication_id: str | None = None
+    if conn is not None:
+        publication_id = record_publication_receipt(
+            conn,
+            review_id=plan.review_id,
+            head_sha=plan.head_sha,
+            status_context=plan.status_context,
+        )
+
+    return PublicationResult(
+        plan=plan,
+        publication_id=publication_id,
+        comment_url=comment_url,
+        status_posted=True,
+        summary=_summary_for(plan, posted=True, publication_id=publication_id),
+    )
+
+
+def ensure_job_row_for_receipt(
+    store: ArtifactStore,
+    sealed: SealedVerdict,
+) -> None:
+    """Ensure ``formal_review_jobs`` has a row so ``github_publications`` FK can fire.
+
+    PR-F owns full sealed-job lifecycle. PR-G only materializes the unique key
+    row when the sealed payload is already authoritative and a receipt is about
+    to be written — never invents a different review_id/head.
+    """
+    from scripts.fleet_comms.formal_review_jobs import (
+        FormalReviewJobsError,
+        FormalReviewJobService,
+    )
+
+    apply_migrations(store.connection)
+    # Do not close the service: it shares the caller's ArtifactStore connection.
+    service = FormalReviewJobService(store=store)
+    existing = service.find_job(
+        sealed.repository,
+        sealed.pr_number,
+        sealed.head_sha,
+        sealed.gate_kind,
+    )
+    if existing is not None:
+        if existing.review_id != sealed.review_id:
+            raise ReviewPublisherError(
+                "formal_job_review_id_mismatch: "
+                f"job={existing.review_id!r} sealed={sealed.review_id!r}"
+            )
+        return
+    by_id = None
+    try:
+        by_id = service.get_job(sealed.review_id, include_attempts=False)
+    except FormalReviewJobsError:
+        by_id = None
+    if by_id is not None:
+        sealed_matches_job(
+            sealed,
+            review_id=by_id.review_id,
+            repository=by_id.repository,
+            pr_number=by_id.pr_number,
+            head_sha=by_id.head_sha,
+            gate_kind=by_id.gate_kind,
+        )
+        return
+    service.create_job(
+        sealed.repository,
+        sealed.pr_number,
+        sealed.head_sha,
+        sealed.gate_kind,
+        review_id=sealed.review_id,
+        state="complete",
+    )
+
+
+def publish_sealed_verdict(
+    sealed: SealedVerdict | Mapping[str, Any] | str | bytes | Path,
+    *,
+    current_head_sha: str | None = None,
+    mutate: bool = False,
+    runner: Runner = subprocess.run,
+    store: ArtifactStore | None = None,
+    require_receipt: bool = False,
+    status_context: str = DEFAULT_STATUS_CONTEXT,
+) -> PublicationResult:
+    """End-to-end sealed path: parse → head check → plan → optional execute.
+
+    When ``current_head_sha`` is omitted, the live PR head is fetched via ``gh``.
+    When ``store`` is provided, receipts are written to its SQLite connection.
+    """
+    if isinstance(sealed, Path):
+        sealed = sealed.read_text(encoding="utf-8")
+    if not isinstance(sealed, SealedVerdict):
+        sealed = parse_sealed_verdict_payload(sealed)
+
+    head = current_head_sha
+    if head is None:
+        head = fetch_pr_head_sha(
+            repository=sealed.repository,
+            pr_number=sealed.pr_number,
+            runner=runner,
+        )
+
+    conn: sqlite3.Connection | None = None
+    already_key: str | None = None
+    if store is not None:
+        conn = store.connection
+        apply_migrations(conn)
+        if mutate:
+            # Materialize FK parent before any GitHub post when receipts are on.
+            ensure_job_row_for_receipt(store, sealed)
+        already_key = already_published_key_for_job(
+            conn, sealed, status_context=status_context
+        )
+
+    plan = plan_publication(
+        sealed,
+        current_head_sha=head,
+        already_published_key=already_key,
+        mutate=mutate,
+        status_context=status_context,
+    )
+    return execute_publication(
+        plan,
+        runner=runner,
+        conn=conn,
+        require_receipt=require_receipt,
+    )
+
+
+def load_sealed_payload_file(path: Path) -> SealedVerdict:
+    """Load and validate a sealed verdict JSON file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ReviewPublisherError(f"sealed_payload_unreadable: {path}") from exc
+    try:
+        return parse_sealed_verdict_payload(text)
+    except ReviewPublicationError as exc:
+        raise ReviewPublisherError(str(exc)) from exc
+
+
+def sealed_matches_job(
+    sealed: SealedVerdict,
+    *,
+    review_id: str,
+    repository: str,
+    pr_number: int,
+    head_sha: str,
+    gate_kind: str,
+) -> None:
+    """Fail closed when sealed payload does not match the durable job row."""
+    if sealed.review_id != review_id:
+        raise ReviewPublisherError(
+            f"sealed_job_mismatch: review_id sealed={sealed.review_id!r} job={review_id!r}"
+        )
+    if sealed.repository != repository:
+        raise ReviewPublisherError(
+            f"sealed_job_mismatch: repository sealed={sealed.repository!r} job={repository!r}"
+        )
+    if sealed.pr_number != pr_number:
+        raise ReviewPublisherError(
+            f"sealed_job_mismatch: pr sealed={sealed.pr_number} job={pr_number}"
+        )
+    if sealed.head_sha.lower() != head_sha.lower():
+        raise ReviewPublisherError(
+            f"sealed_job_mismatch: head_sha sealed={sealed.head_sha!r} job={head_sha!r}"
+        )
+    if sealed.gate_kind != gate_kind:
+        raise ReviewPublisherError(
+            f"sealed_job_mismatch: gate_kind sealed={sealed.gate_kind!r} job={gate_kind!r}"
+        )
+
+
+def dump_plan_json(result: PublicationResult) -> str:
+    """JSON dump for CLI dry-run inspection."""
+    return json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n"
+
+
+__all__ = [
+    "PublicationResult",
+    "ReviewPublisherError",
+    "Runner",
+    "already_published_key_for_job",
+    "dump_plan_json",
+    "ensure_job_row_for_receipt",
+    "execute_publication",
+    "fetch_pr_head_sha",
+    "load_sealed_payload_file",
+    "lookup_publication_receipt",
+    "post_commit_status",
+    "post_pr_comment",
+    "publish_sealed_verdict",
+    "record_publication_receipt",
+    "sealed_matches_job",
+    "split_repository",
+]

--- a/scripts/fleet_comms/review_publisher.py
+++ b/scripts/fleet_comms/review_publisher.py
@@ -8,10 +8,13 @@ Sol fleet-comms (#5512) PR-G owns the GitHub side of formal review publication:
   and one commit status under ``fleet/cross-family-review``
 * record a durable row in ``github_publications`` (schema v1)
 
-This module still does **not** create formal jobs, seal snapshots, or cut over
-``review-pr``. Those remain PR-F / later wiring. Callers that only have a sealed
-payload (not a stored job) can publish without a plane DB; receipt recording
-requires an open plane store.
+**Formal-job boundary (honest):** when a plane store is used and the plan is a
+live ``publish``, this module may **materialize the FK-parent**
+``formal_review_jobs`` row from sealed-payload identity fields only (so
+``github_publications.review_id`` can satisfy the schema FK). That is *not* a
+PR-F seal cutover: PR-F still owns attempts, snapshot sealing, reviewer
+resolution, lifecycle transitions, and ``review-pr`` wiring. This module does
+not seal snapshots and does not cut over ``review-pr``.
 """
 
 from __future__ import annotations
@@ -474,9 +477,6 @@ def publish_sealed_verdict(
     if store is not None:
         conn = store.connection
         apply_migrations(conn)
-        if mutate:
-            # Materialize FK parent before any GitHub post when receipts are on.
-            ensure_job_row_for_receipt(store, sealed)
         already_key = already_published_key_for_job(
             conn, sealed, status_context=status_context
         )
@@ -488,6 +488,13 @@ def publish_sealed_verdict(
         mutate=mutate,
         status_context=status_context,
     )
+    # Materialize FK parent only when we are about to post (not on stale/skip/dry-run).
+    if (
+        store is not None
+        and plan.action == "publish"
+        and plan.mutate
+    ):
+        ensure_job_row_for_receipt(store, sealed)
     return execute_publication(
         plan,
         runner=runner,

--- a/tests/test_fleet_comms_review_publisher.py
+++ b/tests/test_fleet_comms_review_publisher.py
@@ -1,0 +1,225 @@
+"""Fake-GitHub tests for Fleet Comms PR-G live publisher (#5512)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.fleet_comms.artifacts import ArtifactStore
+from scripts.fleet_comms.review_publication import (
+    DEFAULT_STATUS_CONTEXT,
+    STATUS_ERROR,
+    STATUS_FAILURE,
+    STATUS_SUCCESS,
+    plan_publication,
+)
+from scripts.fleet_comms.review_publisher import (
+    ReviewPublisherError,
+    execute_publication,
+    fetch_pr_head_sha,
+    lookup_publication_receipt,
+    publish_sealed_verdict,
+    sealed_matches_job,
+)
+
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+_REPO = "learn-ukrainian/learn-ukrainian.github.io"
+
+
+def _sealed(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "review_id": "review_deadbeef",
+        "repository": _REPO,
+        "pr_number": 5512,
+        "head_sha": _SHA_A,
+        "gate_kind": "cross-family-review",
+        "verdict": "APPROVED",
+        "model": "claude-opus-4-6",
+        "family": "anthropic",
+        "harness": "claude",
+    }
+    base.update(overrides)
+    return base
+
+
+class FakeGh:
+    """Records gh invocations and returns scripted responses."""
+
+    def __init__(self, *, head: str = _SHA_A) -> None:
+        self.head = head
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self, command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(command))
+        if len(command) >= 3 and command[1] == "pr" and command[2] == "view":
+            return subprocess.CompletedProcess(command, 0, stdout=f"{self.head}\n", stderr="")
+        if len(command) >= 3 and command[1] == "pr" and command[2] == "comment":
+            return subprocess.CompletedProcess(
+                command, 0, stdout="https://example.test/comment/1\n", stderr=""
+            )
+        if len(command) >= 2 and command[1] == "api" and "statuses" in command[2]:
+            return subprocess.CompletedProcess(command, 0, stdout="{}", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected")
+
+
+def test_fetch_pr_head_sha_uses_repo_flag() -> None:
+    gh = FakeGh(head=_SHA_A)
+    assert fetch_pr_head_sha(repository=_REPO, pr_number=12, runner=gh) == _SHA_A
+    assert "--repo" in gh.calls[0]
+    assert _REPO in gh.calls[0]
+
+
+@pytest.mark.parametrize(
+    ("verdict", "status"),
+    [
+        ("APPROVED", STATUS_SUCCESS),
+        ("CHANGES_REQUESTED", STATUS_FAILURE),
+        ("BLOCKED", STATUS_ERROR),
+    ],
+)
+def test_publish_matrix_posts_comment_and_status(
+    tmp_path: Path, verdict: str, status: str
+) -> None:
+    gh = FakeGh(head=_SHA_A)
+    with ArtifactStore(root=tmp_path / "plane") as store:
+        result = publish_sealed_verdict(
+            _sealed(verdict=verdict),
+            current_head_sha=_SHA_A,
+            mutate=True,
+            runner=gh,
+            store=store,
+            require_receipt=True,
+        )
+    assert result.plan.action == "publish"
+    assert result.plan.status_state == status
+    assert result.status_posted is True
+    assert result.publication_id is not None
+    assert result.comment_url == "https://example.test/comment/1"
+    # view may be skipped when current_head_sha provided; comment + status required
+    kinds = [c[1] for c in gh.calls]
+    assert "pr" in kinds
+    assert "api" in kinds
+    comment_calls = [c for c in gh.calls if c[1:3] == ["pr", "comment"]]
+    assert len(comment_calls) == 1
+    body = comment_calls[0][comment_calls[0].index("--body") + 1]
+    assert f"VERDICT: {verdict}" in body
+    assert "findings" not in body.lower()
+    status_calls = [c for c in gh.calls if c[1] == "api"]
+    assert any(f"state={status}" in " ".join(c) for c in status_calls)
+    assert any(DEFAULT_STATUS_CONTEXT in " ".join(c) for c in status_calls)
+
+
+def test_stale_head_refuses_without_github_mutation(tmp_path: Path) -> None:
+    gh = FakeGh(head=_SHA_B)
+    with ArtifactStore(root=tmp_path / "plane") as store:
+        result = publish_sealed_verdict(
+            _sealed(),
+            current_head_sha=_SHA_B,
+            mutate=True,
+            runner=gh,
+            store=store,
+        )
+    assert result.plan.action == "refuse_stale"
+    assert result.status_posted is False
+    assert result.publication_id is None
+    assert gh.calls == []
+
+
+def test_repeat_publish_is_idempotent(tmp_path: Path) -> None:
+    gh = FakeGh(head=_SHA_A)
+    root = tmp_path / "plane"
+    with ArtifactStore(root=root) as store:
+        first = publish_sealed_verdict(
+            _sealed(),
+            current_head_sha=_SHA_A,
+            mutate=True,
+            runner=gh,
+            store=store,
+            require_receipt=True,
+        )
+        assert first.status_posted is True
+        receipt = lookup_publication_receipt(
+            store.connection, review_id="review_deadbeef"
+        )
+        assert receipt is not None
+
+    gh2 = FakeGh(head=_SHA_A)
+    with ArtifactStore(root=root) as store:
+        second = publish_sealed_verdict(
+            _sealed(),
+            current_head_sha=_SHA_A,
+            mutate=True,
+            runner=gh2,
+            store=store,
+            require_receipt=True,
+        )
+    assert second.plan.action == "skip_idempotent"
+    assert second.status_posted is False
+    assert gh2.calls == []
+
+
+def test_dry_run_never_posts(tmp_path: Path) -> None:
+    gh = FakeGh(head=_SHA_A)
+    with ArtifactStore(root=tmp_path / "plane") as store:
+        result = publish_sealed_verdict(
+            _sealed(),
+            current_head_sha=_SHA_A,
+            mutate=False,
+            runner=gh,
+            store=store,
+        )
+    assert result.plan.action == "publish"
+    assert result.plan.mutate is False
+    assert result.status_posted is False
+    assert gh.calls == []
+
+
+def test_require_receipt_without_conn_refuses_live() -> None:
+    sealed = _sealed()
+    plan = plan_publication(
+        __import__(
+            "scripts.fleet_comms.review_publication", fromlist=["parse_sealed_verdict_payload"]
+        ).parse_sealed_verdict_payload(sealed),
+        current_head_sha=_SHA_A,
+        mutate=True,
+    )
+    with pytest.raises(ReviewPublisherError, match="receipt_required"):
+        execute_publication(plan, runner=FakeGh(), conn=None, require_receipt=True)
+
+
+def test_sealed_matches_job_fail_closed() -> None:
+    from scripts.fleet_comms.review_publication import parse_sealed_verdict_payload
+
+    sealed = parse_sealed_verdict_payload(_sealed())
+    with pytest.raises(ReviewPublisherError, match="sealed_job_mismatch"):
+        sealed_matches_job(
+            sealed,
+            review_id="review_other",
+            repository=_REPO,
+            pr_number=5512,
+            head_sha=_SHA_A,
+            gate_kind="cross-family-review",
+        )
+
+
+def test_sealed_payload_file_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "sealed.json"
+    path.write_text(json.dumps(_sealed(verdict="BLOCKED")), encoding="utf-8")
+    gh = FakeGh(head=_SHA_A)
+    with ArtifactStore(root=tmp_path / "plane") as store:
+        result = publish_sealed_verdict(
+            path,
+            current_head_sha=_SHA_A,
+            mutate=True,
+            runner=gh,
+            store=store,
+        )
+    assert result.plan.verdict == "BLOCKED"
+    assert result.plan.status_state == STATUS_ERROR
+    assert result.status_posted is True

--- a/tests/test_fleet_comms_review_publisher.py
+++ b/tests/test_fleet_comms_review_publisher.py
@@ -125,10 +125,19 @@ def test_stale_head_refuses_without_github_mutation(tmp_path: Path) -> None:
             runner=gh,
             store=store,
         )
+        # Stale path must not materialize formal_review_jobs or publications.
+        jobs = store.connection.execute(
+            "SELECT COUNT(*) FROM formal_review_jobs"
+        ).fetchone()[0]
+        pubs = store.connection.execute(
+            "SELECT COUNT(*) FROM github_publications"
+        ).fetchone()[0]
     assert result.plan.action == "refuse_stale"
     assert result.status_posted is False
     assert result.publication_id is None
     assert gh.calls == []
+    assert jobs == 0
+    assert pubs == 0
 
 
 def test_repeat_publish_is_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Sol fleet-comms **PR-G** live publisher: execute planned thin PR comment + `fleet/cross-family-review` commit status, with stale-head refuse and idempotent `github_publications` receipts.
- Bridge CLI: `publish-review-verdict --sealed-payload` (optional `--review-id` bind, `--plane-root`, `--require-receipt`, `--json`). Provenance comes from sealed JSON only on this path.
- Legacy `--verdict-file` / `--findings-json` + CLI model/family/harness path unchanged (comment-only temporary poster).
- Does **not** cut over `review-pr` or claim PR-F sealed-job writers complete.

## Parent
- Stream epic #4707 · product #5512 · depends on pure helpers #5566 + formal-job skeleton #5567 (both on main).

## Test plan
- [x] `PYTHONPATH=scripts .venv/bin/python -m pytest tests/test_fleet_comms_review_publisher.py tests/test_fleet_comms_review_publication.py tests/ai_agent_bridge/test_review_verdict.py -q` (52 passed)
- [x] Fake-GitHub matrix: APPROVED / CHANGES_REQUESTED / BLOCKED + stale + idempotent + dry-run
- [ ] CI green
- [ ] Independent cross-family review (not Grok)