### PR TITLE
fix(api): Cursor CodexBar burn tracks Total, not Auto

### DIFF
--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -175,7 +175,7 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
                 weekly_win = cand
                 best_dist = dist
 
-    # Absolute fallback
+    # Absolute fallback (Claude/Codex-shaped providers).
     if not primary_win:
         primary_win = usage.get("primary") or openai_db.get("primaryLimit")
     if not weekly_win:
@@ -191,11 +191,23 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
             return None
         return max(0.0, min(100.0, 100.0 - used))
 
-    # Named windows from the provider payload (Cursor: primary=allotment-A,
-    # secondary=allotment-B / plan included, tertiary=API / on-demand).
+    # Named windows from the provider payload.
+    # Cursor Pro+ CodexBar text labels (live-verified 2026-07-21):
+    #   primary   = Total  (account-level scarcity → burn/status)
+    #   secondary = Auto
+    #   tertiary  = API / on-demand
+    # All three share the billing-cycle window (~44640 min), not 5h+weekly.
     named_primary = usage.get("primary") if isinstance(usage.get("primary"), dict) else None
     named_secondary = usage.get("secondary") if isinstance(usage.get("secondary"), dict) else None
     named_tertiary = usage.get("tertiary") if isinstance(usage.get("tertiary"), dict) else None
+
+    cursor_window_labels: dict[str, str] | None = None
+    if lane == "cursor":
+        # Burn/status must track Total, not Auto. The generic absolute fallback
+        # wrongly promoted secondary→weekly and understated account pressure.
+        primary_win = named_primary or primary_win
+        weekly_win = named_primary or weekly_win
+        cursor_window_labels = {"primary": "Total", "secondary": "Auto", "tertiary": "API"}
 
     primary_used_pct = _used_pct(primary_win) if primary_win else _used_pct(named_primary)
     if primary_used_pct is None:
@@ -204,9 +216,12 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
     weekly_used_pct = _used_pct(weekly_win) if weekly_win else _used_pct(named_secondary)
     if weekly_used_pct is None:
         weekly_used_pct = _used_pct(named_secondary)
+    if lane == "cursor" and primary_used_pct is not None:
+        # Prefer Total even when a leftover weekly_win still points elsewhere.
+        weekly_used_pct = primary_used_pct
 
     secondary_used_pct = _used_pct(named_secondary)
-    if secondary_used_pct is None and weekly_used_pct is not None:
+    if secondary_used_pct is None and lane != "cursor" and weekly_used_pct is not None:
         secondary_used_pct = weekly_used_pct
 
     tertiary_used_pct = _used_pct(named_tertiary)
@@ -219,6 +234,8 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
     if not weekly_resets_at and named_secondary:
         weekly_resets_at = named_secondary.get("resetsAt")
     if not weekly_resets_at and named_primary:
+        weekly_resets_at = named_primary.get("resetsAt")
+    if lane == "cursor" and named_primary and named_primary.get("resetsAt"):
         weekly_resets_at = named_primary.get("resetsAt")
 
     monthly_cap_usd = None
@@ -257,6 +274,8 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
                 win_mins = 10080
                 if weekly_win and weekly_win.get("windowMinutes") is not None:
                     win_mins = int(weekly_win["windowMinutes"])
+                elif lane == "cursor" and named_primary and named_primary.get("windowMinutes") is not None:
+                    win_mins = int(named_primary["windowMinutes"])
 
                 window_duration_seconds = win_mins * 60
                 window_start_dt = resets_at_dt - timedelta(seconds=window_duration_seconds)
@@ -275,15 +294,24 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
             except Exception:
                 pass
 
