### PR TITLE
fix(api): make /api/delegate/active complete and stable (#5207)

### DIFF
--- a/scripts/api/delegate_router.py
+++ b/scripts/api/delegate_router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
@@ -17,6 +18,9 @@ router = APIRouter(tags=["delegate"])
 
 TASKS_DIR = BATCH_STATE_DIR / "tasks"
 RESULT_BYTES_LIMIT = 64 * 1024
+TASK_READ_RETRIES = 2
+TASK_READ_RETRY_SECONDS = 0.01
+ACTIVE_TASK_STATUSES = {"running", "spawning"}
 
 
 def _parse_iso_datetime(value: str | None) -> datetime | None:
@@ -37,13 +41,16 @@ def _task_state_path(task_id: str) -> Path:
 
 
 def _read_task_state(path: Path) -> dict[str, Any] | None:
-    if not path.exists():
-        return None
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    return data if isinstance(data, dict) else None
+    for attempt in range(TASK_READ_RETRIES):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            if attempt + 1 == TASK_READ_RETRIES:
+                return None
+            time.sleep(TASK_READ_RETRY_SECONDS)
+            continue
+        return data if isinstance(data, dict) else None
+    return None
 
 
 def _pid_alive(pid: int | None) -> bool:
@@ -76,12 +83,7 @@ def _derived_task_status(task: dict[str, Any]) -> tuple[str, bool]:
     return status, alive
 
 
-def list_delegate_tasks(
-    *,
-    status: Literal["running", "done", "failed", "timeout", "spawning", "all"] = "all",
-    limit: int = 50,
-) -> dict[str, Any]:
-    task_limit = min(max(1, int(limit)), 500)
+def _delegate_task_rows(statuses: set[str] | None = None) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     if TASKS_DIR.exists():
         for path in sorted(TASKS_DIR.glob("*.json")):
@@ -89,7 +91,7 @@ def list_delegate_tasks(
             if task is None:
                 continue
             derived_status, alive = _derived_task_status(task)
-            if status != "all" and derived_status != status:
+            if statuses is not None and derived_status not in statuses:
                 continue
             rows.append({
                 "task_id": task.get("task_id") or path.stem,
@@ -108,6 +110,17 @@ def list_delegate_tasks(
         key=lambda item: _parse_iso_datetime(item.get("started_at")) or datetime.min.replace(tzinfo=UTC),
         reverse=True,
     )
+    return rows
+
+
+def list_delegate_tasks(
+    *,
+    status: Literal["running", "done", "failed", "timeout", "spawning", "all"] = "all",
+    limit: int = 50,
+) -> dict[str, Any]:
+    task_limit = min(max(1, int(limit)), 500)
+    statuses = None if status == "all" else {status}
+    rows = _delegate_task_rows(statuses)
     return {"total": len(rows), "tasks": rows[:task_limit]}
 
 
@@ -142,17 +155,11 @@ def get_delegate_task_detail(task_id: str) -> tuple[dict[str, Any] | None, dict[
 
 
 def active_delegate_count() -> int:
-    tasks = list_delegate_tasks(status="all", limit=500)["tasks"]
-    return sum(1 for task in tasks if task["status"] in {"running", "spawning"})
+    return len(_delegate_task_rows(ACTIVE_TASK_STATUSES))
 
 
 def active_delegate_tasks() -> dict[str, Any]:
-    tasks = list_delegate_tasks(status="all", limit=500)["tasks"]
-    active = [
-        task
-        for task in tasks
-        if task["status"] in {"running", "spawning"}
-    ]
+    active = _delegate_task_rows(ACTIVE_TASK_STATUSES)
     return {"total": len(active), "tasks": active}
 
 

--- a/tests/api/test_delegate_active.py
+++ b/tests/api/test_delegate_active.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
@@ -117,3 +118,78 @@ def test_delegate_active_includes_spawning_task_without_pid(tmp_path, monkeypatc
     assert [task["task_id"] for task in active["tasks"]] == ["spawning", "running"]
     assert active["tasks"][0]["status"] == "spawning"
     assert active["tasks"][0]["alive"] is False
+
+
+def test_delegate_active_filters_before_limit_truncation(tmp_path, monkeypatch):
+    tasks_dir = tmp_path / "tasks"
+    monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
+
+    def fake_kill(pid: int, sig: int) -> None:
+        if pid != 111:
+            raise ProcessLookupError
+
+    monkeypatch.setattr(delegate_router.os, "kill", fake_kill)
+    now = datetime.now(UTC)
+    for index in range(600):
+        _write_task(
+            tasks_dir / f"done-{index:03d}.json",
+            _task_payload(
+                f"done-{index:03d}",
+                started_at=_iso(now - timedelta(minutes=index)),
+            ),
+        )
+    _write_task(
+        tasks_dir / "running.json",
+        _task_payload(
+            "running",
+            status="running",
+            pid=111,
+            started_at=_iso(now - timedelta(days=1)),
+        ),
+    )
+    _write_task(
+        tasks_dir / "spawning.json",
+        _task_payload(
+            "spawning",
+            status="spawning",
+            pid=None,
+            started_at=_iso(now - timedelta(days=1, minutes=1)),
+        ),
+    )
+
+    response = client.get("/api/delegate/active")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+    assert [task["task_id"] for task in data["tasks"]] == ["running", "spawning"]
+    assert delegate_router.active_delegate_count() == 2
+
+
+def test_delegate_active_retries_transient_invalid_json(tmp_path, monkeypatch):
+    tasks_dir = tmp_path / "tasks"
+    task_path = tasks_dir / "running.json"
+    monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
+    _write_task(task_path, _task_payload("running", status="running", pid=111))
+
+    original_read_text = Path.read_text
+    read_attempts = 0
+    retry_delays = []
+
+    def flaky_read_text(path: Path, *args, **kwargs) -> str:
+        nonlocal read_attempts
+        if path == task_path and read_attempts == 0:
+            read_attempts += 1
+            return "{"
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+    monkeypatch.setattr(delegate_router.time, "sleep", retry_delays.append)
+    monkeypatch.setattr(delegate_router.os, "kill", lambda pid, sig: None)
+
+    response = client.get("/api/delegate/active")
+
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+    assert response.json()["tasks"][0]["task_id"] == "running"
+    assert retry_delays == [delegate_router.TASK_READ_RETRY_SECONDS]


### PR DESCRIPTION
Closes #5207

- Filters active tasks before limit truncation
- Adds resilient retry on transient JSON decode errors during concurrent reads
- Expands regression tests