### PR TITLE
fix(hooks): align Codex lifecycle contracts

### DIFF
--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -20,7 +20,7 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent_runtime/codex_hook_entry.sh\" pre-tool-use",
-            "timeout": 65,
+            "timeout": 55,
             "statusMessage": "Running Codex tool policy"
           }
         ]

--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -15,60 +15,13 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "^Bash$",
+        "matcher": "^(Bash|Write|Edit|MultiEdit|apply_patch)$",
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/enforce-venv.sh\"",
-            "timeout": 3,
-            "statusMessage": "Checking Bash Python interpreter"
-          },
-          {
-            "type": "command",
-            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/heal-core-bare.py\"",
-            "timeout": 3,
-            "statusMessage": "Checking git worktree health"
-          },
-          {
-            "type": "command",
-            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-branch-switch-in-main.py\"",
-            "timeout": 3,
-            "statusMessage": "Checking branch-switch safety"
-          },
-          {
-            "type": "command",
-            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-admin-merge.py\"",
-            "timeout": 30,
-            "statusMessage": "Checking admin merge safety"
-          },
-          {
-            "type": "command",
-            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-pr-merge.py\"",
-            "timeout": 30,
-            "statusMessage": "Checking PR merge safety"
-          },
-          {
-            "type": "command",
-            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-secret-print.py\"",
-            "timeout": 5,
-            "statusMessage": "Checking secret-print safety"
-          },
-          {
-            "type": "command",
-            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-primary-checkout-write.py\"",
-            "timeout": 5,
-            "statusMessage": "Checking primary-checkout write safety"
-          }
-        ]
-      },
-      {
-        "matcher": "^(Write|Edit|MultiEdit|apply_patch)$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-primary-checkout-write.py\"",
-            "timeout": 5,
-            "statusMessage": "Checking primary-checkout write safety"
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent_runtime/codex_hook_entry.sh\" pre-tool-use",
+            "timeout": 45,
+            "statusMessage": "Running Codex tool policy"
           }
         ]
       }
@@ -79,34 +32,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/tool-timing.sh\"",
-            "timeout": 1,
-            "statusMessage": "Recording tool timing"
-          },
-          {
-            "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/stamp-pytest.sh\"",
-            "timeout": 3,
-            "statusMessage": "Stamping pytest telemetry"
-          }
-        ]
-      }
-    ],
-    "PostToolUseFailure": [
-      {
-        "matcher": "^(Bash|apply_patch|Edit|Write)$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/tool-timing.sh\"",
-            "timeout": 1,
-            "statusMessage": "Recording tool timing"
-          },
-          {
-            "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/stamp-pytest.sh\"",
-            "timeout": 3,
-            "statusMessage": "Stamping pytest telemetry"
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent_runtime/codex_hook_entry.sh\" post-tool-use",
+            "timeout": 5,
+            "statusMessage": "Recording Codex tool result"
           }
         ]
       }
@@ -116,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/check-gemini-inbox.sh\"",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent_runtime/codex_hook_entry.sh\" user-prompt-submit",
             "timeout": 5,
             "statusMessage": "Checking cross-agent inbox"
           }

--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -20,7 +20,7 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent_runtime/codex_hook_entry.sh\" pre-tool-use",
-            "timeout": 45,
+            "timeout": 65,
             "statusMessage": "Running Codex tool policy"
           }
         ]

--- a/agents_extensions/shared/hooks/check-gemini-inbox.sh
+++ b/agents_extensions/shared/hooks/check-gemini-inbox.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Hook: Check for unread Gemini messages on every prompt submit
+# Hook: Check for unread cross-agent messages on every prompt submit
 # Queries the MCP message broker SQLite DB directly (no MCP overhead)
 #
 # PIPELINE GUARD: Skips during build_module / ai_agent_bridge runs
@@ -12,13 +12,21 @@ fi
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 DB="$PROJECT_DIR/.mcp/servers/message-broker/messages.db"
+RECIPIENT="${LEARN_UK_HOOK_RECIPIENT:-claude}"
+
+case "$RECIPIENT" in
+  claude|codex|gemini|agy|grok|orchestrator) ;;
+  *) exit 0 ;;
+esac
+
+RECIPIENT_LABEL=$(printf '%s' "$RECIPIENT" | tr '[:lower:]' '[:upper:]')
 
 if [ ! -f "$DB" ]; then
   exit 0
 fi
 
-# Count unclaimed, unacknowledged messages for Claude
-COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM messages WHERE to_llm='claude' AND acknowledged=0 AND claimed_by IS NULL" 2>/dev/null)
+# Count unclaimed, unacknowledged messages for this hook's provider.
+COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM messages WHERE to_llm='$RECIPIENT' AND acknowledged=0 AND claimed_by IS NULL" 2>/dev/null)
 
 if [ -z "$COUNT" ] || [ "$COUNT" -eq 0 ]; then
   exit 0
@@ -34,12 +42,12 @@ PREVIEWS=$(sqlite3 -separator '|' "$DB" "
     substr(content, 1, 120),
     timestamp
   FROM messages
-  WHERE to_llm='claude' AND acknowledged=0 AND claimed_by IS NULL
+  WHERE to_llm='$RECIPIENT' AND acknowledged=0 AND claimed_by IS NULL
   ORDER BY id ASC
   LIMIT 5
 " 2>/dev/null)
 
-CONTEXT="GEMINI INBOX: ${COUNT} unread message(s) waiting.
+CONTEXT="${RECIPIENT_LABEL} INBOX: ${COUNT} unread message(s) waiting.
 ---"
 
 while IFS='|' read -r id from type task preview ts; do

--- a/agents_extensions/shared/hooks/enforce-venv.sh
+++ b/agents_extensions/shared/hooks/enforce-venv.sh
@@ -42,8 +42,10 @@ if echo "$COMMAND" | grep -qE '^python3?[[:space:]]'; then
     exit 2
   fi
 
-  FIXED=$(printf '%s' "$COMMAND" \
-    | sed -E "s|^python3?[[:space:]]|$PYTHON_BIN |")
+  case "$COMMAND" in
+    python3*) FIXED="${PYTHON_BIN}${COMMAND#python3}" ;;
+    python*) FIXED="${PYTHON_BIN}${COMMAND#python}" ;;
+  esac
 
   if [ "${LEARN_UK_HOOK_PROVIDER:-claude}" = "codex" ]; then
     jq -n --arg command "$FIXED" '{

--- a/agents_extensions/shared/hooks/enforce-venv.sh
+++ b/agents_extensions/shared/hooks/enforce-venv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Hook: PreToolUse (Bash) — Enforce .venv/bin/python usage
-# Rewrites bare `python3` or `python` commands to `.venv/bin/python`
+# Rewrites bare `python3` or `python` commands to the canonical project venv.
 # Prevents accidentally using system Python instead of project venv.
 
 # Read tool input from stdin
