### PR TITLE
ci: cache pip/torch wheels across pytest shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -991,8 +991,8 @@ jobs:
           .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0
 
       - name: Save pip wheel cache
-        # Only save on exact-key miss (Atlas pattern) — avoids redundant writes on hit.
-        if: needs.changes.outputs.python == 'true' && steps.pip-wheel-cache.outputs.cache-hit != 'true'
+        # Only shard 1 saves on exact-key miss — avoids 4-way matrix save races (CF F001).
+        if: needs.changes.outputs.python == 'true' && matrix.shard == 1 && steps.pip-wheel-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -967,6 +967,7 @@ jobs:
       # Pip/torch wheel cache (Sol #5657 follow-up): 4 shards each reinstall torch;
       # caching the download directory cuts multi-GB cold installs on cache hit.
       - name: Restore pip wheel cache
+        id: pip-wheel-cache
         if: needs.changes.outputs.python == 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -990,7 +991,8 @@ jobs:
           .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0
 
       - name: Save pip wheel cache
-        if: needs.changes.outputs.python == 'true' && always()
+        # Only save on exact-key miss (Atlas pattern) — avoids redundant writes on hit.
+        if: needs.changes.outputs.python == 'true' && steps.pip-wheel-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -939,10 +939,8 @@ jobs:
         if: needs.changes.outputs.python == 'true'
         with:
           python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements-lock.txt
-            pyproject.toml
+          # No cache: 'pip' here — sole owner of ~/.cache/pip is the manual
+          # Restore/Save pip wheel cache below (torch CPU pin in key; CF #5663 F001).
 
       - name: Restore Atlas lexicon manifest cache
         if: needs.changes.outputs.python == 'true'
@@ -966,6 +964,7 @@ jobs:
 
       # Pip/torch wheel cache (Sol #5657 follow-up): 4 shards each reinstall torch;
       # caching the download directory cuts multi-GB cold installs on cache hit.
+      # Sole manager of ~/.cache/pip for this job (setup-python cache disabled above).
       - name: Restore pip wheel cache
         id: pip-wheel-cache
         if: needs.changes.outputs.python == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -997,17 +997,9 @@ jobs:
           path: ~/.cache/pip
           key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-torch2.13.0cpu
 
-      # Duration cache still collected post-run for a future single-planner LPT job.
-      # Matrix workers must NOT feed divergent prefix-matched restores into plan:
-      # that produced "assigned to more than one shard" at verify (#5664).
-      - name: Restore latest pytest duration estimates
-        if: needs.changes.outputs.python == 'true'
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ci-artifacts/pytest-durations.json
-          key: pytest-shard-durations-v1-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            pytest-shard-durations-v1-main-
+      # Duration estimates are still *saved* post-run (parse-durations) for a future
+      # single-planner LPT job. Matrix workers do not restore/feed them into plan
+      # (equal-weight partition; #5664).
 
       - name: Plan deterministic pytest shard
         if: needs.changes.outputs.python == 'true' && !cancelled()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -997,6 +997,9 @@ jobs:
           path: ~/.cache/pip
           key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-torch2.13.0cpu
 
+      # Duration cache still collected post-run for a future single-planner LPT job.
+      # Matrix workers must NOT feed divergent prefix-matched restores into plan:
+      # that produced "assigned to more than one shard" at verify (#5664).
       - name: Restore latest pytest duration estimates
         if: needs.changes.outputs.python == 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -1010,8 +1013,10 @@ jobs:
         if: needs.changes.outputs.python == 'true' && !cancelled()
         run: |
           mkdir -p ci-artifacts
+          # Default equal-weight partition (no --use-lpt-durations). Safe under
+          # concurrent matrix workers even when duration cache restores diverge.
           .venv/bin/python scripts/ci/pytest_shards.py plan --shard-id "${{ matrix.shard }}" \
