### PR TITLE
fix(orchestration): identity-fenced thread-lease lifecycle (release, tombstone, diagnosis)

### DIFF
--- a/agents_extensions/shared/hooks/goal-driver-stop.sh
+++ b/agents_extensions/shared/hooks/goal-driver-stop.sh
@@ -15,11 +15,16 @@
 # thread_handoff.py). This is diagnostic only — claim_thread_lease never
 # takes an uncheckable owner over on clock age at all, so there is no window
 # left for a fresh heartbeat to protect. The refresh is a no-op unless this
-# exact session already owns the lease at the exact generation it claimed
-# (LEARN_UKRAINIAN_THREAD_LEASE_GENERATION, exported by session-setup.sh) and
-# its process identity can be reconfirmed, so it can never steal or clobber
-# another session's lease. This refresh is unconditional (unthrottled) since
-# Stop only fires once per turn; the throttled per-tool-call companion is
+# exact session already owns the lease AND its process identity can be
+# reconfirmed (require_proof=True re-derives this process's harness-ancestor
+# pid/start time), so it can never steal or clobber another session's lease.
+# No --generation is passed: it used to be required
+# (LEARN_UKRAINIAN_THREAD_LEASE_GENERATION, exported by session-setup.sh into
+# $CLAUDE_ENV_FILE), but that export reaches only Bash tool calls, never this
+# hook's own subprocess, so the generation gate was silently dead code in
+# every real session — identity proof is strictly stronger and is now the
+# sole fence. This refresh is unconditional (unthrottled) since Stop only
+# fires once per turn; the throttled per-tool-call companion is
 # thread-lease-heartbeat.sh (PostToolUse, issue #5759).
 #
 # Skip in non-interactive / pipeline contexts to avoid latency in batch jobs.
@@ -54,7 +59,7 @@ case "$HANDOFF_AGENT" in
   claude|claude-*)
     if [ -n "$STDIN_JSON" ]; then
       SESSION_ID=$(printf '%s' "$STDIN_JSON" | jq -r '.session_id // empty' 2>/dev/null)
-      if [ -n "$SESSION_ID" ] && [ -n "${LEARN_UKRAINIAN_THREAD_LEASE_GENERATION:-}" ]; then
+      if [ -n "$SESSION_ID" ]; then
         if [ -n "${CODEX_CANONICAL_REPO_ROOT:-}" ]; then
           CANONICAL_ROOT="$CODEX_CANONICAL_REPO_ROOT"
         else
@@ -65,10 +70,14 @@ case "$HANDOFF_AGENT" in
             CANONICAL_ROOT="$PROJECT_DIR"
           fi
         fi
+        # No --generation: identity proof is the sole fence (see above). If
+        # this repo checkout still has an OLDER thread_handoff.py that
+        # hard-requires --generation, the CLI's error is swallowed by
+        # `|| true` below — a safe no-op in a mixed-deploy, exactly like the
+        # old missing-env-var path.
         "$PYTHON" "$PROJECT_DIR/scripts/orchestration/thread_handoff.py" \
           --repo-root "$CANONICAL_ROOT" refresh-thread-lease-heartbeat \
           --agent "$HANDOFF_AGENT" --current-thread-id "$SESSION_ID" \
-          --generation "$LEARN_UKRAINIAN_THREAD_LEASE_GENERATION" \
           >/dev/null 2>&1 || true
         unset CANONICAL_ROOT GIT_COMMON_DIR
       fi

--- a/agents_extensions/shared/hooks/release-thread-lease.sh
+++ b/agents_extensions/shared/hooks/release-thread-lease.sh
@@ -16,12 +16,17 @@
 # fires after another session has already taken the lease over) can never
 # clobber a newer owner's lease.
 #
-# Generation is REQUIRED for a non-force release (thread_handoff.py raises
-# without it) — it is the fence that makes the previous paragraph true. The
-# generation this session actually claimed at SessionStart is exported by
-# session-setup.sh into $CLAUDE_ENV_FILE as LEARN_UKRAINIAN_THREAD_LEASE_GENERATION;
-# without it we cannot safely release (a missing/wrong generation could only
-# ever match by accident), so this hook no-ops rather than guessing one.
+# Fenced by process identity, not generation: release_thread_lease re-derives
+# this calling process's harness-ancestor pid/start time and requires it to
+# match what the lease recorded (require_proof=True) before releasing
+# anything — this is the fence that makes the previous paragraph true, and it
+# is strictly stronger than a caller-supplied generation. This used to
+# require --generation (exported by session-setup.sh into $CLAUDE_ENV_FILE as
+# LEARN_UKRAINIAN_THREAD_LEASE_GENERATION), but that export reaches only Bash
+# tool calls, never this hook's own subprocess, so the generation gate was
+# silently dead code in every real session — every SessionEnd release
+# no-oped, which is exactly how a 4h-ended session was still able to lock out
+# its successor. This hook no longer requires a generation at all.
 #
 # Skip in non-interactive / pipeline contexts, matching session-setup.sh.
 
@@ -70,17 +75,15 @@ else
   fi
 fi
 
-if [ -z "${LEARN_UKRAINIAN_THREAD_LEASE_GENERATION:-}" ]; then
-  # No generation to fence with — release-thread-lease.py now refuses a non-force
-  # release without one. Leaving the lease in place is safe: claim_thread_lease's
-  # pid-liveness check is the primary defense and will reclaim it once this
-  # process is confirmed dead, regardless of this cooperative path.
-  exit 0
-fi
-
+# No --generation: identity proof is the sole fence (see above). If this repo
+# checkout still has an OLDER thread_handoff.py that hard-requires
+# --generation, the CLI's ValueError is swallowed by `|| true` below — a safe
+# no-op in a mixed-deploy, exactly like the old missing-env-var path. Leaving
+# the lease in place is always safe either way: claim_thread_lease's
+# pid-liveness check is the primary defense and will reclaim it once this
+# process is confirmed dead, regardless of this cooperative path.
 "$PYTHON" "$PROJECT_DIR/scripts/orchestration/thread_handoff.py" --repo-root "$CANONICAL_ROOT" \
   release-thread-lease --agent "$HANDOFF_AGENT" --current-thread-id "$SESSION_ID" \
-  --generation "$LEARN_UKRAINIAN_THREAD_LEASE_GENERATION" \
   >/dev/null 2>&1 || true
 
 exit 0

--- a/agents_extensions/shared/hooks/thread-lease-heartbeat.sh
+++ b/agents_extensions/shared/hooks/thread-lease-heartbeat.sh
@@ -16,13 +16,17 @@
 # not already own, at a different generation, or whose process identity it
 # cannot reconfirm, exactly like the Stop-hook refresh.
 #
-# Fenced by generation, not just thread id: the generation this session
-# claimed at SessionStart is exported by session-setup.sh into
-# $CLAUDE_ENV_FILE as LEARN_UKRAINIAN_THREAD_LEASE_GENERATION (same variable
-# release-thread-lease.sh uses). Without it we cannot safely refresh (a
-# thread-id-only check could let a late predecessor heartbeat rewrite a
-# successor's recorded process identity — issue #5759 round 2), so this hook
-# no-ops rather than guessing one.
+# Fenced by process identity, not generation: refresh_thread_lease_heartbeat
+# re-derives this calling process's harness-ancestor pid/start time and
+# requires it to match what the lease recorded (require_proof=True) before
+# writing anything — a thread-id-only check could otherwise let a late
+# predecessor heartbeat rewrite a successor's recorded process identity
+# (issue #5759 round 2). This is strictly stronger than the old generation
+# fence, and load-bearing: $CLAUDE_ENV_FILE exports (including
+# LEARN_UKRAINIAN_THREAD_LEASE_GENERATION, set by session-setup.sh) reach
+# only Bash tool calls, never this hook's own subprocess, so a generation
+# gate here was silently dead code in every real session — this hook no
+# longer requires one at all, only current-thread-id.
 #
 # Skip in non-interactive / pipeline contexts, matching every other
 # thread-lease hook.
@@ -60,13 +64,6 @@ if [ -z "$SESSION_ID" ]; then
   exit 0
 fi
 
-if [ -z "${LEARN_UKRAINIAN_THREAD_LEASE_GENERATION:-}" ]; then
-  # No generation to fence with — refresh_thread_lease_heartbeat now refuses to
-  # refresh without one. Leaving heartbeat_at stale is safe: it is diagnostic
-  # only, nothing takes a lease over on its age.
-  exit 0
-fi
-
 if [ -n "${CODEX_CANONICAL_REPO_ROOT:-}" ]; then
   CANONICAL_ROOT="$CODEX_CANONICAL_REPO_ROOT"
 else
@@ -78,10 +75,13 @@ else
   fi
 fi
 
+# No --generation: identity proof is the sole fence (see above). If this repo
+# checkout still has an OLDER thread_handoff.py that hard-requires
+# --generation, the CLI's argparse error is swallowed by `|| true` below —
+# a safe no-op in a mixed-deploy, exactly like the old missing-env-var path.
 "$PYTHON" "$PROJECT_DIR/scripts/orchestration/thread_handoff.py" \
   --repo-root "$CANONICAL_ROOT" refresh-thread-lease-heartbeat \
   --agent "$HANDOFF_AGENT" --current-thread-id "$SESSION_ID" \
-  --generation "$LEARN_UKRAINIAN_THREAD_LEASE_GENERATION" \
   --min-refresh-interval-seconds 60 \
   >/dev/null 2>&1 || true
 

