### PR TITLE
test(hramatka): calibrate QG gate against real known-bad lesson fixtures (#5254)

### DIFF
--- a/scripts/audit/hramatka_qg_rules.py
+++ b/scripts/audit/hramatka_qg_rules.py
@@ -53,6 +53,8 @@ from scripts.lexicon.heritage_classifier import (
 )
 from scripts.verification.vesum import verify_word
 
+_UNSET = object()  # distinguishes "caller passed nothing" from "caller resolved to None"
+
 RULE_SET_ID = "hramatka"
 CHECKER_VERSION = "hramatka_ua_qg_rules.v2"
 EVIDENCE_SCHEMA_VERSION = "hramatka_ua_qg_evidence.v1"
@@ -1094,13 +1096,25 @@ def check_invented_forms(ctx: _ScanContext) -> list[dict[str, Any]]:
     return findings
 
 
-def _iter_mc_items(activity: Mapping[str, Any]) -> Iterable[tuple[str, list[str], Any]]:
-    """Yield (prompt, options, correct_answer) for multiple-choice style items."""
+def _iter_mc_items(
+    activity: Mapping[str, Any], answer_key: Any = _UNSET
+) -> Iterable[tuple[str, list[str], Any]]:
+    """Yield (prompt, options, correct_answer) for multiple-choice style items.
+
+    ``answer_key`` should be the caller's already-resolved key (prefer
+    ``_answer_key_for(entry, activity)`` so a BLOCK-level answer_key is visible
+    here too, not just an activity-level one). Omitting it falls back to
+    ``activity.get("answer_key")`` only, for backward compatibility — that
+    fallback silently loses every item's `correct` on lessons that store the
+    answer key on the enclosing block, which then makes every option (the
+    correct one included) look like a distractor to callers (#5691 review).
+    """
     payload = _payload(activity)
     items = payload.get("items") or activity.get("items") or []
     if not isinstance(items, list):
         return
-    answer_key = activity.get("answer_key")
+    if answer_key is _UNSET:
+        answer_key = activity.get("answer_key")
     key_items: list[Any] = []
     if isinstance(answer_key, Mapping) and isinstance(answer_key.get("items"), list):
         key_items = list(answer_key["items"])
@@ -1175,7 +1189,10 @@ def check_invalid_distractors(ctx: _ScanContext) -> list[dict[str, Any]]:
 
     for act_idx, entry in enumerate(ctx.activities):
         activity = _activity_body(entry)
-        for item_idx, (_prompt, options, correct) in enumerate(_iter_mc_items(activity)):
+        resolved_answer_key = _answer_key_for(entry, activity)
+        for item_idx, (_prompt, options, correct) in enumerate(
+            _iter_mc_items(activity, resolved_answer_key)
+        ):
             if len(options) < 2:
                 continue
             correct_opt = _resolve_correct_option(options, correct)

--- a/scripts/audit/hramatka_qg_rules.py
+++ b/scripts/audit/hramatka_qg_rules.py
@@ -663,8 +663,12 @@ def _hyphen_compound_all_attested(token: str) -> bool:
     """
     if "-" not in token:
         return False
-    parts = [p for p in token.split("-") if p]
-    if len(parts) < 2:
+    parts = token.split("-")
+    # Reject empty segments (leading/trailing/repeated hyphens, e.g. "текст--опора"):
+    # filtering them out would let a malformed token slip through as a valid
+    # two-part compound whenever the surviving fragments happen to be VESUM-real,
+    # bypassing the Russianism/invented-form check it exists to protect (#5691 review).
+    if len(parts) < 2 or not all(parts):
         return False
     return all(_vesum_hits(part) for part in parts)
 

--- a/scripts/audit/hramatka_qg_rules.py
+++ b/scripts/audit/hramatka_qg_rules.py
@@ -4,10 +4,11 @@
 Deterministic ($0, no-LLM) checks for generative hramatka lesson_json artifacts.
 Call local Python APIs only — never shell out to MCP.
 
-Tier-1: russianism/surzhyk/calque · invalid distractor · answer-key placeholder
+Tier-1: russianism/surzhyk/calque · invalid distractor (incl. degenerate reuse) · answer-key placeholder
 Tier-2: structural activity integrity · empty learner surface · task-language CEFR · invented form
 
-Issue: load-bearing QG for hramatka (#5187 feedback).
+Issue: load-bearing QG for hramatka (#5187 feedback). Calibrated against real
+generated-lesson defects, not just synthetic planted faults (#5254).
 """
 
 from __future__ import annotations
@@ -53,7 +54,7 @@ from scripts.lexicon.heritage_classifier import (
 from scripts.verification.vesum import verify_word
 
 RULE_SET_ID = "hramatka"
-CHECKER_VERSION = "hramatka_ua_qg_rules.v1"
+CHECKER_VERSION = "hramatka_ua_qg_rules.v2"
 EVIDENCE_SCHEMA_VERSION = "hramatka_ua_qg_evidence.v1"
 FIXTURE_SCHEMA_VERSION = "hramatka_ua_qg_fixtures.v1"
 
@@ -139,6 +140,12 @@ _ACTIVITY_KEEP_KEYS = frozenset(
 )
 
 _CYRILLIC_TOKEN_RE = re.compile(r"[А-Яа-яЁёІіЇїЄєҐґ][А-Яа-яЁёІіЇїЄєҐґ'ʼ’\-]*")
+# Pedagogical stress annotation (наголос) — combining acute/grave accent after a
+# vowel, e.g. "соро́чка". Real hramatka anchors carry these; stripped before
+# tokenizing so a stressed word attests against VESUM as one token instead of
+# shattering into fragments ("соро" + "чка") that false-fire NON_VESUM_FORM /
+# RUSSIAN_SHADOW_RUSSICISM. Verified against real generated soak lessons (#5254).
+_STRESS_MARK_RE = re.compile("[\u0300\u0301]")
 # Whole-value placeholders only — ellipsis inside a real answer is not a placeholder.
 _PLACEHOLDER_EXACT_RE = re.compile(
     r"(?:"
@@ -231,6 +238,7 @@ def checker_config_hash() -> str:
         "checks": [
             "russianism_calque",
             "invalid_distractor",
+            "degenerate_distractor_reuse",
             "answer_key_placeholder",
             "structural_activity_integrity",
             "empty_learner_surface",
@@ -477,8 +485,12 @@ def adapt_lesson_json_to_module_dir(
 # ---------------------------------------------------------------------------
 
 
+def _strip_stress_marks(text: str) -> str:
+    return _STRESS_MARK_RE.sub("", text)
+
+
 def _cyrillic_tokens(text: str) -> list[str]:
-    return _CYRILLIC_TOKEN_RE.findall(text)
+    return _CYRILLIC_TOKEN_RE.findall(_strip_stress_marks(text))
 
 
 def _apostrophe_variants(token: str) -> list[str]:
@@ -640,12 +652,29 @@ def _unknown_token_status() -> dict[str, Any]:
     }
 
 
+def _hyphen_compound_all_attested(token: str) -> bool:
+    """True when every hyphen-separated part of a compound is its own VESUM word.
+
+    Appositive noun+noun compounds (текст-опора, речення-опора, держав-учасниць)
+    are not VESUM lemmas as a whole, but both halves independently are. Without
+    this check the per-token russian-shadow / invented-form pass sees one
+    VESUM-absent blob and misfires — a real false-fail found on real generated
+    hramatka content (#5254).
+    """
+    if "-" not in token:
+        return False
+    parts = [p for p in token.split("-") if p]
+    if len(parts) < 2:
+        return False
+    return all(_vesum_hits(part) for part in parts)
+
+
 def _classify_token(token: str) -> dict[str, Any]:
     """Classify with VESUM-first short-circuit (performance + apostrophe tolerance).
 
     Partial sources.db / missing VESUM → degrade to unknown (no crash).
     """
-    if _vesum_hits(token):
+    if _vesum_hits(token) or _hyphen_compound_all_attested(token):
         return {
             "classification": "standard",
             "attestations": [{"source": "vesum", "ref": token}],
@@ -1085,6 +1114,19 @@ def _iter_mc_items(activity: Mapping[str, Any]) -> Iterable[tuple[str, list[str]
             correct = entry.get("correct") if isinstance(entry, Mapping) else entry
         yield str(item.get("prompt") or item.get("question") or item.get("stem") or ""), options, correct
 
+    # Cloze blanks carry their own per-blank distractor options — same shape,
+    # answer already resolved (no answer_key fallback needed).
+    blanks = payload.get("blanks")
+    if isinstance(blanks, list):
+        for idx, blank in enumerate(blanks):
+            if not isinstance(blank, Mapping):
+                continue
+            options_raw = blank.get("options") or []
+            if not isinstance(options_raw, list) or not options_raw:
+                continue
+            options = [str(o) for o in options_raw]
+            yield str(blank.get("id") or f"blank[{idx}]"), options, blank.get("answer")
+
 
 def _resolve_correct_option(options: Sequence[str], correct: Any) -> str | None:
     if correct is None:
@@ -1120,6 +1162,12 @@ def check_invalid_distractors(ctx: _ScanContext) -> list[dict[str, Any]]:
     """Tier-1: distractors must be real VESUM forms, distinct, non-duplicate, non-synonym."""
     findings: list[dict[str, Any]] = []
     file_text = ctx.texts.get("activities.yaml") or ctx.texts.get("module.md") or ""
+    # Same distractor set reused verbatim across items — a real generation defect
+    # (soak-verified, #5254): the model gets stuck and copy-pastes one "filler"
+    # pair everywhere, so the learner can answer by pattern-matching the filler
+    # instead of reading the text. Tracked across the whole lesson, not just one
+    # activity, because the real defect repeats across activity boundaries too.
+    distractor_set_locations: dict[tuple[str, ...], list[tuple[int, int]]] = {}
 
     for act_idx, entry in enumerate(ctx.activities):
         activity = _activity_body(entry)
@@ -1132,6 +1180,7 @@ def check_invalid_distractors(ctx: _ScanContext) -> list[dict[str, Any]]:
             correct_lemma = correct_tokens[0] if len(correct_tokens) == 1 else correct_norm
 
             seen_norms: set[str] = set()
+            item_distractor_norms: set[str] = set()
             for opt in options:
                 norm = _normalize_option(opt)
                 if not norm:
@@ -1175,6 +1224,7 @@ def check_invalid_distractors(ctx: _ScanContext) -> list[dict[str, Any]]:
                     )
                     continue
                 seen_norms.add(norm.casefold())
+                item_distractor_norms.add(norm.casefold())
 
                 tokens = _cyrillic_tokens(norm)
                 # Single-token distractors: require VESUM form
@@ -1262,6 +1312,32 @@ def check_invalid_distractors(ctx: _ScanContext) -> list[dict[str, Any]]:
                             text=file_text,
                         )
                     )
+
+            if len(item_distractor_norms) >= 2:
+                key = tuple(sorted(item_distractor_norms))
+                distractor_set_locations.setdefault(key, []).append((act_idx, item_idx))
+
+    for distractor_set, locations in distractor_set_locations.items():
+        if len(locations) < 3:
+            continue
+        first_act, first_item = locations[0]
+        findings.append(
+            _finding(
+                issue_id="DEGENERATE_DISTRACTOR_REUSE",
+                rule_id="hramatka_degenerate_distractor_reuse",
+                dimension="distractor_quality",
+                severity="critical",
+                file="activities.yaml",
+                line=1,
+                excerpt=" / ".join(distractor_set)[:160],
+                message=(
+                    f"Distractor set {list(distractor_set)} is reused verbatim across "
+                    f"{len(locations)} items (first: activity[{first_act}] item[{first_item}]) — "
+                    "learner can answer by pattern-matching the filler, not by reading the text."
+                ),
+                text=file_text,
+            )
+        )
     return findings
 
 

--- a/tests/audit/test_hramatka_qg_rules.py
+++ b/tests/audit/test_hramatka_qg_rules.py
@@ -312,6 +312,13 @@ def test_hyphen_compound_all_attested_helper() -> None:
     assert not hq._hyphen_compound_all_attested("текст-жмурклея")
     # No hyphen at all → not a compound, nothing to split.
     assert not hq._hyphen_compound_all_attested("жмурклея")
+    # Malformed repeated/leading/trailing hyphens must NOT be rescued even when
+    # every surviving non-empty fragment is independently VESUM-real — an empty
+    # segment is evidence of a broken token, not a clean two-part compound
+    # (cross-family review finding on #5691).
+    assert not hq._hyphen_compound_all_attested("текст--опора")
+    assert not hq._hyphen_compound_all_attested("-текст-опора")
+    assert not hq._hyphen_compound_all_attested("текст-опора-")
     status = hq._classify_token("тексті-опорі")
     assert status["vesum_attested"] is True
     assert not hq._is_russianism_token("тексті-опорі", status)

--- a/tests/audit/test_hramatka_qg_rules.py
+++ b/tests/audit/test_hramatka_qg_rules.py
@@ -54,7 +54,19 @@ _PLANTED_NON_VESUM = frozenset(
 )
 _OVERLEVEL_TOKEN = "чигати"
 
-_CYR_TOKEN_RE = re.compile(r"[А-Яа-яЁёІіЇїЄєҐґ][А-Яа-яЁёІіЇїЄєҐґ'ʼ’\-]*")
+# Hyphenated appositive compounds that must resolve via _hyphen_compound_all_attested
+# (each half independently VESUM-real), not via a literal whole-compound VESUM row.
+# Excluded from controlled-VESUM auto-population so the real-fixture tests below
+# actually exercise the split-and-verify fallback instead of accidentally passing
+# because the compound itself got auto-inserted as one form. Real false-positive
+# documented against generated content (#5254).
+_HYPHEN_COMPOUND_WHOLE_EXCLUDED = frozenset(
+    {
+        "тексті-опорі",
+        "речення-опора",
+        "держав-учасниць",
+    }
+)
 
 
 def _by_id(report: dict) -> dict[str, dict]:
@@ -66,14 +78,18 @@ def _issue_ids(evidence: dict) -> set[str]:
 
 
 def _collect_fixture_tokens() -> set[str]:
-    """Surface tokens from synthetic fixtures + hard-coded clean lessons in this file."""
+    """Surface tokens from synthetic fixtures + hard-coded clean lessons in this file.
+
+    Uses hq._cyrillic_tokens (not a locally-drifted regex) so stress-mark
+    stripping stays in sync with what the checks themselves see (#5254).
+    """
     data = yaml.safe_load(FIXTURE_FILE.read_text(encoding="utf-8"))
     tokens: set[str] = set()
     for entry in data.get("fixtures") or []:
         lesson = entry.get("lesson_json") or {}
         adapted = adapt_lesson_json(lesson, slug=str(entry.get("id") or "x"))
         for _path, text in adapted.learner_strings:
-            for tok in _CYR_TOKEN_RE.findall(text or ""):
+            for tok in hq._cyrillic_tokens(text or ""):
                 tokens.add(tok.casefold())
     # Hard-coded clean lessons used by CLI / dispatch / direct-scan tests.
     extras = (
@@ -99,7 +115,7 @@ def _collect_fixture_tokens() -> set[str]:
         "НАТО",
     )
     for text in extras:
-        for tok in _CYR_TOKEN_RE.findall(text):
+        for tok in hq._cyrillic_tokens(text):
             tokens.add(tok.casefold())
     return tokens
 
@@ -109,7 +125,9 @@ def _build_controlled_vesum(path: Path) -> None:
     tokens = sorted(
         t
         for t in _collect_fixture_tokens()
-        if t not in _PLANTED_NON_VESUM and not re.fullmatch(r"ф+", t)
+        if t not in _PLANTED_NON_VESUM
+        and t not in _HYPHEN_COMPOUND_WHOLE_EXCLUDED
+        and not re.fullmatch(r"ф+", t)
     )
     conn = sqlite3.connect(str(path))
     try:
@@ -239,7 +257,7 @@ def test_hramatka_fixture_suite_load_bearing() -> None:
         for row in report["results"]
         if not row["passed"]
     }
-    assert report["summary"]["total"] >= 10
+    assert report["summary"]["total"] >= 13
 
     by_id = _by_id(report)
     assert by_id["clean-b1-lesson"]["actual_verdict"] == "PASS"
@@ -252,6 +270,52 @@ def test_hramatka_fixture_suite_load_bearing() -> None:
     assert by_id["planted-invented-form"]["actual_verdict"] == "WARN"
     assert by_id["planted-empty-surface"]["actual_verdict"] == "FAIL"
     assert by_id["planted-mc-too-few"]["actual_verdict"] == "FAIL"
+    # Real (soak-generated, not planted) fixtures — #5254.
+    assert by_id["real-degenerate-distractor-reuse"]["actual_verdict"] == "FAIL"
+    assert by_id["real-hyphen-compound-clean"]["actual_verdict"] == "PASS"
+    assert by_id["real-stress-mark-clean"]["actual_verdict"] == "PASS"
+
+
+def test_real_generated_defects_are_caught() -> None:
+    """Real (soak-generated) known-bad lessons must be caught — the #5254 bar.
+
+    catches-planted-faults (#5253) is necessary but not sufficient: a gate is
+    only load-bearing once proven against an artifact a real run actually
+    produced. real-degenerate-distractor-reuse is trimmed from a real
+    Києво-Печерська лавра B1 lesson (generator: google/gemma-4-31b-it) where
+    the SAME distractor pair was reused verbatim across every quiz item —
+    observed in 5/5 retained real "ready" soak lessons, not a synthetic plant.
+    """
+    report = run_fixtures(FIXTURE_FILE)
+    by_id = _by_id(report)
+
+    evidence = by_id["real-degenerate-distractor-reuse"]["evidence"]
+    assert evidence["verdict"] == "FAIL"
+    assert "DEGENERATE_DISTRACTOR_REUSE" in _issue_ids(evidence)
+
+    # And the two real false-positive fixes hold on the real content that
+    # exposed them (both reported as false-fails against real generated output).
+    for real_clean_id in ("real-hyphen-compound-clean", "real-stress-mark-clean"):
+        clean_evidence = by_id[real_clean_id]["evidence"]
+        assert clean_evidence["verdict"] == "PASS"
+        assert all_findings(clean_evidence) == [], (
+            f"{real_clean_id} must have zero findings, got {all_findings(clean_evidence)}"
+        )
+
+
+def test_hyphen_compound_all_attested_helper() -> None:
+    """Direct unit coverage: split-and-verify only when EVERY half is VESUM-real."""
+    assert hq._hyphen_compound_all_attested("тексті-опорі")
+    assert hq._hyphen_compound_all_attested("речення-опора")
+    assert hq._hyphen_compound_all_attested("держав-учасниць")
+    # A hyphenated token with a genuinely-invented half must NOT be rescued.
+    assert not hq._hyphen_compound_all_attested("текст-жмурклея")
+    # No hyphen at all → not a compound, nothing to split.
+    assert not hq._hyphen_compound_all_attested("жмурклея")
+    status = hq._classify_token("тексті-опорі")
+    assert status["vesum_attested"] is True
+    assert not hq._is_russianism_token("тексті-опорі", status)
+    assert not hq._is_invented_form("тексті-опорі", status)
 
 
 def test_each_check_fires_on_planted_fault() -> None:

--- a/tests/audit/test_hramatka_qg_rules.py
+++ b/tests/audit/test_hramatka_qg_rules.py
@@ -274,6 +274,7 @@ def test_hramatka_fixture_suite_load_bearing() -> None:
     assert by_id["real-degenerate-distractor-reuse"]["actual_verdict"] == "FAIL"
     assert by_id["real-hyphen-compound-clean"]["actual_verdict"] == "PASS"
     assert by_id["real-stress-mark-clean"]["actual_verdict"] == "PASS"
+    assert by_id["distractor-reuse-block-level-key-clean"]["actual_verdict"] == "PASS"
 
 
 def test_real_generated_defects_are_caught() -> None:
@@ -301,6 +302,26 @@ def test_real_generated_defects_are_caught() -> None:
         assert all_findings(clean_evidence) == [], (
             f"{real_clean_id} must have zero findings, got {all_findings(clean_evidence)}"
         )
+
+
+def test_iter_mc_items_sees_block_level_answer_key() -> None:
+    """Distractor-reuse detector must resolve `correct` via a BLOCK-level answer_key.
+
+    Three questions sharing one 3-option pool with a DIFFERENT correct answer
+    each is a legitimate activity shape. Before the fix, _iter_mc_items only
+    read activity.answer_key; a block-level-only key left `correct` as None for
+    every item, which recorded every option (including the true answer) as a
+    distractor and false-fired DEGENERATE_DISTRACTOR_REUSE on all three
+    questions sharing the same underlying option set (cross-family review
+    finding on #5691).
+    """
+    report = run_fixtures(FIXTURE_FILE)
+    by_id = _by_id(report)
+    evidence = by_id["distractor-reuse-block-level-key-clean"]["evidence"]
+    assert evidence["verdict"] == "PASS"
+    assert all_findings(evidence) == [], (
+        f"expected zero findings, got {all_findings(evidence)}"
+    )
 
 
 def test_hyphen_compound_all_attested_helper() -> None:

--- a/tests/fixtures/hramatka_qg/fixtures.yaml
+++ b/tests/fixtures/hramatka_qg/fixtures.yaml
@@ -362,3 +362,149 @@ fixtures:
       - issue_id: MC_TOO_FEW_OPTIONS
         dimension: activity_structure
         severity: critical
+
+  # ---------------------------------------------------------------------
+  # REAL calibration fixtures (#5254) — sourced from actually-generated
+  # hramatka lesson artifacts (retained local/ab soak runs, google/gemma-4-31b-it
+  # + deepseek-v4 lanes), not hand-planted faults. Trimmed for test size but the
+  # defect-bearing text is verbatim/near-verbatim from the real generated output.
+  # ---------------------------------------------------------------------
+
+  # Real generated defect: the model reused the SAME distractor pair verbatim
+  # across every quiz item instead of drawing fresh wrong answers — the learner
+  # can answer by pattern-matching "not ла, not київський" without reading the
+  # text. Observed in 100% of retained real "ready" soak lessons (5/5), always
+  # >=7 repeats; threshold here is 3. Trimmed from a real Києво-Печерська лавра
+  # B1 lesson (generator: google/gemma-4-31b-it).
+  - id: real-degenerate-distractor-reuse
+    level: b1
+    slug: real-degenerate-distractor-reuse
+    expected_verdict: FAIL
+    lesson_json:
+      title: "Ки́єво-Пече́рська ла́вра — київський православний монастирський комплекс"
+      level: B1
+      anchor:
+        text: >
+          Ки́єво-Пече́рська ла́вра — київський православний монастирський комплекс.
+          Один із найбільших християнських центрів України. Лавра належить державі,
+          а релігійні організації користуються нею на правах оренди. Заснована 1051
+          року як печерний монастир за межами Києва.
+      blocks:
+        - type: quiz
+          activity:
+            type: quiz
+            title: Тест
+            payload:
+              type: quiz
+              instruction: Оберіть правильну відповідь за текстом.
+              items:
+                - question: Яке з цих слів зустрічається в реченні про християнські центри України?
+                  options: [із, ла, київський]
+                  correct: 0
+                - question: Яке з цих слів зустрічається в реченні про власність лаври?
+                  options: [належить, ла, київський]
+                  correct: 0
+                - question: Яке з цих слів зустрічається в реченні про заснування монастиря?
+                  options: [печерний, ла, київський]
+                  correct: 0
+            answer_key:
+              items:
+                - index: 0
+                  correct: 0
+                - index: 1
+                  correct: 0
+                - index: 2
+                  correct: 0
+          answer_key:
+            items:
+              - index: 0
+                correct: 0
+              - index: 1
+                correct: 0
+              - index: 2
+                correct: 0
+    expected_findings:
+      - issue_id: DEGENERATE_DISTRACTOR_REUSE
+        excerpt: "ла"
+        dimension: distractor_quality
+        severity: critical
+
+  # Real false-positive fix: hyphenated appositive noun+noun compounds
+  # (тексті-опорі / речення-опора / держав-учасниць) are not VESUM lemmas as a
+  # whole, but every half independently is. Before the fix these critical-failed
+  # legitimate Ukrainian. тексті-опорі / речення-опора are the exact forms
+  # reported against real generated content on issue #5254; держав-учасниць
+  # ("представники держав-учасниць Конвенції ЮНЕСКО") is verbatim from a real
+  # generated borsch-heritage lesson anchor.
+  - id: real-hyphen-compound-clean
+    level: b1
+    slug: real-hyphen-compound-clean
+    expected_verdict: PASS
+    lesson_json:
+      title: Урок про текст-опору
+      level: B1
+      anchor:
+        text: >
+          Учитель обирає короткий текст і зберігає в ньому опору для кожного уроку:
+          у тексті є факти, а в опорі — приклади. Опора завжди спирається на
+          реальний текст. Кожне речення в тексті важливе. У тексті-опорі завжди є
+          щось корисне для учня, а кожне речення-опора береться з тексту, а не
+          вигадується. У світі є багато держав, і в кожному міжнародному проєкті
+          було багато учасниць. Міжурядовий комітет з охорони нематеріальної
+          культурної спадщини, до складу якого увійшли представники
+          держав-учасниць Конвенції ЮНЕСКО, вніс культуру приготування
+          українського борщу до Списку нематеріальної культурної спадщини ЮНЕСКО.
+      blocks:
+        - type: true-false
+          activity:
+            type: true-false
+            title: Перевірка
+            payload:
+              type: true-false
+              instruction: Позначте, чи правильні твердження за текстом.
+              items:
+                - statement: Кожне речення-опора береться з тексту.
+                  correct: true
+            answer_key:
+              items:
+                - index: 0
+                  correct: true
+          answer_key: "1 П"
+
+  # Real false-positive fix: pedagogical stress annotation (наголос, combining
+  # acute accent) shatters real words into meaningless fragments under the old
+  # tokenizer ("соро́чка" -> "соро" + "чка"), false-firing NON_VESUM_FORM on
+  # completely legitimate Ukrainian. Title/anchor/statement text below is
+  # verbatim from a real generated "Вишиванка" B1 lesson (generator:
+  # google/gemma-4-31b-it).
+  - id: real-stress-mark-clean
+    level: b1
+    slug: real-stress-mark-clean
+    expected_verdict: PASS
+    lesson_json:
+      title: "Виши́ва́нка — новітня назва народної руської сорочки"
+      level: B1
+      anchor:
+        text: >
+          Виши́ва́нка — новітня назва народної руської (української та білоруської)
+          сорочки, прикрашеної орнаментованою вишивкою. Важлива складова
+          українського національного вбрання. Поділяється на жіночі й чоловічі
+          сорочки. Має спільне походження з вишитими сорочками слов'янських
+          народів Східної та Центральної Європи.
+      blocks:
+        - type: fill-in
+          activity:
+            type: fill-in
+            title: Оберіть правильну форму
+            payload:
+              type: fill-in
+              instruction: Оберіть правильну форму.
+              items:
+                - sentence: "Традиційні назви — ____, вишита сорочка, вишивана сорочка."
+                  answer: соро́чка
+                  options: [соро́чка, вишита, вишивана]
+            answer_key:
+              items:
+                - index: 0
+                  answer: соро́чка
+          answer_key: "1 сорочка"

--- a/tests/fixtures/hramatka_qg/fixtures.yaml
+++ b/tests/fixtures/hramatka_qg/fixtures.yaml
@@ -429,6 +429,53 @@ fixtures:
         dimension: distractor_quality
         severity: critical
 
+  # False-positive fix: the distractor-reuse detector must see a BLOCK-level
+  # answer_key, not just an activity-level one. Three questions here legitimately
+  # share the same 3-option pool while each targets a DIFFERENT correct answer —
+  # a normal, valid activity shape, not the model-filler-repeat defect above.
+  # Before the fix, _iter_mc_items only read activity.answer_key (absent here —
+  # this lesson stores it on the enclosing block instead), so `correct` resolved
+  # to None for every item and every option — including the true answer — was
+  # recorded as a distractor, making all three questions look like the SAME
+  # 3-way distractor set and false-firing DEGENERATE_DISTRACTOR_REUSE
+  # (cross-family review finding on #5691, not a soak observation).
+  - id: distractor-reuse-block-level-key-clean
+    level: b1
+    slug: distractor-reuse-block-level-key-clean
+    expected_verdict: PASS
+    lesson_json:
+      title: Слова уроку
+      level: B1
+      anchor:
+        text: >
+          На уроці ми читаємо текст, складаємо речення й шукаємо опору для
+          власних думок. Текст дає факти, речення передає завершену думку,
+          а опора допомагає висловитися впевнено.
+      blocks:
+        - type: quiz
+          activity:
+            type: quiz
+            title: Тест
+            payload:
+              type: quiz
+              instruction: Оберіть правильне слово за визначенням.
+              items:
+                - question: Яке слово означає писемний матеріал для читання?
+                  options: [текст, речення, опора]
+                - question: Яке слово означає граматично завершену думку?
+                  options: [текст, речення, опора]
+                - question: Яке слово означає підтримку чи основу для думки?
+                  options: [текст, речення, опора]
+          answer_key:
+            items:
+              - index: 0
+                correct: 0
+              - index: 1
+                correct: 1
+              - index: 2
+                correct: 2
+    expected_findings: []
+
   # Real false-positive fix: hyphenated appositive noun+noun compounds
   # (тексті-опорі / речення-опора / держав-учасниць) are not VESUM lemmas as a
   # whole, but every half independently is. Before the fix these critical-failed


### PR DESCRIPTION
## Summary

Closes the loop from "catches planted faults" (#5253) to "catches real
failures" (#5254's actual bar) by wiring 3 calibration fixtures trimmed from
**actually-generated** hramatka lesson artifacts (real retained local/ab soak
runs, `google/gemma-4-31b-it` generator lane) into `scripts/audit/hramatka_qg_rules.py`,
and fixing the 2 real precision gaps they exposed.

## Real defects found (soak-verified, not planted)

- **New `DEGENERATE_DISTRACTOR_REUSE` check** (`distractor_quality`): the
  generator reuses the *same* distractor pair verbatim across nearly every
  quiz/cloze item in a lesson — e.g. every option list in a "Києво-Печерська
  лавра" B1 lesson was `[correct, "ла", "київський"]`. The learner can answer
  by pattern-matching the filler, never reading the text. **This was present
  in 5/5 retained real "ready" soak lessons I scanned (100%)** and was
  previously invisible to the gate — each individual filler word is itself a
  real VESUM form, so the existing per-option checks stayed quiet. Fixed by
  tracking distractor-set signatures per lesson and flagging ≥3 verbatim
  reuses. Also extends `_iter_mc_items` to cover cloze `blanks` (previously
  only `items` was checked), since the real defect shows up there too.
- **Hyphenated-compound false-fail fix**: appositive noun+noun compounds
  (`тексті-опорі`, `речення-опора`, `держав-учасниць`) aren't VESUM lemmas as
  a whole, but every half independently is. Before this fix they
  critical-failed as `RUSSIAN_SHADOW_RUSSICISM`/`NON_VESUM_FORM` — including
  the project's own ULP "text-opora" convention, exactly as reported against
  real generated content on this issue's comment thread. Fixed via
  `_hyphen_compound_all_attested`: split on `-`, require every part to be its
  own VESUM word.
- **Stress-mark false-fail fix**: pedagogical stress annotation (combining
  acute accent, U+0301) shattered real words into meaningless fragments
  under the old tokenizer (`"соро́чка"` → `"соро"` + `"чка"`), false-firing
  `NON_VESUM_FORM` on completely legitimate Ukrainian. Fixed by stripping
  combining stress marks before tokenizing (`_strip_stress_marks`).

## Honest gap

**Placeholder-answer-key, broken/structural-activity, and Russianism/calque
real-generated exemplars were not found** despite scanning all currently
retained real soak + bakeoff lesson artifacts (~36 lessons across
gemma-ais / deepseek-v4-pro / deepseek-v4-flash lanes) plus 56 retained
failure records (none carry `lesson_json` — they fail before assembly).
Those 3 categories remain covered by the existing synthetic/corpus-real
fixtures from #5253. Posting a status comment on #5254 with this finding for
content lane to keep soaking against.

## Verification

```
.venv/bin/python -m pytest tests/audit/test_hramatka_qg_rules.py -q
# 21 passed (was 19; +2 new tests, 3 new fixtures)

.venv/bin/ruff check scripts/audit/hramatka_qg_rules.py tests/audit/test_hramatka_qg_rules.py
# All checks passed!
```

`CHECKER_VERSION` bumped `v1` → `v2` (rule-set behavior materially changed:
new check + 2 detection-logic fixes). No other module hardcodes the hramatka
checker version/hash string — verified via repo-wide grep.

`tests/audit/test_curriculum_qg_harness.py::test_current_b1_27_scans_as_pass_with_compact_evidence_shape`
fails in this worktree both before and after this change — pre-existing,
caused by the sparse checkout excluding `curriculum/`, not by this PR.

## Test plan
- [x] `pytest tests/audit/test_hramatka_qg_rules.py -q` — 21 passed
- [x] `ruff check` on both changed source files — clean
- [x] Confirmed no regression on `origin/main` for the one unrelated
      curriculum-harness test failure (sparse-checkout artifact)
- [ ] Independent cross-family review (not self-approved/auto-merged)

Refs #5254, #4542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)