### PR TITLE
fix(delegate): tmp reap must survive mid-walk errors

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -142,6 +142,7 @@ _RUNTIME_TMP_TERMINAL_STATUSES = frozenset(
     }
 )
 _RUNTIME_TMP_ORPHAN_MAX_AGE_S = 7 * 24 * 60 * 60
+_RUNTIME_TMP_SWEEP_ERROR_DETAILS_LIMIT = 10
 _FALLBACK_SUBS_PATH = _REPO_ROOT / "scripts" / "config" / "agent_fallback_substitutions.yaml"
 # Single source for dispatchable agents: argparse choices AND the hard-sub
 # validation in _resolve_agent_with_budget_guard (a yaml typo must never
@@ -552,26 +553,32 @@ def _runtime_tmp_lease_bytes(lease_root: Path) -> int:
     return total
 
 
-def _grant_owner_rwx_at(path: Path, *, dir_fd: int) -> None:
+def _grant_owner_rwx_at(path: Path, *, dir_fd: int) -> bool:
     """Give the owner access to a non-symlink path anchored at ``dir_fd``."""
     try:
         entry = os.stat(path, dir_fd=dir_fd, follow_symlinks=False)
     except FileNotFoundError:
-        return
+        return False
     if stat.S_ISLNK(entry.st_mode):
-        return
+        return False
+    mode = stat.S_IMODE(entry.st_mode)
+    repaired_mode = mode | stat.S_IRWXU
+    if repaired_mode == mode:
+        return False
     os.chmod(
         path,
-        stat.S_IMODE(entry.st_mode) | stat.S_IRWXU,
+        repaired_mode,
         dir_fd=dir_fd,
         follow_symlinks=False,
     )
+    return True
 
 
 def _runtime_tmp_reap_onexc(
     lease: Path,
     namespace: Path,
     namespace_fd: int,
+    repairs: set[Path],
 ):
     """Build an ``rmtree`` repair callback confined to one verified lease."""
 
@@ -584,8 +591,10 @@ def _runtime_tmp_reap_onexc(
             candidate.relative_to(lease.name)
         except ValueError:
             raise exc from None
-        _grant_owner_rwx_at(candidate, dir_fd=namespace_fd)
-        _grant_owner_rwx_at(candidate.parent, dir_fd=namespace_fd)
+        if _grant_owner_rwx_at(candidate, dir_fd=namespace_fd):
+            repairs.add(candidate)
+        if _grant_owner_rwx_at(candidate.parent, dir_fd=namespace_fd):
+            repairs.add(candidate.parent)
 
     return repair
 
@@ -600,15 +609,18 @@ def _remove_runtime_tmp_lease(lease: Path, namespace: Path) -> None:
     open_flags |= os.O_NOFOLLOW
     last_error: OSError | None = None
     # ``shutil.rmtree`` calls onexc but cannot resume an ``os.open`` that
-    # failed while descending into a mode-000 directory. The next complete
-    # pass is safe because the handler repaired only verified lease entries.
-    for _attempt in range(2):
+    # failed while descending into a mode-000 directory. Re-run the complete,
+    # fd-relative walk after every actual permission repair: a tree can have
+    # any number of nested restricted directories, so a fixed retry count
+    # abandons valid entries below the next barrier.
+    while os.path.lexists(lease):
+        repairs: set[Path] = set()
         namespace_fd = os.open(namespace, open_flags)
         try:
             shutil.rmtree(
                 lease.name,
                 dir_fd=namespace_fd,
-                onexc=_runtime_tmp_reap_onexc(lease, namespace, namespace_fd),
+                onexc=_runtime_tmp_reap_onexc(lease, namespace, namespace_fd, repairs),
             )
         except FileNotFoundError:
             return
@@ -618,8 +630,16 @@ def _remove_runtime_tmp_lease(lease: Path, namespace: Path) -> None:
             os.close(namespace_fd)
         if not os.path.lexists(lease):
             return
-    detail = f": {last_error}" if last_error is not None else ""
-    raise OSError(f"runtime tmp lease survived hardened cleanup: {lease}{detail}")
+        if not repairs:
+            break
+    if last_error is not None:
+        raise OSError(
+            last_error.errno,
+            f"runtime tmp lease survived hardened cleanup: {lease}: "
+            f"{last_error.strerror or last_error}",
+            last_error.filename or str(lease),
+        )
+    raise OSError(f"runtime tmp lease survived hardened cleanup: {lease}")
 
 
 def _runtime_tmp_state_for_lease(lease_name: str) -> dict[str, Any] | None:
@@ -652,22 +672,29 @@ def _runtime_tmp_state_has_live_pid(state: dict[str, Any]) -> bool:
 def _sweep_runtime_tmp_orphans(
     *,
     now: float | None = None,
-) -> dict[str, int]:
+) -> dict[str, Any]:
     """Reap terminal or clearly abandoned task leases before a new dispatch.
 
     A state-backed lease is removed only once its task is terminal and no
     recorded process is alive. A state-less lease must be older than seven
     days. Symlinks and malformed entries are skipped rather than followed.
     """
