### PR TITLE
feat(fleet-comms): Gate A shadow default + Gate D v1 residual

### DIFF
--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -41,7 +41,9 @@ Launchers already claim leases. Drivers must **also** speak the message-plane + 
 .venv/bin/python -m scripts.fleet_comms plane-status
 ```
 
-Implemented modes are **only** `off` | `shadow` | `dual_write` (default **`off`**).
+Implemented modes are **only** `off` | `shadow` | `dual_write`. Production default is
+**`shadow`** after Gate A parity + operator finish GO (2026-07-23); override with
+`FLEET_COMMS_MESSAGE_PLANE=off|dual_write`.
 
 | Fact | Binding |
 | --- | --- |

--- a/docs/decisions/2026-07-23-fleet-comms-v1-gate-d-residual.md
+++ b/docs/decisions/2026-07-23-fleet-comms-v1-gate-d-residual.md
@@ -1,0 +1,40 @@
+# Decision: fleet-comms v1 Gate D residual (formal CF eligibility)
+
+**Date:** 2026-07-23  
+**Stream:** #4707 · **Product:** #5512  
+**Status:** accepted for v1 closeout
+
+## Context
+
+Isolation design spikes (#5614 / #5617 / #5620) closed **Option C fail-closed residual**.
+Wire issues #5615–#5616 (AGY), #5618–#5619 (Kimi), #5621–#5622 (Grok) cannot flip
+`formal_review_eligible` without Option A (native seal flags) or proven Option B
+(proxy/wrapper) — both need new engineering + advisor review for architecture.
+
+## Decision
+
+For **fleet-comms v1 completion**:
+
+1. **Keep** `formal_review_eligible: false` for agy / kimi / grok.
+2. **Keep** fail-closed isolation raises + substitute formal CF path
+   (`review-pr --reviewer claude|codex|glm`).
+3. **Close** wire/enablement issues as **v1 residual** (not silent partial seal).
+4. **Leave** parents #5555–#5557 open only as *future isolation engineering* trackers
+   (or close with residual note if product prefers a single open epic line).
+
+## Non-decisions
+
+- Not a permanent wontfix for isolation engineering.
+- Not a flip of stream authority (Gate B) or retention apply (Gate C).
+- Not dual_write plane default (Gate A is shadow only in this decision).
+
+## Evidence
+
+- Runbooks: `docs/runbooks/{agy,kimi,grok}-formal-cf-isolation.md`
+- Tests: `tests/test_review_isolation.py` (`agy_isolated`, grok OAuth/isolation)
+- Config: `scripts/config/fleet_communications.yaml` eligibility flags
+
+## Operator finish-mode
+
+Operator directed 2026-07-23: fully finish fleet-comms without optional stop-asks.
+Gate D residual closeout is required so v1 is not blocked on unproven seals.

--- a/docs/runbooks/agy-formal-cf-isolation.md
+++ b/docs/runbooks/agy-formal-cf-isolation.md
@@ -1,6 +1,10 @@
 # AGY sealed formal CF isolation (#5555)
 
-## Status (2026-07-21)
+## Status (2026-07-23 — v1 residual Option C)
+
+Design spikes closed **Option C fail-closed residual** (not permanent wontfix for
+future isolation engineering). For **fleet-comms v1 (#5512)**, AGY remains a live
+**orchestrator** seat and is **not** a sealed formal CF reviewer.
 
 | Capability | AGY (Antigravity / Gemini) | Formal CF sealed path |
 | --- | --- | --- |
@@ -8,7 +12,15 @@
 | Ambient MCP / hooks / nested reviewers | **Unproven** | Fail-closed |
 | Sealed snapshot cwd only | Hard raise in `prepare_isolated_review_launch` | Refuse |
 | `review-pr --reviewer agy` | **Not implemented** | Use substitute seats |
-| Registry `formal_review_eligible` | `false` for `agy` | Correct until proof |
+| Registry `formal_review_eligible` | `false` for `agy` | **v1 complete residual** |
+| Wire #5615 / enable #5616 | Residual closeout | Reopen only with Option A/B proof |
+
+**Proof command (must stay green):**
+
+```bash
+.venv/bin/python -m pytest tests/test_review_isolation.py -k agy_isolated -q
+# expect: ReviewIsolationError agy_isolated_review_unsupported
+```
 
 ## Orchestrator vs formal reviewer (do not conflate)
 

--- a/docs/runbooks/grok-formal-cf-isolation.md
+++ b/docs/runbooks/grok-formal-cf-isolation.md
@@ -1,6 +1,9 @@
 # Grok sealed formal CF isolation (#5557)
 
-## Status (2026-07-21)
+## Status (2026-07-23 — v1 residual Option C)
+
+Design spikes closed **Option C fail-closed residual**. For **fleet-comms v1 (#5512)**,
+Grok is a live **orchestrator / implement** seat and is **not** a sealed formal CF reviewer.
 
 | Capability | Native Grok CLI | Formal CF sealed path |
 | --- | --- | --- |
@@ -8,8 +11,15 @@
 | Auth never staged into model-read scope | **Proven** (tests: `test_grok_oauth_store_is_never_staged_*`) | Correct refusal, not a silent leak |
 | Sealed snapshot cwd + OS sandbox | Not reached for `engine=grok` | Hard raise before launch |
 | `review-pr --reviewer grok` | **Not implemented** (reviewers: `auto\|codex\|glm\|claude` only) | Use substitute seats |
-| Registry `formal_review_eligible` | `false` for `grok` in `scripts/config/fleet_communications.yaml` | Correct until proof |
-| Cursor explicit `grok-4.5` | Live for **orchestrator / implement / advisory** when native dark | **Not** sealed formal CF (Cursor harness identity + no grok seal) |
+| Registry `formal_review_eligible` | `false` for `grok` | **v1 complete residual** |
+| Wire #5621 / enable #5622 | Residual closeout | Reopen only with Option A/B proof |
+| Cursor explicit `grok-4.5` | Live for **orchestrator / implement / advisory** when native dark | **Not** sealed formal CF |
+
+**Proof command:**
+
+```bash
+.venv/bin/python -m pytest tests/test_review_isolation.py -k 'grok_isolated or oauth_store_is_never_staged' -q
+```
 
 ## Written decision (stream #5512)
 

--- a/docs/runbooks/kimi-formal-cf-isolation.md
+++ b/docs/runbooks/kimi-formal-cf-isolation.md
@@ -1,6 +1,9 @@
 # Kimi sealed formal CF isolation (#5556)
 
-## Status (2026-07-21)
+## Status (2026-07-23 — v1 residual Option C)
+
+Design spikes closed **Option C fail-closed residual**. For **fleet-comms v1 (#5512)**,
+Kimi is not a sealed formal CF reviewer; substitute seats remain the product path.
 
 | Capability | Native Kimi Code CLI | Formal CF sealed path |
 | --- | --- | --- |
@@ -9,7 +12,8 @@
 | Hooks / nested reviewers | **Unproven** | Fail-closed |
 | Sealed snapshot cwd only | Not wired through `prepare_isolated_review_launch` for engine `kimi` | Absent → refuse |
 | `review-pr --reviewer kimi` | **Not implemented** (reviewers: auto\|codex\|glm\|claude only) | Use substitute seats |
-| Registry `formal_review_eligible` | `false` in `scripts/config/fleet_communications.yaml` | Correct until proof |
+| Registry `formal_review_eligible` | `false` | **v1 complete residual** |
+| Wire #5618 / enable #5619 | Residual closeout | Reopen only with Option A/B proof |
 
 ## Live lane (non-formal)
 

--- a/scripts/config/fleet_communications.yaml
+++ b/scripts/config/fleet_communications.yaml
@@ -1,5 +1,12 @@
 ---
 version: 1
+# Message plane production default (Gate A / #5512). Env FLEET_COMMS_MESSAGE_PLANE
+# always wins when set. Modes: off | shadow | dual_write.
+# Operator finish-mode 2026-07-23 + parity window 8/8 ok → default shadow.
+# dual_write remains opt-in (still not stream-authority cutover; files authoritative).
+message_plane:
+  default_mode: shadow
+
 # formal_review_eligible is fail-closed until sealed CF isolation is proven and
 # the matching isolation issue closes (#5555 AGY, #5556 Kimi, #5557 Grok). Only
 # claude|codex are proven formal CF seats today; unproven live lanes stay

--- a/scripts/fleet_comms/message_plane.py
+++ b/scripts/fleet_comms/message_plane.py
@@ -64,7 +64,8 @@ def _configured_default_plane_mode() -> PlaneMode:
         return "off"
     try:
         data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
-    except OSError:
+    except (OSError, yaml.YAMLError, UnicodeError):
+        # Fail-open to off: never crash plane-status / MessagePlane on bad config.
         return "off"
     if not isinstance(data, dict):
         return "off"

--- a/scripts/fleet_comms/message_plane.py
+++ b/scripts/fleet_comms/message_plane.py
@@ -3,15 +3,19 @@
 Routes ask/reply work through the canonical request plane **when enabled**,
 while legacy bridge tables remain the default writer until operator cutover.
 
-Modes (env ``FLEET_COMMS_MESSAGE_PLANE`` or constructor):
+Modes (env ``FLEET_COMMS_MESSAGE_PLANE``, config ``message_plane.default_mode``,
+or constructor):
 
-- ``off`` (default) — no-op; legacy bridge unchanged
+- ``off`` — no-op; legacy bridge unchanged
 - ``shadow`` — create durable requests + capture completion; never change
-  legacy status; emit parity telemetry only
+  legacy status; emit parity telemetry only (production default after Gate A
+  parity + operator finish GO 2026-07-23)
 - ``dual_write`` — same as shadow, and only project ``replied`` to legacy
   when completion is proven ``complete`` (incomplete never becomes replied)
 
-No silent global flip. Background workers may reload by ``request_id`` only.
+Resolution: explicit constructor/raw → env → config default → off.
+File dual-write diaries stay authoritative in every mode. Background workers
+may reload by ``request_id`` only.
 """
 
 from __future__ import annotations
@@ -43,8 +47,53 @@ DEFAULT_TELEMETRY_NAME = Path("telemetry") / "plane-parity.jsonl"
 _TELEMETRY_SUMMARY_LIMIT = 50
 
 
+def _configured_default_plane_mode() -> PlaneMode:
+    """Read message_plane.default_mode from fleet_communications.yaml (fail-open off).
+
+    Uses this checkout's config path (not primary-only) so worktree PRs that
+    change the default are testable before merge.
+    """
+    try:
+        import yaml
+    except ImportError:  # pragma: no cover
+        return "off"
+
+    # scripts/fleet_comms/message_plane.py → parents[2] = checkout root
+    cfg_path = Path(__file__).resolve().parents[2] / "scripts" / "config" / "fleet_communications.yaml"
+    if not cfg_path.is_file():
+        return "off"
+    try:
+        data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    except OSError:
+        return "off"
+    if not isinstance(data, dict):
+        return "off"
+    plane = data.get("message_plane") or {}
+    if not isinstance(plane, dict):
+        return "off"
+    raw = plane.get("default_mode", "off")
+    if raw is None:
+        return "off"
+    value = str(raw).strip().lower()
+    if value in {"", "0", "false", "off", "disabled"}:
+        return "off"
+    if value in {"shadow", "dual_write"}:
+        return value  # type: ignore[return-value]
+    if value in {"dual-write", "dualwrite"}:
+        return "dual_write"
+    # Unknown config value: fail closed to off (do not invent modes).
+    return "off"
+
+
 def resolve_plane_mode(raw: str | None = None) -> PlaneMode:
-    value = (raw if raw is not None else os.environ.get(ENV_MODE, "off")).strip().lower()
+    """Resolve plane mode: explicit raw → env → configured default → off."""
+    if raw is not None:
+        value = raw.strip().lower()
+    else:
+        env = os.environ.get(ENV_MODE)
+        if env is None or not str(env).strip():
+            return _configured_default_plane_mode()
+        value = str(env).strip().lower()
     if value in {"", "0", "false", "off", "disabled"}:
         return "off"
     if value in {"shadow", "dual_write", "off"}:

--- a/tests/test_comms_plane_status_api.py
+++ b/tests/test_comms_plane_status_api.py
@@ -21,13 +21,14 @@ def _client() -> TestClient:
     return TestClient(app)
 
 
-def test_read_plane_status_defaults_off(tmp_path: Path, monkeypatch) -> None:
+def test_read_plane_status_defaults_to_configured_mode(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.delenv("FLEET_COMMS_MESSAGE_PLANE", raising=False)
     monkeypatch.delenv("FLEET_COMMS_ROOT", raising=False)
     monkeypatch.delenv("FLEET_COMMS_PLANE_TELEMETRY", raising=False)
     status = read_plane_status(repo_root=tmp_path)
-    assert status["mode"] == "off"
-    assert status["enabled"] is False
+    # Config default is shadow (Gate A finish); env still wins when set.
+    assert status["mode"] == "shadow"
+    assert status["enabled"] is True
     assert status["read_only"] is True
     assert status["schema"]["known_version"] == 2
     assert status["schema"]["applied_version"] is None

--- a/tests/test_fleet_comms_cli.py
+++ b/tests/test_fleet_comms_cli.py
@@ -90,7 +90,8 @@ def test_plane_status_cli_root_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     rc = main(["plane-status", "--root", str(root)])
     assert rc == EXIT_OK
     data = json.loads(capsys.readouterr().out)
-    assert data["mode"] == "off"
+    # Config default is shadow; --root only redirects storage, not mode.
+    assert data["mode"] == "shadow"
     assert data["plane_root"] == str(root)
 
 

--- a/tests/test_fleet_comms_message_plane.py
+++ b/tests/test_fleet_comms_message_plane.py
@@ -25,6 +25,19 @@ def test_resolve_plane_mode() -> None:
         resolve_plane_mode("production")
 
 
+def test_resolve_plane_mode_env_unset_uses_configured_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gate A: production default is config message_plane.default_mode (shadow)."""
+    monkeypatch.delenv("FLEET_COMMS_MESSAGE_PLANE", raising=False)
+    # Config on main/this PR pins shadow after parity window + operator finish GO.
+    assert resolve_plane_mode(None) == "shadow"
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "off")
+    assert resolve_plane_mode(None) == "off"
+    monkeypatch.setenv("FLEET_COMMS_MESSAGE_PLANE", "dual_write")
+    assert resolve_plane_mode(None) == "dual_write"
+
+
 def test_invocation_digest_stable_for_fg_bg_parity() -> None:
     a = invocation_digest(recipient="codex", body="hello", model="m", mode="read-only", cwd="/tmp/x")
     b = invocation_digest(recipient="codex", body="hello", model="m", mode="read-only", cwd="/tmp/x")

--- a/tests/test_fleet_comms_message_plane.py
+++ b/tests/test_fleet_comms_message_plane.py
@@ -38,6 +38,27 @@ def test_resolve_plane_mode_env_unset_uses_configured_default(
     assert resolve_plane_mode(None) == "dual_write"
 
 
+def test_configured_default_fail_open_on_malformed_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Malformed fleet_communications.yaml must not crash resolve (CF #5666 F001)."""
+    import scripts.fleet_comms.message_plane as mp
+
+    checkout = tmp_path / "repo"
+    cfg_dir = checkout / "scripts" / "config"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "fleet_communications.yaml").write_text(
+        "message_plane: [\n  not: valid\n", encoding="utf-8"
+    )
+    fake_file = checkout / "scripts" / "fleet_comms" / "message_plane.py"
+    fake_file.parent.mkdir(parents=True)
+    fake_file.write_text("# stub\n", encoding="utf-8")
+    monkeypatch.delenv("FLEET_COMMS_MESSAGE_PLANE", raising=False)
+    monkeypatch.setattr(mp, "__file__", str(fake_file))
+    assert mp._configured_default_plane_mode() == "off"
+    assert mp.resolve_plane_mode(None) == "off"
+
+
 def test_invocation_digest_stable_for_fg_bg_parity() -> None:
     a = invocation_digest(recipient="codex", body="hello", model="m", mode="read-only", cwd="/tmp/x")
     b = invocation_digest(recipient="codex", body="hello", model="m", mode="read-only", cwd="/tmp/x")


### PR DESCRIPTION
## Summary
Finishes fleet-comms **implementable** cutovers under operator finish-mode (2026-07-23):

### Gate A — message plane default → `shadow`
- Evidence: shadow open+complete **8/8 parity_ok** (local receipt `batch_state/fleet-comms/gate-a-shadow-parity-window-2026-07-23.json`)
- Config: `message_plane.default_mode: shadow` in `fleet_communications.yaml`
- Resolution: env → config → off; constructor/raw still explicit
- **Not** dual_write default; file dual-write diaries remain authoritative
- Override: `FLEET_COMMS_MESSAGE_PLANE=off|dual_write`

### Gate D — formal CF residual (v1 complete without unproven seals)
- Option C residual for AGY / Kimi / Grok documented in runbooks + decision
- `formal_review_eligible` stays **false** for those seats
- Wire/enablement issues (#5615–22) close as residual after merge (no silent flip)

### Still deferred (calendar / product)
- **Gate C apply**: observation still mid-window (3/7); apply remains OFF until day 7 or explicit apply GO
- **Gate B authority**: stream **db_primary** cutover not implemented; dual-write files authoritative (by design)
- Isolation **engineering** (Option A/B) remains future work under #5555–57 if reopened

## Test plan
- [x] tests/test_fleet_comms_message_plane.py + plane-status API + CLI (27)
- [x] lint_fleet_roster
- [ ] CI Gate green
- [ ] CF Claude APPROVED

Refs: #5512 · #4707 · Gate A/D