### PR TITLE
fix(guards): #5404 gitignored primary writes + shell $VAR expansion

### DIFF
--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -738,9 +738,15 @@ _SHELL_ASSIGN_RE = re.compile(
 _SHELL_VAR_RE = re.compile(r"^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$")
 
 
-def parse_shell_assignments(command: str) -> dict[str, str]:
-    """Best-effort VAR=value map from a Bash command string (issue #5404)."""
+def parse_shell_assignments(command: str) -> tuple[dict[str, str], set[str]]:
+    """Best-effort VAR=value map from a Bash command string (issue #5404).
+
+    Returns ``(assignments, ambiguous_names)``. A name is ambiguous when it is
+    assigned more than one distinct value in the command — last-wins expansion
+    would disagree with bash ordering at the write site (Claude CF F001).
+    """
     out: dict[str, str] = {}
+    ambiguous: set[str] = set()
     for m in _SHELL_ASSIGN_RE.finditer(command or ""):
         name = m.group(1)
         if m.group(2) is not None:
@@ -749,16 +755,29 @@ def parse_shell_assignments(command: str) -> dict[str, str]:
             val = m.group(3)
         else:
             val = m.group(4) or ""
+        if name in out and out[name] != val:
+            ambiguous.add(name)
         out[name] = val
-    return out
+    return out, ambiguous
 
 
-def expand_shell_target(target: str, assignments: dict[str, str]) -> str:
-    """Expand a pure ``$VAR`` / ``${VAR}`` write target when assignment is known."""
+def expand_shell_target(
+    target: str,
+    assignments: dict[str, str],
+    *,
+    ambiguous: set[str] | None = None,
+) -> str:
+    """Expand a pure ``$VAR`` / ``${VAR}`` write target when assignment is known.
+
+    Ambiguous multi-assign names are left unexpanded so the caller blocks with
+    ``unresolved_shell_variable`` rather than allowing a reassignment bypass.
+    """
     m = _SHELL_VAR_RE.match((target or "").strip())
     if not m:
         return target
     name = m.group(1)
+    if ambiguous and name in ambiguous:
+        return target
     if assignments.get(name):
         return assignments[name]
     return target
@@ -845,12 +864,15 @@ def main() -> int:
 
     # #5404: expand $VAR write targets from same-command assignments so
     # gitignored lane-state is not mis-classified against the literal "$A".
-    assignments = parse_shell_assignments(command) if tool_name == "Bash" else {}
+    if tool_name == "Bash":
+        assignments, ambiguous = parse_shell_assignments(command)
+    else:
+        assignments, ambiguous = {}, set()
 
     try:
         decisions: list[tuple[str, object]] = []
         for raw in raw_targets:
-            expanded = expand_shell_target(raw, assignments)
+            expanded = expand_shell_target(raw, assignments, ambiguous=ambiguous)
             if is_unresolved_shell_var(expanded):
                 decisions.append(
                     (

--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import sys
 from pathlib import Path
@@ -726,6 +727,46 @@ def _block_git_mediated(summary: str, main_root: Path, reason: str) -> int:
 # decision
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# shell variable expansion for Bash write targets (issue #5404)
+# ---------------------------------------------------------------------------
+
+_SHELL_ASSIGN_RE = re.compile(
+    r"(?:^|[;\n&|]\s*|\(\s*)([A-Za-z_][A-Za-z0-9_]*)="
+    r"(?:'([^']*)'|\"([^\"]*)\"|([^\s;|&]+))"
+)
+_SHELL_VAR_RE = re.compile(r"^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$")
+
+
+def parse_shell_assignments(command: str) -> dict[str, str]:
+    """Best-effort VAR=value map from a Bash command string (issue #5404)."""
+    out: dict[str, str] = {}
+    for m in _SHELL_ASSIGN_RE.finditer(command or ""):
+        name = m.group(1)
+        if m.group(2) is not None:
+            val = m.group(2)
+        elif m.group(3) is not None:
+            val = m.group(3)
+        else:
+            val = m.group(4) or ""
+        out[name] = val
+    return out
+
+
+def expand_shell_target(target: str, assignments: dict[str, str]) -> str:
+    """Expand a pure ``$VAR`` / ``${VAR}`` write target when assignment is known."""
+    m = _SHELL_VAR_RE.match((target or "").strip())
+    if not m:
+        return target
+    name = m.group(1)
+    if assignments.get(name):
+        return assignments[name]
+    return target
+
+
+def is_unresolved_shell_var(target: str) -> bool:
+    return bool(_SHELL_VAR_RE.match((target or "").strip()))
+
 
 def _resolve(path_str: str, cwd: str) -> Path:
     """Resolve a possibly-relative target against the payload cwd."""
@@ -802,10 +843,39 @@ def main() -> int:
     if not raw_targets:
         return 0
 
+    # #5404: expand $VAR write targets from same-command assignments so
+    # gitignored lane-state is not mis-classified against the literal "$A".
+    assignments = parse_shell_assignments(command) if tool_name == "Bash" else {}
+
     try:
-        decisions = [
-            (raw, wc.evaluate_write(_resolve(raw, cwd), cwd=cwd)) for raw in raw_targets
-        ]
+        decisions: list[tuple[str, object]] = []
+        for raw in raw_targets:
+            expanded = expand_shell_target(raw, assignments)
+            if is_unresolved_shell_var(expanded):
+                decisions.append(
+                    (
+                        raw,
+                        type(
+                            "_UnresolvedVar",
+                            (),
+                            {
+                                "allowed": False,
+                                "reason": "unresolved_shell_variable",
+                                "message": (
+                                    "Shell variable write target is unresolved. "
+                                    "Expand it in the same command "
+                                    '(A=.claude/<epic>/file; echo x > "$A") '
+                                    "or use a literal gitignored path."
+                                ),
+                            },
+                        )(),
+                    )
+                )
+                continue
+            label = raw if expanded == raw else f"{raw}→{expanded}"
+            decisions.append(
+                (label, wc.evaluate_write(_resolve(expanded, cwd), cwd=cwd))
+            )
     except Exception:  # pragma: no cover - defensive fail-open
         return 0
 

--- a/scripts/guardrails/worktree_containment.py
+++ b/scripts/guardrails/worktree_containment.py
@@ -145,6 +145,20 @@ def canonicalize(path: Path | str) -> Path:
     return Path(path).expanduser().resolve()
 
 
+def absolute_path(path: Path | str, cwd: Path | str | None = None) -> Path:
+    """Absolute-ize ``path`` against ``cwd`` (default process cwd) then canonicalize.
+
+    Relative write targets from hooks/agents are always cwd-relative (issue
+    #5404). Classifying bare relative pathspecs against process cwd mis-labels
+    gitignored lane-state under a different working directory.
+    """
+    p = Path(path).expanduser()
+    if not p.is_absolute():
+        base = Path(cwd) if cwd is not None else Path.cwd()
+        p = Path(base).expanduser() / p
+    return canonicalize(p)
+
+
 class NotAGitRepositoryError(RuntimeError):
     """Raised by :func:`resolve_main_root` when ``start`` is not in a repo."""
 
@@ -254,7 +268,7 @@ def classify_repo_path(path: Path | str, cwd: Path | str | None = None) -> PathC
     the primary root from; the classification is about ``path`` itself. Returns
     one of :data:`PathClass`.
     """
-    target = canonicalize(path)
+    target = absolute_path(path, cwd=cwd)
     anchor = canonicalize(cwd) if cwd is not None else Path.cwd().resolve()
     main_root = _resolve_main_root_or_none(anchor)
     if main_root is None:
@@ -493,17 +507,18 @@ def evaluate_write(path: Path | str, cwd: Path | str | None = None) -> WriteDeci
         return WriteDecision(allowed=True, reason=path_class, path_class=path_class)
 
     # class == primary_checkout guarantees the target resolved under a real
-    # primary root; resolve it once and reuse for both plumbing calls.
-    anchor = canonicalize(cwd) if cwd is not None else canonicalize(path)
-    main_root = _resolve_main_root_or_none(anchor) or _resolve_main_root_or_none(canonicalize(path))
-    if is_tracked(path, main_root):
+    # primary root; resolve the write target once against cwd (#5404).
+    target = absolute_path(path, cwd=cwd)
+    anchor = canonicalize(cwd) if cwd is not None else target
+    main_root = _resolve_main_root_or_none(anchor) or _resolve_main_root_or_none(target)
+    if is_tracked(target, main_root):
         return WriteDecision(
             allowed=False,
             reason="tracked_primary_checkout",
             path_class=path_class,
             message=_WORKTREE_HINT,
         )
-    if is_ignored(path, main_root):
+    if is_ignored(target, main_root):
         return WriteDecision(
             allowed=True,
             reason="gitignored_local_state",

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -621,3 +621,20 @@ def test_bash_untracked_non_ignored_still_blocked(repo: Path):
     result = _run(repo, payload)
     assert result.returncode == 2, result.stderr
     assert "untracked_primary_checkout" in result.stderr
+
+
+def test_bash_shell_var_reassignment_not_expanded(repo: Path):
+    """#5404 CF F001: multi-assign $A must not expand to last (benign) value."""
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {
+            "command": (
+                "A=curriculum/tracked.md; echo x > $A; A=local_state/ok.log"
+            ),
+        },
+    }
+    result = _run(repo, payload)
+    # Must not allow (would dirty tracked file under bash's true binding).
+    assert result.returncode == 2, result.stderr
+    assert "unresolved_shell_variable" in result.stderr or "tracked_primary" in result.stderr

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -565,3 +565,59 @@ def test_git_checkout_branch_only_not_blocked_by_git_guard(repo: Path):
     result = _run(repo, payload)
     # No git-mediated path intent → this hook allows (other hooks may still fire).
     assert result.returncode == 0, result.stderr
+
+
+def test_bash_shell_var_to_gitignored_allowed(repo: Path):
+    """#5404: A=gitignored/path; echo x > $A must be allowed after expansion."""
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {
+            "command": "A=local_state/from_var.log; echo x > $A",
+        },
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 0, result.stderr
+
+
+def test_bash_unresolved_shell_var_blocked_with_distinct_reason(repo: Path):
+    """#5404: bare $A without assignment is not treated as a path under primary."""
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {"command": "echo x > $A"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 2, result.stderr
+    assert "unresolved_shell_variable" in result.stderr
+
+
+def test_bash_redirect_to_claude_epic_archive_from_subdir_allowed(repo: Path):
+    """#5404: cwd inside gitignored epic dir + relative archive path allowed."""
+    epic = repo / ".claude" / "atlas-epic"
+    epic.mkdir(parents=True, exist_ok=True)
+    (epic / "archive").mkdir(exist_ok=True)
+    # Ensure .claude is ignored like production (fixture may already ignore local_state only)
+    gitignore = repo / ".gitignore"
+    gi = gitignore.read_text(encoding="utf-8") if gitignore.is_file() else ""
+    if ".claude/" not in gi:
+        gitignore.write_text(gi.rstrip() + "\n.claude/\n", encoding="utf-8")
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(epic),
+        "tool_input": {"command": "echo x > archive/t.md"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 0, result.stderr
+
+
+def test_bash_untracked_non_ignored_still_blocked(repo: Path):
+    (repo / "docs").mkdir(exist_ok=True)
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {"command": "echo x > docs/brand-new-untracked.md"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 2, result.stderr
+    assert "untracked_primary_checkout" in result.stderr

--- a/tests/test_worktree_containment.py
+++ b/tests/test_worktree_containment.py
@@ -276,3 +276,14 @@ def test_module_is_robust_to_hostile_git_env(layout: Layout, monkeypatch):
         False,
         "tracked_primary_checkout",
     )
+
+
+def test_relative_gitignored_path_resolved_against_cwd(layout: Layout):
+    """#5404: relative write under a gitignored subdir cwd must be allowed."""
+    ignored_dir = layout.main / "local_state" / "nested"
+    ignored_dir.mkdir(parents=True, exist_ok=True)
+    # ensure local_state is gitignored in fixture (test_gitignored_local_state uses local_state/)
+    rel = "nested/out.log"
+    decision = wc.evaluate_write(rel, cwd=ignored_dir)
+    assert decision.allowed is True, decision
+    assert decision.reason == "gitignored_local_state"


### PR DESCRIPTION
## Summary
Fixes #5404 so fleet/harness diary dual-write and other gitignored lane state under the primary checkout are not false-blocked by the primary write guard.

### Root causes
1. **Relative paths + cwd**: `evaluate_write` / `classify_repo_path` canonicalized relative targets against process cwd, so `archive/t.md` with cwd `.claude/atlas-epic` could miss `git check-ignore` under the primary root.
2. **Shell variables**: Bash targets like `$A` were evaluated as literal paths → `untracked_primary_checkout` even when `A=.claude/...` was set in the same command.

### Fix
- `absolute_path(path, cwd)` and use it in classify/evaluate.
- Parse same-command `VAR=value` assignments; expand pure `$VAR` / `${VAR}` write targets before classification.
- Unresolved `$VAR` → distinct `unresolved_shell_variable` block reason.

### Tests
- Relative gitignored path against cwd
- `A=local_state/x; echo > $A` allowed
- bare `$A` blocked with distinct reason
- `.claude/…/archive` from subdir allowed
- untracked non-ignored still blocked

## Stream
#4707 fleet-comms / infra — unblocks dual-write diary ops without cutover GO.

Closes #5404.