### PR TITLE
feat(infra): add devops as alias for harness/infra epic stream

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -29,7 +29,7 @@ The registry `scripts/config/issue_streams.yaml` is the single source of truth (
 | atlas-practice | #4387 → #4700 | Word Atlas + Practice Hub product & UX |
 | atlas-intake | #4220, #4378 | Full-corpus intake into the Atlas |
 | corpus-channels | #4706 | Acquisition & ingestion (textbooks · ZNO · Ohoiko-media · press · academic) |
-| infra-harness | #4707 | Fleet, hooks, deps, routing, CI reliability |
+| infra-harness | #4707 | Infra, DevOps & fleet reliability (hooks, deps, dispatch, routing) |
 | eval-harness | #4913 | UA eval harness: QG grounding/entailment gates, grammar-lexical gate, annotation, bakeoffs, cutovers |
 | benchmark-2156 | #4639 | UA LLM factuality benchmark community release |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |

--- a/docs/runbooks/epic-orchestrator-roster.md
+++ b/docs/runbooks/epic-orchestrator-roster.md
@@ -17,7 +17,7 @@ and cold-starts the driver, which runs the `drive-epic` skill to orchestrate its
 
 | Epic | Recommended seat | Run |
 | --- | --- | --- |
-| **harness / infra** | Gemini (AGY) | `./start-gemini-drive.sh harness` |
+| **harness / infra / devops** | Gemini (AGY) | `./start-gemini-drive.sh devops` |
 | **corpus** (acquisition & ingestion) | Gemini (AGY) | `./start-gemini-drive.sh corpus` |
 | **atlas** (Word Atlas + Practice Hub product) | Grok 4.5 | `./start-grok-drive.sh atlas` |
 | **hramatka** (teacher lesson service) | Grok 4.5 · Sonnet-5 if judgment-heavy | `./start-grok-drive.sh hramatka` |

--- a/docs/runbooks/gemini-orchestrator.md
+++ b/docs/runbooks/gemini-orchestrator.md
@@ -54,7 +54,7 @@ The cold-start prompt explicitly tells Gemini **not** to open or resume the leas
 | Epic | `SESSION_HANDOFF_AGENT` |
 | --- | --- |
 | atlas, hramatka, folk, bio, … | `gemini-<epic>` |
-| harness / infra | `gemini-infra` |
+| harness / infra / devops | `gemini-infra` |
 
 ## Fleet Management & Rate Limits (`codexbar`)
 

--- a/docs/runbooks/kimi-orchestrator.md
+++ b/docs/runbooks/kimi-orchestrator.md
@@ -58,7 +58,7 @@ K3 is always max effort; an explicit `--effort` is ignored for K3.
 | Epic | `SESSION_HANDOFF_AGENT` |
 | --- | --- |
 | atlas, hramatka, folk, bio, … | `kimi-<epic>` |
-| harness / infra | `kimi-infra` |
+| harness / infra / devops | `kimi-infra` |
 
 ## Session lifecycle
 

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -57,20 +57,23 @@ eq "$(handoff_identity_for_epic atlas)" "claude-atlas" "epic atlas → claude-at
 eq "$(handoff_identity_for_epic hramatka)" "claude-hramatka" "epic hramatka → claude-hramatka"
 eq "$(handoff_identity_for_epic harness)" "claude-infra" "epic harness → claude-infra (#5201)"
 eq "$(handoff_identity_for_epic infra)" "claude-infra" "epic infra → claude-infra alias"
+eq "$(handoff_identity_for_epic devops)" "claude-infra" "epic devops → claude-infra alias"
 eq "$(handoff_identity_for_epic)" "" "no epic → empty slot"
 
-# Codex uses provider-specific per-epic slots; harness/infra share one alias.
+# Codex uses provider-specific per-epic slots; harness/infra/devops share one alias.
 eq "$(handoff_identity_for_codex_epic atlas)" "codex-atlas" "Codex atlas → codex-atlas"
 eq "$(handoff_identity_for_codex_epic hramatka)" "codex-hramatka" "Codex hramatka → codex-hramatka"
 eq "$(handoff_identity_for_codex_epic harness)" "codex-infra" "Codex harness → codex-infra"
 eq "$(handoff_identity_for_codex_epic infra)" "codex-infra" "Codex infra → codex-infra alias"
+eq "$(handoff_identity_for_codex_epic devops)" "codex-infra" "Codex devops → codex-infra alias"
 eq "$(handoff_identity_for_codex_epic)" "" "Codex no epic → empty slot"
 
-# Gemini uses provider-specific per-epic slots; harness/infra share one alias.
+# Gemini uses provider-specific per-epic slots; harness/infra/devops share one alias.
 eq "$(handoff_identity_for_gemini_epic atlas)" "gemini-atlas" "Gemini atlas → gemini-atlas"
 eq "$(handoff_identity_for_gemini_epic hramatka)" "gemini-hramatka" "Gemini hramatka → gemini-hramatka"
 eq "$(handoff_identity_for_gemini_epic harness)" "gemini-infra" "Gemini harness → gemini-infra"
 eq "$(handoff_identity_for_gemini_epic infra)" "gemini-infra" "Gemini infra → gemini-infra alias"
+eq "$(handoff_identity_for_gemini_epic devops)" "gemini-infra" "Gemini devops → gemini-infra alias"
 eq "$(handoff_identity_for_gemini_epic)" "" "Gemini no epic → empty slot"
 
 

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -19,7 +19,7 @@ streams:
     title: "Corpus channels — acquisition & ingestion"
     epics: [4706]
   infra-harness:
-    title: "Infra & fleet reliability (hooks, deps, dispatch, routing)"
+    title: "Infra, DevOps & fleet reliability (hooks, deps, dispatch, routing)"
     epics: [4707]
   eval-harness:
     title: "UA eval harness — QG gates, grammar-lexical gate, annotation, bakeoffs"

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -131,13 +131,13 @@ epic_name_valid() {
 # Canonical-slot aliases: some epics are NOT free-standing lanes — they already
 # have a durable handoff identity elsewhere. Mapping them to a phantom
 # claude-<epic> slot hides live packets and causes silent cold starts (#5201).
-# harness (infra & fleet reliability / --epic harness) → claude-infra, the same
+# harness/infra/devops (infra, DevOps & fleet reliability) → claude-infra, the same
 # slot as --agent infra-orchestrator (lineage dir, session-state, inbox).
 handoff_identity_for_epic() {
   local epic="${1:-}"
   [ -n "$epic" ] || return 0
   case "$epic" in
-    harness|infra) printf '%s' 'claude-infra' ;;
+    harness|infra|devops) printf '%s' 'claude-infra' ;;
     *) printf 'claude-%s' "$epic" ;;
   esac
 }
