### PR TITLE
fix(ci): map zizmor offline mode to online-audits (v0.6.0)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -51,4 +51,7 @@ jobs:
           # throttles/blocks. Skip online audits — all 21 baseline findings
           # (17 artipacked + 4 secrets-inherit) are produced by offline
           # YAML-static rules, so we lose nothing in coverage.
-          advanced-args: '--offline'
+          #
+          # zizmor-action v0.6.0 dropped `advanced-args: '--offline'` in favor
+          # of the first-class `online-audits` input (Dependabot #5869).
+          online-audits: 'false'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -44,14 +44,14 @@ jobs:
       - name: 'Run zizmor 🌈'
         uses: 'zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02' # v0.6.0
         with:
-          # 2026-05-23: workflow began failing at 15:57Z with the artipacked
-          # audit hitting HTTP 401 on `actions/checkout` git-upload-pack.
-          # Online verification by zizmor's audit requires unauthenticated
-          # git-fetch to other repos, which Microsoft's git host increasingly
-          # throttles/blocks. Skip online audits — all 21 baseline findings
-          # (17 artipacked + 4 secrets-inherit) are produced by offline
-          # YAML-static rules, so we lose nothing in coverage.
+          # 2026-05-23 intent: skip online audits. artipacked online verification
+          # hits HTTP 401 on unauthenticated git-upload-pack to actions/checkout,
+          # which Microsoft's git host increasingly throttles/blocks.
           #
-          # zizmor-action v0.6.0 dropped `advanced-args: '--offline'` in favor
-          # of the first-class `online-audits` input (Dependabot #5869).
+          # `advanced-args: '--offline'` was never a recognized zizmor-action
+          # input (always a no-op / Unexpected-input warning), so online audits
+          # kept running at the action default. Use the first-class
+          # `online-audits` input (present since at least v0.5.7) to actually
+          # enforce the offline posture. Some online-only audit coverage is
+          # lost; the known baseline findings are offline YAML-static rules.
           online-audits: 'false'


### PR DESCRIPTION
## Summary
- Replace unrecognized `advanced-args: '--offline'` (always a no-op / Unexpected-input warning) with first-class `online-audits: false`.
- This finally enforces the 2026-05-23 offline posture that the old comment claimed but never actually applied.
- Surfaced after Dependabot #5869 bumped zizmor-action to v0.6.0 (annotation became visible).

## Test plan
- [x] zizmor workflow green without `Unexpected input(s) 'advanced-args'` annotation
- [ ] CI Gate green
- [ ] No unexpected code-scanning alert flood after merge

## CF review
GLM `approve_with_comments` (ask #5399): comment framing corrected in follow-up commit.