### PR TITLE
fix(ci): green main — repair Ohoiko intake and Atlas freshness

### DIFF
--- a/scripts/lexicon/ohoiko_atlas_intake.py
+++ b/scripts/lexicon/ohoiko_atlas_intake.py
@@ -244,6 +244,20 @@ def build_ohoiko_intake(
     units = discover_source_units(private_root=private_root, june_notes_root=june_notes_root)
     occurrences = collect_ohoiko_occurrences(units, private_root=private_root, june_notes_root=june_notes_root)
     forms = tuple(sorted({occurrence.form for occurrence in occurrences}, key=core.stable_lemma_sort_key))
+    if not forms:
+        # With no source forms, no candidate can be filtered against the Atlas,
+        # source-decision ledger, or committed inventories. Avoid hydrating and
+        # parsing those unrelated data sets so an unavailable private corpus is
+        # a fast, deterministic empty intake.
+        return core.AtlasIntakeResult(
+            workflow=WORKFLOW_ID,
+            source_family=SOURCE_FAMILY,
+            source_units=tuple(_public_source_unit(unit) for unit in units),
+            token_occurrences=0,
+            unique_forms=0,
+            candidates=(),
+            inventory_path=inventory_path,
+        )
     resolutions = core.resolve_forms(forms, vesum_lookup=vesum_lookup)
     atlas_keys = manifest_lemma_keys if manifest_lemma_keys is not None else core.load_atlas_lemma_keys()
     ledger_keys = (

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "17667fd093d04365da2f0f715df44a98709be2c97cb3e9b3e74bed6568bd6856",
+  "fingerprint": "74b91f3cdf5d3d172921e821d58de283a68594e9ca621293b2c06a8aeadb379a",
   "inputs": {
     "lexicon_code": [
       {
@@ -43,6 +43,10 @@
         "sha256": "f0b9b17fd194700272ca88c93050f38fea1c680e82845181d69146fd673df78c"
       },
       {
+        "path": "scripts/lexicon/build_teacher_deck_cloze.py",
+        "sha256": "ce05f8fbef73722ebaefd91033e7cf037f29bbfb21b7309ac0c3a2d551f878cd"
+      },
+      {
         "path": "scripts/lexicon/calque_corrections.py",
         "sha256": "d1af3c47b47916c90f7e9fa6fa1e2a9e29283ffda14e430415a97848f91556c5"
       },
@@ -76,7 +80,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "b2fe216f34b00f35bdb85edfe9c68beee875405d148b2b8378cbf36272856ed5"
+        "sha256": "0307b5c171f3ad3585666100c1055769013f2db18888f7a2ac36a63b78cf6f6f"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -120,7 +124,7 @@
       },
       {
         "path": "scripts/lexicon/heritage_classifier.py",
-        "sha256": "fde3fb8e0fc380719aa1e11763f584b85e2b0ee0a48f45bc09bca0cdab2392ac"
+        "sha256": "c820ae8560296ab6d1e02c0fa2deca159c001633e91062b2e48e13a971ff1a47"
       },
       {
         "path": "scripts/lexicon/lemma_normalization.py",
@@ -160,7 +164,7 @@
       },
       {
         "path": "scripts/lexicon/ohoiko_atlas_intake.py",
-        "sha256": "d87fafc2b0d0e8e23c6d40c98b1320e79cfe439079ff393787af4eff02e84528"
+        "sha256": "98081166a4df2a694d1a686ebbf89553761646a36824dcd89ae5618ab04f29ba"
       },
       {
         "path": "scripts/lexicon/park_thin_entries.py",
@@ -169,6 +173,10 @@
       {
         "path": "scripts/lexicon/promote_grow_candidates.py",
         "sha256": "197d9a8c4791be86899a6b35357e97732bb58657222bc01e50598c92a2f6c5cf"
+      },
+      {
+        "path": "scripts/lexicon/promote_teacher_lesson_intake.py",
+        "sha256": "99eb174d108a18087bc6a895bb81e35de11078dcfc6e899b1c512edd7977a306"
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
@@ -200,7 +208,7 @@
       },
       {
         "path": "scripts/lexicon/verify_manifest.py",
-        "sha256": "47df54386fda97fb7b372e8e68f89afb3ac5bd647c5a292a7380f14c5ae1f4b0"
+        "sha256": "de72b894b26028f2f19d8b8cd34d0c29d3c7f9b48f826e55182af1efd82615e8"
       },
       {
         "path": "scripts/lexicon/verify_synonym_pairs.py",
@@ -211,6 +219,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 51
+    "lexicon_code_files": 53
   }
 }

--- a/tests/test_ohoiko_atlas_intake.py
+++ b/tests/test_ohoiko_atlas_intake.py
@@ -398,10 +398,18 @@ def test_heritage_rejection_and_uncertainty_are_fail_closed() -> None:
 def test_main_with_absent_private_root_exits_zero_with_empty_outputs(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     missing_private = tmp_path / "nonexistent-private"
     inventory_out = tmp_path / "inventory.json"
     report_out = tmp_path / "report.json"
+
+    def fail_if_loaded(*_: object, **__: object) -> None:
+        pytest.fail("an empty intake must not load unrelated Atlas or source-ledger data")
+
+    monkeypatch.setattr(core, "load_atlas_lemma_keys", fail_if_loaded)
+    monkeypatch.setattr(core, "load_existing_ledger_keys", fail_if_loaded)
+    monkeypatch.setattr(core, "load_committed_inventory_keys", fail_if_loaded)
 
     exit_code = intake.main(
         [

--- a/tests/test_ohoiko_source_inventory_scope.py
+++ b/tests/test_ohoiko_source_inventory_scope.py
@@ -9,6 +9,8 @@ import yaml
 from scripts.audit import source_inventory_review_decisions as decisions
 from scripts.audit.source_inventory_intake import read_source_inventory
 
+SAFE_YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 ABETKA_DIR = PROJECT_ROOT / "curriculum/l2-uk-direct/a1"
 OHOIKO_INVENTORY = PROJECT_ROOT / "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml"
@@ -52,7 +54,7 @@ def test_ohoiko_abetka_inventory_has_review_decisions_for_all_rows() -> None:
     )
     approved_rows: Counter[tuple[str, str]] = Counter()
     for path in sorted(DECISION_DIR.glob("*.yaml")):
-        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        payload = yaml.load(path.read_text(encoding="utf-8"), Loader=SAFE_YAML_LOADER)
         for row in payload.get("decisions", []):
             source_inventory = row.get("source_inventory", {})
             if (


### PR DESCRIPTION
## Summary

- Return an empty Ohoiko intake before loading the Atlas, review ledger, or committed inventories when the private corpus yields no forms.
- Parse the 41 MB committed decision inventory with PyYAML's safe C loader in the scope test.
- Refresh the committed Atlas fingerprint sidecar.

## Root cause

The two reported pytest nodes did not fail their assertions: their xdist workers crashed after the 120-second timeout while parsing data unrelated to their stated assertions. The empty-corpus path unnecessarily loaded the whole decision ledger, and the scope test used PyYAML's pure-Python safe loader over every committed decision file.

The Contracts job reported a stale fingerprint sidecar: committed `17667fd...` versus current `4534b65...`.

## Validation

- `.venv/bin/python -m pytest tests/test_ohoiko_atlas_intake.py tests/test_ohoiko_source_inventory_scope.py -q` — 17 passed
- Same focused suite with `-n 2` — 17 passed
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py` — freshness OK
- `.venv/bin/ruff check ...` — all checks passed
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py` — zero leaks

Refs #5766