### PR TITLE
perf(audit): parse committed decision YAML with libyaml's CSafeLoader (#5768)

### DIFF
--- a/scripts/audit/source_inventory_review_decisions.py
+++ b/scripts/audit/source_inventory_review_decisions.py
@@ -318,9 +318,23 @@ def resolve_staged_inventory_path(inventory_path: str) -> Path:
     return candidate
 
 
+# libyaml's C parser, when available. `yaml.safe_load` does NOT auto-select it,
+# so this module was parsing 41MB of committed decision YAML with the pure-Python
+# loader. Measured on the largest committed file (20.7MB):
+#     yaml.safe_load  → ~70s, 563MB peak RSS
+#     yaml.CSafeLoader→  3.2s, 390MB peak RSS
+# That 563MB peak x 4 xdist workers is what produced `MemoryError` /
+# `worker 'gwN' crashed` on CI shards (#5768).
+#
+# CSafeLoader is the C implementation of SafeLoader — same guarantees, no
+# arbitrary Python object construction. It is NOT yaml.CLoader, which executes
+# `!!python/object` tags and must never be used on committed data.
+_SafeLoader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+
+
 def _read_yaml_mapping(path: Path) -> dict[str, Any]:
     try:
-        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        payload = yaml.load(path.read_text(encoding="utf-8"), Loader=_SafeLoader)
     except FileNotFoundError as exc:
         raise SourceInventoryError(f"{path}: not found") from exc
     if not isinstance(payload, dict):

--- a/tests/test_source_inventory_review_decisions.py
+++ b/tests/test_source_inventory_review_decisions.py
@@ -81,6 +81,33 @@ def test_default_committed_decision_files_validate() -> None:
     assert summary["decision_counts"]["approve_for_publish"] >= 20
 
 
+def test_committed_yaml_uses_the_c_safe_loader_when_available() -> None:
+    # Guards #5768. `yaml.safe_load` silently uses PyYAML's PURE-PYTHON loader even
+    # when libyaml is installed — PyYAML never auto-selects the C implementation. That
+    # is why this module parsed 41MB of committed decision YAML at ~590MB peak RSS and
+    # hit MemoryError on CI. A refactor that reverts to `yaml.safe_load` must fail
+    # here, not silently cost 20% of the suite's memory again three weeks later.
+    if not hasattr(yaml, "CSafeLoader"):
+        pytest.skip("this PyYAML build has no libyaml C extension")
+    assert decisions._SafeLoader is yaml.CSafeLoader
+
+
+def test_committed_yaml_loader_refuses_python_object_tags(tmp_path: Path) -> None:
+    # The security boundary behind the perf fix, asserted behaviourally so it holds
+    # whichever loader is wired in. `CSafeLoader` is the C implementation of
+    # SafeLoader; `CLoader`/`Loader` are the C/py implementations of the FULL loader
+    # and construct arbitrary Python objects from `!!python/object` tags. They differ
+    # by four characters and a code-execution boundary, and this module parses
+    # committed data files, so that boundary is real and not theoretical.
+    hostile = tmp_path / "hostile.yaml"
+    hostile.write_text(
+        'decisions: !!python/object/apply:os.system ["echo pwned"]\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(yaml.YAMLError):
+        decisions._read_yaml_mapping(hostile)
+
+
 def test_decision_validator_rejects_bad_source_key(tmp_path: Path) -> None:
     payload = _minimal_payload()
     row = payload["decisions"][0]  # type: ignore[index]


### PR DESCRIPTION
Closes part of #5768.

## What

`yaml.safe_load` uses PyYAML's **pure-Python** loader even when libyaml is installed —
PyYAML never auto-selects the C implementation. `scripts/audit/source_inventory_review_decisions.py`
parses 41 MB of committed decision YAML through that path. This wires in `CSafeLoader`
(falling back to `SafeLoader` where libyaml is absent) and adds two guards.

## Measured, on this machine, on the test that fails CI

`tests/…::test_default_committed_decision_files_validate`, `/usr/bin/time -l`, single process:

| | wall | peak RSS |
| --- | --- | --- |
| `yaml.safe_load` (before) | 108.9 s | **588 MB** |
| `CSafeLoader` (after) | 92.8 s | **467 MB** |

**−20% peak RSS, −15% wall.** Real, but I want to be explicit about what this is **not**:

⚠️ **This does NOT prove #5758's `MemoryError` is fixed.** An earlier micro-benchmark on a single
20.7 MB file suggested 70 s → 3.2 s / 563 → 390 MB; that ratio **does not survive** at the level of
this test, and I measured it rather than inheriting it. 467 MB is still a large peak for one test.
Treat this as a real reduction on the hot path, not as a closure of the OOM.
The machine carried other load (~6) during both runs; the wall figures are therefore indicative and
the *relative* comparison is the meaningful part. Peak RSS is load-independent.

## Guards (why this can't silently regress)

1. `test_committed_yaml_uses_the_c_safe_loader_when_available` — the wired loader IS
   `yaml.CSafeLoader` when libyaml exists, so a future refactor cannot quietly drop back to the
   pure-Python loader.
2. `test_committed_yaml_loader_refuses_python_object_tags` — behavioural assertion of the security
   boundary. `CSafeLoader` is the C implementation of **SafeLoader**; `CLoader` is the C
   implementation of the **full** loader and executes `!!python/object` tags. They differ by four
   characters.

**Guard 2 is verified load-bearing, not assumed:** substituting `yaml.CLoader` makes the
committed-data parser execute `os.system` straight out of a YAML tag (printed `PWNED_MARKER`) and
raise nothing — the test fails, as designed.

## Reviewer checklist

- Confirm the diff contains **`CSafeLoader`, never `CLoader`** and no bare `yaml.load(` without an
  explicit safe `Loader=`.
- 21/21 tests in the file pass locally (`96 s`), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)