### PR TITLE
fix(security): never print a live OAuth token into a terminal (#5738)

### DIFF
--- a/scripts/lib/kimi_coding_oauth.py
+++ b/scripts/lib/kimi_coding_oauth.py
@@ -44,11 +44,23 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
+# Import secret_redactor (stdlib-only helper in parent scripts directory)
+try:
+    from secret_redactor import redact_text
+except ImportError:
+    _scripts_dir = str(Path(__file__).resolve().parent.parent)
+    if _scripts_dir not in sys.path:
+        sys.path.insert(0, _scripts_dir)
+    from secret_redactor import redact_text
+
 DEFAULT_OAUTH_HOST = "https://auth.kimi.com"
 # Public client id of the Kimi Code CLI device-code flow (no secret).
 DEFAULT_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098"
 DEFAULT_MARGIN_SECONDS = 120
 REQUEST_TIMEOUT_SECONDS = 15
+
+_OUT_FILE_ENV = "KIMI_CODE_OAUTH_OUT_FILE"
+_OUT_FILE_ENV_ALT = "KIMI_OAUTH_OUT_FILE"
 
 
 def _credentials_path() -> Path:
@@ -86,12 +98,26 @@ def _fresh_token(data: dict, margin: int) -> str | None:
     return token
 
 
+def _print_err(message: object) -> None:
+    """Print an error message to stderr after redacting any token shapes."""
+    redacted = redact_text(str(message))
+    print(redacted, file=sys.stderr)
+
+
 class NoCredentialsError(Exception):
     """Credential file cannot produce a token (missing/unusable)."""
+
+    def __init__(self, message: object = "") -> None:
+        msg_str = redact_text(str(message)) if message is not None else ""
+        super().__init__(msg_str)
 
 
 class RefreshFailedError(Exception):
     """The refresh grant against the auth host failed."""
+
+    def __init__(self, message: object = "") -> None:
+        msg_str = redact_text(str(message)) if message is not None else ""
+        super().__init__(msg_str)
 
 
 def _refresh(data: dict) -> dict:
@@ -120,7 +146,8 @@ def _refresh(data: dict) -> dict:
         with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")[:200]
+        raw_detail = exc.read().decode("utf-8", errors="replace")[:200]
+        detail = redact_text(raw_detail) or ""
         raise RefreshFailedError(f"token refresh failed: HTTP {exc.code} ({detail})") from exc
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
         raise RefreshFailedError(f"token refresh failed: {exc}") from exc
@@ -203,35 +230,50 @@ def force_refresh_token() -> str:
         return token
 
 
-_FORCE_TTY_ENV = "KIMI_OAUTH_ALLOW_TTY"
+def _write_token_to_file(out_path: Path, token: str) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, tmp_name = tempfile.mkstemp(dir=str(out_path.parent), prefix=out_path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(token.strip() + "\n")
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, out_path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
 
 
 def _emit_token(token: str) -> int:
-    """Write the OAuth token to stdout — but never into a terminal by accident.
+    """Write the OAuth token safely.
 
-    Printing the credential IS this command's contract: it is Claude Code's
-    `apiKeyHelper`, the same shape as `gh auth token`, and the launchd refresher
-    sends stdout to /dev/null. Both automated consumers pipe, so neither is
-    affected by the check below.
+    Refuses to print a live OAuth token to a terminal (TTY) under any
+    circumstances. No opt-in flag is provided that prints to a screen.
+    When stdout is a TTY, the token can be delivered to a secure file
+    (mode 0600) if KIMI_CODE_OAUTH_OUT_FILE or KIMI_OAUTH_OUT_FILE is set.
 
-    The residual exposure is the operator running it by hand: a live token then
-    sits in terminal scrollback and shell history, where it long outlives its
-    ~15-minute lifetime in a place nobody thinks to clear. CodeQL flags this line
-    (`py/clear-text-logging-sensitive-data`) and it is right to.
-
-    So refuse when stdout is a TTY unless explicitly overridden. This keeps the
-    helper contract intact, removes the accidental-exposure path, and makes the
-    remaining suppression honest rather than a shrug.
+    When stdout is not a TTY (piped or redirected), prints token to stdout.
     """
-    if sys.stdout.isatty() and os.environ.get(_FORCE_TTY_ENV) != "1":
-        print(
+    out_file = os.environ.get(_OUT_FILE_ENV) or os.environ.get(_OUT_FILE_ENV_ALT)
+    if out_file:
+        out_path = Path(out_file).expanduser()
+        try:
+            _write_token_to_file(out_path, token)
+            _print_err(f"kimi-coding-oauth: token written to {out_path} (mode 0600)")
+            return 0
+        except OSError as exc:
+            _print_err(f"kimi-coding-oauth: cannot write token to {out_path}: {exc}")
+            return 3
+
+    if sys.stdout.isatty():
+        _print_err(
             "kimi-coding-oauth: refusing to print a live OAuth token to a terminal.\n"
             "  It would persist in scrollback and shell history long after the token expires.\n"
-            "  Pipe it (`... token | pbcopy`), or set "
-            f"{_FORCE_TTY_ENV}=1 to override deliberately.",
-            file=sys.stderr,
+            "  Pipe it (`... token | pbcopy`), redirect it (`... token > token.txt`), or set "
+            f"{_OUT_FILE_ENV}=/path/to/file to deliver to a 0600 file."
         )
         return 3
+
     print(token)
     return 0
 
@@ -240,7 +282,7 @@ def cmd_token() -> int:
     path = _credentials_path()
     margin = _margin_seconds()
     if not path.is_file():
-        print(f"kimi-coding-oauth: credential file not found: {path} (run `kimi login`)", file=sys.stderr)
+        _print_err(f"kimi-coding-oauth: credential file not found: {path} (run `kimi login`)")
         return 2
 
     # Serialize refreshes across concurrent apiKeyHelper invocations. The lock
@@ -253,7 +295,7 @@ def cmd_token() -> int:
         try:
             data = _read_credentials(path)
         except (OSError, ValueError) as exc:
-            print(f"kimi-coding-oauth: cannot read credentials: {exc}", file=sys.stderr)
+            _print_err(f"kimi-coding-oauth: cannot read credentials: {exc}")
             return 2
 
         token = _fresh_token(data, margin)
@@ -263,21 +305,21 @@ def cmd_token() -> int:
         try:
             merged = _refresh(data)
         except NoCredentialsError as exc:
-            print(f"kimi-coding-oauth: {exc}", file=sys.stderr)
+            _print_err(f"kimi-coding-oauth: {exc}")
             return 2
         except RefreshFailedError as exc:
-            print(f"kimi-coding-oauth: {exc}", file=sys.stderr)
+            _print_err(f"kimi-coding-oauth: {exc}")
             return 3
         try:
             _write_credentials(path, merged)
         except OSError as exc:
-            print(f"kimi-coding-oauth: cannot write credentials: {exc}", file=sys.stderr)
+            _print_err(f"kimi-coding-oauth: cannot write credentials: {exc}")
             return 3
 
         token = _fresh_token(merged, 0)
         if token is not None:
             return _emit_token(token)
-        print("kimi-coding-oauth: refreshed token is already expired", file=sys.stderr)
+        _print_err("kimi-coding-oauth: refreshed token is already expired")
         return 3
 
 
@@ -286,23 +328,24 @@ def cmd_refresh() -> int:
     try:
         token = force_refresh_token()
     except NoCredentialsError as exc:
-        print(f"kimi-coding-oauth: {exc}", file=sys.stderr)
+        _print_err(f"kimi-coding-oauth: {exc}")
         return 2
     except RefreshFailedError as exc:
-        print(f"kimi-coding-oauth: {exc}", file=sys.stderr)
+        _print_err(f"kimi-coding-oauth: {exc}")
         return 3
     except OSError as exc:
-        print(f"kimi-coding-oauth: cannot write credentials: {exc}", file=sys.stderr)
+        _print_err(f"kimi-coding-oauth: cannot write credentials: {exc}")
         return 3
     return _emit_token(token)
 
 
 def main(argv: list[str]) -> int:
     if len(argv) != 2 or argv[1] not in {"token", "refresh"}:
-        print(__doc__, file=sys.stderr)
+        _print_err(__doc__)
         return 64
     return cmd_token() if argv[1] == "token" else cmd_refresh()
 
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv))
+

--- a/scripts/lib/kimi_coding_oauth.py
+++ b/scripts/lib/kimi_coding_oauth.py
@@ -203,6 +203,39 @@ def force_refresh_token() -> str:
         return token
 
 
+_FORCE_TTY_ENV = "KIMI_OAUTH_ALLOW_TTY"
+
+
+def _emit_token(token: str) -> int:
+    """Write the OAuth token to stdout — but never into a terminal by accident.
+
+    Printing the credential IS this command's contract: it is Claude Code's
+    `apiKeyHelper`, the same shape as `gh auth token`, and the launchd refresher
+    sends stdout to /dev/null. Both automated consumers pipe, so neither is
+    affected by the check below.
+
+    The residual exposure is the operator running it by hand: a live token then
+    sits in terminal scrollback and shell history, where it long outlives its
+    ~15-minute lifetime in a place nobody thinks to clear. CodeQL flags this line
+    (`py/clear-text-logging-sensitive-data`) and it is right to.
+
+    So refuse when stdout is a TTY unless explicitly overridden. This keeps the
+    helper contract intact, removes the accidental-exposure path, and makes the
+    remaining suppression honest rather than a shrug.
+    """
+    if sys.stdout.isatty() and os.environ.get(_FORCE_TTY_ENV) != "1":
+        print(
+            "kimi-coding-oauth: refusing to print a live OAuth token to a terminal.\n"
+            "  It would persist in scrollback and shell history long after the token expires.\n"
+            "  Pipe it (`... token | pbcopy`), or set "
+            f"{_FORCE_TTY_ENV}=1 to override deliberately.",
+            file=sys.stderr,
+        )
+        return 3
+    print(token)
+    return 0
+
+
 def cmd_token() -> int:
     path = _credentials_path()
     margin = _margin_seconds()
@@ -225,8 +258,7 @@ def cmd_token() -> int:
 
         token = _fresh_token(data, margin)
         if token is not None:
-            print(token)
-            return 0
+            return _emit_token(token)
 
         try:
             merged = _refresh(data)
@@ -243,11 +275,10 @@ def cmd_token() -> int:
             return 3
 
         token = _fresh_token(merged, 0)
-        if token is None:
-            print("kimi-coding-oauth: refreshed token is already expired", file=sys.stderr)
-            return 3
-        print(token)
-        return 0
+        if token is not None:
+            return _emit_token(token)
+        print("kimi-coding-oauth: refreshed token is already expired", file=sys.stderr)
+        return 3
 
 
 def cmd_refresh() -> int:
@@ -263,8 +294,7 @@ def cmd_refresh() -> int:
     except OSError as exc:
         print(f"kimi-coding-oauth: cannot write credentials: {exc}", file=sys.stderr)
         return 3
-    print(token)
-    return 0
+    return _emit_token(token)
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/lib/kimi_coding_oauth.py
+++ b/scripts/lib/kimi_coding_oauth.py
@@ -42,6 +42,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Iterable
 from pathlib import Path
 
 # Import secret_redactor (stdlib-only helper in parent scripts directory)
@@ -98,32 +99,91 @@ def _fresh_token(data: dict, margin: int) -> str | None:
     return token
 
 
-def _print_err(message: object) -> None:
-    """Print an error message to stderr after redacting any token shapes."""
-    redacted = redact_text(str(message))
+_METADATA_KEYS = {
+    "token_type",
+    "scope",
+    "expires_in",
+    "expires_at",
+    "client_id",
+    "grant_type",
+    "error",
+    "error_description",
+    "message",
+    "detail",
+    "status",
+    "host",
+    "url",
+    "path",
+    "filename",
+}
+
+
+def _held_secrets(*sources: dict | None) -> set[str]:
+    """Collect known credential string values from dictionary sources and environment."""
+    secrets: set[str] = set()
+    for src in sources:
+        if isinstance(src, dict):
+            for k, v in src.items():
+                if isinstance(v, str) and v:
+                    if k in {"access_token", "refresh_token", "id_token", "client_secret", "secret", "api_key", "token", "password"}:
+                        secrets.add(v)
+                    elif k not in _METADATA_KEYS:
+                        secrets.add(v)
+    for env_var in ("KIMI_CODE_OAUTH_CLIENT_SECRET", "KIMI_OAUTH_CLIENT_SECRET"):
+        val = os.environ.get(env_var)
+        if val:
+            secrets.add(val)
+    return secrets
+
+
+def redact_exact(text: str, secrets: Iterable[str]) -> str:
+    """Redact known secret strings from text by exact substring match."""
+    if not text:
+        return text
+    result = str(text)
+    valid_secrets = sorted({s for s in secrets if isinstance(s, str) and s}, key=len, reverse=True)
+    for sec in valid_secrets:
+        result = result.replace(sec, "[REDACTED_SECRET]")
+    return result
+
+
+def redact_oauth_text(text: str, secrets: Iterable[str] = ()) -> str:
+    """Redact text using exact-value match on held secrets, then redact_text shape matching."""
+    if not text:
+        return text
+    cleaned = redact_exact(text, secrets)
+    return redact_text(cleaned)
+
+
+def _print_err(message: object, secrets: Iterable[str] = ()) -> None:
+    """Print an error message to stderr after redacting any token shapes or held secrets."""
+    redacted = redact_oauth_text(str(message), secrets)
     print(redacted, file=sys.stderr)
 
 
 class NoCredentialsError(Exception):
     """Credential file cannot produce a token (missing/unusable)."""
 
-    def __init__(self, message: object = "") -> None:
-        msg_str = redact_text(str(message)) if message is not None else ""
-        super().__init__(msg_str)
+    def __init__(self, message: object = "", secrets: Iterable[str] = ()) -> None:
+        msg_str = str(message) if message is not None else ""
+        redacted = redact_oauth_text(msg_str, secrets)
+        super().__init__(redacted)
 
 
 class RefreshFailedError(Exception):
     """The refresh grant against the auth host failed."""
 
-    def __init__(self, message: object = "") -> None:
-        msg_str = redact_text(str(message)) if message is not None else ""
-        super().__init__(msg_str)
+    def __init__(self, message: object = "", secrets: Iterable[str] = ()) -> None:
+        msg_str = str(message) if message is not None else ""
+        redacted = redact_oauth_text(msg_str, secrets)
+        super().__init__(redacted)
 
 
 def _refresh(data: dict) -> dict:
+    held = _held_secrets(data)
     refresh_token = data.get("refresh_token")
     if not isinstance(refresh_token, str) or not refresh_token:
-        raise NoCredentialsError("no refresh_token in credential file — run `kimi login` again")
+        raise NoCredentialsError("no refresh_token in credential file — run `kimi login` again", secrets=held)
     host = os.environ.get("KIMI_CODE_OAUTH_HOST") or os.environ.get("KIMI_OAUTH_HOST") or DEFAULT_OAUTH_HOST
     client_id = os.environ.get("KIMI_CODE_OAUTH_CLIENT_ID") or DEFAULT_CLIENT_ID
     body = "&".join(
@@ -147,12 +207,18 @@ def _refresh(data: dict) -> dict:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         raw_detail = exc.read().decode("utf-8", errors="replace")[:200]
-        detail = redact_text(raw_detail) or ""
-        raise RefreshFailedError(f"token refresh failed: HTTP {exc.code} ({detail})") from exc
+        detail = redact_oauth_text(raw_detail, held) or ""
+        raise RefreshFailedError(f"token refresh failed: HTTP {exc.code} ({detail})", secrets=held) from exc
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
-        raise RefreshFailedError(f"token refresh failed: {exc}") from exc
+        msg = redact_oauth_text(f"token refresh failed: {exc}", held)
+        raise RefreshFailedError(msg, secrets=held) from exc
     if not isinstance(payload, dict) or not isinstance(payload.get("access_token"), str):
-        raise RefreshFailedError("token refresh returned no access_token")
+        if isinstance(payload, dict):
+            held.update(_held_secrets(payload))
+        msg = redact_oauth_text("token refresh returned no access_token", held)
+        raise RefreshFailedError(msg, secrets=held)
+
+    held.update(_held_secrets(payload))
 
     merged = dict(data)
     merged["access_token"] = payload["access_token"]
@@ -222,11 +288,13 @@ def force_refresh_token() -> str:
         except (OSError, ValueError) as exc:
             raise NoCredentialsError(f"cannot read credentials: {exc}") from exc
 
+        held = _held_secrets(data)
         merged = _refresh(data)
+        held.update(_held_secrets(merged))
         _write_credentials(path, merged)
         token = _fresh_token(merged, 0)
         if token is None:
-            raise RefreshFailedError("refreshed token is already expired")
+            raise RefreshFailedError("refreshed token is already expired", secrets=held)
         return token
 
 
@@ -298,28 +366,30 @@ def cmd_token() -> int:
             _print_err(f"kimi-coding-oauth: cannot read credentials: {exc}")
             return 2
 
+        held = _held_secrets(data)
         token = _fresh_token(data, margin)
         if token is not None:
             return _emit_token(token)
 
         try:
             merged = _refresh(data)
+            held.update(_held_secrets(merged))
         except NoCredentialsError as exc:
-            _print_err(f"kimi-coding-oauth: {exc}")
+            _print_err(f"kimi-coding-oauth: {exc}", secrets=held)
             return 2
         except RefreshFailedError as exc:
-            _print_err(f"kimi-coding-oauth: {exc}")
+            _print_err(f"kimi-coding-oauth: {exc}", secrets=held)
             return 3
         try:
             _write_credentials(path, merged)
         except OSError as exc:
-            _print_err(f"kimi-coding-oauth: cannot write credentials: {exc}")
+            _print_err(f"kimi-coding-oauth: cannot write credentials: {exc}", secrets=held)
             return 3
 
         token = _fresh_token(merged, 0)
         if token is not None:
             return _emit_token(token)
-        _print_err("kimi-coding-oauth: refreshed token is already expired")
+        _print_err("kimi-coding-oauth: refreshed token is already expired", secrets=held)
         return 3
 
 

--- a/scripts/lib/kimi_coding_oauth.py
+++ b/scripts/lib/kimi_coding_oauth.py
@@ -124,11 +124,15 @@ def _held_secrets(*sources: dict | None) -> set[str]:
     for src in sources:
         if isinstance(src, dict):
             for k, v in src.items():
-                if isinstance(v, str) and v:
-                    if k in {"access_token", "refresh_token", "id_token", "client_secret", "secret", "api_key", "token", "password"}:
-                        secrets.add(v)
-                    elif k not in _METADATA_KEYS:
-                        secrets.add(v)
+                if (
+                    isinstance(v, str)
+                    and v
+                    and (
+                        k in {"access_token", "refresh_token", "id_token", "client_secret", "secret", "api_key", "token", "password"}
+                        or k not in _METADATA_KEYS
+                    )
+                ):
+                    secrets.add(v)
     for env_var in ("KIMI_CODE_OAUTH_CLIENT_SECRET", "KIMI_OAUTH_CLIENT_SECRET"):
         val = os.environ.get(env_var)
         if val:
@@ -206,8 +210,8 @@ def _refresh(data: dict) -> dict:
         with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
-        raw_detail = exc.read().decode("utf-8", errors="replace")[:200]
-        detail = redact_oauth_text(raw_detail, held) or ""
+        raw_detail = exc.read().decode("utf-8", errors="replace")
+        detail = redact_oauth_text(raw_detail, held)[:200] or ""
         raise RefreshFailedError(f"token refresh failed: HTTP {exc.code} ({detail})", secrets=held) from exc
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
         msg = redact_oauth_text(f"token refresh failed: {exc}", held)

--- a/tests/test_kimi_oauth_tty_guard.py
+++ b/tests/test_kimi_oauth_tty_guard.py
@@ -16,8 +16,12 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
+import os
 import stat
+import subprocess
 import sys
+import time
 import urllib.error
 from pathlib import Path
 
@@ -92,6 +96,41 @@ def test_pipes_normally_when_stdout_is_not_a_terminal(monkeypatch):
 
     assert rc == 0
     assert sys.stdout.getvalue().strip() == TOKEN
+
+
+def test_helper_sub_process_piped_contract(tmp_path: Path):
+    """Consumer contract: invoking helper with stdout piped yields exit 0 and non-empty token on stdout."""
+    cred_file = tmp_path / "kimi-code.json"
+    cred_file.write_text(
+        json.dumps(
+            {
+                "access_token": "sk-piped-delivery-token-12345",
+                "refresh_token": "r-refresh-token",
+                "expires_at": time.time() + 900,
+                "expires_in": 900,
+                "token_type": "Bearer",
+                "scope": "kimi-code",
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["KIMI_CODE_CREDENTIALS_PATH"] = str(cred_file)
+    env["KIMI_CODE_OAUTH_HOST"] = "http://127.0.0.1:9"
+    env.pop(oauth._OUT_FILE_ENV, None)
+    env.pop(oauth._OUT_FILE_ENV_ALT, None)
+
+    proc = subprocess.run(
+        [sys.executable, str(MODULE), "token"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+
+    assert proc.returncode == 0, f"Expected exit 0, got {proc.returncode}. Stderr: {proc.stderr}"
+    assert proc.stdout.strip() == "sk-piped-delivery-token-12345", "Token must be printed to stdout when stdout is piped"
+    assert len(proc.stdout.strip()) > 0, "stdout must be non-empty"
 
 
 def test_out_file_delivers_token_securely_mode_0600(tmp_path: Path, monkeypatch, capsys):

--- a/tests/test_kimi_oauth_tty_guard.py
+++ b/tests/test_kimi_oauth_tty_guard.py
@@ -8,15 +8,20 @@ The exposure is the operator running it by hand: the token then sits in scrollba
 and shell history long after its ~15-minute life, somewhere nobody thinks to clear.
 CodeQL flags it (`py/clear-text-logging-sensitive-data`) and is right to.
 
-Operator chose this over suppressing the alert (2026-07-25).
+This test module verifies both P1-a (no escape hatch printing to terminal, optional 0600 file delivery)
+and P1-b (all error paths, HTTP error bodies, and exceptions redacted by token shape).
 """
 
 from __future__ import annotations
 
 import importlib.util
 import io
+import stat
 import sys
+import urllib.error
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODULE = REPO_ROOT / "scripts" / "lib" / "kimi_coding_oauth.py"
@@ -26,7 +31,7 @@ assert spec and spec.loader
 oauth = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(oauth)
 
-TOKEN = "sk-live-do-not-leak-me"
+TOKEN = "sk-live-do-not-leak-me-1234567890"
 
 
 class _Stdout(io.StringIO):
@@ -40,7 +45,8 @@ class _Stdout(io.StringIO):
 
 def test_refuses_to_print_into_a_terminal(monkeypatch, capsys):
     monkeypatch.setattr(sys, "stdout", _Stdout(tty=True))
-    monkeypatch.delenv(oauth._FORCE_TTY_ENV, raising=False)
+    monkeypatch.delenv(oauth._OUT_FILE_ENV, raising=False)
+    monkeypatch.delenv(oauth._OUT_FILE_ENV_ALT, raising=False)
 
     rc = oauth._emit_token(TOKEN)
 
@@ -48,23 +54,39 @@ def test_refuses_to_print_into_a_terminal(monkeypatch, capsys):
     assert TOKEN not in sys.stdout.getvalue(), "the token was written to a terminal"
 
 
-def test_refusal_explains_the_two_ways_forward(monkeypatch, capsys):
+def test_refusal_explains_how_to_deliver_safely(monkeypatch, capsys):
     monkeypatch.setattr(sys, "stdout", _Stdout(tty=True))
-    monkeypatch.delenv(oauth._FORCE_TTY_ENV, raising=False)
+    monkeypatch.delenv(oauth._OUT_FILE_ENV, raising=False)
+    monkeypatch.delenv(oauth._OUT_FILE_ENV_ALT, raising=False)
 
     oauth._emit_token(TOKEN)
 
     err = capsys.readouterr().err
     assert "scrollback" in err, "say WHY, not just no"
     assert "Pipe it" in err
-    assert oauth._FORCE_TTY_ENV in err, "the override must be discoverable"
+    assert oauth._OUT_FILE_ENV in err, "the file output option must be discoverable"
+    assert "KIMI_OAUTH_ALLOW_TTY" not in err, "the deprecated dangerous flag must not be suggested"
     assert TOKEN not in err, "the refusal must not leak the token it is protecting"
+
+
+def test_env_override_allow_tty_is_ignored_and_still_refuses(monkeypatch, capsys):
+    """An opt-in flag that prints a live token to a TTY is forbidden (P1-a)."""
+    monkeypatch.setattr(sys, "stdout", _Stdout(tty=True))
+    monkeypatch.setenv("KIMI_OAUTH_ALLOW_TTY", "1")
+    monkeypatch.delenv(oauth._OUT_FILE_ENV, raising=False)
+    monkeypatch.delenv(oauth._OUT_FILE_ENV_ALT, raising=False)
+
+    rc = oauth._emit_token(TOKEN)
+
+    assert rc == 3
+    assert TOKEN not in sys.stdout.getvalue()
+    assert TOKEN not in capsys.readouterr().err
 
 
 def test_pipes_normally_when_stdout_is_not_a_terminal(monkeypatch):
     """The apiKeyHelper and launchd paths both pipe — they must be untouched."""
     monkeypatch.setattr(sys, "stdout", _Stdout(tty=False))
-    monkeypatch.delenv(oauth._FORCE_TTY_ENV, raising=False)
+    monkeypatch.delenv(oauth._OUT_FILE_ENV, raising=False)
 
     rc = oauth._emit_token(TOKEN)
 
@@ -72,22 +94,97 @@ def test_pipes_normally_when_stdout_is_not_a_terminal(monkeypatch):
     assert sys.stdout.getvalue().strip() == TOKEN
 
 
-def test_explicit_override_is_honoured(monkeypatch):
+def test_out_file_delivers_token_securely_mode_0600(tmp_path: Path, monkeypatch, capsys):
+    """Operator can deliver token to a file with 0600 permissions instead of printing to TTY."""
+    out_file = tmp_path / "tokens" / "secret_token.txt"
     monkeypatch.setattr(sys, "stdout", _Stdout(tty=True))
-    monkeypatch.setenv(oauth._FORCE_TTY_ENV, "1")
+    monkeypatch.setenv(oauth._OUT_FILE_ENV, str(out_file))
 
     rc = oauth._emit_token(TOKEN)
 
     assert rc == 0
-    assert sys.stdout.getvalue().strip() == TOKEN
+    assert out_file.is_file()
+    assert out_file.read_text(encoding="utf-8").strip() == TOKEN
+    assert stat.S_IMODE(out_file.stat().st_mode) == 0o600
+    assert TOKEN not in sys.stdout.getvalue()
+    err = capsys.readouterr().err
+    assert "token written to" in err
+    assert TOKEN not in err
 
 
-def test_override_must_be_exactly_1(monkeypatch):
-    """A stray truthy value must not disable a credential guard."""
+def test_out_file_alt_env_var_works(tmp_path: Path, monkeypatch):
+    out_file = tmp_path / "secret_alt.txt"
     monkeypatch.setattr(sys, "stdout", _Stdout(tty=True))
-    monkeypatch.setenv(oauth._FORCE_TTY_ENV, "true")
+    monkeypatch.setenv(oauth._OUT_FILE_ENV_ALT, str(out_file))
 
-    assert oauth._emit_token(TOKEN) == 3
+    rc = oauth._emit_token(TOKEN)
+
+    assert rc == 0
+    assert out_file.is_file()
+    assert out_file.read_text(encoding="utf-8").strip() == TOKEN
+    assert stat.S_IMODE(out_file.stat().st_mode) == 0o600
+
+
+def test_refresh_failed_error_redacts_http_400_body_tokens(monkeypatch):
+    """OAuth error bodies in HTTP 400 responses must be redacted by token shape (P1-b)."""
+    synthetic_body = (
+        '{"error": "invalid_grant", "received_access_token": "sk-synthetic-live-token-12345678901234567890"}'
+    )
+    fp = io.BytesIO(synthetic_body.encode("utf-8"))
+    exc = urllib.error.HTTPError("http://auth.kimi.com/api/oauth/token", 400, "Bad Request", {}, fp)  # type: ignore[arg-type]
+
+    def _mock_urlopen(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(urllib.request, "urlopen", _mock_urlopen)
+
+    data = {"refresh_token": "r-synthetic-refresh-1234567890"}
+    with pytest.raises(oauth.RefreshFailedError) as exc_info:
+        oauth._refresh(data)
+    err_msg = str(exc_info.value)
+    assert "sk-synthetic-live-token" not in err_msg, "synthetic token leaked in exception message"
+    assert "[REDACTED_SECRET]" in err_msg, "expected redaction placeholder in exception message"
+
+
+def test_refresh_failed_error_redacts_unanticipated_nested_keys(monkeypatch):
+    """Redaction must be by token SHAPE, not key name, for provider-controlled bodies."""
+    unanticipated_body = (
+        '{"error": "invalid", "provider_unanticipated_key": "sk-synthetic-secret-token-99999999999"}'
+    )
+    fp = io.BytesIO(unanticipated_body.encode("utf-8"))
+    exc = urllib.error.HTTPError("http://auth.kimi.com/api/oauth/token", 400, "Bad Request", {}, fp)  # type: ignore[arg-type]
+
+    def _mock_urlopen(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(urllib.request, "urlopen", _mock_urlopen)
+
+    data = {"refresh_token": "r-synthetic-refresh-1234567890"}
+    with pytest.raises(oauth.RefreshFailedError) as exc_info:
+        oauth._refresh(data)
+    err_msg = str(exc_info.value)
+    assert "sk-synthetic-secret-token" not in err_msg
+    assert "[REDACTED_SECRET]" in err_msg
+
+
+def test_exception_init_redacts_token_in_message():
+    raw_msg = "Refresh failed for token sk-synthetic-secret-1234567890123456"
+    err = oauth.RefreshFailedError(raw_msg)
+    assert "sk-synthetic-secret" not in str(err)
+    assert "[REDACTED_SECRET]" in str(err)
+
+    no_cred_err = oauth.NoCredentialsError(raw_msg)
+    assert "sk-synthetic-secret" not in str(no_cred_err)
+    assert "[REDACTED_SECRET]" in str(no_cred_err)
+
+
+def test_print_err_redacts_token_shapes(capsys):
+    raw_msg = "kimi-coding-oauth: failed with token sk-synthetic-secret-1234567890123456"
+    oauth._print_err(raw_msg)
+
+    err = capsys.readouterr().err
+    assert "sk-synthetic-secret" not in err
+    assert "[REDACTED_SECRET]" in err
 
 
 def test_every_token_emission_path_goes_through_the_guard():

--- a/tests/test_kimi_oauth_tty_guard.py
+++ b/tests/test_kimi_oauth_tty_guard.py
@@ -231,3 +231,31 @@ def test_refresh_failed_error_redacts_opaque_synthetic_tokens(monkeypatch, respo
     assert opaque_token not in err_msg, f"opaque synthetic token leaked in exception message: {err_msg}"
     assert "[REDACTED_SECRET]" in err_msg, f"expected redaction placeholder in exception message: {err_msg}"
 
+
+def test_refresh_failed_error_redacts_token_straddling_truncation_boundary(monkeypatch):
+    """Token straddling 200-byte truncation boundary must be redacted before truncation."""
+    opaque_token = "6f1d2a9c7b8e9f0a1b2c3d4e5f6a7b8c"
+    # Position token so it starts at offset 190, straddling the 200-byte boundary.
+    padding_before = "x" * 190
+    padding_after = "y" * 50
+    response_body = f"{padding_before}{opaque_token}{padding_after}"
+
+    fp = io.BytesIO(response_body.encode("utf-8"))
+    exc = urllib.error.HTTPError("http://auth.kimi.com/api/oauth/token", 400, "Bad Request", {}, fp)  # type: ignore[arg-type]
+
+    def _mock_urlopen(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(urllib.request, "urlopen", _mock_urlopen)
+
+    data = {"refresh_token": opaque_token}
+    with pytest.raises(oauth.RefreshFailedError) as exc_info:
+        oauth._refresh(data)
+    err_msg = str(exc_info.value)
+
+    # Assert no prefix of length >= 8 of the secret appears in the output
+    for i in range(8, len(opaque_token) + 1):
+        prefix = opaque_token[:i]
+        assert prefix not in err_msg, f"secret prefix {prefix!r} leaked in exception message: {err_msg}"
+
+

--- a/tests/test_kimi_oauth_tty_guard.py
+++ b/tests/test_kimi_oauth_tty_guard.py
@@ -203,3 +203,31 @@ def test_every_token_emission_path_goes_through_the_guard():
     emit_def = source.index("def _emit_token")
     next_def = source.index("\ndef ", emit_def + 1)
     assert "print(token)" in source[emit_def:next_def], "the surviving print must be the guarded one"
+
+
+@pytest.mark.parametrize(
+    "response_body",
+    [
+        '{"error": "invalid_grant", "error_description": "token 9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c is expired"}',
+        '{"detail": "refresh failed for 9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c"}',
+        'refresh failed: 9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c rejected',
+    ],
+)
+def test_refresh_failed_error_redacts_opaque_synthetic_tokens(monkeypatch, response_body):
+    """Held credentials (opaque, non-prefixed) must be redacted by exact value on provider error text."""
+    opaque_token = "9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c"
+    fp = io.BytesIO(response_body.encode("utf-8"))
+    exc = urllib.error.HTTPError("http://auth.kimi.com/api/oauth/token", 400, "Bad Request", {}, fp)  # type: ignore[arg-type]
+
+    def _mock_urlopen(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(urllib.request, "urlopen", _mock_urlopen)
+
+    data = {"refresh_token": opaque_token}
+    with pytest.raises(oauth.RefreshFailedError) as exc_info:
+        oauth._refresh(data)
+    err_msg = str(exc_info.value)
+    assert opaque_token not in err_msg, f"opaque synthetic token leaked in exception message: {err_msg}"
+    assert "[REDACTED_SECRET]" in err_msg, f"expected redaction placeholder in exception message: {err_msg}"
+

--- a/tests/test_kimi_oauth_tty_guard.py
+++ b/tests/test_kimi_oauth_tty_guard.py
@@ -30,6 +30,33 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODULE = REPO_ROOT / "scripts" / "lib" / "kimi_coding_oauth.py"
 
+
+def _resolve_venv_python() -> Path | None:
+    """Project venv; falls back to the main worktree when run from a linked worktree.
+
+    The repo forbids `sys.executable` / bare `python`: subprocesses must run the
+    project interpreter. Mirrors the helper in tests/test_start_kimicc.py.
+    """
+    candidates = [REPO_ROOT / ".venv" / "bin" / "python"]
+    try:
+        common = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if common.returncode == 0 and common.stdout.strip():
+            candidates.append(Path(common.stdout.strip()).parent / ".venv" / "bin" / "python")
+    except (OSError, subprocess.SubprocessError):
+        pass
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+VENV_PYTHON = _resolve_venv_python()
+
 spec = importlib.util.spec_from_file_location("kimi_oauth_under_test", MODULE)
 assert spec and spec.loader
 oauth = importlib.util.module_from_spec(spec)
@@ -120,8 +147,11 @@ def test_helper_sub_process_piped_contract(tmp_path: Path):
     env.pop(oauth._OUT_FILE_ENV, None)
     env.pop(oauth._OUT_FILE_ENV_ALT, None)
 
+    if VENV_PYTHON is None:
+        pytest.skip("project .venv interpreter not found; repo forbids sys.executable here")
+
     proc = subprocess.run(
-        [sys.executable, str(MODULE), "token"],
+        [str(VENV_PYTHON), str(MODULE), "token"],
         capture_output=True,
         text=True,
         env=env,

--- a/tests/test_kimi_oauth_tty_guard.py
+++ b/tests/test_kimi_oauth_tty_guard.py
@@ -1,0 +1,108 @@
+"""A live OAuth token must never land in a terminal by accident.
+
+Printing the credential IS this command's contract — it is Claude Code's
+`apiKeyHelper`, the same shape as `gh auth token`, and the launchd refresher sends
+stdout to /dev/null. Both automated consumers pipe, so neither is affected.
+
+The exposure is the operator running it by hand: the token then sits in scrollback
+and shell history long after its ~15-minute life, somewhere nobody thinks to clear.
+CodeQL flags it (`py/clear-text-logging-sensitive-data`) and is right to.
+
+Operator chose this over suppressing the alert (2026-07-25).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULE = REPO_ROOT / "scripts" / "lib" / "kimi_coding_oauth.py"
+
+spec = importlib.util.spec_from_file_location("kimi_oauth_under_test", MODULE)
+assert spec and spec.loader
+oauth = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(oauth)
+
+TOKEN = "sk-live-do-not-leak-me"
+
+
+class _Stdout(io.StringIO):
+    def __init__(self, tty: bool) -> None:
+        super().__init__()
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+def test_refuses_to_print_into_a_terminal(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdout", _Stdout(tty=True))
+    monkeypatch.delenv(oauth._FORCE_TTY_ENV, raising=False)
+
+    rc = oauth._emit_token(TOKEN)
+
+    assert rc == 3
+    assert TOKEN not in sys.stdout.getvalue(), "the token was written to a terminal"
+
+
+def test_refusal_explains_the_two_ways_forward(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdout", _Stdout(tty=True))
+    monkeypatch.delenv(oauth._FORCE_TTY_ENV, raising=False)
+
+    oauth._emit_token(TOKEN)
+
+    err = capsys.readouterr().err
+    assert "scrollback" in err, "say WHY, not just no"
+    assert "Pipe it" in err
+    assert oauth._FORCE_TTY_ENV in err, "the override must be discoverable"
+    assert TOKEN not in err, "the refusal must not leak the token it is protecting"
+
+
+def test_pipes_normally_when_stdout_is_not_a_terminal(monkeypatch):
+    """The apiKeyHelper and launchd paths both pipe — they must be untouched."""
+    monkeypatch.setattr(sys, "stdout", _Stdout(tty=False))
+    monkeypatch.delenv(oauth._FORCE_TTY_ENV, raising=False)
+
+    rc = oauth._emit_token(TOKEN)
+
+    assert rc == 0
+    assert sys.stdout.getvalue().strip() == TOKEN
+
+
+def test_explicit_override_is_honoured(monkeypatch):
+    monkeypatch.setattr(sys, "stdout", _Stdout(tty=True))
+    monkeypatch.setenv(oauth._FORCE_TTY_ENV, "1")
+
+    rc = oauth._emit_token(TOKEN)
+
+    assert rc == 0
+    assert sys.stdout.getvalue().strip() == TOKEN
+
+
+def test_override_must_be_exactly_1(monkeypatch):
+    """A stray truthy value must not disable a credential guard."""
+    monkeypatch.setattr(sys, "stdout", _Stdout(tty=True))
+    monkeypatch.setenv(oauth._FORCE_TTY_ENV, "true")
+
+    assert oauth._emit_token(TOKEN) == 3
+
+
+def test_every_token_emission_path_goes_through_the_guard():
+    """The sibling-path check.
+
+    A guard on one of three print sites is not a guard. `cmd_token` has two exits
+    that produce a token (cached and post-refresh) and `cmd_refresh` has a third;
+    all must route through `_emit_token`, or the protection is bypassed by simply
+    taking another branch.
+    """
+    source = MODULE.read_text(encoding="utf-8")
+    assert source.count("print(token)") == 1, (
+        "exactly one bare `print(token)` may exist, inside _emit_token; "
+        "another emission path would bypass the TTY guard"
+    )
+    emit_def = source.index("def _emit_token")
+    next_def = source.index("\ndef ", emit_def + 1)
+    assert "print(token)" in source[emit_def:next_def], "the surviving print must be the guarded one"

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -46,6 +46,7 @@ def _require_launcher_sources() -> None:
     """Seed from checkout once; do not depend on root scripts surviving full CI suite."""
     missing = [path for path in (
         _LAUNCHER,
+        _REPO_ROOT / "scripts" / "secret_redactor.py",
         _REPO_ROOT / "scripts" / "lib" / "claude_route_guard.sh",
         _REPO_ROOT / "scripts" / "lib" / "profile_resolver.sh",
         _REPO_ROOT / "scripts" / "lib" / "context_profiles.py",
@@ -74,6 +75,10 @@ def _seed_fake_project(tmp_path: Path) -> Path:
     _write_executable(
         project / "start-claude.sh",
         "#!/usr/bin/env bash\n# Test stub: kimicc already exported env; exec fake claude from PATH.\nexec claude \"$@\"\n",
+    )
+    secret_redactor = _REPO_ROOT / "scripts" / "secret_redactor.py"
+    (project / "scripts" / "secret_redactor.py").write_text(
+        secret_redactor.read_text(encoding="utf-8"), encoding="utf-8"
     )
     for name in ("claude_route_guard.sh", "profile_resolver.sh", "context_profiles.py", "kimi_coding_oauth.py"):
         src = _REPO_ROOT / "scripts" / "lib" / name


### PR DESCRIPTION
Targets `agy/kimicc-lane` so it lands **inside** #5738 and clears that PR's only blocker.

Operator chose **option A** over suppressing the CodeQL alert (2026-07-25).

## The tension this resolves

`py/clear-text-logging-sensitive-data` (**high**) fires on `kimi_coding_oauth.py` printing a live
access token to stdout. The alert is right — and the print is also the command's **contract**: it is
Claude Code's `apiKeyHelper`, the same shape as `gh auth token`, and the launchd refresher sends
stdout to `/dev/null`.

Both automated consumers **pipe**, so neither is affected by this change.

The real exposure is the operator running it by hand: a live token then sits in scrollback and shell
history long after its ~15-minute lifetime, somewhere nobody thinks to clear.

## What changed

`_emit_token` refuses when stdout is a TTY, explains **why**, names both ways forward (pipe it, or
`KIMI_OAUTH_ALLOW_TTY=1`), and does not echo the token in its own refusal message. The override must be
exactly `"1"` — a stray truthy value must not disable a credential guard.

## The part that mattered most: sibling paths

There were **three** emission sites, not one. `cmd_token` exits with a token twice — cached, and
post-refresh — and `cmd_refresh` a third time. **A guard on one of three is not a guard, it is a
detour**: the protection is bypassed by simply taking another branch.

All three now route through `_emit_token`, and a test asserts exactly one bare `print(token)` exists in
the file and that it is the guarded one. **Verified load-bearing:** restoring a single bypassed path
fails that test.

Six tests, 11/11 in the file, ruff clean.

## Why this is worth doing tonight

#5738 is the fix for a lane that is currently **dead**. Measured today while assembling an advisor
panel: `ask-kimi` returns a message id, the worker exits instantly, the log is **0 bytes**, no usage
record is written. `glm-5.2` had to be substituted mid-panel.

Landing this clears the alert on its own merits rather than dismissing it, so #5738 can proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
