### PR TITLE
feat(dispatch): writable-path ownership admission guard WARN (#5643)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2401,6 +2401,35 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print(dirty_primary_error, file=sys.stderr)
         return 2
 
+    # Writable-path admission guard (#5643 Δ2-A WARN; #5645 REFUSE later).
+    # Runs before task-state write / worktree / branch side effects so a refuse
+    # leaves no residue. Read-only modes are exempt inside the helper.
+    try:
+        from scripts.delegate_ownership import admit_write_paths, env_guard_mode
+    except ImportError:  # pragma: no cover - flat script path
+        from delegate_ownership import admit_write_paths, env_guard_mode  # type: ignore
+
+    ownership = admit_write_paths(
+        task_id=task_id,
+        mode=str(args.mode),
+        owned_paths=getattr(args, "research_owned_path", None),
+        allow_path_overlap=getattr(args, "allow_path_overlap", None),
+        pid=os.getpid(),
+        guard_mode=env_guard_mode(),
+    )
+    if ownership.would_refuse or ownership.override_reason:
+        print(
+            f"⚠️  write-path ownership: {ownership.reason} "
+            f"(conflicts={len(ownership.conflicts)})",
+            file=sys.stderr,
+        )
+    if not ownership.admitted:
+        print(
+            f"❌ write-path ownership refused for task_id={task_id!r}: {ownership.reason}",
+            file=sys.stderr,
+        )
+        return 2
+
     # Refuse to clobber a task that's still alive — whether it's in
     # "running" (worker up and executing) OR "spawning" (worker created
     # but not yet past its own state-update step). Without the
@@ -3604,7 +3633,18 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="GLOB",
         help=(
             "ADR-011 P3 research context: an owned/changed path for the task. "
-            "Repeatable. Matched against each record's owned_paths globs."
+            "Repeatable. Matched against each record's owned_paths globs. "
+            "Also feeds the writable-path admission guard (#5643)."
+        ),
+    )
+    d.add_argument(
+        "--allow-path-overlap",
+        default=None,
+        metavar="REASON",
+        help=(
+            "Explicitly admit a write-capable dispatch that intersects another "
+            "active claim. Records task, conflicts, reason, and caller in the "
+            "ownership ledger. Required text reason; empty string is ignored."
         ),
     )
     d.set_defaults(func=cmd_dispatch)

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2877,6 +2877,21 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         state_with_pid = _read_state(state_path) or initial_state
         state_with_pid["pid"] = proc.pid
         _write_state_atomic(state_path, state_with_pid)
+        # Bind ownership ledger rows to the long-lived worker PID (not the
+        # short-lived dispatch CLI). Best-effort: WARN path must not fail spawn.
+        if str(args.mode) in _WRITE_CAPABLE_MODES:
+            try:
+                from scripts.delegate_ownership import update_write_claim_pid
+            except ImportError:  # pragma: no cover
+                from delegate_ownership import update_write_claim_pid  # type: ignore
+
+            try:
+                update_write_claim_pid(task_id, int(proc.pid))
+            except Exception as own_exc:
+                print(
+                    f"⚠️  write-path ownership: failed to bind worker pid: {own_exc}",
+                    file=sys.stderr,
+                )
 
         assert proc.stdin is not None  # we passed stdin=PIPE
         try:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2401,6 +2401,27 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print(dirty_primary_error, file=sys.stderr)
         return 2
 
+    # Refuse to clobber a task that's still alive — whether it's in
+    # "running" (worker up and executing) OR "spawning" (worker created
+    # but not yet past its own state-update step). Without the
+    # "spawning" check, a fast second dispatch during the tiny window
+    # between Popen and _run_worker's first state write could overwrite
+    # state and launch a duplicate worker for the same task_id.
+    # Codex 2026-04-10 review finding.
+    # Must run BEFORE ownership admission so a rejected duplicate cannot
+    # DELETE/replace the live task's write claims (#5643 CF F001).
+    existing = _read_state(state_path)
+    if existing and existing.get("status") in ("running", "spawning"):
+        pid = existing.get("pid")
+        if pid and _pid_alive(int(pid)):
+            print(
+                f"❌ task_id {task_id!r} is already {existing['status']} "
+                f"(pid={pid}). Use 'delegate.py status {task_id}' to check, "
+                f"or pick a different task-id.",
+                file=sys.stderr,
+            )
+            return 2
+
     # Writable-path admission guard (#5643 Δ2-A WARN; #5645 REFUSE later).
     # Runs before task-state write / worktree / branch side effects so a refuse
     # leaves no residue. Read-only modes are exempt inside the helper.
@@ -2429,25 +2450,6 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-
-    # Refuse to clobber a task that's still alive — whether it's in
-    # "running" (worker up and executing) OR "spawning" (worker created
-    # but not yet past its own state-update step). Without the
-    # "spawning" check, a fast second dispatch during the tiny window
-    # between Popen and _run_worker's first state write could overwrite
-    # state and launch a duplicate worker for the same task_id.
-    # Codex 2026-04-10 review finding.
-    existing = _read_state(state_path)
-    if existing and existing.get("status") in ("running", "spawning"):
-        pid = existing.get("pid")
-        if pid and _pid_alive(int(pid)):
-            print(
-                f"❌ task_id {task_id!r} is already {existing['status']} "
-                f"(pid={pid}). Use 'delegate.py status {task_id}' to check, "
-                f"or pick a different task-id.",
-                file=sys.stderr,
-            )
-            return 2
 
     # Resolve prompt: literal --prompt, or - for stdin, or --prompt-file.
     if args.prompt_file:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2425,31 +2425,34 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # Writable-path admission guard (#5643 Δ2-A WARN; #5645 REFUSE later).
     # Runs before task-state write / worktree / branch side effects so a refuse
     # leaves no residue. Read-only modes are exempt inside the helper.
-    try:
-        from scripts.delegate_ownership import admit_write_paths, env_guard_mode
-    except ImportError:  # pragma: no cover - flat script path
-        from delegate_ownership import admit_write_paths, env_guard_mode  # type: ignore
+    # Dry-run must leave zero residue (same contract as tmp-lease reap) — skip
+    # the shared ownership ledger entirely (Claude CF #5649 r11).
+    if not bool(getattr(args, "dry_run", False)):
+        try:
+            from scripts.delegate_ownership import admit_write_paths, env_guard_mode
+        except ImportError:  # pragma: no cover - flat script path
+            from delegate_ownership import admit_write_paths, env_guard_mode  # type: ignore
 
