### PR TITLE
fix(delegate): raise initial-response timeout default to 600s + actionable timeout messages

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -203,7 +203,10 @@ DEFAULT_HARD_TIMEOUT_S = 7200
 DEFAULT_SILENCE_TIMEOUT_S = 3600
 # Fail fast when Codex (or any agent) never produces stdout/stderr/liveness
 # activity at startup — distinct from the long silence window above (#2071).
-DEFAULT_INITIAL_RESPONSE_TIMEOUT_S = 180
+# 600s: reasoning-heavy models at high/max effort routinely think for minutes
+# before their first token; the old 180s killed healthy workers mid-thought
+# (observed: deepseek review dispatch reaped at 181s, 1s over the limit).
+DEFAULT_INITIAL_RESPONSE_TIMEOUT_S = 600
 
 
 # ---------------------------------------------------------------------------
@@ -2424,16 +2427,28 @@ def _run_worker(
     except AgentStalledError as exc:
         timed_out = True
         substitution = getattr(exc, "substitution", None)
-        prefix = (
-            "initial_response_timeout"
-            if getattr(exc, "kind", "stall") == "initial_response_timeout"
-            else "stdout_silence_timeout"
-        )
-        stderr_excerpt = f"{prefix}: {exc}"[:500]
+        if getattr(exc, "kind", "stall") == "initial_response_timeout":
+            stderr_excerpt = (
+                f"initial_response_timeout fired after {exc.stall_timeout}s "
+                f"with no first stdout/stderr/liveness activity: {exc} "
+                f"— raise it with --initial-response-timeout "
+                f"(current default {DEFAULT_INITIAL_RESPONSE_TIMEOUT_S}s)"
+            )[:500]
+        else:
+            stderr_excerpt = (
+                f"stdout_silence_timeout fired after {exc.stall_timeout}s "
+                f"without watchdog activity: {exc} "
+                f"— raise it with --silence-timeout "
+                f"(current default {DEFAULT_SILENCE_TIMEOUT_S}s)"
+            )[:500]
         returncode_reason = "runtime timeout raised before a terminal subprocess returncode was available"
     except AgentTimeoutError as exc:
         substitution = getattr(exc, "substitution", None)
-        stderr_excerpt = f"hard_timeout: {exc}"[:500]
+        stderr_excerpt = (
+            f"hard_timeout fired after {exc.hard_timeout}s: {exc} "
+            f"— raise it with --hard-timeout "
+            f"(current default {DEFAULT_HARD_TIMEOUT_S}s)"
+        )[:500]
         returncode_reason = "runtime timeout raised before a terminal subprocess returncode was available"
     except AgentRuntimeError as exc:
         stderr_excerpt = f"runtime error: {type(exc).__name__}: {exc}"[:500]

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -315,6 +315,39 @@ def test_explicit_silence_timeout_override_still_works():
     assert args.silence_timeout == 600
 
 
+def test_initial_response_timeout_default_is_600():
+    """Reasoning-heavy models think for minutes before their first token;
+    the default startup probe must tolerate that (# dispatch-timeouts)."""
+    args = delegate.build_parser().parse_args([
+        "dispatch",
+        "--agent",
+        "codex",
+        "--task-id",
+        "defaults",
+        "--prompt",
+        "hi",
+    ])
+
+    assert args.initial_response_timeout == 600
+    assert delegate.DEFAULT_INITIAL_RESPONSE_TIMEOUT_S == 600
+
+
+def test_explicit_initial_response_timeout_override_still_works():
+    args = delegate.build_parser().parse_args([
+        "dispatch",
+        "--agent",
+        "codex",
+        "--task-id",
+        "override",
+        "--prompt",
+        "hi",
+        "--initial-response-timeout",
+        "120",
+    ])
+
+    assert args.initial_response_timeout == 120
+
+
 def test_dispatch_help_documents_timeout_interaction(capsys):
     parser = delegate.build_parser()
 
@@ -1974,6 +2007,129 @@ def test_run_worker_silence_timeout_kills_silent_subprocess(
     assert events[-1]["task_id"] == "silent-timeout"
     assert events[-1]["status"] == "timeout"
     assert events[-1]["silence_timeout_s"] == 1
+
+
+def _sleeping_adapter(returncode_file: Path) -> Any:
+    """Adapter whose CLI never produces output (sleeps until reaped)."""
+
+    class SleepingAdapter:
+        name = "claude"
+        default_model = "fixture-model"
+        supported_modes = frozenset({"read-only"})
+
+        def build_invocation(self, **kwargs: Any) -> InvocationPlan:
+            return InvocationPlan(
+                cmd=["/bin/sh", "-c", "sleep 60"],
+                cwd=Path(kwargs["cwd"]),
+            )
+
+        def parse_response(self, *, returncode: int, **_kwargs: Any) -> ParseResult:
+            returncode_file.write_text(str(returncode), encoding="utf-8")
+            return ParseResult(ok=False, response="", stderr_excerpt="")
+
+        def liveness_signal_paths(self, _plan: InvocationPlan) -> tuple[Path, ...]:
+            return ()
+
+    return SleepingAdapter()
+
+
+def _patch_runtime_for_sleeping_adapter(
+    monkeypatch: pytest.MonkeyPatch, adapter: Any
+) -> None:
+    from agent_runtime import runner as runtime_runner
+
+    monkeypatch.setattr(runtime_runner, "has_headroom", lambda *_args: (True, ""))
+    monkeypatch.setattr(runtime_runner, "write_record", lambda _record: None)
+    monkeypatch.setattr(
+        runtime_runner,
+        "resolve_invocation_telemetry",
+        lambda **_kwargs: InvocationTelemetry(
+            model="fixture-model",
+            effort="unknown",
+            cli_version="fixture",
+        ),
+    )
+    monkeypatch.setitem(runtime_runner._ADAPTER_CACHE, "claude", adapter)
+
+
+def test_run_worker_initial_response_timeout_still_reaps_silent_startup(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """A worker that exceeds the startup probe is still reaped (timeouts
+    are not disabled) and the death message names the timeout, its value,
+    and the flag to raise it."""
+    state_path = delegate._state_path("initial-timeout")
+    returncode_file = tmp_path / "returncode.txt"
+    delegate._write_state_atomic(state_path, {"task_id": "initial-timeout"})
+    _patch_runtime_for_sleeping_adapter(
+        monkeypatch, _sleeping_adapter(returncode_file)
+    )
+
+    started = time.monotonic()
+    rc = delegate._run_worker(
+        task_id="initial-timeout",
+        agent="claude",
+        prompt="hi",
+        mode="read-only",
+        cwd_str=str(tmp_path),
+        model=None,
+        hard_timeout=30,
+        silence_timeout=30,
+        effort=None,
+        initial_response_timeout=1,
+    )
+    elapsed = time.monotonic() - started
+
+    state = delegate._read_state(state_path)
+
+    assert rc == 1
+    assert elapsed < 6
+    assert int(returncode_file.read_text("utf-8")) == -signal.SIGKILL
+    assert state is not None
+    assert state["status"] == "timeout"
+    excerpt = state["stderr_excerpt"] or ""
+    assert "initial_response_timeout" in excerpt
+    assert "fired after 1s" in excerpt
+    assert "--initial-response-timeout" in excerpt
+
+
+def test_run_worker_silence_timeout_message_names_flag_and_value(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """The silence-timeout death message must also be actionable: name the
+    timeout, its configured value, and the flag to raise it."""
+    state_path = delegate._state_path("silence-message")
+    returncode_file = tmp_path / "returncode.txt"
+    delegate._write_state_atomic(state_path, {"task_id": "silence-message"})
+    _patch_runtime_for_sleeping_adapter(
+        monkeypatch, _sleeping_adapter(returncode_file)
+    )
+
+    rc = delegate._run_worker(
+        task_id="silence-message",
+        agent="claude",
+        prompt="hi",
+        mode="read-only",
+        cwd_str=str(tmp_path),
+        model=None,
+        hard_timeout=30,
+        silence_timeout=1,
+        effort=None,
+    )
+
+    state = delegate._read_state(state_path)
+
+    assert rc == 1
+    assert state is not None
+    assert state["status"] == "timeout"
+    excerpt = state["stderr_excerpt"] or ""
+    assert "stdout_silence_timeout" in excerpt
+    assert "fired after 1s" in excerpt
+    assert "--silence-timeout" in excerpt
 
 
 def test_run_worker_periodic_stdout_avoids_silence_timeout(


### PR DESCRIPTION
## Problem

`scripts/delegate.py` set `DEFAULT_INITIAL_RESPONSE_TIMEOUT_S = 180`. Workers that think before emitting their first output were killed at 3 minutes, having done nothing wrong.

Observed:
- a deepseek review dispatch died with `initial_response_timeout: deepseek stalled: 181s since last activity (stall_timeout=180s)` — 1 second over
- several dispatches needed 400-600s of real work; survivors only made it because `--initial-response-timeout` was passed manually per call
- reasoning-heavy models at high/max effort routinely take minutes before their first token

## Changes

- **`DEFAULT_INITIAL_RESPONSE_TIMEOUT_S`: 180 → 600** (10 min).
- **Sibling defaults reviewed, unchanged:**
  - `DEFAULT_SILENCE_TIMEOUT_S = 3600` — it's a *composite* watchdog: stdout, liveness-file updates, and process-tree CPU/disk activity all reset it, so a quiet-but-busy long test run never trips it. 3600s of true inactivity is a genuine hang. (Comment at the constant already warns against lowering it — #3875 false-kill shape.)
  - `DEFAULT_HARD_TIMEOUT_S = 7200` — 12x headroom over the observed 400-600s real-work dispatches.
- **Effort-aware defaults: considered, skipped.** Effort is unset on most dispatches, first-token latency is as model-dependent as effort-dependent, and threading effort into argparse defaults at two parsers (`dispatch`, `worker`) complicates incident-time reasoning for no observed gain — the uniform 600s floor already covers the max-effort case.
- **Actionable death messages** in `_run_worker`: each timeout path now names which timeout fired, its configured value, and the flag to raise it, e.g.
  `initial_response_timeout fired after 600s with no first stdout/stderr/liveness activity: … — raise it with --initial-response-timeout (current default 600s)`
  Same treatment for `stdout_silence_timeout` (`--silence-timeout`) and `hard_timeout` (`--hard-timeout`).

Not changed: flag semantics of `--initial-response-timeout` / `--silence-timeout` / `--hard-timeout`; timeouts are not disabled — a genuinely hung worker is still reaped (covered by test).

## Tests

New tests in `tests/test_delegate.py`:
- `test_initial_response_timeout_default_is_600` — default is the new value
- `test_run_worker_initial_response_timeout_still_reaps_silent_startup` — a worker exceeding the probe is still SIGKILLed and persisted `status=timeout`
- `test_run_worker_silence_timeout_message_names_flag_and_value` — message names timeout, value, and flag
- (`test_explicit_initial_response_timeout_override_still_works` — flag semantics unchanged)

All three required tests **verified to fail against the pre-change code** (via `git stash` of `scripts/delegate.py`): default asserted 180, messages lacked value/flag.

## Verification

- `pytest tests/test_delegate.py -q` — **145 passed** (default REFUSE ownership mode; the ~8 synthetic ownership failures mentioned in the dispatch brief did not reproduce after fast-forwarding onto latest `origin/main`)
- `DELEGATE_OWNERSHIP_MODE=warn pytest tests/test_delegate.py -q` — **145 passed**
- `ruff check scripts/delegate.py tests/test_delegate.py` — clean
- `lint_opsec_leaks.py` — zero leaks; `lint_agent_trailer.py` — trailer present

X-Agent: kimi/fix-dispatch-timeouts
