### PR TITLE
feat(infra): add Sol-approved launcher CLI dot-notation selectors (#5512)

### DIFF
--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -44,20 +44,27 @@ eq "$(handoff_identity_for_agent "$agent")" "claude-infra" "e2e: --agent infra-o
 agent="$(handoff_agent_from_argv --chrome --agent curriculum-orchestrator)"
 eq "$(handoff_identity_for_agent "$agent")" "" "e2e: --agent curriculum-orchestrator → default claude"
 
-# --- epic argv extraction: spaced + equals forms, .epic suffix normalized ---
+# --- epic argv extraction: spaced + equals forms; legacy suffix remains supported ---
 eq "$(handoff_epic_from_argv --agent curriculum-orchestrator --epic atlas)" "atlas" "spaced --epic"
 eq "$(handoff_epic_from_argv --epic=hramatka)" "hramatka" "equals --epic"
-eq "$(handoff_epic_from_argv --epic atlas.epic)" "atlas" "spaced --epic with .epic suffix"
-eq "$(handoff_epic_from_argv --epic=harness.epic)" "harness" "equals --epic with .epic suffix"
+eq "$(handoff_epic_from_argv --epic atlas.epic)" "atlas" "spaced --epic with legacy suffix"
+eq "$(handoff_epic_from_argv --epic=harness.epic)" "harness" "equals --epic with legacy suffix"
 eq "$(handoff_epic_from_argv --agent curriculum-orchestrator)" "" "no --epic flag"
 eq "$(handoff_epic_from_argv)" "" "empty argv (epic)"
 
-# --- epic → slot mapping: epic beats agent-type; empty epic maps to nothing ---
+# --- selector → canonical lane, stream, and provider slot mapping ---
+eq "$(launcher_selector_lane infra.fleet-comms)" "infra" "fleet-comms resolves to infra"
+eq "$(launcher_selector_stream infra.devops)" "epic:4707" "devops resolves to infra stream"
+eq "$(launcher_selector_lane atlas.practice)" "atlas" "atlas practice resolves to atlas"
+eq "$(launcher_selector_stream hramatka.lessons)" "epic:4542" "hramatka lessons resolves"
+launcher_selector_resolve unknown && fail "unknown selector must fail closed"
+
+# --- selector → slot mapping: selector beats agent-type; empty selector maps to nothing ---
 eq "$(handoff_identity_for_epic atlas)" "claude-atlas" "epic atlas → claude-atlas"
 eq "$(handoff_identity_for_epic hramatka)" "claude-hramatka" "epic hramatka → claude-hramatka"
 eq "$(handoff_identity_for_epic harness)" "claude-infra" "epic harness → claude-infra (#5201)"
 eq "$(handoff_identity_for_epic infra)" "claude-infra" "epic infra → claude-infra alias"
-eq "$(handoff_identity_for_epic devops)" "claude-infra" "epic devops → claude-infra alias"
+eq "$(handoff_identity_for_epic infra.devops)" "claude-infra" "dot devops → claude-infra alias"
 eq "$(handoff_identity_for_epic)" "" "no epic → empty slot"
 
 # Codex uses provider-specific per-epic slots; harness/infra/devops share one alias.
@@ -65,7 +72,7 @@ eq "$(handoff_identity_for_codex_epic atlas)" "codex-atlas" "Codex atlas → cod
 eq "$(handoff_identity_for_codex_epic hramatka)" "codex-hramatka" "Codex hramatka → codex-hramatka"
 eq "$(handoff_identity_for_codex_epic harness)" "codex-infra" "Codex harness → codex-infra"
 eq "$(handoff_identity_for_codex_epic infra)" "codex-infra" "Codex infra → codex-infra alias"
-eq "$(handoff_identity_for_codex_epic devops)" "codex-infra" "Codex devops → codex-infra alias"
+eq "$(handoff_identity_for_codex_epic infra.devops)" "codex-infra" "Codex dot devops → codex-infra alias"
 eq "$(handoff_identity_for_codex_epic)" "" "Codex no epic → empty slot"
 
 # Gemini uses provider-specific per-epic slots; harness/infra/devops share one alias.
@@ -73,7 +80,7 @@ eq "$(handoff_identity_for_gemini_epic atlas)" "gemini-atlas" "Gemini atlas → 
 eq "$(handoff_identity_for_gemini_epic hramatka)" "gemini-hramatka" "Gemini hramatka → gemini-hramatka"
 eq "$(handoff_identity_for_gemini_epic harness)" "gemini-infra" "Gemini harness → gemini-infra"
 eq "$(handoff_identity_for_gemini_epic infra)" "gemini-infra" "Gemini infra → gemini-infra alias"
-eq "$(handoff_identity_for_gemini_epic devops)" "gemini-infra" "Gemini devops → gemini-infra alias"
+eq "$(handoff_identity_for_gemini_epic infra.devops)" "gemini-infra" "Gemini dot devops → gemini-infra alias"
 eq "$(handoff_identity_for_gemini_epic)" "" "Gemini no epic → empty slot"
 
 

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -57,6 +57,11 @@ eq "$(launcher_selector_lane infra.fleet-comms)" "infra" "fleet-comms resolves t
 eq "$(launcher_selector_stream infra.devops)" "epic:4707" "devops resolves to infra stream"
 eq "$(launcher_selector_lane atlas.practice)" "atlas" "atlas practice resolves to atlas"
 eq "$(launcher_selector_stream hramatka.lessons)" "epic:4542" "hramatka lessons resolves"
+# corpus is a documented, currently-recommended driver epic
+# (docs/runbooks/epic-orchestrator-roster.md: `./start-gemini-drive.sh corpus`) — it must
+# stay in the allowlist alongside infra/atlas/hramatka/folk/bio.
+eq "$(launcher_selector_lane corpus)" "corpus" "corpus resolves to corpus lane"
+eq "$(launcher_selector_stream corpus-channels)" "epic:4706" "corpus-channels resolves to corpus stream"
 launcher_selector_resolve unknown && fail "unknown selector must fail closed"
 
 # --- selector → slot mapping: selector beats agent-type; empty selector maps to nothing ---

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -25,7 +25,7 @@ launcher_selector_resolve() {
     infra|harness|infra.fleet-comms|infra.devops)
       printf 'infra\tepic:4707\n'
       ;;
-    atlas|practice|atlas.practice)
+    atlas|practice|practice-hub|atlas.practice)
       printf 'atlas\tepic:4387\n'
       ;;
     hramatka|hramatka.lessons)

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -12,8 +12,64 @@
 # selected --agent, so each lane reads/writes its OWN slot and we don't maintain
 # a per-lane wrapper script.
 #