-    ownership = admit_write_paths(
-        task_id=task_id,
-        mode=str(args.mode),
-        owned_paths=getattr(args, "research_owned_path", None),
-        allow_path_overlap=getattr(args, "allow_path_overlap", None),
-        pid=os.getpid(),
-        guard_mode=env_guard_mode(),
-    )
-    if ownership.would_refuse or ownership.override_reason:
-        print(
-            f"⚠️  write-path ownership: {ownership.reason} "
-            f"(conflicts={len(ownership.conflicts)})",
-            file=sys.stderr,
+        ownership = admit_write_paths(
+            task_id=task_id,
+            mode=str(args.mode),
+            owned_paths=getattr(args, "research_owned_path", None),
+            allow_path_overlap=getattr(args, "allow_path_overlap", None),
+            pid=os.getpid(),
+            guard_mode=env_guard_mode(),
         )
-    if not ownership.admitted:
-        print(
-            f"❌ write-path ownership refused for task_id={task_id!r}: {ownership.reason}",
-            file=sys.stderr,
-        )
-        return 2
+        if ownership.would_refuse or ownership.override_reason:
+            print(
+                f"⚠️  write-path ownership: {ownership.reason} "
+                f"(conflicts={len(ownership.conflicts)})",
+                file=sys.stderr,
+            )
+        if not ownership.admitted:
+            print(
+                f"❌ write-path ownership refused for task_id={task_id!r}: {ownership.reason}",
+                file=sys.stderr,
+            )
+            return 2
 
     # Resolve prompt: literal --prompt, or - for stdin, or --prompt-file.
     if args.prompt_file:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2429,30 +2429,54 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # the shared ownership ledger entirely (Claude CF #5649 r11).
     if not bool(getattr(args, "dry_run", False)):
         try:
-            from scripts.delegate_ownership import admit_write_paths, env_guard_mode
+            from scripts.delegate_ownership import (
+                GuardMode,
+                admit_write_paths,
+                env_guard_mode,
+            )
         except ImportError:  # pragma: no cover - flat script path
-            from delegate_ownership import admit_write_paths, env_guard_mode  # type: ignore
+            from delegate_ownership import (  # type: ignore
+                GuardMode,
+                admit_write_paths,
+                env_guard_mode,
+            )
 
-        ownership = admit_write_paths(
-            task_id=task_id,
-            mode=str(args.mode),
-            owned_paths=getattr(args, "research_owned_path", None),
-            allow_path_overlap=getattr(args, "allow_path_overlap", None),
-            pid=os.getpid(),
-            guard_mode=env_guard_mode(),
-        )
-        if ownership.would_refuse or ownership.override_reason:
+        guard_mode = env_guard_mode()
+        try:
+            ownership = admit_write_paths(
+                task_id=task_id,
+                mode=str(args.mode),
+                owned_paths=getattr(args, "research_owned_path", None),
+                allow_path_overlap=getattr(args, "allow_path_overlap", None),
+                pid=os.getpid(),
+                guard_mode=guard_mode,
+            )
+        except Exception as own_exc:
+            # WARN (default): never crash dispatch on ledger I/O/lock errors.
+            # REFUSE: fail closed so conflicts cannot silently proceed.
             print(
-                f"⚠️  write-path ownership: {ownership.reason} "
-                f"(conflicts={len(ownership.conflicts)})",
+                f"⚠️  write-path ownership: ledger error: {own_exc}",
                 file=sys.stderr,
             )
-        if not ownership.admitted:
-            print(
-                f"❌ write-path ownership refused for task_id={task_id!r}: {ownership.reason}",
-                file=sys.stderr,
-            )
-            return 2
+            if guard_mode == GuardMode.REFUSE:
+                print(
+                    f"❌ write-path ownership refused (ledger error) for task_id={task_id!r}",
+                    file=sys.stderr,
+                )
+                return 2
+        else:
+            if ownership.would_refuse or ownership.override_reason:
+                print(
+                    f"⚠️  write-path ownership: {ownership.reason} "
+                    f"(conflicts={len(ownership.conflicts)})",
+                    file=sys.stderr,
+                )
+            if not ownership.admitted:
+                print(
+                    f"❌ write-path ownership refused for task_id={task_id!r}: {ownership.reason}",
+                    file=sys.stderr,
+                )
+                return 2
 
     # Resolve prompt: literal --prompt, or - for stdin, or --prompt-file.
     if args.prompt_file:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2429,13 +2429,13 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # the shared ownership ledger entirely (Claude CF #5649 r11).
     if not bool(getattr(args, "dry_run", False)):
         try:
-            from scripts.delegate_ownership import (
+            from scripts.guardrails.delegate_ownership import (
                 GuardMode,
                 admit_write_paths,
                 env_guard_mode,
             )
         except ImportError:  # pragma: no cover - flat script path
-            from delegate_ownership import (  # type: ignore
+            from guardrails.delegate_ownership import (  # type: ignore
                 GuardMode,
                 admit_write_paths,
                 env_guard_mode,
@@ -2908,9 +2908,9 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         # short-lived dispatch CLI). Best-effort: WARN path must not fail spawn.
         if str(args.mode) in _WRITE_CAPABLE_MODES:
             try:
-                from scripts.delegate_ownership import update_write_claim_pid
+                from scripts.guardrails.delegate_ownership import update_write_claim_pid
             except ImportError:  # pragma: no cover
-                from delegate_ownership import update_write_claim_pid  # type: ignore
+                from guardrails.delegate_ownership import update_write_claim_pid  # type: ignore
 
             try:
                 update_write_claim_pid(task_id, int(proc.pid))

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -312,6 +312,81 @@ class OwnershipLedger:
             conn.execute("BEGIN IMMEDIATE")
             self._reconcile_stale(conn)
 
+            # Same-task_id live reservation: concurrent duplicate dispatch race
+            # between admission and state write (CF r7 F001). Refuse if another
+            # live PID already holds claims for this task_id.
+            same_rows = conn.execute(
+                "SELECT DISTINCT pid FROM write_claims WHERE task_id = ?",
+                (task_id,),
+            ).fetchall()
+            for row in same_rows:
+                other_pid = int(row["pid"]) if row["pid"] is not None else None
+                if other_pid is None or other_pid <= 0:
+                    continue
+                if pid is not None and other_pid == pid:
+                    continue  # same process re-admit / retry
+                if _pid_alive(other_pid):
+                    event = {
+                        "task_id": task_id,
+                        "other_pid": other_pid,
+                        "caller": caller,
+                    }
+                    if self.mode == GuardMode.REFUSE:
+                        conn.execute(
+                            "INSERT INTO admission_events (ts, task_id, event, payload) "
+                            "VALUES (?,?,?,?)",
+                            (
+                                time.time(),
+                                task_id,
+                                "refused_same_task",
+                                json.dumps(event, sort_keys=True),
+                            ),
+                        )
+                        conn.execute("COMMIT")
+                        return AdmissionResult(
+                            admitted=False,
+                            mode=self.mode,
+                            would_refuse=True,
+                            reason=(
+                                f"task_id already admitted by live pid={other_pid} (REFUSE)"
+                            ),
+                            conflicts=[
+                                {
+                                    "other_task_id": task_id,
+                                    "other_pid": other_pid,
+                                    "our_claim": {"raw": "(same-task race)"},
+                                }
+                            ],
+                        )
+                    # WARN: keep existing claim; do not replace; admit with would_refuse
+                    conn.execute(
+                        "INSERT INTO admission_events (ts, task_id, event, payload) "
+                        "VALUES (?,?,?,?)",
+                        (
+                            time.time(),
+                            task_id,
+                            "would_refuse_same_task",
+                            json.dumps(event, sort_keys=True),
+                        ),
+                    )
+                    conn.execute("COMMIT")
+                    return AdmissionResult(
+                        admitted=True,
+                        mode=self.mode,
+                        would_refuse=True,
+                        reason=(
+                            f"would-refuse same task_id held by live pid={other_pid}; "
+                            f"admitted under {self.mode.value} without replacing claims"
+                        ),
+                        conflicts=[
+                            {
+                                "other_task_id": task_id,
+                                "other_pid": other_pid,
+                                "our_claim": {"raw": "(same-task race)"},
+                            }
+                        ],
+                    )
+
             active_rows = conn.execute(
                 "SELECT task_id, claim_json, pid FROM write_claims WHERE task_id != ?",
                 (task_id,),

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -151,9 +151,14 @@ def _pid_alive(pid: int) -> bool:
         return True
 
 
+def _safe_task_state_name(task_id: str) -> str:
+    """Match scripts/delegate.py::_state_path sanitization for slashful task ids."""
+    return task_id.replace("/", "_").replace("\\", "_")
+
+
 def _task_still_active(task_id: str, pid: int | None, state_dir: Path) -> bool:
     """True if task state is non-terminal and pid (when known) is alive."""
-    state_path = state_dir / f"{task_id}.json"
+    state_path = state_dir / f"{_safe_task_state_name(task_id)}.json"
     status = None
     state_pid: int | None = None
     if state_path.is_file():

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -161,7 +161,13 @@ def _safe_task_state_name(task_id: str) -> str:
 
 
 def _task_still_active(task_id: str, pid: int | None, state_dir: Path) -> bool:
-    """True if task state is non-terminal and pid (when known) is alive."""
+    """True if the ownership claim should still be considered held.
+
+    Prefer a *live ledger PID* over a terminal state file: admission reserves
+    claims before the new spawning state is written, so a reused task_id can
+    briefly show terminal status while the admitting process is still alive
+    (#5643 CF r6 F001).
+    """
     state_path = state_dir / f"{_safe_task_state_name(task_id)}.json"
     status = None
     state_pid: int | None = None
@@ -177,8 +183,14 @@ def _task_still_active(task_id: str, pid: int | None, state_dir: Path) -> bool:
                 state_pid = raw_pid
             elif isinstance(raw_pid, str) and raw_pid.isdigit():
                 state_pid = int(raw_pid)
+
+    # Ledger PID alive → hold claim (covers admission→state-write race).
+    if pid is not None and pid > 0 and _pid_alive(pid):
+        return True
+
     if status in TERMINAL_TASK_STATUSES:
         return False
+
     check_pid = state_pid if state_pid is not None else pid
     if check_pid is not None and check_pid > 0 and not _pid_alive(check_pid):
         return False

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -327,7 +327,13 @@ class OwnershipLedger:
                         )
 
             # Missing/unknown claims cannot prove disjointness against an active writer.
-            unprovable = bool(active) and (not concrete or bool(unknown))
+            # Also: an active peer with UNKNOWN intent blocks proof of disjointness.
+            active_unknown = any(
+                other_claim.kind == ClaimKind.UNKNOWN for _, other_claim, _ in active
+            )
+            unprovable = bool(active) and (
+                not concrete or bool(unknown) or active_unknown
+            )
             would_refuse = bool(conflicts) or unprovable
 
             override = (allow_path_overlap or "").strip() or None

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -410,17 +410,6 @@ class OwnershipLedger:
                     )
                 )
 
-            # Truly solo + no claims → admit without ledger noise (Fable note).
-            if not claims and not active:
-                conn.execute("COMMIT")
-                return AdmissionResult(
-                    admitted=True,
-                    mode=self.mode,
-                    would_refuse=False,
-                    reason="no owned-path claims; solo admit",
-                    claims=[],
-                )
-
             conflicts: list[dict[str, object]] = []
             for other_task, other_claim, other_pid in active:
                 for mine in concrete:
@@ -470,7 +459,9 @@ class OwnershipLedger:
                     unknown_claims=unknown,
                 )
 
-            # Admit: replace this task's claims.
+            # Admit: replace this task's claims. Always leave a ledger footprint for
+            # write-capable no-path tasks so later writers can see unprovable peers
+            # (CF r8 F001) — solo still admitted with would_refuse=False.
             conn.execute("DELETE FROM write_claims WHERE task_id = ?", (task_id,))
             now = time.time()
             for claim in concrete:
@@ -478,9 +469,8 @@ class OwnershipLedger:
                     "INSERT INTO write_claims (task_id, claim_json, pid, created_at) VALUES (?,?,?,?)",
                     (task_id, json.dumps(claim.as_dict(), sort_keys=True), pid, now),
                 )
