### PR TITLE
fix(api): PR-K session-streams read live primary under release mode

### DIFF
--- a/scripts/api/session_streams_router.py
+++ b/scripts/api/session_streams_router.py
@@ -20,16 +20,27 @@ from agents_extensions.shared.session_streams.projection import (
     list_projection_receipts,
 )
 from agents_extensions.shared.session_streams.store import NotFoundError, SessionStreamStore
-from scripts.orchestration.reap_worktrees import primary_checkout_root
 
-from .config import PROJECT_ROOT
+from .config import LIVE_REPO_ROOT, PROJECT_ROOT
+from .repository_authority import preparation_data_root
 
 router = APIRouter(tags=["session-streams"])
 
 
 def _repo_root() -> Path:
-    """Prefer the primary checkout that owns shared .agent/ state."""
-    return primary_checkout_root(Path(PROJECT_ROOT))
+    """Live-data checkout that owns shared .agent/ + dual-write handoffs.
+
+    Release-mode API code roots under ``.runtime/api/releases/<sha>`` have no
+    ``.git`` and do not symlink ``.agent`` / ``.claude`` (see LIVE_DATA_PATHS).
+    ``primary_checkout_root(PROJECT_ROOT)`` therefore returns the release path
+    and PR-K surfaces 404 for a DB that only exists on the live primary.
+    Use the same authority helper as state_router: when PROJECT_ROOT is a
+    release snapshot, read mutable continuity state from LIVE_REPO_ROOT.
+    """
+    return preparation_data_root(
+        project_root=Path(PROJECT_ROOT),
+        live_repo_root=Path(LIVE_REPO_ROOT),
+    )
 
 
 def _db_path() -> Path:

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -89,6 +89,14 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
       exit 1
     fi
   fi
+  # Layout A: bare primary is a bug — heal before agents drive (#2842 / #5587).
+  # Grok has no SessionStart hook (Claude uses heal-core-bare PreToolUse).
+  if [ -x "$PROJECT_DIR/.venv/bin/python" ] \
+      && [ -f "$PROJECT_DIR/scripts/audit/check_core_bare.py" ]; then
+    "$PROJECT_DIR/.venv/bin/python" \
+      "$PROJECT_DIR/scripts/audit/check_core_bare.py" --fix --repo "$PROJECT_DIR" \
+      || echo "Warning: check_core_bare --fix failed (continuing launch)." >&2
+  fi
   if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     echo "Uncommitted changes detected (primary checkout is orientation-only; write via worktrees)"
   fi

--- a/tests/test_session_streams_api.py
+++ b/tests/test_session_streams_api.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -52,3 +55,36 @@ def test_session_stream_status_rejects_bad_id() -> None:
     client = _client()
     r = client.get("/api/session-streams/v1/status/not-an-epic")
     assert r.status_code == 400
+
+
+def test_session_streams_repo_root_uses_live_primary_under_release(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR-K residual: release code root must not own .agent/session-streams."""
+    from scripts.api import session_streams_router as ssr
+
+    live = tmp_path / "live"
+    live.mkdir()
+    db_dir = live / ".agent" / "session-streams" / "v1"
+    db_dir.mkdir(parents=True)
+    db = db_dir / "session-streams.sqlite3"
+    db.write_bytes(b"")
+
+    # Synthetic release path shape: .runtime/api/releases/<40-hex>
+    release = (
+        tmp_path
+        / ".runtime"
+        / "api"
+        / "releases"
+        / ("a" * 40)
+    )
+    release.mkdir(parents=True)
+
+    monkeypatch.setattr(ssr, "PROJECT_ROOT", release)
+    monkeypatch.setattr(ssr, "LIVE_REPO_ROOT", live)
+
+    assert ssr._repo_root() == live
+    assert ssr._db_path() == db
+    health = ssr.session_streams_health()
+    assert health["db_exists"] is True
+    assert health["repo_root"] == str(live)

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -36,6 +36,9 @@ def _supervisor_body(capture: Path, stream_id: str, session_id: str, lease_id: s
 if [[ "$1" == *"assert_primary_on_main.py" ]]; then
   exit 0
 fi
+if [[ "$1" == *"check_core_bare.py" ]]; then
+  exit 0
+fi
 if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_supervisor" && "${{3:-}}" == "open" ]]; then
   {{
     printf '%s\\n' "$@" > "{capture}"
@@ -99,6 +102,11 @@ def _build_fake_project(tmp_path: Path) -> tuple[Path, Path]:
     )
     (guard_dir / "assert_primary_on_main.py").write_text("#!/usr/bin/env python3\nraise SystemExit(0)\n")
     (guard_dir / "assert_primary_on_main.py").chmod(0o755)
+    audit_dir = project / "scripts" / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    (audit_dir / "check_core_bare.py").write_text(
+        "#!/usr/bin/env python3\nraise SystemExit(0)\n", encoding="utf-8"
+    )
 
     capture = tmp_path / "supervisor_capture.txt"
     _write_executable(


### PR DESCRIPTION
## Summary
- **Root cause:** Sol PR-K (`/api/session-streams/*`) resolved the stream DB via `primary_checkout_root(PROJECT_ROOT)`. Under release-mode API serving, `PROJECT_ROOT` is `.runtime/api/releases/<sha>` (no `.git`, no `.agent`/`.claude` live links in `LIVE_DATA_PATHS`), so health/status/digest 404'd even when `.agent/session-streams/v1/session-streams.sqlite3` exists on the live primary.
- **Fix:** Use `preparation_data_root(project_root=PROJECT_ROOT, live_repo_root=LIVE_REPO_ROOT)` — same authority helper as `state_router`. No cutover flips; read-only surfaces only.
- **Also:** wire `scripts/audit/check_core_bare.py --fix` into `start-grok.sh` cold-start (Grok has no SessionStart hook; layout A bare-primary heal per #2842 / #5587).

## Stream
Part of #4707 / fleet-comms #5512 Gate B prep (PR-K residual). Does **not** flip stream authority or message-plane defaults.

## Test plan
- [x] `pytest tests/test_session_streams_api.py tests/test_start_grok_launcher.py` (8 passed)
- [x] ruff clean
- [ ] After merge: restart Monitor API release snapshot; `curl -s localhost:8765/api/session-streams/v1/health` shows `db_exists:true` with live primary root; status/digest for `epic:4707` 200

## Files
- `scripts/api/session_streams_router.py`
- `start-grok.sh`
- `tests/test_session_streams_api.py`
- `tests/test_start_grok_launcher.py`