### PR TITLE
fix(site): hide the 404 hero when the atlas shell renders a word page

### DIFF
--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -103,6 +103,15 @@ test('all СУМ-11 definition cards are hidden from word pages (Soviet dictiona
   await expect(page.locator('.def-card.sum20')).toHaveCount(1);
 });
 
+test('Atlas shell hides the 404 hero only for rendered word pages', async ({ page }) => {
+  await page.goto('/lexicon/прапор/');
+  await expect(page.locator('h1.word-title')).toBeVisible();
+  await expect(page.locator('.lu-hero:visible').filter({ hasText: 'Page Not Found' })).toHaveCount(0);
+
+  await page.goto('/definitely-not-a-real-page/');
+  await expect(page.locator('.lu-hero:visible').filter({ hasText: 'Page Not Found' })).toHaveCount(1);
+});
+
 for (const path of ['/lexicon/', '/words-of-the-day/', '/lexicon/browse/']) {
   test(`${path} loads without console errors`, async ({ page }) => {
     const consoleErrors = trackConsoleErrors(page);

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -94,6 +94,12 @@ const atlasAssetBase = `${baseUrl === '/' ? '' : baseUrl.replace(/\/$/, '')}/atl
   </section>
 </CourseLayout>
 
+<style>
+  :global(html[data-atlas-shell] .lu-hero) {
+    display: none;
+  }
+</style>
+
 <style is:global>
   .atlas-client-shell-state {
     display: grid;

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -29,18 +29,7 @@ const atlasAssetBase = `${baseUrl === '/' ? '' : baseUrl.replace(/\/$/, '')}/atl
   heroVariant="unavailable"
   wide
 >
-  {/* Generic site-wide OpenGraph on 404 (spec R2 — tail lemmas share these tags). */}
-  <meta slot="head" property="og:type" content="website" />
-  <meta slot="head" property="og:site_name" content="Learn Ukrainian" />
-  <meta slot="head" property="og:title" content={ogTitle} />
-  <meta slot="head" property="og:description" content={ogDescription} />
-  <meta slot="head" property="og:url" content={siteUrl} />
-  <meta slot="head" property="og:image" content={ogImage} />
-  <meta slot="head" name="twitter:card" content="summary" />
-  <meta slot="head" name="twitter:title" content={ogTitle} />
-  <meta slot="head" name="twitter:description" content={ogDescription} />
-
-  <script is:inline define:vars={{ baseUrl }}>
+  <script slot="head" is:inline define:vars={{ baseUrl }}>
     (() => {
       const base = baseUrl === '/' ? '' : String(baseUrl).replace(/\/$/, '');
       const path = location.pathname;
@@ -59,6 +48,17 @@ const atlasAssetBase = `${baseUrl === '/' ? '' : baseUrl.replace(/\/$/, '')}/atl
       });
     })();
   </script>
+
+  {/* Generic site-wide OpenGraph on 404 (spec R2 — tail lemmas share these tags). */}
+  <meta slot="head" property="og:type" content="website" />
+  <meta slot="head" property="og:site_name" content="Learn Ukrainian" />
+  <meta slot="head" property="og:title" content={ogTitle} />
+  <meta slot="head" property="og:description" content={ogDescription} />
+  <meta slot="head" property="og:url" content={siteUrl} />
+  <meta slot="head" property="og:image" content={ogImage} />
+  <meta slot="head" name="twitter:card" content="summary" />
+  <meta slot="head" name="twitter:title" content={ogTitle} />
+  <meta slot="head" name="twitter:description" content={ogDescription} />
 
   <div data-atlas-shell-boot hidden>
     <div


### PR DESCRIPTION
## Summary
- hide the CourseLayout 404 hero as soon as the Atlas shell marker is present
- add a regression control for an Atlas word page and a genuine missing route

## Verification
- npm run build:shell
- PLAYWRIGHT_PORT=4323 npx playwright test e2e/atlas-practice.spec.ts --workers=1 (29 passed)
- Dev-mode visual check: /lexicon/прапор/ renders its article with no visible 404 hero; /definitely-not-a-real-page/ retains it
- Targeted TypeScript check and ESLint completed

Cross-family advisory review: AGY/Gemini (no actionable finding under the explicit selector/test constraints).