### PR TITLE
fix(site): serve atlas shards raw in dev/preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ dist/
 /build/
 *.tsbuildinfo
 output/json/
+site/public/atlas/
 
 # IDE
 .idea/

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -10,6 +10,7 @@ import rehypeMermaid from 'rehype-mermaid';
 import remarkDirective from 'remark-directive';
 import remarkGfm from 'remark-gfm';
 import remarkAdmonitions from './plugins/remark-admonitions.mjs';
+import { rawAtlasShardTransport } from './plugins/raw-atlas-shard-transport.mjs';
 import vocabEtymologyLinker from './plugins/vocab-etymology-link.mjs';
 
 const remarkPlugins = [remarkDirective, remarkAdmonitions, remarkGfm, vocabEtymologyLinker];
@@ -48,6 +49,20 @@ const isRedirectSource = (page) => {
   );
 };
 
+/** @type {import('astro').AstroAdapter} */
+const rawAtlasPreviewAdapter = {
+  name: 'raw-atlas-preview',
+  previewEntrypoint: fileURLToPath(new URL('./plugins/astro-raw-atlas-preview.mjs', import.meta.url)),
+  supportedAstroFeatures: {
+    hybridOutput: { message: 'Static preview only', support: 'unsupported', suppress: 'all' },
+    serverOutput: { message: 'Static preview only', support: 'unsupported', suppress: 'all' },
+    sharpImageService: { message: 'Static preview only', support: 'unsupported', suppress: 'all' },
+    staticOutput: 'stable',
+  },
+  entrypointResolution: 'auto',
+};
+let isPreviewCommand = false;
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://learn-ukrainian.github.io',
@@ -62,6 +77,7 @@ export default defineConfig({
 
   // Prevent duplicate React instances (SSR + client hydration)
   vite: {
+    plugins: [rawAtlasShardTransport()],
     server: {
       fs: {
         allow: [starlightRoot, starlightNodeModules],
@@ -80,6 +96,17 @@ export default defineConfig({
   },
 
   integrations: [
+    {
+      name: 'raw-atlas-preview-adapter',
+      hooks: {
+        'astro:config:setup': ({ command }) => {
+          isPreviewCommand = command === 'preview';
+        },
+        'astro:config:done': ({ setAdapter }) => {
+          if (isPreviewCommand) setAdapter(rawAtlasPreviewAdapter);
+        },
+      },
+    },
     // GoatCounter — privacy-friendly analytics (no cookies, no PII). Injected on
     // every page from astro.config so coverage does not depend on any single layout.
     // Site code is hardcoded (always active in the production build — no env var that

--- a/site/plugins/astro-raw-atlas-preview.mjs
+++ b/site/plugins/astro-raw-atlas-preview.mjs
@@ -1,47 +1,30 @@
-import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { performance } from 'node:perf_hooks';
 import { resolve } from 'node:path';
-import { fileURLToPath, URL } from 'node:url';
-import { preview } from 'vite';
+import { fileURLToPath } from 'node:url';
+import { mergeConfig, preview } from 'vite';
+import { BuildTimeAstroVersionProvider } from '../node_modules/astro/dist/cli/infra/build-time-astro-version-provider.js';
+import { piccoloreTextStyler } from '../node_modules/astro/dist/cli/infra/piccolore-text-styler.js';
+import { resolveConfig } from '../node_modules/astro/dist/core/config/config.js';
+import * as msg from '../node_modules/astro/dist/core/messages/runtime.js';
+import { getResolvedHostForHttpServer } from '../node_modules/astro/dist/core/preview/util.js';
+import { vitePluginAstroPreview } from '../node_modules/astro/dist/core/preview/vite-plugin-astro-preview.js';
 import { rawAtlasShardTransport } from './raw-atlas-shard-transport.mjs';
 
-const serveStaticDirectories = () => ({
-  name: 'astro-static-directory-preview',
-  configurePreviewServer(server) {
-    server.middlewares.use((request, _response, next) => {
-      const url = new URL(request.url ?? '/', 'http://localhost');
-      if (url.pathname.endsWith('/')) request.url = `${url.pathname}index.html${url.search}`;
-      next();
-    });
-  },
-});
+const require = createRequire(import.meta.url);
+const supportedAstroVersion = '7.1.3';
+const { version: installedAstroVersion } = require('../node_modules/astro/package.json');
 
-const serveAstro404 = (outputDir) => ({
-  name: 'astro-static-404-preview',
-  configurePreviewServer(server) {
-    return () => {
-      server.middlewares.use(async (request, response, next) => {
-        if (!['GET', 'HEAD'].includes(request.method ?? 'GET')) {
-          next();
-          return;
-        }
-
-        try {
-          const page = await readFile(resolve(outputDir, '404.html'));
-          response.statusCode = 404;
-          response.setHeader('Content-Type', 'text/html');
-          response.end(request.method === 'HEAD' ? undefined : page);
-        } catch (error) {
-          next(error);
-        }
-      });
-    };
-  },
-});
+if (installedAstroVersion !== supportedAstroVersion) {
+  throw new Error(
+    `[raw-atlas-preview] Unsupported Astro ${installedAstroVersion}; this adapter is validated only for Astro ${supportedAstroVersion}.`,
+  );
+}
 
 /**
- * Astro's static preview server omits `vite.plugins` by design. Its supported
- * adapter preview entrypoint lets the Atlas transport middleware run before
- * Vite's static-file middleware, just as it does in development.
+ * Astro's static preview server intentionally omits user Vite plugins. This
+ * adapter copies its setup, inserts only the raw Atlas transport after Astro's
+ * guard plugin, and leaves all non-shard routing to Astro's own static plugin.
  */
 export default async function startPreview({
   host,
@@ -52,21 +35,74 @@ export default async function startPreview({
   allowedHosts,
   open,
   root,
+  logger,
 }) {
+  const startServerTime = performance.now();
   const outputDir = fileURLToPath(outDir);
-  const previewServer = await preview({
+  const rootDir = fileURLToPath(root);
+  const { astroConfig } = await resolveConfig({ root: rootDir }, 'preview');
+  const settings = {
+    config: {
+      ...astroConfig,
+      base,
+      outDir,
+      root,
+      server: {
+        ...astroConfig.server,
+        allowedHosts,
+        headers,
+        host,
+        open,
+        port,
+      },
+    },
+  };
+  const astroPreviewConfig = {
     appType: 'mpa',
     base,
     build: { outDir: outputDir },
     configFile: false,
     plugins: [
-      rawAtlasShardTransport(resolve(outputDir, 'atlas')),
-      serveStaticDirectories(),
-      serveAstro404(outputDir),
+      vitePluginAstroPreview(settings),
+      rawAtlasShardTransport(resolve(outputDir, 'atlas'), base),
     ],
-    preview: { allowedHosts, headers, host, open, port },
-    root: fileURLToPath(root),
+    preview: { headers, host, open, port },
+    root: rootDir,
+  };
+  const userViteConfig = { ...(astroConfig.vite ?? {}) };
+  delete userViteConfig.plugins;
+  const mergedViteConfig = mergeConfig(userViteConfig, astroPreviewConfig);
+  if (typeof allowedHosts === 'boolean' || (Array.isArray(allowedHosts) && allowedHosts.length > 0)) {
+    mergedViteConfig.preview ??= {};
+    mergedViteConfig.preview.allowedHosts = allowedHosts;
+  }
+
+  let previewServer;
+  try {
+    previewServer = await preview(mergedViteConfig);
+  } catch (error) {
+    if (error instanceof Error) logger.error(null, error.stack || error.message);
+    throw error;
+  }
+  previewServer.bindCLIShortcuts({
+    customShortcuts: [
+      { key: 'r', description: '' },
+      { key: 'u', description: '' },
+      { key: 'c', description: '' },
+      { key: 's', description: '' },
+    ],
   });
+  logger.info(
+    'SKIP_FORMAT',
+    msg.serverStart({
+      startupTime: performance.now() - startServerTime,
+      resolvedUrls: previewServer.resolvedUrls ?? { local: [], network: [] },
+      host,
+      base,
+      astroVersionProvider: new BuildTimeAstroVersionProvider(),
+      textStyler: piccoloreTextStyler,
+    }),
+  );
   const address = previewServer.httpServer.address();
   const actualPort = address && typeof address === 'object' ? address.port : port;
 
@@ -76,7 +112,7 @@ export default async function startPreview({
         previewServer.httpServer.addListener('close', resolve);
         previewServer.httpServer.addListener('error', reject);
       }),
-    host: typeof host === 'string' ? host : 'localhost',
+    host: getResolvedHostForHttpServer(host),
     port: actualPort,
     server: previewServer.httpServer,
     stop: () => previewServer.close(),

--- a/site/plugins/astro-raw-atlas-preview.mjs
+++ b/site/plugins/astro-raw-atlas-preview.mjs
@@ -1,0 +1,84 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath, URL } from 'node:url';
+import { preview } from 'vite';
+import { rawAtlasShardTransport } from './raw-atlas-shard-transport.mjs';
+
+const serveStaticDirectories = () => ({
+  name: 'astro-static-directory-preview',
+  configurePreviewServer(server) {
+    server.middlewares.use((request, _response, next) => {
+      const url = new URL(request.url ?? '/', 'http://localhost');
+      if (url.pathname.endsWith('/')) request.url = `${url.pathname}index.html${url.search}`;
+      next();
+    });
+  },
+});
+
+const serveAstro404 = (outputDir) => ({
+  name: 'astro-static-404-preview',
+  configurePreviewServer(server) {
+    return () => {
+      server.middlewares.use(async (request, response, next) => {
+        if (!['GET', 'HEAD'].includes(request.method ?? 'GET')) {
+          next();
+          return;
+        }
+
+        try {
+          const page = await readFile(resolve(outputDir, '404.html'));
+          response.statusCode = 404;
+          response.setHeader('Content-Type', 'text/html');
+          response.end(request.method === 'HEAD' ? undefined : page);
+        } catch (error) {
+          next(error);
+        }
+      });
+    };
+  },
+});
+
+/**
+ * Astro's static preview server omits `vite.plugins` by design. Its supported
+ * adapter preview entrypoint lets the Atlas transport middleware run before
+ * Vite's static-file middleware, just as it does in development.
+ */
+export default async function startPreview({
+  host,
+  outDir,
+  port,
+  base,
+  headers,
+  allowedHosts,
+  open,
+  root,
+}) {
+  const outputDir = fileURLToPath(outDir);
+  const previewServer = await preview({
+    appType: 'mpa',
+    base,
+    build: { outDir: outputDir },
+    configFile: false,
+    plugins: [
+      rawAtlasShardTransport(resolve(outputDir, 'atlas')),
+      serveStaticDirectories(),
+      serveAstro404(outputDir),
+    ],
+    preview: { allowedHosts, headers, host, open, port },
+    root: fileURLToPath(root),
+  });
+  const address = previewServer.httpServer.address();
+  const actualPort = address && typeof address === 'object' ? address.port : port;
+
+  return {
+    closed: () =>
+      new Promise((resolve, reject) => {
+        previewServer.httpServer.addListener('close', resolve);
+        previewServer.httpServer.addListener('error', reject);
+      }),
+    host: typeof host === 'string' ? host : 'localhost',
+    port: actualPort,
+    server: previewServer.httpServer,
+    stop: () => previewServer.close(),
+  };
+}

--- a/site/plugins/raw-atlas-shard-transport.mjs
+++ b/site/plugins/raw-atlas-shard-transport.mjs
@@ -9,20 +9,34 @@ const isAtlasShardPath = (pathname) =>
   pathname.startsWith('/atlas/') && pathname.endsWith('.json.gz');
 
 /**
+ * @param {string} pathname
+ * @param {string} base
+ */
+const stripBase = (pathname, base) => {
+  if (base === '/') return pathname;
+  const baseWithoutTrailingSlash = base.endsWith('/') ? base.slice(0, -1) : base;
+  if (pathname === base || pathname === baseWithoutTrailingSlash) return '/';
+  return pathname.startsWith(`${baseWithoutTrailingSlash}/`)
+    ? pathname.slice(baseWithoutTrailingSlash.length)
+    : null;
+};
+
+/**
  * @param {import('node:http').IncomingMessage} request
  * @param {import('node:http').ServerResponse} response
  * @param {(error?: Error) => void} next
  */
-const serveRawAtlasShard = async (atlasRoot, request, response, next) => {
+const serveRawAtlasShard = async (atlasRoot, base, request, response, next) => {
   const method = request.method ?? 'GET';
   const pathname = request.url ? new URL(request.url, 'http://localhost').pathname : '';
+  const atlasPathname = stripBase(pathname, base);
 
-  if (!['GET', 'HEAD'].includes(method) || !isAtlasShardPath(pathname)) {
+  if (!['GET', 'HEAD'].includes(method) || !atlasPathname || !isAtlasShardPath(atlasPathname)) {
     next();
     return;
   }
 
-  const filePath = resolve(atlasRoot, `.${pathname.slice('/atlas'.length)}`);
+  const filePath = resolve(atlasRoot, `.${atlasPathname.slice('/atlas'.length)}`);
   const relativePath = relative(atlasRoot, filePath);
   if (isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
     next();
@@ -33,6 +47,7 @@ const serveRawAtlasShard = async (atlasRoot, request, response, next) => {
     const bytes = await readFile(filePath);
     response.setHeader('Content-Type', 'application/gzip');
     response.setHeader('Content-Length', bytes.length);
+    response.removeHeader('Content-Encoding');
     response.end(method === 'HEAD' ? undefined : bytes);
   } catch (error) {
     if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
@@ -46,18 +61,18 @@ const serveRawAtlasShard = async (atlasRoot, request, response, next) => {
 // Vite invokes these hooks before its static middleware, so no Content-Encoding
 // header can be inferred from the .gz filename.
 /** @returns {import('vite').Plugin} */
-export const rawAtlasShardTransport = (atlasRoot = atlasPublicRoot) => ({
+export const rawAtlasShardTransport = (atlasRoot = atlasPublicRoot, base = '/') => ({
   name: 'raw-atlas-shard-transport',
   /** @param {import('vite').ViteDevServer} server */
   configureServer(server) {
     server.middlewares.use((request, response, next) =>
-      serveRawAtlasShard(atlasRoot, request, response, next),
+      serveRawAtlasShard(atlasRoot, base, request, response, next),
     );
   },
   /** @param {import('vite').PreviewServer} server */
   configurePreviewServer(server) {
     server.middlewares.use((request, response, next) =>
-      serveRawAtlasShard(atlasRoot, request, response, next),
+      serveRawAtlasShard(atlasRoot, base, request, response, next),
     );
   },
 });

--- a/site/plugins/raw-atlas-shard-transport.mjs
+++ b/site/plugins/raw-atlas-shard-transport.mjs
@@ -1,0 +1,63 @@
+import { readFile } from 'node:fs/promises';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath, URL } from 'node:url';
+
+const atlasPublicRoot = fileURLToPath(new URL('../public/atlas/', import.meta.url));
+
+/** @param {string} pathname */
+const isAtlasShardPath = (pathname) =>
+  pathname.startsWith('/atlas/') && pathname.endsWith('.json.gz');
+
+/**
+ * @param {import('node:http').IncomingMessage} request
+ * @param {import('node:http').ServerResponse} response
+ * @param {(error?: Error) => void} next
+ */
+const serveRawAtlasShard = async (atlasRoot, request, response, next) => {
+  const method = request.method ?? 'GET';
+  const pathname = request.url ? new URL(request.url, 'http://localhost').pathname : '';
+
+  if (!['GET', 'HEAD'].includes(method) || !isAtlasShardPath(pathname)) {
+    next();
+    return;
+  }
+
+  const filePath = resolve(atlasRoot, `.${pathname.slice('/atlas'.length)}`);
+  const relativePath = relative(atlasRoot, filePath);
+  if (isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
+    next();
+    return;
+  }
+
+  try {
+    const bytes = await readFile(filePath);
+    response.setHeader('Content-Type', 'application/gzip');
+    response.setHeader('Content-Length', bytes.length);
+    response.end(method === 'HEAD' ? undefined : bytes);
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      next();
+      return;
+    }
+    next(error);
+  }
+};
+
+// Vite invokes these hooks before its static middleware, so no Content-Encoding
+// header can be inferred from the .gz filename.
+/** @returns {import('vite').Plugin} */
+export const rawAtlasShardTransport = (atlasRoot = atlasPublicRoot) => ({
+  name: 'raw-atlas-shard-transport',
+  /** @param {import('vite').ViteDevServer} server */
+  configureServer(server) {
+    server.middlewares.use((request, response, next) =>
+      serveRawAtlasShard(atlasRoot, request, response, next),
+    );
+  },
+  /** @param {import('vite').PreviewServer} server */
+  configurePreviewServer(server) {
+    server.middlewares.use((request, response, next) =>
+      serveRawAtlasShard(atlasRoot, request, response, next),
+    );
+  },
+});

--- a/site/tests/unit/raw-atlas-shard-transport.test.ts
+++ b/site/tests/unit/raw-atlas-shard-transport.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { get as getHttp } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { createServer, type ViteDevServer } from 'vite';
+import { afterEach, describe, expect, test } from 'vitest';
+import startPreview from '@site/plugins/astro-raw-atlas-preview.mjs';
+import { rawAtlasShardTransport } from '@site/plugins/raw-atlas-shard-transport.mjs';
+
+const rawShard = new Uint8Array([0x1f, 0x8b, 0x08, 0x00, 0x2a, 0x54, 0x5a, 0x01]);
+const untouchedAsset = new Uint8Array([0x7b, 0x22, 0x6f, 0x6b, 0x22, 0x3a, 0x74, 0x72, 0x75, 0x65, 0x7d]);
+const notFoundPage = '<h1>real Astro 404</h1>';
+const temporaryRoots: string[] = [];
+
+type RunningServer = {
+  baseUrl: string;
+  stop: () => Promise<void>;
+};
+
+type HttpResponse = {
+  body: Uint8Array;
+  headers: Record<string, string | string[] | undefined>;
+  status: number;
+};
+
+function serverUrl(httpServer: ViteDevServer['httpServer']): string {
+  const address = httpServer?.address();
+  if (!address || typeof address === 'string') throw new Error('Vite did not expose a TCP address');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function get(url: string): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const request = getHttp(url, (response) => {
+      const chunks: Uint8Array[] = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => {
+        resolve({
+          body: new Uint8Array(Buffer.concat(chunks)),
+          headers: response.headers,
+          status: response.statusCode ?? 0,
+        });
+      });
+    });
+    request.on('error', reject);
+  });
+}
+
+async function writeFixture(assetRoot: string, root: string): Promise<void> {
+  await mkdir(join(assetRoot, 'atlas'), { recursive: true });
+  await mkdir(join(assetRoot, 'lexicon'), { recursive: true });
+  await writeFile(join(assetRoot, 'atlas', 'fixture.json.gz'), rawShard);
+  await writeFile(join(assetRoot, 'atlas', 'untouched.json'), untouchedAsset);
+  await writeFile(join(assetRoot, 'lexicon', 'index.html'), '<h1>lexicon fixture</h1>');
+  await writeFile(join(assetRoot, '404.html'), notFoundPage);
+  await writeFile(
+    join(root, 'astro.config.mjs'),
+    "export default { base: '/preview-base/', trailingSlash: 'always', vite: { preview: { headers: { 'X-Project-Vite': 'merged' } } } };\n",
+  );
+}
+
+async function startDev(root: string, publicDir: string): Promise<RunningServer> {
+  const server = await createServer({
+    appType: 'mpa',
+    configFile: false,
+    plugins: [rawAtlasShardTransport(join(publicDir, 'atlas'))],
+    publicDir,
+    root,
+    server: { host: '127.0.0.1', port: 0 },
+  });
+  await server.listen();
+  return { baseUrl: serverUrl(server.httpServer), stop: () => server.close() };
+}
+
+async function startGuardedPreview(root: string, outDir: string): Promise<RunningServer> {
+  const server = await startPreview({
+    allowedHosts: [],
+    base: '/preview-base/',
+    headers: {},
+    host: '127.0.0.1',
+    logger: { error: () => {}, info: () => {} },
+    open: false,
+    outDir: pathToFileURL(outDir),
+    port: 0,
+    root: pathToFileURL(`${root}/`),
+  });
+  return { baseUrl: `http://127.0.0.1:${server.port}`, stop: () => server.stop() };
+}
+
+async function expectRawShardTransport(server: RunningServer, prefix = ''): Promise<void> {
+  const response = await get(`${server.baseUrl}${prefix}/atlas/fixture.json.gz`);
+  expect(response.status).toBe(200);
+  expect(response.headers['content-encoding'] ?? null).toBeNull();
+  expect(response.headers['content-type']?.toString().split(';', 1)[0]).toBe('application/gzip');
+  expect(Number(response.headers['content-length'])).toBe(rawShard.byteLength);
+  expect(response.body).toEqual(rawShard);
+}
+
+async function expectUnchangedAsset(server: RunningServer, prefix = ''): Promise<void> {
+  const response = await get(`${server.baseUrl}${prefix}/atlas/untouched.json`);
+  expect(response.status).toBe(200);
+  expect(response.headers['content-type']?.toString().split(';', 1)[0]).toBe('application/json');
+  expect(response.body).toEqual(untouchedAsset);
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe('raw Atlas shard transport', () => {
+  test('serves raw shard bytes in real Vite dev and guarded Astro preview servers', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'raw-atlas-shard-transport-'));
+    temporaryRoots.push(root);
+    const publicDir = join(root, 'public');
+    const outDir = join(root, 'dist');
+    await writeFixture(publicDir, root);
+    await writeFixture(outDir, root);
+
+    const dev = await startDev(root, publicDir);
+    try {
+      await expectRawShardTransport(dev);
+      await expectUnchangedAsset(dev);
+    } finally {
+      await dev.stop();
+    }
+
+    const previewServer = await startGuardedPreview(root, outDir);
+    try {
+      await expectRawShardTransport(previewServer, '/preview-base');
+      await expectUnchangedAsset(previewServer, '/preview-base');
+      expect(
+        (await get(`${previewServer.baseUrl}/preview-base/atlas/untouched.json`)).headers[
+          'x-project-vite'
+        ],
+      ).toBe('merged');
+
+      const slashless = await get(`${previewServer.baseUrl}/preview-base/lexicon`);
+      expect(slashless.status).toBe(404);
+      expect((await get(`${previewServer.baseUrl}/preview-base/lexicon/`)).status).toBe(200);
+      expect((await get(`${previewServer.baseUrl}/atlas/fixture.json.gz`)).status).toBe(404);
+
+      const notFound = await get(`${previewServer.baseUrl}/preview-base/not-here/`);
+      expect(notFound.status).toBe(404);
+      expect(new TextDecoder().decode(notFound.body)).toBe(notFoundPage);
+    } finally {
+      await previewServer.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- serve Atlas `.json.gz` shards as raw gzip bytes in Astro dev
- use an Astro preview entrypoint so preview applies the same raw transport to `dist/atlas`
- ignore generated `site/public/atlas/`

## Verification
- raw-shard header checks in isolated dev and preview servers: no `Content-Encoding`, `Content-Type: application/gzip`
- Playwright word page rendered `прапор` in dev and preview
- fresh-preview Atlas browser suite: 16/16 passed
- `npx vitest run tests/unit/atlas-runtime-shards.test.ts`: 13 passed, 4 skipped
- ESLint on touched files and `git diff --check` passed

## Review
- Gemini 3.1 Pro advisory review approved after the preview asset-root correction.

No merge requested; awaiting formal cross-family review.