### PR TITLE
feat(fleet-comms): Kimi formal CF fail-closed + isolation inventory (#5556)

### DIFF
--- a/docs/runbooks/kimi-formal-cf-isolation.md
+++ b/docs/runbooks/kimi-formal-cf-isolation.md
@@ -1,0 +1,37 @@
+# Kimi sealed formal CF isolation (#5556)
+
+## Status (2026-07-21)
+
+| Capability | Native Kimi Code CLI | Formal CF sealed path |
+| --- | --- | --- |
+| Project instructions suppress | **Unproven** — no documented equivalent of Codex `--sandbox` / Claude disable-project-instructions for repo `AGENTS.md` / Claude-style project prompts | Fail-closed |
+| Ambient MCP suppress | **Unproven** for sealed review transport | Fail-closed |
+| Hooks / nested reviewers | **Unproven** | Fail-closed |
+| Sealed snapshot cwd only | Not wired through `prepare_isolated_review_launch` for engine `kimi` | Absent → refuse |
+| `review-pr --reviewer kimi` | **Not implemented** (reviewers: auto\|codex\|glm\|claude only) | Use substitute seats |
+| Registry `formal_review_eligible` | `false` in `scripts/config/fleet_communications.yaml` | Correct until proof |
+
+## Live lane (non-formal)
+
+- `delegate.py --agent kimi` (default `k2.7-coding`; K3 via model override)
+- `ai_agent_bridge ask-kimi` / `process-kimi`
+- `./start-kimi.sh --epic …` (supervisor + canary mint)
+- `./start-kimicc.sh` (Claude UI → Kimi API route)
+
+## Substitute formal CF
+
+```bash
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer glm   # local
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer codex
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer claude
+```
+
+## Flip criteria (do not skip)
+
+1. Isolation capability matrix with proven CLI flags or sandbox profile.
+2. `prepare_isolated_review_launch` positive path + ambient-instruction negative test.
+3. `review-pr --reviewer kimi` or sealed transport registration.
+4. Real smoke formal CF on a PR.
+5. Then flip `formal_review_eligible: true`.
+
+Parent: #5556 · stream #4707 · product #5512.

--- a/scripts/review/isolation.py
+++ b/scripts/review/isolation.py
@@ -3135,6 +3135,12 @@ def prepare_isolated_review_launch(
     :func:`apply_review_isolation_to_invocation` which delegates here).
     """
     engine_key = normalize_engine_name(engine)
+    if engine_key == "kimi":
+        raise ReviewIsolationError(
+            "kimi_isolated_review_unsupported: sealed formal CF isolation is not proven "
+            "for native Kimi Code (project instructions / MCP / hooks / nested reviewers). "
+            "Use review-pr --reviewer claude|glm|codex. See #5556 / docs/runbooks/kimi-formal-cf-isolation.md."
+        )
     if engine_key == "agy":
         raise ReviewIsolationError(
             "agy_isolated_review_unsupported: native project-instruction, MCP, "

--- a/tests/test_kimi_sealed_review_refuse.py
+++ b/tests/test_kimi_sealed_review_refuse.py
@@ -1,0 +1,29 @@
+"""Kimi sealed formal review is fail-closed until isolation is proven (#5556)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.review.isolation import ReviewIsolationError, prepare_isolated_review_launch
+
+
+def test_kimi_endpoint_not_formal_review_eligible() -> None:
+    from scripts.fleet_comms.endpoints import load_endpoint_registry
+
+    registry = load_endpoint_registry()
+    endpoint, _ = registry.resolve("kimi")
+    assert endpoint.formal_review_eligible is False
+
+
+def test_kimi_isolated_review_refuses_explicitly(tmp_path: Path) -> None:
+    with pytest.raises(ReviewIsolationError, match="kimi_isolated_review_unsupported"):
+        prepare_isolated_review_launch(
+            engine="kimi",
+            argv=["kimi", "-p", "review"],
+            snapshot_root=tmp_path / "snap",
+            reject_root=tmp_path / "reject",
+            write_root=tmp_path / "write",
+            exec_root=tmp_path / "exec",
+        )


### PR DESCRIPTION
## Summary
P2 formal CF ladder for **Kimi** (#5556):
- Inventory runbook: residual isolation gaps
- `prepare_isolated_review_launch` fails closed for engine `kimi`
- Registry stays `formal_review_eligible: false` (no silent enablement)

## Tests
- `tests/test_kimi_sealed_review_refuse.py`

Parent: #5556 / #5512 / #4707