### PR TITLE
feat(fleet-comms): Sol PR-M efficiency metrics + backlog/dead-letter surfaces

### DIFF
--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -43,6 +43,11 @@ except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
 from pydantic import BaseModel
 
+from scripts.fleet_comms.efficiency_metrics import (
+    collect_dead_letters,
+    collect_delivery_backlog,
+    collect_efficiency_metrics,
+)
 from scripts.fleet_comms.message_plane import read_plane_status
 from scripts.fleet_comms.migrations import apply_migrations
 
@@ -1949,3 +1954,40 @@ def comms_inbox(
         "truncated": truncated,
         "limit": limit,
     }
+
+
+@router.get("/v1/backlog")
+async def comms_v1_backlog(
+    limit: int = Query(100, ge=1, le=500),
+    exclude_retired: bool = Query(True),
+) -> dict:
+    """Pending delivery backlog (no message content). Sol PR-M."""
+    if not MESSAGE_DB.exists():
+        return {"total": 0, "by_agent": {}, "by_status": {}, "rows": [], "db_missing": True}
+    payload = collect_delivery_backlog(
+        MESSAGE_DB, limit=limit, exclude_retired=exclude_retired
+    )
+    payload["db_path"] = str(MESSAGE_DB)
+    payload["content_included"] = False
+    return payload
+
+
+@router.get("/v1/dead-letters")
+async def comms_v1_dead_letters(limit: int = Query(100, ge=1, le=500)) -> dict:
+    """Dead-letter inventory (metadata only). Sol PR-M."""
+    if not MESSAGE_DB.exists():
+        return {"total": 0, "by_reason": {}, "rows": [], "db_missing": True}
+    payload = collect_dead_letters(MESSAGE_DB, limit=limit)
+    payload["db_path"] = str(MESSAGE_DB)
+    payload["content_included"] = False
+    return payload
+
+
+@router.get("/v1/metrics")
+async def comms_v1_metrics() -> dict:
+    """Efficiency metrics from durable timestamps (no content). Sol PR-M."""
+    if not MESSAGE_DB.exists():
+        return {"content_included": False, "db_missing": True}
+    payload = collect_efficiency_metrics(MESSAGE_DB)
+    payload["db_path"] = str(MESSAGE_DB)
+    return payload

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -6,21 +6,33 @@ Usage::
     .venv/bin/python -m scripts.fleet_comms formal-job get <review_id>
     .venv/bin/python -m scripts.fleet_comms formal-job accept \\
         --pr 5571 --verdict APPROVED --model M --family F --harness H
+    .venv/bin/python -m scripts.fleet_comms metrics
+    .venv/bin/python -m scripts.fleet_comms backlog
+    .venv/bin/python -m scripts.fleet_comms dead-letters
 
 ``formal-job accept`` is the post-``review-pr`` glue (create/reuse job + sealed
 verdict accept). Optional ``--publish`` posts GitHub comment/status via PR-G.
 Does not cut over ``review-pr`` itself.
+
+``metrics`` / ``backlog`` / ``dead-letters`` are Sol PR-M efficiency surfaces
+(metadata only; never message content).
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
 import sys
 from pathlib import Path
 from typing import Any
 
+from scripts.fleet_comms.efficiency_metrics import (
+    collect_dead_letters,
+    collect_delivery_backlog,
+    collect_efficiency_metrics,
+)
 from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
 from scripts.fleet_comms.review_publication import DEFAULT_GATE_KIND
 
@@ -50,6 +62,83 @@ def cmd_plane_status(args: argparse.Namespace) -> int:
         recent_limit=args.recent_limit,
     )
     sys.stdout.write(_json_dump(status))
