### PR TITLE
fix(lexicon): keep worker memory limits out of reduce/fetch coordinators

### DIFF
--- a/scripts/lexicon/runner/fetch_ulif_20k.py
+++ b/scripts/lexicon/runner/fetch_ulif_20k.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import sys
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -346,7 +347,11 @@ def _run(args: argparse.Namespace) -> int:
     repo = args.repo.resolve()
     _load_runner(repo)
     from scripts.lexicon.runner.ledger import CasStatus, Ledger
-    from scripts.lexicon.runner.memory import MemoryPolicy, apply_worker_memory_limit
+    from scripts.lexicon.runner.memory import (
+        MemoryPolicy,
+        require_hard_cap_protection,
+        run_startup_self_test,
+    )
     from scripts.lexicon.runner.network_cache import NetworkCache
     from scripts.lexicon.runner.network_worker import NetworkWorkItem
 
@@ -354,9 +359,13 @@ def _run(args: argparse.Namespace) -> int:
     work_dir.mkdir(parents=True, exist_ok=True)
     lemmas, cohort_digest = _cohort(args.cohort.resolve())
     memory_policy = MemoryPolicy(high_bytes=1536 * 1024**2, max_bytes=2048 * 1024**2)
-    enforcement = apply_worker_memory_limit(memory_policy)
-    if enforcement == "none":
-        raise RuntimeError("MemoryPolicy could not enforce a hard cap")
+    # Proof runs in a disposable child (see memory.run_startup_self_test) — this
+    # fetch loop runs single-process (no forked worker), so self-applying a hard
+    # cap here would RLIMIT/cgroup-cap whatever process drives _run(), including
+    # pytest itself when a test calls this in-process (#5776/#5786).
+    proof = run_startup_self_test(test_max_bytes=min(64 * 1024 * 1024, memory_policy.max_bytes))
+    require_hard_cap_protection(proof)
+    enforcement = proof.kind
 
     config = {
         "cohort_path": str(args.cohort.resolve()),
@@ -465,7 +474,7 @@ def _run(args: argparse.Namespace) -> int:
                 return 0
 
 
-def main() -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", type=Path, default=Path.cwd())
     parser.add_argument("--work-dir", type=Path, default=Path("/home/ops/atlas-runner/run-20k"))
@@ -475,7 +484,7 @@ def main() -> int:
         default=Path("data/lexicon/cohort-20k-20260717.txt"),
     )
     parser.add_argument("--max-lemmas", type=int, default=None)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     return _run(args)
 
 

--- a/scripts/lexicon/runner/reduce_ulif_20k.py
+++ b/scripts/lexicon/runner/reduce_ulif_20k.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import sys
 import time
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -38,7 +39,11 @@ def _event(name: str, **fields: Any) -> None:
 def _run(args: argparse.Namespace) -> int:
     repo = args.repo.resolve()
     _load_repo(repo)
-    from scripts.lexicon.runner.memory import MemoryPolicy, apply_worker_memory_limit
+    from scripts.lexicon.runner.memory import (
+        MemoryPolicy,
+        require_hard_cap_protection,
+        run_startup_self_test,
+    )
     from scripts.lexicon.runner.offline_reduce import reduce_offline_slice
 
     work_dir = args.work_dir.resolve()
@@ -48,15 +53,22 @@ def _run(args: argparse.Namespace) -> int:
         high_bytes=int(args.memory_high_mib) * 1024**2,
         max_bytes=int(args.memory_max_mib) * 1024**2,
     )
-    enforcement = apply_worker_memory_limit(memory_policy)
+    # Proof runs in a disposable child (see memory.run_startup_self_test) — the
+    # coordinator itself is never RLIMIT'd/cgroup-capped here. The reduce loop
+    # below runs in this same process (no forked worker), so self-applying a
+    # hard cap would land on whatever process drives _run() — production
+    # coordinator or, in-process, pytest itself (#5776/#5786).
+    proof = run_startup_self_test(test_max_bytes=min(64 * 1024 * 1024, memory_policy.max_bytes))
     _event(
         "memory_policy",
-        enforcement=enforcement,
+        enforcement=proof.kind,
+        enforced=proof.enforced,
+        scope="coordinator_self_test",
         high_bytes=memory_policy.high_bytes,
         max_bytes=memory_policy.max_bytes,
     )
