### PR TITLE
feat(bridge): record live driver message consumption

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -41,6 +41,17 @@ session-health signal **by seat**: **grok / gemini / kimi** have a canary lane �
 **Claude / Sonnet** have **no** canary lane and use the native SessionStart / PostCompact
 hook chain + thread-handoff instead (do not call a non-existent `<model>_lane`).
 
+### 0a. Required live-driver inbox drain — cycle start
+At the start of **every** cycle, inspect this driver's legacy inbox. The live loop —
+not a detached `process-*` / `ask-*` worker — must read and apply every message marked
+`unread` or `read-but-not-live-consumed`, then record that consumption explicitly:
+```bash
+.venv/bin/python -m scripts.ai_agent_bridge inbox --for "$SESSION_HANDOFF_AGENT"
+.venv/bin/python -m scripts.ai_agent_bridge ack --consumed-by-live-driver <message-id> [<message-id> ...]
+```
+Never use a plain `ack` for messages this live loop has consumed: plain acknowledgement
+also records one-shot/headless processing and is not delivery proof for the live driver.
+
 ### 1. Read topology + metrics (don't hold state — query it)
 ```bash
 .venv/bin/python -m scripts.fleet_comms metrics        # efficiency metrics (no content)
@@ -72,6 +83,15 @@ the worker**) and the `#M-4` evidence preamble (each claim + its deterministic t
 quoted raw evidence). Classify the task and pass the research flags
 (`--research-role/-task-family/-track/-owned-path`). Stagger same-lane spawns ~10s.
 
+### 4a. Required live-driver inbox drain — immediately before dispatch
+Immediately before each dispatch, repeat the drain so new instructions or a reply cannot
+be missed between routing and worker launch. Read and apply every `unread` or
+`read-but-not-live-consumed` entry before dispatching, then run:
+```bash
+.venv/bin/python -m scripts.ai_agent_bridge inbox --for "$SESSION_HANDOFF_AGENT"
+.venv/bin/python -m scripts.ai_agent_bridge ack --consumed-by-live-driver <message-id> [<message-id> ...]
+```
+
 ### 5. Settle-loop (never poll by hand)
 Watch the task's `batch_state/tasks/<id>.json` `status` with the **Monitor** tool.
 Terminal vocab (match `scripts/delegate.py`): **`done` = SUCCESS** (NOT "completed");