-            # Also store UNKNOWN claims so concurrent writers can see unprovable intent.
             store_unknown = list(unknown)
-            if not claims and active:
+            if not claims:
                 store_unknown = [no_claim_sentinel]
             for claim in store_unknown:
                 conn.execute(
@@ -509,6 +499,8 @@ class OwnershipLedger:
                 reason = (
                     f"would-refuse recorded ({event_name}); admitted under {self.mode.value}"
                 )
+            elif not claims:
+                reason = "no owned-path claims; solo admit with sentinel reservation"
             else:
                 reason = "admitted; paths disjoint"
 

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Writable-path admission guard for concurrent dispatches (#5643 Δ2-A).
+
+Local single-host ledger (`batch_state/tasks/write-ownership.sqlite3`) with
+``BEGIN IMMEDIATE`` atomic reconcile → compare → reserve. Read-only modes are
+exempt. WARN mode (default) admits on conflict but records would-refuse;
+REFUSE mode is armed later (#5645).
+
+Claims come from normalized ``--research-owned-path`` values but are stored
+separately from the fail-open research registry.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LEDGER_PATH = _REPO_ROOT / "batch_state" / "tasks" / "write-ownership.sqlite3"
+DEFAULT_TASK_STATE_DIR = _REPO_ROOT / "batch_state" / "tasks"
+
+WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
+TERMINAL_TASK_STATUSES = frozenset(
+    {
+        "done",
+        "failed",
+        "timeout",
+        "rate_limited",
+        "cancelled",
+        "crashed",
+        "dry_run",
+    }
+)
+
+
+class ClaimKind(StrEnum):
+    FILE = "file"
+    SUBTREE = "subtree"
+    UNKNOWN = "ownership_unknown"
+
+
+class GuardMode(StrEnum):
+    WARN = "warn"
+    REFUSE = "refuse"
+
+
+@dataclass(frozen=True)
+class PathClaim:
+    raw: str
+    kind: ClaimKind
+    # Normalized repo-relative path without trailing slashes / ** for compare.
+    norm: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"raw": self.raw, "kind": self.kind.value, "norm": self.norm}
+
+
+@dataclass
+class AdmissionResult:
+    admitted: bool
+    mode: GuardMode
+    would_refuse: bool
+    reason: str
+    conflicts: list[dict[str, object]] = field(default_factory=list)
+    claims: list[PathClaim] = field(default_factory=list)
+    unknown_claims: list[PathClaim] = field(default_factory=list)
+    override_reason: str | None = None
+    skipped: bool = False
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "admitted": self.admitted,
+            "mode": self.mode.value,
+            "would_refuse": self.would_refuse,
+            "reason": self.reason,
+            "conflicts": self.conflicts,
+            "claims": [c.as_dict() for c in self.claims],
+            "unknown_claims": [c.as_dict() for c in self.unknown_claims],
+            "override_reason": self.override_reason,
+            "skipped": self.skipped,
+        }
+
+
+def normalize_claim(raw: str) -> PathClaim:
+    """Normalize a single --research-owned-path value into a claim."""
+    text = (raw or "").strip().replace("\\", "/")
+    if not text or text in {".", "./"}:
+        return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm="")
+
+    # Drop leading ./
+    while text.startswith("./"):
+        text = text[2:]
+
+    # Reject absolute / parent escapes as unknown (not comparable safely).
+    if text.startswith("/") or text.startswith("../") or "/../" in f"/{text}/":
+        return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
+
+    # Subtree forms: path/ or path/**
+    if text.endswith("/**"):
+        base = text[: -len("/**")].rstrip("/")
+        if not base or "*" in base or "?" in base or "[" in base:
+            return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
+        return PathClaim(raw=raw, kind=ClaimKind.SUBTREE, norm=base)
+    if text.endswith("/"):
+        base = text.rstrip("/")
+        if not base or "*" in base or "?" in base or "[" in base:
+            return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
+        return PathClaim(raw=raw, kind=ClaimKind.SUBTREE, norm=base)
+
+    # Any other wildcard → unknown
+    if any(ch in text for ch in "*?["):
+        return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
+
+    return PathClaim(raw=raw, kind=ClaimKind.FILE, norm=text.rstrip("/"))
+
+
+def claims_conflict(a: PathClaim, b: PathClaim) -> bool:
+    """Return True if two concrete claims intersect. UNKNOWN never proves overlap alone."""
+    if a.kind == ClaimKind.UNKNOWN or b.kind == ClaimKind.UNKNOWN:
+        return False
+    if a.kind == ClaimKind.FILE and b.kind == ClaimKind.FILE:
+        return a.norm == b.norm
+    if a.kind == ClaimKind.FILE and b.kind == ClaimKind.SUBTREE:
+        return a.norm == b.norm or a.norm.startswith(b.norm + "/")
+    if a.kind == ClaimKind.SUBTREE and b.kind == ClaimKind.FILE:
+        return b.norm == a.norm or b.norm.startswith(a.norm + "/")
+    # subtree/subtree
+    return (
+        a.norm == b.norm
+        or a.norm.startswith(b.norm + "/")
+        or b.norm.startswith(a.norm + "/")
+    )
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    else:
+        return True
+
+
+def _task_still_active(task_id: str, pid: int | None, state_dir: Path) -> bool:
+    """True if task state is non-terminal and pid (when known) is alive."""
+    state_path = state_dir / f"{task_id}.json"
+    status = None
+    state_pid: int | None = None
+    if state_path.is_file():
+        try:
+            data = json.loads(state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        if isinstance(data, dict):
+            status = data.get("status")
+            raw_pid = data.get("pid")
+            if isinstance(raw_pid, int):
+                state_pid = raw_pid
+            elif isinstance(raw_pid, str) and raw_pid.isdigit():
+                state_pid = int(raw_pid)
+    if status in TERMINAL_TASK_STATUSES:
+        return False
+    check_pid = state_pid if state_pid is not None else pid
+    if check_pid is not None and check_pid > 0 and not _pid_alive(check_pid):
+        return False
+    # No state file and no pid → treat as stale (cannot prove active).
+    if status is None and (check_pid is None or check_pid <= 0):
+        return False
+    # spawning/running/needs_finalize/empty with live pid (or unknown pid) = active
+    if status in ("running", "spawning", "needs_finalize", "", None):
+        if check_pid is None or check_pid <= 0:
+            # State says active but no pid — keep claim conservatively if status explicit.
+            return status in ("running", "spawning", "needs_finalize")
+        return _pid_alive(check_pid)
+    return False
+
+
+class OwnershipLedger:
+    def __init__(
+        self,
+        path: Path = DEFAULT_LEDGER_PATH,
+        *,
+        task_state_dir: Path = DEFAULT_TASK_STATE_DIR,
+        mode: GuardMode = GuardMode.WARN,
+    ) -> None:
+        self.path = Path(path)
+        self.task_state_dir = Path(task_state_dir)
+        self.mode = mode
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.path), timeout=30.0, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=30000")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS write_claims (
+                task_id TEXT NOT NULL,
+                claim_json TEXT NOT NULL,
+                pid INTEGER,
+                created_at REAL NOT NULL,
+                PRIMARY KEY (task_id, claim_json)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS admission_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts REAL NOT NULL,
+                task_id TEXT NOT NULL,
+                event TEXT NOT NULL,
+                payload TEXT NOT NULL
+            )
+            """
+        )
+        return conn
+
+    def _reconcile_stale(self, conn: sqlite3.Connection) -> list[str]:
+        released: list[str] = []
+        rows = conn.execute(
+            "SELECT DISTINCT task_id, pid FROM write_claims"
+        ).fetchall()
+        for row in rows:
+            task_id = str(row["task_id"])
+            pid = row["pid"]
+            pid_i = int(pid) if pid is not None else None
+            if not _task_still_active(task_id, pid_i, self.task_state_dir):
+                conn.execute("DELETE FROM write_claims WHERE task_id = ?", (task_id,))
+                released.append(task_id)
+        return released
+
+    def release(self, task_id: str) -> None:
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute("DELETE FROM write_claims WHERE task_id = ?", (task_id,))
+            conn.execute("COMMIT")
+
+    def admit(
+        self,
+        *,
+        task_id: str,
+        mode: str,
+        owned_paths: Sequence[str] | None,
+        allow_path_overlap: str | None = None,
+        pid: int | None = None,
+        caller: str = "delegate.cmd_dispatch",
+    ) -> AdmissionResult:
+        """Attempt admission. WARN always admits; REFUSE may refuse."""
+        if mode not in WRITE_CAPABLE_MODES:
+            return AdmissionResult(
+                admitted=True,
+                mode=self.mode,
+                would_refuse=False,
+                reason="read-only exempt",
+                skipped=True,
+            )
+
+        claims = [normalize_claim(p) for p in (owned_paths or ())]
+        unknown = [c for c in claims if c.kind == ClaimKind.UNKNOWN]
+        concrete = [c for c in claims if c.kind != ClaimKind.UNKNOWN]
+
+        # Solo dispatch with no claims stays admitted (Fable note).
+        if not claims:
+            return AdmissionResult(
+                admitted=True,
+                mode=self.mode,
+                would_refuse=False,
+                reason="no owned-path claims; solo admit",
+                claims=[],
+            )
+
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._reconcile_stale(conn)
+
+            active_rows = conn.execute(
+                "SELECT task_id, claim_json, pid FROM write_claims WHERE task_id != ?",
+                (task_id,),
+            ).fetchall()
+            active: list[tuple[str, PathClaim, int | None]] = []
+            for row in active_rows:
+                try:
+                    payload = json.loads(row["claim_json"])
+                    claim = PathClaim(
+                        raw=str(payload.get("raw", "")),
+                        kind=ClaimKind(str(payload.get("kind"))),
+                        norm=str(payload.get("norm", "")),
+                    )
+                except (json.JSONDecodeError, ValueError, TypeError, KeyError):
+                    continue
+                active.append(
+                    (
+                        str(row["task_id"]),
+                        claim,
+                        int(row["pid"]) if row["pid"] is not None else None,
+                    )
+                )
+
+            conflicts: list[dict[str, object]] = []
+            for other_task, other_claim, other_pid in active:
+                for mine in concrete:
+                    if claims_conflict(mine, other_claim):
+                        conflicts.append(
+                            {
+                                "other_task_id": other_task,
+                                "other_pid": other_pid,
+                                "other_claim": other_claim.as_dict(),
+                                "our_claim": mine.as_dict(),
+                            }
+                        )
+
+            # Missing/unknown claims cannot prove disjointness against an active writer.
+            unprovable = bool(active) and (not concrete or bool(unknown))
+            would_refuse = bool(conflicts) or unprovable
+
+            override = (allow_path_overlap or "").strip() or None
+            if override:
+                would_refuse = False  # explicit override clears refuse intent for logging
+
+            if would_refuse and self.mode == GuardMode.REFUSE and not override:
+                event = {
+                    "task_id": task_id,
+                    "conflicts": conflicts,
+                    "unknown": [c.as_dict() for c in unknown],
+                    "caller": caller,
+                }
+                conn.execute(
+                    "INSERT INTO admission_events (ts, task_id, event, payload) VALUES (?,?,?,?)",
+                    (time.time(), task_id, "refused", json.dumps(event, sort_keys=True)),
+                )
+                conn.execute("COMMIT")
+                return AdmissionResult(
+                    admitted=False,
+                    mode=self.mode,
+                    would_refuse=True,
+                    reason="path ownership conflict (REFUSE)",
+                    conflicts=conflicts,
+                    claims=concrete,
+                    unknown_claims=unknown,
+                )
+
+            # Admit: replace this task's claims.
+            conn.execute("DELETE FROM write_claims WHERE task_id = ?", (task_id,))
+            now = time.time()
+            for claim in concrete:
+                conn.execute(
+                    "INSERT INTO write_claims (task_id, claim_json, pid, created_at) VALUES (?,?,?,?)",
+                    (task_id, json.dumps(claim.as_dict(), sort_keys=True), pid, now),
+                )
+            # Also store UNKNOWN claims so concurrent writers can see unprovable intent.
+            for claim in unknown:
+                conn.execute(
+                    "INSERT INTO write_claims (task_id, claim_json, pid, created_at) VALUES (?,?,?,?)",
+                    (task_id, json.dumps(claim.as_dict(), sort_keys=True), pid, now),
+                )
+
+            event_name = "admitted"
+            if conflicts or unprovable:
+                event_name = "would_refuse_warn" if not override else "override"
+            event = {
+                "task_id": task_id,
+                "conflicts": conflicts,
+                "unknown": [c.as_dict() for c in unknown],
+                "override_reason": override,
+                "caller": caller,
+                "mode": self.mode.value,
+            }
+            conn.execute(
+                "INSERT INTO admission_events (ts, task_id, event, payload) VALUES (?,?,?,?)",
+                (now, task_id, event_name, json.dumps(event, sort_keys=True)),
+            )
+            conn.execute("COMMIT")
+
+            if conflicts or unprovable:
+                reason = (
+                    f"would-refuse recorded ({event_name}); admitted under {self.mode.value}"
+                )
+            else:
+                reason = "admitted; paths disjoint"
+
+            return AdmissionResult(
+                admitted=True,
+                mode=self.mode,
+                would_refuse=bool(conflicts or unprovable) and not override,
+                reason=reason,
+                conflicts=conflicts,
+                claims=concrete,
+                unknown_claims=unknown,
+                override_reason=override,
+            )
+
+
+def admit_write_paths(
+    *,
+    task_id: str,
+    mode: str,
+    owned_paths: Sequence[str] | None,
+    allow_path_overlap: str | None = None,
+    pid: int | None = None,
+    ledger_path: Path = DEFAULT_LEDGER_PATH,
+    task_state_dir: Path = DEFAULT_TASK_STATE_DIR,
+    guard_mode: GuardMode | str = GuardMode.WARN,
+) -> AdmissionResult:
+    gm = GuardMode(guard_mode) if not isinstance(guard_mode, GuardMode) else guard_mode
+    ledger = OwnershipLedger(ledger_path, task_state_dir=task_state_dir, mode=gm)
+    return ledger.admit(
+        task_id=task_id,
+        mode=mode,
+        owned_paths=owned_paths,
+        allow_path_overlap=allow_path_overlap,
+        pid=pid,
+    )
+
+
+def env_guard_mode() -> GuardMode:
+    """Resolve guard mode from env (default WARN). REFUSE only after soak (#5645)."""
+    raw = (os.environ.get("DELEGATE_OWNERSHIP_MODE") or "warn").strip().lower()
+    if raw in {"refuse", "deny", "fail"}:
+        return GuardMode.REFUSE
+    return GuardMode.WARN

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -114,8 +114,16 @@ def normalize_claim(raw: str) -> PathClaim:
     if norm in {"", "."}:
         return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
 
-    # Reject absolute / parent escapes as unknown (not comparable safely).
-    if norm.startswith("/") or norm.startswith("../") or norm == ".." or "/../" in f"/{norm}/":
+    # Reject absolute / parent escapes / drive-qualified paths as unknown
+    # (not comparable safely as repo-relative claims).
+    drive_qualified = len(norm) >= 2 and norm[0].isalpha() and norm[1] == ":"
+    if (
+        norm.startswith("/")
+        or norm.startswith("../")
+        or norm == ".."
+        or "/../" in f"/{norm}/"
+        or drive_qualified
+    ):
         return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
 
     if is_double_star or is_subtree_slash:

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -275,16 +275,11 @@ class OwnershipLedger:
         claims = [normalize_claim(p) for p in (owned_paths or ())]
         unknown = [c for c in claims if c.kind == ClaimKind.UNKNOWN]
         concrete = [c for c in claims if c.kind != ClaimKind.UNKNOWN]
-
-        # Solo dispatch with no claims stays admitted (Fable note).
-        if not claims:
-            return AdmissionResult(
-                admitted=True,
-                mode=self.mode,
-                would_refuse=False,
-                reason="no owned-path claims; solo admit",
-                claims=[],
-            )
+        # No declared paths still participate in the ledger when peers are active
+        # (cannot prove disjointness — Fable solo-admit only when truly alone).
+        no_claim_sentinel = PathClaim(
+            raw="*", kind=ClaimKind.UNKNOWN, norm="*"
+        )
 
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
@@ -313,6 +308,17 @@ class OwnershipLedger:
                     )
                 )
 
