### PR TITLE
fix(ci): fail plan when a pytest shard gets zero tests

### DIFF
--- a/scripts/ci/pytest_shards.py
+++ b/scripts/ci/pytest_shards.py
@@ -136,6 +136,10 @@ def write_plan(*, shard_id: int, shard_count: int, durations_path: Path | None, 
     durations = load_durations(durations_path)
     shards = assign_shards(nodeids, shard_count, durations)
     assigned = shards[shard_id - 1]
+    if not assigned:
+        raise RuntimeError(
+            f"shard {shard_id} received zero assigned tests out of {len(nodeids)} collected"
+        )
     args_output.parent.mkdir(parents=True, exist_ok=True)
     args_output.write_text("\n".join(assigned) + "\n", encoding="utf-8")
     _write_json(

--- a/tests/test_pytest_shards.py
+++ b/tests/test_pytest_shards.py
@@ -120,3 +120,24 @@ def test_run_nodeids_passes_nodeids_to_pytest_main(tmp_path: Path, monkeypatch) 
     rc = pytest_shards.run_nodeids(nodeids, ["--", "-q", "-n", "auto"])
     assert rc == 7
     assert captured == [["-q", "-n", "auto", "tests/test_a.py::test_a", "tests/test_b.py::test_b"]]
+
+
+def test_write_plan_rejects_empty_shard(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(pytest_shards, "collect_nodeids", lambda args=(): ["only-one"])
+    monkeypatch.setattr(
+        pytest_shards,
+        "assign_shards",
+        lambda nodeids, shard_count, durations: [[], ["only-one"], [], []],
+    )
+    try:
+        pytest_shards.write_plan(
+            shard_id=1,
+            shard_count=4,
+            durations_path=None,
+            output=tmp_path / "plan.json",
+            args_output=tmp_path / "nodeids.txt",
+        )
+    except RuntimeError as error:
+        assert "zero assigned" in str(error)
+    else:
+        raise AssertionError("empty shard must fail at plan time")


### PR DESCRIPTION
## Summary
Residual P3 from Claude CF on #5658: `write_plan` raises if a shard receives zero node IDs so the failure is attributed to planning, not a later empty node-id file.

## Test plan
- [x] pytest tests/test_pytest_shards.py
- [x] ruff on touched files

Related: #5657 (landed), stream #4707