### PR TITLE
fix(devops): separate launcher stream from Infra

### DIFF
--- a/agents_extensions/shared/agents/infra-orchestrator.md
+++ b/agents_extensions/shared/agents/infra-orchestrator.md
@@ -12,8 +12,9 @@ initialPrompt: |
     report the conflict to the user in one sentence, and do not drive it as this agent type regardless
     of what the SESSION PROFILE CAPSULE's banner says. Only once `lane-assignments.md` confirms (or is
     silent on) this agent type does the SESSION PROFILE CAPSULE's "ASSIGNED EPIC" banner BIND: you are
-    the <epic> lane; handoff slot `claude-<epic>` (canonical aliases: `harness`|`infra`|`devops` →
-    `claude-infra`, #5201/#5681); lane SSOT = `.claude/<epic>-epic/CLAUDE-DRIVER-HANDOFF.md`
+    the <epic> lane; handoff slot `claude-<epic>` (canonical aliases: `harness`|`infra` →
+    `claude-infra`, #5201/#5681; `devops` is the independent `claude-devops` slot);
+    lane SSOT = `.claude/<epic>-epic/CLAUDE-DRIVER-HANDOFF.md`
     (gitignored local — check ALL alias-spelled `<epic>-epic/` directories per COLD-START step 2, not
     just the capsule-named one). Stay in that epic's scope; other lanes' queues are hands-off.
   - No `--epic` → do NOT default-claim a lane. Resolve in the capsule's NO-EPIC order: (1) the

--- a/agents_extensions/shared/agents/infra-orchestrator.md
+++ b/agents_extensions/shared/agents/infra-orchestrator.md
@@ -30,9 +30,10 @@ initialPrompt: |
      condition; never adopt or inspect a different lane's packet.
   2. Load lane state layered: the validated rollover packet first (when one exists), THEN the epic
      driver handoff (lane SSOT) — resume from its IN-FLIGHT + NEXT ACTION sections. **For the
-     harness/infra/devops epic specifically, its handoff directories are NOT yet unified across alias
-     spellings — check `.claude/harness-epic/`, `.claude/devops-epic/`, AND `.claude/infra-epic/`, not
-     just the one the capsule names.** Filesystem mtime is NOT a valid freshness signal here (these
+     harness/infra epic specifically, its handoff directories are NOT yet unified across alias
+     spellings — check `.claude/harness-epic/` and `.claude/infra-epic/`, not just the one the
+     capsule names. DevOps is an independent stream; never inspect or adopt
+     `.claude/devops-epic/` from an Infra session.** Filesystem mtime is NOT a valid freshness signal here (these
      files are gitignored and can be copied/touched/restored independently of when the work actually
      happened) — instead parse each file's topmost `## Session <YYYY-MM-DD>` heading (an explicit,
      semantic date the writer put there) to find the actual newest entry. If more than one directory's
@@ -120,10 +121,11 @@ and load-bearing.
   fixes were correct and tested, but they were not your call to make — hand off (comment with findings,
   step back), don't drive, once you recognize a different epic's work.
 - **ALIAS-DIRECTORY FRAGMENTATION (known gap, found 2026-07-23):** this epic's driver-handoff
-  directories (`.claude/harness-epic/`, `.claude/devops-epic/`, `.claude/infra-epic/` — one per alias
+  directories (`.claude/harness-epic/` and `.claude/infra-epic/` — one per Infra alias
   spelling, #5201/#5681) are NOT unified; a capsule saying "no driver handoff exists yet" for its named
-  spelling does NOT mean none exists at another. See COLD-START step 2 above for the check-all-three /
-  Session-date-freshness / STOP-on-ambiguity procedure — do not re-derive or restate it here; one
+  spelling does NOT mean none exists at another. See COLD-START step 2 above for the check-both /
+  Session-date-freshness / STOP-on-ambiguity procedure. `.claude/devops-epic/` belongs to the
+  independent DevOps stream and is outside this recovery search. Do not re-derive or restate it here; one
   procedure, one place, so it can't drift out of sync with itself again.
 - **YOURS — infrastructure + our code:** `scripts/build/`, `scripts/audit/`, `scripts/agent_runtime/`,
   `scripts/orchestration/`, `scripts/lexicon/` + Atlas, `linear_pipeline.py` + the V7 pipeline, gates +

--- a/agents_extensions/shared/rules/fleet-comms-coordination.md
+++ b/agents_extensions/shared/rules/fleet-comms-coordination.md
@@ -110,12 +110,13 @@ Every epic driver session (any harness) MUST:
 - Seat routing reminder: `docs/runbooks/epic-orchestrator-roster.md` (Gemini→harness/corpus,
   Grok→atlas/tracks, Sonnet-5→judgment-dense). **Live policy** is still
   `model_catalog.orchestrator_seats` + `/api/rules`.
-- **Codex is the named alternate for the harness / infra / devops stream** (re-added
+- **Codex is the named alternate for the harness / infra and DevOps streams** (re-added
   2026-07-23 after HydrationCapsuleV1 changed the rollover-cost calculus). Its launcher
   fails closed before lease acquisition on ambiguous, already-resumed, or native-app
   rollover packets; a fresh CLI packet is bound to the exact SessionStart task ID and
-  the generated cold-start board is injected automatically. Codex never concurrently
-  co-owns the stream and remains a formal-CF **review** + coding lane.
+  the generated cold-start board is injected automatically. Infra uses `epic:4707`;
+  DevOps independently uses `epic:5703`. Codex never concurrently co-owns a same-stream
+  lease and remains a formal-CF **review** + coding lane.
 
 ## Offline fallback path
 

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -219,7 +219,7 @@ model-specific section — everything above is identical across seats.
 | **Gemini / AGY (gemini-3.6-flash-high)** | Harness/infra scope. MCP-leading tool use + 1M window + low cost = ideal infra driver. **Do not claim curriculum content lanes.** Route UK-language work to the sanctioned language lanes, not to yourself. |
 | **Kimi K3** | Frontier coder/reviewer + cross-family escalation authority (independent of Anthropic & OpenAI). `max-effort-only` makes a continuous loop costly — drive when assigned, else stay a reviewer/escalation seat. |
 | **Claude (when driving a track)** | Reserve the Opus seat for the hardest judgment + the CF review of record; prefer Sonnet-5 for routine track driving so Opus quota stays free. |
-| **Codex / GPT-5.6 Terra** | Named alternate only for harness / infra / devops. The launcher injects the HydrationCapsuleV1 cold-start board and binds at most one exact fresh CLI rollover; stop on any SessionStart setup error. Codex has no Monitor-equivalent watcher, so use bounded foreground waits and escalate hard judgment to Sol. |
+| **Codex / GPT-5.6 Terra** | Named alternate only for harness / infra (`epic:4707`) and the independent DevOps stream (`epic:5703`). The launcher injects the HydrationCapsuleV1 cold-start board and binds at most one exact fresh CLI rollover; stop on any SessionStart setup error. Codex has no Monitor-equivalent watcher, so use bounded foreground waits and escalate hard judgment to Sol. |
 
 ---
 

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -29,7 +29,8 @@ The registry `scripts/config/issue_streams.yaml` is the single source of truth (
 | atlas-practice | #4387 → #4700 | Word Atlas + Practice Hub product & UX |
 | atlas-intake | #4220, #4378 | Full-corpus intake into the Atlas |
 | corpus-channels | #4706 | Acquisition & ingestion (textbooks · ZNO · Ohoiko-media · press · academic) |
-| infra-harness | #4707 | Infra, DevOps & fleet reliability (hooks, deps, dispatch, routing) |
+| infra-harness | #4707 | Infra & fleet reliability (hooks, dispatch, routing) |
+| devops | #5703 | DevOps automation, CI, release & launcher reliability |
 | eval-harness | #4913 | UA eval harness: QG grounding/entailment gates, grammar-lexical gate, annotation, bakeoffs, cutovers |
 | benchmark-2156 | #4639 | UA LLM factuality benchmark community release |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |

--- a/docs/runbooks/epic-orchestrator-roster.md
+++ b/docs/runbooks/epic-orchestrator-roster.md
@@ -17,8 +17,10 @@ and cold-starts the driver, which runs the `drive-epic` skill to orchestrate its
 
 | Epic | Recommended seat | Run |
 | --- | --- | --- |
-| **harness / infra / devops** | Gemini (AGY) | `./start-gemini-drive.sh devops` |
-| **harness / infra / devops** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-drive.sh devops` |
+| **harness / infra** | Gemini (AGY) | `./start-gemini-drive.sh infra` |
+| **harness / infra** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-drive.sh infra` |
+| **devops** | Gemini (AGY) | `./start-gemini-drive.sh devops` |
+| **devops** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-drive.sh devops` |
 | **corpus** (acquisition & ingestion) | Gemini (AGY) | `./start-gemini-drive.sh corpus` |
 | **atlas** (Word Atlas + Practice Hub product) | Grok 4.5 | `./start-grok-drive.sh atlas` |
 | **hramatka** (teacher lesson service) | Grok 4.5 · Sonnet-5 if judgment-heavy | `./start-grok-drive.sh hramatka` |
@@ -49,7 +51,7 @@ cross-family **GPT ↔ Claude** (no DeepSeek, and Grok is never a judge seat) �
   dropped on 2026-07-22 for its 272K window, then **re-added on 2026-07-23** as the named
   harness / infra / devops alternate: HydrationCapsuleV1's score-from-memory and small capsule
   hydrate change the rollover-cost calculus. Codex remains a formal-CF **review** seat + coding lane;
-  the shared lease prevents concurrent co-ownership.
+  each stream's lease prevents concurrent co-ownership.
 - **Kimi K3** — frontier coder/reviewer + cross-family escalation authority (`max-effort-only` makes a continuous loop costly).
 
 ### Machine-authority projection (lint #5642)
@@ -95,6 +97,8 @@ language + review lanes free and puts the loop on the most replaceable capacity:
   Anthropic capacity that does **not** consume the Opus review-of-record seat.
 - **HydrationCapsuleV1** gives Codex (272K) a measured, low-overhead score-and-hydrate path, so it
   can serve as the harness / infra / devops alternate without co-owning Gemini's stream lease.
+  Infra (`epic:4707`) and DevOps (`epic:5703`) are independent streams: one live driver does
+  not block the other, while a second driver on either same stream still fails closed.
 
 ---
 
@@ -102,8 +106,10 @@ language + review lanes free and puts the loop on the most replaceable capacity:
 
 1. Launcher pins `SESSION_EPIC`, claims the stream lease, and — for grok/gemini/kimi —
    mints the session canary; Claude/Sonnet use the SessionStart hook chain (no canary lane).
-   The Codex DevOps alternate preflights its lane-scoped rollover namespace before the
-   lease: zero packets starts fresh, one fresh unbound CLI packet exports exact IDs, and
+   The Codex DevOps alternate preflights its dedicated `codex-devops` rollover namespace
+   before acquiring `epic:5703`, independently of Infra's `codex-infra` / `epic:4707`
+   ownership. It then selects at most one applicable rollover: zero packets starts fresh,
+   one fresh unbound CLI packet exports exact IDs, and
    ambiguity, an already-resumed packet, or a native-app packet fails closed. After the
    lease and canary are ready, SessionStart binds the official new task ID and injects
    `CODEX-COLD-START.md`.

--- a/docs/runbooks/epic-stream-handoff.md
+++ b/docs/runbooks/epic-stream-handoff.md
@@ -31,8 +31,10 @@ driver (e.g. Codex on hramatka) leaves, content dual-write alone is not enough:
 
 ### Codex DevOps zero-touch boundary
 
-`./start-codex-drive.sh devops` scans only its assigned `codex-infra` rollover
-namespace before acquiring `epic:4707`. It starts a fresh task when no packet
+`./start-codex-drive.sh devops` scans only its assigned `codex-devops` rollover
+namespace before acquiring `epic:5703`. Infra keeps the separate `codex-infra`
+namespace and `epic:4707` lease, so a live Infra driver does not block DevOps.
+The launcher starts a fresh task when no packet
 exists, or exports one exact fresh unbound `codex-cli` packet for SessionStart
 to bind to the newly created task ID. Multiple packets, an already-resumed
 packet, and a packet requiring the native Codex app adapter all stop the

--- a/docs/runbooks/gemini-orchestrator.md
+++ b/docs/runbooks/gemini-orchestrator.md
@@ -54,7 +54,8 @@ The cold-start prompt explicitly tells Gemini **not** to open or resume the leas
 | Epic | `SESSION_HANDOFF_AGENT` |
 | --- | --- |
 | atlas, hramatka, folk, bio, … | `gemini-<epic>` |
-| harness / infra / devops | `gemini-infra` |
+| harness / infra | `gemini-infra` |
+| devops | `gemini-devops` |
 
 ## Fleet Management & Rate Limits (`codexbar`)
 

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -54,7 +54,8 @@ eq "$(handoff_epic_from_argv)" "" "empty argv (epic)"
 
 # --- selector → canonical lane, stream, and provider slot mapping ---
 eq "$(launcher_selector_lane infra.fleet-comms)" "infra" "fleet-comms resolves to infra"
-eq "$(launcher_selector_stream infra.devops)" "epic:4707" "devops resolves to infra stream"
+eq "$(launcher_selector_lane devops)" "devops" "devops resolves to dedicated lane"
+eq "$(launcher_selector_stream infra.devops)" "epic:5703" "devops resolves to dedicated stream"
 eq "$(launcher_selector_lane atlas.practice)" "atlas" "atlas practice resolves to atlas"
 eq "$(launcher_selector_stream hramatka.lessons)" "epic:4542" "hramatka lessons resolves"
 # corpus is a documented, currently-recommended driver epic
@@ -69,23 +70,23 @@ eq "$(handoff_identity_for_epic atlas)" "claude-atlas" "epic atlas → claude-at
 eq "$(handoff_identity_for_epic hramatka)" "claude-hramatka" "epic hramatka → claude-hramatka"
 eq "$(handoff_identity_for_epic harness)" "claude-infra" "epic harness → claude-infra (#5201)"
 eq "$(handoff_identity_for_epic infra)" "claude-infra" "epic infra → claude-infra alias"
-eq "$(handoff_identity_for_epic infra.devops)" "claude-infra" "dot devops → claude-infra alias"
+eq "$(handoff_identity_for_epic infra.devops)" "claude-devops" "dot devops → claude-devops"
 eq "$(handoff_identity_for_epic)" "" "no epic → empty slot"
 
-# Codex uses provider-specific per-epic slots; harness/infra/devops share one alias.
+# Codex uses provider-specific per-epic slots; DevOps is independent from Infra.
 eq "$(handoff_identity_for_codex_epic atlas)" "codex-atlas" "Codex atlas → codex-atlas"
 eq "$(handoff_identity_for_codex_epic hramatka)" "codex-hramatka" "Codex hramatka → codex-hramatka"
 eq "$(handoff_identity_for_codex_epic harness)" "codex-infra" "Codex harness → codex-infra"
 eq "$(handoff_identity_for_codex_epic infra)" "codex-infra" "Codex infra → codex-infra alias"
-eq "$(handoff_identity_for_codex_epic infra.devops)" "codex-infra" "Codex dot devops → codex-infra alias"
+eq "$(handoff_identity_for_codex_epic infra.devops)" "codex-devops" "Codex dot devops → codex-devops"
 eq "$(handoff_identity_for_codex_epic)" "" "Codex no epic → empty slot"
 
-# Gemini uses provider-specific per-epic slots; harness/infra/devops share one alias.
+# Gemini uses provider-specific per-epic slots; DevOps is independent from Infra.
 eq "$(handoff_identity_for_gemini_epic atlas)" "gemini-atlas" "Gemini atlas → gemini-atlas"
 eq "$(handoff_identity_for_gemini_epic hramatka)" "gemini-hramatka" "Gemini hramatka → gemini-hramatka"
 eq "$(handoff_identity_for_gemini_epic harness)" "gemini-infra" "Gemini harness → gemini-infra"
 eq "$(handoff_identity_for_gemini_epic infra)" "gemini-infra" "Gemini infra → gemini-infra alias"
-eq "$(handoff_identity_for_gemini_epic infra.devops)" "gemini-infra" "Gemini dot devops → gemini-infra alias"
+eq "$(handoff_identity_for_gemini_epic infra.devops)" "gemini-devops" "Gemini dot devops → gemini-devops"
 eq "$(handoff_identity_for_gemini_epic)" "" "Gemini no epic → empty slot"
 
 

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -19,8 +19,11 @@ streams:
     title: "Corpus channels — acquisition & ingestion"
     epics: [4706]
   infra-harness:
-    title: "Infra, DevOps & fleet reliability (hooks, deps, dispatch, routing)"
+    title: "Infra & fleet reliability (hooks, dispatch, routing)"
     epics: [4707]
+  devops:
+    title: "DevOps automation, CI, release & launcher reliability"
+    epics: [5703]
   eval-harness:
     title: "UA eval harness — QG gates, grammar-lexical gate, annotation, bakeoffs"
     epics: [4913]

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -470,7 +470,7 @@ review_candidates:
     review_profiles: [code, infra]
     capabilities: [code_review]
 
-# Fleet-comms stream orchestrator seats (#5512 / #4707). These lanes may own a
+# Fleet-comms stream orchestrator seats (#5512 / #4707 / #5703). These lanes may own a
 # cold-start loop (prioritize → delegate → CF → merge-in-lane). Formal *sealed*
 # CF remains fail-closed on agy|kimi|grok until #5555–#5557; orchestrators still
 # *request* CF via review-pr codex|claude|glm.
@@ -494,9 +494,10 @@ orchestrator_seats:
       Re-added as orchestrator seat 2026-07-23 (reverses the 2026-07-22 removal) specifically for
       HydrationCapsuleV1 long-horizon support — score-from-memory + a ~100ms capsule hydrate is
       designed to minimize the rollover-token overhead the prior removal objected to. Named
-      alternate/overflow on the harness/infra/devops stream (epic:4707) alongside Gemini — never a
-      concurrent co-owner; the shared session-stream lease already fails closed on a live foreign
-      holder, so no new exclusivity logic is needed.
+      alternate/overflow on harness/infra (epic:4707) and the independent DevOps stream
+      (epic:5703) alongside Gemini — never a concurrent same-stream co-owner; each
+      session-stream lease already fails closed on a live foreign holder, so no new
+      exclusivity logic is needed.
   # 2026-07-22 removal note retained for history: "the 272K window is not worth the session-
   # start/end rollover-token overhead relative to its small context" — see the 2026-07-23 note
   # above for why that calculus changed.

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -22,8 +22,11 @@
 # Unknown selectors return 1 and print nothing, so callers can fail closed.
 launcher_selector_resolve() {
   case "${1:-}" in
-    infra|harness|devops|infra.fleet-comms|infra.devops)
+    infra|harness|infra.fleet-comms)
       printf 'infra\tepic:4707\n'
+      ;;
+    devops|infra.devops)
+      printf 'devops\tepic:5703\n'
       ;;
     atlas|practice|practice-hub|atlas.practice)
       printf 'atlas\tepic:4387\n'
@@ -66,7 +69,8 @@ launcher_selector_stream() {
 launcher_selector_help() {
   cat <<'EOF'
 Valid lane selectors:
-  infra | harness | infra.fleet-comms | infra.devops
+  infra | harness | infra.fleet-comms
+  devops | infra.devops
   atlas | practice | atlas.practice
   hramatka | hramatka.lessons
   folk | seminars-folk
@@ -196,8 +200,8 @@ handoff_identity_for_epic() {
 # handoff_identity_for_codex_epic "<epic-name>"
 # Echo the per-epic Codex rollover slot. Codex needs the same lane separation
 # as Claude, but its namespaces must remain provider-specific so a Codex launch
-# never adopts a Claude packet. The infra alias mirrors the canonical
-# claude-infra convention and avoids inventing parallel harness/infra slots.
+# never adopts a Claude packet. Infra aliases share the canonical infra slot;
+# DevOps has its own slot because it owns an independent stream lease.
 handoff_identity_for_codex_epic() {
   local lane=''
   [ -n "${1:-}" ] || return 0
@@ -207,7 +211,7 @@ handoff_identity_for_codex_epic() {
 
 # handoff_identity_for_kimi_epic "<epic-name>"
 # Echo the per-epic Kimi Code orchestrator rollover slot. Provider-specific so
-# a Kimi seat never adopts Claude/Codex/Grok packets. harness/infra/devops → kimi-infra.
+# a Kimi seat never adopts Claude/Codex/Grok packets.
 handoff_identity_for_kimi_epic() {
   local lane=''
   [ -n "${1:-}" ] || return 0
@@ -217,7 +221,7 @@ handoff_identity_for_kimi_epic() {
 
 # handoff_identity_for_gemini_epic "<epic-name>"
 # Echo the per-epic Gemini / Antigravity orchestrator rollover slot. Provider-specific so
-# a Gemini seat never adopts Claude/Codex/Grok/Kimi packets. harness/infra/devops → gemini-infra.
+# a Gemini seat never adopts Claude/Codex/Grok/Kimi packets.
 handoff_identity_for_gemini_epic() {
   local lane=''
   [ -n "${1:-}" ] || return 0

--- a/scripts/session_canary/grok_lane.py
+++ b/scripts/session_canary/grok_lane.py
@@ -61,7 +61,6 @@ EPIC_STREAM_DEFAULTS: dict[str, str] = {
     "harness": "epic:4707",
     "infra": "epic:4707",
     "devops": "epic:5703",
-    "infra.devops": "epic:5703",
     "hramatka": "epic:4542",
     "folk": "epic:2836",
     "seminars-folk": "epic:2836",

--- a/scripts/session_canary/grok_lane.py
+++ b/scripts/session_canary/grok_lane.py
@@ -60,6 +60,8 @@ EPIC_STREAM_DEFAULTS: dict[str, str] = {
     "practice-hub": "epic:4387",
     "harness": "epic:4707",
     "infra": "epic:4707",
+    "devops": "epic:5703",
+    "infra.devops": "epic:5703",
     "hramatka": "epic:4542",
     "folk": "epic:2836",
     "seminars-folk": "epic:2836",

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -182,13 +182,13 @@ def prepare_cli_driver_rollover(primary: Path, *, active_thread_id: str) -> dict
             primary,
             "prepare",
             "--agent",
-            "codex-infra",
+            "codex-devops",
             "--harness",
             "codex-cli",
             "--active-thread-id",
             active_thread_id,
             "--stream-epic",
-            "4707",
+            "5703",
             "--semantic-title",
             "Continue the isolated Codex DevOps launcher test",
             "--task-family",
@@ -204,23 +204,29 @@ def prepare_cli_driver_rollover(primary: Path, *, active_thread_id: str) -> dict
     return json.loads(completed.stdout)
 
 
-def seed_driver_stream(primary: Path) -> SessionStreamStore:
+def seed_driver_stream(
+    primary: Path,
+    *,
+    stream_id: str,
+    close: bool,
+    instance_id: str = "fixture-seed",
+) -> SessionStreamStore:
     store = SessionStreamStore(
         SessionStreamDatabase(primary / ".agent/session-streams/v1/session-streams.sqlite3")
     )
     lease = store.open_session(
-        stream_id="epic:4707",
+        stream_id=stream_id,
         holder=LeaseHolder(
             agent="fixture",
             harness="pytest",
-            instance_id="fixture-seed",
+            instance_id=instance_id,
             process_id=os.getpid(),
-            task_id="fixture-seed",
+            task_id=instance_id,
         ),
-        lineage_id="lineage-fixture-seed",
+        lineage_id=f"lineage-{instance_id}",
         ttl_seconds=60,
-        session_id="session-fixture-seed",
-        lease_id="lease-fixture-seed",
+        session_id=f"session-{instance_id}",
+        lease_id=f"lease-{instance_id}",
     )
     entries = [
         (EntryType.BINDING_ORDER, "Drive only the isolated DevOps launcher acceptance lane."),
@@ -237,9 +243,10 @@ def seed_driver_stream(primary: Path) -> SessionStreamStore:
             lease,
             entry_type=entry_type,
             body=body,
-            idempotency_key=f"fixture-entry-{index}",
+            idempotency_key=f"{instance_id}-entry-{index}",
         )
-    store.close_session(lease)
+    if close:
+        store.close_session(lease)
     return store
 
 
@@ -824,7 +831,18 @@ def test_real_codex_devops_launcher_injects_board_and_binds_exact_fresh_rollover
     tmp_path: Path,
 ) -> None:
     primary, _ = init_repo(tmp_path, bootstrap_sources=True)
-    store = seed_driver_stream(primary)
+    store = seed_driver_stream(
+        primary,
+        stream_id="epic:4707",
+        close=False,
+        instance_id="live-infra",
+    )
+    seed_driver_stream(
+        primary,
+        stream_id="epic:5703",
+        close=True,
+        instance_id="devops-history",
+    )
     packet = prepare_cli_driver_rollover(primary, active_thread_id=SOURCE_THREAD_ID)
     fake_bin = tmp_path / "bin"
     fake_home_bin = tmp_path / "home" / ".local" / "bin"
@@ -895,7 +913,8 @@ def test_real_codex_devops_launcher_injects_board_and_binds_exact_fresh_rollover
     argv = argv_capture.read_text(encoding="utf-8").splitlines()
     assert "resume" not in argv
     assert "fork" not in argv
-    assert store.dump_stream("epic:4707")["sessions"][-1]["state"] == "closed"
+    assert store.dump_stream("epic:4707")["sessions"][-1]["state"] == "open"
+    assert store.dump_stream("epic:5703")["sessions"][-1]["state"] == "closed"
     assert git(primary, "status", "--short", "--untracked-files=all").stdout == ""
 
 
@@ -903,7 +922,7 @@ def test_real_codex_devops_launcher_fails_before_lease_on_rollover_ambiguity(
     tmp_path: Path,
 ) -> None:
     primary, _ = init_repo(tmp_path, bootstrap_sources=True)
-    store = seed_driver_stream(primary)
+    store = seed_driver_stream(primary, stream_id="epic:5703", close=True)
     first = prepare_cli_driver_rollover(primary, active_thread_id=SOURCE_THREAD_ID)
     second = prepare_cli_driver_rollover(primary, active_thread_id=SECOND_SOURCE_THREAD_ID)
     fake_bin = tmp_path / "bin"
@@ -953,5 +972,65 @@ def test_real_codex_devops_launcher_fails_before_lease_on_rollover_ambiguity(
     assert not started.exists()
     assert load_lease(primary, first)["replacement"]["status"] == "pending_start"
     assert load_lease(primary, second)["replacement"]["status"] == "pending_start"
-    assert len(store.dump_stream("epic:4707")["sessions"]) == 1
-    assert store.dump_stream("epic:4707")["sessions"][0]["state"] == "closed"
+    assert len(store.dump_stream("epic:5703")["sessions"]) == 1
+    assert store.dump_stream("epic:5703")["sessions"][0]["state"] == "closed"
+
+
+def test_real_codex_devops_launcher_refuses_second_live_devops_driver(
+    tmp_path: Path,
+) -> None:
+    primary, _ = init_repo(tmp_path, bootstrap_sources=True)
+    store = seed_driver_stream(
+        primary,
+        stream_id="epic:5703",
+        close=False,
+        instance_id="live-devops",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_home_bin = tmp_path / "home" / ".local" / "bin"
+    fake_bin.mkdir(parents=True)
+    fake_home_bin.mkdir(parents=True)
+    started = tmp_path / "codex-started"
+
+    fake_npm = fake_home_bin / "npm"
+    fake_npm.write_text(
+        "#!/bin/bash\n"
+        "set -e\n"
+        "mkdir -p .codex/hooks\n"
+        "cp agents_extensions/codex/hooks.json .codex/hooks.json\n"
+        "cp agents_extensions/shared/hooks/session-setup.sh .codex/hooks/session-setup.sh\n",
+        encoding="utf-8",
+    )
+    fake_npm.chmod(0o755)
+    fake_codex = fake_home_bin / "codex"
+    fake_codex.write_text(
+        f"#!/bin/bash\ntouch {os.fspath(started)!r}\n",
+        encoding="utf-8",
+    )
+    fake_codex.chmod(0o755)
+
+    env = os.environ.copy()
+    for key in tuple(env):
+        if key.startswith("SESSION_") or key.startswith("LEARN_UKRAINIAN_") or key.startswith(
+            "CODEX_LAUNCHER_ROLLOVER_"
+        ) or key in {"CODEX_CANONICAL_REPO_ROOT", "CODEX_SESSION"}:
+            env.pop(key, None)
+    env.update(
+        {
+            "HOME": os.fspath(tmp_path / "home"),
+            "PATH": f"{fake_bin}:{fake_home_bin}:/usr/bin:/bin",
+            "PYENV_ROOT": os.fspath(tmp_path / "pyenv"),
+        }
+    )
+    launched = run(
+        [primary / "start-codex-drive.sh", "devops", "--model", "gpt-5.6-sol"],
+        cwd=primary,
+        env=env,
+    )
+
+    assert launched.returncode == 1
+    assert "already has live session" in launched.stderr
+    assert not started.exists()
+    assert len(store.dump_stream("epic:5703")["sessions"]) == 1
+    assert store.dump_stream("epic:5703")["sessions"][0]["state"] == "open"
+    assert git(primary, "status", "--short", "--untracked-files=all").stdout == ""

--- a/tests/test_codex_lane_canary.py
+++ b/tests/test_codex_lane_canary.py
@@ -106,6 +106,15 @@ def test_bootstrap_uses_normalized_epic_for_default_stream_id(tmp_path: Path) ->
     assert "never on compact count" in board
 
 
+def test_bootstrap_uses_dedicated_devops_stream(tmp_path: Path) -> None:
+    assert codex_lane.main(["--repo", str(tmp_path), "bootstrap", "--epic", "devops"]) == 0
+
+    board = (tmp_path / ".claude" / "devops-epic" / "CODEX-COLD-START.md").read_text(
+        encoding="utf-8"
+    )
+    assert "**Stream:** `epic:5703`" in board
+
+
 def test_bootstrap_records_exact_rollover_without_rendering_lease_credentials(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_codex_lane_canary.py
+++ b/tests/test_codex_lane_canary.py
@@ -115,6 +115,11 @@ def test_bootstrap_uses_dedicated_devops_stream(tmp_path: Path) -> None:
     assert "**Stream:** `epic:5703`" in board
 
 
+def test_stream_defaults_require_canonical_devops_selector() -> None:
+    assert codex_lane.EPIC_STREAM_DEFAULTS["devops"] == "epic:5703"
+    assert "infra.devops" not in codex_lane.EPIC_STREAM_DEFAULTS
+
+
 def test_bootstrap_records_exact_rollover_without_rendering_lease_credentials(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_handoff_identity.py
+++ b/tests/test_handoff_identity.py
@@ -16,10 +16,12 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _HOOK_TEST = _REPO_ROOT / "scripts" / "audit" / "test_handoff_identity.sh"
 _HANDOFF_IDENTITY = _REPO_ROOT / "scripts" / "lib" / "handoff_identity.sh"
+_ISSUE_STREAMS = _REPO_ROOT / "scripts" / "config" / "issue_streams.yaml"
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
@@ -43,12 +45,12 @@ def test_handoff_identity_fixtures() -> None:
 @pytest.mark.parametrize(
     ("resolver", "expected"),
     [
-        ("handoff_identity_for_epic", "claude-infra"),
-        ("handoff_identity_for_gemini_epic", "gemini-infra"),
-        ("handoff_identity_for_codex_epic", "codex-infra"),
+        ("handoff_identity_for_epic", "claude-devops"),
+        ("handoff_identity_for_gemini_epic", "gemini-devops"),
+        ("handoff_identity_for_codex_epic", "codex-devops"),
     ],
 )
-def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: str) -> None:
+def test_devops_resolves_to_dedicated_provider_slot(resolver: str, expected: str) -> None:
     result = subprocess.run(
         ["bash", "-c", 'source "$1"; "$2" devops', "bash", str(_HANDOFF_IDENTITY), resolver],
         cwd=_REPO_ROOT,
@@ -65,8 +67,8 @@ def test_devops_alias_resolves_to_canonical_infra_slot(resolver: str, expected: 
     ("selector", "lane", "stream", "claude_slot", "gemini_slot", "grok_slot"),
     [
         ("infra.fleet-comms", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
-        ("infra.devops", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
-        ("devops", "infra", "epic:4707", "claude-infra", "gemini-infra", "grok-infra"),
+        ("infra.devops", "devops", "epic:5703", "claude-devops", "gemini-devops", "grok-devops"),
+        ("devops", "devops", "epic:5703", "claude-devops", "gemini-devops", "grok-devops"),
         ("atlas.practice", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
         ("practice-hub", "atlas", "epic:4387", "claude-atlas", "gemini-atlas", "grok-atlas"),
         ("hramatka.lessons", "hramatka", "epic:4542", "claude-hramatka", "gemini-hramatka", "grok-hramatka"),
@@ -132,6 +134,13 @@ def test_unknown_selector_fails_closed() -> None:
     )
     assert result.returncode == 1
     assert result.stdout == ""
+
+
+def test_devops_epic_is_registered_separately_from_infra() -> None:
+    registry = yaml.safe_load(_ISSUE_STREAMS.read_text(encoding="utf-8"))["streams"]
+
+    assert registry["infra-harness"]["epics"] == [4707]
+    assert registry["devops"]["epics"] == [5703]
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")

--- a/tests/test_start_claude_supervisor.py
+++ b/tests/test_start_claude_supervisor.py
@@ -36,7 +36,7 @@ def _write_executable(path: Path, body: str) -> None:
     ("selector", "canonical_lane", "stream", "handoff"),
     [
         ("harness", "harness", "epic:4707", "claude-infra"),
-        ("devops", "infra", "epic:4707", "claude-infra"),
+        ("devops", "devops", "epic:5703", "claude-devops"),
         ("practice-hub", "atlas", "epic:4387", "claude-atlas"),
         ("seminars-folk", "folk", "epic:2836", "claude-folk"),
         ("seminars-bio", "bio", "epic:4431", "claude-bio"),

--- a/tests/test_start_codex_launcher.py
+++ b/tests/test_start_codex_launcher.py
@@ -183,18 +183,18 @@ def test_trusted_epic_claims_codex_lease_then_runs_canary_steps(tmp_path: Path) 
     supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
     assert supervisor_args[supervisor_args.index("--agent") + 1] == "codex"
     assert supervisor_args[supervisor_args.index("--harness") + 1] == "codex-cli"
-    assert supervisor_args[supervisor_args.index("--stream") + 1] == "epic:4707"
+    assert supervisor_args[supervisor_args.index("--stream") + 1] == "epic:5703"
     assert canary_capture.read_text(encoding="utf-8").splitlines() == [
         "-m",
         "scripts.session_canary.codex_lane",
         "mint",
         "--epic",
-        "infra",
+        "devops",
         "-m",
         "scripts.session_canary.codex_lane",
         "bootstrap",
         "--epic",
-        "infra",
+        "devops",
     ]
     assert "CODEX-COLD-START.md" in result.stdout
 

--- a/tests/test_start_codex_launcher.py
+++ b/tests/test_start_codex_launcher.py
@@ -64,18 +64,18 @@ def _build_project(tmp_path: Path) -> tuple[Path, Path, Path]:
 if [[ "${{1:-}}" == */scripts/orchestration/thread_handoff.py && "$*" == *" detect "* ]]; then
   case "${{CODEX_LAUNCHER_TEST_ROLLOVER:-none}}" in
     none)
-      printf '%s\\n' '{{"agent":"codex-infra","status":"none"}}'
+      printf '%s\\n' '{{"agent":"codex-devops","status":"none"}}'
       exit 0
       ;;
     pending)
       cat <<'JSON'
-{{"agent":"codex-infra","packet_agent":"codex-infra","lineage_id":"lineage-launcher-fresh","rollover_id":"rollover-launcher-fresh","status":"pending_start","identity":{{"replacement_task_id":null}},"title_transition":{{"native_title_supported":false,"state":"awaiting_replacement_binding"}}}}
+{{"agent":"codex-devops","packet_agent":"codex-devops","lineage_id":"lineage-launcher-fresh","rollover_id":"rollover-launcher-fresh","status":"pending_start","identity":{{"replacement_task_id":null}},"title_transition":{{"native_title_supported":false,"state":"awaiting_replacement_binding"}}}}
 JSON
       exit 0
       ;;
     resumed)
       cat <<'JSON'
-{{"agent":"codex-infra","packet_agent":"codex-infra","lineage_id":"lineage-launcher-old","rollover_id":"rollover-launcher-old","status":"resumed","identity":{{"replacement_task_id":"old-task"}},"title_transition":{{"native_title_supported":false,"state":"fallback_recorded"}}}}
+{{"agent":"codex-devops","packet_agent":"codex-devops","lineage_id":"lineage-launcher-old","rollover_id":"rollover-launcher-old","status":"resumed","identity":{{"replacement_task_id":"old-task"}},"title_transition":{{"native_title_supported":false,"state":"fallback_recorded"}}}}
 JSON
       exit 0
       ;;
@@ -245,7 +245,7 @@ def test_fresh_exact_rollover_is_exported_to_new_codex_task(tmp_path: Path) -> N
     assert result.returncode == 0, result.stderr + result.stdout
     assert supervisor_capture.exists()
     assert (tmp_path / "codex.txt").read_text(encoding="utf-8").splitlines()[-3:] == [
-        "rollover_agent=codex-infra",
+        "rollover_agent=codex-devops",
         "lineage=lineage-launcher-fresh",
         "rollover=rollover-launcher-fresh",
     ]

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -255,7 +255,7 @@ def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[
 @pytest.mark.parametrize(
     ("selector", "canonical_lane", "stream", "handoff"),
     [
-        ("devops", "infra", "epic:4707", "gemini-infra"),
+        ("devops", "devops", "epic:5703", "gemini-devops"),
         ("practice-hub", "atlas", "epic:4387", "gemini-atlas"),
         ("seminars-folk", "folk", "epic:2836", "gemini-folk"),
         ("seminars-bio", "bio", "epic:4431", "gemini-bio"),
@@ -292,11 +292,11 @@ def test_dot_notation_infra_devops_uses_canonical_stream_and_handoff(tmp_path: P
         tmp_path, ["--epic", "infra.devops"]
     )
     assert result.returncode == 0, result.stderr + result.stdout
-    assert values["session_epic"] == "infra"
-    assert values["handoff"] == "gemini-infra"
+    assert values["session_epic"] == "devops"
+    assert values["handoff"] == "gemini-devops"
     supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
     stream_index = supervisor_args.index("--stream")
-    assert supervisor_args[stream_index + 1] == "epic:4707"
+    assert supervisor_args[stream_index + 1] == "epic:5703"
 
 
 def test_unknown_epic_selector_fails_closed_with_help(tmp_path: Path) -> None:

--- a/tests/test_start_grok_launcher.py
+++ b/tests/test_start_grok_launcher.py
@@ -282,7 +282,7 @@ def test_legacy_epic_suffix_normalizes_to_atlas(tmp_path: Path, arguments: list[
 @pytest.mark.parametrize(
     ("selector", "canonical_lane", "stream", "handoff"),
     [
-        ("devops", "infra", "epic:4707", "grok-infra"),
+        ("devops", "devops", "epic:5703", "grok-devops"),
         ("practice-hub", "atlas", "epic:4387", "grok-atlas"),
         ("seminars-folk", "folk", "epic:2836", "grok-folk"),
         ("seminars-bio", "bio", "epic:4431", "grok-bio"),
@@ -404,8 +404,8 @@ def test_dot_notation_infra_devops_uses_canonical_stream_and_handoff(tmp_path: P
         ["--epic", "infra.devops"],
     )
     assert result.returncode == 0, result.stderr + result.stdout
-    assert values["session_epic"] == "infra"
-    assert values["handoff"] == "grok-infra"
+    assert values["session_epic"] == "devops"
+    assert values["handoff"] == "grok-devops"
     supervisor_args = supervisor_capture.read_text(encoding="utf-8").splitlines()
     stream_index = supervisor_args.index("--stream")
-    assert supervisor_args[stream_index + 1] == "epic:4707"
+    assert supervisor_args[stream_index + 1] == "epic:5703"


### PR DESCRIPTION
## Summary

- register the operator-approved dedicated DevOps stream as `epic:5703`
- route `devops` and `infra.devops` to distinct DevOps lease and rollover namespaces
- preserve Infra on `infra / epic:4707` with unchanged same-stream exclusivity
- align the canary mapping, model catalog, Infra recovery boundary, roster, shared guidance, and workstream documentation
- add isolated real-launcher coverage for concurrent Infra + DevOps operation and same-stream DevOps exclusion

## Root cause

The shared launcher selector collapsed `devops` and `infra` into the same canonical lane and `epic:4707`, so the session supervisor correctly treated a DevOps launch as a competing Infra driver.

## Operator decision

Issue #5703 records present-tense operator approval for `devops → epic:5703`. This PR implements that mapping. It deliberately does not close #5703 because #5703 is now the open DevOps stream epic.

## Verification

- 190 affected launcher, canary, supervisor, registry, model-catalog, and rollover tests passed
- 94 affected pre-commit tests passed across two commits
- isolated real launcher: live `epic:4707` Infra lease + successful `epic:5703` DevOps launch
- isolated real launcher: second live `epic:5703` DevOps launch refused before Codex starts
- Ruff, shell syntax, targeted ShellCheck, YAML parsing, fleet-roster projection, Markdown lint on clean changed docs, deployment, deployment parity, OPSEC lint, agent-trailer lint, and `git diff --check` passed
- protected configs and generated-artifact exclusions verified

## Review cycle

The initial Claude Sonnet 5 pass identified a stale authoritative `model_catalog.yaml` statement that still described DevOps as sharing `epic:4707`. That finding was adjudicated as an in-scope blocker and fixed, along with the matching provider-launcher fixtures and Infra recovery boundary. A fresh verdict is required on head `56b053bdb3`.

## Scope

19 files; no supervisor fencing bypass, no Infra lease weakening, and no generated runtime artifacts.