### PR TITLE
fix(orchestration): detect excludes registry-terminal rollover packets (#5851)

### DIFF
--- a/scripts/orchestration/claudex_supervisor.py
+++ b/scripts/orchestration/claudex_supervisor.py
@@ -389,7 +389,23 @@ def _load_valid_lease(
         raise SupervisorError("rollover lease generation does not match the request")
     if replacement.get("rollover_id") != rollover_id:
         raise SupervisorError("rollover lease id does not match the request")
+    try:
+        reg_path = thread_handoff.task_family_rollover_registry.record_path(
+            state_root, agent=handoff_agent, lineage_id=lineage_id, rollover_id=rollover_id
+        )
+        if reg_path.is_file():
+            rec = thread_handoff.task_family_rollover_registry.load_record(
+                state_root, agent=handoff_agent, lineage_id=lineage_id, rollover_id=rollover_id
+            )
+            rec_state = rec.get("state")
+            if thread_handoff.task_family_rollover_registry.is_terminal_state(rec_state):
+                raise SupervisorError(f"rollover lease is terminal in registry ({rec_state})")
+    except SupervisorError:
+        raise
+    except Exception:
+        pass
     native = replacement.get("native_lifecycle")
+
     if not isinstance(native, dict) or native.get("source_thread_id") != runtime.get("session_id"):
         raise SupervisorError("rollover native lifecycle does not match the bound session")
     return state, replacement, lease_path

--- a/scripts/orchestration/task_family/rollover_registry.py
+++ b/scripts/orchestration/task_family/rollover_registry.py
@@ -1095,6 +1095,21 @@ def is_live_pending(record: Mapping[str, Any]) -> bool:
     return RolloverState(str(record.get("state"))) in LIVE_PENDING_STATES
 
 
+def is_terminal_state(state: str | RolloverState) -> bool:
+    try:
+        st = RolloverState(str(state))
+    except ValueError:
+        return False
+    if st in TERMINAL_STATES:
+        return True
+    rank = SUCCESS_RANK.get(st)
+    return rank is not None and rank >= SUCCESS_RANK[RolloverState.CONFIRMED]
+
+
+def is_terminal_record(record: Mapping[str, Any]) -> bool:
+    return is_terminal_state(str(record.get("state")))
+
+
 def allows_exact_progress(record: Mapping[str, Any]) -> bool:
     """Return whether ordinary exact progress is safe without blocker adjudication."""
     state = RolloverState(str(record.get("state")))

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -4311,6 +4311,7 @@ def rollover_identity_snapshot(state_root: Path, agent: str | None = None) -> di
     root = state_root / ".agent" / "thread-rollovers"
     candidates: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
+    excluded_terminal: list[dict[str, str]] = []
     paths = root.glob(f"{agent}/*/lease.json") if agent else root.glob("*/*/lease.json")
     for path in sorted(paths):
         lease_agent = path.parent.parent.name
@@ -4320,6 +4321,31 @@ def rollover_identity_snapshot(state_root: Path, agent: str | None = None) -> di
             errors.append({"state_file": rel(path, state_root), "error": error})
             continue
         if replacement is not None and replacement.get("status") in {"pending_start", "resumed"}:
+            lineage_id = state.get("lineage_id")
+            rollover_id = replacement.get("rollover_id")
+            candidate_agent = str(state.get("agent") or lease_agent)
+            if lineage_id and rollover_id:
+                try:
+                    reg_path = task_family_rollover_registry.record_path(
+                        state_root, agent=candidate_agent, lineage_id=lineage_id, rollover_id=rollover_id
+                    )
+                    if reg_path.is_file():
+                        rec = task_family_rollover_registry.load_record(
+                            state_root, agent=candidate_agent, lineage_id=lineage_id, rollover_id=rollover_id
+                        )
+                        rec_state = rec.get("state")
+                        if task_family_rollover_registry.is_terminal_state(rec_state):
+                            excluded_terminal.append(
+                                {
+                                    "agent": candidate_agent,
+                                    "lineage_id": str(lineage_id),
+                                    "rollover_id": str(rollover_id),
+                                    "state": str(rec_state),
+                                }
+                            )
+                            continue
+                except Exception as exc:
+                    errors.append({"state_file": rel(path, state_root), "error": f"registry load error: {exc}"})
             diagnostic = task_identity.candidate_diagnostic(
                 state,
                 replacement,
@@ -4327,30 +4353,45 @@ def rollover_identity_snapshot(state_root: Path, agent: str | None = None) -> di
             )
             diagnostic["agent"] = lease_agent
             candidates.append(diagnostic)
-    return {
+    out: dict[str, Any] = {
         "schema_version": "rollover-identity-snapshot.v1",
         "generated_at": isoformat_z(utc_now()),
         "candidate_count": len(candidates),
         "candidates": candidates,
         "errors": errors,
     }
+    if excluded_terminal:
+        out["excluded_terminal"] = excluded_terminal
+    return out
+
 
 
 def render_session_start_context(candidate: dict[str, Any] | None, *, agent: str, current_thread_id: str) -> str:
     """Render the only SessionStart handoff text; shell hooks never parse leases."""
-    if candidate is None:
+    if candidate is None or candidate.get("status") == "none":
         facts_path = ".agent/orientation-health-facts.json"
-        return "\n".join(
-            [
-                "COLD START: NO LIVE THREAD ROLLOVER",
-                "No pending or resumed packet exists for this agent.",
-                "Orient from durable project state with tool-backed reads before ordinary work.",
-                "Create exactly ten truthful legacy orientation facts, then run:",
-                f".venv/bin/python scripts/context_canary.py mint --facts {facts_path} --out .agent/orientation-health-probe.json",
-                "Do not invent a lineage_id or rollover_id; prepare creates both only when this thread later rolls over.",
-                "Keep the primary checkout read-only and use a dispatch worktree for implementation.",
-            ]
-        )
+        lines = [
+            "COLD START: NO LIVE THREAD ROLLOVER",
+            "No pending or resumed packet exists for this agent.",
+            "Orient from durable project state with tool-backed reads before ordinary work.",
+            "Create exactly ten truthful legacy orientation facts, then run:",
+            f".venv/bin/python scripts/context_canary.py mint --facts {facts_path} --out .agent/orientation-health-probe.json",
+            "Do not invent a lineage_id or rollover_id; prepare creates both only when this thread later rolls over.",
+            "Keep the primary checkout read-only and use a dispatch worktree for implementation.",
+        ]
+        if isinstance(candidate, dict):
+            if candidate.get("excluded_terminal"):
+                lines.append(
+                    "Excluded terminal rollover: "
+                    + ", ".join(
+                        f"{item['agent']}/{item['lineage_id']}/{item['rollover_id']} ({item['state']})"
+                        for item in candidate["excluded_terminal"]
+                    )
+                )
+            if candidate.get("registry_errors"):
+                for err in candidate["registry_errors"]:
+                    lines.append(f"Registry error: {err}")
+        return "\n".join(lines)
     thread_id = current_thread_id or "<current-codex-thread-id>"
     lineage_id = candidate["lineage_id"]
     rollover_id = candidate["rollover_id"]
@@ -4410,6 +4451,17 @@ def render_session_start_context(candidate: dict[str, Any] | None, *, agent: str
             "Do not auto-run any mutation above. Cleanup remains locked unless both exact proofs pass.",
         ]
     )
+    if candidate.get("excluded_terminal"):
+        lines.append(
+            "Excluded terminal rollover: "
+            + ", ".join(
+                f"{item['agent']}/{item['lineage_id']}/{item['rollover_id']} ({item['state']})"
+                for item in candidate["excluded_terminal"]
+            )
+        )
+    if candidate.get("registry_errors"):
+        for err in candidate["registry_errors"]:
+            lines.append(f"Registry error: {err}")
     return "\n".join(lines)
 
 
@@ -4449,6 +4501,8 @@ def _render_multiple_pending_session_start(
     agent: str,
     candidates: list[dict[str, Any]],
     task_family_filter: str,
+    excluded_terminal: list[dict[str, str]] | None = None,
+    registry_errors: list[str] | None = None,
 ) -> str:
     lines = [
         f"MULTIPLE LIVE PENDING ROLLOVERS for agent `{agent}` (#5398 class).",
@@ -4473,11 +4527,23 @@ def _render_multiple_pending_session_start(
             f"--replacement-task-id <this-thread-id> --evidence <harness-binding>"
         )
         lines.append("")
+    if excluded_terminal:
+        lines.append(
+            "Excluded terminal rollover: "
+            + ", ".join(
+                f"{item['agent']}/{item['lineage_id']}/{item['rollover_id']} ({item['state']})"
+                for item in excluded_terminal
+            )
+        )
+    if registry_errors:
+        for err in registry_errors:
+            lines.append(f"Registry error: {err}")
     lines.append(
         "Resolution: bind the exact candidate for THIS lane (or re-run detect with "
         "`--task-family <family>` / launch with `--epic <name>`)."
     )
     return "\n".join(lines)
+
 
 
 def cmd_detect(args: argparse.Namespace) -> int:
@@ -4500,6 +4566,8 @@ def cmd_detect(args: argparse.Namespace) -> int:
         scan_agents.append("codex")
 
     live_leases: list[tuple[Path, dict[str, Any], dict[str, Any], str]] = []
+    excluded_terminal: list[dict[str, str]] = []
+    registry_errors: list[str] = []
 
     for scan_agent in scan_agents:
         agent_dir = state_root / ".agent" / "thread-rollovers" / scan_agent
@@ -4512,12 +4580,45 @@ def cmd_detect(args: argparse.Namespace) -> int:
                 print(json.dumps({"error": f"invalid rollover lease {rel(path, state_root)}: {error}"}, indent=2))
                 return 2
             if replacement is not None and replacement["status"] in {"pending_start", "resumed"}:
+                lineage_id = state.get("lineage_id")
+                rollover_id = replacement.get("rollover_id")
+                candidate_agent = str(state.get("agent") or scan_agent)
+                if lineage_id and rollover_id:
+                    try:
+                        reg_path = task_family_rollover_registry.record_path(
+                            state_root, agent=candidate_agent, lineage_id=lineage_id, rollover_id=rollover_id
+                        )
+                        if reg_path.is_file():
+                            rec = task_family_rollover_registry.load_record(
+                                state_root, agent=candidate_agent, lineage_id=lineage_id, rollover_id=rollover_id
+                            )
+                            rec_state = rec.get("state")
+                            if task_family_rollover_registry.is_terminal_state(rec_state):
+                                excluded_terminal.append(
+                                    {
+                                        "agent": candidate_agent,
+                                        "lineage_id": str(lineage_id),
+                                        "rollover_id": str(rollover_id),
+                                        "state": str(rec_state),
+                                    }
+                                )
+                                continue
+
+
+                    except Exception as exc:
+                        registry_errors.append(
+                            f"registry record corrupt or unreadable for {candidate_agent}/{lineage_id}/{rollover_id}: {exc}"
+                        )
                 live_leases.append((path, state, replacement, scan_agent))
 
     if not live_leases:
         output: dict[str, Any] = {"agent": agent, "status": "none"}
+        if excluded_terminal:
+            output["excluded_terminal"] = excluded_terminal
+        if registry_errors:
+            output["registry_errors"] = registry_errors
         print(
-            render_session_start_context(None, agent=agent, current_thread_id=args.current_thread_id)
+            render_session_start_context(output, agent=agent, current_thread_id=args.current_thread_id)
             if args.format == "session-start"
             else json.dumps(output, indent=2)
         )
@@ -4561,12 +4662,19 @@ def cmd_detect(args: argparse.Namespace) -> int:
                 "--epic launch filter when the lane is known."
             ),
         }
+        if excluded_terminal:
+            payload["excluded_terminal"] = excluded_terminal
+        if registry_errors:
+            payload["registry_errors"] = registry_errors
+
         if args.format == "session-start":
             print(
                 _render_multiple_pending_session_start(
                     agent=agent,
                     candidates=candidates,
                     task_family_filter=task_family_filter,
+                    excluded_terminal=excluded_terminal,
+                    registry_errors=registry_errors,
                 )
             )
         else:
@@ -4614,12 +4722,18 @@ def cmd_detect(args: argparse.Namespace) -> int:
         "title_transition": replacement.get("title_transition"),
         "task_family_filter": task_family_filter or None,
     }
