### PR TITLE
feat(fleet-comms): add per-stream bottleneck metrics

### DIFF
--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -98,12 +98,27 @@ def cmd_bottleneck_metrics(args: argparse.Namespace) -> int:
     """Per-stream lifecycle bottlenecks from task, plane, and GitHub metadata."""
     tasks_dir = Path(args.tasks_dir).expanduser()
     plane_root = Path(args.root).expanduser() if args.root else default_plane_root()
+    plane_db = plane_root / "comms.sqlite3"
+    # Match sibling cmds: never let sqlite3.connect create an empty plane DB
+    # as a side effect of a metadata-only command (Claude CF #5653 F001).
+    if not plane_db.is_file():
+        sys.stdout.write(
+            _json_dump(
+                {
+                    "content_included": False,
+                    "db_missing": True,
+                    "plane_db": str(plane_db),
+                    "tasks_dir": str(tasks_dir),
+                }
+            )
+        )
+        return EXIT_OK
     payload = collect_stream_bottleneck_metrics(
         tasks_dir=tasks_dir,
-        plane_db=plane_root / "comms.sqlite3",
+        plane_db=plane_db,
     )
     payload["tasks_dir"] = str(tasks_dir)
-    payload["plane_db"] = str(plane_root / "comms.sqlite3")
+    payload["plane_db"] = str(plane_db)
     sys.stdout.write(_json_dump(payload))
     return EXIT_OK
 

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -33,6 +33,7 @@ from scripts.fleet_comms.efficiency_metrics import (
     collect_dead_letters,
     collect_delivery_backlog,
     collect_efficiency_metrics,
+    collect_stream_bottleneck_metrics,
 )
 from scripts.fleet_comms.github_pr_metrics import collect_github_pr_metrics
 from scripts.fleet_comms.message_plane import default_plane_root, read_plane_status
@@ -89,6 +90,20 @@ def cmd_metrics(args: argparse.Namespace) -> int:
         return EXIT_OK
     payload = collect_efficiency_metrics(db)
     payload["db_path"] = str(db)
+    sys.stdout.write(_json_dump(payload))
+    return EXIT_OK
+
+
+def cmd_bottleneck_metrics(args: argparse.Namespace) -> int:
+    """Per-stream lifecycle bottlenecks from task, plane, and GitHub metadata."""
+    tasks_dir = Path(args.tasks_dir).expanduser()
+    plane_root = Path(args.root).expanduser() if args.root else default_plane_root()
+    payload = collect_stream_bottleneck_metrics(
+        tasks_dir=tasks_dir,
+        plane_db=plane_root / "comms.sqlite3",
+    )
+    payload["tasks_dir"] = str(tasks_dir)
+    payload["plane_db"] = str(plane_root / "comms.sqlite3")
     sys.stdout.write(_json_dump(payload))
     return EXIT_OK
 
@@ -418,6 +433,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Broker SQLite path (default: AB_DB_PATH or .mcp/servers/message-broker/messages.db)",
     )
     metrics.set_defaults(func=cmd_metrics)
