### PR TITLE
fix(build): share durable LLM-QG store across worktrees (#5796)

### DIFF
--- a/docs/runbooks/module-quality-gates.md
+++ b/docs/runbooks/module-quality-gates.md
@@ -89,12 +89,17 @@ inside prose evidence.
 LLM-QG output is expensive and must not be lost.
 
 - Raw forensic files remain in the run archive.
-- Current queryable LLM-QG state is persisted to local SQLite at
-  `data/telemetry/llm_qg.db`.
+- Current queryable LLM-QG state is persisted to the primary checkout's
+  repository-owned SQLite store at `data/telemetry/llm_qg.db`, shared by every
+  linked worktree. Set `LEARN_UKRAINIAN_LLM_QG_DB` to use one exact alternate
+  store; an explicit missing store is a cache miss, not a fallback trigger.
 - The store is content-hash bound to `module.md`, `activities.yaml`,
   `vocabulary.yaml`, and `resources.yaml`.
-- API readers prefer the current SQLite record and fall back to module-local
-  `llm_qg.json` only when the file is newer than all learner-facing content.
+- Build and promotion resume require a current SQLite PASS record with the
+  expected gate version and prompt hash. A module-local `llm_qg.json` never
+  authorizes a gate skip.
+- Monitor readers may display a module-local `llm_qg.json` when it is newer
+  than learner-facing content, but mark it as non-authoritative observation.
 - Corrupt local telemetry DBs degrade to missing QG rather than breaking the
   Monitor API.
 - Generated QG artifacts and telemetry DBs stay out of PR diffs.

--- a/scripts/api/state_compute.py
+++ b/scripts/api/state_compute.py
@@ -245,18 +245,26 @@ def _read_json_file(path: Path) -> dict | None:
 
 
 def read_llm_qg(track_dir: Path, slug: str) -> dict | None:
-    """Read a module's LLM quality-gate artifact if present."""
+    """Read QG state for Monitor display, retaining its authority source.
+
+    A current SQLite record is authoritative.  A fresh module-local JSON file
+    is display-only observational data; build and promotion code must use the
+    SQLite lookup in ``scripts.audit.llm_qg_store`` instead.
+    """
     try:
         module_dir = safe_join(track_dir, slug)
         current = current_payload_for_module(track_dir.name, slug, module_dir)
         if current is not None:
-            return current
+            return {**current, "_qg_authoritative": True, "_qg_source": "current_db"}
         path = safe_join(module_dir, "llm_qg.json")
     except ValueError:
         return None
     if not llm_qg_file_is_current_for_module(module_dir, path):
         return None
-    return _read_json_file(path)
+    observed = _read_json_file(path)
+    if observed is None:
+        return None
+    return {**observed, "_qg_authoritative": False, "_qg_source": "file_observation"}
 
 
 def read_wiki_gate(track_dir: Path, slug: str) -> dict | None:

--- a/scripts/audit/llm_qg_store.py
+++ b/scripts/audit/llm_qg_store.py
@@ -12,11 +12,13 @@ import argparse
 import hashlib
 import json
 import os
+import random
 import sqlite3
 import subprocess
+import time
 from collections import Counter
 from collections.abc import Mapping, Sequence
-from contextlib import closing
+from contextlib import closing, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -46,6 +48,39 @@ EVIDENCE_SCHEMA_VERSION = "llm_qg_evidence.v1"
 SUPPORTED_EVIDENCE_GATE_VERSIONS = frozenset({"v7.llm_qg.1"})
 DIMENSION_ORDER = ("pedagogical", "naturalness", "decolonization", "engagement", "tone")
 TOOL_EVENT_KEYS = ("tool", "input", "status", "tool_call_id", "output")
+
+_LOCK_RETRY_ATTEMPTS = 6
+_LOCK_RETRY_BASE_S = 0.25
+_LOCK_RETRY_CAP_S = 4.0
+
+
+def _connect_sqlite_db(path: Path, *, writable: bool = False, timeout: float = 5.0) -> sqlite3.Connection:
+    conn = connect_sqlite(str(path), timeout=timeout)
+    conn.execute("PRAGMA busy_timeout = 5000")
+    if writable:
+        journal_mode = str(conn.execute("PRAGMA journal_mode = WAL").fetchone()[0]).lower()
+        if journal_mode != "wal":
+            raise RuntimeError(f"LLM-QG database did not enter WAL mode: {journal_mode}")
+    return conn
+
+
+def _run_with_lock_retry(func: Any, *args: Any, **kwargs: Any) -> Any:
+    """Execute a DB operation with bounded retry on sqlite3.OperationalError locked/busy."""
+    last_error: sqlite3.OperationalError | None = None
+    for attempt in range(_LOCK_RETRY_ATTEMPTS):
+        try:
+            return func(*args, **kwargs)
+        except sqlite3.OperationalError as error:
+            message = str(error).lower()
+            if "locked" not in message and "busy" not in message:
+                raise
+            last_error = error
+            if attempt == _LOCK_RETRY_ATTEMPTS - 1:
+                break
+            delay = min(_LOCK_RETRY_BASE_S * (2**attempt), _LOCK_RETRY_CAP_S)
+            time.sleep(delay + random.uniform(0, delay / 2))
+    if last_error is not None:
+        raise last_error
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,7 +138,12 @@ def _repository_root(checkout_root: Path | None = None) -> Path:
     is instead ``<primary>/.git`` for this repository layout and is shared by
     every linked worktree.
     """
-    checkout = (checkout_root or LIVE_REPO_ROOT).resolve()
+    checkout = checkout_root or LIVE_REPO_ROOT
+    if hasattr(checkout, "resolve"):
+        with suppress(OSError):
+            checkout = checkout.resolve()
+
+
     try:
         result = subprocess.run(
             [
@@ -114,22 +154,58 @@ def _repository_root(checkout_root: Path | None = None) -> Path:
                 "--path-format=absolute",
                 "--git-common-dir",
             ],
-            check=True,
+            check=False,
             capture_output=True,
             text=True,
+            timeout=10,
         )
-    except (OSError, subprocess.CalledProcessError) as exc:
+    except (OSError, subprocess.SubprocessError) as exc:
         raise RuntimeError(
-            f"Could not resolve the repository-owned LLM-QG store for {checkout}"
+            f"Could not resolve the repository-owned LLM-QG store for {checkout}: {exc}"
         ) from exc
 
-    common_dir = Path(result.stdout.strip()).resolve()
-    if common_dir.name != ".git":
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or "git rev-parse failed"
         raise RuntimeError(
-            "Git common directory must be the primary checkout's .git directory: "
-            f"{common_dir}"
+            f"Could not resolve the repository-owned LLM-QG store for {checkout}: {stderr}"
         )
-    return common_dir.parent
+
+    common_dir_text = result.stdout.strip()
+    if not common_dir_text:
+        raise RuntimeError(
+            f"Could not resolve the repository-owned LLM-QG store for {checkout}: git reported empty common directory"
+        )
+
+    common_dir = Path(common_dir_text)
+    if common_dir.name == ".git":
+        return common_dir.parent
+
+    try:
+        main = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(checkout),
+                "worktree",
+                "list",
+                "--porcelain",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if main.returncode == 0:
+            for line in main.stdout.splitlines():
+                if line.startswith("worktree "):
+                    return Path(line.split(" ", 1)[1])
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    raise RuntimeError(
+        f"Git common directory must be the primary checkout's .git directory: {common_dir}"
+    )
+
 
 
 def circuit_state_path(path: Path | None = None) -> Path:
@@ -204,64 +280,69 @@ def init_db(path: Path | None = None) -> Path:
     """Create the LLM-QG persistence schema if needed."""
     resolved = db_path(path)
     resolved.parent.mkdir(parents=True, exist_ok=True)
-    with closing(connect_sqlite(str(resolved))) as conn:
-        conn.executescript(
-            """
-            CREATE TABLE IF NOT EXISTS llm_qg_runs (
-                run_id          TEXT PRIMARY KEY,
-                created_at      TEXT NOT NULL,
-                level           TEXT NOT NULL,
-                slug            TEXT NOT NULL,
-                content_sha     TEXT NOT NULL,
-                gate_version    TEXT NOT NULL,
-                prompt_hash     TEXT,
-                checker_version TEXT,
-                level_policy_family TEXT,
-                reviewer_model  TEXT,
-                reviewer_family TEXT,
-                source          TEXT NOT NULL,
-                verdict         TEXT,
-                terminal_verdict TEXT,
-                min_score       REAL,
-                min_dim         TEXT,
-                payload_json    TEXT NOT NULL
-            );
-            CREATE INDEX IF NOT EXISTS idx_llm_qg_level_slug_created
-                ON llm_qg_runs(level, slug, created_at DESC);
-            CREATE INDEX IF NOT EXISTS idx_llm_qg_level_slug_content
-                ON llm_qg_runs(level, slug, content_sha, created_at DESC);
 
-            CREATE TABLE IF NOT EXISTS llm_qg_findings (
-                id              INTEGER PRIMARY KEY AUTOINCREMENT,
-                run_id          TEXT NOT NULL,
-                category        TEXT,
-                severity        TEXT,
-                file            TEXT,
-                quote           TEXT,
-                replacement     TEXT,
-                payload_json    TEXT NOT NULL,
-                FOREIGN KEY(run_id) REFERENCES llm_qg_runs(run_id)
-                    ON DELETE CASCADE
-            );
-            CREATE INDEX IF NOT EXISTS idx_llm_qg_findings_run
-                ON llm_qg_findings(run_id, id);
-            CREATE INDEX IF NOT EXISTS idx_llm_qg_findings_category
-                ON llm_qg_findings(category, severity);
-            """
-        )
-        _ensure_composite_columns(conn)
-        conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_llm_qg_composite
-                ON llm_qg_runs(
-                    level, slug, content_sha, gate_version, prompt_hash,
-                    checker_version, level_policy_family, reviewer_model,
-                    created_at DESC
-                )
-            """
-        )
-        conn.commit()
+    def _do_init() -> None:
+        with closing(_connect_sqlite_db(resolved, writable=True)) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS llm_qg_runs (
+                    run_id          TEXT PRIMARY KEY,
+                    created_at      TEXT NOT NULL,
+                    level           TEXT NOT NULL,
+                    slug            TEXT NOT NULL,
+                    content_sha     TEXT NOT NULL,
+                    gate_version    TEXT NOT NULL,
+                    prompt_hash     TEXT,
+                    checker_version TEXT,
+                    level_policy_family TEXT,
+                    reviewer_model  TEXT,
+                    reviewer_family TEXT,
+                    source          TEXT NOT NULL,
+                    verdict         TEXT,
+                    terminal_verdict TEXT,
+                    min_score       REAL,
+                    min_dim         TEXT,
+                    payload_json    TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_llm_qg_level_slug_created
+                    ON llm_qg_runs(level, slug, created_at DESC);
+                CREATE INDEX IF NOT EXISTS idx_llm_qg_level_slug_content
+                    ON llm_qg_runs(level, slug, content_sha, created_at DESC);
+
+                CREATE TABLE IF NOT EXISTS llm_qg_findings (
+                    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id          TEXT NOT NULL,
+                    category        TEXT,
+                    severity        TEXT,
+                    file            TEXT,
+                    quote           TEXT,
+                    replacement     TEXT,
+                    payload_json    TEXT NOT NULL,
+                    FOREIGN KEY(run_id) REFERENCES llm_qg_runs(run_id)
+                        ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_llm_qg_findings_run
+                    ON llm_qg_findings(run_id, id);
+                CREATE INDEX IF NOT EXISTS idx_llm_qg_findings_category
+                    ON llm_qg_findings(category, severity);
+                """
+            )
+            _ensure_composite_columns(conn)
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_llm_qg_composite
+                    ON llm_qg_runs(
+                        level, slug, content_sha, gate_version, prompt_hash,
+                        checker_version, level_policy_family, reviewer_model,
+                        created_at DESC
+                    )
+                """
+            )
+            conn.commit()
+
+    _run_with_lock_retry(_do_init)
     return resolved
+
 
 
 def live_tier2_circuit_status(path: Path | None = None) -> dict[str, Any]:
@@ -527,102 +608,106 @@ def record_llm_qg(
     )
     normalized_gate_outcomes = dict(gate_outcomes) if isinstance(gate_outcomes, Mapping) else None
 
-    with closing(connect_sqlite(str(resolved))) as conn:
-        conn.execute("PRAGMA foreign_keys = ON")
-        _ensure_composite_columns(conn)
-        conn.execute(
-            """
-            INSERT INTO llm_qg_runs (
-                run_id, created_at, level, slug, content_sha, gate_version,
-                prompt_hash, checker_version, level_policy_family,
-                reviewer_model, reviewer_family, route_name,
-                tool_call_count, tools_used_json, tool_events_json,
-                raw_response, raw_response_sha256, dispatch_json,
-                retry_history_json, gate_outcomes_json, attempt_id,
-                source, verdict, terminal_verdict,
-                min_score, min_dim, payload_json
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(run_id) DO UPDATE SET
-                created_at = excluded.created_at,
-                level = excluded.level,
-                slug = excluded.slug,
-                content_sha = excluded.content_sha,
-                gate_version = excluded.gate_version,
-                prompt_hash = excluded.prompt_hash,
-                checker_version = excluded.checker_version,
-                level_policy_family = excluded.level_policy_family,
-                reviewer_model = excluded.reviewer_model,
-                reviewer_family = excluded.reviewer_family,
-                route_name = excluded.route_name,
-                tool_call_count = excluded.tool_call_count,
-                tools_used_json = excluded.tools_used_json,
-                tool_events_json = excluded.tool_events_json,
-                raw_response = excluded.raw_response,
-                raw_response_sha256 = excluded.raw_response_sha256,
-                dispatch_json = excluded.dispatch_json,
-                retry_history_json = excluded.retry_history_json,
-                gate_outcomes_json = excluded.gate_outcomes_json,
-                attempt_id = excluded.attempt_id,
-                source = excluded.source,
-                verdict = excluded.verdict,
-                terminal_verdict = excluded.terminal_verdict,
-                min_score = excluded.min_score,
-                min_dim = excluded.min_dim,
-                payload_json = excluded.payload_json
-            """,
-            (
-                clean_run_id,
-                created_at,
-                clean_level,
-                clean_slug,
-                content_sha,
-                gate_version,
-                prompt_hash,
-                checker_version,
-                level_policy_family,
-                reviewer_model,
-                reviewer_family,
-                route_name,
-                tool_call_count_int,
-                _json_dumps(list(tools_used_tuple)),
-                _json_dumps(list(normalized_tool_events)),
-                raw_response,
-                raw_response_sha256,
-                _json_dumps(normalized_dispatch) if normalized_dispatch is not None else None,
-                _json_dumps(normalized_history) if normalized_history is not None else None,
-                _json_dumps(normalized_gate_outcomes) if normalized_gate_outcomes is not None else None,
-                attempt_id,
-                source,
-                aggregate.get("verdict"),
-                aggregate.get("terminal_verdict"),
-                aggregate.get("min_score"),
-                aggregate.get("min_dim"),
-                _json_dumps(payload),
-            ),
-        )
-        conn.execute("DELETE FROM llm_qg_findings WHERE run_id = ?", (clean_run_id,))
-        conn.executemany(
-            """
-            INSERT INTO llm_qg_findings (
-                run_id, category, severity, file, quote, replacement, payload_json
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            [
+    def _do_record() -> None:
+        with closing(_connect_sqlite_db(resolved, writable=True)) as conn:
+            conn.execute("PRAGMA foreign_keys = ON")
+            _ensure_composite_columns(conn)
+            conn.execute(
+                """
+                INSERT INTO llm_qg_runs (
+                    run_id, created_at, level, slug, content_sha, gate_version,
+                    prompt_hash, checker_version, level_policy_family,
+                    reviewer_model, reviewer_family, route_name,
+                    tool_call_count, tools_used_json, tool_events_json,
+                    raw_response, raw_response_sha256, dispatch_json,
+                    retry_history_json, gate_outcomes_json, attempt_id,
+                    source, verdict, terminal_verdict,
+                    min_score, min_dim, payload_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    created_at = excluded.created_at,
+                    level = excluded.level,
+                    slug = excluded.slug,
+                    content_sha = excluded.content_sha,
+                    gate_version = excluded.gate_version,
+                    prompt_hash = excluded.prompt_hash,
+                    checker_version = excluded.checker_version,
+                    level_policy_family = excluded.level_policy_family,
+                    reviewer_model = excluded.reviewer_model,
+                    reviewer_family = excluded.reviewer_family,
+                    route_name = excluded.route_name,
+                    tool_call_count = excluded.tool_call_count,
+                    tools_used_json = excluded.tools_used_json,
+                    tool_events_json = excluded.tool_events_json,
+                    raw_response = excluded.raw_response,
+                    raw_response_sha256 = excluded.raw_response_sha256,
+                    dispatch_json = excluded.dispatch_json,
+                    retry_history_json = excluded.retry_history_json,
+                    gate_outcomes_json = excluded.gate_outcomes_json,
+                    attempt_id = excluded.attempt_id,
+                    source = excluded.source,
+                    verdict = excluded.verdict,
+                    terminal_verdict = excluded.terminal_verdict,
+                    min_score = excluded.min_score,
+                    min_dim = excluded.min_dim,
+                    payload_json = excluded.payload_json
+                """,
                 (
                     clean_run_id,
-                    _finding_category(item),
-                    item.get("severity"),
-                    item.get("file"),
-                    item.get("quote"),
-                    item.get("replacement"),
-                    _json_dumps(item),
+                    created_at,
+                    clean_level,
+                    clean_slug,
+                    content_sha,
+                    gate_version,
+                    prompt_hash,
+                    checker_version,
+                    level_policy_family,
+                    reviewer_model,
+                    reviewer_family,
+                    route_name,
+                    tool_call_count_int,
+                    _json_dumps(list(tools_used_tuple)),
+                    _json_dumps(list(normalized_tool_events)),
+                    raw_response,
+                    raw_response_sha256,
+                    _json_dumps(normalized_dispatch) if normalized_dispatch is not None else None,
+                    _json_dumps(normalized_history) if normalized_history is not None else None,
+                    _json_dumps(normalized_gate_outcomes) if normalized_gate_outcomes is not None else None,
+                    attempt_id,
+                    source,
+                    aggregate.get("verdict"),
+                    aggregate.get("terminal_verdict"),
+                    aggregate.get("min_score"),
+                    aggregate.get("min_dim"),
+                    _json_dumps(payload),
+                ),
+            )
+            conn.execute("DELETE FROM llm_qg_findings WHERE run_id = ?", (clean_run_id,))
+            conn.executemany(
+                """
+                INSERT INTO llm_qg_findings (
+                    run_id, category, severity, file, quote, replacement, payload_json
                 )
-                for item in findings
-            ],
-        )
-        conn.commit()
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        clean_run_id,
+                        _finding_category(item),
+                        item.get("severity"),
+                        item.get("file"),
+                        item.get("quote"),
+                        item.get("replacement"),
+                        _json_dumps(item),
+                    )
+                    for item in findings
+                ],
+            )
+            conn.commit()
+
+    _run_with_lock_retry(_do_record)
+
 
     return StoredQG(
         run_id=clean_run_id,
@@ -752,41 +837,46 @@ def latest_llm_qg(
     path: Path | None = None,
 ) -> StoredQG | None:
     """Return the newest persisted QG run for a module, optionally hash-bound."""
-    resolved = db_path(path)
-    if not resolved.exists():
-        return None
-    params: list[Any] = [level.strip().lower(), slug.strip()]
-    where = "level = ? AND slug = ?"
-    for column, value in (
-        ("content_sha", content_sha),
-        ("gate_version", gate_version),
-        ("prompt_hash", prompt_hash),
-        ("checker_version", checker_version),
-        ("level_policy_family", level_policy_family),
-        ("reviewer_model", reviewer_model),
-        ("route_name", route_name),
-    ):
-        if value is not None:
-            where += f" AND {column} = ?"
-            params.append(value)
     try:
-        with closing(connect_sqlite(str(resolved))) as conn:
-            _ensure_composite_columns(conn)
-            conn.commit()
-            conn.row_factory = sqlite3.Row
-            row = conn.execute(
-                f"""
-                SELECT *
-                FROM llm_qg_runs
-                WHERE {where}
-                ORDER BY created_at DESC, run_id DESC
-                LIMIT 1
-                """,
-                params,
-            ).fetchone()
-        return _row_to_record(row) if row else None
-    except (json.JSONDecodeError, OSError, sqlite3.DatabaseError, ValueError):
+        resolved = db_path(path)
+        if not resolved.exists():
+            return None
+        params: list[Any] = [level.strip().lower(), slug.strip()]
+        where = "level = ? AND slug = ?"
+        for column, value in (
+            ("content_sha", content_sha),
+            ("gate_version", gate_version),
+            ("prompt_hash", prompt_hash),
+            ("checker_version", checker_version),
+            ("level_policy_family", level_policy_family),
+            ("reviewer_model", reviewer_model),
+            ("route_name", route_name),
+        ):
+            if value is not None:
+                where += f" AND {column} = ?"
+                params.append(value)
+
+        def _do_query() -> StoredQG | None:
+            with closing(_connect_sqlite_db(resolved, writable=False)) as conn:
+                _ensure_composite_columns(conn)
+                conn.commit()
+                conn.row_factory = sqlite3.Row
+                row = conn.execute(
+                    f"""
+                    SELECT *
+                    FROM llm_qg_runs
+                    WHERE {where}
+                    ORDER BY created_at DESC, run_id DESC
+                    LIMIT 1
+                    """,
+                    params,
+                ).fetchone()
+            return _row_to_record(row) if row else None
+
+        return _run_with_lock_retry(_do_query)
+    except (json.JSONDecodeError, OSError, sqlite3.DatabaseError, RuntimeError, ValueError):
         return None
+
 
 
 def current_llm_qg_for_module(

--- a/scripts/audit/llm_qg_store.py
+++ b/scripts/audit/llm_qg_store.py
@@ -283,8 +283,13 @@ def init_db(path: Path | None = None) -> Path:
 
     def _do_init() -> None:
         with closing(_connect_sqlite_db(resolved, writable=True)) as conn:
+            # ``executescript`` commits an already-pending transaction before it
+            # runs, so the write lock must be the first statement in the script.
+            # Keep every schema operation below, including column migrations,
+            # under this one lock.
             conn.executescript(
                 """
+                BEGIN IMMEDIATE;
                 CREATE TABLE IF NOT EXISTS llm_qg_runs (
                     run_id          TEXT PRIMARY KEY,
                     created_at      TEXT NOT NULL,
@@ -515,7 +520,11 @@ def _ensure_composite_columns(conn: sqlite3.Connection) -> None:
     }
     for name, column_type in additions.items():
         if name not in existing:
-            conn.execute(f"ALTER TABLE llm_qg_runs ADD COLUMN {name} {column_type}")
+            try:
+                conn.execute(f"ALTER TABLE llm_qg_runs ADD COLUMN {name} {column_type}")
+            except sqlite3.OperationalError as error:
+                if str(error).casefold() != f"duplicate column name: {name}".casefold():
+                    raise
 
 
 def _aggregate(payload: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/audit/llm_qg_store.py
+++ b/scripts/audit/llm_qg_store.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import os
 import sqlite3
+import subprocess
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from contextlib import closing
@@ -22,10 +23,9 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from scripts.api.config import PROJECT_ROOT
+from scripts.api.config import LIVE_REPO_ROOT, PROJECT_ROOT
 from scripts.api.resilience import connect_sqlite
 
-DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "telemetry" / "llm_qg.db"
 DB_ENV_VAR = "LEARN_UKRAINIAN_LLM_QG_DB"
 DEFAULT_CIRCUIT_STATE_PATH = PROJECT_ROOT / "data" / "telemetry" / "llm_qg_live_circuit.json"
 CIRCUIT_ENV_VAR = "LEARN_UKRAINIAN_LLM_QG_CIRCUIT"
@@ -81,10 +81,55 @@ class StoredQG:
 
 
 def db_path(path: Path | None = None) -> Path:
-    """Return the configured QG database path."""
+    """Return the configured per-repository QG database path.
+
+    The implicit store belongs to the primary checkout that owns Git's common
+    directory, not to whichever linked worktree imported this module.  An
+    explicit environment override is the only store for that process.
+    """
     if path is not None:
         return path
-    return Path(os.environ.get(DB_ENV_VAR, str(DEFAULT_DB_PATH)))
+    configured = os.environ.get(DB_ENV_VAR)
+    if configured is not None:
+        return Path(configured)
+    return _repository_root() / "data" / "telemetry" / "llm_qg.db"
+
+
+def _repository_root(checkout_root: Path | None = None) -> Path:
+    """Resolve the primary checkout for ``checkout_root``'s Git repository.
+
+    ``git rev-parse --show-toplevel`` deliberately identifies a linked
+    worktree, so it cannot define durable shared state.  Git's common directory
+    is instead ``<primary>/.git`` for this repository layout and is shared by
+    every linked worktree.
+    """
+    checkout = (checkout_root or LIVE_REPO_ROOT).resolve()
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(checkout),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError(
+            f"Could not resolve the repository-owned LLM-QG store for {checkout}"
+        ) from exc
+
+    common_dir = Path(result.stdout.strip()).resolve()
+    if common_dir.name != ".git":
+        raise RuntimeError(
+            "Git common directory must be the primary checkout's .git directory: "
+            f"{common_dir}"
+        )
+    return common_dir.parent
 
 
 def circuit_state_path(path: Path | None = None) -> Path:

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -23,7 +23,6 @@ if str(PROJECT_ROOT) not in sys.path:
 from scripts.agent_runtime.errors import AgentStalledError
 from scripts.audit.llm_qg_store import (
     current_payload_for_module,
-    llm_qg_file_is_current_for_module,
     prompt_hash_for_text,
     record_llm_qg,
 )
@@ -52,6 +51,7 @@ WRITER_ALIASES = {
 }
 WRITER_CHOICES = (*linear_pipeline.WRITER_CHOICES, *WRITER_ALIASES)
 LLM_QG_DIM_MAX_ATTEMPTS = 2
+LLM_QG_GATE_VERSION = "v7.llm_qg.1"
 
 
 @dataclass(slots=True)
@@ -1315,16 +1315,18 @@ def _persist_llm_qg_result(
     llm_qg: dict[str, Any],
     reviewer: str,
     source: str,
+    prompt_hash: str | None = None,
 ) -> None:
     defaults = linear_pipeline.REVIEWER_DEFAULTS.get(reviewer, {})
+    effective_prompt_hash = prompt_hash or _combined_llm_qg_prompt_hash(module_dir)
     try:
         record_llm_qg(
             level=level,
             slug=slug,
             module_dir=module_dir,
             payload=llm_qg,
-            gate_version="v7.llm_qg.1",
-            prompt_hash=_combined_llm_qg_prompt_hash(module_dir),
+            gate_version=LLM_QG_GATE_VERSION,
+            prompt_hash=effective_prompt_hash,
             reviewer_model=defaults.get("model"),
             reviewer_family=reviewer,
             source=source,
@@ -1336,12 +1338,50 @@ def _persist_llm_qg_result(
 
 
 def _combined_llm_qg_prompt_hash(module_dir: Path) -> str | None:
+    """Hash prompts emitted by a completed LLM-QG run for durable storage."""
     prompt_parts: list[str] = []
     for dim in QG_DIMS:
         prompt_path = module_dir / f"llm-qg-{dim}-prompt.md"
         if not prompt_path.exists():
             return None
         prompt_parts.append(f"## {dim}\n{prompt_path.read_text(encoding='utf-8')}")
+    return prompt_hash_for_text("\n\n".join(prompt_parts))
+
+
+def _expected_llm_qg_prompt_hash(
+    *,
+    plan: Mapping[str, Any],
+    plan_content: str,
+    module_dir: Path,
+    wiki_manifest: str | Mapping[str, Any] | None,
+    implementation_map: Mapping[str, Any] | None,
+    use_generator: bool,
+    obligation_checklist: Mapping[str, Any] | None,
+) -> str | None:
+    """Hash the prompts that the current module inputs would send to LLM-QG.
+
+    This computes the expected identity instead of trusting mutable prompt
+    artifacts from an earlier worktree.  If current inputs cannot produce a
+    complete prompt set, resume fails closed.
+    """
+    try:
+        generated_content = _generated_content(module_dir)
+        prompt_parts = [
+            f"## {dim}\n"
+            + linear_pipeline.render_review_prompt(
+                plan,
+                plan_content,
+                generated_content,
+                dim,
+                wiki_manifest,
+                implementation_map,
+                use_generator=use_generator,
+                obligation_checklist=obligation_checklist,
+            )
+            for dim in QG_DIMS
+        ]
+    except (KeyError, OSError, TypeError, ValueError):
+        return None
     return prompt_hash_for_text("\n\n".join(prompt_parts))
 
 
@@ -1593,10 +1633,11 @@ def main(argv: list[str] | None = None) -> int:
 
 # ----- Resume helpers ---------------------------------------------------------
 #
-# Resume policy: skip a phase iff its on-disk artifact exists AND reports the
-# canonical success shape for that phase. Any missing / failed artifact forces
-# the phase to re-run. Once one phase re-runs, every downstream phase also
-# re-runs unconditionally (the corrections may invalidate later verdicts).
+# Resume policy: skip a phase iff its artifact reports the canonical success
+# shape; LLM-QG additionally requires its authoritative, input-bound SQLite
+# record. Any missing / failed artifact forces the phase to re-run. Once one
+# phase re-runs, every downstream phase also re-runs unconditionally (the
+# corrections may invalidate later verdicts).
 #
 # Codified after the 2026-05-21 cascade burned ~14 minutes of writer time per
 # iteration on phase-6 fixes. With resume, iteration drops to ~45s for the
@@ -1609,7 +1650,12 @@ def _read_json(path: Path) -> Any:
         return None
 
 
-def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
+def _phase_artifact_passes(
+    module_dir: Path,
+    phase: str,
+    *,
+    expected_llm_qg_prompt_hash: str | None = None,
+) -> bool:
     """Return True if `phase`'s on-disk artifact exists and reports success.
 
     The on-disk shapes mirror the success conditions enforced in `_run` itself
@@ -1663,7 +1709,10 @@ def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
             and str(data.get("overall_verdict", "")).upper() == "PASS"
         )
     if phase == "llm_qg":
-        return _current_db_llm_qg_passes(module_dir)
+        return _authoritative_llm_qg_payload(
+            module_dir,
+            expected_prompt_hash=expected_llm_qg_prompt_hash,
+        ) is not None
     return False
 
 
@@ -1677,14 +1726,28 @@ def _llm_qg_payload_passes(payload: Mapping[str, Any] | None) -> bool:
     return str(terminal_verdict).upper() == "PASS"
 
 
-def _current_db_llm_qg_payload(module_dir: Path) -> dict[str, Any] | None:
+def _authoritative_llm_qg_payload(
+    module_dir: Path,
+    *,
+    expected_prompt_hash: str | None,
+) -> dict[str, Any] | None:
+    """Return a PASS record that is current for all LLM-QG gate inputs.
+
+    The SQLite store is the only resume authority.  A raw ``llm_qg.json`` is
+    presentation evidence and is never consulted here.
+    """
+    if expected_prompt_hash is None:
+        return None
     level = module_dir.parent.name
     slug = module_dir.name
-    return current_payload_for_module(level, slug, module_dir)
-
-
-def _current_db_llm_qg_passes(module_dir: Path) -> bool:
-    return _llm_qg_payload_passes(_current_db_llm_qg_payload(module_dir))
+    payload = current_payload_for_module(
+        level,
+        slug,
+        module_dir,
+        gate_version=LLM_QG_GATE_VERSION,
+        prompt_hash=expected_prompt_hash,
+    )
+    return payload if _llm_qg_payload_passes(payload) else None
 
 
 def _run_stress_annotation_for_level(module_dir: Path, level: str) -> dict[str, Any]:
@@ -2172,11 +2235,23 @@ def _run(args: argparse.Namespace) -> int:
         llm_qg_reviewer_samples = linear_pipeline.llm_qg_reviewer_samples_for_level(level)
         timeout_agent = _reviewer_for_writer(writer, llm_qg_reviewer_override)
         started_at = time.monotonic()
-        resumed_llm_qg = _current_db_llm_qg_payload(module_dir)
+        expected_llm_qg_prompt_hash = _expected_llm_qg_prompt_hash(
+            plan=plan,
+            plan_content=plan_content,
+            module_dir=module_dir,
+            wiki_manifest=wiki_manifest,
+            implementation_map=impl_map,
+            use_generator=use_generator,
+            obligation_checklist=obligation_checklist,
+        )
+        resumed_llm_qg = _authoritative_llm_qg_payload(
+            module_dir,
+            expected_prompt_hash=expected_llm_qg_prompt_hash,
+        )
         if (
             resume_enabled
             and not force_rerun
-            and _llm_qg_payload_passes(resumed_llm_qg)
+            and resumed_llm_qg is not None
         ):
             llm_qg = resumed_llm_qg
             llm_qg_source = "v7_build:resumed-db"
@@ -2204,6 +2279,15 @@ def _run(args: argparse.Namespace) -> int:
             )
             linear_pipeline.write_json(module_dir / "llm_qg.json", llm_qg)
             llm_qg_source = "v7_build"
+            expected_llm_qg_prompt_hash = _expected_llm_qg_prompt_hash(
+                plan=plan,
+                plan_content=plan_content,
+                module_dir=module_dir,
+                wiki_manifest=wiki_manifest,
+                implementation_map=impl_map,
+                use_generator=use_generator,
+                obligation_checklist=obligation_checklist,
+            )
         _persist_llm_qg_result(
             level=level,
             slug=slug,
@@ -2211,6 +2295,7 @@ def _run(args: argparse.Namespace) -> int:
             llm_qg=llm_qg,
             reviewer=_reviewer_for_writer(writer, llm_qg_reviewer_override),
             source=llm_qg_source,
+            prompt_hash=expected_llm_qg_prompt_hash,
         )
         aggregate = llm_qg["aggregate"]
         tracker.emit(

--- a/tests/audit/test_llm_qg_store.py
+++ b/tests/audit/test_llm_qg_store.py
@@ -404,3 +404,58 @@ def test_evidence_record_rejects_unknown_schema_gate_and_terminal_verdict(tmp_pa
 
     failing_terminal = {**evidence, "terminal_verdict": "FAIL"}
     assert not evidence_record_passes_for_module(failing_terminal, module_dir)
+
+
+def _concurrent_worker(args: tuple[Path, Path, int]) -> None:
+    module_dir, db_path, i = args
+    record_llm_qg(
+        level="b1",
+        slug="aspect-in-imperatives",
+        module_dir=module_dir,
+        payload=_payload(),
+        gate_version="test.v1",
+        run_id=f"run-{i}",
+        path=db_path,
+    )
+
+
+def test_concurrent_writers_shared_store(tmp_path: Path) -> None:
+    import concurrent.futures
+    module_dir = _module(tmp_path)
+    db_path = tmp_path / "shared_qg.db"
+    num_procs = 16
+
+    tasks = [(module_dir, db_path, i) for i in range(num_procs)]
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=num_procs) as executor:
+        futures = [executor.submit(_concurrent_worker, task) for task in tasks]
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
+
+def test_db_uses_wal_mode_and_busy_timeout(tmp_path: Path) -> None:
+    from scripts.audit.llm_qg_store import init_db
+
+    db_path = tmp_path / "wal_test.db"
+    init_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert str(journal_mode).lower() == "wal"
+
+
+
+
+def test_repository_root_failure_degrades_gracefully(monkeypatch) -> None:
+    from scripts.audit import llm_qg_store
+
+    monkeypatch.delenv(llm_qg_store.DB_ENV_VAR, raising=False)
+
+    def mock_repo_root(*args: object, **kwargs: object) -> Path:
+        raise RuntimeError("git execution failed: mock failure")
+
+    monkeypatch.setattr(llm_qg_store, "_repository_root", mock_repo_root)
+
+    # Should degrade to returning None instead of propagating RuntimeError
+    assert llm_qg_store.latest_llm_qg("b1", "aspect-in-imperatives", path=None) is None
+
+

--- a/tests/audit/test_llm_qg_store.py
+++ b/tests/audit/test_llm_qg_store.py
@@ -432,6 +432,9 @@ def test_concurrent_writers_shared_store(tmp_path: Path) -> None:
         for future in concurrent.futures.as_completed(futures):
             future.result()
 
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT count(*) FROM llm_qg_runs").fetchone()[0] == num_procs
+
 def test_db_uses_wal_mode_and_busy_timeout(tmp_path: Path) -> None:
     from scripts.audit.llm_qg_store import init_db
 
@@ -457,5 +460,4 @@ def test_repository_root_failure_degrades_gracefully(monkeypatch) -> None:
 
     # Should degrade to returning None instead of propagating RuntimeError
     assert llm_qg_store.latest_llm_qg("b1", "aspect-in-imperatives", path=None) is None
-
 

--- a/tests/build/test_v7_build_resume.py
+++ b/tests/build/test_v7_build_resume.py
@@ -13,14 +13,15 @@ single source of truth that downstream resume logic depends on.
 from __future__ import annotations
 
 import json
-import os
-import time
+import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from scripts.build import v7_build
+from scripts.audit import llm_qg_store
+from scripts.audit.llm_qg_store import CONTENT_FILES, DB_ENV_VAR, db_path, record_llm_qg
+from scripts.build import linear_pipeline, v7_build
 
 
 @pytest.fixture()
@@ -30,6 +31,56 @@ def module_dir(tmp_path: Path) -> Path:
 
 def _write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _qg_pass_payload() -> dict[str, Any]:
+    return {
+        "aggregate": {
+            "verdict": "PASS",
+            "terminal_verdict": "PASS",
+            "min_score": 9.0,
+            "min_dim": "naturalness",
+        },
+        "dimensions": {},
+    }
+
+
+def _write_module_content(module_dir: Path) -> None:
+    module_dir.mkdir(parents=True, exist_ok=True)
+    contents = {
+        "module.md": "# Тестовий модуль\n\nТекст для перевірки.\n",
+        "activities.yaml": "[]\n",
+        "vocabulary.yaml": "[]\n",
+        "resources.yaml": "[]\n",
+    }
+    for name, content in contents.items():
+        (module_dir / name).write_text(content, encoding="utf-8")
+
+
+def _write_resumable_artifacts(module_dir: Path) -> None:
+    (module_dir / "knowledge_packet.md").write_text("knowledge packet\n", encoding="utf-8")
+    _write_json(module_dir / "wiki_manifest.json", {})
+    for artifact in linear_pipeline.WRITER_ARTIFACTS:
+        path = module_dir / artifact
+        if not path.exists():
+            path.write_text(f"{artifact}\n", encoding="utf-8")
+    (module_dir / "writer_output.raw.md").write_text("writer output\n", encoding="utf-8")
+    _write_json(module_dir / "implementation_map.json", {"entries": []})
+    _write_json(module_dir / "stress_annotation.json", {"passed": True})
+    _write_json(module_dir / "ulp_fidelity_gate.json", {"passed": True})
+    _write_json(module_dir / "python_qg.json", {"gates": {"passed": True}})
+    _write_json(module_dir / "wiki_completeness_gate.json", {"verdict": "PASS"})
+    _write_json(module_dir / "wiki_coverage_gate.json", {"passed": True})
+    _write_json(module_dir / "wiki_coverage_review.json", {"overall_verdict": "PASS", "verdicts": []})
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 # ----- knowledge_packet -------------------------------------------------------
@@ -165,109 +216,222 @@ def test_wiki_coverage_review_reruns_when_overall_fail(module_dir: Path) -> None
 
 
 # ----- llm_qg ------------------------------------------------------------------
-#
-# QUARANTINED — these three encode a contract that DIRECTLY CONTRADICTS
-# tests/test_v7_build_reviewer_assert.py::test_llm_qg_phase_artifact_requires_current_db_record.
-# Both cannot hold at once:
-#
-#   * here: a fresh on-disk llm_qg.json MAY stand in for a DB record, so a resumed
-#     build in a freshly dispatched worktree (which has no gitignored llm_qg.db) does
-#     not re-run paid LLM quality-gate calls;
-#   * there: a fresh llm_qg.json must NOT count as a pass without a current DB record,
-#     so a stale or hand-written file cannot make a build skip its LLM quality gate.
-#
-# They coexisted undetected because CI selected tests by changed files and never ran
-# both. #5766 made the suite run unconditionally and the contradiction surfaced
-# immediately. PR #5784 restored the fallback and satisfied these three while silently
-# breaking the gate-integrity test; that production change has been reverted here,
-# because weakening a quality gate is not a call to make in passing.
-#
-# Which contract wins is a DESIGN decision (gate integrity vs. resume cost) and is
-# handed to the advisor seat — see the issue referenced in the marker below.
-# strict=True on purpose: if someone makes these pass, this file FAILS until the
-# contradiction is resolved deliberately rather than drifting back.
 
-_LLM_QG_CONTRACT_CONFLICT = pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "contradicts test_llm_qg_phase_artifact_requires_current_db_record: a fresh "
-        "llm_qg.json may not substitute for a current DB record. Design decision pending "
-        "(gate integrity vs. resume cost) — see #5796."
-    ),
-)
-
-
-@_LLM_QG_CONTRACT_CONFLICT
-def test_llm_qg_skipped_when_terminal_verdict_pass(module_dir: Path) -> None:
-    _write_json(
-        module_dir / "llm_qg.json",
+def test_llm_qg_payload_terminal_verdict_pass_wins_over_warning_aggregate() -> None:
+    """Payload shape is compatible; a DB record remains required to resume."""
+    assert v7_build._llm_qg_payload_passes(
         {
             "aggregate": {
                 "verdict": "REJECT",
                 "terminal_verdict": "PASS",
                 "min_score": 4.0,
             }
-        },
+        }
     )
