### PR TITLE
feat(fleet-comms): shared mid-cutover rule for all standalone TUI/UIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,14 +24,18 @@ gates bind · **12** **Advisor/operator approval gate**: no architecture, layout
 process decisions without present-tense **operator** or designated **advisor** approval
 (current advisors: **Fable**, **Sol** — roster may change; check `/api/rules`).
 
-### Fleet-comms mid-cutover (binding for standalone TUI/UI drivers; #5512)
+### Fleet-comms mid-cutover (binding for standalone TUI/UI drivers; #5512 / #5632)
 
 Full text: `agents_extensions/shared/rules/fleet-comms-coordination.md` (also in
-`GET /api/rules`). Digest: prefer `.venv/bin/python -m scripts.fleet_comms plane-status` +
-`review-pr` / `publish-review-verdict` for topology and formal CF; while plane
-`mode=off`, **file dual-write remains authoritative** — do not invent a competing
-design or flip dual_write / stream authority / `formal_review_eligible` without
-operator/advisor GO. Stream leases are already claimed by launchers.
+`GET /api/rules`). Method: skill **`drive-epic`**; operator seats:
+`docs/runbooks/epic-orchestrator-roster.md` + `./start-<model>-drive.sh <epic>`.
+Digest: prefer `.venv/bin/python -m scripts.fleet_comms plane-status` +
+`review-pr <PR_NUMBER>` / `publish-review-verdict` for topology and formal CF.
+Plane modes are only `off|shadow|dual_write` — **file dual-write stays authoritative
+in every mode** (`dual_write` is shadow/mirror, not authority cutover). Do not invent
+a competing design or flip plane / retention apply / `formal_review_eligible` without
+operator/advisor GO. Codex is a review/coding seat, **not** an epic-driver loop.
+Stream leases are already claimed by launchers.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ process decisions without present-tense **operator** or designated **advisor** a
 ### Fleet-comms mid-cutover (binding for standalone TUI/UI drivers; #5512)
 
 Full text: `agents_extensions/shared/rules/fleet-comms-coordination.md` (also in
-`GET /api/rules`). Digest: prefer `python -m scripts.fleet_comms plane-status` +
+`GET /api/rules`). Digest: prefer `.venv/bin/python -m scripts.fleet_comms plane-status` +
 `review-pr` / `publish-review-verdict` for topology and formal CF; while plane
 `mode=off`, **file dual-write remains authoritative** — do not invent a competing
 design or flip dual_write / stream authority / `formal_review_eligible` without

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,15 @@ gates bind · **12** **Advisor/operator approval gate**: no architecture, layout
 process decisions without present-tense **operator** or designated **advisor** approval
 (current advisors: **Fable**, **Sol** — roster may change; check `/api/rules`).
 
+### Fleet-comms mid-cutover (binding for standalone TUI/UI drivers; #5512)
+
+Full text: `agents_extensions/shared/rules/fleet-comms-coordination.md` (also in
+`GET /api/rules`). Digest: prefer `python -m scripts.fleet_comms plane-status` +
+`review-pr` / `publish-review-verdict` for topology and formal CF; while plane
+`mode=off`, **file dual-write remains authoritative** — do not invent a competing
+design or flip dual_write / stream authority / `formal_review_eligible` without
+operator/advisor GO. Stream leases are already claimed by launchers.
+
 ---
 
 ## Project Research Registry — Orchestrator Duty (binding)

--- a/agents_extensions/shared/rules/_load-via-api.md
+++ b/agents_extensions/shared/rules/_load-via-api.md
@@ -3,7 +3,8 @@
 <critical>
 
 The full agent rule set (critical · non-negotiable · workflow ·
-delegate-worktree · cli-help · model-assignment) is served at:
+fleet-comms-coordination · delegate-worktree · cli-help · model-assignment)
+is served at:
 
     GET /api/rules?format=markdown    (Monitor API on localhost:8765)
 
@@ -17,6 +18,7 @@ Offline fallback (API unreachable):
     agents_extensions/shared/rules/critical-rules.md
     agents_extensions/shared/rules/non-negotiable-rules.md
     agents_extensions/shared/rules/workflow.md
+    agents_extensions/shared/rules/fleet-comms-coordination.md
     agents_extensions/shared/rules/delegate-must-use-worktree.md
     agents_extensions/shared/rules/cli-help-standard.md
     agents_extensions/shared/rules/model-assignment.md

--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -3,37 +3,58 @@
 <critical>
 
 **Product epic:** #5512 · **Stream:** #4707 (infra-harness) · **Sol memo:** `SHIP-THIS-ARCHITECTURE`  
-**Applies to:** every standalone TUI/UI and orchestrator seat (Claude, Codex, Grok, AGY/Gemini, Kimi, Cursor, wrappers) — not only agents that load a skill.
+**Applies to:** every standalone TUI/UI and epic-driver seat (Claude/Sonnet, Grok, AGY/Gemini, Kimi, Cursor, wrappers) — not only agents that load a skill.
 
-This is the **shared-context SSOT** for coordination during the fleet-comms cutover. Launchers may inject a short pointer; skills teach method (`drive-epic`); neither may invent a competing design or silently flip cutovers.
+This is the **shared-context SSOT** for coordination during the fleet-comms cutover. It is
+served in `GET /api/rules`. Launchers inject a short pointer; the **`drive-epic` skill**
+teaches the full method loop. Neither may invent a competing design or silently flip
+cutovers.
+
+Aligned with the post-#5632 surface (drive-epic + per-model drive wrappers + Sol CF on
+that skill). Do not reintroduce claims Sol rejected (see §Plane modes).
+
+## Layering (do not conflate)
+
+| Layer | Role | Where |
+| --- | --- | --- |
+| **This rule** | Binding musts for every TUI/UI cold-start | `/api/rules` + offline path |
+| **`drive-epic` skill** | Method playbook (orient → topology → route → dispatch → settle → CF → merge → handoff) | `agents_extensions/shared/skills/drive-epic/SKILL.md` |
+| **Epic roster runbook** | Operator seat routing (which model drives which epic) | `docs/runbooks/epic-orchestrator-roster.md` |
+| **Live routing data** | Caps, ladders, formal CF pins | `/api/rules` model-assignment + `scripts/config/model_catalog.yaml` + `scripts/config/fleet_communications.yaml` |
+| **Launchers** | Lease claim + dual-aware pointer (not a second design) | `start-*.sh`, `start-*-drive.sh` |
+
+**Golden rule (from drive-epic):** rules + skill teach **method**; roster/caps are **live
+data** — always re-read; never hard-code from memory.
 
 ## Two halves (do not conflate)
 
 | Half | Status | Surfaces |
 | --- | --- | --- |
-| **Session stream / lease** | Live | `claim_session_supervisor_env`, `SESSION_STREAM_*`, stream tail/digest, canary mint |
+| **Session stream / lease** | Live | `claim_session_supervisor_env`, `SESSION_STREAM_*`, stream tail/digest, canary mint (hook-less seats) |
 | **Message plane + CF-comms** | Mid-cutover | `scripts.fleet_comms`, `review-pr`, `publish-review-verdict` |
 
-Launchers already claim leases. Drivers must **also** speak the message-plane + CF half — prefer plane when enabled; fall back to file dual-write while plane is off.
+Launchers already claim leases. Drivers must **also** speak the message-plane + CF half.
 
-## Dual-aware cutover (operator/advisor gated)
+## Plane modes (Sol-corrected — #5632 F003)
 
-1. **Check first (every cold-start / before coordination decisions):**
-   ```bash
-   .venv/bin/python -m scripts.fleet_comms plane-status
-   ```
-   Modes: `off` | `shadow` | `dual_write`. Default remains **`off`** until parity receipt + present-tense operator/advisor GO.
+```bash
+.venv/bin/python -m scripts.fleet_comms plane-status
+```
 
