### PR TITLE
fix(canary): handle Gemini commands without stream

### DIFF
--- a/scripts/session_canary/gemini_lane.py
+++ b/scripts/session_canary/gemini_lane.py
@@ -116,7 +116,9 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    stream_id = args.stream or EPIC_STREAM_DEFAULTS.get(args.epic, f"epic:{args.epic}")
+    stream_id = getattr(args, "stream", None) or EPIC_STREAM_DEFAULTS.get(
+        args.epic, f"epic:{args.epic}"
+    )
 
     if args.subcommand == "bootstrap":
         epic_path = _epic_dir(ROOT, args.epic)

--- a/tests/test_gemini_lane_session_canary.py
+++ b/tests/test_gemini_lane_session_canary.py
@@ -1,0 +1,19 @@
+"""Regression coverage for the Gemini session-canary command parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.session_canary import gemini_lane
+
+
+@pytest.mark.parametrize("subcommand", ["mint", "bootstrap", "protocol", "status"])
+def test_subcommands_accept_missing_stream_argument(
+    subcommand: str,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Commands without ``--stream`` must not access a missing Namespace attribute."""
+    monkeypatch.setattr(gemini_lane, "ROOT", tmp_path)
+
+    assert gemini_lane.main([subcommand, "--epic", "harness"]) == 0


### PR DESCRIPTION
## Summary
- avoid accessing a missing `stream` argument for Gemini protocol and status commands
- add regression coverage for mint, bootstrap, protocol, and status

## Verification
- `.venv/bin/python -m pytest tests/test_gemini_lane_session_canary.py tests/test_grok_lane_session_canary.py tests/test_session_canary_diary.py tests/test_session_canary_hydrate.py`
- `.venv/bin/ruff check scripts/session_canary/gemini_lane.py tests/test_gemini_lane_session_canary.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

Repository-wide `.venv/bin/ruff check` remains blocked by 41 existing violations in unrelated files; changed-file Ruff passes.