### PR TITLE
fix(hooks): distinguish lease claim runner failures

### DIFF
--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -400,31 +400,38 @@ case "$HANDOFF_AGENT" in
   claude|claude-*)
     if [ -z "$CURRENT_THREAD_ID" ]; then
       HANDOFF_CONTEXT="ERROR: Cannot acquire durable thread lease: SessionStart did not provide a current thread id. Stop; do not drive this queue."
-    elif ! THREAD_LEASE_OUTPUT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
-      --repo-root "$CANONICAL_ROOT" claim-thread-lease --agent "$HANDOFF_AGENT" \
-      --current-thread-id "$CURRENT_THREAD_ID" 2>&1); then
-      HANDOFF_CONTEXT="ERROR: DURABLE THREAD LEASE CONFLICT — stop; do not cold-start or drive this queue.
+    else
+      THREAD_LEASE_RC=0
+      THREAD_LEASE_OUTPUT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+        --repo-root "$CANONICAL_ROOT" claim-thread-lease --agent "$HANDOFF_AGENT" \
+        --current-thread-id "$CURRENT_THREAD_ID" 2>&1) || THREAD_LEASE_RC=$?
+      if [ "$THREAD_LEASE_RC" -eq 124 ] || [ "$THREAD_LEASE_RC" -eq 127 ]; then
+        HANDOFF_CONTEXT="ERROR: LEASE CLAIM COULD NOT RUN (timeout/budget/runner missing) — stop; lease state UNKNOWN; do NOT force-release.
 Output:
 $THREAD_LEASE_OUTPUT"
-    else
-      # Propagate the exact generation this session just claimed so the SessionEnd
-      # release hook (release-thread-lease.sh) can fence its release with it —
-      # thread_handoff.py now refuses a non-force release without one (#5759).
-      THREAD_LEASE_GENERATION=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
+      elif [ "$THREAD_LEASE_RC" -ne 0 ]; then
+        HANDOFF_CONTEXT="ERROR: DURABLE THREAD LEASE CONFLICT — stop; do not cold-start or drive this queue.
+Output:
+$THREAD_LEASE_OUTPUT"
+      else
+        # Propagate the exact generation this session just claimed so the SessionEnd
+        # release hook (release-thread-lease.sh) can fence its release with it —
+        # thread_handoff.py now refuses a non-force release without one (#5759).
+        THREAD_LEASE_GENERATION=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
 try:
   d=json.loads(sys.stdin.read()); print(d.get("generation") or "")
 except Exception:
   print("")' 2>/dev/null || true)
-      if [ -n "$THREAD_LEASE_GENERATION" ] && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-        printf 'export LEARN_UKRAINIAN_THREAD_LEASE_GENERATION=%s\n' "$THREAD_LEASE_GENERATION" >> "$CLAUDE_ENV_FILE" 2>/dev/null || true
-      fi
-      unset THREAD_LEASE_GENERATION
+        if [ -n "$THREAD_LEASE_GENERATION" ] && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+          printf 'export LEARN_UKRAINIAN_THREAD_LEASE_GENERATION=%s\n' "$THREAD_LEASE_GENERATION" >> "$CLAUDE_ENV_FILE" 2>/dev/null || true
+        fi
+        unset THREAD_LEASE_GENERATION
 
-      # A successful claim can still be a takeover (the previous owner was confirmed
-      # dead/zombie, or its pid was reused) or a heal from a corrupt on-disk lease.
-      # Neither may ever be silent — surface it into SessionStart context so the
-      # operator is told a slot changed hands before driving it (#5759).
-      THREAD_LEASE_TAKEOVER_BANNER=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
+        # A successful claim can still be a takeover (the previous owner was confirmed
+        # dead/zombie, or its pid was reused) or a heal from a corrupt on-disk lease.
+        # Neither may ever be silent — surface it into SessionStart context so the
+        # operator is told a slot changed hands before driving it (#5759).
+        THREAD_LEASE_TAKEOVER_BANNER=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
 try:
     d = json.loads(sys.stdin.read())
 except Exception:
