### PR TITLE
fix(ci): name the hanging test — faulthandler watchdog + per-worker breadcrumbs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
         with:
           name: pytest-breadcrumbs-shard-${{ matrix.shard }}
           path: .pytest_breadcrumbs
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,12 +158,14 @@ jobs:
       # will simply move — and the cap now makes that a bounded, visible failure
       # rather than a silent six-hour stall.
       - name: Run pytest
+        timeout-minutes: 25
         # The predicate is evaluated by the expression engine and reaches the
         # shell as the literal string "true"/"false" via env — `github.ref` is
         # never spliced into `run:`, so a hostile branch name cannot inject.
         env:
           IS_MAIN_PUSH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           SHARD: ${{ matrix.shard }}
+          PYTEST_BREADCRUMB_DIR: .pytest_breadcrumbs
         run: |
           cov_args=""
           if [ "$IS_MAIN_PUSH" = "true" ]; then
@@ -180,6 +182,16 @@ jobs:
           .venv/bin/python -m pytest "${shard_files[@]}" -n auto --strict-markers \
             --timeout=120 --timeout-method=thread --durations=25 $cov_args \
             --deselect=tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast
+
+      - name: Upload test breadcrumbs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: pytest-breadcrumbs-shard-${{ matrix.shard }}
+          path: .pytest_breadcrumbs
+          if-no-files-found: ignore
+          retention-days: 7
+
 
       # Restores the `--fail-under=35` floor the deleted shard aggregation
       # enforced (origin/main ci.yml:1183). Cross-family review of #5762 caught

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+timeout = 120
+timeout_method = "thread"
+faulthandler_timeout = 110
 # atlas_release is publish-time only (requires data/atlas.db); run explicitly with -m atlas_release
 addopts = "-v --tb=short -m 'not atlas_release'"
 filterwarnings = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ Pytest configuration and shared fixtures for audit tests.
 Provides reusable content snippets and module templates for testing.
 """
 
+import contextlib
 import os
 import sqlite3
 import sys
@@ -16,6 +17,35 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _get_breadcrumb_file() -> Path | None:
+    breadcrumb_dir_str = os.environ.get("PYTEST_BREADCRUMB_DIR", ".pytest_breadcrumbs")
+    if not breadcrumb_dir_str:
+        return None
+    dir_path = Path(breadcrumb_dir_str)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    return dir_path / f"breadcrumb_{worker_id}.txt"
+
+
+def _append_breadcrumb(line: str) -> None:
+    breadcrumb_file = _get_breadcrumb_file()
+    if breadcrumb_file:
+        with open(breadcrumb_file, "a", encoding="utf-8") as f:
+            f.write(line)
+            f.flush()
+            with contextlib.suppress(OSError):
+                os.fsync(f.fileno())
+
+
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]) -> None:
+    _append_breadcrumb(f"START {nodeid}\n")
+
+
+def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str]) -> None:
+    _append_breadcrumb(f"FINISH {nodeid}\n")
+
 
 
 def _require_data_artifact(

--- a/tests/test_ci_attribution.py
+++ b/tests/test_ci_attribution.py
@@ -1,0 +1,85 @@
+"""Unit tests for CI test timeout attribution and per-worker breadcrumb hooks."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.conftest import _get_breadcrumb_file, pytest_runtest_logfinish, pytest_runtest_logstart
+
+
+def test_get_breadcrumb_file_default(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PYTEST_BREADCRUMB_DIR", raising=False)
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+
+    breadcrumb_file = _get_breadcrumb_file()
+    assert breadcrumb_file is not None
+    assert breadcrumb_file.name == "breadcrumb_master.txt"
+    assert breadcrumb_file.parent.name == ".pytest_breadcrumbs"
+
+
+def test_get_breadcrumb_file_custom_dir_and_worker(tmp_path: Path, monkeypatch) -> None:
+    bdir = tmp_path / "custom_breadcrumbs"
+    monkeypatch.setenv("PYTEST_BREADCRUMB_DIR", str(bdir))
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw2")
+
+    breadcrumb_file = _get_breadcrumb_file()
+    assert breadcrumb_file is not None
+    assert breadcrumb_file.name == "breadcrumb_gw2.txt"
+    assert breadcrumb_file.parent == bdir
+
+
+def test_breadcrumb_logstart_and_logfinish(tmp_path: Path, monkeypatch) -> None:
+    bdir = tmp_path / "breadcrumbs"
+    monkeypatch.setenv("PYTEST_BREADCRUMB_DIR", str(bdir))
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+
+    pytest_runtest_logstart("tests/test_foo.py::test_bar", ("tests/test_foo.py", 1, "test_bar"))
+    breadcrumb_file = bdir / "breadcrumb_gw0.txt"
+    assert breadcrumb_file.exists()
+    assert breadcrumb_file.read_text(encoding="utf-8") == "START tests/test_foo.py::test_bar\n"
+
+    pytest_runtest_logfinish("tests/test_foo.py::test_bar", ("tests/test_foo.py", 1, "test_bar"))
+    lines = breadcrumb_file.read_text(encoding="utf-8").splitlines()
+    assert lines == [
+        "START tests/test_foo.py::test_bar",
+        "FINISH tests/test_foo.py::test_bar",
+    ]
+
+
+def test_breadcrumb_subprocess_pytest_run(tmp_path: Path) -> None:
+    repo_root = Path(__file__).parents[1]
+    bdir = tmp_path / "breadcrumbs"
+    test_file = repo_root / "tests" / "_temp_breadcrumb_test.py"
+    try:
+        test_file.write_text("def test_one(): pass\ndef test_two(): pass\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        env["PYTEST_BREADCRUMB_DIR"] = str(bdir)
+        env["PYTEST_XDIST_WORKER"] = "gw1"
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(test_file),
+            "-o",
+            f"cache_dir={tmp_path / '.pytest_cache'}",
+        ]
+        res = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False, cwd=str(repo_root))
+        assert res.returncode == 0, f"stdout: {res.stdout}\nstderr: {res.stderr}"
+
+        breadcrumb_file = bdir / "breadcrumb_gw1.txt"
+        assert breadcrumb_file.exists(), (
+            f"Breadcrumb file missing in {bdir}. Files present: {list(bdir.glob('*')) if bdir.exists() else 'bdir missing'}\n"
+            f"stdout: {res.stdout}\nstderr: {res.stderr}"
+        )
+        lines = breadcrumb_file.read_text(encoding="utf-8").splitlines()
+        assert "START tests/_temp_breadcrumb_test.py::test_one" in lines
+        assert "FINISH tests/_temp_breadcrumb_test.py::test_one" in lines
+        assert "START tests/_temp_breadcrumb_test.py::test_two" in lines
+        assert "FINISH tests/_temp_breadcrumb_test.py::test_two" in lines
+    finally:
+        if test_file.exists():
+            test_file.unlink()


