### PR TITLE
docs(rules): forbid scratch files in primary checkout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ eats it. Full protocol: `agents_extensions/shared/rules/workflow.md` § Work int
 ## Global Codex Operating Rules
 
 - Start every task at the repository root and run `git status --short --branch` before editing. **This is a read-only preflight/orientation step only.** Do not use this as permission to implement from the primary checkout.
+- **The primary checkout is strictly read-only.** Do not drop scratch files, test scripts, or command outputs into its root directory under any circumstances. If you need a temporary file for discovery or testing, put it in your assigned worktree or an ignored scratch directory (like `batch_state/`).
 - **Any implementation edit, branch work, commit, or PR MUST happen from a worktree (`.worktrees/dispatch/<agent>/<task>/`)** unless the user explicitly authorizes an exception. This prose rule is a reminder/backstop; mechanical enforcement is tracked in #4444-#4450.
 - Preserve user and unrelated changes; do not revert, delete, or clean up work outside the task.
 - Use multi-agent delegation for non-trivial work that can run in parallel without shared-file contention.

--- a/agents_extensions/shared/rules/operator-expectations.md
+++ b/agents_extensions/shared/rules/operator-expectations.md
@@ -20,6 +20,10 @@ tie-breakers.
    and the services'; agents live under `.worktrees/`.** Primary
    `~/projects/learn-ukrainian` is a **normal non-bare** checkout, pinned to `main`, where
    `git status` works; agents implement only in `.worktrees/dispatch/<agent>/<task>/`.
+   **The primary checkout is strictly read-only.** Do not drop scratch files, test scripts,
+   or command outputs into its root directory under any circumstances. If you need a
+   temporary file for discovery or testing, put it in your assigned worktree or an ignored
+   scratch directory (like `batch_state/`).
    `core.bare=true` on primary is a **bug** to heal (`git config core.bare false` +
    `extensions.worktreeConfig=true`), never an intentional mode. PRs for everything — no
    direct commits to main. After merge: delete branch local + remote, remove worktree. Close


### PR DESCRIPTION
## Summary
- make the primary checkout explicitly and strictly read-only for agents
- prohibit scratch files, test scripts, and command outputs in the primary root
- direct temporary discovery and test artifacts to the assigned worktree or ignored `batch_state/`

## Verification
- `git diff --check`
- `node_modules/.bin/markdownlint-cli2 agents_extensions/shared/rules/operator-expectations.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

`AGENTS.md` retains two pre-existing Markdownlint violations (MD018 line 63; MD012 line 441 in `HEAD`); this PR does not alter them.