-    if args.require_memory_cap and enforcement == "none":
-        raise RuntimeError("MemoryPolicy could not enforce a hard cap")
+    if args.require_memory_cap:
+        require_hard_cap_protection(proof)
 
     lemmas: list[str] | None = None
     expected_sha = EXPECTED_COHORT_SHA256 if not args.skip_cohort_pin else None
@@ -162,7 +174,7 @@ def _maybe_enrich(
     return 0
 
 
-def main() -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", type=Path, default=Path.cwd())
     parser.add_argument(
@@ -227,7 +239,7 @@ def main() -> int:
     )
     parser.add_argument("--enrich-chunk-size", type=int, default=25)
     parser.add_argument("--enrich-stop-after-chunks", type=int, default=None)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.network_cache is None:
         args.network_cache = args.work_dir / "network-cache.sqlite"
     if args.with_offline_enrich:

--- a/tests/test_lexicon_runner_fetch_ulif_20k.py
+++ b/tests/test_lexicon_runner_fetch_ulif_20k.py
@@ -1,0 +1,86 @@
+"""CLI driver for the ULIF 20k network fetch phase — #5230, sibling of #5786 (#5776)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON = str(ROOT / ".venv" / "bin" / "python")
+DRIVER = ROOT / "scripts" / "lexicon" / "runner" / "fetch_ulif_20k.py"
+
+
+def test_help_exits_zero_without_side_effects(tmp_path: Path) -> None:
+    work = tmp_path / "work"
+    proc = subprocess.run(
+        [PYTHON, str(DRIVER), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    help_text = (proc.stdout + proc.stderr).lower()
+    assert "usage:" in help_text
+    assert "--cohort" in help_text
+    assert not work.exists()
+
+
+def test_in_process_fetch_never_applies_worker_memory_limit_to_coordinator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#5776 sibling of #5786: the coordinator must defer memory enforcement, not self-apply.
+
+    Fails (via the raising stub below) if ``_run`` ever goes back to calling
+    ``apply_worker_memory_limit`` directly instead of the disposable-child
+    self-test — that direct call would RLIMIT/cgroup-cap whatever process
+    drives it, including pytest itself when a test drives this in-process.
+    """
+    from scripts.lexicon.runner import fetch_ulif_20k
+    from scripts.lexicon.runner.fetch_ulif_20k import main as fetch_main
+    from scripts.lexicon.runner.memory import EnforcementProof
+
+    # Real cohort pin validation is out of scope here — this fixes the
+    # in-process lemma list without exercising the (real, 20k-entry) cohort file.
+    monkeypatch.setattr(fetch_ulif_20k, "_cohort", lambda _path: (["привіт"], "test-digest"))
+    monkeypatch.setattr(
+        fetch_ulif_20k.DictUAClient,
+        "fetch_lookup",
+        lambda self, lemma: {"lemma": lemma, "status": "not_found", "responses": []},
+    )
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.memory.run_startup_self_test",
+        lambda **_kwargs: EnforcementProof(
+            kind="rlimit_as",
+            enforced=True,
+            detail="test stub",
+            max_bytes=64 * 1024 * 1024,
+        ),
+    )
+
+    def _parent_memory_limit_must_not_be_applied(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("the coordinator must not apply a worker memory limit to pytest")
+
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.memory.apply_worker_memory_limit",
+        _parent_memory_limit_must_not_be_applied,
+    )
+
+    work = tmp_path / "fetch_work"
+    code = fetch_main(
+        [
+            "--repo",
+            str(ROOT),
+            "--work-dir",
+            str(work),
+            "--cohort",
+            str(tmp_path / "unused-cohort.txt"),
+            "--max-lemmas",
+            "1",
+        ]
+    )
+    assert code == 0
+    assert (work / "ledger.sqlite").is_file()