@@ -151,32 +151,31 @@ handoff_identity_for_codex_epic() {
   local epic="${1:-}"
   [ -n "$epic" ] || return 0
   case "$epic" in
-    harness|infra) printf '%s' 'codex-infra' ;;
+    harness|infra|devops) printf '%s' 'codex-infra' ;;
     *) printf 'codex-%s' "$epic" ;;
   esac
 }
 
 # handoff_identity_for_kimi_epic "<epic-name>"
 # Echo the per-epic Kimi Code orchestrator rollover slot. Provider-specific so
-# a Kimi seat never adopts Claude/Codex/Grok packets. harness/infra → kimi-infra.
+# a Kimi seat never adopts Claude/Codex/Grok packets. harness/infra/devops → kimi-infra.
 handoff_identity_for_kimi_epic() {
   local epic="${1:-}"
   [ -n "$epic" ] || return 0
   case "$epic" in
-    harness|infra) printf '%s' 'kimi-infra' ;;
+    harness|infra|devops) printf '%s' 'kimi-infra' ;;
     *) printf 'kimi-%s' "$epic" ;;
   esac
 }
 
 # handoff_identity_for_gemini_epic "<epic-name>"
 # Echo the per-epic Gemini / Antigravity orchestrator rollover slot. Provider-specific so
