### PR TITLE
fix(hooks): session-start bounds r2 — lease-claim failure distinction, ambiguity-stop preservation, budget clamp

### DIFF
--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/session-setup.sh\"",
-          "timeout": 15,
+            "timeout": 15,
             "statusMessage": "Checking learn-ukrainian session state"
           }
         ]

--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/session-setup.sh\"",
-            "timeout": 10,
+          "timeout": 15,
             "statusMessage": "Checking learn-ukrainian session state"
           }
         ]

--- a/agents_extensions/shared/hooks/post-compact.sh
+++ b/agents_extensions/shared/hooks/post-compact.sh
@@ -8,12 +8,26 @@ if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$LEARN_UKRAINIAN_PIPELINE" ] || [ -
 fi
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+CANONICAL_ROOT="${CODEX_CANONICAL_REPO_ROOT:-$PROJECT_DIR}"
+BOUNDED_PYTHON="${THREAD_ROLLOVER_PYTHON:-$CANONICAL_ROOT/.venv/bin/python}"
+BOUNDED_RUNNER="${SESSION_BOUNDED_RUNNER:-$PROJECT_DIR/scripts/agent_runtime/bounded_command.py}"
+if [ ! -f "$BOUNDED_RUNNER" ]; then
+  _HOOK_SOURCE_ROOT=$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd)
+  BOUNDED_RUNNER="$_HOOK_SOURCE_ROOT/scripts/agent_runtime/bounded_command.py"
+  unset _HOOK_SOURCE_ROOT
+fi
+run_bounded() {
+  local timeout_seconds="$1"
+  shift
+  "$BOUNDED_PYTHON" "$BOUNDED_RUNNER" --timeout "$timeout_seconds" -- "$@"
+}
 CONTEXT=""
 
 # 1. Find current in-progress modules
 IN_PROGRESS=""
 if [ -d "$PROJECT_DIR/curriculum" ]; then
-  IN_PROGRESS=$(find "$PROJECT_DIR/curriculum" -name "state-v3.json" -exec grep -l '"in_progress"' {} \; 2>/dev/null | head -3)
+  IN_PROGRESS=$(run_bounded 2 find "$PROJECT_DIR/curriculum" -name "state-v3.json" \
+    -exec grep -l '"in_progress"' {} \; 2>/dev/null | head -3)
 fi
 
 if [ -n "$IN_PROGRESS" ]; then
@@ -37,10 +51,9 @@ if [ -z "$HANDOFF_AGENT" ]; then
     HANDOFF_AGENT="claude"
   fi
 fi
-CANONICAL_ROOT="${CODEX_CANONICAL_REPO_ROOT:-$PROJECT_DIR}"
 ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$PROJECT_DIR/.venv/bin/python}"
 ROLLOVER_SCRIPT="${THREAD_ROLLOVER_SCRIPT:-$PROJECT_DIR/scripts/orchestration/thread_handoff.py}"
-ROLLOVER_HEALTH=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+ROLLOVER_HEALTH=$(run_bounded 2 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
   --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" 2>&1) || true
 
 # 3. Key reminders

--- a/agents_extensions/shared/hooks/post-compact.sh
+++ b/agents_extensions/shared/hooks/post-compact.sh
@@ -11,14 +11,12 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 CANONICAL_ROOT="${CODEX_CANONICAL_REPO_ROOT:-$PROJECT_DIR}"
 BOUNDED_PYTHON="${THREAD_ROLLOVER_PYTHON:-$CANONICAL_ROOT/.venv/bin/python}"
 BOUNDED_RUNNER="${SESSION_BOUNDED_RUNNER:-$PROJECT_DIR/scripts/agent_runtime/bounded_command.py}"
-if [ ! -f "$BOUNDED_RUNNER" ]; then
-  _HOOK_SOURCE_ROOT=$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd)
-  BOUNDED_RUNNER="$_HOOK_SOURCE_ROOT/scripts/agent_runtime/bounded_command.py"
-  unset _HOOK_SOURCE_ROOT
-fi
 run_bounded() {
   local timeout_seconds="$1"
   shift
+  if [ ! -x "$BOUNDED_PYTHON" ] || [ ! -f "$BOUNDED_RUNNER" ]; then
+    return 127
+  fi
   "$BOUNDED_PYTHON" "$BOUNDED_RUNNER" --timeout "$timeout_seconds" -- "$@"
 }
 CONTEXT=""

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -3,6 +3,8 @@
 # Validates environment and reports project state.
 # Skips in headless/pipeline mode to avoid adding latency.
 
+SESSION_START_STARTED_SECONDS=$SECONDS
+
 # 0. Pyenv-rehash stale-lock cleanup. Runs BEFORE the headless-skip
 #    because every shell startup (including pipeline jobs) hits pyenv
 #    init, and a stale lock costs 60s per Bash invocation.
@@ -112,11 +114,25 @@ fi
 
 BOUNDED_PYTHON="${CLAUDE_SESSION_RECORD_PYTHON:-$CANONICAL_ROOT/.venv/bin/python}"
 BOUNDED_RUNNER="${SESSION_BOUNDED_RUNNER:-$PROJECT_DIR/scripts/agent_runtime/bounded_command.py}"
+SESSION_START_BUDGET_SECONDS="${SESSION_START_BUDGET_SECONDS:-12}"
+if ! [[ "$SESSION_START_BUDGET_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  SESSION_START_BUDGET_SECONDS=12
+fi
 run_bounded() {
-  local timeout_seconds="$1"
+  local requested_timeout="$1"
+  local elapsed_seconds=$((SECONDS - SESSION_START_STARTED_SECONDS))
+  local remaining_seconds=$((SESSION_START_BUDGET_SECONDS - elapsed_seconds))
+  local timeout_seconds="$requested_timeout"
   shift
   if [ ! -x "$BOUNDED_PYTHON" ] || [ ! -f "$BOUNDED_RUNNER" ]; then
     return 127
+  fi
+  if [ "$remaining_seconds" -le 0 ]; then
+    echo "SessionStart aggregate ${SESSION_START_BUDGET_SECONDS}s command budget exhausted." >&2
+    return 124
+  fi
+  if [ "$timeout_seconds" -gt "$remaining_seconds" ]; then
+    timeout_seconds="$remaining_seconds"
   fi
   "$BOUNDED_PYTHON" "$BOUNDED_RUNNER" --timeout "$timeout_seconds" -- "$@"
 }

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -508,6 +508,27 @@ if [ -n "${SESSION_EPIC:-}" ]; then
   esac
 fi
 
+render_ambiguous_rollover_context() {
+  local original_detect_output="$1"
+  local formatted_context=""
+
+  if formatted_context=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+    --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
+    --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" \
+    --format session-start 2>&1); then
+    printf '%s' "$formatted_context"
+    return 0
+  fi
+
+  cat <<EOF
+ERROR: MULTIPLE live pending rollovers — do not cold-start; bind one exact candidate.
+Formatting lookup failed:
+${formatted_context:-no output}
+Detection output:
+$original_detect_output
+EOF
+}
+
 if [ -z "$HANDOFF_CONTEXT" ] && ! DETECT_OUTPUT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
   --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
   --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" --format json 2>&1); then
@@ -518,10 +539,7 @@ try:
 except Exception:
   print("")' 2>/dev/null || true)
   if [ "$DETECT_ERR_CODE" = "MULTIPLE_LIVE_PENDING_ROLLOVERS" ]; then
-    HANDOFF_CONTEXT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
-      --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
-      --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" \
-      --format session-start 2>&1 || true)
+    HANDOFF_CONTEXT=$(render_ambiguous_rollover_context "$DETECT_OUTPUT")
   else
     HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.
 Output:
@@ -534,10 +552,7 @@ elif ! DETECT_STATUS=$(printf '%s' "$DETECT_OUTPUT" | "$ROLLOVER_PYTHON" -c 'imp
 Output:
 $DETECT_OUTPUT"
 elif [ "$DETECT_STATUS" = "ambiguous" ]; then
-  HANDOFF_CONTEXT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
-    --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
-    --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" \
-    --format session-start 2>&1 || true)
+  HANDOFF_CONTEXT=$(render_ambiguous_rollover_context "$DETECT_OUTPUT")
 elif [ "$DETECT_STATUS" = "pending_start" ] || [ "$DETECT_STATUS" = "resumed" ]; then
   if ! HANDOFF_CONTEXT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
     --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -112,11 +112,6 @@ fi
 
 BOUNDED_PYTHON="${CLAUDE_SESSION_RECORD_PYTHON:-$CANONICAL_ROOT/.venv/bin/python}"
 BOUNDED_RUNNER="${SESSION_BOUNDED_RUNNER:-$PROJECT_DIR/scripts/agent_runtime/bounded_command.py}"
-if [ ! -f "$BOUNDED_RUNNER" ]; then
-  _HOOK_SOURCE_ROOT=$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd)
-  BOUNDED_RUNNER="$_HOOK_SOURCE_ROOT/scripts/agent_runtime/bounded_command.py"
-  unset _HOOK_SOURCE_ROOT
-fi
 run_bounded() {
   local timeout_seconds="$1"
   shift

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -400,31 +400,38 @@ case "$HANDOFF_AGENT" in
   claude|claude-*)
     if [ -z "$CURRENT_THREAD_ID" ]; then
       HANDOFF_CONTEXT="ERROR: Cannot acquire durable thread lease: SessionStart did not provide a current thread id. Stop; do not drive this queue."
-    elif ! THREAD_LEASE_OUTPUT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
-      --repo-root "$CANONICAL_ROOT" claim-thread-lease --agent "$HANDOFF_AGENT" \
-      --current-thread-id "$CURRENT_THREAD_ID" 2>&1); then
-      HANDOFF_CONTEXT="ERROR: DURABLE THREAD LEASE CONFLICT — stop; do not cold-start or drive this queue.
+    else
+      THREAD_LEASE_RC=0
+      THREAD_LEASE_OUTPUT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+        --repo-root "$CANONICAL_ROOT" claim-thread-lease --agent "$HANDOFF_AGENT" \
+        --current-thread-id "$CURRENT_THREAD_ID" 2>&1) || THREAD_LEASE_RC=$?
+      if [ "$THREAD_LEASE_RC" -eq 124 ] || [ "$THREAD_LEASE_RC" -eq 127 ]; then
+        HANDOFF_CONTEXT="ERROR: LEASE CLAIM COULD NOT RUN (timeout/budget/runner missing) — stop; lease state UNKNOWN; do NOT force-release.
 Output:
 $THREAD_LEASE_OUTPUT"
