### PR TITLE
fix(ci): align action pin version comments (zizmor #331/#332/#338)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload test breadcrumbs
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-breadcrumbs-shard-${{ matrix.shard }}
           path: .pytest_breadcrumbs
@@ -208,7 +208,7 @@ jobs:
       # vacuously. Each shard publishes its data; `coverage-floor` combines.
       - name: Upload shard coverage data
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-shard-${{ matrix.shard }}
           path: .coverage
@@ -253,7 +253,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6 — SHA-pinned per supply-chain hardening 2026-05-19
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -522,7 +522,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6 — SHA-pinned per supply-chain hardening 2026-05-19
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -590,7 +590,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6 — SHA-pinned per supply-chain hardening 2026-05-19
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -682,7 +682,7 @@ jobs:
           python-version: '3.12'
       - name: Download shard coverage data
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-shard-*
           path: coverage-artifacts

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -212,7 +212,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6 — SHA-pinned per supply-chain hardening 2026-05-19
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6 — SHA-pinned per supply-chain hardening 2026-05-19
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Summary
- Fixes open code-scanning alerts `zizmor/ref-version-mismatch` #331, #332, #338 by aligning SHA-pin version comments with the commits they actually point at.
- `actions/upload-artifact@043fb46…` → `# v7.0.1` (was `# v4`)
- `actions/download-artifact@3e5f45b…` → `# v8.0.1` (was `# v4`)
- `actions/setup-node@82076278…` → `# v7.0.0` (was `# v6`) in ci/hygiene/security-audit

Comment-only change; no action SHA or workflow behavior change.

## Test plan
- [ ] CI Gate green
- [ ] zizmor workflow green on this PR
- [ ] After merge, code-scanning alerts #331/#332/#338 auto-resolve (or confirm closed)


Made with [Cursor](https://cursor.com)