### PR TITLE
feat(fleet-comms): PR-J1 Grok + Kimi common session supervisor onboarding

### DIFF
--- a/docs/runbooks/grok-session-canary.md
+++ b/docs/runbooks/grok-session-canary.md
@@ -107,13 +107,16 @@ Artifacts live under gitignored `.claude/<epic>-epic/canary/`.
 ## Lifecycle
 
 ```
-START  → open stream lease → load diary + stream → mint canary
+START  → start-grok.sh --epic <name> claims stream lease via common supervisor
+         → load diary + stream → mint canary
 DRIVE  → stamp diary after each batch
          at ~60–70% context OR after auto-compact → score from memory
          PASS → diary canary line; continue
          FAIL → STATE AT HANDBACK + close stream + quit
 END    → handback while PASS (optional) before forced compact
 ```
+
+The launcher owns lease open/close for Grok. The cold-start prompt explicitly tells the model not to open or resume the lease itself.
 
 ## SSOT
 

--- a/docs/runbooks/kimi-orchestrator.md
+++ b/docs/runbooks/kimi-orchestrator.md
@@ -1,0 +1,83 @@
+# Kimi orchestrator runbook
+
+## Launcher
+
+`start-kimi.sh` is the native Kimi Code CLI launcher. It mirrors `start-grok.sh` but targets the Kimi seat.
+
+## Usage
+
+```bash
+# Pin a lane and auto-claim the stream lease
+./start-kimi.sh --epic atlas
+
+# Explicit stream override
+./start-kimi.sh --epic atlas --stream epic:4387
+
+# Use K3 for a consequential review
+./start-kimi.sh --epic harness --model k3 "review the open PR"
+
+# No epic — plain kimi prompt mode (no supervisor claim)
+./start-kimi.sh --model k2.7-coding "summarize the diff"
+```
+
+## Launcher-only flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--epic <name>` | Pin lane (atlas, harness, hramatka, …) |
+| `--stream <id>` | Override the stream id (default derived from epic) |
+| `--handoff-agent <id>` | Override `SESSION_HANDOFF_AGENT` |
+| `--model <id>` | Kimi model (default: `k2.7-coding`) |
+| `--help-launcher` | Show launcher help |
+
+All other arguments are treated as the prompt passed to `kimi -p …`.
+
+## Cold-start flow with `--epic`
+
+1. Launcher resolves the epic to a stream id.
+2. Launcher calls the common session supervisor (`scripts.session_supervisor open --role driver`) with agent `kimi` / harness `kimi-code`.
+3. Launcher sources `SESSION_STREAM_*` from supervisor output.
+4. Launcher writes a capsule to `.agent/session-capsules/<stream>/`.
+5. Launcher injects an auto-continue prompt if none was supplied.
+6. Launcher execs `kimi -p <prompt> -m <model> --output-format stream-json`.
+
+The cold-start prompt explicitly tells the model **not** to open or resume the lease — the launcher has already claimed it.
+
+## Models
+
+| Short name | Maps to | Use case |
+| --- | --- | --- |
+| `k2.7-coding` | `kimi-code/kimi-for-coding` | Routine / bounded coding (default) |
+| `k2.7-coding-highspeed` | `kimi-code/kimi-for-coding-highspeed` | Fast routine work |
+| `k3` | `kimi-code/k3` | Consequential coding, deep review, cross-family review |
+
+K3 is always max effort; an explicit `--effort` is ignored for K3.
+
+## Handoff identity
+
+| Epic | `SESSION_HANDOFF_AGENT` |
+| --- | --- |
+| atlas, hramatka, folk, bio, … | `kimi-<epic>` |
+| harness / infra | `kimi-infra` |
+
+## Session lifecycle
+
+- Lease is claimed by the launcher PID (which becomes the `kimi` PID after `exec`).
+- Heartbeat / clean-close hooks are available via `agents_extensions.shared.session_streams hook` but are not automatically wired for Kimi in PR-J1; call them explicitly if a long-running prompt session needs to keep the lease alive.
+- End-of-session canary policy follows the same `FAIL-HANDOFF (<8/10)` rule as Grok.
+
+## No lease folklore
+
+The model must not:
+- Call `scripts.session_supervisor` open/close, `handoff-claim`, or any other lease lifecycle command.
+- Invent a second stream lease.
+- Ignore the `SESSION_STREAM_ID` already exported by the launcher.
+
+If the launcher fails to claim the lease, it exits before starting Kimi.
+
+## Related
+
+- `start-kimi.sh`
+- `scripts/lib/session_supervisor.sh`
+- `docs/runbooks/session-supervisor.md`
+- `scripts/agent_runtime/adapters/kimi.py`

--- a/docs/runbooks/session-supervisor.md
+++ b/docs/runbooks/session-supervisor.md
@@ -12,24 +12,102 @@ returns a JSON capsule in the required order: identity, pending rollover slot,
 digest watermark, dual-write handoff status, then diagnostics.
 
 ```bash
-.venv/bin/python -m scripts.session_supervisor --db /approved/session-streams.sqlite3 \
-  --repo-root "$PWD" open --role driver --stream epic:4707 --agent codex \
-  --harness codex-cli --instance-id codex-4707-1 --process-id "$$" \
-  --lineage-id lineage-4707-codex --ttl-seconds 300
+.venv/bin/python -m scripts.session_supervisor \
+  --repo-root "$PWD" open \
+  --role driver --stream epic:4707 --agent grok \
+  --harness grok-tui --instance-id grok-4707-1 --process-id $$ \
+  --lineage-id lineage-4707-grok --ttl-seconds 300
 ```
 
-The capsule contains lease identifiers for binding and audit only; it exports no
-lease credentials and gives no model-owned lifecycle command. A future launcher
-keeps the exact lease envelope in its supervisor-owned environment, then calls
-the matching lifecycle action on clean exit:
+The capsule contains lease identifiers for binding and audit only; the supervisor
+exports no lease credentials and gives no model-owned lifecycle command. The
+launcher reads the capsule, exports the full `SESSION_STREAM_*` envelope that the
+hook surface requires, and writes a small diagnostics capsule before exec-ing the
+harness.
+
+On clean exit the launcher (or a wrapper) calls the matching lifecycle action:
 
 ```bash
-.venv/bin/python -m scripts.session_supervisor --db /approved/session-streams.sqlite3 close --role driver
+.venv/bin/python -m scripts.session_supervisor close --role driver
 ```
 
 `resume` and `heartbeat` also consume that exact supervisor-owned
 `SESSION_STREAM_*` envelope. Fencing is enforced by
 `agents_extensions.shared.session_streams`; a stale envelope is refused.
