### PR TITLE
fix(security): CodeQL path-injection + postcss 8.5.18

### DIFF
--- a/scripts/api/delegate_router.py
+++ b/scripts/api/delegate_router.py
@@ -35,37 +35,39 @@ def _parse_iso_datetime(value: str | None) -> datetime | None:
     return parsed.astimezone(UTC)
 
 
-def _task_state_path(task_id: str) -> Path:
+def _task_state_path(task_id: str) -> str:
     """Resolve ``task_id`` to a state JSON path under ``TASKS_DIR``.
 
-    Slash/backslash sanitization alone is not a CodeQL-recognized barrier
-    (``py/path-injection`` alert #317). Use the ``os.path.realpath`` +
-    ``startswith(root + os.sep)`` idiom that the analyzer accepts as a
-    sanitizer — same pattern as ``session_router._safe_project_path``.
-    Escapes collapse to a guaranteed-nonexistent path inside the root so
-    callers that treat missing state as ``None`` keep working.
+    CodeQL ``py/path-injection`` (#317) only treats the checked *string* as
+    sanitized when the sink is ``open(fullpath)`` — wrapping in ``Path`` and
+    calling ``read_text()`` re-taints the flow (same false-negative on
+    ``session_router``). Return the realpath string after a
+    ``startswith(root + os.sep)`` check; escapes collapse to a guaranteed-
+    nonexistent path inside the root so missing-state callers keep working.
     """
     safe = task_id.replace("/", "_").replace("\\", "_")
     root = os.path.realpath(str(TASKS_DIR))
-    candidate = os.path.realpath(os.path.join(root, f"{safe}.json"))
-    if not candidate.startswith(root + os.sep):
-        candidate = os.path.join(root, "__rejected__.json")
-    return Path(candidate)
+    fullpath = os.path.realpath(os.path.join(root, f"{safe}.json"))
+    if not fullpath.startswith(root + os.sep):
+        fullpath = os.path.join(root, "__rejected__.json")
+    return fullpath
 
 
-def _safe_result_path(result_file: str) -> Path | None:
+def _safe_result_path(result_file: str) -> str | None:
     """Allow result reads only under ``TASKS_DIR`` (delegate writes ``.result`` siblings)."""
     root = os.path.realpath(str(TASKS_DIR))
-    candidate = os.path.realpath(result_file)
-    if not candidate.startswith(root + os.sep):
+    fullpath = os.path.realpath(result_file)
+    if not fullpath.startswith(root + os.sep):
         return None
-    return Path(candidate)
+    return fullpath
 
 
-def _read_task_state(path: Path) -> dict[str, Any] | None:
+def _read_task_state(path: str) -> dict[str, Any] | None:
     for attempt in range(TASK_READ_RETRIES):
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
+            # ``open`` on the containment-checked string is the CodeQL-recognized sink form.
+            with open(path, encoding="utf-8") as handle:
+                data = json.loads(handle.read())
         except (OSError, json.JSONDecodeError):
             if attempt + 1 == TASK_READ_RETRIES:
                 return None
