### PR TITLE
fix(harness): thread lease checks owner liveness, not the clock

### DIFF
--- a/agents_extensions/shared/hooks/goal-driver-stop.sh
+++ b/agents_extensions/shared/hooks/goal-driver-stop.sh
@@ -16,7 +16,10 @@
 # what keeps that window from ever mistaking it for dead — see
 # refresh_thread_lease_heartbeat in scripts/orchestration/thread_handoff.py).
 # The refresh is a no-op unless this exact session already owns the lease, so
-# it can never steal or clobber another session's lease.
+# it can never steal or clobber another session's lease. This refresh is
+# unconditional (unthrottled) since Stop only fires once per turn; the
+# throttled per-tool-call companion is thread-lease-heartbeat.sh (PostToolUse,
+# issue #5759) — it covers a single tool call running longer than one turn.
 #
 # Skip in non-interactive / pipeline contexts to avoid latency in batch jobs.
 

--- a/agents_extensions/shared/hooks/goal-driver-stop.sh
+++ b/agents_extensions/shared/hooks/goal-driver-stop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Hook: Stop — /goal driver async-dispatch awareness.
+# Hook: Stop — /goal driver async-dispatch awareness + thread-lease heartbeat.
 #
 # Reads the Stop-event JSON on stdin and asks scripts/goal_driver/stop_hook.py
 # to inspect the transcript's last status line. The Python module emits
@@ -9,6 +9,14 @@
 # This hook NEVER blocks Stop. /goal's native predicate enforcement is
 # unchanged; this hook only annotates state so the next turn's counters
 # stay honest under async-heavy work. See issue #1933.
+#
+# It also best-effort refreshes this session's durable thread-lease heartbeat
+# (claim_thread_lease's short emergency TTL only covers the window where pid
+# liveness is uncheckable; a live owner refreshing its own heartbeat here is
+# what keeps that window from ever mistaking it for dead — see
+# refresh_thread_lease_heartbeat in scripts/orchestration/thread_handoff.py).
+# The refresh is a no-op unless this exact session already owns the lease, so
+# it can never steal or clobber another session's lease.
 #
 # Skip in non-interactive / pipeline contexts to avoid latency in batch jobs.
 
@@ -30,4 +38,39 @@ fi
 # root first; fail open if it is unreachable. (cwd-drift bug family: #4912/#4899.)
 cd "$PROJECT_DIR" || exit 0
 
-exec "$PYTHON" -m scripts.goal_driver.stop_hook
+# Read stdin exactly once — both the heartbeat refresh below and the exec'd
+# stop_hook module need the same session_id / transcript payload.
+STDIN_JSON=""
+if [ ! -t 0 ]; then
+  STDIN_JSON=$(cat)
+fi
+
+HANDOFF_AGENT="${SESSION_HANDOFF_AGENT:-claude}"
+case "$HANDOFF_AGENT" in
+  claude|claude-*)
+    if [ -n "$STDIN_JSON" ]; then
+      SESSION_ID=$(printf '%s' "$STDIN_JSON" | jq -r '.session_id // empty' 2>/dev/null)
+      if [ -n "$SESSION_ID" ]; then
+        if [ -n "${CODEX_CANONICAL_REPO_ROOT:-}" ]; then
+          CANONICAL_ROOT="$CODEX_CANONICAL_REPO_ROOT"
+        else
+          GIT_COMMON_DIR=$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+          if [ -n "$GIT_COMMON_DIR" ] && [ "$(basename "$GIT_COMMON_DIR")" = ".git" ]; then
+            CANONICAL_ROOT=$(dirname "$GIT_COMMON_DIR")
+          else
+            CANONICAL_ROOT="$PROJECT_DIR"
+          fi
+        fi
+        "$PYTHON" "$PROJECT_DIR/scripts/orchestration/thread_handoff.py" \
+          --repo-root "$CANONICAL_ROOT" refresh-thread-lease-heartbeat \
+          --agent "$HANDOFF_AGENT" --current-thread-id "$SESSION_ID" \
+          >/dev/null 2>&1 || true
+        unset CANONICAL_ROOT GIT_COMMON_DIR
+      fi
+      unset SESSION_ID
+    fi
+    ;;
+esac
+unset HANDOFF_AGENT
+
+exec "$PYTHON" -m scripts.goal_driver.stop_hook <<<"$STDIN_JSON"

--- a/agents_extensions/shared/hooks/goal-driver-stop.sh
+++ b/agents_extensions/shared/hooks/goal-driver-stop.sh
@@ -11,15 +11,16 @@
 # stay honest under async-heavy work. See issue #1933.
 #
 # It also best-effort refreshes this session's durable thread-lease heartbeat
-# (claim_thread_lease's short emergency TTL only covers the window where pid
-# liveness is uncheckable; a live owner refreshing its own heartbeat here is
-# what keeps that window from ever mistaking it for dead — see
-# refresh_thread_lease_heartbeat in scripts/orchestration/thread_handoff.py).
-# The refresh is a no-op unless this exact session already owns the lease, so
-# it can never steal or clobber another session's lease. This refresh is
-# unconditional (unthrottled) since Stop only fires once per turn; the
-# throttled per-tool-call companion is thread-lease-heartbeat.sh (PostToolUse,
-# issue #5759) — it covers a single tool call running longer than one turn.
+# (see refresh_thread_lease_heartbeat in scripts/orchestration/
+# thread_handoff.py). This is diagnostic only — claim_thread_lease never
+# takes an uncheckable owner over on clock age at all, so there is no window
+# left for a fresh heartbeat to protect. The refresh is a no-op unless this
+# exact session already owns the lease at the exact generation it claimed
+# (LEARN_UKRAINIAN_THREAD_LEASE_GENERATION, exported by session-setup.sh) and
+# its process identity can be reconfirmed, so it can never steal or clobber
+# another session's lease. This refresh is unconditional (unthrottled) since
+# Stop only fires once per turn; the throttled per-tool-call companion is
+# thread-lease-heartbeat.sh (PostToolUse, issue #5759).
 #
 # Skip in non-interactive / pipeline contexts to avoid latency in batch jobs.
 
@@ -53,7 +54,7 @@ case "$HANDOFF_AGENT" in
   claude|claude-*)
     if [ -n "$STDIN_JSON" ]; then
       SESSION_ID=$(printf '%s' "$STDIN_JSON" | jq -r '.session_id // empty' 2>/dev/null)
-      if [ -n "$SESSION_ID" ]; then
+      if [ -n "$SESSION_ID" ] && [ -n "${LEARN_UKRAINIAN_THREAD_LEASE_GENERATION:-}" ]; then
         if [ -n "${CODEX_CANONICAL_REPO_ROOT:-}" ]; then
           CANONICAL_ROOT="$CODEX_CANONICAL_REPO_ROOT"
         else
@@ -67,6 +68,7 @@ case "$HANDOFF_AGENT" in
         "$PYTHON" "$PROJECT_DIR/scripts/orchestration/thread_handoff.py" \
           --repo-root "$CANONICAL_ROOT" refresh-thread-lease-heartbeat \
           --agent "$HANDOFF_AGENT" --current-thread-id "$SESSION_ID" \
+          --generation "$LEARN_UKRAINIAN_THREAD_LEASE_GENERATION" \
           >/dev/null 2>&1 || true
         unset CANONICAL_ROOT GIT_COMMON_DIR
       fi

--- a/agents_extensions/shared/hooks/release-thread-lease.sh
+++ b/agents_extensions/shared/hooks/release-thread-lease.sh
@@ -16,6 +16,13 @@
 # fires after another session has already taken the lease over) can never
 # clobber a newer owner's lease.
 #
+# Generation is REQUIRED for a non-force release (thread_handoff.py raises
+# without it) — it is the fence that makes the previous paragraph true. The
+# generation this session actually claimed at SessionStart is exported by
+# session-setup.sh into $CLAUDE_ENV_FILE as LEARN_UKRAINIAN_THREAD_LEASE_GENERATION;
+# without it we cannot safely release (a missing/wrong generation could only
+# ever match by accident), so this hook no-ops rather than guessing one.
+#
 # Skip in non-interactive / pipeline contexts, matching session-setup.sh.
 
 if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$LEARN_UKRAINIAN_PIPELINE" ] || [ -n "$GEMINI_SESSION" ]; then
@@ -63,8 +70,17 @@ else
   fi
 fi
 
+if [ -z "${LEARN_UKRAINIAN_THREAD_LEASE_GENERATION:-}" ]; then
+  # No generation to fence with — release-thread-lease.py now refuses a non-force
+  # release without one. Leaving the lease in place is safe: claim_thread_lease's
+  # pid-liveness check is the primary defense and will reclaim it once this
+  # process is confirmed dead, regardless of this cooperative path.
+  exit 0
+fi
+
 "$PYTHON" "$PROJECT_DIR/scripts/orchestration/thread_handoff.py" --repo-root "$CANONICAL_ROOT" \
   release-thread-lease --agent "$HANDOFF_AGENT" --current-thread-id "$SESSION_ID" \
+  --generation "$LEARN_UKRAINIAN_THREAD_LEASE_GENERATION" \
   >/dev/null 2>&1 || true
 
 exit 0

--- a/agents_extensions/shared/hooks/release-thread-lease.sh
+++ b/agents_extensions/shared/hooks/release-thread-lease.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Hook: SessionEnd — best-effort release of this session's durable thread lease.
+#
+# session-setup.sh claims a single-writer lease per agent slot at SessionStart
+# so two driver sessions can never double-drive the same queue. Historically
+# there was no release path at all: an exited or crashed session held the
+# slot until its heartbeat aged past a fixed clock window, which is exactly
+# the operator-restart lockout this lease exists to prevent from recurring in
+# the *other* direction.
+#
+# This hook is the fast, cooperative release path. It is intentionally
+# best-effort: SessionEnd does not fire on SIGKILL or a hard crash, so the
+# owner-pid liveness check in claim_thread_lease (scripts/orchestration/
+# thread_handoff.py) remains the primary mechanism. Release is a no-op unless
+# this exact session id still owns the lease, so a hook that fires late (or
+# fires after another session has already taken the lease over) can never
+# clobber a newer owner's lease.
+#
+# Skip in non-interactive / pipeline contexts, matching session-setup.sh.
+
+if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$LEARN_UKRAINIAN_PIPELINE" ] || [ -n "$GEMINI_SESSION" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PYTHON="$PROJECT_DIR/.venv/bin/python"
+
+if [ ! -x "$PYTHON" ]; then
+  # Fail open: never let a missing venv block SessionEnd.
+  exit 0
+fi
+
+cd "$PROJECT_DIR" || exit 0
+
+STDIN_JSON=""
+if [ ! -t 0 ]; then
+  STDIN_JSON=$(cat)
+fi
+
+if [ -z "$STDIN_JSON" ]; then
+  exit 0
+fi
+
+SESSION_ID=$(printf '%s' "$STDIN_JSON" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+HANDOFF_AGENT="${SESSION_HANDOFF_AGENT:-claude}"
+case "$HANDOFF_AGENT" in
+  claude|claude-*) ;;
+  *) exit 0 ;;
+esac
+
+if [ -n "${CODEX_CANONICAL_REPO_ROOT:-}" ]; then
+  CANONICAL_ROOT="$CODEX_CANONICAL_REPO_ROOT"
+else
+  GIT_COMMON_DIR=$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  if [ -n "$GIT_COMMON_DIR" ] && [ "$(basename "$GIT_COMMON_DIR")" = ".git" ]; then
+    CANONICAL_ROOT=$(dirname "$GIT_COMMON_DIR")
+  else
+    CANONICAL_ROOT="$PROJECT_DIR"
+  fi
+fi
+
+"$PYTHON" "$PROJECT_DIR/scripts/orchestration/thread_handoff.py" --repo-root "$CANONICAL_ROOT" \
+  release-thread-lease --agent "$HANDOFF_AGENT" --current-thread-id "$SESSION_ID" \
+  >/dev/null 2>&1 || true
+
+exit 0

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -495,6 +495,46 @@ case "$HANDOFF_AGENT" in
       HANDOFF_CONTEXT="ERROR: DURABLE THREAD LEASE CONFLICT — stop; do not cold-start or drive this queue.
 Output:
 $THREAD_LEASE_OUTPUT"
+    else
+      # Propagate the exact generation this session just claimed so the SessionEnd
+      # release hook (release-thread-lease.sh) can fence its release with it —
+      # thread_handoff.py now refuses a non-force release without one (#5759).
+      THREAD_LEASE_GENERATION=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
+try:
+  d=json.loads(sys.stdin.read()); print(d.get("generation") or "")
+except Exception:
+  print("")' 2>/dev/null || true)
+      if [ -n "$THREAD_LEASE_GENERATION" ] && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+        printf 'export LEARN_UKRAINIAN_THREAD_LEASE_GENERATION=%s\n' "$THREAD_LEASE_GENERATION" >> "$CLAUDE_ENV_FILE" 2>/dev/null || true
+      fi
+      unset THREAD_LEASE_GENERATION
+
+      # A successful claim can still be a takeover (the previous owner was confirmed
+      # dead/zombie, or its pid was reused) or a heal from a corrupt on-disk lease.
+      # Neither may ever be silent — surface it into SessionStart context so the
+      # operator is told a slot changed hands before driving it (#5759).
+      THREAD_LEASE_TAKEOVER_BANNER=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    raise SystemExit(0)
+parts = []
+replaced = d.get("replaced_owner_thread_id")
+if replaced:
+    parts.append(
+        "THREAD LEASE TAKEOVER: this session (generation " + str(d.get("generation"))
+        + ") replaced owner " + str(replaced) + " -- reason: " + str(d.get("takeover_reason", "unknown")) + "."
+    )
+corrupt = d.get("recovered_from_corrupt_lease")
+if corrupt:
+    parts.append("THREAD LEASE HEALED: on-disk lease was corrupt and was reset -- " + str(corrupt) + ".")
+if parts:
+    print("\n".join(parts))
+' 2>/dev/null || true)
+      if [ -n "$THREAD_LEASE_TAKEOVER_BANNER" ]; then
+        INFO+=("$THREAD_LEASE_TAKEOVER_BANNER")
+      fi
+      unset THREAD_LEASE_TAKEOVER_BANNER
     fi
     ;;
 esac

--- a/agents_extensions/shared/hooks/thread-lease-heartbeat.sh
+++ b/agents_extensions/shared/hooks/thread-lease-heartbeat.sh
@@ -1,24 +1,28 @@
 #!/bin/bash
 # Hook: PostToolUse — throttled thread-lease heartbeat refresh (issue #5759).
 #
-# The Stop hook (goal-driver-stop.sh) only refreshes this session's durable
-# thread-lease heartbeat when a turn completes. A single tool call inside one
-# turn can run far longer than claim_thread_lease's 900s emergency TTL (the
-# fallback used only when the previous owner's liveness cannot be checked),
-# during which this session's own lease would look stale to a competing
-# SessionStart even though it is very much alive. This hook closes that gap
-# by firing on the much more frequent PostToolUse event instead.
+# This is diagnostic, not a safety mechanism: claim_thread_lease never takes
+# an uncheckable owner over on clock age at all (no emergency TTL exists
+# anymore — see thread_handoff.py), so there is no steal window left for a
+# fresh heartbeat to protect against. This hook exists only to keep
+# heartbeat_at meaningful for operators inspecting a lease file, refreshing
+# it far more often than the Stop hook (which only fires once per turn) by
+# also firing on the much more frequent PostToolUse event.
 #
 # Throttled to stay cheap: refresh_thread_lease_heartbeat only rewrites the
 # lease file when the existing heartbeat is already older than 60s, so the
 # common case (many tool calls per minute) is a read, never a write. It is
 # best-effort and never a takeover — a no-op for a lease this session does
-# not already own, exactly like the Stop-hook refresh.
+# not already own, at a different generation, or whose process identity it
+# cannot reconfirm, exactly like the Stop-hook refresh.
 #
-# Residual gap (documented, not fixed here): a single tool call that itself
-# runs longer than the emergency TTL, with a genuinely uncheckable owner and
-# no OTHER tool call firing in between, is still theoretically stealable —
-# this hook only ever runs between tool calls, never during one.
+# Fenced by generation, not just thread id: the generation this session
+# claimed at SessionStart is exported by session-setup.sh into
+# $CLAUDE_ENV_FILE as LEARN_UKRAINIAN_THREAD_LEASE_GENERATION (same variable
+# release-thread-lease.sh uses). Without it we cannot safely refresh (a
+# thread-id-only check could let a late predecessor heartbeat rewrite a
+# successor's recorded process identity — issue #5759 round 2), so this hook
+# no-ops rather than guessing one.
 #
 # Skip in non-interactive / pipeline contexts, matching every other
 # thread-lease hook.
@@ -56,6 +60,13 @@ if [ -z "$SESSION_ID" ]; then
   exit 0
 fi
 
+if [ -z "${LEARN_UKRAINIAN_THREAD_LEASE_GENERATION:-}" ]; then
+  # No generation to fence with — refresh_thread_lease_heartbeat now refuses to
+  # refresh without one. Leaving heartbeat_at stale is safe: it is diagnostic
+  # only, nothing takes a lease over on its age.
+  exit 0
+fi
+
 if [ -n "${CODEX_CANONICAL_REPO_ROOT:-}" ]; then
   CANONICAL_ROOT="$CODEX_CANONICAL_REPO_ROOT"
 else
@@ -70,6 +81,7 @@ fi
 "$PYTHON" "$PROJECT_DIR/scripts/orchestration/thread_handoff.py" \
   --repo-root "$CANONICAL_ROOT" refresh-thread-lease-heartbeat \
   --agent "$HANDOFF_AGENT" --current-thread-id "$SESSION_ID" \
+  --generation "$LEARN_UKRAINIAN_THREAD_LEASE_GENERATION" \
   --min-refresh-interval-seconds 60 \
   >/dev/null 2>&1 || true
 

