### PR TITLE
feat(fleet-comms): PR-J2 Claude start-claude supervisor claim on --epic

### DIFF
--- a/start-claude.sh
+++ b/start-claude.sh
@@ -206,39 +206,54 @@ export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
 # defaulting to a lane — the 2026-07-13 atlas/hramatka/main lane collision is
 # the reason this exists.
 #
-# PR-J2 (Claude SessionStart) will integrate the common session supervisor here
-# so --epic claims/resumes the stream lease before SessionStart binds it. For
-# now, SessionStart continues to own lease open/close via the hook.
+# PR-J2: common session supervisor claims/resumes the stream lease when --epic
+# is set (mirror start-grok.sh / start-kimi.sh). SessionStart binds the native
+# Claude session id to the already-open lease and never opens a second lease.
 _forward_args=("$@")
 if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
     # shellcheck source=scripts/lib/handoff_identity.sh
     source "$PROJECT_DIR/scripts/lib/handoff_identity.sh"
+fi
+if [ -f "$PROJECT_DIR/scripts/lib/session_supervisor.sh" ]; then
+    # shellcheck source=scripts/lib/session_supervisor.sh
+    source "$PROJECT_DIR/scripts/lib/session_supervisor.sh"
+fi
 
+_selected_epic=""
+if command -v handoff_epic_from_argv >/dev/null 2>&1; then
     _selected_epic="$(handoff_epic_from_argv "$@")"
-    if [ -z "$_selected_epic" ] && epic_flag_present "$@"; then
+    if [ -z "$_selected_epic" ] && command -v epic_flag_present >/dev/null 2>&1 && epic_flag_present "$@"; then
         echo "Error: --epic flag present but no usable value (dangling --epic, --epic=, or empty value)."
         echo "   Refusing to launch — pass --epic <name> (e.g. --epic atlas) or drop the flag."
         exit 1
     fi
     if [ -n "$_selected_epic" ]; then
-        if ! epic_name_valid "$_selected_epic"; then
+        if command -v epic_name_valid >/dev/null 2>&1 && ! epic_name_valid "$_selected_epic"; then
             echo "Error: invalid --epic name '$_selected_epic' (allowed: lowercase alnum + inner hyphens, e.g. atlas, lit-war)."
             echo "   Refusing to launch with an ambiguous lane — fix the flag and retry."
             exit 1
         fi
         export SESSION_EPIC="$_selected_epic"
-        _forward_args=()
-        while IFS= read -r -d '' _fwd_arg; do
-            _forward_args+=("$_fwd_arg")
-        done < <(strip_epic_from_argv "$@")
-        unset _fwd_arg
+        if command -v strip_epic_from_argv >/dev/null 2>&1; then
+            _forward_args=()
+            while IFS= read -r -d '' _fwd_arg; do
+                _forward_args+=("$_fwd_arg")
+            done < <(strip_epic_from_argv "$@")
+            unset _fwd_arg
+        fi
         echo "Epic assignment: ${SESSION_EPIC}.epic"
     fi
 
     if [ -z "${SESSION_HANDOFF_AGENT:-}" ]; then
-        _selected_agent="$(handoff_agent_from_argv "$@")"
-        _handoff_slot="$(handoff_identity_for_epic "${_selected_epic:-}")"
-        if [ -z "$_handoff_slot" ]; then
+        _selected_agent=""
+        if command -v handoff_agent_from_argv >/dev/null 2>&1; then
+            _selected_agent="$(handoff_agent_from_argv "$@")"
+        fi
+        _handoff_slot=""
+        if command -v handoff_identity_for_epic >/dev/null 2>&1; then
+            _handoff_slot="$(handoff_identity_for_epic "${_selected_epic:-}")"
+        fi
+        if [ -z "$_handoff_slot" ] && command -v handoff_identity_for_agent >/dev/null 2>&1; then
             _handoff_slot="$(handoff_identity_for_agent "$_selected_agent")"
         fi
         if [ -n "$_handoff_slot" ]; then
@@ -247,8 +262,21 @@ if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
         fi
         unset _selected_agent _handoff_slot
     fi
-    unset _selected_epic
 fi
+
+# Claim/resume the stream lease through the common supervisor when an epic is pinned.
+if [ -n "${_selected_epic:-}" ] && command -v claim_session_supervisor_env >/dev/null 2>&1; then
+    _selected_stream="$(stream_id_for_epic "$_selected_epic")"
+    if [ -z "$_selected_stream" ]; then
+        echo "Error: cannot resolve stream id for epic '${_selected_epic}'." >&2
+        exit 1
+    fi
+    _launcher_task_id="${SESSION_TASK_ID:-${LEARN_UK_LAUNCHER_TASK_ID:-5512-pr-j2-sessionstart}}"
+    _launcher_instance_id="${SESSION_INSTANCE_ID:-claude-$$}"
+    claim_session_supervisor_env         "$_selected_stream"         "claude"         "claude-code"         "$_launcher_task_id"         "$_launcher_instance_id"         "$PROJECT_DIR"         "start-claude.sh"         "$_selected_epic"
+    unset _launcher_task_id _launcher_instance_id _selected_stream
+fi
+unset _selected_epic
 
 echo "Launching Claude Code (native install)..."
 exec "$CLAUDE_BIN" --chrome --permission-mode bypassPermissions "${_forward_args[@]}"

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -265,16 +265,32 @@ if command -v handoff_epic_from_argv >/dev/null 2>&1; then
 fi
 
 # Claim/resume the stream lease through the common supervisor when an epic is pinned.
