### PR TITLE
feat(launchers): start-kimicc.sh + Claudex interactive route safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ on:
       - 'scripts/check_rules_deployment.sh'
       - 'scripts/deploy_prompts.sh'
       - 'start-claude.sh'
+      - 'start-claudex.sh'
+      - 'start-kimicc.sh'
       - 'scripts/lib/handoff_identity.sh'
+      - 'scripts/lib/claude_route_guard.sh'
       - 'start-codex.sh'
       - 'tests/**/*.py'
       - 'pyproject.toml'
@@ -676,8 +679,11 @@ jobs:
         run: |
           bash -n \
             start-claude.sh \
+            start-claudex.sh \
+            start-kimicc.sh \
             start-codex.sh \
             scripts/lib/handoff_identity.sh \
+            scripts/lib/claude_route_guard.sh \
             scripts/deploy_prompts.sh \
             scripts/check_rules_deployment.sh
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -17,14 +17,38 @@ meet it so agents can use them without source-diving.
 Project-local wrappers for interactive agent sessions:
 
 ```bash
-./start-claude.sh
-./start-claudex.sh
-./start-codex.sh
+./start-claude.sh      # native Anthropic Claude Code (original config)
+./start-claudex.sh     # Claude Code UI → GPT-5.6 Sol via CLIProxyAPI (interactive)
+./start-kimicc.sh      # Claude Code UI → Kimi K3 / K2.7 (interactive)
+./start-codex.sh       # native Codex
+./start-grok.sh        # native Grok Build TUI
 ```
 