@@ -80,6 +100,14 @@ crashed | dry_run` (dry_run is terminal, not success) + `needs_finalize`. Emit o
 status NOT in `{spawning, running, ""}`. The task file is truth; `/api/delegate/active`
 can omit live tasks. **Before declaring a dispatch dead:** `gh pr list --state open`
 first, then check the worktree for finished-but-unpushed work.
+
+### 5a. Required live-driver inbox drain — after settle
+Once the settle-loop reaches its decision point, drain again before choosing the next
+action. Read and apply every `unread` or `read-but-not-live-consumed` entry, then run:
+```bash
+.venv/bin/python -m scripts.ai_agent_bridge inbox --for "$SESSION_HANDOFF_AGENT"
+.venv/bin/python -m scripts.ai_agent_bridge ack --consumed-by-live-driver <message-id> [<message-id> ...]
+```
 
 ### 6. Cross-family review gate (load-bearing — discussion ≠ review)
 A review of record is **independent and cross-family** (outside the author's model
@@ -93,7 +121,15 @@ Pick the reviewer family from the served reviewer-seat rule; the writer's family
 never eligible. For a hard / non-routine change, escalate the seat with
 `--model gpt-5.6-sol` (or `claude-fable-5`) `--effort xhigh`. Read the review CONTENT
 (not just pass/fail), apply the deltas, re-probe gate-driving data yourself before
-trusting "verified".
+trusting "verified". A review request is not a passive notification: after invoking
+`review-pr <PR_NUMBER>`, the requester owns its request state and must explicitly poll
+it on each subsequent cycle with:
+```bash
+.venv/bin/python -m scripts.ai_agent_bridge asks --task-id review-pr-<PR_NUMBER>
+```
+Wait for that request to show `replied`; treat `sent`, `processing`, `timed-out`, or
+`failed` as its actual state and act on it. Do not assume a disconnected reply will
+surface in the live driver's context.
 
 ### 7. Merge discipline
 PRs only — never commit or merge to `main` directly. **Arm auto-merge the moment the
@@ -111,6 +147,16 @@ orchestrator). Flag another lane's PR with `needs=merge` rather than merging it.
 End the session on your seat's handoff signal (canary FAIL-HANDOFF for grok/gemini/kimi;
 the SessionStart / thread-handoff for Claude/Sonnet), not on a compact count. Keep the
 file handoff current — it stays authoritative through every plane mode (below).
+
+### 8a. Required live-driver inbox drain — before handoff
+Immediately before writing or signalling handoff, make one final live-loop drain. Read
+and apply every `unread` or `read-but-not-live-consumed` entry, then run:
+```bash
+.venv/bin/python -m scripts.ai_agent_bridge inbox --for "$SESSION_HANDOFF_AGENT"
+.venv/bin/python -m scripts.ai_agent_bridge ack --consumed-by-live-driver <message-id> [<message-id> ...]
+```
+Record any action or unresolved request in the authoritative file handoff after this
+drain; never claim the handoff is complete because a one-shot worker acknowledged it.
 
 ---
 

--- a/scripts/ai_agent_bridge/_ask_lifecycle.py
+++ b/scripts/ai_agent_bridge/_ask_lifecycle.py
@@ -216,7 +216,7 @@ def print_asks(task_id: str | None = None) -> None:
     try:
         rows = conn.execute(
             f"""
-            SELECT id, task_id, to_llm, status, timestamp
+            SELECT id, task_id, to_llm, status, timestamp, acknowledged, consumed_by_live_driver
             FROM messages
             WHERE {where}
             ORDER BY id DESC
@@ -231,10 +231,11 @@ def print_asks(task_id: str | None = None) -> None:
         print("No tracked asks.")
         return
 
-    print("ID  TASK  TO  STATUS  SENT")
+    print("ID  TASK  TO  STATUS  CONSUMPTION  SENT")
     for row in rows:
         status = _display_status(str(row[3] or "sent"))
-        print(f"{row[0]}  {row[1] or '-'}  {row[2]}  {status}  {row[4]}")
+        consumption = _message_consumption_state(row[5], row[6])
+        print(f"{row[0]}  {row[1] or '-'}  {row[2]}  {status}  {consumption}  {row[4]}")
 
 
 def maybe_print_timeout_notice() -> None:
@@ -416,6 +417,15 @@ def _display_status(status: str) -> str:
     if status.startswith("failed:"):
         return "failed"
     return status
+
+
+def _message_consumption_state(acknowledged: int, consumed_by_live_driver: int) -> str:
+    """Return the legacy-message consumption state shown by ``asks``."""
+    if consumed_by_live_driver:
+        return "live-consumed"
+    if acknowledged:
+        return "read-but-not-live-consumed"
+    return "unread"
 
 
 def _looks_like_timeout(detail: str) -> bool:

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -495,10 +495,20 @@ def _build_parser() -> argparse.ArgumentParser:
     # ack
     ack_parser = subparsers.add_parser("ack", help="Acknowledge message(s)")
     ack_parser.add_argument("message_ids", type=int, nargs="+", help="Message ID(s) to acknowledge")
+    ack_parser.add_argument(
+        "--consumed-by-live-driver",
+        action="store_true",
+        help="Record that this live driver's own loop consumed the message(s)",
+    )
 
     # ack-all
     ack_all_parser = subparsers.add_parser("ack-all", help="Acknowledge ALL unread messages for an agent")
     ack_all_parser.add_argument("agent", choices=recipient_choices, help="Agent whose inbox to clear")
+    ack_all_parser.add_argument(
+        "--consumed-by-live-driver",
+        action="store_true",
+        help="Record that this live driver's own loop consumed the unread messages",
+    )
 
     # conversation
     conv_parser = subparsers.add_parser("conversation", help="Get conversation history")
@@ -1218,9 +1228,15 @@ def _dispatch_command(args):
             args.content, args.task_id, args.type, data, args.from_llm, args.to_llm, args.from_model, args.to_model
         )
     elif args.command == "ack":
-        acknowledge(args.message_ids)
+        acknowledge(
+            args.message_ids,
+            consumed_by_live_driver=getattr(args, "consumed_by_live_driver", False),
+        )
     elif args.command == "ack-all":
-        acknowledge_all(args.agent)
+        acknowledge_all(
+            args.agent,
+            consumed_by_live_driver=getattr(args, "consumed_by_live_driver", False),
+        )
     elif args.command == "conversation":
         get_conversation(args.task_id)
     elif args.command == "thread":

--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -39,6 +39,8 @@ CREATE TABLE IF NOT EXISTS messages (
     data TEXT,
     timestamp TEXT NOT NULL,
     acknowledged INTEGER DEFAULT 0,
+    consumed_by_live_driver INTEGER DEFAULT 0,
+    consumed_at TEXT,
     status TEXT DEFAULT 'pending'
 );
 
@@ -315,9 +317,19 @@ def get_db():
         if not columns:
             # Table doesn't exist yet — create everything from scratch
             conn.executescript(_LEGACY_SCHEMA)
-        elif "status" not in columns:
-            print("🔧 Migrating database: adding 'status' column to 'messages' table")
-            _add_column_racesafe(conn, "ALTER TABLE messages ADD COLUMN status TEXT DEFAULT 'pending'")
+        else:
+            if "status" not in columns:
+                print("🔧 Migrating database: adding 'status' column to 'messages' table")
+                _add_column_racesafe(conn, "ALTER TABLE messages ADD COLUMN status TEXT DEFAULT 'pending'")
+            if "consumed_by_live_driver" not in columns:
+                print("🔧 Migrating database: adding 'consumed_by_live_driver' column to 'messages' table")
+                _add_column_racesafe(
+                    conn,
+                    "ALTER TABLE messages ADD COLUMN consumed_by_live_driver INTEGER DEFAULT 0",
+                )
+            if "consumed_at" not in columns:
+                print("🔧 Migrating database: adding 'consumed_at' column to 'messages' table")
+                _add_column_racesafe(conn, "ALTER TABLE messages ADD COLUMN consumed_at TEXT")
         _ensure_legacy_indexes(conn)
 
         # --- Sessions table migration (#604) ---

--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -327,6 +327,23 @@ def get_db():
                     conn,
                     "ALTER TABLE messages ADD COLUMN consumed_by_live_driver INTEGER DEFAULT 0",
                 )
+                # Backfill: every message that was already acknowledged before this
+                # column existed predates the live-driver-consumption concept entirely.
+                # Without this, adding the column retroactively turns the fleet's
+                # entire acknowledged history into "read-but-not-live-consumed"
+                # backlog that every live driver would be required to wade through
+                # on its very next inbox drain (verified: 3103 messages fleet-wide
+                # as of 2026-07-23 — claude alone had 1119). Grandfather pre-existing
+                # acknowledged rows in as already handled; consumed_at stays NULL
+                # for them since the real consumption time is unknown, not "now".
+                conn.execute(
+                    "UPDATE messages SET consumed_by_live_driver = 1 "
+                    "WHERE acknowledged = 1 AND consumed_by_live_driver = 0"
+                )
+                # Explicit commit: don't rely on the next ALTER TABLE's implicit
+                # DDL-commit behavior to persist this DML — that's an incidental
+                # side effect of statement ordering, not a guarantee.
+                conn.commit()
             if "consumed_at" not in columns:
                 print("🔧 Migrating database: adding 'consumed_at' column to 'messages' table")
                 _add_column_racesafe(conn, "ALTER TABLE messages ADD COLUMN consumed_at TEXT")

--- a/scripts/ai_agent_bridge/_messaging.py
+++ b/scripts/ai_agent_bridge/_messaging.py
@@ -30,9 +30,10 @@ def check_inbox(for_llm: str = "gemini"):
     placeholders = ", ".join("?" for _ in recipients)
     cursor.execute(
         f"""
-        SELECT id, from_llm, message_type, substr(content, 1, 100), timestamp
+        SELECT id, from_llm, message_type, substr(content, 1, 100), timestamp,
+               acknowledged, consumed_by_live_driver
         FROM messages
-        WHERE to_llm IN ({placeholders}) AND acknowledged = 0
+        WHERE to_llm IN ({placeholders})
         ORDER BY id ASC
         """,
         recipients,
@@ -42,16 +43,24 @@ def check_inbox(for_llm: str = "gemini"):
     conn.close()
 
     if not rows:
-        print(f"📭 No unread messages for {for_llm}")
+        print(f"📭 No messages for {for_llm}")
         return
 
-    print(f"📬 {len(rows)} unread message(s) for {for_llm}:\n")
+    states = [_message_consumption_state(row[5], row[6]) for row in rows]
+    unread = states.count("unread")
+    read_not_live = states.count("read-but-not-live-consumed")
+    live_consumed = states.count("live-consumed")
+    print(
+        f"📬 Inbox for {for_llm}: {unread} unread | "
+        f"{read_not_live} read-but-not-live-consumed | {live_consumed} live-consumed\n"
+    )
     for row in rows:
-        msg_id, from_llm, msg_type, preview, timestamp = row
+        msg_id, from_llm, msg_type, preview, timestamp, acknowledged, consumed_by_live_driver = row
         preview = (redact_text(preview) or "").replace('\n', ' ')
         if len(preview) >= 100:
             preview += "..."
-        print(f"  [{msg_id}] From: {from_llm} | Type: {msg_type} | {timestamp}")
+        state = _message_consumption_state(acknowledged, consumed_by_live_driver)
+        print(f"  [{msg_id}] [{state}] From: {from_llm} | Type: {msg_type} | {timestamp}")
         print(f"      {preview}\n")
 
 
@@ -220,28 +229,51 @@ def send_to_codex(content: str, task_id: str | None = None, msg_type: str = "que
                         to_llm="codex", from_model=from_model, to_model=to_model, quiet=quiet)
 
 
-def acknowledge(message_ids: list[int] | int, quiet: bool = False):
-    """Mark message(s) as acknowledged."""
+def acknowledge(
+    message_ids: list[int] | int,
+    quiet: bool = False,
+    *,
+    consumed_by_live_driver: bool = False,
+):
+    """Mark message(s) as acknowledged, optionally as live-driver consumed."""
     if isinstance(message_ids, int):
         message_ids = [message_ids]
 
     conn = get_db()
     cursor = conn.cursor()
 
-    for msg_id in message_ids:
-        cursor.execute("UPDATE messages SET acknowledged = 1 WHERE id = ?", (msg_id,))
+    if consumed_by_live_driver:
+        consumed_at = datetime.now(UTC).isoformat()
+        for msg_id in message_ids:
+            cursor.execute(
+                """
+                UPDATE messages
+                SET acknowledged = 1,
+                    consumed_by_live_driver = 1,
+                    consumed_at = COALESCE(consumed_at, ?)
+                WHERE id = ?
+                """,
+                (consumed_at, msg_id),
+            )
+    else:
+        for msg_id in message_ids:
+            cursor.execute("UPDATE messages SET acknowledged = 1 WHERE id = ?", (msg_id,))
 
     conn.commit()
     conn.close()
 
     if not quiet:
+        suffix = " as consumed by live driver" if consumed_by_live_driver else ""
         if len(message_ids) == 1:
-            print(f"✓ Message {message_ids[0]} acknowledged")
+            print(f"✓ Message {message_ids[0]} acknowledged{suffix}")
         else:
-            print(f"✓ {len(message_ids)} messages acknowledged: {', '.join(map(str, message_ids))}")
+            print(
+                f"✓ {len(message_ids)} messages acknowledged{suffix}: "
+                f"{', '.join(map(str, message_ids))}"
+            )
 
 
-def acknowledge_all(for_llm: str):
+def acknowledge_all(for_llm: str, *, consumed_by_live_driver: bool = False):
     """Acknowledge ALL unread messages for a given agent (dual-READ aliases)."""
     try:
         from agent_runtime.agent_identity import seat_read_aliases
@@ -272,18 +304,40 @@ def acknowledge_all(for_llm: str):
 
     msg_ids = [row[0] for row in rows]
 
-    cursor.execute(
-        f"""
-        UPDATE messages SET acknowledged = 1
-        WHERE to_llm IN ({placeholders}) AND acknowledged = 0
-        """,
-        recipients,
-    )
+    if consumed_by_live_driver:
+        cursor.execute(
+            f"""
+            UPDATE messages
+            SET acknowledged = 1,
+                consumed_by_live_driver = 1,
+                consumed_at = COALESCE(consumed_at, ?)
+            WHERE to_llm IN ({placeholders}) AND acknowledged = 0
+            """,
+            (datetime.now(UTC).isoformat(), *recipients),
+        )
+    else:
+        cursor.execute(
+            f"""
+            UPDATE messages SET acknowledged = 1
+            WHERE to_llm IN ({placeholders}) AND acknowledged = 0
+            """,
+            recipients,
+        )
 
     conn.commit()
     conn.close()
 
-    print(f"✓ Acknowledged {len(msg_ids)} messages for {for_llm}: {', '.join(map(str, msg_ids))}")
+    suffix = " as consumed by live driver" if consumed_by_live_driver else ""
+    print(f"✓ Acknowledged {len(msg_ids)} messages{suffix} for {for_llm}: {', '.join(map(str, msg_ids))}")
+
+
+def _message_consumption_state(acknowledged: int, consumed_by_live_driver: int) -> str:
+    """Return the live-driver consumption state displayed by bridge commands."""
+    if consumed_by_live_driver:
+        return "live-consumed"
+    if acknowledged:
+        return "read-but-not-live-consumed"
+    return "unread"
 
 
 def get_conversation(task_id: str):

--- a/tests/test_coverage_bridge_audit.py
+++ b/tests/test_coverage_bridge_audit.py
@@ -465,6 +465,7 @@ class TestMessaging:
             task_id TEXT, from_llm TEXT NOT NULL, to_llm TEXT NOT NULL,
             message_type TEXT DEFAULT 'message', content TEXT NOT NULL,
             data TEXT, timestamp TEXT NOT NULL, acknowledged INTEGER DEFAULT 0,
+            consumed_by_live_driver INTEGER DEFAULT 0, consumed_at TEXT,
             status TEXT DEFAULT 'pending'
         )""")
         conn.commit()
@@ -562,7 +563,9 @@ class TestMessaging:
     def test_check_inbox_empty(self, msg_db, capsys):
         from scripts.ai_agent_bridge._messaging import check_inbox
         check_inbox("gemini")
-        assert "No unread" in capsys.readouterr().out
+        # check_inbox now shows all consumption states, not just unread, so an
+        # empty inbox is worded "No messages" rather than "No unread messages".
+        assert "No messages" in capsys.readouterr().out
 
     def test_check_inbox_with_messages(self, msg_db, capsys):
         from scripts.ai_agent_bridge._messaging import check_inbox

--- a/tests/test_live_driver_message_consumption.py
+++ b/tests/test_live_driver_message_consumption.py
@@ -1,0 +1,149 @@
+"""Regression coverage for live epic-driver legacy-message consumption (#5687)."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge import _ask_lifecycle, _cli, _db, _messaging
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DRIVE_EPIC_SKILL = PROJECT_ROOT / "agents_extensions/shared/skills/drive-epic/SKILL.md"
+
+
+@pytest.fixture(autouse=True)
+def isolate_db(tmp_path: Path):
+    """Keep legacy-message rows isolated for each consumption-state test."""
+    db_file = tmp_path / "messages.db"
+    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch("ai_agent_bridge._db.DB_PATH", db_file):
+        _db.init_db().close()
+        yield db_file
+
+
+def _run_cli(argv: list[str]) -> int:
+    with patch.object(sys, "argv", ["ab", *argv]):
+        try:
+            _cli.main()
+        except SystemExit as exc:
+            return exc.code if isinstance(exc.code, int) else 0
+    return 0
+
+
+def _message_consumption(message_id: int) -> tuple[int, int, str | None]:
+    conn = _db.get_db()
+    try:
+        row = conn.execute(
+            "SELECT acknowledged, consumed_by_live_driver, consumed_at FROM messages WHERE id = ?",
+            (message_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    return int(row[0]), int(row[1]), row[2]
+
+
+def test_legacy_messages_migrate_live_driver_consumption_columns(tmp_path: Path):
+    """Existing bridge DBs receive both consumption fields through the race-safe migration."""
+    legacy_db = tmp_path / "legacy-messages.db"
+    conn = sqlite3.connect(legacy_db)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id TEXT,
+                from_llm TEXT NOT NULL,
+                to_llm TEXT NOT NULL,
+                message_type TEXT DEFAULT 'message',
+                content TEXT NOT NULL,
+                data TEXT,
+                timestamp TEXT NOT NULL,
+                acknowledged INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'pending'
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with patch("ai_agent_bridge._config.DB_PATH", legacy_db), patch("ai_agent_bridge._db.DB_PATH", legacy_db):
+        migrated = _db.get_db()
+        try:
+            columns = {row[1] for row in migrated.execute("PRAGMA table_info(messages)").fetchall()}
+        finally:
+            migrated.close()
+
+    assert {"consumed_by_live_driver", "consumed_at"}.issubset(columns)
+
+
+def test_live_driver_ack_is_distinct_from_plain_one_shot_ack(capsys):
+    """A live-loop acknowledgement is distinguishable from headless processing."""
+    one_shot_id = _messaging.send_message(
+        "headless worker handled this", task_id="review-pr-5687", from_llm="claude", to_llm="codex", quiet=True
+    )
+    live_driver_id = _messaging.send_message(
+        "live driver must apply this", task_id="review-pr-5687", from_llm="claude", to_llm="codex", quiet=True
+    )
+
+    _messaging.acknowledge(one_shot_id, quiet=True)
+    assert _message_consumption(one_shot_id) == (1, 0, None)
+
+    assert _run_cli(["inbox", "--for", "codex"]) == 0
+    inbox = capsys.readouterr().out
+    assert "read-but-not-live-consumed" in inbox
+    assert "unread" in inbox
+
+    assert _run_cli(["ack", "--consumed-by-live-driver", str(live_driver_id)]) == 0
+    acknowledged, consumed, consumed_at = _message_consumption(live_driver_id)
+    assert (acknowledged, consumed) == (1, 1)
+    assert consumed_at is not None
+    assert _message_consumption(one_shot_id) == (1, 0, None)
+
+
+def test_ack_all_flag_is_opt_in_and_asks_surfaces_consumption(capsys):
+    """Existing ack-all callers stay plain while the explicit flag marks live consumption."""
+    plain_id = _messaging.send_message(
+        "plain acknowledgement", task_id="review-pr-5687-plain", from_llm="claude", to_llm="codex", quiet=True
+    )
+    _messaging.acknowledge_all("codex")
+    assert _message_consumption(plain_id) == (1, 0, None)
+
+    live_id = _messaging.send_message(
+        "tracked review request", task_id="review-pr-5687-live", from_llm="claude", to_llm="codex", quiet=True
+    )
+    _ask_lifecycle.register_ask(live_id)
+    assert _run_cli(["ack-all", "codex", "--consumed-by-live-driver"]) == 0
+    acknowledged, consumed, consumed_at = _message_consumption(live_id)
+    assert (acknowledged, consumed) == (1, 1)
+    assert consumed_at is not None
+
+    assert _run_cli(["asks", "--task-id", "review-pr-5687-live"]) == 0
+    asks = capsys.readouterr().out
+    assert "CONSUMPTION" in asks
+    assert "live-consumed" in asks
+
+
+def test_drive_epic_skill_keeps_all_required_live_inbox_boundaries():
+    """The portable driver contract must not silently lose its inbox drain steps."""
+    text = DRIVE_EPIC_SKILL.read_text(encoding="utf-8")
+    required_headings = (
+        "### 0a. Required live-driver inbox drain — cycle start",
+        "### 4a. Required live-driver inbox drain — immediately before dispatch",
+        "### 5a. Required live-driver inbox drain — after settle",
+        "### 8a. Required live-driver inbox drain — before handoff",
+    )
+    for heading in required_headings:
+        assert heading in text
+
+    inbox_command = '.venv/bin/python -m scripts.ai_agent_bridge inbox --for "$SESSION_HANDOFF_AGENT"'
+    acknowledgement = ".venv/bin/python -m scripts.ai_agent_bridge ack --consumed-by-live-driver"
+    assert text.count(inbox_command) == 4
+    assert text.count(acknowledgement) == 4
+    assert ".venv/bin/python -m scripts.ai_agent_bridge asks --task-id review-pr-<PR_NUMBER>" in text


### PR DESCRIPTION
## Summary

- add a race-safe legacy-message migration that distinguishes live-driver consumption from ordinary acknowledgement
- expose the explicit --consumed-by-live-driver acknowledgement path and consumption state in inbox and ask-lifecycle output
- require four safe-boundary inbox drains and task-scoped review polling in the portable driver skill
- add migration, round-trip, compatibility, and skill-contract regression coverage

Refs #5687. This implements the approved pull-and-acknowledge baseline: one-shot processing does not prove a live epic driver consumed a message.

## Validation

- focused bridge regression suite: 73 passed
- changed-file Ruff and fleet-roster lint passed
- the broader requested pytest selection cannot collect in this sparse worktree because curriculum/l2-uk-en/curriculum.yaml is absent by dispatch design

No auto-merge armed; cross-family code review is still required.