@@ -442,10 +449,12 @@ if corrupt:
 if parts:
     print("\n".join(parts))
 ' 2>/dev/null || true)
-      if [ -n "$THREAD_LEASE_TAKEOVER_BANNER" ]; then
-        INFO+=("$THREAD_LEASE_TAKEOVER_BANNER")
+        if [ -n "$THREAD_LEASE_TAKEOVER_BANNER" ]; then
+          INFO+=("$THREAD_LEASE_TAKEOVER_BANNER")
+        fi
+        unset THREAD_LEASE_TAKEOVER_BANNER
       fi
-      unset THREAD_LEASE_TAKEOVER_BANNER
+      unset THREAD_LEASE_RC
     fi
     ;;
 esac

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -80,6 +80,11 @@ accumulate past the outer hook deadline. Hook-owned advisory locks use a
 one-second bounded wait; the lock remains fail-safe, while a live but wedged
 owner can no longer stall a new session indefinitely.
 
+A `SIGKILL` can land after `claim-thread-lease` persists the lease but before the
+claim reports back to SessionStart. In that case the session must stop and the
+lease can remain held; do not force-release based only on a claim timeout. The
+lease-lifecycle work in the infrastructure lane is making this recovery explicit.
+
 Broad curriculum scans, service probes, GitHub issue listings, and governance
 audits were removed from the synchronous hook. The hook now points to
 `/api/orient` for those optional diagnostics. Multiple pending rollovers remain

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -108,7 +108,7 @@ run_hook() {
     SESSION_BOUNDED_RUNNER="$REPO_ROOT/scripts/agent_runtime/bounded_command.py" \
     CLAUDEX_SUPERVISOR_SCRIPT="$REPO_ROOT/scripts/orchestration/claudex_supervisor.py" \
     CLAUDEX_SUPERVISOR_PYTHON="$REPO_ROOT/.venv/bin/python" \
-    THREAD_ROLLOVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
+    THREAD_ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$REPO_ROOT/.venv/bin/python}" \
     THREAD_ROLLOVER_SCRIPT="$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     SESSION_HANDOFF_AGENT="$handoff_agent" \
     SESSION_EPIC="$session_epic" \
@@ -479,6 +479,24 @@ output_harness="$(run_hook "$fixture_root" 0 "$harness_slot")"
 assert_contains "$output_harness" "PENDING THREAD ROLLOVER DETECTED" "epic harness surfaces claude-infra packet (#5201)"
 assert_contains "$output_harness" "--agent claude-infra" "epic harness surfaces claude-infra packet (#5201)"
 assert_not_contains "$output_harness" "COLD START: NO LIVE THREAD ROLLOVER" "epic harness surfaces claude-infra packet (#5201)"
+
+# 17b. An exhausted aggregate budget leaves the durable lease state unknown;
+# it is not evidence of a thread lease conflict and must never suggest force release.
+setup_fixture "$fixture_root"
+slow_python="$fixture_root/.venv/bin/slow-python"
+cat > "$slow_python" <<'EOF'
+#!/usr/bin/env bash
+sleep 2
+EOF
+chmod +x "$slow_python"
+output="$(
+  SESSION_START_BUDGET_SECONDS=1 THREAD_ROLLOVER_PYTHON="$slow_python" \
+    run_hook "$fixture_root" 0 claude
+)"
+assert_contains "$output" \
+  "ERROR: LEASE CLAIM COULD NOT RUN (timeout/budget/runner missing) — stop; lease state UNKNOWN; do NOT force-release." \
+  "lease claim budget exhaustion"
+assert_not_contains "$output" "DURABLE THREAD LEASE CONFLICT" "lease claim budget exhaustion"
 
 # 18. Official SessionStart fields drive the native profile and exact transcript record.
 setup_fixture "$fixture_root"

