### PR TITLE
fix(ci): regenerate stale lesson-schema fingerprint blocking every PR

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 2ad46d68a24540fddf933b0851514413be7b2423f3b471b40825296f843f6543
+  components_sha256: 4ff37f411c901b226ec75d964311d19aa8a6862a25baf6749333e763ff904784
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:


### PR DESCRIPTION
## Main is red; every branch inherits it

`test_committed_lesson_schema_fingerprints_are_fresh` fails on current `main`:

    docs/lesson-schema.yaml is stale vs its inputs:
    committed 2ad46d68a24540fddf933b0851514413be7b2423f3b471b40825296f843f6543
    actual    4ff37f411c901b226ec75d964311d19aa8a6862a25baf6749333e763ff904784

Reproduced locally on a clean worktree off `origin/main` — **not** introduced by any PR. Observed failing identically as `Test (pytest) [2/4]` on two unrelated PRs (#5747, #5758), which is what pointed at main rather than at either branch.

## Cause

Same class as #5746: a component change landed without regenerating the schema. The committed `2ad46d68` is the hash produced when a previous session regenerated the schema on a merged component state; `site/src/components/**` has changed since.

## Fix

```
.venv/bin/python scripts/build/generate_lesson_schema.py
```

One line changes. `tests/test_lesson_schema_filter_coverage.py` → `2 passed`.

## Note

This is the second recurrence of the same failure mode and it froze the merge queue both times. The durable fix is preventing component changes from reaching `main` without regeneration — tracked separately; this PR only unblocks.