### PR TITLE
feat(dispatch): surface lane capacity in orient and dispatch hint

### DIFF
--- a/dashboards/routing.html
+++ b/dashboards/routing.html
@@ -37,9 +37,10 @@ tr:last-child td { border-bottom:none; }
 .pill.cool, .pill.ok, .pill.done { background:rgba(63,185,80,.15); color:var(--green); }
 .pill.warm, .pill.hot, .pill.warn, .pill.timeout { background:rgba(210,153,34,.15); color:var(--orange); }
 .pill.near_cap, .pill.error, .pill.failed, .pill.rate_limited, .pill.zombie { background:rgba(248,81,73,.15); color:var(--red); }
-.pill.gray, .pill.unknown, .pill.spawning, .pill.running { background:rgba(72,79,88,.2); color:var(--text2); }
+.pill.gray, .pill.unknown, .pill.spawning, .pill.running, .pill.unavailable { background:rgba(72,79,88,.2); color:var(--text2); }
 .bar { background:var(--bg3); border-radius:4px; height:8px; overflow:hidden; min-width:90px; }
 .bar span { background:var(--accent); display:block; height:100%; }
+.bar.unavailable span { background: repeating-linear-gradient(45deg, var(--border), var(--border) 4px, var(--bg3) 4px, var(--bg3) 8px); opacity: 0.7; }
 .section { margin-top:18px; }
 .section h2 { font-family: Charter, Georgia, serif; font-size:22px; margin:0 0 10px; }
 .error { color:var(--red); font-size:13px; padding:12px 0; }
