### PR TITLE
fix(delegate): a finished worker must always reach a terminal status

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2562,7 +2562,9 @@ def _run_worker(
                     needs_finalize = False
                     ok_outcome = True
                     final_status = "done"
-    except Exception as finalize_exc:  # noqa: BLE001 - telemetry must never mask the outcome
+    # Deliberately broad: this is measurement about a worker that has already
+    # finished, and no measurement failure may cost the task its terminal status.
+    except Exception as finalize_exc:
         finalize_error = f"{type(finalize_exc).__name__}: {finalize_exc}"[:300]
         # Unknown telemetry cannot prove the work was committed, so surface
         # the task for a human instead of settling it as done.

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2433,102 +2433,26 @@ def _run_worker(
     runtime_tmp_reap: dict[str, int | str | None] | None = None
 
     cancelled = False
-    try:
-        stdout_silence_timeout = silence_timeout if silence_timeout > 0 else None
-        initial_probe = initial_response_timeout if initial_response_timeout > 0 else None
-        tool_config: dict[str, Any] = {}
-        if max_budget_usd is not None:
-            tool_config["max_budget_usd"] = max_budget_usd
-        if provider is not None:
-            tool_config[RUNTIME_ROUTE_TOOL_CONFIG_KEY] = {"provider": provider}
-        if output_schema_path is not None:
-            tool_config["output_schema_path"] = output_schema_path
-            tool_config["output_schema_sha256"] = output_schema_sha256
-        tool_config = tool_config or None
-        result = runtime_invoke(
-            agent,
-            prompt,
-            mode=mode,
-            cwd=cwd,
-            model=model,
-            task_id=task_id,
-            session_id=None,  # Layer 3 is always fresh-session
-            tool_config=tool_config,
-            entrypoint="delegate",
-            hard_timeout=hard_timeout,
-            stdout_silence_timeout=stdout_silence_timeout,
-            initial_response_timeout=initial_probe,
-            effort=effort,
-        )
-        ok_outcome = result.ok
-        response = result.response
-        stderr_excerpt = result.stderr_excerpt
-        returncode = result.returncode
-        rate_limited = result.rate_limited
-        substitution = getattr(result, "substitution", None)
-    except KeyboardInterrupt as exc:
-        # Raised by our SIGTERM handler (or by Ctrl+C in manual runs).
-        # The runtime's finally block has already killed the CLI
-        # subprocess and stopped the watchdog by the time we catch
-        # this, so no extra cleanup is needed here. Mark as cancelled.
-        cancelled = True
-        stderr_excerpt = f"cancelled via SIGTERM or Ctrl+C: {exc}"[:500]
-        returncode_reason = "worker interrupted before a terminal subprocess returncode was available"
-    except RateLimitedError as exc:
-        rate_limited = True
-        stderr_excerpt = str(exc)[:500]
-        returncode_reason = "runtime rejected the dispatch before a terminal subprocess returncode was available"
-    except AgentStalledError as exc:
-        timed_out = True
-        substitution = getattr(exc, "substitution", None)
-        prefix = (
-            "initial_response_timeout"
-            if getattr(exc, "kind", "stall") == "initial_response_timeout"
-            else "stdout_silence_timeout"
-        )
-        stderr_excerpt = f"{prefix}: {exc}"[:500]
-        returncode_reason = "runtime timeout raised before a terminal subprocess returncode was available"
-    except AgentTimeoutError as exc:
-        substitution = getattr(exc, "substitution", None)
-        stderr_excerpt = f"hard_timeout: {exc}"[:500]
-        returncode_reason = "runtime timeout raised before a terminal subprocess returncode was available"
-    except AgentRuntimeError as exc:
-        stderr_excerpt = f"runtime error: {type(exc).__name__}: {exc}"[:500]
-        returncode_reason = "runtime exception did not expose a terminal subprocess returncode"
-    except Exception as exc:
-        # Last-ditch: don't crash the worker on an unexpected bug — we
-        # need to update the state file or the parent will see us as
-        # "crashed" forever.
-        stderr_excerpt = f"worker unexpected: {type(exc).__name__}: {exc}"[:500]
-        returncode_reason = "unexpected worker exception before a terminal subprocess returncode was available"
-    finally:
-        if runtime_tmp_root is not None or runtime_tmp_namespace_root is not None:
-            # This cleanup runs AFTER the worker has finished but BEFORE the
-            # guarded span below, and it catches Exception rather than the
-            # KeyboardInterrupt a SIGTERM raises — so a cancel landing here used
-            # to unwind out of _run_worker with no terminal status written.
-            # Deferring the signal across the cleanup drops a cancel that has
-            # nothing left to cancel (the work is already done) in exchange for
-            # never losing the record that it was done. (Cross-family review of
-            # #5807.) Cleanup stays in `finally` so an interrupt during the
-            # runtime call itself still frees the lease.
-            with _sigterm_deferred():
-                runtime_tmp_reap = _reap_runtime_tmp_lease(
-                    runtime_tmp_root,
-                    runtime_tmp_namespace_root,
-                )
-
-    # ONE recovery region covers everything between "the worker finished" and
-    # "that fact is on disk". Five review rounds of patching individual windows
-    # — the reaper, the checkpoint, a second signal, lease cleanup — each closed
-    # an instance and left the next one open, because the interval kept being
-    # split into guarded and unguarded halves. The region below is the whole
-    # interval, so a cancellation anywhere in it records the outcome and then
-    # continues to propagate. What remains uncoverable in-process is SIGKILL,
-    # which the dead-pid probe in cmd_status/cmd_wait already handles.
+    # ONE recovery region, spanning the runtime call itself through the moment
+    # the outcome is on disk.
+    #
+    # Seven review rounds each found a different instruction-level gap — the
+    # reaper, the checkpoint, a second signal, lease cleanup, the boundary right
+    # after lease cleanup — and each fix guarded that gap and created the next
+    # one, because the interval kept being cut into guarded and unguarded
+    # halves. The gaps were not the bug; splitting the interval was. This region
+    # is the whole interval, so there is no boundary left to land between.
+    #
+    # A cancellation during the runtime call records ``cancelled`` — accurate,
+    # the worker really was stopped. A cancellation after it records the
+    # outcome the worker reached. Either way the state file stops saying
+    # "running" about a process that is gone, and the signal still propagates.
+    # What remains uncoverable in-process is SIGKILL, which the dead-pid probe
+    # in cmd_status/cmd_wait already reports.
     #
     # Nothing the fallback reads may be bound only inside this region: a handler
-    # that raises UnboundLocalError fails exactly when it is needed.
+    # that raises UnboundLocalError fails exactly when it is needed. Every name
+    # it touches is initialized above, including the runtime-outcome flags.
     final_state: dict[str, Any] = {}
     final_status = ""
     duration_s = time.monotonic() - start
@@ -2541,6 +2465,91 @@ def _run_worker(
     telemetry_settled = False
 
     try:
+        try:
+            stdout_silence_timeout = silence_timeout if silence_timeout > 0 else None
+            initial_probe = initial_response_timeout if initial_response_timeout > 0 else None
+            tool_config: dict[str, Any] = {}
+            if max_budget_usd is not None:
+                tool_config["max_budget_usd"] = max_budget_usd
+            if provider is not None:
+                tool_config[RUNTIME_ROUTE_TOOL_CONFIG_KEY] = {"provider": provider}
+            if output_schema_path is not None:
+                tool_config["output_schema_path"] = output_schema_path
+                tool_config["output_schema_sha256"] = output_schema_sha256
+            tool_config = tool_config or None
+            result = runtime_invoke(
+                agent,
+                prompt,
+                mode=mode,
+                cwd=cwd,
+                model=model,
+                task_id=task_id,
+                session_id=None,  # Layer 3 is always fresh-session
+                tool_config=tool_config,
+                entrypoint="delegate",
+                hard_timeout=hard_timeout,
+                stdout_silence_timeout=stdout_silence_timeout,
+                initial_response_timeout=initial_probe,
+                effort=effort,
+            )
+            ok_outcome = result.ok
+            response = result.response
+            stderr_excerpt = result.stderr_excerpt
+            returncode = result.returncode
+            rate_limited = result.rate_limited
+            substitution = getattr(result, "substitution", None)
+        except KeyboardInterrupt as exc:
+            # Raised by our SIGTERM handler (or by Ctrl+C in manual runs).
+            # The runtime's finally block has already killed the CLI
+            # subprocess and stopped the watchdog by the time we catch
+            # this, so no extra cleanup is needed here. Mark as cancelled.
+            cancelled = True
+            stderr_excerpt = f"cancelled via SIGTERM or Ctrl+C: {exc}"[:500]
+            returncode_reason = "worker interrupted before a terminal subprocess returncode was available"
+        except RateLimitedError as exc:
+            rate_limited = True
+            stderr_excerpt = str(exc)[:500]
+            returncode_reason = "runtime rejected the dispatch before a terminal subprocess returncode was available"
+        except AgentStalledError as exc:
+            timed_out = True
+            substitution = getattr(exc, "substitution", None)
+            prefix = (
+                "initial_response_timeout"
+                if getattr(exc, "kind", "stall") == "initial_response_timeout"
+                else "stdout_silence_timeout"
+            )
+            stderr_excerpt = f"{prefix}: {exc}"[:500]
+            returncode_reason = "runtime timeout raised before a terminal subprocess returncode was available"
+        except AgentTimeoutError as exc:
+            substitution = getattr(exc, "substitution", None)
+            stderr_excerpt = f"hard_timeout: {exc}"[:500]
+            returncode_reason = "runtime timeout raised before a terminal subprocess returncode was available"
+        except AgentRuntimeError as exc:
+            stderr_excerpt = f"runtime error: {type(exc).__name__}: {exc}"[:500]
+            returncode_reason = "runtime exception did not expose a terminal subprocess returncode"
+        except Exception as exc:
+            # Last-ditch: don't crash the worker on an unexpected bug — we
+            # need to update the state file or the parent will see us as
+            # "crashed" forever.
+            stderr_excerpt = f"worker unexpected: {type(exc).__name__}: {exc}"[:500]
+            returncode_reason = "unexpected worker exception before a terminal subprocess returncode was available"
+        finally:
+            if runtime_tmp_root is not None or runtime_tmp_namespace_root is not None:
+                # This cleanup runs AFTER the worker has finished but BEFORE the
+                # guarded span below, and it catches Exception rather than the
+                # KeyboardInterrupt a SIGTERM raises — so a cancel landing here used
+                # to unwind out of _run_worker with no terminal status written.
+                # Deferring the signal across the cleanup drops a cancel that has
+                # nothing left to cancel (the work is already done) in exchange for
+                # never losing the record that it was done. (Cross-family review of
+                # #5807.) Cleanup stays in `finally` so an interrupt during the
+                # runtime call itself still frees the lease.
+                with _sigterm_deferred():
+                    runtime_tmp_reap = _reap_runtime_tmp_lease(
+                        runtime_tmp_root,
+                        runtime_tmp_namespace_root,
+                    )
+
         duration_s = time.monotonic() - start
         final_status = _classify_final_status(
             cancelled=cancelled,

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2468,6 +2468,40 @@ def _run_worker(
 
     duration_s = time.monotonic() - start
 
+    # Everything the interrupt fallback below needs is bound BEFORE the guarded
+    # span. A handler that raises UnboundLocalError while trying to record the
+    # outcome is worse than no handler at all: it fails exactly when it is
+    # needed. (Cross-family review of this PR.)
+    final_status = _classify_final_status(
+        cancelled=cancelled,
+        rate_limited=rate_limited,
+        ok_outcome=ok_outcome,
+        timed_out=timed_out,
+    )
+
+    # A successful runtime result must carry the completed child process's
+    # return code.  Refuse to persist a misleading ``done``/null combination
+    # if a future runner regression drops it; failures without a child code
+    # retain a precise reason instead of inventing a number (#4837).
+    if final_status == "done" and returncode is None:
+        final_status = "failed"
+        ok_outcome = False
+        returncode_reason = "runtime reported success without a terminal subprocess returncode"
+        stderr_excerpt = "runtime reported success without a terminal subprocess returncode"
+    elif returncode is None and returncode_reason is None:
+        returncode_reason = "no terminal subprocess returncode was available"
+
+    final_state = _read_state(state_path) or {}
+    result_file: str | None = None
+    dirty_on_exit: bool | None = None
+    commits_ahead: int | None = None
+    needs_finalize = False
+    finalize_error: str | None = None
+    auto_finalize: AutoFinalizeResult | None = None
+    # True once the worktree telemetry has actually run: only then is
+    # ``needs_finalize`` a verdict rather than an unmeasured default.
+    telemetry_settled = False
+
     # A SIGTERM arriving anywhere in this span raises KeyboardInterrupt (see
     # _worker_sigterm_handler), which is NOT an Exception and would unwind
     # straight out of _run_worker — leaving a worker that HAS finished
@@ -2476,7 +2510,6 @@ def _run_worker(
     # that the work completed. (Cross-family review of this PR.)
     try:
         # Write the full response to a result file (may be large).
-        result_file: str | None = None
         if response:
             result_path = state_path.with_suffix(".result")
             try:
@@ -2485,39 +2518,13 @@ def _run_worker(
             except OSError:
                 result_file = None
 
-        final_status = _classify_final_status(
-            cancelled=cancelled,
-            rate_limited=rate_limited,
-            ok_outcome=ok_outcome,
-            timed_out=timed_out,
-        )
-
-        # A successful runtime result must carry the completed child process's
-        # return code.  Refuse to persist a misleading ``done``/null combination
-        # if a future runner regression drops it; failures without a child code
-        # retain a precise reason instead of inventing a number (#4837).
-        if final_status == "done" and returncode is None:
-            final_status = "failed"
-            ok_outcome = False
-            returncode_reason = "runtime reported success without a terminal subprocess returncode"
-            stderr_excerpt = "runtime reported success without a terminal subprocess returncode"
-        elif returncode is None and returncode_reason is None:
-            returncode_reason = "no terminal subprocess returncode was available"
-
-        final_state = _read_state(state_path) or {}
-
         # Fix 5 (#1476 AC 5): dispatch-finish telemetry — record whether the
         # worktree exited dirty so follow-up reviewers can see at a glance
         # that the dispatched agent left uncommitted changes behind.
-        dirty_on_exit: bool | None = None
         worktree_path = final_state.get("worktree_path")
         if worktree_path:
             dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
 
-        commits_ahead: int | None = None
-        needs_finalize = False
-        finalize_error: str | None = None
-        auto_finalize: AutoFinalizeResult | None = None
         # EVERYTHING from here to the state write is telemetry ABOUT a worker that
         # has already finished. None of it may prevent the terminal status from
         # being recorded: a task stuck at ``running`` with a dead pid is worse than
@@ -2579,6 +2586,10 @@ def _run_worker(
             # Unknown telemetry cannot prove the work was committed, so surface
             # the task for a human instead of settling it as done.
             needs_finalize = True
+        # Either way the verdict is now measured rather than assumed, so an
+        # interrupt below must persist it as-is instead of forcing attention
+        # onto a dispatch already shown to be clean and committed.
+        telemetry_settled = True
 
         if needs_finalize:
             final_status = "needs_finalize"
@@ -2619,18 +2630,30 @@ def _run_worker(
         }
         _write_state_atomic(state_path, {**final_state, **core_terminal_state})
     except BaseException as interrupt_exc:
+        # Honour a verdict the telemetry already reached; fail closed only when
+        # the interrupt beat the measurement to it — and only for modes that can
+        # leave work behind, so an interrupted read-only review is not dressed up
+        # as a dispatch needing manual finalization.
+        interrupted_needs_finalize = (
+            needs_finalize if telemetry_settled else mode in _WRITE_CAPABLE_MODES
+        )
         _write_state_atomic(
             state_path,
             {
                 **final_state,
-                "status": final_status or "cancelled",
+                # final_status is classified before this span, so it is always
+                # bound and already reflects the worker's own outcome.
+                "status": (
+                    "needs_finalize" if interrupted_needs_finalize else final_status
+                ),
                 "finished_at": datetime.now(UTC).isoformat(),
                 "duration_s": round(duration_s, 3),
                 "returncode": returncode,
                 "stderr_excerpt": stderr_excerpt,
-                # Interrupted before the worktree could be inspected, so
-                # nothing here proves the work was committed.
-                "needs_finalize": True,
+                "needs_finalize": interrupted_needs_finalize,
+                "worktree_dirty_on_exit": dirty_on_exit,
+                "commits_ahead": commits_ahead,
+                "result_file": result_file,
                 "finalize_error": (
                     f"interrupted during finalize: {type(interrupt_exc).__name__}"
                 ),

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1134,15 +1134,27 @@ def _resolve_sha(path: Path, ref: str = "HEAD") -> str | None:
 
 
 def _count_commits_ahead(worktree: Path, base_ref: str) -> int | None:
-    """Return commits on HEAD not reachable from ``base_ref``, or None."""
-    proc = subprocess.run(
-        ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
-        cwd=worktree,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=_sanitized_git_env(),
-    )
+    """Return commits on HEAD not reachable from ``base_ref``, or None.
+
+    ``None`` means "cannot count", and a vanished worktree is exactly that: on
+    2026-07-25 a dispatch whose worktree disappeared mid-run raised
+    FileNotFoundError out of here, which killed the finalize path before it
+    could write a terminal status and left the task reading ``running`` with a
+    dead pid — invisible to every settle-loop watching it. The sibling
+    ``_worktree_is_dirty`` already treated OSError as unknown; this is the same
+    contract, and callers already fail closed on ``None``.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_sanitized_git_env(),
+        )
+    except OSError:
+        return None
     if proc.returncode != 0:
         return None
     try:
@@ -2494,53 +2506,67 @@ def _run_worker(
 
     commits_ahead: int | None = None
     needs_finalize = False
+    finalize_error: str | None = None
     auto_finalize: AutoFinalizeResult | None = None
-    # The dirty-worktree safety net must cover EVERY write-capable mode, not just
-    # ``danger``. It was gated on ``danger`` alone, so a ``workspace-write``
-    # dispatch that left finished work uncommitted settled as ``done`` — a real
-    # failure reported as success. On 2026-07-25 three lanes did exactly that
-    # (``timeouts-B3``, ``timeouts-B6``, ``timeouts-B4-orig``: dirty worktrees,
-    # zero commits, ``status: done``) and 31 files of finished work were one agent
-    # restart away from being lost. Detection now runs for the whole write-capable
-    # set; the riskier auto-finalize action stays scoped to ``danger``.
-    if worktree_path and mode in _WRITE_CAPABLE_MODES:
-        base_branch = str(final_state.get("worktree_base") or "main")
-        base_ref = _origin_base_ref(base_branch)
-        commits_ahead = _count_commits_ahead(
-            Path(worktree_path),
-            base_ref,
-        )
-        # Fail CLOSED on BOTH unknowns — they are the same bug in two variables.
-        #
-        # ``_count_commits_ahead`` returns None when it cannot count, and
-        # ``commits_ahead == 0`` silently skipped that case, which is how the B4
-        # dispatch (commits_ahead=None, dirty_on_exit=True) still reported ``done``.
-        #
-        # ``_worktree_is_dirty`` can ALSO return None (OSError, or a non-zero
-        # ``git status --porcelain``). A bare ``if dirty_on_exit`` treats that unknown
-        # as falsy and skips the check entirely — failing OPEN in precisely the way
-        # this fix exists to prevent. Caught in cross-family review of #5754, which
-        # noted the asymmetry after the count half had been fixed.
-        #
-        # Neither unknown can prove the work was committed, so either one surfaces
-        # the task for finalization rather than letting it settle as ``done``.
-        if dirty_on_exit in (True, None) and commits_ahead in (0, None):
-            needs_finalize = True
-
-        if needs_finalize and returncode == 0 and mode == "danger":
-            auto_finalize = _auto_finalize_dirty_worktree(
-                worktree=Path(worktree_path),
-                task_id=task_id,
-                agent=agent,
-                branch=final_state.get("worktree_branch"),
-                base_branch=base_branch,
+    # EVERYTHING from here to the state write is telemetry ABOUT a worker that
+    # has already finished. None of it may prevent the terminal status from
+    # being recorded: a task stuck at ``running`` with a dead pid is worse than
+    # a task with unknown telemetry, because no settle-loop can ever wake on it
+    # and the operator sees a job that appears to still be working. See the
+    # 2026-07-25 incident where a vanished worktree crashed the count and hid a
+    # dead dispatch for 52 minutes.
+    try:
+        # The dirty-worktree safety net must cover EVERY write-capable mode, not just
+        # ``danger``. It was gated on ``danger`` alone, so a ``workspace-write``
+        # dispatch that left finished work uncommitted settled as ``done`` — a real
+        # failure reported as success. On 2026-07-25 three lanes did exactly that
+        # (``timeouts-B3``, ``timeouts-B6``, ``timeouts-B4-orig``: dirty worktrees,
+        # zero commits, ``status: done``) and 31 files of finished work were one agent
+        # restart away from being lost. Detection now runs for the whole write-capable
+        # set; the riskier auto-finalize action stays scoped to ``danger``.
+        if worktree_path and mode in _WRITE_CAPABLE_MODES:
+            base_branch = str(final_state.get("worktree_base") or "main")
+            base_ref = _origin_base_ref(base_branch)
+            commits_ahead = _count_commits_ahead(
+                Path(worktree_path),
+                base_ref,
             )
-            dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
-            commits_ahead = _count_commits_ahead(Path(worktree_path), base_ref)
-            if auto_finalize.ok:
-                needs_finalize = False
-                ok_outcome = True
-                final_status = "done"
+            # Fail CLOSED on BOTH unknowns — they are the same bug in two variables.
+            #
+            # ``_count_commits_ahead`` returns None when it cannot count, and
+            # ``commits_ahead == 0`` silently skipped that case, which is how the B4
+            # dispatch (commits_ahead=None, dirty_on_exit=True) still reported ``done``.
+            #
+            # ``_worktree_is_dirty`` can ALSO return None (OSError, or a non-zero
+            # ``git status --porcelain``). A bare ``if dirty_on_exit`` treats that unknown
+            # as falsy and skips the check entirely — failing OPEN in precisely the way
+            # this fix exists to prevent. Caught in cross-family review of #5754, which
+            # noted the asymmetry after the count half had been fixed.
+            #
+            # Neither unknown can prove the work was committed, so either one surfaces
+            # the task for finalization rather than letting it settle as ``done``.
+            if dirty_on_exit in (True, None) and commits_ahead in (0, None):
+                needs_finalize = True
+
+            if needs_finalize and returncode == 0 and mode == "danger":
+                auto_finalize = _auto_finalize_dirty_worktree(
+                    worktree=Path(worktree_path),
+                    task_id=task_id,
+                    agent=agent,
+                    branch=final_state.get("worktree_branch"),
+                    base_branch=base_branch,
+                )
+                dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
+                commits_ahead = _count_commits_ahead(Path(worktree_path), base_ref)
+                if auto_finalize.ok:
+                    needs_finalize = False
+                    ok_outcome = True
+                    final_status = "done"
+    except Exception as finalize_exc:  # noqa: BLE001 - telemetry must never mask the outcome
+        finalize_error = f"{type(finalize_exc).__name__}: {finalize_exc}"[:300]
+        # Unknown telemetry cannot prove the work was committed, so surface
+        # the task for a human instead of settling it as done.
+        needs_finalize = True
 
     if needs_finalize:
         final_status = "needs_finalize"
@@ -2589,6 +2615,9 @@ def _run_worker(
             "worktree_dirty_on_exit": dirty_on_exit,
             "commits_ahead": commits_ahead,
             "needs_finalize": needs_finalize,
+            # Non-null means the finish telemetry above raised: the worker's own
+            # outcome still stands, but nothing here could be measured.
+            "finalize_error": finalize_error,
             "keep_worktree": keep_worktree,
             "worktree_reap": worktree_reap,
             "tmp_bytes_freed": (
@@ -3550,7 +3579,22 @@ def cmd_status_or_fail(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 _TERMINAL_STATUSES = frozenset(
-    {"done", "failed", "timeout", "rate_limited", "crashed", "cancelled", "dry_run"},
+    {
+        "done",
+        "failed",
+        "timeout",
+        "rate_limited",
+        "crashed",
+        "cancelled",
+        "dry_run",
+        # A worker that settles as ``needs_finalize`` HAS finished — the status
+        # flags leftover work for a human, it does not mean "still running".
+        # Omitting it made ``delegate.py wait`` poll a finished task until its
+        # own timeout, and made ``cancel`` willing to signal a stored PID the OS
+        # may already have recycled. Every other terminal vocabulary in this
+        # file already includes it (see _BRANCH_HOLDER_RELEASABLE_STATUSES).
+        "needs_finalize",
+    },
 )
 
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -219,6 +219,48 @@ def _state_path(task_id: str) -> Path:
     return _TASKS_DIR / f"{safe}.json"
 
 
+def _core_terminal_fields(
+    *,
+    status: str,
+    duration_s: float,
+    response: str,
+    result_file: str | None,
+    stderr_excerpt: str | None,
+    returncode: int | None,
+    returncode_reason: str | None,
+    dirty_on_exit: bool | None,
+    commits_ahead: int | None,
+    needs_finalize: bool,
+    finalize_error: str | None,
+) -> dict[str, Any]:
+    """The complete set of fields that define a finished dispatch's outcome.
+
+    Both writers that can be the LAST word on a task — the normal checkpoint and
+    the interrupt fallback — build their record here. The fallback used to
+    hand-assemble a subset, so an interrupted run persisted a terminal status
+    beside stale placeholder ``response_chars``/``exit_code``/``last_error``:
+    the same duplication that let the return-code invariant apply on one path
+    and not the other. One definition, both paths. (Cross-family review of
+    #5807, round ten.)
+    """
+    return {
+        "status": status,
+        "finished_at": datetime.now(UTC).isoformat(),
+        "duration_s": round(duration_s, 3),
+        "response_chars": len(response),
+        "result_file": result_file,
+        "stderr_excerpt": stderr_excerpt,
+        "returncode": returncode,
+        "returncode_reason": returncode_reason,
+        "last_error": _first_error_line(stderr_excerpt) if status != "done" else None,
+        "exit_code": returncode,
+        "worktree_dirty_on_exit": dirty_on_exit,
+        "commits_ahead": commits_ahead,
+        "needs_finalize": needs_finalize,
+        "finalize_error": finalize_error,
+    }
+
+
 def _apply_returncode_invariant(status: str, returncode: int | None) -> str:
     """A success without a terminal child return code is not a success (#4837).
 
@@ -2681,22 +2723,19 @@ def _run_worker(
         # and true. Only genuinely optional metadata (reap telemetry, usage record,
         # runtime model/effort/cli labels) is left to the second write.
         # (Both points from cross-family review of this PR.)
-        core_terminal_state = {
-            "status": final_status,
-            "finished_at": datetime.now(UTC).isoformat(),
-            "duration_s": round(duration_s, 3),
-            "response_chars": len(response),
-            "result_file": result_file,
-            "stderr_excerpt": stderr_excerpt,
-            "returncode": returncode,
-            "returncode_reason": returncode_reason,
-            "last_error": last_error,
-            "exit_code": returncode,
-            "worktree_dirty_on_exit": dirty_on_exit,
-            "commits_ahead": commits_ahead,
-            "needs_finalize": needs_finalize,
-            "finalize_error": finalize_error,
-        }
+        core_terminal_state = _core_terminal_fields(
+            status=final_status,
+            duration_s=duration_s,
+            response=response,
+            result_file=result_file,
+            stderr_excerpt=stderr_excerpt,
+            returncode=returncode,
+            returncode_reason=returncode_reason,
+            dirty_on_exit=dirty_on_exit,
+            commits_ahead=commits_ahead,
+            needs_finalize=needs_finalize,
+            finalize_error=finalize_error,
+        )
         _write_state_atomic(state_path, {**final_state, **core_terminal_state})
     except BaseException as interrupt_exc:
         # Defer SIGTERM across the ENTIRE handler, not just its write. A second
@@ -2726,27 +2765,31 @@ def _run_worker(
                 ),
                 returncode,
             )
+            if interrupted_needs_finalize:
+                interrupted_status = "needs_finalize"
             _write_state_atomic(
                 state_path,
                 {
                     # final_state was read before the region, so this MERGES onto
-                    # the real task record instead of replacing it.
+                    # the real task record instead of replacing it...
                     **final_state,
-                    "status": (
-                        "needs_finalize"
-                        if interrupted_needs_finalize
-                        else interrupted_status
-                    ),
-                    "finished_at": datetime.now(UTC).isoformat(),
-                    "duration_s": round(duration_s, 3),
-                    "returncode": returncode,
-                    "stderr_excerpt": stderr_excerpt,
-                    "needs_finalize": interrupted_needs_finalize,
-                    "worktree_dirty_on_exit": dirty_on_exit,
-                    "commits_ahead": commits_ahead,
-                    "result_file": result_file,
-                    "finalize_error": (
-                        f"interrupted during finalize: {type(interrupt_exc).__name__}"
+                    # ...and the outcome fields come from the same builder the
+                    # checkpoint uses, so an interrupted run never persists a
+                    # terminal status beside stale placeholder values.
+                    **_core_terminal_fields(
+                        status=interrupted_status,
+                        duration_s=duration_s,
+                        response=response,
+                        result_file=result_file,
+                        stderr_excerpt=stderr_excerpt,
+                        returncode=returncode,
+                        returncode_reason=returncode_reason,
+                        dirty_on_exit=dirty_on_exit,
+                        commits_ahead=commits_ahead,
+                        needs_finalize=interrupted_needs_finalize,
+                        finalize_error=(
+                            f"interrupted during finalize: {type(interrupt_exc).__name__}"
+                        ),
                     ),
                 },
             )

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2468,129 +2468,176 @@ def _run_worker(
 
     duration_s = time.monotonic() - start
 
-    # Write the full response to a result file (may be large).
-    result_file: str | None = None
-    if response:
-        result_path = state_path.with_suffix(".result")
-        try:
-            result_path.write_text(response)
-            result_file = str(result_path)
-        except OSError:
-            result_file = None
-
-    final_status = _classify_final_status(
-        cancelled=cancelled,
-        rate_limited=rate_limited,
-        ok_outcome=ok_outcome,
-        timed_out=timed_out,
-    )
-
-    # A successful runtime result must carry the completed child process's
-    # return code.  Refuse to persist a misleading ``done``/null combination
-    # if a future runner regression drops it; failures without a child code
-    # retain a precise reason instead of inventing a number (#4837).
-    if final_status == "done" and returncode is None:
-        final_status = "failed"
-        ok_outcome = False
-        returncode_reason = "runtime reported success without a terminal subprocess returncode"
-        stderr_excerpt = "runtime reported success without a terminal subprocess returncode"
-    elif returncode is None and returncode_reason is None:
-        returncode_reason = "no terminal subprocess returncode was available"
-
-    final_state = _read_state(state_path) or {}
-
-    # Fix 5 (#1476 AC 5): dispatch-finish telemetry — record whether the
-    # worktree exited dirty so follow-up reviewers can see at a glance
-    # that the dispatched agent left uncommitted changes behind.
-    dirty_on_exit: bool | None = None
-    worktree_path = final_state.get("worktree_path")
-    if worktree_path:
-        dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
-
-    commits_ahead: int | None = None
-    needs_finalize = False
-    finalize_error: str | None = None
-    auto_finalize: AutoFinalizeResult | None = None
-    # EVERYTHING from here to the state write is telemetry ABOUT a worker that
-    # has already finished. None of it may prevent the terminal status from
-    # being recorded: a task stuck at ``running`` with a dead pid is worse than
-    # a task with unknown telemetry, because no settle-loop can ever wake on it
-    # and the operator sees a job that appears to still be working. See the
-    # 2026-07-25 incident where a vanished worktree crashed the count and hid a
-    # dead dispatch for 52 minutes.
+    # A SIGTERM arriving anywhere in this span raises KeyboardInterrupt (see
+    # _worker_sigterm_handler), which is NOT an Exception and would unwind
+    # straight out of _run_worker — leaving a worker that HAS finished
+    # recorded as running until some later probe guesses it crashed. The
+    # cancellation still propagates; it just does not get to erase the fact
+    # that the work completed. (Cross-family review of this PR.)
     try:
-        # The dirty-worktree safety net must cover EVERY write-capable mode, not just
-        # ``danger``. It was gated on ``danger`` alone, so a ``workspace-write``
-        # dispatch that left finished work uncommitted settled as ``done`` — a real
-        # failure reported as success. On 2026-07-25 three lanes did exactly that
-        # (``timeouts-B3``, ``timeouts-B6``, ``timeouts-B4-orig``: dirty worktrees,
-        # zero commits, ``status: done``) and 31 files of finished work were one agent
-        # restart away from being lost. Detection now runs for the whole write-capable
-        # set; the riskier auto-finalize action stays scoped to ``danger``.
-        if worktree_path and mode in _WRITE_CAPABLE_MODES:
-            base_branch = str(final_state.get("worktree_base") or "main")
-            base_ref = _origin_base_ref(base_branch)
-            commits_ahead = _count_commits_ahead(
-                Path(worktree_path),
-                base_ref,
-            )
-            # Fail CLOSED on BOTH unknowns — they are the same bug in two variables.
-            #
-            # ``_count_commits_ahead`` returns None when it cannot count, and
-            # ``commits_ahead == 0`` silently skipped that case, which is how the B4
-            # dispatch (commits_ahead=None, dirty_on_exit=True) still reported ``done``.
-            #
-            # ``_worktree_is_dirty`` can ALSO return None (OSError, or a non-zero
-            # ``git status --porcelain``). A bare ``if dirty_on_exit`` treats that unknown
-            # as falsy and skips the check entirely — failing OPEN in precisely the way
-            # this fix exists to prevent. Caught in cross-family review of #5754, which
-            # noted the asymmetry after the count half had been fixed.
-            #
-            # Neither unknown can prove the work was committed, so either one surfaces
-            # the task for finalization rather than letting it settle as ``done``.
-            if dirty_on_exit in (True, None) and commits_ahead in (0, None):
-                needs_finalize = True
+        # Write the full response to a result file (may be large).
+        result_file: str | None = None
+        if response:
+            result_path = state_path.with_suffix(".result")
+            try:
+                result_path.write_text(response)
+                result_file = str(result_path)
+            except OSError:
+                result_file = None
 
-            if needs_finalize and returncode == 0 and mode == "danger":
-                auto_finalize = _auto_finalize_dirty_worktree(
-                    worktree=Path(worktree_path),
-                    task_id=task_id,
-                    agent=agent,
-                    branch=final_state.get("worktree_branch"),
-                    base_branch=base_branch,
+        final_status = _classify_final_status(
+            cancelled=cancelled,
+            rate_limited=rate_limited,
+            ok_outcome=ok_outcome,
+            timed_out=timed_out,
+        )
+
+        # A successful runtime result must carry the completed child process's
+        # return code.  Refuse to persist a misleading ``done``/null combination
+        # if a future runner regression drops it; failures without a child code
+        # retain a precise reason instead of inventing a number (#4837).
+        if final_status == "done" and returncode is None:
+            final_status = "failed"
+            ok_outcome = False
+            returncode_reason = "runtime reported success without a terminal subprocess returncode"
+            stderr_excerpt = "runtime reported success without a terminal subprocess returncode"
+        elif returncode is None and returncode_reason is None:
+            returncode_reason = "no terminal subprocess returncode was available"
+
+        final_state = _read_state(state_path) or {}
+
+        # Fix 5 (#1476 AC 5): dispatch-finish telemetry — record whether the
+        # worktree exited dirty so follow-up reviewers can see at a glance
+        # that the dispatched agent left uncommitted changes behind.
+        dirty_on_exit: bool | None = None
+        worktree_path = final_state.get("worktree_path")
+        if worktree_path:
+            dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
+
+        commits_ahead: int | None = None
+        needs_finalize = False
+        finalize_error: str | None = None
+        auto_finalize: AutoFinalizeResult | None = None
+        # EVERYTHING from here to the state write is telemetry ABOUT a worker that
+        # has already finished. None of it may prevent the terminal status from
+        # being recorded: a task stuck at ``running`` with a dead pid is worse than
+        # a task with unknown telemetry, because no settle-loop can ever wake on it
+        # and the operator sees a job that appears to still be working. See the
+        # 2026-07-25 incident where a vanished worktree crashed the count and hid a
+        # dead dispatch for 52 minutes.
+        try:
+            # The dirty-worktree safety net must cover EVERY write-capable mode, not just
+            # ``danger``. It was gated on ``danger`` alone, so a ``workspace-write``
+            # dispatch that left finished work uncommitted settled as ``done`` — a real
+            # failure reported as success. On 2026-07-25 three lanes did exactly that
+            # (``timeouts-B3``, ``timeouts-B6``, ``timeouts-B4-orig``: dirty worktrees,
+            # zero commits, ``status: done``) and 31 files of finished work were one agent
+            # restart away from being lost. Detection now runs for the whole write-capable
+            # set; the riskier auto-finalize action stays scoped to ``danger``.
+            if worktree_path and mode in _WRITE_CAPABLE_MODES:
+                base_branch = str(final_state.get("worktree_base") or "main")
+                base_ref = _origin_base_ref(base_branch)
+                commits_ahead = _count_commits_ahead(
+                    Path(worktree_path),
+                    base_ref,
                 )
-                dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
-                commits_ahead = _count_commits_ahead(Path(worktree_path), base_ref)
-                if auto_finalize.ok:
-                    needs_finalize = False
-                    ok_outcome = True
-                    final_status = "done"
-    # Deliberately broad: this is measurement about a worker that has already
-    # finished, and no measurement failure may cost the task its terminal status.
-    except Exception as finalize_exc:
-        finalize_error = f"{type(finalize_exc).__name__}: {finalize_exc}"[:300]
-        # Unknown telemetry cannot prove the work was committed, so surface
-        # the task for a human instead of settling it as done.
-        needs_finalize = True
+                # Fail CLOSED on BOTH unknowns — they are the same bug in two variables.
+                #
+                # ``_count_commits_ahead`` returns None when it cannot count, and
+                # ``commits_ahead == 0`` silently skipped that case, which is how the B4
+                # dispatch (commits_ahead=None, dirty_on_exit=True) still reported ``done``.
+                #
+                # ``_worktree_is_dirty`` can ALSO return None (OSError, or a non-zero
+                # ``git status --porcelain``). A bare ``if dirty_on_exit`` treats that unknown
+                # as falsy and skips the check entirely — failing OPEN in precisely the way
+                # this fix exists to prevent. Caught in cross-family review of #5754, which
+                # noted the asymmetry after the count half had been fixed.
+                #
+                # Neither unknown can prove the work was committed, so either one surfaces
+                # the task for finalization rather than letting it settle as ``done``.
+                if dirty_on_exit in (True, None) and commits_ahead in (0, None):
+                    needs_finalize = True
 
-    if needs_finalize:
-        final_status = "needs_finalize"
+                if needs_finalize and returncode == 0 and mode == "danger":
+                    auto_finalize = _auto_finalize_dirty_worktree(
+                        worktree=Path(worktree_path),
+                        task_id=task_id,
+                        agent=agent,
+                        branch=final_state.get("worktree_branch"),
+                        base_branch=base_branch,
+                    )
+                    dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
+                    commits_ahead = _count_commits_ahead(Path(worktree_path), base_ref)
+                    if auto_finalize.ok:
+                        needs_finalize = False
+                        ok_outcome = True
+                        final_status = "done"
+        # Deliberately broad: this is measurement about a worker that has already
+        # finished, and no measurement failure may cost the task its terminal status.
+        except Exception as finalize_exc:
+            finalize_error = f"{type(finalize_exc).__name__}: {finalize_exc}"[:300]
+            # Unknown telemetry cannot prove the work was committed, so surface
+            # the task for a human instead of settling it as done.
+            needs_finalize = True
 
-    # CHECKPOINT: record that this worker finished, before any further
-    # best-effort work. Everything below — worktree reaping, usage extraction,
-    # the enriched state assembly — is enrichment, and any of it can raise:
-    # `_reap_finished_worktree` performs its import OUTSIDE its own exception
-    # handler, so an unimportable reaper module would skip the final write
-    # entirely and stand the task back up as ``running`` with a dead pid. That
-    # is the exact failure this change exists to remove, so the terminal status
-    # is persisted first and enriched afterwards rather than being persisted
-    # once at the end. (Found in cross-family review of this PR.)
-    _write_state_atomic(
-        state_path,
-        {**final_state, "status": final_status, "finalize_error": finalize_error},
-    )
+        if needs_finalize:
+            final_status = "needs_finalize"
 
-    last_error = _first_error_line(stderr_excerpt) if final_status != "done" else None
+        last_error = _first_error_line(stderr_excerpt) if final_status != "done" else None
+
+        # CHECKPOINT: persist the COMPLETE core outcome before any best-effort work.
+        #
+        # Everything below — worktree reaping, usage extraction, the enriched state
+        # assembly — is enrichment, and any of it can raise: `_reap_finished_worktree`
+        # performed its import outside its own handler, so an unimportable reaper
+        # module skipped the write entirely and stood the task back up as ``running``
+        # with a dead pid. Ordering fixes that by construction, where wrapping each
+        # statement would only hold until someone adds the next one.
+        #
+        # The checkpoint carries every field that defines the outcome, not just the
+        # status: a watcher that sees ``done`` must not find null ``finished_at`` /
+        # ``duration_s`` / ``result_file`` / ``returncode`` next to it, and if this
+        # process dies mid-enrichment the surviving record must still be complete
+        # and true. Only genuinely optional metadata (reap telemetry, usage record,
+        # runtime model/effort/cli labels) is left to the second write.
+        # (Both points from cross-family review of this PR.)
+        core_terminal_state = {
+            "status": final_status,
+            "finished_at": datetime.now(UTC).isoformat(),
+            "duration_s": round(duration_s, 3),
+            "response_chars": len(response),
+            "result_file": result_file,
+            "stderr_excerpt": stderr_excerpt,
+            "returncode": returncode,
+            "returncode_reason": returncode_reason,
+            "last_error": last_error,
+            "exit_code": returncode,
+            "worktree_dirty_on_exit": dirty_on_exit,
+            "commits_ahead": commits_ahead,
+            "needs_finalize": needs_finalize,
+            "finalize_error": finalize_error,
+        }
+        _write_state_atomic(state_path, {**final_state, **core_terminal_state})
+    except BaseException as interrupt_exc:
+        _write_state_atomic(
+            state_path,
+            {
+                **final_state,
+                "status": final_status or "cancelled",
+                "finished_at": datetime.now(UTC).isoformat(),
+                "duration_s": round(duration_s, 3),
+                "returncode": returncode,
+                "stderr_excerpt": stderr_excerpt,
+                # Interrupted before the worktree could be inspected, so
+                # nothing here proves the work was committed.
+                "needs_finalize": True,
+                "finalize_error": (
+                    f"interrupted during finalize: {type(interrupt_exc).__name__}"
+                ),
+            },
+        )
+        raise
+
     if last_error:
         # Task logs capture this worker's stderr, while agent_runtime captures
         # the CLI child's stderr internally. Re-emit the excerpt so an
@@ -2617,26 +2664,14 @@ def _run_worker(
 
     final_state.update(
         {
+            # The core outcome was already checkpointed above; re-stating it here
+            # keeps this write self-contained and idempotent — same values, so a
+            # reader between the two writes never sees the status change.
+            **core_terminal_state,
             "model": getattr(result, "model", final_state.get("model")),
             "effort": getattr(result, "effort", final_state.get("effort")),
             "cli_version": getattr(result, "cli_version", final_state.get("cli_version")),
             "substitution": substitution,
-            "status": final_status,
-            "finished_at": datetime.now(UTC).isoformat(),
-            "duration_s": round(duration_s, 3),
-            "response_chars": len(response),
-            "result_file": result_file,
-            "stderr_excerpt": stderr_excerpt,
-            "returncode": returncode,
-            "returncode_reason": returncode_reason,
-            "last_error": last_error,
-            "exit_code": returncode,
-            "worktree_dirty_on_exit": dirty_on_exit,
-            "commits_ahead": commits_ahead,
-            "needs_finalize": needs_finalize,
-            # Non-null means the finish telemetry above raised: the worker's own
-            # outcome still stands, but nothing here could be measured.
-            "finalize_error": finalize_error,
             "keep_worktree": keep_worktree,
             "worktree_reap": worktree_reap,
             "tmp_bytes_freed": (

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1475,9 +1475,12 @@ def _reap_finished_worktree(worktree: Path) -> dict[str, Any]:
     """Try to reap a clean successful delegate worktree, returning state metadata."""
     if str(_REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(_REPO_ROOT))
-    from scripts.orchestration import reap_worktrees
 
     try:
+        # Imported inside the handler: an unimportable reaper is a reaping
+        # failure like any other, not a reason to take down the caller.
+        from scripts.orchestration import reap_worktrees
+
         results = reap_worktrees.reap_worktrees(
             repo_root=_REPO_ROOT,
             apply=True,
@@ -2572,6 +2575,20 @@ def _run_worker(
 
     if needs_finalize:
         final_status = "needs_finalize"
+
+    # CHECKPOINT: record that this worker finished, before any further
+    # best-effort work. Everything below — worktree reaping, usage extraction,
+    # the enriched state assembly — is enrichment, and any of it can raise:
+    # `_reap_finished_worktree` performs its import OUTSIDE its own exception
+    # handler, so an unimportable reaper module would skip the final write
+    # entirely and stand the task back up as ``running`` with a dead pid. That
+    # is the exact failure this change exists to remove, so the terminal status
+    # is persisted first and enriched afterwards rather than being persisted
+    # once at the end. (Found in cross-family review of this PR.)
+    _write_state_atomic(
+        state_path,
+        {**final_state, "status": final_status, "finalize_error": finalize_error},
+    )
 
     last_error = _first_error_line(stderr_excerpt) if final_status != "done" else None
     if last_error:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2504,49 +2504,51 @@ def _run_worker(
                     runtime_tmp_namespace_root,
                 )
 
+    # ONE recovery region covers everything between "the worker finished" and
+    # "that fact is on disk". Five review rounds of patching individual windows
+    # — the reaper, the checkpoint, a second signal, lease cleanup — each closed
+    # an instance and left the next one open, because the interval kept being
+    # split into guarded and unguarded halves. The region below is the whole
+    # interval, so a cancellation anywhere in it records the outcome and then
+    # continues to propagate. What remains uncoverable in-process is SIGKILL,
+    # which the dead-pid probe in cmd_status/cmd_wait already handles.
+    #
+    # Nothing the fallback reads may be bound only inside this region: a handler
+    # that raises UnboundLocalError fails exactly when it is needed.
+    final_state: dict[str, Any] = {}
+    final_status = ""
     duration_s = time.monotonic() - start
-
-    # Everything the interrupt fallback below needs is bound BEFORE the guarded
-    # span. A handler that raises UnboundLocalError while trying to record the
-    # outcome is worse than no handler at all: it fails exactly when it is
-    # needed. (Cross-family review of this PR.)
-    final_status = _classify_final_status(
-        cancelled=cancelled,
-        rate_limited=rate_limited,
-        ok_outcome=ok_outcome,
-        timed_out=timed_out,
-    )
-
-    # A successful runtime result must carry the completed child process's
-    # return code.  Refuse to persist a misleading ``done``/null combination
-    # if a future runner regression drops it; failures without a child code
-    # retain a precise reason instead of inventing a number (#4837).
-    if final_status == "done" and returncode is None:
-        final_status = "failed"
-        ok_outcome = False
-        returncode_reason = "runtime reported success without a terminal subprocess returncode"
-        stderr_excerpt = "runtime reported success without a terminal subprocess returncode"
-    elif returncode is None and returncode_reason is None:
-        returncode_reason = "no terminal subprocess returncode was available"
-
-    final_state = _read_state(state_path) or {}
     result_file: str | None = None
     dirty_on_exit: bool | None = None
     commits_ahead: int | None = None
     needs_finalize = False
     finalize_error: str | None = None
     auto_finalize: AutoFinalizeResult | None = None
-    # True once the worktree telemetry has actually run: only then is
-    # ``needs_finalize`` a verdict rather than an unmeasured default.
     telemetry_settled = False
 
-    # A SIGTERM arriving anywhere in this span raises KeyboardInterrupt (see
-    # _worker_sigterm_handler), which is NOT an Exception and would unwind
-    # straight out of _run_worker — leaving a worker that HAS finished
-    # recorded as running until some later probe guesses it crashed. The
-    # cancellation still propagates; it just does not get to erase the fact
-    # that the work completed. (Cross-family review of this PR.)
     try:
+        duration_s = time.monotonic() - start
+        final_status = _classify_final_status(
+            cancelled=cancelled,
+            rate_limited=rate_limited,
+            ok_outcome=ok_outcome,
+            timed_out=timed_out,
+        )
+
+        # A successful runtime result must carry the completed child process's
+        # return code.  Refuse to persist a misleading ``done``/null combination
+        # if a future runner regression drops it; failures without a child code
+        # retain a precise reason instead of inventing a number (#4837).
+        if final_status == "done" and returncode is None:
+            final_status = "failed"
+            ok_outcome = False
+            returncode_reason = "runtime reported success without a terminal subprocess returncode"
+            stderr_excerpt = "runtime reported success without a terminal subprocess returncode"
+        elif returncode is None and returncode_reason is None:
+            returncode_reason = "no terminal subprocess returncode was available"
+
+        final_state = _read_state(state_path) or {}
+
         # Write the full response to a result file (may be large).
         if response:
             result_path = state_path.with_suffix(".result")
@@ -2675,6 +2677,14 @@ def _run_worker(
         interrupted_needs_finalize = (
             needs_finalize if telemetry_settled else mode in _WRITE_CAPABLE_MODES
         )
+        # The interrupt may have landed before classification ran, so derive the
+        # outcome from the runtime flags rather than persisting an empty status.
+        interrupted_status = final_status or _classify_final_status(
+            cancelled=cancelled,
+            rate_limited=rate_limited,
+            ok_outcome=ok_outcome,
+            timed_out=timed_out,
+        )
         with _sigterm_deferred():
             _write_state_atomic(
                 state_path,
@@ -2683,7 +2693,9 @@ def _run_worker(
                     # final_status is classified before this span, so it is
                     # always bound and reflects the worker's own outcome.
                     "status": (
-                        "needs_finalize" if interrupted_needs_finalize else final_status
+                        "needs_finalize"
+                        if interrupted_needs_finalize
+                        else interrupted_status
                     ),
                     "finished_at": datetime.now(UTC).isoformat(),
                     "duration_s": round(duration_s, 3),

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2489,10 +2489,20 @@ def _run_worker(
         returncode_reason = "unexpected worker exception before a terminal subprocess returncode was available"
     finally:
         if runtime_tmp_root is not None or runtime_tmp_namespace_root is not None:
-            runtime_tmp_reap = _reap_runtime_tmp_lease(
-                runtime_tmp_root,
-                runtime_tmp_namespace_root,
-            )
+            # This cleanup runs AFTER the worker has finished but BEFORE the
+            # guarded span below, and it catches Exception rather than the
+            # KeyboardInterrupt a SIGTERM raises — so a cancel landing here used
+            # to unwind out of _run_worker with no terminal status written.
+            # Deferring the signal across the cleanup drops a cancel that has
+            # nothing left to cancel (the work is already done) in exchange for
+            # never losing the record that it was done. (Cross-family review of
+            # #5807.) Cleanup stays in `finally` so an interrupt during the
+            # runtime call itself still frees the lease.
+            with _sigterm_deferred():
+                runtime_tmp_reap = _reap_runtime_tmp_lease(
+                    runtime_tmp_root,
+                    runtime_tmp_namespace_root,
+                )
 
     duration_s = time.monotonic() - start
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2453,7 +2453,13 @@ def _run_worker(
     # Nothing the fallback reads may be bound only inside this region: a handler
     # that raises UnboundLocalError fails exactly when it is needed. Every name
     # it touches is initialized above, including the runtime-outcome flags.
-    final_state: dict[str, Any] = {}
+    # Read the persisted record BEFORE the region, not inside it. Starting the
+    # fallback from {} meant an early interrupt atomically REPLACED the task
+    # file — recording a terminal status while destroying task_id, pid, mode,
+    # cwd and worktree metadata that status/wait/cleanup and the operator all
+    # read. A terminal status with no context is not an improvement over a stale
+    # running one. (Cross-family review of #5807, round nine.)
+    final_state: dict[str, Any] = _read_state(state_path) or {}
     final_status = ""
     duration_s = time.monotonic() - start
     result_file: str | None = None
@@ -2693,32 +2699,39 @@ def _run_worker(
         }
         _write_state_atomic(state_path, {**final_state, **core_terminal_state})
     except BaseException as interrupt_exc:
-        # Honour a verdict the telemetry already reached; fail closed only when
-        # the interrupt beat the measurement to it — and only for modes that can
-        # leave work behind, so an interrupted read-only review is not dressed up
-        # as a dispatch needing manual finalization.
-        interrupted_needs_finalize = (
-            needs_finalize if telemetry_settled else mode in _WRITE_CAPABLE_MODES
-        )
-        # The interrupt may have landed before classification ran, so derive the
-        # outcome from the runtime flags rather than persisting an empty status.
-        interrupted_status = _apply_returncode_invariant(
-            final_status
-            or _classify_final_status(
-                cancelled=cancelled,
-                rate_limited=rate_limited,
-                ok_outcome=ok_outcome,
-                timed_out=timed_out,
-            ),
-            returncode,
-        )
+        # Defer SIGTERM across the ENTIRE handler, not just its write. A second
+        # cancel arriving while the fallback was still computing raised from
+        # inside this `except` suite, which the same suite cannot catch — the
+        # same boundary-between-guarded-spans mistake as the region itself, one
+        # level down. (Cross-family review of #5807, round nine.)
         with _sigterm_deferred():
+            # Honour a verdict the telemetry already reached; fail closed only
+            # when the interrupt beat the measurement to it — and only for modes
+            # that can leave work behind, so an interrupted read-only review is
+            # not dressed up as a dispatch needing manual finalization.
+            interrupted_needs_finalize = (
+                needs_finalize if telemetry_settled else mode in _WRITE_CAPABLE_MODES
+            )
+            # The interrupt may have landed before classification ran, so derive
+            # the outcome from the runtime flags rather than persisting an empty
+            # status, and apply the same return-code invariant the normal path
+            # enforces.
+            interrupted_status = _apply_returncode_invariant(
+                final_status
+                or _classify_final_status(
+                    cancelled=cancelled,
+                    rate_limited=rate_limited,
+                    ok_outcome=ok_outcome,
+                    timed_out=timed_out,
+                ),
+                returncode,
+            )
             _write_state_atomic(
                 state_path,
                 {
+                    # final_state was read before the region, so this MERGES onto
+                    # the real task record instead of replacing it.
                     **final_state,
-                    # final_status is classified before this span, so it is
-                    # always bound and reflects the worker's own outcome.
                     "status": (
                         "needs_finalize"
                         if interrupted_needs_finalize

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -87,6 +87,7 @@ Issue: #1184.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
 import logging
@@ -216,6 +217,33 @@ def _state_path(task_id: str) -> Path:
     # task-ids with slashes would break paths; sanitize
     safe = task_id.replace("/", "_").replace("\\", "_")
     return _TASKS_DIR / f"{safe}.json"
+
+
+@contextlib.contextmanager
+def _sigterm_deferred():
+    """Ignore SIGTERM for the duration of a critical write, then restore.
+
+    The worker's SIGTERM handler raises KeyboardInterrupt, and an exception
+    raised inside an ``except`` suite is not caught by that same suite. So a
+    SECOND cancel arriving while the terminal-status fallback is writing escapes
+    before the atomic rename, and the task stays recorded as ``running`` even
+    though its worker finished — the very failure the fallback exists to prevent
+    (cross-family review of #5807).
+
+    The window is one small file write. Deferring the signal across it cannot
+    hang a cancel meaningfully, and the interrupt is re-raised immediately after.
+    Degrades to a no-op off the main thread, where ``signal.signal`` is illegal.
+    """
+    try:
+        previous = signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    except (ValueError, OSError):  # not the main thread — nothing to defer
+        yield
+        return
+    try:
+        yield
+    finally:
+        with contextlib.suppress(ValueError, OSError):
+            signal.signal(signal.SIGTERM, previous)
 
 
 def _write_state_atomic(path: Path, state: dict[str, Any]) -> None:
@@ -2637,28 +2665,29 @@ def _run_worker(
         interrupted_needs_finalize = (
             needs_finalize if telemetry_settled else mode in _WRITE_CAPABLE_MODES
         )
-        _write_state_atomic(
-            state_path,
-            {
-                **final_state,
-                # final_status is classified before this span, so it is always
-                # bound and already reflects the worker's own outcome.
-                "status": (
-                    "needs_finalize" if interrupted_needs_finalize else final_status
-                ),
-                "finished_at": datetime.now(UTC).isoformat(),
-                "duration_s": round(duration_s, 3),
-                "returncode": returncode,
-                "stderr_excerpt": stderr_excerpt,
-                "needs_finalize": interrupted_needs_finalize,
-                "worktree_dirty_on_exit": dirty_on_exit,
-                "commits_ahead": commits_ahead,
-                "result_file": result_file,
-                "finalize_error": (
-                    f"interrupted during finalize: {type(interrupt_exc).__name__}"
-                ),
-            },
-        )
+        with _sigterm_deferred():
+            _write_state_atomic(
+                state_path,
+                {
+                    **final_state,
+                    # final_status is classified before this span, so it is
+                    # always bound and reflects the worker's own outcome.
+                    "status": (
+                        "needs_finalize" if interrupted_needs_finalize else final_status
+                    ),
+                    "finished_at": datetime.now(UTC).isoformat(),
+                    "duration_s": round(duration_s, 3),
+                    "returncode": returncode,
+                    "stderr_excerpt": stderr_excerpt,
+                    "needs_finalize": interrupted_needs_finalize,
+                    "worktree_dirty_on_exit": dirty_on_exit,
+                    "commits_ahead": commits_ahead,
+                    "result_file": result_file,
+                    "finalize_error": (
+                        f"interrupted during finalize: {type(interrupt_exc).__name__}"
+                    ),
+                },
+            )
         raise
 
     if last_error:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -219,6 +219,20 @@ def _state_path(task_id: str) -> Path:
     return _TASKS_DIR / f"{safe}.json"
 
 
+def _apply_returncode_invariant(status: str, returncode: int | None) -> str:
+    """A success without a terminal child return code is not a success (#4837).
+
+    Lives on its own because it is applied twice: once on the normal completion
+    path and once in the interrupt fallback. When only the normal path enforced
+    it, a cancel landing between classification and the check persisted
+    ``done`` with a null return code — the fallback contradicting the invariant
+    precisely when it was exercised (cross-family review of #5807).
+    """
+    if status == "done" and returncode is None:
+        return "failed"
+    return status
+
+
 @contextlib.contextmanager
 def _sigterm_deferred():
     """Ignore SIGTERM for the duration of a critical write, then restore.
@@ -2539,8 +2553,8 @@ def _run_worker(
         # return code.  Refuse to persist a misleading ``done``/null combination
         # if a future runner regression drops it; failures without a child code
         # retain a precise reason instead of inventing a number (#4837).
-        if final_status == "done" and returncode is None:
-            final_status = "failed"
+        if _apply_returncode_invariant(final_status, returncode) != final_status:
+            final_status = _apply_returncode_invariant(final_status, returncode)
             ok_outcome = False
             returncode_reason = "runtime reported success without a terminal subprocess returncode"
             stderr_excerpt = "runtime reported success without a terminal subprocess returncode"
@@ -2679,11 +2693,15 @@ def _run_worker(
         )
         # The interrupt may have landed before classification ran, so derive the
         # outcome from the runtime flags rather than persisting an empty status.
-        interrupted_status = final_status or _classify_final_status(
-            cancelled=cancelled,
-            rate_limited=rate_limited,
-            ok_outcome=ok_outcome,
-            timed_out=timed_out,
+        interrupted_status = _apply_returncode_invariant(
+            final_status
+            or _classify_final_status(
+                cancelled=cancelled,
+                rate_limited=rate_limited,
+                ok_outcome=ok_outcome,
+                timed_out=timed_out,
+            ),
+            returncode,
         )
         with _sigterm_deferred():
             _write_state_atomic(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4683,3 +4683,65 @@ def test_interrupt_during_the_runtime_call_still_records_a_terminal_status(
     assert state is not None
     assert state["status"] != "running", "a killed worker was left claiming to run"
     assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]
+
+
+def test_interrupt_at_the_cleanup_boundary_is_inside_the_region(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """The exact boundary round eight reported: cleanup done, handler restored.
+
+    _sigterm_deferred restores the SIGTERM handler on exit, and the old region
+    began only afterwards — so a signal delivered in that instruction gap
+    escaped. Raising from the context manager's exit places the interrupt
+    precisely there. It now lands inside the region because the runtime
+    `finally` is itself inside it.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("boundary-interrupt")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "boundary-interrupt",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "done", "stderr_excerpt": None, "returncode": 0,
+            "rate_limited": False, "model": "gpt-5.5", "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    @contextlib.contextmanager
+    def interrupt_on_restore():
+        yield
+        raise KeyboardInterrupt("SIGTERM as the handler was restored")
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_sigterm_deferred", interrupt_on_restore),
+        patch.object(delegate, "_worktree_is_dirty", return_value=False),
+        patch.object(delegate, "_count_commits_ahead", return_value=2),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="boundary-interrupt",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+                runtime_tmp_root=str(tmp_path / "runtime-tmp"),
+            )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] != "running", "interrupt at the boundary stranded the task"
+    assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4745,3 +4745,143 @@ def test_interrupt_at_the_cleanup_boundary_is_inside_the_region(
     assert state is not None
     assert state["status"] != "running", "interrupt at the boundary stranded the task"
     assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]
+
+
+def test_interrupt_fallback_preserves_the_task_record(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """The fallback must MERGE onto the task record, never replace it.
+
+    Cross-family review of #5807, round nine (F002): the fallback started from
+    an empty dict, so an early interrupt atomically replaced the task file —
+    recording a terminal status while destroying task_id, pid, mode, cwd and
+    worktree metadata that status/wait/cleanup and the operator all read. A
+    terminal status with no context is not an improvement over a stale running
+    one; it is a different way to lose the same information.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("preserve-record")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "preserve-record",
+        "status": "running",
+        "pid": 4242,
+        "mode": "workspace-write",
+        "agent": "codex",
+        "cwd": str(tmp_path),
+        "worktree_path": str(tmp_path),
+        "worktree_branch": "codex/preserve-record",
+        "worktree_base": "main",
+        "prompt_chars": 17,
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "done", "stderr_excerpt": None, "returncode": 0,
+            "rate_limited": False, "model": "gpt-5.5", "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    @contextlib.contextmanager
+    def interrupt_on_restore():
+        yield
+        raise KeyboardInterrupt("SIGTERM at the cleanup boundary")
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_sigterm_deferred", interrupt_on_restore),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="preserve-record",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+                runtime_tmp_root=str(tmp_path / "runtime-tmp"),
+            )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] != "running"
+    # Every field the rest of the system reads must still be there.
+    # (pid is legitimately rewritten to the live worker pid early in the run,
+    # so assert it is still recorded rather than pinning the seeded value.)
+    assert isinstance(state.get("pid"), int)
+    for key, expected in (
+        ("task_id", "preserve-record"),
+        ("agent", "codex"),
+        ("worktree_branch", "codex/preserve-record"),
+        ("worktree_path", str(tmp_path)),
+        ("prompt_chars", 17),
+    ):
+        assert state.get(key) == expected, f"fallback dropped {key}: {state.get(key)!r}"
+
+
+def test_interrupt_fallback_defers_sigterm_before_computing(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """SIGTERM is deferred for the whole handler, not only its write.
+
+    Round nine (F001): fallback computations ran before the deferral, so a
+    second cancel raised from inside the `except` suite — which that suite
+    cannot catch — and nothing was written.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("defer-before-compute")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "defer-before-compute",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "done", "stderr_excerpt": None, "returncode": 0,
+            "rate_limited": False, "model": "gpt-5.5", "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    seen = {}
+    real_invariant = delegate._apply_returncode_invariant
+
+    def observe(status, returncode):
+        # Runs inside the fallback, BEFORE the state write.
+        seen["disposition"] = signal.getsignal(signal.SIGTERM)
+        return real_invariant(status, returncode)
+
+    def cancel(*_args, **_kwargs):
+        raise KeyboardInterrupt("first SIGTERM")
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_worktree_is_dirty", side_effect=cancel),
+        patch.object(delegate, "_apply_returncode_invariant", side_effect=observe),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="defer-before-compute",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+            )
+
+    assert seen.get("disposition") is signal.SIG_IGN, seen
+    assert signal.getsignal(signal.SIGTERM) is not signal.SIG_IGN

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4550,3 +4550,68 @@ def test_sigterm_during_runtime_lease_cleanup_cannot_lose_the_outcome(
     assert signal.getsignal(signal.SIGTERM) is not signal.SIG_IGN
     state = delegate._read_state(state_path)
     assert state is not None and state["status"] in delegate._TERMINAL_STATUSES
+
+
+def test_interrupt_in_the_post_cleanup_gap_still_records_the_outcome(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """The window between lease cleanup and classification is covered too.
+
+    Cross-family review of #5807, round six: each earlier fix guarded one window
+    and left the next one open. The recovery region now spans everything between
+    the worker finishing and that fact being on disk, so an interrupt during
+    status classification — previously unguarded — still persists a terminal
+    record.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("gap-interrupt")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "gap-interrupt",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "done", "stderr_excerpt": None, "returncode": 0,
+            "rate_limited": False, "model": "gpt-5.5", "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    calls = {"n": 0}
+    real_classify = delegate._classify_final_status
+
+    def interrupt_on_first_classify(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise KeyboardInterrupt("SIGTERM during classification")
+        return real_classify(**kwargs)
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_classify_final_status", side_effect=interrupt_on_first_classify),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="gap-interrupt",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+            )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] != "running", "interrupt in the gap stranded a finished worker"
+    assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]
+    # The fallback derived a real outcome instead of persisting an empty status.
+    assert state["status"] in {"needs_finalize", "done"}

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4073,3 +4073,80 @@ def test_apply_dispatch_sparse_checkout_real_git(tmp_path):
     assert meta3["full_checkout"] is True
     assert (worktree / "curriculum" / "f.txt").is_file()
     assert (worktree / "wiki" / "f.txt").is_file()
+
+
+def test_count_commits_ahead_treats_a_vanished_worktree_as_unknown(tmp_path):
+    """A missing worktree is "cannot count", not an exception.
+
+    _worktree_is_dirty already returned None on OSError; its sibling raised, and
+    that asymmetry took down a whole dispatch's finalize path (2026-07-25).
+    """
+    missing = tmp_path / "never-existed"
+    assert delegate._count_commits_ahead(missing, "origin/main") is None
+    assert delegate._worktree_is_dirty(missing) is None
+
+
+def test_run_worker_reaches_a_terminal_status_when_finalize_telemetry_raises(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """Finish telemetry must never cost the task its terminal status.
+
+    A task left at "running" with a dead pid is invisible to every settle-loop
+    watching it: the operator sees a job that still looks busy, forever. On
+    2026-07-25 a dispatch whose worktree disappeared mid-run did exactly that and
+    hid a dead worker for 52 minutes.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("finalize-explodes")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "finalize-explodes",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+    (tmp_path / "work.txt").write_text("finished work", encoding="utf-8")
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "gpt-5.5",
+            "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    def explode(*_args, **_kwargs):
+        raise FileNotFoundError(2, "No such file or directory", str(tmp_path))
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_count_commits_ahead", side_effect=explode),
+    ):
+        delegate._run_worker(
+            task_id="finalize-explodes",
+            agent="codex",
+            prompt="hi",
+            mode="workspace-write",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+            effort="xhigh",
+        )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]
+    assert state["status"] != "running"
+    # Unknown telemetry cannot prove the work was committed, so it surfaces.
+    assert state["needs_finalize"] is True
+    assert state["status"] == "needs_finalize"
+    # And the reason the telemetry is unknown is recorded, not swallowed.
+    assert "FileNotFoundError" in (state.get("finalize_error") or "")

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4885,3 +4885,68 @@ def test_interrupt_fallback_defers_sigterm_before_computing(
 
     assert seen.get("disposition") is signal.SIG_IGN, seen
     assert signal.getsignal(signal.SIGTERM) is not signal.SIG_IGN
+
+
+def test_interrupt_fallback_records_the_complete_outcome(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """The fallback's record must be as complete as the checkpoint's.
+
+    Round ten of cross-family review on #5807: the fallback hand-assembled a
+    subset of the outcome fields, so an interrupted run persisted a terminal
+    status beside stale placeholder response_chars / exit_code / last_error.
+    Both writers now build their record from _core_terminal_fields.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("complete-outcome")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "complete-outcome",
+        "status": "running",
+        "response_chars": None,
+        "exit_code": None,
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "a real response body", "stderr_excerpt": None,
+            "returncode": 0, "rate_limited": False, "model": "gpt-5.5",
+            "effort": "xhigh", "cli_version": "0.131.0",
+        },
+    )()
+
+    @contextlib.contextmanager
+    def interrupt_on_restore():
+        yield
+        raise KeyboardInterrupt("SIGTERM at the cleanup boundary")
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_sigterm_deferred", interrupt_on_restore),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="complete-outcome",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+                runtime_tmp_root=str(tmp_path / "runtime-tmp"),
+            )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    # No placeholder may survive next to a terminal status.
+    assert state["response_chars"] == len("a real response body")
+    assert state["exit_code"] == 0
+    assert state["returncode"] == 0
+    assert state.get("finished_at")
+    assert isinstance(state.get("duration_s"), float)

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4230,3 +4230,61 @@ def test_reap_finished_worktree_survives_an_unimportable_reaper(tmp_path, monkey
     out = delegate._reap_finished_worktree(tmp_path)
     assert isinstance(out, dict)
     assert out.get("ok") is not True
+
+
+def test_run_worker_records_completion_even_when_cancelled_during_finalize(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A SIGTERM after the worker finished must not erase that it finished.
+
+    _worker_sigterm_handler raises KeyboardInterrupt, which is a BaseException:
+    an Exception-only guard let it unwind straight out of _run_worker, leaving a
+    completed worker recorded as running until some later probe guessed it had
+    crashed. Cross-family review of #5807.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("cancelled-in-finalize")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "cancelled-in-finalize",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "done", "stderr_excerpt": None, "returncode": 0,
+            "rate_limited": False, "model": "gpt-5.5", "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    def cancel(*_args, **_kwargs):
+        raise KeyboardInterrupt("SIGTERM during finalize")
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_worktree_is_dirty", side_effect=cancel),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="cancelled-in-finalize",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+            )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] != "running", "cancellation erased a completed worker"
+    assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]
+    assert state["needs_finalize"] is True
+    assert "KeyboardInterrupt" in (state.get("finalize_error") or "")

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4638,3 +4638,48 @@ def test_returncode_invariant_is_shared_by_both_status_paths():
     # Non-success statuses are never rewritten by it.
     for status in ("failed", "timeout", "rate_limited", "cancelled", "needs_finalize"):
         assert delegate._apply_returncode_invariant(status, None) == status
+
+
+def test_interrupt_during_the_runtime_call_still_records_a_terminal_status(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """The region covers the runtime call itself, not just what follows it.
+
+    Round eight of cross-family review on #5807 found a SIGTERM window between
+    the deferred lease cleanup and the old region's start. That was the fifth
+    boundary of the same shape, so the region now spans the runtime call too:
+    there is no boundary left to land between. A cancel here is recorded as
+    cancelled — accurate, the worker really was stopped — instead of leaving the
+    task claiming to run.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("interrupt-mid-runtime")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "interrupt-mid-runtime",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    def cancel_mid_run(*_args, **_kwargs):
+        raise KeyboardInterrupt("SIGTERM while the worker was running")
+
+    with patch("agent_runtime.runner.invoke", side_effect=cancel_mid_run):
+        with contextlib.suppress(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="interrupt-mid-runtime",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+            )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] != "running", "a killed worker was left claiming to run"
+    assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4487,3 +4487,63 @@ def test_terminal_fallback_write_defers_a_second_sigterm(
     assert signal.getsignal(signal.SIGTERM) is not signal.SIG_IGN
     state = delegate._read_state(state_path)
     assert state is not None and state["status"] != "running"
+
+
+def test_sigterm_during_runtime_lease_cleanup_cannot_lose_the_outcome(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """The pre-guard cleanup window must not swallow a completed worker.
+
+    Runtime-lease cleanup runs in the runtime `finally` — after the worker has
+    finished, before the guarded span — and catches Exception, not the
+    KeyboardInterrupt a SIGTERM raises. Cross-family review of #5807.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("sigterm-in-cleanup")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "sigterm-in-cleanup",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "done", "stderr_excerpt": None, "returncode": 0,
+            "rate_limited": False, "model": "gpt-5.5", "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    seen = {}
+
+    def reap_under_deferral(*_args, **_kwargs):
+        seen["sigterm_disposition"] = signal.getsignal(signal.SIGTERM)
+        return {"tmp_bytes_freed": 0, "tmp_reap_error": None}
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_reap_runtime_tmp_lease", side_effect=reap_under_deferral),
+        patch.object(delegate, "_worktree_is_dirty", return_value=False),
+        patch.object(delegate, "_count_commits_ahead", return_value=1),
+    ):
+        delegate._run_worker(
+            task_id="sigterm-in-cleanup",
+            agent="codex",
+            prompt="hi",
+            mode="workspace-write",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+            effort="xhigh",
+        )
+
+    if seen:  # only asserts when the dispatch actually leases runtime tmp
+        assert seen["sigterm_disposition"] is signal.SIG_IGN, seen
+    assert signal.getsignal(signal.SIGTERM) is not signal.SIG_IGN
+    state = delegate._read_state(state_path)
+    assert state is not None and state["status"] in delegate._TERMINAL_STATUSES

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4150,3 +4150,83 @@ def test_run_worker_reaches_a_terminal_status_when_finalize_telemetry_raises(
     assert state["status"] == "needs_finalize"
     # And the reason the telemetry is unknown is recorded, not swallowed.
     assert "FileNotFoundError" in (state.get("finalize_error") or "")
+
+
+def test_run_worker_records_terminal_status_before_best_effort_reaping(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """Post-worker enrichment must not be able to strand a finished task.
+
+    Cross-family review of #5807: the first guard covered the finish telemetry
+    but not the worktree reaping below it, and _reap_finished_worktree performs
+    its import OUTSIDE its own handler — so an unimportable reaper module still
+    skipped the state write and left the task reading "running".
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("reap-explodes")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "reap-explodes",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "gpt-5.5",
+            "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    def unimportable(*_args, **_kwargs):
+        raise ImportError("No module named 'scripts.orchestration.reap_worktrees'")
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_count_commits_ahead", return_value=1),
+        patch.object(delegate, "_worktree_is_dirty", return_value=False),
+        patch.object(delegate, "_reap_finished_worktree", side_effect=unimportable),
+    ):
+        with contextlib.suppress(ImportError):
+            delegate._run_worker(
+                task_id="reap-explodes",
+                agent="codex",
+                prompt="hi",
+                mode="danger",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+            )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] != "running", "a finished worker was left looking busy"
+    assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]
+
+
+def test_reap_finished_worktree_survives_an_unimportable_reaper(tmp_path, monkeypatch):
+    """The reaper's own import belongs inside its error handling."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "scripts.orchestration" or name.endswith("reap_worktrees"):
+            raise ImportError(f"simulated missing module: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    out = delegate._reap_finished_worktree(tmp_path)
+    assert isinstance(out, dict)
+    assert out.get("ok") is not True

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4419,3 +4419,71 @@ def test_interrupt_after_clean_telemetry_does_not_invent_finalize_work(
     assert state["needs_finalize"] is False, "invented finalize work for a clean dispatch"
     assert state["status"] == "done"
     assert state["commits_ahead"] == 3
+
+
+def test_terminal_fallback_write_defers_a_second_sigterm(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A repeat cancel must not escape mid-write and undo the guarantee.
+
+    An exception raised inside an `except` suite is not caught by that same
+    suite, so a second SIGTERM arriving while the fallback writes would escape
+    before the atomic rename and leave the finished worker recorded as running.
+    Cross-family review of #5807.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("double-sigterm")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "double-sigterm",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "done", "stderr_excerpt": None, "returncode": 0,
+            "rate_limited": False, "model": "gpt-5.5", "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    observed = {}
+    real_write = delegate._write_state_atomic
+
+    def record_signal_state(path, state):
+        if "finalize_error" in state and state.get("finalize_error"):
+            observed["sigterm_disposition"] = signal.getsignal(signal.SIGTERM)
+        return real_write(path, state)
+
+    def interrupt(*_args, **_kwargs):
+        raise KeyboardInterrupt("first SIGTERM")
+
+    installed_before = signal.getsignal(signal.SIGTERM)
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_worktree_is_dirty", side_effect=interrupt),
+        patch.object(delegate, "_write_state_atomic", side_effect=record_signal_state),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="double-sigterm",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+            )
+
+    # During the fallback write, a repeat SIGTERM cannot raise.
+    assert observed.get("sigterm_disposition") is signal.SIG_IGN, observed
+    # ...and the handler is restored afterwards, so cancellation still works.
+    assert signal.getsignal(signal.SIGTERM) is not signal.SIG_IGN
+    state = delegate._read_state(state_path)
+    assert state is not None and state["status"] != "running"

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4540,10 +4540,13 @@ def test_sigterm_during_runtime_lease_cleanup_cannot_lose_the_outcome(
             model=None,
             hard_timeout=60,
             effort="xhigh",
+            # A real dispatch always leases runtime tmp; pass one explicitly so
+            # this test actually enters the cleanup path instead of skipping it.
+            runtime_tmp_root=str(tmp_path / "runtime-tmp"),
         )
 
-    if seen:  # only asserts when the dispatch actually leases runtime tmp
-        assert seen["sigterm_disposition"] is signal.SIG_IGN, seen
+    assert seen, "the lease-cleanup path was never entered — test proves nothing"
+    assert seen["sigterm_disposition"] is signal.SIG_IGN, seen
     assert signal.getsignal(signal.SIGTERM) is not signal.SIG_IGN
     state = delegate._read_state(state_path)
     assert state is not None and state["status"] in delegate._TERMINAL_STATUSES

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4615,3 +4615,26 @@ def test_interrupt_in_the_post_cleanup_gap_still_records_the_outcome(
     assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]
     # The fallback derived a real outcome instead of persisting an empty status.
     assert state["status"] in {"needs_finalize", "done"}
+
+
+def test_returncode_invariant_is_shared_by_both_status_paths():
+    """A success without a child return code is never persisted as done.
+
+    Cross-family review of #5807, round seven: the normal path enforced this and
+    the interrupt fallback did not, so a cancel landing between classification
+    and the check wrote status=done with returncode=null — the fallback
+    contradicting the invariant exactly when it was exercised.
+
+    The race window itself has no callable between the two statements, so no
+    patch can place an interrupt inside it. I wrote an end-to-end test that
+    appeared to cover it, found it was passing for the wrong reason — the
+    interrupt landed before the worker ran at all — and deleted it rather than
+    keep a test that cannot fail for its stated reason. The shared rule is
+    tested directly instead, and both call sites now route through it.
+    """
+    assert delegate._apply_returncode_invariant("done", None) == "failed"
+    assert delegate._apply_returncode_invariant("done", 0) == "done"
+    assert delegate._apply_returncode_invariant("done", 1) == "done"
+    # Non-success statuses are never rewritten by it.
+    for status in ("failed", "timeout", "rate_limited", "cancelled", "needs_finalize"):
+        assert delegate._apply_returncode_invariant(status, None) == status

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -4288,3 +4288,134 @@ def test_run_worker_records_completion_even_when_cancelled_during_finalize(
     assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]
     assert state["needs_finalize"] is True
     assert "KeyboardInterrupt" in (state.get("finalize_error") or "")
+
+
+def test_interrupt_before_telemetry_still_records_the_outcome(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """The fallback must not depend on names bound inside the span it guards.
+
+    Cross-family review of #5807: the handler read final_state and final_status,
+    both assigned inside the try, so an interrupt arriving early raised
+    UnboundLocalError *inside the handler* — failing at exactly the moment it
+    existed for. Interrupt during the result-file write, the very first statement
+    of the span.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("interrupt-early")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "interrupt-early",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "a response", "stderr_excerpt": None, "returncode": 0,
+            "rate_limited": False, "model": "gpt-5.5", "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    real_write_text = Path.write_text
+
+    def interrupt_on_result_file(self, *args, **kwargs):
+        if self.suffix == ".result":
+            raise KeyboardInterrupt("SIGTERM during result-file write")
+        return real_write_text(self, *args, **kwargs)
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(Path, "write_text", interrupt_on_result_file),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="interrupt-early",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+            )
+
+    state = delegate._read_state(state_path)
+    assert state is not None, "handler blew up instead of recording the outcome"
+    assert state["status"] != "running"
+    assert state["status"] in delegate._TERMINAL_STATUSES, state["status"]
+
+
+def test_interrupt_after_clean_telemetry_does_not_invent_finalize_work(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A dispatch already measured clean and committed stays done.
+
+    Cross-family review of #5807 (F002): unconditionally writing
+    needs_finalize=True on the interrupt path turned a healthy, already-verified
+    dispatch into a false manual-finalization alert.
+    """
+    _init_git_repo_for_test(tmp_path, monkeypatch)
+    state_path = delegate._state_path("interrupt-after-clean")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "interrupt-after-clean",
+        "status": "running",
+        "worktree_path": str(tmp_path),
+        "worktree_base": "main",
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True, "response": "done", "stderr_excerpt": None, "returncode": 0,
+            "rate_limited": False, "model": "gpt-5.5", "effort": "xhigh",
+            "cli_version": "0.131.0",
+        },
+    )()
+
+    # Interrupt lands exactly ON the checkpoint write: telemetry has settled
+    # (clean worktree, 3 commits) but nothing has been persisted yet. The
+    # fallback write that follows must succeed, so only the first call raises.
+    real_write = delegate._write_state_atomic
+    fired = {"once": False}
+
+    def interrupt_first_write(path, state):
+        # The checkpoint is the first write carrying the finished-outcome fields;
+        # earlier writes record the running task. Fire once so the fallback write
+        # that follows can still land.
+        if not fired["once"] and "duration_s" in state:
+            fired["once"] = True
+            raise KeyboardInterrupt("SIGTERM at the checkpoint")
+        return real_write(path, state)
+
+    with (
+        patch("agent_runtime.runner.invoke", return_value=mock_result),
+        patch.object(delegate, "_worktree_is_dirty", return_value=False),
+        patch.object(delegate, "_count_commits_ahead", return_value=3),
+        patch.object(delegate, "_write_state_atomic", side_effect=interrupt_first_write),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            delegate._run_worker(
+                task_id="interrupt-after-clean",
+                agent="codex",
+                prompt="hi",
+                mode="workspace-write",
+                cwd_str=str(tmp_path),
+                model=None,
+                hard_timeout=60,
+                effort="xhigh",
+            )
+
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["needs_finalize"] is False, "invented finalize work for a clean dispatch"
+    assert state["status"] == "done"
+    assert state["commits_ahead"] == 3


### PR DESCRIPTION
A dispatch died today and read `running` for 52 minutes with a dead pid. It was invisible — every settle-loop waits for a terminal status, so the operator sees a job that still looks busy while nothing is working. Worse, the worker *had* produced an answer: its result file said its command runner had broken and asked to be re-dispatched. Nobody saw it.

## Three defects, one behaviour

**1. `_count_commits_ahead` raised on a vanished worktree.** Its docstring promises `or None`; its sibling `_worktree_is_dirty` already returns `None` on `OSError`; callers already fail closed on `None`. Only this one raised — and the comment right above the call site describes that exact asymmetry class ("the same bug in two variables") from a previous fix. Same shape, third variable.

**2. The exception escaped the finish-telemetry block.** That block sits *after* the try/finally around the runtime call and *before* the single state write. The existing last-ditch handler says, in its own words, "we need to update the state file or the parent will see us as crashed forever" — the protection simply stopped short. The telemetry is now wrapped: it is measurement about a worker that has already finished, and it may never cost the task its terminal status. Unknown telemetry cannot prove the work was committed, so the task settles `needs_finalize`, and the exception is recorded in a new `finalize_error` field instead of vanishing.

**3. `wait` did not treat `needs_finalize` as terminal.** So `delegate.py wait` polled a *finished* task until its own timeout, and `cancel` was willing to signal that task's stored PID — which the OS may have recycled. Every other terminal vocabulary in the file already includes it (`_BRANCH_HOLDER_RELEASABLE_STATUSES`). Found while writing the test for defect 2.

## Verification
- New: a vanished worktree yields `None` from both helpers; a worker whose finish telemetry raises still lands terminal, as `needs_finalize`, with `FileNotFoundError` recorded in `finalize_error`.
- `tests/test_delegate.py` — 135 passed, plus the 2 new.
- `ruff check` clean.

## Reviewer note on local failures
8 tests in this file fail **locally on a busy machine** for an unrelated reason: they admit write paths against the live fleet ledger, so they see whatever dispatches happen to be running. That is #5804 (already reviewed, awaiting merge). It does not affect CI, which has no live dispatches — verified by the same 8 failing identically on unmodified `main`.

## What I did not do
I did not harden the other 15 helpers that run git inside a worktree. Most are setup-phase, where crashing early is correct — a dispatch that cannot prepare its worktree *should* fail loudly. The invariant that matters is narrower: once a worker has finished, nothing may prevent recording that it finished.