### PR TITLE
feat(fleet-comms): PR-K session-streams Monitor API surfaces

### DIFF
--- a/docs/runbooks/session-streams-monitor-api.md
+++ b/docs/runbooks/session-streams-monitor-api.md
@@ -1,0 +1,16 @@
+# Session streams Monitor API (Sol PR-K)
+
+Read-only Monitor surfaces for epic session streams. **No silent cutover.**
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/session-streams/v1/health` | DB presence / repo root |
+| GET | `/api/session-streams/v1/status/{stream_id}` | Lease/handoff diagnosis (`epic:N`) |
+| GET | `/api/session-streams/v1/digest/{stream_id}?limit=20` | Pinned + recent entries |
+| GET | `/api/session-streams/v1/dual-write-status` | Handoff file inventory existence |
+| GET | `/api/session-streams/v1/drift?dry_run=true` | Projection receipts snapshot (default) |
+| GET | `/api/session-streams/v1/plane-continuity` | Bundle board (streams + dual-write + plane pointer) |
+
+Message plane status remains `/api/comms/v1/plane-status` (default off).
+
+Parent: #5512 · stream #4707.

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -85,6 +85,7 @@ from .route_contracts import router as contracts_router
 from .rules_router import router as rules_router
 from .runtime_router import router as runtime_router
 from .session_router import router as session_router
+from .session_streams_router import router as session_streams_router
 from .site_router import router as site_router
 from .state_helpers import cache_get, cache_invalidate, cache_set
 from .state_router import router as state_router
@@ -146,6 +147,7 @@ app.include_router(agent_router, prefix="/api/agent", tags=["agent"])
 app.include_router(artifacts_router, prefix="/api/artifacts", tags=["artifacts"])
 app.include_router(blue_router, prefix="/api/blue")
 app.include_router(comms_router, prefix="/api/comms")
+app.include_router(session_streams_router, prefix="/api/session-streams", tags=["session-streams"])
 app.include_router(coordination_router, prefix="/api/coordination")
 app.include_router(consultation_router, prefix="/api/consultation")
 app.include_router(cost_router, prefix="/api/cost")

--- a/scripts/api/session_streams_router.py
+++ b/scripts/api/session_streams_router.py
@@ -32,8 +32,14 @@ def _repo_root() -> Path:
     return primary_checkout_root(Path(PROJECT_ROOT))
 
 
+def _db_path() -> Path:
+    return _repo_root() / ".agent" / "session-streams" / "v1" / "session-streams.sqlite3"
+
+
 def _store() -> SessionStreamStore:
-    db_path = _repo_root() / ".agent" / "session-streams" / "v1" / "session-streams.sqlite3"
+    db_path = _db_path()
+    if not db_path.is_file():
+        raise FileNotFoundError(f"session-stream database does not exist: {db_path}")
     return SessionStreamStore(SessionStreamDatabase(db_path))
 
 
@@ -41,7 +47,7 @@ def _store() -> SessionStreamStore:
 def session_streams_health() -> dict[str, Any]:
     """Liveness for the session-streams monitor surface (no cutover)."""
     root = _repo_root()
-    db_path = root / ".agent" / "session-streams" / "v1" / "session-streams.sqlite3"
+    db_path = _db_path()
     return {
         "ok": True,
         "repo_root": str(root),
@@ -58,7 +64,7 @@ def session_stream_status(stream_id: str) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail="stream_id must look like epic:N")
     try:
         status = diagnose_handoff(_store(), stream_id)
-    except NotFoundError as exc:
+    except (NotFoundError, FileNotFoundError) as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive API boundary
         raise HTTPException(status_code=500, detail=f"status_failed:{exc}") from exc
@@ -75,7 +81,7 @@ def session_stream_digest(
         raise HTTPException(status_code=400, detail="stream_id must look like epic:N")
     try:
         digest = _store().load_digest(stream_id, limit=limit)
-    except NotFoundError as exc:
+    except (NotFoundError, FileNotFoundError) as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover
         raise HTTPException(status_code=500, detail=f"digest_failed:{exc}") from exc

--- a/scripts/api/session_streams_router.py
+++ b/scripts/api/session_streams_router.py
@@ -1,0 +1,184 @@
+"""Sol PR-K: read-only Monitor surfaces for session streams + dual-write drift.
+
+Exposes stream digest/status, dual-write inventory, and projection drift without
+any cutover mutation. Operator cutovers remain explicit CLI/events.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase
+from agents_extensions.shared.session_streams.dual_write import list_handoff_candidates
+from agents_extensions.shared.session_streams.handoff import diagnose_handoff
+from agents_extensions.shared.session_streams.model import entry_as_dict
+from agents_extensions.shared.session_streams.projection import (
+    detect_projection_drift,
+    list_projection_receipts,
+)
+from agents_extensions.shared.session_streams.store import NotFoundError, SessionStreamStore
+from scripts.orchestration.reap_worktrees import primary_checkout_root
+
+from .config import PROJECT_ROOT
+
+router = APIRouter(tags=["session-streams"])
+
+
+def _repo_root() -> Path:
+    """Prefer the primary checkout that owns shared .agent/ state."""
+    return primary_checkout_root(Path(PROJECT_ROOT))
+
+
+def _store() -> SessionStreamStore:
+    db_path = _repo_root() / ".agent" / "session-streams" / "v1" / "session-streams.sqlite3"
+    return SessionStreamStore(SessionStreamDatabase(db_path))
+
+
+@router.get("/v1/health")
+def session_streams_health() -> dict[str, Any]:
+    """Liveness for the session-streams monitor surface (no cutover)."""
+    root = _repo_root()
+    db_path = root / ".agent" / "session-streams" / "v1" / "session-streams.sqlite3"
+    return {
+        "ok": True,
+        "repo_root": str(root),
+        "db_exists": db_path.is_file(),
+        "db_path": str(db_path),
+        "cutover": "operator-gated",
+    }
+
+
+@router.get("/v1/status/{stream_id:path}")
+def session_stream_status(stream_id: str) -> dict[str, Any]:
+    """Handoff/lease diagnosis for one stream (read-only; no claim)."""
+    if not stream_id.startswith("epic:"):
+        raise HTTPException(status_code=400, detail="stream_id must look like epic:N")
+    try:
+        status = diagnose_handoff(_store(), stream_id)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive API boundary
+        raise HTTPException(status_code=500, detail=f"status_failed:{exc}") from exc
+    return status.as_dict()
+
+
+@router.get("/v1/digest/{stream_id:path}")
+def session_stream_digest(
+    stream_id: str,
+    limit: int = Query(default=20, ge=0, le=500),
+) -> dict[str, Any]:
+    """Pinned entries plus last N non-pinned entries (bounded)."""
+    if not stream_id.startswith("epic:"):
+        raise HTTPException(status_code=400, detail="stream_id must look like epic:N")
+    try:
+        digest = _store().load_digest(stream_id, limit=limit)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=500, detail=f"digest_failed:{exc}") from exc
+    return {
+        "stream_id": stream_id,
+        "limit": limit,
+        "pinned": [entry_as_dict(e) for e in digest.pinned],
+        "recent": [entry_as_dict(e) for e in digest.recent],
+        "pinned_count": len(digest.pinned),
+        "recent_count": len(digest.recent),
+    }
+
+
+@router.get("/v1/dual-write-status")
+def dual_write_status() -> dict[str, Any]:
+    """Inventory-derived handoff dual-write paths and file existence (no cutover)."""
+    root = _repo_root()
+    candidates = list_handoff_candidates(root)
+    rows = [
+        {
+            "stream_id": c.stream_id,
+            "stream_name": c.stream_name,
+            "title": c.title,
+            "path": str(c.path.relative_to(root)) if c.path.is_relative_to(root) else str(c.path),
+            "exists": c.exists,
+        }
+        for c in candidates
+    ]
+    missing = sum(1 for r in rows if not r["exists"])
+    return {
+        "repo_root": str(root),
+        "total": len(rows),
+        "missing_files": missing,
+        "candidates": rows,
+        "cutover": "operator-gated",
+    }
+
+
+@router.get("/v1/drift")
+def projection_drift(
+    stream_id: str | None = Query(default=None, description="Optional epic:N filter"),
+    dry_run: bool = Query(
+        default=True,
+        description="When true, classify only without writing new receipts when possible",
+    ),
+) -> dict[str, Any]:
+    """Projection drift surface for dual-write (PR-K).
+
+    Default dry_run=true returns the latest receipt snapshot + dual-write
+    missing-file count without forcing a full project rewrite. Set dry_run=false
+    to run detect_projection_drift (records receipts; still no stream cutover).
+    """
+    root = _repo_root()
+    store = _store()
+    if dry_run:
+        receipts = list_projection_receipts(store, stream_id=stream_id)
+        dual = dual_write_status()
+        return {
+            "mode": "receipts_snapshot",
+            "stream_id": stream_id,
+            "receipt_count": len(receipts),
+            "receipts": receipts[-50:],  # bounded
+            "dual_write_missing_files": dual["missing_files"],
+            "cutover": "operator-gated",
+        }
+
+    stream_ids = (stream_id,) if stream_id else None
+    try:
+        batch = detect_projection_drift(store, root, stream_ids=stream_ids)
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=500, detail=f"drift_failed:{exc}") from exc
+    # ProjectionBatchResult may be a dataclass — best-effort serialization
+    if hasattr(batch, "as_dict"):
+        payload = batch.as_dict()
+    elif hasattr(batch, "__dict__"):
+        payload = dict(batch.__dict__)
+    else:
+        payload = {"result": str(batch)}
+    return {
+        "mode": "detect_projection_drift",
+        "stream_id": stream_id,
+        "batch": payload,
+        "cutover": "operator-gated",
+    }
+
+
+@router.get("/v1/plane-continuity")
+def plane_continuity_bundle() -> dict[str, Any]:
+    """One-shot continuity board: health + dual-write + optional plane-status pointer.
+
+    Does not mutate streams or flip message-plane defaults.
+    """
+    health = session_streams_health()
+    dual = dual_write_status()
+    return {
+        "session_streams": health,
+        "dual_write": {
+            "total": dual["total"],
+            "missing_files": dual["missing_files"],
+        },
+        "message_plane": {
+            "status_path": "/api/comms/v1/plane-status",
+            "default_cutover": "off — operator-gated",
+        },
+        "cutover": "operator-gated",
+    }

--- a/tests/test_session_streams_api.py
+++ b/tests/test_session_streams_api.py
@@ -1,0 +1,54 @@
+"""PR-K Monitor surfaces for session streams (read-only)."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from scripts.api.session_streams_router import router
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/session-streams")
+    return TestClient(app)
+
+
+def test_session_streams_health_and_dual_write() -> None:
+    client = _client()
+    h = client.get("/api/session-streams/v1/health")
+    assert h.status_code == 200
+    body = h.json()
+    assert body["ok"] is True
+    assert "db_exists" in body
+
+    d = client.get("/api/session-streams/v1/dual-write-status")
+    assert d.status_code == 200
+    dual = d.json()
+    assert "candidates" in dual
+    assert dual["total"] >= 0
+
+    c = client.get("/api/session-streams/v1/plane-continuity")
+    assert c.status_code == 200
+    assert c.json()["cutover"] == "operator-gated"
+
+
+def test_session_stream_status_and_digest_for_harness() -> None:
+    client = _client()
+    s = client.get("/api/session-streams/v1/status/epic:4707")
+    assert s.status_code in {200, 404}
+    if s.status_code == 200:
+        assert s.json()["stream_id"] == "epic:4707"
+
+    dig = client.get("/api/session-streams/v1/digest/epic:4707", params={"limit": 5})
+    assert dig.status_code in {200, 404}
+    if dig.status_code == 200:
+        assert dig.json()["limit"] == 5
+        assert "pinned" in dig.json()
+        assert "recent" in dig.json()
+
+
+def test_session_stream_status_rejects_bad_id() -> None:
+    client = _client()
+    r = client.get("/api/session-streams/v1/status/not-an-epic")
+    assert r.status_code == 400


### PR DESCRIPTION
## Summary
Sol **PR-K** (first slice): read-only Monitor API for session streams continuity.

### Endpoints
- `GET /api/session-streams/v1/health`
- `GET /api/session-streams/v1/status/{stream_id}`
- `GET /api/session-streams/v1/digest/{stream_id}`
- `GET /api/session-streams/v1/dual-write-status`
- `GET /api/session-streams/v1/drift`
- `GET /api/session-streams/v1/plane-continuity`

No message-plane cutover.

Parent: #5512 / #4707