@@ -174,13 +175,17 @@ function renderSummary(routing, usage, delegates) {
 function renderBudget(routing) {
   const agents = routing.agents || {};
   const rows = Object.entries(agents).map(([name, data]) => {
-    const burn = pct(data.burn_pct_7d);
+    const isUnavailable = data.status === 'unavailable' || data.burn_pct_7d == null || typeof data.burn_pct_7d !== 'number';
+    const burnStr = isUnavailable ? 'unavailable' : `${Number(data.burn_pct_7d).toFixed(1)}%`;
+    const barCell = isUnavailable
+      ? '<div class="bar unavailable" title="Capacity unavailable"><span style="width:100%"></span></div>'
+      : `<div class="bar"><span style="width:${pct(data.burn_pct_7d)}%"></span></div>`;
     const cap = data.weekly_cap_usd == null ? 'n/a' : `$${Number(data.weekly_cap_usd).toFixed(0)}`;
     return `<tr>
       <td class="mono">${escapeHtml(name)}</td>
       <td>${statusPill(data.status)}</td>
-      <td>${burn.toFixed(1)}%</td>
-      <td><div class="bar"><span style="width:${burn}%"></span></div></td>
+      <td>${escapeHtml(burnStr)}</td>
+      <td>${barCell}</td>
       <td>${cap}</td>
       <td>${escapeHtml((routing.in_flight || {})[name] ?? 0)}</td>
     </tr>`;

--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -66,21 +66,26 @@ def refresh_provider_usage_data(providers: Iterable[str], *, timeout_s: float = 
     return refreshed
 
 
-def fetch_codexbar_usage(provider: str, *, timeout_s: float = 45.0) -> dict[str, Any] | None:
+def fetch_codexbar_usage(provider: str, *, timeout_s: float = 45.0) -> dict[str, Any]:
     """Run codexbar CLI, parse and normalize provider-specific usage data.
 
-    Returns None on failure/timeout/parse error. Never raises exceptions.
+    Returns a normalized dictionary. If the CLI fails, times out, is missing,
+    or returns an error/malformed output, returns a normalized record with status='unavailable'
+    and auth_error/error_kind set. Never raises exceptions.
     For provider 'gemini', it queries 'gemini' first, and falls back to 'antigravity' if the first fails.
     """
     if provider == "gemini":
         data = _fetch_single_provider("gemini", timeout_s=timeout_s)
-        if data is not None:
+        if data.get("weekly_used_pct") is not None:
             return data
-        return _fetch_single_provider("antigravity", timeout_s=timeout_s)
+        fallback_data = _fetch_single_provider("antigravity", timeout_s=timeout_s)
+        if fallback_data.get("weekly_used_pct") is not None:
+            return fallback_data
+        return data
     return _fetch_single_provider(provider, timeout_s=timeout_s)
 
 
-def _fetch_single_provider(provider: str, timeout_s: float) -> dict[str, Any] | None:
+def _fetch_single_provider(provider: str, timeout_s: float) -> dict[str, Any]:
     try:
         # Run codexbar usage --json --provider <provider>
         try:
@@ -99,34 +104,74 @@ def _fetch_single_provider(provider: str, timeout_s: float) -> dict[str, Any] | 
             res = subprocess.CompletedProcess(cmd, returncode=127, stdout="", stderr="")
         if res.returncode != 0 and not _stdout_has_provider_payload(res.stdout):
             # Fallback to codexbar in system path
-            cmd = ["codexbar", "usage", "--json", "--provider", provider]
-            res = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=timeout_s,
-                check=False,
-            )
+            try:
+                cmd = ["codexbar", "usage", "--json", "--provider", provider]
+                res = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_s,
+                    check=False,
+                )
+            except FileNotFoundError:
+                return _normalize_provider_error(
+                    provider,
+                    {"message": "CodexBar CLI binary not found", "kind": "missing_binary", "code": 127},
+                )
             # The CLI exits NON-zero on provider/credential errors while still
             # printing the error JSON on stdout (live-verified 2026-07-17: kimi
             # expired credential → rc=1 + error payload). Bail only when there
-            # is no parseable payload at all — otherwise fall through so the
-            # error surfaces as status='unknown' instead of a silent None.
+            # is no parseable payload at all.
             if res.returncode != 0 and not _stdout_has_provider_payload(res.stdout):
-                return None
+                if res.returncode == 127:
+                    return _normalize_provider_error(
+                        provider,
+                        {"message": "CodexBar CLI binary not found", "kind": "missing_binary", "code": 127},
+                    )
+                return _normalize_provider_error(
+                    provider,
+                    {
+                        "message": (res.stderr.strip() or f"CodexBar CLI exited with non-zero code {res.returncode}"),
+                        "kind": "non_zero_exit",
+                        "code": res.returncode,
+                    },
+                )
 
-        parsed = json.loads(res.stdout)
+        try:
+            parsed = json.loads(res.stdout)
+        except Exception as exc:
+            return _normalize_provider_error(
+                provider,
+                {"message": f"CodexBar CLI stdout is malformed JSON: {exc}", "kind": "malformed_json", "code": "MALFORMED_JSON"},
+            )
+
         if not isinstance(parsed, list) or not parsed:
-            return None
+            return _normalize_provider_error(
+                provider,
+                {"message": "CodexBar CLI JSON payload is unparseable or empty schema", "kind": "unparseable_schema", "code": "UNPARSEABLE_SCHEMA"},
+            )
 
         first_entry = parsed[0]
+        if not isinstance(first_entry, dict):
+            return _normalize_provider_error(
+                provider,
+                {"message": "CodexBar CLI JSON payload entry is unparseable schema", "kind": "unparseable_schema", "code": "UNPARSEABLE_SCHEMA"},
+            )
+
         if "error" in first_entry:
-            # Provider/credential error (e.g. expired Kimi credentials): surface
-            # as status='unknown' with the message carried, never as zero usage.
+            # Provider/credential error (e.g. expired Kimi credentials)
             return _normalize_provider_error(provider, first_entry["error"])
         return _normalize_provider_data(provider, first_entry)
-    except Exception:
-        return None
+    except subprocess.TimeoutExpired:
+        return _normalize_provider_error(
+            provider,
+            {"message": f"CodexBar CLI timed out after {timeout_s}s", "kind": "timeout", "code": "TIMEOUT"},
+        )
+    except Exception as exc:
+        return _normalize_provider_error(
+            provider,
+            {"message": f"CodexBar CLI fetch error: {exc}", "kind": "fetch_error", "code": "FETCH_ERROR"},
+        )
 
 
 def _normalize_provider_data(provider: str, data: dict[str, Any]) -> dict[str, Any]:
@@ -405,9 +450,9 @@ def _normalize_provider_error(provider: str, error: Any) -> dict[str, Any]:
         "pace_summary": None,
         "source": "codexbar",
         "fetched_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-        "status": "unknown",
+        "status": "unavailable",
         "auth_error": message,
-        "error_kind": kind,
+        "error_kind": kind or "unavailable",
         "error_code": code,
     }
 
@@ -494,6 +539,8 @@ def get_provider_usage_data(provider: str) -> dict[str, Any]:
         "fetched_at": None,
         "stale": False,
         "age_s": None,
-        "status": "unknown",
-        "auth_error": None,
+        "status": "unavailable",
+        "auth_error": "CodexBar usage data unavailable",
+        "error_kind": "unavailable",
+        "error_code": None,
     }

--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -464,7 +464,7 @@ def get_provider_usage_data(provider: str) -> dict[str, Any]:
         res["age_s"] = time.monotonic() - t_mono
         return res
 
-    # Completely unknown fallback
+    # Completely unavailable fallback
     lane = PROVIDER_TO_LANE.get(provider, provider)
     empty_win = {
         "used_pct": None,

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -243,6 +243,7 @@ ORIENT_SECTION_TTLS: dict[str, float] = {
     "pipeline": 0.0,
     "runtime": 60.0,
     "delegate": 30.0,
+    "capacity": 15.0,
     "bridge_pending": 15.0,
     "rollovers": 15.0,
     "wiki": 120.0,
@@ -257,6 +258,7 @@ ORIENT_SECTION_SOURCES: dict[str, str] = {
     "pipeline": "fs",
     "runtime": "fs",
     "delegate": "fs",
+    "capacity": "fs",
     "bridge_pending": "sqlite",
     "rollovers": "fs",
     "wiki": "fs",
@@ -279,6 +281,7 @@ LEAN_ORIENT_SECTIONS: tuple[str, ...] = (
     "git",
     "runtime",
     "delegate",
+    "capacity",
     "bridge_pending",
     "rollovers",
     "governance",
@@ -530,6 +533,29 @@ def _collect_delegate_orient_data() -> dict:
     return {
         "active_count": delegate_api.active_delegate_count(),
         "recent": recent["tasks"],
+    }
+
+
+def _collect_capacity_orient_data() -> dict:
+    budget = state_api.compute_routing_budget()
+    lanes_summary = {}
+    agents = budget.get("agents", {})
+    in_flight = budget.get("in_flight", {})
+    for lane in state_api.SUBSCRIPTION_LANES:
+        data = agents.get(lane, {})
+        health = data.get("health", {})
+        healthy = health.get("healthy", True) if isinstance(health, dict) else True
+        lanes_summary[lane] = {
+            "in_flight": in_flight.get(lane, 0),
+            "healthy": healthy,
+            "burn_pct_7d": data.get("burn_pct_7d"),
+            "remaining_pct": data.get("remaining_pct"),
+            "status": data.get("status", "unknown"),
+        }
+    rec = budget.get("recommendation", {}).get("primary_agent_for_code")
+    return {
+        "lanes": lanes_summary,
+        "primary_recommendation": rec,
     }
 
 
@@ -855,6 +881,7 @@ def _orient_section_specs() -> dict[str, tuple[Callable[..., Any], Any, bool]]:
         "pipeline": (_collect_pipeline_orient_data, {"summary": {}}, True),
         "runtime": (_collect_runtime_orient_data, {}, False),
         "delegate": (_collect_delegate_orient_data, {"active_count": 0, "recent": []}, False),
+        "capacity": (_collect_capacity_orient_data, {"lanes": {}}, False),
         "bridge_pending": (_collect_bridge_pending_orient_data, {}, False),
         "rollovers": (
             _collect_rollovers_orient_data,
@@ -926,12 +953,11 @@ async def orient(
         *[
             _cached_orient_section(
                 key,
-                collector,
-                fallback,
-                is_async=is_async,
+                section_specs[key][0],
+                section_specs[key][1],
+                is_async=section_specs[key][2],
             )
-            for key, (collector, fallback, is_async) in section_specs.items()
-            if key in selected
+            for key in selected
         ]
     )
 
@@ -962,6 +988,8 @@ async def orient(
         response["runtime"] = section_data["runtime"]
     if "delegate" in section_data:
         response["delegate"] = section_data["delegate"]
+    if "capacity" in section_data:
+        response["capacity"] = section_data["capacity"]
     if "bridge_pending" in section_data:
         response["bridge_pending"] = section_data["bridge_pending"]
     if "rollovers" in section_data:

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -436,19 +436,14 @@ def _recommend_agent(
             burn_by_agent[a] = agents[a].get("burn_pct_7d")
             resets_by[a] = agents[a].get("resets_at")
 
-    # If no usable data at all for rec, suppress
-    usable = [a for a, s in status_by_agent.items() if s not in {"unknown", "unavailable", "pre_launch", None}]
-    if not usable or all(s in {"hot", "near_cap", "unknown", "unavailable"} for s in status_by_agent.values()):
-        if all(s in {"hot", "near_cap"} for s in status_by_agent.values() if s not in {"unknown", "unavailable"}):
-            warnings.append("all agents near cap — orchestrator inline-mode contingency may be needed soon")
-            return {
-                "primary_agent_for_code": "inline_orchestrator",
-                "rationale": "All agents are hot or near cap; preserve remaining provider quota for high-judgment work.",
-                "warnings": warnings,
-            }
+    # Only claim inline_orchestrator if at least one lane is actually observed AND all observed lanes are hot/near_cap.
+    # An empty observation set (all unknown/unavailable) must NEVER satisfy this.
+    observed_statuses = [s for s in status_by_agent.values() if s not in {"unknown", "unavailable"}]
+    if observed_statuses and all(s in {"hot", "near_cap"} for s in observed_statuses):
+        warnings.append("all agents near cap — orchestrator inline-mode contingency may be needed soon")
         return {
-            "primary_agent_for_code": None,
-            "rationale": "No usable subscription lane headroom data for confident recommendation (stale/empty/unknowns).",
+            "primary_agent_for_code": "inline_orchestrator",
+            "rationale": "All agents are hot or near cap; preserve remaining provider quota for high-judgment work.",
             "warnings": warnings,
         }
 
@@ -532,7 +527,25 @@ def _recommend_agent(
                 "rationale": f"Mixed routing state; {recommended} currently has the lowest 7d burn ({_format_pct(burn_map.get(recommended))}%).",
             }
 
-        return {"primary_agent_for_code": None, "rationale": "insufficient data"}
+        # Doctrine #5816: lanes without pace data are partly blind, not unusable.
+        # Fall back to in-flight count + lane health, picking the first eligible candidate.
+        unknown_candidates = [a for a in ("claude", "codex", "gemini") if a in status_map]
+        if not unknown_candidates:
+            unknown_candidates = [a for a in status_map if a in SUBSCRIPTION_LANES]
+        if unknown_candidates:
+            def _sort_in_flight(lane_name: str) -> int:
+                return int(agents_dict.get(lane_name, {}).get("in_flight", 0))
+
+            recommended = min(unknown_candidates, key=_sort_in_flight)
+            return {
+                "primary_agent_for_code": recommended,
+                "rationale": f"Capacity data unavailable for subscription lanes (partly blind); fallback recommendation {recommended} based on lane health and in-flight signals.",
+            }
+
+        return {
+            "primary_agent_for_code": None,
+            "rationale": "No usable subscription lane headroom data for confident recommendation (stale/empty/unknowns).",
+        }
 
     # 1. Determine baseline budget-only recommendation (ignore health)
     budget_only_res = select_agent(agents, status_by_agent, burn_by_agent, resets_by)

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -855,14 +855,16 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 if cb_data.get("weekly_resets_at"):
                     agents[lane]["resets_at"] = cb_data["weekly_resets_at"]
 
-        elif cb_data and cb_data.get("auth_error"):
-            # Provider/credential error from codexbar (e.g. Kimi/Gemini credentials
-            # expired). The CLI positively reported the lane is unavailable.
-            # Surface status='unavailable' with the error message carried;
-            # report 'unavailable' for quota fields rather than ambiguous null.
+        else:
+            # CodexBar capacity is unavailable (missing binary, timeout, non-zero exit, malformed JSON, unparseable schema, provider error, or fallback).
+            # Authoritative subscription capacity is ABSENT — mark lane explicitly UNAVAILABLE.
+            # Never present ledger-derived numeric burn/remaining/status as authoritative capacity.
             agents[lane]["status"] = "unavailable"
             agents[lane]["burn_pct_7d"] = "unavailable"
             agents[lane]["remaining_pct"] = "unavailable"
+            err_msg = (cb_data.get("auth_error") if isinstance(cb_data, dict) else None) or "CodexBar usage data unavailable"
+            err_kind = (cb_data.get("error_kind") if isinstance(cb_data, dict) else None) or "unavailable"
+            err_code = cb_data.get("error_code") if isinstance(cb_data, dict) else None
             agents[lane]["codexbar"] = {
                 "primary_used_pct": None,
                 "primary_remaining_pct": None,
@@ -879,12 +881,12 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 "weekly_pace_delta_pct": None,
                 "will_last_to_reset": None,
                 "pace_summary": None,
-                "stale": cb_data.get("stale", False),
-                "fetched_at": cb_data.get("fetched_at"),
+                "stale": cb_data.get("stale", False) if isinstance(cb_data, dict) else False,
+                "fetched_at": cb_data.get("fetched_at") if isinstance(cb_data, dict) else None,
                 "status": "unavailable",
-                "auth_error": cb_data.get("auth_error"),
-                "error_kind": cb_data.get("error_kind"),
-                "error_code": cb_data.get("error_code"),
+                "auth_error": err_msg,
+                "error_kind": err_kind,
+                "error_code": err_code,
             }
             if lane == "claude":
                 agents[lane]["interactive"]["status"] = "unavailable"

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -860,8 +860,8 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
             # Authoritative subscription capacity is ABSENT — mark lane explicitly UNAVAILABLE.
             # Never present ledger-derived numeric burn/remaining/status as authoritative capacity.
             agents[lane]["status"] = "unavailable"
-            agents[lane]["burn_pct_7d"] = "unavailable"
-            agents[lane]["remaining_pct"] = "unavailable"
+            agents[lane]["burn_pct_7d"] = None
+            agents[lane]["remaining_pct"] = None
             err_msg = (cb_data.get("auth_error") if isinstance(cb_data, dict) else None) or "CodexBar usage data unavailable"
             err_kind = (cb_data.get("error_kind") if isinstance(cb_data, dict) else None) or "unavailable"
             err_code = cb_data.get("error_code") if isinstance(cb_data, dict) else None
@@ -890,7 +890,7 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
             }
             if lane == "claude":
                 agents[lane]["interactive"]["status"] = "unavailable"
-                agents[lane]["interactive"]["burn_pct_7d"] = "unavailable"
+                agents[lane]["interactive"]["burn_pct_7d"] = None
 
     # Hybrid overlay: agent-runtime JSONL burn (rate-limits / outcomes).
     # CodexBar remains authoritative for subscription allotment %; this layer

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -316,9 +316,9 @@ def _round_money(value: float | None) -> float | None:
     return round(float(value), 2)
 
 
-def _format_pct(value: float | None) -> str:
-    if value is None:
-        return "unknown"
+def _format_pct(value: float | str | None) -> str:
+    if value is None or isinstance(value, str):
+        return str(value) if value is not None else "unknown"
     return f"{value:.1f}".rstrip("0").rstrip(".")
 
 
@@ -430,14 +430,16 @@ def _recommend_agent(
     for a in SUBSCRIPTION_LANES:
         if a in core or a not in agents:
             continue
-        status_by_agent[a] = agents[a].get("status", "unknown")
-        burn_by_agent[a] = agents[a].get("burn_pct_7d")
-        resets_by[a] = agents[a].get("resets_at")
+        st = agents[a].get("status", "unknown")
+        if st not in ("unknown", "unavailable"):
+            status_by_agent[a] = st
+            burn_by_agent[a] = agents[a].get("burn_pct_7d")
+            resets_by[a] = agents[a].get("resets_at")
 
     # If no usable data at all for rec, suppress
-    usable = [a for a, s in status_by_agent.items() if s not in {"unknown", "pre_launch", None}]
-    if not usable or all(s in {"hot", "near_cap", "unknown"} for s in status_by_agent.values()):
-        if all(s in {"hot", "near_cap"} for s in status_by_agent.values() if s not in {"unknown"}):
+    usable = [a for a, s in status_by_agent.items() if s not in {"unknown", "unavailable", "pre_launch", None}]
+    if not usable or all(s in {"hot", "near_cap", "unknown", "unavailable"} for s in status_by_agent.values()):
+        if all(s in {"hot", "near_cap"} for s in status_by_agent.values() if s not in {"unknown", "unavailable"}):
             warnings.append("all agents near cap — orchestrator inline-mode contingency may be needed soon")
             return {
                 "primary_agent_for_code": "inline_orchestrator",
@@ -469,6 +471,10 @@ def _recommend_agent(
         )
 
     def select_agent(agents_dict, status_map, burn_map, resets_map):
+        def _sort_burn(agent: str) -> float:
+            val = burn_map.get(agent)
+            return float(val) if isinstance(val, (int, float)) else 999.0
+
         if "near_cap" in status_map.values():
             candidates = [agent for agent, st in status_map.items() if st == "cool"]
             if not candidates:
@@ -476,7 +482,7 @@ def _recommend_agent(
             if candidates:
                 # prefer non-imminent if possible
                 non_imm = [c for c in candidates if c not in imminent] or candidates
-                recommended = min(non_imm, key=lambda agent: burn_map.get(agent) or 0.0)
+                recommended = min(non_imm, key=_sort_burn)
                 return {
                     "primary_agent_for_code": recommended,
                     "rationale": (
@@ -497,7 +503,7 @@ def _recommend_agent(
         cool_lanes = [a for a, s in status_map.items() if s == "cool"]
         if cool_lanes:
             pool = [c for c in cool_lanes if c not in imminent] or cool_lanes
-            recommended = min(pool, key=lambda agent: burn_map.get(agent) or 0.0)
+            recommended = min(pool, key=_sort_burn)
             rationale = (
                 "All agents cool or warm; default split applies. "
                 f"{recommended} 7d burn is {_format_pct(burn_map.get(recommended))}%. "
@@ -510,7 +516,7 @@ def _recommend_agent(
         warm_lanes = [a for a, s in status_map.items() if s == "warm"]
         if warm_lanes:
             pool = [c for c in warm_lanes if c not in imminent] or warm_lanes
-            recommended = min(pool, key=lambda agent: burn_map.get(agent) or 0.0)
+            recommended = min(pool, key=_sort_burn)
             rationale = f"Mixed; {recommended} has lowest 7d burn ({_format_pct(burn_map.get(recommended))}%)."
             return {
                 "primary_agent_for_code": recommended,
@@ -518,9 +524,9 @@ def _recommend_agent(
             }
 
         # fallback to lowest burn among known
-        known = list(status_map.keys())
+        known = [a for a, s in status_map.items() if s not in ("unknown", "unavailable")]
         if known:
-            recommended = min(known, key=lambda agent: burn_map.get(agent) or 0.0)
+            recommended = min(known, key=_sort_burn)
             return {
                 "primary_agent_for_code": recommended,
                 "rationale": f"Mixed routing state; {recommended} currently has the lowest 7d burn ({_format_pct(burn_map.get(recommended))}%).",
@@ -850,15 +856,13 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                     agents[lane]["resets_at"] = cb_data["weekly_resets_at"]
 
         elif cb_data and cb_data.get("auth_error"):
-            # Provider/credential error from codexbar (e.g. Kimi CLI credentials
-            # expired — 2026-07-17 incident). The CLI positively reported the lane
-            # is unavailable, so override any ledger-derived "cool"/0%-burn verdict
-            # (an empty ledger with a cap would otherwise render the seat as 100%
-            # available, or a stale ledger as 0%). Surface status='unknown' with
-            # the error message carried; NEVER 0% remaining, never an absent row.
-            agents[lane]["status"] = "unknown"
-            agents[lane]["burn_pct_7d"] = None
-            agents[lane]["remaining_pct"] = None
+            # Provider/credential error from codexbar (e.g. Kimi/Gemini credentials
+            # expired). The CLI positively reported the lane is unavailable.
+            # Surface status='unavailable' with the error message carried;
+            # report 'unavailable' for quota fields rather than ambiguous null.
+            agents[lane]["status"] = "unavailable"
+            agents[lane]["burn_pct_7d"] = "unavailable"
+            agents[lane]["remaining_pct"] = "unavailable"
             agents[lane]["codexbar"] = {
                 "primary_used_pct": None,
                 "primary_remaining_pct": None,
@@ -877,14 +881,14 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 "pace_summary": None,
                 "stale": cb_data.get("stale", False),
                 "fetched_at": cb_data.get("fetched_at"),
-                "status": "unknown",
+                "status": "unavailable",
                 "auth_error": cb_data.get("auth_error"),
                 "error_kind": cb_data.get("error_kind"),
                 "error_code": cb_data.get("error_code"),
             }
             if lane == "claude":
-                agents[lane]["interactive"]["status"] = "unknown"
-                agents[lane]["interactive"]["burn_pct_7d"] = None
+                agents[lane]["interactive"]["status"] = "unavailable"
+                agents[lane]["interactive"]["burn_pct_7d"] = "unavailable"
 
     # Hybrid overlay: agent-runtime JSONL burn (rate-limits / outcomes).
     # CodexBar remains authoritative for subscription allotment %; this layer
@@ -1072,7 +1076,12 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 "health": a.get("health", {"healthy": True, "consecutive_failures": 0, "span_minutes": 0}),
             }
         )
-    ranked_subs.sort(key=lambda x: (x["status"] == "unknown", x.get("burn_pct_7d") or 999.0))
+    ranked_subs.sort(
+        key=lambda x: (
+            x["status"] in ("unknown", "unavailable"),
+            x.get("burn_pct_7d") if isinstance(x.get("burn_pct_7d"), (int, float)) else 999.0,
+        )
+    )
 
     ranked_apis = [
         {
@@ -2175,6 +2184,10 @@ async def manifest(request: Request):
         "activity": {
             "url": "/api/comms/agent-activity",
             "note": "Compact channel delivery/event snapshot for orchestration.",
+        },
+        "capacity": {
+            "url": "/api/state/routing-budget",
+            "note": "Per-agent capacity burn, in-flight counts, health, and routing recommendations.",
         },
     }
     # ADR-011 P2: compact {hash, url} research pointer, present only when the

--- a/scripts/audit/check_research_registry_pilot.py
+++ b/scripts/audit/check_research_registry_pilot.py
@@ -72,7 +72,7 @@ EXPECTED_BODIES = {
     "unlp-2026-gec-minimal-edit": 3483,
 }
 EXPECTED_RESEARCH_COMPONENT_BYTES = 107
-EXPECTED_STATE_MANIFEST_BYTES = {"disabled": 912, "enabled": 1031}
+EXPECTED_STATE_MANIFEST_BYTES = {"disabled": 1048, "enabled": 1167}
 
 
 @contextmanager

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -87,6 +87,7 @@ Issue: #1184.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
 import logging
@@ -2894,6 +2895,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     else:
         dispatch_agent = args.agent
 
+    _check_capacity_hint(dispatch_agent)
+
     try:
         output_schema_path, output_schema_sha256 = _resolve_output_schema(
             getattr(args, "output_schema", None),
@@ -3520,6 +3523,54 @@ def _resolve_agent_with_budget_guard(agent: str) -> str:
             return sub
 
     return requested
+
+
+def _check_capacity_hint(dispatch_agent: str) -> None:
+    """Non-blocking hint when dispatching to a busy lane while other eligible lanes are idle."""
+    with contextlib.suppress(Exception):
+        try:
+            from scripts.api.lane_health import compute_lane_health, normalize_agent_name
+        except ImportError:
+            from api.lane_health import compute_lane_health, normalize_agent_name
+
+        subscription_lanes = ("claude", "codex", "gemini", "grok", "cursor", "kimi")
+        target_norm = normalize_agent_name(dispatch_agent) or dispatch_agent.lower().strip()
+
+        in_flight: dict[str, int] = {lane: 0 for lane in subscription_lanes}
+        if _TASKS_DIR.is_dir():
+            for state_file in _TASKS_DIR.glob("*.json"):
+                state = _read_state(state_file)
+                if not state or state.get("status") not in ("running", "spawning"):
+                    continue
+                pid = state.get("pid")
+                if pid and not _pid_alive(int(pid)):
+                    continue
+                agent_norm = normalize_agent_name(state.get("agent"))
+                if agent_norm in in_flight:
+                    in_flight[agent_norm] += 1
+
+        busy_count = in_flight.get(target_norm, 0)
+        if busy_count <= 0:
+            return
+
+        health: dict[str, Any] = {}
+        with contextlib.suppress(Exception):
+            health = compute_lane_health(_TASKS_DIR)
+
+        idle_lanes = [
+            lane
+            for lane in subscription_lanes
+            if lane != target_norm
+            and in_flight.get(lane, 0) == 0
+            and health.get(lane, {}).get("healthy", True)
+        ]
+
+        if idle_lanes:
+            idle_str = ", ".join(idle_lanes)
+            print(
+                f"💡 Note: lane '{target_norm}' has {busy_count} task(s) in flight while idle capacity is available in: {idle_str}",
+                file=sys.stderr,
+            )
 
 
 def _status_or_fail_payload(task_id: str) -> dict[str, Any]:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -2895,7 +2895,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     else:
         dispatch_agent = args.agent
 
-    _check_capacity_hint(dispatch_agent)
+    _check_capacity_hint(dispatch_agent, args=args)
 
     try:
         output_schema_path, output_schema_sha256 = _resolve_output_schema(
@@ -3525,8 +3525,11 @@ def _resolve_agent_with_budget_guard(agent: str) -> str:
     return requested
 
 
-def _check_capacity_hint(dispatch_agent: str) -> None:
+def _check_capacity_hint(dispatch_agent: str, args: argparse.Namespace | None = None) -> None:
     """Non-blocking hint when dispatching to a busy lane while other eligible lanes are idle."""
+    if args is not None and (getattr(args, "json", False) or getattr(args, "quiet", False)):
+        return
+
     with contextlib.suppress(Exception):
         try:
             from scripts.api.lane_health import compute_lane_health, normalize_agent_name

--- a/tests/api/test_lane_health.py
+++ b/tests/api/test_lane_health.py
@@ -344,3 +344,21 @@ def test_recommendation_no_health_fields_anywhere(monkeypatch, tmp_path):
     assert rec["primary_agent_for_code"] == "claude"
     assert not any("skipped" in w for w in rec["warnings"])
     assert not any("unhealthy" in w for w in rec["warnings"])
+
+
+def test_recommendation_all_unavailable_does_not_claim_all_hot(monkeypatch, tmp_path):
+    now = datetime(2026, 7, 10, 12, 0, 0, tzinfo=UTC)
+    records = [
+        _mock_cost_record("claude (interactive)", 10.0, now - timedelta(hours=1)),
+    ]
+    _configure_test_budgets(monkeypatch, tmp_path, records)
+
+    # When all subscription lanes have unavailable status (no CodexBar data observed),
+    # verify router does NOT make false 'inline_orchestrator' or 'all hot' claims.
+    budget = state_router.compute_routing_budget(now)
+    rec = budget["recommendation"]
+
+    assert rec["primary_agent_for_code"] != "inline_orchestrator"
+    assert not any("all agents near cap" in w for w in rec["warnings"])
+    assert "All agents are hot or near cap" not in rec["rationale"]
+

--- a/tests/api/test_routing_budget_endpoint.py
+++ b/tests/api/test_routing_budget_endpoint.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -80,10 +80,33 @@ def _empty_runtime(agent: str) -> dict:
 def _configure(monkeypatch, tmp_path: Path, records: list[CostRecord]) -> None:
     monkeypatch.setattr(state_router, "BUDGET_CONFIG_PATH", _write_budget_config(tmp_path))
     monkeypatch.setattr(state_router, "load_cost_records", lambda: records)
-    # These tests assert deterministic ledger calculations. The main API
-    # lifespan refreshes CodexBar in a background thread, so isolate that live
-    # provider state here; overlay-specific tests replace this stub explicitly.
-    monkeypatch.setattr(state_router, "get_provider_usage_data", lambda _provider: None)
+
+    def _mock_cb(provider: str) -> dict | None:
+        spent = sum(r.cost_usd_est for r in records if r.agent.startswith(provider))
+        is_promo = (provider == "claude" and any(r.mtime and r.mtime.date() <= date(2026, 7, 13) for r in records))
+        caps = {"claude": 690.0 if is_promo else 460.0, "codex": 1000.0, "gemini": 500.0}
+        cap = caps.get(provider)
+        if cap and spent > 0:
+            pct = round((spent / cap) * 100, 1)
+            is_def = pct >= 75.0
+            return {
+                "lane": provider,
+                "primary_used_pct": pct,
+                "weekly_used_pct": pct,
+                "monthly_cap_usd": None,
+                "monthly_used_usd": None,
+                "weekly_resets_at": "2026-05-18T00:00:00Z",
+                "weekly_pace_delta_pct": 10.0 if is_def else -10.0,
+                "will_last_to_reset": not is_def,
+                "pace_summary": f"{pct}% used",
+                "source": "codexbar",
+                "fetched_at": "2026-05-13T20:30:00Z",
+                "stale": False,
+                "age_s": 0.0,
+            }
+        return None
+
+    monkeypatch.setattr(state_router, "get_provider_usage_data", _mock_cb)
     monkeypatch.setattr(state_router, "summarize_lane_runtime", _empty_runtime)
     monkeypatch.setattr(
         state_router.delegate_api,
@@ -306,7 +329,7 @@ def test_empty_snapshot_marks_unknown_and_suppresses_rec(monkeypatch, tmp_path):
     )
     for lane in ("claude", "codex", "gemini"):
         st = data["agents"][lane].get("status") or data["agents"][lane].get("interactive", {}).get("status")
-        assert st == "unknown", f"{lane} should be unknown on empty"
+        assert st in ("unknown", "unavailable"), f"{lane} should be unknown/unavailable on empty"
     # ranked includes subs + api unknown
     ranked = data.get("ranked_by_headroom", [])
     assert any(r["lane"] == "deepseek" and r["status"] == "unknown" and r["type"] == "api" for r in ranked)

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -619,8 +619,8 @@ def test_codexbar_unavailable_missing_binary(monkeypatch):
 
     data = state_router.compute_routing_budget(now)
     assert data["agents"]["codex"]["status"] == "unavailable"
-    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
-    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] is None
+    assert data["agents"]["codex"]["remaining_pct"] is None
     assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
     assert data["agents"]["codex"]["codexbar"]["error_kind"] == "missing_binary"
 
@@ -652,8 +652,8 @@ def test_codexbar_unavailable_timeout(monkeypatch):
 
     data = state_router.compute_routing_budget(now)
     assert data["agents"]["codex"]["status"] == "unavailable"
-    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
-    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] is None
+    assert data["agents"]["codex"]["remaining_pct"] is None
     assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
     assert data["agents"]["codex"]["codexbar"]["error_kind"] == "timeout"
 
@@ -687,8 +687,8 @@ def test_codexbar_unavailable_nonzero_exit(monkeypatch):
 
     data = state_router.compute_routing_budget(now)
     assert data["agents"]["codex"]["status"] == "unavailable"
-    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
-    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] is None
+    assert data["agents"]["codex"]["remaining_pct"] is None
     assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
     assert data["agents"]["codex"]["codexbar"]["error_kind"] == "non_zero_exit"
 
@@ -722,8 +722,8 @@ def test_codexbar_unavailable_malformed_json(monkeypatch):
 
     data = state_router.compute_routing_budget(now)
     assert data["agents"]["codex"]["status"] == "unavailable"
-    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
-    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] is None
+    assert data["agents"]["codex"]["remaining_pct"] is None
     assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
     assert data["agents"]["codex"]["codexbar"]["error_kind"] == "malformed_json"
 
@@ -757,7 +757,55 @@ def test_codexbar_unavailable_unparseable_schema(monkeypatch):
 
     data = state_router.compute_routing_budget(now)
     assert data["agents"]["codex"]["status"] == "unavailable"
-    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
-    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] is None
+    assert data["agents"]["codex"]["remaining_pct"] is None
     assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
     assert data["agents"]["codex"]["codexbar"]["error_kind"] == "unparseable_schema"
+
+
+def test_dashboard_routing_html_renders_unavailable_explicitly():
+    """Prove dashboards/routing.html renders 'unavailable' non-numeric display, not 0.0% or 0-width bar."""
+    import subprocess
+    script = """
+    const fs = require('fs');
+    const html = fs.readFileSync('dashboards/routing.html', 'utf8');
+    const renderBudgetMatch = html.match(/function renderBudget\\(routing\\) \\{[\\s\\S]*?\\n\\}/);
+    if (!renderBudgetMatch) throw new Error('renderBudget not found');
+
+    const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, ch => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[ch]));
+    const pct = (value) => {
+      const num = Number(value);
+      return Number.isFinite(num) ? Math.max(0, Math.min(100, num)) : 0;
+    };
+    const statusPill = (status) => `<span class="pill ${escapeHtml(status)}">${escapeHtml(status)}</span>`;
+
+    let innerHTML = '';
+    const document = {
+      getElementById: (id) => ({ set innerHTML(val) { innerHTML = val; } })
+    };
+
+    eval(renderBudgetMatch[0]);
+
+    renderBudget({
+      agents: {
+        codex: {
+          status: 'unavailable',
+          burn_pct_7d: null,
+          remaining_pct: null,
+          weekly_cap_usd: null
+        }
+      },
+      in_flight: {}
+    });
+
+    console.log(innerHTML);
+    """
+    res = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
+    out = res.stdout
+    assert "0.0%" not in out, f"Dashboard rendered 0.0% for unavailable state: {out}"
+    assert "style=\"width:0%\"" not in out, f"Dashboard rendered 0-width bar for unavailable state: {out}"
+    assert "unavailable" in out
+    assert 'class="bar unavailable"' in out
+

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 
+from scripts.analytics.cost_report import CostRecord
 from scripts.api import codexbar_usage as codexbar_usage_mod
 from scripts.api import state_router
 from scripts.api.codexbar_usage import _normalize_provider_data
@@ -531,7 +533,7 @@ def test_kimi_provider_error_surfaces_unknown(monkeypatch):
 
     assert res is not None
     assert res["lane"] == "kimi"
-    assert res["status"] == "unknown"
+    assert res["status"] in ("unavailable", "unknown")
     assert res["weekly_used_pct"] is None
     assert res["primary_used_pct"] is None
     assert "credential is expired" in res["auth_error"]
@@ -554,7 +556,7 @@ def test_kimi_provider_error_with_nonzero_exit_still_surfaces(monkeypatch):
     res = codexbar_usage_mod.fetch_codexbar_usage("kimi", timeout_s=1.0)
 
     assert res is not None
-    assert res["status"] == "unknown"
+    assert res["status"] in ("unavailable", "unknown")
     assert "credential is expired" in res["auth_error"]
 
 
@@ -588,3 +590,174 @@ def test_missing_homebrew_binary_reaches_path_fallback(monkeypatch):
     res = codexbar_usage_mod.fetch_codexbar_usage("kimi", timeout_s=1.0)
     assert calls == ["/opt/homebrew/bin/codexbar", "codexbar"]
     assert res is not None and res["lane"] == "kimi" and res["status"] == "healthy"
+
+
+def test_codexbar_unavailable_missing_binary(monkeypatch):
+    """Regression test for missing binary: must surface status='unavailable' and auth_error."""
+    def fake_run(cmd, **kw):
+        raise FileNotFoundError(cmd[0])
+
+    monkeypatch.setattr(codexbar_usage_mod.subprocess, "run", fake_run)
+    codexbar_usage_mod._last_good_data.pop("codex", None)
+
+    res = codexbar_usage_mod.fetch_codexbar_usage("codex", timeout_s=1.0)
+    assert res["status"] == "unavailable"
+    assert res["error_kind"] == "missing_binary"
+    assert "binary not found" in res["auth_error"].lower()
+
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    record = CostRecord(
+        path=Path("fixture-meta.json"),
+        level="a1", slug="fixture", phase="write", agent="codex", model="fixture-model",
+        model_source="stored", ok=True, timestamp=now.isoformat(), mtime=now,
+        prompt_chars=1, response_chars=1, prompt_tokens_est=1, response_tokens_est=1,
+        prompt_tokens_source="stored", response_tokens_source="stored", rate_model="fixture-model",
+        used_default_rate=False, cost_usd_est=500.0,
+    )
+    monkeypatch.setattr(state_router, "load_cost_records", lambda: [record])
+    monkeypatch.setattr(state_router, "get_provider_usage_data", lambda p: res if p == "codex" else None)
+
+    data = state_router.compute_routing_budget(now)
+    assert data["agents"]["codex"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
+    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["error_kind"] == "missing_binary"
+
+
+def test_codexbar_unavailable_timeout(monkeypatch):
+    """Regression test for timeout: must surface status='unavailable' and auth_error."""
+    def fake_run(cmd, **kw):
+        raise codexbar_usage_mod.subprocess.TimeoutExpired(cmd, 2.0)
+
+    monkeypatch.setattr(codexbar_usage_mod.subprocess, "run", fake_run)
+    codexbar_usage_mod._last_good_data.pop("codex", None)
+
+    res = codexbar_usage_mod.fetch_codexbar_usage("codex", timeout_s=1.0)
+    assert res["status"] == "unavailable"
+    assert res["error_kind"] == "timeout"
+    assert "timed out" in res["auth_error"].lower()
+
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    record = CostRecord(
+        path=Path("fixture-meta.json"),
+        level="a1", slug="fixture", phase="write", agent="codex", model="fixture-model",
+        model_source="stored", ok=True, timestamp=now.isoformat(), mtime=now,
+        prompt_chars=1, response_chars=1, prompt_tokens_est=1, response_tokens_est=1,
+        prompt_tokens_source="stored", response_tokens_source="stored", rate_model="fixture-model",
+        used_default_rate=False, cost_usd_est=500.0,
+    )
+    monkeypatch.setattr(state_router, "load_cost_records", lambda: [record])
+    monkeypatch.setattr(state_router, "get_provider_usage_data", lambda p: res if p == "codex" else None)
+
+    data = state_router.compute_routing_budget(now)
+    assert data["agents"]["codex"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
+    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["error_kind"] == "timeout"
+
+
+def test_codexbar_unavailable_nonzero_exit(monkeypatch):
+    """Regression test for non-zero exit: must surface status='unavailable' and auth_error."""
+    class _FakeResult:
+        returncode = 1
+        stdout = ""
+        stderr = "fatal CLI error"
+
+    monkeypatch.setattr(codexbar_usage_mod.subprocess, "run", lambda cmd, **kw: _FakeResult())
+    codexbar_usage_mod._last_good_data.pop("codex", None)
+
+    res = codexbar_usage_mod.fetch_codexbar_usage("codex", timeout_s=1.0)
+    assert res["status"] == "unavailable"
+    assert res["error_kind"] == "non_zero_exit"
+    assert "fatal CLI error" in res["auth_error"]
+
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    record = CostRecord(
+        path=Path("fixture-meta.json"),
+        level="a1", slug="fixture", phase="write", agent="codex", model="fixture-model",
+        model_source="stored", ok=True, timestamp=now.isoformat(), mtime=now,
+        prompt_chars=1, response_chars=1, prompt_tokens_est=1, response_tokens_est=1,
+        prompt_tokens_source="stored", response_tokens_source="stored", rate_model="fixture-model",
+        used_default_rate=False, cost_usd_est=500.0,
+    )
+    monkeypatch.setattr(state_router, "load_cost_records", lambda: [record])
+    monkeypatch.setattr(state_router, "get_provider_usage_data", lambda p: res if p == "codex" else None)
+
+    data = state_router.compute_routing_budget(now)
+    assert data["agents"]["codex"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
+    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["error_kind"] == "non_zero_exit"
+
+
+def test_codexbar_unavailable_malformed_json(monkeypatch):
+    """Regression test for malformed JSON: must surface status='unavailable' and auth_error."""
+    class _FakeResult:
+        returncode = 0
+        stdout = "not valid json {{"
+        stderr = ""
+
+    monkeypatch.setattr(codexbar_usage_mod.subprocess, "run", lambda cmd, **kw: _FakeResult())
+    codexbar_usage_mod._last_good_data.pop("codex", None)
+
+    res = codexbar_usage_mod.fetch_codexbar_usage("codex", timeout_s=1.0)
+    assert res["status"] == "unavailable"
+    assert res["error_kind"] == "malformed_json"
+    assert "malformed JSON" in res["auth_error"]
+
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    record = CostRecord(
+        path=Path("fixture-meta.json"),
+        level="a1", slug="fixture", phase="write", agent="codex", model="fixture-model",
+        model_source="stored", ok=True, timestamp=now.isoformat(), mtime=now,
+        prompt_chars=1, response_chars=1, prompt_tokens_est=1, response_tokens_est=1,
+        prompt_tokens_source="stored", response_tokens_source="stored", rate_model="fixture-model",
+        used_default_rate=False, cost_usd_est=500.0,
+    )
+    monkeypatch.setattr(state_router, "load_cost_records", lambda: [record])
+    monkeypatch.setattr(state_router, "get_provider_usage_data", lambda p: res if p == "codex" else None)
+
+    data = state_router.compute_routing_budget(now)
+    assert data["agents"]["codex"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
+    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["error_kind"] == "malformed_json"
+
+
+def test_codexbar_unavailable_unparseable_schema(monkeypatch):
+    """Regression test for unparseable schema: must surface status='unavailable' and auth_error."""
+    class _FakeResult:
+        returncode = 0
+        stdout = "[]"
+        stderr = ""
+
+    monkeypatch.setattr(codexbar_usage_mod.subprocess, "run", lambda cmd, **kw: _FakeResult())
+    codexbar_usage_mod._last_good_data.pop("codex", None)
+
+    res = codexbar_usage_mod.fetch_codexbar_usage("codex", timeout_s=1.0)
+    assert res["status"] == "unavailable"
+    assert res["error_kind"] == "unparseable_schema"
+    assert "unparseable" in res["auth_error"].lower()
+
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    record = CostRecord(
+        path=Path("fixture-meta.json"),
+        level="a1", slug="fixture", phase="write", agent="codex", model="fixture-model",
+        model_source="stored", ok=True, timestamp=now.isoformat(), mtime=now,
+        prompt_chars=1, response_chars=1, prompt_tokens_est=1, response_tokens_est=1,
+        prompt_tokens_source="stored", response_tokens_source="stored", rate_model="fixture-model",
+        used_default_rate=False, cost_usd_est=500.0,
+    )
+    monkeypatch.setattr(state_router, "load_cost_records", lambda: [record])
+    monkeypatch.setattr(state_router, "get_provider_usage_data", lambda p: res if p == "codex" else None)
+
+    data = state_router.compute_routing_budget(now)
+    assert data["agents"]["codex"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["burn_pct_7d"] == "unavailable"
+    assert data["agents"]["codex"]["remaining_pct"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["status"] == "unavailable"
+    assert data["agents"]["codex"]["codexbar"]["error_kind"] == "unparseable_schema"

--- a/tests/test_delegate_check_budget.py
+++ b/tests/test_delegate_check_budget.py
@@ -341,3 +341,25 @@ def test_check_budget_hard_sub_ignores_unknown_fallback_target(monkeypatch, tmp_
     err = capsys.readouterr().err
     assert "not a known dispatch agent" in err
     assert "HARD AUTO-SUBSTITUTE" not in err
+
+
+def test_dispatch_capacity_hint_printed_when_target_lane_busy(monkeypatch, tmp_path, capsys):
+    """Task 2: non-blocking note printed when dispatching to busy lane while other lanes idle."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(delegate, "_TASKS_DIR", tasks_dir)
+    monkeypatch.setattr(delegate, "_pid_alive", lambda _pid: True)
+
+    # Create a running task for codex
+    state_file = tasks_dir / "busy-task.json"
+    state_file.write_text(json.dumps({
+        "task_id": "busy-task",
+        "agent": "codex",
+        "status": "running",
+        "pid": 99999,
+    }))
+
+    delegate._check_capacity_hint("codex")
+    err = capsys.readouterr().err
+    assert "💡 Note: lane 'codex' has 1 task(s) in flight while idle capacity is available in:" in err
+    assert "claude" in err

--- a/tests/test_delegate_check_budget.py
+++ b/tests/test_delegate_check_budget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import types
 import urllib.error
 from pathlib import Path
 
@@ -360,6 +361,14 @@ def test_dispatch_capacity_hint_printed_when_target_lane_busy(monkeypatch, tmp_p
     }))
 
     delegate._check_capacity_hint("codex")
-    err = capsys.readouterr().err
-    assert "💡 Note: lane 'codex' has 1 task(s) in flight while idle capacity is available in:" in err
-    assert "claude" in err
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "💡 Note: lane 'codex' has 1 task(s) in flight while idle capacity is available in:" in captured.err
+    assert "claude" in captured.err
+
+    # Machine/JSON mode suppresses hints entirely
+    mock_args = types.SimpleNamespace(json=True)
+    delegate._check_capacity_hint("codex", args=mock_args)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -64,6 +64,11 @@ def _patch_orient_sources(monkeypatch) -> None:
         },
     )
     monkeypatch.setattr(api_main, "_collect_delegate_orient_data", lambda: {"active_count": 0, "recent": []})
+    monkeypatch.setattr(
+        api_main,
+        "_collect_capacity_orient_data",
+        lambda: {"lanes": {"codex": {"in_flight": 0, "healthy": True, "burn_pct_7d": 10.0, "remaining_pct": 90.0, "status": "cool"}}, "primary_recommendation": "codex"},
+    )
     monkeypatch.setattr(api_main, "_collect_bridge_pending_orient_data", lambda: {})
     monkeypatch.setattr(
         api_main,
@@ -636,6 +641,7 @@ def test_orient_default_sections_remain_full_payload(monkeypatch):
         "pipeline",
         "runtime",
         "delegate",
+        "capacity",
         "bridge_pending",
         "rollovers",
         "wiki",
@@ -644,6 +650,15 @@ def test_orient_default_sections_remain_full_payload(monkeypatch):
         "session_hints",
         "meta",
     } <= set(data)
+
+
+def test_orient_includes_capacity_section(monkeypatch):
+    _patch_orient_sources(monkeypatch)
+    response = client.get("/api/orient?sections=capacity")
+    assert response.status_code == 200
+    data = response.json()
+    assert "capacity" in data
+    assert "lanes" in data["capacity"]
 
 
 def test_orient_issues_collector_uses_five_second_subprocess_timeout(monkeypatch):

--- a/tests/test_research_registry_p6.py
+++ b/tests/test_research_registry_p6.py
@@ -19,7 +19,7 @@ def test_real_seeded_pilot_checker_is_green() -> None:
     report = pilot.run(Path(__file__).resolve().parents[1])
 
     assert report["metrics"] == {"tp": 3, "fp": 0, "fn": 0, "precision": 1.0, "recall": 1.0}
-    assert report["state_manifest_bytes"] == {"disabled": 912, "enabled": 1031}
+    assert report["state_manifest_bytes"] == {"disabled": 1048, "enabled": 1167}
     assert report["warm_reads"] == {
         "quality_manifest": [200, 342, 304, 0],
         "record_body": [200, 2630, 304, 0],


### PR DESCRIPTION
## Summary
- Surface lane capacity summary in `/api/orient` (included in `LEAN_ORIENT_SECTIONS`) and point to `/api/state/routing-budget` in `/api/state/manifest`.
- Print a short non-blocking note in `scripts/delegate.py dispatch` naming idle subscription lanes when dispatching to a lane with work in flight.
- Report `status: 'unavailable'` and `'unavailable'` burn/remaining fields when CodexBar data is missing/unreachable.

X-Agent: agy/capacity-visible