### PR TITLE
feat(delegate): primary-integrity watchdog — detect drift, repair only when safe (#5803 follow-up)

### DIFF
--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -660,6 +660,37 @@ def _self_symlink_canary() -> bool:
     return ok
 
 
+def _primary_integrity_canary() -> bool:
+    """Detection + conservative repair canary for primary-checkout drift.
+
+    #5803 follow-up: a worker detached the primary checkout (`checkout: moving
+    from main to FETCH_HEAD`). Git-layer prevention was proven impossible
+    against a same-UID process (design panel: gpt-5.6-sol + agy), so this
+    canary DETECTS and repairs ONLY detached+clean+idle drift; anything else
+    (dirty tree, op in progress, running dispatch, main moved unexpectedly)
+    alerts and preserves evidence without touching the human's checkout.
+    Never raises: the canary must not break health collection.
+    """
+    try:
+        from scripts.audit.check_primary_integrity import (  # noqa: PLC0415 — script-path fallback
+            check_primary_integrity,
+        )
+    except ImportError:  # path-flavoured import for test/script contexts
+        from audit.check_primary_integrity import check_primary_integrity  # noqa: PLC0415 — script-path fallback
+    try:
+        ok, message = check_primary_integrity(
+            PROJECT_ROOT,
+            fix=True,
+            tasks_dir=PROJECT_ROOT / "batch_state" / "tasks",
+        )
+    except Exception:
+        logger.exception("primary-integrity canary failed to run")
+        return True  # fail-open: don't raise a false alarm on canary error
+    if not ok or "repaired" in message:
+        logger.warning("primary-integrity canary: %s", message)
+    return ok
+
+
 def _collect_health_orient_data() -> dict:
     return {
         "api": True,
@@ -668,6 +699,7 @@ def _collect_health_orient_data() -> dict:
         "message_broker": _readable_file(MESSAGE_DB),
         "git_core_bare_ok": _core_bare_canary(),
         "node_modules_symlinks_ok": _self_symlink_canary(),
+        "primary_integrity_ok": _primary_integrity_canary(),
     }
 
 

--- a/scripts/api/preload.py
+++ b/scripts/api/preload.py
@@ -41,6 +41,8 @@ PRELOAD_MODULES = [
     "audit.check_core_bare",
     "scripts.audit.check_self_symlinks",
     "audit.check_self_symlinks",
+    "scripts.audit.check_primary_integrity",
+    "audit.check_primary_integrity",
     "scripts.build.phase_constants",
     "agent_runtime.adapters.gemini",
     "research_quality",

--- a/scripts/audit/check_primary_integrity.py
+++ b/scripts/audit/check_primary_integrity.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Primary-checkout integrity watchdog: DETECT drift, repair ONLY when safe.
+
+Follow-up to #5803 / #5389 / #5396. A dispatched worker ran git against the
+PRIMARY checkout and left it detached (``checkout: moving from main to
+FETCH_HEAD``) because it believed local ``origin/main`` was stale and the
+primary was the nearest fresh copy. PR #5803 tried git-level prevention via a
+``reference-transaction`` hook; cross-family review bypassed it with three live
+commands, and a two-seat design panel (gpt-5.6-sol, agy) concluded git-layer
+enforcement against a same-UID process is categorically impossible.
+
+So this module is **detection + conservative repair**, not prevention:
+
+- DETECT: HEAD not symbolically attached to ``refs/heads/main`` (detached or
+  wrong branch), git operation in progress (merge/rebase/bisect/cherry-pick/
+  revert state dirs, ``index.lock``), and working-tree cleanliness.
+- RECORD: every detection appends a JSONL event with HEAD/main SHAs, a reflog
+  excerpt, dirty detail, and the dispatches running at the time — enough to
+  identify the likely offending actor.
+- REPAIR only when ALL of: HEAD detached, tree demonstrably clean, no
+  operation in progress, no dispatch running, and ``main`` has NOT moved since
+  the drift was first recorded (baseline). Re-attach is ``git symbolic-ref``
+  when HEAD already equals main's tip (zero working-tree effect) or a plain
+  ``git checkout main`` on a clean tree (no committed or uncommitted state can
+  be lost either way).
+- NEVER touch a DIRTY tree, an in-progress operation, or a ``main`` that moved
+  unexpectedly: ALERT and preserve evidence instead. A human may be working in
+  the primary checkout — never blindly reset it (advisor directive).
+
+Usage::
+
+    python scripts/audit/check_primary_integrity.py          # check only
+    python scripts/audit/check_primary_integrity.py --fix    # repair when safe
+
+Wired into: ``cmd_dispatch`` pre-dispatch gate, ``_run_worker`` post-exit
+sweep (both in ``scripts/delegate.py``), and the Monitor API health-orient
+canary (``scripts/api/main.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Git commit hooks inject GIT_DIR / GIT_INDEX_FILE / etc. into the environment.
+# Integrity checks must not inherit those or they inspect the outer repo, not
+# the fixture / --repo path under test. Same scrub list as check_core_bare.
+_GIT_REDIRECT_KEYS = frozenset(
+    {
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_PREFIX",
+        "GIT_NAMESPACE",
+    }
+)
+
+# Git state markers that mean an operation is in progress in the primary.
+_OP_STATE_MARKERS = (
+    "MERGE_HEAD",
+    "CHERRY_PICK_HEAD",
+    "REVERT_HEAD",
+    "BISECT_LOG",
+    "rebase-merge",
+    "rebase-apply",
+)
+
+_HEALTHY_BRANCHES = ("main", "master")
+
+
+def _clean_git_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _GIT_REDIRECT_KEYS}
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_git_env(),
+        timeout=60,
+    )
+
+
+def _resolve_main_root(repo: Path) -> Path:
+    """Resolve the primary checkout root that owns the shared .git store."""
+    try:
+        from scripts.guardrails.worktree_containment import resolve_main_root
+    except ImportError:  # path-flavoured import for test/script contexts
+        # Invoked as a file path (python scripts/audit/...py): sys.path[0] is
+        # the script's own directory, so neither `scripts.` nor `guardrails.`
+        # resolves until the repo root is on sys.path.
+        _repo_candidate = Path(__file__).resolve().parents[2]
+        if str(_repo_candidate) not in sys.path:
+            sys.path.insert(0, str(_repo_candidate))
+        try:
+            from scripts.guardrails.worktree_containment import resolve_main_root
+        except ImportError:
+            try:
+                from guardrails.worktree_containment import resolve_main_root
+            except ImportError:
+                resolve_main_root = None  # type: ignore[assignment]
+    if resolve_main_root is not None:
+        try:
+            return resolve_main_root(repo)
+        except Exception:
+            pass
+    # Structural fallback. A plain checkout has a .git DIRECTORY; a linked
+    # worktree has a .git FILE pointing at <primary>/.git/worktrees/<name> —
+    # follow it so a worktree is never mistaken for the primary.
+    git_path = repo / ".git"
+    if git_path.is_file():
+        try:
+            first = git_path.read_text(encoding="utf-8").splitlines()[0]
+            if first.startswith("gitdir:"):
+                git_dir = Path(first.split(":", 1)[1].strip())
+                if not git_dir.is_absolute():
+                    git_dir = repo / git_dir
+                if git_dir.parent.name == "worktrees" and git_dir.parent.parent.name == ".git":
+                    return git_dir.parent.parent.parent
+        except (IndexError, OSError):
+            pass
+    return repo
+
+
+def _git_dir(main_root: Path) -> Path:
+    proc = _git(main_root, "rev-parse", "--git-dir")
+    if proc.returncode == 0:
+        raw = Path(proc.stdout.strip())
+        return raw if raw.is_absolute() else (main_root / raw).resolve()
+    return main_root / ".git"
+
+
+def _head_state(main_root: Path) -> dict[str, Any]:
+    """HEAD attachment state: symbolic target (or None) plus the commit SHA."""
+    sym = _git(main_root, "symbolic-ref", "-q", "HEAD")
+    attached_to = sym.stdout.strip() if sym.returncode == 0 else None
+    sha_proc = _git(main_root, "rev-parse", "HEAD")
+    head_sha = sha_proc.stdout.strip() if sha_proc.returncode == 0 else None
+    return {"attached_to": attached_to, "head_sha": head_sha}
+
+
+def _branch_sha(main_root: Path, branch: str) -> str | None:
+    proc = _git(main_root, "rev-parse", "--verify", f"refs/heads/{branch}")
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def _op_in_progress(main_root: Path) -> list[str]:
+    git_dir = _git_dir(main_root)
+    found = [name for name in _OP_STATE_MARKERS if (git_dir / name).exists()]
+    if (git_dir / "index.lock").exists():
+        found.append("index.lock")
+    return found
+
+
+def _dirty_entries(main_root: Path) -> list[str] | None:
+    """Porcelain dirty entries; None when cleanliness cannot be determined."""
+    proc = _git(main_root, "status", "--porcelain=v1", "--untracked-files=all")
+    if proc.returncode != 0:
+        return None
+    return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _reflog_excerpt(main_root: Path, *, lines: int = 8) -> list[str]:
+    proc = _git(main_root, "reflog", "-n", str(lines), "--date=iso")
+    if proc.returncode != 0:
+        return []
+    return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _running_dispatches(tasks_dir: Path | None) -> list[dict[str, Any]]:
+    """Dispatch tasks whose state says running/spawning with a live PID."""
+    if tasks_dir is None or not tasks_dir.is_dir():
+        return []
+    running: list[dict[str, Any]] = []
+    for path in sorted(tasks_dir.glob("*.json")):
+        try:
+            state = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if state.get("status") not in ("running", "spawning"):
+            continue
+        pid = state.get("pid")
+        if pid and _pid_alive(int(pid)):
+            running.append(
+                {
+                    "task_id": state.get("task_id") or path.stem,
+                    "agent": state.get("agent"),
+                    "pid": pid,
+                    "status": state.get("status"),
+                }
+            )
+    return running
+
+
+def _state_dir(main_root: Path, state_dir: Path | None) -> Path:
+    # data/telemetry/ is gitignored local runtime state (never committed).
+    return state_dir or (main_root / "data" / "telemetry" / "primary-integrity")
+
+
+def _load_state(state_dir: Path) -> dict[str, Any]:
+    path = state_dir / "state.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_state(state_dir: Path, state: dict[str, Any]) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    tmp = state_dir / f"state.json.tmp.{os.getpid()}"
+    tmp.write_text(json.dumps(state, indent=2, default=str))
+    os.replace(tmp, state_dir / "state.json")
+
+
+def _append_event(state_dir: Path, event: str, **fields: Any) -> None:
+    payload = {"ts": datetime.now(UTC).isoformat(), "event": event, **fields}
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        with open(state_dir / "events.jsonl", "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(payload, ensure_ascii=False, default=str) + "\n")
+    except OSError as exc:
+        print(
+            f"[primary-integrity] WARNING: failed to log event: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+
+
+def _repair(main_root: Path, *, head_sha: str | None, main_sha: str) -> tuple[bool, str]:
+    """Re-attach HEAD to main. Caller guarantees clean tree + idle + no dispatch."""
+    if head_sha == main_sha:
+        # HEAD already sits on main's tip: a pure symbolic-ref flip with ZERO
+        # working-tree effect — the safest possible repair.
+        proc = _git(main_root, "symbolic-ref", "HEAD", "refs/heads/main")
+        if proc.returncode != 0:
+            return False, f"git symbolic-ref HEAD refs/heads/main failed: {proc.stderr.strip()}"
+        return True, f"re-attached HEAD to main via symbolic-ref (unchanged tip {main_sha[:12]})"
+    # Clean tree at a different commit: checkout cannot lose committed state
+    # and refuses rather than clobbering conflicting untracked files.
+    proc = _git(main_root, "checkout", "main")
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        return False, f"git checkout main failed: {detail}"
+    return True, f"checked out main from detached {str(head_sha)[:12]} (clean tree, no data loss)"
+
+
+def check_primary_integrity(
+    repo: Path,
+    *,
+    fix: bool = False,
+    tasks_dir: Path | None = None,
+    state_dir: Path | None = None,
+) -> tuple[bool, str]:
+    """Check (and conservatively repair) primary-checkout attachment to main.
+
+    Returns ``(ok, message)``. ``ok`` is True when the primary is on main (or
+    master), or when drift was repaired. ``ok`` is False for unrepaired drift —
+    dirty tree, operation in progress, running dispatch, unexpected main
+    movement, or ``fix`` not requested. Never mutates anything except the
+    watchdog's own state/log unless the full repair gate passes.
+    """
+    main_root = _resolve_main_root(Path(repo))
+    sdir = _state_dir(main_root, state_dir)
+    state = _load_state(sdir)
+
+    head = _head_state(main_root)
+    attached_to = head["attached_to"]
+    head_sha = head["head_sha"]
+
+    if attached_to is not None:
+        branch = attached_to.removeprefix("refs/heads/")
+        if not branch:
+            # rc 0 with empty stdout is not something real git produces (it
+            # shows up when subprocess.run is stubbed in tests). No positive
+            # evidence of drift — fail open rather than grounding the fleet
+            # on an inconclusive read.
+            return True, "HEAD symbolic-ref inconclusive (empty) — no drift evidence"
+        if branch in _HEALTHY_BRANCHES:
+            if state.get("drift") is not None:
+                state["drift"] = None
+            state["healthy_main_sha"] = _branch_sha(main_root, branch)
+            _save_state(sdir, state)
+            return True, f"primary on {branch} ({main_root})"
+        # Wrong branch: not the detached-HEAD case this watchdog repairs.
+        _append_event(
+            sdir,
+            "primary_drift_alert",
+            reason="wrong_branch",
+            branch=branch,
+            head_sha=head_sha,
+            main_root=str(main_root),
+            reflog=_reflog_excerpt(main_root),
+        )
+        return False, (
+            f"ALERT: primary checkout is on branch {branch!r}, not main — "
+            "refusing to switch a human checkout; inspect and `git checkout main` manually"
+        )
+
+    # --- HEAD is detached: gather full evidence BEFORE any decision. ---
+    main_sha = _branch_sha(main_root, "main")
+    ops = _op_in_progress(main_root)
+    dirty = _dirty_entries(main_root)
+    running = _running_dispatches(tasks_dir)
+    evidence = {
+        "head_sha": head_sha,
+        "main_sha": main_sha,
+        "ops_in_progress": ops,
+        "dirty_entries": dirty,
+        "running_dispatches": running,
+        "reflog": _reflog_excerpt(main_root),
+        "main_root": str(main_root),
+    }
+    _append_event(sdir, "primary_drift_detected", **evidence)
+
+    def _alert(reason: str) -> tuple[bool, str]:
+        _append_event(sdir, "primary_drift_alert", reason=reason, **evidence)
+        return False, (
+            f"ALERT: primary checkout DETACHED at {str(head_sha)[:12]} — {reason}. "
+            "NOT touched; evidence preserved under "
+            f"{sdir}/events.jsonl. A human may be working there — inspect manually."
+        )
+
+    # Tree dirty (or cleanliness unknown): never touch a human checkout.
+    if dirty is None:
+        return _alert("working-tree cleanliness could not be determined")
+    if dirty:
+        return _alert(f"working tree is DIRTY ({len(dirty)} entr{'y' if len(dirty) == 1 else 'ies'})")
+    # Operation in progress: merge/rebase/bisect/cherry-pick/revert/index.lock.
+    if ops:
+        return _alert(f"git operation in progress ({', '.join(ops)})")
+    # A running dispatch may legitimately be mid-operation on the shared refs;
+    # defer repair rather than racing it. Never kill the running dispatch.
+    if running:
+        ids = ", ".join(str(d["task_id"]) for d in running)
+        return _alert(f"dispatch(es) still running ({ids}) — repair deferred")
+    # main must exist to re-attach to.
+    if main_sha is None:
+        return _alert("refs/heads/main does not exist")
+
+    # Main-movement baseline: the first sighting of a drift episode records
+    # where main was. Repair is allowed only once main has been observed
+    # STABLE across two checks — if it moved while HEAD was detached, that is
+    # unexpected primary-side activity: alert and preserve, do not touch.
+    drift = state.get("drift")
+    if not drift or drift.get("head_sha") != head_sha:
+        state["drift"] = {
+            "first_seen": datetime.now(UTC).isoformat(),
+            "head_sha": head_sha,
+            "main_sha": main_sha,
+        }
+        _save_state(sdir, state)
+        return _alert("drift baseline recorded; awaiting a stable-main confirmation pass")
+    if drift.get("main_sha") != main_sha:
+        state["drift"] = {
+            "first_seen": datetime.now(UTC).isoformat(),
+            "head_sha": head_sha,
+            "main_sha": main_sha,
+        }
+        _save_state(sdir, state)
+        return _alert(
+            f"main moved unexpectedly while detached "
+            f"({str(drift.get('main_sha'))[:12]} → {main_sha[:12]})"
+        )
+
+    if not fix:
+        return False, (
+            f"primary DETACHED at {str(head_sha)[:12]} (clean, idle, main stable) — "
+            "repairable; re-run with --fix to re-attach HEAD to main"
+        )
+
+    ok, detail = _repair(main_root, head_sha=head_sha, main_sha=main_sha)
+    if not ok:
+        return _alert(f"repair attempted but failed safely: {detail}")
+    state["drift"] = None
+    state["healthy_main_sha"] = main_sha
+    _save_state(sdir, state)
+    _append_event(sdir, "primary_drift_repaired", detail=detail, **evidence)
+    return True, f"repaired: {detail}"
+
+
+def worktree_origin_points_at_remote(worktree: Path) -> tuple[bool, str]:
+    """Verify a dispatch worktree's ``origin`` is the canonical REMOTE, not a
+    local filesystem path to the primary checkout (#5803 root cause: the
+    worker treated the primary as the nearest fresh copy of main).
+
+    Returns ``(ok, message)``. ``ok`` is False when origin is unset or is a
+    local path — in which case fetches silently bind to the primary and the
+    worker has every reason to go poke it.
+    """
+    proc = _git(Path(worktree), "config", "--get", "remote.origin.url")
+    url = proc.stdout.strip() if proc.returncode == 0 else ""
+    if not url:
+        return False, "remote.origin.url is not set — fetches cannot reach the canonical remote"
+    # Local path forms: /abs/path, ../rel/path, file:// URLs.
+    if url.startswith(("/", ".", "file://")) or ("://" not in url and "@" not in url):
+        return False, (
+            f"remote.origin.url resolves to a LOCAL path ({url!r}) — fetches would bind to "
+            "the primary checkout instead of the canonical remote; point it at "
+            "github.com:learn-ukrainian/learn-ukrainian.github.io"
+        )
+    return True, f"origin → {url}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect (and conservatively repair) primary-checkout drift (#5803 follow-up).",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="re-attach HEAD to main ONLY when detached + clean + idle + no dispatch + stable main",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="suppress the OK message (alerts and repairs still print)",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repo path to check (default: this project root)",
+    )
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        default=None,
+        help="dispatch tasks dir for the running-dispatch gate (default: <root>/batch_state/tasks)",
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=None,
+        help="watchdog state/log dir (default: <main_root>/data/telemetry/primary-integrity)",
+    )
+    args = parser.parse_args(argv)
+
+    tasks_dir = args.tasks_dir
+    if tasks_dir is None:
+        try:
+            tasks_dir = _resolve_main_root(args.repo) / "batch_state" / "tasks"
+        except Exception:
+            tasks_dir = None
+
+    ok, message = check_primary_integrity(
+        args.repo,
+        fix=args.fix,
+        tasks_dir=tasks_dir,
+        state_dir=args.state_dir,
+    )
+    if not ok:
+        print(f"❌ {message}", file=sys.stderr)
+        return 1
+    if "repaired" in message:
+        print(f"⚠️  {message}", file=sys.stderr)
+    elif not args.quiet:
+        print(f"✅ {message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -638,6 +638,25 @@ def _is_verified_added_worktree(path: Path) -> bool:
     return False
 
 
+def _apply_worktree_git_ceiling(worker_env: dict[str, str], worktree_path: Path) -> None:
+    """Pin GIT_CEILING_DIRECTORIES at the worktree's PARENT (#5803 follow-up).
+
+    Damage reduction, NOT isolation: stops git repo discovery at the dispatch
+    parent dir so a broken/missing worktree .git pointer can never bind the
+    worker to the PRIMARY checkout via upward traversal. The ceiling must be
+    the parent — a ceiling at the worktree root itself excludes the root from
+    the discovery walk and breaks git from subdirectories (verified
+    2026-07-25). Linked worktrees resolve their own .git file at the root and
+    share the git control plane, so normal ops (subdirs, fetch, commit) are
+    unaffected.
+    """
+    ceiling = str(worktree_path.parent)
+    existing_ceiling = worker_env.get("GIT_CEILING_DIRECTORIES")
+    worker_env["GIT_CEILING_DIRECTORIES"] = (
+        f"{existing_ceiling}{os.pathsep}{ceiling}" if existing_ceiling else ceiling
+    )
+
+
 def _resolve_write_cwd_error(
     *,
     mode: str,
@@ -754,6 +773,52 @@ def _resolve_dirty_primary_checkout_error(*, mode: str) -> str | None:
         f"{extra_diagnostic}"
         "   Clean/stash the primary checkout, or keep only gitignored local "
         "runtime state, then retry."
+    )
+
+
+def _resolve_primary_integrity_error(*, mode: str) -> str | None:
+    """Block NEW write-capable dispatches while the primary checkout is drifted.
+
+    #5803 follow-up: a worker detached the primary (`checkout: moving from main
+    to FETCH_HEAD`) and every worktree branched afterwards would inherit a
+    wrong base. The watchdog repairs detached+clean+idle drift conservatively
+    and reports anything else as unrepaired — in which case new dispatches must
+    stop (running ones are never killed). Read-only dispatches stay allowed for
+    preflight and diagnosis, same contract as the dirty-primary guard.
+    """
+    if mode not in _WRITE_CAPABLE_MODES:
+        return None
+
+    try:
+        try:
+            from scripts.audit.check_primary_integrity import check_primary_integrity
+        except ImportError:  # path-flavoured import for test/script contexts
+            from audit.check_primary_integrity import check_primary_integrity
+
+        ok, message = check_primary_integrity(_REPO_ROOT, fix=True, tasks_dir=_TASKS_DIR)
+    except Exception as exc:
+        print(
+            f"⚠️  primary-integrity watchdog errored ({type(exc).__name__}: {exc}); "
+            "proceeding — the health-poll canary will surface persistent failures",
+            file=sys.stderr,
+        )
+        return None
+
+    if ok:
+        if "repaired" in message:
+            _append_dispatch_event("primary_integrity_repaired_pre_dispatch", detail=message)
+        return None
+
+    return (
+        "❌ primary checkout drift is UNREPAIRED; refusing to start a new "
+        "write-capable dispatch (it would branch from a wrong base). Running "
+        "dispatches are not touched.\n"
+        f"   watchdog: {message}\n"
+        "   The first detection only records a baseline — if the drift is "
+        "detached+clean+idle and main is stable, simply retry the dispatch and "
+        "the watchdog re-attaches HEAD automatically. Otherwise inspect the "
+        "primary checkout manually; evidence is under "
+        "data/telemetry/primary-integrity/events.jsonl."
     )
 
 
@@ -1906,13 +1971,20 @@ def _ensure_worktree(
         if _fetch_base(base):
             worktree_base_ref = origin_ref
         else:
-            print(
-                f"⚠️  `git fetch origin {_base_branch_name(base)}` failed or "
-                f"{origin_ref} is unresolvable; falling back to local {base}. "
-                f"This worktree may be branched from a stale tip.",
-                file=sys.stderr,
+            # #5803 follow-up: NO silent fallback to the local base. That
+            # fallback is exactly why a worker concluded "origin/main may be
+            # stale" and went to the PRIMARY checkout for a fresh copy,
+            # leaving it detached. Fail with an actionable error instead.
+            branch_name = _base_branch_name(base)
+            raise RuntimeError(
+                f"could not fetch origin/{branch_name} and {origin_ref} is "
+                f"unresolvable — refusing to branch from possibly-stale local "
+                f"{branch_name}. Check connectivity and that "
+                "`git remote get-url origin` points at the canonical remote "
+                "(github.com:learn-ukrainian/learn-ukrainian.github.io), then "
+                f"run `git fetch origin {branch_name}` and retry the dispatch. "
+                "Do NOT use the primary checkout as a freshness source."
             )
-            worktree_base_ref = base
 
     # Ensure parent dirs exist for the dispatch/ subtree layout.
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1967,6 +2039,13 @@ def _augment_prompt_with_worktree(
         "[delegate worktree]\n"
         f"Run all file edits, tests, and git commands inside this worktree: {worktree_path}\n"
         "Do not switch branches in the main checkout.\n"
+        # #5803 follow-up: remove the workflow reason to visit the primary.
+        # A linked worktree shares the canonical `origin` remote, so fresh
+        # main is always one fetch away from INSIDE the worktree.
+        "If you need a fresh base, run `git fetch origin main` INSIDE this worktree — "
+        "`origin` here points at the canonical GitHub remote and fetch works from any "
+        "linked worktree. NEVER use the primary checkout as a source of freshness "
+        "(no `git -C <primary> pull/fetch/checkout`); it is the human's interactive home.\n"
         f"{sparse_note}\n"
         f"{prompt}"
     )
@@ -2544,6 +2623,34 @@ def _run_worker(
         fallback_prompt_chars=len(prompt),
     )
 
+    # Post-worker primary-integrity sweep (#5803 follow-up): if THIS worker
+    # touched the primary checkout, the drift is caught here while its
+    # task_id/agent/pid are still known, so the drift event names the likely
+    # actor. Conservative: repairs only detached+clean+idle drift and never
+    # raises into teardown. Runs after final_state is persisted, so this task
+    # no longer counts as a running dispatch for the repair gate.
+    try:
+        try:
+            from scripts.audit.check_primary_integrity import check_primary_integrity
+        except ImportError:  # path-flavoured import for test/script contexts
+            from audit.check_primary_integrity import check_primary_integrity
+
+        pi_ok, pi_message = check_primary_integrity(_REPO_ROOT, fix=True, tasks_dir=_TASKS_DIR)
+        if not pi_ok or "repaired" in pi_message:
+            _append_dispatch_event(
+                "primary_integrity_post_worker",
+                task_id=task_id,
+                agent=agent,
+                ok=pi_ok,
+                detail=pi_message,
+            )
+    except Exception as pi_exc:
+        print(
+            f"[delegate] WARNING: primary-integrity post-worker sweep failed: "
+            f"{type(pi_exc).__name__}: {pi_exc}",
+            file=sys.stderr,
+        )
+
     if timed_out:
         _append_dispatch_event(
             "dispatch_silence_timeout",
@@ -2636,6 +2743,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     dirty_primary_error = _resolve_dirty_primary_checkout_error(mode=args.mode)
     if dirty_primary_error:
         print(dirty_primary_error, file=sys.stderr)
+        return 2
+
+    primary_integrity_error = _resolve_primary_integrity_error(mode=args.mode)
+    if primary_integrity_error:
+        print(primary_integrity_error, file=sys.stderr)
         return 2
 
     # Refuse to clobber a task that's still alive — whether it's in
@@ -3078,6 +3190,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     worker_env["TMPDIR"] = str(runtime_tmp_root)
     worker_env["LU_RUNTIME_TMP_ROOT"] = str(runtime_tmp_root)
     worker_env["LU_RUNTIME_TMP_BASE_ROOT"] = str(runtime_tmp_namespace_root.parent)
+    if worktree_path is not None:
+        _apply_worktree_git_ceiling(worker_env, worktree_path)
     if getattr(args, "allow_merge", False):
         worker_env.pop("AGENT_NO_MERGE", None)
         worker_env["AGENT_ALLOW_MERGE"] = "1"

--- a/tests/test_agent_runtime_effort.py
+++ b/tests/test_agent_runtime_effort.py
@@ -49,6 +49,21 @@ def _clear_state():
     _reset_rate_limit_cache_for_tests()
 
 
+@pytest.fixture(autouse=True)
+def _stub_primary_integrity_sweep(monkeypatch):
+    """Keep _run_worker tests hermetic from the ambient checkout (the #5803
+    post-worker sweep runs real git against delegate._REPO_ROOT; a detached
+    CI workspace reads as drift and leaks dispatch events / repair attempts).
+    Covered for real in tests/test_delegate_primary_integrity.py."""
+    import scripts.audit.check_primary_integrity as cpi
+
+    monkeypatch.setattr(
+        cpi,
+        "check_primary_integrity",
+        lambda *_args, **_kwargs: (True, "primary on main (test stub)"),
+    )
+
+
 # ---------------------------------------------------------------------------
 # AC5.1 — delegate.py dispatch --effort parses
 # ---------------------------------------------------------------------------

--- a/tests/test_check_primary_integrity.py
+++ b/tests/test_check_primary_integrity.py
@@ -347,7 +347,7 @@ def test_worktree_origin_points_at_remote(tmp_path):
 
     ok, message = worktree_origin_points_at_remote(worktree)
     assert ok is True
-    assert "github.com" in message
+    assert message == "origin → git@github.com:learn-ukrainian/learn-ukrainian.github.io.git"
 
 
 def test_worktree_origin_local_path_is_flagged(tmp_path):

--- a/tests/test_check_primary_integrity.py
+++ b/tests/test_check_primary_integrity.py
@@ -1,0 +1,387 @@
+"""Tests for the primary-checkout integrity watchdog.
+
+scripts/audit/check_primary_integrity.py — #5803 follow-up: detection +
+CONSERVATIVE repair of primary-checkout drift. The repair gate is the whole
+point: repair ONLY when detached + clean + idle + no running dispatch + main
+stable; alert and preserve evidence (never touch) otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+from audit.check_primary_integrity import (
+    check_primary_integrity,
+    main,
+    worktree_origin_points_at_remote,
+)
+
+_GIT_REDIRECT = frozenset(
+    {
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_PREFIX",
+    }
+)
+
+
+def _clean_env() -> dict[str, str]:
+    """Drop git redirect env so fixtures are not the outer commit hook repo."""
+    return {k: v for k, v in os.environ.items() if k not in _GIT_REDIRECT}
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        env=_clean_env(),
+        timeout=30,
+    )
+
+
+def _init_repo(path: Path) -> Path:
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(path)],
+        check=True,
+        env=_clean_env(),
+        timeout=30,
+    )
+    _git(path, "config", "user.email", "watchdog-test@example.com")
+    _git(path, "config", "user.name", "watchdog-test")
+    (path / "README.md").write_text("fixture\n")
+    _git(path, "add", "README.md")
+    _git(path, "commit", "-q", "-m", "init")
+    return path
+
+
+def _detach(repo: Path) -> str:
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "checkout", "-q", "--detach", "HEAD")
+    return sha
+
+
+def _head_symbolic_target(repo: Path) -> str | None:
+    proc = _git(repo, "symbolic-ref", "-q", "HEAD", check=False)
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def _events(state_dir: Path) -> list[dict]:
+    path = state_dir / "events.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _check(repo: Path, tmp_path: Path, *, fix: bool = False, tasks_dir: Path | None = None):
+    return check_primary_integrity(
+        repo,
+        fix=fix,
+        tasks_dir=tasks_dir if tasks_dir is not None else (tmp_path / "no-tasks"),
+        state_dir=tmp_path / "watchdog-state",
+    )
+
+
+# ---------------------------------------------------------------------------
+# healthy cases
+# ---------------------------------------------------------------------------
+
+
+def test_ok_when_primary_on_main(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    ok, message = _check(repo, tmp_path)
+    assert ok is True
+    assert "main" in message
+
+
+def test_wrong_branch_alerts_without_touching(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _git(repo, "checkout", "-q", "-b", "feature-x")
+    ok, message = _check(repo, tmp_path, fix=True)
+    assert ok is False
+    assert "feature-x" in message
+    # Untouched: still on the wrong branch.
+    assert _head_symbolic_target(repo) == "refs/heads/feature-x"
+
+
+def test_check_from_linked_worktree_targets_primary(tmp_path):
+    """Invoked with a linked-worktree path, the watchdog must check the
+    PRIMARY — a worktree's .git is a file, not a directory, and must never be
+    mistaken for the primary checkout."""
+    repo = _init_repo(tmp_path / "repo")
+    worktree = tmp_path / "linked"
+    _git(repo, "worktree", "add", "-q", "-b", "agent/task-x", str(worktree))
+
+    ok, message = _check(worktree, tmp_path)
+    assert ok is True
+    assert str(repo) in message  # primary root, not the worktree
+
+    # Detach the PRIMARY; checking via the worktree path must see it.
+    _detach(repo)
+    ok, _message = _check(worktree, tmp_path, fix=True)
+    assert ok is False
+    assert _head_symbolic_target(repo) is None
+
+
+# ---------------------------------------------------------------------------
+# repair gate: detached + clean + idle → repaired (after stable-main pass)
+# ---------------------------------------------------------------------------
+
+
+def test_detached_clean_idle_is_repaired(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+
+    # First sighting records the main-movement baseline — no repair yet.
+    ok, message = _check(repo, tmp_path, fix=True)
+    assert ok is False
+    assert "baseline" in message
+    assert _head_symbolic_target(repo) is None  # still detached
+
+    # Second pass: main observed stable → conservative repair.
+    ok, message = _check(repo, tmp_path, fix=True)
+    assert ok is True
+    assert "repaired" in message
+    assert _head_symbolic_target(repo) == "refs/heads/main"
+
+    # Repair event logged with actor-identification context.
+    repaired = [e for e in _events(tmp_path / "watchdog-state") if e["event"] == "primary_drift_repaired"]
+    assert repaired, "repair must be logged"
+    assert repaired[0]["head_sha"]
+    assert repaired[0]["reflog"]
+
+
+def test_detached_clean_idle_no_fix_reports_repairable(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+    _check(repo, tmp_path)  # baseline pass
+    ok, message = _check(repo, tmp_path, fix=False)
+    assert ok is False
+    assert "repairable" in message
+    assert _head_symbolic_target(repo) is None
+
+
+def test_detached_at_older_commit_repaired_via_checkout(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    first_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    (repo / "README.md").write_text("fixture v2\n")
+    _git(repo, "commit", "-qam", "second")
+    _git(repo, "checkout", "-q", first_sha)  # detached at older commit, clean
+
+    _check(repo, tmp_path, fix=True)  # baseline
+    ok, _message = _check(repo, tmp_path, fix=True)
+    assert ok is True
+    assert _head_symbolic_target(repo) == "refs/heads/main"
+    # Working tree moved to main's tip without losing anything.
+    assert (repo / "README.md").read_text() == "fixture v2\n"
+
+
+# ---------------------------------------------------------------------------
+# alert-only cases: NEVER touched
+# ---------------------------------------------------------------------------
+
+
+def test_detached_dirty_tree_not_touched(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+    (repo / "README.md").write_text("human work in progress\n")
+
+    ok, message = _check(repo, tmp_path, fix=True)
+    assert ok is False
+    assert "DIRTY" in message
+    assert _head_symbolic_target(repo) is None  # still detached
+    assert (repo / "README.md").read_text() == "human work in progress\n"
+
+    # Evidence preserved: alert event carries the dirty entries + reflog.
+    alerts = [e for e in _events(tmp_path / "watchdog-state") if e["event"] == "primary_drift_alert"]
+    assert alerts
+    assert any("README.md" in entry for entry in alerts[0]["dirty_entries"])
+    assert alerts[0]["reflog"]
+
+
+def test_detached_untracked_file_counts_as_dirty(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+    (repo / "stray.txt").write_text("untracked\n")
+    ok, _message = _check(repo, tmp_path, fix=True)
+    assert ok is False
+    assert _head_symbolic_target(repo) is None
+
+
+def test_operation_in_progress_not_touched(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+    (repo / ".git" / "MERGE_HEAD").write_text("deadbeef\n")
+    ok, message = _check(repo, tmp_path, fix=True)
+    assert ok is False
+    assert "MERGE_HEAD" in message
+    assert _head_symbolic_target(repo) is None
+
+
+def test_index_lock_not_touched(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+    (repo / ".git" / "index.lock").write_text("")
+    ok, message = _check(repo, tmp_path, fix=True)
+    assert ok is False
+    assert "index.lock" in message
+    assert _head_symbolic_target(repo) is None
+
+
+def test_rebase_state_dir_not_touched(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+    (repo / ".git" / "rebase-merge").mkdir()
+    ok, _message = _check(repo, tmp_path, fix=True)
+    assert ok is False
+    assert _head_symbolic_target(repo) is None
+
+
+def test_main_moved_unexpectedly_not_touched(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+
+    ok, _ = _check(repo, tmp_path, fix=True)  # baseline recorded
+    assert ok is False
+
+    # main moves while HEAD is detached — unexpected primary-side activity.
+    (repo / "mover.txt").write_text("moved\n")
+    _git(repo, "add", "mover.txt")
+    _git(repo, "commit", "-qm", "mover commit")  # commits on detached HEAD
+    _git(repo, "update-ref", "refs/heads/main", "HEAD")
+    _git(repo, "reset", "-q", "--hard", "HEAD~1")  # back to clean detached state
+
+    ok, message = _check(repo, tmp_path, fix=True)
+    assert ok is False
+    assert "main moved unexpectedly" in message
+    assert _head_symbolic_target(repo) is None
+
+
+# ---------------------------------------------------------------------------
+# running-dispatch gate: repair deferred, dispatch never killed
+# ---------------------------------------------------------------------------
+
+
+def test_running_dispatch_defers_repair(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "codex-live-task.json").write_text(
+        json.dumps(
+            {
+                "task_id": "codex/live-task",
+                "agent": "codex",
+                "status": "running",
+                "pid": os.getpid(),  # this test process is alive
+            }
+        )
+    )
+
+    ok, message = _check(repo, tmp_path, fix=True, tasks_dir=tasks_dir)
+    assert ok is False
+    assert "deferred" in message
+    assert "live-task" in message
+    assert _head_symbolic_target(repo) is None  # NOT touched
+
+
+def test_dead_dispatch_pid_does_not_block_repair(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "zombie.json").write_text(
+        json.dumps({"task_id": "zombie", "status": "running", "pid": 2**22})
+    )
+
+    _check(repo, tmp_path, fix=True, tasks_dir=tasks_dir)  # baseline
+    ok, message = _check(repo, tmp_path, fix=True, tasks_dir=tasks_dir)
+    assert ok is True, message
+    assert _head_symbolic_target(repo) == "refs/heads/main"
+
+
+def test_detection_event_names_running_dispatches(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _detach(repo)
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "gemini-suspect.json").write_text(
+        json.dumps(
+            {
+                "task_id": "gemini/suspect",
+                "agent": "gemini",
+                "status": "running",
+                "pid": os.getpid(),
+            }
+        )
+    )
+    _check(repo, tmp_path, fix=True, tasks_dir=tasks_dir)
+    detected = [e for e in _events(tmp_path / "watchdog-state") if e["event"] == "primary_drift_detected"]
+    assert detected
+    running = detected[0]["running_dispatches"]
+    assert any(d["task_id"] == "gemini/suspect" for d in running)
+
+
+# ---------------------------------------------------------------------------
+# worktree origin verification (#5803 root cause: origin must be the REMOTE)
+# ---------------------------------------------------------------------------
+
+
+def test_worktree_origin_points_at_remote(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _git(repo, "remote", "add", "origin", "git@github.com:learn-ukrainian/learn-ukrainian.github.io.git")
+    worktree = tmp_path / "linked"
+    _git(repo, "worktree", "add", "-q", "-b", "agent/task", str(worktree))
+
+    ok, message = worktree_origin_points_at_remote(worktree)
+    assert ok is True
+    assert "github.com" in message
+
+
+def test_worktree_origin_local_path_is_flagged(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    _git(repo, "remote", "add", "origin", str(repo))  # local FS path = the bug
+    worktree = tmp_path / "linked"
+    _git(repo, "worktree", "add", "-q", "-b", "agent/task2", str(worktree))
+
+    ok, message = worktree_origin_points_at_remote(worktree)
+    assert ok is False
+    assert "LOCAL path" in message
+
+
+def test_worktree_origin_missing_is_flagged(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    ok, message = worktree_origin_points_at_remote(repo)
+    assert ok is False
+    assert "not set" in message
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_exit_codes(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    state_dir = tmp_path / "cli-state"
+    tasks_dir = tmp_path / "no-tasks"
+
+    assert main(["--repo", str(repo), "--state-dir", str(state_dir), "--tasks-dir", str(tasks_dir)]) == 0
+
+    _detach(repo)
+    argv = ["--repo", str(repo), "--state-dir", str(state_dir), "--tasks-dir", str(tasks_dir)]
+    assert main(argv) == 1  # drift, no --fix (baseline recorded)
+    assert main([*argv, "--fix"]) == 0  # stable-main pass repairs
+    assert _head_symbolic_target(repo) == "refs/heads/main"

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -40,6 +40,27 @@ def tmp_tasks_dir(tmp_path, monkeypatch):
     return tasks_dir
 
 
+@pytest.fixture(autouse=True)
+def _stub_primary_integrity_sweep(monkeypatch):
+    """Keep _run_worker/cmd_dispatch tests hermetic from the ambient checkout.
+
+    The primary-integrity watchdog sweep (#5803 follow-up) runs real git
+    against delegate._REPO_ROOT. Its verdict depends on the machine running
+    the tests: a detached CI workspace (actions/checkout) reads as DRIFT, so
+    the sweep appends primary_integrity_post_worker to dispatch_events.jsonl
+    — breaking tests that assert on that file — and a stable-main second pass
+    would even "repair" (mutate) the host repo mid-suite. The sweep itself is
+    covered against fixture repos in tests/test_delegate_primary_integrity.py.
+    """
+    import scripts.audit.check_primary_integrity as cpi
+
+    monkeypatch.setattr(
+        cpi,
+        "check_primary_integrity",
+        lambda *_args, **_kwargs: (True, "primary on main (test stub)"),
+    )
+
+
 def _sanitize_git_env_for_test(monkeypatch) -> None:
     for key in tuple(os.environ):
         if key.startswith(("GIT_", "PRE_COMMIT")):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -3180,9 +3180,12 @@ def test_augment_prompt_mentions_sparse_exclusions():
     assert "sparse" in text.lower() or "Sparse" in text
 
 
-def test_ensure_worktree_falls_back_when_fetch_fails(tmp_tasks_dir, tmp_path, monkeypatch, capsys):
-    """Fix 1 (#1476): offline/no-remote scenarios fall back to local
-    base rather than hard-failing. A warning is logged on stderr.
+def test_ensure_worktree_refuses_stale_base_when_fetch_fails(tmp_tasks_dir, tmp_path, monkeypatch, capsys):
+    """Fix 1 (#1476) amended by #5803 follow-up: offline/no-remote scenarios
+    used to fall back to the local base with only a stderr warning. That
+    silent fallback is why a worker concluded "origin/main may be stale" and
+    went to the PRIMARY checkout for freshness, leaving it detached. Fetch
+    failure is now an actionable hard error — no stale-base worktree.
     """
     target = tmp_path / "offline-worktree"
 
@@ -3199,18 +3202,15 @@ def test_ensure_worktree_falls_back_when_fetch_fails(tmp_tasks_dir, tmp_path, mo
 
     monkeypatch.setattr(delegate.subprocess, "run", fake_run)
 
-    _, branch, _ = delegate._ensure_worktree(
-        agent="codex",
-        task_id="1476-offline",
-        raw_path=str(target),
-        base="main",
-    )
-    assert branch == "codex/1476-offline"
-    captured = capsys.readouterr()
-    assert (
-        ("fetch" in captured.err and "fallback" in captured.err.lower())
-        or "stale" in captured.err.lower()
-    )
+    with pytest.raises(RuntimeError, match="git fetch origin main"):
+        delegate._ensure_worktree(
+            agent="codex",
+            task_id="1476-offline",
+            raw_path=str(target),
+            base="main",
+        )
+    # No worktree was branched from the stale local base.
+    assert not target.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_delegate_primary_integrity.py
+++ b/tests/test_delegate_primary_integrity.py
@@ -1,0 +1,281 @@
+"""Tests for the #5803-follow-up primary-integrity wiring in scripts/delegate.py.
+
+- pre-dispatch gate: unrepaired primary drift blocks NEW write-capable
+  dispatches (running ones are never touched)
+- instructive fetch failure: no silent fallback to a stale local base
+- worktree prompt tells workers to fetch from origin INSIDE the worktree
+- GIT_CEILING_DIRECTORIES damage-reduction env for worker spawns
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import delegate
+
+_GIT_REDIRECT = frozenset(
+    {
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_PREFIX",
+    }
+)
+
+
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _GIT_REDIRECT}
+
+
+def _git(repo: Path, *args: str, check: bool = True, env: dict | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        env=env or _clean_env(),
+        timeout=30,
+    )
+
+
+def _init_repo(path: Path) -> Path:
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(path)],
+        check=True,
+        env=_clean_env(),
+        timeout=30,
+    )
+    _git(path, "config", "user.email", "gate-test@example.com")
+    _git(path, "config", "user.name", "gate-test")
+    # Mirror the real repo's .gitignore so the watchdog's own state/log files
+    # under data/telemetry/ (and dispatch state under batch_state/) do not
+    # count as primary-checkout dirt.
+    (path / ".gitignore").write_text("data/telemetry/\nbatch_state/\n.worktrees/\n")
+    (path / "README.md").write_text("fixture\n")
+    _git(path, "add", ".gitignore", "README.md")
+    _git(path, "commit", "-q", "-m", "init")
+    return path
+
+
+@pytest.fixture
+def primary_repo(tmp_path, monkeypatch):
+    """A fixture 'primary' checkout wired in as delegate._REPO_ROOT with an
+    isolated tasks dir and watchdog state under gitignored-looking tmp paths."""
+    repo = _init_repo(tmp_path / "primary")
+    tasks_dir = tmp_path / "tasks"
+    monkeypatch.setattr(delegate, "_REPO_ROOT", repo)
+    monkeypatch.setattr(delegate, "_TASKS_DIR", tasks_dir)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# pre-dispatch gate
+# ---------------------------------------------------------------------------
+
+
+def test_gate_allows_healthy_primary(primary_repo):
+    assert delegate._resolve_primary_integrity_error(mode="danger") is None
+    assert delegate._resolve_primary_integrity_error(mode="workspace-write") is None
+
+
+def test_gate_exempts_read_only_mode(primary_repo):
+    _git(primary_repo, "checkout", "-q", "--detach", "HEAD")
+    assert delegate._resolve_primary_integrity_error(mode="read-only") is None
+
+
+def test_gate_blocks_unrepaired_drift(primary_repo):
+    _git(primary_repo, "checkout", "-q", "--detach", "HEAD")
+    (primary_repo / "README.md").write_text("human work\n")  # dirty → never repaired
+
+    error = delegate._resolve_primary_integrity_error(mode="danger")
+    assert error is not None
+    assert "UNREPAIRED" in error
+    # Primary NOT touched.
+    proc = _git(primary_repo, "symbolic-ref", "-q", "HEAD", check=False)
+    assert proc.returncode != 0
+    assert (primary_repo / "README.md").read_text() == "human work\n"
+
+
+def test_gate_repairs_safe_drift_then_allows(primary_repo):
+    _git(primary_repo, "checkout", "-q", "--detach", "HEAD")
+
+    # First call records the stable-main baseline and blocks.
+    error = delegate._resolve_primary_integrity_error(mode="danger")
+    assert error is not None
+    assert "baseline" in error
+
+    # Second call: main observed stable → watchdog repairs → dispatch allowed.
+    assert delegate._resolve_primary_integrity_error(mode="danger") is None
+    proc = _git(primary_repo, "symbolic-ref", "-q", "HEAD")
+    assert proc.stdout.strip() == "refs/heads/main"
+
+
+def test_gate_defers_while_dispatch_running(primary_repo):
+    _git(primary_repo, "checkout", "-q", "--detach", "HEAD")
+    delegate._TASKS_DIR.mkdir(parents=True)
+    (delegate._TASKS_DIR / "codex-live.json").write_text(
+        f'{{"task_id": "codex/live", "status": "running", "pid": {os.getpid()}}}'
+    )
+
+    error = delegate._resolve_primary_integrity_error(mode="danger")
+    assert error is not None
+    assert "deferred" in error
+    # Still detached — the running dispatch was not killed or raced.
+    proc = _git(primary_repo, "symbolic-ref", "-q", "HEAD", check=False)
+    assert proc.returncode != 0
+
+
+def test_gate_fail_open_on_watchdog_error(primary_repo, monkeypatch, capsys):
+    # None in sys.modules makes `from <module> import ...` raise ImportError;
+    # both import paths fail → the generic except must fail OPEN.
+    monkeypatch.setitem(sys.modules, "scripts.audit.check_primary_integrity", None)
+    monkeypatch.setitem(sys.modules, "audit.check_primary_integrity", None)
+    assert delegate._resolve_primary_integrity_error(mode="danger") is None
+    assert "watchdog errored" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# instructive fetch failure (no silent stale-base fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_worktree_fetch_failure_is_actionable_error(tmp_tasks_dir, tmp_path, monkeypatch):
+    """#5803 follow-up: the old silent fallback to local base is WHY a worker
+    went to the primary for freshness. Fetch failure must now be an actionable
+    error naming `git fetch origin`."""
+    target = tmp_path / "offline-worktree"
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(cmd, 1, "", "fatal: unable to access")
+        if cmd[:2] == ["git", "rev-parse"] and "--verify" in cmd:
+            return subprocess.CompletedProcess(cmd, 1, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="git fetch origin main"):
+        delegate._ensure_worktree(
+            agent="codex",
+            task_id="5803-offline",
+            raw_path=str(target),
+            base="main",
+        )
+
+
+def test_ensure_worktree_fetch_failure_mentions_canonical_remote(tmp_tasks_dir, tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(cmd, 1, "", "fatal: unable to access")
+        if cmd[:2] == ["git", "rev-parse"] and "--verify" in cmd:
+            return subprocess.CompletedProcess(cmd, 1, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="canonical remote"):
+        delegate._ensure_worktree(
+            agent="codex",
+            task_id="5803-offline-2",
+            raw_path=str(tmp_path / "wt2"),
+            base="main",
+        )
+
+
+@pytest.fixture
+def tmp_tasks_dir(tmp_path, monkeypatch):
+    tasks_dir = tmp_path / "tasks"
+    monkeypatch.setattr(delegate, "_TASKS_DIR", tasks_dir)
+    return tasks_dir
+
+
+# ---------------------------------------------------------------------------
+# worktree prompt removes the workflow reason to visit the primary
+# ---------------------------------------------------------------------------
+
+
+def test_worktree_prompt_teaches_in_worktree_fetch():
+    prompt = delegate._augment_prompt_with_worktree("do the thing", Path("/tmp/wt"))
+    assert "git fetch origin main" in prompt
+    assert "INSIDE this worktree" in prompt
+    assert "primary checkout" in prompt
+
+
+# ---------------------------------------------------------------------------
+# GIT_CEILING_DIRECTORIES damage reduction
+# ---------------------------------------------------------------------------
+
+
+def test_git_ceiling_env_set_to_worktree_parent():
+    env: dict[str, str] = {}
+    worktree = Path("/repo/.worktrees/dispatch/codex/task-1")
+    delegate._apply_worktree_git_ceiling(env, worktree)
+    assert env["GIT_CEILING_DIRECTORIES"] == "/repo/.worktrees/dispatch/codex"
+
+
+def test_git_ceiling_env_appends_to_existing():
+    env = {"GIT_CEILING_DIRECTORIES": "/elsewhere"}
+    worktree = Path("/repo/.worktrees/dispatch/codex/task-1")
+    delegate._apply_worktree_git_ceiling(env, worktree)
+    assert env["GIT_CEILING_DIRECTORIES"] == f"/elsewhere{os.pathsep}/repo/.worktrees/dispatch/codex"
+
+
+def test_git_ceiling_keeps_linked_worktree_ops_working(tmp_path):
+    """Integration proof for the comment in _apply_worktree_git_ceiling: with
+    the ceiling at the worktree PARENT, git from the worktree root AND from a
+    subdirectory still resolves the worktree's own repo."""
+    repo = _init_repo(tmp_path / "primary")
+    worktree = tmp_path / "dispatch" / "codex" / "task-1"
+    worktree.parent.mkdir(parents=True)
+    _git(repo, "worktree", "add", "-q", "-b", "codex/task-1", str(worktree))
+    (worktree / "sub").mkdir()
+
+    env = _clean_env()
+    env["GIT_CEILING_DIRECTORIES"] = str(worktree.parent)
+
+    top = _git(worktree, "rev-parse", "--show-toplevel", env=env)
+    assert top.stdout.strip() == str(worktree)
+    sub = _git(worktree / "sub", "rev-parse", "--show-toplevel", env=env)
+    assert sub.stdout.strip() == str(worktree)
+    # status works from a subdirectory too.
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=worktree / "sub",
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert status.returncode == 0
+
+
+def test_git_ceiling_blocks_upward_discovery_to_primary(tmp_path):
+    """If the worktree's .git pointer is gone, upward discovery must stop at
+    the ceiling instead of silently binding to an ancestor repo."""
+    repo = _init_repo(tmp_path / "primary")
+    nested = repo / ".worktrees" / "dispatch" / "codex" / "task-1"
+    nested.mkdir(parents=True)  # plain dir INSIDE the primary, no .git pointer
+
+    env = _clean_env()
+    env["GIT_CEILING_DIRECTORIES"] = str(nested.parent)
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=nested,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert proc.returncode != 0  # fails loudly…
+    # …instead of discovering the primary checkout.
+    assert str(repo) not in proc.stdout


### PR DESCRIPTION
## Primary-checkout integrity: detection + CONSERVATIVE repair, and removing the reason workers go there

Follow-up to #5803, #5389, #5396.

A worker ran git against the PRIMARY checkout and left it detached (`checkout: moving from main to FETCH_HEAD`). Its own log: *"Local origin/main may be stale. Pulling latest main from the primary checkout, then merging."*

PR #5803 tried git-level prevention with a `reference-transaction` hook; cross-family review defeated it with three live commands (`git -c core.hooksPath=/dev/null ...`, the self-grantable env override, and `script -q` faking a TTY). The two-seat design panel (gpt-5.6-sol, agy) then independently concluded:

> **git-layer enforcement against a same-UID process is categorically impossible** — hooks and config are cooperative policy, not a boundary.

So this PR is **detection + conservative repair**, plus removing the workflow reason the worker went to the primary. It deliberately does **not** add another bypass-able guard.

### Deliverable 1 — primary-integrity watchdog (`scripts/audit/check_primary_integrity.py`)

**Detects:** HEAD not symbolically attached to `refs/heads/main` (detached or wrong branch), git operation in progress (`MERGE_HEAD`, `rebase-merge/`, `rebase-apply/`, `CHERRY_PICK_HEAD`, `REVERT_HEAD`, `BISECT_LOG`, `index.lock`), and working-tree cleanliness.

**Repairs ONLY when ALL of:** HEAD detached AND tree demonstrably clean AND no operation in progress AND no dispatch running AND `main` observed **stable across two checks** (a baseline recorded at first sighting guards against "main moved unexpectedly"). Repair is a `git symbolic-ref` flip when HEAD already equals main's tip (zero working-tree effect), else a plain `git checkout main` on a clean tree — no committed or uncommitted state can be lost either way.

**ALERT and PRESERVE EVIDENCE — never touch — when:** the tree is DIRTY (or cleanliness undeterminable), an operation is in progress, a dispatch is running, or `main` moved unexpectedly. Evidence (porcelain status, reflog excerpt, running task ids) is appended to `data/telemetry/primary-integrity/events.jsonl` (gitignored local runtime state) so the offending actor can be identified. Per the advisor: *never blindly reset a human checkout.*

**Wired at the fleet's existing lifecycle boundaries** (no new daemon):
- **Before dispatch** — `_resolve_primary_integrity_error` in `cmd_dispatch` (scripts/delegate.py), right after the existing dirty-primary guard: unrepaired drift blocks NEW write-capable dispatches with an actionable message; read-only preflight stays exempt; running dispatches are never killed. Watchdog errors fail open with a warning (a canary bug must not ground the fleet).
- **After each worker exits** — post-worker sweep at the end of `_run_worker` (scripts/delegate.py), after the terminal state write: drift is caught while the exiting worker's task_id/agent/pid are still known and logged as a `primary_integrity_post_worker` dispatch event. Never raises into teardown.
- **Periodic health poll** — `_primary_integrity_canary` in `_collect_health_orient_data` (scripts/api/main.py), next to the existing `core.bare` (#2842) and ELOOP-symlink canaries, surfaced as `primary_integrity_ok` in the orient `health` section. Never raises; fail-open.

### Deliverable 2 — remove the WORKFLOW REASON (the actual root cause)

The worker went to the primary because it believed `origin/main` was stale and the primary was the nearest fresh copy.

- **No more silent stale-base fallback.** `_ensure_worktree` used to warn and branch from possibly-stale local `main` when `git fetch origin main` failed — that is exactly what taught the worker "origin/main may be stale". It now raises an actionable error naming `git fetch origin main` and the canonical remote. (The old `test_ensure_worktree_falls_back_when_fetch_fails` is updated to this contract.)
- **Prompt-level fix.** The `[delegate worktree]` header now tells every worker: run `git fetch origin main` INSIDE the worktree — `origin` points at the canonical GitHub remote and fetch works from any linked worktree; NEVER use the primary checkout as a freshness source.
- **`origin` verified.** Inside dispatch worktrees `remote.origin.url` resolves to `git@github.com:learn-ukrainian/learn-ukrainian.github.io.git` — the canonical remote, not a local path to the primary (shared git config). Regression-tested via `worktree_origin_points_at_remote` (flags local-path and missing origins).
- **`GIT_CEILING_DIRECTORIES`** pinned at the worktree's **parent** for worker spawns. Per the panel's constraint, linked worktrees SHARE a git control plane — this is **damage reduction, not isolation**: if a worktree's `.git` pointer breaks, upward repo discovery now fails loudly instead of silently binding the worker to the primary (which sits at an ancestor path of `.worktrees/dispatch/<agent>/<task>/`). Verified live: `status`/`log`/`rev-parse`/`fetch` from the worktree root AND subdirectories all work with the ceiling set; a ceiling at the worktree root *itself* breaks subdirectory git (`fatal: not a git repository`) and was rejected.

### What this does NOT do

- No new git hook as a security control (proven bypass-able).
- Does not make the primary bare (Layout A contract; and bare still has mutable HEAD/refs).
- Does not change the human operator's interactive workflow in the primary.
- Does not isolate the shared git control plane — a determined same-UID process can still mutate shared refs. This PR detects, conservatively repairs, preserves evidence, and removes the benign reason to go there. Nothing more is claimed.

### Verification

- 32 new tests: repair gate matrix (detached+clean+idle → repaired after stable-main pass; DIRTY → untouched+alert; op-in-progress → untouched; `index.lock` → untouched; main moved → untouched+alert; running dispatch → deferred, never killed; dead PID → repaired), evidence logging (events name running dispatches + reflog), worktree-origin verification, pre-dispatch gate (blocks unrepaired drift, repairs safe drift, exempts read-only, fail-open on watchdog error), instructive fetch failure, prompt content, GIT_CEILING env + live integration proofs.
- Every behavioral test **verified failing against the pre-change code** (new module absent → collection error; 11 delegate-wiring tests fail on stashed base).
- `pytest tests/test_check_primary_integrity.py tests/test_delegate_primary_integrity.py tests/test_check_core_bare.py tests/test_assert_primary_on_main.py` — **39 passed**.
- `pytest tests/test_delegate.py` — 133 passed, 8 failed with **failure sets byte-identical before/after this change** (pre-existing environmental failures in this worktree; diffed to confirm).
- `ruff check` on all touched files — clean.
- OPSEC lint — clean. X-Agent trailer lint — clean.
- CLI smoke: `.venv/bin/python scripts/audit/check_primary_integrity.py --repo .` from this worktree correctly resolves and reports the real primary: `✅ primary on main`.

Refs #5803 #5389 #5396
