### PR TITLE
fix(kimi): prefer hermes npm install over legacy standalone binary

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -26,8 +26,9 @@ Project-local wrappers for interactive agent sessions:
 
 Native Kimi Code (separate app/CLI, OAuth subscription) is the **headless / fleet**
 lane via `scripts/delegate.py --agent kimi` and `ab ask-kimi`. Interactive native
-Kimi is `kimi` from `~/.kimi-code/bin` (or a dedicated `start-kimi.sh` when that
-wrapper is present) — not `start-kimicc.sh`.
+Kimi is `kimi` (the hermes npm install at `~/.hermes/node/bin/kimi` is preferred;
+`~/.kimi-code/bin/kimi` is the legacy standalone binary and last-resort fallback)
+or a dedicated `start-kimi.sh` when that wrapper is present — not `start-kimicc.sh`.
 
 ### Parallel routes and original Claude config
 

--- a/scripts/agent_runtime/adapters/kimi.py
+++ b/scripts/agent_runtime/adapters/kimi.py
@@ -207,9 +207,12 @@ class KimiAdapter:
 
 def _resolve_kimi_binary() -> str:
     override = os.environ.get("LEARN_UK_KIMI_BIN")
+    # The hermes npm install (@moonshot-ai/kimi-code) is the maintained one;
+    # ~/.kimi-code/bin/kimi is the legacy standalone binary and is often stale.
     candidates = (
         override,
         shutil.which("kimi"),
+        str(Path.home() / ".hermes" / "node" / "bin" / "kimi"),
         str(Path.home() / ".kimi-code" / "bin" / "kimi"),
     )
     for candidate in candidates:

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -34,7 +34,7 @@
 
 set -euo pipefail
 
-export PATH="${HOME}/.local/bin:/opt/homebrew/bin:${HOME}/.kimi-code/bin:${PATH:-}"
+export PATH="${HOME}/.local/bin:/opt/homebrew/bin:${HOME}/.hermes/node/bin:${PATH:-}"
 hash -r 2>/dev/null || true
 
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -58,11 +58,15 @@ usage_launcher() {
   exit 0
 }
 # --- locate kimi binary ---
+# Preference order: explicit override → ambient PATH (the hermes npm install,
+# ~/.hermes/node/bin, is the maintained one) → hermes explicit → legacy
+# standalone binary at ~/.kimi-code/bin (last resort; often stale).
 KIMI_BIN="${LEARN_UK_KIMI_BIN:-}"
 if [ -z "$KIMI_BIN" ] || [ ! -x "$KIMI_BIN" ]; then
   KIMI_BIN=""
   for cand in \
     "$(command -v kimi 2>/dev/null || true)" \
+    "${HOME}/.hermes/node/bin/kimi" \
     "${HOME}/.kimi-code/bin/kimi"
   do
     if [ -n "$cand" ] && [ -x "$cand" ]; then

