### PR TITLE
docs(model-catalog): add claude-opus-4-8 to model topology and formal review policy

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -42,6 +42,8 @@ Record the harness fallback explicitly; it is a transport fallback, not a model 
   * **Codex seat**: `gpt-5.6-terra` (standard practical review)
   * **GLM seat**: `glm-5.2` (local-only)
   * **Gemini seat**: `gemini-3.6-flash-high`
+* **Complex Non-Advisory Tasks & Deep Reviews**:
+  * **Anthropic Opus seat**: `claude-opus-4-8` (complex coding, deep reasoning, adversarial review)
 * **Escalatory Advisor / Critical Authority Reviews** (reserved for architecture, security, or design escalation):
   * **Anthropic Advisor**: `claude-fable-5` (Fable 5)
   * **OpenAI Advisor**: `gpt-5.6-sol` (`--effort xhigh`)

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -413,6 +413,13 @@ review_candidates:
     review_profiles: [code, infra]
     capabilities: [code_review]
     requires_data_egress_policy: local_interactive
+  claude-opus-4-8:
+    model_id: claude-opus-4-8
+    route: claude
+    transport: native_claude
+    invocation: .venv/bin/python scripts/delegate.py dispatch --agent claude --model claude-opus-4-8
+    review_profiles: [code, infra]
+    capabilities: [code_review]
   claude-sonnet-5:
     model_id: claude-sonnet-5
     route: claude


### PR DESCRIPTION
Adds `claude-opus-4-8` under Anthropic models for complex non-advisory tasks, deep reasoning, and adversarial reviews in `model_catalog.yaml` and `model-assignment.md`.