### PR TITLE
fix(deploy): unblock deploy on source deletions + make predeploy failure visible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ temp/
 *.yml.orig
 .venv/
 .agent/
+# Local state owned by scripts/deploy_prompts.sh. It records which shared files
+# deploy placed in .agent/ so only those paths can be reaped on a later deploy.
+.deploy-state/
 # deploy target (rsync'd from agents_extensions/shared/skills); like .claude/.codex/.agent
 .agents/
 # Temporary/sample images in docs (textbook screenshots, vision test outputs)

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -252,6 +252,20 @@ if [ -f "$MEMORY_FILE" ]; then
   fi
 fi
 
+# 7a. Report the LAUNCH-TIME predeploy verdict. The launcher prints a failure
+# banner, but the agent CLI clears the terminal on start, so that banner never
+# reaches the operator or the session. scripts/lib/deploy_extensions.sh leaves
+# a durable breadcrumb; surface it here or the session boots against a stale
+# .claude/ believing it is current (incident 2026-07-26).
+PREDEPLOY_STATUS="$PROJECT_DIR/.agent/last-deploy-status"
+if [ -f "$PREDEPLOY_STATUS" ] && head -1 "$PREDEPLOY_STATUS" 2>/dev/null | grep -q '^FAILED'; then
+  PD_EXIT=$(grep '^exit_code=' "$PREDEPLOY_STATUS" 2>/dev/null | cut -d= -f2)
+  PD_SCRIPT=$(grep '^script=' "$PREDEPLOY_STATUS" 2>/dev/null | cut -d= -f2)
+  PD_REASON=$(grep -m1 -E '^(❌|  ⚠️)' "$PROJECT_DIR/.agent/last-deploy-failure.log" 2>/dev/null | sed 's/^[[:space:]]*//')
+  [ -z "$PD_REASON" ] && PD_REASON="see .agent/last-deploy-failure.log"
+  ISSUES+=("PREDEPLOY FAILED at launch (npm run ${PD_SCRIPT:-agents:deploy}, exit ${PD_EXIT:-?}) — deploy targets are STALE, this session may be running outdated hooks/skills/settings. Reason: $PD_REASON")
+fi
+
 # 7. Check agents_extensions/shared/ → .claude/ sync drift
 if [ -d "$PROJECT_DIR/agents_extensions/shared" ] && [ -d "$PROJECT_DIR/.claude" ]; then
   DIFF_EXCLUDES=(".DS_Store")

--- a/scripts/audit/test_deploy_extensions.sh
+++ b/scripts/audit/test_deploy_extensions.sh
@@ -60,6 +60,33 @@ contains "$out" "rsync: permission denied somewhere" "failure surfaces real depl
 contains "$out" "may be STALE" "failure warns about stale targets"
 not_contains "$out" "Agent extensions deployed" "failure never claims success"
 
+# --- failure leaves a DURABLE breadcrumb for session-setup.sh ---
+# The banner alone is not enough: the launcher hands the terminal to the agent
+# CLI, which clears it, so the session boots blind against a stale target.
+STATUS_FILE="$WORK_DIR/project/.agent/last-deploy-status"
+FAILURE_LOG="$WORK_DIR/project/.agent/last-deploy-failure.log"
+[[ -f "$STATUS_FILE" ]] || fail "failure did not persist $STATUS_FILE"
+head -1 "$STATUS_FILE" | grep -q '^FAILED' \
+  || fail "status file does not start with FAILED"
+grep -q '^exit_code=3' "$STATUS_FILE" || fail "status file lost the exit code"
+grep -q '^script=agents:deploy' "$STATUS_FILE" || fail "status file lost the script name"
+[[ -f "$FAILURE_LOG" ]] || fail "failure did not persist $FAILURE_LOG"
+grep -q 'rsync: permission denied somewhere' "$FAILURE_LOG" \
+  || fail "persisted log lost the real deploy output"
+
+# --- a later SUCCESS must clear the breadcrumb (no stale alarm next launch) ---
+out="$(FAKE_NPM_EXIT=0 deploy_agent_extensions "$WORK_DIR/project" agents:deploy)" \
+  || fail "post-failure success case: expected exit 0, got $?"
+[[ ! -f "$STATUS_FILE" ]] || fail "success did not clear $STATUS_FILE"
+[[ ! -f "$FAILURE_LOG" ]] || fail "success did not clear $FAILURE_LOG"
+
+# --- session-setup.sh actually reads the breadcrumb back (wiring guard) ---
+SESSION_SETUP="$REPO_ROOT/agents_extensions/shared/hooks/session-setup.sh"
+grep -q 'last-deploy-status' "$SESSION_SETUP" \
+  || fail "session-setup.sh no longer reads the predeploy status breadcrumb"
+grep -q 'PREDEPLOY FAILED' "$SESSION_SETUP" \
+  || fail "session-setup.sh no longer reports a failed predeploy"
+
 # --- missing npm script: explicit skip warning, exit 0 ---
 mkdir -p "$WORK_DIR/bare"
 printf '{"scripts": {}}\n' > "$WORK_DIR/bare/package.json"

--- a/scripts/deploy/agent_directory.py
+++ b/scripts/deploy/agent_directory.py
@@ -1,0 +1,24 @@
+"""Shared descriptor-bound access to the mutable ``.agent`` directory."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+
+
+def open_agent_directory(agent_root: str) -> int:
+    """Create (when absent) and open ``agent_root`` without following links.
+
+    The final open is the security boundary. If another process creates or swaps
+    the name after ``mkdir``, ``O_NOFOLLOW`` rejects a symlink and the returned
+    descriptor remains bound to the opened directory.
+    """
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        return os.open(agent_root, flags)
+    except FileNotFoundError:
+        with contextlib.suppress(FileExistsError):
+            os.mkdir(agent_root)
+        return os.open(agent_root, flags)

--- a/scripts/deploy/reap_agent_mirrors.py
+++ b/scripts/deploy/reap_agent_mirrors.py
@@ -119,13 +119,19 @@ def _walk_to_parent(agent_root: str, parts: list[str]) -> tuple[int, list[int]]:
         try:
             fd = _open_dir_nofollow(None, agent_root)
         except OSError as exc:
-            raise ComponentRefused(agent_root, _classify_component(None, agent_root)) from exc
+            reason = _classify_component(None, agent_root)
+            if reason in {"symlinked component", "non-directory component"}:
+                raise ComponentRefused(agent_root, reason) from exc
+            raise
         opened.append(fd)
         for component in parts[:-1]:
             try:
                 fd = _open_dir_nofollow(fd, component)
             except OSError as exc:
-                raise ComponentRefused(component, _classify_component(fd, component)) from exc
+                reason = _classify_component(fd, component)
+                if reason in {"symlinked component", "non-directory component"}:
+                    raise ComponentRefused(component, reason) from exc
+                raise
             opened.append(fd)
     except BaseException:
         # Review finding P2: this list is LOCAL. When we raise, the caller's own
@@ -141,16 +147,6 @@ def _close_all(fds: list[int]) -> None:
     for fd in fds:
         with contextlib.suppress(OSError):
             os.close(fd)
-
-
-def _describe(exc: OSError, relative: str) -> str:
-    if exc.errno == errno.ELOOP:
-        return f"{REDACTED_UNSAFE} '{relative}': symlinked component refused"
-    if exc.errno == errno.ENOTDIR:
-        return f"{REDACTED_UNSAFE} '{relative}': component is not a directory"
-    if exc.errno == errno.ENOENT:
-        return f"  .agent: nothing to remove for '{relative}'"
-    return f"{REDACTED_UNSAFE} '{relative}': {exc.strerror}"
 
 
 def reap_entry(agent_root: str, kind: str, relative: str) -> tuple[bool, str]:
@@ -170,8 +166,8 @@ def reap_entry(agent_root: str, kind: str, relative: str) -> tuple[bool, str]:
         # now closes its own fds before propagating. Closing a stale number here
         # would risk closing an unrelated fd that reused it.
         return False, f"  .agent: {unsafe}: {exc.reason} '{exc.component}'"
-    except OSError as exc:
-        return False, f"  .agent: {_describe(exc, relative)}"
+    except FileNotFoundError:
+        return False, f"  .agent: nothing to remove for '{relative}'"
 
     try:
         try:
@@ -206,8 +202,11 @@ def reap_entry(agent_root: str, kind: str, relative: str) -> tuple[bool, str]:
                     return False, ""
                 raise
         return True, f"  .agent: removed retired deploy artifact '{relative}'"
-    except OSError as exc:
-        return False, f"  .agent: {_describe(exc, relative)}"
+    except OSError:
+        # Refusals are returned explicitly above.  Any other filesystem error
+        # (for example EIO from unlink) is operational: propagate it so main()
+        # reports the affected entry and returns a non-zero status.
+        raise
     finally:
         _close_all(opened)
 
@@ -285,6 +284,10 @@ def main(argv: list[str]) -> int:
         nonlocal refused, errored
         try:
             removed, message = reap_entry(agent_root, kind, relative)
+        except OSError as exc:
+            errored += 1
+            print(f"  .agent: operational error reaping '{relative}': {exc}", file=sys.stderr)
+            return
         except Exception as exc:  # broad on purpose: one bad entry must not abort the reap
             errored += 1
             print(f"  .agent: internal error reaping '{relative}': {exc}", file=sys.stderr)

--- a/scripts/deploy/reap_agent_mirrors.py
+++ b/scripts/deploy/reap_agent_mirrors.py
@@ -116,16 +116,24 @@ def _walk_to_parent(agent_root: str, parts: list[str]) -> tuple[int, list[int]]:
     """
     opened: list[int] = []
     try:
-        fd = _open_dir_nofollow(None, agent_root)
-    except OSError as exc:
-        raise ComponentRefused(agent_root, _classify_component(None, agent_root)) from exc
-    opened.append(fd)
-    for component in parts[:-1]:
         try:
-            fd = _open_dir_nofollow(fd, component)
+            fd = _open_dir_nofollow(None, agent_root)
         except OSError as exc:
-            raise ComponentRefused(component, _classify_component(fd, component)) from exc
+            raise ComponentRefused(agent_root, _classify_component(None, agent_root)) from exc
         opened.append(fd)
+        for component in parts[:-1]:
+            try:
+                fd = _open_dir_nofollow(fd, component)
+            except OSError as exc:
+                raise ComponentRefused(component, _classify_component(fd, component)) from exc
+            opened.append(fd)
+    except BaseException:
+        # Review finding P2: this list is LOCAL. When we raise, the caller's own
+        # `opened` was never assigned, so it closed nothing and every refused entry
+        # leaked one directory fd — a corrupt manifest could exhaust the table and
+        # deny the reap entirely. Close our own fds before propagating.
+        _close_all(opened)
+        raise
     return fd, opened
 
 
@@ -157,10 +165,12 @@ def reap_entry(agent_root: str, kind: str, relative: str) -> tuple[bool, str]:
     try:
         parent_fd, opened = _walk_to_parent(agent_root, parts)
     except ComponentRefused as exc:
-        _close_all(opened)
+        # No _close_all here: on failure `opened` was never assigned, so it is still
+        # empty and closing it did nothing — that WAS the leak (P2). _walk_to_parent
+        # now closes its own fds before propagating. Closing a stale number here
+        # would risk closing an unrelated fd that reused it.
         return False, f"  .agent: {unsafe}: {exc.reason} '{exc.component}'"
     except OSError as exc:
-        _close_all(opened)
         return False, f"  .agent: {_describe(exc, relative)}"
 
     try:
@@ -209,20 +219,33 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--source-root", required=True)
     args = parser.parse_args(argv)
 