--- a/agents_extensions/shared/hooks/thread-lease-heartbeat.sh
+++ b/agents_extensions/shared/hooks/thread-lease-heartbeat.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Hook: PostToolUse — throttled thread-lease heartbeat refresh (issue #5759).
+#
+# The Stop hook (goal-driver-stop.sh) only refreshes this session's durable
+# thread-lease heartbeat when a turn completes. A single tool call inside one
+# turn can run far longer than claim_thread_lease's 900s emergency TTL (the
+# fallback used only when the previous owner's liveness cannot be checked),
+# during which this session's own lease would look stale to a competing
+# SessionStart even though it is very much alive. This hook closes that gap
+# by firing on the much more frequent PostToolUse event instead.
+#
+# Throttled to stay cheap: refresh_thread_lease_heartbeat only rewrites the
+# lease file when the existing heartbeat is already older than 60s, so the
+# common case (many tool calls per minute) is a read, never a write. It is
+# best-effort and never a takeover — a no-op for a lease this session does
+# not already own, exactly like the Stop-hook refresh.
+#
+# Residual gap (documented, not fixed here): a single tool call that itself
+# runs longer than the emergency TTL, with a genuinely uncheckable owner and
+# no OTHER tool call firing in between, is still theoretically stealable —
+# this hook only ever runs between tool calls, never during one.
+#
+# Skip in non-interactive / pipeline contexts, matching every other
+# thread-lease hook.
+
+if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$LEARN_UKRAINIAN_PIPELINE" ] || [ -n "$GEMINI_SESSION" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PYTHON="$PROJECT_DIR/.venv/bin/python"
+
+if [ ! -x "$PYTHON" ]; then
+  # Fail open: never let a missing venv slow down or block a tool call.
+  exit 0
+fi
+
+cd "$PROJECT_DIR" || exit 0
+
+HANDOFF_AGENT="${SESSION_HANDOFF_AGENT:-claude}"
+case "$HANDOFF_AGENT" in
+  claude|claude-*) ;;
+  *) exit 0 ;;
+esac
+
+STDIN_JSON=""
+if [ ! -t 0 ]; then
+  STDIN_JSON=$(cat)
+fi
+if [ -z "$STDIN_JSON" ]; then
+  exit 0
+fi
+
+SESSION_ID=$(printf '%s' "$STDIN_JSON" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+if [ -n "${CODEX_CANONICAL_REPO_ROOT:-}" ]; then
+  CANONICAL_ROOT="$CODEX_CANONICAL_REPO_ROOT"
+else
+  GIT_COMMON_DIR=$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  if [ -n "$GIT_COMMON_DIR" ] && [ "$(basename "$GIT_COMMON_DIR")" = ".git" ]; then
+    CANONICAL_ROOT=$(dirname "$GIT_COMMON_DIR")
+  else
+    CANONICAL_ROOT="$PROJECT_DIR"
+  fi
+fi
+
+"$PYTHON" "$PROJECT_DIR/scripts/orchestration/thread_handoff.py" \
+  --repo-root "$CANONICAL_ROOT" refresh-thread-lease-heartbeat \
+  --agent "$HANDOFF_AGENT" --current-thread-id "$SESSION_ID" \
+  --min-refresh-interval-seconds 60 \
+  >/dev/null 2>&1 || true
+
+exit 0

--- a/agents_extensions/shared/settings.json
+++ b/agents_extensions/shared/settings.json
@@ -795,6 +795,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/release-thread-lease.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/agents_extensions/shared/settings.json
+++ b/agents_extensions/shared/settings.json
@@ -709,6 +709,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/stamp-pytest.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/thread-lease-heartbeat.sh",
+            "timeout": 3
           }
         ]
       }

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import os
 import re
+import socket
 import sqlite3
 import subprocess
 import sys
@@ -59,11 +60,28 @@ ORCHESTRATOR_HANDOFF_PATH = Path("docs/session-state/codex-orchestrator-handoff.
 DEFAULT_STALE_HOURS = 12
 # Default warning threshold (percentage of window)
 DEFAULT_CONTEXT_THRESHOLD = 88.0
-THREAD_LEASE_SCHEMA_VERSION = 1
-# A session's lease is refreshed at each SessionStart. Keep a conservative
-# takeover window: a live driver can work for hours between compaction events,
-# while a crashed session can still be deliberately recovered after this age.
-DEFAULT_THREAD_LEASE_FRESH_SECONDS = DEFAULT_STALE_HOURS * 60 * 60
+THREAD_LEASE_SCHEMA_VERSION = 2
+# Executable basenames trusted as durable agent-driver harness processes. The
+# ancestor walk in _find_harness_ancestor stops at the nearest one of these; a
+# transient hook-launcher subshell is never mistaken for the long-lived owner.
+KNOWN_HARNESS_EXECUTABLES = frozenset(
+    {"claude", "codex", "agy", "kimi", "cursor", "opencode", "hermes"}
+)
+MAX_HARNESS_ANCESTOR_HOPS = 10
+# Liveness is checked (pid + start time + machine id), not inferred from a
+# clock. This TTL only covers the residual case where liveness is genuinely
+# uncheckable (legacy v1 lease, cross-machine lease, unreadable process
+# state): it must stay short, because it is the ONLY protection against a
+# truly dead owner in that case. It is deliberately much shorter than the old
+# 12h clock-only window — that window existed only to compensate for having
+# no death signal, and keeping it here would leave the reported cold-start
+# lockout reachable in production whenever liveness cannot be checked.
+DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS = 15 * 60
+# Tolerance for comparing a recorded process start time against a freshly
+# probed one. psutil reports sub-second precision; the `ps -o lstart=`
+# fallback only has whole-second precision, and pid reuse within this window
+# is not distinguished from the original process (an accepted, documented gap).
+PROCESS_START_TIME_TOLERANCE_SECONDS = 2.0
 
 
 @dataclass(frozen=True)
@@ -628,38 +646,379 @@ def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
     os.replace(tmp, path)
 
 
-def _load_thread_lease(path: Path) -> dict[str, Any] | None:
-    """Load one durable cold-start lease without accepting malformed state."""
-    if not path.exists():
+@dataclass(frozen=True)
+class ProcessSnapshot:
+    """One process's identity facts, gathered atomically from a single probe.
+
+    ``candidate_basenames`` deliberately holds more than one name: measured on
+    a real Claude Code session, ``psutil.Process.name()`` for the ``claude``
+    harness process returns its version string (e.g. ``"2.1.220"``), not
+    ``claude`` — the CLI overrides its own process title. ``cmdline()[0]`` and
+    ``ps -o comm=`` both still resolve to a path basename of ``claude``.
+    Matching against every candidate we can cheaply gather is what makes the
+    harness-ancestor walk work on the machine it actually has to run on,
+    rather than only in a clean test environment.
+    """
+
+    pid: int
+    ppid: int | None
+    candidate_basenames: frozenset[str]
+    started_at: float | None
+
+
+def _parse_ps_lstart(raw: str) -> float | None:
+    """Parse ``ps -o lstart=`` (whole-second, local-time) into epoch seconds."""
+    try:
+        parsed = datetime.strptime(raw.strip(), "%a %b %d %H:%M:%S %Y")
+    except ValueError:
         return None
+    return parsed.timestamp()
+
+
+def _default_process_snapshot(pid: int) -> ProcessSnapshot | None:
+    """Probe one live process for ppid, candidate executable names, and start time.
+
+    Prefers psutil (locked in requirements-lock.txt) for one atomic read.
+    Falls back to ``ps`` (forced ``LC_ALL=C`` so ``lstart`` parses regardless
+    of locale) when psutil is unavailable or cannot see the process.
+    """
+    try:
+        import psutil
+
+        try:
+            proc = psutil.Process(pid)
+            candidates: set[str] = set()
+            name = proc.name()
+            if name:
+                candidates.add(Path(name).name)
+            for accessor in (proc.exe, proc.cmdline):
+                try:
+                    value = accessor()
+                except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+                    continue
+                if isinstance(value, list):
+                    if value and value[0]:
+                        candidates.add(Path(value[0]).name)
+                elif value:
+                    candidates.add(Path(value).name)
+            return ProcessSnapshot(
+                pid=pid,
+                ppid=proc.ppid(),
+                candidate_basenames=frozenset(candidates),
+                started_at=proc.create_time(),
+            )
+        except psutil.NoSuchProcess:
+            return None
+        except psutil.AccessDenied:
+            pass  # fall through to the ps fallback, which may still resolve lstart
+    except ImportError:
+        pass
+
+    env = git_environment()
+    env["LC_ALL"] = "C"
+    result = run_command(
+        ["ps", "-o", "ppid=,comm=,lstart=", "-p", str(pid)],
+        cwd=Path.cwd(),
+        env=env,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    fields = result.stdout.strip().split(None, 2)
+    if len(fields) < 3:
+        return None
+    try:
+        ppid = int(fields[0])
+    except ValueError:
+        ppid = None
+    candidate_basenames = frozenset({Path(fields[1]).name}) if fields[1] else frozenset()
+    started_at = _parse_ps_lstart(fields[2])
+    return ProcessSnapshot(pid=pid, ppid=ppid, candidate_basenames=candidate_basenames, started_at=started_at)
+
+
+def _find_harness_ancestor(
+    starting_pid: int,
+    *,
+    process_snapshot: Callable[[int], ProcessSnapshot | None] | None = None,
+    max_hops: int = MAX_HARNESS_ANCESTOR_HOPS,
+) -> ProcessSnapshot | None:
+    """Walk the parent-pid chain (bounded) for the nearest known-harness ancestor.
+
+    A hook subprocess's immediate parent is often a short-lived launcher
+    subshell, never the durable session owner. Recording that transient pid
+    as ``owner_pid`` would make a live session look dead the moment the
+    subshell exits, and the lease would be stolen out from under it while it
+    is still driving. Walking to the nearest recognizable harness process
+    (``claude``, ``codex``, ...) finds the actual long-lived owner instead.
+
+    ``process_snapshot`` resolves inside the body (not as a bound default) so
+    tests can either inject a fake process table here or monkeypatch
+    ``_default_process_snapshot`` and have callers like ``claim_thread_lease``
+    (which never pass an override) pick it up too.
+    """
+    snapshot_fn = process_snapshot or _default_process_snapshot
+    pid: int | None = starting_pid
+    seen: set[int] = set()
+    for _ in range(max_hops):
+        if pid is None or pid <= 0 or pid in seen:
+            return None
+        seen.add(pid)
+        snapshot = snapshot_fn(pid)
+        if snapshot is None:
+            return None
+        if snapshot.candidate_basenames & KNOWN_HARNESS_EXECUTABLES:
+            return snapshot
+        pid = snapshot.ppid
+    return None
+
+
+def _default_machine_id() -> str | None:
+    """Return a stable machine identifier — never a network hostname.
+
+    Hostnames change under macOS mDNS renames, VPN reassociation, and
+    container rebuilds; keying liveness off one would silently and
+    permanently push every lease onto the cross-machine fallback path and
+    resurrect the exact lockout this design fixes.
+    """
+    if sys.platform == "darwin":
+        result = run_command(
+            ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+            cwd=Path.cwd(),
+            env=git_environment(),
+        )
+        if result.returncode == 0:
+            match = re.search(r'"IOPlatformUUID"\s*=\s*"([^"]+)"', result.stdout)
+            if match:
+                return match.group(1)
+    else:
+        machine_id_path = Path("/etc/machine-id")
+        try:
+            value = machine_id_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            value = ""
+        if value:
+            return value
+    hostname = socket.gethostname().strip()
+    return hostname or None
+
+
+def _process_is_alive(pid: int) -> bool:
+    """POSIX liveness probe. EPERM means the process exists (owned by another user)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _derive_owner_liveness_fields(
+    starting_pid: int,
+    *,
+    process_snapshot: Callable[[int], ProcessSnapshot | None] | None = None,
+    machine_id: Callable[[], str | None] | None = None,
+) -> dict[str, Any]:
+    """Derive the v2 identity fields, or {} when liveness cannot be established.
+
+    An empty result is a legitimate, expected outcome (no harness ancestor
+    found, or no stable machine id available) — callers write a v2 lease
+    without liveness fields, which is the documented uncheckable path.
+    """
+    machine_id_fn = machine_id or _default_machine_id
+    try:
+        ancestor = _find_harness_ancestor(starting_pid, process_snapshot=process_snapshot)
+    except Exception:
+        ancestor = None
+    if ancestor is None or ancestor.started_at is None:
+        return {}
+    try:
+        resolved_machine_id = machine_id_fn()
+    except Exception:
+        resolved_machine_id = None
+    if not resolved_machine_id:
+        return {}
+    return {
+        "owner_pid": ancestor.pid,
+        "owner_pid_started_at": ancestor.started_at,
+        "owner_machine_id": resolved_machine_id,
+    }
+
+
+def _lease_liveness_checkable(
+    lease: Mapping[str, Any],
+    *,
+    machine_id: Callable[[], str | None] | None = None,
+) -> bool:
+    """A lease's liveness is checkable only with a complete, current-machine v2 identity."""
+    if lease.get("schema_version") != THREAD_LEASE_SCHEMA_VERSION:
+        return False
+    pid = lease.get("owner_pid")
+    started_at = lease.get("owner_pid_started_at")
+    recorded_machine_id = lease.get("owner_machine_id")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return False
+    if not isinstance(started_at, (int, float)) or isinstance(started_at, bool):
+        return False
+    if not isinstance(recorded_machine_id, str) or not recorded_machine_id.strip():
+        return False
+    machine_id_fn = machine_id or _default_machine_id
+    try:
+        current_machine_id = machine_id_fn()
+    except Exception:
+        return False
+    return bool(current_machine_id) and recorded_machine_id == current_machine_id
+
+
+def _evaluate_owner_liveness(
+    lease: Mapping[str, Any],
+    *,
+    process_is_alive: Callable[[int], bool] | None = None,
+    process_snapshot: Callable[[int], ProcessSnapshot | None] | None = None,
+    machine_id: Callable[[], str | None] | None = None,
+) -> tuple[str, str]:
+    """Return (path, reason); path is one of "alive", "dead", "uncheckable".
+
+    Never raises: a probe failure of any kind is an uncheckable verdict, not
+    an exception that could block a SessionStart hook.
+    """
+    if not _lease_liveness_checkable(lease, machine_id=machine_id):
+        return "uncheckable", "lease has no complete, current-machine liveness identity"
+    pid = int(lease["owner_pid"])
+    recorded_started_at = float(lease["owner_pid_started_at"])
+    is_alive_fn = process_is_alive or _process_is_alive
+    snapshot_fn = process_snapshot or _default_process_snapshot
+    try:
+        alive = is_alive_fn(pid)
+    except Exception as exc:
+        return "uncheckable", f"liveness probe raised: {type(exc).__name__}: {exc}"
+    if not alive:
+        return "dead", "owner process not found (ESRCH)"
+    try:
+        snapshot = snapshot_fn(pid)
+    except Exception as exc:
+        return "uncheckable", f"start-time probe raised: {type(exc).__name__}: {exc}"
+    if snapshot is None or snapshot.started_at is None:
+        return "uncheckable", "owner process is alive but its start time could not be determined"
+    if abs(snapshot.started_at - recorded_started_at) > PROCESS_START_TIME_TOLERANCE_SECONDS:
+        return "dead", "owner pid was reused by an unrelated process (start time mismatch)"
+    return "alive", "owner process is alive and its start time matches"
+
+
+def _read_lease_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Read a lease file without ever raising. Returns (payload, corrupt_error).
+
+    ``(None, None)`` means no file exists. ``(None, "<error>")`` means the file
+    exists but is unreadable or not a JSON object — unlike the old raising
+    loader, this is recoverable: the caller heals by acquiring a fresh lease
+    rather than wedging SessionStart shut with no release path.
+    """
+    if not path.exists():
+        return None, None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError(f"unreadable thread lease: {type(exc).__name__}: {exc}") from exc
+        return None, f"{type(exc).__name__}: {exc}"
     if not isinstance(payload, dict):
-        raise ValueError("thread lease is not a JSON object")
-    return payload
+        return None, "thread lease is not a JSON object"
+    return payload, None
 
 
-def _validate_thread_lease(lease: Mapping[str, Any], *, agent: str) -> dict[str, Any]:
-    """Validate the immutable ownership facts needed to block a second start."""
-    if lease.get("schema_version") != THREAD_LEASE_SCHEMA_VERSION:
-        raise ValueError(f"thread lease schema_version must be {THREAD_LEASE_SCHEMA_VERSION}")
-    if lease.get("agent") != agent:
-        raise ValueError(f"thread lease agent {lease.get('agent')!r} does not match requested agent {agent!r}")
-    owner_thread_id = lease.get("owner_thread_id")
-    if not isinstance(owner_thread_id, str) or not owner_thread_id.strip():
-        raise ValueError("thread lease owner_thread_id is missing or malformed")
-    generation = lease.get("generation")
-    if not isinstance(generation, int) or generation < 1:
-        raise ValueError("thread lease generation is missing or malformed")
-    heartbeat_at = parse_iso_datetime(lease.get("heartbeat_at"))
-    if heartbeat_at is None:
-        raise ValueError("thread lease heartbeat_at is missing or malformed")
-    acquired_at = parse_iso_datetime(lease.get("acquired_at"))
-    if acquired_at is None:
-        raise ValueError("thread lease acquired_at is missing or malformed")
-    return dict(lease)
+def _new_thread_lease_record(
+    *,
+    agent: str,
+    generation: int,
+    owner_thread_id: str,
+    acquired_at: str,
+    now: datetime,
+    starting_pid: int,
+    previous_owner_thread_id: str | None,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "schema_version": THREAD_LEASE_SCHEMA_VERSION,
+        "agent": agent,
+        "generation": generation,
+        "owner_thread_id": owner_thread_id,
+        "acquired_at": acquired_at,
+        "heartbeat_at": isoformat_z(now),
+        **_derive_owner_liveness_fields(starting_pid),
+    }
+    if previous_owner_thread_id is not None:
+        record["replaced_owner_thread_id"] = previous_owner_thread_id
+    return record
+
+
+def _fresh_acquire_result(
+    lease_path: Path,
+    *,
+    agent: str,
+    owner_thread_id: str,
+    now: datetime,
+    starting_pid: int,
+    recovered_from_corrupt_lease: str | None = None,
+) -> dict[str, Any]:
+    """Write and report a brand-new generation-1 lease (no prior owner to reconcile)."""
+    record = _new_thread_lease_record(
+        agent=agent,
+        generation=1,
+        owner_thread_id=owner_thread_id,
+        acquired_at=isoformat_z(now),
+        now=now,
+        starting_pid=starting_pid,
+        previous_owner_thread_id=None,
+    )
+    write_json_atomic(lease_path, record)
+    result = {
+        "status": "acquired",
+        "lease_path": lease_path,
+        "owner_thread_id": owner_thread_id,
+        "generation": 1,
+        "heartbeat_at": record["heartbeat_at"],
+        "replaced_owner_thread_id": None,
+        "liveness_fields_recorded": "owner_pid" in record,
+    }
+    if recovered_from_corrupt_lease is not None:
+        result["recovered_from_corrupt_lease"] = recovered_from_corrupt_lease
+    return result
+
+
+def _same_owner_refresh_result(
+    lease_path: Path,
+    existing_raw: Mapping[str, Any],
+    *,
+    agent: str,
+    owner_thread_id: str,
+    now: datetime,
+    starting_pid: int,
+) -> dict[str, Any]:
+    """Rewrite the lease this exact owner already holds, re-deriving liveness identity.
+
+    Rule E: this always re-derives the full v2 identity fields, so a legacy
+    v1 lease refreshed by its own owner is upgraded to v2 rather than staying
+    permanently stuck on the uncheckable fallback path.
+    """
+    raw_generation = existing_raw.get("generation")
+    generation = raw_generation if isinstance(raw_generation, int) and raw_generation >= 1 else 1
+    acquired_at = existing_raw.get("acquired_at")
+    if not isinstance(acquired_at, str) or parse_iso_datetime(acquired_at) is None:
+        acquired_at = isoformat_z(now)
+    record = _new_thread_lease_record(
+        agent=agent,
+        generation=generation,
+        owner_thread_id=owner_thread_id,
+        acquired_at=acquired_at,
+        now=now,
+        starting_pid=starting_pid,
+        previous_owner_thread_id=None,
+    )
+    write_json_atomic(lease_path, record)
+    return {
+        "status": "refreshed",
+        "lease_path": lease_path,
+        "owner_thread_id": owner_thread_id,
+        "generation": generation,
+        "heartbeat_at": record["heartbeat_at"],
+        "liveness_fields_recorded": "owner_pid" in record,
+    }
 
 
 def claim_thread_lease(
@@ -668,80 +1027,246 @@ def claim_thread_lease(
     agent: str,
     current_thread_id: str,
     now: datetime,
-    fresh_after: timedelta,
+    emergency_ttl: timedelta = timedelta(seconds=DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS),
+    starting_pid: int | None = None,
 ) -> dict[str, Any]:
     """Atomically claim or refresh a driver-session lease for ``agent``.
 
-    A fresh lease owned by a different SessionStart identity is a hard conflict:
-    callers must stop rather than guess which live session owns the queue.  A
-    stale lease is reclaimable and its generation advances, leaving durable
-    evidence of the takeover in the replacement lease.
+    Liveness is checked, not inferred from a clock: a different owner is a
+    conflict only while its process is confirmed alive (or, absent a
+    checkable process identity, only within a short emergency TTL). A
+    confirmed-dead or pid-reused owner is reclaimed immediately regardless of
+    clock age; an unreadable or malformed on-disk lease is treated as
+    recoverable state, never as a reason to raise and block SessionStart.
     """
     owner_thread_id = current_thread_id.strip()
     if not owner_thread_id:
         raise ValueError("current thread id is required to claim a durable thread lease")
-    if fresh_after <= timedelta(0):
-        raise ValueError("thread lease freshness must be positive")
+    if emergency_ttl <= timedelta(0):
+        raise ValueError("thread lease emergency TTL must be positive")
 
+    resolved_starting_pid = starting_pid if starting_pid is not None else os.getpid()
     lease_path = repo_local_path(state_root, default_thread_lease_path(agent))
     lock_path = lease_path.with_suffix(lease_path.suffix + ".lock")
+
     with task_family_advisory_lock(lock_path):
-        existing = _load_thread_lease(lease_path)
-        if existing is not None:
-            validated = _validate_thread_lease(existing, agent=agent)
-            heartbeat_at = parse_iso_datetime(str(validated["heartbeat_at"]))
-            assert heartbeat_at is not None  # validated above
-            held_by = str(validated["owner_thread_id"])
-            fresh = now - heartbeat_at <= fresh_after
-            if held_by != owner_thread_id and fresh:
+        existing_raw, corrupt_error = _read_lease_json(lease_path)
+
+        if corrupt_error is not None:
+            return _fresh_acquire_result(
+                lease_path,
+                agent=agent,
+                owner_thread_id=owner_thread_id,
+                now=now,
+                starting_pid=resolved_starting_pid,
+                recovered_from_corrupt_lease=corrupt_error,
+            )
+
+        if existing_raw is None:
+            return _fresh_acquire_result(
+                lease_path,
+                agent=agent,
+                owner_thread_id=owner_thread_id,
+                now=now,
+                starting_pid=resolved_starting_pid,
+            )
+
+        held_by = existing_raw.get("owner_thread_id")
+        held_by_valid = isinstance(held_by, str) and bool(held_by.strip())
+
+        if held_by_valid and held_by == owner_thread_id:
+            return _same_owner_refresh_result(
+                lease_path,
+                existing_raw,
+                agent=agent,
+                owner_thread_id=owner_thread_id,
+                now=now,
+                starting_pid=resolved_starting_pid,
+            )
+
+        raw_generation = existing_raw.get("generation")
+        generation = raw_generation if isinstance(raw_generation, int) and raw_generation >= 1 else 0
+        heartbeat_at = parse_iso_datetime(existing_raw.get("heartbeat_at"))
+        previous_owner = held_by if held_by_valid else None
+        liveness_path, liveness_reason = _evaluate_owner_liveness(existing_raw)
+
+        if liveness_path == "alive":
+            return {
+                "status": "conflict",
+                "lease_path": lease_path,
+                "owner_thread_id": previous_owner,
+                "generation": generation,
+                "heartbeat_at": isoformat_z(heartbeat_at) if heartbeat_at else None,
+                "liveness": "live_owner",
+                "reason": liveness_reason,
+            }
+
+        if liveness_path == "uncheckable":
+            age = now - heartbeat_at if heartbeat_at is not None else None
+            if age is not None and age <= emergency_ttl:
                 return {
                     "status": "conflict",
                     "lease_path": lease_path,
-                    "owner_thread_id": held_by,
-                    "generation": validated["generation"],
-                    "heartbeat_at": isoformat_z(heartbeat_at),
-                    "fresh_after_seconds": int(fresh_after.total_seconds()),
+                    "owner_thread_id": previous_owner,
+                    "generation": generation,
+                    "heartbeat_at": isoformat_z(heartbeat_at) if heartbeat_at else None,
+                    "liveness": "liveness_unknown",
+                    "reason": liveness_reason,
+                    "emergency_ttl_seconds": int(emergency_ttl.total_seconds()),
                 }
-            if held_by == owner_thread_id:
-                refreshed = {
-                    **validated,
-                    "heartbeat_at": isoformat_z(now),
-                }
-                write_json_atomic(lease_path, refreshed)
-                return {
-                    "status": "refreshed",
-                    "lease_path": lease_path,
-                    "owner_thread_id": owner_thread_id,
-                    "generation": refreshed["generation"],
-                    "heartbeat_at": refreshed["heartbeat_at"],
-                    "fresh_after_seconds": int(fresh_after.total_seconds()),
-                }
-            generation = int(validated["generation"]) + 1
-            previous_owner = held_by
+            takeover_reason = (
+                f"liveness uncheckable ({liveness_reason}) and heartbeat is older than the "
+                f"{int(emergency_ttl.total_seconds())}s emergency TTL"
+                if age is not None
+                else f"liveness uncheckable ({liveness_reason}) and heartbeat_at could not be parsed"
+            )
         else:
-            generation = 1
-            previous_owner = None
+            takeover_reason = liveness_reason
 
-        acquired = {
-            "schema_version": THREAD_LEASE_SCHEMA_VERSION,
-            "agent": agent,
-            "generation": generation,
-            "owner_thread_id": owner_thread_id,
-            "acquired_at": isoformat_z(now),
-            "heartbeat_at": isoformat_z(now),
-        }
-        if previous_owner is not None:
-            acquired["replaced_owner_thread_id"] = previous_owner
-        write_json_atomic(lease_path, acquired)
+        new_generation = generation + 1
+        record = _new_thread_lease_record(
+            agent=agent,
+            generation=new_generation,
+            owner_thread_id=owner_thread_id,
+            acquired_at=isoformat_z(now),
+            now=now,
+            starting_pid=resolved_starting_pid,
+            previous_owner_thread_id=previous_owner,
+        )
+        write_json_atomic(lease_path, record)
         return {
             "status": "acquired",
             "lease_path": lease_path,
             "owner_thread_id": owner_thread_id,
-            "generation": generation,
-            "heartbeat_at": acquired["heartbeat_at"],
-            "fresh_after_seconds": int(fresh_after.total_seconds()),
+            "generation": new_generation,
+            "heartbeat_at": record["heartbeat_at"],
             "replaced_owner_thread_id": previous_owner,
+            "liveness_fields_recorded": "owner_pid" in record,
+            "takeover_reason": takeover_reason,
         }
+
+
+def release_thread_lease(
+    *,
+    state_root: Path,
+    agent: str,
+    current_thread_id: str,
+    now: datetime,
+    generation: int | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Release a durable thread lease this exact owner (and generation) holds.
+
+    Best-effort by design: SessionEnd does not fire on SIGKILL, so the pid
+    liveness check in ``claim_thread_lease`` remains the primary defense —
+    this is only the fast, cooperative path. Never rewrites or upgrades a
+    lease it does not own; fencing (owner + generation match) means a late
+    release from a session that has already been superseded by a takeover
+    cannot clobber the new owner's lease.
+    """
+    owner_thread_id = current_thread_id.strip()
+    if not force and not owner_thread_id:
+        raise ValueError("current thread id is required to release a durable thread lease")
+
+    lease_path = repo_local_path(state_root, default_thread_lease_path(agent))
+    lock_path = lease_path.with_suffix(lease_path.suffix + ".lock")
+
+    with task_family_advisory_lock(lock_path):
+        existing_raw, corrupt_error = _read_lease_json(lease_path)
+        if existing_raw is None:
+            return {
+                "status": "noop",
+                "lease_path": lease_path,
+                "reason": "no lease file present" if corrupt_error is None else f"lease unreadable: {corrupt_error}",
+            }
+
+        held_by = existing_raw.get("owner_thread_id")
+        held_generation = existing_raw.get("generation")
+
+        if force:
+            lease_path.unlink(missing_ok=True)
+            return {
+                "status": "released",
+                "lease_path": lease_path,
+                "forced": True,
+                "previous_owner_thread_id": held_by,
+                "previous_generation": held_generation,
+            }
+
+        if held_by != owner_thread_id:
+            return {
+                "status": "noop",
+                "lease_path": lease_path,
+                "reason": "lease is owned by a different thread id; not releasing",
+                "current_owner_thread_id": held_by,
+                "current_generation": held_generation,
+            }
+        if generation is not None and held_generation != generation:
+            return {
+                "status": "noop",
+                "lease_path": lease_path,
+                "reason": "lease generation does not match; a takeover superseded this owner",
+                "current_owner_thread_id": held_by,
+                "current_generation": held_generation,
+            }
+
+        lease_path.unlink(missing_ok=True)
+        return {
+            "status": "released",
+            "lease_path": lease_path,
+            "forced": False,
+            "owner_thread_id": owner_thread_id,
+            "generation": held_generation,
+        }
+
+
+def refresh_thread_lease_heartbeat(
+    *,
+    state_root: Path,
+    agent: str,
+    current_thread_id: str,
+    now: datetime,
+    starting_pid: int | None = None,
+) -> dict[str, Any]:
+    """Best-effort heartbeat refresh for the ``Stop`` hook. A no-op unless we already own the lease.
+
+    This never attempts a takeover — unlike ``claim_thread_lease``, a
+    different owner (or an unreadable lease) is simply left alone. This is
+    what makes the short emergency TTL in ``claim_thread_lease`` safe: a live
+    owner working on the liveness-uncheckable path keeps its own heartbeat
+    fresh here, so it is never mistaken for stale and stolen mid-session.
+    """
+    owner_thread_id = current_thread_id.strip()
+    if not owner_thread_id:
+        return {"status": "noop", "reason": "no current thread id supplied"}
+
+    resolved_starting_pid = starting_pid if starting_pid is not None else os.getpid()
+    lease_path = repo_local_path(state_root, default_thread_lease_path(agent))
+    lock_path = lease_path.with_suffix(lease_path.suffix + ".lock")
+
+    with task_family_advisory_lock(lock_path):
+        existing_raw, corrupt_error = _read_lease_json(lease_path)
+        if existing_raw is None:
+            return {
+                "status": "noop",
+                "lease_path": lease_path,
+                "reason": "no lease file present" if corrupt_error is None else f"lease unreadable: {corrupt_error}",
+            }
+        held_by = existing_raw.get("owner_thread_id")
+        if held_by != owner_thread_id:
+            return {
+                "status": "noop",
+                "lease_path": lease_path,
+                "reason": "lease is owned by a different thread id; not refreshing",
+            }
+        return _same_owner_refresh_result(
+            lease_path,
+            existing_raw,
+            agent=agent,
+            owner_thread_id=owner_thread_id,
+            now=now,
+            starting_pid=resolved_starting_pid,
+        )
 
 
 def write_text_atomic(path: Path, text: str) -> None:
@@ -3648,6 +4173,13 @@ def cmd_detect(args: argparse.Namespace) -> int:
     return 0
 
 
+def _force_release_command(agent: str) -> str:
+    return (
+        f".venv/bin/python scripts/orchestration/thread_handoff.py release-thread-lease "
+        f"--agent {agent} --force"
+    )
+
+
 def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
     """Claim the durable single-driver lease used during SessionStart."""
     try:
@@ -3658,7 +4190,8 @@ def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
             agent=agent,
             current_thread_id=args.current_thread_id,
             now=utc_now(),
-            fresh_after=timedelta(seconds=args.fresh_after_seconds),
+            emergency_ttl=timedelta(seconds=args.emergency_ttl_seconds),
+            starting_pid=args.starting_pid,
         )
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
@@ -3671,15 +4204,89 @@ def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
         **result,
     }
     if payload["status"] == "conflict":
