### PR TITLE
fix(ci): equal-weight pytest shard plans under matrix workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -977,6 +977,9 @@ jobs:
             torch==2.13.0 torchvision==0.28.0
           .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0
 
+      # Duration cache still collected post-run for a future single-planner LPT job.
+      # Matrix workers must NOT feed divergent prefix-matched restores into plan:
+      # that produced "assigned to more than one shard" at verify (#5664).
       - name: Restore latest pytest duration estimates
         if: needs.changes.outputs.python == 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -990,8 +993,10 @@ jobs:
         if: needs.changes.outputs.python == 'true' && !cancelled()
         run: |
           mkdir -p ci-artifacts
+          # Default equal-weight partition (no --use-lpt-durations). Safe under
+          # concurrent matrix workers even when duration cache restores diverge.
           .venv/bin/python scripts/ci/pytest_shards.py plan --shard-id "${{ matrix.shard }}" \
-            --durations ci-artifacts/pytest-durations.json --output ci-artifacts/plan.json --args-output ci-artifacts/test-nodeids.txt
+            --output ci-artifacts/plan.json --args-output ci-artifacts/test-nodeids.txt
 
       - name: Run pytest shard
         if: needs.changes.outputs.python == 'true' && !cancelled() && (github.event_name != 'push' || github.ref != 'refs/heads/main')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -977,17 +977,9 @@ jobs:
             torch==2.13.0 torchvision==0.28.0
           .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0
 
-      # Duration cache still collected post-run for a future single-planner LPT job.
-      # Matrix workers must NOT feed divergent prefix-matched restores into plan:
-      # that produced "assigned to more than one shard" at verify (#5664).
-      - name: Restore latest pytest duration estimates
-        if: needs.changes.outputs.python == 'true'
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ci-artifacts/pytest-durations.json
-          key: pytest-shard-durations-v1-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            pytest-shard-durations-v1-main-
+      # Duration estimates are still *saved* post-run (parse-durations) for a future
+      # single-planner LPT job. Matrix workers do not restore/feed them into plan
+      # (equal-weight partition; #5664).
 
       - name: Plan deterministic pytest shard
         if: needs.changes.outputs.python == 'true' && !cancelled()

