### PR TITLE
feat(canary): post-compact re-ground + Active Working Set

### DIFF
--- a/docs/runbooks/grok-session-canary.md
+++ b/docs/runbooks/grok-session-canary.md
@@ -15,10 +15,32 @@ hydrate, or re-load the diary. Restart only when FAIL-HANDOFF ends the seat
 
 | Signal | Meaning |
 | --- | --- |
-| Auto-compact | **Re-score** canary; keep driving only if PASS |
+| Auto-compact | **Re-score** canary → on PASS **auto-hydrate + RE-GROUND** (not blind continue) |
+| Canary **PASS** | Durable **anchors** OK only — **not** proof mid-flight working memory survived |
 | Canary **&lt; 8/10** (`pass-ratio` 0.8) | **FAIL-HANDOFF** → auto **STATE AT HANDBACK** on diary + stream note → close stream → `/quit` |
 | Compact count / “compactions remaining” | **Not** an end criterion |
 | First compact | **Not** required before you may end; **not** a reason to delay a clean end |
+
+### Working-set honesty (canary is not full memory)
+
+Promote load-bearing mid-flight facts **before** compact risk (~60–70% context or after each batch):
+
+```bash
+.venv/bin/python -m scripts.session_canary.grok_lane stamp --epic <epic> \
+  --title "pre-compact promote" \
+  --bullet "what just finished" \
+  --next "concrete next action" \
+  --workset "open blocker / phase receipt path / pilot clone path"
+```
+
+Mintable sections: **## Next Drive**, **## Active Working Set**, **## Hands-off**.
+
+After every compact (including when canary still PASSes):
+
+1. Score from memory → auto-hydrate capsule (includes **RE-GROUND CHECKLIST** footer)
+2. Re-read Next Drive + Active Working Set
+3. Open the active phase receipt named there
+4. If open task is missing from dual-write → **STOP inventing** — stamp or hand off
 
 Production **thread rollover** still uses strict **10/10** via `scripts/context_canary.py mint --snapshot` (separate protocol).
 
@@ -35,12 +57,16 @@ The dual-write board under `.claude/<epic>-epic/*-DRIVER-HANDOFF.md` is a **diar
 
 ### Mintable sections (keep short)
 
