### PR TITLE
feat(kimicc): default to coding endpoint, isolated config, infra-orchestrator

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -102,10 +102,11 @@ terminal while native Claude runs in the first.
 
 **Defaults (operator lane):** `--endpoint coding` (subscription),
 `--isolate-config` (CLAUDE_CONFIG_DIR=$HOME/.claude-kimicc), and
-`--agent infra-orchestrator`. Overrides: `--endpoint platform`,
-`--no-isolate-config`, `--agent NAME`; env: `KIMICC_ENDPOINT`,
-`KIMICC_ISOLATE_CONFIG=0`, `KIMICC_AGENT` (empty string inherits the project
-settings.json default, curriculum-orchestrator).
+`--agent infra-orchestrator` **when no `--epic` is given** (an epic already
+implies the lane identity). Overrides: `--endpoint platform`,
+`--no-isolate-config`, `--agent NAME` (explicit always wins); env:
+`KIMICC_ENDPOINT`, `KIMICC_ISOLATE_CONFIG=0`, `KIMICC_AGENT` (empty string
+inherits the project settings.json default, curriculum-orchestrator).
 
 **Subscription auth (no platform API key):** run `kimi login` once — the
 launcher picks up the OAuth credential automatically

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -91,22 +91,30 @@ Use it when you want Claude Code ergonomics with K3 or K2.7 in a second
 terminal while native Claude runs in the first.
 
 ```bash
-export MOONSHOT_API_KEY=sk-…   # https://platform.kimi.ai/console/api-keys
-./start-kimicc.sh                    # K3, 1M window / ~996k compact
+./start-kimicc.sh                    # defaults: coding endpoint + isolated config
+                                     # + infra-orchestrator agent, K3, 1M / ~996k compact
 ./start-kimicc.sh --model k2.7       # K2.7 Code, 256k / ~249k compact
 ./start-kimicc.sh --model k2.7-highspeed
-./start-kimicc.sh --endpoint coding  # Kimi Code subscription base URL
-./start-kimicc.sh --isolate-config   # optional CLAUDE_CONFIG_DIR=$HOME/.claude-kimicc
+./start-kimicc.sh --agent curriculum-orchestrator   # explicit --agent always wins
+./start-kimicc.sh --endpoint platform               # pay-as-you-go (needs MOONSHOT_API_KEY)
+./start-kimicc.sh --no-isolate-config               # use live ~/.claude config
 ```
 
-**Subscription auth (no platform API key):** run `kimi login` once, then use
-`--endpoint coding` — the launcher picks up the OAuth credential automatically
+**Defaults (operator lane):** `--endpoint coding` (subscription),
+`--isolate-config` (CLAUDE_CONFIG_DIR=$HOME/.claude-kimicc), and
+`--agent infra-orchestrator`. Overrides: `--endpoint platform`,
+`--no-isolate-config`, `--agent NAME`; env: `KIMICC_ENDPOINT`,
+`KIMICC_ISOLATE_CONFIG=0`, `KIMICC_AGENT` (empty string inherits the project
+settings.json default, curriculum-orchestrator).
+
+**Subscription auth (no platform API key):** run `kimi login` once — the
+launcher picks up the OAuth credential automatically
 (`scripts/lib/kimi_coding_oauth.py`, refresh_token grant against
-`https://auth.kimi.com/api/oauth/token`). OAuth access tokens live ~15 minutes,
-so for sessions longer than that add `--isolate-config`: an `apiKeyHelper` is
-then written into the **isolated** settings.json and Claude Code re-mints the
-token on a schedule (`CLAUDE_CODE_API_KEY_HELPER_TTL_MS`, default 300000).
-Without isolation the token is fixed at launch — fine for short sessions.
+`https://auth.kimi.com/api/oauth/token`). OAuth access tokens live ~15 minutes;
+with the default isolated config an `apiKeyHelper` is written into the
+**isolated** settings.json and Claude Code re-mints the token on a schedule
+(`CLAUDE_CODE_API_KEY_HELPER_TTL_MS`, default 300000). With
+`--no-isolate-config` the token is fixed at launch — fine for short sessions.
 `KIMICC_DRY_RUN=1` prints the resolved route/auth and exits before launch.
 
 The same helper also keeps CodexBar's Kimi tile alive (CodexBar never

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -41,11 +41,17 @@ export PATH="${HOME}/.local/bin:${PATH:-}"
 hash -r 2>/dev/null || true
 
 # Default: Kimi Open Platform Anthropic endpoint (pay-as-you-go API key).
