### PR TITLE
fix(launchers): bash-3.2-safe empty-array expansion in rollover preflight

### DIFF
--- a/scripts/lib/thread_rollover_link.sh
+++ b/scripts/lib/thread_rollover_link.sh
@@ -109,8 +109,12 @@ resolve_codex_pending_rollover() {
     return 1
   fi
 
+  # ${arr[@]+...} guard: expanding an EMPTY array with "${arr[@]}" trips
+  # `set -u` on bash 3.2 (macOS /bin/bash) even though bash 4.4+ tolerates it —
+  # this line aborted every local run of the thread-restart e2e suite while CI
+  # (bash 5) stayed green.
   if ! parsed="$(
-    printf '%s' "$detect_output" | "${parser_runner[@]}" "$python_bin" -c '
+    printf '%s' "$detect_output" | ${parser_runner[@]+"${parser_runner[@]}"} "$python_bin" -c '
 import json
 import re
 import sys

--- a/tests/test_hook_deadline_contract.py
+++ b/tests/test_hook_deadline_contract.py
@@ -68,7 +68,9 @@ def test_rollover_and_postcompact_commands_are_bounded() -> None:
     assert 'run_bounded 3 "$ROLLOVER_PYTHON"' in session_source
     assert 'run_bounded 2 "$ROLLOVER_PYTHON"' in compact_source
     assert 'parser_runner=("${runner[@]}")' in rollover_link_source
-    assert '"${parser_runner[@]}" "$python_bin" -c' in rollover_link_source
+    # bash-3.2-safe guarded expansion (#5859): still the runner-wrapped, bounded
+    # parser invocation — the ${arr[@]+...} form only skips expansion when empty.
+    assert '${parser_runner[@]+"${parser_runner[@]}"} "$python_bin" -c' in rollover_link_source
     assert "_HOOK_SOURCE_ROOT" not in session_source
     assert "_HOOK_SOURCE_ROOT" not in compact_source
     assert compact_source.count('[ ! -f "$BOUNDED_RUNNER" ]') == 1


### PR DESCRIPTION
Every local (macOS bash 3.2) run of the thread-restart e2e suite failed at the rollover preflight: `parser_runner[@]: unbound variable` under `set -u` when no THREAD_ROLLOVER_COMMAND_RUNNER is configured — an empty-array expansion bash 4.4+ tolerates but 3.2 does not, so CI stayed green while local runs were dead. One-line `${arr[@]+...}` guard + sibling sweep (details in the commit).

Verified end-to-end: the two e2e tests that failed on main pass with the guard (`2 passed in 3.76s`) and fail without it; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)