### PR TITLE
feat(practice): scope daily picks to the selected deck (D10)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 2644080beb10b8dd8078ab90f8e422954213e4585b839ea9b91b683b856e37dd
+  components_sha256: 6b598612cd5eefec70cdc1e6414f41e47d0686cc373f9cfb5469f55c4137097d
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1642,7 +1642,11 @@ components:
         type: CefrLevel
         description: learnerLevel prop.
         ukrainian_text: 'false'
-      optional: []
+      optional:
+      - name: deckTitle
+        type: string | null
+        description: deckTitle prop.
+        ukrainian_text: 'false'
     nested_types: {}
     example:
       snapshot: <DailyPracticeDeckSnapshot>

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 6b598612cd5eefec70cdc1e6414f41e47d0686cc373f9cfb5469f55c4137097d
+  components_sha256: 704691415f8ca7bcfd8ea23f1fa0d9010c3ddc5ec8cebbc84fd28c208ccae338
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1643,9 +1643,13 @@ components:
         description: learnerLevel prop.
         ukrainian_text: 'false'
       optional:
-      - name: deckTitle
+      - name: deckTitleUk
         type: string | null
-        description: deckTitle prop.
+        description: deckTitleUk prop.
+        ukrainian_text: 'false'
+      - name: deckTitleEn
+        type: string | null
+        description: deckTitleEn prop.
         ukrainian_text: 'false'
     nested_types: {}
     example:

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -711,6 +711,122 @@ test('A7: word cards render the level exactly once', async ({ page, context }) =
   expect(occurrences).toBe(1);
 });
 