-    else
-      # Propagate the exact generation this session just claimed so the SessionEnd
-      # release hook (release-thread-lease.sh) can fence its release with it —
-      # thread_handoff.py now refuses a non-force release without one (#5759).
-      THREAD_LEASE_GENERATION=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
+      elif [ "$THREAD_LEASE_RC" -ne 0 ]; then
+        HANDOFF_CONTEXT="ERROR: DURABLE THREAD LEASE CONFLICT — stop; do not cold-start or drive this queue.
+Output:
+$THREAD_LEASE_OUTPUT"
+      else
+        # Propagate the exact generation this session just claimed so the SessionEnd
+        # release hook (release-thread-lease.sh) can fence its release with it —
+        # thread_handoff.py now refuses a non-force release without one (#5759).
+        THREAD_LEASE_GENERATION=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
 try:
   d=json.loads(sys.stdin.read()); print(d.get("generation") or "")
 except Exception:
   print("")' 2>/dev/null || true)
-      if [ -n "$THREAD_LEASE_GENERATION" ] && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-        printf 'export LEARN_UKRAINIAN_THREAD_LEASE_GENERATION=%s\n' "$THREAD_LEASE_GENERATION" >> "$CLAUDE_ENV_FILE" 2>/dev/null || true
-      fi
-      unset THREAD_LEASE_GENERATION
+        if [ -n "$THREAD_LEASE_GENERATION" ] && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+          printf 'export LEARN_UKRAINIAN_THREAD_LEASE_GENERATION=%s\n' "$THREAD_LEASE_GENERATION" >> "$CLAUDE_ENV_FILE" 2>/dev/null || true
+        fi
+        unset THREAD_LEASE_GENERATION
 
-      # A successful claim can still be a takeover (the previous owner was confirmed
-      # dead/zombie, or its pid was reused) or a heal from a corrupt on-disk lease.
-      # Neither may ever be silent — surface it into SessionStart context so the
-      # operator is told a slot changed hands before driving it (#5759).
-      THREAD_LEASE_TAKEOVER_BANNER=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
+        # A successful claim can still be a takeover (the previous owner was confirmed
+        # dead/zombie, or its pid was reused) or a heal from a corrupt on-disk lease.
+        # Neither may ever be silent — surface it into SessionStart context so the
+        # operator is told a slot changed hands before driving it (#5759).
+        THREAD_LEASE_TAKEOVER_BANNER=$(printf '%s' "$THREAD_LEASE_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys
 try:
     d = json.loads(sys.stdin.read())
 except Exception:
@@ -442,10 +449,12 @@ if corrupt:
 if parts:
     print("\n".join(parts))
 ' 2>/dev/null || true)
-      if [ -n "$THREAD_LEASE_TAKEOVER_BANNER" ]; then
-        INFO+=("$THREAD_LEASE_TAKEOVER_BANNER")
+        if [ -n "$THREAD_LEASE_TAKEOVER_BANNER" ]; then
+          INFO+=("$THREAD_LEASE_TAKEOVER_BANNER")
+        fi
+        unset THREAD_LEASE_TAKEOVER_BANNER
       fi
-      unset THREAD_LEASE_TAKEOVER_BANNER
+      unset THREAD_LEASE_RC
     fi
     ;;
 esac

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -110,6 +110,28 @@ else
   fi
 fi
 
+BOUNDED_PYTHON="${CLAUDE_SESSION_RECORD_PYTHON:-$CANONICAL_ROOT/.venv/bin/python}"
+BOUNDED_RUNNER="${SESSION_BOUNDED_RUNNER:-$PROJECT_DIR/scripts/agent_runtime/bounded_command.py}"
+if [ ! -f "$BOUNDED_RUNNER" ]; then
+  _HOOK_SOURCE_ROOT=$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd)
+  BOUNDED_RUNNER="$_HOOK_SOURCE_ROOT/scripts/agent_runtime/bounded_command.py"
+  unset _HOOK_SOURCE_ROOT
+fi
+run_bounded() {
+  local timeout_seconds="$1"
+  shift
+  if [ ! -x "$BOUNDED_PYTHON" ] || [ ! -f "$BOUNDED_RUNNER" ]; then
+    return 127
+  fi
+  "$BOUNDED_PYTHON" "$BOUNDED_RUNNER" --timeout "$timeout_seconds" -- "$@"
+}
+
+# Hook-owned state uses the same bounded local-lock contract. fcntl releases
+# locks when an owner dies; this deadline handles a live but wedged owner.
+export LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS=1
+export THREAD_ROLLOVER_COMMAND_RUNNER="$BOUNDED_RUNNER"
+export THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS=3
+
 if [ -n "${SESSION_HANDOFF_AGENT:-}" ]; then
   HANDOFF_AGENT="$SESSION_HANDOFF_AGENT"
 elif [[ "${0:-}" == *"/.codex/"* ]]; then
@@ -154,7 +176,7 @@ if [ -n "$SESSION_ID" ] && [ -f "$SESSION_RECORD_SCRIPT" ] && [ -x "$SESSION_REC
   [ -n "$OBSERVED_MODEL" ] && SESSION_RECORD_CMD+=(--observed-model "$OBSERVED_MODEL")
   [ -n "$AGENT_TYPE" ] && SESSION_RECORD_CMD+=(--agent-type "$AGENT_TYPE")
   [ -n "$REQUESTED_PROFILE_ID" ] && SESSION_RECORD_CMD+=(--profile-id "$REQUESTED_PROFILE_ID")
-  if ! "${SESSION_RECORD_CMD[@]}" >/dev/null; then
+  if ! run_bounded 2 "${SESSION_RECORD_CMD[@]}" >/dev/null; then
     ISSUES+=("SESSION RECORD FAILED: official SessionStart identity could not be persisted.")
   fi
   unset SESSION_RECORD_CMD
@@ -179,7 +201,7 @@ if [ -n "${LEARN_UKRAINIAN_CLAUDEX_RUN_ID:-}" ]; then
     )
     [ -n "$SOURCE" ] && SUPERVISOR_BIND_CMD+=(--source "$SOURCE")
     [ -n "$OBSERVED_MODEL" ] && SUPERVISOR_BIND_CMD+=(--model "$OBSERVED_MODEL")
-    if ! "${SUPERVISOR_BIND_CMD[@]}" >/dev/null 2>&1; then
+    if ! run_bounded 3 "${SUPERVISOR_BIND_CMD[@]}" >/dev/null 2>&1; then
       ISSUES+=("CLAUDEX SUPERVISOR BIND FAILED: SessionStart did not match the owned child generation.")
     fi
     unset SUPERVISOR_BIND_CMD
@@ -190,7 +212,7 @@ fi
 if [ ! -f "$PROJECT_DIR/.venv/bin/python" ]; then
   ISSUES+=("VENV MISSING: .venv/bin/python not found. Recreate: rm -rf .venv && ~/.pyenv/versions/3.12.8/bin/python -m venv .venv")
 else
-  PY_VERSION=$("$PROJECT_DIR/.venv/bin/python" --version 2>/dev/null)
+  PY_VERSION=$(run_bounded 1 "$PROJECT_DIR/.venv/bin/python" --version 2>/dev/null)
   if [[ "$PY_VERSION" != *"3.12"* ]]; then
     ISSUES+=("VENV WRONG PYTHON: Expected 3.12.x, got $PY_VERSION")
   fi