-    result = {"leases_reaped": 0, "bytes_freed": 0, "errors": 0}
+    error_details: list[tuple[str, int | None, str]] = []
+    result: dict[str, Any] = {
+        "leases_reaped": 0,
+        "bytes_freed": 0,
+        "errors": 0,
+        "error_details": error_details,
+    }
     tmp_root = Path(tempfile.gettempdir())
     namespace = tmp_root / "learn-ukrainian"
     try:
         namespace_stat = namespace.lstat()
     except FileNotFoundError:
         return result
-    except OSError:
+    except OSError as exc:
         result["errors"] += 1
+        error_details.append((namespace.name, exc.errno, str(exc.filename or namespace)))
         return result
     if stat.S_ISLNK(namespace_stat.st_mode) or not stat.S_ISDIR(namespace_stat.st_mode):
         result["errors"] += 1
@@ -676,16 +703,19 @@ def _sweep_runtime_tmp_orphans(
     cutoff = (time.time() if now is None else now) - _RUNTIME_TMP_ORPHAN_MAX_AGE_S
     try:
         candidates = tuple(namespace.iterdir())
-    except OSError:
+    except OSError as exc:
         result["errors"] += 1
+        error_details.append((namespace.name, exc.errno, str(exc.filename or namespace)))
         return result
     for lease in candidates:
         try:
             lease_stat = lease.lstat()
         except FileNotFoundError:
             continue
-        except OSError:
+        except OSError as exc:
             result["errors"] += 1
+            if len(error_details) < _RUNTIME_TMP_SWEEP_ERROR_DETAILS_LIMIT:
+                error_details.append((lease.name, exc.errno, str(exc.filename or lease)))
             continue
         if stat.S_ISLNK(lease_stat.st_mode) or not stat.S_ISDIR(lease_stat.st_mode):
             continue
@@ -701,8 +731,10 @@ def _sweep_runtime_tmp_orphans(
         try:
             bytes_freed = _runtime_tmp_lease_bytes(lease)
             _remove_runtime_tmp_lease(lease, namespace)
-        except OSError:
+        except OSError as exc:
             result["errors"] += 1
+            if len(error_details) < _RUNTIME_TMP_SWEEP_ERROR_DETAILS_LIMIT:
+                error_details.append((lease.name, exc.errno, str(exc.filename or lease)))
             continue
         result["leases_reaped"] += 1
         result["bytes_freed"] += bytes_freed
@@ -3432,7 +3464,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             "🧹 runtime tmp orphan sweep: "
             f"leases_reaped={runtime_tmp_sweep['leases_reaped']} "
             f"bytes_freed={runtime_tmp_sweep['bytes_freed']} "
-            f"errors={runtime_tmp_sweep['errors']}",
+            f"errors={runtime_tmp_sweep['errors']} "
+            f"error_details={runtime_tmp_sweep['error_details']}",
             file=sys.stderr,
         )
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -632,6 +632,11 @@ def _remove_runtime_tmp_lease(lease: Path, namespace: Path) -> None:
             return
         if not repairs:
             break
+    # A lease already gone at entry (e.g. a concurrent sweep won the race) is
+    # success, not a survived-cleanup failure — the loop guard never ran rmtree,
+    # so nothing above could return early on its behalf.
+    if not os.path.lexists(lease):
+        return
     if last_error is not None:
         raise OSError(
             last_error.errno,

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -10,6 +10,7 @@ Issue: #1184.
 from __future__ import annotations
 
 import contextlib
+import errno
 import json
 import os
 import signal
@@ -248,6 +249,36 @@ def test_runtime_tmp_reap_repairs_mode_zero_descendant(tmp_path, monkeypatch):
             blocked.chmod(0o700)
 
 
+def test_runtime_tmp_reap_retries_past_multiple_mode_zero_barriers(tmp_path, monkeypatch):
+    """Every repaired unreadable directory must be retried until the lease is gone."""
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    namespace_root = tmp_path / "learn-ukrainian"
+    lease_root = namespace_root / "task"
+    first_blocked = lease_root / "00-blocked"
+    second_blocked = first_blocked / "00-blocked-again"
+    second_blocked.mkdir(parents=True)
+    (second_blocked / "sealed.txt").write_text("sealed", encoding="utf-8")
+    (first_blocked / "10-ordinary-after-first-error.txt").write_text("ordinary", encoding="utf-8")
+    (lease_root / "10-ordinary-after-first-error.txt").write_text("ordinary", encoding="utf-8")
+    ordinary_tree = lease_root / "20-ordinary-tree" / "nested"
+    ordinary_tree.mkdir(parents=True)
+    (ordinary_tree / "ordinary.txt").write_text("ordinary", encoding="utf-8")
+    second_blocked.chmod(0o000)
+    first_blocked.chmod(0o000)
+
+    try:
+        result = delegate._reap_runtime_tmp_lease(lease_root, namespace_root)
+
+        assert result["tmp_reap_error"] is None
+        assert not os.path.lexists(lease_root)
+    finally:
+        for blocked in (first_blocked, second_blocked):
+            with contextlib.suppress(FileNotFoundError, PermissionError):
+                blocked.chmod(0o700)
+        with contextlib.suppress(FileNotFoundError, OSError):
+            delegate.shutil.rmtree(lease_root)
+
+
 def test_runtime_tmp_reap_records_cleanup_errors(tmp_path, monkeypatch):
     monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
     namespace_root = tmp_path / "learn-ukrainian"
@@ -299,11 +330,39 @@ def test_runtime_tmp_orphan_sweep_reaps_only_safe_candidates(tmp_tasks_dir, tmp_
     assert result["leases_reaped"] == 2
     assert result["bytes_freed"] == len("terminal-task") + len("old-unknown")
     assert result["errors"] == 0
+    assert result["error_details"] == []
     assert not terminal.exists()
     assert not old_unknown.exists()
     assert running.exists()
     assert live_pid.exists()
     assert young_unknown.exists()
+
+
+def test_runtime_tmp_orphan_sweep_reports_bounded_error_details(tmp_tasks_dir, tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    namespace = tmp_path / "learn-ukrainian"
+    count = delegate._RUNTIME_TMP_SWEEP_ERROR_DETAILS_LIMIT + 1
+    for index in range(count):
+        lease = namespace / f"failed-{index}"
+        lease.mkdir(parents=True)
+        delegate._write_state_atomic(
+            delegate._state_path(lease.name),
+            {"task_id": lease.name, "status": "done", "pid": None},
+        )
+
+    def fail_reap(lease: Path, _namespace: Path) -> None:
+        raise OSError(errno.ENOTEMPTY, "Directory not empty", str(lease / "residue"))
+
+    monkeypatch.setattr(delegate, "_remove_runtime_tmp_lease", fail_reap)
+
+    result = delegate._sweep_runtime_tmp_orphans()
+
+    assert result["errors"] == count
+    details = result["error_details"]
+    assert len(details) == delegate._RUNTIME_TMP_SWEEP_ERROR_DETAILS_LIMIT
+    assert all(lease.startswith("failed-") for lease, _errno, _path in details)
+    assert all(error_number == errno.ENOTEMPTY for _lease, error_number, _path in details)
+    assert all(path.endswith("/residue") for _lease, _errno, path in details)
 
 
 def test_write_state_atomic_no_partial_reads(tmp_tasks_dir):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -249,6 +249,18 @@ def test_runtime_tmp_reap_repairs_mode_zero_descendant(tmp_path, monkeypatch):
             blocked.chmod(0o700)
 
 
+def test_runtime_tmp_remove_absent_lease_returns_cleanly(tmp_path, monkeypatch):
+    """A lease a concurrent sweep already removed is success, not a survived-cleanup raise."""
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    namespace_root = tmp_path / "learn-ukrainian"
+    namespace_root.mkdir()
+    lease_root = namespace_root / "task-already-gone"
+
+    delegate._remove_runtime_tmp_lease(lease_root, namespace_root)
+
+    assert not os.path.lexists(lease_root)
+
+
 def test_runtime_tmp_reap_retries_past_multiple_mode_zero_barriers(tmp_path, monkeypatch):
     """Every repaired unreadable directory must be retried until the lease is gone."""
     monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))


### PR DESCRIPTION
Fixes #5843

## Summary

- Retry the fd-relative runtime lease cleanup until a pass makes no permission-repair progress.
- Preserve the final cleanup errno and path for the orphan sweep.
- Report at most ten `(lease, errno, path)` sweep failures.
- Cover nested mode-000 directories plus ordinary sibling files and subtrees.

## Root cause

Python's fd-safe `shutil.rmtree(..., onexc=...)` calls the permission repair callback but does not resume the failed directory descent. The prior fixed two-pass retry left descendants behind when more than one restricted-directory barrier occurred, ending with `ENOTEMPTY`.

## Raw evidence

```text
$ .venv/bin/python -m pytest tests/test_delegate.py::test_runtime_tmp_reap_retries_past_multiple_mode_zero_barriers -q --basetemp "$test_root"
E assert "OSError: [Errno 66] runtime tmp lease survived hardened cleanup: .../learn-ukrainian/task: Directory not empty: 'task/00-blocked'" is None
```

This is the mutation check after replacing the progress loop with the previous two-pass limit. Restoring the loop makes the fixture pass.

## Validation

- `.venv/bin/python -m pytest tests/test_delegate.py -q --basetemp "$test_root"` — 182 passed
- `.venv/bin/python -m ruff check scripts/delegate.py tests/test_delegate.py` — passed
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main..HEAD` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

## NOT VERIFIED

Repository-wide `.venv/bin/python -m ruff check scripts/` is currently blocked by two pre-existing, untouched violations in `scripts/build/linear_pipeline.py` (I001) and `scripts/wiki/run_chunk_policy_bakeoff.py` (RUF100). This PR is deliberately a draft and must not be merged.