+// --- D10 (design delta amendment, 2026-07-27): deck-scoped daily picks ---
+
+function customSetFixture(id: string, title: string, lemmaKeys: string[]) {
+  return {
+    id,
+    title,
+    description: '',
+    lemma_keys: lemmaKeys,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    device_id: 'e2e-device',
+    revision: 1,
+  };
+}
+
+/** Opens the daily-zone disclosure (idempotent — `PracticeDailyDeck` can remount and
+ * reset `detailsOpen` across a deck switch) and reads the full featured word list. */
+async function readDailyDeckWords(page: Page): Promise<string[]> {
+  await expect(page.getByTestId('practice-daily-deck')).toBeVisible();
+  const summary = page.getByTestId('practice-daily-summary');
+  if ((await summary.getAttribute('aria-expanded')) !== 'true') {
+    await summary.click();
+  }
+  const rows = page.locator('.daily-deck-row .row-lemma');
+  await expect(rows.first()).toBeVisible();
+  return rows.allTextContents();
+}
+
+test('A8: two different custom decks show different daily-zone sets, each drawn from its own deck', async ({
+  page,
+  context,
+}) => {
+  await context.clearCookies();
+  const deckAlpha = customSetFixture('e2e-d10-alpha', 'E2E D10 Alpha Deck', [
+    'e2eD10Alpha1',
+    'e2eD10Alpha2',
+    'e2eD10Alpha3',
+  ]);
+  const deckBeta = customSetFixture('e2e-d10-beta', 'E2E D10 Beta Deck', [
+    'e2eD10Beta1',
+    'e2eD10Beta2',
+    'e2eD10Beta3',
+  ]);
+  await page.addInitScript(
+    ([alpha, beta]) => {
+      window.localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([alpha, beta]));
+    },
+    [deckAlpha, deckBeta] as const,
+  );
+
+  await page.goto('/words-of-the-day/practice/');
+
+  await page.getByRole('button', { name: /E2E D10 Alpha Deck/ }).click();
+  await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Alpha Deck');
+  const alphaWords = await readDailyDeckWords(page);
+  // Both fixture decks have fewer than 12 words — the zone shows all of them (D10 edge case).
+  expect(new Set(alphaWords)).toEqual(new Set(deckAlpha.lemma_keys));
+
+  await page.getByRole('button', { name: /E2E D10 Beta Deck/ }).click();
+  await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Beta Deck');
+  const betaWords = await readDailyDeckWords(page);
+  expect(new Set(betaWords)).toEqual(new Set(deckBeta.lemma_keys));
+
+  expect(alphaWords.some((word) => betaWords.includes(word))).toBe(false);
+});
+
+test('A9a: a deck-scoped daily set is stable within a day and rotates across days', async ({ page, context }) => {
+  await context.clearCookies();
+  const words = Array.from({ length: 20 }, (_, i) => `e2eD10Rot${i}`);
+  const deck = customSetFixture('e2e-d10-rot', 'E2E D10 Rotation Deck', words);
+  await page.addInitScript((set) => {
+    window.localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([set]));
+  }, deck);
+
+  async function selectDeckAndReadWords(clockTime: string): Promise<string[]> {
+    await page.clock.setFixedTime(new Date(clockTime));
+    await page.goto('/words-of-the-day/practice/');
+    await page.getByRole('button', { name: /E2E D10 Rotation Deck/ }).click();
+    await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Rotation Deck');
+    return readDailyDeckWords(page);
+  }
+
+  await page.clock.install({ time: new Date('2026-07-20T12:00:00.000Z') });
+  const day1First = await selectDeckAndReadWords('2026-07-20T12:00:00.000Z');
+  expect(day1First.length).toBe(12);
+
+  // Same calendar day, different time of day: stability.
+  const day1Second = await selectDeckAndReadWords('2026-07-20T18:00:00.000Z');
+  expect(new Set(day1Second)).toEqual(new Set(day1First));
+
+  // A different calendar day: rotation (20-word pool makes a same-12 collision negligible).
+  const day2 = await selectDeckAndReadWords('2026-07-21T12:00:00.000Z');
+  expect(new Set(day2)).not.toEqual(new Set(day1First));
+});
+
+test('A9b: the All-Words daily set is stable within a day and rotates across days', async ({ page, context }) => {
+  await context.clearCookies();
+  await page.addInitScript(() => window.localStorage.setItem('lu-learner-level', 'A1'));
+
+  async function readAllWordsAt(clockTime: string): Promise<string[]> {
+    await page.clock.setFixedTime(new Date(clockTime));
+    await page.goto('/words-of-the-day/practice/');
+    return readDailyDeckWords(page);
+  }
+
+  await page.clock.install({ time: new Date('2026-07-20T12:00:00.000Z') });
+  const day1First = await readAllWordsAt('2026-07-20T12:00:00.000Z');
+  expect(day1First.length).toBeGreaterThan(0);
+
+  const day1Second = await readAllWordsAt('2026-07-20T18:00:00.000Z');
+  expect(new Set(day1Second)).toEqual(new Set(day1First));
+
+  const day2 = await readAllWordsAt('2026-07-21T12:00:00.000Z');
+  expect(new Set(day2)).not.toEqual(new Set(day1First));
+});
+
 test.describe('daily preview UTC boundary', () => {
   test.use({ timezoneId: 'UTC' });
 

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -82,7 +82,7 @@ import {
   normalizeCefrLevel,
   type CefrLevel,
 } from '../lib/lexicon/levels';
-import { dateSeed, pickDaily, type DailyWord } from '../lib/lexicon/daily';
+import { dateSeed, deckSeed, pickDaily, type DailyWord } from '../lib/lexicon/daily';
 import { getTeacherLessonVirtualDeck, readLocalCustomSets, saveLocalCustomSet, deleteLocalCustomSet, type CustomSet } from '../lib/lexicon/custom-decks';
 import { syncCustomSetsToDrive, requestGoogleAccessToken, setInMemoryAccessToken, getInMemoryAccessToken } from '../lib/lexicon/google-drive-sync';
 import { LexiconCustomDeckManager } from './LexiconCustomDeckManager';
@@ -1054,6 +1054,18 @@ function filterIndexByDeckFilter(
   return index.filter((item) => deckFilterAllowsLemma(item.lemmaId, item.lemma, deckFilter, customSets));
 }
 
+/**
+ * D10 (design delta 2026-07-27): the raw lemma keys owned by the active deck filter,
+ * or `null` for 'all' — meaning the atlas-global daily pool applies unchanged (D2).
+ * Mirrors `deckFilterAllowsLemma`'s own key resolution so the daily zone can never
+ * disagree with the session/estimate machinery about which deck owns which lemma.
+ */
+function resolveDeckLemmaKeys(deckFilter: string, customSets: CustomSet[]): string[] | null {
+  if (deckFilter === 'all') return null;
+  if (deckFilter === 'virtual_teacher_lesson') return getTeacherLessonVirtualDeck().lemma_keys;
+  return customSets.find((s) => s.id === deckFilter)?.lemma_keys ?? [];
+}
+
 /** Learner level persisted in the shared `lu-learner-level` key (also used by Words of the Day). */
 function readLearnerLevel(fallback: CefrLevel): CefrLevel {
   if (typeof window === 'undefined') return fallback;
@@ -1342,6 +1354,16 @@ function LexiconPracticeIsland({
   // chromeLocale via ChromeText/ChromeDual — never slash-dual (#5503).
   const showEnglishSubtitles = learnerLevel === 'A1' || chromeLocale === 'en';
 
+  // D10: the Words-of-the-Day zone's source line names the active deck. `null`
+  // for 'all' (and for a stale/deleted deck id) falls back to the plain title.
+  const activeDeckTitle = useMemo(() => {
+    if (selectedDeckFilter === 'all') return null;
+    if (selectedDeckFilter === 'virtual_teacher_lesson') {
+      return chromeLocale === 'uk' ? 'Відібрана добірка' : 'Curated Deck';
+    }
+    return customSets.find((s) => s.id === selectedDeckFilter)?.title ?? null;
+  }, [selectedDeckFilter, customSets, chromeLocale]);
+
   const matchedSelectedRatingRef = useRef<PracticeRating | null>(null);
   const matchingTargetOutcomeRef = useRef<CompletionOutcome | null>(null);
 
@@ -1530,6 +1552,11 @@ function LexiconPracticeIsland({
   // lemma/gloss/pos data. The daily pool and practice-core shards are built
   // independently, so an orphaned pool row is normalized into a displayable
   // preview card from its verified pool metadata rather than rendering as —.
+  //
+  // D10 (amendment, 2026-07-27): 'All Words' keeps the above unchanged. Any other
+  // deck filter draws the daily picks FROM THAT DECK instead — pickDaily(deckPool,
+  // dateSeed(now) + deckSeed(deckId), 12) — so the featured zone (and its default
+  // session) react to the learner's deck choice, not just the atlas-global pool.
   useEffect(() => {
     if (sessionPhase !== 'idle') return;
 
@@ -1542,24 +1569,41 @@ function LexiconPracticeIsland({
         const dateKey = todayKey(now);
         const state = loadState();
         const indexSource = deck?.index ?? dueIndex ?? [];
+        const deckLemmaKeys = resolveDeckLemmaKeys(selectedDeckFilter, customSets);
 
-        const pool = await getShardJson<DailyWord[]>(
-          '/lexicon/daily-pool.json',
-          shardJsonCacheRef.current,
-        );
-        const eligiblePool = filterByCumulativeLevel(pool, learnerLevel);
-        const picks = pickDaily(eligiblePool, dateSeed(now), DAILY_PRACTICE_DECK_SIZE);
+        let picks: DailyWord[] = [];
+        let representedLevels: Set<string>;
 
-        // Fetch lexeme cores only for levels represented among today's picks —
-        // or all selected-level cores for the defined fallback when the daily
-        // pool is empty.
-        const levelsForDailyPreview = picks.length > 0
-          ? picks.map((word) => word.cefr)
-          : levelsUpTo(learnerLevel);
-        const representedLevels = new Set(
-          levelsForDailyPreview.filter((cefr): cefr is string => Boolean(cefr)),
-        );
-        const levelEntries = deck
+        if (deckLemmaKeys === null) {
+          const pool = await getShardJson<DailyWord[]>(
+            '/lexicon/daily-pool.json',
+            shardJsonCacheRef.current,
+          );
+          const eligiblePool = filterByCumulativeLevel(pool, learnerLevel);
+          picks = pickDaily(eligiblePool, dateSeed(now), DAILY_PRACTICE_DECK_SIZE);
+
+          // Fetch lexeme cores only for levels represented among today's picks —
+          // or all selected-level cores for the defined fallback when the daily
+          // pool is empty.
+          const levelsForDailyPreview = picks.length > 0
+            ? picks.map((word) => word.cefr)
+            : levelsUpTo(learnerLevel);
+          representedLevels = new Set(
+            levelsForDailyPreview.filter((cefr): cefr is string => Boolean(cefr)),
+          );
+        } else {
+          // A deck's words can sit at any level (or none — an unverified custom
+          // import) — resolve against every published level's shard rather than
+          // guessing from the learner's currently selected level.
+          representedLevels = new Set<string>(PUBLISHED_PRACTICE_LEVELS);
+        }
+
+        // The atlas branch can skip this fetch once `deck` already covers the
+        // learner's levels. The deck-scoped branch cannot: `deck` only gets
+        // per-lemma coverage for the ACTIVE deck filter when a drill mode has
+        // loaded cloze (`ensureDeckCustomSetCoverage`), which the idle setup
+        // screen has often never triggered — so it fetches independently.
+        const levelEntries = deck && deckLemmaKeys === null
           ? []
           : await Promise.all(
               Array.from(representedLevels).map(async (level) => {
@@ -1596,41 +1640,75 @@ function LexiconPracticeIsland({
           ...(deck?.cloze ?? []),
           ...levelEntries.flatMap((batch) => batch.cloze),
         ]);
-        for (const word of picks) {
-          if (lexemes.has(word.slug)) continue;
-          // The daily pool is itself a verified learner-facing source. Preserve
-          // its unified pick even when the independently generated practice
-          // shard lacks that lemma, using the metadata available on the row.
-          lexemes.set(word.slug, {
-            lemmaId: word.slug,
-            lemma: word.lemma,
-            lemmaPlain: word.lemma,
-            ipa: null,
-            gloss: word.gloss ?? word.lemma,
-            pos: null,
-            cefr: word.cefr ?? null,
-            heritage: null,
-            severity: null,
-            paradigm: { cases: {} },
+
+        let displayablePicks: DailyWord[];
+        if (deckLemmaKeys !== null) {
+          // Case-insensitive lookup, matching `deckFilterAllowsLemma`'s own
+          // lemmaId-or-lemma comparison — deck keys are free-form learner input.
+          const lexemesByLower = new Map<string, PracticeLexeme>();
+          for (const entry of lexemes.values()) {
+            lexemesByLower.set(entry.lemmaId.toLowerCase(), entry);
+            lexemesByLower.set(entry.lemma.toLowerCase(), entry);
+          }
+          const deckPool: DailyWord[] = deckLemmaKeys.map((key) => {
+            const match = lexemes.get(key) ?? lexemesByLower.get(key.toLowerCase()) ?? null;
+            // A deck word with no atlas/level match still deserves a real-looking
+            // card — same cleanup `ensureDeckCustomSetCoverage` applies for the
+            // session pool, so the preview and the session never disagree.
+            const cleanKey = key.replace(/\(.*?\)/g, '').trim() || key;
+            return {
+              lemma: match?.lemma ?? cleanKey,
+              slug: match?.lemmaId ?? key,
+              gloss: match?.gloss ?? cleanKey,
+              cefr: match?.cefr ?? undefined,
+              pos: match?.pos ?? undefined,
+              example: match?.example ?? undefined,
+              exampleEn: match?.exampleEn ?? undefined,
+            };
           });
+          displayablePicks = pickDaily(
+            deckPool,
+            dateSeed(now) + deckSeed(selectedDeckFilter),
+            DAILY_PRACTICE_DECK_SIZE,
+          );
+        } else {
+          for (const word of picks) {
+            if (lexemes.has(word.slug)) continue;
+            // The daily pool is itself a verified learner-facing source. Preserve
+            // its unified pick even when the independently generated practice
+            // shard lacks that lemma, using the metadata available on the row.
+            lexemes.set(word.slug, {
+              lemmaId: word.slug,
+              lemma: word.lemma,
+              lemmaPlain: word.lemma,
+              ipa: null,
+              gloss: word.gloss ?? word.lemma,
+              pos: null,
+              cefr: word.cefr ?? null,
+              heritage: null,
+              severity: null,
+              paradigm: { cases: {} },
+            });
+          }
+          // A genuinely empty daily pool has no unified pick set. In that case,
+          // deterministically use the selected level's curated practice cores
+          // rather than render an empty daily card.
+          const fallbackPool: DailyWord[] = Array.from(lexemes.values()).map((lexeme) => ({
+            lemma: lexeme.lemma,
+            slug: lexeme.lemmaId,
+            gloss: lexeme.gloss,
+            cefr: lexeme.cefr ?? undefined,
+          }));
+          displayablePicks = picks.length > 0
+            ? picks
+            : pickDaily(fallbackPool, dateSeed(now), DAILY_PRACTICE_DECK_SIZE);
         }
-        // A genuinely empty daily pool has no unified pick set. In that case,
-        // deterministically use the selected level's curated practice cores
-        // rather than render an empty daily card.
-        const fallbackPool: DailyWord[] = Array.from(lexemes.values()).map((lexeme) => ({
-          lemma: lexeme.lemma,
-          slug: lexeme.lemmaId,
-          gloss: lexeme.gloss,
-          cefr: lexeme.cefr ?? undefined,
-        }));
-        const displayablePicks = picks.length > 0
-          ? picks
-          : pickDaily(fallbackPool, dateSeed(now), DAILY_PRACTICE_DECK_SIZE);
+
         const snapshot: DailyPracticeDeckSnapshot = {
           version: 2,
           date: dateKey,
           level: learnerLevel,
-          deckVersion: 'daily-pool',
+          deckVersion: deckLemmaKeys !== null ? selectedDeckFilter : 'daily-pool',
           createdAt: now.getTime(),
           items: displayablePicks.map((word) => ({
             lemmaId: word.slug,
@@ -1658,7 +1736,17 @@ function LexiconPracticeIsland({
     return () => {
       cancelled = true;
     };
-  }, [deck?.index, deck?.lexemes, deck?.cloze, dueIndex, learnerLevel, sessionPhase, shardBaseUrl]);
+  }, [
+    deck?.index,
+    deck?.lexemes,
+    deck?.cloze,
+    dueIndex,
+    learnerLevel,
+    sessionPhase,
+    shardBaseUrl,
+    selectedDeckFilter,
+    customSets,
+  ]);
 
   const indexForStats = (deck?.index ?? dueIndex ?? []).filter(
     (item) => !focusedLemmaId || item.lemmaId === focusedLemmaId
@@ -2993,7 +3081,16 @@ function LexiconPracticeIsland({
               {dailySnapshotLoading || !dailySnapshot ? (
                 <div className="practice-daily-deck k3-words-loading" data-testid="practice-daily-deck-loading">
                   <div className="daily-deck-header">
-                    <h2><ChromeText k="practice.wordsTitle" /></h2>
+                    <h2>
+                      {activeDeckTitle ? (
+                        <ChromeDual
+                          uk={`Слова дня — ${activeDeckTitle}`}
+                          en={`Words of the day — ${activeDeckTitle}`}
+                        />
+                      ) : (
+                        <ChromeText k="practice.wordsTitle" />
+                      )}
+                    </h2>
                   </div>
                   <div className="daily-deck-preview-shell">
                     <div className="flashcard daily-preview-card">
@@ -3016,6 +3113,7 @@ function LexiconPracticeIsland({
                   atlasLemmaHref={atlasLemmaHref}
                   chromeLocale={chromeLocale}
                   learnerLevel={learnerLevel}
+                  deckTitle={activeDeckTitle}
                 />
               )}
             </div>

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1356,13 +1356,14 @@ function LexiconPracticeIsland({
 
   // D10: the Words-of-the-Day zone's source line names the active deck. `null`
   // for 'all' (and for a stale/deleted deck id) falls back to the plain title.
-  const activeDeckTitle = useMemo(() => {
+  const activeDeckTitles = useMemo(() => {
     if (selectedDeckFilter === 'all') return null;
     if (selectedDeckFilter === 'virtual_teacher_lesson') {
-      return chromeLocale === 'uk' ? 'Відібрана добірка' : 'Curated Deck';
+      return { uk: 'Відібрана добірка', en: 'Curated Deck' };
     }
-    return customSets.find((s) => s.id === selectedDeckFilter)?.title ?? null;
-  }, [selectedDeckFilter, customSets, chromeLocale]);
+    const title = customSets.find((s) => s.id === selectedDeckFilter)?.title;
+    return title ? { uk: title, en: title } : null;
+  }, [selectedDeckFilter, customSets]);
 
   const matchedSelectedRatingRef = useRef<PracticeRating | null>(null);
   const matchingTargetOutcomeRef = useRef<CompletionOutcome | null>(null);
@@ -1660,6 +1661,7 @@ function LexiconPracticeIsland({
               lemma: match?.lemma ?? cleanKey,
               slug: match?.lemmaId ?? key,
               gloss: match?.gloss ?? cleanKey,
+              hasAtlasEntry: Boolean(match),
               cefr: match?.cefr ?? undefined,
               pos: match?.pos ?? undefined,
               example: match?.example ?? undefined,
@@ -1697,6 +1699,7 @@ function LexiconPracticeIsland({
             lemma: lexeme.lemma,
             slug: lexeme.lemmaId,
             gloss: lexeme.gloss,
+            hasAtlasEntry: true,
             cefr: lexeme.cefr ?? undefined,
           }));
           displayablePicks = picks.length > 0
@@ -1715,6 +1718,7 @@ function LexiconPracticeIsland({
             origin: classifyDailyPracticeOrigin(word.slug, indexSource, state.cards, now),
             lemma: word.lemma,
             gloss: word.gloss,
+            hasAtlasEntry: word.hasAtlasEntry ?? true,
             cefr: word.cefr ?? null,
             pos: word.pos ?? null,
             example: word.example ?? null,
@@ -3082,10 +3086,10 @@ function LexiconPracticeIsland({
                 <div className="practice-daily-deck k3-words-loading" data-testid="practice-daily-deck-loading">
                   <div className="daily-deck-header">
                     <h2>
-                      {activeDeckTitle ? (
+                      {activeDeckTitles ? (
                         <ChromeDual
-                          uk={`Слова дня — ${activeDeckTitle}`}
-                          en={`Words of the day — ${activeDeckTitle}`}
+                          uk={`Слова дня — ${activeDeckTitles.uk}`}
+                          en={`Words of the day — ${activeDeckTitles.en}`}
                         />
                       ) : (
                         <ChromeText k="practice.wordsTitle" />
@@ -3113,7 +3117,8 @@ function LexiconPracticeIsland({
                   atlasLemmaHref={atlasLemmaHref}
                   chromeLocale={chromeLocale}
                   learnerLevel={learnerLevel}
-                  deckTitle={activeDeckTitle}
+                  deckTitleUk={activeDeckTitles?.uk}
+                  deckTitleEn={activeDeckTitles?.en}
                 />
               )}
             </div>

--- a/site/src/components/PracticeDailyDeck.tsx
+++ b/site/src/components/PracticeDailyDeck.tsx
@@ -20,6 +20,8 @@ export interface PracticeDailyDeckProps {
   atlasLemmaHref: (lemmaId: string) => string;
   chromeLocale: ChromeLocale;
   learnerLevel: CefrLevel;
+  /** D10: the active deck's display title, or `null` for 'All Words' (unscoped). */
+  deckTitle?: string | null;
 }
 
 const STATUS_META = {
@@ -39,6 +41,7 @@ export default function PracticeDailyDeck({
   atlasLemmaHref,
   chromeLocale,
   learnerLevel,
+  deckTitle = null,
 }: PracticeDailyDeckProps) {
   const [previewIndex, setPreviewIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
@@ -90,8 +93,15 @@ export default function PracticeDailyDeck({
   return (
     <div className="practice-daily-deck" data-testid="practice-daily-deck">
       <div className="daily-deck-header">
-        <h2>
-          <ChromeText k="practice.wordsTitle" />
+        <h2 data-testid="practice-daily-deck-title">
+          {deckTitle ? (
+            <ChromeDual
+              uk={`Слова дня — ${deckTitle}`}
+              en={`Words of the day — ${deckTitle}`}
+            />
+          ) : (
+            <ChromeText k="practice.wordsTitle" />
+          )}
         </h2>
         <span className="daily-deck-position" aria-live="polite">
           <ChromeDual

--- a/site/src/components/PracticeDailyDeck.tsx
+++ b/site/src/components/PracticeDailyDeck.tsx
@@ -20,8 +20,9 @@ export interface PracticeDailyDeckProps {
   atlasLemmaHref: (lemmaId: string) => string;
   chromeLocale: ChromeLocale;
   learnerLevel: CefrLevel;
-  /** D10: the active deck's display title, or `null` for 'All Words' (unscoped). */
-  deckTitle?: string | null;
+  /** D10: independently localized active-deck titles, or undefined for All Words. */
+  deckTitleUk?: string | null;
+  deckTitleEn?: string | null;
 }
 
 const STATUS_META = {
@@ -41,7 +42,8 @@ export default function PracticeDailyDeck({
   atlasLemmaHref,
   chromeLocale,
   learnerLevel,
-  deckTitle = null,
+  deckTitleUk = null,
+  deckTitleEn = null,
 }: PracticeDailyDeckProps) {
   const [previewIndex, setPreviewIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
@@ -94,10 +96,10 @@ export default function PracticeDailyDeck({
     <div className="practice-daily-deck" data-testid="practice-daily-deck">
       <div className="daily-deck-header">
         <h2 data-testid="practice-daily-deck-title">
-          {deckTitle ? (
+          {deckTitleUk && deckTitleEn ? (
             <ChromeDual
-              uk={`Слова дня — ${deckTitle}`}
-              en={`Words of the day — ${deckTitle}`}
+              uk={`Слова дня — ${deckTitleUk}`}
+              en={`Words of the day — ${deckTitleEn}`}
             />
           ) : (
             <ChromeText k="practice.wordsTitle" />
@@ -182,7 +184,7 @@ export default function PracticeDailyDeck({
       </div>
 
       <div className="daily-deck-preview-actions">
-        {currentLemmaId && (
+        {currentLemmaId && currentItem?.hasAtlasEntry !== false && (
           <a
             href={atlasLemmaHref(currentLemmaId)}
             className="daily-deck-atlas-link"
@@ -234,6 +236,24 @@ export default function PracticeDailyDeck({
                 : row.state === 'new'
                   ? { uk: 'Нове слово', en: 'New word' }
                   : { uk: 'Вивчено · сьогодні', en: 'Done · today' };
+            const rowContent = (
+              <>
+                <span className="row-marker" aria-hidden="true">
+                  {meta.glyph}
+                </span>
+                <span className="row-number">{index + 1}</span>
+                <span className="row-identity">
+                  <span className="row-lemma">{displayLemma(rowLemma)}</span>
+                  {rowGloss ? <span className="row-gloss">{rowGloss}</span> : null}
+                  <span className="row-why" data-testid={`practice-daily-why-${row.item.lemmaId}`}>
+                    <ChromeDual uk={why.uk} en={why.en} />
+                  </span>
+                </span>
+                <span className="row-status">
+                  <ChromeText k={meta.labelKey} />
+                </span>
+              </>
+            );
             return (
               <li
                 key={row.item.lemmaId}
@@ -241,25 +261,18 @@ export default function PracticeDailyDeck({
                 data-state={row.state}
                 style={{ '--row-accent': meta.colorVar } as React.CSSProperties}
               >
-                <a
-                  href={atlasLemmaHref(row.item.lemmaId)}
-                  className="daily-deck-row-link"
-                >
-                  <span className="row-marker" aria-hidden="true">
-                    {meta.glyph}
-                  </span>
-                  <span className="row-number">{index + 1}</span>
-                  <span className="row-identity">
-                    <span className="row-lemma">{displayLemma(rowLemma)}</span>
-                    {rowGloss ? <span className="row-gloss">{rowGloss}</span> : null}
-                    <span className="row-why" data-testid={`practice-daily-why-${row.item.lemmaId}`}>
-                      <ChromeDual uk={why.uk} en={why.en} />
-                    </span>
-                  </span>
-                  <span className="row-status">
-                    <ChromeText k={meta.labelKey} />
-                  </span>
-                </a>
+                {row.item.hasAtlasEntry !== false ? (
+                  <a
+                    href={atlasLemmaHref(row.item.lemmaId)}
+                    className="daily-deck-row-link"
+                  >
+                    {rowContent}
+                  </a>
+                ) : (
+                  <div className="daily-deck-row-link">
+                    {rowContent}
+                  </div>
+                )}
               </li>
             );
           })}

--- a/site/src/lib/lexicon/daily.ts
+++ b/site/src/lib/lexicon/daily.ts
@@ -44,3 +44,18 @@ export function pickDaily<T>(pool: T[], seed: number, n: number): T[] {
   }
   return result.slice(0, Math.max(0, Math.min(n, result.length)));
 }
+
+/**
+ * Deterministic numeric contribution for a deck id, for combining with `dateSeed`
+ * (D10: `pickDaily(deckPool, dateSeed(today) + deckId, 12)`). `deckId` is a string,
+ * so a literal `+` would coerce the whole expression to NaN/0 — this hash gives the
+ * formula's intent (date AND deck both drive the draw) a real numeric seed.
+ */
+export function deckSeed(deckId: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < deckId.length; index += 1) {
+    hash ^= deckId.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}

--- a/site/src/lib/lexicon/daily.ts
+++ b/site/src/lib/lexicon/daily.ts
@@ -4,6 +4,11 @@ export interface DailyWord {
   lemma: string;
   slug: string;
   gloss: string | null;
+  /**
+   * Whether `slug` resolves to a real Atlas lemma page. Custom deck keys can
+   * remain displayable even when they have no atlas/practice-shard match.
+   */
+  hasAtlasEntry?: boolean;
   k?: string;
   lessonTag?: string;
   cefr?: string;

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -512,6 +512,8 @@ export interface DailyPracticeDeckItem {
   origin: 'due' | 'new';
   lemma: string;
   gloss: string | null;
+  /** False only for displayable custom-deck keys without an Atlas lexeme match. */
+  hasAtlasEntry?: boolean;
   cefr: string | null;
   pos: string | null;
   example?: string | null;
@@ -2456,6 +2458,7 @@ function normalizeDailyPracticeDeckSnapshot(
     if (!isValidDailyPracticeDeckOrigin(item.origin)) return null;
     if (typeof item.lemma !== 'string' || !item.lemma) return null;
     if (typeof item.gloss !== 'string' && item.gloss !== null) return null;
+    if (typeof item.hasAtlasEntry !== 'boolean' && item.hasAtlasEntry !== undefined) return null;
     if (typeof item.cefr !== 'string' && item.cefr !== null) return null;
     if (typeof item.pos !== 'string' && item.pos !== null) return null;
     const example =
@@ -2471,6 +2474,7 @@ function normalizeDailyPracticeDeckSnapshot(
       origin: item.origin,
       lemma: item.lemma,
       gloss: item.gloss,
+      ...(item.hasAtlasEntry !== undefined ? { hasAtlasEntry: item.hasAtlasEntry } : {}),
       cefr: item.cefr,
       pos: item.pos,
       ...(example !== undefined ? { example } : {}),

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -790,6 +790,63 @@ describe('LexiconPractice', () => {
     expect(screen.queryByText('—')).not.toBeInTheDocument();
   });
 
+  test('omits Atlas links for an unmatched custom-deck key but keeps them for a matched lemma', () => {
+    const makeSnapshot = (hasAtlasEntry: boolean): DailyPracticeDeckSnapshot => ({
+      version: 2,
+      date: '2026-06-23',
+      level: 'A1',
+      deckVersion: 'custom-deck',
+      createdAt: NOW.getTime(),
+      items: [{
+        lemmaId: 'synthetic-custom-key',
+        origin: 'new',
+        lemma: 'Синтетичний ключ',
+        gloss: 'Synthetic key',
+        hasAtlasEntry,
+        cefr: null,
+        pos: null,
+      }],
+    });
+    const rowsFor = (snapshot: DailyPracticeDeckSnapshot) => ({
+      pendingDue: [],
+      pendingNew: [{ item: snapshot.items[0]!, state: 'new' as const, lastSeenAt: null }],
+      done: [],
+    });
+    const atlasLemmaHref = (lemmaId: string) => `/lexicon/${lemmaId}/`;
+    const orphan = makeSnapshot(false);
+    const { container, rerender } = render(
+      <PracticeDailyDeck
+        snapshot={orphan}
+        rows={rowsFor(orphan)}
+        lexemes={new Map()}
+        atlasLemmaHref={atlasLemmaHref}
+        chromeLocale="uk"
+        learnerLevel="A1"
+      />,
+    );
+
+    expect(screen.queryByTestId('practice-preview-atlas-link')).not.toBeInTheDocument();
+    expect(container.querySelectorAll('a[href="/lexicon/synthetic-custom-key/"]')).toHaveLength(0);
+
+    const matched = makeSnapshot(true);
+    rerender(
+      <PracticeDailyDeck
+        snapshot={matched}
+        rows={rowsFor(matched)}
+        lexemes={new Map()}
+        atlasLemmaHref={atlasLemmaHref}
+        chromeLocale="uk"
+        learnerLevel="A1"
+      />,
+    );
+
+    expect(screen.getByTestId('practice-preview-atlas-link')).toHaveAttribute(
+      'href',
+      '/lexicon/synthetic-custom-key/',
+    );
+    expect(container.querySelectorAll('a[href="/lexicon/synthetic-custom-key/"]')).toHaveLength(2);
+  });
+
   test('enriches the daily card with ipa/pos from the practice-lexemes map when the pick payload has neither (#5852)', () => {
     const enrichment = lexeme('борщ', 'борщ', 'borscht (lexeme gloss)', {
       nominative: 'борщ',
@@ -3300,6 +3357,14 @@ describe('LexiconPractice', () => {
       await user.click(teacherBtn);
       expect(teacherBtn).toHaveClass('btn-primary');
       expect(screen.queryByText(/We couldn’t load practice/i)).not.toBeInTheDocument();
+
+      const dailyTitle = await screen.findByTestId('practice-daily-deck-title');
+      expect(dailyTitle.querySelector('[data-loc="uk"]')).toHaveTextContent(
+        'Слова дня — Відібрана добірка',
+      );
+      expect(dailyTitle.querySelector('[data-loc="en"]')).toHaveTextContent(
+        'Words of the day — Curated Deck',
+      );
     });
 
     test.each([

--- a/site/tests/unit/lexicon-daily.test.ts
+++ b/site/tests/unit/lexicon-daily.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { dateSeed, pickDaily } from '@site/src/lib/lexicon/daily';
+import { dateSeed, deckSeed, pickDaily } from '@site/src/lib/lexicon/daily';
 
 describe('dateSeed', () => {
   test('uses the local calendar date', () => {
@@ -27,5 +27,33 @@ describe('pickDaily', () => {
     const pool = [{ slug: 'a' }, { slug: 'b' }];
 
     expect(pickDaily(pool, 20260623, 24)).toHaveLength(pool.length);
+  });
+});
+
+describe('deckSeed', () => {
+  test('is deterministic and varies by deck id', () => {
+    expect(deckSeed('virtual_teacher_lesson')).toBe(deckSeed('virtual_teacher_lesson'));
+    expect(deckSeed('set_alpha')).not.toBe(deckSeed('set_beta'));
+    expect(deckSeed('all')).not.toBe(deckSeed('virtual_teacher_lesson'));
+  });
+
+  test('combined with dateSeed, draws different sets for different decks on the same day', () => {
+    const pool = Array.from({ length: 30 }, (_, i) => `word-${i}`);
+    const day = dateSeed(new Date(2026, 5, 23));
+
+    const deckA = pickDaily(pool, day + deckSeed('set_alpha'), 12);
+    const deckB = pickDaily(pool, day + deckSeed('set_beta'), 12);
+
+    expect(deckA).not.toEqual(deckB);
+  });
+
+  test('combined with dateSeed, is stable for the same deck and day but rotates across days', () => {
+    const pool = Array.from({ length: 30 }, (_, i) => `word-${i}`);
+    const day1 = dateSeed(new Date(2026, 5, 23));
+    const day2 = dateSeed(new Date(2026, 5, 24));
+    const seed = deckSeed('set_alpha');
+
+    expect(pickDaily(pool, day1 + seed, 12)).toEqual(pickDaily(pool, day1 + seed, 12));
+    expect(pickDaily(pool, day1 + seed, 12)).not.toEqual(pickDaily(pool, day2 + seed, 12));
   });
 });


### PR DESCRIPTION
## Summary
- Normative spec: `.claude/atlas-epic/design/2026-07-26-practice-ux-batch-design.md` § D10 (frozen, amendment to the D2/D3 practice-UX delta, rides on PR #5856's payload-first render layer).
- 'All Words' keeps the unchanged atlas-global `pickDaily(atlasPool, dateSeed(today), 12)` (D2). Selecting a specific deck (Curated Deck or a custom set) now draws the Words-of-the-Day zone from that deck's own words instead — `pickDaily(deckPool, dateSeed(today) + deckSeed(deckId), 12)` (new `deckSeed` hash, since a literal `+` between a number and a string seed would coerce to NaN/0).
- `deckPool` is built from the deck's `lemma_keys` resolved against loaded lexeme data (matching `deckFilterAllowsLemma`'s own lemmaId-or-lemma, case-insensitive lookup), each carrying the same DailyWord shape the flashcard already renders from (lemma/slug/gloss/cefr/example where present) — with a clean-key fallback (mirroring `ensureDeckCustomSetCoverage`) for deck words with no shard match.
- The zone's source line now names the active deck ("Слова дня — <title>" / "Words of the day — <title>"), both locales, in both the loaded state and the loading placeholder.
- Edge cases: a deck under 12 words shows all of them (existing `pickDaily` cap); an empty deck falls back to the pre-existing "—" empty-state card; the Curated Deck's unlock gate is untouched (not referenced by this change).
- Fixed a real staleness bug along the way: the daily-snapshot effect's dependency array was missing `selectedDeckFilter`/`customSets`, so switching decks could leave the zone showing a stale pool until an unrelated dependency happened to change.
- The session snapshot's deckId mismatch-discard (D2's "a stored atlas-pool snapshot must not survive selecting a custom deck, and vice versa") was already implemented and already covered by an existing unit test (`practice-session.test.ts`) — verified it still passes, nothing new needed there.

## Test plan
- [x] `tests/unit/lexicon-daily.test.ts` — new `deckSeed` determinism/variance tests, plus a combined-with-`dateSeed` stability/rotation test
- [x] Full unit suite (`vitest run`, 53 files / 836 passed, 4 skipped — pre-existing skips) green
- [x] `tsc --noEmit` — 0 new errors (780 pre-existing, unrelated, verified identical against the pre-change baseline)
- [x] `eslint` on all touched files — 0 new warnings/errors (27 pre-existing, unrelated, verified identical against the pre-change baseline)
- [x] New e2e: A8 (two custom decks → disjoint, deck-scoped sets), A9a (deck-scoped stability within a day + rotation across days), A9b (same for 'All Words')
- [x] Full `e2e/atlas-practice.spec.ts` (31 tests, including A1–A9) green against a fresh `npm run build` + `astro preview`

## Notes for the reviewer
- Local dev note (not part of this diff): `npm install` on Node 26 fails on `fsevents`' install script under `--strict-allow-scripts` (not in `allowScripts`); denying it (`"fsevents": false`) unblocks install with no functional loss (it's an optional macOS fs-watcher shim). Left out of this PR since it's unrelated to D10 — flagging in case others hit it on a fresh machine.
- Also hit a Node 26 vs. the CI-pinned Node 22 mismatch: Node 26's stabilized native `globalThis.localStorage` shadows happy-dom's polyfill unless vitest is run with `NODE_OPTIONS=--no-experimental-webstorage`. Not a repo issue — just what made unit tests need that flag locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix-round note
- Daily-zone synthetic custom-deck keys now render without an Atlas link; matched entries retain it. The analogous synthetic-id behavior in the main session view is pre-existing and intentionally out of scope for this targeted fix round.