### PR TITLE
feat(fleet): Fable-5 judgment seat, Opus-5 de-advisored, summoned-cadence topology

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -43,12 +43,14 @@ Record the harness fallback explicitly; it is a transport fallback, not a model 
   * **GLM seat**: `glm-5.2` (local-only)
   * **Gemini seat**: `gemini-3.6-flash-high`
 * **Complex Non-Advisory Tasks & Deep Reviews**:
-  * **Anthropic Opus seat**: `claude-opus-5` (complex coding, deep reasoning, adversarial review)
+  * **Anthropic Opus seat**: `claude-opus-5` (complex coding, deep reasoning). NOT an
+    advisor seat — operator ruling 2026-07-26: weak in the advisor role and over-verbose
+    there; this REVERSES the 2026-07-24 "Opus replaces Fable as default Anthropic advisor"
+    ruling.
 * **Escalatory Advisor / Critical Authority Reviews** (reserved for architecture, security, or design escalation):
-  * **Top advisors @ `xhigh`**: `gpt-5.6-sol` · `claude-opus-5` · `claude-fable-5`.
-    Fable remains listed, but is too expensive: prefer `claude-opus-5` when the
-    Anthropic advisor is needed — it replaced Fable 5 as the default Anthropic
-    advisor on 2026-07-24; reserve Fable for a case Opus 5 has already failed.
+  * **Top advisors @ `xhigh`**: `claude-fable-5` · `gpt-5.6-sol` — the ONLY top-tier
+    advisor seats (operator 2026-07-26). Fable's cost is accepted for advisor turns:
+    they are rare, short, and decision-bearing; never spend them on queue grind.
   * **Other advisors**: `gemini-3.1-pro-high` · `gemini-3.6-flash-high` ·
     `kimi-k3-max` · `glm-5.2` · `grok-4.5` @ `high`.
   * `gpt-5.6-terra` is **not an advisor**; it remains the practical/routine
@@ -142,7 +144,7 @@ Machine-readable pins: `scripts/config/model_catalog.yaml` → `orchestrator_sea
 
   | Seat | Default (loop) | Escalate (deep) | Notes |
   | --- | --- | --- | --- |
-  | **claude** | `claude-opus-5` @ high | **`gpt-5.6-sol` @ xhigh** | Escalation is CROSS-FAMILY: Claude is a target, not an escalator. Other lanes escalate **to** Claude (`claude-opus-5` @ xhigh) or to Sol — pick by CodexBar headroom |
+  | **claude** | `claude-fable-5` @ high | **`gpt-5.6-sol` @ xhigh** | Escalation is CROSS-FAMILY: Claude is a target, not an escalator. Other lanes escalate **to** Claude (`claude-fable-5` @ xhigh) or to Sol — pick by CodexBar headroom. Fable drives in the SUMMONED cadence only (see § Orchestration operating pattern) |
   | **codex** | `gpt-5.6-terra` @ high | **`gpt-5.6-sol` @ xhigh** | Named alternate for harness / infra / devops; never co-owns a live lease |
   | **grok** | `grok-4.5` @ high | same SKU (no higher pin yet) | Cursor **explicit** `grok-4.5` = availability fallback, not quality escalate |
   | **agy** | `gemini-3.6-flash-high` @ high | **`gemini-3.1-pro-high` @ high** | Flash loop; Pro deep single-shot |
@@ -151,7 +153,7 @@ Machine-readable pins: `scripts/config/model_catalog.yaml` → `orchestrator_sea
   | seat | model_id | effort | escalate_model_id | escalate_effort |
   | --- | --- | --- | --- | --- |
   | agy | gemini-3.6-flash-high | high | gemini-3.1-pro-high | high |
-  | claude | claude-opus-5 | high | gpt-5.6-sol | xhigh |
+  | claude | claude-fable-5 | high | gpt-5.6-sol | xhigh |
   | codex | gpt-5.6-terra | high | gpt-5.6-sol | xhigh |
   | grok | grok-4.5 | high | grok-4.5 | high |
   <!-- fleet-roster-projection:end orchestrator_seats -->
