### PR TITLE
feat(fleet): orchestrator escalate pins Sol / Fable / Pro (#5512)

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -90,18 +90,25 @@ Machine-readable pins: `scripts/config/model_catalog.yaml` → `orchestrator_sea
   implementation on the orchestrator seat — delegate it (>50 LOC non-test, mechanical, fixtures, or
   anything parallelizable → a worker).
 
-  | Seat | Default model | Effort | Notes |
+  | Seat | Default (loop) | Escalate (deep) | Notes |
   | --- | --- | --- | --- |
-  | **claude** | `claude-sonnet-5` | high | Practical orchestrator default; escalate Fable/Opus only when judgment requires it |
-  | **codex** | `gpt-5.6-terra` | high | Native sealed formal CF default for `review-pr` |
-  | **grok** | `grok-4.5` | high | Native first; Cursor **explicit** `grok-4.5` if native dark |
-  | **agy** | **`gemini-3.6-flash-high`** | **high** | **Google-family orchestrator (user 2026-07-21).** Pro only for deep single-shot, not the default loop |
+  | **claude** | `claude-sonnet-5` @ high | **`claude-fable-5` @ xhigh** | Same pattern as AGY Flash→Pro |
+  | **codex** | `gpt-5.6-terra` @ high | **`gpt-5.6-sol` @ xhigh** | Terra loop; Sol for architecture / hard judgment |
+  | **grok** | `grok-4.5` @ high | same SKU (no higher pin yet) | Cursor **explicit** `grok-4.5` = availability fallback, not quality escalate |
+  | **agy** | `gemini-3.6-flash-high` @ high | **`gemini-3.1-pro-high` @ high** | Flash loop; Pro deep single-shot |
+
+  **Escalate when:** deep single-shot, architecture, hard multi-file judgment, high-stakes synthesis —
+  not for routine queue grind. Machine fields: `escalate_model_id` / `escalate_effort` /
+  `escalate_when` on each seat in `model_catalog.yaml`.
 
   When an orchestrator needs **formal sealed CF**, request it via
   `review-pr --reviewer codex|claude|glm` (agy|kimi|grok remain `formal_review_eligible: false`
-  until #5555–#5557). AGY as *orchestrator* is live now; AGY as *sealed formal reviewer* is not.
+  until #5555–#5557). Authority CF escalate:
+  `review-pr <N> --model gpt-5.6-sol --effort xhigh` or
+  `review-pr <N> --reviewer claude --model claude-fable-5 --effort xhigh`.
 
-- **Advisor = `gpt-5.6-sol` @ `xhigh` (on-demand, NOT a standing worker).** Convene for the hard,
+- **Advisor = `gpt-5.6-sol` @ `xhigh` (on-demand, NOT a standing worker).** Same as codex
+  orchestrator escalate — convene for the hard,
   high-judgment calls only: architecture, high-stakes design/spec/ADR review, difficult debugging, final
   synthesis. Consult BEFORE committing a substantive design; do not use for routine work.
 - **Workers = every other lane** — `gpt-5.6-luna`, `cursor`, `kimi`, `deepseek`, `pool` (**Laguna family exact IDs:** default **`laguna-s-2.1`** gen-2 S; light **`laguna-xs-2.1`** gen-2 XS; fallback only **`laguna-m.1`** gen-1 — never invent s2/m2 orthography),

--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -65,20 +65,23 @@ file handoffs remain authoritative until then.
 Any of these may own a cold-start / drive-board loop. Pins live in
 `scripts/config/model_catalog.yaml` → `orchestrator_seats`.
 
-| Seat | Model | Effort | Sealed formal CF as *reviewer* |
+| Seat | Default (loop) | Escalate (deep) | Sealed formal CF as *reviewer* |
 | --- | --- | --- | --- |
-| **claude** | `claude-sonnet-5` | high | yes (`review-pr --reviewer claude`) |
-| **codex** | `gpt-5.6-terra` | high | yes (default `review-pr`) |
-| **grok** | `grok-4.5` (Cursor explicit if native dark) | high | no until #5557 |
-| **agy** | **`gemini-3.6-flash-high`** | **high** | no until #5555 — still *requests* CF via review-pr |
+| **claude** | `claude-sonnet-5` @ high | **`claude-fable-5` @ xhigh** | yes (`review-pr --reviewer claude`) |
+| **codex** | `gpt-5.6-terra` @ high | **`gpt-5.6-sol` @ xhigh** | yes (default `review-pr`) |
+| **grok** | `grok-4.5` @ high | same SKU (Cursor = avail. fallback) | no until #5557 |
+| **agy** | `gemini-3.6-flash-high` @ high | **`gemini-3.1-pro-high` @ high** | no until #5555 — still *requests* CF |
 
-AGY start (orchestrator loop, not sealed reviewer):
+Escalate when: architecture, hard multi-file judgment, high-stakes synthesis — not routine queue.
 
 ```bash
-.venv/bin/python scripts/delegate.py dispatch --agent agy --model gemini-3.6-flash-high \
-  --mode danger --worktree --task-id <stream-task> --prompt-file BRIEF
-# or interactive / bridge:
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - --task-id agy-orch --to-model gemini-3.6-flash-high
+# AGY default / escalate
+.venv/bin/python scripts/delegate.py dispatch --agent agy --model gemini-3.6-flash-high ...
+.venv/bin/python scripts/delegate.py dispatch --agent agy --model gemini-3.1-pro-high ...
+# Codex escalate
+.venv/bin/python scripts/delegate.py dispatch --agent codex --model gpt-5.6-sol ...
+# Claude escalate
+.venv/bin/python scripts/delegate.py dispatch --agent claude --model claude-fable-5 ...
 ```
 
 ## Formal CF defaults (orchestrator-ready)
@@ -89,6 +92,9 @@ Practical seats @ **high** — not Sol/Fable on routine PRs:
 .venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N>              # codex / gpt-5.6-terra @ high
 .venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer claude  # claude-sonnet-5 @ high
 .venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer glm     # glm-5.2 LOCAL-ONLY
+# Authority escalate (critical / hard judgment only):
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --model gpt-5.6-sol --effort xhigh
+.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N> --reviewer claude --model claude-fable-5 --effort xhigh
 .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-pool ...  # default Laguna S 2.1
 .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-pool ... --model poolside/poolside/laguna-xs-2.1  # XS 2.1 light
 ```

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -219,13 +219,16 @@ def register_review_pr_parser(subparsers: Any) -> None:
         default=None,
         help=(
             "Override formal CF model pin "
-            "(default: codex→gpt-5.6-terra, claude→claude-sonnet-5, glm→glm-5.2)"
+            "(default: codex→gpt-5.6-terra, claude→claude-sonnet-5, glm→glm-5.2; "
+            "authority escalate: gpt-5.6-sol / claude-fable-5)"
         ),
     )
     parser.add_argument(
         "--effort",
         default=None,
-        help="Override formal CF effort pin (default: high for codex/claude)",
+        help=(
+            "Override formal CF effort pin (default: high; authority escalate: xhigh)"
+        ),
     )
     parser.add_argument(
         "--claude-available",

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -456,25 +456,40 @@ review_candidates:
 # cold-start loop (prioritize → delegate → CF → merge-in-lane). Formal *sealed*
 # CF remains fail-closed on agy|kimi|grok until #5555–#5557; orchestrators still
 # *request* CF via review-pr codex|claude|glm.
+# Parallel escalate ladder (user 2026-07-22): practical default + authority deep.
+# Same shape for every orchestrator seat — like AGY Flash → Pro.
 orchestrator_seats:
   claude:
     model_id: claude-sonnet-5
     effort: high
-    note: practical default for routine orchestrator judgment; escalate to Fable/Opus only when needed
+    escalate_model_id: claude-fable-5
+    escalate_effort: xhigh
+    escalate_when: deep_single_shot_or_architecture
+    note: default Sonnet 5 @ high; escalate Fable 5 @ xhigh (Opus only if Fable unavailable)
   codex:
     model_id: gpt-5.6-terra
     effort: high
+    escalate_model_id: gpt-5.6-sol
+    escalate_effort: xhigh
+    escalate_when: deep_single_shot_or_architecture
+    note: default Terra @ high; escalate Sol @ xhigh for architecture / hard judgment
   grok:
     model_id: grok-4.5
     effort: high
+    # No higher Grok SKU in catalog yet — keep native pin; Cursor pin is availability fallback only.
+    escalate_model_id: grok-4.5
+    escalate_effort: high
+    escalate_when: n/a_same_sku
     fallback_transport: cursor
     fallback_model_id: grok-4.5
+    note: native grok-4.5; Cursor explicit grok-4.5 if native dark (not a quality escalate)
   agy:
     model_id: gemini-3.6-flash-high
     effort: high
     escalate_model_id: gemini-3.1-pro-high
+    escalate_effort: high
     escalate_when: deep_single_shot_or_architecture
-    note: Google-family orchestrator (user 2026-07-21); Flash default loop; Pro escalate only
+    note: Google-family orchestrator; Flash default loop; Pro escalate only
 
 # Formal CF transport defaults for review-pr (model + effort). Authority seats
 # (Sol/Fable/Opus) are critical-ladder only — not routine review-pr pins.
@@ -482,9 +497,14 @@ formal_cf_defaults:
   codex:
     model_id: gpt-5.6-terra
     effort: high
+    # Authority escalate for critical / hard CF (review-pr --model gpt-5.6-sol --effort xhigh)
+    escalate_model_id: gpt-5.6-sol
+    escalate_effort: xhigh
   claude:
     model_id: claude-sonnet-5
     effort: high
+    escalate_model_id: claude-fable-5
+    escalate_effort: xhigh
   glm:
     model_id: glm-5.2
     effort: high

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -138,8 +138,10 @@ def test_fable_routes_native_claude_before_pinned_cursor_fallback():
 
 def test_formal_cf_defaults_pin_practical_seats_at_high_effort():
     defaults = load_model_catalog()["formal_cf_defaults"]
-    assert defaults["codex"] == {"model_id": "gpt-5.6-terra", "effort": "high"}
-    assert defaults["claude"] == {"model_id": "claude-sonnet-5", "effort": "high"}
+    assert defaults["codex"]["model_id"] == "gpt-5.6-terra"
+    assert defaults["codex"]["effort"] == "high"
+    assert defaults["claude"]["model_id"] == "claude-sonnet-5"
+    assert defaults["claude"]["effort"] == "high"
     assert defaults["glm"]["model_id"] == "glm-5.2"
     assert defaults["pool"]["model_id"] == "poolside/laguna-s-2.1"
     assert defaults["grok"]["fallback_transport"] == "cursor"
@@ -158,6 +160,21 @@ def test_orchestrator_seats_include_agy_flash_36_high():
     assert seats["codex"]["model_id"] == "gpt-5.6-terra"
     assert seats["claude"]["model_id"] == "claude-sonnet-5"
     assert seats["grok"]["fallback_model_id"] == "grok-4.5"
+
+
+def test_orchestrator_escalate_pins_parallel_sol_fable_pro():
+    """Each seat has default + escalate like AGY Flash→Pro (user 2026-07-22)."""
+    seats = load_model_catalog()["orchestrator_seats"]
+    assert seats["codex"]["escalate_model_id"] == "gpt-5.6-sol"
+    assert seats["codex"]["escalate_effort"] == "xhigh"
+    assert seats["claude"]["escalate_model_id"] == "claude-fable-5"
+    assert seats["claude"]["escalate_effort"] == "xhigh"
+    assert seats["agy"]["escalate_model_id"] == "gemini-3.1-pro-high"
+    assert seats["agy"]["escalate_effort"] == "high"
+    # formal CF authority escalate mirrors orchestrator escalate
+    fc = load_model_catalog()["formal_cf_defaults"]
+    assert fc["codex"]["escalate_model_id"] == "gpt-5.6-sol"
+    assert fc["claude"]["escalate_model_id"] == "claude-fable-5"
 
 
 def test_practical_ladders_exclude_authority_seats():


### PR DESCRIPTION
## Summary

Parallel **default → escalate** pins for every orchestrator seat (same shape as AGY Flash→Pro):

| Seat | Default (loop) | Escalate (deep) |
| --- | --- | --- |
| codex | `gpt-5.6-terra` @ high | **`gpt-5.6-sol` @ xhigh** |
| claude | `claude-sonnet-5` @ high | **`claude-fable-5` @ xhigh** |
| agy | `gemini-3.6-flash-high` @ high | **`gemini-3.1-pro-high` @ high** |
| grok | `grok-4.5` @ high | same SKU (Cursor = availability only) |

Also on `formal_cf_defaults` for authority CF:
```bash
review-pr <N> --model gpt-5.6-sol --effort xhigh
review-pr <N> --reviewer claude --model claude-fable-5 --effort xhigh
```

## Test plan
- [x] `pytest tests/test_model_catalog.py`
- [x] pre-commit

Related: #5512 #4707