@@ -13,19 +13,49 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Check if command starts with bare python3 or python (not already using .venv)
+# Check if the command starts with an unqualified interpreter name.
 # Match: "python3 ...", "python ...", but NOT ".venv/bin/python ..." or "/path/to/python ..."
-if echo "$COMMAND" | grep -qE '^python3?\s'; then
+if echo "$COMMAND" | grep -qE '^python3?[[:space:]]'; then
   # Already using venv? Skip.
   if echo "$COMMAND" | grep -qE '^\./\.venv/|^\.venv/|^/.*\.venv/'; then
     exit 0
   fi
 
-  # Rewrite python3/python to .venv/bin/python
-  FIXED=$(printf '%s' "$COMMAND" | sed -E 's/^python3?\s/.venv\/bin\/python /')
+  CANONICAL_ROOT="${LEARN_UK_CANONICAL_ROOT:-}"
+  if [ -z "$CANONICAL_ROOT" ]; then
+    TOOL_CWD=$(printf '%s' "$INPUT" | jq -r '
+      .tool_input.workdir
+      // .tool_input.cwd
+      // .tool_input.working_directory
+      // .cwd
+      // empty
+    ')
+    [ -n "$TOOL_CWD" ] || TOOL_CWD="$PWD"
+    COMMON_DIR=$(git -C "$TOOL_CWD" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
+      || COMMON_DIR=""
+    [ -z "$COMMON_DIR" ] || CANONICAL_ROOT="$(dirname "$COMMON_DIR")"
+  fi
 
-  # Return modified input
-  printf '{"modifiedInput": {"command": %s}}' "$(printf '%s' "$FIXED" | jq -Rs '.')"
+  PYTHON_BIN="${CANONICAL_ROOT:+$CANONICAL_ROOT/}.venv/bin/python"
+  if [ ! -x "$PYTHON_BIN" ]; then
+    printf 'Unqualified interpreter blocked: project venv is missing at %s\n' "$PYTHON_BIN" >&2
+    exit 2
+  fi
+
+  FIXED=$(printf '%s' "$COMMAND" \
+    | sed -E "s|^python3?[[:space:]]|$PYTHON_BIN |")
+
+  if [ "${LEARN_UK_HOOK_PROVIDER:-claude}" = "codex" ]; then
+    jq -n --arg command "$FIXED" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        updatedInput: {command: $command}
+      }
+    }'
+  else
+    jq -n --arg command "$FIXED" '{modifiedInput: {command: $command}}'
+  fi
   exit 0
 fi
 

--- a/agents_extensions/shared/hooks/tool-timing.sh
+++ b/agents_extensions/shared/hooks/tool-timing.sh
@@ -27,7 +27,12 @@ PAYLOAD=$(printf '%s' "$INPUT" | jq -ce --arg ts "$TS" '
         if (($input.session_id? | type) == "string" and ($input.session_id | length) > 0)
         then $input.session_id else null end
       ),
-      failed: ($input.hook_event_name == "PostToolUseFailure")
+      failed: (
+        ($input.hook_event_name == "PostToolUseFailure")
+        or (($input.tool_response.exit_code? | type) == "number" and $input.tool_response.exit_code != 0)
+        or ($input.tool_response.is_error? == true)
+        or ($input.tool_response.status? == "failed")
+      )
     }
 ') || exit 0
 

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -14,6 +14,42 @@ Codex hook facts verified from the current OpenAI Codex manual on 2026-07-05:
 - Hook command trust is separate from project trust. For automation that already
   vets the hook source, use `--dangerously-bypass-hook-trust`.
 
+## Codex event and output contract
+
+Re-verified against the current OpenAI Codex Hooks reference on 2026-07-26:
+
+- Supported result hooks use `PostToolUse`; it also fires after a Bash command
+  exits non-zero. Codex does not define a separate `PostToolUseFailure` event.
+- A `PreToolUse` rewrite must return
+  `hookSpecificOutput.permissionDecision: "allow"` with an `updatedInput`
+  object. Claude's `modifiedInput` shape is not the Codex rewrite contract.
+- All matching command hooks for one event launch concurrently. One matching
+  command cannot keep another matching command from starting.
+- Hook commands start in the session cwd. The tool's actual cwd can instead be
+  present in `tool_input.workdir` or `tool_input.cwd`.
+
+The Codex manifest therefore sends each tool event through one tracked,
+deterministic entry point:
+`scripts/agent_runtime/codex_hook_entry.sh`. `PreToolUse` policy checks run
+sequentially in a fixed order; `PostToolUse` telemetry and pytest stamping do
+the same. This removes the prior seven-process Bash fan-out and the unsupported
+failure-event duplicate.
+
+The entry point resolves the exact tool worktree from structured hook input and
+the canonical checkout from Git's common directory. Python policies use the
+canonical checkout's `.venv/bin/python`, so a linked worktree does not need its
+own `.venv` symlink. Bare `python`/`python3` calls are rewritten to that absolute
+project interpreter using the Codex `updatedInput` schema. If the project
+interpreter is genuinely absent, the policy blocks instead of falling back to a
+system interpreter.
+
+`UserPromptSubmit` invokes the inbox hook with recipient `codex`; the shared
+script retains `claude` as its default for Claude settings. A Codex session now
+queries Codex-addressed messages rather than silently reporting Claude's inbox.
+
+The repository deploy manages project-local `.codex/hooks.json`; it does not
+edit the separate user-level `~/.codex/hooks.json`.
+
 ## Pytest stamp and pre-push guard
 
 `agents_extensions/shared/hooks/stamp-pytest.sh` is the deployed

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -45,6 +45,10 @@ tool call; a timeout therefore fails closed. The manifest's 55-second outer
 timeout remains a last-resort ceiling above the 3-second rewrite, local-chain,
 and concurrent network-guard budgets.
 
+Only the venv rewrite may write the final Codex JSON response to stdout.
+Unexpected stdout from any policy guard is redirected to diagnostics and
+fails closed, preventing multiple payloads from corrupting the hook response.
+
 The entry point resolves the exact tool worktree from structured hook input and
 the canonical checkout from Git's common directory. Python policies use the
 canonical checkout's `.venv/bin/python`, so a linked worktree does not need its

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -30,8 +30,9 @@ Re-verified against the current OpenAI Codex Hooks reference on 2026-07-26:
 
 The Codex manifest therefore sends each tool event through one tracked,
 deterministic entry point:
