### PR TITLE
feat(atlas): admit heritage attestations with period badge

### DIFF
--- a/scripts/atlas/lexical_projection.py
+++ b/scripts/atlas/lexical_projection.py
@@ -99,6 +99,14 @@ class AdmittedPeriodRow:
 
 
 @dataclass(frozen=True)
+class NormalizedLanguagePeriods:
+    """Validated period metadata shared by the admission gate and badge."""
+
+    attestation: str | None
+    source: str | None
+
+
+@dataclass(frozen=True)
 class BuildResult:
     accepted_records: int
     rejected_records: tuple[RejectedRecord, ...]
@@ -310,29 +318,47 @@ def _is_textbook_source(source: dict[str, Any], attestation: dict[str, Any]) -> 
     return source.get("source_kind") == "textbook"
 
 
-def attestation_period_badge(attestation: dict[str, Any], source: dict[str, Any]) -> str | None:
-    """Return the exact non-modern period to expose for an admitted attestation."""
-    periods = (attestation.get("language_period"), source.get("language_period"))
-    if "modern" in periods:
+def _normalize_language_period(record: dict[str, Any], field_name: str) -> str | None:
+    """Validate a period field and collapse blank producer stamps to absence."""
+    value = record.get("language_period")
+    if value is None:
         return None
-    for period in periods:
-        if period is not None:
-            if not isinstance(period, str):
-                raise ProjectionError("language_period must be a string when present")
+    if not isinstance(value, str):
+        raise ProjectionError(f"{field_name} must be a string, got {value!r}")
+    return value.strip() or None
+
+
+def normalize_attestation_language_periods(
+    attestation: dict[str, Any], source: dict[str, Any]
+) -> NormalizedLanguagePeriods:
+    """Return the one canonical period view for an attestation and its source."""
+    return NormalizedLanguagePeriods(
+        attestation=_normalize_language_period(attestation, "attestation.language_period"),
+        source=_normalize_language_period(source, "source.language_period"),
+    )
+
+
+def attestation_period_badge(periods: NormalizedLanguagePeriods) -> str | None:
+    """Return the exact non-modern period to expose for an admitted attestation."""
+    for period in (periods.attestation, periods.source):
+        if period is not None and period != "modern":
             return period
     return None
 
 
 def attestation_rejection_reason(
-    attestation: dict[str, Any], source: dict[str, Any], vesum_forms: frozenset[str]
+    attestation: dict[str, Any],
+    source: dict[str, Any],
+    vesum_forms: frozenset[str],
+    *,
+    periods: NormalizedLanguagePeriods | None = None,
 ) -> str | None:
     """Return the first calibrated quality-gate failure for an attestation."""
-    source_period = source.get("language_period")
-    chunk_period = attestation.get("language_period")
+    periods = periods or normalize_attestation_language_periods(attestation, source)
     # Literary producers must stamp their period.  Heritage attestations are
     # admitted with a badge; only a wholly unstamped literary source fails
     # closed.  Textbooks legitimately carry no period metadata.
-    if source_period is None and chunk_period is None and not _is_textbook_source(source, attestation):
+    if periods.source is None and periods.attestation is None and not _is_textbook_source(source, attestation):
         return "language_period_not_modern"
 
     text = _required_string(attestation, "text")