-# a Gemini seat never adopts Claude/Codex/Grok/Kimi packets. harness/infra → gemini-infra.
+# a Gemini seat never adopts Claude/Codex/Grok/Kimi packets. harness/infra/devops → gemini-infra.
 handoff_identity_for_gemini_epic() {
   local epic="${1:-}"
   [ -n "$epic" ] || return 0
   case "$epic" in
-    harness|infra) printf '%s' 'gemini-infra' ;;
+    harness|infra|devops) printf '%s' 'gemini-infra' ;;
     *) printf 'gemini-%s' "$epic" ;;
   esac
 }
-

--- a/scripts/lib/session_supervisor.sh
+++ b/scripts/lib/session_supervisor.sh
@@ -24,7 +24,7 @@
 stream_id_for_epic() {
   case "${1:-}" in
     atlas|practice|practice-hub) printf '%s' 'epic:4387' ;;
-    harness|infra) printf '%s' 'epic:4707' ;;
+    harness|infra|devops) printf '%s' 'epic:4707' ;;
     hramatka) printf '%s' 'epic:4542' ;;
     folk|seminars-folk) printf '%s' 'epic:2836' ;;
     bio|seminars-bio) printf '%s' 'epic:4431' ;;

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -207,7 +207,7 @@ export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
 # a LAUNCHER-ONLY flag (stripped before exec — the claude CLI does not know it).
 # It pins the session to one epic lane: SESSION_EPIC is exported for the
 # SessionStart hook to print a binding assignment banner, and the handoff slot
-# becomes claude-<epic> (with canonical aliases: harness/infra → claude-infra
+# becomes claude-<epic> (with canonical aliases: harness/infra/devops → claude-infra
 # so packets under the durable infra slot surface — #5201) so two sessions of
 # the SAME agent type on DIFFERENT epics never share (or clobber) a thread
 # handoff. Without --epic the hook tells the session to ASK the user instead of

--- a/start-gemini-drive.sh
+++ b/start-gemini-drive.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ $# -lt 1 ]; then
   echo "usage: $(basename "$0") <epic> [flags]" >&2
-  echo "  epics: harness  atlas  hramatka  bio  folk  corpus  (see docs/runbooks/epic-orchestrator-roster.md)" >&2
+  echo "  epics: harness  infra  devops  atlas  hramatka  bio  folk  corpus  (see docs/runbooks/epic-orchestrator-roster.md)" >&2
   exit 2
 fi
 EPIC="$1"; shift

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -253,7 +253,7 @@ if [ -n "$_selected_epic" ]; then
       export SESSION_HANDOFF_AGENT="$(handoff_identity_for_gemini_epic "$_selected_epic")"
     else
       case "$_selected_epic" in
-        harness|infra) export SESSION_HANDOFF_AGENT='gemini-infra' ;;
+        harness|infra|devops) export SESSION_HANDOFF_AGENT='gemini-infra' ;;
         *) export SESSION_HANDOFF_AGENT="gemini-${_selected_epic}" ;;
       esac
     fi

--- a/start-grok-drive.sh
+++ b/start-grok-drive.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ $# -lt 1 ]; then
   echo "usage: $(basename "$0") <epic> [flags]" >&2
-  echo "  epics: harness  atlas  hramatka  bio  folk  corpus  (see docs/runbooks/epic-orchestrator-roster.md)" >&2
+  echo "  epics: harness  infra  devops  atlas  hramatka  bio  folk  corpus  (see docs/runbooks/epic-orchestrator-roster.md)" >&2
   exit 2
 fi
 EPIC="$1"; shift

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -239,7 +239,7 @@ if [ -n "$_selected_epic" ]; then
   # Grok-specific handoff slot (not claude-<epic>)
   if [ -z "${SESSION_HANDOFF_AGENT:-}" ] && [ -z "$_handoff_override" ]; then
     case "$_selected_epic" in
