### PR TITLE
fix(ci): run pytest on scripts/config/** changes (close config-only skip gap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - 'requirements*.txt'
       - 'requirements.lock'
       - 'scripts/**/*.py'
+      # Config YAML is runtime input for catalog/fleet tests (CF F001 on #5638).
+      - 'scripts/config/**'
       - 'scripts/check_rules_deployment.sh'
       - 'scripts/deploy_prompts.sh'
       - 'start-claude.sh'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,12 @@ jobs:
               - 'pyproject.toml'
               - 'scripts/**/*.py'
               - 'tests/**/*.py'
+              # Config with test fixture mirrors: test_model_catalog reads
+              # model_catalog.yaml + fleet_communications.yaml; a config-only edit
+              # (no .py) must run pytest, else an orchestrator_seats / model-pin
+              # regression reaches main unguarded (same #3873/#4888/#4936 class —
+              # a yaml change that skipped pytest would ship broken routing to main).
+              - 'scripts/config/**'
               # Learner content that python tests read at runtime — a deletion/edit
               # here must run pytest, else a content regression reaches main unguarded
               # (this is the #3873 root cause: #3867 deleted curriculum files,


### PR DESCRIPTION
## Problem

The `python` paths-filter in `.github/workflows/ci.yml` gates the required `Test (pytest)` job. It covered `scripts/**/*.py` and `tests/**/*.py` but **not `scripts/config/**`** — even though `tests/test_model_catalog.py` reads `scripts/config/model_catalog.yaml` and `fleet_communications.yaml` at runtime.

**Result:** a config-only edit (no `.py` touched) would **skip pytest**, letting an `orchestrator_seats` / model-pin regression reach `main` unguarded — and turn `main` red for the next PR. This is the exact `#3873/#4888/#4936` class the filter has been patched for repeatedly (data-only edits skipping pytest).

Found while merging #5632: the codex-drop was a `model_catalog.yaml` change that breaks `test_model_catalog.py`, and pytest only ran because that PR *also* touched a test file. A pure config edit would have slipped through green.

## Fix

Add `- 'scripts/config/**'` to the `python` filter. Declarative glob only — no `run:` command, no untrusted input (the GitHub Actions injection warning does not apply).

## Validation

- `ci.yml` YAML parses; actionlint runs in CI.
- Behavior: any `scripts/config/**` change now triggers pytest; docs-only PRs still skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)