### PR TITLE
fix(ci): make ledger aggregate check bounded

### DIFF
--- a/tests/test_source_inventory_review_decisions.py
+++ b/tests/test_source_inventory_review_decisions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from pathlib import Path
 
@@ -15,6 +16,7 @@ FIRST_BATCH = (
 )
 EXPECTED_COMMITTED_DECISION_FILE_COUNT = 51
 COMMITTED_DECISION_FILES = tuple(sorted(decisions.DEFAULT_DECISION_DIR.glob("*.yaml")))
+DECISION_LINE = re.compile(r"^\s+decision:\s+([a-z_]+)\s*$")
 
 
 def _write_decision_file(path: Path, payload: dict[str, object]) -> None:
@@ -66,6 +68,17 @@ def _minimal_payload() -> dict[str, object]:
     }
 
 
+def _decision_counts_from_validated_lines(path: Path) -> Counter[str]:
+    """Count decision rows without constructing a second 41 MB YAML object graph."""
+    counts: Counter[str] = Counter()
+    with path.open(encoding="utf-8") as stream:
+        for line in stream:
+            match = DECISION_LINE.fullmatch(line.rstrip("\n"))
+            if match:
+                counts[match.group(1)] += 1
+    return counts
+
+
 def test_committed_first_source_inventory_review_batch_validates() -> None:
     summary = decisions.validate_committed_decision_files([FIRST_BATCH])
 
@@ -99,10 +112,9 @@ def test_default_committed_decision_files_keep_aggregate_floors() -> None:
     decision_counts: Counter[str] = Counter()
     total_rows = 0
     for path in COMMITTED_DECISION_FILES:
-        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
-        rows = payload["decisions"]
-        total_rows += len(rows)
-        decision_counts.update(row["decision"] for row in rows)
+        counts = _decision_counts_from_validated_lines(path)
+        total_rows += sum(counts.values())
+        decision_counts.update(counts)
 
     assert len(COMMITTED_DECISION_FILES) >= 1
     assert total_rows >= 20
@@ -128,6 +140,9 @@ def test_default_committed_decision_files_validate(
     assert summary["path"] == str(ledger_path)
     assert summary["rows"] >= 1
     assert summary["decision_counts"]
+    line_counts = _decision_counts_from_validated_lines(ledger_path)
+    assert sum(line_counts.values()) == summary["rows"]
+    assert line_counts == Counter(summary["decision_counts"])
 
 
 def test_committed_decision_validation_reuses_shared_source_index(

--- a/tests/test_source_inventory_review_decisions.py
+++ b/tests/test_source_inventory_review_decisions.py
@@ -113,7 +113,7 @@ def test_default_committed_decision_files_keep_aggregate_floors(
 ) -> None:
     sample_summary = decisions.validate_decision_file(
         FIRST_BATCH,
-        source_index=committed_source_index,
+        source_index=dict(committed_source_index),
     )
     sample_counts = _decision_counts_from_validated_lines(FIRST_BATCH)
     assert sum(sample_counts.values()) == sample_summary["rows"]

--- a/tests/test_source_inventory_review_decisions.py
+++ b/tests/test_source_inventory_review_decisions.py
@@ -108,7 +108,17 @@ def test_default_committed_decision_file_parametrization_is_complete() -> None:
     assert len(set(COMMITTED_DECISION_FILES)) == len(COMMITTED_DECISION_FILES)
 
 
-def test_default_committed_decision_files_keep_aggregate_floors() -> None:
+def test_default_committed_decision_files_keep_aggregate_floors(
+    committed_source_index: dict[tuple[str, str, str], SourceInventoryRecord],
+) -> None:
+    sample_summary = decisions.validate_decision_file(
+        FIRST_BATCH,
+        source_index=committed_source_index,
+    )
+    sample_counts = _decision_counts_from_validated_lines(FIRST_BATCH)
+    assert sum(sample_counts.values()) == sample_summary["rows"]
+    assert sample_counts == Counter(sample_summary["decision_counts"])
+
     decision_counts: Counter[str] = Counter()
     total_rows = 0
     for path in COMMITTED_DECISION_FILES:


### PR DESCRIPTION
## Summary

Close the remaining source-inventory ledger timeout exposed by the post-merge
`main` run.

- Replace the single-node 41 MB YAML object-graph rebuild used only for
  aggregate floors with a streaming decision-line count.
- Preserve full semantic validation for every committed ledger.
- In every parametrized ledger node, assert that the streaming count exactly
  matches the semantic validator's row and decision counts.

This does not lower a threshold or skip a test. It removes duplicated parsing
from the aggregate node while binding its result to the full validators.

## Failure evidence

On `main` run `30202514206`, shard 3 started
`test_default_committed_decision_files_keep_aggregate_floors` at
12:54:33 UTC and its worker died at 12:56:33 UTC: the exact 120-second pytest
timeout. The same node took 72.71 seconds on the faster PR runner.

## Verification

- Aggregate node: 1 passed in 0.71s; call duration 0.21s.
- Full file, serial: 75 passed in 26.73s.
- Full file, 10 xdist workers: 75 passed in 36.48s after the self-contained
  semantic proof was added.
- Isolated self-contained aggregate proof after review fixes: passed in 4.10s;
  call duration 0.96s, setup 0.87s.
- Ruff, `git diff --check`, staged OPSEC, and agent-trailer lint passed.

## Review

Claude Sonnet 5 found two P3 hardening opportunities: make the aggregate node's
semantic proof self-contained and defensively copy the session fixture. Both
were fixed. The final exact-head re-review found zero remaining defects.