-# Add a new lane by adding ONE case arm to handoff_identity_for_agent below.
-# Unknown / absent agents fall back to the default `claude` slot (echo nothing).
+# Launcher lane selectors are intentionally allowlisted below.  Do not derive a
+# slot or stream id from arbitrary user input: that creates phantom handoff
+# files and can silently attach a session to the wrong stream.
+
+# launcher_selector_resolve "<lane-or-lane.topic>"
+# Print the canonical lane and stream id, separated by a tab.  This is the
+# single selector table shared by handoff identities and session supervision.
+# Unknown selectors return 1 and print nothing, so callers can fail closed.
+launcher_selector_resolve() {
+  case "${1:-}" in
+    infra|harness|infra.fleet-comms|infra.devops)
+      printf 'infra\tepic:4707\n'
+      ;;
+    atlas|practice|atlas.practice)
+      printf 'atlas\tepic:4387\n'
+      ;;
+    hramatka|hramatka.lessons)
+      printf 'hramatka\tepic:4542\n'
+      ;;
+    folk|seminars-folk)
+      printf 'folk\tepic:2836\n'
+      ;;
+    bio|seminars-bio)
+      printf 'bio\tepic:4431\n'
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# launcher_selector_lane "<selector>"
+# Print the canonical lane for a selector.
+launcher_selector_lane() {
+  local resolved=''
+  resolved="$(launcher_selector_resolve "${1:-}")" || return 1
+  printf '%s' "${resolved%%$'\t'*}"
+}
+
+# launcher_selector_stream "<selector>"
+# Print the canonical stream id for a selector.
+launcher_selector_stream() {
+  local resolved=''
+  resolved="$(launcher_selector_resolve "${1:-}")" || return 1
+  printf '%s' "${resolved#*$'\t'}"
+}
+
+# launcher_selector_help
+# Keep launcher diagnostics in one place so every entry point documents the
+# exact same public selector surface.
+launcher_selector_help() {
+  cat <<'EOF'
+Valid lane selectors:
+  infra | harness | infra.fleet-comms | infra.devops
+  atlas | practice | atlas.practice
+  hramatka | hramatka.lessons
+  folk | seminars-folk
+  bio | seminars-bio
+EOF
+}
 
 # handoff_agent_from_argv "$@"
 # Echo the value of `--agent <v>` / `--agent=<v>` from an argv list, or nothing.
@@ -50,8 +106,8 @@ handoff_identity_for_agent() {
 # handoff_epic_from_argv "$@"
 # Echo the value of `--epic <v>` / `--epic=<v>` from an argv list, or nothing.
 # `--epic` is a LAUNCHER flag, not a claude CLI flag: the caller must ALSO
-# strip it from the argv it forwards (see strip_epic_from_argv). Accepts both
-# `atlas` and `atlas.epic` spellings; a `.epic` suffix is dropped.
+# strip it from the argv it forwards (see strip_epic_from_argv).  The legacy
+# `.epic` display suffix is removed before launchers resolve the selector.
 # First occurrence wins.
 handoff_epic_from_argv() {
   local prev='' arg='' value=''
@@ -123,23 +179,14 @@ epic_name_valid() {
 }
 
 # handoff_identity_for_epic "<epic-name>"
-# Echo the per-epic SESSION_HANDOFF_AGENT slot, or nothing when no epic is given.
-# Default: claude-<epic>. An explicit epic BEATS the agent-type mapping so two
-# sessions of the same agent type on different epics never share a handoff slot
-# (root cause of the 2026-07-13 atlas/hramatka/main lane collision).
-#
-# Canonical-slot aliases: some epics are NOT free-standing lanes — they already
-# have a durable handoff identity elsewhere. Mapping them to a phantom
-# claude-<epic> slot hides live packets and causes silent cold starts (#5201).
-# harness/infra/devops (infra, DevOps & fleet reliability) → claude-infra, the same
-# slot as --agent infra-orchestrator (lineage dir, session-state, inbox).
+# Echo the allowlisted per-lane SESSION_HANDOFF_AGENT slot, or nothing when no
+# selector is given. An explicit selector beats the agent-type mapping so two
+# sessions on different lanes never share a handoff slot.
 handoff_identity_for_epic() {
-  local epic="${1:-}"
-  [ -n "$epic" ] || return 0
-  case "$epic" in
-    harness|infra|devops) printf '%s' 'claude-infra' ;;
-    *) printf 'claude-%s' "$epic" ;;
-  esac
+  local lane=''
+  [ -n "${1:-}" ] || return 0
+  lane="$(launcher_selector_lane "$1")" || return 1
+  printf 'claude-%s' "$lane"
 }
 
 # handoff_identity_for_codex_epic "<epic-name>"
@@ -148,34 +195,37 @@ handoff_identity_for_epic() {
 # never adopts a Claude packet. The infra alias mirrors the canonical
 # claude-infra convention and avoids inventing parallel harness/infra slots.
 handoff_identity_for_codex_epic() {
-  local epic="${1:-}"
-  [ -n "$epic" ] || return 0
-  case "$epic" in
-    harness|infra|devops) printf '%s' 'codex-infra' ;;
-    *) printf 'codex-%s' "$epic" ;;
-  esac
+  local lane=''
+  [ -n "${1:-}" ] || return 0
+  lane="$(launcher_selector_lane "$1")" || return 1
+  printf 'codex-%s' "$lane"
 }
 
 # handoff_identity_for_kimi_epic "<epic-name>"
 # Echo the per-epic Kimi Code orchestrator rollover slot. Provider-specific so
 # a Kimi seat never adopts Claude/Codex/Grok packets. harness/infra/devops → kimi-infra.
 handoff_identity_for_kimi_epic() {
-  local epic="${1:-}"
-  [ -n "$epic" ] || return 0
-  case "$epic" in
-    harness|infra|devops) printf '%s' 'kimi-infra' ;;
-    *) printf 'kimi-%s' "$epic" ;;
-  esac
+  local lane=''
+  [ -n "${1:-}" ] || return 0
+  lane="$(launcher_selector_lane "$1")" || return 1
+  printf 'kimi-%s' "$lane"
 }
 
 # handoff_identity_for_gemini_epic "<epic-name>"
 # Echo the per-epic Gemini / Antigravity orchestrator rollover slot. Provider-specific so
 # a Gemini seat never adopts Claude/Codex/Grok/Kimi packets. harness/infra/devops → gemini-infra.
 handoff_identity_for_gemini_epic() {
-  local epic="${1:-}"
-  [ -n "$epic" ] || return 0
-  case "$epic" in
-    harness|infra|devops) printf '%s' 'gemini-infra' ;;
-    *) printf 'gemini-%s' "$epic" ;;
-  esac
+  local lane=''
+  [ -n "${1:-}" ] || return 0
+  lane="$(launcher_selector_lane "$1")" || return 1
+  printf 'gemini-%s' "$lane"
+}
+
+# handoff_identity_for_grok_epic "<selector>"
+# Grok uses the same canonical selector table as the other launchers.
+handoff_identity_for_grok_epic() {
+  local lane=''
+  [ -n "${1:-}" ] || return 0
+  lane="$(launcher_selector_lane "$1")" || return 1
+  printf 'grok-%s' "$lane"
 }

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -22,7 +22,7 @@
 # Unknown selectors return 1 and print nothing, so callers can fail closed.
 launcher_selector_resolve() {
   case "${1:-}" in
-    infra|harness|infra.fleet-comms|infra.devops)
+    infra|harness|devops|infra.fleet-comms|infra.devops)
       printf 'infra\tepic:4707\n'
       ;;
     atlas|practice|practice-hub|atlas.practice)

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -37,6 +37,9 @@ launcher_selector_resolve() {
     bio|seminars-bio)
       printf 'bio\tepic:4431\n'
       ;;