-# Use --endpoint coding for the Kimi Code subscription Anthropic base URL.
-ENDPOINT="${KIMICC_ENDPOINT:-platform}"
+# Defaults: Kimi Code subscription endpoint (OAuth via kimi login), isolated
+# Claude config (apiKeyHelper auto-refresh), infra-lane agent. The pay-as-you-go
+# platform endpoint stays available via --endpoint platform.
+ENDPOINT="${KIMICC_ENDPOINT:-coding}"
 MODEL_ALIAS="${KIMICC_MODEL:-k3}"
 FORWARD_ARGS=()
-ISOLATE_CONFIG=0
+ISOLATE_CONFIG="${KIMICC_ISOLATE_CONFIG:-1}"
+# Default session agent (kimicc is the infra-lane UI). An explicit --agent on
+# the command line always wins; set KIMICC_AGENT="" to inherit the project's
+# settings.json default (curriculum-orchestrator) instead.
+DEFAULT_AGENT="${KIMICC_AGENT-infra-orchestrator}"
 
 usage() {
   cat <<'EOF'
@@ -57,13 +63,21 @@ Does not rewrite ~/.claude/settings.json — original Claude config stays intact
 Options:
   --model ALIAS     k3 (default) | k2.7 | k2.7-highspeed
                     Also accepts full IDs: kimi-k3[1m], kimi-k2.7-code, …
-  --endpoint NAME   platform (default, api.moonshot.ai/anthropic)
-                    coding   (Kimi Code subscription, api.kimi.com/coding)
-  --isolate-config  Use CLAUDE_CONFIG_DIR=$HOME/.claude-kimicc (separate sessions)
+  --endpoint NAME   coding (default; Kimi Code subscription, api.kimi.com/coding)
+                    platform (pay-as-you-go, api.moonshot.ai/anthropic)
+  --isolate-config  Use CLAUDE_CONFIG_DIR=$HOME/.claude-kimicc (DEFAULT; separate
+                    sessions, apiKeyHelper auto-refresh for OAuth)
+  --no-isolate-config
+                    Use the operator's live ~/.claude config instead
+  --agent NAME      Session agent (forwarded to Claude Code). Default:
+                    infra-orchestrator; explicit --agent wins
   -h, --help        Show this help
 
 Environment:
   KIMICC_MODEL / KIMICC_ENDPOINT     Defaults for --model / --endpoint
+  KIMICC_AGENT                     Default agent (default infra-orchestrator;
+                                   empty string = inherit project settings.json default)
+  KIMICC_ISOLATE_CONFIG=0          Same as --no-isolate-config
   MOONSHOT_API_KEY / KIMI_API_KEY    Platform API key (preferred for platform)
   KIMICC_AUTH_TOKEN                  Explicit auth token override
   KIMICC_BASE_URL                    Override Anthropic-compatible base URL
@@ -209,6 +223,10 @@ while (($#)); do
       ISOLATE_CONFIG=1
       shift
       ;;
+    --no-isolate-config)
+      ISOLATE_CONFIG=0
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -229,6 +247,14 @@ case "$ENDPOINT" in
   platform|coding) ;;
   *)
     echo "Error: unsupported endpoint '$ENDPOINT' (use platform or coding)." >&2
+    exit 2
+    ;;
+esac
+
+case "$ISOLATE_CONFIG" in
+  0|1) ;;
+  *)
+    echo "Error: KIMICC_ISOLATE_CONFIG must be 0 or 1 (got '$ISOLATE_CONFIG')." >&2
     exit 2
     ;;
 esac
@@ -396,6 +422,23 @@ for arg in "${FORWARD_ARGS[@]+"${FORWARD_ARGS[@]}"}"; do
   _cleaned+=("$arg")
   _prev="$arg"
 done
