### PR TITLE
fix(hooks): SESSION_EPIC validates against the fleet taxonomy (step 4a)

### DIFF
--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -521,10 +521,25 @@ Do not dump or rewrite docs/session-state/current.md. For thread rollover, run:
 EOF
 }
 
+# Validate SESSION_EPIC if set against fleet taxonomy selectors.
+HANDOFF_IDENTITY_SH="${CLAUDE_HANDOFF_IDENTITY_SH:-$PROJECT_DIR/scripts/lib/handoff_identity.sh}"
+if [ -f "$HANDOFF_IDENTITY_SH" ]; then
+  # shellcheck disable=SC1090
+  source "$HANDOFF_IDENTITY_SH"
+fi
+
+SESSION_EPIC_VALID=1
+if [ -n "${SESSION_EPIC:-}" ]; then
+  if declare -f launcher_selector_resolve >/dev/null 2>&1 \
+     && ! launcher_selector_resolve "$SESSION_EPIC" >/dev/null 2>&1; then
+    SESSION_EPIC_VALID=0
+  fi
+fi
+
 # Optional task-family filter from launcher epic (#5398). SESSION_EPIC is the
 # epic name (hramatka, atlas, harness); task_family on packets usually matches.
 TASK_FAMILY_ARGS=()
-if [ -n "${SESSION_EPIC:-}" ]; then
+if [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "1" ]; then
   case "${SESSION_EPIC}" in
     harness|infra) : ;; # do not over-filter infra packets
     *) TASK_FAMILY_ARGS=(--task-family "$SESSION_EPIC") ;;
@@ -652,7 +667,7 @@ fi
 
 # Epic assignment banner
 EPIC_BANNER=""
-if [ -n "${SESSION_EPIC:-}" ]; then
+if [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "1" ]; then
   EPIC_HANDOFF_PATH=".claude/${SESSION_EPIC}-epic/CLAUDE-DRIVER-HANDOFF.md"
   case "$HANDOFF_AGENT" in
     codex|codex-*)
@@ -673,6 +688,19 @@ is the lane SSOT): $EPIC_HANDOFF_PATH"
 (No driver handoff exists yet for this epic — create it at first rollover.)"
   fi
   unset EPIC_HANDOFF_PATH
+elif [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "0" ]; then
+  VALID_SELECTORS_HELP=""
+  if declare -f launcher_selector_help >/dev/null 2>&1; then
+    VALID_SELECTORS_HELP="$(launcher_selector_help)"
+  fi
+  EPIC_BANNER="ERROR: unknown SESSION_EPIC '${SESSION_EPIC}' — epic binding STOPPED.
+${VALID_SELECTORS_HELP:+$VALID_SELECTORS_HELP
+}NO EPIC ASSIGNED (unknown SESSION_EPIC fell back to unassigned mode).
+Do NOT default to 'main orchestrator'. Resolve your lane in this order:
+1. The user's first message names the epic → that binds.
+2. .agent/lane-assignments.md maps this agent type to exactly ONE epic → that binds.
+3. Otherwise ASK THE USER one question ('which epic is this session?') BEFORE
+   claiming any lane, reading any thread handoff as your own, or touching queues."
 else
   EPIC_BANNER="NO EPIC ASSIGNED (launcher had no --epic flag).
 Do NOT default to 'main orchestrator'. Resolve your lane in this order:
@@ -688,7 +716,7 @@ fi
 CODEX_COLD_START_BOARD=""
 case "$HANDOFF_AGENT" in
   codex|codex-*)
-    if [ -n "${SESSION_EPIC:-}" ]; then
+    if [ -n "${SESSION_EPIC:-}" ] && [ "$SESSION_EPIC_VALID" = "1" ]; then
       CODEX_COLD_START_PATH="$PROJECT_DIR/.claude/${SESSION_EPIC}-epic/CODEX-COLD-START.md"
       if [ -f "$CODEX_COLD_START_PATH" ]; then
         CODEX_COLD_START_BOARD=$(<"$CODEX_COLD_START_PATH")

