### PR TITLE
fix(fleet-comms): APPROVED verdicts require sealed evidence; validate reviewer provenance

### DIFF
--- a/scripts/ai_agent_bridge/_review_verdict.py
+++ b/scripts/ai_agent_bridge/_review_verdict.py
@@ -31,6 +31,7 @@ from scripts.fleet_comms.review_publication import (
     ReviewPublicationError,
     build_review_comment,
     resolve_verdict_and_evidence,
+    validate_review_gate_input,
     verdict_from_review_evidence,
 )
 
@@ -122,14 +123,22 @@ def build_verdict_comment(
             f"review_evidence_verdict_mismatch: verdict={normalized_verdict} "
             f"evidence={evidence_verdict}"
         )
-    return build_review_comment(
-        verdict=normalized_verdict,
-        head_sha=_single_line(head_sha, label="head_sha"),
-        model=_single_line(model, label="model"),
-        family=_single_line(family, label="family"),
-        harness=_single_line(harness, label="harness"),
-        review_evidence=evidence,
-    )
+    try:
+        validate_review_gate_input(
+            verdict=normalized_verdict,
+            model=model,
+            review_evidence=evidence,
+        )
+        return build_review_comment(
+            verdict=normalized_verdict,
+            head_sha=_single_line(head_sha, label="head_sha"),
+            model=_single_line(model, label="model"),
+            family=_single_line(family, label="family"),
+            harness=_single_line(harness, label="harness"),
+            review_evidence=evidence,
+        )
+    except ReviewPublicationError as exc:
+        raise ReviewSafetyError(str(exc)) from exc
 
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]

--- a/scripts/fleet_comms/formal_review_finalize.py
+++ b/scripts/fleet_comms/formal_review_finalize.py
@@ -34,6 +34,7 @@ from scripts.fleet_comms.review_publication import (
     parse_sealed_verdict_payload,
     parse_verdict_token,
     resolve_verdict_and_evidence,
+    validate_review_gate_input,
 )
 from scripts.fleet_comms.review_publisher import (
     ReviewPublisherError,
@@ -211,6 +212,15 @@ def finalize_formal_review_verdict(
             f"review_evidence_verdict_mismatch: verdict={resolved_verdict} "
             f"evidence={findings_verdict}"
         )
+
+    try:
+        validate_review_gate_input(
+            verdict=resolved_verdict,
+            model=model,
+            review_evidence=review_evidence,
+        )
+    except ReviewPublicationError as exc:
+        raise FormalReviewFinalizeError(str(exc)) from exc
 
     sha = head_sha
     if sha is None:

--- a/scripts/fleet_comms/formal_review_jobs.py
+++ b/scripts/fleet_comms/formal_review_jobs.py
@@ -32,6 +32,7 @@ from scripts.fleet_comms.review_publication import (
     ReviewPublicationError,
     SealedVerdict,
     parse_sealed_verdict_payload,
+    validate_review_gate_input,
 )
 
 JOB_STATES = frozenset({"open", "running", "complete", "failed", "blocked"})
@@ -286,6 +287,11 @@ class FormalReviewJobService:
         try:
             if not isinstance(sealed, SealedVerdict):
                 sealed = parse_sealed_verdict_payload(sealed)
+            validate_review_gate_input(
+                verdict=sealed.verdict,
+                model=sealed.model,
+                review_evidence=sealed.review_evidence,
+            )
         except ReviewPublicationError as exc:
             raise FormalReviewJobsError(f"sealed_verdict_invalid: {exc}") from exc
 

--- a/scripts/fleet_comms/review_publication.py
+++ b/scripts/fleet_comms/review_publication.py
@@ -153,6 +153,54 @@ class SealedVerdict:
         }
 
 