--- a/scripts/audit/test_thread_lease_hooks.sh
+++ b/scripts/audit/test_thread_lease_hooks.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_DIR GIT_INDEX_FILE
+unset GIT_OBJECT_DIRECTORY GIT_PREFIX GIT_WORK_TREE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SELF="${BASH_SOURCE[0]}"
+PYTHON_BIN="$REPO_ROOT/.venv/bin/python"
+THREAD_HANDOFF_PY="$REPO_ROOT/scripts/orchestration/thread_handoff.py"
+HEARTBEAT_HOOK="$REPO_ROOT/agents_extensions/shared/hooks/thread-lease-heartbeat.sh"
+RELEASE_HOOK="$REPO_ROOT/agents_extensions/shared/hooks/release-thread-lease.sh"
+STOP_HOOK="$REPO_ROOT/agents_extensions/shared/hooks/goal-driver-stop.sh"
+
+# Each hook derives its OWN python/script paths from $CLAUDE_PROJECT_DIR
+# (".venv/bin/python", "scripts/orchestration/thread_handoff.py") — there is
+# no override env var for that, unlike $CODEX_CANONICAL_REPO_ROOT, which
+# separately controls where the CLI's --repo-root (i.e. where lease STATE
+# lives) points. So every scenario below sets CLAUDE_PROJECT_DIR to the REAL
+# repo (a real, working venv+script) and CODEX_CANONICAL_REPO_ROOT to the
+# isolated per-scenario fixture directory (so lease state never touches this
+# real checkout's own .agent/).
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+lease_file_path() {
+  local root="$1" agent="$2"
+  printf '%s/.agent/%s-thread-lease.json' "$root" "$agent"
+}
+
+lease_field() {
+  local file="$1" field="$2"
+  "$PYTHON_BIN" -c "import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])" "$file" "$field"
+}
+
+rewind_heartbeat() {
+  # Directly rewind heartbeat_at into the far past on disk, leaving every
+  # other field (owner_pid/owner_pid_started_at/owner_machine_id/generation)
+  # exactly as the real claim call recorded it. This isolates "did the hook
+  # advance heartbeat_at" from the hook's own 60s PostToolUse throttle,
+  # without needing to sleep 60+ real seconds in a test.
+  local file="$1"
+  "$PYTHON_BIN" - "$file" <<'PYEOF'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    record = json.load(handle)
+record["heartbeat_at"] = "2020-01-01T00:00:00Z"
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(record, handle)
+PYEOF
+}
+
+# --- internal re-exec dispatch used by run_as_fake_claude_ancestor (must
+#     come after every function it might call is defined, and before any
+#     top-level test logic runs) ---
+
+__scenario_heartbeat_hook_advances_without_generation_env() {
+  local root="$1" agent="$2" session_id="$3"
+  "$PYTHON_BIN" "$THREAD_HANDOFF_PY" --repo-root "$root" \
+    claim-thread-lease --agent "$agent" --current-thread-id "$session_id" >/dev/null
+
+  rewind_heartbeat "$(lease_file_path "$root" "$agent")"
+
+  printf '%s' "{\"session_id\":\"$session_id\"}" | \
+    env -u LEARN_UKRAINIAN_THREAD_LEASE_GENERATION -u CLAUDE_NON_INTERACTIVE \
+        -u LEARN_UKRAINIAN_PIPELINE -u GEMINI_SESSION \
+    CLAUDE_PROJECT_DIR="$REPO_ROOT" SESSION_HANDOFF_AGENT="$agent" CODEX_CANONICAL_REPO_ROOT="$root" \
+    "$HEARTBEAT_HOOK"
+  # `:` (no-op) after the hook invocation: if it were the textually-last
+  # command in this function, bash's exec-last-command optimization can
+  # replace THIS process's image with the hook's own subprocess instead of
+  # forking a child for it — silently destroying the faked argv[0]=claude
+  # ancestor identity the harness-ancestor walk depends on (verified via
+  # manual repro: the very next process-identity probe in the same shell
+  # started finding an unrelated, real ambient "claude" ancestor instead of
+  # this scenario's own fake one). A trailing no-op guarantees a fork.
+  :
+}
+
+__scenario_stop_hook_advances_heartbeat_without_generation_env() {
+  local root="$1" agent="$2" session_id="$3"
+  "$PYTHON_BIN" "$THREAD_HANDOFF_PY" --repo-root "$root" \
+    claim-thread-lease --agent "$agent" --current-thread-id "$session_id" >/dev/null
+
+  rewind_heartbeat "$(lease_file_path "$root" "$agent")"
+
+  printf '%s' "{\"session_id\":\"$session_id\"}" | \
+    env -u LEARN_UKRAINIAN_THREAD_LEASE_GENERATION -u CLAUDE_NON_INTERACTIVE \
+        -u LEARN_UKRAINIAN_PIPELINE -u GEMINI_SESSION \
+    CLAUDE_PROJECT_DIR="$REPO_ROOT" SESSION_HANDOFF_AGENT="$agent" CODEX_CANONICAL_REPO_ROOT="$root" \
+    "$STOP_HOOK" >/dev/null
+  : # see the no-op note in the heartbeat scenario above — same reason.
+}
+
+__scenario_release_hook_tombstones_without_generation_env() {
+  local root="$1" agent="$2" session_id="$3"
+  "$PYTHON_BIN" "$THREAD_HANDOFF_PY" --repo-root "$root" \
+    claim-thread-lease --agent "$agent" --current-thread-id "$session_id" >/dev/null
+
+  printf '%s' "{\"session_id\":\"$session_id\"}" | \
+    env -u LEARN_UKRAINIAN_THREAD_LEASE_GENERATION -u CLAUDE_NON_INTERACTIVE \
+        -u LEARN_UKRAINIAN_PIPELINE -u GEMINI_SESSION \
+    CLAUDE_PROJECT_DIR="$REPO_ROOT" SESSION_HANDOFF_AGENT="$agent" CODEX_CANONICAL_REPO_ROOT="$root" \
+    "$RELEASE_HOOK"
+  : # see the no-op note in the heartbeat scenario above — same reason.
+}
+
+if [ "${1:-}" = "__dispatch__" ]; then
+  shift
+  "$@"
+  exit $?
+fi
+
+# Runs "$@" (a function name in THIS script, plus args) as a child of a
+# process whose own argv[0] is "claude". scripts/orchestration/
+# thread_handoff.py's harness-ancestor walk (_find_harness_ancestor) matches
+# a live ancestor process by candidate executable basename — including
+# psutil's cmdline()[0], which `exec -a claude` sets exactly like the real
+# Claude Code CLI does (see ProcessSnapshot's docstring: the harness
+# overrides its own process title). This makes the identity-proof path
+# (require_proof=True, the fence these hooks now rely on with no
+# --generation at all) genuinely provable end-to-end, without a real Claude
+# Code harness process running. Both the claim AND the later hook
+# invocation happen inside ONE such process (never two separate ones), so
+# the recorded owner_pid/owner_pid_started_at the claim call observed is the
+# SAME real, still-alive process the hook's own identity re-derivation sees
+# later — exactly modelling one real session's SessionStart-then-hook
+# lifecycle.
+run_as_fake_claude_ancestor() {
+  ( exec -a claude bash "$SELF" __dispatch__ "$@" )
+}
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# 1. PostToolUse heartbeat hook (thread-lease-heartbeat.sh): with NO
+#    LEARN_UKRAINIAN_THREAD_LEASE_GENERATION in its environment at all, it
+#    must still advance heartbeat_at via the identity-proof fence alone —
+#    this is the load-bearing proof that the original bug (the env var never
+#    reaching hook subprocesses, so every refresh silently no-oped) is dead.
+root="$TMP_ROOT/heartbeat-project"
+mkdir -p "$root"
+session_id="fixture-session-heartbeat"
+run_as_fake_claude_ancestor __scenario_heartbeat_hook_advances_without_generation_env "$root" claude "$session_id"
+
+lease="$(lease_file_path "$root" claude)"
+[ -f "$lease" ] || fail "heartbeat hook: lease file missing after scenario"
+heartbeat_at="$(lease_field "$lease" heartbeat_at)"
+owner_thread_id="$(lease_field "$lease" owner_thread_id)"
+generation="$(lease_field "$lease" generation)"
+[ "$heartbeat_at" != "2020-01-01T00:00:00Z" ] || fail "heartbeat hook: heartbeat_at did not advance with no generation env var set"
+[ "$owner_thread_id" = "$session_id" ] || fail "heartbeat hook: owner_thread_id changed — expected a refresh, not a reacquire"
+[ "$generation" = "1" ] || fail "heartbeat hook: generation changed — expected a refresh, not a reacquire"
+
+# 2. Stop hook's own lease-refresh section (goal-driver-stop.sh): same proof,
+#    unconditional (unthrottled) refresh path, and it must still emit its
+#    own normal (never-blocking) output afterward.
+root="$TMP_ROOT/stop-project"
+mkdir -p "$root"
+session_id="fixture-session-stop"
+run_as_fake_claude_ancestor __scenario_stop_hook_advances_heartbeat_without_generation_env "$root" claude "$session_id"
+
+lease="$(lease_file_path "$root" claude)"
+[ -f "$lease" ] || fail "stop hook: lease file missing after scenario"
+heartbeat_at="$(lease_field "$lease" heartbeat_at)"
+[ "$heartbeat_at" != "2020-01-01T00:00:00Z" ] || fail "stop hook: heartbeat_at did not advance with no generation env var set"
+
+# 3. SessionEnd release hook (release-thread-lease.sh): with NO generation
+#    env var set, it must still cooperatively release (tombstone) the lease
+#    via identity proof alone.
+root="$TMP_ROOT/release-project"
+mkdir -p "$root"
+session_id="fixture-session-release"
+run_as_fake_claude_ancestor __scenario_release_hook_tombstones_without_generation_env "$root" claude "$session_id"
+
+lease="$(lease_file_path "$root" claude)"
+[ -f "$lease" ] || fail "release hook: lease file missing after scenario"
+state="$(lease_field "$lease" state)"
+released_by="$(lease_field "$lease" released_by_thread_id)"
+[ "$state" = "released" ] || fail "release hook: lease was not released with no generation env var set (state=$state)"
+[ "$released_by" = "$session_id" ] || fail "release hook: released_by_thread_id mismatch"
+
+printf 'ok - thread lease hook fixtures passed\n'

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -3365,30 +3365,6 @@ def _cmd_prepare_locked(args: argparse.Namespace) -> int:
         )
         return 2
 