--- a/scripts/lib/thread_rollover_link.sh
+++ b/scripts/lib/thread_rollover_link.sh
@@ -75,12 +75,14 @@ resolve_codex_pending_rollover() {
   local title_state=""
   local replacement_task_id=""
   local runner=()
+  local parser_runner=()
 
   if [ -n "${THREAD_ROLLOVER_COMMAND_RUNNER:-}" ]; then
     runner=(
       "$python_bin" "$THREAD_ROLLOVER_COMMAND_RUNNER"
       --timeout "${THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS:-3}" --
     )
+    parser_runner=("${runner[@]}")
   fi
 
   clear_codex_launcher_rollover_env
@@ -108,7 +110,7 @@ resolve_codex_pending_rollover() {
   fi
 
   if ! parsed="$(
-    printf '%s' "$detect_output" | "$python_bin" -c '
+    printf '%s' "$detect_output" | "${parser_runner[@]}" "$python_bin" -c '
 import json
 import re
 import sys

--- a/scripts/orchestration/task_family/storage.py
+++ b/scripts/orchestration/task_family/storage.py
@@ -64,7 +64,10 @@ def advisory_lock(path: Path) -> Iterator[None]:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a+", encoding="utf-8") as handle:
         timeout_text = os.environ.get("LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS", "")
-        timeout_seconds = float(timeout_text) if timeout_text else None
+        try:
+            timeout_seconds = float(timeout_text) if timeout_text else None
+        except ValueError:
+            timeout_seconds = None
         if timeout_seconds is None:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         else:

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -4366,6 +4366,11 @@ def _force_release_command(agent: str) -> str:
     )
 
 
+def _lock_timeout_exit(exc: TimeoutError) -> int:
+    print(json.dumps({"error_code": "LOCK_TIMEOUT", "error": str(exc)}, indent=2))
+    return 124
+
+
 def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
     """Claim the durable single-driver lease used during SessionStart."""
     try:
@@ -4378,6 +4383,8 @@ def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
             now=utc_now(),
             starting_pid=args.starting_pid,
         )
+    except TimeoutError as exc:
+        return _lock_timeout_exit(exc)
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
         return 2
@@ -4438,6 +4445,8 @@ def cmd_release_thread_lease(args: argparse.Namespace) -> int:
             generation=args.generation,
             force=args.force,
         )
+    except TimeoutError as exc:
+        return _lock_timeout_exit(exc)
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
         return 2

--- a/tests/orchestration/task_family/test_rollover.py
+++ b/tests/orchestration/task_family/test_rollover.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import pytest
 
 from scripts.orchestration import task_identity
-from scripts.orchestration.task_family import codex_state, rollover
+from scripts.orchestration.task_family import codex_state, rollover, storage
 from scripts.orchestration.task_family.model import RelationType
 from scripts.orchestration.task_family.storage import TaskFamilyStorage, advisory_lock
 
