### PR TITLE
feat(fleet-comms): formal-job accept finalize glue after review-pr (#5512)

### DIFF
--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -172,3 +172,6 @@ def register_review_pr_parser(subparsers: Any) -> None:
     parser.add_argument("--background", action="store_true")
     parser.add_argument("--no-timeout", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
+    # Post-reply finalize is a separate CLI so review-pr stays pointer-only:
+    #   .venv/bin/python -m scripts.fleet_comms formal-job accept \
+    #       --pr N --verdict APPROVED --model M --family F --harness H [--publish]

--- a/scripts/ai_agent_bridge/_review_verdict.py
+++ b/scripts/ai_agent_bridge/_review_verdict.py
@@ -147,6 +147,48 @@ def publish_review_verdict(
     return summary
 
 
+def _emit_publication_result(args: argparse.Namespace, result: Any) -> int:
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        summary = result.summary
+        if len(summary.encode("utf-8")) > MAX_VERDICT_SUMMARY_BYTES:
+            print("publish-review-verdict: verdict_summary_exceeds_cap", file=sys.stderr)
+            return 2
+        print(summary)
+    if result.plan.action == "refuse_stale":
+        return 3
+    return 0
+
+
+def _handle_review_id_only(args: argparse.Namespace) -> int:
+    """PR-F+G path: load sealed verdict from durable job; no CLI provenance."""
+    from scripts.fleet_comms.formal_review_jobs import (
+        FormalReviewJobsError,
+        FormalReviewJobService,
+    )
+    from scripts.fleet_comms.review_publisher import (
+        ReviewPublisherError,
+        publish_sealed_verdict,
+    )
+
+    plane_root = Path(args.plane_root).expanduser() if args.plane_root else None
+    try:
+        with FormalReviewJobService(root=plane_root) as service:
+            sealed = service.load_sealed_verdict(args.review_id)
+            result = publish_sealed_verdict(
+                sealed,
+                mutate=not args.dry_run,
+                # Formal --review-id path always records github_publications receipts.
+                require_receipt=True,
+                store=service.store,
+            )
+    except (FormalReviewJobsError, ReviewPublisherError) as exc:
+        print(f"publish-review-verdict: {exc}", file=sys.stderr)
+        return 2
+    return _emit_publication_result(args, result)
+
+
 def _handle_sealed_path(args: argparse.Namespace) -> int:
     """PR-G sealed path: pure plan + optional GitHub mutate + receipts."""
     from scripts.fleet_comms.artifacts import ArtifactStore
@@ -193,6 +235,16 @@ def _handle_sealed_path(args: argparse.Namespace) -> int:
             except ReviewPublisherError as exc:
                 print(f"publish-review-verdict: {exc}", file=sys.stderr)
                 return 2
+            # Persist sealed verdict if not already (enables future --review-id alone).
+            try:
+                service.accept_sealed_verdict(
+                    job.review_id,
+                    sealed,
+                    record_complete_attempt=not job.has_sealed_verdict,
+                )
+            except FormalReviewJobsError as exc:
+                print(f"publish-review-verdict: {exc}", file=sys.stderr)
+                return 2
             store = service.store
         elif plane_root is not None or args.require_receipt:
             store = ArtifactStore(root=plane_root)
@@ -212,24 +264,18 @@ def _handle_sealed_path(args: argparse.Namespace) -> int:
         elif store is not None:
             store.close()
 
-    if args.json:
-        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
-    else:
-        summary = result.summary
-        if len(summary.encode("utf-8")) > MAX_VERDICT_SUMMARY_BYTES:
-            print("publish-review-verdict: verdict_summary_exceeds_cap", file=sys.stderr)
-            return 2
-        print(summary)
-
-    # Non-zero when plan refused to publish (stale head) so orchestrators fail closed.
-    if result.plan.action == "refuse_stale":
-        return 3
-    return 0
+    return _emit_publication_result(args, result)
 
 
 def handle_publish_review_verdict(args: argparse.Namespace) -> int:
     """CLI handler for ``publish-review-verdict``."""
-    if getattr(args, "sealed_payload", None):
+    has_legacy_file = bool(getattr(args, "verdict_file", None) or getattr(args, "findings_json", None))
+    has_sealed_file = bool(getattr(args, "sealed_payload", None))
+    has_review_id = bool(getattr(args, "review_id", None))
+
+    if has_review_id and not has_sealed_file and not has_legacy_file:
+        return _handle_review_id_only(args)
+    if has_sealed_file:
         return _handle_sealed_path(args)
 
     # Legacy path: require CLI provenance flags.
@@ -242,13 +288,14 @@ def handle_publish_review_verdict(args: argparse.Namespace) -> int:
         print(
             "publish-review-verdict: legacy path requires "
             + ", ".join(f"--{m}" for m in missing)
-            + " (or use --sealed-payload)",
+            + " (or use --sealed-payload / --review-id)",
             file=sys.stderr,
         )
         return 2
-    if not args.verdict_file and not args.findings_json:
+    if not has_legacy_file:
         print(
-            "publish-review-verdict: provide --verdict-file, --findings-json, or --sealed-payload",
+            "publish-review-verdict: provide --verdict-file, --findings-json, "
+            "--sealed-payload, or --review-id",
             file=sys.stderr,
         )
         return 2
@@ -279,11 +326,11 @@ def register_publish_review_verdict_parser(subparsers: Any) -> None:
     parser = subparsers.add_parser(
         "publish-review-verdict",
         help=(
-            "Post one thin formal-review verdict (legacy file path, or PR-G "
-            "--sealed-payload with commit status + receipts)"
+            "Post one thin formal-review verdict (legacy file path, "
+            "--sealed-payload, or --review-id alone after PR-F accept)"
         ),
     )
-    source = parser.add_mutually_exclusive_group(required=True)
+    source = parser.add_mutually_exclusive_group(required=False)
     source.add_argument("--verdict-file", help="Short text containing a VERDICT line (legacy)")
     source.add_argument(
         "--findings-json",
@@ -300,8 +347,8 @@ def register_publish_review_verdict_parser(subparsers: Any) -> None:
     parser.add_argument(
         "--review-id",
         help=(
-            "Optional durable formal-job id to bind against --sealed-payload "
-            "(identity check + publication receipt). Job must already exist (PR-F)."
+            "PR-F durable formal-job id. Alone: reload sealed verdict from the job "
+            "and publish (no CLI provenance). With --sealed-payload: bind + accept."
         ),
     )
     parser.add_argument(

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -1,11 +1,15 @@
-"""Thin read-only CLI for fleet-comms plane status and formal review jobs.
+"""Fleet-comms CLI: plane status, formal-job get, formal-job accept (+ optional publish).
 
 Usage::
 
     .venv/bin/python -m scripts.fleet_comms plane-status
     .venv/bin/python -m scripts.fleet_comms formal-job get <review_id>
+    .venv/bin/python -m scripts.fleet_comms formal-job accept \\
+        --pr 5571 --verdict APPROVED --model M --family F --harness H
 
-No writers, no GitHub, no review-pr cutover. Dumps JSON to stdout.
+``formal-job accept`` is the post-``review-pr`` glue (create/reuse job + sealed
+verdict accept). Optional ``--publish`` posts GitHub comment/status via PR-G.
+Does not cut over ``review-pr`` itself.
 """
 
 from __future__ import annotations
@@ -18,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
+from scripts.fleet_comms.review_publication import DEFAULT_GATE_KIND
 
 EXIT_OK = 0
 EXIT_USAGE = 2
@@ -26,7 +31,7 @@ EXIT_ERROR = 3
 
 
 class FleetCommsCliError(RuntimeError):
-    """CLI refused a read-only operation."""
+    """CLI refused an operation."""
 
 
 def _json_dump(payload: Any, *, indent: int | None = 2) -> str:
@@ -136,12 +141,55 @@ def cmd_formal_job_get(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_formal_job_accept(args: argparse.Namespace) -> int:
+    """Create/reuse formal job, accept sealed verdict, optionally publish."""
+    from scripts.fleet_comms.formal_review_finalize import (
+        FormalReviewFinalizeError,
+        finalize_formal_review_verdict,
+    )
+
+    root = Path(args.root).expanduser() if args.root else None
+    verdict_file = Path(args.verdict_file) if args.verdict_file else None
+    findings = Path(args.findings_json) if args.findings_json else None
+    verdict_text = None
+    if verdict_file is not None:
+        try:
+            verdict_text = verdict_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            sys.stderr.write(f"verdict_file_unreadable: {exc}\n")
+            return EXIT_ERROR
+
+    try:
+        result = finalize_formal_review_verdict(
+            pr_number=int(args.pr),
+            model=args.model,
+            family=args.family,
+            harness=args.harness,
+            repository=args.repository,
+            gate_kind=args.gate_kind,
+            verdict=args.verdict,
+            verdict_text=verdict_text,
+            findings_path=findings,
+            review_id=args.review_id,
+            head_sha=args.head_sha,
+            publish=bool(args.publish),
+            dry_run_publish=bool(args.dry_run_publish),
+            plane_root=root,
+        )
+    except FormalReviewFinalizeError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_ERROR
+
+    sys.stdout.write(_json_dump(result.to_dict()))
+    return EXIT_OK
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m scripts.fleet_comms",
         description=(
-            "Thin read-only fleet-comms CLI: plane-status dump and formal-job get. "
-            "No GitHub mutation, no review-pr cutover."
+            "Fleet-comms CLI: plane-status, formal-job get (read-only), "
+            "formal-job accept (writer + optional GitHub publish)."
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
@@ -175,7 +223,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     formal = sub.add_parser(
         "formal-job",
-        help="Read-only formal review job queries (plane SQLite)",
+        help="Formal review job get (RO) and accept (writer)",
     )
     formal_sub = formal.add_subparsers(dest="formal_command", required=True)
 
@@ -200,6 +248,61 @@ def build_parser() -> argparse.ArgumentParser:
         help="Omit formal_review_attempts rows",
     )
     formal_get.set_defaults(func=cmd_formal_job_get)
+
+    formal_accept = formal_sub.add_parser(
+        "accept",
+        help=(
+            "Create/reuse formal job for PR head, accept sealed verdict, "
+            "optionally publish (post-review-pr glue)"
+        ),
+    )
+    formal_accept.add_argument("--pr", type=int, required=True, help="Pull request number")
+    formal_accept.add_argument("--model", required=True, help="Exact reviewer model ID")
+    formal_accept.add_argument("--family", required=True, help="Reviewer model family")
+    formal_accept.add_argument("--harness", required=True, help="Reviewer harness")
+    formal_accept.add_argument(
+        "--repository",
+        default="learn-ukrainian/learn-ukrainian.github.io",
+        help="owner/repo (default: learn-ukrainian/learn-ukrainian.github.io)",
+    )
+    formal_accept.add_argument(
+        "--gate-kind",
+        default=DEFAULT_GATE_KIND,
+        help=f"Gate kind (default: {DEFAULT_GATE_KIND})",
+    )
+    formal_accept.add_argument("--verdict", help="APPROVED|CHANGES_REQUESTED|BLOCKED")
+    formal_accept.add_argument(
+        "--verdict-file",
+        help="Text file containing VERDICT: … line",
+    )
+    formal_accept.add_argument(
+        "--findings-json",
+        help="Findings JSON with top-level verdict field",
+    )
+    formal_accept.add_argument(
+        "--review-id",
+        help="Optional review_id when creating the job (default: auto)",
+    )
+    formal_accept.add_argument(
+        "--head-sha",
+        help="Override PR head SHA (default: gh pr view)",
+    )
+    formal_accept.add_argument(
+        "--root",
+        default=None,
+        help="Plane ArtifactStore root (default under batch_state/fleet-comms/v1)",
+    )
+    formal_accept.add_argument(
+        "--publish",
+        action="store_true",
+        help="After accept, live-publish comment + fleet/cross-family-review status",
+    )
+    formal_accept.add_argument(
+        "--dry-run-publish",
+        action="store_true",
+        help="Plan publication without mutating GitHub (still accepts sealed verdict)",
+    )
+    formal_accept.set_defaults(func=cmd_formal_job_accept)
 
     return parser
 

--- a/scripts/fleet_comms/formal_review_finalize.py
+++ b/scripts/fleet_comms/formal_review_finalize.py
@@ -191,41 +191,42 @@ def finalize_formal_review_verdict(
 
     job_created = False
     with FormalReviewJobService(root=plane_root) as service:
-        existing = service.find_job(
-            repository, pr_number, sha, gate_kind, include_attempts=False
-        )
-        if existing is None:
-            job = service.create_job(
-                repository,
-                pr_number,
-                sha,
-                gate_kind,
-                review_id=review_id,
-                state="running",
-            )
-            job_created = True
-        else:
-            job = existing
-            if review_id and review_id != job.review_id:
-                raise FormalReviewFinalizeError(
-                    f"review_id_mismatch: requested={review_id!r} "
-                    f"existing={job.review_id!r}"
-                )
-
-        sealed = build_sealed_verdict(
-            review_id=job.review_id,
-            repository=repository,
-            pr_number=pr_number,
-            head_sha=sha,
-            gate_kind=gate_kind,
-            verdict=resolved_verdict,
-            model=model.strip(),
-            family=family.strip(),
-            harness=harness.strip(),
-        )
         try:
+            existing = service.find_job(
+                repository, pr_number, sha, gate_kind, include_attempts=False
+            )
+            if existing is None:
+                job = service.create_job(
+                    repository,
+                    pr_number,
+                    sha,
+                    gate_kind,
+                    review_id=review_id,
+                    state="running",
+                )
+                job_created = True
+            else:
+                job = existing
+                if review_id and review_id != job.review_id:
+                    raise FormalReviewFinalizeError(
+                        f"review_id_mismatch: requested={review_id!r} "
+                        f"existing={job.review_id!r}"
+                    )
+
+            sealed = build_sealed_verdict(
+                review_id=job.review_id,
+                repository=repository,
+                pr_number=pr_number,
+                head_sha=sha,
+                gate_kind=gate_kind,
+                verdict=resolved_verdict,
+                model=model.strip(),
+                family=family.strip(),
+                harness=harness.strip(),
+            )
             service.accept_sealed_verdict(job.review_id, sealed)
         except FormalReviewJobsError as exc:
+            # Includes concurrent create races and accept failures.
             raise FormalReviewFinalizeError(str(exc)) from exc
 
         refreshed = service.get_job(job.review_id, include_attempts=False)

--- a/scripts/fleet_comms/formal_review_finalize.py
+++ b/scripts/fleet_comms/formal_review_finalize.py
@@ -1,0 +1,279 @@
+"""PR-F/G glue: create formal job + accept sealed verdict (+ optional publish).
+
+Closes the gap between ``review-pr`` (ask-only) and Sol milestone 2:
+
+1. Resolve immutable PR head via ``gh``
+2. Create (or reuse) formal job for ``(repo, pr, head, gate)``
+3. ``accept_sealed_verdict`` with full provenance in the sealed payload
+4. Optionally ``publish_sealed_verdict`` (``--review-id`` path)
+
+Does **not** invoke reviewers, create sealed worktrees, or cut over ``review-pr``
+defaults. Operators/orchestrators call this after a review reply is in hand.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.fleet_comms.formal_review_jobs import (
+    FormalReviewJobsError,
+    FormalReviewJobService,
+)
+from scripts.fleet_comms.review_publication import (
+    DEFAULT_GATE_KIND,
+    ReviewPublicationError,
+    SealedVerdict,
+    normalize_verdict,
+    parse_sealed_verdict_payload,
+    parse_verdict_token,
+)
+from scripts.fleet_comms.review_publisher import (
+    ReviewPublisherError,
+    fetch_pr_head_sha,
+    publish_sealed_verdict,
+    split_repository,
+)
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+DEFAULT_REPOSITORY = "learn-ukrainian/learn-ukrainian.github.io"
+_SHA_RE = re.compile(r"^[0-9a-f]{7,64}$", re.IGNORECASE)
+
+
+class FormalReviewFinalizeError(RuntimeError):
+    """Finalize refused an operation (fail closed)."""
+
+
+@dataclass(frozen=True, slots=True)
+class FinalizeResult:
+    review_id: str
+    repository: str
+    pr_number: int
+    head_sha: str
+    gate_kind: str
+    verdict: str
+    sealed_verdict_artifact_id: str | None
+    published: bool
+    publication_summary: str | None
+    job_created: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "review_id": self.review_id,
+            "repository": self.repository,
+            "pr_number": self.pr_number,
+            "head_sha": self.head_sha,
+            "gate_kind": self.gate_kind,
+            "verdict": self.verdict,
+            "sealed_verdict_artifact_id": self.sealed_verdict_artifact_id,
+            "published": self.published,
+            "publication_summary": self.publication_summary,
+            "job_created": self.job_created,
+        }
+
+
+def resolve_verdict_token(
+    *,
+    verdict: str | None = None,
+    verdict_text: str | None = None,
+    findings_path: Path | None = None,
+) -> str:
+    """Normalize a verdict from explicit token, free text, or findings JSON."""
+    if verdict and str(verdict).strip():
+        try:
+            return normalize_verdict(verdict)
+        except ReviewPublicationError as exc:
+            raise FormalReviewFinalizeError(str(exc)) from exc
+    if findings_path is not None:
+        try:
+            payload = json.loads(findings_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise FormalReviewFinalizeError(f"findings_unreadable: {exc}") from exc
+        if not isinstance(payload, dict) or "verdict" not in payload:
+            raise FormalReviewFinalizeError("findings_json_missing_verdict")
+        try:
+            return normalize_verdict(payload["verdict"])
+        except ReviewPublicationError as exc:
+            raise FormalReviewFinalizeError(str(exc)) from exc
+    if verdict_text and str(verdict_text).strip():
+        try:
+            return parse_verdict_token(verdict_text)
+        except ReviewPublicationError as exc:
+            raise FormalReviewFinalizeError(str(exc)) from exc
+    raise FormalReviewFinalizeError(
+        "verdict_required: pass --verdict, --verdict-file, or --findings-json"
+    )
+
+
+def build_sealed_verdict(
+    *,
+    review_id: str,
+    repository: str,
+    pr_number: int,
+    head_sha: str,
+    gate_kind: str,
+    verdict: str,
+    model: str,
+    family: str,
+    harness: str,
+) -> SealedVerdict:
+    """Build a SealedVerdict from explicit fields (provenance never invented)."""
+    payload = {
+        "review_id": review_id,
+        "repository": repository,
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "gate_kind": gate_kind,
+        "verdict": verdict,
+        "model": model,
+        "family": family,
+        "harness": harness,
+    }
+    try:
+        return parse_sealed_verdict_payload(payload)
+    except ReviewPublicationError as exc:
+        raise FormalReviewFinalizeError(str(exc)) from exc
+
+
+def finalize_formal_review_verdict(
+    *,
+    pr_number: int,
+    model: str,
+    family: str,
+    harness: str,
+    repository: str = DEFAULT_REPOSITORY,
+    gate_kind: str = DEFAULT_GATE_KIND,
+    verdict: str | None = None,
+    verdict_text: str | None = None,
+    findings_path: Path | None = None,
+    review_id: str | None = None,
+    head_sha: str | None = None,
+    publish: bool = False,
+    dry_run_publish: bool = False,
+    plane_root: Path | None = None,
+    runner: Runner = subprocess.run,
+) -> FinalizeResult:
+    """Create/reuse job, accept sealed verdict, optionally publish to GitHub."""
+    if pr_number < 1:
+        raise FormalReviewFinalizeError(f"invalid_pr: {pr_number}")
+    for label, value in (("model", model), ("family", family), ("harness", harness)):
+        if not value or not str(value).strip():
+            raise FormalReviewFinalizeError(f"missing_{label}")
+
+    # Validate repository shape early.
+    split_repository(repository)
+
+    resolved_verdict = resolve_verdict_token(
+        verdict=verdict,
+        verdict_text=verdict_text,
+        findings_path=findings_path,
+    )
+
+    sha = head_sha
+    if sha is None:
+        try:
+            sha = fetch_pr_head_sha(
+                repository=repository,
+                pr_number=pr_number,
+                runner=runner,
+            )
+        except ReviewPublisherError as exc:
+            raise FormalReviewFinalizeError(str(exc)) from exc
+    sha = sha.strip().lower()
+    if not _SHA_RE.match(sha):
+        raise FormalReviewFinalizeError(f"invalid_head_sha: {sha!r}")
+
+    job_created = False
+    with FormalReviewJobService(root=plane_root) as service:
+        existing = service.find_job(
+            repository, pr_number, sha, gate_kind, include_attempts=False
+        )
+        if existing is None:
+            job = service.create_job(
+                repository,
+                pr_number,
+                sha,
+                gate_kind,
+                review_id=review_id,
+                state="running",
+            )
+            job_created = True
+        else:
+            job = existing
+            if review_id and review_id != job.review_id:
+                raise FormalReviewFinalizeError(
+                    f"review_id_mismatch: requested={review_id!r} "
+                    f"existing={job.review_id!r}"
+                )
+
+        sealed = build_sealed_verdict(
+            review_id=job.review_id,
+            repository=repository,
+            pr_number=pr_number,
+            head_sha=sha,
+            gate_kind=gate_kind,
+            verdict=resolved_verdict,
+            model=model.strip(),
+            family=family.strip(),
+            harness=harness.strip(),
+        )
+        try:
+            service.accept_sealed_verdict(job.review_id, sealed)
+        except FormalReviewJobsError as exc:
+            raise FormalReviewFinalizeError(str(exc)) from exc
+
+        refreshed = service.get_job(job.review_id, include_attempts=False)
+        publication_summary: str | None = None
+        published = False
+        if publish or dry_run_publish:
+            try:
+                result = publish_sealed_verdict(
+                    sealed,
+                    mutate=publish and not dry_run_publish,
+                    require_receipt=True,
+                    store=service.store,
+                    runner=runner,
+                )
+            except ReviewPublisherError as exc:
+                raise FormalReviewFinalizeError(str(exc)) from exc
+            publication_summary = result.summary
+            published = bool(result.status_posted)
+            if result.plan.action == "refuse_stale":
+                raise FormalReviewFinalizeError(result.plan.reason)
+
+        return FinalizeResult(
+            review_id=job.review_id,
+            repository=repository,
+            pr_number=pr_number,
+            head_sha=sha,
+            gate_kind=gate_kind,
+            verdict=resolved_verdict,
+            sealed_verdict_artifact_id=refreshed.sealed_verdict_artifact_id,
+            published=published,
+            publication_summary=publication_summary,
+            job_created=job_created,
+        )
+
+
+def sealed_dict_from_mapping(payload: Mapping[str, Any]) -> SealedVerdict:
+    try:
+        return parse_sealed_verdict_payload(payload)
+    except ReviewPublicationError as exc:
+        raise FormalReviewFinalizeError(str(exc)) from exc
+
+
+__all__ = [
+    "DEFAULT_REPOSITORY",
+    "FinalizeResult",
+    "FormalReviewFinalizeError",
+    "build_sealed_verdict",
+    "finalize_formal_review_verdict",
+    "resolve_verdict_token",
+    "sealed_dict_from_mapping",
+]

--- a/scripts/fleet_comms/formal_review_jobs.py
+++ b/scripts/fleet_comms/formal_review_jobs.py
@@ -1,18 +1,25 @@
-"""Formal review job skeleton (Fleet Comms Sol PR-F first slice / #5512).
+"""Formal review jobs (Fleet Comms Sol PR-F / #5512).
 
 Durable SQLite usage of ``formal_review_jobs`` / ``formal_review_attempts``
 (schema from fleet_comms migrations). Unique key (one job per head; attempts accumulate):
 
     (repository, pr_number, head_sha, gate_kind)
 
-Concurrent duplicate creates are rejected. This module does **not** cut over
-``review-pr``, seal snapshots, resolve reviewers, validate verdicts, or publish
-to GitHub (those are later PR-F / PR-G slices).
+Concurrent duplicate creates are rejected.
+
+PR-F slice 2 (sealed verdict acceptance): store a content-addressed sealed
+verdict payload on the job so PR-G can publish with
+``publish-review-verdict --review-id`` alone (no CLI-supplied provenance).
+
+This module still does **not** cut over ``review-pr``, create reviewer-neutral
+snapshots, or resolve reviewers (later PR-F slices / Terra ownership).
 """
 
 from __future__ import annotations
 
+import json
 import sqlite3
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -21,8 +28,12 @@ from typing import Any
 from scripts.fleet_comms.artifacts import ArtifactStore
 from scripts.fleet_comms.contracts import CompletionState, new_id
 from scripts.fleet_comms.migrations import apply_migrations
+from scripts.fleet_comms.review_publication import (
+    ReviewPublicationError,
+    SealedVerdict,
+    parse_sealed_verdict_payload,
+)
 
-# Job lifecycle for this skeleton. Publication / sealed verdict acceptance land later.
 JOB_STATES = frozenset({"open", "running", "complete", "failed", "blocked"})
 ACTIVE_JOB_STATES = frozenset({"open", "running"})
 
@@ -73,12 +84,17 @@ class FormalReviewJob:
     gate_kind: str
     state: str
     snapshot_artifact_id: str | None
+    sealed_verdict_artifact_id: str | None
     created_at: str
     attempts: tuple[FormalReviewAttempt, ...] = field(default_factory=tuple)
 
     @property
     def unique_key(self) -> tuple[str, int, str, str]:
         return (self.repository, self.pr_number, self.head_sha, self.gate_kind)
+
+    @property
+    def has_sealed_verdict(self) -> bool:
+        return self.sealed_verdict_artifact_id is not None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -89,6 +105,7 @@ class FormalReviewJob:
             "gate_kind": self.gate_kind,
             "state": self.state,
             "snapshot_artifact_id": self.snapshot_artifact_id,
+            "sealed_verdict_artifact_id": self.sealed_verdict_artifact_id,
             "created_at": self.created_at,
             "attempts": [attempt.to_dict() for attempt in self.attempts],
         }
@@ -251,6 +268,126 @@ class FormalReviewJobService:
             created_at=created,
         )
 
+    def accept_sealed_verdict(
+        self,
+        review_id: str,
+        sealed: SealedVerdict | Mapping[str, Any] | str | bytes,
+        *,
+        record_complete_attempt: bool = True,
+        raw_capture_artifact_id: str | None = None,
+    ) -> SealedVerdict:
+        """Accept a schema-valid sealed verdict and bind it to the job (fail closed).
+
+        Provenance (model/family/harness/verdict) is taken **only** from the
+        sealed payload. The payload's repository/pr/head/gate/review_id must
+        match the durable job row exactly.
+        """
+        job = self.get_job(review_id, include_attempts=False)
+        try:
+            if not isinstance(sealed, SealedVerdict):
+                sealed = parse_sealed_verdict_payload(sealed)
+        except ReviewPublicationError as exc:
+            raise FormalReviewJobsError(f"sealed_verdict_invalid: {exc}") from exc
+
+        if sealed.review_id != job.review_id:
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: review_id sealed={sealed.review_id!r} "
+                f"job={job.review_id!r}"
+            )
+        if sealed.repository != job.repository:
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: repository sealed={sealed.repository!r} "
+                f"job={job.repository!r}"
+            )
+        if sealed.pr_number != job.pr_number:
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: pr sealed={sealed.pr_number} job={job.pr_number}"
+            )
+        if sealed.head_sha.lower() != job.head_sha.lower():
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: head_sha sealed={sealed.head_sha!r} "
+                f"job={job.head_sha!r}"
+            )
+        if sealed.gate_kind != job.gate_kind:
+            raise FormalReviewJobsError(
+                f"sealed_job_mismatch: gate_kind sealed={sealed.gate_kind!r} "
+                f"job={job.gate_kind!r}"
+            )
+
+        if job.sealed_verdict_artifact_id is not None:
+            # Idempotent re-accept of identical payload only.
+            existing = self.load_sealed_verdict(job.review_id)
+            if existing.to_dict() != sealed.to_dict():
+                raise FormalReviewJobsError(
+                    f"sealed_verdict_already_set: job {job.review_id} already holds a "
+                    "different sealed verdict; refuse overwrite"
+                )
+            return existing
+
+        payload = json.dumps(sealed.to_dict(), sort_keys=True, separators=(",", ":"))
+        artifact = self.store.store_text(
+            payload,
+            producer="formal-review-jobs",
+            retention_class="sealed-verdict",
+            logical_filename=f"{job.review_id}.sealed-verdict.json",
+            mime_type="application/json; charset=utf-8",
+        )
+        try:
+            self._conn.execute(
+                """UPDATE formal_review_jobs
+                   SET sealed_verdict_artifact_id = ?, state = ?
+                   WHERE review_id = ?""",
+                (artifact.artifact_id, "complete", job.review_id),
+            )
+            self._conn.commit()
+        except sqlite3.Error as exc:
+            self._conn.rollback()
+            raise FormalReviewJobsError(
+                f"failed to bind sealed verdict for {job.review_id}: {exc}"
+            ) from exc
+
+        if record_complete_attempt:
+            self.record_attempt(
+                job.review_id,
+                completion_state=CompletionState.COMPLETE,
+                raw_capture_artifact_id=raw_capture_artifact_id or artifact.artifact_id,
+            )
+        return sealed
+
+    def load_sealed_verdict(self, review_id: str) -> SealedVerdict:
+        """Reload the durable sealed verdict for PR-G ``--review-id`` publish."""
+        job = self.get_job(review_id, include_attempts=False)
+        if job.sealed_verdict_artifact_id is None:
+            raise FormalReviewJobsError(
+                f"sealed_verdict_missing: job {job.review_id} has no accepted sealed "
+                "verdict (call accept_sealed_verdict first)"
+            )
+        try:
+            raw = self.store.read_bytes(job.sealed_verdict_artifact_id)
+        except Exception as exc:
+            raise FormalReviewJobsError(
+                f"sealed_verdict_artifact_unreadable: {job.sealed_verdict_artifact_id}: {exc}"
+            ) from exc
+        try:
+            sealed = parse_sealed_verdict_payload(raw)
+        except ReviewPublicationError as exc:
+            raise FormalReviewJobsError(
+                f"sealed_verdict_corrupt: {job.sealed_verdict_artifact_id}: {exc}"
+            ) from exc
+        # Re-validate binding on every load (fail closed if DB/job drifted).
+        if (
+            sealed.review_id != job.review_id
+            or sealed.repository != job.repository
+            or sealed.pr_number != job.pr_number
+            or sealed.head_sha.lower() != job.head_sha.lower()
+            or sealed.gate_kind != job.gate_kind
+        ):
+            raise FormalReviewJobsError(
+                f"sealed_verdict_job_drift: artifact for {job.review_id} does not "
+                "match durable job identity"
+            )
+        return sealed
+
     def get_job(self, review_id: str, *, include_attempts: bool = True) -> FormalReviewJob:
         rid = self._require_nonempty(review_id, "review_id")
         row = self._conn.execute(
@@ -381,6 +518,10 @@ class FormalReviewJobService:
         *,
         attempts: tuple[FormalReviewAttempt, ...],
     ) -> FormalReviewJob:
+        keys = set(row.keys()) if hasattr(row, "keys") else set()
+        sealed_id = None
+        if "sealed_verdict_artifact_id" in keys and row["sealed_verdict_artifact_id"] is not None:
+            sealed_id = str(row["sealed_verdict_artifact_id"])
         return FormalReviewJob(
             review_id=str(row["review_id"]),
             repository=str(row["repository"]),
@@ -391,6 +532,7 @@ class FormalReviewJobService:
             snapshot_artifact_id=(
                 str(row["snapshot_artifact_id"]) if row["snapshot_artifact_id"] is not None else None
             ),
+            sealed_verdict_artifact_id=sealed_id,
             created_at=str(row["created_at"]),
             attempts=attempts,
         )

--- a/scripts/fleet_comms/migrations.py
+++ b/scripts/fleet_comms/migrations.py
@@ -142,7 +142,21 @@ _V1_STATEMENTS = (
     )""",
 )
 
-MIGRATIONS = (Migration(version=1, name="fleet-comms-v1-contracts", statements=_V1_STATEMENTS),)
+# PR-F slice 2: durable sealed verdict blob on the formal job (Sol milestone 2 —
+# publish without manually supplied CLI provenance).
+_V2_STATEMENTS = (
+    """ALTER TABLE formal_review_jobs
+       ADD COLUMN sealed_verdict_artifact_id TEXT""",
+)
+
+MIGRATIONS = (
+    Migration(version=1, name="fleet-comms-v1-contracts", statements=_V1_STATEMENTS),
+    Migration(
+        version=2,
+        name="fleet-comms-v2-sealed-verdict-artifact",
+        statements=_V2_STATEMENTS,
+    ),
+)
 
 
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:

--- a/tests/ai_agent_bridge/test_fleet_comms_migration.py
+++ b/tests/ai_agent_bridge/test_fleet_comms_migration.py
@@ -25,7 +25,7 @@ def test_bridge_upgrades_legacy_copy_without_mutating_legacy_rows(tmp_path, monk
     migrated = _db.get_db()
     try:
         assert migrated.execute("SELECT content FROM messages WHERE task_id = 'legacy'").fetchone()[0] == "body"
-        assert migrated.execute("SELECT MAX(version) FROM comms_schema_migrations").fetchone()[0] == 1
+        assert migrated.execute("SELECT MAX(version) FROM comms_schema_migrations").fetchone()[0] == 2
         tables = {row[0] for row in migrated.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
         assert {"comms_messages", "requests", "artifacts", "formal_review_jobs"}.issubset(tables)
     finally:

--- a/tests/test_comms_plane_status_api.py
+++ b/tests/test_comms_plane_status_api.py
@@ -29,7 +29,7 @@ def test_read_plane_status_defaults_off(tmp_path: Path, monkeypatch) -> None:
     assert status["mode"] == "off"
     assert status["enabled"] is False
     assert status["read_only"] is True
-    assert status["schema"]["known_version"] == 1
+    assert status["schema"]["known_version"] == 2
     assert status["schema"]["applied_version"] is None
     assert status["schema"]["db_exists"] is False
     assert status["parity_telemetry"]["exists"] is False
@@ -43,7 +43,7 @@ def test_read_plane_status_with_schema_and_telemetry(tmp_path: Path, monkeypatch
     conn = sqlite3.connect(str(db_path))
     try:
         applied = apply_migrations(conn)
-        assert applied == 1
+        assert applied == 2
     finally:
         conn.close()
 
@@ -61,8 +61,8 @@ def test_read_plane_status_with_schema_and_telemetry(tmp_path: Path, monkeypatch
     assert status["mode"] == "shadow"
     assert status["enabled"] is True
     assert status["schema"]["db_exists"] is True
-    assert status["schema"]["applied_version"] == 1
-    assert status["schema"]["applied_name"] == "fleet-comms-v1-contracts"
+    assert status["schema"]["applied_version"] == 2
+    assert status["schema"]["applied_name"] == "fleet-comms-v2-sealed-verdict-artifact"
     assert status["parity_telemetry"]["exists"] is True
     assert status["parity_telemetry"]["event_count"] == 3
     assert status["parity_telemetry"]["parity_ok_count"] == 1
@@ -91,7 +91,7 @@ def test_api_plane_status_endpoint(tmp_path: Path, monkeypatch) -> None:
     assert data["plane_root"] == str(tmp_path / "plane")
     assert data["parity_telemetry"]["exists"] is True
     assert data["parity_telemetry"]["event_count"] == 1
-    assert data["schema"]["known_version"] == 1
+    assert data["schema"]["known_version"] == 2
 
 
 def test_api_plane_status_invalid_mode(monkeypatch) -> None:

--- a/tests/test_fleet_comms_cli.py
+++ b/tests/test_fleet_comms_cli.py
@@ -24,7 +24,7 @@ def _seed_plane_db(root: Path) -> Path:
     db_path = root / "comms.sqlite3"
     conn = sqlite3.connect(str(db_path))
     try:
-        assert apply_migrations(conn) == 1
+        assert apply_migrations(conn) == 2
         conn.execute(
             """INSERT INTO formal_review_jobs(
                 review_id, repository, pr_number, head_sha, gate_kind,

--- a/tests/test_fleet_comms_contracts.py
+++ b/tests/test_fleet_comms_contracts.py
@@ -99,9 +99,9 @@ def test_migrations_are_idempotent_and_reject_unknown_future_version(tmp_path: P
     db_path = tmp_path / "messages.db"
     conn = sqlite3.connect(db_path)
     conn.execute("CREATE TABLE deliveries (delivery_id TEXT PRIMARY KEY, status TEXT)")
-    assert apply_migrations(conn) == 1
+    assert apply_migrations(conn) == 2
     first = conn.execute("SELECT version, checksum FROM comms_schema_migrations").fetchall()
-    assert apply_migrations(conn) == 1
+    assert apply_migrations(conn) == 2
     assert conn.execute("SELECT version, checksum FROM comms_schema_migrations").fetchall() == first
     assert {"request_id", "endpoint_id", "expires_at", "fence_token"}.issubset(
         {row[1] for row in conn.execute("PRAGMA table_info(deliveries)")}

--- a/tests/test_fleet_comms_formal_finalize.py
+++ b/tests/test_fleet_comms_formal_finalize.py
@@ -1,0 +1,166 @@
+"""Tests for formal-job accept finalize glue (#5512)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.fleet_comms.formal_review_finalize import (
+    FormalReviewFinalizeError,
+    finalize_formal_review_verdict,
+    resolve_verdict_token,
+)
+from scripts.fleet_comms.formal_review_jobs import FormalReviewJobService
+
+_SHA = "a" * 40
+_REPO = "learn-ukrainian/learn-ukrainian.github.io"
+
+
+class FakeGh:
+    def __init__(self, *, head: str = _SHA) -> None:
+        self.head = head
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self, command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(command))
+        if len(command) >= 3 and command[1] == "pr" and command[2] == "view":
+            return subprocess.CompletedProcess(command, 0, stdout=f"{self.head}\n", stderr="")
+        if len(command) >= 3 and command[1] == "pr" and command[2] == "comment":
+            return subprocess.CompletedProcess(
+                command, 0, stdout="https://example.test/c\n", stderr=""
+            )
+        if len(command) >= 2 and command[1] == "api":
+            return subprocess.CompletedProcess(command, 0, stdout="{}", stderr="")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="unexpected")
+
+
+def test_resolve_verdict_token_sources(tmp_path: Path) -> None:
+    assert resolve_verdict_token(verdict="approved") == "APPROVED"
+    assert (
+        resolve_verdict_token(verdict_text="notes\nVERDICT: CHANGES_REQUESTED\n")
+        == "CHANGES_REQUESTED"
+    )
+    f = tmp_path / "f.json"
+    f.write_text(json.dumps({"verdict": "BLOCKED"}), encoding="utf-8")
+    assert resolve_verdict_token(findings_path=f) == "BLOCKED"
+    with pytest.raises(FormalReviewFinalizeError, match="verdict_required"):
+        resolve_verdict_token()
+
+
+def test_finalize_creates_job_and_accepts(tmp_path: Path) -> None:
+    root = tmp_path / "plane"
+    gh = FakeGh()
+    result = finalize_formal_review_verdict(
+        pr_number=5571,
+        model="zai-coding-plan/glm-5.2",
+        family="zhipu",
+        harness="opencode",
+        verdict="APPROVED",
+        plane_root=root,
+        runner=gh,
+    )
+    assert result.job_created is True
+    assert result.verdict == "APPROVED"
+    assert result.head_sha == _SHA
+    assert result.sealed_verdict_artifact_id is not None
+    assert result.published is False
+    with FormalReviewJobService(root=root) as svc:
+        job = svc.get_job(result.review_id)
+        assert job.has_sealed_verdict
+        sealed = svc.load_sealed_verdict(result.review_id)
+        assert sealed.model == "zai-coding-plan/glm-5.2"
+        assert sealed.family == "zhipu"
+
+
+def test_finalize_reuses_job_idempotent(tmp_path: Path) -> None:
+    root = tmp_path / "plane"
+    gh = FakeGh()
+    first = finalize_formal_review_verdict(
+        pr_number=100,
+        model="m",
+        family="f",
+        harness="h",
+        verdict="APPROVED",
+        plane_root=root,
+        runner=gh,
+    )
+    second = finalize_formal_review_verdict(
+        pr_number=100,
+        model="m",
+        family="f",
+        harness="h",
+        verdict="APPROVED",
+        plane_root=root,
+        runner=gh,
+    )
+    assert first.review_id == second.review_id
+    assert second.job_created is False
+
+
+def test_finalize_publish_dry_run_and_live(tmp_path: Path) -> None:
+    root = tmp_path / "plane"
+    gh = FakeGh()
+    dry = finalize_formal_review_verdict(
+        pr_number=200,
+        model="m",
+        family="f",
+        harness="h",
+        verdict="CHANGES_REQUESTED",
+        plane_root=root,
+        runner=gh,
+        dry_run_publish=True,
+    )
+    assert dry.published is False
+    assert dry.publication_summary is not None
+    assert "posted=false" in dry.publication_summary or "action=" in dry.publication_summary
+
+    gh2 = FakeGh()
+    live = finalize_formal_review_verdict(
+        pr_number=201,
+        model="m",
+        family="f",
+        harness="h",
+        verdict="APPROVED",
+        plane_root=root,
+        runner=gh2,
+        publish=True,
+    )
+    assert live.published is True
+    assert any(c[1:3] == ["pr", "comment"] for c in gh2.calls)
+
+
+def test_cli_formal_job_accept(tmp_path: Path) -> None:
+    from scripts.fleet_comms.cli import main
+
+    root = tmp_path / "plane"
+    # Inject head via --head-sha to avoid real gh
+    rc = main(
+        [
+            "formal-job",
+            "accept",
+            "--pr",
+            "300",
+            "--verdict",
+            "APPROVED",
+            "--model",
+            "m",
+            "--family",
+            "f",
+            "--harness",
+            "h",
+            "--head-sha",
+            _SHA,
+            "--root",
+            str(root),
+        ]
+    )
+    assert rc == 0
+    with FormalReviewJobService(root=root) as svc:
+        jobs = svc.list_jobs(pr=300)
+        assert len(jobs) == 1
+        assert jobs[0].has_sealed_verdict

--- a/tests/test_fleet_comms_formal_review_jobs.py
+++ b/tests/test_fleet_comms_formal_review_jobs.py
@@ -164,3 +164,79 @@ def test_snapshot_artifact_id_must_exist(tmp_path: Path) -> None:
                     GATE,
                     snapshot_artifact_id="artifact_nope",
                 )
+
+
+_SHA = "a" * 40
+
+
+def _sealed_payload(review_id: str, **overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "review_id": review_id,
+        "repository": REPO,
+        "pr_number": 5512,
+        "head_sha": _SHA,
+        "gate_kind": GATE,
+        "verdict": "APPROVED",
+        "model": "claude-opus-4-6",
+        "family": "anthropic",
+        "harness": "claude",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_accept_and_load_sealed_verdict(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, _SHA, GATE)
+        assert job.sealed_verdict_artifact_id is None
+        sealed = svc.accept_sealed_verdict(job.review_id, _sealed_payload(job.review_id))
+        assert sealed.verdict == "APPROVED"
+        loaded_job = svc.get_job(job.review_id)
+        assert loaded_job.has_sealed_verdict
+        assert loaded_job.state == "complete"
+        again = svc.load_sealed_verdict(job.review_id)
+        assert again.to_dict() == sealed.to_dict()
+        # Idempotent re-accept of identical payload
+        same = svc.accept_sealed_verdict(job.review_id, _sealed_payload(job.review_id))
+        assert same.verdict == "APPROVED"
+
+
+def test_accept_sealed_verdict_rejects_identity_mismatch(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, _SHA, GATE)
+        with pytest.raises(FormalReviewJobsError, match="sealed_job_mismatch"):
+            svc.accept_sealed_verdict(
+                job.review_id,
+                _sealed_payload(job.review_id, pr_number=9999),
+            )
+
+
+def test_accept_sealed_verdict_refuses_overwrite(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, _SHA, GATE)
+        svc.accept_sealed_verdict(job.review_id, _sealed_payload(job.review_id))
+        with pytest.raises(FormalReviewJobsError, match="sealed_verdict_already_set"):
+            svc.accept_sealed_verdict(
+                job.review_id,
+                _sealed_payload(job.review_id, verdict="CHANGES_REQUESTED"),
+            )
+
+
+def test_load_sealed_verdict_missing(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 42, _SHA, GATE)
+        with pytest.raises(FormalReviewJobsError, match="sealed_verdict_missing"):
+            svc.load_sealed_verdict(job.review_id)
+
+
+def test_migration_v2_adds_sealed_column(tmp_path: Path) -> None:
+    import sqlite3
+
+    from scripts.fleet_comms.migrations import apply_migrations
+
+    db = tmp_path / "c.sqlite3"
+    conn = sqlite3.connect(str(db))
+    assert apply_migrations(conn) == 2
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(formal_review_jobs)")}
+    assert "sealed_verdict_artifact_id" in cols
+    conn.close()

--- a/tests/test_fleet_comms_review_publisher.py
+++ b/tests/test_fleet_comms_review_publisher.py
@@ -232,3 +232,39 @@ def test_sealed_payload_file_round_trip(tmp_path: Path) -> None:
     assert result.plan.verdict == "BLOCKED"
     assert result.plan.status_state == STATUS_ERROR
     assert result.status_posted is True
+
+
+def test_publish_from_review_id_via_accept_sealed(tmp_path: Path) -> None:
+    """Sol milestone 2: publish without CLI-supplied provenance after accept."""
+    from scripts.fleet_comms.formal_review_jobs import FormalReviewJobService
+
+    root = tmp_path / "plane"
+    gh = FakeGh(head=_SHA_A)
+    with FormalReviewJobService(root=root) as svc:
+        job = svc.create_job(_REPO, 5512, _SHA_A, "cross-family-review")
+        svc.accept_sealed_verdict(
+            job.review_id,
+            {
+                "review_id": job.review_id,
+                "repository": _REPO,
+                "pr_number": 5512,
+                "head_sha": _SHA_A,
+                "gate_kind": "cross-family-review",
+                "verdict": "APPROVED",
+                "model": "gpt-5.6-terra",
+                "family": "openai",
+                "harness": "codex",
+            },
+        )
+        sealed = svc.load_sealed_verdict(job.review_id)
+        result = publish_sealed_verdict(
+            sealed,
+            current_head_sha=_SHA_A,
+            mutate=True,
+            runner=gh,
+            store=svc.store,
+            require_receipt=True,
+        )
+    assert result.status_posted is True
+    assert result.plan.verdict == "APPROVED"
+    assert result.publication_id is not None


### PR DESCRIPTION
## Summary
- **Post-`review-pr` glue:** `scripts.fleet_comms.formal_review_finalize` + CLI `formal-job accept`
- Create/reuse job for `(repo, pr, head, gate)` → `accept_sealed_verdict` → optional `--publish`
- Documents finalize path on `review-pr` help; does **not** auto-run inside `review-pr`
- Stacks on #5571 (PR-F sealed verdict storage)

## Usage after a CF reply
```bash
.venv/bin/python -m scripts.fleet_comms formal-job accept \
  --pr 5571 \
  --verdict APPROVED \
  --model zai-coding-plan/glm-5.2 \
  --family zhipu \
  --harness opencode \
  [--publish]
```

## Parent
#5512 · depends on #5571

## Test plan
- [x] `pytest tests/test_fleet_comms_formal_finalize.py` (5 passed)
- [ ] CI green after base merges
- [ ] Cross-family review