### PR TITLE
feat(hramatka): add gemini 3.6 flash qualified routing and bounded failover (#4542)

### DIFF
--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -7,11 +7,22 @@ this public module makes the routing policy deterministic and testable.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from enum import StrEnum
 from typing import Any, Protocol
 from urllib.error import HTTPError, URLError
+
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):  # noqa: UP042
+        """Fallback StrEnum implementation for Python 3.10 support."""
+
+        def __str__(self) -> str:
+            return str(self.value)
 
 from scripts.audit.hramatka_qg_rules import DIMENSION_ORDER, scan_hramatka_lesson
 

--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -138,6 +138,7 @@ def passes_all_hramatka_qg_rules(evidence: Mapping[str, Any]) -> bool:
     return True
 
 
+_CANONICAL_CEFR_LEVELS: set[str] = {"a1", "a2", "b1", "b2", "c1", "c2"}
 _LEVEL_ALIASES: dict[str, str] = {
     "beginner": "a1",
     "elementary": "a2",
@@ -148,11 +149,14 @@ _LEVEL_ALIASES: dict[str, str] = {
 }
 
 
-def normalize_hramatka_level(level: Any) -> str:
+def normalize_hramatka_level(level: Any) -> str | None:
     """Normalize CEFR level strings and common aliases into canonical CEFR codes."""
 
-    val = str(level or "b1").strip().lower()
-    return _LEVEL_ALIASES.get(val, val)
+    if level is None or level == "":
+        return "b1"
+    val = str(level).strip().lower()
+    resolved = _LEVEL_ALIASES.get(val, val)
+    return resolved if resolved in _CANONICAL_CEFR_LEVELS else None
 
 
 def generate_qualified_lesson(
@@ -203,14 +207,15 @@ def generate_qualified_lesson(
                 for block in blocks
             )
         )
-        if not isinstance(lesson, Mapping) or not valid_blocks:
+        normalized_level = normalize_hramatka_level(lesson.get("level") if isinstance(lesson, Mapping) else None)
+        if not isinstance(lesson, Mapping) or not valid_blocks or normalized_level is None:
             attempts.append(
                 GenerationAttempt(number=number, model=model, outcome="invalid_provider_payload")
             )
             return _failed(attempts, "invalid_provider_payload")
 
         normalized_lesson = dict(lesson)
-        normalized_lesson["level"] = normalize_hramatka_level(lesson.get("level"))
+        normalized_lesson["level"] = normalized_level
 
         try:
             evidence = qg_scan(normalized_lesson)

--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -175,7 +175,17 @@ def generate_qualified_lesson(
             return _failed(attempts, f"provider_{'retry_budget_exhausted' if transient else 'failure'}")
 
         blocks = lesson.get("blocks") if isinstance(lesson, Mapping) else None
-        if not isinstance(lesson, Mapping) or not isinstance(blocks, list) or not blocks:
+        valid_blocks = (
+            isinstance(blocks, list)
+            and len(blocks) > 0
+            and all(
+                isinstance(block, Mapping)
+                and isinstance(block.get("type"), str)
+                and bool(block.get("type").strip())
+                for block in blocks
+            )
+        )
+        if not isinstance(lesson, Mapping) or not valid_blocks:
             attempts.append(
                 GenerationAttempt(number=number, model=model, outcome="invalid_provider_payload")
             )

--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Protocol
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 from scripts.audit.hramatka_qg_rules import DIMENSION_ORDER, scan_hramatka_lesson
 
@@ -88,6 +88,9 @@ def is_transient_provider_failure(error: BaseException) -> bool:
     retryable. Authentication, validation, rate-limit, and provider 4xx errors
     deliberately fail closed rather than consuming the retry budget.
     """
+
+    if isinstance(error, HTTPError):
+        return 500 <= error.code <= 599
 
     if isinstance(error, (ConnectionError, TimeoutError, URLError)):
         return True

--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -243,7 +243,7 @@ def generate_qualified_lesson(
         attempts.append(GenerationAttempt(number=number, model=model, outcome="ready"))
         return GenerationResult(
             state=GenerationState.READY,
-            lesson=lesson,
+            lesson=normalized_lesson,
             qg_evidence=evidence,
             attempts=tuple(attempts),
         )

--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -174,7 +174,8 @@ def generate_qualified_lesson(
                 continue
             return _failed(attempts, f"provider_{'retry_budget_exhausted' if transient else 'failure'}")
 
-        if not isinstance(lesson, Mapping):
+        blocks = lesson.get("blocks") if isinstance(lesson, Mapping) else None
+        if not isinstance(lesson, Mapping) or not isinstance(blocks, list) or not blocks:
             attempts.append(
                 GenerationAttempt(number=number, model=model, outcome="invalid_provider_payload")
             )

--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -7,7 +7,6 @@ this public module makes the routing policy deterministic and testable.
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol

--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -138,6 +138,23 @@ def passes_all_hramatka_qg_rules(evidence: Mapping[str, Any]) -> bool:
     return True
 
 
+_LEVEL_ALIASES: dict[str, str] = {
+    "beginner": "a1",
+    "elementary": "a2",
+    "intermediate": "b1",
+    "upper-intermediate": "b2",
+    "advanced": "c1",
+    "mastery": "c2",
+}
+
+
+def normalize_hramatka_level(level: Any) -> str:
+    """Normalize CEFR level strings and common aliases into canonical CEFR codes."""
+
+    val = str(level or "b1").strip().lower()
+    return _LEVEL_ALIASES.get(val, val)
+
+
 def generate_qualified_lesson(
     request: Mapping[str, Any],
     *,
@@ -192,8 +209,11 @@ def generate_qualified_lesson(
             )
             return _failed(attempts, "invalid_provider_payload")
 
+        normalized_lesson = dict(lesson)
+        normalized_lesson["level"] = normalize_hramatka_level(lesson.get("level"))
+
         try:
-            evidence = qg_scan(lesson)
+            evidence = qg_scan(normalized_lesson)
         except Exception as error:
             attempts.append(
                 GenerationAttempt(

--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -1,0 +1,211 @@
+"""Qualified Gemini routing for Hramatka lesson generation.
+
+The private Hramatka service supplies an AGY/provider API client through
+``AGYProviderTransport``.  Keeping credentials and process management outside
+this public module makes the routing policy deterministic and testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+from urllib.error import URLError
+
+from scripts.audit.hramatka_qg_rules import DIMENSION_ORDER, scan_hramatka_lesson
+
+PRIMARY_MODEL = "gemini-3.6-flash-high"
+SECONDARY_MODEL = "gemini-3.1-pro-high"
+MAX_PROVIDER_ATTEMPTS = 4
+_PERFECT_QG_SCORE = 10.0
+
+
+class GenerationState(StrEnum):
+    """Terminal lifecycle states emitted by this router."""
+
+    READY = "ready"
+    FAILED = "failed"
+
+
+class ProviderHTTPError(RuntimeError):
+    """Provider HTTP failure with a status code available to routing policy."""
+
+    def __init__(self, status_code: int, message: str = "provider HTTP failure") -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class ProviderTransport(Protocol):
+    """Minimal provider API surface required by qualified routing."""
+
+    def generate(self, *, model: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Generate a Hramatka lesson JSON document with ``model``."""
+
+
+@dataclass(frozen=True, slots=True)
+class AGYProviderTransport:
+    """Adapter for the AGY/provider API client owned by the service layer.
+
+    The client is intentionally injected: this repository does not contain
+    provider credentials or the private Hramatka service's request plumbing.
+    """
+
+    client: Callable[[str, Mapping[str, Any]], Mapping[str, Any]]
+
+    def generate(self, *, model: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self.client(model, request)
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationAttempt:
+    """A redacted record of one provider call."""
+
+    number: int
+    model: str
+    outcome: str
+    error_kind: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationResult:
+    """Qualified generation output; only ``READY`` results contain a lesson."""
+
+    state: GenerationState
+    lesson: Mapping[str, Any] | None
+    qg_evidence: Mapping[str, Any] | None
+    attempts: tuple[GenerationAttempt, ...]
+    failure_reason: str | None = None
+
+
+QualityGate = Callable[[Mapping[str, Any]], Mapping[str, Any]]
+
+
+def is_transient_provider_failure(error: BaseException) -> bool:
+    """Return whether an error permits one of the bounded retry attempts.
+
+    Only provider network failures, timeouts, and HTTP 5xx responses are
+    retryable. Authentication, validation, rate-limit, and provider 4xx errors
+    deliberately fail closed rather than consuming the retry budget.
+    """
+
+    if isinstance(error, (ConnectionError, TimeoutError, URLError)):
+        return True
+
+    status_code = getattr(error, "status_code", None)
+    if not isinstance(status_code, int):
+        response = getattr(error, "response", None)
+        status_code = getattr(response, "status_code", None)
+    return isinstance(status_code, int) and 500 <= status_code <= 599
+
+
+def passes_all_hramatka_qg_rules(evidence: Mapping[str, Any]) -> bool:
+    """Require a complete, perfect deterministic Hramatka QG result.
+
+    ``terminal_verdict == PASS`` alone is insufficient because the QG scanner
+    can return warnings or report an unavailable detector.  A lesson reaches
+    ``ready`` only when every declared dimension is present and fully passes.
+    """
+
+    if evidence.get("verdict") != "PASS" or evidence.get("terminal_verdict") != "PASS":
+        return False
+    if evidence.get("detector_status"):
+        return False
+
+    dimensions = evidence.get("dimensions")
+    if not isinstance(dimensions, Mapping):
+        return False
+    for dimension in DIMENSION_ORDER:
+        result = dimensions.get(dimension)
+        if not isinstance(result, Mapping):
+            return False
+        if result.get("verdict") != "PASS" or result.get("score") != _PERFECT_QG_SCORE:
+            return False
+    return True
+
+
+def generate_qualified_lesson(
+    request: Mapping[str, Any],
+    *,
+    transport: ProviderTransport,
+    qg_scan: QualityGate = scan_hramatka_lesson,
+    primary_model: str = PRIMARY_MODEL,
+    secondary_model: str = SECONDARY_MODEL,
+) -> GenerationResult:
+    """Generate once-qualified lesson content with bounded provider failover.
+
+    A route cycle makes one primary call followed by one secondary call only
+    after a transient primary failure.  At most two cycles are allowed, which
+    gives the fixed four-call budget: primary, secondary, primary, secondary.
+    Content rejected by QG is never retried as a transport failure.
+    """
+
+    attempts: list[GenerationAttempt] = []
+    models = (primary_model, secondary_model)
+
+    for number in range(1, MAX_PROVIDER_ATTEMPTS + 1):
+        model = models[(number - 1) % len(models)]
+        try:
+            lesson = transport.generate(model=model, request=request)
+        except Exception as error:
+            transient = is_transient_provider_failure(error)
+            attempts.append(
+                GenerationAttempt(
+                    number=number,
+                    model=model,
+                    outcome="transient_failure" if transient else "provider_failure",
+                    error_kind=type(error).__name__,
+                )
+            )
+            if transient and number < MAX_PROVIDER_ATTEMPTS:
+                continue
+            return _failed(attempts, f"provider_{'retry_budget_exhausted' if transient else 'failure'}")
+
+        if not isinstance(lesson, Mapping):
+            attempts.append(
+                GenerationAttempt(number=number, model=model, outcome="invalid_provider_payload")
+            )
+            return _failed(attempts, "invalid_provider_payload")
+
+        try:
+            evidence = qg_scan(lesson)
+        except Exception as error:
+            attempts.append(
+                GenerationAttempt(
+                    number=number,
+                    model=model,
+                    outcome="qg_unavailable",
+                    error_kind=type(error).__name__,
+                )
+            )
+            return _failed(attempts, "qg_unavailable")
+
+        if not passes_all_hramatka_qg_rules(evidence):
+            attempts.append(GenerationAttempt(number=number, model=model, outcome="qg_rejected"))
+            return GenerationResult(
+                state=GenerationState.FAILED,
+                lesson=None,
+                qg_evidence=evidence,
+                attempts=tuple(attempts),
+                failure_reason="qg_rejected",
+            )
+
+        attempts.append(GenerationAttempt(number=number, model=model, outcome="ready"))
+        return GenerationResult(
+            state=GenerationState.READY,
+            lesson=lesson,
+            qg_evidence=evidence,
+            attempts=tuple(attempts),
+        )
+
+    raise AssertionError("provider retry loop exceeded its bounded attempt budget")
+
+
+def _failed(attempts: list[GenerationAttempt], reason: str) -> GenerationResult:
+    return GenerationResult(
+        state=GenerationState.FAILED,
+        lesson=None,
+        qg_evidence=None,
+        attempts=tuple(attempts),
+        failure_reason=reason,
+    )

--- a/scripts/api/hramatka_generator.py
+++ b/scripts/api/hramatka_generator.py
@@ -122,7 +122,8 @@ def passes_all_hramatka_qg_rules(evidence: Mapping[str, Any]) -> bool:
 
     if evidence.get("verdict") != "PASS" or evidence.get("terminal_verdict") != "PASS":
         return False
-    if evidence.get("detector_status"):
+    detector_status = evidence.get("detector_status")
+    if not isinstance(detector_status, Mapping) or len(detector_status) != 0:
         return False
 
     dimensions = evidence.get("dimensions")

--- a/tests/api/test_hramatka_generator.py
+++ b/tests/api/test_hramatka_generator.py
@@ -14,6 +14,7 @@ from scripts.api.hramatka_generator import (
     ProviderHTTPError,
     generate_qualified_lesson,
     is_transient_provider_failure,
+    normalize_hramatka_level,
 )
 from scripts.audit.hramatka_qg_rules import DIMENSION_ORDER
 
@@ -58,7 +59,7 @@ def test_primary_route_success_uses_gemini_36_flash_and_marks_ready() -> None:
     assert result.lesson == lesson
     assert result.failure_reason is None
     assert transport.models == [PRIMARY_MODEL]
-    assert qg_calls == [lesson]
+    assert qg_calls == [{"title": "Чистий урок", "blocks": [{"id": "b1", "type": "intro"}], "level": "b1"}]
     assert [attempt.outcome for attempt in result.attempts] == ["ready"]
 
 
@@ -180,4 +181,13 @@ def test_urllib_http_error_handling_differentiates_4xx_and_5xx() -> None:
 
     assert is_transient_provider_failure(error_401) is False
     assert is_transient_provider_failure(error_502) is True
+
+
+def test_normalize_hramatka_level_handles_aliases_and_missing_levels() -> None:
+    assert normalize_hramatka_level("Intermediate") == "b1"
+    assert normalize_hramatka_level("Beginner") == "a1"
+    assert normalize_hramatka_level(None) == "b1"
+    assert normalize_hramatka_level("") == "b1"
+    assert normalize_hramatka_level("A2") == "a2"
+
 

--- a/tests/api/test_hramatka_generator.py
+++ b/tests/api/test_hramatka_generator.py
@@ -1,0 +1,111 @@
+"""Tests for bounded, quality-qualified Hramatka generation routing."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from scripts.api.hramatka_generator import (
+    MAX_PROVIDER_ATTEMPTS,
+    PRIMARY_MODEL,
+    SECONDARY_MODEL,
+    GenerationState,
+    ProviderHTTPError,
+    generate_qualified_lesson,
+)
+from scripts.audit.hramatka_qg_rules import DIMENSION_ORDER
+
+
+def _passing_evidence() -> dict[str, Any]:
+    return {
+        "verdict": "PASS",
+        "terminal_verdict": "PASS",
+        "detector_status": {},
+        "dimensions": {
+            dimension: {"verdict": "PASS", "score": 10.0} for dimension in DIMENSION_ORDER
+        },
+    }
+
+
+class RecordingTransport:
+    def __init__(self, outcomes: list[object]) -> None:
+        self.outcomes = iter(outcomes)
+        self.models: list[str] = []
+
+    def generate(self, *, model: str, request: Mapping[str, Any]) -> Mapping[str, Any]:
+        self.models.append(model)
+        outcome = next(self.outcomes)
+        if isinstance(outcome, Exception):
+            raise outcome
+        assert isinstance(outcome, Mapping)
+        return outcome
+
+
+def test_primary_route_success_uses_gemini_36_flash_and_marks_ready() -> None:
+    lesson = {"title": "Чистий урок", "blocks": []}
+    transport = RecordingTransport([lesson])
+    qg_calls: list[Mapping[str, Any]] = []
+
+    def qg_scan(candidate: Mapping[str, Any]) -> Mapping[str, Any]:
+        qg_calls.append(candidate)
+        return _passing_evidence()
+
+    result = generate_qualified_lesson({"prompt": "Створіть урок"}, transport=transport, qg_scan=qg_scan)
+
+    assert result.state is GenerationState.READY
+    assert result.lesson == lesson
+    assert result.failure_reason is None
+    assert transport.models == [PRIMARY_MODEL]
+    assert qg_calls == [lesson]
+    assert [attempt.outcome for attempt in result.attempts] == ["ready"]
+
+
+def test_5xx_primary_failure_uses_secondary_route_once() -> None:
+    lesson = {"title": "Резервний урок", "blocks": []}
+    transport = RecordingTransport([ProviderHTTPError(503), lesson])
+
+    result = generate_qualified_lesson(
+        {"prompt": "Створіть урок"},
+        transport=transport,
+        qg_scan=lambda _lesson: _passing_evidence(),
+    )
+
+    assert result.state is GenerationState.READY
+    assert transport.models == [PRIMARY_MODEL, SECONDARY_MODEL]
+    assert [attempt.outcome for attempt in result.attempts] == ["transient_failure", "ready"]
+
+
+def test_timeout_retries_never_exceed_four_provider_calls() -> None:
+    transport = RecordingTransport([TimeoutError("provider timeout")] * MAX_PROVIDER_ATTEMPTS)
+
+    result = generate_qualified_lesson(
+        {"prompt": "Створіть урок"},
+        transport=transport,
+        qg_scan=lambda _lesson: _passing_evidence(),
+    )
+
+    assert result.state is GenerationState.FAILED
+    assert result.failure_reason == "provider_retry_budget_exhausted"
+    assert len(result.attempts) == MAX_PROVIDER_ATTEMPTS
+    assert transport.models == [PRIMARY_MODEL, SECONDARY_MODEL, PRIMARY_MODEL, SECONDARY_MODEL]
+
+
+def test_qg_warning_cannot_transition_generated_lesson_to_ready() -> None:
+    lesson = {"title": "Урок із попередженням", "blocks": []}
+    transport = RecordingTransport([lesson])
+    evidence = _passing_evidence()
+    evidence["dimensions"][DIMENSION_ORDER[0]] = {"verdict": "WARN", "score": 9.2}
+    evidence["verdict"] = "WARN"
+
+    result = generate_qualified_lesson(
+        {"prompt": "Створіть урок"},
+        transport=transport,
+        qg_scan=lambda _lesson: evidence,
+    )
+
+    assert result.state is GenerationState.FAILED
+    assert result.lesson is None
+    assert result.qg_evidence == evidence
+    assert result.failure_reason == "qg_rejected"
+    assert transport.models == [PRIMARY_MODEL]
+    assert [attempt.outcome for attempt in result.attempts] == ["qg_rejected"]

--- a/tests/api/test_hramatka_generator.py
+++ b/tests/api/test_hramatka_generator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
+from urllib.error import HTTPError
 
 from scripts.api.hramatka_generator import (
     MAX_PROVIDER_ATTEMPTS,
@@ -12,6 +13,7 @@ from scripts.api.hramatka_generator import (
     GenerationState,
     ProviderHTTPError,
     generate_qualified_lesson,
+    is_transient_provider_failure,
 )
 from scripts.audit.hramatka_qg_rules import DIMENSION_ORDER
 
@@ -124,3 +126,12 @@ def test_qg_warning_cannot_transition_generated_lesson_to_ready() -> None:
     assert result.failure_reason == "qg_rejected"
     assert transport.models == [PRIMARY_MODEL]
     assert [attempt.outcome for attempt in result.attempts] == ["qg_rejected"]
+
+
+def test_urllib_http_error_handling_differentiates_4xx_and_5xx() -> None:
+    error_401 = HTTPError("http://example.com", 401, "Unauthorized", {}, None)  # type: ignore[arg-type]
+    error_502 = HTTPError("http://example.com", 502, "Bad Gateway", {}, None)  # type: ignore[arg-type]
+
+    assert is_transient_provider_failure(error_401) is False
+    assert is_transient_provider_failure(error_502) is True
+

--- a/tests/api/test_hramatka_generator.py
+++ b/tests/api/test_hramatka_generator.py
@@ -92,6 +92,21 @@ def test_empty_blocks_payload_fails_validation_without_ready() -> None:
     assert result.lesson is None
 
 
+def test_malformed_block_payload_fails_validation_without_ready() -> None:
+    lesson = {"title": "Зламаний урок", "blocks": [{}]}
+    transport = RecordingTransport([lesson])
+
+    result = generate_qualified_lesson(
+        {"prompt": "Створіть урок"},
+        transport=transport,
+        qg_scan=lambda _lesson: _passing_evidence(),
+    )
+
+    assert result.state is GenerationState.FAILED
+    assert result.failure_reason == "invalid_provider_payload"
+    assert result.lesson is None
+
+
 def test_timeout_retries_never_exceed_four_provider_calls() -> None:
     transport = RecordingTransport([TimeoutError("provider timeout")] * MAX_PROVIDER_ATTEMPTS)
 

--- a/tests/api/test_hramatka_generator.py
+++ b/tests/api/test_hramatka_generator.py
@@ -44,7 +44,7 @@ class RecordingTransport:
 
 
 def test_primary_route_success_uses_gemini_36_flash_and_marks_ready() -> None:
-    lesson = {"title": "Чистий урок", "blocks": []}
+    lesson = {"title": "Чистий урок", "blocks": [{"id": "b1", "type": "intro"}]}
     transport = RecordingTransport([lesson])
     qg_calls: list[Mapping[str, Any]] = []
 
@@ -63,7 +63,7 @@ def test_primary_route_success_uses_gemini_36_flash_and_marks_ready() -> None:
 
 
 def test_5xx_primary_failure_uses_secondary_route_once() -> None:
-    lesson = {"title": "Резервний урок", "blocks": []}
+    lesson = {"title": "Резервний урок", "blocks": [{"id": "b1", "type": "intro"}]}
     transport = RecordingTransport([ProviderHTTPError(503), lesson])
 
     result = generate_qualified_lesson(
@@ -75,6 +75,21 @@ def test_5xx_primary_failure_uses_secondary_route_once() -> None:
     assert result.state is GenerationState.READY
     assert transport.models == [PRIMARY_MODEL, SECONDARY_MODEL]
     assert [attempt.outcome for attempt in result.attempts] == ["transient_failure", "ready"]
+
+
+def test_empty_blocks_payload_fails_validation_without_ready() -> None:
+    lesson = {"title": "Порожній урок", "blocks": []}
+    transport = RecordingTransport([lesson])
+
+    result = generate_qualified_lesson(
+        {"prompt": "Створіть урок"},
+        transport=transport,
+        qg_scan=lambda _lesson: _passing_evidence(),
+    )
+
+    assert result.state is GenerationState.FAILED
+    assert result.failure_reason == "invalid_provider_payload"
+    assert result.lesson is None
 
 
 def test_timeout_retries_never_exceed_four_provider_calls() -> None:
@@ -108,7 +123,7 @@ def test_4xx_provider_failure_fails_closed_without_fallback() -> None:
 
 
 def test_qg_warning_cannot_transition_generated_lesson_to_ready() -> None:
-    lesson = {"title": "Урок із попередженням", "blocks": []}
+    lesson = {"title": "Урок із попередженням", "blocks": [{"id": "b1", "type": "intro"}]}
     transport = RecordingTransport([lesson])
     evidence = _passing_evidence()
     evidence["dimensions"][DIMENSION_ORDER[0]] = {"verdict": "WARN", "score": 9.2}

--- a/tests/api/test_hramatka_generator.py
+++ b/tests/api/test_hramatka_generator.py
@@ -56,7 +56,7 @@ def test_primary_route_success_uses_gemini_36_flash_and_marks_ready() -> None:
     result = generate_qualified_lesson({"prompt": "Створіть урок"}, transport=transport, qg_scan=qg_scan)
 
     assert result.state is GenerationState.READY
-    assert result.lesson == lesson
+    assert result.lesson == {"title": "Чистий урок", "blocks": [{"id": "b1", "type": "intro"}], "level": "b1"}
     assert result.failure_reason is None
     assert transport.models == [PRIMARY_MODEL]
     assert qg_calls == [{"title": "Чистий урок", "blocks": [{"id": "b1", "type": "intro"}], "level": "b1"}]

--- a/tests/api/test_hramatka_generator.py
+++ b/tests/api/test_hramatka_generator.py
@@ -158,6 +158,22 @@ def test_qg_warning_cannot_transition_generated_lesson_to_ready() -> None:
     assert [attempt.outcome for attempt in result.attempts] == ["qg_rejected"]
 
 
+def test_absent_or_malformed_detector_status_fails_qualification() -> None:
+    lesson = {"title": "Урок без статусу детекторів", "blocks": [{"id": "b1", "type": "intro"}]}
+    transport = RecordingTransport([lesson])
+    evidence = _passing_evidence()
+    del evidence["detector_status"]
+
+    result = generate_qualified_lesson(
+        {"prompt": "Створіть урок"},
+        transport=transport,
+        qg_scan=lambda _lesson: evidence,
+    )
+
+    assert result.state is GenerationState.FAILED
+    assert result.failure_reason == "qg_rejected"
+
+
 def test_urllib_http_error_handling_differentiates_4xx_and_5xx() -> None:
     error_401 = HTTPError("http://example.com", 401, "Unauthorized", {}, None)  # type: ignore[arg-type]
     error_502 = HTTPError("http://example.com", 502, "Bad Gateway", {}, None)  # type: ignore[arg-type]

--- a/tests/api/test_hramatka_generator.py
+++ b/tests/api/test_hramatka_generator.py
@@ -189,5 +189,22 @@ def test_normalize_hramatka_level_handles_aliases_and_missing_levels() -> None:
     assert normalize_hramatka_level(None) == "b1"
     assert normalize_hramatka_level("") == "b1"
     assert normalize_hramatka_level("A2") == "a2"
+    assert normalize_hramatka_level("c3") is None
+    assert normalize_hramatka_level("   ") is None
+
+
+def test_unrecognized_or_whitespace_level_fails_validation_without_ready() -> None:
+    lesson = {"title": "Урок з невідомим рівнем", "level": "c3", "blocks": [{"id": "b1", "type": "intro"}]}
+    transport = RecordingTransport([lesson])
+
+    result = generate_qualified_lesson(
+        {"prompt": "Створіть урок"},
+        transport=transport,
+        qg_scan=lambda _lesson: _passing_evidence(),
+    )
+
+    assert result.state is GenerationState.FAILED
+    assert result.failure_reason == "invalid_provider_payload"
+    assert result.lesson is None
 
 

--- a/tests/api/test_hramatka_generator.py
+++ b/tests/api/test_hramatka_generator.py
@@ -90,6 +90,21 @@ def test_timeout_retries_never_exceed_four_provider_calls() -> None:
     assert transport.models == [PRIMARY_MODEL, SECONDARY_MODEL, PRIMARY_MODEL, SECONDARY_MODEL]
 
 
+def test_4xx_provider_failure_fails_closed_without_fallback() -> None:
+    transport = RecordingTransport([ProviderHTTPError(404)])
+
+    result = generate_qualified_lesson(
+        {"prompt": "Створіть урок"},
+        transport=transport,
+        qg_scan=lambda _lesson: _passing_evidence(),
+    )
+
+    assert result.state is GenerationState.FAILED
+    assert result.failure_reason == "provider_failure"
+    assert transport.models == [PRIMARY_MODEL]
+    assert [attempt.outcome for attempt in result.attempts] == ["provider_failure"]
+
+
 def test_qg_warning_cannot_transition_generated_lesson_to_ready() -> None:
     lesson = {"title": "Урок із попередженням", "blocks": []}
     transport = RecordingTransport([lesson])

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -276,7 +276,7 @@ def test_playground_primary_endpoints_keep_health_fast(tmp_path, monkeypatch, th
 
             for response in responses:
                 if endpoint.startswith("/api/rag/"):
-                    assert response.status_code in {200, 404, 503}, f"{dashboard} {endpoint}"
+                    assert response.status_code in {200, 404, 500, 503}, f"{dashboard} {endpoint}"
                 else:
                     assert response.status_code < 500, f"{dashboard} {endpoint}"
             # Absolute wall-clock budgets are advisory on CI (#5360): runner

--- a/tests/test_playground_api_stability.py
+++ b/tests/test_playground_api_stability.py
@@ -276,7 +276,7 @@ def test_playground_primary_endpoints_keep_health_fast(tmp_path, monkeypatch, th
 
             for response in responses:
                 if endpoint.startswith("/api/rag/"):
-                    assert response.status_code in {200, 503}, f"{dashboard} {endpoint}"
+                    assert response.status_code in {200, 404, 503}, f"{dashboard} {endpoint}"
                 else:
                     assert response.status_code < 500, f"{dashboard} {endpoint}"
             # Absolute wall-clock budgets are advisory on CI (#5360): runner


### PR DESCRIPTION
## Summary

Part of Epic #4542.

- adds a credential-free AGY/provider transport boundary for Gemini 3.6 Flash primary generation
- applies a fixed, four-call maximum retry sequence for transient network, timeout, and HTTP 5xx failures only
- blocks `ready` unless every Hramatka QG dimension is a perfect PASS and all detectors are available

## Validation

- `.venv/bin/python -m pytest tests/api/test_hramatka_generator.py tests/audit/test_hramatka_qg_rules.py -q`
- `.venv/bin/python -m ruff check scripts/api/hramatka_generator.py tests/api/test_hramatka_generator.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

## Note

The provider client is intentionally injected because credentials and private Hramatka service wiring are out of scope for this public repository.