### PR DESCRIPTION
## Context & Goal
Resolves #5821 per advisor-approved plan `plan-ci-sharding-v2 §2`.

When an `xdist` worker overruns under `--timeout-method=thread`, pytest terminates the worker with `os._exit(1)`, causing CI to log "worker crashed" with a moving victim and no named culprit. This PR implements **ATTRIBUTION** (keeping `--timeout-method=thread`) by adding a C-thread `faulthandler_timeout` watchdog and per-worker flushed breadcrumbs.

## Summary of Changes
1. **Pytest Config Watchdog**: Added `faulthandler_timeout = 110` to `pyproject.toml` (under `[tool.pytest.ini_options]`), set just under the 120s per-test timeout (`timeout = 120`, `timeout_method = "thread"`). The `faulthandler` C-thread watchdog dumps all thread tracebacks and explicitly names the hanging test file and function even when the Python GIL is held.
2. **Per-Worker Breadcrumbs**: Implemented `pytest_runtest_logstart` and `pytest_runtest_logfinish` hooks in `tests/conftest.py` that log `START <nodeid>` and `FINISH <nodeid>` lines to per-worker breadcrumb files (`breadcrumb_<worker_id>.txt`), with immediate `flush()` and `os.fsync()` prior to test execution. An `os._exit(1)` kill leaves the hanging test as the last breadcrumb line.
3. **CI Workflow Safeguard**: Updated `.github/workflows/ci.yml` `Run pytest` step with a `timeout-minutes: 25` step deadline (shorter than the job's 30m limit) and added an `if: always()` step uploading `.pytest_breadcrumbs` artifacts.
4. **Unit Tests**: Added `tests/test_ci_attribution.py` covering breadcrumb file path resolution, hook formatting, logstart/logfinish line ordering, and subprocess pytest execution.

---

## 1. PRECHECK (Fable's Requirement)
Command:
```bash
ugrep -rn "SIGALRM|signal.alarm" tests/ scripts/
```
Raw Output:
```text
(0 matches found)
```
No existing tests or scripts manage their own `SIGALRM` or `signal.alarm` signals.

---

## 5. Scratch Run Verification Raw Outputs

### (a) Faulthandler Names the Hanging Test
Scratch test `tests/_scratch_hang_verification.py` running `time.sleep(10)` with `-o faulthandler_timeout=2 --timeout=3 --timeout-method=thread`:
```text
=== FAULTHANDLER / PYTEST STDOUT & STDERR ===
Exit Code: 1
STDOUT:
 ============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/ci-attribution
configfile: pyproject.toml
plugins: xdist-3.8.0, timeout-2.4.0
timeout: 3.0s
timeout method: thread
timeout func_only: False
created: 1/1 worker
1 worker [1 item]

scheduling tests via LoadScheduling

tests/_scratch_hang_verification.py::test_deliberately_hanging_node 
[gw0] node down: Not properly terminated
[gw0] [100%] FAILED tests/_scratch_hang_verification.py::test_deliberately_hanging_node 

replacing crashed worker gw0

=================================== FAILURES ===================================
_____________________ tests/_scratch_hang_verification.py ______________________
[gw0] darwin -- Python 3.12.13
worker 'gw0' crashed while running 'tests/_scratch_hang_verification.py::test_deliberately_hanging_node'
=========================== short test summary info ============================
FAILED tests/_scratch_hang_verification.py::test_deliberately_hanging_node - ...
============================== 1 failed in 4.38s ===============================

STDERR:
 Timeout (0:00:02)!
Thread 0x00000001f430dd80 (most recent call first):
  File "/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/ci-attribution/tests/_scratch_hang_verification.py", line 4 in test_deliberately_hanging_node
```

### (b) Breadcrumb File's Last Line is the Hanging Node ID
```text
=== BREADCRUMB FILE CONTENT ===
--- breadcrumb_gw0.txt ---
START tests/_scratch_hang_verification.py::test_deliberately_hanging_node
```

---

## Verification
- Unit test suite: `.venv/bin/pytest tests/test_ci_attribution.py -v` (4 passed)
- Python linter: `ruff check tests/conftest.py tests/test_ci_attribution.py` (Passed)
- Workflow linter: `actionlint .github/workflows/ci.yml` (Passed)

---

## NOT VERIFIED
- Execution of the 25-minute step-level deadline on actual GitHub Actions runner hardware (requires push and workflow run on GitHub infrastructure).