+    return EXIT_OK
+
+
+def _default_message_db() -> Path:
+    env = os.environ.get("AB_DB_PATH")
+    if env:
+        return Path(env).expanduser()
+    # Prefer cwd-relative broker path (matches Monitor API MESSAGE_DB default).
+    return Path(".mcp/servers/message-broker/messages.db")
+
+
+def _resolve_message_db(args: argparse.Namespace) -> Path:
+    if getattr(args, "db", None):
+        return Path(args.db).expanduser()
+    return _default_message_db()
+
+
+def cmd_metrics(args: argparse.Namespace) -> int:
+    """Efficiency metrics from durable timestamps (no content)."""
+    db = _resolve_message_db(args)
+    if not db.is_file():
+        sys.stdout.write(_json_dump({"content_included": False, "db_missing": True, "db_path": str(db)}))
+        return EXIT_OK
+    payload = collect_efficiency_metrics(db)
+    payload["db_path"] = str(db)
+    sys.stdout.write(_json_dump(payload))
+    return EXIT_OK
+
+
+def cmd_backlog(args: argparse.Namespace) -> int:
+    """Pending delivery backlog excluding retired endpoints by default."""
+    db = _resolve_message_db(args)
+    if not db.is_file():
+        sys.stdout.write(
+            _json_dump(
+                {
+                    "total": 0,
+                    "by_agent": {},
+                    "by_status": {},
+                    "rows": [],
+                    "db_missing": True,
+                    "db_path": str(db),
+                }
+            )
+        )
+        return EXIT_OK
+    payload = collect_delivery_backlog(
+        db,
+        limit=args.limit,
+        exclude_retired=not args.include_retired,
+    )
+    payload["db_path"] = str(db)
+    payload["content_included"] = False
+    sys.stdout.write(_json_dump(payload))
+    return EXIT_OK
+
+
+def cmd_dead_letters(args: argparse.Namespace) -> int:
+    """Dead-letter inventory (metadata only)."""
+    db = _resolve_message_db(args)
+    if not db.is_file():
+        sys.stdout.write(
+            _json_dump(
+                {
+                    "total": 0,
+                    "by_reason": {},
+                    "rows": [],
+                    "db_missing": True,
+                    "db_path": str(db),
+                }
+            )
+        )
+        return EXIT_OK
+    payload = collect_dead_letters(db, limit=args.limit)
+    payload["db_path"] = str(db)
+    payload["content_included"] = False
+    sys.stdout.write(_json_dump(payload))
     return EXIT_OK
 
 
@@ -189,7 +278,8 @@ def build_parser() -> argparse.ArgumentParser:
         prog="python -m scripts.fleet_comms",
         description=(
             "Fleet-comms CLI: plane-status, formal-job get (read-only), "
-            "formal-job accept (writer + optional GitHub publish)."
+            "formal-job accept (writer + optional GitHub publish), "
+            "metrics/backlog/dead-letters (Sol PR-M)."
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
@@ -303,6 +393,56 @@ def build_parser() -> argparse.ArgumentParser:
         help="Plan publication without mutating GitHub (still accepts sealed verdict)",
     )
     formal_accept.set_defaults(func=cmd_formal_job_accept)
+
+    metrics = sub.add_parser(
+        "metrics",
+        help="Efficiency metrics from durable timestamps (no content; Sol PR-M)",
+    )
+    metrics.add_argument(
+        "--db",
+        default=None,
+        help="Broker SQLite path (default: AB_DB_PATH or .mcp/servers/message-broker/messages.db)",
+    )
+    metrics.set_defaults(func=cmd_metrics)
+
+    backlog = sub.add_parser(
+        "backlog",
+        help="Pending/dispatched delivery backlog without bodies (Sol PR-M)",
+    )
+    backlog.add_argument(
+        "--db",
+        default=None,
+        help="Broker SQLite path (default: AB_DB_PATH or .mcp/servers/message-broker/messages.db)",
+    )
+    backlog.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Max backlog rows (default: 100)",
+    )
+    backlog.add_argument(
+        "--include-retired",
+        action="store_true",
+        help="Include retired endpoints such as gemini (default: exclude)",
+    )
+    backlog.set_defaults(func=cmd_backlog)
+
+    dead = sub.add_parser(
+        "dead-letters",
+        help="Dead-letter inventory metadata only (Sol PR-M)",
+    )
+    dead.add_argument(
+        "--db",
+        default=None,
+        help="Broker SQLite path (default: AB_DB_PATH or .mcp/servers/message-broker/messages.db)",
+    )
+    dead.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Max dead-letter rows (default: 100)",
+    )
+    dead.set_defaults(func=cmd_dead_letters)
 
     return parser
 

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -9,6 +9,7 @@ Usage::
     .venv/bin/python -m scripts.fleet_comms metrics
     .venv/bin/python -m scripts.fleet_comms backlog
     .venv/bin/python -m scripts.fleet_comms dead-letters
