### PR TITLE
feat(canary): add Kimi OAuth refresh chain canary (#5628)

### DIFF
--- a/scripts/canary/__init__.py
+++ b/scripts/canary/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable operational canaries."""

--- a/scripts/canary/kimi_oauth_canary.py
+++ b/scripts/canary/kimi_oauth_canary.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Prove the Kimi Code OAuth refresh-token chain is healthy.
+
+The canary intentionally performs one real ``refresh_token`` grant and persists
+the rotated credential through :mod:`scripts.lib.kimi_coding_oauth`. It does
+not print an access token. Run it from the repository root:
+
+    .venv/bin/python -m scripts.canary.kimi_oauth_canary
+
+For unattended use, schedule it no more frequently than every 30 minutes;
+forcing a refresh more often creates needless refresh-token churn.
+
+On a failure, the canary returns the OAuth helper's compatible exit code and
+posts a redacted, action-required system alert to the ``fleet-comms`` channel.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.ai_agent_bridge import _channels
+from scripts.lib import kimi_coding_oauth
+
+ALERT_CHANNEL = "fleet-comms"
+ALERT_RECIPIENTS = ["kimi", "claude-infra"]
+
+
+@dataclass(frozen=True, slots=True)
+class CanaryResult:
+    """Outcome that keeps alert delivery separate from OAuth health."""
+
+    exit_code: int
+    alert_posted: bool
+    failure_kind: str | None = None
+
+
+def _failure_kind(exc: BaseException) -> tuple[str, int]:
+    if isinstance(exc, kimi_coding_oauth.NoCredentialsError):
+        return "credentials", 2
+    if isinstance(exc, kimi_coding_oauth.RefreshFailedError):
+        return "refresh", 3
+    return "local_io", 3
+
+
+def post_failure_alert(failure_kind: str) -> bool:
+    """Post a metadata-only alert; alert errors never mask OAuth failure."""
+    body = (
+        "ACTION REQUIRED: Kimi OAuth refresh canary failed. "
+        f"component=kimi_oauth_refresh; failure_kind={failure_kind}. "
+        "Run `.venv/bin/python -m scripts.canary.kimi_oauth_canary`; if credentials are invalid, run `kimi login`."
+    )
+    try:
+        _channels.post(
+            ALERT_CHANNEL,
+            "kimi",
+            body,
+            to_agents=ALERT_RECIPIENTS,
+            correlation_id="canary:kimi-oauth-refresh",
+            kind="system",
+            priority=_channels.PRIORITY_ACTION_REQUIRED,
+            auto_snapshot=False,
+            verify_citations=False,
+        )
+    except Exception as exc:
+        # Do not include the OAuth exception here: an upstream response could
+        # echo sensitive request material. The command's non-zero exit remains
+        # the durable signal when fleet-comms itself is unavailable.
+        print(f"kimi-oauth-canary: fleet-comms alert failed: {type(exc).__name__}", file=sys.stderr)
+        return False
+    return True
+
+
+def run_canary(
+    *,
+    refresh: Callable[[], str] = kimi_coding_oauth.force_refresh_token,
+    alert: Callable[[str], bool] = post_failure_alert,
+) -> CanaryResult:
+    """Force the refresh grant and alert on any credential, remote, or I/O failure."""
+    try:
+        refresh()
+    except (kimi_coding_oauth.NoCredentialsError, kimi_coding_oauth.RefreshFailedError, OSError, ValueError) as exc:
+        failure_kind, exit_code = _failure_kind(exc)
+        alert_posted = alert(failure_kind)
+        print(f"kimi-oauth-canary: FAIL ({failure_kind})", file=sys.stderr)
+        return CanaryResult(exit_code=exit_code, alert_posted=alert_posted, failure_kind=failure_kind)
+    print("kimi-oauth-canary: PASS (refresh grant succeeded)")
+    return CanaryResult(exit_code=0, alert_posted=False)
+
+
+def main() -> int:
+    return run_canary().exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/kimi_coding_oauth.py
+++ b/scripts/lib/kimi_coding_oauth.py
@@ -16,6 +16,7 @@ Stdlib-only: safe to run with any Python 3.9+.
 
 Usage:
     kimi_coding_oauth.py token
+    kimi_coding_oauth.py refresh
 
 Exit codes:
     0  token printed on stdout
@@ -168,6 +169,40 @@ def _write_credentials(path: Path, data: dict) -> None:
         raise
 
 
+def force_refresh_token() -> str:
+    """Refresh the stored OAuth credential even when its access token is fresh.
+
+    This is intentionally separate from :func:`cmd_token`: consumers that only
+    need a usable token should preserve the current token until its safety
+    margin. A health canary, however, must prove the refresh-token grant and
+    token rotation still work. The complete read → refresh → atomic write
+    sequence stays under the same lock as ``cmd_token`` so a concurrent
+    ``apiKeyHelper`` process cannot use or overwrite a stale refresh token.
+
+    The returned token is for trusted in-process callers only. Callers that
+    report health must never log or otherwise expose it.
+    """
+    path = _credentials_path()
+    if not path.is_file():
+        raise NoCredentialsError(f"credential file not found: {path}")
+
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            data = _read_credentials(path)
+        except (OSError, ValueError) as exc:
+            raise NoCredentialsError(f"cannot read credentials: {exc}") from exc
+
+        merged = _refresh(data)
+        _write_credentials(path, merged)
+        token = _fresh_token(merged, 0)
+        if token is None:
+            raise RefreshFailedError("refreshed token is already expired")
+        return token
+
+
 def cmd_token() -> int:
     path = _credentials_path()
     margin = _margin_seconds()
@@ -215,11 +250,28 @@ def cmd_token() -> int:
         return 0
 
 
+def cmd_refresh() -> int:
+    """Force one refresh-token grant for diagnostics and trusted automation."""
+    try:
+        token = force_refresh_token()
+    except NoCredentialsError as exc:
+        print(f"kimi-coding-oauth: {exc}", file=sys.stderr)
+        return 2
+    except RefreshFailedError as exc:
+        print(f"kimi-coding-oauth: {exc}", file=sys.stderr)
+        return 3
+    except OSError as exc:
+        print(f"kimi-coding-oauth: cannot write credentials: {exc}", file=sys.stderr)
+        return 3
+    print(token)
+    return 0
+
+
 def main(argv: list[str]) -> int:
-    if len(argv) != 2 or argv[1] != "token":
+    if len(argv) != 2 or argv[1] not in {"token", "refresh"}:
         print(__doc__, file=sys.stderr)
         return 64
-    return cmd_token()
+    return cmd_token() if argv[1] == "token" else cmd_refresh()
 
 
 if __name__ == "__main__":

--- a/tests/test_kimi_oauth_canary.py
+++ b/tests/test_kimi_oauth_canary.py
@@ -1,0 +1,140 @@
+"""Tests for the runnable Kimi OAuth refresh-chain canary."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.canary import kimi_oauth_canary as canary
+from scripts.lib import kimi_coding_oauth
+
+
+class _RefreshServer:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.bodies: list[str] = []
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length", "0"))
+                outer.bodies.append(self.rfile.read(length).decode("utf-8"))
+                body = json.dumps(outer.payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args: object) -> None:
+                pass
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    @property
+    def url(self) -> str:
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+    def __enter__(self) -> _RefreshServer:
+        self.thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+def _credential(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+                "expires_at": time.time() + 3_600,
+            }
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+
+
+def test_force_refresh_proves_grant_and_rotates_credential(tmp_path: Path, monkeypatch) -> None:
+    credential = tmp_path / "kimi-code.json"
+    _credential(credential)
+    monkeypatch.setenv("KIMI_CODE_CREDENTIALS_PATH", str(credential))
+    payload = {"access_token": "new-access", "refresh_token": "new-refresh", "expires_in": 900}
+
+    with _RefreshServer(payload) as server:
+        monkeypatch.setenv("KIMI_CODE_OAUTH_HOST", server.url)
+        token = kimi_coding_oauth.force_refresh_token()
+
+    assert token == "new-access"
+    assert "grant_type=refresh_token" in server.bodies[0]
+    stored = json.loads(credential.read_text(encoding="utf-8"))
+    assert stored["access_token"] == "new-access"
+    assert stored["refresh_token"] == "new-refresh"
+
+
+def test_success_does_not_print_or_alert_token(capsys) -> None:
+    alerts: list[str] = []
+    result = canary.run_canary(refresh=lambda: "do-not-print-this-token", alert=alerts.append)
+
+    assert result == canary.CanaryResult(exit_code=0, alert_posted=False)
+    assert alerts == []
+    captured = capsys.readouterr()
+    assert "PASS" in captured.out
+    assert "do-not-print-this-token" not in captured.out + captured.err
+
+
+def test_missing_credentials_alerts_with_compatible_exit_code(capsys) -> None:
+    alerts: list[str] = []
+    result = canary.run_canary(
+        refresh=lambda: (_ for _ in ()).throw(kimi_coding_oauth.NoCredentialsError("missing")),
+        alert=lambda kind: alerts.append(kind) or True,
+    )
+
+    assert result == canary.CanaryResult(exit_code=2, alert_posted=True, failure_kind="credentials")
+    assert alerts == ["credentials"]
+    assert "FAIL (credentials)" in capsys.readouterr().err
+
+
+def test_refresh_failure_is_redacted_even_when_alert_delivery_fails(capsys) -> None:
+    secret = "refresh-token-must-not-leak"
+    result = canary.run_canary(
+        refresh=lambda: (_ for _ in ()).throw(kimi_coding_oauth.RefreshFailedError(secret)),
+        alert=lambda _: False,
+    )
+
+    assert result == canary.CanaryResult(exit_code=3, alert_posted=False, failure_kind="refresh")
+    captured = capsys.readouterr()
+    assert "FAIL (refresh)" in captured.err
+    assert secret not in captured.out + captured.err
+
+
+def test_failure_alert_uses_action_required_fleet_comms_message() -> None:
+    with patch("scripts.canary.kimi_oauth_canary._channels.post") as post:
+        assert canary.post_failure_alert("refresh") is True
+
+    args, kwargs = post.call_args
+    assert args[0] == "fleet-comms"
+    assert args[1] == "kimi"
+    assert "failure_kind=refresh" in args[2]
+    assert kwargs["to_agents"] == ["kimi", "claude-infra"]
+    assert kwargs["kind"] == "system"
+    assert kwargs["priority"] == "action_required"
+    assert kwargs["auto_snapshot"] is False
+    assert kwargs["verify_citations"] is False
+
+
+def test_failure_alert_does_not_raise_when_fleet_comms_is_unavailable(capsys) -> None:
+    with patch("scripts.canary.kimi_oauth_canary._channels.post", side_effect=RuntimeError("down")):
+        assert canary.post_failure_alert("local_io") is False
+
+    assert "fleet-comms alert failed: RuntimeError" in capsys.readouterr().err


### PR DESCRIPTION
Closes #5628

- Implements scheduled/runnable Kimi OAuth refresh canary
- Surfaces refresh failures to fleet-comms / monitor API
- Adds unit tests