### PR TITLE
feat(fleet-comms): roster + formal-CF eligibility drift lint (#5642)

### DIFF
--- a/.github/workflows/model-catalog-freshness.yml
+++ b/.github/workflows/model-catalog-freshness.yml
@@ -4,23 +4,33 @@ on:
   pull_request:
     paths:
       - 'scripts/config/model_catalog.yaml'
+      - 'scripts/config/fleet_communications.yaml'
       - 'scripts/review/model_catalog.py'
       - 'scripts/review/reviewer_resolver.py'
       - 'scripts/agent_runtime/registry.py'
       - 'scripts/lint/lint_model_catalog.py'
+      - 'scripts/lint/lint_fleet_roster.py'
       - 'agents_extensions/shared/rules/model-assignment.md'
+      - 'docs/runbooks/fleet-comms-open-gaps.md'
+      - 'docs/runbooks/epic-orchestrator-roster.md'
       - 'docs/best-practices/agent-activity-matrix.md'
+      - 'tests/test_lint_fleet_roster.py'
       - '.github/workflows/model-catalog-freshness.yml'
   push:
     branches: [main]
     paths:
       - 'scripts/config/model_catalog.yaml'
+      - 'scripts/config/fleet_communications.yaml'
       - 'scripts/review/model_catalog.py'
       - 'scripts/review/reviewer_resolver.py'
       - 'scripts/agent_runtime/registry.py'
       - 'scripts/lint/lint_model_catalog.py'
+      - 'scripts/lint/lint_fleet_roster.py'
       - 'agents_extensions/shared/rules/model-assignment.md'
+      - 'docs/runbooks/fleet-comms-open-gaps.md'
+      - 'docs/runbooks/epic-orchestrator-roster.md'
       - 'docs/best-practices/agent-activity-matrix.md'
+      - 'tests/test_lint_fleet_roster.py'
       - '.github/workflows/model-catalog-freshness.yml'
   schedule:
     - cron: '17 7 * * 1'
@@ -48,3 +58,6 @@ jobs:
 
       - name: Validate catalog structure and freshness
         run: .venv/bin/python scripts/lint/lint_model_catalog.py
+
+      - name: Validate fleet roster + formal-CF eligibility projections
+        run: .venv/bin/python scripts/lint/lint_fleet_roster.py

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -104,14 +104,25 @@ Machine-readable pins: `scripts/config/model_catalog.yaml` → `orchestrator_sea
 - **Orchestrator seats (fleet-comms stream #5512 / #4707)** — any of these may own a cold-start /
   drive-board loop (prioritize → delegate → request CF → merge-in-lane). Do **not** run worker-level
   implementation on the orchestrator seat — delegate it (>50 LOC non-test, mechanical, fixtures, or
-  anything parallelizable → a worker).
+  anything parallelizable → a worker). **Codex is not a driver seat** (user 2026-07-22): it remains a
+  first-class coding lane + sealed formal-CF reviewer; the 272K window is not worth driver rollover
+  overhead. Machine authority: `model_catalog.yaml` → `orchestrator_seats` (lint: #5642).
+
+  Human-readable summary (pins must match the marked projection below):
 
   | Seat | Default (loop) | Escalate (deep) | Notes |
   | --- | --- | --- | --- |
   | **claude** | `claude-sonnet-5` @ high | **`claude-fable-5` @ xhigh** | Same pattern as AGY Flash→Pro |
-  | **codex** | `gpt-5.6-terra` @ high | **`gpt-5.6-sol` @ xhigh** | Terra loop; Sol for architecture / hard judgment |
   | **grok** | `grok-4.5` @ high | same SKU (no higher pin yet) | Cursor **explicit** `grok-4.5` = availability fallback, not quality escalate |
   | **agy** | `gemini-3.6-flash-high` @ high | **`gemini-3.1-pro-high` @ high** | Flash loop; Pro deep single-shot |
+
+  <!-- fleet-roster-projection:begin orchestrator_seats -->
+  | seat | model_id | effort | escalate_model_id | escalate_effort |
+  | --- | --- | --- | --- | --- |
+  | agy | gemini-3.6-flash-high | high | gemini-3.1-pro-high | high |
+  | claude | claude-sonnet-5 | high | claude-fable-5 | xhigh |
+  | grok | grok-4.5 | high | grok-4.5 | high |
+  <!-- fleet-roster-projection:end orchestrator_seats -->
 
   **Escalate when:** deep single-shot, architecture, hard multi-file judgment, high-stakes synthesis —
   not for routine queue grind. Machine fields: `escalate_model_id` / `escalate_effort` /
@@ -123,11 +134,25 @@ Machine-readable pins: `scripts/config/model_catalog.yaml` → `orchestrator_sea
   `review-pr <N> --model gpt-5.6-sol --effort xhigh` or
   `review-pr <N> --reviewer claude --model claude-fable-5 --effort xhigh`.
 
+  <!-- fleet-roster-projection:begin formal_review_eligible -->
+  | endpoint | formal_review_eligible |
+  | --- | --- |
+  | agy | false |
+  | claude | true |
+  | codex | true |
+  | cursor | false |
+  | gemini | false |
+  | glm-local | false |
+  | grok | false |
+  | kimi | false |
+  <!-- fleet-roster-projection:end formal_review_eligible -->
+
 - **Advisor = `gpt-5.6-sol` @ `xhigh` (on-demand, NOT a standing worker).** Same as codex
-  orchestrator escalate — convene for the hard,
+  formal-CF / authority escalate (coding + sealed review seat — not a driver) — convene for the hard,
   high-judgment calls only: architecture, high-stakes design/spec/ADR review, difficult debugging, final
   synthesis. Consult BEFORE committing a substantive design; do not use for routine work.
-- **Workers = every other lane** — `gpt-5.6-luna`, `cursor`, `kimi`, `deepseek`, `pool` (**Laguna family exact IDs:** default **`laguna-s-2.1`** gen-2 S; light **`laguna-xs-2.1`** gen-2 XS; fallback only **`laguna-m.1`** gen-1 — never invent s2/m2 orthography),
+- **Workers = every other lane** — `gpt-5.6-terra` / `gpt-5.6-luna` (codex coding, not driver),
+  `cursor`, `kimi`, `deepseek`, `pool` (**Laguna family exact IDs:** default **`laguna-s-2.1`** gen-2 S; light **`laguna-xs-2.1`** gen-2 XS; fallback only **`laguna-m.1`** gen-1 — never invent s2/m2 orthography),
   `gemma`, `glm` (LOCAL-ONLY), plus non-orchestrating use of the seats above. They do the build /
   implementation / mechanical / review work. Keep lanes busy; queue rather than idle.
 

--- a/docs/runbooks/epic-orchestrator-roster.md
+++ b/docs/runbooks/epic-orchestrator-roster.md
@@ -50,6 +50,33 @@ cross-family **GPT ↔ Claude** (no DeepSeek, and Grok is never a judge seat) �
   and the codex comms endpoint) — it just no longer owns a driver loop.
 - **Kimi K3** — frontier coder/reviewer + cross-family escalation authority (`max-effort-only` makes a continuous loop costly).
 