+            # Truly solo + no claims → admit without ledger noise (Fable note).
+            if not claims and not active:
+                conn.execute("COMMIT")
+                return AdmissionResult(
+                    admitted=True,
+                    mode=self.mode,
+                    would_refuse=False,
+                    reason="no owned-path claims; solo admit",
+                    claims=[],
+                )
+
             conflicts: list[dict[str, object]] = []
             for other_task, other_claim, other_pid in active:
                 for mine in concrete:
@@ -332,7 +338,7 @@ class OwnershipLedger:
                 other_claim.kind == ClaimKind.UNKNOWN for _, other_claim, _ in active
             )
             unprovable = bool(active) and (
-                not concrete or bool(unknown) or active_unknown
+                not concrete or bool(unknown) or active_unknown or not claims
             )
             would_refuse = bool(conflicts) or unprovable
 
@@ -371,7 +377,10 @@ class OwnershipLedger:
                     (task_id, json.dumps(claim.as_dict(), sort_keys=True), pid, now),
                 )
             # Also store UNKNOWN claims so concurrent writers can see unprovable intent.
-            for claim in unknown:
+            store_unknown = list(unknown)
+            if not claims and active:
+                store_unknown = [no_claim_sentinel]
+            for claim in store_unknown:
                 conn.execute(
                     "INSERT INTO write_claims (task_id, claim_json, pid, created_at) VALUES (?,?,?,?)",
                     (task_id, json.dumps(claim.as_dict(), sort_keys=True), pid, now),
@@ -383,7 +392,7 @@ class OwnershipLedger:
             event = {
                 "task_id": task_id,
                 "conflicts": conflicts,
-                "unknown": [c.as_dict() for c in unknown],
+                "unknown": [c.as_dict() for c in store_unknown],
                 "override_reason": override,
                 "caller": caller,
                 "mode": self.mode.value,
@@ -408,7 +417,7 @@ class OwnershipLedger:
                 reason=reason,
                 conflicts=conflicts,
                 claims=concrete,
-                unknown_claims=unknown,
+                unknown_claims=store_unknown,
                 override_reason=override,
             )
 

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 import sqlite3
 import time
 from collections.abc import Sequence
@@ -87,37 +88,40 @@ class AdmissionResult:
         }
 
 