-2. **While `mode=off` (current production):**
-   - Prefer plane/CF **command surfaces** for topology, metrics, and formal review.
-   - **File dual-write remains authoritative** for continuity diaries  
-     (`.claude/<epic>-epic/*-DRIVER-HANDOFF.md`, stream dual-write, `docs/session-state/` pointers).
-   - Do **not** treat streams as sole authority; do **not** retire file handoffs.
-   - Do **not** set `FLEET_COMMS_MESSAGE_PLANE=dual_write` (or flip stream-authority / `formal_review_eligible`) without GO.
+Implemented modes are **only** `off` | `shadow` | `dual_write` (default **`off`**).
 
-3. **When plane is `shadow` or `dual_write`:** prefer plane for coordination; keep diary dual-write until stream-authority cutover is explicitly approved. Drop file-handoff folklore as the primary coordination path after that cutover — a config/process flip, not a new design.
+| Fact | Binding |
+| --- | --- |
+| File dual-write / diary | **Stays authoritative in every plane mode** today |
+| `dual_write` mode | Shadow/mirror of plane traffic — **not** stream-authority cutover |
+| Post-cutover “plane-only authority” | **Not implemented** — do not claim a one-line yaml flip retires files |
+| Who may flip plane / retention apply / eligibility | **Infra/harness lane** after parity + present-tense operator/advisor GO |
 
-4. **Forbidden:** inventing a third message bus, encoding only file-handoff folklore in new cold-prompts, or “for now” plane flips.
+**Never drop the file handoff on your own.** Retiring file handoffs is a future infra step
+gated on an authority signal the plane does not yet expose.
+
+Forbidden: inventing a third message bus; encoding only file-handoff folklore in new
+cold-prompts; silent plane flips; “for now” cutovers.
 
 ## Required primitives (tool-backed)
 
@@ -48,12 +69,15 @@ Launchers already claim leases. Drivers must **also** speak the message-plane + 
 .venv/bin/python -m agents_extensions.shared.session_streams tail --stream epic:<N> --limit 20
 .venv/bin/python -m agents_extensions.shared.session_streams dual-write-status
 