@@ -201,44 +223,9 @@ if [ -z "$CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS" ]; then
   ISSUES+=("ENV MISSING: CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS not set. Add to .bashrc: export CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS=32000")
 fi
 
-if [ "${LEARN_UKRAINIAN_COLD_START_PROFILE:-}" != "compact" ]; then
-  # 3. Check message broker DB exists
-  MCP_DB="$PROJECT_DIR/.mcp/servers/message-broker/messages.db"
-  if [ ! -f "$MCP_DB" ]; then
-    INFO+=("Message broker DB not found at $MCP_DB — Gemini comms unavailable")
-  fi
-
-  # 4. Check for stale orchestration state (in-progress builds older than 24h)
-  STALE_COUNT=0
-  if [ -d "$PROJECT_DIR/curriculum" ]; then
-    while IFS= read -r -d '' state_file; do
-      if [ -f "$state_file" ]; then
-        if grep -q '"in_progress"' "$state_file" 2>/dev/null; then
-          MOD_TIME=$(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)
-          NOW=$(date +%s)
-          AGE=$(( (NOW - MOD_TIME) / 3600 ))
-          if [ "$AGE" -gt 24 ]; then
-            STALE_COUNT=$((STALE_COUNT + 1))
-          fi
-        fi
-      fi
-    done < <(find "$PROJECT_DIR/curriculum" -name "state-v3.json" -print0 2>/dev/null)
-  fi
-
-  if [ "$STALE_COUNT" -gt 0 ]; then
-    INFO+=("$STALE_COUNT stale orchestration state file(s) found (in_progress > 24h old). Consider cleanup.")
-  fi
-
-  # 5. Report in-progress module builds
-  IN_PROGRESS_COUNT=0
-  if [ -d "$PROJECT_DIR/curriculum" ]; then
-    IN_PROGRESS_COUNT=$(find "$PROJECT_DIR/curriculum" -name "state-v3.json" -exec grep -l '"in_progress"' {} \; 2>/dev/null | wc -l | tr -d ' ')
-  fi
-
-  if [ "$IN_PROGRESS_COUNT" -gt 0 ]; then
-    INFO+=("$IN_PROGRESS_COUNT module build(s) currently in progress")
-  fi
-fi
+# Broad curriculum scans, service probes, GitHub issue listings, and governance
+# audits are deliberately absent here. They are optional orientation data and
+# belong behind /api/orient, not on the synchronous session-availability path.
 
 # 6. Check MEMORY.md line count (truncated at 200 lines by system)
 MEMORY_DIR="$HOME/.claude/projects/-Users-krisztiankoos-projects-learn-ukrainian/memory"
