### PR TITLE
fix(practice): resolve deck-scoped picks against cumulative level shards

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 704691415f8ca7bcfd8ea23f1fa0d9010c3ddc5ec8cebbc84fd28c208ccae338
+  components_sha256: 5ccef5cfb3c0891f36d30a29bc4f6f7c83881453be25112d356a51e29fc98fcd
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -735,6 +735,85 @@ function customSetFixture(id: string, title: string, lemmaKeys: string[]) {
   };
 }
 
+test('A8a: an A1 custom deck resolves a level-less key and keeps a true orphan unlinked', async ({
+  page,
+  context,
+}) => {
+  await context.clearCookies();
+  const catDeck = customSetFixture('e2e-d10-cat', 'E2E D10 Cat Deck', ['кіт']);
+  const orphanDeck = customSetFixture('e2e-d10-orphan', 'E2E D10 Orphan Deck', ['вигаданий термін']);
+  const cat = {
+    lemmaId: 'кіт',
+    lemma: 'кіт',
+    lemmaPlain: 'кіт',
+    gloss: 'cat',
+    ipa: null,
+    pos: 'noun',
+    cefr: 'A1',
+    heritage: null,
+    severity: null,
+    paradigm: { cases: {} },
+  };
+
+  await page.route(/\/lexicon\/practice-(index|lexemes|cloze)\.(A1|A2|B1|B2|C1)\.json$/, async (route) => {
+    const { pathname } = new URL(route.request().url());
+    if (pathname.endsWith('practice-index.A1.json')) {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          deckVersion: 'e2e-d10',
+          level: 'A1',
+          items: [{
+            lemmaId: cat.lemmaId,
+            lemma: cat.lemma,
+            cefr: 'A1',
+            modes: ['flashcards'],
+            hasCloze: false,
+            clozeIds: [],
+            newOrder: 0,
+          }],
+        }),
+      });
+      return;
+    }
+    if (pathname.endsWith('practice-lexemes.A1.json')) {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ deckVersion: 'e2e-d10', level: 'A1', lexemes: [cat] }),
+      });
+      return;
+    }
+    if (pathname.endsWith('practice-cloze.A1.json')) {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ cloze: [] }) });
+      return;
+    }
+    await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
+  });
+  await page.addInitScript(([catSet, orphanSet]) => {
+    window.localStorage.setItem('lu-learner-level', 'A1');
+    window.localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([catSet, orphanSet]));
+  }, [catDeck, orphanDeck] as const);
+
+  await page.goto('/words-of-the-day/practice/');
+
+  await page.getByRole('button', { name: /E2E D10 Cat Deck/ }).click();
+  await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Cat Deck');
+  const catCard = page.locator('.daily-preview-card');
+  await expect(catCard).toContainText('кіт');
+  await expect(page.getByTestId('practice-preview-atlas-link')).toHaveAttribute(
+    'href',
+    '/lexicon/%D0%BA%D1%96%D1%82/',
+  );
+  await catCard.click();
+  await expect(catCard).toContainText('cat');
+  await expect(catCard).toContainText('noun');
+
+  await page.getByRole('button', { name: /E2E D10 Orphan Deck/ }).click();
+  await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Orphan Deck');
+  await expect(page.locator('.daily-preview-card')).toContainText('вигаданий термін');
+  await expect(page.getByTestId('practice-preview-atlas-link')).toHaveCount(0);
+});
+
 /** Opens the daily-zone disclosure (idempotent — `PracticeDailyDeck` can remount and
  * reset `detailsOpen` across a deck switch) and reads the full featured word list. */
 async function readDailyDeckWords(page: Page): Promise<string[]> {

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1594,9 +1594,11 @@ function LexiconPracticeIsland({
           );
         } else {
           // A deck's words can sit at any level (or none — an unverified custom
-          // import) — resolve against every published level's shard rather than
-          // guessing from the learner's currently selected level.
-          representedLevels = new Set<string>(PUBLISHED_PRACTICE_LEVELS);
+          // import). Resolve its keys across the learner's complete accessible
+          // range, the same A1..learnerLevel set `filterByCumulativeLevel`
+          // uses for atlas-global picks. That gives level-less custom keys their
+          // verified metadata without loading shards above the learner's level.
+          representedLevels = new Set<string>(levelsUpTo(learnerLevel));
         }
 
         // The atlas branch can skip this fetch once `deck` already covers the

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1067,6 +1067,111 @@ describe('LexiconPractice', () => {
     expect(screen.getAllByText(withPos!.pos!).length).toBeGreaterThan(0);
   });
 
+  test('resolves a level-less custom deck key from the learner cumulative shards', async () => {
+    const cat = lexeme('кіт', 'кіт', 'cat', {
+      nominative: 'кіт',
+      accusative: 'кота',
+      locative: 'коті',
+    });
+    const customSet: CustomSet = {
+      id: 'custom-cats',
+      title: 'Коти',
+      lemma_keys: ['кіт'],
+      cloze_items: [],
+      created_at: '2026-07-27T12:00:00.000Z',
+      updated_at: '2026-07-27T12:00:00.000Z',
+      device_id: 'test-device',
+      revision: 1,
+    };
+    localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([customSet]));
+
+    const requested: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) {
+        return okJson({
+          deckVersion: 'cats',
+          level: 'A1',
+          items: [{
+            lemmaId: cat.lemmaId,
+            lemma: cat.lemma,
+            cefr: 'A1',
+            modes: ['flashcards'],
+            hasCloze: false,
+            clozeIds: [],
+            newOrder: 0,
+          }],
+        });
+      }
+      if (url.includes('practice-lexemes.A1.json')) {
+        return okJson({ deckVersion: 'cats', level: 'A1', lexemes: [cat] });
+      }
+      if (url.includes('practice-cloze.A1.json')) return okJson({ cloze: [] });
+      return notFoundResponse();
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<LexiconPractice />);
+    await user.click(await screen.findByRole('button', { name: /Коти/ }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('practice-daily-deck-title')).toHaveTextContent('Коти'),
+    );
+    await user.click(container.querySelector<HTMLElement>('.daily-preview-card')!);
+
+    expect(screen.getAllByText('cat').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('noun').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('practice-preview-atlas-link')).toHaveAttribute(
+      'href',
+      '/lexicon/%D0%BA%D1%96%D1%82/',
+    );
+    expect(requested.some((url) => url.includes('practice-lexemes.A2.json'))).toBe(false);
+  });
+
+  test('keeps a genuinely absent custom deck key on the orphan path', async () => {
+    const customSet: CustomSet = {
+      id: 'custom-orphan',
+      title: 'Невідомі слова',
+      lemma_keys: ['неіснуюча лексема'],
+      cloze_items: [],
+      created_at: '2026-07-27T12:00:00.000Z',
+      updated_at: '2026-07-27T12:00:00.000Z',
+      device_id: 'test-device',
+      revision: 1,
+    };
+    localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([customSet]));
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) {
+        return okJson({ deckVersion: 'empty', level: 'A1', items: [] });
+      }
+      if (url.includes('practice-lexemes.A1.json')) {
+        return okJson({ deckVersion: 'empty', level: 'A1', lexemes: [] });
+      }
+      if (url.includes('practice-cloze.A1.json')) return okJson({ cloze: [] });
+      return notFoundResponse();
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<LexiconPractice />);
+    await user.click(await screen.findByRole('button', { name: /Невідомі слова/ }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('practice-daily-deck-title')).toHaveTextContent('Невідомі слова'),
+    );
+    expect(screen.getAllByText('неіснуюча лексема').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('practice-preview-atlas-link')).not.toBeInTheDocument();
+    expect(
+      container.querySelectorAll(
+        'a[href="/lexicon/%D0%BD%D0%B5%D1%96%D1%81%D0%BD%D1%83%D1%8E%D1%87%D0%B0%20%D0%BB%D0%B5%D0%BA%D1%81%D0%B5%D0%BC%D0%B0/"]',
+      ),
+    ).toHaveLength(0);
+  });
+
   test('shows due review count on the home before any session starts', async () => {
     const { fn } = mockShardFetch({ A1: 3 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);


### PR DESCRIPTION
## Summary
- Resolve selected-deck daily picks across A1 through the learner’s selected CEFR level.
- Preserve All Words’ existing represented-level loading path.
- Add unit and fresh-preview E2E coverage for resolved level-less deck words and true orphans.

## Verification
- `PATH=/Users/krisztiankoos/.hermes/node/bin:$PATH npx vitest run tests/unit/LexiconPractice.test.tsx --reporter=verbose` — 109 passed.
- `npm run build` — 18,137 static pages built.
- `PLAYWRIGHT_PORT=4179 NODE_OPTIONS='--localstorage-file=/tmp/learn-ukrainian-playwright-localstorage' npx playwright test e2e/atlas-practice.spec.ts --reporter=list` — 33 passed.
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main..HEAD` — passed.

X-Agent: codex/atlas-d10-resolution-fix