### PR TITLE
feat(taxonomy): registry-derived slot inbox identities + slot→holder resolution (step 4b)

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -71,7 +71,7 @@ class StaleClaimError(Exception):
 
 # ── Constants ──────────────────────────────────────────────────────────
 
-VALID_AGENTS = (
+STATIC_VALID_AGENTS = (
     "agy",
     "claude",
     "claude-infra",
@@ -88,8 +88,87 @@ VALID_AGENTS = (
     "claude-desktop",
     "codex-desktop",
 )
+VALID_AGENTS = STATIC_VALID_AGENTS
 VALID_POST_AGENTS = (*VALID_AGENTS, "user")
 VALID_RECIPIENT_AGENTS = VALID_AGENTS
+
+ASSIGNMENTS_PATH = REPO_ROOT / "scripts" / "config" / "area_assignments.yaml"
+_SLOTS_CACHE: dict[str, Any] = {"key": None, "slots": ()}
+
+
+def _load_registry_slots(assignments_path: Path | None = None) -> tuple[str, ...]:
+    """Load slot identities from area_assignments.yaml.
+
+    Lazy load, fail-open: returns empty tuple on missing file, parse error,
+    or missing PyYAML.
+    """
+    path = (assignments_path or ASSIGNMENTS_PATH).resolve()
+    try:
+        if not path.is_file():
+            return ()
+        text = path.read_text(encoding="utf-8")
+        try:
+            import yaml
+
+            raw_data = yaml.safe_load(text)
+        except ImportError:
+            return ()
+        if not isinstance(raw_data, dict):
+            return ()
+        assignments = raw_data.get("assignments")
+        if not isinstance(assignments, dict):
+            return ()
+        slots: list[str] = []
+        for area_data in assignments.values():
+            if isinstance(area_data, dict):
+                area_slots = area_data.get("slots", [])
+                if isinstance(area_slots, (list, tuple)):
+                    for slot in area_slots:
+                        if isinstance(slot, str) and slot.strip() and slot.strip() not in slots:
+                            slots.append(slot.strip())
+        return tuple(slots)
+    except Exception:
+        return ()
+
+
+def get_valid_agents(*, assignments_path: Path | None = None) -> tuple[str, ...]:
+    """Return valid agent identities: static tuple extended by registry-derived slots.
+
+    Keyed by file mtime+size to prevent stale caching in long-lived processes
+    while avoiding re-parsing unchanged files.
+    """
+    path = (assignments_path or ASSIGNMENTS_PATH).resolve()
+    slots: tuple[str, ...] = ()
+    try:
+        st = path.stat()
+        cache_key = (str(path), st.st_mtime, st.st_size)
+        if cache_key == _SLOTS_CACHE.get("key"):
+            slots = _SLOTS_CACHE.get("slots", ())
+        else:
+            slots = _load_registry_slots(path)
+            if slots:
+                _SLOTS_CACHE["key"] = cache_key
+                _SLOTS_CACHE["slots"] = slots
+    except Exception:
+        slots = ()
+
+    combined = list(STATIC_VALID_AGENTS)
+    for slot in slots:
+        if slot not in combined:
+            combined.append(slot)
+    return tuple(combined)
+
+
+def get_valid_post_agents(*, assignments_path: Path | None = None) -> tuple[str, ...]:
+    valids = get_valid_agents(assignments_path=assignments_path)
+    if "user" not in valids:
+        return (*valids, "user")
+    return valids
+
+
+def get_valid_recipient_agents(*, assignments_path: Path | None = None) -> tuple[str, ...]:
+    return get_valid_agents(assignments_path=assignments_path)
+
 VALID_KINDS = ("post", "reply", "system", "fanout_start", "fanout_end")
 VALID_DELIVERY_STATUSES = (
     "pending",
@@ -206,19 +285,22 @@ def context_sha256(path: Path) -> str:
         return ""
 
 
-def _validate_agent(agent: str) -> None:
-    if agent not in VALID_AGENTS:
-        raise ValueError(f"Unknown agent '{agent}'. Expected one of {VALID_AGENTS}.")
+def _validate_agent(agent: str, *, assignments_path: Path | None = None) -> None:
+    valids = get_valid_agents(assignments_path=assignments_path)
+    if agent not in valids:
+        raise ValueError(f"Unknown agent '{agent}'. Expected one of {valids}.")
 
 
-def _validate_post_agent(agent: str) -> None:
-    if agent not in VALID_POST_AGENTS:
-        raise ValueError(f"Unknown agent '{agent}'. Expected one of {VALID_POST_AGENTS}.")
+def _validate_post_agent(agent: str, *, assignments_path: Path | None = None) -> None:
+    valids = get_valid_post_agents(assignments_path=assignments_path)
+    if agent not in valids:
+        raise ValueError(f"Unknown agent '{agent}'. Expected one of {valids}.")
 
 
-def _validate_recipient_agent(agent: str) -> None:
-    if agent not in VALID_RECIPIENT_AGENTS:
-        raise ValueError(f"Unknown delivery target '{agent}'. Expected one of {VALID_RECIPIENT_AGENTS}.")
+def _validate_recipient_agent(agent: str, *, assignments_path: Path | None = None) -> None:
+    valids = get_valid_recipient_agents(assignments_path=assignments_path)
+    if agent not in valids:
+        raise ValueError(f"Unknown delivery target '{agent}'. Expected one of {valids}.")
 
 
 def _validate_priority(priority: str) -> None:
@@ -239,9 +321,10 @@ def dead_lane_agents() -> frozenset[str]:
 
 
 def live_agents() -> list[str]:
-    """Return ``VALID_AGENTS`` minus current dead lanes, registry order preserved."""
+    """Return ``get_valid_agents()`` minus current dead lanes, registry order preserved."""
     dead = dead_lane_agents()
-    return [a for a in VALID_AGENTS if a not in dead]
+    return [a for a in get_valid_agents() if a not in dead]
+
 
 
 def _validate_kind(kind: str) -> None:
@@ -899,8 +982,25 @@ def post(
     _validate_post_agent(from_agent)
     _validate_kind(kind)
     _validate_priority(priority)
+    warnings: list[str] = []
     for agent in to_agents or []:
         _validate_recipient_agent(agent)
+        if "-" in agent and agent not in STATIC_VALID_AGENTS:
+            try:
+                from scripts.orchestration.slot_routing import resolve_slot_holder
+
+                res = resolve_slot_holder(agent)
+                if not res.has_holder:
+                    msg = (
+                        f"⚠️ channel-bridge: recipient slot '{agent}' has no live holder "
+                        f"(queued at {res.queue_location})"
+                    )
+                    warnings.append(msg)
+                    import sys as _sys
+
+                    print(msg, file=_sys.stderr)
+            except Exception:
+                pass
     body = redact_text(body) or ""
     attachments = redact_value(attachments)
     monitor_state_snapshot = redact_value(monitor_state_snapshot)

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -146,9 +146,8 @@ def get_valid_agents(*, assignments_path: Path | None = None) -> tuple[str, ...]
             slots = _SLOTS_CACHE.get("slots", ())
         else:
             slots = _load_registry_slots(path)
-            if slots:
-                _SLOTS_CACHE["key"] = cache_key
-                _SLOTS_CACHE["slots"] = slots
+            _SLOTS_CACHE["key"] = cache_key
+            _SLOTS_CACHE["slots"] = slots
     except Exception:
         slots = ()
 

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -490,7 +490,7 @@ def register_channel_commands(subparsers: Any) -> None:
         )
         inbox_run.add_argument(
             "agent",
-            choices=list(_channels.VALID_AGENTS),
+            choices=list(_channels.get_valid_agents()),
             help="Agent inbox to drain",
         )
         inbox_mode = inbox_run.add_mutually_exclusive_group()
@@ -535,7 +535,7 @@ def register_channel_commands(subparsers: Any) -> None:
         )
         inbox_show.add_argument(
             "agent",
-            choices=list(_channels.VALID_AGENTS),
+            choices=list(_channels.get_valid_agents()),
             help="Agent inbox to inspect",
         )
         inbox_ack = inbox_sub.add_parser(
@@ -567,7 +567,7 @@ def register_channel_commands(subparsers: Any) -> None:
     sync_parser.add_argument(
         "agent",
         nargs="?",
-        choices=list(_channels.VALID_AGENTS),
+        choices=list(_channels.get_valid_agents()),
         help="Single agent inbox to drain",
     )
     sync_parser.add_argument(
@@ -1148,7 +1148,7 @@ def _broadcast_recipients(channel: dict[str, Any]) -> list[str]:
     """All live seats for a channel — its subscribers, or every valid agent
     if the channel has none configured — minus current dead lanes (#4837)."""
     live = set(_channels.live_agents())
-    base = channel["subscribers"] or list(_channels.VALID_AGENTS)
+    base = channel["subscribers"] or list(_channels.get_valid_agents())
     return [a for a in base if a in live]
 
 
@@ -1218,7 +1218,7 @@ def _handle_post(args) -> int:
         label = "📢 broadcast" if broadcast else "→"
         print(f"   {label} {', '.join(to_agents)}  ({len(result['delivery_ids'])} deliveries)")
     if broadcast:
-        excluded = sorted((set(ch["subscribers"] or _channels.VALID_AGENTS)) & _channels.dead_lane_agents())
+        excluded = sorted((set(ch["subscribers"] or _channels.get_valid_agents())) & _channels.dead_lane_agents())
         if excluded:
             print(f"   excluded dead lanes: {', '.join(excluded)}")
     return 0
@@ -1416,7 +1416,7 @@ def _handle_sync(args) -> int:
         return 2
 
     agents = (
-        [agent for agent in _channels.VALID_AGENTS if _cli_available_agent(agent)]
+        [agent for agent in _channels.get_valid_agents() if _cli_available_agent(agent)]
         if args.all
         else [args.agent]
     )
@@ -1494,11 +1494,11 @@ def _handle_discuss(args) -> int:
             file=sys.stderr,
         )
         return 1
-    unknown = [a for a in with_agents if a not in _channels.VALID_AGENTS]
+    unknown = [a for a in with_agents if a not in _channels.get_valid_agents()]
     if unknown:
         print(
             f"❌ unknown agent(s): {', '.join(unknown)} "
-            f"(valid: {', '.join(sorted(_channels.VALID_AGENTS))})",
+            f"(valid: {', '.join(sorted(_channels.get_valid_agents()))})",
             file=sys.stderr,
         )
         return 1

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -416,7 +416,7 @@ def register_channel_commands(subparsers: Any) -> None:
     )
     post_parser.add_argument(
         "--from-agent", default="user",
-        choices=list(_channels.VALID_POST_AGENTS),
+        choices=_channels.get_valid_post_agents(),
         help="Sender agent (default: user)",
     )
     post_parser.add_argument(

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -89,12 +89,12 @@ def _map_legacy_gemini_model_to_agy(model: str | None) -> str | None:
 
 def _detect_caller_identity_from_env() -> str | None:
     """Infer the sending agent for legacy ask-* commands from wrapper env."""
-    from ._channels import VALID_AGENTS
+    from . import _channels
 
     handoff_agent = os.environ.get("SESSION_HANDOFF_AGENT")
     if handoff_agent:
         normalized = handoff_agent.strip().lower()
-        if normalized in VALID_AGENTS:
+        if normalized in _channels.get_valid_agents():
             return normalized
     claude_name = os.environ.get("CLAUDE_AGENT_NAME")
     if claude_name:
@@ -436,9 +436,9 @@ def _build_parser() -> argparse.ArgumentParser:
     # original claude/gemini/codex trio — otherwise grok-build, grok, kimi, agy, and
     # cursor cannot be targeted by `send --to`, listed by `inbox --for`, or
     # cleared by `ack-all`, which silently second-classes those lanes.
-    from ._channels import VALID_RECIPIENT_AGENTS
+    from . import _channels
 
-    recipient_choices = sorted(VALID_RECIPIENT_AGENTS)
+    recipient_choices = sorted(_channels.get_valid_recipient_agents())
     parser = argparse.ArgumentParser(
         description=(
             "Bridge CLI for Claude, Gemini, and Codex message passing.\n"
@@ -1085,6 +1085,14 @@ def _build_parser() -> argparse.ArgumentParser:
     # status
     subparsers.add_parser("status", help="Show running bridge processes")
 
+    # slot-holder (step 4b)
+    slot_holder_parser = subparsers.add_parser(
+        "slot-holder",
+        help="Resolve slot to live lease holder facts in session-streams DB",
+    )
+    slot_holder_parser.add_argument("slot", help="Slot name (e.g. claude-atlas, grok-infra)")
+    slot_holder_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+
     # serve
     serve_parser = subparsers.add_parser("serve", help="Serve local HTTP bridge surfaces")
     serve_parser.add_argument(
@@ -1372,6 +1380,8 @@ def _dispatch_command(args):
             argv += [args.message]
         rc = _ui_agy_cli_main(argv)
         sys.exit(rc)
+    elif args.command == "slot-holder":
+        _handle_slot_holder(args)
     elif args.command in ("channel", "post", "p", "reconcile", "sync", "discuss"):
         # Channel bridge commands (#1190)
         from ._channels_cli import dispatch_channel_command
@@ -1704,6 +1714,27 @@ def _handle_ask_gemini(args):
         **kwargs,
         **_background_kwargs(args),
     )
+
+
+def _handle_slot_holder(args):
+    """Handle slot-holder subcommand."""
+    from scripts.orchestration.slot_routing import resolve_slot_holder
+
+    res = resolve_slot_holder(args.slot)
+    if getattr(args, "json", False):
+        print(json.dumps(res.to_dict(), indent=2))
+    else:
+        if res.has_holder:
+            print(f"Slot: {res.slot}")
+            print(f"Area: {res.area_id}")
+            print(f"Stream ID: {res.stream_id}")
+            print(f"Session ID: {res.session_id}")
+            print(f"Holder Agent: {res.holder_agent}")
+            print(f"Holder Harness: {res.holder_harness}")
+            print(f"Generation: {res.generation}")
+            print(f"Expires At: {res.expires_at}")
+        else:
+            print(f"no-live-holder (queue: {res.queue_location})")
 
 
 def main():

--- a/scripts/ai_agent_bridge/_inbox.py
+++ b/scripts/ai_agent_bridge/_inbox.py
@@ -188,9 +188,10 @@ def _iso_after(value: str, *, seconds: int) -> str:
 
 
 def _validate_agent(agent: str) -> None:
-    if agent not in _channels.VALID_AGENTS:
+    valids = _channels.get_valid_agents()
+    if agent not in valids:
         raise ValueError(
-            f"Unknown agent '{agent}'. Expected one of {_channels.VALID_AGENTS}."
+            f"Unknown agent '{agent}'. Expected one of {valids}."
         )
 
 

--- a/scripts/config/area_assignments.yaml
+++ b/scripts/config/area_assignments.yaml
@@ -6,22 +6,72 @@ schema_version: 1
 assignments:
   infra:
     driver_agent_type: infra-orchestrator
-    slots: []
+    slots:
+      - claude-infra
+      - codex-infra
+      - gemini-infra
+      - grok-infra
+      - kimi-infra
   devops:
     driver_agent_type: infra-orchestrator
-    slots: []
+    slots:
+      - claude-devops
+      - codex-devops
+      - gemini-devops
+      - grok-devops
+      - kimi-devops
   harness:
     driver_agent_type: infra-orchestrator
-    slots: []
+    slots:
+      - claude-harness
+      - codex-harness
+      - gemini-harness
+      - grok-harness
+      - kimi-harness
+      - claude-corpus
+      - codex-corpus
+      - gemini-corpus
+      - grok-corpus
+      - kimi-corpus
   atlas:
     driver_agent_type: infra-orchestrator
-    slots: []
+    slots:
+      - claude-atlas
+      - codex-atlas
+      - gemini-atlas
+      - grok-atlas
+      - kimi-atlas
   core:
     driver_agent_type: curriculum-orchestrator
-    slots: []
+    slots:
+      - claude-core
+      - codex-core
+      - gemini-core
+      - grok-core
+      - kimi-core
   seminars:
     driver_agent_type: curriculum-orchestrator
-    slots: []
+    slots:
+      - claude-seminars
+      - codex-seminars
+      - gemini-seminars
+      - grok-seminars
+      - kimi-seminars
+      - claude-folk
+      - codex-folk
+      - gemini-folk
+      - grok-folk
+      - kimi-folk
+      - claude-bio
+      - codex-bio
+      - gemini-bio
+      - grok-bio
+      - kimi-bio
   hramatka:
     driver_agent_type: curriculum-orchestrator
-    slots: []
+    slots:
+      - claude-hramatka
+      - codex-hramatka
+      - gemini-hramatka
+      - grok-hramatka
+      - kimi-hramatka

--- a/scripts/config/area_assignments.yaml
+++ b/scripts/config/area_assignments.yaml
@@ -1,6 +1,9 @@
 # Area assignments registry — MUTABLE mapping of area -> driver_agent_type, slots roster.
 # Replaces .agent/lane-assignments.md as machine authority (in later step).
 # See #5281 / #5279 design decisions.
+#
+# Derivation rule: slots = provider identity functions × launcher_selector_resolve lanes;
+# see scripts/lib/handoff_identity.sh — do not add rows without a mintable selector.
 
 schema_version: 1
 assignments:
@@ -23,11 +26,6 @@ assignments:
   harness:
     driver_agent_type: infra-orchestrator
     slots:
-      - claude-harness
-      - codex-harness
-      - gemini-harness
-      - grok-harness
-      - kimi-harness
       - claude-corpus
       - codex-corpus
       - gemini-corpus
@@ -43,20 +41,11 @@ assignments:
       - kimi-atlas
   core:
     driver_agent_type: curriculum-orchestrator
-    slots:
-      - claude-core
-      - codex-core
-      - gemini-core
-      - grok-core
-      - kimi-core
+    # no launcher selector mints a core slot (C7)
+    slots: []
   seminars:
     driver_agent_type: curriculum-orchestrator
     slots:
-      - claude-seminars
-      - codex-seminars
-      - gemini-seminars
-      - grok-seminars
-      - kimi-seminars
       - claude-folk
       - codex-folk
       - gemini-folk

--- a/scripts/fleet_comms/bottleneck_alerts.py
+++ b/scripts/fleet_comms/bottleneck_alerts.py
@@ -81,7 +81,7 @@ def _active_lease_holder(stream_epic: str, *, session_db: Path, now: datetime) -
         logger.error("bottleneck alerts: invalid lease expiry for epic %s", stream_epic)
         return None
     holder = str(row["holder_agent"] or "")
-    if expires_at <= now or holder not in _channels.VALID_RECIPIENT_AGENTS:
+    if expires_at <= now or holder not in _channels.get_valid_recipient_agents():
         return None
     return holder
 

--- a/scripts/orchestration/slot_routing.py
+++ b/scripts/orchestration/slot_routing.py
@@ -105,10 +105,12 @@ def resolve_slot_holder(
     3. Query session-streams DB for active leases matching the area's epics.
     4. Return holder facts if an active, non-expired lease exists; else no-holder.
 
+    For multi-epic areas with several live leases, the farthest-expiry lease wins.
+
     READ-ONLY — never writes that DB from this path.
     """
     clean_slot = slot.strip()
-    queue_loc = f".agent/wake/{clean_slot}"
+    queue_loc = f"channels DB delivery queue for '{clean_slot}'"
 
     assign_path = (assignments_path or DEFAULT_ASSIGNMENTS_PATH).resolve()
     area_candidate = _find_area_for_slot(clean_slot, assign_path)

--- a/scripts/orchestration/slot_routing.py
+++ b/scripts/orchestration/slot_routing.py
@@ -1,0 +1,233 @@
+"""Slot to holder resolution helper for fleet taxonomy (step 4b).
+
+Resolves a slot (e.g. claude-atlas, grok-infra, claude-folk) -> area -> live lease rows
+in .agent/session-streams/v1/session-streams.sqlite3.
+
+READ-ONLY: Never writes or mutates the session-streams database.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.orchestration.fleet_taxonomy import (
+    UnknownAreaError,
+    resolve_area,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SESSION_DB_PATH = (
+    PROJECT_ROOT / ".agent" / "session-streams" / "v1" / "session-streams.sqlite3"
+)
+DEFAULT_ASSIGNMENTS_PATH = PROJECT_ROOT / "scripts" / "config" / "area_assignments.yaml"
+
+
+@dataclass(frozen=True, slots=True)
+class SlotHolderResult:
+    """Outcome of slot->holder resolution."""
+
+    has_holder: bool
+    slot: str
+    area_id: str | None = None
+    stream_id: str | None = None
+    session_id: str | None = None
+    holder_agent: str | None = None
+    holder_harness: str | None = None
+    generation: int | None = None
+    expires_at: str | None = None
+    queue_location: str | None = None
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert result to a dictionary representation."""
+        return {
+            "has_holder": self.has_holder,
+            "slot": self.slot,
+            "area_id": self.area_id,
+            "stream_id": self.stream_id,
+            "session_id": self.session_id,
+            "holder_agent": self.holder_agent,
+            "holder_harness": self.holder_harness,
+            "generation": self.generation,
+            "expires_at": self.expires_at,
+            "queue_location": self.queue_location,
+            "reason": self.reason,
+        }
+
+
+def _parse_iso(value: str) -> datetime:
+    val = value.strip()
+    if val.endswith("Z"):
+        val = val[:-1] + "+00:00"
+    return datetime.fromisoformat(val).astimezone(UTC)
+
+
+def _find_area_for_slot(slot: str, assignments_path: Path) -> str | None:
+    """Look up slot in area_assignments.yaml to find its area ID."""
+    try:
+        if not assignments_path.is_file():
+            return None
+        text = assignments_path.read_text(encoding="utf-8")
+        import yaml
+        raw_data = yaml.safe_load(text)
+        if not isinstance(raw_data, dict):
+            return None
+        assignments = raw_data.get("assignments")
+        if not isinstance(assignments, dict):
+            return None
+        for area_id, area_data in assignments.items():
+            if isinstance(area_data, dict):
+                slots = area_data.get("slots", [])
+                if isinstance(slots, (list, tuple)) and slot in slots:
+                    return str(area_id)
+    except Exception:
+        pass
+    return None
+
+
+def resolve_slot_holder(
+    slot: str,
+    *,
+    taxonomy_path: Path | None = None,
+    assignments_path: Path | None = None,
+    session_db_path: Path | None = None,
+    now: datetime | None = None,
+) -> SlotHolderResult:
+    """Resolve a slot identity to its live lease holder facts.
+
+    Steps:
+    1. Look up slot in area_assignments.yaml, or parse slot into provider prefix & area part.
+    2. Resolve area via resolve_area() (canonical ID or alias).
+    3. Query session-streams DB for active leases matching the area's epics.
+    4. Return holder facts if an active, non-expired lease exists; else no-holder.
+
+    READ-ONLY — never writes that DB from this path.
+    """
+    clean_slot = slot.strip()
+    queue_loc = f".agent/wake/{clean_slot}"
+
+    assign_path = (assignments_path or DEFAULT_ASSIGNMENTS_PATH).resolve()
+    area_candidate = _find_area_for_slot(clean_slot, assign_path)
+
+    if area_candidate is None:
+        if "-" not in clean_slot:
+            return SlotHolderResult(
+                has_holder=False,
+                slot=clean_slot,
+                queue_location=queue_loc,
+                reason="invalid-slot-format",
+            )
+        provider, area_part = clean_slot.split("-", 1)
+        if not provider or not area_part:
+            return SlotHolderResult(
+                has_holder=False,
+                slot=clean_slot,
+                queue_location=queue_loc,
+                reason="invalid-slot-format",
+            )
+        area_candidate = area_part
+
+    try:
+        area = resolve_area(area_candidate, taxonomy_path=taxonomy_path)
+    except UnknownAreaError:
+        return SlotHolderResult(
+            has_holder=False,
+            slot=clean_slot,
+            queue_location=queue_loc,
+            reason="unknown-area",
+        )
+
+    db_path = (session_db_path or DEFAULT_SESSION_DB_PATH).resolve()
+    if not db_path.is_file():
+        return SlotHolderResult(
+            has_holder=False,
+            slot=clean_slot,
+            area_id=area.id,
+            queue_location=queue_loc,
+            reason="no-live-holder",
+        )
+
+    epic_stream_ids = [f"epic:{epic.number}" for epic in area.epics]
+    if not epic_stream_ids:
+        return SlotHolderResult(
+            has_holder=False,
+            slot=clean_slot,
+            area_id=area.id,
+            queue_location=queue_loc,
+            reason="no-live-holder",
+        )
+
+    placeholders = ", ".join("?" for _ in epic_stream_ids)
+    query = f"""
+        SELECT l.stream_id, l.session_id, l.holder_agent, l.holder_harness,
+               l.generation, l.expires_at, l.state AS lease_state, s.state AS session_state
+        FROM stream_leases AS l
+        JOIN sessions AS s ON s.stream_id = l.stream_id AND s.session_id = l.session_id
+        WHERE l.stream_id IN ({placeholders})
+          AND l.state = 'active'
+          AND s.state IN ('open', 'rolling')
+        ORDER BY l.expires_at DESC
+    """
+
+    current_time = (now or datetime.now(UTC)).astimezone(UTC)
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(query, epic_stream_ids).fetchall()
+        finally:
+            conn.close()
+    except (sqlite3.Error, OSError) as exc:
+        return SlotHolderResult(
+            has_holder=False,
+            slot=clean_slot,
+            area_id=area.id,
+            queue_location=queue_loc,
+            reason=f"db-error: {exc}",
+        )
+
+    if not rows:
+        return SlotHolderResult(
+            has_holder=False,
+            slot=clean_slot,
+            area_id=area.id,
+            queue_location=queue_loc,
+            reason="no-live-holder",
+        )
+
+    for row in rows:
+        exp_str = str(row["expires_at"] or "")
+        if exp_str:
+            try:
+                exp_dt = _parse_iso(exp_str)
+                if exp_dt <= current_time:
+                    # Expired lease treated as no-live-holder
+                    continue
+            except ValueError:
+                continue
+
+        return SlotHolderResult(
+            has_holder=True,
+            slot=clean_slot,
+            area_id=area.id,
+            stream_id=str(row["stream_id"]),
+            session_id=str(row["session_id"]),
+            holder_agent=str(row["holder_agent"]),
+            holder_harness=str(row["holder_harness"]) if row["holder_harness"] else None,
+            generation=int(row["generation"]) if row["generation"] is not None else None,
+            expires_at=exp_str,
+            queue_location=queue_loc,
+        )
+
+    return SlotHolderResult(
+        has_holder=False,
+        slot=clean_slot,
+        area_id=area.id,
+        queue_location=queue_loc,
+        reason="no-live-holder",
+    )

--- a/tests/test_channels_discuss_resume.py
+++ b/tests/test_channels_discuss_resume.py
@@ -163,6 +163,16 @@ def test_discuss_unknown_agent_defaults_to_no_resume(monkeypatch):
     """Agents not in registry get resume_policy='never' equivalent - no session_id."""
     _channels.create_channel("shared")
     monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    # discuss validates via get_valid_agents() (STATIC + registry slots), not the
+    # legacy VALID_AGENTS module constant — patch the dynamic helpers.
+    base_valid = _channels.get_valid_agents()
+    base_post = _channels.get_valid_post_agents()
+    monkeypatch.setattr(
+        _channels, "get_valid_agents", lambda **_kw: (*base_valid, "mystery")
+    )
+    monkeypatch.setattr(
+        _channels, "get_valid_post_agents", lambda **_kw: (*base_post, "mystery")
+    )
     monkeypatch.setattr(_channels, "VALID_AGENTS", (*_channels.VALID_AGENTS, "mystery"))
     monkeypatch.setattr(
         _channels,

--- a/tests/test_fleet_taxonomy_slot_addressing.py
+++ b/tests/test_fleet_taxonomy_slot_addressing.py
@@ -1,0 +1,268 @@
+"""Hermetic contract and unit tests for Taxonomy Step 4b — slot addressing and slot->holder resolution."""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.ai_agent_bridge import _channels, _inbox
+from scripts.orchestration.slot_routing import resolve_slot_holder
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AREA_ASSIGNMENTS_YAML = _REPO_ROOT / "scripts" / "config" / "area_assignments.yaml"
+
+
+# ---------------------------------------------------------------------------
+# 1. Slot Roster Acceptance & Validation Tests
+# ---------------------------------------------------------------------------
+
+
+def test_static_tuple_members_unchanged() -> None:
+    """Verify that static tuple members remain untouched and present in valid agents."""
+    valids = _channels.get_valid_agents()
+    for member in _channels.STATIC_VALID_AGENTS:
+        assert member in valids
+    assert "claude-infra" in _channels.STATIC_VALID_AGENTS
+
+
+def test_roster_slots_accepted_by_validation() -> None:
+    """Verify every slot configured in area_assignments.yaml is accepted by validation."""
+    all_valids = _channels.get_valid_agents(assignments_path=_AREA_ASSIGNMENTS_YAML)
+    assert "grok-infra" in all_valids
+    assert "claude-atlas" in all_valids
+    assert "codex-devops" in all_valids
+    assert "kimi-hramatka" in all_valids
+    assert "claude-folk" in all_valids
+    assert "codex-corpus" in all_valids
+
+    # Verify _validate_agent, _validate_post_agent, _validate_recipient_agent do not raise
+    _channels._validate_agent("grok-infra", assignments_path=_AREA_ASSIGNMENTS_YAML)
+    _channels._validate_post_agent("claude-atlas", assignments_path=_AREA_ASSIGNMENTS_YAML)
+    _channels._validate_recipient_agent("codex-devops", assignments_path=_AREA_ASSIGNMENTS_YAML)
+    _inbox._validate_agent("grok-infra")
+
+
+def test_unknown_slot_rejected_naming_valids() -> None:
+    """Verify unknown slot 'claude-nosucharea' is rejected with an error message listing valid agents."""
+    with pytest.raises(ValueError) as exc_info:
+        _channels._validate_agent("claude-nosucharea", assignments_path=_AREA_ASSIGNMENTS_YAML)
+
+    err_msg = str(exc_info.value)
+    assert "Unknown agent 'claude-nosucharea'" in err_msg
+    assert "claude-infra" in err_msg
+    assert "grok-infra" in err_msg
+
+    with pytest.raises(ValueError):
+        _inbox._validate_agent("claude-nosucharea")
+
+
+def test_registry_absent_or_unreadable_fallback_to_static_tuple(tmp_path: Path) -> None:
+    """Verify fallback to STATIC_VALID_AGENTS when area_assignments.yaml is missing or corrupt.
+
+    MUTATION-CHECK: If fallback is removed/broken, get_valid_agents fails or crashes.
+    """
+    missing_file = tmp_path / "non_existent_area_assignments.yaml"
+    valids_missing = _channels.get_valid_agents(assignments_path=missing_file)
+    assert valids_missing == _channels.STATIC_VALID_AGENTS
+
+    corrupt_file = tmp_path / "corrupt_area_assignments.yaml"
+    corrupt_file.write_text("invalid: yaml: ::: [[", encoding="utf-8")
+    valids_corrupt = _channels.get_valid_agents(assignments_path=corrupt_file)
+    assert valids_corrupt == _channels.STATIC_VALID_AGENTS
+
+
+def test_cache_invalidation_on_registry_edit(tmp_path: Path) -> None:
+    """Verify cache invalidation when area_assignments.yaml is edited (mtime/size changed).
+
+    MUTATION-CHECK: A static/bare LRU cache without mtime check fails to see new slots.
+    """
+    test_file = tmp_path / "area_assignments.yaml"
+    test_file.write_text(
+        """schema_version: 1
+assignments:
+  infra:
+    slots:
+      - custom-slot-v1
+""",
+        encoding="utf-8",
+    )
+
+    valids1 = _channels.get_valid_agents(assignments_path=test_file)
+    assert "custom-slot-v1" in valids1
+
+    # Sleep slightly or modify time to ensure mtime changes
+    time.sleep(0.01)
+    test_file.write_text(
+        """schema_version: 1
+assignments:
+  infra:
+    slots:
+      - custom-slot-v1
+      - custom-slot-v2
+""",
+        encoding="utf-8",
+    )
+
+    valids2 = _channels.get_valid_agents(assignments_path=test_file)
+    assert "custom-slot-v2" in valids2
+
+
+# ---------------------------------------------------------------------------
+# 2. Slot->Holder Resolution Helper Tests (resolve_slot_holder)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session_db_fixture(tmp_path: Path) -> Path:
+    """Create a temporary schema-conformant session-streams.sqlite3 database."""
+    db_path = tmp_path / "session-streams.sqlite3"
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE sessions (
+            session_id TEXT PRIMARY KEY,
+            stream_id TEXT NOT NULL,
+            state TEXT NOT NULL
+        );
+
+        CREATE TABLE stream_leases (
+            stream_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            holder_agent TEXT NOT NULL,
+            holder_harness TEXT,
+            generation INTEGER NOT NULL,
+            expires_at TEXT NOT NULL,
+            state TEXT NOT NULL
+        );
+    """)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_resolve_slot_holder_live_holder(session_db_fixture: Path) -> None:
+    """Verify resolve_slot_holder returns holder facts for an active, non-expired lease."""
+    db_path = session_db_fixture
+    future_time = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO sessions (session_id, stream_id, state) VALUES (?, ?, ?)",
+        ("sess_atlas_123", "epic:4387", "open"),
+    )
+    conn.execute(
+        """INSERT INTO stream_leases
+           (stream_id, session_id, holder_agent, holder_harness, generation, expires_at, state)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        ("epic:4387", "sess_atlas_123", "claude-infra", "claude", 1, future_time, "active"),
+    )
+    conn.commit()
+    conn.close()
+
+    res = resolve_slot_holder("claude-atlas", session_db_path=db_path)
+    assert res.has_holder is True
+    assert res.slot == "claude-atlas"
+    assert res.area_id == "atlas"
+    assert res.stream_id == "epic:4387"
+    assert res.session_id == "sess_atlas_123"
+    assert res.holder_agent == "claude-infra"
+    assert res.holder_harness == "claude"
+    assert res.generation == 1
+    assert res.expires_at == future_time
+    assert res.queue_location == ".agent/wake/claude-atlas"
+
+
+def test_resolve_slot_holder_no_holder(session_db_fixture: Path) -> None:
+    """Verify resolve_slot_holder returns has_holder=False when no active lease exists."""
+    res = resolve_slot_holder("grok-infra", session_db_path=session_db_fixture)
+    assert res.has_holder is False
+    assert res.slot == "grok-infra"
+    assert res.area_id == "infra"
+    assert res.queue_location == ".agent/wake/grok-infra"
+    assert res.reason == "no-live-holder"
+
+
+def test_resolve_slot_holder_expired_lease_treated_as_no_live_holder(session_db_fixture: Path) -> None:
+    """Verify expired lease (expires_at in past) is treated as no-live-holder."""
+    db_path = session_db_fixture
+    past_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO sessions (session_id, stream_id, state) VALUES (?, ?, ?)",
+        ("sess_devops_456", "epic:5703", "open"),
+    )
+    conn.execute(
+        """INSERT INTO stream_leases
+           (stream_id, session_id, holder_agent, holder_harness, generation, expires_at, state)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        ("epic:5703", "sess_devops_456", "codex-infra", "codex", 1, past_time, "active"),
+    )
+    conn.commit()
+    conn.close()
+
+    res = resolve_slot_holder("codex-devops", session_db_path=db_path)
+    assert res.has_holder is False
+    assert res.slot == "codex-devops"
+    assert res.area_id == "devops"
+    assert res.reason == "no-live-holder"
+
+
+def test_resolve_slot_holder_unknown_area_slot() -> None:
+    """Verify resolve_slot_holder returns unknown-area reason for unmapped area slot."""
+    res = resolve_slot_holder("claude-nosucharea")
+    assert res.has_holder is False
+    assert res.slot == "claude-nosucharea"
+    assert res.reason == "unknown-area"
+
+
+def test_resolve_slot_holder_alias_slot(session_db_fixture: Path) -> None:
+    """Verify alias slot resolution (e.g. claude-folk -> area seminars -> epic:2836)."""
+    db_path = session_db_fixture
+    future_time = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO sessions (session_id, stream_id, state) VALUES (?, ?, ?)",
+        ("sess_folk_789", "epic:2836", "rolling"),
+    )
+    conn.execute(
+        """INSERT INTO stream_leases
+           (stream_id, session_id, holder_agent, holder_harness, generation, expires_at, state)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        ("epic:2836", "sess_folk_789", "grok-infra", "grok", 2, future_time, "active"),
+    )
+    conn.commit()
+    conn.close()
+
+    res = resolve_slot_holder("claude-folk", session_db_path=db_path)
+    assert res.has_holder is True
+    assert res.slot == "claude-folk"
+    assert res.area_id == "seminars"
+    assert res.stream_id == "epic:2836"
+    assert res.holder_agent == "grok-infra"
+
+
+# ---------------------------------------------------------------------------
+# 3. Bounce Visibility Warning in Post
+# ---------------------------------------------------------------------------
+
+
+def test_post_to_slot_with_no_live_holder_warns_and_queues(capsys: pytest.CaptureFixture[str]) -> None:
+    """Verify post to a valid slot with no live holder prints a stderr warning while still queuing delivery."""
+    with contextlib.suppress(Exception):
+        _channels.init_db()
+
+    with contextlib.suppress(ValueError):
+        _channels.create_channel("test-slot", description="test channel")
+
+    result = _channels.post("test-slot", "user", "Hello slot", to_agents=["grok-infra"], auto_snapshot=False)
+    captured = capsys.readouterr()
+
+    assert "⚠️ channel-bridge: recipient slot 'grok-infra' has no live holder" in captured.err
+    assert ".agent/wake/grok-infra" in captured.err
+    assert len(result["delivery_ids"]) == 1

--- a/tests/test_fleet_taxonomy_slot_addressing.py
+++ b/tests/test_fleet_taxonomy_slot_addressing.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.ai_agent_bridge import _channels, _inbox
 from scripts.orchestration.slot_routing import resolve_slot_holder
@@ -45,6 +46,28 @@ def test_roster_slots_accepted_by_validation() -> None:
     _channels._validate_post_agent("claude-atlas", assignments_path=_AREA_ASSIGNMENTS_YAML)
     _channels._validate_recipient_agent("codex-devops", assignments_path=_AREA_ASSIGNMENTS_YAML)
     _inbox._validate_agent("grok-infra")
+
+
+def test_roster_slot_count_is_35() -> None:
+    """Verify area_assignments.yaml contains exactly 35 mintable roster slots (5 providers x 7 lanes)."""
+    text = _AREA_ASSIGNMENTS_YAML.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    slots = []
+    for area_data in data["assignments"].values():
+        if isinstance(area_data, dict):
+            slots.extend(area_data.get("slots", []))
+    assert len(slots) == 35
+
+
+def test_phantom_slots_absent_from_valid_agents() -> None:
+    """Guard test: *-harness, *-seminars, and *-core phantom slots are NOT in get_valid_agents()."""
+    valids = _channels.get_valid_agents(assignments_path=_AREA_ASSIGNMENTS_YAML)
+    providers = ("claude", "codex", "gemini", "grok", "kimi")
+    phantoms = ("harness", "seminars", "core")
+    for provider in providers:
+        for suffix in phantoms:
+            phantom_slot = f"{provider}-{suffix}"
+            assert phantom_slot not in valids, f"Phantom slot '{phantom_slot}' found in valid agents"
 
 
 def test_unknown_slot_rejected_naming_valids() -> None:
@@ -112,8 +135,67 @@ assignments:
     assert "custom-slot-v2" in valids2
 
 
+def test_empty_roster_caching(tmp_path: Path) -> None:
+    """Verify empty roster result is cached when registry specifies empty slots."""
+    empty_file = tmp_path / "empty_assignments.yaml"
+    empty_file.write_text(
+        """schema_version: 1
+assignments:
+  core:
+    slots: []
+""",
+        encoding="utf-8",
+    )
+    valids1 = _channels.get_valid_agents(assignments_path=empty_file)
+    assert valids1 == _channels.STATIC_VALID_AGENTS
+    # Verify cache key is recorded in _SLOTS_CACHE
+    st = empty_file.resolve().stat()
+    assert _channels._SLOTS_CACHE.get("key") == (str(empty_file.resolve()), st.st_mtime, st.st_size)
+
+
 # ---------------------------------------------------------------------------
-# 2. Slot->Holder Resolution Helper Tests (resolve_slot_holder)
+# 2. R2 Validation Sites Tests
+# ---------------------------------------------------------------------------
+
+
+def test_post_cli_parser_accepts_roster_slot() -> None:
+    """Verify _channels_cli parser accepts a registry roster slot for --from-agent (R2 site 1)."""
+    from scripts.ai_agent_bridge import _cli
+
+    parser = _cli._build_parser()
+    args = parser.parse_args(["post", "shared", "hello", "--from-agent", "grok-infra", "--no-snapshot"])
+    assert args.from_agent == "grok-infra"
+
+
+def test_bottleneck_alerts_accepts_roster_slot_holder(tmp_path: Path) -> None:
+    """Verify bottleneck_alerts._active_lease_holder accepts a registry roster slot as holder (R2 site 2)."""
+    from agents_extensions.shared.session_streams import LeaseHolder, SessionStreamDatabase, SessionStreamStore
+    from scripts.fleet_comms.bottleneck_alerts import _active_lease_holder
+
+    db_path = tmp_path / "session-streams.sqlite3"
+    db = SessionStreamDatabase(db_path)
+    store = SessionStreamStore(db)
+    now = datetime.now(UTC)
+    store.open_session(
+        stream_id="epic:4707",
+        holder=LeaseHolder(
+            agent="grok-infra",
+            harness="grok",
+            instance_id="inst-1",
+            process_id=100,
+            task_id="task-1",
+        ),
+        lineage_id="lineage-1",
+        ttl_seconds=3600,
+        now=now,
+    )
+
+    holder = _active_lease_holder("4707", session_db=db_path, now=now)
+    assert holder == "grok-infra"
+
+
+# ---------------------------------------------------------------------------
+# 3. Slot->Holder Resolution Helper Tests (resolve_slot_holder)
 # ---------------------------------------------------------------------------
 
 
@@ -173,7 +255,7 @@ def test_resolve_slot_holder_live_holder(session_db_fixture: Path) -> None:
     assert res.holder_harness == "claude"
     assert res.generation == 1
     assert res.expires_at == future_time
-    assert res.queue_location == ".agent/wake/claude-atlas"
+    assert res.queue_location == "channels DB delivery queue for 'claude-atlas'"
 
 
 def test_resolve_slot_holder_no_holder(session_db_fixture: Path) -> None:
@@ -182,7 +264,7 @@ def test_resolve_slot_holder_no_holder(session_db_fixture: Path) -> None:
     assert res.has_holder is False
     assert res.slot == "grok-infra"
     assert res.area_id == "infra"
-    assert res.queue_location == ".agent/wake/grok-infra"
+    assert res.queue_location == "channels DB delivery queue for 'grok-infra'"
     assert res.reason == "no-live-holder"
 
 
@@ -248,7 +330,7 @@ def test_resolve_slot_holder_alias_slot(session_db_fixture: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 3. Bounce Visibility Warning in Post
+# 4. Bounce Visibility Warning in Post
 # ---------------------------------------------------------------------------
 
 
@@ -264,5 +346,5 @@ def test_post_to_slot_with_no_live_holder_warns_and_queues(capsys: pytest.Captur
     captured = capsys.readouterr()
 
     assert "⚠️ channel-bridge: recipient slot 'grok-infra' has no live holder" in captured.err
-    assert ".agent/wake/grok-infra" in captured.err
+    assert "channels DB delivery queue for 'grok-infra'" in captured.err
     assert len(result["delivery_ids"]) == 1


### PR DESCRIPTION
Part of the fleet-taxonomy plan (step 4b).

- Populates area_assignments.yaml slots roster for all 7 areas.
- Extends VALID_AGENTS dynamically with area_assignments.yaml slots via stat-cached loader.
- Implements read-only resolve_slot_holder querying session-streams.sqlite3.
- Adds slot-holder CLI subcommand to AI agent bridge.
- Adds bounce warning when posting to a slot with no live holder.