@@ -279,131 +266,34 @@ if [ -d "$PROJECT_DIR/agents_extensions/shared" ] && [ -d "$PROJECT_DIR/.claude"
     diff_args+=("--exclude=$ex")
   done
 
-  DRIFT=$(diff "${diff_args[@]}" "$PROJECT_DIR/agents_extensions/shared/" "$PROJECT_DIR/.claude/" 2>/dev/null | head -5)
+  DRIFT=$(run_bounded 2 diff "${diff_args[@]}" \
+    "$PROJECT_DIR/agents_extensions/shared/" "$PROJECT_DIR/.claude/" 2>/dev/null | head -5)
   if [ -n "$DRIFT" ]; then
     DRIFT_COUNT=$(echo "$DRIFT" | wc -l | tr -d ' ')
     ISSUES+=("DEPLOY DRIFT: $DRIFT_COUNT file(s) differ between agents_extensions/shared/ and .claude/. Run: npm run agents:deploy")
   fi
 fi
 
-if [ "${LEARN_UKRAINIAN_COLD_START_PROFILE:-}" != "compact" ]; then
-  # 8. Check MCP sources server health (historically called the RAG server)
-  MCP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:8766/sse" 2>/dev/null)
-  if [ "$MCP_STATUS" != "200" ] && [ "$MCP_STATUS" != "000" ]; then
-    INFO+=("MCP sources server returned HTTP $MCP_STATUS — some tools may be unavailable")
-  elif [ "$MCP_STATUS" = "000" ]; then
-    ISSUES+=("MCP sources server unreachable at 127.0.0.1:8766 — VESUM + textbook + dictionary tools unavailable. Start with: ./services.sh start sources")
-  fi
-
-  # 10. Check for stale decisions
-  if [ -f "$PROJECT_DIR/.venv/bin/python" ] && [ -f "$PROJECT_DIR/scripts/check_decisions.py" ]; then
-    STALE_DECISIONS=$("$PROJECT_DIR/.venv/bin/python" "$PROJECT_DIR/scripts/check_decisions.py" --quiet 2>/dev/null)
-    if [ -n "$STALE_DECISIONS" ]; then
-      INFO+=("$STALE_DECISIONS")
-    fi
-  fi
-
-  # 10b. Check ADR hygiene
-  if [ -f "$PROJECT_DIR/.venv/bin/python" ] && [ -f "$PROJECT_DIR/scripts/audit/check_adrs.py" ]; then
-    ADR_REPORT=$("$PROJECT_DIR/.venv/bin/python" "$PROJECT_DIR/scripts/audit/check_adrs.py" --quiet 2>/dev/null)
-    ADR_EXIT=$?
-    if [ "$ADR_EXIT" -ge 2 ] && [ -n "$ADR_REPORT" ]; then
-      ISSUES+=("ADR hygiene: $ADR_REPORT — see docs/best-practices/adr-management.md")
-    elif [ -n "$ADR_REPORT" ]; then
-      INFO+=("ADR hygiene: $ADR_REPORT")
-    fi
-  fi
-
-  # 10c. Check postmortem hygiene
-  if [ -f "$PROJECT_DIR/.venv/bin/python" ] && [ -f "$PROJECT_DIR/scripts/audit/check_postmortems.py" ]; then
-    POSTMORTEM_REPORT=$("$PROJECT_DIR/.venv/bin/python" "$PROJECT_DIR/scripts/audit/check_postmortems.py" --quiet 2>/dev/null)
-    if [ -n "$POSTMORTEM_REPORT" ]; then
-      ISSUES+=("Postmortem hygiene: $POSTMORTEM_REPORT — see docs/best-practices/postmortem-management.md")
-    fi
-  fi
-
-  # 11. Open GH issues summary
-  if command -v gh >/dev/null 2>&1; then
-    OPEN_ISSUES=$(gh issue list --state open --json number,title,labels --limit 10 2>/dev/null)
-    if [ $? -eq 0 ] && [ -n "$OPEN_ISSUES" ] && [ "$OPEN_ISSUES" != "[]" ]; then
-      ISSUE_COUNT=$(echo "$OPEN_ISSUES" | jq 'length')
-      ISSUE_LIST=$(echo "$OPEN_ISSUES" | jq -r '.[] | "  #\(.number): \(.title)"' | head -5)
-      INFO+=("$ISSUE_COUNT open issue(s):
-  $ISSUE_LIST")
-    fi
-  fi
-
-  # 11b. Issue-stream hygiene
-  STREAM_AUDIT_CACHE="$PROJECT_DIR/batch_state/issue_stream_audit.json"
-  if [ -f "$PROJECT_DIR/scripts/orchestration/issue_stream_audit.py" ]; then
-    STREAM_FRESH=0
-    if [ -f "$STREAM_AUDIT_CACHE" ]; then
-      STREAM_AGE=$(( $(date +%s) - $(jq -r '.generated_at // 0' "$STREAM_AUDIT_CACHE" 2>/dev/null || echo 0) ))
-      [ "$STREAM_AGE" -lt 3600 ] && STREAM_FRESH=1
-    fi
-    if [ "$STREAM_FRESH" -eq 1 ]; then
-      ORPHAN_COUNT=$(jq -r '.orphans | length' "$STREAM_AUDIT_CACHE" 2>/dev/null || echo 0)
-      if [ "$ORPHAN_COUNT" -gt 0 ]; then
-        ORPHAN_LIST=$(jq -r '.orphans[:5][] | "  #\(.number): \(.title)"' "$STREAM_AUDIT_CACHE" 2>/dev/null)
-        ISSUES+=("$ORPHAN_COUNT issue(s) in NO stream epic (link them — registry: scripts/config/issue_streams.yaml):
-  $ORPHAN_LIST")
-      fi
-      MISSING_EPICS=$(jq -r '.closed_or_missing_epics | join(", ")' "$STREAM_AUDIT_CACHE" 2>/dev/null)
-      [ -n "$MISSING_EPICS" ] && ISSUES+=("Stream epic(s) closed/missing: #$MISSING_EPICS — fix scripts/config/issue_streams.yaml or reopen")
-
-      if [ -f "$PROJECT_DIR/scripts/audit/check_research_registry.py" ] && \
-         [ -f "$PROJECT_DIR/docs/references/research-registry.yaml" ] && \
-         [ -x "$PROJECT_DIR/.venv/bin/python" ]; then
-        STRICT_JSON=$(cd "$PROJECT_DIR" && "$PROJECT_DIR/.venv/bin/python" scripts/audit/check_research_registry.py --strict-adoption --json 2>/dev/null)
-        STRICT_OK=$(echo "$STRICT_JSON" | jq -r '.ok' 2>/dev/null)
-        if [ "$STRICT_OK" = "false" ]; then
-          STRICT_ERRORS=$(echo "$STRICT_JSON" | jq -r '.errors[]? | "  - \(.)"' 2>/dev/null)
-          ISSUES+=("Research registry strict-adoption gate FAILED (ADR-011 P4 — ownership/consumer drift vs live GitHub, scripts/audit/check_research_registry.py --strict-adoption):
-  $STRICT_ERRORS")
-        fi
-      fi
-    elif command -v gh >/dev/null 2>&1; then
-      (cd "$PROJECT_DIR" && nohup "$PROJECT_DIR/.venv/bin/python" -m scripts.orchestration.issue_stream_audit --json >/dev/null 2>&1 &)
-      INFO+=("issue-stream audit cache stale — background refresh started (#4708)")
-    fi
-  fi
-
-  # 12. Git hygiene
-  if command -v git >/dev/null 2>&1 && [ -d "$PROJECT_DIR/.git" ]; then
-    HYGIENE_THRESHOLD_WARN=5
-    HYGIENE_THRESHOLD_ISSUE=20
-
-    DIRTY_NONEXEMPT=$(
-      git -C "$PROJECT_DIR" status --short 2>/dev/null \
-        | grep -vE ' (wiki/|data/corpus_audit/draft_tickets/)' \
-        | wc -l | tr -d ' '
-    )
-
-    if [ "$DIRTY_NONEXEMPT" -gt "$HYGIENE_THRESHOLD_ISSUE" ]; then
-      ISSUES+=("GIT HYGIENE: $DIRTY_NONEXEMPT dirty files outside exempt paths (threshold: $HYGIENE_THRESHOLD_ISSUE). Triage BEFORE starting work — see docs/best-practices/git-hygiene.md. Often these are stale-behind-main drift; \`git checkout HEAD -- <file>\` fixes each one.")
-    elif [ "$DIRTY_NONEXEMPT" -gt "$HYGIENE_THRESHOLD_WARN" ]; then
-      INFO+=("Git hygiene: $DIRTY_NONEXEMPT dirty files outside exempt paths. Under the issue threshold ($HYGIENE_THRESHOLD_ISSUE) but worth inspecting with \`git status --short | grep -vE ' (wiki/|data/corpus_audit/draft_tickets/)'\`. Policy: docs/best-practices/git-hygiene.md.")
-    fi
-
-    # 12b. Primary must stay attached to main (#4857) — auto-heal when possible.
-    if [ -x "$PROJECT_DIR/.venv/bin/python" ] \
-        && [ -f "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" ]; then
-      if ! "$PROJECT_DIR/.venv/bin/python" \
-          "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
-          --cwd "$PROJECT_DIR" --quiet 2>/dev/null; then
-        if "$PROJECT_DIR/.venv/bin/python" \
-            "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
-            --cwd "$PROJECT_DIR" --heal 2>/dev/null; then
-          INFO+=("PRIMARY HEAD was off main/detached — auto-healed to main (#4857). Prefer worktrees for all branch work.")
-        else
-          ISSUES+=("PRIMARY HEAD is detached or not on main (#4857). Run: .venv/bin/python scripts/guardrails/assert_primary_on_main.py --heal. Never gh pr checkout / git checkout <sha> on primary.")
-        fi
-      fi
-    fi
-  fi
+if [ "${LEARN_UKRAINIAN_COLD_START_PROFILE:-}" = "compact" ]; then
+  INFO+=("Orientation diagnostics: http://localhost:8765/api/orient?lean=true&session=${SESSION_ID:-}")
 else
-  # 9. Compact mode orientation link
-  INFO+=("Lean orientation: http://localhost:8765/api/orient?lean=true&session=${SESSION_ID:-}")
+  INFO+=("Orientation diagnostics: http://localhost:8765/api/orient?session=${SESSION_ID:-}")
+fi
+
+# Keep only the local protected-branch canary on the synchronous path.
+if [ -x "$PROJECT_DIR/.venv/bin/python" ] \
+    && [ -f "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" ]; then
+  if ! run_bounded 2 "$PROJECT_DIR/.venv/bin/python" \
+      "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
+      --cwd "$PROJECT_DIR" --quiet 2>/dev/null; then
+    if run_bounded 2 "$PROJECT_DIR/.venv/bin/python" \
+        "$PROJECT_DIR/scripts/guardrails/assert_primary_on_main.py" \
+        --cwd "$PROJECT_DIR" --heal 2>/dev/null; then
+      INFO+=("PRIMARY HEAD was off main/detached — auto-healed to main (#4857). Prefer worktrees for all branch work.")
+    else
+      ISSUES+=("PRIMARY HEAD is detached or not on main (#4857). Run: .venv/bin/python scripts/guardrails/assert_primary_on_main.py --heal.")
+    fi
+  fi
 fi
 
 # 13. Session handoff. Claude uses the official SessionStart session id; Codex
@@ -450,7 +340,7 @@ $VERIFY_OUTPUT"
         --rollover-id "$CODEX_LAUNCHER_ROLLOVER_ID"
       )
       BIND_OUTPUT=""
-      if ! BIND_OUTPUT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" --repo-root "$CANONICAL_ROOT" \
+      if ! BIND_OUTPUT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" --repo-root "$CANONICAL_ROOT" \
         bind-replacement "${EXACT_ROLLOVER_COMMON[@]}" \
         --replacement-task-id "$CURRENT_THREAD_ID" \
         --evidence "Codex launcher SessionStart bound the exact fresh CLI task ID" 2>&1); then
@@ -459,13 +349,13 @@ Output:
 $BIND_OUTPUT"
       else
         RESUME_OUTPUT=""
-        if ! RESUME_OUTPUT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" --repo-root "$CANONICAL_ROOT" \
+        if ! RESUME_OUTPUT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" --repo-root "$CANONICAL_ROOT" \
           resume "${EXACT_ROLLOVER_COMMON[@]}" \
           --replacement-thread-id "$CURRENT_THREAD_ID" 2>&1); then
           HANDOFF_CONTEXT="ERROR: CODEX LAUNCHER EXACT ROLLOVER RESUME FAILED — stop.
 Output:
 $RESUME_OUTPUT"
-        elif ! HANDOFF_CONTEXT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" --repo-root "$CANONICAL_ROOT" \
+        elif ! HANDOFF_CONTEXT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" --repo-root "$CANONICAL_ROOT" \
           detect --agent "$CODEX_LAUNCHER_ROLLOVER_AGENT" \
           --current-thread-id "$CURRENT_THREAD_ID" --format session-start 2>&1); then
           HANDOFF_CONTEXT="ERROR: CODEX LAUNCHER EXACT ROLLOVER READBACK FAILED — stop.
@@ -489,7 +379,7 @@ case "$HANDOFF_AGENT" in
   claude|claude-*)
     if [ -z "$CURRENT_THREAD_ID" ]; then
       HANDOFF_CONTEXT="ERROR: Cannot acquire durable thread lease: SessionStart did not provide a current thread id. Stop; do not drive this queue."
-    elif ! THREAD_LEASE_OUTPUT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+    elif ! THREAD_LEASE_OUTPUT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
       --repo-root "$CANONICAL_ROOT" claim-thread-lease --agent "$HANDOFF_AGENT" \
       --current-thread-id "$CURRENT_THREAD_ID" 2>&1); then
       HANDOFF_CONTEXT="ERROR: DURABLE THREAD LEASE CONFLICT — stop; do not cold-start or drive this queue.
@@ -597,7 +487,7 @@ if [ -n "${SESSION_EPIC:-}" ]; then
   esac
 fi
 
-if [ -z "$HANDOFF_CONTEXT" ] && ! DETECT_OUTPUT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+if [ -z "$HANDOFF_CONTEXT" ] && ! DETECT_OUTPUT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
   --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
   --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" --format json 2>&1); then
   # Exit 2 may be multi-packet ambiguity (#5398) — surface candidates, never cold-start.
@@ -607,8 +497,10 @@ try:
 except Exception:
   print("")' 2>/dev/null || true)
   if [ "$DETECT_ERR_CODE" = "MULTIPLE_LIVE_PENDING_ROLLOVERS" ]; then
-    HANDOFF_CONTEXT="ERROR: MULTIPLE live pending rollovers — do not cold-start; bind one exact candidate.
-$DETECT_OUTPUT"
+    HANDOFF_CONTEXT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+      --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
+      --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" \
+      --format session-start 2>&1 || true)
   else
     HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.
 Output:
@@ -621,10 +513,12 @@ elif ! DETECT_STATUS=$(printf '%s' "$DETECT_OUTPUT" | "$ROLLOVER_PYTHON" -c 'imp
 Output:
 $DETECT_OUTPUT"
 elif [ "$DETECT_STATUS" = "ambiguous" ]; then
-  HANDOFF_CONTEXT="ERROR: MULTIPLE live pending rollovers — do not cold-start; bind one exact candidate.
-$DETECT_OUTPUT"
+  HANDOFF_CONTEXT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+    --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
+    --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" \
+    --format session-start 2>&1 || true)
 elif [ "$DETECT_STATUS" = "pending_start" ] || [ "$DETECT_STATUS" = "resumed" ]; then
-  if ! HANDOFF_CONTEXT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+  if ! HANDOFF_CONTEXT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
     --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
     --current-thread-id "$CURRENT_THREAD_ID" "${TASK_FAMILY_ARGS[@]}" --format session-start 2>&1); then
     HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.
@@ -658,6 +552,7 @@ elif [ "$DETECT_STATUS" = "none" ]; then
     fi
 
     if [ -z "$HANDOFF_CONTEXT" ]; then
+      # shellcheck disable=SC2016
       TABLE_BRIEF=$(sed -n 's/.*\*\*Brief (read first):\*\* `\([^`]*\)`.*/\1/p' "$HANDOFF_FILE" 2>/dev/null | head -1)
 
       if [ -n "$TABLE_BRIEF" ]; then
@@ -684,7 +579,7 @@ elif [ "$DETECT_STATUS" = "none" ]; then
   fi
 
   if [ -z "$HANDOFF_CONTEXT" ]; then