@@ -109,7 +111,7 @@ def _delegate_task_rows(statuses: set[str] | None = None) -> list[dict[str, Any]
     rows: list[dict[str, Any]] = []
     if TASKS_DIR.exists():
         for path in sorted(TASKS_DIR.glob("*.json")):
-            task = _read_task_state(path)
+            task = _read_task_state(str(path))
             if task is None:
                 continue
             derived_status, alive = _derived_task_status(task)

--- a/scripts/api/delegate_router.py
+++ b/scripts/api/delegate_router.py
@@ -35,38 +35,35 @@ def _parse_iso_datetime(value: str | None) -> datetime | None:
     return parsed.astimezone(UTC)
 
 
+def _tasks_root() -> str:
+    return os.path.realpath(str(TASKS_DIR))
+
+
 def _task_state_path(task_id: str) -> str:
     """Resolve ``task_id`` to a state JSON path under ``TASKS_DIR``.
 
-    CodeQL ``py/path-injection`` (#317) only treats the checked *string* as
-    sanitized when the sink is ``open(fullpath)`` — wrapping in ``Path`` and
-    calling ``read_text()`` re-taints the flow (same false-negative on
-    ``session_router``). Return the realpath string after a
-    ``startswith(root + os.sep)`` check; escapes collapse to a guaranteed-
-    nonexistent path inside the root so missing-state callers keep working.
+    Slash/backslash sanitization alone is not enough. Callers that ``open``
+    must re-check ``startswith(root + os.sep)`` in the *same* function as the
+    sink — CodeQL does not treat a previously returned path as sanitized
+    (#317). Escapes collapse to a guaranteed-nonexistent path inside the root.
     """
     safe = task_id.replace("/", "_").replace("\\", "_")
-    root = os.path.realpath(str(TASKS_DIR))
+    root = _tasks_root()
     fullpath = os.path.realpath(os.path.join(root, f"{safe}.json"))
     if not fullpath.startswith(root + os.sep):
         fullpath = os.path.join(root, "__rejected__.json")
     return fullpath
 
 
-def _safe_result_path(result_file: str) -> str | None:
-    """Allow result reads only under ``TASKS_DIR`` (delegate writes ``.result`` siblings)."""
-    root = os.path.realpath(str(TASKS_DIR))
-    fullpath = os.path.realpath(result_file)
+def _read_task_state(path: str) -> dict[str, Any] | None:
+    """Read task JSON only after a local containment check (CodeQL sink guard)."""
+    root = _tasks_root()
+    fullpath = os.path.realpath(path)
     if not fullpath.startswith(root + os.sep):
         return None
-    return fullpath
-
-
-def _read_task_state(path: str) -> dict[str, Any] | None:
     for attempt in range(TASK_READ_RETRIES):
         try:
-            # ``open`` on the containment-checked string is the CodeQL-recognized sink form.
-            with open(path, encoding="utf-8") as handle:
+            with open(fullpath, encoding="utf-8") as handle:
                 data = json.loads(handle.read())
         except (OSError, json.JSONDecodeError):
             if attempt + 1 == TASK_READ_RETRIES:
@@ -75,6 +72,19 @@ def _read_task_state(path: str) -> dict[str, Any] | None:
             continue
         return data if isinstance(data, dict) else None
     return None
+
+
+def _read_result_file(result_file: str) -> str | None:
+    """Read a ``.result`` sibling under ``TASKS_DIR`` (check + open colocated)."""
+    root = _tasks_root()
+    fullpath = os.path.realpath(result_file)
+    if not fullpath.startswith(root + os.sep):
+        return None
+    try:
+        with open(fullpath, encoding="utf-8") as handle:
+            return handle.read(RESULT_BYTES_LIMIT + 1)
+    except OSError:
+        return None
 
 
 def _pid_alive(pid: int | None) -> bool:
@@ -159,17 +169,12 @@ def get_delegate_task_detail(task_id: str) -> tuple[dict[str, Any] | None, dict[
     truncated = False
     if task.get("status") != "running":
         result_file = task.get("result_file")
-        safe_result = _safe_result_path(str(result_file)) if result_file else None
-        if safe_result is not None:
-            try:
-                with open(safe_result, encoding="utf-8") as handle:
-                    result_text = handle.read(RESULT_BYTES_LIMIT + 1)
-                if result_text is not None and len(result_text.encode("utf-8")) > RESULT_BYTES_LIMIT:
-                    while len(result_text.encode("utf-8")) > RESULT_BYTES_LIMIT:
-                        result_text = result_text[:-1]
-                    truncated = True
-            except OSError:
-                result_text = None
+        if result_file:
+            result_text = _read_result_file(str(result_file))
+            if result_text is not None and len(result_text.encode("utf-8")) > RESULT_BYTES_LIMIT:
+                while len(result_text.encode("utf-8")) > RESULT_BYTES_LIMIT:
+                    result_text = result_text[:-1]
+                truncated = True
 
     return task, {
         "task": task,

--- a/scripts/api/hramatka_router.py
+++ b/scripts/api/hramatka_router.py
@@ -247,8 +247,13 @@ def _load_support_schema() -> dict[str, Any]:
     return json.loads(LESSON_SUPPORT_SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
-def _support_path(lesson_id: UUID) -> Path:
-    return SUPPORT_DIR / f"{lesson_id}.json"
+def _support_path(lesson_id: UUID) -> str:
+    """Resolve support sidecar path under ``SUPPORT_DIR`` (CodeQL-safe string)."""
+    root = os.path.realpath(str(SUPPORT_DIR))
+    fullpath = os.path.realpath(os.path.join(root, f"{lesson_id}.json"))
+    if not fullpath.startswith(root + os.sep):
+        raise HTTPException(status_code=400, detail="invalid lesson support path")
+    return fullpath
 
 
 @router.get("/lessons/{lesson_id}/support")
@@ -264,7 +269,8 @@ def lesson_support(lesson_id: UUID, x_hramatka_owner: str = Header(...)) -> dict
         raise HTTPException(status_code=409, detail="lesson is not ready")
 
     try:
-        sidecar = json.loads(_support_path(lesson_id).read_text(encoding="utf-8"))
+        with open(_support_path(lesson_id), encoding="utf-8") as handle:
+            sidecar = json.loads(handle.read())
         errors = list(Draft7Validator(_load_support_schema()).iter_errors(sidecar))
     except (OSError, json.JSONDecodeError) as exc:
         raise HTTPException(status_code=503, detail="lesson support unavailable") from exc

--- a/scripts/api/hramatka_router.py
+++ b/scripts/api/hramatka_router.py
@@ -247,15 +247,6 @@ def _load_support_schema() -> dict[str, Any]:
     return json.loads(LESSON_SUPPORT_SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
-def _support_path(lesson_id: UUID) -> str:
-    """Resolve support sidecar path under ``SUPPORT_DIR`` (CodeQL-safe string)."""
-    root = os.path.realpath(str(SUPPORT_DIR))
-    fullpath = os.path.realpath(os.path.join(root, f"{lesson_id}.json"))
-    if not fullpath.startswith(root + os.sep):
-        raise HTTPException(status_code=400, detail="invalid lesson support path")
-    return fullpath
-
-
 @router.get("/lessons/{lesson_id}/support")
 def lesson_support(lesson_id: UUID, x_hramatka_owner: str = Header(...)) -> dict[str, Any]:
     """Return a schema-valid sidecar only after the corresponding job is ready."""
@@ -269,7 +260,12 @@ def lesson_support(lesson_id: UUID, x_hramatka_owner: str = Header(...)) -> dict
         raise HTTPException(status_code=409, detail="lesson is not ready")
 
     try:
-        with open(_support_path(lesson_id), encoding="utf-8") as handle:
+        # Containment check must sit in the same function as ``open`` for CodeQL (#319).
+        root = os.path.realpath(str(SUPPORT_DIR))
+        fullpath = os.path.realpath(os.path.join(root, f"{lesson_id}.json"))
+        if not fullpath.startswith(root + os.sep):
+            raise HTTPException(status_code=400, detail="invalid lesson support path")
+        with open(fullpath, encoding="utf-8") as handle:
             sidecar = json.loads(handle.read())
         errors = list(Draft7Validator(_load_support_schema()).iter_errors(sidecar))
     except (OSError, json.JSONDecodeError) as exc:

--- a/scripts/research/consumption.py
+++ b/scripts/research/consumption.py
@@ -163,8 +163,9 @@ def _persist_200_evidence(task_id: str, research_id: str, etag: str) -> None:
             evidence = {}
         evidence[research_id] = etag
         state[_EVIDENCE_FIELD] = evidence
-        tmp = path.with_suffix(f".json.tmp.{os.getpid()}")
-        tmp.write_text(json.dumps(state, indent=2, default=str))
+        tmp = f"{path}.tmp.{os.getpid()}"
+        with open(tmp, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(state, indent=2, default=str))
         os.replace(tmp, path)
     except Exception:
         pass

--- a/scripts/research/consumption.py
+++ b/scripts/research/consumption.py
@@ -152,9 +152,12 @@ def _persist_200_evidence(task_id: str, research_id: str, etag: str) -> None:
     for this record isn't attributable, which is the safe (fail-closed) direction.
     """
     try:
-        from scripts.api.delegate_router import _read_task_state, _task_state_path
+        from scripts.api.delegate_router import TASKS_DIR, _read_task_state, _task_state_path
 
-        path = _task_state_path(task_id)
+        root = os.path.realpath(str(TASKS_DIR))
+        path = os.path.realpath(_task_state_path(task_id))
+        if not path.startswith(root + os.sep):
+            return
         state = _read_task_state(path)
         if not isinstance(state, dict):
             return
@@ -163,7 +166,10 @@ def _persist_200_evidence(task_id: str, research_id: str, etag: str) -> None:
             evidence = {}
         evidence[research_id] = etag
         state[_EVIDENCE_FIELD] = evidence
-        tmp = f"{path}.tmp.{os.getpid()}"
+        # Re-check tmp under the same root — concat alone does not sanitize for CodeQL.
+        tmp = os.path.realpath(f"{path}.tmp.{os.getpid()}")
+        if not tmp.startswith(root + os.sep):
+            return
         with open(tmp, "w", encoding="utf-8") as handle:
             handle.write(json.dumps(state, indent=2, default=str))
         os.replace(tmp, path)

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8011,9 +8011,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/site/package.json
+++ b/site/package.json
@@ -62,7 +62,8 @@
     "esbuild": ">=0.28.1",
     "vite": ">=8.0.13",
     "js-yaml": "^4.3.0",
-    "markdown-it": ">=14.2.0"
+    "markdown-it": ">=14.2.0",
+    "postcss": "8.5.18"
   },
   "allowScripts": {
     "better-sqlite3@12.11.1": true,

--- a/tests/api/test_delegate_active.py
+++ b/tests/api/test_delegate_active.py
@@ -172,18 +172,28 @@ def test_delegate_active_retries_transient_invalid_json(tmp_path, monkeypatch):
     monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
     _write_task(task_path, _task_payload("running", status="running", pid=111))
 
-    original_read_text = Path.read_text
+    # _read_task_state opens via builtins.open (CodeQL sink-colocated guard),
+    # not Path.read_text — patch the real sink.
+    import builtins
+    from io import StringIO
+
+    original_open = builtins.open
     read_attempts = 0
     retry_delays = []
+    target = task_path.resolve()
 
-    def flaky_read_text(path: Path, *args, **kwargs) -> str:
+    def flaky_open(file, *args, **kwargs):
         nonlocal read_attempts
-        if path == task_path and read_attempts == 0:
+        try:
+            opened = Path(file).resolve()
+        except OSError:
+            opened = None
+        if opened == target and read_attempts == 0:
             read_attempts += 1
-            return "{"
-        return original_read_text(path, *args, **kwargs)
+            return StringIO("{")
+        return original_open(file, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+    monkeypatch.setattr(builtins, "open", flaky_open)
     monkeypatch.setattr(delegate_router.time, "sleep", retry_delays.append)
     monkeypatch.setattr(delegate_router.os, "kill", lambda pid, sig: None)
 

--- a/tests/test_delegate_api.py
+++ b/tests/test_delegate_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
@@ -123,7 +124,7 @@ def test_task_state_path_stays_under_tasks_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
 
     for task_id in ("normal", "agent/task", "../../etc/passwd", r"..\..\windows"):
-        path = delegate_router._task_state_path(task_id)
+        path = Path(delegate_router._task_state_path(task_id))
         resolved = path.resolve()
         assert resolved == tasks_dir.resolve() / resolved.name
         assert resolved.is_relative_to(tasks_dir.resolve())


### PR DESCRIPTION
## Summary
- Clear CodeQL `py/path-injection` #317 (`delegate_router`) and #319 (`hramatka_router`) by returning containment-checked path strings and using `open()` (CodeQL does not treat `Path.read_text()` as using the sanitized value).
- Pin `postcss` to `8.5.18` via npm overrides for Dependabot #235 (GHSA-r28c-9q8g-f849).

## Test plan
- [x] `pytest tests/test_delegate_api.py tests/api/test_hramatka_router.py` — 15 passed
- [ ] CI green + CodeQL python on PR shows no path-injection on these sinks
- [ ] Alerts #317, #319, Dependabot #235 close after merge

Made with [Cursor](https://cursor.com)