### PR TITLE
fix(delegate): a dirty write-capable worktree must not settle as `done`

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2431,12 +2431,21 @@ def _run_worker(
             Path(worktree_path),
             base_ref,
         )
-        # Fail CLOSED when the count is unknown. ``_count_commits_ahead`` returns
-        # None when it cannot count, and ``commits_ahead == 0`` silently skipped
-        # that case — which is how the B4 dispatch (commits_ahead=None,
-        # dirty_on_exit=True) still reported ``done``. Unknown plus dirty means we
-        # cannot prove the work was committed, so surface it for finalization.
-        if dirty_on_exit and commits_ahead in (0, None):
+        # Fail CLOSED on BOTH unknowns — they are the same bug in two variables.
+        #
+        # ``_count_commits_ahead`` returns None when it cannot count, and
+        # ``commits_ahead == 0`` silently skipped that case, which is how the B4
+        # dispatch (commits_ahead=None, dirty_on_exit=True) still reported ``done``.
+        #
+        # ``_worktree_is_dirty`` can ALSO return None (OSError, or a non-zero
+        # ``git status --porcelain``). A bare ``if dirty_on_exit`` treats that unknown
+        # as falsy and skips the check entirely — failing OPEN in precisely the way
+        # this fix exists to prevent. Caught in cross-family review of #5754, which
+        # noted the asymmetry after the count half had been fixed.
+        #
+        # Neither unknown can prove the work was committed, so either one surfaces
+        # the task for finalization rather than letting it settle as ``done``.
+        if dirty_on_exit in (True, None) and commits_ahead in (0, None):
             needs_finalize = True
 
         if needs_finalize and returncode == 0 and mode == "danger":

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2416,17 +2416,30 @@ def _run_worker(
     commits_ahead: int | None = None
     needs_finalize = False
     auto_finalize: AutoFinalizeResult | None = None
-    if worktree_path and mode == "danger":
+    # The dirty-worktree safety net must cover EVERY write-capable mode, not just
+    # ``danger``. It was gated on ``danger`` alone, so a ``workspace-write``
+    # dispatch that left finished work uncommitted settled as ``done`` — a real
+    # failure reported as success. On 2026-07-25 three lanes did exactly that
+    # (``timeouts-B3``, ``timeouts-B6``, ``timeouts-B4-orig``: dirty worktrees,
+    # zero commits, ``status: done``) and 31 files of finished work were one agent
+    # restart away from being lost. Detection now runs for the whole write-capable
+    # set; the riskier auto-finalize action stays scoped to ``danger``.
+    if worktree_path and mode in _WRITE_CAPABLE_MODES:
         base_branch = str(final_state.get("worktree_base") or "main")
         base_ref = _origin_base_ref(base_branch)
         commits_ahead = _count_commits_ahead(
             Path(worktree_path),
             base_ref,
         )
-        if commits_ahead == 0 and dirty_on_exit:
+        # Fail CLOSED when the count is unknown. ``_count_commits_ahead`` returns
+        # None when it cannot count, and ``commits_ahead == 0`` silently skipped
+        # that case — which is how the B4 dispatch (commits_ahead=None,
+        # dirty_on_exit=True) still reported ``done``. Unknown plus dirty means we
+        # cannot prove the work was committed, so surface it for finalization.
+        if dirty_on_exit and commits_ahead in (0, None):
             needs_finalize = True
 
-        if needs_finalize and returncode == 0:
+        if needs_finalize and returncode == 0 and mode == "danger":
             auto_finalize = _auto_finalize_dirty_worktree(
                 worktree=Path(worktree_path),
                 task_id=task_id,

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1380,6 +1380,118 @@ def test_run_worker_marks_needs_finalize_for_dirty_danger_worktree(
     assert state["auto_finalize"]["error"] == "simulated finalize failure"
 
 
+def _init_git_repo_for_test(path, monkeypatch):
+    """Minimal git repo used by the dirty-worktree finalize tests."""
+    _sanitize_git_env_for_test(monkeypatch)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, timeout=30)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "test"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def _finalize_mock_result():
+    return type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "grok-4.5",
+            "effort": "high",
+            "cli_version": "0.2.111",
+        },
+    )()
+
+
+@pytest.mark.parametrize(
+    "commits_ahead,case",
+    [
+        (0, "zero-commits"),
+        (None, "unknown-commit-count"),
+    ],
+)
+def test_run_worker_marks_needs_finalize_for_dirty_workspace_write_worktree(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+    commits_ahead,
+    case,
+):
+    """A dirty ``workspace-write`` worktree must NOT settle as ``done``.
+
+    Regression for 2026-07-25: the dirty-worktree safety net was gated on
+    ``mode == "danger"``, so three ``workspace-write`` dispatches
+    (``timeouts-B3``, ``timeouts-B6``, ``timeouts-B4-orig``) each left finished
+    work uncommitted and still reported ``status: done`` — three real failures
+    read as three successes, with 31 files one agent restart from being lost.
+
+    The ``None`` case is the second half of the same bug: ``_count_commits_ahead``
+    returns None when it cannot count, and the old ``commits_ahead == 0`` test
+    skipped that path, which is exactly how the B4 dispatch
+    (``commits_ahead: None``, ``worktree_dirty_on_exit: True``) escaped as ``done``.
+    Unknown plus dirty cannot prove the work was committed, so it fails closed.
+    """
+    task_id = f"needs-finalize-ws-{case}"
+    state_path = delegate._state_path(task_id)
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    delegate._write_state_atomic(state_path, {
+        "task_id": task_id,
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+    (tmp_path / "finished_work.txt").write_text("uncommitted", encoding="utf-8")
+
+    auto_finalize_calls = []
+
+    def _record_auto_finalize(**kwargs):
+        auto_finalize_calls.append(kwargs)
+        raise AssertionError("auto-finalize must stay scoped to danger mode")
+
+    monkeypatch.setattr(delegate, "_auto_finalize_dirty_worktree", _record_auto_finalize)
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=_finalize_mock_result()),
+        patch.object(delegate, "_count_commits_ahead", return_value=commits_ahead),
+    ):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="grok",
+            prompt="bound the subprocess calls",
+            mode="workspace-write",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+            effort="high",
+        )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "needs_finalize", (
+        f"dirty workspace-write worktree reported {state['status']!r}; a dispatch that "
+        "produced no commit must never settle as done"
+    )
+    assert state["needs_finalize"] is True
+    assert state["worktree_dirty_on_exit"] is True
+    assert rc == 1
+    # The riskier auto-commit/push/PR action stays scoped to danger mode.
+    assert auto_finalize_calls == []
+    assert state.get("auto_finalize") is None
+
+
 def test_run_worker_auto_finalizes_dirty_agy_worktree(
     tmp_tasks_dir,
     tmp_path,

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1492,6 +1492,58 @@ def test_run_worker_marks_needs_finalize_for_dirty_workspace_write_worktree(
     assert state.get("auto_finalize") is None
 
 
+def test_run_worker_marks_needs_finalize_when_dirty_state_is_unknown(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """An UNKNOWN dirty state must fail closed, exactly like an unknown commit count.
+
+    Sibling of the bug above, caught in cross-family review of #5754 after the count
+    half was fixed. ``_worktree_is_dirty`` returns None when it cannot tell (OSError,
+    or a non-zero ``git status --porcelain``). A bare ``if dirty_on_exit`` treats that
+    unknown as falsy and skips the whole check — failing OPEN in the precise way this
+    safety net exists to prevent, and letting a dispatch settle as ``done`` when we
+    cannot prove anything was committed.
+    """
+    task_id = "needs-finalize-unknown-dirty"
+    state_path = delegate._state_path(task_id)
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    delegate._write_state_atomic(state_path, {
+        "task_id": task_id,
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    monkeypatch.setattr(delegate, "_auto_finalize_dirty_worktree", lambda **_k: None)
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=_finalize_mock_result()),
+        # Dirty state unknowable, and the commit count unknowable too.
+        patch.object(delegate, "_worktree_is_dirty", return_value=None),
+        patch.object(delegate, "_count_commits_ahead", return_value=None),
+    ):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="grok",
+            prompt="do the work",
+            mode="workspace-write",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+            effort="high",
+        )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "needs_finalize", (
+        f"unknown dirty state reported {state['status']!r}; an unknowable worktree "
+        "cannot prove the work was committed and must fail closed"
+    )
+    assert state["needs_finalize"] is True
+    assert rc == 1
+
+
 def test_run_worker_auto_finalizes_dirty_agy_worktree(
     tmp_tasks_dir,
     tmp_path,


### PR DESCRIPTION
## This is the root cause of the night that produced nothing

The safety net already existed. `delegate.py` sets `status: needs_finalize` when a dispatch ends with
edits but no commits — but the check was gated on:

```python
if worktree_path and mode == "danger":
```

Every real dispatch runs **`workspace-write`**. So the net never fired.

**What that cost on 2026-07-25:** three lanes (`timeouts-B3`, `timeouts-B6`, `timeouts-B4-orig`) each
did genuine work, left it **uncommitted** in their worktrees, and reported **`status: done`**. Three
failures read as three successes. 31 files of finished work sat one agent restart from being lost, and
were recovered only because a human asked why the PRs didn't exist.

An orchestrator watching status fields would have seen a productive night and an empty repository.

## Second half of the same bug

`_count_commits_ahead` returns `None` when it cannot count, and `commits_ahead == 0` silently skipped
that case. The B4 dispatch exited with `commits_ahead: None` **and** `worktree_dirty_on_exit: true` —
and still settled as `done`. Unknown-plus-dirty cannot prove the work was committed, so it now **fails
closed**.

## The change

- Detection runs for the whole `_WRITE_CAPABLE_MODES` set — the constant the rest of the file already
  uses (lines 664, 718). This site simply predated it.
- An unknown commit count is treated as unfinalized rather than fine.
- **Auto-finalize stays scoped to `danger`.** That action auto-commits, pushes, and opens a PR; widening
  it is a separate decision and was deliberately not taken here. The test asserts it is *not* invoked in
  `workspace-write`, so the scoping cannot silently widen later.

## Deliberately NOT changed

Worktree **reaping** is also `danger`-only (line ~2470). Extending it would start auto-removing
`workspace-write` worktrees — and `MEMORY #M-10` exists precisely because removing a worktree with
uncommitted work destroys it. Tonight's three rescues came *out of* such worktrees. Separate decision,
not a drive-by.

## The test is proven load-bearing, not decorative

With the fix reverted, both new cases fail with exactly the bug's signature:

```
E     - needs_finalize
E     + done
FAILED …test_run_worker_marks_needs_finalize_for_dirty_workspace_write_worktree[0-zero-commits]
FAILED …test_run_worker_marks_needs_finalize_for_dirty_workspace_write_worktree[None-unknown-commit-count]
```

With the fix, they pass. Parametrized over `commits_ahead=0` and `commits_ahead=None`.

**Verified:** 140 passed in `tests/test_delegate.py`; ruff clean.

## What this does not fix

The other half of the false-`done` family is that **`--mode` defaults to `read-only`**, so a
code-writing brief dispatched without `--mode workspace-write --worktree` gets no worktree, cannot write,
and exits 0. Four dispatches died that way tonight. That is a CLI-ergonomics fix (warn or refuse when a
write-shaped dispatch is launched read-only) and is tracked separately rather than bundled here.

Refs #5740