### PR TITLE
feat(launchers): add `--` CLI-flag passthrough to start-kimi.sh and start-kimicc.sh

### DIFF
--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -8,6 +8,10 @@
 #   --model <id>                      Kimi model: k3 (default), k2.7, k2.7-highspeed
 #                                     (mapped to the kimi-code/* aliases in config.toml)
 #   --help-launcher                   This help (does not start kimi)
+#   -- <kimi-cli flags...>            Everything after -- is passed verbatim to
+#                                     the kimi CLI (e.g. -- -y, -- --plan).
+#                                     Unrecognized args BEFORE -- are joined
+#                                     into the prompt text, as before.
 #
 # Environment exported for hooks / dual-write / session streams:
 #   SESSION_EPIC              from --epic
@@ -31,6 +35,8 @@
 #   ./start-kimi.sh --epic atlas --stream epic:4387 --model k3
 #   ./start-kimi.sh --epic harness "continue the infra queue"
 #   ./start-kimi.sh --model k2.7 "review the open PR"
+#   ./start-kimi.sh -- -y                           # interactive TUI with --yolo
+#   ./start-kimi.sh "triage the queue" -- -y --plan # headless prompt + CLI flags
 
 set -euo pipefail
 
@@ -54,7 +60,7 @@ if git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 usage_launcher() {
-  sed -n '2,33p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
+  sed -n '2,39p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
   exit 0
 }
 # --- locate kimi binary ---
@@ -113,6 +119,10 @@ fi
 
 # --- parse launcher-only flags; build forward argv and prompt ---
 _forward=()
+# CLI passthrough: everything after a literal `--` is forwarded verbatim to the
+# kimi binary (appended last, so user flags can override launcher defaults).
+_cli_flags=()
+_past_ddash=0
 _selected_epic=""
 _selected_stream=""
 _handoff_override=""
@@ -121,6 +131,18 @@ _has_model=0
 _prev=""
 
 for arg in "$@"; do
+  if [ "$_past_ddash" = "1" ]; then
+    _cli_flags+=("$arg")
+    continue
+  fi
+  if [ "$arg" = "--" ]; then
+    if [ -n "$_prev" ]; then
+      echo "Error: dangling launcher flag '$_prev' without a value before '--'." >&2
+      exit 1
+    fi
+    _past_ddash=1
+    continue
+  fi
   if [ "$_prev" = "--epic" ]; then
     _selected_epic="${arg%.epic}"
     _prev=""
@@ -349,14 +371,14 @@ fi
 echo "Launching Kimi Code..."
 if [ "${#_forward[@]}" -eq 0 ]; then
   # Interactive TUI: no prompt anywhere (bare launch, no --epic). The kimi CLI
-  # rejects an empty -p, so never pass one.
-  exec "$KIMI_BIN" ${_model_args[@]+"${_model_args[@]}"}
+  # rejects an empty -p, so never pass one. Passthrough flags (-- ...) apply.
+  exec "$KIMI_BIN" ${_model_args[@]+"${_model_args[@]}"} ${_cli_flags[@]+"${_cli_flags[@]}"}
 fi
 # Headless one-shot (explicit PROMPT or epic cold-start). stream-json is for
 # machine consumers (piped stdout, e.g. fleet capture); a human on a TTY gets
-# the default plain-text response.
+# the default plain-text response. Passthrough flags come last and win ties.
 _out_args=()
 if [ ! -t 1 ]; then
   _out_args=(--output-format stream-json)
 fi
-exec "$KIMI_BIN" -p "${_forward[*]}" ${_model_args[@]+"${_model_args[@]}"} ${_out_args[@]+"${_out_args[@]}"}
+exec "$KIMI_BIN" -p "${_forward[*]}" ${_model_args[@]+"${_model_args[@]}"} ${_out_args[@]+"${_out_args[@]}"} ${_cli_flags[@]+"${_cli_flags[@]}"}

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -73,6 +73,13 @@ Options:
                     infra-orchestrator when no --epic is given (an epic already
                     implies the lane identity); explicit --agent wins
   -h, --help        Show this help