@@ -159,6 +161,29 @@ Machine-readable pins: `scripts/config/model_catalog.yaml` → `orchestrator_sea
   **Escalate when:** deep single-shot, architecture, hard multi-file judgment, high-stakes synthesis —
   not for routine queue grind. Machine fields: `escalate_model_id` / `escalate_effort` /
   `escalate_when` on each seat in `model_catalog.yaml`.
+
+## Orchestration operating pattern (operator 2026-07-26 — binding)
+
+The knowledge-monopoly + quota-burn cycle (only the Anthropic frontier seat holds the whole
+system; letting it drive daily exhausts the weekly in ~2 days; cheaper drivers then degrade
+the system until it returns) is broken by ROLE SPLIT, not by a better single driver:
+
+- **Daily driver: `grok-4.5`** — owns the epic loops (dispatch, babysit, settle, reap,
+  re-fire) under the mechanical rails (evidence-mandatory reviews, lease lifecycle,
+  merge/stamp guards, delegate origin-sync). Operator-rated the best price/quality
+  orchestrator currently available.
+- **Summoned judgment: `claude-fable-5`** — NOT a resident driver. One or two SHORT
+  scheduled sessions per day: read the fleet's verdicts, correct course, lock designs,
+  write the next precise briefs, leave. Drive dispatch-heavy, never inline-heavy
+  (measured 2026-07-26: a dispatch-heavy Fable orchestration hour costs ~2 weekly-quota
+  points; inline-heavy driving is what burns the window in days). Also the escalation
+  target and top Anthropic advisor seat.
+- **Understudy trial: `glm-5.2`** — sanctioned as a BOUNDED driver trial on one epic under
+  the standard capsule/handoff contract (operator 2026-07-26; untested as driver, repeatedly
+  the sharpest cheap seat on code review). Evaluate against the same rails; report before
+  widening.
+- Session-cadence seats stay unchanged for kimi (capable, slow), agy (compaction loses
+  orchestration state — not a driver), gemini CLI (retired → agy).
 
   When an orchestrator needs **formal sealed CF**, request it via
   `review-pr --reviewer codex|claude|glm` (agy|kimi|grok remain `formal_review_eligible: false`

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -182,6 +182,11 @@ the system until it returns) is broken by ROLE SPLIT, not by a better single dri
   the standard capsule/handoff contract (operator 2026-07-26; untested as driver, repeatedly
   the sharpest cheap seat on code review). Evaluate against the same rails; report before
   widening.
+- **GPT lane never orchestrates as primary.** If it did, the seat would be Sol — and it is
+  not worth it: orientation alone consumes ~33% of the GPT context window before any work
+  (operator measurement 2026-07-26). Sol stays advisor/escalation-only; the codex seat
+  remains a named ALTERNATE (HydrationCapsuleV1 exists to cut exactly that orientation
+  cost), never the daily driver.
 - Session-cadence seats stay unchanged for kimi (capable, slow), agy (compaction loses
   orchestration state — not a driver), gemini CLI (retired → agy).
 

--- a/docs/runbooks/epic-orchestrator-roster.md
+++ b/docs/runbooks/epic-orchestrator-roster.md
@@ -27,7 +27,7 @@ and cold-starts the driver, which runs the `drive-epic` skill to orchestrate its
 | **folk** (curriculum track) | Grok 4.5 † | `./start-grok-drive.sh folk` |
 | **bio** (curriculum track) | Grok 4.5 | `./start-grok-drive.sh bio` |
 | **any epic** — incident · architecture cutover · contested review | Sonnet-5 | `./start-sonnet-drive.sh <epic>` |
-| **any epic** — hardest judgment only (see the reserved-seat cost below) | Opus | `./start-opus-drive.sh <epic>` |
+| **any epic** — hardest judgment only (SUMMONED cadence; see the reserved-seat cost below) | Fable 5 | `./start-opus-drive.sh <epic>` (wrapper now pins Fable) |
 
 **Per-model launcher convention:** `./start-<model>-drive.sh <epic>` where `<model>` ∈
 `codex · grok · gemini · sonnet · opus`. Epic is the first arg; extra flags forward
@@ -37,23 +37,28 @@ and by manual `$drive-epic` invocation until then. The Codex DevOps alternate is
 first zero-touch path: its generated board is injected into SessionStart and explicitly
 directs the task to load `$drive-epic`; the other wrappers do not yet auto-load the skill.
 
-**Sonnet-5 is the DEFAULT Anthropic driver seat** — near-Opus judgment without spending the
-Opus review-of-record capacity. `./start-opus-drive.sh <epic>` exists for the rare
-hardest-judgment session (live incident, architecture cutover, contested verdict) and prints
-a reserved-seat notice on launch so the cost is never spent by habit; it replaces the older
-"use raw `./start-claude.sh --epic <x>`" advice, which skipped that notice and left the model
-pin implicit. Both Anthropic wrappers resolve to the same `claude-<lane>` handoff slot, so the
-stream lease still allows only one Anthropic driver per lane. The legacy
-`scripts/start-bio-driver.sh` runs Claude + the `curriculum-track-orchestrator` agent-def if
-you specifically want that agent.
+**Sonnet-5 is the DEFAULT Anthropic driver seat** — strong judgment without spending the
+top-tier capacity. `./start-opus-drive.sh <epic>` now pins **Fable 5** (operator
+2026-07-26 — Opus 5 removed from the advisor/judgment role: weak there and over-verbose;
+the wrapper name is kept until the renames-last migration step) and exists for the rare
+hardest-judgment session (live incident, architecture cutover, contested verdict) in the
+SUMMONED cadence — 1-2 short scheduled sessions/day, dispatch-heavy, never a resident
+polling loop (see model-assignment.md § Orchestration operating pattern). It prints a
+reserved-seat notice on launch so the cost is never spent by habit. Both Anthropic wrappers
+resolve to the same `claude-<lane>` handoff slot, so the stream lease still allows only one
+Anthropic driver per lane. The legacy `scripts/start-bio-driver.sh` runs Claude + the
+`curriculum-track-orchestrator` agent-def if you specifically want that agent.
 
 † **folk carve-out:** the *driver* may be Grok, but folk content **review** stays
 cross-family **GPT ↔ Claude** (no DeepSeek, and Grok is never a judge seat) — the
 `drive-epic` skill enforces this.
 
 **Recommended against as a driver seat (least-bite — the live `model_catalog.orchestrator_seats` policy is authoritative):**
-- **Opus** (current Anthropic frontier) — hardest judgment + the cross-family review of record.
-  Don't burn it on a polling loop. `./start-opus-drive.sh` exists for the exceptions, not the default.
+- **Fable 5** (Anthropic top tier) — hardest judgment + the cross-family review of record +
+  top Anthropic advisor (with Sol). Don't burn it on a polling loop. `./start-opus-drive.sh`
+  (Fable-pinned) exists for the exceptions, not the default. **Opus 5 is neither an advisor
+  nor an orchestrator seat** (operator 2026-07-26) — it remains a complex-coding/deep-review
+  dispatch seat only.
 - **Kimi K2.7** 256K — under the ~500K window we want for a driver. **Codex (GPT-5.6)** was
   dropped on 2026-07-22 for its 272K window, then **re-added on 2026-07-23** as the named
   harness / infra / devops alternate: HydrationCapsuleV1's score-from-memory and small capsule
@@ -71,7 +76,7 @@ Exact tables below must match `scripts/config/model_catalog.yaml` → `orchestra
 | seat | model_id | effort | escalate_model_id | escalate_effort |
 | --- | --- | --- | --- | --- |
 | agy | gemini-3.6-flash-high | high | gemini-3.1-pro-high | high |
