### PR TITLE
test(subprocess): bound subprocess calls with explicit timeouts (batch B4)

### DIFF
--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -451,6 +451,7 @@ def test_squash_merge_branch_force_delete(
         cwd=repo,
         capture_output=True,
         text=True,
+        timeout=30,
     )
     assert "codex/squash-merged" not in proc.stdout
 

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -359,6 +359,7 @@ def test_direct_script_help_from_repository_root():
         text=True,
         env=env,
         check=False,
+        timeout=30,
     )
 
     assert completed.returncode == 0, completed.stderr
@@ -2106,11 +2107,12 @@ def test_default_runtime_root_is_shared_by_real_linked_worktree(tmp_path: Path, 
         ["git", "config", "user.email", "test@example.invalid"],
         ["git", "config", "user.name", "Test"],
     ):
-        subprocess.run(command, cwd=primary, check=True, capture_output=True, text=True, env=git_env)
+        subprocess.run(command, cwd=primary, check=True, capture_output=True, text=True, env=git_env, timeout=30)
     (primary / "README.md").write_text("fixture\n", encoding="utf-8")
-    subprocess.run(["git", "add", "README.md"], cwd=primary, check=True, capture_output=True, text=True, env=git_env)
+    subprocess.run(["git", "add", "README.md"], cwd=primary, check=True, capture_output=True, text=True, env=git_env, timeout=30)
     subprocess.run(
-        ["git", "commit", "-m", "fixture"], cwd=primary, check=True, capture_output=True, text=True, env=git_env
+        ["git", "commit", "-m", "fixture"], cwd=primary, check=True, capture_output=True, text=True, env=git_env,
+        timeout=30,
     )
     subprocess.run(
         ["git", "worktree", "add", "-b", "linked", str(linked)],
@@ -2119,6 +2121,7 @@ def test_default_runtime_root_is_shared_by_real_linked_worktree(tmp_path: Path, 
         capture_output=True,
         text=True,
         env=git_env,
+        timeout=30,
     )
 
     assert th.canonical_state_root(primary) == primary.resolve()
@@ -2494,6 +2497,7 @@ def test_epic_harness_session_start_surfaces_claude_infra_pending_packet(tmp_pat
     mapped = subprocess.check_output(
         ["bash", "-c", f'source "{identity_sh}" && handoff_identity_for_epic harness'],
         text=True,
+        timeout=30,
     ).strip()
     assert mapped == "claude-infra", f"--epic harness must map to claude-infra, got {mapped!r}"
     assert mapped != "claude-harness"

--- a/tests/test_assess_kaikki_fillability.py
+++ b/tests/test_assess_kaikki_fillability.py
@@ -114,7 +114,7 @@ def test_assess_kaikki_fillability_cli(tmp_path: Path):
         "--out", str(report_file)
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
 
     # Assert stdout output
     assert "Raw Union Count (N): 5" in result.stdout

--- a/tests/test_certification_evidence.py
+++ b/tests/test_certification_evidence.py
@@ -1260,14 +1260,15 @@ def test_completed_provisional_run_resumes_for_fresh_qg_without_legacy_authority
 def test_common_repository_tree_rejects_primary_current_and_sibling_worktree_evidence(tmp_path: Path) -> None:
     repo, config_path, _ledger_root, _ledger, inputs = _completion_case(tmp_path)
     git_env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
-    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True, text=True, env=git_env)
-    subprocess.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True, text=True, env=git_env)
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True, text=True, env=git_env, timeout=30)
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True, text=True, env=git_env, timeout=30)
     subprocess.run(
         ["git", "-C", str(repo), "-c", "user.name=Fixture", "-c", "user.email=fixture@example.test", "commit", "-m", "fixture"],
         check=True,
         capture_output=True,
         text=True,
         env=git_env,
+        timeout=30,
     )
     current = repo / ".worktrees/dispatch/codex/current"
     sibling = repo / ".worktrees/dispatch/codex/sibling"
@@ -1277,6 +1278,7 @@ def test_common_repository_tree_rejects_primary_current_and_sibling_worktree_evi
         capture_output=True,
         text=True,
         env=git_env,
+        timeout=30,
     )
     subprocess.run(
         ["git", "-C", str(repo), "worktree", "add", "-b", "fixture-sibling", str(sibling)],
@@ -1284,6 +1286,7 @@ def test_common_repository_tree_rejects_primary_current_and_sibling_worktree_evi
         capture_output=True,
         text=True,
         env=git_env,
+        timeout=30,
     )
     current_config = current / config_path.relative_to(repo)
     current_ledger_root = tmp_path / "ledgers-current"

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -396,6 +396,7 @@ def test_cli_reports_missing_static_shard(tmp_path: Path) -> None:
         check=False,
         capture_output=True,
         text=True,
