### PR TITLE
docs(session): bind next cold-start to #5512 cutovers

### DIFF
--- a/docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md
+++ b/docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md
@@ -1,0 +1,97 @@
+---
+session: "Fleet-comms #5512 — operator cutovers are NEXT SESSION primary targets (binding)"
+date: 2026-07-22
+epic: 5512
+stream: 4707
+status: open
+priority: P0-next-cold-start
+---
+
+# 2026-07-22 — Fleet-comms cutover handoff (binding for next cold-start)
+
+**Do not wait for the operator to restate targets.** On cold-start, orient then **execute** the queue below.
+
+## NEXT SESSION — PRIMARY TARGETS (binding)
+
+**Epic:** [#5512](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5512) Fleet Communications System v1  
+**Stream:** [#4707](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4707) infra-harness
+
+### Item 2 — Operator cutovers (DO THESE FIRST)
+
+1. **Message-plane dual_write cutover after parity**
+   - Check: `.venv/bin/python -m scripts.fleet_comms plane-status`
+   - Expect: was `mode: off` / dual_write not default — cutover only after parity receipt
+   - Streams: `session_streams dual-write-status` / `inventory --register` (17/17 ok, drift=0 previously)
+   - **No silent flip** — record parity evidence, then operator/advisor-approved enable
+
+2. **Retention Gate 5 — daily dry-run × ≥7 days before scheduled apply**
+   - Command: `.venv/bin/python scripts/hygiene/retention_engine.py plan` (dry-run only)
+   - **7d = observation window**, not data TTL (`stale_hours` default 72; apply still OFF)
+   - Confirm plans stable; no active/leased work in `would_reap`
+   - Only then enable scheduled **apply** (never arm example plist blindly)
+   - API: `curl -s http://localhost:8765/api/ops/v1/retention/latest`
+
+3. **Cold-start smoke — Claude + Grok + Codex + AGY**
+   - Prove launchers/streams without manual folklore
+   - AGY: `./start-gemini.sh --epic harness` (default `gemini-3.6-flash-high`; Pro escalate)
+   - Claude infra: `./start-claude.sh --epic harness` / `--agent infra-orchestrator`
+   - Grok / Codex: project start scripts + stream lease for epic 4707
+
+### Parallel (do not block cutovers)
+
+**Isolation fan-out** under #5555–#5557 — design spikes first, then wire, then enable:
+
+| Family | Parent | Design | Wire | Enable |
+| --- | --- | --- | --- | --- |
+| AGY | #5555 | #5614 | #5615 | #5616 |
+| Kimi | #5556 | #5617 | #5618 | #5619 |
+| Grok | #5557 | #5620 | #5621 | #5622 |
+
+**Hard rule:** do **not** flip `formal_review_eligible` without wire green + cross-family CF on enablement PR.  
+Until flip: formal CF = `review-pr` codex|claude|glm (Terra/Sonnet5/GLM @ high; Sol/Fable escalate for hard only).
+
+## Already on main (do not re-litigate)
+
+| Ship | PR / note |
+| --- | --- |
+| Practical formal CF pins + Laguna S/XS/M.1 + AGY orchestrator seat | #5602 |
+| Escalate: Sol / Fable / Pro parallel to AGY Pro | #5611 |
+| Sealed CF line_mismatch relocate | #5613 |
+| Metrics / backlog / dead-letters / github-metrics | #5584 PR-M |
+| Retention plan/apply engine (apply default OFF) | #5585 PR-L |
+| Sol phases 0–5 thin review program | #5484 closed |
+
+## Orient at cold-start
+
+```bash
+cd ~/projects/learn-ukrainian
+git fetch origin main --prune && git status -sb
+git pull --ff-only origin main
+curl -sS --max-time 2 "http://127.0.0.1:8765/api/orient?lean=true" || true
+.venv/bin/python -m scripts.fleet_comms plane-status
+.venv/bin/python -m agents_extensions.shared.session_streams dual-write-status
+.venv/bin/python scripts/hygiene/retention_engine.py plan
+gh issue view 5512
+# This brief is authoritative for next actions:
+# docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md
+```
+
+## Operating rules (unchanged)
+
+- Implementation only under `.worktrees/dispatch/<agent>/<task>/`
+- `X-Agent` trailer on every commit
+- Cross-family `review-pr` before merge; arm auto-merge after gate
+- No architecture cutover without present-tense operator/advisor approval when required by Gate C/A
+
+## Out of scope for this handoff queue
+
+- Atlas/practice product epics unless cutovers are green and capacity remains
+- Isolation enablement before design+wire complete
+- Inventing a competing fleet-comms design
+
+## Done when (cutover slice)
+
+- [ ] Plane dual_write: parity receipt + approved cutover state (or explicit deferred with owner)
+- [ ] Retention: ≥1 plan run recorded this session + 7d plan log started/continued; apply still OFF until day 7
+- [ ] Cold-start smoke: evidence comment on #5512 for Claude + Grok + Codex + AGY
+- [ ] Isolation: at least design spikes moving or dispatched (#5614/#5617/#5620) without blocking cutovers

--- a/docs/session-state/codex-orchestrator-handoff.md
+++ b/docs/session-state/codex-orchestrator-handoff.md
@@ -1,6 +1,6 @@
-# Current - Codex / Grok Orchestrator Handoff (2026-07-19)
+# Current - Codex / Grok Orchestrator Handoff (2026-07-22)
 
-Latest-Brief: docs/session-state/2026-07-19-orchestrator-practice-atlas-fleet-comms-finish-brief.md
+Latest-Brief: docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md
 
 ## Role
 
@@ -13,25 +13,49 @@ Do not use `docs/session-state/current.md` as scratch space. Durable state lives
 the Latest-Brief above and this file. Thread rollover packets live under
 `.agent/<agent>-thread-handoff.md` (machine-local).
 
-## Current State (session close 2026-07-19)
+---
 
-Finish wave **closed**. Main at ~`b845eb95b5` (and successors once this handoff PR merges).
+## NEXT SESSION — START HERE (binding)
 
-### Shipped / closed
+**Do not ask the operator what to work on.** Read the Latest-Brief and **execute**.
 
-- Practice chrome dual-locale residuals: **#5479** (#5355)
-- Paronym expansion + apostrophe fix: **#5480**, **#5489** (#4506)
-- Source-backed sentence inventory for daily: **#5487** (#5483 closed)
-- Textbook bulk promote with enrichment floor: **#5477** (#3934); backlog **#5478** open
-- Fleet doctrine + Haiku recon: **#5474**, **#5475**
-- Fleet-comms Sol phases 0–5 epic **#5484** closed via **#5488** (#5485/#5486)
-- Warn-not-reject fat formal PR CF ask (prefer `review-pr`): **#5491**
+### Primary — Fleet-comms #5512 operator cutovers (item 2)
+
+1. **Message-plane dual_write cutover after parity**
+2. **Retention Gate 5** — daily `retention_engine.py plan` dry-run (7d observation before apply)
+3. **Cold-start smoke** — Claude + Grok + Codex + AGY
+
+### Parallel — Isolation fan-out (does not block cutovers)
+
+- #5555 AGY → #5614 design → #5615 wire → #5616 enable  
+- #5556 Kimi → #5617 design → #5618 wire → #5619 enable  
+- #5557 Grok → #5620 design → #5621 wire → #5622 enable  
+
+**Hard rule:** do **not** flip `formal_review_eligible` without wire green + cross-family CF.
+
+Full commands and acceptance: **Latest-Brief** above.
+
+---
+
+## Current State (session close 2026-07-22)
+
+Fleet-comms code/pins largely landed on main (`#5602`, `#5611`, `#5613`, PR-M/L).  
+**Operator cutovers and multi-family isolation enablement remain.**
+
+### Shipped (recent)
+
+- Practical formal CF pins + Laguna S 2.1 / XS 2.1 / M.1 + AGY orchestrator: **#5602**
+- Orchestrator escalate Sol / Fable / Pro: **#5611**
+- Sealed CF line_mismatch relocate: **#5613**
+- Metrics / retention engine (apply default OFF): **#5584**, **#5585**
+- Isolation fan-out tickets: **#5614–#5622** (parents #5555–#5557 reopened)
 
 ### Explicit non-goals for next cold-start
 
-- Do not re-litigate closed fleet-comms phases 0–5
-- Do not re-promote unenriched textbook heads without #5478 enrichment work
-- Do not import Clozemaster as a product; inventory is multi-surface / corpus-first
+- Do not re-litigate Sol phases 0–5 (#5484 closed)
+- Do not invent a competing fleet-comms architecture
+- Do not enable retention **apply** until ≥7 days of dry-run plans are clean
+- Do not flip formal_review_eligible on agy/kimi/grok without isolation wire + CF
 
 ## Operating Rules
 
@@ -41,7 +65,6 @@ Finish wave **closed**. Main at ~`b845eb95b5` (and successors once this handoff 
 - Never touch `.python-version`, `.yamllint`, `.markdownlint.json`
 - No status/audit/review artifact dumps in code PRs
 - CF review gate = independent cross-family `review-pr` (discuss ≠ review)
-- Prefer activity/practice product work over textbook re-enrich unless reprioritized
 
 ## Startup Checks
 
@@ -49,15 +72,17 @@ Finish wave **closed**. Main at ~`b845eb95b5` (and successors once this handoff 
 cd /Users/krisztiankoos/projects/learn-ukrainian
 git fetch origin main --prune
 git status --short --branch
-gh pr list --state open --json number,title,isDraft,mergeStateStatus,headRefName,url --limit 30
+git pull --ff-only origin main
+gh pr list --state open --limit 20
 curl -sS --max-time 2 "http://127.0.0.1:8765/api/orient?lean=true" || true
-# Read latest brief:
-# docs/session-state/2026-07-19-orchestrator-practice-atlas-fleet-comms-finish-brief.md
+# BINDING next targets:
+# docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md
+.venv/bin/python -m scripts.fleet_comms plane-status
+.venv/bin/python scripts/hygiene/retention_engine.py plan
 ```
 
-## Next Focus
+## Next Focus (priority order)
 
-1. Spot-check live daily practice examples (inventory #5487 already merged).
-2. When enrichment capacity is intentional: **#5478** re-enrich held textbook heads.
-3. Atlas/practice depth: #4387, #4700, #4707, #5411 (glosses via enrich, not raw inject).
-4. Infra backlog only when free: #5392, #5400, #5366, #5472 (prep prove-out).
+1. **#5512 cutovers** (dual_write · retention Gate 5 · cold-start smoke) — THIS SESSION
+2. Isolation design spikes in parallel if capacity: #5614 / #5617 / #5620
+3. Only after cutovers green: other #4707 backlog / product streams

--- a/docs/session-state/current.claude-infra.md
+++ b/docs/session-state/current.claude-infra.md
@@ -20,6 +20,10 @@
 3. Use the validated automatic SessionStart rollover output as authoritative. Do not manually parse flat handoff files or leases if a rollover packet was surfaced at startup.
 4. If the SessionStart hook output is unavailable, or the API is down, or the hook explicitly surfaces the legacy file, use the legacy flat file fallback: `.agent/claude-infra-thread-handoff.md` (gitignored, machine-local).
 5. Orient via Monitor API (lean cold-start mode): `curl -s --max-time 2 "http://127.0.0.1:8765/api/orient?lean=true&session=$LEARN_UKRAINIAN_SESSION_ID"`
+6. **BINDING queue (2026-07-22):** read and execute  
+   `docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md`  
+   — fleet-comms **#5512** operator cutovers first (dual_write · retention Gate 5 · cold-start smoke).  
+   Isolation fan-out #5614–#5622 parallel. Do not wait for the operator to restate targets.
 
 
 ## Lane boundaries

--- a/docs/session-state/current.orchestrator.md
+++ b/docs/session-state/current.orchestrator.md
@@ -4,9 +4,16 @@ The durable orchestrator handoff lives at:
 
 `docs/session-state/codex-orchestrator-handoff.md`
 
-**Latest session brief (2026-07-19 finish wave):**
+**Latest session brief (BINDING next cold-start — fleet-comms cutovers):**
 
-`docs/session-state/2026-07-19-orchestrator-practice-atlas-fleet-comms-finish-brief.md`
+`docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md`
+
+**Primary targets (do not wait for operator to restate):**
+
+1. Message-plane dual_write cutover after parity (#5512)
+2. Retention Gate 5 — daily `retention_engine.py plan` × ≥7d before apply
+3. Cold-start smoke Claude + Grok + Codex + AGY  
+   Parallel: isolation fan-out #5614–#5622 (no formal_review_eligible flip without wire+CF)
 
 `docs/session-state/current.md` may still point here for compatibility with
 older cold-start hooks. Do not write detailed session state into this pointer.


### PR DESCRIPTION
## Summary

Durable session handoff so the **next** cold-start agent starts fleet-comms cutovers **without the operator re-prompting**.

### Binding next targets
1. Message-plane dual_write cutover after parity  
2. Retention Gate 5 — daily `retention_engine.py plan` (7d observation before apply)  
3. Cold-start smoke Claude + Grok + Codex + AGY  

Parallel: isolation fan-out #5614–#5622; no `formal_review_eligible` flip without wire+CF.

### Files
- `docs/session-state/2026-07-22-fleet-comms-cutover-handoff.md` (authoritative brief)
- `docs/session-state/codex-orchestrator-handoff.md` (Latest-Brief + START HERE)
- `docs/session-state/current.orchestrator.md` (pointer)
- `docs/session-state/current.claude-infra.md` (cold-start step 6)

Related: #5512 #4707