+
+# Default the session agent to the infra lane (kimicc is the infra UI); an
+# explicit --agent on the command line always wins.
+_has_agent=0
+for arg in ${_cleaned[@]+"${_cleaned[@]}"}; do
+  case "$arg" in
+    --agent|--agent=*)
+      _has_agent=1
+      break
+      ;;
+  esac
+done
+if [ "$_has_agent" -eq 0 ] && [ -n "$DEFAULT_AGENT" ]; then
+  _cleaned+=(--agent "$DEFAULT_AGENT")
+  echo "        agent=$DEFAULT_AGENT (default; override with --agent)"
+fi
+unset _has_agent
 
 if [ "${KIMICC_DRY_RUN:-0}" = "1" ]; then
   echo "KIMICC_DRY_RUN=1: would exec $PROJECT_DIR/start-claude.sh --model $LEAD_MODEL ${_cleaned[*]+"${_cleaned[*]}"}"

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -70,7 +70,8 @@ Options:
   --no-isolate-config
                     Use the operator's live ~/.claude config instead
   --agent NAME      Session agent (forwarded to Claude Code). Default:
-                    infra-orchestrator; explicit --agent wins
+                    infra-orchestrator when no --epic is given (an epic already
+                    implies the lane identity); explicit --agent wins
   -h, --help        Show this help
 
 Environment:
@@ -423,22 +424,29 @@ for arg in "${FORWARD_ARGS[@]+"${FORWARD_ARGS[@]}"}"; do
   _prev="$arg"
 done
 
-# Default the session agent to the infra lane (kimicc is the infra UI); an
-# explicit --agent on the command line always wins.
+# Default the session agent to the infra lane (kimicc is the infra UI), but
+# only when no epic lane is pinned: an epic already implies the lane identity,
+# and an infra persona on e.g. the atlas lane would be a mismatch. An explicit
+# --agent on the command line always wins.
 _has_agent=0
+_has_epic=0
 for arg in ${_cleaned[@]+"${_cleaned[@]}"}; do
   case "$arg" in
     --agent|--agent=*)
       _has_agent=1
-      break
+      ;;
+    --epic|--epic=*)
+      _has_epic=1
       ;;
   esac
 done
-if [ "$_has_agent" -eq 0 ] && [ -n "$DEFAULT_AGENT" ]; then
+if [ "$_has_agent" -eq 0 ] && [ "$_has_epic" -eq 0 ] && [ -n "$DEFAULT_AGENT" ]; then
   _cleaned+=(--agent "$DEFAULT_AGENT")
   echo "        agent=$DEFAULT_AGENT (default; override with --agent)"
+elif [ "$_has_agent" -eq 0 ] && [ "$_has_epic" -eq 1 ]; then
+  echo "        agent=(epic lane set; identity derives from --epic, no default agent)"
 fi
-unset _has_agent
+unset _has_agent _has_epic
 
 if [ "${KIMICC_DRY_RUN:-0}" = "1" ]; then
   echo "KIMICC_DRY_RUN=1: would exec $PROJECT_DIR/start-claude.sh --model $LEAD_MODEL ${_cleaned[*]+"${_cleaned[*]}"}"

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -522,3 +522,27 @@ def test_epic_plus_explicit_agent_keeps_agent(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert "arg=--epic" in output
     assert "arg=infra-orchestrator" in output
+
+
+def test_isolate_config_env_rejects_invalid_value(tmp_path: Path) -> None:
+    _, result = _run_with_fakes(
+        tmp_path,
+        [],
+        env_overrides={"KIMICC_ISOLATE_CONFIG": "2"},
+    )
+    assert result.returncode == 2
+    assert "KIMICC_ISOLATE_CONFIG must be 0 or 1" in result.stderr
+
+
+def test_empty_kimicc_agent_inherits_project_default(tmp_path: Path) -> None:
+    """KIMICC_AGENT='' (set but empty) suppresses the default --agent injection,
+    so Claude Code falls back to the project settings.json default agent."""
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "platform", "--no-isolate-config"],
+        env_overrides={"KIMICC_AGENT": ""},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "arg=--agent" not in output
+    assert "arg=infra-orchestrator" not in output
+    assert "default; override with --agent" not in result.stdout

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -159,6 +159,8 @@ fi
             "KIMICC_BASE_URL",
             "KIMICC_MODEL",
             "KIMICC_ENDPOINT",
