### PR TITLE
feat(guardrails): arm ownership guard REFUSE after soak (#5645)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2452,8 +2452,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 guard_mode=guard_mode,
             )
         except Exception as own_exc:
-            # WARN (default): never crash dispatch on ledger I/O/lock errors.
-            # REFUSE: fail closed so conflicts cannot silently proceed.
+            # WARN (opt-in via DELEGATE_OWNERSHIP_MODE=warn): never crash on ledger I/O.
+            # REFUSE (default after #5645): fail closed so conflicts cannot proceed.
             print(
                 f"⚠️  write-path ownership: ledger error: {own_exc}",
                 file=sys.stderr,

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -4,8 +4,7 @@
 Local single-host ledger (`batch_state/tasks/write-ownership.sqlite3`) with
 ``BEGIN IMMEDIATE`` atomic reconcile → compare → reserve. Read-only modes are
 exempt. REFUSE mode (default after #5645 soak) blocks conflicting writable admits;
-WARN mode admits on conflict but records would-refuse;
-REFUSE mode is armed later (#5645).
+WARN mode admits on conflict but records would-refuse (opt-in via DELEGATE_OWNERSHIP_MODE=warn).
 
 Claims come from normalized ``--research-owned-path`` values but are stored
 separately from the fail-open research registry.

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -3,7 +3,8 @@
 
 Local single-host ledger (`batch_state/tasks/write-ownership.sqlite3`) with
 ``BEGIN IMMEDIATE`` atomic reconcile → compare → reserve. Read-only modes are
-exempt. WARN mode (default) admits on conflict but records would-refuse;
+exempt. REFUSE mode (default after #5645 soak) blocks conflicting writable admits;
+WARN mode admits on conflict but records would-refuse;
 REFUSE mode is armed later (#5645).
 
 Claims come from normalized ``--research-owned-path`` values but are stored
@@ -586,11 +587,21 @@ def admit_write_paths(
 
 
 def env_guard_mode() -> GuardMode:
-    """Resolve guard mode from env (default WARN). REFUSE only after soak (#5645)."""
-    raw = (os.environ.get("DELEGATE_OWNERSHIP_MODE") or "warn").strip().lower()
-    if raw in {"refuse", "deny", "fail"}:
+    """Resolve guard mode from env.
+
+    Default **REFUSE** after soak (#5645, receipt batch_state/fleet-comms/ownership-soak-5645.json).
+    Solo dispatch with no owned-path claims still admits (sentinel reservation; refuse only when
+    disjointness is unprovable vs an **active** writer, or concrete paths conflict).
+
+    Set ``DELEGATE_OWNERSHIP_MODE=warn`` to restore pre-soak admit-with-warn behavior.
+    """
+    raw = (os.environ.get("DELEGATE_OWNERSHIP_MODE") or "refuse").strip().lower()
+    if raw in {"warn", "warning", "soft"}:
+        return GuardMode.WARN
+    if raw in {"refuse", "deny", "fail", ""}:
         return GuardMode.REFUSE
-    return GuardMode.WARN
+    # Unknown values fail closed to REFUSE (do not silently soft-admit).
+    return GuardMode.REFUSE
 
 
 def update_write_claim_pid(

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -245,11 +245,12 @@ class OwnershipLedger:
         path: Path = DEFAULT_LEDGER_PATH,
         *,
         task_state_dir: Path = DEFAULT_TASK_STATE_DIR,
-        mode: GuardMode = GuardMode.WARN,
+        mode: GuardMode | None = None,
     ) -> None:
         self.path = Path(path)
         self.task_state_dir = Path(task_state_dir)
-        self.mode = mode
+        # Default follows env (REFUSE after #5645 soak). Explicit mode still wins.
+        self.mode = mode if mode is not None else env_guard_mode()
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
     def _connect(self) -> sqlite3.Connection:
@@ -572,9 +573,15 @@ def admit_write_paths(
     pid: int | None = None,
     ledger_path: Path = DEFAULT_LEDGER_PATH,
     task_state_dir: Path = DEFAULT_TASK_STATE_DIR,
-    guard_mode: GuardMode | str = GuardMode.WARN,
+    guard_mode: GuardMode | str | None = None,
 ) -> AdmissionResult:
-    gm = GuardMode(guard_mode) if not isinstance(guard_mode, GuardMode) else guard_mode
+    """Admit writable paths. ``guard_mode=None`` → :func:`env_guard_mode` (default REFUSE)."""
+    if guard_mode is None:
+        gm = env_guard_mode()
+    elif isinstance(guard_mode, GuardMode):
+        gm = guard_mode
+    else:
+        gm = GuardMode(guard_mode)
     ledger = OwnershipLedger(ledger_path, task_state_dir=task_state_dir, mode=gm)
     return ledger.admit(
         task_id=task_id,

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -488,3 +488,8 @@ def test_env_guard_mode_defaults_to_refuse(monkeypatch):
 def test_env_guard_mode_warn_opt_in(monkeypatch):
     monkeypatch.setenv("DELEGATE_OWNERSHIP_MODE", "warn")
     assert env_guard_mode() is GuardMode.WARN
+
+
+def test_env_guard_mode_unknown_fails_closed_to_refuse(monkeypatch):
+    monkeypatch.setenv("DELEGATE_OWNERSHIP_MODE", "maybe")
+    assert env_guard_mode() is GuardMode.REFUSE

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -529,9 +529,19 @@ def test_admit_write_paths_default_follows_env_refuse(
     assert refused.would_refuse is True
 
 
-def test_ownership_ledger_default_mode_follows_env(monkeypatch) -> None:
+def test_ownership_ledger_default_mode_follows_env(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Default mode follows env; paths must stay tmp-scoped (CF #5662 r4 P2)."""
     monkeypatch.delenv("DELEGATE_OWNERSHIP_MODE", raising=False)
-    assert OwnershipLedger().mode is GuardMode.REFUSE
+    ledger = tmp_path / "own.sqlite3"
+    state = tmp_path / "tasks"
+    assert (
+        OwnershipLedger(ledger, task_state_dir=state).mode is GuardMode.REFUSE
+    )
     monkeypatch.setenv("DELEGATE_OWNERSHIP_MODE", "warn")
-    assert OwnershipLedger().mode is GuardMode.WARN
-    assert OwnershipLedger(mode=GuardMode.REFUSE).mode is GuardMode.REFUSE
+    assert OwnershipLedger(ledger, task_state_dir=state).mode is GuardMode.WARN
+    assert (
+        OwnershipLedger(ledger, task_state_dir=state, mode=GuardMode.REFUSE).mode
+        is GuardMode.REFUSE
+    )

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -493,3 +493,45 @@ def test_env_guard_mode_warn_opt_in(monkeypatch):
 def test_env_guard_mode_unknown_fails_closed_to_refuse(monkeypatch):
     monkeypatch.setenv("DELEGATE_OWNERSHIP_MODE", "maybe")
     assert env_guard_mode() is GuardMode.REFUSE
+
+
+def test_admit_write_paths_default_follows_env_refuse(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Library default is env_guard_mode(), not hardcoded WARN (CF #5662 F001)."""
+    monkeypatch.delenv("DELEGATE_OWNERSHIP_MODE", raising=False)
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    (state_dir / "h.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    admit_write_paths(
+        task_id="h",
+        mode="workspace-write",
+        owned_paths=["same.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    # No guard_mode kwarg → must refuse on conflict (default REFUSE).
+    refused = admit_write_paths(
+        task_id="c",
+        mode="workspace-write",
+        owned_paths=["same.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert refused.mode is GuardMode.REFUSE
+    assert refused.admitted is False
+    assert refused.would_refuse is True
+
+
+def test_ownership_ledger_default_mode_follows_env(monkeypatch) -> None:
+    monkeypatch.delenv("DELEGATE_OWNERSHIP_MODE", raising=False)
+    assert OwnershipLedger().mode is GuardMode.REFUSE
+    monkeypatch.setenv("DELEGATE_OWNERSHIP_MODE", "warn")
+    assert OwnershipLedger().mode is GuardMode.WARN
+    assert OwnershipLedger(mode=GuardMode.REFUSE).mode is GuardMode.REFUSE

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -12,6 +12,7 @@ from scripts.guardrails.delegate_ownership import (
     OwnershipLedger,
     admit_write_paths,
     claims_conflict,
+    env_guard_mode,
     normalize_claim,
 )
 
@@ -477,3 +478,13 @@ def test_same_task_id_live_pid_does_not_replace_claims(tmp_path: Path, monkeypat
     )
     assert retry.admitted is True
     assert retry.would_refuse is False
+
+
+def test_env_guard_mode_defaults_to_refuse(monkeypatch):
+    monkeypatch.delenv("DELEGATE_OWNERSHIP_MODE", raising=False)
+    assert env_guard_mode() is GuardMode.REFUSE
+
+
+def test_env_guard_mode_warn_opt_in(monkeypatch):
+    monkeypatch.setenv("DELEGATE_OWNERSHIP_MODE", "warn")
+    assert env_guard_mode() is GuardMode.WARN


### PR DESCRIPTION
## Summary
Closes #5645.

Default ownership mode is **REFUSE** after soak evidence (local receipt `batch_state/fleet-comms/ownership-soak-5645.json`).

### Soak
- 24 parallel writable admits across claude / grok / agy
- Zero ownership_unknown on soak batch
- Live-PID overlap: WARN records would_refuse; REFUSE denies

### Semantics
- Solo no-claim dispatch still admits (sentinel)
- `DELEGATE_OWNERSHIP_MODE=warn` restores soft mode

## Test plan
- [x] tests/test_delegate_ownership.py (18)
- [x] ruff

Refs: #5641 · #5512 · #4707