### PR TITLE
fix(wiki): case-insensitive Cyrillic + phrase-substring style_guide lookup

### DIFF
--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -1792,14 +1792,68 @@ def search_wikipedia(ukr_keywords: set[str], max_total: int = 10) -> list[dict]:
 # ── Dictionary lookup functions (indexed tables) ────────────────
 
 
+def _fold_dict_key(value: str) -> str:
+    """Case-fold a headword/query for Cyrillic-safe matching.
+
+    SQLite's `COLLATE NOCASE` only folds ASCII A-Z, so a lowercase Cyrillic
+    query (e.g. "приймати") never matches a capitalized headword (e.g.
+    "Приймати") through SQL alone. Python's Unicode-aware `.lower()` does,
+    and stripping the combining acute (U+0301) also lets stressed and
+    unstressed forms match each other.
+    """
+    return value.replace("\u0301", "").strip().lower()
+
+
+def _dict_lookup_contains(
+    conn: sqlite3.Connection,
+    table: str,
+    word: str,
+    limit: int,
+) -> list[dict]:
+    """Case-fold + substring headword match for small multi-word tables.
+
+    Loads the full table (e.g. `style_guide`'s ~340 rows) since headwords
+    there are phrases rather than single tokens — a SQL prefix `LIKE` would
+    match "Приймати" but miss "На протязі" for a "протязі" query. Exact
+    (case-folded) matches are ranked ahead of substring matches.
+    """
+    query_key = _fold_dict_key(word)
+    if not query_key:
+        return []
+
+    try:
+        rows = conn.execute(f"SELECT * FROM {table}").fetchall()
+    except sqlite3.OperationalError:
+        return []
+
+    exact: list[dict] = []
+    partial: list[dict] = []
+    for row in rows:
+        item = dict(row)
+        headword_key = _fold_dict_key(str(item.get("word", "")))
+        if not headword_key:
+            continue
+        if headword_key == query_key:
+            exact.append(item)
+        elif query_key in headword_key or headword_key in query_key:
+            partial.append(item)
+
+    return (exact + partial)[:limit]
+
+
 def _dict_lookup(
     table: str,
     word: str,
     limit: int = 10,
     *,
     db_path: str | Path | None = None,
+    contains: bool = False,
 ) -> list[dict]:
-    """Generic headword lookup on an indexed dictionary table."""
+    """Generic headword lookup on an indexed dictionary table.
+
+    Pass ``contains=True`` for tables whose headwords are multi-word
+    phrases — see :func:`_dict_lookup_contains`.
+    """
     conn = None
     try:
         conn = _get_conn_for(db_path)