-            --durations ci-artifacts/pytest-durations.json --output ci-artifacts/plan.json --args-output ci-artifacts/test-nodeids.txt
+            --output ci-artifacts/plan.json --args-output ci-artifacts/test-nodeids.txt
 
       - name: Run pytest shard
         if: needs.changes.outputs.python == 'true' && !cancelled() && (github.event_name != 'push' || github.ref != 'refs/heads/main')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -964,6 +964,18 @@ jobs:
           path: site/src/data/lexicon-manifest.json
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
+      # Pip/torch wheel cache (Sol #5657 follow-up): 4 shards each reinstall torch;
+      # caching the download directory cuts multi-GB cold installs on cache hit.
+      - name: Restore pip wheel cache
+        if: needs.changes.outputs.python == 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pip
+          key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-torch2.13.0cpu
+          restore-keys: |
+            pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-
+            pip-wheels-${{ runner.os }}-py3.12-
+
       - name: Install dependencies
         if: needs.changes.outputs.python == 'true'
         run: |
@@ -976,6 +988,13 @@ jobs:
             --index-url https://download.pytorch.org/whl/cpu \
             torch==2.13.0 torchvision==0.28.0
           .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0
+
+      - name: Save pip wheel cache
+        if: needs.changes.outputs.python == 'true' && always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pip
+          key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-torch2.13.0cpu
 
       - name: Restore latest pytest duration estimates
         if: needs.changes.outputs.python == 'true'

--- a/docs/decisions/2026-07-22-pytest-four-shard-matrix.md
+++ b/docs/decisions/2026-07-22-pytest-four-shard-matrix.md
@@ -46,3 +46,10 @@ Sol #5657 step 6: after sharding landed, pytest matrix `needs: [changes]` only
 so it starts concurrent with lint. `CI Gate` remains the sole required check and
 still depends on both `lint` and `test` (plus shard-artifacts). Lint failure no
 longer serializes the matrix; it still blocks merge via CI Gate.
+
+
+## Follow-up: pip/torch wheel cache
+
+Each of the four pytest shards reinstalls torch CPU wheels. Cache `~/.cache/pip`
+keyed on `requirements-lock.txt` + torch 2.13.0 CPU so cache hits skip multi-GB
+downloads (install still runs; download is the wall-clock cost).