-        payload.update(
-            {
-                "error_code": "THREAD_LEASE_CONFLICT",
-                "error": "durable thread lease is held by another fresh session; stop to avoid double-driving",
-                "resolution": "Wait for the owner heartbeat to become stale, or verify that the owner session stopped before retrying.",
-            }
-        )
+        liveness = payload.get("liveness")
+        if liveness == "liveness_unknown":
+            payload.update(
+                {
+                    "error_code": "THREAD_LEASE_LIVENESS_UNKNOWN",
+                    "error": (
+                        "durable thread lease owner's liveness could not be checked and its "
+                        "heartbeat is still within the emergency TTL; stop to avoid double-driving"
+                    ),
+                    "resolution": (
+                        f"Wait for the emergency TTL to expire, or if the previous owner is "
+                        f"confirmed gone, force-release with: {_force_release_command(agent)}"
+                    ),
+                }
+            )
+        else:
+            payload.update(
+                {
+                    "error_code": "THREAD_LEASE_CONFLICT",
+                    "error": "durable thread lease is held by another live session; stop to avoid double-driving",
+                    "resolution": (
+                        f"Wait for the owner session to stop, or if it is confirmed gone, "
+                        f"force-release with: {_force_release_command(agent)}"
+                    ),
+                }
+            )
         print(json.dumps(payload, indent=2))
         return 2
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def cmd_release_thread_lease(args: argparse.Namespace) -> int:
+    """Release the durable single-driver lease, e.g. from a SessionEnd hook."""
+    try:
+        _, state_root = resolve_roots(args.repo_root)
+        agent = normalize_agent_name(args.agent)
+        if not args.force and not args.current_thread_id:
+            raise ValueError("--current-thread-id is required unless --force is given")
+        result = release_thread_lease(
+            state_root=state_root,
+            agent=agent,
+            current_thread_id=args.current_thread_id or "",
+            now=utc_now(),
+            generation=args.generation,
+            force=args.force,
+        )
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 2
+
+    lease_path = result.pop("lease_path")
+    payload = {
+        "agent": agent,
+        "lease_file": rel(lease_path, state_root),
+        **result,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def cmd_refresh_thread_lease_heartbeat(args: argparse.Namespace) -> int:
+    """Best-effort heartbeat refresh from the ``Stop`` hook. Always exits 0."""
+    try:
+        _, state_root = resolve_roots(args.repo_root)
+        agent = normalize_agent_name(args.agent)
+        result = refresh_thread_lease_heartbeat(
+            state_root=state_root,
+            agent=agent,
+            current_thread_id=args.current_thread_id,
+            now=utc_now(),
+            starting_pid=args.starting_pid,
+        )
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 0
+
+    lease_path = result.pop("lease_path", None)
+    payload = {
+        "agent": agent,
+        **({"lease_file": rel(lease_path, state_root)} if lease_path is not None else {}),
+        **result,
+    }
     print(json.dumps(payload, indent=2))
     return 0
 
@@ -3900,12 +4507,51 @@ def build_parser() -> argparse.ArgumentParser:
     claim_thread_lease_parser.add_argument("--agent", type=argparse_agent_name, required=True)
     claim_thread_lease_parser.add_argument("--current-thread-id", required=True)
     claim_thread_lease_parser.add_argument(
-        "--fresh-after-seconds",
+        "--emergency-ttl-seconds",
         type=int,
-        default=DEFAULT_THREAD_LEASE_FRESH_SECONDS,
-        help=f"Treat another owner heartbeat as live for this many seconds (default: {DEFAULT_THREAD_LEASE_FRESH_SECONDS}).",
+        default=DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS,
+        help=(
+            "Only used when the existing owner's liveness cannot be checked (legacy lease, "
+            "cross-machine, or unreadable process state): treat its heartbeat as live for this "
+            f"many seconds (default: {DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS}). A checkable "
+            "live or dead owner is decided by liveness alone, regardless of this value."
+        ),
+    )
+    claim_thread_lease_parser.add_argument(
+        "--starting-pid",
+        type=int,
+        default=None,
+        help="Override the pid the harness-ancestor walk starts from (defaults to this process's own pid).",
     )
     claim_thread_lease_parser.set_defaults(func=cmd_claim_thread_lease)
+
+    release_thread_lease_parser = subparsers.add_parser(
+        "release-thread-lease",
+        help="Release one agent slot's durable cold-start lease, e.g. from a SessionEnd hook.",
+    )
+    release_thread_lease_parser.add_argument("--agent", type=argparse_agent_name, required=True)
+    release_thread_lease_parser.add_argument("--current-thread-id", default="")
+    release_thread_lease_parser.add_argument(
+        "--generation",
+        type=int,
+        default=None,
+        help="Only release if the on-disk lease is still at this exact generation (fencing).",
+    )
+    release_thread_lease_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Operator escape hatch: release regardless of current owner/generation.",
+    )
+    release_thread_lease_parser.set_defaults(func=cmd_release_thread_lease)
+
+    refresh_heartbeat_parser = subparsers.add_parser(
+        "refresh-thread-lease-heartbeat",
+        help="Best-effort heartbeat refresh for the lease this exact thread already owns (Stop hook).",
+    )
+    refresh_heartbeat_parser.add_argument("--agent", type=argparse_agent_name, required=True)
+    refresh_heartbeat_parser.add_argument("--current-thread-id", required=True)
+    refresh_heartbeat_parser.add_argument("--starting-pid", type=int, default=None)
+    refresh_heartbeat_parser.set_defaults(func=cmd_refresh_thread_lease_heartbeat)
     return parser
 
 

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -77,11 +77,14 @@ MAX_HARNESS_ANCESTOR_HOPS = 10
 # no death signal, and keeping it here would leave the reported cold-start
 # lockout reachable in production whenever liveness cannot be checked.
 DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS = 15 * 60