+        timeout=60,
     )
 
     assert result.returncode == 1
@@ -647,6 +648,7 @@ def test_cli_prints_coverage_table(tmp_path: Path) -> None:
         check=False,
         capture_output=True,
         text=True,
+        timeout=60,
     )
 
     assert result.returncode == 0

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -87,6 +87,7 @@ def _run(repo: Path, script: Path) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         check=False,
         text=True,
+        timeout=120,
     )
 
 
@@ -97,6 +98,7 @@ def _run_command(repo: Path, command: list[str]) -> subprocess.CompletedProcess[
         capture_output=True,
         check=False,
         text=True,
+        timeout=30,
     )
 
 
@@ -191,6 +193,7 @@ echo "GEMINI:${ORPHAN_PATHS_GEMINI}"
         capture_output=True,
         check=True,
         text=True,
+        timeout=30,
     )
     sets: dict[str, frozenset[str]] = {}
     for line in result.stdout.splitlines():

--- a/tests/test_grok_lane_session_canary.py
+++ b/tests/test_grok_lane_session_canary.py
@@ -182,6 +182,7 @@ def test_cli_module_help() -> None:
         capture_output=True,
         text=True,
         check=False,
+        timeout=15,
     )
     assert proc.returncode == 0
     assert "mint" in proc.stdout

--- a/tests/test_migrate_to_html.py
+++ b/tests/test_migrate_to_html.py
@@ -17,6 +17,7 @@ def _run_migrate(input_path: Path, output_path: Path, *extra_args: str) -> subpr
         capture_output=True,
         check=False,
         text=True,
+        timeout=30,
     )
 
 

--- a/tests/test_safe_env.py
+++ b/tests/test_safe_env.py
@@ -26,6 +26,7 @@ def _run(args: list[str], env_extra: dict[str, str] | None = None) -> subprocess
         capture_output=True,
         text=True,
         env=env,
+        timeout=15,
     )
 
 
@@ -50,6 +51,7 @@ def test_check_reports_unset_for_absent_var():
         capture_output=True,
         text=True,
         env=env,
+        timeout=15,
     )
     assert res.returncode == 1
     assert "SAFE_ENV_DEFINITELY_ABSENT: UNSET" in res.stdout
@@ -73,6 +75,7 @@ def test_is_set_is_silent_and_uses_exit_code():
         capture_output=True,
         text=True,
         env={k: v for k, v in os.environ.items() if k != "SAFE_ENV_DEFINITELY_ABSENT"},
+        timeout=15,
     )
     assert unset_res.returncode == 1
 

--- a/tests/test_scrape_diasporiana.py
+++ b/tests/test_scrape_diasporiana.py
@@ -40,6 +40,7 @@ def _find_unicode_font() -> str:
         capture_output=True,
         text=True,
         check=False,
+        timeout=10,
     )
     font_path = result.stdout.strip().splitlines()[0] if result.stdout.strip() else ""
     if font_path and Path(font_path).exists():

--- a/tests/test_start_claudex.py
+++ b/tests/test_start_claudex.py
@@ -178,6 +178,7 @@ def test_claudex_status_settings_cover_main_and_subagent_visibility() -> None:
         capture_output=True,
         check=True,
         cwd=_REPO_ROOT,
+        timeout=15,
     )
     assert "[GPT-5.6 Sol]" in main.stdout
     assert "[ctx: 68K/272K (25%)]" in main.stdout
@@ -207,6 +208,7 @@ def test_claudex_status_settings_cover_main_and_subagent_visibility() -> None:
         capture_output=True,
         check=True,
         cwd=_REPO_ROOT,
+        timeout=15,
     )
     assert json.loads(subagent.stdout) == {
         "id": "agent-1",

--- a/tests/test_start_gemini_launcher.py
+++ b/tests/test_start_gemini_launcher.py
@@ -116,13 +116,13 @@ def _build_fake_project(tmp_path: Path) -> tuple[Path, Path]:
     )
 
     env = _clean_environ()
-    subprocess.run(["git", "init", "--quiet", str(project)], check=True, env=env)
-    subprocess.run(["git", "-C", str(project), "config", "user.email", "test@example.com"], check=True, env=env)
-    subprocess.run(["git", "-C", str(project), "config", "user.name", "Test"], check=True, env=env)
+    subprocess.run(["git", "init", "--quiet", str(project)], check=True, env=env, timeout=30)
+    subprocess.run(["git", "-C", str(project), "config", "user.email", "test@example.com"], check=True, env=env, timeout=30)
+    subprocess.run(["git", "-C", str(project), "config", "user.name", "Test"], check=True, env=env, timeout=30)
     (project / "README.md").write_text("# test", encoding="utf-8")