-Canary mint pulls bullets from headings matching **Next Drive** / **Hands-off** (see `scripts/session_canary/grok_lane.py`). Prefer:
+Canary mint pulls bullets from headings matching **Next Drive** / **Active Working Set** /
+**Hands-off** (see `scripts/session_canary/grok_lane.py`). Prefer:
 
 ```markdown
 ## Next Drive
 1. Concrete next action
 2. Another action
+
+## Active Working Set
+- Load-bearing mid-flight facts (paths, PR numbers, open blockers)
 
 ## Hands-off
 - Foreign lanes

--- a/scripts/session_canary/diary.py
+++ b/scripts/session_canary/diary.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 DIARY_MARKER = "## 📔 Diary — reverse chrono (newest first)"
 NEXT_DRIVE_MARKER = "## Next Drive"
+WORKING_SET_MARKER = "## Active Working Set"
 HANDS_OFF_MARKER = "## Hands-off"
 HANDBACK_MARKER = "## STATE AT HANDBACK"
 
@@ -76,6 +77,11 @@ def ensure_diary_skeleton(text: str, *, epic: str, stream_id: str) -> str:
         NEXT_DRIVE_MARKER,
         "1. (update after each batch — short bullets only; canary mints these)\n",
     )
+    text = _ensure_section(
+        text,
+        WORKING_SET_MARKER,
+        "- (promote load-bearing mid-flight facts here before compact risk)\n",
+    )
     # Accept either "## Hands-off" or "## Hands-off / Out of scope"
     if not re.search(r"^##\s+Hands-off", text, re.MULTILINE | re.IGNORECASE):
         text = text.rstrip() + f"\n\n{HANDS_OFF_MARKER}\n- (lane boundaries)\n"
@@ -102,9 +108,10 @@ def append_diary_stamp(
     title: str,
     bullets: Sequence[str],
     next_drive: Sequence[str] | None = None,
+    working_set: Sequence[str] | None = None,
     stamp: str | None = None,
 ) -> str:
-    """Prepend a diary entry; optionally replace Next Drive bullets. Returns stamp used."""
+    """Prepend a diary entry; optionally replace Next Drive / Active Working Set. Returns stamp used."""
     stamp = stamp or utc_stamp()
     path.parent.mkdir(parents=True, exist_ok=True)
     text = path.read_text(encoding="utf-8", errors="replace") if path.is_file() else ""
@@ -131,36 +138,83 @@ def append_diary_stamp(
 
     if next_drive is not None:
         text = replace_next_drive_bullets(text, next_drive)
+    if working_set is not None:
+        text = replace_working_set_bullets(text, working_set)
 
     path.write_text(text if text.endswith("\n") else text + "\n", encoding="utf-8")
     return stamp
 
 
-def replace_next_drive_bullets(text: str, bullets: Sequence[str]) -> str:
-    """Replace content under ## Next Drive until next ## heading."""
+def _replace_h2_section_bullets(
+    text: str,
+    *,
+    heading_re: str,
+    bullets: Sequence[str],
+    numbered: bool,
+) -> str:
+    """Replace body under a ## heading until the next ## heading."""
     lines = text.splitlines(keepends=True)
     out: list[str] = []
     i = 0
+    matched = False
     while i < len(lines):
         out.append(lines[i])
-        if re.match(r"^##\s+Next Drive\b", lines[i], re.IGNORECASE):
+        if re.match(heading_re, lines[i], re.IGNORECASE):
+            matched = True
             i += 1
-            # skip old body until next ##
             while i < len(lines) and not re.match(r"^##\s+", lines[i]):
                 i += 1
             for n, b in enumerate(bullets, start=1):
                 b = b.strip()
                 if not b:
                     continue
-                # Prefer numbered list for mint friendliness
-                if re.match(r"^\d+\.", b):
-                    out.append(b + "\n")
+                if numbered:
+                    if re.match(r"^\d+\.", b):
+                        out.append(b + "\n")
+                    else:
+                        out.append(f"{n}. {b}\n")
                 else:
-                    out.append(f"{n}. {b}\n")
+                    if re.match(r"^[-*]\s+", b):
+                        out.append(b + "\n")
+                    else:
+                        out.append(f"- {b}\n")
             out.append("\n")
             continue
         i += 1
+    if not matched:
+        # Append section so promotion never silently no-ops on old diaries.
+        label = "Next Drive" if numbered else "Active Working Set"
+        out.append(f"\n## {label}\n")
+        for n, b in enumerate(bullets, start=1):
+            b = b.strip()
+            if not b:
+                continue
+            if numbered:
+                out.append(f"{n}. {b}\n" if not re.match(r"^\d+\.", b) else b + "\n")
+            else:
+                out.append(f"- {b}\n" if not re.match(r"^[-*]\s+", b) else b + "\n")
+        out.append("\n")
     return "".join(out)
+
+
+def replace_next_drive_bullets(text: str, bullets: Sequence[str]) -> str:
+    """Replace content under ## Next Drive until next ## heading."""
+    return _replace_h2_section_bullets(
+        text,
+        heading_re=r"^##\s+Next Drive\b",
+        bullets=bullets,
+        numbered=True,
+    )
+
+
+def replace_working_set_bullets(text: str, bullets: Sequence[str]) -> str:
+    """Replace content under ## Active Working Set until next ## heading."""
+    return _replace_h2_section_bullets(
+        text,
+        heading_re=r"^##\s+Active Working Set\b",
+        bullets=bullets,
+        numbered=False,
+    )
 
 
 def format_canary_score_line(
@@ -384,7 +438,6 @@ def build_hydrate_capsule(
     over budget. Never silently truncates mid-item. Returns (capsule, meta).
     """
     max_tokens = max(200, min(int(max_tokens), 1600))
-    char_ceiling = max_tokens * 4  # 6400 chars at 1600 tok
 
     session = _section_from_heading(
         diary_text,
@@ -443,22 +496,54 @@ def build_hydrate_capsule(
             kept_lines.append(line)
         stream = "\n".join(kept_lines).strip()
 
-    # Priority pack (Sol order): identity → next drive → pins → hands-off → stamps → stream
+    working_set = _section_from_heading(
+        diary_text,
+        r"^##\s+Active Working Set[^\n]*\n|^###\s+Active Working Set[^\n]*\n",
+        [r"^##\s+", r"^###\s+"],
+    )
+
+    # Priority pack: identity → next drive → active working set → pins → hands-off → stamps → stream
+    # Canary PASS only proves anchors; this capsule is not full session memory.
     header = (
         f"# HYDRATE CAPSULE (post-compact)\n"
         f"**Epic / stream:** `{epic}` / `{stream_id}`\n"
         f"**Provenance:** diary dual-write + optional stream tail · "
         f"not a new SSOT · max_tokens={max_tokens}\n"
-        f"**Protocol:** score canary FROM MEMORY first; hydrate once; do not re-mint from chat.\n"
+        f"**Protocol:** score canary FROM MEMORY first; hydrate once; "
+        f"**then RE-GROUND** (see footer) — do not invent from chat.\n"
+        f"**Canary scope:** PASS = durable anchors OK · **not** proof the mid-flight "
+        f"working set survived compact.\n"
     )
     sections: list[tuple[str, str]] = [
         ("identity", identity_block),
         ("next_drive", next_drive),
+        (
+            "working_set",
+            f"## Active Working Set (load-bearing; mintable)\n\n{working_set}"
+            if working_set
+            else "",
+        ),
         ("pins", pins),
         ("hands_off", hands_off),
         ("recent_stamps", f"## Recent diary stamps (newest first)\n\n{stamps}" if stamps else ""),
         ("stream_tail", f"## Stream tail (bounded)\n\n{stream}" if stream else ""),
     ]
+
+    # Mandatory re-ground footer: always pack (never drop) so PASS cannot mean blind continue.
+    reground = (
+        "## RE-GROUND CHECKLIST (mandatory after every compact — canary PASS is not enough)\n\n"
+        "1. **Canary PASS** only proves durable anchors (identity / mintable Next Drive / Hands-off).\n"
+        "2. Re-read **Next Drive** + **Active Working Set** from this capsule (or diary if missing).\n"
+        "3. Open the **active phase receipt** named in Next Drive / Working Set "
+        "(private `docs/entire/...` or stream pin) — do not resume from vibe.\n"
+        "4. If the open task is **not** spelled in Next Drive or Active Working Set: "
+        "**STOP inventing** — stamp dual-write or hand off / re-mint.\n"
+        "5. Anything not dual-written before compact is **allowed to have evaporated**.\n"
+    )
+    # Reserve budget for footer so it is never squeezed out by stamps/stream.
+    reground_tok = approx_tokens(reground)
+    pack_max = max(200, max_tokens - reground_tok)
+    pack_char_ceiling = pack_max * 4
 
     included: list[str] = [header]
     dropped: list[str] = []
@@ -467,7 +552,7 @@ def build_hydrate_capsule(
         if not body:
             continue
         trial = "\n\n".join([*included, body]).strip() + "\n"
-        if approx_tokens(trial) > max_tokens or len(trial) > char_ceiling:
+        if approx_tokens(trial) > pack_max or len(trial) > pack_char_ceiling:
             # never drop identity
             if name == "identity":
                 included.append(body)
@@ -475,6 +560,8 @@ def build_hydrate_capsule(
                 dropped.append(name)
             continue
         included.append(body)
+
+    included.append(reground)
 
     capsule = "\n\n".join(included).strip() + "\n"
     meta: dict[str, object] = {
@@ -486,6 +573,8 @@ def build_hydrate_capsule(
         "dropped_sections": dropped,
         "has_identity": bool(session or handback),
         "has_next_drive": bool(next_drive),
+        "has_working_set": bool(working_set),
+        "has_reground_checklist": True,
         "capsule_sha256": __import__("hashlib").sha256(capsule.encode("utf-8")).hexdigest()[:16],
     }
     if not meta["has_identity"] or not meta["has_next_drive"]:

--- a/scripts/session_canary/diary.py
+++ b/scripts/session_canary/diary.py
@@ -569,10 +569,24 @@ def build_hydrate_capsule(
     included.append(reground)
 
     capsule = "\n\n".join(included).strip() + "\n"
-    # Final bound: if still over (huge identity), keep header + reground only.
+    # Final bound: hard-cap at max_tokens (footer first, then minimal header).
     if approx_tokens(capsule) > max_tokens:
-        capsule = "\n\n".join([header, reground]).strip() + "\n"
-        dropped = list(dict.fromkeys([*dropped, "all_sections_over_budget"]))
+        mini_header = (
+            f"# HYDRATE CAPSULE (post-compact)\n"
+            f"**Epic / stream:** `{epic}` / `{stream_id}`\n"
+            f"**Note:** budget-tight capsule; re-read diary Next Drive + Active Working Set.\n"
+        )
+        mini_reground = (
+            "## RE-GROUND CHECKLIST (mandatory after every compact)\n\n"
+            "1. Canary PASS = anchors only.\n"
+            "2. Re-read Next Drive + Active Working Set from diary.\n"
+            "3. Open active phase receipt; stop inventing if open task missing.\n"
+        )
+        capsule = "\n\n".join([mini_header, mini_reground]).strip() + "\n"
+        # If still over pathological tiny budgets, keep only reground lines that fit.
+        while approx_tokens(capsule) > max_tokens and len(capsule) > 80:
+            capsule = "\n".join(capsule.splitlines()[:-1]).strip() + "\n"
+        dropped = list(dict.fromkeys([*dropped, "budget_tight_minimal_reground"]))
     meta: dict[str, object] = {
         "epic": epic,
         "stream_id": stream_id,

--- a/scripts/session_canary/diary.py
+++ b/scripts/session_canary/diary.py
@@ -541,8 +541,9 @@ def build_hydrate_capsule(
         "5. Anything not dual-written before compact is **allowed to have evaporated**.\n"
     )
     # Reserve budget for footer so it is never squeezed out by stamps/stream.
+    # Do not re-floor pack_max to 200: that can push final capsule over max_tokens.
     reground_tok = approx_tokens(reground)
-    pack_max = max(200, max_tokens - reground_tok)
+    pack_max = max(0, int(max_tokens) - reground_tok)
     pack_char_ceiling = pack_max * 4
 
     included: list[str] = [header]
@@ -553,9 +554,13 @@ def build_hydrate_capsule(
             continue
         trial = "\n\n".join([*included, body]).strip() + "\n"
         if approx_tokens(trial) > pack_max or len(trial) > pack_char_ceiling:
-            # never drop identity
+            # Prefer keeping identity even if pack_max is tight; may still fit with footer.
             if name == "identity":
-                included.append(body)
+                with_id = "\n\n".join([*included, body, reground]).strip() + "\n"
+                if approx_tokens(with_id) <= max_tokens:
+                    included.append(body)
+                else:
+                    dropped.append("identity_truncated")
             else:
                 dropped.append(name)
             continue
@@ -564,6 +569,10 @@ def build_hydrate_capsule(
     included.append(reground)
 
     capsule = "\n\n".join(included).strip() + "\n"
+    # Final bound: if still over (huge identity), keep header + reground only.
+    if approx_tokens(capsule) > max_tokens:
+        capsule = "\n\n".join([header, reground]).strip() + "\n"
+        dropped = list(dict.fromkeys([*dropped, "all_sections_over_budget"]))
     meta: dict[str, object] = {
         "epic": epic,
         "stream_id": stream_id,

--- a/scripts/session_canary/grok_lane.py
+++ b/scripts/session_canary/grok_lane.py
@@ -228,6 +228,18 @@ def _build_facts(
             bullet,
         )
 
+    # Active Working Set — load-bearing mid-flight facts promoted before compact.
+    working_set = _extract_handoff_bullets(
+        handoff_text,
+        heading_substrings=("active working set", "working set"),
+    )
+    for i, bullet in enumerate(working_set[:2], start=1):
+        add(
+            f"workset-{i}",
+            f"According to the dual-write handoff, what is active working-set fact #{i}?",
+            bullet,
+        )
+
     hands_off = _extract_handoff_bullets(
         handoff_text,
         heading_substrings=("hands-off", "handsoff", "do not", "out of scope"),
@@ -515,8 +527,8 @@ def cmd_score(args: argparse.Namespace) -> int:
                 title="canary score PASS",
                 bullets=[
                     canary_line,
-                    "Continue drive; dual-write after next batch.",
-                    "Auto-hydrate runs after PASS (operator need not invoke hydrate).",
+                    "PASS = anchors only — not full working memory.",
+                    "Auto-hydrate + RE-GROUND checklist printed; dual-write after next batch.",
                 ],
             )
             print(f"diary stamp -> {handoff_path}")
@@ -526,7 +538,7 @@ def cmd_score(args: argparse.Namespace) -> int:
                 idempotency_key=f"canary-pass-{_utc_now()}",
             )
             # Sol Option D: score first (done), then hydrate once automatically.
-            # Operator never has to remember hydrate / restart for diary load.
+            # After hydrate: RE-GROUND (Next Drive / Active Working Set / phase receipt).
             if not getattr(args, "no_hydrate", False):
                 try:
                     emit_hydrate_capsule(
@@ -542,6 +554,15 @@ def cmd_score(args: argparse.Namespace) -> int:
                             "=== AUTO-HYDRATE (post canary PASS) — restore board from diary; "
                             "do not ask the operator to restart or re-load diary ==="
                         ),
+                    )
+                    print(
+                        "\n=== POST-COMPACT RE-GROUND (mandatory) ===\n"
+                        "Canary PASS ≠ full memory. From the capsule above:\n"
+                        "  1) Re-read Next Drive + Active Working Set\n"
+                        "  2) Open the active phase receipt named there\n"
+                        "  3) If open task is missing from dual-write: STOP inventing — stamp or hand off\n"
+                        "  4) Anything not dual-written before compact may have evaporated\n"
+                        "=== END RE-GROUND ===\n"
                     )
                 except Exception as hexc:  # fail-open: score already succeeded
                     print(
@@ -706,10 +727,14 @@ After every real batch (merge, issue close, dispatch start, advisor note, block)
   --next "next action 1" --next "next action 2"
 ```
 Keep **## Next Drive** as short numbered bullets (canary mints these). No secrets/PII.
