### PR TITLE
fix(security): CodeQL stack-trace exposure + js-yaml/brace-expansion bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-plugin-jsdoc": "^61.5.0",
         "eslint-plugin-prettier": "^5.5.4",
         "jest": "^30.2.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.0",
         "markdownlint-cli2": "^0.20.0",
         "prettier": "^3.7.4",
         "puppeteer": "^24.32.0",
@@ -855,9 +855,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -929,9 +929,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3625,9 +3625,9 @@
       }
     },
     "node_modules/babel-plugin-istanbul/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3921,9 +3921,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4948,9 +4948,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6931,9 +6931,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "eslint-plugin-jsdoc": "^61.5.0",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^30.2.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "markdownlint-cli2": "^0.20.0",
     "prettier": "^3.7.4",
     "puppeteer": "^24.32.0",
@@ -120,7 +120,9 @@
   },
   "overrides": {
     "uuid": "11.1.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
+    "brace-expansion@1": "1.1.16",
+    "brace-expansion@2": "2.1.2",
     "markdown-it": ">=14.2.0",
     "adm-zip": "0.6.0"
   }

--- a/scripts/api/ops_router.py
+++ b/scripts/api/ops_router.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 from fastapi import APIRouter
 
 from .config import PROJECT_ROOT
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["ops"])
 
@@ -29,11 +32,12 @@ async def retention_latest() -> dict:
         }
     try:
         payload = json.loads(latest.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, json.JSONDecodeError):
+        # Do not return exception text to HTTP clients (CodeQL py/stack-trace-exposure).
+        logger.exception("retention plan unreadable: %s", latest)
         return {
             "schema": "fleet-comms.retention.plan.v1",
             "error": "unreadable_plan",
-            "detail": str(exc),
             "plan_path": str(latest),
         }
     if isinstance(payload, dict):

--- a/scripts/fleet_comms/message_plane.py
+++ b/scripts/fleet_comms/message_plane.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import sqlite3
 from dataclasses import dataclass
@@ -27,6 +28,8 @@ from typing import Any, Literal
 
 from scripts.fleet_comms.contracts import CompletionState
 from scripts.fleet_comms.request_executor import RequestExecutor, RequestRecord
+
+logger = logging.getLogger(__name__)
 
 PlaneMode = Literal["off", "shadow", "dual_write"]
 ENV_MODE = "FLEET_COMMS_MESSAGE_PLANE"
@@ -475,8 +478,11 @@ def _read_applied_schema_version(db_path: Path) -> dict[str, Any]:
                 payload["applied_name"] = str(row[1]) if row[1] is not None else None
         finally:
             conn.close()
-    except sqlite3.Error as exc:
-        payload["db_error"] = str(exc)
+    except sqlite3.Error:
+        # Opaque code only — exception text must not reach HTTP clients
+        # (CodeQL py/stack-trace-exposure via /api/comms/v1/plane-status).
+        logger.exception("plane schema read failed: %s", db_path)
+        payload["db_error"] = "schema_read_failed"
     return payload
 
 
@@ -499,8 +505,9 @@ def _summarize_parity_telemetry(
         return summary
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError as exc:
-        summary["read_error"] = str(exc)
+    except OSError:
+        logger.exception("parity telemetry unreadable: %s", path)
+        summary["read_error"] = "telemetry_read_failed"
         return summary
     events: list[dict[str, Any]] = []
     for line in lines:
@@ -544,9 +551,13 @@ def read_plane_status(
     mode_error: str | None = None
     try:
         mode: PlaneMode | str = resolve_plane_mode()
-    except ValueError as exc:
+    except ValueError:
+        # Opaque code — do not echo exception / env value to HTTP clients.
+        logger.warning(
+            "invalid FLEET_COMMS_MESSAGE_PLANE value; reporting mode=invalid"
+        )
         mode = "invalid"
-        mode_error = str(exc)
+        mode_error = "invalid_mode"
 
     plane_root = Path(root) if root is not None else default_plane_root(repo_root=repo_root)
     db_path = plane_root / "comms.sqlite3"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5976,9 +5976,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/site/package.json
+++ b/site/package.json
@@ -61,7 +61,7 @@
     "yaml-language-server": "1.23.0",
     "esbuild": ">=0.28.1",
     "vite": ">=8.0.13",
-    "js-yaml": ">=4.2.0",
+    "js-yaml": "^4.3.0",
     "markdown-it": ">=14.2.0"
   },
   "allowScripts": {

--- a/tests/test_comms_plane_status_api.py
+++ b/tests/test_comms_plane_status_api.py
@@ -102,4 +102,4 @@ def test_api_plane_status_invalid_mode(monkeypatch) -> None:
     data = response.json()
     assert data["mode"] == "invalid"
     assert data["enabled"] is False
-    assert "mode_error" in data
+    assert data["mode_error"] == "invalid_mode"


### PR DESCRIPTION
## Summary
- Close CodeQL `py/stack-trace-exposure` alerts (#313, #314) by returning opaque error codes from `/api/ops/v1/retention/latest` and `/api/comms/v1/plane-status` (via `message_plane.read_plane_status`) instead of `str(exc)`, logging details server-side.
- Bump `js-yaml` to `^4.3.0` (root + site overrides) and `brace-expansion` to `1.1.16` / `2.1.2` via npm overrides to clear Dependabot advisories #196–#198, #218.

## Context
Dependabot `fast-uri` PRs #5648 / #5650 were already merged separately.

## Test plan
- [x] `pytest tests/test_comms_plane_status_api.py tests/api/test_services_ops.py tests/test_fleet_comms_message_plane.py` — 18 passed, 1 skipped
- [x] `ruff check` on touched Python files
- [x] `npm audit` in `/site` — 0 vulnerabilities
- [ ] CI green
- [ ] Cross-family review


Made with [Cursor](https://cursor.com)