### PR TITLE
feat(launchers): wire drive-epic playbook into hook-less cold prompts (closes #5632 F005)

### DIFF
--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -361,6 +361,8 @@ if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
     _fc="Fleet-comms (#5512): obey agents_extensions/shared/rules/fleet-comms-coordination.md; plane-status + review-pr; file dual-write stays authoritative in every plane mode (dual_write=shadow/mirror)."
   fi
   _cold_prompt="You are the Gemini ${SESSION_EPIC} lane orchestrator (stream ${SESSION_STREAM_ID:-unset}). The launcher has already claimed the stream lease; do NOT open or resume it yourself. Immediately: (1) Check stream state in ${_handoff_path} or docs/session-state/; (2) Run 'codexbar usage' to monitor fleet quota/limits; (3) Assess tasks, pick the optimal model/agent from the capability matrix (AGENTS.md, model-assignment.md via /api/rules); (4) Dispatch worker sub-tasks via worktrees using 'scripts/delegate.py dispatch ...'; (5) Obey advisor approval gate (Fable / Sol) for architecture/process changes; (6) Enforce independent cross-family review via review-pr / publish-review-verdict before PR merges. ${_fc} Primary checkout is read-only — all edits belong in worktrees."
+  # Wire the drive-epic playbook into the cold prompt (Sol review #5632 F005).
+  _cold_prompt="${_cold_prompt} Your orchestration playbook is agents_extensions/shared/skills/drive-epic/SKILL.md (invoke \$drive-epic if your harness exposes skills) — load it before acting; it defines the topology→route→dispatch→cross-family-review→merge→handoff loop and the escalation triggers."
   echo "Cold-start: injecting epic orchestrator auto-continue prompt."
   if [ "$_has_print" -eq 1 ]; then
     _forward+=("$_cold_prompt")

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -389,6 +389,8 @@ if [ -n "${SESSION_EPIC:-}" ] && [ "$_has_prompt" -eq 0 ]; then
       _cold_prompt="You are the ${SESSION_EPIC} lane driver (SESSION_STREAM_ID=${SESSION_STREAM_ID:-unset}). You are NOT the main orchestrator. The launcher has already claimed the stream lease; do NOT open or resume it yourself. Cold-start: load the epic handoff dual-write under .claude/${SESSION_EPIC}-epic/ (or stream tail if SESSION_STREAM_ID is set), mint canary via .venv/bin/python -m scripts.session_canary.grok_lane mint --epic ${SESSION_EPIC}, reconcile reality, and drive the next unblocked action without a menu. ${_fc} End on canary FAIL-HANDOFF not compact count (docs/runbooks/grok-session-canary.md). Primary checkout is read-only — writes via worktrees."
       ;;
   esac
+  # Wire the drive-epic playbook into every epic's cold prompt (Sol review #5632 F005).
+  _cold_prompt="${_cold_prompt} Your orchestration playbook is agents_extensions/shared/skills/drive-epic/SKILL.md (invoke \$drive-epic if your harness exposes skills) — load it before acting; it defines the topology→route→dispatch→cross-family-review→merge→handoff loop and the escalation triggers."
   _forward+=("$_cold_prompt")
   unset _cold_prompt _fc
 fi

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -381,6 +381,8 @@ if [ -n "${SESSION_EPIC:-}" ] && [ "${#_forward[@]}" -eq 0 ]; then
       ;;
   esac
   echo "Cold-start: injecting epic auto-continue prompt (no user PROMPT given)."
+  # Wire the drive-epic playbook into every epic's cold prompt (Sol review #5632 F005).
+  _cold_prompt="${_cold_prompt} Your orchestration playbook is agents_extensions/shared/skills/drive-epic/SKILL.md (invoke \$drive-epic if your harness exposes skills) — load it before acting; it defines the topology→route→dispatch→cross-family-review→merge→handoff loop and the escalation triggers."
   _forward=("$_cold_prompt")
   unset _cold_prompt _fc
 fi


### PR DESCRIPTION
## Why

PR #5632 shipped the `drive-epic` skill + `start-<model>-drive.sh` wrappers, but Sol's review flagged **F005**: the wrappers *advertise* the skill yet nothing loads it — the hook-less launchers (grok/gemini/kimi) inject hand-written per-epic cold prompts that never mention the playbook, so a driver launched via a wrapper could run under the legacy bespoke prompt and skip the routing/review/escalation/cutover contracts. #5632 reworded the wrappers to be honest ("does NOT auto-load; invoke manually"); **this PR closes the gap at the source.**

## Change

Append **one** universal instruction to each hook-less launcher's cold prompt, pointing the driver at the playbook:

> Your orchestration playbook is `agents_extensions/shared/skills/drive-epic/SKILL.md` (invoke `$drive-epic` if your harness exposes skills) — load it before acting…

- **File-path form** so grok/kimi work even without a skills mechanism; `$drive-epic` for skill-capable harnesses (Claude/Gemini).
- One append per launcher (`start-grok.sh`, `start-gemini.sh`, `start-kimi.sh`) covers every epic branch — no per-epic churn.
- **Claude/Sonnet** load the skill via the SessionStart chain, so their launcher needs no change.

## Validation

- `bash -n` clean on all three launchers.
- Declarative prompt-string append only; no control-flow change.

## Follow-up note

Once this lands, the `start-<model>-drive.sh` wrappers' "does NOT auto-load the skill" caveat (added in #5632) can be softened, since the launchers now inject the playbook pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)