### PR TITLE
fix(hooks): bound merge guard lookups

### DIFF
--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -20,7 +20,7 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent_runtime/codex_hook_entry.sh\" pre-tool-use",
-            "timeout": 55,
+          "timeout": 45,
             "statusMessage": "Running Codex tool policy"
           }
         ]

--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -20,7 +20,7 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent_runtime/codex_hook_entry.sh\" pre-tool-use",
-          "timeout": 45,
+            "timeout": 45,
             "statusMessage": "Running Codex tool policy"
           }
         ]

--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -20,6 +20,7 @@ Blocking (required) checks per #M-0.5: pytest, ruff, frontend/vitest, schema/MDX
 gitleaks/secret-scan, radon/quality-gates, prompt-lint, CodeQL/Analyze. Matched by name
 substring (case-insensitive); erring toward "treat as blocking" is the safe direction here.
 """
+
 from __future__ import annotations
 
 import json
@@ -210,9 +211,7 @@ def _skip_command_prefix(seg: list[str], i: int) -> int:
     missed (#4877)."""
     while i < len(seg):
         tok = seg[i]
-        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(
-            tok
-        ):
+        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(tok):
             i += 1
         else:
             break
@@ -229,23 +228,11 @@ def _admin_merge_args(seg: list[str]) -> list[str] | None:
 
 
 def _pr_number(args: list[str]) -> str | None:
-    """First numeric positional after `merge`, else the current branch's PR number."""
+    """First numeric positional after `merge`; implicit discovery is refused."""
     for a in args:
         if not a.startswith("-") and a.isdigit():
             return a
-    try:
-        out = subprocess.run(
-            ["gh", "pr", "view", "--json", "number", "-q", ".number"],
-            capture_output=True,
-            env=_gh_env(),
-            text=True,
-            timeout=10,
-        )
-        # Decolorized before use, not just before json.loads: a colorized "5" is passed
-        # straight to the next gh call as the PR selector, where the escapes break it.
-        return _decolorize(out.stdout or "").strip() or None
-    except Exception:
-        return None
+    return None
 
 
 def _failing_blocking_checks(pr: str) -> list[str] | None:

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -37,8 +37,10 @@ Nothing matching on Bash commands can close that, so the job is to make the CARE
 refuse, not the deliberate path impossible. A shell here-string (`sh <<< '<cmd>'`) is
 likewise unread — a deliberate-only shape, documented rather than papered over.
 """
+
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import os
 import re
@@ -63,6 +65,7 @@ def _gh_env() -> dict[str, str]:
 
 def _decolorize(text: str) -> str:
     return _ANSI_RE.sub("", text)
+
 
 # A check is treated as merge-blocking unless its name marks it explicitly advisory.
 # Same inversion as guard-admin-merge.py, and it matters more here: an allowlist of
@@ -364,9 +367,7 @@ def _skip_command_prefix(seg: list[str], i: int) -> int:
     `env FOO=1 gh pr merge` or `{ gh pr merge; }` is not missed (#4877)."""
     while i < len(seg):
         tok = seg[i]
-        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(
-            tok
-        ):
+        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(tok):
             i += 1
         else:
             break
@@ -385,9 +386,27 @@ def _find_merge(seg: list[str], start: int) -> int | None:
 
 
 # xargs options that consume a value; everything else short is a switch.
-_XARGS_VALUE_OPTS = {"-n", "-P", "-I", "-i", "-L", "-l", "-s", "-d", "-E", "-e", "-a", "--max-args",
-                     "--max-procs", "--replace", "--max-lines", "--max-chars", "--delimiter",
-                     "--eof", "--arg-file"}
+_XARGS_VALUE_OPTS = {
+    "-n",
+    "-P",
+    "-I",
+    "-i",
+    "-L",
+    "-l",
+    "-s",
+    "-d",
+    "-E",
+    "-e",
+    "-a",
+    "--max-args",
+    "--max-procs",
+    "--replace",
+    "--max-lines",
+    "--max-chars",
+    "--delimiter",
+    "--eof",
+    "--arg-file",
+}
 
 
 def _invoked_start(seg: list[str]) -> tuple[int, bool]:
@@ -632,13 +651,18 @@ def _merge_args(seg: list[str]) -> list[str] | None:
 # commit subject and the real target is the current branch's PR. Judging the wrong PR is a
 # fail-open (green PR #5 waves through a red current branch), not a cosmetic slip.
 _VALUE_FLAGS = {
-    "--subject", "-t",
-    "--body", "-b",
-    "--body-file", "-F",
+    "--subject",
+    "-t",
+    "--body",
+    "-b",
+    "--body-file",
+    "-F",
     "--match-head-commit",
-    "--author-email", "-A",
+    "--author-email",
+    "-A",
     # Inherited by every `gh pr` subcommand: `-R, --repo [HOST/]OWNER/REPO`.
-    "--repo", "-R",
+    "--repo",
+    "-R",
 }
 
 
@@ -747,24 +771,9 @@ def _pr_selector(args: list[str]) -> str | None:
 
 
 def _pr_ref(args: list[str], repo: str | None = None, cwd: str | None = None) -> str | None:
-    """The PR to judge: the explicit selector, else the current branch's PR number."""
-    selector = _pr_selector(args)
-    if selector:
-        return selector
-    try:
-        out = subprocess.run(
-            ["gh", "pr", "view", *_repo_args(repo), "--json", "number", "-q", ".number"],
-            capture_output=True,
-            env=_gh_env(),
-            cwd=cwd,
-            text=True,
-            timeout=10,
-        )
-    except Exception:
-        return None
-    if out.returncode != 0:
-        return None
-    return out.stdout.strip() or None
+    """The explicit PR selector; implicit current-branch discovery is refused."""
+    del repo, cwd
+    return _pr_selector(args)
 
 
 def _owner_repo_from_url(url: str) -> str | None:
@@ -891,6 +900,18 @@ def _base_protected(owner_repo: str, base: str) -> bool | None:
     return bool(contexts or checks)
 
 