-| claude | claude-opus-5 | high | gpt-5.6-sol | xhigh |
+| claude | claude-fable-5 | high | gpt-5.6-sol | xhigh |
 | codex | gpt-5.6-terra | high | gpt-5.6-sol | xhigh |
 | grok | grok-4.5 | high | grok-4.5 | high |
 <!-- fleet-roster-projection:end orchestrator_seats -->

--- a/docs/runbooks/fleet-comms-open-gaps.md
+++ b/docs/runbooks/fleet-comms-open-gaps.md
@@ -79,7 +79,7 @@ lint: #5642 / `scripts/lint/lint_fleet_roster.py`.
 | seat | model_id | effort | escalate_model_id | escalate_effort |
 | --- | --- | --- | --- | --- |
 | agy | gemini-3.6-flash-high | high | gemini-3.1-pro-high | high |
-| claude | claude-opus-5 | high | gpt-5.6-sol | xhigh |
+| claude | claude-fable-5 | high | gpt-5.6-sol | xhigh |
 | codex | gpt-5.6-terra | high | gpt-5.6-sol | xhigh |
 | grok | grok-4.5 | high | grok-4.5 | high |
 <!-- fleet-roster-projection:end orchestrator_seats -->

--- a/scripts/config/fleet_communications.yaml
+++ b/scripts/config/fleet_communications.yaml
@@ -20,7 +20,8 @@ message_plane:
 # Authority Sol/Fable only on critical resolve-reviewer ladder.
 #
 # Orchestrator seats for this stream (model_catalog.orchestrator_seats):
