### PR TITLE
fix(session): reclaim dead-holder leases before TTL expiry

### DIFF
--- a/agents_extensions/shared/session_streams/cli.py
+++ b/agents_extensions/shared/session_streams/cli.py
@@ -336,10 +336,10 @@ Related:
 
     handoff_claim = subparsers.add_parser(
         "handoff-claim",
-        help="Force-close expired dead holder if needed, open a new session, pin new driver (#5530).",
+        help="Force-close dead holder if needed (TTL need not expire), open a new session, pin new driver (#5530).",
         description=(
-            "Cross-agent epic-stream claim. Refuses if a live unexpired lease exists. "
-            "Claimer process must be live and instance_id must differ from the expired holder."
+            "Cross-agent epic-stream claim. Refuses if a live holder process exists. "
+            "Claimer process must be live and instance_id must differ from the dead holder."
         ),
     )
     handoff_claim.add_argument("--stream", required=True, help="Exact stream ID, for example epic:4542.")

--- a/agents_extensions/shared/session_streams/handoff.py
+++ b/agents_extensions/shared/session_streams/handoff.py
@@ -126,13 +126,19 @@ def diagnose_handoff(
     alive = bool(probe(pid)) if callable(probe) else _process_alive(pid)
 
     lease_state = str(lease.get("state") or "")
-    claimable = lease_state == "active" and expired and not alive
-    if lease_state == "active" and not expired:
+    # Dead holder PID is claimable even before wall-clock TTL expires. A crashed
+    # local process cannot renew; requiring expiry left launchers blocked for the
+    # full launcher TTL (often 6h). Live holders remain untouchable.
+    claimable = lease_state == "active" and not alive
+    if lease_state == "active" and alive and not expired:
         reason = "live unexpired lease — only the holder may close; claim refused"
-    elif lease_state == "active" and expired and alive:
+    elif lease_state == "active" and alive and expired:
         reason = "lease expired but holder PID still live — claim refused"
     elif claimable:
-        reason = "expired lease + dead holder PID — claimable via force-close then open"
+        if expired:
+            reason = "expired lease + dead holder PID — claimable via force-close then open"
+        else:
+            reason = "dead holder PID (lease unexpired) — claimable via force-close then open"
     else:
         reason = f"lease state {lease_state!r}; inspect dump before claim"
     return HandoffStatus(

--- a/agents_extensions/shared/session_streams/store.py
+++ b/agents_extensions/shared/session_streams/store.py
@@ -433,7 +433,14 @@ class SessionStreamStore:
         now: datetime | None = None,
         reason: str = "proof-gated crashed-holder force close",
     ) -> ForceCloseProof:
-        """Force-close only an expired session whose exact holder process is absent."""
+        """Force-close a crashed session whose exact holder process is absent.
+
+        The holder PID must be proven dead (``os.kill(pid, 0)`` → ProcessLookupError).
+        TTL expiry is **not** required: a dead local process cannot renew the lease,
+        and waiting for a multi-hour launcher TTL blocked relaunch after crash (#5630
+        only covered expired+dead). A still-live holder process is never force-closed,
+        whether or not the wall-clock TTL has elapsed.
+        """
         stream_id = validate_stream_id(stream_id)
         candidate.validate()
         current_time = now or utc_now()
@@ -448,12 +455,12 @@ class SessionStreamStore:
             ).fetchone()
             if row is None or row["state"] != "active":
                 raise LeaseConflictError("crashed session has no exact active lease to prove and close")
-            expires_at = parse_timestamp(str(row["expires_at"]))
-            if current_time < expires_at:
-                raise LeaseConflictError("valid live lease is untouchable until its TTL expires")
             holder_pid = int(row["holder_process_id"])
             if self._process_probe(holder_pid):
-                raise LeaseConflictError("expired lease holder process is still live; force-close refused")
+                raise LeaseConflictError(
+                    "holder process is still live; force-close refused "
+                    "(only the holder may close, or wait until the process is gone)"
+                )
             if candidate.instance_id == row["holder_instance_id"]:
                 raise LeaseConflictError("force-close candidate must be a distinct runtime instance")
             if not self._process_probe(candidate.process_id):
@@ -481,7 +488,7 @@ class SessionStreamStore:
                 event_type="stale_observed",
                 timestamp=timestamp,
                 proof=proof_payload,
