### PR TITLE
feat(fleet-comms): alert on stream bottlenecks

### DIFF
--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -157,6 +157,26 @@ CREATE TABLE IF NOT EXISTS channel_events (
 
 CREATE INDEX IF NOT EXISTS idx_channel_events_thread_event
     ON channel_events(thread_id, event_id);
+
+-- Durable, metadata-only alert state.  The alert body stays solely in the
+-- channel log; this table carries no prompt or message content.
+CREATE TABLE IF NOT EXISTS bottleneck_alert_state (
+    stream_epic TEXT NOT NULL,
+    span TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 0,
+    rearm_level INTEGER NOT NULL DEFAULT 1,
+    last_alert_age_s REAL,
+    last_alert_at TEXT,
+    message_id TEXT,
+    last_delivery_error TEXT,
+    delivery_failure_reported INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (stream_epic, span)
+);
+
+CREATE TABLE IF NOT EXISTS bottleneck_alert_scan_control (
+    control_key TEXT PRIMARY KEY,
+    last_scanned_at TEXT NOT NULL
+);
 """
 
 
@@ -410,6 +430,41 @@ def get_db():
                         """
                         CREATE INDEX IF NOT EXISTS idx_channel_events_thread_event
                         ON channel_events(thread_id, event_id)
+                        """
+                    )
+
+                # #5646 alert state is deliberately part of the existing
+                # channel/inbox broker, not a second scheduler or database.
+                cursor.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='bottleneck_alert_state'"
+                )
+                if not cursor.fetchone():
+                    conn.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS bottleneck_alert_state (
+                            stream_epic TEXT NOT NULL,
+                            span TEXT NOT NULL,
+                            active INTEGER NOT NULL DEFAULT 0,
+                            rearm_level INTEGER NOT NULL DEFAULT 1,
+                            last_alert_age_s REAL,
+                            last_alert_at TEXT,
+                            message_id TEXT,
+                            last_delivery_error TEXT,
+                            delivery_failure_reported INTEGER NOT NULL DEFAULT 0,
+                            PRIMARY KEY (stream_epic, span)
+                        )
+                        """
+                    )
+                cursor.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='bottleneck_alert_scan_control'"
+                )
+                if not cursor.fetchone():
+                    conn.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS bottleneck_alert_scan_control (
+                            control_key TEXT PRIMARY KEY,
+                            last_scanned_at TEXT NOT NULL
+                        )
                         """
                     )
 

--- a/scripts/ai_agent_bridge/_inbox.py
+++ b/scripts/ai_agent_bridge/_inbox.py
@@ -10,6 +10,7 @@ that thread on the next wake. See #1192.
 
 from __future__ import annotations
 
+import logging
 import sys
 import threading
 import time
@@ -105,6 +106,8 @@ from ._gemini_session_link import (
 from ._orphan_recovery import RecoveryCandidate, RecoveryResult, recover_orphan_commit
 from ._prompts import review_protocol_prefix
 from ._reconcile import reconcile_deliveries
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_HARD_TIMEOUT_SECONDS = 900
 _DEFAULT_STALL_TIMEOUT_SECONDS = 600
@@ -890,6 +893,14 @@ def run_inbox(
     if stop_after_seconds is not None and stop_after_seconds <= 0:
         raise ValueError("stop_after_seconds must be > 0 when provided")
     _validate_hard_timeout_seconds(hard_timeout, field_name="hard_timeout")
+    # #5646: a bounded, durable diagnostic checkpoint, not a daemon and never
+    # a dispatch/merge gate.  The scanner self-rate-limits across all workers.
+    try:
+        from scripts.fleet_comms.bottleneck_alerts import scan_bottlenecks_at_inbox_checkpoint
+
+        scan_bottlenecks_at_inbox_checkpoint(repo_root=REPO_ROOT)
+    except Exception:
+        logger.exception("bottleneck alert checkpoint failed; continuing inbox drain")
     _channels.expire_stale_deliveries()
 
     claimed_total = 0

--- a/scripts/fleet_comms/bottleneck_alerts.py
+++ b/scripts/fleet_comms/bottleneck_alerts.py
@@ -1,0 +1,343 @@
+"""Rate-limited, metadata-only stream bottleneck alerts (#5646).
+
+The inbox worker calls :func:`scan_bottlenecks_at_inbox_checkpoint`; this
+module deliberately owns no daemon or gate.  Alert delivery uses the existing
+channel inbox, while the broker stores only alert lifecycle metadata needed for
+dedupe and re-arming.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from agents_extensions.shared.session_streams.db import SessionStreamDatabase, default_database_path
+from agents_extensions.shared.session_streams.model import parse_timestamp
+from scripts.ai_agent_bridge import _channels
+from scripts.ai_agent_bridge._db import get_db
+from scripts.fleet_comms.efficiency_metrics import collect_stream_bottleneck_metrics
+from scripts.fleet_comms.message_plane import default_plane_root
+
+logger = logging.getLogger(__name__)
+
+ALERT_CHANNEL = "fleet-comms"
+ESCALATION_RECIPIENT = "claude-infra"
+SCAN_RATE_LIMIT_SECONDS = 300
+REARM_MULTIPLIER = 2
+_CONTROL_KEY = "bottleneck-alerts"
+
+
+@dataclass(frozen=True, slots=True)
+class AlertScanResult:
+    """Metadata-only outcome for one checkpoint invocation."""
+
+    scanned: bool
+    alerts_posted: int
+    cleared: int
+    delivery_failures: int
+    source_errors: tuple[dict[str, str], ...]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _active_lease_holder(stream_epic: str, *, session_db: Path, now: datetime) -> str | None:
+    """Return the non-expired stream holder, without creating a session DB."""
+    if not session_db.is_file():
+        return None
+    try:
+        database = SessionStreamDatabase(session_db)
+        with database.connect(read_only=True) as conn:
+            row = conn.execute(
+                """
+                SELECT l.holder_agent, l.expires_at
+                FROM stream_leases AS l
+                JOIN sessions AS s ON s.stream_id = l.stream_id
+                    AND s.session_id = l.session_id
+                WHERE l.stream_id = ?
+                  AND l.state = 'active'
+                  AND s.state IN ('open', 'rolling')
+                """,
+                (f"epic:{stream_epic}",),
+            ).fetchone()
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        logger.error("bottleneck alerts: lease lookup failed for epic %s: %s", stream_epic, exc)
+        return None
+    if row is None:
+        return None
+    try:
+        expires_at = parse_timestamp(str(row["expires_at"]))
+    except ValueError:
+        logger.error("bottleneck alerts: invalid lease expiry for epic %s", stream_epic)
+        return None
+    holder = str(row["holder_agent"] or "")
+    if expires_at <= now or holder not in _channels.VALID_RECIPIENT_AGENTS:
+        return None
+    return holder
+
+
+def _reserve_scan(conn: sqlite3.Connection, *, now: datetime, rate_limit_seconds: int) -> bool:
+    """Persistently rate-limit the scanner across independent inbox workers."""
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        row = conn.execute(
+            "SELECT last_scanned_at FROM bottleneck_alert_scan_control WHERE control_key = ?",
+            (_CONTROL_KEY,),
+        ).fetchone()
+        if row is not None:
+            try:
+                last = parse_timestamp(str(row["last_scanned_at"]))
+            except ValueError:
+                last = None
+            if last is not None and (now - last).total_seconds() < rate_limit_seconds:
+                conn.commit()
+                return False
+        conn.execute(
+            """
+            INSERT INTO bottleneck_alert_scan_control(control_key, last_scanned_at)
+            VALUES (?, ?)
+            ON CONFLICT(control_key) DO UPDATE SET last_scanned_at = excluded.last_scanned_at
+            """,
+            (_CONTROL_KEY, _iso(now)),
+        )
+        conn.commit()
+        return True
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _state_row(conn: sqlite3.Connection, stream_epic: str, span: str) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM bottleneck_alert_state WHERE stream_epic = ? AND span = ?",
+        (stream_epic, span),
+    ).fetchone()
+
+
+def _record_clear(conn: sqlite3.Connection, stream_epic: str, span: str) -> bool:
+    row = _state_row(conn, stream_epic, span)
+    if row is None or not bool(row["active"]):
+        return False
+    conn.execute(
+        """
+        UPDATE bottleneck_alert_state
+        SET active = 0, rearm_level = 1, last_alert_age_s = NULL,
+            message_id = NULL, last_delivery_error = NULL, delivery_failure_reported = 0
+        WHERE stream_epic = ? AND span = ?
+        """,
+        (stream_epic, span),
+    )
+    conn.commit()
+    return True
+
+
+def _requires_alert(row: sqlite3.Row | None, *, age_s: float, threshold_s: int) -> tuple[bool, int]:
+    if row is None or not bool(row["active"]):
+        return True, 1
+    level = max(1, int(row["rearm_level"]))
+    # A failed post has no durable channel message to deduplicate against;
+    # retry it at the next rate-limited checkpoint instead of waiting for 2x.
+    if not row["message_id"]:
+        return True, level
+    if age_s >= threshold_s * (REARM_MULTIPLIER**level):
+        return True, level + 1
+    return False, level
+
+
+def _record_delivery_failures(conn: sqlite3.Connection) -> int:
+    """Make failed alert deliveries loud once; the channel remains the record."""
+    rows = conn.execute(
+        """
+        SELECT s.stream_epic, s.span, MIN(COALESCE(d.error, 'delivery failed')) AS error
+        FROM bottleneck_alert_state AS s
+        JOIN deliveries AS d ON d.message_id = s.message_id
+        WHERE s.active = 1 AND s.delivery_failure_reported = 0
+          AND d.status IN ('failed', 'expired')
+        GROUP BY s.stream_epic, s.span
+        """
+    ).fetchall()
+    for row in rows:
+        error = str(row["error"] or "delivery failed")[:300]
+        logger.error(
+            "bottleneck alert delivery failed for epic %s %s: %s",
+            row["stream_epic"],
+            row["span"],
+            error,
+        )
+        conn.execute(
+            """
+            UPDATE bottleneck_alert_state
+            SET last_delivery_error = ?, delivery_failure_reported = 1
+            WHERE stream_epic = ? AND span = ?
+            """,
+            (error, row["stream_epic"], row["span"]),
+        )
+    conn.commit()
+    return len(rows)
+
+
+def _alert_body(*, stream_epic: str, span: str, age_s: float, threshold_s: int) -> str:
+    return (
+        "ACTION REQUIRED: stream bottleneck detected. "
+        f"epic={stream_epic}; span={span}; backlog_age_s={round(age_s, 3)}; "
+        f"threshold_s={threshold_s}. Inspect lifecycle metadata and unblock or hand off."
+    )
+
+
+def scan_bottlenecks_at_inbox_checkpoint(
+    *,
+    repo_root: Path,
+    now: datetime | None = None,
+    tasks_dir: Path | None = None,
+    plane_db: Path | None = None,
+    session_db: Path | None = None,
+    rate_limit_seconds: int = SCAN_RATE_LIMIT_SECONDS,
+    metrics_collector: Callable[..., dict[str, Any]] = collect_stream_bottleneck_metrics,
+) -> AlertScanResult:
+    """Scan and post deduplicated action-required alerts without blocking a drain.
+
+    A persistent breach re-arms at 2x, 4x, and subsequent powers of its
+    threshold.  A clear resets the level, so a later breach is immediately
+    eligible again.  Neither alerts nor their state include task prompts or
+    message bodies.
+    """
+    if rate_limit_seconds < 0:
+        raise ValueError("rate_limit_seconds must be non-negative")
+    clock = (now or _utc_now()).astimezone(UTC)
+    task_path = tasks_dir or repo_root / "batch_state" / "tasks"
+    plane_path = plane_db or default_plane_root(repo_root=repo_root) / "comms.sqlite3"
+    if session_db is not None:
+        lease_path = session_db
+    else:
+        try:
+            lease_path = default_database_path(repo_root)
+        except Exception as exc:
+            # A missing canonical checkout is equivalent to no live lease for
+            # this best-effort diagnostic; escalation must still proceed.
+            logger.error("bottleneck alerts: cannot resolve session-stream DB: %s", exc)
+            lease_path = repo_root / ".agent" / "session-streams" / "missing.sqlite3"
+
+    conn = get_db()
+    try:
+        if not _reserve_scan(conn, now=clock, rate_limit_seconds=rate_limit_seconds):
+            return AlertScanResult(False, 0, 0, _record_delivery_failures(conn), ())
+        delivery_failures = _record_delivery_failures(conn)
+    finally:
+        conn.close()
+
+    try:
+        metrics = metrics_collector(tasks_dir=task_path, plane_db=plane_path, now=clock)
+    except Exception as exc:  # A diagnostics failure must never break inbox delivery.
+        logger.exception("bottleneck alerts: metrics collection failed: %s", exc)
+        return AlertScanResult(True, 0, 0, delivery_failures, ({"source": "alerts", "error": str(exc)},))
+
+    thresholds = metrics.get("threshold_seconds", {})
+    breaches: dict[tuple[str, str], tuple[float, int]] = {}
+    by_stream = metrics.get("by_stream_epic", {})
+    if isinstance(by_stream, dict):
+        for stream_epic, spans in by_stream.items():
+            if not isinstance(spans, dict):
+                continue
+            for span, summary in spans.items():
+                if not isinstance(summary, dict):
+                    continue
+                age_s = summary.get("backlog_age_s")
+                threshold_s = thresholds.get(span)
+                if isinstance(age_s, (int, float)) and isinstance(threshold_s, int) and age_s >= threshold_s:
+                    breaches[(str(stream_epic), str(span))] = (float(age_s), threshold_s)
+
+    conn = get_db()
+    alerts_posted = 0
+    cleared = 0
+    try:
+        prior_active = conn.execute(
+            "SELECT stream_epic, span FROM bottleneck_alert_state WHERE active = 1"
+        ).fetchall()
+        error_sources = {
+            str(error.get("source"))
+            for error in metrics.get("source_errors", [])
+            if isinstance(error, dict)
+        }
+        span_sources = {
+            "dispatch": {"dispatch"},
+            "formal_cf_publication": {"formal_cf"},
+            "gate_to_merge": {"formal_cf", "github"},
+        }
+        for row in prior_active:
+            identity = (str(row["stream_epic"]), str(row["span"]))
+            # A source outage is unknown, not clear.  Retain its alert state
+            # until the relevant lifecycle source reports a genuine clear.
+            if identity not in breaches and not (span_sources.get(identity[1], set()) & error_sources):
+                cleared += int(_record_clear(conn, *identity))
+
+        for (stream_epic, span), (age_s, threshold_s) in sorted(breaches.items()):
+            row = _state_row(conn, stream_epic, span)
+            should_alert, new_level = _requires_alert(row, age_s=age_s, threshold_s=threshold_s)
+            if not should_alert:
+                continue
+            holder = _active_lease_holder(stream_epic, session_db=lease_path, now=clock)
+            recipients = list(dict.fromkeys([*( [holder] if holder else []), ESCALATION_RECIPIENT]))
+            try:
+                _channels.create_channel(ALERT_CHANNEL, description="Fleet lifecycle alerts")
+                post = _channels.post(
+                    ALERT_CHANNEL,
+                    "user",
+                    _alert_body(
+                        stream_epic=stream_epic,
+                        span=span,
+                        age_s=age_s,
+                        threshold_s=threshold_s,
+                    ),
+                    to_agents=recipients,
+                    correlation_id=f"bottleneck:{stream_epic}:{span}:{new_level}",
+                    kind="system",
+                    priority=_channels.PRIORITY_ACTION_REQUIRED,
+                    auto_snapshot=False,
+                    verify_citations=False,
+                )
+            except Exception as exc:
+                logger.exception("bottleneck alert post failed for epic %s %s: %s", stream_epic, span, exc)
+                conn.execute(
+                    """
+                    INSERT INTO bottleneck_alert_state(
+                        stream_epic, span, active, rearm_level, last_delivery_error
+                    ) VALUES (?, ?, 1, ?, ?)
+                    ON CONFLICT(stream_epic, span) DO UPDATE SET
+                        active = 1, rearm_level = excluded.rearm_level,
+                        last_delivery_error = excluded.last_delivery_error
+                    """,
+                    (stream_epic, span, new_level, str(exc)[:300]),
+                )
+                conn.commit()
+                continue
+            conn.execute(
+                """
+                INSERT INTO bottleneck_alert_state(
+                    stream_epic, span, active, rearm_level, last_alert_age_s,
+                    last_alert_at, message_id, last_delivery_error, delivery_failure_reported
+                ) VALUES (?, ?, 1, ?, ?, ?, ?, NULL, 0)
+                ON CONFLICT(stream_epic, span) DO UPDATE SET
+                    active = 1, rearm_level = excluded.rearm_level,
+                    last_alert_age_s = excluded.last_alert_age_s,
+                    last_alert_at = excluded.last_alert_at, message_id = excluded.message_id,
+                    last_delivery_error = NULL, delivery_failure_reported = 0
+                """,
+                (stream_epic, span, new_level, age_s, _iso(clock), post["message_id"]),
+            )
+            conn.commit()
+            alerts_posted += 1
+    finally:
+        conn.close()
+
+    errors = tuple(error for error in metrics.get("source_errors", []) if isinstance(error, dict))
+    return AlertScanResult(True, alerts_posted, cleared, delivery_failures, errors)