+            "KIMICC_AGENT",
+            "KIMICC_ISOLATE_CONFIG",
             "KIMICC_DRY_RUN",
             "KIMICC_API_KEY_HELPER_TTL_MS",
             "CLAUDE_CODE_API_KEY_HELPER_TTL_MS",
@@ -218,7 +220,11 @@ def test_routes_models_and_compaction(
     compact: str,
     effort: str,
 ) -> None:
-    output, result = _run_with_fakes(tmp_path, arguments)
+    # Explicitly pin the platform endpoint and live config: the launcher
+    # defaults are now coding + isolated config.
+    output, result = _run_with_fakes(
+        tmp_path, ["--endpoint", "platform", "--no-isolate-config", *arguments]
+    )
     assert result.returncode == 0, result.stderr
     assert "base=https://api.moonshot.ai/anthropic" in output
     assert "auth=sk-test-moonshot" in output
@@ -255,7 +261,7 @@ def test_coding_endpoint_uses_subscription_base_and_model_ids(tmp_path: Path) ->
 def test_refuses_settings_json_route_env_pins(tmp_path: Path) -> None:
     output, result = _run_with_fakes(
         tmp_path,
-        [],
+        ["--endpoint", "platform", "--no-isolate-config"],
         settings_env={"ANTHROPIC_BASE_URL": "https://evil.example/anthropic"},
     )
     assert result.returncode == 1
@@ -274,7 +280,7 @@ def test_isolate_config_bypasses_live_settings_pins(tmp_path: Path) -> None:
         settings_env={"ANTHROPIC_BASE_URL": "https://evil.example/anthropic"},
     )
     assert result.returncode == 0, result.stderr
-    assert "base=https://api.moonshot.ai/anthropic" in output
+    assert "base=https://api.kimi.com/coding" in output
     assert str(tmp_path / "home" / ".claude-kimicc") in output or "config_dir=" in output
     assert "config_dir=" in output
     assert "evil.example" not in output
