### PR TITLE
test(ci): skip unprovisioned corpus tests honestly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,83 @@ Provides reusable content snippets and module templates for testing.
 """
 
 import os
+import sqlite3
 import sys
+from collections.abc import Collection
+from pathlib import Path
 
 import pytest
 
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _require_data_artifact(
+    relative_path: str,
+    *,
+    required_sqlite_tables: Collection[str] = (),
+) -> Path:
+    """Return a local data artifact or skip tests that cannot run without it."""
+    data_root = Path(os.environ.get("LEARN_UKRAINIAN_TEST_DATA_ROOT", _REPO_ROOT))
+    artifact = data_root / relative_path
+    if not artifact.is_file():
+        pytest.skip(f"requires {relative_path} (not provisioned in CI)")
+
+    if required_sqlite_tables:
+        try:
+            with sqlite3.connect(f"file:{artifact}?mode=ro", uri=True) as connection:
+                available_tables = {
+                    row[0]
+                    for row in connection.execute(
+                        "SELECT name FROM sqlite_master WHERE type = 'table'"
+                    )
+                }
+        except sqlite3.Error:
+            available_tables = set()
+        missing_tables = sorted(set(required_sqlite_tables) - available_tables)
+        if missing_tables:
+            pytest.skip(
+                f"requires {relative_path} with SQLite tables: "
+                f"{', '.join(missing_tables)} (not provisioned in CI)"
+            )
+    return artifact
+
+
+@pytest.fixture
+def requires_sources_db() -> Path:
+    """Skip a test requiring the complete uncommitted sources corpus database."""
+    return _require_data_artifact(
+        "data/sources.db",
+        required_sqlite_tables=(
+            "external_articles",
+            "external_fts",
+            "literary_fts",
+            "literary_texts",
+            "textbook_sections",
+            "textbooks",
+            "textbooks_fts",
+            "ukrainian_wiki",
+            "ukrainian_wiki_fts",
+            "wikipedia",
+            "wikipedia_fts",
+        ),
+    )
+
+
+@pytest.fixture
+def requires_vesum_db() -> Path:
+    """Skip a test requiring the uncommitted VESUM database."""
+    return _require_data_artifact("data/vesum.db", required_sqlite_tables=("forms",))
+
+
+@pytest.fixture
+def requires_literary_wave12_jsonl() -> Path:
+    """Skip a test requiring the uncommitted Wave 12 literary corpus fixture."""
+    return _require_data_artifact(
+        "data/literary_texts/wave12-krupnytsky-orlyk-biohrafiia.jsonl"
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_morphological_validator.py
+++ b/tests/test_morphological_validator.py
@@ -6,6 +6,8 @@ Issue: #753
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from audit.checks.morphological_validator import (
@@ -128,6 +130,7 @@ class TestAllowedChunks:
 # Core validation tests (TC1-TC9 from issue #753)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestVerbDetection:
     """TC1: Verbs caught in pre-verb modules (M01-M03 have no_verbs=True)."""
 
@@ -145,6 +148,7 @@ class TestVerbDetection:
         assert len(verb_issues) == 0
 
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestCaseDetection:
     """TC2: Non-nominative cases caught in early modules."""
 
@@ -163,6 +167,7 @@ class TestCaseDetection:
         assert len(issues) == 0
 
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestChunkExceptions:
     """TC3: Memorized chunks exempt from constraints."""
 
@@ -179,6 +184,7 @@ class TestTableExclusion:
         assert len(issues) == 0
 
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestImperativeDetection:
     """TC8: Imperative forms detected via VESUM tags."""
 
@@ -195,6 +201,7 @@ class TestImperativeDetection:
         assert len(issues) == 0
 
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestPOSMismatch:
     """TC9: Words used as wrong POS detected in no_verbs phase."""
 
@@ -204,6 +211,7 @@ class TestPOSMismatch:
         assert any("переніс" in i["text"] for i in issues)
 
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestStressMarks:
     """Stress marks (combining acute accent) handled correctly."""
 
@@ -218,6 +226,7 @@ class TestStressMarks:
         assert len(issues) == 0
 
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestAccusativeConstraint:
     """Accusative case detected in nominative-only modules."""
 
@@ -227,6 +236,7 @@ class TestAccusativeConstraint:
         assert any("accusative" in i["text"].lower() or "книгу" in i["text"] for i in issues)
 
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestPresentTenseOnly:
     """Non-present tense detected in present-only modules."""
 
@@ -243,6 +253,7 @@ class TestPresentTenseOnly:
         assert len(past_issues) == 0
 
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestAccusativeHomonyms:
     """Accusative escape hatch for verb homonyms."""
 
@@ -253,6 +264,7 @@ class TestAccusativeHomonyms:
         assert len(acc_issues) == 0
 
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestNonA1Imperatives:
     """Non-A1 tracks should not block imperatives."""
 
@@ -291,6 +303,7 @@ class TestReplacements:
 # Agreement tests
 # ---------------------------------------------------------------------------
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestAgreement:
     """Adjective-noun gender/case agreement detection."""
 
@@ -324,6 +337,7 @@ class TestAgreement:
 # Bracket stripping — phonetic transcriptions (#1053)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.usefixtures("requires_vesum_db")
 class TestBracketStripping:
     """Phonetic transcriptions in [brackets] should not be validated (#1053)."""
 

--- a/tests/test_scrape_diasporiana.py
+++ b/tests/test_scrape_diasporiana.py
@@ -110,6 +110,10 @@ def image_only_pdf(tmp_path: Path) -> Path:
     return pdf_path
 
 
+@pytest.mark.skipif(
+    shutil.which("pdfinfo") is None,
+    reason="pdfinfo not installed",
+)
 class TestDiasporianaTextLayerProbe:
     def test_text_layer_probe_extracts_cyrillic_pages(
         self,
@@ -184,6 +188,7 @@ class TestDiasporianaJsonlSchema:
     def test_chunk_schema_matches_existing_litopys_waves(
         self,
         sample_spec: sd.SourceSpec,
+        requires_literary_wave12_jsonl: Path,
     ) -> None:
         pages = [
             sd.PageText(

--- a/tests/wiki/test_t1_t2_pipeline.py
+++ b/tests/wiki/test_t1_t2_pipeline.py
@@ -34,7 +34,7 @@ CONCEPT_PATTERNS = {
 }
 
 
-def test_t1_t2_pipeline_surfaces_section_level_a1_evidence(monkeypatch):
+def test_t1_t2_pipeline_surfaces_section_level_a1_evidence(monkeypatch, requires_sources_db):
     bucket_a, bucket_b = build_query_buckets(DISCOVERY_PATH, "a1")
     assert bucket_a
     assert bucket_b


### PR DESCRIPTION
# Summary

Addresses CI residue exposed by the #5766 full-suite reboot. The change reuses the `tests/conftest.py` artifact-fixture mechanism, adding only schema validation needed to distinguish a complete `sources.db` corpus from the incomplete SQLite file CI exposed.

| File | Dependency / disposition | Evidence |
| --- | --- | --- |
| `tests/test_morphological_validator.py` | `data/vesum.db` with `forms`; conditional class-level fixture | CI: `FileNotFoundError: VESUM database not found at .../data/vesum.db` |
| `tests/test_scrape_diasporiana.py` text layer | `pdfinfo` executable; conditional `skipif` | CI: `FileNotFoundError: [Errno 2] No such file or directory: 'pdfinfo'` |
| `tests/test_scrape_diasporiana.py` JSONL schema | `data/literary_texts/wave12-krupnytsky-orlyk-biohrafiia.jsonl`; exact artifact fixture | CI: `FileNotFoundError: [Errno 2] No such file or directory: '.../wave12-krupnytsky-orlyk-biohrafiia.jsonl'` |
| `tests/wiki/test_t1_t2_pipeline.py` | complete `data/sources.db`; fixture now verifies tables required by its parallel corpus search | CI: `sqlite3.OperationalError: no such table: literary_fts` |
| `tests/build/test_linear_pipeline_wiki_packet.py` | real failure — intentionally untouched | CI reached `assert "Подача теми «Мій ранок»" in packet` |

# Verification

Artifact present (temporary links to the local VESUM DB and Wave 12 JSONL):

> `.venv/bin/python -m pytest -q tests/test_morphological_validator.py tests/test_scrape_diasporiana.py`
>
> `51 passed, 1 skipped in 0.48s`

Diasporiana with all its local dependencies available:

> `.venv/bin/python -m pytest -q -rs tests/test_scrape_diasporiana.py`
>
> `4 passed in 2.59s`

Artifact absent (empty `LEARN_UKRAINIAN_TEST_DATA_ROOT`):

> `.venv/bin/python -m pytest -q -rs tests/test_morphological_validator.py tests/wiki/test_t1_t2_pipeline.py`
>
> `26 passed, 26 skipped in 0.44s`
>
> `SKIPPED [1] tests/wiki/test_t1_t2_pipeline.py:37: requires data/sources.db (not provisioned in CI)`

Incomplete source DB (the CI-shaped condition):

> `SKIPPED [1] tests/wiki/test_t1_t2_pipeline.py:37: requires data/sources.db with SQLite tables: external_articles, external_fts, literary_fts, literary_texts, textbook_sections, textbooks, textbooks_fts, ukrainian_wiki, ukrainian_wiki_fts, wikipedia, wikipedia_fts (not provisioned in CI)`

Missing executable and corpus fixture:

> `1 passed, 3 skipped in 0.18s`
>
> `SKIPPED [1] tests/test_scrape_diasporiana.py:118: pdfinfo not installed`
>
> `SKIPPED [1] tests/test_scrape_diasporiana.py:188: requires data/literary_texts/wave12-krupnytsky-orlyk-biohrafiia.jsonl (not provisioned in CI)`

Changed-file lint:

> `.venv/bin/ruff check tests/conftest.py tests/test_morphological_validator.py tests/test_scrape_diasporiana.py tests/wiki/test_t1_t2_pipeline.py`
>
> `All checks passed!`

Full-repository lint: NOT VERIFIED clean. `.venv/bin/ruff check .` reported pre-existing unrelated violations, ending with:

> `Found 28 errors.`

Commit and OPSEC checks:

> `.venv/bin/python scripts/audit/lint_agent_trailer.py origin/claude/ci-reboot..HEAD`
>
> `✅ All 1 non-skipped commit(s) carry an X-Agent trailer.`
>
> `.venv/bin/python scripts/audit/lint_opsec_leaks.py origin/claude/ci-reboot..HEAD`
>
> `✅ OPSEC check passed. Zero leaks detected.`

The present-artifact execution of the t1/t2 assertion is NOT VERIFIED in this dispatched sparse worktree: `curriculum/` is intentionally unavailable, and I did not bypass the supplied sparse-checkout rule. Its absent and incomplete-artifact branches are verified above. Do not merge or arm auto-merge from this PR.