--- a/tests/test_fleet_comms_bottleneck_alerts.py
+++ b/tests/test_fleet_comms_bottleneck_alerts.py
@@ -1,0 +1,228 @@
+"""Acceptance coverage for #5646 metadata-only bottleneck alerts."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agents_extensions.shared.session_streams import LeaseHolder, SessionStreamDatabase, SessionStreamStore
+from scripts.ai_agent_bridge import _channels, _db, _inbox
+from scripts.fleet_comms.bottleneck_alerts import scan_bottlenecks_at_inbox_checkpoint
+
+NOW = datetime(2026, 7, 22, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def isolate_broker(tmp_path: Path):
+    broker_db = tmp_path / "messages.db"
+    with patch("scripts.ai_agent_bridge._config.DB_PATH", broker_db), patch(
+        "scripts.ai_agent_bridge._db.DB_PATH", broker_db
+    ):
+        _db.init_db()
+        yield broker_db
+
+
+def _metrics(*, age_s: float | None, threshold_s: int = 7_200, **_: object) -> dict[str, object]:
+    return {
+        "content_included": False,
+        "threshold_seconds": {
+            "dispatch": threshold_s,
+            "formal_cf_publication": 3_600,
+            "gate_to_merge": 3_600,
+        },
+        "by_stream_epic": {
+            "4707": {
+                "dispatch": {"backlog_age_s": age_s, "raw": {"unfinished_count": 1}},
+            }
+        },
+        "source_errors": [],
+    }
+
+
+def _open_lease(path: Path, *, holder: str = "claude") -> None:
+    store = SessionStreamStore(SessionStreamDatabase(path))
+    store.open_session(
+        stream_id="epic:4707",
+        holder=LeaseHolder(
+            agent=holder,
+            harness="test",
+            instance_id="instance-1",
+            process_id=1,
+            task_id="5646",
+        ),
+        lineage_id="test-lineage",
+        ttl_seconds=3_600,
+        now=NOW,
+    )
+
+
+def _alerts() -> list[dict[str, object]]:
+    return _channels.read("fleet-comms", tail=20)
+
+
+def test_duplicate_scan_posts_one_action_required_system_alert(tmp_path: Path) -> None:
+    session_db = tmp_path / "streams.sqlite3"
+    _open_lease(session_db)
+
+    def collector(**kwargs: object) -> dict[str, object]:
+        return _metrics(age_s=7_200, **kwargs)
+
+    first = scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path,
+        now=NOW,
+        session_db=session_db,
+        rate_limit_seconds=0,
+        metrics_collector=collector,
+    )
+    second = scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path,
+        now=NOW + timedelta(seconds=1),
+        session_db=session_db,
+        rate_limit_seconds=0,
+        metrics_collector=collector,
+    )
+
+    assert first.alerts_posted == 1
+    assert second.alerts_posted == 0
+    messages = _alerts()
+    assert len(messages) == 1
+    assert messages[0]["kind"] == "system"
+    assert messages[0]["priority"] == "action_required"
+    conn = _db.get_db()
+    try:
+        recipients = {
+            row["to_agent"]
+            for row in conn.execute("SELECT to_agent FROM deliveries WHERE message_id = ?", (messages[0]["message_id"],))
+        }
+    finally:
+        conn.close()
+    assert recipients == {"claude", "claude-infra"}
+
+
+def test_persistent_breach_rearms_at_next_threshold_multiple(tmp_path: Path) -> None:
+    def collector(**kwargs: object) -> dict[str, object]:
+        return _metrics(age_s=7_200, **kwargs)
+
+    scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path, now=NOW, rate_limit_seconds=0, metrics_collector=collector
+    )
+    rearmed = scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path,
+        now=NOW + timedelta(seconds=1),
+        rate_limit_seconds=0,
+        metrics_collector=lambda **kwargs: _metrics(age_s=14_400, **kwargs),
+    )
+
+    assert rearmed.alerts_posted == 1
+    assert len(_alerts()) == 2
+
+
+def test_clear_resets_alert_state_for_a_later_breach(tmp_path: Path) -> None:
+    scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path,
+        now=NOW,
+        rate_limit_seconds=0,
+        metrics_collector=lambda **kwargs: _metrics(age_s=7_200, **kwargs),
+    )
+    cleared = scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path,
+        now=NOW + timedelta(seconds=1),
+        rate_limit_seconds=0,
+        metrics_collector=lambda **kwargs: _metrics(age_s=None, **kwargs),
+    )
+    again = scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path,
+        now=NOW + timedelta(seconds=2),
+        rate_limit_seconds=0,
+        metrics_collector=lambda **kwargs: _metrics(age_s=7_200, **kwargs),
+    )
+
+    assert cleared.cleared == 1
+    assert again.alerts_posted == 1
+    assert len(_alerts()) == 2
+
+
+def test_no_or_stale_lease_escalates_to_claude_infra_only(tmp_path: Path) -> None:
+    result = scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path,
+        now=NOW,
+        session_db=tmp_path / "missing.sqlite3",
+        rate_limit_seconds=0,
+        metrics_collector=lambda **kwargs: _metrics(age_s=7_200, **kwargs),
+    )
+
+    assert result.alerts_posted == 1
+    conn = _db.get_db()
+    try:
+        recipients = [row["to_agent"] for row in conn.execute("SELECT to_agent FROM deliveries")]
+    finally:
+        conn.close()
+    assert recipients == ["claude-infra"]
+
+
+def test_failed_delivery_is_loud_and_recorded_without_blocking_rescan(tmp_path: Path) -> None:
+    def collector(**kwargs: object) -> dict[str, object]:
+        return _metrics(age_s=7_200, **kwargs)
+
+    scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path, now=NOW, rate_limit_seconds=0, metrics_collector=collector
+    )
+    conn = _db.get_db()
+    try:
+        conn.execute("UPDATE deliveries SET status = 'failed', error = 'test transport failure'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path,
+        now=NOW + timedelta(seconds=1),
+        rate_limit_seconds=0,
+        metrics_collector=collector,
+    )
+
+    assert result.delivery_failures == 1
+    conn = _db.get_db()
+    try:
+        state = conn.execute(
+            "SELECT last_delivery_error, delivery_failure_reported FROM bottleneck_alert_state"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert state["last_delivery_error"] == "test transport failure"
+    assert state["delivery_failure_reported"] == 1
+
+
+def test_inbox_drain_invokes_the_rate_limited_alert_checkpoint() -> None:
+    with patch("scripts.fleet_comms.bottleneck_alerts.scan_bottlenecks_at_inbox_checkpoint") as scan:
+        _inbox.run_inbox("claude", until_idle=False)
+
+    scan.assert_called_once_with(repo_root=_inbox.REPO_ROOT)
+
+
+def test_alert_state_and_messages_never_contain_collector_prompt_or_body(tmp_path: Path) -> None:
+    payload = _metrics(age_s=7_200)
+    payload["prompt"] = "PRIVATE PROMPT TEXT"
+    payload["body"] = "PRIVATE MESSAGE BODY"
+    scan_bottlenecks_at_inbox_checkpoint(
+        repo_root=tmp_path,
+        now=NOW,
+        rate_limit_seconds=0,
+        metrics_collector=lambda **kwargs: payload,
+    )
+
+    conn = _db.get_db()
+    try:
+        state = [dict(row) for row in conn.execute("SELECT * FROM bottleneck_alert_state")]
+    finally:
+        conn.close()
+    serialized = json.dumps({"state": state, "messages": _alerts()}).lower()
+    assert "private prompt" not in serialized
+    assert "private message" not in serialized
+    # The channel message necessarily has its own generated alert body, but
+    # never reflects untrusted task/message payload fields from the collector.
+    assert "inspect lifecycle metadata" in serialized


### PR DESCRIPTION
Closes #5646.\n\nAdds the rate-limited inbox-drain bottleneck scanner using existing lifecycle metrics, stream leases, and channel deliveries. Alerts are action-required system messages, deduplicated in broker state, re-arm at threshold multiples, reset after a confirmed clear, and report delivery failures without blocking drains.\n\nValidation:\n- .venv/bin/python -m pytest tests/test_fleet_comms_bottleneck_alerts.py tests/test_fleet_comms_bottleneck_metrics.py tests/test_bridge_inbox.py -q\n- .venv/bin/ruff check scripts/fleet_comms/bottleneck_alerts.py scripts/ai_agent_bridge/_db.py scripts/ai_agent_bridge/_inbox.py tests/test_fleet_comms_bottleneck_alerts.py\n- .venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main..HEAD