@@ -373,7 +379,7 @@ def test_coding_endpoint_falls_back_to_kimi_login_oauth(tmp_path: Path) -> None:
     cred = _write_oauth_credentials(tmp_path)
     output, result = _run_with_fakes(
         tmp_path,
-        ["--endpoint", "coding"],
+        ["--endpoint", "coding", "--no-isolate-config"],
         env_overrides={
             **_OAUTH_ENV_CLEAR,
             "KIMI_CODE_CREDENTIALS_PATH": str(cred),
@@ -438,3 +444,66 @@ def test_dry_run_resolves_route_without_launching(tmp_path: Path) -> None:
     assert "auth=MOONSHOT_API_KEY" in result.stdout
     # Fake claude was never executed.
     assert output == ""
+
+
+def test_defaults_are_coding_isolated_infra_agent(tmp_path: Path) -> None:
+    """Bare launch: coding endpoint + isolated config + infra-orchestrator agent."""
+    cred = _write_oauth_credentials(tmp_path)
+    output, result = _run_with_fakes(
+        tmp_path,
+        [],
+        env_overrides={
+            **_OAUTH_ENV_CLEAR,
+            "KIMI_CODE_CREDENTIALS_PATH": str(cred),
+            "KIMI_CODE_OAUTH_HOST": "http://127.0.0.1:9",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert "base=https://api.kimi.com/coding" in output
+    # OAuth + isolation → apiKeyHelper mode, no static token exported.
+    assert "auth=unset" in output
+    assert "helper_ttl=300000" in output
+    assert "config_dir=" in output
+    assert ".claude-kimicc" in output
+    # Default agent injected and forwarded.
+    assert "arg=--agent" in output
+    assert "arg=infra-orchestrator" in output
+    assert "agent=infra-orchestrator (default; override with --agent)" in result.stdout
+
+
+def test_explicit_agent_overrides_default(tmp_path: Path) -> None:
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "platform", "--no-isolate-config", "--agent", "curriculum-orchestrator"],
+    )
+    assert result.returncode == 0, result.stderr
+    assert "arg=curriculum-orchestrator" in output
+    assert "arg=infra-orchestrator" not in output
+    assert "default; override with --agent" not in result.stdout
+
+
+def test_no_isolate_config_uses_live_config_dir(tmp_path: Path) -> None:
+    cred = _write_oauth_credentials(tmp_path)
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--no-isolate-config"],
+        env_overrides={
+            **_OAUTH_ENV_CLEAR,
+            "KIMI_CODE_CREDENTIALS_PATH": str(cred),
+            "KIMI_CODE_OAUTH_HOST": "http://127.0.0.1:9",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert "config_dir=unset" in output
+    # Without isolation the OAuth token is exported directly (short-session mode).
+    assert "auth=oauth-acc" in output
+    assert "helper_ttl=unset" in output
+
+
+def test_epic_flag_is_forwarded(tmp_path: Path) -> None:
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "platform", "--no-isolate-config", "--epic=atlas"],
+    )
+    assert result.returncode == 0, result.stderr
+    assert "arg=--epic=atlas" in output

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -507,3 +507,18 @@ def test_epic_flag_is_forwarded(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert "arg=--epic=atlas" in output
+    # Epic implies the lane identity: the infra-orchestrator default must NOT
+    # be injected (an infra persona on the atlas lane would be a mismatch).
+    assert "arg=--agent" not in output
+    assert "arg=infra-orchestrator" not in output
+    assert "identity derives from --epic" in result.stdout
+
+
+def test_epic_plus_explicit_agent_keeps_agent(tmp_path: Path) -> None:
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "platform", "--no-isolate-config", "--epic", "atlas", "--agent", "infra-orchestrator"],
+    )
+    assert result.returncode == 0, result.stderr
+    assert "arg=--epic" in output
+    assert "arg=infra-orchestrator" in output


### PR DESCRIPTION
## Summary

The operator's daily kimicc invocation required spelling out `--endpoint coding --isolate-config` every time, and sessions started as **curriculum-orchestrator** (the project `.claude/settings.json` `agent` default) even though kimicc is the infra-lane UI.

New defaults (every one overridable):

| knob | old default | new default | override |
| --- | --- | --- | --- |
| endpoint | `platform` | `coding` (subscription) | `--endpoint platform` / `KIMICC_ENDPOINT` |
| isolated config | off | **on** | `--no-isolate-config` / `KIMICC_ISOLATE_CONFIG=0` |
| session agent | *(project default: curriculum-orchestrator)* | `infra-orchestrator` | `--agent NAME` (explicit wins) / `KIMICC_AGENT` (empty = inherit project default) |

Net effect: bare `./start-kimicc.sh` is now the full OAuth + apiKeyHelper long-session route on the infra lane, zero flags. `./start-kimicc.sh --agent infra-orchestrator --epic=atlas` also works — `--epic`/`--agent` pass through to `start-claude.sh` (epic handled there; agent forwarded to Claude Code and mapped to the `claude-infra` handoff slot).

`KIMICC_ISOLATE_CONFIG` env is validated (`0|1`).

## Verification

- Live dry-run with the operator's real OAuth credential: bare `./start-kimicc.sh` resolves `endpoint=coding`, isolated config with apiKeyHelper (existing `~/.claude-kimicc/settings.json` keys preserved by the JSON merge), and `agent=infra-orchestrator (default; override with --agent)`.
- Tests: 3 existing cases re-pinned to the modes they exercise (platform / no-isolate), 4 new (bare defaults, explicit-agent wins, no-isolate live-config mode, `--epic` passthrough). **23/23 pass**; ruff, shellcheck, markdownlint clean.

`docs/SCRIPTS.md` KimiCC section updated for the new defaults.

X-Agent: kimi/kimicc-infra-defaults
