### PR TITLE
fix(hooks): pytest stamp requires proof of success, not event name

### DIFF
--- a/.githooks/pytest_stamp.py
+++ b/.githooks/pytest_stamp.py
@@ -345,18 +345,14 @@ def _passing_summaries(output: str) -> list[bool]:
 
 
 def payload_proves_pytest_success(payload: dict[str, Any]) -> bool:
-    """Accept only a proven pytest success for the command shape and event."""
+    """Accept only a proven pytest success for a recognized command shape."""
     tool_input = _tool_input(payload)
     command = tool_input.get("command") or payload.get("command")
     if not isinstance(command, str) or not command.strip():
         return False
 
-    compound = _command_is_compound_pytest(command)
-    if compound is None:
+    if _command_is_compound_pytest(command) is None:
         return False
-    event_name = str(payload.get("hook_event_name") or "")
-    if event_name == "PostToolUse" and not compound:
-        return True
 
     summaries = _passing_summaries(_command_output(payload))
     return bool(summaries) and all(summaries)

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -101,14 +101,13 @@ worktree, and checked-out branch. A fresh marker from another clone, worktree,
 or same-named branch cannot satisfy the guard. Marker contents carry the same
 identity key, so legacy, empty, or partially written marker files fail closed.
 
-The writer trusts a successful hook event only for one direct pytest invocation.
-Compound commands and failure events require a clean pytest summary in the
-captured output; masked failures, zero-test runs, multiple pytest invocations,
-and collection/help-only modes do not stamp. Only named result/output envelope
-fields are inspected; arbitrary metadata and command-input strings are not
-trusted as test output. The exact checkout comes from the structured Bash
-`cwd`/`workdir` payload. A command-level `cd`/`pushd` is not guessed from shell
-text—set the tool's `workdir` instead.
+The writer requires a clean pytest summary in captured output for every
+recognized command shape; event names never prove success. Masked failures,
+zero-test runs, multiple pytest invocations, and collection/help-only modes do
+not stamp. Only named result/output envelope fields are inspected; arbitrary
+metadata and command-input strings are not trusted as test output. The exact
+checkout comes from the structured Bash `cwd`/`workdir` payload. A command-level
+`cd`/`pushd` is not guessed from shell text—set the tool's `workdir` instead.
 
 Stamping remains observational and exits successfully when it cannot prove the
 run. It uses the checkout or shared primary `.venv/bin/python` and deliberately

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -279,6 +279,7 @@ def test_full_pre_push_chain_replays_updates_to_the_pytest_guard(tmp_path):
                 "cwd": str(repo),
                 "hook_event_name": "PostToolUse",
                 "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+                "tool_response": {"stdout": "2 passed in 0.01s"},
             }
         ),
     )

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -376,11 +376,18 @@ def test_git_environment_removes_the_agent_push_guard(monkeypatch):
         "/arbitrary/path/.venv/bin/python -m pytest tests/test_pre_push_hook.py -q",
     ),
 )
-def test_stamp_writer_records_successful_pytest_runs(tmp_path, command):
+def test_stamp_writer_records_captured_successful_pytest_runs(tmp_path, command):
     repo, _, _ = _repo_with_change(tmp_path)
     stamp_dir = tmp_path / "stamps"
 
-    result = _run_stamp_writer(repo, {"tool_input": {"command": command}}, tmpdir=stamp_dir)
+    result = _run_stamp_writer(
+        repo,
+        {
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": "2 passed in 0.01s"},
+        },
+        tmpdir=stamp_dir,
+    )
 
     assert result.returncode == 0
     assert _stamp(stamp_dir, repo).exists()