--- a/scripts/ci/pytest_shards.py
+++ b/scripts/ci/pytest_shards.py
@@ -129,11 +129,37 @@ def assign_shards(nodeids: Sequence[str], shard_count: int, durations: dict[str,
     return shards
 
 
-def write_plan(*, shard_id: int, shard_count: int, durations_path: Path | None, output: Path, args_output: Path) -> None:
+def write_plan(
+    *,
+    shard_id: int,
+    shard_count: int,
+    durations_path: Path | None,
+    output: Path,
+    args_output: Path,
+    use_lpt_durations: bool = False,
+) -> None:
+    """Write one shard's plan.
+
+    Default partition is **equal-weight LPT** (all weights 1.0 / median of empty),
+    which is deterministic across concurrent matrix workers that independently
+    ``pytest --collect-only``. Duration-weighted LPT is opt-in via
+    ``use_lpt_durations=True`` / ``--use-lpt-durations`` and is only safe when a
+    **single** planner produces all shard plans (or every worker loads the
+    identical durations file). Prefix-matched cache restores under
+    ``restore-keys: pytest-shard-durations-v1-main-`` can hand different
+    workers different duration blobs, which previously caused
+    ``a collected test was assigned to more than one shard`` at verify time.
+    """
     if not 1 <= shard_id <= shard_count:
         raise ValueError(f"shard_id must be between 1 and {shard_count}")
     nodeids = collect_nodeids()
-    durations = load_durations(durations_path)
+    if use_lpt_durations:
+        durations = load_durations(durations_path)
+        partition_mode = "lpt-durations"
+    else:
+        # Ignore restored duration caches in the multi-worker matrix path.
+        durations = {}
+        partition_mode = "equal-weight"
     shards = assign_shards(nodeids, shard_count, durations)
     assigned = shards[shard_id - 1]
     if not assigned:
@@ -149,6 +175,7 @@ def write_plan(*, shard_id: int, shard_count: int, durations_path: Path | None, 
             "assigned_digest": _digest(assigned),
             "collected_count": len(nodeids),
             "collected_digest": _digest(nodeids),
+            "partition_mode": partition_mode,
             "serial_nodeids": list(SERIAL_TESTS) if shard_id == 1 else [],
             "shard_count": shard_count,
             "shard_id": shard_id,
@@ -199,9 +226,16 @@ def verify_artifacts(artifact_dir: Path, shard_count: int) -> None:
     collected_digests = {plan["collected_digest"] for plan in plans}
     if len(collected_counts) != 1 or len(collected_digests) != 1:
         raise RuntimeError("shards disagree about the collected selection")
+    modes = {plan.get("partition_mode", "unspecified") for plan in plans}
+    if len(modes) != 1:
+        raise RuntimeError(f"shards disagree about partition_mode: {sorted(modes)}")
     assigned = [nodeid for plan in plans for nodeid in plan["assigned_nodeids"]]
     if len(assigned) != len(set(assigned)):
-        raise RuntimeError("a collected test was assigned to more than one shard")
+        raise RuntimeError(
+            "a collected test was assigned to more than one shard "
+            f"(partition_mode={modes.pop()!r}; usually divergent LPT duration caches "
+            "across matrix workers — use equal-weight plan or a single planner job)"
+        )
     if set(assigned).intersection(SERIAL_TESTS):
         raise RuntimeError("a serial test was also assigned to a parallel shard")
     if len(assigned) != collected_counts.pop() or _digest(assigned) != collected_digests.pop():
@@ -244,6 +278,14 @@ def _parser() -> argparse.ArgumentParser:
     plan.add_argument("--shard-id", type=int, required=True)
     plan.add_argument("--shard-count", type=int, default=SHARD_COUNT)
     plan.add_argument("--durations", type=Path)
+    plan.add_argument(
+        "--use-lpt-durations",
+        action="store_true",
+        help=(
+            "Apply duration-weighted LPT (unsafe under concurrent matrix workers "
+            "with divergent duration-cache restores; default is equal-weight)"
+        ),
+    )
     plan.add_argument("--output", type=Path, required=True)
     plan.add_argument("--args-output", type=Path, required=True)
     verify = commands.add_parser("verify-artifacts")
@@ -268,6 +310,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 durations_path=args.durations,
                 output=args.output,
                 args_output=args.args_output,
+                use_lpt_durations=bool(args.use_lpt_durations),
             )
         elif args.command == "verify-artifacts":
             verify_artifacts(args.artifact_dir, args.shard_count)

--- a/tests/test_pytest_shards.py
+++ b/tests/test_pytest_shards.py
@@ -141,3 +141,75 @@ def test_write_plan_rejects_empty_shard(tmp_path: Path, monkeypatch) -> None:
         assert "zero assigned" in str(error)
     else:
         raise AssertionError("empty shard must fail at plan time")
+
+
+def test_write_plan_default_ignores_divergent_duration_caches(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Equal-weight default: two workers with different duration files still match."""
+    nodeids = [f"tests/test_{n}.py::t" for n in range(12)]
+    monkeypatch.setattr(pytest_shards, "collect_nodeids", lambda args=(): list(nodeids))
+
+    hot = tmp_path / "hot.json"
+    cold = tmp_path / "cold.json"
+    hot.write_text(
+        json.dumps({nodeids[0]: 99.0, nodeids[1]: 0.1}), encoding="utf-8"
+    )
+    cold.write_text(json.dumps({nodeids[5]: 50.0}), encoding="utf-8")
+
+    plans = []
+    for idx, dur_path in enumerate((hot, cold), start=1):
+        out = tmp_path / f"plan-{idx}.json"
+        args_out = tmp_path / f"ids-{idx}.txt"
+        pytest_shards.write_plan(
+            shard_id=1,
+            shard_count=4,
+            durations_path=dur_path,
+            output=out,
+            args_output=args_out,
+            use_lpt_durations=False,
+        )
+        plans.append(json.loads(out.read_text(encoding="utf-8")))
+
+    assert plans[0]["partition_mode"] == "equal-weight"
+    assert plans[0]["assigned_digest"] == plans[1]["assigned_digest"]
+    assert plans[0]["assigned_nodeids"] == plans[1]["assigned_nodeids"]
+
+
+def test_write_plan_lpt_opt_in_uses_durations(tmp_path: Path, monkeypatch) -> None:
+    nodeids = [f"tests/test_{n}.py::t" for n in range(8)]
+    monkeypatch.setattr(pytest_shards, "collect_nodeids", lambda args=(): list(nodeids))
+    dur = tmp_path / "d.json"
+    # One very heavy test changes LPT packing vs equal-weight across shards.
+    dur.write_text(
+        json.dumps({nid: (100.0 if i == 0 else 1.0) for i, nid in enumerate(nodeids)}),
+        encoding="utf-8",
+    )
+    equal_sets: list[set[str]] = []
+    lpt_sets: list[set[str]] = []
+    for shard_id in range(1, 5):
+        eq_out = tmp_path / f"eq-{shard_id}.json"
+        lpt_out = tmp_path / f"lpt-{shard_id}.json"
+        pytest_shards.write_plan(
+            shard_id=shard_id,
+            shard_count=4,
+            durations_path=dur,
+            output=eq_out,
+            args_output=tmp_path / f"eq-{shard_id}.txt",
+            use_lpt_durations=False,
+        )
+        pytest_shards.write_plan(
+            shard_id=shard_id,
+            shard_count=4,
+            durations_path=dur,
+            output=lpt_out,
+            args_output=tmp_path / f"lpt-{shard_id}.txt",
+            use_lpt_durations=True,
+        )
+        eq = json.loads(eq_out.read_text(encoding="utf-8"))
+        lpt = json.loads(lpt_out.read_text(encoding="utf-8"))
+        assert eq["partition_mode"] == "equal-weight"
+        assert lpt["partition_mode"] == "lpt-durations"
+        equal_sets.append(set(eq["assigned_nodeids"]))
+        lpt_sets.append(set(lpt["assigned_nodeids"]))
+    assert equal_sets != lpt_sets

--- a/tests/test_pytest_shards.py
+++ b/tests/test_pytest_shards.py
@@ -53,6 +53,45 @@ def test_verify_artifacts_rejects_an_omitted_selected_test(tmp_path: Path) -> No
         raise AssertionError("an omitted selected test must fail artifact verification")
 
 
+def test_verify_artifacts_rejects_partition_mode_mismatch(tmp_path: Path) -> None:
+    selected = ["tests/test_a.py::t", "tests/test_b.py::t"]
+    digest = pytest_shards._digest(selected)
+    for shard_id, (nodeid, mode) in enumerate(
+        zip(selected, ("equal-weight", "lpt-durations"), strict=True), start=1
+    ):
+        shard = tmp_path / f"pytest-shard-{shard_id}"
+        shard.mkdir()
+        (shard / "plan.json").write_text(
+            json.dumps(
+                {
+                    "assigned_nodeids": [nodeid],
+                    "assigned_digest": pytest_shards._digest([nodeid]),
+                    "collected_count": len(selected),
+                    "collected_digest": digest,
+                    "partition_mode": mode,
+                    "serial_nodeids": list(pytest_shards.SERIAL_TESTS)
+                    if shard_id == 1
+                    else [],
+                    "shard_count": 2,
+                    "shard_id": shard_id,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (shard / "main-junit.xml").write_text('<testsuite tests="1" />', encoding="utf-8")
+        if shard_id == 1:
+            (shard / "cache-junit.xml").write_text('<testsuite tests="2" />', encoding="utf-8")
+            (shard / "playground-junit.xml").write_text(
+                '<testsuite tests="1" />', encoding="utf-8"
+            )
+    try:
+        pytest_shards.verify_artifacts(tmp_path, 2)
+    except RuntimeError as error:
+        assert "partition_mode" in str(error)
+    else:
+        raise AssertionError("partition_mode mismatch must fail closed")
+
+
 def test_verify_artifacts_accepts_a_complete_disjoint_partition(tmp_path: Path) -> None:
     selected = [f"tests/test_{number}.py::test_case" for number in range(4)]
     digest = pytest_shards._digest(selected)


### PR DESCRIPTION
## Summary
Fixes CI Gate failures on **#5662** / **#5663** (and main residual from #5661): `pytest shard error: a collected test was assigned to more than one shard`.

**Root cause:** each matrix worker runs `pytest_shards.py plan` independently and loads duration estimates from a **prefix-matched** cache restore (`pytest-shard-durations-v1-main-`). Different workers can restore different duration blobs → different LPT partitions → overlapping assigned node IDs at verify time. Collection digests still matched (same tests, different packing).

**Fix:** default partition is **equal-weight** (deterministic across workers). Duration-weighted LPT is opt-in (`--use-lpt-durations`) for a future single-planner job. CI plan step no longer passes `--durations`.

## Evidence
- Downloaded plans from run `29963880302`: same `collected_digest`, **3313** overlapping assignments across shards.
- Unit tests cover equal-weight stability under divergent duration files + LPT opt-in.

## Test plan
- [x] `tests/test_pytest_shards.py` (9)
- [ ] CI Gate green on this PR
- [ ] Rebase/re-run #5662 + #5663 after merge

Closes residual CI flake from #5658 stack. Refs #5657 · #4707 · #5512