### PR TITLE
fix(security): clear CodeQL path-injection and zizmor pin mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1135,7 +1135,7 @@ jobs:
 
       - name: Download pytest shard artifacts
         if: needs.changes.outputs.python == 'true' && needs.test.result == 'success'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v7.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: pytest-shard-*
           path: pytest-artifacts
@@ -1148,7 +1148,7 @@ jobs:
 
       - name: Download coverage shards
         if: needs.changes.outputs.python == 'true' && needs.test.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v7.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: pytest-coverage-*
           path: coverage-artifacts

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: cb13611723173f08fd9ab53448230f54fc2a771f525772ed72323b23de4f0e4a
+  components_sha256: 0761d51a0b7e07b7a4e4090356223a41ce73476b175898fd5460bd1d29571b52
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1075,6 +1075,28 @@ components:
       letters:
       - <LetterEntry>
       title: Приклад
+    deprecated: false
+    deprecation_reason: null
+  LexiconCustomDeckManager:
+    tab: lesson
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: chromeLocale
+        type: '''en'' | ''uk'''
+        description: chromeLocale prop.
+        ukrainian_text: 'false'
+      - name: activeDeckFilter
+        type: string
+        description: activeDeckFilter prop.
+        ukrainian_text: 'false'
+      optional: []
+    nested_types: {}
+    example:
+      chromeLocale: <'en' | 'uk'>
+      activeDeckFilter: Приклад
     deprecated: false
     deprecation_reason: null
   LexiconPractice:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 93dc922581f94097d187e3094f4cb6026f205140fdde22341d1e3530774f6a9a
+  components_sha256: 1413f8bc7649a6455c2a541baf1c9389eb800f541ebbbb4c667d28448dc04ad7
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 0418fbc8e1e28854f05d619e5d31daac11d4a3a2e8e7d05ad999a29dd98381f1
+  components_sha256: 93dc922581f94097d187e3094f4cb6026f205140fdde22341d1e3530774f6a9a
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 975d0cef459388d5b71e74b8930984d7026346f7116408a7ede4abda3abafe49
+  components_sha256: 15934f94d2e21f72116c79996cad01fb57150bdadb90c9f8543e8d24582c9f8a
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 15934f94d2e21f72116c79996cad01fb57150bdadb90c9f8543e8d24582c9f8a
+  components_sha256: 0418fbc8e1e28854f05d619e5d31daac11d4a3a2e8e7d05ad999a29dd98381f1
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 0761d51a0b7e07b7a4e4090356223a41ce73476b175898fd5460bd1d29571b52
+  components_sha256: 975d0cef459388d5b71e74b8930984d7026346f7116408a7ede4abda3abafe49
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1092,11 +1092,21 @@ components:
         type: string
         description: activeDeckFilter prop.
         ukrainian_text: 'false'
+      - name: onSelectDeckFilter
+        type: '(filterId: string) => void'
+        description: onSelectDeckFilter prop.
+        ukrainian_text: 'false'
+      - name: onClose
+        type: () => void
+        description: onClose prop.
+        ukrainian_text: 'false'
       optional: []
     nested_types: {}
     example:
       chromeLocale: <'en' | 'uk'>
       activeDeckFilter: Приклад
+      onSelectDeckFilter: '<(filterId: string) => void>'
+      onClose: <() => void>
     deprecated: false
     deprecation_reason: null
   LexiconPractice:

--- a/scripts/api/delegate_router.py
+++ b/scripts/api/delegate_router.py
@@ -36,8 +36,30 @@ def _parse_iso_datetime(value: str | None) -> datetime | None:
 
 
 def _task_state_path(task_id: str) -> Path:
+    """Resolve ``task_id`` to a state JSON path under ``TASKS_DIR``.
+
+    Slash/backslash sanitization alone is not a CodeQL-recognized barrier
+    (``py/path-injection`` alert #317). Use the ``os.path.realpath`` +
+    ``startswith(root + os.sep)`` idiom that the analyzer accepts as a
+    sanitizer — same pattern as ``session_router._safe_project_path``.
+    Escapes collapse to a guaranteed-nonexistent path inside the root so
+    callers that treat missing state as ``None`` keep working.
+    """
     safe = task_id.replace("/", "_").replace("\\", "_")
-    return TASKS_DIR / f"{safe}.json"
+    root = os.path.realpath(str(TASKS_DIR))
+    candidate = os.path.realpath(os.path.join(root, f"{safe}.json"))
+    if not candidate.startswith(root + os.sep):
+        candidate = os.path.join(root, "__rejected__.json")
+    return Path(candidate)
+
+
+def _safe_result_path(result_file: str) -> Path | None:
+    """Allow result reads only under ``TASKS_DIR`` (delegate writes ``.result`` siblings)."""
+    root = os.path.realpath(str(TASKS_DIR))
+    candidate = os.path.realpath(result_file)
+    if not candidate.startswith(root + os.sep):
+        return None
+    return Path(candidate)
 
 
 def _read_task_state(path: Path) -> dict[str, Any] | None:
@@ -135,9 +157,10 @@ def get_delegate_task_detail(task_id: str) -> tuple[dict[str, Any] | None, dict[
     truncated = False
     if task.get("status") != "running":
         result_file = task.get("result_file")
-        if result_file:
+        safe_result = _safe_result_path(str(result_file)) if result_file else None
+        if safe_result is not None:
             try:
-                with open(result_file, encoding="utf-8") as handle:
+                with open(safe_result, encoding="utf-8") as handle:
                     result_text = handle.read(RESULT_BYTES_LIMIT + 1)
                 if result_text is not None and len(result_text.encode("utf-8")) > RESULT_BYTES_LIMIT:
                     while len(result_text.encode("utf-8")) > RESULT_BYTES_LIMIT:

--- a/site/src/components/LexiconCustomDeckManager.tsx
+++ b/site/src/components/LexiconCustomDeckManager.tsx
@@ -22,8 +22,8 @@ import { syncCustomSetsToDrive, requestGoogleAccessToken, setInMemoryAccessToken
 interface LexiconCustomDeckManagerProps {
   chromeLocale: 'en' | 'uk';
   activeDeckFilter: string;
-  onSelectDeckFilter(filterId: string): void;
-  onClose(): void;
+  onSelectDeckFilter: (filterId: string) => void;
+  onClose: () => void;
 }
 
 interface CandidateWord {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -668,6 +668,7 @@ describe('LexiconPractice', () => {
 
     await screen.findByTestId('practice-daily-deck');
     const dashboard = container.querySelector('.k3-practice-dashboard')!;
+    // Ignore anonymous wrappers (drive sync / deck filter bars have no data-testid).
     expect(
       Array.from(dashboard.children)
         .map((child) => child.getAttribute('data-testid'))
@@ -675,8 +676,6 @@ describe('LexiconPractice', () => {
     ).toEqual([
       'practice-dashboard-hero',
       'practice-dashboard-stats',
-      null, // k3-drive-sync-bar
-      null, // k3-deck-filter-bar
       'practice-dashboard-words',
       'practice-dashboard-session',
       'practice-dashboard-secondary',

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -675,6 +675,8 @@ describe('LexiconPractice', () => {
     ).toEqual([
       'practice-dashboard-hero',
       'practice-dashboard-stats',
+      null, // k3-drive-sync-bar
+      null, // k3-deck-filter-bar
       'practice-dashboard-words',
       'practice-dashboard-session',
       'practice-dashboard-secondary',

--- a/tests/test_delegate_api.py
+++ b/tests/test_delegate_api.py
@@ -117,10 +117,25 @@ def test_active_lists_only_live_running_tasks(tmp_path, monkeypatch):
     assert data["tasks"][0]["task_id"] == "running"
 
 
+def test_task_state_path_stays_under_tasks_dir(tmp_path, monkeypatch):
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
+
+    for task_id in ("normal", "agent/task", "../../etc/passwd", r"..\..\windows"):
+        path = delegate_router._task_state_path(task_id)
+        resolved = path.resolve()
+        assert resolved == tasks_dir.resolve() / resolved.name
+        assert resolved.is_relative_to(tasks_dir.resolve())
+
+
 def test_task_detail_truncates_large_result(tmp_path, monkeypatch):
     tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
     monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
-    result_file = tmp_path / "big.result"
+    # Production writes ``.result`` siblings under TASKS_DIR; reads are
+    # containment-checked there (CodeQL py/path-injection).
+    result_file = tasks_dir / "large.result"
     result_file.write_text("x" * (70 * 1024), encoding="utf-8")
     _write_task(
         tasks_dir / "large.json",
@@ -133,6 +148,24 @@ def test_task_detail_truncates_large_result(tmp_path, monkeypatch):
     data = response.json()
     assert data["result_truncated"] is True
     assert len(data["result"].encode("utf-8")) <= delegate_router.RESULT_BYTES_LIMIT
+
+
+def test_task_detail_rejects_result_outside_tasks_dir(tmp_path, monkeypatch):
+    tasks_dir = tmp_path / "tasks"
+    monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
+    escape = tmp_path / "outside.result"
+    escape.write_text("secret", encoding="utf-8")
+    _write_task(
+        tasks_dir / "escape.json",
+        _task_payload("escape", result_file=str(escape), status="done"),
+    )
+
+    response = client.get("/api/delegate/tasks/escape")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"] is None
+    assert data["result_truncated"] is False
 
 
 def test_zombie_detection_works_on_dead_pid(tmp_path, monkeypatch):

--- a/tests/test_grow_lexicon_from_content.py
+++ b/tests/test_grow_lexicon_from_content.py
@@ -206,7 +206,7 @@ def _patch_enrich_entry_heavy_helpers(monkeypatch) -> None:
     monkeypatch.setattr(enrich_manifest_module, "_curated_calque", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest_module, "_reverse_calques", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest_module, "_kaikki_pronunciation", lambda *args, **kwargs: None)
-    monkeypatch.setattr(enrich_manifest_module, "_synonyms_slovnyk", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_synonyms_mphdict", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest_module, "_antonyms_wiktionary", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest_module, "_idioms", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda *args, **kwargs: "")


### PR DESCRIPTION
## Summary
- Clear CodeQL `py/path-injection` (#317): contain delegate task-state and result-file reads under `TASKS_DIR` with the CodeQL-recognized `realpath` + `startswith(root + sep)` barrier.
- Clear zizmor `ref-version-mismatch` (#315/#316): `actions/download-artifact` was pinned to the v4.3.0 SHA while labeled `# v7.0.0`; retarget to the real v7.0.0 SHA (`37930b1c2aba…`).

## Test plan
- [x] `pytest tests/test_delegate_api.py tests/api/test_delegate_active.py` (11 passed)
- [x] `ruff check` on touched Python
- [ ] CI green (CI Gate)
- [ ] Code scanning alerts #315–#317 close after merge scan


Made with [Cursor](https://cursor.com)