+### Machine-authority projection (lint #5642)
+
+Exact tables below must match `scripts/config/model_catalog.yaml` → `orchestrator_seats` and
+`scripts/config/fleet_communications.yaml` → `endpoints[*].formal_review_eligible`. Enforced by
+`.venv/bin/python scripts/lint/lint_fleet_roster.py` (never rewrites prose).
+
+<!-- fleet-roster-projection:begin orchestrator_seats -->
+| seat | model_id | effort | escalate_model_id | escalate_effort |
+| --- | --- | --- | --- | --- |
+| agy | gemini-3.6-flash-high | high | gemini-3.1-pro-high | high |
+| claude | claude-sonnet-5 | high | claude-fable-5 | xhigh |
+| grok | grok-4.5 | high | grok-4.5 | high |
+<!-- fleet-roster-projection:end orchestrator_seats -->
+
+<!-- fleet-roster-projection:begin formal_review_eligible -->
+| endpoint | formal_review_eligible |
+| --- | --- |
+| agy | false |
+| claude | true |
+| codex | true |
+| cursor | false |
+| gemini | false |
+| glm-local | false |
+| grok | false |
+| kimi | false |
+<!-- fleet-roster-projection:end formal_review_eligible -->
+
 ---
 
 ## Why these seats (the "least-bite" logic)

--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -63,14 +63,23 @@ file handoffs remain authoritative until then.
 ## Orchestrator seats (fleet-comms stream)
 
 Any of these may own a cold-start / drive-board loop. Pins live in
-`scripts/config/model_catalog.yaml` → `orchestrator_seats`.
+`scripts/config/model_catalog.yaml` → `orchestrator_seats`. **Codex is not a driver**
+(user 2026-07-22) — coding + sealed formal CF only. Drift lint: #5642 /
+`scripts/lint/lint_fleet_roster.py`.
 
 | Seat | Default (loop) | Escalate (deep) | Sealed formal CF as *reviewer* |
 | --- | --- | --- | --- |
 | **claude** | `claude-sonnet-5` @ high | **`claude-fable-5` @ xhigh** | yes (`review-pr --reviewer claude`) |
-| **codex** | `gpt-5.6-terra` @ high | **`gpt-5.6-sol` @ xhigh** | yes (default `review-pr`) |
 | **grok** | `grok-4.5` @ high | same SKU (Cursor = avail. fallback) | no until #5557 |
 | **agy** | `gemini-3.6-flash-high` @ high | **`gemini-3.1-pro-high` @ high** | no until #5555 — still *requests* CF |
+
+<!-- fleet-roster-projection:begin orchestrator_seats -->
+| seat | model_id | effort | escalate_model_id | escalate_effort |
+| --- | --- | --- | --- | --- |
+| agy | gemini-3.6-flash-high | high | gemini-3.1-pro-high | high |
+| claude | claude-sonnet-5 | high | claude-fable-5 | xhigh |
+| grok | grok-4.5 | high | grok-4.5 | high |
+<!-- fleet-roster-projection:end orchestrator_seats -->
 
 Escalate when: architecture, hard multi-file judgment, high-stakes synthesis — not routine queue.
 
@@ -78,13 +87,29 @@ Escalate when: architecture, hard multi-file judgment, high-stakes synthesis —
 # AGY default / escalate
 .venv/bin/python scripts/delegate.py dispatch --agent agy --model gemini-3.6-flash-high ...
 .venv/bin/python scripts/delegate.py dispatch --agent agy --model gemini-3.1-pro-high ...
-# Codex escalate
-.venv/bin/python scripts/delegate.py dispatch --agent codex --model gpt-5.6-sol ...
 # Claude escalate
 .venv/bin/python scripts/delegate.py dispatch --agent claude --model claude-fable-5 ...
