### PR TITLE
fix(skills): harden curriculum workflow portability

### DIFF
--- a/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: curriculum-lifecycle
-description: Run or resume the manifest-derived curriculum lifecycle for one active track, using the coordinator for ordered waves and routing each acquired module through the canonical preparation or track-completion owner.
+description: Run or resume the manifest-derived curriculum lifecycle for one active track. Use when an operator asks to process a track in manifest order, select built, unbuilt, stale, or one-module scope, or resume an exact coordinator run. Route every acquired module through curriculum-preparation or track-completion; do not use for an uncoordinated standalone module.
 ---
 
 # Curriculum lifecycle
@@ -8,8 +8,8 @@ description: Run or resume the manifest-derived curriculum lifecycle for one act
 Keep the operator request short:
 
 ```text
-Use $curriculum-lifecycle for folk.
-Use $curriculum-lifecycle for c1, scope unbuilt.
+Use $curriculum-lifecycle for folk, terminal goal merge.
+Use $curriculum-lifecycle for c1, scope unbuilt, terminal goal certify.
 Resume $curriculum-lifecycle for bio.
 ```
 
@@ -28,7 +28,10 @@ only bounded-completion authority.
 1. Satisfy the repository issue, stream, worktree, research-classification,
    pending-decision, and quota/health preflight before mutation. Learner changes
    belong to the target track's stream epic, not the shared infrastructure epic.
-2. For a new run, map the requested selector to one of `all`, `built`,
+2. Require an explicit operator-selected terminal goal for every new run. If it
+   is absent, ask once before starting; never infer it from scope or history.
+   Resume uses the immutable goal in the exact recorded run.
+3. For a new run, map the requested selector to one of `all`, `built`,
    `unbuilt`, `stale`, or `one`, then start exactly one manifest-backed run:
 
    ```bash
@@ -44,7 +47,7 @@ only bounded-completion authority.
    The goal is immutable authority, not a progress label. A legacy run without
    one must use `migrate-terminal-goal` on its exact run id; never infer intent
    from `complete` or `PBR_PASS_QG_PENDING` history.
-3. Resume only the exact recorded run:
+4. Resume only the exact recorded run:
 
    ```bash
    .venv/bin/python scripts/orchestration/curriculum_coordinator.py resume \
@@ -90,10 +93,13 @@ only bounded-completion authority.
    When every current requirement passes but a built result remains `prepare`
    solely because of `PREPARATION_IDENTITY_MISSING` or
    `PREPARATION_IDENTITY_DRIFT`, hand the exact target to `$track-completion`.
-   Its authoritative ledger reruns readiness with the consumed identity from
-   `BUILD_RECORDED`, then either certifies or takes its existing explicit rebuild
-   transition. Do not reacquire, repeat the evaluator, or loop through
-   preparation. Fail closed on mixed or unknown combinations.
+   After that skill starts or resumes its authoritative ledger, it must run the
+   documented `request-preparation-rebuild <track/slug> --run-id <id>`
+   transition before any post-build review. That transition reruns readiness
+   with the consumed identity from `BUILD_RECORDED`, then either returns
+   `BUILD_REQUIRED` or records the exact preparation blocker. Do not reacquire,
+   repeat the evaluator, or loop through preparation. Fail closed on mixed or
+   unknown combinations.
 
    For `stop`, run the canonical evaluator once to validate the full typed
    result. `PREPARATION_HOLD_ACTIVE` without a partial-bundle finding is a
@@ -107,7 +113,10 @@ only bounded-completion authority.
 3. For `build`, `certify`, an identity-only `prepare` exception, or the exact
    partial-bundle `stop` exception, resolve the acquired track's registered
    semantic profile from the manifest. Put the typed context in a gitignored