@@ -1807,6 +1861,9 @@ def _dict_lookup(
         return []
 
     try:
+        if contains:
+            return _dict_lookup_contains(conn, table, word, limit)
+
         # Exact match first, then prefix match
         try:
             rows = conn.execute(
@@ -2401,8 +2458,17 @@ def search_style_guide(
     *,
     db_path: str | Path | None = None,
 ) -> list[dict]:
-    """Look up calques/Russianisms in Антоненко-Давидович style guide."""
-    return _dict_lookup("style_guide", word, limit, db_path=db_path)
+    """Look up calques/Russianisms in Антоненко-Давидович style guide.
+
+    Headwords are often multi-word phrases ("Приймати участь", "На
+    протязі"), so matching is case-insensitive (Cyrillic-safe, unlike SQL
+    `COLLATE NOCASE`) and phrase-substring in either direction — see
+    :func:`_dict_lookup_contains`.
+    """
+    rows = _dict_lookup("style_guide", word, limit, db_path=db_path, contains=True)
+    for row in rows:
+        row["source"] = row.get("source") or "Антоненко-Давидович"
+    return rows
 
 
 def search_ua_gec_errors(

--- a/tests/test_sources_db.py
+++ b/tests/test_sources_db.py
@@ -89,7 +89,13 @@ def sample_data(tmp_path):
         ("ukrajinet", [{"synset_id": "s1", "words": "великий, здоровий, чималий", "text": "великий синонім", "source": "UNet"}]),
         ("wiktionary", [{"word": "кіт", "definitions": "Домашня тварина", "synonyms": "", "antonyms": "", "text": "кіт", "source": "Wikt"}]),
         ("frazeolohichnyi", [{"word": "вода", "definition": "Не розлий вода", "text": "вода — фразеологізм", "source": "Фраз"}]),
-        ("antonenko-davydovych", [{"word": "процент", "section": "Лексика", "text": "Кажіть відсоток", "source": "АД"}]),
+        ("antonenko-davydovych", [
+            {"word": "процент", "section": "Лексика", "text": "Кажіть відсоток", "source": "АД"},
+            {"word": "Приймати участь", "section": "Лексика",
+             "text": "Приймати участь — калька з рос. Кажіть: брати участь.", "source": "АД"},
+            {"word": "На протязі", "section": "Прийменники",
+             "text": "На протязі — калька з рос. 'в течение'. Кажіть: протягом.", "source": ""},
+        ]),
     ]:
         d = gdrive / name
         d.mkdir(parents=True)
@@ -142,7 +148,7 @@ class TestBuildSourcesDb:
         assert conn.execute("SELECT COUNT(*) FROM ukrajinet").fetchone()[0] == 1
         assert conn.execute("SELECT COUNT(*) FROM wiktionary").fetchone()[0] == 1
         assert conn.execute("SELECT COUNT(*) FROM frazeolohichnyi").fetchone()[0] == 1
-        assert conn.execute("SELECT COUNT(*) FROM style_guide").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM style_guide").fetchone()[0] == 3
 
         # FTS works
         fts = conn.execute(
@@ -333,6 +339,38 @@ class TestSourcesDb:
         from wiki.sources_db import search_style_guide
         results = search_style_guide("процент")
         assert len(results) == 1
+
+    def test_search_style_guide_lowercase_phrase_matches_capitalized_headword(
+        self, sample_data, monkeypatch
+    ):
+        self._build_and_patch(sample_data, monkeypatch)
+        from wiki.sources_db import search_style_guide
+
+        results = search_style_guide("приймати участь")
+        assert len(results) == 1
+        assert results[0]["word"] == "Приймати участь"
+        assert results[0]["source"] == "АД"
+
+    def test_search_style_guide_substring_matches_multiword_headword(
+        self, sample_data, monkeypatch
+    ):
+        self._build_and_patch(sample_data, monkeypatch)
+        from wiki.sources_db import search_style_guide
+
+        results = search_style_guide("протязі")
+        assert len(results) == 1
+        assert results[0]["word"] == "На протязі"
+        # The fixture's `source` field is empty — search_style_guide fills
+        # in the canonical attribution rather than returning "".
+        assert results[0]["source"] == "Антоненко-Давидович"
+
+    def test_search_style_guide_nonexistent_query_returns_empty(
+        self, sample_data, monkeypatch
+    ):
+        self._build_and_patch(sample_data, monkeypatch)
+        from wiki.sources_db import search_style_guide
+
+        assert search_style_guide("нежиттєздатнийтермін") == []
 
     def test_lookup_by_url(self, sample_data, monkeypatch):
         self._build_and_patch(sample_data, monkeypatch)


### PR DESCRIPTION
## Summary
- Fixes #5368 (P0, item 1 of epic #4542): `search_style_guide` / `_dict_lookup` missed queries like `приймати участь` or `протязі` against `style_guide` headwords like `Приймати участь` / `На протязі`.
- Root cause: SQLite `COLLATE NOCASE` only folds ASCII A-Z (not Cyrillic), and the prefix-only `LIKE 'word%'` fallback can't match a query that's a substring of a multi-word headword.
- Adds `_dict_lookup_contains` — a Python-side, Unicode-aware case-fold (plus stress-mark stripping) + bidirectional substring match, loading the small (~340-row) `style_guide` table directly. Opt-in via a new `contains=True` kwarg on `_dict_lookup`, so the other (much larger) dictionary tables keep their existing SQL-based fast path unchanged.
- `search_style_guide` now uses `contains=True` and guarantees a `source` fallback of `"Антоненко-Давидович"` when a row's `source` field is empty.

## Test plan
- [x] Added `tests/test_sources_db.py` cases: lowercase phrase match (`приймати участь` → `Приймати участь`), substring match (`протязі` → `На протязі`), and empty-result-on-miss.
- [x] `.venv/bin/python -m pytest tests/test_sources_db.py -q` — 27 passed
- [x] `.venv/bin/python -m ruff check scripts/wiki/sources_db.py tests/test_sources_db.py` — clean
- [x] Confirmed `_dict_lookup` has no other callers outside `sources_db.py` (new kwarg is additive/opt-in, default preserves old behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)