+    .venv/bin/python -m scripts.fleet_comms github-metrics
 
 ``formal-job accept`` is the post-``review-pr`` glue (create/reuse job + sealed
 verdict accept). Optional ``--publish`` posts GitHub comment/status via PR-G.
@@ -33,6 +34,7 @@ from scripts.fleet_comms.efficiency_metrics import (
     collect_delivery_backlog,
     collect_efficiency_metrics,
 )
+from scripts.fleet_comms.github_pr_metrics import collect_github_pr_metrics
 from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
 from scripts.fleet_comms.review_publication import DEFAULT_GATE_KIND
 
@@ -273,6 +275,18 @@ def cmd_formal_job_accept(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+
+def cmd_github_metrics(args: argparse.Namespace) -> int:
+    """PR open→merge latency from GitHub (metadata only; Sol PR-M residual)."""
+    payload = collect_github_pr_metrics(
+        repo=args.repo,
+        search=args.search,
+        limit=args.limit,
+    )
+    sys.stdout.write(_json_dump(payload))
+    return EXIT_OK if payload.get("ok", True) else EXIT_ERROR
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m scripts.fleet_comms",
@@ -443,6 +457,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Max dead-letter rows (default: 100)",
     )
     dead.set_defaults(func=cmd_dead_letters)
+
+
+    gh_metrics = sub.add_parser(
+        "github-metrics",
+        help="PR open→merge latency from GitHub (metadata only; Sol PR-M residual)",
+    )
+    gh_metrics.add_argument(
+        "--repo",
+        default="learn-ukrainian/learn-ukrainian.github.io",
+        help="owner/repo",
+    )
+    gh_metrics.add_argument(
+        "--search",
+        default="fleet-comms",
+        help="GitHub PR search filter (default: fleet-comms)",
+    )
+    gh_metrics.add_argument("--limit", type=int, default=30, help="Max merged PRs")
+    gh_metrics.set_defaults(func=cmd_github_metrics)
 
     return parser
 

--- a/scripts/fleet_comms/efficiency_metrics.py
+++ b/scripts/fleet_comms/efficiency_metrics.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
 
-def _connect(db_path: Path) -> sqlite3.Connection:
+@contextmanager
+def _connect(db_path: Path) -> Iterator[sqlite3.Connection]:
+    """Open a read path connection and always close it (sqlite3 `with` only commits)."""
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
-    return conn
+    try:
+        yield conn
+    finally:
+        conn.close()
 
 
 def _table_exists(conn: sqlite3.Connection, name: str) -> bool:

--- a/scripts/fleet_comms/efficiency_metrics.py
+++ b/scripts/fleet_comms/efficiency_metrics.py
@@ -179,19 +179,36 @@ def collect_efficiency_metrics(db_path: Path) -> dict[str, Any]:
                 metrics["requests"][str(r["state"])] = int(r["c"])
 
         if _table_exists(conn, "messages"):
