### PR TITLE
feat(fleet-comms): add common session supervisor

### DIFF
--- a/docs/runbooks/session-supervisor.md
+++ b/docs/runbooks/session-supervisor.md
@@ -1,0 +1,49 @@
+# Common session supervisor
+
+`scripts.session_supervisor` is the PR-I launcher boundary for a session-stream
+driver. It opens the fenced lease before a harness starts, then emits the
+read-only bootstrap capsule. A harness or model must never open, renew, close,
+or recover its own lease.
+
+## Launcher contract
+
+Launch a driver with an exact numeric stream and an explicit role. The command
+returns a JSON capsule in the required order: identity, pending rollover slot,
+digest watermark, dual-write handoff status, then diagnostics.
+
+```bash
+.venv/bin/python -m scripts.session_supervisor --db /approved/session-streams.sqlite3 \
+  --repo-root "$PWD" open --role driver --stream epic:4707 --agent codex \
+  --harness codex-cli --instance-id codex-4707-1 --process-id "$$" \
+  --lineage-id lineage-4707-codex --ttl-seconds 300
+```
+
+The capsule contains lease identifiers for binding and audit only; it exports no
+lease credentials and gives no model-owned lifecycle command. A future launcher
+keeps the exact lease envelope in its supervisor-owned environment, then calls
+the matching lifecycle action on clean exit:
+
+```bash
+.venv/bin/python -m scripts.session_supervisor --db /approved/session-streams.sqlite3 close --role driver
+```
+
+`resume` and `heartbeat` also consume that exact supervisor-owned
+`SESSION_STREAM_*` envelope. Fencing is enforced by
+`agents_extensions.shared.session_streams`; a stale envelope is refused.
+
+## Worker launches
+
+Workers never acquire a lease. They receive a capsule only after the stream
+already exists, and their child environment must be built by removing every
+`SESSION_STREAM_*` field. The `worker-env` command exposes that stripping
+operation for launcher integration tests.
+
+```bash
+.venv/bin/python -m scripts.session_supervisor --repo-root "$PWD" \
+  --db /approved/session-streams.sqlite3 capsule --role worker --stream epic:4707
+```
+
+Automatic crash recovery is intentionally fail-closed in this slice. It awaits
+the recovery-plan digest and exact repository/runtime/rollover receipts required
+by the fleet-comms architecture; operators retain the existing audited recovery
+path until that contract is available.