-#   claude · codex(gpt-5.6-terra @ high) · grok · agy(gemini-3.6-flash-high @ high)
+#   claude(claude-fable-5 @ high, SUMMONED cadence — grok drives daily; operator 2026-07-26)
+#   · codex(gpt-5.6-terra @ high) · grok(daily driver) · agy(gemini-3.6-flash-high @ high)
 #   (codex was dropped as a driver on 2026-07-22, then re-added on 2026-07-23 because
 #    HydrationCapsuleV1 reduces rollover overhead; formal-CF eligibility is unchanged.)
 # Each may own cold-start / drive-board loops. Sealed formal CF requests still

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -526,19 +526,22 @@ review_candidates:
 # Same shape for every orchestrator seat — like AGY Flash → Pro.
 orchestrator_seats:
   claude:
-    model_id: claude-opus-5
+    model_id: claude-fable-5
     effort: high
     escalate_model_id: gpt-5.6-sol
     escalate_effort: xhigh
     escalate_when: deep_single_shot_or_architecture
     note: >-
-      Opus 5 @ high drives the lane; escalation is CROSS-FAMILY to Sol @ xhigh
-      (user 2026-07-24). Claude is an escalation TARGET, not an escalator — other
-      lanes escalate to Claude or Sol by whichever has CodexBar headroom. Fable is
-      NOT the default Anthropic advisor: it is the top capability tier but burns
-      subscription usage the fleet needs elsewhere; reserve it for a case Opus 5
-      has already failed. Driving is `high`, not `xhigh` — xhigh is the documented
-      START for agentic work, and the same docs say sweep down from it.
+      Fable 5 is the Anthropic orchestration/judgment seat (operator 2026-07-26;
+      REVERSES the 2026-07-24 Opus-as-default ruling — operator: Opus 5 is weak in
+      the advisor role and over-verbose). Fable runs in the SUMMONED cadence, not
+      as a resident daily driver: grok-4.5 owns the daily epic loops; Fable takes
+      1-2 short scheduled judgment sessions/day (verdict reads, course corrections,
+      design locks, briefs) driven dispatch-heavy, never inline-heavy — measured
+      2026-07-26 at ~2 weekly-quota points per orchestration hour in that style.
+      Escalation stays CROSS-FAMILY to Sol @ xhigh; Claude is an escalation TARGET,
+      not an escalator. Opus 5 remains a complex-coding/deep-reasoning seat only —
+      not an advisor, not an orchestrator. Driving is `high`, not `xhigh`.
   codex:
     model_id: gpt-5.6-terra
     effort: high

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -630,11 +630,9 @@ review_ladders:
   # Grok / K3 / GLM / DS-Pro / pool S 2.1) — not Sol/Fable on routine PRs.
   critical:
     - [openai_frontier]
