### PR TITLE
fix(delegate): truthful write-path refusals + hermetic ownership ledger in tests

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2703,9 +2703,14 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 return 2
         else:
             if ownership.would_refuse or ownership.override_reason:
+                # Only report a conflict count when there ARE conflicts: an
+                # unprovable-disjointness refusal has none, and printing
+                # "conflicts=0" next to it reads as a guard bug (#5340-adjacent).
+                suffix = (
+                    f" (conflicts={len(ownership.conflicts)})" if ownership.conflicts else ""
+                )
                 print(
-                    f"⚠️  write-path ownership: {ownership.reason} "
-                    f"(conflicts={len(ownership.conflicts)})",
+                    f"⚠️  write-path ownership: {ownership.reason}{suffix}",
                     file=sys.stderr,
                 )
             if not ownership.admitted:

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -33,6 +33,30 @@ except ImportError:  # pragma: no cover - flat script path
 _REPO_ROOT = resolve_repo_root(Path(__file__), 2)
 DEFAULT_LEDGER_PATH = _REPO_ROOT / "batch_state" / "tasks" / "write-ownership.sqlite3"
 DEFAULT_TASK_STATE_DIR = _REPO_ROOT / "batch_state" / "tasks"
+
+LEDGER_ENV_VAR = "LEARN_UKRAINIAN_OWNERSHIP_LEDGER"
+TASK_STATE_ENV_VAR = "LEARN_UKRAINIAN_OWNERSHIP_TASK_STATE_DIR"
+
+
+def default_ledger_path() -> Path:
+    """Ledger location, resolved at CALL time so tests can redirect it.
+
+    Root cause this closes: the ledger was a module-level constant baked into
+    default arguments at import, so every process — including the test suite —
+    shared the live fleet ledger. Dispatch tests then admitted against whatever
+    real dispatches happened to be running and refused, i.e. they passed on an
+    idle machine and failed on a busy one.
+    """
+    override = (os.environ.get(LEDGER_ENV_VAR) or "").strip()
+    return Path(override) if override else DEFAULT_LEDGER_PATH
+
+
+def default_task_state_dir() -> Path:
+    """Task-state directory, resolved at call time (see :func:`default_ledger_path`)."""
+    override = (os.environ.get(TASK_STATE_ENV_VAR) or "").strip()
+    return Path(override) if override else DEFAULT_TASK_STATE_DIR
+
+
 # Admission uses the short-lived CLI PID until the worker PID is written.
 # Live-PID fast path only applies inside this grace window (seconds).
 ADMISSION_PID_GRACE_S = 180.0
@@ -143,6 +167,55 @@ def normalize_claim(raw: str) -> PathClaim:
     return PathClaim(raw=raw, kind=ClaimKind.FILE, norm=norm)
 
 
+def _peer_label(peer: dict[str, object]) -> str:
+    """Render one blocking peer as `task-id(pid N)` for operator-facing messages."""
+    pid = peer.get("other_pid")
+    task = str(peer.get("other_task_id") or "?")
+    return f"{task}(pid {pid})" if pid else task
+
+
+def refusal_message(
+    *,
+    conflicts: list[dict[str, object]],
+    unprovable_peers: list[dict[str, object]],
+    self_unprovable: bool,
+    unknown: list[PathClaim],
+) -> str:
+    """Explain a REFUSE so the operator can act on it.
+
+    Two very different conditions used to share the string "path ownership
+    conflict": a real overlap between declared paths, and an *unprovable*
+    admission where nobody overlaps but some active writer declared no paths at
+    all. The second one reported ``conflicts=0`` while refusing, which reads as
+    a guard bug and hides the fix (declare paths, or override deliberately).
+    """
+    if conflicts:
+        shown = ", ".join(
+            f"{_peer_label(c)} on {(c.get('other_claim') or {}).get('norm', '?')}"  # type: ignore[union-attr]
+            for c in conflicts[:3]
+        )
+        more = f" (+{len(conflicts) - 3} more)" if len(conflicts) > 3 else ""
+        return f"path ownership conflict (REFUSE): overlaps {shown}{more}"
+
+    parts: list[str] = []
+    if self_unprovable:
+        declared = ", ".join(repr(c.raw) for c in unknown[:3]) if unknown else "none declared"
+        parts.append(
+            f"this task declared no comparable --research-owned-path ({declared})"
+        )
+    if unprovable_peers:
+        peers = ", ".join(_peer_label(p) for p in unprovable_peers[:3])
+        more = f" (+{len(unprovable_peers) - 3} more)" if len(unprovable_peers) > 3 else ""
+        parts.append(f"active writer(s) with undeclared paths: {peers}{more}")
+    detail = "; ".join(parts) or "no comparable claims among active writers"
+    return (
+        f"cannot prove write-path disjointness (REFUSE): {detail}. "
+        "No actual path overlap was found. Fix by re-running the undeclared "
+        "dispatches with --research-owned-path, or pass "
+        "--allow-path-overlap '<why this is safe>'."
+    )
+
+
 def claims_conflict(a: PathClaim, b: PathClaim) -> bool:
     """Return True if two concrete claims intersect. UNKNOWN never proves overlap alone."""
     if a.kind == ClaimKind.UNKNOWN or b.kind == ClaimKind.UNKNOWN:
@@ -242,13 +315,15 @@ def _task_still_active(
 class OwnershipLedger:
     def __init__(
         self,
-        path: Path = DEFAULT_LEDGER_PATH,
+        path: Path | None = None,
         *,
-        task_state_dir: Path = DEFAULT_TASK_STATE_DIR,
+        task_state_dir: Path | None = None,
         mode: GuardMode | None = None,
     ) -> None:
-        self.path = Path(path)
-        self.task_state_dir = Path(task_state_dir)
+        self.path = Path(path) if path is not None else default_ledger_path()
+        self.task_state_dir = (
+            Path(task_state_dir) if task_state_dir is not None else default_task_state_dir()
+        )
         # Default follows env (REFUSE after #5645 soak). Explicit mode still wins.
         self.mode = mode if mode is not None else env_guard_mode()
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -473,12 +548,17 @@ class OwnershipLedger:
 
             # Missing/unknown claims cannot prove disjointness against an active writer.
             # Also: an active peer with UNKNOWN intent blocks proof of disjointness.
-            active_unknown = any(
-                other_claim.kind == ClaimKind.UNKNOWN for _, other_claim, _ in active
-            )
-            unprovable = bool(active) and (
-                not concrete or bool(unknown) or active_unknown or not claims
-            )
+            unprovable_peers = [
+                {
+                    "other_task_id": other_task,
+                    "other_pid": other_pid,
+                    "other_claim": other_claim.as_dict(),
+                }
+                for other_task, other_claim, other_pid in active
+                if other_claim.kind == ClaimKind.UNKNOWN
+            ]
+            self_unprovable = bool(active) and (not concrete or bool(unknown) or not claims)
+            unprovable = self_unprovable or (bool(active) and bool(unprovable_peers))
             would_refuse = bool(conflicts) or unprovable
 
             override = (allow_path_overlap or "").strip() or None
@@ -486,11 +566,19 @@ class OwnershipLedger:
                 would_refuse = False  # explicit override clears refuse intent for logging
 
             if would_refuse and self.mode == GuardMode.REFUSE and not override:
+                refusal_reason = refusal_message(
+                    conflicts=conflicts,
+                    unprovable_peers=unprovable_peers,
+                    self_unprovable=self_unprovable,
+                    unknown=unknown,
+                )
                 event = {
                     "task_id": task_id,
                     "conflicts": conflicts,
+                    "unprovable_peers": unprovable_peers,
                     "unknown": [c.as_dict() for c in unknown],
                     "caller": caller,
+                    "reason": refusal_reason,
                 }
                 conn.execute(
                     "INSERT INTO admission_events (ts, task_id, event, payload) VALUES (?,?,?,?)",
@@ -501,7 +589,7 @@ class OwnershipLedger:
                     admitted=False,
                     mode=self.mode,
                     would_refuse=True,
-                    reason="path ownership conflict (REFUSE)",
+                    reason=refusal_reason,
                     conflicts=conflicts,
                     claims=concrete,
                     unknown_claims=unknown,
@@ -571,8 +659,8 @@ def admit_write_paths(
     owned_paths: Sequence[str] | None,
     allow_path_overlap: str | None = None,
     pid: int | None = None,
-    ledger_path: Path = DEFAULT_LEDGER_PATH,
-    task_state_dir: Path = DEFAULT_TASK_STATE_DIR,
+    ledger_path: Path | None = None,
+    task_state_dir: Path | None = None,
     guard_mode: GuardMode | str | None = None,
 ) -> AdmissionResult:
     """Admit writable paths. ``guard_mode=None`` → :func:`env_guard_mode` (default REFUSE)."""
@@ -614,8 +702,8 @@ def update_write_claim_pid(
     task_id: str,
     new_pid: int,
     *,
-    ledger_path: Path = DEFAULT_LEDGER_PATH,
-    task_state_dir: Path = DEFAULT_TASK_STATE_DIR,
+    ledger_path: Path | None = None,
+    task_state_dir: Path | None = None,
 ) -> None:
     """Public helper: bind claim rows to the detached worker PID after Popen."""
     OwnershipLedger(ledger_path, task_state_dir=task_state_dir).update_claim_pid(

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -17,6 +17,7 @@ import os
 import posixpath
 import sqlite3
 import time
+import unicodedata
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -168,7 +169,9 @@ def normalize_claim(raw: str) -> PathClaim:
 
 
 _DISPLAY_LIMIT = 120
-_CONTROL_CHARS = {c: f"\\x{c:02x}" for c in range(0x20)} | {0x7F: "\\x7f"}
+# Cc control, Cf format (bidi overrides, zero-width joiners), Cs surrogate,
+# Co private use — none of these belong in a one-line operator message.
+_UNSAFE_UNICODE_CATEGORIES = frozenset({"Cc", "Cf", "Cs", "Co"})
 
 
 def sanitize_for_display(value: object, *, limit: int = _DISPLAY_LIMIT) -> str:
@@ -177,11 +180,21 @@ def sanitize_for_display(value: object, *, limit: int = _DISPLAY_LIMIT) -> str:
     Task ids and claim paths come from other processes, so they reach this
     message as untrusted text. Raw interpolation let a task id containing a
     newline or an ANSI escape forge extra operator-looking lines in the guard's
-    own output (CF review of #5804). Control characters are escaped rather than
-    dropped so the value stays recognisable, and the result is length-bounded.
+    own output (CF review of #5804).
+
+    Escaping only the ASCII control range would still let U+202E RIGHT-TO-LEFT
+    OVERRIDE visually reverse the rest of the line, so every Unicode
+    control/format code point is escaped — as an escape sequence rather than a
+    deletion, so the value stays recognisable — and the result is bounded.
     """
-    text = str(value)
-    escaped = text.translate(_CONTROL_CHARS)
+    out: list[str] = []
+    for ch in str(value):
+        if unicodedata.category(ch) in _UNSAFE_UNICODE_CATEGORIES:
+            point = ord(ch)
+            out.append(f"\\x{point:02x}" if point < 0x100 else f"\\u{point:04x}")
+        else:
+            out.append(ch)
+    escaped = "".join(out)
     if len(escaped) > limit:
         escaped = escaped[: limit - 1] + "…"
     return escaped

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -170,8 +170,12 @@ def normalize_claim(raw: str) -> PathClaim:
 
 _DISPLAY_LIMIT = 120
 # Cc control, Cf format (bidi overrides, zero-width joiners), Cs surrogate,
-# Co private use — none of these belong in a one-line operator message.
-_UNSAFE_UNICODE_CATEGORIES = frozenset({"Cc", "Cf", "Cs", "Co"})
+# Co private use — none of these belong in a one-line operator message. Zl/Zp
+# are U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR: not control
+# characters by category, but terminals and log viewers render them as line
+# breaks, so leaving them through kept the forged-line hole open (CF re-review
+# of #5804, F001).
+_UNSAFE_UNICODE_CATEGORIES = frozenset({"Cc", "Cf", "Cs", "Co", "Zl", "Zp"})
 
 
 def sanitize_for_display(value: object, *, limit: int = _DISPLAY_LIMIT) -> str:
@@ -187,17 +191,29 @@ def sanitize_for_display(value: object, *, limit: int = _DISPLAY_LIMIT) -> str:
     control/format code point is escaped — as an escape sequence rather than a
     deletion, so the value stays recognisable — and the result is bounded.
     """
-    out: list[str] = []
+    units: list[str] = []
     for ch in str(value):
         if unicodedata.category(ch) in _UNSAFE_UNICODE_CATEGORIES:
             point = ord(ch)
-            out.append(f"\\x{point:02x}" if point < 0x100 else f"\\u{point:04x}")
+            units.append(f"\\x{point:02x}" if point < 0x100 else f"\\u{point:04x}")
         else:
-            out.append(ch)
-    escaped = "".join(out)
-    if len(escaped) > limit:
-        escaped = escaped[: limit - 1] + "…"
-    return escaped
+            units.append(ch)
+
+    if sum(len(u) for u in units) <= limit:
+        return "".join(units)
+
+    # Truncate on escape-unit boundaries. Slicing the joined string could cut
+    # "‮" into a bare backslash, which is both misleading and a different
+    # string than the one that is actually blocking the operator (CF re-review
+    # of #5804, F002). One character of the budget is reserved for the ellipsis.
+    kept: list[str] = []
+    used = 0
+    for unit in units:
+        if used + len(unit) > limit - 1:
+            break
+        kept.append(unit)
+        used += len(unit)
+    return "".join(kept) + "…"
 
 
 def _peer_key(peer: dict[str, object]) -> tuple[str, object]:

--- a/scripts/guardrails/delegate_ownership.py
+++ b/scripts/guardrails/delegate_ownership.py
@@ -167,11 +167,48 @@ def normalize_claim(raw: str) -> PathClaim:
     return PathClaim(raw=raw, kind=ClaimKind.FILE, norm=norm)
 
 
+_DISPLAY_LIMIT = 120
+_CONTROL_CHARS = {c: f"\\x{c:02x}" for c in range(0x20)} | {0x7F: "\\x7f"}
+
+
+def sanitize_for_display(value: object, *, limit: int = _DISPLAY_LIMIT) -> str:
+    """Make a ledger-sourced string safe to print in an operator message.
+
+    Task ids and claim paths come from other processes, so they reach this
+    message as untrusted text. Raw interpolation let a task id containing a
+    newline or an ANSI escape forge extra operator-looking lines in the guard's
+    own output (CF review of #5804). Control characters are escaped rather than
+    dropped so the value stays recognisable, and the result is length-bounded.
+    """
+    text = str(value)
+    escaped = text.translate(_CONTROL_CHARS)
+    if len(escaped) > limit:
+        escaped = escaped[: limit - 1] + "…"
+    return escaped
+
+
+def _peer_key(peer: dict[str, object]) -> tuple[str, object]:
+    """Identity of a blocking peer: one task, one pid — NOT one claim row."""
+    return (str(peer.get("other_task_id") or "?"), peer.get("other_pid"))
+
+
 def _peer_label(peer: dict[str, object]) -> str:
     """Render one blocking peer as `task-id(pid N)` for operator-facing messages."""
     pid = peer.get("other_pid")
-    task = str(peer.get("other_task_id") or "?")
+    task = sanitize_for_display(peer.get("other_task_id") or "?")
     return f"{task}(pid {pid})" if pid else task
+
+
+def _dedupe_peers(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Collapse claim rows to distinct peers, preserving first-seen order.
+
+    A peer holding four claims is ONE blocking peer. Counting rows made the
+    message say "(+1 more)" about a single agent (CF review of #5804).
+    """
+    seen: dict[tuple[str, object], dict[str, object]] = {}
+    for row in rows:
+        seen.setdefault(_peer_key(row), row)
+    return list(seen.values())
 
 
 def refusal_message(
@@ -190,22 +227,46 @@ def refusal_message(
     a guard bug and hides the fix (declare paths, or override deliberately).
     """
     if conflicts:
+        # Group overlapping paths under the peer that holds them: N claim rows
+        # from one agent is one blocker, not N blockers.
+        by_peer: dict[tuple[str, object], list[str]] = {}
+        labels: dict[tuple[str, object], str] = {}
+        for row in conflicts:
+            key = _peer_key(row)
+            labels.setdefault(key, _peer_label(row))
+            claim = row.get("other_claim") or {}
+            norm = claim.get("norm", "?") if isinstance(claim, dict) else "?"
+            paths = by_peer.setdefault(key, [])
+            if norm not in paths:
+                paths.append(str(norm))
+        shown_keys = list(by_peer)[:3]
         shown = ", ".join(
-            f"{_peer_label(c)} on {(c.get('other_claim') or {}).get('norm', '?')}"  # type: ignore[union-attr]
-            for c in conflicts[:3]
+            f"{labels[key]} on "
+            + ", ".join(sanitize_for_display(p) for p in by_peer[key][:2])
+            + (
+                f" (+{len(by_peer[key]) - 2} more paths)"
+                if len(by_peer[key]) > 2
+                else ""
+            )
+            for key in shown_keys
         )
-        more = f" (+{len(conflicts) - 3} more)" if len(conflicts) > 3 else ""
+        more = f" (+{len(by_peer) - 3} more)" if len(by_peer) > 3 else ""
         return f"path ownership conflict (REFUSE): overlaps {shown}{more}"
 
     parts: list[str] = []
     if self_unprovable:
-        declared = ", ".join(repr(c.raw) for c in unknown[:3]) if unknown else "none declared"
+        declared = (
+            ", ".join(repr(sanitize_for_display(c.raw)) for c in unknown[:3])
+            if unknown
+            else "none declared"
+        )
         parts.append(
             f"this task declared no comparable --research-owned-path ({declared})"
         )
-    if unprovable_peers:
-        peers = ", ".join(_peer_label(p) for p in unprovable_peers[:3])
-        more = f" (+{len(unprovable_peers) - 3} more)" if len(unprovable_peers) > 3 else ""
+    distinct_peers = _dedupe_peers(unprovable_peers)
+    if distinct_peers:
+        peers = ", ".join(_peer_label(p) for p in distinct_peers[:3])
+        more = f" (+{len(distinct_peers) - 3} more)" if len(distinct_peers) > 3 else ""
         parts.append(f"active writer(s) with undeclared paths: {peers}{more}")
     detail = "; ".join(parts) or "no comparable claims among active writers"
     return (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,7 @@ def _isolate_llm_qg_runtime_stores(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_write_ownership_ledger(tmp_path, monkeypatch):
+def _isolate_write_ownership_ledger(tmp_path_factory, monkeypatch):
     """Every test gets its own write-path ownership ledger.
 
     Root cause (2026-07-25): the ledger path was a module constant baked into
@@ -109,9 +109,14 @@ def _isolate_write_ownership_ledger(tmp_path, monkeypatch):
     be running: eight of them failed on a busy machine and passed on an idle
     one, which is indistinguishable from flakiness and silently erodes the
     pre-push pytest signal. Tests that want the real ledger override this.
+
+    The directory comes from ``tmp_path_factory``, NOT from the test's own
+    ``tmp_path``: an autouse fixture that creates a subdirectory there breaks
+    every test asserting its ``tmp_path`` is empty. Caught in CI by
+    test_grok_envelope_failure_skips_forensics_when_unconfigured after the
+    first version of this fixture did exactly that.
     """
-    ledger_dir = tmp_path / "ownership"
-    ledger_dir.mkdir(exist_ok=True)
+    ledger_dir = tmp_path_factory.mktemp("write-ownership")
     monkeypatch.setenv("LEARN_UKRAINIAN_OWNERSHIP_LEDGER", str(ledger_dir / "write-ownership.sqlite3"))
     monkeypatch.setenv("LEARN_UKRAINIAN_OWNERSHIP_TASK_STATE_DIR", str(ledger_dir))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,23 @@ def _isolate_llm_qg_runtime_stores(tmp_path, monkeypatch):
     monkeypatch.setenv("LEARN_UKRAINIAN_LLM_QG_CIRCUIT", str(tmp_path / "llm_qg_live_circuit.json"))
 
 
+@pytest.fixture(autouse=True)
+def _isolate_write_ownership_ledger(tmp_path, monkeypatch):
+    """Every test gets its own write-path ownership ledger.
+
+    Root cause (2026-07-25): the ledger path was a module constant baked into
+    default arguments, so the suite admitted against the LIVE fleet ledger in
+    batch_state/. Dispatch tests then saw whatever real dispatches happened to
+    be running: eight of them failed on a busy machine and passed on an idle
+    one, which is indistinguishable from flakiness and silently erodes the
+    pre-push pytest signal. Tests that want the real ledger override this.
+    """
+    ledger_dir = tmp_path / "ownership"
+    ledger_dir.mkdir(exist_ok=True)
+    monkeypatch.setenv("LEARN_UKRAINIAN_OWNERSHIP_LEDGER", str(ledger_dir / "write-ownership.sqlite3"))
+    monkeypatch.setenv("LEARN_UKRAINIAN_OWNERSHIP_TASK_STATE_DIR", str(ledger_dir))
+
+
 # =============================================================================
 # MODULE TEMPLATES
 # =============================================================================

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -545,3 +545,82 @@ def test_ownership_ledger_default_mode_follows_env(
         OwnershipLedger(ledger, task_state_dir=state, mode=GuardMode.REFUSE).mode
         is GuardMode.REFUSE
     )
+
+
+def test_unprovable_refusal_names_peer_and_is_not_called_a_conflict(tmp_path: Path):
+    """A refusal with zero overlaps must not masquerade as a path conflict.
+
+    Regression: five live dispatches that were fired without
+    ``--research-owned-path`` blocked every subsequent write dispatch fleet-wide,
+    and the guard reported ``path ownership conflict ... (conflicts=0)`` — a
+    message that names no peer, offers no fix, and reads as a guard bug.
+    """
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    (state_dir / "undeclared.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    # Peer runs write-capable without declaring any owned path.
+    peer = admit_write_paths(
+        task_id="undeclared",
+        mode="workspace-write",
+        owned_paths=[],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    assert peer.admitted is True
+
+    # Our task declares one concrete file that overlaps nothing.
+    blocked = admit_write_paths(
+        task_id="mine",
+        mode="workspace-write",
+        owned_paths=["docs/plans/brand-new-file.md"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.REFUSE,
+    )
+    assert blocked.admitted is False
+    assert blocked.conflicts == []
+    reason = blocked.reason
+    assert "path ownership conflict" not in reason, reason
+    assert "cannot prove write-path disjointness" in reason, reason
+    assert "undeclared" in reason, reason  # the blocking peer is named
+    assert f"pid {pid}" in reason, reason
+    assert "--research-owned-path" in reason and "--allow-path-overlap" in reason, reason
+
+
+def test_real_conflict_refusal_still_reads_as_a_conflict(tmp_path: Path):
+    """The genuine-overlap message keeps its name and points at the shared path."""
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    (state_dir / "holder.json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+    admit_write_paths(
+        task_id="holder",
+        mode="workspace-write",
+        owned_paths=["scripts/shared.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+    )
+    blocked = admit_write_paths(
+        task_id="challenger",
+        mode="workspace-write",
+        owned_paths=["scripts/shared.py"],
+        pid=pid,
+        ledger_path=ledger,
+        task_state_dir=state_dir,
+        guard_mode=GuardMode.REFUSE,
+    )
+    assert blocked.admitted is False
+    assert blocked.conflicts
+    assert "path ownership conflict" in blocked.reason
+    assert "scripts/shared.py" in blocked.reason
+    assert "holder" in blocked.reason

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -14,6 +14,8 @@ from scripts.guardrails.delegate_ownership import (
     claims_conflict,
     env_guard_mode,
     normalize_claim,
+    refusal_message,
+    sanitize_for_display,
 )
 
 
@@ -624,3 +626,78 @@ def test_real_conflict_refusal_still_reads_as_a_conflict(tmp_path: Path):
     assert "path ownership conflict" in blocked.reason
     assert "scripts/shared.py" in blocked.reason
     assert "holder" in blocked.reason
+
+
+def test_refusal_message_escapes_untrusted_task_ids_and_paths():
+    """Ledger-sourced text is untrusted: it must not forge operator output.
+
+    CF review of #5804: a task id containing a newline printed a second line that
+    read as the guard itself speaking ("OPERATOR: override granted").
+    """
+    evil_task = "evil\n❌ OPERATOR: override granted"
+    evil_path = "scripts/a.py\x1b[31m\rSAFE TO MERGE"
+
+    unprovable = refusal_message(
+        conflicts=[],
+        unprovable_peers=[{"other_task_id": evil_task, "other_pid": 42}],
+        self_unprovable=False,
+        unknown=[],
+    )
+    conflict = refusal_message(
+        conflicts=[
+            {
+                "other_task_id": "peer",
+                "other_pid": 7,
+                "other_claim": {"raw": evil_path, "kind": "file", "norm": evil_path},
+            }
+        ],
+        unprovable_peers=[],
+        self_unprovable=False,
+        unknown=[],
+    )
+    for message in (unprovable, conflict):
+        assert "\n" not in message and "\r" not in message, repr(message)
+        assert "\x1b" not in message, repr(message)
+    assert "\\x0a" in unprovable  # escaped, not silently dropped
+    assert "\\x1b" in conflict and "\\x0d" in conflict
+
+    # Length-bounded so one absurd claim cannot bury the message.
+    assert len(sanitize_for_display("x" * 5000)) <= 120
+
+
+def test_refusal_message_counts_peers_not_claim_rows():
+    """One agent holding four claims is ONE blocker (CF review of #5804)."""
+    rows = [
+        {"other_task_id": "busy", "other_pid": 333, "other_claim": {"norm": "*"}}
+        for _ in range(4)
+    ]
+    message = refusal_message(
+        conflicts=[], unprovable_peers=rows, self_unprovable=False, unknown=[]
+    )
+    assert message.count("busy(pid 333)") == 1, message
+    assert "more" not in message.split("No actual path overlap")[0], message
+
+    # Four DISTINCT peers still truncate honestly at three.
+    distinct = [
+        {"other_task_id": f"peer{i}", "other_pid": 100 + i, "other_claim": {"norm": "*"}}
+        for i in range(4)
+    ]
+    many = refusal_message(
+        conflicts=[], unprovable_peers=distinct, self_unprovable=False, unknown=[]
+    )
+    assert "(+1 more)" in many, many
+
+    # Conflicts group paths under their peer instead of repeating the peer.
+    overlaps = [
+        {
+            "other_task_id": "one",
+            "other_pid": 777,
+            "other_claim": {"norm": f"scripts/f{i}.py"},
+        }
+        for i in range(4)
+    ]
+    conflict = refusal_message(
+        conflicts=overlaps, unprovable_peers=[], self_unprovable=False, unknown=[]
+    )
+    assert conflict.count("one(pid 777)") == 1, conflict
+    assert "(+2 more paths)" in conflict, conflict

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -664,6 +664,14 @@ def test_refusal_message_escapes_untrusted_task_ids_and_paths():
     # Length-bounded so one absurd claim cannot bury the message.
     assert len(sanitize_for_display("x" * 5000)) <= 120
 
+    # Beyond ASCII: a bidi override would visually reverse the rest of the line
+    # even though it is not a C0 control character.
+    bidi = sanitize_for_display("safe‮evil")
+    assert "‮" not in bidi and "\\u202e" in bidi, bidi
+    assert sanitize_for_display("zero​width").count("\\u200b") == 1
+    # Ordinary non-ASCII text must survive untouched — Ukrainian paths are normal.
+    assert sanitize_for_display("данні/слово.md") == "данні/слово.md"
+
 
 def test_refusal_message_counts_peers_not_claim_rows():
     """One agent holding four claims is ONE blocker (CF review of #5804)."""

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -740,6 +740,30 @@ def test_every_admission_reason_is_display_safe(tmp_path: Path):
             guard_mode=GuardMode.WARN,
         ),
     ]
+
+    # The same-task/different-live-PID race branch needs a SECOND live pid, or it
+    # is never entered — the reviewer noticed the first version of this test only
+    # claimed to cover it. The parent process is live and is not us.
+    other_live_pid = os.getppid()
+    race_state = tmp_path / "race"
+    race_state.mkdir()
+    race_ledger = tmp_path / "race.sqlite3"
+    (race_state / _safe_task_state_name(hostile)).with_suffix(".json").write_text(
+        json.dumps({"status": "running", "pid": other_live_pid}), encoding="utf-8"
+    )
+    admit_write_paths(
+        task_id=hostile, mode="workspace-write", owned_paths=[hostile],
+        pid=other_live_pid, ledger_path=race_ledger, task_state_dir=race_state,
+    )
+    for mode in (GuardMode.REFUSE, GuardMode.WARN):
+        raced = admit_write_paths(
+            task_id=hostile, mode="workspace-write", owned_paths=[hostile],
+            pid=pid, ledger_path=race_ledger, task_state_dir=race_state,
+            guard_mode=mode,
+        )
+        assert "pid" in raced.reason  # proves we entered the same-task race branch
+        assert str(other_live_pid) in raced.reason
+        results.append(raced)
     for result in results:
         bad = [c for c in result.reason if unicodedata.category(c) in unsafe]
         assert not bad, (result.reason, [hex(ord(c)) for c in bad])

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import json
 import os
 import re
+import unicodedata
 from pathlib import Path
 
 from scripts.guardrails.delegate_ownership import (
     ClaimKind,
     GuardMode,
     OwnershipLedger,
+    _safe_task_state_name,
     admit_write_paths,
     claims_conflict,
     env_guard_mode,
@@ -693,6 +695,58 @@ def test_sanitizer_escapes_unicode_line_separators():
             unknown=[],
         )
         assert sep not in message, repr(message)
+
+
+def test_every_admission_reason_is_display_safe(tmp_path: Path):
+    """INVARIANT: AdmissionResult.reason is safe to print, on every path.
+
+    delegate.py prints `ownership.reason` directly, so a reason built anywhere in
+    this module must never carry raw control or line-separator characters. Today
+    the non-refusal reasons interpolate only pids and mode names, and the refusal
+    reasons route through the sanitizer — this test is what keeps that true when
+    someone later adds a reason string with a task id in it.
+
+    (A cross-family reviewer suspected a hole here. There is none — the same-task
+    race reasons interpolate `other_pid` only, and delegate.py prints task ids via
+    `!r`, whose repr escapes LF/CR/NEL/U+2028/U+2029/ESC. This test pins both.)
+    """
+    hostile = "evil ❌ OPERATOR: all clearx\x1b[31m y\n"
+    unsafe = {"Cc", "Cf", "Cs", "Co", "Zl", "Zp"}
+    ledger = tmp_path / "own.sqlite3"
+    state_dir = tmp_path / "tasks"
+    state_dir.mkdir()
+    pid = os.getpid()
+    (state_dir / _safe_task_state_name(hostile)).with_suffix(".json").write_text(
+        json.dumps({"status": "running", "pid": pid}), encoding="utf-8"
+    )
+
+    results = [
+        admit_write_paths(
+            task_id=hostile, mode="read-only", owned_paths=[hostile],
+            ledger_path=ledger, task_state_dir=state_dir,
+        ),
+        admit_write_paths(
+            task_id=hostile, mode="workspace-write", owned_paths=[hostile],
+            pid=pid, ledger_path=ledger, task_state_dir=state_dir,
+        ),
+        admit_write_paths(
+            task_id="peer", mode="workspace-write", owned_paths=[hostile],
+            pid=pid, ledger_path=ledger, task_state_dir=state_dir,
+            guard_mode=GuardMode.REFUSE,
+        ),
+        admit_write_paths(
+            task_id="peer2", mode="workspace-write", owned_paths=[],
+            pid=pid, ledger_path=ledger, task_state_dir=state_dir,
+            guard_mode=GuardMode.WARN,
+        ),
+    ]
+    for result in results:
+        bad = [c for c in result.reason if unicodedata.category(c) in unsafe]
+        assert not bad, (result.reason, [hex(ord(c)) for c in bad])
+
+    # And the way delegate.py renders a task id is itself escaping.
+    rendered = f"task_id={hostile!r}"
+    assert "\n" not in rendered and " " not in rendered and "\x1b" not in rendered
 
 
 def test_sanitizer_never_truncates_mid_escape():

--- a/tests/test_delegate_ownership.py
+++ b/tests/test_delegate_ownership.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 
 from scripts.guardrails.delegate_ownership import (
@@ -666,11 +667,58 @@ def test_refusal_message_escapes_untrusted_task_ids_and_paths():
 
     # Beyond ASCII: a bidi override would visually reverse the rest of the line
     # even though it is not a C0 control character.
-    bidi = sanitize_for_display("safe‮evil")
-    assert "‮" not in bidi and "\\u202e" in bidi, bidi
-    assert sanitize_for_display("zero​width").count("\\u200b") == 1
+    bidi = sanitize_for_display("safe\u202eevil")
+    assert "\u202e" not in bidi and "\\u202e" in bidi, bidi
+    assert sanitize_for_display("zero\u200bwidth").count("\\u200b") == 1
     # Ordinary non-ASCII text must survive untouched — Ukrainian paths are normal.
     assert sanitize_for_display("данні/слово.md") == "данні/слово.md"
+
+
+def test_sanitizer_escapes_unicode_line_separators():
+    """U+2028/U+2029 are not control CATEGORIES but do render as line breaks.
+
+    CF re-review of #5804 (F001): escaping only Cc/Cf/Cs/Co left the forged-line
+    hole open for a task id carrying a LINE SEPARATOR.
+    """
+    for sep, code in (("\u2028", "\\u2028"), ("\u2029", "\\u2029")):
+        rendered = sanitize_for_display(f"before{sep}after")
+        assert sep not in rendered, repr(rendered)
+        assert code in rendered, repr(rendered)
+        message = refusal_message(
+            conflicts=[],
+            unprovable_peers=[
+                {"other_task_id": f"evil{sep}❌ OPERATOR: all clear", "other_pid": 9}
+            ],
+            self_unprovable=False,
+            unknown=[],
+        )
+        assert sep not in message, repr(message)
+
+
+def test_sanitizer_never_truncates_mid_escape():
+    """The length bound must cut between escape units, not inside one.
+
+    CF re-review of #5804 (F002): slicing the joined string turned a trailing
+    "\\u202e" into a lone backslash — a value the operator cannot match against
+    anything real.
+    """
+    limit = 20
+    # A bidi override lands exactly on the boundary: its 6-char escape cannot fit.
+    value = "x" * (limit - 2) + "\u202e" + "tail"
+    rendered = sanitize_for_display(value, limit=limit)
+    assert len(rendered) <= limit, (len(rendered), rendered)
+    assert rendered.endswith("…")
+    body = rendered[:-1]
+    assert not body.endswith("\\"), rendered
+    # Any backslash still present must head a COMPLETE escape unit.
+    for idx, ch in enumerate(body):
+        if ch == "\\":
+            tail = body[idx:]
+            assert re.match(r"\\x[0-9a-f]{2}|\\u[0-9a-f]{4}", tail), rendered
+
+    # Degenerate budget: a single unit wider than the whole limit yields only
+    # the ellipsis rather than a corrupted fragment.
+    assert sanitize_for_display("\u202e", limit=3) == "…"
 
 
 def test_refusal_message_counts_peers_not_claim_rows():


### PR DESCRIPTION
Two defects in the write-path admission guard, found while it blocked a docs-only atlas dispatch three times in a row.

## 1. A refusal with zero conflicts called itself a conflict

The guard refuses in two different situations and used one sentence for both: `path ownership conflict (REFUSE)`.

The second situation has no conflict. Any live write dispatch fired *without* `--research-owned-path` reserves an UNKNOWN `*` sentinel; after that the guard cannot prove any later writer is disjoint, so it refuses everyone — while printing `conflicts=0`. That message names no peer, no path, and no way forward, so it reads as a guard bug rather than a real admission decision.

Before:
```
⚠️  write-path ownership: path ownership conflict (REFUSE) (conflicts=0)
```
After:
```
⚠️  write-path ownership: cannot prove write-path disjointness (REFUSE): active writer(s)
    with undeclared paths: fix-guard-gap(pid 86169), rereview-5783(pid 80989).
    No actual path overlap was found. Fix by re-running the undeclared dispatches with
    --research-owned-path, or pass --allow-path-overlap '<why this is safe>'.
```
Genuine overlaps keep the conflict wording and now name the shared path. The refusal event records the blocking peers. **Policy is unchanged** — same admissions, same refusals, still fail-closed.

## 2. The test suite was admitting against the live fleet ledger

Eight tests in `tests/test_delegate.py` failed here and pass on an idle machine. Not flaky — they read production state: the ledger path was a module constant baked into default arguments at import, so tests admitted against the real `batch_state` ledger and saw whatever the fleet was running.

Ledger and task-state dir now resolve at call time behind `LEARN_UKRAINIAN_OWNERSHIP_LEDGER` / `..._TASK_STATE_DIR`, with an autouse fixture giving each test its own — the same pattern already used for the llm_qg stores after an identical incident on 2026-07-07.

`tests/test_delegate*.py`: **8 failed / 182 passed → 190 passed**, fleet still busy.

## For the reviewer — a policy question I did not decide

One dispatch fired without owned paths blocks *every* later write dispatch fleet-wide until it exits. Fail-closed is defensible, but the practical effect is that the common case (no declared paths) becomes a global lock. I only made the refusal explain itself; whether the policy should soften (e.g. sentinel peers block only unprovable claimants, not concrete disjoint ones) is a design call I'd like a second opinion on rather than change unilaterally.

## Unrelated, noticed in passing

`tests/test_research_registry_p4.py::test_strict_adoption_gate_runs_as_bare_script` hardcodes `.venv/bin/python` relative to the checkout, so it fails in any worktree. Pre-existing on main, untouched here.

## Verification
- `tests/test_delegate*.py` — 190 passed
- `tests/test_dispatch.py tests/test_git_cleanup_router.py tests/test_agent_runtime.py` — 262 passed
- `ruff check` clean on all changed files
- Refusal text confirmed by replaying the exact five live peers that caused the original block