-    if ! HANDOFF_CONTEXT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+    if ! HANDOFF_CONTEXT=$(run_bounded 3 "$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
       --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
       --current-thread-id "$CURRENT_THREAD_ID" --format session-start 2>&1); then
       HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -118,23 +118,28 @@ SESSION_START_BUDGET_SECONDS="${SESSION_START_BUDGET_SECONDS:-12}"
 if ! [[ "$SESSION_START_BUDGET_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
   SESSION_START_BUDGET_SECONDS=12
 fi
-run_bounded() {
+clamp_bounded_timeout() {
   local requested_timeout="$1"
   local elapsed_seconds=$((SECONDS - SESSION_START_STARTED_SECONDS))
   local remaining_seconds=$((SESSION_START_BUDGET_SECONDS - elapsed_seconds))
-  local timeout_seconds="$requested_timeout"
-  shift
-  if [ ! -x "$BOUNDED_PYTHON" ] || [ ! -f "$BOUNDED_RUNNER" ]; then
-    return 127
-  fi
   if [ "$remaining_seconds" -le 0 ]; then
     echo "SessionStart aggregate ${SESSION_START_BUDGET_SECONDS}s command budget exhausted." >&2
     return 124
   fi
-  if [ "$timeout_seconds" -gt "$remaining_seconds" ]; then
-    timeout_seconds="$remaining_seconds"
+  CLAMPED_BOUNDED_TIMEOUT_SECONDS="$requested_timeout"
+  if [ "$CLAMPED_BOUNDED_TIMEOUT_SECONDS" -gt "$remaining_seconds" ]; then
+    CLAMPED_BOUNDED_TIMEOUT_SECONDS="$remaining_seconds"
   fi
-  "$BOUNDED_PYTHON" "$BOUNDED_RUNNER" --timeout "$timeout_seconds" -- "$@"
+}
+run_bounded() {
+  local requested_timeout="$1"
+  shift
+  if [ ! -x "$BOUNDED_PYTHON" ] || [ ! -f "$BOUNDED_RUNNER" ]; then
+    return 127
+  fi
+  clamp_bounded_timeout "$requested_timeout" || return $?
+  "$BOUNDED_PYTHON" "$BOUNDED_RUNNER" \
+    --timeout "$CLAMPED_BOUNDED_TIMEOUT_SECONDS" -- "$@"
 }
 
 # Hook-owned state uses the same bounded local-lock contract. fcntl releases
@@ -335,12 +340,17 @@ if [ "${CODEX_SESSION:-0}" = "1" ] \
     # shellcheck disable=SC1090
     source "$ROLLOVER_LINK_HELPER"
     VERIFY_OUTPUT=""
-    if ! VERIFY_OUTPUT=$(verify_codex_pending_rollover \
-      "$CANONICAL_ROOT" \
-      "$HANDOFF_AGENT" \
-      "$CODEX_LAUNCHER_ROLLOVER_AGENT" \
-      "$CODEX_LAUNCHER_ROLLOVER_LINEAGE_ID" \
-      "$CODEX_LAUNCHER_ROLLOVER_ID" 2>&1); then
+    if ! clamp_bounded_timeout 3; then
+      HANDOFF_CONTEXT="ERROR: CODEX LAUNCHER ROLLOVER PREFLIGHT SKIPPED — SessionStart command budget exhausted; no rollover was mutated."
+    elif ! VERIFY_OUTPUT=$(
+      THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS="$CLAMPED_BOUNDED_TIMEOUT_SECONDS" \
+        verify_codex_pending_rollover \
+          "$CANONICAL_ROOT" \
+          "$HANDOFF_AGENT" \
+          "$CODEX_LAUNCHER_ROLLOVER_AGENT" \
+          "$CODEX_LAUNCHER_ROLLOVER_LINEAGE_ID" \
+          "$CODEX_LAUNCHER_ROLLOVER_ID" 2>&1
+    ); then
       HANDOFF_CONTEXT="ERROR: CODEX LAUNCHER ROLLOVER PREFLIGHT CHANGED — stop; no rollover was mutated.
 Output:
 $VERIFY_OUTPUT"

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -66,11 +66,13 @@ edit the separate user-level `~/.codex/hooks.json`.
 
 ## Session availability and rollover deadlines
 
-`SessionStart` is an availability path with a 15-second outer ceiling. Mandatory
-identity, protected-branch, and rollover work runs locally with 1–3 second
-subprocess deadlines. Hook-owned advisory locks use a one-second bounded wait;
-the lock remains fail-safe, while a live but wedged owner can no longer stall a
-new session indefinitely.
+`SessionStart` is an availability path with a 15-second outer ceiling. Its
+subprocesses share a 12-second aggregate command budget: every 1–3 second local
+deadline is clamped to the time remaining in that budget. This leaves time to
+render the final JSON context instead of letting individually bounded commands
+accumulate past the outer hook deadline. Hook-owned advisory locks use a
+one-second bounded wait; the lock remains fail-safe, while a live but wedged
+owner can no longer stall a new session indefinitely.
 
 Broad curriculum scans, service probes, GitHub issue listings, and governance
 audits were removed from the synchronous hook. The hook now points to

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -64,6 +64,23 @@ queries Codex-addressed messages rather than silently reporting Claude's inbox.
 The repository deploy manages project-local `.codex/hooks.json`; it does not
 edit the separate user-level `~/.codex/hooks.json`.
 
+## Session availability and rollover deadlines
+
+`SessionStart` is an availability path with a 15-second outer ceiling. Mandatory
+identity, protected-branch, and rollover work runs locally with 1–3 second
+subprocess deadlines. Hook-owned advisory locks use a one-second bounded wait;
+the lock remains fail-safe, while a live but wedged owner can no longer stall a
+new session indefinitely.
+
+Broad curriculum scans, service probes, GitHub issue listings, and governance
+audits were removed from the synchronous hook. The hook now points to
+`/api/orient` for those optional diagnostics. Multiple pending rollovers remain
+a stop condition, but SessionStart renders the existing concise exact-identity
+inventory rather than injecting the full lease JSON.
+
+`PostCompact` remains read-only. Its curriculum scan and rollover-health read
+have separate two-second deadlines under the existing 10-second outer ceiling.
+
 ## Pytest stamp and pre-push guard
 
 `agents_extensions/shared/hooks/stamp-pytest.sh` is the deployed

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -74,6 +74,11 @@ accumulate past the outer hook deadline. Hook-owned advisory locks use a
 one-second bounded wait; the lock remains fail-safe, while a live but wedged
 owner can no longer stall a new session indefinitely.
 
+A `SIGKILL` can land after `claim-thread-lease` persists the lease but before the
+claim reports back to SessionStart. In that case the session must stop and the
+lease can remain held; do not force-release based only on a claim timeout. The
+lease-lifecycle work in the infrastructure lane is making this recovery explicit.
+
 Broad curriculum scans, service probes, GitHub issue listings, and governance
 audits were removed from the synchronous hook. The hook now points to
 `/api/orient` for those optional diagnostics. Multiple pending rollovers remain

--- a/scripts/agent_runtime/bounded_command.py
+++ b/scripts/agent_runtime/bounded_command.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Run one hook subprocess with a hard deadline and process-group cleanup."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+from contextlib import suppress
+
+TIMEOUT_EXIT_CODE = 124
+
+
+def run(command: list[str], timeout_seconds: float) -> int:
+    """Run ``command`` and kill its process group if the deadline expires."""
+    process = subprocess.Popen(command, start_new_session=True)
+    try:
+        return process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+        print(
+            f"Session hook command exceeded {timeout_seconds:g}s and was terminated: {command[0]}",
+            file=sys.stderr,
+        )
+        return TIMEOUT_EXIT_CODE
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--timeout", type=float, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+    if not command:
+        parser.error("a command is required after --")
+    return run(command, args.timeout)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -105,6 +105,7 @@ run_hook() {
     CLAUDE_PROFILE_RESOLVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
     CLAUDE_SESSION_RECORD_SCRIPT="$REPO_ROOT/scripts/lib/session_record.py" \
     CLAUDE_SESSION_RECORD_PYTHON="$REPO_ROOT/.venv/bin/python" \
+    SESSION_BOUNDED_RUNNER="$REPO_ROOT/scripts/agent_runtime/bounded_command.py" \
     CLAUDEX_SUPERVISOR_SCRIPT="$REPO_ROOT/scripts/orchestration/claudex_supervisor.py" \
     CLAUDEX_SUPERVISOR_PYTHON="$REPO_ROOT/.venv/bin/python" \
     THREAD_ROLLOVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
@@ -216,6 +217,7 @@ run_post_compact() {
     CLAUDE_PROJECT_DIR="$root" SESSION_HANDOFF_AGENT="codex" CODEX_CANONICAL_REPO_ROOT="$root" \
     THREAD_ROLLOVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
     THREAD_ROLLOVER_SCRIPT="$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    SESSION_BOUNDED_RUNNER="$REPO_ROOT/scripts/agent_runtime/bounded_command.py" \
     "$POST_COMPACT_HOOK"
 }
 

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -108,7 +108,7 @@ run_hook() {
     SESSION_BOUNDED_RUNNER="$REPO_ROOT/scripts/agent_runtime/bounded_command.py" \
     CLAUDEX_SUPERVISOR_SCRIPT="$REPO_ROOT/scripts/orchestration/claudex_supervisor.py" \
     CLAUDEX_SUPERVISOR_PYTHON="$REPO_ROOT/.venv/bin/python" \
-    THREAD_ROLLOVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
+    THREAD_ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$REPO_ROOT/.venv/bin/python}" \
     THREAD_ROLLOVER_SCRIPT="$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     SESSION_HANDOFF_AGENT="$handoff_agent" \
     SESSION_EPIC="$session_epic" \
@@ -479,6 +479,24 @@ output_harness="$(run_hook "$fixture_root" 0 "$harness_slot")"
 assert_contains "$output_harness" "PENDING THREAD ROLLOVER DETECTED" "epic harness surfaces claude-infra packet (#5201)"
 assert_contains "$output_harness" "--agent claude-infra" "epic harness surfaces claude-infra packet (#5201)"
 assert_not_contains "$output_harness" "COLD START: NO LIVE THREAD ROLLOVER" "epic harness surfaces claude-infra packet (#5201)"
+
+# 17b. An exhausted aggregate budget leaves the durable lease state unknown;
+# it is not evidence of a thread lease conflict and must never suggest force release.
+setup_fixture "$fixture_root"
+slow_python="$fixture_root/.venv/bin/slow-python"
+cat > "$slow_python" <<'EOF'
+#!/usr/bin/env bash
+sleep 2
+EOF
+chmod +x "$slow_python"
+output="$(
+  SESSION_START_BUDGET_SECONDS=1 THREAD_ROLLOVER_PYTHON="$slow_python" \
+    run_hook "$fixture_root" 0 claude
+)"
+assert_contains "$output" \
+  "ERROR: LEASE CLAIM COULD NOT RUN (timeout/budget/runner missing) — stop; lease state UNKNOWN; do NOT force-release." \
+  "lease claim budget exhaustion"
+assert_not_contains "$output" "DURABLE THREAD LEASE CONFLICT" "lease claim budget exhaustion"
 
 # 18. Official SessionStart fields drive the native profile and exact transcript record.
 setup_fixture "$fixture_root"

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -372,8 +372,7 @@ assert_contains "$output" "Thread handoff: .agent/claude-infra-thread-handoff.md
 assert_not_contains "$output" "Thread handoff: .agent/claude-thread-handoff.md" "infra lane isolation"
 assert_not_contains "$output" "WARN:" "infra lane isolation"
 
-# 9. Research-registry strict-adoption gate (ADR-011 P4, PR #4998 review):
-#    a fresh stream-audit cache plus a failing gate must surface an ISSUES entry.
+# 9. Optional governance diagnostics are deferred from synchronous startup.
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/scripts/audit" "$fixture_root/scripts/orchestration" "$fixture_root/docs/references" "$fixture_root/batch_state"
 printf '# stub\n' > "$fixture_root/scripts/audit/check_research_registry.py"
@@ -385,25 +384,11 @@ export STRICT_GATE_FAKE_JSON='{"ok": false, "errors": ["demo-record: consumer is
 export STRICT_GATE_FAKE_EXIT=2
 output="$(run_hook "$fixture_root")"
 unset STRICT_GATE_FAKE_JSON STRICT_GATE_FAKE_EXIT
-assert_contains "$output" "Research registry strict-adoption gate FAILED" "strict gate wired"
-assert_contains "$output" "demo-record: consumer issue 999 did not resolve" "strict gate wired"
+assert_not_contains "$output" "Research registry strict-adoption gate FAILED" "strict gate deferred"
+assert_not_contains "$output" "demo-record: consumer issue 999 did not resolve" "strict gate deferred"
+assert_contains "$output" "Orientation diagnostics:" "strict gate deferred"
 
-# 10. A passing strict-adoption gate must remain silent on success.
-setup_fixture "$fixture_root"
-mkdir -p "$fixture_root/scripts/audit" "$fixture_root/scripts/orchestration" "$fixture_root/docs/references" "$fixture_root/batch_state"
-printf '# stub\n' > "$fixture_root/scripts/audit/check_research_registry.py"
-printf '# stub\n' > "$fixture_root/scripts/orchestration/issue_stream_audit.py"
-printf 'records: []\n' > "$fixture_root/docs/references/research-registry.yaml"
-printf '{"generated_at": %s, "orphans": [], "closed_or_missing_epics": []}\n' \
-  "$(date +%s)" > "$fixture_root/batch_state/issue_stream_audit.json"
-export STRICT_GATE_FAKE_JSON='{"ok": true, "errors": [], "drift": [], "cache": "fresh"}'
-export STRICT_GATE_FAKE_EXIT=0
-output="$(run_hook "$fixture_root")"
-unset STRICT_GATE_FAKE_JSON STRICT_GATE_FAKE_EXIT
-assert_not_contains "$output" "Research registry strict-adoption gate FAILED" "strict gate passing"
-assert_not_contains "$output" "WARN:" "strict gate passing"
-
-# 11. Engine-generated pending packet is authoritative.
+# 10. Engine-generated pending packet is authoritative.
 setup_fixture "$fixture_root"
 prepare_fixture "$fixture_root" claude old-thread
 output="$(run_hook "$fixture_root")"
@@ -440,7 +425,8 @@ setup_fixture "$fixture_root"
 prepare_fixture "$fixture_root" codex old-a
 prepare_fixture "$fixture_root" codex old-b
 output="$(run_hook "$fixture_root" 0 codex)"
-assert_contains "$output" "Multiple live pending rollovers found for agent codex" "ambiguous packet"
+assert_contains "$output" "MULTIPLE LIVE PENDING ROLLOVERS for agent \`codex\`" "ambiguous packet"
+assert_contains "$output" "Candidate count: 2." "ambiguous packet"
 
 # 15. Resumed packet for current thread allowed; mismatch blocks.
 setup_fixture "$fixture_root"

--- a/scripts/lib/thread_rollover_link.sh
+++ b/scripts/lib/thread_rollover_link.sh
@@ -90,10 +90,17 @@ resolve_codex_pending_rollover() {
     return 1
   fi
 
-  detect_output="$(
-    "${runner[@]}" "$python_bin" "$handoff_script" --repo-root "$project_dir" \
-      detect --agent "$handoff_agent" --format json 2>&1
-  )" || detect_rc=$?
+  if [ -n "${THREAD_ROLLOVER_COMMAND_RUNNER:-}" ]; then
+    detect_output="$(
+      "${runner[@]}" "$python_bin" "$handoff_script" --repo-root "$project_dir" \
+        detect --agent "$handoff_agent" --format json 2>&1
+    )" || detect_rc=$?
+  else
+    detect_output="$(
+      "$python_bin" "$handoff_script" --repo-root "$project_dir" \
+        detect --agent "$handoff_agent" --format json 2>&1
+    )" || detect_rc=$?
+  fi
   if [ "$detect_rc" -ne 0 ]; then
     printf 'Error: Codex rollover preflight refused launch for %s.\n' "$handoff_agent" >&2
     printf '%s\n' "$detect_output" >&2

--- a/scripts/lib/thread_rollover_link.sh
+++ b/scripts/lib/thread_rollover_link.sh
@@ -75,12 +75,14 @@ resolve_codex_pending_rollover() {
   local title_state=""
   local replacement_task_id=""
   local runner=()
+  local parser_runner=()
 
   if [ -n "${THREAD_ROLLOVER_COMMAND_RUNNER:-}" ]; then
     runner=(
       "$python_bin" "$THREAD_ROLLOVER_COMMAND_RUNNER"
       --timeout "${THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS:-3}" --
     )
+    parser_runner=("${runner[@]}")
   fi
 
   clear_codex_launcher_rollover_env
@@ -108,7 +110,7 @@ resolve_codex_pending_rollover() {
   fi
 
   if ! parsed="$(
-    printf '%s' "$detect_output" | "$python_bin" -c '
+    printf '%s' "$detect_output" | "${parser_runner[@]}" "$python_bin" -c '
 import json
 import re
 import sys

--- a/scripts/lib/thread_rollover_link.sh
+++ b/scripts/lib/thread_rollover_link.sh
@@ -74,6 +74,14 @@ resolve_codex_pending_rollover() {
   local native_title_supported=""
   local title_state=""
   local replacement_task_id=""
+  local runner=()
+
+  if [ -n "${THREAD_ROLLOVER_COMMAND_RUNNER:-}" ]; then
+    runner=(
+      "$python_bin" "$THREAD_ROLLOVER_COMMAND_RUNNER"
+      --timeout "${THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS:-3}" --
+    )
+  fi
 
   clear_codex_launcher_rollover_env
 
@@ -83,7 +91,7 @@ resolve_codex_pending_rollover() {
   fi
 
   detect_output="$(
-    "$python_bin" "$handoff_script" --repo-root "$project_dir" \
+    "${runner[@]}" "$python_bin" "$handoff_script" --repo-root "$project_dir" \
       detect --agent "$handoff_agent" --format json 2>&1
   )" || detect_rc=$?
   if [ "$detect_rc" -ne 0 ]; then

--- a/scripts/orchestration/task_family/storage.py
+++ b/scripts/orchestration/task_family/storage.py
@@ -6,6 +6,7 @@ import fcntl
 import json
 import os
 import tempfile
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from pathlib import Path
@@ -59,10 +60,25 @@ def atomic_write_text(path: Path, text: str) -> None:
 
 @contextmanager
 def advisory_lock(path: Path) -> Iterator[None]:
-    """Cooperate with other planners; never alters or deletes Git lock files."""
+    """Cooperate with other planners; optionally bound hook-startup lock waits."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a+", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        timeout_text = os.environ.get("LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS", "")
+        timeout_seconds = float(timeout_text) if timeout_text else None
+        if timeout_seconds is None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        else:
+            deadline = time.monotonic() + timeout_seconds
+            while True:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"timed out after {timeout_seconds:g}s waiting for local state lock: {path}"
+                        ) from None
+                    time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
         try:
             yield
         finally:

--- a/scripts/orchestration/task_family/storage.py
+++ b/scripts/orchestration/task_family/storage.py
@@ -64,7 +64,10 @@ def advisory_lock(path: Path) -> Iterator[None]:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a+", encoding="utf-8") as handle:
         timeout_text = os.environ.get("LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS", "")
-        timeout_seconds = float(timeout_text) if timeout_text else None
+        try:
+            timeout_seconds = float(timeout_text) if timeout_text else None
+        except ValueError:
+            timeout_seconds = None
         if timeout_seconds is None:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         else:

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -4366,6 +4366,11 @@ def _force_release_command(agent: str) -> str:
     )
 
 
+def _lock_timeout_exit(exc: TimeoutError) -> int:
+    print(json.dumps({"error_code": "LOCK_TIMEOUT", "error": str(exc)}, indent=2))
+    return 124
+
+
 def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
     """Claim the durable single-driver lease used during SessionStart."""
     try:
@@ -4378,6 +4383,8 @@ def cmd_claim_thread_lease(args: argparse.Namespace) -> int:
             now=utc_now(),
             starting_pid=args.starting_pid,
         )
+    except TimeoutError as exc:
+        return _lock_timeout_exit(exc)
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
         return 2
@@ -4438,6 +4445,8 @@ def cmd_release_thread_lease(args: argparse.Namespace) -> int:
             generation=args.generation,
             force=args.force,
         )
+    except TimeoutError as exc:
+        return _lock_timeout_exit(exc)
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
         return 2

--- a/tests/orchestration/task_family/test_rollover.py
+++ b/tests/orchestration/task_family/test_rollover.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import subprocess
 import time
@@ -251,6 +252,41 @@ def test_advisory_lock_blocks_a_second_process_until_release(tmp_path: Path) -> 
     stdout, stderr = child.communicate(timeout=5)
     assert child.returncode == 0, (stdout, stderr)
     assert acquired_path.read_text(encoding="utf-8") == "acquired"
+
+
+def test_advisory_lock_honors_hook_deadline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    lock_path = tmp_path / "lineage" / ".native-intent.lock"
+    ready_path = tmp_path / "child-ready"
+    code = (
+        "import sys,time\n"
+        "from pathlib import Path\n"
+        "from scripts.orchestration.task_family.storage import advisory_lock\n"
+        "lock_path, ready_path = map(Path, sys.argv[1:])\n"
+        "with advisory_lock(lock_path):\n"
+        "    ready_path.write_text('ready', encoding='utf-8')\n"
+        "    time.sleep(5)\n"
+    )
+    repo_root = Path(__file__).resolve().parents[3]
+    environment = os.environ.copy()
+    environment.pop("LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS", None)
+    child = subprocess.Popen(
+        [".venv/bin/python", "-c", code, str(lock_path), str(ready_path)],
+        cwd=repo_root,
+        env=environment,
+    )
+    deadline = time.monotonic() + 5
+    while not ready_path.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert ready_path.exists()
+    monkeypatch.setenv("LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS", "0.05")
+
+    try:
+        with pytest.raises(TimeoutError, match="waiting for local state lock"):
+            with advisory_lock(lock_path):
+                pass
+    finally:
+        child.terminate()
+        child.wait(timeout=5)
 
 
 def test_pristine_transition_supersession_is_durable_idempotent_and_blocks_old_create(tmp_path: Path) -> None:

--- a/tests/orchestration/task_family/test_rollover.py
+++ b/tests/orchestration/task_family/test_rollover.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import pytest
 
 from scripts.orchestration import task_identity
-from scripts.orchestration.task_family import codex_state, rollover
+from scripts.orchestration.task_family import codex_state, rollover, storage
 from scripts.orchestration.task_family.model import RelationType
 from scripts.orchestration.task_family.storage import TaskFamilyStorage, advisory_lock
 
@@ -287,6 +287,23 @@ def test_advisory_lock_honors_hook_deadline(tmp_path: Path, monkeypatch: pytest.
     finally:
         child.terminate()
         child.wait(timeout=5)
+
+
+def test_advisory_lock_treats_malformed_hook_timeout_as_unbounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    flock_flags: list[int] = []
+
+    def record_flock(_: int, flags: int) -> None:
+        flock_flags.append(flags)
+
+    monkeypatch.setenv("LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS", "not-a-number")
+    monkeypatch.setattr(storage.fcntl, "flock", record_flock)
+
+    with advisory_lock(tmp_path / "lineage" / ".native-intent.lock"):
+        pass
+
+    assert flock_flags == [storage.fcntl.LOCK_EX, storage.fcntl.LOCK_UN]
 
 
 def test_pristine_transition_supersession_is_durable_idempotent_and_blocks_old_create(tmp_path: Path) -> None:

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -1324,6 +1324,32 @@ def test_claim_thread_lease_command_reports_a_clear_double_launch_conflict(tmp_p
     assert "release-thread-lease" in payload["resolution"]
 
 
+def test_claim_thread_lease_command_reports_structured_lock_timeout(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+):
+    def raise_timeout(_: Path) -> None:
+        raise TimeoutError("timed out waiting for local state lock")
+
+    monkeypatch.setattr(th, "task_family_advisory_lock", raise_timeout)
+
+    assert th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "claim-thread-lease",
+            "--agent",
+            "claude-infra",
+            "--current-thread-id",
+            "session-under-lock",
+        ]
+    ) == 124
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "error_code": "LOCK_TIMEOUT",
+        "error": "timed out waiting for local state lock",
+    }
+
+
 def test_release_thread_lease_command_end_to_end(tmp_path: Path, capsys):
     """CLI-level: claim then release through the same subcommands a real hook would call."""
     repo_args = ["--repo-root", str(tmp_path)]

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -101,6 +101,7 @@ def init_repo(tmp_path: Path, *, bootstrap_sources: bool = False) -> tuple[Path,
             [
                 "start-codex.sh",
                 "start-codex-drive.sh",
+                "scripts/agent_runtime/bounded_command.py",
                 "scripts/lib/thread_rollover_link.sh",
                 "scripts/lib/deploy_extensions.sh",
                 "scripts/lib/handoff_identity.sh",

--- a/tests/test_hook_deadline_contract.py
+++ b/tests/test_hook_deadline_contract.py
@@ -56,6 +56,13 @@ def test_rollover_and_postcompact_commands_are_bounded() -> None:
         'THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS="$CLAMPED_BOUNDED_TIMEOUT_SECONDS"'
         in session_source
     )
+    assert "render_ambiguous_rollover_context" in session_source
+    assert "--format session-start 2>&1 || true" not in session_source
+    assert (
+        "ERROR: MULTIPLE live pending rollovers — do not cold-start; "
+        "bind one exact candidate."
+        in session_source
+    )
     assert 'run_bounded 3 "$ROLLOVER_PYTHON"' in session_source
     assert 'run_bounded 2 "$ROLLOVER_PYTHON"' in compact_source
     assert "_HOOK_SOURCE_ROOT" not in session_source

--- a/tests/test_hook_deadline_contract.py
+++ b/tests/test_hook_deadline_contract.py
@@ -49,3 +49,6 @@ def test_rollover_and_postcompact_commands_are_bounded() -> None:
     assert "THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS=3" in session_source
     assert 'run_bounded 3 "$ROLLOVER_PYTHON"' in session_source
     assert 'run_bounded 2 "$ROLLOVER_PYTHON"' in compact_source
+    assert "_HOOK_SOURCE_ROOT" not in session_source
+    assert "_HOOK_SOURCE_ROOT" not in compact_source
+    assert compact_source.count('[ ! -f "$BOUNDED_RUNNER" ]') == 1

--- a/tests/test_hook_deadline_contract.py
+++ b/tests/test_hook_deadline_contract.py
@@ -12,6 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CODEX_HOOKS = REPO_ROOT / "agents_extensions" / "codex" / "hooks.json"
 SESSION_SETUP = REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "session-setup.sh"
 POST_COMPACT = REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "post-compact.sh"
+ROLLOVER_LINK = REPO_ROOT / "scripts" / "lib" / "thread_rollover_link.sh"
 
 
 def test_bounded_command_terminates_a_slow_process() -> None:
@@ -49,6 +50,7 @@ def test_session_start_defers_optional_network_diagnostics() -> None:
 def test_rollover_and_postcompact_commands_are_bounded() -> None:
     session_source = SESSION_SETUP.read_text(encoding="utf-8")
     compact_source = POST_COMPACT.read_text(encoding="utf-8")
+    rollover_link_source = ROLLOVER_LINK.read_text(encoding="utf-8")
 
     assert "LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS=1" in session_source
     assert "THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS=3" in session_source
@@ -65,6 +67,8 @@ def test_rollover_and_postcompact_commands_are_bounded() -> None:
     )
     assert 'run_bounded 3 "$ROLLOVER_PYTHON"' in session_source
     assert 'run_bounded 2 "$ROLLOVER_PYTHON"' in compact_source
+    assert 'parser_runner=("${runner[@]}")' in rollover_link_source
+    assert '"${parser_runner[@]}" "$python_bin" -c' in rollover_link_source
     assert "_HOOK_SOURCE_ROOT" not in session_source
     assert "_HOOK_SOURCE_ROOT" not in compact_source
     assert compact_source.count('[ ! -f "$BOUNDED_RUNNER" ]') == 1

--- a/tests/test_hook_deadline_contract.py
+++ b/tests/test_hook_deadline_contract.py
@@ -1,0 +1,51 @@
+"""Deadlock-prevention contracts for synchronous lifecycle hooks."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from scripts.agent_runtime.bounded_command import TIMEOUT_EXIT_CODE, run
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CODEX_HOOKS = REPO_ROOT / "agents_extensions" / "codex" / "hooks.json"
+SESSION_SETUP = REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "session-setup.sh"
+POST_COMPACT = REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "post-compact.sh"
+
+
+def test_bounded_command_terminates_a_slow_process() -> None:
+    started = time.monotonic()
+
+    result = run(["/bin/bash", "-c", "sleep 5"], timeout_seconds=0.05)
+
+    assert result == TIMEOUT_EXIT_CODE
+    assert time.monotonic() - started < 1
+
+
+def test_session_start_has_a_hard_outer_budget() -> None:
+    manifest = json.loads(CODEX_HOOKS.read_text(encoding="utf-8"))
+    session_hook = manifest["hooks"]["SessionStart"][0]["hooks"][0]
+
+    assert session_hook["timeout"] == 15
+
+
+def test_session_start_defers_optional_network_diagnostics() -> None:
+    source = SESSION_SETUP.read_text(encoding="utf-8")
+
+    assert "gh issue list" not in source
+    assert "curl " not in source
+    assert "check_decisions.py" not in source
+    assert "check_adrs.py" not in source
+    assert "check_postmortems.py" not in source
+    assert "Orientation diagnostics:" in source
+
+
+def test_rollover_and_postcompact_commands_are_bounded() -> None:
+    session_source = SESSION_SETUP.read_text(encoding="utf-8")
+    compact_source = POST_COMPACT.read_text(encoding="utf-8")
+
+    assert "LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS=1" in session_source
+    assert "THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS=3" in session_source
+    assert 'run_bounded 3 "$ROLLOVER_PYTHON"' in session_source
+    assert 'run_bounded 2 "$ROLLOVER_PYTHON"' in compact_source

--- a/tests/test_hook_deadline_contract.py
+++ b/tests/test_hook_deadline_contract.py
@@ -31,7 +31,8 @@ def test_session_start_has_a_hard_outer_budget() -> None:
     source = SESSION_SETUP.read_text(encoding="utf-8")
     assert 'SESSION_START_BUDGET_SECONDS="${SESSION_START_BUDGET_SECONDS:-12}"' in source
     assert "remaining_seconds=$((SESSION_START_BUDGET_SECONDS - elapsed_seconds))" in source
-    assert 'if [ "$timeout_seconds" -gt "$remaining_seconds" ]' in source
+    assert 'clamp_bounded_timeout "$requested_timeout" || return $?' in source
+    assert 'if [ "$CLAMPED_BOUNDED_TIMEOUT_SECONDS" -gt "$remaining_seconds" ]' in source
 
 
 def test_session_start_defers_optional_network_diagnostics() -> None:
@@ -51,6 +52,10 @@ def test_rollover_and_postcompact_commands_are_bounded() -> None:
 
     assert "LEARN_UKRAINIAN_LOCK_TIMEOUT_SECONDS=1" in session_source
     assert "THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS=3" in session_source
+    assert (
+        'THREAD_ROLLOVER_COMMAND_TIMEOUT_SECONDS="$CLAMPED_BOUNDED_TIMEOUT_SECONDS"'
+        in session_source
+    )
     assert 'run_bounded 3 "$ROLLOVER_PYTHON"' in session_source
     assert 'run_bounded 2 "$ROLLOVER_PYTHON"' in compact_source
     assert "_HOOK_SOURCE_ROOT" not in session_source

--- a/tests/test_hook_deadline_contract.py
+++ b/tests/test_hook_deadline_contract.py
@@ -28,6 +28,10 @@ def test_session_start_has_a_hard_outer_budget() -> None:
     session_hook = manifest["hooks"]["SessionStart"][0]["hooks"][0]
 
     assert session_hook["timeout"] == 15
+    source = SESSION_SETUP.read_text(encoding="utf-8")
+    assert 'SESSION_START_BUDGET_SECONDS="${SESSION_START_BUDGET_SECONDS:-12}"' in source
+    assert "remaining_seconds=$((SESSION_START_BUDGET_SECONDS - elapsed_seconds))" in source
+    assert 'if [ "$timeout_seconds" -gt "$remaining_seconds" ]' in source
 
 
 def test_session_start_defers_optional_network_diagnostics() -> None:


### PR DESCRIPTION
Re-lands the fix round for the #5835 REQUEST CHANGES findings that were live on main after the early merge (predecessor session's queue item): run_bounded rc 124/127 must not render the DURABLE THREAD LEASE CONFLICT banner (wrongful force-release / double-drive vector), advisory-lock TimeoutError mislabel, unguarded float() env parse — plus the aggregate startup budget and deadline-runner test fixtures.

Branch is the original `codex/5831-session-start-bounds` with the r2 commits that never reached main (#5835 squash-merged before the round finished). Review routed to glm per the specifying-reviewer rule (Claude specified these fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)