### PR TITLE
fix(lexicon): keep worker memory limits out of coordinator (#5776)

### DIFF
--- a/scripts/lexicon/runner/enrich_offline_20k.py
+++ b/scripts/lexicon/runner/enrich_offline_20k.py
@@ -303,7 +303,7 @@ def _run(args: argparse.Namespace) -> int:
 
     repo = args.repo.resolve()
     _load_repo(repo)
-    from scripts.lexicon.runner.memory import MemoryPolicy, apply_worker_memory_limit
+    from scripts.lexicon.runner.memory import MemoryPolicy
     from scripts.lexicon.runner.offline_engine import enrich_offline_slice
 
     work_dir = args.work_dir.resolve()
@@ -334,15 +334,13 @@ def _run(args: argparse.Namespace) -> int:
         high_bytes=int(args.memory_high_mib) * 1024**2,
         max_bytes=int(args.memory_max_mib) * 1024**2,
     )
-    enforcement = apply_worker_memory_limit(memory_policy)
     _event(
         "memory_policy",
-        enforcement=enforcement,
+        enforcement="deferred_to_worker_child",
+        scope="worker_child",
         high_bytes=memory_policy.high_bytes,
         max_bytes=memory_policy.max_bytes,
     )
-    if args.require_memory_cap and enforcement == "none":
-        raise RuntimeError("MemoryPolicy could not enforce a hard cap")
 
     manifest_for_engine = input_path
     if args.max_lemmas is not None:

--- a/tests/test_lexicon_runner_enrich_offline_20k.py
+++ b/tests/test_lexicon_runner_enrich_offline_20k.py
@@ -152,6 +152,14 @@ def test_in_process_slice_stop_after_chunks(tmp_path: Path, monkeypatch: pytest.
         ),
     )
 
+    def _parent_memory_limit_must_not_be_applied(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("the coordinator must not apply a worker memory limit to pytest")
+
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.memory.apply_worker_memory_limit",
+        _parent_memory_limit_must_not_be_applied,
+    )
+
     def _fake_enrich(payload: dict) -> dict[str, str]:
         import hashlib
 


### PR DESCRIPTION
## Summary

The offline-enrich coordinator no longer applies a worker-only OS memory cap to its own process. The cap remains enforced by worker children and the existing startup self-test.

## Root cause evidence

`gh run view 30167163623 --job 89702047343 --log | rg -n -C 24 "MemoryError|test_in_process_slice_stop_after_chunks|FAILED"` produced:

```text
... test_in_process_slice_stop_after_chunks
Exception ignored in sys.unraisablehook: ...
MemoryError:
[gw0] [ 61%] FAILED tests/test_lexicon_runner_enrich_offline_20k.py::test_in_process_slice_stop_after_chunks
```

The failing test calls the CLI in-process. Before this change, that CLI called `apply_worker_memory_limit`, permanently constraining the pytest worker; later allocation and failure reporting could then stall.

## Verification

CWD for every command below: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/fix-hanging-tests`

`PYTHONFAULTHANDLER=1 .venv/bin/python -m pytest tests/test_lexicon_runner_enrich_offline_20k.py tests/wiki/test_ukrainian_wiki_corpus.py -p no:randomly -n 1 --timeout=120 --timeout-method=thread -vv` produced:

```text
============================== 21 passed in 1.20s ==============================
```

`PYTHONFAULTHANDLER=1 .venv/bin/python -m pytest tests/test_lexicon_runner_enrich_offline_20k.py tests/wiki/test_ukrainian_wiki_corpus.py -p no:randomly -n auto --timeout=120 --timeout-method=thread -q` produced:

```text
.....................                                                    [100%]
============================== 21 passed in 2.06s ==============================
```

`.venv/bin/ruff check scripts/lexicon/runner/enrich_offline_20k.py tests/test_lexicon_runner_enrich_offline_20k.py` produced:

```text
All checks passed!
```

`.venv/bin/python scripts/audit/lint_opsec_leaks.py` produced:

```text
✅ OPSEC check passed. Zero leaks detected.
```

NOT VERIFIED: repository-wide `.venv/bin/ruff check .` is clean. The deterministic command produced `Found 41 errors.` in pre-existing files outside this two-file diff.

NOT VERIFIED: a complete full-suite run in this sparse worktree; collection fails before execution because `curriculum/l2-uk-en/curriculum.yaml` is intentionally absent.