--- a/docs/projects/fleet-taxonomy/alias-audit.md
+++ b/docs/projects/fleet-taxonomy/alias-audit.md
@@ -22,7 +22,7 @@ It details the accepted spellings, the behavior when encountering unknown spelli
 | `start-sonnet-drive.sh` | `$1` (`<lane-or-lane.topic>`) | 17 selectors via `launcher_selector_resolve` | Errors and exits 1 | `start-sonnet-drive.sh:30-34`, `scripts/lib/handoff_identity.sh:23-48` |
 | `scripts/orchestration/drive_epic*` | N/A | None (Script not present in repo) | N/A | N/A (verified missing) |
 | `scripts/delegate.py` | `--agent <name>` | `_DISPATCH_AGENT_CHOICES` (`codex`, `gemini`, `claude`, `grok`, `grok-build`, `grok-hermes`, `kimi`, `deepseek`, `agy`, `cursor`) | Argparse errors and exits 2 | `scripts/delegate.py:150-161`, `scripts/delegate.py:4595` |
-| SessionStart hook | `SESSION_EPIC` env var | Any string string-substituted into file paths (`.claude/${SESSION_EPIC}-epic/...`) | Accepts silently; missing handoff file banner shown | `agents_extensions/shared/hooks/session-setup.sh:527-532`, `agents_extensions/shared/hooks/session-setup.sh:655-683` |
+| SessionStart hook | `SESSION_EPIC` env var | 17 selectors via `launcher_selector_resolve` | Fails closed (prints fail-closed banner naming valid selectors and stops epic binding) | `agents_extensions/shared/hooks/session-setup.sh:524-539`, `agents_extensions/shared/hooks/session-setup.sh:670-700` |
 | `thread_handoff.py` | `--agent <name>` | Any lower-case string matching regex `[a-z][a-z0-9-]*` | Accepts silently if regex matches; error if regex fails | `scripts/orchestration/thread_handoff.py:129-141`, `scripts/orchestration/thread_handoff.py:4883` |
 | Bridge Channels (`_channels.py`) | Agent names | `VALID_AGENTS` tuple (`agy`, `claude`, `claude-infra`, `gemini`, `codex`, `grok`, `grok-build`, `grok-hermes`, `glm`, `kimi`, `deepseek`, `qwen`, `cursor`, `claude-desktop`, `codex-desktop`) | Raises `ValueError` | `scripts/ai_agent_bridge/_channels.py:74-90`, `scripts/ai_agent_bridge/_channels.py:209-211` |
 | `session_streams/inventory.py` | `stream_name` | Hardcoded `_STREAM_NAME_TO_CLAUDE_DIR` dictionary mapping 11 stream names | Falls through to `stream_name.replace("_", "-")` | `agents_extensions/shared/session_streams/inventory.py:54-66`, `agents_extensions/shared/session_streams/inventory.py:94` |
@@ -33,8 +33,8 @@ It details the accepted spellings, the behavior when encountering unknown spelli
    All root shell wrappers (`start-claude.sh`, `start-codex.sh`, `start-gemini.sh`, `start-grok.sh`, `start-kimi.sh`, `start-*-drive.sh`, `start-opus-drive.sh`, `start-sonnet-drive.sh`) source `scripts/lib/handoff_identity.sh` and delegate selector validation to `launcher_selector_resolve` / `launcher_selector_lane`.
 2. **Missing `drive_epic*` Script**:
    No standalone `drive_epic*` script exists in `scripts/orchestration/`.
