### PR TITLE
fix(practice): daily picks survive the UTC date boundary (#5862)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: aad98692b5839cc2b7d46a79099b0f6205302c1f0e86a26b53482dbef220ec34
+  components_sha256: f6a90bc144b2966ebfeaca7b09bd19d80d434d5f2c77534d4cfbd5f092e58b82
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -689,3 +689,56 @@ test('A7: word cards render the level exactly once', async ({ page, context }) =
   );
   expect(occurrences).toBe(1);
 });
+
+test.describe('daily preview UTC boundary', () => {
+  test.use({ timezoneId: 'UTC' });
+
+  test('keeps a displayable daily card on both sides of midnight when the pool has orphaned rows', async ({ page, context }) => {
+    await context.clearCookies();
+    const dailyPool = [
+      { lemma: 'видиме-один', slug: 'visible-one', gloss: 'visible one', cefr: 'A1' },
+      { lemma: 'видиме-два', slug: 'visible-two', gloss: 'visible two', cefr: 'A1' },
+      { lemma: 'сирота', slug: 'orphaned-row', gloss: 'orphaned row', cefr: 'A1' },
+    ];
+    const lexemes = dailyPool.slice(0, 2).map((word) => ({
+      lemmaId: word.slug,
+      lemma: word.lemma,
+      lemmaPlain: word.lemma,
+      ipa: null,
+      gloss: word.gloss,
+      pos: 'noun',
+      cefr: word.cefr,
+      heritage: null,
+      severity: null,
+      paradigm: { cases: {} },
+    }));
+
+    await page.route('**/lexicon/daily-pool.json', (route) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify(dailyPool) }),
+    );
+    await page.route('**/lexicon/practice-lexemes.A1.json', (route) =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ deckVersion: 'daily-boundary-fixture', level: 'A1', lexemes }),
+      }),
+    );
+    await page.clock.install({ time: new Date('2026-07-26T23:55:00.000Z') });
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+      window.localStorage.setItem('lu-learner-level', 'A1');
+    });
+
+    for (const { instant, expectedWord } of [
+      { instant: '2026-07-26T23:55:00.000Z', expectedWord: 'видиме-два' },
+      { instant: '2026-07-27T00:05:00.000Z', expectedWord: 'сирота' },
+    ]) {
+      await page.clock.setFixedTime(new Date(instant));
+      await page.goto('/words-of-the-day/practice/');
+
+      const front = page.locator('.daily-preview-card .flashcard-front');
+      await expect(page.getByTestId('practice-daily-deck')).toBeVisible();
+      await expect(front).toContainText(expectedWord);
+      await expect(front).not.toHaveText('—');
+    }
+  });
+});

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1527,7 +1527,9 @@ function LexiconPracticeIsland({
   // word across days (confirmed live bug: борщ every visit, while the page
   // itself showed a rotating 12). Loads lexeme cores only for the levels
   // represented among today's picks so the preview rows have verified
-  // lemma/gloss/pos data without pulling every shard.
+  // lemma/gloss/pos data. The daily pool and practice-core shards are built
+  // independently, so an orphaned pool row is normalized into a displayable
+  // preview card from its verified pool metadata rather than rendering as —.
   useEffect(() => {
     if (sessionPhase !== 'idle') return;
 
@@ -1548,26 +1550,14 @@ function LexiconPracticeIsland({
         const eligiblePool = filterByCumulativeLevel(pool, learnerLevel);
         const picks = pickDaily(eligiblePool, dateSeed(now), DAILY_PRACTICE_DECK_SIZE);
 
-        const snapshot: DailyPracticeDeckSnapshot = {
-          version: 1,
-          date: dateKey,
-          level: learnerLevel,
-          deckVersion: 'daily-pool',
-          createdAt: now.getTime(),
-          items: picks.map((word) => ({
-            lemmaId: word.slug,
-            origin: classifyDailyPracticeOrigin(word.slug, indexSource, state.cards, now),
-          })),
-        };
-
-        if (cancelled) return;
-        setDailySnapshot(snapshot);
-
         // Fetch lexeme cores only for levels represented among today's picks —
-        // each `DailyWord` already carries its own `cefr`, so this no longer
-        // needs to cross-reference the SRS index at all.
+        // or all selected-level cores for the defined fallback when the daily
+        // pool is empty.
+        const levelsForDailyPreview = picks.length > 0
+          ? picks.map((word) => word.cefr)
+          : levelsUpTo(learnerLevel);
         const representedLevels = new Set(
-          picks.map((word) => word.cefr).filter((cefr): cefr is string => Boolean(cefr)),
+          levelsForDailyPreview.filter((cefr): cefr is string => Boolean(cefr)),
         );
         const levelEntries = deck
           ? []
@@ -1602,10 +1592,55 @@ function LexiconPracticeIsland({
         for (const entry of levelEntries.flatMap((batch) => batch.lexemes)) {
           merged.set(entry.lemmaId, entry);
         }
-        setDailyLexemes(addDailyExamples(merged, [
+        const lexemes = addDailyExamples(merged, [
           ...(deck?.cloze ?? []),
           ...levelEntries.flatMap((batch) => batch.cloze),
-        ]));
+        ]);
+        for (const word of picks) {
+          if (lexemes.has(word.slug)) continue;
+          // The daily pool is itself a verified learner-facing source. Preserve
+          // its unified pick even when the independently generated practice
+          // shard lacks that lemma, using the metadata available on the row.
+          lexemes.set(word.slug, {
+            lemmaId: word.slug,
+            lemma: word.lemma,
+            lemmaPlain: word.lemma,
+            ipa: null,
+            gloss: word.gloss ?? word.lemma,
+            pos: null,
+            cefr: word.cefr ?? null,
+            heritage: null,
+            severity: null,
+            paradigm: { cases: {} },
+          });
+        }
+        // A genuinely empty daily pool has no unified pick set. In that case,
+        // deterministically use the selected level's curated practice cores
+        // rather than render an empty daily card.
+        const fallbackPool: DailyWord[] = Array.from(lexemes.values()).map((lexeme) => ({
+          lemma: lexeme.lemma,
+          slug: lexeme.lemmaId,
+          gloss: lexeme.gloss,
+          cefr: lexeme.cefr ?? undefined,
+        }));
+        const displayablePicks = picks.length > 0
+          ? picks
+          : pickDaily(fallbackPool, dateSeed(now), DAILY_PRACTICE_DECK_SIZE);
+        const snapshot: DailyPracticeDeckSnapshot = {
+          version: 1,
+          date: dateKey,
+          level: learnerLevel,
+          deckVersion: 'daily-pool',
+          createdAt: now.getTime(),
+          items: displayablePicks.map((word) => ({
+            lemmaId: word.slug,
+            origin: classifyDailyPracticeOrigin(word.slug, indexSource, state.cards, now),
+          })),
+        };
+
+        if (cancelled) return;
+        setDailyLexemes(lexemes);
+        setDailySnapshot(snapshot);
       } catch {
         if (!cancelled) setDailySnapshot(null);
       } finally {


### PR DESCRIPTION
Closes #5862

## Root cause
`site/src/components/LexiconPractice.tsx` selected the unified daily rows with `const picks = pickDaily(eligiblePool, dateSeed(now), DAILY_PRACTICE_DECK_SIZE);`, but treated each selected row as displayable only when a separately generated practice-lexeme shard supplied the same `lemmaId`. After the UTC date rollover, the seeded first row was absent from that shard, leaving `currentLexeme` null and rendering `—`.

## Fix
- Preserve the exact unified `/words-of-the-day/` pick set, including A1 parity.
- Normalize a selected daily-pool row missing from a practice shard into a displayable lexeme from its verified daily-pool metadata.
- Use selected-level curated practice cores as a deterministic fallback only when the daily pool itself is empty.

## Validation
- `npm run build`
- `npx playwright test e2e/atlas-practice.spec.ts` — 27 passed
- `npm run test:unit`
- UTC boundary regression pins `2026-07-26T23:55:00Z` and `2026-07-27T00:05:00Z`; both render a non-empty card.

No merge or auto-merge has been requested; the orchestrator owns the cross-family review gate.