-# Formal cross-family CF (never self-seal; agy|kimi|grok stay fail-closed until isolation proofs)
-.venv/bin/python -m scripts.ai_agent_bridge review-pr <N> --reviewer codex|claude|glm
+# Formal cross-family CF — PR number is REQUIRED and positional
+.venv/bin/python -m scripts.ai_agent_bridge review-pr <PR_NUMBER> --reviewer codex|claude|glm
 .venv/bin/python -m scripts.ai_agent_bridge publish-review-verdict ...
 ```
 
-Live routing seats remain in `model-assignment.md` (this same `/api/rules` blob). Isolation fail-closed matrix: #5555–#5557.
+- **agy | kimi | grok** remain `formal_review_eligible: false` until isolation proofs
+  (#5555–#5557). They **request** CF via `review-pr`; they do not self-seal.
+- Escalate hard/non-routine CF with Sol / Fable (`--model gpt-5.6-sol` or `claude-fable-5`
+  `--effort xhigh`) per model-assignment.
 
 ## Standalone TUI/UI contract
 
@@ -61,11 +85,32 @@ Every epic driver session (any harness) MUST:
 
 1. Obey this rule (via `/api/rules` or offline fallback of this file).
 2. Run `plane-status` before assuming message-plane availability.
-3. Use `review-pr` / `publish-review-verdict` for formal PR CF — not “ask the same family to rubber-stamp.”
-4. Dual-write the lane diary while files are authoritative; stamp after each batch.
+3. Prefer plane/CF **command surfaces** for topology and formal review; **keep** the lane
+   diary dual-write current (`.claude/<epic>-epic/*-DRIVER-HANDOFF.md` and stream notes)
+   in **all** plane modes.
+4. Use `review-pr <PR_NUMBER> …` / `publish-review-verdict` for formal PR CF — discussion
+   and same-family chat are not the review gate.
 5. Treat launcher-claimed stream leases as held — do not open/resume the lease yourself.
+6. **Session health by seat:**
+   - **grok / gemini / kimi:** canary mint/score
+     (`.venv/bin/python -m scripts.session_canary.{grok,gemini,kimi}_lane …`); end on
+     FAIL-HANDOFF (&lt;8/10), not compact count.
+   - **Claude / Sonnet:** SessionStart / PostCompact + thread-handoff — **no** canary lane
+     (do not invent `<model>_lane`).
+7. When driving an epic end-to-end, load the **`drive-epic`** skill for the method loop
+   (wrappers `start-*-drive.sh` do not auto-load it yet — invoke `$drive-epic` until
+   cold-prompt wiring lands).
 
-Optional method playbook: skill `drive-epic` (when installed). Skills are **not** a substitute for this rule.
+## Operator launch surface (#5632)
+
+- Per-model driver: `./start-grok-drive.sh <epic>`, `./start-gemini-drive.sh <epic>`,
+  `./start-sonnet-drive.sh <epic>` (thin wrappers over `start-*.sh --epic`).
+- Seat routing reminder: `docs/runbooks/epic-orchestrator-roster.md` (Gemini→harness/corpus,
+  Grok→atlas/tracks, Sonnet-5→judgment-dense). **Live policy** is still
+  `model_catalog.orchestrator_seats` + `/api/rules`.
+- **Codex is not a driver seat** (dropped 2026-07-22: 272K window vs rollover cost). Codex
+  remains a formal-CF **review** + coding lane. Do not launch Codex as a continuous
+  epic-driver loop.
 
 ## Offline fallback path
 

--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -1,0 +1,75 @@
+# Fleet-comms coordination (binding mid-cutover)
+
+<critical>
+
+**Product epic:** #5512 · **Stream:** #4707 (infra-harness) · **Sol memo:** `SHIP-THIS-ARCHITECTURE`  
+**Applies to:** every standalone TUI/UI and orchestrator seat (Claude, Codex, Grok, AGY/Gemini, Kimi, Cursor, wrappers) — not only agents that load a skill.
+
+This is the **shared-context SSOT** for coordination during the fleet-comms cutover. Launchers may inject a short pointer; skills teach method (`drive-epic`); neither may invent a competing design or silently flip cutovers.
+
+## Two halves (do not conflate)
+
+| Half | Status | Surfaces |
+| --- | --- | --- |
+| **Session stream / lease** | Live | `claim_session_supervisor_env`, `SESSION_STREAM_*`, stream tail/digest, canary mint |
+| **Message plane + CF-comms** | Mid-cutover | `scripts.fleet_comms`, `review-pr`, `publish-review-verdict` |
+
+Launchers already claim leases. Drivers must **also** speak the message-plane + CF half — prefer plane when enabled; fall back to file dual-write while plane is off.
+
+## Dual-aware cutover (operator/advisor gated)
+
+1. **Check first (every cold-start / before coordination decisions):**
+   ```bash
+   .venv/bin/python -m scripts.fleet_comms plane-status
+   ```
+   Modes: `off` | `shadow` | `dual_write`. Default remains **`off`** until parity receipt + present-tense operator/advisor GO.
+
+2. **While `mode=off` (current production):**
+   - Prefer plane/CF **command surfaces** for topology, metrics, and formal review.
+   - **File dual-write remains authoritative** for continuity diaries  
+     (`.claude/<epic>-epic/*-DRIVER-HANDOFF.md`, stream dual-write, `docs/session-state/` pointers).
+   - Do **not** treat streams as sole authority; do **not** retire file handoffs.
+   - Do **not** set `FLEET_COMMS_MESSAGE_PLANE=dual_write` (or flip stream-authority / `formal_review_eligible`) without GO.
+
+3. **When plane is `shadow` or `dual_write`:** prefer plane for coordination; keep diary dual-write until stream-authority cutover is explicitly approved. Drop file-handoff folklore as the primary coordination path after that cutover — a config/process flip, not a new design.
+
+4. **Forbidden:** inventing a third message bus, encoding only file-handoff folklore in new cold-prompts, or “for now” plane flips.
+
+## Required primitives (tool-backed)
+
+```bash
+# Topology / health / parity
+.venv/bin/python -m scripts.fleet_comms plane-status
+.venv/bin/python -m scripts.fleet_comms metrics
+.venv/bin/python -m scripts.fleet_comms backlog
+.venv/bin/python -m scripts.fleet_comms dead-letters
+
+# Continuity (lease already claimed by launcher — do not re-open)
+.venv/bin/python -m agents_extensions.shared.session_streams tail --stream epic:<N> --limit 20
+.venv/bin/python -m agents_extensions.shared.session_streams dual-write-status
+
+# Formal cross-family CF (never self-seal; agy|kimi|grok stay fail-closed until isolation proofs)
+.venv/bin/python -m scripts.ai_agent_bridge review-pr <N> --reviewer codex|claude|glm
+.venv/bin/python -m scripts.ai_agent_bridge publish-review-verdict ...
+```
+
+Live routing seats remain in `model-assignment.md` (this same `/api/rules` blob). Isolation fail-closed matrix: #5555–#5557.
+
+## Standalone TUI/UI contract
+
+Every epic driver session (any harness) MUST:
+
+1. Obey this rule (via `/api/rules` or offline fallback of this file).
+2. Run `plane-status` before assuming message-plane availability.
+3. Use `review-pr` / `publish-review-verdict` for formal PR CF — not “ask the same family to rubber-stamp.”
+4. Dual-write the lane diary while files are authoritative; stamp after each batch.
+5. Treat launcher-claimed stream leases as held — do not open/resume the lease yourself.
+
+Optional method playbook: skill `drive-epic` (when installed). Skills are **not** a substitute for this rule.
+
+## Offline fallback path
+
+`agents_extensions/shared/rules/fleet-comms-coordination.md` (this file).  
+Served in `GET /api/rules` (`scripts/api/rules_router.py` `RULE_SOURCES`).
+
+</critical>

--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -40,7 +40,10 @@ curl -s "http://localhost:8765/api/orient?lean=true&session=$S"         # lean, 
 curl -s 'http://localhost:8765/api/knowledge/cold-start?role=quality'  # role-scoped pointers
 # Generic or genuinely role-unknown session: skip the role-scoped request; remain pointer-free.
 curl -s 'http://localhost:8765/api/comms/inbox?agent=claude'  # unread messages
+# Fleet-comms mid-cutover (#5512): plane mode + parity (default off — dual-aware; see fleet-comms-coordination.md)
+.venv/bin/python -m scripts.fleet_comms plane-status
 ```
+
 
 ### Project Research Registry — orchestrator dispatch duty
 

--- a/scripts/api/rules_router.py
+++ b/scripts/api/rules_router.py
@@ -74,6 +74,8 @@ RULE_SOURCES: tuple[str, ...] = (
     "agents_extensions/shared/rules/critical-rules.md",
     "agents_extensions/shared/rules/non-negotiable-rules.md",
     "agents_extensions/shared/rules/workflow.md",
+    # Fleet-comms mid-cutover coordination (standalone TUI/UI SSOT; #5512 / #4707).
+    "agents_extensions/shared/rules/fleet-comms-coordination.md",
     "agents_extensions/shared/rules/delegate-must-use-worktree.md",
     "agents_extensions/shared/rules/cli-help-standard.md",
     "agents_extensions/shared/rules/model-assignment.md",

--- a/scripts/deploy_orphan_paths.sh
+++ b/scripts/deploy_orphan_paths.sh
@@ -72,6 +72,7 @@ CLAUDE_RULE_AUTOLOAD_EXCLUDES=(
     "rules/critical-rules.md"
     "rules/non-negotiable-rules.md"
     "rules/workflow.md"
+    "rules/fleet-comms-coordination.md"
     "rules/delegate-must-use-worktree.md"
     "rules/cli-help-standard.md"
     "rules/model-assignment.md"

--- a/scripts/lib/fleet_comms_cold_start.sh
+++ b/scripts/lib/fleet_comms_cold_start.sh
@@ -2,15 +2,16 @@
 # fleet_comms_cold_start.sh — shared dual-aware fleet-comms cold-start helpers for launchers.
 #
 # Binding doctrine: agents_extensions/shared/rules/fleet-comms-coordination.md
-# (also served at GET /api/rules). Launchers inject a short pointer; they must not
-# invent a competing design or flip plane/stream/eligibility cutovers.
+# (also served at GET /api/rules). Method playbook: drive-epic skill (#5632).
+# Aligned with Sol CF on #5632: file handoffs stay authoritative in every plane mode;
+# dual_write is not stream-authority cutover.
 #
 # Usage (from a start-*.sh after PROJECT_DIR is set):
 #   # shellcheck source=scripts/lib/fleet_comms_cold_start.sh
 #   source "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh"
 #   export FLEET_COMMS_PLANE_MODE="$(fleet_comms_resolve_plane_mode)"
-#   fleet_comms_print_banner_line   # optional compact operator line
-#   _clause="$(fleet_comms_cold_clause)"  # append into cold-start prompts
+#   fleet_comms_print_banner_line
+#   _clause="$(fleet_comms_cold_clause)"
 
 # shellcheck disable=SC2034  # PROJECT_DIR is provided by the sourcing launcher
 
@@ -18,7 +19,7 @@ fleet_comms_rule_relpath() {
   printf '%s' "agents_extensions/shared/rules/fleet-comms-coordination.md"
 }
 
-# Resolve plane mode once (fail-open → off).
+# Resolve plane mode once (fail-open → off). Modes: off|shadow|dual_write only.
 fleet_comms_resolve_plane_mode() {
   local mode="off"
   local root="${PROJECT_DIR:-.}"
@@ -37,22 +38,24 @@ fleet_comms_resolve_plane_mode() {
   printf '%s' "$mode"
 }
 
-# Compact dual-aware clause for injected cold-start prompts.
+# Compact dual-aware clause for injected cold-start prompts (post-#5632 Sol-aligned).
 fleet_comms_cold_clause() {
   local plane_mode="${FLEET_COMMS_PLANE_MODE:-off}"
   local rule
   rule="$(fleet_comms_rule_relpath)"
   printf '%s' \
     "Fleet-comms (#5512) mid-cutover — obey ${rule} (also in /api/rules). " \
-    "Prefer message-plane + CF surfaces; fall back to file dual-write while plane mode is ${plane_mode} " \
-    "(do not flip cutovers without operator/advisor GO; do not invent a competing design). " \
+    "Method playbook: load skill drive-epic (start-*-drive.sh does not auto-load it yet). " \
+    "Prefer plane + CF surfaces; file dual-write diary stays authoritative in every plane mode " \
+    "(current mode=${plane_mode}; dual_write is shadow/mirror, not authority cutover — " \
+    "do not flip cutovers or invent a competing design). " \
     "Topology: \`.venv/bin/python -m scripts.fleet_comms plane-status\` (+ metrics/backlog/dead-letters). " \
-    "Formal CF: \`.venv/bin/python -m scripts.ai_agent_bridge review-pr <N>\` then publish-review-verdict " \
-    "(cross-family; never self-seal). Continuity: stream lease already claimed; dual-write " \
-    "\`.claude/<epic>-epic/*-DRIVER-HANDOFF.md\` remains authoritative until stream-authority cutover."
+    "Formal CF: \`.venv/bin/python -m scripts.ai_agent_bridge review-pr <PR_NUMBER> --reviewer <cross-family>\` " \
+    "then publish-review-verdict (PR number required; never self-seal). " \
+    "Continuity: stream lease already claimed; dual-write \`.claude/<epic>-epic/*-DRIVER-HANDOFF.md\`."
 }
 
-# One-line operator banner (stdout). Safe when FLEET_COMMS_PLANE_MODE unset (resolves off).
+# One-line operator banner (stdout).
 fleet_comms_print_banner_line() {
   local plane_mode="${FLEET_COMMS_PLANE_MODE:-}"
   if [ -z "$plane_mode" ]; then
@@ -60,13 +63,13 @@ fleet_comms_print_banner_line() {
   fi
   case "$plane_mode" in
     off)
-      echo "  fleet-comms: plane=off → file dual-write fallback; CF via review-pr; rule=$(fleet_comms_rule_relpath)"
+      echo "  fleet-comms: plane=off · diary authoritative · CF via review-pr · rule=$(fleet_comms_rule_relpath) · skill=drive-epic"
       ;;
     shadow|dual_write)
-      echo "  fleet-comms: plane=${plane_mode} → prefer plane; keep diary dual-write until authority cutover; rule=$(fleet_comms_rule_relpath)"
+      echo "  fleet-comms: plane=${plane_mode} (shadow/mirror; diary still authoritative) · rule=$(fleet_comms_rule_relpath) · skill=drive-epic"
       ;;
     *)
-      echo "  fleet-comms: plane=${plane_mode} (unknown) → treat as off; rule=$(fleet_comms_rule_relpath)"
+      echo "  fleet-comms: plane=${plane_mode} (unknown→treat off) · rule=$(fleet_comms_rule_relpath)"
       ;;
   esac
 }

--- a/scripts/lib/fleet_comms_cold_start.sh
+++ b/scripts/lib/fleet_comms_cold_start.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# fleet_comms_cold_start.sh — shared dual-aware fleet-comms cold-start helpers for launchers.
+#
+# Binding doctrine: agents_extensions/shared/rules/fleet-comms-coordination.md
+# (also served at GET /api/rules). Launchers inject a short pointer; they must not
+# invent a competing design or flip plane/stream/eligibility cutovers.
+#
+# Usage (from a start-*.sh after PROJECT_DIR is set):
+#   # shellcheck source=scripts/lib/fleet_comms_cold_start.sh
+#   source "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh"
+#   export FLEET_COMMS_PLANE_MODE="$(fleet_comms_resolve_plane_mode)"
+#   fleet_comms_print_banner_line   # optional compact operator line
+#   _clause="$(fleet_comms_cold_clause)"  # append into cold-start prompts
+
+# shellcheck disable=SC2034  # PROJECT_DIR is provided by the sourcing launcher
+
+fleet_comms_rule_relpath() {
+  printf '%s' "agents_extensions/shared/rules/fleet-comms-coordination.md"
+}
+
+# Resolve plane mode once (fail-open → off).
+fleet_comms_resolve_plane_mode() {
+  local mode="off"
+  local root="${PROJECT_DIR:-.}"
+  if [ -x "$root/.venv/bin/python" ] \
+      && [ -f "$root/scripts/fleet_comms/message_plane.py" ]; then
+    mode="$(
+      "$root/.venv/bin/python" -c \
+        'from scripts.fleet_comms.message_plane import resolve_plane_mode; print(resolve_plane_mode(None))' \
+        2>/dev/null || true
+    )"
+    case "${mode}" in
+      off|shadow|dual_write) ;;
+      *) mode="off" ;;
+    esac
+  fi
+  printf '%s' "$mode"
+}
+
+# Compact dual-aware clause for injected cold-start prompts.
+fleet_comms_cold_clause() {
+  local plane_mode="${FLEET_COMMS_PLANE_MODE:-off}"
+  local rule
+  rule="$(fleet_comms_rule_relpath)"
+  printf '%s' \
+    "Fleet-comms (#5512) mid-cutover — obey ${rule} (also in /api/rules). " \
+    "Prefer message-plane + CF surfaces; fall back to file dual-write while plane mode is ${plane_mode} " \
+    "(do not flip cutovers without operator/advisor GO; do not invent a competing design). " \
+    "Topology: \`.venv/bin/python -m scripts.fleet_comms plane-status\` (+ metrics/backlog/dead-letters). " \
+    "Formal CF: \`.venv/bin/python -m scripts.ai_agent_bridge review-pr <N>\` then publish-review-verdict " \
+    "(cross-family; never self-seal). Continuity: stream lease already claimed; dual-write " \
+    "\`.claude/<epic>-epic/*-DRIVER-HANDOFF.md\` remains authoritative until stream-authority cutover."
+}
+
+# One-line operator banner (stdout). Safe when FLEET_COMMS_PLANE_MODE unset (resolves off).
+fleet_comms_print_banner_line() {
+  local plane_mode="${FLEET_COMMS_PLANE_MODE:-}"
+  if [ -z "$plane_mode" ]; then
+    plane_mode="$(fleet_comms_resolve_plane_mode)"
+  fi
+  case "$plane_mode" in
+    off)
+      echo "  fleet-comms: plane=off → file dual-write fallback; CF via review-pr; rule=$(fleet_comms_rule_relpath)"
+      ;;
+    shadow|dual_write)
+      echo "  fleet-comms: plane=${plane_mode} → prefer plane; keep diary dual-write until authority cutover; rule=$(fleet_comms_rule_relpath)"
+      ;;
+    *)
+      echo "  fleet-comms: plane=${plane_mode} (unknown) → treat as off; rule=$(fleet_comms_rule_relpath)"
+      ;;
+  esac
+}

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -300,6 +300,18 @@ if [ -n "${_selected_epic:-}" ] && command -v claim_session_supervisor_env >/dev
         unset _launcher_task_id _launcher_instance_id _selected_stream
     fi
 fi
+
+# Fleet-comms dual-aware banner (Claude loads /api/rules for full doctrine; cold-prompt is SessionStart).
+if [ -n "${SESSION_EPIC:-}" ] && [ -f "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh" ]; then
+    # shellcheck source=scripts/lib/fleet_comms_cold_start.sh
+    source "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh"
+    if command -v fleet_comms_resolve_plane_mode >/dev/null 2>&1; then
+        export FLEET_COMMS_PLANE_MODE="$(fleet_comms_resolve_plane_mode)"
+    fi
+    if command -v fleet_comms_print_banner_line >/dev/null 2>&1; then
+        fleet_comms_print_banner_line
+    fi
+fi
 unset _selected_epic
 
 echo "Launching Claude Code (native install)..."

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -115,6 +115,17 @@ if [ -n "$SELECTED_EPIC" ]; then
     unset FORWARD_ARG HANDOFF_SLOT
     printf 'Epic assignment: %s.epic\n' "$SESSION_EPIC"
     printf 'Handoff identity: %s\n' "$SESSION_HANDOFF_AGENT"
+    # Fleet-comms dual-aware banner (Codex loads AGENTS.md + /api/rules for full doctrine).
+    if [ -f "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh" ]; then
+        # shellcheck source=scripts/lib/fleet_comms_cold_start.sh
+        source "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh"
+        if command -v fleet_comms_resolve_plane_mode >/dev/null 2>&1; then
+            export FLEET_COMMS_PLANE_MODE="$(fleet_comms_resolve_plane_mode)"
+        fi
+        if command -v fleet_comms_print_banner_line >/dev/null 2>&1; then
+            fleet_comms_print_banner_line
+        fi
+    fi
 fi
 unset HANDOFF_IDENTITY_SH SELECTED_EPIC
 

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -232,6 +232,10 @@ if [ -f "$PROJECT_DIR/scripts/lib/session_supervisor.sh" ]; then
   # shellcheck source=scripts/lib/session_supervisor.sh
   source "$PROJECT_DIR/scripts/lib/session_supervisor.sh"
 fi
+if [ -f "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh" ]; then
+  # shellcheck source=scripts/lib/fleet_comms_cold_start.sh
+  source "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh"
+fi
 
 # Validate epic name when the helper is present.
 if command -v epic_name_valid >/dev/null 2>&1 && [ -n "$_selected_epic" ]; then
@@ -338,15 +342,28 @@ for a in "${_forward[@]+"${_forward[@]}"}"; do
 done
 
 if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
+  if command -v fleet_comms_resolve_plane_mode >/dev/null 2>&1; then
+    export FLEET_COMMS_PLANE_MODE="$(fleet_comms_resolve_plane_mode)"
+  else
+    export FLEET_COMMS_PLANE_MODE="off"
+  fi
+  if command -v fleet_comms_print_banner_line >/dev/null 2>&1; then
+    fleet_comms_print_banner_line
+  fi
   _handoff_path=".agent/${SESSION_HANDOFF_AGENT:-gemini-${SESSION_EPIC}}-thread-handoff.md"
-  _cold_prompt="You are the Gemini ${SESSION_EPIC} lane orchestrator (stream ${SESSION_STREAM_ID:-unset}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) Check stream state in ${_handoff_path} or docs/session-state/; (2) Run 'codexbar usage' to monitor fleet quota/limits; (3) Assess tasks, pick the optimal model/agent from the capability matrix (AGENTS.md, model-assignment.md); (4) Dispatch worker sub-tasks via worktrees using 'scripts/delegate.py dispatch ...'; (5) Obey advisor approval gate (Fable / Sol) for architecture/process changes; (6) Enforce independent cross-family review before PR merges. Primary checkout is read-only — all edits belong in worktrees."
+  if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
+    _fc="$(fleet_comms_cold_clause)"
+  else
+    _fc="Fleet-comms (#5512): obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status + review-pr; file dual-write while plane off."
+  fi
+  _cold_prompt="You are the Gemini ${SESSION_EPIC} lane orchestrator (stream ${SESSION_STREAM_ID:-unset}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) Check stream state in ${_handoff_path} or docs/session-state/; (2) Run 'codexbar usage' to monitor fleet quota/limits; (3) Assess tasks, pick the optimal model/agent from the capability matrix (AGENTS.md, model-assignment.md via /api/rules); (4) Dispatch worker sub-tasks via worktrees using 'scripts/delegate.py dispatch ...'; (5) Obey advisor approval gate (Fable / Sol) for architecture/process changes; (6) Enforce independent cross-family review via review-pr / publish-review-verdict before PR merges. ${_fc} Primary checkout is read-only — all edits belong in worktrees."
   echo "Cold-start: injecting epic orchestrator auto-continue prompt."
   if [ "$_has_print" -eq 1 ]; then
     _forward+=("$_cold_prompt")
   else
     _defaults+=("-i" "$_cold_prompt")
   fi
-  unset _cold_prompt
+  unset _cold_prompt _fc
 elif [ "$_has_prompt" -eq 1 ] && [ "$_has_print" -eq 0 ]; then
   # If a positional prompt is given for interactive mode, pass it via -i
   _forward_without_prompt=()

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -358,7 +358,7 @@ if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
   if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
     _fc="$(fleet_comms_cold_clause)"
   else
-    _fc="Fleet-comms (#5512): obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status + review-pr; file dual-write while plane off."
+    _fc="Fleet-comms (#5512): obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status + review-pr; file dual-write stays authoritative in every plane mode (dual_write=shadow/mirror)."
   fi
   _cold_prompt="You are the Gemini ${SESSION_EPIC} lane orchestrator (stream ${SESSION_STREAM_ID:-unset}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) Check stream state in ${_handoff_path} or docs/session-state/; (2) Run 'codexbar usage' to monitor fleet quota/limits; (3) Assess tasks, pick the optimal model/agent from the capability matrix (AGENTS.md, model-assignment.md via /api/rules); (4) Dispatch worker sub-tasks via worktrees using 'scripts/delegate.py dispatch ...'; (5) Obey advisor approval gate (Fable / Sol) for architecture/process changes; (6) Enforce independent cross-family review via review-pr / publish-review-verdict before PR merges. ${_fc} Primary checkout is read-only — all edits belong in worktrees."
   echo "Cold-start: injecting epic orchestrator auto-continue prompt."

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -264,6 +264,18 @@ if [ -n "$_handoff_override" ]; then
   export SESSION_HANDOFF_AGENT="$_handoff_override"
 fi
 
+# Fleet-comms plane mode + banner whenever epic is set (including explicit PROMPT paths).
+if [ -n "${SESSION_EPIC:-}" ]; then
+  if command -v fleet_comms_resolve_plane_mode >/dev/null 2>&1; then
+    export FLEET_COMMS_PLANE_MODE="$(fleet_comms_resolve_plane_mode)"
+  else
+    export FLEET_COMMS_PLANE_MODE="off"
+  fi
+  if command -v fleet_comms_print_banner_line >/dev/null 2>&1; then
+    fleet_comms_print_banner_line
+  fi
+fi
+
 # Claim/resume the stream lease through the common supervisor when an epic is pinned.
 if [ -n "$_selected_epic" ]; then
   if [ -z "$_selected_stream" ]; then
@@ -342,14 +354,6 @@ for a in "${_forward[@]+"${_forward[@]}"}"; do
 done
 
 if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
-  if command -v fleet_comms_resolve_plane_mode >/dev/null 2>&1; then
-    export FLEET_COMMS_PLANE_MODE="$(fleet_comms_resolve_plane_mode)"
-  else
-    export FLEET_COMMS_PLANE_MODE="off"
-  fi
-  if command -v fleet_comms_print_banner_line >/dev/null 2>&1; then
-    fleet_comms_print_banner_line
-  fi
   _handoff_path=".agent/${SESSION_HANDOFF_AGENT:-gemini-${SESSION_EPIC}}-thread-handoff.md"
   if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
     _fc="$(fleet_comms_cold_clause)"

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -319,15 +319,15 @@ if [ -n "${SESSION_EPIC:-}" ]; then
   case "${SESSION_EPIC}" in
     atlas)
       echo "  canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas"
-      echo "  board:  .claude/atlas-epic/TAKEOVER-PROMPT.md + INTERIM-DRIVER-HANDOFF.md (fallback while plane off)"
+      echo "  board:  .claude/atlas-epic/TAKEOVER-PROMPT.md + INTERIM-DRIVER-HANDOFF.md (diary authoritative every plane mode)"
       ;;
     harness|infra)
       echo "  canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic harness"
-      echo "  board:  .claude/harness-epic/*-DRIVER-HANDOFF.md + docs/session-state/ (fallback while plane off)"
+      echo "  board:  .claude/harness-epic/*-DRIVER-HANDOFF.md + docs/session-state/ (diary authoritative every plane mode)"
       ;;
     *)
       echo "  canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic ${SESSION_EPIC}"
-      echo "  board:  .claude/${SESSION_EPIC}-epic/ (fallback while plane off)"
+      echo "  board:  .claude/${SESSION_EPIC}-epic/ (diary authoritative every plane mode)"
       ;;
   esac
   echo "  writes: worktrees only · end on canary FAIL-HANDOFF (docs/runbooks/grok-session-canary.md)"
@@ -373,11 +373,11 @@ if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
   if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
     _fc="$(fleet_comms_cold_clause)"
   else
-    _fc="Fleet-comms (#5512) mid-cutover: obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status then review-pr; file dual-write while plane off."
+    _fc="Fleet-comms (#5512) mid-cutover: obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status then review-pr; file dual-write stays authoritative in every plane mode (dual_write=shadow/mirror)."
   fi
   case "${SESSION_EPIC}" in
     atlas|practice|practice-hub)
-      _cold_prompt="You are the interim ATLAS lane driver (stream ${SESSION_STREAM_ID:-epic:4387}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md while plane is off; (2) mint the session canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas --stream ${SESSION_STREAM_ID:-epic:4387} (docs/runbooks/grok-session-canary.md). ${_fc} Drive the next unblocked action without a menu. End session on canary FAIL-HANDOFF (<8/10), not on compact count; after any auto-compact re-score from memory then AUTO-HYDRATE on PASS — never ask the operator to restart. Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the interim ATLAS lane driver (stream ${SESSION_STREAM_ID:-epic:4387}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md in every plane mode; (2) mint the session canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas --stream ${SESSION_STREAM_ID:-epic:4387} (docs/runbooks/grok-session-canary.md). ${_fc} Drive the next unblocked action without a menu. End session on canary FAIL-HANDOFF (<8/10), not on compact count; after any auto-compact re-score from memory then AUTO-HYDRATE on PASS — never ask the operator to restart. Primary checkout is read-only — writes via worktrees."
       ;;
     harness|infra)
       _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the infra handoff dual-write (.claude/harness-epic/*-DRIVER-HANDOFF.md) and stream tail; mint canary (.venv/bin/python -m scripts.session_canary.grok_lane mint --epic harness); reconcile in-flight work; drive the next unblocked infra action. ${_fc} End on canary FAIL-HANDOFF not compact count (docs/runbooks/grok-session-canary.md). After auto-compact you own recovery: score canary FROM MEMORY then read the AUTO-HYDRATE capsule score prints on PASS — never ask the operator to restart or re-load the diary. Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -63,34 +63,11 @@ usage_launcher() {
   exit 0
 }
 
-# Compact dual-aware fleet-comms clause for cold-start prompts (#5512 mid-cutover).
-# Prefer plane + CF primitives; file dual-write is fallback while plane mode is off.
-_fleet_comms_cold_clause() {
-  local plane_mode="${FLEET_COMMS_PLANE_MODE:-off}"
-  printf '%s' \
-    "Fleet-comms (#5512) mid-cutover: prefer message-plane + CF surfaces; fall back to file dual-write while plane mode is ${plane_mode} (do not flip cutovers without operator/advisor GO; do not invent a competing design). " \
-    "Topology/metrics: \`.venv/bin/python -m scripts.fleet_comms plane-status\` (+ metrics/backlog/dead-letters as needed). " \
-    "Formal CF: \`.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr <N>\` then publish-review-verdict (cross-family; never self-seal). " \
-    "Continuity: stream lease already claimed; dual-write diary under \`.claude/<epic>-epic/*-DRIVER-HANDOFF.md\` remains authoritative until stream-authority cutover."
-}
-
-# Resolve plane mode once (fail-open → off). Used for banner + cold-prompt wording.
-_resolve_fleet_comms_plane_mode() {
-  local mode="off"
-  if [ -x "$PROJECT_DIR/.venv/bin/python" ] \
-      && [ -f "$PROJECT_DIR/scripts/fleet_comms/message_plane.py" ]; then
-    mode="$(
-      "$PROJECT_DIR/.venv/bin/python" -c \
-        'from scripts.fleet_comms.message_plane import resolve_plane_mode; print(resolve_plane_mode(None))' \
-        2>/dev/null || true
-    )"
-    case "${mode}" in
-      off|shadow|dual_write) ;;
-      *) mode="off" ;;
-    esac
-  fi
-  printf '%s' "$mode"
-}
+# Shared dual-aware fleet-comms helpers (SSOT rule: fleet-comms-coordination.md).
+if [ -f "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh" ]; then
+  # shellcheck source=scripts/lib/fleet_comms_cold_start.sh
+  source "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh"
+fi
 
 # --- locate grok binary ---
 GROK_BIN=""
@@ -298,7 +275,11 @@ fi
 
 export LEARN_UKRAINIAN_GROK_LAUNCH=1
 export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
-export FLEET_COMMS_PLANE_MODE="$(_resolve_fleet_comms_plane_mode)"
+if command -v fleet_comms_resolve_plane_mode >/dev/null 2>&1; then
+  export FLEET_COMMS_PLANE_MODE="$(fleet_comms_resolve_plane_mode)"
+else
+  export FLEET_COMMS_PLANE_MODE="off"
+fi
 
 # Defaults for grok CLI
 _defaults=()
@@ -330,14 +311,11 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
 fi
 if [ -n "${SESSION_EPIC:-}" ]; then
   echo "Grok ${_grok_ver} · epic=${SESSION_EPIC} stream=${SESSION_STREAM_ID:-unset} handoff=${SESSION_HANDOFF_AGENT:-unset} plane=${FLEET_COMMS_PLANE_MODE}${_branch:+ · ${_branch}}"
-  case "${FLEET_COMMS_PLANE_MODE}" in
-    off)
-      echo "  fleet-comms: plane off → file dual-write fallback; CF via review-pr/publish-review-verdict"
-      ;;
-    shadow|dual_write)
-      echo "  fleet-comms: plane ${FLEET_COMMS_PLANE_MODE} → prefer plane; keep diary dual-write until authority cutover"
-      ;;
-  esac
+  if command -v fleet_comms_print_banner_line >/dev/null 2>&1; then
+    fleet_comms_print_banner_line
+  else
+    echo "  fleet-comms: plane=${FLEET_COMMS_PLANE_MODE} (shared helper missing — treat dual-aware)"
+  fi
   case "${SESSION_EPIC}" in
     atlas)
       echo "  canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas"
@@ -392,7 +370,11 @@ for a in "${_forward[@]+"${_forward[@]}"}"; do
 done
 
 if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
-  _fc="$(_fleet_comms_cold_clause)"
+  if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
+    _fc="$(fleet_comms_cold_clause)"
+  else
+    _fc="Fleet-comms (#5512) mid-cutover: obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status then review-pr; file dual-write while plane off."
+  fi
   case "${SESSION_EPIC}" in
     atlas|practice|practice-hub)
       _cold_prompt="You are the interim ATLAS lane driver (stream ${SESSION_STREAM_ID:-epic:4387}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md while plane is off; (2) mint the session canary: .venv/bin/python -m scripts.session_canary.grok_lane mint --epic atlas --stream ${SESSION_STREAM_ID:-epic:4387} (docs/runbooks/grok-session-canary.md). ${_fc} Drive the next unblocked action without a menu. End session on canary FAIL-HANDOFF (<8/10), not on compact count; after any auto-compact re-score from memory then AUTO-HYDRATE on PASS — never ask the operator to restart. Primary checkout is read-only — writes via worktrees."

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -320,12 +320,12 @@ if [ -n "${SESSION_EPIC:-}" ]; then
   case "${SESSION_EPIC}" in
     atlas)
       echo "  Stream SSOT: ${SESSION_STREAM_ID:-epic:4387}  (session_streams tail --stream ${SESSION_STREAM_ID:-epic:4387})"
-      echo "  File dual-write (fallback while plane off): .claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md"
+      echo "  File dual-write (diary authoritative every plane mode): .claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md"
       echo "  TAKEOVER: .claude/atlas-epic/TAKEOVER-PROMPT.md"
       ;;
     harness|infra)
       echo "  Stream: ${SESSION_STREAM_ID:-epic:4707}"
-      echo "  Infra diary (fallback while plane off): .claude/harness-epic/*-DRIVER-HANDOFF.md"
+      echo "  Infra diary (diary authoritative every plane mode): .claude/harness-epic/*-DRIVER-HANDOFF.md"
       ;;
     *)
       echo "  Open stream: SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}"
@@ -342,11 +342,11 @@ if [ -n "${SESSION_EPIC:-}" ] && [ "${#_forward[@]}" -eq 0 ]; then
   if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
     _fc="$(fleet_comms_cold_clause)"
   else
-    _fc="Fleet-comms (#5512): obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status + review-pr; file dual-write while plane off."
+    _fc="Fleet-comms (#5512): obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status + review-pr; file dual-write stays authoritative in every plane mode (dual_write=shadow/mirror)."
   fi
   case "${SESSION_EPIC}" in
     atlas|practice|practice-hub)
-      _cold_prompt="You are the interim ATLAS lane driver (stream ${SESSION_STREAM_ID:-epic:4387}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md while plane is off; (2) load the session stream digest and mint a canary if one is required. ${_fc} Drive the next unblocked action without a menu. End on canary FAIL-HANDOFF (<8/10). Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the interim ATLAS lane driver (stream ${SESSION_STREAM_ID:-epic:4387}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md in every plane mode; (2) load the session stream digest and mint a canary if one is required. ${_fc} Drive the next unblocked action without a menu. End on canary FAIL-HANDOFF (<8/10). Primary checkout is read-only — writes via worktrees."
       ;;
     harness|infra)
       _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the infra handoff dual-write and stream tail; reconcile in-flight work; drive the next unblocked infra action. ${_fc} End on canary FAIL-HANDOFF. Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -201,6 +201,10 @@ if [ -f "$PROJECT_DIR/scripts/lib/session_supervisor.sh" ]; then
   # shellcheck source=scripts/lib/session_supervisor.sh
   source "$PROJECT_DIR/scripts/lib/session_supervisor.sh"
 fi
+if [ -f "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh" ]; then
+  # shellcheck source=scripts/lib/fleet_comms_cold_start.sh
+  source "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh"
+fi
 
 # Validate epic name when the helper is present.
 if command -v epic_name_valid >/dev/null 2>&1 && [ -n "$_selected_epic" ]; then
@@ -303,17 +307,25 @@ fi
 
 # Lane cold-start hint (printed always when epic is set)
 if [ -n "${SESSION_EPIC:-}" ]; then
+  if command -v fleet_comms_resolve_plane_mode >/dev/null 2>&1; then
+    export FLEET_COMMS_PLANE_MODE="$(fleet_comms_resolve_plane_mode)"
+  else
+    export FLEET_COMMS_PLANE_MODE="off"
+  fi
   echo ""
   echo "Lane: ${SESSION_EPIC} (you are NOT the main orchestrator)."
+  if command -v fleet_comms_print_banner_line >/dev/null 2>&1; then
+    fleet_comms_print_banner_line
+  fi
   case "${SESSION_EPIC}" in
     atlas)
       echo "  Stream SSOT: ${SESSION_STREAM_ID:-epic:4387}  (session_streams tail --stream ${SESSION_STREAM_ID:-epic:4387})"
-      echo "  File dual-write: .claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md (or CLAUDE-DRIVER-HANDOFF.md read-only)"
+      echo "  File dual-write (fallback while plane off): .claude/atlas-epic/INTERIM-DRIVER-HANDOFF.md"
       echo "  TAKEOVER: .claude/atlas-epic/TAKEOVER-PROMPT.md"
       ;;
     harness|infra)
       echo "  Stream: ${SESSION_STREAM_ID:-epic:4707}"
-      echo "  Infra handoff: docs/session-state/ + .agent/claude-infra-thread-handoff.md (read; write your own kimi slot)"
+      echo "  Infra diary (fallback while plane off): .claude/harness-epic/*-DRIVER-HANDOFF.md"
       ;;
     *)
       echo "  Open stream: SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}"
@@ -327,23 +339,28 @@ fi
 
 # Auto-continue the epic stream when --epic is set and the user did not pass a PROMPT.
 if [ -n "${SESSION_EPIC:-}" ] && [ "${#_forward[@]}" -eq 0 ]; then
+  if command -v fleet_comms_cold_clause >/dev/null 2>&1; then
+    _fc="$(fleet_comms_cold_clause)"
+  else
+    _fc="Fleet-comms (#5512): obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status + review-pr; file dual-write while plane off."
+  fi
   case "${SESSION_EPIC}" in
     atlas|practice|practice-hub)
-      _cold_prompt="You are the interim ATLAS lane driver (stream ${SESSION_STREAM_ID:-epic:4387}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md; (2) load the session stream digest and mint a canary if one is required. Drive the next unblocked action without a menu. End on canary FAIL-HANDOFF (<8/10). Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the interim ATLAS lane driver (stream ${SESSION_STREAM_ID:-epic:4387}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) read/execute .claude/atlas-epic/TAKEOVER-PROMPT.md — tail stream, reconcile board, dual-write INTERIM-DRIVER-HANDOFF.md while plane is off; (2) load the session stream digest and mint a canary if one is required. ${_fc} Drive the next unblocked action without a menu. End on canary FAIL-HANDOFF (<8/10). Primary checkout is read-only — writes via worktrees."
       ;;
     harness|infra)
-      _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the infra handoff and stream tail; reconcile in-flight work; drive the next unblocked infra action. End on canary FAIL-HANDOFF. Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the INFRA / harness lane driver (stream ${SESSION_STREAM_ID:-epic:4707}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the infra handoff dual-write and stream tail; reconcile in-flight work; drive the next unblocked infra action. ${_fc} End on canary FAIL-HANDOFF. Do not claim curriculum content lanes. Primary checkout is read-only — writes via worktrees."
       ;;
     hramatka)
-      _cold_prompt="You are the hramatka lane driver (stream ${SESSION_STREAM_ID:-epic:4542}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the epic handoff and stream if present; reconcile and drive the next unblocked action. End on canary FAIL-HANDOFF. Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the hramatka lane driver (stream ${SESSION_STREAM_ID:-epic:4542}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start from the epic handoff dual-write and stream if present; reconcile and drive the next unblocked action. ${_fc} End on canary FAIL-HANDOFF. Primary checkout is read-only — writes via worktrees."
       ;;
     *)
-      _cold_prompt="You are the ${SESSION_EPIC} lane driver (SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}). You are NOT the main orchestrator. The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start: load the epic handoff under .claude/${SESSION_EPIC}-epic/ (or stream tail if SESSION_STREAM_ID is set), reconcile reality, and drive the next unblocked action without a menu. End on canary FAIL-HANDOFF. Primary checkout is read-only — writes via worktrees."
+      _cold_prompt="You are the ${SESSION_EPIC} lane driver (SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}). You are NOT the main orchestrator. The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start: load the epic handoff under .claude/${SESSION_EPIC}-epic/ (or stream tail if SESSION_STREAM_ID is set), reconcile reality, and drive the next unblocked action without a menu. ${_fc} End on canary FAIL-HANDOFF. Primary checkout is read-only — writes via worktrees."
       ;;
   esac
   echo "Cold-start: injecting epic auto-continue prompt (no user PROMPT given)."
   _forward=("$_cold_prompt")
-  unset _cold_prompt
+  unset _cold_prompt _fc
 fi
 
 echo "Launching Kimi Code..."

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -30,6 +30,7 @@ UNSCOPED_RULE_FILES = (
     "critical-rules.md",
     "non-negotiable-rules.md",
     "workflow.md",
+    "fleet-comms-coordination.md",
     "delegate-must-use-worktree.md",
     "cli-help-standard.md",
     "model-assignment.md",

--- a/tests/test_fleet_comms_launcher_awareness.py
+++ b/tests/test_fleet_comms_launcher_awareness.py
@@ -1,0 +1,60 @@
+"""Standalone TUI launchers must point at shared fleet-comms mid-cutover doctrine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+HELPER = REPO / "scripts/lib/fleet_comms_cold_start.sh"
+RULE = REPO / "agents_extensions/shared/rules/fleet-comms-coordination.md"
+
+# Epic-capable standalone TUIs / UIs that cold-start drivers.
+LAUNCHERS = (
+    "start-grok.sh",
+    "start-gemini.sh",
+    "start-kimi.sh",
+    "start-claude.sh",
+    "start-codex.sh",
+)
+
+
+def test_shared_fleet_comms_rule_and_helper_exist() -> None:
+    assert RULE.is_file(), "missing shared rule SSOT"
+    body = RULE.read_text(encoding="utf-8")
+    assert "plane-status" in body
+    assert "review-pr" in body
+    assert "dual_write" in body or "dual-write" in body
+    assert "competing design" in body
+    assert HELPER.is_file(), "missing shared launcher helper"
+    helper = HELPER.read_text(encoding="utf-8")
+    assert "fleet_comms_cold_clause" in helper
+    assert "fleet_comms_resolve_plane_mode" in helper
+    assert "fleet-comms-coordination.md" in helper
+
+
+def test_epic_launchers_source_shared_helper_or_rule_pointer() -> None:
+    for name in LAUNCHERS:
+        path = REPO / name
+        assert path.is_file(), f"missing launcher {name}"
+        text = path.read_text(encoding="utf-8")
+        assert "fleet_comms_cold_start.sh" in text, (
+            f"{name} must source scripts/lib/fleet_comms_cold_start.sh "
+            "(or at least reference it for dual-aware banners)"
+        )
+
+
+def test_prompt_injecting_launchers_include_plane_and_cf_surfaces() -> None:
+    """Grok / Gemini / Kimi inject free-text cold prompts — must mention dual-aware surfaces."""
+    for name in ("start-grok.sh", "start-gemini.sh", "start-kimi.sh"):
+        text = (REPO / name).read_text(encoding="utf-8")
+        # Clause comes from shared helper function name or inlined fallback.
+        assert "fleet_comms_cold_clause" in text or "plane-status" in text
+        assert "fleet-comms-coordination" in text or "fleet_comms_cold_clause" in text
+
+
+def test_agents_md_carries_fleet_comms_mid_cutover_digest() -> None:
+    """Codex-family boots from AGENTS.md — need a non-skippable digest pointer."""
+    body = (REPO / "AGENTS.md").read_text(encoding="utf-8")
+    assert "fleet-comms-coordination.md" in body
+    assert "plane-status" in body
+    assert "dual_write" in body or "dual-write" in body or "plane" in body

--- a/tests/test_fleet_comms_launcher_awareness.py
+++ b/tests/test_fleet_comms_launcher_awareness.py
@@ -25,11 +25,19 @@ def test_shared_fleet_comms_rule_and_helper_exist() -> None:
     assert "review-pr" in body
     assert "dual_write" in body or "dual-write" in body
     assert "competing design" in body
+    # Post-#5632 Sol alignment (Opus drive-epic skill).
+    assert "drive-epic" in body
+    assert "start-" in body and "drive.sh" in body
+    assert "authoritative" in body.lower()
+    assert "not implemented" in body.lower() or "shadow/mirror" in body.lower()
+    assert "PR_NUMBER" in body or "PR number" in body.lower()
     assert HELPER.is_file(), "missing shared launcher helper"
     helper = HELPER.read_text(encoding="utf-8")
     assert "fleet_comms_cold_clause" in helper
     assert "fleet_comms_resolve_plane_mode" in helper
     assert "fleet-comms-coordination.md" in helper
+    assert "drive-epic" in helper
+    assert "authoritative" in helper
 
 
 def test_epic_launchers_source_shared_helper_or_rule_pointer() -> None:
@@ -58,3 +66,19 @@ def test_agents_md_carries_fleet_comms_mid_cutover_digest() -> None:
     assert "fleet-comms-coordination.md" in body
     assert "plane-status" in body
     assert "dual_write" in body or "dual-write" in body or "plane" in body
+    assert "drive-epic" in body
+    assert "authoritative" in body.lower()
+
+
+def test_drive_wrappers_exist_and_point_at_base_launchers() -> None:
+    """#5632 per-model drive wrappers must remain thin peers of start-*.sh."""
+    for name, needle in (
+        ("start-grok-drive.sh", "start-grok.sh"),
+        ("start-gemini-drive.sh", "start-gemini.sh"),
+        ("start-sonnet-drive.sh", "start-claude.sh"),
+    ):
+        path = REPO / name
+        assert path.is_file(), f"missing {name} from #5632"
+        text = path.read_text(encoding="utf-8")
+        assert needle in text
+        assert "drive-epic" in text or "epic-orchestrator-roster" in text

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -36,6 +36,7 @@ def test_rule_sources_includes_all_unscoped_files():
         "agents_extensions/shared/rules/critical-rules.md",
         "agents_extensions/shared/rules/non-negotiable-rules.md",
         "agents_extensions/shared/rules/workflow.md",
+        "agents_extensions/shared/rules/fleet-comms-coordination.md",
         "agents_extensions/shared/rules/delegate-must-use-worktree.md",
         "agents_extensions/shared/rules/cli-help-standard.md",
         "agents_extensions/shared/rules/model-assignment.md",
@@ -47,6 +48,17 @@ def test_rule_sources_includes_all_unscoped_files():
     assert rules_router.RULE_SOURCES.index(
         "agents_extensions/shared/rules/model-assignment.md"
     ) < rules_router.RULE_SOURCES.index("docs/best-practices/fleet-role-scorecard.md")
+    # Fleet-comms mid-cutover rule sits with operational workflow, before model table.
+    assert rules_router.RULE_SOURCES.index(
+        "agents_extensions/shared/rules/workflow.md"
+    ) < rules_router.RULE_SOURCES.index(
+        "agents_extensions/shared/rules/fleet-comms-coordination.md"
+    )
+    assert rules_router.RULE_SOURCES.index(
+        "agents_extensions/shared/rules/fleet-comms-coordination.md"
+    ) < rules_router.RULE_SOURCES.index(
+        "agents_extensions/shared/rules/model-assignment.md"
+    )
 
 
 def test_rules_live_assembly_includes_fleet_scorecard():
@@ -61,6 +73,20 @@ def test_rules_live_assembly_includes_fleet_scorecard():
     assert "Fleet role scorecard" in md
     assert "Fleet topology" in md or "orchestrator" in md.lower()
     assert body["hash"] == hashlib.sha256(md.encode("utf-8")).hexdigest()
+
+
+def test_rules_live_assembly_includes_fleet_comms_coordination():
+    """Standalone TUI/UI drivers must receive dual-aware fleet-comms mid-cutover SSOT."""
+    resp = client.get("/api/rules?format=json")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "agents_extensions/shared/rules/fleet-comms-coordination.md" in body["sources"]
+    md = body["markdown"]
+    assert "Fleet-comms coordination" in md or "fleet-comms coordination" in md.lower()
+    assert "plane-status" in md
+    assert "review-pr" in md
+    assert "dual_write" in md or "dual-write" in md
+    assert "do not invent a competing design" in md.lower() or "competing design" in md
 
 
 def test_rules_markdown_default(monkeypatch, tmp_path):

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -87,6 +87,9 @@ def test_rules_live_assembly_includes_fleet_comms_coordination():
     assert "review-pr" in md
     assert "dual_write" in md or "dual-write" in md
     assert "do not invent a competing design" in md.lower() or "competing design" in md
+    # Sol #5632 F003: no false "post-cutover drop file handoffs" doctrine.
+    assert "authoritative in every" in md.lower() or "stays authoritative" in md.lower()
+    assert "drive-epic" in md
 
 
 def test_rules_markdown_default(monkeypatch, tmp_path):

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -100,6 +100,10 @@ def _build_fake_project(tmp_path: Path) -> tuple[Path, Path]:
         (_REPO_ROOT / "scripts" / "lib" / "handoff_identity.sh").read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+    (lib_dir / "fleet_comms_cold_start.sh").write_text(
+        (_REPO_ROOT / "scripts" / "lib" / "fleet_comms_cold_start.sh").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
     (guard_dir / "assert_primary_on_main.py").write_text("#!/usr/bin/env python3\nraise SystemExit(0)\n")
     (guard_dir / "assert_primary_on_main.py").chmod(0o755)
     audit_dir = project / "scripts" / "audit"


### PR DESCRIPTION
## Summary
Makes dual-aware **fleet-comms mid-cutover** binding for every standalone TUI/UI via shared rules (`/api/rules`), not only Grok cold-prompts or an optional skill.

### Binding SSOT
- New `agents_extensions/shared/rules/fleet-comms-coordination.md`
- Registered in `RULE_SOURCES` (after workflow, before model-assignment)
- Offline fallback + workflow cold-start includes `plane-status`
- `AGENTS.md` digest for Codex-family boots that may not refetch `/api/rules` immediately

### Launchers (thin pointer, shared helper)
- `scripts/lib/fleet_comms_cold_start.sh` — resolve plane mode, banner, cold-prompt clause
- `start-grok.sh` / `start-gemini.sh` / `start-kimi.sh` — inject dual-aware clause
- `start-claude.sh` / `start-codex.sh` — epic banner + `FLEET_COMMS_PLANE_MODE` export

### Explicit non-goals
- Does **not** flip `dual_write`, stream authority, or `formal_review_eligible`
- Does **not** touch Claude’s `drive-epic` skill (#5632) — skill = method; this rule = must

## Related
- #5512 product · #4707 stream · complements #5631 (Grok launcher) + #5632 (drive-epic skill)

## Test plan
- [x] `bash -n` on touched launchers + helper
- [x] `pytest tests/test_fleet_comms_launcher_awareness.py tests/test_start_grok_launcher.py tests/test_manifest_api.py` (45 green with operator wiring)
- [ ] CI green
- [ ] Cross-family CF (non-Grok) → auto-merge