### PR TITLE
fix(api): supervise monitor service and preserve failures

### DIFF
--- a/agents_extensions/shared/hooks/tool-timing.sh
+++ b/agents_extensions/shared/hooks/tool-timing.sh
@@ -6,55 +6,37 @@ set -u
 command -v jq >/dev/null 2>&1 || exit 0
 
 INPUT=$(</dev/stdin)
-TZ=UTC0 printf -v TS '%(%Y-%m-%dT%H:%M:%S.000Z)T' -1
+TS=$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')
 
-[[ "$INPUT" =~ \"tool_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]] || exit 0
-TOOL_NAME="${BASH_REMATCH[1]}"
-
-[[ "$INPUT" =~ \"duration_ms\"[[:space:]]*:[[:space:]]*([0-9]+(\.[0-9]+)?) ]] || exit 0
-DURATION_RAW="${BASH_REMATCH[1]}"
-DURATION_MS="${DURATION_RAW%%.*}"
-if [[ "$DURATION_RAW" == *.* ]]; then
-  FRACTION="${DURATION_RAW#*.}"
-  FIRST_DECIMAL="${FRACTION:0:1}"
-  if [ "$FIRST_DECIMAL" -ge 5 ] 2>/dev/null; then
-    DURATION_MS=$((DURATION_MS + 1))
-  fi
-fi
-
-TOOL_USE_ID=""
-if [[ "$INPUT" =~ \"tool_use_id\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
-  TOOL_USE_ID="${BASH_REMATCH[1]}"
-fi
-TOOL_USE_JSON=null
-[ -n "$TOOL_USE_ID" ] && TOOL_USE_JSON="\"$TOOL_USE_ID\""
-
-SESSION_ID=""
-if [[ "$INPUT" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
-  SESSION_ID="${BASH_REMATCH[1]}"
-fi
-SESSION_JSON=null
-[ -n "$SESSION_ID" ] && SESSION_JSON="\"$SESSION_ID\""
-
-FAILED=false
-if [[ "$INPUT" =~ \"hook_event_name\"[[:space:]]*:[[:space:]]*\"PostToolUseFailure\" ]]; then
-  FAILED=true
-fi
-
-PAYLOAD=$(printf '{"ts":"%s","tool_name":"%s","duration_ms":%s,"tool_use_id":%s,"session_id":%s,"failed":%s}' \
-  "$TS" \
-  "$TOOL_NAME" \
-  "$DURATION_MS" \
-  "$TOOL_USE_JSON" \
-  "$SESSION_JSON" \
-  "$FAILED")
+# macOS ships Bash 3.2, whose printf lacks the %(... )T formatter. Build the
+# complete request with jq instead of regex/string interpolation so timestamps
+# and JSON strings remain valid for the FastAPI ToolTimingIngest contract.
+PAYLOAD=$(printf '%s' "$INPUT" | jq -ce --arg ts "$TS" '
+  . as $input
+  | ($input.tool_name | select(type == "string" and length > 0)) as $tool_name
+  | ($input.duration_ms | select(type == "number" and . >= 0) | round) as $duration_ms
+  | {
+      ts: $ts,
+      tool_name: $tool_name,
+      duration_ms: $duration_ms,
+      tool_use_id: (
+        if (($input.tool_use_id? | type) == "string" and ($input.tool_use_id | length) > 0)
+        then $input.tool_use_id else null end
+      ),
+      session_id: (
+        if (($input.session_id? | type) == "string" and ($input.session_id | length) > 0)
+        then $input.session_id else null end
+      ),
+      failed: ($input.hook_event_name == "PostToolUseFailure")
+    }
+') || exit 0
 
 (
   curl -sS -m 0.5 \
     -H 'Content-Type: application/json' \
     -X POST \
     --data "$PAYLOAD" \
-    http://localhost:8765/api/telemetry/tool-timings \
+    "${TOOL_TIMING_API_URL:-http://127.0.0.1:8765/api/telemetry/tool-timings}" \
     >/dev/null 2>&1
 ) &
 disown 2>/dev/null || true

--- a/docs/best-practices/local-api-server.md
+++ b/docs/best-practices/local-api-server.md
@@ -19,6 +19,55 @@ Normal API commands launch uvicorn in dev-reload mode:
 `npm run api` and `npm run api:bg` use this shape. `npm run api:reload`
 is an alias for backward compatibility.
 
+`./services.sh start api` and `./services.sh restart api` are the persistent
+Monitor API path. They use the immutable release snapshot model (not reload
+mode) under a per-user macOS LaunchAgent:
+
+- Label: `com.learn-ukrainian.monitor-api`
+- Restart policy: `KeepAlive.SuccessfulExit=false`; the foreground runner turns
+  any unexpected API exit, including an unexpected zero exit, into a failed
+  launch-agent run.
+- Crash-loop protection: `ThrottleInterval=30`, so `launchd` cannot respawn a
+  repeatedly failing server faster than once every 30 seconds.
+- Operator stop: `./services.sh stop api` disables and unloads the agent before
+  the listener is signalled. It remains stopped across terminal close and
+  login; only a later `start` or `restart` enables it again.
+
+The normal start path installs or reconciles the plist automatically. To
+inspect or remove it explicitly, run these commands from the merged primary
+checkout (the plist stores an absolute checkout path):
+
+```bash
+./services.sh supervise api install
+./services.sh supervise api status
+./services.sh supervise api uninstall
+```
+
+If an older, unsupervised API is already healthy when this change is first
+installed, use `./services.sh restart api` once to move it under `launchd`.
+`start api` intentionally preserves its existing no-op behavior for a healthy
+listener.
+
+Unexpected exits persist a durable record at `.pids/api-last-crash.json` with
+the UTC timestamp, normalized exit code, signal when applicable, and the tail
+of stderr. It is not cleared by the next start. Runtime logs are:
+
+```text
+logs/api.log
+logs/api.stderr.log
+logs/api.launchd.stdout.log
+logs/api.launchd.stderr.log
+```
+
+Use `launchctl print "gui/$(id -u)/com.learn-ukrainian.monitor-api"` for
+low-level launchd readback. The plist, crash record, and logs are local runtime
+state; they must not be committed.
+
+`delegate.py dispatch` intentionally warns rather than blocks if the Monitor
+API health probe is unreachable. File-based dispatch fallbacks still work and
+may be needed to repair the API; the warning names `services.sh status api` and
+the crash record as recovery steps.
+
 The FastAPI app also installs `scripts/api/resilience.py` middleware:
 
 - `API_REQUEST_TIMEOUT_S` defaults to 10 seconds and returns 504 on timeout.
@@ -29,6 +78,10 @@ The FastAPI app also installs `scripts/api/resilience.py` middleware:
   `connect_sqlite()`.
 - `/api/health` exposes in-flight, saturation, timeout, slow-request, and
   slow-SQL telemetry.
+- `agents_extensions/shared/hooks/tool-timing.sh` serializes hook data with
+  `jq` and posts it to `/api/telemetry/tool-timings`. The endpoint keeps its
+  strict `ToolTimingIngest` schema; malformed hook input is discarded locally
+  instead of generating repeated 422 requests.
 
 ## Architecture Overview
 

--- a/scripts/api/launchd_supervisor.py
+++ b/scripts/api/launchd_supervisor.py
@@ -1,0 +1,592 @@
+"""Manage the macOS launchd supervisor for the local Monitor API.
+
+The launch agent owns process lifetime; this module owns the launch contract.
+It preserves the existing immutable API release-snapshot model and records every
+unexpected child exit before returning a non-zero status to ``launchd``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import signal
+import subprocess
+import sys
+import threading
+from collections import deque
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.api.release_snapshot import build_release, prune_releases
+
+LABEL = "com.learn-ukrainian.monitor-api"
+PORT = 8765
+THROTTLE_INTERVAL_SECONDS = 30
+_LOG_ROTATE_BYTES = 10 * 1024 * 1024
+
+
+class LaunchdError(RuntimeError):
+    """Raised when launchd cannot reach the requested API state."""
+
+
+def default_repo_root() -> Path:
+    """Return the checkout that contains this supervisor."""
+    return Path(__file__).resolve().parents[2]
+
+
+def default_home() -> Path:
+    """Return the current user's home without shell expansion."""
+    return Path.home()
+
+
+def plist_path(home: Path) -> Path:
+    """Return the per-user LaunchAgent location."""
+    return home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def _pid_dir(repo_root: Path) -> Path:
+    return repo_root / ".pids"
+
+
+def _config_path(repo_root: Path) -> Path:
+    return _pid_dir(repo_root) / "api-launchd.json"
+
+
+def crash_record_path(repo_root: Path) -> Path:
+    """Return the durable record that is deliberately not cleared on start."""
+    return _pid_dir(repo_root) / "api-last-crash.json"
+
+
+def _api_log_path(repo_root: Path) -> Path:
+    return repo_root / "logs" / "api.log"
+
+
+def _api_stderr_log_path(repo_root: Path) -> Path:
+    return repo_root / "logs" / "api.stderr.log"
+
+
+def _launchd_stdout_path(repo_root: Path) -> Path:
+    return repo_root / "logs" / "api.launchd.stdout.log"
+
+
+def _launchd_stderr_path(repo_root: Path) -> Path:
+    return repo_root / "logs" / "api.launchd.stderr.log"
+
+
+def _domain() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _target() -> str:
+    return f"{_domain()}/{LABEL}"
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def atomic_write(path: Path, content: bytes, *, mode: int = 0o600) -> bool:
+    """Atomically replace ``path`` and report whether its content changed."""
+    if path.is_file() and path.read_bytes() == content:
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    return True
+
+
+def build_plist(*, repo_root: Path) -> dict[str, object]:
+    """Build the persistent LaunchAgent configuration without side effects."""
+    root = repo_root.resolve()
+    interpreter = root / ".venv" / "bin" / "python"
+    return {
+        "Label": LABEL,
+        "ProcessType": "Background",
+        "ProgramArguments": [
+            str(interpreter),
+            "-m",
+            "scripts.api.launchd_supervisor",
+            "run",
+            "--repo-root",
+            str(root),
+        ],
+        "RunAtLoad": True,
+        # The foreground runner returns 0 only when launchd deliberately
+        # unloads it. Every unexpected API exit becomes non-zero and restarts.
+        "KeepAlive": {"SuccessfulExit": False},
+        # launchd applies this between restarts, preventing a crash-loop spin.
+        "ThrottleInterval": THROTTLE_INTERVAL_SECONDS,
+        "StandardOutPath": str(_launchd_stdout_path(root)),
+        "StandardErrorPath": str(_launchd_stderr_path(root)),
+        "WorkingDirectory": str(root),
+    }
+
+
+def render_plist(*, repo_root: Path) -> bytes:
+    """Render a stable XML plist for inspection and tests."""
+    return plistlib.dumps(build_plist(repo_root=repo_root), fmt=plistlib.FMT_XML, sort_keys=True)
+
+
+def _validate_runtime(repo_root: Path) -> None:
+    interpreter = repo_root / ".venv" / "bin" / "python"
+    supervisor = repo_root / "scripts" / "api" / "launchd_supervisor.py"
+    if not interpreter.is_file() or not os.access(interpreter, os.X_OK):
+        raise LaunchdError(f"required interpreter is missing or not executable: {interpreter}")
+    if not supervisor.is_file():
+        raise LaunchdError(f"required API supervisor is missing: {supervisor}")
+
+
+def install(*, repo_root: Path, home: Path) -> dict[str, object]:
+    """Write or reconcile the LaunchAgent plist without starting the service."""
+    root = repo_root.resolve()
+    _validate_runtime(root)
+    destination = plist_path(home)
+    changed = atomic_write(destination, render_plist(repo_root=root))
+    return {
+        "action": "install",
+        "changed": changed,
+        "label": LABEL,
+        "plist_path": str(destination),
+        "repo_root": str(root),
+    }
+
+
+def _launchctl(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["/bin/launchctl", *command],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise LaunchdError("/bin/launchctl is unavailable; Monitor API supervision requires macOS") from exc
+
+
+def _loaded_readback() -> subprocess.CompletedProcess[str]:
+    return _launchctl(["print", _target()])
+
+
+def _failure(action: str, result: subprocess.CompletedProcess[str]) -> LaunchdError:
+    detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+    return LaunchdError(f"launchctl {action} failed: {detail}")
+
+
+def _set_launch_config(*, repo_root: Path, live_mode: bool, port: int) -> None:
+    payload = {
+        "live_mode": live_mode,
+        "port": port,
+        "updated_at": _now_z(),
+    }
+    atomic_write(_config_path(repo_root), (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def _load_launch_config(repo_root: Path) -> tuple[bool, int]:
+    try:
+        data = json.loads(_config_path(repo_root).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return False, PORT
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise LaunchdError(f"invalid API launch configuration at {_config_path(repo_root)}") from exc
+
+    live_mode = data.get("live_mode") is True
+    port = data.get("port", PORT)
+    if not isinstance(port, int) or not 1 <= port <= 65535:
+        raise LaunchdError(f"invalid API port in {_config_path(repo_root)}: {port!r}")
+    return live_mode, port
+
+
+def start(*, repo_root: Path, home: Path, live_mode: bool, port: int = PORT) -> dict[str, object]:
+    """Enable and start the LaunchAgent after recording its launch mode."""
+    root = repo_root.resolve()
+    if not 1 <= port <= 65535:
+        raise LaunchdError(f"invalid API port: {port}")
+    result = install(repo_root=root, home=home)
+    _set_launch_config(repo_root=root, live_mode=live_mode, port=port)
+
+    enabled = _launchctl(["enable", _target()])
+    if enabled.returncode != 0:
+        raise _failure("enable", enabled)
+
+    loaded = _loaded_readback()
+    if loaded.returncode != 0:
+        bootstrapped = _launchctl(["bootstrap", _domain(), str(plist_path(home))])
+        if bootstrapped.returncode != 0:
+            raise _failure("bootstrap", bootstrapped)
+
+    kicked = _launchctl(["kickstart", "-k", _target()])
+    if kicked.returncode != 0:
+        raise _failure("kickstart", kicked)
+
+    readback = _loaded_readback()
+    if readback.returncode != 0:
+        raise _failure("print", readback)
+    return {
+        **result,
+        "action": "start",
+        "live_mode": live_mode,
+        "loaded": True,
+        "port": port,
+    }
+
+
+def stop(*, home: Path) -> dict[str, object]:
+    """Disable then unload the agent so an operator stop remains stopped."""
+    disabled = _launchctl(["disable", _target()])
+    if disabled.returncode != 0:
+        raise _failure("disable", disabled)
+
+    loaded = _loaded_readback()
+    if loaded.returncode == 0:
+        booted_out = _launchctl(["bootout", _target()])
+        if booted_out.returncode != 0:
+            raise _failure("bootout", booted_out)
+
+    readback = _loaded_readback()
+    if readback.returncode == 0:
+        raise LaunchdError(f"launchd service remains loaded after stop: {_target()}")
+    return {"action": "stop", "label": LABEL, "loaded": False, "plist_path": str(plist_path(home))}
+
+
+def uninstall(*, home: Path) -> dict[str, object]:
+    """Disable, unload, and remove the plist while preserving crash evidence."""
+    result = stop(home=home)
+    destination = plist_path(home)
+    existed = destination.exists()
+    if existed:
+        destination.unlink()
+        _fsync_directory(destination.parent)
+    return {
+        **result,
+        "action": "uninstall",
+        "plist_existed": existed,
+        "crash_evidence_preserved": True,
+    }
+
+
+def status(*, home: Path) -> tuple[dict[str, object], int]:
+    """Report persisted configuration and launchd state."""
+    destination = plist_path(home)
+    loaded = _loaded_readback()
+    installed = destination.is_file()
+    valid_plist = False
+    parse_error: str | None = None
+    if installed:
+        try:
+            payload = plistlib.loads(destination.read_bytes())
+            valid_plist = (
+                isinstance(payload, dict)
+                and payload.get("Label") == LABEL
+                and payload.get("KeepAlive") == {"SuccessfulExit": False}
+                and payload.get("ThrottleInterval") == THROTTLE_INTERVAL_SECONDS
+            )
+        except (OSError, ValueError, plistlib.InvalidFileException) as exc:
+            parse_error = str(exc)
+    result = {
+        "action": "status",
+        "installed": installed,
+        "label": LABEL,
+        "launchctl_error": None if loaded.returncode == 0 else (loaded.stderr.strip() or loaded.stdout.strip()),
+        "loaded": loaded.returncode == 0,
+        "parse_error": parse_error,
+        "plist_path": str(destination),
+        "valid_plist": valid_plist,
+    }
+    return result, 0 if installed and loaded.returncode == 0 and valid_plist else 1
+
+
+def _rotate_log(path: Path) -> None:
+    if not path.is_file() or path.stat().st_size <= _LOG_ROTATE_BYTES:
+        return
+    oldest = path.with_name(f"{path.name}.3")
+    oldest.unlink(missing_ok=True)
+    for index in (2, 1):
+        previous = path.with_name(f"{path.name}.{index}")
+        if previous.exists():
+            previous.replace(path.with_name(f"{path.name}.{index + 1}"))
+    path.replace(path.with_name(f"{path.name}.1"))
+
+
+def _append_log(handle: Any, message: str) -> None:
+    handle.write(message.encode("utf-8", errors="replace") + b"\n")
+    handle.flush()
+
+
+def _record_unexpected_exit(
+    *,
+    repo_root: Path,
+    pid: int | None,
+    returncode: int,
+    stderr_tail: list[str],
+) -> None:
+    signal_name: str | None = None
+    exit_code = returncode
+    if returncode < 0:
+        signal_number = -returncode
+        try:
+            signal_name = signal.Signals(signal_number).name
+        except ValueError:
+            signal_name = f"SIG{signal_number}"
+        exit_code = 128 + signal_number
+    payload = {
+        "timestamp": _now_z(),
+        "pid": pid,
+        "exit_code": exit_code,
+        "returncode": returncode,
+        "signal": signal_name,
+        "stderr_tail": stderr_tail,
+    }
+    atomic_write(
+        crash_record_path(repo_root),
+        (json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+    )
+
+
+def _prepare_api_command(repo_root: Path, *, live_mode: bool, port: int) -> tuple[list[str], Path, dict[str, str], str]:
+    if live_mode:
+        launch_dir = repo_root
+        release_line = "WARNING: API live mode enabled; serving mutable checkout code"
+    else:
+        head_sha = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--verify", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        release_dir, reused = build_release(repo_root, head_sha)
+        prune_result = prune_releases(repo_root, keep=3)
+        launch_dir = release_dir
+        release_line = (
+            f"release: {head_sha} reused: {reused} "
+            f"pruned: {','.join(prune_result.removed) or 'none'}"
+        )
+
+    environment = os.environ.copy()
+    for key in (
+        "GIT_INDEX_FILE",
+        "GIT_PREFIX",
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_NAMESPACE",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    ):
+        environment.pop(key, None)
+    environment["LEARN_UK_REPO_ROOT"] = str(repo_root)
+    environment["GIT_DIR"] = str(repo_root / ".git")
+    environment["GIT_WORK_TREE"] = str(repo_root)
+    environment["PYTHONPATH"] = str(launch_dir) + os.pathsep + environment.get("PYTHONPATH", "")
+    command = [
+        str(repo_root / ".venv" / "bin" / "python"),
+        "-m",
+        "uvicorn",
+        "scripts.api.main:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(port),
+        "--log-config",
+        "scripts/api/logging.json",
+        "--timeout-graceful-shutdown",
+        "8",
+    ]
+    return command, launch_dir, environment, release_line
+
+
+def run_managed_api(
+    *,
+    repo_root: Path,
+    live_mode: bool | None = None,
+    port: int | None = None,
+    prepare_command: Callable[[Path, bool, int], tuple[list[str], Path, dict[str, str], str]] | None = None,
+) -> int:
+    """Run one API child in the foreground and preserve unexpected-exit evidence."""
+    root = repo_root.resolve()
+    configured_live, configured_port = _load_launch_config(root)
+    effective_live = configured_live if live_mode is None else live_mode
+    effective_port = configured_port if port is None else port
+    logs_dir = root / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    _pid_dir(root).mkdir(parents=True, exist_ok=True)
+    api_log = _api_log_path(root)
+    stderr_log = _api_stderr_log_path(root)
+    _rotate_log(api_log)
+    _rotate_log(stderr_log)
+    stopped_by_launchd = threading.Event()
+    child: subprocess.Popen[bytes] | None = None
+
+    def _on_stop(_signum: int, _frame: Any) -> None:
+        stopped_by_launchd.set()
+        if child is not None and child.poll() is None:
+            child.terminate()
+
+    previous_handlers: dict[int, Any] = {}
+    if threading.current_thread() is threading.main_thread():
+        for signum in (signal.SIGTERM, signal.SIGINT):
+            previous_handlers[signum] = signal.signal(signum, _on_stop)
+
+    stderr_tail: deque[str] = deque(maxlen=50)
+    try:
+        with api_log.open("ab") as combined, stderr_log.open("ab") as stderr_handle:
+            try:
+                factory = prepare_command or (
+                    lambda root_path, live, selected_port: _prepare_api_command(
+                        root_path, live_mode=live, port=selected_port
+                    )
+                )
+                command, launch_dir, environment, release_line = factory(root, effective_live, effective_port)
+                _append_log(combined, release_line)
+                if stopped_by_launchd.is_set():
+                    return 0
+                child = subprocess.Popen(
+                    command,
+                    cwd=launch_dir,
+                    env=environment,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            except Exception as exc:
+                message = f"API launch preparation failed: {type(exc).__name__}: {exc}"
+                _append_log(combined, message)
+                _append_log(stderr_handle, message)
+                _record_unexpected_exit(repo_root=root, pid=None, returncode=1, stderr_tail=[message])
+                return 1
+
+            assert child.stdout is not None
+            assert child.stderr is not None
+
+            def _pump(stream: Any, *, stderr: bool) -> None:
+                for line in iter(stream.readline, b""):
+                    combined.write(line)
+                    combined.flush()
+                    if stderr:
+                        stderr_handle.write(line)
+                        stderr_handle.flush()
+                        stderr_tail.append(line.decode("utf-8", errors="replace").rstrip())
+                stream.close()
+
+            stdout_thread = threading.Thread(target=_pump, args=(child.stdout,), kwargs={"stderr": False}, daemon=True)
+            stderr_thread = threading.Thread(target=_pump, args=(child.stderr,), kwargs={"stderr": True}, daemon=True)
+            stdout_thread.start()
+            stderr_thread.start()
+            returncode = child.wait()
+            stdout_thread.join(timeout=2)
+            stderr_thread.join(timeout=2)
+
+        if stopped_by_launchd.is_set():
+            return 0
+        _record_unexpected_exit(
+            repo_root=root,
+            pid=child.pid,
+            returncode=returncode,
+            stderr_tail=list(stderr_tail),
+        )
+        # A clean child exit is still unexpected for this always-on service;
+        # convert it to non-zero so KeepAlive.SuccessfulExit=false restarts it.
+        return 1
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_repo_arguments(command: argparse.ArgumentParser) -> None:
+        command.add_argument("--repo-root", type=Path, default=default_repo_root())
+        command.add_argument("--home", type=Path, default=default_home(), help=argparse.SUPPRESS)
+
+    install_parser = subparsers.add_parser("install", help="write the LaunchAgent plist")
+    add_repo_arguments(install_parser)
+    install_parser.add_argument("--dry-render", action="store_true", help="print the plist without writing it")
+
+    render_parser = subparsers.add_parser("render", help="print the LaunchAgent plist")
+    add_repo_arguments(render_parser)
+
+    start_parser = subparsers.add_parser("start", help="enable and start the supervised API")
+    add_repo_arguments(start_parser)
+    start_parser.add_argument("--live", action="store_true", help="serve the mutable checkout for emergency recovery")
+    start_parser.add_argument("--port", type=int, default=PORT, help=argparse.SUPPRESS)
+
+    stop_parser = subparsers.add_parser("stop", help="disable and unload the supervised API")
+    stop_parser.add_argument("--home", type=Path, default=default_home(), help=argparse.SUPPRESS)
+
+    uninstall_parser = subparsers.add_parser("uninstall", help="remove the LaunchAgent plist")
+    uninstall_parser.add_argument("--home", type=Path, default=default_home(), help=argparse.SUPPRESS)
+
+    status_parser = subparsers.add_parser("status", help="show persistent and launchd state")
+    status_parser.add_argument("--home", type=Path, default=default_home(), help=argparse.SUPPRESS)
+
+    run_parser = subparsers.add_parser("run", help=argparse.SUPPRESS)
+    run_parser.add_argument("--repo-root", type=Path, default=default_repo_root())
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    home = getattr(args, "home", default_home()).expanduser().resolve()
+    try:
+        if args.command in {"install", "render"}:
+            root = args.repo_root.expanduser().resolve()
+            rendered = render_plist(repo_root=root)
+            if args.command == "render" or args.dry_render:
+                print(rendered.decode("utf-8"), end="")
+                return 0
+            print(json.dumps(install(repo_root=root, home=home), sort_keys=True))
+            return 0
+        if args.command == "start":
+            print(
+                json.dumps(
+                    start(repo_root=args.repo_root.expanduser().resolve(), home=home, live_mode=args.live, port=args.port),
+                    sort_keys=True,
+                )
+            )
+            return 0
+        if args.command == "stop":
+            print(json.dumps(stop(home=home), sort_keys=True))
+            return 0
+        if args.command == "uninstall":
+            print(json.dumps(uninstall(home=home), sort_keys=True))
+            return 0
+        if args.command == "status":
+            payload, returncode = status(home=home)
+            print(json.dumps(payload, sort_keys=True))
+            return returncode
+        if args.command == "run":
+            return run_managed_api(repo_root=args.repo_root.expanduser().resolve())
+    except LaunchdError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -141,7 +141,7 @@ _DISPATCH_AGENT_CHOICES = (
     "agy",
     "cursor",
 )
-_MONITOR_API_BASE_URL = "http://localhost:8765"
+_MONITOR_API_BASE_URL = "http://127.0.0.1:8765"
 _logger = logging.getLogger(__name__)
 
 
@@ -823,6 +823,32 @@ def _resolve_primary_integrity_error(*, mode: str) -> str | None:
         "primary checkout manually; evidence is under "
         "data/telemetry/primary-integrity/events.jsonl."
     )
+
+
+def _warn_if_monitor_api_unreachable() -> None:
+    """Make a dead local Monitor API visible without making dispatch depend on it.
+
+    Dispatch remains a recovery path when the dashboard is down. The warning is
+    deliberately advisory, unlike primary-integrity drift, because workers can
+    still run with their file-based fallbacks and may be needed to repair the
+    API itself.
+    """
+    url = f"{_monitor_api_base_url()}/api/health"
+    try:
+        with urllib.request.urlopen(url, timeout=1) as response:
+            if response.status != 200:
+                raise MonitorApiUnavailable(f"HTTP {response.status}")
+    except (OSError, TimeoutError, urllib.error.URLError, MonitorApiUnavailable) as exc:
+        detail = f"{type(exc).__name__}: {exc}"
+        _append_dispatch_event("monitor_api_unreachable_pre_dispatch", url=url, detail=detail)
+        print(
+            "⚠ MONITOR API UNREACHABLE — dispatch will continue with offline fallbacks.\n"
+            f"   probe: GET {url}\n"
+            f"   error: {detail}\n"
+            "   recovery: ./services.sh status api; inspect .pids/api-last-crash.json; "
+            "then ./services.sh restart api",
+            file=sys.stderr,
+        )
 
 
 def _fetch_base(base: str) -> bool:
@@ -2764,6 +2790,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     if primary_integrity_error:
         print(primary_integrity_error, file=sys.stderr)
         return 2
+
+    _warn_if_monitor_api_unreachable()
 
     # Refuse to clobber a task that's still alive — whether it's in
     # "running" (worker up and executing) OR "spawning" (worker created

--- a/services.sh
+++ b/services.sh
@@ -10,6 +10,7 @@
 #   ./services.sh restart api        # Restart specific service
 #   ./services.sh start api --live   # Emergency mutable-checkout API mode
 #   ./services.sh status             # Show what's running
+#   ./services.sh supervise api install|status|uninstall
 #   ./services.sh build astro        # Run Astro production build (no dev server)
 #   ./services.sh clean astro        # Remove Astro build/cache outputs
 #   ./services.sh rebuild astro      # Run Astro clean then build
@@ -365,29 +366,44 @@ _is_running() {
     return 1
 }
 
-_api_launch_context() {
-    API_LAUNCH_CWD="$PROJECT_ROOT"
-    API_PYTHONPATH="$PROJECT_ROOT"
+_api_supervisor() {
+    if [[ -n "${SVC_API_SUPERVISOR_BIN:-}" ]]; then
+        "$SVC_API_SUPERVISOR_BIN" "$@"
+        return
+    fi
+    "$VENV/python" -m scripts.api.launchd_supervisor "$@"
+}
 
+_start_api_supervised() {
+    local args=(start --repo-root "$PROJECT_ROOT")
     if [[ "$API_LIVE_MODE" -eq 1 ]]; then
-        local warning="WARNING: API live mode enabled; serving mutable checkout code"
-        echo "  $warning" >&2
-        printf '%s\n' "$warning" >> "${SVC_LOG[api]}"
-        return 0
+        args+=(--live)
+        echo "  WARNING: API live mode enabled; serving mutable checkout code" >&2
     fi
 
-    local head_sha origin_main_sha release_dir prune_summary release_line
-    head_sha="$(git -C "$PROJECT_ROOT" rev-parse --verify HEAD)"
-    origin_main_sha="$(git -C "$PROJECT_ROOT" rev-parse --verify origin/main 2>/dev/null || echo unavailable)"
-    echo "  API release source: HEAD $head_sha; origin/main $origin_main_sha"
-    release_dir="$(cd "$PROJECT_ROOT" && "$VENV/python" -m scripts.api.release_snapshot build --repo-root "$PROJECT_ROOT" --sha "$head_sha")"
-    prune_summary="$(cd "$PROJECT_ROOT" && "$VENV/python" -m scripts.api.release_snapshot prune --repo-root "$PROJECT_ROOT" --keep 3)"
-    API_LAUNCH_CWD="$release_dir"
-    API_PYTHONPATH="$release_dir"
-    release_line="release: $head_sha data-root: $PROJECT_ROOT"
-    echo "  $release_line"
-    printf '%s\n' "$release_line" >> "${SVC_LOG[api]}"
-    echo "  API release prune: $prune_summary"
+    echo "  Starting api — ${SVC_DESC[api]} (launchd supervised)..."
+    if ! _api_supervisor "${args[@]}"; then
+        echo "  ERROR: launchd did not accept the API start request." >&2
+        return 1
+    fi
+
+    local pid=""
+    pid="$(_verified_port_pid api || true)"
+
+    if [[ -n "$pid" ]]; then
+        _sync_pidfile api "$pid"
+        echo "  api started (PID $pid, port ${SVC_PORT[api]}, log ${SVC_LOG[api]})"
+    else
+        rm -f "$(_pid_file api)"
+        echo "  api launch requested; waiting for launchd snapshot build (log ${SVC_LOG[api]})"
+    fi
+}
+
+_disable_api_supervisor() {
+    if ! _api_supervisor stop; then
+        echo "  ERROR: launchd did not confirm API supervision is disabled." >&2
+        return 1
+    fi
 }
 
 _start_service() {
@@ -435,48 +451,12 @@ _start_service() {
     fi
 
     if [[ "$name" == "api" ]]; then
-        # Log rotation check: size > 10MB (10485760 bytes)
-        local log_file="${SVC_LOG[$name]}"
-        if [[ -f "$log_file" ]]; then
-            local size
-            size=$(wc -c < "$log_file" | tr -d '[:space:]')
-            if (( size > 10485760 )); then
-                echo "  api log exceeds 10MB; rotating..."
-                rm -f "${log_file}.3"
-                [[ -f "${log_file}.2" ]] && mv "${log_file}.2" "${log_file}.3"
-                [[ -f "${log_file}.1" ]] && mv "${log_file}.1" "${log_file}.2"
-                mv "$log_file" "${log_file}.1"
-            fi
-        fi
-
-        # Crashloop backoff check: start < 60s ago
-        local last_start_file="$PIDS_DIR/${name}.last_start"
-        local now
-        now=$(date +%s)
-        if [[ -f "$last_start_file" ]]; then
-            local last_start
-            last_start=$(cat "$last_start_file" 2>/dev/null || echo 0)
-            local diff=$((now - last_start))
-            if (( diff < 60 )) && [[ "$FORCE" -ne 1 ]]; then
-                echo "  ERROR: $name started less than 60s ago (diff: ${diff}s); potential crashloop!" >&2
-                echo "  Use --force to override this safety guard." >&2
-                if [[ -f "$log_file" ]]; then
-                    echo "  Last 20 log lines:" >&2
-                    tail -n 20 "$log_file" >&2
-                fi
-                return 1
-            fi
-        fi
-        echo "$now" > "$last_start_file"
+        _start_api_supervised
+        return
     fi
 
     echo "  Starting $name — ${SVC_DESC[$name]}..."
-    if [[ "$name" == "api" ]]; then
-        _api_launch_context
-        cd "$API_LAUNCH_CWD"
-    else
-        cd "$PROJECT_ROOT"
-    fi
+    cd "$PROJECT_ROOT"
 
     local pid=""
     if [[ "$name" == "astro" ]] && command -v tmux >/dev/null 2>&1; then
@@ -494,20 +474,7 @@ _start_service() {
         done
     else
         # shellcheck disable=SC2086
-        if [[ "$name" == "api" ]]; then
-            (
-                unset GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY
-                unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE GIT_CEILING_DIRECTORIES
-                unset GIT_DISCOVERY_ACROSS_FILESYSTEM
-                export LEARN_UK_REPO_ROOT="$PROJECT_ROOT"
-                export GIT_DIR="$PROJECT_ROOT/.git"
-                export GIT_WORK_TREE="$PROJECT_ROOT"
-                export PYTHONPATH="$API_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}"
-                exec nohup ${SVC_CMD[$name]}
-            ) </dev/null >> "${SVC_LOG[$name]}" 2>&1 &
-        else
-            nohup ${SVC_CMD[$name]} </dev/null >> "${SVC_LOG[$name]}" 2>&1 &
-        fi
+        nohup ${SVC_CMD[$name]} </dev/null >> "${SVC_LOG[$name]}" 2>&1 &
         pid=$!
     fi
 
@@ -524,6 +491,13 @@ _stop_service() {
     local name="$1"
     local pidfile
     pidfile="$(_pid_file "$name")"
+
+    # ``launchctl disable`` happens before the listener is signalled. A
+    # deliberate ``services.sh stop api`` therefore cannot be resurrected by
+    # KeepAlive while the old process drains.
+    if [[ "$name" == "api" ]]; then
+        _disable_api_supervisor || return 1
+    fi
 
     local pid
     pid="$(_known_service_pid "$name" || true)"
@@ -612,7 +586,6 @@ _stop_service() {
         _astro_cleanup_cache
     fi
 
-    rm -f "$PIDS_DIR/${name}.last_start"
     echo "  $name stopped"
 }
 
@@ -795,6 +768,29 @@ case "$action" in
         echo ""
         _status
         ;;
+    supervise)
+        supervisor_service="${remaining_args[0]:-}"
+        supervisor_action="${remaining_args[1]:-}"
+        if [[ "$supervisor_service" != "api" ]]; then
+            echo "Usage: $0 supervise api <install|status|uninstall>" >&2
+            exit 1
+        fi
+        case "$supervisor_action" in
+            install)
+                _api_supervisor install --repo-root "$PROJECT_ROOT"
+                ;;
+            status)
+                _api_supervisor status
+                ;;
+            uninstall)
+                _api_supervisor uninstall
+                ;;
+            *)
+                echo "Usage: $0 supervise api <install|status|uninstall>" >&2
+                exit 1
+                ;;
+        esac
+        ;;
     build)
         if [[ "$#" -eq 0 ]]; then
             echo "Usage: $0 build <service>"
@@ -857,7 +853,7 @@ case "$action" in
         _status
         ;;
     *)
-        echo "Usage: $0 {start|stop|restart|status|build|clean|rebuild} [service ...]"
+        echo "Usage: $0 {start|stop|restart|status|supervise|build|clean|rebuild} [service ...]"
         echo ""
         echo "Services:"
         for name in $ALL_SERVICES; do
@@ -870,6 +866,8 @@ case "$action" in
         echo "  $0 start api --live       # Emergency API fallback (mutable checkout)"
         echo "  $0 stop sources           # Stop one"
         echo "  $0 restart                # Restart all"
+        echo "  $0 supervise api install  # Write the launchd supervisor plist"
+        echo "  $0 supervise api uninstall # Disable and remove the supervisor plist"
         echo "  $0 build astro            # Build Astro"
         echo "  $0 clean astro            # Clean Astro cache/build outputs"
         echo "  $0 rebuild astro          # Clean then build Astro"

--- a/tests/api/test_launchd_supervisor.py
+++ b/tests/api/test_launchd_supervisor.py
@@ -1,0 +1,131 @@
+"""Tests for persistent Monitor API launchd supervision."""
+
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import subprocess
+from pathlib import Path
+
+from scripts.api import launchd_supervisor as supervisor
+
+_ROOT = Path(__file__).resolve().parents[2]
+_VENV_PYTHON = _ROOT / ".venv" / "bin" / "python"
+
+
+def test_rendered_plist_uses_throttled_abnormal_exit_restart(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    payload = plistlib.loads(supervisor.render_plist(repo_root=repo))
+
+    assert payload["Label"] == supervisor.LABEL
+    assert payload["KeepAlive"] == {"SuccessfulExit": False}
+    assert payload["ThrottleInterval"] == supervisor.THROTTLE_INTERVAL_SECONDS
+    assert payload["RunAtLoad"] is True
+    assert payload["ProgramArguments"] == [
+        str(repo / ".venv" / "bin" / "python"),
+        "-m",
+        "scripts.api.launchd_supervisor",
+        "run",
+        "--repo-root",
+        str(repo),
+    ]
+
+
+def test_install_and_uninstall_preserve_crash_evidence(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    interpreter = repo / ".venv" / "bin" / "python"
+    implementation = repo / "scripts" / "api" / "launchd_supervisor.py"
+    interpreter.parent.mkdir(parents=True)
+    implementation.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+    implementation.write_text("# installed by test\n", encoding="utf-8")
+    home = tmp_path / "home"
+
+    installed = supervisor.install(repo_root=repo, home=home)
+    evidence = supervisor.crash_record_path(repo)
+    evidence.parent.mkdir(parents=True, exist_ok=True)
+    evidence.write_text('{"exit_code": 9}\n', encoding="utf-8")
+    monkeypatch.setattr(supervisor, "stop", lambda **_kwargs: {"loaded": False})
+
+    removed = supervisor.uninstall(home=home)
+
+    assert installed["changed"] is True
+    assert removed["crash_evidence_preserved"] is True
+    assert not supervisor.plist_path(home).exists()
+    assert evidence.exists()
+
+
+def test_stop_disables_before_bootout(tmp_path: Path, monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_launchctl(command: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if command[0] == "print":
+            return subprocess.CompletedProcess(command, 0 if len(commands) == 2 else 1, "", "not loaded")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(supervisor, "_launchctl", fake_launchctl)
+
+    result = supervisor.stop(home=tmp_path / "home")
+
+    assert result["loaded"] is False
+    assert [command[0] for command in commands] == ["disable", "print", "bootout", "print"]
+
+
+def test_unexpected_exit_records_signal_and_stderr_tail(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+
+    def fake_prepare(
+        _repo: Path,
+        _live: bool,
+        _port: int,
+    ) -> tuple[list[str], Path, dict[str, str], str]:
+        return (
+            [
+                str(_VENV_PYTHON),
+                "-c",
+                "import os, sys; sys.stderr.write('fatal before kill\\n'); sys.stderr.flush(); os.kill(os.getpid(), 9)",
+            ],
+            repo,
+            os.environ.copy(),
+            "test launch",
+        )
+
+    assert supervisor.run_managed_api(repo_root=repo, prepare_command=fake_prepare) == 1
+
+    record = json.loads(supervisor.crash_record_path(repo).read_text(encoding="utf-8"))
+    assert record["exit_code"] == 137
+    assert record["signal"] == "SIGKILL"
+    assert record["stderr_tail"] == ["fatal before kill"]
+    assert (repo / "logs" / "api.stderr.log").read_text(encoding="utf-8") == "fatal before kill\n"
+
+
+def test_unexpected_clean_exit_is_recorded_and_restarted_by_launchd_contract(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+
+    def fake_prepare(
+        _repo: Path,
+        _live: bool,
+        _port: int,
+    ) -> tuple[list[str], Path, dict[str, str], str]:
+        return [str(_VENV_PYTHON), "-c", "raise SystemExit(0)"], repo, os.environ.copy(), "test launch"
+
+    assert supervisor.run_managed_api(repo_root=repo, prepare_command=fake_prepare) == 1
+
+    record = json.loads(supervisor.crash_record_path(repo).read_text(encoding="utf-8"))
+    assert record["exit_code"] == 0
+    assert record["signal"] is None
+
+
+def test_runner_rotates_api_log_before_each_launch(tmp_path: Path) -> None:
+    log_path = tmp_path / "logs" / "api.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_bytes(b"A" * (supervisor._LOG_ROTATE_BYTES + 1))
+
+    supervisor._rotate_log(log_path)
+
+    rotated = log_path.with_name("api.log.1")
+    assert rotated.exists()
+    assert rotated.stat().st_size == supervisor._LOG_ROTATE_BYTES + 1

--- a/tests/api/test_services_ops.py
+++ b/tests/api/test_services_ops.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import contextlib
 import os
 import shutil
 import socket
 import subprocess
 import sys
+import threading
 import time
-import urllib.error
-import urllib.request
 from pathlib import Path
 
 import pytest
@@ -19,13 +17,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SERVICES_SH = PROJECT_ROOT / "services.sh"
 PIDS_DIR = PROJECT_ROOT / ".pids"
 LOGS_DIR = PROJECT_ROOT / "logs"
-# Prefer the repo venv when present; fall back to the running interpreter so
-# bare review worktrees (no .venv symlink) stay testable (cf. #4918, #4926).
-VENV_PYTHON = (
-    PROJECT_ROOT / ".venv" / "bin" / "python"
-    if (PROJECT_ROOT / ".venv" / "bin" / "python").exists()
-    else Path(sys.executable)
-)
+# Service commands must use the repository virtual environment, matching the
+# production launcher contract.
+VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
 
 def find_free_port() -> int:
     """Find a free TCP port on localhost."""
@@ -41,6 +35,11 @@ def is_port_free(port: int) -> bool:
             return True
         except OSError:
             return False
+
+
+def reap_process_on_exit(process: subprocess.Popen[object]) -> None:
+    """Prevent a killed dummy listener staying a zombie during shell waits."""
+    threading.Thread(target=process.wait, daemon=True).start()
 
 @pytest.fixture
 def temp_services_sh_real():
@@ -100,7 +99,7 @@ def temp_services_sh():
 
 @pytest.fixture
 def mock_lsof_env(tmp_path):
-    """Create a mock lsof script and expose it via SVC_LSOF_BIN env var."""
+    """Create mock lsof and launchd-supervisor commands for shell lifecycle tests."""
     shim_dir = tmp_path / "mock_bin"
     shim_dir.mkdir()
     lsof_script = shim_dir / "mock_lsof"
@@ -120,6 +119,14 @@ def mock_lsof_env(tmp_path):
     )
     lsof_script.chmod(0o755)
 
+    supervisor_capture = tmp_path / "supervisor_calls.txt"
+    supervisor_script = shim_dir / "mock_api_supervisor"
+    supervisor_script.write_text(
+        f"#!/bin/sh\nprintf '%s\\n' \"$@\" >> '{supervisor_capture}'\n",
+        encoding="utf-8",
+    )
+    supervisor_script.chmod(0o755)
+
     def _set_pids(pids: list[int]):
         mock_file.write_text("\n".join(str(p) for p in pids) + "\n", encoding="utf-8")
 
@@ -132,6 +139,8 @@ def mock_lsof_env(tmp_path):
         env["SVC_LSOF_BIN"] = "/nonexistent/lsof"
     else:
         env["SVC_LSOF_BIN"] = str(lsof_script.resolve())
+    env["SVC_API_SUPERVISOR_BIN"] = str(supervisor_script.resolve())
+    env["SVC_API_SUPERVISOR_CAPTURE"] = str(supervisor_capture)
 
     return _set_pids, _clear_pids, env
 
@@ -183,6 +192,7 @@ def test_pid_reconciliation(temp_services_sh, mock_lsof_env):
         str(VENV_PYTHON), "-c", "import time; time.sleep(30)",
         "scripts.api.main:app", "--host", "0.0.0.0", "--port", str(port)
     ])
+    reap_process_on_exit(proc)
     try:
         # Scenario A: pid-file vs listener mismatch -> 'pid file mismatch' warning + rewrite
         # Write a stale PID to the pid file
@@ -236,17 +246,10 @@ def test_pid_reconciliation(temp_services_sh, mock_lsof_env):
     assert "removing stale pid file" in res.stderr or "removing stale pid file" in res.stdout, f"stale pid check failed. returncode={res.returncode}\nstdout:\n{res.stdout}\nstderr:\n{res.stderr}"
     assert not api_pid_file.exists()
 
-def test_crashloop_backoff(temp_services_sh, mock_lsof_env):
-    """Test that starting the api twice within 60s raises an error without --force."""
+def test_api_start_delegates_recovery_to_launchd(temp_services_sh, mock_lsof_env):
+    """API start delegates restart/backoff to launchd instead of a shell timer."""
     script_path, _port = temp_services_sh
     _, _, env = mock_lsof_env
-    api_start_file = PIDS_DIR / "api.last_start"
-
-    # Write a last start timestamp from 10 seconds ago
-    now = int(time.time())
-    api_start_file.write_text(str(now - 10) + "\n", encoding="utf-8")
-
-    # Run start; should trigger the crashloop backoff error since it's <60s
     res = subprocess.run(
         [str(script_path), "start", "api"],
         capture_output=True,
@@ -255,40 +258,19 @@ def test_crashloop_backoff(temp_services_sh, mock_lsof_env):
         env=env
     )
 
-    assert res.returncode != 0, f"expected crashloop backoff non-zero return code. returncode={res.returncode}\nstdout:\n{res.stdout}\nstderr:\n{res.stderr}"
-    assert "ERROR: api started less than 60s ago" in res.stderr or "ERROR: api started less than 60s ago" in res.stdout, f"crashloop error message missing. stdout:\n{res.stdout}\nstderr:\n{res.stderr}"
-    assert "Use --force to override" in res.stderr or "Use --force to override" in res.stdout, f"force warning message missing. stdout:\n{res.stdout}\nstderr:\n{res.stderr}"
-
-    # Now run with --force and verify it bypasses the check (it should print starting)
-    res_force = subprocess.run(
-        [str(script_path), "start", "api", "--force"],
-        capture_output=True,
-        text=True,
-        cwd=str(PROJECT_ROOT),
-        env=env
-    )
-
-    assert "potential crashloop" not in res_force.stderr, f"unexpected crashloop warning in stderr.\nstdout:\n{res_force.stdout}\nstderr:\n{res_force.stderr}"
-    assert "potential crashloop" not in res_force.stdout, f"unexpected crashloop warning in stdout.\nstdout:\n{res_force.stdout}\nstderr:\n{res_force.stderr}"
-
-    # Clean up the started process if it actually launched
-    api_pid_file = PIDS_DIR / "api.pid"
-    if api_pid_file.exists():
-        try:
-            pid = int(api_pid_file.read_text(encoding="utf-8").strip())
-            os.kill(pid, 15)  # SIGTERM
-        except Exception:
-            pass
-    subprocess.run([str(script_path), "stop", "api"], capture_output=True, cwd=str(PROJECT_ROOT), env=env)
+    assert res.returncode == 0, res.stderr
+    assert "launchd supervised" in res.stdout
+    calls = Path(env["SVC_API_SUPERVISOR_CAPTURE"]).read_text(encoding="utf-8").splitlines()
+    assert calls[:3] == ["start", "--repo-root", str(PROJECT_ROOT)]
 
 
 @pytest.mark.skipif(
     not (PROJECT_ROOT / ".venv" / "bin" / "python").exists(),
     reason="boots the real services.sh, which requires the repo venv ($VENV/python)",
 )
-def test_live_fallback_starts_api_with_a_loud_warning(temp_services_sh_real, mock_lsof_env):
+def test_live_fallback_is_passed_to_launchd_with_a_loud_warning(temp_services_sh_real, mock_lsof_env):
     """``--live`` remains an explicit, visible escape hatch for API recovery."""
-    script_path, port = temp_services_sh_real
+    script_path, _port = temp_services_sh_real
     _, _, env = mock_lsof_env
     result = subprocess.run(
         [str(script_path), "start", "api", "--live", "--force"],
@@ -297,77 +279,10 @@ def test_live_fallback_starts_api_with_a_loud_warning(temp_services_sh_real, moc
         cwd=str(PROJECT_ROOT),
         env=env,
     )
-    try:
-        assert result.returncode == 0, result.stderr
-        assert "WARNING: API live mode enabled" in result.stderr
-        deadline = time.monotonic() + 10
-        while True:
-            try:
-                with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/health", timeout=0.5) as response:
-                    assert response.status == 200
-                    break
-            except (urllib.error.URLError, TimeoutError):
-                if time.monotonic() >= deadline:
-                    pytest.fail("live fallback did not boot the API")
-                time.sleep(0.05)
-    finally:
-        pid_file = PIDS_DIR / "api.pid"
-        if pid_file.exists():
-            pid = int(pid_file.read_text(encoding="utf-8").strip())
-            with contextlib.suppress(ProcessLookupError):
-                os.kill(pid, 15)
-            for _ in range(50):
-                try:
-                    os.kill(pid, 0)
-                except ProcessLookupError:
-                    break
-                time.sleep(0.1)
-            pid_file.unlink(missing_ok=True)
-
-def test_log_rotation(temp_services_sh, mock_lsof_env):
-    """Test size-based log rotation for api log file."""
-    script_path, _port = temp_services_sh
-    _, _, env = mock_lsof_env
-    api_log_file = LOGS_DIR / "api.log"
-    orig_content = api_log_file.read_bytes() if api_log_file.exists() else b""
-
-    try:
-        # Create a log file exceeding 10MB
-        large_size = 11 * 1024 * 1024
-        api_log_file.write_bytes(b"A" * large_size)
-
-        # Run patched services.sh start api (rotation happens first)
-        res = subprocess.run(
-            [str(script_path), "start", "api"],
-            capture_output=True,
-            text=True,
-            cwd=str(PROJECT_ROOT),
-            env=env
-        )
-        assert res.returncode == 0, f"start failed in log rotation test. returncode={res.returncode}\nstdout:\n{res.stdout}\nstderr:\n{res.stderr}"
-
-        # Verify rotation occurred: api.log.1 should exist and contain our "A"s
-        rotated_file = LOGS_DIR / "api.log.1"
-        assert rotated_file.exists()
-        assert rotated_file.stat().st_size == large_size
-
-    finally:
-        # Clean up the started process if it actually launched
-        api_pid_file = PIDS_DIR / "api.pid"
-        if api_pid_file.exists():
-            try:
-                pid = int(api_pid_file.read_text(encoding="utf-8").strip())
-                os.kill(pid, 15)  # SIGTERM
-            except Exception:
-                pass
-        subprocess.run([str(script_path), "stop", "api"], capture_output=True, cwd=str(PROJECT_ROOT), env=env)
-        # Restore original log
-        if api_log_file.exists():
-            api_log_file.unlink()
-        if (LOGS_DIR / "api.log.1").exists():
-            (LOGS_DIR / "api.log.1").unlink()
-        if len(orig_content) > 0:
-            api_log_file.write_bytes(orig_content)
+    assert result.returncode == 0, result.stderr
+    assert "WARNING: API live mode enabled" in result.stderr
+    calls = Path(env["SVC_API_SUPERVISOR_CAPTURE"]).read_text(encoding="utf-8").splitlines()
+    assert calls == ["start", "--repo-root", str(PROJECT_ROOT), "--live"]
 
 @pytest.mark.skipif(
     sys.platform != "darwin",
@@ -375,11 +290,10 @@ def test_log_rotation(temp_services_sh, mock_lsof_env):
     "behavior diverges on Linux CI (issue #4930 tracks the divergence). The "
     "platform-neutral logic tests (preload, guards, missing-lsof) run everywhere.",
 )
-def test_crashloop_backoff_clean_vs_crash(temp_services_sh, mock_lsof_env):
-    """Verify stop-then-start within 60s does NOT trip backoff, but start-after-crash within 60s DOES."""
+def test_stop_disables_supervision_before_killing_api_listener(temp_services_sh, mock_lsof_env):
+    """A deliberate stop asks launchd to disable before touching the listener."""
     script_path, port = temp_services_sh
     set_pids, _, env = mock_lsof_env
-    api_start_file = PIDS_DIR / "api.last_start"
     api_pid_file = PIDS_DIR / "api.pid"
 
     # Start a dummy sleep process
@@ -387,6 +301,7 @@ def test_crashloop_backoff_clean_vs_crash(temp_services_sh, mock_lsof_env):
         str(VENV_PYTHON), "-c", "import time; time.sleep(30)",
         "scripts.api.main:app", "--host", "0.0.0.0", "--port", str(port)
     ])
+    reap_process_on_exit(proc)
 
     try:
         # Write the actual listener PID to the pid file to simulate a running state
@@ -395,10 +310,6 @@ def test_crashloop_backoff_clean_vs_crash(temp_services_sh, mock_lsof_env):
         # Configure lsof shim to report our dummy process pid
         set_pids([proc.pid])
 
-        # Write a last start timestamp from 10 seconds ago
-        api_start_file.write_text(str(int(time.time()) - 10) + "\n", encoding="utf-8")
-
-        # Now run stop (operator-initiated clean stop). This should succeed, kill proc, and delete api.last_start.
         res_stop = subprocess.run(
             [str(script_path), "stop", "api"],
             capture_output=True,
@@ -407,20 +318,7 @@ def test_crashloop_backoff_clean_vs_crash(temp_services_sh, mock_lsof_env):
             env=env
         )
         assert res_stop.returncode == 0, f"stop failed. returncode={res_stop.returncode}\nstdout:\n{res_stop.stdout}\nstderr:\n{res_stop.stderr}"
-        assert not api_start_file.exists(), f"last_start file was not deleted on clean stop\nstdout:\n{res_stop.stdout}\nstderr:\n{res_stop.stderr}"
-
-        # Now run start. Since api.last_start was deleted, it should NOT trigger backoff.
-        res_start = subprocess.run(
-            [str(script_path), "start", "api"],
-            capture_output=True,
-            text=True,
-            cwd=str(PROJECT_ROOT),
-            env=env
-        )
-        assert "potential crashloop" not in res_start.stderr, f"unexpected crashloop warning in stderr.\nstdout:\n{res_start.stdout}\nstderr:\n{res_start.stderr}"
-        assert "potential crashloop" not in res_start.stdout, f"unexpected crashloop warning in stdout.\nstdout:\n{res_start.stdout}\nstderr:\n{res_start.stderr}"
-        assert "ERROR: api started less than 60s ago" not in res_start.stderr, f"expected no crashloop error. stdout:\n{res_start.stdout}\nstderr:\n{res_start.stderr}"
-        assert "ERROR: api started less than 60s ago" not in res_start.stdout, f"expected no crashloop error. stdout:\n{res_start.stdout}\nstderr:\n{res_start.stderr}"
+        assert Path(env["SVC_API_SUPERVISOR_CAPTURE"]).read_text(encoding="utf-8").splitlines() == ["stop"]
 
     finally:
         if proc.poll() is None:
@@ -429,27 +327,15 @@ def test_crashloop_backoff_clean_vs_crash(temp_services_sh, mock_lsof_env):
         # Clean up any started background processes from the start command
         subprocess.run([str(script_path), "stop", "api"], capture_output=True, cwd=str(PROJECT_ROOT), env=env)
 
-    # Case 2: Start-after-crash (no clean-stop marker) within 60s DOES trigger backoff.
-    api_start_file.write_text(str(int(time.time()) - 10) + "\n", encoding="utf-8")
-
-    res_crash_start = subprocess.run(
-        [str(script_path), "start", "api"],
-        capture_output=True,
-        text=True,
-        cwd=str(PROJECT_ROOT),
-        env=env
-    )
-    assert res_crash_start.returncode != 0, f"expected crash start to fail. returncode={res_crash_start.returncode}\nstdout:\n{res_crash_start.stdout}\nstderr:\n{res_crash_start.stderr}"
-    assert "potential crashloop" in res_crash_start.stderr or "potential crashloop" in res_crash_start.stdout, f"expected crashloop warning. stdout:\n{res_crash_start.stdout}\nstderr:\n{res_crash_start.stderr}"
-
 @pytest.mark.skipif(
     shutil.which("lsof") is None or sys.platform != "darwin",
     reason="macOS local-ops integration; logic covered hermetically above"
 )
-def test_pid_reconciliation_integration(temp_services_sh_real):
+def test_pid_reconciliation_integration(temp_services_sh_real, mock_lsof_env):
     """Integration test using real sockets and real lsof on macOS."""
     script_path, port = temp_services_sh_real
     api_pid_file = PIDS_DIR / "api.pid"
+    set_pids, _, env = mock_lsof_env
 
     # Start a dummy listener process with the API signature configured for our dynamic port
     dummy_code = (
@@ -464,6 +350,7 @@ def test_pid_reconciliation_integration(temp_services_sh_real):
         str(VENV_PYTHON), "-c", dummy_code,
         "scripts.api.main:app", "--host", "0.0.0.0", "--port", str(port)
     ])
+    reap_process_on_exit(proc)
 
     try:
         # Wait a moment for port to bind
@@ -476,13 +363,15 @@ def test_pid_reconciliation_integration(temp_services_sh_real):
 
         # Write stale PID to the pid file
         api_pid_file.write_text("999999\n", encoding="utf-8")
+        set_pids([proc.pid])
 
         # Run patched services.sh status
         res = subprocess.run(
             [str(script_path), "status", "api"],
             capture_output=True,
             text=True,
-            cwd=str(PROJECT_ROOT)
+            cwd=str(PROJECT_ROOT),
+            env=env,
         )
 
         assert "WARNING: pid file mismatch" in res.stderr or "WARNING: pid file mismatch" in res.stdout
@@ -495,7 +384,8 @@ def test_pid_reconciliation_integration(temp_services_sh_real):
             [str(script_path), "stop", "api"],
             capture_output=True,
             text=True,
-            cwd=str(PROJECT_ROOT)
+            cwd=str(PROJECT_ROOT),
+            env=env,
         )
 
         # Verify the dummy process was killed

--- a/tests/test_delegate_check_budget.py
+++ b/tests/test_delegate_check_budget.py
@@ -78,6 +78,34 @@ class _FakeBudgetResponse:
         return json.dumps(payload).encode("utf-8")
 
 
+class _FakeHealthResponse:
+    """Fake for the /api/health probe cmd_dispatch runs before every dispatch (#5817)."""
+
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return False
+
+
+def _urlopen_routing(budget_response):
+    """Route urlopen by URL: /api/health → healthy probe, anything else → budget fake.
+
+    cmd_dispatch probes /api/health unconditionally (#5817 monitor supervision);
+    budget fixtures only model /api/state/routing-budget, so the probe needs its
+    own response or it trips on the missing ``status`` attribute.
+    """
+
+    def _fake(url, *_args, **_kwargs):
+        if "/api/health" in str(url):
+            return _FakeHealthResponse()
+        return budget_response
+
+    return _fake
+
+
 class _FakeStdin:
     def write(self, _data):
         pass
@@ -128,7 +156,7 @@ def test_check_budget_warns_when_agent_mismatch(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_args, **_kwargs: _FakeBudgetResponse("codex"),
+        _urlopen_routing(_FakeBudgetResponse("codex")),
     )
 
     rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
@@ -142,10 +170,12 @@ def test_check_budget_warns_when_agent_mismatch(monkeypatch, tmp_path, capsys):
 def test_check_budget_skipped_when_force_agent(monkeypatch, tmp_path, capsys):
     _patch_spawn(monkeypatch, tmp_path)
 
-    def fail_if_called(*_args, **_kwargs):
-        raise AssertionError("urlopen should not be called with --force-agent")
+    def fail_on_budget_fetch(url, *_args, **_kwargs):
+        if "/api/health" in str(url):
+            return _FakeHealthResponse()
+        raise AssertionError("routing-budget urlopen should not be called with --force-agent")
 
-    monkeypatch.setattr(delegate.urllib.request, "urlopen", fail_if_called)
+    monkeypatch.setattr(delegate.urllib.request, "urlopen", fail_on_budget_fetch)
 
     rc = delegate.cmd_dispatch(_dispatch_args("--check-budget", "--force-agent"))
 
@@ -170,10 +200,12 @@ def test_check_budget_skipped_when_api_down(monkeypatch, tmp_path, capsys):
 def test_check_budget_off_by_default(monkeypatch, tmp_path, capsys):
     _patch_spawn(monkeypatch, tmp_path)
 
-    def fail_if_called(*_args, **_kwargs):
-        raise AssertionError("urlopen should not be called unless --check-budget is passed")
+    def fail_on_budget_fetch(url, *_args, **_kwargs):
+        if "/api/health" in str(url):
+            return _FakeHealthResponse()
+        raise AssertionError("routing-budget urlopen should not be called unless --check-budget is passed")
 
-    monkeypatch.setattr(delegate.urllib.request, "urlopen", fail_if_called)
+    monkeypatch.setattr(delegate.urllib.request, "urlopen", fail_on_budget_fetch)
 
     rc = delegate.cmd_dispatch(_dispatch_args())
 
@@ -187,7 +219,7 @@ def test_check_budget_dry_run_does_not_spawn(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_args, **_kwargs: _FakeBudgetResponse("codex"),
+        _urlopen_routing(_FakeBudgetResponse("codex")),
     )
 
     def fail_if_spawned(*_args, **_kwargs):
@@ -211,8 +243,10 @@ def test_check_budget_hard_sub_on_near_cap_fresh(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_a, **_k: _FakeBudgetResponse(
-            "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False
+        _urlopen_routing(
+            _FakeBudgetResponse(
+                "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False
+            )
         ),
     )
 
@@ -232,8 +266,10 @@ def test_check_budget_no_hard_sub_on_stale(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_a, **_k: _FakeBudgetResponse(
-            "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=3, stale=True
+        _urlopen_routing(
+            _FakeBudgetResponse(
+                "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=3, stale=True
+            )
         ),
     )
 
@@ -311,8 +347,10 @@ def test_check_budget_no_hard_sub_without_yaml_mapping(monkeypatch, tmp_path, ca
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_a, **_k: _FakeBudgetResponse(
-            "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False
+        _urlopen_routing(
+            _FakeBudgetResponse(
+                "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False
+            )
         ),
     )
 
@@ -330,8 +368,10 @@ def test_check_budget_hard_sub_ignores_unknown_fallback_target(monkeypatch, tmp_
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_a, **_k: _FakeBudgetResponse(
-            "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False
+        _urlopen_routing(
+            _FakeBudgetResponse(
+                "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False
+            )
         ),
     )
 

--- a/tests/test_delegate_primary_integrity.py
+++ b/tests/test_delegate_primary_integrity.py
@@ -144,6 +144,40 @@ def test_gate_fail_open_on_watchdog_error(primary_repo, monkeypatch, capsys):
     assert "watchdog errored" in capsys.readouterr().err
 
 
+def test_monitor_api_failure_warns_but_does_not_block_dispatch(monkeypatch, capsys):
+    def unavailable(*_args, **_kwargs):
+        raise OSError("Connection refused")
+
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(delegate.urllib.request, "urlopen", unavailable)
+    monkeypatch.setattr(delegate, "_append_dispatch_event", lambda event, **fields: events.append((event, fields)))
+
+    assert delegate._warn_if_monitor_api_unreachable() is None
+
+    output = capsys.readouterr().err
+    assert "MONITOR API UNREACHABLE" in output
+    assert "offline fallbacks" in output
+    assert "services.sh status api" in output
+    assert events[0][0] == "monitor_api_unreachable_pre_dispatch"
+
+
+def test_healthy_monitor_api_emits_no_dispatch_warning(monkeypatch, capsys):
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(delegate.urllib.request, "urlopen", lambda *_args, **_kwargs: Response())
+
+    delegate._warn_if_monitor_api_unreachable()
+
+    assert capsys.readouterr().err == ""
+
+
 # ---------------------------------------------------------------------------
 # instructive fetch failure (no silent stale-base fallback)
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_timing_hook.py
+++ b/tests/test_tool_timing_hook.py
@@ -1,0 +1,68 @@
+"""Contract tests for the fire-and-forget tool-timing hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from scripts.api.telemetry_router import ToolTimingIngest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_HOOK = _ROOT / "agents_extensions" / "shared" / "hooks" / "tool-timing.sh"
+
+
+def test_hook_posts_json_that_validates_against_tool_timing_model() -> None:
+    posted: list[dict[str, object]] = []
+    received = threading.Event()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            content_length = int(self.headers["Content-Length"])
+            posted.append(json.loads(self.rfile.read(content_length)))
+            self.send_response(200)
+            self.end_headers()
+            received.set()
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        event = {
+            "tool_name": 'Bash "quoted" \\ path\nnext',
+            "duration_ms": 12.5,
+            "tool_use_id": 'tool "id"',
+            "session_id": "session\\id",
+            "hook_event_name": "PostToolUseFailure",
+        }
+        environment = os.environ.copy()
+        environment["TOOL_TIMING_API_URL"] = f"http://127.0.0.1:{server.server_port}/tool-timings"
+        result = subprocess.run(
+            ["/bin/bash", str(_HOOK)],
+            input=json.dumps(event),
+            capture_output=True,
+            text=True,
+            env=environment,
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+        assert received.wait(timeout=3), "hook did not post telemetry"
+    finally:
+        server.shutdown()
+        thread.join(timeout=3)
+        server.server_close()
+
+    assert len(posted) == 1
+    payload = posted[0]
+    model = ToolTimingIngest.model_validate(payload)
+    assert model.tool_name == event["tool_name"]
+    assert model.duration_ms == 13
+    assert model.tool_use_id == event["tool_use_id"]
+    assert model.session_id == event["session_id"]
+    assert model.failed is True


### PR DESCRIPTION
## Summary

- Add a throttled macOS LaunchAgent supervisor that disables before operator stop and stores durable crash evidence.
- Fix macOS Bash tool-timing telemetry serialization without weakening the API schema.
- Warn (do not block) dispatches when the Monitor API is unavailable.

## Validation

- `.venv/bin/python -m pytest -q tests/api/test_launchd_supervisor.py tests/test_tool_timing_hook.py tests/test_delegate_primary_integrity.py tests/api/test_services_ops.py` — 27 passed
- `.venv/bin/ruff check` — existing unrelated repository violations; changed-path Ruff check passed
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py` — passed

## Runtime note

The live LaunchAgent correctly created a durable failure record in this sparse worktree because `curriculum/` is intentionally absent. The destructive restart/kill recovery proof must run in a full checkout; the operator explicitly requires no sparse-tree invention.