### PR TITLE
fix(session): auto-recover expired dead-holder leases on launcher open

### DIFF
--- a/docs/runbooks/session-supervisor.md
+++ b/docs/runbooks/session-supervisor.md
@@ -128,6 +128,32 @@ operation for launcher integration tests.
   launcher exits with an error; no session is started.
 - Incomplete supervisor output → launcher fails closed.
 
+### Stale expired lease (no operator memory required)
+
+If a previous driver crashed without `hook close`, the stream can keep an
+`open` session with an **expired** lease and a **dead** holder PID. On the next
+`open`, the supervisor **automatically** proof-gated force-closes that session
+and opens a new one (same gates as `handoff-claim` / #5530).
+
+You do **not** need a manual recover step for that case. Just relaunch:
+
+```bash
+./start-grok.sh --epic=harness
+# same for start-kimi.sh / other launchers that use the common supervisor
+```
+
+Still refused (by design):
+
+- live unexpired lease held by another running process
+- expired lease whose holder PID is still alive
+
+Diagnose only when a launch still fails:
+
+```bash
+.venv/bin/python -m agents_extensions.shared.session_streams handoff-status \
+  --stream epic:4707
+```
+
 ## Claude
 
 Claude's SessionStart hook currently owns its own lease binding. PR-J2 will

--- a/scripts/lib/session_supervisor.sh
+++ b/scripts/lib/session_supervisor.sh
@@ -136,6 +136,13 @@ claim_session_supervisor_env() {
   if ! "$python_bin" "${supervisor_args[@]}" > "$supervisor_tmp" 2>&1; then
     echo "Error: session supervisor failed to claim ${stream}" >&2
     sed 's/^/  supervisor: /' "$supervisor_tmp" >&2
+    # Expired dead-holder leases auto-recover on open. Remaining failures are
+    # almost always a *live* holder — diagnose, do not invent a force-close.
+    if grep -q "already has live session" "$supervisor_tmp" 2>/dev/null; then
+      echo "  hint: another process still holds this epic stream." >&2
+      echo "  diagnose: .venv/bin/python -m agents_extensions.shared.session_streams handoff-status --stream ${stream}" >&2
+      echo "  if that holder is dead+expired, relaunch (open recovers automatically)." >&2
+    fi
     return 1
   fi
 

--- a/scripts/session_supervisor/__init__.py
+++ b/scripts/session_supervisor/__init__.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from agents_extensions.shared.session_streams.db import SessionStreamDatabase
 from agents_extensions.shared.session_streams.dual_write import resolve_handoff_path
+from agents_extensions.shared.session_streams.handoff import diagnose_handoff
 from agents_extensions.shared.session_streams.hooks import clean_exit_hook, lease_from_environment
 from agents_extensions.shared.session_streams.inventory import epic_handoff_map
 from agents_extensions.shared.session_streams.model import (
@@ -31,7 +32,11 @@ from agents_extensions.shared.session_streams.model import (
     sha256_text,
 )
 from agents_extensions.shared.session_streams.receipts import list_migration_state
-from agents_extensions.shared.session_streams.store import SessionStreamError, SessionStreamStore
+from agents_extensions.shared.session_streams.store import (
+    LifecycleError,
+    SessionStreamError,
+    SessionStreamStore,
+)
 
 CAPSULE_SCHEMA = "session-supervisor-bootstrap.v1"
 LEASE_ENV_PREFIX = "SESSION_STREAM_"
@@ -124,15 +129,37 @@ class SessionSupervisor:
         lineage_id: str,
         ttl_seconds: int,
     ) -> Lease:
-        """Open one exact fenced driver lease before a harness is started."""
+        """Open one exact fenced driver lease before a harness is started.
+
+        If the stream has an expired lease whose holder PID is dead, proof-gated
+        force-close runs automatically so launchers do not need a manual recovery
+        step (same safety gates as handoff-claim / #5530). Live unexpired holders
+        still refuse.
+        """
         self._require_driver(role)
-        return self.store.open_session(
-            stream_id=stream_id,
-            holder=holder,
-            lineage_id=lineage_id,
-            ttl_seconds=ttl_seconds,
-            reason="common session supervisor driver open",
-        )
+        try:
+            return self.store.open_session(
+                stream_id=stream_id,
+                holder=holder,
+                lineage_id=lineage_id,
+                ttl_seconds=ttl_seconds,
+                reason="common session supervisor driver open",
+            )
+        except LifecycleError as exc:
+            recovered = self._recover_claimable_expired_session(
+                stream_id=stream_id,
+                holder=holder,
+                conflict=exc,
+            )
+            if not recovered:
+                raise
+            return self.store.open_session(
+                stream_id=stream_id,
+                holder=holder,
+                lineage_id=lineage_id,
+                ttl_seconds=ttl_seconds,
+                reason="common session supervisor driver open after proof-gated recover",
+            )
 
     def resume_driver(self, *, role: LaunchRole | str, lease: Lease) -> Lease:
         """Resume only the exact pre-existing lease envelope by heartbeating it."""
@@ -149,12 +176,81 @@ class SessionSupervisor:
         self._require_driver(role)
         return clean_exit_hook(self.store, lease).state
 
-    def recover_expired_driver(self, *, role: LaunchRole | str, stream_id: str) -> None:
-        """Fail closed until recovery-plan receipts bind the full PR-I proof set."""
+    def recover_expired_driver(
+        self,
+        *,
+        role: LaunchRole | str,
+        stream_id: str,
+        holder: LeaseHolder,
+    ) -> bool:
+        """Proof-gated force-close of an expired dead-holder session.
+
+        Returns True when a session was force-closed. Raises SupervisorError when
+        the stream is held by a live unexpired lease or is otherwise not claimable.
+        Returns False when there is no open/rolling session to recover.
+        """
         self._require_driver(role)
-        raise SupervisorError(
-            "automatic recovery is unavailable: require an audited recovery-plan digest and exact receipts"
+        status = diagnose_handoff(self.store, stream_id)
+        if not status.session_id or status.session_state not in {"open", "rolling"}:
+            return False
+        if not status.claimable_force_close:
+            raise SupervisorError(
+                f"stream {stream_id} is not claimable for recovery: {status.reason}"
+            )
+        if status.holder_instance_id and status.holder_instance_id == holder.instance_id:
+            raise SupervisorError(
+                f"stream {stream_id}: recovery candidate instance_id must differ from "
+                f"dead holder ({holder.instance_id})"
+            )
+        self.store.force_close_expired_session(
+            stream_id=stream_id,
+            session_id=status.session_id,
+            candidate=holder,
+            reason=(
+                f"session supervisor proof-gated recover by "
+                f"{holder.agent}/{holder.harness}"
+            ),
         )
+        return True
+
+    def _recover_claimable_expired_session(
+        self,
+        *,
+        stream_id: str,
+        holder: LeaseHolder,
+        conflict: LifecycleError,
+    ) -> bool:
+        """On open conflict, force-close only when handoff diagnosis says claimable."""
+        message = str(conflict)
+        if "already has live session" not in message and "unreleased lease" not in message:
+            return False
+        status = diagnose_handoff(self.store, stream_id)
+        if status.claimable_force_close and status.session_id:
+            if status.holder_instance_id and status.holder_instance_id == holder.instance_id:
+                raise SupervisorError(
+                    f"stream {stream_id}: recovery candidate instance_id must differ from "
+                    f"dead holder ({holder.instance_id})"
+                ) from conflict
+            self.store.force_close_expired_session(
+                stream_id=stream_id,
+                session_id=status.session_id,
+                candidate=holder,
+                reason=(
+                    f"session supervisor open: proof-gated recover expired dead holder "
+                    f"({status.session_id})"
+                ),
+            )
+            return True
+        raise SupervisorError(
+            f"stream {stream_id} already has live session "
+            f"{status.session_id or 'unknown'} "
+            f"({status.session_state or 'unknown'}); "
+            f"holder {status.holder_agent or '?'}/{status.holder_harness or '?'} "
+            f"pid={status.holder_process_id} alive={status.holder_process_alive}. "
+            f"{status.reason}. "
+            f"If that process is yours, exit it cleanly or wait for lease expiry; "
+            f"do not force-close a live unexpired holder."
+        ) from conflict
 
     def build_capsule(
         self,

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -89,10 +89,115 @@ def test_worker_environment_strips_every_lease_credential() -> None:
     assert strip_lease_credentials(environment) == {"KEEP_ME": "safe"}
 
 
-def test_automatic_recovery_fails_closed_without_audited_plan(tmp_path: Path) -> None:
+def test_open_driver_auto_recovers_expired_dead_holder(tmp_path: Path) -> None:
+    """Launcher open must recover claimable crashed sessions without a manual step."""
+    from datetime import timedelta
+
+    from agents_extensions.shared.session_streams.model import utc_now
+
     supervisor = _supervisor(tmp_path)
-    with pytest.raises(SupervisorError, match="recovery-plan digest"):
-        supervisor.recover_expired_driver(role="driver", stream_id="epic:4707")
+    dead_pid = 999_999_001
+    assert not _pid_alive(dead_pid)
+
+    opened_at = utc_now() - timedelta(hours=7)
+    supervisor.store.open_session(
+        stream_id="epic:4707",
+        holder=LeaseHolder(
+            agent="grok",
+            harness="grok-tui",
+            instance_id="grok-dead-holder",
+            process_id=dead_pid,
+            task_id="stale",
+        ),
+        lineage_id="lineage-stale",
+        ttl_seconds=300,
+        now=opened_at,
+    )
+    successor = supervisor.open_driver(
+        role="driver",
+        stream_id="epic:4707",
+        holder=LeaseHolder(
+            agent="grok",
+            harness="grok-tui",
+            instance_id="grok-fresh-launcher",
+            process_id=os.getpid(),
+            task_id="fresh-open",
+        ),
+        lineage_id="lineage-fresh",
+        ttl_seconds=300,
+    )
+    assert successor.holder.instance_id == "grok-fresh-launcher"
+    assert successor.session_id != "session-stale"
+
+
+def test_open_driver_refuses_live_unexpired_holder(tmp_path: Path) -> None:
+    supervisor = _supervisor(tmp_path)
+    live = supervisor.open_driver(
+        role="driver",
+        stream_id="epic:4707",
+        holder=_holder(),
+        lineage_id="lineage-live",
+        ttl_seconds=3600,
+    )
+    with pytest.raises(SupervisorError, match="already has live session"):
+        supervisor.open_driver(
+            role="driver",
+            stream_id="epic:4707",
+            holder=LeaseHolder(
+                agent="grok",
+                harness="grok-tui",
+                instance_id="grok-other",
+                process_id=os.getpid(),
+            ),
+            lineage_id="lineage-other",
+            ttl_seconds=300,
+        )
+    assert supervisor.close_driver(role="driver", lease=live) == "closed"
+
+
+def test_recover_expired_driver_force_closes_claimable(tmp_path: Path) -> None:
+    from datetime import timedelta
+
+    from agents_extensions.shared.session_streams.model import utc_now
+
+    supervisor = _supervisor(tmp_path)
+    dead_pid = 999_999_002
+    assert not _pid_alive(dead_pid)
+    supervisor.store.open_session(
+        stream_id="epic:4707",
+        holder=LeaseHolder(
+            agent="grok",
+            harness="grok-tui",
+            instance_id="grok-dead-2",
+            process_id=dead_pid,
+        ),
+        lineage_id="lineage-dead-2",
+        ttl_seconds=60,
+        now=utc_now() - timedelta(hours=2),
+    )
+    holder = LeaseHolder(
+        agent="grok",
+        harness="grok-tui",
+        instance_id="grok-recover-cli",
+        process_id=os.getpid(),
+    )
+    assert supervisor.recover_expired_driver(
+        role="driver", stream_id="epic:4707", holder=holder
+    ) is True
+    # Second recover finds nothing open.
+    assert supervisor.recover_expired_driver(
+        role="driver", stream_id="epic:4707", holder=holder
+    ) is False
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
 
 
 def test_cli_refuses_worker_open_attempt(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary

`./start-grok.sh --epic=harness` (and other common-supervisor launchers) no longer fail when a previous driver crashed without `hook close`.

On `session_supervisor open`, if the stream has an **expired** lease whose holder PID is **dead**, the supervisor proof-gated force-closes that session and opens a new one — same safety gates as `handoff-claim` (#5530). Operators do not need a manual recover recipe.

Live unexpired holders still refuse, with a clearer error + `handoff-status` hint from the shell helper.

## Changes

- `scripts/session_supervisor/__init__.py` — auto-recover on open; implement proof-gated `recover_expired_driver`
- `scripts/lib/session_supervisor.sh` — diagnose hint when open still fails for a live holder
- `tests/test_session_supervisor.py` — recover path + live-refusal coverage
- `docs/runbooks/session-supervisor.md` — document that relaunch is enough

## Test plan

- [x] `pytest tests/test_session_supervisor.py tests/test_session_supervisor_shell.py tests/test_session_stream_handoff.py`
- [x] ruff clean
- [ ] After merge: `./start-grok.sh --epic=harness` after a simulated crash path should open without manual force-close