-    # Opus 5 is the Anthropic authority rung (user 2026-07-24). Fable sits BELOW it:
-    # same tier, ~2x the token cost, and the fleet keeps running out of subscription
-    # headroom — so it is the fallback for a case Opus 5 has already failed, not the
-    # first Anthropic pick.
-    - [claude-opus-5]
+    # Fable 5 is the Anthropic authority rung (operator 2026-07-26 — Opus 5
+    # de-advisored: weak in the role, over-verbose; reverses 2026-07-24). Opus is
+    # NOT on the authority ladder at all; it remains a practical/coding seat.
     - [claude-fable-5]
     - [claude-fable-5-cursor-fallback]
     - [gpt-5.6-terra]

--- a/scripts/config/model_catalog.yaml
+++ b/scripts/config/model_catalog.yaml
@@ -93,7 +93,8 @@ models:
       Separate rate-limit bucket from the Opus 4.x pool.
     sources:
       - https://platform.claude.com/docs/en/about-claude/models/overview
-  # Retained alongside claude-opus-5: the advisor ROSTER now points at opus-5, but
+  # Retained alongside claude-opus-5 (which since 2026-07-26 is a coding seat, not an
+  # advisor — the advisor roster points at claude-fable-5 + gpt-5.6-sol), but
   # this id is still referenced by scripts/context_canary.py, scripts/pipeline/dispatch.py,
   # ai_agent_bridge/openai_proxy.py and _dispatch_wrappers.py. Removing the entry
   # broke collection with KeyError: 'claude-opus-4-8'.
@@ -590,9 +591,9 @@ formal_cf_defaults:
   claude:
     model_id: claude-sonnet-5
     effort: high
-    # Others escalate TO Claude: Opus 5 @ xhigh is the Anthropic advisor seat
-    # (replaced Fable 5 on 2026-07-24 — same authority role, half the burn).
-    escalate_model_id: claude-opus-5
+    # Others escalate TO Claude: Fable 5 @ xhigh is the Anthropic advisor/authority
+    # seat (operator 2026-07-26 — Opus 5 de-advisored; reverses the 2026-07-24 swap).
+    escalate_model_id: claude-fable-5
     escalate_effort: xhigh
   glm:
     model_id: glm-5.2

--- a/start-opus-drive.sh
+++ b/start-opus-drive.sh
@@ -8,14 +8,10 @@
 # the `drive-epic` skill — automatic once the cold-prompt wiring lands (follow-up PR);
 # invoke $drive-epic manually until then; the wrapper does NOT force it.
 #
-# MODEL PIN: we pass the CLI's `opus` ALIAS, not a versioned id. Two reasons:
-#   1. The Anthropic lane rotates (Opus 4.6 -> 4.8 -> 5). A pinned id silently points at a
-#      retired model — scripts/config/model_catalog.yaml still reads claude-opus-4-8 while
-#      the live seat is claude-opus-5. The alias always resolves to the current Opus.
-#   2. `opus` matches the `^(opus|sonnet|haiku)$` pattern in scripts/config/context_profiles.yaml,
-#      so the session resolves the TRUSTED native_claude profile (1M window) instead of
-#      falling back to the untrusted `fallback` profile with a 0-token denominator.
-# Pin a specific build with OPUS_DRIVER_MODEL when a rotation needs to be held back.
+# MODEL PIN: claude-fable-5 (operator 2026-07-26 — Fable is the Anthropic judgment seat;
+# Opus 5 is neither an advisor nor an orchestrator: weak in the role and over-verbose).
+# The wrapper NAME is kept until the renames-last migration step of the taxonomy work.
+# Override with OPUS_DRIVER_MODEL when a rotation needs to be held back or tested.
 #
 # HANDOFF SLOT: both Anthropic wrappers resolve to `claude-<lane>` (handoff_identity_for_epic),
 # so an Opus driver and a Sonnet driver on the SAME lane contend for one stream lease and the