+def _posix_norm(path: str) -> str:
+    """Collapse // and . segments; leave .. rejection to the caller."""
+    cleaned = path.replace("\\", "/")
+    # posixpath.normpath keeps a leading /; for relative paths it collapses // and .
+    return posixpath.normpath(cleaned)
+
+
 def normalize_claim(raw: str) -> PathClaim:
     """Normalize a single --research-owned-path value into a claim."""
     text = (raw or "").strip().replace("\\", "/")
     if not text or text in {".", "./"}:
         return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm="")
 
-    # Drop leading ./
-    while text.startswith("./"):
-        text = text[2:]
+    # Preserve subtree intent before normpath (which strips trailing /).
+    is_double_star = text.endswith("/**")
+    is_subtree_slash = text.endswith("/") and not is_double_star
+    body = text[: -len("/**")] if is_double_star else text.rstrip("/") if is_subtree_slash else text
+
+    # Any wildcard in the body (or non-/** wildcards) → unknown before norm.
+    if any(ch in body for ch in "*?[") or ("*" in text and not is_double_star):
+        return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
+
+    norm = _posix_norm(body)
+    if norm in {"", "."}:
+        return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
 
     # Reject absolute / parent escapes as unknown (not comparable safely).
-    if text.startswith("/") or text.startswith("../") or "/../" in f"/{text}/":
+    if norm.startswith("/") or norm.startswith("../") or norm == ".." or "/../" in f"/{norm}/":
         return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
 
-    # Subtree forms: path/ or path/**
-    if text.endswith("/**"):
-        base = text[: -len("/**")].rstrip("/")
-        if not base or "*" in base or "?" in base or "[" in base:
-            return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
-        return PathClaim(raw=raw, kind=ClaimKind.SUBTREE, norm=base)
-    if text.endswith("/"):
-        base = text.rstrip("/")
-        if not base or "*" in base or "?" in base or "[" in base:
-            return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
-        return PathClaim(raw=raw, kind=ClaimKind.SUBTREE, norm=base)
+    if is_double_star or is_subtree_slash:
+        return PathClaim(raw=raw, kind=ClaimKind.SUBTREE, norm=norm)
 