+Keep **## Active Working Set** for load-bearing mid-flight facts (also mintable).
+**Promote before compact risk** (~60–70% context or before a big batch): if it is not in
+Next Drive / Active Working Set / a stamp, it is allowed to evaporate on compact.
 
 ### End signal = canary score, NOT compact count
 - Auto-compact is lossy for working memory. Disk logs ≠ model brain.
 - **First auto-compact ⇒ re-score**, do not auto-quit solely because compact fired.
+- **Canary PASS = durable anchors only** — not proof the mid-flight working set survived.
 - **FAIL-HANDOFF (&lt; 8/10 at pass-ratio 0.8) ⇒ end now** regardless of token %.
 
 ### Cold-start (order is load-bearing)
@@ -736,8 +761,12 @@ You own compact recovery. **Never ask the operator** whether to restart, hydrate
   --answers .claude/{epic}-epic/canary/answers.json --context-tokens <N>
 ```
 2. If FAIL-HANDOFF → handback is already written → close stream + `/quit` (new session via launcher).
-3. If PASS → **auto-hydrate is already printed** by `score` (bounded capsule + stream tail). Read it; resume from Next Drive / pins. Do **not** load the full diary.
-4. Only use standalone `hydrate` if you need a re-print; default path is score→auto-hydrate.
+3. If PASS → **auto-hydrate is already printed** by `score` (bounded capsule + stream tail + **RE-GROUND checklist**).
+4. **RE-GROUND (mandatory after every compact, even on PASS):**
+   - Re-read Next Drive + Active Working Set from the capsule
+   - Open the active phase receipt named there (do not resume from vibe)
+   - If the open task is not spelled in dual-write: **STOP inventing** — stamp or hand off
+5. Only use standalone `hydrate` if you need a re-print; default path is score→auto-hydrate→re-ground.
 
 ### Score procedure (from memory — no re-read of probe answers)
 1. `.venv/bin/python -m scripts.session_canary.grok_lane questions --epic {epic}`
@@ -789,11 +818,13 @@ def cmd_stamp(args: argparse.Namespace) -> int:
         print("error: provide --bullet at least once (or a meaningful --title)", file=sys.stderr)
         return 2
     next_drive = list(args.next) if args.next else None
+    working_set = list(args.workset) if getattr(args, "workset", None) else None
     stamp = diary_mod.append_diary_stamp(
         path,
         title=args.title or "batch",
         bullets=bullets,
         next_drive=next_drive,
+        working_set=working_set,
     )
     print(f"diary stamp {stamp} -> {path}")
     note = f"DIARY {stamp}: {args.title or 'batch'}; " + "; ".join(bullets[:5])
@@ -907,6 +938,12 @@ def build_parser() -> argparse.ArgumentParser:
     stamp.add_argument("--title", default="batch", help="Diary entry title")
     stamp.add_argument("--bullet", action="append", default=[], help="Diary bullet (repeatable)")
     stamp.add_argument("--next", action="append", default=[], help="Replace Next Drive bullets (repeatable)")
+    stamp.add_argument(
+        "--workset",
+        action="append",
+        default=[],
+        help="Replace Active Working Set bullets (repeatable; promote before compact)",
+    )
     stamp.set_defaults(func=cmd_stamp)
 
 

--- a/scripts/session_canary/grok_lane.py
+++ b/scripts/session_canary/grok_lane.py
@@ -207,16 +207,8 @@ def _build_facts(
             entry["body"],
         )
 
-    # 4) Next actions from stream (prefer typed next_action)
-    nexts = [e for e in stream_entries if e["type"] == "next_action"]
-    for i, entry in enumerate(nexts[:3], start=1):
-        add(
-            f"next-stream-{i}",
-            f"What next-action entry #{i} was recorded on the stream?",
-            entry["body"],
-        )
-
-    # 5) Handoff dual-write: next drive / in-flight / hands-off
+    # 4) Handoff dual-write first (survives compact only if written): Next Drive + Working Set
+    # before lower-priority stream next_action spam so workset is not truncated out of 10.
     next_bullets = _extract_handoff_bullets(
         handoff_text,
         heading_substrings=("next drive", "next after", "next action", "in flight", "live session"),
@@ -228,7 +220,6 @@ def _build_facts(
             bullet,
         )
 
-    # Active Working Set — load-bearing mid-flight facts promoted before compact.
     working_set = _extract_handoff_bullets(
         handoff_text,
         heading_substrings=("active working set", "working set"),
@@ -249,6 +240,17 @@ def _build_facts(
             f"handsoff-{i}",
             f"According to the dual-write handoff, what is hands-off rule #{i}?",
             bullet,
+        )
+
+    # 5) Stream next_action only after diary mintables (fill remaining slots)
+    nexts = [e for e in stream_entries if e["type"] == "next_action"]
+    for i, entry in enumerate(nexts[:3], start=1):
+        if len(facts) >= N_ANCHORS:
+            break
+        add(
+            f"next-stream-{i}",
+            f"What next-action entry #{i} was recorded on the stream?",
+            entry["body"],
         )
 
     # 6) Recent durable decisions from stream if still short

--- a/scripts/session_canary/grok_lane.py
+++ b/scripts/session_canary/grok_lane.py
@@ -168,16 +168,27 @@ def _build_facts(
     facts: list[dict[str, str]] = []
     used_answers: set[str] = set()
 
-    def add(fid: str, q: str, a: str) -> None:
+    # Pre-extract working set so we can reserve probe slots (CF F001 on #5716).
+    working_set = _extract_handoff_bullets(
+        handoff_text,
+        heading_substrings=("active working set", "working set"),
+    )
+    workset_reserve = min(2, len(working_set))
+
+    def add(fid: str, q: str, a: str, *, reserve: int = 0) -> bool:
+        """Add a fact if unique. Respect optional slot reservation for later workset."""
+        if len(facts) >= N_ANCHORS - max(0, reserve):
+            return False
         a_norm = _clip(a, 280)
         if not a_norm or a_norm in used_answers:
-            return
+            return False
         if any(f["id"] == fid for f in facts):
-            return
+            return False
         used_answers.add(a_norm)
         facts.append({"id": fid, "q": q, "a": a_norm})
+        return True
 
-    # 1) Session identity (always)
+    # 1) Session identity (always; never reserved against)
     add(
         "lane-stream",
         "What session stream id is this Grok lane driving?",
@@ -189,46 +200,49 @@ def _build_facts(
         epic,
     )
 
-    # 2) Pinned binding orders from stream
+    # 2) Pinned binding orders from stream (leave room for workset when present)
     pinned_orders = [e for e in stream_entries if e["type"] == "binding_order"]
     for i, entry in enumerate(pinned_orders[:4], start=1):
-        add(
+        if not add(
             f"bind-{i}",
             f"What is binding order #{i} for this lane (plain paraphrase of the frozen stream pin)?",
             entry["body"],
-        )
+            reserve=workset_reserve,
+        ):
+            break
 
     # 3) Negative constraints from stream
     negs = [e for e in stream_entries if e["type"] == "negative_constraint"]
     for i, entry in enumerate(negs[:2], start=1):
-        add(
+        if not add(
             f"neg-{i}",
             f"What is negative constraint #{i} pinned on this stream?",
             entry["body"],
-        )
+            reserve=workset_reserve,
+        ):
+            break
 
-    # 4) Handoff dual-write first (survives compact only if written): Next Drive + Working Set
-    # before lower-priority stream next_action spam so workset is not truncated out of 10.
+    # 4) Handoff dual-write: Next Drive (reserve workset slots after these)
     next_bullets = _extract_handoff_bullets(
         handoff_text,
         heading_substrings=("next drive", "next after", "next action", "in flight", "live session"),
     )
     for i, bullet in enumerate(next_bullets[:3], start=1):
-        add(
+        if not add(
             f"next-handoff-{i}",
             f"According to the dual-write handoff ({handoff_rel}), what is next-item #{i}?",
             bullet,
-        )
+            reserve=workset_reserve,
+        ):
+            break
 
-    working_set = _extract_handoff_bullets(
-        handoff_text,
-        heading_substrings=("active working set", "working set"),
-    )
+    # 4b) Active Working Set — reserved slots (load-bearing mid-flight facts)
     for i, bullet in enumerate(working_set[:2], start=1):
         add(
             f"workset-{i}",
             f"According to the dual-write handoff, what is active working-set fact #{i}?",
             bullet,
+            reserve=0,
         )
 
     hands_off = _extract_handoff_bullets(
@@ -236,44 +250,43 @@ def _build_facts(
         heading_substrings=("hands-off", "handsoff", "do not", "out of scope"),
     )
     for i, bullet in enumerate(hands_off[:2], start=1):
-        add(
+        if not add(
             f"handsoff-{i}",
             f"According to the dual-write handoff, what is hands-off rule #{i}?",
             bullet,
-        )
+            reserve=0,
+        ):
+            break
 
-    # 5) Stream next_action only after diary mintables (fill remaining slots)
+    # 5) Stream next_action fill remaining slots
     nexts = [e for e in stream_entries if e["type"] == "next_action"]
     for i, entry in enumerate(nexts[:3], start=1):
-        if len(facts) >= N_ANCHORS:
-            break
-        add(
+        if not add(
             f"next-stream-{i}",
             f"What next-action entry #{i} was recorded on the stream?",
             entry["body"],
-        )
+        ):
+            break
 
     # 6) Recent durable decisions from stream if still short
     decisions = [e for e in stream_entries if e["type"] == "decision"]
     for i, entry in enumerate(decisions[:3], start=1):
-        if len(facts) >= N_ANCHORS:
-            break
-        add(
+        if not add(
             f"decision-{i}",
             f"What decision #{i} was recorded on the stream?",
             entry["body"],
-        )
+        ):
+            break
 
     # 7) Recent state if still short (still dual-written stream entries — durable)
     states = [e for e in stream_entries if e["type"] == "state"]
     for i, entry in enumerate(reversed(states[-6:]), start=1):
-        if len(facts) >= N_ANCHORS:
-            break
-        add(
+        if not add(
             f"state-{i}",
             f"What recent state note #{i} is on the stream (paraphrase the frozen text)?",
             entry["body"],
-        )
+        ):
+            break
 
     if len(facts) < N_ANCHORS:
         raise SystemExit(

--- a/tests/test_session_canary_hydrate.py
+++ b/tests/test_session_canary_hydrate.py
@@ -63,10 +63,26 @@ def test_hydrate_capsule_bounded_and_includes_next_drive() -> None:
     assert "HYDRATE CAPSULE" in capsule
     assert "Next drive" in capsule or "next drive" in capsule.lower()
     assert "Standing pins" in capsule or "Layout A" in capsule
+    assert "RE-GROUND CHECKLIST" in capsule
+    assert meta["has_reground_checklist"] is True
     assert meta["approx_tokens"] <= 1600
     assert meta["has_identity"] is True
     assert meta["has_next_drive"] is True
     assert approx_tokens(capsule) == meta["approx_tokens"]
+
+
+def test_hydrate_includes_active_working_set_when_present() -> None:
+    diary = _diary() + "\n## Active Working Set\n- pilot clone at /tmp/x\n- PR #274 merged\n"
+    capsule, meta = build_hydrate_capsule(
+        diary,
+        epic="harness",
+        stream_id="epic:4707",
+        max_tokens=1400,
+    )
+    assert "Active Working Set" in capsule
+    assert "pilot clone" in capsule
+    assert meta["has_working_set"] is True
+    assert "RE-GROUND CHECKLIST" in capsule
 
 
 def test_hydrate_drops_low_priority_whole_sections_under_tiny_budget() -> None:
@@ -173,6 +189,8 @@ def test_score_auto_hydrates_on_pass(tmp_path: Path, monkeypatch, capsys) -> Non
     out = capsys.readouterr().out
     assert "AUTO-HYDRATE" in out
     assert "HYDRATE CAPSULE" in out
+    assert "POST-COMPACT RE-GROUND" in out
+    assert "RE-GROUND CHECKLIST" in out
 
 
 def test_score_no_hydrate_flag_skips(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_session_canary_hydrate.py
+++ b/tests/test_session_canary_hydrate.py
@@ -239,3 +239,40 @@ def test_score_no_hydrate_flag_skips(tmp_path: Path, monkeypatch, capsys) -> Non
     assert rc == 0
     out = capsys.readouterr().out
     assert "AUTO-HYDRATE" not in out
+
+
+def test_mint_reserves_working_set_under_saturated_stream_pins() -> None:
+    """When stream pins fill the budget, diary Active Working Set still mints."""
+    from scripts.session_canary.grok_lane import _build_facts
+
+    stream_entries = []
+    for i in range(4):
+        stream_entries.append({"type": "binding_order", "body": f"binding order pin number {i} unique"})
+    for i in range(2):
+        stream_entries.append({"type": "negative_constraint", "body": f"negative constraint pin {i} unique"})
+    for i in range(3):
+        stream_entries.append({"type": "next_action", "body": f"stream next action {i} unique"})
+
+    handoff = """# diary
+## Next Drive
+1. first next action unique
+2. second next action unique
+3. third next action unique
+
+## Active Working Set
+- pilot clone path must survive compact unique-ws-1
+- deny guard installed unique-ws-2
+
+## Hands-off
+- foreign lanes unique-ho
+"""
+    facts = _build_facts(
+        epic="devops",
+        stream_id="epic:5703",
+        stream_entries=stream_entries,
+        handoff_text=handoff,
+        handoff_rel=".claude/devops-epic/CLAUDE-DRIVER-HANDOFF.md",
+    )
+    ids = [f["id"] for f in facts]
+    assert len(facts) == 10
+    assert any(i.startswith("workset-") for i in ids), ids


### PR DESCRIPTION
## Summary

Implements working-set honesty for Grok compact recovery:

- **Canary PASS** = durable anchors only (not full mid-flight memory)
- Auto-hydrate always includes a **RE-GROUND CHECKLIST** footer
- New mintable **## Active Working Set** section
- `stamp --workset` promotes load-bearing facts **before** compact
- Protocol/runbook updated: score → hydrate → re-ground after every compact

## Why

Without dual-writing mid-flight state, hydrate can keep canary green while useful context evaporated. Agents must promote working set before compact risk, then re-ground after PASS.

## Test plan

- [x] `tests/test_session_canary_hydrate.py` (6 passed)
- [x] ruff on changed files

## Pre-merge operator note

After merge, devops diary should be stamped with current Entire Phase 1 working set so the *next* compact has real anchors (can stamp on primary gitignored diary immediately without this PR for content; mint benefits from code merge).