+
+## Environment envelope
+
+A launcher that claims a lease must export every `SESSION_STREAM_*` variable the
+hook surface expects:
+
+| Variable | Source | Example |
+| --- | --- | --- |
+| `SESSION_STREAM_ID` | stream id | `epic:4707` |
+| `SESSION_STREAM_SESSION_ID` | new session id | `session-…` |
+| `SESSION_STREAM_LEASE_ID` | new lease id | `lease-…` |
+| `SESSION_STREAM_GENERATION` | session generation | `1` |
+| `SESSION_STREAM_FENCING_TOKEN` | fencing token | `1` |
+| `SESSION_STREAM_AGENT` | agent identity | `grok` |
+| `SESSION_STREAM_HARNESS` | harness identity | `grok-tui` |
+| `SESSION_STREAM_INSTANCE_ID` | distinct runtime instance | `grok-12345` |
+| `SESSION_STREAM_PROCESS_ID` | holder PID | `12345` |
+| `SESSION_STREAM_TASK_ID` | optional task id | `5512-pr-j1-launchers` |
+| `SESSION_STREAM_HEARTBEAT_AT` | last heartbeat timestamp | `2026-07-20T21:00:00Z` |
+| `SESSION_STREAM_EXPIRES_AT` | lease expiry timestamp | `2026-07-21T03:00:00Z` |
+| `SESSION_STREAM_TTL_SECONDS` | lease TTL | `21600` |
+| `SESSION_STREAM_VERSION` | lease schema version | `1` |
+
+The hook CLI consumes the same envelope:
+
+```bash
+.venv/bin/python -m agents_extensions.shared.session_streams hook heartbeat
+.venv/bin/python -m agents_extensions.shared.session_streams hook close
+```
+
+## Launcher helper
+
+`scripts/lib/session_supervisor.sh` is the shared bash helper for non-Claude
+launchers.
+
+```bash
+source "${PROJECT_DIR}/scripts/lib/session_supervisor.sh"
+claim_session_supervisor_env \
+  "epic:4707" "grok" "grok-tui" "5512-pr-j1-launchers" "grok-$$" \
+  "$PROJECT_DIR" "start-grok.sh" "harness"
+```
+
+The helper:
+
+1. Calls `scripts.session_supervisor open --role driver`.
+2. Parses the JSON capsule and exports `SESSION_STREAM_*` from the lease plus the
+   launcher-supplied holder fields.
+3. Writes a JSON capsule under
+   `<canonical-state-root>/.agent/session-capsules/<stream-safe>/<iso>-<pid>.json`
+   in the canonical state root.
+4. Exports `SESSION_SUPERVISOR_CAPSULE_PATH` pointing to the capsule.
+5. Fails the launch closed on supervisor error or an incomplete envelope.
+
+## Capsule schema
+
+```json
+{
+  "schema_version": 1,
+  "written_at": "2026-07-20T21:00:00Z",
+  "launcher": "start-grok.sh",
+  "epic": "harness",
+  "stream_id": "epic:4707",
+  "session_id": "session-…",
+  "lease_id": "lease-…",
+  "agent": "grok",
+  "harness": "grok-tui",
+  "instance_id": "grok-12345",
+  "process_id": 12345,
+  "task_id": "5512-pr-j1-launchers"
+}
+```
+
+Capsules are runtime diagnostics only; they are not committed and are not a
+source of truth for lease state.
 
 ## Worker launches
 
@@ -39,11 +117,28 @@ already exists, and their child environment must be built by removing every
 operation for launcher integration tests.
 
 ```bash
-.venv/bin/python -m scripts.session_supervisor --repo-root "$PWD" \
-  --db /approved/session-streams.sqlite3 capsule --role worker --stream epic:4707
+.venv/bin/python -m scripts.session_supervisor \
+  --repo-root "$PWD" capsule --role worker --stream epic:4707
 ```
 
-Automatic crash recovery is intentionally fail-closed in this slice. It awaits
-the recovery-plan digest and exact repository/runtime/rollover receipts required
-by the fleet-comms architecture; operators retain the existing audited recovery
-path until that contract is available.
+## Error behavior
+
+- Unknown epic → launcher fails before calling the supervisor.
+- Supervisor refuses (live unexpired lease, claimer PID not live, etc.) →
+  launcher exits with an error; no session is started.
+- Incomplete supervisor output → launcher fails closed.
+
+## Claude
+
+Claude's SessionStart hook currently owns its own lease binding. PR-J2 will
+integrate the common supervisor into `start-claude.sh` so `--epic` claims the
+lease before SessionStart binds it.
+
+## Related
+
+- `scripts/session_supervisor/__init__.py`
+- `scripts/session_supervisor/__main__.py`
+- `agents_extensions/shared/session_streams/hooks.py`
+- `scripts/lib/session_supervisor.sh`
+- `docs/runbooks/grok-session-canary.md`
+- `docs/runbooks/kimi-orchestrator.md`