-# Tolerance for comparing a recorded process start time against a freshly
-# probed one. psutil reports sub-second precision; the `ps -o lstart=`
-# fallback only has whole-second precision, and pid reuse within this window
-# is not distinguished from the original process (an accepted, documented gap).
-PROCESS_START_TIME_TOLERANCE_SECONDS = 2.0
+# Start times are compared at whole-second resolution, not a wider tolerance.
+# psutil reports sub-second precision; the `ps -o lstart=` fallback only has
+# whole-second precision. Truncating both to integer epoch seconds before
+# comparing is exact given that shared precision floor — a wider tolerance
+# would silently accept a pid-reused process that started within the same
+# multi-second window as a "match". Pid reuse within the same wall-clock
+# second is not distinguished from the original process (an accepted,
+# documented gap — the real precision boundary, not an arbitrary widening).
 
 
 @dataclass(frozen=True)
@@ -666,6 +669,16 @@ class ProcessSnapshot:
     started_at: float | None
 
 
+def _epoch_seconds(value: float) -> int:
+    """Truncate to whole epoch seconds — the precision both start-time probes share.
+
+    psutil.create_time() returns sub-second precision; the `ps -o lstart=` fallback only
+    parses whole seconds. Comparing at whole-second resolution is exact for both instead of
+    papering over the gap with an arbitrary tolerance window.
+    """
+    return int(value)
+
+
 def _parse_ps_lstart(raw: str) -> float | None:
     """Parse ``ps -o lstart=`` (whole-second, local-time) into epoch seconds."""
     try:
@@ -802,14 +815,45 @@ def _default_machine_id() -> str | None:
 
 
 def _process_is_alive(pid: int) -> bool:
-    """POSIX liveness probe. EPERM means the process exists (owned by another user)."""
+    """POSIX liveness probe. EPERM means the process exists (owned by another user).
+
+    A zombie (defunct) process also answers `kill(pid, 0)` successfully — its pid slot is
+    reserved until its parent reaps it — but it can never run again, refresh a heartbeat, or
+    release its lease. Treating it as alive would conflict with every future claim forever,
+    recreating the original lockout (a dead owner blocking every restart) under a new name.
+    A confirmed zombie is dead here, not merely absent.
+    """
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
     except PermissionError:
         return True
