### PR TITLE
fix(hooks): guard-push-pytest must judge the tree the push runs in (#5771)

### DIFF
--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -246,14 +246,29 @@ def _effective_cwd(command: str, base: str) -> str:
     is not a directory) collapses back to `base`. That is the SAFE direction:
     base is the primary checkout, so an ambiguous command leaves the guard armed
     rather than silently disarmed.
+
+    Models `cd`, `pushd` and `popd`. Residual limitation, stated rather than
+    implied: shell constructs this cannot model — `eval`, subshells, shell
+    functions, aliases — fall through to `base`. This guard exists to catch an
+    operator's own untested push, not to withstand a crafted evasion; a caller
+    determined to bypass it can simply set `SKIP_PYTEST_HOOK=1`.
     """
     current = base
+    stack: list[str] = []
     for tokens in _segments(command):
         if not tokens:
             continue
         if _git_push_args(tokens) is not None:
             break
-        if tokens[0] != "cd":
+        verb = tokens[0]
+        if verb == "popd":
+            # Cross-family review P1 (round 3): the directory stack moves the shell
+            # too. An empty stack means the command is not modellable here.
+            if not stack:
+                return base
+            current = stack.pop()
+            continue
+        if verb not in {"cd", "pushd"}:
             continue
         if len(tokens) < 2:
             return base
@@ -269,6 +284,8 @@ def _effective_cwd(command: str, base: str) -> str:
             return base
         if not resolved.is_dir():
             return base
+        if verb == "pushd":
+            stack.append(current)
         current = str(resolved)
     return current
 

--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -223,13 +223,79 @@ def _has_inline_skip(command: str) -> bool:
     return False
 
 
-def _current_branch() -> str | None:
+def _payload_cwd(payload: dict) -> str:
+    """The directory the guarded tool call runs in (mirrors guard-primary-checkout-write)."""
+    cwd = payload.get("cwd") or payload.get("working_directory")
+    return str(cwd) if cwd else os.getcwd()
+
+
+def _cd_target(command: str) -> str | None:
+    """A literal leading ``cd <path>`` in the command, if any.
+
+    The hook process's own cwd is the primary checkout, which under layout A is
+    always `main`. A push issued from a dispatch worktree therefore looked like a
+    push from `main` and was judged against main's diff (#5771). Variable or
+    substituted targets (`cd $X`, `cd "$(...)"`, `cd -`) are deliberately not
+    resolved: guessing there is how a guard silently judges the wrong tree.
+    """
+    for tokens in _segments(command):
+        if not tokens:
+            continue
+        if tokens[0] != "cd":
+            # Only a LEADING cd re-homes the whole command. Anything else first
+            # (including another cd later in the chain) leaves the effective
+            # directory ambiguous, so fall back to the payload cwd.
+            return None
+        if len(tokens) < 2:
+            return None
+        target = tokens[1]
+        if target.startswith(("$", "-", "`")) or '"$' in target or "'$" in target:
+            return None
+        return target.strip("\"'")
+    return None
+
+
+def _git_cwd(payload: dict, command: str) -> str:
+    """Resolve the working tree the push will actually run in."""
+    base = _payload_cwd(payload)
+    target = _cd_target(command)
+    if not target:
+        return base
+    path = Path(target).expanduser()
+    if not path.is_absolute():
+        path = Path(base) / path
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return base
+    return str(resolved) if resolved.is_dir() else base
+
+
+def _git_env() -> dict:
+    """Environment with git's repo-location overrides stripped.
+
+    `cwd=` alone does NOT decide which repository git operates on: GIT_DIR,
+    GIT_WORK_TREE, GIT_INDEX_FILE and GIT_PREFIX take precedence over the
+    working directory. Any invocation from inside a git hook (pre-commit, and
+    every agent command that runs under one) inherits them, so without this the
+    guard would keep inspecting the WRONG repository — the same wrong-tree bug
+    at one remove. Caught by the pre-commit run of this file's own tests.
+    """
+    env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        env.pop(key, None)
+    return env
+
+
+def _current_branch(cwd: str) -> str | None:
     try:
         out = subprocess.run(
             ["git", "branch", "--show-current"],
             capture_output=True,
             text=True,
             timeout=5,
+            cwd=cwd,
+            env=_git_env(),
         )
     except Exception:
         return None
@@ -239,13 +305,15 @@ def _current_branch() -> str | None:
     return branch or None
 
 
-def _changed_paths() -> list[str] | None:
+def _changed_paths(cwd: str) -> list[str] | None:
     try:
         out = subprocess.run(
             ["git", "diff", "--name-only", "origin/main..HEAD"],
             capture_output=True,
             text=True,
             timeout=20,
+            cwd=cwd,
+            env=_git_env(),
         )
     except Exception:
         return None
@@ -302,12 +370,13 @@ def main() -> int:
     if _has_inline_skip(command):
         return 0
 
-    branch = _current_branch()
+    git_cwd = _git_cwd(payload, command)
+    branch = _current_branch(git_cwd)
     if branch != "main":
         return 0
 
-    paths = _changed_paths()
-    if paths is None or not _has_trigger_path(paths):
+    paths = _changed_paths(git_cwd)
+    if not paths or not _has_trigger_path(paths):
         return 0
 
     marker = _marker_path(branch)

--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -229,6 +229,40 @@ def _payload_cwd(payload: dict) -> str:
     return str(cwd) if cwd else os.getcwd()
 
 
+def _git_dir_override(seg: list[str]) -> str | None:
+    """A `-C <path>` / `--work-tree=<path>` on the git invocation itself.
+
+    Cross-family review P1 (round 4): `git -C /main push origin main` runs the push
+    against /main with no `cd` anywhere. Breaking at the push segment and keeping the
+    payload cwd therefore judged the wrong tree and would wave an untested main push
+    through. `-C` is an ordinary, common invocation, not an exotic evasion.
+    """
+    i = 0
+    while i < len(seg) and (
+        seg[i] in WRAPPERS or seg[i] in {"command", "exec", "{"} or _is_env_assignment(seg[i])
+    ):
+        i += 1
+    if i >= len(seg) or seg[i] != "git":
+        return None
+    i += 1
+    target: str | None = None
+    while i < len(seg) and seg[i].startswith("-"):
+        if seg[i] == "-C" and i + 1 < len(seg):
+            target = seg[i + 1]  # last -C wins, as git itself applies them in order
+            i += 2
+        elif seg[i].startswith("--work-tree="):
+            target = seg[i].split("=", 1)[1]
+            i += 1
+        elif seg[i] == "--work-tree" and i + 1 < len(seg):
+            target = seg[i + 1]
+            i += 2
+        elif seg[i] in {"-c", "--git-dir"} and i + 1 < len(seg):
+            i += 2
+        else:
+            i += 1
+    return target
+
+
 def _effective_cwd(command: str, base: str) -> str:
     """Directory the push runs in, following EVERY cd that precedes it.
 
