### PR TITLE
feat(retention): auto-append Gate 5 observation log on plan

### DIFF
--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -149,7 +149,7 @@ Do **not** write `laguna-s2`, `laguna.s2`, or `laguna.m1` as IDs — hyphens and
 - [x] efficiency CLI: `fleet_comms metrics` / `github-metrics` / `dead-letters` (PR-M on main)
 - [x] isolation runbooks AGY/Kimi/Grok (#5555–#5557 fail-closed residual documented)
 - [x] operator finish-mode: message-plane **shadow** default after parity (#5666; dual_write still opt-in)
-- [~] operator: retention plan dry-run × ≥7 days before scheduled apply (auto-logged by `retention_engine.py plan`; apply still OFF)
+- [ ] operator: retention plan dry-run × ≥7 days before scheduled apply (auto-logged by `retention_engine.py plan`; apply still OFF; 3/7 as of 2026-07-23)
 - [x] isolation residual closeout Option C (#5555–57 / wire issues closed; formal CF = claude|codex|glm)
 - [ ] operator: Claude + Grok + Codex + AGY cold-start stream smoke (launchers dual-aware; live multi-CLI soak optional)
 - [ ] optional later: dual_write plane default after longer shadow soak

--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -148,7 +148,8 @@ Do **not** write `laguna-s2`, `laguna.s2`, or `laguna.m1` as IDs — hyphens and
 - [x] formal CF model+effort pins + practical ladders (2026-07-21)
 - [x] efficiency CLI: `fleet_comms metrics` / `github-metrics` / `dead-letters` (PR-M on main)
 - [x] isolation runbooks AGY/Kimi/Grok (#5555–#5557 fail-closed residual documented)
-- [ ] operator: message-plane dual_write cutover flip after parity receipt
-- [ ] operator: retention plan dry-run × ≥7 days before scheduled apply
-- [ ] operator: Claude + Grok + Codex + AGY cold-start stream smoke
-- [ ] operator: AGY orchestrator self-setup review
+- [x] operator finish-mode: message-plane **shadow** default after parity (#5666; dual_write still opt-in)
+- [~] operator: retention plan dry-run × ≥7 days before scheduled apply (auto-logged by `retention_engine.py plan`; apply still OFF)
+- [x] isolation residual closeout Option C (#5555–57 / wire issues closed; formal CF = claude|codex|glm)
+- [ ] operator: Claude + Grok + Codex + AGY cold-start stream smoke (launchers dual-aware; live multi-CLI soak optional)
+- [ ] optional later: dual_write plane default after longer shadow soak

--- a/scripts/hygiene/retention_engine.py
+++ b/scripts/hygiene/retention_engine.py
@@ -184,14 +184,14 @@ def _gate5_ready_for_apply_go(
     Sparse multi-year samples must not report ready (CF #5667 P1). Latest day
     must be within 1 calendar day of ``now_utc``.
     """
-    if target_days < 1 or len(days) < target_days:
+    if target_days < 1:
         return False
     try:
         parsed = sorted({date.fromisoformat(d) for d in days})
         today = date.fromisoformat(now_utc[:10])
     except ValueError:
         return False
-    if not parsed:
+    if len(parsed) < target_days:
         return False
     latest = parsed[-1]
     if (today - latest) > timedelta(days=1):

--- a/scripts/hygiene/retention_engine.py
+++ b/scripts/hygiene/retention_engine.py
@@ -29,7 +29,9 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_PLAN_DIR = REPO_ROOT / "batch_state" / "fleet-comms" / "retention"
+DEFAULT_OBSERVATION_LOG = DEFAULT_PLAN_DIR / "gate5-observation-log.json"
 DEFAULT_ARCHIVE_ROOT = Path.home() / "Library" / "Application Support" / "learn-ukrainian" / "retention-archives"
+GATE5_TARGET_DAYS = 7
 
 # Ensure repo scripts/ is importable when invoked as a file path.
 if str(REPO_ROOT) not in sys.path:
@@ -169,6 +171,74 @@ def write_plan(plan: dict[str, Any], plan_dir: Path) -> Path:
     return path
 
 
+def record_gate5_observation(
+    plan: dict[str, Any],
+    *,
+    plan_path: Path,
+    log_path: Path = DEFAULT_OBSERVATION_LOG,
+    target_days: int = GATE5_TARGET_DAYS,
+) -> dict[str, Any]:
+    """Append Gate 5 dry-run evidence. One calendar day (UTC) per unique day label.
+
+    Does **not** arm apply. ``apply_armed`` stays false until an explicit operator
+    GO after ``target_days`` observation days (Sol Gate 5).
+    """
+    day = str(plan.get("created_at") or _utc_now())[:10]
+    entry = {
+        "file": plan_path.name,
+        "created_at": plan.get("created_at"),
+        "digest": plan.get("digest"),
+        "mode": plan.get("mode", "dry-run"),
+        "mutations": int(plan.get("mutations") or 0),
+        "would_reap": int((plan.get("counts") or {}).get("would_reap") or 0),
+        "scanner_stale": int((plan.get("counts") or {}).get("scanner_stale") or 0),
+    }
+    log: dict[str, Any]
+    if log_path.is_file():
+        try:
+            raw = json.loads(log_path.read_text(encoding="utf-8"))
+            log = raw if isinstance(raw, dict) else {}
+        except (OSError, json.JSONDecodeError, UnicodeError):
+            log = {}
+    else:
+        log = {}
+
+    days = [str(d) for d in (log.get("observation_days_recorded") or []) if d]
+    if day not in days:
+        days.append(day)
+    days = sorted(set(days))
+
+    plans = list(log.get("plans") or [])
+    if not any(
+        isinstance(p, dict) and p.get("file") == entry["file"] and p.get("digest") == entry["digest"]
+        for p in plans
+    ):
+        plans.append(entry)
+
+    log.update(
+        {
+            "schema": "fleet-comms.retention.gate5-observation.v1",
+            "updated_at": _utc_now(),
+            "policy_note": (
+                f"{target_days}d observation before scheduled apply; "
+                "apply OFF until day count met + operator GO"
+            ),
+            "apply_armed": False,
+            "observation_days_recorded": days,
+            "days_count": len(days),
+            "target_days": target_days,
+            "plans": plans[-50:],  # bound growth
+            "ready_for_apply_go": len(days) >= target_days,
+        }
+    )
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(
+        json.dumps(log, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+    return log
+
+
 def load_plan(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -270,8 +340,24 @@ def cmd_plan(args: argparse.Namespace) -> int:
         include_home=args.include_home,
         safe_only=not args.unsafe,
     )
-    path = write_plan(plan, Path(args.plan_dir))
-    out = {**plan, "plan_path": str(path)}
+    plan_dir = Path(args.plan_dir)
+    path = write_plan(plan, plan_dir)
+    observation = record_gate5_observation(
+        plan,
+        plan_path=path,
+        log_path=plan_dir / "gate5-observation-log.json",
+    )
+    out = {
+        **plan,
+        "plan_path": str(path),
+        "gate5_observation": {
+            "days_count": observation.get("days_count"),
+            "target_days": observation.get("target_days"),
+            "ready_for_apply_go": observation.get("ready_for_apply_go"),
+            "apply_armed": observation.get("apply_armed"),
+            "log_path": str(plan_dir / "gate5-observation-log.json"),
+        },
+    }
     sys.stdout.write(json.dumps(out, indent=2, sort_keys=True, default=str) + "\n")
     return EXIT_OK
 

--- a/scripts/hygiene/retention_engine.py
+++ b/scripts/hygiene/retention_engine.py
@@ -19,8 +19,10 @@ operator approval after seven days of dry-run evidence.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
+import os
 import sys
 from dataclasses import asdict
 from datetime import UTC, date, datetime, timedelta
@@ -243,10 +245,16 @@ def record_gate5_observation(
         }
     )
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log_path.write_text(
-        json.dumps(log, indent=2, sort_keys=True, default=str) + "\n",
-        encoding="utf-8",
-    )
+    payload = json.dumps(log, indent=2, sort_keys=True, default=str) + "\n"
+    # Atomic replace so concurrent plan jobs never leave a truncated log (CF P2).
+    tmp_path = log_path.with_suffix(log_path.suffix + f".tmp.{os.getpid()}")
+    try:
+        tmp_path.write_text(payload, encoding="utf-8")
+        os.replace(tmp_path, log_path)
+    finally:
+        if tmp_path.exists():
+            with contextlib.suppress(OSError):
+                tmp_path.unlink()
     return log
 
 

--- a/scripts/hygiene/retention_engine.py
+++ b/scripts/hygiene/retention_engine.py
@@ -23,7 +23,7 @@ import hashlib
 import json
 import sys
 from dataclasses import asdict
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -215,20 +215,31 @@ def record_gate5_observation(
     ):
         plans.append(entry)
 
+    # Ready only with enough distinct UTC days AND a fresh latest sample (not a
+    # stale multi-year log that happens to have ≥ target_days labels — CF P2).
+    ready = False
+    if len(days) >= target_days:
+        try:
+            latest = date.fromisoformat(max(days))
+            today = date.fromisoformat(_utc_now()[:10])
+            ready = (today - latest) <= timedelta(days=1)
+        except ValueError:
+            ready = False
+
     log.update(
         {
             "schema": "fleet-comms.retention.gate5-observation.v1",
             "updated_at": _utc_now(),
             "policy_note": (
                 f"{target_days}d observation before scheduled apply; "
-                "apply OFF until day count met + operator GO"
+                "apply OFF until day count met + recent sample + operator GO"
             ),
             "apply_armed": False,
             "observation_days_recorded": days,
             "days_count": len(days),
             "target_days": target_days,
             "plans": plans[-50:],  # bound growth
-            "ready_for_apply_go": len(days) >= target_days,
+            "ready_for_apply_go": ready,
         }
     )
     log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/hygiene/retention_engine.py
+++ b/scripts/hygiene/retention_engine.py
@@ -173,6 +173,33 @@ def write_plan(plan: dict[str, Any], plan_dir: Path) -> Path:
     return path
 
 
+def _gate5_ready_for_apply_go(
+    days: list[str],
+    *,
+    target_days: int,
+    now_utc: str,
+) -> bool:
+    """True when the trailing ``target_days`` labels are contiguous and fresh.
+
+    Sparse multi-year samples must not report ready (CF #5667 P1). Latest day
+    must be within 1 calendar day of ``now_utc``.
+    """
+    if target_days < 1 or len(days) < target_days:
+        return False
+    try:
+        parsed = sorted({date.fromisoformat(d) for d in days})
+        today = date.fromisoformat(now_utc[:10])
+    except ValueError:
+        return False
+    if not parsed:
+        return False
+    latest = parsed[-1]
+    if (today - latest) > timedelta(days=1):
+        return False
+    tail = parsed[-target_days:]
+    return all((tail[i] - tail[i - 1]).days == 1 for i in range(1, len(tail)))
+
+
 def record_gate5_observation(
     plan: dict[str, Any],
     *,
@@ -183,7 +210,7 @@ def record_gate5_observation(
     """Append Gate 5 dry-run evidence. One calendar day (UTC) per unique day label.
 
     Does **not** arm apply. ``apply_armed`` stays false until an explicit operator
-    GO after ``target_days`` observation days (Sol Gate 5).
+    GO after ``target_days`` *contiguous* observation days (Sol Gate 5).
     """
     day = str(plan.get("created_at") or _utc_now())[:10]
     entry = {
@@ -195,66 +222,76 @@ def record_gate5_observation(
         "would_reap": int((plan.get("counts") or {}).get("would_reap") or 0),
         "scanner_stale": int((plan.get("counts") or {}).get("scanner_stale") or 0),
     }
-    log: dict[str, Any]
-    if log_path.is_file():
-        try:
-            raw = json.loads(log_path.read_text(encoding="utf-8"))
-            log = raw if isinstance(raw, dict) else {}
-        except (OSError, json.JSONDecodeError, UnicodeError):
-            log = {}
-    else:
-        log = {}
 
-    days = [str(d) for d in (log.get("observation_days_recorded") or []) if d]
-    if day not in days:
-        days.append(day)
-    days = sorted(set(days))
-
-    plans = list(log.get("plans") or [])
-    if not any(
-        isinstance(p, dict) and p.get("file") == entry["file"] and p.get("digest") == entry["digest"]
-        for p in plans
-    ):
-        plans.append(entry)
-
-    # Ready only with enough distinct UTC days AND a fresh latest sample (not a
-    # stale multi-year log that happens to have ≥ target_days labels — CF P2).
-    ready = False
-    if len(days) >= target_days:
-        try:
-            latest = date.fromisoformat(max(days))
-            today = date.fromisoformat(_utc_now()[:10])
-            ready = (today - latest) <= timedelta(days=1)
-        except ValueError:
-            ready = False
-
-    log.update(
-        {
-            "schema": "fleet-comms.retention.gate5-observation.v1",
-            "updated_at": _utc_now(),
-            "policy_note": (
-                f"{target_days}d observation before scheduled apply; "
-                "apply OFF until day count met + recent sample + operator GO"
-            ),
-            "apply_armed": False,
-            "observation_days_recorded": days,
-            "days_count": len(days),
-            "target_days": target_days,
-            "plans": plans[-50:],  # bound growth
-            "ready_for_apply_go": ready,
-        }
-    )
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(log, indent=2, sort_keys=True, default=str) + "\n"
-    # Atomic replace so concurrent plan jobs never leave a truncated log (CF P2).
-    tmp_path = log_path.with_suffix(log_path.suffix + f".tmp.{os.getpid()}")
-    try:
-        tmp_path.write_text(payload, encoding="utf-8")
-        os.replace(tmp_path, log_path)
-    finally:
-        if tmp_path.exists():
-            with contextlib.suppress(OSError):
-                tmp_path.unlink()
+    lock_path = log_path.with_suffix(log_path.suffix + ".lock")
+    # Exclusive lock around read-modify-write (CF concurrent-plan safety).
+    with lock_path.open("a+", encoding="utf-8") as lock_fh:
+        try:
+            import fcntl
+
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        except (ImportError, OSError):
+            pass  # Windows / exotic FS: best-effort without lock
+
+        log: dict[str, Any]
+        if log_path.is_file():
+            try:
+                raw = json.loads(log_path.read_text(encoding="utf-8"))
+                log = raw if isinstance(raw, dict) else {}
+            except (OSError, json.JSONDecodeError, UnicodeError):
+                log = {}
+        else:
+            log = {}
+
+        days = [str(d) for d in (log.get("observation_days_recorded") or []) if d]
+        if day not in days:
+            days.append(day)
+        days = sorted(set(days))
+
+        plans = list(log.get("plans") or [])
+        if not any(
+            isinstance(p, dict)
+            and p.get("file") == entry["file"]
+            and p.get("digest") == entry["digest"]
+            for p in plans
+        ):
+            plans.append(entry)
+
+        now = _utc_now()
+        ready = _gate5_ready_for_apply_go(days, target_days=target_days, now_utc=now)
+
+        log.update(
+            {
+                "schema": "fleet-comms.retention.gate5-observation.v1",
+                "updated_at": now,
+                "policy_note": (
+                    f"{target_days}d contiguous observation before scheduled apply; "
+                    "apply OFF until contiguous days + recent sample + operator GO"
+                ),
+                "apply_armed": False,
+                "observation_days_recorded": days,
+                "days_count": len(days),
+                "target_days": target_days,
+                "plans": plans[-50:],  # bound growth
+                "ready_for_apply_go": ready,
+            }
+        )
+        payload = json.dumps(log, indent=2, sort_keys=True, default=str) + "\n"
+        tmp_path = log_path.with_suffix(log_path.suffix + f".tmp.{os.getpid()}")
+        try:
+            tmp_path.write_text(payload, encoding="utf-8")
+            os.replace(tmp_path, log_path)
+        finally:
+            if tmp_path.exists():
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink()
+        try:
+            import fcntl
+
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+        except (ImportError, OSError):
+            pass
     return log
 
 

--- a/tests/test_retention_engine.py
+++ b/tests/test_retention_engine.py
@@ -75,6 +75,8 @@ def test_plan_digest_stable_and_apply_rejects_mismatch(tmp_path: Path) -> None:
 
 
 def test_record_gate5_observation_one_day_per_calendar_label(tmp_path: Path) -> None:
+    from scripts.hygiene.retention_engine import _gate5_ready_for_apply_go
+
     plan_dir = tmp_path / "retention"
     plan = {
         "schema": "fleet-comms.retention.plan.v1",
@@ -100,12 +102,11 @@ def test_record_gate5_observation_one_day_per_calendar_label(tmp_path: Path) -> 
     assert log2["days_count"] == 1
     assert len(log2["plans"]) == 2
 
-    # New day advances count
+    # Contiguous new day → ready at target_days=2
     plan3 = dict(plan)
     plan3["created_at"] = "2026-07-25T01:00:00Z"
     plan3["digest"] = "ghi789"
     path3 = write_plan(plan3, plan_dir)
-    # Pin "today" so readiness uses recency (CF P2), not wall-clock alone.
     with patch(
         "scripts.hygiene.retention_engine._utc_now",
         return_value="2026-07-25T02:00:00Z",
@@ -119,6 +120,25 @@ def test_record_gate5_observation_one_day_per_calendar_label(tmp_path: Path) -> 
     assert log3["days_count"] == 2
     assert log3["ready_for_apply_go"] is True
     assert log3["apply_armed"] is False
+
+    # Sparse days are not contiguous → not ready (CF #5667 P1)
+    assert (
+        _gate5_ready_for_apply_go(
+            ["2026-01-01", "2026-03-01", "2026-07-25"],
+            target_days=3,
+            now_utc="2026-07-25T00:00:00Z",
+        )
+        is False
+    )
+    # Contiguous tail of length 3 is ready
+    assert (
+        _gate5_ready_for_apply_go(
+            ["2026-07-23", "2026-07-24", "2026-07-25"],
+            target_days=3,
+            now_utc="2026-07-25T00:00:00Z",
+        )
+        is True
+    )
 
     # Stale latest day → not ready even if day count is high
     with patch(

--- a/tests/test_retention_engine.py
+++ b/tests/test_retention_engine.py
@@ -105,15 +105,34 @@ def test_record_gate5_observation_one_day_per_calendar_label(tmp_path: Path) -> 
     plan3["created_at"] = "2026-07-25T01:00:00Z"
     plan3["digest"] = "ghi789"
     path3 = write_plan(plan3, plan_dir)
-    log3 = record_gate5_observation(
-        plan3,
-        plan_path=path3,
-        log_path=plan_dir / "gate5-observation-log.json",
-        target_days=2,
-    )
+    # Pin "today" so readiness uses recency (CF P2), not wall-clock alone.
+    with patch(
+        "scripts.hygiene.retention_engine._utc_now",
+        return_value="2026-07-25T02:00:00Z",
+    ):
+        log3 = record_gate5_observation(
+            plan3,
+            plan_path=path3,
+            log_path=plan_dir / "gate5-observation-log.json",
+            target_days=2,
+        )
     assert log3["days_count"] == 2
     assert log3["ready_for_apply_go"] is True
     assert log3["apply_armed"] is False
+
+    # Stale latest day → not ready even if day count is high
+    with patch(
+        "scripts.hygiene.retention_engine._utc_now",
+        return_value="2026-08-10T00:00:00Z",
+    ):
+        log4 = record_gate5_observation(
+            plan3,
+            plan_path=path3,
+            log_path=plan_dir / "gate5-observation-log.json",
+            target_days=2,
+        )
+    assert log4["days_count"] == 2
+    assert log4["ready_for_apply_go"] is False
 
 
 def test_apply_runs_reaper_only_when_digest_matches(tmp_path: Path) -> None:

--- a/tests/test_retention_engine.py
+++ b/tests/test_retention_engine.py
@@ -9,6 +9,7 @@ from scripts.hygiene.retention_engine import (
     apply_plan,
     build_plan,
     plan_digest,
+    record_gate5_observation,
     write_plan,
 )
 from scripts.orchestration.reap_worktrees import ReapResult
@@ -71,6 +72,48 @@ def test_plan_digest_stable_and_apply_rejects_mismatch(tmp_path: Path) -> None:
         assert receipt2["ok"] is False
         assert receipt2["error"] == "plan_digest_mismatch"
         assert receipt2["mutations"] == 0
+
+
+def test_record_gate5_observation_one_day_per_calendar_label(tmp_path: Path) -> None:
+    plan_dir = tmp_path / "retention"
+    plan = {
+        "schema": "fleet-comms.retention.plan.v1",
+        "mode": "dry-run",
+        "created_at": "2026-07-24T12:00:00Z",
+        "digest": "abc123",
+        "mutations": 0,
+        "counts": {"would_reap": 0, "scanner_stale": 0},
+    }
+    path = write_plan(plan, plan_dir)
+    log1 = record_gate5_observation(plan, plan_path=path, log_path=plan_dir / "gate5-observation-log.json")
+    assert log1["days_count"] == 1
+    assert log1["observation_days_recorded"] == ["2026-07-24"]
+    assert log1["apply_armed"] is False
+    assert log1["ready_for_apply_go"] is False
+
+    # Same calendar day, second plan — day count stays 1
+    plan2 = dict(plan)
+    plan2["created_at"] = "2026-07-24T18:00:00Z"
+    plan2["digest"] = "def456"
+    path2 = write_plan(plan2, plan_dir)
+    log2 = record_gate5_observation(plan2, plan_path=path2, log_path=plan_dir / "gate5-observation-log.json")
+    assert log2["days_count"] == 1
+    assert len(log2["plans"]) == 2
+
+    # New day advances count
+    plan3 = dict(plan)
+    plan3["created_at"] = "2026-07-25T01:00:00Z"
+    plan3["digest"] = "ghi789"
+    path3 = write_plan(plan3, plan_dir)
+    log3 = record_gate5_observation(
+        plan3,
+        plan_path=path3,
+        log_path=plan_dir / "gate5-observation-log.json",
+        target_days=2,
+    )
+    assert log3["days_count"] == 2
+    assert log3["ready_for_apply_go"] is True
+    assert log3["apply_armed"] is False
 
 
 def test_apply_runs_reaper_only_when_digest_matches(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Gate C observation no longer depends on the driver manually editing `gate5-observation-log.json`.

`retention_engine.py plan` now:
- writes the plan (unchanged)
- appends Gate 5 observation evidence (one UTC calendar day per day label)
- reports `gate5_observation.days_count` / `ready_for_apply_go` in plan JSON
- **never** arms apply (`apply_armed: false`)

## Why
Finish-mode for #5512: only remaining v1 gate is 7-day retention observation. Auto-logging makes daily plans count even when no human edits the log.

## Test plan
- [x] `tests/test_retention_engine.py` (day uniqueness + ready_for_apply_go)
- [ ] CI + CF Claude

Refs: #5512 · #4707 · Gate C