+def _validate_reviewer_model(model: str) -> str:
+    """Require an exact catalog model id or declared alias for gate provenance."""
+    normalized = _require_nonempty_str(model, field="model")
+    try:
+        from scripts.review.model_catalog import ModelCatalogError, load_model_catalog
+
+        catalog = load_model_catalog()
+    except ModelCatalogError as exc:
+        raise ReviewPublicationError(f"reviewer_model_catalog_invalid: {exc}") from exc
+
+    models = catalog["models"]
+    known_models = set(models)
+    known_models.update(
+        alias
+        for entry in models.values()
+        for alias in entry.get("aliases", [])
+    )
+    if normalized not in known_models:
+        raise ReviewPublicationError(f"unknown_reviewer_model: {normalized!r}")
+    return normalized
+
+
+def validate_review_gate_input(
+    *,
+    verdict: str,
+    model: str,
+    review_evidence: ReviewEvidence | None,
+) -> str:
+    """Validate the evidence and provenance needed to grant a review gate.
+
+    A BLOCKED verdict is intentionally allowed without evidence: it is the
+    conservative fast path. Every APPROVED verdict, however it arrived, must
+    retain canonical evidence so a successful merge gate is auditable.
+    """
+    normalized_verdict = normalize_verdict(verdict)
+    _validate_reviewer_model(model)
+    if normalized_verdict == "APPROVED" and (
+        review_evidence is None
+        or not isinstance(review_evidence, ReviewEvidence)
+        or not review_evidence.explanation.strip()
+    ):
+        raise ReviewPublicationError(
+            "approved_review_evidence_required: "
+            "verdict=APPROVED review_evidence=missing"
+        )
+    return normalized_verdict
+
+
 @dataclass(frozen=True, slots=True)
 class HeadFreshness:
     """Result of comparing the sealed job head to the live PR head."""
@@ -619,6 +667,11 @@ def build_review_comment(
     review_id: str | None = None,
 ) -> str:
     """Render one auditable formal-review comment for a GitHub PR."""
