### PR TITLE
fix(launchers): stop using Hermes private Node on PATH

### DIFF
--- a/agents_extensions/shared/memory/MEMORY.md
+++ b/agents_extensions/shared/memory/MEMORY.md
@@ -55,8 +55,11 @@ Before EVER asking the user for additional pedagogical material, check: `docs/re
 ## #0I — DON'T STACK MICRO-DILEMMAS, DECIDE FOR THE USER (2026-05-04)
 Compound decisions = ONE table + ONE recommendation, NEVER N parallel sign-off questions. Required shape: (1) state of play 1-3 sentences, (2) options table 2-3 rows max, (3) **MY RECOMMENDATION** with one explicit pick + why + reject worst by name, (4) "going to execute unless you stop me" + first action verb. A numbered "sign off on these N" list IS a menu — forbidden.
 
-## #0H — MERGING PRs IS MY JOB (action bias)
-Review each PR (body + diff + CI), merge if clean: `gh pr merge N --squash --delete-branch`. Don't ask, do it. Hold only for BLOCKING CI fails (advisory Gemini-Dispatch fails ≠ blocking). LEAD AND GUIDE: state next action + execute + report, don't present status + wait. Same applies to memory/rules/docs cleanup — don't deflect to user.
+## #0H — CF REVIEW MANDATORY ON EVERY PR; THEN MERGE (2026-07-27)
+**Independent cross-family (CF) formal review is ALWAYS mandatory before merge.** No exceptions for “small,” docs-only, launcher, or infra PRs. Discussion / self-review / same-family review ≠ the gate.
+- Request immediately after `gh pr create`: `.venv/bin/python -m scripts.ai_agent_bridge review-pr <N> --reviewer codex|claude|glm --from <author-family>` (default codex sealed path). **agy / kimi / grok are NOT formal_review_eligible reviewers** — never self-seal.
+- Closeout incomplete until CF is requested (and settled). Failure encoded: 2026-07-27 Grok shipped #5875 without `review-pr`; operator had to ask.
+- After CF pass + green blocking CI: `gh pr merge N --auto --squash --delete-branch` (action bias — don’t leave PRs limbo). Hold only for CF fail or blocking CI.
 
 ## #0G — NEVER REPORT ASYNC-TASK STATE FROM MEMORY (2026-05-08)
 Before saying "task X is running / X just finished / X is at step Y", ALWAYS query `delegate.py status-or-fail X` or Monitor API `/api/delegate/active`. Memory of state from 2 minutes ago is wrong by default. Established 2026-05-08 after orchestrator reported bakeoff "Gemini mid-write" when it had finished.

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -38,9 +38,10 @@ Project-local wrappers for interactive agent sessions:
 
 Native Kimi Code (separate app/CLI, OAuth subscription) is the **headless / fleet**
 lane via `scripts/delegate.py --agent kimi` and `ab ask-kimi`. Interactive native
-Kimi is `kimi` (the hermes npm install at `~/.hermes/node/bin/kimi` is preferred;
-`~/.kimi-code/bin/kimi` is the legacy standalone binary and last-resort fallback)
-or a dedicated `start-kimi.sh` when that wrapper is present — not `start-kimicc.sh`.
+Kimi is `kimi` (user npm global at `~/.local/bin/kimi` is preferred;
+`~/.kimi-code/bin/kimi` is the legacy standalone binary and last-resort fallback).
+Do not use `~/.hermes/node/bin` — that Node tree is Hermes-private only.
+Interactive launch is `./start-kimi.sh` — not `start-kimicc.sh`.
 
 ### Parallel routes and original Claude config
 

--- a/scripts/lib/scrub_hermes_node_path.sh
+++ b/scripts/lib/scrub_hermes_node_path.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Scrub Hermes-private Node from PATH.
+#
+# Hermes may keep a private runtime at ~/.hermes/node for its own agent.
+# That tree must never shadow system Node (Homebrew) or user globals (~/.local).
+# Long-lived orchestrator shells often still carry the old
+#   export PATH="$HOME/.hermes/node/bin:$PATH"
+# from before the detach — launchers must strip it on every start.
+#
+# Usage (from a repo-root start-*.sh):
+#   # shellcheck source=scripts/lib/scrub_hermes_node_path.sh
+#   source "$ROOT/scripts/lib/scrub_hermes_node_path.sh"
+#   scrub_hermes_node_from_path
+
+scrub_hermes_node_from_path() {
+  local hermes_node_bin="${HOME}/.hermes/node/bin"
+  local scrubbed="" p
+  local _old_ifs="$IFS"
+  local -a parts=()
+
+  IFS=':'
+  # shellcheck disable=SC2206  # intentional word-split on PATH
+  parts=(${PATH:-})
+  IFS="$_old_ifs"
+
+  for p in "${parts[@]+"${parts[@]}"}"; do
+    [ -n "$p" ] || continue
+    if [ "$p" = "$hermes_node_bin" ]; then
+      continue
+    fi
+    if [ -n "$scrubbed" ]; then
+      scrubbed="${scrubbed}:${p}"
+    else
+      scrubbed="$p"
+    fi
+  done
+
+  export PATH="$scrubbed"
+  hash -r 2>/dev/null || true
+}

--- a/scripts/lib/scrub_hermes_node_path.sh
+++ b/scripts/lib/scrub_hermes_node_path.sh
@@ -7,6 +7,9 @@
 #   export PATH="$HOME/.hermes/node/bin:$PATH"
 # from before the detach — launchers must strip it on every start.
 #
+# Empty colon-delimited PATH fields are valid (they mean cwd). Rebuild PATH
+# without dropping them; only remove entries exactly equal to the Hermes bin.
+#
 # Usage (from a repo-root start-*.sh):
 #   # shellcheck source=scripts/lib/scrub_hermes_node_path.sh
 #   source "$ROOT/scripts/lib/scrub_hermes_node_path.sh"
@@ -14,27 +17,28 @@
 
 scrub_hermes_node_from_path() {
   local hermes_node_bin="${HOME}/.hermes/node/bin"
-  local scrubbed="" p
-  local _old_ifs="$IFS"
-  local -a parts=()
+  local out="" sep="" rest="${PATH-}"
+  local comp more=1
 
-  IFS=':'
-  # shellcheck disable=SC2206  # intentional word-split on PATH
-  parts=(${PATH:-})
-  IFS="$_old_ifs"
-
-  for p in "${parts[@]+"${parts[@]}"}"; do
-    [ -n "$p" ] || continue
-    if [ "$p" = "$hermes_node_bin" ]; then
+  # Split on ':' while preserving empty fields (unlike unquoted ${PATH} split).
+  while [ "$more" -eq 1 ]; do
+    case "$rest" in
+      *:*)
+        comp="${rest%%:*}"
+        rest="${rest#*:}"
+        ;;
+      *)
+        comp="$rest"
+        more=0
+        ;;
+    esac
+    if [ "$comp" = "$hermes_node_bin" ]; then
       continue
     fi
-    if [ -n "$scrubbed" ]; then
-      scrubbed="${scrubbed}:${p}"
-    else
-      scrubbed="$p"
-    fi
+    out="${out}${sep}${comp}"
+    sep=":"
   done
 
-  export PATH="$scrubbed"
+  export PATH="$out"
   hash -r 2>/dev/null || true
 }

--- a/scripts/lib/scrub_hermes_node_path.sh
+++ b/scripts/lib/scrub_hermes_node_path.sh
@@ -8,7 +8,8 @@
 # from before the detach — launchers must strip it on every start.
 #
 # Empty colon-delimited PATH fields are valid (they mean cwd). Rebuild PATH
-# without dropping them; only remove entries exactly equal to the Hermes bin.
+# without dropping them. Compare non-empty components to Hermes by physical
+# path (pwd -P) so ../ and symlink spellings are also removed.
 #
 # Usage (from a repo-root start-*.sh):
 #   # shellcheck source=scripts/lib/scrub_hermes_node_path.sh
@@ -17,8 +18,10 @@
 
 scrub_hermes_node_from_path() {
   local hermes_node_bin="${HOME}/.hermes/node/bin"
-  local out="" sep="" rest="${PATH-}"
-  local comp more=1
+  local hermes_phys out="" sep="" rest="${PATH-}"
+  local comp more=1 phys
+
+  hermes_phys="$(cd "$hermes_node_bin" 2>/dev/null && pwd -P)" || hermes_phys=""
 
   # Split on ':' while preserving empty fields (unlike unquoted ${PATH} split).
   while [ "$more" -eq 1 ]; do
@@ -32,9 +35,20 @@ scrub_hermes_node_from_path() {
         more=0
         ;;
     esac
-    if [ "$comp" = "$hermes_node_bin" ]; then
-      continue
+
+    # Drop Hermes-private bin (lexical or physical equivalence).
+    if [ -n "$comp" ]; then
+      if [ "$comp" = "$hermes_node_bin" ]; then
+        continue
+      fi
+      if [ -n "$hermes_phys" ] && { [ -d "$comp" ] || [ -L "$comp" ]; }; then
+        phys="$(cd "$comp" 2>/dev/null && pwd -P)" || phys=""
+        if [ -n "$phys" ] && [ "$phys" = "$hermes_phys" ]; then
+          continue
+        fi
+      fi
     fi
+
     out="${out}${sep}${comp}"
     sep=":"
   done

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -5,6 +5,13 @@
 set -e
 
 # Ensure ~/.local/bin is in PATH (where claude installs by default)
+_LU_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh" ]; then
+  # shellcheck source=scripts/lib/scrub_hermes_node_path.sh
+  source "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh"
+  scrub_hermes_node_from_path
+fi
+unset _LU_ROOT
 export PATH="$HOME/.local/bin:$PATH"
 hash -r 2>/dev/null || true  # Clear command cache
 

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -3,6 +3,13 @@
 
 set -euo pipefail
 
+_LU_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh" ]; then
+  # shellcheck source=scripts/lib/scrub_hermes_node_path.sh
+  source "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh"
+  scrub_hermes_node_from_path
+fi
+unset _LU_ROOT
 export PATH="$HOME/.local/bin:/opt/homebrew/bin:${PATH:-}"
 # Avoid optional index refresh locks while the primary checkout is used for
 # orientation. Task writes still belong in scoped dispatch worktrees.

--- a/start-gemini.sh
+++ b/start-gemini.sh
@@ -30,6 +30,13 @@
 
 set -euo pipefail
 
+_LU_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh" ]; then
+  # shellcheck source=scripts/lib/scrub_hermes_node_path.sh
+  source "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh"
+  scrub_hermes_node_from_path
+fi
+unset _LU_ROOT
 export PATH="${HOME}/.local/bin:/opt/homebrew/bin:${HOME}/.gemini/bin:${PATH:-}"
 hash -r 2>/dev/null || true
 

--- a/start-grok.sh
+++ b/start-grok.sh
@@ -42,6 +42,13 @@
 
 set -euo pipefail
 
+_LU_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh" ]; then
+  # shellcheck source=scripts/lib/scrub_hermes_node_path.sh
+  source "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh"
+  scrub_hermes_node_from_path
+fi
+unset _LU_ROOT
 export PATH="${HOME}/.local/bin:/opt/homebrew/bin:${HOME}/.grok/bin:${PATH:-}"
 hash -r 2>/dev/null || true
 

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -90,7 +90,7 @@ is_hermes_private_node_bin() {
       cand_phys="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$cand" 2>/dev/null)" || cand_phys=""
     fi
     if [ -n "$cand_phys" ]; then
-      cand_dir="$(dirname -- "$cand_phys")"
+      cand_dir="$(dirname "$cand_phys")"
       if [ "$cand_dir" = "$hermes_phys" ]; then
         return 0
       fi

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -75,6 +75,14 @@ usage_launcher() {
 # legacy standalone binary at ~/.kimi-code/bin (last resort; often stale).
 # Do NOT fall back to ~/.hermes/node/bin — that tree is Hermes-private only.
 KIMI_BIN="${LEARN_UK_KIMI_BIN:-}"
+# Never accept Hermes-private installs — including explicit LEARN_UK_KIMI_BIN overrides.
+case "$KIMI_BIN" in
+  */.hermes/node/bin/*)
+    echo "Error: LEARN_UK_KIMI_BIN points at Hermes-private Node ($KIMI_BIN)." >&2
+    echo "  Use ~/.local/bin/kimi (npm -g @moonshot-ai/kimi-code) instead." >&2
+    exit 1
+    ;;
+esac
 if [ -z "$KIMI_BIN" ] || [ ! -x "$KIMI_BIN" ]; then
   KIMI_BIN=""
   for cand in \

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -40,10 +40,15 @@
 
 set -euo pipefail
 
-export PATH="${HOME}/.local/bin:/opt/homebrew/bin:${HOME}/.hermes/node/bin:${PATH:-}"
-hash -r 2>/dev/null || true
-
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Drop Hermes-private Node from inherited PATH, then prefer user globals + brew.
+if [ -f "$PROJECT_DIR/scripts/lib/scrub_hermes_node_path.sh" ]; then
+  # shellcheck source=scripts/lib/scrub_hermes_node_path.sh
+  source "$PROJECT_DIR/scripts/lib/scrub_hermes_node_path.sh"
+  scrub_hermes_node_from_path
+fi
+export PATH="${HOME}/.local/bin:/opt/homebrew/bin:${PATH:-}"
+hash -r 2>/dev/null || true
 # Absolute path to THIS script, captured before any cd: usage_launcher reads
 # its own header, and the worktree redirect below changes cwd.
 SCRIPT_PATH="$PROJECT_DIR/$(basename "${BASH_SOURCE[0]}")"
@@ -65,17 +70,22 @@ usage_launcher() {
   exit 0
 }
 # --- locate kimi binary ---
-# Preference order: explicit override → ambient PATH (the hermes npm install,
-# ~/.hermes/node/bin, is the maintained one) → hermes explicit → legacy
-# standalone binary at ~/.kimi-code/bin (last resort; often stale).
+# Preference order: explicit override → ambient PATH (after PATH fix above,
+# that is ~/.local + Homebrew) → explicit ~/.local/bin/kimi (user npm -g) →
+# legacy standalone binary at ~/.kimi-code/bin (last resort; often stale).
+# Do NOT fall back to ~/.hermes/node/bin — that tree is Hermes-private only.
 KIMI_BIN="${LEARN_UK_KIMI_BIN:-}"
 if [ -z "$KIMI_BIN" ] || [ ! -x "$KIMI_BIN" ]; then
   KIMI_BIN=""
   for cand in \
     "$(command -v kimi 2>/dev/null || true)" \
-    "${HOME}/.hermes/node/bin/kimi" \
+    "${HOME}/.local/bin/kimi" \
     "${HOME}/.kimi-code/bin/kimi"
   do
+    # Never accept Hermes-private installs even if something re-injected PATH.
+    case "$cand" in
+      */.hermes/node/bin/*) continue ;;
+    esac
     if [ -n "$cand" ] && [ -x "$cand" ]; then
       KIMI_BIN="$cand"
       break
@@ -83,7 +93,8 @@ if [ -z "$KIMI_BIN" ] || [ ! -x "$KIMI_BIN" ]; then
   done
 fi
 if [ -z "$KIMI_BIN" ]; then
-  echo "Error: Kimi Code CLI not found. Install it or set LEARN_UK_KIMI_BIN." >&2
+  echo "Error: Kimi Code CLI not found. Install with: npm i -g @moonshot-ai/kimi-code" >&2
+  echo "  (user prefix ~/.local; see ~/.npmrc) or set LEARN_UK_KIMI_BIN." >&2
   exit 1
 fi
 

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -75,17 +75,25 @@ usage_launcher() {
 # legacy standalone binary at ~/.kimi-code/bin (last resort; often stale).
 # Do NOT fall back to ~/.hermes/node/bin — that tree is Hermes-private only.
 #
-# Returns 0 if path is the Hermes-private node bin tree (physical path match,
-# not just lexical */.hermes/node/bin/* — blocks $HOME/.hermes/node/bin/../bin/kimi).
+# Returns 0 if path is the Hermes-private node bin tree.
+# Uses physical path of the *executable* (resolves symlinks and ../), not just
+# a lexical prefix check — blocks overrides and PATH hits that land on Hermes.
 is_hermes_private_node_bin() {
   local cand="$1"
   [ -n "$cand" ] || return 1
-  local hermes_phys cand_dir
+  local hermes_phys cand_phys cand_dir
   hermes_phys="$(cd "${HOME}/.hermes/node/bin" 2>/dev/null && pwd -P)" || hermes_phys=""
-  if [ -n "$hermes_phys" ] && [ -e "$cand" ]; then
-    cand_dir="$(cd "$(dirname -- "$cand")" 2>/dev/null && pwd -P)" || cand_dir=""
-    if [ -n "$cand_dir" ] && [ "$cand_dir" = "$hermes_phys" ]; then
-      return 0
+  if [ -n "$hermes_phys" ] && { [ -e "$cand" ] || [ -L "$cand" ]; }; then
+    if command -v realpath >/dev/null 2>&1; then
+      cand_phys="$(realpath "$cand" 2>/dev/null)" || cand_phys=""
+    else
+      cand_phys="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$cand" 2>/dev/null)" || cand_phys=""
+    fi
+    if [ -n "$cand_phys" ]; then
+      cand_dir="$(dirname -- "$cand_phys")"
+      if [ "$cand_dir" = "$hermes_phys" ]; then
+        return 0
+      fi
     fi
   fi
   case "$cand" in
@@ -93,6 +101,7 @@ is_hermes_private_node_bin() {
   esac
   return 1
 }
+
 
 KIMI_BIN="${LEARN_UK_KIMI_BIN:-}"
 # Never accept Hermes-private installs — including explicit LEARN_UK_KIMI_BIN overrides.

--- a/start-kimi.sh
+++ b/start-kimi.sh
@@ -74,15 +74,33 @@ usage_launcher() {
 # that is ~/.local + Homebrew) → explicit ~/.local/bin/kimi (user npm -g) →
 # legacy standalone binary at ~/.kimi-code/bin (last resort; often stale).
 # Do NOT fall back to ~/.hermes/node/bin — that tree is Hermes-private only.
+#
+# Returns 0 if path is the Hermes-private node bin tree (physical path match,
+# not just lexical */.hermes/node/bin/* — blocks $HOME/.hermes/node/bin/../bin/kimi).
+is_hermes_private_node_bin() {
+  local cand="$1"
+  [ -n "$cand" ] || return 1
+  local hermes_phys cand_dir
+  hermes_phys="$(cd "${HOME}/.hermes/node/bin" 2>/dev/null && pwd -P)" || hermes_phys=""
+  if [ -n "$hermes_phys" ] && [ -e "$cand" ]; then
+    cand_dir="$(cd "$(dirname -- "$cand")" 2>/dev/null && pwd -P)" || cand_dir=""
+    if [ -n "$cand_dir" ] && [ "$cand_dir" = "$hermes_phys" ]; then
+      return 0
+    fi
+  fi
+  case "$cand" in
+    */.hermes/node/bin/*|"${HOME}/.hermes/node/bin"/*) return 0 ;;
+  esac
+  return 1
+}
+
 KIMI_BIN="${LEARN_UK_KIMI_BIN:-}"
 # Never accept Hermes-private installs — including explicit LEARN_UK_KIMI_BIN overrides.
-case "$KIMI_BIN" in
-  */.hermes/node/bin/*)
-    echo "Error: LEARN_UK_KIMI_BIN points at Hermes-private Node ($KIMI_BIN)." >&2
-    echo "  Use ~/.local/bin/kimi (npm -g @moonshot-ai/kimi-code) instead." >&2
-    exit 1
-    ;;
-esac
+if [ -n "$KIMI_BIN" ] && is_hermes_private_node_bin "$KIMI_BIN"; then
+  echo "Error: LEARN_UK_KIMI_BIN points at Hermes-private Node ($KIMI_BIN)." >&2
+  echo "  Use ~/.local/bin/kimi (npm -g @moonshot-ai/kimi-code) instead." >&2
+  exit 1
+fi
 if [ -z "$KIMI_BIN" ] || [ ! -x "$KIMI_BIN" ]; then
   KIMI_BIN=""
   for cand in \
@@ -90,10 +108,9 @@ if [ -z "$KIMI_BIN" ] || [ ! -x "$KIMI_BIN" ]; then
     "${HOME}/.local/bin/kimi" \
     "${HOME}/.kimi-code/bin/kimi"
   do
-    # Never accept Hermes-private installs even if something re-injected PATH.
-    case "$cand" in
-      */.hermes/node/bin/*) continue ;;
-    esac
+    if is_hermes_private_node_bin "$cand"; then
+      continue
+    fi
     if [ -n "$cand" ] && [ -x "$cand" ]; then
       KIMI_BIN="$cand"
       break

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -38,6 +38,13 @@ if env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR git -C "$PROJECT_DIR" rev-p
   fi
   unset _git_common _main_wt
 fi
+_LU_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh" ]; then
+  # shellcheck source=scripts/lib/scrub_hermes_node_path.sh
+  source "$_LU_ROOT/scripts/lib/scrub_hermes_node_path.sh"
+  scrub_hermes_node_from_path
+fi
+unset _LU_ROOT
 export PATH="${HOME}/.local/bin:${PATH:-}"
 hash -r 2>/dev/null || true
 

--- a/tests/test_start_kimi_launcher.py
+++ b/tests/test_start_kimi_launcher.py
@@ -409,21 +409,26 @@ def test_learn_uk_kimi_bin_hermes_override_rejected(tmp_path: Path) -> None:
 
     env = _clean_environ()
     env["HOME"] = os.fspath(home)
-    env["LEARN_UK_KIMI_BIN"] = os.fspath(hermes_bin / "kimi")
     env["PATH"] = "/usr/bin:/bin"
 
-    result = subprocess.run(
-        [os.fspath(project / "start-kimi.sh"), "hi"],
-        cwd=project,
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=30,
-    )
-    assert result.returncode != 0
-    assert "Hermes-private" in result.stderr
-    assert not capture.exists()
+    for override in (
+        hermes_bin / "kimi",
+        # lexical bypass attempt: .../bin/../bin/kimi still resolves under Hermes
+        hermes_bin / ".." / "bin" / "kimi",
+    ):
+        env["LEARN_UK_KIMI_BIN"] = os.fspath(override)
+        result = subprocess.run(
+            [os.fspath(project / "start-kimi.sh"), "hi"],
+            cwd=project,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+        assert result.returncode != 0, (override, result.stderr, result.stdout)
+        assert "Hermes-private" in result.stderr
+        assert not capture.exists()
 
 
 def test_passthrough_flags_only_launch_interactive_tui(tmp_path: Path) -> None:

--- a/tests/test_start_kimi_launcher.py
+++ b/tests/test_start_kimi_launcher.py
@@ -411,10 +411,16 @@ def test_learn_uk_kimi_bin_hermes_override_rejected(tmp_path: Path) -> None:
     env["HOME"] = os.fspath(home)
     env["PATH"] = "/usr/bin:/bin"
 
+    # Outside-tree symlink whose target is still the Hermes binary.
+    outside = home / "elsewhere"
+    outside.mkdir(parents=True)
+    (outside / "kimi-link").symlink_to(hermes_bin / "kimi")
+
     for override in (
         hermes_bin / "kimi",
         # lexical bypass attempt: .../bin/../bin/kimi still resolves under Hermes
         hermes_bin / ".." / "bin" / "kimi",
+        outside / "kimi-link",
     ):
         env["LEARN_UK_KIMI_BIN"] = os.fspath(override)
         result = subprocess.run(

--- a/tests/test_start_kimi_launcher.py
+++ b/tests/test_start_kimi_launcher.py
@@ -397,6 +397,35 @@ def test_legacy_used_when_local_missing_and_hermes_ignored(tmp_path: Path) -> No
     assert capture.read_text(encoding="utf-8").strip() == "legacy"
 
 
+
+def test_learn_uk_kimi_bin_hermes_override_rejected(tmp_path: Path) -> None:
+    """LEARN_UK_KIMI_BIN must not allow selecting Hermes-private kimi (CF F002)."""
+    project, _supervisor_capture = _build_fake_project(tmp_path)
+    home = tmp_path / "home"
+    hermes_bin = home / ".hermes" / "node" / "bin"
+    hermes_bin.mkdir(parents=True)
+    capture = tmp_path / "which-kimi.txt"
+    _write_executable(hermes_bin / "kimi", f'#!/usr/bin/env bash\necho hermes > "{capture}"\n')
+
+    env = _clean_environ()
+    env["HOME"] = os.fspath(home)
+    env["LEARN_UK_KIMI_BIN"] = os.fspath(hermes_bin / "kimi")
+    env["PATH"] = "/usr/bin:/bin"
+
+    result = subprocess.run(
+        [os.fspath(project / "start-kimi.sh"), "hi"],
+        cwd=project,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "Hermes-private" in result.stderr
+    assert not capture.exists()
+
+
 def test_passthrough_flags_only_launch_interactive_tui(tmp_path: Path) -> None:
     """`-- <flags>` with no prompt: interactive TUI, flags reach the CLI verbatim."""
     values, argv_blob, result, _project, supervisor_capture = _run_launcher(

--- a/tests/test_start_kimi_launcher.py
+++ b/tests/test_start_kimi_launcher.py
@@ -106,6 +106,10 @@ def _build_fake_project(tmp_path: Path) -> tuple[Path, Path]:
         (_REPO_ROOT / "scripts" / "lib" / "handoff_identity.sh").read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+    (lib_dir / "scrub_hermes_node_path.sh").write_text(
+        (_REPO_ROOT / "scripts" / "lib" / "scrub_hermes_node_path.sh").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
     (guard_dir / "assert_primary_on_main.py").write_text("#!/usr/bin/env python3\nraise SystemExit(0)\n")
     (guard_dir / "assert_primary_on_main.py").chmod(0o755)
     (review_dir / "model_catalog.py").write_text(
@@ -325,24 +329,30 @@ def test_unknown_model_rejected_before_launch(tmp_path: Path) -> None:
     assert "unknown --model" in result.stderr
 
 
-def test_hermes_install_preferred_over_legacy_binary(tmp_path: Path) -> None:
-    """With no kimi on PATH, the launcher must pick ~/.hermes/node/bin/kimi
-    (maintained npm install) over the legacy ~/.kimi-code/bin/kimi binary."""
+def test_local_install_preferred_over_legacy_binary(tmp_path: Path) -> None:
+    """With no kimi on PATH, the launcher must pick ~/.local/bin/kimi
+    (user npm global) over the legacy ~/.kimi-code/bin/kimi binary."""
     project, _supervisor_capture = _build_fake_project(tmp_path)
     home = tmp_path / "home"
-    hermes_bin = home / ".hermes" / "node" / "bin"
+    local_bin = home / ".local" / "bin"
     legacy_bin = home / ".kimi-code" / "bin"
-    hermes_bin.mkdir(parents=True)
+    hermes_bin = home / ".hermes" / "node" / "bin"
+    local_bin.mkdir(parents=True)
     legacy_bin.mkdir(parents=True)
+    hermes_bin.mkdir(parents=True)
     capture = tmp_path / "which-kimi.txt"
-    _write_executable(hermes_bin / "kimi", f'#!/usr/bin/env bash\necho hermes > "{capture}"\n')
+    _write_executable(local_bin / "kimi", f'#!/usr/bin/env bash\necho local > "{capture}"\n')
     _write_executable(legacy_bin / "kimi", f'#!/usr/bin/env bash\necho legacy > "{capture}"\n')
+    # Hermes copy must never win even if present on disk.
+    _write_executable(hermes_bin / "kimi", f'#!/usr/bin/env bash\necho hermes > "{capture}"\n')
 
     env = _clean_environ()
     env.pop("LEARN_UK_KIMI_BIN", None)
     env["HOME"] = os.fspath(home)
     # Deliberately no kimi anywhere on PATH: forces the explicit fallback chain.
-    env["PATH"] = "/usr/bin:/bin:/opt/homebrew/bin"
+    # Include hermes on PATH to prove the launcher does not prefer it via PATH
+    # pollution either (export PATH puts .local ahead; hermes is not injected).
+    env["PATH"] = f"/usr/bin:/bin:/opt/homebrew/bin:{hermes_bin}"
 
     result = subprocess.run(
         [os.fspath(project / "start-kimi.sh"), "hi"],
@@ -354,7 +364,37 @@ def test_hermes_install_preferred_over_legacy_binary(tmp_path: Path) -> None:
         timeout=30,
     )
     assert result.returncode == 0, result.stderr + result.stdout
-    assert capture.read_text(encoding="utf-8").strip() == "hermes"
+    assert capture.read_text(encoding="utf-8").strip() == "local"
+
+
+def test_legacy_used_when_local_missing_and_hermes_ignored(tmp_path: Path) -> None:
+    """Hermes-private kimi must not be selected; fall back to legacy only."""
+    project, _supervisor_capture = _build_fake_project(tmp_path)
+    home = tmp_path / "home"
+    legacy_bin = home / ".kimi-code" / "bin"
+    hermes_bin = home / ".hermes" / "node" / "bin"
+    legacy_bin.mkdir(parents=True)
+    hermes_bin.mkdir(parents=True)
+    capture = tmp_path / "which-kimi.txt"
+    _write_executable(legacy_bin / "kimi", f'#!/usr/bin/env bash\necho legacy > "{capture}"\n')
+    _write_executable(hermes_bin / "kimi", f'#!/usr/bin/env bash\necho hermes > "{capture}"\n')
+
+    env = _clean_environ()
+    env.pop("LEARN_UK_KIMI_BIN", None)
+    env["HOME"] = os.fspath(home)
+    env["PATH"] = f"/usr/bin:/bin:{hermes_bin}"
+
+    result = subprocess.run(
+        [os.fspath(project / "start-kimi.sh"), "hi"],
+        cwd=project,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert capture.read_text(encoding="utf-8").strip() == "legacy"
 
 
 def test_passthrough_flags_only_launch_interactive_tui(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Hermes may keep a private Node at `~/.hermes/node`, but launchers must not use it as system Node.
- All `start-*.sh` launchers scrub `~/.hermes/node/bin` from inherited PATH (old orchestrator shells still carry it).
- `start-kimi.sh` prefers `~/.local/bin/kimi` (user npm global) and never falls back to Hermes.
- Shared helper: `scripts/lib/scrub_hermes_node_path.sh`.
- Docs + tests updated.

## Operator action after merge
Restart any long-lived orchestrator shells so they re-exec the fixed launchers (or at least open a new login shell and re-run `./start-*.sh`). Do **not** delete `~/.hermes/node` yet until remaining consumers are confirmed clean.

## Test plan
- [x] `pytest tests/test_start_kimi_launcher.py` (24 passed)
- [ ] Restart orchestrators after merge; confirm `type -a node kimi` first hits are brew / `~/.local`, not Hermes