### PR TITLE
fix(ci): make Atlas manifest freshness gate PR-scoped (#5147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,7 +472,15 @@ jobs:
           .venv/bin/python -m pip install PyYAML
 
       - name: Check DB-free Atlas manifest freshness
-        run: .venv/bin/python scripts/lexicon/check_manifest_freshness.py
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            .venv/bin/python scripts/lexicon/check_manifest_freshness.py \
+              --pr-scoped \
+              --base-ref "${{ github.event.pull_request.base.sha }}" \
+              --head-ref "${{ github.event.pull_request.head.sha }}"
+          else
+            .venv/bin/python scripts/lexicon/check_manifest_freshness.py
+          fi
 
       # Root-cause guard for the #3631 empty-atlas regression: a manifest committed
       # without enrichment (enrichment_generated False / ~0 enriched entries) renders

--- a/scripts/lexicon/check_manifest_freshness.py
+++ b/scripts/lexicon/check_manifest_freshness.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -14,15 +16,46 @@ if str(ROOT) not in sys.path:
 
 from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, build_fingerprint
 
+LEXICON_PATH_PREFIX = "scripts/lexicon/"
+FINGERPRINT_SIDECAR_PATH = "site/src/data/lexicon-manifest.fingerprint.json"
+GIT_SCOPE_ENV_VARS = ("GIT_COMMON_DIR", "GIT_DIR", "GIT_INDEX_FILE", "GIT_PREFIX", "GIT_WORK_TREE")
+
 
 def _load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _git_env() -> dict[str, str]:
+    """Return an environment that lets Git resolve the requested repository."""
+    env = os.environ.copy()
+    for name in GIT_SCOPE_ENV_VARS:
+        env.pop(name, None)
+    return env
+
+
+def pr_touches_manifest_scope(*, root: Path, base_ref: str, head_ref: str = "HEAD") -> bool:
+    """Return whether a PR changes lexicon code or the fingerprint sidecar."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--no-renames", base_ref, head_ref, "--"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_git_env(),
+    )
+    return any(
+        path.startswith(LEXICON_PATH_PREFIX) or path == FINGERPRINT_SIDECAR_PATH
+        for path in result.stdout.splitlines()
+    )
 
 
 def check_freshness(
     *,
     root: Path = ROOT,
     fingerprint_path: Path = DEFAULT_FINGERPRINT,
+    pr_scoped: bool = False,
+    base_ref: str = "origin/main",
+    head_ref: str = "HEAD",
 ) -> int:
     current = build_fingerprint(root)
     if not fingerprint_path.exists():
@@ -35,6 +68,27 @@ def check_freshness(
 
     committed = _load_json(fingerprint_path)
     if committed.get("fingerprint") != current["fingerprint"]:
+        if pr_scoped:
+            try:
+                touches_manifest_scope = pr_touches_manifest_scope(
+                    root=root,
+                    base_ref=base_ref,
+                    head_ref=head_ref,
+                )
+            except subprocess.CalledProcessError as error:
+                print(
+                    "::error::Atlas manifest freshness could not determine PR-scoped "
+                    f"changes against {base_ref!r}: {error.stderr.strip()}"
+                )
+                return 2
+            if not touches_manifest_scope:
+                print(
+                    "::notice::Atlas manifest freshness sidecar differs, but this PR "
+                    "does not modify lexicon code or the fingerprint sidecar "
+                    f"relative to {base_ref}; "
+                    "allowing unrelated drift."
+                )
+                return 0
         print(
             "::error::Atlas manifest stale vs lexicon code; "
             "run `make atlas` locally and commit the updated manifest + fingerprint."
@@ -62,12 +116,33 @@ def main() -> int:
         default=DEFAULT_FINGERPRINT,
         help="Committed fingerprint sidecar.",
     )
+    parser.add_argument(
+        "--pr-scoped",
+        action="store_true",
+        help="Allow stale sidecars only when this PR did not change scripts/lexicon/.",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Git base ref used by --pr-scoped (default: origin/main).",
+    )
+    parser.add_argument(
+        "--head-ref",
+        default="HEAD",
+        help="Git head ref used by --pr-scoped (default: HEAD).",
+    )
     args = parser.parse_args()
     root = args.root.resolve()
     fingerprint = args.fingerprint
     if not fingerprint.is_absolute():
         fingerprint = root / fingerprint
-    return check_freshness(root=root, fingerprint_path=fingerprint)
+    return check_freshness(
+        root=root,
+        fingerprint_path=fingerprint,
+        pr_scoped=args.pr_scoped,
+        base_ref=args.base_ref,
+        head_ref=args.head_ref,
+    )
 
 
 if __name__ == "__main__":

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "d875d8b7b582e307b4de97d442bf5f2107be64c4af6c667505eda95d92d16daf",
+  "fingerprint": "c45805af37531c74b972a3eb8bc7be3614a3565ef2cca547c7769ba605ba12d5",
   "inputs": {
     "lexicon_code": [
       {
@@ -48,7 +48,7 @@
       },
       {
         "path": "scripts/lexicon/check_manifest_freshness.py",
-        "sha256": "eaafd2f61e199ff9f56cfe114a683533aad908d92f97cb2791eadb9560e9d0a9"
+        "sha256": "8918fff75c16bb38c28e469f3ccc415e4141f777de3ca8a3d819aca78e19aaa6"
       },
       {
         "path": "scripts/lexicon/check_manifest_vocabulary_coverage.py",

--- a/tests/test_lexicon_manifest_fingerprint.py
+++ b/tests/test_lexicon_manifest_fingerprint.py
@@ -1,7 +1,13 @@
 import json
+import os
+import subprocess
 from pathlib import Path
 
-from scripts.lexicon.check_manifest_freshness import check_freshness
+from scripts.lexicon.check_manifest_freshness import (
+    GIT_SCOPE_ENV_VARS,
+    check_freshness,
+    pr_touches_manifest_scope,
+)
 from scripts.lexicon.check_manifest_vocabulary_coverage import check_vocabulary_coverage
 from scripts.lexicon.manifest_fingerprint import build_fingerprint, write_fingerprint
 
@@ -21,6 +27,29 @@ def _fixture_repo(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     return root
+
+
+def _git(root: Path, *args: str) -> None:
+    env = os.environ.copy()
+    for name in GIT_SCOPE_ENV_VARS:
+        env.pop(name, None)
+    subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _commit_fixture_repo(root: Path) -> None:
+    _git(root, "init", "--quiet", "-b", "main")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    _git(root, "add", ".")
+    _git(root, "commit", "--quiet", "-m", "base")
+    _git(root, "branch", "base")
 
 
 def _write_manifest(root: Path, entries: list[dict]) -> Path:
@@ -134,6 +163,64 @@ def test_manifest_freshness_check_fails_on_mismatched_sidecar(tmp_path: Path, ca
     output = capsys.readouterr().out
     assert "Atlas manifest stale vs lexicon code" in output
     assert "dictionary DB/cache version drift is out of scope" in output
+
+
+def test_pr_scoped_freshness_allows_unrelated_drift(tmp_path: Path, capsys) -> None:
+    root = _fixture_repo(tmp_path)
+    sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
+    write_fingerprint(sidecar, root=root)
+    _commit_fixture_repo(root)
+    (root / "README.md").write_text("unrelated PR change\n", encoding="utf-8")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "--quiet", "-m", "docs change")
+    (root / "scripts" / "lexicon" / "beta.py").write_text("VALUE = 200\n", encoding="utf-8")
+
+    assert pr_touches_manifest_scope(root=root, base_ref="base") is False
+    assert check_freshness(
+        root=root,
+        fingerprint_path=sidecar,
+        pr_scoped=True,
+        base_ref="base",
+    ) == 0
+    assert "allowing unrelated drift" in capsys.readouterr().out
+
+
+def test_pr_scoped_freshness_fails_when_pr_changes_lexicon(tmp_path: Path, capsys) -> None:
+    root = _fixture_repo(tmp_path)
+    sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
+    write_fingerprint(sidecar, root=root)
+    _commit_fixture_repo(root)
+    (root / "scripts" / "lexicon" / "beta.py").write_text("VALUE = 200\n", encoding="utf-8")
+    _git(root, "add", "scripts/lexicon/beta.py")
+    _git(root, "commit", "--quiet", "-m", "lexicon change")
+
+    assert pr_touches_manifest_scope(root=root, base_ref="base") is True
+    assert check_freshness(
+        root=root,
+        fingerprint_path=sidecar,
+        pr_scoped=True,
+        base_ref="base",
+    ) == 2
+    assert "Atlas manifest stale vs lexicon code" in capsys.readouterr().out
+
+
+def test_pr_scoped_freshness_fails_when_pr_changes_sidecar(tmp_path: Path, capsys) -> None:
+    root = _fixture_repo(tmp_path)
+    sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
+    write_fingerprint(sidecar, root=root)
+    _commit_fixture_repo(root)
+    sidecar.write_text('{"fingerprint": "stale"}\n', encoding="utf-8")
+    _git(root, "add", sidecar.relative_to(root).as_posix())
+    _git(root, "commit", "--quiet", "-m", "sidecar change")
+
+    assert pr_touches_manifest_scope(root=root, base_ref="base") is True
+    assert check_freshness(
+        root=root,
+        fingerprint_path=sidecar,
+        pr_scoped=True,
+        base_ref="base",
+    ) == 2
+    assert "Atlas manifest stale vs lexicon code" in capsys.readouterr().out
 
 
 def test_manifest_vocabulary_coverage_fails_when_new_vocab_lemma_missing(


### PR DESCRIPTION
Closes #5147

- Adds --pr-scoped mode to check_manifest_freshness.py
- Prevents serial PR invalidation when unrelated PRs exist concurrently
- Expands test coverage