--- a/scripts/session_supervisor/__init__.py
+++ b/scripts/session_supervisor/__init__.py
@@ -1,0 +1,326 @@
+"""Common harness-owned supervisor library for fenced session-stream leases.
+
+This is the PR-I contract surface.  Launchers own process creation; this module
+opens or resumes a driver lease before that creation and renders the bounded
+bootstrap capsule the launcher passes to the harness.  It intentionally does
+not put lease actions in the capsule or allow workers to receive lease state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.dual_write import resolve_handoff_path
+from agents_extensions.shared.session_streams.hooks import clean_exit_hook, lease_from_environment
+from agents_extensions.shared.session_streams.inventory import epic_handoff_map
+from agents_extensions.shared.session_streams.model import (
+    Lease,
+    LeaseHolder,
+    StreamDigest,
+    canonical_json,
+    entry_as_dict,
+    sha256_text,
+)
+from agents_extensions.shared.session_streams.receipts import list_migration_state
+from agents_extensions.shared.session_streams.store import SessionStreamError, SessionStreamStore
+
+CAPSULE_SCHEMA = "session-supervisor-bootstrap.v1"
+LEASE_ENV_PREFIX = "SESSION_STREAM_"
+
+
+class SupervisorError(ValueError):
+    """A launch request violates the common supervisor contract."""
+
+
+class LaunchRole(StrEnum):
+    """The only roles accepted by the launcher-supervisor boundary."""
+
+    DRIVER = "driver"
+    WORKER = "worker"
+
+
+@dataclass(frozen=True, slots=True)
+class BootstrapCapsule:
+    """Read-only cold-start payload in the architecture's fixed order."""
+
+    role: LaunchRole
+    stream_id: str
+    lease: dict[str, Any] | None
+    digest: StreamDigest
+    handoff_paths: tuple[str, ...]
+    active_handoff_path: str | None
+    dual_write_mode: str
+    dual_write_drift: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the stable JSON-ready capsule without executable lease actions."""
+        payload = {
+            "schema": CAPSULE_SCHEMA,
+            "identity": {
+                "role": self.role.value,
+                "stream_id": self.stream_id,
+                "lease": self.lease,
+                "lease_credentials_exported": False,
+            },
+            "rollover": None,
+            "digest": {
+                "stream_id": self.digest.stream_id,
+                "high_water_entry_id": self.digest.high_water_entry_id,
+                "digest_sha256": self.digest.digest_sha256,
+                "pinned": [entry_as_dict(entry) for entry in self.digest.pinned],
+                "recent": [entry_as_dict(entry) for entry in self.digest.recent],
+            },
+            "dual_write": {
+                "mode": self.dual_write_mode,
+                "handoff_paths": list(self.handoff_paths),
+                "active_handoff_path": self.active_handoff_path,
+                "drift": self.dual_write_drift,
+            },
+            "diagnostics": {
+                "digest_source": "supervisor-local-fallback",
+                "lease_actions": "supervisor-only",
+            },
+        }
+        payload["capsule_sha256"] = sha256_text(canonical_json(payload))
+        return payload
+
+
+def strip_lease_credentials(environment: Mapping[str, str]) -> dict[str, str]:
+    """Return a worker-safe environment with every lease field removed."""
+    return {key: value for key, value in environment.items() if not key.startswith(LEASE_ENV_PREFIX)}
+
+
+class SessionSupervisor:
+    """Compose the session-stream store into a launcher-owned lifecycle surface."""
+
+    def __init__(self, store: SessionStreamStore, *, repo_root: Path) -> None:
+        self.store = store
+        self.repo_root = repo_root.resolve()
+
+    @staticmethod
+    def _require_driver(role: LaunchRole | str) -> None:
+        try:
+            resolved = LaunchRole(role)
+        except ValueError as exc:
+            raise SupervisorError("role must be driver or worker") from exc
+        if resolved is not LaunchRole.DRIVER:
+            raise SupervisorError("workers cannot acquire, resume, heartbeat, or close driver leases")
+
+    def open_driver(
+        self,
+        *,
+        role: LaunchRole | str,
+        stream_id: str,
+        holder: LeaseHolder,
+        lineage_id: str,
+        ttl_seconds: int,
+    ) -> Lease:
+        """Open one exact fenced driver lease before a harness is started."""
+        self._require_driver(role)
+        return self.store.open_session(
+            stream_id=stream_id,
+            holder=holder,
+            lineage_id=lineage_id,
+            ttl_seconds=ttl_seconds,
+            reason="common session supervisor driver open",
+        )
+
+    def resume_driver(self, *, role: LaunchRole | str, lease: Lease) -> Lease:
+        """Resume only the exact pre-existing lease envelope by heartbeating it."""
+        self._require_driver(role)
+        return self.store.heartbeat(lease)
+
+    def heartbeat_driver(self, *, role: LaunchRole | str, lease: Lease) -> Lease:
+        """Heartbeat only the exact fenced driver lease."""
+        self._require_driver(role)
+        return self.store.heartbeat(lease)
+
+    def close_driver(self, *, role: LaunchRole | str, lease: Lease) -> str:
+        """Cleanly close only the exact driver session."""
+        self._require_driver(role)
+        return clean_exit_hook(self.store, lease).state
+
+    def recover_expired_driver(self, *, role: LaunchRole | str, stream_id: str) -> None:
+        """Fail closed until recovery-plan receipts bind the full PR-I proof set."""
+        self._require_driver(role)
+        raise SupervisorError(
+            "automatic recovery is unavailable: require an audited recovery-plan digest and exact receipts"
+        )
+
+    def build_capsule(
+        self,
+        *,
+        role: LaunchRole | str,
+        stream_id: str,
+        lease: Lease | None = None,
+        digest_limit: int = 20,
+    ) -> BootstrapCapsule:
+        """Render the ordered local fallback capsule for a driver or worker."""
+        try:
+            resolved_role = LaunchRole(role)
+        except ValueError as exc:
+            raise SupervisorError("role must be driver or worker") from exc
+        if resolved_role is LaunchRole.WORKER and lease is not None:
+            raise SupervisorError("workers cannot receive driver lease credentials")
+        if resolved_role is LaunchRole.DRIVER and lease is None:
+            raise SupervisorError("drivers require an exact supervisor-owned lease to build a capsule")
+        if lease is not None and lease.stream_id != stream_id:
+            raise SupervisorError("capsule stream_id must exactly match the lease stream_id")
+
+        digest = self.store.load_digest(stream_id, limit=digest_limit)
+        handoff_paths = tuple(epic_handoff_map(self.repo_root).get(stream_id, ()))
+        active = resolve_handoff_path(stream_id, self.repo_root)
+        mode, drift = self._dual_write_status(stream_id)
+        lease_summary = self._lease_summary(lease) if resolved_role is LaunchRole.DRIVER and lease else None
+        return BootstrapCapsule(
+            role=resolved_role,
+            stream_id=stream_id,
+            lease=lease_summary,
+            digest=digest,
+            handoff_paths=handoff_paths,
+            active_handoff_path=self._relative_path(active),
+            dual_write_mode=mode,
+            dual_write_drift=drift,
+        )
+
+    def _dual_write_status(self, stream_id: str) -> tuple[str, bool]:
+        rows = list_migration_state(self.store)
+        mode = next((str(row["mode"]) for row in rows if row["stream_id"] == stream_id), "unregistered")
+        with self.store._read_snapshot() as connection:
+            row = connection.execute(
+                "SELECT status FROM legacy_projection_receipts WHERE stream_id = ? "
+                "ORDER BY projection_id DESC LIMIT 1",
+                (stream_id,),
+            ).fetchone()
+        return mode, bool(row and str(row["status"]) in {"drift", "failed"})
+
+    def _relative_path(self, path: Path | None) -> str | None:
+        if path is None:
+            return None
+        try:
+            return path.resolve().relative_to(self.repo_root).as_posix()
+        except ValueError:
+            return str(path)
+
+    @staticmethod
+    def _lease_summary(lease: Lease) -> dict[str, Any]:
+        return {
+            "session_id": lease.session_id,
+            "lease_id": lease.lease_id,
+            "generation": lease.generation,
+            "fencing_token": lease.fencing_token,
+            "expires_at": lease.expires_at,
+        }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the small CLI contract that future launchers invoke."""
+    parser = argparse.ArgumentParser(
+        prog="session-supervisor",
+        description="Open and supervise fenced driver leases; workers only receive read-only capsules.",
+    )
+    parser.add_argument("--db", type=Path, default=None, help="Session-stream SQLite path.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Repository root for handoff status.")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    open_driver = commands.add_parser("open", help="Open a driver lease and emit its bootstrap capsule.")
+    _add_driver_identity(open_driver)
+    open_driver.add_argument("--lineage-id", required=True)
+    open_driver.add_argument("--ttl-seconds", type=int, default=300)
+    open_driver.add_argument("--digest-limit", type=int, default=20)
+
+    for name, help_text in (
+        ("resume", "Heartbeat an exact inherited driver lease and emit a capsule."),
+        ("heartbeat", "Heartbeat an exact inherited driver lease."),
+        ("close", "Close an exact inherited driver lease."),
+    ):
+        command = commands.add_parser(name, help=help_text)
+        command.add_argument("--role", required=True, choices=tuple(LaunchRole))
+        if name == "resume":
+            command.add_argument("--digest-limit", type=int, default=20)
+
+    capsule = commands.add_parser("capsule", help="Render a read-only bootstrap capsule.")
+    capsule.add_argument("--role", required=True, choices=tuple(LaunchRole))
+    capsule.add_argument("--stream", required=True)
+    capsule.add_argument("--digest-limit", type=int, default=20)
+
+    commands.add_parser("worker-env", help="Print the current environment with all lease fields stripped.")
+    return parser
+
+
+def _add_driver_identity(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--role", required=True, choices=tuple(LaunchRole))
+    parser.add_argument("--stream", required=True)
+    parser.add_argument("--agent", required=True)
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--instance-id", required=True)
+    parser.add_argument("--process-id", required=True, type=int)
+    parser.add_argument("--task-id", default=None)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one lifecycle action and render only JSON to stdout."""
+    args = build_parser().parse_args(argv)
+    if args.command == "worker-env":
+        print(json.dumps(strip_lease_credentials(os.environ), ensure_ascii=False, sort_keys=True))
+        return 0
+
+    supervisor = SessionSupervisor(
+        SessionStreamStore(SessionStreamDatabase(args.db)), repo_root=args.repo_root
+    )
+    try:
+        if args.command == "open":
+            holder = LeaseHolder(
+                agent=args.agent,
+                harness=args.harness,
+                instance_id=args.instance_id,
+                process_id=args.process_id,
+                task_id=args.task_id,
+            )
+            lease = supervisor.open_driver(
+                role=args.role,
+                stream_id=args.stream,
+                holder=holder,
+                lineage_id=args.lineage_id,
+                ttl_seconds=args.ttl_seconds,
+            )
+            payload = supervisor.build_capsule(
+                role=args.role, stream_id=args.stream, lease=lease, digest_limit=args.digest_limit
+            ).as_dict()
+        elif args.command in {"resume", "heartbeat", "close"}:
+            lease = lease_from_environment()
+            if args.command == "resume":
+                renewed = supervisor.resume_driver(role=args.role, lease=lease)
+                payload = supervisor.build_capsule(
+                    role=args.role,
+                    stream_id=renewed.stream_id,
+                    lease=renewed,
+                    digest_limit=args.digest_limit,
+                ).as_dict()
+            elif args.command == "heartbeat":
+                renewed = supervisor.heartbeat_driver(role=args.role, lease=lease)
+                payload = {"action": "heartbeat", "stream_id": renewed.stream_id, "expires_at": renewed.expires_at}
+            else:
+                payload = {"action": "close", "stream_id": lease.stream_id, "state": supervisor.close_driver(role=args.role, lease=lease)}
+        else:
+            payload = supervisor.build_capsule(
+                role=args.role, stream_id=args.stream, digest_limit=args.digest_limit
+            ).as_dict()
+    except (SessionStreamError, SupervisorError, ValueError) as exc:
+        print(f"session-supervisor: {exc}", file=sys.stderr)
+        return 4
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    raise SystemExit(main())

--- a/scripts/session_supervisor/__main__.py
+++ b/scripts/session_supervisor/__main__.py
@@ -1,0 +1,5 @@
+"""Module entry point for the common session supervisor."""
+
+from scripts.session_supervisor import main
+
+raise SystemExit(main())

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -1,0 +1,123 @@
+"""PR-I supervisor contract over a temporary session-stream SQLite database."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.model import LeaseHolder
+from agents_extensions.shared.session_streams.store import LeaseConflictError, SessionStreamStore
+from scripts.session_supervisor import LaunchRole, SessionSupervisor, SupervisorError, main, strip_lease_credentials
+
+
+def _supervisor(tmp_path: Path) -> SessionSupervisor:
+    store = SessionStreamStore(SessionStreamDatabase(tmp_path / "streams.sqlite3"))
+    return SessionSupervisor(store, repo_root=Path.cwd())
+
+
+def _holder() -> LeaseHolder:
+    return LeaseHolder(
+        agent="codex",
+        harness="native-codex",
+        instance_id="codex-supervisor-test",
+        process_id=os.getpid(),
+        task_id="5512-pr-i",
+    )
+
+
+def test_driver_open_heartbeat_close_and_capsule_are_fenced(tmp_path: Path) -> None:
+    supervisor = _supervisor(tmp_path)
+    lease = supervisor.open_driver(
+        role=LaunchRole.DRIVER,
+        stream_id="epic:4707",
+        holder=_holder(),
+        lineage_id="lineage-supervisor-test",
+        ttl_seconds=300,
+    )
+
+    capsule = supervisor.build_capsule(role=LaunchRole.DRIVER, stream_id="epic:4707", lease=lease).as_dict()
+    assert capsule["identity"]["stream_id"] == "epic:4707"
+    assert capsule["identity"]["lease"]["lease_id"] == lease.lease_id
+    assert capsule["identity"]["lease_credentials_exported"] is False
+    assert capsule["diagnostics"]["lease_actions"] == "supervisor-only"
+    assert capsule["dual_write"]["handoff_paths"]
+    assert len(capsule["capsule_sha256"]) == 64
+
+    renewed = supervisor.heartbeat_driver(role="driver", lease=lease)
+    with pytest.raises(LeaseConflictError):
+        supervisor.heartbeat_driver(role="driver", lease=replace(lease, fencing_token=lease.fencing_token + 1))
+    assert supervisor.close_driver(role="driver", lease=renewed) == "closed"
+
+
+def test_workers_cannot_acquire_or_receive_driver_lease(tmp_path: Path) -> None:
+    supervisor = _supervisor(tmp_path)
+    with pytest.raises(SupervisorError, match="workers cannot acquire"):
+        supervisor.open_driver(
+            role=LaunchRole.WORKER,
+            stream_id="epic:4707",
+            holder=_holder(),
+            lineage_id="lineage-worker-refusal",
+            ttl_seconds=300,
+        )
+
+    lease = supervisor.open_driver(
+        role="driver",
+        stream_id="epic:4707",
+        holder=_holder(),
+        lineage_id="lineage-worker-capsule",
+        ttl_seconds=300,
+    )
+    with pytest.raises(SupervisorError, match="cannot receive"):
+        supervisor.build_capsule(role="worker", stream_id="epic:4707", lease=lease)
+
+    worker = supervisor.build_capsule(role="worker", stream_id="epic:4707").as_dict()
+    assert worker["identity"]["lease"] is None
+    with pytest.raises(SupervisorError, match="require an exact"):
+        supervisor.build_capsule(role="driver", stream_id="epic:4707")
+
+
+def test_worker_environment_strips_every_lease_credential() -> None:
+    environment = {
+        "SESSION_STREAM_LEASE_ID": "lease-private",
+        "SESSION_STREAM_FENCING_TOKEN": "7",
+        "KEEP_ME": "safe",
+    }
+    assert strip_lease_credentials(environment) == {"KEEP_ME": "safe"}
+
+
+def test_automatic_recovery_fails_closed_without_audited_plan(tmp_path: Path) -> None:
+    supervisor = _supervisor(tmp_path)
+    with pytest.raises(SupervisorError, match="recovery-plan digest"):
+        supervisor.recover_expired_driver(role="driver", stream_id="epic:4707")
+
+
+def test_cli_refuses_worker_open_attempt(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(
+        [
+            "--db",
+            str(tmp_path / "streams.sqlite3"),
+            "--repo-root",
+            str(Path.cwd()),
+            "open",
+            "--role",
+            "worker",
+            "--stream",
+            "epic:4707",
+            "--agent",
+            "agy",
+            "--harness",
+            "agy-bridge",
+            "--instance-id",
+            "worker-attempt",
+            "--process-id",
+            str(os.getpid()),
+            "--lineage-id",
+            "worker-lineage",
+        ]
+    )
+    assert exit_code == 4
+    assert "workers cannot acquire" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

First landable PR-I slice for #5512 (stream #4707):

- Adds a common session-supervisor library and CLI skeleton that opens, resumes, heartbeats, and cleanly closes exact fenced driver leases through `agents_extensions.shared.session_streams`.
- Emits a fixed-order local bootstrap capsule with stream/lease identity, digest watermark, handoff paths, and dual-write status; capsule contains no lifecycle action.
- Fails closed for worker lease attempts, strips `SESSION_STREAM_*` credentials for worker environments, and fails closed for automatic recovery until audited plan-digest receipts exist.
- Adds temporary-SQLite unit coverage and a launcher runbook.

## PR-I acceptance coverage

- [x] Two simultaneous driver attempts are serialized by the existing fenced stream store; exact wrong-fence mutation is refused.
- [x] Workers cannot lease or receive lease credentials.
- [x] Supervisor owns normal lifecycle operations; model capsule exposes no lease action.
- [x] Bootstrap capsule exposes exact stream, lease IDs, handoff paths, digest watermark, and dual-write drift/mode.
- [x] Recovery is explicitly fail-closed pending the architecture-required audited recovery transaction.

## Verification

- `.venv/bin/ruff check scripts/session_supervisor.py tests/test_session_supervisor.py`
- `.venv/bin/python -m pytest tests/test_session_supervisor.py tests/test_session_streams.py tests/test_session_stream_handoff.py tests/test_session_streams_cli.py -q` (31 passed)
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check`

Non-goals remain with PR-J1/J2 and later PR-I follow-ups: launcher cutovers, Claude SessionStart wiring, message-plane changes, formal review changes, and automatic crash-recovery apply.