+    verdict = validate_review_gate_input(
+        verdict=verdict,
+        model=model,
+        review_evidence=review_evidence,
+    )
     lines = [
         f"VERDICT: {verdict}",
         f"Head SHA: {head_sha}",
@@ -678,6 +731,12 @@ def plan_publication(
     """
     if not isinstance(sealed, SealedVerdict):
         raise ReviewPublicationError("sealed_verdict_invalid: expected SealedVerdict")
+
+    validate_review_gate_input(
+        verdict=sealed.verdict,
+        model=sealed.model,
+        review_evidence=sealed.review_evidence,
+    )
 
     context = _require_nonempty_str(status_context, field="status_context")
     key = publication_idempotency_key(
@@ -780,5 +839,6 @@ __all__ = [
     "plan_publication",
     "publication_idempotency_key",
     "resolve_verdict_and_evidence",
+    "validate_review_gate_input",
     "verdict_from_review_evidence",
 ]

--- a/scripts/fleet_comms/review_publisher.py
+++ b/scripts/fleet_comms/review_publisher.py
@@ -40,6 +40,7 @@ from scripts.fleet_comms.review_publication import (
     parse_sealed_verdict_payload,
     plan_publication,
     publication_idempotency_key,
+    validate_review_gate_input,
 )
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]
@@ -463,6 +464,14 @@ def publish_sealed_verdict(
         sealed = sealed.read_text(encoding="utf-8")
     if not isinstance(sealed, SealedVerdict):
         sealed = parse_sealed_verdict_payload(sealed)
+    try:
+        validate_review_gate_input(
+            verdict=sealed.verdict,
+            model=sealed.model,
+            review_evidence=sealed.review_evidence,
+        )
+    except ReviewPublicationError as exc:
+        raise ReviewPublisherError(str(exc)) from exc
 
     head = current_head_sha
     if head is None:

--- a/tests/ai_agent_bridge/test_review_verdict.py
+++ b/tests/ai_agent_bridge/test_review_verdict.py
@@ -10,6 +10,18 @@ from ai_agent_bridge import _review_verdict as publisher
 from ai_agent_bridge._review_safety import ReviewSafetyError
 
 
+def _approved_evidence() -> dict[str, object]:
+    return {
+        "schema_version": "code-review-findings.v1",
+        "overall": {
+            "correctness": "correct",
+            "explanation": "The review found no defects that block approval.",
+            "confidence": 0.95,
+        },
+        "findings": [],
+    }
+
+
 def test_publish_review_verdict_dry_run_is_thin_and_does_not_post() -> None:
     calls: list[list[str]] = []
 
@@ -23,6 +35,7 @@ def test_publish_review_verdict_dry_run_is_thin_and_does_not_post() -> None:
         model="gpt-5.6-terra",
         family="openai",
         harness="codex",
+        review_evidence=_approved_evidence(),
         dry_run=True,
         runner=fake_runner,
     )
@@ -31,6 +44,26 @@ def test_publish_review_verdict_dry_run_is_thin_and_does_not_post() -> None:
     assert "pr=5458" in summary
     assert "head_sha=deadbeef" in summary
     assert len(summary.encode("utf-8")) <= publisher.MAX_VERDICT_SUMMARY_BYTES
+
+
+def test_publish_review_verdict_refuses_evidence_free_approved() -> None:
+    calls: list[list[str]] = []
+
+    def fake_runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="deadbeef\n", stderr="")
+
+    with pytest.raises(ReviewSafetyError, match="approved_review_evidence_required"):
+        publisher.publish_review_verdict(
+            pr=5458,
+            verdict="APPROVED",
+            model="gpt-5.6-terra",
+            family="openai",
+            harness="codex",
+            dry_run=True,
+            runner=fake_runner,
+        )
+    assert calls == [["gh", "pr", "view", "5458", "--json", "headRefOid", "--jq", ".headRefOid"]]
 
 
 def test_publish_review_verdict_marks_legacy_verdict_without_evidence() -> None:

--- a/tests/test_fleet_comms_formal_finalize.py
+++ b/tests/test_fleet_comms_formal_finalize.py
@@ -17,6 +17,7 @@ from scripts.fleet_comms.formal_review_jobs import FormalReviewJobService
 
 _SHA = "a" * 40
 _REPO = "learn-ukrainian/learn-ukrainian.github.io"
+_MODEL = "glm-5.2"
 
 
 class FakeGh:
@@ -52,15 +53,47 @@ def test_resolve_verdict_token_sources(tmp_path: Path) -> None:
         resolve_verdict_token()
 
 
-def test_finalize_creates_job_and_accepts(tmp_path: Path) -> None:
+def test_finalize_refuses_explicit_approved_without_evidence(tmp_path: Path) -> None:
+    gh = FakeGh()
+    with pytest.raises(
+        FormalReviewFinalizeError, match="approved_review_evidence_required"
+    ):
+        finalize_formal_review_verdict(
+            pr_number=5571,
+            model=_MODEL,
+            family="zhipu",
+            harness="opencode",
+            verdict="APPROVED",
+            plane_root=tmp_path / "plane",
+            runner=gh,
+        )
+    assert gh.calls == []
+
+
+def test_finalize_accepts_approved_findings_and_seals_evidence(tmp_path: Path) -> None:
     root = tmp_path / "plane"
+    findings_path = tmp_path / "review-findings.json"
+    findings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "code-review-findings.v1",
+                "overall": {
+                    "correctness": "correct",
+                    "explanation": "The reviewed change has no blocking defects.",
+                    "confidence": 0.95,
+                },
+                "findings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
     gh = FakeGh()
     result = finalize_formal_review_verdict(
         pr_number=5571,
-        model="zai-coding-plan/glm-5.2",
+        model=_MODEL,
         family="zhipu",
         harness="opencode",
-        verdict="APPROVED",
+        findings_path=findings_path,
         plane_root=root,
         runner=gh,
     )
@@ -73,8 +106,10 @@ def test_finalize_creates_job_and_accepts(tmp_path: Path) -> None:
         job = svc.get_job(result.review_id)
         assert job.has_sealed_verdict
         sealed = svc.load_sealed_verdict(result.review_id)
-        assert sealed.model == "zai-coding-plan/glm-5.2"
+        assert sealed.model == _MODEL
         assert sealed.family == "zhipu"
+        assert sealed.review_evidence is not None
+        assert sealed.review_evidence.explanation == "The reviewed change has no blocking defects."
 
 
 def test_finalize_reuses_job_idempotent(tmp_path: Path) -> None:
@@ -82,19 +117,19 @@ def test_finalize_reuses_job_idempotent(tmp_path: Path) -> None:
     gh = FakeGh()
     first = finalize_formal_review_verdict(
         pr_number=100,
-        model="m",
-        family="f",
-        harness="h",
-        verdict="APPROVED",
+        model=_MODEL,
+        family="zhipu",
+        harness="opencode",
+        verdict="BLOCKED",
         plane_root=root,
         runner=gh,
     )
     second = finalize_formal_review_verdict(
         pr_number=100,
-        model="m",
-        family="f",
-        harness="h",
-        verdict="APPROVED",
+        model=_MODEL,
+        family="zhipu",
+        harness="opencode",
+        verdict="BLOCKED",
         plane_root=root,
         runner=gh,
     )
@@ -107,9 +142,9 @@ def test_finalize_publish_dry_run_and_live(tmp_path: Path) -> None:
     gh = FakeGh()
     dry = finalize_formal_review_verdict(
         pr_number=200,
-        model="m",
-        family="f",
-        harness="h",
+        model=_MODEL,
+        family="zhipu",
+        harness="opencode",
         verdict="CHANGES_REQUESTED",
         plane_root=root,
         runner=gh,
@@ -122,10 +157,10 @@ def test_finalize_publish_dry_run_and_live(tmp_path: Path) -> None:
     gh2 = FakeGh()
     live = finalize_formal_review_verdict(
         pr_number=201,
-        model="m",
-        family="f",
-        harness="h",
-        verdict="APPROVED",
+        model=_MODEL,
+        family="zhipu",
+        harness="opencode",
+        verdict="BLOCKED",
         plane_root=root,
         runner=gh2,
         publish=True,
@@ -174,9 +209,9 @@ def test_finalize_preserves_canonical_evidence_for_publication(tmp_path: Path) -
 
     result = finalize_formal_review_verdict(
         pr_number=202,
-        model="m",
-        family="f",
-        harness="h",
+        model=_MODEL,
+        family="zhipu",
+        harness="opencode",
         findings_path=findings_path,
         plane_root=root,
         runner=gh,
@@ -194,6 +229,35 @@ def test_finalize_preserves_canonical_evidence_for_publication(tmp_path: Path) -
     assert "The mutable cache is reused by the next request." in body
 
 
+@pytest.mark.parametrize("model", ["glm-5.2", "gemini-3.1-pro"])
+def test_finalize_accepts_catalog_model_and_alias(tmp_path: Path, model: str) -> None:
+    result = finalize_formal_review_verdict(
+        pr_number=302,
+        model=model,
+        family="zhipu",
+        harness="opencode",
+        verdict="BLOCKED",
+        plane_root=tmp_path / model,
+        head_sha=_SHA,
+    )
+    assert result.verdict == "BLOCKED"
+
+
+def test_finalize_refuses_unknown_reviewer_model(tmp_path: Path) -> None:
+    with pytest.raises(
+        FormalReviewFinalizeError, match=r"unknown_reviewer_model: 'gemini-1.5-pro'"
+    ):
+        finalize_formal_review_verdict(
+            pr_number=301,
+            model="gemini-1.5-pro",
+            family="google",
+            harness="agy",
+            verdict="BLOCKED",
+            plane_root=tmp_path / "plane",
+            head_sha=_SHA,
+        )
+
+
 def test_cli_formal_job_accept(tmp_path: Path) -> None:
     from scripts.fleet_comms.cli import main
 
@@ -206,13 +270,13 @@ def test_cli_formal_job_accept(tmp_path: Path) -> None:
             "--pr",
             "300",
             "--verdict",
-            "APPROVED",
+            "BLOCKED",
             "--model",
-            "m",
+            _MODEL,
             "--family",
-            "f",
+            "zhipu",
             "--harness",
-            "h",
+            "opencode",
             "--head-sha",
             _SHA,
             "--root",

--- a/tests/test_fleet_comms_formal_review_jobs.py
+++ b/tests/test_fleet_comms_formal_review_jobs.py
@@ -177,9 +177,18 @@ def _sealed_payload(review_id: str, **overrides: object) -> dict[str, object]:
         "head_sha": _SHA,
         "gate_kind": GATE,
         "verdict": "APPROVED",
-        "model": "claude-opus-4-6",
+        "model": "claude-opus-5",
         "family": "anthropic",
         "harness": "claude",
+        "review_evidence": {
+            "schema_version": "code-review-findings.v1",
+            "overall": {
+                "correctness": "correct",
+                "explanation": "The review found no defects that block approval.",
+                "confidence": 0.95,
+            },
+            "findings": [],
+        },
     }
     base.update(overrides)
     return base
@@ -211,6 +220,35 @@ def test_accept_sealed_verdict_rejects_identity_mismatch(tmp_path: Path) -> None
             )
 
 
+def test_accept_sealed_verdict_refuses_evidence_free_approved(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, _SHA, GATE)
+        with pytest.raises(
+            FormalReviewJobsError, match="approved_review_evidence_required"
+        ):
+            svc.accept_sealed_verdict(
+                job.review_id,
+                _sealed_payload(job.review_id, review_evidence=None),
+            )
+
+
+def test_accept_sealed_verdict_refuses_unknown_reviewer_model(tmp_path: Path) -> None:
+    with _service(tmp_path) as svc:
+        job = svc.create_job(REPO, 5512, _SHA, GATE)
+        with pytest.raises(
+            FormalReviewJobsError, match=r"unknown_reviewer_model: 'gemini-1.5-pro'"
+        ):
+            svc.accept_sealed_verdict(
+                job.review_id,
+                _sealed_payload(
+                    job.review_id,
+                    verdict="BLOCKED",
+                    model="gemini-1.5-pro",
+                    review_evidence=None,
+                ),
+            )
+
+
 def test_accept_sealed_verdict_refuses_overwrite(tmp_path: Path) -> None:
     with _service(tmp_path) as svc:
         job = svc.create_job(REPO, 5512, _SHA, GATE)
@@ -218,7 +256,11 @@ def test_accept_sealed_verdict_refuses_overwrite(tmp_path: Path) -> None:
         with pytest.raises(FormalReviewJobsError, match="sealed_verdict_already_set"):
             svc.accept_sealed_verdict(
                 job.review_id,
-                _sealed_payload(job.review_id, verdict="CHANGES_REQUESTED"),
+                _sealed_payload(
+                    job.review_id,
+                    verdict="CHANGES_REQUESTED",
+                    review_evidence=None,
+                ),
             )
 
 

--- a/tests/test_fleet_comms_review_publication.py
+++ b/tests/test_fleet_comms_review_publication.py
@@ -24,6 +24,7 @@ from scripts.fleet_comms.review_publication import (
     parse_verdict_token,
     plan_publication,
     publication_idempotency_key,
+    validate_review_gate_input,
 )
 
 _SHA_A = "a" * 40
@@ -38,12 +39,24 @@ def _sealed(**overrides: object) -> dict[str, object]:
         "head_sha": _SHA_A,
         "gate_kind": DEFAULT_GATE_KIND,
         "verdict": "APPROVED",
-        "model": "claude-opus-4-6",
+        "model": "claude-opus-5",
         "family": "anthropic",
         "harness": "claude",
     }
     base.update(overrides)
     return base
+
+
+def _approved_evidence() -> dict[str, object]:
+    return {
+        "schema_version": "code-review-findings.v1",
+        "overall": {
+            "correctness": "correct",
+            "explanation": "The review found no defects that block approval.",
+            "confidence": 0.95,
+        },
+        "findings": [],
+    }
 
 
 # ── verdict parsing ──────────────────────────────────────────────────────────
@@ -234,7 +247,7 @@ def test_build_verdict_comment_marks_missing_review_evidence() -> None:
     assert "VERDICT: BLOCKED" in body
     assert f"Head SHA: {_SHA_A}" in body
     assert "Review ID: review_deadbeef" in body
-    assert "model=claude-opus-4-6" in body
+    assert "model=claude-opus-5" in body
     assert "NO EVIDENCE SUPPLIED" in body
 
 
@@ -331,7 +344,9 @@ def test_build_verdict_comment_truncates_findings_last_with_record_pointer() -> 
 
 
 def test_plan_publication_dry_run_default_ready() -> None:
-    sealed = parse_sealed_verdict_payload(_sealed())
+    sealed = parse_sealed_verdict_payload(
+        _sealed(review_evidence=_approved_evidence())
+    )
     plan = plan_publication(sealed, current_head_sha=_SHA_A)
     assert plan.action == "publish"
     assert plan.mutate is False
@@ -359,7 +374,9 @@ def test_plan_publication_mutate_flag_only_marks_intent() -> None:
 
 
 def test_plan_publication_refuses_stale_head_without_posting() -> None:
-    sealed = parse_sealed_verdict_payload(_sealed())
+    sealed = parse_sealed_verdict_payload(
+        _sealed(review_evidence=_approved_evidence())
+    )
     plan = plan_publication(sealed, current_head_sha=_SHA_B, mutate=True)
     assert plan.action == "refuse_stale"
     assert plan.mutate is False  # never mutate on stale
@@ -369,7 +386,9 @@ def test_plan_publication_refuses_stale_head_without_posting() -> None:
 
 
 def test_plan_publication_idempotent_skip_on_repeat() -> None:
-    sealed = parse_sealed_verdict_payload(_sealed())
+    sealed = parse_sealed_verdict_payload(
+        _sealed(review_evidence=_approved_evidence())
+    )
     key = publication_idempotency_key(
         repository=sealed.repository,
         pr_number=sealed.pr_number,
@@ -395,8 +414,36 @@ def test_plan_publication_all_verdicts_for_fake_github_matrix() -> None:
         ("CHANGES_REQUESTED", STATUS_FAILURE),
         ("BLOCKED", STATUS_ERROR),
     ):
-        sealed = parse_sealed_verdict_payload(_sealed(verdict=verdict))
+        payload = _sealed(verdict=verdict)
+        if verdict == "APPROVED":
+            payload["review_evidence"] = _approved_evidence()
+        sealed = parse_sealed_verdict_payload(payload)
         plan = plan_publication(sealed, current_head_sha=_SHA_A)
         assert plan.action == "publish"
         assert plan.status_state == status
         assert plan.to_dict()["verdict"] == verdict
+
+
+def test_plan_publication_refuses_evidence_free_approved_verdict() -> None:
+    sealed = parse_sealed_verdict_payload(_sealed())
+    with pytest.raises(ReviewPublicationError, match="approved_review_evidence_required"):
+        plan_publication(sealed, current_head_sha=_SHA_A)
+
+
+def test_plan_publication_refuses_unknown_reviewer_model() -> None:
+    sealed = parse_sealed_verdict_payload(
+        _sealed(verdict="BLOCKED", model="gemini-1.5-pro")
+    )
+    with pytest.raises(
+        ReviewPublicationError, match=r"unknown_reviewer_model: 'gemini-1.5-pro'"
+    ):
+        plan_publication(sealed, current_head_sha=_SHA_A)
+
+
+def test_validation_refuses_unparsed_approved_evidence() -> None:
+    with pytest.raises(ReviewPublicationError, match="approved_review_evidence_required"):
+        validate_review_gate_input(
+            verdict="APPROVED",
+            model="claude-opus-5",
+            review_evidence={"explanation": "Not canonical evidence"},  # type: ignore[arg-type]
+        )

--- a/tests/test_fleet_comms_review_publisher.py
+++ b/tests/test_fleet_comms_review_publisher.py
@@ -38,12 +38,24 @@ def _sealed(**overrides: object) -> dict[str, object]:
         "head_sha": _SHA_A,
         "gate_kind": "cross-family-review",
         "verdict": "APPROVED",
-        "model": "claude-opus-4-6",
+        "model": "claude-opus-5",
         "family": "anthropic",
         "harness": "claude",
     }
     base.update(overrides)
     return base
+
+
+def _approved_evidence() -> dict[str, object]:
+    return {
+        "schema_version": "code-review-findings.v1",
+        "overall": {
+            "correctness": "correct",
+            "explanation": "The review found no defects that block approval.",
+            "confidence": 0.95,
+        },
+        "findings": [],
+    }
 
 
 class FakeGh:
@@ -87,9 +99,12 @@ def test_publish_matrix_posts_comment_and_status(
     tmp_path: Path, verdict: str, status: str
 ) -> None:
     gh = FakeGh(head=_SHA_A)
+    payload = _sealed(verdict=verdict)
+    if verdict == "APPROVED":
+        payload["review_evidence"] = _approved_evidence()
     with ArtifactStore(root=tmp_path / "plane") as store:
         result = publish_sealed_verdict(
-            _sealed(verdict=verdict),
+            payload,
             current_head_sha=_SHA_A,
             mutate=True,
             runner=gh,
@@ -109,7 +124,10 @@ def test_publish_matrix_posts_comment_and_status(
     assert len(comment_calls) == 1
     body = comment_calls[0][comment_calls[0].index("--body") + 1]
     assert f"VERDICT: {verdict}" in body
-    assert "NO EVIDENCE SUPPLIED" in body
+    if verdict == "APPROVED":
+        assert "The review found no defects that block approval." in body
+    else:
+        assert "NO EVIDENCE SUPPLIED" in body
     status_calls = [c for c in gh.calls if c[1] == "api"]
     assert any(f"state={status}" in " ".join(c) for c in status_calls)
     assert any(DEFAULT_STATUS_CONTEXT in " ".join(c) for c in status_calls)
@@ -119,7 +137,7 @@ def test_stale_head_refuses_without_github_mutation(tmp_path: Path) -> None:
     gh = FakeGh(head=_SHA_B)
     with ArtifactStore(root=tmp_path / "plane") as store:
         result = publish_sealed_verdict(
-            _sealed(),
+            _sealed(verdict="BLOCKED"),
             current_head_sha=_SHA_B,
             mutate=True,
             runner=gh,
@@ -145,7 +163,7 @@ def test_repeat_publish_is_idempotent(tmp_path: Path) -> None:
     root = tmp_path / "plane"
     with ArtifactStore(root=root) as store:
         first = publish_sealed_verdict(
-            _sealed(),
+            _sealed(verdict="BLOCKED"),
             current_head_sha=_SHA_A,
             mutate=True,
             runner=gh,
@@ -161,7 +179,7 @@ def test_repeat_publish_is_idempotent(tmp_path: Path) -> None:
     gh2 = FakeGh(head=_SHA_A)
     with ArtifactStore(root=root) as store:
         second = publish_sealed_verdict(
-            _sealed(),
+            _sealed(verdict="BLOCKED"),
             current_head_sha=_SHA_A,
             mutate=True,
             runner=gh2,
@@ -177,7 +195,7 @@ def test_dry_run_never_posts(tmp_path: Path) -> None:
     gh = FakeGh(head=_SHA_A)
     with ArtifactStore(root=tmp_path / "plane") as store:
         result = publish_sealed_verdict(
-            _sealed(),
+            _sealed(verdict="BLOCKED"),
             current_head_sha=_SHA_A,
             mutate=False,
             runner=gh,
@@ -190,7 +208,7 @@ def test_dry_run_never_posts(tmp_path: Path) -> None:
 
 
 def test_require_receipt_without_conn_refuses_live() -> None:
-    sealed = _sealed()
+    sealed = _sealed(verdict="BLOCKED")
     plan = plan_publication(
         __import__(
             "scripts.fleet_comms.review_publication", fromlist=["parse_sealed_verdict_payload"]
@@ -234,6 +252,24 @@ def test_sealed_payload_file_round_trip(tmp_path: Path) -> None:
     assert result.status_posted is True
 
 
+def test_publish_refuses_evidence_free_approved_without_github_mutation(
+    tmp_path: Path,
+) -> None:
+    gh = FakeGh(head=_SHA_A)
+    with ArtifactStore(root=tmp_path / "plane") as store:
+        with pytest.raises(
+            ReviewPublisherError, match="approved_review_evidence_required"
+        ):
+            publish_sealed_verdict(
+                _sealed(),
+                current_head_sha=_SHA_A,
+                mutate=True,
+                runner=gh,
+                store=store,
+            )
+    assert gh.calls == []
+
+
 def test_publish_from_review_id_via_accept_sealed(tmp_path: Path) -> None:
     """Sol milestone 2: publish without CLI-supplied provenance after accept."""
     from scripts.fleet_comms.formal_review_jobs import FormalReviewJobService
@@ -254,6 +290,7 @@ def test_publish_from_review_id_via_accept_sealed(tmp_path: Path) -> None:
                 "model": "gpt-5.6-terra",
                 "family": "openai",
                 "harness": "codex",
+                "review_evidence": _approved_evidence(),
             },
         )
         sealed = svc.load_sealed_verdict(job.review_id)

--- a/tests/test_fleet_comms_rollout_acceptance.py
+++ b/tests/test_fleet_comms_rollout_acceptance.py
@@ -61,6 +61,27 @@ def _request_for_legacy_message(plane_root: Path, message_id: int) -> tuple[str,
     return str(row[0]), str(row[1])
 
 
+@pytest.fixture
+def approved_findings_path(tmp_path: Path) -> Path:
+    """Persist canonical, evidence-backed findings for an approved review."""
+    path = tmp_path / "review-findings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "code-review-findings.v1",
+                "overall": {
+                    "correctness": "correct",
+                    "explanation": "The review found no defects that block approval.",
+                    "confidence": 0.95,
+                },
+                "findings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
 @pytest.mark.parametrize(
     ("recipient", "send"),
     [
@@ -142,7 +163,9 @@ def test_schema_v2_contains_rollout_contract_tables_and_columns(tmp_path: Path) 
     )
 
 
-def test_formal_review_verdict_is_sealed_as_an_immutable_json_artifact(tmp_path: Path) -> None:
+def test_formal_review_verdict_is_sealed_as_an_immutable_json_artifact(
+    tmp_path: Path, approved_findings_path: Path
+) -> None:
     """Formal verdict provenance is durably sealed before any live publication."""
     root = tmp_path / "batch_state" / "fleet-comms" / "v1"
     result = finalize_formal_review_verdict(
@@ -153,6 +176,7 @@ def test_formal_review_verdict_is_sealed_as_an_immutable_json_artifact(tmp_path:
         verdict="APPROVED",
         repository=_REPOSITORY,
         head_sha=_HEAD_SHA,
+        findings_path=approved_findings_path,
         plane_root=root,
     )
 
@@ -174,7 +198,15 @@ def test_formal_review_verdict_is_sealed_as_an_immutable_json_artifact(tmp_path:
         "model": "claude-sonnet-5",
         "pr_number": 5512,
         "repository": _REPOSITORY,
-        "review_evidence": None,
+        "review_evidence": {
+            "schema_version": "code-review-findings.v1",
+            "overall": {
+                "correctness": "correct",
+                "explanation": "The review found no defects that block approval.",
+                "confidence": 0.95,
+            },
+            "findings": [],
+        },
         "review_id": result.review_id,
         "verdict": "APPROVED",
     }


### PR DESCRIPTION
## Summary

- Refuse every terminal APPROVED accept/publish path unless canonical review evidence is sealed.
- Preserve evidence-free BLOCKED as the conservative fast path.
- Validate reviewer model IDs against the canonical catalog, including declared aliases.

## Raw evidence

```text
$ .venv/bin/python -m scripts.fleet_comms formal-job accept --pr 5824 --verdict APPROVED --model glm-5.2 --family zhipu --harness opencode --head-sha <40-hex-sha> --root <temp-dir>
approved_review_evidence_required: verdict=APPROVED review_evidence=missing
```

Mutation check, after intentionally dropping the shared evidence condition:

```text
FAILED tests/test_fleet_comms_formal_finalize.py::test_finalize_refuses_explicit_approved_without_evidence
E   Failed: DID NOT RAISE <class 'scripts.fleet_comms.formal_review_finalize.FormalReviewFinalizeError'>
```

## Verification

- `PYTHONPATH=scripts .venv/bin/python -m pytest -q tests/test_fleet_comms_formal_finalize.py tests/test_fleet_comms_formal_review_jobs.py tests/test_fleet_comms_review_publication.py tests/test_fleet_comms_review_publisher.py tests/ai_agent_bridge/test_review_verdict.py` — 88 passed.
- Ruff, `git diff --check`, OPSEC audit, and X-Agent trailer audit passed.

## Round 2 — approval-sealing sweep

- Updated `tests/test_fleet_comms_rollout_acceptance.py::test_formal_review_verdict_is_sealed_as_an_immutable_json_artifact` to seal canonical `code-review-findings.v1` evidence; its immutable-artifact assertions remain intact.
- Audited `tests/test_fleet_comms_formal_finalize.py`, `tests/test_fleet_comms_formal_review_jobs.py`, `tests/test_fleet_comms_review_publication.py`, and `tests/test_fleet_comms_review_publisher.py`: every successful APPROVED seal/publish path supplies canonical evidence; evidence-free cases intentionally assert rejection.

```text
$ test -d tests/fleet_comms && .venv/bin/python -m pytest -q tests/fleet_comms/
tests/fleet_comms/: absent in this sparse checkout

$ .venv/bin/python -m pytest -q tests/test_fleet_comms_rollout_acceptance.py tests/test_fleet_comms_formal_finalize.py tests/test_fleet_comms_formal_review_jobs.py tests/test_fleet_comms_review_publication.py tests/test_fleet_comms_review_publisher.py tests/ai_agent_bridge/test_review_verdict.py
============================== 95 passed in 1.20s ==============================
```

## Review status

NOT VERIFIED — the AGY sealed-review route refused because it cannot prove the required native formal-review isolation. A Gemini advisory review found one defense-in-depth issue, which this PR fixes and tests. Do not merge or enable auto-merge until an eligible independent cross-family formal review passes.