+    agent_root = args.agent_root
+    # Validate the mirror root FIRST — before the missing-manifest early return.
+    # Review finding P1: with the check after that return, a first run (no manifest
+    # yet) exited 0 having never looked at the root at all, and deploy_prompts.sh
+    # then runs a path-based `rsync` into `.agent/`. A symlinked root therefore
+    # redirected deploy WRITES outside the repository. Validating here means the
+    # helper refuses loudly on every path through it, first run included.
+    # Distinguish ABSENT from REDIRECTED. On a first deploy `.agent` does not exist
+    # yet and rsync creates it — refusing there breaks every clean install (caught by
+    # the existing suite when I first wrote this check as `not isdir`). What must be
+    # refused is a root that EXISTS but is not a real directory, which is the actual
+    # redirect.
+    if os.path.lexists(agent_root):
+        if os.path.islink(agent_root) or not os.path.isdir(agent_root):
+            print(
+                f"  .agent: refusing manifest reap: '{agent_root}' is not a real directory",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        # Nothing deployed yet, so nothing to reap. rsync will create a real directory.
+        return 0
+
     manifest = Path(args.manifest)
     if not manifest.is_file():
         print("  .agent: no deploy manifest yet; preserving all existing paths during migration")
         return 0
-
-    agent_root = args.agent_root
-    # Refuse outright if the mirror root is not a real directory: a symlinked
-    # .agent would make every subsequent operation land somewhere else.
-    if os.path.islink(agent_root) or not os.path.isdir(agent_root):
-        print(
-            f"  .agent: refusing manifest reap: '{agent_root}' is not a real directory",
-            file=sys.stderr,
-        )
-        return 1
 
     source_root = Path(args.source_root)
     files: list[tuple[str, str]] = []
@@ -247,18 +270,39 @@ def main(argv: list[str]) -> int:
             continue
         (dirs if kind == "d" else files).append((kind, relative))
 
-    failed = False
-    for kind, relative in files:
-        removed, message = reap_entry(agent_root, kind, relative)
+    # Review finding P2: `failed` was declared and never assigned — a flag that
+    # cannot fire, so the exit code claimed success unconditionally. Deliberate
+    # semantics now, stated rather than implied:
+    #   REFUSING an entry is the SAFE outcome (we preserved a file we were unsure
+    #   about) and must NOT fail deploy — a symlink an agent legitimately left in
+    #   .agent/ would otherwise block every deploy.
+    #   An UNEXPECTED internal error is different: it means the reap did not do what
+    #   it was asked, and a silently-skipped reap is a false-green.
+    refused = 0
+    errored = 0
+
+    def _run(kind: str, relative: str) -> None:
+        nonlocal refused, errored
+        try:
+            removed, message = reap_entry(agent_root, kind, relative)
+        except Exception as exc:  # broad on purpose: one bad entry must not abort the reap
+            errored += 1
+            print(f"  .agent: internal error reaping '{relative}': {exc}", file=sys.stderr)
+            return
         if message:
             print(message, file=sys.stdout if removed else sys.stderr)
+        if not removed and message:
+            refused += 1
+
+    for kind, relative in files:
+        _run(kind, relative)
     # Deepest first, so a parent becomes empty only after its children are gone.
     for kind, relative in sorted(dirs, key=lambda item: item[1].count("/"), reverse=True):
-        removed, message = reap_entry(agent_root, kind, relative)
-        if message:
-            print(message, file=sys.stdout if removed else sys.stderr)
+        _run(kind, relative)
 
-    return 1 if failed else 0
+    if refused:
+        print(f"  .agent: {refused} manifest entry(ies) refused and preserved", file=sys.stderr)
+    return 1 if errored else 0
 
 
 if __name__ == "__main__":

--- a/scripts/deploy/reap_agent_mirrors.py
+++ b/scripts/deploy/reap_agent_mirrors.py
@@ -1,0 +1,265 @@
+"""Race-safe reaper for retired deploy artifacts under ``.agent/``.
+
+Deploy records what it wrote to ``.agent/`` in a manifest, and on the next run
+removes only entries that have since disappeared from the source tree. That much
+was already correct in shell. What shell could not express is doing it *safely*.
+
+The shell version validated a PATH and then deleted by that same PATH. Between
+those two steps the path can be redirected: a review reproduced a symlink swapped
+in after validation, and deploy then deleted a file OUTSIDE the repository
+(``TOCTOU_FILE_EXTERNAL_VICTIM=DELETED``, and the same for ``rmdir``). This is not
+a hypothetical race here — ``.agent/`` is written by agents, deploy runs while
+other agents are live, and deploy runs with the operator's full privileges.
+
+No amount of path validation closes a check-then-use race, so this module does not
+validate paths and then delete them. It walks the components with
+``O_NOFOLLOW | O_DIRECTORY``, so a symlinked component fails at *open* time, and
+then unlinks relative to that directory file descriptor. The entry removed is the
+one inside the directory actually opened, whatever happens to any path prefix
+afterwards.
+
+Kind semantics, matching the manifest format ``TYPE<TAB>PATH``:
+
+``f``
+    Remove a regular file. Refuses if the leaf is a symlink — deleting through it
+    would follow the link.
+``l``
+    Remove a symlink. Removes the LINK itself, never its target.
+``d``
+    Remove a directory, and only when already empty.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import errno
+import os
+import stat as stat_module
+import sys
+from pathlib import Path
+
+REDACTED_UNSAFE = "ignoring unsafe manifest entry"
+VALID_KINDS = frozenset({"d", "f", "l"})
+
+
+def path_is_lexically_safe(relative: str) -> bool:
+    """Reject absolute paths, traversal, and separator-bearing oddities.
+
+    This is the cheap first layer. It is NOT the security boundary — the
+    ``O_NOFOLLOW`` walk below is. Keeping it means a malformed manifest is
+    rejected with a clear message before we touch the filesystem at all.
+    """
+    if not relative or relative.startswith("/"):
+        return False
+    if "\n" in relative or "\t" in relative or "\0" in relative:
+        return False
+    parts = relative.split("/")
+    return not any(part in ("", ".", "..") for part in parts)
+
+
+def _open_dir_nofollow(parent_fd: int | None, name: str) -> int:
+    """Open a directory component, refusing to traverse a symlink.
+
+    ``O_NOFOLLOW`` makes this raise ELOOP when *name* is a symlink, which is
+    exactly the escape the shell version allowed. ``O_DIRECTORY`` additionally
+    rejects a non-directory component.
+    """
+    flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if parent_fd is None:
+        return os.open(name, flags)
+    return os.open(name, flags, dir_fd=parent_fd)
+
+
+class ComponentRefused(Exception):
+    """A path component could not be traversed safely.
+
+    Carries the component name so the operator sees WHICH one was refused. The
+    errno for a symlinked directory component differs across platforms (ELOOP on
+    Linux, ENOTDIR on macOS), so the reason is classified by inspecting the entry
+    rather than by mapping errno — the message must not be platform-dependent.
+    """
+
+    def __init__(self, component: str, reason: str) -> None:
+        super().__init__(f"{reason} '{component}'")
+        self.component = component
+        self.reason = reason
+
+
+def _classify_component(parent_fd: int | None, name: str) -> str:
+    """Explain why a component could not be opened. Message-only, never a gate.
+
+    Safety comes from ``O_NOFOLLOW`` failing the open. This lstat runs only after
+    that failure, purely to name the cause.
+    """
+    try:
+        info = (
+            os.lstat(name) if parent_fd is None else os.lstat(name, dir_fd=parent_fd)
+        )
+    except OSError:
+        return "cannot resolve component"
+    if stat_module.S_ISLNK(info.st_mode):
+        return "symlinked component"
+    if not stat_module.S_ISDIR(info.st_mode):
+        return "non-directory component"
+    return "unreadable component"
+
+
+def _walk_to_parent(agent_root: str, parts: list[str]) -> tuple[int, list[int]]:
+    """Open every intermediate component without following symlinks.
+
+    Returns the parent directory fd plus every fd opened, so the caller can close
+    them all. Raises ComponentRefused if any component is a symlink or not a
+    directory — the O_NOFOLLOW open is what enforces that, not a prior check.
+    """
+    opened: list[int] = []
+    try:
+        fd = _open_dir_nofollow(None, agent_root)
+    except OSError as exc:
+        raise ComponentRefused(agent_root, _classify_component(None, agent_root)) from exc
+    opened.append(fd)
+    for component in parts[:-1]:
+        try:
+            fd = _open_dir_nofollow(fd, component)
+        except OSError as exc:
+            raise ComponentRefused(component, _classify_component(fd, component)) from exc
+        opened.append(fd)
+    return fd, opened
+
+
+def _close_all(fds: list[int]) -> None:
+    for fd in fds:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+def _describe(exc: OSError, relative: str) -> str:
+    if exc.errno == errno.ELOOP:
+        return f"{REDACTED_UNSAFE} '{relative}': symlinked component refused"
+    if exc.errno == errno.ENOTDIR:
+        return f"{REDACTED_UNSAFE} '{relative}': component is not a directory"
+    if exc.errno == errno.ENOENT:
+        return f"  .agent: nothing to remove for '{relative}'"
+    return f"{REDACTED_UNSAFE} '{relative}': {exc.strerror}"
+
+
+def reap_entry(agent_root: str, kind: str, relative: str) -> tuple[bool, str]:
+    """Remove one manifest entry. Returns (removed, message)."""
+    if kind not in VALID_KINDS or not path_is_lexically_safe(relative):
+        return False, f"  .agent: {REDACTED_UNSAFE} '{kind} {relative}'"
+
+    parts = relative.split("/")
+    leaf = parts[-1]
+    opened: list[int] = []
+    unsafe = f"{REDACTED_UNSAFE} '{kind} {relative}'"
+    try:
+        parent_fd, opened = _walk_to_parent(agent_root, parts)
+    except ComponentRefused as exc:
+        _close_all(opened)
+        return False, f"  .agent: {unsafe}: {exc.reason} '{exc.component}'"
+    except OSError as exc:
+        _close_all(opened)
+        return False, f"  .agent: {_describe(exc, relative)}"
+
+    try:
+        try:
+            info = os.stat(leaf, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return False, f"  .agent: nothing to remove for '{relative}'"
+
+        is_link = stat_module.S_ISLNK(info.st_mode)
+        is_dir = stat_module.S_ISDIR(info.st_mode)
+
+        if kind == "l":
+            if not is_link:
+                return False, f"  .agent: {REDACTED_UNSAFE} '{relative}': expected a symlink"
+            os.unlink(leaf, dir_fd=parent_fd)
+        elif kind == "f":
+            if is_link:
+                # Deleting a symlink declared as a file would follow the link.
+                return False, f"  .agent: {REDACTED_UNSAFE} '{relative}': symlinked leaf declared 'f'"
+            if is_dir:
+                return False, f"  .agent: {REDACTED_UNSAFE} '{relative}': directory declared 'f'"
+            os.unlink(leaf, dir_fd=parent_fd)
+        else:  # kind == "d"
+            if is_link:
+                return False, f"  .agent: {REDACTED_UNSAFE} '{relative}': symlinked leaf declared 'd'"
+            if not is_dir:
+                return False, f"  .agent: {REDACTED_UNSAFE} '{relative}': not a directory"
+            try:
+                os.rmdir(leaf, dir_fd=parent_fd)
+            except OSError as exc:
+                if exc.errno in (errno.ENOTEMPTY, errno.EEXIST):
+                    # Runtime scratch still lives here — preserve by default (#4741).
+                    return False, ""
+                raise
+        return True, f"  .agent: removed retired deploy artifact '{relative}'"
+    except OSError as exc:
+        return False, f"  .agent: {_describe(exc, relative)}"
+    finally:
+        _close_all(opened)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-root", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--source-root", required=True)
+    args = parser.parse_args(argv)
+
+    manifest = Path(args.manifest)
+    if not manifest.is_file():
+        print("  .agent: no deploy manifest yet; preserving all existing paths during migration")
+        return 0
+
+    agent_root = args.agent_root
+    # Refuse outright if the mirror root is not a real directory: a symlinked
+    # .agent would make every subsequent operation land somewhere else.
+    if os.path.islink(agent_root) or not os.path.isdir(agent_root):
+        print(
+            f"  .agent: refusing manifest reap: '{agent_root}' is not a real directory",
+            file=sys.stderr,
+        )
+        return 1
+
+    source_root = Path(args.source_root)
+    files: list[tuple[str, str]] = []
+    dirs: list[tuple[str, str]] = []
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        kind, _, relative = line.partition("\t")
+        if not relative:
+            print(f"  .agent: {REDACTED_UNSAFE} '{line}'", file=sys.stderr)
+            continue
+        # Validate BEFORE consulting the source tree. `source_root / relative` returns
+        # the absolute path unchanged when `relative` is absolute, so an absolute entry
+        # naming an existing external file would otherwise look "still in source" and be
+        # skipped silently instead of refused loudly. Refusing must be the visible outcome.
+        if kind not in VALID_KINDS or not path_is_lexically_safe(relative):
+            print(f"  .agent: {REDACTED_UNSAFE} '{kind} {relative}'", file=sys.stderr)
+            continue
+        # Still present in source => not retired.
+        candidate = source_root / relative
+        if candidate.exists() or candidate.is_symlink():
+            continue
+        (dirs if kind == "d" else files).append((kind, relative))
+
+    failed = False
+    for kind, relative in files:
+        removed, message = reap_entry(agent_root, kind, relative)
+        if message:
+            print(message, file=sys.stdout if removed else sys.stderr)
+    # Deepest first, so a parent becomes empty only after its children are gone.
+    for kind, relative in sorted(dirs, key=lambda item: item[1].count("/"), reverse=True):
+        removed, message = reap_entry(agent_root, kind, relative)
+        if message:
+            print(message, file=sys.stdout if removed else sys.stderr)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/deploy/sync_agent_mirror.py
+++ b/scripts/deploy/sync_agent_mirror.py
@@ -14,36 +14,11 @@ macOS does not provide a usable ``/proc/self/fd`` path for this purpose;
 from __future__ import annotations
 
 import argparse
-import contextlib
 import os
 import sys
 from pathlib import Path
 
-
-def _directory_flags() -> int:
-    """Return flags that open a real directory without following a symlink."""
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    return flags
-
-
-def open_agent_directory(agent_root: str) -> int:
-    """Create (when absent) and open ``agent_root`` without following links.
-
-    The final open is always the security boundary.  If another process creates
-    or swaps the name after ``mkdir``, ``O_NOFOLLOW`` rejects a symlink and the
-    descriptor returned for a directory remains bound to the opened object.
-    """
-    flags = _directory_flags()
-    try:
-        return os.open(agent_root, flags)
-    except FileNotFoundError:
-        with contextlib.suppress(FileExistsError):
-            os.mkdir(agent_root)
-        # A concurrent creator may have won the race.  The no-follow open below
-        # still verifies that its entry is a real directory.
-        return os.open(agent_root, flags)
+from agent_directory import open_agent_directory
 
 
 def sync_agent_mirror(source_root: str, agent_root: str) -> None:

--- a/scripts/deploy/sync_agent_mirror.py
+++ b/scripts/deploy/sync_agent_mirror.py
@@ -1,0 +1,84 @@
+"""Synchronize shared extensions into ``.agent`` without a path-swap window.
+
+``.agent`` is mutable runtime state: other local agents can rename it or replace
+it with a symlink while deploy is running.  Opening it by pathname and later
+passing that pathname to rsync is therefore unsafe.  This helper opens the
+directory with ``O_NOFOLLOW | O_DIRECTORY``, changes into that held descriptor,
+and only then execs rsync with ``.`` as its destination.  A later rename changes
+what the pathname names, but cannot change rsync's working directory.
+
+macOS does not provide a usable ``/proc/self/fd`` path for this purpose;
+``fchdir`` is the portable descriptor-bound operation used here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+
+def _directory_flags() -> int:
+    """Return flags that open a real directory without following a symlink."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    return flags
+
+
+def open_agent_directory(agent_root: str) -> int:
+    """Create (when absent) and open ``agent_root`` without following links.
+
+    The final open is always the security boundary.  If another process creates
+    or swaps the name after ``mkdir``, ``O_NOFOLLOW`` rejects a symlink and the
+    descriptor returned for a directory remains bound to the opened object.
+    """
+    flags = _directory_flags()
+    try:
+        return os.open(agent_root, flags)
+    except FileNotFoundError:
+        with contextlib.suppress(FileExistsError):
+            os.mkdir(agent_root)
+        # A concurrent creator may have won the race.  The no-follow open below
+        # still verifies that its entry is a real directory.
+        return os.open(agent_root, flags)
+
+
+def sync_agent_mirror(source_root: str, agent_root: str) -> None:
+    """Exec rsync into the directory represented by an open descriptor."""
+    source = Path(source_root).resolve(strict=True)
+    if not source.is_dir():
+        raise NotADirectoryError(f"shared source is not a directory: {source}")
+
+    agent_fd = open_agent_directory(agent_root)
+    try:
+        # Python makes newly opened fds non-inheritable.  Keep this descriptor
+        # open in rsync as well: that makes the held-directory lifetime explicit
+        # from validation through the write, in addition to the descriptor-bound
+        # working directory selected by fchdir.
+        os.set_inheritable(agent_fd, True)
+        os.fchdir(agent_fd)
+        os.execvp("rsync", ("rsync", "-av", f"{source}/", "."))
+    finally:
+        # execvp never returns on success.  Close only on an fchdir/exec failure.
+        os.close(agent_fd)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-root", required=True)
+    parser.add_argument("--agent-root", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        sync_agent_mirror(args.source_root, args.agent_root)
+    except OSError as exc:
+        print(f"Error: refusing .agent mirror sync: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/deploy/update_agent_deploy_status.py
+++ b/scripts/deploy/update_agent_deploy_status.py
@@ -1,0 +1,97 @@
+"""Safely persist or clear launcher deploy breadcrumbs under ``.agent``.
+
+``.agent`` is writable runtime state. The launcher cannot write status files
+there by pathname because a concurrent agent can replace that path with a
+symlink after a check. Every operation below is relative to a directory opened
+with ``O_NOFOLLOW | O_DIRECTORY``; temporary files and replacements use the
+same held descriptor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import secrets
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from agent_directory import open_agent_directory
+
+STATUS_FILE = "last-deploy-status"
+FAILURE_LOG = "last-deploy-failure.log"
+
+
+def _write_atomically(agent_fd: int, filename: str, contents: bytes) -> None:
+    """Write one breadcrumb without following a leaf or root symlink."""
+    temporary = f".{filename}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    fd = os.open(temporary, flags, 0o600, dir_fd=agent_fd)
+    try:
+        with os.fdopen(fd, "wb") as destination:
+            destination.write(contents)
+            destination.flush()
+            os.fsync(destination.fileno())
+        os.replace(temporary, filename, src_dir_fd=agent_fd, dst_dir_fd=agent_fd)
+    except BaseException:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary, dir_fd=agent_fd)
+        raise
+
+
+def record_failure(agent_root: str, script: str, exit_code: int, failure_log: Path) -> None:
+    """Store a failed deploy status and its captured log under a held root fd."""
+    status = (
+        "FAILED\n"
+        f"script={script}\n"
+        f"exit_code={exit_code}\n"
+        f"when={datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ')}\n"
+    ).encode()
+    log_contents = failure_log.read_bytes()
+    agent_fd = open_agent_directory(agent_root)
+    try:
+        _write_atomically(agent_fd, STATUS_FILE, status)
+        _write_atomically(agent_fd, FAILURE_LOG, log_contents)
+    finally:
+        os.close(agent_fd)
+
+
+def clear_breadcrumb(agent_root: str) -> None:
+    """Remove the two breadcrumb leaves without traversing their targets."""
+    agent_fd = open_agent_directory(agent_root)
+    try:
+        for filename in (STATUS_FILE, FAILURE_LOG):
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(filename, dir_fd=agent_fd)
+    finally:
+        os.close(agent_fd)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    actions = parser.add_subparsers(dest="action", required=True)
+    clear = actions.add_parser("clear")
+    clear.add_argument("--agent-root", required=True)
+    failure = actions.add_parser("record-failure")
+    failure.add_argument("--agent-root", required=True)
+    failure.add_argument("--script", required=True)
+    failure.add_argument("--exit-code", required=True, type=int)
+    failure.add_argument("--failure-log", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.action == "clear":
+            clear_breadcrumb(args.agent_root)
+        else:
+            record_failure(args.agent_root, args.script, args.exit_code, args.failure_log)
+    except OSError as exc:
+        print(f"Error: refusing .agent deploy-status update: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -11,9 +11,10 @@
 #
 # .agent/ is special (preserve-by-default since #4741): runtime scratch
 # written by agents (handoffs, dispatch-briefs, canaries, tmp/, etc.)
-# must never be deleted by deploy. We rsync WITHOUT --delete for .agent/
-# so the preflight orphan check and ORPHAN_PATHS_AGENT no longer apply to it.
-# Source content (if any) from agents_extensions/shared is overlaid.
+# must never be deleted by deploy. We overlay the complete source tree without
+# --delete, then delete only within the source-managed entries that currently
+# exist under agents_extensions/shared/. This makes a retired hook/rule/skill
+# stop executing without touching agent-owned runtime scratch.
 #
 # For other targets, if you add a destination-only path, add it to
 # ORPHAN_PATHS_<TARGET> in scripts/deploy_orphan_paths.sh.
@@ -49,6 +50,24 @@ build_shared_skill_overlay_excludes() {
     for shared_skill in "$SHARED_EXTENSIONS"/skills/*; do
         [[ -d "$shared_skill" ]] || continue
         echo "--exclude=/skills/$(basename "$shared_skill")/"
+    done
+}
+
+# .agent/ contains both deployed definitions and live runtime state. Its
+# source-managed boundary is deliberately derived from the source tree, not a
+# hard-coded list: every current top-level directory (and top-level file) in
+# agents_extensions/shared is a mirror where source deletions must propagate.
+# Everything else in .agent/ remains preserve-by-default (#4741).
+sync_shared_agent_mirrors() {
+    local shared_entry entry_name
+    for shared_entry in "$SHARED_EXTENSIONS"/*; do
+        [[ -e "$shared_entry" ]] || continue
+        entry_name="$(basename "$shared_entry")"
+        if [[ -d "$shared_entry" ]]; then
+            rsync -av --delete "$shared_entry/" ".agent/$entry_name/"
+        else
+            rsync -av --delete "$shared_entry" ".agent/$entry_name"
+        fi
     done
 }
 
@@ -318,10 +337,11 @@ fi
 echo "=== Syncing ==="
 # shellcheck disable=SC2046  # intentional word-splitting of build_excludes output
 rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CLAUDE $CLAUDE_RULE_AUTOLOAD_EXCLUDE_PATHS") "$SHARED_EXTENSIONS/" .claude/
-# .agent/ uses plain rsync (no --delete) — runtime scratch is preserve-by-default.
-# Source files from agents_extensions/shared are overlaid if present; agent-written
-# files (dispatch briefs, canaries, handoffs, tmp/, etc.) are never deleted. #4741
+# .agent/ overlays the whole source without --delete, preserving runtime scratch.
+# Then source-managed entries are individually mirrored with --delete so retired
+# definitions (for example hooks/auto-audit.sh) cannot remain executable. #4741
 rsync -av "$SHARED_EXTENSIONS/" .agent/
+sync_shared_agent_mirrors
 # shellcheck disable=SC2046
 rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CODEX $CODEX_OVERLAY_PATHS") "$SHARED_EXTENSIONS/" .codex/
 if [[ -d "$CODEX_EXTENSIONS" ]]; then

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -424,6 +424,19 @@ rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CLAUDE $CLAUDE_RULE_AUTOLOAD_
 # retired paths which an earlier deploy recorded, preserving all other runtime
 # scratch even when it shares a source directory such as prompts/. #4741
 reap_retired_shared_agent_paths
+# Review finding P1: the reap is fd-bound, but this rsync is PATH-based, so a
+# symlinked `.agent` redirects deploy WRITES outside the repository. Check as late
+# as possible — immediately before the write, not once at the top.
+#
+# HONEST LIMIT: this narrows the window, it does not eliminate it. rsync takes a
+# path, not a file descriptor, so a swap between this test and the rsync below is
+# still theoretically possible. Closing it fully means replacing rsync for this
+# target. Documented rather than glossed: the reap (the DESTRUCTIVE half) is fully
+# fd-bound; this overlay (the WRITE half) is best-effort.
+if [[ -e .agent || -L .agent ]] && { [[ -L .agent ]] || [[ ! -d .agent ]]; }; then
+    echo "Error: refusing to deploy into .agent — it exists but is not a real directory." >&2
+    exit 1
+fi
 rsync -av "$SHARED_EXTENSIONS/" .agent/
 write_shared_agent_manifest
 # shellcheck disable=SC2046

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -67,6 +67,63 @@ agent_manifest_path_is_safe() {
     esac
 }
 
+# A lexically safe manifest path can still escape through a symlinked
+# intermediate component.  This check is deliberately separate from the
+# lexical check above: defence in depth matters because .agent/ is writable
+# runtime state and its manifest is persisted locally.
+#
+# A manifest symlink entry is the one safe exception at the leaf: rm -f on the
+# link removes the link itself and never follows it.  Every intermediate
+# component must be a real directory, and all other leaf types must be real
+# filesystem objects.  The resolved parent is then required to sit beneath the
+# physical .agent/ root before any deletion is attempted.
+agent_manifest_path_is_safe_to_delete() {
+    local kind="$1" relative="$2" agent_root_real current component
+    local resolved_parent resolved_path
+    local -a components
+    local index last_index
+
+    if [[ ! -d .agent || -L .agent ]]; then
+        echo "  .agent: refusing manifest deletion '$relative': .agent is not a real directory" >&2
+        return 1
+    fi
+    agent_root_real="$(cd -P -- .agent && pwd)" || return 1
+
+    IFS='/' read -r -a components <<< "$relative"
+    last_index=$((${#components[@]} - 1))
+    current=".agent"
+    for ((index = 0; index < last_index; index++)); do
+        component="${components[index]}"
+        current+="/$component"
+        if [[ -L "$current" ]]; then
+            echo "  .agent: refusing manifest deletion '$relative': symlinked component '$component'" >&2
+            return 1
+        fi
+        if [[ ! -d "$current" ]]; then
+            echo "  .agent: refusing manifest deletion '$relative': cannot resolve component '$component'" >&2
+            return 1
+        fi
+    done
+
+    resolved_parent="$(cd -P -- "$current" && pwd)" || {
+        echo "  .agent: refusing manifest deletion '$relative': cannot resolve parent" >&2
+        return 1
+    }
+    resolved_path="$resolved_parent/${components[last_index]}"
+    case "$resolved_path" in
+        "$agent_root_real"/*) ;;
+        *)
+            echo "  .agent: refusing manifest deletion '$relative': resolved path escapes .agent" >&2
+            return 1
+            ;;
+    esac
+
+    if [[ -L "$current/${components[last_index]}" && "$kind" != l ]]; then
+        echo "  .agent: refusing manifest deletion '$relative': symlinked leaf has manifest type '$kind'" >&2
+        return 1
+    fi
+}
+
 shared_source_path_exists() {
     local relative="$1"
     [[ -e "$SHARED_EXTENSIONS/$relative" || -L "$SHARED_EXTENSIONS/$relative" ]]
@@ -141,6 +198,10 @@ reap_retired_shared_agent_paths() {
     while IFS=$'\t' read -r kind relative || [[ -n "$kind" ]]; do
         if [[ "$kind" != d && "$kind" != f && "$kind" != l ]] \
             || ! agent_manifest_path_is_safe "$relative"; then
+            echo "  .agent: ignoring unsafe manifest entry '$kind $relative'" >&2
+            continue
+        fi
+        if ! agent_manifest_path_is_safe_to_delete "$kind" "$relative"; then
             echo "  .agent: ignoring unsafe manifest entry '$kind $relative'" >&2
             continue
         fi

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -154,6 +154,15 @@ reap_retired_shared_agent_paths() {
         --source-root "$SHARED_EXTENSIONS"
 }
 
+sync_shared_agent_mirror() {
+    # The source is absolute because the helper fchdirs into a descriptor for
+    # .agent before it execs rsync.  Passing . as the destination keeps the write
+    # bound to that descriptor even if another agent swaps the .agent pathname.
+    "$PROJECT_ROOT/.venv/bin/python" "$PROJECT_ROOT/scripts/deploy/sync_agent_mirror.py" \
+        --source-root "$PROJECT_ROOT/$SHARED_EXTENSIONS" \
+        --agent-root .agent
+}
+
 remove_claude_autoload_rules() {
     local p
     for p in "${CLAUDE_RULE_AUTOLOAD_EXCLUDES[@]}"; do
@@ -424,20 +433,10 @@ rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CLAUDE $CLAUDE_RULE_AUTOLOAD_
 # retired paths which an earlier deploy recorded, preserving all other runtime
 # scratch even when it shares a source directory such as prompts/. #4741
 reap_retired_shared_agent_paths
-# Review finding P1: the reap is fd-bound, but this rsync is PATH-based, so a
-# symlinked `.agent` redirects deploy WRITES outside the repository. Check as late
-# as possible — immediately before the write, not once at the top.
-#
-# HONEST LIMIT: this narrows the window, it does not eliminate it. rsync takes a
-# path, not a file descriptor, so a swap between this test and the rsync below is
-# still theoretically possible. Closing it fully means replacing rsync for this
-# target. Documented rather than glossed: the reap (the DESTRUCTIVE half) is fully
-# fd-bound; this overlay (the WRITE half) is best-effort.
-if [[ -e .agent || -L .agent ]] && { [[ -L .agent ]] || [[ ! -d .agent ]]; }; then
-    echo "Error: refusing to deploy into .agent — it exists but is not a real directory." >&2
-    exit 1
-fi
-rsync -av "$SHARED_EXTENSIONS/" .agent/
+# The .agent overlay is descriptor-bound all the way through rsync.  A late
+# pathname check is not sufficient: another local agent can swap the directory
+# after the check and redirect a path-based write outside this repository.
+sync_shared_agent_mirror
 write_shared_agent_manifest
 # shellcheck disable=SC2046
 rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CODEX $CODEX_OVERLAY_PATHS") "$SHARED_EXTENSIONS/" .codex/

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -77,52 +77,6 @@ agent_manifest_path_is_safe() {
 # component must be a real directory, and all other leaf types must be real
 # filesystem objects.  The resolved parent is then required to sit beneath the
 # physical .agent/ root before any deletion is attempted.
-agent_manifest_path_is_safe_to_delete() {
-    local kind="$1" relative="$2" agent_root_real current component
-    local resolved_parent resolved_path
-    local -a components
-    local index last_index
-
-    if [[ ! -d .agent || -L .agent ]]; then
-        echo "  .agent: refusing manifest deletion '$relative': .agent is not a real directory" >&2
-        return 1
-    fi
-    agent_root_real="$(cd -P -- .agent && pwd)" || return 1
-
-    IFS='/' read -r -a components <<< "$relative"
-    last_index=$((${#components[@]} - 1))
-    current=".agent"
-    for ((index = 0; index < last_index; index++)); do
-        component="${components[index]}"
-        current+="/$component"
-        if [[ -L "$current" ]]; then
-            echo "  .agent: refusing manifest deletion '$relative': symlinked component '$component'" >&2
-            return 1
-        fi
-        if [[ ! -d "$current" ]]; then
-            echo "  .agent: refusing manifest deletion '$relative': cannot resolve component '$component'" >&2
-            return 1
-        fi
-    done
-
-    resolved_parent="$(cd -P -- "$current" && pwd)" || {
-        echo "  .agent: refusing manifest deletion '$relative': cannot resolve parent" >&2
-        return 1
-    }
-    resolved_path="$resolved_parent/${components[last_index]}"
-    case "$resolved_path" in
-        "$agent_root_real"/*) ;;
-        *)
-            echo "  .agent: refusing manifest deletion '$relative': resolved path escapes .agent" >&2
-            return 1
-            ;;
-    esac
-
-    if [[ -L "$current/${components[last_index]}" && "$kind" != l ]]; then
-        echo "  .agent: refusing manifest deletion '$relative': symlinked leaf has manifest type '$kind'" >&2
-        return 1
-    fi
-}
 
 shared_source_path_exists() {
     local relative="$1"
@@ -188,52 +142,16 @@ write_shared_agent_manifest() {
 }
 
 reap_retired_shared_agent_paths() {
-    local kind relative
-    local -a stale_dirs=()
-    [[ -f "$AGENT_SHARED_MANIFEST" ]] || {
-        echo "  .agent: no deploy manifest yet; preserving all existing paths during migration"
-        return 0
-    }
-
-    while IFS=$'\t' read -r kind relative || [[ -n "$kind" ]]; do
-        if [[ "$kind" != d && "$kind" != f && "$kind" != l ]] \
-            || ! agent_manifest_path_is_safe "$relative"; then
-            echo "  .agent: ignoring unsafe manifest entry '$kind $relative'" >&2
-            continue
-        fi
-        if ! agent_manifest_path_is_safe_to_delete "$kind" "$relative"; then
-            echo "  .agent: ignoring unsafe manifest entry '$kind $relative'" >&2
-            continue
-        fi
-        shared_source_path_exists "$relative" && continue
-        case "$kind" in
-            f)
-                if [[ -f ".agent/$relative" && ! -L ".agent/$relative" ]]; then
-                    rm -f -- ".agent/$relative"
-                    echo "  .agent: removed retired deploy artifact '$relative'"
-                fi
-                ;;
-            l)
-                if [[ -L ".agent/$relative" ]]; then
-                    rm -f -- ".agent/$relative"
-                    echo "  .agent: removed retired deploy artifact '$relative'"
-                fi
-                ;;
-            d)
-                if [[ -d ".agent/$relative" && ! -L ".agent/$relative" ]]; then
-                    stale_dirs+=("$relative")
-                fi
-                ;;
-        esac
-    done <"$AGENT_SHARED_MANIFEST"
-
-    if (( ${#stale_dirs[@]} > 0 )); then
-        printf '%s\n' "${stale_dirs[@]}" | sort -r | while IFS= read -r relative; do
-            if rmdir -- ".agent/$relative" 2>/dev/null; then
-                echo "  .agent: removed retired deploy directory '$relative'"
-            fi
-        done
-    fi
+    # Delegated to Python: the reap must not be redirectable between validation and
+    # deletion. Shell can only validate a PATH and then delete by that same PATH, and
+    # a review reproduced a symlink swapped in between those two steps deleting a file
+    # OUTSIDE the repository. The helper walks components with O_NOFOLLOW|O_DIRECTORY
+    # and unlinks relative to the resulting directory fd, so the entry removed is the
+    # one inside the directory actually opened. See scripts/deploy/reap_agent_mirrors.py.
+    "$PROJECT_ROOT/.venv/bin/python" "$PROJECT_ROOT/scripts/deploy/reap_agent_mirrors.py" \
+        --agent-root .agent \
+        --manifest "$AGENT_SHARED_MANIFEST" \
+        --source-root "$SHARED_EXTENSIONS"
 }
 
 remove_claude_autoload_rules() {

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -10,11 +10,12 @@
 # deploy, so we exclude them explicitly.
 #
 # .agent/ is special (preserve-by-default since #4741): runtime scratch
-# written by agents (handoffs, dispatch-briefs, canaries, tmp/, etc.)
-# must never be deleted by deploy. We overlay the complete source tree without
-# --delete, then delete only within the source-managed entries that currently
-# exist under agents_extensions/shared/. This makes a retired hook/rule/skill
-# stop executing without touching agent-owned runtime scratch.
+# written by agents (handoffs, dispatch-briefs, canaries, tmp/, etc.) must
+# never be deleted by deploy. A deploy-owned manifest records exactly the
+# source paths previously copied there. On a later deploy, only paths in that
+# manifest which have disappeared from source may be reaped. This propagates
+# retired hooks without treating a colliding namespace (such as prompts/) as
+# wholly deploy-owned.
 #
 # For other targets, if you add a destination-only path, add it to
 # ORPHAN_PATHS_<TARGET> in scripts/deploy_orphan_paths.sh.
@@ -29,6 +30,8 @@ source "$PROJECT_ROOT/scripts/deploy_orphan_paths.sh"
 AGENT_EXTENSIONS_ROOT="agents_extensions"
 SHARED_EXTENSIONS="$AGENT_EXTENSIONS_ROOT/shared"
 CODEX_EXTENSIONS="$AGENT_EXTENSIONS_ROOT/codex"
+DEPLOY_STATE_DIR="${DEPLOY_STATE_DIR:-$PROJECT_ROOT/.deploy-state}"
+AGENT_SHARED_MANIFEST="$DEPLOY_STATE_DIR/shared-to-agent.manifest"
 
 DRY_RUN=false
 if [[ "${1:-}" == "--dry-run" ]]; then
@@ -53,22 +56,123 @@ build_shared_skill_overlay_excludes() {
     done
 }
 
-# .agent/ contains both deployed definitions and live runtime state. Its
-# source-managed boundary is deliberately derived from the source tree, not a
-# hard-coded list: every current top-level directory (and top-level file) in
-# agents_extensions/shared is a mirror where source deletions must propagate.
-# Everything else in .agent/ remains preserve-by-default (#4741).
-sync_shared_agent_mirrors() {
-    local shared_entry entry_name
-    for shared_entry in "$SHARED_EXTENSIONS"/*; do
-        [[ -e "$shared_entry" ]] || continue
-        entry_name="$(basename "$shared_entry")"
-        if [[ -d "$shared_entry" ]]; then
-            rsync -av --delete "$shared_entry/" ".agent/$entry_name/"
-        else
-            rsync -av --delete "$shared_entry" ".agent/$entry_name"
-        fi
+# A manifest entry is TYPE<TAB>PATH, where TYPE is d, f, or l.  Paths are
+# source-controlled, but validate persisted entries before acting on them so a
+# corrupt local state file can never escape .agent/.
+agent_manifest_path_is_safe() {
+    local path="$1"
+    [[ -n "$path" && "$path" != /* && "$path" != *$'\n'* && "$path" != *$'\t'* ]] || return 1
+    case "/$path/" in
+        *"//"*|*"/./"*|*"/../"*) return 1 ;;
+    esac
+}
+
+shared_source_path_exists() {
+    local relative="$1"
+    [[ -e "$SHARED_EXTENSIONS/$relative" || -L "$SHARED_EXTENSIONS/$relative" ]]
+}
+
+write_current_shared_agent_paths() {
+    local kind
+    for kind in d f l; do
+        (
+            cd "$SHARED_EXTENSIONS"
+            find . -mindepth 1 -type "$kind" -print
+        ) | while IFS= read -r path; do
+            agent_manifest_path_is_safe "${path#./}" || {
+                echo "Cannot record unsafe shared source path: $path" >&2
+                exit 1
+            }
+            printf '%s\t%s\n' "$kind" "${path#./}"
+        done
     done
+}
+
+# Before this manifest existed, the only safe legacy paths to adopt are files
+# whose bytes still match the last tracked source version deleted from Git.
+# This lets the migration reap an old deployed hook on the *next* deploy while
+# refusing to claim arbitrary .agent/ scratch as deploy-owned.
+legacy_agent_file_matches_deleted_source() {
+    local relative="$1" destination="$2" deletion_commit
+    [[ -f "$destination" && ! -L "$destination" ]] || return 1
+    git rev-parse --git-dir >/dev/null 2>&1 || return 1
+    deletion_commit="$(git log --diff-filter=D --format=%H -1 -- "$SHARED_EXTENSIONS/$relative" 2>/dev/null)"
+    [[ -n "$deletion_commit" ]] || return 1
+    git show "$deletion_commit^:$SHARED_EXTENSIONS/$relative" 2>/dev/null | cmp -s - "$destination"
+}
+
+write_legacy_shared_agent_paths() {
+    local source_path relative
+    git rev-parse --git-dir >/dev/null 2>&1 || return 0
+    git log -z --diff-filter=D --name-only --format= -- "$SHARED_EXTENSIONS" 2>/dev/null \
+        | while IFS= read -r -d '' source_path; do
+            case "$source_path" in
+                "$SHARED_EXTENSIONS"/*) relative="${source_path#"$SHARED_EXTENSIONS/"}" ;;
+                *) continue ;;
+            esac
+            agent_manifest_path_is_safe "$relative" || continue
+            shared_source_path_exists "$relative" && continue
+            if legacy_agent_file_matches_deleted_source "$relative" ".agent/$relative"; then
+                printf 'f\t%s\n' "$relative"
+            fi
+        done
+}
+
+write_shared_agent_manifest() {
+    local manifest_tmp
+    mkdir -p "$DEPLOY_STATE_DIR"
+    manifest_tmp="$(mktemp "$DEPLOY_STATE_DIR/shared-to-agent.manifest.XXXXXX")"
+    write_current_shared_agent_paths >"$manifest_tmp"
+    if [[ ! -f "$AGENT_SHARED_MANIFEST" ]]; then
+        write_legacy_shared_agent_paths >>"$manifest_tmp"
+    fi
+    sort -u "$manifest_tmp" -o "$manifest_tmp"
+    mv "$manifest_tmp" "$AGENT_SHARED_MANIFEST"
+}
+
+reap_retired_shared_agent_paths() {
+    local kind relative
+    local -a stale_dirs=()
+    [[ -f "$AGENT_SHARED_MANIFEST" ]] || {
+        echo "  .agent: no deploy manifest yet; preserving all existing paths during migration"
+        return 0
+    }
+
+    while IFS=$'\t' read -r kind relative || [[ -n "$kind" ]]; do
+        if [[ "$kind" != d && "$kind" != f && "$kind" != l ]] \
+            || ! agent_manifest_path_is_safe "$relative"; then
+            echo "  .agent: ignoring unsafe manifest entry '$kind $relative'" >&2
+            continue
+        fi
+        shared_source_path_exists "$relative" && continue
+        case "$kind" in
+            f)
+                if [[ -f ".agent/$relative" && ! -L ".agent/$relative" ]]; then
+                    rm -f -- ".agent/$relative"
+                    echo "  .agent: removed retired deploy artifact '$relative'"
+                fi
+                ;;
+            l)
+                if [[ -L ".agent/$relative" ]]; then
+                    rm -f -- ".agent/$relative"
+                    echo "  .agent: removed retired deploy artifact '$relative'"
+                fi
+                ;;
+            d)
+                if [[ -d ".agent/$relative" && ! -L ".agent/$relative" ]]; then
+                    stale_dirs+=("$relative")
+                fi
+                ;;
+        esac
+    done <"$AGENT_SHARED_MANIFEST"
+
+    if (( ${#stale_dirs[@]} > 0 )); then
+        printf '%s\n' "${stale_dirs[@]}" | sort -r | while IFS= read -r relative; do
+            if rmdir -- ".agent/$relative" 2>/dev/null; then
+                echo "  .agent: removed retired deploy directory '$relative'"
+            fi
+        done
+    fi
 }
 
 remove_claude_autoload_rules() {
@@ -337,11 +441,12 @@ fi
 echo "=== Syncing ==="
 # shellcheck disable=SC2046  # intentional word-splitting of build_excludes output
 rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CLAUDE $CLAUDE_RULE_AUTOLOAD_EXCLUDE_PATHS") "$SHARED_EXTENSIONS/" .claude/
-# .agent/ overlays the whole source without --delete, preserving runtime scratch.
-# Then source-managed entries are individually mirrored with --delete so retired
-# definitions (for example hooks/auto-audit.sh) cannot remain executable. #4741
+# .agent/ overlays source without --delete. A deploy-owned manifest reaps only
+# retired paths which an earlier deploy recorded, preserving all other runtime
+# scratch even when it shares a source directory such as prompts/. #4741
+reap_retired_shared_agent_paths
 rsync -av "$SHARED_EXTENSIONS/" .agent/
-sync_shared_agent_mirrors
+write_shared_agent_manifest
 # shellcheck disable=SC2046
 rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CODEX $CODEX_OVERLAY_PATHS") "$SHARED_EXTENSIONS/" .codex/
 if [[ -d "$CODEX_EXTENSIONS" ]]; then

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -59,6 +59,29 @@ remove_claude_autoload_rules() {
     done
 }
 
+# A destination-only path is a STALE DEPLOY ARTIFACT, not an undeclared
+# orphan, when git shows the source path was tracked and has since been
+# deleted. Removing the destination copy is the intended propagation of that
+# deletion — aborting on it deadlocks every future deploy until a human
+# hand-deletes the target file.
+#
+# Git is the SSOT, so git decides: tracked in HEAD -> still owned by source;
+# absent from HEAD but deleted in history -> stale artifact. Anything git has
+# never heard of stays an undeclared orphan and still aborts (fail-closed).
+#
+# Incident 2026-07-26: #5783 deleted hooks/guard-push-pytest.py from source.
+# Every local deploy aborted from then on, so .claude/settings.json kept the
+# retired hook registered and live. CI never caught it — CI deploys into a
+# clean checkout where the gitignored destination trees carry no stale copy.
+git_source_deleted() {
+    local src="$1" rel="$2"
+    git rev-parse --git-dir >/dev/null 2>&1 || return 1
+    # Still tracked at HEAD → source owns it; not a deletion.
+    git cat-file -e "HEAD:$src/$rel" 2>/dev/null && return 1
+    # Absent from HEAD and history records a deletion → stale deploy artifact.
+    [[ -n "$(git log --diff-filter=D --format=%H -1 -- "$src/$rel" 2>/dev/null)" ]]
+}
+
 # Preflight assertion: warn if an undeclared orphan is in the destination
 # but missing from source. This catches "someone dropped a new file in
 # .gemini/ without updating ORPHAN_PATHS_GEMINI" situations before the
@@ -78,6 +101,10 @@ check_orphans() {
                 break
             fi
         done
+        if [[ "$matched" == false ]] && git_source_deleted "$src" "$orphan"; then
+            echo "  ♻️  $label: stale deploy artifact '$orphan' (deleted from source in git) — deploy will remove it"
+            continue
+        fi
         if [[ "$matched" == false ]]; then
             echo "  ⚠️  $label: undeclared orphan '$orphan' in destination"
             echo "     rsync --delete would wipe this. Either:"

--- a/scripts/lib/deploy_extensions.sh
+++ b/scripts/lib/deploy_extensions.sh
@@ -47,13 +47,21 @@ deploy_agent_extensions() {
     # it on start, so the operator never sees the banner and the agent boots
     # with no idea its own config is stale. Persist the verdict where
     # session-setup.sh can read it back into the session capsule.
-    local status_file="$project_dir/.agent/last-deploy-status"
-    local failure_log="$project_dir/.agent/last-deploy-failure.log"
-    mkdir -p "$project_dir/.agent" 2>/dev/null || true
+    # .agent is concurrent agent-owned state. The helper opens it with
+    # O_NOFOLLOW|O_DIRECTORY and updates leaves by dir_fd; plain shell
+    # redirection/cp/rm here would reintroduce deploy's path-swap escape.
+    local scripts_dir helper_project_root status_helper
+    scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    helper_project_root="$(cd "$scripts_dir/.." && pwd)"
+    status_helper="$scripts_dir/deploy/update_agent_deploy_status.py"
 
     if [ "$exit_code" -eq 0 ]; then
+        if ! "$helper_project_root/.venv/bin/python" "$status_helper" clear --agent-root "$project_dir/.agent"; then
+            echo "Error: agent extensions deployed but deploy-status cleanup refused an unsafe .agent root." >&2
+            rm -f "$log_file"
+            return 1
+        fi
         echo "Agent extensions deployed ($npm_script)"
-        rm -f "$status_file" "$failure_log"
     else
         echo ""
         echo "⚠️⚠️  AGENT-EXTENSIONS DEPLOY FAILED (npm run $npm_script, exit $exit_code)  ⚠️⚠️"
@@ -62,13 +70,13 @@ deploy_agent_extensions() {
         tail -15 "$log_file"
         echo "────────────────────────────────────────"
         echo "Reproduce with: npm run $npm_script"
-        {
-            echo "FAILED"
-            echo "script=$npm_script"
-            echo "exit_code=$exit_code"
-            echo "when=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo unknown)"
-        } >"$status_file" 2>/dev/null || true
-        cp "$log_file" "$failure_log" 2>/dev/null || true
+        if ! "$helper_project_root/.venv/bin/python" "$status_helper" record-failure \
+            --agent-root "$project_dir/.agent" \
+            --script "$npm_script" \
+            --exit-code "$exit_code" \
+            --failure-log "$log_file"; then
+            echo "Error: deploy-status update refused an unsafe .agent root." >&2
+        fi
     fi
     rm -f "$log_file"
     return "$exit_code"

--- a/scripts/lib/deploy_extensions.sh
+++ b/scripts/lib/deploy_extensions.sh
@@ -43,8 +43,18 @@ deploy_agent_extensions() {
     local exit_code=0
     (cd "$project_dir" && npm run --silent "$npm_script" >"$log_file" 2>&1) || exit_code=$?
 
+    # Durable status breadcrumb. Printing the banner to the terminal is NOT
+    # enough: the launcher hands the terminal to the agent CLI, which clears
+    # it on start, so the operator never sees the banner and the agent boots
+    # with no idea its own config is stale. Persist the verdict where
+    # session-setup.sh can read it back into the session capsule.
+    local status_file="$project_dir/.agent/last-deploy-status"
+    local failure_log="$project_dir/.agent/last-deploy-failure.log"
+    mkdir -p "$project_dir/.agent" 2>/dev/null || true
+
     if [ "$exit_code" -eq 0 ]; then
         echo "Agent extensions deployed ($npm_script)"
+        rm -f "$status_file" "$failure_log"
     else
         echo ""
         echo "⚠️⚠️  AGENT-EXTENSIONS DEPLOY FAILED (npm run $npm_script, exit $exit_code)  ⚠️⚠️"
@@ -53,6 +63,13 @@ deploy_agent_extensions() {
         tail -15 "$log_file"
         echo "────────────────────────────────────────"
         echo "Reproduce with: npm run $npm_script"
+        {
+            echo "FAILED"
+            echo "script=$npm_script"
+            echo "exit_code=$exit_code"
+            echo "when=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo unknown)"
+        } >"$status_file" 2>/dev/null || true
+        cp "$log_file" "$failure_log" 2>/dev/null || true
     fi
     rm -f "$log_file"
     return "$exit_code"

--- a/scripts/lib/deploy_extensions.sh
+++ b/scripts/lib/deploy_extensions.sh
@@ -11,9 +11,8 @@
 #
 # This helper runs the deploy with output captured, prints one line on
 # success, and on failure prints a loud banner plus the tail of the real
-# output. It returns the npm exit code so callers can decide whether to
-# abort; launchers deliberately continue (an interactive session with stale
-# skills beats no session) but the operator now SEES the failure.
+# output. It returns the npm exit code so callers can choose whether to abort;
+# start-claude.sh refuses to launch against stale definitions.
 #
 # Usage: deploy_agent_extensions <project_dir> <npm_script>
 # Load-bearing tests: scripts/audit/test_deploy_extensions.sh (wrapped by

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -93,13 +93,15 @@ if git rev-parse --git-dir > /dev/null 2>&1; then
     fi
 fi
 
-# Deploy agent extensions (always run to ensure up-to-date). Fail-honest: a
-# failing deploy prints a loud banner + the real output instead of the old
-# silent `|| true` that claimed "Skills deployed" over a stale .claude/.
+# Deploy agent extensions before launching. A failed deploy means Claude would
+# run against stale definitions, so refuse to launch rather than report a
+# successful session with retired hooks/rules still active.
 # shellcheck source=scripts/lib/deploy_extensions.sh
 source "$PROJECT_DIR/scripts/lib/deploy_extensions.sh"
-deploy_agent_extensions "$PROJECT_DIR" agents:deploy \
-    || echo "Continuing launch despite deploy failure (see banner above)."
+if ! deploy_agent_extensions "$PROJECT_DIR" agents:deploy; then
+    echo "Error: refusing to launch Claude because the agent-extensions deploy failed." >&2
+    exit 1
+fi
 
 # Show project status
 echo ""

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -109,6 +109,11 @@ def init_repo(tmp_path: Path, *, bootstrap_sources: bool = False) -> tuple[Path,
                 "scripts/config/issue_streams.yaml",
                 "agents_extensions/codex/hooks.json",
                 "agents_extensions/shared/hooks/session-setup.sh",
+                # Deploy status breadcrumbs (PR #5814 r6): deploy_prompts.sh now
+                # invokes this helper, so fixture repos must ship it and its
+                # sibling import.
+                "scripts/deploy/update_agent_deploy_status.py",
+                "scripts/deploy/agent_directory.py",
             ]
         )
         sources.extend(

--- a/tests/test_deploy_prompts_orphan_guard.sh
+++ b/tests/test_deploy_prompts_orphan_guard.sh
@@ -24,6 +24,8 @@ EXTRACT=$(mktemp)
 trap 'rm -f "$EXTRACT"' EXIT
 sed -n '/^build_excludes()/,/^}$/p' "$SCRIPT" >> "$EXTRACT"
 echo "" >> "$EXTRACT"
+sed -n '/^git_source_deleted()/,/^}$/p' "$SCRIPT" >> "$EXTRACT"
+echo "" >> "$EXTRACT"
 sed -n '/^check_orphans()/,/^}$/p' "$SCRIPT" >> "$EXTRACT"
 
 # shellcheck disable=SC1090
@@ -101,6 +103,49 @@ _assert_rc "docs/ multi-file undeclared → rc 1" "1" "$?"
 # With docs/ declared → passes
 check_orphans "$TEST_DIR/src5" "$TEST_DIR/dst5" "docs/" "docs/ multi-file declared" >/dev/null 2>&1
 _assert_rc "docs/ multi-file declared → rc 0" "0" "$?"
+
+echo ""
+echo "=== git-deleted source → stale artifact, not orphan (#5783 deadlock) ==="
+# A file deleted from source in git must NOT abort the deploy: rsync --delete
+# removing the destination copy IS the propagation of that deletion. Before
+# this, one deletion in the SSOT deadlocked every local deploy forever.
+GITREPO="$TEST_DIR/gitrepo"
+mkdir -p "$GITREPO"
+(
+    cd "$GITREPO" || exit 1
+    git init -q .
+    git config user.email t@t.t
+    git config user.name t
+    mkdir -p src/hooks dst/hooks
+    echo "keep" > src/hooks/kept.py
+    echo "retired" > src/hooks/retired.py
+    git add -A && git commit -qm "add both hooks"
+    git rm -q src/hooks/retired.py
+    git commit -qm "retire one hook"
+) >/dev/null 2>&1
+
+# Destination still carries the retired hook (deploy never got to remove it).
+echo "keep" > "$GITREPO/dst/hooks/kept.py"
+echo "retired" > "$GITREPO/dst/hooks/retired.py"
+
+rc=0
+out=$( cd "$GITREPO" && check_orphans "src" "dst" "" "git-deleted" 2>&1 ) || rc=$?
+_assert_rc "git-deleted source file → rc 0 (deploy proceeds)" "0" "$rc"
+if echo "$out" | grep -q "stale deploy artifact 'hooks/retired.py'"; then
+    echo "  ✓ reports it as a stale deploy artifact"
+    PASS=$((PASS + 1))
+else
+    echo "  ✗ did not report stale deploy artifact"
+    echo "    output: $out"
+    FAIL=$((FAIL + 1))
+fi
+
+# Fail-closed: a destination file git has NEVER tracked is still an undeclared
+# orphan and must still abort. The git check must not become a blanket bypass.
+echo "mystery" > "$GITREPO/dst/hooks/never-in-git.py"
+rc=0
+( cd "$GITREPO" && check_orphans "src" "dst" "" "unknown-file" >/dev/null 2>&1 ) || rc=$?
+_assert_rc "file git never tracked → rc 1 (still aborts)" "1" "$rc"
 
 echo ""
 echo "=== results ==="

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -54,6 +54,11 @@ def _copy_repo_subset(target: Path) -> None:
         DEPLOY_SCRIPT,
         CHECK_SCRIPT,
         ORPHAN_PATHS_FILE,
+        # deploy_prompts.sh delegates the .agent reap to this helper (fd-bound
+        # deletion, see scripts/deploy/reap_agent_mirrors.py). The fixture must
+        # mirror every file the script actually invokes, or deploy exits non-zero
+        # here for a reason that has nothing to do with the behaviour under test.
+        Path("scripts/deploy/reap_agent_mirrors.py"),
         Path("scripts/lint_prompts.py"),
         Path("scripts/lint/lint_prompts.py"),
         Path("scripts/lint/lint_agent_skills.py"),

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -12,6 +12,7 @@ PROJECT_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
 DEPLOY_SCRIPT = Path("scripts/deploy_prompts.sh")
 CHECK_SCRIPT = Path("scripts/check_rules_deployment.sh")
 ORPHAN_PATHS_FILE = Path("scripts/deploy_orphan_paths.sh")
+AGENT_DEPLOY_MANIFEST = Path(".deploy-state/shared-to-agent.manifest")
 ORPHAN_PATH_VARS = (
     "ORPHAN_PATHS_CLAUDE",
     "ORPHAN_PATHS_AGENT",  # kept for compat (empty; .agent/ preserve-by-default)
@@ -102,6 +103,33 @@ def _run_command(repo: Path, command: list[str]) -> subprocess.CompletedProcess[
     )
 
 
+def _init_git_history(repo: Path) -> None:
+    """Create the source history used to verify legacy deploy artifacts."""
+    for command in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "deploy-test@example.invalid"],
+        ["git", "config", "user.name", "Deploy test"],
+        ["git", "add", "-A"],
+        ["git", "commit", "-qm", "seed deploy source"],
+    ):
+        result = _run_command(repo, command)
+        assert result.returncode == 0, result.stderr
+
+
+def _delete_source_file(repo: Path, relative: Path) -> bytes:
+    """Delete a tracked source file and commit the deletion for a deploy test."""
+    source = repo / "agents_extensions" / "shared" / relative
+    original = source.read_bytes()
+    source.unlink()
+    for command in (
+        ["git", "add", "-A"],
+        ["git", "commit", "-qm", f"retire {relative.name}"],
+    ):
+        result = _run_command(repo, command)
+        assert result.returncode == 0, result.stderr
+    return original
+
+
 def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
     """A clean checkout should deploy successfully and pass drift checks."""
     repo = _init_checkout(tmp_path)
@@ -151,6 +179,70 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
     assert codex_hooks_diff.returncode == 0, (
         f"Codex hooks drift after fresh deploy:\nstdout: {codex_hooks_diff.stdout}\nstderr: {codex_hooks_diff.stderr}"
     )
+
+
+def test_agent_manifest_reaps_retired_hook_without_touching_agent_state(tmp_path: Path) -> None:
+    """A recorded hook is reaped; unrecorded .agent runtime paths survive."""
+    repo = _init_checkout(tmp_path)
+    _init_git_history(repo)
+    retired = Path("hooks/auto-audit.sh")
+
+    first = _run(repo, DEPLOY_SCRIPT)
+    assert first.returncode == 0, first.stderr
+    assert (repo / AGENT_DEPLOY_MANIFEST).is_file()
+
+    agent_prompt = repo / ".agent/prompts/agent-written.md"
+    rollover = repo / ".agent/thread-rollovers/x/handoff.md"
+    runtime_tmp = repo / ".agent/tmp/y"
+    for path, contents in (
+        (agent_prompt, "agent-owned prompt\n"),
+        (rollover, "agent-owned handoff\n"),
+        (runtime_tmp, "agent-owned scratch\n"),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+
+    _delete_source_file(repo, retired)
+    deploy = _run(repo, DEPLOY_SCRIPT)
+
+    assert deploy.returncode == 0, deploy.stderr
+    assert "removed retired deploy artifact 'hooks/auto-audit.sh'" in deploy.stdout
+    assert not (repo / ".agent" / retired).exists()
+    assert not (repo / ".claude" / retired).exists()
+    assert not (repo / ".codex" / retired).exists()
+    assert agent_prompt.read_text(encoding="utf-8") == "agent-owned prompt\n"
+    assert rollover.read_text(encoding="utf-8") == "agent-owned handoff\n"
+    assert runtime_tmp.read_text(encoding="utf-8") == "agent-owned scratch\n"
+
+
+def test_agent_manifest_migration_defers_reaping_verified_legacy_artifact(tmp_path: Path) -> None:
+    """The first manifest deploy preserves legacy output; the next one reaps it."""
+    repo = _init_checkout(tmp_path)
+    _init_git_history(repo)
+    retired = Path("hooks/auto-audit.sh")
+    original = _delete_source_file(repo, retired)
+
+    stale_target = repo / ".agent" / retired
+    agent_owned = repo / ".agent/hooks/custom-agent-hook.sh"
+    stale_target.parent.mkdir(parents=True)
+    stale_target.write_bytes(original)
+    agent_owned.write_text("agent-owned hook\n", encoding="utf-8")
+    assert not (repo / AGENT_DEPLOY_MANIFEST).exists()
+
+    first = _run(repo, DEPLOY_SCRIPT)
+    assert first.returncode == 0, first.stderr
+    assert "no deploy manifest yet; preserving all existing paths during migration" in first.stdout
+    assert stale_target.read_bytes() == original
+    manifest = (repo / AGENT_DEPLOY_MANIFEST).read_text(encoding="utf-8")
+    assert "f\thooks/auto-audit.sh" in manifest
+    assert "custom-agent-hook.sh" not in manifest
+    assert agent_owned.read_text(encoding="utf-8") == "agent-owned hook\n"
+
+    second = _run(repo, DEPLOY_SCRIPT)
+    assert second.returncode == 0, second.stderr
+    assert "removed retired deploy artifact 'hooks/auto-audit.sh'" in second.stdout
+    assert not stale_target.exists()
+    assert agent_owned.read_text(encoding="utf-8") == "agent-owned hook\n"
 
 
 def test_curriculum_preparation_documents_canonical_helper_paths() -> None:

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -215,6 +215,99 @@ def test_agent_manifest_reaps_retired_hook_without_touching_agent_state(tmp_path
     assert runtime_tmp.read_text(encoding="utf-8") == "agent-owned scratch\n"
 
 
+def test_agent_manifest_rejects_symlinked_intermediate_component(tmp_path: Path) -> None:
+    """A manifest path must not follow a symlinked .agent/ subdirectory."""
+    repo = _init_checkout(tmp_path)
+    first = _run(repo, DEPLOY_SCRIPT)
+    assert first.returncode == 0, first.stderr
+
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    victim = external_dir / "victim.txt"
+    victim.write_text("must survive\n", encoding="utf-8")
+    (repo / ".agent" / "escape").symlink_to(external_dir, target_is_directory=True)
+    with (repo / AGENT_DEPLOY_MANIFEST).open("a", encoding="utf-8") as manifest:
+        manifest.write("f\tescape/victim.txt\n")
+
+    deploy = _run(repo, DEPLOY_SCRIPT)
+    output = f"{deploy.stdout}\n{deploy.stderr}"
+    assert deploy.returncode == 0, output
+    assert victim.read_text(encoding="utf-8") == "must survive\n"
+    assert (repo / ".agent" / "escape").is_symlink()
+    assert "symlinked component 'escape'" in output
+    assert "ignoring unsafe manifest entry 'f escape/victim.txt'" in output
+
+
+def test_agent_manifest_unlinks_symlink_leaf_without_following_target(tmp_path: Path) -> None:
+    """A recorded symlink leaf is unlinked, never followed to its target."""
+    repo = _init_checkout(tmp_path)
+    first = _run(repo, DEPLOY_SCRIPT)
+    assert first.returncode == 0, first.stderr
+
+    external_target = tmp_path / "external-target.txt"
+    external_target.write_text("must survive\n", encoding="utf-8")
+    link = repo / ".agent" / "link"
+    link.symlink_to(external_target)
+    with (repo / AGENT_DEPLOY_MANIFEST).open("a", encoding="utf-8") as manifest:
+        manifest.write("l\tlink\n")
+
+    deploy = _run(repo, DEPLOY_SCRIPT)
+    assert deploy.returncode == 0, deploy.stderr
+    assert "removed retired deploy artifact 'link'" in deploy.stdout
+    assert external_target.read_text(encoding="utf-8") == "must survive\n"
+    assert not link.is_symlink()
+
+
+def test_agent_manifest_keeps_lexically_unsafe_entries_rejected(tmp_path: Path) -> None:
+    """Existing absolute and parent-directory manifest rejections remain in force."""
+    repo = _init_checkout(tmp_path)
+    first = _run(repo, DEPLOY_SCRIPT)
+    assert first.returncode == 0, first.stderr
+
+    parent_victim = tmp_path / "outside"
+    absolute_victim = tmp_path / "absolute-outside"
+    parent_victim.write_text("must survive\n", encoding="utf-8")
+    absolute_victim.write_text("must survive\n", encoding="utf-8")
+    # The deploy script exits early on a true no-op, so add a legitimate source
+    # change to exercise manifest reaping during this regression.
+    source_change = repo / "agents_extensions" / "shared" / "hooks" / "force-redeploy.sh"
+    source_change.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    source_change.chmod(0o755)
+    with (repo / AGENT_DEPLOY_MANIFEST).open("a", encoding="utf-8") as manifest:
+        manifest.write("f\t../outside\n")
+        manifest.write(f"f\t{absolute_victim}\n")
+
+    deploy = _run(repo, DEPLOY_SCRIPT)
+    output = f"{deploy.stdout}\n{deploy.stderr}"
+    assert deploy.returncode == 0, output
+    assert "ignoring unsafe manifest entry 'f ../outside'" in output
+    assert f"ignoring unsafe manifest entry 'f {absolute_victim}'" in output
+    assert parent_victim.read_text(encoding="utf-8") == "must survive\n"
+    assert absolute_victim.read_text(encoding="utf-8") == "must survive\n"
+
+
+def test_agent_manifest_reaps_legitimate_nested_file(tmp_path: Path) -> None:
+    """Physical-path validation still permits a retired nested .agent/ artifact."""
+    repo = _init_checkout(tmp_path)
+    retired = Path("hooks/nested/retired.sh")
+    source = repo / "agents_extensions" / "shared" / retired
+    source.parent.mkdir(parents=True)
+    source.write_text("#!/usr/bin/env bash\necho retired\n", encoding="utf-8")
+    source.chmod(0o755)
+    _init_git_history(repo)
+
+    first = _run(repo, DEPLOY_SCRIPT)
+    assert first.returncode == 0, first.stderr
+    deployed = repo / ".agent" / retired
+    assert deployed.exists()
+
+    _delete_source_file(repo, retired)
+    deploy = _run(repo, DEPLOY_SCRIPT)
+    assert deploy.returncode == 0, deploy.stderr
+    assert "removed retired deploy artifact 'hooks/nested/retired.sh'" in deploy.stdout
+    assert not deployed.exists()
+
+
 def test_agent_manifest_migration_defers_reaping_verified_legacy_artifact(tmp_path: Path) -> None:
     """The first manifest deploy preserves legacy output; the next one reaps it."""
     repo = _init_checkout(tmp_path)

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -435,6 +435,53 @@ def test_agent_transient_briefs_are_preserved(tmp_path: Path) -> None:
     assert collected.exists(), "dispatch-briefs/ brief was wiped"
 
 
+def test_agent_source_managed_subtrees_propagate_deletions_without_wiping_runtime(
+    tmp_path: Path,
+) -> None:
+    """A retired shared hook is removed, while .agent runtime scratch survives.
+
+    The source-managed set is derived from ``agents_extensions/shared``. This
+    exercises the exact production boundary: ``hooks/`` is mirrored with
+    deletion propagation, but ``thread-rollovers/`` and ``tmp/`` are runtime
+    state outside that source tree and remain preserve-by-default.
+    """
+    repo = _init_checkout(tmp_path)
+    source_hook = repo / "agents_extensions" / "shared" / "hooks" / "auto-audit.sh"
+    source_hook.write_text("#!/usr/bin/env bash\necho auto-audit\n", encoding="utf-8")
+    source_hook.chmod(0o755)
+    for command in (
+        ["git", "init", "--quiet"],
+        ["git", "config", "user.email", "test@example.invalid"],
+        ["git", "config", "user.name", "Deploy test"],
+        ["git", "add", "agents_extensions"],
+        ["git", "commit", "--quiet", "-m", "add source hook"],
+    ):
+        result = _run_command(repo, command)
+        assert result.returncode == 0, result.stderr
+
+    first_deploy = _run(repo, DEPLOY_SCRIPT)
+    assert first_deploy.returncode == 0, first_deploy.stderr + first_deploy.stdout
+    deployed_hook = repo / ".agent" / "hooks" / "auto-audit.sh"
+    assert deployed_hook.exists(), "test fixture hook was not deployed"
+
+    handoff = repo / ".agent" / "thread-rollovers" / "x" / "handoff.md"
+    handoff.parent.mkdir(parents=True)
+    handoff.write_text("live handoff\n", encoding="utf-8")
+    runtime_tmp = repo / ".agent" / "tmp" / "y"
+    runtime_tmp.parent.mkdir(parents=True)
+    runtime_tmp.write_text("live scratch\n", encoding="utf-8")
+
+    deletion = _run_command(repo, ["git", "rm", "agents_extensions/shared/hooks/auto-audit.sh"])
+    assert deletion.returncode == 0, deletion.stderr
+    deletion_commit = _run_command(repo, ["git", "commit", "--quiet", "-m", "retire source hook"])
+    assert deletion_commit.returncode == 0, deletion_commit.stderr
+    second_deploy = _run(repo, DEPLOY_SCRIPT)
+    assert second_deploy.returncode == 0, second_deploy.stderr + second_deploy.stdout
+    assert not deployed_hook.exists(), "deleted source hook still executes from .agent"
+    assert handoff.read_text(encoding="utf-8") == "live handoff\n"
+    assert runtime_tmp.read_text(encoding="utf-8") == "live scratch\n"
+
+
 def test_claude_epic_dirs_are_preserved(tmp_path: Path) -> None:
     """Curriculum-track *-epic/ driver-handoff dirs in .claude/ must survive deploy.
 

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -60,6 +60,7 @@ def _copy_repo_subset(target: Path) -> None:
         # deletion, see scripts/deploy/reap_agent_mirrors.py). The fixture must
         # mirror every file the script actually invokes, or deploy exits non-zero
         # here for a reason that has nothing to do with the behaviour under test.
+        Path("scripts/deploy/agent_directory.py"),
         Path("scripts/deploy/reap_agent_mirrors.py"),
         Path("scripts/deploy/sync_agent_mirror.py"),
         Path("scripts/lint_prompts.py"),

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -59,6 +61,7 @@ def _copy_repo_subset(target: Path) -> None:
         # mirror every file the script actually invokes, or deploy exits non-zero
         # here for a reason that has nothing to do with the behaviour under test.
         Path("scripts/deploy/reap_agent_mirrors.py"),
+        Path("scripts/deploy/sync_agent_mirror.py"),
         Path("scripts/lint_prompts.py"),
         Path("scripts/lint/lint_prompts.py"),
         Path("scripts/lint/lint_agent_skills.py"),
@@ -241,6 +244,76 @@ def test_agent_manifest_rejects_symlinked_intermediate_component(tmp_path: Path)
     assert (repo / ".agent" / "escape").is_symlink()
     assert "symlinked component 'escape'" in output
     assert "ignoring unsafe manifest entry 'f escape/victim.txt'" in output
+
+
+def test_agent_overlay_write_stays_in_held_directory_after_root_swap(tmp_path: Path) -> None:
+    """A post-validation `.agent` symlink swap must not redirect rsync writes.
+
+    The rsync shim waits only when the agent overlay begins.  At that point the
+    production helper has already opened and fchdir'ed into `.agent`; the test
+    swaps the pathname to an external directory before allowing the real rsync
+    binary to run.  A regression to ``rsync ... .agent/`` writes settings.json
+    outside the fixture and fails this test.
+    """
+    repo = _init_checkout(tmp_path)
+    # Exercise the post-validation race from the review: the root is a real
+    # directory before deploy starts, then becomes a symlink immediately before
+    # rsync writes.  (A clean first deploy is covered separately.)
+    (repo / ".agent").mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    ready = tmp_path / "rsync-ready"
+    release = tmp_path / "rsync-release"
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    real_rsync = shutil.which("rsync")
+    assert real_rsync, "rsync is required for the deploy integration test"
+    (fake_bin / "rsync").write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'last="${!#}"\n'
+        'if [[ "$last" == "." || "$last" == ".agent" || "$last" == ".agent/" ]]; then\n'
+        '    : > "$SYNC_AGENT_RACE_READY"\n'
+        '    while [[ ! -e "$SYNC_AGENT_RACE_RELEASE" ]]; do sleep 0.01; done\n'
+        "fi\n"
+        f"exec {shlex.quote(real_rsync)} \"$@\"\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "rsync").chmod(0o755)
+    environment = os.environ | {
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "SYNC_AGENT_RACE_READY": str(ready),
+        "SYNC_AGENT_RACE_RELEASE": str(release),
+    }
+    process = subprocess.Popen(
+        ["bash", str(DEPLOY_SCRIPT)],
+        cwd=repo,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while not ready.exists() and process.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert ready.exists(), "the descriptor-bound .agent rsync never started"
+
+        held_agent = repo / ".agent-held"
+        (repo / ".agent").rename(held_agent)
+        (repo / ".agent").symlink_to(outside, target_is_directory=True)
+    finally:
+        release.touch()
+        stdout, stderr = process.communicate(timeout=120)
+
+    output = f"{stdout}\n{stderr}"
+    assert process.returncode == 0, output
+    assert not (outside / "settings.json").exists(), (
+        "shared content was written through the swapped .agent symlink"
+    )
+    assert (repo / ".agent-held" / "settings.json").is_file(), (
+        "rsync did not write into the directory held before the pathname swap"
+    )
 
 
 def test_agent_manifest_unlinks_symlink_leaf_without_following_target(tmp_path: Path) -> None:

--- a/tests/test_reap_agent_mirrors.py
+++ b/tests/test_reap_agent_mirrors.py
@@ -17,6 +17,7 @@ old behaviour so the guarantee cannot silently regress to path semantics.
 
 from __future__ import annotations
 
+import errno
 import importlib.util
 import os
 from pathlib import Path
@@ -226,3 +227,47 @@ def test_internal_error_is_reported_and_fails_loudly(tmp_path: Path, monkeypatch
     assert rc == 1, "an internal error must not report success"
     assert "internal error" in capsys.readouterr().err
     assert inner.exists(), "the entry must be left alone when the reap errored"
+
+
+def test_refused_symlinked_leaf_is_preserved_without_failing_reap(
+    tmp_path: Path, capsys
+) -> None:
+    """A deliberate unsafe refusal preserves the entry but remains a successful reap."""
+    agent, _inner, external = _fixture(tmp_path)
+    (agent / "leafptr").symlink_to(external)
+    manifest = tmp_path / "m.manifest"
+    manifest.write_text("f\tleafptr\n", encoding="utf-8")
+    source = tmp_path / "src"
+    source.mkdir()
+
+    rc = reaper.main(
+        ["--agent-root", str(agent), "--manifest", str(manifest), "--source-root", str(source)]
+    )
+
+    assert rc == 0, "a deliberate unsafe refusal must not fail deploy"
+    assert (agent / "leafptr").is_symlink()
+    assert external.exists()
+    assert "symlinked leaf declared 'f'" in capsys.readouterr().err
+
+
+def test_operational_unlink_error_fails_reap_and_names_entry(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Unexpected filesystem failures must not be relabelled as safe refusals."""
+    agent, inner, _external = _fixture(tmp_path)
+    manifest = tmp_path / "m.manifest"
+    manifest.write_text("f\tsub/victim.txt\n", encoding="utf-8")
+    source = tmp_path / "src"
+    source.mkdir()
+
+    def fail_unlink(*_args, **_kwargs) -> None:
+        raise OSError(errno.EIO, "Input/output error")
+
+    monkeypatch.setattr(reaper.os, "unlink", fail_unlink)
+    rc = reaper.main(
+        ["--agent-root", str(agent), "--manifest", str(manifest), "--source-root", str(source)]
+    )
+
+    assert rc == 1, "an operational unlink failure must fail the reap"
+    assert inner.exists(), "the failed unlink must leave its entry intact"
+    assert "operational error reaping 'sub/victim.txt'" in capsys.readouterr().err

--- a/tests/test_reap_agent_mirrors.py
+++ b/tests/test_reap_agent_mirrors.py
@@ -1,0 +1,155 @@
+"""The `.agent` reaper must not be redirectable between validation and deletion.
+
+A cross-family review proved the previous shell implementation deleted a file
+OUTSIDE the repository: it validated a path, then deleted by that same path, and a
+symlink swapped in between the two steps redirected the deletion
+(`TOCTOU_FILE_EXTERNAL_VICTIM=DELETED`, same for `rmdir`).
+
+That window is reachable in normal operation, not only under attack: `.agent/` is
+written by agents, deploy runs while other agents are live, and deploy runs with
+the operator's full privileges.
+
+`test_fd_bound_deletion_survives_path_swap` is the load-bearing one. It performs
+the swap explicitly between opening the directory and unlinking, and asserts the
+external victim survives. `test_path_based_deletion_would_have_escaped` pins the
+old behaviour so the guarantee cannot silently regress to path semantics.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULE_PATH = REPO_ROOT / "scripts" / "deploy" / "reap_agent_mirrors.py"
+
+spec = importlib.util.spec_from_file_location("reap_agent_mirrors_under_test", MODULE_PATH)
+assert spec and spec.loader
+reaper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(reaper)
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """agent root with a real nested target, plus an external victim directory."""
+    agent = tmp_path / "proj" / ".agent"
+    (agent / "sub").mkdir(parents=True)
+    inner = agent / "sub" / "victim.txt"
+    inner.write_text("inner", encoding="utf-8")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    external = outside / "victim.txt"
+    external.write_text("external", encoding="utf-8")
+    return agent, inner, external
+
+
+def test_fd_bound_deletion_survives_path_swap(tmp_path: Path) -> None:
+    """Swap the parent to an external symlink AFTER the fd is open.
+
+    The unlink must still land inside the directory that was actually opened.
+    """
+    agent, inner, external = _fixture(tmp_path)
+
+    parent_fd, opened = reaper._walk_to_parent(str(agent), ["sub", "victim.txt"])
+    try:
+        # The race: between validation/open and deletion, redirect the path.
+        (agent / "sub").rename(tmp_path / "sub-moved")
+        (agent / "sub").symlink_to(external.parent, target_is_directory=True)
+        assert (agent / "sub").is_symlink()
+
+        os.unlink("victim.txt", dir_fd=parent_fd)
+    finally:
+        reaper._close_all(opened)
+
+    assert external.exists(), "external victim was deleted through the swapped path"
+    assert external.read_text(encoding="utf-8") == "external"
+    assert not (tmp_path / "sub-moved" / "victim.txt").exists(), (
+        "the real in-.agent target should have been removed"
+    )
+    # After the swap the ORIGINAL path resolves through the symlink to the external
+    # file, which is exactly why path-based deletion was dangerous: the same string
+    # now names a different file. The fd-bound unlink above ignored that entirely.
+    assert inner.exists(), "sanity: the swapped path should now resolve outside .agent"
+    assert inner.resolve() == external.resolve()
+
+
+def test_path_based_deletion_would_have_escaped(tmp_path: Path) -> None:
+    """Pin the OLD behaviour, so a regression to path semantics is visible.
+
+    This documents why the fd walk exists: the same swap against a path-based
+    unlink destroys the external file.
+    """
+    agent, _inner, external = _fixture(tmp_path)
+
+    (agent / "sub").rename(tmp_path / "sub-moved")
+    (agent / "sub").symlink_to(external.parent, target_is_directory=True)
+
+    os.unlink(str(agent / "sub" / "victim.txt"))  # path-based: follows the symlink
+
+    assert not external.exists(), (
+        "expected the path-based deletion to escape; if this fails the fixture no longer "
+        "reproduces the original defect and the guarantee above proves nothing"
+    )
+
+
+def test_symlinked_component_is_refused(tmp_path: Path) -> None:
+    agent, _inner, external = _fixture(tmp_path)
+    (agent / "escape").symlink_to(external.parent, target_is_directory=True)
+
+    removed, message = reaper.reap_entry(str(agent), "f", "escape/victim.txt")
+
+    assert removed is False
+    assert "escape/victim.txt" in message
+    assert external.exists(), "external victim deleted through a symlinked component"
+
+
+def test_symlinked_leaf_declared_as_file_is_refused(tmp_path: Path) -> None:
+    agent, _inner, external = _fixture(tmp_path)
+    (agent / "leafptr").symlink_to(external)
+
+    removed, message = reaper.reap_entry(str(agent), "f", "leafptr")
+
+    assert removed is False
+    assert "symlinked leaf" in message
+    assert external.exists(), "external target deleted through a symlinked leaf"
+    assert (agent / "leafptr").is_symlink(), "the link itself should be left alone for kind 'f'"
+
+
+def test_symlink_leaf_declared_as_link_removes_only_the_link(tmp_path: Path) -> None:
+    agent, _inner, external = _fixture(tmp_path)
+    (agent / "leafptr").symlink_to(external)
+
+    removed, _message = reaper.reap_entry(str(agent), "l", "leafptr")
+
+    assert removed is True
+    assert not (agent / "leafptr").exists()
+    assert external.exists(), "removing a link must never remove its target"
+
+
+def test_legitimate_nested_file_is_still_reaped(tmp_path: Path) -> None:
+    """A guard that refuses everything is also broken."""
+    agent, inner, _external = _fixture(tmp_path)
+
+    removed, message = reaper.reap_entry(str(agent), "f", "sub/victim.txt")
+
+    assert removed is True, message
+    assert not inner.exists()
+
+
+def test_non_empty_directory_is_preserved(tmp_path: Path) -> None:
+    """Runtime scratch shares directories with deployed content (#4741)."""
+    agent, _inner, _external = _fixture(tmp_path)
+    (agent / "sub" / "agent-written.md").write_text("live", encoding="utf-8")
+
+    removed, _message = reaper.reap_entry(str(agent), "d", "sub")
+
+    assert removed is False
+    assert (agent / "sub" / "agent-written.md").exists()
+
+
+@pytest.mark.parametrize("relative", ["../outside/victim.txt", "/etc/passwd", "a/../../b", ""])
+def test_lexically_unsafe_entries_refused(relative: str) -> None:
+    assert reaper.path_is_lexically_safe(relative) is False

--- a/tests/test_reap_agent_mirrors.py
+++ b/tests/test_reap_agent_mirrors.py
@@ -153,3 +153,76 @@ def test_non_empty_directory_is_preserved(tmp_path: Path) -> None:
 @pytest.mark.parametrize("relative", ["../outside/victim.txt", "/etc/passwd", "a/../../b", ""])
 def test_lexically_unsafe_entries_refused(relative: str) -> None:
     assert reaper.path_is_lexically_safe(relative) is False
+
+
+def _open_fd_count() -> int:
+    """Best-effort open-fd count; the leak assertion needs a delta, not a total."""
+    return len(os.listdir("/dev/fd")) if os.path.isdir("/dev/fd") else -1
+
+
+def test_missing_manifest_still_validates_the_root_first(tmp_path: Path, capsys) -> None:
+    """Review P1: the root check must run BEFORE the missing-manifest early return.
+
+    With the old ordering a first run exited 0 without ever looking at the root, and
+    deploy_prompts.sh then rsynced into `.agent/` by path — so a symlinked root
+    redirected deploy WRITES outside the repo.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link_root = tmp_path / "agent-link"
+    link_root.symlink_to(outside, target_is_directory=True)
+
+    rc = reaper.main(
+        [
+            "--agent-root", str(link_root),
+            "--manifest", str(tmp_path / "does-not-exist.manifest"),
+            "--source-root", str(tmp_path / "src"),
+        ]
+    )
+
+    assert rc == 1, "a symlinked root must be refused even when no manifest exists yet"
+    err = capsys.readouterr().err
+    assert "not a real directory" in err
+    assert "preserving all existing paths during migration" not in err
+
+
+def test_refused_entries_do_not_leak_directory_fds(tmp_path: Path) -> None:
+    """Review P2: a corrupt manifest could exhaust the fd table and deny the reap."""
+    agent, _inner, _external = _fixture(tmp_path)
+
+    before = _open_fd_count()
+    outcomes = [
+        reaper.reap_entry(str(agent), "f", "NONEXISTENT_COMPONENT/victim.txt")[0]
+        for _ in range(8)
+    ]
+    after = _open_fd_count()
+
+    assert outcomes == [False] * 8
+    if before >= 0:
+        assert after - before == 0, f"leaked {after - before} fds across 8 refused entries"
+
+
+def test_internal_error_is_reported_and_fails_loudly(tmp_path: Path, monkeypatch, capsys) -> None:
+    """A silently-skipped reap is a false-green, so real errors must set the exit code.
+
+    Refusals deliberately do NOT fail deploy — preserving a file we were unsure about
+    is the safe outcome, and a symlink an agent legitimately left in .agent/ must not
+    block every deploy.
+    """
+    agent, inner, _external = _fixture(tmp_path)
+    manifest = tmp_path / "m.manifest"
+    manifest.write_text("f\tsub/victim.txt\n", encoding="utf-8")
+    src = tmp_path / "src"
+    src.mkdir()
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("synthetic internal failure")
+
+    monkeypatch.setattr(reaper, "reap_entry", boom)
+    rc = reaper.main(
+        ["--agent-root", str(agent), "--manifest", str(manifest), "--source-root", str(src)]
+    )
+
+    assert rc == 1, "an internal error must not report success"
+    assert "internal error" in capsys.readouterr().err
+    assert inner.exists(), "the entry must be left alone when the reap errored"

--- a/tests/test_start_claude_profiles.py
+++ b/tests/test_start_claude_profiles.py
@@ -93,6 +93,42 @@ fi
     return values, result
 
 
+def test_predeploy_failure_refuses_to_launch_claude(tmp_path: Path) -> None:
+    """A failed deploy must return non-zero and never exec the Claude binary."""
+    home_bin = tmp_path / "home" / ".local" / "bin"
+    home_bin.mkdir(parents=True)
+    capture = tmp_path / "claude-was-launched.txt"
+    _write_executable(
+        home_bin / "claude",
+        f"""#!/usr/bin/env bash
+if [[ "${{1:-}}" == "--version" ]]; then
+    echo test-claude
+    exit 0
+fi
+printf launched > {capture}
+""",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "npm", "#!/usr/bin/env bash\nexit 3\n")
+
+    env = os.environ.copy()
+    env.update({"HOME": os.fspath(tmp_path / "home"), "PATH": f"{fake_bin}:{env['PATH']}"})
+    result = subprocess.run(
+        [os.fspath(_LAUNCHER), "--resume", "session-id"],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode != 0
+    assert "AGENT-EXTENSIONS DEPLOY FAILED" in result.stdout
+    assert "refusing to launch Claude" in result.stderr
+    assert not capture.exists(), "Claude launched after its predeploy failed"
+
+
 def test_certified_native_route_keeps_native_capacity_and_clears_proxy_flags(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_update_agent_deploy_status.py
+++ b/tests/test_update_agent_deploy_status.py
@@ -1,0 +1,79 @@
+"""Regression tests for descriptor-bound deploy-status breadcrumb updates."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEPLOY_DIR = REPO_ROOT / "scripts" / "deploy"
+MODULE_PATH = DEPLOY_DIR / "update_agent_deploy_status.py"
+
+sys.path.insert(0, str(DEPLOY_DIR))
+spec = importlib.util.spec_from_file_location("update_agent_deploy_status_under_test", MODULE_PATH)
+assert spec and spec.loader
+status_writer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(status_writer)
+
+
+def test_failure_breadcrumb_stays_in_held_directory_after_root_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The status and log write must ignore a post-open `.agent` path swap."""
+    agent_root = tmp_path / "project" / ".agent"
+    agent_root.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    failure_log = tmp_path / "deploy.log"
+    failure_log.write_text("rsync failed\n", encoding="utf-8")
+    held_agent = tmp_path / "held-agent"
+    swapped = False
+    original_open = status_writer.open_agent_directory
+
+    def open_then_swap(root: str) -> int:
+        nonlocal swapped
+        agent_fd = original_open(root)
+        if not swapped:
+            agent_root.rename(held_agent)
+            agent_root.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return agent_fd
+
+    monkeypatch.setattr(status_writer, "open_agent_directory", open_then_swap)
+    status_writer.record_failure(str(agent_root), "agents:deploy", 3, failure_log)
+
+    assert not (outside / status_writer.STATUS_FILE).exists()
+    assert not (outside / status_writer.FAILURE_LOG).exists()
+    assert (held_agent / status_writer.STATUS_FILE).read_text(encoding="utf-8").startswith("FAILED\n")
+    assert (held_agent / status_writer.FAILURE_LOG).read_text(encoding="utf-8") == "rsync failed\n"
+
+
+def test_clear_unlinks_symlink_leaf_without_touching_its_target(tmp_path: Path) -> None:
+    """Success cleanup removes only a breadcrumb symlink, never its target."""
+    agent_root = tmp_path / "project" / ".agent"
+    agent_root.mkdir(parents=True)
+    external_status = tmp_path / "external-status"
+    external_status.write_text("must survive\n", encoding="utf-8")
+    (agent_root / status_writer.STATUS_FILE).symlink_to(external_status)
+
+    status_writer.clear_breadcrumb(str(agent_root))
+
+    assert external_status.read_text(encoding="utf-8") == "must survive\n"
+    assert not (agent_root / status_writer.STATUS_FILE).exists()
+
+
+def test_symlinked_agent_root_is_refused(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A pre-existing root symlink is rejected before a status write can escape."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link_root = tmp_path / "project" / ".agent"
+    link_root.parent.mkdir()
+    link_root.symlink_to(outside, target_is_directory=True)
+
+    rc = status_writer.main(["clear", "--agent-root", str(link_root)])
+
+    assert rc == 1
+    assert "refusing .agent deploy-status update" in capsys.readouterr().err


### PR DESCRIPTION
## Incident

`npm run agents:deploy` has been aborting on every developer machine since #5783 merged. The user hit it at session start today.

**Root cause.** #5783 deleted `agents_extensions/shared/hooks/guard-push-pytest.py` from the source of truth. The preflight orphan guard then saw that file still present in `.claude/hooks/` and `.codex/hooks/` with no source counterpart, classified it as an undeclared orphan, and aborted before syncing anything.

The guard cannot distinguish two opposite situations:

| Destination-only file | Correct action |
| --- | --- |
| Someone dropped it there; `--delete` would lose it | abort (what it does) |
| git deleted it from source; `--delete` should remove it | proceed (what it also did — abort) |

So **any deletion in the SSOT permanently deadlocks the local deploy** until a human hand-deletes the destination copy.

**Impact.** With deploy blocked, `.claude/settings.json` kept the retired `guard-push-pytest.py` registered as a live hook — the very hook #5771 removed for wrongly blocking pushes. It was active in the running session.

**Why CI stayed green.** `rules-deployment-check` deploys into a clean checkout, where the gitignored destination trees carry no stale copy, so the guard has nothing to trip on. Green CI, broken laptops.

## Fixes

1. **`scripts/deploy_prompts.sh`** — new `git_source_deleted()` predicate. git is the SSOT, so git decides: tracked at `HEAD` → source still owns it; absent from `HEAD` with a deletion in history → stale deploy artifact, report and proceed. Anything git has never tracked remains an undeclared orphan and still aborts (fail-closed).

2. **`scripts/lib/deploy_extensions.sh`** — the predeploy printed a failure banner and then deleted the log. The agent CLI clears the terminal on start, so both copies of the evidence vanished and the session booted blind. Now persists `.agent/last-deploy-status` + `.agent/last-deploy-failure.log`; a later success clears them.

3. **`agents_extensions/shared/hooks/session-setup.sh`** — reads that breadcrumb back and raises `PREDEPLOY FAILED at launch (… exit N) — deploy targets are STALE` in the session capsule, with the reason line.

## Verification

- `tests/test_deploy_prompts_orphan_guard.sh` — 13/13. New cases build a real git repo, delete a tracked source file, and assert the deploy proceeds *and* that a never-tracked file still aborts.
- `scripts/audit/test_deploy_extensions.sh` — breadcrumb written on failure with exit code and real output, cleared on success, plus a wiring guard that session-setup still reads it.
- `pytest tests/test_deploy_extensions.py tests/test_deploy_script_idempotency.py tests/test_session_setup_hook.py` — 19 passed.
- **Mutation-checked** (#M-16): reverting the git-aware branch fails 2 orphan-guard assertions; stripping the breadcrumb write fails the extensions fixture. Neither test can pass without its fix.
- End-to-end against the real tree: replanted the stale hook, preflight now prints `♻️ stale deploy artifact … deploy will remove it` and continues instead of aborting.

## Round 6 - descriptor-bound deploy safety

All identified .agent deploy writes and deletes are now bound to a directory opened with O_NOFOLLOW | O_DIRECTORY. The mirror uses fchdir then rsync to dot; reaping and status breadcrumbs use dir_fd operations. A concurrent rename or symlink replacement of .agent cannot redirect these operations outside the repository.

### Verification

- Reaper, deploy-status, and deploy-extension tests: 20 passed in 0.66s.
- Deploy idempotency suite: 23 tests passed.
- Orphan guard: Passed: 13; Failed: 0.
- Ruff, OPSEC, and the agent-trailer gate pass.

### Mutation checks

- Restoring path-based rsync writes fails: shared content was written through the swapped .agent symlink.
- Forcing reaping to exit zero after EIO fails: assert 0 == 1.
- Replacing fd-relative breadcrumb writes with a path write fails: outside/last-deploy-status exists.

### Independent review

Claude Sonnet 5 reviewed final head 55b3f8ba1c in a sealed read-only snapshot: APPROVED, zero findings, confidence 0.82.