@@ -259,7 +293,19 @@ def _effective_cwd(command: str, base: str) -> str:
         if not tokens:
             continue
         if _git_push_args(tokens) is not None:
-            break
+            override = _git_dir_override(tokens)
+            if override is None:
+                break
+            if override.startswith(("$", "-", "`")) or '"$' in override or "'$" in override:
+                return base
+            path = Path(override.strip("\"'")).expanduser()
+            if not path.is_absolute():
+                path = Path(current) / path
+            try:
+                resolved = path.resolve()
+            except OSError:
+                return base
+            return str(resolved) if resolved.is_dir() else base
         verb = tokens[0]
         if verb == "popd":
             # Cross-family review P1 (round 3): the directory stack moves the shell

--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -229,46 +229,53 @@ def _payload_cwd(payload: dict) -> str:
     return str(cwd) if cwd else os.getcwd()
 
 
-def _cd_target(command: str) -> str | None:
-    """A literal leading ``cd <path>`` in the command, if any.
+def _effective_cwd(command: str, base: str) -> str:
+    """Directory the push runs in, following EVERY cd that precedes it.
 
     The hook process's own cwd is the primary checkout, which under layout A is
     always `main`. A push issued from a dispatch worktree therefore looked like a
-    push from `main` and was judged against main's diff (#5771). Variable or
-    substituted targets (`cd $X`, `cd "$(...)"`, `cd -`) are deliberately not
-    resolved: guessing there is how a guard silently judges the wrong tree.
+    push from `main` and was judged against main's diff (#5771).
+
+    Cross-family review P1: honouring only the FIRST cd is a bypass —
+    `cd /feature && cd /main && git push origin main` would be judged in
+    /feature, see a non-main branch, and wave an untested push to main straight
+    through. So walk the segments in order, applying each cd cumulatively, and
+    stop at the segment that performs the push.
+
+    Anything unresolvable (`cd $VAR`, `cd -`, command substitution, a path that
+    is not a directory) collapses back to `base`. That is the SAFE direction:
+    base is the primary checkout, so an ambiguous command leaves the guard armed
+    rather than silently disarmed.
     """
+    current = base
     for tokens in _segments(command):
         if not tokens:
             continue
+        if _git_push_args(tokens) is not None:
+            break
         if tokens[0] != "cd":
-            # Only a LEADING cd re-homes the whole command. Anything else first
-            # (including another cd later in the chain) leaves the effective
-            # directory ambiguous, so fall back to the payload cwd.
-            return None
+            continue
         if len(tokens) < 2:
-            return None
+            return base
         target = tokens[1]
         if target.startswith(("$", "-", "`")) or '"$' in target or "'$" in target:
-            return None
-        return target.strip("\"'")
-    return None
+            return base
+        path = Path(target.strip("\"'")).expanduser()
+        if not path.is_absolute():
+            path = Path(current) / path
+        try:
+            resolved = path.resolve()
+        except OSError:
+            return base
+        if not resolved.is_dir():
+            return base
+        current = str(resolved)
+    return current
 
 
 def _git_cwd(payload: dict, command: str) -> str:
     """Resolve the working tree the push will actually run in."""
-    base = _payload_cwd(payload)
-    target = _cd_target(command)
-    if not target:
-        return base
-    path = Path(target).expanduser()
-    if not path.is_absolute():
-        path = Path(base) / path
-    try:
-        resolved = path.resolve()
-    except OSError:
-        return base
-    return str(resolved) if resolved.is_dir() else base
+    return _effective_cwd(command, _payload_cwd(payload))
 
 
 def _git_env() -> dict:
@@ -282,7 +289,21 @@ def _git_env() -> dict:
     at one remove. Caught by the pre-commit run of this file's own tests.
     """
     env = os.environ.copy()
