### PR TITLE
feat(kimicc): kimi login OAuth for --endpoint coding + apiKeyHelper long sessions

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -88,6 +88,16 @@ export MOONSHOT_API_KEY=sk-…   # https://platform.kimi.ai/console/api-keys
 ./start-kimicc.sh --isolate-config   # optional CLAUDE_CONFIG_DIR=$HOME/.claude-kimicc
 ```
 
+**Subscription auth (no platform API key):** run `kimi login` once, then use
+`--endpoint coding` — the launcher picks up the OAuth credential automatically
+(`scripts/lib/kimi_coding_oauth.py`, refresh_token grant against
+`https://auth.kimi.com/api/oauth/token`). OAuth access tokens live ~15 minutes,
+so for sessions longer than that add `--isolate-config`: an `apiKeyHelper` is
+then written into the **isolated** settings.json and Claude Code re-mints the
+token on a schedule (`CLAUDE_CODE_API_KEY_HELPER_TTL_MS`, default 300000).
+Without isolation the token is fixed at launch — fine for short sessions.
+`KIMICC_DRY_RUN=1` prints the resolved route/auth and exits before launch.
+
 | Model alias | Platform model id | Context | Auto-compact |
 | --- | --- | --- | --- |
 | `k3` (default) | `kimi-k3[1m]` | 1 048 576 | 996 147 |