+def _pr_snapshot(
+    pr: str,
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> tuple[dict | None, tuple[list[str], list[str]] | None]:
+    """Read independent PR metadata and check state concurrently."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        meta_future = pool.submit(_pr_meta, pr, repo, cwd)
+        states_future = pool.submit(_check_states, pr, repo, cwd)
+        return meta_future.result(), states_future.result()
+
+
 _FOOTER = (
     "GitHub will merge a draft or a red PR without complaint — branch protection stops only\n"
     "what it was configured to require, and on a free-plan private repo it cannot be configured\n"
@@ -921,7 +942,7 @@ def _judge(args: list[str], cwd: str | None = None) -> str | None:
             "could not determine which PR this merges",
             "Name the PR explicitly (`gh pr merge <number> ...`) so the merge can be verified.",
         )
-    meta = _pr_meta(pr, repo, cwd=cwd)
+    meta, states = _pr_snapshot(pr, repo, cwd=cwd)
     if meta is None:
         return _block_msg(
             f"could not verify PR {pr}'s draft status (gh error, timeout, or unexpected schema)",
@@ -935,7 +956,6 @@ def _judge(args: list[str], cwd: str | None = None) -> str | None:
             "(the #189 incident: a draft was squash-merged before anyone reviewed it). Mark it\n"
             "ready (`gh pr ready`) and get the review gate first.",
         )
-    states = _check_states(pr, repo, cwd=cwd)
     if states is None:
         return _block_msg(
             f"could not verify PR {pr} check states (gh error, timeout, or an unrecognized check state)",

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -34,20 +34,26 @@ deterministic entry point:
 its own 3-second fail-closed deadline. `PreToolUse` local policy checks then run
 sequentially with their former 3–5 second individual deadlines. The two
 independent, network-backed merge guards run concurrently with separate
-30-second deadlines, and their results are emitted in a fixed order.
+20-second aggregate deadlines, and their results are emitted in a fixed order.
 `PostToolUse` telemetry and pytest stamping run sequentially. This removes the
 prior seven-process Bash fan-out and the unsupported failure-event duplicate
 without letting one slow merge guard starve the other.
 
 `codex_hook_policy.py` converts an individual guard timeout into exit code `2`
 with a concrete reason. Per the Codex `PreToolUse` contract, exit `2` blocks the
-tool call; a timeout therefore fails closed. The manifest's 55-second outer
+tool call; a timeout therefore fails closed. The manifest's 45-second outer
 timeout remains a last-resort ceiling above the 3-second rewrite, local-chain,
 and concurrent network-guard budgets.
 
 Only the venv rewrite may write the final Codex JSON response to stdout.
 Unexpected stdout from any policy guard is redirected to diagnostics and
 fails closed, preventing multiple payloads from corrupting the hook response.
+
+Merge commands must name the PR explicitly. This removes the preliminary
+current-branch discovery call and prevents the guard from checking one PR while
+`gh` resolves another. For normal merges, independent PR metadata and check
+lookups run concurrently; `--auto` branch-protection verification follows only
+after those results identify the exact base.
 
 The entry point resolves the exact tool worktree from structured hook input and
 the canonical checkout from Git's common directory. Python policies use the

--- a/scripts/agent_runtime/codex_hook_policy.py
+++ b/scripts/agent_runtime/codex_hook_policy.py
@@ -20,8 +20,8 @@ LOCAL_BASH_GUARDS = (
 ENFORCE_VENV_TIMEOUT = 3
 PRIMARY_WRITE_GUARD = ("guard-primary-checkout-write.py", 5)
 MERGE_GUARDS = (
-    ("guard-admin-merge.py", 30),
-    ("guard-pr-merge.py", 30),
+    ("guard-admin-merge.py", 20),
+    ("guard-pr-merge.py", 20),
 )
 
 

--- a/tests/test_codex_hooks_contract.py
+++ b/tests/test_codex_hooks_contract.py
@@ -78,7 +78,7 @@ def test_codex_tool_events_have_one_deterministic_command_hook() -> None:
     assert len(pre_groups[0]["hooks"]) == 1
     pre_hook = pre_groups[0]["hooks"][0]
     assert 'codex_hook_entry.sh" pre-tool-use' in pre_hook["command"]
-    assert pre_hook["timeout"] == 55
+    assert pre_hook["timeout"] == 45
 
     post_groups = hooks["PostToolUse"]
     assert len(post_groups) == 1
@@ -95,8 +95,8 @@ def test_codex_policy_preserves_tool_scopes_and_per_guard_deadlines() -> None:
     )
     assert PRIMARY_WRITE_GUARD == ("guard-primary-checkout-write.py", 5)
     assert MERGE_GUARDS == (
-        ("guard-admin-merge.py", 30),
-        ("guard-pr-merge.py", 30),
+        ("guard-admin-merge.py", 20),
+        ("guard-pr-merge.py", 20),
     )
 
 

--- a/tests/test_guard_admin_merge.py
+++ b/tests/test_guard_admin_merge.py
@@ -43,9 +43,7 @@ def _run(monkeypatch, command: str, *, pr: str | None = "5", failing=()) -> int:
     payload = json.dumps({"tool_input": {"command": command}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
     monkeypatch.setattr(guard, "_pr_number", lambda args: pr)
-    monkeypatch.setattr(
-        guard, "_failing_blocking_checks", lambda p: (list(failing) if failing is not None else None)
-    )
+    monkeypatch.setattr(guard, "_failing_blocking_checks", lambda p: list(failing) if failing is not None else None)
     return guard.main()
 
 
@@ -157,9 +155,7 @@ def test_failing_checks_garbage_output_is_failclosed(monkeypatch):
 
 
 def _any_admin(command: str) -> bool:
-    return any(
-        guard._admin_merge_args(s) is not None for s in guard._segments(command)
-    )
+    return any(guard._admin_merge_args(s) is not None for s in guard._segments(command))
 
 
 @pytest.mark.parametrize(
@@ -213,11 +209,11 @@ def test_unclosed_heredoc_does_not_hide_admin():
 
 # Escapes sit OUTSIDE the string tokens, as gh's colorizer actually emits them.
 _COLORIZED_ROWS = (
-    '\x1b[1;37m[\x1b[m{\n'
+    "\x1b[1;37m[\x1b[m{\n"
     '  \x1b[1;34m"name"\x1b[m: \x1b[32m"Test (pytest)"\x1b[m,\n'
     '  \x1b[1;34m"bucket"\x1b[m: \x1b[32m"pass"\x1b[m,\n'
     '  \x1b[1;34m"state"\x1b[m: \x1b[32m"SUCCESS"\x1b[m\n'
-    '}\x1b[1;37m]\x1b[m\n'
+    "}\x1b[1;37m]\x1b[m\n"
 )
 
 
@@ -282,22 +278,17 @@ def test_colorized_blocking_failure_still_blocks(monkeypatch):
     assert guard._failing_blocking_checks("5") == ["Test (pytest)"]
 
 
-def test_colorized_pr_number_recovered(monkeypatch):
-    """`-q .number` output is passed to the NEXT gh call as the selector, so escapes
-    there break it just as surely as a failed parse."""
-    _fake_gh(monkeypatch, returncode=0, stdout="\x1b[32m5\x1b[m\n")
-    assert guard._pr_number(["--admin"]) == "5"
+def test_pr_number_requires_explicit_numeric_selector():
+    assert guard._pr_number(["--admin"]) is None
+    assert guard._pr_number(["5", "--admin"]) == "5"
 
 
-def test_both_gh_sites_run_with_scrubbed_env(monkeypatch):
-    """Both subprocess sites, not just one: the sibling's B1 fix was partial exactly
-    because a second raw call site was missed."""
+def test_gh_check_lookup_runs_with_scrubbed_env(monkeypatch):
     monkeypatch.setenv("CLICOLOR_FORCE", "1")
     monkeypatch.setenv("FORCE_COLOR", "1")
     calls = _capture_gh(monkeypatch, returncode=0, stdout="[]")
-    guard._pr_number(["--admin"])
     guard._failing_blocking_checks("5")
-    assert len(calls) == 2
+    assert len(calls) == 1
     for cmd, kwargs in calls:
         env = kwargs.get("env")
         assert env is not None, f"{cmd} ran without a scrubbed env"
@@ -306,12 +297,9 @@ def test_both_gh_sites_run_with_scrubbed_env(monkeypatch):
 
 
 def test_gh_timeouts_stay_within_hook_budget(monkeypatch):
-    """Both gh calls can run in one main() pass; their timeouts must fit the hook's
-    registered 30s budget (settings.json) with headroom, else a slow gh is killed by the
-    harness mid-verdict rather than fail-closing cleanly."""
+    """The only admin lookup must fit the aggregate merge-guard budget."""
     calls = _capture_gh(monkeypatch, returncode=0, stdout="[]")
-    guard._pr_number(["--admin"])
     guard._failing_blocking_checks("5")
     timeouts = [kwargs["timeout"] for _cmd, kwargs in calls]
     assert all(t > 0 for t in timeouts)
-    assert sum(timeouts) < 30
+    assert sum(timeouts) < 20

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -23,6 +23,7 @@ import io
 import json
 import os
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
@@ -68,7 +69,7 @@ def _run(
     monkeypatch.setattr(
         guard,
         "_pr_meta",
-        lambda p, repo=None, cwd=None: ({"isDraft": False, "baseRefName": "main", "url": _URL} if meta is None else meta),
+        lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": _URL} if meta is None else meta,
     )
     monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: checks)
     monkeypatch.setattr(guard, "_owner_repo_from_url", lambda u: owner_repo)
@@ -111,6 +112,28 @@ def test_is_advisory():
     assert not guard._is_advisory("Test (pytest)")
 
 
+def test_pr_snapshot_reads_metadata_and_checks_concurrently(monkeypatch):
+    barrier = threading.Barrier(2)
+
+    def meta(*_args):
+        barrier.wait(timeout=1)
+        return {"isDraft": False}
+
+    def states(*_args):
+        barrier.wait(timeout=1)
+        return ([], [])
+
+    monkeypatch.setattr(guard, "_pr_meta", meta)
+    monkeypatch.setattr(guard, "_check_states", states)
+
+    assert guard._pr_snapshot("5") == ({"isDraft": False}, ([], []))
+
+
+def test_pr_ref_requires_explicit_selector():
+    assert guard._pr_ref(["--squash"]) is None
+    assert guard._pr_ref(["5", "--squash"]) == "5"
+
+
 # --- main() decision (fail-closed) -----------------------------------------
 
 
@@ -129,9 +152,10 @@ def test_admin_merge_is_other_guards_job(monkeypatch):
 
 def test_disable_auto_is_not_a_merge(monkeypatch):
     # Disarming auto-merge on a draft is the remedy this guard asks for — never block it.
-    assert _run(
-        monkeypatch, "gh pr merge 5 --disable-auto", meta={"isDraft": True, "baseRefName": "main", "url": _URL}
-    ) == 0
+    assert (
+        _run(monkeypatch, "gh pr merge 5 --disable-auto", meta={"isDraft": True, "baseRefName": "main", "url": _URL})
+        == 0
+    )
 
 
 def test_draft_is_blocked(monkeypatch):
@@ -287,7 +311,9 @@ def test_auto_on_base_with_empty_required_checks_is_blocked(monkeypatch):
     payload = json.dumps({"tool_input": {"command": "gh pr merge 5 --auto --squash"}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
     monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None, cwd=None: "5")
-    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": _URL})
+    monkeypatch.setattr(
+        guard, "_pr_meta", lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": _URL}
+    )
     monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: ([], []))
     monkeypatch.setattr(guard, "_owner_repo_from_url", lambda u: "owner/repo")
     assert guard.main() == 2
@@ -338,9 +364,12 @@ def test_auto_equals_false_is_a_normal_merge(monkeypatch):
 
 def test_disable_auto_equals_true_is_not_a_merge(monkeypatch):
     # F005: the safe disarm was judged (and blocked) in its `=true` spelling.
-    assert _run(
-        monkeypatch, "gh pr merge 5 --disable-auto=true", meta={"isDraft": True, "baseRefName": "main", "url": _URL}
-    ) == 0
+    assert (
+        _run(
+            monkeypatch, "gh pr merge 5 --disable-auto=true", meta={"isDraft": True, "baseRefName": "main", "url": _URL}
+        )
+        == 0
+    )
 
 
 def test_admin_equals_true_is_judged_here(monkeypatch):
@@ -463,7 +492,10 @@ def test_pr_selector(args, expected):
 @pytest.mark.parametrize(
     "url,expected",
     [
-        ("https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5324", "learn-ukrainian/learn-ukrainian.github.io"),
+        (
+            "https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5324",
+            "learn-ukrainian/learn-ukrainian.github.io",
+        ),
         ("https://github.com/other/repo/pull/9", "other/repo"),
         ("https://ghe.example.com/o/r/pull/1", "o/r"),
         ("not a url", None),
@@ -483,7 +515,11 @@ def test_cross_repo_url_selector_uses_that_repo(monkeypatch):
     monkeypatch.setattr(
         guard,
         "_pr_meta",
-        lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": "https://github.com/other/repo/pull/9"},
+        lambda p, repo=None, cwd=None: {
+            "isDraft": False,
+            "baseRefName": "main",
+            "url": "https://github.com/other/repo/pull/9",
+        },
     )
     monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: ([], []))
     monkeypatch.setattr(guard, "_base_protected", lambda o, b: seen.setdefault("repo", o) and True)
@@ -495,7 +531,9 @@ def test_cross_repo_url_selector_uses_that_repo(monkeypatch):
 
 def test_pr_meta_requires_url_field(monkeypatch):
     # url is load-bearing for the protection lookup; gh must actually return it.
-    _fake_gh(monkeypatch, returncode=0, stdout='{"isDraft":false,"baseRefName":"main","url":"https://github.com/o/r/pull/5"}')
+    _fake_gh(
+        monkeypatch, returncode=0, stdout='{"isDraft":false,"baseRefName":"main","url":"https://github.com/o/r/pull/5"}'
+    )
     assert guard._pr_meta("5") == {
         "isDraft": False,
         "baseRefName": "main",
@@ -542,7 +580,9 @@ def test_recursion_cap_fails_closed(monkeypatch):
     # selector, and _pr_ref falls back to the CURRENT BRANCH's PR — so without an
     # explicit marker check, a green current branch would approve an unread payload.
     monkeypatch.setattr(guard, "_pr_ref", lambda args, repo=None, cwd=None: "5")
-    monkeypatch.setattr(guard, "_pr_meta", lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": _URL})
+    monkeypatch.setattr(
+        guard, "_pr_meta", lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": _URL}
+    )
     monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: ([], []))  # all green
     assert guard._judge([guard._UNREADABLE_MARKER]) is not None
 
@@ -610,7 +650,9 @@ def test_repo_is_propagated_to_every_gh_lookup(monkeypatch):
         calls.append(argv)
         if argv[:3] == ["gh", "pr", "view"]:
             return types.SimpleNamespace(
-                returncode=0, stdout='{"isDraft":false,"baseRefName":"main","url":"https://github.com/other/repo/pull/9"}', stderr=""
+                returncode=0,
+                stdout='{"isDraft":false,"baseRefName":"main","url":"https://github.com/other/repo/pull/9"}',
+                stderr="",
             )
         return types.SimpleNamespace(returncode=0, stdout="[]", stderr="")
 
@@ -801,11 +843,11 @@ def test_backslash_continuation_merge_detected():
 # fail-closes. The guard must scrub the env AND tolerate residual ANSI.
 
 _COLORIZED_JSON = (
-    '\x1b[1;37m{\x1b[m\n'
+    "\x1b[1;37m{\x1b[m\n"
     '  \x1b[1;34m"baseRefName"\x1b[m: \x1b[32m"main"\x1b[m,\n'
     '  \x1b[1;34m"isDraft"\x1b[m: \x1b[35mfalse\x1b[m,\n'
     '  \x1b[1;34m"url"\x1b[m: \x1b[32m"https://github.com/owner/repo/pull/5"\x1b[m\n'
-    '\x1b[1;37m}\x1b[m\n'
+    "\x1b[1;37m}\x1b[m\n"
 )
 
 
@@ -867,12 +909,12 @@ def test_colorized_base_protection_still_classified(monkeypatch):
     """_base_protected's parse was raw too. Colorized protection JSON must classify as
     protected — reading it as undeterminable blocks legitimate --auto on a guarded base."""
     colorized = (
-        '\x1b[1;37m{\x1b[m\n'
+        "\x1b[1;37m{\x1b[m\n"
         '  \x1b[1;34m"required_status_checks"\x1b[m: \x1b[1;37m{\x1b[m\n'
         '    \x1b[1;34m"contexts"\x1b[m: [\x1b[32m"Test (pytest)"\x1b[m],\n'
         '    \x1b[1;34m"strict"\x1b[m: \x1b[35mtrue\x1b[m\n'
-        '  \x1b[1;37m}\x1b[m\n'
-        '\x1b[1;37m}\x1b[m\n'
+        "  \x1b[1;37m}\x1b[m\n"
+        "\x1b[1;37m}\x1b[m\n"
     )
     completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=colorized, stderr="")
     monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
@@ -913,9 +955,7 @@ def test_cd_then_merge_threads_cwd(monkeypatch):
         seen["cwd"] = cwd
         return None
 
-    payload = json.dumps(
-        {"tool_input": {"command": "cd /tmp && gh pr merge 7 --squash"}}
-    )
+    payload = json.dumps({"tool_input": {"command": "cd /tmp && gh pr merge 7 --squash"}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
     monkeypatch.setattr(guard, "_judge", fake_judge)
     assert guard.main() == 0
@@ -923,9 +963,7 @@ def test_cd_then_merge_threads_cwd(monkeypatch):
 
 
 def test_unreadable_cd_before_merge_blocks(monkeypatch):
-    payload = json.dumps(
-        {"tool_input": {"command": 'cd "$WORKDIR" && gh pr merge 7 --squash'}}
-    )
+    payload = json.dumps({"tool_input": {"command": 'cd "$WORKDIR" && gh pr merge 7 --squash'}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
     assert guard.main() == 2
 
@@ -989,9 +1027,7 @@ def test_shell_c_cd_does_not_leak_out(monkeypatch):
     `bash -c 'cd /inner && true'` ends with the outer shell still where it started, so
     PR 9 is resolved there — not in /inner, whose PR 9 is a different PR entirely.
     """
-    assert _judged_cwds(monkeypatch, "bash -c 'cd /inner && true' && gh pr merge 9") == [
-        ("9", None)
-    ]
+    assert _judged_cwds(monkeypatch, "bash -c 'cd /inner && true' && gh pr merge 9") == [("9", None)]
 
 
 def test_subshell_cd_does_not_leak_out(monkeypatch):
@@ -1039,9 +1075,7 @@ def test_glued_subshell_operators_keep_scope(monkeypatch):
 
 def test_command_substitution_cd_does_not_leak(monkeypatch):
     """`$(...)` runs in a subshell, so its cd dies at the `)` — as bash does."""
-    assert _judged_cwds(monkeypatch, "cd /a && echo $(cd /b; pwd) && gh pr merge 1") == [
-        ("1", "/a")
-    ]
+    assert _judged_cwds(monkeypatch, "cd /a && echo $(cd /b; pwd) && gh pr merge 1") == [("1", "/a")]
 
 
 def test_unreadable_cd_inside_payload_does_not_escape(monkeypatch):
@@ -1075,9 +1109,7 @@ def test_cd_threads_across_lines(monkeypatch):
 
 
 def test_multiline_merges_track_their_own_cwd(monkeypatch):
-    assert _judged_cwds(
-        monkeypatch, "cd /a\ngh pr merge 1\ncd /b\ngh pr merge 2"
-    ) == [("1", "/a"), ("2", "/b")]
+    assert _judged_cwds(monkeypatch, "cd /a\ngh pr merge 1\ncd /b\ngh pr merge 2") == [("1", "/a"), ("2", "/b")]
 
 
 # --- #5333 r2: the fail-closed path's own two bugs ----------------------------
@@ -1097,9 +1129,7 @@ def test_repo_option_is_honoured_when_cwd_is_unreadable(monkeypatch):
 
     The `case` arm's bare `)` is what makes the cwd unreadable here (see N1 below).
     """
-    assert _judged_cwds(
-        monkeypatch, "case x in y) true;; esac; gh pr merge 9 --squash -R owner/repo"
-    ) == [("9", None)]
+    assert _judged_cwds(monkeypatch, "case x in y) true;; esac; gh pr merge 9 --squash -R owner/repo") == [("9", None)]
 
 
 def test_repo_option_under_unreadable_cwd_is_judged_not_waved_through(monkeypatch):
@@ -1108,9 +1138,7 @@ def test_repo_option_under_unreadable_cwd_is_judged_not_waved_through(monkeypatc
     A draft PR named with `-R` is still a draft.
     """
     monkeypatch.setattr(guard, "_pr_meta", lambda pr, repo=None, cwd=None: {"isDraft": True})
-    payload = json.dumps(
-        {"tool_input": {"command": "case x in y) true;; esac; gh pr merge 9 -R owner/repo"}}
-    )
+    payload = json.dumps({"tool_input": {"command": "case x in y) true;; esac; gh pr merge 9 -R owner/repo"}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
     assert guard.main() == 2
 
@@ -1152,9 +1180,7 @@ def test_quoted_close_paren_does_not_pop_a_real_scope(monkeypatch):
 def test_quoted_open_paren_does_not_push_a_scope(monkeypatch):
     """B2, mirror: a fake `open` swallows the real `)`, so a real subshell's `cd` leaks
     out to the merge that follows it. Bash runs PR 9 in the session cwd."""
-    assert _judged_cwds(monkeypatch, "echo '(' && (cd /a && true) && gh pr merge 9") == [
-        ("9", None)
-    ]
+    assert _judged_cwds(monkeypatch, "echo '(' && (cd /a && true) && gh pr merge 9") == [("9", None)]
 
 
 def test_quoted_paren_stays_in_argv():


### PR DESCRIPTION
Closes #5834


## Summary

- require explicit PR selectors instead of an extra current-branch discovery request
- run independent PR metadata and check-state reads concurrently
- reduce the aggregate merge-guard ceiling from 30s to 20s and the full PreToolUse ceiling from 55s to 45s without weakening any underlying lookup timeout
- preserve fail-closed draft, CI, branch-protection, `--auto`, and `--admin` behavior

## Verification

- `242 passed` across normal/admin merge guards, Codex hook contracts, and timing behavior
- ruff, JSON, markdownlint, diff-check, OPSEC, and commit-trailer checks passed
