### PR TITLE
fix(delegate): auto-release stale clean branch holders (#5340)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -926,19 +926,21 @@ def _task_status_for_worktree(path: Path) -> str | None:
         except OSError:
             continue
 
-    # 2) Fallback candidates from path layout.
+    # 2) Fallback candidates from path layout — only if state records an
+    # exact worktree_path/cwd match. Never accept path-less legacy states
+    # (CF F001 #5708): a shared path-component name must not authorize remove.
     for task_id in _task_status_candidates_for_worktree(path):
         state = _read_state(_state_path(task_id))
         if not isinstance(state, dict):
             continue
-        # Prefer states that either match path or omit path (legacy).
         wt = state.get("worktree_path") or state.get("cwd")
-        if wt:
-            try:
-                if Path(str(wt)).resolve() != resolved:
-                    continue
-            except OSError:
+        if not wt:
+            continue
+        try:
+            if Path(str(wt)).resolve() != resolved:
                 continue
+        except OSError:
+            continue
         status = state.get("status")
         if status is not None:
             return str(status)

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1024,8 +1024,10 @@ def _release_stale_branch_holders(
             )
             released.append(path)
             continue
+        # No --force: if the tree went dirty after the cleanliness check
+        # (TOCTOU), git refuses removal and we leave the holder mounted (#5708 CF).
         proc = subprocess.run(
-            ["git", "worktree", "remove", "--force", str(path)],
+            ["git", "worktree", "remove", str(path)],
             cwd=_REPO_ROOT,
             capture_output=True,
             text=True,

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -856,6 +856,131 @@ def _branch_worktree_paths(branch: str) -> list[Path]:
     return matches
 
 
+def _dispatch_task_id_from_worktree(path: Path) -> str | None:
+    """Return task-id when ``path`` is ``.worktrees/dispatch/<agent>/<task>/``."""
+    try:
+        rel = path.resolve().relative_to((_REPO_ROOT / ".worktrees" / "dispatch").resolve())
+    except ValueError:
+        return None
+    if len(rel.parts) >= 2:
+        return rel.parts[1]
+    return None
+
+
+def _task_status_for_worktree(path: Path) -> str | None:
+    """Load batch_state status for a dispatch worktree, or None if unknown."""
+    task_id = _dispatch_task_id_from_worktree(path)
+    if not task_id:
+        return None
+    state = _read_state(_state_path(task_id))
+    if not isinstance(state, dict):
+        return None
+    status = state.get("status")
+    return str(status) if status is not None else None
+
+
+def _worktree_is_clean(path: Path) -> bool:
+    proc = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    if proc.returncode != 0:
+        return False
+    return not bool((proc.stdout or "").strip())
+
+
+def _worktree_matches_origin_branch(path: Path, branch: str) -> bool:
+    """True when HEAD and origin/<branch> point at the same commit."""
+    head = _resolve_sha(path, "HEAD")
+    remote = _resolve_sha(_REPO_ROOT, f"origin/{branch}")
+    if not head or not remote:
+        # origin may only be resolvable from the worktree after local fetch
+        remote = _resolve_sha(path, f"origin/{branch}")
+    return bool(head and remote and head == remote)
+
+
+# Terminal statuses that mean a prior dispatch no longer needs the worktree
+# mounted. Includes failure modes — a crashed review worktree should not
+# permanently pin a PR branch for follow-up dispatches (#5340).
+_BRANCH_HOLDER_RELEASABLE_STATUSES = frozenset(
+    {"done", "failed", "timeout", "rate_limited", "crashed", "cancelled", "dry_run", "needs_finalize"}
+)
+
+
+def _stale_branch_holder_releasable(path: Path, branch: str) -> tuple[bool, str]:
+    """Return (ok, reason) for auto-releasing a worktree holding ``branch`` (#5340).
+
+    Safe only when clean, fully pushed (HEAD == origin/<branch>), and any
+    resolvable owning task is terminal. Live/running tasks and dirty trees
+    keep today's hard refuse.
+    """
+    if not _worktree_is_clean(path):
+        return False, "dirty"
+    if not _worktree_matches_origin_branch(path, branch):
+        return False, "HEAD != origin/<branch>"
+    status = _task_status_for_worktree(path)
+    if status is None:
+        return True, "clean+synced; no resolvable task state"
+    if status in _BRANCH_HOLDER_RELEASABLE_STATUSES:
+        return True, f"clean+synced; task status={status}"
+    return False, f"task still active (status={status})"
+
+
+def _release_stale_branch_holders(
+    *,
+    branch: str,
+    holders: list[Path],
+    dry_run: bool,
+) -> list[Path]:
+    """Remove releasable holders of ``branch`` so a new worktree can attach.
+
+    Returns paths successfully released (or that would be released in dry-run).
+    Non-releasable holders are left in place for the caller to refuse on.
+    """
+    released: list[Path] = []
+    for path in holders:
+        ok, reason = _stale_branch_holder_releasable(path, branch)
+        if not ok:
+            print(
+                f"ℹ️  branch {branch!r} held by {path} not auto-releasable ({reason})",
+                file=sys.stderr,
+            )
+            continue
+        if dry_run:
+            print(
+                f"🌲 dry-run: would release stale branch holder {path} ({reason})",
+                file=sys.stderr,
+            )
+            released.append(path)
+            continue
+        proc = subprocess.run(
+            ["git", "worktree", "remove", "--force", str(path)],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_sanitized_git_env(),
+        )
+        if proc.returncode != 0:
+            print(
+                f"⚠️  failed to release stale branch holder {path}: "
+                f"{_format_process_failure(proc)}",
+                file=sys.stderr,
+            )
+            continue
+        print(
+            f"🌲 released stale branch holder {path} ({reason}) so "
+            f"{branch!r} can attach to a new dispatch worktree",
+            file=sys.stderr,
+        )
+        released.append(path)
+    return released
+
+
 def _resolve_sha(path: Path, ref: str = "HEAD") -> str | None:
     """Return the commit SHA at ``ref`` in ``path``, or None if unresolvable."""
     proc = subprocess.run(
@@ -1634,11 +1759,30 @@ def _ensure_worktree(
         occupied_paths = _branch_worktree_paths(requested_branch)
         elsewhere = [path for path in occupied_paths if path != worktree_path]
         if elsewhere:
-            locations = ", ".join(str(path) for path in elsewhere)
-            raise WorktreeBranchMismatch(
-                f"branch {requested_branch!r} is already checked out in {locations}; "
-                "refusing to attach it to another worktree"
+            # #5340: clean+synced+terminal holders are pure friction — release
+            # them instead of bouncing the dispatch. Live/dirty holders still refuse.
+            _release_stale_branch_holders(
+                branch=requested_branch,
+                holders=elsewhere,
+                dry_run=dry_run,
             )
+            occupied_paths = _branch_worktree_paths(requested_branch)
+            elsewhere = [path for path in occupied_paths if path != worktree_path]
+            # dry-run treats releasable holders as free without mutating
+            if dry_run:
+                still_blocking = [
+                    path
+                    for path in elsewhere
+                    if not _stale_branch_holder_releasable(path, requested_branch)[0]
+                ]
+            else:
+                still_blocking = elsewhere
+            if still_blocking:
+                locations = ", ".join(str(path) for path in still_blocking)
+                raise WorktreeBranchMismatch(
+                    f"branch {requested_branch!r} is already checked out in {locations}; "
+                    "refusing to attach it to another worktree"
+                )
 
     if worktree_path.exists():
         if not worktree_path.is_dir():

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -856,27 +856,93 @@ def _branch_worktree_paths(branch: str) -> list[Path]:
     return matches
 
 
-def _dispatch_task_id_from_worktree(path: Path) -> str | None:
-    """Return task-id when ``path`` is ``.worktrees/dispatch/<agent>/<task>/``."""
+def _dispatch_layout_parts(path: Path) -> tuple[str, str] | None:
+    """Return ``(agent, path_component)`` for ``.worktrees/dispatch/<agent>/<task>/``."""
     try:
         rel = path.resolve().relative_to((_REPO_ROOT / ".worktrees" / "dispatch").resolve())
     except ValueError:
         return None
     if len(rel.parts) >= 2:
-        return rel.parts[1]
+        return rel.parts[0], rel.parts[1]
     return None
 
 
+def _task_status_candidates_for_worktree(path: Path) -> list[str]:
+    """Candidate task IDs that may own a dispatch worktree path.
+
+    Path components are *normalized* (agent prefix stripped, non-alnum flattened)
+    while state files keep the original task_id with ``/`` → ``_``. Prefer an
+    exact ``worktree_path`` match in batch_state; candidates are a fallback only.
+    """
+    parts = _dispatch_layout_parts(path)
+    if parts is None:
+        return []
+    agent, component = parts
+    candidates = [
+        component,
+        f"{agent}-{component}",
+        f"{agent}/{component}",
+        f"{agent}_{component}",
+    ]
+    # Preserve order, drop duplicates.
+    seen: set[str] = set()
+    out: list[str] = []
+    for cand in candidates:
+        if cand not in seen:
+            seen.add(cand)
+            out.append(cand)
+    return out
+
+
 def _task_status_for_worktree(path: Path) -> str | None:
-    """Load batch_state status for a dispatch worktree, or None if unknown."""
-    task_id = _dispatch_task_id_from_worktree(path)
-    if not task_id:
-        return None
-    state = _read_state(_state_path(task_id))
-    if not isinstance(state, dict):
-        return None
-    status = state.get("status")
-    return str(status) if status is not None else None
+    """Load batch_state status for a worktree, or None if owner cannot be resolved.
+
+    Resolution order:
+    1. Exact ``worktree_path`` match in any task state (authoritative).
+    2. Candidate task IDs reconstructed from the dispatch layout.
+
+    Fail closed: callers must not treat ``None`` as releasable for dispatch
+    holders (#5340 CF F001).
+    """
+    resolved = path.resolve()
+    # 1) Authoritative: scan states for worktree_path match.
+    try:
+        state_files = list(_TASKS_DIR.glob("*.json")) if _TASKS_DIR.is_dir() else []
+    except OSError:
+        state_files = []
+    for state_file in state_files:
+        if state_file.name.endswith(".tmp") or ".tmp." in state_file.name:
+            continue
+        state = _read_state(state_file)
+        if not isinstance(state, dict):
+            continue
+        wt = state.get("worktree_path") or state.get("cwd")
+        if not wt:
+            continue
+        try:
+            if Path(str(wt)).resolve() == resolved:
+                status = state.get("status")
+                return str(status) if status is not None else None
+        except OSError:
+            continue
+
+    # 2) Fallback candidates from path layout.
+    for task_id in _task_status_candidates_for_worktree(path):
+        state = _read_state(_state_path(task_id))
+        if not isinstance(state, dict):
+            continue
+        # Prefer states that either match path or omit path (legacy).
+        wt = state.get("worktree_path") or state.get("cwd")
+        if wt:
+            try:
+                if Path(str(wt)).resolve() != resolved:
+                    continue
+            except OSError:
+                continue
+        status = state.get("status")
+        if status is not None:
+            return str(status)
+    return None
 
 
 def _worktree_is_clean(path: Path) -> bool:
@@ -914,9 +980,10 @@ _BRANCH_HOLDER_RELEASABLE_STATUSES = frozenset(
 def _stale_branch_holder_releasable(path: Path, branch: str) -> tuple[bool, str]:
     """Return (ok, reason) for auto-releasing a worktree holding ``branch`` (#5340).
 
-    Safe only when clean, fully pushed (HEAD == origin/<branch>), and any
-    resolvable owning task is terminal. Live/running tasks and dirty trees
-    keep today's hard refuse.
+    Safe only when clean, fully pushed (HEAD == origin/<branch>), and the
+    owning task is known and terminal. Unresolvable owners fail closed so a
+    running dispatch whose state key does not match the path component cannot
+    be force-removed (CF F001 on PR #5708).
     """
     if not _worktree_is_clean(path):
         return False, "dirty"
@@ -924,7 +991,7 @@ def _stale_branch_holder_releasable(path: Path, branch: str) -> tuple[bool, str]
         return False, "HEAD != origin/<branch>"
     status = _task_status_for_worktree(path)
     if status is None:
-        return True, "clean+synced; no resolvable task state"
+        return False, "owner task unresolvable (fail-closed)"
     if status in _BRANCH_HOLDER_RELEASABLE_STATUSES:
         return True, f"clean+synced; task status={status}"
     return False, f"task still active (status={status})"

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2649,7 +2649,12 @@ def test_branch_reuse_releases_clean_terminal_holder_then_attaches(
     # Owning task is terminal (done review).
     delegate._write_state_atomic(
         delegate._state_path("review-5338-deepseek"),
-        {"task_id": "review-5338-deepseek", "agent": "deepseek", "status": "done"},
+        {
+            "task_id": "review-5338-deepseek",
+            "agent": "deepseek",
+            "status": "done",
+            "worktree_path": str(occupied),
+        },
     )
 
     _, actual_branch, telemetry = delegate._ensure_worktree(
@@ -2699,6 +2704,7 @@ def test_branch_reuse_refuses_clean_holder_with_active_task(
             "task_id": "atlas-5230-runner-pr1-delta",
             "agent": "cursor",
             "status": "running",
+            "worktree_path": str(occupied),
         },
     )
 
@@ -2709,6 +2715,99 @@ def test_branch_reuse_refuses_clean_holder_with_active_task(
             raw_path=str(target),
             branch=branch,
         )
+
+
+def test_branch_reuse_fail_closed_when_owner_unresolvable(tmp_path, monkeypatch, tmp_tasks_dir):
+    """#5340 CF F001: clean synced holder without resolvable task must refuse."""
+    target = tmp_path / "target"
+    occupied = (
+        Path(delegate._REPO_ROOT)
+        / ".worktrees"
+        / "dispatch"
+        / "codex"
+        / "foo"
+    )
+    branch = "codex/foo"
+    _, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "worktree", "list"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                f"worktree {occupied}\nbranch refs/heads/{branch}\n\n",
+                "",
+            )
+        return base_stub(cmd, **kwargs)
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    # No batch_state entry at all — fail closed.
+
+    with pytest.raises(delegate.WorktreeBranchMismatch, match="already checked out"):
+        delegate._ensure_worktree(
+            agent="cursor",
+            task_id="follow-up",
+            raw_path=str(target),
+            branch=branch,
+        )
+
+
+def test_branch_reuse_resolves_owner_via_worktree_path_when_ids_diverge(
+    tmp_path, monkeypatch, tmp_tasks_dir
+):
+    """#5340 CF F001: state key codex_foo vs path component foo still finds owner."""
+    target = tmp_path / "target"
+    occupied = (
+        Path(delegate._REPO_ROOT)
+        / ".worktrees"
+        / "dispatch"
+        / "codex"
+        / "foo"
+    )
+    branch = "codex/foo-followup"
+    calls, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+    list_hits = {"n": 0}
+    removes: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["git", "worktree", "list"]:
+            list_hits["n"] += 1
+            body = (
+                f"worktree {occupied}\nbranch refs/heads/{branch}\n\n"
+                if list_hits["n"] == 1
+                else ""
+            )
+            return subprocess.CompletedProcess(cmd, 0, body, "")
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            removes.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rev-parse"] and cmd[-1] == f"refs/heads/{branch}":
+            return subprocess.CompletedProcess(cmd, 0, "same-sha", "")
+        calls.pop()
+        return base_stub(cmd, **kwargs)
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    # State file is slash-sanitized original task id, not path component alone.
+    delegate._write_state_atomic(
+        delegate._state_path("codex/foo"),
+        {
+            "task_id": "codex/foo",
+            "agent": "codex",
+            "status": "done",
+            "worktree_path": str(occupied),
+        },
+    )
+
+    _, actual_branch, telemetry = delegate._ensure_worktree(
+        agent="cursor",
+        task_id="retry",
+        raw_path=str(target),
+        branch=branch,
+    )
+    assert actual_branch == branch
+    assert telemetry["reused"] is False
+    assert removes and str(occupied) in removes[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2575,10 +2575,12 @@ def test_branch_reuse_refuses_protected_branch_before_git_calls(tmp_path, monkey
 
 
 def test_branch_reuse_refuses_branch_checked_out_in_another_worktree(tmp_path, monkeypatch):
+    """Dirty holders still hard-refuse (#5340 keeps safety for live trees)."""
     target = tmp_path / "target"
     occupied = tmp_path / "occupied"
     branch = "cursor/follow-up"
-    _, base_stub = _make_run_stub()
+    # Dirty porcelain => not auto-releasable; keep refuse behavior.
+    _, base_stub = _make_run_stub(status_porcelain=" M dirty.txt")
 
     def fake_run(cmd, **kwargs):
         if cmd[:3] == ["git", "worktree", "list"]:
@@ -2591,6 +2593,114 @@ def test_branch_reuse_refuses_branch_checked_out_in_another_worktree(tmp_path, m
         return base_stub(cmd, **kwargs)
 
     monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(delegate.WorktreeBranchMismatch, match="already checked out"):
+        delegate._ensure_worktree(
+            agent="cursor",
+            task_id="follow-up",
+            raw_path=str(target),
+            branch=branch,
+        )
+
+
+def test_branch_reuse_releases_clean_terminal_holder_then_attaches(
+    tmp_path, monkeypatch, tmp_tasks_dir
+):
+    """#5340: clean + synced + terminal-task holder is released, not a bounce."""
+    target = tmp_path / "target"
+    # Layout matches .worktrees/dispatch/<agent>/<task>/
+    occupied = (
+        Path(delegate._REPO_ROOT)
+        / ".worktrees"
+        / "dispatch"
+        / "deepseek"
+        / "review-5338-deepseek"
+    )
+    branch = "grok-build/atlas-slice3-vendoring-retry"
+    calls, base_stub = _make_run_stub(
+        status_porcelain="",
+        rev_parse_head_sha="same-sha",
+    )
+    list_hits = {"n": 0}
+    removes: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["git", "worktree", "list"]:
+            list_hits["n"] += 1
+            # First list: still occupied. After remove: free.
+            body = (
+                f"worktree {occupied}\nbranch refs/heads/{branch}\n\n"
+                if list_hits["n"] == 1
+                else ""
+            )
+            return subprocess.CompletedProcess(cmd, 0, body, "")
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            removes.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        # Local branch may already exist after a prior worktree held it.
+        if cmd[:2] == ["git", "rev-parse"] and cmd[-1] == f"refs/heads/{branch}":
+            return subprocess.CompletedProcess(cmd, 0, "same-sha", "")
+        # Avoid double-recording when base_stub also appends.
+        calls.pop()
+        return base_stub(cmd, **kwargs)
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    # Owning task is terminal (done review).
+    delegate._write_state_atomic(
+        delegate._state_path("review-5338-deepseek"),
+        {"task_id": "review-5338-deepseek", "agent": "deepseek", "status": "done"},
+    )
+
+    _, actual_branch, telemetry = delegate._ensure_worktree(
+        agent="cursor",
+        task_id="follow-up-retry",
+        raw_path=str(target),
+        branch=branch,
+    )
+
+    assert actual_branch == branch
+    assert telemetry["reused"] is False
+    assert list_hits["n"] >= 2
+    assert removes and removes[0][:3] == ["git", "worktree", "remove"]
+    assert str(occupied) in removes[0]
+    assert any(c[:3] == ["git", "worktree", "add"] for c in calls)
+
+
+def test_branch_reuse_refuses_clean_holder_with_active_task(
+    tmp_path, monkeypatch, tmp_tasks_dir
+):
+    """#5340: clean synced holder with running task still refuses."""
+    target = tmp_path / "target"
+    occupied = (
+        Path(delegate._REPO_ROOT)
+        / ".worktrees"
+        / "dispatch"
+        / "cursor"
+        / "atlas-5230-runner-pr1-delta"
+    )
+    branch = "cursor/atlas-5230"
+    _, base_stub = _make_run_stub(status_porcelain="", rev_parse_head_sha="same-sha")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "worktree", "list"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                f"worktree {occupied}\nbranch refs/heads/{branch}\n\n",
+                "",
+            )
+        return base_stub(cmd, **kwargs)
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    delegate._write_state_atomic(
+        delegate._state_path("atlas-5230-runner-pr1-delta"),
+        {
+            "task_id": "atlas-5230-runner-pr1-delta",
+            "agent": "cursor",
+            "status": "running",
+        },
+    )
 
     with pytest.raises(delegate.WorktreeBranchMismatch, match="already checked out"):
         delegate._ensure_worktree(


### PR DESCRIPTION
## Summary

- When `delegate.py --branch` hits a branch already checked out elsewhere, auto-release the holder if it is **clean**, **HEAD == origin/<branch>**, and any resolvable owning task is **terminal**
- Dirty or live-task holders still hard-refuse (unchanged safety)
- Covers the #5340 bounce class (settled review / prior-session clean worktrees pinning a PR branch)

## Root cause

`--branch` attach refused any other worktree occupancy without checking whether the holder was finished. Session-start reaper is fail-open and does not run mid-dispatch, so settled clean holders bounced follow-up dispatches.

## Test plan

- [x] `tests/test_delegate.py` — 136 passed (pre-commit)
- [x] New cases: release clean+terminal holder; refuse dirty; refuse clean+running
- [x] Ruff + OPSEC + X-Agent trailer

## Stream

DevOps `epic:5703` · issue #5340