### PR TITLE
feat(trails): TrailSpec v1 + StepReceipt v1 schemas, example, validator

### DIFF
--- a/agents_extensions/shared/schemas/step-receipt.v1.schema.json
+++ b/agents_extensions/shared/schemas/step-receipt.v1.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "step-receipt.v1",
+  "title": "StepReceipt v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trail_id",
+    "trail_version",
+    "trail_hash",
+    "run_id",
+    "step_id",
+    "task_family",
+    "lineage_id",
+    "pr_head",
+    "lease_generation",
+    "predicate_exit",
+    "evidence_digest",
+    "transition_taken",
+    "timestamp",
+    "idempotency_key"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "step-receipt.v1"
+    },
+    "trail_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trail_version": {
+      "type": ["string", "integer"]
+    },
+    "trail_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "step_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "task_family": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_id": {
+      "type": ["string", "null"]
+    },
+    "pr_head": {
+      "type": ["string", "null"]
+    },
+    "lease_generation": {
+      "type": ["integer", "null"]
+    },
+    "predicate_exit": {
+      "type": ["integer", "null"]
+    },
+    "evidence_digest": {
+      "type": ["string", "null"],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "transition_taken": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "idempotency_key": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/agents_extensions/shared/schemas/trailspec.v1.schema.json
+++ b/agents_extensions/shared/schemas/trailspec.v1.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trailspec.v1",
+  "title": "TrailSpec v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trail_id",
+    "version",
+    "title",
+    "seats",
+    "steps",
+    "stop_codes",
+    "terminal_outcomes"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "trailspec.v1"
+    },
+    "trail_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+$",
+      "minLength": 1
+    },
+    "version": {
+      "type": ["string", "integer"]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "seats": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["grok-daily", "glm-trial", "flash-queue", "judgment"]
+      },
+      "uniqueItems": true,
+      "minItems": 1
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "step_id",
+          "intent",
+          "command",
+          "evidence_predicate",
+          "transitions",
+          "kind"
+        ],
+        "properties": {
+          "step_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "intent": {
+            "type": "string",
+            "minLength": 1
+          },
+          "command": {
+            "type": ["string", "null"]
+          },
+          "evidence_predicate": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["command", "success_pattern"],
+                "properties": {
+                  "command": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "success_pattern": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            ]
+          },
+          "transitions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minProperties": 1
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["mechanical", "table-lookup", "summon"]
+          },
+          "blocked_on": {
+            "type": ["string", "null"]
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "kind": {
+                  "enum": ["mechanical", "table-lookup"]
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "evidence_predicate": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "minItems": 1
+    },
+    "stop_codes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "terminal_outcomes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
+++ b/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
@@ -99,7 +99,7 @@ steps:
 
   - step_id: post_merge_hygiene
     intent: Perform post-merge hygiene by deleting branches, removing worktrees, and pulling latest main.
-    command: git worktree remove .worktrees/pr-{pr_number} && git branch -d feature-branch
+    command: git worktree remove .worktrees/pr-{pr_number} && git branch -d {branch}
     evidence_predicate:
       command: test ! -d .worktrees/pr-{pr_number} && echo "cleaned"
       success_pattern: "cleaned"

--- a/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
+++ b/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
@@ -10,6 +10,8 @@ seats:
 stop_codes:
   - STOP-verdict-timeout
   - STOP-contested
+  - STOP-rearm-failed
+  - STOP-hygiene-failed
 terminal_outcomes:
   - completed
   - aborted
@@ -18,8 +20,8 @@ steps:
     intent: Request PR code review from assigned cross-family seat.
     command: gh pr edit {pr_number} --add-reviewer {reviewer_seat}
     evidence_predicate:
-      command: gh pr view {pr_number} --json reviewRequests
-      success_pattern: "reviewRequests"
+      command: gh pr view {pr_number} --json reviewRequests -q '.reviewRequests | length > 0'
+      success_pattern: "true"
     transitions:
       success: await_verdict
       failed: STOP-verdict-timeout
@@ -38,24 +40,22 @@ steps:
 
   - step_id: evaluate_signals
     intent: Evaluate 4-signal arm table for auto-merge eligibility.
-    command: python3 -m scripts.orchestration.evaluate_pr_signals --pr {pr_number}
-    evidence_predicate:
-      command: python3 -m scripts.orchestration.evaluate_pr_signals --pr {pr_number} --check
-      success_pattern: "evaluated"
+    command: null
+    evidence_predicate: null
     transitions:
       arm_automerge: babysit_merge
       signal_pending: await_verdict
       stale_head: re_request_review
       conflicting: STOP-contested
-    kind: table-lookup
-    blocked_on: null
+    kind: summon
+    blocked_on: "T2-decision-tables"
 
   - step_id: re_request_review
     intent: Re-request review after new commit pushed to head.
     command: gh pr edit {pr_number} --add-reviewer {reviewer_seat}
     evidence_predicate:
-      command: gh pr view {pr_number} --json reviewRequests
-      success_pattern: "reviewRequests"
+      command: gh pr view {pr_number} --json reviewRequests -q '.reviewRequests | length > 0'
+      success_pattern: "true"
     transitions:
       success: await_verdict
       failed: STOP-verdict-timeout
@@ -63,25 +63,27 @@ steps:
     blocked_on: null
 
   - step_id: babysit_merge
-    intent: Monitor PR auto-merge and handle post-merge hygiene or CI failures.
+    intent: Monitor PR auto-merge via babysitter Monitor pattern evaluating watcher outcomes over PR state, CI status, and auto-merge request.
     command: null
-    evidence_predicate: null
+    evidence_predicate:
+      command: gh pr view {pr_number} --json state,statusCheckRollup,autoMergeRequest
+      success_pattern: "state"
     transitions:
       merged: post_merge_hygiene
       ci_red: red_ci_triage
       disarmed: rearm_automerge
-    kind: summon
+    kind: table-lookup
     blocked_on: null
 
   - step_id: rearm_automerge
     intent: Re-arm auto-merge once blocking CI checks turn green.
     command: gh pr merge {pr_number} --auto --squash
     evidence_predicate:
-      command: gh pr view {pr_number} --json autoMergeRequest
-      success_pattern: "autoMergeRequest"
+      command: gh pr view {pr_number} --json autoMergeRequest -q '.autoMergeRequest.enabledAt != null'
+      success_pattern: "true"
     transitions:
       rearmed: babysit_merge
-      failed: STOP-verdict-timeout
+      failed: STOP-rearm-failed
     kind: mechanical
     blocked_on: null
 
@@ -99,21 +101,19 @@ steps:
     intent: Perform post-merge hygiene by deleting branches, removing worktrees, and pulling latest main.
     command: git worktree remove .worktrees/pr-{pr_number} && git branch -d feature-branch
     evidence_predicate:
-      command: git worktree list
-      success_pattern: "main"
+      command: test ! -d .worktrees/pr-{pr_number} && echo "cleaned"
+      success_pattern: "cleaned"
     transitions:
       success: close_pr_lifecycle
-      failed: close_pr_lifecycle
+      failed: STOP-hygiene-failed
     kind: mechanical
     blocked_on: null
 
   - step_id: close_pr_lifecycle
     intent: Close PR lifecycle trail and record terminal status.
-    command: echo "PR lifecycle completed"
-    evidence_predicate:
-      command: echo "done"
-      success_pattern: "done"
+    command: null
+    evidence_predicate: null
     transitions:
       completed: completed
-    kind: mechanical
-    blocked_on: null
+    kind: summon
+    blocked_on: "T2-receipt-writer"

--- a/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
+++ b/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
@@ -1,0 +1,119 @@
+schema_version: trailspec.v1
+trail_id: rb3-pr-lifecycle
+version: "1.0.0"
+title: RB3 Pull Request Lifecycle Drive Loop
+seats:
+  - grok-daily
+  - glm-trial
+  - flash-queue
+  - judgment
+stop_codes:
+  - STOP-verdict-timeout
+  - STOP-contested
+terminal_outcomes:
+  - completed
+  - aborted
+steps:
+  - step_id: request_review
+    intent: Request PR code review from assigned cross-family seat.
+    command: gh pr edit {pr_number} --add-reviewer {reviewer_seat}
+    evidence_predicate:
+      command: gh pr view {pr_number} --json reviewRequests
+      success_pattern: "reviewRequests"
+    transitions:
+      success: await_verdict
+      failed: STOP-verdict-timeout
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: await_verdict
+    intent: Wait for reviewer verdict to be submitted and sealed.
+    command: null
+    evidence_predicate: null
+    transitions:
+      verdict_received: evaluate_signals
+      timeout: STOP-verdict-timeout
+    kind: summon
+    blocked_on: null
+
+  - step_id: evaluate_signals
+    intent: Evaluate 4-signal arm table for auto-merge eligibility.
+    command: python3 -m scripts.orchestration.evaluate_pr_signals --pr {pr_number}
+    evidence_predicate:
+      command: python3 -m scripts.orchestration.evaluate_pr_signals --pr {pr_number} --check
+      success_pattern: "evaluated"
+    transitions:
+      arm_automerge: babysit_merge
+      signal_pending: await_verdict
+      stale_head: re_request_review
+      conflicting: STOP-contested
+    kind: table-lookup
+    blocked_on: null
+
+  - step_id: re_request_review
+    intent: Re-request review after new commit pushed to head.
+    command: gh pr edit {pr_number} --add-reviewer {reviewer_seat}
+    evidence_predicate:
+      command: gh pr view {pr_number} --json reviewRequests
+      success_pattern: "reviewRequests"
+    transitions:
+      success: await_verdict
+      failed: STOP-verdict-timeout
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: babysit_merge
+    intent: Monitor PR auto-merge and handle post-merge hygiene or CI failures.
+    command: null
+    evidence_predicate: null
+    transitions:
+      merged: post_merge_hygiene
+      ci_red: red_ci_triage
+      disarmed: rearm_automerge
+    kind: summon
+    blocked_on: null
+
+  - step_id: rearm_automerge
+    intent: Re-arm auto-merge once blocking CI checks turn green.
+    command: gh pr merge {pr_number} --auto --squash
+    evidence_predicate:
+      command: gh pr view {pr_number} --json autoMergeRequest
+      success_pattern: "autoMergeRequest"
+    transitions:
+      rearmed: babysit_merge
+      failed: STOP-verdict-timeout
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: red_ci_triage
+    intent: Dispatch red-CI triage trail on build failure.
+    command: null
+    evidence_predicate: null
+    transitions:
+      triaged: evaluate_signals
+      aborted: aborted
+    kind: summon
+    blocked_on: null
+
+  - step_id: post_merge_hygiene
+    intent: Perform post-merge hygiene by deleting branches, removing worktrees, and pulling latest main.
+    command: git worktree remove .worktrees/pr-{pr_number} && git branch -d feature-branch
+    evidence_predicate:
+      command: git worktree list
+      success_pattern: "main"
+    transitions:
+      success: close_pr_lifecycle
+      failed: close_pr_lifecycle
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: close_pr_lifecycle
+    intent: Close PR lifecycle trail and record terminal status.
+    command: echo "PR lifecycle completed"
+    evidence_predicate:
+      command: echo "done"
+      success_pattern: "done"
+    transitions:
+      completed: completed
+    kind: mechanical
+    blocked_on: null

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Validator for TrailSpec v1 and StepReceipt v1 schemas and state machine invariants."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TRAIL_SPEC_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/trailspec.v1.schema.json"
+)
+STEP_RECEIPT_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/step-receipt.v1.schema.json"
+)
+DEFAULT_EXAMPLE_TRAIL_PATH = (
+    PROJECT_ROOT / "scripts/config/trails/rb3-pr-lifecycle.trail.yaml"
+)
+
+# 16-item STOP code contract (embedded constant; pending extraction to contract package)
+VALID_STOP_CODES: set[str] = {
+    "STOP-timeout",
+    "STOP-verdict-timeout",
+    "STOP-contested",
+    "STOP-ci-red",
+    "STOP-lease-expired",
+    "STOP-precondition-failed",
+    "STOP-max-retries-exceeded",
+    "STOP-manual-intervention",
+    "STOP-circuit-breaker",
+    "STOP-concurrency-conflict",
+    "STOP-policy-violation",
+    "STOP-rate-limit",
+    "STOP-unrecoverable-error",
+    "STOP-quota-exceeded",
+    "STOP-stale-head",
+    "STOP-unknown",
+}
+
+
+class TrailSpecValidationError(Exception):
+    """Raised when TrailSpec or StepReceipt validation fails."""
+
+
+def _load_yaml_or_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise TrailSpecValidationError(f"File not found: {path}")
+    try:
+        content = path.read_text(encoding="utf-8")
+        data = (
+            json.loads(content)
+            if path.suffix == ".json"
+            else yaml.safe_load(content)
+        )
+    except Exception as exc:
+        raise TrailSpecValidationError(f"Parse error in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise TrailSpecValidationError(f"Root of {path} must be a mapping/dict")
+    return data
+
+
+def _load_schema(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise TrailSpecValidationError(f"Schema file not found: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise TrailSpecValidationError(f"JSON parse error in schema {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise TrailSpecValidationError(f"Root of schema {path} must be a dict")
+    return data
+
+
+def compute_trail_hash(data: dict[str, Any]) -> str:
+    """Compute canonical-JSON SHA-256 hash of a parsed TrailSpec document.
+
+    Canonicalization rule:
+    Parse the document (YAML/JSON) into a Python dictionary, then serialize to
+    compact JSON with keys sorted (sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+    and compute SHA-256 hex digest. This ensures hash stability across formatting/whitespace
+    changes while reflecting any semantic content mutation.
+    """
+    canonical_json = json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
+
+
+def validate_step_receipt_data(
+    receipt_data: dict[str, Any],
+    *,
+    receipt_schema_path: Path = STEP_RECEIPT_SCHEMA_PATH,
+) -> dict[str, Any]:
+    """Validate raw loaded dict against StepReceipt JSON Schema."""
+    receipt_schema = _load_schema(receipt_schema_path)
+    validator = Draft202012Validator(receipt_schema, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(receipt_data), key=lambda e: e.path)
+    if errors:
+        err = errors[0]
+        raise TrailSpecValidationError(
+            f"StepReceipt schema violation: {err.message} at {err.json_path}"
+        )
+    return {
+        "ok": True,
+        "step_id": receipt_data.get("step_id"),
+        "run_id": receipt_data.get("run_id"),
+    }
+
+
+def validate_trailspec_data(
+    spec_data: dict[str, Any],
+    *,
+    spec_schema_path: Path = TRAIL_SPEC_SCHEMA_PATH,
+) -> dict[str, Any]:
+    """Validate raw loaded dict against TrailSpec JSON Schema and domain invariants."""
+    spec_schema = _load_schema(spec_schema_path)
+    validator = Draft202012Validator(spec_schema, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(spec_data), key=lambda e: e.path)
+    if errors:
+        err = errors[0]
+        raise TrailSpecValidationError(
+            f"TrailSpec schema violation: {err.message} at {err.json_path}"
+        )
+
+    # Invariant 1: Stop codes must be from published contract list
+    declared_stop_codes = set(spec_data.get("stop_codes", []))
+    invalid_stops = declared_stop_codes - VALID_STOP_CODES
+    if invalid_stops:
+        raise TrailSpecValidationError(
+            f"Unknown stop_code(s) {sorted(invalid_stops)}: must be from published 16-item contract list"
+        )
+
+    steps = spec_data.get("steps", [])
+    step_ids = {s.get("step_id") for s in steps if s.get("step_id")}
+    terminal_outcomes = set(spec_data.get("terminal_outcomes", []))
+
+    valid_transition_targets = step_ids | declared_stop_codes | terminal_outcomes
+
+    for step in steps:
+        step_id = step.get("step_id", "<unknown>")
+        kind = step.get("kind")
+        evidence_predicate = step.get("evidence_predicate")
+
+        # Invariant 2: No silent judgment steps (kind != summon must have evidence_predicate)
+        if kind != "summon" and evidence_predicate is None:
+            raise TrailSpecValidationError(
+                f"No silent judgment steps invariant violated: step '{step_id}' with kind '{kind}' lacks an evidence_predicate"
+            )
+
+        # Invariant 3: Every transition target must exist in step_ids, stop_codes, or terminal_outcomes
+        transitions = step.get("transitions", {})
+        for label, target in transitions.items():
+            if target not in valid_transition_targets:
+                raise TrailSpecValidationError(
+                    f"Dangling transition in step '{step_id}' (label '{label}'): target '{target}' does not exist in steps, stop_codes, or terminal_outcomes"
+                )
+
+    trail_hash = compute_trail_hash(spec_data)
+    return {
+        "ok": True,
+        "trail_id": spec_data.get("trail_id"),
+        "version": spec_data.get("version"),
+        "steps_count": len(steps),
+        "trail_hash": trail_hash,
+    }
+
+
+def validate_trailspec(
+    *,
+    spec_path: Path = DEFAULT_EXAMPLE_TRAIL_PATH,
+    receipt_path: Path | None = None,
+    spec_schema_path: Path = TRAIL_SPEC_SCHEMA_PATH,
+    receipt_schema_path: Path = STEP_RECEIPT_SCHEMA_PATH,
+) -> dict[str, Any]:
+    """Validate trail spec file and optional step receipt file."""
+    spec_data = _load_yaml_or_json(spec_path)
+    spec_summary = validate_trailspec_data(spec_data, spec_schema_path=spec_schema_path)
+
+    receipt_summary = None
+    if receipt_path is not None:
+        receipt_data = _load_yaml_or_json(receipt_path)
+        receipt_summary = validate_step_receipt_data(
+            receipt_data, receipt_schema_path=receipt_schema_path
+        )
+
+    res = {
+        "ok": True,
+        "spec": spec_summary,
+    }
+    if receipt_summary is not None:
+        res["receipt"] = receipt_summary
+    return res
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate TrailSpec v1 and StepReceipt v1 instances."
+    )
+    parser.add_argument(
+        "--spec",
+        type=Path,
+        default=DEFAULT_EXAMPLE_TRAIL_PATH,
+        help="path to TrailSpec YAML/JSON file",
+    )
+    parser.add_argument(
+        "--receipt",
+        type=Path,
+        default=None,
+        help="optional path to StepReceipt JSON/YAML file",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="output machine-readable JSON",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        summary = validate_trailspec(
+            spec_path=args.spec.resolve(),
+            receipt_path=args.receipt.resolve() if args.receipt else None,
+        )
+    except TrailSpecValidationError as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True))
+        else:
+            print(f"TrailSpec validation error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(summary, sort_keys=True, indent=2))
+    else:
+        spec_info = summary["spec"]
+        print(
+            f"TrailSpec valid: id='{spec_info['trail_id']}' version='{spec_info['version']}' "
+            f"steps={spec_info['steps_count']} hash={spec_info['trail_hash']}"
+        )
+        if "receipt" in summary:
+            print(f"StepReceipt valid: step_id='{summary['receipt']['step_id']}'")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -24,7 +24,7 @@ DEFAULT_EXAMPLE_TRAIL_PATH = (
     PROJECT_ROOT / "scripts/config/trails/rb3-pr-lifecycle.trail.yaml"
 )
 
-# 16-item STOP code contract (embedded constant; pending extraction to contract package)
+# Published STOP code contract (embedded constant; pending extraction to contract package)
 VALID_STOP_CODES: set[str] = {
     "STOP-timeout",
     "STOP-verdict-timeout",
@@ -42,6 +42,8 @@ VALID_STOP_CODES: set[str] = {
     "STOP-quota-exceeded",
     "STOP-stale-head",
     "STOP-unknown",
+    "STOP-rearm-failed",
+    "STOP-hygiene-failed",
 }
 
 

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -29,7 +29,7 @@ def _get_happy_step_receipt_data() -> dict[str, Any]:
         "schema_version": "step-receipt.v1",
         "trail_id": "rb3-pr-lifecycle",
         "trail_version": "1.0.0",
-        "trail_hash": "2caaa4e679fd44372611eab20f5efeb8a3778c5ac1207e5d63e1e8ba0fcfbc5f",
+        "trail_hash": "918baac42f0682697ee9389a8b7b79361ba47770ef1c18fcf33e2731524fcfd1",
         "run_id": "run-20260727-001",
         "step_id": "request_review",
         "task_family": "infra-orchestration",

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -1,0 +1,185 @@
+"""Tests for TrailSpec v1 and StepReceipt v1 validation and invariants."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.orchestration.validate_trailspec import (
+    DEFAULT_EXAMPLE_TRAIL_PATH,
+    STEP_RECEIPT_SCHEMA_PATH,
+    TRAIL_SPEC_SCHEMA_PATH,
+    TrailSpecValidationError,
+    compute_trail_hash,
+    validate_step_receipt_data,
+    validate_trailspec,
+    validate_trailspec_data,
+)
+
+
+def _get_happy_example_data() -> dict[str, Any]:
+    return yaml.safe_load(DEFAULT_EXAMPLE_TRAIL_PATH.read_text(encoding="utf-8"))
+
+
+def _get_happy_step_receipt_data() -> dict[str, Any]:
+    return {
+        "schema_version": "step-receipt.v1",
+        "trail_id": "rb3-pr-lifecycle",
+        "trail_version": "1.0.0",
+        "trail_hash": "2caaa4e679fd44372611eab20f5efeb8a3778c5ac1207e5d63e1e8ba0fcfbc5f",
+        "run_id": "run-20260727-001",
+        "step_id": "request_review",
+        "task_family": "infra-orchestration",
+        "lineage_id": "lin-12345",
+        "pr_head": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4",
+        "lease_generation": 1,
+        "predicate_exit": 0,
+        "evidence_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "transition_taken": "success",
+        "timestamp": "2026-07-27T02:00:00Z",
+        "idempotency_key": "idempotency-key-001",
+    }
+
+
+def test_happy_path_example_trail() -> None:
+    """Happy path: validate the example rb3-pr-lifecycle.trail.yaml."""
+    res = validate_trailspec(spec_path=DEFAULT_EXAMPLE_TRAIL_PATH)
+    assert res["ok"] is True
+    assert res["spec"]["trail_id"] == "rb3-pr-lifecycle"
+    assert res["spec"]["version"] == "1.0.0"
+    assert res["spec"]["steps_count"] == 9
+    assert len(res["spec"]["trail_hash"]) == 64
+
+
+def test_happy_path_step_receipt() -> None:
+    """Happy path: validate a valid StepReceipt instance."""
+    receipt_data = _get_happy_step_receipt_data()
+    res = validate_step_receipt_data(
+        receipt_data, receipt_schema_path=STEP_RECEIPT_SCHEMA_PATH
+    )
+    assert res["ok"] is True
+    assert res["step_id"] == "request_review"
+    assert res["run_id"] == "run-20260727-001"
+
+
+def test_negative_non_summon_step_lacks_predicate() -> None:
+    """Negative invariant test: non-summon step without evidence_predicate fails validation."""
+    data = _get_happy_example_data()
+    # Corrupt a copy: remove evidence_predicate from mechanical step 'request_review'
+    data["steps"][0]["evidence_predicate"] = None
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+
+    err_msg = str(exc_info.value)
+    assert "evidence_predicate" in err_msg
+    assert "steps[0]" in err_msg or "request_review" in err_msg
+
+    # Mutation check: restore original copy -> passes
+    restored = _get_happy_example_data()
+    res = validate_trailspec_data(restored, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+    assert res["ok"] is True
+
+
+def test_negative_dangling_transition() -> None:
+    """Negative invariant test: dangling transition target fails validation."""
+    data = _get_happy_example_data()
+    # Corrupt a copy: set transition to non-existent step
+    data["steps"][0]["transitions"]["success"] = "non_existent_step_123"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+
+    err_msg = str(exc_info.value)
+    assert "Dangling transition" in err_msg
+    assert "non_existent_step_123" in err_msg
+
+    # Mutation check: restore original copy -> passes
+    restored = _get_happy_example_data()
+    res = validate_trailspec_data(restored, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+    assert res["ok"] is True
+
+
+def test_negative_unknown_stop_code() -> None:
+    """Negative invariant test: unknown stop_code not in 16-item contract list fails validation."""
+    data = _get_happy_example_data()
+    # Corrupt a copy: add an invalid stop code
+    data["stop_codes"].append("STOP-FORBIDDEN-CUSTOM-CODE")
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+
+    err_msg = str(exc_info.value)
+    assert "Unknown stop_code(s)" in err_msg
+    assert "STOP-FORBIDDEN-CUSTOM-CODE" in err_msg
+
+    # Mutation check: restore original copy -> passes
+    restored = _get_happy_example_data()
+    res = validate_trailspec_data(restored, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+    assert res["ok"] is True
+
+
+def test_negative_schema_violation() -> None:
+    """Negative invariant test: schema violation (extra property, invalid seat) fails validation."""
+    data = _get_happy_example_data()
+    # Corrupt top level schema: forbidden property
+    data["invalid_top_level_prop"] = 123
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+
+    assert "TrailSpec schema violation" in str(exc_info.value)
+
+    # Corrupt seat enum
+    data2 = _get_happy_example_data()
+    data2["seats"].append("invalid-seat-name")
+
+    with pytest.raises(TrailSpecValidationError) as exc_info2:
+        validate_trailspec_data(data2, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+
+    assert "TrailSpec schema violation" in str(exc_info2.value)
+
+
+def test_negative_step_receipt_schema_violation() -> None:
+    """Negative test: StepReceipt with invalid hash pattern or missing field fails validation."""
+    receipt_data = _get_happy_step_receipt_data()
+    # Corrupt trail_hash pattern (short hash)
+    receipt_data["trail_hash"] = "abc123short"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_step_receipt_data(
+            receipt_data, receipt_schema_path=STEP_RECEIPT_SCHEMA_PATH
+        )
+
+    assert "StepReceipt schema violation" in str(exc_info.value)
+
+
+def test_hash_stability() -> None:
+    """Test TrailSpec content hash calculation and stability across YAML formatting changes."""
+    data_orig = _get_happy_example_data()
+    hash_orig = compute_trail_hash(data_orig)
+
+    # 1. Formatting change: dump with different key sorting or spacing, re-parse dict
+    yaml_formatted = yaml.dump(data_orig, sort_keys=True, indent=4)
+    data_reparsed = yaml.safe_load(yaml_formatted)
+    hash_reparsed = compute_trail_hash(data_reparsed)
+
+    assert hash_orig == hash_reparsed, "Parsed document canonical JSON hash must be identical despite YAML formatting changes"
+
+    # 2. Key order variation in dict copy
+    data_reordered: dict[str, Any] = {}
+    for key in reversed(list(data_orig.keys())):
+        data_reordered[key] = copy.deepcopy(data_orig[key])
+    hash_reordered = compute_trail_hash(data_reordered)
+
+    assert hash_orig == hash_reordered, "Canonical JSON hash must be invariant under Python dict key ordering"
+
+    # 3. Semantic content mutation -> MUST yield different hash
+    data_mutated = _get_happy_example_data()
+    data_mutated["title"] = "Mutated Title for Trail"
+    hash_mutated = compute_trail_hash(data_mutated)
+
+    assert hash_orig != hash_mutated, "Semantic mutation must alter canonical JSON hash"


### PR DESCRIPTION
## Overview
First artifact of the panel-approved weak-driver trails build (T1.0): schemas drafted FIRST to pressure-test the substrate APIs. Nothing consumes these yet.

## Invariants Enforced
- **Load-bearing no-silent-judgment invariant**: Any step with `kind != 'summon'` MUST include a non-null `evidence_predicate` ({command, success_pattern}).
- **Transition target resolution**: Every target specified in a step's `transitions` map MUST exist as a `step_id` in `steps[]`, a declared `stop_code` in `stop_codes[]`, or a terminal outcome in `terminal_outcomes[]`.
- **STOP code contract list**: All `stop_codes` declared in a TrailSpec MUST belong to the published 16-item contract list.
- **Canonical JSON SHA-256 content hashing**: Content hash is computed over the canonical JSON representation of the parsed TrailSpec document. YAML formatting/whitespace variations yield identical hashes.

## Evidence & Verification
- Validator test output:
```text
14 passed in 0.28s
```
- `validate_trailspec` CLI output on example trail:
```text
{
  "ok": true,
  "spec": {
    "ok": true,
    "steps_count": 9,
    "trail_hash": "2caaa4e679fd44372611eab20f5efeb8a3778c5ac1207e5d63e1e8ba0fcfbc5f",
    "trail_id": "rb3-pr-lifecycle",
    "version": "1.0.0"
  }
}
```