-    def _window_block(win: dict[str, Any] | None, used: float | None) -> dict[str, Any]:
-        return {
+    def _window_block(
+        win: dict[str, Any] | None,
+        used: float | None,
+        *,
+        label: str | None = None,
+    ) -> dict[str, Any]:
+        block = {
             "used_pct": used,
             "remaining_pct": _remaining_pct(used),
             "resets_at": (win or {}).get("resetsAt") if isinstance(win, dict) else None,
             "window_minutes": (win or {}).get("windowMinutes") if isinstance(win, dict) else None,
             "reset_description": (win or {}).get("resetDescription") if isinstance(win, dict) else None,
         }
+        if label is not None:
+            block["label"] = label
+        return block
 
+    labels = cursor_window_labels or {}
     return {
         "lane": lane,
         "primary_used_pct": primary_used_pct,
@@ -292,13 +320,19 @@ def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, A
         "secondary_remaining_pct": _remaining_pct(secondary_used_pct),
         "tertiary_used_pct": tertiary_used_pct,
         "tertiary_remaining_pct": _remaining_pct(tertiary_used_pct),
-        # Back-compat aliases: weekly ≈ secondary allotment for most providers.
+        # Back-compat: weekly ≈ secondary for Claude/Codex; Cursor weekly ≈ Total (primary).
         "weekly_used_pct": weekly_used_pct,
         "weekly_remaining_pct": _remaining_pct(weekly_used_pct),
         "windows": {
-            "primary": _window_block(named_primary or primary_win, primary_used_pct),
-            "secondary": _window_block(named_secondary or weekly_win, secondary_used_pct),
-            "tertiary": _window_block(named_tertiary, tertiary_used_pct),
+            "primary": _window_block(
+                named_primary or primary_win, primary_used_pct, label=labels.get("primary")
+            ),
+            "secondary": _window_block(
+                named_secondary or (None if lane == "cursor" else weekly_win),
+                secondary_used_pct,
+                label=labels.get("secondary"),
+            ),
+            "tertiary": _window_block(named_tertiary, tertiary_used_pct, label=labels.get("tertiary")),
         },
         "monthly_cap_usd": monthly_cap_usd,
         "monthly_used_usd": monthly_used_usd,

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -973,18 +973,49 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 pace_sum = f"burn pct {burn_pct}%" if burn_pct is not None else "unknown"
 
             if is_in_deficit:
-                # Deficit is a WEEKLY-pace signal. Quote the 5h window too:
-                # a lane can be week-deficit yet have full 5h reserve for
-                # normal work now — weekly-only wording misled toward
-                # over-restriction (user correction 2026-07-09).
-                five_h_pct = cb.get("primary_used_pct") if cb else None
-                if five_h_pct is not None:
+                # Deficit is a plan-period pace signal. Quote the short/primary
+                # window too — but only call it "5h" when that window is ≤5h.
+                # Cursor primary is Total (billing cycle), not a 5h window.
+                primary_pct = cb.get("primary_used_pct") if cb else None
+                primary_mins = None
+                if cb:
+                    primary_mins = ((cb.get("windows") or {}).get("primary") or {}).get("window_minutes")
+                if primary_pct is not None:
+                    if lane == "cursor":
+                        auto_pct = cb.get("secondary_used_pct")
+                        api_pct = cb.get("tertiary_used_pct")
+                        short_bit = (
+                            f"Total {primary_pct:.0f}% used"
+                            + (f", Auto {auto_pct:.0f}%" if auto_pct is not None else "")
+                            + (f", API {api_pct:.0f}%" if api_pct is not None else "")
+                        )
+                    elif primary_mins is None or int(primary_mins) <= 300:
+                        # Claude/Codex primary is the ≤5h window; mocks may omit minutes.
+                        short_bit = (
+                            f"5h window {primary_pct:.0f}% used, {100 - primary_pct:.0f}% reserve"
+                        )
+                    else:
+                        short_bit = (
+                            f"primary window {primary_pct:.0f}% used, "
+                            f"{100 - primary_pct:.0f}% reserve"
+                        )
                     warnings.append(
-                        f"lane {lane} is in deficit ({pace_sum}; weekly-pace signal — "
-                        f"5h window {five_h_pct:.0f}% used, {100 - five_h_pct:.0f}% reserve)"
+                        f"lane {lane} is in deficit ({pace_sum}; weekly-pace signal — {short_bit})"
                     )
                 else:
                     warnings.append(f"lane {lane} is in deficit ({pace_sum})")
+
+            if (
+                lane == "cursor"
+                and cb
+                and cb.get("tertiary_used_pct") is not None
+                and float(cb["tertiary_used_pct"]) >= 90.0
+            ):
+                warnings.append(
+                    "lane cursor API/on-demand allotment near empty "
+                    f"({cb['tertiary_used_pct']:.0f}% used); "
+                    "included Total/Auto still from CodexBar — prefer Auto/Composer, not API"
+                )
 
     # Legacy Claude Interactive warning
     if "claude" in agents:

--- a/scripts/config/agent_budgets.yaml
+++ b/scripts/config/agent_budgets.yaml
@@ -34,8 +34,8 @@ grok:
   # cap value not duplicated here to avoid drift with user's live tracking.
 # grok-hermes is API/Hermes-path and intentionally ABSENT from subscription caps.
 cursor:
-  # cursor composer subscription lane
-  # cap value not duplicated here to avoid drift with user's live tracking.
+  # Cursor Pro+ subscription lane (CodexBar: Total / Auto / API).
+  # Burn/status tracks Total; do not invent a synthetic dollar cap here.
 kimi:
   # Native Kimi Code OAuth subscription lane (K3). CodexBar exposes request
   # windows directly; do not duplicate a synthetic dollar cap here.

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -182,7 +182,7 @@ def test_normalize_claude_shape():
 
 
 def test_normalize_cursor_three_windows():
-    """Cursor Pro exposes primary/secondary/tertiary allotments (API = tertiary)."""
+    """Cursor Pro+ exposes Total/Auto/API as primary/secondary/tertiary."""
     raw = {
         "provider": "cursor",
         "source": "web",
@@ -213,12 +213,18 @@ def test_normalize_cursor_three_windows():
     assert res["secondary_remaining_pct"] == 64.0
     assert res["tertiary_used_pct"] == 100.0
     assert res["tertiary_remaining_pct"] == 0.0
-    # weekly alias tracks secondary allotment for Cursor-style plans
-    assert res["weekly_used_pct"] == 36.0
-    assert res["weekly_remaining_pct"] == 64.0
+    # Burn/status alias tracks Total (primary), not Auto (secondary).
+    assert res["weekly_used_pct"] == 44.7
+    assert abs(res["weekly_remaining_pct"] - 55.3) < 0.01
+    assert res["weekly_resets_at"] == "2026-08-01T09:58:38Z"
+    assert res["windows"]["primary"]["label"] == "Total"
+    assert res["windows"]["secondary"]["label"] == "Auto"
+    assert res["windows"]["tertiary"]["label"] == "API"
     assert res["windows"]["tertiary"]["used_pct"] == 100.0
     assert res["windows"]["tertiary"]["remaining_pct"] == 0.0
     assert res["windows"]["primary"]["resets_at"] == "2026-08-01T09:58:38Z"
+    # Must not quietly copy Total into the Auto window block.
+    assert res["windows"]["secondary"]["used_pct"] == 36.0
 
 
 def test_normalize_codex_shape():
@@ -343,6 +349,88 @@ def test_routing_budget_surfaces_deficit_warnings(monkeypatch):
     assert "5h window 10% used" in deficit_warnings[0]
     assert "90% reserve" in deficit_warnings[0]
     assert "weekly-pace signal" in deficit_warnings[0]
+
+
+def test_routing_budget_cursor_burns_total_and_warns_on_api(monkeypatch):
+    """Cursor burn tracks Total; exhausted API allotment emits an advisory warning."""
+    cursor_row = {
+        "lane": "cursor",
+        "primary_used_pct": 44.7,
+        "primary_remaining_pct": 55.3,
+        "secondary_used_pct": 36.0,
+        "secondary_remaining_pct": 64.0,
+        "tertiary_used_pct": 100.0,
+        "tertiary_remaining_pct": 0.0,
+        "weekly_used_pct": 44.7,
+        "weekly_remaining_pct": 55.3,
+        "windows": {
+            "primary": {
+                "used_pct": 44.7,
+                "remaining_pct": 55.3,
+                "resets_at": "2026-08-01T09:58:38Z",
+                "window_minutes": 44640,
+                "label": "Total",
+            },
+            "secondary": {
+                "used_pct": 36.0,
+                "remaining_pct": 64.0,
+                "resets_at": "2026-08-01T09:58:38Z",
+                "window_minutes": 44640,
+                "label": "Auto",
+            },
+            "tertiary": {
+                "used_pct": 100.0,
+                "remaining_pct": 0.0,
+                "resets_at": "2026-08-01T09:58:38Z",
+                "window_minutes": 44640,
+                "label": "API",
+            },
+        },
+        "monthly_cap_usd": None,
+        "monthly_used_usd": None,
+        "weekly_resets_at": "2026-08-01T09:58:38Z",
+        "weekly_pace_delta_pct": -20.0,
+        "will_last_to_reset": True,
+        "pace_summary": "-20% pace delta",
+        "source": "codexbar",
+        "fetched_at": "2026-07-21T19:00:00Z",
+        "stale": False,
+        "age_s": 1.0,
+        "status": "healthy",
+        "auth_error": None,
+    }
+
+    def mock_usage(provider):
+        if provider == "cursor":
+            return dict(cursor_row)
+        return {
+            "lane": provider,
+            "primary_used_pct": None,
+            "weekly_used_pct": None,
+            "monthly_cap_usd": None,
+            "monthly_used_usd": None,
+            "weekly_resets_at": None,
+            "weekly_pace_delta_pct": None,
+            "will_last_to_reset": None,
+            "pace_summary": None,
+            "source": "codexbar",
+            "fetched_at": None,
+            "stale": False,
+            "age_s": None,
+            "status": "unknown",
+        }
+
+    monkeypatch.setattr(state_router, "get_provider_usage_data", mock_usage)
+    monkeypatch.setattr(state_router, "load_cost_records", lambda: [])
+
+    res = state_router.compute_routing_budget(datetime(2026, 7, 21, 19, 0, tzinfo=UTC))
+    cursor = res["agents"]["cursor"]
+    assert cursor["burn_pct_7d"] == 44.7
+    assert cursor["status"] == "cool"
+    assert cursor["codexbar"]["windows"]["primary"]["label"] == "Total"
+    api_warnings = [w for w in res["recommendation"]["warnings"] if "API/on-demand" in w]
+    assert api_warnings
+    assert "100% used" in api_warnings[0]
 
 
 def test_monthly_window_only_does_not_mislabel_weekly_used_pct():


### PR DESCRIPTION
## Summary
- CodexBar labels Cursor windows as **Total / Auto / API**; routing was burning on Auto (~36%) while Total (~45%) is the real account scarcity signal.
- Map Cursor `weekly_used_pct` / burn / status to **Total (primary)**; keep Auto + API as labeled secondary/tertiary windows.
- Deficit warnings no longer call Cursor primary a "5h window"; emit an advisory when the API/on-demand bucket is ≥90% used.

## Test plan
- [x] `pytest tests/test_codexbar_usage.py tests/api/test_routing_budget_endpoint.py`
- [ ] CI green
- [ ] After merge: `./services.sh restart api` and confirm `agents.cursor.burn_pct_7d` ≈ Total used% with `windows.*.label` Total/Auto/API


Made with [Cursor](https://cursor.com)