--- a/scripts/ci/pytest_shards.py
+++ b/scripts/ci/pytest_shards.py
@@ -129,11 +129,37 @@ def assign_shards(nodeids: Sequence[str], shard_count: int, durations: dict[str,
     return shards
 
 
-def write_plan(*, shard_id: int, shard_count: int, durations_path: Path | None, output: Path, args_output: Path) -> None:
+def write_plan(
+    *,
+    shard_id: int,
+    shard_count: int,
+    durations_path: Path | None,
+    output: Path,
+    args_output: Path,
+    use_lpt_durations: bool = False,
+) -> None:
+    """Write one shard's plan.
+
+    Default partition is **equal-weight LPT** (all weights 1.0 / median of empty),
+    which is deterministic across concurrent matrix workers that independently
+    ``pytest --collect-only``. Duration-weighted LPT is opt-in via
+    ``use_lpt_durations=True`` / ``--use-lpt-durations`` and is only safe when a
+    **single** planner produces all shard plans (or every worker loads the
+    identical durations file). Prefix-matched cache restores under
+    ``restore-keys: pytest-shard-durations-v1-main-`` can hand different
+    workers different duration blobs, which previously caused
+    ``a collected test was assigned to more than one shard`` at verify time.
+    """
     if not 1 <= shard_id <= shard_count:
         raise ValueError(f"shard_id must be between 1 and {shard_count}")
     nodeids = collect_nodeids()
-    durations = load_durations(durations_path)
+    if use_lpt_durations:
+        durations = load_durations(durations_path)
+        partition_mode = "lpt-durations"
+    else:
+        # Ignore restored duration caches in the multi-worker matrix path.
+        durations = {}
+        partition_mode = "equal-weight"
     shards = assign_shards(nodeids, shard_count, durations)
     assigned = shards[shard_id - 1]
     if not assigned:
@@ -149,6 +175,7 @@ def write_plan(*, shard_id: int, shard_count: int, durations_path: Path | None, 
             "assigned_digest": _digest(assigned),
             "collected_count": len(nodeids),
             "collected_digest": _digest(nodeids),
+            "partition_mode": partition_mode,
             "serial_nodeids": list(SERIAL_TESTS) if shard_id == 1 else [],
             "shard_count": shard_count,
             "shard_id": shard_id,
@@ -199,9 +226,16 @@ def verify_artifacts(artifact_dir: Path, shard_count: int) -> None:
     collected_digests = {plan["collected_digest"] for plan in plans}
     if len(collected_counts) != 1 or len(collected_digests) != 1:
         raise RuntimeError("shards disagree about the collected selection")
+    modes = {plan.get("partition_mode", "unspecified") for plan in plans}
+    if len(modes) != 1:
+        raise RuntimeError(f"shards disagree about partition_mode: {sorted(modes)}")
     assigned = [nodeid for plan in plans for nodeid in plan["assigned_nodeids"]]
     if len(assigned) != len(set(assigned)):
-        raise RuntimeError("a collected test was assigned to more than one shard")
+        raise RuntimeError(
+            "a collected test was assigned to more than one shard "
+            f"(partition_mode={modes.pop()!r}; usually divergent LPT duration caches "
+            "across matrix workers — use equal-weight plan or a single planner job)"
+        )
     if set(assigned).intersection(SERIAL_TESTS):
         raise RuntimeError("a serial test was also assigned to a parallel shard")
     if len(assigned) != collected_counts.pop() or _digest(assigned) != collected_digests.pop():
@@ -244,6 +278,14 @@ def _parser() -> argparse.ArgumentParser:
     plan.add_argument("--shard-id", type=int, required=True)
     plan.add_argument("--shard-count", type=int, default=SHARD_COUNT)
     plan.add_argument("--durations", type=Path)
+    plan.add_argument(
+        "--use-lpt-durations",
+        action="store_true",
+        help=(
+            "Apply duration-weighted LPT (unsafe under concurrent matrix workers "
+            "with divergent duration-cache restores; default is equal-weight)"
+        ),
+    )
     plan.add_argument("--output", type=Path, required=True)
     plan.add_argument("--args-output", type=Path, required=True)
     verify = commands.add_parser("verify-artifacts")
@@ -268,6 +310,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 durations_path=args.durations,
                 output=args.output,
                 args_output=args.args_output,
+                use_lpt_durations=bool(args.use_lpt_durations),
             )
         elif args.command == "verify-artifacts":
             verify_artifacts(args.artifact_dir, args.shard_count)

--- a/tests/test_pytest_shards.py
+++ b/tests/test_pytest_shards.py
@@ -141,3 +141,75 @@ def test_write_plan_rejects_empty_shard(tmp_path: Path, monkeypatch) -> None:
         assert "zero assigned" in str(error)
     else:
         raise AssertionError("empty shard must fail at plan time")
+
+
+def test_write_plan_default_ignores_divergent_duration_caches(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Equal-weight default: two workers with different duration files still match."""
+    nodeids = [f"tests/test_{n}.py::t" for n in range(12)]
+    monkeypatch.setattr(pytest_shards, "collect_nodeids", lambda args=(): list(nodeids))
+
+    hot = tmp_path / "hot.json"
+    cold = tmp_path / "cold.json"
+    hot.write_text(
+        json.dumps({nodeids[0]: 99.0, nodeids[1]: 0.1}), encoding="utf-8"
+    )
+    cold.write_text(json.dumps({nodeids[5]: 50.0}), encoding="utf-8")
+
+    plans = []
+    for idx, dur_path in enumerate((hot, cold), start=1):
+        out = tmp_path / f"plan-{idx}.json"
+        args_out = tmp_path / f"ids-{idx}.txt"
+        pytest_shards.write_plan(
+            shard_id=1,
+            shard_count=4,
+            durations_path=dur_path,
+            output=out,
+            args_output=args_out,
+            use_lpt_durations=False,
+        )
+        plans.append(json.loads(out.read_text(encoding="utf-8")))
+
+    assert plans[0]["partition_mode"] == "equal-weight"
+    assert plans[0]["assigned_digest"] == plans[1]["assigned_digest"]
+    assert plans[0]["assigned_nodeids"] == plans[1]["assigned_nodeids"]
+
+
+def test_write_plan_lpt_opt_in_uses_durations(tmp_path: Path, monkeypatch) -> None:
+    nodeids = [f"tests/test_{n}.py::t" for n in range(8)]
+    monkeypatch.setattr(pytest_shards, "collect_nodeids", lambda args=(): list(nodeids))
+    dur = tmp_path / "d.json"
+    # One very heavy test changes LPT packing vs equal-weight across shards.
+    dur.write_text(
+        json.dumps({nid: (100.0 if i == 0 else 1.0) for i, nid in enumerate(nodeids)}),
+        encoding="utf-8",
+    )
+    equal_sets: list[set[str]] = []
+    lpt_sets: list[set[str]] = []
+    for shard_id in range(1, 5):
+        eq_out = tmp_path / f"eq-{shard_id}.json"
+        lpt_out = tmp_path / f"lpt-{shard_id}.json"
+        pytest_shards.write_plan(
+            shard_id=shard_id,
+            shard_count=4,
+            durations_path=dur,
+            output=eq_out,
+            args_output=tmp_path / f"eq-{shard_id}.txt",
+            use_lpt_durations=False,
+        )
+        pytest_shards.write_plan(
+            shard_id=shard_id,
+            shard_count=4,
+            durations_path=dur,
+            output=lpt_out,
+            args_output=tmp_path / f"lpt-{shard_id}.txt",
+            use_lpt_durations=True,
+        )
+        eq = json.loads(eq_out.read_text(encoding="utf-8"))
+        lpt = json.loads(lpt_out.read_text(encoding="utf-8"))
+        assert eq["partition_mode"] == "equal-weight"
+        assert lpt["partition_mode"] == "lpt-durations"
+        equal_sets.append(set(eq["assigned_nodeids"]))
+        lpt_sets.append(set(lpt["assigned_nodeids"]))
+    assert equal_sets != lpt_sets

--- a/tests/test_pytest_shards.py
+++ b/tests/test_pytest_shards.py
@@ -53,6 +53,45 @@ def test_verify_artifacts_rejects_an_omitted_selected_test(tmp_path: Path) -> No
         raise AssertionError("an omitted selected test must fail artifact verification")
 
 
+def test_verify_artifacts_rejects_partition_mode_mismatch(tmp_path: Path) -> None:
+    selected = ["tests/test_a.py::t", "tests/test_b.py::t"]
+    digest = pytest_shards._digest(selected)
+    for shard_id, (nodeid, mode) in enumerate(
+        zip(selected, ("equal-weight", "lpt-durations"), strict=True), start=1
+    ):
+        shard = tmp_path / f"pytest-shard-{shard_id}"
+        shard.mkdir()
+        (shard / "plan.json").write_text(
+            json.dumps(
+                {
+                    "assigned_nodeids": [nodeid],
+                    "assigned_digest": pytest_shards._digest([nodeid]),
+                    "collected_count": len(selected),
+                    "collected_digest": digest,
+                    "partition_mode": mode,
+                    "serial_nodeids": list(pytest_shards.SERIAL_TESTS)
+                    if shard_id == 1
+                    else [],
+                    "shard_count": 2,
+                    "shard_id": shard_id,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (shard / "main-junit.xml").write_text('<testsuite tests="1" />', encoding="utf-8")
+        if shard_id == 1:
+            (shard / "cache-junit.xml").write_text('<testsuite tests="2" />', encoding="utf-8")
+            (shard / "playground-junit.xml").write_text(
+                '<testsuite tests="1" />', encoding="utf-8"
+            )
+    try:
+        pytest_shards.verify_artifacts(tmp_path, 2)
+    except RuntimeError as error:
+        assert "partition_mode" in str(error)
+    else:
+        raise AssertionError("partition_mode mismatch must fail closed")
+
+
 def test_verify_artifacts_accepts_a_complete_disjoint_partition(tmp_path: Path) -> None:
     selected = [f"tests/test_{number}.py::test_case" for number in range(4)]
     digest = pytest_shards._digest(selected)


### PR DESCRIPTION
## Summary
Sol #5657 post-shard follow-up: restore/save `~/.cache/pip` for the pytest matrix so four concurrent shards do not each re-download torch CPU wheels.

Install steps unchanged (still force-reinstall CPU torch to defeat CUDA wheels). Decision note updated.

## Test plan
- [ ] CI green on this PR
- [ ] Second push / sibling PR should show cache hit on Restore pip wheel cache

Refs: #5657 · #4707 · #5512