### PR TITLE
feat(statusline): add steps count, compaction count, and handoff warning badge

### DIFF
--- a/agents_extensions/shared/statusline/statusline.sh
+++ b/agents_extensions/shared/statusline/statusline.sh
@@ -212,6 +212,44 @@ if [ -n "$ctx_pct" ]; then
   fi
 fi
 
+# ── Steps & Compactions Telemetry ─────────────────────────────
+steps_seg=""
+compacts_seg=""
+handoff_seg=""
+steps_count=0
+compacts_count=0
+
+if [ -n "$transcript_path" ] && [ -f "$transcript_path" ]; then
+  steps_count=$(wc -l < "$transcript_path" 2>/dev/null | tr -d ' ')
+  if is_positive_integer "$steps_count"; then
+    steps_seg="[steps: ${steps_count}]"
+  else
+    steps_count=0
+  fi
+
+  compacts_count=$(grep -c -E '"(compact|compacted|is_compacted|subtype":"compact"|CONVERSATION_HISTORY)' "$transcript_path" 2>/dev/null || true)
+  if is_positive_integer "$compacts_count"; then
+    if [ "$compacts_count" -ge 3 ]; then
+      compacts_seg="\033[31m[compacts: ${compacts_count}]\033[0m"
+    elif [ "$compacts_count" -ge 2 ]; then
+      compacts_seg="\033[33m[compacts: ${compacts_count}]\033[0m"
+    else
+      compacts_seg="[compacts: ${compacts_count}]"
+    fi
+  else
+    compacts_count=0
+  fi
+fi
+
+# Handoff recommendation badge based on context %, step count, and compaction count
+if [ -n "${ctx_int:-}" ] && is_positive_integer "$ctx_int" && [ "$ctx_int" -ge 85 ] \
+   || [ "$compacts_count" -ge 3 ] || [ "$steps_count" -ge 100 ]; then
+  handoff_seg="\033[1;41;37m[HANDOFF NOW (rot risk)]\033[0m"
+elif [ -n "${ctx_int:-}" ] && is_positive_integer "$ctx_int" && [ "$ctx_int" -ge 75 ] \
+     || [ "$compacts_count" -ge 2 ] || [ "$steps_count" -ge 70 ]; then
+  handoff_seg="\033[1;33m[HANDOFF SUGGESTED]\033[0m"
+fi
+
 # Effort level
 effort_seg=""
 effort_level=$(json_get '.effort.level')
@@ -247,16 +285,20 @@ rl7d_seg=$(rate_limit_seg "7d" ".rate_limits.seven_day.used_percentage")
 # ── Assemble ────────────────────────────────────────────────────
 
 parts=()
-[ -n "$model" ]      && parts+=("[$model]")
+[ -n "$model" ]        && parts+=("[$model]")
 parts+=("$cwd_name")
-[ -n "$wt_seg" ]     && parts+=("$wt_seg")
-[ -n "$branch_seg" ] && parts+=("$branch_seg")
-[ -n "$ctx_seg" ]    && parts+=("$ctx_seg")
+[ -n "$wt_seg" ]       && parts+=("$wt_seg")
+[ -n "$branch_seg" ]   && parts+=("$branch_seg")
+[ -n "$ctx_seg" ]      && parts+=("$ctx_seg")
+[ -n "$steps_seg" ]    && parts+=("$steps_seg")
+[ -n "$compacts_seg" ] && parts+=("$compacts_seg")
+[ -n "$handoff_seg" ]  && parts+=("$handoff_seg")
 [ -n "$mismatch_seg" ] && parts+=("$mismatch_seg")
-[ -n "$effort_seg" ] && parts+=("$effort_seg")
+[ -n "$effort_seg" ]   && parts+=("$effort_seg")
 [ -n "$thinking_seg" ] && parts+=("$thinking_seg")
-[ -n "$rl5h_seg" ]   && parts+=("$rl5h_seg")
-[ -n "$rl7d_seg" ]   && parts+=("$rl7d_seg")
+[ -n "$rl5h_seg" ]     && parts+=("$rl5h_seg")
+[ -n "$rl7d_seg" ]     && parts+=("$rl7d_seg")
 
 # %b interprets the ANSI escape codes embedded in coloured segments.
 printf '%b\n' "${parts[*]}"
+

--- a/tests/test_context_window_consumers.py
+++ b/tests/test_context_window_consumers.py
@@ -341,3 +341,40 @@ def test_context_consumer_shell_syntax(script: Path) -> None:
         check=False,
     )
     assert completed.returncode == 0, completed.stderr
+
+
+def test_statusline_reports_steps_compacts_and_handoff_warning(tmp_path: Path) -> None:
+    project, record_path = _fake_project(tmp_path, _record())
+    transcript = tmp_path / "transcript_test.jsonl"
+    lines = []
+    for i in range(75):
+        lines.append(json.dumps({"type": "user", "step_index": i}))
+    lines.append(json.dumps({"type": "system", "subtype": "compact"}))
+    lines.append(json.dumps({"type": "system", "subtype": "compact"}))
+    transcript.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    payload = {
+        "session_id": "status-session",
+        "transcript_path": os.fspath(transcript),
+        "model": {"id": "gpt-5.6-sol", "display_name": "GPT-5.6 Sol"},
+        "workspace": {"current_dir": os.fspath(tmp_path)},
+        "context_window": {
+            "context_window_size": 260_000,
+            "total_input_tokens": 50_000,
+        },
+    }
+
+    completed = subprocess.run(
+        [os.fspath(STATUSLINE)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=True,
+        cwd=tmp_path,
+        env=_environment(project, record_path),
+    )
+
+    assert "[steps: 77]" in completed.stdout
+    assert "[compacts: 2]" in completed.stdout
+    assert "HANDOFF SUGGESTED" in completed.stdout
+


### PR DESCRIPTION
## Summary
- **Steps Counter**: Parses total turn steps from active transcript JSONL (`[steps: N]`).
- **Compactions Counter**: Tracks context compaction events (`[compacts: C]`) to surface memory rot risk.
- **Handoff Warning Badges**:
  - `[HANDOFF SUGGESTED]`: Yellow badge when `steps >= 70`, `compacts >= 2`, or `ctx >= 75%`.
  - `[HANDOFF NOW (rot risk)]`: Bold white-on-red badge when `steps >= 100`, `compacts >= 3`, or `ctx >= 85%`.

## Verification
- Added `test_statusline_reports_steps_compacts_and_handoff_warning` to `tests/test_context_window_consumers.py`.
- Passed all 9 context window consumer unit tests.
- Tested against historical 8,735-step transcript (correctly flagged `[HANDOFF NOW (rot risk)]`).
- Verified OPSEC (`lint_opsec_leaks.py`) and agent trailer (`X-Agent: gemini/statusline-handoff-warning`).

X-Agent: gemini/statusline-handoff-warning