@@ -393,7 +400,10 @@ def test_stamp_writer_leaves_no_stamp_from_detached_head(tmp_path):
 
     result = _run_stamp_writer(
         repo,
-        {"tool_input": {"command": ".venv/bin/python -m pytest tests/test_pre_push_hook.py -q"}},
+        {
+            "tool_input": {"command": ".venv/bin/python -m pytest tests/test_pre_push_hook.py -q"},
+            "tool_response": {"stdout": "2 passed in 0.01s"},
+        },
         tmpdir=stamp_dir,
     )
 
@@ -461,6 +471,7 @@ def test_stamp_writer_uses_tool_workdir_instead_of_hook_process_cwd(tmp_path):
             "command": ".venv/bin/python -m pytest tests/ -q",
             "workdir": str(tested_repo),
         },
+        "tool_response": {"stdout": "2 passed in 0.01s"},
     }
 
     result = _run_stamp_writer(
@@ -482,6 +493,93 @@ def test_successful_shell_wrapper_does_not_mask_failed_pytest(tmp_path):
         "hook_event_name": "PostToolUse",
         "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q || true"},
         "tool_output": "================== 1 failed, 19 passed in 0.65s ==================",
+    }
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert not _stamp(stamp_dir, repo).exists()
+
+
+def test_codex_post_tool_use_with_failed_pytest_output_does_not_stamp(tmp_path):
+    """Codex emits PostToolUse even when Bash exits nonzero."""
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+        "tool_response": {"stdout": "1 failed, 0 passed in 0.10s"},
+    }
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert not _stamp(stamp_dir, repo).exists()
+
+
+def test_codex_post_tool_use_with_passing_pytest_output_stamps(tmp_path):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+        "tool_response": {"stdout": "2 passed in 0.01s"},
+    }
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert _stamp(stamp_dir, repo).exists()
+
+
+def test_codex_post_tool_use_with_no_tests_ran_does_not_stamp(tmp_path):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_input": {"command": ".venv/bin/python -m pytest -k matches_nothing -q"},
+        "tool_response": {"stdout": "no tests ran in 0.00s"},
+    }
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert not _stamp(stamp_dir, repo).exists()
+
+
+@pytest.mark.parametrize(
+    "output_payload",
+    (
+        {},
+        {"tool_output": ""},
+        {"tool_response": {"stdout": ""}},
+        {"tool_response": {"stdout": None}},
+    ),
+)
+def test_codex_post_tool_use_with_missing_or_empty_output_does_not_stamp(tmp_path, output_payload):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    payload: dict[str, object] = {
+        "hook_event_name": "PostToolUse",
+        "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+    }
+    payload.update(output_payload)
+
+    result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
+
+    assert result.returncode == 0
+    assert not _stamp(stamp_dir, repo).exists()
+
+
+def test_codex_post_tool_use_with_mixed_passing_and_failing_summaries_does_not_stamp(tmp_path):
+    repo, _, _ = _repo_with_change(tmp_path)
+    stamp_dir = tmp_path / "stamps"
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+        "tool_response": {
+            "stdout": "2 passed in 0.01s\n1 failed, 1 passed in 0.01s"
+        },
     }
 
     result = _run_stamp_writer(repo, payload, tmpdir=stamp_dir)
@@ -619,6 +717,7 @@ def test_same_branch_name_in_another_repo_cannot_reuse_stamp(tmp_path):
         {
             "hook_event_name": "PostToolUse",
             "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+            "tool_response": {"stdout": "2 passed in 0.01s"},
         },
         tmpdir=stamp_dir,
     )
@@ -718,6 +817,7 @@ def test_actual_head_to_main_push_accepts_stamp_for_the_invoking_worktree(tmp_pa
         {
             "hook_event_name": "PostToolUse",
             "tool_input": {"command": ".venv/bin/python -m pytest tests/ -q"},
+            "tool_response": {"stdout": "2 passed in 0.01s"},
         },
         tmpdir=stamp_dir,
     )


### PR DESCRIPTION
## Summary