+    corpus|corpus-channels)
+      printf 'corpus\tepic:4706\n'
+      ;;
     *) return 1 ;;
   esac
 }
@@ -68,6 +71,7 @@ Valid lane selectors:
   hramatka | hramatka.lessons
   folk | seminars-folk
   bio | seminars-bio
+  corpus | corpus-channels
 EOF
 }
 

--- a/scripts/lib/session_supervisor.sh
+++ b/scripts/lib/session_supervisor.sh
@@ -17,18 +17,28 @@
 # The helper fails the launch closed (exit 1) if the supervisor returns an
 # error or if the exported lease envelope is incomplete.
 
-# stream_id_for_epic <epic-name>
-# Return the canonical session stream id (epic:<n>) for a launcher shorthand.
-# This is intentionally a small, stable launcher lookup; the authoritative
-# stream→epic mapping lives in scripts/config/issue_streams.yaml.
+# Load the selector SSOT when this helper is sourced independently.  The
+# launcher normally sources handoff_identity.sh first; this guarded import also
+# keeps stream resolution available to direct session-supervisor consumers.
+if ! declare -F launcher_selector_stream >/dev/null 2>&1; then
+  _session_supervisor_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ -f "$_session_supervisor_lib_dir/handoff_identity.sh" ]; then
+    # shellcheck source=scripts/lib/handoff_identity.sh
+    source "$_session_supervisor_lib_dir/handoff_identity.sh"
+  fi
+  unset _session_supervisor_lib_dir
+fi
+
+# stream_id_for_epic <lane-or-lane.topic>
+# Return the canonical session stream id.  The exact allowlist lives in
+# launcher_selector_resolve in handoff_identity.sh; unknown selectors return
+# empty and must be rejected by callers.
 stream_id_for_epic() {
-  case "${1:-}" in
-    atlas|practice|practice-hub) printf '%s' 'epic:4387' ;;
-    harness|infra|devops) printf '%s' 'epic:4707' ;;
-    hramatka) printf '%s' 'epic:4542' ;;
-    folk|seminars-folk) printf '%s' 'epic:2836' ;;
-    bio|seminars-bio) printf '%s' 'epic:4431' ;;
-  esac
+  if declare -F launcher_selector_stream >/dev/null 2>&1; then
+    launcher_selector_stream "${1:-}"
+  else
+    return 1
+  fi
 }
 
 # _git_env

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -22,6 +22,7 @@ Valid lane selectors:
   hramatka | hramatka.lessons
   folk | seminars-folk
   bio | seminars-bio
+  corpus | corpus-channels
 EOF
 }
 
@@ -282,7 +283,7 @@ if command -v handoff_epic_from_argv >/dev/null 2>&1; then
             exit 1
         fi
         case "$_requested_selector" in
-            *.*|practice|practice-hub|seminars-folk|seminars-bio|corpus-channels) _selected_epic="$_canonical_lane" ;;
+            *.*|devops|practice|practice-hub|seminars-folk|seminars-bio|corpus-channels) _selected_epic="$_canonical_lane" ;;
         esac
         unset _requested_selector _canonical_lane
         export SESSION_EPIC="$_selected_epic"

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -282,7 +282,7 @@ if command -v handoff_epic_from_argv >/dev/null 2>&1; then
             exit 1
         fi
         case "$_requested_selector" in
-            *.*) _selected_epic="$_canonical_lane" ;;
+            *.*|practice|practice-hub|seminars-folk|seminars-bio) _selected_epic="$_canonical_lane" ;;
         esac
         unset _requested_selector _canonical_lane
         export SESSION_EPIC="$_selected_epic"

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -282,7 +282,7 @@ if command -v handoff_epic_from_argv >/dev/null 2>&1; then
             exit 1
         fi
         case "$_requested_selector" in
-            *.*|practice|practice-hub|seminars-folk|seminars-bio) _selected_epic="$_canonical_lane" ;;
+            *.*|practice|practice-hub|seminars-folk|seminars-bio|corpus-channels) _selected_epic="$_canonical_lane" ;;
         esac
         unset _requested_selector _canonical_lane
         export SESSION_EPIC="$_selected_epic"

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -11,6 +11,46 @@ hash -r 2>/dev/null || true  # Clear command cache
 # Get script directory (project root)
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+launcher_usage() {
+    cat <<'EOF'
+Usage: ./start-claude.sh [Claude flags] [--epic <lane-or-lane.topic>]
+
+`--epic` is launcher-only and is removed before Claude starts.
+Valid lane selectors:
+  infra | harness | infra.fleet-comms | infra.devops
+  atlas | practice | atlas.practice
+  hramatka | hramatka.lessons
+  folk | seminars-folk
+  bio | seminars-bio
+EOF
+}
+
+case "${1:-}" in
+    --help|--help-launcher|-h)
+        launcher_usage
+        exit 0
+        ;;
+esac
+
+# Parse launcher-private epic selection before expensive launch preflight.  This
+# gives typos the same fail-closed diagnostic whether or not Claude is installed.
+# shellcheck source=scripts/lib/handoff_identity.sh
+source "$PROJECT_DIR/scripts/lib/handoff_identity.sh"
+if epic_flag_present "$@"; then
+    _early_selector="$(handoff_epic_from_argv "$@")"
+    if [ -z "$_early_selector" ]; then
+        echo "Error: --epic flag present but no usable value." >&2
+        launcher_selector_help >&2
+        exit 1
+    fi
+    if ! launcher_selector_resolve "$_early_selector" >/dev/null; then
+        echo "Error: unknown lane selector '$_early_selector'." >&2
+        launcher_selector_help >&2
+        exit 1
+    fi
+    unset _early_selector
+fi
+
 echo "Starting Claude in Learn Ukrainian project..."
 echo "Project: $PROJECT_DIR"
 
@@ -207,9 +247,8 @@ export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
 # a LAUNCHER-ONLY flag (stripped before exec — the claude CLI does not know it).
 # It pins the session to one epic lane: SESSION_EPIC is exported for the
 # SessionStart hook to print a binding assignment banner, and the handoff slot
-# becomes claude-<epic> (with canonical aliases: harness/infra/devops → claude-infra
-# so packets under the durable infra slot surface — #5201) so two sessions of
-# the SAME agent type on DIFFERENT epics never share (or clobber) a thread
+# becomes the canonical claude-<lane> slot (for example all infra selectors map
+# to claude-infra) so two sessions on different lanes never share (or clobber) a thread
 # handoff. Without --epic the hook tells the session to ASK the user instead of
 # defaulting to a lane — the 2026-07-13 atlas/hramatka/main lane collision is
 # the reason this exists.
@@ -236,11 +275,16 @@ if command -v handoff_epic_from_argv >/dev/null 2>&1; then
         exit 1
     fi
     if [ -n "$_selected_epic" ]; then
