### PR TITLE
fix(infra): map devops epic slug to stream epic:5512 to prevent lease collisions (#5512)

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -29,7 +29,8 @@ The registry `scripts/config/issue_streams.yaml` is the single source of truth (
 | atlas-practice | #4387 → #4700 | Word Atlas + Practice Hub product & UX |
 | atlas-intake | #4220, #4378 | Full-corpus intake into the Atlas |
 | corpus-channels | #4706 | Acquisition & ingestion (textbooks · ZNO · Ohoiko-media · press · academic) |
-| infra-harness | #4707 | Infra, DevOps & fleet reliability (hooks, deps, dispatch, routing) |
+| infra-harness | #4707 | Infrastructure & harness reliability (hooks, deps, dispatch, routing) |
+| devops | #5512 | Fleet-Comms DevOps coordination |
 | eval-harness | #4913 | UA eval harness: QG grounding/entailment gates, grammar-lexical gate, annotation, bakeoffs, cutovers |
 | benchmark-2156 | #4639 | UA LLM factuality benchmark community release |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -58,6 +58,7 @@ eq "$(handoff_identity_for_epic hramatka)" "claude-hramatka" "epic hramatka → 
 eq "$(handoff_identity_for_epic harness)" "claude-infra" "epic harness → claude-infra (#5201)"
 eq "$(handoff_identity_for_epic infra)" "claude-infra" "epic infra → claude-infra alias"
 eq "$(handoff_identity_for_epic devops)" "claude-infra" "epic devops → claude-infra alias"
+eq "$(handoff_identity_for_epic fleet-comms)" "claude-infra" "epic fleet-comms → claude-infra alias"
 eq "$(handoff_identity_for_epic)" "" "no epic → empty slot"
 
 # Codex uses provider-specific per-epic slots; harness/infra/devops share one alias.

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -19,8 +19,11 @@ streams:
     title: "Corpus channels — acquisition & ingestion"
     epics: [4706]
   infra-harness:
-    title: "Infra, DevOps & fleet reliability (hooks, deps, dispatch, routing)"
+    title: "Infrastructure & harness reliability (hooks, deps, dispatch, routing)"
     epics: [4707]
+  devops:
+    title: "Fleet-Comms DevOps coordination"
+    epics: [5512]
   eval-harness:
     title: "UA eval harness — QG gates, grammar-lexical gate, annotation, bakeoffs"
     epics: [4913]

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -131,13 +131,14 @@ epic_name_valid() {
 # Canonical-slot aliases: some epics are NOT free-standing lanes — they already
 # have a durable handoff identity elsewhere. Mapping them to a phantom
 # claude-<epic> slot hides live packets and causes silent cold starts (#5201).
-# harness/infra/devops (infra, DevOps & fleet reliability) → claude-infra, the same
-# slot as --agent infra-orchestrator (lineage dir, session-state, inbox).
+# harness/infra → claude-infra, the same slot as --agent infra-orchestrator
+# (lineage dir, session-state, inbox). devops/fleet-comms use the Fleet-Comms
+# stream (epic:5512) but deliberately retain that canonical infra handoff slot.
 handoff_identity_for_epic() {
   local epic="${1:-}"
   [ -n "$epic" ] || return 0
   case "$epic" in
-    harness|infra|devops) printf '%s' 'claude-infra' ;;
+    harness|infra|devops|fleet-comms) printf '%s' 'claude-infra' ;;
     *) printf 'claude-%s' "$epic" ;;
   esac
 }

--- a/scripts/lib/session_supervisor.sh
+++ b/scripts/lib/session_supervisor.sh
@@ -24,7 +24,8 @@
 stream_id_for_epic() {
   case "${1:-}" in
     atlas|practice|practice-hub) printf '%s' 'epic:4387' ;;
-    harness|infra|devops) printf '%s' 'epic:4707' ;;
+    harness|infra) printf '%s' 'epic:4707' ;;
+    devops|fleet-comms) printf '%s' 'epic:5512' ;;
     hramatka) printf '%s' 'epic:4542' ;;
     folk|seminars-folk) printf '%s' 'epic:2836' ;;
     bio|seminars-bio) printf '%s' 'epic:4431' ;;

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -58,3 +58,22 @@ def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: 
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout == expected
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_fleet_comms_alias_resolves_to_canonical_infra_slot() -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; handoff_identity_for_epic fleet-comms',
+            "bash",
+            str(_HANDOFF_IDENTITY),
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "claude-infra"

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -251,14 +251,14 @@ def test_epic_harness_derives_gemini_infra_handoff(tmp_path: Path) -> None:
     assert ".agent/gemini-infra-thread-handoff.md" in prompt
 
 
-def test_epic_devops_uses_canonical_infra_stream_and_handoff(tmp_path: Path) -> None:
+def test_epic_devops_uses_dedicated_fleet_comms_stream_and_infra_handoff(tmp_path: Path) -> None:
     values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", "devops"])
     assert result.returncode == 0, result.stderr + result.stdout
     assert values["session_epic"] == "devops"
     assert values["handoff"] == "gemini-infra"
     supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
     stream_index = supervisor_args.index("--stream")
-    assert supervisor_args[stream_index + 1] == "epic:4707"
+    assert supervisor_args[stream_index + 1] == "epic:5512"
 
 
 def test_epic_equals_form_and_explicit_prompt_uses_interactive_prompt(tmp_path: Path) -> None:

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -340,7 +340,15 @@ def test_epic_harness_cold_prompt_is_fleet_comms_dual_aware(tmp_path: Path) -> N
     assert "plane=off" in out
 
 
-def test_epic_devops_uses_canonical_infra_stream_and_handoff(tmp_path: Path) -> None:
+def test_epic_devops_uses_dedicated_stream_without_harness_lease_collision(tmp_path: Path) -> None:
+    harness_tmp = tmp_path / "harness"
+    harness_tmp.mkdir()
+    harness_values, _argv_blob, harness_result, _project, harness_capture = _run_launcher(
+        harness_tmp,
+        ["--epic", "harness"],
+    )
+    assert harness_result.returncode == 0, harness_result.stderr + harness_result.stdout
+
     values, _argv_blob, result, _project, supervisor_capture = _run_launcher(
         tmp_path,
         ["--epic", "devops"],
@@ -348,6 +356,11 @@ def test_epic_devops_uses_canonical_infra_stream_and_handoff(tmp_path: Path) -> 
     assert result.returncode == 0, result.stderr + result.stdout
     assert values["session_epic"] == "devops"
     assert values["handoff"] == "grok-infra"
+    assert harness_values["session_stream"] == "epic:4707"
+    assert values["session_stream"] == "epic:5512"
+    assert values["session_stream"] != harness_values["session_stream"]
+    harness_args = harness_capture.read_text(encoding="utf-8").splitlines()
+    assert harness_args[harness_args.index("--stream") + 1] == "epic:4707"
     supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
     stream_index = supervisor_args.index("--stream")
-    assert supervisor_args[stream_index + 1] == "epic:4707"
+    assert supervisor_args[stream_index + 1] == "epic:5512"


### PR DESCRIPTION
Closes #5512

- Maps devops to epic:5512
- Allows concurrent Sonnet devops driver alongside Gemini harness driver
- Expands test coverage