### PR TITLE
fix(review): exec-root validator must accept the ownership sentinel

### DIFF
--- a/scripts/review/isolation.py
+++ b/scripts/review/isolation.py
@@ -905,8 +905,17 @@ def _validate_private_exec_root(
         raise ReviewIsolationError("review_exec_root_wrong_owner")
     if stat.S_IMODE(st.st_mode) & 0o077:
         raise ReviewIsolationError("review_exec_root_not_owner_only")
-    if any(root.iterdir()):
-        raise ReviewIsolationError("review_exec_root_not_empty")
+    # A freshly created review temp root legitimately contains exactly one entry:
+    # the ownership sentinel written by create_review_temp_root(). Anything else
+    # (or a sentinel that is not a regular non-symlink file) still refuses —
+    # the sentinel integration broke every bridge review on 2026-07-26 when this
+    # check predated the marker.
+    for entry in root.iterdir():
+        if entry.name != REVIEW_TEMP_ROOT_MARKER_NAME:
+            raise ReviewIsolationError("review_exec_root_not_empty")
+        entry_st = entry.lstat()
+        if stat.S_ISLNK(entry_st.st_mode) or not stat.S_ISREG(entry_st.st_mode):
+            raise ReviewIsolationError("review_exec_root_marker_not_regular")
     return root
 
 

--- a/tests/test_review_isolation.py
+++ b/tests/test_review_isolation.py
@@ -3605,3 +3605,59 @@ def test_f18_changed_binary_denied_unchanged_binary_preserved(tmp_path: Path) ->
         assert (snap.path / "assets" / "pixel.bin").read_bytes() == (b"\x00SECRET_BYTES_NOT_SAFE\x00")
     finally:
         cleanup_snapshot_state(state)
+
+
+class TestExecRootAcceptsSentinel:
+    """The sentinel written by create_review_temp_root must not fail the
+    exec-root emptiness check (2026-07-26: the sentinel integration broke every
+    bridge formal review with review_exec_root_not_empty)."""
+
+    def _validate(self, exec_root, tmp_path):
+        from scripts.review import isolation
+
+        snapshot_root = tmp_path / "snap"
+        write_root = tmp_path / "write"
+        snapshot_root.mkdir(exist_ok=True)
+        write_root.mkdir(exist_ok=True)
+        return isolation._validate_private_exec_root(
+            exec_root=exec_root,
+            snapshot_root=snapshot_root,
+            write_root=write_root,
+            reject_roots=(),
+        )
+
+    def test_factory_created_root_with_sentinel_validates(self, tmp_path, monkeypatch):
+        from scripts.review import isolation
+
+        monkeypatch.setenv("TMPDIR", str(tmp_path / "t"))
+        (tmp_path / "t").mkdir()
+        root = isolation.create_review_temp_root(prefix="lu-review-exec-")
+        root.chmod(0o700)
+        assert (root / isolation.REVIEW_TEMP_ROOT_MARKER_NAME).is_file()
+        assert self._validate(root, tmp_path) == root.resolve()
+
+    def test_root_with_extra_entry_still_refuses(self, tmp_path, monkeypatch):
+        import pytest
+
+        from scripts.review import isolation
+
+        monkeypatch.setenv("TMPDIR", str(tmp_path / "t"))
+        (tmp_path / "t").mkdir()
+        root = isolation.create_review_temp_root(prefix="lu-review-exec-")
+        root.chmod(0o700)
+        (root / "stray.txt").write_text("x", encoding="utf-8")
+        with pytest.raises(isolation.ReviewIsolationError, match="review_exec_root_not_empty"):
+            self._validate(root, tmp_path)
+
+    def test_symlinked_marker_refuses(self, tmp_path):
+        import pytest
+
+        from scripts.review import isolation
+
+        root = tmp_path / "exec"
+        root.mkdir(mode=0o700)
+        outside = tmp_path / "outside"
+        outside.write_text("x", encoding="utf-8")
+        (root / isolation.REVIEW_TEMP_ROOT_MARKER_NAME).symlink_to(outside)
+        with pytest.raises(isolation.ReviewIsolationError, match="marker_not_regular"):
+            self._validate(root, tmp_path)


### PR DESCRIPTION
P1 operational fix: since #5843 merged, EVERY bridge formal review fails with `review_exec_root_not_empty` (live incident, bridge msgs #5292/#5294) — the sentinel factory writes `.lu-review-root` into every fresh root and the exec-root validator demanded emptiness.

Fix: the emptiness check tolerates exactly the sentinel, and only as a regular non-symlink file; any other entry (or a symlinked/irregular marker) still refuses with the original errors.

Verification (raw):
- `tests/test_review_isolation.py` → `102 passed` (3 new: factory-root validates; extra entry still refuses; symlinked marker refuses)
- Mutation-check: `git stash` the validator change → sentinel test FAILS with the incident's exact error; restore → passes.
- ruff clean.

NOT VERIFIED pre-merge: a live `review-pr` run end-to-end (the broken path is the review pipeline itself). Will verify immediately post-merge by rerunning the pending #5846 review.

Review note: formal sealed CF is unavailable BECAUSE of this bug — cross-family verdict obtained via bridge one-shot ask (substitution noted per rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)