-    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is True
 
 
-def test_llm_qg_reruns_when_terminal_verdict_revise(module_dir: Path) -> None:
-    _write_json(
-        module_dir / "llm_qg.json",
+def test_llm_qg_payload_rejects_terminal_revise() -> None:
+    assert not v7_build._llm_qg_payload_passes(
         {
             "aggregate": {
                 "verdict": "REVISE",
                 "terminal_verdict": "REVISE",
                 "min_score": 8.5,
             }
-        },
+        }
     )
-    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is False
 
 
-@_LLM_QG_CONTRACT_CONFLICT
-def test_llm_qg_skipped_for_legacy_aggregate_pass(module_dir: Path) -> None:
-    _write_json(
-        module_dir / "llm_qg.json",
-        {"aggregate": {"verdict": "PASS", "min_score": 9.0}},
+def test_llm_qg_payload_supports_legacy_aggregate_pass() -> None:
+    """Legacy payload compatibility does not change the DB authority rule."""
+    assert v7_build._llm_qg_payload_passes({"aggregate": {"verdict": "PASS", "min_score": 9.0}})
+
+
+def test_llm_qg_payload_rejects_missing_aggregate() -> None:
+    assert not v7_build._llm_qg_payload_passes({"placeholder": True})
+
+
+@pytest.mark.parametrize("changed_name", CONTENT_FILES)
+def test_llm_qg_authority_rejects_each_changed_content_file(
+    tmp_path: Path,
+    changed_name: str,
+) -> None:
+    module = tmp_path / "b1" / "target"
+    _write_module_content(module)
+    expected_prompt_hash = "expected-prompt-hash"
+    record_llm_qg(
+        level="b1",
+        slug="target",
+        module_dir=module,
+        payload=_qg_pass_payload(),
+        gate_version=v7_build.LLM_QG_GATE_VERSION,
+        prompt_hash=expected_prompt_hash,
     )
-    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is True
 
-
-def test_llm_qg_reruns_when_aggregate_missing(module_dir: Path) -> None:
-    _write_json(module_dir / "llm_qg.json", {"placeholder": True})
-    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is False
-
-
-@_LLM_QG_CONTRACT_CONFLICT
-def test_llm_qg_skipped_when_db_empty_but_json_file_is_fresh(module_dir: Path) -> None:
-    """A freshly dispatched worktree has no local llm_qg.db (gitignored).
-
-    Resume must fall back to a module-local llm_qg.json when it is not older
-    than the module's learner-facing content, mirroring
-    scripts.api.state_compute.read_llm_qg (docs/runbooks/module-quality-gates.md
-    Persistence).
-    """
-    (module_dir / "module.md").write_text("# Fixture\n", encoding="utf-8")
-    time.sleep(0.01)
-    _write_json(
-        module_dir / "llm_qg.json",
-        {"aggregate": {"verdict": "PASS", "terminal_verdict": "PASS", "min_score": 9.0}},
+    assert v7_build._phase_artifact_passes(
+        module,
+        "llm_qg",
+        expected_llm_qg_prompt_hash=expected_prompt_hash,
     )
-    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is True
-
-
-def test_llm_qg_reruns_when_json_file_is_stale_relative_to_content(module_dir: Path) -> None:
-    """A pass artifact older than the current module content must not be trusted."""
-    _write_json(
-        module_dir / "llm_qg.json",
-        {"aggregate": {"verdict": "PASS", "terminal_verdict": "PASS", "min_score": 9.0}},
+    (module / changed_name).write_text("changed\n", encoding="utf-8")
+    assert not v7_build._phase_artifact_passes(
+        module,
+        "llm_qg",
+        expected_llm_qg_prompt_hash=expected_prompt_hash,
     )
-    stale_mtime = time.time() - 3600
-    os.utime(module_dir / "llm_qg.json", (stale_mtime, stale_mtime))
-    (module_dir / "module.md").write_text("# Fixture, revised\n", encoding="utf-8")
-    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is False
+
+
+def test_llm_qg_authority_rejects_wrong_gate_or_prompt_hash(tmp_path: Path) -> None:
+    module = tmp_path / "b1" / "target"
+    _write_module_content(module)
+    record_llm_qg(
+        level="b1",
+        slug="target",
+        module_dir=module,
+        payload=_qg_pass_payload(),
+        gate_version="v7.llm_qg.old",
+        prompt_hash="expected-prompt-hash",
+    )
+    assert not v7_build._phase_artifact_passes(
+        module,
+        "llm_qg",
+        expected_llm_qg_prompt_hash="expected-prompt-hash",
+    )
+
+    record_llm_qg(
+        level="b1",
+        slug="target",
+        module_dir=module,
+        payload=_qg_pass_payload(),
+        gate_version=v7_build.LLM_QG_GATE_VERSION,
+        prompt_hash="wrong-prompt-hash",
+    )
+    assert not v7_build._phase_artifact_passes(
+        module,
+        "llm_qg",
+        expected_llm_qg_prompt_hash="expected-prompt-hash",
+    )
+
+
+def test_llm_qg_authority_fails_closed_without_expected_prompt_hash(tmp_path: Path) -> None:
+    module = tmp_path / "b1" / "target"
+    _write_module_content(module)
+    record_llm_qg(
+        level="b1",
+        slug="target",
+        module_dir=module,
+        payload=_qg_pass_payload(),
+        gate_version=v7_build.LLM_QG_GATE_VERSION,
+        prompt_hash="expected-prompt-hash",
+    )
+
+    assert not v7_build._phase_artifact_passes(module, "llm_qg")
+
+def test_llm_qg_resumes_from_shared_store_in_linked_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    _git(primary, "init")
+    _git(primary, "config", "user.email", "test@example.invalid")
+    _git(primary, "config", "user.name", "LLM QG test")
+    (primary / "README.md").write_text("fixture\n", encoding="utf-8")
+    _git(primary, "add", "README.md")
+    _git(primary, "commit", "-m", "fixture")
+    linked = tmp_path / "linked"
+    _git(primary, "worktree", "add", "--detach", str(linked), "HEAD")
+
+    monkeypatch.delenv(DB_ENV_VAR)
+    monkeypatch.setattr(llm_qg_store, "LIVE_REPO_ROOT", primary)
+    shared_db = db_path()
+    monkeypatch.setattr(llm_qg_store, "LIVE_REPO_ROOT", linked)
+    assert db_path() == shared_db
+    assert shared_db == primary / "data" / "telemetry" / "llm_qg.db"
+
+    plan = {"level": "b1", "slug": "target", "sequence": 1}
+    plan_content = "level: b1\nslug: target\n"
+    module_a = primary / "curriculum" / "l2-uk-en" / "b1" / "target"
+    module_b = linked / "curriculum" / "l2-uk-en" / "b1" / "target"
+    _write_module_content(module_a)
+    _write_module_content(module_b)
+    _write_resumable_artifacts(module_a)
+    _write_resumable_artifacts(module_b)
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "render_review_prompt",
+        lambda *_args, **_kwargs: f"prompt::{_args[3]}",
+    )
+    monkeypatch.setattr(v7_build, "read_implementation_map", lambda _path: {"entries": []})
+    expected_prompt_hash = v7_build._expected_llm_qg_prompt_hash(
+        plan=plan,
+        plan_content=plan_content,
+        module_dir=module_a,
+        wiki_manifest={},
+        implementation_map={"entries": []},
+        use_generator=False,
+        obligation_checklist=None,
+    )
+    assert expected_prompt_hash is not None
+    record_llm_qg(
+        level="b1",
+        slug="target",
+        module_dir=module_a,
+        payload=_qg_pass_payload(),
+        gate_version=v7_build.LLM_QG_GATE_VERSION,
+        prompt_hash=expected_prompt_hash,
+    )
+
+    assert shared_db.exists()
+    assert not (linked / "data" / "telemetry" / "llm_qg.db").exists()
+    assert not (module_b / "llm_qg.json").exists()
+    assert v7_build._phase_artifact_passes(
+        module_b,
+        "llm_qg",
+        expected_llm_qg_prompt_hash=expected_prompt_hash,
+    )
+
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(plan_content, encoding="utf-8")
+    monkeypatch.setattr(v7_build.linear_pipeline, "plan_path_for", lambda *_args: plan_path)
+    monkeypatch.setattr(v7_build.linear_pipeline, "load_plan", lambda _path: plan)
+    monkeypatch.setattr(v7_build.linear_pipeline, "validate_plan", lambda _plan: None)
+    monkeypatch.setattr(v7_build.linear_pipeline, "curriculum_profile_for_level", lambda _level: "core")
+    monkeypatch.setattr(v7_build.linear_pipeline, "assemble_mdx", lambda *_args: None)
+
+    def paid_reviewer_must_not_run(**_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("paid LLM-QG reviewer ran despite a shared current record")
+
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "run_llm_qg_with_corrections",
+        paid_reviewer_must_not_run,
+    )
+    args = v7_build.parse_args(["b1", "target", "--out", str(module_b)])
+    assert v7_build._run(args) == 0
+    assert not (module_b / "llm_qg.json").exists()
+
+    explicit_db = tmp_path / "explicit" / "llm_qg.db"
+    monkeypatch.setenv(DB_ENV_VAR, str(explicit_db))
+    assert db_path() == explicit_db
+    assert not v7_build._phase_artifact_passes(
+        module_b,
+        "llm_qg",
+        expected_llm_qg_prompt_hash=expected_prompt_hash,
+    )
+    record_llm_qg(
+        level="b1",
+        slug="target",
+        module_dir=module_b,
+        payload=_qg_pass_payload(),
+        gate_version=v7_build.LLM_QG_GATE_VERSION,
+        prompt_hash=expected_prompt_hash,
+    )
+    assert v7_build._phase_artifact_passes(
+        module_b,
+        "llm_qg",
+        expected_llm_qg_prompt_hash=expected_prompt_hash,
+    )
 
 
 # ----- unknown phase ----------------------------------------------------------

--- a/tests/test_api_state_scores.py
+++ b/tests/test_api_state_scores.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 import scripts.api.main as api_main
+import scripts.api.state_compute as state_compute
 import scripts.api.state_router as state_router
 from scripts.api.state_router import _read_llm_qg_scores
 from scripts.audit.llm_qg_store import DB_ENV_VAR, record_llm_qg
@@ -64,6 +65,24 @@ def test_read_scores_parses_dims_and_aggregate(tmp_path: Path) -> None:
 def test_read_scores_missing_file_degrades(tmp_path: Path) -> None:
     out = _read_llm_qg_scores(tmp_path / "does-not-exist")
     assert out == {"aggregate": None, "dimensions": {}}
+
+
+def test_read_llm_qg_marks_file_fallback_as_non_authoritative(tmp_path: Path) -> None:
+    track_dir = tmp_path / "b1"
+    module_dir = track_dir / "display-only"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Тест\n\nТекст.\n", encoding="utf-8")
+    _write_llm_qg(
+        module_dir,
+        dims={"naturalness": 8.0},
+        aggregate={"verdict": "PASS", "terminal_verdict": "PASS"},
+    )
+
+    observed = state_compute.read_llm_qg(track_dir, "display-only")
+
+    assert observed is not None
+    assert observed["_qg_source"] == "file_observation"
+    assert observed["_qg_authoritative"] is False
 
 
 def test_read_scores_malformed_json_degrades(tmp_path: Path) -> None:

--- a/tests/test_v7_build_reviewer_assert.py
+++ b/tests/test_v7_build_reviewer_assert.py
@@ -61,6 +61,9 @@ def test_llm_qg_phase_artifact_requires_current_db_record(
     (module_dir / "llm_qg.json").write_text(
         json.dumps(
             {
+                "content_sha": "self-asserted-content-hash",
+                "gate_version": v7_build.LLM_QG_GATE_VERSION,
+                "prompt_hash": "self-asserted-prompt-hash",
                 "aggregate": {
                     "verdict": "PASS",
                     "terminal_verdict": "PASS",
@@ -72,18 +75,84 @@ def test_llm_qg_phase_artifact_requires_current_db_record(
         ),
         encoding="utf-8",
     )
+    _set_mtime_ns(module_dir / "llm_qg.json", 2_000_000_000_000_000_000)
+    expected_prompt_hash = "current-computed-prompt-hash"
 
-    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is False
+    assert not db_path.exists()
+    assert not v7_build._phase_artifact_passes(
+        module_dir,
+        "llm_qg",
+        expected_llm_qg_prompt_hash=expected_prompt_hash,
+    )
 
     record_llm_qg(
         level="b1",
         slug="target",
         module_dir=module_dir,
         payload=json.loads((module_dir / "llm_qg.json").read_text(encoding="utf-8")),
-        gate_version="test.v1",
+        gate_version=v7_build.LLM_QG_GATE_VERSION,
+        prompt_hash=expected_prompt_hash,
     )
 
-    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is True
+    assert v7_build._phase_artifact_passes(
+        module_dir,
+        "llm_qg",
+        expected_llm_qg_prompt_hash=expected_prompt_hash,
+    )
+
+
+def test_llm_qg_phase_artifact_rejects_future_file_when_db_is_corrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "corrupt-llm-qg.db"
+    monkeypatch.setenv("LEARN_UKRAINIAN_LLM_QG_DB", str(db_path))
+    db_path.write_text("not a SQLite database", encoding="utf-8")
+    module_dir = tmp_path / "b1" / "target"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Тест\n\nТекст.\n", encoding="utf-8")
+    (module_dir / "llm_qg.json").write_text(
+        json.dumps(
+            {
+                "content_sha": "self-asserted-content-hash",
+                "gate_version": v7_build.LLM_QG_GATE_VERSION,
+                "prompt_hash": "self-asserted-prompt-hash",
+                "aggregate": {"verdict": "PASS", "terminal_verdict": "PASS"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    _set_mtime_ns(module_dir / "llm_qg.json", 2_000_000_000_000_000_000)
+
+    assert not v7_build._phase_artifact_passes(
+        module_dir,
+        "llm_qg",
+        expected_llm_qg_prompt_hash="current-computed-prompt-hash",
+    )
+
+
+def test_llm_qg_persistence_failure_is_a_build_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "b1" / "target"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Тест\n", encoding="utf-8")
+
+    def fail_persistence(**_kwargs) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(v7_build, "record_llm_qg", fail_persistence)
+    with pytest.raises(linear_pipeline.LinearPipelineError, match="result persistence failed"):
+        v7_build._persist_llm_qg_result(
+            level="b1",
+            slug="target",
+            module_dir=module_dir,
+            llm_qg={"aggregate": {"verdict": "PASS", "terminal_verdict": "PASS"}},
+            reviewer="codex-tools",
+            source="test",
+            prompt_hash="current-computed-prompt-hash",
+        )
 
 
 def test_seminar_llm_qg_routes_away_from_gemini_reviewer():


### PR DESCRIPTION
Fixes #5796.

## Verification

Command (cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/impl-5796-shared-store):

    .venv/bin/python -m pytest tests/build/ tests/test_v7_build_reviewer_assert.py tests/audit/test_llm_qg_store.py -q

Raw output:

    ======================= 455 passed, 1 skipped in 36.35s ========================

Command (same cwd):

    .venv/bin/ruff check scripts/audit/llm_qg_store.py scripts/build/v7_build.py scripts/api/state_compute.py tests/build/test_v7_build_resume.py tests/test_v7_build_reviewer_assert.py tests/audit/test_llm_qg_store.py tests/test_api_state_scores.py

Raw output:

    All checks passed!

Command (same cwd):

    .venv/bin/ruff check .

Raw output:

    Found 28 errors.
    No fixes available (15 hidden fixes can be enabled with the `--unsafe-fixes` option).

NOT VERIFIED: repository-wide Ruff is not clean; its reported paths are untouched legacy files under `docs/reports/` and `plans/`.