-3. **SessionStart Hook Silent Acceptance**:
-   `agents_extensions/shared/hooks/session-setup.sh` accepts any arbitrary `SESSION_EPIC` string passed via environment variables without validating against the fleet taxonomy registry.
+3. **SessionStart Hook Validation (Step 4a)**:
+   `agents_extensions/shared/hooks/session-setup.sh` validates `SESSION_EPIC` against `launcher_selector_resolve` and fails closed on unknown selectors.
 4. **Session Streams Inventory Wiring Gap**:
    `agents_extensions/shared/session_streams/inventory.py` previously relied on a hardcoded map (`_STREAM_NAME_TO_CLAUDE_DIR`) rather than querying canonical area assignments from `fleet_taxonomy.yaml`.
 5. **Launcher Preflight & Prereq-Before-Validation Ordering Inconsistency (Step-6 Launcher Parity Input)**:

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -103,6 +103,7 @@ run_hook() {
     CLAUDE_PROFILE_RESOLVER_SH="$REPO_ROOT/scripts/lib/profile_resolver.sh" \
     CLAUDE_PROFILE_RESOLVER_PY="$REPO_ROOT/scripts/lib/context_profiles.py" \
     CLAUDE_PROFILE_RESOLVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
+    CLAUDE_HANDOFF_IDENTITY_SH="$REPO_ROOT/scripts/lib/handoff_identity.sh" \
     CLAUDE_SESSION_RECORD_SCRIPT="$REPO_ROOT/scripts/lib/session_record.py" \
     CLAUDE_SESSION_RECORD_PYTHON="$REPO_ROOT/.venv/bin/python" \
     SESSION_BOUNDED_RUNNER="$REPO_ROOT/scripts/agent_runtime/bounded_command.py" \
@@ -275,10 +276,20 @@ assert_not_contains "$output" ".claude/atlas-epic/CODEX-DRIVER-HANDOFF.md" "Code
 # 2d. A brand-new Codex epic initializes the shared lane handoff path rather
 # than creating a provider-only fork that Claude cannot discover.
 setup_fixture "$fixture_root"
-output="$(run_hook "$fixture_root" 0 codex-new-lane "" "" native_codex "" "" new-lane)"
-assert_contains "$output" ".claude/new-lane-epic/CLAUDE-DRIVER-HANDOFF.md" "Codex new epic fallback"
-assert_not_contains "$output" ".claude/new-lane-epic/CODEX-DRIVER-HANDOFF.md" "Codex new epic fallback"
+output="$(run_hook "$fixture_root" 0 codex-devops "" "" native_codex "" "" devops)"
+assert_contains "$output" ".claude/devops-epic/CLAUDE-DRIVER-HANDOFF.md" "Codex new epic fallback"
+assert_not_contains "$output" ".claude/devops-epic/CODEX-DRIVER-HANDOFF.md" "Codex new epic fallback"
 assert_contains "$output" "No driver handoff exists yet" "Codex new epic fallback"
+
+# 2e. An unknown SESSION_EPIC fails closed: epic binding is stopped and a
+# fail-closed banner listing valid selectors is surfaced.
+setup_fixture "$fixture_root"
+output="$(run_hook "$fixture_root" 0 claude "" "" native_claude "" "" invalid-epic-xyz)"
+assert_contains "$output" "ERROR: unknown SESSION_EPIC 'invalid-epic-xyz' — epic binding STOPPED." "unknown SESSION_EPIC"
+assert_contains "$output" "Valid lane selectors:" "unknown SESSION_EPIC"
+assert_contains "$output" "infra | harness | infra.fleet-comms" "unknown SESSION_EPIC"
+assert_not_contains "$output" "ASSIGNED EPIC: invalid-epic-xyz.epic" "unknown SESSION_EPIC"
+assert_not_contains "$output" ".claude/invalid-epic-xyz-epic" "unknown SESSION_EPIC"
 
 # 3. Marker path is used when legacy router is explicitly enabled.
 setup_fixture "$fixture_root"

--- a/tests/test_fleet_taxonomy_aliases.py
+++ b/tests/test_fleet_taxonomy_aliases.py
@@ -318,3 +318,75 @@ def test_inventory_handoff_candidates_survive_missing_resolver(monkeypatch):
     # Legacy-map answer ('harness'); the resolver would give 'infra' — so a hoisted
     # module-level import makes this assertion fail, keeping the mutation detectable.
     assert candidates[0] == ".claude/harness-epic/CLAUDE-DRIVER-HANDOFF.md"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+@pytest.mark.parametrize(
+    ("session_epic", "expected_mode", "expected_token"),
+    [
+        ("hramatka", "valid", "ASSIGNED EPIC: hramatka.epic"),
+        ("invalid_selector_xyz", "unknown", "ERROR: unknown SESSION_EPIC 'invalid_selector_xyz'"),
+        ("", "empty", "NO EPIC ASSIGNED (launcher had no --epic flag)"),
+    ],
+)
+def test_session_setup_hook_epic_validation_contract(
+    tmp_path: Path,
+    session_epic: str,
+    expected_mode: str,
+    expected_token: str,
+) -> None:
+    """Verify SessionStart hook validates SESSION_EPIC against launcher_selector_resolve."""
+    import json
+
+    hook_path = _REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "session-setup.sh"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    venv_bin = project_dir / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "python").write_text("#!/bin/sh\necho 'Python 3.12.8'\n", encoding="utf-8")
+    (venv_bin / "python").chmod(0o755)
+
+    scripts_lib = project_dir / "scripts" / "lib"
+    scripts_lib.mkdir(parents=True)
+    shutil.copy2(_HANDOFF_IDENTITY_SH, scripts_lib / "handoff_identity.sh")
+
+    env = {
+        "CLAUDE_PROJECT_DIR": str(project_dir),
+        "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "32000",
+        "HOME": str(tmp_path / "home"),
+        "PATH": f"{venv_bin}:{os.environ.get('PATH', '')}",
+        "SESSION_EPIC": session_epic,
+        "CLAUDE_PROFILE_RESOLVER_SH": str(_REPO_ROOT / "scripts/lib/profile_resolver.sh"),
+        "CLAUDE_PROFILE_RESOLVER_PY": str(_REPO_ROOT / "scripts/lib/context_profiles.py"),
+        "CLAUDE_PROFILE_RESOLVER_PYTHON": str(_REPO_ROOT / ".venv/bin/python"),
+        "CLAUDE_SESSION_RECORD_SCRIPT": str(_REPO_ROOT / "scripts/lib/session_record.py"),
+        "CLAUDE_SESSION_RECORD_PYTHON": str(_REPO_ROOT / ".venv/bin/python"),
+        "LEARN_UKRAINIAN_REQUESTED_PROFILE_ID": "native_claude",
+        "CODEX_CANONICAL_REPO_ROOT": str(project_dir),
+    }
+
+    result = subprocess.run(
+        ["bash", str(hook_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"hook failed: {result.stderr}\n{result.stdout}"
+    data = json.loads(result.stdout)
+    context = data.get("hookSpecificOutput", {}).get("additionalContext", "")
+
+    assert expected_token in context
+
+    if expected_mode == "valid":
+        assert ".claude/hramatka-epic/CLAUDE-DRIVER-HANDOFF.md" in context
+        assert "ERROR: unknown SESSION_EPIC" not in context
+    elif expected_mode == "unknown":
+        assert "Valid lane selectors:" in context
+        assert "infra | harness | infra.fleet-comms" in context
+        assert "ASSIGNED EPIC: invalid_selector_xyz.epic" not in context
+        assert ".claude/invalid_selector_xyz-epic" not in context
+    elif expected_mode == "empty":
+        assert "ERROR: unknown SESSION_EPIC" not in context
+        assert "ASSIGNED EPIC:" not in context


### PR DESCRIPTION
### Summary

Validate `SESSION_EPIC` in `agents_extensions/shared/hooks/session-setup.sh` against the canonical 17-selector table in `scripts/lib/handoff_identity.sh` via `launcher_selector_resolve`.

- An unknown `SESSION_EPIC` prints a fail-closed banner naming valid selectors and stops epic binding (clears task-family args, skips cold-start board injection, falls back to unassigned mode guidance).
- Unset/empty `SESSION_EPIC` remains untouched byte-for-byte.
- Updated `docs/projects/fleet-taxonomy/alias-audit.md` audit table.
- Added contract tests in `tests/test_fleet_taxonomy_aliases.py` and `scripts/audit/test_session_setup_hook.sh`.