### PR TITLE
fix(guardrails): guard the primary checkout at git level, not harness level (#5389/#5396)

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# post-checkout — LFS passthrough + primary-checkout stay-on-main heal.
+#
+# This file makes the #5389/#4857 heal ACTUALLY live: the heal fragment was
+# installed into .git/hooks/post-checkout, but core.hooksPath points at the
+# (previously nonexistent) tracked .githooks/ directory, so .git/hooks/* never
+# fired — which is why the 2026-07-25 detached-FETCH_HEAD incident was not
+# auto-healed. With this tracked copy, every checkout in any worktree runs it.
+#
+# post-checkout args: <prev HEAD> <new HEAD> <flag: 1=branch, 0=file>.
+# A post-checkout hook can never veto (the checkout already happened); the
+# pre-flight block lives in .githooks/reference-transaction.
+
+# Git LFS passthrough (was .git/hooks/post-checkout, shadowed since
+# core.hooksPath was set). Guarded: a missing git-lfs must not break checkout.
+if command -v git-lfs >/dev/null 2>&1; then
+  git lfs post-checkout "$@" || true
+fi
+
+# Keep the PRIMARY worktree attached to main (#4857). The fragment no-ops in
+# linked worktrees (it compares git-dir vs git-common-dir itself).
+if [ -f "scripts/guardrails/primary_post_checkout_heal.sh" ]; then
+  sh "scripts/guardrails/primary_post_checkout_heal.sh" "$@" || true
+fi
+
+exit 0

--- a/.githooks/reference-transaction
+++ b/.githooks/reference-transaction
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# reference-transaction guard — keep the PRIMARY checkout on main, at git level.
+#
+# Why this exists (incident 2026-07-25, refs #5389 / #5396):
+#   A cursor dispatch worker, running inside its own worktree, reached OUT and
+#   ran git commands against the primary checkout, leaving it detached at
+#   FETCH_HEAD:
+#       a8d9a8f949 HEAD@{0}: checkout: moving from main to FETCH_HEAD
+#       ba468fdab8 HEAD@{1}: pull: Fast-forward
+#   Every pre-existing guard is harness-side (Claude/Codex PreToolUse hooks) or
+#   PATH-side (scripts/agent_runtime/shims/git) — a worker on a different
+#   harness with the real git binary bypasses all of them. This hook lives in
+#   git itself (core.hooksPath=.githooks, tracked), so it binds EVERY harness,
+#   every shell, and every `git -C <primary>` reach-across equally.
+#
+# What it blocks (state=prepared, non-interactive, no override):
+#   * Any update to refs/heads/main|master — commit/pull/reset/branch -f/
+#     update-ref against the protected branch, from ANY worktree context.
+#   * Any HEAD update whose new value is a raw commit (a DETACH) when the
+#     command's git dir IS the primary checkout's git dir — this is the
+#     `git checkout FETCH_HEAD` incident class.
+#
+# What it deliberately allows:
+#   * HEAD symref retargets (checkout -b / checkout <branch> / worktree add).
+#     A `git worktree add` internal HEAD write is byte-for-byte
+#     indistinguishable from a branch switch inside this hook (verified
+#     empirically), and worktree creation from the primary is the standard
+#     dispatch flow — blocking it would break delegate.py. Wrong-branch
+#     primaries are instead auto-healed by .githooks/post-checkout +
+#     scripts/guardrails/primary_post_checkout_heal.sh (#4857).
+#   * Everything in linked worktrees (git dir != common dir).
+#   * fetch / remote ref updates (refs/remotes/*, FETCH_HEAD, ORIG_HEAD,
+#     AUTO_MERGE), refs/stash, agent branches.
+#
+# Operator escape hatches (never silently block a human):
+#   * An interactive terminal (stdout or stderr is a TTY) is always allowed —
+#     the human operator working in the primary by hand is unaffected.
+#   * Scripted operator/service flows set LEARN_UK_ALLOW_PRIMARY_REF_WRITE=1
+#     for the invocation. The block message names this variable.
+#
+# The hook FAILS OPEN on any internal error: it is a guard rail against
+# accidents, not an adversarial boundary, and must never wedge git itself.
+
+set -u
+
+state="${1:-}"
+# Only `prepared` may veto; preparing/committed/aborted are informational.
+[ "$state" = "prepared" ] || exit 0
+
+# --- scan stdin for refs we care about; exit fast for everything else -------
+block_detached_head=""   # set to 1 when a primary-context HEAD detach is seen
+block_main_ref=""        # set to 1 when refs/heads/main|master is touched
+while IFS= read -r line; do
+  ref="${line##* }"
+  case "$ref" in
+    refs/heads/main | refs/heads/master)
+      block_main_ref=1
+      ;;
+    HEAD)
+      # new value is the middle field; a 40/64-hex value = detach, a
+      # ref:refs/heads/... value = symref retarget (allowed, see header).
+      set -- $line
+      new_value="${2:-}"
+      case "$new_value" in
+        ref:*) ;;
+        *[!0-9a-f]*)
+          # non-hex, non-symref — unexpected; stay out of the way
+          ;;
+        *)
+          if [ "${#new_value}" -eq 40 ] || [ "${#new_value}" -eq 64 ]; then
+            block_detached_head=1
+          fi
+          ;;
+      esac
+      ;;
+  esac
+done
+
+[ -n "$block_main_ref" ] || [ -n "$block_detached_head" ] || exit 0
+
+# --- operator escape hatches -------------------------------------------------
+if [ "${LEARN_UK_ALLOW_PRIMARY_REF_WRITE:-}" = "1" ]; then
+  exit 0
+fi
+if [ -t 1 ] || [ -t 2 ]; then
+  # Interactive terminal: the human operator is driving — never block.
+  exit 0
+fi
+
+# --- context: is this the primary checkout, and does the rule apply? --------
+# git-dir == git-common-dir identifies the primary worktree. A HEAD detach is
+# only blocked in primary context (worktrees may detach freely); a main-tip
+# move is blocked from ANY context (the protected ref is shared).
+_abs() {
+  (cd "$(dirname "$1")" 2>/dev/null && printf '%s/%s' "$(pwd)" "$(basename "$1")")
+}
+
+is_primary=0
+git_dir="$(git rev-parse --git-dir 2>/dev/null)" || exit 0
+common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || exit 0
+[ -n "$git_dir" ] && [ -n "$common_dir" ] || exit 0
+git_dir_abs="$(_abs "$git_dir")"
+common_dir_abs="$(_abs "$common_dir")"
+[ -n "$git_dir_abs" ] && [ -n "$common_dir_abs" ] || exit 0
+if [ "$git_dir_abs" = "$common_dir_abs" ]; then
+  is_primary=1
+fi
+
+if [ "$is_primary" -ne 1 ] && [ -z "$block_main_ref" ]; then
+  exit 0
+fi
+
+# --- fail loudly -------------------------------------------------------------
+{
+  echo "BLOCKED by .githooks/reference-transaction (primary-checkout ref guard):"
+  if [ -n "$block_main_ref" ]; then
+    echo "  - this command would move refs/heads/main (or master) from a"
+    echo "    non-interactive context."
+  fi
+  if [ -n "$block_detached_head" ] && [ "$is_primary" -eq 1 ]; then
+    echo "  - this command would DETACH the primary checkout's HEAD"
+    echo "    (the 2026-07-25 'checkout: moving from main to FETCH_HEAD'"
+    echo "    incident class, #5389/#5396)."
+  fi
+  echo ""
+  echo "The primary checkout stays attached to main. Agents do ref work in"
+  echo "their dispatch worktree (.worktrees/dispatch/<agent>/<task>/), never"
+  echo "via 'git -C <primary>'."
+  echo ""
+  echo "If you are the operator running this intentionally from a script or"
+  echo "service, re-run with the documented one-shot override:"
+  echo ""
+  echo "  LEARN_UK_ALLOW_PRIMARY_REF_WRITE=1 git <your command>"
+  echo ""
+  echo "See docs/runbooks/primary-checkout-ref-guard.md."
+} >&2
+exit 1

