### PR TITLE
fix(ci): green main — cache validation and replay reports

### DIFF
--- a/scripts/audit/source_inventory_review_decisions.py
+++ b/scripts/audit/source_inventory_review_decisions.py
@@ -90,7 +90,15 @@ def validate_committed_decision_files(
     if not decision_paths:
         raise SourceInventoryError("no source-inventory review decision files found")
 
-    summaries = [validate_decision_file(path) for path in decision_paths]
+    # Every committed decision ledger is checked against the same immutable
+    # inventory corpus. Loading that corpus per ledger was needlessly expensive
+    # (and pushed the complete CI shard past pytest's per-test timeout). Keep one
+    # shared index for this validation pass; `validate_decision_file` extends it
+    # only when a ledger references a present staged inventory.
+    source_index = _source_record_index(
+        read_source_inventories(COMMITTED_SOURCE_INVENTORIES, project_root=PROJECT_ROOT)
+    )
+    summaries = [validate_decision_file(path, source_index=source_index) for path in decision_paths]
     decision_counts: Counter[str] = Counter()
     total_rows = 0
     for summary in summaries:
@@ -147,11 +155,10 @@ def validate_decision_file(
     if not isinstance(decisions, list) or not decisions:
         raise SourceInventoryError(f"{path}: decisions must be a non-empty list")
 
-    if source_index is not None:
-        index = source_index
-        absent_inventories: set[str] = set()
-    else:
-        index, absent_inventories = _index_and_absent_inventories(payload)
+    index, absent_inventories = _index_and_absent_inventories(
+        payload,
+        source_index=source_index,
+    )
     seen_source_keys: set[str] = set()
     decision_counts: Counter[str] = Counter()
     for idx, row in enumerate(decisions, start=1):
@@ -176,6 +183,8 @@ def validate_decision_file(
 
 def _index_and_absent_inventories(
     payload: Mapping[str, Any],
+    *,
+    source_index: Mapping[tuple[str, str, str], SourceInventoryRecord] | None = None,
 ) -> tuple[dict[tuple[str, str, str], SourceInventoryRecord], set[str]]:
     """Build the source-record index, tolerating absent regenerable inventories.
 
@@ -191,7 +200,21 @@ def _index_and_absent_inventories(
     before — fail-open applies only to the genuinely-absent regenerable case.
     """
 
-    read_paths: list[Path] = list(COMMITTED_SOURCE_INVENTORIES)
+    # `validate_committed_decision_files` supplies a mutable shared index, so
+    # repeated ledgers do not reparse the immutable committed corpus (or the
+    # same staged inventory). Keep standalone `validate_decision_file` fully
+    # self-contained by loading that corpus when no index was supplied.
+    if source_index is None:
+        index = _source_record_index(
+            read_source_inventories(COMMITTED_SOURCE_INVENTORIES, project_root=PROJECT_ROOT)
+        )
+    elif isinstance(source_index, dict):
+        index = source_index
+    else:
+        index = dict(source_index)
+
+    indexed_inventory_paths = {record.inventory_path for record in index.values()}
+    read_paths: list[Path] = []
     absent: set[str] = set()
     decisions = payload.get("decisions")
     if isinstance(decisions, list):
@@ -205,15 +228,18 @@ def _index_and_absent_inventories(
             if not isinstance(raw_path, str) or not raw_path.strip():
                 continue
             resolved = resolve_staged_inventory_path(raw_path)
-            if resolved.exists():
+            if raw_path not in indexed_inventory_paths and resolved.exists():
                 read_paths.append(resolved)
             else:
-                absent.add(raw_path.strip())
-    records = read_source_inventories(
-        tuple(dict.fromkeys(read_paths)),
-        project_root=PROJECT_ROOT,
-    )
-    return _source_record_index(records), absent
+                if not resolved.exists():
+                    absent.add(raw_path.strip())
+    if read_paths:
+        records = read_source_inventories(
+            tuple(dict.fromkeys(read_paths)),
+            project_root=PROJECT_ROOT,
+        )
+        index.update(_source_record_index(records))
+    return index, absent
 
 
 def _validate_decision_row(

--- a/tests/orchestration/test_curriculum_lifecycle_pilot.py
+++ b/tests/orchestration/test_curriculum_lifecycle_pilot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -130,7 +131,8 @@ def test_shadow_detects_any_learner_tree_change(monkeypatch: pytest.MonkeyPatch)
 
 def test_report_tampering_and_false_pass_fail_closed() -> None:
     matrix = pilot.load_matrix(repo_root=REPO_ROOT)
-    report = _report()
+    valid_report = _report()
+    report = deepcopy(valid_report)
     report["rows"][0]["passed"] = False
 
     with pytest.raises(pilot.PilotError, match="identity does not match"):
@@ -140,7 +142,7 @@ def test_report_tampering_and_false_pass_fail_closed() -> None:
     with pytest.raises(pilot.PilotError, match="row evidence does not match"):
         pilot.validate_report_value(report, matrix=matrix, repo_root=REPO_ROOT)
 
-    report = _report()
+    report = deepcopy(valid_report)
     report["metrics"]["prompt_bytes"] += 1
     report["identity_sha256"] = pilot._report_identity(report)
     with pytest.raises(pilot.PilotError, match="metrics do not match"):

--- a/tests/test_source_inventory_review_decisions.py
+++ b/tests/test_source_inventory_review_decisions.py
@@ -7,7 +7,7 @@ import pytest
 import yaml
 
 from scripts.audit import source_inventory_review_decisions as decisions
-from scripts.audit.source_inventory_intake import SourceInventoryError
+from scripts.audit.source_inventory_intake import SourceInventoryError, SourceInventoryRecord
 
 FIRST_BATCH = (
     decisions.DEFAULT_DECISION_DIR / "2026-06-29-first-approved-publish-batch.yaml"
@@ -79,6 +79,43 @@ def test_default_committed_decision_files_validate() -> None:
     assert summary["files"] >= 1
     assert summary["rows"] >= 20
     assert summary["decision_counts"]["approve_for_publish"] >= 20
+
+
+def test_committed_decision_validation_reuses_shared_source_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inventory = tmp_path / "committed-inventory.yaml"
+    first = tmp_path / "first.yaml"
+    second = tmp_path / "second.yaml"
+    _write_decision_file(first, _minimal_payload())
+    _write_decision_file(second, _minimal_payload())
+    record = SourceInventoryRecord(
+        lemma="ананас",
+        source_family="ohoiko",
+        extraction_mode="fixture",
+        inventory_path="data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml",
+        inventory_locator="letters[А].key_word",
+        source_id="ohoiko-abetka-1-keywords",
+        source_locator="letters[А].key_word",
+    )
+    calls: list[tuple[Path, ...]] = []
+
+    def read_once(paths: tuple[Path, ...], *, project_root: Path) -> list[SourceInventoryRecord]:
+        calls.append(paths)
+        return [record]
+
+    monkeypatch.setattr(decisions, "COMMITTED_SOURCE_INVENTORIES", (inventory,))
+    monkeypatch.setattr(decisions, "read_source_inventories", read_once)
+
+    summary = decisions.validate_committed_decision_files([first, second])
+
+    assert summary == {
+        "files": 2,
+        "rows": 2,
+        "decision_counts": {"approve_for_publish": 2},
+    }
+    assert calls == [(inventory,)]
 
 
 def test_committed_yaml_uses_the_c_safe_loader_when_available() -> None:


### PR DESCRIPTION
## Summary
- share the committed source-inventory index across all 51 decision ledgers
- preserve the lifecycle fail-closed assertions while replaying the shadow report once

## Validation
- `.venv/bin/python -m pytest tests/test_source_inventory_review_decisions.py tests/orchestration/test_curriculum_lifecycle_pilot.py -q` → 36 passed (twice)
- `.venv/bin/ruff check scripts/audit/source_inventory_review_decisions.py tests/test_source_inventory_review_decisions.py tests/orchestration/test_curriculum_lifecycle_pilot.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`

No auto-merge requested.