+# Skip when a lease envelope is already exported (nested launchers / tests).
+# Soft-fail when LEARN_UKRAINIAN_CLAUDEX_MANAGED_LAUNCH=1 or CLAUDEX_TEST_CAPTURE is set
+# (start-claudex nested path); hard-fail for normal interactive epic launches.
 if [ -n "${_selected_epic:-}" ] && command -v claim_session_supervisor_env >/dev/null 2>&1; then
-    _selected_stream="$(stream_id_for_epic "$_selected_epic")"
-    if [ -z "$_selected_stream" ]; then
-        echo "Error: cannot resolve stream id for epic '${_selected_epic}'." >&2
-        exit 1
+    if [ -n "${SESSION_STREAM_ID:-}" ] && [ -n "${SESSION_STREAM_SESSION_ID:-}" ] && [ -n "${SESSION_STREAM_LEASE_ID:-}" ]; then
+        echo "Session supervisor: using pre-exported lease ${SESSION_STREAM_ID} (${SESSION_STREAM_SESSION_ID})"
+    else
+        _selected_stream="$(stream_id_for_epic "$_selected_epic")"
+        if [ -z "$_selected_stream" ]; then
+            echo "Error: cannot resolve stream id for epic '${_selected_epic}'." >&2
+            exit 1
+        fi
+        _launcher_task_id="${SESSION_TASK_ID:-${LEARN_UK_LAUNCHER_TASK_ID:-5512-pr-j2-sessionstart}}"
+        _launcher_instance_id="${SESSION_INSTANCE_ID:-claude-$$}"
+        if claim_session_supervisor_env             "$_selected_stream"             "claude"             "claude-code"             "$_launcher_task_id"             "$_launcher_instance_id"             "$PROJECT_DIR"             "start-claude.sh"             "$_selected_epic"; then
+            :
+        else
+            if [ -n "${LEARN_UKRAINIAN_CLAUDEX_MANAGED_LAUNCH:-}" ] || [ -n "${CLAUDEX_TEST_CAPTURE:-}" ]; then
+                echo "Warning: session supervisor claim failed for ${_selected_stream} (managed/nested launch continues)." >&2
+            else
+                echo "Error: session supervisor claim failed for ${_selected_stream}." >&2
+                exit 1
+            fi
+        fi
+        unset _launcher_task_id _launcher_instance_id _selected_stream
     fi
-    _launcher_task_id="${SESSION_TASK_ID:-${LEARN_UK_LAUNCHER_TASK_ID:-5512-pr-j2-sessionstart}}"
-    _launcher_instance_id="${SESSION_INSTANCE_ID:-claude-$$}"
-    claim_session_supervisor_env         "$_selected_stream"         "claude"         "claude-code"         "$_launcher_task_id"         "$_launcher_instance_id"         "$PROJECT_DIR"         "start-claude.sh"         "$_selected_epic"
-    unset _launcher_task_id _launcher_instance_id _selected_stream
 fi
 unset _selected_epic
 