+Native Kimi Code (separate app/CLI, OAuth subscription) is the **headless / fleet**
+lane via `scripts/delegate.py --agent kimi` and `ab ask-kimi`. Interactive native
+Kimi is `kimi` from `~/.kimi-code/bin` (or a dedicated `start-kimi.sh` when that
+wrapper is present) — not `start-kimicc.sh`.
+
+### Parallel routes and original Claude config
+
+`start-claudex.sh` and `start-kimicc.sh` route **only via process environment**
+(Moonshot Method 1 / CLIProxyAPI pattern). They **never rewrite**
+`~/.claude/settings.json`. That means:
+
+- `./start-claude.sh` always keeps the original Anthropic / Claude Code setup
+- You can run native Claude and KimiCC (or Claudex) in **parallel terminals**
+- Tools like [cc-switch](https://github.com/farion1231/cc-switch) that pin
+  `ANTHROPIC_*` into `settings.json env` will **block** these launchers until
+  those keys are removed (or you use `--isolate-config` / `CLAUDE_CONFIG_DIR`)
+
+### Claudex (GPT-5.6 interactive)
+
 `start-claudex.sh` keeps Claude Code's interface while routing the lead model
-to GPT-5.6 Sol through a local CLIProxyAPI server. Its subagents default to Sol;
-select a lower-cost tier without changing the lead:
+to GPT-5.6 Sol through a local CLIProxyAPI server. **Interactive only** —
+headless GPT work stays on `./start-codex.sh` / bridge. Compaction is certified
+by the `sol_lead` profile: **372k window, 353k auto-compact**.
+
+Subagents default to Sol; select a lower-cost tier without changing the lead:
 
 ```bash
 ./start-claudex.sh --subagent terra
@@ -48,6 +72,33 @@ client token by default. Override them with `CLAUDEX_BASE_URL` and
 `CLAUDEX_AUTH_TOKEN`; credentials are inherited only by the launched process
 and are never written to the repository. `--subagent` accepts `sol`, `terra`,
 or `luna` (and their full `gpt-5.6-*` model IDs).
+
+### KimiCC (Kimi via Claude Code UI, interactive)
+
+`start-kimicc.sh` is **Claude Code UI + Kimi models** (not the native Kimi TUI).
+Use it when you want Claude Code ergonomics with K3 or K2.7 in a second
+terminal while native Claude runs in the first.
+
+```bash
+export MOONSHOT_API_KEY=sk-…   # https://platform.kimi.ai/console/api-keys
+./start-kimicc.sh                    # K3, 1M window / ~996k compact
+./start-kimicc.sh --model k2.7       # K2.7 Code, 256k / ~249k compact
+./start-kimicc.sh --model k2.7-highspeed
+./start-kimicc.sh --endpoint coding  # Kimi Code subscription base URL
+./start-kimicc.sh --isolate-config   # optional CLAUDE_CONFIG_DIR=$HOME/.claude-kimicc
+```
+
+| Model alias | Platform model id | Context | Auto-compact |
+| --- | --- | --- | --- |
+| `k3` (default) | `kimi-k3[1m]` | 1 048 576 | 996 147 |
+| `k2.7` | `kimi-k2.7-code` | 262 144 | 249 036 |
+| `k2.7-highspeed` | `kimi-k2.7-code-highspeed` | 262 144 | 249 036 |
+
+**Headless / fleet Kimi stays on the native Kimi Code app** (`delegate.py --agent kimi`,
+`ab ask-kimi`, or bare `kimi`). Do not point headless jobs at kimicc.
+
+K2.7 requires **Thinking ON** in the Claude Code TUI (`Tab`) or the endpoint
+rejects requests. Official guide: [Use Kimi in Claude Code](https://platform.kimi.ai/docs/guide/claude-code-kimi).
 
 `start-codex.sh` launches Codex with:
 

--- a/scripts/config/context_profiles.yaml
+++ b/scripts/config/context_profiles.yaml
@@ -37,6 +37,51 @@ profiles:
     cold_start_budget_tokens: 100000
     rollover_warning_percentages: [75.0, 85.0, 95.0]
 
+  # Interactive Claude Code + Kimi Anthropic-compatible endpoint (start-kimicc.sh).
+  # Compaction must stay below the true window (schema + Sol-pattern ~95% margin).
+  # Official Moonshot guide uses full-window CLAUDE_CODE_AUTO_COMPACT_WINDOW; we keep
+  # a small headroom so emergency rollover can still fire first.
+  kimicc_k3:
+    profile_id: kimicc_k3
+    transport: kimicc
+    main_model_id: kimi-k3[1m]
+    model_id_patterns:
+      - '^kimi-k3(\[1m\])?$'
+      - '^k3$'
+    main_context_window_tokens: 1048576
+    auto_compact_capacity_tokens: 996147
+    cold_start_profile: compact
+    cold_start_budget_tokens: 104857
+    rollover_warning_percentages: [75.0, 85.0, 92.0]
+
+  kimicc_k27:
+    profile_id: kimicc_k27
+    transport: kimicc
+    main_model_id: kimi-k2.7-code
+    model_id_patterns:
+      - '^kimi-k2\.7-code$'
+      - '^kimi-for-coding$'
+      - '^k2\.7(-coding)?$'
+    main_context_window_tokens: 262144
+    auto_compact_capacity_tokens: 249036
+    cold_start_profile: compact
+    cold_start_budget_tokens: 26214
+    rollover_warning_percentages: [75.0, 85.0, 92.0]
+
+  kimicc_k27_highspeed:
+    profile_id: kimicc_k27_highspeed
+    transport: kimicc
+    main_model_id: kimi-k2.7-code-highspeed
+    model_id_patterns:
+      - '^kimi-k2\.7-code-highspeed$'
+      - '^kimi-for-coding-highspeed$'
+      - '^k2\.7(-coding)?-highspeed$'
+    main_context_window_tokens: 262144
+    auto_compact_capacity_tokens: 249036
+    cold_start_profile: compact
+    cold_start_budget_tokens: 26214
+    rollover_warning_percentages: [75.0, 85.0, 92.0]
+
   fallback:
     profile_id: fallback
     transport: unknown

--- a/scripts/lib/claude_route_guard.sh
+++ b/scripts/lib/claude_route_guard.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Shared guards for interactive Claude Code alternate routes (Claudex, KimiCC).
+#
+# Contract:
+# - NEVER mutate ~/.claude/settings.json or other Claude config files.
+# - Process-scoped env vars are the only routing mechanism (Moonshot Method 1 /
+#   CLIProxyAPI pattern). This keeps ./start-claude.sh on the original Anthropic
+#   configuration when run in parallel.
+# - If settings.json already contains an `env` block with route keys, those
+#   values OVERRIDE process env in Claude Code — refuse until the operator
+#   clears them (or points CLAUDE_CONFIG_DIR at an isolated directory).
+
+# Keys that third-party tools (cc-switch, hand-edited settings) may pin into
+# ~/.claude/settings.json env, silently hijacking native Claude and our launchers.
+CLAUDE_ROUTE_ENV_KEYS=(
+  ANTHROPIC_BASE_URL
+  ANTHROPIC_API_KEY
+  ANTHROPIC_AUTH_TOKEN
+  ANTHROPIC_MODEL
+  ANTHROPIC_SMALL_FAST_MODEL
+  ANTHROPIC_DEFAULT_OPUS_MODEL
+  ANTHROPIC_DEFAULT_OPUS_MODEL_NAME
+  ANTHROPIC_DEFAULT_SONNET_MODEL
+  ANTHROPIC_DEFAULT_SONNET_MODEL_NAME
+  ANTHROPIC_DEFAULT_HAIKU_MODEL
+  ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME
+  ANTHROPIC_DEFAULT_FABLE_MODEL
+  ANTHROPIC_DEFAULT_FABLE_MODEL_NAME
+  CLAUDE_CODE_SUBAGENT_MODEL
+  ENABLE_TOOL_SEARCH
+  CLAUDE_CODE_AUTO_COMPACT_WINDOW
+  CLAUDE_CODE_EFFORT_LEVEL
+)
+
+# Print space-separated route keys present under settings.json env (if any).
+# Uses the project venv when available; falls back to python3.
+claude_settings_conflicting_route_keys() {
+  local settings_path="${1:-${HOME}/.claude/settings.json}"
+  local py_bin="${CLAUDE_ROUTE_GUARD_PYTHON:-}"
+  local keys_csv
+  local key
+
+  if [ ! -f "$settings_path" ]; then
+    return 0
+  fi
+
+  if [ -z "$py_bin" ]; then
+    if [ -n "${PROJECT_DIR:-}" ] && [ -x "${PROJECT_DIR}/.venv/bin/python" ]; then
+      py_bin="${PROJECT_DIR}/.venv/bin/python"
+    elif command -v python3 >/dev/null 2>&1; then
+      py_bin="$(command -v python3)"
+    else
+      echo "Error: python3 is required to inspect Claude settings at $settings_path." >&2
+      return 2
+    fi
+  fi
+
+  keys_csv="$(
+    "$py_bin" - "$settings_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+try:
+    data = json.loads(path.read_text(encoding="utf-8"))
+except Exception as exc:  # noqa: BLE001 — surface parse failures to the shell
+    print(f"PARSE_ERROR:{exc}", file=sys.stderr)
+    sys.exit(3)
+
+env = data.get("env")
+if not isinstance(env, dict):
+    sys.exit(0)
+
+keys = [
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL_NAME",
+    "CLAUDE_CODE_SUBAGENT_MODEL",
+    "ENABLE_TOOL_SEARCH",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+    "CLAUDE_CODE_EFFORT_LEVEL",
+]
+present = [k for k in keys if k in env]
+print(" ".join(present))
+PY
+  )" || return $?
+
+  # shellcheck disable=SC2086
+  for key in $keys_csv; do
+    printf '%s\n' "$key"
+  done
+}
+
+# Refuse launch when settings.json would override process-scoped route env.
+# Pass-through when CLAUDE_CONFIG_DIR is set to a non-default isolated dir, or
+# when CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV=1 (explicit operator override).
+assert_claude_settings_route_clean() {
+  local route_name="${1:-alternate Claude route}"
+  local settings_path="${CLAUDE_SETTINGS_PATH:-${HOME}/.claude/settings.json}"
+  local config_dir="${CLAUDE_CONFIG_DIR:-}"
+  local conflicts=()
+  local line
+
+  if [ "${CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV:-0}" = "1" ]; then
+    echo "Warning: CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV=1 — settings.json env may override $route_name." >&2
+    return 0
+  fi
+
+  # Isolated config dir means we are not reading the operator's live settings.
+  if [ -n "$config_dir" ] && [ "$config_dir" != "${HOME}/.claude" ]; then
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    [ -n "$line" ] && conflicts+=("$line")
+  done < <(claude_settings_conflicting_route_keys "$settings_path")
+
+  if ((${#conflicts[@]} == 0)); then
+    return 0
+  fi
+
+  echo "Error: $route_name refuses to launch because $settings_path pins route env keys:" >&2
+  printf '  - %s\n' "${conflicts[@]}" >&2
+  echo >&2
+  echo "Claude Code applies settings.json env OVER process environment, so these" >&2
+  echo "pins would hijack native Claude and this launcher. We do NOT rewrite that" >&2
+  echo "file (original config must stay operator-owned)." >&2
+  echo >&2
+  echo "Options:" >&2
+  echo "  1) Remove those keys from settings.json env (recommended; keep Method-1 env routing)." >&2
+  echo "  2) Launch with an isolated config dir, e.g. CLAUDE_CONFIG_DIR=\$HOME/.claude-kimicc" >&2
+  echo "  3) Emergency only: CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV=1 (not recommended)." >&2
+  echo >&2
+  echo "cc-switch and similar tools often write these keys — prefer project launchers" >&2
+  echo "(./start-claude.sh, ./start-claudex.sh, ./start-kimicc.sh) over global switches." >&2
+  return 1
+}

--- a/scripts/lib/context_profiles.py
+++ b/scripts/lib/context_profiles.py
@@ -53,8 +53,16 @@ def validate_profile(profile: dict[str, Any], *, key: str | None = None) -> list
     elif key is not None and profile_id != key:
         errors.append(f"profile_id {profile_id!r} does not match registry key {key!r}")
 
-    if profile["transport"] not in {"claudex", "native", "native_codex", "unknown"}:
-        errors.append("transport must be claudex, native, native_codex, or unknown")
+    if profile["transport"] not in {
+        "claudex",
+        "kimicc",
+        "native",
+        "native_codex",
+        "unknown",
+    }:
+        errors.append(
+            "transport must be claudex, kimicc, native, native_codex, or unknown"
+        )
     if not isinstance(profile["main_model_id"], str) or not profile["main_model_id"].strip():
         errors.append("main_model_id must be a non-empty string")
 

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -131,12 +131,17 @@ for arg in "$@"; do
     _prev="$arg"
 done
 
-# Direct use of this certified wrapper is the native-Claude route. The Claudex
-# supervisor marks only the process it owns; the marker is consumed here so a
-# later nested native launch cannot inherit the proxy route by ambient state.
+# Direct use of this certified wrapper is the native-Claude route. Claudex and
+# KimiCC mark only the process they own; markers are consumed here so a later
+# nested native launch cannot inherit an alternate route by ambient state.
 _claudex_managed_launch="${LEARN_UKRAINIAN_CLAUDEX_MANAGED_LAUNCH:-0}"
+_kimicc_managed_launch="${LEARN_UKRAINIAN_KIMICC_MANAGED_LAUNCH:-0}"
 unset LEARN_UKRAINIAN_CLAUDEX_MANAGED_LAUNCH
+unset LEARN_UKRAINIAN_KIMICC_MANAGED_LAUNCH
 if [ "$_claudex_managed_launch" != "1" ] && [ "${LEARN_UKRAINIAN_TRANSPORT:-}" = "claudex" ]; then
+    unset LEARN_UKRAINIAN_REQUESTED_PROFILE_ID
+fi
+if [ "$_kimicc_managed_launch" != "1" ] && [ "${LEARN_UKRAINIAN_TRANSPORT:-}" = "kimicc" ]; then
     unset LEARN_UKRAINIAN_REQUESTED_PROFILE_ID
 fi
 _requested_profile="${LEARN_UKRAINIAN_REQUESTED_PROFILE_ID:-native_claude}"
@@ -154,11 +159,14 @@ if [ "$LEARN_UKRAINIAN_TRUSTED" != "1" ]; then
     fi
 fi
 
-# The certified native route must not inherit Claudex's proxy, delegation,
-# deferred-tool, or supervisor identity state.
+# The certified native route must not inherit Claudex/KimiCC proxy, delegation,
+# deferred-tool, effort, or supervisor identity state.
 if [ "$LEARN_UKRAINIAN_TRANSPORT" = "native" ]; then
     unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_SUBAGENT_MODEL
-    unset ENABLE_TOOL_SEARCH LEARN_UKRAINIAN_CLAUDEX_RUN_ID
+    unset ANTHROPIC_MODEL ANTHROPIC_DEFAULT_OPUS_MODEL ANTHROPIC_DEFAULT_SONNET_MODEL
+    unset ANTHROPIC_DEFAULT_HAIKU_MODEL ANTHROPIC_DEFAULT_FABLE_MODEL
+    unset ENABLE_TOOL_SEARCH CLAUDE_CODE_EFFORT_LEVEL
+    unset LEARN_UKRAINIAN_CLAUDEX_RUN_ID
     unset LEARN_UKRAINIAN_CLAUDEX_LAUNCH_GENERATION
 fi
 
@@ -171,7 +179,7 @@ fi
 
 # One concise diagnostic; no endpoint, authorization, or forwarded arguments.
 echo "Context profile: id=$LEARN_UKRAINIAN_PROFILE_ID model=$LEARN_UKRAINIAN_MAIN_MODEL_ID window=$LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS budget=$LEARN_UKRAINIAN_COLD_START_BUDGET_TOKENS compact=${LEARN_UKRAINIAN_AUTO_COMPACT_CAPACITY_TOKENS:-native} reason=$LEARN_UKRAINIAN_RESOLUTION_REASON"
-unset _claudex_managed_launch _requested_profile _prev
+unset _claudex_managed_launch _kimicc_managed_launch _requested_profile _prev
 
 export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
 

--- a/start-claudex.sh
+++ b/start-claudex.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
-# Run Claude Code on GPT-5.6 Sol through CLIProxyAPI.
+# Interactive Claude Code UI on GPT-5.6 Sol through CLIProxyAPI.
+#
+# Interactive only — headless GPT/Codex work stays on ./start-codex.sh or the
+# bridge. Process-scoped env only: never rewrites ~/.claude/settings.json, so
+# ./start-claude.sh (native Anthropic) remains available in parallel.
+#
+# Compaction: sol_lead profile = 372k window, 353k auto-compact capacity
+# (scripts/config/context_profiles.yaml). Do not raise English immersion policy
+# via this launcher — it only changes the model route.
 
 set -euo pipefail
 
@@ -12,8 +20,8 @@ usage() {
     cat <<'EOF'
 Usage: ./start-claudex.sh [--subagent sol|terra|luna] [CLAUDE_ARGS...]
 
-Launch Claude Code with GPT-5.6 Sol as the lead model and a configurable
-GPT-5.6 subagent model. Other arguments are forwarded to start-claude.sh.
+Interactive Claude Code with GPT-5.6 Sol lead (372k context / 353k compact)
+and a configurable GPT-5.6 subagent. Does not rewrite ~/.claude/settings.json.
 
 Options:
   --subagent MODEL  Subagent tier: sol (default), terra, or luna
@@ -23,6 +31,9 @@ Environment:
   CLAUDEX_SUBAGENT   Default subagent tier
   CLAUDEX_BASE_URL   CLIProxyAPI URL (default: http://127.0.0.1:8317)
   CLAUDEX_AUTH_TOKEN CLIProxyAPI token (default: sk-dummy)
+
+Parallel native Claude: ./start-claude.sh in another terminal (original config).
+Headless GPT: ./start-codex.sh or ab ask-codex — not this launcher.
 EOF
 }
 
@@ -64,6 +75,12 @@ while (($#)); do
     esac
 done
 
+# shellcheck source=scripts/lib/claude_route_guard.sh
+source "$PROJECT_DIR/scripts/lib/claude_route_guard.sh"
+if ! assert_claude_settings_route_clean "Claudex"; then
+    exit 1
+fi
+
 # Resolve the Sol lead contract before delegated-model selection. The delegated
 # model must not influence any main-session capacity or cold-start field.
 # shellcheck source=scripts/lib/profile_resolver.sh
@@ -77,6 +94,7 @@ if [ "$LEARN_UKRAINIAN_TRUSTED" != "1" ] || [ "$LEARN_UKRAINIAN_PROFILE_ID" != "
     exit 1
 fi
 export LEARN_UKRAINIAN_REQUESTED_PROFILE_ID="sol_lead"
+# 372k Sol window → 353k certified auto-compact (emergency rollover fires first).
 export CLAUDE_CODE_AUTO_COMPACT_WINDOW="$LEARN_UKRAINIAN_AUTO_COMPACT_CAPACITY_TOKENS"
 
 if ! SUBAGENT_MODEL="$(resolve_model "$SUBAGENT")"; then
@@ -110,4 +128,5 @@ if ! curl --fail --silent --show-error --output /dev/null --header @- \
 fi
 
 echo "Claudex: lead=$LEAD_MODEL subagent=$SUBAGENT_MODEL profile=$LEARN_UKRAINIAN_PROFILE_ID"
+echo "         window=$LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS compact=$CLAUDE_CODE_AUTO_COMPACT_WINDOW (env-only; settings.json untouched)"
 exec "$PROJECT_DIR/.venv/bin/python" "$PROJECT_DIR/scripts/orchestration/claudex_supervisor.py" "$PROJECT_DIR/start-claude.sh" --model "$LEAD_MODEL" "${FORWARD_ARGS[@]}"

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -57,7 +57,7 @@ Examples:
   ./start-kimicc.sh
   ./start-kimicc.sh --model k2.7
   ./start-kimicc.sh --model k2.7-highspeed --epic harness
-  MOONSHOT_API_KEY=sk-… ./start-kimicc.sh --model k3
+  MOONSHOT_API_KEY=<your-key> ./start-kimicc.sh --model k3
 
 Headless / native Kimi (not this launcher):
   scripts/delegate.py dispatch --agent kimi --model k3 …

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -217,7 +217,7 @@ if ! assert_claude_settings_route_clean "KimiCC"; then
   exit 1
 fi
 
-if ! AUTH_TOKEN="$(resolve_auth_token)"; then
+if ! _resolved_auth="$(resolve_auth_token)"; then
   echo "Error: no Kimi API credential found for the kimicc route." >&2
   echo "  Set one of: MOONSHOT_API_KEY, KIMI_API_KEY, or KIMICC_AUTH_TOKEN" >&2
   echo "  Platform keys: https://platform.kimi.ai/console/api-keys" >&2
@@ -242,7 +242,7 @@ export LEARN_UKRAINIAN_TRANSPORT=kimicc
 
 # Moonshot Anthropic-compatible routing (process-scoped only).
 export ANTHROPIC_BASE_URL="$BASE_URL"
-export ANTHROPIC_AUTH_TOKEN="$AUTH_TOKEN"
+export ANTHROPIC_AUTH_TOKEN="$_resolved_auth"
 unset ANTHROPIC_API_KEY
 
 export ANTHROPIC_MODEL="$LEAD_MODEL"

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# Interactive Claude Code UI routed to Kimi (K3 / K2.7) via Anthropic-compatible API.
+#
+# This is NOT the native Kimi Code TUI. For headless / native Kimi use:
+#   kimi                       # interactive native Kimi Code CLI (OAuth)
+#   delegate.py --agent kimi   # headless fleet lane (default)
+#   ab ask-kimi                # bridge one-shot
+#
+# Design (parallel-safe with ./start-claude.sh):
+# - Process-scoped env only (Moonshot Method 1). Never writes ~/.claude/settings.json.
+# - Original Anthropic Claude config stays untouched; run native Claude in another terminal.
+# - Refuses to launch if settings.json already pins route env keys (cc-switch hazard).
+# - Compaction comes from scripts/config/context_profiles.yaml (1M for K3, 256K for K2.7).
+#
+# Official references:
+# - https://platform.kimi.ai/docs/guide/claude-code-kimi
+# - https://github.com/farion1231/cc-switch  (do NOT use it to rewrite project Claude config)
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PATH="${HOME}/.local/bin:${PATH:-}"
+hash -r 2>/dev/null || true
+
+# Default: Kimi Open Platform Anthropic endpoint (pay-as-you-go API key).
+# Use --endpoint coding for the Kimi Code subscription Anthropic base URL.
+ENDPOINT="${KIMICC_ENDPOINT:-platform}"
+MODEL_ALIAS="${KIMICC_MODEL:-k3}"
+FORWARD_ARGS=()
+ISOLATE_CONFIG=0
+
+usage() {
+  cat <<'EOF'
+Usage: ./start-kimicc.sh [options] [CLAUDE_ARGS...]
+
+Launch Claude Code with Kimi as the lead model (interactive only).
+Does not rewrite ~/.claude/settings.json — original Claude config stays intact.
+
+Options:
+  --model ALIAS     k3 (default) | k2.7 | k2.7-highspeed
+                    Also accepts full IDs: kimi-k3[1m], kimi-k2.7-code, …
+  --endpoint NAME   platform (default, api.moonshot.ai/anthropic)
+                    coding   (Kimi Code subscription, api.kimi.com/coding)
+  --isolate-config  Use CLAUDE_CONFIG_DIR=$HOME/.claude-kimicc (separate sessions)
+  -h, --help        Show this help
+
+Environment:
+  KIMICC_MODEL / KIMICC_ENDPOINT     Defaults for --model / --endpoint
+  MOONSHOT_API_KEY / KIMI_API_KEY    Platform API key (preferred)
+  KIMICC_AUTH_TOKEN                  Explicit auth token override
+  KIMICC_BASE_URL                    Override Anthropic-compatible base URL
+  CLAUDE_CONFIG_DIR                  Isolated Claude config directory
+  CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV=1
+                                     Bypass settings.json env conflict check (emergency)
+
+Examples:
+  ./start-kimicc.sh
+  ./start-kimicc.sh --model k2.7
+  ./start-kimicc.sh --model k2.7-highspeed --epic harness
+  MOONSHOT_API_KEY=sk-… ./start-kimicc.sh --model k3
+
+Headless / native Kimi (not this launcher):
+  scripts/delegate.py dispatch --agent kimi --model k3 …
+  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-kimi …
+EOF
+}
+
+resolve_model_alias() {
+  # Bracketed IDs (kimi-k3[1m]) cannot live in bash `case` arms — [ is a char class.
+  local raw="$1"
+  case "$raw" in
+    'kimi-k3[1m]'|k3|kimi-k3|kimi-code/k3)
+      printf '%s\n' 'k3'
+      ;;
+    k2.7|k2.7-coding|kimi-k2.7-code|kimi-for-coding|kimi-code/kimi-for-coding)
+      printf '%s\n' 'k2.7'
+      ;;
+    k2.7-highspeed|k2.7-coding-highspeed|kimi-k2.7-code-highspeed|kimi-for-coding-highspeed|kimi-code/kimi-for-coding-highspeed)
+      printf '%s\n' 'k2.7-highspeed'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+platform_model_id() {
+  case "$1" in
+    k3) printf '%s\n' 'kimi-k3[1m]' ;;
+    k2.7) printf '%s\n' 'kimi-k2.7-code' ;;
+    k2.7-highspeed) printf '%s\n' 'kimi-k2.7-code-highspeed' ;;
+    *) return 1 ;;
+  esac
+}
+
+coding_model_id() {
+  # Kimi Code subscription Anthropic surface uses the managed seat names.
+  case "$1" in
+    k3) printf '%s\n' 'k3' ;;
+    k2.7) printf '%s\n' 'kimi-for-coding' ;;
+    k2.7-highspeed) printf '%s\n' 'kimi-for-coding-highspeed' ;;
+    *) return 1 ;;
+  esac
+}
+
+profile_for_alias() {
+  case "$1" in
+    k3) printf '%s\n' 'kimicc_k3' ;;
+    k2.7) printf '%s\n' 'kimicc_k27' ;;
+    k2.7-highspeed) printf '%s\n' 'kimicc_k27_highspeed' ;;
+    *) return 1 ;;
+  esac
+}
+
+default_base_url() {
+  case "$1" in
+    platform) printf '%s\n' 'https://api.moonshot.ai/anthropic' ;;
+    coding) printf '%s\n' 'https://api.kimi.com/coding' ;;
+    *) return 1 ;;
+  esac
+}
+
+resolve_auth_token() {
+  if [ -n "${KIMICC_AUTH_TOKEN:-}" ]; then
+    printf '%s\n' "$KIMICC_AUTH_TOKEN"
+    return 0
+  fi
+  if [ -n "${MOONSHOT_API_KEY:-}" ]; then
+    printf '%s\n' "$MOONSHOT_API_KEY"
+    return 0
+  fi
+  if [ -n "${KIMI_API_KEY:-}" ]; then
+    printf '%s\n' "$KIMI_API_KEY"
+    return 0
+  fi
+  if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ "${ENDPOINT}" = "coding" ]; then
+    # Allow an already-exported coding token when operator sets it intentionally.
+    printf '%s\n' "$ANTHROPIC_AUTH_TOKEN"
+    return 0
+  fi
+  return 1
+}
+
+while (($#)); do
+  case "$1" in
+    --model)
+      if (($# < 2)); then
+        echo "Error: --model requires k3, k2.7, or k2.7-highspeed." >&2
+        exit 2
+      fi
+      MODEL_ALIAS="$2"
+      shift 2
+      ;;
+    --model=*)
+      MODEL_ALIAS="${1#*=}"
+      shift
+      ;;
+    --endpoint)
+      if (($# < 2)); then
+        echo "Error: --endpoint requires platform or coding." >&2
+        exit 2
+      fi
+      ENDPOINT="$2"
+      shift 2
+      ;;
+    --endpoint=*)
+      ENDPOINT="${1#*=}"
+      shift
+      ;;
+    --isolate-config)
+      ISOLATE_CONFIG=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      FORWARD_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if ! MODEL_ALIAS="$(resolve_model_alias "$MODEL_ALIAS")"; then
+  echo "Error: unsupported model '$MODEL_ALIAS' (use k3, k2.7, k2.7-highspeed)." >&2
+  exit 2
+fi
+
+case "$ENDPOINT" in
+  platform|coding) ;;
+  *)
+    echo "Error: unsupported endpoint '$ENDPOINT' (use platform or coding)." >&2
+    exit 2
+    ;;
+esac
+
+if [ "$ENDPOINT" = "platform" ]; then
+  LEAD_MODEL="$(platform_model_id "$MODEL_ALIAS")"
+else
+  LEAD_MODEL="$(coding_model_id "$MODEL_ALIAS")"
+fi
+PROFILE_ID="$(profile_for_alias "$MODEL_ALIAS")"
+BASE_URL="${KIMICC_BASE_URL:-$(default_base_url "$ENDPOINT")}"
+BASE_URL="${BASE_URL%/}"
+
+# shellcheck source=scripts/lib/claude_route_guard.sh
+source "$PROJECT_DIR/scripts/lib/claude_route_guard.sh"
+
+if [ "$ISOLATE_CONFIG" = "1" ] && [ -z "${CLAUDE_CONFIG_DIR:-}" ]; then
+  export CLAUDE_CONFIG_DIR="${HOME}/.claude-kimicc"
+  mkdir -p "$CLAUDE_CONFIG_DIR"
+  echo "Isolated Claude config: $CLAUDE_CONFIG_DIR (original ~/.claude untouched)"
+fi
+
+if ! assert_claude_settings_route_clean "KimiCC"; then
+  exit 1
+fi
+
+if ! AUTH_TOKEN="$(resolve_auth_token)"; then
+  echo "Error: no Kimi API credential found for the kimicc route." >&2
+  echo "  Set one of: MOONSHOT_API_KEY, KIMI_API_KEY, or KIMICC_AUTH_TOKEN" >&2
+  echo "  Platform keys: https://platform.kimi.ai/console/api-keys" >&2
+  echo "  Native Kimi OAuth (kimi login) is for ./start-kimi.sh / headless kimi — not Claude Code." >&2
+  exit 1
+fi
+
+# shellcheck source=scripts/lib/profile_resolver.sh
+source "$PROJECT_DIR/scripts/lib/profile_resolver.sh"
+if ! resolve_context_profile "$PROFILE_ID" "$LEAD_MODEL"; then
+  echo "Error: could not resolve kimicc profile '$PROFILE_ID' for model '$LEAD_MODEL'." >&2
+  exit 1
+fi
+if [ "$LEARN_UKRAINIAN_TRUSTED" != "1" ] || [ "$LEARN_UKRAINIAN_PROFILE_ID" != "$PROFILE_ID" ]; then
+  echo "Error: kimicc profile did not resolve to a trusted contract ($LEARN_UKRAINIAN_RESOLUTION_REASON)." >&2
+  exit 1
+fi
+
+export LEARN_UKRAINIAN_REQUESTED_PROFILE_ID="$PROFILE_ID"
+export LEARN_UKRAINIAN_KIMICC_MANAGED_LAUNCH=1
+export LEARN_UKRAINIAN_TRANSPORT=kimicc
+
+# Moonshot Anthropic-compatible routing (process-scoped only).
+export ANTHROPIC_BASE_URL="$BASE_URL"
+export ANTHROPIC_AUTH_TOKEN="$AUTH_TOKEN"
+unset ANTHROPIC_API_KEY
+
+export ANTHROPIC_MODEL="$LEAD_MODEL"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="$LEAD_MODEL"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="$LEAD_MODEL"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="$LEAD_MODEL"
+export ANTHROPIC_DEFAULT_FABLE_MODEL="$LEAD_MODEL"
+export CLAUDE_CODE_SUBAGENT_MODEL="$LEAD_MODEL"
+
+# Kimi endpoint does not support Claude Code tool-search yet (official guide).
+export ENABLE_TOOL_SEARCH=false
+
+# Compaction: certified profile capacity (below true window; emergency rollover first).
+export CLAUDE_CODE_AUTO_COMPACT_WINDOW="$LEARN_UKRAINIAN_AUTO_COMPACT_CAPACITY_TOKENS"
+
+# K3 defaults to max effort on the platform guide; k2.7 always-thinks (Tab thinking in UI).
+if [ "$MODEL_ALIAS" = "k3" ]; then
+  export CLAUDE_CODE_EFFORT_LEVEL="${KIMICC_EFFORT_LEVEL:-max}"
+else
+  # Leave effort unset for k2.7 unless operator overrides; thinking must stay on in the TUI.
+  if [ -n "${KIMICC_EFFORT_LEVEL:-}" ]; then
+    export CLAUDE_CODE_EFFORT_LEVEL="$KIMICC_EFFORT_LEVEL"
+  fi
+fi
+
+echo "KimiCC: model=$LEAD_MODEL alias=$MODEL_ALIAS endpoint=$ENDPOINT profile=$PROFILE_ID"
+echo "        window=$LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS compact=$CLAUDE_CODE_AUTO_COMPACT_WINDOW"
+echo "        base=$ANTHROPIC_BASE_URL (env-only; ~/.claude/settings.json not modified)"
+echo "        tip: keep ./start-claude.sh in another terminal for native Anthropic Claude"
+if [ "$MODEL_ALIAS" != "k3" ]; then
+  echo "        note: k2.7 requires Thinking ON in the TUI (Tab) or requests are rejected"
+fi
+
+# Strip any ambient --model from forwarded args; lead model is owned by this launcher.
+_cleaned=()
+_prev=""
+for arg in "${FORWARD_ARGS[@]+"${FORWARD_ARGS[@]}"}"; do
+  if [ "$_prev" = "--model" ]; then
+    _prev=""
+    continue
+  fi
+  case "$arg" in
+    --model|--model=*)
+      echo "Error: KimiCC owns the lead model ($LEAD_MODEL); drop --model from the command line." >&2
+      exit 2
+      ;;
+  esac
+  _cleaned+=("$arg")
+  _prev="$arg"
+done
+
+if ((${#_cleaned[@]})); then
+  exec "$PROJECT_DIR/start-claude.sh" --model "$LEAD_MODEL" "${_cleaned[@]}"
+else
+  exec "$PROJECT_DIR/start-claude.sh" --model "$LEAD_MODEL"
+fi

--- a/tests/test_context_profiles.py
+++ b/tests/test_context_profiles.py
@@ -74,6 +74,20 @@ def test_production_registry_separates_sol_capacity_values() -> None:
         "rollover_warning_percentages": [75.0, 85.0, 92.0],
     }
     assert profiles["native_claude"]["auto_compact_capacity_tokens"] is None
+    assert profiles["kimicc_k3"] == {
+        "profile_id": "kimicc_k3",
+        "transport": "kimicc",
+        "main_model_id": "kimi-k3[1m]",
+        "model_id_patterns": [r"^kimi-k3(\[1m\])?$", r"^k3$"],
+        "main_context_window_tokens": 1_048_576,
+        "auto_compact_capacity_tokens": 996_147,
+        "cold_start_profile": "compact",
+        "cold_start_budget_tokens": 104_857,
+        "rollover_warning_percentages": [75.0, 85.0, 92.0],
+    }
+    assert profiles["kimicc_k27"]["main_context_window_tokens"] == 262_144
+    assert profiles["kimicc_k27"]["auto_compact_capacity_tokens"] == 249_036
+    assert profiles["kimicc_k27_highspeed"]["main_model_id"] == "kimi-k2.7-code-highspeed"
 
 
 def test_native_codex_profile_accepts_sol_and_rejects_other_models() -> None:

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -1,0 +1,261 @@
+"""Behavior checks for the interactive Claude Code + Kimi (kimicc) launcher."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LAUNCHER = _REPO_ROOT / "start-kimicc.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_with_fakes(
+    tmp_path: Path,
+    arguments: list[str],
+    *,
+    env_overrides: dict[str, str] | None = None,
+    settings_env: dict[str, str] | None = None,
+) -> tuple[str, subprocess.CompletedProcess[str]]:
+    home = tmp_path / "home"
+    home_bin = home / ".local" / "bin"
+    home_bin.mkdir(parents=True)
+    capture = tmp_path / "capture.txt"
+
+    if settings_env is not None:
+        claude_dir = home / ".claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"env": settings_env, "model": "opus[1m]"}),
+            encoding="utf-8",
+        )
+
+    _write_executable(
+        home_bin / "claude",
+        """#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+    echo "test-claude"
+    exit 0
+fi
+{
+    printf 'base=%s\\n' "${ANTHROPIC_BASE_URL-unset}"
+    printf 'auth=%s\\n' "${ANTHROPIC_AUTH_TOKEN-unset}"
+    if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then printf 'api_key=SET\\n'; else printf 'api_key=UNSET\\n'; fi
+    printf 'model=%s\\n' "${ANTHROPIC_MODEL-unset}"
+    printf 'opus=%s\\n' "${ANTHROPIC_DEFAULT_OPUS_MODEL-unset}"
+    printf 'sonnet=%s\\n' "${ANTHROPIC_DEFAULT_SONNET_MODEL-unset}"
+    printf 'haiku=%s\\n' "${ANTHROPIC_DEFAULT_HAIKU_MODEL-unset}"
+    printf 'fable=%s\\n' "${ANTHROPIC_DEFAULT_FABLE_MODEL-unset}"
+    printf 'subagent=%s\\n' "${CLAUDE_CODE_SUBAGENT_MODEL-unset}"
+    printf 'tool_search=%s\\n' "${ENABLE_TOOL_SEARCH-unset}"
+    printf 'effort=%s\\n' "${CLAUDE_CODE_EFFORT_LEVEL-unset}"
+    printf 'auto_compact=%s\\n' "${CLAUDE_CODE_AUTO_COMPACT_WINDOW-unset}"
+    printf 'profile=%s\\n' "$LEARN_UKRAINIAN_PROFILE_ID"
+    printf 'transport=%s\\n' "$LEARN_UKRAINIAN_TRANSPORT"
+    printf 'main_window=%s\\n' "$LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS"
+    printf 'config_dir=%s\\n' "${CLAUDE_CONFIG_DIR-unset}"
+    printf 'arg=%s\\n' "$@"
+} > "$KIMICC_TEST_CAPTURE"
+""",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "npm", "#!/usr/bin/env bash\nexit 0\n")
+
+    env = os.environ.copy()
+    for name in tuple(env):
+        if name.startswith("LEARN_UKRAINIAN_") or name in {
+            "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+            "CLAUDE_CODE_SUBAGENT_MODEL",
+            "CLAUDE_CODE_EFFORT_LEVEL",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_MODEL",
+            "MOONSHOT_API_KEY",
+            "KIMI_API_KEY",
+            "KIMICC_AUTH_TOKEN",
+            "KIMICC_BASE_URL",
+            "KIMICC_MODEL",
+            "KIMICC_ENDPOINT",
+            "CLAUDE_CONFIG_DIR",
+            "SESSION_EPIC",
+            "SESSION_HANDOFF_AGENT",
+        }:
+            env.pop(name, None)
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "KIMICC_TEST_CAPTURE": str(capture),
+            "MOONSHOT_API_KEY": "sk-test-moonshot",
+        }
+    )
+    env.update(env_overrides or {})
+
+    result = subprocess.run(
+        [str(_LAUNCHER), *arguments],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    output = capture.read_text(encoding="utf-8") if capture.exists() else ""
+    return output, result
+
+
+@pytest.mark.parametrize(
+    ("arguments", "model", "profile", "window", "compact", "effort"),
+    [
+        ([], "kimi-k3[1m]", "kimicc_k3", "1048576", "996147", "max"),
+        (["--model", "k3"], "kimi-k3[1m]", "kimicc_k3", "1048576", "996147", "max"),
+        (["--model", "k2.7"], "kimi-k2.7-code", "kimicc_k27", "262144", "249036", "unset"),
+        (
+            ["--model", "k2.7-highspeed"],
+            "kimi-k2.7-code-highspeed",
+            "kimicc_k27_highspeed",
+            "262144",
+            "249036",
+            "unset",
+        ),
+    ],
+)
+def test_routes_models_and_compaction(
+    tmp_path: Path,
+    arguments: list[str],
+    model: str,
+    profile: str,
+    window: str,
+    compact: str,
+    effort: str,
+) -> None:
+    output, result = _run_with_fakes(tmp_path, arguments)
+    assert result.returncode == 0, result.stderr
+    assert "base=https://api.moonshot.ai/anthropic" in output
+    assert "auth=sk-test-moonshot" in output
+    assert "api_key=UNSET" in output
+    assert f"model={model}" in output
+    assert f"opus={model}" in output
+    assert f"sonnet={model}" in output
+    assert f"haiku={model}" in output
+    assert f"fable={model}" in output
+    assert f"subagent={model}" in output
+    assert "tool_search=false" in output
+    assert f"effort={effort}" in output
+    assert f"auto_compact={compact}" in output
+    assert f"profile={profile}" in output
+    assert "transport=kimicc" in output
+    assert f"main_window={window}" in output
+    assert "arg=--model" in output
+    assert f"arg={model}" in output
+
+
+def test_coding_endpoint_uses_subscription_base_and_model_ids(tmp_path: Path) -> None:
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "coding", "--model", "k2.7"],
+        env_overrides={"KIMICC_AUTH_TOKEN": "sk-coding-token"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "base=https://api.kimi.com/coding" in output
+    assert "auth=sk-coding-token" in output
+    assert "model=kimi-for-coding" in output
+    assert "profile=kimicc_k27" in output
+
+
+def test_refuses_settings_json_route_env_pins(tmp_path: Path) -> None:
+    output, result = _run_with_fakes(
+        tmp_path,
+        [],
+        settings_env={"ANTHROPIC_BASE_URL": "https://evil.example/anthropic"},
+    )
+    assert result.returncode == 1
+    assert "refuses to launch" in result.stderr
+    assert "ANTHROPIC_BASE_URL" in result.stderr
+    assert output == ""
+    # Original settings file is not mutated.
+    settings = (tmp_path / "home" / ".claude" / "settings.json").read_text(encoding="utf-8")
+    assert "evil.example" in settings
+
+
+def test_isolate_config_bypasses_live_settings_pins(tmp_path: Path) -> None:
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--isolate-config"],
+        settings_env={"ANTHROPIC_BASE_URL": "https://evil.example/anthropic"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "base=https://api.moonshot.ai/anthropic" in output
+    assert str(tmp_path / "home" / ".claude-kimicc") in output or "config_dir=" in output
+    assert "config_dir=" in output
+    assert "evil.example" not in output
+
+
+def test_missing_api_key_fails_cleanly(tmp_path: Path) -> None:
+    _, result = _run_with_fakes(
+        tmp_path,
+        [],
+        env_overrides={
+            # Explicitly clear every credential source the launcher accepts.
+            "MOONSHOT_API_KEY": "",
+            "KIMI_API_KEY": "",
+            "KIMICC_AUTH_TOKEN": "",
+            "ANTHROPIC_AUTH_TOKEN": "",
+        },
+    )
+    # Empty strings are still "set"; re-run with keys removed entirely.
+    env = os.environ.copy()
+    for name in (
+        "MOONSHOT_API_KEY",
+        "KIMI_API_KEY",
+        "KIMICC_AUTH_TOKEN",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_API_KEY",
+    ):
+        env.pop(name, None)
+    home = tmp_path / "home-no-key"
+    (home / ".local" / "bin").mkdir(parents=True)
+    _write_executable(home / ".local" / "bin" / "claude", "#!/usr/bin/env bash\nexit 0\n")
+    fake_bin = tmp_path / "bin-no-key"
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "npm", "#!/usr/bin/env bash\nexit 0\n")
+    env.update({"HOME": str(home), "PATH": f"{fake_bin}:{env['PATH']}"})
+    result = subprocess.run(
+        [str(_LAUNCHER)],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 1
+    assert "no Kimi API credential" in result.stderr
+
+
+def test_rejects_forwarded_model_flag(tmp_path: Path) -> None:
+    _, result = _run_with_fakes(tmp_path, ["--model", "k3", "--model", "opus"])
+    # Second --model is parsed as the lead alias and fails as unsupported.
+    assert result.returncode == 2
+    assert "unsupported model" in result.stderr
+
+
+def test_help_mentions_native_kimi_headless_separation(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [str(_LAUNCHER), "--help"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0
+    assert "ask-kimi" in result.stdout
+    assert "settings.json" in result.stdout

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -18,6 +18,54 @@ def _write_executable(path: Path, body: str) -> None:
     path.chmod(0o755)
 
 
+def _require_launcher_sources() -> None:
+    """Seed from checkout once; do not depend on root scripts surviving full CI suite."""
+    missing = [path for path in (
+        _LAUNCHER,
+        _REPO_ROOT / "scripts" / "lib" / "claude_route_guard.sh",
+        _REPO_ROOT / "scripts" / "lib" / "profile_resolver.sh",
+        _REPO_ROOT / "scripts" / "lib" / "context_profiles.py",
+    ) if not path.is_file()]
+    if missing:
+        names = ", ".join(str(path.relative_to(_REPO_ROOT)) for path in missing)
+        raise FileNotFoundError(f"kimicc launcher sources missing: {names}")
+
+
+def _seed_fake_project(tmp_path: Path) -> Path:
+    """Copy launcher + sourced helpers into an isolated project root."""
+    _require_launcher_sources()
+    project = tmp_path / "project"
+    lib = project / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    cfg = project / "scripts" / "config"
+    cfg.mkdir(parents=True)
+    venv_bin = project / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    _write_executable(project / "start-kimicc.sh", _LAUNCHER.read_text(encoding="utf-8"))
+    _write_executable(
+        project / "start-claude.sh",
+        "#!/usr/bin/env bash\n# Test stub: kimicc already exported env; exec fake claude from PATH.\nexec claude \"$@\"\n",
+    )
+    for name in ("claude_route_guard.sh", "profile_resolver.sh", "context_profiles.py"):
+        src = _REPO_ROOT / "scripts" / "lib" / name
+        dest = lib / name
+        dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+        if name.endswith(".py"):
+            dest.chmod(0o755)
+    profiles = _REPO_ROOT / "scripts" / "config" / "context_profiles.yaml"
+    if profiles.is_file():
+        (cfg / "context_profiles.yaml").write_text(profiles.read_text(encoding="utf-8"), encoding="utf-8")
+    # Point profile resolver at a real Python that has project deps if present.
+    real_py = _REPO_ROOT / ".venv" / "bin" / "python"
+    py_body = (
+        f"#!/usr/bin/env bash\nexec {real_py} \"$@\"\n"
+        if real_py.is_file()
+        else "#!/usr/bin/env bash\nexec /usr/bin/env python3 \"$@\"\n"
+    )
+    _write_executable(venv_bin / "python", py_body)
+    return project
+
+
 def _run_with_fakes(
     tmp_path: Path,
     arguments: list[str],
@@ -101,9 +149,10 @@ fi
     )
     env.update(env_overrides or {})
 
+    project = _seed_fake_project(tmp_path)
     result = subprocess.run(
-        [str(_LAUNCHER), *arguments],
-        cwd=_REPO_ROOT,
+        [str(project / "start-kimicc.sh"), *arguments],
+        cwd=project,
         env=env,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

- Add `./start-kimicc.sh` — interactive **Claude Code UI** routed to **Kimi K3 / K2.7** via Anthropic-compatible API (env-only Method 1).
- Harden `./start-claudex.sh` — still interactive GPT-5.6 Sol (372k / 353k compact), now with settings-route guard.
- **Never rewrite** `~/.claude/settings.json` so native `./start-claude.sh` stays usable in parallel.
- Refuse launch if `settings.json env` already pins route keys (cc-switch hazard); optional `--isolate-config` / `CLAUDE_CONFIG_DIR`.

Headless Kimi stays on native Kimi Code (`delegate.py --agent kimi`, `ab ask-kimi`, `kimi`).

## Compaction contracts

| Route | Window | Auto-compact |
| --- | --- | --- |
| Claudex Sol | 372 000 | 353 000 |
| KimiCC K3 | 1 048 576 | 996 147 |
| KimiCC K2.7 / highspeed | 262 144 | 249 036 |

## Usage

```bash
# Native Anthropic Claude (original config)
./start-claude.sh

# GPT-5.6 via Claude Code UI (interactive)
./start-claudex.sh

# Kimi via Claude Code UI (interactive)
export MOONSHOT_API_KEY=sk-…   # platform.kimi.ai
./start-kimicc.sh
./start-kimicc.sh --model k2.7
```

## Verification

- `bash -n` on launchers + route guard
- `pytest tests/test_start_kimicc.py tests/test_start_claudex.py tests/test_context_profiles.py tests/test_start_claude_profiles.py` → 37 passed

X-Agent: grok/kimicc-claudex-launchers