+    if excluded_terminal:
+        output["excluded_terminal"] = excluded_terminal
+    if registry_errors:
+        output["registry_errors"] = registry_errors
+
     print(
         render_session_start_context(output, agent=agent, current_thread_id=args.current_thread_id)
         if args.format == "session-start"
         else json.dumps(output, indent=2)
     )
     return 0
+
 
 
 def _lock_timeout_exit(exc: TimeoutError) -> int:

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -4203,3 +4203,92 @@ def test_confirmation_revalidates_probe_before_handwritten_pass_can_unlock_clean
     assert resumed == before_confirmation
     assert resumed["replacement"]["status"] == "resumed"
     assert resumed["cleanup"]["old_automation_ready_to_delete"] is False
+
+
+def test_detect_excludes_registry_terminal_rollover_packets(tmp_path: Path, capsys, monkeypatch):
+    """#5851: detect excludes registry-terminal rollover packets (e.g. SUPERSEDED)."""
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+
+    # 1. Prepare packet 1
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "t1"]) == 0
+    p1 = json.loads(capsys.readouterr().out)
+    lineage1, rollover1 = p1["lineage_id"], p1["rollover_id"]
+
+    # Mark packet 1 as SUPERSEDED in registry
+    reg_path1 = tmp_path / ".agent" / "thread-rollover-registry" / "v1" / "codex" / lineage1 / rollover1 / "record.json"
+    rec1 = json.loads(reg_path1.read_text(encoding="utf-8"))
+    rec1["state"] = "SUPERSEDED"
+    rec1["terminal_reason"] = "superseded by new packet"
+    th.write_json_atomic(reg_path1, rec1)
+
+    # Detect with single superseded packet -> status: none, excluded_terminal populated
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 0
+    detected_single = json.loads(capsys.readouterr().out)
+    assert detected_single["status"] == "none"
+    assert detected_single["excluded_terminal"] == [
+        {"agent": "codex", "lineage_id": lineage1, "rollover_id": rollover1, "state": "SUPERSEDED"}
+    ]
+
+    # Test session-start output for single superseded packet
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex", "--format", "session-start"]) == 0
+    start_output = capsys.readouterr().out
+    assert "COLD START: NO LIVE THREAD ROLLOVER" in start_output
+    assert f"Excluded terminal rollover: codex/{lineage1}/{rollover1} (SUPERSEDED)" in start_output
+
+    # 2. Prepare packet 2 (live)
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "t2"]) == 0
+    p2 = json.loads(capsys.readouterr().out)
+    lineage2, rollover2 = p2["lineage_id"], p2["rollover_id"]
+
+    # Detect with 1 superseded packet + 1 live packet -> resolves packet 2 directly instead of ambiguous error
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 0
+    detected_multi = json.loads(capsys.readouterr().out)
+    assert detected_multi["status"] == "pending_start"
+    assert detected_multi["lineage_id"] == lineage2
+    assert detected_multi["rollover_id"] == rollover2
+    assert detected_multi["excluded_terminal"] == [
+        {"agent": "codex", "lineage_id": lineage1, "rollover_id": rollover1, "state": "SUPERSEDED"}
+    ]
+
+    # Sibling sweep: check rollover_identity_snapshot
+    snapshot = th.rollover_identity_snapshot(tmp_path, agent="codex")
+    assert snapshot["candidate_count"] == 1
+    assert snapshot["candidates"][0]["lineage_id"] == lineage2
+    assert snapshot["excluded_terminal"] == [
+        {"agent": "codex", "lineage_id": lineage1, "rollover_id": rollover1, "state": "SUPERSEDED"}
+    ]
+
+
+def test_detect_registry_non_terminal_record_is_detected(tmp_path: Path, capsys, monkeypatch):
+    """Negative control: non-terminal registry record is still detected as live."""
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "t1"]) == 0
+    p1 = json.loads(capsys.readouterr().out)
+
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 0
+    detected = json.loads(capsys.readouterr().out)
+    assert detected["status"] == "pending_start"
+    assert detected["lineage_id"] == p1["lineage_id"]
+    assert "excluded_terminal" not in detected
+
+
+def test_detect_corrupt_registry_record_fails_open(tmp_path: Path, capsys, monkeypatch):
+    """Corrupt registry record must not crash detect, fails open, and surfaces error."""
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "t1"]) == 0
+    p1 = json.loads(capsys.readouterr().out)
+    lineage1, rollover1 = p1["lineage_id"], p1["rollover_id"]
+
+    # Corrupt registry record
+    reg_path1 = tmp_path / ".agent" / "thread-rollover-registry" / "v1" / "codex" / lineage1 / rollover1 / "record.json"
+    reg_path1.write_text("{invalid json", encoding="utf-8")
+
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 0
+    detected = json.loads(capsys.readouterr().out)
+    assert detected["status"] == "pending_start"
+    assert detected["lineage_id"] == lineage1
+    assert "registry_errors" in detected
+    assert len(detected["registry_errors"]) == 1
+    assert "corrupt or unreadable" in detected["registry_errors"][0]