-    return True
+    return not _process_is_zombie(pid)
+
+
+def _process_is_zombie(pid: int) -> bool:
+    """Best-effort zombie probe. Never raises; an inconclusive read means "not confirmed zombie".
+
+    Prefers psutil's structured status. Falls back to `ps -o stat=` (forced `LC_ALL=C`,
+    matching `_default_process_snapshot`) when psutil is unavailable — the leading `Z` in the
+    state column is portable across macOS and Linux `ps` implementations.
+    """
+    try:
+        import psutil
+
+        try:
+            return psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            return False
+    except ImportError:
+        pass
+    env = git_environment()
+    env["LC_ALL"] = "C"
+    result = run_command(["ps", "-o", "stat=", "-p", str(pid)], cwd=Path.cwd(), env=env)
+    if result.returncode != 0:
+        return False
+    return result.stdout.strip()[:1] == "Z"
 
 
 def _derive_owner_liveness_fields(
@@ -892,14 +936,14 @@ def _evaluate_owner_liveness(
     except Exception as exc:
         return "uncheckable", f"liveness probe raised: {type(exc).__name__}: {exc}"
     if not alive:
-        return "dead", "owner process not found (ESRCH)"
+        return "dead", "owner process not found or is a zombie (ESRCH, or confirmed defunct)"
     try:
         snapshot = snapshot_fn(pid)
     except Exception as exc:
         return "uncheckable", f"start-time probe raised: {type(exc).__name__}: {exc}"
     if snapshot is None or snapshot.started_at is None:
         return "uncheckable", "owner process is alive but its start time could not be determined"
-    if abs(snapshot.started_at - recorded_started_at) > PROCESS_START_TIME_TOLERANCE_SECONDS:
+    if _epoch_seconds(snapshot.started_at) != _epoch_seconds(recorded_started_at):
         return "dead", "owner pid was reused by an unrelated process (start time mismatch)"
     return "alive", "owner process is alive and its start time matches"
 
@@ -1021,6 +1065,71 @@ def _same_owner_refresh_result(
     }
 
 
+def _same_owner_identity_confirmed(existing_raw: Mapping[str, Any], starting_pid: int) -> bool:
+    """True only when a resumed thread id is provably driven by the SAME process as before.
+
+    A same-owner refresh must never blindly preserve generation across a process change: a
+    resumed thread id (e.g. `claude --resume`) can be driven by a brand-new harness process
+    with a different pid, and if its lease kept the old generation, a delayed SessionEnd
+    release from the dead predecessor process — which cached that same old generation from
+    its own SessionStart — would still pass release_thread_lease's fencing and delete the
+    *successor's* live lease. When the recorded identity is checkable but a fresh probe
+    cannot confirm it still matches, this returns False so the caller reacquires with a new
+    generation instead of assuming continuity across an unproven process boundary.
+
+    When the recorded lease has no checkable identity at all (legacy v1, or a v2 lease that
+    could never derive one), there is nothing to contradict continuity with, so this returns
+    True and the existing v1->v2 upgrade-on-refresh behavior (rule E) is preserved unchanged.
+    """
+    if not _lease_liveness_checkable(existing_raw):
+        return True
+    new_fields = _derive_owner_liveness_fields(starting_pid)
+    if not new_fields:
+        return False
+    if new_fields["owner_pid"] != existing_raw.get("owner_pid"):
+        return False
+    return _epoch_seconds(new_fields["owner_pid_started_at"]) == _epoch_seconds(existing_raw.get("owner_pid_started_at"))
+
+
+def _identity_changed_reacquire_result(
+    lease_path: Path,
+    existing_raw: Mapping[str, Any],
+    *,
+    agent: str,
+    owner_thread_id: str,
+    now: datetime,
+    starting_pid: int,
+) -> dict[str, Any]:
+    """Reacquire with an incremented generation when the resuming process's identity changed.
+
+    See `_same_owner_identity_confirmed`: this is what actually fences a delayed release from
+    the dead predecessor process out — its cached generation no longer matches this lease.
+    """
+    raw_generation = existing_raw.get("generation")
+    generation = raw_generation if isinstance(raw_generation, int) and raw_generation >= 1 else 1
+    new_generation = generation + 1
+    record = _new_thread_lease_record(
+        agent=agent,
+        generation=new_generation,
+        owner_thread_id=owner_thread_id,
+        acquired_at=isoformat_z(now),
+        now=now,
+        starting_pid=starting_pid,
+        previous_owner_thread_id=owner_thread_id,
+    )
+    write_json_atomic(lease_path, record)
+    return {
+        "status": "acquired",
+        "lease_path": lease_path,
+        "owner_thread_id": owner_thread_id,
+        "generation": new_generation,
+        "heartbeat_at": record["heartbeat_at"],
+        "replaced_owner_thread_id": owner_thread_id,
+        "liveness_fields_recorded": "owner_pid" in record,
+        "takeover_reason": "same thread id resumed under a different process identity (pid/start time changed)",
+    }
+
+
 def claim_thread_lease(
     *,
     state_root: Path,
@@ -1075,7 +1184,16 @@ def claim_thread_lease(
         held_by_valid = isinstance(held_by, str) and bool(held_by.strip())
 
         if held_by_valid and held_by == owner_thread_id:
-            return _same_owner_refresh_result(
+            if _same_owner_identity_confirmed(existing_raw, resolved_starting_pid):
+                return _same_owner_refresh_result(
+                    lease_path,
+                    existing_raw,
+                    agent=agent,
+                    owner_thread_id=owner_thread_id,
+                    now=now,
+                    starting_pid=resolved_starting_pid,
+                )
+            return _identity_changed_reacquire_result(
                 lease_path,
                 existing_raw,
                 agent=agent,
@@ -1155,7 +1273,7 @@ def release_thread_lease(
     generation: int | None = None,
     force: bool = False,
 ) -> dict[str, Any]:
-    """Release a durable thread lease this exact owner (and generation) holds.
+    """Release a durable thread lease this exact owner and generation holds.
 
     Best-effort by design: SessionEnd does not fire on SIGKILL, so the pid
     liveness check in ``claim_thread_lease`` remains the primary defense —
@@ -1163,10 +1281,24 @@ def release_thread_lease(
     lease it does not own; fencing (owner + generation match) means a late
     release from a session that has already been superseded by a takeover
     cannot clobber the new owner's lease.
+
+    ``generation`` is mandatory unless ``force`` is given: the only production
+    call site (release-thread-lease.sh, the SessionEnd hook) must always pass
+    the exact generation it claimed at SessionStart. Generation is also what
+    fences a release by *process identity*, not merely thread id:
+    `claim_thread_lease`'s same-owner path (`_same_owner_identity_confirmed`)
+    increments generation whenever a resumed thread id is driven by a
+    different underlying process, so a delayed release from a dead
+    predecessor process — which can only ever know the generation it itself
+    observed — is refused here rather than deleting its live successor's lease.
     """
     owner_thread_id = current_thread_id.strip()
     if not force and not owner_thread_id:
         raise ValueError("current thread id is required to release a durable thread lease")
+    if not force and generation is None:
+        raise ValueError(
+            "generation is required to release a durable thread lease (fencing) unless force is given"
+        )
 
     lease_path = repo_local_path(state_root, default_thread_lease_path(agent))
     lock_path = lease_path.with_suffix(lease_path.suffix + ".lock")
@@ -1201,7 +1333,7 @@ def release_thread_lease(
                 "current_owner_thread_id": held_by,
                 "current_generation": held_generation,
             }
-        if generation is not None and held_generation != generation:
+        if held_generation != generation:
             return {
                 "status": "noop",
                 "lease_path": lease_path,
@@ -1227,14 +1359,21 @@ def refresh_thread_lease_heartbeat(
     current_thread_id: str,
     now: datetime,
     starting_pid: int | None = None,
+    min_refresh_interval: timedelta | None = None,
 ) -> dict[str, Any]:
-    """Best-effort heartbeat refresh for the ``Stop`` hook. A no-op unless we already own the lease.
+    """Best-effort heartbeat refresh. A no-op unless we already own the lease.
 
     This never attempts a takeover — unlike ``claim_thread_lease``, a
     different owner (or an unreadable lease) is simply left alone. This is
     what makes the short emergency TTL in ``claim_thread_lease`` safe: a live
-    owner working on the liveness-uncheckable path keeps its own heartbeat
-    fresh here, so it is never mistaken for stale and stolen mid-session.
+    owner keeps its own heartbeat fresh here, so it is never mistaken for
+    stale and stolen mid-session.
+
+    ``min_refresh_interval``, when given, throttles the write: the hot path
+    (called from ``PostToolUse``, on every tool call) is a cheap read that
+    no-ops — status ``"throttled"`` — unless the existing heartbeat is
+    already older than the interval. The ``Stop`` hook fires far less often
+    and omits this, refreshing unconditionally every call.
     """
     owner_thread_id = current_thread_id.strip()
     if not owner_thread_id:
@@ -1259,6 +1398,14 @@ def refresh_thread_lease_heartbeat(
                 "lease_path": lease_path,
                 "reason": "lease is owned by a different thread id; not refreshing",
             }
+        if min_refresh_interval is not None:
+            heartbeat_at = parse_iso_datetime(existing_raw.get("heartbeat_at"))
+            if heartbeat_at is not None and (now - heartbeat_at) < min_refresh_interval:
+                return {
+                    "status": "throttled",
+                    "lease_path": lease_path,
+                    "heartbeat_at": isoformat_z(heartbeat_at),
+                }
         return _same_owner_refresh_result(
             lease_path,
             existing_raw,
@@ -4266,7 +4413,7 @@ def cmd_release_thread_lease(args: argparse.Namespace) -> int:
 
 
 def cmd_refresh_thread_lease_heartbeat(args: argparse.Namespace) -> int:
-    """Best-effort heartbeat refresh from the ``Stop`` hook. Always exits 0."""
+    """Best-effort heartbeat refresh from the ``Stop``/``PostToolUse`` hooks. Always exits 0."""
     try:
         _, state_root = resolve_roots(args.repo_root)
         agent = normalize_agent_name(args.agent)
@@ -4276,6 +4423,11 @@ def cmd_refresh_thread_lease_heartbeat(args: argparse.Namespace) -> int:
             current_thread_id=args.current_thread_id,
             now=utc_now(),
             starting_pid=args.starting_pid,
+            min_refresh_interval=(
+                timedelta(seconds=args.min_refresh_interval_seconds)
+                if args.min_refresh_interval_seconds is not None
+                else None
+            ),
         )
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
@@ -4535,7 +4687,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--generation",
         type=int,
         default=None,
-        help="Only release if the on-disk lease is still at this exact generation (fencing).",
+        help=(
+            "Required unless --force: only release if the on-disk lease is still at this "
+            "exact generation (fencing, including across a process-identity change)."
+        ),
     )
     release_thread_lease_parser.add_argument(
         "--force",
@@ -4546,11 +4701,23 @@ def build_parser() -> argparse.ArgumentParser:
 
     refresh_heartbeat_parser = subparsers.add_parser(
         "refresh-thread-lease-heartbeat",
-        help="Best-effort heartbeat refresh for the lease this exact thread already owns (Stop hook).",
+        help=(
+            "Best-effort heartbeat refresh for the lease this exact thread already owns "
+            "(Stop and PostToolUse hooks)."
+        ),
     )
     refresh_heartbeat_parser.add_argument("--agent", type=argparse_agent_name, required=True)
     refresh_heartbeat_parser.add_argument("--current-thread-id", required=True)
     refresh_heartbeat_parser.add_argument("--starting-pid", type=int, default=None)
+    refresh_heartbeat_parser.add_argument(
+        "--min-refresh-interval-seconds",
+        type=float,
+        default=None,
+        help=(
+            "Throttle: no-op (cheap read only) unless the existing heartbeat is older than "
+            "this many seconds. Omit for an unconditional refresh (e.g. the Stop hook)."
+        ),
+    )
     refresh_heartbeat_parser.set_defaults(func=cmd_refresh_thread_lease_heartbeat)
     return parser
 

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -68,15 +68,6 @@ KNOWN_HARNESS_EXECUTABLES = frozenset(
     {"claude", "codex", "agy", "kimi", "cursor", "opencode", "hermes"}
 )
 MAX_HARNESS_ANCESTOR_HOPS = 10
-# Liveness is checked (pid + start time + machine id), not inferred from a
-# clock. This TTL only covers the residual case where liveness is genuinely
-# uncheckable (legacy v1 lease, cross-machine lease, unreadable process
-# state): it must stay short, because it is the ONLY protection against a
-# truly dead owner in that case. It is deliberately much shorter than the old
-# 12h clock-only window — that window existed only to compensate for having
-# no death signal, and keeping it here would leave the reported cold-start
-# lockout reachable in production whenever liveness cannot be checked.
-DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS = 15 * 60
 # Start times are compared at whole-second resolution, not a wider tolerance.
 # psutil reports sub-second precision; the `ps -o lstart=` fallback only has
 # whole-second precision. Truncating both to integer epoch seconds before
@@ -1065,7 +1056,9 @@ def _same_owner_refresh_result(
     }
 
 
-def _same_owner_identity_confirmed(existing_raw: Mapping[str, Any], starting_pid: int) -> bool:
+def _same_owner_identity_confirmed(
+    existing_raw: Mapping[str, Any], starting_pid: int, *, require_proof: bool = False
+) -> bool:
     """True only when a resumed thread id is provably driven by the SAME process as before.
 
     A same-owner refresh must never blindly preserve generation across a process change: a
@@ -1077,12 +1070,21 @@ def _same_owner_identity_confirmed(existing_raw: Mapping[str, Any], starting_pid
     cannot confirm it still matches, this returns False so the caller reacquires with a new
     generation instead of assuming continuity across an unproven process boundary.
 
-    When the recorded lease has no checkable identity at all (legacy v1, or a v2 lease that
-    could never derive one), there is nothing to contradict continuity with, so this returns
-    True and the existing v1->v2 upgrade-on-refresh behavior (rule E) is preserved unchanged.
+    ``require_proof`` controls what happens when the recorded lease has NO checkable identity
+    at all (legacy v1, or a v2 lease that could never derive one) — there is nothing to
+    contradict continuity with, but also nothing to prove it either:
+
+    - Default (``False``), used by ``claim_thread_lease``'s explicit same-owner resume: this
+      returns True, so the existing v1->v2 upgrade-on-refresh behavior (rule E) still heals a
+      legacy lease the first time its own owner resumes it.
+    - ``True``, used by ``refresh_thread_lease_heartbeat``: this returns False. A heartbeat
+      call is implicit and frequent, not an explicit resume — it must never assume unproven
+      process continuity just to keep writing a lease it cannot actually verify it still owns.
+      A no-op there is safe: nothing takes a lease over on heartbeat age anymore, so a stale
+      heartbeat on an uncheckable lease costs nothing.
     """
     if not _lease_liveness_checkable(existing_raw):
-        return True
+        return not require_proof
     new_fields = _derive_owner_liveness_fields(starting_pid)
     if not new_fields:
         return False
@@ -1136,23 +1138,26 @@ def claim_thread_lease(
     agent: str,
     current_thread_id: str,
     now: datetime,
-    emergency_ttl: timedelta = timedelta(seconds=DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS),
     starting_pid: int | None = None,
 ) -> dict[str, Any]:
     """Atomically claim or refresh a driver-session lease for ``agent``.
 
     Liveness is checked, not inferred from a clock: a different owner is a
-    conflict only while its process is confirmed alive (or, absent a
-    checkable process identity, only within a short emergency TTL). A
-    confirmed-dead or pid-reused owner is reclaimed immediately regardless of
-    clock age; an unreadable or malformed on-disk lease is treated as
-    recoverable state, never as a reason to raise and block SessionStart.
+    conflict while its process is confirmed alive, AND while its liveness
+    cannot be checked at all (legacy v1 lease, cross-machine lease,
+    unreadable process state). The clock never grants ownership to anyone —
+    there is no emergency TTL that takes an uncheckable owner over on age.
+    Silently stealing from a possibly-live owner would corrupt the very
+    mutual exclusion this lease exists to provide; an uncheckable conflict
+    instead surfaces the exact operator command (``release-thread-lease
+    --force``) to unlock it. A confirmed-dead or pid-reused owner is
+    reclaimed immediately regardless of clock age; an unreadable or
+    malformed on-disk lease is treated as recoverable state, never as a
+    reason to raise and block SessionStart.
     """
     owner_thread_id = current_thread_id.strip()
     if not owner_thread_id:
         raise ValueError("current thread id is required to claim a durable thread lease")
-    if emergency_ttl <= timedelta(0):
-        raise ValueError("thread lease emergency TTL must be positive")
 
     resolved_starting_pid = starting_pid if starting_pid is not None else os.getpid()
     lease_path = repo_local_path(state_root, default_thread_lease_path(agent))
@@ -1220,27 +1225,20 @@ def claim_thread_lease(
             }
 
         if liveness_path == "uncheckable":
-            age = now - heartbeat_at if heartbeat_at is not None else None
-            if age is not None and age <= emergency_ttl:
-                return {
-                    "status": "conflict",
-                    "lease_path": lease_path,
-                    "owner_thread_id": previous_owner,
-                    "generation": generation,
-                    "heartbeat_at": isoformat_z(heartbeat_at) if heartbeat_at else None,
-                    "liveness": "liveness_unknown",
-                    "reason": liveness_reason,
-                    "emergency_ttl_seconds": int(emergency_ttl.total_seconds()),
-                }
-            takeover_reason = (
-                f"liveness uncheckable ({liveness_reason}) and heartbeat is older than the "
-                f"{int(emergency_ttl.total_seconds())}s emergency TTL"
-                if age is not None
-                else f"liveness uncheckable ({liveness_reason}) and heartbeat_at could not be parsed"
-            )
-        else:
-            takeover_reason = liveness_reason
+            # Never take over on clock age: an uncheckable owner might be alive.
+            # heartbeat_at is diagnostic only here; it grants nobody ownership.
+            return {
+                "status": "conflict",
+                "lease_path": lease_path,
+                "owner_thread_id": previous_owner,
+                "generation": generation,
+                "heartbeat_at": isoformat_z(heartbeat_at) if heartbeat_at else None,
+                "liveness": "liveness_unknown",
+                "reason": liveness_reason,
+            }
 
+        # Only "dead" reaches here: a confirmed-dead or pid-reused owner is
+        # reclaimed immediately, regardless of clock age.
         new_generation = generation + 1
         record = _new_thread_lease_record(
             agent=agent,
@@ -1260,7 +1258,7 @@ def claim_thread_lease(
             "heartbeat_at": record["heartbeat_at"],
             "replaced_owner_thread_id": previous_owner,
             "liveness_fields_recorded": "owner_pid" in record,
-            "takeover_reason": takeover_reason,
+            "takeover_reason": liveness_reason,
         }
 
 
@@ -1357,6 +1355,7 @@ def refresh_thread_lease_heartbeat(
     state_root: Path,
     agent: str,
     current_thread_id: str,
+    generation: int,
     now: datetime,
     starting_pid: int | None = None,
     min_refresh_interval: timedelta | None = None,
@@ -1364,10 +1363,25 @@ def refresh_thread_lease_heartbeat(
     """Best-effort heartbeat refresh. A no-op unless we already own the lease.
 
     This never attempts a takeover — unlike ``claim_thread_lease``, a
-    different owner (or an unreadable lease) is simply left alone. This is
-    what makes the short emergency TTL in ``claim_thread_lease`` safe: a live
-    owner keeps its own heartbeat fresh here, so it is never mistaken for
-    stale and stolen mid-session.
+    different owner, a stale generation, or an unconfirmed process identity
+    is simply left alone. Fenced by BOTH ``owner_thread_id`` and
+    ``generation``: thread id alone is not enough, because a takeover that
+    resumes the SAME thread id under a NEW process (see
+    ``_same_owner_identity_confirmed``) bumps generation but keeps the old
+    thread id — a late heartbeat call still in flight from the dead
+    predecessor process would otherwise pass a thread-id-only check and
+    overwrite the successor's recorded process identity with its own stale
+    one. On top of that, the recorded process identity must be reconfirmed
+    against the calling process (``require_proof=True``: an uncheckable
+    identity is never assumed to be continuous here, unlike the explicit
+    same-owner resume path in ``claim_thread_lease``) — any mismatch, or any
+    identity that cannot be reconfirmed, is a no-op, never a rewrite.
+
+    This is diagnostic, not a safety mechanism: there is no emergency TTL
+    left for a fresh heartbeat to protect against (see ``claim_thread_lease``
+    — an uncheckable owner is never taken over on clock age at all now), so
+    a no-op here just leaves ``heartbeat_at`` looking a little stale, which
+    costs nothing.
 
     ``min_refresh_interval``, when given, throttles the write: the hot path
     (called from ``PostToolUse``, on every tool call) is a cheap read that
@@ -1398,6 +1412,14 @@ def refresh_thread_lease_heartbeat(
                 "lease_path": lease_path,
                 "reason": "lease is owned by a different thread id; not refreshing",
             }
+        held_generation = existing_raw.get("generation")
+        if held_generation != generation:
+            return {
+                "status": "noop",
+                "lease_path": lease_path,
+                "reason": "lease generation does not match; a takeover superseded this owner",
+                "current_generation": held_generation,
+            }
         if min_refresh_interval is not None:
             heartbeat_at = parse_iso_datetime(existing_raw.get("heartbeat_at"))
             if heartbeat_at is not None and (now - heartbeat_at) < min_refresh_interval:
@@ -1406,6 +1428,12 @@ def refresh_thread_lease_heartbeat(
                     "lease_path": lease_path,
                     "heartbeat_at": isoformat_z(heartbeat_at),
                 }
+        if not _same_owner_identity_confirmed(existing_raw, resolved_starting_pid, require_proof=True):
+            return {
+                "status": "noop",
+                "lease_path": lease_path,
+                "reason": "recorded process identity could not be reconfirmed; not refreshing",
+            }
         return _same_owner_refresh_result(
             lease_path,
             existing_raw,
@@ -4337,7 +4365,6 @@ def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
             agent=agent,
             current_thread_id=args.current_thread_id,
             now=utc_now(),
-            emergency_ttl=timedelta(seconds=args.emergency_ttl_seconds),
             starting_pid=args.starting_pid,
         )
     except ValueError as exc:
@@ -4357,12 +4384,14 @@ def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
                 {
                     "error_code": "THREAD_LEASE_LIVENESS_UNKNOWN",
                     "error": (
-                        "durable thread lease owner's liveness could not be checked and its "
-                        "heartbeat is still within the emergency TTL; stop to avoid double-driving"
+                        "durable thread lease owner's liveness could not be checked and it is "
+                        "never taken over automatically (no clock-based takeover); stop to avoid "
+                        "double-driving"
                     ),
                     "resolution": (
-                        f"Wait for the emergency TTL to expire, or if the previous owner is "
-                        f"confirmed gone, force-release with: {_force_release_command(agent)}"
+                        f"If the previous owner ({payload.get('lease_file')}) is confirmed gone, "
+                        f"force-release with: {_force_release_command(agent)} — then start normally "
+                        f"again. Otherwise wait for it to exit and release cooperatively."
                     ),
                 }
             )
@@ -4421,6 +4450,7 @@ def cmd_refresh_thread_lease_heartbeat(args: argparse.Namespace) -> int:
             state_root=state_root,
             agent=agent,
             current_thread_id=args.current_thread_id,
+            generation=args.generation,
             now=utc_now(),
             starting_pid=args.starting_pid,
             min_refresh_interval=(
@@ -4659,17 +4689,6 @@ def build_parser() -> argparse.ArgumentParser:
     claim_thread_lease_parser.add_argument("--agent", type=argparse_agent_name, required=True)
     claim_thread_lease_parser.add_argument("--current-thread-id", required=True)
     claim_thread_lease_parser.add_argument(
-        "--emergency-ttl-seconds",
-        type=int,
-        default=DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS,
-        help=(
-            "Only used when the existing owner's liveness cannot be checked (legacy lease, "
-            "cross-machine, or unreadable process state): treat its heartbeat as live for this "
-            f"many seconds (default: {DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS}). A checkable "
-            "live or dead owner is decided by liveness alone, regardless of this value."
-        ),
-    )
-    claim_thread_lease_parser.add_argument(
         "--starting-pid",
         type=int,
         default=None,
@@ -4708,6 +4727,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     refresh_heartbeat_parser.add_argument("--agent", type=argparse_agent_name, required=True)
     refresh_heartbeat_parser.add_argument("--current-thread-id", required=True)
+    refresh_heartbeat_parser.add_argument(
+        "--generation",
+        type=int,
+        required=True,
+        help=(
+            "Fencing: only refresh if the on-disk lease is still at this exact generation "
+            "(the generation this session claimed at SessionStart, e.g. "
+            "$LEARN_UKRAINIAN_THREAD_LEASE_GENERATION)."
+        ),
+    )
     refresh_heartbeat_parser.add_argument("--starting-pid", type=int, default=None)
     refresh_heartbeat_parser.add_argument(
         "--min-refresh-interval-seconds",

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -1075,16 +1075,27 @@ def _same_owner_identity_confirmed(
     contradict continuity with, but also nothing to prove it either:
 
     - Default (``False``), used by ``claim_thread_lease``'s explicit same-owner resume: this
-      returns True, so the existing v1->v2 upgrade-on-refresh behavior (rule E) still heals a
-      legacy lease the first time its own owner resumes it.
+      returns True **only for a legacy v1 lease**, so the v1->v2 upgrade-on-refresh behavior
+      (rule E) still heals a legacy lease the first time its own owner resumes it.
     - ``True``, used by ``refresh_thread_lease_heartbeat``: this returns False. A heartbeat
       call is implicit and frequent, not an explicit resume — it must never assume unproven
       process continuity just to keep writing a lease it cannot actually verify it still owns.
       A no-op there is safe: nothing takes a lease over on heartbeat age anymore, so a stale
       heartbeat on an uncheckable lease costs nothing.
+
+    A **v2** lease whose identity is merely unusable (incomplete liveness fields, or another
+    machine's) is NOT eligible for that upgrade concession, even on the explicit-resume path.
+    Its predecessor ran under this schema and therefore may already have exported this exact
+    generation at its own SessionStart, so preserving the generation would let a delayed
+    ``SessionEnd`` from that dead process pass ``release_thread_lease``'s fencing and delete
+    the *successor's* live lease — the precise double-driving the generation fence exists to
+    stop, leaking in exactly the case where the lease is least verifiable. Only v1 predates
+    the generation export and so provably cannot hold a generation to release with.
     """
     if not _lease_liveness_checkable(existing_raw):
-        return not require_proof
+        if existing_raw.get("schema_version") != THREAD_LEASE_SCHEMA_VERSION:
+            return not require_proof
+        return False
     new_fields = _derive_owner_liveness_fields(starting_pid)
     if not new_fields:
         return False

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -643,43 +643,444 @@ def test_default_agent_paths_are_agent_specific():
     assert th.default_handoff_path("claude") == Path("docs/session-state/current.claude.md")
 
 
-def test_fresh_thread_lease_blocks_a_second_claude_infra_session(tmp_path: Path):
+def _v2_lease(
+    *,
+    owner_thread_id: str = "old-owner",
+    generation: int = 1,
+    heartbeat_at: str = "2026-07-23T10:00:00Z",
+    acquired_at: str = "2026-07-23T09:00:00Z",
+    owner_pid: int = 4242,
+    owner_pid_started_at: float = 1000.0,
+    owner_machine_id: str = "machine-a",
+    agent: str = "claude-infra",
+) -> dict:
+    return {
+        "schema_version": 2,
+        "agent": agent,
+        "generation": generation,
+        "owner_thread_id": owner_thread_id,
+        "acquired_at": acquired_at,
+        "heartbeat_at": heartbeat_at,
+        "owner_pid": owner_pid,
+        "owner_pid_started_at": owner_pid_started_at,
+        "owner_machine_id": owner_machine_id,
+    }
+
+
+def _write_lease(tmp_path: Path, agent: str, lease: dict) -> Path:
+    path = tmp_path / f".agent/{agent}-thread-lease.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(lease), encoding="utf-8")
+    return path
+
+
+def _fake_snapshot(**overrides) -> th.ProcessSnapshot:
+    defaults = {"pid": 4242, "ppid": 1, "candidate_basenames": frozenset(), "started_at": 1000.0}
+    defaults.update(overrides)
+    return th.ProcessSnapshot(**defaults)
+
+
+# --- claim_thread_lease: liveness-based takeover (test matrix items 1-13) ---
+
+
+def test_dead_owner_fresh_clock_takes_over(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Matrix 1: today's user-facing bug — a dead owner must never lock out a restart."""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
-    first = th.claim_thread_lease(
-        state_root=tmp_path,
-        agent="claude-infra",
-        current_thread_id="infra-session-one",
-        now=now,
-        fresh_after=timedelta(minutes=15),
-    )
-    second = th.claim_thread_lease(
-        state_root=tmp_path,
-        agent="claude-infra",
-        current_thread_id="infra-session-two",
-        now=now + timedelta(minutes=1),
-        fresh_after=timedelta(minutes=15),
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:59:00Z")  # 1 minute old: fresh under the old clock design
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_process_is_alive", lambda pid: False)
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
     )
 
-    lease_path = tmp_path / ".agent/claude-infra-thread-lease.json"
-    assert first["status"] == "acquired"
-    assert second == {
-        "status": "conflict",
-        "lease_path": lease_path,
-        "owner_thread_id": "infra-session-one",
-        "generation": 1,
-        "heartbeat_at": "2026-07-23T10:00:00Z",
-        "fresh_after_seconds": 900,
+    assert result["status"] == "acquired"
+    assert result["generation"] == 2
+    assert result["replaced_owner_thread_id"] == "old-owner"
+    assert "not found" in result["takeover_reason"]
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["owner_thread_id"] == "new-owner"
+    assert on_disk["generation"] == 2
+
+
+def test_live_owner_fresh_clock_conflicts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Matrix 2: unchanged behavior — a genuinely live owner is never stolen from."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:59:00Z")
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_process_is_alive", lambda pid: True)
+    monkeypatch.setattr(th, "_default_process_snapshot", lambda pid: _fake_snapshot(pid=pid))
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "live_owner"
+    assert result["owner_thread_id"] == "old-owner"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "old-owner"
+
+
+def test_live_owner_beyond_old_clock_window_still_conflicts_not_stolen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Matrix 3: today's opposite bug — a live owner working >12h must not be stolen from."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-22T08:00:00Z")  # 26h old: reclaimable under the old clock-only design
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_process_is_alive", lambda pid: True)
+    monkeypatch.setattr(th, "_default_process_snapshot", lambda pid: _fake_snapshot(pid=pid))
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "live_owner"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "old-owner"
+
+
+def test_pid_reused_by_unrelated_process_takes_over(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Matrix 4: start-time mismatch means the pid was recycled — takeover regardless of clock age."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:59:00Z", owner_pid_started_at=1000.0)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_process_is_alive", lambda pid: True)
+    monkeypatch.setattr(th, "_default_process_snapshot", lambda pid: _fake_snapshot(pid=pid, started_at=5000.0))
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "acquired"
+    assert "reused" in result["takeover_reason"]
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "new-owner"
+
+
+def test_legacy_v1_lease_with_stale_heartbeat_is_healed_by_takeover(tmp_path: Path):
+    """Matrix 5 / rule C: the migration heal — this is the exact stuck-lease shape on disk today."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    v1_lease = {
+        "schema_version": 1,
+        "agent": "claude-infra",
+        "generation": 3,
+        "owner_thread_id": "old-owner-v1",
+        "acquired_at": "2026-07-22T01:00:00Z",
+        "heartbeat_at": "2026-07-23T01:00:00Z",  # 9 hours old
     }
-    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "infra-session-one"
+    lease_path = _write_lease(tmp_path, "claude-infra", v1_lease)
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "acquired"
+    assert result["generation"] == 4
+    assert result["replaced_owner_thread_id"] == "old-owner-v1"
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["schema_version"] == 2
+    assert on_disk["owner_thread_id"] == "new-owner"
+
+
+def test_legacy_v1_lease_within_emergency_ttl_conflicts_as_liveness_unknown(tmp_path: Path):
+    """Matrix 6: the short emergency TTL, not the old 12h window, gates the uncheckable path."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    v1_lease = {
+        "schema_version": 1,
+        "agent": "claude-infra",
+        "generation": 1,
+        "owner_thread_id": "old-owner-v1",
+        "acquired_at": "2026-07-23T09:55:00Z",
+        "heartbeat_at": "2026-07-23T09:55:00Z",  # 5 minutes old: inside the 900s default TTL
+    }
+    lease_path = _write_lease(tmp_path, "claude-infra", v1_lease)
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "liveness_unknown"
+    assert result["owner_thread_id"] == "old-owner-v1"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "old-owner-v1"
+
+
+def test_different_machine_id_is_uncheckable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Matrix 7: a lease recorded on another machine can never be liveness-checked here."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:55:00Z", owner_machine_id="machine-remote")
+    _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-local")
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "liveness_unknown"
+
+
+def test_liveness_probe_raising_never_escapes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Matrix 8: a probe failure of any kind is an uncheckable verdict, never an exception."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:55:00Z")
+    _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+
+    def _boom(pid: int) -> bool:
+        raise OSError("simulated probe failure")
+
+    monkeypatch.setattr(th, "_process_is_alive", _boom)
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "liveness_unknown"
+    assert "probe raised" in result["reason"]
+
+
+def test_eperm_from_os_kill_is_treated_as_alive_and_conflicts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Matrix 9: EPERM means the process exists (owned by another user), not that it's dead."""
+
+    def _raise_eperm(pid: int, sig: int) -> None:
+        raise PermissionError("no permission")
+
+    monkeypatch.setattr(th.os, "kill", _raise_eperm)
+    assert th._process_is_alive(4242) is True  # unit-level: the EPERM branch itself
+
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:55:00Z", owner_pid=4242, owner_pid_started_at=1000.0)
+    _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_default_process_snapshot", lambda pid: _fake_snapshot(pid=pid))
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "live_owner"
+
+
+def test_malformed_v2_liveness_fields_are_uncheckable_not_raised(tmp_path: Path):
+    """Matrix 10: a malformed individual field degrades to uncheckable, never raises."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:55:00Z")
+    lease["owner_pid"] = "not-an-int"
+    _write_lease(tmp_path, "claude-infra", lease)
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "liveness_unknown"
+
+
+def test_unknown_future_schema_version_is_uncheckable_not_raised(tmp_path: Path):
+    """Matrix 11: SessionStart must never be blocked by a schema version this code predates."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:55:00Z")
+    lease["schema_version"] = 3
+    _write_lease(tmp_path, "claude-infra", lease)
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "liveness_unknown"
+
+
+def test_corrupt_json_lease_heals_via_fresh_acquire(tmp_path: Path):
+    """Matrix 12: unreadable/corrupt state is recoverable, never a reason to raise and block."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease_path = tmp_path / ".agent/claude-infra-thread-lease.json"
+    lease_path.parent.mkdir(parents=True)
+    lease_path.write_text("{not-valid-json", encoding="utf-8")
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "acquired"
+    assert result["generation"] == 1
+    assert "recovered_from_corrupt_lease" in result
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["owner_thread_id"] == "new-owner"
+    assert on_disk["schema_version"] == 2
+
+
+def test_same_owner_refresh_upgrades_v1_lease_to_v2(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Matrix 13 / rule E: a same-owner refresh must not leave a v1 lease stuck on the fallback path."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    v1_lease = {
+        "schema_version": 1,
+        "agent": "claude-infra",
+        "generation": 2,
+        "owner_thread_id": "same-owner",
+        "acquired_at": "2026-07-23T09:00:00Z",
+        "heartbeat_at": "2026-07-23T09:00:00Z",
+    }
+    lease_path = _write_lease(tmp_path, "claude-infra", v1_lease)
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 555, "owner_pid_started_at": 42.0, "owner_machine_id": "machine-a"},
+    )
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="same-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "refreshed"
+    assert result["generation"] == 2
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["schema_version"] == 2
+    assert on_disk["owner_pid"] == 555
+    assert on_disk["owner_machine_id"] == "machine-a"
+    assert on_disk["acquired_at"] == "2026-07-23T09:00:00Z"  # preserved across the v1->v2 upgrade
+    assert on_disk["heartbeat_at"] == "2026-07-23T10:00:00Z"  # refreshed
+
+
+# --- release_thread_lease: fencing (test matrix items 14-16) ---
+
+
+def test_release_by_non_owner_is_noop(tmp_path: Path):
+    """Matrix 14: release never touches a lease it does not own."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="real-owner", generation=1)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+
+    result = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="impostor", now=now
+    )
+
+    assert result["status"] == "noop"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "real-owner"
+
+
+def test_release_after_takeover_is_fenced_by_owner_and_generation(tmp_path: Path):
+    """Matrix 15: a stale former owner's late SessionEnd must not clobber the new owner's lease."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    # On-disk state after a real takeover: "new-owner" now holds generation 2.
+    current_lease = _v2_lease(owner_thread_id="new-owner", generation=2)
+    lease_path = _write_lease(tmp_path, "claude-infra", current_lease)
+
+    # The old owner's late SessionEnd, still believing it holds generation 1.
+    result = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="old-owner", now=now, generation=1
+    )
+
+    assert result["status"] == "noop"
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["owner_thread_id"] == "new-owner"
+    assert on_disk["generation"] == 2
+
+    # Generation fencing also holds even when the owner_thread_id happens to match.
+    result_same_owner_wrong_generation = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, generation=1
+    )
+    assert result_same_owner_wrong_generation["status"] == "noop"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["generation"] == 2
+
+
+def test_release_thread_lease_takes_the_advisory_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Matrix 16: an unlocked release could lose updates or clobber a newer generation."""
+    events: list[str] = []
+
+    class RecordingLock:
+        def __enter__(self) -> None:
+            events.append("lock-entered")
+
+        def __exit__(self, *_args: object) -> None:
+            events.append("lock-exited")
+
+    monkeypatch.setattr(th, "task_family_advisory_lock", lambda _path: RecordingLock())
+
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    result = th.release_thread_lease(state_root=tmp_path, agent="claude-infra", current_thread_id="whoever", now=now)
+
+    assert result["status"] == "noop"  # no lease file exists — the lock must still be taken
+    assert events == ["lock-entered", "lock-exited"]
+
+
+def test_release_thread_lease_force_bypasses_ownership(tmp_path: Path):
+    """The operator escape hatch named in every conflict message."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="somebody-else", generation=5)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+
+    result = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="", now=now, force=True
+    )
+
+    assert result["status"] == "released"
+    assert result["forced"] is True
+    assert not lease_path.exists()
+
+
+# --- harness-ancestor walk (test matrix items 17-18) ---
+
+
+def test_ancestor_walk_skips_transient_subshell_and_finds_harness():
+    """Matrix 17: a fake process table, no shelling out — the launcher subshell must be skipped."""
+    table = {
+        100: _fake_snapshot(pid=100, ppid=200, candidate_basenames=frozenset({"python3.12"}), started_at=10.0),
+        200: _fake_snapshot(pid=200, ppid=300, candidate_basenames=frozenset({"bash"}), started_at=9.0),
+        300: _fake_snapshot(pid=300, ppid=1, candidate_basenames=frozenset({"claude"}), started_at=1.0),
+    }
+
+    ancestor = th._find_harness_ancestor(100, process_snapshot=lambda pid: table.get(pid))
+
+    assert ancestor is not None
+    assert ancestor.pid == 300
+    assert ancestor.started_at == 1.0
+
+
+def test_ancestor_walk_with_no_harness_ancestor_records_no_liveness_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Matrix 18: no known-harness ancestor means the uncheckable path, never a guessed pid."""
+    table = {
+        100: _fake_snapshot(pid=100, ppid=200, candidate_basenames=frozenset({"python3.12"}), started_at=10.0),
+        200: _fake_snapshot(pid=200, ppid=1, candidate_basenames=frozenset({"launchd"}), started_at=1.0),
+    }
+
+    ancestor = th._find_harness_ancestor(100, process_snapshot=lambda pid: table.get(pid))
+    assert ancestor is None
+
+    fields = th._derive_owner_liveness_fields(100, process_snapshot=lambda pid: table.get(pid))
+    assert fields == {}
+
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    monkeypatch.setattr(th, "_default_process_snapshot", lambda pid: table.get(pid))
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="fresh-owner", now=now, starting_pid=100
+    )
+
+    assert result["status"] == "acquired"
+    assert result["liveness_fields_recorded"] is False
+    on_disk = json.loads((tmp_path / ".agent/claude-infra-thread-lease.json").read_text(encoding="utf-8"))
+    assert "owner_pid" not in on_disk
 
 
 def test_claim_thread_lease_command_reports_a_clear_double_launch_conflict(tmp_path: Path, capsys):
+    """CLI-level: deterministic across environments via --starting-pid 1 (never a known harness)."""
     command = [
         "--repo-root",
         str(tmp_path),
         "claim-thread-lease",
         "--agent",
         "claude-infra",
+        "--starting-pid",
+        "1",
         "--current-thread-id",
     ]
 
@@ -688,9 +1089,41 @@ def test_claim_thread_lease_command_reports_a_clear_double_launch_conflict(tmp_p
     assert th.main([*command, "second-session"]) == 2
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["error_code"] == "THREAD_LEASE_CONFLICT"
+    assert payload["error_code"] == "THREAD_LEASE_LIVENESS_UNKNOWN"
     assert payload["owner_thread_id"] == "first-session"
     assert "stop to avoid double-driving" in payload["error"]
+    assert "release-thread-lease" in payload["resolution"]
+
+
+def test_release_thread_lease_command_end_to_end(tmp_path: Path, capsys):
+    """CLI-level: claim then release through the same subcommands a real hook would call."""
+    repo_args = ["--repo-root", str(tmp_path)]
+
+    assert th.main([*repo_args, "claim-thread-lease", "--agent", "claude-infra", "--starting-pid", "1",
+                     "--current-thread-id", "cli-session"]) == 0
+    capsys.readouterr()
+
+    assert th.main([*repo_args, "release-thread-lease", "--agent", "claude-infra",
+                     "--current-thread-id", "cli-session"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "released"
+    assert not (tmp_path / ".agent/claude-infra-thread-lease.json").exists()
+
+
+def test_refresh_thread_lease_heartbeat_command_is_noop_for_a_different_owner(tmp_path: Path, capsys):
+    """Rule G: the Stop-hook heartbeat refresh must never take over — only ever refresh its own lease."""
+    repo_args = ["--repo-root", str(tmp_path)]
+    assert th.main([*repo_args, "claim-thread-lease", "--agent", "claude-infra", "--starting-pid", "1",
+                     "--current-thread-id", "owner-session"]) == 0
+    capsys.readouterr()
+
+    assert th.main([*repo_args, "refresh-thread-lease-heartbeat", "--agent", "claude-infra",
+                     "--current-thread-id", "someone-else", "--starting-pid", "1"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "noop"
+    assert json.loads((tmp_path / ".agent/claude-infra-thread-lease.json").read_text())["owner_thread_id"] == (
+        "owner-session"
+    )
 
 
 def test_checkout_continuity_requires_clean_source_binding_and_same_clean_head():

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -999,6 +999,47 @@ def test_corrupt_json_lease_heals_via_fresh_acquire(tmp_path: Path):
     assert on_disk["schema_version"] == 2
 
 
+def test_same_owner_resume_of_uncheckable_v2_lease_reacquires_with_new_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A v2 lease with no usable identity must NOT keep its generation on an explicit resume.
+
+    Cross-family review finding F002 (gpt-5.6-sol, PR #5758). The v1->v2 upgrade concession is
+    safe only because a v1 lease predates the generation export, so its predecessor cannot hold
+    a generation to release with. A v2 lease whose liveness fields are absent is different: its
+    predecessor ran under this schema and may already have exported generation 2, so preserving
+    it would let that dead predecessor's delayed SessionEnd pass release fencing and delete THIS
+    process's live lease.
+    """
+    now = datetime(2026, 7, 25, 10, 0, tzinfo=UTC)
+    uncheckable_v2 = {
+        "schema_version": th.THREAD_LEASE_SCHEMA_VERSION,
+        "agent": "claude-infra",
+        "generation": 2,
+        "owner_thread_id": "same-owner",
+        "acquired_at": "2026-07-25T09:00:00Z",
+        "heartbeat_at": "2026-07-25T09:00:00Z",
+        # v2, but carries no owner_pid/owner_pid_started_at/owner_machine_id — nothing to probe.
+    }
+    lease_path = _write_lease(tmp_path, "claude-infra", uncheckable_v2)
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 777, "owner_pid_started_at": 99.0, "owner_machine_id": "machine-a"},
+    )
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="same-owner", now=now, starting_pid=1
+    )
+
+    # The generation MUST advance: absence of proof is not proof of continuity.
+    assert result["generation"] == 3, "an uncheckable v2 lease must reacquire, not refresh in place"
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["generation"] == 3
+    assert on_disk["owner_pid"] == 777
+    assert on_disk["owner_machine_id"] == "machine-a"
+
+
 def test_same_owner_refresh_upgrades_v1_lease_to_v2(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Matrix 13 / rule E: a same-owner refresh must not leave a v1 lease stuck on the fallback path."""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import sqlite3
@@ -798,33 +799,9 @@ def test_start_time_one_whole_second_apart_is_treated_as_pid_reuse(tmp_path: Pat
     assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "new-owner"
 
 
-def test_legacy_v1_lease_with_stale_heartbeat_is_healed_by_takeover(tmp_path: Path):
-    """Matrix 5 / rule C: the migration heal — this is the exact stuck-lease shape on disk today."""
-    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
-    v1_lease = {
-        "schema_version": 1,
-        "agent": "claude-infra",
-        "generation": 3,
-        "owner_thread_id": "old-owner-v1",
-        "acquired_at": "2026-07-22T01:00:00Z",
-        "heartbeat_at": "2026-07-23T01:00:00Z",  # 9 hours old
-    }
-    lease_path = _write_lease(tmp_path, "claude-infra", v1_lease)
-
-    result = th.claim_thread_lease(
-        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
-    )
-
-    assert result["status"] == "acquired"
-    assert result["generation"] == 4
-    assert result["replaced_owner_thread_id"] == "old-owner-v1"
-    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
-    assert on_disk["schema_version"] == 2
-    assert on_disk["owner_thread_id"] == "new-owner"
-
-
-def test_legacy_v1_lease_within_emergency_ttl_conflicts_as_liveness_unknown(tmp_path: Path):
-    """Matrix 6: the short emergency TTL, not the old 12h window, gates the uncheckable path."""
+def test_legacy_v1_lease_with_fresh_heartbeat_conflicts_as_liveness_unknown(tmp_path: Path):
+    """Matrix 5/6: an uncheckable owner (legacy v1 lease) is never taken over — a DIFFERENT
+    thread id claiming it always conflicts and points at the operator force-release command."""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
     v1_lease = {
         "schema_version": 1,
@@ -832,7 +809,7 @@ def test_legacy_v1_lease_within_emergency_ttl_conflicts_as_liveness_unknown(tmp_
         "generation": 1,
         "owner_thread_id": "old-owner-v1",
         "acquired_at": "2026-07-23T09:55:00Z",
-        "heartbeat_at": "2026-07-23T09:55:00Z",  # 5 minutes old: inside the 900s default TTL
+        "heartbeat_at": "2026-07-23T09:55:00Z",  # 5 minutes old
     }
     lease_path = _write_lease(tmp_path, "claude-infra", v1_lease)
 
@@ -844,6 +821,46 @@ def test_legacy_v1_lease_within_emergency_ttl_conflicts_as_liveness_unknown(tmp_
     assert result["liveness"] == "liveness_unknown"
     assert result["owner_thread_id"] == "old-owner-v1"
     assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "old-owner-v1"
+
+
+def test_uncheckable_lease_never_taken_over_regardless_of_clock_age(tmp_path: Path):
+    """Fix 5 (design change, supersedes the 900s emergency TTL): this used to be the exact
+    stuck-lease shape that healed via a clock-based takeover once the heartbeat aged past the
+    TTL (formerly ``test_legacy_v1_lease_with_stale_heartbeat_is_healed_by_takeover``, deleted
+    — it asserted status == "acquired" here, which is now the vulnerability, not the fix).
+    Silently stealing from a possibly-live owner whose liveness just cannot be checked would
+    corrupt the mutual exclusion this lease exists to provide, so a DIFFERENT thread id must
+    conflict no matter how old the heartbeat is — there is no longer a clock that grants
+    ownership to anyone. The legacy lease still heals, but only via the same-owner refresh
+    upgrade path (see test_same_owner_refresh_upgrades_v1_lease_to_v2) or an explicit
+    --force release, never via a timer."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    v1_lease = {
+        "schema_version": 1,
+        "agent": "claude-infra",
+        "generation": 3,
+        "owner_thread_id": "old-owner-v1",
+        "acquired_at": "2026-07-22T01:00:00Z",
+        "heartbeat_at": "2026-07-23T01:00:00Z",  # 9 hours old: reclaimable under the old TTL design
+    }
+    lease_path = _write_lease(tmp_path, "claude-infra", v1_lease)
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "liveness_unknown"
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["owner_thread_id"] == "old-owner-v1"  # untouched — no takeover happened
+    assert on_disk["schema_version"] == 1  # not healed by this path either
+
+
+def test_claim_thread_lease_has_no_emergency_ttl_parameter(tmp_path: Path):
+    """Fix 5: the emergency TTL and its parameter are deleted outright, not merely unused —
+    guards against a future reintroduction of clock-based takeover."""
+    assert "emergency_ttl" not in inspect.signature(th.claim_thread_lease).parameters
+    assert not hasattr(th, "DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS")
 
 
 def test_different_machine_id_is_uncheckable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -1307,7 +1324,8 @@ def test_refresh_thread_lease_heartbeat_command_is_noop_for_a_different_owner(tm
     capsys.readouterr()
 
     assert th.main([*repo_args, "refresh-thread-lease-heartbeat", "--agent", "claude-infra",
-                     "--current-thread-id", "someone-else", "--starting-pid", "1"]) == 0
+                     "--current-thread-id", "someone-else", "--starting-pid", "1",
+                     "--generation", "1"]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "noop"
     assert json.loads((tmp_path / ".agent/claude-infra-thread-lease.json").read_text())["owner_thread_id"] == (
@@ -1315,9 +1333,98 @@ def test_refresh_thread_lease_heartbeat_command_is_noop_for_a_different_owner(tm
     )
 
 
+def test_refresh_thread_lease_heartbeat_is_noop_for_a_stale_generation(tmp_path: Path):
+    """Fix 2: a takeover that resumes the SAME thread id under a NEW process bumps generation
+    but keeps the old thread id — a late heartbeat call still in flight from the dead
+    predecessor process, carrying the OLD generation it cached, must not rewrite the
+    successor's recorded process identity just because the thread id still matches."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="resumed-thread", generation=2, owner_pid=222, owner_pid_started_at=5000.0)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    original = lease_path.read_text(encoding="utf-8")
+
+    result = th.refresh_thread_lease_heartbeat(
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="resumed-thread",
+        generation=1,  # the dead predecessor's stale, cached generation
+        now=now,
+        starting_pid=111,  # the dead predecessor's own pid
+    )
+
+    assert result["status"] == "noop"
+    assert "generation" in result["reason"]
+    assert lease_path.read_text(encoding="utf-8") == original  # never rewritten
+
+
+def test_refresh_thread_lease_heartbeat_is_noop_when_process_identity_unconfirmed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Fix 2: even with a matching thread id AND generation, the heartbeat refresh must
+    reconfirm the calling process's identity — unlike claim_thread_lease's explicit
+    same-owner resume, it never assumes unproven continuity for an uncheckable lease."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="owner-session", generation=1, owner_pid=111, owner_pid_started_at=1000.0)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    original = lease_path.read_text(encoding="utf-8")
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    # A fresh probe from the calling process resolves to a DIFFERENT identity.
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 222, "owner_pid_started_at": 5000.0, "owner_machine_id": "machine-a"},
+    )
+
+    result = th.refresh_thread_lease_heartbeat(
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="owner-session",
+        generation=1,
+        now=now,
+        starting_pid=222,
+    )
+
+    assert result["status"] == "noop"
+    assert "identity" in result["reason"]
+    assert lease_path.read_text(encoding="utf-8") == original  # never rewritten
+
+
+def test_refresh_thread_lease_heartbeat_is_noop_for_an_uncheckable_lease(tmp_path: Path):
+    """Fix 2: an uncheckable lease (e.g. legacy v1) must never be blindly refreshed here —
+    unproven continuity is not assumed on the implicit, frequent heartbeat path, only on
+    claim_thread_lease's explicit same-owner resume."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    v1_lease = {
+        "schema_version": 1,
+        "agent": "claude-infra",
+        "generation": 1,
+        "owner_thread_id": "owner-session",
+        "acquired_at": "2026-07-23T09:00:00Z",
+        "heartbeat_at": "2026-07-23T09:58:30Z",  # 90s old, past any throttle
+    }
+    lease_path = _write_lease(tmp_path, "claude-infra", v1_lease)
+    original = lease_path.read_text(encoding="utf-8")
+
+    result = th.refresh_thread_lease_heartbeat(
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="owner-session",
+        generation=1,
+        now=now,
+        starting_pid=1,
+        min_refresh_interval=timedelta(seconds=60),
+    )
+
+    assert result["status"] == "noop"
+    assert "identity" in result["reason"]
+    assert lease_path.read_text(encoding="utf-8") == original  # never rewritten
+
+
 def test_throttled_heartbeat_refresh_is_a_cheap_noop_within_the_interval(tmp_path: Path):
-    """Fix 5: the PostToolUse hook fires on every tool call — it must not rewrite the lease
-    file every time, only once the existing heartbeat is already older than the throttle."""
+    """The PostToolUse hook fires on every tool call — it must not rewrite the lease
+    file every time, only once the existing heartbeat is already older than the throttle.
+    Throttle is checked before process identity, so this stays a cheap read even when
+    identity would be unconfirmed."""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
     lease = _v2_lease(owner_thread_id="owner-session", heartbeat_at="2026-07-23T09:59:30Z")  # 30s old
     lease_path = _write_lease(tmp_path, "claude-infra", lease)
@@ -1327,6 +1434,7 @@ def test_throttled_heartbeat_refresh_is_a_cheap_noop_within_the_interval(tmp_pat
         state_root=tmp_path,
         agent="claude-infra",
         current_thread_id="owner-session",
+        generation=1,
         now=now,
         starting_pid=1,
         min_refresh_interval=timedelta(seconds=60),
@@ -1337,17 +1445,26 @@ def test_throttled_heartbeat_refresh_is_a_cheap_noop_within_the_interval(tmp_pat
     assert json.loads(lease_path.read_text(encoding="utf-8"))["heartbeat_at"] == "2026-07-23T09:59:30Z"
 
 
-def test_throttled_heartbeat_refresh_writes_once_the_interval_has_elapsed(tmp_path: Path):
-    """Fix 5: past the throttle window, the refresh must still actually happen — otherwise the
-    PostToolUse hook would never protect a long single tool call from the emergency TTL."""
+def test_throttled_heartbeat_refresh_writes_once_the_interval_has_elapsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Past the throttle window, the refresh must still actually happen when generation and
+    process identity both confirm this session still owns the lease."""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
     lease = _v2_lease(owner_thread_id="owner-session", heartbeat_at="2026-07-23T09:58:30Z")  # 90s old
     lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 4242, "owner_pid_started_at": 1000.0, "owner_machine_id": "machine-a"},
+    )
 
     result = th.refresh_thread_lease_heartbeat(
         state_root=tmp_path,
         agent="claude-infra",
         current_thread_id="owner-session",
+        generation=1,
         now=now,
         starting_pid=1,
         min_refresh_interval=timedelta(seconds=60),
@@ -1368,6 +1485,7 @@ def test_refresh_thread_lease_heartbeat_command_throttles_via_min_refresh_interv
 
     assert th.main([*repo_args, "refresh-thread-lease-heartbeat", "--agent", "claude-infra",
                      "--current-thread-id", "owner-session", "--starting-pid", "1",
+                     "--generation", "1",
                      "--min-refresh-interval-seconds", "3600"]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "throttled"  # fresh claim heartbeat is well within the 3600s window

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -761,6 +761,43 @@ def test_pid_reused_by_unrelated_process_takes_over(tmp_path: Path, monkeypatch:
     assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "new-owner"
 
 
+def test_start_time_within_the_same_whole_second_still_matches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Fix 6: sub-second jitter between psutil and the ps-fallback probe must not look like reuse."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:59:00Z", owner_pid_started_at=1000.9)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_process_is_alive", lambda pid: True)
+    monkeypatch.setattr(th, "_default_process_snapshot", lambda pid: _fake_snapshot(pid=pid, started_at=1000.0))
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "conflict"
+    assert result["liveness"] == "live_owner"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "old-owner"
+
+
+def test_start_time_one_whole_second_apart_is_treated_as_pid_reuse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Fix 6: exact whole-second comparison, not a 2s tolerance — a gap this small used to be
+    (wrongly) absorbed by the old tolerance and would have missed a genuine pid reuse."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:59:00Z", owner_pid_started_at=1000.0)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_process_is_alive", lambda pid: True)
+    monkeypatch.setattr(th, "_default_process_snapshot", lambda pid: _fake_snapshot(pid=pid, started_at=1001.0))
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "acquired"
+    assert "reused" in result["takeover_reason"]
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "new-owner"
+
+
 def test_legacy_v1_lease_with_stale_heartbeat_is_healed_by_takeover(tmp_path: Path):
     """Matrix 5 / rule C: the migration heal — this is the exact stuck-lease shape on disk today."""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
@@ -868,6 +905,34 @@ def test_eperm_from_os_kill_is_treated_as_alive_and_conflicts(tmp_path: Path, mo
     assert result["liveness"] == "live_owner"
 
 
+def test_process_is_alive_treats_zombie_as_dead(monkeypatch: pytest.MonkeyPatch):
+    """Fix 4 (unit-level): kill(pid, 0) succeeds for a zombie — without a status check it
+    would look identical to a live owner and conflict forever."""
+    monkeypatch.setattr(th.os, "kill", lambda pid, sig: None)  # zombie: kill(0) still succeeds
+    monkeypatch.setattr(th, "_process_is_zombie", lambda pid: True)
+
+    assert th._process_is_alive(4242) is False
+
+
+def test_zombie_owner_is_reclaimed_not_treated_as_live(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Fix 4: a zombie owner must be reclaimable immediately, exactly like a confirmed-dead one —
+    otherwise it recreates the original lockout (a dead-looking owner blocking every restart)."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(heartbeat_at="2026-07-23T09:59:00Z")  # fresh under the old clock-only design
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th.os, "kill", lambda pid, sig: None)
+    monkeypatch.setattr(th, "_process_is_zombie", lambda pid: True)
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="new-owner", now=now, starting_pid=1
+    )
+
+    assert result["status"] == "acquired"
+    assert result["generation"] == 2
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "new-owner"
+
+
 def test_malformed_v2_liveness_fields_are_uncheckable_not_raised(tmp_path: Path):
     """Matrix 10: a malformed individual field degrades to uncheckable, never raises."""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
@@ -949,7 +1014,111 @@ def test_same_owner_refresh_upgrades_v1_lease_to_v2(tmp_path: Path, monkeypatch:
     assert on_disk["heartbeat_at"] == "2026-07-23T10:00:00Z"  # refreshed
 
 
+def test_same_thread_id_with_matching_process_identity_preserves_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Fix 2 (regression guard): a genuine resume by the SAME process must stay on the fast,
+    generation-preserving refresh path — only an identity CHANGE should force a reacquire."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="resumed-thread", generation=3, owner_pid=111, owner_pid_started_at=1000.0)
+    _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 111, "owner_pid_started_at": 1000.0, "owner_machine_id": "machine-a"},
+    )
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="resumed-thread", now=now, starting_pid=111
+    )
+
+    assert result["status"] == "refreshed"
+    assert result["generation"] == 3
+
+
+def test_same_thread_id_with_changed_process_identity_increments_generation_and_fences_late_release(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Fix 2: resuming the same thread id under a NEW harness process (different pid/start
+    time) must NOT silently preserve generation. If it did, the dead predecessor process —
+    which cached the OLD generation from its own SessionStart — could still release-fence
+    its way past a late SessionEnd and delete the SUCCESSOR's live lease."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="resumed-thread", generation=1, owner_pid=111, owner_pid_started_at=1000.0)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    # The predecessor process (pid 111) is gone; a NEW process (pid 222) resumes the thread id.
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 222, "owner_pid_started_at": 5000.0, "owner_machine_id": "machine-a"},
+    )
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="resumed-thread", now=now, starting_pid=222
+    )
+
+    assert result["status"] == "acquired"
+    assert result["generation"] == 2
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["generation"] == 2
+    assert on_disk["owner_pid"] == 222
+
+    # The predecessor's late SessionEnd still remembers generation 1 (it can only ever know
+    # what it observed at its own SessionStart) — it must be refused, not delete the successor.
+    late_release = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="resumed-thread", now=now, generation=1
+    )
+    assert late_release["status"] == "noop"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["generation"] == 2
+
+    # The successor's own release, with the generation it actually claimed, must succeed.
+    own_release = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="resumed-thread", now=now, generation=2
+    )
+    assert own_release["status"] == "released"
+    assert not lease_path.exists()
+
+
+def test_same_thread_id_with_unresolvable_new_identity_reacquires_defensively(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Fix 2: when the recorded identity is checkable but a fresh probe cannot confirm it still
+    matches (e.g. the harness-ancestor walk fails this time), continuity must NOT be assumed —
+    assuming it would recreate the exact vulnerability finding 2 describes."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="resumed-thread", generation=1, owner_pid=111, owner_pid_started_at=1000.0)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_derive_owner_liveness_fields", lambda starting_pid: {})
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="resumed-thread", now=now, starting_pid=999
+    )
+
+    assert result["status"] == "acquired"
+    assert result["generation"] == 2
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["generation"] == 2
+
+
 # --- release_thread_lease: fencing (test matrix items 14-16) ---
+
+
+def test_release_without_generation_is_refused_unless_forced(tmp_path: Path):
+    """Fix 1: generation is mandatory for a non-force release — the only call site
+    (release-thread-lease.sh) must always pass it, or the fencing this whole design
+    depends on is dead code at its one production caller."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="real-owner", generation=1)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+
+    with pytest.raises(ValueError, match="generation"):
+        th.release_thread_lease(
+            state_root=tmp_path, agent="claude-infra", current_thread_id="real-owner", now=now
+        )
+
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "real-owner"
 
 
 def test_release_by_non_owner_is_noop(tmp_path: Path):
@@ -959,7 +1128,7 @@ def test_release_by_non_owner_is_noop(tmp_path: Path):
     lease_path = _write_lease(tmp_path, "claude-infra", lease)
 
     result = th.release_thread_lease(
-        state_root=tmp_path, agent="claude-infra", current_thread_id="impostor", now=now
+        state_root=tmp_path, agent="claude-infra", current_thread_id="impostor", now=now, generation=1
     )
 
     assert result["status"] == "noop"
@@ -1005,7 +1174,9 @@ def test_release_thread_lease_takes_the_advisory_lock(tmp_path: Path, monkeypatc
     monkeypatch.setattr(th, "task_family_advisory_lock", lambda _path: RecordingLock())
 
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
-    result = th.release_thread_lease(state_root=tmp_path, agent="claude-infra", current_thread_id="whoever", now=now)
+    result = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="whoever", now=now, generation=1
+    )
 
     assert result["status"] == "noop"  # no lease file exists — the lock must still be taken
     assert events == ["lock-entered", "lock-exited"]
@@ -1101,13 +1272,31 @@ def test_release_thread_lease_command_end_to_end(tmp_path: Path, capsys):
 
     assert th.main([*repo_args, "claim-thread-lease", "--agent", "claude-infra", "--starting-pid", "1",
                      "--current-thread-id", "cli-session"]) == 0
-    capsys.readouterr()
+    claim_payload = json.loads(capsys.readouterr().out)
 
     assert th.main([*repo_args, "release-thread-lease", "--agent", "claude-infra",
-                     "--current-thread-id", "cli-session"]) == 0
+                     "--current-thread-id", "cli-session",
+                     "--generation", str(claim_payload["generation"])]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "released"
     assert not (tmp_path / ".agent/claude-infra-thread-lease.json").exists()
+
+
+def test_release_thread_lease_command_requires_generation_unless_forced(tmp_path: Path, capsys):
+    """Fix 1: release-thread-lease.sh is the only call site — it must always pass --generation,
+    or a SessionEnd release is no longer fenced by anything but thread id."""
+    repo_args = ["--repo-root", str(tmp_path)]
+
+    assert th.main([*repo_args, "claim-thread-lease", "--agent", "claude-infra", "--starting-pid", "1",
+                     "--current-thread-id", "cli-session"]) == 0
+    capsys.readouterr()
+
+    assert th.main([*repo_args, "release-thread-lease", "--agent", "claude-infra",
+                     "--current-thread-id", "cli-session"]) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert "generation" in payload["error"]
+    # Refused, not released: the lease must survive an attempted release with no generation.
+    assert (tmp_path / ".agent/claude-infra-thread-lease.json").exists()
 
 
 def test_refresh_thread_lease_heartbeat_command_is_noop_for_a_different_owner(tmp_path: Path, capsys):
@@ -1124,6 +1313,64 @@ def test_refresh_thread_lease_heartbeat_command_is_noop_for_a_different_owner(tm
     assert json.loads((tmp_path / ".agent/claude-infra-thread-lease.json").read_text())["owner_thread_id"] == (
         "owner-session"
     )
+
+
+def test_throttled_heartbeat_refresh_is_a_cheap_noop_within_the_interval(tmp_path: Path):
+    """Fix 5: the PostToolUse hook fires on every tool call — it must not rewrite the lease
+    file every time, only once the existing heartbeat is already older than the throttle."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="owner-session", heartbeat_at="2026-07-23T09:59:30Z")  # 30s old
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    original_mtime = lease_path.stat().st_mtime_ns
+
+    result = th.refresh_thread_lease_heartbeat(
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="owner-session",
+        now=now,
+        starting_pid=1,
+        min_refresh_interval=timedelta(seconds=60),
+    )
+
+    assert result["status"] == "throttled"
+    assert lease_path.stat().st_mtime_ns == original_mtime  # never rewritten
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["heartbeat_at"] == "2026-07-23T09:59:30Z"
+
+
+def test_throttled_heartbeat_refresh_writes_once_the_interval_has_elapsed(tmp_path: Path):
+    """Fix 5: past the throttle window, the refresh must still actually happen — otherwise the
+    PostToolUse hook would never protect a long single tool call from the emergency TTL."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="owner-session", heartbeat_at="2026-07-23T09:58:30Z")  # 90s old
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+
+    result = th.refresh_thread_lease_heartbeat(
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="owner-session",
+        now=now,
+        starting_pid=1,
+        min_refresh_interval=timedelta(seconds=60),
+    )
+
+    assert result["status"] == "refreshed"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["heartbeat_at"] == "2026-07-23T10:00:00Z"
+
+
+def test_refresh_thread_lease_heartbeat_command_throttles_via_min_refresh_interval_seconds(
+    tmp_path: Path, capsys
+):
+    """CLI-level: --min-refresh-interval-seconds is the flag the PostToolUse hook actually passes."""
+    repo_args = ["--repo-root", str(tmp_path)]
+    assert th.main([*repo_args, "claim-thread-lease", "--agent", "claude-infra", "--starting-pid", "1",
+                     "--current-thread-id", "owner-session"]) == 0
+    capsys.readouterr()
+
+    assert th.main([*repo_args, "refresh-thread-lease-heartbeat", "--agent", "claude-infra",
+                     "--current-thread-id", "owner-session", "--starting-pid", "1",
+                     "--min-refresh-interval-seconds", "3600"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "throttled"  # fresh claim heartbeat is well within the 3600s window
 
 
 def test_checkout_continuity_requires_clean_source_binding_and_same_clean_head():


### PR DESCRIPTION
## Summary

`claim_thread_lease` (`scripts/orchestration/thread_handoff.py`) is a single-writer lease per agent slot (`.agent/<agent>-thread-lease.json`) meant to stop two driver sessions double-driving one queue. It refused **every** operator restart, deterministically, for three root causes — all now fixed:

1. **`CURRENT_THREAD_ID` is the harness session id** (`session-setup.sh:411`), new on every restart, so a restart never matches `owner_thread_id` by design. That's expected — but there was no other liveness signal to fall back on.
2. **No release path existed** — no `release-thread-lease` subcommand, no `SessionEnd` hook. An exited or crashed session held the slot until the clock aged out.
3. **Liveness was inferred only from wall clock** (`fresh = now - heartbeat_at <= fresh_after`, 12h), and `heartbeat_at` only refreshed at SessionStart for the same thread id. The clock measured "time since the owner last started", never "time since the owner was alive". Both directions were broken: a dead owner looked alive for 12h (the reported restart lockout), and a live owner working >12h looked dead and could lose its own lease mid-flight (the exact double-driving the lease exists to prevent).

## What changed

**The process is the heartbeat.** Lease schema v2 adds `owner_pid`, `owner_pid_started_at` (epoch seconds), `owner_machine_id`. A different owner is now reclaimed the moment its pid is confirmed dead or reused — *regardless of clock age* — and a confirmed-live owner is never stolen from, *regardless of clock age either*. The old 12h clock survives only as a **900s emergency TTL**, and only for the genuinely uncheckable case (legacy v1 lease, cross-machine lease, unreadable process state). Keeping 12h there would leave today's lockout reachable in production — that's why the TTL is short, not a "fix" back to the old value.

- `owner_pid` is derived via a bounded (≤10 hop) walk up the parent-pid chain to the nearest known-harness ancestor (`claude`, `codex`, `agy`, `kimi`, `cursor`, `opencode`, `hermes`) — never raw `$PPID`, so a transient hook-launcher subshell can't be mistaken for the durable owner and have its lease stolen mid-drive.
- `owner_pid_started_at` prefers `psutil.Process.create_time()`, falls back to `LC_ALL=C ps -o lstart=` parsed to epoch.
- `owner_machine_id` is `IOPlatformUUID` (macOS) / `/etc/machine-id` (Linux), never a hostname (mDNS/VPN/container rebuilds change those).
- `EPERM` from `os.kill` is treated as alive (process exists, owned by another user).
- A malformed/corrupt/unknown-schema lease **never raises** — SessionStart is never blocked by lease state. Corrupt JSON heals via an immediate fresh acquire; malformed/legacy/cross-machine leases fall onto the uncheckable path (short TTL), reported as `THREAD_LEASE_LIVENESS_UNKNOWN`, distinct from a true live-owner `THREAD_LEASE_CONFLICT`.
- A same-owner refresh always re-derives the full v2 identity, so a v1 lease refreshed by its own owner upgrades to v2 instead of staying stuck on the fallback path forever — this is what actually heals the lease that's on disk right now.
- New `release-thread-lease` subcommand (+ `SessionEnd` hook `release-thread-lease.sh`): takes the same advisory lock as claim, no-ops unless owner_thread_id **and** generation both match (fencing a late release from a superseded session), `--force` for operators (named in every conflict message).
- New `refresh-thread-lease-heartbeat` subcommand, wired into the existing `goal-driver-stop.sh` `Stop` hook: best-effort, no-op unless we already own the lease, never attempts a takeover. This is what makes the short emergency TTL safe — a live owner on the uncheckable path keeps its own heartbeat fresh here.

## Verified vs. not

- **Full pytest**: `.venv/bin/python -m pytest tests/orchestration/test_thread_handoff.py -q` → `106 passed in 1.73s`.
- **Ruff**: `.venv/bin/ruff check scripts/orchestration/thread_handoff.py tests/orchestration/test_thread_handoff.py` → `All checks passed!`.
- **Load-bearing revert proof**: reverted only `thread_handoff.py` to pre-fix HEAD (`git stash push -- scripts/orchestration/thread_handoff.py`), ran the dead-owner-takeover / live-owner-beyond-12h / v1-migration-heal tests → `3 failed` (`AttributeError: ... has no attribute '_default_machine_id'` / `TypeError: claim_thread_lease() got an unexpected keyword argument 'starting_pid'`). Restored (`git stash pop`), re-ran the same three → `3 passed in 0.17s`.
- **Real-harness acceptance check**: ran `claim-thread-lease` for real from this session. It recorded `owner_pid: 66929`, and independently via `ps -p 66929 -o pid,ppid,etime,comm` that pid resolved to `/Users/krisztiankoos/.local/bin/claude` with a growing elapsed time (12m27s, then 21m36s on a later check) — i.e. the actual long-lived session process, not a transient hook wrapper, and confirmed still alive mid-session rather than merely alive at hook time.
  - Notable finding along the way: on this machine `psutil.Process.name()` for the `claude` process returns its version string (e.g. `"2.1.220"`), not `"claude"` — the CLI overrides its own process title. The ancestor walk therefore matches against `name()`, `cmdline()[0]`, and `exe()` basenames together (`ProcessSnapshot.candidate_basenames`), not `name()` alone; this was caught precisely by running the acceptance check for real rather than trusting unit tests with injected pids.
- **Not verified**: behavior on Linux (`/etc/machine-id` path) or under an actual concurrent two-session race in production — only via advisory-lock unit tests and the manual CLI smoke tests in this session.

## Test plan
- [x] `tests/orchestration/test_thread_handoff.py` — full 18-scenario matrix (dead/live owner, pid reuse, v1 migration heal, TTL-vs-liveness paths, EPERM, malformed/corrupt/unknown-schema leases, same-owner v1→v2 upgrade, release fencing + lock, ancestor-walk skip/miss) plus CLI-level claim/release/heartbeat-refresh tests.
- [x] Pre-commit hooks (ruff + pytest) passed on commit.
- [ ] Not yet reviewed — no auto-merge armed; orchestrator arms it after the review gate per repo policy.

---

## Fix round (advisor review, seat `gpt-5.6-sol`) — 7 blocking findings

The above design was endorsed; a cross-family review found seven ways it was still exploitable or silent. All seven are fixed in the follow-up commit on this branch:

1. **Release was not generation-fenced in practice.** `release-thread-lease.sh` called `release-thread-lease` with no `--generation`, so `SessionEnd` deleted any lease carrying its thread id — the fencing was dead code at its only call site. `generation` is now **mandatory** for a non-`--force` release (`release_thread_lease` raises without it). `session-setup.sh` propagates the generation it just claimed into `$CLAUDE_ENV_FILE` (`LEARN_UKRAINIAN_THREAD_LEASE_GENERATION`) so the SessionEnd hook can pass it back; if that variable is unset, the hook now no-ops instead of releasing unfenced.
2. **Resuming the same thread could clobber its successor.** The same-owner refresh path preserved generation without checking process identity. `claim_thread_lease` now compares the resuming process's pid/start-time against the recorded identity on every same-owner match (`_same_owner_identity_confirmed`); when it differs, or can't be confirmed, it reacquires with an **incremented generation** instead of refreshing in place. A delayed release from the dead predecessor — which can only ever know the generation it observed at its own SessionStart — then fails the (now-mandatory) generation fence in finding 1 rather than deleting the successor's live lease.
3. **Takeovers and corrupt recovery were silent at SessionStart.** `session-setup.sh` captured `THREAD_LEASE_OUTPUT` but only surfaced it on the failure branch. A successful claim is now parsed for `replaced_owner_thread_id` / `takeover_reason` / `recovered_from_corrupt_lease` and surfaced as a `THREAD LEASE TAKEOVER` / `THREAD LEASE HEALED` banner in SessionStart's `additionalContext`.
4. **`os.kill(pid, 0)` proves existence, not liveness — zombies.** A zombie owner passed the old check and would have conflicted forever (the original lockout under a new name). `_process_is_alive` now treats a confirmed `psutil.STATUS_ZOMBIE` (or `ps -o stat=` state `Z` as fallback) as dead.
5. **The 900s emergency TTL wasn't made safe by the `Stop` hook alone.** `Stop` only fires once per turn, so a single tool call running longer than the TTL was still stealable mid-turn. Added a new `PostToolUse` hook, `thread-lease-heartbeat.sh`, that refreshes the heartbeat but is **throttled**: it only rewrites the lease when the existing heartbeat is already >60s old, so the common case (many tool calls per minute) is a cheap read. Best-effort, never a takeover, no-op unless the lease is already ours. **Residual gap, by design, documented in the hook's own comment**: one uncheckable tool call that itself runs longer than the TTL, with zero other tool calls firing in between, is still theoretically stealable.
6. **Start-time tolerance (2.0s) was wider than the "sub-second" precision the comment claimed.** Both probes are now truncated to integer epoch seconds and compared **exactly** (`_epoch_seconds`) — the real shared precision floor between `psutil.create_time()` and the `ps -o lstart=` fallback. Comment updated to match.
7. **Commit hygiene.** This round's commit carries `Refs #5759` and an `X-Agent: claude/5759-lease-liveness` trailer.

### Verified this round
- **Full pytest**: `.venv/bin/python -m pytest tests/orchestration/test_thread_handoff.py -q` → `118 passed` (up from 106; 12 new tests for findings 1/2/4/5/6, plus 2 regression guards).
- **Ruff**: clean on every touched Python file.
- **Load-bearing revert proof, one finding at a time**: for findings 1, 2, 4, 5, and 6, temporarily reverted just that code change, re-ran the new test(s), confirmed they failed with the exact wrong behavior (e.g. release succeeding with no generation; identity-changed resume staying on `"refreshed"` instead of `"acquired"`; a mocked zombie owner reporting `"conflict"`/`"live_owner"` instead of being reclaimed; the throttled heartbeat writing every call; a 1-second start-time gap being absorbed as "still alive" instead of pid reuse) — then restored and confirmed all pass again.
- **Findings 1 and 3, end-to-end against the real hook scripts** (not just unit tests): built a live git+python fixture (symlinked `.venv`/`scripts` so the real interpreter and module run), and:
  - Ran `session-setup.sh` for a fresh claim → confirmed `LEARN_UKRAINIAN_THREAD_LEASE_GENERATION=1` written to a real `$CLAUDE_ENV_FILE`, no takeover banner (correct — nothing to report).
  - Pre-wrote a v2 lease with a different-machine, unreachable owner and an old heartbeat, ran `session-setup.sh` again with a new session id → confirmed the real `additionalContext` output contained `THREAD LEASE TAKEOVER: this session (generation 2) replaced owner session-A -- reason: liveness uncheckable (...) and heartbeat is older than the 900s emergency TTL.` and `LEARN_UKRAINIAN_THREAD_LEASE_GENERATION=2` was exported.
  - Ran `release-thread-lease.sh` with the stale predecessor's generation (1) → lease **survived** (fenced, as intended). Ran it again with the actual generation (2) → lease was deleted.
  - Ran `release-thread-lease.sh` with no generation env var set at all → no-op, lease survived (the intended fail-safe for finding 1).
- **Finding 5's throttling, end-to-end**: first call to `thread-lease-heartbeat.sh` against a >60s-stale heartbeat rewrote it; an immediate second call left the file byte-for-byte unchanged (throttled).
- **Not verified**: behavior on Linux, or a real concurrent two-process race under load — only via unit tests, revert proofs, and the manual end-to-end fixture runs above.

### Scoping note (advisor's primitive concern — recorded, not acted on)
Parent-process discovery (the harness-ancestor walk) is heuristic across GUI hosts, wrappers, PID namespaces, and harness upgrades — it is scoped to the **verified Claude CLI topology** this repo actually runs on, not a general-purpose process-supervision primitive. The durable end state, per the advisor, is a launcher/supervisor-held advisory lock that the kernel itself releases on process death, removing the need for pid/start-time heuristics entirely. That is a real architectural follow-up, tracked as such — **not built in this round**, per the instruction to record rather than act on it now.

### Known residual gap in this round — resolved in fix round 2 below
~~The lint enforced by `scripts/audit/lint_agent_trailer.py` (AGENTS.md rule #11) still reports the **original** commit on this branch...~~ Fixed by rebasing the branch (finding 7 of round 2) — see below.

---

## Fix round 2 (advisor re-review, seat `gpt-5.6-sol`) — 3 of 7 findings still outstanding

Findings 1, 3, 4, 6 from round 1 were confirmed fixed and untouched this round. Findings 2, 5, 7 required further changes:

### Finding 2 — heartbeat refresh was fenced only by thread id, not generation
`refresh_thread_lease_heartbeat` compared only `owner_thread_id` against the on-disk lease. A takeover that resumes the **same thread id** under a **new process** (the `_same_owner_identity_confirmed` path in `claim_thread_lease`) bumps generation but keeps the old thread id — a late heartbeat call still in flight from the dead predecessor process, carrying its own stale/cached generation, would have passed the thread-id-only check and overwritten the successor's recorded process identity with its own. Separately, `_same_owner_identity_confirmed` treated an *uncheckable* existing lease as automatically "confirmed" (process continuity assumed, not proven) — fine for `claim_thread_lease`'s explicit same-owner resume (it's what heals a legacy v1 lease), unsafe for the heartbeat's implicit, frequent calls.

Fix: `refresh_thread_lease_heartbeat` now takes a required `--generation` and no-ops on any mismatch, *and* reconfirms the on-disk process identity against the calling process before writing (`_same_owner_identity_confirmed(..., require_proof=True)`) — an uncheckable identity is now **never** assumed continuous on this path; any mismatch, in either check, is a no-op, never a rewrite. The generation is threaded through from `$LEARN_UKRAINIAN_THREAD_LEASE_GENERATION` (the same variable `release-thread-lease.sh` already used), now also exported to and consumed by `thread-lease-heartbeat.sh` (PostToolUse) and `goal-driver-stop.sh` (Stop).

### Finding 5 — remove the TTL takeover for the uncheckable case entirely (design change)
A `PostToolUse` heartbeat only runs *between* tool calls, so it could never protect an uncheckable owner during a single tool call longer than the 900s emergency TTL from round 1 — closing that residual gap with a continuous heartbeat needs a supervisor process, explicitly out of scope. Rather than keep chasing it, **the steal window is eliminated instead**: an uncheckable liveness verdict (legacy v1 lease, cross-machine lease, probe failure, malformed record) now **always conflicts**, regardless of heartbeat age, surfacing `THREAD_LEASE_LIVENESS_UNKNOWN` and the exact operator command to force it (`thread_handoff.py release-thread-lease --agent <agent> --force`, then start normally). `DEFAULT_THREAD_LEASE_EMERGENCY_TTL_SECONDS`, the `--emergency-ttl-seconds` flag, and every takeover-on-clock-age code path are deleted outright — the clock no longer grants ownership to anyone. `heartbeat_at` is kept as a diagnostic field only; both hooks' comments are corrected to stop claiming it makes anything safe. A legacy v1 lease still heals two ways, neither a timer: the same-owner refresh upgrade path (its own owner resumes it — unaffected by this change) and an explicit `--force` release.

Rationale (now also in the code comment): silently stealing from a possibly-live owner would corrupt the very mutual exclusion this lease exists to provide. An occasional explicit one-command unlock is the strictly safer failure mode, and the uncheckable path is rare once process checking works — the whole point of round 1.

### Finding 7 — commit trailers
`87e2412bf6` (round 1's first commit) carried neither an `X-Agent` trailer nor a `#5759` reference. Rebased the branch (`git commit-tree`, not `rebase -i`) to rewrite that commit's message in place — content byte-identical, verified via an empty `git diff` between the old and new tip before moving the branch pointer — adding `Refs #5759` and `X-Agent: claude/5759-lease-liveness`, matching the format the second commit already used. Force-pushed with `--force-with-lease`.

### Verified this round
- **Full pytest**: `.venv/bin/python -m pytest tests/orchestration/test_thread_handoff.py -q` → `122 passed` (up from 118; 3 new heartbeat-fencing tests for finding 2, 1 new + 1 rewritten test for finding 5, 1 signature-guard test).
- **Deleted, not merely edited**: `test_legacy_v1_lease_with_stale_heartbeat_is_healed_by_takeover` — it asserted `status == "acquired"` for a 9-hour-stale uncheckable lease claimed by a different thread id, which is exactly the vulnerability finding 5 removes. Replaced by `test_uncheckable_lease_never_taken_over_regardless_of_clock_age`, same fixture, asserting `status == "conflict"` and the lease untouched on disk.
- **Load-bearing, by construction** (each test fails if the corresponding fencing check is removed): `test_refresh_thread_lease_heartbeat_is_noop_for_a_stale_generation`, `test_refresh_thread_lease_heartbeat_is_noop_when_process_identity_unconfirmed`, `test_refresh_thread_lease_heartbeat_is_noop_for_an_uncheckable_lease`.
- **Ruff**: `.venv/bin/ruff check scripts/orchestration/thread_handoff.py tests/orchestration/test_thread_handoff.py` → `All checks passed!`.
- **Shellcheck**: clean on both touched hooks (`thread-lease-heartbeat.sh`, `goal-driver-stop.sh`).
- **`lint_agent_trailer.py` after the rebase**: `.venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..HEAD` → `✅ All 3 non-skipped commit(s) carry an X-Agent trailer.` (0 missing, up from 1/2 missing before the rebase).
- **Real-harness check, finding 2**: claimed a real lease from this session (`claim-thread-lease`) → `owner_pid` resolved to this session's actual long-lived `claude` process (pid confirmed via `ps`, same pid/start-time on a second sample 3s later). `refresh-thread-lease-heartbeat --generation 1` (the correct, just-claimed generation) → `"status": "refreshed"`. Same command with `--generation 99` → `"status": "noop", "reason": "lease generation does not match; a takeover superseded this owner"` — the file was not rewritten.
- **Real-harness check, finding 5**: wrote a synthetic legacy v1 lease with a 6-year-old heartbeat, claimed it from a different thread id → `"status": "conflict"`, `"error_code": "THREAD_LEASE_LIVENESS_UNKNOWN"`, exit code 2, lease file byte-for-byte unchanged on disk (no takeover regardless of the extreme clock age).
- **Not verified**: behavior on Linux, or a real concurrent two-process race under load — unchanged from round 1's caveat; this round's changes are additional fencing on the same design, not a new surface.

**Not merged, auto-merge not armed** — awaiting review.