--- a/tests/test_lexicon_runner_reduce_ulif_20k.py
+++ b/tests/test_lexicon_runner_reduce_ulif_20k.py
@@ -1,0 +1,140 @@
+"""CLI driver for offline reduce (20k ULIF path) — #5230, sibling of #5786 (#5776)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.lexicon.runner.network_cache import NetworkCache, compute_request_key
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "ulif_dictua"
+USER_AGENT = "learn-ukrainian-atlas/1.0 (noncommercial educational ULIF per-lemma fetch; issue #5230)"
+
+
+def _seed_network_cache(path: Path, lemma: str) -> None:
+    """Write one fetch-shaped raw_cache row so offline reduce has something to parse."""
+    envelope = {
+        "lemma": lemma,
+        "status": "ok",
+        "responses": [
+            {
+                "stage": "initial",
+                "status_code": 200,
+                "headers": {"content-type": "text/html"},
+                "html": (FIXTURES / "privit-paradigm.html").read_text(encoding="utf-8"),
+            }
+        ],
+    }
+    cache = NetworkCache(path, owner_id="test-reduce-driver-seed")
+    cache.open()
+    try:
+        body = (json.dumps(envelope, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+        request_body = json.dumps(
+            {"adapter": "ulif-dictua-fetch-v1", "lemma": lemma}, ensure_ascii=False, sort_keys=True
+        ).encode("utf-8")
+        headers = {"user-agent": USER_AGENT}
+        request_key = compute_request_key(
+            method="POST",
+            url="https://lcorp.ulif.org.ua/dictua/",
+            request_body=request_body,
+            response_affecting_headers=headers,
+        )
+        cache.ensure_claim_row(request_key)
+        claim = cache.claim_request(request_key, cache.owner_id)
+        assert claim.ok and claim.lease_generation is not None
+        result = cache.commit_raw(
+            request_key,
+            cache.owner_id,
+            claim.lease_generation,
+            method="POST",
+            url="https://lcorp.ulif.org.ua/dictua/",
+            request_body=request_body,
+            response_affecting_headers=headers,
+            adapter_version="ulif-dictua-fetch-v1",
+            status_code=200,
+            response_headers={"content-type": "application/json; charset=utf-8"},
+            body=body,
+            meta={"logical_request": "ulif_dictua_lookup", "lemma": lemma},
+        )
+        assert result.ok, result
+    finally:
+        cache.close()
+
+
+def test_in_process_reduce_never_applies_worker_memory_limit_to_coordinator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#5776 sibling of #5786: the coordinator must defer memory enforcement, not self-apply.
+
+    Fails (via the raising stub below) if ``_run`` ever goes back to calling
+    ``apply_worker_memory_limit`` directly instead of the disposable-child
+    self-test — that direct call would RLIMIT/cgroup-cap whatever process
+    drives it, including pytest itself when a test drives this in-process.
+    """
+    from scripts.lexicon.runner.memory import EnforcementProof
+    from scripts.lexicon.runner.reduce_ulif_20k import main as reduce_main
+
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.memory.run_startup_self_test",
+        lambda **_kwargs: EnforcementProof(
+            kind="rlimit_as",
+            enforced=True,
+            detail="test stub",
+            max_bytes=64 * 1024 * 1024,
+        ),
+    )
+
+    def _parent_memory_limit_must_not_be_applied(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("the coordinator must not apply a worker memory limit to pytest")
+
+    monkeypatch.setattr(
+        "scripts.lexicon.runner.memory.apply_worker_memory_limit",
+        _parent_memory_limit_must_not_be_applied,
+    )
+
+    network_cache = tmp_path / "network-cache.sqlite"
+    _seed_network_cache(network_cache, "привіт")
+
+    slice_file = tmp_path / "slice.txt"
+    slice_file.write_text("привіт\n", encoding="utf-8")
+
+    work = tmp_path / "reduce_work"
+    code = reduce_main(
+        [
+            "--repo",
+            str(ROOT),
+            "--work-dir",
+            str(work),
+            "--network-cache",
+            str(network_cache),
+            "--slice-file",
+            str(slice_file),
+            "--require-memory-cap",
+        ]
+    )
+    assert code == 0
+    candidate = json.loads((work / "candidate-ulif-reduce.json").read_text(encoding="utf-8"))
+    assert candidate["entries"][0]["lemma"] == "привіт"
+
+
+def test_help_exits_zero_without_side_effects(tmp_path: Path) -> None:
+    """Sanity companion: --help must not start a reduce run or write work artifacts."""
+    import subprocess
+
+    work = tmp_path / "work"
+    proc = subprocess.run(
+        [str(ROOT / ".venv" / "bin" / "python"), str(ROOT / "scripts" / "lexicon" / "runner" / "reduce_ulif_20k.py"), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    help_text = (proc.stdout + proc.stderr).lower()
+    assert "usage:" in help_text
+    assert "--require-memory-cap" in help_text
+    assert not work.exists()


### PR DESCRIPTION
## Summary

Sibling fix to #5786. That PR fixed a hang in `enrich_offline_20k.py::_run()`: the coordinator called `apply_worker_memory_limit()` on itself, so a test driving that path in-process set an RLIMIT on the pytest process and wedged it.

The same coordinator-self-mutation pattern was still live in two runners:

- `scripts/lexicon/runner/reduce_ulif_20k.py:_run()` (was line 51)
- `scripts/lexicon/runner/fetch_ulif_20k.py:_run()` (was line 357, unconditional — no `--require-memory-cap` flag gates it)

Verified via `git log -1 -p 59b6c9b99c` (quoted in dispatch context) — #5786's shape.

## Why this isn't a straight copy of #5786

Enrich's fix could simply delete the coordinator call because the real memory-heavy work happens in per-chunk **worker child processes** (`scripts/lexicon/runner/worker.py:31` still calls `apply_worker_memory_limit` for itself — a genuinely separate process). Reduce and fetch have no such child: `reduce_offline_slice` and the fetch loop both run entirely **in the calling process** (confirmed by reading `offline_reduce.py` and `fetch_ulif_20k.py` — single-process, no subprocess fork per lemma).

Deleting the call outright would have made `--require-memory-cap` (reduce) / the unconditional cap (fetch) silent no-ops — unacceptable per the dispatch brief ("a flag that no longer does anything is worse than the hang").

Fix: both coordinators now call `memory.run_startup_self_test()` (spawns a **disposable child subprocess** to prove cgroup_v2/RLIMIT_AS enforcement is available — never mutates the caller) and `memory.require_hard_cap_protection()` to fail closed when it isn't. This is the same self-test/protection pair `offline_engine.enrich_offline_slice` already uses internally (`scripts/lexicon/runner/offline_engine.py:76-78`) — so the contract is preserved via the existing pattern rather than invented new.

- `reduce_ulif_20k.py`: gated on `--require-memory-cap` (unchanged flag semantics).
- `fetch_ulif_20k.py`: unconditional, matching its pre-existing unconditional raise.

Both `main()` functions gained an `argv: Sequence[str] | None = None` parameter (matching `enrich_offline_20k.py`'s existing shape) so tests can drive them in-process.

## Test plan

- [x] New regression test per runner, same shape as #5786's: monkeypatches `scripts.lexicon.runner.memory.apply_worker_memory_limit` to raise `AssertionError`, drives the runner's `main()` in-process, asserts success. Manually verified each test **fails** against the pre-fix code (reintroduced the old call, confirmed `AssertionError: the coordinator must not apply a worker memory limit to pytest` before restoring the fix).
- [x] `.venv/bin/python -m pytest tests/test_lexicon_runner_reduce_ulif_20k.py tests/test_lexicon_runner_fetch_ulif_20k.py tests/test_lexicon_runner_enrich_offline_20k.py tests/test_lexicon_runner_offline_reduce.py -v` → 16 passed.
- [x] `.venv/bin/python -m pytest tests/test_lexicon_runner*.py -q` → 84 passed, 1 skipped (no regressions in the wider runner suite).
- [x] `.venv/bin/ruff check` on all 4 changed files → all checks passed.

NOT VERIFIED: behavior under a real Linux cgroup v2 launch (`launch_reduce.sh`'s `systemd-run --property=MemoryHigh/MemoryMax`) — this dev/CI environment is macOS, so `run_startup_self_test`'s cgroup_v2 path was never exercised for real; only the RLIMIT_AS fallback and the test's stubbed `EnforcementProof` were exercised here.

X-Agent: claude/fix-sibling-memlimit