### PR TITLE
ci: cut GitHub Actions runner-slot fan-out to fix CI starvation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,6 +14,10 @@ name: actionlint
 # check). The pinned version + checksums live in scripts/audit/check_workflows.sh,
 # which both this job and local devs invoke (single source of truth).
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,21 +741,6 @@ jobs:
             -v --tb=short --junitxml=ci-artifacts/cache-junit.xml || status=$?
           set -o pipefail
           .venv/bin/python -m pytest tests/ -v --tb=short -k "not slow and not website" \
-            --ignore=tests/test_rag.py \
-            --ignore=tests/test_a1_review_scores.py \
-            --ignore=tests/test_agent_runtime.py \
-            --ignore=tests/test_channels_registry.py \
-            --ignore=tests/test_convergence_loop.py \
-            --ignore=tests/test_morphological_validator.py \
-            --ignore=tests/test_plan_hash.py \
-            --ignore=tests/test_scrape_diasporiana.py \
-            --ignore=tests/test_v6_plan_hash_drift.py \
-            --ignore=tests/test_vocab_gen.py \
-            --ignore=tests/test_wiki_channels.py \
-            --ignore=tests/test_wiki_enrichment.py \
-            --ignore=tests/wiki/test_grade_filter.py \
-            --ignore=tests/wiki/test_mlx_fault_injection.py \
-            --ignore=tests/wiki/test_t1_t2_pipeline.py \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
             --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
@@ -787,21 +772,6 @@ jobs:
             -v --tb=short --junitxml=ci-artifacts/cache-junit.xml --cov=scripts --cov-append --cov-report= || status=$?
           set -o pipefail
           .venv/bin/python -m pytest tests/ -v --tb=short -k "not slow and not website" \
-            --ignore=tests/test_rag.py \
-            --ignore=tests/test_a1_review_scores.py \
-            --ignore=tests/test_agent_runtime.py \
-            --ignore=tests/test_channels_registry.py \
-            --ignore=tests/test_convergence_loop.py \
-            --ignore=tests/test_morphological_validator.py \
-            --ignore=tests/test_plan_hash.py \
-            --ignore=tests/test_scrape_diasporiana.py \
-            --ignore=tests/test_v6_plan_hash_drift.py \
-            --ignore=tests/test_vocab_gen.py \
-            --ignore=tests/test_wiki_channels.py \
-            --ignore=tests/test_wiki_enrichment.py \
-            --ignore=tests/wiki/test_grade_filter.py \
-            --ignore=tests/wiki/test_mlx_fault_injection.py \
-            --ignore=tests/wiki/test_t1_t2_pipeline.py \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
             --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ on:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       # code = any high-signal source/config change. Used by the broad secret scan.
       code: ${{ steps.filter.outputs.code }}
@@ -268,6 +269,7 @@ jobs:
   static-checks:
     name: Static & Agent Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: changes
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.agent_config == 'true' || needs.changes.outputs.postmortems == 'true'
     steps:
@@ -463,6 +465,7 @@ jobs:
   content-schema-checks:
     name: Content & Schema Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: changes
     permissions:
       contents: read
@@ -735,6 +738,7 @@ jobs:
   test:
     name: Test (pytest)
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     permissions:
       contents: read
       actions: write
@@ -916,6 +920,7 @@ jobs:
   frontend:
     name: Frontend (build + vitest)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       actions: write
@@ -975,6 +980,7 @@ jobs:
   frontend-e2e:
     name: Frontend E2E (playwright)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
       actions: write
@@ -1040,6 +1046,7 @@ jobs:
   secret-scan:
     name: Secret Scanning (gitleaks)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:
@@ -1055,6 +1062,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     needs:
       - changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,13 @@ on:
       - 'docs/references/research-registry.yaml'
       - 'docs/references/research-digests/**'
       - 'schemas/research_registry.schema.json'
+  # CI/docs-only required-check note:
+  # Keep PRs unfiltered so the required `Test (pytest)` check is always emitted.
+  # Docs-only PRs otherwise leave branch protection stuck on "expected" (#1641).
+  # Earlier path widenings only fixed individual recurrences (#1544, #1546);
+  # #1644 moves the anti-whack-a-mole path list into `dorny/paths-filter`:
+  # non-required jobs skip cleanly on docs-only PRs, while `Test (pytest)`
+  # still emits the required check and skips its inner pytest body.
   pull_request:
   workflow_dispatch:
 
@@ -55,13 +62,34 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
+      # code = any high-signal source/config change. Used by the broad secret scan.
       code: ${{ steps.filter.outputs.code }}
+      # python = Python/test paths PLUS learner curriculum/site content that tests
+      # read at runtime. Gates pytest + ruff/radon/root guards. Learner bundles
+      # and site/src/content/** are INCLUDED because content-reading tests
+      # (citation_resolve, llm_qg_api, reading_coverage, reading_links, parity, ...)
+      # load those files at runtime — excluding them let a content-deletion PR
+      # (#3867) skip pytest entirely and ship a regression to main (root cause: #3873).
+      # BIO preparation-only data is excluded and routed to the focused preparation
+      # gate below; mixed PRs still match their Python or learner-content paths.
       python: ${{ steps.filter.outputs.python }}
+      # frontend = generated site inputs/outputs. Gates the build/vitest job plus
+      # MDX source/drift checks, so curriculum source edits cannot leave stale
+      # committed MDX.
       frontend: ${{ steps.filter.outputs.frontend }}
+      # agent_config = agent/MCP/prompt deployment config. Gates lightweight
+      # JSON/shell/deploy checks without forcing the full pytest suite.
       agent_config: ${{ steps.filter.outputs.agent_config }}
+      # lesson_schema = schema contract inputs. Gates only the schema drift job.
       lesson_schema: ${{ steps.filter.outputs.lesson_schema }}
+      # atlas = inputs that can stale the committed DB-enriched Word Atlas
+      # manifest but are available on CI.
       atlas: ${{ steps.filter.outputs.atlas }}
+      # postmortems = bug-autopsy docs + the checker. Gates the postmortem
+      # hygiene job so a malformed autopsy or stale INDEX cannot merge (#3725).
       postmortems: ${{ steps.filter.outputs.postmortems }}