-      harness|infra) export SESSION_HANDOFF_AGENT='grok-infra' ;;
+      harness|infra|devops) export SESSION_HANDOFF_AGENT='grok-infra' ;;
       *) export SESSION_HANDOFF_AGENT="grok-${_selected_epic}" ;;
     esac
   fi

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -246,7 +246,7 @@ if [ -n "$_selected_epic" ]; then
       export SESSION_HANDOFF_AGENT="$(handoff_identity_for_kimi_epic "$_selected_epic")"
     else
       case "$_selected_epic" in
-        harness|infra) export SESSION_HANDOFF_AGENT='kimi-infra' ;;
+        harness|infra|devops) export SESSION_HANDOFF_AGENT='kimi-infra' ;;
         *) export SESSION_HANDOFF_AGENT="kimi-${_selected_epic}" ;;
       esac
     fi

--- a/start-sonnet-drive.sh
+++ b/start-sonnet-drive.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ $# -lt 1 ]; then
   echo "usage: $(basename "$0") <epic> [flags]" >&2
-  echo "  epics: harness  atlas  hramatka  bio  folk  corpus  (see docs/runbooks/epic-orchestrator-roster.md)" >&2
+  echo "  epics: harness  infra  devops  atlas  hramatka  bio  folk  corpus  (see docs/runbooks/epic-orchestrator-roster.md)" >&2
   exit 2
 fi
 EPIC="$1"; shift

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -19,6 +19,7 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _HOOK_TEST = _REPO_ROOT / "scripts" / "audit" / "test_handoff_identity.sh"
+_HANDOFF_IDENTITY = _REPO_ROOT / "scripts" / "lib" / "handoff_identity.sh"
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
@@ -36,3 +37,24 @@ def test_handoff_identity_fixtures() -> None:
         f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
     )
     assert "ok - handoff identity fixtures passed" in result.stdout
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.parametrize(
+    ("resolver", "expected"),
+    [
+        ("handoff_identity_for_epic", "claude-infra"),
+        ("handoff_identity_for_gemini_epic", "gemini-infra"),
+        ("handoff_identity_for_codex_epic", "codex-infra"),
+    ],
+)
+def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: str) -> None:
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; "$2" devops', "bash", str(_HANDOFF_IDENTITY), resolver],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == expected

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -251,6 +251,15 @@ def test_epic_harness_derives_gemini_infra_handoff(tmp_path: Path) -> None:
     assert ".agent/gemini-infra-thread-handoff.md" in prompt
 
 
+def test_epic_devops_uses_canonical_infra_stream_and_handoff(tmp_path: Path) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", "devops"])
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "devops"
+    assert values["handoff"] == "gemini-infra"
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    stream_index = supervisor_args.index("--stream")
+    assert supervisor_args[stream_index + 1] == "epic:4707"
+
 
 def test_epic_equals_form_and_explicit_prompt_uses_interactive_prompt(tmp_path: Path) -> None:
     values, argv_blob, result, _project, _supervisor_capture = _run_launcher(

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -338,3 +338,16 @@ def test_epic_harness_cold_prompt_is_fleet_comms_dual_aware(tmp_path: Path) -> N
     out = result.stdout
     assert "Starting Grok in Learn Ukrainian project..." not in out
     assert "plane=off" in out
+
+
+def test_epic_devops_uses_canonical_infra_stream_and_handoff(tmp_path: Path) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(
+        tmp_path,
+        ["--epic", "devops"],
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "devops"
+    assert values["handoff"] == "grok-infra"
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    stream_index = supervisor_args.index("--stream")
+    assert supervisor_args[stream_index + 1] == "epic:4707"


### PR DESCRIPTION
Closes #5512

- Enables ./start-*-drive.sh devops
- Maps devops to canonical infra handoff slots
- Updates roster documentation and test coverage