- Removed the untrusted `hook_event_name` success fast path. Every recognized pytest command now requires a non-empty, all-passing parsed summary from captured output.
- Added Codex-shaped regression coverage for failed output, honest success, zero collection, missing or empty output, and mixed passing/failing summaries.
- Updated the deployed-hook runbook.

Regression of #5828.

## Verification — raw output

CWD: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/fix-5828-stamp-gate`

    $ .venv/bin/python -m pytest tests/test_pre_push_hook.py tests/test_git_hooks.py -q
    collected 63 items
    tests/test_pre_push_hook.py ............................................ [ 69%]
    ......                                                                   [ 79%]
    tests/test_git_hooks.py .............                                    [100%]
    ============================= 63 passed in 12.95s ==============================

    $ .venv/bin/ruff check .githooks/pytest_stamp.py tests/test_pre_push_hook.py tests/test_git_hooks.py
    All checks passed!

    $ npx markdownlint-cli2 docs/runbooks/codex-hooks.md
    Summary: 0 error(s)

    $ .venv/bin/python scripts/audit/lint_agent_trailer.py
    aa2cdf6dd3  PASS  X-Agent: codex/fix-5828-stamp-gate
    All 1 non-skipped commit(s) carry an X-Agent trailer.

    $ .venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main..HEAD
    OPSEC check passed. Zero leaks detected.

## Mutation check — raw intentional failure

Temporarily restoring the removed `PostToolUse` fast path made both regression tests fail:

    $ .venv/bin/python -m pytest tests/test_pre_push_hook.py::test_codex_post_tool_use_with_failed_pytest_output_does_not_stamp tests/test_pre_push_hook.py::test_codex_post_tool_use_with_no_tests_ran_does_not_stamp -q
    collected 2 items
    tests/test_pre_push_hook.py FF
    FAILED tests/test_pre_push_hook.py::test_codex_post_tool_use_with_failed_pytest_output_does_not_stamp
    FAILED tests/test_pre_push_hook.py::test_codex_post_tool_use_with_no_tests_ran_does_not_stamp
    ============================== 2 failed in 0.41s ===============================

After removing it again:

    $ .venv/bin/python -m pytest tests/test_pre_push_hook.py::test_codex_post_tool_use_with_failed_pytest_output_does_not_stamp tests/test_pre_push_hook.py::test_codex_post_tool_use_with_no_tests_ran_does_not_stamp -q
    ============================== 2 passed in 0.41s ===============================

## Sibling sweep — raw output

    $ rg -n -i "hook_event_name|event[_ -]?(identity|name)|PostToolUse|PreToolUse" .githooks -g "*"
    No .githooks event-identity references remain.

## NOT VERIFIED

The required broad Ruff command remains red outside this PR scope:

    $ .venv/bin/ruff check .githooks/ tests/ --output-format concise
    tests/test_slovnyk_me_tool.py:14:5: I001 [*] Import block is un-sorted or un-formatted
    tests/test_sum20_official.py:17:1: I001 [*] Import block is un-sorted or un-formatted
    tests/test_wiki_packet_dictionary_context.py:36:5: I001 [*] Import block is un-sorted or un-formatted
    tests/wiki/test_chunking.py:378:5: I001 [*] Import block is un-sorted or un-formatted
    tests/wiki/test_chunking.py:417:5: I001 [*] Import block is un-sorted or un-formatted
    tests/wiki/test_cold_encode.py:13:1: I001 [*] Import block is un-sorted or un-formatted
    tests/wiki/test_embedding_manifest.py:12:1: I001 [*] Import block is un-sorted or un-formatted
    tests/wiki/test_multi_corpus_retrieval.py:13:1: I001 [*] Import block is un-sorted or un-formatted
    tests/wiki/test_t1_t2_pipeline.py:9:1: I001 [*] Import block is un-sorted or un-formatted
    tests/wiki/test_ukrainian_wiki_corpus.py:14:1: I001 [*] Import block is un-sorted or un-formatted
    Found 10 errors.