--- a/scripts/lib/session_supervisor.sh
+++ b/scripts/lib/session_supervisor.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Common session supervisor helper for non-Claude launchers (Grok, Kimi, ...).
+#
+# Launchers source this file and call claim_session_supervisor_env to open or
+# resume an epic stream lease through the agent-agnostic session-stream
+# supervisor (`scripts.session_supervisor`). The supervisor emits a JSON
+# bootstrap capsule; this helper parses it, exports the full SESSION_STREAM_*
+# envelope the hook surface expects, verifies the required subset, and writes a
+# JSON capsule for later diagnostics.
+#
+# Usage:
+#   source "${PROJECT_DIR}/scripts/lib/session_supervisor.sh"
+#   claim_session_supervisor_env \
+#       "epic:4707" "grok" "grok-tui" "5512-pr-j1-launchers" "grok-$$" \
+#       "${PROJECT_DIR}" "start-grok.sh" "harness"
+#
+# The helper fails the launch closed (exit 1) if the supervisor returns an
+# error or if the exported lease envelope is incomplete.
+
+# stream_id_for_epic <epic-name>
+# Return the canonical session stream id (epic:<n>) for a launcher shorthand.
+# This is intentionally a small, stable launcher lookup; the authoritative
+# stream→epic mapping lives in scripts/config/issue_streams.yaml.
+stream_id_for_epic() {
+  case "${1:-}" in
+    atlas|practice|practice-hub) printf '%s' 'epic:4387' ;;
+    harness|infra) printf '%s' 'epic:4707' ;;
+    hramatka) printf '%s' 'epic:4542' ;;
+    folk|seminars-folk) printf '%s' 'epic:2836' ;;
+    bio|seminars-bio) printf '%s' 'epic:4431' ;;
+  esac
+}
+
+# _git_env
+# Print a sanitized environment block that ignores inherited Git redirection
+# variables, so commands run against the repo root the launcher is starting in.
+_git_env() {
+  env -u GIT_ALTERNATE_OBJECT_DIRECTORIES \
+      -u GIT_COMMON_DIR \
+      -u GIT_DIR \
+      -u GIT_INDEX_FILE \
+      -u GIT_OBJECT_DIRECTORY \
+      -u GIT_PREFIX \
+      -u GIT_WORK_TREE \
+      "$@"
+}
+
+# _canonical_state_root <repo-root>
+# Print the primary checkout path that owns shared .agent runtime state.
+_canonical_state_root() {
+  local repo_root="${1:-$(pwd)}"
+  local common_dir
+  common_dir="$(_git_env git -C "$repo_root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+  if [ -z "$common_dir" ] || [ "$(basename "$common_dir")" != ".git" ]; then
+    echo "Error: cannot resolve canonical state root for ${repo_root}" >&2
+    return 1
+  fi
+  dirname "$common_dir"
+}
+
+# _iso_timestamp
+# Print current UTC timestamp in ISO-8601 Z format.
+_iso_timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# _shell_json_string <value>
+# Escape a string for inclusion in a JSON object (no surrounding quotes).
+_shell_json_string() {
+  local text="$1"
+  text="${text//\\/\\\\}"
+  text="${text//\"/\\\"}"
+  text="${text//$'\n'/\\n}"
+  text="${text//$'\r'/\\r}"
+  text="${text//$'\t'/\\t}"
+  printf '%s' "$text"
+}
+
+# claim_session_supervisor_env <stream> <agent> <harness> <task-id> <instance-id> <project-dir> <launcher> <epic>
+#
+# Calls the common supervisor to open the stream lease, parses the returned
+# JSON capsule, exports SESSION_STREAM_* variables, and writes a capsule under
+# <canonical-state-root>/.agent/session-capsules/<stream-safe>/<iso>-<pid>.json.
+claim_session_supervisor_env() {
+  if [ "$#" -lt 8 ]; then
+    echo "Error: claim_session_supervisor_env requires 8 arguments." >&2
+    return 1
+  fi
+
+  local stream="$1"
+  local agent="$2"
+  local harness="$3"
+  local task_id="$4"
+  local instance_id="${5:-${2}-$$}"
+  local project_dir="$6"
+  local launcher="$7"
+  local epic="$8"
+
+  local python_bin="$project_dir/.venv/bin/python"
+  if [ ! -x "$python_bin" ]; then
+    echo "Error: project Python not found at ${python_bin}" >&2
+    return 1
+  fi
+
+  local state_root
+  state_root="$(_canonical_state_root "$project_dir")" || return 1
+
+  local supervisor_tmp
+  supervisor_tmp="$(mktemp)"
+  # Ensure cleanup even on early return.
+  # shellcheck disable=SC2064
+  trap "rm -f '$supervisor_tmp'" RETURN
+
+  local stream_normalized="${stream//:/-}"
+  local lineage_id="lineage-${stream_normalized}-${agent}-${$}"
+  local ttl_seconds=21600
+  local heartbeat_at
+  heartbeat_at="$(_iso_timestamp)"
+
+  local -a supervisor_args=(
+    "-m" "scripts.session_supervisor"
+    "open"
+    "--role" "driver"
+    "--stream" "$stream"
+    "--agent" "$agent"
+    "--harness" "$harness"
+    "--instance-id" "$instance_id"
+    "--process-id" "$$"
+    "--lineage-id" "$lineage_id"
+    "--ttl-seconds" "$ttl_seconds"
+  )
+  if [ -n "$task_id" ]; then
+    supervisor_args+=("--task-id" "$task_id")
+  fi
+
+  if ! "$python_bin" "${supervisor_args[@]}" > "$supervisor_tmp" 2>&1; then
+    echo "Error: session supervisor failed to claim ${stream}" >&2
+    sed 's/^/  supervisor: /' "$supervisor_tmp" >&2
+    return 1
+  fi
+
+  # Parse the supervisor's JSON capsule into sourceable export statements.
+  local exports
+  exports="$($python_bin - "$stream" "$agent" "$harness" "$instance_id" "$$" "$task_id" "$ttl_seconds" "$heartbeat_at" "$supervisor_tmp" <<'PY'
+import json, shlex, sys
+
+capsule_path = sys.argv[-1]
+with open(capsule_path, encoding="utf-8") as handle:
+    capsule = json.load(handle)
+lease = (capsule.get("identity") or {}).get("lease") or {}
+stream, agent, harness, instance_id, process_id, task_id, ttl, heartbeat_at = sys.argv[1:-1]
+
+exports = {
+    "SESSION_STREAM_ID": stream,
+    "SESSION_STREAM_SESSION_ID": lease.get("session_id", ""),
+    "SESSION_STREAM_LEASE_ID": lease.get("lease_id", ""),
+    "SESSION_STREAM_GENERATION": str(lease.get("generation", "")),
+    "SESSION_STREAM_FENCING_TOKEN": str(lease.get("fencing_token", "")),
+    "SESSION_STREAM_AGENT": agent,
+    "SESSION_STREAM_HARNESS": harness,
+    "SESSION_STREAM_INSTANCE_ID": instance_id,
+    "SESSION_STREAM_PROCESS_ID": process_id,
+    "SESSION_STREAM_HEARTBEAT_AT": heartbeat_at,
+    "SESSION_STREAM_EXPIRES_AT": lease.get("expires_at", ""),
+    "SESSION_STREAM_TTL_SECONDS": ttl,
+    "SESSION_STREAM_VERSION": "1",
+}
+if task_id:
+    exports["SESSION_STREAM_TASK_ID"] = task_id
+
+for key, value in exports.items():
+    print(f"export {shlex.quote(key)}={shlex.quote(str(value))}")
+PY
+)"
+  if [ -z "$exports" ]; then
+    echo "Error: failed to parse supervisor capsule for ${stream}." >&2
+    cat "$supervisor_tmp" >&2
+    return 1
+  fi
+
+  # shellcheck source=/dev/null
+  eval "$exports"
+
+  # Required envelope check.
+  if [ -z "${SESSION_STREAM_ID:-}" ] || [ -z "${SESSION_STREAM_SESSION_ID:-}" ] || [ -z "${SESSION_STREAM_LEASE_ID:-}" ]; then
+    echo "Error: supervisor output is missing required SESSION_STREAM_* fields." >&2
+    cat "$supervisor_tmp" >&2
+    return 1
+  fi
+
+  # Write a versioned capsule for diagnostics and resume.
+  local stream_safe="${stream//:/-}"
+  stream_safe="${stream_safe// /-}"
+  local capsule_dir="$state_root/.agent/session-capsules/$stream_safe"
+  mkdir -p "$capsule_dir"
+  local capsule_name="$(_iso_timestamp)-$$.json"
+  # Normalize to a safe filename (replace colons and spaces).
+  capsule_name="${capsule_name//:/-}"
+  capsule_name="${capsule_name// /-}"
+  local capsule_path="$capsule_dir/$capsule_name"
+
+  local task_id_json
+  if [ -n "${SESSION_STREAM_TASK_ID:-}" ]; then
+    task_id_json="\"$(_shell_json_string "$SESSION_STREAM_TASK_ID")\""
+  else
+    task_id_json="null"
+  fi
+
+  cat > "$capsule_path" <<EOF
+{
+  "schema_version": 1,
+  "written_at": "$(_iso_timestamp)",
+  "launcher": "$(_shell_json_string "$launcher")",
+  "epic": "$(_shell_json_string "$epic")",
+  "stream_id": "$(_shell_json_string "$SESSION_STREAM_ID")",
+  "session_id": "$(_shell_json_string "$SESSION_STREAM_SESSION_ID")",
+  "lease_id": "$(_shell_json_string "$SESSION_STREAM_LEASE_ID")",
+  "agent": "$(_shell_json_string "$SESSION_STREAM_AGENT")",
+  "harness": "$(_shell_json_string "$SESSION_STREAM_HARNESS")",
+  "instance_id": "$(_shell_json_string "$SESSION_STREAM_INSTANCE_ID")",
+  "process_id": ${SESSION_STREAM_PROCESS_ID},
+  "task_id": $task_id_json
+}
+EOF
+
+  echo "Session supervisor: claimed ${SESSION_STREAM_ID} session ${SESSION_STREAM_SESSION_ID}"
+  echo "Session capsule: ${capsule_path#"$state_root/"}"
+
+  # Export the capsule path for consumers / tests.
+  export SESSION_SUPERVISOR_CAPSULE_PATH="$capsule_path"
+}

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -197,6 +197,10 @@ export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
 # handoff. Without --epic the hook tells the session to ASK the user instead of
 # defaulting to a lane — the 2026-07-13 atlas/hramatka/main lane collision is
 # the reason this exists.
+#
+# PR-J2 (Claude SessionStart) will integrate the common session supervisor here
+# so --epic claims/resumes the stream lease before SessionStart binds it. For
+# now, SessionStart continues to own lease open/close via the hook.
 _forward_args=("$@")
 if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
     # shellcheck source=scripts/lib/handoff_identity.sh

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -17,10 +17,11 @@
 # Environment exported for hooks / dual-write / session streams:
 #   SESSION_EPIC              from --epic
 #   SESSION_HANDOFF_AGENT     grok-<epic> (or override / harness→grok-infra)
-#   SESSION_STREAM_ID         epic:<n> from --stream or epic→number map
+#   SESSION_STREAM_*          from the common session supervisor (scripts.session_supervisor)
 #   LEARN_UKRAINIAN_GROK_LAUNCH=1
 #
-# Cold-start: with --epic and no free-text PROMPT, the launcher injects an
+# Cold-start: with --epic and no free-text PROMPT, the launcher claims the
+# stream lease through the common supervisor, writes a capsule, and injects an
 # auto-continue prompt (Grok has no SessionStart hook like Claude). Pass an
 # explicit PROMPT to override. Use --no-always-approve to require tool confirms.
 #
@@ -191,36 +192,27 @@ if [ "$_prev" = "--epic" ] || [ "$_prev" = "--stream" ] || [ "$_prev" = "--hando
   exit 1
 fi
 
-# Validate epic via shared helper when present
+# Load shared helpers.
 if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
   # shellcheck source=scripts/lib/handoff_identity.sh
   source "$PROJECT_DIR/scripts/lib/handoff_identity.sh"
-  if [ -n "$_selected_epic" ]; then
-    if ! epic_name_valid "$_selected_epic"; then
-      echo "Error: invalid --epic name '${_selected_epic}' (lowercase alnum + inner hyphens)." >&2
-      exit 1
-    fi
-  fi
+fi
+if [ -f "$PROJECT_DIR/scripts/lib/session_supervisor.sh" ]; then
+  # shellcheck source=scripts/lib/session_supervisor.sh
+  source "$PROJECT_DIR/scripts/lib/session_supervisor.sh"
 fi
 
-# Epic → default stream id (override with --stream)
-_stream_for_epic() {
-  case "${1:-}" in
-    atlas|practice|practice-hub) printf '%s' 'epic:4387' ;;
-    harness|infra) printf '%s' 'epic:4707' ;;
-    hramatka) printf '%s' 'epic:4542' ;;
-    folk|seminars-folk) printf '%s' 'epic:2836' ;;
-    bio|seminars-bio) printf '%s' 'epic:4431' ;;
-    *) ;;
-  esac
-}
+# Validate epic name when the helper is present.
+if command -v epic_name_valid >/dev/null 2>&1 && [ -n "$_selected_epic" ]; then
+  if ! epic_name_valid "$_selected_epic"; then
+    echo "Error: invalid --epic name '${_selected_epic}' (lowercase alnum + inner hyphens)." >&2
+    exit 1
+  fi
+fi
 
 if [ -n "$_selected_epic" ]; then
   export SESSION_EPIC="$_selected_epic"
   echo "Epic assignment: ${SESSION_EPIC}.epic"