-        if command -v epic_name_valid >/dev/null 2>&1 && ! epic_name_valid "$_selected_epic"; then
-            echo "Error: invalid --epic name '$_selected_epic' (allowed: lowercase alnum + inner hyphens, e.g. atlas, lit-war)."
-            echo "   Refusing to launch with an ambiguous lane — fix the flag and retry."
+        _requested_selector="$_selected_epic"
+        if ! _canonical_lane="$(launcher_selector_lane "$_requested_selector")"; then
+            echo "Error: unknown lane selector '$_requested_selector'." >&2
+            launcher_selector_help >&2
             exit 1
         fi
+        case "$_requested_selector" in
+            *.*) _selected_epic="$_canonical_lane" ;;
+        esac
+        unset _requested_selector _canonical_lane
         export SESSION_EPIC="$_selected_epic"
         if command -v strip_epic_from_argv >/dev/null 2>&1; then
             _forward_args=()

--- a/start-gemini-drive.sh
+++ b/start-gemini-drive.sh
@@ -1,16 +1,32 @@
 #!/bin/bash
-# Gemini 3.6 Flash (AGY) in DRIVER mode for an epic lane.
-#   ./start-gemini-drive.sh <epic> [extra flags]    e.g.  ./start-gemini-drive.sh harness
+# Gemini 3.6 Flash (AGY) in DRIVER mode for an allowlisted lane selector.
+#   ./start-gemini-drive.sh <lane-or-lane.topic> [extra flags]
 # Which epic routes to which model? -> docs/runbooks/epic-orchestrator-roster.md
 # Thin wrapper over start-gemini.sh. The driver should load the `drive-epic` skill —
 # automatic once the cold-prompt wiring lands (follow-up PR); invoke $drive-epic
 # manually until then. This wrapper does NOT itself force the skill to load.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/handoff_identity.sh
+source "$ROOT/scripts/lib/handoff_identity.sh"
+usage() {
+  echo "Usage: $(basename "$0") <lane-or-lane.topic> [Gemini flags]"
+  launcher_selector_help
+}
 if [ $# -lt 1 ]; then
-  echo "usage: $(basename "$0") <epic> [flags]" >&2
-  echo "  epics: harness  infra  devops  atlas  hramatka  bio  folk  corpus  (see docs/runbooks/epic-orchestrator-roster.md)" >&2
+  usage >&2
   exit 2
 fi
-EPIC="$1"; shift
-exec "$ROOT/start-gemini.sh" --epic "$EPIC" "$@"
+case "$1" in
+  --help|--help-launcher|-h)
+    usage
+    exit 0
+    ;;
+esac
+SELECTOR="$1"; shift
+if ! launcher_selector_resolve "$SELECTOR" >/dev/null; then
+  echo "Error: unknown lane selector '$SELECTOR'." >&2
+  launcher_selector_help >&2
+  exit 2
+fi
+exec "$ROOT/start-gemini.sh" --epic "$SELECTOR" "$@"

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -246,7 +246,7 @@ if [ -n "$_selected_epic" ]; then
     exit 1
   fi
   case "$_requested_selector" in
-    *.*|practice|practice-hub) _selected_epic="$_canonical_lane" ;;
+    *.*|practice|practice-hub|seminars-folk|seminars-bio) _selected_epic="$_canonical_lane" ;;
   esac
   unset _requested_selector _canonical_lane
 fi

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -133,7 +133,7 @@ resolve_gemini_model_alias() {
 
 for arg in "$@"; do
   if [ "$_prev" = "--epic" ]; then
-    _selected_epic="${arg%.epic}"
+    _selected_epic="$arg"
     _prev=""
     continue
   fi
@@ -165,7 +165,6 @@ for arg in "$@"; do
       ;;
     --epic=*)
       _selected_epic="${arg#--epic=}"
-      _selected_epic="${_selected_epic%.epic}"
       continue
       ;;
     --stream)
@@ -237,12 +236,18 @@ if [ -f "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh" ]; then
   source "$PROJECT_DIR/scripts/lib/fleet_comms_cold_start.sh"
 fi
 
-# Validate epic name when the helper is present.
-if command -v epic_name_valid >/dev/null 2>&1 && [ -n "$_selected_epic" ]; then
-  if ! epic_name_valid "$_selected_epic"; then
-    echo "Error: invalid --epic name '${_selected_epic}' (lowercase alnum + inner hyphens)." >&2
+# Resolve the public selector exactly once, before deriving state or identities.
+if [ -n "$_selected_epic" ]; then
+  _requested_selector="$_selected_epic"
+  if ! _canonical_lane="$(launcher_selector_lane "$_requested_selector")"; then
+    echo "Error: unknown lane selector '${_requested_selector}'." >&2
+    launcher_selector_help >&2
     exit 1
   fi
+  case "$_requested_selector" in
+    *.*) _selected_epic="$_canonical_lane" ;;
+  esac
+  unset _requested_selector _canonical_lane
 fi
 
 if [ -n "$_selected_epic" ]; then

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -246,7 +246,7 @@ if [ -n "$_selected_epic" ]; then
     exit 1
   fi
   case "$_requested_selector" in
-    *.*|practice|practice-hub|seminars-folk|seminars-bio) _selected_epic="$_canonical_lane" ;;
+    *.*|practice|practice-hub|seminars-folk|seminars-bio|corpus-channels) _selected_epic="$_canonical_lane" ;;
   esac
   unset _requested_selector _canonical_lane
 fi

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -133,7 +133,7 @@ resolve_gemini_model_alias() {
 
 for arg in "$@"; do
   if [ "$_prev" = "--epic" ]; then
-    _selected_epic="$arg"
+    _selected_epic="${arg%.epic}"
     _prev=""
     continue
   fi
@@ -165,6 +165,7 @@ for arg in "$@"; do
       ;;
     --epic=*)
       _selected_epic="${arg#--epic=}"
+      _selected_epic="${_selected_epic%.epic}"
       continue
       ;;
     --stream)
@@ -245,7 +246,7 @@ if [ -n "$_selected_epic" ]; then
     exit 1
   fi
   case "$_requested_selector" in
-    *.*) _selected_epic="$_canonical_lane" ;;
+    *.*|practice|practice-hub) _selected_epic="$_canonical_lane" ;;
   esac
   unset _requested_selector _canonical_lane
 fi

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -246,7 +246,7 @@ if [ -n "$_selected_epic" ]; then
     exit 1
   fi
   case "$_requested_selector" in
-    *.*|practice|practice-hub|seminars-folk|seminars-bio|corpus-channels) _selected_epic="$_canonical_lane" ;;
+    *.*|devops|practice|practice-hub|seminars-folk|seminars-bio|corpus-channels) _selected_epic="$_canonical_lane" ;;
   esac
   unset _requested_selector _canonical_lane
 fi

--- a/start-grok-drive.sh
+++ b/start-grok-drive.sh
@@ -1,16 +1,32 @@
 #!/bin/bash