-                reason="expired heartbeat and absent exact holder process observed",
+                reason="absent exact holder process observed (dead PID proof)",
             )
             force_event_id = self._insert_lease_event_from_row(
                 connection,

--- a/docs/runbooks/epic-stream-handoff.md
+++ b/docs/runbooks/epic-stream-handoff.md
@@ -16,8 +16,8 @@ driver (e.g. Codex on hramatka) leaves, content dual-write alone is not enough:
 ## Contract (v0)
 
 1. **Predecessor** clean-exits (`hook close`) **or** successor runs **proof-gated
-   force-close** (lease expired **and** holder PID dead **and** claimer is a
-   distinct live instance).
+   force-close** (holder PID dead **and** claimer is a distinct live instance;
+   wall-clock TTL need not have expired — a dead process cannot renew).
 2. **Successor opens a NEW session/lease** on the same `epic:N` — never reopens a
    closed session.
 3. **Pin transfer:** append a binding order that names the new driver; do not leave
@@ -51,8 +51,9 @@ PID still up, etc.) · `5` unexpected.
 ## Manual checklist (until CLI is habitual)
 
 1. `handoff-status --stream epic:N`
-2. If expired + dead PID → `handoff-claim` (or force-close then open)
-3. If live foreign holder → **stop** — ask that harness to close
+2. If dead PID (`alive=False`) → `handoff-claim` / relaunch (or force-close then open);
+   no need to wait for `expires_at`
+3. If live foreign holder (`alive=True`) → **stop** — ask that harness to close
 4. Tail stream + dual-write board; fold into your handoff file
 5. Launch with `--epic <name>` and bind exact rollover if any
 6. Drive; dual-write after each batch; clean close on end

--- a/docs/runbooks/session-supervisor.md
+++ b/docs/runbooks/session-supervisor.md
@@ -124,18 +124,20 @@ operation for launcher integration tests.
 ## Error behavior
 
 - Unknown epic → launcher fails before calling the supervisor.
-- Supervisor refuses (live unexpired lease, claimer PID not live, etc.) →
+- Supervisor refuses (live holder process, claimer PID not live, etc.) →
   launcher exits with an error; no session is started.
 - Incomplete supervisor output → launcher fails closed.
 
-### Stale expired lease (no operator memory required)
+### Stale dead-holder lease (no operator memory required)
 
 If a previous driver crashed without `hook close`, the stream can keep an
-`open` session with an **expired** lease and a **dead** holder PID. On the next
+`open` session with an **active** lease and a **dead** holder PID — even while
+the wall-clock TTL (often 6h from the launcher) has not yet expired. On the next
 `open`, the supervisor **automatically** proof-gated force-closes that session
