### PR TITLE
docs(dispatch-briefs): archive #5254/#5187 briefs to canonical location

### DIFF
--- a/docs/dispatch-briefs/2026-07-23-5187-hramatka-target-adapter.md
+++ b/docs/dispatch-briefs/2026-07-23-5187-hramatka-target-adapter.md
@@ -1,0 +1,39 @@
+# Brief: Issue #5187 - Lesson-artifact target adapter for shadow llm_qg capture contract
+
+## Goal
+Implement the lesson-artifact target adapter for `hramatka` teacher-lesson artifacts so they can enter the `qg_shadow_run` / `qg_workflow` capture contract cleanly.
+
+## Background
+Currently `qg_workflow.ReviewTarget` assumes standard module directories (containing `module.md`, `activities.yaml`, `vocabulary.yaml`, `resources.yaml`). `hramatka` teacher-lesson artifacts have a different shape (teacher lesson JSON/YAML schemas).
+Issue #5187 calls for a target adapter for `hramatka` teacher-lesson artifacts before they enter `qg_shadow_run`.
+
+## Requirements
+1. Create `scripts/audit/hramatka_target_adapter.py`:
+   - Learner-facing field selection (selects user-facing text from hramatka lesson structure for evaluation, filtering out non-learner metadata).
+   - Canonical serialization + SHA256 content hash generator.
+   - Level/policy mapping (map hramatka level metadata to standard CEFR level/policy).
+   - Source / teacher-note EXCLUSION (filters out teacher internal prompts, source references, private annotations).
+   - Privacy/retention rules enforcement (strips user identifiers, private tokens, raw infrastructure secrets).
+   - Provide an adapter method `convert_hramatka_lesson_to_review_target(...)` or `HramatkaLessonAdapter` class that produces or wraps a `qg_workflow.ReviewTarget` or schema compatible with `qg_shadow_run.py`.
+
+2. Create comprehensive pytest test suite in `tests/test_hramatka_target_adapter.py`:
+   - Test field selection & exclusions (teacher notes excluded, learner fields included).
+   - Test canonical serialization & content hashing.
+   - Test level/policy mapping.
+   - Test privacy/retention sanitization.
+   - Test integration/conversion to `ReviewTarget` shape.
+
+3. Rules & Constraints:
+   - Python 3.12 compatible.
+   - Follow all repo rules: use `.venv/bin/python`, no modification to linter configs or `.python-version`.
+   - Run `pytest tests/test_hramatka_target_adapter.py` and `ruff check scripts/audit/hramatka_target_adapter.py tests/test_hramatka_target_adapter.py`.
+   - Commit with conventional commit message: `feat(harness): implement hramatka target adapter for llm_qg shadow capture (#5187)`
+   - Trailer: `X-Agent: codex/5187-hramatka-target-adapter`
+   - Create PR referencing #5187 and #4542.
+   - DO NOT auto-merge or self-approve.
+
+## Provenance
+Recovered from a misplaced runtime copy at `.claude/dispatch-briefs/dispatch-5187.md` (gitignored
+deploy target — never a durable location; broke `npm run agents:deploy` orphan-path parity) and
+archived here at its canonical, git-tracked location per `scripts/audit/lint_dispatch_brief.py`'s
+`BRIEFS_GLOB`. Executed as PR #5690 (merged).

--- a/docs/dispatch-briefs/2026-07-23-5254-hramatka-real-fixtures.md
+++ b/docs/dispatch-briefs/2026-07-23-5254-hramatka-real-fixtures.md
@@ -1,0 +1,34 @@
+# Brief: Issue #5254 - Calibrate hramatka QG gate against REAL known-bad lessons (fixtures)
+
+## Goal
+Calibrate `scripts/audit/hramatka_qg_rules.py` against REAL known-bad lesson fixtures (real generated defects, not just synthetic planted-fault fixtures).
+
+## Background
+Currently `scripts/audit/hramatka_qg_rules.py` is calibrated against synthetic planted-fault fixtures. Issue #5254 calls for adding real generated defect fixtures (Russianism/calque, invalid distractor, placeholder answer key, broken activity, over-level task word) to ensure full load-bearing coverage.
+
+## Requirements
+1. In `tests/test_hramatka_qg_rules.py` (or dedicated fixture file under `tests/fixtures/hramatka/`):
+   - Add real known-bad lesson exemplars representing:
+     - Real generated Russianism / calque defect
+     - Invalid distractor defect
+     - Placeholder answer key defect
+     - Structural activity defect
+     - Over-level task vocabulary defect
+   - Assert that `run_hramatka_qg()` catches every real exemplar.
+   - If any real exemplar slips through existing rules in `scripts/audit/hramatka_qg_rules.py` -> fix/extend the corresponding rule in `scripts/audit/hramatka_qg_rules.py` so that it is caught.
+
+2. Verify:
+   - Run `pytest tests/test_hramatka_qg_rules.py` and ensure all tests pass.
+   - Run `ruff check scripts/audit/hramatka_qg_rules.py tests/test_hramatka_qg_rules.py`.
+
+3. Commit & PR:
+   - Commit message: `test(hramatka): calibrate QG gate against real known-bad lesson fixtures (#5254)`
+   - Trailer: `X-Agent: sonnet/5254-hramatka-real-fixtures` (or whichever agent/lane is assigned)
+   - Create PR referencing #5254 and #4542.
+   - DO NOT auto-merge or self-approve.
+
+## Provenance
+Recovered from a misplaced runtime copy at `.claude/dispatch-briefs/dispatch-5254.md` (gitignored
+deploy target — never a durable location; broke `npm run agents:deploy` orphan-path parity) and
+archived here at its canonical, git-tracked location per `scripts/audit/lint_dispatch_brief.py`'s
+`BRIEFS_GLOB`. Executed as PR #5691.


### PR DESCRIPTION
## Summary
- Two dispatch-brief scratch files had landed directly under `.claude/dispatch-briefs/` — a gitignored deploy target that must exactly mirror `agents_extensions/shared/` via `npm run agents:deploy`.
- This tripped the orphan-path preflight guard (`scripts/deploy_orphan_paths.sh`), aborting every deploy with "undeclared orphan 'dispatch-briefs' in destination".
- Archived both briefs to their canonical, lint-covered location (`docs/dispatch-briefs/`, checked by `scripts/audit/lint_dispatch_brief.py`) and deleted the misplaced runtime copies.
- Verified `npm run agents:deploy` now completes cleanly with no orphan warning.

## Test plan
- [x] `npm run agents:deploy` — completes, no orphan-path abort.
- [x] `.venv/bin/python scripts/audit/lint_dispatch_brief.py --brief docs/dispatch-briefs/2026-07-23-5254-hramatka-real-fixtures.md` — clean.
- [x] `.venv/bin/python scripts/audit/lint_dispatch_brief.py --brief docs/dispatch-briefs/2026-07-23-5187-hramatka-target-adapter.md` — clean.
- [x] Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)