### PR TITLE
[atlas][perf] Implement process-local connection pooling in heritage_classifier.py (#5713)

### DIFF
--- a/scripts/lexicon/heritage_classifier.py
+++ b/scripts/lexicon/heritage_classifier.py
@@ -15,7 +15,9 @@ import os
 import re
 import sqlite3
 import sys
-from contextlib import closing
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -214,7 +216,7 @@ def _classify(
 
     attestations: list[dict[str, Any]] = []
     classification = "unknown"
-    with closing(_source_conn(db_path)) as conn:
+    with _source_conn(db_path) as conn:
         auth_hits = _strict_heritage_attestations(conn, term, surface=surface)
         has_standard_hit = any(hit["classification"] == "standard" for hit in auth_hits)
         for hit in auth_hits:
@@ -390,21 +392,56 @@ def compute_warning_severity(
     return "none"
 
 
+_THREAD_LOCAL = threading.local()
+
+
+def close_cached_connections() -> None:
+    """Close and clear all thread-local source DB connections on current thread."""
+    conns = getattr(_THREAD_LOCAL, "conns", None)
+    if conns:
+        for conn in list(conns.values()):
+            with suppress(Exception):
+                conn.close()
+        conns.clear()
+
+
+def _clear_thread_local_cache_in_child() -> None:
+    if hasattr(_THREAD_LOCAL, "conns"):
+        _THREAD_LOCAL.conns = {}
+
+
+if hasattr(os, "register_at_fork"):
+    with suppress(Exception):
+        os.register_at_fork(after_in_child=_clear_thread_local_cache_in_child)
+
+
 def _source_db_path(db_path: str | Path | None = None) -> Path:
     target = Path(db_path) if db_path is not None else SOURCES_DB
-    primary = Path("/Users/krisztiankoos/projects/learn-ukrainian/data/sources.db")
+    primary = ROOT / "data" / "sources.db"
     if (not target.is_file() or target.stat().st_size < 1_000_000) and primary.is_file():
         return primary
     return target
 
 
-def _source_conn(db_path: str | Path | None = None) -> sqlite3.Connection:
+def _get_thread_local_conn(source_db: Path) -> sqlite3.Connection:
+    if not hasattr(_THREAD_LOCAL, "conns"):
+        _THREAD_LOCAL.conns = {}
+    key = str(source_db.resolve())
+    conn = _THREAD_LOCAL.conns.get(key)
+    if conn is None:
+        conn = sqlite3.connect(f"file:{source_db.resolve()}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA query_only = 1")
+        _THREAD_LOCAL.conns[key] = conn
+    return conn
+
+
+@contextmanager
+def _source_conn(db_path: str | Path | None = None) -> Iterator[sqlite3.Connection]:
     source_db = _source_db_path(db_path)
     if not source_db.exists():
         raise FileNotFoundError(f"local sources database not found: {source_db}")
-    conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
-    conn.row_factory = sqlite3.Row
-    return conn
+    yield _get_thread_local_conn(source_db)
 
 
 def _normalize_word(word: str) -> str:
@@ -921,7 +958,7 @@ def _sum11_sovietization_risk_for_term(
 ) -> int:
     try:
         has_flag_columns = _source_sum11_has_flag_columns(db_path)
-        with closing(_source_conn(db_path)) as conn:
+        with _source_conn(db_path) as conn:
             if has_flag_columns:
                 risk = 0
                 for variant in _apostrophe_variants(term):

--- a/tests/test_heritage_classifier.py
+++ b/tests/test_heritage_classifier.py
@@ -321,3 +321,49 @@ def test_compute_warning_severity_is_pure(
         )
         == expected
     )
+
+
+def test_connection_pooling_same_thread_reuses_connection() -> None:
+    from scripts.lexicon.heritage_classifier import _source_conn, close_cached_connections
+    close_cached_connections()
+    with _source_conn(DB) as conn1:
+        with _source_conn(DB) as conn2:
+            assert conn1 is conn2
+    close_cached_connections()
+
+
+def test_connection_pooling_usable_after_context_exit() -> None:
+    from scripts.lexicon.heritage_classifier import _source_conn, close_cached_connections
+    close_cached_connections()
+    with _source_conn(DB) as conn:
+        pass
+    # Connection remains open and cached for future queries
+    with _source_conn(DB) as conn2:
+        row = conn2.execute("SELECT 1").fetchone()
+        assert row[0] == 1
+    close_cached_connections()
+
+
+def test_connection_pooling_close_cached_connections() -> None:
+    from scripts.lexicon.heritage_classifier import _source_conn, close_cached_connections
+    with _source_conn(DB) as conn1:
+        pass
+    close_cached_connections()
+    with _source_conn(DB) as conn2:
+        assert conn1 is not conn2
+    close_cached_connections()
+
+
+def test_connection_pooling_query_only_mode() -> None:
+    import sqlite3
+
+    import pytest
+
+    from scripts.lexicon.heritage_classifier import _source_conn, close_cached_connections
+    with _source_conn(DB) as conn:
+        try:
+            conn.execute("CREATE TABLE _test_ro_fail (id INT)")
+            pytest.fail("Should have raised OperationalError in query_only mode")
+        except sqlite3.OperationalError:
+            pass
+    close_cached_connections()


### PR DESCRIPTION
Implements thread-local connection pooling for SQLite sources.db lookups per Fable advisor specifications.

- Eliminates 19,264 open/close connection thrashing cycles per manifest scan
- Uses `threading.local()` with path resolution (`str(source_db.resolve())`)
- Refactors `_source_conn` as `@contextmanager` yielding thread-cached connection
- Enforces `PRAGMA query_only = 1` and `mode=ro` URI
- Adds `os.register_at_fork(after_in_child=...)` fork guard
- Fixes non-portable absolute path fallback
- Includes 4 resource-safety unit tests (25 passed in 0.71s)

Fixes #5713