-   runtime JSON file; never add free-form prompt prose to a profile:
+   runtime JSON file. Supply the schema-required `track`, `slug`, `family`,
+   `phase`, `module_state`, and `evidence_identity` from the acquired result and
+   authoritative module ledger; do not infer them or add free-form prompt prose
+   to a profile:
 
    ```bash
    .venv/bin/python scripts/orchestration/prompt_contracts.py resolve-track \

--- a/agents_extensions/shared/skills/curriculum-lifecycle/agents/openai.yaml
+++ b/agents_extensions/shared/skills/curriculum-lifecycle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Curriculum Lifecycle"
+  short_description: "Coordinate one curriculum track safely"
+  default_prompt: "Use $curriculum-lifecycle for c1, scope unbuilt, terminal goal merge."

--- a/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
@@ -5,6 +5,10 @@ description: Prepare, audit, or resume missing or stale prerequisite evidence fo
 
 # Curriculum preparation
 
+Run repository commands from the repository root. Use canonical resource paths
+under `agents_extensions/shared/skills/`; provider-specific skill directories
+are deploy mirrors, not alternate sources.
+
 Use `scripts/orchestration/curriculum_readiness.py` as the only readiness
 engine. Prepare prerequisite evidence only. Produce no learner module bundle and
 never invoke `$curriculum-lifecycle`; that skill may call this one, and this one
@@ -38,8 +42,11 @@ before mutation and require the same track, `profile_id`, `profile_version`, and
 Treat `--missing-only` as deterministic, read-only inventory only. Resolve the
 roster with `load_active_manifest()` and `load_manifest_track()` from
 `scripts.orchestration.curriculum_readiness`, evaluate the whole active track
-locally, and return failed or stale candidates in manifest order. Do not mutate,
-call a model, silently select an unbounded work scope, or scan another track.
+locally, and return the evaluator's preparation-owned missing or stale
+candidates in manifest order. This inventory intentionally excludes an
+identity-missing built module whose requirements otherwise pass; that route
+belongs to `$track-completion`. Do not mutate, call a model, silently broaden
+the canonical inventory, select an unbounded work scope, or scan another track.
 Stop after the inventory; actual preparation requires a new explicit one-target
 invocation or finite homogeneous packet with `--limit`.
 
@@ -96,10 +103,15 @@ packet.
 
 For model-assisted preparation, enforce one shared budget for the exact scope:
 
-Use `scripts/bounded_packet.py` for executable packet admission, exact PASS
-reuse, hash-derived review scope, and compact receipt/HOLD projection only.
-Drive all review, repair, and verification transitions through the canonical
-`../track-completion/scripts/bounded_completion.py` helper.
+Import the functions in
+`agents_extensions/shared/skills/curriculum-preparation/scripts/bounded_packet.py`
+for packet admission, exact PASS reuse, hash-derived review scope, and compact
+receipt/HOLD projection. Use its `admit_packet`,
+`pending_dispatch_receipt`, and `terminal_hold_receipt` APIs; it is a pure
+library, not a CLI or controller. Those projections load the canonical
+`agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py`
+state-machine helper. Neither helper provides semantic-review transport, and
+executing either file is not review evidence.
 
 1. Before every review dispatch, persist conservative budget evidence in the
    invoking task or controller's existing durable progress ledger or issue

--- a/agents_extensions/shared/skills/curriculum-preparation/agents/openai.yaml
+++ b/agents_extensions/shared/skills/curriculum-preparation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Curriculum Preparation"
   short_description: "Prepare missing curriculum evidence safely"
-  default_prompt: "Use $curriculum-preparation to prepare failed readiness evidence for bio/example-slug."
+  default_prompt: "Use $curriculum-preparation for c1 --missing-only."

--- a/agents_extensions/shared/skills/track-completion/SKILL.md
+++ b/agents_extensions/shared/skills/track-completion/SKILL.md
@@ -35,10 +35,18 @@ closed.
 
 For the exception, derive the consumed preparation identity from the latest
 `BUILD_RECORDED` event in this authoritative ledger and rerun canonical
-readiness with it. Continue only from that fresh result: certify when current,
-or take the existing explicit preparation-rebuild transition when the identity
-differs. A failed requirement or mixed/unknown combination fails closed. Do not
-weaken or bypass this identity-consumption gate.
+readiness with it. Before any post-build review, take the explicit transition:
+
+```bash
+.venv/bin/python \
+  agents_extensions/shared/skills/track-completion/scripts/track_completion.py \
+  request-preparation-rebuild <track/slug> --run-id <id>
+```
+
+Continue only from its fresh result: rebuild from `BUILD_REQUIRED`, or preserve
+and report `PREPARATION_BLOCKED`. A failed requirement or mixed/unknown
+combination fails closed. Do not weaken or bypass this identity-consumption
+gate.
 
 ## Canonical entry paths
 
@@ -90,16 +98,27 @@ review evidence. The durable ledger retains the initial/final review, the
 consolidated repair, remaining canonical budgets, terminal disposition, and
 any deferred audit-tooling drift. A ledger without `bounded_completion` is
 a legacy ledger: its historic reviews remain provisional and it never receives
-an inferred bounded history. Run `migrate-bounded-completion`, then
-`restart-bounded-completion --run-id <legacy-run-id> --owner <operator>` to
-quarantine that run and create a fresh bounded run without deleting its evidence.
+an inferred bounded history. Quarantine it and create a fresh bounded run
+without deleting its evidence:
+
+```bash
+.venv/bin/python \
+  agents_extensions/shared/skills/track-completion/scripts/track_completion.py \
+  migrate-bounded-completion <track/slug> --run-id <legacy-run-id>
+.venv/bin/python \
+  agents_extensions/shared/skills/track-completion/scripts/track_completion.py \
+  restart-bounded-completion <track/slug> --run-id <legacy-run-id> \
+  --owner <agent/task>
+```
+
 The restart moves prior reviews, certification records, publication/QG records,
 and identities into non-authoritative archival ledger storage.
 
 ## Start or resume
 
-1. Preserve the legacy parity boundary documented below. Post-build review v5
-   owns semantic readiness; the outer skill owns lifecycle and persistence.
+1. Preserve the legacy parity boundary documented below. The current versioned
+   post-build review owns semantic readiness; the outer skill owns lifecycle
+   and persistence.
 2. Satisfy repository issue, stream, worktree, research-classification, and
    pending-decision preflight before mutation. Work in the existing scoped
    issue worktree; do not ask V7 to create another worktree.
@@ -130,10 +149,19 @@ and identities into non-authoritative archival ledger storage.
    engine classifies it as `AUDIT_TOOLING_DEFERRED` and queues it for a later
    run: it does not reopen this run, consume either bounded budget, or make
    frozen evidence current under the new tooling.
-   A legacy ledger without a goal is non-authoritative. Use
-   `migrate-terminal-goal` with the exact old run id and explicit intent; a
-   `PBR_PASS_QG_PENDING` migration must also name its exact PR and 40-character
-   merge SHA. Never infer a goal from historical cursor state.
+   A legacy ledger without a goal is non-authoritative. Migrate it with explicit
+   intent:
+
+   ```bash
+   .venv/bin/python \
+     agents_extensions/shared/skills/track-completion/scripts/track_completion.py \
+     migrate-terminal-goal <track/slug> --run-id <legacy-run-id> \
+     --terminal-goal <merge|certify|deploy>
+   ```
+
+   A `PBR_PASS_QG_PENDING` migration must also supply `--pr <number>` and
+   `--merge-sha <40-character-sha>`. Never infer a goal from historical cursor
+   state.
 
    The deterministic module resume command is:
 

--- a/tests/orchestration/test_prompt_contracts.py
+++ b/tests/orchestration/test_prompt_contracts.py
@@ -762,7 +762,9 @@ def test_curriculum_skills_define_one_non_recursive_preparation_handoff() -> Non
     assert "PREPARATION_IDENTITY_DRIFT" in normalized_completion
     assert "any `prepare` with a failed plan/preparation requirement" in normalized_completion
     assert "rerun canonical readiness with it" in normalized_completion
-    assert "existing explicit preparation-rebuild transition" in normalized_completion
+    assert "Before any post-build review, take the explicit transition" in normalized_completion
+    assert "request-preparation-rebuild <track/slug> --run-id <id>" in normalized_completion
+    assert "rebuild from `BUILD_REQUIRED`, or preserve and report `PREPARATION_BLOCKED`" in normalized_completion
     assert "latest `BUILD_RECORDED` event" in normalized_completion
     assert "identity-consumption gate" in normalized_completion
     assert "`plan`, `prepare`, and `stop` remain outside this skill" not in normalized_completion

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -25,6 +25,7 @@ CODEX_HOOKS_CONFIG = Path(".codex/hooks.json")
 PROMPT_CONTRACT_MANIFEST = Path("prompt-contracts/manifests/curriculum-lifecycle.module.v1.yaml")
 READINESS_PROFILE_CONFIG = Path("curriculum-lifecycle/config/readiness-profiles.v1.yaml")
 COORDINATOR_CONFIG = Path("curriculum-lifecycle/config/coordinator.v1.yaml")
+SHARED_CURRICULUM_SKILLS = ("curriculum-lifecycle", "curriculum-preparation")
 UNSCOPED_RULE_FILES = (
     "operator-expectations.md",
     "critical-rules.md",
@@ -132,6 +133,14 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
         canonical = repo / "agents_extensions/shared" / shared_file
         for mirror_root in (".claude", ".agent", ".codex"):
             assert (repo / mirror_root / shared_file).read_bytes() == canonical.read_bytes()
+    for skill_name in SHARED_CURRICULUM_SKILLS:
+        canonical_skill = repo / "agents_extensions" / "shared" / "skills" / skill_name
+        for mirror_root in (".claude", ".agent", ".agents", ".codex", ".gemini"):
+            deployed_skill = repo / mirror_root / "skills" / skill_name
+            assert (deployed_skill / "SKILL.md").read_bytes() == (canonical_skill / "SKILL.md").read_bytes()
+            assert (deployed_skill / "agents" / "openai.yaml").read_bytes() == (
+                canonical_skill / "agents" / "openai.yaml"
+            ).read_bytes()
 
     codex_hooks_diff = _run_command(
         repo,
@@ -140,6 +149,22 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
     assert codex_hooks_diff.returncode == 0, (
         f"Codex hooks drift after fresh deploy:\nstdout: {codex_hooks_diff.stdout}\nstderr: {codex_hooks_diff.stderr}"
     )
+
+
+def test_curriculum_preparation_documents_canonical_helper_paths() -> None:
+    """Preparation must identify its import-only helpers from the repository root."""
+    skill_path = REPO_ROOT / "agents_extensions/shared/skills/curriculum-preparation/SKILL.md"
+    skill = skill_path.read_text(encoding="utf-8")
+    helper_paths = (
+        Path("agents_extensions/shared/skills/curriculum-preparation/scripts/bounded_packet.py"),
+        Path("agents_extensions/shared/skills/track-completion/scripts/bounded_completion.py"),
+    )
+
+    for helper_path in helper_paths:
+        assert (REPO_ROOT / helper_path).is_file()
+        assert str(helper_path) in skill
+    assert "`scripts/bounded_packet.py`" not in skill
+    assert "`../track-completion/scripts/bounded_completion.py`" not in skill
 
 
 def test_claude_rule_exclusion_list_covers_unscoped_files() -> None:


### PR DESCRIPTION
## Summary

- make `curriculum-lifecycle` and `curriculum-preparation` discoverable and byte-identical across the Claude, generic agent, Codex, and Gemini deployment mirrors
- add lifecycle UI metadata and safe default prompts
- replace non-resolving preparation helper references with canonical repository paths and document the import-only API boundary
- make terminal-goal and preparation-rebuild transitions explicit
- repair the directly composed `track-completion` recovery command examples
- add deployment and helper-path regression coverage

## Root cause

The shared deployment topology was correct, but `curriculum-preparation` documented helper paths that do not resolve from the repository root, `curriculum-lifecycle` lacked product metadata, and several composed completion transitions omitted required CLI arguments or ordering. Existing linting did not exercise those documentation contracts.

## Impact

Agents can invoke either shared curriculum skill from any supported deployed mirror and follow executable, non-recursive handoffs without guessing helper locations, terminal goals, or the stale-preparation rebuild transition.

## Validation

- `74 passed` — focused deployment, prompt-contract, and bounded-packet tests
- `ruff check` passed on both changed Python test files
- agent-skill metadata lint passed for 18 skills
- prompt lint passed
- `npm run agents:deploy` completed; both named `SKILL.md` and `agents/openai.yaml` files matched byte-for-byte across `.claude`, `.agent`, `.agents`, `.codex`, and `.gemini`
- `lint_agent_trailer.py` passed
- OPSEC leak lint passed
- independent cross-family review: Claude Sonnet 5 `PASS`, no blocking findings

`swarm_used: true` — two bounded same-family audits plus two fresh-context forward tests were used for portability and behavior validation; the formal merge gate was satisfied separately by the Anthropic review.