### PR TITLE
fix(review): sealed CF relocates line_mismatch when quote is found (#5285)

### DIFF
--- a/scripts/ai_agent_bridge/_review_worktree.py
+++ b/scripts/ai_agent_bridge/_review_worktree.py
@@ -36,7 +36,9 @@ if str(_REPO_ROOT) not in sys.path:
 
 from scripts.orchestration.task_identity import DEFAULT_REPOSITORY
 from scripts.review.evidence import (
+    OUTCOME_LINE_MISMATCH,
     OUTCOME_VERIFIED,
+    expected_end_line_for_quote,
     split_lines_preserve_content,
     verify_finding_evidence,
 )
@@ -1341,6 +1343,30 @@ def _deleted_file_evidence(manifest: dict[str, Any]) -> dict[str, str]:
     return evidence
 
 
+def _relocate_finding_to_matched_line(
+    finding: dict[str, Any],
+    matched_line: int,
+) -> dict[str, Any] | None:
+    """Return a copy of *finding* with location shifted to *matched_line*.
+
+    Used when sealed-review evidence finds the verbatim quote on a different
+    line than the model claimed (``line_mismatch:matched_at_line:N``). Inflated
+    or shortened ranges are not relocated — those stay fail-closed.
+    """
+    if matched_line < 1:
+        return None
+    location = finding.get("location")
+    verbatim = finding.get("verbatim")
+    if not isinstance(location, dict) or not isinstance(verbatim, str) or not verbatim:
+        return None
+    relocated = dict(finding)
+    new_loc = dict(location)
+    new_loc["start_line"] = matched_line
+    new_loc["end_line"] = expected_end_line_for_quote(matched_line, verbatim)
+    relocated["location"] = new_loc
+    return relocated
+
+
 def validate_code_review_response(
     response: str,
     *,
@@ -1417,6 +1443,7 @@ def validate_code_review_response(
                         target=target,
                         changed_lines=finding_lines,
                     )
+                    evidence_for_relocate = deleted_root
             else:
                 result = verify_finding_evidence(
                     finding,
@@ -1424,6 +1451,26 @@ def validate_code_review_response(
                     target=target,
                     changed_lines=finding_lines,
                 )
+                evidence_for_relocate = evidence_root
+            # Sealed CF path: if the quote is real but the claimed line is off,
+            # relocate to the matched line and re-verify. Prevents hard-fail on
+            # honest findings with drifted line numbers (Codex line_mismatch F001).
+            # Inflated ranges / missing quotes still fail closed.
+            if (
+                result.outcome == OUTCOME_LINE_MISMATCH
+                and isinstance(finding, dict)
+                and result.matched_line is not None
+                and "matched_at_line:" in (result.detail or "")
+                and "range_span_mismatch" not in (result.detail or "")
+            ):
+                relocated = _relocate_finding_to_matched_line(finding, result.matched_line)
+                if relocated is not None:
+                    result = verify_finding_evidence(
+                        relocated,
+                        repo_root=evidence_for_relocate,
+                        target=target,
+                        changed_lines=finding_lines,
+                    )
             if result.outcome != OUTCOME_VERIFIED:
                 finding_id = finding.get("id", "unknown") if isinstance(finding, dict) else "unknown"
                 raise ReviewWorktreeError(

--- a/scripts/ai_agent_bridge/_review_worktree.py
+++ b/scripts/ai_agent_bridge/_review_worktree.py
@@ -1367,6 +1367,41 @@ def _relocate_finding_to_matched_line(
     return relocated
 
 
+def _verify_finding_with_optional_line_relocate(
+    finding: dict[str, Any],
+    *,
+    repo_root: Path,
+    target: CanonicalReviewTarget,
+    changed_lines: dict[str, set[int]],
+):
+    """Verify finding; if quote exists on another line, relocate and re-verify.
+
+    Must be called while *repo_root* still exists (deleted-file temp dirs must
+    stay open for both passes).
+    """
+    result = verify_finding_evidence(
+        finding,
+        repo_root=repo_root,
+        target=target,
+        changed_lines=changed_lines,
+    )
+    if (
+        result.outcome == OUTCOME_LINE_MISMATCH
+        and result.matched_line is not None
+        and "matched_at_line:" in (result.detail or "")
+        and "range_span_mismatch" not in (result.detail or "")
+    ):
+        relocated = _relocate_finding_to_matched_line(finding, result.matched_line)
+        if relocated is not None:
+            result = verify_finding_evidence(
+                relocated,
+                repo_root=repo_root,
+                target=target,
+                changed_lines=changed_lines,
+            )
+    return result
+
+
 def validate_code_review_response(
     response: str,
     *,
@@ -1425,6 +1460,8 @@ def validate_code_review_response(
             ):
                 old_text = deleted_evidence.get(path)
             finding_lines = canonical_lines
+            if not isinstance(finding, dict):
+                raise ReviewWorktreeError("review_response_evidence:unknown:malformed:finding_not_object")
             if old_text is not None:
                 finding_lines = dict(canonical_lines)
                 old_line_count = len(split_lines_preserve_content(old_text))
@@ -1437,40 +1474,20 @@ def validate_code_review_response(
                     deleted_path.parent.mkdir(parents=True, exist_ok=True)
                     deleted_path.write_text(old_text, encoding="utf-8")
                     deleted_path.chmod(0o400)
-                    result = verify_finding_evidence(
+                    # Both verify + optional relocate while temp root is alive.
+                    result = _verify_finding_with_optional_line_relocate(
                         finding,
                         repo_root=deleted_root,
                         target=target,
                         changed_lines=finding_lines,
                     )
-                    evidence_for_relocate = deleted_root
             else:
-                result = verify_finding_evidence(
+                result = _verify_finding_with_optional_line_relocate(
                     finding,
                     repo_root=evidence_root,
                     target=target,
                     changed_lines=finding_lines,
                 )
-                evidence_for_relocate = evidence_root
-            # Sealed CF path: if the quote is real but the claimed line is off,
-            # relocate to the matched line and re-verify. Prevents hard-fail on
-            # honest findings with drifted line numbers (Codex line_mismatch F001).
-            # Inflated ranges / missing quotes still fail closed.
-            if (
-                result.outcome == OUTCOME_LINE_MISMATCH
-                and isinstance(finding, dict)
-                and result.matched_line is not None
-                and "matched_at_line:" in (result.detail or "")
-                and "range_span_mismatch" not in (result.detail or "")
-            ):
-                relocated = _relocate_finding_to_matched_line(finding, result.matched_line)
-                if relocated is not None:
-                    result = verify_finding_evidence(
-                        relocated,
-                        repo_root=evidence_for_relocate,
-                        target=target,
-                        changed_lines=finding_lines,
-                    )
             if result.outcome != OUTCOME_VERIFIED:
                 finding_id = finding.get("id", "unknown") if isinstance(finding, dict) else "unknown"
                 raise ReviewWorktreeError(

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -1694,6 +1694,70 @@ def test_deleted_file_finding_uses_hash_bound_old_side_evidence(tmp_path: Path) 
         )
 
 
+def test_deleted_file_line_mismatch_relocates_while_temp_root_alive(tmp_path: Path) -> None:
+    """Multi-line deleted old_text + wrong claim line still relocates inside TemporaryDirectory."""
+    evidence_root = tmp_path / "evidence"
+    bundle = evidence_root / ".review-bundle"
+    bundle.mkdir(parents=True)
+    old_content = "header()\nrequired_registration()\nfooter()\n"
+    encoded = old_content.encode("utf-8")
+    (bundle / "manifest.json").write_text(
+        json.dumps(
+            {
+                "deleted_files": [
+                    {
+                        "path": "src/registry.py",
+                        "mode": 0o644,
+                        "sha256": hashlib.sha256(encoded).hexdigest(),
+                        "bytes": len(encoded),
+                        "content": old_content,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    payload = {
+        "schema_version": "code-review-findings.v1",
+        "overall": {
+            "correctness": "incorrect",
+            "explanation": "A required registration was deleted.",
+            "confidence": 0.95,
+        },
+        "findings": [
+            {
+                "id": "F001",
+                "title": "Restore the required registration",
+                "body": "Deleting the registration breaks startup.",
+                "priority": "P1",
+                "confidence": 0.95,
+                "category": "regression",
+                "location": {
+                    "path": "src/registry.py",
+                    # Claim line 1; quote actually lives on line 2 of old_text.
+                    "start_line": 1,
+                    "end_line": 1,
+                    "claim_type": "present",
+                },
+                "verbatim": "required_registration()",
+                "why_wrong": "The startup path still requires this registration.",
+                "smallest_fix": "Restore the deleted registration.",
+                "sources": ["none"],
+            }
+        ],
+    }
+    digest = review_worktree.validate_code_review_response(
+        json.dumps(payload),
+        base_sha="b" * 40,
+        head_sha="a" * 40,
+        patch_sha256="c" * 64,
+        changed_paths=("src/registry.py",),
+        evidence_root=evidence_root,
+        changed_lines={"src/registry.py": frozenset()},
+    )
+    assert len(digest) == 64
+
+
 def test_provision_review_worktree_fetches_origin_head_and_reaps_on_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -1574,6 +1574,7 @@ def test_review_response_schema_is_canonical_strict_and_surface_bound(tmp_path: 
     payload["findings"][0]["location"]["path"] = "src/app.py"
     payload["findings"][0]["location"]["start_line"] = 999
     payload["findings"][0]["location"]["end_line"] = 999
+    payload["findings"][0]["verbatim"] = "not_present_in_file = True"
     with pytest.raises(review_worktree.ReviewWorktreeError, match="review_response_evidence"):
         review_worktree.validate_code_review_response(
             json.dumps(payload),
@@ -1584,6 +1585,22 @@ def test_review_response_schema_is_canonical_strict_and_surface_bound(tmp_path: 
             evidence_root=evidence_root,
             changed_lines={"src/app.py": frozenset({1})},
         )
+
+    # Quote exists at line 2 but model claimed line 1 → relocate + accept (sealed CF).
+    (evidence_root / "src" / "app.py").write_text("keep = 1\nbad = True\n", encoding="utf-8")
+    payload["findings"][0]["location"]["start_line"] = 1
+    payload["findings"][0]["location"]["end_line"] = 1
+    payload["findings"][0]["verbatim"] = "bad = True"
+    relocated_digest = review_worktree.validate_code_review_response(
+        json.dumps(payload),
+        base_sha=base,
+        head_sha=head,
+        patch_sha256=patch,
+        changed_paths=("src/app.py",),
+        evidence_root=evidence_root,
+        changed_lines={"src/app.py": frozenset({1, 2})},
+    )
+    assert len(relocated_digest) == 64
 
     legacy = {
         "schema_version": "code-review-findings.v1",


### PR DESCRIPTION
## Summary

Sealed formal CF (`validate_code_review_response`) was hard-failing when Codex (or any reviewer) cited the right `verbatim` on the wrong line number:

`review_response_evidence:F001:line_mismatch:matched_at_line:N`

**Fix:** if the quote is found at another line (not a range-span inflation), relocate the finding to `matched_at_line` and re-verify. Still fail-closed for missing quotes and inflated ranges.

Standalone `verify_review` / CLI evidence behavior is unchanged.

## Test plan
- [x] `pytest tests/ai_agent_bridge/test_review_worktree.py` (56)

Related: #5285 fleet-comms formal CF reliability