### PR TITLE
fix(delegate): self-liquidating runtime-tmp reap + origin-synced --branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ docs/bolshakova_*.png
 
 gha-creds-*.json
 .pytest_cache/
+.pytest_breadcrumbs/
 
 # uv lockfiles are local scratch in this repo; dependencies are managed through
 # pyproject.toml plus the project venv.

--- a/scripts/ai_agent_bridge/_review_worktree.py
+++ b/scripts/ai_agent_bridge/_review_worktree.py
@@ -19,7 +19,6 @@ import json
 import os
 import re
 import shlex
-import shutil
 import stat
 import subprocess
 import sys
@@ -49,10 +48,12 @@ from scripts.review.isolation import (
     build_reviewer_env,
     canonical_isolated_review_schema,
     is_sensitive_path,
+    remove_review_temp_tree,
     resolve_external_executable,
     resolve_trusted_reviewer_executable,
     review_isolation_tool_config,
     secret_like_findings,
+    sweep_review_temp_orphans,
 )
 from scripts.review.review_contract import ContractError, validate_reviewer_payload
 from scripts.review.snapshot import (
@@ -2372,28 +2373,7 @@ def _create_reviewer_view(
 
 def _remove_review_root(root: Path) -> None:
     """Remove a private root without following reviewer-created symlinks."""
-    try:
-        root_stat = root.lstat()
-    except FileNotFoundError:
-        return
-    if stat.S_ISLNK(root_stat.st_mode) or not stat.S_ISDIR(root_stat.st_mode):
-        raise OSError(f"temporary root is not a private directory: {root}")
-    for dirpath, dirnames, filenames in os.walk(root, topdown=False, followlinks=False):
-        base = Path(dirpath)
-        for name in filenames:
-            path = base / name
-            if path.is_symlink():
-                path.unlink()
-        for name in dirnames:
-            path = base / name
-            if path.is_symlink():
-                path.unlink()
-            else:
-                path.chmod(0o700)
-    root.chmod(0o700)
-    shutil.rmtree(root, ignore_errors=False)
-    if root.exists():
-        raise OSError(f"temporary root survived cleanup: {root}")
+    remove_review_temp_tree(root)
 
 
 def _create_private_write_root() -> Path:
@@ -2472,6 +2452,7 @@ def provision_review_worktree(
     Post-review acceptance verifies snapshot, bundle, original-source state,
     and requires bound isolation evidence from the runner.
     """
+    sweep_review_temp_orphans()
     if target is None:
         if allow_local_fallback:
             with _provision_local_review_worktree(repo_root=repo_root) as checkout:
@@ -2727,6 +2708,7 @@ def provision_local_review_snapshot(
     """
     from scripts.review.snapshot import capture_local_review_state
 
+    sweep_review_temp_orphans()
     root = repo_root.resolve()
     git_bin, _gh = _trusted_bins(root)
     try:

--- a/scripts/ai_agent_bridge/_review_worktree.py
+++ b/scripts/ai_agent_bridge/_review_worktree.py
@@ -19,6 +19,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import stat
 import subprocess
 import sys
@@ -43,10 +44,12 @@ from scripts.review.evidence import (
 )
 from scripts.review.isolation import (
     ISOLATION_POLICY_VERSION,
+    REVIEW_TEMP_ROOT_MARKER_NAME,
     SEALED_READ_CHUNK_BYTES,
     ReviewIsolationError,
     build_reviewer_env,
     canonical_isolated_review_schema,
+    create_review_temp_root,
     is_sensitive_path,
     remove_review_temp_tree,
     resolve_external_executable,
@@ -1656,7 +1659,7 @@ def _init_neutral_bare_repository(
     *, git_bin: Path, env: dict[str, str]
 ) -> Path:
     """Create a private config-neutral object repository for one review."""
-    root = Path(tempfile.mkdtemp(prefix="lu-review-git-"))
+    root = create_review_temp_root(prefix="lu-review-git-")
     try:
         _run_command(
             [str(git_bin), "init", "--bare", "--template=", str(root)],
@@ -2261,7 +2264,10 @@ def _reviewer_context_paths(snapshot: ReviewSnapshot) -> frozenset[str]:
         for name in filenames:
             source = base / name
             rel = source.relative_to(snapshot.path).as_posix()
-            if rel == ".review-snapshot-metadata.json" or rel in inert_unchanged:
+            if rel in {
+                ".review-snapshot-metadata.json",
+                REVIEW_TEMP_ROOT_MARKER_NAME,
+            } or rel in inert_unchanged:
                 continue
             if rel.startswith(".review-bundle/"):
                 continue
@@ -2307,6 +2313,8 @@ def _verify_reviewer_view(
             if path.is_symlink() or not path.is_file():
                 raise ReviewWorktreeError(f"review_view_non_regular:{path}")
             rel = path.relative_to(view).as_posix()
+            if rel == REVIEW_TEMP_ROOT_MARKER_NAME:
+                continue
             actual.add(rel)
             source = snapshot.path / rel
             if not source.is_file() or source.is_symlink():
@@ -2331,7 +2339,7 @@ def _create_reviewer_view(
     context_paths: tuple[str, ...] | None = None,
 ) -> Path:
     """Expose safe tracked text and the sealed bundle to reviewer tools."""
-    view = Path(tempfile.mkdtemp(prefix="lu-review-view-"))
+    view = create_review_temp_root(prefix="lu-review-view-")
     try:
         try:
             manifest = json.loads(
@@ -2378,7 +2386,7 @@ def _remove_review_root(root: Path) -> None:
 
 def _create_private_write_root() -> Path:
     """Create the complete parent-owned write layout before adapter planning."""
-    root = Path(tempfile.mkdtemp(prefix="lu-review-write-"))
+    root = create_review_temp_root(prefix="lu-review-write-")
     root.chmod(0o700)
     try:
         for name in ("tmp", "home", "exec"):
@@ -2397,7 +2405,7 @@ def _create_private_write_root() -> Path:
 
 def _create_private_exec_root() -> Path:
     """Create a parent-owned root for the immutable staged reviewer runtime."""
-    root = Path(tempfile.mkdtemp(prefix="lu-review-exec-"))
+    root = create_review_temp_root(prefix="lu-review-exec-")
     root.chmod(0o700)
     return root
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -128,6 +128,20 @@ _REPO_ROOT = resolve_repo_root(Path(__file__), 1)
 _TASKS_DIR = _REPO_ROOT / "batch_state" / "tasks"
 _BASH_SECRETS_PATH = Path.home() / ".bash_secrets"
 _GH_TOKEN_AGENTS = {"codex", "claude", "bridge"}
+_RUNTIME_TMP_TERMINAL_STATUSES = frozenset(
+    {
+        "done",
+        "failed",
+        "timeout",
+        "rate_limited",
+        "cancelled",
+        "crashed",
+        "dry_run",
+        "needs_finalize",
+        "no_deliverable",
+    }
+)
+_RUNTIME_TMP_ORPHAN_MAX_AGE_S = 7 * 24 * 60 * 60
 _FALLBACK_SUBS_PATH = _REPO_ROOT / "scripts" / "config" / "agent_fallback_substitutions.yaml"
 # Single source for dispatchable agents: argparse choices AND the hard-sub
 # validation in _resolve_agent_with_budget_guard (a yaml typo must never
@@ -450,6 +464,10 @@ class WorktreeStaleBase(RuntimeError):
     """Existing worktree is behind origin/<base> and the fast-forward rebase failed."""
 
 
+class WorktreeBranchDiverged(RuntimeError):
+    """A local --branch ref contains commits absent from its fetched origin ref."""
+
+
 def _normalize_task_id(agent: str, task_id: str) -> str:
     """Strip a leading ``{agent}-`` or ``{agent}/`` from task_id.
 
@@ -534,6 +552,163 @@ def _runtime_tmp_lease_bytes(lease_root: Path) -> int:
     return total
 
 
+def _grant_owner_rwx_at(path: Path, *, dir_fd: int) -> None:
+    """Give the owner access to a non-symlink path anchored at ``dir_fd``."""
+    try:
+        entry = os.stat(path, dir_fd=dir_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(entry.st_mode):
+        return
+    os.chmod(
+        path,
+        stat.S_IMODE(entry.st_mode) | stat.S_IRWXU,
+        dir_fd=dir_fd,
+        follow_symlinks=False,
+    )
+
+
+def _runtime_tmp_reap_onexc(
+    lease: Path,
+    namespace: Path,
+    namespace_fd: int,
+):
+    """Build an ``rmtree`` repair callback confined to one verified lease."""
+
+    def repair(_func: Any, raw_path: str | os.PathLike[str], exc: BaseException) -> None:
+        if not isinstance(exc, PermissionError):
+            raise exc
+        path = Path(raw_path)
+        try:
+            candidate = path.relative_to(namespace) if path.is_absolute() else path
+            candidate.relative_to(lease.name)
+        except ValueError:
+            raise exc from None
+        _grant_owner_rwx_at(candidate, dir_fd=namespace_fd)
+        _grant_owner_rwx_at(candidate.parent, dir_fd=namespace_fd)
+
+    return repair
+
+
+def _remove_runtime_tmp_lease(lease: Path, namespace: Path) -> None:
+    """Delete one verified lease, repairing restrictive owned entries first."""
+    if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
+        raise RuntimeError("platform rmtree lacks symlink-attack protection")
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise RuntimeError("platform lacks O_NOFOLLOW for runtime tmp cleanup")
+    open_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    open_flags |= os.O_NOFOLLOW
+    last_error: OSError | None = None
+    # ``shutil.rmtree`` calls onexc but cannot resume an ``os.open`` that
+    # failed while descending into a mode-000 directory. The next complete
+    # pass is safe because the handler repaired only verified lease entries.
+    for _attempt in range(2):
+        namespace_fd = os.open(namespace, open_flags)
+        try:
+            shutil.rmtree(
+                lease.name,
+                dir_fd=namespace_fd,
+                onexc=_runtime_tmp_reap_onexc(lease, namespace, namespace_fd),
+            )
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            last_error = exc
+        finally:
+            os.close(namespace_fd)
+        if not os.path.lexists(lease):
+            return
+    detail = f": {last_error}" if last_error is not None else ""
+    raise OSError(f"runtime tmp lease survived hardened cleanup: {lease}{detail}")
+
+
+def _runtime_tmp_state_for_lease(lease_name: str) -> dict[str, Any] | None:
+    """Find the task state that owns a deterministic runtime-lease name."""
+    try:
+        state_files = tuple(_TASKS_DIR.glob("*.json")) if _TASKS_DIR.is_dir() else ()
+    except OSError:
+        return None
+    for state_path in state_files:
+        if state_path.name.endswith(".tmp") or ".tmp." in state_path.name:
+            continue
+        state = _read_state(state_path)
+        task_id = state.get("task_id") if isinstance(state, dict) else None
+        if isinstance(task_id, str) and _runtime_tmp_lease_name(task_id) == lease_name:
+            return state
+    return None
+
+
+def _runtime_tmp_state_has_live_pid(state: dict[str, Any]) -> bool:
+    """Treat a valid live recorded PID as an active lease regardless of status."""
+    pid = state.get("pid")
+    if isinstance(pid, bool):
+        return False
+    try:
+        return isinstance(pid, (int, str)) and int(pid) > 0 and _pid_alive(int(pid))
+    except (TypeError, ValueError):
+        return False
+
+
+def _sweep_runtime_tmp_orphans(
+    *,
+    now: float | None = None,
+) -> dict[str, int]:
+    """Reap terminal or clearly abandoned task leases before a new dispatch.
+
+    A state-backed lease is removed only once its task is terminal and no
+    recorded process is alive. A state-less lease must be older than seven
+    days. Symlinks and malformed entries are skipped rather than followed.
+    """
+    result = {"leases_reaped": 0, "bytes_freed": 0, "errors": 0}
+    tmp_root = Path(tempfile.gettempdir())
+    namespace = tmp_root / "learn-ukrainian"
+    try:
+        namespace_stat = namespace.lstat()
+    except FileNotFoundError:
+        return result
+    except OSError:
+        result["errors"] += 1
+        return result
+    if stat.S_ISLNK(namespace_stat.st_mode) or not stat.S_ISDIR(namespace_stat.st_mode):
+        result["errors"] += 1
+        return result
+
+    cutoff = (time.time() if now is None else now) - _RUNTIME_TMP_ORPHAN_MAX_AGE_S
+    try:
+        candidates = tuple(namespace.iterdir())
+    except OSError:
+        result["errors"] += 1
+        return result
+    for lease in candidates:
+        try:
+            lease_stat = lease.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            result["errors"] += 1
+            continue
+        if stat.S_ISLNK(lease_stat.st_mode) or not stat.S_ISDIR(lease_stat.st_mode):
+            continue
+
+        state = _runtime_tmp_state_for_lease(lease.name)
+        if state is not None:
+            status = state.get("status")
+            if status not in _RUNTIME_TMP_TERMINAL_STATUSES or _runtime_tmp_state_has_live_pid(state):
+                continue
+        elif lease_stat.st_mtime >= cutoff:
+            continue
+
+        try:
+            bytes_freed = _runtime_tmp_lease_bytes(lease)
+            _remove_runtime_tmp_lease(lease, namespace)
+        except OSError:
+            result["errors"] += 1
+            continue
+        result["leases_reaped"] += 1
+        result["bytes_freed"] += bytes_freed
+    return result
+
+
 def _reap_runtime_tmp_lease(
     lease_root: Path | str | None,
     namespace_root: Path | str | None,
@@ -592,16 +767,9 @@ def _reap_runtime_tmp_lease(
             raise RuntimeError("platform rmtree lacks symlink-attack protection")
 
         bytes_freed = _runtime_tmp_lease_bytes(lease)
-        open_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-        if hasattr(os, "O_NOFOLLOW"):
-            open_flags |= os.O_NOFOLLOW
-        namespace_fd = os.open(namespace, open_flags)
-        try:
-            # Passing a basename plus dir_fd keeps the deletion anchored to
-            # the verified namespace even if an ancestor changes afterwards.
-            shutil.rmtree(lease.name, dir_fd=namespace_fd)
-        finally:
-            os.close(namespace_fd)
+        _remove_runtime_tmp_lease(lease, namespace)
+        if os.path.lexists(lease):
+            raise OSError(f"runtime tmp lease survived hardened cleanup: {lease}")
         result["tmp_bytes_freed"] = bytes_freed
     except Exception as exc:
         result["tmp_reap_error"] = (f"{type(exc).__name__}: {exc}")[:500]
@@ -1114,6 +1282,43 @@ def _fetch_existing_branch(branch: str) -> None:
     )
     if verify.returncode != 0:
         raise RuntimeError(f"origin/{branch} was not found after fetch; --branch requires an existing remote branch")
+
+
+def _require_local_branch_is_ancestor_of_origin(branch: str) -> str:
+    """Return fetched origin SHA or refuse a local-only branch divergence."""
+    origin_ref = f"origin/{branch}"
+    local_ref = f"refs/heads/{branch}"
+    origin_sha = _resolve_sha(_REPO_ROOT, origin_ref)
+    if origin_sha is None:
+        raise RuntimeError(f"{origin_ref} was not found after fetch; --branch requires an existing remote branch")
+    local_sha = _resolve_sha(_REPO_ROOT, local_ref)
+    if local_sha is None or local_sha == origin_sha:
+        return origin_sha
+
+    ancestry = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", local_ref, origin_ref],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    if ancestry.returncode == 0:
+        return origin_sha
+    if ancestry.returncode != 1:
+        raise RuntimeError(
+            f"could not compare local {branch!r} against {origin_ref}: "
+            f"{_format_process_failure(ancestry)}"
+        )
+    raise WorktreeBranchDiverged(
+        f"refusing --branch {branch!r}: local {local_ref} is not an ancestor of "
+        f"{origin_ref}; local_sha={local_sha} origin_sha={origin_sha}. "
+        "Reconcile explicitly before dispatching: inspect with "
+        f"`git log --left-right --graph --oneline {local_ref}...{origin_ref}`; "
+        f"to preserve local commits, run `git switch {branch} && git rebase {origin_ref}` "
+        f"then `git push --force-with-lease origin {branch}`; to discard the local-only "
+        f"ref, run `git branch -f {branch} {origin_ref}`."
+    )
 
 
 def _branch_worktree_paths(branch: str) -> list[Path]:
@@ -2141,6 +2346,7 @@ def _ensure_worktree(
 
     if requested_branch:
         _fetch_existing_branch(requested_branch)
+        _require_local_branch_is_ancestor_of_origin(requested_branch)
         occupied_paths = _branch_worktree_paths(requested_branch)
         elsewhere = [path for path in occupied_paths if path != worktree_path]
         if elsewhere:
@@ -2239,10 +2445,20 @@ def _ensure_worktree(
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
     add_command = ["git", "worktree", "add"]
-    if requested_branch and _resolve_sha(_REPO_ROOT, f"refs/heads/{requested_branch}"):
-        add_command.extend([str(worktree_path), requested_branch])
-    elif requested_branch:
-        add_command.extend(["--track", "-b", requested_branch, str(worktree_path), f"origin/{requested_branch}"])
+    if requested_branch:
+        # ``-B`` intentionally resets a behind local tracking ref to the SHA
+        # fetched from origin. _require_local_branch_is_ancestor_of_origin()
+        # already refused any local-only commits, and branch holders were
+        # released/refused above, so this cannot silently overwrite work.
+        add_command.extend(
+            [
+                "--track",
+                "-B",
+                requested_branch,
+                str(worktree_path),
+                f"origin/{requested_branch}",
+            ]
+        )
     else:
         add_command.extend(["-b", worktree_branch, str(worktree_path), worktree_base_ref])
     proc = subprocess.run(
@@ -3208,6 +3424,17 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         return 2
 
     _warn_if_monitor_api_unreachable()
+    if bool(getattr(args, "dry_run", False)):
+        print("🧹 runtime tmp orphan sweep: skipped=dry-run", file=sys.stderr)
+    else:
+        runtime_tmp_sweep = _sweep_runtime_tmp_orphans()
+        print(
+            "🧹 runtime tmp orphan sweep: "
+            f"leases_reaped={runtime_tmp_sweep['leases_reaped']} "
+            f"bytes_freed={runtime_tmp_sweep['bytes_freed']} "
+            f"errors={runtime_tmp_sweep['errors']}",
+            file=sys.stderr,
+        )
 
     # Refuse to clobber a task that's still alive — whether it's in
     # "running" (worker up and executing) OR "spawning" (worker created

--- a/scripts/review/isolation.py
+++ b/scripts/review/isolation.py
@@ -29,6 +29,7 @@ import json
 import os
 import platform
 import re
+import secrets
 import shutil
 import stat
 import subprocess
@@ -53,11 +54,95 @@ REVIEW_TEMP_ROOT_PREFIXES = (
     "lu-review-write-",
 )
 REVIEW_TEMP_ORPHAN_MAX_AGE_S = 48 * 60 * 60
+REVIEW_TEMP_ROOT_MARKER_NAME = ".lu-review-root"
+_REVIEW_TEMP_ROOT_MARKER_RE = re.compile(
+    rb"^lu-review-root-v1:[0-9a-f]{64}\n$"
+)
+_REVIEW_TEMP_ROOT_MARKER_MAX_BYTES = 96
 
 
 def _is_review_temp_root(path: Path) -> bool:
     """Return whether a path has one of the review-owned temp prefixes."""
     return path.name.startswith(REVIEW_TEMP_ROOT_PREFIXES)
+
+
+def _open_review_temp_root_fd(root: Path) -> int:
+    """Open one private review root without traversing a replacement symlink."""
+    entry = root.lstat()
+    if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+        raise OSError(f"review temporary root is not a private directory: {root}")
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise OSError("platform lacks O_NOFOLLOW for review temporary cleanup")
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NONBLOCK", 0)
+    flags |= os.O_NOFOLLOW
+    return os.open(root, flags)
+
+
+def _write_review_temp_root_marker(root: Path) -> None:
+    """Bind a newly created private root to review cleanup with a random nonce."""
+    root_fd = _open_review_temp_root_fd(root)
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+        marker_fd = os.open(
+            REVIEW_TEMP_ROOT_MARKER_NAME,
+            flags,
+            0o400,
+            dir_fd=root_fd,
+        )
+        try:
+            marker = f"lu-review-root-v1:{secrets.token_hex(32)}\n".encode("ascii")
+            with os.fdopen(marker_fd, "wb") as handle:
+                handle.write(marker)
+                handle.flush()
+                os.fchmod(handle.fileno(), 0o400)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(marker_fd)
+            raise
+    finally:
+        os.close(root_fd)
+
+
+def create_review_temp_root(
+    *,
+    prefix: str,
+    dir: str | os.PathLike[str] | None = None,
+) -> Path:
+    """Create a private review root whose cleanup identity is its sentinel."""
+    root = Path(tempfile.mkdtemp(prefix=prefix, dir=dir))
+    try:
+        _write_review_temp_root_marker(root)
+    except BaseException:
+        # The factory never exposes an unmarked root. This exact just-created
+        # directory is not yet a cleanup caller input.
+        with contextlib.suppress(OSError):
+            shutil.rmtree(root)
+        raise
+    return root
+
+
+def _has_review_temp_root_marker(root: Path) -> bool:
+    """Return whether ``root`` carries an intact regular-file review marker."""
+    try:
+        root_fd = _open_review_temp_root_fd(root)
+    except (FileNotFoundError, OSError):
+        return False
+    try:
+        flags = os.O_RDONLY | os.O_NOFOLLOW
+        try:
+            marker_fd = os.open(REVIEW_TEMP_ROOT_MARKER_NAME, flags, dir_fd=root_fd)
+        except OSError:
+            return False
+        try:
+            marker_stat = os.fstat(marker_fd)
+            if not stat.S_ISREG(marker_stat.st_mode) or marker_stat.st_nlink != 1:
+                return False
+            marker = os.read(marker_fd, _REVIEW_TEMP_ROOT_MARKER_MAX_BYTES + 1)
+            return bool(_REVIEW_TEMP_ROOT_MARKER_RE.fullmatch(marker))
+        finally:
+            os.close(marker_fd)
+    finally:
+        os.close(root_fd)
 
 
 def _grant_owner_rwx(path: Path) -> None:
@@ -82,15 +167,10 @@ def restore_review_temp_tree_permissions(root: Path) -> None:
     directory descriptors opened with ``O_NOFOLLOW`` so a concurrent symlink
     swap cannot turn permission restoration into a write outside the root.
     """
-    entry = root.lstat()
-    if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
-        raise OSError(f"review temporary root is not a private directory: {root}")
     _grant_owner_rwx(root)
-    if not hasattr(os, "O_NOFOLLOW"):
-        raise OSError("platform lacks O_NOFOLLOW for review temporary cleanup")
+    root_fd = _open_review_temp_root_fd(root)
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NONBLOCK", 0)
     flags |= os.O_NOFOLLOW
-    root_fd = os.open(root, flags)
     pending = [root_fd]
     try:
         while pending:
@@ -156,10 +236,8 @@ def _review_temp_reap_onexc(root: Path):
     return repair
 
 
-def remove_review_temp_tree(root: Path) -> None:
-    """Hardened removal for one review-owned temp root, with final proof."""
-    if not _is_review_temp_root(root):
-        raise OSError(f"refusing to remove non-review temporary root: {root}")
+def _remove_review_temp_tree(root: Path) -> None:
+    """Hardened removal after the caller has proven root ownership."""
     try:
         entry = root.lstat()
     except FileNotFoundError:
@@ -183,6 +261,26 @@ def remove_review_temp_tree(root: Path) -> None:
             return
     detail = f": {last_error}" if last_error is not None else ""
     raise OSError(f"review temporary root survived cleanup: {root}{detail}")
+
+
+def remove_review_temp_tree(root: Path) -> None:
+    """Remove one sentinel-marked review-owned temp root, with final proof."""
+    try:
+        entry = root.lstat()
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+        raise OSError(f"review temporary root is not a private directory: {root}")
+    if not _has_review_temp_root_marker(root):
+        raise OSError(f"refusing to remove unmarked review temporary root: {root}")
+    _remove_review_temp_tree(root)
+
+
+def _remove_review_temp_orphan(root: Path) -> None:
+    """Remove an old loose TMPDIR root when its prefix is the only identity."""
+    if not _is_review_temp_root(root):
+        raise OSError(f"refusing to remove non-review temporary root: {root}")
+    _remove_review_temp_tree(root)
 
 
 def _review_temp_root_bytes(root: Path) -> int:
@@ -256,7 +354,7 @@ def sweep_review_temp_orphans(*, now: float | None = None) -> dict[str, int]:
             continue
         try:
             bytes_freed = _review_temp_root_bytes(root)
-            remove_review_temp_tree(root)
+            _remove_review_temp_orphan(root)
         except OSError:
             result["errors"] += 1
             continue

--- a/scripts/review/isolation.py
+++ b/scripts/review/isolation.py
@@ -45,6 +45,224 @@ from scripts.utils.claude_version import _parse_claude_semver
 
 ISOLATION_POLICY_VERSION = "review-isolation-v2"
 CLAUDE_MIN_SUPPORTED_CLI_VERSION = (2, 1, 116)
+REVIEW_TEMP_ROOT_PREFIXES = (
+    "lu-review-snap-",
+    "lu-review-git-",
+    "lu-review-exec-",
+    "lu-review-view-",
+    "lu-review-write-",
+)
+REVIEW_TEMP_ORPHAN_MAX_AGE_S = 48 * 60 * 60
+
+
+def _is_review_temp_root(path: Path) -> bool:
+    """Return whether a path has one of the review-owned temp prefixes."""
+    return path.name.startswith(REVIEW_TEMP_ROOT_PREFIXES)
+
+
+def _grant_owner_rwx(path: Path) -> None:
+    """Restore owner access for one owned non-symlink path if it remains."""
+    try:
+        entry = path.lstat()
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(entry.st_mode):
+        return
+    os.chmod(
+        path,
+        stat.S_IMODE(entry.st_mode) | stat.S_IRWXU,
+        follow_symlinks=False,
+    )
+
+
+def restore_review_temp_tree_permissions(root: Path) -> None:
+    """Restore owner write/traversal access without following symlinks.
+
+    Review snapshots and views deliberately remove write bits. This walks
+    directory descriptors opened with ``O_NOFOLLOW`` so a concurrent symlink
+    swap cannot turn permission restoration into a write outside the root.
+    """
+    entry = root.lstat()
+    if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+        raise OSError(f"review temporary root is not a private directory: {root}")
+    _grant_owner_rwx(root)
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise OSError("platform lacks O_NOFOLLOW for review temporary cleanup")
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NONBLOCK", 0)
+    flags |= os.O_NOFOLLOW
+    root_fd = os.open(root, flags)
+    pending = [root_fd]
+    try:
+        while pending:
+            directory_fd = pending.pop()
+            try:
+                directory_stat = os.fstat(directory_fd)
+                if not stat.S_ISDIR(directory_stat.st_mode):
+                    raise OSError("review temporary descriptor is not a directory")
+                os.fchmod(
+                    directory_fd,
+                    stat.S_IMODE(directory_stat.st_mode) | stat.S_IRWXU,
+                )
+                with os.scandir(directory_fd) as entries:
+                    children = tuple(entries)
+                for child in children:
+                    try:
+                        child_stat = os.stat(
+                            child.name,
+                            dir_fd=directory_fd,
+                            follow_symlinks=False,
+                        )
+                    except FileNotFoundError:
+                        continue
+                    if stat.S_ISLNK(child_stat.st_mode):
+                        continue
+                    os.chmod(
+                        child.name,
+                        stat.S_IMODE(child_stat.st_mode) | stat.S_IRWXU,
+                        dir_fd=directory_fd,
+                        follow_symlinks=False,
+                    )
+                    if not stat.S_ISDIR(child_stat.st_mode):
+                        continue
+                    try:
+                        child_fd = os.open(child.name, flags, dir_fd=directory_fd)
+                    except FileNotFoundError:
+                        continue
+                    pending.append(child_fd)
+            finally:
+                os.close(directory_fd)
+    except BaseException:
+        for directory_fd in pending:
+            with contextlib.suppress(OSError):
+                os.close(directory_fd)
+        raise
+
+
+def _review_temp_reap_onexc(root: Path):
+    """Build an rmtree callback that repairs the blocking entry and parent."""
+
+    def repair(_func: Any, raw_path: str | os.PathLike[str], exc: BaseException) -> None:
+        if not isinstance(exc, PermissionError):
+            raise exc
+        path = Path(raw_path)
+        try:
+            path.relative_to(root)
+            path.parent.relative_to(root.parent)
+        except ValueError:
+            raise exc from None
+        _grant_owner_rwx(path)
+        _grant_owner_rwx(path.parent)
+
+    return repair
+
+
+def remove_review_temp_tree(root: Path) -> None:
+    """Hardened removal for one review-owned temp root, with final proof."""
+    if not _is_review_temp_root(root):
+        raise OSError(f"refusing to remove non-review temporary root: {root}")
+    try:
+        entry = root.lstat()
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+        raise OSError(f"review temporary root is not a private directory: {root}")
+    if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
+        raise OSError("platform rmtree lacks symlink-attack protection")
+
+    restore_review_temp_tree_permissions(root)
+    repair = _review_temp_reap_onexc(root)
+    last_error: OSError | None = None
+    for _attempt in range(2):
+        try:
+            shutil.rmtree(root, onexc=repair)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            last_error = exc
+        if not os.path.lexists(root):
+            return
+    detail = f": {last_error}" if last_error is not None else ""
+    raise OSError(f"review temporary root survived cleanup: {root}{detail}")
+
+
+def _review_temp_root_bytes(root: Path) -> int:
+    """Count regular-file payload bytes without following symlink targets."""
+    total = 0
+    for directory, dirnames, filenames in os.walk(root, followlinks=False):
+        for name in [*dirnames, *filenames]:
+            path = Path(directory) / name
+            try:
+                entry = path.lstat()
+            except FileNotFoundError:
+                continue
+            if stat.S_ISREG(entry.st_mode) or stat.S_ISLNK(entry.st_mode):
+                total += entry.st_size
+    return total
+
+
+def _review_temp_orphan_candidates(tmp_root: Path) -> tuple[Path, ...]:
+    """Return only direct review-owned roots under loose and task TMPDIRs."""
+    candidates: list[Path] = []
+    parent_sets = [tmp_root]
+    namespace = tmp_root / "learn-ukrainian"
+    try:
+        namespace_stat = namespace.lstat()
+    except FileNotFoundError:
+        namespace_stat = None
+    if namespace_stat is not None and not stat.S_ISLNK(namespace_stat.st_mode) and stat.S_ISDIR(namespace_stat.st_mode):
+        try:
+            for path in namespace.iterdir():
+                path_stat = path.lstat()
+                if not stat.S_ISLNK(path_stat.st_mode) and stat.S_ISDIR(path_stat.st_mode):
+                    parent_sets.append(path)
+        except OSError:
+            pass
+    for parent in parent_sets:
+        try:
+            children = tuple(parent.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            try:
+                child_stat = child.lstat()
+            except FileNotFoundError:
+                continue
+            if (
+                _is_review_temp_root(child)
+                and not stat.S_ISLNK(child_stat.st_mode)
+                and stat.S_ISDIR(child_stat.st_mode)
+            ):
+                candidates.append(child)
+    return tuple(candidates)
+
+
+def sweep_review_temp_orphans(*, now: float | None = None) -> dict[str, int]:
+    """Remove review-owned temp roots older than 48 hours before a review."""
+    result = {"roots_reaped": 0, "bytes_freed": 0, "errors": 0}
+    # Delegate workers override TMPDIR with their lease. The dispatcher keeps
+    # this base value so nested review cleanup can still cover both loose and
+    # task-namespaced review roots.
+    base = Path(os.environ.get("LU_RUNTIME_TMP_BASE_ROOT", tempfile.gettempdir()))
+    cutoff = (time.time() if now is None else now) - REVIEW_TEMP_ORPHAN_MAX_AGE_S
+    for root in _review_temp_orphan_candidates(base):
+        try:
+            root_stat = root.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            result["errors"] += 1
+            continue
+        if root_stat.st_mtime >= cutoff:
+            continue
+        try:
+            bytes_freed = _review_temp_root_bytes(root)
+            remove_review_temp_tree(root)
+        except OSError:
+            result["errors"] += 1
+            continue
+        result["roots_reaped"] += 1
+        result["bytes_freed"] += bytes_freed
+    return result
 
 # Process-injection / Git-override variables stripped for every reviewer.
 _PROCESS_INJECTION_ENV_KEYS = frozenset(

--- a/scripts/review/snapshot.py
+++ b/scripts/review/snapshot.py
@@ -37,7 +37,9 @@ from pathlib import Path
 from typing import Any
 
 from scripts.review.isolation import (
+    REVIEW_TEMP_ROOT_MARKER_NAME,
     ReviewIsolationError,
+    create_review_temp_root,
     is_sensitive_path,
     is_within,
     preflight_review_inputs,
@@ -625,7 +627,7 @@ def _fingerprint_snapshot_tree(
             if full.is_symlink():
                 raise ReviewSnapshotError(f"{DIAG_SYMLINK}:{full}")
             rel = full.relative_to(root).as_posix()
-            if rel != ".review-snapshot-metadata.json":
+            if rel not in {".review-snapshot-metadata.json", REVIEW_TEMP_ROOT_MARKER_NAME}:
                 paths.append(rel)
 
     hasher = _source_fingerprint_hasher(
@@ -1918,7 +1920,7 @@ def materialize_review_snapshot(
     if is_within(parent.resolve(), root):
         raise ReviewSnapshotError("tmpdir_inside_repo")
 
-    dest = Path(tempfile.mkdtemp(prefix="lu-review-snap-", dir=str(parent)))
+    dest = create_review_temp_root(prefix="lu-review-snap-", dir=str(parent))
     try:
         remove_paths = set(deleted_paths)
         remove_paths.update(old for old, _new in rename_pairs)

--- a/scripts/review/snapshot.py
+++ b/scripts/review/snapshot.py
@@ -41,6 +41,7 @@ from scripts.review.isolation import (
     is_sensitive_path,
     is_within,
     preflight_review_inputs,
+    remove_review_temp_tree,
     resolve_external_executable,
     safe_engine_path,
     secret_like_findings,
@@ -1147,24 +1148,6 @@ def _set_tree_read_only(root: Path) -> None:
     root.chmod(root.stat().st_mode & ~stat.S_IWUSR & ~stat.S_IWGRP & ~stat.S_IWOTH)
 
 
-def _set_tree_writable(root: Path) -> None:
-    if not root.exists():
-        return
-    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
-        base = Path(dirpath)
-        for name in [*dirnames, *filenames]:
-            p = base / name
-            try:
-                if p.is_symlink():
-                    continue
-                mode = p.stat().st_mode
-                p.chmod(mode | stat.S_IWUSR)
-            except OSError:
-                continue
-    with contextlib.suppress(OSError):
-        root.chmod(root.stat().st_mode | stat.S_IWUSR)
-
-
 def derive_changed_paths_and_patch(
     repo_root: Path,
     *,
@@ -2152,10 +2135,7 @@ def verify_review_acceptance(
 
 
 def _cleanup_snapshot(path: Path) -> None:
-    if not path.exists():
-        return
-    _set_tree_writable(path)
-    shutil.rmtree(path, ignore_errors=False)
+    remove_review_temp_tree(path)
 
 
 def cleanup_snapshot_state(state: _SnapshotState) -> None:

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 from ai_agent_bridge import _agy, _claude, _cli, _codex, _grok_build
 from ai_agent_bridge import _review_worktree as review_worktree
 
+from scripts.review.isolation import create_review_temp_root
 from scripts.review.snapshot import (
     ReviewSnapshot,
     _SnapshotState,
@@ -1210,7 +1211,7 @@ def test_remove_review_root_unlinks_reviewer_symlinks_without_following(
     outside_dir = tmp_path / "outside-dir"
     outside_dir.mkdir()
     (outside_dir / "preserve.txt").write_text("preserve\n", encoding="utf-8")
-    root = tmp_path / "private-root"
+    root = create_review_temp_root(prefix="private-root-", dir=tmp_path)
     nested = root / "home" / ".codex" / "tmp" / "arg0"
     nested.mkdir(parents=True)
     (nested / "applypatch").symlink_to(outside_file)
@@ -1769,8 +1770,7 @@ def test_provision_review_worktree_fetches_origin_head_and_reaps_on_error(
 ) -> None:
     """A failing reviewer cannot strand the fetched neutral snapshot."""
     sha = "a" * 40
-    snap_path = tmp_path / "snap"
-    snap_path.mkdir()
+    snap_path = create_review_temp_root(prefix="snapshot-", dir=tmp_path)
     _write_fake_bundle(snap_path)
     (snap_path / "tracked.py").write_text("value = 1\n", encoding="utf-8")
     calls: list[list[str]] = []
@@ -1880,8 +1880,7 @@ def test_provision_review_worktree_fetches_origin_head_and_reaps_on_error(
 
 def test_pr_review_target_resolves_head_then_fetches_origin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     sha = "b" * 40
-    snap_path = tmp_path / "snap"
-    snap_path.mkdir()
+    snap_path = create_review_temp_root(prefix="snapshot-", dir=tmp_path)
     _write_fake_bundle(snap_path)
     calls: list[list[str]] = []
 
@@ -2038,8 +2037,7 @@ def test_review_target_present_but_non_dict_fails_closed() -> None:
 
 def test_source_drift_raises_after_yield(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     sha = "c" * 40
-    snap_path = tmp_path / "snap"
-    snap_path.mkdir()
+    snap_path = create_review_temp_root(prefix="snapshot-", dir=tmp_path)
     _write_fake_bundle(snap_path)
     monkeypatch.setattr(
         review_worktree,
@@ -2112,11 +2110,10 @@ def test_source_drift_raises_after_yield(monkeypatch: pytest.MonkeyPatch, tmp_pa
 def test_cleanup_attempts_snapshot_view_and_auth_root_independently(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    snapshot = tmp_path / "snapshot"
-    view = tmp_path / "view"
-    write = tmp_path / "write"
+    snapshot = create_review_temp_root(prefix="snapshot-", dir=tmp_path)
+    view = create_review_temp_root(prefix="view-", dir=tmp_path)
+    write = create_review_temp_root(prefix="write-", dir=tmp_path)
     for root in (snapshot, view, write):
-        root.mkdir()
         (root / "data").write_text("x", encoding="utf-8")
 
     class State:
@@ -2137,8 +2134,7 @@ def test_cleanup_attempts_snapshot_view_and_auth_root_independently(
 def test_partial_root_creation_failure_cleans_parent_owned_write_root(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    write = tmp_path / "write"
-    write.mkdir(mode=0o700)
+    write = create_review_temp_root(prefix="write-", dir=tmp_path)
     monkeypatch.setattr(review_worktree, "_create_private_write_root", lambda: write)
     monkeypatch.setattr(
         review_worktree,

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -61,6 +61,16 @@ def _stub_primary_integrity_sweep(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _fixture_runtime_tmp_root(tmp_path, monkeypatch):
+    """Keep dispatch-time orphan sweeps inside each test fixture only."""
+    runtime_tmp = tmp_path / "runtime-tmp"
+    runtime_tmp.mkdir()
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(runtime_tmp))
+    monkeypatch.delenv("LU_RUNTIME_TMP_BASE_ROOT", raising=False)
+    return runtime_tmp
+
+
 def _sanitize_git_env_for_test(monkeypatch) -> None:
     for key in tuple(os.environ):
         if key.startswith(("GIT_", "PRE_COMMIT")):
@@ -219,6 +229,25 @@ def test_runtime_tmp_reap_unlinks_child_symlinks_without_following_them(tmp_path
     assert payload.read_text(encoding="utf-8") == "keep"
 
 
+def test_runtime_tmp_reap_repairs_mode_zero_descendant(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    namespace_root = tmp_path / "learn-ukrainian"
+    lease_root = namespace_root / "task"
+    blocked = lease_root / "lu-review-view-restrictive"
+    blocked.mkdir(parents=True)
+    (blocked / "evidence.txt").write_text("sealed", encoding="utf-8")
+    blocked.chmod(0o000)
+
+    try:
+        result = delegate._reap_runtime_tmp_lease(lease_root, namespace_root)
+
+        assert result["tmp_reap_error"] is None
+        assert not os.path.lexists(lease_root)
+    finally:
+        if blocked.exists():
+            blocked.chmod(0o700)
+
+
 def test_runtime_tmp_reap_records_cleanup_errors(tmp_path, monkeypatch):
     monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
     namespace_root = tmp_path / "learn-ukrainian"
@@ -236,6 +265,45 @@ def test_runtime_tmp_reap_records_cleanup_errors(tmp_path, monkeypatch):
     assert result["tmp_bytes_freed"] == 0
     assert "permission denied" in str(result["tmp_reap_error"])
     assert lease_root.exists()
+
+
+def test_runtime_tmp_orphan_sweep_reaps_only_safe_candidates(tmp_tasks_dir, tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    namespace = tmp_path / "learn-ukrainian"
+    terminal = namespace / "terminal-task"
+    running = namespace / "running-task"
+    live_pid = namespace / "live-pid-task"
+    old_unknown = namespace / "old-unknown"
+    young_unknown = namespace / "young-unknown"
+    for lease in (terminal, running, live_pid, old_unknown, young_unknown):
+        lease.mkdir(parents=True)
+        (lease / "payload").write_text(lease.name, encoding="utf-8")
+    now = time.time()
+    old = now - delegate._RUNTIME_TMP_ORPHAN_MAX_AGE_S - 1
+    os.utime(old_unknown, (old, old))
+    delegate._write_state_atomic(
+        delegate._state_path("terminal-task"),
+        {"task_id": "terminal-task", "status": "done", "pid": None},
+    )
+    delegate._write_state_atomic(
+        delegate._state_path("running-task"),
+        {"task_id": "running-task", "status": "running", "pid": None},
+    )
+    delegate._write_state_atomic(
+        delegate._state_path("live-pid-task"),
+        {"task_id": "live-pid-task", "status": "done", "pid": os.getpid()},
+    )
+
+    result = delegate._sweep_runtime_tmp_orphans(now=now)
+
+    assert result["leases_reaped"] == 2
+    assert result["bytes_freed"] == len("terminal-task") + len("old-unknown")
+    assert result["errors"] == 0
+    assert not terminal.exists()
+    assert not old_unknown.exists()
+    assert running.exists()
+    assert live_pid.exists()
+    assert young_unknown.exists()
 
 
 def test_write_state_atomic_no_partial_reads(tmp_tasks_dir):
@@ -2958,6 +3026,11 @@ def test_dispatch_dry_run_records_and_reaps_runtime_tmp_lease(
     monkeypatch,
 ):
     monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        delegate,
+        "_sweep_runtime_tmp_orphans",
+        lambda: pytest.fail("dry-run must not sweep ambient runtime tmp leases"),
+    )
     args = delegate.build_parser().parse_args(
         [
             "dispatch",
@@ -3186,7 +3259,7 @@ def test_dispatch_uses_existing_worktree_without_git_add(tmp_tasks_dir, tmp_path
 
 
 def test_branch_reuse_creates_worktree_from_existing_remote_branch(tmp_tasks_dir, tmp_path, monkeypatch):
-    """--branch must attach to its fetched branch, never origin/main (#4837)."""
+    """--branch must reset its worktree to the fetched origin branch."""
     target = tmp_path / "branch-reuse"
     branch = "cursor/follow-up"
     calls, base_stub = _make_run_stub(rev_parse_head_sha="branch-head")
@@ -3216,11 +3289,148 @@ def test_branch_reuse_creates_worktree_from_existing_remote_branch(tmp_tasks_dir
         "worktree",
         "add",
         "--track",
-        "-b",
+        "-B",
         branch,
         str(target.resolve()),
         f"origin/{branch}",
     ]
+
+
+def test_branch_reuse_resets_behind_local_ref_to_fetched_origin(tmp_tasks_dir, tmp_path, monkeypatch):
+    target = tmp_path / "behind-local"
+    branch = "claude/predeploy-visibility"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rev-parse"]:
+            ref = cmd[-1]
+            sha = {
+                f"origin/{branch}": "1ef217eed9",
+                f"refs/heads/{branch}": "729a7990a3",
+                "HEAD": "1ef217eed9",
+            }.get(ref, "1ef217eed9")
+            return subprocess.CompletedProcess(cmd, 0, sha, "")
+        if cmd[:3] == ["git", "merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:3] == ["git", "worktree", "list"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "ls-tree"]:
+            return subprocess.CompletedProcess(cmd, 0, "docs\nscripts\ntests\n", "")
+        if cmd[:2] == ["git", "sparse-checkout"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    path, actual_branch, telemetry = delegate._ensure_worktree(
+        agent="claude",
+        task_id="predeploy-visibility",
+        raw_path=str(target),
+        branch=branch,
+    )
+
+    assert path == target.resolve()
+    assert actual_branch == branch
+    assert telemetry["base_sha"] == "1ef217eed9"
+    assert ["git", "fetch", "origin", branch] in calls
+    assert [
+        "git",
+        "merge-base",
+        "--is-ancestor",
+        f"refs/heads/{branch}",
+        f"origin/{branch}",
+    ] in calls
+    add_cmd = next(command for command in calls if command[:3] == ["git", "worktree", "add"])
+    assert add_cmd[-1] == f"origin/{branch}"
+    assert "-B" in add_cmd
+
+
+def test_branch_reuse_real_worktree_head_matches_fetched_origin(tmp_tasks_dir, tmp_path, monkeypatch):
+    remote = tmp_path / "remote.git"
+    source = tmp_path / "source"
+    client = tmp_path / "client"
+    env = delegate._sanitized_git_env()
+
+    def git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, env=env)
+    source.mkdir()
+    git(source, "init", "-b", "main")
+    git(source, "config", "user.email", "test@example.com")
+    git(source, "config", "user.name", "Test")
+    git(source, "commit", "--allow-empty", "-m", "base")
+    git(source, "remote", "add", "origin", str(remote))
+    git(source, "push", "-u", "origin", "main")
+    git(source, "switch", "-c", "claude/predeploy-visibility")
+    git(source, "commit", "--allow-empty", "-m", "remote branch head")
+    git(source, "push", "-u", "origin", "claude/predeploy-visibility")
+    subprocess.run(["git", "clone", str(remote), str(client)], check=True, capture_output=True, env=env)
+    git(client, "branch", "claude/predeploy-visibility", "origin/main")
+
+    monkeypatch.setattr(delegate, "_REPO_ROOT", client.resolve())
+    monkeypatch.setattr(delegate, "_apply_dispatch_sparse_checkout", lambda *_args, **_kwargs: {})
+    worktree = tmp_path / "dispatched"
+    path, branch, _telemetry = delegate._ensure_worktree(
+        agent="claude",
+        task_id="predeploy-visibility",
+        raw_path=str(worktree),
+        branch="claude/predeploy-visibility",
+    )
+
+    assert path == worktree.resolve()
+    assert branch == "claude/predeploy-visibility"
+    assert git(path, "rev-parse", "HEAD").stdout.strip() == git(
+        client,
+        "rev-parse",
+        "origin/claude/predeploy-visibility",
+    ).stdout.strip()
+
+
+def test_branch_reuse_refuses_diverged_local_ref(tmp_tasks_dir, tmp_path, monkeypatch):
+    branch = "claude/predeploy-visibility"
+
+    def fake_run(cmd, **_kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[:2] == ["git", "rev-parse"]:
+            ref = cmd[-1]
+            sha = {
+                f"origin/{branch}": "1ef217eed9",
+                f"refs/heads/{branch}": "729a7990a3",
+            }.get(ref, "")
+            return subprocess.CompletedProcess(cmd, 0 if sha else 1, sha, "")
+        if cmd[:3] == ["git", "merge-base", "--is-ancestor"]:
+            return subprocess.CompletedProcess(cmd, 1, "", "")
+        pytest.fail(f"unexpected git command after divergence refusal: {cmd}")
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(delegate.WorktreeBranchDiverged) as exc_info:
+        delegate._ensure_worktree(
+            agent="claude",
+            task_id="predeploy-visibility",
+            raw_path=str(tmp_path / "diverged-local"),
+            branch=branch,
+        )
+
+    message = str(exc_info.value)
+    assert "729a7990a3" in message
+    assert "1ef217eed9" in message
+    assert "git log --left-right --graph --oneline" in message
+    assert "git branch -f" in message
 
 
 def test_branch_reuse_dry_run_validates_existing_worktree_without_adding(

--- a/tests/test_review_isolation.py
+++ b/tests/test_review_isolation.py
@@ -32,6 +32,7 @@ from scripts.review.isolation import (
     build_codex_review_argv,
     build_macos_sandbox_profile,
     build_reviewer_env,
+    create_review_temp_root,
     detect_engine_capabilities,
     is_sensitive_path,
     preflight_review_inputs,
@@ -161,7 +162,7 @@ def _private_review_roots(tmp_path: Path, label: str = "review") -> tuple[Path, 
 
 
 def test_review_temp_cleanup_removes_restrictive_view_after_simulated_review(tmp_path: Path) -> None:
-    review_root = tmp_path / "lu-review-view-simulated"
+    review_root = create_review_temp_root(prefix="lu-review-view-", dir=tmp_path)
     restricted = review_root / "context" / "restricted"
     blocked = restricted / "deeper"
     blocked.mkdir(parents=True)
@@ -179,6 +180,18 @@ def test_review_temp_cleanup_removes_restrictive_view_after_simulated_review(tmp
             blocked.chmod(0o700)
         if restricted.exists():
             restricted.chmod(0o700)
+
+
+def test_review_temp_cleanup_refuses_unmarked_prefixed_directory(tmp_path: Path) -> None:
+    root = tmp_path / "lu-review-view-unmarked"
+    root.mkdir()
+    (root / "payload").write_text("preserve", encoding="utf-8")
+
+    with pytest.raises(OSError, match="unmarked review temporary root"):
+        remove_review_temp_tree(root)
+
+    assert root.exists()
+    assert (root / "payload").read_text(encoding="utf-8") == "preserve"
 
 
 def test_review_temp_orphan_sweep_reaps_only_old_loose_and_task_roots(

--- a/tests/test_review_isolation.py
+++ b/tests/test_review_isolation.py
@@ -9,6 +9,7 @@ import os
 import stat
 import subprocess
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -36,6 +37,7 @@ from scripts.review.isolation import (
     preflight_review_inputs,
     prepare_host_sandbox,
     prepare_isolated_review_launch,
+    remove_review_temp_tree,
     require_engine_isolation,
     require_supported_engine_version,
     resolve_external_executable,
@@ -44,6 +46,7 @@ from scripts.review.isolation import (
     safe_proxy_url,
     secret_like_findings,
     stage_engine_auth,
+    sweep_review_temp_orphans,
     wrap_argv_with_sandbox,
 )
 from scripts.review.snapshot import (
@@ -70,6 +73,18 @@ from scripts.review.snapshot import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fixture_review_tmp_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Keep review-start orphan sweeps inside a test-owned TMPDIR only."""
+    from scripts.review import isolation
+
+    review_tmp = tmp_path / "review-tmp"
+    review_tmp.mkdir()
+    monkeypatch.setattr(isolation.tempfile, "gettempdir", lambda: str(review_tmp))
+    monkeypatch.delenv("LU_RUNTIME_TMP_BASE_ROOT", raising=False)
+    return review_tmp
 
 
 def _frag(*parts: str) -> str:
@@ -143,6 +158,57 @@ def _private_review_roots(tmp_path: Path, label: str = "review") -> tuple[Path, 
     (write / "empty-mcp.json").write_text('{"mcpServers":{}}\n', encoding="utf-8")
     (write / "empty-mcp.json").chmod(0o400)
     return write, execution
+
+
+def test_review_temp_cleanup_removes_restrictive_view_after_simulated_review(tmp_path: Path) -> None:
+    review_root = tmp_path / "lu-review-view-simulated"
+    restricted = review_root / "context" / "restricted"
+    blocked = restricted / "deeper"
+    blocked.mkdir(parents=True)
+    (blocked / "evidence.txt").write_text("sealed", encoding="utf-8")
+    blocked.chmod(0o000)
+    restricted.chmod(0o000)
+
+    try:
+        remove_review_temp_tree(review_root)
+
+        assert not review_root.exists()
+        assert not tuple(tmp_path.glob("lu-review-*"))
+    finally:
+        if blocked.exists():
+            blocked.chmod(0o700)
+        if restricted.exists():
+            restricted.chmod(0o700)
+
+
+def test_review_temp_orphan_sweep_reaps_only_old_loose_and_task_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts.review import isolation
+
+    loose_old = tmp_path / "lu-review-git-old"
+    task_old = tmp_path / "learn-ukrainian" / "task" / "lu-review-view-old"
+    loose_young = tmp_path / "lu-review-write-young"
+    unrelated = tmp_path / "not-review"
+    for root in (loose_old, task_old, loose_young, unrelated):
+        root.mkdir(parents=True)
+        (root / "payload").write_text(root.name, encoding="utf-8")
+    now = time.time()
+    old = now - isolation.REVIEW_TEMP_ORPHAN_MAX_AGE_S - 1
+    os.utime(loose_old, (old, old))
+    os.utime(task_old, (old, old))
+    monkeypatch.setattr(isolation.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.delenv("LU_RUNTIME_TMP_BASE_ROOT", raising=False)
+
+    result = sweep_review_temp_orphans(now=now)
+
+    assert result["roots_reaped"] == 2
+    assert result["errors"] == 0
+    assert not loose_old.exists()
+    assert not task_old.exists()
+    assert loose_young.exists()
+    assert unrelated.exists()
 
 
 def _init_repo(path: Path) -> None:


### PR DESCRIPTION
## Evidence

CWD: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/fix-delegate-tmp-branch`

Command:
```text
.venv/bin/python -m pytest -q tests/test_delegate.py
```

Raw output:
```text
180 passed in 15.30s
```

Command:
```text
.venv/bin/python -m pytest -q tests/test_review_isolation.py
```

Raw output:
```text
98 passed in 21.20s
```

Command:
```text
.venv/bin/ruff check scripts/delegate.py scripts/review/isolation.py scripts/review/snapshot.py scripts/ai_agent_bridge/_review_worktree.py tests/test_delegate.py tests/test_review_isolation.py
```

Raw output:
```text
All checks passed!
```

Command:
```text
.venv/bin/python scripts/audit/lint_opsec_leaks.py
```

Raw output:
```text
OPSEC check passed. Zero leaks detected.
```

Command:
```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
```

Raw output:
```text
2a199d09d0  PASS  X-Agent: codex/fix-delegate-tmp-branch
All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Mutation checks (intentional guard removal; each exited 1)

Command:
```text
.venv/bin/python -m pytest -q tests/test_delegate.py::test_runtime_tmp_reap_repairs_mode_zero_descendant
```

Raw failing output after `onexc=None`:
```text
assert "OSError: runtime tmp lease survived hardened cleanup: ... Permission denied: task/lu-review-view-restrictive" is None
```

Command:
```text
.venv/bin/python -m pytest -q tests/test_delegate.py::test_runtime_tmp_orphan_sweep_reaps_only_safe_candidates
```

Raw failing output after terminal-state eligibility was disabled:
```text
assert 1 == 2
```

Command:
```text
.venv/bin/python -m pytest -q tests/test_review_isolation.py::test_review_temp_cleanup_removes_restrictive_view_after_simulated_review
```

Raw failing output after permission restoration was disabled:
```text
OSError: review temporary root survived cleanup: .../lu-review-view-simulated: [Errno 66] Directory not empty: .../context/restricted
```

Command:
```text
.venv/bin/python -m pytest -q tests/test_delegate.py::test_branch_reuse_refuses_diverged_local_ref
```

Raw failing output after the ancestry guard was removed:
```text
Failed: unexpected git command after divergence refusal: ['git', 'worktree', 'list', '--porcelain']
```

## NOT VERIFIED

- No production `$TMPDIR` sweep was run. All cleanup tests redirect TMPDIR to `tmp_path` fixtures.
- Live GitHub CI and cross-family formal review are pending. This PR is intentionally not merged.