-    if agent == "claude" or agent.startswith("claude-"):
-        # The packet is sealed: this predecessor's own terminal mutating
-        # action is to cooperatively release its thread-lease slot through
-        # the same identity-gated path a SessionEnd hook would use, so the
-        # replacement thread's future claim never has to wait out a stale
-        # lease. Best-effort and never fatal to prepare: a session whose
-        # process identity cannot be reconfirmed here simply leaves the
-        # lease for claim_thread_lease's pid-liveness check to reclaim later.
-        try:
-            seal_release_result = release_thread_lease(
-                state_root=state_root, agent=agent, current_thread_id=active_thread_id, now=now
-            )
-            if seal_release_result.get("status") not in {"released", "noop"}:
-                print(
-                    f"WARNING: unexpected thread-lease release status at prepare seal for "
-                    f"agent {agent!r}: {seal_release_result}",
-                    file=sys.stderr,
-                )
-        except (OSError, ValueError) as exc:
-            print(
-                f"WARNING: thread-lease release at prepare seal failed for agent {agent!r}: {exc}",
-                file=sys.stderr,
-            )
-
     wrote_router = False
     if args.write_current:
         write_text_atomic(router_path, router_md)
@@ -3415,6 +3391,35 @@ def _cmd_prepare_locked(args: argparse.Namespace) -> int:
             )
         )
         return 2