-  if [ -z "$_selected_stream" ]; then
-    _selected_stream="$(_stream_for_epic "$_selected_epic")"
-  fi
   # Grok-specific handoff slot (not claude-<epic>)
   if [ -z "${SESSION_HANDOFF_AGENT:-}" ] && [ -z "$_handoff_override" ]; then
     case "$_selected_epic" in
@@ -234,9 +226,28 @@ if [ -n "$_handoff_override" ]; then
   export SESSION_HANDOFF_AGENT="$_handoff_override"
 fi
 
-if [ -n "$_selected_stream" ]; then
-  export SESSION_STREAM_ID="$_selected_stream"
-  echo "Session stream: $SESSION_STREAM_ID"
+# Claim/resume the stream lease through the common supervisor when an epic is pinned.
+if [ -n "$_selected_epic" ]; then
+  if [ -z "$_selected_stream" ]; then
+    _selected_stream="$(stream_id_for_epic "$_selected_epic")"
+  fi
+  if [ -z "$_selected_stream" ]; then
+    echo "Error: cannot resolve stream id for epic '${_selected_epic}'." >&2
+    exit 1
+  fi
+
+  _launcher_task_id="${SESSION_TASK_ID:-${LEARN_UK_LAUNCHER_TASK_ID:-5512-pr-j1-launchers}}"
+  _launcher_instance_id="${SESSION_INSTANCE_ID:-grok-$$}"
+  claim_session_supervisor_env \
+    "$_selected_stream" \
+    "grok" \
+    "grok-tui" \
+    "$_launcher_task_id" \
+    "$_launcher_instance_id" \
+    "$PROJECT_DIR" \
+    "start-grok.sh" \
+    "$_selected_epic"
+  unset _launcher_task_id _launcher_instance_id
 fi
 
 if [ -n "${SESSION_HANDOFF_AGENT:-}" ]; then
@@ -274,7 +285,7 @@ if [ -n "${SESSION_EPIC:-}" ]; then
   echo "Lane: ${SESSION_EPIC} (you are NOT the main orchestrator)."
   case "${SESSION_EPIC}" in
     atlas)
-      echo "  Stream SSOT: epic:4387  (session_streams tail --stream epic:4387)"
+      echo "  Stream SSOT: ${SESSION_STREAM_ID:-epic:4387}  (session_streams tail --stream ${SESSION_STREAM_ID:-epic:4387})"
       echo "  File dual-write: .claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md (or CLAUDE-DRIVER-HANDOFF.md read-only)"
       echo "  TAKEOVER: .claude/atlas-epic/TAKEOVER-PROMPT.md"
       echo "  Canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas"
@@ -286,7 +297,7 @@ if [ -n "${SESSION_EPIC:-}" ]; then
       echo "  Canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic harness"
       ;;
     *)
-      echo "  Open stream if known: SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}"
+      echo "  Open stream: SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}"
       echo "  Epic dir (if any): .claude/${SESSION_EPIC}-epic/"
       echo "  Canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic ${SESSION_EPIC}"
       ;;
@@ -331,16 +342,16 @@ done
 if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
   case "${SESSION_EPIC}" in
     atlas|practice|practice-hub)
-      _cold_prompt="You are the interim ATLAS lane driver (stream epic:4387). Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, open/resume lease, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md; (2) mint the session canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas --stream epic:4387 (see docs/runbooks/grok-session-canary.md). Drive the next unblocked action without a menu. End session on canary FAIL-HANDOFF (<8/10), not on compact count; after any auto-compact re-score from memory. Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the interim ATLAS lane driver (stream ${SESSION_STREAM_ID:-epic:4387}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md; (2) mint the session canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas --stream ${SESSION_STREAM_ID:-epic:4387} (see docs/runbooks/grok-session-canary.md). Drive the next unblocked action without a menu. End session on canary FAIL-HANDOFF (<8/10), not on compact count; after any auto-compact re-score from memory. Primary checkout is read-only — writes via worktrees."
       ;;
     harness|infra)
-      _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). Cold-start from the infra handoff and stream tail; mint canary (.venv/bin/python -m scripts.session_canary.grok_lane mint --epic harness); reconcile in-flight work; drive the next unblocked infra action. End on canary FAIL-HANDOFF not compact count (docs/runbooks/grok-session-canary.md). Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the infra handoff and stream tail; mint canary (.venv/bin/python -m scripts.session_canary.grok_lane mint --epic harness); reconcile in-flight work; drive the next unblocked infra action. End on canary FAIL-HANDOFF not compact count (docs/runbooks/grok-session-canary.md). Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."
       ;;
     hramatka)
-      _cold_prompt="You are the hramatka lane driver (stream ${SESSION_STREAM_ID:-epic:4542}). Cold-start from the epic handoff and stream if present; mint canary (.venv/bin/python -m scripts.session_canary.grok_lane mint --epic hramatka); reconcile and drive the next unblocked action. End on canary FAIL-HANDOFF (docs/runbooks/grok-session-canary.md). Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the hramatka lane driver (stream ${SESSION_STREAM_ID:-epic:4542}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the epic handoff and stream if present; mint canary (.venv/bin/python -m scripts.session_canary.grok_lane mint --epic hramatka); reconcile and drive the next unblocked action. End on canary FAIL-HANDOFF (docs/runbooks/grok-session-canary.md). Primary checkout is read-only — writes via worktrees."
       ;;
     *)