### PR DESCRIPTION
## Root Cause Recap
`scripts/orchestration/thread_handoff.py::cmd_detect` scanned lease files under `.agent/thread-rollovers/<agent>/*/lease.json` and counted any lease with status `pending_start` or `resumed` as live. However, it failed to cross-reference the canonical fleet rollover registry (`.agent/thread-rollover-registry/v1/...`). When a rollover packet was superseded or terminated in the registry (state `SUPERSEDED`, `ABANDONED_WITH_PROOF`, or `CONFIRMED` / later), its lease on disk remained unmutated, causing `cmd_detect` to report superseded packets as live pending rollovers and blocking cold starts or creating ambiguous candidate sets.

## Sibling Sweep Coverage
- `scripts/orchestration/thread_handoff.py::cmd_detect`: Primary fix site. Excludes registry-terminal records from `live_leases` and collects them into `excluded_terminal` (surfaced in JSON output & a single summary line in `session-start` output). Corrupt registry records fail open (treated as non-terminal) with errors surfaced in `registry_errors`.
- `scripts/orchestration/thread_handoff.py::rollover_identity_snapshot` (`cmd_check`): Updated candidate collection to inspect registry records and exclude terminal states so `cmd_check` does not report superseded packets as live candidates.
- `scripts/orchestration/claudex_supervisor.py::_load_valid_lease`: Added registry record terminal check to prevent loading terminal/superseded rollover leases for replacement starts (`SupervisorError`).
- `scripts/orchestration/rollover_registry_cli.py`: Audited — uses `registry.is_live_pending(record)` which already checks `LIVE_PENDING_STATES` and ignores terminal states.

## Evidence & Verification
pytest:
```
============================= 143 passed in 2.82s ==============================
```
ruff check:
```
All checks passed!
```
Mutation check:
```
FAILED tests/orchestration/test_thread_handoff.py::test_detect_excludes_registry_terminal_rollover_packets
E   AssertionError: assert 'pending_start' == 'none'
```

Closes #5851.