### PR TITLE
fix(review): publish formal review evidence

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -196,18 +196,28 @@ steering warning with `BRIDGE_ALLOW_LEGACY_REVIEW_ASK=1`.
 `publish-review-verdict`. `scripts/audit/llm_reviewer_dispatch.py` content-review
 routes remain `ask-* --review` (module QG, not PR CF).
 
-After a reviewer writes a short verdict or findings JSON, publish exactly one
-PR comment without relaying the full body through the orchestrator:
+After a reviewer writes canonical `code-review-findings.v1` JSON, publish it
+with exactly one PR comment. The publisher retains the overall explanation and
+every finding; it derives the gate verdict from the canonical evidence rather
+than treating a detached verdict line as proof:
 
 ```bash
 .venv/bin/python scripts/ai_agent_bridge/__main__.py publish-review-verdict \
-  --pr 5458 --verdict-file /tmp/review-verdict.txt \
+  --pr 5458 --findings-json /tmp/review-findings.json \
   --model gpt-5.6-terra --family openai --harness codex
 ```
 
-The comment contains only `VERDICT`, the PR head SHA, and reviewer provenance.
-The command prints a ≤2 KiB status summary; use `--findings-json` for a JSON
-file with a top-level `verdict`, and `--dry-run` to verify the payload locally.
+The comment keeps `VERDICT`, the PR head SHA, and reviewer provenance, then
+renders the explanation and each finding's priority, path/line, description,
+rationale, smallest fix, and sources. A verdict with no explanation and no
+findings is marked **NO EVIDENCE SUPPLIED** in the published comment. If a
+review is too large for GitHub, the publisher retains the overall explanation,
+truncates findings last, and names the full structured record. The command
+prints a ≤2 KiB status summary; use `--dry-run` to verify the payload locally.
+
+`--verdict-file` remains a legacy escape hatch, but its published comment
+explicitly says that no review evidence was supplied. It is not equivalent to
+a canonical review.
 
 `.venv/bin/python scripts/ai_agent_bridge/__main__.py review-deep <PR-or-path> [--effort xhigh]` dispatches an
 adversarial Claude review run. It hardcodes `--agent claude --mode

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -52,10 +52,11 @@ _DEFAULT_CHECKLIST = """\
 the operator to paste the diff.
 
 ### Required output
-End with exactly one line:
-`VERDICT: APPROVED` or `VERDICT: CHANGES_REQUESTED` or `VERDICT: BLOCKED`
-
-If CHANGES_REQUESTED/BLOCKED, list blockers with paths.
+Emit exactly one canonical `code-review-findings.v1` JSON object — no markdown
+or trailing `VERDICT:` line. It must contain `overall`
+(`correctness`, `explanation`, `confidence`) and every finding with its
+canonical location and evidence fields. Publication derives the GitHub gate
+verdict from this evidence and preserves the review body in the PR comment.
 """
 
 

--- a/scripts/ai_agent_bridge/_review_verdict.py
+++ b/scripts/ai_agent_bridge/_review_verdict.py
@@ -1,4 +1,4 @@
-"""Publish a deliberately thin formal-review verdict to one GitHub PR comment.
+"""Publish an auditable formal-review verdict to one GitHub PR comment.
 
 Two paths:
 
@@ -8,7 +8,7 @@ Two paths:
 2. **PR-G sealed path** — ``--sealed-payload`` (JSON matching
    ``scripts.fleet_comms.review_publication.SealedVerdict``). Optionally bind
    ``--review-id`` to a durable formal-job row (identity check only; PR-F still
-   owns sealed-job writers). Posts thin comment + ``fleet/cross-family-review``
+   owns sealed-job writers). Posts evidence-bearing comment + ``fleet/cross-family-review``
    commit status, with stale-head / idempotent receipt handling.
 
 Full default cutover of all formal CF to ``--review-id`` alone waits for PR-F
@@ -25,6 +25,14 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+
+from scripts.fleet_comms.review_publication import (
+    ReviewEvidence,
+    ReviewPublicationError,
+    build_review_comment,
+    resolve_verdict_and_evidence,
+    verdict_from_review_evidence,
+)
 
 from ._review_safety import MAX_VERDICT_SUMMARY_BYTES, ReviewSafetyError
 
@@ -50,47 +58,77 @@ def _read_small_file(path: Path) -> str:
     if size > _MAX_INPUT_BYTES:
         raise ReviewSafetyError(
             f"verdict_file_exceeds_cap: bytes={size} limit={_MAX_INPUT_BYTES}. "
-            "Publish only a verdict or findings JSON, never a full review body."
+            "Use canonical findings JSON so the evidence can be published."
         )
     return path.read_text(encoding="utf-8")
 
 
 def verdict_from_text(text: str) -> str:
-    """Extract the required verdict without retaining the review body."""
+    """Extract the required verdict from a legacy free-text input."""
     match = _VERDICT_RE.search(text)
     if not match:
         raise ReviewSafetyError("verdict_missing: expected VERDICT: APPROVED|CHANGES_REQUESTED|BLOCKED")
     return match.group(1).upper()
 
 
-def verdict_from_findings_json(path: Path) -> str:
-    """Read a findings JSON document and extract its top-level verdict field."""
+def review_from_findings_json(path: Path) -> tuple[str, ReviewEvidence | None]:
+    """Read canonical findings JSON and retain all publishable review evidence."""
     try:
         payload = json.loads(_read_small_file(path))
     except json.JSONDecodeError as exc:
         raise ReviewSafetyError(f"findings_json_invalid: {path}") from exc
     if not isinstance(payload, dict):
-        raise ReviewSafetyError("findings_json_invalid: expected an object with a verdict field")
-    raw = payload.get("verdict")
-    if not isinstance(raw, str) or raw.upper() not in _VALID_VERDICTS:
-        raise ReviewSafetyError("findings_json_missing_verdict: expected APPROVED|CHANGES_REQUESTED|BLOCKED")
-    return raw.upper()
+        raise ReviewSafetyError("findings_json_invalid: expected an object")
+    try:
+        return resolve_verdict_and_evidence(payload)
+    except ReviewPublicationError as exc:
+        raise ReviewSafetyError(str(exc)) from exc
 
 
-def build_verdict_comment(*, verdict: str, head_sha: str, model: str, family: str, harness: str) -> str:
-    """Build the complete comment body; it intentionally has no review findings."""
+def verdict_from_findings_json(path: Path) -> str:
+    """Compatibility helper returning the verdict resolved from findings JSON."""
+    return review_from_findings_json(path)[0]
+
+
+def _coerce_review_evidence(
+    review_evidence: ReviewEvidence | dict[str, Any] | None,
+) -> tuple[str | None, ReviewEvidence | None]:
+    if review_evidence is None:
+        return None, None
+    if isinstance(review_evidence, ReviewEvidence):
+        return verdict_from_review_evidence(review_evidence), review_evidence
+    try:
+        return resolve_verdict_and_evidence(review_evidence)
+    except ReviewPublicationError as exc:
+        raise ReviewSafetyError(str(exc)) from exc
+
+
+def build_verdict_comment(
+    *,
+    verdict: str,
+    head_sha: str,
+    model: str,
+    family: str,
+    harness: str,
+    review_evidence: ReviewEvidence | dict[str, Any] | None = None,
+) -> str:
+    """Build the complete legacy-path comment through the shared renderer."""
     normalized_verdict = _single_line(verdict, label="verdict").upper()
     if normalized_verdict not in _VALID_VERDICTS:
         raise ReviewSafetyError(f"invalid_verdict: {normalized_verdict!r}")
-    return "\n".join(
-        (
-            f"VERDICT: {normalized_verdict}",
-            f"Head SHA: {_single_line(head_sha, label='head_sha')}",
-            "Reviewer provenance: "
-            f"model={_single_line(model, label='model')}; "
-            f"family={_single_line(family, label='family')}; "
-            f"harness={_single_line(harness, label='harness')}",
+    evidence_verdict, evidence = _coerce_review_evidence(review_evidence)
+    if evidence_verdict is not None and evidence_verdict != normalized_verdict:
+        raise ReviewSafetyError(
+            f"review_evidence_verdict_mismatch: verdict={normalized_verdict} "
+            f"evidence={evidence_verdict}"
         )
+    return build_review_comment(
+        verdict=normalized_verdict,
+        head_sha=_single_line(head_sha, label="head_sha"),
+        model=_single_line(model, label="model"),
+        family=_single_line(family, label="family"),
+        harness=_single_line(harness, label="harness"),
+        review_evidence=evidence,
     )
 
 
@@ -104,10 +142,11 @@ def publish_review_verdict(
     model: str,
     family: str,
     harness: str,
+    review_evidence: ReviewEvidence | dict[str, Any] | None = None,
     dry_run: bool = False,
     runner: Runner = subprocess.run,
 ) -> str:
-    """Legacy path: post one comment and return a bounded, body-free summary."""
+    """Legacy path: post one evidence-bearing comment and a bounded summary."""
     if pr <= 0:
         raise ReviewSafetyError(f"invalid_pr: {pr}")
     head = runner(
@@ -125,6 +164,7 @@ def publish_review_verdict(
         model=model,
         family=family,
         harness=harness,
+        review_evidence=review_evidence,
     )
     if not dry_run:
         posted = runner(
@@ -301,11 +341,11 @@ def handle_publish_review_verdict(args: argparse.Namespace) -> int:
         return 2
 
     try:
-        verdict = (
-            verdict_from_findings_json(Path(args.findings_json))
-            if args.findings_json
-            else verdict_from_text(_read_small_file(Path(args.verdict_file)))
-        )
+        if args.findings_json:
+            verdict, review_evidence = review_from_findings_json(Path(args.findings_json))
+        else:
+            verdict = verdict_from_text(_read_small_file(Path(args.verdict_file)))
+            review_evidence = None
         print(
             publish_review_verdict(
                 pr=int(args.pr),
@@ -313,6 +353,7 @@ def handle_publish_review_verdict(args: argparse.Namespace) -> int:
                 model=args.model,
                 family=args.family,
                 harness=args.harness,
+                review_evidence=review_evidence,
                 dry_run=args.dry_run,
             )
         )
@@ -326,7 +367,7 @@ def register_publish_review_verdict_parser(subparsers: Any) -> None:
     parser = subparsers.add_parser(
         "publish-review-verdict",
         help=(
-            "Post one thin formal-review verdict (legacy file path, "
+            "Post one auditable formal-review verdict (legacy file path, "
             "--sealed-payload, or --review-id alone after PR-F accept)"
         ),
     )

--- a/scripts/fleet_comms/formal_review_finalize.py
+++ b/scripts/fleet_comms/formal_review_finalize.py
@@ -27,11 +27,13 @@ from scripts.fleet_comms.formal_review_jobs import (
 )
 from scripts.fleet_comms.review_publication import (
     DEFAULT_GATE_KIND,
+    ReviewEvidence,
     ReviewPublicationError,
     SealedVerdict,
     normalize_verdict,
     parse_sealed_verdict_payload,
     parse_verdict_token,
+    resolve_verdict_and_evidence,
 )
 from scripts.fleet_comms.review_publisher import (
     ReviewPublisherError,
@@ -95,10 +97,10 @@ def resolve_verdict_token(
             payload = json.loads(findings_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise FormalReviewFinalizeError(f"findings_unreadable: {exc}") from exc
-        if not isinstance(payload, dict) or "verdict" not in payload:
-            raise FormalReviewFinalizeError("findings_json_missing_verdict")
         try:
-            return normalize_verdict(payload["verdict"])
+            if not isinstance(payload, dict):
+                raise FormalReviewFinalizeError("findings_json_invalid: expected an object")
+            return resolve_verdict_and_evidence(payload)[0]
         except ReviewPublicationError as exc:
             raise FormalReviewFinalizeError(str(exc)) from exc
     if verdict_text and str(verdict_text).strip():
@@ -122,6 +124,7 @@ def build_sealed_verdict(
     model: str,
     family: str,
     harness: str,
+    review_evidence: ReviewEvidence | None = None,
 ) -> SealedVerdict:
     """Build a SealedVerdict from explicit fields (provenance never invented)."""
     payload = {
@@ -134,6 +137,9 @@ def build_sealed_verdict(
         "model": model,
         "family": family,
         "harness": harness,
+        "review_evidence": (
+            review_evidence.to_dict() if review_evidence is not None else None
+        ),
     }
     try:
         return parse_sealed_verdict_payload(payload)
@@ -169,11 +175,42 @@ def finalize_formal_review_verdict(
     # Validate repository shape early.
     split_repository(repository)
 
-    resolved_verdict = resolve_verdict_token(
-        verdict=verdict,
-        verdict_text=verdict_text,
-        findings_path=findings_path,
-    )
+    findings_verdict: str | None = None
+    review_evidence: ReviewEvidence | None = None
+    if findings_path is not None:
+        try:
+            findings_payload = json.loads(findings_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise FormalReviewFinalizeError(f"findings_unreadable: {exc}") from exc
+        if not isinstance(findings_payload, dict):
+            raise FormalReviewFinalizeError("findings_json_invalid: expected an object")
+        try:
+            findings_verdict, review_evidence = resolve_verdict_and_evidence(findings_payload)
+        except ReviewPublicationError as exc:
+            raise FormalReviewFinalizeError(str(exc)) from exc
+
+    if verdict and str(verdict).strip():
+        try:
+            resolved_verdict = normalize_verdict(verdict)
+        except ReviewPublicationError as exc:
+            raise FormalReviewFinalizeError(str(exc)) from exc
+    elif findings_verdict is not None:
+        resolved_verdict = findings_verdict
+    elif verdict_text and str(verdict_text).strip():
+        try:
+            resolved_verdict = parse_verdict_token(verdict_text)
+        except ReviewPublicationError as exc:
+            raise FormalReviewFinalizeError(str(exc)) from exc
+    else:
+        raise FormalReviewFinalizeError(
+            "verdict_required: pass --verdict, --verdict-file, or --findings-json"
+        )
+
+    if findings_verdict is not None and resolved_verdict != findings_verdict:
+        raise FormalReviewFinalizeError(
+            f"review_evidence_verdict_mismatch: verdict={resolved_verdict} "
+            f"evidence={findings_verdict}"
+        )
 
     sha = head_sha
     if sha is None:
@@ -223,6 +260,7 @@ def finalize_formal_review_verdict(
                 model=model.strip(),
                 family=family.strip(),
                 harness=harness.strip(),
+                review_evidence=review_evidence,
             )
             service.accept_sealed_verdict(job.review_id, sealed)
         except FormalReviewJobsError as exc:

--- a/scripts/fleet_comms/review_publication.py
+++ b/scripts/fleet_comms/review_publication.py
@@ -357,10 +357,6 @@ def resolve_verdict_and_evidence(payload: Mapping[str, Any]) -> tuple[str, Revie
         if evidence is not None
         else _verdict_from_degenerate_evidence(payload)
     )
-    if derived is None:
-        raise ReviewPublicationError(
-            "review_evidence_invalid: no verdict can be derived from degenerate evidence"
-        )
     if explicit is not None and explicit != derived:
         raise ReviewPublicationError(
             f"review_evidence_verdict_mismatch: verdict={explicit} evidence={derived}"

--- a/scripts/fleet_comms/review_publication.py
+++ b/scripts/fleet_comms/review_publication.py
@@ -30,6 +30,10 @@ from typing import Any, Literal
 VALID_VERDICTS = frozenset({"APPROVED", "CHANGES_REQUESTED", "BLOCKED"})
 DEFAULT_GATE_KIND = "cross-family-review"
 DEFAULT_STATUS_CONTEXT = "fleet/cross-family-review"
+REVIEW_SCHEMA_VERSION = "code-review-findings.v1"
+# GitHub accepts 65,536 characters per comment. Reserve room for markup and
+# the explicit truncation notice rather than relying on a remote rejection.
+GITHUB_COMMENT_CHAR_LIMIT = 64_000
 # GitHub commit status states used for the merge gate.
 STATUS_SUCCESS = "success"
 STATUS_FAILURE = "failure"
@@ -51,12 +55,74 @@ class ReviewPublicationError(ValueError):
 
 
 @dataclass(frozen=True, slots=True)
-class SealedVerdict:
-    """Minimal sealed formal-review verdict needed to plan a GitHub gate post.
+class ReviewFinding:
+    """Immutable projection of one validated canonical review finding."""
 
-    Provenance fields (model/family/harness) are required so the thin PR comment
-    never invents CLI-supplied identity after PR-G cutover. PR-F owns job
-    storage; this structure is the in-memory view the publisher consumes.
+    finding_id: str
+    title: str
+    body: str
+    priority: str
+    confidence: float
+    category: str
+    path: str
+    start_line: int
+    end_line: int
+    claim_type: str
+    verbatim: str
+    why_wrong: str
+    smallest_fix: str
+    sources: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.finding_id,
+            "title": self.title,
+            "body": self.body,
+            "priority": self.priority,
+            "confidence": self.confidence,
+            "category": self.category,
+            "location": {
+                "path": self.path,
+                "start_line": self.start_line,
+                "end_line": self.end_line,
+                "claim_type": self.claim_type,
+            },
+            "verbatim": self.verbatim,
+            "why_wrong": self.why_wrong,
+            "smallest_fix": self.smallest_fix,
+            "sources": list(self.sources),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewEvidence:
+    """Validated review evidence retained with the formal verdict."""
+
+    correctness: str
+    explanation: str
+    confidence: float
+    findings: tuple[ReviewFinding, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": REVIEW_SCHEMA_VERSION,
+            "overall": {
+                "correctness": self.correctness,
+                "explanation": self.explanation,
+                "confidence": self.confidence,
+            },
+            "findings": [finding.to_dict() for finding in self.findings],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SealedVerdict:
+    """Sealed formal-review verdict needed to plan a GitHub gate post.
+
+    Provenance fields (model/family/harness) are required so the PR comment
+    never invents CLI-supplied identity after PR-G cutover. ``review_evidence``
+    is the immutable canonical projection that makes the public verdict
+    auditable; an absent projection is rendered as an explicit warning.
     """
 
     review_id: str
@@ -68,6 +134,7 @@ class SealedVerdict:
     model: str
     family: str
     harness: str
+    review_evidence: ReviewEvidence | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -80,6 +147,9 @@ class SealedVerdict:
             "model": self.model,
             "family": self.family,
             "harness": self.harness,
+            "review_evidence": (
+                self.review_evidence.to_dict() if self.review_evidence is not None else None
+            ),
         }
 
 
@@ -171,6 +241,138 @@ def normalize_verdict(raw: Any) -> str:
     return verdict
 
 
+def _canonical_evidence_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract the canonical reviewer payload from a wrapper mapping."""
+    return {
+        field: payload[field]
+        for field in ("schema_version", "overall", "findings")
+        if field in payload
+    }
+
+
+def _has_canonical_review_evidence(payload: Mapping[str, Any]) -> bool:
+    return "schema_version" in payload or "overall" in payload
+
+
+def _is_degenerate_review_evidence(payload: Mapping[str, Any]) -> bool:
+    """Recognize a reviewer that supplied neither explanation nor findings.
+
+    The canonical schema deliberately rejects an empty explanation. Publication
+    nevertheless needs to surface this exact reviewer failure rather than turn
+    it into a clean-looking verdict or discard it with a generic schema error.
+    """
+    if payload.get("schema_version") != REVIEW_SCHEMA_VERSION:
+        return False
+    findings = payload.get("findings")
+    overall = payload.get("overall")
+    if findings != [] or not isinstance(overall, Mapping):
+        return False
+    explanation = overall.get("explanation")
+    return not isinstance(explanation, str) or not explanation.strip()
+
+
+def parse_review_evidence(payload: Mapping[str, Any]) -> ReviewEvidence | None:
+    """Validate and freeze canonical reviewer evidence for public rendering.
+
+    ``None`` is reserved for the explicit no-evidence case: an empty explanation
+    and no findings. All other malformed evidence fails closed before it can
+    produce a misleading GitHub gate comment.
+    """
+    canonical = _canonical_evidence_fields(payload)
+    if _is_degenerate_review_evidence(canonical):
+        return None
+
+    try:
+        from scripts.review.review_contract import ContractError, validate_reviewer_payload
+
+        validated = validate_reviewer_payload(canonical)
+    except ContractError as exc:
+        raise ReviewPublicationError(f"review_evidence_invalid: {exc}") from exc
+
+    overall = validated["overall"]
+    findings = tuple(
+        ReviewFinding(
+            finding_id=finding["id"],
+            title=finding["title"],
+            body=finding["body"],
+            priority=finding["priority"],
+            confidence=float(finding["confidence"]),
+            category=finding["category"],
+            path=finding["location"]["path"],
+            start_line=int(finding["location"]["start_line"]),
+            end_line=int(finding["location"]["end_line"]),
+            claim_type=finding["location"]["claim_type"],
+            verbatim=finding["verbatim"],
+            why_wrong=finding["why_wrong"],
+            smallest_fix=finding["smallest_fix"],
+            sources=tuple(finding["sources"]),
+        )
+        for finding in validated["findings"]
+    )
+    return ReviewEvidence(
+        correctness=overall["correctness"],
+        explanation=overall["explanation"],
+        confidence=float(overall["confidence"]),
+        findings=findings,
+    )
+
+
+def verdict_from_review_evidence(evidence: ReviewEvidence) -> str:
+    """Derive the only gate verdict consistent with canonical review evidence."""
+    if evidence.findings or evidence.correctness == "incorrect":
+        return "CHANGES_REQUESTED"
+    if evidence.correctness == "correct":
+        return "APPROVED"
+    return "BLOCKED"
+
+
+def _verdict_from_degenerate_evidence(payload: Mapping[str, Any]) -> str | None:
+    overall = payload.get("overall")
+    if not isinstance(overall, Mapping):
+        return None
+    correctness = overall.get("correctness")
+    if correctness == "correct":
+        return "APPROVED"
+    if correctness == "incorrect":
+        return "CHANGES_REQUESTED"
+    if correctness == "uncertain":
+        return "BLOCKED"
+    return None
+
+
+def resolve_verdict_and_evidence(payload: Mapping[str, Any]) -> tuple[str, ReviewEvidence | None]:
+    """Resolve a verdict and retain any canonical evidence from one payload.
+
+    Legacy payloads may still carry only a top-level ``verdict``. Canonical
+    ``code-review-findings.v1`` payloads derive the verdict from their verified
+    meaning; an explicit conflicting token fails closed.
+    """
+    raw_verdict = payload.get("verdict")
+    explicit = normalize_verdict(raw_verdict) if raw_verdict is not None else None
+    if not _has_canonical_review_evidence(payload):
+        if explicit is None:
+            raise ReviewPublicationError(
+                "findings_json_missing_verdict: expected verdict or canonical review evidence"
+            )
+        return explicit, None
+
+    evidence = parse_review_evidence(payload)
+    derived = (
+        verdict_from_review_evidence(evidence)
+        if evidence is not None
+        else _verdict_from_degenerate_evidence(payload)
+    )
+    if derived is None:
+        raise ReviewPublicationError(
+            "review_evidence_invalid: no verdict can be derived from degenerate evidence"
+        )
+    if explicit is not None and explicit != derived:
+        raise ReviewPublicationError(
+            f"review_evidence_verdict_mismatch: verdict={explicit} evidence={derived}"
+        )
+    return derived, evidence
+
+
 def parse_verdict_token(text: str) -> str:
     """Extract a VERDICT line from free text without retaining the body."""
     if not isinstance(text, str) or not text.strip():
@@ -191,9 +393,9 @@ def parse_sealed_verdict_payload(payload: Mapping[str, Any] | str | bytes) -> Se
     * a mapping / JSON object with explicit fields, or
     * JSON text that decodes to that object.
 
-    The ``verdict`` field is required. A free-text ``verdict_text`` with a
-    ``VERDICT:`` line is accepted only when ``verdict`` is absent (bridge
-    compatibility while PR-F jobs land).
+    A canonical ``review_evidence`` payload derives the verdict. A free-text
+    ``verdict_text`` with a ``VERDICT:`` line is accepted only when canonical
+    evidence is absent (legacy bridge compatibility).
     """
     data: Mapping[str, Any]
     if isinstance(payload, (str, bytes)):
@@ -212,13 +414,29 @@ def parse_sealed_verdict_payload(payload: Mapping[str, Any] | str | bytes) -> Se
             f"sealed_payload_invalid: unsupported type {type(payload).__name__}"
         )
 
-    if "verdict" in data and data["verdict"] is not None:
+    review_payload: Mapping[str, Any] | None = None
+    raw_evidence = data.get("review_evidence")
+    if raw_evidence is not None:
+        if not isinstance(raw_evidence, Mapping):
+            raise ReviewPublicationError("review_evidence_invalid: expected an object")
+        review_payload = dict(raw_evidence)
+        if "verdict" in data and "verdict" not in review_payload:
+            review_payload = {**review_payload, "verdict": data["verdict"]}
+    elif _has_canonical_review_evidence(data):
+        review_payload = _canonical_evidence_fields(data)
+        if "verdict" in data:
+            review_payload["verdict"] = data["verdict"]
+
+    review_evidence: ReviewEvidence | None = None
+    if review_payload is not None:
+        verdict, review_evidence = resolve_verdict_and_evidence(review_payload)
+    elif "verdict" in data and data["verdict"] is not None:
         verdict = normalize_verdict(data["verdict"])
     elif data.get("verdict_text"):
         verdict = parse_verdict_token(str(data["verdict_text"]))
     else:
         raise ReviewPublicationError(
-            "sealed_payload_missing_verdict: expected verdict field"
+            "sealed_payload_missing_verdict: expected verdict field or review evidence"
         )
 
     gate_kind = (
@@ -237,6 +455,7 @@ def parse_sealed_verdict_payload(payload: Mapping[str, Any] | str | bytes) -> Se
         model=_require_nonempty_str(data.get("model"), field="model"),
         family=_require_nonempty_str(data.get("family"), field="family"),
         harness=_require_nonempty_str(data.get("harness"), field="harness"),
+        review_evidence=review_evidence,
     )
 
 
@@ -307,19 +526,145 @@ def map_verdict_to_commit_status(verdict: str) -> CommitStatusState:
     return STATUS_ERROR
 
 
-def build_thin_verdict_comment(sealed: SealedVerdict) -> str:
-    """Build the thin PR comment body (no findings, provenance from sealed job)."""
+def _format_location(finding: ReviewFinding) -> str:
+    if finding.start_line == finding.end_line:
+        return f"{finding.path}:{finding.start_line}"
+    return f"{finding.path}:{finding.start_line}-{finding.end_line}"
+
+
+def _render_finding(finding: ReviewFinding) -> str:
+    sources = ", ".join(finding.sources)
     return "\n".join(
         (
-            f"VERDICT: {sealed.verdict}",
-            f"Head SHA: {sealed.head_sha}",
-            f"Review ID: {sealed.review_id}",
-            "Reviewer provenance: "
-            f"model={sealed.model}; "
-            f"family={sealed.family}; "
-            f"harness={sealed.harness}",
+            f"### {finding.finding_id} — Severity: {finding.priority}",
+            f"**Location:** `{_format_location(finding)}` ({finding.claim_type})",
+            f"**Title:** {finding.title}",
+            f"**Category:** {finding.category} · **Confidence:** {finding.confidence:g}",
+            "",
+            f"**Description:** {finding.body}",
+            "",
+            f"**Why it is wrong:** {finding.why_wrong}",
+            "",
+            f"**Smallest fix:** {finding.smallest_fix}",
+            "",
+            f"**Sources:** {sources}",
         )
     )
+
+
+def _render_evidence(
+    *,
+    prefix: str,
+    evidence: ReviewEvidence | None,
+    record_reference: str,
+) -> str:
+    if evidence is None:
+        return "\n\n".join(
+            (
+                prefix,
+                "## Review evidence\n"
+                "> **NO EVIDENCE SUPPLIED.** The reviewer supplied no overall explanation "
+                "and no findings. This verdict is not independently auditable.",
+            )
+        )
+
+    overall = "\n".join(
+        (
+            "## Overall review",
+            f"**Correctness:** `{evidence.correctness}` · **Confidence:** {evidence.confidence:g}",
+            "",
+            evidence.explanation,
+        )
+    )
+    findings = [_render_finding(finding) for finding in evidence.findings]
+    complete = "\n\n".join((prefix, overall, "## Findings", "\n\n".join(findings)))
+    if len(complete) <= GITHUB_COMMENT_CHAR_LIMIT:
+        return complete
+
+    findings_header = "## Findings"
+    truncation = (
+        "> **FINDINGS TRUNCATED.** Published {published} of {total} findings to stay within "
+        "GitHub's comment limit. Full structured review record: {record_reference}."
+    )
+    baseline = "\n\n".join((prefix, overall, findings_header))
+    minimum_notice = truncation.format(
+        published=0,
+        total=len(findings),
+        record_reference=record_reference,
+    )
+    if len("\n\n".join((baseline, minimum_notice))) > GITHUB_COMMENT_CHAR_LIMIT:
+        raise ReviewPublicationError(
+            "review_evidence_overall_exceeds_comment_limit: cannot truncate overall explanation"
+        )
+
+    published: list[str] = []
+    for finding in findings:
+        candidate = [*published, finding]
+        notice = truncation.format(
+            published=len(candidate),
+            total=len(findings),
+            record_reference=record_reference,
+        )
+        if len("\n\n".join((baseline, *candidate, notice))) > GITHUB_COMMENT_CHAR_LIMIT:
+            break
+        published.append(finding)
+
+    notice = truncation.format(
+        published=len(published),
+        total=len(findings),
+        record_reference=record_reference,
+    )
+    return "\n\n".join((baseline, *published, notice))
+
+
+def build_review_comment(
+    *,
+    verdict: str,
+    head_sha: str,
+    model: str,
+    family: str,
+    harness: str,
+    review_evidence: ReviewEvidence | None = None,
+    review_id: str | None = None,
+) -> str:
+    """Render one auditable formal-review comment for a GitHub PR."""
+    lines = [
+        f"VERDICT: {verdict}",
+        f"Head SHA: {head_sha}",
+    ]
+    if review_id is not None:
+        lines.append(f"Review ID: {review_id}")
+    lines.append(
+        "Reviewer provenance: "
+        f"model={model}; family={family}; harness={harness}"
+    )
+    record_reference = (
+        f"review ID `{review_id}` (sealed formal-job artifact)"
+        if review_id is not None
+        else "the supplied `--findings-json` input (legacy publication path)"
+    )
+    return _render_evidence(
+        prefix="\n".join(lines),
+        evidence=review_evidence,
+        record_reference=record_reference,
+    )
+
+
+def build_verdict_comment(sealed: SealedVerdict) -> str:
+    """Render one auditable GitHub comment from a sealed formal review."""
+    return build_review_comment(
+        verdict=sealed.verdict,
+        head_sha=sealed.head_sha,
+        review_id=sealed.review_id,
+        model=sealed.model,
+        family=sealed.family,
+        harness=sealed.harness,
+        review_evidence=sealed.review_evidence,
+    )
+
+
+# Kept as a compatibility alias while external callers move to the honest name.
+build_thin_verdict_comment = build_verdict_comment
 
 
 def plan_publication(
@@ -403,7 +748,7 @@ def plan_publication(
         verdict=sealed.verdict,
         status_context=context,
         status_state=map_verdict_to_commit_status(sealed.verdict),
-        comment_body=build_thin_verdict_comment(sealed),
+        comment_body=build_verdict_comment(sealed),
         mutate=bool(mutate),
         reason=(
             "ready_to_publish"
@@ -416,6 +761,8 @@ def plan_publication(
 __all__ = [
     "DEFAULT_GATE_KIND",
     "DEFAULT_STATUS_CONTEXT",
+    "GITHUB_COMMENT_CHAR_LIMIT",
+    "REVIEW_SCHEMA_VERSION",
     "STATUS_ERROR",
     "STATUS_FAILURE",
     "STATUS_PENDING",
@@ -425,15 +772,22 @@ __all__ = [
     "HeadFreshness",
     "PublicationAction",
     "PublicationPlan",
+    "ReviewEvidence",
+    "ReviewFinding",
     "ReviewPublicationError",
     "SealedVerdict",
     "assert_head_fresh",
+    "build_review_comment",
     "build_thin_verdict_comment",
+    "build_verdict_comment",
     "check_head_freshness",
     "map_verdict_to_commit_status",
     "normalize_verdict",
+    "parse_review_evidence",
     "parse_sealed_verdict_payload",
     "parse_verdict_token",
     "plan_publication",
     "publication_idempotency_key",
+    "resolve_verdict_and_evidence",
+    "verdict_from_review_evidence",
 ]

--- a/scripts/fleet_comms/review_publication.py
+++ b/scripts/fleet_comms/review_publication.py
@@ -326,18 +326,13 @@ def verdict_from_review_evidence(evidence: ReviewEvidence) -> str:
     return "BLOCKED"
 
 
-def _verdict_from_degenerate_evidence(payload: Mapping[str, Any]) -> str | None:
-    overall = payload.get("overall")
-    if not isinstance(overall, Mapping):
-        return None
-    correctness = overall.get("correctness")
-    if correctness == "correct":
-        return "APPROVED"
-    if correctness == "incorrect":
-        return "CHANGES_REQUESTED"
-    if correctness == "uncertain":
-        return "BLOCKED"
-    return None
+def _verdict_from_degenerate_evidence(_payload: Mapping[str, Any]) -> str:
+    """Fail closed when a canonical review supplies no auditable evidence.
+
+    A reviewer-provided correctness label without an explanation or finding is
+    not evidence. It must never grant a green formal-review gate.
+    """
+    return "BLOCKED"
 
 
 def resolve_verdict_and_evidence(payload: Mapping[str, Any]) -> tuple[str, ReviewEvidence | None]:

--- a/scripts/fleet_comms/review_publisher.py
+++ b/scripts/fleet_comms/review_publisher.py
@@ -4,7 +4,7 @@ Sol fleet-comms (#5512) PR-G owns the GitHub side of formal review publication:
 
 * resolve current PR head (fail closed on lookup failure)
 * plan via pure ``review_publication.plan_publication`` (stale / idempotent / ready)
-* when mutate is requested and the plan says ``publish``: post one thin PR comment
+* when mutate is requested and the plan says ``publish``: post one evidence-bearing PR comment
   and one commit status under ``fleet/cross-family-review``
 * record a durable row in ``github_publications`` (schema v1)
 

--- a/tests/ai_agent_bridge/test_review_pr.py
+++ b/tests/ai_agent_bridge/test_review_pr.py
@@ -30,6 +30,6 @@ def test_build_review_pr_prompt_has_contract_and_cap() -> None:
     )
     assert "READ-ONLY REVIEW CONTRACT" in prompt
     assert "pull/5443" in prompt
-    assert "VERDICT:" in prompt
+    assert "code-review-findings.v1" in prompt
     assert "gpt-5.6-terra" in prompt
     assert "effort=high" in prompt

--- a/tests/ai_agent_bridge/test_review_verdict.py
+++ b/tests/ai_agent_bridge/test_review_verdict.py
@@ -33,7 +33,7 @@ def test_publish_review_verdict_dry_run_is_thin_and_does_not_post() -> None:
     assert len(summary.encode("utf-8")) <= publisher.MAX_VERDICT_SUMMARY_BYTES
 
 
-def test_publish_review_verdict_posts_one_comment_without_findings() -> None:
+def test_publish_review_verdict_marks_legacy_verdict_without_evidence() -> None:
     calls: list[list[str]] = []
 
     def fake_runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -57,7 +57,60 @@ def test_publish_review_verdict_posts_one_comment_without_findings() -> None:
     assert "VERDICT: CHANGES_REQUESTED" in comment
     assert "Head SHA: abc123" in comment
     assert "model=glm-5.2" in comment
-    assert "findings" not in comment.lower()
+    assert "NO EVIDENCE SUPPLIED" in comment
+
+
+def test_publish_review_verdict_posts_structured_explanation_and_findings() -> None:
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        if command[2] == "view":
+            return subprocess.CompletedProcess(command, 0, stdout="abc123\n", stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    publisher.publish_review_verdict(
+        pr=99,
+        verdict="CHANGES_REQUESTED",
+        model="claude-sonnet-5",
+        family="anthropic",
+        harness="claude",
+        review_evidence={
+            "schema_version": "code-review-findings.v1",
+            "overall": {
+                "correctness": "incorrect",
+                "explanation": "The shared index leaks state between calls.",
+                "confidence": 0.95,
+            },
+            "findings": [
+                {
+                    "id": "F001",
+                    "title": "Shared index state leaks",
+                    "body": "A mutation survives into the next review request.",
+                    "priority": "P1",
+                    "confidence": 0.9,
+                    "category": "regression",
+                    "location": {
+                        "path": "scripts/index.py",
+                        "start_line": 42,
+                        "end_line": 42,
+                        "claim_type": "present",
+                    },
+                    "verbatim": "INDEX.append(item)",
+                    "why_wrong": "The next request observes stale state.",
+                    "smallest_fix": "Create an index for each request.",
+                    "sources": ["none"],
+                }
+            ],
+        },
+        runner=fake_runner,
+    )
+
+    comment = calls[1][5]
+    assert "The shared index leaks state between calls." in comment
+    assert "scripts/index.py:42" in comment
+    assert "Severity: P1" in comment
+    assert "A mutation survives into the next review request." in comment
 
 
 def test_verdict_from_findings_json_requires_explicit_verdict(tmp_path) -> None:

--- a/tests/test_fleet_comms_formal_finalize.py
+++ b/tests/test_fleet_comms_formal_finalize.py
@@ -134,6 +134,66 @@ def test_finalize_publish_dry_run_and_live(tmp_path: Path) -> None:
     assert any(c[1:3] == ["pr", "comment"] for c in gh2.calls)
 
 
+def test_finalize_preserves_canonical_evidence_for_publication(tmp_path: Path) -> None:
+    root = tmp_path / "plane"
+    findings_path = tmp_path / "review-findings.json"
+    findings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "code-review-findings.v1",
+                "overall": {
+                    "correctness": "incorrect",
+                    "explanation": "The shared cache is retained between requests.",
+                    "confidence": 0.95,
+                },
+                "findings": [
+                    {
+                        "id": "F001",
+                        "title": "Shared cache survives requests",
+                        "body": "The mutable cache is reused by the next request.",
+                        "priority": "P1",
+                        "confidence": 0.9,
+                        "category": "regression",
+                        "location": {
+                            "path": "scripts/cache.py",
+                            "start_line": 19,
+                            "end_line": 19,
+                            "claim_type": "present",
+                        },
+                        "verbatim": "cache.update(values)",
+                        "why_wrong": "Requests observe stale entries.",
+                        "smallest_fix": "Construct a new cache per request.",
+                        "sources": ["none"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    gh = FakeGh()
+
+    result = finalize_formal_review_verdict(
+        pr_number=202,
+        model="m",
+        family="f",
+        harness="h",
+        findings_path=findings_path,
+        plane_root=root,
+        runner=gh,
+        publish=True,
+    )
+
+    assert result.verdict == "CHANGES_REQUESTED"
+    with FormalReviewJobService(root=root) as service:
+        sealed = service.load_sealed_verdict(result.review_id)
+    assert sealed.review_evidence is not None
+    assert sealed.review_evidence.explanation == "The shared cache is retained between requests."
+    comment = next(call for call in gh.calls if call[1:3] == ["pr", "comment"])
+    body = comment[comment.index("--body") + 1]
+    assert "scripts/cache.py:19" in body
+    assert "The mutable cache is reused by the next request." in body
+
+
 def test_cli_formal_job_accept(tmp_path: Path) -> None:
     from scripts.fleet_comms.cli import main
 

--- a/tests/test_fleet_comms_review_publication.py
+++ b/tests/test_fleet_comms_review_publication.py
@@ -200,7 +200,7 @@ def test_publication_idempotency_key_stable_and_sensitive() -> None:
     assert len({key1, different_sha, different_pr, different_gate}) == 4
 
 
-# ── status mapping + thin comment ────────────────────────────────────────────
+# ── status mapping + published comment ───────────────────────────────────────
 
 
 @pytest.mark.parametrize(
@@ -215,14 +215,72 @@ def test_map_verdict_to_commit_status(verdict: str, state: str) -> None:
     assert map_verdict_to_commit_status(verdict) == state
 
 
-def test_build_thin_verdict_comment_has_no_findings() -> None:
-    sealed = parse_sealed_verdict_payload(_sealed(verdict="CHANGES_REQUESTED"))
+def test_build_verdict_comment_marks_missing_review_evidence() -> None:
+    sealed = parse_sealed_verdict_payload(
+        _sealed(
+            verdict="CHANGES_REQUESTED",
+            review_evidence={
+                "schema_version": "code-review-findings.v1",
+                "overall": {
+                    "correctness": "incorrect",
+                    "explanation": "",
+                    "confidence": 0.9,
+                },
+                "findings": [],
+            },
+        )
+    )
     body = build_thin_verdict_comment(sealed)
     assert "VERDICT: CHANGES_REQUESTED" in body
     assert f"Head SHA: {_SHA_A}" in body
     assert "Review ID: review_deadbeef" in body
     assert "model=claude-opus-4-6" in body
-    assert "findings" not in body.lower()
+    assert "NO EVIDENCE SUPPLIED" in body
+
+
+def test_build_verdict_comment_truncates_findings_last_with_record_pointer() -> None:
+    findings = [
+        {
+            "id": f"F{number:03}",
+            "title": f"Finding {number}",
+            "body": "x" * 4_000,
+            "priority": "P2",
+            "confidence": 0.9,
+            "category": "correctness",
+            "location": {
+                "path": "scripts/example.py",
+                "start_line": number,
+                "end_line": number,
+                "claim_type": "present",
+            },
+            "verbatim": "value = shared_state",
+            "why_wrong": "The state is not reset.",
+            "smallest_fix": "Rebuild the state for every call.",
+            "sources": ["none"],
+        }
+        for number in range(1, 32)
+    ]
+    sealed = parse_sealed_verdict_payload(
+        _sealed(
+            verdict="CHANGES_REQUESTED",
+            review_evidence={
+                "schema_version": "code-review-findings.v1",
+                "overall": {
+                    "correctness": "incorrect",
+                    "explanation": "The review found several independent defects.",
+                    "confidence": 0.95,
+                },
+                "findings": findings,
+            }
+        )
+    )
+
+    body = build_thin_verdict_comment(sealed)
+
+    assert len(body) <= 64_000
+    assert "FINDINGS TRUNCATED" in body
+    assert "Full structured review record: review ID `review_deadbeef`" in body
+    assert "The review found several independent defects." in body
 
 
 # ── publication plan (dry-run default, no live mutation) ─────────────────────

--- a/tests/test_fleet_comms_review_publication.py
+++ b/tests/test_fleet_comms_review_publication.py
@@ -218,7 +218,7 @@ def test_map_verdict_to_commit_status(verdict: str, state: str) -> None:
 def test_build_verdict_comment_marks_missing_review_evidence() -> None:
     sealed = parse_sealed_verdict_payload(
         _sealed(
-            verdict="CHANGES_REQUESTED",
+            verdict="BLOCKED",
             review_evidence={
                 "schema_version": "code-review-findings.v1",
                 "overall": {
@@ -231,11 +231,55 @@ def test_build_verdict_comment_marks_missing_review_evidence() -> None:
         )
     )
     body = build_thin_verdict_comment(sealed)
-    assert "VERDICT: CHANGES_REQUESTED" in body
+    assert "VERDICT: BLOCKED" in body
     assert f"Head SHA: {_SHA_A}" in body
     assert "Review ID: review_deadbeef" in body
     assert "model=claude-opus-4-6" in body
     assert "NO EVIDENCE SUPPLIED" in body
+
+
+@pytest.mark.parametrize("correctness", ["correct", "incorrect", "uncertain"])
+def test_degenerate_review_evidence_is_always_blocked(correctness: str) -> None:
+    """A bare reviewer label cannot grant or deny the formal merge gate."""
+    sealed = parse_sealed_verdict_payload(
+        _sealed(
+            verdict="BLOCKED",
+            review_evidence={
+                "schema_version": "code-review-findings.v1",
+                "overall": {
+                    "correctness": correctness,
+                    "explanation": "",
+                    "confidence": 0.9,
+                },
+                "findings": [],
+            },
+        )
+    )
+
+    plan = plan_publication(sealed, current_head_sha=_SHA_A, mutate=True)
+
+    assert sealed.verdict == "BLOCKED"
+    assert sealed.review_evidence is None
+    assert plan.status_state == STATUS_ERROR
+    assert plan.comment_body is not None
+    assert "NO EVIDENCE SUPPLIED" in plan.comment_body
+
+
+def test_degenerate_review_evidence_rejects_an_explicit_approved_verdict() -> None:
+    with pytest.raises(ReviewPublicationError, match="review_evidence_verdict_mismatch"):
+        parse_sealed_verdict_payload(
+            _sealed(
+                review_evidence={
+                    "schema_version": "code-review-findings.v1",
+                    "overall": {
+                        "correctness": "correct",
+                        "explanation": "",
+                        "confidence": 0.9,
+                    },
+                    "findings": [],
+                }
+            )
+        )
 
 
 def test_build_verdict_comment_truncates_findings_last_with_record_pointer() -> None:

--- a/tests/test_fleet_comms_review_publisher.py
+++ b/tests/test_fleet_comms_review_publisher.py
@@ -109,7 +109,7 @@ def test_publish_matrix_posts_comment_and_status(
     assert len(comment_calls) == 1
     body = comment_calls[0][comment_calls[0].index("--body") + 1]
     assert f"VERDICT: {verdict}" in body
-    assert "findings" not in body.lower()
+    assert "NO EVIDENCE SUPPLIED" in body
     status_calls = [c for c in gh.calls if c[1] == "api"]
     assert any(f"state={status}" in " ".join(c) for c in status_calls)
     assert any(DEFAULT_STATUS_CONTEXT in " ".join(c) for c in status_calls)

--- a/tests/test_fleet_comms_rollout_acceptance.py
+++ b/tests/test_fleet_comms_rollout_acceptance.py
@@ -174,6 +174,7 @@ def test_formal_review_verdict_is_sealed_as_an_immutable_json_artifact(tmp_path:
         "model": "claude-sonnet-5",
         "pr_number": 5512,
         "repository": _REPOSITORY,
+        "review_evidence": None,
         "review_id": result.review_id,
         "verdict": "APPROVED",
     }


### PR DESCRIPTION
## Summary

- Retain validated `code-review-findings.v1` evidence in sealed formal-review verdicts.
- Render the overall explanation and every finding in the PR comment; show a visible no-evidence marker for degenerate reviews.
- Truncate findings last at the GitHub comment limit and point to the sealed review record.

## Verification

- `PYTHONPATH=scripts .venv/bin/python -m pytest tests/ai_agent_bridge/test_review_verdict.py tests/ai_agent_bridge/test_review_pr.py tests/test_fleet_comms_review_publication.py tests/test_fleet_comms_review_publisher.py tests/test_fleet_comms_formal_finalize.py -q`
- `.venv/bin/ruff check` on changed Python files and tests
- `markdownlint-cli2 --config .markdownlint.json docs/best-practices/agent-bridge.md`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`

Refs #5802 and #5809.