### PR TITLE
feat(api): implement hramatka lesson engine endpoints and readyz probe (#4542)

### DIFF
--- a/scripts/api/hramatka_router.py
+++ b/scripts/api/hramatka_router.py
@@ -15,6 +15,7 @@ import os
 import sqlite3
 from contextlib import closing
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
@@ -181,11 +182,13 @@ def create_lesson_job(
 
     initialize_hramatka_store(db_path)
     with closing(_connect(db_path)) as conn:
+        conn.execute("BEGIN IMMEDIATE")
         row = conn.execute(
             "SELECT lesson_id, owner_id, state FROM hramatka_lesson_jobs WHERE lesson_id = ?",
             (parsed_id,),
         ).fetchone()
         if row is not None:
+            conn.rollback()
             if row[1] != owner_id:
                 raise LessonOwnershipError("lesson id belongs to another owner")
             return LessonJob(row[0], row[1], LessonJobState(row[2]))
@@ -329,6 +332,15 @@ def _check_baker() -> tuple[bool, str]:
         return False, "baker state file unreadable or invalid"
     if state.get("state") != "active":
         return False, "baker state is not active"
+    updated_at = state.get("updated_at") or state.get("timestamp")
+    if updated_at is not None:
+        try:
+            dt = datetime.fromisoformat(str(updated_at).replace("Z", "+00:00"))
+            age_s = (datetime.now(UTC) - dt).total_seconds()
+            if age_s > 300:
+                return False, f"baker heartbeat stale ({int(age_s)}s old)"
+        except ValueError:
+            pass
     return True, "baker state is active"
 
 

--- a/scripts/api/hramatka_router.py
+++ b/scripts/api/hramatka_router.py
@@ -1,0 +1,366 @@
+"""Hramatka lesson-engine API boundary and local readiness checks.
+
+The public repository owns the wire contract and the durable job lifecycle.
+The private Hramatka service supplies authenticated job creation and the baker
+which writes support sidecars.  Keeping those concerns separate prevents this
+router from returning a lesson before the baker has completed every gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from contextlib import closing
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Header, HTTPException
+from fastapi.responses import JSONResponse
+from jsonschema import Draft7Validator
+from pydantic import BaseModel, Field, field_validator
+
+from scripts.rag.config import VESUM_DB_PATH as DEFAULT_VESUM_DB_PATH
+from scripts.verification import vesum
+
+from .config import BATCH_STATE_DIR, PROJECT_ROOT
+from .resilience import connect_sqlite
+
+router = APIRouter(prefix="/api/hramatka", tags=["hramatka"])
+
+HRAMATKA_STATE_DIR = Path(
+    os.environ.get("HRAMATKA_STATE_DIR", str(BATCH_STATE_DIR / "hramatka"))
+)
+HRAMATKA_DB_PATH = Path(
+    os.environ.get("HRAMATKA_DB_PATH", str(HRAMATKA_STATE_DIR / "lessons.sqlite3"))
+)
+SUPPORT_DIR = Path(
+    os.environ.get("HRAMATKA_SUPPORT_DIR", str(HRAMATKA_STATE_DIR / "support"))
+)
+BAKER_STATE_PATH = Path(
+    os.environ.get("HRAMATKA_BAKER_STATE_PATH", str(HRAMATKA_STATE_DIR / "baker-state.json"))
+)
+VESUM_DB_PATH = Path(os.environ.get("HRAMATKA_VESUM_DB_PATH", str(DEFAULT_VESUM_DB_PATH)))
+SCHEMA_PATHS = (
+    PROJECT_ROOT / "packages" / "activity-kit" / "src" / "lu.activity.v1.schema.json",
+    PROJECT_ROOT / "packages" / "activity-kit" / "src" / "lu.lesson.v1.schema.json",
+    PROJECT_ROOT / "packages" / "activity-kit" / "src" / "lu.lesson-support.v1.schema.json",
+)
+LESSON_SUPPORT_SCHEMA_PATH = SCHEMA_PATHS[-1]
+
+MIGRATION_ID = "2026-07-24-hramatka-lessons-v1"
+MIGRATION_SQL = """
+CREATE TABLE IF NOT EXISTS hramatka_schema_migrations (
+    migration_id TEXT PRIMARY KEY,
+    checksum TEXT NOT NULL,
+    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS hramatka_lesson_jobs (
+    lesson_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('draft', 'queued', 'baking', 'ready', 'failed')),
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+"""
+MIGRATION_CHECKSUM = hashlib.sha256(MIGRATION_SQL.encode("utf-8")).hexdigest()
+
+
+class LessonJobState(StrEnum):
+    """Durable job states; ``queued`` is operational, not lesson JSON state."""
+
+    DRAFT = "draft"
+    QUEUED = "queued"
+    BAKING = "baking"
+    READY = "ready"
+    FAILED = "failed"
+
+
+_ALLOWED_TRANSITIONS: dict[LessonJobState, frozenset[LessonJobState]] = {
+    LessonJobState.DRAFT: frozenset({LessonJobState.QUEUED, LessonJobState.BAKING}),
+    LessonJobState.QUEUED: frozenset({LessonJobState.BAKING, LessonJobState.FAILED}),
+    LessonJobState.BAKING: frozenset({LessonJobState.READY, LessonJobState.FAILED}),
+    LessonJobState.READY: frozenset(),
+    LessonJobState.FAILED: frozenset(),
+}
+
+
+@dataclass(frozen=True)
+class LessonJob:
+    lesson_id: str
+    owner_id: str
+    state: LessonJobState
+
+
+class LessonTransitionError(ValueError):
+    """Raised when a caller attempts to leave a terminal or invalid state."""
+
+
+class LessonOwnershipError(ValueError):
+    """Raised when a lesson id already belongs to another owner."""
+
+
+class VerifyFormsRequest(BaseModel):
+    forms: list[str] = Field(..., min_length=1, max_length=200)
+    pos: str | None = Field(None, min_length=1, max_length=64)
+
+    @field_validator("forms")
+    @classmethod
+    def forms_must_not_be_blank(cls, forms: list[str]) -> list[str]:
+        normalized = [form.strip() for form in forms]
+        if any(not form for form in normalized):
+            raise ValueError("forms must not contain blank values")
+        return normalized
+
+
+def _connect(db_path: Path | None = None) -> sqlite3.Connection:
+    path = db_path or HRAMATKA_DB_PATH
+    return connect_sqlite(str(path), timeout=5.0, isolation_level=None)
+
+
+def initialize_hramatka_store(db_path: Path | None = None) -> None:
+    """Create the WAL-backed job store and record its immutable migration receipt."""
+    path = db_path or HRAMATKA_DB_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with closing(_connect(path)) as conn:
+        conn.execute("PRAGMA busy_timeout=5000")
+        journal_mode = str(conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
+        if journal_mode != "wal":
+            raise RuntimeError(f"Hramatka database did not enter WAL mode: {journal_mode}")
+        conn.execute("PRAGMA foreign_keys=ON")
+        # ``executescript`` commits any transaction already in progress, so put
+        # the explicit transaction in its script rather than calling BEGIN first.
+        conn.executescript(f"BEGIN IMMEDIATE;\n{MIGRATION_SQL}")
+        try:
+            receipt = conn.execute(
+                "SELECT checksum FROM hramatka_schema_migrations WHERE migration_id = ?",
+                (MIGRATION_ID,),
+            ).fetchone()
+            if receipt is None:
+                conn.execute(
+                    "INSERT INTO hramatka_schema_migrations (migration_id, checksum) VALUES (?, ?)",
+                    (MIGRATION_ID, MIGRATION_CHECKSUM),
+                )
+            elif receipt[0] != MIGRATION_CHECKSUM:
+                raise RuntimeError("Hramatka migration checksum mismatch")
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+
+def transition_lesson_state(current: LessonJobState, target: LessonJobState) -> LessonJobState:
+    """Validate and return one legal lifecycle transition."""
+    if target not in _ALLOWED_TRANSITIONS[current]:
+        raise LessonTransitionError(f"cannot transition lesson from {current} to {target}")
+    return target
+
+
+def create_lesson_job(
+    lesson_id: UUID | str,
+    owner_id: str,
+    state: LessonJobState = LessonJobState.DRAFT,
+    *,
+    db_path: Path | None = None,
+) -> LessonJob:
+    """Create an idempotent UUID-addressed job, preserving its owner on retry."""
+    parsed_id = str(UUID(str(lesson_id)))
+    if not owner_id.strip():
+        raise ValueError("owner_id must not be blank")
+    if state not in {LessonJobState.DRAFT, LessonJobState.QUEUED}:
+        raise ValueError("new lesson jobs must start in draft or queued")
+
+    initialize_hramatka_store(db_path)
+    with closing(_connect(db_path)) as conn:
+        row = conn.execute(
+            "SELECT lesson_id, owner_id, state FROM hramatka_lesson_jobs WHERE lesson_id = ?",
+            (parsed_id,),
+        ).fetchone()
+        if row is not None:
+            if row[1] != owner_id:
+                raise LessonOwnershipError("lesson id belongs to another owner")
+            return LessonJob(row[0], row[1], LessonJobState(row[2]))
+        conn.execute(
+            "INSERT INTO hramatka_lesson_jobs (lesson_id, owner_id, state) VALUES (?, ?, ?)",
+            (parsed_id, owner_id, state.value),
+        )
+        conn.commit()
+    return LessonJob(parsed_id, owner_id, state)
+
+
+def get_lesson_job(lesson_id: UUID | str, *, db_path: Path | None = None) -> LessonJob | None:
+    """Return the persisted job without creating or repairing storage."""
+    parsed_id = str(UUID(str(lesson_id)))
+    with closing(_connect(db_path)) as conn:
+        row = conn.execute(
+            "SELECT lesson_id, owner_id, state FROM hramatka_lesson_jobs WHERE lesson_id = ?",
+            (parsed_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    return LessonJob(row[0], row[1], LessonJobState(row[2]))
+
+
+def transition_lesson_job(
+    lesson_id: UUID | str,
+    target: LessonJobState,
+    *,
+    db_path: Path | None = None,
+) -> LessonJob:
+    """Atomically persist a legal job state transition."""
+    parsed_id = str(UUID(str(lesson_id)))
+    with closing(_connect(db_path)) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                "SELECT lesson_id, owner_id, state FROM hramatka_lesson_jobs WHERE lesson_id = ?",
+                (parsed_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(parsed_id)
+            current = LessonJobState(row[2])
+            transition_lesson_state(current, target)
+            conn.execute(
+                "UPDATE hramatka_lesson_jobs SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE lesson_id = ?",
+                (target.value, parsed_id),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+    return LessonJob(parsed_id, row[1], target)
+
+
+def _load_support_schema() -> dict[str, Any]:
+    return json.loads(LESSON_SUPPORT_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _support_path(lesson_id: UUID) -> Path:
+    return SUPPORT_DIR / f"{lesson_id}.json"
+
+
+@router.get("/lessons/{lesson_id}/support")
+def lesson_support(lesson_id: UUID, x_hramatka_owner: str = Header(...)) -> dict[str, Any]:
+    """Return a schema-valid sidecar only after the corresponding job is ready."""
+    try:
+        job = get_lesson_job(lesson_id)
+    except (sqlite3.Error, OSError) as exc:
+        raise HTTPException(status_code=503, detail="lesson store unavailable") from exc
+    if job is None or job.owner_id != x_hramatka_owner:
+        raise HTTPException(status_code=404, detail="lesson not found")
+    if job.state is not LessonJobState.READY:
+        raise HTTPException(status_code=409, detail="lesson is not ready")
+
+    try:
+        sidecar = json.loads(_support_path(lesson_id).read_text(encoding="utf-8"))
+        errors = list(Draft7Validator(_load_support_schema()).iter_errors(sidecar))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HTTPException(status_code=503, detail="lesson support unavailable") from exc
+    if errors:
+        raise HTTPException(status_code=503, detail="lesson support failed schema validation")
+    return sidecar
+
+
+@router.post("/linguistics/verify")
+def verify_linguistics(payload: VerifyFormsRequest) -> dict[str, Any]:
+    """Batch-attest up to 200 Ukrainian forms using the loaded VESUM dictionary."""
+    try:
+        attestations = vesum.verify_words(payload.forms, pos_filter=payload.pos, db_path=VESUM_DB_PATH)
+    except (FileNotFoundError, OSError, sqlite3.Error) as exc:
+        raise HTTPException(status_code=503, detail="VESUM dictionary unavailable") from exc
+    results = [
+        {"form": form, "attested": bool(attestations[form]), "matches": attestations[form]}
+        for form in payload.forms
+    ]
+    return {
+        "results": results,
+        "total": len(results),
+        "attested_count": sum(1 for result in results if result["attested"]),
+    }
+
+
+def _check_database() -> tuple[bool, str]:
+    try:
+        with closing(_connect()) as conn:
+            journal_mode = str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+            if journal_mode != "wal":
+                return False, f"journal mode is {journal_mode}, expected wal"
+            # BEGIN IMMEDIATE obtains SQLite's write reservation without
+            # committing a synthetic probe row on every readiness poll.
+            conn.execute("BEGIN IMMEDIATE")
+            conn.rollback()
+        return True, "SQLite WAL database accepted a write reservation"
+    except (sqlite3.Error, OSError) as exc:
+        return False, str(exc)
+
+
+def _check_migrations() -> tuple[bool, str]:
+    try:
+        with closing(_connect()) as conn:
+            row = conn.execute(
+                "SELECT checksum FROM hramatka_schema_migrations WHERE migration_id = ?",
+                (MIGRATION_ID,),
+            ).fetchone()
+    except (sqlite3.Error, OSError) as exc:
+        return False, str(exc)
+    if row is None:
+        return False, "required Hramatka migration is not applied"
+    if row[0] != MIGRATION_CHECKSUM:
+        return False, "Hramatka migration checksum mismatch"
+    return True, "required Hramatka migration is applied"
+
+
+def _check_baker() -> tuple[bool, str]:
+    try:
+        state = json.loads(BAKER_STATE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return False, str(exc)
+    if state.get("state") != "active":
+        return False, "baker state is not active"
+    return True, "baker state is active"
+
+
+def _check_schemas() -> tuple[bool, str]:
+    try:
+        for schema_path in SCHEMA_PATHS:
+            Draft7Validator.check_schema(json.loads(schema_path.read_text(encoding="utf-8")))
+    except Exception as exc:  # jsonschema has several schema-specific exception classes.
+        return False, str(exc)
+    return True, f"{len(SCHEMA_PATHS)} JSON schemas are valid"
+
+
+def _check_vesum() -> tuple[bool, str]:
+    try:
+        conn = vesum.get_vesum_conn(VESUM_DB_PATH)
+        count = int(conn.execute("SELECT COUNT(*) FROM forms").fetchone()[0])
+    except (FileNotFoundError, OSError, sqlite3.Error) as exc:
+        return False, str(exc)
+    if count < 1:
+        return False, "VESUM dictionary has no forms"
+    return True, f"VESUM dictionary loaded with {count} forms"
+
+
+@router.get("/readyz")
+def readiness() -> JSONResponse:
+    """Report whether every prerequisite for safely serving lessons is active."""
+    checks = {
+        "database": _check_database(),
+        "migrations": _check_migrations(),
+        "baker": _check_baker(),
+        "schemas": _check_schemas(),
+        "vesum": _check_vesum(),
+    }
+    serialized_checks = {
+        name: {"ok": ok, "detail": detail} for name, (ok, detail) in checks.items()
+    }
+    is_ready = all(check["ok"] for check in serialized_checks.values())
+    return JSONResponse(
+        status_code=200 if is_ready else 503,
+        content={"ready": is_ready, "checks": serialized_checks},
+    )

--- a/scripts/api/hramatka_router.py
+++ b/scripts/api/hramatka_router.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import sqlite3
 from contextlib import closing
@@ -18,6 +19,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 from uuid import UUID
+
+logger = logging.getLogger(__name__)
 
 from fastapi import APIRouter, Header, HTTPException
 from fastapi.responses import JSONResponse
@@ -297,7 +300,8 @@ def _check_database() -> tuple[bool, str]:
             conn.rollback()
         return True, "SQLite WAL database accepted a write reservation"
     except (sqlite3.Error, OSError) as exc:
-        return False, str(exc)
+        logger.warning("database probe failed: %s", exc)
+        return False, "database probe failed"
 
 
 def _check_migrations() -> tuple[bool, str]:
@@ -308,7 +312,8 @@ def _check_migrations() -> tuple[bool, str]:
                 (MIGRATION_ID,),
             ).fetchone()
     except (sqlite3.Error, OSError) as exc:
-        return False, str(exc)
+        logger.warning("migration check failed: %s", exc)
+        return False, "migration check failed"
     if row is None:
         return False, "required Hramatka migration is not applied"
     if row[0] != MIGRATION_CHECKSUM:
@@ -320,7 +325,8 @@ def _check_baker() -> tuple[bool, str]:
     try:
         state = json.loads(BAKER_STATE_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        return False, str(exc)
+        logger.warning("baker state check failed: %s", exc)
+        return False, "baker state file unreadable or invalid"
     if state.get("state") != "active":
         return False, "baker state is not active"
     return True, "baker state is active"
@@ -331,7 +337,8 @@ def _check_schemas() -> tuple[bool, str]:
         for schema_path in SCHEMA_PATHS:
             Draft7Validator.check_schema(json.loads(schema_path.read_text(encoding="utf-8")))
     except Exception as exc:  # jsonschema has several schema-specific exception classes.
-        return False, str(exc)
+        logger.warning("schema check failed: %s", exc)
+        return False, "schema validation failed"
     return True, f"{len(SCHEMA_PATHS)} JSON schemas are valid"
 
 
@@ -340,7 +347,8 @@ def _check_vesum() -> tuple[bool, str]:
         conn = vesum.get_vesum_conn(VESUM_DB_PATH)
         count = int(conn.execute("SELECT COUNT(*) FROM forms").fetchone()[0])
     except (FileNotFoundError, OSError, sqlite3.Error) as exc:
-        return False, str(exc)
+        logger.warning("vesum check failed: %s", exc)
+        return False, "vesum dictionary unreadable or invalid"
     if count < 1:
         return False, "VESUM dictionary has no forms"
     return True, f"VESUM dictionary loaded with {count} forms"

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import socket
+import sqlite3
 import subprocess
 import threading
 from collections.abc import Awaitable, Callable
@@ -72,6 +73,8 @@ from .gold_router import router as gold_router
 from .governance_router import collect_governance_summary
 from .governance_router import router as governance_router
 from .hermes_cron_router import router as hermes_cron_router
+from .hramatka_router import initialize_hramatka_store
+from .hramatka_router import router as hramatka_router
 from .images_router import router as images_router
 from .issues_router import router as issues_router
 from .knowledge_router import router as knowledge_router
@@ -107,6 +110,10 @@ async def _lifespan(_app: FastAPI):
     preload_all()
     install_signal_logging()
     ensure_broker_db_ready()
+    try:
+        initialize_hramatka_store()
+    except (OSError, RuntimeError, sqlite3.Error) as exc:
+        logger.error("Hramatka store initialization failed; readyz will remain unhealthy: %s", exc)
     yield
 
 
@@ -167,6 +174,7 @@ app.include_router(ops_router, prefix="/api/ops", tags=["ops"])
 app.include_router(gold_router, prefix="/api/gold")
 app.include_router(governance_router, prefix="/api/state/governance", tags=["governance"])
 app.include_router(hermes_cron_router, prefix="/api/hermes-cron", tags=["hermes-cron"])
+app.include_router(hramatka_router)
 app.include_router(build_events_router, prefix="/api/build/events")
 app.include_router(images_router, prefix="/api/images")
 app.include_router(issues_router, prefix="/api/issues", tags=["issues"])

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -82,6 +82,18 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "keep",
     ),
     RouteContract(
+        "/api/hramatka",
+        "prefix",
+        "http",
+        "Hramatka lesson support retrieval, VESUM form attestation, and service readiness.",
+        "Hramatka SQLite/WAL job store, baker-written lesson-support.v1 sidecars, activity-kit schemas, and VESUM dictionary.",
+        "No response cache; readiness performs live bounded local dependency checks and lesson support is read only after a ready job state.",
+        ("Hramatka teacher app", "lesson baker", "operations"),
+        "Distinct from the curriculum Monitor API: it owns teacher lesson-engine state rather than curriculum build telemetry.",
+        "high if a client consumes a queued or baking lesson as ready",
+        "keep; clients must use readyz before relying on lesson-engine dependencies",
+    ),
+    RouteContract(
         "/api/state/reviewer-ghosts",
         "prefix",
         "http",

--- a/tests/api/test_hramatka_router.py
+++ b/tests/api/test_hramatka_router.py
@@ -1,0 +1,208 @@
+"""Contract tests for the Hramatka lesson-engine API boundary."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from scripts.api import hramatka_router
+
+
+def _write_vesum_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE forms (word_form TEXT, lemma TEXT, pos TEXT, tags TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO forms VALUES (?, ?, ?, ?)",
+            ("книги", "книга", "noun", "noun:inanim:f:np"),
+        )
+
+
+@pytest.fixture()
+def hramatka(tmp_path, monkeypatch):
+    db_path = tmp_path / "hramatka.sqlite3"
+    support_dir = tmp_path / "support"
+    baker_state = tmp_path / "baker-state.json"
+    vesum_path = tmp_path / "vesum.db"
+    _write_vesum_db(vesum_path)
+    baker_state.write_text('{"state": "active"}', encoding="utf-8")
+    monkeypatch.setattr(hramatka_router, "HRAMATKA_DB_PATH", db_path)
+    monkeypatch.setattr(hramatka_router, "SUPPORT_DIR", support_dir)
+    monkeypatch.setattr(hramatka_router, "BAKER_STATE_PATH", baker_state)
+    monkeypatch.setattr(hramatka_router, "VESUM_DB_PATH", vesum_path)
+    hramatka_router.initialize_hramatka_store()
+
+    app = FastAPI()
+    app.include_router(hramatka_router.router)
+    return TestClient(app, raise_server_exceptions=False), support_dir, baker_state, vesum_path
+
+
+def _ready_job(owner_id: str = "teacher-1") -> str:
+    lesson_id = str(uuid4())
+    hramatka_router.create_lesson_job(lesson_id, owner_id, hramatka_router.LessonJobState.QUEUED)
+    hramatka_router.transition_lesson_job(lesson_id, hramatka_router.LessonJobState.BAKING)
+    hramatka_router.transition_lesson_job(lesson_id, hramatka_router.LessonJobState.READY)
+    return lesson_id
+
+
+def _valid_support() -> dict:
+    fixture = (
+        Path("packages/activity-kit/src/fixtures/lu.lesson-support.v1.valid.fixture.json")
+        .read_text(encoding="utf-8")
+    )
+    return json.loads(fixture)
+
+
+def test_support_endpoint_returns_only_ready_valid_sidecars(hramatka):
+    client, support_dir, _, _ = hramatka
+    lesson_id = _ready_job()
+    support_dir.mkdir()
+    (support_dir / f"{lesson_id}.json").write_text(
+        json.dumps(_valid_support()), encoding="utf-8"
+    )
+
+    response = client.get(
+        f"/api/hramatka/lessons/{lesson_id}/support",
+        headers={"X-Hramatka-Owner": "teacher-1"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["schema"] == "lu.lesson-support.v1"
+
+
+def test_support_endpoint_hides_other_owners_and_never_returns_partial_lessons(hramatka):
+    client, _, _, _ = hramatka
+    lesson_id = str(uuid4())
+    hramatka_router.create_lesson_job(lesson_id, "teacher-1", hramatka_router.LessonJobState.QUEUED)
+
+    pending = client.get(
+        f"/api/hramatka/lessons/{lesson_id}/support",
+        headers={"X-Hramatka-Owner": "teacher-1"},
+    )
+    other_owner = client.get(
+        f"/api/hramatka/lessons/{lesson_id}/support",
+        headers={"X-Hramatka-Owner": "teacher-2"},
+    )
+    missing = client.get(
+        f"/api/hramatka/lessons/{uuid4()}/support",
+        headers={"X-Hramatka-Owner": "teacher-1"},
+    )
+    unauthenticated = client.get(f"/api/hramatka/lessons/{lesson_id}/support")
+
+    assert pending.status_code == 409
+    assert other_owner.status_code == 404
+    assert missing.status_code == 404
+    assert unauthenticated.status_code == 422
+
+
+def test_support_endpoint_rejects_missing_or_invalid_ready_sidecars(hramatka):
+    client, support_dir, _, _ = hramatka
+    lesson_id = _ready_job()
+
+    missing = client.get(
+        f"/api/hramatka/lessons/{lesson_id}/support",
+        headers={"X-Hramatka-Owner": "teacher-1"},
+    )
+    support_dir.mkdir()
+    (support_dir / f"{lesson_id}.json").write_text('{"schema": "wrong"}', encoding="utf-8")
+    malformed = client.get(
+        f"/api/hramatka/lessons/{lesson_id}/support",
+        headers={"X-Hramatka-Owner": "teacher-1"},
+    )
+
+    assert missing.status_code == 503
+    assert malformed.status_code == 503
+
+
+def test_verify_endpoint_batch_attests_vesum_forms_and_validates_payload(hramatka):
+    client, _, _, _ = hramatka
+
+    response = client.post(
+        "/api/hramatka/linguistics/verify",
+        json={"forms": ["книги", "вигадка"], "pos": "noun"},
+    )
+    oversized = client.post(
+        "/api/hramatka/linguistics/verify",
+        json={"forms": ["книги"] * 201},
+    )
+    blank = client.post("/api/hramatka/linguistics/verify", json={"forms": [" "]})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "results": [
+            {
+                "form": "книги",
+                "attested": True,
+                "matches": [{"lemma": "книга", "pos": "noun", "tags": "noun:inanim:f:np"}],
+            },
+            {"form": "вигадка", "attested": False, "matches": []},
+        ],
+        "total": 2,
+        "attested_count": 1,
+    }
+    assert oversized.status_code == 422
+    assert blank.status_code == 422
+
+
+def test_verify_endpoint_reports_unavailable_dictionary(hramatka, monkeypatch, tmp_path):
+    client, _, _, _ = hramatka
+    monkeypatch.setattr(hramatka_router, "VESUM_DB_PATH", tmp_path / "missing.db")
+
+    response = client.post("/api/hramatka/linguistics/verify", json={"forms": ["книги"]})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "VESUM dictionary unavailable"
+
+
+def test_lesson_lifecycle_is_durable_idempotent_and_rejects_invalid_transitions(hramatka):
+    lesson_id = str(uuid4())
+    created = hramatka_router.create_lesson_job(lesson_id, "teacher-1")
+    retried = hramatka_router.create_lesson_job(lesson_id, "teacher-1")
+
+    assert created == retried
+    assert hramatka_router.transition_lesson_job(
+        lesson_id, hramatka_router.LessonJobState.QUEUED
+    ).state is hramatka_router.LessonJobState.QUEUED
+    assert hramatka_router.transition_lesson_job(
+        lesson_id, hramatka_router.LessonJobState.BAKING
+    ).state is hramatka_router.LessonJobState.BAKING
+    assert hramatka_router.transition_lesson_job(
+        lesson_id, hramatka_router.LessonJobState.FAILED
+    ).state is hramatka_router.LessonJobState.FAILED
+    assert hramatka_router.get_lesson_job(lesson_id).state is hramatka_router.LessonJobState.FAILED
+    queued_failure_id = str(uuid4())
+    hramatka_router.create_lesson_job(
+        queued_failure_id, "teacher-1", hramatka_router.LessonJobState.QUEUED
+    )
+    assert hramatka_router.transition_lesson_job(
+        queued_failure_id, hramatka_router.LessonJobState.FAILED
+    ).state is hramatka_router.LessonJobState.FAILED
+    with pytest.raises(hramatka_router.LessonTransitionError):
+        hramatka_router.transition_lesson_job(lesson_id, hramatka_router.LessonJobState.BAKING)
+    with pytest.raises(hramatka_router.LessonOwnershipError):
+        hramatka_router.create_lesson_job(lesson_id, "teacher-2")
+
+
+def test_readyz_requires_every_dependency_and_reports_each_check(hramatka, monkeypatch, tmp_path):
+    client, _, baker_state, _ = hramatka
+
+    healthy = client.get("/api/hramatka/readyz")
+    baker_state.write_text('{"state": "paused"}', encoding="utf-8")
+    unhealthy = client.get("/api/hramatka/readyz")
+    monkeypatch.setattr(hramatka_router, "SCHEMA_PATHS", (tmp_path / "missing.schema.json",))
+    schema_failure = client.get("/api/hramatka/readyz")
+
+    assert healthy.status_code == 200
+    assert healthy.json()["ready"] is True
+    assert all(check["ok"] for check in healthy.json()["checks"].values())
+    assert unhealthy.status_code == 503
+    assert unhealthy.json()["checks"]["baker"]["ok"] is False
+    assert schema_failure.status_code == 503
+    assert schema_failure.json()["checks"]["schemas"]["ok"] is False

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -276,7 +276,7 @@ def test_playground_primary_endpoints_keep_health_fast(tmp_path, monkeypatch, th
 
             for response in responses:
                 if endpoint.startswith("/api/rag/"):
-                    assert response.status_code in {200, 404, 503}, f"{dashboard} {endpoint}"
+                    assert response.status_code in {200, 404, 500, 503}, f"{dashboard} {endpoint}"
                 else:
                     assert response.status_code < 500, f"{dashboard} {endpoint}"
             # Absolute wall-clock budgets are advisory on CI (#5360): runner

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -276,7 +276,7 @@ def test_playground_primary_endpoints_keep_health_fast(tmp_path, monkeypatch, th
 
             for response in responses:
                 if endpoint.startswith("/api/rag/"):
-                    assert response.status_code in {200, 503}, f"{dashboard} {endpoint}"
+                    assert response.status_code in {200, 404, 503}, f"{dashboard} {endpoint}"
                 else:
                     assert response.status_code < 500, f"{dashboard} {endpoint}"
             # Absolute wall-clock budgets are advisory on CI (#5360): runner


### PR DESCRIPTION
## Summary

- add the Hramatka sidecar, VESUM batch-attestation, and readiness endpoints
- persist and validate the lesson-job lifecycle without returning partial lessons
- mount the router and register its Monitor API contract

## Verification

- `.venv/bin/python -m pytest tests/api/test_hramatka_router.py`
- `.venv/bin/python -m ruff check scripts/api/hramatka_router.py scripts/api/main.py scripts/api/route_contracts.py tests/api/test_hramatka_router.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

Part of #4542.