--- a/docs/runbooks/primary-checkout-ref-guard.md
+++ b/docs/runbooks/primary-checkout-ref-guard.md
@@ -1,0 +1,84 @@
+# Primary-checkout ref guard (`.githooks/reference-transaction`)
+
+Git-level guard that keeps the **primary checkout attached to `main`** for
+every harness, not just the ones with PreToolUse hooks.
+
+## Why (incident 2026-07-25, refs #5389 / #5396)
+
+A `cursor` dispatch worker, running inside its own worktree
+(`.worktrees/dispatch/cursor/rebase-5729`), reached out of it and ran git
+commands against the primary checkout. Primary reflog:
+
+```
+a8d9a8f949 HEAD@{0}: checkout: moving from main to FETCH_HEAD
+ba468fdab8 HEAD@{1}: pull: Fast-forward
+```
+
+The existing layers did not fire:
+
+- `agents_extensions/shared/hooks/guard-primary-checkout-write.py` and
+  `guard-branch-switch-in-main.py` are **harness** PreToolUse hooks — they
+  only see Claude/Codex tool calls. Cursor/kimi/agy/deepseek workers never
+  consult them.
+- `scripts/agent_runtime/shims/git` only works when the shim directory is on
+  `PATH` — a worker with the real git binary bypasses it.
+- The #5389 heal fragment was installed into `.git/hooks/post-checkout`, but
+  `core.hooksPath` is set to `.githooks` — which did not exist — so **no**
+  `.git/hooks/*` hook was running at all. The detach was never healed.
+
+A guard that lives in git itself (`core.hooksPath`, tracked `.githooks/`)
+binds every harness, every shell, and every `git -C <primary>` reach-across.
+
+## What the guard does
+
+`.githooks/reference-transaction` fires on every ref transaction. In the
+`prepared` state (the only state that can veto) it blocks, from
+non-interactive contexts without the override:
+
+- any update to `refs/heads/main` / `refs/heads/master` — commit, pull,
+  `reset --hard`, `branch -f`, `update-ref` — **from any worktree context**
+  (the protected ref is shared);
+- any `HEAD` update whose new value is a raw commit — a **detach** — when the
+  command targets the primary checkout (`git-dir == git-common-dir`). This is
+  the `checkout: moving from main to FETCH_HEAD` incident class.
+
+Deliberately allowed:
+
+- `HEAD` symref retargets (`checkout -b`, `checkout <branch>`,
+  `git worktree add`). A worktree-add internal HEAD write is indistinguishable
+  from a branch switch inside the hook (verified empirically), and worktree
+  creation from the primary is the standard dispatch flow. Wrong-branch
+  primaries are auto-healed instead: `.githooks/post-checkout` runs
+  `scripts/guardrails/primary_post_checkout_heal.sh` (#4857), which was
+  previously dead code shadowed by `core.hooksPath`.
+- everything inside linked worktrees (their git dir differs from the common
+  dir);
+- `fetch` / `refs/remotes/*` / `FETCH_HEAD` / `ORIG_HEAD` / `refs/stash`.
+
+## Operator override
+
+The guard never silently blocks a human:
+
+- an **interactive terminal** (stdout or stderr is a TTY) is always allowed;
+- scripted operator/service flows use the documented one-shot override:
+
+```bash
+LEARN_UK_ALLOW_PRIMARY_REF_WRITE=1 git <command>
+```
+
+The block message on stderr names this variable. The sanctioned heal path
+(`assert_primary_on_main.py --heal`) sets it internally for its own
+`checkout -B` / `pull --ff-only` subprocesses.
+
+## Activation
+
+`core.hooksPath=.githooks` is already set in the primary's `.git/config`. The
+guard becomes active in a checkout as soon as that checkout contains the
+tracked `.githooks/` directory (i.e. once the primary fast-forwards past the
+merge of this change). To activate manually elsewhere:
+
+```bash
+git config core.hooksPath .githooks   # repo-local, relative to worktree top
+```
+
+Fresh clones need the same one-line config; the hooks themselves are tracked.

--- a/scripts/guardrails/assert_primary_on_main.py
+++ b/scripts/guardrails/assert_primary_on_main.py
@@ -102,6 +102,13 @@ def primary_head_state(cwd: Path | None = None) -> dict[str, object]:
 
 def heal_primary_to_main(main_root: Path) -> tuple[bool, str]:
     """Force primary back onto main (no force-reset of dirty files)."""
+    # Healing is the one SANCTIONED mutation of the primary's refs: the
+    # checkout -B / ff-only pull below move refs/heads/main, which the
+    # .githooks/reference-transaction guard blocks in non-interactive contexts
+    # (e.g. when this heal is triggered by .githooks/post-checkout after an
+    # agent's checkout, or by a session launcher). Carry the documented
+    # override for our own subprocesses only.
+    os.environ["LEARN_UK_ALLOW_PRIMARY_REF_WRITE"] = "1"
     # Prefer local main; if missing, create tracking branch from origin/main.
     show = _git(main_root, "show-ref", "--verify", "--quiet", "refs/heads/main")
     if show.returncode != 0:

--- a/tests/test_githooks_primary_ref_guard.py
+++ b/tests/test_githooks_primary_ref_guard.py
@@ -1,0 +1,297 @@
+"""Tests for the git-level primary-checkout ref guard (.githooks/).
+
+Incident class (#5389 / #5396, 2026-07-25): a dispatch worker on a harness
+WITHOUT PreToolUse hooks reached out of its worktree and detached the primary
+checkout (``checkout: moving from main to FETCH_HEAD``). The fix lives in git
+itself: a tracked ``.githooks/reference-transaction`` hook (core.hooksPath is
+already set) that vetoes protected-ref moves, plus a ``.githooks/post-checkout``
+that makes the previously-shadowed stay-on-main heal actually run.
+
+These tests build a scratch repo + linked worktree per test and exercise the
+hooks with the REAL git binary (the repo's agent_runtime git shim is filtered
+from PATH): no harness, no shim, exactly the incident's bypass conditions.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOKS_SRC = REPO_ROOT / ".githooks"
+OVERRIDE_ENV = "LEARN_UK_ALLOW_PRIMARY_REF_WRITE"
+
+
+def _real_git() -> str:
+    """Absolute path of the real git binary, skipping the agent_runtime shim."""
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if "scripts/agent_runtime/shims" in entry:
+            continue
+        candidate = Path(entry) / "git"
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    pytest.skip("no real git binary found on PATH")
+
+
+GIT = _real_git()
+
+
+def _run(
+    args: list[str],
+    cwd: Path | None = None,
+    env_extra: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    # Neutralize shim/agent toggles so only the git hooks under test act.
+    for key in ("AGENT_NO_MERGE", "AGENT_GIT_SHIM_GUARD_ACTIVE"):
+        env.pop(key, None)
+    env.pop(OVERRIDE_ENV, None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [GIT, *args],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+@pytest.fixture()
+def scratch_repo(tmp_path: Path) -> dict[str, Path]:
+    """A scratch repo on `main` with the tracked .githooks/ installed.
+
+    Returns {"primary": <path>}. The hooks are committed into the repo so
+    linked worktrees (created later by tests) carry them too.
+    """
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    assert _run(["init", "-q", "-b", "main"], cwd=primary).returncode == 0
+    _run(["config", "user.email", "test@example.invalid"], cwd=primary)
+    _run(["config", "user.name", "Test User"], cwd=primary)
+    (primary / "f").write_text("a\n", encoding="utf-8")
+    assert _run(["add", "f"], cwd=primary).returncode == 0
+    assert _run(["commit", "-qm", "init"], cwd=primary).returncode == 0
+
+    hooks_dst = primary / ".githooks"
+    shutil.copytree(HOOKS_SRC, hooks_dst)
+    for hook in hooks_dst.iterdir():
+        hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+    assert _run(["add", ".githooks"], cwd=primary).returncode == 0
+    assert _run(["commit", "-qm", "add githooks"], cwd=primary).returncode == 0
+    assert _run(["config", "core.hooksPath", ".githooks"], cwd=primary).returncode == 0
+    return {"primary": primary}
+
+
+def _add_worktree(primary: Path, name: str = "wt1") -> Path:
+    wt = primary.parent / name
+    proc = _run(["-C", str(primary), "worktree", "add", "-q", str(wt), "-b", f"{name}-branch"])
+    assert proc.returncode == 0, proc.stderr
+    return wt
+
+
+def _head_branch(repo: Path) -> str:
+    proc = _run(["-C", str(repo), "symbolic-ref", "--quiet", "--short", "HEAD"])
+    return proc.stdout.strip()
+
+
+def _head_sha(repo: Path) -> str:
+    proc = _run(["-C", str(repo), "rev-parse", "HEAD"])
+    assert proc.returncode == 0
+    return proc.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# worker-style reach-across is refused
+# ---------------------------------------------------------------------------
+
+
+def test_worker_detach_of_primary_from_worktree_is_refused(scratch_repo):
+    """The exact 2026-07-25 incident: from a worktree, detach the primary."""
+    primary = scratch_repo["primary"]
+    wt = _add_worktree(primary)
+    sha = _head_sha(primary)
+
+    proc = _run(["-C", str(primary), "checkout", sha], cwd=wt)
+
+    assert proc.returncode != 0, "worker-style detach of the primary must be refused"
+    assert "BLOCKED by .githooks/reference-transaction" in proc.stderr
+    assert OVERRIDE_ENV in proc.stderr  # block message names the override
+    assert _head_branch(primary) == "main"  # primary untouched
+
+
+def test_main_tip_update_ref_from_worktree_is_refused(scratch_repo):
+    """A worker moving refs/heads/main directly is refused from any context."""
+    primary = scratch_repo["primary"]
+    wt = _add_worktree(primary)
+    wt_sha = _head_sha(wt)  # == main's sha; craft a second commit to move to
+    (wt / "f").write_text("b\n", encoding="utf-8")
+    assert _run(["commit", "-qam", "c2"], cwd=wt).returncode == 0
+    new_sha = _head_sha(wt)
+
+    proc = _run(
+        ["-C", str(primary), "update-ref", "refs/heads/main", new_sha], cwd=wt
+    )
+
+    assert proc.returncode != 0
+    assert "BLOCKED by .githooks/reference-transaction" in proc.stderr
+
+
+def test_commit_on_main_in_primary_blocked_when_non_interactive(scratch_repo):
+    """Non-interactive commit directly on main in the primary is refused."""
+    primary = scratch_repo["primary"]
+
+    proc = _run(["commit", "--allow-empty", "-m", "agent-commit"], cwd=primary)
+
+    assert proc.returncode != 0
+    assert "BLOCKED by .githooks/reference-transaction" in proc.stderr
+    assert _head_branch(primary) == "main"
+
+
+# ---------------------------------------------------------------------------
+# operator escape hatches
+# ---------------------------------------------------------------------------
+
+
+def test_override_env_allows_intentional_operator_action(scratch_repo):
+    """LEARN_UK_ALLOW_PRIMARY_REF_WRITE=1 re-enables scripted operator flows."""
+    primary = scratch_repo["primary"]
+    wt = _add_worktree(primary)
+    sha = _head_sha(primary)
+
+    proc = _run(
+        ["-C", str(primary), "checkout", sha],
+        cwd=wt,
+        env_extra={OVERRIDE_ENV: "1"},
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert _head_branch(primary) == ""  # detached, as the operator intended
+
+    # Cleanup: re-attach under the override too (would otherwise be allowed
+    # anyway — symref retarget to main is never blocked).
+    heal = _run(["-C", str(primary), "checkout", "main"])
+    assert heal.returncode == 0, heal.stderr
+    assert _head_branch(primary) == "main"
+
+
+def test_interactive_tty_is_never_blocked(scratch_repo):
+    """A human at a terminal (TTY on stdout/stderr) keeps full control."""
+    primary = scratch_repo["primary"]
+
+    import pty
+
+    env = os.environ.copy()
+    env.pop(OVERRIDE_ENV, None)
+    master, slave = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            [GIT, "commit", "--allow-empty", "-m", "operator-commit"],
+            cwd=str(primary),
+            stdin=subprocess.DEVNULL,
+            stdout=slave,
+            stderr=slave,
+            env=env,
+        )
+        os.close(slave)
+        slave = -1
+        while True:
+            try:
+                if not os.read(master, 1024):
+                    break
+            except OSError:  # EIO: slave side closed
+                break
+        rc = proc.wait(timeout=30)
+    finally:
+        os.close(master)
+        if slave >= 0:
+            os.close(slave)
+
+    assert rc == 0, "interactive (TTY) operator action must not be blocked"
+
+
+# ---------------------------------------------------------------------------
+# normal worktree operations are unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_worktree_operations_unaffected(scratch_repo):
+    """Commits, detaches, and further worktree adds inside worktrees pass."""
+    primary = scratch_repo["primary"]
+    wt = _add_worktree(primary)
+
+    # commit on the worktree branch
+    (wt / "f").write_text("work\n", encoding="utf-8")
+    proc = _run(["commit", "-qam", "worktree commit"], cwd=wt)
+    assert proc.returncode == 0, proc.stderr
+
+    # detach inside the worktree (agents detach their own trees freely)
+    proc = _run(["checkout", "--detach", "HEAD"], cwd=wt)
+    assert proc.returncode == 0, proc.stderr
+
+    # back onto the branch
+    proc = _run(["checkout", "wt1-branch"], cwd=wt)
+    assert proc.returncode == 0, proc.stderr
+
+    # creating another worktree FROM the primary (the dispatch flow) still works
+    wt2 = primary.parent / "wt2"
+    proc = _run(["-C", str(primary), "worktree", "add", "-q", str(wt2), "-b", "wt2-branch"])
+    assert proc.returncode == 0, proc.stderr
+
+    # primary is still on main throughout
+    assert _head_branch(primary) == "main"
+
+
+def test_fetch_style_ref_updates_unaffected(scratch_repo, tmp_path):
+    """refs/remotes/* and FETCH_HEAD updates (the benign part of the incident) pass."""
+    primary = scratch_repo["primary"]
+    # Make the primary its own "remote" and fetch from a worktree.
+    wt = _add_worktree(primary)
+    proc = _run(["remote", "add", "origin", str(primary)], cwd=wt)
+    assert proc.returncode == 0, proc.stderr
+    proc = _run(["fetch", "-q", "origin"], cwd=wt)
+    assert proc.returncode == 0, proc.stderr
+    assert _head_branch(primary) == "main"
+
+
+# ---------------------------------------------------------------------------
+# post-checkout heal (wrong-branch primary self-repairs)
+# ---------------------------------------------------------------------------
+
+
+def test_branch_switch_in_primary_is_auto_healed(scratch_repo):
+    """checkout -b in the primary is allowed pre-flight (worktree-add is
+    indistinguishable) but the post-checkout heal returns it to main."""
+    primary = scratch_repo["primary"]
+
+    # The heal path needs scripts/guardrails (plus its scripts.common import)
+    # next to the hooks.
+    scripts_dst = primary / "scripts" / "guardrails"
+    scripts_dst.mkdir(parents=True)
+    (primary / "scripts" / "__init__.py").write_text("", encoding="utf-8")
+    (scripts_dst / "__init__.py").write_text("", encoding="utf-8")
+    common_dst = primary / "scripts" / "common"
+    common_dst.mkdir()
+    (common_dst / "__init__.py").write_text("", encoding="utf-8")
+    shutil.copy(REPO_ROOT / "scripts" / "common" / "git_context.py", common_dst)
+    for name in (
+        "assert_primary_on_main.py",
+        "worktree_containment.py",
+        "primary_post_checkout_heal.sh",
+    ):
+        shutil.copy(REPO_ROOT / "scripts" / "guardrails" / name, scripts_dst / name)
+
+    wt = _add_worktree(primary)
+
+    proc = _run(["-C", str(primary), "checkout", "-q", "-b", "evil"], cwd=wt)
+    assert proc.returncode == 0, proc.stderr
+
+    assert _head_branch(primary) == "main", (
+        "post-checkout heal must return a wrong-branch primary to main"
+    )


### PR DESCRIPTION
## Incident (2026-07-25)

A `cursor` dispatch worker, running inside its own worktree at `.worktrees/dispatch/cursor/rebase-5729`, reached OUT of its worktree and ran git commands against the primary checkout, leaving it detached. Worker\'s own words: *"Local origin/main may be stale. Pulling latest main from the primary checkout, then merging."* Primary reflog:

```
a8d9a8f949 HEAD@{0}: checkout: moving from main to FETCH_HEAD
ba468fdab8 HEAD@{1}: pull: Fast-forward
```

## Why every existing layer missed it (investigation of #5389 / #5396)

| Layer | What it actually protects | Why the cursor worker bypassed it |
|---|---|---|
| `agents_extensions/shared/hooks/guard-primary-checkout-write.py` | Claude Code PreToolUse (Bash/Write/Edit) — wired in `agents_extensions/shared/settings.json` | Only sees Claude-harness tool calls |
| same guard in `agents_extensions/codex/hooks.json` | Codex PreToolUse | Only sees Codex-harness tool calls |
| `scripts/agent_runtime/shims/git` (#4450) | any process with the shim dir on `PATH` | Worker ran the real git binary |
| `scripts/guardrails/primary_write_guard.py install-hooks` heal fragment | `.git/hooks/post-checkout` stay-on-main heal | **`core.hooksPath` is set to `.githooks`, which did not exist — so NO `.git/hooks/*` hook was running at all.** The #5389 fix was installed into a shadowed hooks directory. |

Per harness today: **claude** = guarded (PreToolUse), **codex** = guarded (PreToolUse), **gemini/cursor/agy/kimi/deepseek** = nothing at write time; git level = nothing (shadowed). The fleet — the ones with a reason to reach for `main` — was exactly the unguarded set.

## Fix: put the guard in git itself

`core.hooksPath=.githooks` is already set in the primary\'s config; this PR creates the tracked `.githooks/` directory it points at. A git hook binds every harness, every shell, and every `git -C <primary>` reach-across equally — no cooperation from the calling harness required.

- **`.githooks/reference-transaction`** (new): fires on every ref transaction; in the `prepared` state it vetoes, from non-interactive contexts without the override:
  - any update to `refs/heads/main|master` — commit/pull/`reset --hard`/`branch -f`/`update-ref` — from **any** worktree context;
  - any `HEAD` update whose new value is a raw commit (a **detach**) when the command targets the primary checkout (`git-dir == git-common-dir`). This is the exact `checkout: moving from main to FETCH_HEAD` incident class.
- **`.githooks/post-checkout`** (new): restores the LFS passthrough and makes the previously-shadowed #4857/#5389 stay-on-main heal actually live — a wrong-branch primary auto-heals to `main`.
- **`scripts/guardrails/assert_primary_on_main.py`**: the sanctioned `--heal` path carries the override for its own `checkout -B` / `pull --ff-only` subprocesses (they move `refs/heads/main` and would otherwise self-block when run non-interactively, e.g. from the post-checkout heal).

### Deliberate design decisions (empirically verified)

- `HEAD` symref retargets (`checkout -b`, `checkout <branch>`, `worktree add`) are **allowed** by reference-transaction: a `git worktree add` internal HEAD write is byte-for-byte indistinguishable from a branch switch inside the hook (same cwd, same git-dir, same `ref:refs/heads/<branch>` line), and worktree creation from the primary is the standard dispatch flow. Wrong-branch primaries are healed post-checkout instead.
- Blocking `refs/heads/main` moves covers commits directly on main in the primary from non-interactive contexts — which is already policy (agents never commit on the primary). The only in-repo main-mover is the heal script itself (now override-carrying).
- The hook fails open on internal errors and exits fast for uninteresting refs (fetch, stash, worktree-local branches).

### Operator contract (never silently block a human)

- An interactive terminal (stdout/stderr is a TTY) is always allowed.
- Scripted operator/service flows use the documented one-shot override: `LEARN_UK_ALLOW_PRIMARY_REF_WRITE=1 git <command>`. The block message names the variable. Docs: `docs/runbooks/primary-checkout-ref-guard.md`.

**Activation note:** the guard becomes live in each checkout once that checkout contains `.githooks/` — i.e. in the primary after it fast-forwards past this merge. Until then the primary remains protected only by the harness/shim layers.

## Tests

`tests/test_githooks_primary_ref_guard.py` — real git binary (agent shim filtered from PATH), scratch repo + linked worktree, hooks committed as tracked files:

- worker-style `git -C primary checkout <sha>` from a worktree → **refused**, primary stays on main;
- `git -C primary update-ref refs/heads/main …` from a worktree → **refused**;
- non-interactive commit on main in the primary → **refused**;
- override env var → operator action **succeeds**;
- TTY attached (pty) → **never blocked**;
- worktree commit/detach/branch ops, `worktree add` from primary, fetch → **unaffected**;
- `checkout -b` in the primary → **auto-healed** back to main by post-checkout.

## Verification

- `pytest tests/test_githooks_primary_ref_guard.py tests/test_assert_primary_on_main.py tests/test_primary_write_guard.py` — 17 passed
- `ruff check` on changed files — clean
- `bash -n` on both hooks — clean
- OPSEC lint — clean; `X-Agent` trailer lint — clean

Refs #5389, #5396. Not merged per dispatch instructions.

X-Agent: kimi/fix-guard-gap