+      # preparation = BIO source-preparation surfaces. These are plans/research
+      # evidence, not application code or learner bundles.
       preparation: ${{ steps.filter.outputs.preparation }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -107,26 +135,61 @@ jobs:
               - 'pyproject.toml'
               - 'scripts/**/*.py'
               - 'tests/**/*.py'
+              # Config with test fixture mirrors: test_model_catalog reads
+              # model_catalog.yaml + fleet_communications.yaml; a config-only edit
+              # (no .py) must run pytest, else an orchestrator_seats / model-pin
+              # regression reaches main unguarded (same #3873/#4888/#4936 class —
+              # a yaml change that skipped pytest would ship broken routing to main).
               - 'scripts/config/**'
+              # Learner content that python tests read at runtime — a deletion/edit
+              # here must run pytest, else a content regression reaches main unguarded
+              # (this is the #3873 root cause: #3867 deleted curriculum files,
+              # python filter was false, pytest skipped, 4 tests broke on main).
+              # BIO plans/discovery/promotion evidence are preparation data and
+              # take the focused `preparation` lane instead. Picomatch extglobs
+              # preserve broad coverage for all other tracks and BIO learner data.
               - 'curriculum/l2-uk-en/curriculum.yaml'
               - 'curriculum/l2-uk-en/!(plans|bio)/**'
               - 'curriculum/l2-uk-en/plans/!(bio)/**'
               - 'curriculum/l2-uk-en/bio/!(*promotion-evidence.yaml|discovery)/**'
               - 'site/src/content/**'
+              # Schema-validated committed data: pytest validates every file in
+              # this directory (test_source_inventory_review_decisions). A
+              # data-only PR here skipped pytest and turned main red for every
+              # subsequent code PR (2026-07-10, #4888 — same class as #3873).
               - 'data/lexicon/source-inventory-review-decisions/**'
+              # Same class (#4894, review-4893 sibling sweep):
+              # test_source_inventory_intake::test_committed_source_inventory_files_are_valid
+              # globs every file here — data-only edits must run pytest too.
               - 'data/lexicon/source-inventory/**'
+              # Same class again (2026-07-10, #4936 — 3rd manifestation after
+              # #3873/#4888): test_atlas_conformance reads the committed Atlas
+              # manifest; a data(atlas) publish PR skipped pytest and turned
+              # main red for every subsequent code PR.
               - 'site/src/data/lexicon-manifest.json'
               - 'site/src/data/lexicon-manifest.fingerprint.json'
+              # Research registry data (ADR-011): the P1 validator + P2–P4 tests
+              # read these committed files at runtime, so a data-only edit must
+              # run pytest/ruff (same #3873/#4888/#4936 class — a registry/digest
+              # edit that skipped pytest would ship an unvalidated content_hash or
+              # a rot-monitor regression to main).
               - 'docs/references/research-registry.yaml'
               - 'docs/references/research-digests/**'
               - 'schemas/research_registry.schema.json'
             frontend:
               - '.github/workflows/ci.yml'
               - 'site/**'
+              # BIO preparation data does not feed generated MDX or frontend code.
+              # Keep learner bundles and every non-BIO preparation surface covered.
               - 'curriculum/l2-uk-en/curriculum.yaml'
               - 'curriculum/l2-uk-en/!(plans|bio)/**'
               - 'curriculum/l2-uk-en/plans/!(bio)/**'
               - 'curriculum/l2-uk-en/bio/!(*promotion-evidence.yaml|discovery)/**'
+              # MDX generator entry + package (mdx-generation-drift invokes
+              # scripts/generate_mdx.py; mdx-source-parity treats package edits
+              # as generator changes). Missing these let generator-only PRs skip
+              # both drift/parity gates (#5354; class: #5351/#3873/#4888/#4936).
+              # tests/test_mdx_atlas_filter_coverage.py enforces coverage.
               - 'scripts/generate_mdx.py'
               - 'scripts/generate_mdx/**'
               - 'scripts/yaml_activities.py'
@@ -159,6 +222,10 @@ jobs:
               - 'docs/lesson-schema.yaml'
               - 'scripts/build/contracts/**/*.md'
               - 'scripts/build/generate_lesson_schema.py'
+              # Generator INPUTS (hashed into generated_from / shaping output).
+              # Missing these let drift accumulate silently on main and red
+              # unrelated ci.yml-touching PRs (#5351; class: #3873/#4888/#4936).
+              # tests/test_lesson_schema_filter_coverage.py enforces coverage.
               - 'site/src/components/**'
               - 'scripts/pipeline/config_tables.py'
               - 'scripts/build/lesson_schema_extractor.mjs'
@@ -175,9 +242,13 @@ jobs:
               - 'site/src/data/lexicon-daily-pool.json'
               - 'site/src/data/lexicon-manifest.json'
               - 'site/src/data/lexicon-manifest.fingerprint.json'
+              # hashFiles + load_manifest read the pointer; missing it let
+              # pointer-only edits skip atlas-freshness (#5354; class: #5351).
+              # tests/test_mdx_atlas_filter_coverage.py enforces coverage.
               - 'site/src/data/lexicon-manifest.pointer.json'
               - 'site/src/data/lexicon-practice-deck.pointer.json'
               - 'site/src/data/lexicon-practice-reviewed-sources.json'
+              # check_static_practice_assets.py DEFAULT_PRACTICE_DIR
               - 'site/public/lexicon/**'
               - 'site/scripts/hydrate-practice-deck.mjs'
               - 'site/scripts/hydrate-lexicon-api-shards.ts'
@@ -669,6 +740,31 @@ jobs:
       actions: write
     needs: [changes]
     if: '!cancelled()'
+    env:
+      # SINGLE SOURCE OF TRUTH for the CI-only pytest exclusions.
+      # These 15 files need corpus/model data the GitHub runner does not have —
+      # they pass on a dev machine and fail on CI, which is exactly why the list
+      # exists. It previously lived in scripts/ci/pytest_shards.py::COMMON_ARGS;
+      # when the shard planner was retired the list was inlined into BOTH the PR
+      # step and the main-push coverage step. Two copies silently drift (add an
+      # exclusion to one and main-push CI diverges from PR CI), so both steps now
+      # expand this one variable. Change the set HERE and nowhere else.
+      PYTEST_CI_IGNORES: >-
+        --ignore=tests/test_rag.py
+        --ignore=tests/test_a1_review_scores.py
+        --ignore=tests/test_agent_runtime.py
+        --ignore=tests/test_channels_registry.py
+        --ignore=tests/test_convergence_loop.py
+        --ignore=tests/test_morphological_validator.py
+        --ignore=tests/test_plan_hash.py
+        --ignore=tests/test_scrape_diasporiana.py
+        --ignore=tests/test_v6_plan_hash_drift.py
+        --ignore=tests/test_vocab_gen.py
+        --ignore=tests/test_wiki_channels.py
+        --ignore=tests/test_wiki_enrichment.py
+        --ignore=tests/wiki/test_grade_filter.py
+        --ignore=tests/wiki/test_mlx_fault_injection.py
+        --ignore=tests/wiki/test_t1_t2_pipeline.py
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: needs.changes.outputs.python == 'true'
@@ -740,22 +836,9 @@ jobs:
             tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
             -v --tb=short --junitxml=ci-artifacts/cache-junit.xml || status=$?
           set -o pipefail
+          read -ra ignore_args <<< "$PYTEST_CI_IGNORES"
           .venv/bin/python -m pytest tests/ -v --tb=short -k "not slow and not website" \
-            --ignore=tests/test_rag.py \
-            --ignore=tests/test_a1_review_scores.py \
-            --ignore=tests/test_agent_runtime.py \
-            --ignore=tests/test_channels_registry.py \
-            --ignore=tests/test_convergence_loop.py \
-            --ignore=tests/test_morphological_validator.py \
-            --ignore=tests/test_plan_hash.py \
-            --ignore=tests/test_scrape_diasporiana.py \
-            --ignore=tests/test_v6_plan_hash_drift.py \
-            --ignore=tests/test_vocab_gen.py \
-            --ignore=tests/test_wiki_channels.py \
-            --ignore=tests/test_wiki_enrichment.py \
-            --ignore=tests/wiki/test_grade_filter.py \
-            --ignore=tests/wiki/test_mlx_fault_injection.py \
-            --ignore=tests/wiki/test_t1_t2_pipeline.py \
+            "${ignore_args[@]}" \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
             --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
@@ -786,22 +869,9 @@ jobs:
             tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
             -v --tb=short --junitxml=ci-artifacts/cache-junit.xml --cov=scripts --cov-append --cov-report= || status=$?
           set -o pipefail
+          read -ra ignore_args <<< "$PYTEST_CI_IGNORES"
           .venv/bin/python -m pytest tests/ -v --tb=short -k "not slow and not website" \
-            --ignore=tests/test_rag.py \
-            --ignore=tests/test_a1_review_scores.py \
-            --ignore=tests/test_agent_runtime.py \
-            --ignore=tests/test_channels_registry.py \
-            --ignore=tests/test_convergence_loop.py \
-            --ignore=tests/test_morphological_validator.py \
-            --ignore=tests/test_plan_hash.py \
-            --ignore=tests/test_scrape_diasporiana.py \
-            --ignore=tests/test_v6_plan_hash_drift.py \
-            --ignore=tests/test_vocab_gen.py \
-            --ignore=tests/test_wiki_channels.py \
-            --ignore=tests/test_wiki_enrichment.py \
-            --ignore=tests/wiki/test_grade_filter.py \
-            --ignore=tests/wiki/test_mlx_fault_injection.py \
-            --ignore=tests/wiki/test_t1_t2_pipeline.py \
+            "${ignore_args[@]}" \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
             --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,6 +741,21 @@ jobs:
             -v --tb=short --junitxml=ci-artifacts/cache-junit.xml || status=$?
           set -o pipefail
           .venv/bin/python -m pytest tests/ -v --tb=short -k "not slow and not website" \
+            --ignore=tests/test_rag.py \
+            --ignore=tests/test_a1_review_scores.py \
+            --ignore=tests/test_agent_runtime.py \
+            --ignore=tests/test_channels_registry.py \
+            --ignore=tests/test_convergence_loop.py \
+            --ignore=tests/test_morphological_validator.py \
+            --ignore=tests/test_plan_hash.py \
+            --ignore=tests/test_scrape_diasporiana.py \
+            --ignore=tests/test_v6_plan_hash_drift.py \
+            --ignore=tests/test_vocab_gen.py \
+            --ignore=tests/test_wiki_channels.py \
+            --ignore=tests/test_wiki_enrichment.py \
+            --ignore=tests/wiki/test_grade_filter.py \
+            --ignore=tests/wiki/test_mlx_fault_injection.py \
+            --ignore=tests/wiki/test_t1_t2_pipeline.py \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
             --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
@@ -772,6 +787,21 @@ jobs:
             -v --tb=short --junitxml=ci-artifacts/cache-junit.xml --cov=scripts --cov-append --cov-report= || status=$?
           set -o pipefail
           .venv/bin/python -m pytest tests/ -v --tb=short -k "not slow and not website" \
+            --ignore=tests/test_rag.py \
+            --ignore=tests/test_a1_review_scores.py \
+            --ignore=tests/test_agent_runtime.py \
+            --ignore=tests/test_channels_registry.py \
+            --ignore=tests/test_convergence_loop.py \
+            --ignore=tests/test_morphological_validator.py \
+            --ignore=tests/test_plan_hash.py \
+            --ignore=tests/test_scrape_diasporiana.py \
+            --ignore=tests/test_v6_plan_hash_drift.py \
+            --ignore=tests/test_vocab_gen.py \
+            --ignore=tests/test_wiki_channels.py \
+            --ignore=tests/test_wiki_enrichment.py \
+            --ignore=tests/wiki/test_grade_filter.py \
+            --ignore=tests/wiki/test_mlx_fault_injection.py \
+            --ignore=tests/wiki/test_t1_t2_pipeline.py \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
             --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
             --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,6 @@ on:
       - 'docs/references/research-registry.yaml'
       - 'docs/references/research-digests/**'
       - 'schemas/research_registry.schema.json'
-  # CI/docs-only required-check note:
-  # Keep PRs unfiltered so the required `Test (pytest)` check is always emitted.
-  # Docs-only PRs otherwise leave branch protection stuck on "expected" (#1641).
-  # Earlier path widenings only fixed individual recurrences (#1544, #1546);
-  # #1644 moves the anti-whack-a-mole path list into `dorny/paths-filter`:
-  # non-required jobs skip cleanly on docs-only PRs, while `Test (pytest)`
-  # still emits the required check and skips its inner pytest body.
   pull_request:
   workflow_dispatch:
 
@@ -62,34 +55,13 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      # code = any high-signal source/config change. Used by the broad secret scan.
       code: ${{ steps.filter.outputs.code }}
-      # python = Python/test paths PLUS learner curriculum/site content that tests
-      # read at runtime. Gates pytest + ruff/radon/root guards. Learner bundles
-      # and site/src/content/** are INCLUDED because content-reading tests
-      # (citation_resolve, llm_qg_api, reading_coverage, reading_links, parity, ...)
-      # load those files at runtime — excluding them let a content-deletion PR
-      # (#3867) skip pytest entirely and ship a regression to main (root cause: #3873).
-      # BIO preparation-only data is excluded and routed to the focused preparation
-      # gate below; mixed PRs still match their Python or learner-content paths.
       python: ${{ steps.filter.outputs.python }}
-      # frontend = generated site inputs/outputs. Gates the build/vitest job plus
-      # MDX source/drift checks, so curriculum source edits cannot leave stale
-      # committed MDX.
       frontend: ${{ steps.filter.outputs.frontend }}
-      # agent_config = agent/MCP/prompt deployment config. Gates lightweight
-      # JSON/shell/deploy checks without forcing the full pytest suite.
       agent_config: ${{ steps.filter.outputs.agent_config }}
-      # lesson_schema = schema contract inputs. Gates only the schema drift job.
       lesson_schema: ${{ steps.filter.outputs.lesson_schema }}
-      # atlas = inputs that can stale the committed DB-enriched Word Atlas
-      # manifest but are available on CI.
       atlas: ${{ steps.filter.outputs.atlas }}
-      # postmortems = bug-autopsy docs + the checker. Gates the postmortem
-      # hygiene job so a malformed autopsy or stale INDEX cannot merge (#3725).
       postmortems: ${{ steps.filter.outputs.postmortems }}
-      # preparation = BIO source-preparation surfaces. These are plans/research
-      # evidence, not application code or learner bundles.
       preparation: ${{ steps.filter.outputs.preparation }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -135,61 +107,26 @@ jobs:
               - 'pyproject.toml'
               - 'scripts/**/*.py'
               - 'tests/**/*.py'
-              # Config with test fixture mirrors: test_model_catalog reads
-              # model_catalog.yaml + fleet_communications.yaml; a config-only edit
-              # (no .py) must run pytest, else an orchestrator_seats / model-pin
-              # regression reaches main unguarded (same #3873/#4888/#4936 class —
-              # a yaml change that skipped pytest would ship broken routing to main).
               - 'scripts/config/**'
-              # Learner content that python tests read at runtime — a deletion/edit
-              # here must run pytest, else a content regression reaches main unguarded
-              # (this is the #3873 root cause: #3867 deleted curriculum files,
-              # python filter was false, pytest skipped, 4 tests broke on main).
-              # BIO plans/discovery/promotion evidence are preparation data and
-              # take the focused `preparation` lane instead. Picomatch extglobs
-              # preserve broad coverage for all other tracks and BIO learner data.
               - 'curriculum/l2-uk-en/curriculum.yaml'
               - 'curriculum/l2-uk-en/!(plans|bio)/**'
               - 'curriculum/l2-uk-en/plans/!(bio)/**'
               - 'curriculum/l2-uk-en/bio/!(*promotion-evidence.yaml|discovery)/**'
               - 'site/src/content/**'
-              # Schema-validated committed data: pytest validates every file in
-              # this directory (test_source_inventory_review_decisions). A
-              # data-only PR here skipped pytest and turned main red for every
-              # subsequent code PR (2026-07-10, #4888 — same class as #3873).
               - 'data/lexicon/source-inventory-review-decisions/**'
-              # Same class (#4894, review-4893 sibling sweep):
-              # test_source_inventory_intake::test_committed_source_inventory_files_are_valid
-              # globs every file here — data-only edits must run pytest too.
               - 'data/lexicon/source-inventory/**'
-              # Same class again (2026-07-10, #4936 — 3rd manifestation after
-              # #3873/#4888): test_atlas_conformance reads the committed Atlas
-              # manifest; a data(atlas) publish PR skipped pytest and turned
-              # main red for every subsequent code PR.
               - 'site/src/data/lexicon-manifest.json'
               - 'site/src/data/lexicon-manifest.fingerprint.json'
-              # Research registry data (ADR-011): the P1 validator + P2–P4 tests
-              # read these committed files at runtime, so a data-only edit must
-              # run pytest/ruff (same #3873/#4888/#4936 class — a registry/digest
-              # edit that skipped pytest would ship an unvalidated content_hash or
-              # a rot-monitor regression to main).
               - 'docs/references/research-registry.yaml'
               - 'docs/references/research-digests/**'
               - 'schemas/research_registry.schema.json'
             frontend:
               - '.github/workflows/ci.yml'
               - 'site/**'
-              # BIO preparation data does not feed generated MDX or frontend code.
-              # Keep learner bundles and every non-BIO preparation surface covered.
               - 'curriculum/l2-uk-en/curriculum.yaml'
               - 'curriculum/l2-uk-en/!(plans|bio)/**'
               - 'curriculum/l2-uk-en/plans/!(bio)/**'
               - 'curriculum/l2-uk-en/bio/!(*promotion-evidence.yaml|discovery)/**'
-              # MDX generator entry + package (mdx-generation-drift invokes
-              # scripts/generate_mdx.py; mdx-source-parity treats package edits
-              # as generator changes). Missing these let generator-only PRs skip
-              # both drift/parity gates (#5354; class: #5351/#3873/#4888/#4936).
-              # tests/test_mdx_atlas_filter_coverage.py enforces coverage.
               - 'scripts/generate_mdx.py'
               - 'scripts/generate_mdx/**'
               - 'scripts/yaml_activities.py'
@@ -222,10 +159,6 @@ jobs:
               - 'docs/lesson-schema.yaml'
               - 'scripts/build/contracts/**/*.md'
               - 'scripts/build/generate_lesson_schema.py'
-              # Generator INPUTS (hashed into generated_from / shaping output).
-              # Missing these let drift accumulate silently on main and red
-              # unrelated ci.yml-touching PRs (#5351; class: #3873/#4888/#4936).
-              # tests/test_lesson_schema_filter_coverage.py enforces coverage.
               - 'site/src/components/**'
               - 'scripts/pipeline/config_tables.py'
               - 'scripts/build/lesson_schema_extractor.mjs'
@@ -242,13 +175,9 @@ jobs:
               - 'site/src/data/lexicon-daily-pool.json'
               - 'site/src/data/lexicon-manifest.json'
               - 'site/src/data/lexicon-manifest.fingerprint.json'
-              # hashFiles + load_manifest read the pointer; missing it let
-              # pointer-only edits skip atlas-freshness (#5354; class: #5351).
-              # tests/test_mdx_atlas_filter_coverage.py enforces coverage.
               - 'site/src/data/lexicon-manifest.pointer.json'
               - 'site/src/data/lexicon-practice-deck.pointer.json'
               - 'site/src/data/lexicon-practice-reviewed-sources.json'
-              # check_static_practice_assets.py DEFAULT_PRACTICE_DIR
               - 'site/public/lexicon/**'
               - 'site/scripts/hydrate-practice-deck.mjs'
               - 'site/scripts/hydrate-lexicon-api-shards.ts'
@@ -265,11 +194,11 @@ jobs:
               - 'wiki/figures/*.md'
               - 'wiki/figures/*.sources.yaml'
 
-  bio-preparation-data:
-    name: BIO Preparation Data
+  static-checks:
+    name: Static & Agent Checks
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.preparation == 'true'
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.agent_config == 'true' || needs.changes.outputs.postmortems == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -280,26 +209,253 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install preparation validator dependencies
+      - name: Install static check dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install ruff radon PyYAML pytest
+
+      - name: Run ruff
+        if: needs.changes.outputs.python == 'true'
+        run: .venv/bin/ruff check scripts/
+
+      - name: Collect changed scripts for radon
+        if: needs.changes.outputs.python == 'true'
+        id: changed-scripts
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            base_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+          else
+            echo "ℹ️ Skipping changed-file collection on ${{ github.event_name }}"
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git merge-base origin/main "$head_sha")"
+          fi
+
+          mapfile -t changed_files < <(
+            git diff --name-only --diff-filter=AMR "$base_sha" "$head_sha" -- \
+              | rg '^scripts/.*\.py$' \
+              | rg -v '^scripts/(oneoff|retired)/'
+          )
+
+          if ((${#changed_files[@]} == 0)); then
+            echo "✅ No changed Python files under scripts/."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          printf 'Checking radon only on changed files:\n'
+          printf '  %s\n' "${changed_files[@]}"
+          {
+            echo 'files<<EOF'
+            printf '%s\n' "${changed_files[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: No F-grade functions in changed files (CC > 40)
+        if: needs.changes.outputs.python == 'true' && steps.changed-scripts.outputs.files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changed-scripts.outputs.files }}
+        run: |
+          mapfile -t files <<< "$CHANGED_FILES"
+          output=$(.venv/bin/python -m radon cc "${files[@]}" -n F -s 2>/dev/null || true)
+          if [ -n "$output" ]; then
+            echo "::error::F-grade functions found:"
+            echo "$output"
+            exit 1
+          fi
+          echo "✅ No F-grade functions in changed files"
+
+      - name: No MI=C files in changed files (MI < 10)
+        if: needs.changes.outputs.python == 'true' && steps.changed-scripts.outputs.files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changed-scripts.outputs.files }}
+        run: |
+          mapfile -t files <<< "$CHANGED_FILES"
+          output=$(.venv/bin/python -m radon mi "${files[@]}" -s 2>/dev/null | grep " - C " || true)
+          if [ -n "$output" ]; then
+            echo "::error::MI=C files found:"
+            echo "$output"
+            exit 1
+          fi
+          echo "✅ No MI=C files in changed files"
+
+      - name: Check for non-stub scripts in scripts/ root
+        if: needs.changes.outputs.python == 'true'
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            base_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+          else
+            echo "ℹ️ Skipping root-script diff on ${{ github.event_name }}"
+            exit 0
+          fi
+
+          if [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git merge-base origin/main "$head_sha")"
+          fi
+
+          if [[ -z "$base_sha" ]]; then
+            echo "::error::Unable to determine the comparison base for scripts/ root guard."
+            exit 1
+          fi
+
+          allowed="__init__.py|batch_gemini_runner.py|config.py|generate_mdx.py|manifest_direct.py|manifest_utils.py|paths.py|pipeline_lib.py|slug_utils.py|yaml_activities.py"
+          violations=""
+
+          mapfile -t candidates < <(
+            git diff --name-only --diff-filter=AR "$base_sha" "$head_sha" -- scripts \
+              | while IFS= read -r f; do
+                  if [[ "$(dirname "$f")" == "scripts" && "$f" == *.py ]]; then
+                    printf '%s\n' "$f"
+                  fi
+                done
+          )
+
+          for f in "${candidates[@]}"; do
+            [ ! -f "$f" ] && continue
+            basename=$(basename "$f")
+            echo "$basename" | grep -qE "^($allowed)$" && continue
+            grep -q "Stub: module moved" "$f" && continue
+            violations="$violations $f"
+          done
+          if [ -n "$violations" ]; then
+            echo "::error::New non-stub scripts found in scripts/ root (move to a subdirectory):"
+            echo "$violations" | tr ' ' '\n' | grep .
+            exit 1
+          fi
+          echo "✅ No new root-level scripts"
+
+      - name: Lint prompt templates
+        if: needs.changes.outputs.python == 'true' || needs.changes.outputs.agent_config == 'true'
+        run: .venv/bin/python scripts/lint/lint_prompts.py
+
+      - name: Validate bug-autopsy fields + INDEX freshness (#3725)
+        if: needs.changes.outputs.postmortems == 'true'
+        run: .venv/bin/python scripts/audit/check_postmortems.py --check
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        if: needs.changes.outputs.agent_config == 'true'
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Validate agent JSON config
+        if: needs.changes.outputs.agent_config == 'true'
+        run: |
+          jq empty \
+            .mcp.json \
+            .cursor/mcp.json \
+            agents_extensions/shared/settings.json
+          if [[ -f agents_extensions/shared/settings.local.json ]]; then
+            jq empty agents_extensions/shared/settings.local.json
+          fi
+
+      - name: Validate agent shell entrypoints
+        if: needs.changes.outputs.agent_config == 'true'
+        run: |
+          bash -n \
+            start-claude.sh \
+            start-claudex.sh \
+            start-kimicc.sh \
+            start-codex.sh \
+            scripts/lib/handoff_identity.sh \
+            scripts/lib/claude_route_guard.sh \
+            scripts/deploy_prompts.sh \
+            scripts/check_rules_deployment.sh
+
+      - name: Verify agent extension deployment
+        if: needs.changes.outputs.agent_config == 'true'
+        run: |
+          npm run agents:deploy --silent
+          bash scripts/check_rules_deployment.sh
+
+      - name: Run focused agent config tests
+        if: needs.changes.outputs.agent_config == 'true'
+        run: |
+          .venv/bin/python -m pytest \
+            tests/test_deploy_script_idempotency.py \
+            tests/test_agent_runtime_tool_config.py \
+            -v --tb=short
+
+  content-schema-checks:
+    name: Content & Schema Checks
+    runs-on: ubuntu-latest
+    needs: changes
+    permissions:
+      contents: read
+      actions: write
+    if: needs.changes.outputs.preparation == 'true' || needs.changes.outputs.atlas == 'true' || (needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request') || needs.changes.outputs.lesson_schema == 'true'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        if: needs.changes.outputs.lesson_schema == 'true'
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install content and schema dependencies
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install PyYAML jsonschema
 
+      - name: Restore Atlas lexicon manifest cache
+        if: needs.changes.outputs.atlas == 'true' || (needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request')
+        id: atlas-manifest-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: site/src/data/lexicon-manifest.json
+          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
+
+      - name: Verify Atlas manifest matches pointer (rehydrate if stale)
+        if: needs.changes.outputs.atlas == 'true' || (needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request')
+        run: |
+          .venv/bin/python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
+
+      - name: Save Atlas lexicon manifest cache
+        if: (needs.changes.outputs.atlas == 'true' || (needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request')) && steps.atlas-manifest-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: site/src/data/lexicon-manifest.json
+          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
+
       - name: Check changed BIO dossier word-count floor
+        if: needs.changes.outputs.preparation == 'true'
         run: |
           git fetch --no-tags --prune origin '+refs/heads/main:refs/remotes/origin/main'
           .venv/bin/python scripts/audit/check_dossier_wordcount.py --changed
 
       - name: Validate BIO preparation capsules and active holds
+        if: needs.changes.outputs.preparation == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           .venv/bin/python - <<'PY'
-          from pathlib import Path
           import os
           import subprocess
+          from pathlib import Path
 
           from scripts.orchestration import curriculum_readiness as readiness
           from scripts.orchestration.preparation_evidence import load_manual_evidence
@@ -435,47 +591,8 @@ jobs:
           )
           PY
 
-  atlas-freshness:
-    name: Atlas Manifest Freshness
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.atlas == 'true'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          # Full history so the diff-scoped vocab gate can diff vs origin/main (#3150).
-          fetch-depth: 0
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      - name: Restore Atlas lexicon manifest cache
-        id: atlas-manifest-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: site/src/data/lexicon-manifest.json
-          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
-
-      - name: Verify Atlas manifest matches pointer (rehydrate if stale)
-        run: |
-          python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
-
-      - name: Save Atlas lexicon manifest cache
-        if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: site/src/data/lexicon-manifest.json
-          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
-
-      - name: Install YAML parser
-        run: |
-          python -m venv .venv
-          .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install PyYAML
-
       - name: Check DB-free Atlas manifest freshness
+        if: needs.changes.outputs.atlas == 'true'
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             .venv/bin/python scripts/lexicon/check_manifest_freshness.py \
@@ -486,20 +603,12 @@ jobs:
             .venv/bin/python scripts/lexicon/check_manifest_freshness.py
           fi
 
-      # Root-cause guard for the #3631 empty-atlas regression: a manifest committed
-      # without enrichment (enrichment_generated False / ~0 enriched entries) renders
-      # an empty Atlas while the fingerprint/freshness gate above stays green. Blocks it.
       - name: Block thin/un-enriched Atlas manifest (#3658)
+        if: needs.changes.outputs.atlas == 'true'
         run: .venv/bin/python scripts/audit/check_atlas_manifest_enrichment.py
 
-      # Learner-facing static Atlas gate (#3930). ADVISORY since #4515: all
-      # three caps (gloss, anchor, thin pages) audit the LIVE release asset,
-      # not this PR's diff — regressions can only enter at publish time, where
-      # scripts/lexicon/publish_manifest.py compares all three metrics against
-      # the canonical published Release asset and raises ManifestPublishError
-      # only for a regression. Blocking here failed unrelated PRs after the fact
-      # (#4514/#4512, 2026-07-06). Kept for visibility only.
       - name: Gate Atlas POC richness and learner anchors (#3930, advisory since #4515)
+        if: needs.changes.outputs.atlas == 'true'
         continue-on-error: true
         run: |
           .venv/bin/python scripts/audit/audit_atlas_poc_richness.py \
@@ -508,451 +617,69 @@ jobs:
             --max-poc-thin-pages 900
 
       - name: Check static Word Day / practice assets (#3935)
-        run: python scripts/audit/check_static_practice_assets.py
+        if: needs.changes.outputs.atlas == 'true'
+        run: .venv/bin/python scripts/audit/check_static_practice_assets.py
 
-      # Diff-scoped + advisory (#3150): only flags modules whose vocabulary.yaml changed
-      # in THIS PR (no cross-PR coupling on the merge-train), and never blocks merge — a
-      # full manifest regen is ~33 min and the merge-train adds vocab faster than that.
-      # Blocking enforcement belongs on promote / an eventual auto-regen, not here.
       - name: Check Atlas vocabulary manifest coverage (advisory, diff-scoped)
+        if: needs.changes.outputs.atlas == 'true'
         continue-on-error: true
         run: |
           git fetch --no-tags --quiet origin main || true
           .venv/bin/python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main
 
-  lint:
-    name: Lint (ruff)
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.python == 'true'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      - name: Install ruff
-        run: pip install ruff
-
-      - name: Run ruff
-        run: ruff check scripts/
-
-  quality-gates:
-    name: Quality Gates (radon)
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: needs.changes.outputs.python == 'true'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      - name: Install radon
-        run: pip install radon
-
-      - name: Collect changed scripts for radon
-        id: changed-scripts
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base_sha="${{ github.event.pull_request.base.sha }}"
-            head_sha="${{ github.event.pull_request.head.sha }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            base_sha="${{ github.event.before }}"
-            head_sha="${{ github.sha }}"
-          else
-            echo "ℹ️ Skipping changed-file collection on ${{ github.event_name }}"
-            echo "files=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "$base_sha" =~ ^0+$ ]]; then
-            base_sha="$(git merge-base origin/main "$head_sha")"
-          fi
-
-          mapfile -t changed_files < <(
-            git diff --name-only --diff-filter=AMR "$base_sha" "$head_sha" -- \
-              | rg '^scripts/.*\.py$' \
-              | rg -v '^scripts/(oneoff|retired)/'
-          )
-
-          if ((${#changed_files[@]} == 0)); then
-            echo "✅ No changed Python files under scripts/."
-            echo "files=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          printf 'Checking radon only on changed files:\n'
-          printf '  %s\n' "${changed_files[@]}"
-          {
-            echo 'files<<EOF'
-            printf '%s\n' "${changed_files[@]}"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: No F-grade functions in changed files (CC > 40)
-        if: steps.changed-scripts.outputs.files != ''
-        env:
-          CHANGED_FILES: ${{ steps.changed-scripts.outputs.files }}
-        run: |
-          mapfile -t files <<< "$CHANGED_FILES"
-          output=$(python -m radon cc "${files[@]}" -n F -s 2>/dev/null || true)
-          if [ -n "$output" ]; then
-            echo "::error::F-grade functions found:"
-            echo "$output"
-            exit 1
-          fi
-          echo "✅ No F-grade functions in changed files"
-
-      - name: No MI=C files in changed files (MI < 10)
-        if: steps.changed-scripts.outputs.files != ''
-        env:
-          CHANGED_FILES: ${{ steps.changed-scripts.outputs.files }}
-        run: |
-          mapfile -t files <<< "$CHANGED_FILES"
-          output=$(python -m radon mi "${files[@]}" -s 2>/dev/null | grep " - C " || true)
-          if [ -n "$output" ]; then
-            echo "::error::MI=C files found:"
-            echo "$output"
-            exit 1
-          fi
-          echo "✅ No MI=C files in changed files"
-
-  lint-prompts:
-    name: Lint Prompts
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.agent_config == 'true'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      - name: Lint prompt templates
-        run: python scripts/lint/lint_prompts.py
-
-  postmortem-hygiene:
-    name: Postmortem Hygiene
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.postmortems == 'true'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      # Validate bug-autopsy required fields + assert INDEX.md is current, without
-      # writing. Root-cause guard for #3725: a malformed autopsy (#3725 shipped one
-      # with non-canonical headings + no Links) previously only tripped an advisory
-      # SessionStart warning days later — nothing blocked it at PR time.
-      # Direct file path (NOT `-m`): the checker is stdlib-only, but `-m` would
-      # import scripts.audit/__init__ which needs pyyaml (absent on bare setup-python).
-      - name: Validate bug-autopsy fields + INDEX freshness (#3725)
-        run: python scripts/audit/check_postmortems.py --check
-
-  agent-config:
-    name: Agent Config
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.agent_config == 'true'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6 — SHA-pinned per supply-chain hardening 2026-05-19
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - name: Validate agent JSON config
-        run: |
-          jq empty \
-            .mcp.json \
-            .cursor/mcp.json \
-            agents_extensions/shared/settings.json
-          if [[ -f agents_extensions/shared/settings.local.json ]]; then
-            jq empty agents_extensions/shared/settings.local.json
-          fi
-
-      - name: Validate agent shell entrypoints
-        run: |
-          bash -n \
-            start-claude.sh \
-            start-claudex.sh \
-            start-kimicc.sh \
-            start-codex.sh \
-            scripts/lib/handoff_identity.sh \
-            scripts/lib/claude_route_guard.sh \
-            scripts/deploy_prompts.sh \
-            scripts/check_rules_deployment.sh
-
-      - name: Create local test venv
-        run: |
-          python -m venv .venv
-          .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install pytest pyyaml
-
-      - name: Verify agent extension deployment
-        run: |
-          npm run agents:deploy --silent
-          bash scripts/check_rules_deployment.sh
-
-      - name: Run focused agent config tests
-        run: |
-          .venv/bin/python -m pytest \
-            tests/test_deploy_script_idempotency.py \
-            tests/test_agent_runtime_tool_config.py \
-            -v --tb=short
-
-  scripts-root-guard:
-    name: No new root scripts
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.python == 'true'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Check for non-stub scripts in scripts/ root
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base_sha="${{ github.event.pull_request.base.sha }}"
-            head_sha="${{ github.event.pull_request.head.sha }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            base_sha="${{ github.event.before }}"
-            head_sha="${{ github.sha }}"
-          else
-            echo "ℹ️ Skipping root-script diff on ${{ github.event_name }}"
-            exit 0
-          fi
-
-          if [[ "$base_sha" =~ ^0+$ ]]; then
-            base_sha="$(git merge-base origin/main "$head_sha")"
-          fi
-
-          if [[ -z "$base_sha" ]]; then
-            echo "::error::Unable to determine the comparison base for scripts/ root guard."
-            exit 1
-          fi
-
-          # Allowed non-stub files at scripts/ root
-          allowed="__init__.py|batch_gemini_runner.py|config.py|generate_mdx.py|manifest_direct.py|manifest_utils.py|paths.py|pipeline_lib.py|slug_utils.py|yaml_activities.py"
-          violations=""
-
-          mapfile -t candidates < <(
-            git diff --name-only --diff-filter=AR "$base_sha" "$head_sha" -- scripts \
-              | while IFS= read -r f; do
-                  if [[ "$(dirname "$f")" == "scripts" && "$f" == *.py ]]; then
-                    printf '%s\n' "$f"
-                  fi
-                done
-          )
-
-          for f in "${candidates[@]}"; do
-            [ ! -f "$f" ] && continue
-            basename=$(basename "$f")
-            # Skip allowed files
-            echo "$basename" | grep -qE "^($allowed)$" && continue
-            # Skip re-export stubs
-            grep -q "Stub: module moved" "$f" && continue
-            violations="$violations $f"
-          done
-          if [ -n "$violations" ]; then
-            echo "::error::New non-stub scripts found in scripts/ root (move to a subdirectory):"
-            echo "$violations" | tr ' ' '\n' | grep .
-            exit 1
-          fi
-          echo "✅ No new root-level scripts"
-
-  mdx-source-parity:
-    name: MDX Source Parity
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      - name: Restore Atlas lexicon manifest cache
-        id: atlas-manifest-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: site/src/data/lexicon-manifest.json
-          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
-
-      - name: Verify Atlas manifest matches pointer (rehydrate if stale)
-        run: |
-          python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
-
-      - name: Save Atlas lexicon manifest cache
-        if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: site/src/data/lexicon-manifest.json
-          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
-
-      - name: Install dependencies
-        run: |
-          python -m venv .venv
-          .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install PyYAML jsonschema
-
       - name: Check MDX source parity
+        if: needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request'
         env:
-          # Parenthesized: without parens, && binds tighter than || and the
-          # title-tag paths yield boolean `true` (not '1'), which the checker
-          # rejects — the exemption silently never fired (found via PR #4399).
           MDX_PARITY_BULK_REGEN: ${{ (contains(github.event.pull_request.title, '[regen-mdx]') || contains(github.event.pull_request.title, '[bulk-regen]') || contains(github.event.pull_request.body, '[regen-mdx]') || contains(github.event.pull_request.body, '[bulk-regen]')) && '1' || '0' }}
         run: |
           .venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main
 
       - name: Check source-to-site MDX forward parity
+        if: needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request'
         run: |
           .venv/bin/python scripts/audit/check_mdx_forward_parity.py --changed-vs-base origin/main
 
       - name: Check internal IDs are not published
+        if: needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request'
         run: |
           .venv/bin/python scripts/audit/check_no_internal_ids.py --changed-vs-base origin/main
 
       - name: Check locked modules are not published
+        if: needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request'
         run: |
           .venv/bin/python scripts/audit/check_locked_module_not_published.py --changed-vs-base origin/main
 
-  mdx-generation-drift:
-    name: MDX Generation Drift
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      - name: Restore Atlas lexicon manifest cache
-        id: atlas-manifest-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: site/src/data/lexicon-manifest.json
-          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
-
-      - name: Verify Atlas manifest matches pointer (rehydrate if stale)
-        run: |
-          python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
-
-      - name: Save Atlas lexicon manifest cache
-        if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: site/src/data/lexicon-manifest.json
-          key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
-
-      - name: Install generator dependencies
-        run: |
-          python -m venv .venv
-          .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install PyYAML jsonschema
-
       - name: Regenerate changed curriculum MDX and check drift
+        if: needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request'
         run: |
           .venv/bin/python scripts/audit/check_mdx_generation_drift.py --changed-vs-base origin/main
 
-  lesson-schema-drift:
-    name: Lesson Schema Drift
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write
-    needs: changes
-    if: needs.changes.outputs.lesson_schema == 'true'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6 — SHA-pinned per supply-chain hardening 2026-05-19
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - name: Install schema dependencies
-        run: |
-          python -m venv .venv
-          .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install PyYAML
-          npm ci
-
       - name: Regenerate lesson schema and check drift
+        if: needs.changes.outputs.lesson_schema == 'true'
         run: |
+          npm ci
           .venv/bin/python scripts/build/generate_lesson_schema.py
           git diff --exit-code docs/lesson-schema.yaml
 
   test:
-    name: Test (pytest) [${{ matrix.shard }}/4]
+    name: Test (pytest)
     runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: write
-    # Sol #5657 step 6: run pytest concurrent with lint. CI Gate still needs
-    # both lint and test — lint failure fails the required gate without serializing
-    # the pytest matrix behind ruff. Job still uses !cancelled() (#1644 class).
     needs: [changes]
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
     if: '!cancelled()'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: needs.changes.outputs.python == 'true'
         with:
           persist-credentials: false
           fetch-depth: 0
-        if: needs.changes.outputs.python == 'true'
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         if: needs.changes.outputs.python == 'true'
         with:
           python-version: '3.12'
-          # No cache: 'pip' here — sole owner of ~/.cache/pip is the manual
-          # Restore/Save pip wheel cache below (torch CPU pin in key; CF #5663 F001).
 
       - name: Restore Atlas lexicon manifest cache
         if: needs.changes.outputs.python == 'true'
@@ -974,9 +701,6 @@ jobs:
           path: site/src/data/lexicon-manifest.json
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
-      # Pip/torch wheel cache (Sol #5657 follow-up): 4 shards each reinstall torch;
-      # caching the download directory cuts multi-GB cold installs on cache hit.
-      # Sole manager of ~/.cache/pip for this job (setup-python cache disabled above).
       - name: Restore pip wheel cache
         id: pip-wheel-cache
         if: needs.changes.outputs.python == 'true'
@@ -994,207 +718,130 @@ jobs:
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install --no-deps -r requirements-lock.txt
-          # Reinstall CPU wheels after the lockfile so PyPI CUDA builds cannot win
-          # (torch>=2.13 default Linux wheels require libcudart.so.13).
           .venv/bin/python -m pip install --no-deps --force-reinstall \
             --index-url https://download.pytorch.org/whl/cpu \
             torch==2.13.0 torchvision==0.28.0
           .venv/bin/python -m pip install --no-deps multiprocess==0.70.18 huggingface-hub==1.24.0
 
       - name: Save pip wheel cache
-        # Only shard 1 saves on exact-key miss — avoids 4-way matrix save races (CF F001).
-        if: needs.changes.outputs.python == 'true' && matrix.shard == 1 && steps.pip-wheel-cache.outputs.cache-hit != 'true'
+        if: needs.changes.outputs.python == 'true' && steps.pip-wheel-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: pip-wheels-${{ runner.os }}-py3.12-${{ hashFiles('requirements-lock.txt') }}-torch2.13.0cpu
 
-      # Duration estimates are still *saved* post-run (parse-durations) for a future
-      # single-planner LPT job. Matrix workers do not restore/feed them into plan
-      # (equal-weight partition; #5664).
-
-      - name: Plan deterministic pytest shard
-        if: needs.changes.outputs.python == 'true' && !cancelled()
-        run: |
-          mkdir -p ci-artifacts
-          # Default equal-weight partition (no --use-lpt-durations). Safe under
-          # concurrent matrix workers even when duration cache restores diverge.
-          .venv/bin/python scripts/ci/pytest_shards.py plan --shard-id "${{ matrix.shard }}" \
-            --output ci-artifacts/plan.json --args-output ci-artifacts/test-nodeids.txt
-
-      - name: Run pytest shard
+      - name: Run pytest
         if: needs.changes.outputs.python == 'true' && !cancelled() && (github.event_name != 'push' || github.ref != 'refs/heads/main')
         run: |
-          # Track failures without aborting mid-step so main-shard artifacts still upload.
+          mkdir -p ci-artifacts
           status=0
-          if [ "${{ matrix.shard }}" = "1" ]; then
-            # Cache-invalidating tests need a fresh process before the shard body.
-            .venv/bin/python -m pytest \
-              tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
-              tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
-              -v --tb=short --junitxml=ci-artifacts/cache-junit.xml || status=$?
-          fi
+          .venv/bin/python -m pytest \
+            tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
+            tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
+            -v --tb=short --junitxml=ci-artifacts/cache-junit.xml || status=$?
           set -o pipefail
-          .venv/bin/python scripts/ci/pytest_shards.py run --nodeids ci-artifacts/test-nodeids.txt -- \
-            -v --tb=short -n auto --junitxml=ci-artifacts/main-junit.xml --durations=0 \
+          .venv/bin/python -m pytest tests/ -v --tb=short -k "not slow and not website" \
+            --ignore=tests/test_rag.py \
+            --ignore=tests/test_a1_review_scores.py \
+            --ignore=tests/test_agent_runtime.py \
+            --ignore=tests/test_channels_registry.py \
+            --ignore=tests/test_convergence_loop.py \
+            --ignore=tests/test_morphological_validator.py \
+            --ignore=tests/test_plan_hash.py \
+            --ignore=tests/test_scrape_diasporiana.py \
+            --ignore=tests/test_v6_plan_hash_drift.py \
+            --ignore=tests/test_vocab_gen.py \
+            --ignore=tests/test_wiki_channels.py \
+            --ignore=tests/test_wiki_enrichment.py \
+            --ignore=tests/wiki/test_grade_filter.py \
+            --ignore=tests/wiki/test_mlx_fault_injection.py \
+            --ignore=tests/wiki/test_t1_t2_pipeline.py \
+            --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
+            --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
+            --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
+            -n auto --junitxml=ci-artifacts/main-junit.xml --durations=0 \
             2>&1 | tee ci-artifacts/main.log || status=$?
-          if [ "${{ matrix.shard }}" = "1" ]; then
-            # Wall-clock smoke last so an FTS/race flake does not skip the bulk shard body.
-            # Up to 2 retries: /api/rag/search_text can 500 on FTS rebuild races under load.
-            playground_status=1
-            for attempt in 1 2 3; do
-              echo "playground smoke attempt ${attempt}/3"
-              if .venv/bin/python -m pytest \
-                tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
-                -v --tb=short --junitxml=ci-artifacts/playground-junit.xml; then
-                playground_status=0
-                break
-              fi
-              playground_status=$?
-              sleep 3
-            done
-            if [ "$playground_status" -ne 0 ]; then status=$playground_status; fi
-          fi
+          playground_status=1
+          for attempt in 1 2 3; do
+            echo "playground smoke attempt ${attempt}/3"
+            if .venv/bin/python -m pytest \
+              tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
+              -v --tb=short --junitxml=ci-artifacts/playground-junit.xml; then
+              playground_status=0
+              break
+            fi
+            playground_status=$?
+            sleep 3
+          done
+          if [ "$playground_status" -ne 0 ]; then status=$playground_status; fi
           exit "$status"
 
       - name: Run tests with coverage
         if: needs.changes.outputs.python == 'true' && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          # Gradual path: 30 (2025) → 35 (now, 2026-04) → 50 (mid-2026) → 80 on
-          # critical paths (dispatch, activity_repair, audit/core). Measured
-          # current: 39% on 2026-04-10. Bumping the floor above measured
-          # coverage would break CI, so we nudge the minimum and track the
-          # trend. Re-measure after each new batch of tests and raise the floor.
-          #
+          mkdir -p ci-artifacts
           status=0
-          if [ "${{ matrix.shard }}" = "1" ]; then
-            .venv/bin/python -m pytest \
-              tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
-              tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
-              -v --tb=short --junitxml=ci-artifacts/cache-junit.xml --cov=scripts --cov-append --cov-report= || status=$?
-          fi
+          .venv/bin/python -m pytest \
+            tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
+            tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
+            -v --tb=short --junitxml=ci-artifacts/cache-junit.xml --cov=scripts --cov-append --cov-report= || status=$?
           set -o pipefail
-          .venv/bin/python scripts/ci/pytest_shards.py run --nodeids ci-artifacts/test-nodeids.txt -- \
-            -v --tb=short -n auto --junitxml=ci-artifacts/main-junit.xml --durations=0 \
+          .venv/bin/python -m pytest tests/ -v --tb=short -k "not slow and not website" \
+            --ignore=tests/test_rag.py \
+            --ignore=tests/test_a1_review_scores.py \
+            --ignore=tests/test_agent_runtime.py \
+            --ignore=tests/test_channels_registry.py \
+            --ignore=tests/test_convergence_loop.py \
+            --ignore=tests/test_morphological_validator.py \
+            --ignore=tests/test_plan_hash.py \
+            --ignore=tests/test_scrape_diasporiana.py \
+            --ignore=tests/test_v6_plan_hash_drift.py \
+            --ignore=tests/test_vocab_gen.py \
+            --ignore=tests/test_wiki_channels.py \
+            --ignore=tests/test_wiki_enrichment.py \
+            --ignore=tests/wiki/test_grade_filter.py \
+            --ignore=tests/wiki/test_mlx_fault_injection.py \
+            --ignore=tests/wiki/test_t1_t2_pipeline.py \
+            --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
+            --deselect=tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
+            --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
+            -n auto --junitxml=ci-artifacts/main-junit.xml --durations=0 \
             --cov=scripts --cov-append --cov-report= \
             2>&1 | tee ci-artifacts/main.log || status=$?
-          if [ "${{ matrix.shard }}" = "1" ]; then
-            # Coverage instrumentation skews this endpoint latency budget, so it stays outside coverage.
-            playground_status=1
-            for attempt in 1 2 3; do
-              echo "playground smoke attempt ${attempt}/3"
-              if .venv/bin/python -m pytest \
-                tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
-                -v --tb=short --junitxml=ci-artifacts/playground-junit.xml; then
-                playground_status=0
-                break
-              fi
-              playground_status=$?
-              sleep 3
-            done
-            if [ "$playground_status" -ne 0 ]; then status=$playground_status; fi
+          playground_status=1
+          for attempt in 1 2 3; do
+            echo "playground smoke attempt ${attempt}/3"
+            if .venv/bin/python -m pytest \
+              tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast \
+              -v --tb=short --junitxml=ci-artifacts/playground-junit.xml; then
+              playground_status=0
+              break
+            fi
+            playground_status=$?
+            sleep 3
+          done
+          if [ "$playground_status" -ne 0 ]; then status=$playground_status; fi
+          if [ "$status" -eq 0 ]; then
+            .venv/bin/python -m coverage report --fail-under=35
+            .venv/bin/python -m coverage xml -o coverage.xml
           fi
           exit "$status"
 
-      - name: Upload pytest shard plan and results
+      - name: Upload pytest artifacts
         if: always() && needs.changes.outputs.python == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: pytest-shard-${{ matrix.shard }}
+          name: pytest-artifacts
           path: ci-artifacts/
           if-no-files-found: error
 
-      - name: Save coverage data for aggregation
-        if: always() && needs.changes.outputs.python == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          test -f .coverage
-          mkdir -p coverage
-          mv .coverage coverage/.coverage.shard-${{ matrix.shard }}
-
-      - name: Upload coverage shard
-        if: always() && needs.changes.outputs.python == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pytest-coverage-${{ matrix.shard }}
-          path: coverage/
-          include-hidden-files: true
-          if-no-files-found: error
-
-  pytest-shard-artifacts:
-    name: Pytest shard artifacts
-    runs-on: ubuntu-latest
-    if: always()
-    needs: [changes, test]
-    permissions:
-      contents: read
-      actions: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.12'
-
-      - name: Download pytest shard artifacts
-        if: needs.changes.outputs.python == 'true' && needs.test.result == 'success'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: pytest-shard-*
-          path: pytest-artifacts
-
-      - name: Verify complete pytest selection and execution counts
-        if: needs.changes.outputs.python == 'true' && needs.test.result == 'success'
-        run: |
-          python -m venv .venv
-          .venv/bin/python scripts/ci/pytest_shards.py verify-artifacts --artifact-dir pytest-artifacts
-
-      - name: Download coverage shards
-        if: needs.changes.outputs.python == 'true' && needs.test.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: pytest-coverage-*
-          path: coverage-artifacts
-
-      - name: Combine coverage once and enforce the floor
-        if: needs.changes.outputs.python == 'true' && needs.test.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          python -m venv .venv
-          .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install --no-deps -r requirements-lock.txt
-          # upload-artifact strips the coverage/ LCA; download lands files at
-          # coverage-artifacts/pytest-coverage-N/.coverage.shard-N
-          .venv/bin/python -m coverage combine coverage-artifacts/pytest-coverage-*/.coverage.shard-*
-          .venv/bin/python -m coverage report --fail-under=35
-          .venv/bin/python -m coverage xml -o coverage.xml
-
-      # Duration cache must not be blocked by a coverage combine failure (CF r2).
-      - name: Publish next-run duration estimates
-        if: always() && needs.changes.outputs.python == 'true' && needs.test.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          python -m venv .venv
-          .venv/bin/python scripts/ci/pytest_shards.py parse-durations \
-            --log pytest-artifacts/pytest-shard-1/main.log \
-            --log pytest-artifacts/pytest-shard-2/main.log \
-            --log pytest-artifacts/pytest-shard-3/main.log \
-            --log pytest-artifacts/pytest-shard-4/main.log \
-            --output ci-artifacts/pytest-durations.json
-
-      - name: Save next-run duration estimates
-        if: always() && needs.changes.outputs.python == 'true' && needs.test.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ci-artifacts/pytest-durations.json
-          key: pytest-shard-durations-v1-main-${{ github.sha }}
-
-      - name: Upload combined coverage
+      - name: Upload coverage report
         if: always() && needs.changes.outputs.python == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage.xml
-          if-no-files-found: error
+          if-no-files-found: ignore
 
   frontend:
     name: Frontend (build + vitest)
@@ -1335,56 +982,27 @@ jobs:
         with:
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore
 
-  # Aggregation gate (#4803). The deterministic CI jobs above are CONDITIONAL
-  # (path-filtered via dorny/paths-filter), so none can be a branch-protection
-  # required check directly: on a PR that doesn't trigger it, the context never
-  # reports and the PR blocks forever ("Expected — waiting for status"). The
-  # team already hit this for the single required check and solved it narrowly
-  # (Test (pytest) uses `if: !cancelled()`, see #1644). This job generalizes
-  # that fix: it always runs, `needs:` every deterministic gate, and fails iff
-  # any non-skipped dependency failed. Make THIS job (`CI Gate`) the sole
-  # required status check so the whole set becomes load-bearing without the
-  # conditional-required-check footgun.
-  #
-  # Semantics: skipped -> pass (path-filtered out, nothing to check);
-  #            failure/cancelled -> block.
-  # `changes` is in `needs` so a broken paths-filter router fails the gate
-  # rather than silently letting every routed job report skipped.
-  # `frontend-e2e` (playwright) is intentionally EXCLUDED — flaky, stays
-  # advisory to protect fleet merge velocity. `frontend` (build + vitest) IS
-  # included: it is deterministic and a broken frontend build must not merge.
-  # Fleet-reviewed by codex/agy/cursor on #4803.
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
     if: always()
     needs:
       - changes
-      - bio-preparation-data   # BIO Preparation Data
-      - test                  # Test (pytest) [1/4] ... [4/4]
-      - pytest-shard-artifacts # Pytest selection/count and coverage aggregation
-      - lint                  # Lint (ruff)
-      - quality-gates         # Quality Gates (radon)
-      - lint-prompts          # Lint Prompts
-      - lesson-schema-drift   # Lesson Schema Drift
-      - mdx-source-parity     # MDX Source Parity
-      - mdx-generation-drift  # MDX Generation Drift
-      - postmortem-hygiene    # Postmortem Hygiene
-      - agent-config          # Agent Config
-      - scripts-root-guard    # No new root scripts
-      - secret-scan           # Secret Scanning (gitleaks)
-      - atlas-freshness       # Atlas Manifest Freshness
-      - frontend              # Frontend (build + vitest)
+      - static-checks
+      - content-schema-checks
+      - test
+      - secret-scan
+      - frontend
     steps:
       - name: Report required-job results
         env:
           RESULTS: ${{ join(needs.*.result, ',') }}
         run: |
           echo "required job results: $RESULTS"
-      - name: Fail if required pytest matrix did not complete
+      - name: Fail if required pytest job did not complete
         if: needs.changes.outputs.python == 'true' && needs.test.result != 'success'
         run: |
-          echo "::error::A required pytest shard failed, was cancelled, or was unexpectedly skipped."
+          echo "::error::The required pytest job failed, was cancelled, or was unexpectedly skipped."
           exit 1
       - name: Fail if any required job failed or was cancelled
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/content-ci.yml
+++ b/.github/workflows/content-ci.yml
@@ -8,9 +8,17 @@ permissions:
   contents: read
 
 on:
-  # Advisory content gates intentionally avoid a global path filter.
-  # See ci.yml #1641/#1644: filtered required checks can wedge PRs as "expected".
   pull_request:
+    paths:
+      - 'docs/research/**'
+      - 'curriculum/**'
+      - 'plans/**'
+      - 'site/src/content/docs/**'
+      - 'scripts/audit/lint_bio_dossier_xref.py'
+      - 'scripts/audit/check_dossier_wordcount.py'
+      - 'scripts/audit/check_promote_quality_changed.py'
+      - 'scripts/audit/check_framing_compliance_changed.py'
+      - '.github/workflows/content-ci.yml'
 
 jobs:
   changes:

--- a/.github/workflows/model-catalog-freshness.yml
+++ b/.github/workflows/model-catalog-freshness.yml
@@ -1,5 +1,9 @@
 name: Model Catalog Freshness
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/rules-deployment-check.yml
+++ b/.github/workflows/rules-deployment-check.yml
@@ -1,5 +1,9 @@
 name: Rules Deployment Check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -1,5 +1,9 @@
 name: Validate YAML Files
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 1413f8bc7649a6455c2a541baf1c9389eb800f541ebbbb4c667d28448dc04ad7
+  components_sha256: 6b1b37f5ded9c914a4a49c4f5dd5e0653d7716ea2c63966c5fb08fc8fcad2a4a
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/tests/test_bio_preparation_ci_routing.py
+++ b/tests/test_bio_preparation_ci_routing.py
@@ -67,12 +67,12 @@ def test_preparation_output_and_required_gate_are_wired_end_to_end() -> None:
 
     jobs = _workflow()["jobs"]
     assert jobs["changes"]["outputs"]["preparation"] == "${{ steps.filter.outputs.preparation }}"
-    assert jobs["bio-preparation-data"]["if"] == "needs.changes.outputs.preparation == 'true'"
-    assert "bio-preparation-data" in jobs["ci-gate"]["needs"]
+    assert "needs.changes.outputs.preparation == 'true'" in jobs["content-schema-checks"]["if"]
+    assert "content-schema-checks" in jobs["ci-gate"]["needs"]
 
 
 def test_preparation_gate_tracks_registry_entry_changes_and_decomposes_renames() -> None:
-    steps = _workflow()["jobs"]["bio-preparation-data"]["steps"]
+    steps = _workflow()["jobs"]["content-schema-checks"]["steps"]
     validator = next(step for step in steps if step.get("name") == "Validate BIO preparation capsules and active holds")
     script = validator["run"]
 


### PR DESCRIPTION
# Cut GitHub Actions runner-slot fan-out — CI is starved, the fleet is blocked

## Summary

Consolidate runner slots across GitHub Actions workflows to eliminate queue starvation while preserving 100% of required check coverage and keeping `CI Gate` intact as the sole required status check on `main`.

## 1. Concurrency Slot Reduction (Before vs After)

- **Before**: **21 jobs** per push in `ci.yml` (4-shard pytest matrix, 1 pytest aggregator, 11 separate single-step lint/check jobs, 1 paths router, 3 frontend/secret jobs, 1 gate aggregator).
- **After**: **8 total jobs defined** in `ci.yml`, with **6 to 7 jobs running per push** (single unsharded pytest job, 2 consolidated composite jobs `static-checks` and `content-schema-checks`, `secret-scan`, `frontend`, `frontend-e2e`, and `CI Gate`).

Real number achieved per push: **6–7 runner slots** (down from 21).

## 2. Evidence Discipline & Verification

### actionlint local run output
```bash
$ actionlint .github/workflows/actionlint.yml .github/workflows/ci.yml .github/workflows/content-ci.yml .github/workflows/model-catalog-freshness.yml .github/workflows/rules-deployment-check.yml .github/workflows/validate-yaml.yml
(exit code 0, 0 errors, 0 warnings)
```

### Pytest & Workflow Routing Test Suite Output
```bash
$ pytest tests/test_bio_preparation_ci_routing.py tests/test_paths_filter_fail_open.py tests/test_lesson_schema_filter_coverage.py tests/test_mdx_atlas_filter_coverage.py
======================= 12 passed, 1 deselected in 0.43s =======================
```

## 3. Consolidated Jobs & Underlying Commands

### `static-checks` (combines 6 jobs)
- **`lint` (ruff)**: `.venv/bin/ruff check scripts/`
- **`quality-gates` (radon)**: `.venv/bin/python -m radon cc ...` and `.venv/bin/python -m radon mi ...`
- **`scripts-root-guard`**: Bash check verifying no unapproved scripts added to `scripts/` root
- **`lint-prompts`**: `.venv/bin/python scripts/lint/lint_prompts.py`
- **`postmortem-hygiene`**: `.venv/bin/python scripts/audit/check_postmortems.py --check`
- **`agent-config`**: `jq empty ...`, `bash -n ...`, `npm run agents:deploy --silent`, `bash scripts/check_rules_deployment.sh`, `.venv/bin/python -m pytest tests/test_deploy_script_idempotency.py tests/test_agent_runtime_tool_config.py`

### `content-schema-checks` (combines 5 jobs)
- **`bio-preparation-data`**: `.venv/bin/python scripts/audit/check_dossier_wordcount.py --changed`, inline Python capsule/hold validator
- **`atlas-freshness`**: `.venv/bin/python scripts/lexicon/check_manifest_freshness.py`, `check_atlas_manifest_enrichment.py`, `audit_atlas_poc_richness.py` (advisory), `check_static_practice_assets.py`, `check_manifest_vocabulary_coverage.py` (advisory)
- **`mdx-source-parity`**: `.venv/bin/python scripts/audit/check_mdx_source_parity.py`, `check_mdx_forward_parity.py`, `check_no_internal_ids.py`, `check_locked_module_not_published.py`
- **`mdx-generation-drift`**: `.venv/bin/python scripts/audit/check_mdx_generation_drift.py`
- **`lesson-schema-drift`**: `npm ci`, `.venv/bin/python scripts/build/generate_lesson_schema.py`, `git diff --exit-code docs/lesson-schema.yaml`

All step conditions (`if: needs.changes.outputs.<key> == 'true'`) are preserved so each check only executes when its specific paths change.

### `test` (single unsharded pytest job)
- Matrix collapsed from 4 shards to 1 runner.
- Executes serial cache invalidation tests, full pytest suite (`-n auto`), and playground stability smoke test.
- Uploads pytest artifacts and coverage report (on `main` push).
- Redundant `pytest-shard-artifacts` job removed.

## 4. `CI Gate` Transitive Coverage

`CI Gate.needs` now contains:
- `changes` (paths filter router)
- `static-checks` (transitively covers `lint`, `quality-gates`, `scripts-root-guard`, `lint-prompts`, `postmortem-hygiene`, `agent-config`)
- `content-schema-checks` (transitively covers `bio-preparation-data`, `atlas-freshness`, `mdx-source-parity`, `mdx-generation-drift`, `lesson-schema-drift`)
- `test` (covers full pytest suite)
- `secret-scan` (covers `gitleaks` / `trufflehog`)
- `frontend` (covers site build + `vitest`)

`CI Gate` display name is preserved exactly as required by branch protection on `main`.

## 5. Judgment Calls & Concurrency Audit

1. **Added concurrency blocks to**:
   - `.github/workflows/actionlint.yml`
   - `.github/workflows/model-catalog-freshness.yml`
   - `.github/workflows/rules-deployment-check.yml`
   - `.github/workflows/validate-yaml.yml`
2. **`atlas-grow.yml` Concurrency**: Declined `cancel-in-progress: true`. `atlas-grow.yml` runs only on `schedule` / `workflow_dispatch` (never on push/PR) and performs write operations (`git commit`, `git push`, `gh pr create`). Cancelling in-progress runs could leave git states incomplete.
3. **`deploy-pages.yml` Concurrency**: Untouched per instructions (`cancel-in-progress: false`).
4. **Path Filters Added**: Added `paths:` filter to `content-ci.yml` matching its research/curriculum/plans/site content inputs and audit scripts. Declined for `atlas-grow.yml` as it has no push/PR triggers.

X-Agent: agy