--- a/tests/agent_runtime/adapters/test_kimi_adapter.py
+++ b/tests/agent_runtime/adapters/test_kimi_adapter.py
@@ -227,3 +227,38 @@ def test_invocation_telemetry_is_model_aware_and_reports_native_cli_version(tmp_
 
     assert coding_telemetry.model == KIMI_MODEL_ALIASES[KIMI_DEFAULT_MODEL]
     assert coding_telemetry.effort == "not-exposed"  # k2.7 models have no effort knob
+
+
+def test_binary_resolution_prefers_hermes_over_legacy(tmp_path, monkeypatch):
+    """No override + nothing on PATH: hermes npm install beats the legacy binary."""
+    from scripts.agent_runtime.adapters import kimi as kimi_adapter
+
+    home = tmp_path / "home"
+    hermes = home / ".hermes" / "node" / "bin" / "kimi"
+    legacy = home / ".kimi-code" / "bin" / "kimi"
+    for path in (hermes, legacy):
+        path.parent.mkdir(parents=True)
+        path.write_text("#!/bin/sh\n", encoding="utf-8")
+        path.chmod(0o755)
+
+    monkeypatch.delenv("LEARN_UK_KIMI_BIN", raising=False)
+    monkeypatch.setattr(kimi_adapter.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(kimi_adapter.Path, "home", lambda: home)
+
+    assert kimi_adapter._resolve_kimi_binary() == str(hermes)
+
+
+def test_binary_resolution_falls_back_to_legacy_when_hermes_absent(tmp_path, monkeypatch):
+    from scripts.agent_runtime.adapters import kimi as kimi_adapter
+
+    home = tmp_path / "home"
+    legacy = home / ".kimi-code" / "bin" / "kimi"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("#!/bin/sh\n", encoding="utf-8")
+    legacy.chmod(0o755)
+
+    monkeypatch.delenv("LEARN_UK_KIMI_BIN", raising=False)
+    monkeypatch.setattr(kimi_adapter.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(kimi_adapter.Path, "home", lambda: home)
+
+    assert kimi_adapter._resolve_kimi_binary() == str(legacy)

--- a/tests/test_start_kimi_launcher.py
+++ b/tests/test_start_kimi_launcher.py
@@ -300,3 +300,35 @@ def test_unknown_model_rejected_before_launch(tmp_path: Path) -> None:
     )
     assert result.returncode == 1
     assert "unknown --model" in result.stderr
+
+
+def test_hermes_install_preferred_over_legacy_binary(tmp_path: Path) -> None:
+    """With no kimi on PATH, the launcher must pick ~/.hermes/node/bin/kimi
+    (maintained npm install) over the legacy ~/.kimi-code/bin/kimi binary."""
+    project, _supervisor_capture = _build_fake_project(tmp_path)
+    home = tmp_path / "home"
+    hermes_bin = home / ".hermes" / "node" / "bin"
+    legacy_bin = home / ".kimi-code" / "bin"
+    hermes_bin.mkdir(parents=True)
+    legacy_bin.mkdir(parents=True)
+    capture = tmp_path / "which-kimi.txt"
+    _write_executable(hermes_bin / "kimi", f'#!/usr/bin/env bash\necho hermes > "{capture}"\n')
+    _write_executable(legacy_bin / "kimi", f'#!/usr/bin/env bash\necho legacy > "{capture}"\n')
+
+    env = _clean_environ()
+    env.pop("LEARN_UK_KIMI_BIN", None)
+    env["HOME"] = os.fspath(home)
+    # Deliberately no kimi anywhere on PATH: forces the explicit fallback chain.
+    env["PATH"] = "/usr/bin:/bin:/opt/homebrew/bin"
+
+    result = subprocess.run(
+        [os.fspath(project / "start-kimi.sh"), "hi"],
+        cwd=project,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert capture.read_text(encoding="utf-8").strip() == "hermes"


### PR DESCRIPTION
## Summary

Two kimi installs coexist on the operator machine:

| install | version | nature |
| --- | --- | --- |
| `~/.hermes/node/bin/kimi` → `@moonshot-ai/kimi-code` (npm) | **0.28.1** | maintained, updated via npm (Jul 21) |
| `~/.kimi-code/bin/kimi` (+ `kimi.bak` 0.26.0) | 0.27.0 | legacy standalone binary (Jul 17) |

`start-kimi.sh` prepended `~/.kimi-code/bin` to PATH, so the **stale binary always won**; the agent-runtime adapter (`delegate.py` / bridge headless path) had the same legacy-first fallback when PATH is minimal.

Changes:

- `start-kimi.sh`: prepend `~/.hermes/node/bin`; candidate chain `LEARN_UK_KIMI_BIN` → `command -v kimi` → `~/.hermes/node/bin/kimi` → `~/.kimi-code/bin/kimi` (last resort).
- `scripts/agent_runtime/adapters/kimi.py`: same hermes-before-legacy order in `_resolve_kimi_binary`.
- `docs/SCRIPTS.md`: preference documented.

## Verification

- Live: `./start-kimi.sh --model k3 ...` now reports `Kimi: 0.28.1` and completes a headless prompt.
- Tests: launcher fallback-order test (no kimi on PATH → hermes fake beats legacy fake), adapter resolution tests (hermes preferred / legacy fallback). **28/28 pass**; ruff, shellcheck, markdownlint clean.

The legacy binary is left in place as a fallback — nothing is deleted.

X-Agent: kimi/kimi-binary-preference