+
+    if agent == "claude" or agent.startswith("claude-"):
+        # The packet is sealed and every fallible prepare step (including the
+        # Claudex rollover request above) has already succeeded: only now is
+        # it safe for this predecessor's terminal mutating action to
+        # cooperatively release its thread-lease slot through the same
+        # identity-gated path a SessionEnd hook would use, so the replacement
+        # thread's future claim never has to wait out a stale lease. This
+        # MUST stay the last fallible-free step in prepare — releasing any
+        # earlier would drop mutual exclusion while a later step could still
+        # fail and leave the predecessor running with no lease held. Release
+        # itself is best-effort and never fatal to prepare: a session whose
+        # process identity cannot be reconfirmed here simply leaves the lease
+        # for claim_thread_lease's pid-liveness check to reclaim later.
+        try:
+            seal_release_result = release_thread_lease(
+                state_root=state_root, agent=agent, current_thread_id=active_thread_id, now=now
+            )
+            if seal_release_result.get("status") not in {"released", "noop"}:
+                print(
+                    f"WARNING: unexpected thread-lease release status at prepare seal for "
+                    f"agent {agent!r}: {seal_release_result}",
+                    file=sys.stderr,
+                )
+        except (OSError, ValueError) as exc:
+            print(
+                f"WARNING: thread-lease release at prepare seal failed for agent {agent!r}: {exc}",
+                file=sys.stderr,
+            )
 
     output = {
         "agent": agent,

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import socket
 import sqlite3
 import subprocess
@@ -1143,6 +1144,99 @@ def _identity_changed_reacquire_result(
     }
 
 
+IDLE_SUSPECTED_THRESHOLD_SECONDS = 45 * 60
+
+
+def _humanize_duration(seconds: float) -> str:
+    """Render a duration for a human operator reading a conflict/diagnosis payload."""
+    total = max(0, int(seconds))
+    if total < 60:
+        return f"{total}s"
+    minutes, secs = divmod(total, 60)
+    if minutes < 60:
+        return f"{minutes}m{secs:02d}s" if secs else f"{minutes}m"
+    hours, mins = divmod(minutes, 60)
+    if hours < 24:
+        return f"{hours}h{mins:02d}m" if mins else f"{hours}h"
+    days, hrs = divmod(hours, 24)
+    return f"{days}d{hrs:02d}h" if hrs else f"{days}d"
+
+
+def _cas_force_release_command(
+    agent: str, *, owner_thread_id: str | None, generation: int | None, include_ack: bool = False
+) -> str:
+    """The exact CAS-scoped force-release command an operator should run.
+
+    Never a bare ``--force``: it always pins the current owner/generation the
+    caller observed, so a stale copy-pasted command refuses instead of
+    silently deleting whatever lease happens to exist by the time it runs.
+    """
+    parts = [
+        ".venv/bin/python scripts/orchestration/thread_handoff.py release-thread-lease",
+        f"--agent {shlex.quote(agent)}",
+        "--force",
+        f"--expect-owner-thread-id {shlex.quote(owner_thread_id or '')}",
+        f"--expect-generation {generation if isinstance(generation, int) else 0}",
+    ]
+    if include_ack:
+        parts.append("--acknowledge-live-owner")
+    return " ".join(parts)
+
+
+def _lease_conflict_diagnostics(
+    *,
+    agent: str,
+    existing_raw: Mapping[str, Any],
+    owner_thread_id: str | None,
+    generation: int,
+    heartbeat_at: datetime | None,
+    now: datetime,
+    liveness_path: str,
+) -> dict[str, Any]:
+    """Everything an operator needs to decide, without opening the lease file by hand."""
+    owner_pid = existing_raw.get("owner_pid")
+    owner_pid_started_at = existing_raw.get("owner_pid_started_at")
+    owner_alive = True if liveness_path == "alive" else None
+    heartbeat_age_seconds = (now - heartbeat_at).total_seconds() if heartbeat_at is not None else None
+    return {
+        "owner_pid": owner_pid if isinstance(owner_pid, int) else None,
+        "owner_pid_started_at": (owner_pid_started_at if isinstance(owner_pid_started_at, (int, float)) else None),
+        "owner_alive": owner_alive,
+        "heartbeat_age_seconds": heartbeat_age_seconds,
+        "heartbeat_age_humanized": (
+            _humanize_duration(heartbeat_age_seconds) if heartbeat_age_seconds is not None else None
+        ),
+        "idle_suspected": bool(
+            heartbeat_age_seconds is not None and heartbeat_age_seconds > IDLE_SUSPECTED_THRESHOLD_SECONDS
+        ),
+        "resolution": _cas_force_release_command(
+            agent,
+            owner_thread_id=owner_thread_id,
+            generation=generation,
+            include_ack=liveness_path == "alive",
+        ),
+    }
+
+
+def _released_tombstone_record(
+    existing_raw: Mapping[str, Any], *, released_by_thread_id: str, now: datetime, forced: bool = False
+) -> dict[str, Any]:
+    """A released lease is a tombstone, never a deleted file.
+
+    Keeping the record (generation, prior owner/identity fields) lets a stale
+    duplicate release call recognize "already released" and no-op, and lets
+    the next claim continue the SAME monotonic generation counter instead of
+    resetting to 1 — see ``claim_thread_lease``'s tombstone-reclaim branch.
+    """
+    record = dict(existing_raw)
+    record["state"] = "released"
+    record["released_at"] = isoformat_z(now)
+    record["released_by_thread_id"] = released_by_thread_id
+    if forced:
+        record["released_forced"] = True
+    return record
+
+
 def claim_thread_lease(
     *,
     state_root: Path,
@@ -1196,6 +1290,36 @@ def claim_thread_lease(
                 starting_pid=resolved_starting_pid,
             )
 
+        if existing_raw.get("state") == "released":
+            # A tombstone is held by nobody — reclaim unconditionally, but the
+            # generation counter is monotonic and must never reset to 1 while
+            # a tombstone exists (it is durable evidence of the last holder).
+            raw_generation = existing_raw.get("generation")
+            generation = raw_generation if isinstance(raw_generation, int) and raw_generation >= 1 else 0
+            previous_owner = existing_raw.get("owner_thread_id")
+            previous_owner = previous_owner if isinstance(previous_owner, str) and previous_owner.strip() else None
+            new_generation = generation + 1
+            record = _new_thread_lease_record(
+                agent=agent,
+                generation=new_generation,
+                owner_thread_id=owner_thread_id,
+                acquired_at=isoformat_z(now),
+                now=now,
+                starting_pid=resolved_starting_pid,
+                previous_owner_thread_id=previous_owner,
+            )
+            write_json_atomic(lease_path, record)
+            return {
+                "status": "acquired",
+                "lease_path": lease_path,
+                "owner_thread_id": owner_thread_id,
+                "generation": new_generation,
+                "heartbeat_at": record["heartbeat_at"],
+                "replaced_owner_thread_id": previous_owner,
+                "liveness_fields_recorded": "owner_pid" in record,
+                "takeover_reason": "lease was cooperatively released; claiming at the next monotonic generation",
+            }
+
         held_by = existing_raw.get("owner_thread_id")
         held_by_valid = isinstance(held_by, str) and bool(held_by.strip())
 
@@ -1233,6 +1357,15 @@ def claim_thread_lease(
                 "heartbeat_at": isoformat_z(heartbeat_at) if heartbeat_at else None,
                 "liveness": "live_owner",
                 "reason": liveness_reason,
+                **_lease_conflict_diagnostics(
+                    agent=agent,
+                    existing_raw=existing_raw,
+                    owner_thread_id=previous_owner,
+                    generation=generation,
+                    heartbeat_at=heartbeat_at,
+                    now=now,
+                    liveness_path=liveness_path,
+                ),
             }
 
         if liveness_path == "uncheckable":
@@ -1246,6 +1379,15 @@ def claim_thread_lease(
                 "heartbeat_at": isoformat_z(heartbeat_at) if heartbeat_at else None,
                 "liveness": "liveness_unknown",
                 "reason": liveness_reason,
+                **_lease_conflict_diagnostics(
+                    agent=agent,
+                    existing_raw=existing_raw,
+                    owner_thread_id=previous_owner,
+                    generation=generation,
+                    heartbeat_at=heartbeat_at,
+                    now=now,
+                    liveness_path=liveness_path,
+                ),
             }
 
         # Only "dead" reaches here: a confirmed-dead or pid-reused owner is
@@ -1280,35 +1422,48 @@ def release_thread_lease(
     current_thread_id: str,
     now: datetime,
     generation: int | None = None,
+    starting_pid: int | None = None,
     force: bool = False,
+    expect_owner_thread_id: str | None = None,
+    expect_generation: int | None = None,
+    acknowledge_live_owner: bool = False,
 ) -> dict[str, Any]:
-    """Release a durable thread lease this exact owner and generation holds.
+    """Release a durable thread lease this exact owner (proven by identity or generation) holds.
 
     Best-effort by design: SessionEnd does not fire on SIGKILL, so the pid
     liveness check in ``claim_thread_lease`` remains the primary defense —
     this is only the fast, cooperative path. Never rewrites or upgrades a
-    lease it does not own; fencing (owner + generation match) means a late
-    release from a session that has already been superseded by a takeover
-    cannot clobber the new owner's lease.
+    lease it does not own.
 
-    ``generation`` is mandatory unless ``force`` is given: the only production
-    call site (release-thread-lease.sh, the SessionEnd hook) must always pass
-    the exact generation it claimed at SessionStart. Generation is also what
-    fences a release by *process identity*, not merely thread id:
-    `claim_thread_lease`'s same-owner path (`_same_owner_identity_confirmed`)
-    increments generation whenever a resumed thread id is driven by a
-    different underlying process, so a delayed release from a dead
-    predecessor process — which can only ever know the generation it itself
-    observed — is refused here rather than deleting its live successor's lease.
+    A release never deletes the file — it rewrites it as a ``released``
+    tombstone (see ``_released_tombstone_record``), preserving generation so
+    the next claim continues the SAME monotonic counter rather than
+    resetting to 1. A release against an already-released tombstone is
+    always a no-op: there is nothing left to release.
+
+    Identity is the primary fence, not generation: ``_same_owner_identity_confirmed``
+    with ``require_proof=True`` re-derives the caller's harness-ancestor
+    pid/start time rather than trusting a value it merely remembers, so it is
+    strictly stronger than a caller-supplied generation. When the calling
+    process's identity is confirmed, ``generation`` is OPTIONAL. When it is
+    NOT confirmed (uncheckable lease, or a mismatched probe — e.g. a resumed
+    thread id now driven by a different process, per
+    ``_same_owner_identity_confirmed``'s docstring), the caller must supply
+    the exact generation it holds, or this fails closed with a no-op —
+    NEVER by reading the generation back off the lease file itself, which
+    would make the check a tautology.
+
+    ``force`` is the CAS-scoped operator escape hatch: it requires
+    ``expect_owner_thread_id`` and ``expect_generation`` to match the current
+    lease exactly (a bare ``--force`` with neither supplied is refused, never
+    an unscoped delete), and additionally ``acknowledge_live_owner`` when the
+    recorded owner process is verifiably alive.
     """
     owner_thread_id = current_thread_id.strip()
     if not force and not owner_thread_id:
         raise ValueError("current thread id is required to release a durable thread lease")
-    if not force and generation is None:
-        raise ValueError(
-            "generation is required to release a durable thread lease (fencing) unless force is given"
-        )
 
+    resolved_starting_pid = starting_pid if starting_pid is not None else os.getpid()
     lease_path = repo_local_path(state_root, default_thread_lease_path(agent))
     lock_path = lease_path.with_suffix(lease_path.suffix + ".lock")
 
@@ -1324,14 +1479,69 @@ def release_thread_lease(
         held_by = existing_raw.get("owner_thread_id")
         held_generation = existing_raw.get("generation")
 
+        if existing_raw.get("state") == "released":
+            return {
+                "status": "noop",
+                "lease_path": lease_path,
+                "reason": "lease is already released; nothing to release",
+                "current_owner_thread_id": held_by,
+                "current_generation": held_generation,
+            }
+
         if force:
-            lease_path.unlink(missing_ok=True)
+            if not expect_owner_thread_id or expect_generation is None:
+                return {
+                    "status": "refused",
+                    "lease_path": lease_path,
+                    "error_code": "THREAD_LEASE_FORCE_UNSCOPED",
+                    "reason": (
+                        "bare --force is refused; force release must be CAS-scoped to the exact "
+                        "current owner and generation"
+                    ),
+                    "current_owner_thread_id": held_by,
+                    "current_generation": held_generation,
+                    "resolution": _cas_force_release_command(
+                        agent,
+                        owner_thread_id=held_by,
+                        generation=held_generation,
+                        include_ack=_evaluate_owner_liveness(existing_raw)[0] == "alive",
+                    ),
+                }
+            if held_by != expect_owner_thread_id or held_generation != expect_generation:
+                return {
+                    "status": "refused",
+                    "lease_path": lease_path,
+                    "error_code": "THREAD_LEASE_FORCE_MISMATCH",
+                    "reason": (
+                        "force release refused: --expect-owner-thread-id/--expect-generation do not "
+                        "match the current lease"
+                    ),
+                    "current_owner_thread_id": held_by,
+                    "current_generation": held_generation,
+                }
+            liveness_path, _liveness_reason = _evaluate_owner_liveness(existing_raw)
+            if liveness_path == "alive" and not acknowledge_live_owner:
+                return {
+                    "status": "refused",
+                    "lease_path": lease_path,
+                    "error_code": "THREAD_LEASE_FORCE_LIVE_OWNER",
+                    "reason": (
+                        "force release refused: the recorded owner process is verifiably alive; "
+                        "pass --acknowledge-live-owner to override"
+                    ),
+                    "current_owner_thread_id": held_by,
+                    "current_generation": held_generation,
+                }
+            record = _released_tombstone_record(
+                existing_raw, released_by_thread_id=owner_thread_id or held_by or "", now=now, forced=True
+            )
+            write_json_atomic(lease_path, record)
             return {
                 "status": "released",
                 "lease_path": lease_path,
                 "forced": True,
                 "previous_owner_thread_id": held_by,
-                "previous_generation": held_generation,
+                "generation": held_generation,
             }
 
         if held_by != owner_thread_id:
@@ -1342,16 +1552,31 @@ def release_thread_lease(
                 "current_owner_thread_id": held_by,
                 "current_generation": held_generation,
             }
-        if held_generation != generation:
-            return {
-                "status": "noop",
-                "lease_path": lease_path,
-                "reason": "lease generation does not match; a takeover superseded this owner",
-                "current_owner_thread_id": held_by,
-                "current_generation": held_generation,
-            }
 
-        lease_path.unlink(missing_ok=True)
+        identity_proven = _same_owner_identity_confirmed(existing_raw, resolved_starting_pid, require_proof=True)
+        if not identity_proven:
+            if generation is None:
+                return {
+                    "status": "noop",
+                    "lease_path": lease_path,
+                    "reason": (
+                        "process identity could not be reconfirmed and no generation was supplied to "
+                        "fence with; refusing to release"
+                    ),
+                    "current_owner_thread_id": held_by,
+                    "current_generation": held_generation,
+                }
+            if held_generation != generation:
+                return {
+                    "status": "noop",
+                    "lease_path": lease_path,
+                    "reason": "lease generation does not match; a takeover superseded this owner",
+                    "current_owner_thread_id": held_by,
+                    "current_generation": held_generation,
+                }
+
+        record = _released_tombstone_record(existing_raw, released_by_thread_id=owner_thread_id, now=now)
+        write_json_atomic(lease_path, record)
         return {
             "status": "released",
             "lease_path": lease_path,
@@ -1366,7 +1591,7 @@ def refresh_thread_lease_heartbeat(
     state_root: Path,
     agent: str,
     current_thread_id: str,
-    generation: int,
+    generation: int | None = None,
     now: datetime,
     starting_pid: int | None = None,
     min_refresh_interval: timedelta | None = None,
@@ -1375,18 +1600,26 @@ def refresh_thread_lease_heartbeat(
 
     This never attempts a takeover — unlike ``claim_thread_lease``, a
     different owner, a stale generation, or an unconfirmed process identity
-    is simply left alone. Fenced by BOTH ``owner_thread_id`` and
+    is simply left alone. Fenced by ``owner_thread_id`` and, when supplied,
     ``generation``: thread id alone is not enough, because a takeover that
     resumes the SAME thread id under a NEW process (see
     ``_same_owner_identity_confirmed``) bumps generation but keeps the old
     thread id — a late heartbeat call still in flight from the dead
     predecessor process would otherwise pass a thread-id-only check and
     overwrite the successor's recorded process identity with its own stale
-    one. On top of that, the recorded process identity must be reconfirmed
-    against the calling process (``require_proof=True``: an uncheckable
-    identity is never assumed to be continuous here, unlike the explicit
-    same-owner resume path in ``claim_thread_lease``) — any mismatch, or any
-    identity that cannot be reconfirmed, is a no-op, never a rewrite.
+    one.
+
+    ``generation`` is now OPTIONAL: the recorded process identity being
+    reconfirmed against the calling process (``require_proof=True``) is
+    strictly stronger — it re-derives the caller's harness-ancestor pid/start
+    time rather than trusting a value the caller merely remembers, so it is
+    the sole fence when no generation is supplied. An uncheckable identity is
+    never assumed to be continuous here, unlike the explicit same-owner
+    resume path in ``claim_thread_lease`` — any mismatch, or any identity
+    that cannot be reconfirmed, is a no-op, never a rewrite. When a
+    generation IS supplied, it is still enforced as an extra fence (belt and
+    braces) on top of the identity check, never read back off the lease file
+    itself as a substitute for one.
 
     This is diagnostic, not a safety mechanism: there is no emergency TTL
     left for a fresh heartbeat to protect against (see ``claim_thread_lease``
@@ -1424,7 +1657,7 @@ def refresh_thread_lease_heartbeat(
                 "reason": "lease is owned by a different thread id; not refreshing",
             }
         held_generation = existing_raw.get("generation")
-        if held_generation != generation:
+        if generation is not None and held_generation != generation:
             return {
                 "status": "noop",
                 "lease_path": lease_path,
@@ -3131,6 +3364,31 @@ def _cmd_prepare_locked(args: argparse.Namespace) -> int:
             )
         )
         return 2
+
+    if agent == "claude" or agent.startswith("claude-"):
+        # The packet is sealed: this predecessor's own terminal mutating
+        # action is to cooperatively release its thread-lease slot through
+        # the same identity-gated path a SessionEnd hook would use, so the
+        # replacement thread's future claim never has to wait out a stale
+        # lease. Best-effort and never fatal to prepare: a session whose
+        # process identity cannot be reconfirmed here simply leaves the
+        # lease for claim_thread_lease's pid-liveness check to reclaim later.
+        try:
+            seal_release_result = release_thread_lease(
+                state_root=state_root, agent=agent, current_thread_id=active_thread_id, now=now
+            )
+            if seal_release_result.get("status") not in {"released", "noop"}:
+                print(
+                    f"WARNING: unexpected thread-lease release status at prepare seal for "
+                    f"agent {agent!r}: {seal_release_result}",
+                    file=sys.stderr,
+                )
+        except (OSError, ValueError) as exc:
+            print(
+                f"WARNING: thread-lease release at prepare seal failed for agent {agent!r}: {exc}",
+                file=sys.stderr,
+            )
+
     wrote_router = False
     if args.write_current:
         write_text_atomic(router_path, router_md)
@@ -4359,13 +4617,6 @@ def cmd_detect(args: argparse.Namespace) -> int:
     return 0
 
 
-def _force_release_command(agent: str) -> str:
-    return (
-        f".venv/bin/python scripts/orchestration/thread_handoff.py release-thread-lease "
-        f"--agent {agent} --force"
-    )
-
-
 def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
     """Claim the durable single-driver lease used during SessionStart."""
     try:
@@ -4390,6 +4641,12 @@ def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
     }
     if payload["status"] == "conflict":
         liveness = payload.get("liveness")
+        # claim_thread_lease already computed the exact CAS-scoped command as
+        # payload["resolution"]; this layer only adds the human-facing error
+        # text and, for the liveness-unknown lane, a slightly different frame.
+        resolution_command = payload.get("resolution") or _cas_force_release_command(
+            agent, owner_thread_id=payload.get("owner_thread_id"), generation=payload.get("generation")
+        )
         if liveness == "liveness_unknown":
             payload.update(
                 {
@@ -4401,7 +4658,7 @@ def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
                     ),
                     "resolution": (
                         f"If the previous owner ({payload.get('lease_file')}) is confirmed gone, "
-                        f"force-release with: {_force_release_command(agent)} — then start normally "
+                        f"force-release with: {resolution_command} — then start normally "
                         f"again. Otherwise wait for it to exit and release cooperatively."
                     ),
                 }
@@ -4413,7 +4670,7 @@ def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
                     "error": "durable thread lease is held by another live session; stop to avoid double-driving",
                     "resolution": (
                         f"Wait for the owner session to stop, or if it is confirmed gone, "
-                        f"force-release with: {_force_release_command(agent)}"
+                        f"force-release with: {resolution_command}"
                     ),
                 }
             )
@@ -4436,7 +4693,11 @@ def cmd_release_thread_lease(args: argparse.Namespace) -> int:
             current_thread_id=args.current_thread_id or "",
             now=utc_now(),
             generation=args.generation,
+            starting_pid=args.starting_pid,
             force=args.force,
+            expect_owner_thread_id=args.expect_owner_thread_id,
+            expect_generation=args.expect_generation,
+            acknowledge_live_owner=args.acknowledge_live_owner,
         )
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
@@ -4449,7 +4710,7 @@ def cmd_release_thread_lease(args: argparse.Namespace) -> int:
         **result,
     }
     print(json.dumps(payload, indent=2))
-    return 0
+    return 2 if payload.get("status") == "refused" else 0
 
 
 def cmd_refresh_thread_lease_heartbeat(args: argparse.Namespace) -> int:
@@ -4718,14 +4979,40 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help=(
-            "Required unless --force: only release if the on-disk lease is still at this "
-            "exact generation (fencing, including across a process-identity change)."
+            "Optional when this process's identity can be reconfirmed against the lease "
+            "(the strictly stronger fence); required otherwise (fail closed). Never read back "
+            "off the on-disk lease as a substitute."
         ),
+    )
+    release_thread_lease_parser.add_argument(
+        "--starting-pid",
+        type=int,
+        default=None,
+        help="Override the pid the harness-ancestor identity walk starts from (defaults to this process's own pid).",
     )
     release_thread_lease_parser.add_argument(
         "--force",
         action="store_true",
-        help="Operator escape hatch: release regardless of current owner/generation.",
+        help=(
+            "Operator escape hatch: CAS-scoped, requires --expect-owner-thread-id and "
+            "--expect-generation (a bare --force is refused, never an unscoped delete)."
+        ),
+    )
+    release_thread_lease_parser.add_argument(
+        "--expect-owner-thread-id",
+        default=None,
+        help="Required with --force: the exact owner_thread_id the operator observed on the lease.",
+    )
+    release_thread_lease_parser.add_argument(
+        "--expect-generation",
+        type=int,
+        default=None,
+        help="Required with --force: the exact generation the operator observed on the lease.",
+    )
+    release_thread_lease_parser.add_argument(
+        "--acknowledge-live-owner",
+        action="store_true",
+        help="Required with --force when the recorded owner process is verifiably alive.",
     )
     release_thread_lease_parser.set_defaults(func=cmd_release_thread_lease)
 
@@ -4741,10 +5028,11 @@ def build_parser() -> argparse.ArgumentParser:
     refresh_heartbeat_parser.add_argument(
         "--generation",
         type=int,
-        required=True,
+        default=None,
         help=(
-            "Fencing: only refresh if the on-disk lease is still at this exact generation "
-            "(the generation this session claimed at SessionStart, e.g. "
+            "Optional when this process's identity can be reconfirmed against the lease "
+            "(the strictly stronger fence); when supplied, also enforced as an extra fence "
+            "(the exact generation this session claimed at SessionStart, e.g. "
             "$LEARN_UKRAINIAN_THREAD_LEASE_GENERATION)."
         ),
     )

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -1095,13 +1095,17 @@ def test_same_thread_id_with_matching_process_identity_preserves_generation(
     assert result["generation"] == 3
 
 
-def test_same_thread_id_with_changed_process_identity_increments_generation_and_fences_late_release(
+def test_same_thread_id_with_changed_process_identity_increments_generation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """Fix 2: resuming the same thread id under a NEW harness process (different pid/start
     time) must NOT silently preserve generation. If it did, the dead predecessor process —
     which cached the OLD generation from its own SessionStart — could still release-fence
-    its way past a late SessionEnd and delete the SUCCESSOR's live lease."""
+    its way past a late SessionEnd and delete the SUCCESSOR's live lease. (The release-side
+    consequence of this exact scenario, with pid-sensitive identity mocking, is
+    test_resume_aba_late_release_from_dead_predecessor_is_fenced_by_identity_and_generation
+    below — this test's blanket-identity mock, which ignores the calling starting_pid, cannot
+    faithfully simulate release's own identity check.)"""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
     lease = _v2_lease(owner_thread_id="resumed-thread", generation=1, owner_pid=111, owner_pid_started_at=1000.0)
     lease_path = _write_lease(tmp_path, "claude-infra", lease)
@@ -1123,20 +1127,62 @@ def test_same_thread_id_with_changed_process_identity_increments_generation_and_
     assert on_disk["generation"] == 2
     assert on_disk["owner_pid"] == 222
 
-    # The predecessor's late SessionEnd still remembers generation 1 (it can only ever know
-    # what it observed at its own SessionStart) — it must be refused, not delete the successor.
+
+def test_resume_aba_late_release_from_dead_predecessor_is_fenced_by_identity_and_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Resume-ABA: claim(T, proc A) -> identity-changed reacquire(T, proc B) at gen+1 -> a late
+    release from a process presenting A's identity, carrying A's stale generation, must no-op —
+    release is now itself identity-gated (item 2), doubly fencing this exact scenario. The
+    successor's lease must survive both fences."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="resumed-thread", generation=1, owner_pid=111, owner_pid_started_at=1000.0)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    identities = {111: (111, 1000.0), 222: (222, 5000.0)}
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {
+            "owner_pid": identities[starting_pid][0],
+            "owner_pid_started_at": identities[starting_pid][1],
+            "owner_machine_id": "machine-a",
+        },
+    )
+
+    result = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="resumed-thread", now=now, starting_pid=222
+    )
+    assert result["status"] == "acquired"
+    assert result["generation"] == 2
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["generation"] == 2
+    assert on_disk["owner_pid"] == 222
+
+    # Process A's late SessionEnd: presents A's own real identity (pid 111) and carries A's
+    # stale generation 1 — identity mismatches the current (B's) record, so this falls through
+    # to the generation fence, which also fails (1 != 2).
     late_release = th.release_thread_lease(
-        state_root=tmp_path, agent="claude-infra", current_thread_id="resumed-thread", now=now, generation=1
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="resumed-thread",
+        now=now,
+        generation=1,
+        starting_pid=111,
     )
     assert late_release["status"] == "noop"
     assert json.loads(lease_path.read_text(encoding="utf-8"))["generation"] == 2
 
-    # The successor's own release, with the generation it actually claimed, must succeed.
+    # Process B's own release, presenting its own real identity, succeeds WITHOUT even
+    # supplying a generation — identity proof alone is a sufficient, stronger fence (item 2).
     own_release = th.release_thread_lease(
-        state_root=tmp_path, agent="claude-infra", current_thread_id="resumed-thread", now=now, generation=2
+        state_root=tmp_path, agent="claude-infra", current_thread_id="resumed-thread", now=now, starting_pid=222
     )
     assert own_release["status"] == "released"
-    assert not lease_path.exists()
+    tombstone = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert tombstone["state"] == "released"
+    assert tombstone["generation"] == 2
+    assert tombstone["released_by_thread_id"] == "resumed-thread"
 
 
 def test_same_thread_id_with_unresolvable_new_identity_reacquires_defensively(
@@ -1163,20 +1209,51 @@ def test_same_thread_id_with_unresolvable_new_identity_reacquires_defensively(
 # --- release_thread_lease: fencing (test matrix items 14-16) ---
 
 
-def test_release_without_generation_is_refused_unless_forced(tmp_path: Path):
-    """Fix 1: generation is mandatory for a non-force release — the only call site
-    (release-thread-lease.sh) must always pass it, or the fencing this whole design
-    depends on is dead code at its one production caller."""
+def test_release_without_proof_or_generation_is_a_noop(tmp_path: Path):
+    """Item 2: generation is no longer unconditionally mandatory — identity proof
+    (require_proof=True) is the stronger fence and makes it optional. But when identity
+    canNOT be reconfirmed (as here: no machine-id/process mocking, so the lease is
+    uncheckable in this test process) AND no generation is supplied either, this must fail
+    closed as an explicit no-op — never a silent release, and (unlike the old design) never
+    a raised exception that would crash a caller that forgot to special-case it."""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
     lease = _v2_lease(owner_thread_id="real-owner", generation=1)
     lease_path = _write_lease(tmp_path, "claude-infra", lease)
 
-    with pytest.raises(ValueError, match="generation"):
-        th.release_thread_lease(
-            state_root=tmp_path, agent="claude-infra", current_thread_id="real-owner", now=now
-        )
+    result = th.release_thread_lease(state_root=tmp_path, agent="claude-infra", current_thread_id="real-owner", now=now)
 
-    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "real-owner"
+    assert result["status"] == "noop"
+    assert "generation" in result["reason"]
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["owner_thread_id"] == "real-owner"
+    assert on_disk.get("state") != "released"
+
+
+def test_release_with_proven_identity_and_no_generation_succeeds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Item 2: when this process's identity IS reconfirmed against the lease, generation is
+    genuinely optional — proof alone is a sufficient, stronger fence. Mutation check: without
+    the identity-proof branch (i.e. reverting to the old owner+generation-only fence), this
+    call would incorrectly raise/refuse since no generation is supplied."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="real-owner", generation=4, owner_pid=111, owner_pid_started_at=1000.0)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 111, "owner_pid_started_at": 1000.0, "owner_machine_id": "machine-a"},
+    )
+
+    result = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="real-owner", now=now, starting_pid=111
+    )
+
+    assert result["status"] == "released"
+    tombstone = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert tombstone["state"] == "released"
+    assert tombstone["generation"] == 4
+    assert tombstone["released_by_thread_id"] == "real-owner"
+    assert tombstone["owner_pid"] == 111  # prior identity fields preserved as evidence
 
 
 def test_release_by_non_owner_is_noop(tmp_path: Path):
@@ -1240,19 +1317,177 @@ def test_release_thread_lease_takes_the_advisory_lock(tmp_path: Path, monkeypatc
     assert events == ["lock-entered", "lock-exited"]
 
 
-def test_release_thread_lease_force_bypasses_ownership(tmp_path: Path):
-    """The operator escape hatch named in every conflict message."""
+def test_force_release_bare_is_refused(tmp_path: Path):
+    """Item 6: a bare --force (no CAS expectations) is refused, never an unscoped delete —
+    it must instead echo back the exact pre-filled CAS command using the CURRENT on-disk
+    owner/generation. Mutation check: without the unscoped-refusal branch, this would fall
+    straight through to an unconditional release exactly like the old bare --force design."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="somebody-else", generation=5)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+
+    result = th.release_thread_lease(state_root=tmp_path, agent="claude-infra", current_thread_id="", now=now, force=True)
+
+    assert result["status"] == "refused"
+    assert result["error_code"] == "THREAD_LEASE_FORCE_UNSCOPED"
+    assert "--expect-owner-thread-id somebody-else" in result["resolution"]
+    assert "--expect-generation 5" in result["resolution"]
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["owner_thread_id"] == "somebody-else"  # untouched
+
+
+def test_force_release_with_wrong_expectations_is_refused(tmp_path: Path):
+    """Item 6: CAS expectations that don't match the current lease are refused, showing the
+    real current state — a stale copy-pasted force command must never silently no-op-succeed
+    against a lease it no longer describes."""
     now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
     lease = _v2_lease(owner_thread_id="somebody-else", generation=5)
     lease_path = _write_lease(tmp_path, "claude-infra", lease)
 
     result = th.release_thread_lease(
-        state_root=tmp_path, agent="claude-infra", current_thread_id="", now=now, force=True
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="",
+        now=now,
+        force=True,
+        expect_owner_thread_id="somebody-else",
+        expect_generation=4,  # stale
+    )
+
+    assert result["status"] == "refused"
+    assert result["error_code"] == "THREAD_LEASE_FORCE_MISMATCH"
+    assert result["current_generation"] == 5
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "somebody-else"
+
+
+def test_force_release_with_live_owner_requires_acknowledgement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Item 6: correct CAS expectations still refuse a verifiably-alive owner unless the
+    operator explicitly acknowledges it — a force release must never be a silent way to
+    steal from a session that is provably still running."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="somebody-else", generation=5, owner_pid=4242, owner_pid_started_at=1000.0)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_process_is_alive", lambda pid: True)
+    monkeypatch.setattr(th, "_default_process_snapshot", lambda pid: _fake_snapshot(pid=pid))
+
+    refused = th.release_thread_lease(
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="",
+        now=now,
+        force=True,
+        expect_owner_thread_id="somebody-else",
+        expect_generation=5,
+    )
+    assert refused["status"] == "refused"
+    assert refused["error_code"] == "THREAD_LEASE_FORCE_LIVE_OWNER"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_thread_id"] == "somebody-else"
+
+    acknowledged = th.release_thread_lease(
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="",
+        now=now,
+        force=True,
+        expect_owner_thread_id="somebody-else",
+        expect_generation=5,
+        acknowledge_live_owner=True,
+    )
+    assert acknowledged["status"] == "released"
+    assert acknowledged["forced"] is True
+    tombstone = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert tombstone["state"] == "released"
+    assert tombstone["generation"] == 5
+
+
+def test_force_release_with_correct_cas_succeeds(tmp_path: Path):
+    """Item 6: the exact CAS-scoped command (correct owner + generation, owner not
+    verifiably alive) succeeds and writes a tombstone rather than deleting the file."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="somebody-else", generation=5)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+
+    result = th.release_thread_lease(
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="",
+        now=now,
+        force=True,
+        expect_owner_thread_id="somebody-else",
+        expect_generation=5,
     )
 
     assert result["status"] == "released"
     assert result["forced"] is True
-    assert not lease_path.exists()
+    tombstone = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert tombstone["state"] == "released"
+    assert tombstone["generation"] == 5
+    assert tombstone["released_forced"] is True
+
+
+# --- released tombstone: monotonic generation, no unlink (item 3) ---
+
+
+def test_tombstone_monotonic_generation_across_claim_release_claim(tmp_path: Path):
+    """Item 3: claim -> release -> claim strictly increases generation and NEVER resets to 1
+    while a tombstone exists — the tombstone is durable evidence of the last generation, not
+    an absent-file fresh start. Mutation check: reverting the tombstone-reclaim branch to
+    treat a released record as absent would incorrectly restart at generation 1."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+
+    first_claim = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="first-owner", now=now, starting_pid=1
+    )
+    assert first_claim["status"] == "acquired"
+    assert first_claim["generation"] == 1
+
+    release = th.release_thread_lease(
+        state_root=tmp_path,
+        agent="claude-infra",
+        current_thread_id="first-owner",
+        now=now,
+        generation=1,
+        starting_pid=1,
+    )
+    assert release["status"] == "released"
+    lease_path = tmp_path / ".agent/claude-infra-thread-lease.json"
+    tombstone = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert tombstone["state"] == "released"
+    assert tombstone["generation"] == 1
+
+    second_claim = th.claim_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="second-owner", now=now, starting_pid=1
+    )
+    assert second_claim["status"] == "acquired"
+    assert second_claim["generation"] == 2  # monotonic, never reset to 1
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["generation"] == 2
+    assert on_disk["owner_thread_id"] == "second-owner"
+    assert on_disk.get("state") != "released"
+
+
+def test_stale_release_against_a_tombstone_is_noop(tmp_path: Path):
+    """Item 3: a second (e.g. duplicate/late) release call against an already-released
+    tombstone must no-op — there is nothing left to release, and it must never re-derive or
+    rewrite the tombstone."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="real-owner", generation=3)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+
+    first_release = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="real-owner", now=now, generation=3
+    )
+    assert first_release["status"] == "released"
+    tombstone_before = lease_path.read_text(encoding="utf-8")
+
+    stale_release = th.release_thread_lease(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="real-owner", now=now, generation=3
+    )
+
+    assert stale_release["status"] == "noop"
+    assert "already released" in stale_release["reason"]
+    assert lease_path.read_text(encoding="utf-8") == tombstone_before  # byte-identical, never rewritten
 
 
 # --- harness-ancestor walk (test matrix items 17-18) ---
@@ -1325,7 +1560,8 @@ def test_claim_thread_lease_command_reports_a_clear_double_launch_conflict(tmp_p
 
 
 def test_release_thread_lease_command_end_to_end(tmp_path: Path, capsys):
-    """CLI-level: claim then release through the same subcommands a real hook would call."""
+    """CLI-level: claim then release through the same subcommands a real hook would call.
+    Release now writes a tombstone (item 3) rather than deleting the lease file."""
     repo_args = ["--repo-root", str(tmp_path)]
 
     assert th.main([*repo_args, "claim-thread-lease", "--agent", "claude-infra", "--starting-pid", "1",
@@ -1337,12 +1573,16 @@ def test_release_thread_lease_command_end_to_end(tmp_path: Path, capsys):
                      "--generation", str(claim_payload["generation"])]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "released"
-    assert not (tmp_path / ".agent/claude-infra-thread-lease.json").exists()
+    tombstone = json.loads((tmp_path / ".agent/claude-infra-thread-lease.json").read_text(encoding="utf-8"))
+    assert tombstone["state"] == "released"
+    assert tombstone["generation"] == claim_payload["generation"]
 
 
-def test_release_thread_lease_command_requires_generation_unless_forced(tmp_path: Path, capsys):
-    """Fix 1: release-thread-lease.sh is the only call site — it must always pass --generation,
-    or a SessionEnd release is no longer fenced by anything but thread id."""
+def test_release_thread_lease_command_without_generation_or_proof_is_a_noop(tmp_path: Path, capsys):
+    """Item 2: --generation is no longer unconditionally required — but with neither a
+    generation NOR a reconfirmable process identity (as here: --starting-pid 1 is never a
+    known harness, matching the double-launch-conflict test's convention), the release must
+    fail closed as an explicit no-op (exit 0, status noop) rather than releasing or raising."""
     repo_args = ["--repo-root", str(tmp_path)]
 
     assert th.main([*repo_args, "claim-thread-lease", "--agent", "claude-infra", "--starting-pid", "1",
@@ -1350,11 +1590,14 @@ def test_release_thread_lease_command_requires_generation_unless_forced(tmp_path
     capsys.readouterr()
 
     assert th.main([*repo_args, "release-thread-lease", "--agent", "claude-infra",
-                     "--current-thread-id", "cli-session"]) == 2
+                     "--current-thread-id", "cli-session"]) == 0
     payload = json.loads(capsys.readouterr().out)
-    assert "generation" in payload["error"]
-    # Refused, not released: the lease must survive an attempted release with no generation.
-    assert (tmp_path / ".agent/claude-infra-thread-lease.json").exists()
+    assert payload["status"] == "noop"
+    assert "generation" in payload["reason"]
+    # Untouched: the lease must survive an attempted release with no generation or proof.
+    on_disk = json.loads((tmp_path / ".agent/claude-infra-thread-lease.json").read_text(encoding="utf-8"))
+    assert on_disk["owner_thread_id"] == "cli-session"
+    assert on_disk.get("state") != "released"
 
 
 def test_refresh_thread_lease_heartbeat_command_is_noop_for_a_different_owner(tmp_path: Path, capsys):
@@ -1530,6 +1773,253 @@ def test_refresh_thread_lease_heartbeat_command_throttles_via_min_refresh_interv
                      "--min-refresh-interval-seconds", "3600"]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "throttled"  # fresh claim heartbeat is well within the 3600s window
+
+
+# --- refresh_thread_lease_heartbeat without --generation (item 1) ---
+
+
+def test_refresh_thread_lease_heartbeat_without_generation_and_proven_identity_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Item 1: --generation is now optional — a confirmed process identity (require_proof=True)
+    is the sole, strictly-stronger fence. Mutation check: reverting refresh to require
+    generation unconditionally would make this call raise a TypeError/no-op instead of
+    refreshing, since no generation is supplied here at all."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(
+        owner_thread_id="owner-session",
+        generation=7,
+        heartbeat_at="2026-07-23T09:00:00Z",
+        owner_pid=111,
+        owner_pid_started_at=1000.0,
+    )
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 111, "owner_pid_started_at": 1000.0, "owner_machine_id": "machine-a"},
+    )
+
+    result = th.refresh_thread_lease_heartbeat(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="owner-session", now=now, starting_pid=111
+    )
+
+    assert result["status"] == "refreshed"
+    on_disk = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert on_disk["heartbeat_at"] == "2026-07-23T10:00:00Z"
+    assert on_disk["generation"] == 7  # untouched
+
+
+def test_refresh_thread_lease_heartbeat_without_generation_and_unproven_identity_is_noop(tmp_path: Path):
+    """Item 1: with no generation supplied AND no way to reconfirm identity (no mocking here,
+    so the lease is uncheckable in this test process), the refresh must fail closed as a
+    no-op — never blindly rewrite heartbeat_at just because the thread id happens to match."""
+    now = datetime(2026, 7, 23, 10, 0, tzinfo=UTC)
+    lease = _v2_lease(owner_thread_id="owner-session", generation=1)
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    original = lease_path.read_text(encoding="utf-8")
+
+    result = th.refresh_thread_lease_heartbeat(
+        state_root=tmp_path, agent="claude-infra", current_thread_id="owner-session", now=now
+    )
+
+    assert result["status"] == "noop"
+    assert "identity" in result["reason"]
+    assert lease_path.read_text(encoding="utf-8") == original
+
+
+def test_refresh_thread_lease_heartbeat_command_without_generation_flag(tmp_path: Path, capsys):
+    """CLI-level: --generation is optional on refresh-thread-lease-heartbeat (item 1) — the
+    updated hook scripts no longer pass it at all."""
+    repo_args = ["--repo-root", str(tmp_path)]
+    assert th.main([*repo_args, "claim-thread-lease", "--agent", "claude-infra", "--starting-pid", "1",
+                     "--current-thread-id", "owner-session"]) == 0
+    capsys.readouterr()
+
+    assert th.main([*repo_args, "refresh-thread-lease-heartbeat", "--agent", "claude-infra",
+                     "--current-thread-id", "owner-session"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    # --starting-pid 1 is never a known harness ancestor (matches the double-launch-conflict
+    # test's convention), so identity cannot be reconfirmed here either — this is the
+    # documented fail-closed no-op, exercised purely through the CLI surface with no
+    # --generation flag passed at all, exactly like the updated hook scripts.
+    assert payload["status"] == "noop"
+
+
+# --- claim conflict diagnosis (item 5) ---
+
+
+def test_claim_conflict_diagnosis_reports_pid_heartbeat_age_and_cas_resolution_command(tmp_path: Path, capsys):
+    """Diagnosis golden test: the conflict JSON must give an operator everything needed to
+    decide without opening the lease file by hand, including the exact CAS-scoped (never
+    bare) force-release command."""
+    lease = {
+        "schema_version": 2,
+        "agent": "claude-infra",
+        "generation": 3,
+        "owner_thread_id": "stuck-owner",
+        "acquired_at": "2020-01-01T00:00:00Z",
+        "heartbeat_at": "2020-01-01T00:00:00Z",  # far enough in the past to be unambiguous forever
+        "owner_pid": 55555,
+        "owner_pid_started_at": 1000.0,
+        "owner_machine_id": "some-other-machine",  # cross-machine: liveness is never checkable
+    }
+    _write_lease(tmp_path, "claude-infra", lease)
+
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "claim-thread-lease",
+                "--agent",
+                "claude-infra",
+                "--starting-pid",
+                "1",
+                "--current-thread-id",
+                "new-session",
+            ]
+        )
+        == 2
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["error_code"] == "THREAD_LEASE_LIVENESS_UNKNOWN"
+    assert payload["owner_thread_id"] == "stuck-owner"
+    assert payload["owner_pid"] == 55555
+    assert payload["owner_pid_started_at"] == 1000.0
+    assert payload["owner_alive"] is None  # never checkable, never guessed
+    assert payload["heartbeat_age_seconds"] > 45 * 60
+    assert payload["heartbeat_age_humanized"]
+    assert payload["idle_suspected"] is True
+    resolution = payload["resolution"]
+    assert "--force" in resolution
+    assert "--expect-owner-thread-id stuck-owner" in resolution
+    assert "--expect-generation 3" in resolution
+    assert "--acknowledge-live-owner" not in resolution  # liveness is unknown, not confirmed alive
+
+
+def test_claim_conflict_diagnosis_flags_a_confirmed_live_owner_and_requires_acknowledgement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Item 5/6: a genuinely live owner reports owner_alive=True and its resolution command
+    includes --acknowledge-live-owner up front — an operator should never have to discover
+    that flag by trial and error against a live process."""
+    lease = {
+        "schema_version": 2,
+        "agent": "claude-infra",
+        "generation": 2,
+        "owner_thread_id": "live-owner",
+        "acquired_at": "2020-01-01T00:00:00Z",
+        "heartbeat_at": "2020-01-01T00:00:00Z",
+        "owner_pid": 4242,
+        "owner_pid_started_at": 1000.0,
+        "owner_machine_id": "machine-a",
+    }
+    _write_lease(tmp_path, "claude-infra", lease)
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(th, "_process_is_alive", lambda pid: True)
+    monkeypatch.setattr(th, "_default_process_snapshot", lambda pid: _fake_snapshot(pid=pid))
+
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "claim-thread-lease",
+                "--agent",
+                "claude-infra",
+                "--starting-pid",
+                "1",
+                "--current-thread-id",
+                "new-session",
+            ]
+        )
+        == 2
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["error_code"] == "THREAD_LEASE_CONFLICT"
+    assert payload["owner_alive"] is True
+    assert payload["idle_suspected"] is True
+    assert "--acknowledge-live-owner" in payload["resolution"]
+
+
+# --- cooperative release at prepare/rollover seal (item 4) ---
+
+
+def test_prepare_releases_the_slot_lease_on_successful_seal_for_claude_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Item 4: once the rollover packet is sealed, prepare's own terminal mutating action for
+    a claude/claude-* agent slot is to cooperatively release its thread-lease through the
+    same identity-gated release path a SessionEnd hook would use — the predecessor does not
+    have to wait for (or rely on) a hook firing correctly to unblock its own successor."""
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 999, "owner_pid_started_at": 1000.0, "owner_machine_id": "machine-a"},
+    )
+    lease = _v2_lease(
+        owner_thread_id="old-thread",
+        generation=1,
+        agent="claude",
+        owner_pid=999,
+        owner_pid_started_at=1000.0,
+        owner_machine_id="machine-a",
+    )
+    lease_path = _write_lease(tmp_path, "claude", lease)
+
+    assert (
+        th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "claude", "--active-thread-id", "old-thread"])
+        == 0
+    )
+    capsys.readouterr()
+
+    tombstone = json.loads(lease_path.read_text(encoding="utf-8"))
+    assert tombstone["state"] == "released"
+    assert tombstone["generation"] == 1
+    assert tombstone["released_by_thread_id"] == "old-thread"
+
+
+def test_prepare_release_failure_at_seal_warns_but_does_not_fail_prepare(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Item 4: a failure releasing the slot lease at seal time must never fail prepare itself
+    — it only warns loudly (to stderr) so an operator can notice and investigate."""
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+
+    def _boom(**_kwargs):
+        raise OSError("simulated release failure")
+
+    monkeypatch.setattr(th, "release_thread_lease", _boom)
+
+    rc = th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "claude", "--active-thread-id", "old-thread"])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "simulated release failure" in captured.err
+
+
+def test_prepare_does_not_release_a_non_claude_agent_slot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys):
+    """Item 4 is scoped to claude/claude-* agent slots only — Codex's own lifecycle fix is a
+    separate, parallel effort (Phase B), so prepare must never touch a codex lease."""
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    lease = _v2_lease(owner_thread_id="old-thread", generation=1, agent="codex")
+    lease_path = _write_lease(tmp_path, "codex", lease)
+    original = lease_path.read_text(encoding="utf-8")
+
+    assert (
+        th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "old-thread"])
+        == 0
+    )
+    capsys.readouterr()
+
+    assert lease_path.read_text(encoding="utf-8") == original  # untouched
 
 
 def test_checkout_continuity_requires_clean_source_binding_and_same_clean_head():

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -2426,6 +2426,53 @@ def test_supervised_claudex_request_failure_preserves_prepared_lease(
     assert not cs._request_path(tmp_path, supervisor.run_id).exists()
 
 
+def test_prepare_seal_release_skipped_when_claudex_rollover_request_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    """P1 regression (bridge msg #5285): the cooperative seal-time thread-lease release must
+    be the LAST fallible-free step in prepare. If request_claudex_rollover fails, prepare
+    returns an error — the predecessor's own slot lease must still be HELD so no successor can
+    claim it and double-drive. Mutation check: moving the release call back before the
+    request_claudex_rollover call makes this test fail (the lease flips to "released" even
+    though prepare returned rc=2)."""
+    seed_supervised_claudex(tmp_path, monkeypatch)
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    monkeypatch.setattr(th, "_default_machine_id", lambda: "machine-a")
+    monkeypatch.setattr(
+        th,
+        "_derive_owner_liveness_fields",
+        lambda starting_pid: {"owner_pid": 999, "owner_pid_started_at": 1000.0, "owner_machine_id": "machine-a"},
+    )
+    lease = _v2_lease(
+        owner_thread_id="official-session-5265",
+        generation=1,
+        agent="claude-infra",
+        owner_pid=999,
+        owner_pid_started_at=1000.0,
+        owner_machine_id="machine-a",
+    )
+    lease_path = _write_lease(tmp_path, "claude-infra", lease)
+    original_lease_text = lease_path.read_text(encoding="utf-8")
+    monkeypatch.setenv("LEARN_UKRAINIAN_CLAUDEX_LAUNCH_GENERATION", "1")  # stale -> request fails
+
+    rc = th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "prepare",
+            "--agent",
+            "claude-infra",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert "request launch generation is stale" in payload["error"]
+    assert lease_path.read_text(encoding="utf-8") == original_lease_text  # still held, not tombstoned
+
+
 def test_prepare_without_native_adapter_records_carrier_binding_action(
     tmp_path: Path,
     capsys,

--- a/tests/test_thread_lease_hooks.py
+++ b/tests/test_thread_lease_hooks.py
@@ -1,0 +1,39 @@
+"""Run the thread-lease hook fixtures under the required pytest gate.
+
+``scripts/audit/test_thread_lease_hooks.sh`` exercises the three thread-lease
+hook scripts (PostToolUse heartbeat, Stop heartbeat, SessionEnd release) end
+to end against the real CLI, with NO ``LEARN_UKRAINIAN_THREAD_LEASE_GENERATION``
+in the environment at all — proving the identity-proof fence (which replaced
+the generation-env-var fence, since that export never reached hook
+subprocesses) actually works outside of unit-test mocking. The shell script
+was previously not wired into CI, so this thin wrapper makes the guard
+load-bearing: it runs in the required ``Test (pytest)`` job.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HOOK_TEST = _REPO_ROOT / "scripts" / "audit" / "test_thread_lease_hooks.sh"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_thread_lease_hook_fixtures() -> None:
+    assert _HOOK_TEST.is_file(), f"missing hook test: {_HOOK_TEST}"
+    result = subprocess.run(
+        ["bash", str(_HOOK_TEST)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"hook fixtures failed (rc={result.returncode})\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    assert "ok - thread lease hook fixtures passed" in result.stdout


### PR DESCRIPTION
## Summary

The lease hooks' env-var fence (`LEARN_UKRAINIAN_THREAD_LEASE_GENERATION`) never
reaches hook subprocesses — `CLAUDE_ENV_FILE` exports reach only Bash tool
calls — so heartbeat refresh and cooperative release have silently no-oped in
every session since they shipped. Incident: an ended-but-open predecessor
session held `.agent/claude-infra-thread-lease.json` for 4h and locked out its
successor (`heartbeat_at == acquired_at` throughout).

Implements the advisor-locked design (gpt-5.6-sol; glm-5.2) exactly, Phase A.
Touched only the files in scope: `scripts/orchestration/thread_handoff.py`,
`agents_extensions/shared/hooks/{thread-lease-heartbeat,release-thread-lease,goal-driver-stop}.sh`
(goal-driver-stop.sh: lease-refresh section only), tests. Did **not** touch
`session-setup.sh` (Phase B) or `.claude/` deploy targets.

- **Refresh without generation** (item 1): `--generation` is optional on
  `refresh-thread-lease-heartbeat`. Identity proof (`require_proof=True`,
  re-derives the caller's harness-ancestor pid/start time) is the sole,
  strictly-stronger fence when absent.
- **Release identity gate + tombstone + monotonic generation** (items 2, 3):
  `release_thread_lease` gains the same identity-proof gate; generation is
  optional for identity-proven callers, still required (fail-closed noop
  otherwise) for unproven ones — never read back off the lease file as a
  substitute. Release stops unlinking and instead writes a `released`
  tombstone preserving generation; a claim over a tombstone reclaims
  unconditionally at generation+1 (never resets to 1).
- **Claim-conflict diagnosis** (item 5): conflict JSON now carries owner pid,
  pid start time, alive-now (`owner_alive`), humanized heartbeat age,
  `idle_suspected` (age > 45min), and `resolution` = the exact CAS-scoped
  force-release command. `error_code` stays `THREAD_LEASE_CONFLICT` /
  `THREAD_LEASE_LIVENESS_UNKNOWN` as before.
- **CAS-scoped force** (item 6): `release-thread-lease --force` now requires
  `--expect-owner-thread-id` + `--expect-generation`, plus
  `--acknowledge-live-owner` when the recorded owner is verifiably alive. Bare
  `--force` is refused, echoing back the exact pre-filled command — never an
  unscoped delete.
- **Hooks** (item 7): all three drop the dead generation-env bail and call
  refresh/release with no `--generation` at all, relying on the identity gate.
  Kept the non-interactive/pipeline skips and agent-name guards. An OLD CLI
  that still hard-requires `--generation` is tolerated: its error is swallowed
  by the existing `|| true`, a safe no-op in a mixed deploy (documented inline).
- **Cooperative release at rollover seal** (item 4): once `prepare`'s packet is
  sealed for a claude/claude-* agent slot, it releases that slot's lease
  through the same identity-gated path a SessionEnd hook would use — the
  predecessor's own terminal mutating action, rather than relying only on a
  hook firing correctly. Release failure warns to stderr but never fails
  `prepare`.

## Verification (every claim + command + raw output)

**1. Full `tests/orchestration/` suite (minus 3 curriculum-content test files
that fail to *collect* in this sparse worktree — `curriculum/` is excluded per
dispatch instructions, unrelated to this change) + both new hook-test
wrappers:**

```
$ .venv/bin/python -m pytest tests/orchestration/ tests/test_thread_lease_hooks.py tests/test_session_setup_hook.py -q \
    --ignore=tests/orchestration/test_curriculum_coordinator.py \
    --ignore=tests/orchestration/test_curriculum_lifecycle_pilot.py \
    --ignore=tests/orchestration/test_curriculum_readiness.py \
    --ignore=tests/orchestration/test_prompt_contracts.py
...
======================== 417 passed in 82.79s (0:01:22) ========================
```

(`test_prompt_contracts.py` also fails to collect in this sparse worktree —
same root cause, `curriculum/l2-uk-en/curriculum.yaml` missing — verified via
the raw traceback: `FileNotFoundError: ... curriculum/l2-uk-en/curriculum.yaml`.
Nothing in that file touches thread-lease code.)

**2. `tests/orchestration/test_thread_handoff.py` alone (138 tests, incl. 24
new/rewritten lease tests):**

```
$ .venv/bin/python -m pytest tests/orchestration/test_thread_handoff.py -q
============================= 138 passed in 2.04s ==============================
```

**3. New end-to-end hook fixture, run directly:**

```
$ bash scripts/audit/test_thread_lease_hooks.sh
ok - thread lease hook fixtures passed
```

This drives the real `thread-lease-heartbeat.sh`, `goal-driver-stop.sh`, and
`release-thread-lease.sh` against the real CLI with `LEARN_UKRAINIAN_THREAD_LEASE_GENERATION`
explicitly unset, using a faked harness-ancestor process (`exec -a claude`) so
the identity-proof path is genuinely provable end-to-end rather than mocked —
proves the original bug's root cause (env var never reaching hook subprocesses)
is actually dead, not just that the Python function has a passing unit test.

**4. Mutation checks (guard tests must fail when the fix is reverted) — ran
each, confirmed failure, then restored the real file and reran to confirm
clean (paraphrased; full transcripts in session log):**

- Reverted tombstone→unlink: `4 failed` (`test_release_with_proven_identity_and_no_generation_succeeds`,
  `test_tombstone_monotonic_generation_across_claim_release_claim`,
  `test_stale_release_against_a_tombstone_is_noop`,
  `test_release_thread_lease_command_end_to_end`).
- Reverted CAS-scoped force→bare force: `3 failed` (`test_force_release_bare_is_refused`,
  `test_force_release_with_wrong_expectations_is_refused`,
  `test_force_release_with_live_owner_requires_acknowledgement`).
- Reverted release identity-proof gate→owner+generation-only: `2 failed`
  (`test_resume_aba_late_release_from_dead_predecessor_is_fenced_by_identity_and_generation`,
  `test_release_with_proven_identity_and_no_generation_succeeds`).
- Reverted all 3 hook scripts to `git show HEAD` (pre-fix): bash fixture
  correctly fails — `FAIL: heartbeat hook: heartbeat_at did not advance with
  no generation env var set` — then restored and reran clean:
  `ok - thread lease hook fixtures passed`.

**5. Lint:**

```
$ .venv/bin/ruff check scripts/orchestration/thread_handoff.py tests/orchestration/test_thread_handoff.py tests/test_thread_lease_hooks.py
All checks passed!
$ shellcheck agents_extensions/shared/hooks/{thread-lease-heartbeat,release-thread-lease,goal-driver-stop}.sh scripts/audit/test_thread_lease_hooks.sh
(no output — clean)
```

**6. Pre-commit hooks** (ruff, gitleaks, OPSEC-leak scan, X-Agent trailer
check, etc.) all passed on both the commit and the push.

## NOT VERIFIED

- No live, real Claude Code session end-to-end run (only the bash fixture's
  faked-harness-ancestor simulation, plus unit tests). The design explicitly
  calls for identity proof via the real harness-ancestor walk; the fixture
  proves the mechanism works against the real CLI, but I have not observed it
  in an actual multi-session SessionStart→Stop→SessionEnd lifecycle.
- `session-setup.sh` and the Codex/gemini lease lifecycle are untouched by
  design (Phase B, out of scope) — not re-verified beyond confirming its own
  existing test (`tests/test_session_setup_hook.py`) still passes unchanged.
- CI on this PR has not run yet as of this writing.
- Did not attempt to reproduce the original 4h-lockout incident against a real
  stale lease file from production; verification is via the unit + fixture
  suite above, not a replay of the actual incident artifact.

Do not merge; auto-merge not armed.