-# Grok 4.5 in DRIVER mode for an epic lane.
-#   ./start-grok-drive.sh <epic> [extra flags]      e.g.  ./start-grok-drive.sh atlas
+# Grok 4.5 in DRIVER mode for an allowlisted lane selector.
+#   ./start-grok-drive.sh <lane-or-lane.topic> [extra flags]
 # Which epic routes to which model? -> docs/runbooks/epic-orchestrator-roster.md
 # Thin wrapper over start-grok.sh. The driver should load the `drive-epic` skill —
 # automatic once the cold-prompt wiring lands (follow-up PR); invoke $drive-epic
 # manually until then. This wrapper does NOT itself force the skill to load.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/handoff_identity.sh
+source "$ROOT/scripts/lib/handoff_identity.sh"
+usage() {
+  echo "Usage: $(basename "$0") <lane-or-lane.topic> [Grok flags]"
+  launcher_selector_help
+}
 if [ $# -lt 1 ]; then
-  echo "usage: $(basename "$0") <epic> [flags]" >&2
-  echo "  epics: harness  infra  devops  atlas  hramatka  bio  folk  corpus  (see docs/runbooks/epic-orchestrator-roster.md)" >&2
+  usage >&2
   exit 2
 fi
-EPIC="$1"; shift
-exec "$ROOT/start-grok.sh" --epic "$EPIC" "$@"
+case "$1" in
+  --help|--help-launcher|-h)
+    usage
+    exit 0
+    ;;
+esac
+SELECTOR="$1"; shift
+if ! launcher_selector_resolve "$SELECTOR" >/dev/null; then
+  echo "Error: unknown lane selector '$SELECTOR'." >&2
+  launcher_selector_help >&2
+  exit 2
+fi
+exec "$ROOT/start-grok.sh" --epic "$SELECTOR" "$@"

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -235,7 +235,7 @@ if [ -n "$_selected_epic" ]; then
     exit 1
   fi
   case "$_requested_selector" in
-    *.*|practice|practice-hub|seminars-folk|seminars-bio|corpus-channels) _selected_epic="$_canonical_lane" ;;
+    *.*|devops|practice|practice-hub|seminars-folk|seminars-bio|corpus-channels) _selected_epic="$_canonical_lane" ;;
   esac
   unset _requested_selector _canonical_lane
 fi

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -139,7 +139,7 @@ _prev=""
 
 for arg in "$@"; do
   if [ "$_prev" = "--epic" ]; then
-    _selected_epic="$arg"
+    _selected_epic="${arg%.epic}"
     _prev=""
     continue
   fi
@@ -164,6 +164,7 @@ for arg in "$@"; do
       ;;
     --epic=*)
       _selected_epic="${arg#--epic=}"
+      _selected_epic="${_selected_epic%.epic}"
       continue
       ;;
     --stream)
@@ -234,7 +235,7 @@ if [ -n "$_selected_epic" ]; then
     exit 1
   fi
   case "$_requested_selector" in
-    *.*) _selected_epic="$_canonical_lane" ;;
+    *.*|practice|practice-hub) _selected_epic="$_canonical_lane" ;;
   esac
   unset _requested_selector _canonical_lane
 fi

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -139,7 +139,7 @@ _prev=""
 
 for arg in "$@"; do
   if [ "$_prev" = "--epic" ]; then
-    _selected_epic="${arg%.epic}"
+    _selected_epic="$arg"
     _prev=""
     continue
   fi
@@ -164,7 +164,6 @@ for arg in "$@"; do
       ;;
     --epic=*)
       _selected_epic="${arg#--epic=}"
-      _selected_epic="${_selected_epic%.epic}"
       continue
       ;;
     --stream)
@@ -226,22 +225,25 @@ if [ -f "$PROJECT_DIR/scripts/lib/session_supervisor.sh" ]; then
   source "$PROJECT_DIR/scripts/lib/session_supervisor.sh"
 fi
 
-# Validate epic name when the helper is present.
-if command -v epic_name_valid >/dev/null 2>&1 && [ -n "$_selected_epic" ]; then
-  if ! epic_name_valid "$_selected_epic"; then
-    echo "Error: invalid --epic name '${_selected_epic}' (lowercase alnum + inner hyphens)." >&2
+# Resolve the public selector exactly once, before deriving state or identities.
+if [ -n "$_selected_epic" ]; then
+  _requested_selector="$_selected_epic"
+  if ! _canonical_lane="$(launcher_selector_lane "$_requested_selector")"; then
+    echo "Error: unknown lane selector '${_requested_selector}'." >&2
+    launcher_selector_help >&2
     exit 1
   fi
+  case "$_requested_selector" in
+    *.*) _selected_epic="$_canonical_lane" ;;
+  esac
+  unset _requested_selector _canonical_lane
 fi
 
 if [ -n "$_selected_epic" ]; then
   export SESSION_EPIC="$_selected_epic"
   # Grok-specific handoff slot (not claude-<epic>)
   if [ -z "${SESSION_HANDOFF_AGENT:-}" ] && [ -z "$_handoff_override" ]; then
-    case "$_selected_epic" in
-      harness|infra|devops) export SESSION_HANDOFF_AGENT='grok-infra' ;;
-      *) export SESSION_HANDOFF_AGENT="grok-${_selected_epic}" ;;
-    esac
+    export SESSION_HANDOFF_AGENT="$(handoff_identity_for_grok_epic "$_selected_epic")"
   fi
 fi
 

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -235,7 +235,7 @@ if [ -n "$_selected_epic" ]; then
     exit 1
   fi
   case "$_requested_selector" in
-    *.*|practice|practice-hub) _selected_epic="$_canonical_lane" ;;
+    *.*|practice|practice-hub|seminars-folk|seminars-bio) _selected_epic="$_canonical_lane" ;;
   esac
   unset _requested_selector _canonical_lane
 fi

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -235,7 +235,7 @@ if [ -n "$_selected_epic" ]; then
     exit 1
   fi
   case "$_requested_selector" in
-    *.*|practice|practice-hub|seminars-folk|seminars-bio) _selected_epic="$_canonical_lane" ;;
+    *.*|practice|practice-hub|seminars-folk|seminars-bio|corpus-channels) _selected_epic="$_canonical_lane" ;;
   esac
   unset _requested_selector _canonical_lane
 fi

