### PR TITLE
feat(bridge): add live-driver inbox watcher

### DIFF
--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -52,6 +52,29 @@ not a detached `process-*` / `ask-*` worker — must read and apply every messag
 Never use a plain `ack` for messages this live loop has consumed: plain acknowledgement
 also records one-shot/headless processing and is not delivery proof for the live driver.
 
+### 0b. Optional Monitor inbox-watcher wakeup — cold start only
+
+At cold-start, **if your harness has a Monitor-equivalent**, invoke it once with that
+harness's `persistent`/timeout option, pointed at this one shell command:
+
+```bash
+scripts/ai_agent_bridge/inbox_watch.sh "$SESSION_HANDOFF_AGENT"
+```
+
+This is a **wakeup signal only**: each stdout line says that an unconsumed legacy
+message exists, with its id, sender, request id, and a bounded preview. It never reads
+the full body into your context and never marks a message consumed. You still must run
+the existing required `0a` / `4a` / `5a` / `8a` inbox-drain steps to read, apply, and
+explicitly live-consume everything the signal points at; those steps remain the
+universal fallback for every seat, watcher or not.
+
+Direct confirmation exists only for **Claude Code, Gemini/AGY, and Grok CLI**. For any
+other harness, ask the running agent directly whether it has an equivalent before using
+one; do not infer it from documentation or `--help`. Stop a running watcher cleanly
+with `scripts/ai_agent_bridge/inbox_watch.sh --stop "$SESSION_HANDOFF_AGENT"`; if a
+crashed process leaves a stale pidfile, the operating system releases its advisory lock
+and the next watcher replaces the recorded pid safely.
+
 ### 1. Read topology + metrics (don't hold state — query it)
 ```bash
 .venv/bin/python -m scripts.fleet_comms metrics        # efficiency metrics (no content)

--- a/scripts/ai_agent_bridge/_inbox_watch.py
+++ b/scripts/ai_agent_bridge/_inbox_watch.py
@@ -1,0 +1,298 @@
+"""Read-only legacy-inbox wakeup watcher for live fleet drivers.
+
+This module deliberately only reports unconsumed messages.  The live driver
+remains responsible for reading the full inbox and recording consumption with
+``ai_agent_bridge ack --consumed-by-live-driver``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import signal
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+from agent_runtime.agent_identity import seat_read_aliases
+from secret_redactor import redact_text
+
+from ._config import DB_PATH, PRIMARY_REPO_ROOT
+
+DEFAULT_POLL_INTERVAL_SECONDS = 15.0
+MAX_PREVIEW_CHARS = 240
+DEFAULT_LOCK_DIR = PRIMARY_REPO_ROOT / ".agent"
+
+
+class WatcherAlreadyRunningError(RuntimeError):
+    """Raised when another watcher owns an agent slot's lock."""
+
+
+@dataclass(frozen=True)
+class InboxEvent:
+    """Stable metadata needed for a driver to decide whether to drain its inbox."""
+
+    message_id: int
+    sender: str
+    request_id: str
+    content: str
+
+    def notification_line(self) -> str:
+        """Return a one-line, bounded notification safe for Monitor stdout."""
+        return (
+            "INBOX-WATCH "
+            f"id={self.message_id} "
+            f"sender={_escape_one_line(self.sender)} "
+            f"request_id={_escape_one_line(self.request_id)} "
+            f"preview={_bounded_preview(self.content)}"
+        )
+
+
+@dataclass(frozen=True)
+class WatcherLock:
+    """An exclusive, per-seat process lock stored outside the broker database."""
+
+    fd: int
+
+    def release(self) -> None:
+        """Release the advisory lock; the next watcher safely replaces its stale pid."""
+        try:
+            fcntl.flock(self.fd, fcntl.LOCK_UN)
+        finally:
+            os.close(self.fd)
+
+
+def recipients_for_agent(agent: str) -> tuple[str, ...]:
+    """Resolve the bridge's permanent dual-read aliases for an agent seat."""
+    recipients = seat_read_aliases(agent)
+    if not recipients:
+        raise ValueError("agent slot must not be empty")
+    return recipients
+
+
+def canonical_slot(agent: str) -> str:
+    """Return the canonical slot used for duplicate-watcher locking."""
+    return recipients_for_agent(agent)[0]
+
+
+def build_poll_query(recipients: tuple[str, ...]) -> str:
+    """Build the parameterized, read-only query for newly visible messages."""
+    if not recipients:
+        raise ValueError("at least one recipient is required")
+    placeholders = ", ".join("?" for _ in recipients)
+    return f"""
+        SELECT id, from_llm, task_id, content
+        FROM messages
+        WHERE to_llm IN ({placeholders})
+          AND consumed_by_live_driver = 0
+          AND id > ?
+        ORDER BY id ASC
+    """
+
+
+def poll_once(
+    conn: sqlite3.Connection,
+    agent: str,
+    last_seen: int = 0,
+) -> list[InboxEvent]:
+    """Return currently unconsumed messages after the in-memory cursor.
+
+    A fresh watcher starts with ``last_seen=0``, deliberately surfacing every
+    current unconsumed row, including rows that predate the watcher process.
+    """
+    recipients = recipients_for_agent(agent)
+    rows = conn.execute(build_poll_query(recipients), (*recipients, last_seen)).fetchall()
+    return [
+        InboxEvent(
+            message_id=int(row["id"]),
+            sender=str(row["from_llm"]),
+            request_id=str(row["task_id"] or "-"),
+            content=str(row["content"]),
+        )
+        for row in rows
+    ]
+
+
+def emit_notifications(events: list[InboxEvent], last_seen: int, output: TextIO) -> int:
+    """Write events and advance the cursor only after each successful flush."""
+    for event in events:
+        output.write(f"{event.notification_line()}\n")
+        output.flush()
+        last_seen = event.message_id
+    return last_seen
+
+
+def open_readonly_db(db_path: Path) -> sqlite3.Connection:
+    """Open the broker database without running migrations or taking a write lock."""
+    database_uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(database_uri, uri=True, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
+
+def watcher_lock_path(agent: str, lock_dir: Path = DEFAULT_LOCK_DIR) -> Path:
+    """Return the ignored per-seat pidfile path, rejecting unsafe slot strings."""
+    slot = canonical_slot(agent)
+    if not slot.replace("-", "").replace("_", "").replace(".", "").isalnum():
+        raise ValueError(f"agent slot contains unsupported lock-path characters: {slot!r}")
+    return lock_dir / f"inbox-watch-{slot}.pid"
+
+
+def acquire_watcher_lock(agent: str, lock_dir: Path = DEFAULT_LOCK_DIR) -> WatcherLock:
+    """Acquire an exclusive watcher lock and record the owning process id."""
+    path = watcher_lock_path(agent, lock_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = f"{os.getpid()}\n"
+
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        os.close(fd)
+        existing_pid = _read_lock_pid(path)
+        slot = canonical_slot(agent)
+        pid_detail = f" (pid {existing_pid})" if existing_pid is not None else ""
+        raise WatcherAlreadyRunningError(
+            f"inbox watcher already running for {slot!r}{pid_detail}; "
+            f"stop it with scripts/ai_agent_bridge/inbox_watch.sh --stop {slot}"
+        ) from exc
+
+    try:
+        os.ftruncate(fd, 0)
+        os.write(fd, payload.encode("utf-8"))
+    except Exception:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+        raise
+    return WatcherLock(fd=fd)
+
+
+def stop_watcher(agent: str, lock_dir: Path = DEFAULT_LOCK_DIR) -> str:
+    """Request a clean SIGTERM stop for the watcher that owns an agent slot."""
+    path = watcher_lock_path(agent, lock_dir)
+    if not path.exists():
+        return f"No inbox watcher lock exists for {canonical_slot(agent)!r}."
+
+    fd = os.open(path, os.O_WRONLY)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        os.close(fd)
+    else:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+        return f"No inbox watcher is running for {canonical_slot(agent)!r}."
+
+    pid = _read_lock_pid(path)
+    if pid is None or not _pid_is_running(pid):
+        return f"Inbox watcher lock for {canonical_slot(agent)!r} is no longer active."
+
+    os.kill(pid, signal.SIGTERM)
+    return f"Requested clean stop for inbox watcher {canonical_slot(agent)!r} (pid {pid})."
+
+
+def run_watcher(
+    agent: str,
+    *,
+    interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    db_path: Path = DB_PATH,
+    lock_dir: Path = DEFAULT_LOCK_DIR,
+    output: TextIO = sys.stdout,
+    once: bool = False,
+) -> int:
+    """Run the persistent watcher and return the final in-memory cursor.
+
+    No messages-table mutation occurs here.  On a write/flush failure the
+    exception exits the process before the failed event advances ``last_seen``;
+    restarting then deliberately re-emits all still-unconsumed rows.
+    """
+    if interval_seconds <= 0:
+        raise ValueError("poll interval must be greater than zero")
+
+    lock = acquire_watcher_lock(agent, lock_dir)
+    conn: sqlite3.Connection | None = None
+    last_seen = 0
+    try:
+        conn = open_readonly_db(db_path)
+        while True:
+            events = poll_once(conn, agent, last_seen)
+            last_seen = emit_notifications(events, last_seen, output)
+            if once:
+                return last_seen
+            time.sleep(interval_seconds)
+    finally:
+        if conn is not None:
+            conn.close()
+        lock.release()
+
+
+def _escape_one_line(value: str) -> str:
+    """Escape line breaks so one message always yields exactly one event line."""
+    return value.replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n")
+
+
+def _bounded_preview(content: str) -> str:
+    """Redact, escape, and truncate message content for a compact notification."""
+    preview = _escape_one_line(redact_text(content) or "")
+    if len(preview) > MAX_PREVIEW_CHARS:
+        return f"{preview[:MAX_PREVIEW_CHARS]}..."
+    return preview
+
+
+def _read_lock_pid(path: Path) -> int | None:
+    """Read a positive pid from a lockfile, tolerating a partial stale write."""
+    try:
+        first_field = path.read_text(encoding="utf-8").split(maxsplit=1)[0]
+        pid = int(first_field)
+    except (FileNotFoundError, IndexError, OSError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def _pid_is_running(pid: int) -> bool:
+    """Return whether a process exists without changing its state."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the one-command watcher interface used by harness Monitor tools."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("agent", help="driver handoff agent slot to watch")
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=DEFAULT_POLL_INTERVAL_SECONDS,
+        help=f"seconds between polls (default: {DEFAULT_POLL_INTERVAL_SECONDS:g})",
+    )
+    parser.add_argument("--once", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--stop", action="store_true", help="request a clean stop for this slot's watcher")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the watcher CLI while keeping normal polling stdout event-only."""
+    args = build_parser().parse_args(argv)
+    try:
+        if args.stop:
+            print(stop_watcher(args.agent), file=sys.stderr)
+            return 0
+        run_watcher(args.agent, interval_seconds=args.interval, once=args.once)
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
+        print(f"inbox watcher: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ai_agent_bridge/inbox_watch.sh
+++ b/scripts/ai_agent_bridge/inbox_watch.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Read-only wakeup watcher for harness Monitor-equivalent tools.
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd -- "$script_dir/../.." && pwd -P)"
+
+PYTHONPATH="$repo_root/scripts${PYTHONPATH:+:$PYTHONPATH}" \
+  exec "$repo_root/.venv/bin/python" -m ai_agent_bridge._inbox_watch "$@"

--- a/tests/ai_agent_bridge/test_inbox_watch.py
+++ b/tests/ai_agent_bridge/test_inbox_watch.py
@@ -1,0 +1,157 @@
+"""Unit coverage for the live-driver legacy-inbox wakeup watcher."""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from ai_agent_bridge import _db, _inbox_watch, _messaging
+
+
+@pytest.fixture(autouse=True)
+def isolate_db(tmp_path: Path):
+    """Create an isolated broker database with the current messages schema."""
+    db_path = tmp_path / "messages.db"
+    with patch("ai_agent_bridge._config.DB_PATH", db_path), patch("ai_agent_bridge._db.DB_PATH", db_path):
+        _db.init_db().close()
+        yield db_path
+
+
+def _send(
+    content: str,
+    *,
+    task_id: str = "review-pr-5687",
+    to_llm: str = "grok",
+    consumed: bool = False,
+) -> int:
+    message_id = _messaging.send_message(
+        content,
+        task_id=task_id,
+        from_llm="claude",
+        to_llm=to_llm,
+        quiet=True,
+    )
+    if consumed:
+        _messaging.acknowledge(message_id, quiet=True, consumed_by_live_driver=True)
+    return message_id
+
+
+def test_cold_start_surfaces_existing_unconsumed_alias_rows(isolate_db: Path):
+    """A watcher begins at zero and includes permanent read aliases."""
+    canonical_id = _send("canonical pending", to_llm="grok")
+    alias_id = _send("historical pending", to_llm="grok-build")
+    _send("already consumed", to_llm="grok", consumed=True)
+
+    conn = _inbox_watch.open_readonly_db(isolate_db)
+    try:
+        events = _inbox_watch.poll_once(conn, "grok", last_seen=0)
+    finally:
+        conn.close()
+
+    assert [event.message_id for event in events] == [canonical_id, alias_id]
+    query = _inbox_watch.build_poll_query(("grok", "grok-build"))
+    assert "to_llm IN (?, ?)" in query
+    assert "consumed_by_live_driver = 0" in query
+    assert "ORDER BY id ASC" in query
+
+
+def test_cursor_advances_after_emission_and_does_not_reemit(isolate_db: Path):
+    """The in-memory cursor suppresses events only after their flush succeeds."""
+    message_id = _send("please drain")
+    output = io.StringIO()
+    conn = _inbox_watch.open_readonly_db(isolate_db)
+    try:
+        events = _inbox_watch.poll_once(conn, "grok", last_seen=0)
+        cursor = _inbox_watch.emit_notifications(events, last_seen=0, output=output)
+        repeated = _inbox_watch.poll_once(conn, "grok", last_seen=cursor)
+    finally:
+        conn.close()
+
+    assert cursor == message_id
+    assert repeated == []
+    assert f"id={message_id}" in output.getvalue()
+
+
+def test_empty_poll_is_silent(isolate_db: Path, tmp_path: Path):
+    """An empty monitor tick writes no stdout notification."""
+    output = io.StringIO()
+    cursor = _inbox_watch.run_watcher(
+        "grok",
+        db_path=isolate_db,
+        lock_dir=tmp_path / "locks",
+        output=output,
+        once=True,
+    )
+
+    assert cursor == 0
+    assert output.getvalue() == ""
+
+
+def test_notification_escapes_newlines_and_bounds_preview(isolate_db: Path):
+    """One message always creates one bounded Monitor event line."""
+    message_id = _send("first line\nsecond line\r\n" + ("x" * 400))
+    conn = _inbox_watch.open_readonly_db(isolate_db)
+    try:
+        event = _inbox_watch.poll_once(conn, "grok", last_seen=0)[0]
+    finally:
+        conn.close()
+
+    line = event.notification_line()
+    preview = line.split("preview=", maxsplit=1)[1]
+    assert f"id={message_id}" in line
+    assert "sender=claude" in line
+    assert "request_id=review-pr-5687" in line
+    assert "first line\\nsecond line\\r\\n" in line
+    assert "\n" not in line
+    assert len(preview) == _inbox_watch.MAX_PREVIEW_CHARS + len("...")
+
+
+def test_duplicate_watcher_lock_blocks_second_start(isolate_db: Path, tmp_path: Path):
+    """A second process cannot own the same canonical agent-slot watcher lock."""
+    lock_dir = tmp_path / "locks"
+    first = _inbox_watch.acquire_watcher_lock("grok", lock_dir)
+    try:
+        with pytest.raises(_inbox_watch.WatcherAlreadyRunningError, match="already running"):
+            _inbox_watch.run_watcher(
+                "grok-build",
+                db_path=isolate_db,
+                lock_dir=lock_dir,
+                once=True,
+            )
+    finally:
+        first.release()
+
+    assert _inbox_watch.run_watcher(
+        "grok-build",
+        db_path=isolate_db,
+        lock_dir=lock_dir,
+        once=True,
+    ) == 0
+
+
+def test_cursor_does_not_advance_when_stdout_flush_fails(isolate_db: Path):
+    """A failed event flush leaves the caller's cursor unchanged for replay."""
+    _send("retry this")
+    conn = _inbox_watch.open_readonly_db(isolate_db)
+    try:
+        events = _inbox_watch.poll_once(conn, "grok", last_seen=0)
+    finally:
+        conn.close()
+
+    class BrokenOutput:
+        def write(self, _line: str) -> int:
+            return 1
+
+        def flush(self) -> None:
+            raise OSError("stdout closed")
+
+    last_seen = 0
+    with pytest.raises(OSError, match="stdout closed"):
+        last_seen = _inbox_watch.emit_notifications(events, last_seen=last_seen, output=BrokenOutput())
+    assert last_seen == 0


### PR DESCRIPTION
Closes #5687

Brief: harness-neutral bridge inbox watcher — fleet-comms follow-up to #5688.

- Adds one read-only, alias-aware SQLite watcher with bounded one-line wakeup events.
- Guards each canonical handoff slot with an advisory pidfile lock and documents clean stop.
- Keeps the existing live-driver drain/ack checkpoints as the only consumption mechanism.

Validation:
- `.venv/bin/python -m pytest tests/ai_agent_bridge/ tests/test_bridge_*.py tests/test_coverage_bridge_audit.py tests/test_live_driver_message_consumption.py -q`
- `.venv/bin/ruff check scripts/ai_agent_bridge/_inbox_watch.py tests/ai_agent_bridge/test_inbox_watch.py`
- `shellcheck scripts/ai_agent_bridge/inbox_watch.sh`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`