@@ -498,13 +524,14 @@ def _records_for_build(
                 source = sources.get(source_id)
                 if source is None:
                     raise ProjectionError(f"attestation references undeclared source_id {source_id!r}")
-                reason = attestation_rejection_reason(record, source, vesum_forms)
+                periods = normalize_attestation_language_periods(record, source)
+                reason = attestation_rejection_reason(record, source, vesum_forms, periods=periods)
                 if reason:
                     attestation_id = _required_string(record, "attestation_id")
                     rejected.append(RejectedRecord(attestation_id, reason, record))
                     rejected_attestation_ids.add(attestation_id)
                     continue
-                period_badge = attestation_period_badge(record, source)
+                period_badge = attestation_period_badge(periods)
                 if period_badge is not None:
                     record = {**record, "period_badge": period_badge}
                     admitted_period_rows.append(

--- a/scripts/atlas/lexical_projection.py
+++ b/scripts/atlas/lexical_projection.py
@@ -90,17 +90,36 @@ class CascadedDeckItem:
 
 
 @dataclass(frozen=True)
+class AdmittedPeriodRow:
+    """A heritage attestation admitted with its period badge."""
+
+    attestation_id: str
+    period: str
+    record: dict[str, Any]
+
+
+@dataclass(frozen=True)
 class BuildResult:
     accepted_records: int
     rejected_records: tuple[RejectedRecord, ...]
     cascaded_deck_items: int = 0
     cascaded_deck_item_records: tuple[CascadedDeckItem, ...] = ()
+    admitted_period_rows: int = 0
+    admitted_period_row_records: tuple[AdmittedPeriodRow, ...] = ()
 
     @property
     def rejection_counts(self) -> dict[str, int]:
         counts: dict[str, int] = {}
         for rejected in self.rejected_records:
             counts[rejected.reason] = counts.get(rejected.reason, 0) + 1
+        return counts
+
+    @property
+    def admitted_period_counts(self) -> dict[str, int]:
+        """Return admitted heritage-attestation counts keyed by their exact period."""
+        counts: dict[str, int] = {}
+        for admitted in self.admitted_period_row_records:
+            counts[admitted.period] = counts.get(admitted.period, 0) + 1
         return counts
 
 
@@ -291,23 +310,29 @@ def _is_textbook_source(source: dict[str, Any], attestation: dict[str, Any]) -> 
     return source.get("source_kind") == "textbook"
 
 
+def attestation_period_badge(attestation: dict[str, Any], source: dict[str, Any]) -> str | None:
+    """Return the exact non-modern period to expose for an admitted attestation."""
+    periods = (attestation.get("language_period"), source.get("language_period"))
+    if "modern" in periods:
+        return None
+    for period in periods:
+        if period is not None:
+            if not isinstance(period, str):
+                raise ProjectionError("language_period must be a string when present")
+            return period
+    return None
+
+
 def attestation_rejection_reason(
     attestation: dict[str, Any], source: dict[str, Any], vesum_forms: frozenset[str]
 ) -> str | None:
     """Return the first calibrated quality-gate failure for an attestation."""
     source_period = source.get("language_period")
     chunk_period = attestation.get("language_period")
-    # Literary producers must stamp their period. Values that are present fail
-    # closed unless modern; only absent textbook metadata is not a period claim.
-    if (
-        source_period not in {None, "modern"}
-        or chunk_period not in {None, "modern"}
-        or (
-            source_period is None
-            and chunk_period is None
-            and not _is_textbook_source(source, attestation)
-        )
-    ):
+    # Literary producers must stamp their period.  Heritage attestations are
+    # admitted with a badge; only a wholly unstamped literary source fails
+    # closed.  Textbooks legitimately carry no period metadata.
+    if source_period is None and chunk_period is None and not _is_textbook_source(source, attestation):
         return "language_period_not_modern"
 
     text = _required_string(attestation, "text")
@@ -451,7 +476,7 @@ def _insert_record(cursor: sqlite3.Cursor, record: dict[str, Any]) -> None:
 
 def _records_for_build(
     records: Iterable[dict[str, Any]], vesum_forms: frozenset[str]
-) -> tuple[list[dict[str, Any]], list[RejectedRecord], list[CascadedDeckItem]]:
+) -> tuple[list[dict[str, Any]], list[RejectedRecord], list[CascadedDeckItem], list[AdmittedPeriodRow]]:
     by_type = {record_type: [] for record_type in RECORD_TYPES}
     sources: dict[str, dict[str, Any]] = {}
     for record in records:
@@ -464,6 +489,7 @@ def _records_for_build(
     rejected: list[RejectedRecord] = []
     rejected_attestation_ids: set[str] = set()
     cascaded_deck_items: list[CascadedDeckItem] = []
+    admitted_period_rows: list[AdmittedPeriodRow] = []
     for record_type in RECORD_TYPES:
         for record in by_type[record_type]:
             if record_type == "attestation":
@@ -478,6 +504,16 @@ def _records_for_build(
                     rejected.append(RejectedRecord(attestation_id, reason, record))
                     rejected_attestation_ids.add(attestation_id)
                     continue
+                period_badge = attestation_period_badge(record, source)
+                if period_badge is not None:
+                    record = {**record, "period_badge": period_badge}
+                    admitted_period_rows.append(
+                        AdmittedPeriodRow(
+                            attestation_id=_required_string(record, "attestation_id"),
+                            period=period_badge,
+                            record=record,
+                        )
+                    )
             elif record_type == "practice_deck_item":
                 attestation_id = record.get("attestation_id")
                 if isinstance(attestation_id, str) and attestation_id in rejected_attestation_ids:
@@ -491,7 +527,7 @@ def _records_for_build(
                     )
                     continue
             accepted.append(record)
-    return accepted, rejected, cascaded_deck_items
+    return accepted, rejected, cascaded_deck_items, admitted_period_rows
 
 
 def _foreign_key_check(connection: sqlite3.Connection) -> None:
@@ -511,10 +547,12 @@ def build_projection(
     records = _read_jsonl(input_jsonl)
     attestation_count = sum(record.get("record_type") == "attestation" for record in records)
     vesum_forms = load_vesum_forms(vesum_db) if attestation_count else frozenset()
-    accepted, rejected, cascaded_deck_items = _records_for_build(records, vesum_forms)
+    accepted, rejected, cascaded_deck_items, admitted_period_rows = _records_for_build(records, vesum_forms)
     if strict and rejected:
         raise ProjectionError(
-            f"strict build rejected {len(rejected)} attestation record(s): {BuildResult(0, tuple(rejected)).rejection_counts}"
+            "strict build rejected "
+            f"{len(rejected)} attestation record(s): "
+            f"{BuildResult(accepted_records=0, rejected_records=tuple(rejected)).rejection_counts}"
         )
 
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -541,6 +579,8 @@ def build_projection(
         rejected_records=tuple(rejected),
         cascaded_deck_items=len(cascaded_deck_items),
         cascaded_deck_item_records=tuple(cascaded_deck_items),
+        admitted_period_rows=len(admitted_period_rows),
+        admitted_period_row_records=tuple(admitted_period_rows),
     )
 
 
@@ -611,6 +651,8 @@ def main() -> None:
             json.dumps(
                 {
                     "accepted_records": result.accepted_records,
+                    "admitted_period_rows": result.admitted_period_rows,
+                    "admitted_periods": result.admitted_period_counts,
                     "cascaded_deck_items": result.cascaded_deck_items,
                     "rejections": result.rejection_counts,
                 },

--- a/tests/test_atlas_lexical_projection.py
+++ b/tests/test_atlas_lexical_projection.py
@@ -250,6 +250,76 @@ def test_only_unstamped_literary_sources_fail_the_period_gate(
     assert projection.attestation_rejection_reason(attestation, source, frozenset()) == expected_reason
 
 
+def test_empty_literary_period_is_normalized_to_an_unstamped_rejection() -> None:
+    source = _source("source", language_period="")
+    attestation = _attestation("source", "chunk-1", "Її зошит лежить на парті.")
+
+    assert projection.attestation_rejection_reason(attestation, source, frozenset()) == "language_period_not_modern"
+
+
+@pytest.mark.parametrize(
+    ("period_owner", "invalid_period"),
+    [("source", 42), ("attestation", {"period": "modern"})],
+)
+def test_non_string_period_raises_projection_error_without_poisoning_the_next_build(
+    tmp_path: Path, period_owner: str, invalid_period: object
+) -> None:
+    source = _source("source")
+    attestation = _attestation("source", "chunk-1", "Її зошит лежить на парті.")
+    if period_owner == "source":
+        source["language_period"] = invalid_period
+    else:
+        attestation["language_period"] = invalid_period
+    malformed_records: list[dict[str, object]] = [
+        source,
+        {"record_type": "lemma_entry", "entry_slug": "прапор", "lemma": "прапор", "entry_type": "lemma"},
+        {"record_type": "sense", "sense_slug": "прапор:core", "entry_slug": "прапор"},
+        attestation,
+    ]
+    malformed_input = tmp_path / "malformed.jsonl"
+    output_db = tmp_path / "atlas-v2.db"
+    _write_jsonl(malformed_input, malformed_records)
+    vesum_db = _vesum_db(tmp_path / "vesum.db", [])
+
+    with pytest.raises(projection.ProjectionError) as error:
+        projection.build_projection(malformed_input, output_db, vesum_db=vesum_db)
+    assert f"{period_owner}.language_period" in str(error.value)
+    assert repr(invalid_period) in str(error.value)
+    assert not output_db.exists()
+
+    valid_input = tmp_path / "valid.jsonl"
+    valid_records = [
+        _source("source"),
+        {"record_type": "lemma_entry", "entry_slug": "прапор", "lemma": "прапор", "entry_type": "lemma"},
+        {"record_type": "sense", "sense_slug": "прапор:core", "entry_slug": "прапор"},
+        _attestation("source", "chunk-1", "Її зошит лежить на парті."),
+    ]
+    _write_jsonl(valid_input, valid_records)
+
+    assert projection.build_projection(valid_input, output_db, vesum_db=vesum_db).accepted_records == 4
+
+
+def test_mixed_modern_and_heritage_periods_badge_the_heritage_value(tmp_path: Path) -> None:
+    attestation = _attestation("literary-source", "chunk-1", "Її зошит лежить на парті.", language_period="modern")
+    records: list[dict[str, object]] = [
+        _source("literary-source", language_period="middle_ukrainian"),
+        {"record_type": "lemma_entry", "entry_slug": "прапор", "lemma": "прапор", "entry_type": "lemma"},
+        {"record_type": "sense", "sense_slug": "прапор:core", "entry_slug": "прапор"},
+        attestation,
+    ]
+    input_path = tmp_path / "input.jsonl"
+    export_path = tmp_path / "export.jsonl"
+    _write_jsonl(input_path, records)
+
+    result = projection.build_projection(input_path, tmp_path / "atlas-v2.db", vesum_db=_vesum_db(tmp_path / "vesum.db", []))
+    projection.export_projection(tmp_path / "atlas-v2.db", export_path)
+
+    assert result.admitted_period_counts == {"middle_ukrainian": 1}
+    exported_records = [json.loads(line) for line in export_path.read_text(encoding="utf-8").splitlines()]
+    exported_attestation = next(record for record in exported_records if record["record_type"] == "attestation")
+    assert exported_attestation["period_badge"] == "middle_ukrainian"
+
+
 def test_old_east_slavic_attestation_is_exported_with_its_period_badge(tmp_path: Path) -> None:
     attestation = _attestation(
         "literary-source", "old-1", "Її зошит лежить на парті.", language_period="old_east_slavic"

--- a/tests/test_atlas_lexical_projection.py
+++ b/tests/test_atlas_lexical_projection.py
@@ -108,9 +108,15 @@ def test_round_trip_keeps_good_rows_byte_exact_and_rejects_each_bad_attestation_
     export_path = tmp_path / "export.jsonl"
     report_path = tmp_path / "rejections.jsonl"
     _write_jsonl(input_path, records)
-    expected_records = (
-        sorted([good_records[0], *records[6:9]], key=lambda record: str(record["source_id"])) + good_records[1:]
-    )
+    archaic_export = {**bad_archaic, "period_badge": "middle_ukrainian"}
+    expected_records = [
+        *sorted([good_records[0], *records[6:9]], key=lambda record: str(record["source_id"])),
+        good_records[1],
+        good_records[2],
+        archaic_export,
+        good_attestation,
+        *good_records[4:],
+    ]
     _write_jsonl(expected_path, expected_records)
     vesum_db = _vesum_db(tmp_path / "vesum.db", ["ми", "йдемо", "до", "школи"])
 
@@ -120,9 +126,10 @@ def test_round_trip_keeps_good_rows_byte_exact_and_rejects_each_bad_attestation_
 
     # Exact bytes prove that accepted JSONL records retain their source form.
     assert export_path.read_bytes() == expected_path.read_bytes()
-    assert result.accepted_records == 9
+    assert result.accepted_records == 10
+    assert result.admitted_period_rows == 1
+    assert result.admitted_period_counts == {"middle_ukrainian": 1}
     assert result.rejection_counts == {
-        "language_period_not_modern": 1,
         "russian_only_letter": 1,
         "textbook_exercise_instruction": 1,
     }
@@ -133,7 +140,7 @@ def test_round_trip_keeps_good_rows_byte_exact_and_rejects_each_bad_attestation_
         connection.execute("PRAGMA foreign_keys = ON")
         assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
-        assert connection.execute("SELECT COUNT(*) FROM attestations").fetchone()[0] == 1
+        assert connection.execute("SELECT COUNT(*) FROM attestations").fetchone()[0] == 2
         assert connection.execute("SELECT type FROM sqlite_master WHERE name='articles'").fetchone()[0] == "view"
         assert connection.execute("SELECT type FROM sqlite_master WHERE name='article_provenance'").fetchone()[0] == "view"
         assert connection.execute("SELECT type FROM sqlite_master WHERE name='article_payloads'").fetchone()[0] == "view"
@@ -221,10 +228,10 @@ def test_textbook_without_period_metadata_accepts_modern_attestation(tmp_path: P
     [
         ("literary", None, None, "language_period_not_modern"),
         ("textbook", None, None, None),
-        ("literary", "middle_ukrainian", None, "language_period_not_modern"),
+        ("literary", "middle_ukrainian", None, None),
     ],
 )
-def test_period_metadata_waiver_is_limited_to_textbook_sources(
+def test_only_unstamped_literary_sources_fail_the_period_gate(
     source_kind: str,
     source_period: str | None,
     attestation_period: str | None,
@@ -243,10 +250,37 @@ def test_period_metadata_waiver_is_limited_to_textbook_sources(
     assert projection.attestation_rejection_reason(attestation, source, frozenset()) == expected_reason
 
 
+def test_old_east_slavic_attestation_is_exported_with_its_period_badge(tmp_path: Path) -> None:
+    attestation = _attestation(
+        "literary-source", "old-1", "Її зошит лежить на парті.", language_period="old_east_slavic"
+    )
+    records: list[dict[str, object]] = [
+        _source("literary-source", language_period=None),
+        {"record_type": "lemma_entry", "entry_slug": "прапор", "lemma": "прапор", "entry_type": "lemma"},
+        {"record_type": "sense", "sense_slug": "прапор:core", "entry_slug": "прапор"},
+        attestation,
+    ]
+    input_path = tmp_path / "input.jsonl"
+    export_path = tmp_path / "export.jsonl"
+    db_path = tmp_path / "atlas-v2.db"
+    _write_jsonl(input_path, records)
+    vesum_db = _vesum_db(tmp_path / "vesum.db", [])
+
+    result = projection.build_projection(input_path, db_path, vesum_db=vesum_db)
+    projection.export_projection(db_path, export_path)
+
+    assert result.accepted_records == 4
+    assert result.admitted_period_rows == 1
+    assert result.admitted_period_counts == {"old_east_slavic": 1}
+    exported_records = [json.loads(line) for line in export_path.read_text(encoding="utf-8").splitlines()]
+    exported_attestation = next(record for record in exported_records if record["record_type"] == "attestation")
+    assert exported_attestation["period_badge"] == "old_east_slavic"
+
+
 def test_textbook_exercise_screening_requires_full_chunk_text(tmp_path: Path) -> None:
     attestation = _attestation("textbook-source", "chunk-1", "Її зошит лежить на парті.")
     records: list[dict[str, object]] = [
-        _source("textbook-source", language_period=None, source_kind="textbook"),
+        _source("textbook-source", language_period="middle_ukrainian", source_kind="textbook"),
         {"record_type": "lemma_entry", "entry_slug": "прапор", "lemma": "прапор", "entry_type": "lemma"},
         {"record_type": "sense", "sense_slug": "прапор:core", "entry_slug": "прапор"},
         attestation,
@@ -263,6 +297,7 @@ def test_textbook_exercise_screening_requires_full_chunk_text(tmp_path: Path) ->
     result = projection.build_projection(input_path, tmp_path / "atlas-v2.db", vesum_db=vesum_db)
 
     assert result.rejection_counts == {"textbook_exercise_instruction": 1}
+    assert result.admitted_period_rows == 0
 
 
 def test_deck_item_referencing_rejected_attestation_is_cascaded_into_report(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- admit non-modern attestations while stamping the projected/exported row with `period_badge`
- report heritage admissions separately by count and exact period
- preserve unstamped-literary, Russian-contamination, and textbook-exercise rejections

## Verification
- `.venv/bin/python -m pytest tests/test_atlas_lexical_projection.py tests/test_atlas_db.py -q`
- `.venv/bin/ruff check scripts/atlas/lexical_projection.py tests/test_atlas_lexical_projection.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

Cross-family review and auto-merge are intentionally left to the orchestrator.