-`scripts/agent_runtime/codex_hook_entry.sh`. `PreToolUse` local policy checks
-run sequentially with their former 3–5 second individual deadlines. The two
+`scripts/agent_runtime/codex_hook_entry.sh`. The Bash-command venv rewrite has
+its own 3-second fail-closed deadline. `PreToolUse` local policy checks then run
+sequentially with their former 3–5 second individual deadlines. The two
 independent, network-backed merge guards run concurrently with separate
 30-second deadlines, and their results are emitted in a fixed order.
 `PostToolUse` telemetry and pytest stamping run sequentially. This removes the
@@ -41,8 +42,8 @@ without letting one slow merge guard starve the other.
 `codex_hook_policy.py` converts an individual guard timeout into exit code `2`
 with a concrete reason. Per the Codex `PreToolUse` contract, exit `2` blocks the
 tool call; a timeout therefore fails closed. The manifest's 55-second outer
-timeout remains a last-resort ceiling above the local-chain plus concurrent
-network-guard budgets.
+timeout remains a last-resort ceiling above the 3-second rewrite, local-chain,
+and concurrent network-guard budgets.
 
 The entry point resolves the exact tool worktree from structured hook input and
 the canonical checkout from Git's common directory. Python policies use the

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -86,8 +86,11 @@ protected branch (`main`/`master`). It is wired into both providers:
 
 - Claude (`agents_extensions/shared/settings.json`): the `Bash` matcher plus a
   `Write|Edit|MultiEdit` matcher.
-- Codex (`agents_extensions/codex/hooks.json`): the `^Bash$` matcher plus a
-  `^(Write|Edit|MultiEdit|apply_patch)$` matcher.
+- Codex (`agents_extensions/codex/hooks.json`): one consolidated
+  `^(Bash|Write|Edit|MultiEdit|apply_patch)$` matcher calls the deterministic
+  entry point. The entry point preserves the former per-tool policy boundary:
+  all Bash guards run for `Bash`, while structured edit tools run only
+  `guard-primary-checkout-write.py`.
 
 Every containment decision is delegated to
 `scripts.guardrails.worktree_containment` (#4444); the hook only maps each

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -30,10 +30,19 @@ Re-verified against the current OpenAI Codex Hooks reference on 2026-07-26:
 
 The Codex manifest therefore sends each tool event through one tracked,
 deterministic entry point:
-`scripts/agent_runtime/codex_hook_entry.sh`. `PreToolUse` policy checks run
-sequentially in a fixed order; `PostToolUse` telemetry and pytest stamping do
-the same. This removes the prior seven-process Bash fan-out and the unsupported
-failure-event duplicate.
+`scripts/agent_runtime/codex_hook_entry.sh`. `PreToolUse` local policy checks
+run sequentially with their former 3–5 second individual deadlines. The two
+independent, network-backed merge guards run concurrently with separate
+30-second deadlines, and their results are emitted in a fixed order.
+`PostToolUse` telemetry and pytest stamping run sequentially. This removes the
+prior seven-process Bash fan-out and the unsupported failure-event duplicate
+without letting one slow merge guard starve the other.
+
+`codex_hook_policy.py` converts an individual guard timeout into exit code `2`
+with a concrete reason. Per the Codex `PreToolUse` contract, exit `2` blocks the
+tool call; a timeout therefore fails closed. The manifest's 55-second outer
+timeout remains a last-resort ceiling above the local-chain plus concurrent
+network-guard budgets.
 
 The entry point resolves the exact tool worktree from structured hook input and
 the canonical checkout from Git's common directory. Python policies use the

--- a/scripts/agent_runtime/codex_hook_entry.sh
+++ b/scripts/agent_runtime/codex_hook_entry.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Single, deterministic entry point for Codex lifecycle hooks.
+#
+# Codex launches every matching command hook for an event concurrently. Keeping
+# the Bash policy checks in one runner avoids redundant interpreter startup,
+# makes their order deterministic, and prevents policy hooks from contending
+# with each other for Git/GitHub state.
+
+set -u
+
+MODE="${1:-}"
+PAYLOAD=$(cat)
+
+SCRIPT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOKS_DIR="$SCRIPT_ROOT/agents_extensions/shared/hooks"
+
+payload_cwd=$(printf '%s' "$PAYLOAD" | jq -r '
+  .tool_input.workdir
+  // .tool_input.cwd
+  // .tool_input.working_directory
+  // .cwd
+  // empty
+' 2>/dev/null)
+[ -n "$payload_cwd" ] || payload_cwd="$SCRIPT_ROOT"
+
+COMMON_DIR=$(git -C "$payload_cwd" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
+  || COMMON_DIR=$(git -C "$SCRIPT_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
+  || COMMON_DIR=""
+
+if [ -n "$COMMON_DIR" ]; then
+  CANONICAL_ROOT="$(dirname "$COMMON_DIR")"
+else
+  CANONICAL_ROOT="$SCRIPT_ROOT"
+fi
+
+PYTHON_BIN="$CANONICAL_ROOT/.venv/bin/python"
+
+run_python_guard() {
+  local guard="$1"
+  local rc
+
+  printf '%s' "$PAYLOAD" | "$PYTHON_BIN" "$HOOKS_DIR/$guard"
+  rc=${PIPESTATUS[1]}
+  [ "$rc" -eq 0 ] || exit "$rc"
+}
+
+case "$MODE" in
+  pre-tool-use)
+    if [ ! -x "$PYTHON_BIN" ]; then
+      printf 'Codex hook policy cannot run: project interpreter is missing at %s\n' \
+        "$PYTHON_BIN" >&2
+      exit 2
+    fi
+
+    rewrite_output=$(printf '%s' "$PAYLOAD" \
+      | LEARN_UK_HOOK_PROVIDER=codex \
+        LEARN_UK_CANONICAL_ROOT="$CANONICAL_ROOT" \
+        bash "$HOOKS_DIR/enforce-venv.sh")
+    rewrite_rc=$?
+    [ "$rewrite_rc" -eq 0 ] || exit "$rewrite_rc"
+
+    # Cheap/local checks precede the GitHub-backed merge guards.
+    run_python_guard "heal-core-bare.py"
+    run_python_guard "guard-branch-switch-in-main.py"
+    run_python_guard "guard-secret-print.py"
+    run_python_guard "guard-primary-checkout-write.py"
+    run_python_guard "guard-admin-merge.py"
+    run_python_guard "guard-pr-merge.py"
+
+    [ -z "$rewrite_output" ] || printf '%s\n' "$rewrite_output"
+    ;;
+
+  post-tool-use)
+    printf '%s' "$PAYLOAD" \
+      | CLAUDE_PROJECT_DIR="$SCRIPT_ROOT" bash "$HOOKS_DIR/tool-timing.sh"
+    printf '%s' "$PAYLOAD" \
+      | CLAUDE_PROJECT_DIR="$SCRIPT_ROOT" bash "$HOOKS_DIR/stamp-pytest.sh"
+    ;;
+
+  user-prompt-submit)
+    printf '%s' "$PAYLOAD" \
+      | CLAUDE_PROJECT_DIR="$CANONICAL_ROOT" \
+        LEARN_UK_HOOK_RECIPIENT=codex \
+        bash "$HOOKS_DIR/check-gemini-inbox.sh"
+    ;;
+
+  *)
+    printf 'Unknown Codex hook entry mode: %s\n' "$MODE" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/agent_runtime/codex_hook_entry.sh
+++ b/scripts/agent_runtime/codex_hook_entry.sh
@@ -36,15 +36,6 @@ fi
 
 PYTHON_BIN="$CANONICAL_ROOT/.venv/bin/python"
 