-    # Any other wildcard → unknown
-    if any(ch in text for ch in "*?["):
-        return PathClaim(raw=raw, kind=ClaimKind.UNKNOWN, norm=text)
-
-    return PathClaim(raw=raw, kind=ClaimKind.FILE, norm=text.rstrip("/"))
+    return PathClaim(raw=raw, kind=ClaimKind.FILE, norm=norm)
 
 
 def claims_conflict(a: PathClaim, b: PathClaim) -> bool:

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -22,7 +22,14 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+# Anchor ledger + task-state to the PRIMARY checkout (not a worktree copy),
+# matching scripts/delegate.py (Claude CF #5649 r12 F001).
+try:
+    from scripts.common.repo_root import resolve_repo_root
+except ImportError:  # pragma: no cover - flat script path
+    from common.repo_root import resolve_repo_root  # type: ignore
+
+_REPO_ROOT = resolve_repo_root(Path(__file__), 1)
 DEFAULT_LEDGER_PATH = _REPO_ROOT / "batch_state" / "tasks" / "write-ownership.sqlite3"
 DEFAULT_TASK_STATE_DIR = _REPO_ROOT / "batch_state" / "tasks"
 # Admission uses the short-lived CLI PID until the worker PID is written.

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -25,6 +25,9 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_LEDGER_PATH = _REPO_ROOT / "batch_state" / "tasks" / "write-ownership.sqlite3"
 DEFAULT_TASK_STATE_DIR = _REPO_ROOT / "batch_state" / "tasks"
+# Admission uses the short-lived CLI PID until the worker PID is written.
+# Live-PID fast path only applies inside this grace window (seconds).
+ADMISSION_PID_GRACE_S = 180.0
 
 WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
 TERMINAL_TASK_STATUSES = frozenset(
@@ -168,13 +171,21 @@ def _safe_task_state_name(task_id: str) -> str:
     return task_id.replace("/", "_").replace("\\", "_")
 
 
-def _task_still_active(task_id: str, pid: int | None, state_dir: Path) -> bool:
+def _task_still_active(
+    task_id: str,
+    pid: int | None,
+    state_dir: Path,
+    *,
+    created_at: float | None = None,
+    now: float | None = None,
+) -> bool:
     """True if the ownership claim should still be considered held.
 
-    Prefer a *live ledger PID* over a terminal state file: admission reserves
-    claims before the new spawning state is written, so a reused task_id can
-    briefly show terminal status while the admitting process is still alive
-    (#5643 CF r6 F001).
+    Admission records the short-lived CLI PID first; the worker PID is patched
+    in after Popen. Live-PID trust is therefore limited to
+    ``ADMISSION_PID_GRACE_S`` so a recycled CLI PID cannot pin claims forever
+    (Claude CF #5649 F001). Outside the grace window, task-state + worker PID
+    are authoritative.
     """
     state_path = state_dir / f"{_safe_task_state_name(task_id)}.json"
     status = None
@@ -192,14 +203,20 @@ def _task_still_active(task_id: str, pid: int | None, state_dir: Path) -> bool:
             elif isinstance(raw_pid, str) and raw_pid.isdigit():
                 state_pid = int(raw_pid)
 
-    # Ledger PID alive → hold claim (covers admission→state-write race).
-    if pid is not None and pid > 0 and _pid_alive(pid):
+    clock = time.time() if now is None else now
+    in_grace = (
+        created_at is not None and (clock - float(created_at)) <= ADMISSION_PID_GRACE_S
+    )
+
+    # Within grace only: live ledger PID holds claim (admission→state-write race).
+    if in_grace and pid is not None and pid > 0 and _pid_alive(pid):
         return True
 
     if status in TERMINAL_TASK_STATUSES:
         return False
 
-    check_pid = state_pid if state_pid is not None else pid
+    # Prefer state worker PID once present (long-lived).
+    check_pid = state_pid if state_pid is not None else (pid if in_grace else None)
     if check_pid is not None and check_pid > 0 and not _pid_alive(check_pid):
         return False
     # No state file and no pid → treat as stale (cannot prove active).
@@ -259,13 +276,17 @@ class OwnershipLedger:
     def _reconcile_stale(self, conn: sqlite3.Connection) -> list[str]:
         released: list[str] = []
         rows = conn.execute(
-            "SELECT DISTINCT task_id, pid FROM write_claims"
+            "SELECT task_id, pid, MIN(created_at) AS created_at "
+            "FROM write_claims GROUP BY task_id, pid"
         ).fetchall()
         for row in rows:
             task_id = str(row["task_id"])
             pid = row["pid"]
             pid_i = int(pid) if pid is not None else None
-            if not _task_still_active(task_id, pid_i, self.task_state_dir):
+            created = float(row["created_at"]) if row["created_at"] is not None else None
+            if not _task_still_active(
+                task_id, pid_i, self.task_state_dir, created_at=created
+            ):
                 conn.execute("DELETE FROM write_claims WHERE task_id = ?", (task_id,))
                 released.append(task_id)
         return released
@@ -274,6 +295,16 @@ class OwnershipLedger:
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
             conn.execute("DELETE FROM write_claims WHERE task_id = ?", (task_id,))
+            conn.execute("COMMIT")
+
+    def update_claim_pid(self, task_id: str, new_pid: int) -> None:
+        """Patch ledger PID after the long-lived worker is spawned."""
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "UPDATE write_claims SET pid = ? WHERE task_id = ?",
+                (int(new_pid), task_id),
+            )
             conn.execute("COMMIT")
 
     def admit(
@@ -552,3 +583,16 @@ def env_guard_mode() -> GuardMode:
     if raw in {"refuse", "deny", "fail"}:
         return GuardMode.REFUSE
     return GuardMode.WARN
+
+
+def update_write_claim_pid(
+    task_id: str,
+    new_pid: int,
+    *,
+    ledger_path: Path = DEFAULT_LEDGER_PATH,
+    task_state_dir: Path = DEFAULT_TASK_STATE_DIR,
+) -> None:
+    """Public helper: bind claim rows to the detached worker PID after Popen."""
+    OwnershipLedger(ledger_path, task_state_dir=task_state_dir).update_claim_pid(
+        task_id, new_pid
+    )

--- a/scripts/delegate_ownership.py
+++ b/scripts/delegate_ownership.py
@@ -277,6 +277,17 @@ class OwnershipLedger:
             )
 
         claims = [normalize_claim(p) for p in (owned_paths or ())]
+        # Deduplicate by normalized ledger identity (kind+norm) so repeatable
+        # CLI flags / equivalent spellings do not crash on PRIMARY KEY.
+        seen: set[tuple[str, str]] = set()
+        deduped: list[PathClaim] = []
+        for claim in claims:
+            key = (claim.kind.value, claim.norm)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(claim)
+        claims = deduped
         unknown = [c for c in claims if c.kind == ClaimKind.UNKNOWN]
         concrete = [c for c in claims if c.kind != ClaimKind.UNKNOWN]
         # No declared paths still participate in the ledger when peers are active

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -29,7 +29,8 @@ try:
 except ImportError:  # pragma: no cover - flat script path
     from common.repo_root import resolve_repo_root  # type: ignore
 
-_REPO_ROOT = resolve_repo_root(Path(__file__), 1)
+# File lives at scripts/guardrails/… → parents[2] is the checkout root.
+_REPO_ROOT = resolve_repo_root(Path(__file__), 2)
 DEFAULT_LEDGER_PATH = _REPO_ROOT / "batch_state" / "tasks" / "write-ownership.sqlite3"
 DEFAULT_TASK_STATE_DIR = _REPO_ROOT / "batch_state" / "tasks"
 # Admission uses the short-lived CLI PID until the worker PID is written.

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -371,3 +371,35 @@ def test_duplicate_equivalent_claims_do_not_crash(tmp_path: Path):
     )
     assert result.admitted is True
     assert len(result.claims) == 1