-    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+    for key in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_PREFIX",
+        # Cross-family review P1: leaving these set can make `git diff` FAIL, and a
+        # failed probe returns no paths, which lets an untested push to `main`
+        # through. An incomplete strip is a bypass, not a cosmetic gap.
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+        "GIT_NAMESPACE",
+    ):
         env.pop(key, None)
     return env
 

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -424,3 +424,47 @@ def test_unresolvable_cd_falls_back_instead_of_guessing(monkeypatch, repo_with_w
     """`cd $VAR` is ambiguous; the guard must fall back to the payload cwd, not guess."""
     main_co, _worktree = repo_with_worktree
     assert _run_real(monkeypatch, "cd $TARGET && git push origin main", main_co) == 2
+
+
+# --- Cross-family review P1s on the #5771 fix. Both were BYPASSES: they let an
+# --- untested push to `main` through, which is the one thing this guard exists
+# --- to stop. Absence of these tests is what let the first fix look correct.
+
+
+def test_chained_cd_follows_the_last_directory_before_the_push(monkeypatch, repo_with_worktree):
+    """`cd <worktree> && cd <main> && git push origin main` must still be judged as main.
+
+    Honouring only the FIRST cd meant the guard saw a feature branch and waved the
+    push through, even though it actually ran from main.
+    """
+    main_co, worktree = repo_with_worktree
+    command = f"cd {worktree} && cd {main_co} && git push origin main"
+    assert _run_real(monkeypatch, command, worktree) == 2
+
+
+def test_cd_after_the_push_does_not_re_home_it(monkeypatch, repo_with_worktree):
+    """Only cd's BEFORE the push count; a trailing cd must not change the verdict."""
+    main_co, worktree = repo_with_worktree
+    command = f"cd {main_co} && git push origin main && cd {worktree}"
+    assert _run_real(monkeypatch, command, worktree) == 2
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "GIT_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_INDEX_FILE",
+    ],
+)
+def test_hostile_git_env_cannot_disable_the_guard(monkeypatch, repo_with_worktree, var):
+    """A broken git-discovery override must not turn a block into a pass.
+
+    An invalid value makes `git diff` fail; an unstripped variable therefore
+    yielded no changed paths, and no changed paths meant "nothing to guard".
+    """
+    main_co, _worktree = repo_with_worktree
+    monkeypatch.setenv(var, "/nonexistent/hostile/path")
+    assert _run_real(monkeypatch, "git push origin main", main_co) == 2

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -492,3 +492,32 @@ def test_popd_without_a_matching_pushd_is_not_modelled(monkeypatch, repo_with_wo
     """An unbalanced popd is unmodellable; fall back rather than guess a directory."""
     main_co, _worktree = repo_with_worktree
     assert _run_real(monkeypatch, "popd && git push origin main", main_co) == 2
+
+
+def test_git_dash_C_re_homes_the_push(monkeypatch, repo_with_worktree):
+    """Cross-family review P1 (round 4): `git -C <main> push` needs no cd at all.
+
+    An ordinary invocation — not an exotic evasion — that runs the push in another
+    directory. Breaking at the push segment kept the worktree cwd and permitted an
+    untested push to main.
+    """
+    main_co, worktree = repo_with_worktree
+    assert _run_real(monkeypatch, f"git -C {main_co} push origin main", worktree) == 2
+
+
+def test_git_work_tree_flag_re_homes_the_push(monkeypatch, repo_with_worktree):
+    """`--work-tree=<main>` is the same hazard in a different spelling."""
+    main_co, worktree = repo_with_worktree
+    assert _run_real(monkeypatch, f"git --work-tree={main_co} push origin main", worktree) == 2
+
+
+def test_git_dash_C_into_a_worktree_is_not_flagged(monkeypatch, repo_with_worktree):
+    """The converse: -C into a feature worktree must NOT be judged as main."""
+    main_co, worktree = repo_with_worktree
+    assert _run_real(monkeypatch, f"git -C {worktree} push origin HEAD:claude/feature", main_co) == 0
+
+
+def test_unresolvable_git_dash_C_falls_back(monkeypatch, repo_with_worktree):
+    """`git -C $VAR` is ambiguous — fall back to the payload cwd, never guess."""
+    main_co, _worktree = repo_with_worktree
+    assert _run_real(monkeypatch, "git -C $TARGET push origin main", main_co) == 2

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -38,8 +38,8 @@ def _run(
     payload = json.dumps({"tool_input": {"command": command}})
     marker = Path("/tmp/learn-uk-pytest.main.stamp")
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
-    monkeypatch.setattr(guard, "_current_branch", lambda: branch)
-    monkeypatch.setattr(guard, "_changed_paths", lambda: list(paths))
+    monkeypatch.setattr(guard, "_current_branch", lambda _cwd: branch)
+    monkeypatch.setattr(guard, "_changed_paths", lambda _cwd: list(paths))
     monkeypatch.setattr(guard, "_marker_path", lambda _branch: marker)
     monkeypatch.setattr(guard, "_marker_is_fresh", lambda _marker: marker_fresh)
     monkeypatch.delenv("SKIP_PYTEST_HOOK", raising=False)
@@ -87,7 +87,7 @@ def test_non_trigger_diff_allows(monkeypatch):
 def test_hook_errors_fail_open(monkeypatch):
     payload = json.dumps({"tool_input": {"command": "git push origin main"}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
-    monkeypatch.setattr(guard, "_current_branch", lambda: None)
+    monkeypatch.setattr(guard, "_current_branch", lambda _cwd: None)
     monkeypatch.delenv("SKIP_PYTEST_HOOK", raising=False)
     assert guard.main() == 0
 
@@ -330,3 +330,97 @@ def test_block_msg_interpolates_actual_branch():
     assert "direct push from `some-feature-branch`" in msg
     assert "from `main`" not in msg
 
+
+
+# --- #5771: the guard must judge the tree the push actually runs in. ---------
+#
+# Regression tests backed by REAL git repos, not monkeypatched helpers: the bug
+# was that `_current_branch`/`_changed_paths` ran in the hook process's own cwd
+# (the primary checkout, always `main` under layout A), so every dispatch-worktree
+# push was judged as a push from `main` against main's diff. Monkeypatching those
+# two helpers is exactly what hid it, so these tests must not.
+
+
+def _git(cwd: Path, *args: str) -> None:
+    env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        env.pop(key, None)
+    subprocess.run(
+        ["git", *args], cwd=cwd, env=env, check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+@pytest.fixture
+def repo_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """A repo on `main` with a Python commit, plus a worktree on a feature branch."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-b", "main")
+    _git(origin, "config", "user.email", "t@t.t")
+    _git(origin, "config", "user.name", "t")
+    (origin / "seed.py").write_text("x = 1\n", encoding="utf-8")
+    _git(origin, "add", "seed.py")
+    _git(origin, "commit", "-m", "seed")
+
+    main_co = tmp_path / "main_co"
+    _git(tmp_path, "clone", str(origin), str(main_co))
+    _git(main_co, "config", "user.email", "t@t.t")
+    _git(main_co, "config", "user.name", "t")
+    # An unpushed Python commit on main — the guard's trigger condition.
+    (main_co / "changed.py").write_text("y = 2\n", encoding="utf-8")
+    _git(main_co, "add", "changed.py")
+    _git(main_co, "commit", "-m", "python change on main")
+
+    worktree = tmp_path / "wt"
+    _git(main_co, "worktree", "add", str(worktree), "-b", "claude/feature")
+    return main_co, worktree
+
+
+def _run_real(monkeypatch: pytest.MonkeyPatch, command: str, payload_cwd: Path) -> int:
+    payload = json.dumps({"tool_input": {"command": command}, "cwd": str(payload_cwd)})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setattr(guard, "_marker_is_fresh", lambda _marker: False)
+    monkeypatch.delenv("SKIP_PYTEST_HOOK", raising=False)
+    return guard.main()
+
+
+def test_push_from_worktree_branch_is_not_judged_as_main(monkeypatch, repo_with_worktree):
+    """The false positive that trained everyone to set SKIP_PYTEST_HOOK=1."""
+    _main_co, worktree = repo_with_worktree
+    assert _run_real(monkeypatch, "git push origin HEAD:claude/feature", worktree) == 0
+
+
+def test_leading_cd_into_a_worktree_is_honoured(monkeypatch, repo_with_worktree):
+    """`cd <worktree> && git push` must be judged in the worktree, not the payload cwd."""
+    main_co, worktree = repo_with_worktree
+    command = f"cd {worktree} && git push origin HEAD:claude/feature"
+    assert _run_real(monkeypatch, command, main_co) == 0
+
+
+def test_genuine_main_push_with_python_changes_still_blocks(monkeypatch, repo_with_worktree):
+    """The guard must keep its teeth for the case it actually exists to catch."""
+    main_co, _worktree = repo_with_worktree
+    assert _run_real(monkeypatch, "git push origin main", main_co) == 2
+
+
+def test_empty_diff_never_claims_python_changes(monkeypatch, tmp_path):
+    """An empty outgoing diff must not be reported as 'includes Python changes'."""
+    origin = tmp_path / "o2"
+    origin.mkdir()
+    _git(origin, "init", "-b", "main")
+    _git(origin, "config", "user.email", "t@t.t")
+    _git(origin, "config", "user.name", "t")
+    (origin / "seed.py").write_text("x = 1\n", encoding="utf-8")
+    _git(origin, "add", "seed.py")
+    _git(origin, "commit", "-m", "seed")
+    clone = tmp_path / "c2"
+    _git(tmp_path, "clone", str(origin), str(clone))
+    # No commits ahead of origin/main at all.
+    assert _run_real(monkeypatch, "git push origin main", clone) == 0
+
+
+def test_unresolvable_cd_falls_back_instead_of_guessing(monkeypatch, repo_with_worktree):
+    """`cd $VAR` is ambiguous; the guard must fall back to the payload cwd, not guess."""
+    main_co, _worktree = repo_with_worktree
+    assert _run_real(monkeypatch, "cd $TARGET && git push origin main", main_co) == 2

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -468,3 +468,27 @@ def test_hostile_git_env_cannot_disable_the_guard(monkeypatch, repo_with_worktre
     main_co, _worktree = repo_with_worktree
     monkeypatch.setenv(var, "/nonexistent/hostile/path")
     assert _run_real(monkeypatch, "git push origin main", main_co) == 2
+
+
+def test_pushd_re_homes_the_push(monkeypatch, repo_with_worktree):
+    """Cross-family review P1 (round 3): the directory STACK moves the shell too.
+
+    `pushd <main> && git push origin main` from a worktree payload cwd was judged
+    in the worktree, so an untested push to main was permitted.
+    """
+    main_co, worktree = repo_with_worktree
+    command = f"pushd {main_co} && git push origin main"
+    assert _run_real(monkeypatch, command, worktree) == 2
+
+
+def test_popd_returns_to_the_previous_directory(monkeypatch, repo_with_worktree):
+    """`pushd <worktree>` then `popd` lands back on main, so the guard must fire."""
+    main_co, worktree = repo_with_worktree
+    command = f"pushd {worktree} && popd && git push origin main"
+    assert _run_real(monkeypatch, command, main_co) == 2
+
+
+def test_popd_without_a_matching_pushd_is_not_modelled(monkeypatch, repo_with_worktree):
+    """An unbalanced popd is unmodellable; fall back rather than guess a directory."""
+    main_co, _worktree = repo_with_worktree
+    assert _run_real(monkeypatch, "popd && git push origin main", main_co) == 2


### PR DESCRIPTION
Closes #5771.

## The bug

The guard resolved the branch **and** the outgoing diff in the hook process's own cwd — the primary
checkout, which under layout A is always `main`. So every push from a dispatch worktree was judged as
a direct push from `main`, against main's diff.

Observed live: pushing an **empty** commit from `.worktrees/dispatch/claude/ci-reboot`, on branch
`claude/ci-reboot`, was blocked with *"direct push from `main` includes Python/test-trigger changes"*.
Wrong branch, and a commit with no files at all.

## Why it mattered more than a nuisance

The only way past is `SKIP_PYTEST_HOOK=1`. A guard that fires on correct behaviour teaches everyone to
disable it reflexively — and then #M-7 is not enforced for the pushes that genuinely need it. The false
positive is the mechanism by which the guard loses its teeth.

## Two defects, not one

1. **Wrong working tree.** Now resolves the tree the push actually runs in: a literal leading
   `cd <path>`, else the payload `cwd` (the pattern `guard-primary-checkout-write` already uses).
   Ambiguous targets (`cd $VAR`, `cd -`, command substitution) deliberately fall back instead of
   guessing — silently judging the wrong tree is the bug being fixed.

2. **`cwd=` is not enough.** `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` and `GIT_PREFIX` override the
   working directory, and every command run inside a git hook inherits them — so the guard would have
   kept inspecting the wrong repository at one remove. Now stripped from the subprocess environment.

   **Defect 2 was found by the pre-commit run of this PR's own tests**, which failed exactly where a
   direct run passed. Worth stating plainly: the first version of this fix was incomplete, and the
   repo's own gate caught it.

Also treats an empty diff as an explicit non-trigger, so the "includes Python/test-trigger changes"
wording is unreachable when nothing changed.

## Tests — real git, not mocks

Five new tests build actual repos and worktrees. Monkeypatching `_current_branch`/`_changed_paths` is
precisely what hid this bug, so these tests refuse to:

- push from a worktree branch → **not** blocked (the false positive)
- `cd <worktree> && git push` → judged in the worktree
- genuine `main` push with Python changes, no stamp → **still blocked** (teeth intact)
- empty diff → never claims Python changes
- `cd $VAR` → falls back rather than guessing

**Verified load-bearing:** reintroducing the original bug fails
`test_genuine_main_push_with_python_changes_still_blocks` and
`test_unresolvable_cd_falls_back_instead_of_guessing`.

29/29 pass, ruff clean — including with `GIT_DIR`/`GIT_INDEX_FILE` set, the condition that exposed
defect 2.

## After merge

`npm run agents:deploy` to refresh `.claude/hooks/`. Source of truth is `agents_extensions/shared/`;
the deploy target is never edited directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)