### PR TITLE
fix(hooks): bind pytest stamps to exact worktrees (#5827)

### DIFF
--- a/.githooks/check-pytest-stamp.py
+++ b/.githooks/check-pytest-stamp.py
@@ -10,10 +10,18 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import time
 from pathlib import Path
 
-MARKER_MAX_AGE_SECONDS = 10 * 60
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from pytest_stamp import (
+    MARKER_MAX_AGE_SECONDS,
+    StampIdentity,
+    marker_is_fresh,
+    marker_path,
+    stamp_identity_for_branch,
+)
+
 TRIGGER_PREFIXES = (
     "tests/",
     "scripts/",
@@ -98,33 +106,8 @@ def _branch_from_local_ref(local_ref: str, local_sha: str) -> str | None:
     return branches[0] if len(branches) == 1 else None
 
 
-def _marker_path(branch: str) -> Path:
-    """Resolve the stamp path exactly as ``${TMPDIR:-/tmp}`` does for the writer.
-
-    The writer is ``agents_extensions/shared/hooks/stamp-pytest.sh``. Two ways the
-    two sides can disagree, both of which send this hook looking somewhere the stamp
-    was never written:
-
-    * EMPTY ``TMPDIR`` — shell parameter expansion treats it as unset, so ``or`` is
-      used here rather than a ``get()`` default (which would yield ``""``).
-    * NON-ABSOLUTE ``TMPDIR`` — each side would resolve it against its own working
-      directory, and those differ: the stamper runs from a PostToolUse cwd, while git
-      runs this non-bare hook from the worktree root. Neither side can honour a
-      relative value safely, so both fall back to ``/tmp``.
-    """
-    tmpdir = os.environ.get("TMPDIR") or "/tmp"
-    if not tmpdir.startswith("/"):
-        tmpdir = "/tmp"
-    return Path(tmpdir) / f"learn-uk-pytest.{branch}.stamp"
-
-
-def _marker_is_fresh(marker: Path) -> bool | None:
-    try:
-        return time.time() - marker.stat().st_mtime <= MARKER_MAX_AGE_SECONDS
-    except FileNotFoundError:
-        return False
-    except OSError:
-        return None
+def _stamp_identity(branch: str) -> StampIdentity | None:
+    return stamp_identity_for_branch(Path.cwd(), branch)
 
 
 def _block_message(branch: str, marker: Path) -> None:
@@ -189,12 +172,18 @@ def main() -> int:
         if branch is None:
             _verification_error("could not determine the local source branch for the pytest stamp")
             return 1
-        marker = _marker_path(branch)
-        marker_is_fresh = _marker_is_fresh(marker)
-        if marker_is_fresh is None:
+        identity = _stamp_identity(branch)
+        if identity is None:
+            _verification_error(
+                f"could not resolve the registered worktree for local branch '{branch}'"
+            )
+            return 1
+        marker = marker_path(identity)
+        is_fresh = marker_is_fresh(marker, identity)
+        if is_fresh is None:
             _verification_error(f"could not inspect the pytest stamp at {marker}")
             return 1
-        if not marker_is_fresh:
+        if not is_fresh:
             _block_message(branch, marker)
             return 1
 

--- a/.githooks/pytest_stamp.py
+++ b/.githooks/pytest_stamp.py
@@ -296,7 +296,7 @@ def _is_no_run_pytest(segment: list[str]) -> bool:
     return any(token == "--co" or token.partition("=")[0] in _NO_RUN_OPTIONS for token in segment)
 
 
-def _command_shape(command: str) -> tuple[int, bool] | None:
+def _command_is_compound_pytest(command: str) -> bool | None:
     tokens = _shell_tokens(command)
     if not tokens:
         return None
@@ -306,8 +306,7 @@ def _command_shape(command: str) -> tuple[int, bool] | None:
     pytest_invocations = [segment for segment in segments if _is_pytest_segment(segment)]
     if len(pytest_invocations) != 1 or _is_no_run_pytest(pytest_invocations[0]):
         return None
-    pytest_segments = len(pytest_invocations)
-    return pytest_segments, compound or len(segments) != 1
+    return compound or len(segments) != 1
 
 
 def _command_output(value: Any) -> str:
@@ -352,16 +351,15 @@ def payload_proves_pytest_success(payload: dict[str, Any]) -> bool:
     if not isinstance(command, str) or not command.strip():
         return False
 
-    shape = _command_shape(command)
-    if shape is None:
+    compound = _command_is_compound_pytest(command)
+    if compound is None:
         return False
-    pytest_segments, compound = shape
     event_name = str(payload.get("hook_event_name") or "")
-    if event_name == "PostToolUse" and not compound and pytest_segments == 1:
+    if event_name == "PostToolUse" and not compound:
         return True
 
     summaries = _passing_summaries(_command_output(payload))
-    return len(summaries) >= pytest_segments and all(summaries)
+    return bool(summaries) and all(summaries)
 
 
 def record_payload(payload: dict[str, Any]) -> bool:

--- a/.githooks/pytest_stamp.py
+++ b/.githooks/pytest_stamp.py
@@ -1,0 +1,392 @@
+"""Shared pytest-stamp identity and writer for agent and Git hooks.
+
+The agent hook records a successful pytest run. The Git pre-push hook reads the
+same marker before allowing pytest-triggering changes to update ``main``.
+Both sides must use the exact same repository, worktree, branch, and TMPDIR
+contract or the guard alternates between false blocks and false greens.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MARKER_MAX_AGE_SECONDS = 10 * 60
+MARKER_VERSION = 2
+_CONTROL_OPERATORS = frozenset({"&&", "||", ";", "|", "&"})
+_PYTEST_WRAPPERS = frozenset({"env", "nohup", "sudo", "time"})
+_FAILURE_OUTCOMES = frozenset({"failed", "error", "errors"})
+_CWD_MUTATORS = frozenset({"cd", "popd", "pushd"})
+_NO_RUN_OPTIONS = frozenset(
+    {
+        "--collect-only",
+        "--fixtures",
+        "--fixtures-per-test",
+        "--help",
+        "--markers",
+        "--trace-config",
+        "--version",
+        "-h",
+    }
+)
+_SUMMARY_RE = re.compile(
+    r"(?P<counts>(?:\d+\s+[A-Za-z_]+(?:,\s*|\s+))+)"
+    r"in\s+\d+(?:\.\d+)?s\b",
+    re.IGNORECASE,
+)
+_COUNT_RE = re.compile(r"(?P<count>\d+)\s+(?P<outcome>[A-Za-z_]+)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class StampIdentity:
+    """The checkout identity a pytest result belongs to."""
+
+    repository: Path
+    worktree: Path
+    branch: str
+    key: str
+
+
+def _git_environment() -> dict[str, str]:
+    """Remove inherited Git selectors that could redirect repository discovery."""
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
+def _git_output(cwd: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            check=False,
+            cwd=cwd,
+            env=_git_environment(),
+            text=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _absolute_git_path(cwd: Path, value: str) -> Path:
+    path = Path(value)
+    if not path.is_absolute():
+        path = cwd / path
+    return path.resolve()
+
+
+def stamp_identity(worktree: Path, branch: str | None = None) -> StampIdentity | None:
+    """Resolve a collision-resistant identity for one registered Git worktree."""
+    top_output = _git_output(worktree, "rev-parse", "--show-toplevel")
+    common_output = _git_output(worktree, "rev-parse", "--git-common-dir")
+    branch_output = (
+        f"{branch}\n"
+        if branch is not None
+        else _git_output(worktree, "symbolic-ref", "--quiet", "--short", "HEAD")
+    )
+    if top_output is None or common_output is None or branch_output is None:
+        return None
+
+    top_value = top_output.strip()
+    common_value = common_output.strip()
+    branch_value = branch_output.strip()
+    if not top_value or not common_value or not branch_value:
+        return None
+
+    top = _absolute_git_path(worktree, top_value)
+    common = _absolute_git_path(worktree, common_value)
+    raw_identity = "\0".join((str(common), str(top), branch_value))
+    key = hashlib.sha256(raw_identity.encode("utf-8")).hexdigest()[:24]
+    return StampIdentity(
+        repository=common,
+        worktree=top,
+        branch=branch_value,
+        key=key,
+    )
+
+
+def stamp_identity_for_branch(repo_cwd: Path, branch: str) -> StampIdentity | None:
+    """Find the unique registered worktree that currently owns ``branch``."""
+    output = _git_output(repo_cwd, "worktree", "list", "--porcelain")
+    if output is None:
+        return None
+
+    expected_ref = f"refs/heads/{branch}"
+    matches: list[Path] = []
+    worktree: Path | None = None
+    branch_ref: str | None = None
+
+    def finish_record() -> None:
+        if worktree is not None and branch_ref == expected_ref:
+            matches.append(worktree)
+
+    for line in (*output.splitlines(), ""):
+        if not line:
+            finish_record()
+            worktree = None
+            branch_ref = None
+        elif line.startswith("worktree "):
+            worktree = Path(line.removeprefix("worktree ")).resolve()
+        elif line.startswith("branch "):
+            branch_ref = line.removeprefix("branch ")
+
+    if len(matches) != 1:
+        return None
+    return stamp_identity(matches[0], branch)
+
+
+def _tmpdir(environment: dict[str, str] | None = None) -> Path:
+    env = os.environ if environment is None else environment
+    raw = env.get("TMPDIR") or "/tmp"
+    if not raw.startswith("/"):
+        raw = "/tmp"
+    return Path(raw)
+
+
+def marker_path(
+    identity: StampIdentity,
+    environment: dict[str, str] | None = None,
+) -> Path:
+    """Return the namespaced marker path shared by the writer and reader."""
+    return _tmpdir(environment) / f"learn-uk-pytest.v{MARKER_VERSION}.{identity.key}.stamp"
+
+
+def marker_is_fresh(
+    marker: Path,
+    identity: StampIdentity,
+    *,
+    now: float | None = None,
+) -> bool | None:
+    """Return freshness, or ``None`` when marker inspection itself failed."""
+    try:
+        if marker.read_text(encoding="utf-8").strip() != identity.key:
+            return False
+        current_time = time.time() if now is None else now
+        return current_time - marker.stat().st_mtime <= MARKER_MAX_AGE_SECONDS
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return None
+
+
+def write_marker(identity: StampIdentity) -> bool:
+    """Atomically refresh one marker without exposing a partially written file."""
+    marker = marker_path(identity)
+    temporary: Path | None = None
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, raw_path = tempfile.mkstemp(
+            dir=marker.parent,
+            prefix=f".{marker.name}.",
+        )
+        temporary = Path(raw_path)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(f"{identity.key}\n")
+        os.replace(temporary, marker)
+        temporary = None
+    except OSError:
+        return False
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+    return True
+
+
+def _tool_input(payload: dict[str, Any]) -> dict[str, Any]:
+    for key in ("tool_input", "arguments", "input", "params"):
+        value = payload.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def payload_workdir(payload: dict[str, Any]) -> Path | None:
+    """Resolve the Bash execution cwd from structured hook fields.
+
+    Tool-specific cwd fields outrank the session envelope. A relative tool cwd
+    is resolved only against an absolute envelope cwd; guessing from the hook
+    process cwd would recreate the primary-vs-worktree bug this contract fixes.
+    """
+    tool_input = _tool_input(payload)
+    envelope_raw = payload.get("cwd") or payload.get("working_directory")
+    tool_raw = (
+        tool_input.get("cwd")
+        or tool_input.get("workdir")
+        or tool_input.get("working_directory")
+    )
+
+    envelope = Path(str(envelope_raw)).expanduser() if envelope_raw else None
+    candidate = Path(str(tool_raw)).expanduser() if tool_raw else envelope
+    if candidate is None:
+        return None
+    if candidate.is_absolute():
+        return candidate.resolve()
+    if envelope is None or not envelope.is_absolute():
+        return None
+    return (envelope / candidate).resolve()
+
+
+def _shell_tokens(command: str) -> list[str] | None:
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        return list(lexer)
+    except ValueError:
+        return None
+
+
+def _split_segments(tokens: list[str]) -> tuple[list[list[str]], bool]:
+    segments: list[list[str]] = []
+    current: list[str] = []
+    compound = False
+    for token in tokens:
+        if token in _CONTROL_OPERATORS or (token and set(token) <= {"&", "|", ";"}):
+            compound = True
+            if current:
+                segments.append(current)
+                current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(current)
+    return segments, compound
+
+
+def _is_assignment(token: str) -> bool:
+    name, separator, _ = token.partition("=")
+    return bool(separator and name and name.replace("_", "a").isalnum() and not name[0].isdigit())
+
+
+def _is_pytest_segment(segment: list[str]) -> bool:
+    index = 0
+    while index < len(segment) and (
+        segment[index] in _PYTEST_WRAPPERS or _is_assignment(segment[index])
+    ):
+        index += 1
+    if index >= len(segment):
+        return False
+    executable = segment[index]
+    if executable == "pytest" or executable.endswith("/pytest"):
+        return True
+    is_project_python = executable == ".venv/bin/python" or executable.endswith("/.venv/bin/python")
+    if is_project_python and segment[index + 1 : index + 3] == ["-m", "pytest"]:
+        return True
+    return segment[index : index + 3] == ["dagger", "call", "pytest"]
+
+
+def _is_no_run_pytest(segment: list[str]) -> bool:
+    return any(token == "--co" or token.partition("=")[0] in _NO_RUN_OPTIONS for token in segment)
+
+
+def _command_shape(command: str) -> tuple[int, bool] | None:
+    tokens = _shell_tokens(command)
+    if not tokens:
+        return None
+    segments, compound = _split_segments(tokens)
+    if any(segment and segment[0] in _CWD_MUTATORS for segment in segments):
+        return None
+    pytest_invocations = [segment for segment in segments if _is_pytest_segment(segment)]
+    if len(pytest_invocations) != 1 or _is_no_run_pytest(pytest_invocations[0]):
+        return None
+    pytest_segments = len(pytest_invocations)
+    return pytest_segments, compound or len(segments) != 1
+
+
+def _command_output(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        direct: list[str] = []
+        for key in ("tool_output", "output", "result", "stdout", "stderr"):
+            item = value.get(key)
+            if isinstance(item, str) and item:
+                direct.append(item)
+        if direct:
+            return "\n".join(direct)
+        nested: list[str] = []
+        for key in ("tool_response", "tool_result"):
+            item = _command_output(value.get(key))
+            if item:
+                nested.append(item)
+        return "\n".join(nested)
+    if isinstance(value, list):
+        return "\n".join(filter(None, (_command_output(item) for item in value)))
+    return ""
+
+
+def _passing_summaries(output: str) -> list[bool]:
+    summaries: list[bool] = []
+    for match in _SUMMARY_RE.finditer(output):
+        outcomes = {
+            item.group("outcome").lower(): int(item.group("count"))
+            for item in _COUNT_RE.finditer(match.group("counts"))
+        }
+        passed = outcomes.get("passed", 0) > 0
+        failed = any(outcomes.get(outcome, 0) > 0 for outcome in _FAILURE_OUTCOMES)
+        summaries.append(passed and not failed)
+    return summaries
+
+
+def payload_proves_pytest_success(payload: dict[str, Any]) -> bool:
+    """Accept only a proven pytest success for the command shape and event."""
+    tool_input = _tool_input(payload)
+    command = tool_input.get("command") or payload.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return False
+
+    shape = _command_shape(command)
+    if shape is None:
+        return False
+    pytest_segments, compound = shape
+    event_name = str(payload.get("hook_event_name") or "")
+    if event_name == "PostToolUse" and not compound and pytest_segments == 1:
+        return True
+
+    summaries = _passing_summaries(_command_output(payload))
+    return len(summaries) >= pytest_segments and all(summaries)
+
+
+def record_payload(payload: dict[str, Any]) -> bool:
+    """Write a stamp only when checkout identity and pytest success are proven."""
+    if not payload_proves_pytest_success(payload):
+        return False
+    workdir = payload_workdir(payload)
+    if workdir is None:
+        return False
+    identity = stamp_identity(workdir)
+    if identity is None:
+        return False
+    return write_marker(identity)
+
+
+def main() -> int:
+    """Agent hooks are observational: inability to stamp must not block a tool."""
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if isinstance(payload, dict):
+        record_payload(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents_extensions/shared/hooks/stamp-pytest.sh
+++ b/agents_extensions/shared/hooks/stamp-pytest.sh
@@ -19,6 +19,10 @@ if [ ! -x "$PYTHON" ]; then
   PYTHON="$PRIMARY_ROOT/.venv/bin/python"
 fi
 
+# Do not fall back to python/python3 from PATH. Repository commands require the
+# project venv, and a system interpreter can belong to another checkout or lack
+# pinned dependencies (#5134). Stamping is observational: no proven project
+# interpreter means no marker, and the later pre-push guard remains fail-closed.
 [ -x "$PYTHON" ] || exit 0
 [ -f "$HELPER" ] || HELPER="$SOURCE_ROOT/.githooks/pytest_stamp.py"
 [ -f "$HELPER" ] || exit 0

--- a/agents_extensions/shared/hooks/stamp-pytest.sh
+++ b/agents_extensions/shared/hooks/stamp-pytest.sh
@@ -1,177 +1,26 @@
 #!/bin/bash
-# Hook: PostToolUse / PostToolUseFailure - stamp recent pytest runs for the #M-7 push guard.
+# Hook: PostToolUse / PostToolUseFailure — record proven pytest success for #M-7.
 
 set -u
 
-command -v jq >/dev/null 2>&1 || exit 0
-
-INPUT=$(</dev/stdin)
-COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
-[ -n "$COMMAND" ] || exit 0
-
-# Resolve project root robustly by walking up until package.json is found
-DIR="$(cd "$(dirname "$0")" && pwd)"
-while [ "$DIR" != "/" ] && [ ! -f "$DIR/package.json" ]; do
-  DIR="$(dirname "$DIR")"
+SOURCE_ROOT="$(cd "$(dirname "$0")" && pwd)"
+while [ "$SOURCE_ROOT" != "/" ] && [ ! -f "$SOURCE_ROOT/package.json" ]; do
+  SOURCE_ROOT="$(dirname "$SOURCE_ROOT")"
 done
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$DIR}"
-PYTHON="$PROJECT_DIR/.venv/bin/python"
-# The embedded parser is pure stdlib — any python3 works. Without this fallback
-# the PostToolUseFailure path silently no-ops wherever the project venv is not
-# resolvable (e.g. worktrees without a linked .venv), which made the compound-
-# failure fix environment-dependent.
-[ -x "$PYTHON" ] || PYTHON="$(command -v python3 || true)"
+[ -f "$SOURCE_ROOT/package.json" ] || exit 0
 
-HAS_PYTEST=1
-if [ -x "$PYTHON" ]; then
-  # Pass the entire JSON input to python to parse tool_output/tool_response if needed
-  printf '%s' "$INPUT" | "$PYTHON" -c '
-from __future__ import annotations
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$SOURCE_ROOT}"
+PYTHON="$PROJECT_ROOT/.venv/bin/python"
+HELPER="$PROJECT_ROOT/.githooks/pytest_stamp.py"
 
-import json
-import re
-import shlex
-import sys
-from typing import Any
-
-payload_str = sys.stdin.read()
-command = ""
-payload = {}
-try:
-    payload = json.loads(payload_str)
-    if isinstance(payload, dict):
-        command = (payload.get("tool_input") or {}).get("command") or payload.get("command") or ""
-except Exception:
-    command = payload_str
-
-if not command:
-    command = payload_str
-
-if not isinstance(command, str) or not command.strip():
-    sys.exit(1)
-
-try:
-    tokens = shlex.split(command, posix=True)
-except ValueError:
-    sys.exit(1)
-
-segments = []
-current = []
-for tok in tokens:
-    if tok in ("&&", "||", ";", "|"):
-        if current:
-            segments.append(current)
-            current = []
-    else:
-        current.append(tok)
-if current:
-    segments.append(current)
-
-wrappers = {"sudo", "time", "env", "nohup"}
-has_pytest = False
-for seg in segments:
-    i = 0
-    while i < len(seg) and seg[i] in wrappers:
-        i += 1
-    if i >= len(seg):
-        continue
-    # Support absolute path python pytest runs (e.g. /abs/path/.venv/bin/python)
-    is_python = seg[i] == ".venv/bin/python" or seg[i].endswith("/.venv/bin/python")
-    if is_python and seg[i + 1 : i + 3] == ["-m", "pytest"]:
-        has_pytest = True
-        break
-    if seg[i] == "pytest":
-        has_pytest = True
-        break
-    if seg[i : i + 3] == ["dagger", "call", "pytest"]:
-        has_pytest = True
-        break
-
-if not has_pytest:
-    sys.exit(1)
-
-# If the overall command succeeded (PostToolUse) or event name is empty (tests/fallback),
-# we can touch the stamp immediately.
-event_name = (payload.get("hook_event_name") if isinstance(payload, dict) else "") or ""
-if event_name in ("PostToolUse", ""):
-    sys.exit(0)
-
-# If the overall command failed (PostToolUseFailure), we check if the pytest segment
-# itself succeeded by parsing the tool output/stdout for a passing pytest summary.
-# This prevents compound command failures (e.g. pytest && failing-cmd) from blocking pushes.
-def _find_command_output(val: Any) -> str:
-    if isinstance(val, str):
-        return val
-    if isinstance(val, dict):
-        for key in ("tool_output", "output", "result", "stdout", "stderr"):
-            o = val.get(key)
-            if isinstance(o, str) and o:
-                return o
-        for key in ("tool_response", "tool_input", "tool_result"):
-            o = _find_command_output(val.get(key))
-            if o:
-                return o
-        parts = []
-        for v in val.values():
-            o = _find_command_output(v)
-            if o:
-                parts.append(o)
-        return "\n".join(parts)
-    if isinstance(val, list):
-        parts = []
-        for item in val:
-            o = _find_command_output(item)
-            if o:
-                parts.append(o)
-        return "\n".join(parts)
-    return ""
-
-output_str = _find_command_output(payload)
-pytest_summary_pattern = re.compile(
-    r"(?:={2,}\s+)?(?:(?P<counts>[0-9a-zA-Z\s,]+)\s+in\s+(?P<duration>[0-9.]+)s)(?:\s+=+)?"
-)
-matches = list(pytest_summary_pattern.finditer(output_str))
-if matches:
-    last_match = matches[-1]
-    counts = last_match.group("counts")
-    # Require a positive "passed" signal: "no tests ran in 0.12s" and stray
-    # "<word> in N.Ns" lines from other tools must NOT count as a green run.
-    if "passed" in counts and "failed" not in counts and "error" not in counts:
-        sys.exit(0)
-
-sys.exit(1)
-'
-  HAS_PYTEST=$?
-else
-  # Bash fallback if python is not available (only matches command on success event or empty event)
-  EVENT_NAME=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null)
-  if [ -z "$EVENT_NAME" ] || [ "$EVENT_NAME" = "PostToolUse" ]; then
-    if [[ "$COMMAND" =~ (^|[[:space:];|&])[^[:space:]]*\.venv/bin/python[[:space:]]+-m[[:space:]]+pytest($|[[:space:]]) ]] || \
-       [[ "$COMMAND" =~ (^|[[:space:];|&])pytest($|[[:space:]]) ]] || \
-       [[ "$COMMAND" =~ (^|[[:space:];|&])dagger[[:space:]]+call[[:space:]]+pytest($|[[:space:]]) ]]; then
-      HAS_PYTEST=0
-    fi
-  fi
+if [ ! -x "$PYTHON" ]; then
+  COMMON_DIR=$(git -C "$SOURCE_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0
+  PRIMARY_ROOT="$(dirname "$COMMON_DIR")"
+  PYTHON="$PRIMARY_ROOT/.venv/bin/python"
 fi
 
-[ "$HAS_PYTEST" -eq 0 ] || exit 0
+[ -x "$PYTHON" ] || exit 0
+[ -f "$HELPER" ] || HELPER="$SOURCE_ROOT/.githooks/pytest_stamp.py"
+[ -f "$HELPER" ] || exit 0
 
-BRANCH=$(git branch --show-current 2>/dev/null) || exit 0
-[ -n "$BRANCH" ] || exit 0
-
-# A non-absolute TMPDIR would be resolved against this hook's cwd, while the
-# reader (.githooks/pre-push) resolves it against the worktree root git runs it
-# from — so the stamp would be written where the reader never looks. Neither side
-# can honour a relative value safely; both fall back to /tmp. Empty is already
-# handled by ${TMPDIR:-/tmp} treating it as unset.
-STAMP_DIR="${TMPDIR:-/tmp}"
-case "$STAMP_DIR" in
-    /*) ;;
-    *) STAMP_DIR="/tmp" ;;
-esac
-
-STAMP="${STAMP_DIR}/learn-uk-pytest.${BRANCH}.stamp"
-mkdir -p "$(dirname "$STAMP")" 2>/dev/null || exit 0
-touch "$STAMP" 2>/dev/null || true
-
-exit 0
+exec "$PYTHON" "$HELPER"

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -29,13 +29,18 @@ identity key, so legacy, empty, or partially written marker files fail closed.
 The writer trusts a successful hook event only for one direct pytest invocation.
 Compound commands and failure events require a clean pytest summary in the
 captured output; masked failures, zero-test runs, multiple pytest invocations,
-and collection/help-only modes do not stamp. The exact checkout comes from the
-structured Bash `cwd`/`workdir` payload. A command-level `cd`/`pushd` is not
-guessed from shell text—set the tool's `workdir` instead.
+and collection/help-only modes do not stamp. Only named result/output envelope
+fields are inspected; arbitrary metadata and command-input strings are not
+trusted as test output. The exact checkout comes from the structured Bash
+`cwd`/`workdir` payload. A command-level `cd`/`pushd` is not guessed from shell
+text—set the tool's `workdir` instead.
 
 Stamping remains observational and exits successfully when it cannot prove the
-run. The subsequent push then fails with a rerun instruction. An intentional
-operator bypass remains `git push --no-verify`.
+run. It uses the checkout or shared primary `.venv/bin/python` and deliberately
+does not fall back to a system `python3`, which could belong to another checkout
+or violate the repository's pinned-environment contract. The subsequent push
+then fails with a rerun instruction. An intentional operator bypass remains
+`git push --no-verify`.
 
 ## Primary-checkout write guard (#4448)
 

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -14,6 +14,29 @@ Codex hook facts verified from the current OpenAI Codex manual on 2026-07-05:
 - Hook command trust is separate from project trust. For automation that already
   vets the hook source, use `--dangerously-bypass-hook-trust`.
 
+## Pytest stamp and pre-push guard
+
+`agents_extensions/shared/hooks/stamp-pytest.sh` is the deployed
+`PostToolUse`/`PostToolUseFailure` writer. It delegates parsing and marker
+identity to `.githooks/pytest_stamp.py`; `.githooks/check-pytest-stamp.py` uses
+that same contract in the tracked `pre-push` chain.
+
+A marker is namespaced to the canonical Git common directory, exact registered
+worktree, and checked-out branch. A fresh marker from another clone, worktree,
+or same-named branch cannot satisfy the guard. Marker contents carry the same
+identity key, so legacy, empty, or partially written marker files fail closed.
+
+The writer trusts a successful hook event only for one direct pytest invocation.
+Compound commands and failure events require a clean pytest summary in the
+captured output; masked failures, zero-test runs, multiple pytest invocations,
+and collection/help-only modes do not stamp. The exact checkout comes from the
+structured Bash `cwd`/`workdir` payload. A command-level `cd`/`pushd` is not
+guessed from shell text—set the tool's `workdir` instead.
+
+Stamping remains observational and exits successfully when it cannot prove the
+run. The subsequent push then fails with a rerun instruction. An intentional
+operator bypass remains `git push --no-verify`.
+
 ## Primary-checkout write guard (#4448)
 
 `guard-primary-checkout-write.py` is a `PreToolUse` guard that blocks a write

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -20,7 +20,7 @@ for hook_name in "${required_hooks[@]}"; do
     fi
 done
 
-for support_file in _lib.sh check-pytest-stamp.py; do
+for support_file in _lib.sh check-pytest-stamp.py pytest_stamp.py; do
     if [[ ! -r "$hooks_dir/$support_file" ]]; then
         echo "Expected readable hook support file at $hooks_dir/$support_file" >&2
         exit 1

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -269,8 +270,20 @@ def test_full_pre_push_chain_replays_updates_to_the_pytest_guard(tmp_path):
     assert blocked.returncode == 1
     assert "Push to main blocked" in blocked.stderr
 
-    stamp = Path(env["TMPDIR"]) / "learn-uk-pytest.feature.stamp"
-    stamp.touch()
+    stamped = _run(
+        [str(_project_python()), str(repo / ".githooks/pytest_stamp.py")],
+        cwd=repo,
+        env=env,
+        input_text=json.dumps(
+            {
+                "cwd": str(repo),
+                "hook_event_name": "PostToolUse",
+                "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+            }
+        ),
+    )
+    assert stamped.returncode == 0
+    assert len(list(Path(env["TMPDIR"]).glob("learn-uk-pytest.v2.*.stamp"))) == 1
     pushed = _git(repo, "push", "origin", "feature:main", env=env)
     assert pushed.returncode == 0
     calls = Path(env["HOOK_LOG"]).read_text(encoding="utf-8").splitlines()

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -400,6 +401,54 @@ def test_stamp_writer_leaves_no_stamp_from_detached_head(tmp_path):
     assert not stamp_dir.exists()
 
 
+def test_stamp_writer_does_not_fallback_to_system_python(tmp_path):
+    repo = tmp_path / "repo-without-venv"
+    hook = repo / "agents_extensions/shared/hooks/stamp-pytest.sh"
+    helper = repo / ".githooks/pytest_stamp.py"
+    fake_bin = tmp_path / "fake-bin"
+    system_python_log = tmp_path / "system-python.log"
+    hook.parent.mkdir(parents=True)
+    helper.parent.mkdir(parents=True)
+    fake_bin.mkdir()
+    shutil.copy2(STAMP_PATH, hook)
+    helper.write_text("raise SystemExit(99)\n", encoding="utf-8")
+    (repo / "package.json").write_text("{}\n", encoding="utf-8")
+    _git(repo, "init", "-b", "feature")
+    fake_python = fake_bin / "python3"
+    fake_python.write_text(
+        '#!/bin/sh\nprintf "called\\n" >> "$SYSTEM_PYTHON_LOG"\n',
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    environment = _git_environment(
+        {
+            "CLAUDE_PROJECT_DIR": str(repo),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "SYSTEM_PYTHON_LOG": str(system_python_log),
+        }
+    )
+
+    result = subprocess.run(
+        [str(hook)],
+        capture_output=True,
+        check=False,
+        cwd=repo,
+        env=environment,
+        input=json.dumps(
+            {
+                "cwd": str(repo),
+                "hook_event_name": "PostToolUse",
+                "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+            }
+        ),
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    assert not system_python_log.exists()
+
+
 def test_stamp_writer_uses_tool_workdir_instead_of_hook_process_cwd(tmp_path):
     tested_repo, _, _ = _repo_with_change(tmp_path / "tested")
     hook_repo, _, _ = _repo_with_change(tmp_path / "hook")
@@ -522,6 +571,42 @@ def test_stamp_writer_checks_pytest_result_after_a_compound_command(tmp_path, ou
 
     assert result.returncode == 0
     assert _stamp(stamp_dir, repo).exists() is should_stamp
+
+
+def test_nested_known_tool_response_can_prove_compound_pytest_success(tmp_path):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    payload = {
+        "hook_event_name": "PostToolUseFailure",
+        "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q && exit 1"},
+        "tool_response": {
+            "stdout": "====================== 10 passed in 0.40s ======================"
+        },
+    }
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert _stamp(stamp_dir, repo).exists()
+
+
+def test_unrelated_payload_text_cannot_fake_a_passing_summary(tmp_path):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    passing_text = "====================== 10 passed in 0.40s ======================"
+    payload = {
+        "hook_event_name": "PostToolUseFailure",
+        "tool_input": {
+            "command": ".venv/bin/python -m pytest tests/ -q && exit 1",
+            "description": passing_text,
+        },
+        "metadata": {"note": passing_text},
+    }
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert not _stamp(stamp_dir, repo).exists()
 
 
 def test_same_branch_name_in_another_repo_cannot_reuse_stamp(tmp_path):

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -72,7 +72,7 @@ def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> subproces
 
 def _repo_with_change(tmp_path: Path, changed_path: str = "tests/example.py") -> tuple[Path, str, str]:
     repo = tmp_path / "repo"
-    repo.mkdir()
+    repo.mkdir(parents=True)
     _git(repo, "init", "-b", "feature")
     _git(repo, "config", "user.email", "test@example.invalid")
     _git(repo, "config", "user.name", "Test User")
@@ -123,9 +123,22 @@ def _hook(
     )
 
 
-def _stamp(tmp_path: Path, branch: str = "feature") -> Path:
+def _stamp(tmp_path: Path, repo: Path, branch: str = "feature") -> Path:
     tmp_path.mkdir(exist_ok=True)
-    return tmp_path / f"learn-uk-pytest.{branch}.stamp"
+    hook = _load_hook_module()
+    identity = hook.stamp_identity_for_branch(repo, branch)
+    assert identity is not None
+    return hook.marker_path(identity, {"TMPDIR": str(tmp_path)})
+
+
+def _write_valid_stamp(tmp_path: Path, repo: Path, branch: str = "feature") -> Path:
+    hook = _load_hook_module()
+    identity = hook.stamp_identity_for_branch(repo, branch)
+    assert identity is not None
+    marker = hook.marker_path(identity, {"TMPDIR": str(tmp_path)})
+    marker.parent.mkdir(exist_ok=True)
+    marker.write_text(f"{identity.key}\n", encoding="utf-8")
+    return marker
 
 
 def _configure_guard_only_hook(repo: Path, tmp_path: Path) -> None:
@@ -146,14 +159,18 @@ def _run_stamp_writer(
     payload: dict[str, object],
     *,
     tmpdir: Path,
+    hook_cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    resolved_payload = dict(payload)
+    resolved_payload.setdefault("cwd", str(repo))
+    resolved_payload.setdefault("hook_event_name", "PostToolUse")
     return subprocess.run(
         [str(STAMP_PATH)],
         capture_output=True,
         check=False,
-        cwd=repo,
+        cwd=hook_cwd or repo,
         env=_git_environment({"TMPDIR": str(tmpdir)}),
-        input=json.dumps(payload),
+        input=json.dumps(resolved_payload),
         text=True,
         timeout=30,
     )
@@ -171,8 +188,7 @@ def test_blocks_main_update_with_trigger_path_and_no_stamp(tmp_path):
 
 def test_allows_main_update_with_fresh_stamp(tmp_path):
     repo, remote_sha, local_sha = _repo_with_change(tmp_path)
-    stamp = _stamp(tmp_path / "stamps")
-    stamp.touch()
+    stamp = _write_valid_stamp(tmp_path / "stamps", repo)
 
     result = _hook(repo, _update(local_sha, remote_sha), tmpdir=stamp.parent)
 
@@ -181,14 +197,24 @@ def test_allows_main_update_with_fresh_stamp(tmp_path):
 
 def test_blocks_main_update_with_stamp_older_than_600_seconds(tmp_path):
     repo, remote_sha, local_sha = _repo_with_change(tmp_path)
-    stamp = _stamp(tmp_path / "stamps")
-    stamp.touch()
+    stamp = _write_valid_stamp(tmp_path / "stamps", repo)
     stale_time = time.time() - 601
     os.utime(stamp, (stale_time, stale_time))
 
     result = _hook(repo, _update(local_sha, remote_sha), tmpdir=stamp.parent)
 
     assert result.returncode == 1
+
+
+def test_blocks_main_update_with_corrupt_stamp_content(tmp_path):
+    repo, remote_sha, local_sha = _repo_with_change(tmp_path)
+    stamp = _stamp(tmp_path / "stamps", repo)
+    stamp.write_text("not-this-checkout\n", encoding="utf-8")
+
+    result = _hook(repo, _update(local_sha, remote_sha), tmpdir=stamp.parent)
+
+    assert result.returncode == 1
+    assert "Rerun pytest" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -200,7 +226,12 @@ def test_blocks_main_update_with_stamp_older_than_600_seconds(tmp_path):
         ("/var/custom-tmp", "/var/custom-tmp"),  # ordinary absolute value is honoured
     ],
 )
-def test_marker_path_resolution_matches_the_stamp_writer(tmpdir_value, expected_parent, monkeypatch):
+def test_marker_path_resolution_matches_the_stamp_writer(
+    tmp_path,
+    tmpdir_value,
+    expected_parent,
+    monkeypatch,
+):
     """The reader must resolve TMPDIR exactly as `${TMPDIR:-/tmp}` does for the writer.
 
     Writer is `agents_extensions/shared/hooks/stamp-pytest.sh`. Two ways the two sides
@@ -223,10 +254,13 @@ def test_marker_path_resolution_matches_the_stamp_writer(tmpdir_value, expected_
     else:
         monkeypatch.setenv("TMPDIR", tmpdir_value)
 
-    marker = hook._marker_path("feature")
+    repo, _, _ = _repo_with_change(tmp_path)
+    identity = hook.stamp_identity_for_branch(repo, "feature")
+    assert identity is not None
+    marker = hook.marker_path(identity)
 
     assert marker.parent == Path(expected_parent)
-    assert marker.name == "learn-uk-pytest.feature.stamp"
+    assert marker.name == f"learn-uk-pytest.v2.{identity.key}.stamp"
     assert marker.is_absolute(), "a relative marker path can never match the writer's"
 
 
@@ -348,7 +382,7 @@ def test_stamp_writer_records_successful_pytest_runs(tmp_path, command):
     result = _run_stamp_writer(repo, {"tool_input": {"command": command}}, tmpdir=stamp_dir)
 
     assert result.returncode == 0
-    assert _stamp(stamp_dir).exists()
+    assert _stamp(stamp_dir, repo).exists()
 
 
 def test_stamp_writer_leaves_no_stamp_from_detached_head(tmp_path):
@@ -364,6 +398,107 @@ def test_stamp_writer_leaves_no_stamp_from_detached_head(tmp_path):
 
     assert result.returncode == 0
     assert not stamp_dir.exists()
+
+
+def test_stamp_writer_uses_tool_workdir_instead_of_hook_process_cwd(tmp_path):
+    tested_repo, _, _ = _repo_with_change(tmp_path / "tested")
+    hook_repo, _, _ = _repo_with_change(tmp_path / "hook")
+    _git(hook_repo, "branch", "-m", "main")
+    stamp_dir = tmp_path / "stamps"
+    payload = {
+        "cwd": str(hook_repo),
+        "hook_event_name": "PostToolUse",
+        "tool_input": {
+            "command": ".venv/bin/python -m pytest tests/ -q",
+            "workdir": str(tested_repo),
+        },
+    }
+
+    result = _run_stamp_writer(
+        tested_repo,
+        payload,
+        tmpdir=stamp_dir,
+        hook_cwd=hook_repo,
+    )
+
+    assert result.returncode == 0
+    assert _stamp(stamp_dir, tested_repo).exists()
+    assert not _stamp(stamp_dir, hook_repo, "main").exists()
+
+
+def test_successful_shell_wrapper_does_not_mask_failed_pytest(tmp_path):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q || true"},
+        "tool_output": "================== 1 failed, 19 passed in 0.65s ==================",
+    }
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert not _stamp(stamp_dir, repo).exists()
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        ".venv/bin/python -m pytest --collect-only",
+        ".venv/bin/python -m pytest --co",
+        ".venv/bin/python -m pytest --help",
+    ),
+)
+def test_successful_non_execution_pytest_modes_do_not_stamp(tmp_path, command):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+
+    result = _run_stamp_writer(
+        repo,
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"command": command},
+        },
+        tmpdir=stamp_dir,
+    )
+
+    assert result.returncode == 0
+    assert not _stamp(stamp_dir, repo).exists()
+
+
+def test_command_level_directory_change_is_not_misattributed_to_payload_cwd(tmp_path):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_input": {"command": "cd elsewhere && .venv/bin/python -m pytest -q"},
+        "tool_output": "====================== 10 passed in 0.40s ======================",
+    }
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert not _stamp(stamp_dir, repo).exists()
+
+
+def test_every_pytest_segment_must_have_a_passing_summary(tmp_path):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_input": {
+            "command": (
+                ".venv/bin/python -m pytest tests/first.py -q; "
+                ".venv/bin/python -m pytest tests/second.py -q || true"
+            )
+        },
+        "tool_output": "====================== 10 passed in 0.40s ======================",
+    }
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert not _stamp(stamp_dir, repo).exists()
 
 
 @pytest.mark.parametrize(
@@ -386,7 +521,32 @@ def test_stamp_writer_checks_pytest_result_after_a_compound_command(tmp_path, ou
     result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
 
     assert result.returncode == 0
-    assert _stamp(stamp_dir).exists() is should_stamp
+    assert _stamp(stamp_dir, repo).exists() is should_stamp
+
+
+def test_same_branch_name_in_another_repo_cannot_reuse_stamp(tmp_path):
+    first_repo, _, _ = _repo_with_change(tmp_path / "first")
+    second_repo, remote_sha, local_sha = _repo_with_change(tmp_path / "second")
+    stamp_dir = tmp_path / "stamps"
+
+    writer = _run_stamp_writer(
+        first_repo,
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+        },
+        tmpdir=stamp_dir,
+    )
+    guarded_push = _hook(
+        second_repo,
+        _update(local_sha, remote_sha),
+        tmpdir=stamp_dir,
+    )
+
+    assert writer.returncode == 0
+    assert _stamp(stamp_dir, first_repo).exists()
+    assert _stamp(stamp_dir, first_repo) != _stamp(stamp_dir, second_repo)
+    assert guarded_push.returncode == 1
 
 
 def test_no_verify_skips_hook_for_an_actual_push(tmp_path):
@@ -447,6 +607,48 @@ def test_actual_head_to_main_push_is_blocked_from_a_non_main_branch(tmp_path):
 
     assert result.returncode == 1
     assert "Push to main blocked" in result.stderr
+
+
+def test_actual_head_to_main_push_accepts_stamp_for_the_invoking_worktree(tmp_path):
+    repo, _, _ = _repo_with_change(tmp_path)
+    remote = tmp_path / "remote.git"
+    stamp_dir = tmp_path / "stamps"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        check=True,
+        capture_output=True,
+        env=_git_environment(),
+        text=True,
+        timeout=30,
+    )
+    _git(repo, "remote", "add", "origin", str(remote))
+    _configure_guard_only_hook(repo, tmp_path)
+    _git(repo, "push", "--no-verify", "origin", "HEAD:main")
+
+    (repo / "tests" / "second.py").write_text("second change\n", encoding="utf-8")
+    _git(repo, "add", "tests/second.py")
+    _git(repo, "commit", "-m", "second change")
+    writer = _run_stamp_writer(
+        repo,
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+        },
+        tmpdir=stamp_dir,
+    )
+
+    result = subprocess.run(
+        ["git", "push", "origin", "HEAD:main"],
+        capture_output=True,
+        check=False,
+        cwd=repo,
+        env=_git_environment({"TMPDIR": str(stamp_dir)}),
+        text=True,
+        timeout=30,
+    )
+
+    assert writer.returncode == 0
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- move pytest result parsing and marker identity into one shared helper used by the agent writer and Git pre-push reader
- namespace stamps to the canonical repository, exact registered worktree, and branch
- accept direct successful pytest runs while requiring clean pytest summaries for compound or failed shell events
- reject masked failures, zero-run/collection modes, multiple pytest commands, corrupt markers, and ambiguous command-level cwd changes
- validate the new helper in the tracked hook installer and document the operator contract

## Root cause

The writer resolved its branch from the hook process cwd, which can be the primary checkout even when pytest ran in a dispatch worktree. It also treated overall `PostToolUse` success as pytest success, so `pytest ... || true` could produce a false-green marker. Finally, branch-only marker names allowed same-named branches in other checkouts to collide.

## Verification

- `.venv/bin/python -m pytest tests/test_pre_push_hook.py tests/test_git_hooks.py tests/test_hooks_executable.py tests/test_deploy_script_idempotency.py -q` — 71 passed
- `.venv/bin/python -m ruff check .githooks/check-pytest-stamp.py .githooks/pytest_stamp.py tests/test_pre_push_hook.py tests/test_git_hooks.py` — passed
- `shellcheck agents_extensions/shared/hooks/stamp-pytest.sh scripts/install_git_hooks.sh` — passed
- `npx markdownlint-cli2 docs/runbooks/codex-hooks.md` — passed
- `npm run agents:deploy` — completed
- `bash scripts/install_git_hooks.sh` — completed
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- actual branch push passed through the tracked pre-push chain using the new v2 marker

Fixes #5827