+
+
+def test_live_ledger_pid_keeps_claim_despite_terminal_state(tmp_path: Path):
+    """Admission→state-write race: terminal state must not drop live PID claim (CF r6)."""
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    # Stale terminal file for reused task_id, but ledger PID is this live process.
+    (state_dir / "reuse.json").write_text(
+        json.dumps({"status": "done", "pid": 1}), encoding="utf-8"
+    )
+    first = admit_write_paths(
+        task_id="reuse",
+        mode="workspace-write",
+        owned_paths=["scripts/x.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert first.admitted is True
+    # Concurrent peer must still see the claim (would_refuse), not reconcile it away.
+    peer = admit_write_paths(
+        task_id="peer2",
+        mode="workspace-write",
+        owned_paths=["scripts/x.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.WARN,
+    )
+    assert peer.would_refuse is True

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -22,6 +22,12 @@ def test_normalize_file_subtree_unknown():
     assert normalize_claim("scripts/**").kind == ClaimKind.SUBTREE
     assert normalize_claim("scripts/**/*.py").kind == ClaimKind.UNKNOWN
     assert normalize_claim("../escape").kind == ClaimKind.UNKNOWN
+    # Canonicalize equivalent spellings (CF r4 F001)
+    a = normalize_claim("scripts/delegate.py")
+    b = normalize_claim("scripts//delegate.py")
+    c = normalize_claim("scripts/./delegate.py")
+    assert a.norm == b.norm == c.norm
+    assert claims_conflict(a, b) and claims_conflict(a, c)
 
 
 def test_claims_conflict_matrix():

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -1,0 +1,258 @@
+"""Tests for scripts/delegate_ownership.py (#5643 Δ2-A WARN)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from scripts.delegate_ownership import (
+    ClaimKind,
+    GuardMode,
+    OwnershipLedger,
+    admit_write_paths,
+    claims_conflict,
+    normalize_claim,
+)
+
+
+def test_normalize_file_subtree_unknown():
+    assert normalize_claim("scripts/delegate.py").kind == ClaimKind.FILE
+    assert normalize_claim("scripts/").kind == ClaimKind.SUBTREE
+    assert normalize_claim("scripts/**").kind == ClaimKind.SUBTREE
+    assert normalize_claim("scripts/**/*.py").kind == ClaimKind.UNKNOWN
+    assert normalize_claim("../escape").kind == ClaimKind.UNKNOWN
+
+
+def test_claims_conflict_matrix():
+    f_a = normalize_claim("a/b.py")
+    f_c = normalize_claim("a/c.py")
+    sub = normalize_claim("a/")
+    sib = normalize_claim("b/")
+    assert claims_conflict(f_a, f_a)
+    assert not claims_conflict(f_a, f_c)
+    assert claims_conflict(f_a, sub)
+    assert claims_conflict(sub, f_a)
+    assert claims_conflict(normalize_claim("a/x/"), sub)
+    assert not claims_conflict(sub, sib)
+    assert not claims_conflict(f_a, normalize_claim("a/**/*.py"))
+
+
+def test_read_only_exempt(tmp_path: Path):
+    ledger = tmp_path / "own.sqlite3"
+    result = admit_write_paths(
+        task_id="t1",
+        mode="read-only",
+        owned_paths=["scripts/foo.py"],
+        ledger_path=ledger,
+        task_state_dir=tmp_path,
+    )
+    assert result.skipped is True
+    assert result.admitted is True
+
+
+def test_solo_no_claims_admitted(tmp_path: Path):
+    ledger = tmp_path / "own.sqlite3"
+    result = admit_write_paths(
+        task_id="solo",
+        mode="workspace-write",
+        owned_paths=[],
+        ledger_path=ledger,
+        task_state_dir=tmp_path,
+    )
+    assert result.admitted is True
+    assert result.would_refuse is False
+
+
+def test_exact_file_conflict_warn(tmp_path: Path):
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    # Active holder with live pid (this process)
+    pid = os.getpid()
+    (state_dir / "holder.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    first = admit_write_paths(
+        task_id="holder",
+        mode="workspace-write",
+        owned_paths=["scripts/a.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert first.admitted and not first.would_refuse
+
+    second = admit_write_paths(
+        task_id="challenger",
+        mode="workspace-write",
+        owned_paths=["scripts/a.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.WARN,
+    )
+    assert second.admitted is True
+    assert second.would_refuse is True
+    assert second.conflicts
+
+
+def test_file_subtree_and_sibling_disjoint(tmp_path: Path):
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    (state_dir / "h.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    admit_write_paths(
+        task_id="h",
+        mode="danger",
+        owned_paths=["pkg/"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    # file inside subtree conflicts
+    inside = admit_write_paths(
+        task_id="in",
+        mode="danger",
+        owned_paths=["pkg/mod.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert inside.would_refuse is True
+    # sibling disjoint
+    sib = admit_write_paths(
+        task_id="sib",
+        mode="danger",
+        owned_paths=["other/"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert sib.would_refuse is False
+
+
+def test_stale_claim_reconciled(tmp_path: Path):
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    # dead pid
+    (state_dir / "dead.json").write_text(
+        json.dumps({"status": "running", "pid": 99999999}), encoding="utf-8"
+    )
+    # plant claim via first admit then kill state
+    own = OwnershipLedger(ledger, task_state_dir=state_dir, mode=GuardMode.WARN)
+    # manually insert with dead pid after admit with fake live - use direct SQL after admit
+    r = own.admit(
+        task_id="dead",
+        mode="workspace-write",
+        owned_paths=["x.py"],
+        pid=99999999,
+    )
+    assert r.admitted
+    # now challenger should free the stale claim
+    (state_dir / "dead.json").write_text(
+        json.dumps({"status": "done", "pid": 99999999}), encoding="utf-8"
+    )
+    second = own.admit(
+        task_id="live",
+        mode="workspace-write",
+        owned_paths=["x.py"],
+        pid=os.getpid(),
+    )
+    assert second.admitted is True
+    assert second.would_refuse is False
+
+
+def test_override_records_reason(tmp_path: Path):
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    (state_dir / "h.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    admit_write_paths(
+        task_id="h",
+        mode="workspace-write",
+        owned_paths=["same.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    over = admit_write_paths(
+        task_id="c",
+        mode="workspace-write",
+        owned_paths=["same.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        allow_path_overlap="coordinated dual-edit",
+    )
+    assert over.admitted is True
+    assert over.would_refuse is False
+    assert over.override_reason == "coordinated dual-edit"
+
+
+def test_refuse_mode_blocks(tmp_path: Path):
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    (state_dir / "h.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    admit_write_paths(
+        task_id="h",
+        mode="workspace-write",
+        owned_paths=["same.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    refused = admit_write_paths(
+        task_id="c",
+        mode="workspace-write",
+        owned_paths=["same.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.REFUSE,
+    )
+    assert refused.admitted is False
+    assert refused.would_refuse is True
+
+
+def test_simultaneous_admission_one_conflict_visible(tmp_path: Path):
+    """Under BEGIN IMMEDIATE, sequential contenders see each other's claims."""
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    for tid in ("a", "b"):
+        (state_dir / f"{tid}.json").write_text(
+            json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+        )
+    r1 = admit_write_paths(
+        task_id="a",
+        mode="workspace-write",
+        owned_paths=["race.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.REFUSE,
+    )
+    r2 = admit_write_paths(
+        task_id="b",
+        mode="workspace-write",
+        owned_paths=["race.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.REFUSE,
+    )
+    assert r1.admitted is True
+    assert r2.admitted is False

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -22,6 +22,7 @@ def test_normalize_file_subtree_unknown():
     assert normalize_claim("scripts/**").kind == ClaimKind.SUBTREE
     assert normalize_claim("scripts/**/*.py").kind == ClaimKind.UNKNOWN
     assert normalize_claim("../escape").kind == ClaimKind.UNKNOWN
+    assert normalize_claim(r"C:\repo\scripts\delegate.py").kind == ClaimKind.UNKNOWN
     # Canonicalize equivalent spellings (CF r4 F001)
     a = normalize_claim("scripts/delegate.py")
     b = normalize_claim("scripts//delegate.py")

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -354,3 +354,20 @@ def test_no_claims_with_active_peer_is_unprovable(tmp_path: Path):
     )
     assert blank.admitted is True
     assert blank.would_refuse is True
+
+
+def test_duplicate_equivalent_claims_do_not_crash(tmp_path: Path):
+    """Repeatable / equivalent owned paths must not hit PRIMARY KEY (CF r5)."""
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    result = admit_write_paths(
+        task_id="dup",
+        mode="workspace-write",
+        owned_paths=["scripts/a.py", "scripts//a.py", "scripts/./a.py"],
+        pid=os.getpid(),
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert result.admitted is True
+    assert len(result.claims) == 1

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -256,3 +256,35 @@ def test_simultaneous_admission_one_conflict_visible(tmp_path: Path):
     )
     assert r1.admitted is True
     assert r2.admitted is False
+
+
+def test_slashful_task_id_state_file_sanitized(tmp_path: Path):
+    """task_id with slashes must resolve to underscore state files (CF F001)."""
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    # delegate.py stores codex/5643 as codex_5643.json
+    (state_dir / "codex_5643.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    first = admit_write_paths(
+        task_id="codex/5643",
+        mode="workspace-write",
+        owned_paths=["scripts/x.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert first.admitted is True
+    second = admit_write_paths(
+        task_id="other",
+        mode="workspace-write",
+        owned_paths=["scripts/x.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.WARN,
+    )
+    assert second.would_refuse is True
+    assert second.conflicts

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -59,15 +59,30 @@ def test_read_only_exempt(tmp_path: Path):
 
 def test_solo_no_claims_admitted(tmp_path: Path):
     ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
     result = admit_write_paths(
         task_id="solo",
         mode="workspace-write",
         owned_paths=[],
+        pid=pid,
         ledger_path=ledger,
-        task_state_dir=tmp_path,
+        task_state_dir=state_dir,
     )
     assert result.admitted is True
     assert result.would_refuse is False
+    # Sentinel reserved so a later peer is unprovable (CF r8)
+    later = admit_write_paths(
+        task_id="later",
+        mode="workspace-write",
+        owned_paths=["scripts/a.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.WARN,
+    )
+    assert later.would_refuse is True
 
 
 def test_exact_file_conflict_warn(tmp_path: Path):

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -318,3 +318,33 @@ def test_active_unknown_claim_makes_later_concrete_unprovable(tmp_path: Path):
     )
     assert later.admitted is True
     assert later.would_refuse is True
+
+
+def test_no_claims_with_active_peer_is_unprovable(tmp_path: Path):
+    """Write-capable dispatch without owned paths vs active peer (CF r3 F002)."""
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    (state_dir / "peer.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    admit_write_paths(
+        task_id="peer",
+        mode="workspace-write",
+        owned_paths=["scripts/a.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    blank = admit_write_paths(
+        task_id="blank",
+        mode="workspace-write",
+        owned_paths=[],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.WARN,
+    )
+    assert blank.admitted is True
+    assert blank.would_refuse is True

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -403,3 +403,61 @@ def test_live_ledger_pid_keeps_claim_despite_terminal_state(tmp_path: Path):
         guard_mode=GuardMode.WARN,
     )
     assert peer.would_refuse is True
+
+
+def test_same_task_id_live_pid_does_not_replace_claims(tmp_path: Path, monkeypatch):
+    """Concurrent same task_id: second admission must not clobber first claims (CF r7)."""
+    import scripts.delegate_ownership as own_mod
+
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    holder_pid = os.getpid()
+    first = admit_write_paths(
+        task_id="same",
+        mode="workspace-write",
+        owned_paths=["scripts/held.py"],
+        pid=holder_pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert first.admitted is True
+
+    real_alive = own_mod._pid_alive
+
+    def fake_alive(pid: int) -> bool:
+        if pid == 424242:
+            return True
+        return real_alive(pid)
+
+    monkeypatch.setattr(own_mod, "_pid_alive", fake_alive)
+    second = admit_write_paths(
+        task_id="same",
+        mode="workspace-write",
+        owned_paths=["scripts/other.py"],
+        pid=424242,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.WARN,
+    )
+    assert second.admitted is True
+    assert second.would_refuse is True
+    # Original claim retained
+    import sqlite3
+
+    rows = list(sqlite3.connect(ledger).execute("SELECT claim_json FROM write_claims"))
+    assert any("held.py" in r[0] for r in rows)
+    assert not any("other.py" in r[0] for r in rows)
+
+    # Same-pid retry still allowed
+    monkeypatch.setattr(own_mod, "_pid_alive", real_alive)
+    retry = admit_write_paths(
+        task_id="same",
+        mode="workspace-write",
+        owned_paths=["scripts/held.py", "scripts/extra.py"],
+        pid=holder_pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert retry.admitted is True
+    assert retry.would_refuse is False

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -1,4 +1,4 @@
-"""Tests for scripts/delegate_ownership.py (#5643 Δ2-A WARN)."""
+"""Tests for scripts/guardrails/delegate_ownership.py (#5643 Δ2-A WARN)."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import json
 import os
 from pathlib import Path
 
-from scripts.delegate_ownership import (
+from scripts.guardrails.delegate_ownership import (
     ClaimKind,
     GuardMode,
     OwnershipLedger,
@@ -423,7 +423,7 @@ def test_live_ledger_pid_keeps_claim_despite_terminal_state(tmp_path: Path):
 
 def test_same_task_id_live_pid_does_not_replace_claims(tmp_path: Path, monkeypatch):
     """Concurrent same task_id: second admission must not clobber first claims (CF r7)."""
-    import scripts.delegate_ownership as own_mod
+    import scripts.guardrails.delegate_ownership as own_mod
 
     ledger = tmp_path / "own.sqlite3"
     state_dir = tmp_path / "tasks"

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -288,3 +288,33 @@ def test_slashful_task_id_state_file_sanitized(tmp_path: Path):
     )
     assert second.would_refuse is True
     assert second.conflicts
+
+
+def test_active_unknown_claim_makes_later_concrete_unprovable(tmp_path: Path):
+    """Active wildcard claim blocks proof of disjointness for later writers (CF r2)."""
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    (state_dir / "wild.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    admit_write_paths(
+        task_id="wild",
+        mode="workspace-write",
+        owned_paths=["scripts/**/*.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    later = admit_write_paths(
+        task_id="concrete",
+        mode="workspace-write",
+        owned_paths=["scripts/delegate.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.WARN,
+    )
+    assert later.admitted is True
+    assert later.would_refuse is True


### PR DESCRIPTION
## Summary

Implements **#5643 Δ2-A** (Sol strengthen + Fable APPROVE): writable-path admission guard in **WARN** mode.

- `scripts/delegate_ownership.py` — SQLite ledger `batch_state/tasks/write-ownership.sqlite3` with `BEGIN IMMEDIATE`
- Hooked from `cmd_dispatch` **before** task-state / worktree / branch side effects
- Read-only exempt; claims from `--research-owned-path` (stored apart from research registry)
- File + subtree (`path/` / `path/**`); other wildcards → `ownership_unknown`
- `--allow-path-overlap "<reason>"` records override
- WARN: admit on conflict, record `would_refuse_warn`; REFUSE via `DELEGATE_OWNERSHIP_MODE=refuse` later (#5645)

Closes #5643 · parent #5641 · epics #4707 / #5512

## Non-goals

REFUSE arm, driver-inline edits, semantic git conflicts, registry changes, plane flip.

## Test plan

- [x] `pytest tests/test_delegate_ownership.py` (10)
- [x] ruff clean
- [ ] CI Gate green
- [ ] Cross-family CF (non-Grok) APPROVED → auto-merge

## X-Agent

`grok/5643-ownership-warn`