### PR TITLE
docs(scripts): document the CodexBar kimi-credential launchd refresh agent

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -112,7 +112,8 @@ refreshes CLI-owned credentials): the launchd agent
 `~/Library/LaunchAgents/com.learnukrainian.kimi-coding-oauth.plist` runs
 `scripts/lib/kimi_coding_oauth.py token` every 10 minutes (stdout to
 /dev/null, errors to `~/.kimi-code/logs/oauth-refresh.log`). Manage with
-`launchctl bootout|bootstrap gui/$(id -u)/com.learnukrainian.kimi-coding-oauth`.
+`launchctl bootout gui/$(id -u)/com.learnukrainian.kimi-coding-oauth` (unload)
+and `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.learnukrainian.kimi-coding-oauth.plist` (load).
 
 | Model alias | Platform model id | Context | Auto-compact |
 | --- | --- | --- | --- |

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -107,6 +107,13 @@ token on a schedule (`CLAUDE_CODE_API_KEY_HELPER_TTL_MS`, default 300000).
 Without isolation the token is fixed at launch — fine for short sessions.
 `KIMICC_DRY_RUN=1` prints the resolved route/auth and exits before launch.
 
+The same helper also keeps CodexBar's Kimi tile alive (CodexBar never
+refreshes CLI-owned credentials): the launchd agent
+`~/Library/LaunchAgents/com.learnukrainian.kimi-coding-oauth.plist` runs
+`scripts/lib/kimi_coding_oauth.py token` every 10 minutes (stdout to
+/dev/null, errors to `~/.kimi-code/logs/oauth-refresh.log`). Manage with
+`launchctl bootout|bootstrap gui/$(id -u)/com.learnukrainian.kimi-coding-oauth`.
+
 | Model alias | Platform model id | Context | Auto-compact |
 | --- | --- | --- | --- |
 | `k3` (default) | `kimi-k3[1m]` | 1 048 576 | 996 147 |


### PR DESCRIPTION
## Summary

One-paragraph docs addition closing the last open checkbox of #5596: the KimiCC section of `docs/SCRIPTS.md` now documents the launchd agent (`~/Library/LaunchAgents/com.learnukrainian.kimi-coding-oauth.plist`) that runs `scripts/lib/kimi_coding_oauth.py token` every 10 minutes, keeping the OAuth credential fresh so CodexBar's Kimi tile stays live during idle periods (CodexBar never refreshes CLI-owned credentials by design). Includes log location and bootout/bootstrap management commands.

Markdownlint clean; docs-only change.

X-Agent: kimi/codexbar-refresh-doc