@@ -47,6 +43,7 @@ fi
 # Reserved-seat notice (roster "least-bite" logic): Opus is the fleet's cross-family
 # review-of-record seat. Driving a lane with it spends that capacity, so say so out loud
 # rather than letting a habit-launch quietly consume it. Informational only — never blocks.
-echo "Note: Opus is the fleet's cross-family review-of-record seat (docs/runbooks/epic-orchestrator-roster.md)." >&2
-echo "      Driving with it spends that capacity — prefer ./start-sonnet-drive.sh unless this is a hardest-judgment session." >&2
-exec "$ROOT/start-claude.sh" --model "${OPUS_DRIVER_MODEL:-opus}" --epic "$SELECTOR" "$@"
+echo "Note: Fable 5 is the fleet's judgment/advisor seat (docs/runbooks/epic-orchestrator-roster.md)." >&2
+echo "      Summoned cadence only: short judgment sessions, dispatch-heavy. Prefer ./start-grok-drive.sh for daily loops," >&2
+echo "      ./start-sonnet-drive.sh for routine Anthropic driving." >&2
+exec "$ROOT/start-claude.sh" --model "${OPUS_DRIVER_MODEL:-claude-fable-5}" --epic "$SELECTOR" "$@"

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -338,3 +338,15 @@ def test_catalog_rejects_future_review_date():
     validated = validate_catalog(catalog)
     with pytest.raises(ModelCatalogError, match="future"):
         catalog_age_days(validated, as_of=date(2026, 7, 17))
+
+
+def test_critical_ladder_anthropic_authority_is_fable_not_opus():
+    """Operator 2026-07-26: Opus 5 is de-advisored. The critical (authority)
+    ladder must route Anthropic authority reviews to Fable and must not list
+    Opus at all — otherwise the resolver dispatches authority reviews to the
+    explicitly de-advisored model whenever the OpenAI rung is excluded."""
+    ladder = load_model_catalog()["review_ladders"]["critical"]
+    flat = [model for rung in ladder for model in rung]
+    assert "claude-fable-5" in flat
+    assert "claude-opus-5" not in flat
+    assert flat.index("claude-fable-5") < flat.index("claude-sonnet-5")

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -220,7 +220,7 @@ def test_orchestrator_seats_include_agy_flash_36_high():
     assert seats["agy"]["model_id"] == "gemini-3.6-flash-high"
     assert seats["agy"]["effort"] == "high"
     assert seats["agy"]["escalate_model_id"] == "gemini-3.1-pro-high"
-    assert seats["claude"]["model_id"] == "claude-opus-5"
+    assert seats["claude"]["model_id"] == "claude-fable-5"
     assert seats["grok"]["fallback_model_id"] == "grok-4.5"
 
 
@@ -235,7 +235,7 @@ def test_orchestrator_escalate_pins_parallel_sol_fable_pro():
     # formal-CF review seat whose authority escalate is still Sol.
     fc = load_model_catalog()["formal_cf_defaults"]
     assert fc["codex"]["escalate_model_id"] == "gpt-5.6-sol"
-    assert fc["claude"]["escalate_model_id"] == "claude-opus-5"
+    assert fc["claude"]["escalate_model_id"] == "claude-fable-5"
 
 
 def test_practical_ladders_exclude_authority_seats():

