### PR TITLE
feat(fleet-comms): PR-F sealed verdict accept/load + --review-id publish (#5512)

### DIFF
--- a/scripts/ai_agent_bridge/_review_verdict.py
+++ b/scripts/ai_agent_bridge/_review_verdict.py
@@ -147,6 +147,48 @@ def publish_review_verdict(
     return summary
 
 
+def _emit_publication_result(args: argparse.Namespace, result: Any) -> int:
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        summary = result.summary
+        if len(summary.encode("utf-8")) > MAX_VERDICT_SUMMARY_BYTES:
+            print("publish-review-verdict: verdict_summary_exceeds_cap", file=sys.stderr)
+            return 2
+        print(summary)
+    if result.plan.action == "refuse_stale":
+        return 3
+    return 0
+
+
+def _handle_review_id_only(args: argparse.Namespace) -> int:
+    """PR-F+G path: load sealed verdict from durable job; no CLI provenance."""
+    from scripts.fleet_comms.formal_review_jobs import (
+        FormalReviewJobsError,
+        FormalReviewJobService,
+    )
+    from scripts.fleet_comms.review_publisher import (
+        ReviewPublisherError,
+        publish_sealed_verdict,
+    )
+
+    plane_root = Path(args.plane_root).expanduser() if args.plane_root else None
+    try:
+        with FormalReviewJobService(root=plane_root) as service:
+            sealed = service.load_sealed_verdict(args.review_id)
+            result = publish_sealed_verdict(
+                sealed,
+                mutate=not args.dry_run,
+                # Formal --review-id path always records github_publications receipts.
+                require_receipt=True,
+                store=service.store,
+            )
+    except (FormalReviewJobsError, ReviewPublisherError) as exc:
+        print(f"publish-review-verdict: {exc}", file=sys.stderr)
+        return 2
+    return _emit_publication_result(args, result)
+
+
 def _handle_sealed_path(args: argparse.Namespace) -> int:
     """PR-G sealed path: pure plan + optional GitHub mutate + receipts."""
     from scripts.fleet_comms.artifacts import ArtifactStore
@@ -193,6 +235,16 @@ def _handle_sealed_path(args: argparse.Namespace) -> int:
             except ReviewPublisherError as exc:
                 print(f"publish-review-verdict: {exc}", file=sys.stderr)
                 return 2
+            # Persist sealed verdict if not already (enables future --review-id alone).
+            try:
+                service.accept_sealed_verdict(
+                    job.review_id,
+                    sealed,
+                    record_complete_attempt=not job.has_sealed_verdict,
+                )
+            except FormalReviewJobsError as exc:
+                print(f"publish-review-verdict: {exc}", file=sys.stderr)
+                return 2
             store = service.store
         elif plane_root is not None or args.require_receipt:
             store = ArtifactStore(root=plane_root)
@@ -212,24 +264,18 @@ def _handle_sealed_path(args: argparse.Namespace) -> int:
         elif store is not None:
             store.close()
 
-    if args.json:
-        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
-    else:
-        summary = result.summary
-        if len(summary.encode("utf-8")) > MAX_VERDICT_SUMMARY_BYTES:
-            print("publish-review-verdict: verdict_summary_exceeds_cap", file=sys.stderr)
-            return 2
-        print(summary)
-
-    # Non-zero when plan refused to publish (stale head) so orchestrators fail closed.
-    if result.plan.action == "refuse_stale":
-        return 3
-    return 0
+    return _emit_publication_result(args, result)
 
 
 def handle_publish_review_verdict(args: argparse.Namespace) -> int:
     """CLI handler for ``publish-review-verdict``."""
-    if getattr(args, "sealed_payload", None):
+    has_legacy_file = bool(getattr(args, "verdict_file", None) or getattr(args, "findings_json", None))
+    has_sealed_file = bool(getattr(args, "sealed_payload", None))
+    has_review_id = bool(getattr(args, "review_id", None))
+
+    if has_review_id and not has_sealed_file and not has_legacy_file:
+        return _handle_review_id_only(args)
+    if has_sealed_file:
         return _handle_sealed_path(args)
 
     # Legacy path: require CLI provenance flags.
@@ -242,13 +288,14 @@ def handle_publish_review_verdict(args: argparse.Namespace) -> int:
         print(
             "publish-review-verdict: legacy path requires "
             + ", ".join(f"--{m}" for m in missing)
-            + " (or use --sealed-payload)",
+            + " (or use --sealed-payload / --review-id)",
             file=sys.stderr,
         )
         return 2
-    if not args.verdict_file and not args.findings_json:
+    if not has_legacy_file:
         print(
-            "publish-review-verdict: provide --verdict-file, --findings-json, or --sealed-payload",
+            "publish-review-verdict: provide --verdict-file, --findings-json, "
+            "--sealed-payload, or --review-id",
             file=sys.stderr,
         )
         return 2
@@ -279,11 +326,11 @@ def register_publish_review_verdict_parser(subparsers: Any) -> None:
     parser = subparsers.add_parser(
         "publish-review-verdict",
         help=(
-            "Post one thin formal-review verdict (legacy file path, or PR-G "
-            "--sealed-payload with commit status + receipts)"
+            "Post one thin formal-review verdict (legacy file path, "
+            "--sealed-payload, or --review-id alone after PR-F accept)"
         ),
     )
-    source = parser.add_mutually_exclusive_group(required=True)
+    source = parser.add_mutually_exclusive_group(required=False)
     source.add_argument("--verdict-file", help="Short text containing a VERDICT line (legacy)")
     source.add_argument(
         "--findings-json",
@@ -300,8 +347,8 @@ def register_publish_review_verdict_parser(subparsers: Any) -> None:
     parser.add_argument(
         "--review-id",
         help=(
-            "Optional durable formal-job id to bind against --sealed-payload "
-            "(identity check + publication receipt). Job must already exist (PR-F)."
+            "PR-F durable formal-job id. Alone: reload sealed verdict from the job "
+            "and publish (no CLI provenance). With --sealed-payload: bind + accept."
         ),
     )
     parser.add_argument(

--- a/scripts/fleet_comms/formal_review_jobs.py
+++ b/scripts/fleet_comms/formal_review_jobs.py
@@ -1,18 +1,25 @@
-"""Formal review job skeleton (Fleet Comms Sol PR-F first slice / #5512).
+"""Formal review jobs (Fleet Comms Sol PR-F / #5512).
 
 Durable SQLite usage of ``formal_review_jobs`` / ``formal_review_attempts``
 (schema from fleet_comms migrations). Unique key (one job per head; attempts accumulate):
 
     (repository, pr_number, head_sha, gate_kind)
 
-Concurrent duplicate creates are rejected. This module does **not** cut over
-``review-pr``, seal snapshots, resolve reviewers, validate verdicts, or publish
-to GitHub (those are later PR-F / PR-G slices).
+Concurrent duplicate creates are rejected.
+
+PR-F slice 2 (sealed verdict acceptance): store a content-addressed sealed
+verdict payload on the job so PR-G can publish with
+``publish-review-verdict --review-id`` alone (no CLI-supplied provenance).
+
+This module still does **not** cut over ``review-pr``, create reviewer-neutral
+snapshots, or resolve reviewers (later PR-F slices / Terra ownership).
 """
 
 from __future__ import annotations
 
+import json
 import sqlite3
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -21,8 +28,12 @@ from typing import Any
 from scripts.fleet_comms.artifacts import ArtifactStore
 from scripts.fleet_comms.contracts import CompletionState, new_id
 from scripts.fleet_comms.migrations import apply_migrations
+from scripts.fleet_comms.review_publication import (
+    ReviewPublicationError,
+    SealedVerdict,
+    parse_sealed_verdict_payload,
+)
 
-# Job lifecycle for this skeleton. Publication / sealed verdict acceptance land later.
 JOB_STATES = frozenset({"open", "running", "complete", "failed", "blocked"})
 ACTIVE_JOB_STATES = frozenset({"open", "running"})
 
@@ -73,12 +84,17 @@ class FormalReviewJob:
     gate_kind: str
     state: str
     snapshot_artifact_id: str | None
+    sealed_verdict_artifact_id: str | None
     created_at: str
     attempts: tuple[FormalReviewAttempt, ...] = field(default_factory=tuple)
 
     @property
     def unique_key(self) -> tuple[str, int, str, str]:
         return (self.repository, self.pr_number, self.head_sha, self.gate_kind)
+
+    @property
+    def has_sealed_verdict(self) -> bool:
+        return self.sealed_verdict_artifact_id is not None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -89,6 +105,7 @@ class FormalReviewJob:
             "gate_kind": self.gate_kind,
             "state": self.state,
             "snapshot_artifact_id": self.snapshot_artifact_id,
+            "sealed_verdict_artifact_id": self.sealed_verdict_artifact_id,
             "created_at": self.created_at,
             "attempts": [attempt.to_dict() for attempt in self.attempts],
         }
@@ -251,6 +268,126 @@ class FormalReviewJobService:
             created_at=created,
         )
 
+    def accept_sealed_verdict(
+        self,
+        review_id: str,
+        sealed: SealedVerdict | Mapping[str, Any] | str | bytes,
+        *,
+        record_complete_attempt: bool = True,
+        raw_capture_artifact_id: str | None = None,
+    ) -> SealedVerdict:
+        """Accept a schema-valid sealed verdict and bind it to the job (fail closed).
+
+        Provenance (model/family/harness/verdict) is taken **only** from the
+        sealed payload. The payload's repository/pr/head/gate/review_id must
+        match the durable job row exactly.
+        """
+        job = self.get_job(review_id, include_attempts=False)
+        try:
+            if not isinstance(sealed, SealedVerdict):
+                sealed = parse_sealed_verdict_payload(sealed)
+        except ReviewPublicationError as exc:
+            raise FormalReviewJobsError(f"sealed_verdict_invalid: {exc}") from exc
+
+        if sealed.review_id != job.review_id:
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: review_id sealed={sealed.review_id!r} "
+                f"job={job.review_id!r}"
+            )
+        if sealed.repository != job.repository:
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: repository sealed={sealed.repository!r} "
+                f"job={job.repository!r}"
+            )
+        if sealed.pr_number != job.pr_number:
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: pr sealed={sealed.pr_number} job={job.pr_number}"
+            )
+        if sealed.head_sha.lower() != job.head_sha.lower():
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: head_sha sealed={sealed.head_sha!r} "
+                f"job={job.head_sha!r}"
+            )
+        if sealed.gate_kind != job.gate_kind:
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: gate_kind sealed={sealed.gate_kind!r} "
+                f"job={job.gate_kind!r}"
+            )
+
+        if job.sealed_verdict_artifact_id is not None:
+            # Idempotent re-accept of identical payload only.
+            existing = self.load_sealed_verdict(job.review_id)
+            if existing.to_dict() != sealed.to_dict():
+                raise FormalReviewJobsError(
+                    f"sealed_verdict_already_set: job {job.review_id} already holds a "
+                    "different sealed verdict; refuse overwrite"
+                )
+            return existing
+
+        payload = json.dumps(sealed.to_dict(), sort_keys=True, separators=(",", ":"))
+        artifact = self.store.store_text(
+            payload,
+            producer="formal-review-jobs",
+            retention_class="sealed-verdict",
+            logical_filename=f"{job.review_id}.sealed-verdict.json",
+            mime_type="application/json; charset=utf-8",
+        )
+        try:
+            self._conn.execute(
+                """UPDATE formal_review_jobs
+                   SET sealed_verdict_artifact_id = ?, state = ?
+                   WHERE review_id = ?""",
+                (artifact.artifact_id, "complete", job.review_id),
+            )
+            self._conn.commit()
+        except sqlite3.Error as exc:
+            self._conn.rollback()
+            raise FormalReviewJobsError(
+                f"failed to bind sealed verdict for {job.review_id}: {exc}"
+            ) from exc
+
+        if record_complete_attempt:
+            self.record_attempt(
+                job.review_id,
+                completion_state=CompletionState.COMPLETE,
+                raw_capture_artifact_id=raw_capture_artifact_id or artifact.artifact_id,
+            )
+        return sealed
+
+    def load_sealed_verdict(self, review_id: str) -> SealedVerdict:
+        """Reload the durable sealed verdict for PR-G ``--review-id`` publish."""
+        job = self.get_job(review_id, include_attempts=False)
+        if job.sealed_verdict_artifact_id is None:
+            raise FormalReviewJobsError(
+                f"sealed_verdict_missing: job {job.review_id} has no accepted sealed "
+                "verdict (call accept_sealed_verdict first)"
+            )
+        try:
+            raw = self.store.read_bytes(job.sealed_verdict_artifact_id)
+        except Exception as exc:
+            raise FormalReviewJobsError(
+                f"sealed_verdict_artifact_unreadable: {job.sealed_verdict_artifact_id}: {exc}"
+            ) from exc
+        try:
+            sealed = parse_sealed_verdict_payload(raw)
+        except ReviewPublicationError as exc:
+            raise FormalReviewJobsError(
+                f"sealed_verdict_corrupt: {job.sealed_verdict_artifact_id}: {exc}"
+            ) from exc
+        # Re-validate binding on every load (fail closed if DB/job drifted).
+        if (
+            sealed.review_id != job.review_id
+            or sealed.repository != job.repository
+            or sealed.pr_number != job.pr_number
+            or sealed.head_sha.lower() != job.head_sha.lower()
+            or sealed.gate_kind != job.gate_kind
+        ):
+            raise FormalReviewJobsError(
+                f"sealed_verdict_job_drift: artifact for {job.review_id} does not "
+                "match durable job identity"
+            )
+        return sealed
+
     def get_job(self, review_id: str, *, include_attempts: bool = True) -> FormalReviewJob:
         rid = self._require_nonempty(review_id, "review_id")
         row = self._conn.execute(
@@ -381,6 +518,10 @@ class FormalReviewJobService:
         *,
         attempts: tuple[FormalReviewAttempt, ...],
     ) -> FormalReviewJob:
+        keys = set(row.keys()) if hasattr(row, "keys") else set()
+        sealed_id = None
+        if "sealed_verdict_artifact_id" in keys and row["sealed_verdict_artifact_id"] is not None:
+            sealed_id = str(row["sealed_verdict_artifact_id"])
         return FormalReviewJob(
             review_id=str(row["review_id"]),
             repository=str(row["repository"]),
@@ -391,6 +532,7 @@ class FormalReviewJobService:
             snapshot_artifact_id=(
                 str(row["snapshot_artifact_id"]) if row["snapshot_artifact_id"] is not None else None
             ),
+            sealed_verdict_artifact_id=sealed_id,
             created_at=str(row["created_at"]),
             attempts=attempts,
         )

--- a/scripts/fleet_comms/migrations.py
+++ b/scripts/fleet_comms/migrations.py
@@ -142,7 +142,21 @@ _V1_STATEMENTS = (
     )""",
 )
 
-MIGRATIONS = (Migration(version=1, name="fleet-comms-v1-contracts", statements=_V1_STATEMENTS),)
+# PR-F slice 2: durable sealed verdict blob on the formal job (Sol milestone 2 —
+# publish without manually supplied CLI provenance).
+_V2_STATEMENTS = (
+    """ALTER TABLE formal_review_jobs
+       ADD COLUMN sealed_verdict_artifact_id TEXT""",
+)
+
+MIGRATIONS = (
+    Migration(version=1, name="fleet-comms-v1-contracts", statements=_V1_STATEMENTS),
+    Migration(
+        version=2,
+        name="fleet-comms-v2-sealed-verdict-artifact",
+        statements=_V2_STATEMENTS,
+    ),
+)
 
 
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:

--- a/tests/ai_agent_bridge/test_fleet_comms_migration.py
+++ b/tests/ai_agent_bridge/test_fleet_comms_migration.py
@@ -25,7 +25,7 @@ def test_bridge_upgrades_legacy_copy_without_mutating_legacy_rows(tmp_path, monk
     migrated = _db.get_db()
     try:
         assert migrated.execute("SELECT content FROM messages WHERE task_id = 'legacy'").fetchone()[0] == "body"
-        assert migrated.execute("SELECT MAX(version) FROM comms_schema_migrations").fetchone()[0] == 1
+        assert migrated.execute("SELECT MAX(version) FROM comms_schema_migrations").fetchone()[0] == 2
         tables = {row[0] for row in migrated.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
         assert {"comms_messages", "requests", "artifacts", "formal_review_jobs"}.issubset(tables)
     finally:

--- a/tests/test_comms_plane_status_api.py
+++ b/tests/test_comms_plane_status_api.py
@@ -29,7 +29,7 @@ def test_read_plane_status_defaults_off(tmp_path: Path, monkeypatch) -> None:
     assert status["mode"] == "off"
     assert status["enabled"] is False
     assert status["read_only"] is True
-    assert status["schema"]["known_version"] == 1
+    assert status["schema"]["known_version"] == 2
     assert status["schema"]["applied_version"] is None
     assert status["schema"]["db_exists"] is False
     assert status["parity_telemetry"]["exists"] is False
@@ -43,7 +43,7 @@ def test_read_plane_status_with_schema_and_telemetry(tmp_path: Path, monkeypatch
     conn = sqlite3.connect(str(db_path))
     try:
         applied = apply_migrations(conn)
-        assert applied == 1
+        assert applied == 2
     finally:
         conn.close()
 
@@ -61,8 +61,8 @@ def test_read_plane_status_with_schema_and_telemetry(tmp_path: Path, monkeypatch
     assert status["mode"] == "shadow"
     assert status["enabled"] is True
     assert status["schema"]["db_exists"] is True
-    assert status["schema"]["applied_version"] == 1
-    assert status["schema"]["applied_name"] == "fleet-comms-v1-contracts"
+    assert status["schema"]["applied_version"] == 2
+    assert status["schema"]["applied_name"] == "fleet-comms-v2-sealed-verdict-artifact"
     assert status["parity_telemetry"]["exists"] is True
     assert status["parity_telemetry"]["event_count"] == 3
     assert status["parity_telemetry"]["parity_ok_count"] == 1
@@ -91,7 +91,7 @@ def test_api_plane_status_endpoint(tmp_path: Path, monkeypatch) -> None:
     assert data["plane_root"] == str(tmp_path / "plane")
     assert data["parity_telemetry"]["exists"] is True
     assert data["parity_telemetry"]["event_count"] == 1
-    assert data["schema"]["known_version"] == 1
+    assert data["schema"]["known_version"] == 2
 
 
 def test_api_plane_status_invalid_mode(monkeypatch) -> None:

--- a/tests/test_fleet_comms_cli.py
+++ b/tests/test_fleet_comms_cli.py
@@ -24,7 +24,7 @@ def _seed_plane_db(root: Path) -> Path:
     db_path = root / "comms.sqlite3"
     conn = sqlite3.connect(str(db_path))
     try:
-        assert apply_migrations(conn) == 1
+        assert apply_migrations(conn) == 2
         conn.execute(
             """INSERT INTO formal_review_jobs(
                 review_id, repository, pr_number, head_sha, gate_kind,

--- a/tests/test_fleet_comms_contracts.py
+++ b/tests/test_fleet_comms_contracts.py
@@ -99,9 +99,9 @@ def test_migrations_are_idempotent_and_reject_unknown_future_version(tmp_path: P
     db_path = tmp_path / "messages.db"
     conn = sqlite3.connect(db_path)
     conn.execute("CREATE TABLE deliveries (delivery_id TEXT PRIMARY KEY, status TEXT)")
-    assert apply_migrations(conn) == 1
+    assert apply_migrations(conn) == 2
     first = conn.execute("SELECT version, checksum FROM comms_schema_migrations").fetchall()
-    assert apply_migrations(conn) == 1
+    assert apply_migrations(conn) == 2
     assert conn.execute("SELECT version, checksum FROM comms_schema_migrations").fetchall() == first
     assert {"request_id", "endpoint_id", "expires_at", "fence_token"}.issubset(
         {row[1] for row in conn.execute("PRAGMA table_info(deliveries)")}

--- a/tests/test_fleet_comms_formal_review_jobs.py
+++ b/tests/test_fleet_comms_formal_review_jobs.py
@@ -164,3 +164,79 @@ def test_snapshot_artifact_id_must_exist(tmp_path: Path) -> None:
                     GATE,
                     snapshot_artifact_id="artifact_nope",
                 )
+
+
+_SHA = "a" * 40
+
+
+def _sealed_payload(review_id: str, **overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "review_id": review_id,
+        "repository": REPO,
+        "pr_number": 5512,
+        "head_sha": _SHA,
+        "gate_kind": GATE,
+        "verdict": "APPROVED",
+        "model": "claude-opus-4-6",
+        "family": "anthropic",
+        "harness": "claude",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_accept_and_load_sealed_verdict(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, _SHA, GATE)
+        assert job.sealed_verdict_artifact_id is None
+        sealed = svc.accept_sealed_verdict(job.review_id, _sealed_payload(job.review_id))
+        assert sealed.verdict == "APPROVED"
+        loaded_job = svc.get_job(job.review_id)
+        assert loaded_job.has_sealed_verdict
+        assert loaded_job.state == "complete"
+        again = svc.load_sealed_verdict(job.review_id)
+        assert again.to_dict() == sealed.to_dict()
+        # Idempotent re-accept of identical payload
+        same = svc.accept_sealed_verdict(job.review_id, _sealed_payload(job.review_id))
+        assert same.verdict == "APPROVED"
+
+
+def test_accept_sealed_verdict_rejects_identity_mismatch(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, _SHA, GATE)
+        with pytest.raises(FormalReviewJobsError, match="sealed_job_mismatch"):
+            svc.accept_sealed_verdict(
+                job.review_id,
+                _sealed_payload(job.review_id, pr_number=9999),
+            )
+
+
+def test_accept_sealed_verdict_refuses_overwrite(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, _SHA, GATE)
+        svc.accept_sealed_verdict(job.review_id, _sealed_payload(job.review_id))
+        with pytest.raises(FormalReviewJobsError, match="sealed_verdict_already_set"):
+            svc.accept_sealed_verdict(
+                job.review_id,
+                _sealed_payload(job.review_id, verdict="CHANGES_REQUESTED"),
+            )
+
+
+def test_load_sealed_verdict_missing(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 42, _SHA, GATE)
+        with pytest.raises(FormalReviewJobsError, match="sealed_verdict_missing"):
+            svc.load_sealed_verdict(job.review_id)
+
+
+def test_migration_v2_adds_sealed_column(tmp_path: Path) -> None:
+    import sqlite3
+
+    from scripts.fleet_comms.migrations import apply_migrations
+
+    db = tmp_path / "c.sqlite3"
+    conn = sqlite3.connect(str(db))
+    assert apply_migrations(conn) == 2
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(formal_review_jobs)")}
+    assert "sealed_verdict_artifact_id" in cols
+    conn.close()

--- a/tests/test_fleet_comms_review_publisher.py
+++ b/tests/test_fleet_comms_review_publisher.py
@@ -232,3 +232,39 @@ def test_sealed_payload_file_round_trip(tmp_path: Path) -> None:
     assert result.plan.verdict == "BLOCKED"
     assert result.plan.status_state == STATUS_ERROR
     assert result.status_posted is True
+
+
+def test_publish_from_review_id_via_accept_sealed(tmp_path: Path) -> None:
+    """Sol milestone 2: publish without CLI-supplied provenance after accept."""
+    from scripts.fleet_comms.formal_review_jobs import FormalReviewJobService
+
+    root = tmp_path / "plane"
+    gh = FakeGh(head=_SHA_A)
+    with FormalReviewJobService(root=root) as svc:
+        job = svc.create_job(_REPO, 5512, _SHA_A, "cross-family-review")
+        svc.accept_sealed_verdict(
+            job.review_id,
+            {
+                "review_id": job.review_id,
+                "repository": _REPO,
+                "pr_number": 5512,
+                "head_sha": _SHA_A,
+                "gate_kind": "cross-family-review",
+                "verdict": "APPROVED",
+                "model": "gpt-5.6-terra",
+                "family": "openai",
+                "harness": "codex",
+            },
+        )
+        sealed = svc.load_sealed_verdict(job.review_id)
+        result = publish_sealed_verdict(
+            sealed,
+            current_head_sha=_SHA_A,
+            mutate=True,
+            runner=gh,
+            store=svc.store,
+            require_receipt=True,
+        )
+    assert result.status_posted is True
+    assert result.plan.verdict == "APPROVED"
+    assert result.publication_id is not None


### PR DESCRIPTION
## Summary
- **PR-F slice 2:** durable sealed verdict on formal jobs (`accept_sealed_verdict` / `load_sealed_verdict`).
- Schema **v2** `sealed_verdict_artifact_id` on `formal_review_jobs`.
- **PR-G:** `publish-review-verdict --review-id` alone reloads sealed payload and publishes — Sol milestone 2.
- With `--sealed-payload` + `--review-id`, accepts/binds for future `--review-id` alone.
- Does **not** cut over `review-pr` or create sealed worktree snapshots.

## Parent
Stream #4707 · product #5512 · builds on #5567 + #5569

## Test plan
- [x] formal_review_jobs + review_publisher + migration suite (43+)
- [ ] CI green
- [ ] Cross-family review