-      _cold_prompt="You are the ${SESSION_EPIC} lane driver (SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}). You are NOT the main orchestrator. Cold-start: load the epic handoff under .claude/${SESSION_EPIC}-epic/ (or stream tail if SESSION_STREAM_ID is set), mint canary via .venv/bin/python -m scripts.session_canary.grok_lane mint --epic ${SESSION_EPIC}, reconcile reality, and drive the next unblocked action without a menu. End on canary FAIL-HANDOFF not compact count (docs/runbooks/grok-session-canary.md). Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the ${SESSION_EPIC} lane driver (SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}). You are NOT the main orchestrator. The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start: load the epic handoff under .claude/${SESSION_EPIC}-epic/ (or stream tail if SESSION_STREAM_ID is set), mint canary via .venv/bin/python -m scripts.session_canary.grok_lane mint --epic ${SESSION_EPIC}, reconcile reality, and drive the next unblocked action without a menu. End on canary FAIL-HANDOFF not compact count (docs/runbooks/grok-session-canary.md). Primary checkout is read-only — writes via worktrees."
       ;;
   esac
   echo "Cold-start: injecting epic auto-continue prompt (no user PROMPT given)."

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Learn Ukrainian — Kimi Code CLI launcher (peer of start-grok.sh).
+#
+# Launcher-only flags (the kimi CLI does not know them):
+#   --epic <name> | --epic=<name>     Pin lane (atlas, hramatka, harness, …)
+#   --stream <id> | --stream=<id>     Explicit session-stream id (e.g. epic:4387)
+#   --handoff-agent <id>              Override SESSION_HANDOFF_AGENT
+#   --model <id>                      Kimi model (default: k2.7-coding)
+#   --help-launcher                   This help (does not start kimi)
+#
+# Environment exported for hooks / dual-write / session streams:
+#   SESSION_EPIC              from --epic
+#   SESSION_HANDOFF_AGENT     kimi-<epic> (or override / harness→kimi-infra)
+#   SESSION_STREAM_*          from the common session supervisor (scripts.session_supervisor)
+#   LEARN_UKRAINE_KIMI_LAUNCH=1
+#
+# Cold-start: with --epic and no free-text PROMPT, the launcher claims the
+# stream lease through the common supervisor, writes a capsule, and injects an
+# auto-continue prompt. Pass an explicit PROMPT to override.
+#
+# Examples:
+#   ./start-kimi.sh --epic atlas
+#   ./start-kimi.sh --epic atlas --stream epic:4387 --model k3
+#   ./start-kimi.sh --epic harness "continue the infra queue"
+#   ./start-kimi.sh --model k2.7-coding "review the open PR"
+
+set -euo pipefail
+
+export PATH="${HOME}/.local/bin:/opt/homebrew/bin:${HOME}/.kimi-code/bin:${PATH:-}"
+hash -r 2>/dev/null || true
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Prefer the main worktree root when this script is run from a git worktree copy.
+if git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  _git_common="$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "${_git_common:-}" ] && [ -d "$(dirname "$_git_common")" ]; then
+    _main_wt="$(dirname "$_git_common")"
+    if [ -f "$_main_wt/start-kimi.sh" ] || [ -f "$_main_wt/AGENTS.md" ]; then
+      PROJECT_DIR="$_main_wt"
+    fi
+  fi
+  unset _git_common _main_wt
+fi
+
+usage_launcher() {
+  sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+# --- locate kimi binary ---
+KIMI_BIN="${LEARN_UK_KIMI_BIN:-}"
+if [ -z "$KIMI_BIN" ] || [ ! -x "$KIMI_BIN" ]; then
+  KIMI_BIN=""
+  for cand in \
+    "$(command -v kimi 2>/dev/null || true)" \
+    "${HOME}/.kimi-code/bin/kimi"
+  do
+    if [ -n "$cand" ] && [ -x "$cand" ]; then
+      KIMI_BIN="$cand"
+      break
+    fi
+  done
+fi
+if [ -z "$KIMI_BIN" ]; then
+  echo "Error: Kimi Code CLI not found. Install it or set LEARN_UK_KIMI_BIN." >&2
+  exit 1
+fi
+
+echo "Starting Kimi Code in Learn Ukrainian project..."
+echo "Project: $PROJECT_DIR"
+echo "Kimi: $("$KIMI_BIN" --version 2>/dev/null || echo "$KIMI_BIN")"
+
+cd "$PROJECT_DIR"
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Current branch: $(git branch --show-current 2>/dev/null || echo '?')"
+  # Heal detached/wrong-branch primary so agents never start on a raw SHA (#4857).
+  if [ -x "$PROJECT_DIR/.venv/bin/python" ] \
+      && [ -f "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" ]; then
+    if ! "$PROJECT_DIR/.venv/bin/python" \
+        "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
+        --cwd "$PROJECT_DIR" --heal; then
+      echo "Error: primary checkout is not on main and auto-heal failed." >&2
+      exit 1
+    fi
+  fi
+  if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    echo "Uncommitted changes detected (primary checkout is orientation-only; write via worktrees)"
+  fi
+fi
+
+# Optional deploy of shared extensions (fail-open).
+if [ -f "$PROJECT_DIR/scripts/lib/deploy_extensions.sh" ]; then
+  # shellcheck source=scripts/lib/deploy_extensions.sh
+  source "$PROJECT_DIR/scripts/lib/deploy_extensions.sh"
+  deploy_agent_extensions "$PROJECT_DIR" agents:deploy \
+    || echo "Continuing launch despite deploy failure (see banner above)."
+fi
+
+# --- parse launcher-only flags; build forward argv and prompt ---
+_forward=()
+_selected_epic=""
+_selected_stream=""
+_handoff_override=""
+_selected_model=""
+_has_model=0
+_prev=""
+
+for arg in "$@"; do
+  if [ "$_prev" = "--epic" ]; then
+    _selected_epic="${arg%.epic}"
+    _prev=""
+    continue
+  fi
+  if [ "$_prev" = "--stream" ]; then
+    _selected_stream="$arg"
+    _prev=""
+    continue
+  fi
+  if [ "$_prev" = "--handoff-agent" ]; then
+    _handoff_override="$arg"
+    _prev=""
+    continue
+  fi
+  if [ "$_prev" = "--model" ]; then
+    _selected_model="$arg"
+    _has_model=1
+    _prev=""
+    continue
+  fi
+
+  case "$arg" in
+    --help-launcher|-hl)
+      usage_launcher
+      ;;
+    --epic)
+      _prev=--epic
+      continue
+      ;;
+    --epic=*)
+      _selected_epic="${arg#--epic=}"
+      _selected_epic="${_selected_epic%.epic}"
+      continue
+      ;;
+    --stream)
+      _prev=--stream
+      continue
+      ;;
+    --stream=*)
+      _selected_stream="${arg#--stream=}"
+      continue
+      ;;
+    --handoff-agent)
+      _prev=--handoff-agent
+      continue
+      ;;
+    --handoff-agent=*)
+      _handoff_override="${arg#--handoff-agent=}"
+      continue
+      ;;
+    --model)
+      _prev=--model
+      continue
+      ;;
+    --model=*)
+      _selected_model="${arg#--model=}"
+      _has_model=1
+      continue
+      ;;
+  esac
+
+  _prev=""
+  _forward+=("$arg")
+done
+
+if [ "$_prev" = "--epic" ] || [ "$_prev" = "--stream" ] || [ "$_prev" = "--handoff-agent" ] || [ "$_prev" = "--model" ]; then
+  echo "Error: dangling launcher flag '$_prev' without a value." >&2
+  exit 1
+fi
+
+# Load shared helpers.
+if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
+  # shellcheck source=scripts/lib/handoff_identity.sh
+  source "$PROJECT_DIR/scripts/lib/handoff_identity.sh"
+fi
+if [ -f "$PROJECT_DIR/scripts/lib/session_supervisor.sh" ]; then
+  # shellcheck source=scripts/lib/session_supervisor.sh
+  source "$PROJECT_DIR/scripts/lib/session_supervisor.sh"
+fi
+
+# Validate epic name when the helper is present.
+if command -v epic_name_valid >/dev/null 2>&1 && [ -n "$_selected_epic" ]; then
+  if ! epic_name_valid "$_selected_epic"; then
+    echo "Error: invalid --epic name '${_selected_epic}' (lowercase alnum + inner hyphens)." >&2
+    exit 1
+  fi
+fi
+
+if [ -n "$_selected_epic" ]; then
+  export SESSION_EPIC="$_selected_epic"
+  echo "Epic assignment: ${SESSION_EPIC}.epic"
+  # Kimi-specific handoff slot (not claude-<epic>)
+  if [ -z "${SESSION_HANDOFF_AGENT:-}" ] && [ -z "$_handoff_override" ]; then
+    case "$_selected_epic" in
+      harness|infra) export SESSION_HANDOFF_AGENT='kimi-infra' ;;
+      *) export SESSION_HANDOFF_AGENT="kimi-${_selected_epic}" ;;
+    esac
+  fi
+fi
+
+if [ -n "$_handoff_override" ]; then
+  export SESSION_HANDOFF_AGENT="$_handoff_override"
+fi
+
+# Claim/resume the stream lease through the common supervisor when an epic is pinned.
+if [ -n "$_selected_epic" ]; then
+  if [ -z "$_selected_stream" ]; then
+    _selected_stream="$(stream_id_for_epic "$_selected_epic")"
+  fi
+  if [ -z "$_selected_stream" ]; then
+    echo "Error: cannot resolve stream id for epic '${_selected_epic}'." >&2
+    exit 1
+  fi
+
+  _launcher_task_id="${SESSION_TASK_ID:-${LEARN_UK_LAUNCHER_TASK_ID:-5512-pr-j1-launchers}}"
+  _launcher_instance_id="${SESSION_INSTANCE_ID:-kimi-$$}"
+  claim_session_supervisor_env \
+    "$_selected_stream" \
+    "kimi" \
+    "kimi-code" \
+    "$_launcher_task_id" \
+    "$_launcher_instance_id" \
+    "$PROJECT_DIR" \
+    "start-kimi.sh" \
+    "$_selected_epic"
+  unset _launcher_task_id _launcher_instance_id
+fi
+
+if [ -n "${SESSION_HANDOFF_AGENT:-}" ]; then
+  echo "Handoff identity: $SESSION_HANDOFF_AGENT"
+fi
+
+export LEARN_UKRAINE_KIMI_LAUNCH=1
+export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
+
+# Defaults for kimi CLI
+if [ "$_has_model" -eq 0 ]; then
+  _selected_model="k2.7-coding"
+fi
+
+# Lane cold-start hint (printed always when epic is set)
+if [ -n "${SESSION_EPIC:-}" ]; then
+  echo ""
+  echo "Lane: ${SESSION_EPIC} (you are NOT the main orchestrator)."
+  case "${SESSION_EPIC}" in
+    atlas)
+      echo "  Stream SSOT: ${SESSION_STREAM_ID:-epic:4387}  (session_streams tail --stream ${SESSION_STREAM_ID:-epic:4387})"
+      echo "  File dual-write: .claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md (or CLAUDE-DRIVER-HANDOFF.md read-only)"
+      echo "  TAKEOVER: .claude/atlas-epic/TAKEOVER-PROMPT.md"
+      ;;
+    harness|infra)
+      echo "  Stream: ${SESSION_STREAM_ID:-epic:4707}"
+      echo "  Infra handoff: docs/session-state/ + .agent/claude-infra-thread-handoff.md (read; write your own kimi slot)"
+      ;;
+    *)
+      echo "  Open stream: SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}"
+      echo "  Epic dir (if any): .claude/${SESSION_EPIC}-epic/"
+      ;;
+  esac
+  echo "  Primary checkout is READ-ONLY for writes → worktrees via scripts/delegate.py"
+  echo "  Kimi orchestrator runbook: docs/runbooks/kimi-orchestrator.md"
+  echo ""
+fi
+
+# Auto-continue the epic stream when --epic is set and the user did not pass a PROMPT.
+if [ -n "${SESSION_EPIC:-}" ] && [ "${#_forward[@]}" -eq 0 ]; then
+  case "${SESSION_EPIC}" in
+    atlas|practice|practice-hub)
+      _cold_prompt="You are the interim ATLAS lane driver (stream ${SESSION_STREAM_ID:-epic:4387}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md; (2) load the session stream digest and mint a canary if one is required. Drive the next unblocked action without a menu. End on canary FAIL-HANDOFF (<8/10). Primary checkout is read-only — writes via worktrees."
+      ;;
+    harness|infra)
+      _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the infra handoff and stream tail; reconcile in-flight work; drive the next unblocked infra action. End on canary FAIL-HANDOFF. Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."
+      ;;
+    hramatka)
+      _cold_prompt="You are the hramatka lane driver (stream ${SESSION_STREAM_ID:-epic:4542}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the epic handoff and stream if present; reconcile and drive the next unblocked action. End on canary FAIL-HANDOFF. Primary checkout is read-only — writes via worktrees."
+      ;;
+    *)
+      _cold_prompt="You are the ${SESSION_EPIC} lane driver (SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}). You are NOT the main orchestrator. The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start: load the epic handoff under .claude/${SESSION_EPIC}-epic/ (or stream tail if SESSION_STREAM_ID is set), reconcile reality, and drive the next unblocked action without a menu. End on canary FAIL-HANDOFF. Primary checkout is read-only — writes via worktrees."
+      ;;
+  esac
+  echo "Cold-start: injecting epic auto-continue prompt (no user PROMPT given)."
+  _forward=("$_cold_prompt")
+  unset _cold_prompt
+fi
+
+echo "Launching Kimi Code..."
+exec "$KIMI_BIN" -p "${_forward[*]}" -m "$_selected_model" --output-format stream-json

