### PR TITLE
fix(schema): regenerate lesson-schema.yaml to unblock main (13 PRs gated)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 1413f8bc7649a6455c2a541baf1c9389eb800f541ebbbb4c667d28448dc04ad7
+  components_sha256: 6b1b37f5ded9c914a4a49c4f5dd5e0653d7716ea2c63966c5fb08fc8fcad2a4a
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:


### PR DESCRIPTION
## Why this is urgent

`Lesson Schema Drift` is a **required** job (`ci-gate.needs`) and has been red on `main` since
`5f425a5fe1`. Every open PR branches from `main`, inherits the mismatch, and reports `BLOCKED`.
**13 PRs are currently gated behind this one-line artifact.**

## Root cause

Two commits reached `main` **without a PR** — `5f425a5fe1` and `9debd99699`, committer `Test`,
`/commits/{sha}/pulls` returns `NONE` for both, and neither carries the `(#NNNN)` suffix that a
squash-merge adds. Both touch `site/src/components/**` and neither regenerated the tracked
artifact.

Direct pushes skip PR CI entirely, so the required `lesson-schema-drift` job never evaluated them.

**The gate machinery is not at fault.** The `lesson_schema` paths filter explicitly covers
`site/src/components/**` (with `tests/test_lesson_schema_filter_coverage.py` enforcing that
coverage), and the `lesson-schema-drift` pre-commit hook is scoped to the same files. Both were
bypassed, not misconfigured. The real defect is that a direct push to `main` was possible at all —
tracked separately, it needs a repo-settings decision.

## What this changes

Exactly one line — the output of `scripts/build/generate_lesson_schema.py` on current `main`:

    -  components_sha256: 1413f8bc7649a6455c2a541baf1c9389eb800f541ebbbb4c667d28448dc04ad7
    +  components_sha256: 6b1b37f5ded9c914a4a49c4f5dd5e0653d7716ea2c63966c5fb08fc8fcad2a4a

## Verification

- Regenerated in a clean worktree cut from `origin/main` @ `9debd99699`.
- Diff is **only** `components_sha256` — no structural schema change, so no component prop was
  added or removed. This is a content-hash refresh, not a contract change.
- The hash matches what CI independently computed on main run `30121836784` byte-for-byte
  (`+ components_sha256: 6b1b37f5...` in that job's log).
- Generator is **idempotent**: a second run produces no further diff.

## Scope discipline

Deliberately *only* the regeneration. This is the critical path for unblocking the queue, so it
carries no other change. It is intentionally **not** bundled into #5735, whose job-topology
rewrite is under an unresolved architecture ruling — the queue should not wait on that debate.

Refs #5744