--- a/tests/test_start_claude_supervisor.py
+++ b/tests/test_start_claude_supervisor.py
@@ -1,0 +1,180 @@
+"""start-claude.sh PR-J2: supervisor claim on --epic (isolated tmp project)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LAUNCHER = _REPO_ROOT / "start-claude.sh"
+_GIT_REDIRECT = frozenset(
+    {
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_PREFIX",
+    }
+)
+
+
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _GIT_REDIRECT}
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_epic_harness_claims_supervisor_and_strips_flag(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    lib = project / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    venv_bin = project / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    home = tmp_path / "home"
+    bin_dir = home / ".local" / "bin"
+    bin_dir.mkdir(parents=True)
+    capture = tmp_path / "claude_capture.txt"
+    supervisor_capture = tmp_path / "supervisor_capture.txt"
+
+    _write_executable(project / "start-claude.sh", _LAUNCHER.read_text(encoding="utf-8"))
+    for name in ("handoff_identity.sh", "session_supervisor.sh"):
+        (lib / name).write_text(
+            (_REPO_ROOT / "scripts" / "lib" / name).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+    (lib / "deploy_extensions.sh").write_text(
+        "deploy_agent_extensions() { return 0; }\n",
+        encoding="utf-8",
+    )
+    (lib / "profile_resolver.sh").write_text(
+        "resolve_context_profile() {\n"
+        "  export LEARN_UKRAINIAN_PROFILE_ID=test\n"
+        "  export LEARN_UKRAINIAN_MAIN_MODEL_ID=m\n"
+        "  export LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS=1\n"
+        "  export LEARN_UKRAINIAN_COLD_START_BUDGET_TOKENS=1\n"
+        "  export LEARN_UKRAINIAN_AUTO_COMPACT_CAPACITY_TOKENS=1\n"
+        "  export LEARN_UKRAINIAN_RESOLUTION_REASON=test\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    _write_executable(
+        venv_bin / "python",
+        f"""#!/usr/bin/env bash
+if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_supervisor" && "${{3:-}}" == "open" ]]; then
+  printf '%s\\n' "$@" > "{supervisor_capture}"
+  cat <<'JSON'
+{{
+  "schema": "session-supervisor-bootstrap.v1",
+  "identity": {{
+    "role": "driver",
+    "stream_id": "epic:4707",
+    "lease": {{
+      "session_id": "sess-claude-j2",
+      "lease_id": "lease-claude-j2",
+      "generation": 1,
+      "fencing_token": 1,
+      "expires_at": "2026-07-21T12:00:00Z"
+    }},
+    "lease_credentials_exported": false
+  }},
+  "rollover": null,
+  "digest": {{}},
+  "dual_write": {{}},
+  "diagnostics": {{}}
+}}
+JSON
+  exit 0
+fi
+if [[ "${{1:-}}" == "-" ]]; then
+  shift
+  exec /usr/bin/env python3 - "$@"
+fi
+if [[ "${{1:-}}" == "-c" ]]; then
+  shift
+  exec /usr/bin/env python3 -c "$@"
+fi
+echo "unexpected python: $*" >&2
+exit 1
+""",
+    )
+
+    _write_executable(
+        bin_dir / "claude",
+        f"""#!/usr/bin/env bash
+if [[ "${{1:-}}" == "--version" ]]; then
+  echo "test-claude"
+  exit 0
+fi
+{{
+  printf 'epic=%s\\n' "${{SESSION_EPIC-unset}}"
+  printf 'stream=%s\\n' "${{SESSION_STREAM_ID-unset}}"
+  printf 'session=%s\\n' "${{SESSION_STREAM_SESSION_ID-unset}}"
+  printf 'lease=%s\\n' "${{SESSION_STREAM_LEASE_ID-unset}}"
+  printf 'handoff=%s\\n' "${{SESSION_HANDOFF_AGENT-unset}}"
+  printf 'argv='
+  printf '%s\\0' "$@"
+  printf '\\n'
+}} > "{capture}"
+""",
+    )
+
+    env = _clean_env()
+    for name in list(env):
+        if name.startswith("SESSION_") or name.startswith("LEARN_UKRAINIAN_"):
+            env.pop(name, None)
+    env["HOME"] = str(home)
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+    subprocess.run(["git", "init", "--quiet", str(project)], check=True, env=env)
+    subprocess.run(
+        ["git", "-C", str(project), "config", "user.email", "t@example.com"],
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        ["git", "-C", str(project), "config", "user.name", "t"],
+        check=True,
+        env=env,
+    )
+    (project / "README.md").write_text("t\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(project), "add", "."], check=True, env=env)
+    subprocess.run(
+        ["git", "-C", str(project), "commit", "--quiet", "-m", "init"],
+        check=True,
+        env=env,
+    )
+    subprocess.run(["git", "-C", str(project), "branch", "-M", "main"], check=True, env=env)
+
+    result = subprocess.run(
+        [str(project / "start-claude.sh"), "--epic", "harness"],
+        cwd=project,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert supervisor_capture.exists(), result.stderr + result.stdout
+    sup = supervisor_capture.read_text(encoding="utf-8")
+    assert "scripts.session_supervisor" in sup
+    assert "open" in sup
+    assert "claude" in sup
+    assert "claude-code" in sup
+    assert "epic:4707" in sup
+
+    raw = capture.read_text(encoding="utf-8")
+    assert "epic=harness" in raw
+    assert "stream=epic:4707" in raw
+    assert "session=sess-claude-j2" in raw
+    assert "lease=lease-claude-j2" in raw
+    assert "handoff=claude-infra" in raw
+    assert "--epic" not in raw.split("argv=", 1)[-1]


### PR DESCRIPTION
## Summary
Sol **PR-J2**: `./start-claude.sh --epic <name>` claims/resumes the stream lease via the common session supervisor (same contract as Grok/Kimi J1) before SessionStart binds the native Claude session id.

## Tests
- `tests/test_start_claude_supervisor.py` (isolated tmp project)

Parent: #5512 / stream #4707