--- a/tests/test_session_supervisor_shell.py
+++ b/tests/test_session_supervisor_shell.py
@@ -1,0 +1,264 @@
+"""scripts/lib/session_supervisor.sh: claim env + capsule writing."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Git redirection variables inherited from the outer test runner (e.g. a git
+# hook) must not leak into the temporary repos created by these tests.
+_GIT_REDIRECT_VARS = frozenset(
+    {
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_PREFIX",
+        "GIT_WORK_TREE",
+    }
+)
+
+
+def _clean_environ() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _GIT_REDIRECT_VARS}
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _supervisor_ok_body(capture: Path) -> str:
+    return f"""#!/usr/bin/env bash
+if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_supervisor" && "${{3:-}}" == "open" ]]; then
+  {{
+    printf '%s\\n' "$@" > "{capture}"
+    cat <<'JSON'
+{{
+  "schema": "session-supervisor-bootstrap.v1",
+  "identity": {{
+    "role": "driver",
+    "stream_id": "epic:4542",
+    "lease": {{
+      "session_id": "sess-shell-789",
+      "lease_id": "lease-shell-789",
+      "generation": 3,
+      "fencing_token": 3,
+      "expires_at": "2026-07-21T03:00:00Z"
+    }},
+    "lease_credentials_exported": false
+  }},
+  "rollover": null,
+  "digest": {{}},
+  "dual_write": {{}},
+  "diagnostics": {{}}
+}}
+JSON
+  }}
+  exit 0
+fi
+if [[ "$1" == "-c" ]]; then
+  shift
+  exec /usr/bin/env python3 -c "$@"
+fi
+if [[ "$1" == "-" ]]; then
+  shift
+  exec /usr/bin/env python3 - "$@"
+fi
+echo "unexpected python args: $*" >&2
+exit 1
+"""
+
+
+def _build_fake_project(tmp_path: Path) -> tuple[Path, Path]:
+    project = tmp_path / "project"
+    project.mkdir()
+    venv_bin = project / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    lib_dir = project / "scripts" / "lib"
+    lib_dir.mkdir(parents=True)
+
+    (lib_dir / "session_supervisor.sh").write_text(
+        (_REPO_ROOT / "scripts" / "lib" / "session_supervisor.sh").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    capture = tmp_path / "supervisor_capture.txt"
+    _write_executable(venv_bin / "python", _supervisor_ok_body(capture))
+
+    env = _clean_environ()
+    subprocess.run(["git", "init", "--quiet", str(project)], check=True, env=env)
+    subprocess.run(["git", "-C", str(project), "config", "user.email", "test@example.com"], check=True, env=env)
+    subprocess.run(["git", "-C", str(project), "config", "user.name", "Test"], check=True, env=env)
+    (project / "README.md").write_text("# test", encoding="utf-8")
+    subprocess.run(["git", "-C", str(project), "add", "."], check=True, env=env)
+    subprocess.run(["git", "-C", str(project), "commit", "--quiet", "-m", "init"], check=True, env=env)
+    subprocess.run(["git", "-C", str(project), "branch", "-m", "main"], check=True, env=env)
+
+    return project, capture
+
+
+def test_claim_exports_all_session_stream_variables_and_writes_capsule(tmp_path: Path) -> None:
+    project, supervisor_capture = _build_fake_project(tmp_path)
+
+    script = f"""
+set -euo pipefail
+source "{project}/scripts/lib/session_supervisor.sh"
+claim_session_supervisor_env "epic:4542" "test-agent" "test-harness" "test-task" "test-instance" "{project}" "test-launcher.sh" "hramatka"
+printf 'STREAM=%s\\n' "$SESSION_STREAM_ID"
+printf 'SESSION=%s\\n' "$SESSION_STREAM_SESSION_ID"
+printf 'LEASE=%s\\n' "$SESSION_STREAM_LEASE_ID"
+printf 'AGENT=%s\\n' "$SESSION_STREAM_AGENT"
+printf 'HARNESS=%s\\n' "$SESSION_STREAM_HARNESS"
+printf 'INSTANCE=%s\\n' "$SESSION_STREAM_INSTANCE_ID"
+printf 'PROCESS=%s\\n' "$SESSION_STREAM_PROCESS_ID"
+printf 'GENERATION=%s\\n' "$SESSION_STREAM_GENERATION"
+printf 'FENCING=%s\\n' "$SESSION_STREAM_FENCING_TOKEN"
+printf 'CAPSULE=%s\\n' "$SESSION_SUPERVISOR_CAPSULE_PATH"
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+        env=_clean_environ(),
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    lines = {k: v for k, v in (line.split("=", 1) for line in result.stdout.splitlines() if "=" in line)}
+    assert lines["STREAM"] == "epic:4542"
+    assert lines["SESSION"] == "sess-shell-789"
+    assert lines["LEASE"] == "lease-shell-789"
+    assert lines["AGENT"] == "test-agent"
+    assert lines["HARNESS"] == "test-harness"
+    assert lines["INSTANCE"] == "test-instance"
+    assert lines["PROCESS"].isdigit()
+    assert lines["GENERATION"] == "3"
+    assert lines["FENCING"] == "3"
+    capsule_path = Path(lines["CAPSULE"])
+    assert capsule_path.exists()
+
+    capsule = capsule_path.read_text(encoding="utf-8")
+    assert '"schema_version": 1' in capsule
+    assert '"stream_id": "epic:4542"' in capsule
+    assert '"launcher": "test-launcher.sh"' in capsule
+    assert '"epic": "hramatka"' in capsule
+    assert '"agent": "test-agent"' in capsule
+    assert '"harness": "test-harness"' in capsule
+    assert '"task_id": "test-task"' in capsule
+
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    assert supervisor_args[supervisor_args.index("--stream") + 1] == "epic:4542"
+    assert supervisor_args[supervisor_args.index("--agent") + 1] == "test-agent"
+    assert supervisor_args[supervisor_args.index("--harness") + 1] == "test-harness"
+    assert supervisor_args[supervisor_args.index("--instance-id") + 1] == "test-instance"
+    assert supervisor_args[supervisor_args.index("--task-id") + 1] == "test-task"
+    assert supervisor_args[supervisor_args.index("--role") + 1] == "driver"
+    assert "scripts.session_supervisor" in supervisor_args
+    assert "open" in supervisor_args
+
+
+def test_claim_uses_default_instance_id_when_empty(tmp_path: Path) -> None:
+    project, supervisor_capture = _build_fake_project(tmp_path)
+
+    script = f"""
+set -euo pipefail
+source "{project}/scripts/lib/session_supervisor.sh"
+claim_session_supervisor_env "epic:4542" "test-agent" "test-harness" "" "" "{project}" "test-launcher.sh" "hramatka"
+printf 'INSTANCE=%s\\n' "$SESSION_STREAM_INSTANCE_ID"
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+        env=_clean_environ(),
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    lines = {k: v for k, v in (line.split("=", 1) for line in result.stdout.splitlines() if "=" in line)}
+    assert lines["INSTANCE"].startswith("test-agent-")
+
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    assert supervisor_args[supervisor_args.index("--instance-id") + 1].startswith("test-agent-")
+
+
+def test_claim_fails_closed_on_missing_required_fields(tmp_path: Path) -> None:
+    project, _supervisor_capture = _build_fake_project(tmp_path)
+    # Replace fake python with one that returns an incomplete lease.
+    _write_executable(
+        project / ".venv" / "bin" / "python",
+        """#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "scripts.session_supervisor" && "${3:-}" == "open" ]]; then
+  cat <<'JSON'
+{
+  "identity": {
+    "lease": {
+      "session_id": "sess-shell-789"
+    }
+  }
+}
+JSON
+  exit 0
+fi
+if [[ "$1" == "-c" ]]; then
+  shift
+  exec /usr/bin/env python3 -c "$@"
+fi
+if [[ "$1" == "-" ]]; then
+  shift
+  exec /usr/bin/env python3 - "$@"
+fi
+echo "unexpected python args: $*" >&2
+exit 1
+""",
+    )
+
+    script = f"""
+set -euo pipefail
+source "{project}/scripts/lib/session_supervisor.sh"
+claim_session_supervisor_env "epic:4542" "test-agent" "test-harness" "" "" "{project}" "test-launcher.sh" "hramatka" || exit 42
+exit 0
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+        env=_clean_environ(),
+    )
+    assert result.returncode == 42, result.stderr + result.stdout
+    assert "missing required SESSION_STREAM_* fields" in result.stderr
+
+
+def test_claim_fails_closed_on_supervisor_error(tmp_path: Path) -> None:
+    project, _supervisor_capture = _build_fake_project(tmp_path)
+    _write_executable(
+        project / ".venv" / "bin" / "python",
+        """#!/usr/bin/env bash
+echo "supervisor refused" >&2
+exit 1
+""",
+    )
+
+    script = f"""
+set -euo pipefail
+source "{project}/scripts/lib/session_supervisor.sh"
+claim_session_supervisor_env "epic:4542" "test-agent" "test-harness" "" "" "{project}" "test-launcher.sh" "hramatka" || exit 43
+exit 0
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+        env=_clean_environ(),
+    )
+    assert result.returncode == 43, result.stderr + result.stdout
+    assert "session supervisor failed" in result.stderr

--- a/tests/test_start_kimi_launcher.py
+++ b/tests/test_start_kimi_launcher.py
@@ -1,4 +1,4 @@
-"""start-grok.sh launcher: --epic env export + supervisor claim + cold-start prompt."""
+"""start-kimi.sh launcher: --epic env export + supervisor claim + launch argv."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
-_LAUNCHER = _REPO_ROOT / "start-grok.sh"
+_LAUNCHER = _REPO_ROOT / "start-kimi.sh"
 
 _GIT_REDIRECT_VARS = frozenset(
     {
@@ -48,8 +48,8 @@ if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_supervisor" && "${{3:
     "lease": {{
       "session_id": "{session_id}",
       "lease_id": "{lease_id}",
-      "generation": 1,
-      "fencing_token": 1,
+      "generation": 2,
+      "fencing_token": 2,
       "expires_at": "2026-07-21T03:00:00Z"
     }},
     "lease_credentials_exported": false
@@ -87,8 +87,7 @@ def _build_fake_project(tmp_path: Path) -> tuple[Path, Path]:
     guard_dir = project / "scripts" / "guardrails"
     guard_dir.mkdir(parents=True)
 
-    # Copy launcher and shell helpers so PROJECT_DIR resolution stays inside the fake root.
-    _write_executable(project / "start-grok.sh", _LAUNCHER.read_text(encoding="utf-8"))
+    _write_executable(project / "start-kimi.sh", _LAUNCHER.read_text(encoding="utf-8"))
     (lib_dir / "session_supervisor.sh").write_text(
         (_REPO_ROOT / "scripts" / "lib" / "session_supervisor.sh").read_text(encoding="utf-8"),
         encoding="utf-8",
@@ -103,10 +102,9 @@ def _build_fake_project(tmp_path: Path) -> tuple[Path, Path]:
     capture = tmp_path / "supervisor_capture.txt"
     _write_executable(
         venv_bin / "python",
-        _supervisor_body(capture, "epic:4387", "sess-grok-123", "lease-grok-123"),
+        _supervisor_body(capture, "epic:4707", "sess-kimi-456", "lease-kimi-456"),
     )
 
-    # Git repo so session_supervisor.sh can resolve a canonical state root.
     env = _clean_environ()
     subprocess.run(["git", "init", "--quiet", str(project)], check=True, env=env)
     subprocess.run(["git", "-C", str(project), "config", "user.email", "test@example.com"], check=True, env=env)
@@ -123,18 +121,18 @@ def _run_launcher(
     tmp_path: Path,
     arguments: list[str],
 ) -> tuple[dict[str, str], str, subprocess.CompletedProcess[str], Path, Path]:
-    """Run start-grok.sh with a fake grok binary that captures env + argv."""
+    """Run start-kimi.sh with a fake kimi binary that captures env + argv."""
     project, supervisor_capture = _build_fake_project(tmp_path)
     home = tmp_path / "home"
-    grok_bin_dir = home / ".grok" / "bin"
-    grok_bin_dir.mkdir(parents=True)
+    kimi_bin_dir = home / ".kimi-code" / "bin"
+    kimi_bin_dir.mkdir(parents=True)
     capture = tmp_path / "capture.txt"
 
     _write_executable(
-        grok_bin_dir / "grok",
+        kimi_bin_dir / "kimi",
         f"""#!/usr/bin/env bash
 if [[ "${{1:-}}" == "--version" ]]; then
-  echo "test-grok 0.0.0"
+  echo "test-kimi 0.0.0"
   exit 0
 fi
 {{
@@ -147,7 +145,7 @@ fi
   printf 'session_instance=%s\\n' "${{SESSION_STREAM_INSTANCE_ID-unset}}"
   printf 'session_process=%s\\n' "${{SESSION_STREAM_PROCESS_ID-unset}}"
   printf 'handoff=%s\\n' "${{SESSION_HANDOFF_AGENT-unset}}"
-  printf 'launch=%s\\n' "${{LEARN_UKRAINIAN_GROK_LAUNCH-unset}}"
+  printf 'launch=%s\\n' "${{LEARN_UKRAINE_KIMI_LAUNCH-unset}}"
   printf 'capsule=%s\\n' "${{SESSION_SUPERVISOR_CAPSULE_PATH-unset}}"
   printf 'argv='
   printf '%s\\0' "$@"
@@ -167,15 +165,15 @@ fi
         "SESSION_STREAM_INSTANCE_ID",
         "SESSION_STREAM_PROCESS_ID",
         "SESSION_HANDOFF_AGENT",
-        "LEARN_UKRAINIAN_GROK_LAUNCH",
+        "LEARN_UKRAINE_KIMI_LAUNCH",
         "SESSION_SUPERVISOR_CAPSULE_PATH",
     ):
         env.pop(name, None)
     env["HOME"] = os.fspath(home)
-    env["PATH"] = f"{grok_bin_dir}:{env.get('PATH', '')}"
+    env["PATH"] = f"{kimi_bin_dir}:{env.get('PATH', '')}"
 
     result = subprocess.run(
-        [os.fspath(project / "start-grok.sh"), *arguments],
+        [os.fspath(project / "start-kimi.sh"), *arguments],
         cwd=project,
         env=env,
         text=True,
@@ -196,76 +194,63 @@ fi
     return values, argv_blob, result, project, supervisor_capture
 
 
-def test_epic_atlas_exports_env_and_claims_lease(tmp_path: Path) -> None:
-    values, argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", "atlas"])
+def test_epic_harness_exports_env_and_claims_lease(tmp_path: Path) -> None:
+    values, argv_blob, result, _project, supervisor_capture = _run_launcher(
+        tmp_path, ["--epic", "harness"]
+    )
     assert result.returncode == 0, result.stderr + result.stdout
-    assert values["session_epic"] == "atlas"
-    assert values["session_stream"] == "epic:4387"
-    assert values["session_session"] == "sess-grok-123"
-    assert values["session_lease"] == "lease-grok-123"
-    assert values["session_agent"] == "grok"
-    assert values["session_harness"] == "grok-tui"
-    assert values["session_instance"].startswith("grok-")
+    assert values["session_epic"] == "harness"
+    assert values["session_stream"] == "epic:4707"
+    assert values["session_session"] == "sess-kimi-456"
+    assert values["session_lease"] == "lease-kimi-456"
+    assert values["session_agent"] == "kimi"
+    assert values["session_harness"] == "kimi-code"
+    assert values["session_instance"].startswith("kimi-")
     assert values["session_process"].isdigit()
-    assert values["handoff"] == "grok-atlas"
+    assert values["handoff"] == "kimi-infra"
     assert values["launch"] == "1"
     assert values["capsule"] != "unset"
     assert Path(values["capsule"]).exists()
 
-    # Supervisor was invoked for the expected stream/agent/harness.
     supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
     assert "scripts.session_supervisor" in supervisor_args
     assert "open" in supervisor_args
     assert "--role" in supervisor_args and "driver" in supervisor_args
-    assert "--stream" in supervisor_args and "epic:4387" in supervisor_args
-    assert "--agent" in supervisor_args and "grok" in supervisor_args
-    assert "--harness" in supervisor_args and "grok-tui" in supervisor_args
+    stream_index = supervisor_args.index("--stream")
+    assert supervisor_args[stream_index + 1] == "epic:4707"
+    assert supervisor_args[supervisor_args.index("--agent") + 1] == "kimi"
+    assert supervisor_args[supervisor_args.index("--harness") + 1] == "kimi-code"
     assert "--task-id" in supervisor_args
 
-    # Null-separated argv from fake grok; last non-empty token is the prompt.
     parts = [p for p in argv_blob.split("\0") if p]
-    assert parts, "expected grok argv"
-    prompt = parts[-1]
-    assert "ATLAS" in prompt or "atlas" in prompt.lower()
-    assert "TAKEOVER-PROMPT.md" in prompt
-    assert "epic:4387" in prompt
-    assert "open/resume lease" not in prompt.lower()
-    assert "do NOT open or resume it yourself" in prompt
-    assert "--model" in parts
-    assert "grok-4.5" in parts
-    assert "--always-approve" in parts
+    assert parts[0] == "-p"
+    assert "do NOT open or resume it yourself" in parts[1]
+    assert "k2.7-coding" in parts
+    assert "--output-format" in parts
+    assert "stream-json" in parts
 
 
-def test_epic_equals_form_and_explicit_prompt_skips_inject(tmp_path: Path) -> None:
+def test_explicit_prompt_and_model_override(tmp_path: Path) -> None:
     values, argv_blob, result, _project, _supervisor_capture = _run_launcher(
         tmp_path,
-        ["--epic=atlas", "only do the cloze batch"],
+        ["--epic", "atlas", "--model", "k3", "review the open PR"],
     )
     assert result.returncode == 0, result.stderr + result.stdout
     assert values["session_epic"] == "atlas"
     parts = [p for p in argv_blob.split("\0") if p]
-    # Grok launcher keeps the single explicit prompt as argv[-1].
-    assert parts[-1] == "only do the cloze batch"
-    assert "TAKEOVER-PROMPT.md" not in parts[-1]
+    assert parts[0] == "-p"
+    assert parts[1] == "review the open PR"
+    assert "k3" in parts
+    assert "k2.7-coding" not in parts
 
 
 def test_no_epic_no_supervisor_call(tmp_path: Path) -> None:
-    values, argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, [])
-    assert result.returncode == 0, result.stderr + result.stdout
-    assert values["session_epic"] == "unset"
-    assert values["session_stream"] == "unset"
-    assert not supervisor_capture.exists()
-    parts = [p for p in argv_blob.split("\0") if p]
-    # Flags only — no free-text cold-start prompt.
-    assert all(p.startswith("-") or p in {"grok-4.5", "high"} or Path(p).is_absolute() for p in parts)
-
-
-def test_stream_override_is_used_by_supervisor(tmp_path: Path) -> None:
-    _values, _argv_blob, result, _project, supervisor_capture = _run_launcher(
-        tmp_path,
-        ["--epic", "atlas", "--stream", "epic:4707"],
+    values, argv_blob, result, _project, supervisor_capture = _run_launcher(
+        tmp_path, ["hello world"]
     )
     assert result.returncode == 0, result.stderr + result.stdout
-    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
-    stream_index = supervisor_args.index("--stream")
-    assert supervisor_args[stream_index + 1] == "epic:4707"
+    assert values["session_epic"] == "unset"
+    assert not supervisor_capture.exists()
+    parts = [p for p in argv_blob.split("\0") if p]
+    assert parts[0] == "-p"
+    assert parts[1] == "hello world"


### PR DESCRIPTION
## Sol J1 bullets

- Integrates the common session supervisor (`scripts.session_supervisor`) into:
  - `start-grok.sh`
  - `start-kimi.sh`
- Cold-start with `--epic` now opens the stream lease via `scripts.session_supervisor open --role driver`; the launcher parses the returned JSON capsule and exports `SESSION_STREAM_*` for the hook surface.
- Launchers write a JSON diagnostics capsule under `.agent/session-capsules/<stream>/`.
- Removed prompt-owned lease folklore: cold-start prompts explicitly tell the model NOT to open/resume the lease.
- Claude SessionStart left for PR-J2; added pointer comment in `start-claude.sh`.

## Tests

- `tests/test_session_supervisor_shell.py` — shell helper env export + capsule writing + fail-closed behavior.
- `tests/test_start_grok_launcher.py` — supervisor call, env export, no lease folklore in prompt.
- `tests/test_start_kimi_launcher.py` — supervisor call, env export, launch argv.

## Docs

- `docs/runbooks/session-supervisor.md`
- `docs/runbooks/kimi-orchestrator.md`
- Updated `docs/runbooks/grok-session-canary.md`

## Out of scope (follow-up)

- Message plane default flip
- Codex Desktop
- Full AGY onboarding — file follow-up issue

Parent: #5512 / stream #4707.