+  -- [CLAUDE_ARGS...]
+                    Everything after -- is forwarded verbatim to Claude Code,
+                    even args that collide with launcher flags above
+                    (e.g. -- --help shows Claude Code's help, not this one).
+                    Unrecognized args BEFORE -- are already forwarded too;
+                    -- exists for the colliding ones. A forwarded --model is
+                    still rejected: KimiCC owns the lead model.
 
 Environment:
   KIMICC_MODEL / KIMICC_ENDPOINT     Defaults for --model / --endpoint
@@ -101,6 +108,7 @@ Examples:
   ./start-kimicc.sh --model k2.7-highspeed --epic harness
   MOONSHOT_API_KEY=<your-key> ./start-kimicc.sh --model k3
   ./start-kimicc.sh --endpoint coding --isolate-config   # subscription, long session
+  ./start-kimicc.sh -- --verbose --help                  # flags for Claude Code itself
 
 Headless / native Kimi (not this launcher):
   scripts/delegate.py dispatch --agent kimi --model k3 …
@@ -196,6 +204,15 @@ resolve_auth_token() {
 
 while (($#)); do
   case "$1" in
+    --)
+      # Explicit passthrough: forward the rest verbatim (still subject to the
+      # forwarded --model rejection below — KimiCC owns the lead model).
+      shift
+      while (($#)); do
+        FORWARD_ARGS+=("$1")
+        shift
+      done
+      ;;
     --model)
       if (($# < 2)); then
         echo "Error: --model requires k3, k2.7, or k2.7-highspeed." >&2

--- a/tests/test_start_kimi_launcher.py
+++ b/tests/test_start_kimi_launcher.py
@@ -332,3 +332,50 @@ def test_hermes_install_preferred_over_legacy_binary(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr + result.stdout
     assert capture.read_text(encoding="utf-8").strip() == "hermes"
+
+
+def test_passthrough_flags_only_launch_interactive_tui(tmp_path: Path) -> None:
+    """`-- <flags>` with no prompt: interactive TUI, flags reach the CLI verbatim."""
+    values, argv_blob, result, _project, supervisor_capture = _run_launcher(
+        tmp_path, ["--", "-y"]
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "unset"
+    assert not supervisor_capture.exists()
+    parts = [p for p in argv_blob.split("\0") if p]
+    assert parts == ["-y"]
+
+
+def test_passthrough_flags_appended_after_prompt(tmp_path: Path) -> None:
+    """Prompt stays the prompt; flags after -- come last so they win ties."""
+    _values, argv_blob, result, _project, _supervisor_capture = _run_launcher(
+        tmp_path,
+        ["--model", "k3", "do the thing", "--", "-y", "--plan"],
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    parts = [p for p in argv_blob.split("\0") if p]
+    assert parts[0] == "-p"
+    assert parts[1] == "do the thing"
+    assert parts[-2:] == ["-y", "--plan"]
+
+
+def test_passthrough_after_epic_cold_start(tmp_path: Path) -> None:
+    """`--epic harness -- -y`: cold-start prompt injected AND flag forwarded."""
+    values, argv_blob, result, _project, _supervisor_capture = _run_launcher(
+        tmp_path, ["--epic", "harness", "--", "-y"]
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "harness"
+    parts = [p for p in argv_blob.split("\0") if p]
+    assert parts[0] == "-p"
+    assert "do NOT open or resume it yourself" in parts[1]
+    assert parts[-1] == "-y"
+
+
+def test_dangling_launcher_flag_before_passthrough_rejected(tmp_path: Path) -> None:
+    """`--epic -- -y` must fail: --epic would otherwise swallow '--' as its value."""
+    _values, _argv_blob, result, _project, _supervisor_capture = _run_launcher(
+        tmp_path, ["--epic", "--", "-y"]
+    )
+    assert result.returncode == 1
+    assert "dangling launcher flag" in result.stderr

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -545,4 +545,26 @@ def test_empty_kimicc_agent_inherits_project_default(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert "arg=--agent" not in output
     assert "arg=infra-orchestrator" not in output
+
+
+def test_ddash_passthrough_forwards_colliding_flags(tmp_path: Path) -> None:
+    """Args after -- reach Claude Code verbatim, even ones colliding with
+    launcher flags (a bare --endpoint would otherwise be consumed by it)."""
+    output, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "platform", "--no-isolate-config", "--", "--verbose", "--endpoint"],
+    )
+    assert result.returncode == 0, result.stderr
+    assert "arg=--verbose" in output
+    assert "arg=--endpoint" in output
+
+
+def test_ddash_forwarded_model_still_rejected(tmp_path: Path) -> None:
+    """-- does not smuggle a lead-model override past the launcher."""
+    _, result = _run_with_fakes(
+        tmp_path,
+        ["--endpoint", "platform", "--no-isolate-config", "--", "--model", "opus"],
+    )
+    assert result.returncode == 2
+    assert "owns the lead model" in result.stderr
     assert "default; override with --agent" not in result.stdout


### PR DESCRIPTION
## Summary

Add a `--` passthrough convention to both Kimi launchers so operators can forward flags to the underlying CLI — previously impossible, because unrecognized args were treated as prompt text (start-kimi.sh) or consumed by launcher flag parsing (start-kimicc.sh). Motivation: e.g. `./start-kimi.sh -- -y` for an interactive yolo TUI.

## Changes

- `start-kimi.sh` — everything after a literal `--` is forwarded verbatim to the kimi CLI, appended last on the exec line so operator flags win ties over launcher defaults. Works in all launch modes:
  - `./start-kimi.sh -- -y` → interactive TUI with `--yolo`
  - `./start-kimi.sh "prompt" -- -y --plan` → headless prompt + flags
  - `./start-kimi.sh --epic harness -- -y` → cold-start prompt + flag
  - Unrecognized args **before** `--` keep the old join-into-prompt behavior (backward compatible).
  - A dangling launcher flag before `--` (e.g. `--epic -- -y`) now errors instead of silently swallowing `--`.
- `start-kimicc.sh` — same `--` convention; args after it reach Claude Code even when they collide with launcher flags (e.g. `-- --help` shows Claude Code's help). A forwarded `--model` is still rejected: KimiCC owns the lead model.
- Header/usage docs updated in both scripts.

## Tests

- 6 new passthrough tests: 4 in `tests/test_start_kimi_launcher.py`, 2 in `tests/test_start_kimicc.py`.
- Full launcher suites pass: 39 (kimi + kimicc) + 4 (`test_kimi_lane_bootstrap.py`).
- `bash -n` clean on both scripts; pre-commit (ruff + affected pytest) green.

## Checklist

- [x] No linter config / `.python-version` changes
- [x] No generated artifacts in diff (4 files, +113/−5)
- [x] X-Agent trailer present (`kimi/launcher-passthrough`)

## Review gate

Author: Kimi (Moonshot). Cross-family review requested via AGY (Gemini) — see PR comments.

🤖 Generated with Kimi Code
