### PR TITLE
fix(hooks): stop Codex rollover deadlocks

### DIFF
--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -85,12 +85,6 @@
           },
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/context-monitor.sh\"",
-            "timeout": 5,
-            "statusMessage": "Checking context budget"
-          },
-          {
-            "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/stamp-pytest.sh\"",
             "timeout": 3,
             "statusMessage": "Stamping pytest telemetry"

--- a/agents_extensions/shared/hooks/context-monitor.sh
+++ b/agents_extensions/shared/hooks/context-monitor.sh
@@ -107,12 +107,8 @@ PCT=$((TOKENS * 100 / WINDOW))
 
 if [ -n "${SESSION_HANDOFF_AGENT:-}" ]; then
   HANDOFF_AGENT="$SESSION_HANDOFF_AGENT"
-elif [[ "${0:-}" == *"/.codex/"* ]]; then
-  HANDOFF_AGENT="codex"
 elif [[ "${0:-}" == *"/.gemini/"* ]]; then
   HANDOFF_AGENT="gemini"
-elif [ -n "${CODEX_THREAD_ID:-}${CODEX_SESSION_ID:-}" ]; then
-  HANDOFF_AGENT="codex"
 else
   HANDOFF_AGENT="claude"
 fi

--- a/agents_extensions/shared/hooks/context-monitor.sh
+++ b/agents_extensions/shared/hooks/context-monitor.sh
@@ -6,6 +6,17 @@
 # size is a compatibility estimate only. Unknown capacity suppresses percentage
 # warnings rather than fabricating a 1M or auto-compaction denominator.
 
+# Native Codex owns context compaction. A PostToolUse warning is injected as
+# higher-priority context, so imperative rollover text can trap the agent:
+# every tool call re-injects STOP, while the suggested `prepare` command is not
+# repeatable once a pending lease exists. Keep this manual rollover hook silent
+# for Codex; its native runtime remains responsible for compaction/continuation.
+if [ "${SESSION_HANDOFF_AGENT:-}" = "codex" ] \
+  || [[ "${0:-}" == *"/.codex/"* ]] \
+  || [ -n "${CODEX_THREAD_ID:-}${CODEX_SESSION_ID:-}" ]; then
+  exit 0
+fi
+
 # Skip in non-interactive / subagent / pipeline contexts.
 if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$LEARN_UK_PIPELINE" ] || [ -n "$GEMINI_SESSION" ]; then
   exit 0

--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -120,7 +120,18 @@ def _tool_input(payload: dict) -> dict:
 
 
 def _payload_cwd(payload: dict) -> str:
-    cwd = payload.get("cwd") or payload.get("working_directory")
+    # A tool-specific working directory is the execution cwd and therefore
+    # outranks the session-level cwd carried by the hook envelope. Unified
+    # exec calls commonly keep the session cwd at the primary checkout while
+    # placing the dispatch worktree in tool_input.workdir.
+    tool_input = _tool_input(payload)
+    cwd = (
+        tool_input.get("cwd")
+        or tool_input.get("workdir")
+        or tool_input.get("working_directory")
+        or payload.get("cwd")
+        or payload.get("working_directory")
+    )
     return str(cwd) if cwd else os.getcwd()
 
 
@@ -305,9 +316,16 @@ def _tokenize(command: str) -> list[str]:
     """
     try:
         lexer = shlex.shlex(
-            _strip_heredoc_bodies(command), posix=True, punctuation_chars=True
+            _strip_heredoc_bodies(command),
+            posix=True,
+            punctuation_chars="();<>|&\n",
         )
         lexer.whitespace_split = True
+        # Keep newline out of whitespace so shlex returns it as a control
+        # operator. Otherwise adjacent lines collapse into one segment: a later
+        # command's option (for example `find -print`) can be mistaken for an
+        # earlier `sed` invocation's `-i` flag and produce bogus write targets.
+        lexer.whitespace = " \t\r"
         return list(lexer)
     except ValueError:
         # Unbalanced quotes / un-tokenizable — fail open (the shell will reject

--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -305,6 +305,37 @@ def _strip_heredoc_bodies(command: str) -> str:
     return "\n".join(kept)
 
 
+def _collapse_shell_line_continuations(command: str) -> str:
+    """Remove shell ``\\`` + newline continuations outside single quotes.
+
+    The shell removes these pairs before parsing command boundaries, including
+    inside double quotes. Leaving them in the guard's token stream turns one
+    mutating command into two apparent segments and can hide the target of an
+    in-place editor. Backslash-newline remains literal inside single quotes.
+    """
+    collapsed: list[str] = []
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(command):
+        char = command[i]
+        if char == "\\" and not in_single and i + 1 < len(command):
+            following = command[i + 1]
+            if following == "\n":
+                i += 2
+                continue
+            collapsed.extend((char, following))
+            i += 2
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        collapsed.append(char)
+        i += 1
+    return "".join(collapsed)
+
+
 def _tokenize(command: str) -> list[str]:
     """Quote-aware tokens with redirection/control operators kept separate.
 
@@ -316,7 +347,7 @@ def _tokenize(command: str) -> list[str]:
     """
     try:
         lexer = shlex.shlex(
-            _strip_heredoc_bodies(command),
+            _collapse_shell_line_continuations(_strip_heredoc_bodies(command)),
             posix=True,
             punctuation_chars="();<>|&\n",
         )

--- a/tests/test_context_window_consumers.py
+++ b/tests/test_context_window_consumers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -368,6 +369,32 @@ def test_context_monitor_is_silent_for_native_codex(
     completed = subprocess.run(
         [os.fspath(CONTEXT_MONITOR)],
         input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+        timeout=30,
+    )
+
+    assert completed.stdout == ""
+
+
+def test_context_monitor_is_silent_from_deployed_codex_path(tmp_path: Path) -> None:
+    deployed = tmp_path / ".codex" / "hooks" / "context-monitor.sh"
+    deployed.parent.mkdir(parents=True)
+    shutil.copy2(CONTEXT_MONITOR, deployed)
+    env = os.environ.copy()
+    for identity_var in (
+        "SESSION_HANDOFF_AGENT",
+        "CODEX_THREAD_ID",
+        "CODEX_SESSION_ID",
+    ):
+        env.pop(identity_var, None)
+
+    completed = subprocess.run(
+        [os.fspath(deployed)],
+        input="{}",
         text=True,
         capture_output=True,
         check=True,

--- a/tests/test_context_window_consumers.py
+++ b/tests/test_context_window_consumers.py
@@ -18,6 +18,7 @@ SUBAGENT_STATUSLINE = (
     PROJECT_ROOT / "agents_extensions/shared/statusline/subagent-statusline.sh"
 )
 CONTEXT_MONITOR = PROJECT_ROOT / "agents_extensions/shared/hooks/context-monitor.sh"
+CODEX_HOOKS = PROJECT_ROOT / "agents_extensions/codex/hooks.json"
 
 
 def _record(*, actual_window: int | None = 272_000) -> dict[str, object]:
@@ -341,6 +342,55 @@ def test_context_monitor_unknown_capacity_emits_no_warning(tmp_path: Path) -> No
     assert completed.stdout == ""
 
 
+@pytest.mark.parametrize(
+    ("identity_env", "value"),
+    [
+        ("SESSION_HANDOFF_AGENT", "codex"),
+        ("CODEX_THREAD_ID", "codex-thread"),
+        ("CODEX_SESSION_ID", "codex-session"),
+    ],
+)
+def test_context_monitor_is_silent_for_native_codex(
+    tmp_path: Path,
+    identity_env: str,
+    value: str,
+) -> None:
+    project, record_path = _fake_project(tmp_path, _record(actual_window=100))
+    transcript = tmp_path / "monitor.jsonl"
+    _write_transcript(transcript, input_tokens=100, cache_tokens=0)
+    payload = {
+        "session_id": "status-session",
+        "transcript_path": os.fspath(transcript),
+    }
+    env = _environment(project, record_path)
+    env[identity_env] = value
+
+    completed = subprocess.run(
+        [os.fspath(CONTEXT_MONITOR)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+        timeout=30,
+    )
+
+    assert completed.stdout == ""
+
+
+def test_codex_hook_ssot_does_not_register_manual_context_monitor() -> None:
+    config = json.loads(CODEX_HOOKS.read_text(encoding="utf-8"))
+    commands = [
+        hook["command"]
+        for groups in config["hooks"].values()
+        for group in groups
+        for hook in group.get("hooks", [])
+    ]
+
+    assert all("context-monitor.sh" not in command for command in commands)
+
+
 @pytest.mark.parametrize("script", [STATUSLINE, GEMINI_STATUSLINE, CONTEXT_MONITOR])
 def test_context_consumer_shell_syntax(script: Path) -> None:
     completed = subprocess.run(
@@ -420,4 +470,3 @@ def test_statusline_prefer_handoff_over_compaction(tmp_path: Path) -> None:
 
     assert "[compacts: 1]" in completed.stdout
     assert "HANDOFF SUGGESTED" in completed.stdout
-

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -112,6 +112,12 @@ def test_bash_multiline_read_only_commands_do_not_merge_editor_flags():
     assert hook.bash_write_targets(command) == []
 
 
+def test_bash_line_continuation_keeps_in_place_editor_target():
+    command = "sed -i \\\n-e 's/old/new/' curriculum/tracked.md"
+
+    assert hook.bash_write_targets(command) == ["curriculum/tracked.md"]
+
+
 # ===========================================================================
 # Pure extraction — structured write tools
 # ===========================================================================
@@ -239,6 +245,38 @@ def test_bash_tool_input_workdir_controls_relative_write_resolution(repo: Path):
     result = _run(repo, payload)
 
     assert result.returncode == 0, result.stderr
+
+
+def test_bash_tool_input_primary_workdir_cannot_be_spoofed_by_payload_cwd(repo: Path):
+    worktree = repo / ".worktrees/dispatch/claude/task-1"
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(worktree),
+        "tool_input": {
+            "command": "echo x > curriculum/tracked.md",
+            "workdir": str(repo),
+        },
+    }
+
+    result = _run(repo, payload)
+
+    assert result.returncode == 2, result.stderr
+    assert "tracked_primary_checkout" in result.stderr
+
+
+def test_bash_line_continuation_cannot_hide_primary_in_place_edit(repo: Path):
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {
+            "command": "sed -i \\\n-e 's/old/new/' curriculum/tracked.md",
+        },
+    }
+
+    result = _run(repo, payload)
+
+    assert result.returncode == 2, result.stderr
+    assert "tracked_primary_checkout" in result.stderr
 
 
 def test_write_capable_bash_redirect_blocked(repo: Path):

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -102,6 +102,16 @@ def test_bash_no_false_positive_write(command):
     assert hook.bash_write_targets(command) == []
 
 
+def test_bash_multiline_read_only_commands_do_not_merge_editor_flags():
+    command = (
+        "sed -n '1,220p' agents_extensions/codex/hooks.json\n"
+        "find agents_extensions/shared/hooks -maxdepth 1 -type f -print | sort\n"
+        'rg -n "additionalContext|BLOCKED" agents_extensions/shared/hooks'
+    )
+
+    assert hook.bash_write_targets(command) == []
+
+
 # ===========================================================================
 # Pure extraction — structured write tools
 # ===========================================================================
@@ -213,6 +223,22 @@ def test_read_only_bash_allowed(repo: Path):
         payload = {"tool_name": "Bash", "cwd": str(repo), "tool_input": {"command": command}}
         result = _run(repo, payload)
         assert result.returncode == 0, f"{command!r}: {result.stderr}"
+
+
+def test_bash_tool_input_workdir_controls_relative_write_resolution(repo: Path):
+    worktree = repo / ".worktrees/dispatch/claude/task-1"
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(repo),
+        "tool_input": {
+            "command": "echo x > curriculum/tracked.md",
+            "workdir": str(worktree),
+        },
+    }
+
+    result = _run(repo, payload)
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_write_capable_bash_redirect_blocked(repo: Path):


### PR DESCRIPTION
## Summary

- remove the manual context-monitor PostToolUse registration from the Codex hook SSOT
- keep the shared monitor silent for native Codex as defense in depth
- preserve shell newlines in the primary-write guard and honor tool-specific workdir
- collapse shell backslash-newline continuations so an in-place edit cannot hide its target
- add regressions for the rollover trap, multiline false positive, workdir spoof direction, deployed Codex path, and continuation bypass

Part of #5201.

## Root cause

Codex already owns automatic context compaction, but the shared monitor injected imperative STOP instructions after every tool call and recommended a non-idempotent prepare command. Separately, the write guard discarded newlines during shell tokenization, preferred the session cwd over the actual tool workdir, and treated shell line continuations as command boundaries.

## Verification

- 509 hook/guard/deployment tests passed after the final review fixes
- focused hook tests: 98 passed; targeted review regressions: 4 passed
- session setup shell harness passed
- all 12 shell hooks pass `bash -n`
- Ruff, `git diff --check`, agent-trailer lint, and staged OPSEC lint passed
- direct hook entry-point proof: Codex monitor is silent; the multiline read-only command exits 0; a continued `sed -i` targeting primary is blocked
- the live generated `.codex` deploy matches the fixed SSOT and no longer registers context-monitor

## Independent review

Claude Sonnet 5 reviewed the latest head at high effort, reported zero findings, and marked correctness `correct` with 0.85 confidence. The formal approval verdict is published on this PR. Auto-merge is armed pending the remaining CI shard.
