### PR TITLE
docs(decisions): rescue ADR-015 from gitignored .claude/ deploy target

### DIFF
--- a/docs/decisions/2026-07-24-adr-015-google-drive-sync-and-custom-sets.md
+++ b/docs/decisions/2026-07-24-adr-015-google-drive-sync-and-custom-sets.md
@@ -1,0 +1,60 @@
+# ADR-015: Google Drive AppData Sync & Custom Decks Architecture
+
+**Date**: 2026-07-24  
+**Status**: APPROVED (Unanimous Sol `gpt-5.6-sol` & Fable `claude-fable-5` Verdict)  
+**Track**: Practice Hub / Lexicon Frontend Infrastructure  
+
+---
+
+## 1. Context & Motivation
+
+Learners require:
+1. **Teacher Lesson Collection (610+440 Words)**: A built-in, dedicated practice set for private teacher-lesson intake words without duplicating database state.
+2. **Custom Special Decks**: The ability to build, name, edit, and practice custom vocabulary sets.
+3. **Cross-Device Progress Sync**: A zero-backend method to synchronize SRS review history and custom sets across personal devices without requiring centralized user accounts, servers, or commercial cloud databases.
+
+---
+
+## 2. Decided Architecture
+
+### A. Decoupled Built-In Virtual Special Deck
+- The **Teacher Lesson Collection (1,050 words)** is rendered as a **virtual, read-only deck (`virtual_teacher_lesson`)**.
+- Derived dynamically from `site/src/data/lexicon-manifest.json` entries where `sources` includes `"teacher_lesson"`.
+- Adds **0 KB** of user storage and updates automatically whenever new promotion passes merge into the Word Atlas.
+
+### B. Local-First IndexedDB Core
+- IndexedDB database (`learn_ukrainian_db`) serves as the primary local source of truth.
+- App remains **100% functional offline** without Google login.
+
+```typescript
+export interface CustomSet {
+  id: string;             // UUID v4
+  title: string;
+  description?: string;
+  lemma_keys: string[];   // References to Lexicon manifest lemmas
+  created_at: string;     // ISO timestamp
+  updated_at: string;     // ISO timestamp
+  deleted_at?: string;    // Deletion tombstone for 3-way sync
+  device_id: string;
+  revision: number;
+}
+```
+
+### C. Zero-Backend Google Drive AppData Sync
+- **Scope**: `https://www.googleapis.com/auth/drive.appdata` (Restricted app-isolated hidden directory).
+- **Security Assessment**: Non-sensitive / basic OAuth verification. No backend proxy or server required.
+- **Privacy**: The app cannot read, view, or modify any user personal files or documents outside its hidden app directory.
+- **Engine**: Zero bundled libraries (0 KB impact). Lazy-loads Google Identity Services (`gsi/client`) and executes direct browser `fetch()` calls against Google Drive API v3 REST endpoints (`https://www.googleapis.com/drive/v3/files?spaces=appDataFolder`).
+- **Token Hygiene**: Access tokens are kept strictly in volatile JS memory.
+- **Account Isolation**: Local IndexedDB database is bound to the Google account `sub` claim.
+
+### D. Monotonic Progress & 3-Way Tombstone Sync
+- **Progress Sync**: SRS review history is synchronized as an append-only event log (`event_id`, `lemma_key`, `timestamp`, `grade`), from which SRS interval/ease states are derived deterministically.
+- **Custom Sets Sync**: Three-way merge with `deleted_at` tombstones to prevent deck resurrection and handle multi-device creation seamlessly.
+
+---
+
+## 3. Approval Ledger
+
+- **Sol (`gpt-5.6-sol`)**: Approved (Conditional GO satisfied with 3-way tombstones, event-log SRS sync, and virtual special set).
+- **Fable (`claude-fable-5`)**: Approved (GO with GIS token memory hygiene and zero-dependency fetch engine).


### PR DESCRIPTION
## Problem

ADR-015 (*Google Drive AppData Sync & Custom Decks Architecture* — status **APPROVED**, unanimous `gpt-5.6-sol` + `claude-fable-5` verdict, dated 2026-07-24) was written to **`.claude/2026-07-24-adr-015-google-drive-sync-and-custom-sets.md`**.

`.claude/` is a **gitignored deploy target** (CLAUDE.md critical rule 1: never write there; source is `agents_extensions/shared/`). Two consequences:

1. **The approved decision was invisible to git** — one `agents:deploy` with a widened `--delete` scope, or one machine change, and an advisor-approved architecture decision is gone with no trace.
2. **It froze the fleet-wide agent-prompt deploy.** `npm run agents:deploy` aborts on its orphan-path preflight guard, so *no* agent prompt/skill/hook change could deploy while this file sat there.

## Fix

File it in its canonical home, `docs/decisions/`, alongside its siblings (e.g. `2026-05-05-adr-008-…md`). Content is byte-identical — this is pure relocation into version control.

Root-cause fix rather than symptom fix: the guard offers "add it to `ORPHAN_PATHS_*`" as an escape hatch, which would have unblocked the deploy while blessing an approved ADR living permanently in a gitignored directory. Rejected.

## Verification

- `docs/decisions/` confirmed as the ADR home (ADR-008 sibling present).
- `scripts/check_decisions.py` → `6 active, 11 total (budget: 50) · No stale decisions.`
- Docs-only change (`*.md` outside rules dirs), so no pytest mapping applies per the repo's docs-only rule.

## Follow-ups filed separately

- Stale deployed agent prompts (6 files drift `agents_extensions/shared/` → `.claude/`), including `agents/infra-orchestrator.md` still carrying the pre-#5704 `devops → claude-infra` aliasing. Deploy was blocked by the above; runs once this lands.
- `guard-primary-checkout-write.py` does not shell-expand `$VAR` in `git -C "$W" …`, so a correctly-targeted worktree write is misclassified as a primary-checkout write and blocked. Literal paths work.

X-Agent: claude-devops

🤖 Generated with [Claude Code](https://claude.com/claude-code)