--- a/tests/test_review_reviewer_resolver.py
+++ b/tests/test_review_reviewer_resolver.py
@@ -101,9 +101,10 @@ def test_unsupported_risk_fails_closed():
 
 
 def test_critical_uses_authority_while_routine_uses_practical_defaults():
-    # OpenAI author: critical → Opus 5 (Sol advisory); high/medium/low → Sonnet 5.
+    # OpenAI author: critical → Fable 5 (Sol advisory); high/medium/low → Sonnet 5.
+    # Operator 2026-07-26: Opus 5 de-advisored; Fable is the Anthropic authority seat.
     critical = resolve_reviewer(ResolverInputs(author_model="codex", risk="critical"))
-    assert critical.selected.name == "claude-opus-5"
+    assert critical.selected.name == "claude-fable-5"
     for risk in ("high", "medium", "low"):
         resolution = resolve_reviewer(ResolverInputs(author_model="codex", risk=risk))
         assert resolution.selected.name == "claude-sonnet-5", risk
@@ -157,7 +158,7 @@ def test_fable_keeps_native_claude_when_native_health_is_degraded():
         )
     )
 
-    assert resolution.selected.name == "claude-opus-5"
+    assert resolution.selected.name == "claude-fable-5"
     assert resolution.selected.transport == "native_claude"
     assert resolution.selected.health == "degraded"
 
@@ -475,12 +476,10 @@ def test_every_risk_ladder_has_unique_candidates_and_a_cross_family_outcome():
 
 def test_critical_ladder_keeps_authority_before_practical():
     critical = REVIEW_LADDERS["critical"]
-    # Operator directive 2026-07-25: the Anthropic advisor seat is claude-opus-5.
-    # Fable stays listed but is deprioritised on cost; claude-opus-4-8 remains in the
-    # catalog for its non-advisor consumers but is no longer on the critical ladder.
-    assert [rung[0].name for rung in critical[:5]] == [
+    # Operator directive 2026-07-26: Fable 5 is the Anthropic authority seat;
+    # Opus 5 is de-advisored and absent from the critical ladder entirely.
+    assert [rung[0].name for rung in critical[:4]] == [
         "openai_frontier",
-        "claude-opus-5",
         "claude-fable-5",
         "claude-fable-5-cursor-fallback",
         "gpt-5.6-terra",


### PR DESCRIPTION
Operator-ordered fleet topology change (explicit go, 2026-07-26 evening).

## What changes
- **Top advisors: `claude-fable-5` @ xhigh + `gpt-5.6-sol` @ xhigh — only.** Opus 5 removed from advisor and orchestrator roles (operator: weak in the role, over-verbose). Reverses the 2026-07-24 Opus-as-default ruling. Opus 5 remains a complex-coding/deep-reasoning dispatch seat.
- **New `§ Orchestration operating pattern`** (model-assignment.md): grok-4.5 = daily epic driver; Fable = summoned cadence (1–2 short scheduled judgment sessions/day, dispatch-heavy — measured ~2 weekly-quota points/hour in that style); glm-5.2 sanctioned for one bounded driver trial.
- `orchestrator_seats.claude` → `claude-fable-5` (catalog + both lint-enforced projection mirrors).
- `start-opus-drive.sh` pins `claude-fable-5` (wrapper rename deferred to the taxonomy renames-last step). Trusted-profile resolution verified: `^claude-` matches `native_claude`.

## Verification (raw)
- `scripts/lint/lint_fleet_roster.py` → `Fleet roster OK (3 projection file(s); orchestrator_seats + formal_review_eligible exact match)`
- `tests/test_fleet_comms_launcher_awareness.py` → `5 passed`
- `bash -n start-opus-drive.sh` → OK

## NOT VERIFIED
- Live launch of `./start-opus-drive.sh` under the new pin (next Fable session will exercise it).
- Deploy delivery to `.claude/` happens post-merge via `npm run agents:deploy` (verified working earlier today after `git pull`; failure receipt = `.agent/last-deploy-status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)