### PR TITLE
fix(bridge): ask replies stay unread for the requester (#5773)

### DIFF
--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -322,7 +322,6 @@ def process_for_agy(
         from_model=actual_model,
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_reply(message_id, reply_id)
     return response
 
@@ -385,7 +384,7 @@ def _extract_target_model(msg: dict) -> str | None:
 def _handle_agy_error(msg: dict, message_id: int, reason: str) -> None:
     """Record an Agy failure as a response message and acknowledge."""
     print(f"\n❌ Agy error for message #{message_id}: {reason}")
-    reply_id = send_message(
+    send_message(
         content=f"[Agy error] {reason}",
         task_id=msg["task_id"],
         msg_type="error",
@@ -393,7 +392,6 @@ def _handle_agy_error(msg: dict, message_id: int, reason: str) -> None:
         to_llm=msg["from"],
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_failure(
         message_id,
         reason,

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -288,12 +288,11 @@ def _run_claude_sync_via_runtime(
         _response_sent = True
 
         acknowledge(message_id)
-        acknowledge(reply_id)
         record_ask_reply(message_id, reply_id)
 
     except RateLimitedError as exc:
         print(f"\n⏳ Claude rate limited: {exc}")
-        err_id = send_message(
+        send_message(
             content=f"[Bridge Error] Claude rate limited: {exc}",
             task_id=msg['task_id'], msg_type="error",
             from_llm="claude", to_llm=msg['from'],
@@ -301,12 +300,11 @@ def _run_claude_sync_via_runtime(
         )
         _response_sent = True
         acknowledge(message_id)
-        acknowledge(err_id)
         record_ask_failure(message_id, str(exc))
     except (AgentStalledError, AgentTimeoutError) as exc:
         timeout_mins = timeout_val // 60
         print(f"\n❌ Claude CLI timed out ({timeout_mins} min sync limit): {exc}")
-        err_id = send_message(
+        send_message(
             content=(
                 f"[Bridge Error] Claude CLI timed out after {timeout_mins} minutes. "
                 f"({type(exc).__name__}: {exc}). Consider using --async for long tasks."
@@ -317,11 +315,10 @@ def _run_claude_sync_via_runtime(
         )
         _response_sent = True
         acknowledge(message_id)
-        acknowledge(err_id)
         record_ask_failure(message_id, str(exc), timed_out=True)
     except AgentUnavailableError:
         print("❌ claude CLI not found. Is it installed?")
-        err_id = send_message(
+        send_message(
             content="[Bridge Error] Claude CLI not found on system",
             task_id=msg['task_id'], msg_type="error",
             from_llm="claude", to_llm=msg['from'],
@@ -329,10 +326,9 @@ def _run_claude_sync_via_runtime(
         )
         _response_sent = True
         acknowledge(message_id)  # Must ack incoming msg to prevent stuck queue
-        acknowledge(err_id)
         record_ask_failure(message_id, "Claude CLI not found")
     except ReviewWorktreeError as exc:
-        err_id = send_message(
+        send_message(
             content=f"[Bridge Error] Claude review checkout failed: {exc}",
             task_id=msg['task_id'], msg_type="error",
             from_llm="claude", to_llm=msg['from'],
@@ -340,7 +336,6 @@ def _run_claude_sync_via_runtime(
         )
         _response_sent = True
         acknowledge(message_id)
-        acknowledge(err_id)
         record_ask_failure(message_id, str(exc))
     finally:
         if not _response_sent:
@@ -484,13 +479,12 @@ def _handle_claude_error(msg, message_id, stderr):
     print(f"\n❌ Claude CLI error: {error_msg[:500]}")
     sys.stdout.flush()
 
-    err_id = send_message(
+    send_message(
         content=f"[Bridge Error] Claude CLI failed:\n{error_msg[:500]}",
         task_id=msg['task_id'], msg_type="error",
         from_llm="claude", to_llm=msg['from'], from_model="claude-bridge-error"
     )
     acknowledge(message_id)
-    acknowledge(err_id)
     record_ask_failure(message_id, error_msg)
     return True
 
@@ -498,13 +492,12 @@ def _handle_claude_error(msg, message_id, stderr):
 def _send_claude_fallback_error(msg, message_id):
     """Send fallback error when Claude process fails without sending a response."""
     try:
-        err_id = send_message(
+        send_message(
             content=f"[Bridge Error] Claude process failed unexpectedly for message #{message_id}. Check logs.",
             task_id=msg['task_id'], msg_type="error",
             from_llm="claude", to_llm=msg['from'], from_model="claude-bridge-error"
         )
         acknowledge(message_id)
-        acknowledge(err_id)
         record_ask_failure(message_id, "Claude process failed unexpectedly")
     except Exception:
         pass

--- a/scripts/ai_agent_bridge/_codex.py
+++ b/scripts/ai_agent_bridge/_codex.py
@@ -409,7 +409,6 @@ def process_for_codex(message_id: int, new_session: bool = False, no_timeout: bo
         from_model=actual_model,
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_reply(message_id, reply_id)
 
 
@@ -471,7 +470,7 @@ def _extract_effort(msg: dict) -> str | None:
 def _handle_codex_error(msg: dict, message_id: int, error_msg: str) -> None:
     """Send bridge error back to sender."""
     print(f"\n❌ Codex CLI error: {error_msg[:500]}")
-    err_id = send_message(
+    send_message(
         content=f"[Bridge Error] Codex CLI failed:\n{error_msg[:500]}",
         task_id=msg["task_id"],
         msg_type="error",
@@ -480,7 +479,6 @@ def _handle_codex_error(msg: dict, message_id: int, error_msg: str) -> None:
         from_model="codex-bridge-error",
     )
     acknowledge(message_id)
-    acknowledge(err_id)
     record_ask_failure(
         message_id,
         error_msg,
@@ -492,7 +490,7 @@ def _handle_codex_rate_limited(msg: dict, message_id: int, reason: str) -> None:
     """Defer a rate-limited message without acknowledging the inbound row."""
     print(f"\n⛔ Codex rate limited - message {message_id} deferred")
     print(f"   Reason: {reason}")
-    err_id = send_message(
+    send_message(
         content=(
             "[Codex rate limited] Usage limit hit.\n"
             f"Reason: {reason}\n\n"
@@ -506,7 +504,6 @@ def _handle_codex_rate_limited(msg: dict, message_id: int, reason: str) -> None:
         to_llm=msg["from"],
         from_model="codex-bridge-rate-limited",
     )
-    acknowledge(err_id)
     record_ask_failure(message_id, reason)
 
 

--- a/scripts/ai_agent_bridge/_cursor.py
+++ b/scripts/ai_agent_bridge/_cursor.py
@@ -100,7 +100,6 @@ def ask_cursor(
         to_model=from_model,
     )
     acknowledge(msg_id)
-    acknowledge(reply_id)
     record_ask_reply(msg_id, reply_id)
     return msg_id
 
@@ -140,7 +139,6 @@ def process_for_cursor(message_id: int, *, no_timeout: bool = False) -> None:
         to_model=ask_sender_model(msg),
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_reply(message_id, reply_id)
 
 

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -598,26 +598,20 @@ def _route_gemini_response(msg, message_id, model, response, stdout_only, output
             sys.stdout.write("\n")
         sys.stdout.flush()
 
-        # Route reply back to the actual sender, not always to claude
         reply_to = msg.get("from", "claude")
         summary = f"[stdout-only] Gemini finished. {len(response)} chars output to stdout."
-        reply_id = send_message(
+        send_message(
             content=summary, task_id=msg['task_id'], msg_type="response",
             from_llm="gemini", to_llm=reply_to, from_model=model, to_model=None,
             quiet=stdout_only
         )
-        acknowledge(reply_id, quiet=stdout_only)
-        if not stdout_only:
-            print(f"   Auto-acknowledged reply #{reply_id} (stdout delivery — no inbox accumulation)")
     else:
         # Route reply back to the actual sender, not always to claude
         reply_to = msg.get("from", "claude")
-        reply_id = send_message(
+        send_message(
             content=response, task_id=msg['task_id'], msg_type="response",
             from_llm="gemini", to_llm=reply_to, from_model=model, to_model=None
         )
-        acknowledge(reply_id)
-        print(f"   Auto-acknowledged reply #{reply_id} (stdout delivery — no inbox accumulation)")
         if not skip_github:
             _post_review_to_github(msg['task_id'], response, model)
 
@@ -627,12 +621,11 @@ def _send_gemini_error(msg, message_id):
     try:
         # Route error back to the actual sender, not always to claude
         reply_to = msg.get("from", "claude")
-        err_id = send_message(
+        send_message(
             content=f"[Bridge Error] Gemini process failed for message #{message_id}. Check logs.",
             task_id=msg['task_id'], msg_type="error",
             from_llm="gemini", to_llm=reply_to, from_model="gemini-bridge-error"
         )
         acknowledge(message_id)
-        acknowledge(err_id)
     except Exception:
         pass

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -250,7 +250,6 @@ def process_for_grok_build(
         from_model=actual_model,
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_reply(message_id, reply_id)
 
 
@@ -348,7 +347,7 @@ Standing rules for bridge Q&A:
 def _handle_grok_build_error(msg: dict, message_id: int, reason: str) -> None:
     """Record a Grok Build failure as a response message and acknowledge."""
     print(f"\nGrok Build error for message #{message_id}: {reason}")
-    reply_id = send_message(
+    send_message(
         content=f"[Grok Build error] {reason}",
         task_id=msg["task_id"],
         msg_type="error",
@@ -356,7 +355,6 @@ def _handle_grok_build_error(msg: dict, message_id: int, reason: str) -> None:
         to_llm=msg["from"],
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_failure(
         message_id,
         reason,

--- a/scripts/ai_agent_bridge/_hermes.py
+++ b/scripts/ai_agent_bridge/_hermes.py
@@ -150,7 +150,6 @@ def ask_hermes(
         to_model=from_model,
     )
     acknowledge(msg_id)
-    acknowledge(reply_id)
     record_ask_reply(msg_id, reply_id)
     return msg_id
 
@@ -208,7 +207,6 @@ def process_for_hermes(message_id: int, *, no_timeout: bool = False) -> None:
         to_model=ask_sender_model(msg),
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_reply(message_id, reply_id)
 
 

--- a/scripts/ai_agent_bridge/_kimi.py
+++ b/scripts/ai_agent_bridge/_kimi.py
@@ -134,7 +134,6 @@ def process_for_kimi(
         data=provenance_data, from_model=actual_model,
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_reply(message_id, reply_id)
 
 
@@ -184,10 +183,9 @@ def _build_kimi_prompt(
 
 def _handle_kimi_error(msg: dict, message_id: int, reason: str) -> None:
     """Persist a terminal Kimi failure and unblock the original ask."""
-    reply_id = send_message(
+    send_message(
         content=f"[Kimi error] {reason}", task_id=msg["task_id"], msg_type="error",
         from_llm="kimi", to_llm=msg["from"],
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_failure(message_id, reason, timed_out="timeout" in reason.lower() or "stalled" in reason.lower())

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -253,7 +253,6 @@ def ask_opencode(
         data=provenance_data, from_model=actual_model, to_model=from_model,
     )
     acknowledge(msg_id)
-    acknowledge(reply_id)
     record_ask_reply(msg_id, reply_id)
     return msg_id
 
@@ -339,7 +338,6 @@ def ask_pool(
         data=provenance_data, from_model=actual_model, to_model=from_model,
     )
     acknowledge(msg_id)
-    acknowledge(reply_id)
     record_ask_reply(msg_id, reply_id)
     return msg_id
 
@@ -450,7 +448,6 @@ def ask_glm(
         data=provenance_data, from_model=actual_model, to_model=from_model,
     )
     acknowledge(msg_id)
-    acknowledge(reply_id)
     record_ask_reply(msg_id, reply_id)
     return msg_id
 
@@ -547,7 +544,6 @@ def ask_gemma(
         data=provenance_data, from_model=actual_model, to_model=from_model,
     )
     acknowledge(msg_id)
-    acknowledge(reply_id)
     record_ask_reply(msg_id, reply_id)
     return msg_id
 
@@ -628,7 +624,6 @@ def process_for_opencode(
         data=provenance_data, from_model=actual_model, to_model=ask_sender_model(msg),
     )
     acknowledge(message_id)
-    acknowledge(reply_id)
     record_ask_reply(message_id, reply_id)
 
 

--- a/scripts/migrate/migrate_audit_review_paths.py
+++ b/scripts/migrate/migrate_audit_review_paths.py
@@ -29,10 +29,11 @@ from slug_utils import to_bare_slug
 CURRICULUM_DIR = Path(__file__).parent.parent.parent / "curriculum" / "l2-uk-en"
 
 # All track directories to process
-TRACK_DIRS = [
-    d for d in CURRICULUM_DIR.iterdir()
-    if d.is_dir() and d.name not in ("plans", "__pycache__")
-]
+TRACK_DIRS = (
+    [d for d in CURRICULUM_DIR.iterdir() if d.is_dir() and d.name not in ("plans", "__pycache__")]
+    if CURRICULUM_DIR.exists()
+    else []
+)
 
 
 def check_batch_lock():
@@ -59,7 +60,7 @@ def move_reviews(track_dir: Path, dry_run: bool) -> list[str]:
 
         # Determine bare slug from the review filename
         name = f.name
-        slug_part = name[:-len("-llm-review.md")] if name.endswith("-llm-review.md") else name[:-len("-review.md")]
+        slug_part = name[: -len("-llm-review.md")] if name.endswith("-llm-review.md") else name[: -len("-review.md")]
 
         bare = to_bare_slug(slug_part)
         dest = review_dir / f"{bare}-review.md"
@@ -99,7 +100,7 @@ def rename_audit_reports(track_dir: Path, dry_run: bool) -> list[str]:
         if not f.name.endswith("-audit-report.md"):
             continue
 
-        slug_part = f.name[:-len("-audit-report.md")]
+        slug_part = f.name[: -len("-audit-report.md")]
         bare = to_bare_slug(slug_part)
         dest = audit_dir / f"{bare}-audit.md"
 

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -327,3 +327,88 @@ def test_message_plane_import_error_fail_open(bridge_db, monkeypatch, tmp_path):
     reply_id = _reply_for(message_id)
     assert lifecycle.record_ask_reply(message_id, reply_id) is True
     assert _status(message_id) == f"replied:{reply_id}"
+
+
+def test_ask_reply_remains_unacked_for_requester(bridge_db, monkeypatch):
+    """Ask reply message must remain unacknowledged (acknowledged=0) for the requester (#5773)."""
+    ask_id = send_message(
+        "Please review this PR",
+        task_id="task-5773",
+        msg_type="query",
+        from_llm="codex",
+        to_llm="claude",
+        quiet=True,
+    )
+    lifecycle.register_ask(ask_id)
+
+    mock_result = Mock(
+        ok=True,
+        response="VERDICT: APPROVED\n\nLooks good.",
+        model="claude-sonnet-5",
+        effort=None,
+    )
+    monkeypatch.setattr("ai_agent_bridge._claude.runtime_invoke", Mock(return_value=mock_result))
+
+    from ai_agent_bridge._claude import process_for_claude
+
+    process_for_claude(ask_id)
+
+    conn = get_db()
+    try:
+        # Outbound ask message TO claude IS acknowledged by worker
+        ask_row = conn.execute("SELECT acknowledged FROM messages WHERE id = ?", (ask_id,)).fetchone()
+        assert ask_row is not None
+        assert ask_row[0] == 1
+
+        # Inbound reply message TO codex IS NOT acknowledged (acknowledged=0)
+        reply_row = conn.execute(
+            "SELECT id, acknowledged, from_llm, to_llm FROM messages WHERE to_llm = 'codex' AND task_id = 'task-5773'"
+        ).fetchone()
+        assert reply_row is not None
+        assert reply_row[1] == 0
+        assert reply_row[2] == "claude"
+        assert reply_row[3] == "codex"
+    finally:
+        conn.close()
+
+
+def test_background_ask_reply_remains_unacked_for_requester(bridge_db, monkeypatch):
+    """Backgrounded ask reply message must remain unacknowledged (acknowledged=0) for requester (#5773)."""
+    ask_id = send_message(
+        "Background review request",
+        task_id="task-5773-bg",
+        msg_type="query",
+        from_llm="claude-infra",
+        to_llm="claude",
+        quiet=True,
+    )
+    lifecycle.register_ask(ask_id)
+
+    mock_result = Mock(
+        ok=True,
+        response="VERDICT: APPROVED\n\nBackground review complete.",
+        model="claude-sonnet-5",
+        effort=None,
+    )
+    monkeypatch.setattr("ai_agent_bridge._claude.runtime_invoke", Mock(return_value=mock_result))
+    monkeypatch.setattr(lifecycle, "_background_options", lambda *_args: {})
+
+    lifecycle.process_background_ask(ask_id, "claude")
+
+    conn = get_db()
+    try:
+        # Outbound ask message IS acknowledged by worker
+        ask_row = conn.execute("SELECT acknowledged FROM messages WHERE id = ?", (ask_id,)).fetchone()
+        assert ask_row is not None
+        assert ask_row[0] == 1
+
+        # Inbound reply message TO claude-infra IS NOT acknowledged
+        reply_row = conn.execute(
+            "SELECT id, acknowledged, from_llm, to_llm FROM messages WHERE to_llm = 'claude-infra' AND task_id = 'task-5773-bg'"
+        ).fetchone()
+        assert reply_row is not None
+        assert reply_row[1] == 0
+        assert reply_row[2] == "claude"
+        assert reply_row[3] == "claude-infra"
+    finally:
+        conn.close()

--- a/tests/test_codex_bridge.py
+++ b/tests/test_codex_bridge.py
@@ -93,9 +93,16 @@ def _task_messages(task_id: str) -> list[sqlite3.Row]:
 
 
 def test_detect_sender_codex():
-    env = {k: v for k, v in os.environ.items() if k not in ("GEMINI_SESSION", "GOOGLE_API_KEY", "CLAUDE_PROJECT_DIR", "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS")}
-    with patch.dict(os.environ, {**env, "CODEX_SESSION": "1"}, clear=True), \
-         patch("ai_agent_bridge._messaging.Path.exists", return_value=False):
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k
+        not in ("GEMINI_SESSION", "GOOGLE_API_KEY", "CLAUDE_PROJECT_DIR", "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS")
+    }
+    with (
+        patch.dict(os.environ, {**env, "CODEX_SESSION": "1"}, clear=True),
+        patch("ai_agent_bridge._messaging.Path.exists", return_value=False),
+    ):
         assert detect_sender() == "codex"
 
 
@@ -122,8 +129,7 @@ def test_handle_ask_codex_reads_stdin():
         no_timeout=False,
         chain=None,
     )
-    with patch("ai_agent_bridge._cli.ask_codex") as ask_codex_mock, \
-         patch("sys.stdin", io.StringIO("stdin prompt")):
+    with patch("ai_agent_bridge._cli.ask_codex") as ask_codex_mock, patch("sys.stdin", io.StringIO("stdin prompt")):
         _handle_ask_codex(args)
     ask_codex_mock.assert_called_once()
     assert ask_codex_mock.call_args[0][0] == "stdin prompt"
@@ -223,9 +229,7 @@ def test_ask_codex_chain_prefixes_issue_context_without_placeholders():
     with patch("ai_agent_bridge._codex.ask_codex", return_value=11) as ask_codex_mock:
         ask_codex_chain("Review and fix the issue.", ["1177"])
 
-    assert ask_codex_mock.call_args.args[0] == (
-        "GitHub issue #1177 (issue-1177).\n\nReview and fix the issue."
-    )
+    assert ask_codex_mock.call_args.args[0] == ("GitHub issue #1177 (issue-1177).\n\nReview and fix the issue.")
 
 
 def test_resolve_codex_bridge_timeout_defaults_to_normal_timeout():
@@ -324,8 +328,7 @@ def test_process_for_codex_invokes_runtime_with_bridge_shape(
     assert provenance["model_requested"] == "gpt-5.4"
     assert provenance["harness"] == "codex"
     assert mock_send_message.call_count == 1
-    assert mock_acknowledge.call_args_list[0].args == (7,)
-    assert mock_acknowledge.call_args_list[1].args == (99,)
+    mock_acknowledge.assert_called_once_with(7)
 
 
 @patch("ai_agent_bridge._codex.acknowledge")
@@ -399,8 +402,7 @@ def test_process_for_codex_uses_workspace_write_mode_and_never_resumes(
     assert provenance["model_requested"] == "gpt-5.4"
     assert provenance["harness"] == "codex"
     assert mock_send_message.call_count == 1
-    assert mock_acknowledge.call_args_list[0].args == (8,)
-    assert mock_acknowledge.call_args_list[1].args == (100,)
+    mock_acknowledge.assert_called_once_with(8)
 
 
 def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_path):
@@ -451,20 +453,22 @@ def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_
     monkeypatch.setattr("ai_agent_bridge._codex.set_session", lambda *_args: None)
     monkeypatch.setattr(
         "ai_agent_bridge._codex.agent_runner.invoke",
-        lambda *args, **kwargs: captured.update({"prompt": args[1], **kwargs})
-        or Result(
-            ok=True,
-            agent="codex",
-            model="gpt-5.6-terra",
-            mode="read-only",
-            response="reply",
-            stderr_excerpt=None,
-            duration_s=0.1,
-            session_id=None,
-            rate_limited=False,
-            stalled=False,
-            returncode=0,
-            usage_record={},
+        lambda *args, **kwargs: (
+            captured.update({"prompt": args[1], **kwargs})
+            or Result(
+                ok=True,
+                agent="codex",
+                model="gpt-5.6-terra",
+                mode="read-only",
+                response="reply",
+                stderr_excerpt=None,
+                duration_s=0.1,
+                session_id=None,
+                rate_limited=False,
+                stalled=False,
+                returncode=0,
+                usage_record={},
+            )
         ),
     )
 
@@ -485,14 +489,18 @@ def test_process_for_codex_short_circuits_when_no_headroom(bridge_db):
         quiet=True,
     )
 
-    with patch(
-        "ai_agent_bridge._codex.has_codex_headroom",
-        return_value=(False, "rate_limited 30s ago"),
-    ), patch(
-        "ai_agent_bridge._codex.build_codex_prompt",
-    ) as mock_prompt, patch(
-        "agent_runtime.runner.invoke",
-    ) as mock_invoke:
+    with (
+        patch(
+            "ai_agent_bridge._codex.has_codex_headroom",
+            return_value=(False, "rate_limited 30s ago"),
+        ),
+        patch(
+            "ai_agent_bridge._codex.build_codex_prompt",
+        ) as mock_prompt,
+        patch(
+            "agent_runtime.runner.invoke",
+        ) as mock_invoke,
+    ):
         process_for_codex(message_id)
 
     mock_prompt.assert_not_called()
@@ -507,7 +515,7 @@ def test_process_for_codex_short_circuits_when_no_headroom(bridge_db):
     assert reply[3] == "codex-bridge-rate-limited"
     assert reply[4] == "error"
     assert "remains in Codex's inbox" in reply[5]
-    assert int(reply[6]) == 1
+    assert int(reply[6]) == 0
 
 
 def test_rate_limit_error_defers_message(bridge_db):
@@ -521,15 +529,19 @@ def test_rate_limit_error_defers_message(bridge_db):
         quiet=True,
     )
 
-    with patch(
-        "ai_agent_bridge._codex.has_codex_headroom",
-        return_value=(True, ""),
-    ), patch(
-        "ai_agent_bridge._codex.build_codex_prompt",
-        return_value="bridge prompt",
-    ), patch(
-        "agent_runtime.runner.invoke",
-        side_effect=RateLimitedError("codex", "gpt-5.4", "quota exceeded"),
+    with (
+        patch(
+            "ai_agent_bridge._codex.has_codex_headroom",
+            return_value=(True, ""),
+        ),
+        patch(
+            "ai_agent_bridge._codex.build_codex_prompt",
+            return_value="bridge prompt",
+        ),
+        patch(
+            "agent_runtime.runner.invoke",
+            side_effect=RateLimitedError("codex", "gpt-5.4", "quota exceeded"),
+        ),
     ):
         process_for_codex(message_id)
 
@@ -540,7 +552,7 @@ def test_rate_limit_error_defers_message(bridge_db):
     reply = rows[1]
     assert reply[3] == "codex-bridge-rate-limited"
     assert "Sender should NOT retry manually." in reply[5]
-    assert int(reply[6]) == 1
+    assert int(reply[6]) == 0
 
 
 def test_other_errors_still_ack_inbound(bridge_db):
@@ -554,15 +566,19 @@ def test_other_errors_still_ack_inbound(bridge_db):
         quiet=True,
     )
 
-    with patch(
-        "ai_agent_bridge._codex.has_codex_headroom",
-        return_value=(True, ""),
-    ), patch(
-        "ai_agent_bridge._codex.build_codex_prompt",
-        return_value="bridge prompt",
-    ), patch(
-        "agent_runtime.runner.invoke",
-        side_effect=AgentStalledError("codex", 600, 601.0),
+    with (
+        patch(
+            "ai_agent_bridge._codex.has_codex_headroom",
+            return_value=(True, ""),
+        ),
+        patch(
+            "ai_agent_bridge._codex.build_codex_prompt",
+            return_value="bridge prompt",
+        ),
+        patch(
+            "agent_runtime.runner.invoke",
+            side_effect=AgentStalledError("codex", 600, 601.0),
+        ),
     ):
         process_for_codex(message_id)
 
@@ -573,7 +589,8 @@ def test_other_errors_still_ack_inbound(bridge_db):
     reply = rows[1]
     assert reply[3] == "codex-bridge-error"
     assert "[Bridge Error] Codex CLI failed:" in reply[5]
-    assert int(reply[6]) == 1
+    # Re-prove inbound-ack guarantee: inbound message_id was acked (1 above), error reply is NOT acked (0)
+    assert int(reply[6]) == 0
 
 
 def test_codex_usage_cli_reports_counts(capsys, tmp_path):

--- a/tests/test_coverage_misc.py
+++ b/tests/test_coverage_misc.py
@@ -25,11 +25,13 @@ sys.path.insert(0, str(SCRIPTS / "pipeline"))
 # 1. pipeline/screen.py
 # ============================================================================
 
+
 class TestFixExtraH1:
     """Test _fix_extra_h1 from pipeline/screen.py."""
 
     def _import(self):
         from pipeline.screen import _fix_extra_h1
+
         return _fix_extra_h1
 
     def test_single_h1_no_change(self):
@@ -84,6 +86,7 @@ class TestFixIpaBrackets:
 
     def _import(self):
         from pipeline.screen import _fix_ipa_brackets
+
         return _fix_ipa_brackets
 
     def test_no_ipa_no_change(self):
@@ -113,6 +116,7 @@ class TestFixH2Titles:
 
     def _import(self):
         from pipeline.screen import _fix_h2_titles
+
         return _fix_h2_titles
 
     def test_empty_outline_no_change(self):
@@ -166,6 +170,7 @@ class TestRunIpaScan:
 
     def _import(self):
         from pipeline.screen import _run_ipa_scan
+
         return _run_ipa_scan
 
     def test_no_ipa_empty(self):
@@ -208,12 +213,15 @@ class TestRunRussicismScan:
 
     def _import(self):
         from pipeline.screen import _run_russicism_scan
+
         return _run_russicism_scan
 
     def test_russicism_scan_formats_output(self):
         f = self._import()
-        with patch("audit.checks.russicism_detection.check_russicisms",
-                    return_value=[{"severity": "high", "issue": "кот", "fix": "кіт"}]):
+        with patch(
+            "audit.checks.russicism_detection.check_russicisms",
+            return_value=[{"severity": "high", "issue": "кот", "fix": "кіт"}],
+        ):
             issues = f("кот", "/fake/path")
             assert len(issues) == 1
             assert issues[0]["type"] == "RUSSIANISM"
@@ -230,11 +238,13 @@ class TestRunRussicismScan:
 # 2. ai_agent_bridge/_gemini.py
 # ============================================================================
 
+
 class TestWarnLongHandoff:
     """Test _warn_long_handoff."""
 
     def _import(self):
         from ai_agent_bridge._gemini import _warn_long_handoff
+
         return _warn_long_handoff
 
     def test_short_handoff_no_warning(self, capsys):
@@ -265,12 +275,12 @@ class TestHandleGeminiError:
 
     def _import(self):
         from ai_agent_bridge._gemini import _handle_gemini_error
+
         return _handle_gemini_error
 
     def test_model_error_returns_stop(self):
         f = self._import()
-        with patch("ai_agent_bridge._gemini._detect_model_error",
-                    return_value="Model not found"):
+        with patch("ai_agent_bridge._gemini._detect_model_error", return_value="Model not found"):
             result = f("model not found", "test-model", 0, 5, 30)
             assert result == "stop"
 
@@ -289,8 +299,7 @@ class TestHandleGeminiError:
 
     def test_quota_returns_retry(self):
         f = self._import()
-        with patch("ai_agent_bridge._gemini._detect_model_error", return_value=None), \
-             patch("time.sleep"):
+        with patch("ai_agent_bridge._gemini._detect_model_error", return_value=None), patch("time.sleep"):
             result = f("quota exceeded", "test-model", 0, 5, 30)
             assert result == "retry"
 
@@ -306,6 +315,7 @@ class TestExtractAndPrint:
 
     def test_extract_with_tags(self, capsys):
         from ai_agent_bridge._gemini import _extract_and_print
+
         # Call with no matching tags - should still work without crashing
         _extract_and_print("some response text", [])
         # Verify no crash occurred
@@ -319,8 +329,10 @@ class TestExtractAndPrint:
         with patch.dict("sys.modules", {"gemini_output": mock_gemini_output}):
             if "ai_agent_bridge._gemini" in sys.modules:
                 import importlib
+
                 importlib.reload(sys.modules["ai_agent_bridge._gemini"])
             from ai_agent_bridge._gemini import _extract_and_print
+
             _extract_and_print("some response", [])
             out = capsys.readouterr().out
             assert "No complete delimiter" in out
@@ -331,6 +343,7 @@ class TestPrintCompletionStatus:
 
     def _import(self):
         from ai_agent_bridge._gemini import _print_completion_status
+
         return _print_completion_status
 
     def test_with_output_path_existing(self, tmp_path, capsys):
@@ -361,6 +374,7 @@ class TestRouteGeminiResponse:
 
     def _import(self):
         from ai_agent_bridge._gemini import _route_gemini_response
+
         return _route_gemini_response
 
     def test_output_path_mode(self, capsys):
@@ -373,8 +387,10 @@ class TestRouteGeminiResponse:
     def test_stdout_only_mode(self):
         f = self._import()
         msg = {"task_id": "test-task"}
-        with patch("ai_agent_bridge._gemini.send_message", return_value=42) as sm, \
-             patch("ai_agent_bridge._gemini.acknowledge") as ack:
+        with (
+            patch("ai_agent_bridge._gemini.send_message", return_value=42) as sm,
+            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+        ):
             f(msg, 1, "model", "response", True, None, False)
             sm.assert_called_once()
             assert "stdout-only" in sm.call_args.kwargs.get("content", "")
@@ -382,18 +398,22 @@ class TestRouteGeminiResponse:
     def test_normal_mode_with_github(self):
         f = self._import()
         msg = {"task_id": "test-task"}
-        with patch("ai_agent_bridge._gemini.send_message", return_value=42), \
-             patch("ai_agent_bridge._gemini.acknowledge"), \
-             patch("ai_agent_bridge._gemini._post_review_to_github") as gh:
+        with (
+            patch("ai_agent_bridge._gemini.send_message", return_value=42),
+            patch("ai_agent_bridge._gemini.acknowledge"),
+            patch("ai_agent_bridge._gemini._post_review_to_github") as gh,
+        ):
             f(msg, 1, "model", "response", False, None, False)
             gh.assert_called_once()
 
     def test_normal_mode_skip_github(self):
         f = self._import()
         msg = {"task_id": "test-task"}
-        with patch("ai_agent_bridge._gemini.send_message", return_value=42), \
-             patch("ai_agent_bridge._gemini.acknowledge"), \
-             patch("ai_agent_bridge._gemini._post_review_to_github") as gh:
+        with (
+            patch("ai_agent_bridge._gemini.send_message", return_value=42),
+            patch("ai_agent_bridge._gemini.acknowledge"),
+            patch("ai_agent_bridge._gemini._post_review_to_github") as gh,
+        ):
             f(msg, 1, "model", "response", False, None, True)
             gh.assert_not_called()
 
@@ -403,16 +423,19 @@ class TestSendGeminiError:
 
     def _import(self):
         from ai_agent_bridge._gemini import _send_gemini_error
+
         return _send_gemini_error
 
     def test_sends_error_message(self):
         f = self._import()
         msg = {"task_id": "test-task"}
-        with patch("ai_agent_bridge._gemini.send_message", return_value=99) as sm, \
-             patch("ai_agent_bridge._gemini.acknowledge") as ack:
+        with (
+            patch("ai_agent_bridge._gemini.send_message", return_value=99) as sm,
+            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+        ):
             f(msg, 42)
             sm.assert_called_once()
-            assert ack.call_count == 2
+            ack.assert_called_once_with(42)
 
     def test_exception_suppressed(self):
         f = self._import()
@@ -426,28 +449,35 @@ class TestSendGeminiMessage:
 
     def _import(self):
         from ai_agent_bridge._gemini import _send_gemini_message
+
         return _send_gemini_message
 
     def test_output_path_mode(self):
         f = self._import()
-        with patch("ai_agent_bridge._gemini.send_to_gemini", return_value=10) as st, \
-             patch("ai_agent_bridge._gemini.acknowledge") as ack:
+        with (
+            patch("ai_agent_bridge._gemini.send_to_gemini", return_value=10) as st,
+            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+        ):
             result = f("content", "task-1", "query", None, None, None, "model", False, "/out")
             assert result == 10
             ack.assert_called_once()
 
     def test_stdout_only_mode(self):
         f = self._import()
-        with patch("ai_agent_bridge._gemini.send_to_gemini", return_value=11), \
-             patch("ai_agent_bridge._gemini.acknowledge") as ack:
+        with (
+            patch("ai_agent_bridge._gemini.send_to_gemini", return_value=11),
+            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+        ):
             result = f("content", "task-1", "query", None, None, None, "model", True, None)
             assert result == 11
             ack.assert_called_once()
 
     def test_normal_mode(self):
         f = self._import()
-        with patch("ai_agent_bridge._gemini.send_to_gemini", return_value=12), \
-             patch("ai_agent_bridge._gemini.acknowledge") as ack:
+        with (
+            patch("ai_agent_bridge._gemini.send_to_gemini", return_value=12),
+            patch("ai_agent_bridge._gemini.acknowledge") as ack,
+        ):
             result = f("content", "task-1", "query", None, None, None, "model", False, None)
             assert result == 12
             ack.assert_not_called()
@@ -458,6 +488,7 @@ class TestDetectModelError:
 
     def _import(self):
         from ai_agent_bridge._model import _detect_model_error
+
         return _detect_model_error
 
     def test_not_found(self):
@@ -486,9 +517,11 @@ class TestDetectModelError:
 # 4. vocab_extract_proper.py
 # ============================================================================
 
+
 class TestStressedToIpa:
     def _import(self):
         from vocab.vocab_extract_proper import stressed_to_ipa
+
         return stressed_to_ipa
 
     def test_empty_string(self):
@@ -520,6 +553,7 @@ class TestStressedToIpa:
 class TestExtractUkrainianText:
     def _import(self):
         from vocab.vocab_extract_proper import extract_ukrainian_text
+
         return extract_ukrainian_text
 
     def test_basic_extraction(self, tmp_path):
@@ -583,6 +617,7 @@ class TestExtractUkrainianText:
 class TestExtractModuleNumber:
     def _import(self):
         from vocab.vocab_extract_proper import extract_module_number
+
         return extract_module_number
 
     def test_numeric_prefix(self, tmp_path):
@@ -605,6 +640,7 @@ class TestExtractModuleNumber:
 class TestGetKnownLemmas:
     def _import(self):
         from vocab.vocab_extract_proper import get_known_lemmas
+
         return get_known_lemmas
 
     def test_nonexistent_db(self, tmp_path):
@@ -615,6 +651,7 @@ class TestGetKnownLemmas:
     def test_existing_db(self, tmp_path):
         f = self._import()
         import sqlite3
+
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(db_path)
         conn.execute("CREATE TABLE lemmas (uk TEXT)")
@@ -636,6 +673,7 @@ class TestGetKnownLemmas:
 class TestTokenizeAndLemmatize:
     def _import(self):
         from vocab.vocab_extract_proper import tokenize_and_lemmatize
+
         return tokenize_and_lemmatize
 
     def test_basic_tokenization(self):
@@ -696,6 +734,7 @@ class TestTokenizeAndLemmatize:
 class TestCreateVocabularyEntries:
     def _import(self):
         from vocab.vocab_extract_proper import create_vocabulary_entries
+
         return create_vocabulary_entries
 
     def test_basic_entry_creation(self):
@@ -734,6 +773,7 @@ class TestCreateVocabularyEntries:
 class TestProcessModule:
     def _import(self):
         from vocab.vocab_extract_proper import process_module
+
         return process_module
 
     def test_dry_run(self, tmp_path):
@@ -752,8 +792,10 @@ class TestProcessModule:
 
         mock_stressifier = MagicMock(return_value="те\u0301кст")
 
-        with patch("vocab.vocab_extract_proper.get_morph", return_value=mock_morph), \
-             patch("vocab.vocab_extract_proper.get_stressifier", return_value=mock_stressifier):
+        with (
+            patch("vocab.vocab_extract_proper.get_morph", return_value=mock_morph),
+            patch("vocab.vocab_extract_proper.get_stressifier", return_value=mock_stressifier),
+        ):
             stats = f(md, dry_run=True)
 
         assert stats["module"] == "test.md"
@@ -771,8 +813,10 @@ class TestProcessModule:
         mock_morph.parse.return_value = []
         mock_stressifier = MagicMock()
 
-        with patch("vocab.vocab_extract_proper.get_morph", return_value=mock_morph), \
-             patch("vocab.vocab_extract_proper.get_stressifier", return_value=mock_stressifier):
+        with (
+            patch("vocab.vocab_extract_proper.get_morph", return_value=mock_morph),
+            patch("vocab.vocab_extract_proper.get_stressifier", return_value=mock_stressifier),
+        ):
             stats = f(md, dry_run=True)
         # Can't easily check level from stats, but it shouldn't crash
 
@@ -781,9 +825,11 @@ class TestProcessModule:
 # 5. generate_ipa.py
 # ============================================================================
 
+
 class TestPostprocess:
     def _import(self):
         from generate_ipa import _postprocess
+
         return _postprocess
 
     def test_rule1_a_to_open_back(self):
@@ -792,7 +838,7 @@ class TestPostprocess:
 
     def test_rule2_nonsyllabic_i_to_j(self):
         f = self._import()
-        assert f("i\u032F") == "j"
+        assert f("i\u032f") == "j"
 
     def test_rule3_lax_u(self):
         f = self._import()
@@ -812,19 +858,19 @@ class TestPostprocess:
 
     def test_rule5_u_nonsyl_palatalized(self):
         f = self._import()
-        assert f("u\u032Fʲ") == "ʋʲ"
+        assert f("u\u032fʲ") == "ʋʲ"
 
     def test_rule6_u_nonsyl_before_stress(self):
         f = self._import()
-        assert f("u\u032Fˈ") == "ˈʋ"
+        assert f("u\u032fˈ") == "ˈʋ"
 
     def test_rule7_u_nonsyl_before_secondary_stress(self):
         f = self._import()
-        assert f("u\u032Fˌ") == "ˌʋ"
+        assert f("u\u032fˌ") == "ˌʋ"
 
     def test_rule8_u_nonsyl_before_vowel(self):
         f = self._import()
-        assert f("u\u032Fa") == "ʋa"
+        assert f("u\u032fa") == "ʋa"
 
     def test_passthrough(self):
         f = self._import()
@@ -834,6 +880,7 @@ class TestPostprocess:
 class TestGenerateIpa:
     def _import(self):
         from generate_ipa import generate_ipa
+
         return generate_ipa
 
     def test_empty_word(self):
@@ -848,8 +895,10 @@ class TestGenerateIpa:
 
     def test_stress_override(self):
         f = self._import()
-        with patch("generate_ipa._get_ipa_overrides", return_value={}), \
-             patch("generate_ipa._get_stress_overrides", return_value={"тест": "те\u0301ст"}):
+        with (
+            patch("generate_ipa._get_ipa_overrides", return_value={}),
+            patch("generate_ipa._get_stress_overrides", return_value={"тест": "те\u0301ст"}),
+        ):
             mock_ipa_uk = MagicMock()
             mock_ipa_uk.ipa.return_value = "tɛst"
             with patch.dict("sys.modules", {"ipa_uk": mock_ipa_uk}):
@@ -860,17 +909,21 @@ class TestGenerateIpa:
 
     def test_stressifier_failure(self):
         f = self._import()
-        with patch("generate_ipa._get_ipa_overrides", return_value={}), \
-             patch("generate_ipa._get_stress_overrides", return_value={}), \
-             patch("generate_ipa._get_stressifier") as mock_stress:
+        with (
+            patch("generate_ipa._get_ipa_overrides", return_value={}),
+            patch("generate_ipa._get_stress_overrides", return_value={}),
+            patch("generate_ipa._get_stressifier") as mock_stress,
+        ):
             mock_stress.return_value = MagicMock(side_effect=Exception("fail"))
             assert f("тест") is None
 
     def test_ipa_uk_failure(self):
         f = self._import()
-        with patch("generate_ipa._get_ipa_overrides", return_value={}), \
-             patch("generate_ipa._get_stress_overrides", return_value={}), \
-             patch("generate_ipa._get_stressifier") as mock_stress:
+        with (
+            patch("generate_ipa._get_ipa_overrides", return_value={}),
+            patch("generate_ipa._get_stress_overrides", return_value={}),
+            patch("generate_ipa._get_stressifier") as mock_stress,
+        ):
             mock_stress.return_value = MagicMock(return_value="тест")
             mock_ipa_uk = MagicMock()
             mock_ipa_uk.ipa.side_effect = Exception("fail")
@@ -879,9 +932,11 @@ class TestGenerateIpa:
 
     def test_ipa_uk_empty_result(self):
         f = self._import()
-        with patch("generate_ipa._get_ipa_overrides", return_value={}), \
-             patch("generate_ipa._get_stress_overrides", return_value={}), \
-             patch("generate_ipa._get_stressifier") as mock_stress:
+        with (
+            patch("generate_ipa._get_ipa_overrides", return_value={}),
+            patch("generate_ipa._get_stress_overrides", return_value={}),
+            patch("generate_ipa._get_stressifier") as mock_stress,
+        ):
             mock_stress.return_value = MagicMock(return_value="тест")
             mock_ipa_uk = MagicMock()
             mock_ipa_uk.ipa.return_value = ""
@@ -892,6 +947,7 @@ class TestGenerateIpa:
 class TestLoadOverrides:
     def _import(self):
         from generate_ipa import _load_overrides
+
         return _load_overrides
 
     def test_file_not_exists(self, tmp_path):
@@ -903,6 +959,7 @@ class TestLoadOverrides:
     def test_file_with_dict(self, tmp_path):
         f = self._import()
         import yaml
+
         data = {"word": "value"}
         (tmp_path / "test.yaml").write_text(yaml.dump(data))
         with patch("generate_ipa.DATA_DIR", tmp_path):
@@ -920,6 +977,7 @@ class TestLoadOverrides:
 class TestIsIpaContent:
     def _import(self):
         from generate_ipa import _is_ipa_content
+
         return _is_ipa_content
 
     def test_ipa_chars(self):
@@ -938,6 +996,7 @@ class TestIsIpaContent:
 class TestStressifyWord:
     def _import(self):
         from generate_ipa import _stressify_word
+
         return _stressify_word
 
     def test_single_letter(self):
@@ -955,6 +1014,7 @@ class TestStressifyWord:
 class TestStressifyPhrase:
     def _import(self):
         from generate_ipa import _stressify_phrase
+
         return _stressify_phrase
 
     def test_multi_word(self):
@@ -969,6 +1029,7 @@ class TestStressifyPhrase:
 class TestCheckEntryLine:
     def _import(self):
         from generate_ipa import _check_entry_line
+
         return _check_entry_line
 
     def test_lemma_first_line(self):
@@ -1006,6 +1067,7 @@ class TestCheckEntryLine:
 class TestRegenerateVocabIpa:
     def _import(self):
         from generate_ipa import regenerate_vocab_ipa
+
         return regenerate_vocab_ipa
 
     def test_no_changes(self, tmp_path):
@@ -1066,6 +1128,7 @@ class TestRegenerateVocabIpa:
 class TestReplaceProseIpa:
     def _import(self):
         from generate_ipa import replace_prose_ipa
+
         return replace_prose_ipa
 
     def test_no_ipa(self, tmp_path):
@@ -1108,6 +1171,7 @@ class TestReplaceProseIpa:
 class TestClassifyQuestion:
     def _import(self):
         from import_zno import classify_question
+
         return classify_question
 
     def test_nagolos(self):
@@ -1160,6 +1224,7 @@ class TestClassifyQuestion:
 class TestFilterUkrainianLanguage:
     def _import(self):
         from import_zno import filter_ukrainian_language
+
         return filter_ukrainian_language
 
     def test_filters_by_subject(self):
@@ -1187,6 +1252,7 @@ class TestFilterUkrainianLanguage:
 class TestClassifyAll:
     def _import(self):
         from import_zno import classify_all
+
         return classify_all
 
     def test_adds_fields(self):
@@ -1208,6 +1274,7 @@ class TestClassifyAll:
 class TestSaveLoadJsonl:
     def _import(self):
         from import_zno import load_jsonl, save_jsonl
+
         return save_jsonl, load_jsonl
 
     def test_roundtrip(self, tmp_path):
@@ -1234,6 +1301,7 @@ class TestSaveLoadJsonl:
 class TestConvertToActivity:
     def _import(self):
         from import_zno import convert_to_activity
+
         return convert_to_activity
 
     def test_single_correct_quiz(self):
@@ -1290,6 +1358,7 @@ class TestConvertToActivity:
 class TestPrintStats:
     def _import(self):
         from import_zno import print_stats
+
         return print_stats
 
     def test_basic_stats(self, capsys):
@@ -1311,9 +1380,11 @@ class TestPrintStats:
 # 7. migrate_audit_review_paths.py
 # ============================================================================
 
+
 class TestMoveReviews:
     def _import(self):
         from migrate.migrate_audit_review_paths import move_reviews
+
         return move_reviews
 
     def test_no_audit_dir(self, tmp_path):
@@ -1354,6 +1425,7 @@ class TestMoveReviews:
         dest = review_dir / "my-module-review.md"
         dest.write_text("old")
         import time
+
         time.sleep(0.01)
         src.write_text("new")
 
@@ -1372,6 +1444,7 @@ class TestMoveReviews:
         src = audit_dir / "my-module-review.md"
         src.write_text("old")
         import time
+
         time.sleep(0.01)
         dest.write_text("new")
 
@@ -1395,6 +1468,7 @@ class TestMoveReviews:
 class TestRenameAuditReports:
     def _import(self):
         from migrate.migrate_audit_review_paths import rename_audit_reports
+
         return rename_audit_reports
 
     def test_no_audit_dir(self, tmp_path):
@@ -1442,6 +1516,7 @@ class TestRenameAuditReports:
 class TestRenameAuditArtifacts:
     def _import(self):
         from migrate.migrate_audit_review_paths import rename_audit_artifacts
+
         return rename_audit_artifacts
 
     def test_no_audit_dir(self, tmp_path):
@@ -1489,6 +1564,7 @@ class TestRenameAuditArtifacts:
 class TestRenameStatusFiles:
     def _import(self):
         from migrate.migrate_audit_review_paths import rename_status_files
+
         return rename_status_files
 
     def test_no_status_dir(self, tmp_path):
@@ -1539,6 +1615,7 @@ class TestRenameStatusFiles:
 class TestUpdateStatusModuleField:
     def _import(self):
         from migrate.migrate_audit_review_paths import _update_status_module_field
+
         return _update_status_module_field
 
     def test_updates_field(self, tmp_path):
@@ -1568,6 +1645,7 @@ class TestUpdateStatusModuleField:
 class TestCheckBatchLock:
     def _import(self):
         from migrate.migrate_audit_review_paths import check_batch_lock
+
         return check_batch_lock
 
     def test_no_lock_passes(self, tmp_path):
@@ -1608,11 +1686,13 @@ class TestCheckBatchLock:
 # Additional edge case tests to boost coverage
 # ============================================================================
 
+
 class TestPipelineScreenMtimeCache:
     """Test the mtime caching logic in screen.py."""
 
     def test_deterministic_fix_mtimes_dict_exists(self):
         from pipeline.screen import _deterministic_fix_mtimes
+
         assert isinstance(_deterministic_fix_mtimes, dict)
 
 
@@ -1622,11 +1702,13 @@ class TestCefrMapping:
 
     def test_all_skills_have_mapping(self):
         from import_zno import CEFR_MAPPING, SKILL_PATTERNS
+
         for category, _ in SKILL_PATTERNS:
             assert category in CEFR_MAPPING, f"Missing CEFR mapping for {category}"
 
     def test_mapping_structure(self):
         from import_zno import CEFR_MAPPING
+
         for _cat, levels in CEFR_MAPPING.items():
             assert "min" in levels
             assert "max" in levels
@@ -1637,18 +1719,21 @@ class TestVocabExtractConstants:
 
     def test_pos_map_coverage(self):
         from vocab.vocab_extract_proper import POS_MAP
+
         assert "NOUN" in POS_MAP
         assert "VERB" in POS_MAP
         assert "ADJF" in POS_MAP
 
     def test_gender_map(self):
         from vocab.vocab_extract_proper import GENDER_MAP
+
         assert GENDER_MAP["masc"] == "m"
         assert GENDER_MAP["femn"] == "f"
         assert GENDER_MAP["neut"] == "n"
 
     def test_stopwords_not_empty(self):
         from vocab.vocab_extract_proper import STOPWORDS
+
         assert len(STOPWORDS) > 50
 
 
@@ -1657,10 +1742,12 @@ class TestGenerateIpaConstants:
 
     def test_stress_mark(self):
         from generate_ipa import STRESS_MARK
+
         assert STRESS_MARK == "\u0301"
 
     def test_ipa_vowels(self):
         from generate_ipa import IPA_VOWELS
+
         assert "a" in IPA_VOWELS
         assert "ɔ" in IPA_VOWELS
 
@@ -1670,22 +1757,27 @@ class TestSlugUtils:
 
     def test_numeric_prefix_stripped(self):
         from slug_utils import to_bare_slug
+
         assert to_bare_slug("01-my-module") == "my-module"
 
     def test_extension_stripped(self):
         from slug_utils import to_bare_slug
+
         assert to_bare_slug("01-my-module.md") == "my-module"
 
     def test_year_prefix_preserved(self):
         from slug_utils import to_bare_slug
+
         assert to_bare_slug("1991-referendum") == "1991-referendum"
 
     def test_no_prefix(self):
         from slug_utils import to_bare_slug
+
         assert to_bare_slug("my-module") == "my-module"
 
     def test_three_digit_prefix(self):
         from slug_utils import to_bare_slug
+
         assert to_bare_slug("140-syntez-viyna") == "syntez-viyna"
 
 
@@ -1695,6 +1787,7 @@ class TestExportByTopic:
 
     def _import(self):
         from import_zno import export_by_topic
+
         return export_by_topic
 
     def test_export_creates_files(self, tmp_path):
@@ -1738,26 +1831,32 @@ class TestValidateSchema:
 
     def _import(self):
         from import_zno import validate_schema
+
         return validate_schema
 
     def test_valid_schema(self, tmp_path, capsys):
         f = self._import()
         import yaml
+
         by_topic = tmp_path / "by_topic"
         by_topic.mkdir(parents=True)
-        data = [{
-            "type": "quiz",
-            "title": "Test",
-            "items": [{
-                "question": "Q?",
-                "options": [
-                    {"text": "A", "correct": True},
-                    {"text": "B", "correct": False},
-                    {"text": "C", "correct": False},
-                    {"text": "D", "correct": False},
+        data = [
+            {
+                "type": "quiz",
+                "title": "Test",
+                "items": [
+                    {
+                        "question": "Q?",
+                        "options": [
+                            {"text": "A", "correct": True},
+                            {"text": "B", "correct": False},
+                            {"text": "C", "correct": False},
+                            {"text": "D", "correct": False},
+                        ],
+                    }
                 ],
-            }],
-        }]
+            }
+        ]
         (by_topic / "test.yaml").write_text(yaml.dump(data))
         with patch("import_zno.DATA_DIR", tmp_path):
             f()
@@ -1767,15 +1866,20 @@ class TestValidateSchema:
     def test_invalid_schema(self, tmp_path, capsys):
         f = self._import()
         import yaml
+
         by_topic = tmp_path / "by_topic"
         by_topic.mkdir(parents=True)
-        data = [{
-            "type": "quiz",
-            "items": [{
-                "question": "",
-                "options": [{"text": "A", "correct": False}],
-            }],
-        }]
+        data = [
+            {
+                "type": "quiz",
+                "items": [
+                    {
+                        "question": "",
+                        "options": [{"text": "A", "correct": False}],
+                    }
+                ],
+            }
+        ]
         (by_topic / "bad.yaml").write_text(yaml.dump(data))
         with patch("import_zno.DATA_DIR", tmp_path):
             f()


### PR DESCRIPTION
Closes #5773

## Root Cause & Fix
In , all model harnesses (, , , , , , , , ) were calling  (and ) after sending a response to an incoming ask message.

Because  /  is an outbound message sent **TO** the requester, auto-acknowledging it marked the message as  immediately on the requester's behalf. As a result, the requester's inbox queries () never saw the reply.

Removed  and  across all harnesses so that:
1. The outbound ask message () IS still acknowledged by the target worker ().
2. The inbound reply/error message () remains UNACKNOWLEDGED () in the requester's inbox until the requester explicitly reads/acknowledges it.

## Verification
- Added  and  in .
- Mutation checked: re-enabling  in  fails the new guard test with .
- All 228 tests in  passed.
- I001 [*] Import block is un-sorted or un-formatted
    --> .mcp/servers/sources/server.py:1683:5
     |
1681 |       include_definitions = bool(args.get("include_definitions", False))
1682 |
1683 | /     from scripts.verification.check_ru_morph import check_russian_patterns_batch
1684 | |     from scripts.verification.vesum import verify_words
1685 | |     from wiki import sources_db as sdb
     | |______________________________________^
1686 |
1687 |       vesum_results = await asyncio.to_thread(verify_words, words)
     |
help: Organize imports

E701 Multiple statements on one line (colon)
  --> docs/reports/check_b2_plans.py:50:38
   |
48 |     # AC4: at least 2 of reading, listening, writing, discussion
49 |     sits = 0
50 |     if plan.get('reading_situations'): sits += 1
   |                                      ^
51 |     if plan.get('writing_tasks'): sits += 1
52 |     if plan.get('listening_situations'): sits += 1
   |

E701 Multiple statements on one line (colon)
  --> docs/reports/check_b2_plans.py:51:33
   |
49 |     sits = 0
50 |     if plan.get('reading_situations'): sits += 1
51 |     if plan.get('writing_tasks'): sits += 1
   |                                 ^
52 |     if plan.get('listening_situations'): sits += 1
53 |     if plan.get('discussion_topics'): sits += 1
   |

E701 Multiple statements on one line (colon)
  --> docs/reports/check_b2_plans.py:52:40
   |
50 |     if plan.get('reading_situations'): sits += 1
51 |     if plan.get('writing_tasks'): sits += 1
52 |     if plan.get('listening_situations'): sits += 1
   |                                        ^
53 |     if plan.get('discussion_topics'): sits += 1
   |

E701 Multiple statements on one line (colon)
  --> docs/reports/check_b2_plans.py:53:37
   |
51 |     if plan.get('writing_tasks'): sits += 1
52 |     if plan.get('listening_situations'): sits += 1
53 |     if plan.get('discussion_topics'): sits += 1
   |                                     ^
54 |
55 |     if sits < 2:
   |

SIM115 Use a context manager for opening files
 --> docs/reports/fix_mdx_frontmatter.py:6:27
  |
4 | import yaml
5 |
6 | manifest = yaml.safe_load(open("curriculum/l2-uk-en/curriculum.yaml", encoding="utf-8"))
  |                           ^^^^
7 |
8 | for level in ["a1", "a2", "b1", "b2", "c1", "c2"]:
  |

E701 Multiple statements on one line (colon)
  --> docs/reports/fix_mdx_frontmatter.py:12:27
   |
10 |     for mdx_path in mdx_files:
11 |         slug = os.path.basename(mdx_path).replace(".mdx", "")
12 |         if slug == "index": continue
   |                           ^
13 |
14 |         plan_path = f"curriculum/l2-uk-en/plans/{level}/{slug}.yaml"
   |

E722 Do not use bare `except`
  --> docs/reports/fix_mdx_frontmatter.py:22:17
   |
20 |                     if "title" in plan_data:
21 |                         title = plan_data["title"]
22 |                 except:
   |                 ^^^^^^
23 |                     pass
   |

E722 Do not use bare `except`
  --> docs/reports/inject_phases.py:49:17
   |
47 |                     plan = yaml.safe_load(pf)
48 |                     phase = plan.get("phase", "")
49 |                 except:
   |                 ^^^^^^
50 |                     pass
   |

E701 Multiple statements on one line (colon)
  --> docs/reports/inject_upper_phases.py:40:36
   |
38 | for level in ["b2", "c1", "c2"]:
39 |     plan_dir = f"curriculum/l2-uk-en/plans/{level}"
40 |     if not os.path.exists(plan_dir): continue
   |                                    ^
41 |     for f in os.listdir(plan_dir):
42 |         if not f.endswith(".yaml"): continue
   |

E701 Multiple statements on one line (colon)
  --> docs/reports/inject_upper_phases.py:42:35
   |
40 |     if not os.path.exists(plan_dir): continue
41 |     for f in os.listdir(plan_dir):
42 |         if not f.endswith(".yaml"): continue
   |                                   ^
43 |         slug = f.replace(".yaml", "")
44 |         if slug in mapping:
   |

E722 Do not use bare `except`
  --> docs/reports/inject_upper_phases.py:49:17
   |
47 |                 try:
48 |                     plan = yaml_handler.load(pf)
49 |                 except:
   |                 ^^^^^^
50 |                     continue
51 |             if plan.get("phase") != mapping[slug]:
   |

SIM102 Use a single `if` statement instead of nested `if` statements
  --> docs/reports/inject_upper_phases.py:73:5
   |
71 |           in_modules = True
72 |
73 | /     if current_level in ["b2", "c1", "c2"] and in_modules:
74 | |         if re.match(r"^\s+#\s*[A-Z][1-2]\.\w+", line):
   | |______________________________________________________^
75 |               continue  # Skip existing phase comment
   |
help: Combine `if` statements using `and`

E722 Do not use bare `except`
  --> docs/reports/inject_upper_phases.py:90:21
   |
88 |                         plan = yaml_handler.load(pf)
89 |                         phase = plan.get("phase", "")
90 |                     except:
   |                     ^^^^^^
91 |                         pass
   |

SIM102 Use a single `if` statement instead of nested `if` statements
  --> plans/fix_a2_final_exam.py:89:9
   |
87 |           acts = yaml.safe_load(f)
88 |       for act in acts:
89 | /         if act.get('id') == 'mark-the-words-a2-final-exam-9':
90 | |             if len(act['items']) == 4:
   | |______________________________________^
91 |                   act['items'].extend([
92 |                       "Студенти {прямують} до центру тестування.",
   |
help: Combine `if` statements using `and`

SIM102 Use a single `if` statement instead of nested `if` statements
  --> plans/fix_a2_final_exam_2.py:29:5
   |
28 |   for act in acts:
29 | /     if act.get('title') == 'Знайдіть дієслова' or act.get('type') == 'mark-the-words':
30 | |         if len(act.get('answers', [])) == 4:
   | |____________________________________________^
31 |               act['text'] += " Студент прямує додому. Він посміхається."
32 |               act['answers'].extend(["прямує", "посміхається"])
   |
help: Combine `if` statements using `and`

W291 Trailing whitespace
  --> plans/fix_b1_37_part2.py:16:448
   |
15 | …
16 | … вони нагадують кроки або сходинки, якими ви піднімаєтеся на гору. 
   |                                                                    ^
17 | …
   |
help: Remove trailing whitespace

F841 Local variable `text` is assigned to but never used
 --> plans/fix_b2_36.py:5:9
  |
3 |     filepath = 'curriculum/l2-uk-en/b2/word-formation-adjective-formation.md'
4 |     with open(filepath, encoding='utf-8') as f:
5 |         text = f.read()
  |         ^^^^
6 |
7 |     # We will generate a fully rewritten and expanded version of the file.
  |
help: Remove assignment to unused variable `text`

W291 Trailing whitespace
  --> plans/fix_b2_36.py:25:581
   |
24 | …
25 | … багатовікову історію, але водночас є дуже сучасним та динамічним. 
   |                                                                    ^
26 | …
27 | …
   |
help: Remove trailing whitespace

W291 Trailing whitespace
  --> plans/fix_b2_36.py:27:501
   |
25 | …всі сфери життя, перетворюючись на своєрідний бренд та знак якості. Воно містить багатовікову історію, але водночас є дуже сучасним т…
26 | …
27 | … понять є частиною великого культурного міфу, який об'єднує націю. 
   |                                                                    ^
28 | …
29 | …
   |
help: Remove trailing whitespace

W291 Trailing whitespace
  --> plans/fix_b2_36.py:36:336
   |
35 | …
36 | …но передає фактуру, походження та унікальні властивості матеріалу. 
   |                                                                    ^
37 | …
38 | …нологіями. Це одразу асоціюється з певною традицією ткацтва та європейськими стандартами. Подібно до цього, «Волинь» трансформується …
   |
help: Remove trailing whitespace

W291 Trailing whitespace
  --> plans/fix_b2_36.py:68:292
   |
66 | …належність до певної території, нації, соціальної групи або типу людей. Це фундаментальний механізм, який дозволяє нам створювати сло…
67 | …
68 | …ми чуємо щодня у новинах, на вулицях та в академічному середовищі. 
   |                                                                    ^
69 | …
70 | …
   |
help: Remove trailing whitespace

W291 Trailing whitespace
  --> plans/fix_b2_36.py:85:312
   |
84 | …
85 | …ий з таких переходів — це мутація приголосних **к**, **ч**, **ц**. 
   |                                                                    ^
86 | …
87 | …шим та більш плавним. Відсутність цієї мутації робила б мову занадто різкою та незручною для вимови.
   |
help: Remove trailing whitespace

W291 Trailing whitespace
   --> plans/fix_b2_36.py:143:113
    |
141 | 1.  **Студентський квиток** — офіційний документ, що підтверджує статус студента.
142 |     *   «Без пред'явлення **студентського** квитка вхід до бібліотеки платний.»
143 | 2.  **Батьківський комітет** (parental/father's committee) — орган самоврядування батьків у навчальних закладах. 
    |                                                                                                                 ^
144 |     *   «Учора **батьківський** комітет прийняв рішення про закупівлю нових парт для класу.»
145 | 3.  **Міська рада** — орган місцевого самоврядування в місті.
    |
help: Remove trailing whitespace

W291 Trailing whitespace
   --> plans/fix_b2_36.py:183:48
    |
182 | **Музичний vs. Музикальний**
183 | Ця пара є справжнім випробуванням для багатьох. 
    |                                                ^
184 | Прикметник **музичний** (musical - related to music) стосується музики як об'єкта, індустрії, дисципліни або інструмента. Він познача…
185 | *   «Вона закінчила престижну **музичну** школу по класу фортепіано.»
    |
help: Remove trailing whitespace

W291 Trailing whitespace
   --> plans/fix_b2_36.py:286:177
    |
284 | …групу складних прикметників, які описують зовнішність людини і мають другу частину **-лиций** (від слова «лице» — обличчя). Ці епіте…
285 | …
286 | …ладах та класичній літературі для опису ідеалу вроди та здоров'я. 
    |                                                                   ^
287 | …
288 | …
    |
help: Remove trailing whitespace

W291 Trailing whitespace
  --> plans/fix_b2_36_c.py:14:585
   |
12 | …
13 | …
14 | …іль». Замість «курс, який триває два місяці» — «двомісячний курс». 
   |                                                                    ^
15 | …
16 | …
   |
help: Remove trailing whitespace

W291 Trailing whitespace
  --> plans/fix_m68.py:23:242
   |
21 | …
22 | …
23 | …сидіти за столиком, обговорюючи останні новини та суспільні події. 
   |                                                                    ^
24 | …ємною частиною сучасної міської культури Західної України. Це відчуття зупиненого часу глибоко вкорінене в менталітеті львів'ян.
   |
help: Remove trailing whitespace

B007 Loop control variable `i` not used within loop body
  --> plans/patch_yaml.py:9:13
   |
 7 | for act in data:
 8 |     if act.get('type') == 'unjumble':
 9 |         for i, item in enumerate(act['items']):
   |             ^
10 |             # B1 unjumble targets 9-16 words
11 |             ans = item['answer']
   |
help: Rename unused `i` to `_i`

RUF100 [*] Unused `noqa` directive (non-enabled: `UP042`)
  --> scripts/api/hramatka_generator.py:20:32
   |
18 |     from enum import Enum
19 |
20 |     class StrEnum(str, Enum):  # noqa: UP042
   |                                ^^^^^^^^^^^^^
21 |         """Fallback StrEnum implementation for Python 3.10 support."""
   |
help: Remove unused `noqa` directive

I001 [*] Import block is un-sorted or un-formatted
    --> scripts/build/linear_pipeline.py:1631:9
     |
1630 |       try:
1631 | /         from scripts.verification import vesum as vesum_lookup
1632 | |         from wiki import sources_db
     | |___________________________________^
1633 |       except Exception as exc:
1634 |           return f"## Dictionary context\n\n*Dictionary context unavailable: {type(exc).__name__}: {exc}*"
     |
help: Organize imports

RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
   --> scripts/lexicon/runner/memory.py:227:28
    |
226 |               class Rusage(ctypes.Structure):
227 |                   _fields_ = [
    |  ____________________________^
228 | |                     ("ru_utime", ctypes.c_int64 * 2),
229 | |                     ("ru_stime", ctypes.c_int64 * 2),
230 | |                     ("ru_maxrss", ctypes.c_int64),
231 | |                 ]
    | |_________________^
232 |
233 |               getrusage = libc.getrusage
    |

RUF100 [*] Unused `noqa` directive (unused: `I001`)
  --> scripts/wiki/run_chunk_policy_bakeoff.py:78:41
   |
76 | # These imports follow sys.path manipulation above; ruff's import-order
77 | # autofix would break them, so they live below the sys.path.insert call.
78 | from rag.benchmark_embeddings import (  # noqa: I001
   |                                         ^^^^^^^^^^^^
79 |     LITERARY_SOURCE_FILES,
80 |     SAMPLE_SEED,
   |
help: Remove unused `noqa` directive

I001 [*] Import block is un-sorted or un-formatted
  --> tests/test_slovnyk_me_tool.py:14:5
   |
12 |   @pytest.fixture()
13 |   def slovnyk_sources_db(tmp_path, monkeypatch):
14 | /     from wiki.slovnyk_me import db_row_values, ensure_slovnyk_me_schema, normalize_word
15 | |
16 | |     from wiki import sources_db as sdb
   | |______________________________________^
17 |
18 |       db_path = tmp_path / "sources.db"
   |
help: Organize imports

I001 [*] Import block is un-sorted or un-formatted
  --> tests/test_sum20_official.py:17:1
   |
15 |       sys.path.insert(0, str(SCRIPTS_DIR))
16 |
17 | / from ingest import sum20_official_ingest
18 | | from rag.source_query import query_sum20 as source_query_sum20
19 | | from wiki.sum20_official import (
20 | |     FetchOutcome,
21 | |     Sum20ParseError,
22 | |     ensure_sum20_official_schema,
23 | |     fetch_sum20_wordid,
24 | |     parse_sum20_article,
25 | |     upsert_sum20_article,
26 | | )
27 | |
28 | | from wiki import sources_db
   | |___________________________^
29 |
30 |   FIXTURES = Path(__file__).parent / "fixtures" / "sum20_official"
   |
help: Organize imports

I001 [*] Import block is un-sorted or un-formatted
  --> tests/test_wiki_packet_dictionary_context.py:36:5
   |
35 |   def test_build_knowledge_packet_appends_dictionary_context(monkeypatch) -> None:
36 | /     from scripts.verification import vesum
37 | |     from wiki import sources_db
   | |_______________________________^
38 |
39 |       long_definition = " ".join(f"довге{i}" for i in range(80))
   |
help: Organize imports

I001 [*] Import block is un-sorted or un-formatted
   --> tests/wiki/test_chunking.py:378:5
    |
376 |       coordinating ``INDEX_MAX_LENGTH`` (or vice versa)."""
377 |
378 | /     from wiki.dense_rerank import CorpusUnit, _assert_units_fit_index_window
379 | |
380 | |     from wiki import chunking, dense_rerank
    | |___________________________________________^
381 |
382 |       # Synthesize a unit that's clearly over the cap (FakeTokenizer
    |
help: Organize imports

I001 [*] Import block is un-sorted or un-formatted
   --> tests/wiki/test_chunking.py:417:5
    |
415 |       them at index time would invalidate 137K+ vectors."""
416 |
417 | /     from wiki.dense_rerank import CorpusUnit, _assert_units_fit_index_window
418 | |
419 | |     from wiki import dense_rerank
    | |_________________________________^
420 |
421 |       too_long = " ".join(f"word{i}" for i in range(100))
    |
help: Organize imports

I001 [*] Import block is un-sorted or un-formatted
  --> tests/wiki/test_cold_encode.py:13:1
   |
11 |   sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
12 |
13 | / from wiki.embedding_manifest import EmbeddingManifest
14 | |
15 | | from wiki import cold_encode, dense_rerank
   | |__________________________________________^
   |
help: Organize imports

I001 [*] Import block is un-sorted or un-formatted
  --> tests/wiki/test_embedding_manifest.py:12:1
   |
10 |   sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
11 |
12 | / from wiki.embedding_manifest import (
13 | |     LEGACY_SHIPPED_CONFIG,
14 | |     EmbeddingManifest,
15 | |     EncoderConfig,
16 | |     UnitSpecInput,
17 | |     append_shard,
18 | |     filter_new_or_changed,
19 | | )
20 | | from wiki.embedding_manifest_schema import (
21 | |     LEGACY_CHUNK_POLICY_VERSION,
22 | |     LEGACY_INDEX_MAX_LENGTH,
23 | |     LEGACY_POOLING_MODE,
24 | | )
25 | |
26 | | from wiki import embedding_manifest
   | |___________________________________^
   |
help: Organize imports

I001 [*] Import block is un-sorted or un-formatted
  --> tests/wiki/test_multi_corpus_retrieval.py:13:1
   |
11 |   sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
12 |
13 | / from wiki.embedding_manifest import (
14 | |     LEGACY_SHIPPED_CONFIG,
15 | |     EmbeddingManifest,
16 | |     UnitSpecInput,
17 | |     append_shard,
18 | | )
19 | |
20 | | from wiki import dense_rerank, sources_db
   | |_________________________________________^
   |
help: Organize imports

I001 [*] Import block is un-sorted or un-formatted
  --> tests/wiki/test_t1_t2_pipeline.py:9:1
   |
 7 |   sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 8 |
 9 | / from wiki.query_builder import build_query_buckets
10 | |
11 | | from wiki import sources_db
   | |___________________________^
12 |
13 |   DISCOVERY_PATH = (
   |
help: Organize imports

I001 [*] Import block is un-sorted or un-formatted
  --> tests/wiki/test_ukrainian_wiki_corpus.py:14:1
   |
12 |   sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
13 |
14 | / from wiki.embedding_manifest import EmbeddingManifest
15 | |
16 | | from wiki import dense_rerank, sources_db, ukrainian_wiki_corpus
   | |________________________________________________________________^
   |
help: Organize imports

Found 43 errors.
[*] 14 fixable with the `--fix` option (15 hidden fixes can be enabled with the `--unsafe-fixes` option). passed cleanly.