+
+    bottlenecks = sub.add_parser(
+        "bottleneck-metrics",
+        help="Per-stream dispatch/review/merge bottlenecks (metadata only)",
+    )
+    bottlenecks.add_argument(
+        "--tasks-dir",
+        default="batch_state/tasks",
+        help="Delegate task-state directory (default: batch_state/tasks)",
+    )
+    bottlenecks.add_argument(
+        "--root",
+        default=None,
+        help="Plane storage root (default: FLEET_COMMS_ROOT or batch_state/fleet-comms/v1)",
+    )
+    bottlenecks.set_defaults(func=cmd_bottleneck_metrics)
 
     backlog = sub.add_parser(
         "backlog",

--- a/scripts/fleet_comms/cli.py
+++ b/scripts/fleet_comms/cli.py
@@ -99,26 +99,17 @@ def cmd_bottleneck_metrics(args: argparse.Namespace) -> int:
     tasks_dir = Path(args.tasks_dir).expanduser()
     plane_root = Path(args.root).expanduser() if args.root else default_plane_root()
     plane_db = plane_root / "comms.sqlite3"
-    # Match sibling cmds: never let sqlite3.connect create an empty plane DB
-    # as a side effect of a metadata-only command (Claude CF #5653 F001).
-    if not plane_db.is_file():
-        sys.stdout.write(
-            _json_dump(
-                {
-                    "content_included": False,
-                    "db_missing": True,
-                    "plane_db": str(plane_db),
-                    "tasks_dir": str(tasks_dir),
-                }
-            )
-        )
-        return EXIT_OK
+    # Always call the collector: it is fail-open per source and refuses to
+    # sqlite3.connect-create a missing plane DB (is_file guard inside). Skipping
+    # here would drop valid dispatch metrics when plane is uninit (Claude CF r4).
     payload = collect_stream_bottleneck_metrics(
         tasks_dir=tasks_dir,
         plane_db=plane_db,
     )
     payload["tasks_dir"] = str(tasks_dir)
     payload["plane_db"] = str(plane_db)
+    if not plane_db.is_file():
+        payload["db_missing"] = True
     sys.stdout.write(_json_dump(payload))
     return EXIT_OK
 

--- a/scripts/fleet_comms/efficiency_metrics.py
+++ b/scripts/fleet_comms/efficiency_metrics.py
@@ -434,6 +434,8 @@ def collect_stream_bottleneck_metrics(
 
     merged_cache: dict[tuple[str, int], tuple[datetime | None, str | None]] = {}
     try:
+        if not plane_db.is_file():
+            raise FileNotFoundError(f"plane DB missing: {plane_db}")
         with _connect(plane_db) as conn:
             if not (_table_exists(conn, "formal_review_jobs") and _table_exists(conn, "github_publications")):
                 raise sqlite3.DatabaseError("required formal_review_jobs/github_publications tables missing")

--- a/scripts/fleet_comms/efficiency_metrics.py
+++ b/scripts/fleet_comms/efficiency_metrics.py
@@ -333,12 +333,16 @@ def _github_merged_at(
     gh_bin: str = "gh",
 ) -> tuple[datetime | None, str | None]:
     """Fetch a PR merge timestamp only; no body, title, or review text."""
-    proc = subprocess.run(
-        [gh_bin, "pr", "view", str(pr_number), "--repo", repo, "--json", "mergedAt"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            [gh_bin, "pr", "view", str(pr_number), "--repo", repo, "--json", "mergedAt"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "gh pr view timed out after 30s"
     if proc.returncode != 0:
         return None, (proc.stderr or proc.stdout or "gh failed").strip()[:300]
     try:
@@ -474,12 +478,25 @@ def collect_stream_bottleneck_metrics(
                 )
                 if published is None:
                     continue
-                repo, pr_number = str(record["repository"]), int(record["pr_number"])
+                repo = str(record.get("repository") or "")
+                try:
+                    pr_number = int(record["pr_number"])
+                except (KeyError, TypeError, ValueError) as exc:
+                    errors.append(
+                        {
+                            "source": "github",
+                            "error": f"invalid pr_number {record.get('pr_number')!r}: {exc}",
+                        }
+                    )
+                    continue
+                if not repo:
+                    errors.append({"source": "github", "error": "missing repository for gate_to_merge"})
+                    continue
                 cache_key = (repo, pr_number)
                 if cache_key not in merged_cache:
                     try:
                         merged_cache[cache_key] = github_lookup(repo=repo, pr_number=pr_number)
-                    except (OSError, ValueError, TypeError) as exc:
+                    except (OSError, ValueError, TypeError, subprocess.TimeoutExpired) as exc:
                         merged_cache[cache_key] = (None, str(exc))
                 merged, lookup_error = merged_cache[cache_key]
                 if lookup_error:

--- a/scripts/fleet_comms/efficiency_metrics.py
+++ b/scripts/fleet_comms/efficiency_metrics.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
-from collections.abc import Iterator
+import subprocess
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+# Alert thresholds are intentionally reported, not enforced here. #5646 owns
+# consuming them. Dispatch uses the delegate default floor of 7,200 seconds.
+DISPATCH_BOTTLENECK_THRESHOLD_S = 7_200
+FORMAL_CF_PUBLICATION_THRESHOLD_S = 3_600
+GATE_TO_MERGE_THRESHOLD_S = 3_600
 
 
 @contextmanager
@@ -235,3 +244,279 @@ def collect_efficiency_metrics(db_path: Path) -> dict[str, Any]:
             }
 
         return metrics
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    """Parse an ISO-8601 lifecycle timestamp as an aware UTC value."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _identity(record: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Read only explicit lifecycle identity fields; never infer from labels."""
+    stream_epic = record.get("stream_epic")
+    task_family = record.get("task_family")
+    stream = str(stream_epic).strip() if stream_epic is not None else ""
+    family = str(task_family).strip() if task_family is not None else ""
+    return (stream or None, family or None)
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Linearly interpolate sorted samples at index ``(n - 1) * percentile``."""
+    ordered = sorted(samples)
+    index = (len(ordered) - 1) * percentile
+    lower = int(index)
+    upper = min(lower + 1, len(ordered) - 1)
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (index - lower)
+
+
+def _span_summary(durations: list[float], backlog_ages: list[float]) -> dict[str, Any]:
+    """Summarize one span without emitting individual events or content."""
+    summary: dict[str, Any] = {
+        "n": len(durations),
+        "backlog_age_s": round(max(backlog_ages), 3) if backlog_ages else None,
+        "raw": {
+            "event_count": len(durations) + len(backlog_ages),
+            "duration_count": len(durations),
+            "unfinished_count": len(backlog_ages),
+        },
+        "duration_s": {},
+    }
+    if durations:
+        summary["duration_s"] = {
+            "min": round(min(durations), 3),
+            "max": round(max(durations), 3),
+            "avg": round(sum(durations) / len(durations), 3),
+        }
+        if len(durations) >= 20:
+            summary["duration_s"]["p50"] = round(_percentile(durations, 0.50), 3)
+            summary["duration_s"]["p95"] = round(_percentile(durations, 0.95), 3)
+    return summary
+
+
+def _new_buckets() -> dict[str, dict[str, list[float]]]:
+    return {
+        "dispatch": {"durations": [], "backlog_ages": []},
+        "formal_cf_publication": {"durations": [], "backlog_ages": []},
+        "gate_to_merge": {"durations": [], "backlog_ages": []},
+    }
+
+
+def _add_event(
+    buckets: dict[str, dict[str, dict[str, list[float]]]],
+    *,
+    dimension: str,
+    identity: str | None,
+    span: str,
+    duration: float | None,
+    backlog_age: float | None,
+) -> None:
+    key = identity or "unclassified"
+    group = buckets[dimension].setdefault(key, _new_buckets())
+    if duration is not None:
+        group[span]["durations"].append(duration)
+    if backlog_age is not None:
+        group[span]["backlog_ages"].append(backlog_age)
+
+
+def _github_merged_at(
+    *,
+    repo: str,
+    pr_number: int,
+    gh_bin: str = "gh",
+) -> tuple[datetime | None, str | None]:
+    """Fetch a PR merge timestamp only; no body, title, or review text."""
+    proc = subprocess.run(
+        [gh_bin, "pr", "view", str(pr_number), "--repo", repo, "--json", "mergedAt"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None, (proc.stderr or proc.stdout or "gh failed").strip()[:300]
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return None, f"json_decode: {exc}"
+    merged_at = _parse_timestamp(payload.get("mergedAt"))
+    if payload.get("mergedAt") and merged_at is None:
+        return None, "invalid mergedAt timestamp"
+    return merged_at, None
+
+
+def collect_stream_bottleneck_metrics(
+    *,
+    tasks_dir: Path,
+    plane_db: Path,
+    now: datetime | None = None,
+    github_lookup: Callable[..., tuple[datetime | None, str | None]] = _github_merged_at,
+) -> dict[str, Any]:
+    """Collect lifecycle-only per-stream bottlenecks from independent sources.
+
+    Percentiles use linear interpolation of the sorted samples at ``(n - 1) * p``
+    and are intentionally omitted until a span has at least twenty durations.
+    Each source is fail-open: its errors are reported while other sources continue.
+    """
+    clock = (now or datetime.now(UTC)).astimezone(UTC)
+    buckets: dict[str, dict[str, dict[str, list[float]]]] = {
+        "by_stream_epic": {},
+        "by_task_family": {},
+    }
+    errors: list[dict[str, str]] = []
+    dispatch_hard_timeouts: list[int] = []
+
+    def add(
+        identity: tuple[str | None, str | None],
+        span: str,
+        duration: float | None,
+        backlog_age: float | None,
+    ) -> None:
+        _add_event(
+            buckets,
+            dimension="by_stream_epic",
+            identity=identity[0],
+            span=span,
+            duration=duration,
+            backlog_age=backlog_age,
+        )
+        _add_event(
+            buckets,
+            dimension="by_task_family",
+            identity=identity[1],
+            span=span,
+            duration=duration,
+            backlog_age=backlog_age,
+        )
+
+    try:
+        task_paths = sorted(tasks_dir.glob("*.json"))
+        if not tasks_dir.is_dir():
+            raise FileNotFoundError(tasks_dir)
+        for path in task_paths:
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append({"source": "dispatch", "error": f"{path.name}: {exc}"})
+                continue
+            if not isinstance(record, dict):
+                errors.append({"source": "dispatch", "error": f"{path.name}: expected object"})
+                continue
+            hard_timeout = record.get("hard_timeout")
+            if isinstance(hard_timeout, int) and hard_timeout >= 0:
+                dispatch_hard_timeouts.append(hard_timeout)
+            started = _parse_timestamp(record.get("started_at"))
+            if started is None:
+                errors.append({"source": "dispatch", "error": f"{path.name}: invalid started_at"})
+                continue
+            finished_raw = record.get("finished_at")
+            finished = _parse_timestamp(finished_raw)
+            if finished_raw not in (None, "") and finished is None:
+                errors.append({"source": "dispatch", "error": f"{path.name}: invalid finished_at"})
+                continue
+            if finished is not None and finished < started:
+                errors.append({"source": "dispatch", "error": f"{path.name}: negative duration"})
+                continue
+            add(
+                _identity(record),
+                "dispatch",
+                (finished - started).total_seconds() if finished else None,
+                max(0.0, (clock - started).total_seconds()) if finished is None else None,
+            )
+    except OSError as exc:
+        errors.append({"source": "dispatch", "error": str(exc)})
+
+    merged_cache: dict[tuple[str, int], tuple[datetime | None, str | None]] = {}
+    try:
+        with _connect(plane_db) as conn:
+            if not (_table_exists(conn, "formal_review_jobs") and _table_exists(conn, "github_publications")):
+                raise sqlite3.DatabaseError("required formal_review_jobs/github_publications tables missing")
+            columns = _column_names(conn, "formal_review_jobs")
+            publication_columns = _column_names(conn, "github_publications")
+            optional_identity = [name for name in ("stream_epic", "task_family") if name in columns]
+            publication_join = "p.review_id = j.review_id"
+            if "status_context" in publication_columns:
+                publication_join += " AND p.status_context = 'fleet/cross-family-review'"
+            rows = conn.execute(
+                "SELECT j.review_id, j.repository, j.pr_number, j.created_at, "
+                "p.published_at"
+                + "".join(f", j.{name}" for name in optional_identity)
+                + f" FROM formal_review_jobs j LEFT JOIN github_publications p ON {publication_join}"
+            ).fetchall()
+            for row in rows:
+                record = dict(row)
+                identity = _identity(record)
+                created = _parse_timestamp(record.get("created_at"))
+                if created is None:
+                    errors.append({"source": "formal_cf", "error": "invalid formal_review_jobs.created_at"})
+                    continue
+                published_raw = record.get("published_at")
+                published = _parse_timestamp(published_raw)
+                if published_raw not in (None, "") and published is None:
+                    errors.append({"source": "formal_cf", "error": "invalid github_publications.published_at"})
+                    continue
+                if published is not None and published < created:
+                    errors.append({"source": "formal_cf", "error": "negative publication duration"})
+                    continue
+                add(
+                    identity,
+                    "formal_cf_publication",
+                    (published - created).total_seconds() if published else None,
+                    max(0.0, (clock - created).total_seconds()) if published is None else None,
+                )
+                if published is None:
+                    continue
+                repo, pr_number = str(record["repository"]), int(record["pr_number"])
+                cache_key = (repo, pr_number)
+                if cache_key not in merged_cache:
+                    try:
+                        merged_cache[cache_key] = github_lookup(repo=repo, pr_number=pr_number)
+                    except (OSError, ValueError, TypeError) as exc:
+                        merged_cache[cache_key] = (None, str(exc))
+                merged, lookup_error = merged_cache[cache_key]
+                if lookup_error:
+                    errors.append({"source": "github", "error": f"PR {pr_number}: {lookup_error}"})
+                    continue
+                if merged is not None and merged < published:
+                    errors.append({"source": "github", "error": f"PR {pr_number}: negative merge duration"})
+                    continue
+                add(
+                    identity,
+                    "gate_to_merge",
+                    (merged - published).total_seconds() if merged else None,
+                    max(0.0, (clock - published).total_seconds()) if merged is None else None,
+                )
+    except (OSError, sqlite3.Error) as exc:
+        errors.append({"source": "formal_cf", "error": str(exc)})
+
+    def summarize(groups: dict[str, dict[str, dict[str, list[float]]]]) -> dict[str, Any]:
+        return {
+            name: {span: _span_summary(**samples) for span, samples in spans.items()}
+            for name, spans in sorted(groups.items())
+        }
+
+    by_stream = summarize(buckets["by_stream_epic"])
+    by_family = summarize(buckets["by_task_family"])
+    empty_spans = {span: _span_summary(**samples) for span, samples in _new_buckets().items()}
+    return {
+        "content_included": False,
+        "threshold_seconds": {
+            "dispatch": max([DISPATCH_BOTTLENECK_THRESHOLD_S, *dispatch_hard_timeouts]),
+            "formal_cf_publication": FORMAL_CF_PUBLICATION_THRESHOLD_S,
+            "gate_to_merge": GATE_TO_MERGE_THRESHOLD_S,
+        },
+        "percentile_method": "linear interpolation at sorted index (n - 1) * p; emitted only when n >= 20",
+        "by_stream_epic": {key: value for key, value in by_stream.items() if key != "unclassified"},
+        "by_task_family": {key: value for key, value in by_family.items() if key != "unclassified"},
+        "unclassified": {
+            "by_stream_epic": by_stream.get("unclassified", empty_spans),
+            "by_task_family": by_family.get("unclassified", empty_spans),
+        },
+        "source_errors": errors,
+    }

--- a/tests/test_fleet_comms_bottleneck_metrics.py
+++ b/tests/test_fleet_comms_bottleneck_metrics.py
@@ -1,0 +1,209 @@
+"""Per-stream fleet bottlenecks use metadata-only lifecycle timestamps."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from scripts.fleet_comms.efficiency_metrics import collect_stream_bottleneck_metrics
+
+NOW = datetime(2026, 7, 22, 12, 0, tzinfo=UTC)
+
+
+def _write_task(
+    tasks_dir: Path,
+    name: str,
+    *,
+    started: datetime,
+    finished: datetime | None,
+    stream_epic: int | None = 4707,
+    task_family: str | None = "fleet-comms-metrics",
+    hard_timeout: int | None = None,
+) -> None:
+    record: dict[str, object] = {
+        "started_at": started.isoformat(),
+        "finished_at": finished.isoformat() if finished else None,
+    }
+    if stream_epic is not None:
+        record["stream_epic"] = stream_epic
+    if task_family is not None:
+        record["task_family"] = task_family
+    if hard_timeout is not None:
+        record["hard_timeout"] = hard_timeout
+    (tasks_dir / f"{name}.json").write_text(json.dumps(record), encoding="utf-8")
+
+
+def _plane_db(path: Path, *, with_identity: bool = True) -> None:
+    identity_columns = ", stream_epic INTEGER, task_family TEXT" if with_identity else ""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE formal_review_jobs (
+          review_id TEXT PRIMARY KEY,
+          repository TEXT NOT NULL,
+          pr_number INTEGER NOT NULL,
+          created_at TEXT NOT NULL
+        """
+        + identity_columns
+        + """
+        );
+        CREATE TABLE github_publications (
+          publication_id TEXT PRIMARY KEY,
+          review_id TEXT NOT NULL,
+          published_at TEXT NOT NULL
+        );
+        """
+    )
+    columns = "review_id, repository, pr_number, created_at"
+    values: tuple[object, ...] = (
+        "review-1",
+        "learn-ukrainian/learn-ukrainian.github.io",
+        5644,
+        "2026-07-22T11:58:00+00:00",
+    )
+    if with_identity:
+        columns += ", stream_epic, task_family"
+        values += (4707, "fleet-comms-metrics")
+    placeholders = ", ".join("?" for _ in values)
+    conn.execute(f"INSERT INTO formal_review_jobs ({columns}) VALUES ({placeholders})", values)
+    conn.execute(
+        "INSERT INTO github_publications VALUES (?, ?, ?)",
+        ("pub-1", "review-1", "2026-07-22T11:59:00+00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _merged_at(*, repo: str, pr_number: int) -> tuple[datetime | None, str | None]:
+    assert repo == "learn-ukrainian/learn-ukrainian.github.io"
+    assert pr_number == 5644
+    return datetime(2026, 7, 22, 12, 0, tzinfo=UTC), None
+
+
+def test_percentiles_omitted_below_twenty_samples(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for seconds in range(1, 20):
+        _write_task(
+            tasks_dir,
+            f"task-{seconds}",
+            started=NOW - timedelta(seconds=seconds),
+            finished=NOW,
+        )
+    plane_db = tmp_path / "plane.sqlite3"
+    _plane_db(plane_db)
+
+    payload = collect_stream_bottleneck_metrics(
+        tasks_dir=tasks_dir, plane_db=plane_db, now=NOW, github_lookup=_merged_at
+    )
+
+    duration = payload["by_stream_epic"]["4707"]["dispatch"]["duration_s"]
+    assert payload["by_stream_epic"]["4707"]["dispatch"]["n"] == 19
+    assert "p50" not in duration
+    assert "p95" not in duration
+
+
+def test_percentiles_are_deterministic_at_twenty_samples(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for seconds in range(1, 21):
+        _write_task(
+            tasks_dir,
+            f"task-{seconds}",
+            started=NOW - timedelta(seconds=seconds),
+            finished=NOW,
+        )
+    plane_db = tmp_path / "plane.sqlite3"
+    _plane_db(plane_db)
+
+    payload = collect_stream_bottleneck_metrics(
+        tasks_dir=tasks_dir, plane_db=plane_db, now=NOW, github_lookup=_merged_at
+    )
+
+    duration = payload["by_task_family"]["fleet-comms-metrics"]["dispatch"]["duration_s"]
+    assert duration["p50"] == 10.5
+    assert duration["p95"] == 19.05
+
+
+def test_injected_clock_reports_exact_unfinished_backlog_age(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    _write_task(
+        tasks_dir,
+        "running",
+        started=NOW - timedelta(seconds=123),
+        finished=None,
+        hard_timeout=8_000,
+    )
+    plane_db = tmp_path / "plane.sqlite3"
+    _plane_db(plane_db)
+
+    payload = collect_stream_bottleneck_metrics(
+        tasks_dir=tasks_dir, plane_db=plane_db, now=NOW, github_lookup=_merged_at
+    )
+
+    span = payload["by_stream_epic"]["4707"]["dispatch"]
+    assert span["backlog_age_s"] == 123.0
+    assert span["raw"]["unfinished_count"] == 1
+    assert payload["threshold_seconds"]["dispatch"] == 8_000
+
+
+def test_missing_lifecycle_identity_is_unclassified(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    _write_task(
+        tasks_dir,
+        "unclassified",
+        started=NOW - timedelta(seconds=10),
+        finished=NOW,
+        stream_epic=None,
+        task_family=None,
+    )
+    plane_db = tmp_path / "plane.sqlite3"
+    _plane_db(plane_db, with_identity=False)
+
+    payload = collect_stream_bottleneck_metrics(
+        tasks_dir=tasks_dir, plane_db=plane_db, now=NOW, github_lookup=_merged_at
+    )
+
+    assert payload["unclassified"]["by_stream_epic"]["dispatch"]["n"] == 1
+    assert payload["unclassified"]["by_task_family"]["formal_cf_publication"]["n"] == 1
+
+
+def test_broken_source_is_visible_while_other_source_reports(tmp_path: Path) -> None:
+    plane_db = tmp_path / "plane.sqlite3"
+    _plane_db(plane_db)
+
+    payload = collect_stream_bottleneck_metrics(
+        tasks_dir=tmp_path / "missing-tasks", plane_db=plane_db, now=NOW, github_lookup=_merged_at
+    )
+
+    assert payload["source_errors"]
+    assert payload["source_errors"][0]["source"] == "dispatch"
+    assert payload["by_stream_epic"]["4707"]["formal_cf_publication"]["n"] == 1
+
+
+def test_payload_never_contains_task_prompt_or_message_body(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    _write_task(tasks_dir, "task", started=NOW - timedelta(seconds=10), finished=NOW)
+    task = tasks_dir / "task.json"
+    record = json.loads(task.read_text(encoding="utf-8"))
+    record["prompt"] = "PRIVATE PROMPT TEXT"
+    record["body"] = "PRIVATE MESSAGE BODY"
+    task.write_text(json.dumps(record), encoding="utf-8")
+    plane_db = tmp_path / "plane.sqlite3"
+    _plane_db(plane_db)
+
+    payload = collect_stream_bottleneck_metrics(
+        tasks_dir=tasks_dir, plane_db=plane_db, now=NOW, github_lookup=_merged_at
+    )
+    serialized = json.dumps(payload).lower()
+
+    assert payload["content_included"] is False
+    assert "private prompt" not in serialized
+    assert "private message" not in serialized
+    assert '"prompt"' not in serialized
+    assert '"body"' not in serialized


### PR DESCRIPTION
Closes #5644

## Summary
- add lifecycle-only per-stream and task-family bottleneck metrics for dispatch, formal cross-family publication, and gate-to-merge spans
- expose the metadata-only `bottleneck-metrics` CLI with fail-open `source_errors`
- cover percentile thresholds, exact backlog clocks, unclassified identity, source failures, and content exclusion

## Verification
- `.venv/bin/ruff check scripts/fleet_comms/efficiency_metrics.py scripts/fleet_comms/cli.py tests/test_fleet_comms_bottleneck_metrics.py`
- `.venv/bin/python -m pytest tests/test_fleet_comms_bottleneck_metrics.py tests/test_efficiency_metrics.py tests/test_github_pr_metrics.py tests/test_fleet_comms_cli.py -q`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

No plane-mode or formal-review-eligibility changes. Auto-merge intentionally not enabled.