-and opens a new one (same gates as `handoff-claim` / #5530).
+and opens a new one when the holder PID is gone (same gates as `handoff-claim`
+/ #5530, plus dead-unexpired reclaim).
 
-You do **not** need a manual recover step for that case. Just relaunch:
+You do **not** need to wait for lease expiry. Just relaunch:
 
 ```bash
 ./start-grok.sh --epic=harness
@@ -144,8 +146,8 @@ You do **not** need a manual recover step for that case. Just relaunch:
 
 Still refused (by design):
 
-- live unexpired lease held by another running process
-- expired lease whose holder PID is still alive
+- lease held by a process that is still running (`alive=True`)
+- force-close candidate that reuses the dead holder's `instance_id`
 
 Diagnose only when a launch still fails:
 

--- a/scripts/lib/session_supervisor.sh
+++ b/scripts/lib/session_supervisor.sh
@@ -136,12 +136,13 @@ claim_session_supervisor_env() {
   if ! "$python_bin" "${supervisor_args[@]}" > "$supervisor_tmp" 2>&1; then
     echo "Error: session supervisor failed to claim ${stream}" >&2
     sed 's/^/  supervisor: /' "$supervisor_tmp" >&2
-    # Expired dead-holder leases auto-recover on open. Remaining failures are
-    # almost always a *live* holder — diagnose, do not invent a force-close.
+    # Dead-holder leases (expired or not) auto-recover on open. Remaining
+    # failures are almost always a *live* holder — diagnose, do not invent a
+    # force-close against a running process.
     if grep -q "already has live session" "$supervisor_tmp" 2>/dev/null; then
       echo "  hint: another process still holds this epic stream." >&2
       echo "  diagnose: .venv/bin/python -m agents_extensions.shared.session_streams handoff-status --stream ${stream}" >&2
-      echo "  if that holder is dead+expired, relaunch (open recovers automatically)." >&2
+      echo "  if that holder PID is dead (alive=False), relaunch — open recovers automatically even before TTL expiry." >&2
     fi
     return 1
   fi

--- a/scripts/session_canary/kimi_lane.py
+++ b/scripts/session_canary/kimi_lane.py
@@ -273,40 +273,50 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
                     repo=repo,
                 )
                 return 2
-        elif now < expires_at and not prior_alive:
-            # Store only force-closes after TTL; dead holder still blocks open.
-            # Soft-continue: mint canary + cold-start; stream writes wait for expiry.
-            lease_summary = (
-                f"STALE_DEAD: prior {prior_agent}/{row['holder_harness']} pid={prior_pid} "
-                f"dead but TTL until {row['expires_at']} — stream writes blocked until then "
-                f"(or prior seat hook close)"
-            )
-            print(f"bootstrap: {lease_summary}", file=sys.stderr)
-            _write_lease_env_from_row(epic_dir / "session-lease.env", row)
-            blocked = True  # skip open_session; still mint + cold-start below
-        else:
+        elif not prior_alive:
+            # Dead holder PID is reclaimable even before wall-clock TTL expires.
             try:
                 store.force_close_expired_session(
                     stream_id=stream_id,
                     session_id=str(row["session_id"]),
                     candidate=holder,
                     reason=(
-                        "kimi bootstrap reclaim: prior holder process dead or TTL expired"
+                        "kimi bootstrap reclaim: prior holder process dead "
+                        f"(expires_at={row['expires_at']})"
                     ),
                 )
                 print(
-                    f"bootstrap: force-closed expired session {row['session_id']} "
-                    f"(agent={prior_agent} pid={prior_pid})"
+                    f"bootstrap: force-closed dead-holder session {row['session_id']} "
+                    f"(agent={prior_agent} pid={prior_pid} "
+                    f"ttl_remaining={'yes' if now < expires_at else 'no'})"
                 )
             except (LeaseConflictError, LifecycleError) as exc:
                 print(f"bootstrap: force-close refused: {exc}", file=sys.stderr)
                 return 2
+        else:
+            # Live process past TTL — still refuse steal; holder must exit.
+            blocked = True
+            lease_summary = (
+                f"BLOCKED: expired lease but holder pid={prior_pid} still live "
+                f"(agent={prior_agent}/{row['holder_harness']})"
+            )
+            print(
+                f"bootstrap: refusing to steal live stream {stream_id} ({lease_summary})",
+                file=sys.stderr,
+            )
+            _write_cold_start(
+                epic_dir,
+                epic=epic,
+                stream_id=stream_id,
+                lease_summary=lease_summary,
+                repo=repo,
+            )
+            return 2
 
     if (
         not blocked
         and lease is None
         and not lease_summary.startswith("LIVE")
-        and not lease_summary.startswith("STALE_DEAD")
     ):
         try:
             lease = store.open_session(
@@ -404,9 +414,6 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
         print(f"bootstrap: created {kimi_handoff.relative_to(repo)}")
 
     print(f"bootstrap: ok epic={epic} stream={stream_id}")
-    if lease_summary.startswith("STALE_DEAD"):
-        # Soft success: orchestrator can still run; stream dual-write after TTL.
-        return 0 if mint_rc == 0 else mint_rc
     if blocked and lease_summary.startswith("BLOCKED"):
         return 2
     return 0 if mint_rc == 0 else mint_rc

--- a/scripts/session_supervisor/__init__.py
+++ b/scripts/session_supervisor/__init__.py
@@ -131,10 +131,11 @@ class SessionSupervisor:
     ) -> Lease:
         """Open one exact fenced driver lease before a harness is started.
 
-        If the stream has an expired lease whose holder PID is dead, proof-gated
-        force-close runs automatically so launchers do not need a manual recovery
-        step (same safety gates as handoff-claim / #5530). Live unexpired holders
-        still refuse.
+        If the stream has an active lease whose holder PID is dead, proof-gated
+        force-close runs automatically (even when wall-clock TTL has not expired)
+        so launchers do not need a manual recovery step or multi-hour wait.
+        Same safety gates as handoff-claim / #5530, plus dead-unexpired reclaim.
+        Live holder processes still refuse.
         """
         self._require_driver(role)
         try:
@@ -183,10 +184,10 @@ class SessionSupervisor:
         stream_id: str,
         holder: LeaseHolder,
     ) -> bool:
-        """Proof-gated force-close of an expired dead-holder session.
+        """Proof-gated force-close of a dead-holder session (TTL need not have expired).
 
         Returns True when a session was force-closed. Raises SupervisorError when
-        the stream is held by a live unexpired lease or is otherwise not claimable.
+        the stream is held by a live process or is otherwise not claimable.
         Returns False when there is no open/rolling session to recover.
         """
         self._require_driver(role)
@@ -236,8 +237,8 @@ class SessionSupervisor:
                 session_id=status.session_id,
                 candidate=holder,
                 reason=(
-                    f"session supervisor open: proof-gated recover expired dead holder "
-                    f"({status.session_id})"
+                    f"session supervisor open: proof-gated recover dead holder "
+                    f"({status.session_id}; expired={status.lease_expired})"
                 ),
             )
             return True
@@ -248,8 +249,8 @@ class SessionSupervisor:
             f"holder {status.holder_agent or '?'}/{status.holder_harness or '?'} "
             f"pid={status.holder_process_id} alive={status.holder_process_alive}. "
             f"{status.reason}. "
-            f"If that process is yours, exit it cleanly or wait for lease expiry; "
-            f"do not force-close a live unexpired holder."
+            f"If that process is yours, exit it cleanly; do not force-close a live holder. "
+            f"Dead holders auto-recover on relaunch even before TTL expiry."
         ) from conflict
 
     def build_capsule(

--- a/tests/test_session_stream_handoff.py
+++ b/tests/test_session_stream_handoff.py
@@ -68,6 +68,25 @@ def test_diagnose_expired_dead_holder_claimable(tmp_path: Path) -> None:
     assert status.claimable_force_close is True
 
 
+def test_diagnose_unexpired_dead_holder_claimable(tmp_path: Path) -> None:
+    """Crash before TTL: dead PID must be reclaimable without waiting hours."""
+    state = {1001: True}
+    store = _store(tmp_path, state)
+    store.open_session(
+        stream_id="epic:4707",
+        holder=_holder(pid=1001),
+        lineage_id="lineage-a",
+        ttl_seconds=6 * 3600,
+        now=NOW,
+    )
+    state[1001] = False
+    status = diagnose_handoff(store, "epic:4707", now=NOW + timedelta(seconds=30))
+    assert status.lease_expired is False
+    assert status.holder_process_alive is False
+    assert status.claimable_force_close is True
+    assert "dead holder" in status.reason
+
+
 def test_claim_force_closes_and_opens(tmp_path: Path) -> None:
     state = {1001: True, 2002: True}
     store = _store(tmp_path, state)
@@ -96,6 +115,33 @@ def test_claim_force_closes_and_opens(tmp_path: Path) -> None:
     assert status.holder_agent == "claude"
     assert status.claimable_force_close is False
     assert status.lease_expired is False
+
+
+def test_claim_force_closes_unexpired_dead_holder(tmp_path: Path) -> None:
+    state = {1001: True, 2002: True}
+    store = _store(tmp_path, state)
+    store.open_session(
+        stream_id="epic:4707",
+        holder=_holder(pid=1001, instance="grok-dead"),
+        lineage_id="lineage-grok",
+        ttl_seconds=6 * 3600,
+        now=NOW,
+    )
+    state[1001] = False
+    receipt = claim_stream(
+        store,
+        stream_id="epic:4707",
+        agent="grok",
+        harness="grok-tui",
+        instance_id="grok-fresh",
+        process_id=2002,
+        lineage_id="lineage-grok-2",
+        ttl_seconds=6 * 3600,
+        now=NOW + timedelta(seconds=45),
+    )
+    assert receipt["force_closed"] is not None
+    assert receipt["prior_status"]["lease_expired"] is False
+    assert receipt["lease"]["holder"]["agent"] == "grok"
 
 
 def test_claim_refuses_live_lease(tmp_path: Path) -> None:

--- a/tests/test_session_streams.py
+++ b/tests/test_session_streams.py
@@ -334,7 +334,8 @@ def test_valid_lease_untouchable_and_crash_force_close_opens_distinct_session(tm
             session_id="session-two",
             now=NOW + timedelta(seconds=1),
         )
-    with pytest.raises(LeaseConflictError, match="untouchable"):
+    # Live holder is never force-closed, before or after wall-clock TTL.
+    with pytest.raises(LeaseConflictError, match="still live"):
         store.force_close_expired_session(
             stream_id="epic:4707",
             session_id="session-one",
@@ -349,25 +350,26 @@ def test_valid_lease_untouchable_and_crash_force_close_opens_distinct_session(tm
             now=NOW + timedelta(seconds=31),
         )
 
+    # Dead holder is force-closable even while TTL is still unexpired.
     process_state[41001] = False
-    proof = store.force_close_expired_session(
+    proof_early = store.force_close_expired_session(
         stream_id="epic:4707",
         session_id="session-one",
         candidate=candidate,
-        now=NOW + timedelta(seconds=31),
+        now=NOW + timedelta(seconds=5),
     )
-    assert proof.heartbeat_age_seconds == 31
-    assert proof.holder_process_id == 41001
-    assert proof.candidate_instance_id == "runtime-2"
+    assert proof_early.heartbeat_age_seconds == 5
+    assert proof_early.holder_process_id == 41001
+    assert proof_early.candidate_instance_id == "runtime-2"
     with pytest.raises(LeaseConflictError):
-        store.heartbeat(original, now=NOW + timedelta(seconds=32))
+        store.heartbeat(original, now=NOW + timedelta(seconds=6))
     with pytest.raises(LeaseConflictError):
         store.append_entry(
             original,
             entry_type=EntryType.NOTE,
             body="Old holder fenced.",
             idempotency_key="old-holder",
-            now=NOW + timedelta(seconds=32),
+            now=NOW + timedelta(seconds=6),
         )
 
     successor = store.open_session(
@@ -377,7 +379,7 @@ def test_valid_lease_untouchable_and_crash_force_close_opens_distinct_session(tm
         ttl_seconds=30,
         session_id="session-two",
         lease_id="lease-two",
-        now=NOW + timedelta(seconds=32),
+        now=NOW + timedelta(seconds=7),
     )
     assert successor.session_id != original.session_id
     assert successor.generation == original.generation + 1

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -130,6 +130,46 @@ def test_open_driver_auto_recovers_expired_dead_holder(tmp_path: Path) -> None:
     assert successor.session_id != "session-stale"
 
 
+def test_open_driver_auto_recovers_unexpired_dead_holder(tmp_path: Path) -> None:
+    """Dead PID with remaining TTL must not block relaunch for hours (user-visible #5630 gap)."""
+    from datetime import timedelta
+
+    from agents_extensions.shared.session_streams.model import utc_now
+
+    supervisor = _supervisor(tmp_path)
+    dead_pid = 999_999_003
+    assert not _pid_alive(dead_pid)
+
+    # Opened moments ago with 6h launcher TTL; process already gone.
+    supervisor.store.open_session(
+        stream_id="epic:4707",
+        holder=LeaseHolder(
+            agent="grok",
+            harness="grok-tui",
+            instance_id="grok-crash-unexpired",
+            process_id=dead_pid,
+            task_id="crashed",
+        ),
+        lineage_id="lineage-crash",
+        ttl_seconds=6 * 3600,
+        now=utc_now() - timedelta(seconds=20),
+    )
+    successor = supervisor.open_driver(
+        role="driver",
+        stream_id="epic:4707",
+        holder=LeaseHolder(
+            agent="grok",
+            harness="grok-tui",
+            instance_id="grok-relaunch",
+            process_id=os.getpid(),
+            task_id="relaunch",
+        ),
+        lineage_id="lineage-relaunch",
+        ttl_seconds=6 * 3600,
+    )
+    assert successor.holder.instance_id == "grok-relaunch"
+
+
 def test_open_driver_refuses_live_unexpired_holder(tmp_path: Path) -> None:
     supervisor = _supervisor(tmp_path)
     live = supervisor.open_driver(


### PR DESCRIPTION
## Summary

`./start-grok.sh --epic=harness` was still blocked after a crash with:

- `holder_process_id … alive=False`
- `lease_expired: False` (launcher TTL = 6h)
- `claimable_force_close: False`

#5630 only auto-recovered **expired + dead** holders. Crashed Grok/Kimi left a dead PID with remaining TTL, so relaunch waited up to six hours.

### Root cause

Force-close / claimability required wall-clock TTL expiry **and** a dead PID. TTL is a write-authority bound for the live holder; it is not a useful crash-recovery gate once the process is proven gone.

### Fix

- Store force-close: refuse only when the **holder process is still live**; dead PID is enough proof
- Handoff diagnose / claim: `claimable = active and not alive` (even if unexpired)
- Supervisor open: same auto-recover path now covers unexpired dead holders
- Kimi bootstrap: reclaim dead holders instead of soft-blocking until TTL
- Docs + tests for the unexpired crash path

Live holders remain untouchable.

## Immediate operator state

The stuck `epic:4707` session (`session-2d6164faf05a4e…`, pid 59332) was force-closed with this logic against the shared DB and clean-closed. After this merges, relaunch recovers automatically on any future dead-PID crash without waiting for `expires_at`.

## Test plan

- [x] `pytest tests/test_session_streams.py tests/test_session_stream_handoff.py tests/test_session_supervisor.py` (32 passed)
- [x] ruff clean on touched Python
- [x] Real DB: diagnose unexpired dead holder → open recovers → close leaves stream free
- [ ] After merge: kill a grok epic session mid-run, relaunch `./start-grok.sh --epic=harness` without waiting for TTL

Closes the user-visible gap left by #5630. Parent lane: #4707 / #5512.