-run_python_guard() {
-  local guard="$1"
-  local rc
-
-  printf '%s' "$PAYLOAD" | "$PYTHON_BIN" "$HOOKS_DIR/$guard"
-  rc=${PIPESTATUS[1]}
-  [ "$rc" -eq 0 ] || exit "$rc"
-}
-
 case "$MODE" in
   pre-tool-use)
     if [ ! -x "$PYTHON_BIN" ]; then
@@ -62,19 +53,14 @@ case "$MODE" in
       rewrite_rc=$?
       [ "$rewrite_rc" -eq 0 ] || exit "$rewrite_rc"
 
-      # Preserve the former Bash-only scope for shell and merge guards.
-      run_python_guard "heal-core-bare.py"
-      run_python_guard "guard-branch-switch-in-main.py"
-      run_python_guard "guard-secret-print.py"
     fi
 
-    # Structured edit tools need only the primary-checkout containment guard.
-    run_python_guard "guard-primary-checkout-write.py"
-
-    if [ "$TOOL_NAME" = "Bash" ]; then
-      run_python_guard "guard-admin-merge.py"
-      run_python_guard "guard-pr-merge.py"
-    fi
+    printf '%s' "$PAYLOAD" \
+      | "$PYTHON_BIN" "$SCRIPT_ROOT/scripts/agent_runtime/codex_hook_policy.py" \
+        --python-bin "$PYTHON_BIN" \
+        --hooks-dir "$HOOKS_DIR"
+    policy_rc=${PIPESTATUS[1]}
+    [ "$policy_rc" -eq 0 ] || exit "$policy_rc"
 
     [ -z "$rewrite_output" ] || printf '%s\n' "$rewrite_output"
     ;;

