### PR TITLE
fix(dispatch): treat bare primary as clean for dirty-check

### DIFF
--- a/scripts/guardrails/worktree_containment.py
+++ b/scripts/guardrails/worktree_containment.py
@@ -393,9 +393,31 @@ def primary_checkout_dirty_status(start: Path | str | None = None) -> dict:
     count as dirty. Tracked modifications/deletions and untracked non-ignored
     files both count because either would pollute the primary checkout for the
     next dispatched writer.
+
+    Bare primary repositories (no work tree) cannot hold a dirty working tree
+    for product files — ``git status`` fails with "must be run in a work tree".
+    Treat bare primary as clean so write-capable dispatch can run from
+    worktrees without false-blocking the fleet.
     """
     main_root = resolve_main_root(start)
     branch = current_branch(main_root)
+    bare_proc = _run_git(main_root, "rev-parse", "--is-bare-repository")
+    is_bare = bare_proc.returncode == 0 and bare_proc.stdout.strip().lower() == "true"
+    if is_bare:
+        return {
+            "main_root": str(main_root),
+            "branch": branch,
+            "protected_branch": branch in PROTECTED_BRANCHES if branch else False,
+            "dirty": False,
+            "dirty_count": 0,
+            "tracked_dirty_count": 0,
+            "untracked_dirty_count": 0,
+            "entries": [],
+            "checked_cwd": str(main_root),
+            "checked_command": "git rev-parse --is-bare-repository",
+            "bare_primary": True,
+        }
+
     command = ("git", "status", "--porcelain=v1", "-z", "--untracked-files=all")
     proc = _run_git(main_root, *command[1:])
     if proc.returncode != 0:
@@ -419,6 +441,7 @@ def primary_checkout_dirty_status(start: Path | str | None = None) -> dict:
         "entries": entries,
         "checked_cwd": str(main_root),
         "checked_command": " ".join(command),
+        "bare_primary": False,
     }
 
 

--- a/tests/test_worktree_containment_bare.py
+++ b/tests/test_worktree_containment_bare.py
@@ -1,0 +1,49 @@
+"""Bare primary checkout is not dirty-checkable via git status."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from scripts.guardrails import worktree_containment as wc
+
+_GIT_REDIRECT = frozenset(
+    {
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_PREFIX",
+    }
+)
+
+
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _GIT_REDIRECT}
+
+
+def _git(*args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    )
+
+
+def test_primary_checkout_dirty_status_treats_bare_as_clean(tmp_path: Path, monkeypatch) -> None:
+    bare = tmp_path / "primary.git"
+    _git("init", "--bare", str(bare))
+    monkeypatch.setattr(wc, "resolve_main_root", lambda start=None: bare)
+    monkeypatch.setattr(wc, "current_branch", lambda root: "main")
+
+    # _run_git uses sanitized_git_env — still pass bare path via resolve_main_root.
+    status = wc.primary_checkout_dirty_status(bare)
+    assert status["dirty"] is False
+    assert status["dirty_count"] == 0
+    assert status["entries"] == []
+    assert status.get("bare_primary") is True


### PR DESCRIPTION
## Summary
Bare primary checkouts have no work tree, so `git status` fails and blocked every write-capable `delegate.py` dispatch. Treat bare primary as **clean** so fleet workers can run from worktrees.

## Why
This machine's primary is bare; harness/fleet-comms drivers could not dispatch Kimi/Claude/Cursor writers without false-blocking.

## Tests
- `tests/test_worktree_containment_bare.py` (new)
- existing containment suite

Parent: #4707 / unblocks fleet-comms + Kimi dispatch