--- a/scripts/lib/kimi_coding_oauth.py
+++ b/scripts/lib/kimi_coding_oauth.py
@@ -148,11 +148,13 @@ def _refresh(data: dict) -> dict:
 
 
 def _write_credentials(path: Path, data: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     backup = path.with_suffix(path.suffix + ".bak")
     # Backup is best-effort; the atomic replace below is the real guard.
+    # It holds the same tokens, so it gets the same owner-only permissions.
     with contextlib.suppress(OSError):
         backup.write_bytes(path.read_bytes())
+        os.chmod(backup, 0o600)
     fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:

--- a/scripts/lib/kimi_coding_oauth.py
+++ b/scripts/lib/kimi_coding_oauth.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Print a fresh Kimi Code (coding subscription) OAuth access token.
+
+Reads the credential file written by ``kimi login``
+(default ``~/.kimi-code/credentials/kimi-code.json``). If the stored access
+token is still valid beyond the safety margin, it is printed as-is; otherwise
+the token is refreshed via the standard OAuth ``refresh_token`` grant against
+the Kimi auth host and the credential file is updated atomically (keeping the
+rotated ``refresh_token`` when the server returns one).
+
+Used by ``start-kimicc.sh --endpoint coding`` both at launch time and as the
+Claude Code ``apiKeyHelper`` command, which re-invokes this script periodically
+so long sessions survive the short (~15 min) access-token lifetime.
+
+Stdlib-only: safe to run with any Python 3.9+.
+
+Usage:
+    kimi_coding_oauth.py token
+
+Exit codes:
+    0  token printed on stdout
+    2  no usable credentials (file missing / no refresh_token)
+    3  refresh request failed
+
+Environment overrides:
+    KIMI_CODE_CREDENTIALS_PATH   credential file location
+    KIMI_CODE_OAUTH_HOST         auth host (default https://auth.kimi.com)
+    KIMI_CODE_OAUTH_CLIENT_ID    OAuth client id (default: kimi-code CLI id)
+    KIMI_CODE_OAUTH_MARGIN       seconds of required remaining validity (default 120)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import json
+import os
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+DEFAULT_OAUTH_HOST = "https://auth.kimi.com"
+# Public client id of the Kimi Code CLI device-code flow (no secret).
+DEFAULT_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098"
+DEFAULT_MARGIN_SECONDS = 120
+REQUEST_TIMEOUT_SECONDS = 15
+
+
+def _credentials_path() -> Path:
+    override = os.environ.get("KIMI_CODE_CREDENTIALS_PATH")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".kimi-code" / "credentials" / "kimi-code.json"
+
+
+def _margin_seconds() -> int:
+    raw = os.environ.get("KIMI_CODE_OAUTH_MARGIN", "")
+    try:
+        return max(0, int(raw)) if raw else DEFAULT_MARGIN_SECONDS
+    except ValueError:
+        return DEFAULT_MARGIN_SECONDS
+
+
+def _read_credentials(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("credential file is not a JSON object")
+    return data
+
+
+def _fresh_token(data: dict, margin: int) -> str | None:
+    token = data.get("access_token")
+    expires_at = data.get("expires_at")
+    if not isinstance(token, str) or not token:
+        return None
+    if not isinstance(expires_at, (int, float)):
+        return None
+    if expires_at - time.time() <= margin:
+        return None
+    return token
+
+
+class NoCredentialsError(Exception):
+    """Credential file cannot produce a token (missing/unusable)."""
+
+
+class RefreshFailedError(Exception):
+    """The refresh grant against the auth host failed."""
+
+
+def _refresh(data: dict) -> dict:
+    refresh_token = data.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        raise NoCredentialsError("no refresh_token in credential file — run `kimi login` again")
+    host = os.environ.get("KIMI_CODE_OAUTH_HOST") or os.environ.get("KIMI_OAUTH_HOST") or DEFAULT_OAUTH_HOST
+    client_id = os.environ.get("KIMI_CODE_OAUTH_CLIENT_ID") or DEFAULT_CLIENT_ID
+    body = "&".join(
+        [
+            "grant_type=refresh_token",
+            "refresh_token=" + urllib.parse.quote(refresh_token, safe=""),
+            "client_id=" + urllib.parse.quote(client_id, safe=""),
+        ]
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        host.rstrip("/") + "/api/oauth/token",
+        data=body,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:200]
+        raise RefreshFailedError(f"token refresh failed: HTTP {exc.code} ({detail})") from exc
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RefreshFailedError(f"token refresh failed: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("access_token"), str):
+        raise RefreshFailedError("token refresh returned no access_token")
+
+    merged = dict(data)
+    merged["access_token"] = payload["access_token"]
+    if isinstance(payload.get("refresh_token"), str) and payload["refresh_token"]:
+        merged["refresh_token"] = payload["refresh_token"]
+    if isinstance(payload.get("token_type"), str):
+        merged["token_type"] = payload["token_type"]
+    if isinstance(payload.get("scope"), str):
+        merged["scope"] = payload["scope"]
+    expires_in = payload.get("expires_in")
+    if isinstance(expires_in, (int, float)) and expires_in > 0:
+        merged["expires_in"] = int(expires_in)
+        merged["expires_at"] = time.time() + float(expires_in)
+    elif isinstance(payload.get("expires_at"), (int, float)):
+        merged["expires_at"] = float(payload["expires_at"])
+    else:
+        # Server gave no lifetime; assume the kimi-code default so the next
+        # margin check behaves sanely instead of treating it as immortal.
+        merged["expires_at"] = time.time() + 900.0
+    return merged
+
+
+def _write_credentials(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    backup = path.with_suffix(path.suffix + ".bak")
+    # Backup is best-effort; the atomic replace below is the real guard.
+    with contextlib.suppress(OSError):
+        backup.write_bytes(path.read_bytes())
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2)
+            handle.write("\n")
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def cmd_token() -> int:
+    path = _credentials_path()
+    margin = _margin_seconds()
+    if not path.is_file():
+        print(f"kimi-coding-oauth: credential file not found: {path} (run `kimi login`)", file=sys.stderr)
+        return 2
+
+    # Serialize refreshes across concurrent apiKeyHelper invocations. The lock
+    # file is ours; the kimi CLI does not take it, so after acquiring we
+    # re-read and re-check in case another process already refreshed.
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            data = _read_credentials(path)
+        except (OSError, ValueError) as exc:
+            print(f"kimi-coding-oauth: cannot read credentials: {exc}", file=sys.stderr)
+            return 2
+
+        token = _fresh_token(data, margin)
+        if token is not None:
+            print(token)
+            return 0
+
+        try:
+            merged = _refresh(data)
+        except NoCredentialsError as exc:
+            print(f"kimi-coding-oauth: {exc}", file=sys.stderr)
+            return 2
+        except RefreshFailedError as exc:
+            print(f"kimi-coding-oauth: {exc}", file=sys.stderr)
+            return 3
+        try:
+            _write_credentials(path, merged)
+        except OSError as exc:
+            print(f"kimi-coding-oauth: cannot write credentials: {exc}", file=sys.stderr)
+            return 3
+
+        token = _fresh_token(merged, 0)
+        if token is None:
+            print("kimi-coding-oauth: refreshed token is already expired", file=sys.stderr)
+            return 3
+        print(token)
+        return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2 or argv[1] != "token":
+        print(__doc__, file=sys.stderr)
+        return 64
+    return cmd_token()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -11,6 +11,10 @@
 # - Original Anthropic Claude config stays untouched; run native Claude in another terminal.
 # - Refuses to launch if settings.json already pins route env keys (cc-switch hazard).
 # - Compaction comes from scripts/config/context_profiles.yaml (1M for K3, 256K for K2.7).
+# - Subscription auth: the `kimi login` OAuth credential (scripts/lib/kimi_coding_oauth.py)
+#   is used for --endpoint coding when no API key is set; with --isolate-config an
+#   apiKeyHelper is written into the isolated settings.json (never the operator's)
+#   so the ~15-min access token is refreshed on Claude Code's schedule.
 #
 # Official references:
 # - https://platform.kimi.ai/docs/guide/claude-code-kimi
@@ -19,6 +23,20 @@
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Prefer the main worktree root when launched from a git worktree copy, so the
+# apiKeyHelper path baked into the isolated Claude config survives worktree
+# cleanup (same pattern as start-kimi.sh). Ambient GIT_DIR/GIT_WORK_TREE (e.g.
+# from a pre-commit hook) must not leak into these lookups.
+if env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  _git_common="$(env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "${_git_common:-}" ] && [ -d "$(dirname "$_git_common")" ]; then
+    _main_wt="$(dirname "$_git_common")"
+    if [ -f "$_main_wt/start-kimicc.sh" ]; then
+      PROJECT_DIR="$_main_wt"
+    fi
+  fi
+  unset _git_common _main_wt
+fi
 export PATH="${HOME}/.local/bin:${PATH:-}"
 hash -r 2>/dev/null || true
 
@@ -46,18 +64,28 @@ Options:
 
 Environment:
   KIMICC_MODEL / KIMICC_ENDPOINT     Defaults for --model / --endpoint
-  MOONSHOT_API_KEY / KIMI_API_KEY    Platform API key (preferred)
+  MOONSHOT_API_KEY / KIMI_API_KEY    Platform API key (preferred for platform)
   KIMICC_AUTH_TOKEN                  Explicit auth token override
   KIMICC_BASE_URL                    Override Anthropic-compatible base URL
+  KIMICC_DRY_RUN=1                   Resolve route + auth, print summary, exit before launch
+  KIMICC_API_KEY_HELPER_TTL_MS       apiKeyHelper re-invoke interval (default 300000)
   CLAUDE_CONFIG_DIR                  Isolated Claude config directory
   CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV=1
                                      Bypass settings.json env conflict check (emergency)
+
+Subscription auth (no API key needed):
+  Run `kimi login` once. With --endpoint coding the launcher picks up the
+  OAuth credential automatically and refreshes it. Access tokens live ~15 min:
+  without --isolate-config the token is fixed at launch (short sessions);
+  with --isolate-config an apiKeyHelper is installed that auto-refreshes
+  (long sessions).
 
 Examples:
   ./start-kimicc.sh
   ./start-kimicc.sh --model k2.7
   ./start-kimicc.sh --model k2.7-highspeed --epic harness
   MOONSHOT_API_KEY=<your-key> ./start-kimicc.sh --model k3
+  ./start-kimicc.sh --endpoint coding --isolate-config   # subscription, long session
 
 Headless / native Kimi (not this launcher):
   scripts/delegate.py dispatch --agent kimi --model k3 …
@@ -120,22 +148,32 @@ default_base_url() {
   esac
 }
 
+# Resolve the auth credential into globals (no command substitution, so
+# AUTH_SOURCE survives in the caller's shell).
+_resolved_auth=""
+AUTH_SOURCE=""
 resolve_auth_token() {
+  _resolved_auth=""
+  AUTH_SOURCE=""
   if [ -n "${KIMICC_AUTH_TOKEN:-}" ]; then
-    printf '%s\n' "$KIMICC_AUTH_TOKEN"
+    _resolved_auth="$KIMICC_AUTH_TOKEN"
+    AUTH_SOURCE="KIMICC_AUTH_TOKEN"
     return 0
   fi
   if [ -n "${MOONSHOT_API_KEY:-}" ]; then
-    printf '%s\n' "$MOONSHOT_API_KEY"
+    _resolved_auth="$MOONSHOT_API_KEY"
+    AUTH_SOURCE="MOONSHOT_API_KEY"
     return 0
   fi
   if [ -n "${KIMI_API_KEY:-}" ]; then
-    printf '%s\n' "$KIMI_API_KEY"
+    _resolved_auth="$KIMI_API_KEY"
+    AUTH_SOURCE="KIMI_API_KEY"
     return 0
   fi
   if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ "${ENDPOINT}" = "coding" ]; then
     # Allow an already-exported coding token when operator sets it intentionally.
-    printf '%s\n' "$ANTHROPIC_AUTH_TOKEN"
+    _resolved_auth="$ANTHROPIC_AUTH_TOKEN"
+    AUTH_SOURCE="ANTHROPIC_AUTH_TOKEN"
     return 0
   fi
   return 1
@@ -217,11 +255,26 @@ if ! assert_claude_settings_route_clean "KimiCC"; then
   exit 1
 fi
 
-if ! _resolved_auth="$(resolve_auth_token)"; then
+# Explicit credentials win. For --endpoint coding, fall back to the
+# `kimi login` OAuth credential (subscription route): the helper prints a
+# fresh access token, refreshing it via the refresh_token grant when needed.
+KIMI_OAUTH_PY="$PROJECT_DIR/.venv/bin/python"
+KIMI_OAUTH_HELPER="$PROJECT_DIR/scripts/lib/kimi_coding_oauth.py"
+AUTH_VIA_OAUTH=0
+if ! resolve_auth_token; then
+  if [ "$ENDPOINT" = "coding" ] && [ -f "$KIMI_OAUTH_HELPER" ] && [ -x "$KIMI_OAUTH_PY" ]; then
+    if _resolved_auth="$("$KIMI_OAUTH_PY" "$KIMI_OAUTH_HELPER" token 2>/dev/null)" \
+        && [ -n "$_resolved_auth" ]; then
+      AUTH_VIA_OAUTH=1
+      AUTH_SOURCE="oauth(kimi login)"
+    fi
+  fi
+fi
+if [ -z "$_resolved_auth" ]; then
   echo "Error: no Kimi API credential found for the kimicc route." >&2
-  echo "  Set one of: MOONSHOT_API_KEY, KIMI_API_KEY, or KIMICC_AUTH_TOKEN" >&2
+  echo "  Platform (pay-as-you-go): set MOONSHOT_API_KEY, KIMI_API_KEY, or KIMICC_AUTH_TOKEN" >&2
   echo "  Platform keys: https://platform.kimi.ai/console/api-keys" >&2
-  echo "  Native Kimi OAuth (kimi login) is for ./start-kimi.sh / headless kimi — not Claude Code." >&2
+  echo "  Subscription: run \`kimi login\`, then use --endpoint coding (OAuth is picked up automatically)." >&2
   exit 1
 fi
 
@@ -242,8 +295,57 @@ export LEARN_UKRAINIAN_TRANSPORT=kimicc
 
 # Moonshot Anthropic-compatible routing (process-scoped only).
 export ANTHROPIC_BASE_URL="$BASE_URL"
-export ANTHROPIC_AUTH_TOKEN="$_resolved_auth"
 unset ANTHROPIC_API_KEY
+
+# OAuth (`kimi login`) access tokens expire after ~15 minutes. With an
+# isolated config we install an apiKeyHelper that re-mints the token on Claude
+# Code's schedule (long-session mode); without isolation the current token can
+# only be exported into the process env, which is fixed at launch.
+if [ "$AUTH_VIA_OAUTH" = "1" ] && [ "$ISOLATE_CONFIG" = "1" ]; then
+  _helper_cmd="$KIMI_OAUTH_PY $KIMI_OAUTH_HELPER token"
+  if ! KIMICC_SETTINGS_PATH="$CLAUDE_CONFIG_DIR/settings.json" KIMICC_API_KEY_HELPER="$_helper_cmd" \
+      "$KIMI_OAUTH_PY" - <<'PY'
+import json
+import os
+import sys
+
+path = os.environ["KIMICC_SETTINGS_PATH"]
+helper = os.environ["KIMICC_API_KEY_HELPER"]
+data = {}
+if os.path.exists(path):
+    with open(path, encoding="utf-8") as fh:
+        try:
+            data = json.load(fh)
+        except json.JSONDecodeError as exc:
+            print(f"Error: {path} is not valid JSON ({exc}); refusing to modify it.", file=sys.stderr)
+            sys.exit(1)
+    if not isinstance(data, dict):
+        print(f"Error: {path} is not a JSON object; refusing to modify it.", file=sys.stderr)
+        sys.exit(1)
+data["apiKeyHelper"] = helper
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PY
+  then
+    echo "Error: could not install apiKeyHelper into $CLAUDE_CONFIG_DIR/settings.json" >&2
+    exit 1
+  fi
+  unset _helper_cmd
+  # Re-invoke the helper well inside the ~15 min token lifetime.
+  export CLAUDE_CODE_API_KEY_HELPER_TTL_MS="${KIMICC_API_KEY_HELPER_TTL_MS:-300000}"
+  unset ANTHROPIC_AUTH_TOKEN
+  AUTH_NOTE="oauth(kimi login) via apiKeyHelper (auto-refresh, ttl=${CLAUDE_CODE_API_KEY_HELPER_TTL_MS}ms)"
+else
+  export ANTHROPIC_AUTH_TOKEN="$_resolved_auth"
+  if [ "$AUTH_VIA_OAUTH" = "1" ]; then
+    AUTH_NOTE="oauth(kimi login) — short-lived token (~15 min); for long sessions relaunch with --isolate-config"
+  else
+    AUTH_NOTE="$AUTH_SOURCE"
+  fi
+fi
+unset _resolved_auth
 
 export ANTHROPIC_MODEL="$LEAD_MODEL"
 export ANTHROPIC_DEFAULT_OPUS_MODEL="$LEAD_MODEL"
@@ -271,6 +373,7 @@ fi
 echo "KimiCC: model=$LEAD_MODEL alias=$MODEL_ALIAS endpoint=$ENDPOINT profile=$PROFILE_ID"
 echo "        window=$LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS compact=$CLAUDE_CODE_AUTO_COMPACT_WINDOW"
 echo "        base=$ANTHROPIC_BASE_URL (env-only; ~/.claude/settings.json not modified)"
+echo "        auth=$AUTH_NOTE"
 echo "        tip: keep ./start-claude.sh in another terminal for native Anthropic Claude"
 if [ "$MODEL_ALIAS" != "k3" ]; then
   echo "        note: k2.7 requires Thinking ON in the TUI (Tab) or requests are rejected"
@@ -293,6 +396,11 @@ for arg in "${FORWARD_ARGS[@]+"${FORWARD_ARGS[@]}"}"; do
   _cleaned+=("$arg")
   _prev="$arg"
 done
+
+if [ "${KIMICC_DRY_RUN:-0}" = "1" ]; then
+  echo "KIMICC_DRY_RUN=1: would exec $PROJECT_DIR/start-claude.sh --model $LEAD_MODEL ${_cleaned[*]+"${_cleaned[*]}"}"
+  exit 0
+fi
 
 if ((${#_cleaned[@]})); then
   exec "$PROJECT_DIR/start-claude.sh" --model "$LEAD_MODEL" "${_cleaned[@]}"

--- a/tests/test_kimi_coding_oauth.py
+++ b/tests/test_kimi_coding_oauth.py
@@ -44,14 +44,14 @@ pytestmark = pytest.mark.skipif(_PYTHON is None, reason="project .venv python re
 
 def _write_credentials(path: Path, *, expires_in: int, with_refresh: bool = True) -> dict:
     data = {
-        "access_token": "old-access-token",
+        "access_token": "old-access",
         "expires_at": time.time() + expires_in,
         "expires_in": expires_in,
         "token_type": "Bearer",
         "scope": "kimi-code",
     }
     if with_refresh:
-        data["refresh_token"] = "old-refresh-token"
+        data["refresh_token"] = "old-refresh"
     path.write_text(json.dumps(data), encoding="utf-8")
     path.chmod(0o600)
     return data
@@ -125,17 +125,17 @@ def test_fresh_token_printed_without_network(tmp_path: Path) -> None:
     _write_credentials(cred, expires_in=900)
     result = _run_helper(cred)
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "old-access-token"
+    assert result.stdout.strip() == "old-access"
     # Untouched by the run (no refresh, no rotation).
-    assert json.loads(cred.read_text(encoding="utf-8"))["refresh_token"] == "old-refresh-token"
+    assert json.loads(cred.read_text(encoding="utf-8"))["refresh_token"] == "old-refresh"
 
 
 def test_expired_token_refreshes_and_writes_back(tmp_path: Path) -> None:
     cred = tmp_path / "kimi-code.json"
     _write_credentials(cred, expires_in=30)  # inside the 120s margin
     payload = {
-        "access_token": "new-access-token",
-        "refresh_token": "new-refresh-token",
+        "access_token": "new-access",
+        "refresh_token": "new-refresh",
         "expires_in": 900,
         "token_type": "Bearer",
         "scope": "kimi-code",
@@ -143,17 +143,17 @@ def test_expired_token_refreshes_and_writes_back(tmp_path: Path) -> None:
     with _RefreshServer(payload) as server:
         result = _run_helper(cred, KIMI_CODE_OAUTH_HOST=server.url)
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "new-access-token"
+    assert result.stdout.strip() == "new-access"
 
     assert len(server.bodies) == 1
     body = server.bodies[0]
     assert "grant_type=refresh_token" in body
-    assert "refresh_token=old-refresh-token" in body
+    assert "refresh_token=old-refresh" in body
     assert "client_id=" in body
 
     stored = json.loads(cred.read_text(encoding="utf-8"))
-    assert stored["access_token"] == "new-access-token"
-    assert stored["refresh_token"] == "new-refresh-token"
+    assert stored["access_token"] == "new-access"
+    assert stored["refresh_token"] == "new-refresh"
     assert stored["expires_at"] > time.time() + 600
     assert stat.S_IMODE(cred.stat().st_mode) == 0o600
 
@@ -180,4 +180,4 @@ def test_refresh_server_error_exits_3(tmp_path: Path) -> None:
     assert result.returncode == 3
     assert "HTTP 400" in result.stderr
     # Failed refresh must not clobber the stored credential.
-    assert json.loads(cred.read_text(encoding="utf-8"))["access_token"] == "old-access-token"
+    assert json.loads(cred.read_text(encoding="utf-8"))["access_token"] == "old-access"

--- a/tests/test_kimi_coding_oauth.py
+++ b/tests/test_kimi_coding_oauth.py
@@ -1,0 +1,183 @@
+"""Unit tests for scripts/lib/kimi_coding_oauth.py (kimi login OAuth helper)."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HELPER = _REPO_ROOT / "scripts" / "lib" / "kimi_coding_oauth.py"
+
+
+def _resolve_venv_python() -> Path | None:
+    """Project venv; falls back to the main worktree when run from a linked worktree."""
+    candidates = [_REPO_ROOT / ".venv" / "bin" / "python"]
+    try:
+        common = subprocess.run(
+            ["git", "-C", str(_REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if common.returncode == 0 and common.stdout.strip():
+            candidates.append(Path(common.stdout.strip()).parent / ".venv" / "bin" / "python")
+    except (OSError, subprocess.SubprocessError):
+        pass
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+_PYTHON = _resolve_venv_python()
+
+pytestmark = pytest.mark.skipif(_PYTHON is None, reason="project .venv python required")
+
+
+def _write_credentials(path: Path, *, expires_in: int, with_refresh: bool = True) -> dict:
+    data = {
+        "access_token": "old-access-token",
+        "expires_at": time.time() + expires_in,
+        "expires_in": expires_in,
+        "token_type": "Bearer",
+        "scope": "kimi-code",
+    }
+    if with_refresh:
+        data["refresh_token"] = "old-refresh-token"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    path.chmod(0o600)
+    return data
+
+
+def _run_helper(cred_path: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for name in tuple(env):
+        if name.startswith("KIMI_CODE_"):
+            env.pop(name, None)
+    env.update(
+        {
+            "KIMI_CODE_CREDENTIALS_PATH": str(cred_path),
+            # Guaranteed-unroutable host: any accidental network call fails fast.
+            "KIMI_CODE_OAUTH_HOST": "http://127.0.0.1:9",
+        }
+    )
+    env.update(env_overrides)
+    return subprocess.run(
+        [str(_PYTHON), str(_HELPER), "token"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class _RefreshServer:
+    """Minimal /api/oauth/token endpoint recording the last request body."""
+
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self.payload = payload
+        self.status = status
+        self.bodies: list[str] = []
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length", "0"))
+                outer.bodies.append(self.rfile.read(length).decode("utf-8"))
+                body = json.dumps(outer.payload).encode("utf-8")
+                self.send_response(outer.status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args: object) -> None:
+                pass
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    @property
+    def url(self) -> str:
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+    def __enter__(self) -> _RefreshServer:
+        self.thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+def test_fresh_token_printed_without_network(tmp_path: Path) -> None:
+    cred = tmp_path / "kimi-code.json"
+    _write_credentials(cred, expires_in=900)
+    result = _run_helper(cred)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "old-access-token"
+    # Untouched by the run (no refresh, no rotation).
+    assert json.loads(cred.read_text(encoding="utf-8"))["refresh_token"] == "old-refresh-token"
+
+
+def test_expired_token_refreshes_and_writes_back(tmp_path: Path) -> None:
+    cred = tmp_path / "kimi-code.json"
+    _write_credentials(cred, expires_in=30)  # inside the 120s margin
+    payload = {
+        "access_token": "new-access-token",
+        "refresh_token": "new-refresh-token",
+        "expires_in": 900,
+        "token_type": "Bearer",
+        "scope": "kimi-code",
+    }
+    with _RefreshServer(payload) as server:
+        result = _run_helper(cred, KIMI_CODE_OAUTH_HOST=server.url)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "new-access-token"
+
+    assert len(server.bodies) == 1
+    body = server.bodies[0]
+    assert "grant_type=refresh_token" in body
+    assert "refresh_token=old-refresh-token" in body
+    assert "client_id=" in body
+
+    stored = json.loads(cred.read_text(encoding="utf-8"))
+    assert stored["access_token"] == "new-access-token"
+    assert stored["refresh_token"] == "new-refresh-token"
+    assert stored["expires_at"] > time.time() + 600
+    assert stat.S_IMODE(cred.stat().st_mode) == 0o600
+
+
+def test_missing_credential_file_exits_2(tmp_path: Path) -> None:
+    result = _run_helper(tmp_path / "nope.json")
+    assert result.returncode == 2
+    assert "kimi login" in result.stderr
+
+
+def test_expired_without_refresh_token_exits_2(tmp_path: Path) -> None:
+    cred = tmp_path / "kimi-code.json"
+    _write_credentials(cred, expires_in=30, with_refresh=False)
+    result = _run_helper(cred)
+    assert result.returncode == 2
+    assert "refresh_token" in result.stderr
+
+
+def test_refresh_server_error_exits_3(tmp_path: Path) -> None:
+    cred = tmp_path / "kimi-code.json"
+    _write_credentials(cred, expires_in=30)
+    with _RefreshServer({"error": "invalid_grant"}, status=400) as server:
+        result = _run_helper(cred, KIMI_CODE_OAUTH_HOST=server.url)
+    assert result.returncode == 3
+    assert "HTTP 400" in result.stderr
+    # Failed refresh must not clobber the stored credential.
+    assert json.loads(cred.read_text(encoding="utf-8"))["access_token"] == "old-access-token"

--- a/tests/test_kimi_coding_oauth.py
+++ b/tests/test_kimi_coding_oauth.py
@@ -156,6 +156,10 @@ def test_expired_token_refreshes_and_writes_back(tmp_path: Path) -> None:
     assert stored["refresh_token"] == "new-refresh"
     assert stored["expires_at"] > time.time() + 600
     assert stat.S_IMODE(cred.stat().st_mode) == 0o600
+    # Backup holds the same tokens and must be owner-only too (review F001).
+    backup = cred.with_suffix(cred.suffix + ".bak")
+    assert backup.is_file()
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
 
 
 def test_missing_credential_file_exits_2(tmp_path: Path) -> None:

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -347,8 +347,8 @@ def _write_oauth_credentials(tmp_path: Path, *, expires_in: int = 900) -> Path:
     cred.write_text(
         json.dumps(
             {
-                "access_token": "oauth-access-token",
-                "refresh_token": "oauth-refresh-token",
+                "access_token": "oauth-acc",
+                "refresh_token": "oauth-ref",
                 "expires_at": time.time() + expires_in,
                 "expires_in": expires_in,
                 "token_type": "Bearer",
@@ -383,7 +383,7 @@ def test_coding_endpoint_falls_back_to_kimi_login_oauth(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert "base=https://api.kimi.com/coding" in output
-    assert "auth=oauth-access-token" in output
+    assert "auth=oauth-acc" in output
     assert "model=k3" in output
     assert "oauth(kimi login)" in result.stdout
     assert "short-lived" in result.stdout

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -5,12 +5,36 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _LAUNCHER = _REPO_ROOT / "start-kimicc.sh"
+
+
+def _resolve_venv_python() -> Path | None:
+    """Project venv; falls back to the main worktree when run from a linked worktree."""
+    candidates = [_REPO_ROOT / ".venv" / "bin" / "python"]
+    try:
+        common = subprocess.run(
+            ["git", "-C", str(_REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if common.returncode == 0 and common.stdout.strip():
+            candidates.append(Path(common.stdout.strip()).parent / ".venv" / "bin" / "python")
+    except (OSError, subprocess.SubprocessError):
+        pass
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+_VENV_PYTHON = _resolve_venv_python()
 
 
 def _write_executable(path: Path, body: str) -> None:
@@ -25,6 +49,7 @@ def _require_launcher_sources() -> None:
         _REPO_ROOT / "scripts" / "lib" / "claude_route_guard.sh",
         _REPO_ROOT / "scripts" / "lib" / "profile_resolver.sh",
         _REPO_ROOT / "scripts" / "lib" / "context_profiles.py",
+        _REPO_ROOT / "scripts" / "lib" / "kimi_coding_oauth.py",
     ) if not path.is_file()]
     if missing:
         names = ", ".join(str(path.relative_to(_REPO_ROOT)) for path in missing)
@@ -46,7 +71,7 @@ def _seed_fake_project(tmp_path: Path) -> Path:
         project / "start-claude.sh",
         "#!/usr/bin/env bash\n# Test stub: kimicc already exported env; exec fake claude from PATH.\nexec claude \"$@\"\n",
     )
-    for name in ("claude_route_guard.sh", "profile_resolver.sh", "context_profiles.py"):
+    for name in ("claude_route_guard.sh", "profile_resolver.sh", "context_profiles.py", "kimi_coding_oauth.py"):
         src = _REPO_ROOT / "scripts" / "lib" / name
         dest = lib / name
         dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
@@ -56,10 +81,9 @@ def _seed_fake_project(tmp_path: Path) -> Path:
     if profiles.is_file():
         (cfg / "context_profiles.yaml").write_text(profiles.read_text(encoding="utf-8"), encoding="utf-8")
     # Point profile resolver at a real Python that has project deps if present.
-    real_py = _REPO_ROOT / ".venv" / "bin" / "python"
     py_body = (
-        f"#!/usr/bin/env bash\nexec {real_py} \"$@\"\n"
-        if real_py.is_file()
+        f'#!/usr/bin/env bash\nexec "{_VENV_PYTHON}" "$@"\n'
+        if _VENV_PYTHON is not None
         else "#!/usr/bin/env bash\nexec /usr/bin/env python3 \"$@\"\n"
     )
     _write_executable(venv_bin / "python", py_body)
@@ -106,6 +130,7 @@ fi
     printf 'tool_search=%s\\n' "${ENABLE_TOOL_SEARCH-unset}"
     printf 'effort=%s\\n' "${CLAUDE_CODE_EFFORT_LEVEL-unset}"
     printf 'auto_compact=%s\\n' "${CLAUDE_CODE_AUTO_COMPACT_WINDOW-unset}"
+    printf 'helper_ttl=%s\\n' "${CLAUDE_CODE_API_KEY_HELPER_TTL_MS-unset}"
     printf 'profile=%s\\n' "$LEARN_UKRAINIAN_PROFILE_ID"
     printf 'transport=%s\\n' "$LEARN_UKRAINIAN_TRANSPORT"
     printf 'main_window=%s\\n' "$LEARN_UKRAINIAN_MAIN_CONTEXT_WINDOW_TOKENS"
@@ -134,6 +159,12 @@ fi
             "KIMICC_BASE_URL",
             "KIMICC_MODEL",
             "KIMICC_ENDPOINT",
+            "KIMICC_DRY_RUN",
+            "KIMICC_API_KEY_HELPER_TTL_MS",
+            "CLAUDE_CODE_API_KEY_HELPER_TTL_MS",
+            "KIMI_CODE_CREDENTIALS_PATH",
+            "KIMI_CODE_OAUTH_HOST",
+            "KIMI_CODE_OAUTH_MARGIN",
             "CLAUDE_CONFIG_DIR",
             "SESSION_EPIC",
             "SESSION_HANDOFF_AGENT",
@@ -308,3 +339,102 @@ def test_help_mentions_native_kimi_headless_separation(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert "ask-kimi" in result.stdout
     assert "settings.json" in result.stdout
+
+
+def _write_oauth_credentials(tmp_path: Path, *, expires_in: int = 900) -> Path:
+    cred = tmp_path / "oauth-creds" / "kimi-code.json"
+    cred.parent.mkdir(parents=True)
+    cred.write_text(
+        json.dumps(
+            {
+                "access_token": "oauth-access-token",
+                "refresh_token": "oauth-refresh-token",
+                "expires_at": time.time() + expires_in,
+                "expires_in": expires_in,
+                "token_type": "Bearer",
+                "scope": "kimi-code",
+            }
+        ),
+        encoding="utf-8",
+    )
+    cred.chmod(0o600)
+    return cred
+
+
+_OAUTH_ENV_CLEAR = {
+    "MOONSHOT_API_KEY": "",
+    "KIMI_API_KEY": "",
+    "KIMICC_AUTH_TOKEN": "",
+    "ANTHROPIC_AUTH_TOKEN": "",
+}
+
+
+def test_coding_endpoint_falls_back_to_kimi_login_oauth(tmp_path: Path) -> None:
+    cred = _write_oauth_credentials(tmp_path)
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "coding"],
+        env_overrides={
+            **_OAUTH_ENV_CLEAR,
+            "KIMI_CODE_CREDENTIALS_PATH": str(cred),
+            # Fresh stored token (900s > 120s margin): no network needed.
+            "KIMI_CODE_OAUTH_HOST": "http://127.0.0.1:9",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert "base=https://api.kimi.com/coding" in output
+    assert "auth=oauth-access-token" in output
+    assert "model=k3" in output
+    assert "oauth(kimi login)" in result.stdout
+    assert "short-lived" in result.stdout
+
+
+def test_coding_oauth_isolate_config_installs_api_key_helper(tmp_path: Path) -> None:
+    cred = _write_oauth_credentials(tmp_path)
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "coding", "--isolate-config"],
+        env_overrides={
+            **_OAUTH_ENV_CLEAR,
+            "KIMI_CODE_CREDENTIALS_PATH": str(cred),
+            "KIMI_CODE_OAUTH_HOST": "http://127.0.0.1:9",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    # apiKeyHelper mode: no static token is exported into the process env.
+    assert "auth=unset" in output
+    assert "helper_ttl=300000" in output
+    assert "apiKeyHelper" in result.stdout
+    settings_path = tmp_path / "home" / ".claude-kimicc" / "settings.json"
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    helper = settings.get("apiKeyHelper", "")
+    assert "kimi_coding_oauth.py token" in helper
+    # Operator's live config is never touched.
+    assert not (tmp_path / "home" / ".claude" / "settings.json").exists()
+
+
+def test_coding_oauth_missing_credentials_mentions_kimi_login(tmp_path: Path) -> None:
+    _, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "coding"],
+        env_overrides={
+            **_OAUTH_ENV_CLEAR,
+            "KIMI_CODE_CREDENTIALS_PATH": str(tmp_path / "does-not-exist.json"),
+        },
+    )
+    assert result.returncode == 1
+    assert "no Kimi API credential" in result.stderr
+    assert "kimi login" in result.stderr
+
+
+def test_dry_run_resolves_route_without_launching(tmp_path: Path) -> None:
+    output, result = _run_with_fakes(
+        tmp_path,
+        [],
+        env_overrides={"KIMICC_DRY_RUN": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "KIMICC_DRY_RUN=1: would exec" in result.stdout
+    assert "auth=MOONSHOT_API_KEY" in result.stdout
+    # Fake claude was never executed.
+    assert output == ""


### PR DESCRIPTION
## Summary

`start-kimicc.sh` refused to launch for operators whose only Kimi credential is a **Kimi Code subscription** (`kimi login` OAuth) — it exited 1 demanding `MOONSHOT_API_KEY`/`KIMI_API_KEY` and explicitly disowned the OAuth route. This PR makes the subscription a first-class credential for `--endpoint coding`:

- **`scripts/lib/kimi_coding_oauth.py` (new)** — stdlib-only helper that prints a fresh access token from `~/.kimi-code/credentials/kimi-code.json`, refreshing via the standard `refresh_token` grant against `https://auth.kimi.com/api/oauth/token` when inside the expiry margin (endpoint + client id verified against the kimi-code CLI bundle). Locked (`flock`), atomic write-back preserving the rotated `refresh_token`, `0600` perms, best-effort `.bak`. Exit 2 = no usable credentials, 3 = refresh failed.
- **`start-kimicc.sh`**:
  - `--endpoint coding` falls back to the OAuth credential when no explicit API-key env is set. Explicit credentials still win; resolution order unchanged.
  - With `--isolate-config`, writes an `apiKeyHelper` into the **isolated** `settings.json` (never the operator's `~/.claude`) and exports `CLAUDE_CODE_API_KEY_HELPER_TTL_MS=300000`, so the ~15-minute OAuth access token is re-minted on Claude Code's schedule. No static token is exported in this mode.
  - Without isolation, exports the current token and prints a clear ~15-min lifetime warning pointing at `--isolate-config`.
  - Worktree-redirect for `PROJECT_DIR` (same pattern as `start-kimi.sh`) so the apiKeyHelper path survives worktree cleanup; ambient `GIT_DIR`/`GIT_WORK_TREE` (e.g. pre-commit hook env) is scrubbed from the detection calls.
  - `KIMICC_DRY_RUN=1` resolves route + auth and exits before exec.
  - Usage text and the no-credential error now document the subscription route.
- **`docs/SCRIPTS.md`** — KimiCC section documents the subscription flow.

## Live verification (not just mocks)

- Forced a real refresh against `https://auth.kimi.com/api/oauth/token` → new token accepted by the coding endpoint (`POST https://api.kimi.com/coding/v1/messages`, model `k3`, **HTTP 200**).
- End-to-end dry run with `--endpoint coding --isolate-config` → installs `apiKeyHelper`, resolves `kimicc_k3` profile, prints the route summary.

## Tests

- New `tests/test_kimi_coding_oauth.py` (5 tests: fresh-token, refresh+write-back with rotation, missing file, no refresh_token, server 400) using a local mock auth server.
- `tests/test_start_kimicc.py`: +4 tests (OAuth fallback, apiKeyHelper isolation + operator-config untouched, missing-credential message, dry-run). Launcher tests now resolve the main-worktree `.venv`, so they also pass from linked worktrees.
- **19/19 pass**, including under ambient `GIT_DIR`/`GIT_WORK_TREE` (hook conditions); `ruff` and `shellcheck` clean.
- The 11 failures in `test_start_claudex.py` / `test_start_claude_profiles.py` reproduce identically on `origin/main` — pre-existing, unrelated.

## Usage after merge

```bash
kimi login                                   # once
./start-kimicc.sh --endpoint coding --isolate-config   # subscription, long sessions
```

X-Agent: kimi/kimicc-oauth