@@ -287,6 +287,23 @@ def test_advisory_lock_honors_hook_deadline(tmp_path: Path, monkeypatch: pytest.
     finally:
         child.terminate()
         child.wait(timeout=5)
+
+
+def test_advisory_lock_treats_malformed_hook_timeout_as_unbounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    flock_flags: list[int] = []
+
+    def record_flock(_: int, flags: int) -> None:
+        flock_flags.append(flags)
+
+    monkeypatch.setenv("LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS", "not-a-number")
+    monkeypatch.setattr(storage.fcntl, "flock", record_flock)
+
+    with advisory_lock(tmp_path / "lineage" / ".native-intent.lock"):
+        pass
+
+    assert flock_flags == [storage.fcntl.LOCK_EX, storage.fcntl.LOCK_UN]
 
 
 def test_pristine_transition_supersession_is_durable_idempotent_and_blocks_old_create(tmp_path: Path) -> None:

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -1324,6 +1324,32 @@ def test_claim_thread_lease_command_reports_a_clear_double_launch_conflict(tmp_p
     assert "release-thread-lease" in payload["resolution"]
 
 
+def test_claim_thread_lease_command_reports_structured_lock_timeout(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+):
+    def raise_timeout(_: Path) -> None:
+        raise TimeoutError("timed out waiting for local state lock")
+
+    monkeypatch.setattr(th, "task_family_advisory_lock", raise_timeout)
+
+    assert th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "claim-thread-lease",
+            "--agent",
+            "claude-infra",
+            "--current-thread-id",
+            "session-under-lock",
+        ]
+    ) == 124
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "error_code": "LOCK_TIMEOUT",
+        "error": "timed out waiting for local state lock",
+    }
+
+
 def test_release_thread_lease_command_end_to_end(tmp_path: Path, capsys):
     """CLI-level: claim then release through the same subcommands a real hook would call."""
     repo_args = ["--repo-root", str(tmp_path)]

--- a/tests/test_hook_deadline_contract.py
+++ b/tests/test_hook_deadline_contract.py
@@ -12,6 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CODEX_HOOKS = REPO_ROOT / "agents_extensions" / "codex" / "hooks.json"
 SESSION_SETUP = REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "session-setup.sh"
 POST_COMPACT = REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "post-compact.sh"
+ROLLOVER_LINK = REPO_ROOT / "scripts" / "lib" / "thread_rollover_link.sh"
 
 
 def test_bounded_command_terminates_a_slow_process() -> None:
@@ -49,6 +50,7 @@ def test_session_start_defers_optional_network_diagnostics() -> None:
 def test_rollover_and_postcompact_commands_are_bounded() -> None:
     session_source = SESSION_SETUP.read_text(encoding="utf-8")
     compact_source = POST_COMPACT.read_text(encoding="utf-8")
+    rollover_link_source = ROLLOVER_LINK.read_text(encoding="utf-8")
 
     assert "LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS=1" in session_source
     assert "THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS=3" in session_source
@@ -65,6 +67,8 @@ def test_rollover_and_postcompact_commands_are_bounded() -> None:
     )
     assert 'run_bounded 3 "$ROLLOVER_PYTHON"' in session_source
     assert 'run_bounded 2 "$ROLLOVER_PYTHON"' in compact_source
+    assert 'parser_runner=("${runner[@]}")' in rollover_link_source
+    assert '"${parser_runner[@]}" "$python_bin" -c' in rollover_link_source
     assert "_HOOK_SOURCE_ROOT" not in session_source
     assert "_HOOK_SOURCE_ROOT" not in compact_source
     assert compact_source.count('[ ! -f "$BOUNDED_RUNNER" ]') == 1


### PR DESCRIPTION
Follow-up to merged PR #5835. #5835 merged at `bc6cd16384` before this round-two fix was pushed, so this is a clean one-commit follow-up from current `main`.

## Review fixes

- P1: SessionStart preserves the `run_bounded` exit status for `claim-thread-lease`. Exit `124` or `127` now emits `ERROR: LEASE CLAIM COULD NOT RUN (timeout/budget/runner missing) — stop; lease state UNKNOWN; do NOT force-release.` All other nonzero exits retain the durable-lease conflict banner.
- P2: claim and release lease commands translate advisory-lock `TimeoutError` to structured JSON with `error_code: LOCK_TIMEOUT` and exit `124`, so SessionStart takes the P1 unknown-state path rather than suggesting a force release.
- P3: the Codex hooks runbook documents the SIGKILL-after-persisted-claim state and defers explicit recovery to infrastructure-lane lease-lifecycle work.
- P4: malformed `LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS` now falls back to an unbounded advisory lock.

## SessionStart rollover subprocess audit