--- a/scripts/agent_runtime/codex_hook_entry.sh
+++ b/scripts/agent_runtime/codex_hook_entry.sh
@@ -22,7 +22,6 @@ payload_cwd=$(printf '%s' "$PAYLOAD" | jq -r '
   // empty
 ' 2>/dev/null)
 [ -n "$payload_cwd" ] || payload_cwd="$SCRIPT_ROOT"
-TOOL_NAME=$(printf '%s' "$PAYLOAD" | jq -r '.tool_name // empty' 2>/dev/null)
 
 COMMON_DIR=$(git -C "$payload_cwd" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
   || COMMON_DIR=$(git -C "$SCRIPT_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
@@ -44,25 +43,13 @@ case "$MODE" in
       exit 2
     fi
 
-    rewrite_output=""
-    if [ "$TOOL_NAME" = "Bash" ]; then
-      rewrite_output=$(printf '%s' "$PAYLOAD" \
-        | LEARN_UK_HOOK_PROVIDER=codex \
-          LEARN_UK_CANONICAL_ROOT="$CANONICAL_ROOT" \
-          bash "$HOOKS_DIR/enforce-venv.sh")
-      rewrite_rc=$?
-      [ "$rewrite_rc" -eq 0 ] || exit "$rewrite_rc"
-
-    fi
-
     printf '%s' "$PAYLOAD" \
       | "$PYTHON_BIN" "$SCRIPT_ROOT/scripts/agent_runtime/codex_hook_policy.py" \
         --python-bin "$PYTHON_BIN" \
-        --hooks-dir "$HOOKS_DIR"
+        --hooks-dir "$HOOKS_DIR" \
+        --canonical-root "$CANONICAL_ROOT"
     policy_rc=${PIPESTATUS[1]}
     [ "$policy_rc" -eq 0 ] || exit "$policy_rc"
-
-    [ -z "$rewrite_output" ] || printf '%s\n' "$rewrite_output"
     ;;
 
   post-tool-use)

--- a/scripts/agent_runtime/codex_hook_entry.sh
+++ b/scripts/agent_runtime/codex_hook_entry.sh
@@ -22,6 +22,7 @@ payload_cwd=$(printf '%s' "$PAYLOAD" | jq -r '
   // empty
 ' 2>/dev/null)
 [ -n "$payload_cwd" ] || payload_cwd="$SCRIPT_ROOT"
+TOOL_NAME=$(printf '%s' "$PAYLOAD" | jq -r '.tool_name // empty' 2>/dev/null)
 
 COMMON_DIR=$(git -C "$payload_cwd" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
   || COMMON_DIR=$(git -C "$SCRIPT_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
@@ -52,20 +53,28 @@ case "$MODE" in
       exit 2
     fi
 
-    rewrite_output=$(printf '%s' "$PAYLOAD" \
-      | LEARN_UK_HOOK_PROVIDER=codex \
-        LEARN_UK_CANONICAL_ROOT="$CANONICAL_ROOT" \
-        bash "$HOOKS_DIR/enforce-venv.sh")
-    rewrite_rc=$?
-    [ "$rewrite_rc" -eq 0 ] || exit "$rewrite_rc"
+    rewrite_output=""
+    if [ "$TOOL_NAME" = "Bash" ]; then
+      rewrite_output=$(printf '%s' "$PAYLOAD" \
+        | LEARN_UK_HOOK_PROVIDER=codex \
+          LEARN_UK_CANONICAL_ROOT="$CANONICAL_ROOT" \
+          bash "$HOOKS_DIR/enforce-venv.sh")
+      rewrite_rc=$?
+      [ "$rewrite_rc" -eq 0 ] || exit "$rewrite_rc"
 
-    # Cheap/local checks precede the GitHub-backed merge guards.
-    run_python_guard "heal-core-bare.py"
-    run_python_guard "guard-branch-switch-in-main.py"
-    run_python_guard "guard-secret-print.py"
+      # Preserve the former Bash-only scope for shell and merge guards.
+      run_python_guard "heal-core-bare.py"
+      run_python_guard "guard-branch-switch-in-main.py"
+      run_python_guard "guard-secret-print.py"
+    fi
+
+    # Structured edit tools need only the primary-checkout containment guard.
     run_python_guard "guard-primary-checkout-write.py"
-    run_python_guard "guard-admin-merge.py"
-    run_python_guard "guard-pr-merge.py"
+
+    if [ "$TOOL_NAME" = "Bash" ]; then
+      run_python_guard "guard-admin-merge.py"
+      run_python_guard "guard-pr-merge.py"
+    fi
 
     [ -z "$rewrite_output" ] || printf '%s\n' "$rewrite_output"
     ;;

--- a/scripts/agent_runtime/codex_hook_policy.py
+++ b/scripts/agent_runtime/codex_hook_policy.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import json
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -16,6 +17,7 @@ LOCAL_BASH_GUARDS = (
     ("guard-branch-switch-in-main.py", 3),
     ("guard-secret-print.py", 5),
 )
+ENFORCE_VENV_TIMEOUT = 3
 PRIMARY_WRITE_GUARD = ("guard-primary-checkout-write.py", 5)
 MERGE_GUARDS = (
     ("guard-admin-merge.py", 30),
@@ -114,6 +116,44 @@ def _run_merge_guards(
         return [future.result() for future in futures]
 
 
+def _run_enforce_venv(
+    hooks_dir: Path,
+    canonical_root: Path,
+    payload: str,
+) -> GuardResult:
+    environment = os.environ.copy()
+    environment["LEARN_UK_HOOK_PROVIDER"] = "codex"
+    environment["LEARN_UK_CANONICAL_ROOT"] = str(canonical_root)
+    guard = hooks_dir / "enforce-venv.sh"
+    try:
+        completed = subprocess.run(
+            ["/bin/bash", str(guard)],
+            input=payload,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=ENFORCE_VENV_TIMEOUT,
+            env=environment,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return GuardResult(
+            name=guard.name,
+            returncode=2,
+            stdout=_timeout_text(exc.stdout),
+            stderr=(
+                _timeout_text(exc.stderr) + f"Codex hook guard {guard.name} exceeded "
+                f"{ENFORCE_VENV_TIMEOUT}s; blocking the tool call fail-closed.\n"
+            ),
+            timed_out=True,
+        )
+    return GuardResult(
+        name=guard.name,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
 def _result_code(results: list[GuardResult]) -> int:
     for result in results:
         _emit(result)
@@ -126,9 +166,20 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--python-bin", type=Path, required=True)
     parser.add_argument("--hooks-dir", type=Path, required=True)
+    parser.add_argument("--canonical-root", type=Path, required=True)
     args = parser.parse_args()
     payload = sys.stdin.read()
     tool_name = _tool_name(payload)
+    rewrite_result = None
+    if tool_name == "Bash":
+        rewrite_result = _run_enforce_venv(
+            args.hooks_dir,
+            args.canonical_root,
+            payload,
+        )
+        if rewrite_result.returncode:
+            _emit(rewrite_result)
+            return rewrite_result.returncode
 
     local_specs = LOCAL_BASH_GUARDS if tool_name == "Bash" else ()
     local_results = _run_specs(
@@ -142,7 +193,11 @@ def main() -> int:
         return local_code
 
     if tool_name == "Bash":
-        return _result_code(_run_merge_guards(args.python_bin, args.hooks_dir, payload))
+        merge_code = _result_code(_run_merge_guards(args.python_bin, args.hooks_dir, payload))
+        if merge_code:
+            return merge_code
+        if rewrite_result is not None:
+            _emit(rewrite_result)
     return 0
 
 

--- a/scripts/agent_runtime/codex_hook_policy.py
+++ b/scripts/agent_runtime/codex_hook_policy.py
@@ -155,11 +155,24 @@ def _run_enforce_venv(
 
 
 def _result_code(results: list[GuardResult]) -> int:
+    normalized: list[GuardResult] = []
     for result in results:
+        if result.stdout:
+            result = GuardResult(
+                name=result.name,
+                returncode=2,
+                stdout="",
+                stderr=(
+                    result.stderr + f"Codex hook guard {result.name} wrote unexpected stdout; "
+                    "blocking fail-closed to preserve the single JSON response channel.\n" + result.stdout
+                ),
+                timed_out=result.timed_out,
+            )
+        normalized.append(result)
         _emit(result)
-    if any(result.returncode == 2 for result in results):
+    if any(result.returncode == 2 for result in normalized):
         return 2
-    return next((result.returncode for result in results if result.returncode), 0)
+    return next((result.returncode for result in normalized if result.returncode), 0)
 
 
 def main() -> int:

--- a/scripts/agent_runtime/codex_hook_policy.py
+++ b/scripts/agent_runtime/codex_hook_policy.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Run Codex PreToolUse guards with isolated, fail-closed deadlines."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+LOCAL_BASH_GUARDS = (
+    ("heal-core-bare.py", 3),
+    ("guard-branch-switch-in-main.py", 3),
+    ("guard-secret-print.py", 5),
+)
+PRIMARY_WRITE_GUARD = ("guard-primary-checkout-write.py", 5)
+MERGE_GUARDS = (
+    ("guard-admin-merge.py", 30),
+    ("guard-pr-merge.py", 30),
+)
+
+
+@dataclass(frozen=True)
+class GuardResult:
+    name: str
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+
+
+def run_guard(
+    python_bin: Path,
+    guard: Path,
+    payload: str,
+    timeout_seconds: float,
+) -> GuardResult:
+    """Run one guard and convert a deadline expiry into a blocking result."""
+    try:
+        completed = subprocess.run(
+            [str(python_bin), str(guard)],
+            input=payload,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return GuardResult(
+            name=guard.name,
+            returncode=2,
+            stdout=_timeout_text(exc.stdout),
+            stderr=(
+                _timeout_text(exc.stderr) + f"Codex hook guard {guard.name} exceeded {timeout_seconds:g}s; "
+                "blocking the tool call fail-closed.\n"
+            ),
+            timed_out=True,
+        )
+
+    return GuardResult(
+        name=guard.name,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def _timeout_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _emit(result: GuardResult) -> None:
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+
+
+def _tool_name(payload: str) -> str:
+    try:
+        decoded = json.loads(payload or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    value = decoded.get("tool_name") if isinstance(decoded, dict) else None
+    return value if isinstance(value, str) else ""
+
+
+def _run_specs(
+    python_bin: Path,
+    hooks_dir: Path,
+    payload: str,
+    specs: tuple[tuple[str, int], ...],
+) -> list[GuardResult]:
+    return [run_guard(python_bin, hooks_dir / name, payload, timeout) for name, timeout in specs]
+
+
+def _run_merge_guards(
+    python_bin: Path,
+    hooks_dir: Path,
+    payload: str,
+) -> list[GuardResult]:
+    """Run independent network guards concurrently, return configured order."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(MERGE_GUARDS)) as pool:
+        futures = [
+            pool.submit(run_guard, python_bin, hooks_dir / name, payload, timeout) for name, timeout in MERGE_GUARDS
+        ]
+        return [future.result() for future in futures]
+
+
+def _result_code(results: list[GuardResult]) -> int:
+    for result in results:
+        _emit(result)
+    if any(result.returncode == 2 for result in results):
+        return 2
+    return next((result.returncode for result in results if result.returncode), 0)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--python-bin", type=Path, required=True)
+    parser.add_argument("--hooks-dir", type=Path, required=True)
+    args = parser.parse_args()
+    payload = sys.stdin.read()
+    tool_name = _tool_name(payload)
+
+    local_specs = LOCAL_BASH_GUARDS if tool_name == "Bash" else ()
+    local_results = _run_specs(
+        args.python_bin,
+        args.hooks_dir,
+        payload,
+        (*local_specs, PRIMARY_WRITE_GUARD),
+    )
+    local_code = _result_code(local_results)
+    if local_code:
+        return local_code
+
+    if tool_name == "Bash":
+        return _result_code(_run_merge_guards(args.python_bin, args.hooks_dir, payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -22,6 +22,18 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+PROJECT_PYTHON="$PROJECT_ROOT/.venv/bin/python"
+if [[ ! -x "$PROJECT_PYTHON" ]]; then
+    GIT_COMMON_DIR=$(git -C "$PROJECT_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+    if [[ -n "$GIT_COMMON_DIR" ]]; then
+        PROJECT_PYTHON="$(dirname "$GIT_COMMON_DIR")/.venv/bin/python"
+    fi
+fi
+if [[ ! -x "$PROJECT_PYTHON" ]]; then
+    echo "❌ Deploy aborted: project interpreter not found in this or the canonical checkout." >&2
+    exit 1
+fi
+
 # shellcheck disable=SC1091
 source "$PROJECT_ROOT/scripts/deploy_orphan_paths.sh"
 
@@ -125,7 +137,7 @@ echo ""
 
 # Step 1: Lint prompts (blocks deploy on failure)
 echo "=== Lint prompts ==="
-.venv/bin/python scripts/lint_prompts.py
+"$PROJECT_PYTHON" scripts/lint_prompts.py
 echo ""
 
 # Verify that all hooks in source directories are executable on disk
@@ -150,7 +162,7 @@ echo "  ✅ All hook files are executable."
 echo ""
 
 echo "=== Lint agent skills ==="
-.venv/bin/python scripts/lint/lint_agent_skills.py
+"$PROJECT_PYTHON" scripts/lint/lint_agent_skills.py
 echo ""
 
 if [[ "$DRY_RUN" == false ]]; then

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -65,12 +65,23 @@ def test_codex_tool_events_have_one_deterministic_command_hook() -> None:
     assert len(pre_groups) == 1
     assert pre_groups[0]["matcher"] == "^(Bash|Write|Edit|MultiEdit|apply_patch)$"
     assert len(pre_groups[0]["hooks"]) == 1
-    assert 'codex_hook_entry.sh" pre-tool-use' in pre_groups[0]["hooks"][0]["command"]
+    pre_hook = pre_groups[0]["hooks"][0]
+    assert 'codex_hook_entry.sh" pre-tool-use' in pre_hook["command"]
+    assert pre_hook["timeout"] == 65
 
     post_groups = hooks["PostToolUse"]
     assert len(post_groups) == 1
     assert len(post_groups[0]["hooks"]) == 1
     assert 'codex_hook_entry.sh" post-tool-use' in post_groups[0]["hooks"][0]["command"]
+
+
+def test_codex_entry_preserves_bash_only_guard_scope() -> None:
+    entry = ENTRY.read_text(encoding="utf-8")
+
+    assert 'if [ "$TOOL_NAME" = "Bash" ]; then' in entry
+    assert entry.count('run_python_guard "guard-admin-merge.py"') == 1
+    assert entry.count('run_python_guard "guard-pr-merge.py"') == 1
+    assert entry.count('run_python_guard "guard-primary-checkout-write.py"') == 1
 
 
 def test_codex_entry_rewrites_bare_python_from_worktree_without_local_venv(

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -8,6 +8,13 @@ import sqlite3
 import subprocess
 from pathlib import Path
 
+from scripts.agent_runtime.codex_hook_policy import (
+    LOCAL_BASH_GUARDS,
+    MERGE_GUARDS,
+    PRIMARY_WRITE_GUARD,
+    run_guard,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PRIMARY_ROOT = Path(
     subprocess.check_output(
@@ -67,7 +74,7 @@ def test_codex_tool_events_have_one_deterministic_command_hook() -> None:
     assert len(pre_groups[0]["hooks"]) == 1
     pre_hook = pre_groups[0]["hooks"][0]
     assert 'codex_hook_entry.sh" pre-tool-use' in pre_hook["command"]
-    assert pre_hook["timeout"] == 65
+    assert pre_hook["timeout"] == 55
 
     post_groups = hooks["PostToolUse"]
     assert len(post_groups) == 1
@@ -75,13 +82,33 @@ def test_codex_tool_events_have_one_deterministic_command_hook() -> None:
     assert 'codex_hook_entry.sh" post-tool-use' in post_groups[0]["hooks"][0]["command"]
 
 
-def test_codex_entry_preserves_bash_only_guard_scope() -> None:
-    entry = ENTRY.read_text(encoding="utf-8")
+def test_codex_policy_preserves_tool_scopes_and_per_guard_deadlines() -> None:
+    assert LOCAL_BASH_GUARDS == (
+        ("heal-core-bare.py", 3),
+        ("guard-branch-switch-in-main.py", 3),
+        ("guard-secret-print.py", 5),
+    )
+    assert PRIMARY_WRITE_GUARD == ("guard-primary-checkout-write.py", 5)
+    assert MERGE_GUARDS == (
+        ("guard-admin-merge.py", 30),
+        ("guard-pr-merge.py", 30),
+    )
 
-    assert 'if [ "$TOOL_NAME" = "Bash" ]; then' in entry
-    assert entry.count('run_python_guard "guard-admin-merge.py"') == 1
-    assert entry.count('run_python_guard "guard-pr-merge.py"') == 1
-    assert entry.count('run_python_guard "guard-primary-checkout-write.py"') == 1
+
+def test_codex_policy_guard_timeout_fails_closed(tmp_path: Path) -> None:
+    guard = tmp_path / "slow_guard.py"
+    guard.write_text("import time\ntime.sleep(5)\n", encoding="utf-8")
+
+    result = run_guard(
+        PRIMARY_ROOT / ".venv" / "bin" / "python",
+        guard,
+        "{}",
+        timeout_seconds=0.01,
+    )
+
+    assert result.returncode == 2
+    assert result.timed_out is True
+    assert "blocking the tool call fail-closed" in result.stderr
 
 
 def test_codex_entry_rewrites_bare_python_from_worktree_without_local_venv(
@@ -145,6 +172,39 @@ def test_claude_python_rewrite_shape_remains_compatible() -> None:
             "command": f"{PRIMARY_ROOT}/.venv/bin/python --version",
         }
     }
+
+
+def test_python_rewrite_preserves_checkout_path_metacharacters(tmp_path: Path) -> None:
+    canonical = tmp_path / "checkout&pipe|root"
+    canonical.mkdir()
+    (canonical / ".venv").symlink_to(
+        PRIMARY_ROOT / ".venv",
+        target_is_directory=True,
+    )
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "cwd": str(canonical),
+        "tool_name": "Bash",
+        "tool_input": {"command": 'python3 -c "print(1)"'},
+    }
+    environment = os.environ.copy()
+    environment["LEARN_UK_CANONICAL_ROOT"] = str(canonical)
+    environment["LEARN_UK_HOOK_PROVIDER"] = "codex"
+
+    completed = subprocess.run(
+        ["bash", str(VENV_HOOK)],
+        cwd=canonical,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    updated = json.loads(completed.stdout)["hookSpecificOutput"]["updatedInput"]
+    assert updated["command"] == (f'{canonical}/.venv/bin/python -c "print(1)"')
 
 
 def _make_inbox_db(project: Path) -> None:

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -1,0 +1,192 @@
+"""Contracts for the Codex-specific lifecycle-hook manifest and entry point."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRIMARY_ROOT = Path(
+    subprocess.check_output(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        text=True,
+    ).strip()
+).parent
+HOOKS_CONFIG = REPO_ROOT / "agents_extensions" / "codex" / "hooks.json"
+ENTRY = REPO_ROOT / "scripts" / "agent_runtime" / "codex_hook_entry.sh"
+VENV_HOOK = REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "enforce-venv.sh"
+INBOX_HOOK = REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "check-gemini-inbox.sh"
+
+
+def _run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+
+
+def _make_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    primary = tmp_path / "primary"
+    worktree = tmp_path / "linked"
+    primary.mkdir()
+    _run(["git", "init", "-b", "main"], cwd=primary)
+    _run(["git", "config", "user.email", "hooks@example.invalid"], cwd=primary)
+    _run(["git", "config", "user.name", "Hook Tests"], cwd=primary)
+    (primary / "README.md").write_text("hook test\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=primary)
+    _run(["git", "commit", "-m", "test fixture"], cwd=primary)
+    (primary / ".venv").symlink_to(PRIMARY_ROOT / ".venv", target_is_directory=True)
+    _run(["git", "worktree", "add", "-b", "codex/hooks-test", str(worktree)], cwd=primary)
+    return primary, worktree
+
+
+def _manifest() -> dict:
+    return json.loads(HOOKS_CONFIG.read_text(encoding="utf-8"))
+
+
+def test_codex_manifest_uses_only_supported_result_event() -> None:
+    hooks = _manifest()["hooks"]
+
+    assert "PostToolUse" in hooks
+    assert "PostToolUseFailure" not in hooks
+
+
+def test_codex_tool_events_have_one_deterministic_command_hook() -> None:
+    hooks = _manifest()["hooks"]
+
+    pre_groups = hooks["PreToolUse"]
+    assert len(pre_groups) == 1
+    assert pre_groups[0]["matcher"] == "^(Bash|Write|Edit|MultiEdit|apply_patch)$"
+    assert len(pre_groups[0]["hooks"]) == 1
+    assert 'codex_hook_entry.sh" pre-tool-use' in pre_groups[0]["hooks"][0]["command"]
+
+    post_groups = hooks["PostToolUse"]
+    assert len(post_groups) == 1
+    assert len(post_groups[0]["hooks"]) == 1
+    assert 'codex_hook_entry.sh" post-tool-use' in post_groups[0]["hooks"][0]["command"]
+
+
+def test_codex_entry_rewrites_bare_python_from_worktree_without_local_venv(
+    tmp_path: Path,
+) -> None:
+    primary, worktree = _make_linked_worktree(tmp_path)
+    assert not (worktree / ".venv").exists()
+
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "cwd": str(primary),
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": 'python3 -c "print(1)"',
+            "workdir": str(worktree),
+        },
+    }
+    completed = subprocess.run(
+        ["bash", str(ENTRY), "pre-tool-use"],
+        cwd=worktree,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    output = json.loads(completed.stdout)
+    specific = output["hookSpecificOutput"]
+    assert specific["hookEventName"] == "PreToolUse"
+    assert specific["permissionDecision"] == "allow"
+    assert specific["updatedInput"]["command"] == (f'{primary}/.venv/bin/python -c "print(1)"')
+
+
+def test_claude_python_rewrite_shape_remains_compatible() -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "cwd": str(PRIMARY_ROOT),
+        "tool_name": "Bash",
+        "tool_input": {"command": "python --version"},
+    }
+    environment = os.environ.copy()
+    environment["LEARN_UK_CANONICAL_ROOT"] = str(PRIMARY_ROOT)
+    environment.pop("LEARN_UK_HOOK_PROVIDER", None)
+
+    completed = subprocess.run(
+        ["bash", str(VENV_HOOK)],
+        cwd=REPO_ROOT,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout) == {
+        "modifiedInput": {
+            "command": f"{PRIMARY_ROOT}/.venv/bin/python --version",
+        }
+    }
+
+
+def _make_inbox_db(project: Path) -> None:
+    db = project / ".mcp" / "servers" / "message-broker" / "messages.db"
+    db.parent.mkdir(parents=True)
+    with sqlite3.connect(db) as connection:
+        connection.execute(
+            """
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY,
+                from_llm TEXT,
+                to_llm TEXT,
+                message_type TEXT,
+                task_id TEXT,
+                content TEXT,
+                timestamp TEXT,
+                acknowledged INTEGER,
+                claimed_by TEXT
+            )
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO messages
+                (from_llm, to_llm, message_type, task_id, content, timestamp,
+                 acknowledged, claimed_by)
+            VALUES (?, ?, 'status', 'hooks', ?, '2026-07-26T00:00:00Z', 0, NULL)
+            """,
+            [
+                ("claude", "codex", "codex-only message"),
+                ("codex", "claude", "claude-only message"),
+            ],
+        )
+
+
+def test_inbox_hook_targets_requested_provider(tmp_path: Path) -> None:
+    _make_inbox_db(tmp_path)
+    environment = os.environ.copy()
+    environment["CLAUDE_PROJECT_DIR"] = str(tmp_path)
+    environment["LEARN_UK_HOOK_RECIPIENT"] = "codex"
+
+    completed = subprocess.run(
+        ["bash", str(INBOX_HOOK)],
+        input="{}",
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    context = json.loads(completed.stdout)["hookSpecificOutput"]["additionalContext"]
+    assert "CODEX INBOX: 1 unread message" in context
+    assert "codex-only message" in context
+    assert "claude-only message" not in context

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -8,10 +8,13 @@ import sqlite3
 import subprocess
 from pathlib import Path
 
+from scripts.agent_runtime import codex_hook_policy
 from scripts.agent_runtime.codex_hook_policy import (
+    ENFORCE_VENV_TIMEOUT,
     LOCAL_BASH_GUARDS,
     MERGE_GUARDS,
     PRIMARY_WRITE_GUARD,
+    _run_enforce_venv,
     run_guard,
 )
 
@@ -83,6 +86,7 @@ def test_codex_tool_events_have_one_deterministic_command_hook() -> None:
 
 
 def test_codex_policy_preserves_tool_scopes_and_per_guard_deadlines() -> None:
+    assert ENFORCE_VENV_TIMEOUT == 3
     assert LOCAL_BASH_GUARDS == (
         ("heal-core-bare.py", 3),
         ("guard-branch-switch-in-main.py", 3),
@@ -108,6 +112,22 @@ def test_codex_policy_guard_timeout_fails_closed(tmp_path: Path) -> None:
 
     assert result.returncode == 2
     assert result.timed_out is True
+    assert "blocking the tool call fail-closed" in result.stderr
+
+
+def test_codex_policy_venv_rewrite_timeout_fails_closed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    guard = tmp_path / "enforce-venv.sh"
+    guard.write_text("#!/bin/bash\nsleep 5\n", encoding="utf-8")
+    monkeypatch.setattr(codex_hook_policy, "ENFORCE_VENV_TIMEOUT", 0.01)
+
+    result = _run_enforce_venv(tmp_path, tmp_path, "{}")
+
+    assert result.returncode == 2
+    assert result.timed_out is True
+    assert "enforce-venv.sh exceeded 0.01s" in result.stderr
     assert "blocking the tool call fail-closed" in result.stderr
 
 

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -14,6 +14,7 @@ from scripts.agent_runtime.codex_hook_policy import (
     LOCAL_BASH_GUARDS,
     MERGE_GUARDS,
     PRIMARY_WRITE_GUARD,
+    _result_code,
     _run_enforce_venv,
     run_guard,
 )
@@ -113,6 +114,26 @@ def test_codex_policy_guard_timeout_fails_closed(tmp_path: Path) -> None:
     assert result.returncode == 2
     assert result.timed_out is True
     assert "blocking the tool call fail-closed" in result.stderr
+
+
+def test_non_rewrite_guard_stdout_fails_closed(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    guard = tmp_path / "noisy_guard.py"
+    guard.write_text("print('not-json')\n", encoding="utf-8")
+    result = run_guard(
+        PRIMARY_ROOT / ".venv" / "bin" / "python",
+        guard,
+        "{}",
+        timeout_seconds=1,
+    )
+
+    assert _result_code([result]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "unexpected stdout" in captured.err
+    assert "not-json" in captured.err
 
 
 def test_codex_policy_venv_rewrite_timeout_fails_closed(

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -8,7 +8,35 @@ import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-PROJECT_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+
+
+def _resolve_project_python() -> Path:
+    local = REPO_ROOT / ".venv" / "bin" / "python"
+    if local.exists():
+        return local
+
+    common_dir = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(REPO_ROOT),
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        ],
+        text=True,
+        timeout=30,
+    ).strip()
+    canonical = Path(common_dir).parent / ".venv" / "bin" / "python"
+    if canonical.exists():
+        return canonical
+
+    raise RuntimeError(
+        f"Project interpreter missing from this checkout and its canonical Git checkout: {local}, {canonical}"
+    )
+
+
+PROJECT_PYTHON = _resolve_project_python()
 DEPLOY_SCRIPT = Path("scripts/deploy_prompts.sh")
 CHECK_SCRIPT = Path("scripts/check_rules_deployment.sh")
 ORPHAN_PATHS_FILE = Path("scripts/deploy_orphan_paths.sh")

--- a/tests/test_tool_timing_hook.py
+++ b/tests/test_tool_timing_hook.py
@@ -9,13 +9,27 @@ import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
+import pytest
+
 from scripts.api.telemetry_router import ToolTimingIngest
 
 _ROOT = Path(__file__).resolve().parents[1]
 _HOOK = _ROOT / "agents_extensions" / "shared" / "hooks" / "tool-timing.sh"
 
 
-def test_hook_posts_json_that_validates_against_tool_timing_model() -> None:
+@pytest.mark.parametrize(
+    "event_result",
+    [
+        {"hook_event_name": "PostToolUseFailure"},
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_response": {"exit_code": 1},
+        },
+    ],
+)
+def test_hook_posts_json_that_validates_against_tool_timing_model(
+    event_result: dict[str, object],
+) -> None:
     posted: list[dict[str, object]] = []
     received = threading.Event()
 
@@ -34,12 +48,12 @@ def test_hook_posts_json_that_validates_against_tool_timing_model() -> None:
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        event = {
+        event: dict[str, object] = {
             "tool_name": 'Bash "quoted" \\ path\nnext',
             "duration_ms": 12.5,
             "tool_use_id": 'tool "id"',
             "session_id": "session\\id",
-            "hook_event_name": "PostToolUseFailure",
+            **event_result,
         }
         environment = os.environ.copy()
         environment["TOOL_TIMING_API_URL"] = f"http://127.0.0.1:{server.server_port}/tool-timings"


### PR DESCRIPTION
## Summary

- replace seven concurrent Codex Bash policy commands with one deterministic `PreToolUse` entry point
- remove unsupported `PostToolUseFailure` registration; supported `PostToolUse` now handles both successful and non-zero Bash results
- emit the current Codex `updatedInput` rewrite schema and resolve the canonical project venv from linked worktrees
- route Codex inbox checks to `codex`, preserve Claude defaults, and make deploy verification work without a worktree-local `.venv`

## Verification

- `123 passed`: Codex hook contract, timing, context consumers, primary-write guard, deploy idempotency
- linked-worktree behavior proof: Codex rewrite succeeded with no local `.venv` and selected the canonical `.venv/bin/python`
- `npm run agents:deploy` succeeded twice from that no-venv worktree; second run reported `No changes to deploy.`
- Ruff, ShellCheck, Bash syntax, JSON parse, Markdownlint, `git diff --check`, OPSEC, and agent-trailer checks passed

## Contract source

Verified against the current official OpenAI Codex Hooks reference on 2026-07-26.

Fixes #5829