-            for r in conn.execute(
-                "SELECT status, COUNT(*) AS c FROM messages GROUP BY status"
-            ):
-                metrics["messages_legacy"][str(r["status"])] = int(r["c"])
-            # ask/reply pairs by task_id count only
-            pair = conn.execute(
-                """
-                SELECT COUNT(DISTINCT task_id) AS tasks
-                FROM messages
-                WHERE task_id IS NOT NULL AND task_id != ''
-                """
-            ).fetchone()
-            metrics["messages_legacy"]["distinct_task_ids"] = int(pair["tasks"] or 0)
+            msg_cols = _column_names(conn, "messages")
+            # Legacy broker schema uses message_type (+ optional status lifecycle).
+            # Never assume status alone — schemas without it must still return metrics.
+            if "message_type" in msg_cols:
+                by_type: dict[str, int] = {}
+                for r in conn.execute(
+                    "SELECT message_type, COUNT(*) AS c FROM messages GROUP BY message_type"
+                ):
+                    by_type[str(r["message_type"] or "")] = int(r["c"])
+                metrics["messages_legacy"]["by_message_type"] = by_type
+            if "status" in msg_cols:
+                by_status: dict[str, int] = {}
+                for r in conn.execute(
+                    "SELECT status, COUNT(*) AS c FROM messages GROUP BY status"
+                ):
+                    # Truncate long free-form failure strings (not content, but keep compact).
+                    key = str(r["status"] or "")
+                    if len(key) > 80:
+                        key = key[:77] + "..."
+                    by_status[key] = int(r["c"])
+                metrics["messages_legacy"]["by_status"] = by_status
+            if "task_id" in msg_cols:
+                pair = conn.execute(
+                    """
+                    SELECT COUNT(DISTINCT task_id) AS tasks
+                    FROM messages
+                    WHERE task_id IS NOT NULL AND task_id != ''
+                    """
+                ).fetchone()
+                metrics["messages_legacy"]["distinct_task_ids"] = int(pair["tasks"] or 0)
 
         if _table_exists(conn, "dead_letters"):
             metrics["dead_letters"] = int(

--- a/scripts/fleet_comms/efficiency_metrics.py
+++ b/scripts/fleet_comms/efficiency_metrics.py
@@ -1,0 +1,213 @@
+"""Sol PR-M: efficiency metrics from durable broker timestamps (no content)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def _column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(r[1]) for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def collect_delivery_backlog(
+    db_path: Path,
+    *,
+    limit: int = 100,
+    exclude_retired: bool = True,
+) -> dict[str, Any]:
+    """Pending/dispatched delivery backlog without message bodies."""
+    retired = {"gemini"}
+    with _connect(db_path) as conn:
+        if not _table_exists(conn, "deliveries"):
+            return {"total": 0, "by_agent": {}, "by_status": {}, "rows": []}
+        cols = _column_names(conn, "deliveries")
+        # Schema varies across migrations; only SELECT columns that exist.
+        select_cols = [
+            c
+            for c in (
+                "delivery_id",
+                "message_id",
+                "to_agent",
+                "status",
+                "attempt_count",
+                "dispatched_at",
+                "created_at",
+            )
+            if c in cols
+        ]
+        if not select_cols:
+            return {"total": 0, "by_agent": {}, "by_status": {}, "rows": []}
+        order_col = (
+            "dispatched_at"
+            if "dispatched_at" in cols
+            else ("created_at" if "created_at" in cols else select_cols[0])
+        )
+        status_filter = "('pending', 'dispatched')"
+        rows = conn.execute(
+            f"""
+            SELECT {", ".join(select_cols)}
+            FROM deliveries
+            WHERE status IN {status_filter}
+            ORDER BY COALESCE({order_col}, '') DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+
+        by_agent: dict[str, int] = {}
+        by_status: dict[str, int] = {}
+        out_rows: list[dict[str, Any]] = []
+        for r in rows:
+            agent = str(r["to_agent"] if "to_agent" in cols else "") or ""
+            if exclude_retired and agent in retired:
+                continue
+            status = str(r["status"] if "status" in cols else "") or ""
+            by_agent[agent] = by_agent.get(agent, 0) + 1
+            by_status[status] = by_status.get(status, 0) + 1
+            out_rows.append(
+                {
+                    "delivery_id": r["delivery_id"] if "delivery_id" in cols else None,
+                    "message_id": r["message_id"] if "message_id" in cols else None,
+                    "to_agent": agent,
+                    "status": status,
+                    "attempt_count": r["attempt_count"] if "attempt_count" in cols else 0,
+                    "dispatched_at": r["dispatched_at"] if "dispatched_at" in cols else None,
+                }
+            )
+        return {
+            "total": len(out_rows),
+            "by_agent": by_agent,
+            "by_status": by_status,
+            "exclude_retired": sorted(retired) if exclude_retired else [],
+            "rows": out_rows,
+        }
+
+
+def collect_dead_letters(db_path: Path, *, limit: int = 100) -> dict[str, Any]:
+    """Dead-letter counts and metadata rows (no message content)."""
+    with _connect(db_path) as conn:
+        if not _table_exists(conn, "dead_letters"):
+            return {"total": 0, "by_reason": {}, "rows": []}
+        total = conn.execute("SELECT COUNT(*) AS c FROM dead_letters").fetchone()["c"]
+        by_reason_rows = conn.execute(
+            "SELECT reason, COUNT(*) AS c FROM dead_letters GROUP BY reason ORDER BY c DESC"
+        ).fetchall()
+        rows = conn.execute(
+            """
+            SELECT dead_letter_id, request_id, delivery_id, reason, successor,
+                   original_expires_at, created_at
+            FROM dead_letters
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return {
+            "total": int(total),
+            "by_reason": {str(r["reason"]): int(r["c"]) for r in by_reason_rows},
+            "rows": [dict(r) for r in rows],
+        }
+
+
+def collect_efficiency_metrics(db_path: Path) -> dict[str, Any]:
+    """Aggregate ask/reply efficiency from durable timestamps only."""
+    with _connect(db_path) as conn:
+        metrics: dict[str, Any] = {
+            "content_included": False,
+            "deliveries": {},
+            "requests": {},
+            "messages_legacy": {},
+            "dead_letters": 0,
+            "latency_seconds": {},
+        }
+
+        if _table_exists(conn, "deliveries"):
+            for r in conn.execute(
+                "SELECT status, COUNT(*) AS c FROM deliveries GROUP BY status"
+            ):
+                metrics["deliveries"][str(r["status"])] = int(r["c"])
+            # latency for delivered rows with both timestamps
+            lat = conn.execute(
+                """
+                SELECT
+                  COUNT(*) AS n,
+                  AVG(
+                    (julianday(delivered_at) - julianday(dispatched_at)) * 86400.0
+                  ) AS avg_s,
+                  MIN(
+                    (julianday(delivered_at) - julianday(dispatched_at)) * 86400.0
+                  ) AS min_s,
+                  MAX(
+                    (julianday(delivered_at) - julianday(dispatched_at)) * 86400.0
+                  ) AS max_s
+                FROM deliveries
+                WHERE status = 'delivered'
+                  AND delivered_at IS NOT NULL
+                  AND dispatched_at IS NOT NULL
+                  AND delivered_at != ''
+                  AND dispatched_at != ''
+                """
+            ).fetchone()
+            if lat and lat["n"]:
+                metrics["latency_seconds"]["delivery_dispatch_to_done"] = {
+                    "n": int(lat["n"]),
+                    "avg": round(float(lat["avg_s"] or 0.0), 3),
+                    "min": round(float(lat["min_s"] or 0.0), 3),
+                    "max": round(float(lat["max_s"] or 0.0), 3),
+                }
+
+        if _table_exists(conn, "requests"):
+            for r in conn.execute(
+                "SELECT state, COUNT(*) AS c FROM requests GROUP BY state"
+            ):
+                metrics["requests"][str(r["state"])] = int(r["c"])
+
+        if _table_exists(conn, "messages"):
+            for r in conn.execute(
+                "SELECT status, COUNT(*) AS c FROM messages GROUP BY status"
+            ):
+                metrics["messages_legacy"][str(r["status"])] = int(r["c"])
+            # ask/reply pairs by task_id count only
+            pair = conn.execute(
+                """
+                SELECT COUNT(DISTINCT task_id) AS tasks
+                FROM messages
+                WHERE task_id IS NOT NULL AND task_id != ''
+                """
+            ).fetchone()
+            metrics["messages_legacy"]["distinct_task_ids"] = int(pair["tasks"] or 0)
+
+        if _table_exists(conn, "dead_letters"):
+            metrics["dead_letters"] = int(
+                conn.execute("SELECT COUNT(*) AS c FROM dead_letters").fetchone()["c"]
+            )
+
+        # retired endpoint backlog should be zero for gemini inserts going forward
+        if _table_exists(conn, "deliveries"):
+            gemini_pending = conn.execute(
+                """
+                SELECT COUNT(*) AS c FROM deliveries
+                WHERE to_agent = 'gemini' AND status IN ('pending', 'dispatched')
+                """
+            ).fetchone()["c"]
+            metrics["retired_endpoint_pending"] = {
+                "gemini": int(gemini_pending),
+            }
+
+        return metrics

--- a/scripts/fleet_comms/github_pr_metrics.py
+++ b/scripts/fleet_comms/github_pr_metrics.py
@@ -1,0 +1,104 @@
+"""Sol PR-M residual: reconcile PR open→merge metrics from GitHub (no content).
+
+Uses ``gh api`` only. Never stores PR bodies or review text — numbers and
+timestamps only.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime
+from typing import Any
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def collect_github_pr_metrics(
+    *,
+    repo: str = "learn-ukrainian/learn-ukrainian.github.io",
+    search: str = "fleet-comms",
+    limit: int = 30,
+    gh_bin: str = "gh",
+) -> dict[str, Any]:
+    """Return open→merge latency stats for matching PRs (metadata only)."""
+    cmd = [
+        gh_bin,
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "merged",
+        "--search",
+        search,
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,createdAt,mergedAt,additions,deletions,changedFiles",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        return {
+            "content_included": False,
+            "ok": False,
+            "error": (proc.stderr or proc.stdout or "gh failed").strip()[:300],
+            "repo": repo,
+            "search": search,
+        }
+    try:
+        rows = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return {
+            "content_included": False,
+            "ok": False,
+            "error": f"json_decode: {exc}",
+            "repo": repo,
+            "search": search,
+        }
+
+    latencies: list[float] = []
+    samples: list[dict[str, Any]] = []
+    for row in rows:
+        created = _parse_ts(row.get("createdAt"))
+        merged = _parse_ts(row.get("mergedAt"))
+        if not created or not merged:
+            continue
+        seconds = (merged - created).total_seconds()
+        if seconds < 0:
+            continue
+        latencies.append(seconds)
+        samples.append(
+            {
+                "number": row.get("number"),
+                "open_to_merge_seconds": round(seconds, 1),
+                "changed_files": row.get("changedFiles"),
+                # sizes only — no title/body content
+            }
+        )
+
+    summary: dict[str, Any] = {
+        "content_included": False,
+        "ok": True,
+        "repo": repo,
+        "search": search,
+        "n": len(latencies),
+        "open_to_merge_seconds": {},
+        "samples": samples[: limit],
+    }
+    if latencies:
+        summary["open_to_merge_seconds"] = {
+            "n": len(latencies),
+            "avg": round(sum(latencies) / len(latencies), 1),
+            "min": round(min(latencies), 1),
+            "max": round(max(latencies), 1),
+        }
+    return summary

--- a/scripts/fleet_comms/github_pr_metrics.py
+++ b/scripts/fleet_comms/github_pr_metrics.py
@@ -1,7 +1,7 @@
 """Sol PR-M residual: reconcile PR open→merge metrics from GitHub (no content).
 
-Uses ``gh api`` only. Never stores PR bodies or review text — numbers and
-timestamps only.
+Uses ``gh pr list --json`` only. Never stores PR bodies or review text —
+numbers and timestamps only.
 """
 
 from __future__ import annotations

--- a/tests/test_efficiency_metrics.py
+++ b/tests/test_efficiency_metrics.py
@@ -1,0 +1,85 @@
+"""Sol PR-M efficiency metrics (no content leakage)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from scripts.fleet_comms.efficiency_metrics import (
+    collect_dead_letters,
+    collect_delivery_backlog,
+    collect_efficiency_metrics,
+)
+
+
+def _mini_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE deliveries (
+          delivery_id TEXT PRIMARY KEY,
+          message_id TEXT,
+          to_agent TEXT,
+          status TEXT,
+          attempt_count INTEGER DEFAULT 0,
+          dispatched_at TEXT,
+          delivered_at TEXT
+        );
+        CREATE TABLE dead_letters (
+          dead_letter_id TEXT PRIMARY KEY,
+          request_id TEXT,
+          delivery_id TEXT,
+          reason TEXT NOT NULL,
+          successor TEXT,
+          original_expires_at TEXT,
+          created_at TEXT NOT NULL
+        );
+        CREATE TABLE requests (
+          request_id TEXT PRIMARY KEY,
+          request_message_id TEXT,
+          requested_recipient TEXT,
+          resolved_recipient TEXT,
+          state TEXT,
+          expires_at TEXT,
+          completion_state TEXT,
+          created_at TEXT,
+          updated_at TEXT
+        );
+        INSERT INTO deliveries VALUES
+          ('d1','m1','claude','pending',0,NULL,NULL),
+          ('d2','m2','gemini','pending',1,NULL,NULL),
+          ('d3','m3','codex','delivered',1,'2026-07-21T10:00:00','2026-07-21T10:00:05');
+        INSERT INTO dead_letters VALUES
+          ('dl1',NULL,'d9','recipient_retired','agy',NULL,'2026-07-21T09:00:00');
+        INSERT INTO requests VALUES
+          ('r1','cm1','gemini','agy','dead_lettered','2026-07-21T12:00:00','unknown',
+           '2026-07-21T09:00:00','2026-07-21T09:00:00');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_backlog_excludes_retired_gemini(tmp_path: Path) -> None:
+    db = tmp_path / "m.db"
+    _mini_db(db)
+    payload = collect_delivery_backlog(db, exclude_retired=True)
+    assert payload["total"] == 1
+    assert payload["by_agent"] == {"claude": 1}
+    assert "content" not in str(payload).lower() or "content_included" not in payload
+
+
+def test_dead_letters_and_metrics(tmp_path: Path) -> None:
+    db = tmp_path / "m.db"
+    _mini_db(db)
+    dl = collect_dead_letters(db)
+    assert dl["total"] == 1
+    assert dl["by_reason"]["recipient_retired"] == 1
+    assert "body" not in dl["rows"][0]
+
+    m = collect_efficiency_metrics(db)
+    assert m["content_included"] is False
+    assert m["dead_letters"] == 1
+    assert m["deliveries"]["delivered"] == 1
+    assert m["retired_endpoint_pending"]["gemini"] == 1
+    assert m["latency_seconds"]["delivery_dispatch_to_done"]["n"] == 1

--- a/tests/test_efficiency_metrics.py
+++ b/tests/test_efficiency_metrics.py
@@ -12,7 +12,7 @@ from scripts.fleet_comms.efficiency_metrics import (
 )
 
 
-def _mini_db(path: Path) -> None:
+def _mini_db(path: Path, *, legacy_messages: bool = False) -> None:
     conn = sqlite3.connect(path)
     conn.executescript(
         """
@@ -56,6 +56,22 @@ def _mini_db(path: Path) -> None:
            '2026-07-21T09:00:00','2026-07-21T09:00:00');
         """
     )
+    if legacy_messages:
+        # Classic broker schema: message_type present, no status column.
+        conn.executescript(
+            """
+            CREATE TABLE messages (
+              id INTEGER PRIMARY KEY,
+              task_id TEXT,
+              message_type TEXT,
+              content TEXT
+            );
+            INSERT INTO messages VALUES
+              (1,'t1','ask','ignored body'),
+              (2,'t1','reply','ignored body'),
+              (3,'t2','review',NULL);
+            """
+        )
     conn.commit()
     conn.close()
 
@@ -83,3 +99,14 @@ def test_dead_letters_and_metrics(tmp_path: Path) -> None:
     assert m["deliveries"]["delivered"] == 1
     assert m["retired_endpoint_pending"]["gemini"] == 1
     assert m["latency_seconds"]["delivery_dispatch_to_done"]["n"] == 1
+
+
+def test_legacy_messages_without_status_column(tmp_path: Path) -> None:
+    """Codex CF F001: metrics must not require messages.status."""
+    db = tmp_path / "legacy.db"
+    _mini_db(db, legacy_messages=True)
+    m = collect_efficiency_metrics(db)
+    assert m["messages_legacy"]["by_message_type"]["ask"] == 1
+    assert m["messages_legacy"]["by_message_type"]["reply"] == 1
+    assert m["messages_legacy"]["distinct_task_ids"] == 2
+    assert "by_status" not in m["messages_legacy"]

--- a/tests/test_github_pr_metrics.py
+++ b/tests/test_github_pr_metrics.py
@@ -1,0 +1,36 @@
+"""GitHub PR metrics (mocked gh)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from scripts.fleet_comms.github_pr_metrics import collect_github_pr_metrics
+
+
+def test_github_metrics_no_content(monkeypatch=None) -> None:
+    payload = {
+        "number": 1,
+        "title": "SECRET TITLE SHOULD NOT APPEAR",
+        "createdAt": "2026-07-21T10:00:00Z",
+        "mergedAt": "2026-07-21T10:10:00Z",
+        "additions": 10,
+        "deletions": 2,
+        "changedFiles": 3,
+    }
+
+    class Proc:
+        returncode = 0
+        stdout = json.dumps([payload])
+        stderr = ""
+
+    with patch("scripts.fleet_comms.github_pr_metrics.subprocess.run", return_value=Proc()):
+        out = collect_github_pr_metrics(limit=5)
+    assert out["ok"] is True
+    assert out["content_included"] is False
+    assert out["n"] == 1
+    assert out["open_to_merge_seconds"]["avg"] == 600.0
+    sample = out["samples"][0]
+    assert "title" not in sample
+    assert sample["number"] == 1
+    assert "SECRET" not in json.dumps(out)


### PR DESCRIPTION
## Summary
Sol **PR-M** (metrics surfaces) for fleet-comms product epic **#5512** / stream **#4707**.

- `scripts/fleet_comms/efficiency_metrics.py` — backlog / dead-letters / efficiency collectors from durable SQLite timestamps only (no prompt/reply content)
- Monitor API: `GET /api/comms/v1/backlog`, `/v1/dead-letters`, `/v1/metrics`
- CLI: `.venv/bin/python -m scripts.fleet_comms {metrics,backlog,dead-letters}`
- Backlog excludes retired `gemini` by default; deliveries SELECT is PRAGMA column-aware (schemas without `created_at` still work)

## Acceptance (this slice)
| Sol M criterion | Status |
| --- | --- |
| No content in metrics | yes (`content_included: false`) |
| Backlog excludes retired endpoints | yes (gemini filtered) |
| Dead-letter counts match SQL | yes (COUNT + group by reason) |
| Efficiency report script exists | yes (CLI + module + API) |
| Ask/reply latency from durable timestamps | yes when both dispatch/done present |
| GitHub PR lifecycle reconcile | **follow-up** (not in this PR) |
| Old-writer locks / compatibility-read retirement | **follow-up** (depends on E/G/L cutovers) |

## Test plan
- [x] `pytest tests/test_efficiency_metrics.py`
- [x] ruff clean
- [x] CLI smoke against live broker DB (metrics returns delivery counts)
- [ ] CI green
- [ ] Cross-family formal CF