### PR TITLE
fix(delegate): surface empty write dispatches

### DIFF
--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -95,7 +95,7 @@ You are a senior lead developer maintaining the Ukrainian curriculum system. You
 1. Watch: `Monitor` a settle-loop on the task's `batch_state/tasks/<id>.json` `status`. Terminal
    vocab (match `scripts/delegate.py`): **`done` = SUCCESS (NOT "completed")**; other settle states
    `failed|timeout|rate_limited|cancelled|crashed|dry_run` (`dry_run` is terminal, not success)
-   plus the persisted attention status `needs_finalize`; emit on any status NOT in
+   plus the persisted attention statuses `needs_finalize|no_deliverable`; emit on any status NOT in
    {spawning,running,""} — a loop waiting for "completed" silently times out on a finished
    task (burned 2026-07-15). `/api/delegate/active` intermittently omits live tasks (#5207); the
    task file is truth. Never keyword-grep logs as a completion signal; never ScheduleWakeup-poll

--- a/agents_extensions/shared/agents/curriculum-track-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-track-orchestrator.md
@@ -92,7 +92,7 @@ initialPrompt: |
     result file on terminal. **Match the runtime's terminal vocab (`scripts/delegate.py`) — `done`
     (the SUCCESS state, NOT "completed"); other settle states
     `failed|timeout|rate_limited|cancelled|crashed|dry_run` (`dry_run` is terminal, not success)
-    plus the persisted attention status `needs_finalize`; emit on any status NOT in
+    plus the persisted attention statuses `needs_finalize|no_deliverable`; emit on any status NOT in
     {spawning,running,""}** (a dispatch persists `spawning` before it forks
     the worker — treating it as terminal would retry/clean up a live task) — a loop that waits for
     "completed" silently times out on

--- a/agents_extensions/shared/agents/infra-orchestrator.md
+++ b/agents_extensions/shared/agents/infra-orchestrator.md
@@ -177,7 +177,7 @@ is for CROSS-session continuity, not an in-session rot guard. But:
 - **Watch: `Monitor` a settle-loop on the task's `batch_state/tasks/<id>.json` `status`** → read the
   result file on terminal. Terminal vocab (match `scripts/delegate.py`): **`done` = SUCCESS (NOT
   "completed")**; other settle states `failed|timeout|rate_limited|cancelled|crashed|dry_run`
-  (`dry_run` is terminal, not success) plus the persisted attention status `needs_finalize`; emit
+  (`dry_run` is terminal, not success) plus the persisted attention statuses `needs_finalize|no_deliverable`; emit
   on any status NOT in {spawning,running,""} — `spawning` persists before the worker forks, so it
   is not terminal. A loop waiting for "completed" silently times out on a finished task (burned
   2026-07-15). Never keyword-grep logs as a completion signal; never ScheduleWakeup-poll what

--- a/agents_extensions/shared/rules/critical-rules.md
+++ b/agents_extensions/shared/rules/critical-rules.md
@@ -85,10 +85,13 @@ own mode plus whether its worktree is dirty — not a judgement about intent.
 - **`needs_finalize`** — work was produced but not committed or pushed. This is a **failure to finish**,
   and it is now detected mechanically for every write-capable mode (`delegate.py`); a dirty worktree with
   no commits can no longer report `done`.
-- **`no_deliverable`** — a clean write-capable dispatch did not provide verifiable delivery evidence.
-  It is distinct from `needs_finalize`: do not re-enter its worktree expecting uncommitted edits. Resolve
-  the failed task or re-dispatch it. A structured final `DELIVERABLE:` declaration may establish either a
-  committed change or a reasoned no-op; free-form narration and an unstructured commit do not.
+- **`no_deliverable`** — a clean write-capable dispatch produced nothing verifiable: zero commits on
+  its branch, a clean worktree, and only a trivial response that cannot itself be the deliverable.
+  Detection is inferred from observable git facts, not from any formatting contract — commits on the
+  dispatch branch are sufficient proof on their own. A structured final `DELIVERABLE:` line is an
+  **optional** positive signal (a reasoned `no_change` proves a legitimate no-op); its absence never
+  fails a dispatch. `no_deliverable` is distinct from `needs_finalize`: do not re-enter its worktree
+  expecting uncommitted edits. Resolve the failed task or re-dispatch it.
 - **`BLOCKED` / `NEEDS-INPUT`** — genuinely cannot proceed. Reporting this is correct behaviour, not a
   failure of nerve.
 

--- a/agents_extensions/shared/rules/critical-rules.md
+++ b/agents_extensions/shared/rules/critical-rules.md
@@ -80,11 +80,15 @@ legitimately complete with no PR: reviews, audits, research, diagnosis, and any 
 `--mode read-only`. For those, the deliverable *is* the report. The mechanical test is the dispatch's
 own mode plus whether its worktree is dirty — not a judgement about intent.
 
-**Three distinct terminal outcomes; do not collapse them into `done`:**
+**Four distinct terminal outcomes; do not collapse them into `done`:**
 - **`done`** — the deliverable exists (a pushed PR for change tasks, a report for read-only tasks).
 - **`needs_finalize`** — work was produced but not committed or pushed. This is a **failure to finish**,
   and it is now detected mechanically for every write-capable mode (`delegate.py`); a dirty worktree with
   no commits can no longer report `done`.
+- **`no_deliverable`** — a clean write-capable dispatch did not provide verifiable delivery evidence.
+  It is distinct from `needs_finalize`: do not re-enter its worktree expecting uncommitted edits. Resolve
+  the failed task or re-dispatch it. A structured final `DELIVERABLE:` declaration may establish either a
+  committed change or a reasoned no-op; free-form narration and an unstructured commit do not.
 - **`BLOCKED` / `NEEDS-INPUT`** — genuinely cannot proceed. Reporting this is correct behaviour, not a
   failure of nerve.
 

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -119,7 +119,7 @@ be missed between routing and worker launch. Read and apply every `unread` or
 Watch the task's `batch_state/tasks/<id>.json` `status` with the **Monitor** tool.
 Terminal vocab (match `scripts/delegate.py`): **`done` = SUCCESS** (NOT "completed");
 other terminal/attention states: `failed | timeout | rate_limited | cancelled |
-crashed | dry_run` (dry_run is terminal, not success) + `needs_finalize`. Emit on any
+crashed | dry_run` (dry_run is terminal, not success) + `needs_finalize | no_deliverable`. Emit on any
 status NOT in `{spawning, running, ""}`. The task file is truth; `/api/delegate/active`
 can omit live tasks. **Before declaring a dispatch dead:** `gh pr list --state open`
 first, then check the worktree for finished-but-unpushed work.

--- a/scripts/api/delegate_router.py
+++ b/scripts/api/delegate_router.py
@@ -149,7 +149,10 @@ def _delegate_task_rows(statuses: set[str] | None = None) -> list[dict[str, Any]
 
 def list_delegate_tasks(
     *,
-    status: Literal["running", "done", "failed", "timeout", "spawning", "all"] = "all",
+    status: Literal[
+        "running", "done", "failed", "timeout", "spawning",
+        "needs_finalize", "no_deliverable", "all",
+    ] = "all",
     limit: int = 50,
 ) -> dict[str, Any]:
     task_limit = min(max(1, int(limit)), 500)
@@ -195,7 +198,10 @@ def active_delegate_tasks() -> dict[str, Any]:
 
 @router.get("/tasks")
 async def delegate_tasks(
-    status: Literal["running", "done", "failed", "timeout", "spawning", "all"] = Query("all"),
+    status: Literal[
+        "running", "done", "failed", "timeout", "spawning",
+        "needs_finalize", "no_deliverable", "all",
+    ] = Query("all"),
     limit: int = Query(50, ge=1, le=500),
 ):
     return await asyncio.to_thread(list_delegate_tasks, status=status, limit=limit)

--- a/scripts/api/lane_health.py
+++ b/scripts/api/lane_health.py
@@ -43,7 +43,8 @@ def is_spawn_phase_failure(record: dict[str, Any], duration_threshold_s: int = D
     duration_s = record.get("duration_s")
 
     is_failed_status = status in ("failed", "error")
-    # Treat clean exits (returncode == 0) and needs_finalize as healthy signals.
+    # ``needs_finalize`` and ``no_deliverable`` are completion-contract failures,
+    # not provider spawn failures. Keep them out of lane availability scoring.
     # If returncode is None, the process is still running or hasn't updated its returncode yet.
     is_non_zero_rc = returncode is not None and returncode != 0
     is_short_duration = duration_s is not None and duration_s < duration_threshold_s

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -19,9 +19,8 @@ except ModuleNotFoundError:
         sys.path.insert(0, str(_SCRIPTS_DIR))
     from batch_gemini_config import FLASH_MODEL, PRO_MODEL
 
-# A response below this size cannot by itself demonstrate a write-capable
-# dispatch delivered work. It is only used alongside a clean worktree and zero
-# commits to surface the task for human finalization; tune from observed runs.
+# A short unstructured response is useful diagnostic context for a failed
+# delivery declaration, never proof that a write-capable dispatch delivered work.
 DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX = 300
 
 # =============================================================================

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -19,8 +19,11 @@ except ModuleNotFoundError:
         sys.path.insert(0, str(_SCRIPTS_DIR))
     from batch_gemini_config import FLASH_MODEL, PRO_MODEL
 
-# A short unstructured response is useful diagnostic context for a failed
-# delivery declaration, never proof that a write-capable dispatch delivered work.
+# A response at or below this size cannot itself be the deliverable of a
+# write-capable dispatch. It is only used alongside a clean worktree and zero
+# own-branch commits (and no optional DELIVERABLE declaration) to flag the run
+# as no_deliverable; a substantive response — analysis, a no-op conclusion —
+# is accepted as the deliverable. Tune from observed runs.
 DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX = 300
 
 # =============================================================================

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -19,6 +19,11 @@ except ModuleNotFoundError:
         sys.path.insert(0, str(_SCRIPTS_DIR))
     from batch_gemini_config import FLASH_MODEL, PRO_MODEL
 
+# A response below this size cannot by itself demonstrate a write-capable
+# dispatch delivered work. It is only used alongside a clean worktree and zero
+# commits to surface the task for human finalization; tune from observed runs.
+DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX = 300
+
 # =============================================================================
 # TRACK CONFIGURATION
 # =============================================================================

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -237,6 +237,7 @@ def _core_terminal_fields(
     commits_ahead: int | None,
     needs_finalize: bool,
     finalize_error: str | None,
+    last_error: str | None,
 ) -> dict[str, Any]:
     """The complete set of fields that define a finished dispatch's outcome.
 
@@ -257,7 +258,7 @@ def _core_terminal_fields(
         "stderr_excerpt": stderr_excerpt,
         "returncode": returncode,
         "returncode_reason": returncode_reason,
-        "last_error": _first_error_line(stderr_excerpt) if status != "done" else None,
+        "last_error": last_error if status != "done" else None,
         "exit_code": returncode,
         "worktree_dirty_on_exit": dirty_on_exit,
         "commits_ahead": commits_ahead,
@@ -2937,6 +2938,7 @@ def _run_worker(
             commits_ahead=commits_ahead,
             needs_finalize=needs_finalize,
             finalize_error=finalize_error,
+            last_error=last_error,
         )
         _write_state_atomic(state_path, {**final_state, **core_terminal_state})
     except BaseException as interrupt_exc:
@@ -2991,6 +2993,14 @@ def _run_worker(
                         needs_finalize=interrupted_needs_finalize,
                         finalize_error=(
                             f"interrupted during finalize: {type(interrupt_exc).__name__}"
+                        ),
+                        last_error=(
+                            no_deliverable_reason
+                            or (
+                                _first_error_line(stderr_excerpt)
+                                if interrupted_status != "done"
+                                else None
+                            )
                         ),
                     ),
                 },
@@ -4015,6 +4025,7 @@ _TERMINAL_STATUSES = frozenset(
         # may already have recycled. Every other terminal vocabulary in this
         # file already includes it (see _BRANCH_HOLDER_RELEASABLE_STATUSES).
         "needs_finalize",
+        _NO_DELIVERABLE_STATUS,
     },
 )
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -661,14 +661,15 @@ def _classify_worktree_layout(path: Path | str | None) -> str | None:
 _WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
 _NO_DELIVERABLE_STATUS = "no_deliverable"
 _NO_DELIVERABLE_UNKNOWN_COMMIT_COUNT_REASON = "commit_count_unknown"
-_NO_DELIVERABLE_MISSING_DECLARATION_REASON = "missing_delivery_declaration"
-_NO_DELIVERABLE_MISSING_DECLARATION_SHORT_RESPONSE_REASON = (
-    "missing_delivery_declaration_short_response"
+_NO_DELIVERABLE_SHORT_RESPONSE_REASON = (
+    "write_capable_clean_worktree_zero_commits_short_response"
 )
 _NO_DELIVERABLE_INVALID_DECLARATION_REASON = "invalid_delivery_declaration"
-_NO_DELIVERABLE_COMMIT_DIFF_UNKNOWN_REASON = "commit_diff_unknown"
-_NO_DELIVERABLE_COMMIT_DIFF_MISMATCH_REASON = "commit_diff_mismatch"
 _DELIVERY_DECLARATION_PREFIX = "DELIVERABLE:"
+# A declaration is an optional positive signal, so tolerate a few closing
+# lines after it — but do not scan the whole report, or a quoted example of
+# the format would masquerade as the worker's own declaration.
+_DELIVERY_DECLARATION_SCAN_LINES = 5
 _DELIVERY_OUTCOMES = frozenset({"change", "no_change"})
 
 _WRITE_WORKTREE_HINT = (
@@ -680,24 +681,29 @@ _WRITE_WORKTREE_HINT = (
 
 
 def _parse_delivery_declaration(response: str) -> dict[str, Any] | None:
-    """Return one strict structured outcome declaration from a worker response.
+    """Return a structured outcome declaration from a worker response, if any.
 
-    Write-capable work cannot use narration or a commit count alone as delivery
-    proof. The worker must end its response with one machine-readable line:
+    The declaration is an OPTIONAL positive signal: its presence can prove
+    delivery, but its absence never implies failure (git evidence decides
+    first). A worker may close with one machine-readable line:
 
     ``DELIVERABLE: {"outcome":"change",...}`` or
     ``DELIVERABLE: {"outcome":"no_change","reason":"..."}``.
 
-    Requiring the final non-empty line prevents a report from accidentally
-    embedding an example declaration and makes the result-file evidence easy
-    for operators to inspect. This validates structure only; git state supplies
-    the corresponding durable evidence for a declared change/no-change.
+    Only the last few non-empty lines are scanned, so a polite closing line
+    after the declaration does not void it while a mid-report example of the
+    format is not mistaken for the worker's own declaration.
     """
     lines = [line.strip() for line in response.splitlines() if line.strip()]
-    if not lines:
-        return None
-    line = lines[-1]
-    if not line.startswith(_DELIVERY_DECLARATION_PREFIX):
+    line = next(
+        (
+            candidate
+            for candidate in reversed(lines[-_DELIVERY_DECLARATION_SCAN_LINES:])
+            if candidate.startswith(_DELIVERY_DECLARATION_PREFIX)
+        ),
+        None,
+    )
+    if line is None:
         return None
     try:
         declaration = json.loads(line.removeprefix(_DELIVERY_DECLARATION_PREFIX).strip())
@@ -736,48 +742,38 @@ def _parse_delivery_declaration(response: str) -> dict[str, Any] | None:
     }
 
 
-def _committed_paths_ahead(worktree: Path, base_ref: str) -> tuple[str, ...] | None:
-    """Return changed paths in the own-branch range, or None if git cannot prove it."""
-    proc = subprocess.run(
-        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
-        cwd=worktree,
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
-    )
-    if proc.returncode != 0:
-        return None
-    return tuple(sorted({path for path in proc.stdout.splitlines() if path}))
-
-
-def _delivery_declaration_failure_reason(
+def _delivery_failure_reason(
     response: str,
     declaration: dict[str, Any] | None,
     *,
     commits_ahead: int | None,
-    dirty_on_exit: bool | None,
-    committed_paths: tuple[str, ...] | None,
 ) -> str | None:
-    """Return why a clean write outcome lacks verifiable delivery evidence."""
+    """Return why a write-capable run lacks delivery evidence, or None.
+
+    Delivery is inferred from observable facts the runner already has —
+    own-branch commits and response size — never from a formatting contract
+    imposed on every worker's final message:
+
+    - commits on the dispatch branch prove delivery on their own;
+    - an unknown commit count proves nothing, so it fails closed;
+    - a reasoned ``no_change`` declaration proves a legitimate no-op, while a
+      ``change`` claim against a zero-commit branch contradicts the git
+      evidence and is flagged;
+    - with zero commits and no declaration, only a trivially short response
+      (nothing that could BE the deliverable) is flagged; a substantive
+      response — an analysis, an investigation conclusion — is accepted.
+    """
     if commits_ahead is None:
         return _NO_DELIVERABLE_UNKNOWN_COMMIT_COUNT_REASON
-    if declaration is None:
-        if len(response) <= DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX:
-            return _NO_DELIVERABLE_MISSING_DECLARATION_SHORT_RESPONSE_REASON
-        return _NO_DELIVERABLE_MISSING_DECLARATION_REASON
-    if dirty_on_exit is not False:
-        return _NO_DELIVERABLE_INVALID_DECLARATION_REASON
-    outcome = declaration["outcome"]
-    if outcome == "no_change" and commits_ahead == 0:
+    if commits_ahead > 0:
         return None
-    if outcome == "change" and commits_ahead > 0:
-        if committed_paths is None:
-            return _NO_DELIVERABLE_COMMIT_DIFF_UNKNOWN_REASON
-        if committed_paths and tuple(declaration["changed_paths"]) == committed_paths:
+    if declaration is not None:
+        if declaration["outcome"] == "no_change":
             return None
-        return _NO_DELIVERABLE_COMMIT_DIFF_MISMATCH_REASON
-    return _NO_DELIVERABLE_INVALID_DECLARATION_REASON
+        return _NO_DELIVERABLE_INVALID_DECLARATION_REASON
+    if len(response) <= DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX:
+        return _NO_DELIVERABLE_SHORT_RESPONSE_REASON
+    return None
 
 
 def _load_worktree_containment():
@@ -2291,11 +2287,12 @@ def _augment_prompt_with_worktree(
     delivery_note = ""
     if mode in _WRITE_CAPABLE_MODES:
         delivery_note = (
-            "\n[delivery declaration required]\n"
-            "For a write-capable dispatch, end your final response with exactly one machine-readable "
-            "line. For a committed change: `DELIVERABLE: {\"outcome\":\"change\",\"summary\":\"what changed\",\"changed_paths\":[\"path/to/file\"]}`. "
-            "For a verified no-op: `DELIVERABLE: {\"outcome\":\"no_change\",\"reason\":\"why no changes are required\"}`. "
-            "A commit count or free-form narration alone does not prove delivery.\n"
+            "\n[optional delivery signal]\n"
+            "Commits on your dispatch branch are sufficient proof of delivery on their own. "
+            "If you finish with zero commits (a verified no-op), you MAY end your final response "
+            "with one machine-readable line as positive proof: "
+            '`DELIVERABLE: {"outcome":"no_change","reason":"why no changes are required"}`. '
+            "This line is optional — its absence never fails the dispatch.\n"
         )
     return (
         "[delegate worktree]\n"
@@ -2675,7 +2672,6 @@ def _run_worker(
     no_deliverable = False
     no_deliverable_reason: str | None = None
     delivery_declaration: dict[str, Any] | None = None
-    committed_paths: tuple[str, ...] | None = None
     auto_finalize: AutoFinalizeResult | None = None
     telemetry_settled = False
 
@@ -2881,10 +2877,37 @@ def _run_worker(
         # onto a dispatch already shown to be clean and committed.
         telemetry_settled = True
 
+        # A write-capable dispatch that settled ``done`` must have SOME
+        # verifiable deliverable. The signal is inferred from observable
+        # facts — own-branch commits, worktree state, response size — never
+        # from a formatting contract on the worker's final message, so a
+        # worker needs no magic phrase to count as successful. A structured
+        # ``DELIVERABLE:`` line is honoured as an optional positive signal.
+        # Read-only tasks are excluded: their deliverable may be analysis or
+        # an external side effect such as a posted review comment.
+        if (
+            mode in _WRITE_CAPABLE_MODES
+            and final_status == "done"
+            and returncode == 0
+            and not needs_finalize
+        ):
+            delivery_declaration = _parse_delivery_declaration(response)
+            no_deliverable_reason = _delivery_failure_reason(
+                response,
+                delivery_declaration,
+                commits_ahead=commits_ahead,
+            )
+            no_deliverable = no_deliverable_reason is not None
+
         if needs_finalize:
             final_status = "needs_finalize"
+        elif no_deliverable:
+            final_status = _NO_DELIVERABLE_STATUS
+            ok_outcome = False
 
         last_error = _first_error_line(stderr_excerpt) if final_status != "done" else None
+        if no_deliverable_reason is not None:
+            last_error = no_deliverable_reason
 
         # CHECKPOINT: persist the COMPLETE core outcome before any best-effort work.
         #
@@ -2974,45 +2997,6 @@ def _run_worker(
             )
         raise
 
-        # A write-capable task must supply machine-checkable final-outcome
-        # evidence. Response length is retained only to explain a thin response;
-        # it never makes narration a deliverable. Read-only tasks are excluded:
-        # their deliverable may be analysis or an external side effect such as a
-        # posted review comment.
-        if (
-            final_status == "done"
-            and returncode == 0
-            and not needs_finalize
-        ):
-            if auto_finalize and auto_finalize.ok:
-                # The runtime itself committed/pushed this previously dirty tree
-                # and returned its exact path inventory, so this is stronger
-                # evidence than a worker's final-text declaration.
-                committed_paths = tuple(sorted(auto_finalize.changed_files))
-                delivery_declaration = {
-                    "outcome": "change",
-                    "summary": "runtime auto-finalized the dirty worktree",
-                    "changed_paths": list(committed_paths),
-                }
-            else:
-                delivery_declaration = _parse_delivery_declaration(response)
-                if delivery_declaration and delivery_declaration["outcome"] == "change" and commits_ahead:
-                    committed_paths = _committed_paths_ahead(Path(worktree_path), base_ref)
-                no_deliverable_reason = _delivery_declaration_failure_reason(
-                    response,
-                    delivery_declaration,
-                    commits_ahead=commits_ahead,
-                    dirty_on_exit=dirty_on_exit,
-                    committed_paths=committed_paths,
-                )
-                no_deliverable = no_deliverable_reason is not None
-
-    if needs_finalize:
-        final_status = "needs_finalize"
-    elif no_deliverable:
-        final_status = _NO_DELIVERABLE_STATUS
-        ok_outcome = False
-
     last_error = _first_error_line(stderr_excerpt) if final_status != "done" else None
     if no_deliverable_reason is not None:
         last_error = no_deliverable_reason
@@ -3052,7 +3036,6 @@ def _run_worker(
             "substitution": substitution,
             "no_deliverable_reason": no_deliverable_reason,
             "delivery_declaration": delivery_declaration,
-            "committed_paths": committed_paths,
             "keep_worktree": keep_worktree,
             "worktree_reap": worktree_reap,
             "tmp_bytes_freed": (

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -121,6 +121,7 @@ if str(_local_repo_root) not in sys.path:
 
 from scripts.common.repo_root import main_checkout_root as _main_checkout_root
 from scripts.common.repo_root import resolve_repo_root
+from scripts.config import DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX
 
 _REPO_ROOT = resolve_repo_root(Path(__file__), 1)
 _TASKS_DIR = _REPO_ROOT / "batch_state" / "tasks"
@@ -657,6 +658,7 @@ def _classify_worktree_layout(path: Path | str | None) -> str | None:
 # preflight and creating a worktree from the primary checkout stay allowed.
 
 _WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
+_NO_DELIVERABLE_REASON = "write_capable_clean_worktree_zero_commits_short_response"
 
 _WRITE_WORKTREE_HINT = (
     "Write-capable dispatch must run inside a dispatch worktree, never the "
@@ -2538,6 +2540,7 @@ def _run_worker(
     commits_ahead: int | None = None
     needs_finalize = False
     finalize_error: str | None = None
+    no_deliverable_reason: str | None = None
     auto_finalize: AutoFinalizeResult | None = None
     telemetry_settled = False
 
@@ -2836,6 +2839,25 @@ def _run_worker(
             )
         raise
 
+        # A clean, zero-commit write-capable dispatch that only returned a tiny
+        # response has no durable deliverable to inspect. Preserve the existing
+        # attention mechanism instead of misclassifying the terminal process exit
+        # as sufficient evidence of completed work. Read-only tasks are excluded:
+        # their deliverable may be analysis or an external side effect such as a
+        # posted review comment.
+        if (
+            final_status == "done"
+            and returncode == 0
+            and commits_ahead == 0
+            and dirty_on_exit is False
+            and len(response) <= DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX
+        ):
+            needs_finalize = True
+            no_deliverable_reason = _NO_DELIVERABLE_REASON
+
+    if needs_finalize:
+        final_status = "needs_finalize"
+
     if last_error:
         # Task logs capture this worker's stderr, while agent_runtime captures
         # the CLI child's stderr internally. Re-emit the excerpt so an
@@ -2870,6 +2892,7 @@ def _run_worker(
             "effort": getattr(result, "effort", final_state.get("effort")),
             "cli_version": getattr(result, "cli_version", final_state.get("cli_version")),
             "substitution": substitution,
+            "no_deliverable_reason": no_deliverable_reason,
             "keep_worktree": keep_worktree,
             "worktree_reap": worktree_reap,
             "tmp_bytes_freed": (

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -40,7 +40,8 @@ State files live at ``batch_state/tasks/<task-id>.json``. Format:
         "cli_version": str,
         "mode": str,
         "pid": int,
-        "status": "running" | "done" | "failed" | "timeout" | "rate_limited" | "crashed",
+        "status": "running" | "done" | "failed" | "timeout" | "rate_limited" | "crashed"
+                  | "needs_finalize" | "no_deliverable",
         "started_at": iso-8601 UTC,
         "finished_at": iso-8601 UTC | null,
         "duration_s": float | null,
@@ -658,7 +659,17 @@ def _classify_worktree_layout(path: Path | str | None) -> str | None:
 # preflight and creating a worktree from the primary checkout stay allowed.
 
 _WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
-_NO_DELIVERABLE_REASON = "write_capable_clean_worktree_zero_commits_short_response"
+_NO_DELIVERABLE_STATUS = "no_deliverable"
+_NO_DELIVERABLE_UNKNOWN_COMMIT_COUNT_REASON = "commit_count_unknown"
+_NO_DELIVERABLE_MISSING_DECLARATION_REASON = "missing_delivery_declaration"
+_NO_DELIVERABLE_MISSING_DECLARATION_SHORT_RESPONSE_REASON = (
+    "missing_delivery_declaration_short_response"
+)
+_NO_DELIVERABLE_INVALID_DECLARATION_REASON = "invalid_delivery_declaration"
+_NO_DELIVERABLE_COMMIT_DIFF_UNKNOWN_REASON = "commit_diff_unknown"
+_NO_DELIVERABLE_COMMIT_DIFF_MISMATCH_REASON = "commit_diff_mismatch"
+_DELIVERY_DECLARATION_PREFIX = "DELIVERABLE:"
+_DELIVERY_OUTCOMES = frozenset({"change", "no_change"})
 
 _WRITE_WORKTREE_HINT = (
     "Write-capable dispatch must run inside a dispatch worktree, never the "
@@ -666,6 +677,107 @@ _WRITE_WORKTREE_HINT = (
     ".worktrees/dispatch/<agent>/<task>/. Alternatively point `--cwd` at an "
     "existing added worktree there."
 )
+
+
+def _parse_delivery_declaration(response: str) -> dict[str, Any] | None:
+    """Return one strict structured outcome declaration from a worker response.
+
+    Write-capable work cannot use narration or a commit count alone as delivery
+    proof. The worker must end its response with one machine-readable line:
+
+    ``DELIVERABLE: {"outcome":"change",...}`` or
+    ``DELIVERABLE: {"outcome":"no_change","reason":"..."}``.
+
+    Requiring the final non-empty line prevents a report from accidentally
+    embedding an example declaration and makes the result-file evidence easy
+    for operators to inspect. This validates structure only; git state supplies
+    the corresponding durable evidence for a declared change/no-change.
+    """
+    lines = [line.strip() for line in response.splitlines() if line.strip()]
+    if not lines:
+        return None
+    line = lines[-1]
+    if not line.startswith(_DELIVERY_DECLARATION_PREFIX):
+        return None
+    try:
+        declaration = json.loads(line.removeprefix(_DELIVERY_DECLARATION_PREFIX).strip())
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(declaration, dict):
+        return None
+    outcome = declaration.get("outcome")
+    if outcome not in _DELIVERY_OUTCOMES:
+        return None
+    if outcome == "no_change":
+        reason = declaration.get("reason")
+        if not isinstance(reason, str) or not reason.strip():
+            return None
+        return {"outcome": outcome, "reason": reason.strip()}
+    summary = declaration.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        return None
+    changed_paths = declaration.get("changed_paths")
+    if (
+        not isinstance(changed_paths, list)
+        or not changed_paths
+        or any(
+            not isinstance(path, str)
+            or not path
+            or Path(path).is_absolute()
+            or ".." in Path(path).parts
+            for path in changed_paths
+        )
+    ):
+        return None
+    return {
+        "outcome": outcome,
+        "summary": summary.strip(),
+        "changed_paths": sorted(set(changed_paths)),
+    }
+
+
+def _committed_paths_ahead(worktree: Path, base_ref: str) -> tuple[str, ...] | None:
+    """Return changed paths in the own-branch range, or None if git cannot prove it."""
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    return tuple(sorted({path for path in proc.stdout.splitlines() if path}))
+
+
+def _delivery_declaration_failure_reason(
+    response: str,
+    declaration: dict[str, Any] | None,
+    *,
+    commits_ahead: int | None,
+    dirty_on_exit: bool | None,
+    committed_paths: tuple[str, ...] | None,
+) -> str | None:
+    """Return why a clean write outcome lacks verifiable delivery evidence."""
+    if commits_ahead is None:
+        return _NO_DELIVERABLE_UNKNOWN_COMMIT_COUNT_REASON
+    if declaration is None:
+        if len(response) <= DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX:
+            return _NO_DELIVERABLE_MISSING_DECLARATION_SHORT_RESPONSE_REASON
+        return _NO_DELIVERABLE_MISSING_DECLARATION_REASON
+    if dirty_on_exit is not False:
+        return _NO_DELIVERABLE_INVALID_DECLARATION_REASON
+    outcome = declaration["outcome"]
+    if outcome == "no_change" and commits_ahead == 0:
+        return None
+    if outcome == "change" and commits_ahead > 0:
+        if committed_paths is None:
+            return _NO_DELIVERABLE_COMMIT_DIFF_UNKNOWN_REASON
+        if committed_paths and tuple(declaration["changed_paths"]) == committed_paths:
+            return None
+        return _NO_DELIVERABLE_COMMIT_DIFF_MISMATCH_REASON
+    return _NO_DELIVERABLE_INVALID_DECLARATION_REASON
 
 
 def _load_worktree_containment():
@@ -1155,7 +1267,17 @@ def _worktree_matches_origin_branch(path: Path, branch: str) -> bool:
 # mounted. Includes failure modes — a crashed review worktree should not
 # permanently pin a PR branch for follow-up dispatches (#5340).
 _BRANCH_HOLDER_RELEASABLE_STATUSES = frozenset(
-    {"done", "failed", "timeout", "rate_limited", "crashed", "cancelled", "dry_run", "needs_finalize"}
+    {
+        "done",
+        "failed",
+        "timeout",
+        "rate_limited",
+        "crashed",
+        "cancelled",
+        "dry_run",
+        "needs_finalize",
+        _NO_DELIVERABLE_STATUS,
+    }
 )
 
 
@@ -2150,6 +2272,7 @@ def _augment_prompt_with_worktree(
     prompt: str,
     worktree_path: Path | None,
     *,
+    mode: str = "read-only",
     sparse_telemetry: dict[str, Any] | None = None,
 ) -> str:
     """Inject worktree context into the delegated prompt when relevant."""
@@ -2165,6 +2288,15 @@ def _augment_prompt_with_worktree(
                 + ". If you need them, re-dispatch with --sparse-include <dir> "
                 "or --full-checkout (do not invent content for missing paths).\n"
             )
+    delivery_note = ""
+    if mode in _WRITE_CAPABLE_MODES:
+        delivery_note = (
+            "\n[delivery declaration required]\n"
+            "For a write-capable dispatch, end your final response with exactly one machine-readable "
+            "line. For a committed change: `DELIVERABLE: {\"outcome\":\"change\",\"summary\":\"what changed\",\"changed_paths\":[\"path/to/file\"]}`. "
+            "For a verified no-op: `DELIVERABLE: {\"outcome\":\"no_change\",\"reason\":\"why no changes are required\"}`. "
+            "A commit count or free-form narration alone does not prove delivery.\n"
+        )
     return (
         "[delegate worktree]\n"
         f"Run all file edits, tests, and git commands inside this worktree: {worktree_path}\n"
@@ -2176,7 +2308,7 @@ def _augment_prompt_with_worktree(
         "`origin` here points at the canonical GitHub remote and fetch works from any "
         "linked worktree. NEVER use the primary checkout as a source of freshness "
         "(no `git -C <primary> pull/fetch/checkout`); it is the human's interactive home.\n"
-        f"{sparse_note}\n"
+        f"{sparse_note}{delivery_note}\n"
         f"{prompt}"
     )
 
@@ -2540,7 +2672,10 @@ def _run_worker(
     commits_ahead: int | None = None
     needs_finalize = False
     finalize_error: str | None = None
+    no_deliverable = False
     no_deliverable_reason: str | None = None
+    delivery_declaration: dict[str, Any] | None = None
+    committed_paths: tuple[str, ...] | None = None
     auto_finalize: AutoFinalizeResult | None = None
     telemetry_settled = False
 
@@ -2839,25 +2974,48 @@ def _run_worker(
             )
         raise
 
-        # A clean, zero-commit write-capable dispatch that only returned a tiny
-        # response has no durable deliverable to inspect. Preserve the existing
-        # attention mechanism instead of misclassifying the terminal process exit
-        # as sufficient evidence of completed work. Read-only tasks are excluded:
+        # A write-capable task must supply machine-checkable final-outcome
+        # evidence. Response length is retained only to explain a thin response;
+        # it never makes narration a deliverable. Read-only tasks are excluded:
         # their deliverable may be analysis or an external side effect such as a
         # posted review comment.
         if (
             final_status == "done"
             and returncode == 0
-            and commits_ahead == 0
-            and dirty_on_exit is False
-            and len(response) <= DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX
+            and not needs_finalize
         ):
-            needs_finalize = True
-            no_deliverable_reason = _NO_DELIVERABLE_REASON
+            if auto_finalize and auto_finalize.ok:
+                # The runtime itself committed/pushed this previously dirty tree
+                # and returned its exact path inventory, so this is stronger
+                # evidence than a worker's final-text declaration.
+                committed_paths = tuple(sorted(auto_finalize.changed_files))
+                delivery_declaration = {
+                    "outcome": "change",
+                    "summary": "runtime auto-finalized the dirty worktree",
+                    "changed_paths": list(committed_paths),
+                }
+            else:
+                delivery_declaration = _parse_delivery_declaration(response)
+                if delivery_declaration and delivery_declaration["outcome"] == "change" and commits_ahead:
+                    committed_paths = _committed_paths_ahead(Path(worktree_path), base_ref)
+                no_deliverable_reason = _delivery_declaration_failure_reason(
+                    response,
+                    delivery_declaration,
+                    commits_ahead=commits_ahead,
+                    dirty_on_exit=dirty_on_exit,
+                    committed_paths=committed_paths,
+                )
+                no_deliverable = no_deliverable_reason is not None
 
     if needs_finalize:
         final_status = "needs_finalize"
+    elif no_deliverable:
+        final_status = _NO_DELIVERABLE_STATUS
+        ok_outcome = False
 
+    last_error = _first_error_line(stderr_excerpt) if final_status != "done" else None
+    if no_deliverable_reason is not None:
+        last_error = no_deliverable_reason
     if last_error:
         # Task logs capture this worker's stderr, while agent_runtime captures
         # the CLI child's stderr internally. Re-emit the excerpt so an
@@ -2893,6 +3051,8 @@ def _run_worker(
             "cli_version": getattr(result, "cli_version", final_state.get("cli_version")),
             "substitution": substitution,
             "no_deliverable_reason": no_deliverable_reason,
+            "delivery_declaration": delivery_declaration,
+            "committed_paths": committed_paths,
             "keep_worktree": keep_worktree,
             "worktree_reap": worktree_reap,
             "tmp_bytes_freed": (
@@ -2972,7 +3132,7 @@ def _run_worker(
             stderr_excerpt=stderr_excerpt,
         )
 
-    return 0 if ok_outcome and not needs_finalize else 1
+    return 0 if ok_outcome and not needs_finalize and not no_deliverable else 1
 
 
 # ---------------------------------------------------------------------------
@@ -3340,6 +3500,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     prompt = _augment_prompt_with_worktree(
         prompt,
         worktree_path,
+        mode=args.mode,
         sparse_telemetry=worktree_telemetry.get("sparse")
         if isinstance(worktree_telemetry.get("sparse"), dict)
         else None,
@@ -4436,6 +4597,7 @@ def build_parser() -> argparse.ArgumentParser:
             "crashed",
             "cancelled",
             "needs_finalize",
+            _NO_DELIVERABLE_STATUS,
             "dry_run",
         ],
         help="Optional status filter, e.g. running or failed.",

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -67,6 +67,7 @@ TERMINAL_TASK_STATUSES = frozenset(
     {
         "done",
         "failed",
+        "no_deliverable",
         "timeout",
         "rate_limited",
         "cancelled",
@@ -393,7 +394,8 @@ def _task_still_active(
     # No state file and no pid → treat as stale (cannot prove active).
     if status is None and (check_pid is None or check_pid <= 0):
         return False
-    # spawning/running/needs_finalize/empty with live pid (or unknown pid) = active
+    # spawning/running/needs_finalize/empty with live pid (or unknown pid) = active.
+    # no_deliverable is terminal: there is no unfinished tree to protect.
     if status in ("running", "spawning", "needs_finalize", "", None):
         if check_pid is None or check_pid <= 0:
             # State says active but no pid — keep claim conservatively if status explicit.

--- a/scripts/orchestration/orchestrator_control.py
+++ b/scripts/orchestration/orchestrator_control.py
@@ -27,6 +27,7 @@ TASK_STATUS_ATTENTION = {
     "crashed",
     "failed",
     "needs_finalize",
+    "no_deliverable",
     "rate_limited",
     "timeout",
 }
@@ -295,6 +296,7 @@ def summarize_task(
         "worktree_branch": task.get("worktree_branch"),
         "worktree_dirty_on_exit": task.get("worktree_dirty_on_exit"),
         "commits_ahead": task.get("commits_ahead"),
+        "no_deliverable_reason": task.get("no_deliverable_reason"),
         "result_file": str(result_path) if result_path else task.get("result_file"),
         "result_excerpt": result_excerpt,
         "result_truncated": result_truncated,

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -358,7 +358,7 @@ def _qualifying_reason(
                 try:
                     task_data = json.loads(task_file.read_text(encoding="utf-8"))
                     task_status = task_data.get("status")
-                    if task_status in ("done", "failed") and active_ids is not None and task_id not in active_ids:
+                    if task_status in ("done", "failed", "no_deliverable") and active_ids is not None and task_id not in active_ids:
                         task_settled = True
                 except Exception:
                     pass
@@ -378,7 +378,7 @@ def _qualifying_reason(
             try:
                 task_data = json.loads(task_file.read_text(encoding="utf-8"))
                 task_status = task_data.get("status")
-                if task_status in ("done", "failed") and active_ids is not None and task_id not in active_ids:
+                if task_status in ("done", "failed", "no_deliverable") and active_ids is not None and task_id not in active_ids:
                     if info.branch:
                         prs, pr_error = _query_pr_states(repo_root, info.branch)
                         if pr_error is None and not any(pr.state == "OPEN" for pr in prs):

--- a/scripts/session_start.sh
+++ b/scripts/session_start.sh
@@ -44,7 +44,7 @@ echo ""
 # 0. Worktree hygiene — auto-reap finished dispatch/build worktrees
 #    The disk-bleed backstop: dispatch worktrees are each a full ~700MB
 #    checkout, and delegate.py only reaps them on the happy path (danger
-#    mode + status=done + clean). Everything else (needs_finalize, crashed,
+#    mode + status=done + clean). Everything else (needs_finalize, no_deliverable, crashed,
 #    dirty, review mode) leaked forever → 11GB before this was wired in.
 #    reap_worktrees.py is safe-by-default: it ONLY reaps worktrees whose PR
 #    is MERGED/CLOSED or whose HEAD matches origin/<branch>, prunes merged

--- a/tests/api/test_lane_health.py
+++ b/tests/api/test_lane_health.py
@@ -38,6 +38,9 @@ def test_is_spawn_phase_failure():
     # Status needs_finalize -> not a spawn failure
     assert is_spawn_phase_failure({"status": "needs_finalize", "returncode": 1, "duration_s": 10}) is False
 
+    # no_deliverable is a completion-contract failure, not a provider spawn failure.
+    assert is_spawn_phase_failure({"status": "no_deliverable", "returncode": 1, "duration_s": 10}) is False
+
     # Active/running task (no returncode) -> not a spawn failure
     assert is_spawn_phase_failure({"status": "running", "returncode": None, "duration_s": None}) is False
 

--- a/tests/orchestration/test_orchestrator_control.py
+++ b/tests/orchestration/test_orchestrator_control.py
@@ -96,6 +96,39 @@ def test_inbox_markdown_includes_result_excerpt_and_pr_attention(tmp_path: Path,
     assert "Summary text." in output
 
 
+def test_inbox_marks_no_deliverable_for_operator_attention(tmp_path: Path, capsys):
+    _write_task(
+        tmp_path,
+        "missing-deliverable",
+        {
+            "agent": "codex",
+            "status": "no_deliverable",
+            "started_at": "2026-06-06T10:00:00Z",
+            "duration_s": 571.0,
+            "no_deliverable_reason": "missing_delivery_declaration_short_response",
+        },
+    )
+    oc.record_task(tmp_path, "a1-policy", task_id="missing-deliverable", agent="codex")
+
+    rc = oc.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "inbox",
+            "--run-id",
+            "a1-policy",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["tasks"][0]["status"] == "no_deliverable"
+    assert "no_deliverable" in payload["tasks"][0]["attention"]
+    assert payload["tasks"][0]["no_deliverable_reason"] == "missing_delivery_declaration_short_response"
+
+
 def test_inbox_json_reports_missing_recorded_task(tmp_path: Path, capsys):
     oc.record_task(tmp_path, "a1-policy", task_id="missing-worker", agent="codex")
 

--- a/tests/orchestration/test_orchestrator_control.py
+++ b/tests/orchestration/test_orchestrator_control.py
@@ -105,7 +105,7 @@ def test_inbox_marks_no_deliverable_for_operator_attention(tmp_path: Path, capsy
             "status": "no_deliverable",
             "started_at": "2026-06-06T10:00:00Z",
             "duration_s": 571.0,
-            "no_deliverable_reason": "missing_delivery_declaration_short_response",
+            "no_deliverable_reason": "write_capable_clean_worktree_zero_commits_short_response",
         },
     )
     oc.record_task(tmp_path, "a1-policy", task_id="missing-deliverable", agent="codex")
@@ -126,7 +126,9 @@ def test_inbox_marks_no_deliverable_for_operator_attention(tmp_path: Path, capsy
     assert rc == 0
     assert payload["tasks"][0]["status"] == "no_deliverable"
     assert "no_deliverable" in payload["tasks"][0]["attention"]
-    assert payload["tasks"][0]["no_deliverable_reason"] == "missing_delivery_declaration_short_response"
+    assert payload["tasks"][0]["no_deliverable_reason"] == (
+        "write_capable_clean_worktree_zero_commits_short_response"
+    )
 
 
 def test_inbox_json_reports_missing_recorded_task(tmp_path: Path, capsys):

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -292,6 +292,33 @@ def test_class_a_settled_dispatch_removed(
     assert not worktree_path.exists()
 
 
+def test_class_a_no_deliverable_dispatch_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``no_deliverable`` dispatch is terminal; its clean worktree reaps."""
+    repo = init_repo(tmp_path)
+    task_id = "5800-false-success-noop"
+    worktree_path = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    add_worktree(repo, "codex/5800-false-success", path=worktree_path)
+
+    tasks_dir = repo / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps({"status": "no_deliverable"}), encoding="utf-8"
+    )
+
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    patch_gh(monkeypatch, {"codex/5800-false-success": []})
+
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    result = result_for(results, worktree_path)
+    assert result.action == "removed"
+    assert "settled dispatch" in result.reason
+    assert "status=no_deliverable" in result.reason
+    assert not worktree_path.exists()
+
+
 def test_class_a_fail_safe_skips(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1473,6 +1473,147 @@ def _finalize_mock_result():
     )()
 
 
+def _run_successful_worker_for_deliverable_test(
+    *,
+    task_id: str,
+    mode: str,
+    response: str,
+    commits_ahead: int,
+    tmp_path,
+    monkeypatch,
+):
+    """Run a clean successful worker with controllable delivery signals."""
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _init_git_repo_for_test(worktree, monkeypatch)
+    state_path = delegate._state_path(task_id)
+    delegate._write_state_atomic(
+        state_path,
+        {
+            "task_id": task_id,
+            "worktree_path": str(worktree),
+            "worktree_base": "main",
+        },
+    )
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": response,
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "gpt-5.6-terra",
+            "effort": "medium",
+            "cli_version": "fixture",
+        },
+    )()
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_count_commits_ahead", return_value=commits_ahead),
+    ):
+        rc = delegate._run_worker(
+            task_id=task_id,
+            agent="codex",
+            prompt="complete the assigned change",
+            mode=mode,
+            cwd_str=str(worktree),
+            model=None,
+            hard_timeout=60,
+            effort="medium",
+        )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    return rc, state
+
+
+def test_run_worker_marks_needs_finalize_for_clean_zero_commit_tiny_response(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A write dispatch must surface narration-only exits for attention."""
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="no-deliverable-tiny-response",
+        mode="workspace-write",
+        response="I will inspect the files.",
+        commits_ahead=0,
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 1
+    assert state["status"] == "needs_finalize"
+    assert state["needs_finalize"] is True
+    assert state["no_deliverable_reason"] == "write_capable_clean_worktree_zero_commits_short_response"
+
+
+def test_run_worker_does_not_flag_tiny_response_when_commit_exists(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A commit is a durable write-capable dispatch deliverable."""
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="deliverable-commit-present",
+        mode="workspace-write",
+        response="Done.",
+        commits_ahead=1,
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 0
+    assert state["status"] == "done"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] is None
+
+
+def test_run_worker_does_not_flag_read_only_tiny_response(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """Read-only work can deliver through analysis or an external side effect."""
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="read-only-tiny-response",
+        mode="read-only",
+        response="Posted.",
+        commits_ahead=0,
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 0
+    assert state["status"] == "done"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] is None
+
+
+def test_run_worker_does_not_flag_normal_successful_write_dispatch(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A substantive successful write response is not narration-only."""
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="write-substantive-response",
+        mode="danger",
+        response="x" * (delegate.DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX + 1),
+        commits_ahead=0,
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 0
+    assert state["status"] == "done"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] is None
+
+
 @pytest.mark.parametrize(
     "commits_ahead,case",
     [

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1478,7 +1478,8 @@ def _run_successful_worker_for_deliverable_test(
     task_id: str,
     mode: str,
     response: str,
-    commits_ahead: int,
+    commits_ahead: int | None,
+    committed_paths: tuple[str, ...] | None = None,
     tmp_path,
     monkeypatch,
 ):
@@ -1510,6 +1511,9 @@ def _run_successful_worker_for_deliverable_test(
         },
     )()
 
+    if committed_paths is not None:
+        monkeypatch.setattr(delegate, "_committed_paths_ahead", lambda *_args: committed_paths)
+
     with (
         patch("agent_runtime.runner.invoke", return_value=mock_result),
         patch.object(delegate, "_count_commits_ahead", return_value=commits_ahead),
@@ -1530,12 +1534,12 @@ def _run_successful_worker_for_deliverable_test(
     return rc, state
 
 
-def test_run_worker_marks_needs_finalize_for_clean_zero_commit_tiny_response(
+def test_run_worker_marks_no_deliverable_for_clean_zero_commit_tiny_response(
     tmp_tasks_dir,
     tmp_path,
     monkeypatch,
 ):
-    """A write dispatch must surface narration-only exits for attention."""
+    """A clean write dispatch without delivery evidence must fail distinctly."""
     rc, state = _run_successful_worker_for_deliverable_test(
         task_id="no-deliverable-tiny-response",
         mode="workspace-write",
@@ -1546,17 +1550,17 @@ def test_run_worker_marks_needs_finalize_for_clean_zero_commit_tiny_response(
     )
 
     assert rc == 1
-    assert state["status"] == "needs_finalize"
-    assert state["needs_finalize"] is True
-    assert state["no_deliverable_reason"] == "write_capable_clean_worktree_zero_commits_short_response"
+    assert state["status"] == "no_deliverable"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] == "missing_delivery_declaration_short_response"
 
 
-def test_run_worker_does_not_flag_tiny_response_when_commit_exists(
+def test_run_worker_marks_unstructured_commit_as_no_deliverable(
     tmp_tasks_dir,
     tmp_path,
     monkeypatch,
 ):
-    """A commit is a durable write-capable dispatch deliverable."""
+    """A commit alone cannot launder a write dispatch into success."""
     rc, state = _run_successful_worker_for_deliverable_test(
         task_id="deliverable-commit-present",
         mode="workspace-write",
@@ -1566,10 +1570,91 @@ def test_run_worker_does_not_flag_tiny_response_when_commit_exists(
         monkeypatch=monkeypatch,
     )
 
+    assert rc == 1
+    assert state["status"] == "no_deliverable"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] == "missing_delivery_declaration_short_response"
+
+
+def test_run_worker_accepts_structured_committed_change_with_matching_paths(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A declared change must match the durable paths in the own-branch diff."""
+    response = (
+        "Implemented the requested outcome.\n"
+        'DELIVERABLE: {"outcome":"change","summary":"Added no-delivery detection",'
+        '"changed_paths":["scripts/delegate.py"]}'
+    )
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="structured-committed-change",
+        mode="workspace-write",
+        response=response,
+        commits_ahead=1,
+        committed_paths=("scripts/delegate.py",),
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
     assert rc == 0
     assert state["status"] == "done"
     assert state["needs_finalize"] is False
     assert state["no_deliverable_reason"] is None
+    assert state["committed_paths"] == ["scripts/delegate.py"]
+
+
+def test_run_worker_rejects_structured_commit_with_mismatched_paths(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A declaration cannot claim paths absent from the committed diff."""
+    response = (
+        "Implemented the requested outcome.\n"
+        'DELIVERABLE: {"outcome":"change","summary":"Added no-delivery detection",'
+        '"changed_paths":["scripts/config.py"]}'
+    )
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="mismatched-committed-change",
+        mode="workspace-write",
+        response=response,
+        commits_ahead=1,
+        committed_paths=("scripts/delegate.py",),
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 1
+    assert state["status"] == "no_deliverable"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] == "commit_diff_mismatch"
+
+
+def test_run_worker_rejects_structured_empty_commit(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """An empty commit cannot satisfy a declared write outcome."""
+    response = (
+        "Implemented the requested outcome.\n"
+        'DELIVERABLE: {"outcome":"change","summary":"Added no-delivery detection",'
+        '"changed_paths":["scripts/delegate.py"]}'
+    )
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="empty-committed-change",
+        mode="workspace-write",
+        response=response,
+        commits_ahead=1,
+        committed_paths=(),
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 1
+    assert state["status"] == "no_deliverable"
+    assert state["no_deliverable_reason"] == "commit_diff_mismatch"
 
 
 def test_run_worker_does_not_flag_read_only_tiny_response(
@@ -1593,12 +1678,12 @@ def test_run_worker_does_not_flag_read_only_tiny_response(
     assert state["no_deliverable_reason"] is None
 
 
-def test_run_worker_does_not_flag_normal_successful_write_dispatch(
+def test_run_worker_marks_long_narration_without_a_delivery_declaration(
     tmp_tasks_dir,
     tmp_path,
     monkeypatch,
 ):
-    """A substantive successful write response is not narration-only."""
+    """Length is not evidence of a deliverable for a write dispatch."""
     rc, state = _run_successful_worker_for_deliverable_test(
         task_id="write-substantive-response",
         mode="danger",
@@ -1608,10 +1693,82 @@ def test_run_worker_does_not_flag_normal_successful_write_dispatch(
         monkeypatch=monkeypatch,
     )
 
+    assert rc == 1
+    assert state["status"] == "no_deliverable"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] == "missing_delivery_declaration"
+
+
+def test_run_worker_allows_structured_no_change_declaration(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """An explicit reasoned no-op is a legitimate zero-commit outcome."""
+    response = (
+        "I verified the target implementation.\n"
+        'DELIVERABLE: {"outcome":"no_change","reason":"The requested guard already rejects this case."}'
+    )
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="structured-no-change",
+        mode="workspace-write",
+        response=response,
+        commits_ahead=0,
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
     assert rc == 0
     assert state["status"] == "done"
     assert state["needs_finalize"] is False
     assert state["no_deliverable_reason"] is None
+    assert state["delivery_declaration"] == {
+        "outcome": "no_change",
+        "reason": "The requested guard already rejects this case.",
+    }
+
+
+def test_run_worker_fails_closed_when_clean_commit_count_is_unknown(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """Unknown own-branch commit count cannot establish a write deliverable."""
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="unknown-clean-commit-count",
+        mode="workspace-write",
+        response="The task is complete.",
+        commits_ahead=None,
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 1
+    assert state["status"] == "no_deliverable"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] == "commit_count_unknown"
+
+
+def test_run_worker_flags_real_world_other_branch_delivery_miss(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A 571-second run that changed other branches has no own-branch proof."""
+    response = "*(intermediate CI progress — waiting for full completion before reporting)*"
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="fix-red-prs-delivery-miss",
+        mode="workspace-write",
+        response=response,
+        commits_ahead=0,
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 1
+    assert state["status"] == "no_deliverable"
+    assert state["needs_finalize"] is False
+    assert state["no_deliverable_reason"] == "missing_delivery_declaration_short_response"
 
 
 @pytest.mark.parametrize(
@@ -3498,12 +3655,20 @@ def test_augment_prompt_mentions_sparse_exclusions():
     assert "sparse" in text.lower() or "Sparse" in text
 
 
+def test_augment_write_prompt_requires_structured_delivery_declaration():
+    text = delegate._augment_prompt_with_worktree(
+        "do work",
+        Path("/tmp/wt"),
+        mode="workspace-write",
+    )
+
+    assert "DELIVERABLE:" in text
+    assert '"outcome":"change"' in text
+    assert '"outcome":"no_change"' in text
+
+
 def test_ensure_worktree_refuses_stale_base_when_fetch_fails(tmp_tasks_dir, tmp_path, monkeypatch, capsys):
-    """Fix 1 (#1476) amended by #5803 follow-up: offline/no-remote scenarios
-    used to fall back to the local base with only a stderr warning. That
-    silent fallback is why a worker concluded "origin/main may be stale" and
-    went to the PRIMARY checkout for freshness, leaving it detached. Fetch
-    failure is now an actionable hard error — no stale-base worktree.
+    """Fetch failure must not create a worktree from a stale local base."""
     """
     target = tmp_path / "offline-worktree"
 

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -609,6 +609,25 @@ def test_wait_returns_nonzero_on_failed(tmp_tasks_dir, capsys):
     assert rc == 1  # nonzero for any non-done terminal status
 
 
+def test_wait_returns_immediately_on_no_deliverable_with_default_timeout(tmp_tasks_dir, capsys):
+    """A completion-contract failure is terminal even when wait has no deadline."""
+    path = delegate._state_path("wait-no-deliverable")
+    delegate._write_state_atomic(path, {
+        "task_id": "wait-no-deliverable",
+        "status": "no_deliverable",
+    })
+    import argparse
+    args = argparse.Namespace(
+        task_id="wait-no-deliverable", timeout=0, poll_interval=0.1,
+    )
+    t0 = time.monotonic()
+    rc = delegate.cmd_wait(args)
+    elapsed = time.monotonic() - t0
+
+    assert rc == 1
+    assert elapsed < 1.0, "wait on no_deliverable must return without an explicit timeout"
+
+
 def test_wait_returns_124_on_task_timeout(tmp_tasks_dir, capsys):
     path = delegate._state_path("wait-task-timeout")
     delegate._write_state_atomic(path, {
@@ -1001,6 +1020,23 @@ def test_cancel_refuses_crashed_task(tmp_tasks_dir, capsys):
     assert rc == 1
     captured = capsys.readouterr()
     assert "terminal state" in captured.err
+
+
+def test_cancel_refuses_no_deliverable_task(tmp_tasks_dir, capsys):
+    """no_deliverable is terminal, so cancel must not signal its stale PID."""
+    path = delegate._state_path("no-deliverable-task")
+    delegate._write_state_atomic(path, {
+        "task_id": "no-deliverable-task",
+        "status": "no_deliverable",
+        "pid": os.getpid(),
+    })
+    import argparse
+    rc = delegate.cmd_cancel(argparse.Namespace(task_id="no-deliverable-task"))
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "terminal state" in captured.err
+    assert "no_deliverable" in captured.err
 
 
 def test_worker_sigterm_handler_raises_keyboard_interrupt():
@@ -1551,6 +1587,7 @@ def test_run_worker_marks_no_deliverable_for_clean_zero_commit_tiny_response(
     assert state["no_deliverable_reason"] == (
         "write_capable_clean_worktree_zero_commits_short_response"
     )
+    assert state["last_error"] == state["no_deliverable_reason"]
 
 
 def test_run_worker_does_not_flag_committed_change_without_declaration(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1479,7 +1479,6 @@ def _run_successful_worker_for_deliverable_test(
     mode: str,
     response: str,
     commits_ahead: int | None,
-    committed_paths: tuple[str, ...] | None = None,
     tmp_path,
     monkeypatch,
 ):
@@ -1511,9 +1510,6 @@ def _run_successful_worker_for_deliverable_test(
         },
     )()
 
-    if committed_paths is not None:
-        monkeypatch.setattr(delegate, "_committed_paths_ahead", lambda *_args: committed_paths)
-
     with (
         patch("agent_runtime.runner.invoke", return_value=mock_result),
         patch.object(delegate, "_count_commits_ahead", return_value=commits_ahead),
@@ -1539,7 +1535,7 @@ def test_run_worker_marks_no_deliverable_for_clean_zero_commit_tiny_response(
     tmp_path,
     monkeypatch,
 ):
-    """A clean write dispatch without delivery evidence must fail distinctly."""
+    """A clean write dispatch with only a trivial response has no deliverable."""
     rc, state = _run_successful_worker_for_deliverable_test(
         task_id="no-deliverable-tiny-response",
         mode="workspace-write",
@@ -1552,36 +1548,44 @@ def test_run_worker_marks_no_deliverable_for_clean_zero_commit_tiny_response(
     assert rc == 1
     assert state["status"] == "no_deliverable"
     assert state["needs_finalize"] is False
-    assert state["no_deliverable_reason"] == "missing_delivery_declaration_short_response"
+    assert state["no_deliverable_reason"] == (
+        "write_capable_clean_worktree_zero_commits_short_response"
+    )
 
 
-def test_run_worker_marks_unstructured_commit_as_no_deliverable(
+def test_run_worker_does_not_flag_committed_change_without_declaration(
     tmp_tasks_dir,
     tmp_path,
     monkeypatch,
 ):
-    """A commit alone cannot launder a write dispatch into success."""
+    """Commits on the dispatch branch prove delivery; no magic phrase needed.
+
+    A worker that did its job and ended with ordinary completion text must
+    settle as ``done`` — a ``DELIVERABLE:`` line is an optional positive
+    signal, never a requirement.
+    """
     rc, state = _run_successful_worker_for_deliverable_test(
-        task_id="deliverable-commit-present",
+        task_id="committed-change-plain-summary",
         mode="workspace-write",
-        response="Done.",
+        response="Implemented the guard and added regression tests. All 152 tests pass.",
         commits_ahead=1,
         tmp_path=tmp_path,
         monkeypatch=monkeypatch,
     )
 
-    assert rc == 1
-    assert state["status"] == "no_deliverable"
+    assert rc == 0
+    assert state["status"] == "done"
     assert state["needs_finalize"] is False
-    assert state["no_deliverable_reason"] == "missing_delivery_declaration_short_response"
+    assert state["no_deliverable_reason"] is None
+    assert state["delivery_declaration"] is None
 
 
-def test_run_worker_accepts_structured_committed_change_with_matching_paths(
+def test_run_worker_records_optional_declaration_as_positive_signal(
     tmp_tasks_dir,
     tmp_path,
     monkeypatch,
 ):
-    """A declared change must match the durable paths in the own-branch diff."""
+    """A valid declaration accompanying real commits is recorded as evidence."""
     response = (
         "Implemented the requested outcome.\n"
         'DELIVERABLE: {"outcome":"change","summary":"Added no-delivery detection",'
@@ -1592,7 +1596,6 @@ def test_run_worker_accepts_structured_committed_change_with_matching_paths(
         mode="workspace-write",
         response=response,
         commits_ahead=1,
-        committed_paths=("scripts/delegate.py",),
         tmp_path=tmp_path,
         monkeypatch=monkeypatch,
     )
@@ -1601,26 +1604,56 @@ def test_run_worker_accepts_structured_committed_change_with_matching_paths(
     assert state["status"] == "done"
     assert state["needs_finalize"] is False
     assert state["no_deliverable_reason"] is None
-    assert state["committed_paths"] == ["scripts/delegate.py"]
+    assert state["delivery_declaration"] == {
+        "outcome": "change",
+        "summary": "Added no-delivery detection",
+        "changed_paths": ["scripts/delegate.py"],
+    }
 
 
-def test_run_worker_rejects_structured_commit_with_mismatched_paths(
+def test_run_worker_tolerates_trailing_text_after_declaration(
     tmp_tasks_dir,
     tmp_path,
     monkeypatch,
 ):
-    """A declaration cannot claim paths absent from the committed diff."""
+    """A polite closing line after ``DELIVERABLE:`` must not void the signal."""
     response = (
         "Implemented the requested outcome.\n"
         'DELIVERABLE: {"outcome":"change","summary":"Added no-delivery detection",'
-        '"changed_paths":["scripts/config.py"]}'
+        '"changed_paths":["scripts/delegate.py"]}\n'
+        "All 15 tests passed; let me know if you need anything else."
     )
     rc, state = _run_successful_worker_for_deliverable_test(
-        task_id="mismatched-committed-change",
+        task_id="declaration-with-trailing-text",
         mode="workspace-write",
         response=response,
         commits_ahead=1,
-        committed_paths=("scripts/delegate.py",),
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 0
+    assert state["status"] == "done"
+    assert state["no_deliverable_reason"] is None
+    assert state["delivery_declaration"]["outcome"] == "change"
+
+
+def test_run_worker_rejects_declaration_claiming_change_without_commits(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A declared change with a clean zero-commit branch is a contradiction."""
+    response = (
+        "Implemented the requested outcome.\n"
+        'DELIVERABLE: {"outcome":"change","summary":"Added no-delivery detection",'
+        '"changed_paths":["scripts/delegate.py"]}'
+    )
+    rc, state = _run_successful_worker_for_deliverable_test(
+        task_id="claimed-change-zero-commits",
+        mode="workspace-write",
+        response=response,
+        commits_ahead=0,
         tmp_path=tmp_path,
         monkeypatch=monkeypatch,
     )
@@ -1628,33 +1661,7 @@ def test_run_worker_rejects_structured_commit_with_mismatched_paths(
     assert rc == 1
     assert state["status"] == "no_deliverable"
     assert state["needs_finalize"] is False
-    assert state["no_deliverable_reason"] == "commit_diff_mismatch"
-
-
-def test_run_worker_rejects_structured_empty_commit(
-    tmp_tasks_dir,
-    tmp_path,
-    monkeypatch,
-):
-    """An empty commit cannot satisfy a declared write outcome."""
-    response = (
-        "Implemented the requested outcome.\n"
-        'DELIVERABLE: {"outcome":"change","summary":"Added no-delivery detection",'
-        '"changed_paths":["scripts/delegate.py"]}'
-    )
-    rc, state = _run_successful_worker_for_deliverable_test(
-        task_id="empty-committed-change",
-        mode="workspace-write",
-        response=response,
-        commits_ahead=1,
-        committed_paths=(),
-        tmp_path=tmp_path,
-        monkeypatch=monkeypatch,
-    )
-
-    assert rc == 1
-    assert state["status"] == "no_deliverable"
-    assert state["no_deliverable_reason"] == "commit_diff_mismatch"
+    assert state["no_deliverable_reason"] == "invalid_delivery_declaration"
 
 
 def test_run_worker_does_not_flag_read_only_tiny_response(
@@ -1678,25 +1685,38 @@ def test_run_worker_does_not_flag_read_only_tiny_response(
     assert state["no_deliverable_reason"] is None
 
 
-def test_run_worker_marks_long_narration_without_a_delivery_declaration(
+def test_run_worker_does_not_flag_legitimate_noop_write_dispatch(
     tmp_tasks_dir,
     tmp_path,
     monkeypatch,
 ):
-    """Length is not evidence of a deliverable for a write dispatch."""
+    """A substantive zero-commit analysis is a deliverable, not a failure.
+
+    "Investigate and only change if needed" dispatches legitimately conclude
+    with no commits. Their analysis — a non-trivial response — is the
+    deliverable; flagging it trains orchestrators to ignore the signal.
+    """
+    response = (
+        "I investigated the reported failure across scripts/delegate.py and its "
+        "tests. The guard already rejects this exact case: the ownership ledger "
+        "refuses overlapping claims in REFUSE mode, and the regression test at "
+        "tests/test_delegate.py covers it. No code change is required; the "
+        "reported behaviour came from a stale build."
+    )
+    assert len(response) > delegate.DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX
     rc, state = _run_successful_worker_for_deliverable_test(
-        task_id="write-substantive-response",
-        mode="danger",
-        response="x" * (delegate.DELEGATE_NO_DELIVERABLE_RESPONSE_CHARS_MAX + 1),
+        task_id="write-substantive-noop",
+        mode="workspace-write",
+        response=response,
         commits_ahead=0,
         tmp_path=tmp_path,
         monkeypatch=monkeypatch,
     )
 
-    assert rc == 1
-    assert state["status"] == "no_deliverable"
+    assert rc == 0
+    assert state["status"] == "done"
     assert state["needs_finalize"] is False
-    assert state["no_deliverable_reason"] == "missing_delivery_declaration"
+    assert state["no_deliverable_reason"] is None
 
 
 def test_run_worker_allows_structured_no_change_declaration(
@@ -1768,7 +1788,9 @@ def test_run_worker_flags_real_world_other_branch_delivery_miss(
     assert rc == 1
     assert state["status"] == "no_deliverable"
     assert state["needs_finalize"] is False
-    assert state["no_deliverable_reason"] == "missing_delivery_declaration_short_response"
+    assert state["no_deliverable_reason"] == (
+        "write_capable_clean_worktree_zero_commits_short_response"
+    )
 
 
 @pytest.mark.parametrize(
@@ -3655,7 +3677,7 @@ def test_augment_prompt_mentions_sparse_exclusions():
     assert "sparse" in text.lower() or "Sparse" in text
 
 
-def test_augment_write_prompt_requires_structured_delivery_declaration():
+def test_augment_write_prompt_offers_optional_delivery_declaration():
     text = delegate._augment_prompt_with_worktree(
         "do work",
         Path("/tmp/wt"),
@@ -3663,13 +3685,22 @@ def test_augment_write_prompt_requires_structured_delivery_declaration():
     )
 
     assert "DELIVERABLE:" in text
-    assert '"outcome":"change"' in text
     assert '"outcome":"no_change"' in text
+    assert "optional" in text.lower()
+
+
+def test_augment_read_only_prompt_omits_delivery_declaration():
+    text = delegate._augment_prompt_with_worktree(
+        "do work",
+        Path("/tmp/wt"),
+        mode="read-only",
+    )
+
+    assert "DELIVERABLE:" not in text
 
 
 def test_ensure_worktree_refuses_stale_base_when_fetch_fails(tmp_tasks_dir, tmp_path, monkeypatch, capsys):
     """Fetch failure must not create a worktree from a stale local base."""
-    """
     target = tmp_path / "offline-worktree"
 
     def fake_run(cmd, **kwargs):

--- a/tests/test_delegate_api.py
+++ b/tests/test_delegate_api.py
@@ -97,6 +97,23 @@ def test_tasks_timeout_status_is_distinct_from_failed(tmp_path, monkeypatch):
     assert [task["task_id"] for task in failed_response.json()["tasks"]] == ["failed"]
 
 
+def test_tasks_attention_status_filters_are_queryable(tmp_path, monkeypatch):
+    """``needs_finalize``/``no_deliverable`` are real settle states — the API
+    must not 422 when an orchestrator filters by them (#5800 review)."""
+    tasks_dir = tmp_path / "tasks"
+    monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
+    _write_task(tasks_dir / "finalize.json", _task_payload("finalize", status="needs_finalize"))
+    _write_task(tasks_dir / "nodeliv.json", _task_payload("nodeliv", status="no_deliverable"))
+
+    finalize_response = client.get("/api/delegate/tasks?status=needs_finalize")
+    nodeliv_response = client.get("/api/delegate/tasks?status=no_deliverable")
+
+    assert finalize_response.status_code == 200
+    assert nodeliv_response.status_code == 200
+    assert [task["task_id"] for task in finalize_response.json()["tasks"]] == ["finalize"]
+    assert [task["task_id"] for task in nodeliv_response.json()["tasks"]] == ["nodeliv"]
+
+
 def test_active_lists_only_live_running_tasks(tmp_path, monkeypatch):
     tasks_dir = tmp_path / "tasks"
     monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)


### PR DESCRIPTION
## Summary

- mark terminal, write-capable zero-deliverable runs with `needs_finalize` and a machine-readable reason
- retain the existing `needs_finalize` status rather than relabeling the run as failed
- cover the narration-only path and its committed, read-only, and substantive-response exclusions

## Deliberate exclusions

- Read-only analysis and reviews are never flagged: their deliverable can be analysis or an external action such as a `gh pr comment`.
- Dry runs do not start a terminal worker, so this terminal-success detector does not apply.
- Write runs with a commit, an uncommitted worktree (handled by the existing dirty-worktree finalization path), or a substantive response are not marked as no-deliverable.
- Duration is intentionally not a criterion: observed false successes lasted 30–60 seconds, while legitimate operations can complete quickly. The check instead requires all of clean worktree, zero commits, and a response at or below the named tunable limit.

## Verification

- Added regressions failed before the implementation: `4 failed` (missing reason/threshold).
- `DELEGATE_OWNERSHIP_MODE=warn .venv/bin/python -m pytest tests/test_delegate.py -q` → `145 passed`.
- `.venv/bin/ruff check scripts/config.py scripts/delegate.py tests/test_delegate.py` → `All checks passed!`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py` → `OPSEC check passed. Zero leaks detected.`

The default ownership-ledger mode caused eight unrelated spawn tests to refuse their synthetic worktree dispatches because a live shared unknown-path claim prevented proof of disjointness; the WARN-mode test run preserves the tests intended execution path.