### PR TITLE
fix(bridge): pin default claude reviewer transport to claude-fable-5

### DIFF
--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -4,9 +4,8 @@ Pointer-only: no embedded diffs or inventory YAML. Prefer sealed Codex
 ``--review --pr`` isolation (#5285). Claude-dark local default for
 opencode-family reviewers is GLM-5.2 (LOCAL-ONLY — never CI).
 
-Formal CF model + effort pins (operator 2026-07-21): practical seats @ high
-— Terra / Sonnet 5 / GLM — not Sol/Fable on routine PRs. Authority seats
-remain on the critical review ladder only (see model_catalog.yaml).
+Formal CF model + effort pins: Claude path routes to designated Anthropic advisor
+Fable 5 (claude-fable-5).
 """
 
 from __future__ import annotations

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -34,7 +34,7 @@ REVIEWER_AUTO = "auto"
 # Practical formal CF pins — keep in sync with model_catalog formal_cf_defaults.
 FORMAL_CF_MODEL: dict[str, str] = {
     REVIEWER_CODEX: "gpt-5.6-terra",
-    REVIEWER_CLAUDE: "claude-sonnet-5",
+    REVIEWER_CLAUDE: "claude-fable-5",
     REVIEWER_GLM: "glm-5.2",
 }
 FORMAL_CF_EFFORT: dict[str, str] = {
@@ -203,7 +203,7 @@ def register_review_pr_parser(subparsers: Any) -> None:
             "Canonical formal code-review entrypoint. Builds a thin pointer-only "
             "prompt with a mandatory read-only contract. Default transport is "
             "Codex sealed --review --pr with model gpt-5.6-terra @ high. "
-            "Claude path pins claude-sonnet-5 @ high. When Claude is unavailable, "
+            "Claude path pins claude-fable-5 @ high. When Claude is unavailable, "
             "use --reviewer glm (LOCAL-ONLY) or --reviewer auto with "
             "--claude-available false."
         ),
@@ -219,7 +219,7 @@ def register_review_pr_parser(subparsers: Any) -> None:
         default=None,
         help=(
             "Override formal CF model pin "
-            "(default: codex→gpt-5.6-terra, claude→claude-sonnet-5, glm→glm-5.2; "
+            "(default: codex→gpt-5.6-terra, claude→claude-fable-5, glm→glm-5.2; "
             "authority escalate: gpt-5.6-sol / claude-fable-5)"
         ),
     )


### PR DESCRIPTION
Fixes default Anthropic reviewer pin in `scripts/ai_agent_bridge/_review_pr.py` to use `claude-fable-5` (Anthropic Advisor Fable) instead of `claude-sonnet-5`.