+# Codex coding / formal-CF authority escalate (NOT a driver seat)
+.venv/bin/python scripts/delegate.py dispatch --agent codex --model gpt-5.6-sol ...
 ```
 
 ## Formal CF defaults (orchestrator-ready)
+
+Machine eligibility SSOT: `scripts/config/fleet_communications.yaml` →
+`endpoints[*].formal_review_eligible` (fail-closed until #5555–#5557).
+
+<!-- fleet-roster-projection:begin formal_review_eligible -->
+| endpoint | formal_review_eligible |
+| --- | --- |
+| agy | false |
+| claude | true |
+| codex | true |
+| cursor | false |
+| gemini | false |
+| glm-local | false |
+| grok | false |
+| kimi | false |
+<!-- fleet-roster-projection:end formal_review_eligible -->
 
 Practical seats @ **high** — not Sol/Fable on routine PRs:
 

--- a/scripts/lint/lint_fleet_roster.py
+++ b/scripts/lint/lint_fleet_roster.py
@@ -158,29 +158,37 @@ def parse_markdown_table(block: str) -> tuple[tuple[str, ...], list[dict[str, st
 
 
 def extract_projection_blocks(text: str, kind: str) -> list[str]:
-    """Return body text of every matching begin/end marker pair for *kind*."""
+    """Return body text of every matching begin/end marker pair for *kind*.
+
+    Fail-closed on unmatched ends, unclosed begins, nesting, and kind mismatches.
+    Markers for *other* kinds are ignored for this extraction (each kind is scanned
+    independently by the caller).
+    """
+    # Collect only markers for this kind, in document order.
+    events: list[tuple[int, str, re.Match[str]]] = []
+    for m in BEGIN_RE.finditer(text):
+        if m.group("kind") == kind:
+            events.append((m.start(), "begin", m))
+    for m in END_RE.finditer(text):
+        if m.group("kind") == kind:
+            events.append((m.start(), "end", m))
+    events.sort(key=lambda item: item[0])
+
     bodies: list[str] = []
-    pos = 0
-    while True:
-        begin = BEGIN_RE.search(text, pos)
-        if begin is None:
-            break
-        if begin.group("kind") != kind:
-            pos = begin.end()
+    open_begin: re.Match[str] | None = None
+    for _pos, etype, match in events:
+        if etype == "begin":
+            if open_begin is not None:
+                raise ValueError(f"nested fleet-roster-projection for {kind}")
+            open_begin = match
             continue
-        end = END_RE.search(text, begin.end())
-        if end is None:
-            raise ValueError(f"unclosed fleet-roster-projection:begin {kind}")
-        if end.group("kind") != kind:
-            raise ValueError(
-                f"mismatched end marker: expected {kind}, got {end.group('kind')}"
-            )
-        # Reject nested begins of same kind before end.
-        nested = BEGIN_RE.search(text, begin.end())
-        if nested is not None and nested.start() < end.start() and nested.group("kind") == kind:
-            raise ValueError(f"nested fleet-roster-projection for {kind}")
-        bodies.append(text[begin.end() : end.start()])
-        pos = end.end()
+        # end
+        if open_begin is None:
+            raise ValueError(f"unmatched fleet-roster-projection:end {kind}")
+        bodies.append(text[open_begin.end() : match.start()])
+        open_begin = None
+    if open_begin is not None:
+        raise ValueError(f"unclosed fleet-roster-projection:begin {kind}")
     return bodies
 
 

--- a/scripts/lint/lint_fleet_roster.py
+++ b/scripts/lint/lint_fleet_roster.py
@@ -70,6 +70,13 @@ def load_orchestrator_seats(catalog_path: Path = CATALOG_PATH) -> dict[str, dict
     for seat, body in raw.items():
         if not isinstance(seat, str) or not isinstance(body, dict):
             raise ValueError(f"{catalog_path}: invalid orchestrator_seats entry {seat!r}")
+        key = seat.strip()
+        if not key:
+            raise ValueError(f"{catalog_path}: empty orchestrator_seats key {seat!r}")
+        if key in seats:
+            raise ValueError(
+                f"{catalog_path}: duplicate orchestrator_seats name after normalize: {key!r}"
+            )
         row: dict[str, str] = {}
         for field in SEAT_FIELDS:
             value = body.get(field)
@@ -78,7 +85,7 @@ def load_orchestrator_seats(catalog_path: Path = CATALOG_PATH) -> dict[str, dict
                     f"{catalog_path}: orchestrator_seats.{seat}.{field} must be a non-empty string"
                 )
             row[field] = value.strip()
-        seats[seat.strip()] = row
+        seats[key] = row
     return seats
 
 

--- a/scripts/lint/lint_fleet_roster.py
+++ b/scripts/lint/lint_fleet_roster.py
@@ -131,8 +131,10 @@ def parse_markdown_table(block: str) -> tuple[tuple[str, ...], list[dict[str, st
     if not header:
         raise ValueError("invalid table header")
     sep = _split_row(lines[1])
-    if not sep or not _is_separator_row(sep):
-        raise ValueError("invalid table separator")
+    if not sep or not _is_separator_row(sep) or len(sep) != len(header):
+        raise ValueError(
+            f"invalid table separator (need {len(header)} columns of ---, got {len(sep) if sep else 0})"
+        )
     rows: list[dict[str, str]] = []
     for line in lines[2:]:
         cells = _split_row(line)

--- a/scripts/lint/lint_fleet_roster.py
+++ b/scripts/lint/lint_fleet_roster.py
@@ -38,6 +38,15 @@ BEGIN_RE = re.compile(
 END_RE = re.compile(
     r"<!--\s*fleet-roster-projection:end\s+(?P<kind>orchestrator_seats|formal_review_eligible)\s*-->"
 )
+# Any HTML comment that mentions the projection namespace must be an exact supported form.
+ANY_PROJECTION_COMMENT_RE = re.compile(
+    r"<!--\s*fleet-roster-projection:[^>]*-->",
+    re.IGNORECASE,
+)
+SUPPORTED_MARKER_RE = re.compile(
+    r"<!--\s*fleet-roster-projection:(?:begin|end)\s+"
+    r"(?:orchestrator_seats|formal_review_eligible)\s*-->"
+)
 
 SEAT_FIELDS = ("model_id", "effort", "escalate_model_id", "escalate_effort")
 SEAT_HEADER = ("seat", *SEAT_FIELDS)
@@ -157,12 +166,21 @@ def parse_markdown_table(block: str) -> tuple[tuple[str, ...], list[dict[str, st
     return tuple(header), rows
 
 
+def assert_no_malformed_projection_markers(text: str) -> None:
+    """Fail closed if any fleet-roster-projection HTML comment is not a supported marker."""
+    for match in ANY_PROJECTION_COMMENT_RE.finditer(text):
+        token = match.group(0)
+        if SUPPORTED_MARKER_RE.fullmatch(token) is None:
+            raise ValueError(f"malformed fleet-roster-projection marker: {token!r}")
+
+
 def extract_projection_blocks(text: str, kind: str) -> list[str]:
     """Return body text of every matching begin/end marker pair for *kind*.
 
     Fail-closed on unmatched ends, unclosed begins, nesting, and kind mismatches.
     Markers for *other* kinds are ignored for this extraction (each kind is scanned
-    independently by the caller).
+    independently by the caller). Callers must run
+    ``assert_no_malformed_projection_markers`` first so typoed markers cannot hide.
     """
     # Collect only markers for this kind, in document order.
     events: list[tuple[int, str, re.Match[str]]] = []
@@ -264,6 +282,12 @@ def check_file_projections(
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
         return [LintIssue(label, "io", f"cannot read file: {exc}")]
+
+    try:
+        assert_no_malformed_projection_markers(text)
+    except ValueError as exc:
+        issues.append(LintIssue(label, "markers", f"malformed markers: {exc}"))
+        return issues
 
     for kind, expected, parser in (
         ("orchestrator_seats", seats, parse_seat_projection),

--- a/scripts/lint/lint_fleet_roster.py
+++ b/scripts/lint/lint_fleet_roster.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Fail when marked fleet-roster Markdown tables drift from machine authorities.
+
+Authorities (read-only):
+  - scripts/config/model_catalog.yaml → orchestrator_seats
+  - scripts/config/fleet_communications.yaml → endpoints[*].formal_review_eligible
+
+Marked blocks are exact projections. This lint never rewrites prose or config.
+Missing/malformed markers fail closed. See #5642 / Sol strengthen Δ1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CATALOG_PATH = PROJECT_ROOT / "scripts/config/model_catalog.yaml"
+COMMS_PATH = PROJECT_ROOT / "scripts/config/fleet_communications.yaml"
+
+# Source rules only (not deploy copies under .claude/.agent/.gemini).
+DEFAULT_PROJECTION_PATHS = (
+    PROJECT_ROOT / "agents_extensions/shared/rules/model-assignment.md",
+    PROJECT_ROOT / "docs/runbooks/fleet-comms-open-gaps.md",
+    PROJECT_ROOT / "docs/runbooks/epic-orchestrator-roster.md",
+)
+
+BEGIN_RE = re.compile(
+    r"<!--\s*fleet-roster-projection:begin\s+(?P<kind>orchestrator_seats|formal_review_eligible)\s*-->"
+)
+END_RE = re.compile(
+    r"<!--\s*fleet-roster-projection:end\s+(?P<kind>orchestrator_seats|formal_review_eligible)\s*-->"
+)
+
+SEAT_FIELDS = ("model_id", "effort", "escalate_model_id", "escalate_effort")
+SEAT_HEADER = ("seat", *SEAT_FIELDS)
+ELIG_HEADER = ("endpoint", "formal_review_eligible")
+
+
+@dataclass(frozen=True)
+class LintIssue:
+    path: str
+    kind: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"path": self.path, "kind": self.kind, "message": self.message}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: root must be a mapping")
+    return data
+
+
+def load_orchestrator_seats(catalog_path: Path = CATALOG_PATH) -> dict[str, dict[str, str]]:
+    catalog = _load_yaml(catalog_path)
+    raw = catalog.get("orchestrator_seats")
+    if not isinstance(raw, dict) or not raw:
+        raise ValueError(f"{catalog_path}: orchestrator_seats missing or empty")
+    seats: dict[str, dict[str, str]] = {}
+    for seat, body in raw.items():
+        if not isinstance(seat, str) or not isinstance(body, dict):
+            raise ValueError(f"{catalog_path}: invalid orchestrator_seats entry {seat!r}")
+        row: dict[str, str] = {}
+        for field in SEAT_FIELDS:
+            value = body.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    f"{catalog_path}: orchestrator_seats.{seat}.{field} must be a non-empty string"
+                )
+            row[field] = value.strip()
+        seats[seat.strip()] = row
+    return seats
+
+
+def load_formal_review_eligible(comms_path: Path = COMMS_PATH) -> dict[str, bool]:
+    comms = _load_yaml(comms_path)
+    endpoints = comms.get("endpoints")
+    if not isinstance(endpoints, list) or not endpoints:
+        raise ValueError(f"{comms_path}: endpoints missing or empty")
+    eligible: dict[str, bool] = {}
+    for item in endpoints:
+        if not isinstance(item, dict):
+            raise ValueError(f"{comms_path}: endpoint entry must be a mapping")
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"{comms_path}: endpoint name must be a non-empty string")
+        if "formal_review_eligible" not in item:
+            raise ValueError(f"{comms_path}: endpoint {name!r} missing formal_review_eligible")
+        flag = item["formal_review_eligible"]
+        if not isinstance(flag, bool):
+            raise ValueError(
+                f"{comms_path}: endpoint {name!r} formal_review_eligible must be a bool"
+            )
+        key = name.strip()
+        if key in eligible:
+            raise ValueError(f"{comms_path}: duplicate endpoint name {key!r}")
+        eligible[key] = flag
+    return eligible
+
+
+def _split_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|"):
+        return []
+    cells = [c.strip() for c in stripped.strip("|").split("|")]
+    return cells
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    if not cells:
+        return False
+    return all(re.fullmatch(r":?-{3,}:?", c.replace(" ", "")) is not None for c in cells)
+
+
+def parse_markdown_table(block: str) -> tuple[tuple[str, ...], list[dict[str, str]]]:
+    """Parse a single GFM table from a projection block body."""
+    lines = [ln for ln in block.splitlines() if ln.strip()]
+    if len(lines) < 2:
+        raise ValueError("table needs a header and separator row")
+    header = _split_row(lines[0])
+    if not header:
+        raise ValueError("invalid table header")
+    sep = _split_row(lines[1])
+    if not sep or not _is_separator_row(sep):
+        raise ValueError("invalid table separator")
+    rows: list[dict[str, str]] = []
+    for line in lines[2:]:
+        cells = _split_row(line)
+        if not cells:
+            raise ValueError(f"invalid table row: {line!r}")
+        if len(cells) != len(header):
+            raise ValueError(
+                f"column count mismatch: header={len(header)} row={len(cells)} ({line!r})"
+            )
+        if _is_separator_row(cells):
+            continue
+        rows.append({header[i]: cells[i] for i in range(len(header))})
+    return tuple(header), rows
+
+
+def extract_projection_blocks(text: str, kind: str) -> list[str]:
+    """Return body text of every matching begin/end marker pair for *kind*."""
+    bodies: list[str] = []
+    pos = 0
+    while True:
+        begin = BEGIN_RE.search(text, pos)
+        if begin is None:
+            break
+        if begin.group("kind") != kind:
+            pos = begin.end()
+            continue
+        end = END_RE.search(text, begin.end())
+        if end is None:
+            raise ValueError(f"unclosed fleet-roster-projection:begin {kind}")
+        if end.group("kind") != kind:
+            raise ValueError(
+                f"mismatched end marker: expected {kind}, got {end.group('kind')}"
+            )
+        # Reject nested begins of same kind before end.
+        nested = BEGIN_RE.search(text, begin.end())
+        if nested is not None and nested.start() < end.start() and nested.group("kind") == kind:
+            raise ValueError(f"nested fleet-roster-projection for {kind}")
+        bodies.append(text[begin.end() : end.start()])
+        pos = end.end()
+    return bodies
+
+
+def parse_seat_projection(block: str) -> dict[str, dict[str, str]]:
+    header, rows = parse_markdown_table(block)
+    if header != SEAT_HEADER:
+        raise ValueError(
+            f"orchestrator_seats header must be {list(SEAT_HEADER)}, got {list(header)}"
+        )
+    out: dict[str, dict[str, str]] = {}
+    for row in rows:
+        seat = row["seat"].strip().strip("*")
+        if not seat:
+            raise ValueError("empty seat name in orchestrator_seats projection")
+        if seat in out:
+            raise ValueError(f"duplicate seat {seat!r} in projection")
+        out[seat] = {field: row[field].strip().strip("`") for field in SEAT_FIELDS}
+    return out
+
+
+def parse_eligible_projection(block: str) -> dict[str, bool]:
+    header, rows = parse_markdown_table(block)
+    if header != ELIG_HEADER:
+        raise ValueError(
+            f"formal_review_eligible header must be {list(ELIG_HEADER)}, got {list(header)}"
+        )
+    out: dict[str, bool] = {}
+    for row in rows:
+        name = row["endpoint"].strip().strip("*")
+        if not name:
+            raise ValueError("empty endpoint name in formal_review_eligible projection")
+        if name in out:
+            raise ValueError(f"duplicate endpoint {name!r} in projection")
+        raw = row["formal_review_eligible"].strip().lower()
+        if raw not in {"true", "false"}:
+            raise ValueError(
+                f"endpoint {name!r}: formal_review_eligible must be true|false, got {raw!r}"
+            )
+        out[name] = raw == "true"
+    return out
+
+
+def _diff_maps(
+    expected: dict[str, Any], actual: dict[str, Any], *, key_label: str
+) -> list[str]:
+    messages: list[str] = []
+    exp_keys = set(expected)
+    act_keys = set(actual)
+    missing = sorted(exp_keys - act_keys)
+    extra = sorted(act_keys - exp_keys)
+    if missing:
+        messages.append(f"missing {key_label}(s): {', '.join(missing)}")
+    if extra:
+        messages.append(f"extra {key_label}(s): {', '.join(extra)}")
+    for key in sorted(exp_keys & act_keys):
+        if expected[key] != actual[key]:
+            messages.append(
+                f"{key_label} {key!r}: expected {expected[key]!r}, got {actual[key]!r}"
+            )
+    return messages
+
+
+def check_file_projections(
+    path: Path,
+    *,
+    seats: dict[str, dict[str, str]],
+    eligible: dict[str, bool],
+    rel: str | None = None,
+) -> list[LintIssue]:
+    label = rel or str(path)
+    issues: list[LintIssue] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [LintIssue(label, "io", f"cannot read file: {exc}")]
+
+    for kind, expected, parser in (
+        ("orchestrator_seats", seats, parse_seat_projection),
+        ("formal_review_eligible", eligible, parse_eligible_projection),
+    ):
+        try:
+            bodies = extract_projection_blocks(text, kind)
+        except ValueError as exc:
+            issues.append(LintIssue(label, kind, f"malformed markers: {exc}"))
+            continue
+        if not bodies:
+            issues.append(
+                LintIssue(
+                    label,
+                    kind,
+                    f"missing <!-- fleet-roster-projection:begin {kind} --> block",
+                )
+            )
+            continue
+        if len(bodies) > 1:
+            issues.append(
+                LintIssue(
+                    label,
+                    kind,
+                    f"expected exactly one {kind} projection block, found {len(bodies)}",
+                )
+            )
+            continue
+        try:
+            actual = parser(bodies[0])
+        except ValueError as exc:
+            issues.append(LintIssue(label, kind, f"malformed projection table: {exc}"))
+            continue
+        key_label = "seat" if kind == "orchestrator_seats" else "endpoint"
+        for msg in _diff_maps(expected, actual, key_label=key_label):
+            issues.append(LintIssue(label, kind, msg))
+    return issues
+
+
+def lint_fleet_roster(
+    *,
+    catalog_path: Path = CATALOG_PATH,
+    comms_path: Path = COMMS_PATH,
+    projection_paths: tuple[Path, ...] | list[Path] = DEFAULT_PROJECTION_PATHS,
+    project_root: Path = PROJECT_ROOT,
+) -> list[LintIssue]:
+    issues: list[LintIssue] = []
+    try:
+        seats = load_orchestrator_seats(catalog_path)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        return [LintIssue(str(catalog_path), "authority", f"orchestrator_seats: {exc}")]
+    try:
+        eligible = load_formal_review_eligible(comms_path)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        return [LintIssue(str(comms_path), "authority", f"formal_review_eligible: {exc}")]
+
+    # Hard acceptance pin from Sol/Fable: Codex is not a driver; remains CF-eligible.
+    if "codex" in seats:
+        issues.append(
+            LintIssue(
+                str(catalog_path),
+                "orchestrator_seats",
+                "codex must not be an orchestrator_seats driver (coding + formal CF only)",
+            )
+        )
+    if eligible.get("codex") is not True:
+        issues.append(
+            LintIssue(
+                str(comms_path),
+                "formal_review_eligible",
+                "codex must remain formal_review_eligible: true",
+            )
+        )
+
+    for path in projection_paths:
+        try:
+            rel = str(path.resolve().relative_to(project_root.resolve()))
+        except ValueError:
+            rel = str(path)
+        if not path.is_file():
+            issues.append(LintIssue(rel, "io", "projection file missing"))
+            continue
+        issues.extend(
+            check_file_projections(path, seats=seats, eligible=eligible, rel=rel)
+        )
+    return issues
+
+
+def format_seat_table(seats: dict[str, dict[str, str]]) -> str:
+    lines = [
+        "| seat | model_id | effort | escalate_model_id | escalate_effort |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for seat in sorted(seats):
+        row = seats[seat]
+        lines.append(
+            "| {seat} | {model_id} | {effort} | {escalate_model_id} | {escalate_effort} |".format(
+                seat=seat, **row
+            )
+        )
+    return "\n".join(lines)
+
+
+def format_eligible_table(eligible: dict[str, bool]) -> str:
+    lines = [
+        "| endpoint | formal_review_eligible |",
+        "| --- | --- |",
+    ]
+    for name in sorted(eligible):
+        lines.append(f"| {name} | {str(eligible[name]).lower()} |")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--catalog",
+        type=Path,
+        default=CATALOG_PATH,
+        help="path to model_catalog.yaml",
+    )
+    parser.add_argument(
+        "--comms",
+        type=Path,
+        default=COMMS_PATH,
+        help="path to fleet_communications.yaml",
+    )
+    parser.add_argument(
+        "--projection",
+        type=Path,
+        action="append",
+        default=None,
+        help="projection markdown path (repeatable; default: three SSOT docs)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON summary on stdout",
+    )
+    args = parser.parse_args(argv)
+
+    projection_paths = (
+        tuple(p.resolve() for p in args.projection)
+        if args.projection
+        else DEFAULT_PROJECTION_PATHS
+    )
+    issues = lint_fleet_roster(
+        catalog_path=args.catalog.resolve(),
+        comms_path=args.comms.resolve(),
+        projection_paths=projection_paths,
+    )
+    payload = {
+        "ok": not issues,
+        "issue_count": len(issues),
+        "issues": [i.as_dict() for i in issues],
+    }
+    if args.json:
+        print(json.dumps(payload, sort_keys=True, indent=2))
+    elif issues:
+        print("Fleet roster lint failed:", file=sys.stderr)
+        for issue in issues:
+            print(f"  - [{issue.kind}] {issue.path}: {issue.message}", file=sys.stderr)
+    else:
+        print(
+            f"Fleet roster OK ({len(projection_paths)} projection file(s); "
+            "orchestrator_seats + formal_review_eligible exact match)"
+        )
+    return 0 if not issues else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_lint_fleet_roster.py
+++ b/tests/test_lint_fleet_roster.py
@@ -1,0 +1,275 @@
+"""Tests for scripts/lint/lint_fleet_roster.py (#5642 Δ1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import yaml
+
+from scripts.lint.lint_fleet_roster import (
+    SEAT_FIELDS,
+    format_eligible_table,
+    format_seat_table,
+    lint_fleet_roster,
+    load_formal_review_eligible,
+    load_orchestrator_seats,
+    main,
+    parse_eligible_projection,
+    parse_seat_projection,
+)
+
+
+def _seat_block(seats: dict[str, dict[str, str]]) -> str:
+    return (
+        "<!-- fleet-roster-projection:begin orchestrator_seats -->\n"
+        f"{format_seat_table(seats)}\n"
+        "<!-- fleet-roster-projection:end orchestrator_seats -->\n"
+    )
+
+
+def _elig_block(eligible: dict[str, bool]) -> str:
+    return (
+        "<!-- fleet-roster-projection:begin formal_review_eligible -->\n"
+        f"{format_eligible_table(eligible)}\n"
+        "<!-- fleet-roster-projection:end formal_review_eligible -->\n"
+    )
+
+
+def _write_projection(path: Path, seats: dict[str, dict[str, str]], eligible: dict[str, bool]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "# fixture\n\n" + _seat_block(seats) + "\n" + _elig_block(eligible),
+        encoding="utf-8",
+    )
+
+
+def _mini_authorities(tmp: Path) -> tuple[Path, Path, dict, dict]:
+    seats = {
+        "agy": {
+            "model_id": "gemini-3.6-flash-high",
+            "effort": "high",
+            "escalate_model_id": "gemini-3.1-pro-high",
+            "escalate_effort": "high",
+        },
+        "claude": {
+            "model_id": "claude-sonnet-5",
+            "effort": "high",
+            "escalate_model_id": "claude-fable-5",
+            "escalate_effort": "xhigh",
+        },
+        "grok": {
+            "model_id": "grok-4.5",
+            "effort": "high",
+            "escalate_model_id": "grok-4.5",
+            "escalate_effort": "high",
+        },
+    }
+    eligible = {
+        "agy": False,
+        "claude": True,
+        "codex": True,
+        "cursor": False,
+        "gemini": False,
+        "glm-local": False,
+        "grok": False,
+        "kimi": False,
+    }
+    catalog = tmp / "model_catalog.yaml"
+    catalog.write_text(
+        yaml.safe_dump({"orchestrator_seats": seats}, sort_keys=True),
+        encoding="utf-8",
+    )
+    endpoints = [
+        {"name": name, "formal_review_eligible": flag} for name, flag in sorted(eligible.items())
+    ]
+    comms = tmp / "fleet_communications.yaml"
+    comms.write_text(
+        yaml.safe_dump({"version": 1, "endpoints": endpoints}, sort_keys=False),
+        encoding="utf-8",
+    )
+    return catalog, comms, seats, eligible
+
+
+def test_committed_projections_match_machine_authorities():
+    """Green path against the real repo SSOT docs (never arm lint against known-red)."""
+    issues = lint_fleet_roster()
+    assert issues == [], [i.as_dict() for i in issues]
+    seats = load_orchestrator_seats()
+    assert "codex" not in seats
+    assert set(seats) == {"claude", "grok", "agy"}
+    eligible = load_formal_review_eligible()
+    assert eligible["codex"] is True
+    assert eligible["claude"] is True
+    for name in ("agy", "grok", "kimi"):
+        assert eligible[name] is False
+
+
+def test_cli_main_ok_on_repo():
+    assert main([]) == 0
+
+
+def test_seat_add_remove_pin_and_eligibility_flip_fail(tmp_path: Path):
+    catalog, comms, seats, eligible = _mini_authorities(tmp_path)
+    proj = tmp_path / "proj.md"
+
+    # Corrected fixtures pass.
+    _write_projection(proj, seats, eligible)
+    assert lint_fleet_roster(
+        catalog_path=catalog,
+        comms_path=comms,
+        projection_paths=[proj],
+        project_root=tmp_path,
+    ) == []
+
+    # Seat remove (drop grok from projection).
+    broken_seats = {k: v for k, v in seats.items() if k != "grok"}
+    _write_projection(proj, broken_seats, eligible)
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("missing seat(s): grok" in i.message for i in issues)
+
+    # Seat add (codex as fake driver in projection only).
+    with_codex = dict(seats)
+    with_codex["codex"] = {
+        "model_id": "gpt-5.6-terra",
+        "effort": "high",
+        "escalate_model_id": "gpt-5.6-sol",
+        "escalate_effort": "xhigh",
+    }
+    _write_projection(proj, with_codex, eligible)
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("extra seat(s): codex" in i.message for i in issues)
+
+    # Pin change.
+    pin_changed = {k: dict(v) for k, v in seats.items()}
+    pin_changed["claude"]["model_id"] = "claude-opus-4-8"
+    _write_projection(proj, pin_changed, eligible)
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("claude" in i.message and "claude-opus-4-8" in i.message for i in issues)
+
+    # Eligibility flip.
+    flipped = dict(eligible)
+    flipped["agy"] = True
+    _write_projection(proj, seats, flipped)
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("agy" in i.message and "False" in i.message for i in issues)
+
+
+def test_codex_rejected_as_driver_but_cf_eligible(tmp_path: Path):
+    catalog, comms, seats, eligible = _mini_authorities(tmp_path)
+    # Authority wrongly lists codex as driver → lint fails hard.
+    bad_seats = dict(seats)
+    bad_seats["codex"] = {
+        "model_id": "gpt-5.6-terra",
+        "effort": "high",
+        "escalate_model_id": "gpt-5.6-sol",
+        "escalate_effort": "xhigh",
+    }
+    catalog.write_text(
+        yaml.safe_dump({"orchestrator_seats": bad_seats}, sort_keys=True),
+        encoding="utf-8",
+    )
+    proj = tmp_path / "proj.md"
+    _write_projection(proj, bad_seats, eligible)
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("codex must not be an orchestrator_seats driver" in i.message for i in issues)
+
+    # Restore seats; strip codex CF eligibility → fails.
+    catalog.write_text(
+        yaml.safe_dump({"orchestrator_seats": seats}, sort_keys=True),
+        encoding="utf-8",
+    )
+    bad_elig = dict(eligible)
+    bad_elig["codex"] = False
+    endpoints = [
+        {"name": name, "formal_review_eligible": flag}
+        for name, flag in sorted(bad_elig.items())
+    ]
+    comms.write_text(
+        yaml.safe_dump({"version": 1, "endpoints": endpoints}, sort_keys=False),
+        encoding="utf-8",
+    )
+    _write_projection(proj, seats, bad_elig)
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("codex must remain formal_review_eligible: true" in i.message for i in issues)
+
+
+def test_malformed_or_missing_markers_fail(tmp_path: Path):
+    catalog, comms, seats, eligible = _mini_authorities(tmp_path)
+    proj = tmp_path / "proj.md"
+    proj.write_text("# no markers\n", encoding="utf-8")
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any(i.kind == "orchestrator_seats" and "missing" in i.message for i in issues)
+    assert any(i.kind == "formal_review_eligible" and "missing" in i.message for i in issues)
+
+    # Unclosed begin.
+    proj.write_text(
+        "<!-- fleet-roster-projection:begin orchestrator_seats -->\n"
+        f"{format_seat_table(seats)}\n",
+        encoding="utf-8",
+    )
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("unclosed" in i.message for i in issues)
+
+    # Wrong header.
+    proj.write_text(
+        "<!-- fleet-roster-projection:begin orchestrator_seats -->\n"
+        "| seat | wrong |\n| --- | --- |\n| claude | x |\n"
+        "<!-- fleet-roster-projection:end orchestrator_seats -->\n"
+        + _elig_block(eligible),
+        encoding="utf-8",
+    )
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("header must be" in i.message for i in issues)
+
+
+def test_parsers_strip_markdown_emphasis():
+    block = dedent(
+        """\
+        | seat | model_id | effort | escalate_model_id | escalate_effort |
+        | --- | --- | --- | --- | --- |
+        | **claude** | `claude-sonnet-5` | high | `claude-fable-5` | xhigh |
+        """
+    )
+    seats = parse_seat_projection(block)
+    assert seats["claude"]["model_id"] == "claude-sonnet-5"
+    assert set(seats["claude"]) == set(SEAT_FIELDS)
+
+    eblock = dedent(
+        """\
+        | endpoint | formal_review_eligible |
+        | --- | --- |
+        | **codex** | true |
+        """
+    )
+    assert parse_eligible_projection(eblock) == {"codex": True}
+
+
+def test_missing_projection_file_fails(tmp_path: Path):
+    catalog, comms, _, _ = _mini_authorities(tmp_path)
+    missing = tmp_path / "nope.md"
+    issues = lint_fleet_roster(
+        catalog_path=catalog,
+        comms_path=comms,
+        projection_paths=[missing],
+        project_root=tmp_path,
+    )
+    assert any(i.kind == "io" and "missing" in i.message for i in issues)

--- a/tests/test_lint_fleet_roster.py
+++ b/tests/test_lint_fleet_roster.py
@@ -294,3 +294,35 @@ def test_missing_projection_file_fails(tmp_path: Path):
         project_root=tmp_path,
     )
     assert any(i.kind == "io" and "missing" in i.message for i in issues)
+
+
+def test_duplicate_normalized_orchestrator_seat_names_fail(tmp_path: Path):
+    """Whitespace-distinct YAML keys must not silently collapse (CF r2 F001)."""
+    catalog = tmp_path / "model_catalog.yaml"
+    # PyYAML cannot emit two keys that only differ by surrounding spaces via a
+    # normal dump; write the ambiguous authority textually.
+    catalog.write_text(
+        dedent(
+            """\
+            orchestrator_seats:
+              claude:
+                model_id: claude-sonnet-5
+                effort: high
+                escalate_model_id: claude-fable-5
+                escalate_effort: xhigh
+              " claude":
+                model_id: claude-sonnet-5
+                effort: high
+                escalate_model_id: claude-fable-5
+                escalate_effort: xhigh
+            """
+        ),
+        encoding="utf-8",
+    )
+    from scripts.lint.lint_fleet_roster import load_orchestrator_seats
+
+    try:
+        load_orchestrator_seats(catalog)
+        raise AssertionError("expected ValueError for duplicate normalized seats")
+    except ValueError as exc:
+        assert "duplicate orchestrator_seats name after normalize" in str(exc)

--- a/tests/test_lint_fleet_roster.py
+++ b/tests/test_lint_fleet_roster.py
@@ -326,3 +326,21 @@ def test_duplicate_normalized_orchestrator_seat_names_fail(tmp_path: Path):
         raise AssertionError("expected ValueError for duplicate normalized seats")
     except ValueError as exc:
         assert "duplicate orchestrator_seats name after normalize" in str(exc)
+
+
+def test_unmatched_projection_end_marker_fails(tmp_path: Path):
+    """Stray end markers must fail closed (CF r3 F001)."""
+    catalog, comms, seats, eligible = _mini_authorities(tmp_path)
+    proj = tmp_path / "proj.md"
+    proj.write_text(
+        _seat_block(seats)
+        + "\n<!-- fleet-roster-projection:end orchestrator_seats -->\n"
+        + _elig_block(eligible),
+        encoding="utf-8",
+    )
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("unmatched" in i.message and "end" in i.message for i in issues), [
+        i.as_dict() for i in issues
+    ]

--- a/tests/test_lint_fleet_roster.py
+++ b/tests/test_lint_fleet_roster.py
@@ -240,6 +240,27 @@ def test_malformed_or_missing_markers_fail(tmp_path: Path):
     )
     assert any("header must be" in i.message for i in issues)
 
+    # Short separator row (CF F001): header has 5 cols but separator is 1 cell.
+    data_rows = "\n".join(
+        f"| {seat} | {r['model_id']} | {r['effort']} | {r['escalate_model_id']} | {r['escalate_effort']} |"
+        for seat, r in sorted(seats.items())
+    )
+    proj.write_text(
+        "<!-- fleet-roster-projection:begin orchestrator_seats -->\n"
+        "| seat | model_id | effort | escalate_model_id | escalate_effort |\n"
+        "| --- |\n"
+        f"{data_rows}\n"
+        "<!-- fleet-roster-projection:end orchestrator_seats -->\n"
+        + _elig_block(eligible),
+        encoding="utf-8",
+    )
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any("invalid table separator" in i.message for i in issues), [
+        i.as_dict() for i in issues
+    ]
+
 
 def test_parsers_strip_markdown_emphasis():
     block = dedent(

--- a/tests/test_lint_fleet_roster.py
+++ b/tests/test_lint_fleet_roster.py
@@ -344,3 +344,21 @@ def test_unmatched_projection_end_marker_fails(tmp_path: Path):
     assert any("unmatched" in i.message and "end" in i.message for i in issues), [
         i.as_dict() for i in issues
     ]
+
+
+def test_typoed_projection_marker_fails(tmp_path: Path):
+    """Unknown/typoed fleet-roster-projection comments fail closed (CF r4 F001)."""
+    catalog, comms, seats, eligible = _mini_authorities(tmp_path)
+    proj = tmp_path / "proj.md"
+    proj.write_text(
+        _seat_block(seats)
+        + "\n<!-- fleet-roster-projection:begin orchestrator_seatz -->\n"
+        + _elig_block(eligible),
+        encoding="utf-8",
+    )
+    issues = lint_fleet_roster(
+        catalog_path=catalog, comms_path=comms, projection_paths=[proj], project_root=tmp_path
+    )
+    assert any(i.kind == "markers" and "malformed" in i.message for i in issues), [
+        i.as_dict() for i in issues
+    ]


### PR DESCRIPTION
## Summary

Implements **#5642 Δ1** (Sol strengthen design + Fable APPROVE): read-only drift lint so human-readable fleet roster / CF tables cannot contradict machine authorities.

- **Authorities:** `model_catalog.yaml::orchestrator_seats`, `fleet_communications.yaml::endpoints[*].formal_review_eligible`
- **Projections (marked tables):** `model-assignment.md`, `fleet-comms-open-gaps.md`, `epic-orchestrator-roster.md`
- **Lint:** `scripts/lint/lint_fleet_roster.py` — exact set/value compare; missing/malformed markers fail CI; never rewrites prose/config
- **Drift fixed:** docs still listed **Codex as a driver seat** — removed; Codex remains coding + sealed formal CF (`formal_review_eligible: true`)
- **CI:** wired into `model-catalog-freshness.yml` (never armed against known-red — fixes land with the lint)

Closes #5642 · parent #5641 · epics #4707 / #5512

## Acceptance (Sol/Fable)

- [x] Seat add/remove, pin change, eligibility flip each fail tests
- [x] Corrected fixtures pass; committed projections green
- [x] Codex rejected as driver, remains CF-eligible
- [x] ≤7 files (6)

## Non-goals

No roster generation, routing changes, eligibility flips, plane cutover, ownership guard (Δ2), metrics (Δ3).

## Test plan

- [x] `.venv/bin/python scripts/lint/lint_fleet_roster.py` → OK
- [x] `pytest tests/test_lint_fleet_roster.py` → 7 passed
- [x] ruff clean
- [ ] CI model-catalog-freshness + CI Gate green
- [ ] Cross-family formal CF (non-Grok) APPROVED → auto-merge

## X-Agent

`grok/5642-fleet-roster-lint`