-    subprocess.run(["git", "-C", str(project), "add", "."], check=True, env=env)
-    subprocess.run(["git", "-C", str(project), "commit", "--quiet", "-m", "init"], check=True, env=env)
-    subprocess.run(["git", "-C", str(project), "branch", "-m", "main"], check=True, env=env)
+    subprocess.run(["git", "-C", str(project), "add", "."], check=True, env=env, timeout=30)
+    subprocess.run(["git", "-C", str(project), "commit", "--quiet", "-m", "init"], check=True, env=env, timeout=30)
+    subprocess.run(["git", "-C", str(project), "branch", "-m", "main"], check=True, env=env, timeout=30)
 
     return project, capture
 

--- a/tests/test_worktree_containment_bare.py
+++ b/tests/test_worktree_containment_bare.py
@@ -33,6 +33,7 @@ def _git(*args: str, cwd: Path | None = None) -> None:
         text=True,
         cwd=str(cwd) if cwd else None,
         env=_clean_env(),
+        timeout=30,
     )
 
 
@@ -48,6 +49,7 @@ def test_heal_primary_bare_if_needed_resets_core_bare(tmp_path: Path) -> None:
             text=True,
             env=_clean_env(),
             check=False,
+            timeout=30,
         ).stdout.strip()
         == "true"
     )
@@ -62,6 +64,7 @@ def test_heal_primary_bare_if_needed_resets_core_bare(tmp_path: Path) -> None:
             text=True,
             env=_clean_env(),
             check=False,
+            timeout=30,
         ).stdout.strip()
         == "false"
     )
@@ -73,6 +76,7 @@ def test_heal_primary_bare_if_needed_resets_core_bare(tmp_path: Path) -> None:
             text=True,
             env=_clean_env(),
             check=False,
+            timeout=30,
         ).stdout.strip()
         == "true"
     )
@@ -106,6 +110,7 @@ def test_primary_checkout_dirty_status_heals_bare_then_reports_status(
             text=True,
             env=_clean_env(),
             check=False,
+            timeout=30,
         ).stdout.strip()
         == "false"
     )


### PR DESCRIPTION
Completes Wave 1 of the subprocess-timeout sweep for #5740 (joins #5743 B1, #5745 B2, #5747 B3,
#5742 B5, #5748 B6). Adds an explicit `timeout=` to unbounded `subprocess.run` / `check_output` sites
across **13 test files**.

## Provenance — third rescue of the same harness defect

The `grok-4.5` lane ran 427s under dispatch `timeouts-B4-orig`, left the work **uncommitted**
(`worktree_dirty_on_exit: true`, zero commits), and settled as `done`. Recovered and finalized by the
infra driver, with the diff saved to a patch before anything touched the worktree.

Two earlier attempts at this same batch produced **nothing at all**, for two different reasons worth
recording:

1. `delegate.py dispatch` **defaults to `--mode read-only`** — no worktree, no write access. The worker
   narrated its plan, exited 0, and was recorded `done`.
2. Adding a "worker preamble" to the brief made the lane reply **conversationally and exit after ~20s**
   instead of working (prompt 4.6–5.0 KB / ~20 s / ~130 chars out, versus the successful runs at
   ~3.6 KB / 265–427 s / ~850 chars out).

The invocation that works is the **original brief** plus `--mode workspace-write --worktree`.

## A correction I owe this PR

I initially concluded B4 had introduced two regressions
(`tests/api/test_services_ops.py::test_live_fallback_starts_api_with_a_loud_warning` and
`tests/audit/test_certify_module.py::test_build_checks_include_standard_certification_guards`), because
both failed here and passed in another worktree.

**That was wrong.** The "control" worktree had a *different base commit*, so it was not a control at
all. Re-tested properly — reverting B4's change to each file **inside the same worktree** — both tests
still fail. They are **pre-existing failures at the current base**, not B4 defects.

Those two files are held back from this PR (patches preserved at
`.agent/tmp/B4-HELD-*.patch`) only because their tests fail at base, so the local gate cannot pass on
them either way. They land once the base failures are fixed.

## Verified

- **186 tests pass** across the 13 committed files (pre-commit gate; `--no-verify` not used).
- Diff confined to `tests/` — no production code, no assertion weakened, no test skipped.

## One review note worth a careful look

Elsewhere in its batch, this lane converted cleanup `proc.wait()` into `proc.wait(timeout=10)` inside
`finally` blocks. That pattern can **raise inside cleanup and leak the child process**, which is exactly
the advisor's warning that a bare timeout does not reap children — the correct form is
terminate → bounded wait → kill → reap the process group. None of those hunks are in this PR (they were
in the held-back `test_services_ops.py`), but the same pattern should be rejected wherever it appears in
the sibling batches.

Refs #5740