No subprocess remains unbounded on the SessionStart path in `resolve_codex_pending_rollover`: SessionStart exports the runner before calling `verify_codex_pending_rollover`; both the `detect` invocation and the JSON parser now use it. The direct `detect` fallback applies only when the runner is absent, which SessionStart does not permit. `printf` and `read` are shell builtins.

```text
$ rg -n -e THREAD_ROLLOVER_COMMAND_RUNNER -e parser_runner -e verify_codex_pending_rollover scripts/lib/thread_rollover_link.sh agents_extensions/shared/hooks/session-setup.sh
agents_extensions/shared/hooks/session-setup.sh:148:8:export THREAD_ROLLOVER_COMMAND_RUNNER="$BOUNDED_RUNNER"
agents_extensions/shared/hooks/session-setup.sh:347:9:        verify_codex_pending_rollover \
scripts/lib/thread_rollover_link.sh:78:9:  local parser_runner=()
scripts/lib/thread_rollover_link.sh:80:14:  if [ -n "${THREAD_ROLLOVER_COMMAND_RUNNER:-}" ]; then
scripts/lib/thread_rollover_link.sh:82:23:      "$python_bin" "$THREAD_ROLLOVER_COMMAND_RUNNER"
scripts/lib/thread_rollover_link.sh:85:5:    parser_runner=("${runner[@]}")
scripts/lib/thread_rollover_link.sh:95:14:  if [ -n "${THREAD_ROLLOVER_COMMAND_RUNNER:-}" ]; then
scripts/lib/thread_rollover_link.sh:113:39:    printf "%s" "$detect_output" | "${parser_runner[@]}" "$python_bin" -c 
scripts/lib/thread_rollover_link.sh:209:1:verify_codex_pending_rollover() {
```

## Verification

```text
$ scripts/audit/test_session_setup_hook.sh
marker_hit_stdout_bytes=1396
fallback_warn_count=4
ok - session setup hook handoff fixtures passed
session_setup_hook_exit=0

$ .venv/bin/python -m pytest tests/test_hook_deadline_contract.py tests/orchestration/task_family/test_rollover.py tests/orchestration/test_thread_handoff.py -q
collected 152 items
152 passed in 7.61s

$ bash -n agents_extensions/shared/hooks/session-setup.sh scripts/audit/test_session_setup_hook.sh scripts/lib/thread_rollover_link.sh && shellcheck -x agents_extensions/shared/hooks/session-setup.sh scripts/audit/test_session_setup_hook.sh scripts/lib/thread_rollover_link.sh && .venv/bin/ruff check scripts/orchestration/thread_handoff.py scripts/orchestration/task_family/storage.py tests/test_hook_deadline_contract.py tests/orchestration/task_family/test_rollover.py tests/orchestration/test_thread_handoff.py
All checks passed!

$ node_modules/.bin/markdownlint-cli2 docs/runbooks/codex-hooks.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/runbooks/codex-hooks.md
Linting: 1 file(s)
Summary: 0 error(s)

$ .venv/bin/python scripts/audit/lint_agent_trailer.py && .venv/bin/python scripts/audit/lint_opsec_leaks.py
Checking 1 commit(s) in origin/main..HEAD:
  0225a263fb  PASS  X-Agent: codex/fix-5835-r2
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
🔒 Checking 9 files for OPSEC leaks (mode: git diff (origin/main..HEAD))...
✅ OPSEC check passed. Zero leaks detected.
```

## Mutation check

The rc-discrimination condition was temporarily replaced with `if false;`. The regression fixture failed as expected, demonstrating that it detects restoration of the old catch-all conflict banner. The condition was restored before the final verification above.

```text
$ scripts/audit/test_session_setup_hook.sh  # temporary mutation only
FAIL: lease claim budget exhaustion: expected output to contain: ERROR: LEASE CLAIM COULD NOT RUN (timeout/budget/runner missing) — stop; lease state UNKNOWN; do NOT force-release.
mutation_check_exit=1
```