--- a/start-sonnet-drive.sh
+++ b/start-sonnet-drive.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Sonnet-5 in DRIVER mode for an epic lane (judgment-dense sessions: incidents,
+# Sonnet-5 in DRIVER mode for an allowlisted lane selector (judgment-dense sessions: incidents,
 # architecture cutovers, contested reviews).
-#   ./start-sonnet-drive.sh <epic> [extra flags]    e.g.  ./start-sonnet-drive.sh hramatka
+#   ./start-sonnet-drive.sh <lane-or-lane.topic> [extra flags]
 # Which epic routes to which model? -> docs/runbooks/epic-orchestrator-roster.md
 # Thin wrapper over start-claude.sh pinned to Sonnet-5 (does NOT consume the Opus
 # review seat). The driver should load the `drive-epic` skill — automatic once the
@@ -10,10 +10,26 @@
 # Claude CLI expects a different id.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/handoff_identity.sh
+source "$ROOT/scripts/lib/handoff_identity.sh"
+usage() {
+  echo "Usage: $(basename "$0") <lane-or-lane.topic> [Claude flags]"
+  launcher_selector_help
+}
 if [ $# -lt 1 ]; then
-  echo "usage: $(basename "$0") <epic> [flags]" >&2
-  echo "  epics: harness  infra  devops  atlas  hramatka  bio  folk  corpus  (see docs/runbooks/epic-orchestrator-roster.md)" >&2
+  usage >&2
   exit 2
 fi
-EPIC="$1"; shift
-exec "$ROOT/start-claude.sh" --model "${SONNET_DRIVER_MODEL:-claude-sonnet-5}" --epic "$EPIC" "$@"
+case "$1" in
+  --help|--help-launcher|-h)
+    usage
+    exit 0
+    ;;
+esac
+SELECTOR="$1"; shift
+if ! launcher_selector_resolve "$SELECTOR" >/dev/null; then
+  echo "Error: unknown lane selector '$SELECTOR'." >&2
+  launcher_selector_help >&2
+  exit 2
+fi
+exec "$ROOT/start-claude.sh" --model "${SONNET_DRIVER_MODEL:-claude-sonnet-5}" --epic "$SELECTOR" "$@"

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -69,6 +69,8 @@ def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: 
         ("atlas.practice", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
         ("practice-hub", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
         ("hramatka.lessons", "hramatka", "epic:4542", "claude-hramatka", "gemini-hramatka", "grok-hramatka"),
+        ("corpus", "corpus", "epic:4706", "claude-corpus", "gemini-corpus", "grok-corpus"),
+        ("corpus-channels", "corpus", "epic:4706", "claude-corpus", "gemini-corpus", "grok-corpus"),
     ],
 )
 def test_dot_notation_selector_resolves_stream_and_provider_handoff(

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -50,7 +50,7 @@ def test_handoff_identity_fixtures() -> None:
 )
 def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: str) -> None:
     result = subprocess.run(
-        ["bash", "-c", 'source "$1"; "$2" devops', "bash", str(_HANDOFF_IDENTITY), resolver],
+        ["bash", "-c", 'source "$1"; "$2" infra.devops', "bash", str(_HANDOFF_IDENTITY), resolver],
         cwd=_REPO_ROOT,
         capture_output=True,
         text=True,
@@ -58,3 +58,99 @@ def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: 
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout == expected
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.parametrize(
+    ("selector", "lane", "stream", "claude_slot", "gemini_slot", "grok_slot"),
+    [
+        ("infra.fleet-comms", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
+        ("infra.devops", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
+        ("atlas.practice", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
+        ("hramatka.lessons", "hramatka", "epic:4542", "claude-hramatka", "gemini-hramatka", "grok-hramatka"),
+    ],
+)
+def test_dot_notation_selector_resolves_stream_and_provider_handoff(
+    selector: str,
+    lane: str,
+    stream: str,
+    claude_slot: str,
+    gemini_slot: str,
+    grok_slot: str,
+) -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; printf "%s|%s|%s|%s|%s|%s" "$(launcher_selector_lane "$2")" "$(launcher_selector_stream "$2")" "$(handoff_identity_for_epic "$2")" "$(handoff_identity_for_gemini_epic "$2")" "$(handoff_identity_for_grok_epic "$2")" "$(handoff_identity_for_codex_epic "$2")"',
+            "bash",
+            str(_HANDOFF_IDENTITY),
+            selector,
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == f"{lane}|{stream}|{claude_slot}|{gemini_slot}|{grok_slot}|codex-{lane}"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_unknown_selector_fails_closed() -> None:
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; launcher_selector_resolve unknown', "bash", str(_HANDOFF_IDENTITY)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 1
+    assert result.stdout == ""
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.parametrize(
+    "launcher",
+    [
+        "start-gemini-drive.sh",
+        "start-grok-drive.sh",
+        "start-sonnet-drive.sh",
+        "start-claude.sh",
+    ],
+)
+def test_launcher_help_documents_allowlisted_dot_notation(launcher: str) -> None:
+    result = subprocess.run(
+        ["bash", str(_REPO_ROOT / launcher), "--help"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Valid lane selectors:" in result.stdout
+    assert "infra.fleet-comms" in result.stdout
+    assert "atlas.practice" in result.stdout
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.parametrize(
+    ("launcher", "arguments", "expected_code"),
+    [
+        ("start-gemini-drive.sh", ["unknown"], 2),
+        ("start-grok-drive.sh", ["unknown"], 2),
+        ("start-sonnet-drive.sh", ["unknown"], 2),
+        ("start-claude.sh", ["--epic", "unknown"], 1),
+    ],
+)
+def test_launcher_unknown_selector_fails_closed(launcher: str, arguments: list[str], expected_code: int) -> None:
+    result = subprocess.run(
+        ["bash", str(_REPO_ROOT / launcher), *arguments],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == expected_code
+    assert "unknown lane selector 'unknown'" in result.stderr
+    assert "Valid lane selectors:" in result.stderr

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -67,6 +67,7 @@ def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: 
         ("infra.fleet-comms", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
         ("infra.devops", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
         ("atlas.practice", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
+        ("practice-hub", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
         ("hramatka.lessons", "hramatka", "epic:4542", "claude-hramatka", "gemini-hramatka", "grok-hramatka"),
     ],
 )
@@ -94,6 +95,27 @@ def test_dot_notation_selector_resolves_stream_and_provider_handoff(
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout == f"{lane}|{stream}|{claude_slot}|{gemini_slot}|{grok_slot}|codex-{lane}"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.parametrize("arguments", [["--epic", "atlas.epic"], ["--epic=atlas.epic"]])
+def test_legacy_epic_suffix_normalizes_before_selector_resolution(arguments: list[str]) -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; epic="$(handoff_epic_from_argv "${@:2}")"; printf "%s|%s" "$epic" "$(launcher_selector_lane "$epic")"',
+            "bash",
+            str(_HANDOFF_IDENTITY),
+            *arguments,
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "atlas|atlas"
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -50,7 +50,7 @@ def test_handoff_identity_fixtures() -> None:
 )
 def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: str) -> None:
     result = subprocess.run(
-        ["bash", "-c", 'source "$1"; "$2" infra.devops', "bash", str(_HANDOFF_IDENTITY), resolver],
+        ["bash", "-c", 'source "$1"; "$2" devops', "bash", str(_HANDOFF_IDENTITY), resolver],
         cwd=_REPO_ROOT,
         capture_output=True,
         text=True,
@@ -66,6 +66,7 @@ def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: 
     [
         ("infra.fleet-comms", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
         ("infra.devops", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
+        ("devops", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
         ("atlas.practice", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
         ("practice-hub", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
         ("hramatka.lessons", "hramatka", "epic:4542", "claude-hramatka", "gemini-hramatka", "grok-hramatka"),

--- a/tests/test_start_claude_supervisor.py
+++ b/tests/test_start_claude_supervisor.py
@@ -39,6 +39,7 @@ def _write_executable(path: Path, body: str) -> None:
         ("practice-hub", "atlas", "epic:4387", "claude-atlas"),
         ("seminars-folk", "folk", "epic:2836", "claude-folk"),
         ("seminars-bio", "bio", "epic:4431", "claude-bio"),
+        ("corpus-channels", "corpus", "epic:4706", "claude-corpus"),
     ],
 )
 def test_epic_selector_claims_supervisor_and_strips_flag(

--- a/tests/test_start_claude_supervisor.py
+++ b/tests/test_start_claude_supervisor.py
@@ -6,6 +6,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _LAUNCHER = _REPO_ROOT / "start-claude.sh"
 _GIT_REDIRECT = frozenset(
@@ -30,7 +32,18 @@ def _write_executable(path: Path, body: str) -> None:
     path.chmod(0o755)
 
 
-def test_epic_harness_claims_supervisor_and_strips_flag(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("selector", "canonical_lane", "stream", "handoff"),
+    [
+        ("harness", "harness", "epic:4707", "claude-infra"),
+        ("practice-hub", "atlas", "epic:4387", "claude-atlas"),
+        ("seminars-folk", "folk", "epic:2836", "claude-folk"),
+        ("seminars-bio", "bio", "epic:4431", "claude-bio"),
+    ],
+)
+def test_epic_selector_claims_supervisor_and_strips_flag(
+    tmp_path: Path, selector: str, canonical_lane: str, stream: str, handoff: str
+) -> None:
     project = tmp_path / "project"
     project.mkdir()
     lib = project / "scripts" / "lib"
@@ -75,7 +88,7 @@ if [[ "${{1:-}}" == "-m" && "${{2:-}}" == "scripts.session_supervisor" && "${{3:
   "schema": "session-supervisor-bootstrap.v1",
   "identity": {{
     "role": "driver",
-    "stream_id": "epic:4707",
+    "stream_id": "{stream}",
     "lease": {{
       "session_id": "sess-claude-j2",
       "lease_id": "lease-claude-j2",
@@ -154,7 +167,7 @@ fi
     subprocess.run(["git", "-C", str(project), "branch", "-M", "main"], check=True, env=env)
 
     result = subprocess.run(
-        [str(project / "start-claude.sh"), "--epic", "harness"],
+        [str(project / "start-claude.sh"), "--epic", selector],
         cwd=project,
         env=env,
         text=True,
@@ -169,12 +182,12 @@ fi
     assert "open" in sup
     assert "claude" in sup
     assert "claude-code" in sup
-    assert "epic:4707" in sup
+    assert stream in sup
 
     raw = capture.read_text(encoding="utf-8")
-    assert "epic=harness" in raw
-    assert "stream=epic:4707" in raw
+    assert f"epic={canonical_lane}" in raw
+    assert f"stream={stream}" in raw
     assert "session=sess-claude-j2" in raw
     assert "lease=lease-claude-j2" in raw
-    assert "handoff=claude-infra" in raw
+    assert f"handoff={handoff}" in raw
     assert "--epic" not in raw.split("argv=", 1)[-1]

--- a/tests/test_start_claude_supervisor.py
+++ b/tests/test_start_claude_supervisor.py
@@ -36,6 +36,7 @@ def _write_executable(path: Path, body: str) -> None:
     ("selector", "canonical_lane", "stream", "handoff"),
     [
         ("harness", "harness", "epic:4707", "claude-infra"),
+        ("devops", "infra", "epic:4707", "claude-infra"),
         ("practice-hub", "atlas", "epic:4387", "claude-atlas"),
         ("seminars-folk", "folk", "epic:2836", "claude-folk"),
         ("seminars-bio", "bio", "epic:4431", "claude-bio"),
@@ -192,3 +193,15 @@ fi
     assert "lease=lease-claude-j2" in raw
     assert f"handoff={handoff}" in raw
     assert "--epic" not in raw.split("argv=", 1)[-1]
+
+
+def test_help_lists_corpus_channel_selectors() -> None:
+    result = subprocess.run(
+        ["bash", str(_LAUNCHER), "--help"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "corpus | corpus-channels" in result.stdout

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -6,6 +6,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _LAUNCHER = _REPO_ROOT / "start-gemini.sh"
 
@@ -238,6 +240,25 @@ def test_epic_atlas_exports_env_and_claims_lease(tmp_path: Path) -> None:
     assert "--model" in parts
     assert "gemini-3.6-flash-high" in parts
     assert "--dangerously-skip-permissions" in parts
+
+
+@pytest.mark.parametrize("arguments", [["--epic", "atlas.epic"], ["--epic=atlas.epic"]])
+def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[str]) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, arguments)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "atlas"
+    assert values["session_stream"] == "epic:4387"
+    assert values["handoff"] == "gemini-atlas"
+    assert supervisor_capture.exists()
+
+
+def test_practice_hub_alias_normalizes_to_atlas(tmp_path: Path) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", "practice-hub"])
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "atlas"
+    assert values["session_stream"] == "epic:4387"
+    assert values["handoff"] == "gemini-atlas"
+    assert supervisor_capture.exists()
 
 
 def test_epic_harness_derives_gemini_infra_handoff(tmp_path: Path) -> None:

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -252,13 +252,26 @@ def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[
     assert supervisor_capture.exists()
 
 
-def test_practice_hub_alias_normalizes_to_atlas(tmp_path: Path) -> None:
-    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", "practice-hub"])
+@pytest.mark.parametrize(
+    ("selector", "canonical_lane", "stream", "handoff"),
+    [
+        ("practice-hub", "atlas", "epic:4387", "gemini-atlas"),
+        ("seminars-folk", "folk", "epic:2836", "gemini-folk"),
+        ("seminars-bio", "bio", "epic:4431", "gemini-bio"),
+    ],
+)
+def test_alias_normalizes_to_canonical_lane(
+    tmp_path: Path, selector: str, canonical_lane: str, stream: str, handoff: str
+) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", selector])
     assert result.returncode == 0, result.stderr + result.stdout
-    assert values["session_epic"] == "atlas"
-    assert values["session_stream"] == "epic:4387"
-    assert values["handoff"] == "gemini-atlas"
+    assert values["session_epic"] == canonical_lane
+    assert values["session_stream"] == stream
+    assert values["handoff"] == handoff
     assert supervisor_capture.exists()
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    stream_index = supervisor_args.index("--stream")
+    assert supervisor_args[stream_index + 1] == stream
 
 
 def test_epic_harness_derives_gemini_infra_handoff(tmp_path: Path) -> None:

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -255,6 +255,7 @@ def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[
 @pytest.mark.parametrize(
     ("selector", "canonical_lane", "stream", "handoff"),
     [
+        ("devops", "infra", "epic:4707", "gemini-infra"),
         ("practice-hub", "atlas", "epic:4387", "gemini-atlas"),
         ("seminars-folk", "folk", "epic:2836", "gemini-folk"),
         ("seminars-bio", "bio", "epic:4431", "gemini-bio"),

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -251,14 +251,26 @@ def test_epic_harness_derives_gemini_infra_handoff(tmp_path: Path) -> None:
     assert ".agent/gemini-infra-thread-handoff.md" in prompt
 
 
-def test_epic_devops_uses_canonical_infra_stream_and_handoff(tmp_path: Path) -> None:
-    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", "devops"])
+def test_dot_notation_infra_devops_uses_canonical_stream_and_handoff(tmp_path: Path) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(
+        tmp_path, ["--epic", "infra.devops"]
+    )
     assert result.returncode == 0, result.stderr + result.stdout
-    assert values["session_epic"] == "devops"
+    assert values["session_epic"] == "infra"
     assert values["handoff"] == "gemini-infra"
     supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
     stream_index = supervisor_args.index("--stream")
     assert supervisor_args[stream_index + 1] == "epic:4707"
+
+
+def test_unknown_epic_selector_fails_closed_with_help(tmp_path: Path) -> None:
+    _values, _argv_blob, result, _project, supervisor_capture = _run_launcher(
+        tmp_path, ["--epic", "unknown"]
+    )
+    assert result.returncode == 1
+    assert not supervisor_capture.exists()
+    assert "unknown lane selector 'unknown'" in result.stderr
+    assert "Valid lane selectors:" in result.stderr
 
 
 def test_epic_equals_form_and_explicit_prompt_uses_interactive_prompt(tmp_path: Path) -> None:

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -258,6 +258,7 @@ def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[
         ("practice-hub", "atlas", "epic:4387", "gemini-atlas"),
         ("seminars-folk", "folk", "epic:2836", "gemini-folk"),
         ("seminars-bio", "bio", "epic:4431", "gemini-bio"),
+        ("corpus-channels", "corpus", "epic:4706", "gemini-corpus"),
     ],
 )
 def test_alias_normalizes_to_canonical_lane(

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -282,6 +282,7 @@ def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[
 @pytest.mark.parametrize(
     ("selector", "canonical_lane", "stream", "handoff"),
     [
+        ("devops", "infra", "epic:4707", "grok-infra"),
         ("practice-hub", "atlas", "epic:4387", "grok-atlas"),
         ("seminars-folk", "folk", "epic:2836", "grok-folk"),
         ("seminars-bio", "bio", "epic:4431", "grok-bio"),

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -340,13 +340,35 @@ def test_epic_harness_cold_prompt_is_fleet_comms_dual_aware(tmp_path: Path) -> N
     assert "plane=off" in out
 
 
-def test_epic_devops_uses_canonical_infra_stream_and_handoff(tmp_path: Path) -> None:
+def test_dot_notation_atlas_practice_uses_canonical_stream_and_handoff(tmp_path: Path) -> None:
     values, _argv_blob, result, _project, supervisor_capture = _run_launcher(
-        tmp_path,
-        ["--epic", "devops"],
+        tmp_path, ["--epic", "atlas.practice"]
     )
     assert result.returncode == 0, result.stderr + result.stdout
-    assert values["session_epic"] == "devops"
+    assert values["session_epic"] == "atlas"
+    assert values["handoff"] == "grok-atlas"
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    stream_index = supervisor_args.index("--stream")
+    assert supervisor_args[stream_index + 1] == "epic:4387"
+
+
+def test_unknown_epic_selector_fails_closed_with_help(tmp_path: Path) -> None:
+    _values, _argv_blob, result, _project, supervisor_capture = _run_launcher(
+        tmp_path, ["--epic", "unknown"]
+    )
+    assert result.returncode == 1
+    assert not supervisor_capture.exists()
+    assert "unknown lane selector 'unknown'" in result.stderr
+    assert "Valid lane selectors:" in result.stderr
+
+
+def test_dot_notation_infra_devops_uses_canonical_stream_and_handoff(tmp_path: Path) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(
+        tmp_path,
+        ["--epic", "infra.devops"],
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "infra"
     assert values["handoff"] == "grok-infra"
     supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
     stream_index = supervisor_args.index("--stream")

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -279,13 +279,26 @@ def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[
     assert supervisor_capture.exists()
 
 
-def test_practice_hub_alias_normalizes_to_atlas(tmp_path: Path) -> None:
-    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", "practice-hub"])
+@pytest.mark.parametrize(
+    ("selector", "canonical_lane", "stream", "handoff"),
+    [
+        ("practice-hub", "atlas", "epic:4387", "grok-atlas"),
+        ("seminars-folk", "folk", "epic:2836", "grok-folk"),
+        ("seminars-bio", "bio", "epic:4431", "grok-bio"),
+    ],
+)
+def test_alias_normalizes_to_canonical_lane(
+    tmp_path: Path, selector: str, canonical_lane: str, stream: str, handoff: str
+) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", selector])
     assert result.returncode == 0, result.stderr + result.stdout
-    assert values["session_epic"] == "atlas"
-    assert values["session_stream"] == "epic:4387"
-    assert values["handoff"] == "grok-atlas"
+    assert values["session_epic"] == canonical_lane
+    assert values["session_stream"] == stream
+    assert values["handoff"] == handoff
     assert supervisor_capture.exists()
+    supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
+    stream_index = supervisor_args.index("--stream")
+    assert supervisor_args[stream_index + 1] == stream
 
 
 def test_epic_equals_form_and_explicit_prompt_skips_inject(tmp_path: Path) -> None:

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -6,6 +6,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _LAUNCHER = _REPO_ROOT / "start-grok.sh"
 
@@ -265,6 +267,25 @@ def test_epic_atlas_exports_env_and_claims_lease(tmp_path: Path) -> None:
     assert "--model" in parts
     assert "grok-4.5" in parts
     assert "--always-approve" in parts
+
+
+@pytest.mark.parametrize("arguments", [["--epic", "atlas.epic"], ["--epic=atlas.epic"]])
+def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[str]) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, arguments)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "atlas"
+    assert values["session_stream"] == "epic:4387"
+    assert values["handoff"] == "grok-atlas"
+    assert supervisor_capture.exists()
+
+
+def test_practice_hub_alias_normalizes_to_atlas(tmp_path: Path) -> None:
+    values, _argv_blob, result, _project, supervisor_capture = _run_launcher(tmp_path, ["--epic", "practice-hub"])
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert values["session_epic"] == "atlas"
+    assert values["session_stream"] == "epic:4387"
+    assert values["handoff"] == "grok-atlas"
+    assert supervisor_capture.exists()
 
 
 def test_epic_equals_form_and_explicit_prompt_skips_inject(tmp_path: Path) -> None:

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -285,6 +285,7 @@ def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[
         ("practice-hub", "atlas", "epic:4387", "grok-atlas"),
         ("seminars-folk", "folk", "epic:2836", "grok-folk"),
         ("seminars-bio", "bio", "epic:4431", "grok-bio"),
+        ("corpus-channels", "corpus", "epic:4706", "grok-corpus"),
     ],
 )
 def test_alias_normalizes_to_canonical_lane(


### PR DESCRIPTION
Closes #5512

- Adds dot-notation lane.topic selectors (infra.fleet-comms, infra.devops)
- Fails closed on unknown selectors with clean CLI help text
- Expands launcher unit tests