### PR TITLE
feat(hramatka): add vocabulary drawer and theory callout components (#4542)

### DIFF
--- a/packages/activity-kit/src/components/TheoryCallout.tsx
+++ b/packages/activity-kit/src/components/TheoryCallout.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import type { LuLessonSupportTheoryItem } from '../lu.lesson-support.v1.generated';
+
+export interface TheoryCalloutProps {
+  theory: LuLessonSupportTheoryItem;
+  type?: 'rule' | 'tip' | 'warning' | 'note';
+}
+
+export const TheoryCallout: React.FC<TheoryCalloutProps> = ({
+  theory,
+  type = 'rule',
+}) => {
+  const colorMap = {
+    rule: { bg: '#eff6ff', border: '#bfdbfe', text: '#1e3a8a', title: 'Grammar Rule' },
+    tip: { bg: '#f0fdf4', border: '#bbf7d0', text: '#14532d', title: 'Linguistic Tip' },
+    warning: { bg: '#fffbeb', border: '#fde68a', text: '#78350f', title: 'Usage Caution' },
+    note: { bg: '#f8fafc', border: '#cbd5e1', text: '#334155', title: 'Theoretical Note' },
+  };
+
+  const style = colorMap[type] || colorMap.rule;
+
+  return (
+    <div
+      data-testid={`theory-callout-${theory.id}`}
+      style={{
+        padding: '16px 20px',
+        borderRadius: '8px',
+        border: `1px solid ${style.border}`,
+        backgroundColor: style.bg,
+        color: style.text,
+        marginBottom: '16px',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
+        <strong style={{ fontSize: '15px' }}>{style.title}</strong>
+        <span style={{ fontSize: '11px', opacity: 0.7 }}>({theory.id})</span>
+      </div>
+
+      <div style={{ fontSize: '14px', lineHeight: '1.5', whiteSpace: 'pre-wrap' }}>
+        {theory.body}
+      </div>
+
+      {theory.callouts && theory.callouts.length > 0 && (
+        <ul style={{ margin: '12px 0 0', paddingLeft: '20px', fontSize: '13px' }}>
+          {theory.callouts.map((c, i) => (
+            <li key={i} style={{ marginBottom: '4px' }}>{c}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default TheoryCallout;

--- a/packages/activity-kit/src/components/VocabularyDrawer.tsx
+++ b/packages/activity-kit/src/components/VocabularyDrawer.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useMemo } from 'react';
+import type { LuLessonSupportVocabularyItem } from '../lu.lesson-support.v1.generated';
+
+export interface VocabularyDrawerProps {
+  vocabulary: LuLessonSupportVocabularyItem[];
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+}
+
+export const VocabularyDrawer: React.FC<VocabularyDrawerProps> = ({
+  vocabulary = [],
+  isOpen,
+  onClose,
+  title = 'Lesson Vocabulary & Morphology',
+}) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedPos, setSelectedPos] = useState<string>('all');
+
+  // Extract unique POS tags for filtering
+  const availablePos = useMemo(() => {
+    const posSet = new Set<string>();
+    vocabulary.forEach((item) => {
+      if (item.pos) posSet.add(item.pos.toLowerCase());
+    });
+    return Array.from(posSet).sort();
+  }, [vocabulary]);
+
+  // Filtered vocabulary items (search + POS)
+  const filteredVocabulary = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    return vocabulary.filter((item) => {
+      const matchesSearch =
+        !query ||
+        item.surface.toLowerCase().includes(query) ||
+        item.lemma.toLowerCase().includes(query) ||
+        item.gloss.toLowerCase().includes(query);
+
+      const matchesPos = selectedPos === 'all' || item.pos.toLowerCase() === selectedPos;
+
+      return matchesSearch && matchesPos;
+    });
+  }, [vocabulary, searchTerm, selectedPos]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      data-testid="vocabulary-drawer-overlay"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(15, 23, 42, 0.5)',
+        backdropFilter: 'blur(4px)',
+        zIndex: 1000,
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+      onClick={onClose}
+    >
+      <div
+        data-testid="vocabulary-drawer-panel"
+        style={{
+          width: '100%',
+          maxWidth: '440px',
+          height: '100%',
+          backgroundColor: '#ffffff',
+          boxShadow: '-4px 0 24px rgba(0, 0, 0, 0.15)',
+          display: 'flex',
+          flexDirection: 'column',
+          color: '#1e293b',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Drawer Header */}
+        <div style={{ padding: '20px', borderBottom: '1px solid #e2e8f0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div>
+            <h3 style={{ margin: 0, fontSize: '18px', fontWeight: 700, color: '#0f172a' }}>{title}</h3>
+            <span style={{ fontSize: '12px', color: '#64748b' }}>{vocabulary.length} total attested lemmas</span>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              cursor: 'pointer',
+              border: 'none',
+              backgroundColor: '#f1f5f9',
+              borderRadius: '50%',
+              width: '32px',
+              height: '32px',
+              fontWeight: 700,
+              color: '#475569',
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Search & Filter Bar */}
+        <div style={{ padding: '16px 20px', borderBottom: '1px solid #f1f5f9', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <input
+            type="text"
+            placeholder="Search word, lemma, or gloss..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            style={{ width: '100%', padding: '10px 12px', borderRadius: '6px', border: '1px solid #cbd5e1', fontSize: '14px', boxSizing: 'border-box' }}
+          />
+
+          {availablePos.length > 0 && (
+            <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+              <button
+                onClick={() => setSelectedPos('all')}
+                style={{
+                  cursor: 'pointer',
+                  padding: '4px 10px',
+                  borderRadius: '12px',
+                  border: 'none',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  backgroundColor: selectedPos === 'all' ? '#2563eb' : '#f1f5f9',
+                  color: selectedPos === 'all' ? '#ffffff' : '#475569',
+                }}
+              >
+                All
+              </button>
+              {availablePos.map((pos) => (
+                <button
+                  key={pos}
+                  onClick={() => setSelectedPos(pos)}
+                  style={{
+                    cursor: 'pointer',
+                    padding: '4px 10px',
+                    borderRadius: '12px',
+                    border: 'none',
+                    fontSize: '12px',
+                    fontWeight: 600,
+                    backgroundColor: selectedPos === pos ? '#2563eb' : '#f1f5f9',
+                    color: selectedPos === pos ? '#ffffff' : '#475569',
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  {pos}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Vocabulary Items List */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '20px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          {filteredVocabulary.length === 0 ? (
+            <div style={{ padding: '32px', textAlign: 'center', color: '#64748b', fontSize: '14px' }}>
+              No vocabulary items match your query.
+            </div>
+          ) : (
+            filteredVocabulary.map((item, index) => (
+              <div
+                key={`${item.lemma}-${index}`}
+                style={{
+                  padding: '14px',
+                  borderRadius: '8px',
+                  border: '1px solid #e2e8f0',
+                  backgroundColor: '#f8fafc',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '6px',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                  <span style={{ fontSize: '17px', fontWeight: 700, color: '#0f172a' }}>
+                    {item.stress || item.surface}
+                  </span>
+                  <span style={{ fontSize: '11px', fontWeight: 700, padding: '2px 6px', borderRadius: '4px', backgroundColor: '#e2e8f0', color: '#334155', textTransform: 'uppercase' }}>
+                    {item.pos}
+                  </span>
+                </div>
+
+                <div style={{ fontSize: '13px', color: '#475569' }}>
+                  <strong>Lemma:</strong> {item.lemma} {item.surface !== item.lemma ? `(form: ${item.surface})` : ''}
+                </div>
+
+                <div style={{ fontSize: '14px', color: '#1e293b', fontStyle: 'italic' }}>
+                  "{item.gloss}"
+                </div>
+
+                {item.vesum_analysis && (
+                  <div style={{ marginTop: '4px', fontSize: '11px', color: '#64748b', backgroundColor: '#ffffff', padding: '6px', borderRadius: '4px', border: '1px solid #e2e8f0' }}>
+                    <strong>VESUM:</strong> {typeof item.vesum_analysis === 'string' ? item.vesum_analysis : JSON.stringify(item.vesum_analysis)}
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VocabularyDrawer;

--- a/packages/activity-kit/src/index.ts
+++ b/packages/activity-kit/src/index.ts
@@ -9,6 +9,10 @@ export { TeacherDashboard } from './components/TeacherDashboard';
 export type { TeacherDashboardProps, DashboardState, LessonSummary } from './components/TeacherDashboard';
 export { LessonViewer, sanitizeLessonForStudent } from './components/LessonViewer';
 export type { LessonViewerProps, LessonViewerMode } from './components/LessonViewer';
+export { VocabularyDrawer } from './components/VocabularyDrawer';
+export type { VocabularyDrawerProps } from './components/VocabularyDrawer';
+export { TheoryCallout } from './components/TheoryCallout';
+export type { TheoryCalloutProps } from './components/TheoryCallout';
 export type {
   ActivityPlayerActivity,
   ActivityCompletionEvent,

--- a/tests/test_hramatka_vocab_theory.py
+++ b/tests/test_hramatka_vocab_theory.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+def test_vocab_drawer_component_exists_and_exports():
+    vocab_path = PROJECT_ROOT / "packages/activity-kit/src/components/VocabularyDrawer.tsx"
+    assert vocab_path.exists(), "VocabularyDrawer.tsx must exist in activity-kit"
+
+    content = vocab_path.read_text(encoding="utf-8")
+    assert "export const VocabularyDrawer" in content
+    assert "vocabulary-drawer-overlay" in content
+    assert "vocabulary-drawer-panel" in content
+
+def test_theory_callout_component_exists_and_exports():
+    theory_path = PROJECT_ROOT / "packages/activity-kit/src/components/TheoryCallout.tsx"
+    assert theory_path.exists(), "TheoryCallout.tsx must exist in activity-kit"
+
+    content = theory_path.read_text(encoding="utf-8")
+    assert "export const TheoryCallout" in content
+    assert "theory-callout" in content
+
+def test_vocab_theory_index_exports():
+    index_path = PROJECT_ROOT / "packages/activity-kit/src/index.ts"
+    content = index_path.read_text(encoding="utf-8")
+    assert "VocabularyDrawer" in content
+    assert "TheoryCallout" in content


### PR DESCRIPTION
## Ticket #4542-P2.3: Vocabulary Drawer & Theory Callout Component

### Summary of Changes
- Created `VocabularyDrawer` React component in `packages/activity-kit/src/components/VocabularyDrawer.tsx`.
- Created `TheoryCallout` React component in `packages/activity-kit/src/components/TheoryCallout.tsx`.
- Exported `VocabularyDrawer`, `VocabularyDrawerProps`, `TheoryCallout`, and `TheoryCalloutProps` from `packages/activity-kit/src/index.ts`.
- Populates Vocabulary Drawer exclusively from `lesson-support.v1` sidecar with search by surface/lemma/gloss, POS pill filters, stress marks, and VESUM attestation metadata.
- Renders 100% offline once lesson sidecar is loaded.
- Added unit tests in `tests/test_hramatka_vocab_theory.py` (3/3 passing).

X-Agent: gemini/4542-P2-3-vocab-drawer