### PR TITLE
fix(practice): fall back to the atlas index for deck words outside the practice set

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 5ccef5cfb3c0891f36d30a29bc4f6f7c83881453be25112d356a51e29fc98fcd
+  components_sha256: 433a3730af3158bcb962d85caaf2344dbb3ea4d1e951ed3c75c7c73913d0c3d6
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 433a3730af3158bcb962d85caaf2344dbb3ea4d1e951ed3c75c7c73913d0c3d6
+  components_sha256: 6bff6c36b4fba32fa6484ef0662d1afde2b6f29edb4c8a296dfb1c26aab2baf4
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -768,7 +768,21 @@ test('A8a: an Atlas-only custom-deck key gets its gloss and route while a true o
     }
     await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
   });
-  await page.route('**/lexicon/search-index.json', (route) =>
+  await page.route('**/lexicon/search-shards.json', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        schema: 'atlas-search-shards',
+        schemaVersion: 1,
+        total: 1,
+        shardCount: 1,
+        fullIndex: { path: '/lexicon/search-index.json', count: 1, bytes: 1, sha256: 'full' },
+        prefixMap: { к: 'u043a' },
+        shards: { u043a: { path: '/lexicon/search/u043a.json', count: 1, bytes: 1, sha256: 'cat' } },
+      }),
+    }),
+  );
+  await page.route('**/lexicon/search/u043a.json', (route) =>
     route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify([{ l: 'кіт', s: 'кіт', g: 'cat', t: 'lemma', c: 'A1' }]),
@@ -797,6 +811,17 @@ test('A8a: an Atlas-only custom-deck key gets its gloss and route while a true o
   await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Orphan Deck');
   await expect(page.locator('.daily-preview-card')).toContainText('вигаданий термін');
   await expect(page.getByTestId('practice-preview-atlas-link')).toHaveCount(0);
+
+  await page.getByRole('button', { name: /E2E D10 Cat Deck/ }).click();
+  // The daily card is only the preview path. Start a real flashcard session
+  // and reveal its back so the deck's committed lexeme, not preview state,
+  // proves the Atlas shard enrichment reached `cardData()`.
+  await page.locator('button[data-mode="flashcards"]').click();
+  const sessionCard = page.locator('[data-activity="flashcard"]');
+  await expect(sessionCard).toBeVisible();
+  await sessionCard.click();
+  await expect(sessionCard.locator('.flashcard-back .flashcard-word')).toHaveText('cat');
+  await expect(sessionCard.locator('.flashcard-subtitle')).toHaveCount(0);
 });
 
 /** Opens the daily-zone disclosure (idempotent — `PracticeDailyDeck` can remount and

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -735,26 +735,13 @@ function customSetFixture(id: string, title: string, lemmaKeys: string[]) {
   };
 }
 
-test('A8a: an A1 custom deck resolves a level-less key and keeps a true orphan unlinked', async ({
+test('A8a: an Atlas-only custom-deck key gets its gloss and route while a true orphan stays unlinked', async ({
   page,
   context,
 }) => {
   await context.clearCookies();
   const catDeck = customSetFixture('e2e-d10-cat', 'E2E D10 Cat Deck', ['кіт']);
   const orphanDeck = customSetFixture('e2e-d10-orphan', 'E2E D10 Orphan Deck', ['вигаданий термін']);
-  const cat = {
-    lemmaId: 'кіт',
-    lemma: 'кіт',
-    lemmaPlain: 'кіт',
-    gloss: 'cat',
-    ipa: null,
-    pos: 'noun',
-    cefr: 'A1',
-    heritage: null,
-    severity: null,
-    paradigm: { cases: {} },
-  };
-
   await page.route(/\/lexicon\/practice-(index|lexemes|cloze)\.(A1|A2|B1|B2|C1)\.json$/, async (route) => {
     const { pathname } = new URL(route.request().url());
     if (pathname.endsWith('practice-index.A1.json')) {
@@ -763,15 +750,7 @@ test('A8a: an A1 custom deck resolves a level-less key and keeps a true orphan u
         body: JSON.stringify({
           deckVersion: 'e2e-d10',
           level: 'A1',
-          items: [{
-            lemmaId: cat.lemmaId,
-            lemma: cat.lemma,
-            cefr: 'A1',
-            modes: ['flashcards'],
-            hasCloze: false,
-            clozeIds: [],
-            newOrder: 0,
-          }],
+          items: [],
         }),
       });
       return;
@@ -779,7 +758,7 @@ test('A8a: an A1 custom deck resolves a level-less key and keeps a true orphan u
     if (pathname.endsWith('practice-lexemes.A1.json')) {
       await route.fulfill({
         contentType: 'application/json',
-        body: JSON.stringify({ deckVersion: 'e2e-d10', level: 'A1', lexemes: [cat] }),
+        body: JSON.stringify({ deckVersion: 'e2e-d10', level: 'A1', lexemes: [] }),
       });
       return;
     }
@@ -789,6 +768,12 @@ test('A8a: an A1 custom deck resolves a level-less key and keeps a true orphan u
     }
     await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
   });
+  await page.route('**/lexicon/search-index.json', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([{ l: 'кіт', s: 'кіт', g: 'cat', t: 'lemma', c: 'A1' }]),
+    }),
+  );
   await page.addInitScript(([catSet, orphanSet]) => {
     window.localStorage.setItem('lu-learner-level', 'A1');
     window.localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([catSet, orphanSet]));
@@ -806,7 +791,7 @@ test('A8a: an A1 custom deck resolves a level-less key and keeps a true orphan u
   );
   await catCard.click();
   await expect(catCard).toContainText('cat');
-  await expect(catCard).toContainText('noun');
+  await expect(catCard).not.toContainText('noun');
 
   await page.getByRole('button', { name: /E2E D10 Orphan Deck/ }).click();
   await expect(page.getByTestId('practice-daily-deck-title')).toContainText('E2E D10 Orphan Deck');

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -85,6 +85,7 @@ import {
 import { dateSeed, deckSeed, pickDaily, type DailyWord } from '../lib/lexicon/daily';
 import { getTeacherLessonVirtualDeck, readLocalCustomSets, saveLocalCustomSet, deleteLocalCustomSet, type CustomSet } from '../lib/lexicon/custom-decks';
 import { syncCustomSetsToDrive, requestGoogleAccessToken, setInMemoryAccessToken, getInMemoryAccessToken } from '../lib/lexicon/google-drive-sync';
+import { type SearchRow } from '../lib/lexicon/search';
 import { LexiconCustomDeckManager } from './LexiconCustomDeckManager';
 
 
@@ -1165,7 +1166,7 @@ function DigitChoiceShortcuts({
   return null;
 }
 
-/** Deduped fetch for a practice shard JSON by URL. Concurrent or repeated callers share the promise. */
+/** Deduped fetch for practice and Atlas JSON by URL. Concurrent or repeated callers share the promise. */
 async function getShardJson<T>(url: string, cache: Map<string, Promise<unknown>>): Promise<T> {
   let p = cache.get(url) as Promise<T> | undefined;
   if (!p) {
@@ -1631,6 +1632,16 @@ function LexiconPracticeIsland({
               }),
             );
 
+        // The public Atlas search index is the route-existence source for deck
+        // words outside the smaller practice set. Keep it out of the all-words
+        // path, and use the shared JSON cache so deck changes never refetch it.
+        const atlasSearchIndex = deckLemmaKeys === null
+          ? []
+          : await getShardJson<SearchRow[]>(
+              '/lexicon/search-index.json',
+              shardJsonCacheRef.current,
+            ).catch(() => []);
+
         if (cancelled) return;
         const merged = new Map<string, PracticeLexeme>();
         for (const entry of deck?.lexemes ?? []) {
@@ -1653,17 +1664,24 @@ function LexiconPracticeIsland({
             lexemesByLower.set(entry.lemmaId.toLowerCase(), entry);
             lexemesByLower.set(entry.lemma.toLowerCase(), entry);
           }
+          const atlasEntriesByLower = new Map<string, SearchRow>();
+          for (const entry of atlasSearchIndex) {
+            atlasEntriesByLower.set(entry.s.toLowerCase(), entry);
+            atlasEntriesByLower.set(entry.l.toLowerCase(), entry);
+          }
           const deckPool: DailyWord[] = deckLemmaKeys.map((key) => {
             const match = lexemes.get(key) ?? lexemesByLower.get(key.toLowerCase()) ?? null;
-            // A deck word with no atlas/level match still deserves a real-looking
-            // card — same cleanup `ensureDeckCustomSetCoverage` applies for the
-            // session pool, so the preview and the session never disagree.
             const cleanKey = key.replace(/\(.*?\)/g, '').trim() || key;
+            const atlasMatch = atlasEntriesByLower.get(key.toLowerCase())
+              ?? atlasEntriesByLower.get(cleanKey.toLowerCase())
+              ?? null;
+            // Practice lexemes are richer than the search index. If neither
+            // source recognizes a deck key, preserve the unlinked orphan card.
             return {
-              lemma: match?.lemma ?? cleanKey,
-              slug: match?.lemmaId ?? key,
-              gloss: match?.gloss ?? cleanKey,
-              hasAtlasEntry: Boolean(match),
+              lemma: match?.lemma ?? atlasMatch?.l ?? cleanKey,
+              slug: match?.lemmaId ?? atlasMatch?.s ?? key,
+              gloss: match?.gloss ?? atlasMatch?.g ?? cleanKey,
+              hasAtlasEntry: Boolean(match ?? atlasMatch),
               cefr: match?.cefr ?? undefined,
               pos: match?.pos ?? undefined,
               example: match?.example ?? undefined,

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -85,7 +85,7 @@ import {
 import { dateSeed, deckSeed, pickDaily, type DailyWord } from '../lib/lexicon/daily';
 import { getTeacherLessonVirtualDeck, readLocalCustomSets, saveLocalCustomSet, deleteLocalCustomSet, type CustomSet } from '../lib/lexicon/custom-decks';
 import { syncCustomSetsToDrive, requestGoogleAccessToken, setInMemoryAccessToken, getInMemoryAccessToken } from '../lib/lexicon/google-drive-sync';
-import { type SearchRow } from '../lib/lexicon/search';
+import { searchShardForQuery, type SearchRow, type SearchShardManifest } from '../lib/lexicon/search';
 import { LexiconCustomDeckManager } from './LexiconCustomDeckManager';
 
 
@@ -102,11 +102,138 @@ function PracticeChromeDual({ uk, en }: { uk: string; en: string }): ReactElemen
   return <ChromeDual en={en} uk={uk} />;
 }
 
-function ensureDeckCustomSetCoverage(deck: PracticeDeckData, lemmaKeys: string[]): PracticeDeckData {
+interface AtlasDeckMatch {
+  lemma: string;
+  slug: string;
+  gloss: string | null;
+  cefr: string | null;
+}
+
+interface DeckKeyResolution {
+  practice: PracticeLexeme | null;
+  atlas: AtlasDeckMatch | null;
+}
+
+function cleanDeckKey(key: string): string {
+  return key.replace(/\(.*?\)/g, '').trim() || key;
+}
+
+function keyLookupVariants(key: string): string[] {
+  return Array.from(new Set([key, cleanDeckKey(key)].map((value) => value.toLocaleLowerCase())));
+}
+
+function practiceLexemesByKey(lexemes: readonly PracticeLexeme[]): Map<string, PracticeLexeme> {
+  const byKey = new Map<string, PracticeLexeme>();
+  for (const entry of lexemes) {
+    byKey.set(entry.lemmaId.toLocaleLowerCase(), entry);
+    byKey.set(entry.lemma.toLocaleLowerCase(), entry);
+  }
+  return byKey;
+}
+
+function searchRowsByKey(rows: readonly SearchRow[]): Map<string, SearchRow> {
+  const byKey = new Map<string, SearchRow>();
+  for (const entry of rows) {
+    byKey.set(entry.s.toLocaleLowerCase(), entry);
+    byKey.set(entry.l.toLocaleLowerCase(), entry);
+  }
+  return byKey;
+}
+
+/**
+ * Resolve deck keys through the practice cores first, then Atlas's prefix shards.
+ * The complete index is deliberately reserved for a missing/broken shard manifest
+ * or a shard lookup that cannot find an exact key: it is a compatibility fallback,
+ * not the normal custom-deck transport.
+ */
+async function resolveDeckKeyMetadata(
+  lemmaKeys: readonly string[],
+  lexemes: readonly PracticeLexeme[],
+  cache: Map<string, Promise<unknown>>,
+): Promise<Map<string, DeckKeyResolution>> {
+  const practiceByKey = practiceLexemesByKey(lexemes);
+  const resolutions = new Map<string, DeckKeyResolution>();
+  const unresolved: string[] = [];
+
+  for (const key of lemmaKeys) {
+    const practice = keyLookupVariants(key)
+      .map((variant) => practiceByKey.get(variant))
+      .find((entry): entry is PracticeLexeme => Boolean(entry)) ?? null;
+    resolutions.set(key, { practice, atlas: null });
+    if (!practice) unresolved.push(key);
+  }
+
+  // The common case is a deck entirely covered by the practice cores. Do not
+  // download any Atlas index artifact in that case.
+  if (unresolved.length === 0) return resolutions;
+
+  let rows: SearchRow[] = [];
+  let needsFullIndexFallback = false;
+  try {
+    const manifest = await getShardJson<SearchShardManifest>('/lexicon/search-shards.json', cache);
+    const shardPaths = Array.from(
+      new Set(
+        unresolved.flatMap((key) =>
+          keyLookupVariants(key)
+            .map((variant) => searchShardForQuery(manifest, variant)?.path)
+            .filter((path): path is string => Boolean(path)),
+        ),
+      ),
+    );
+    if (shardPaths.length === 0) {
+      needsFullIndexFallback = true;
+    } else {
+      rows = (await Promise.all(
+        shardPaths.map((path) => getShardJson<SearchRow[]>(path, cache)),
+      )).flat();
+      const shardRowsByKey = searchRowsByKey(rows);
+      needsFullIndexFallback = unresolved.some(
+        (key) => !keyLookupVariants(key).some((variant) => shardRowsByKey.has(variant)),
+      );
+    }
+  } catch {
+    needsFullIndexFallback = true;
+  }
+
+  if (needsFullIndexFallback) {
+    // Last resort only: older/static deployments can lack a manifest or a
+    // relevant shard even though their legacy complete index still has the row.
+    rows = await getShardJson<SearchRow[]>('/lexicon/search-index.json', cache).catch(() => []);
+  }
+
+  const atlasByKey = searchRowsByKey(rows);
+  for (const key of unresolved) {
+    const atlasRow = keyLookupVariants(key)
+      .map((variant) => atlasByKey.get(variant))
+      .find((entry): entry is SearchRow => Boolean(entry));
+    if (!atlasRow) continue;
+    const gloss = atlasRow.g ? cleanGloss(atlasRow.g) : '';
+    resolutions.set(key, {
+      practice: null,
+      atlas: {
+        lemma: atlasRow.l,
+        slug: atlasRow.s,
+        // Search-index text can be a dictionary definition. Only retain the
+        // same concise first-sense labels eligible for practice cards.
+        gloss: isPhraseGloss(gloss) ? null : gloss,
+        cefr: atlasRow.c ?? null,
+      },
+    });
+  }
+  return resolutions;
+}
+
+function ensureDeckCustomSetCoverage(
+  deck: PracticeDeckData,
+  lemmaKeys: string[],
+  resolutions: ReadonlyMap<string, DeckKeyResolution>,
+): PracticeDeckData {
   if (!deck || !lemmaKeys || lemmaKeys.length === 0) return deck;
-  const existingIndexLemmas = new Set(
-    (deck.index ?? []).map((i) => (i.lemmaId || i.lemma || '').toLowerCase()),
-  );
+  const existingIndexLemmas = new Set<string>();
+  for (const item of deck.index ?? []) {
+    existingIndexLemmas.add(item.lemmaId.toLocaleLowerCase());
+    existingIndexLemmas.add(item.lemma.toLocaleLowerCase());
+  }
   const newIndexItems: PracticeIndexItem[] = [];
   const newLexemes: PracticeLexeme[] = [];
 
@@ -158,14 +285,15 @@ function ensureDeckCustomSetCoverage(deck: PracticeDeckData, lemmaKeys: string[]
     const keyLower = key.toLowerCase();
     if (!existingIndexLemmas.has(keyLower)) {
       existingIndexLemmas.add(keyLower);
-      const cleanKey = key.replace(/\(.*?\)/g, '').trim() || key;
+      const cleanKey = cleanDeckKey(key);
+      const atlas = resolutions.get(key)?.atlas ?? null;
       const matchedClozeIds = clozeByLemma.get(keyLower) ?? [];
       const hasCloze = matchedClozeIds.length > 0;
 
       newIndexItems.push({
-        lemmaId: key,
-        lemma: cleanKey,
-        cefr: 'A1',
+        lemmaId: atlas?.slug ?? key,
+        lemma: atlas?.lemma ?? cleanKey,
+        cefr: atlas?.cefr ?? 'A1',
         modes: hasCloze
           ? ['flashcards', 'cloze', 'stress', 'classify', 'paradigm', 'synonym', 'paronym', 'heritage']
           : ['flashcards', 'stress', 'classify', 'paradigm', 'synonym', 'paronym', 'heritage'],
@@ -175,13 +303,13 @@ function ensureDeckCustomSetCoverage(deck: PracticeDeckData, lemmaKeys: string[]
       });
 
       newLexemes.push({
-        lemmaId: key,
-        lemma: cleanKey,
-        lemmaPlain: cleanKey,
+        lemmaId: atlas?.slug ?? key,
+        lemma: atlas?.lemma ?? cleanKey,
+        lemmaPlain: atlas?.lemma ?? cleanKey,
         ipa: null,
-        gloss: cleanKey,
-        pos: 'noun',
-        cefr: 'A1',
+        gloss: atlas?.gloss ?? cleanKey,
+        pos: null,
+        cefr: atlas?.cefr ?? 'A1',
         heritage: null,
         severity: null,
         paradigm: { cases: {} },
@@ -1632,16 +1760,6 @@ function LexiconPracticeIsland({
               }),
             );
 
-        // The public Atlas search index is the route-existence source for deck
-        // words outside the smaller practice set. Keep it out of the all-words
-        // path, and use the shared JSON cache so deck changes never refetch it.
-        const atlasSearchIndex = deckLemmaKeys === null
-          ? []
-          : await getShardJson<SearchRow[]>(
-              '/lexicon/search-index.json',
-              shardJsonCacheRef.current,
-            ).catch(() => []);
-
         if (cancelled) return;
         const merged = new Map<string, PracticeLexeme>();
         for (const entry of deck?.lexemes ?? []) {
@@ -1654,6 +1772,16 @@ function LexiconPracticeIsland({
           ...(deck?.cloze ?? []),
           ...levelEntries.flatMap((batch) => batch.cloze),
         ]);
+        // Both the preview and the live session use this one resolver. It skips
+        // Atlas entirely when practice cores already cover the selected deck,
+        // otherwise it probes only the relevant search-prefix shards.
+        const deckKeyResolutions = deckLemmaKeys === null
+          ? new Map<string, DeckKeyResolution>()
+          : await resolveDeckKeyMetadata(
+              deckLemmaKeys,
+              Array.from(lexemes.values()),
+              shardJsonCacheRef.current,
+            );
 
         let displayablePicks: DailyWord[];
         if (deckLemmaKeys !== null) {
@@ -1664,25 +1792,18 @@ function LexiconPracticeIsland({
             lexemesByLower.set(entry.lemmaId.toLowerCase(), entry);
             lexemesByLower.set(entry.lemma.toLowerCase(), entry);
           }
-          const atlasEntriesByLower = new Map<string, SearchRow>();
-          for (const entry of atlasSearchIndex) {
-            atlasEntriesByLower.set(entry.s.toLowerCase(), entry);
-            atlasEntriesByLower.set(entry.l.toLowerCase(), entry);
-          }
           const deckPool: DailyWord[] = deckLemmaKeys.map((key) => {
             const match = lexemes.get(key) ?? lexemesByLower.get(key.toLowerCase()) ?? null;
-            const cleanKey = key.replace(/\(.*?\)/g, '').trim() || key;
-            const atlasMatch = atlasEntriesByLower.get(key.toLowerCase())
-              ?? atlasEntriesByLower.get(cleanKey.toLowerCase())
-              ?? null;
+            const cleanKey = cleanDeckKey(key);
+            const atlasMatch = deckKeyResolutions.get(key)?.atlas ?? null;
             // Practice lexemes are richer than the search index. If neither
             // source recognizes a deck key, preserve the unlinked orphan card.
             return {
-              lemma: match?.lemma ?? atlasMatch?.l ?? cleanKey,
-              slug: match?.lemmaId ?? atlasMatch?.s ?? key,
-              gloss: match?.gloss ?? atlasMatch?.g ?? cleanKey,
+              lemma: match?.lemma ?? atlasMatch?.lemma ?? cleanKey,
+              slug: match?.lemmaId ?? atlasMatch?.slug ?? key,
+              gloss: match?.gloss ?? atlasMatch?.gloss ?? cleanKey,
               hasAtlasEntry: Boolean(match ?? atlasMatch),
-              cefr: match?.cefr ?? undefined,
+              cefr: match?.cefr ?? atlasMatch?.cefr ?? undefined,
               pos: match?.pos ?? undefined,
               example: match?.example ?? undefined,
               exampleEn: match?.exampleEn ?? undefined,
@@ -1967,6 +2088,8 @@ function LexiconPracticeIsland({
       const targetLevel = level;
       const lowerLevels = levels.slice(0, -1);
       const needDrills = includeCloze && (force || !clozeLoaded);
+      const deckLemmaKeys = resolveDeckLemmaKeys(deckFilter, customSets);
+      let deckKeyResolutions: Map<string, DeckKeyResolution> | null = null;
 
       if (!nextDeck) {
         // PROGRESSIVE: Load the SELECTED level's core shards (index + lexemes) FIRST.
@@ -1980,11 +2103,17 @@ function LexiconPracticeIsland({
           getShardJson<PracticeLexemeShard>(lexUrl, shardJsonCacheRef.current),
         ]);
         nextDeck = combinePracticeShards(indexShard, lexemeShard);
-        // Set early so that beginSession proceeds and first item can render from the
-        // selected level alone.
-        if (deckRequestId.current === requestId) {
-          setDeck(nextDeck);
+        if (deckLemmaKeys !== null) {
+          deckKeyResolutions = await resolveDeckKeyMetadata(
+            deckLemmaKeys,
+            nextDeck.lexemes ?? [],
+            shardJsonCacheRef.current,
+          );
+          nextDeck = ensureDeckCustomSetCoverage(nextDeck, deckLemmaKeys, deckKeyResolutions);
         }
+        // The first committed deck must already contain Atlas-enriched custom
+        // entries; background lower-level growth may safely extend it after this.
+        if (deckRequestId.current === requestId) setDeck(nextDeck);
 
         // Fire-and-forget background load of lower-level *cores*. Merge into live pool
         // as they arrive; selector cache per deck identity (#4656) receives the new deck
@@ -2068,7 +2197,6 @@ function LexiconPracticeIsland({
           } catch {
             // Degrades gracefully if teacher cloze shard is missing
           }
-          nextDeck = ensureDeckCustomSetCoverage(nextDeck!, teacherDeck.lemma_keys);
         }
 
         // Merge custom set document cloze items if active
@@ -2081,15 +2209,10 @@ function LexiconPracticeIsland({
                 cloze: [...(nextDeck.cloze ?? []), ...activeSet.cloze_items],
               };
             }
-            nextDeck = ensureDeckCustomSetCoverage(nextDeck!, activeSet.lemma_keys);
           }
         }
 
         nextClozeLoaded = true;
-        if (deckRequestId.current === requestId) {
-          setDeck(nextDeck);
-          setClozeLoaded(true);
-        }
 
         // Background lower drills (merge live when they land).
         if (lowerLevels.length > 0) {
@@ -2136,6 +2259,21 @@ function LexiconPracticeIsland({
             });
           })();
         }
+      }
+
+      // A custom/teacher deck may contain a valid Atlas word outside the
+      // practice-core lexemes. Resolve it before committing the deck, so the
+      // actual session (including a flashcard-only session) receives the same
+      // real slug and card-safe gloss as the idle preview.
+      if (deckLemmaKeys !== null) {
+        deckKeyResolutions ??= await resolveDeckKeyMetadata(
+          deckLemmaKeys,
+          nextDeck!.lexemes ?? [],
+          shardJsonCacheRef.current,
+        );
+        // Re-run the synchronous merge after a custom cloze document was added,
+        // so its IDs attach to the already-resolved custom index item.
+        nextDeck = ensureDeckCustomSetCoverage(nextDeck!, deckLemmaKeys, deckKeyResolutions);
       }
 
       // Ignore the result if a newer fetch (e.g. a later level switch) has superseded this one.

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1183,6 +1183,192 @@ describe('LexiconPractice', () => {
     expect(requested.filter((url) => url.includes('search-index.json'))).toHaveLength(1);
   });
 
+  test('starts a custom-deck flashcard session from a practice-core match without fetching Atlas', async () => {
+    const cat = lexeme('кіт', 'кіт', 'cat', {
+      nominative: 'кіт',
+      accusative: 'кота',
+      locative: 'коті',
+    });
+    const customSet: CustomSet = {
+      id: 'session-practice-cat',
+      title: 'Коти з практики',
+      lemma_keys: ['кіт'],
+      cloze_items: [],
+      created_at: '2026-07-27T12:00:00.000Z',
+      updated_at: '2026-07-27T12:00:00.000Z',
+      device_id: 'test-device',
+      revision: 1,
+    };
+    localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([customSet]));
+
+    const requested: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) {
+        return okJson({
+          deckVersion: 'cats',
+          level: 'A1',
+          items: [{ lemmaId: cat.lemmaId, lemma: cat.lemma, cefr: 'A1', modes: ['flashcards'], hasCloze: false, clozeIds: [], newOrder: 0 }],
+        });
+      }
+      if (url.includes('practice-lexemes.A1.json')) return okJson({ deckVersion: 'cats', level: 'A1', lexemes: [cat] });
+      if (url.includes('practice-cloze.A1.json')) return okJson({ cloze: [] });
+      return notFoundResponse();
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<LexiconPractice />);
+    await user.click(await screen.findByRole('button', { name: /Коти з практики/ }));
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
+
+    await waitFor(() => expect(container.querySelector('[data-activity="flashcard"]')).toBeInTheDocument());
+    const flashcard = container.querySelector<HTMLElement>('[data-activity="flashcard"]')!;
+    await user.click(flashcard);
+    expect(container.querySelector('.flashcard-back .flashcard-word')).toHaveTextContent('cat');
+    expect(requested.some((url) => url.includes('search-shards.json'))).toBe(false);
+    expect(requested.some((url) => url.includes('search-index.json'))).toBe(false);
+  });
+
+  test('enriches an Atlas-only custom-deck key in the live flashcard session via its prefix shard', async () => {
+    const customSet: CustomSet = {
+      id: 'session-atlas-cat',
+      title: 'Коти з Атласу: сесія',
+      lemma_keys: ['кіт'],
+      cloze_items: [],
+      created_at: '2026-07-27T12:00:00.000Z',
+      updated_at: '2026-07-27T12:00:00.000Z',
+      device_id: 'test-device',
+      revision: 1,
+    };
+    localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([customSet]));
+
+    const requested: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) return okJson({ deckVersion: 'empty', level: 'A1', items: [] });
+      if (url.includes('practice-lexemes.A1.json')) return okJson({ deckVersion: 'empty', level: 'A1', lexemes: [] });
+      if (url.includes('practice-cloze.A1.json')) return okJson({ cloze: [] });
+      if (url.includes('search-shards.json')) {
+        return okJson({
+          schema: 'atlas-search-shards', schemaVersion: 1, total: 1, shardCount: 1,
+          fullIndex: { path: '/lexicon/search-index.json', count: 1, bytes: 1, sha256: 'full' },
+          prefixMap: { к: 'u043a' },
+          shards: { u043a: { path: '/lexicon/search/u043a.json', count: 1, bytes: 1, sha256: 'cat' } },
+        });
+      }
+      if (url.includes('/lexicon/search/u043a.json')) return okJson([{ l: 'кіт', s: 'кіт', g: 'cat', t: 'lemma', c: 'A1' }]);
+      return notFoundResponse();
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<LexiconPractice />);
+    await user.click(await screen.findByRole('button', { name: /Коти з Атласу: сесія/ }));
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
+
+    await waitFor(() => expect(container.querySelector('[data-activity="flashcard"]')).toBeInTheDocument());
+    const flashcard = container.querySelector<HTMLElement>('[data-activity="flashcard"]')!;
+    await user.click(flashcard);
+    expect(container.querySelector('.flashcard-back .flashcard-word')).toHaveTextContent('cat');
+    expect(container.querySelectorAll('.flashcard-subtitle')).toHaveLength(0);
+    expect(requested.filter((url) => url.includes('search-shards.json'))).toHaveLength(1);
+    expect(requested.filter((url) => url.includes('/lexicon/search/u043a.json'))).toHaveLength(1);
+    expect(requested.some((url) => url.includes('search-index.json'))).toBe(false);
+  });
+
+  test('keeps the clean-key fallback in a live session when Atlas supplies a dictionary-length gloss', async () => {
+    const customSet: CustomSet = {
+      id: 'session-atlas-long-gloss',
+      title: 'Довгий атласний глос',
+      lemma_keys: ['кіт'],
+      cloze_items: [],
+      created_at: '2026-07-27T12:00:00.000Z',
+      updated_at: '2026-07-27T12:00:00.000Z',
+      device_id: 'test-device',
+      revision: 1,
+    };
+    localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([customSet]));
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) return okJson({ deckVersion: 'empty', level: 'A1', items: [] });
+      if (url.includes('practice-lexemes.A1.json')) return okJson({ deckVersion: 'empty', level: 'A1', lexemes: [] });
+      if (url.includes('practice-cloze.A1.json')) return okJson({ cloze: [] });
+      if (url.includes('search-shards.json')) {
+        return okJson({
+          schema: 'atlas-search-shards', schemaVersion: 1, total: 1, shardCount: 1,
+          fullIndex: { path: '/lexicon/search-index.json', count: 1, bytes: 1, sha256: 'full' },
+          prefixMap: { к: 'u043a' },
+          shards: { u043a: { path: '/lexicon/search/u043a.json', count: 1, bytes: 1, sha256: 'cat' } },
+        });
+      }
+      if (url.includes('/lexicon/search/u043a.json')) {
+        return okJson([{
+          l: 'кіт', s: 'кіт',
+          g: 'A domestic cat is a small carnivorous mammal commonly kept as a pet.',
+          t: 'lemma', c: 'A1',
+        }]);
+      }
+      return notFoundResponse();
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<LexiconPractice />);
+    await user.click(await screen.findByRole('button', { name: /Довгий атласний глос/ }));
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
+
+    await waitFor(() => expect(container.querySelector('[data-activity="flashcard"]')).toBeInTheDocument());
+    await user.click(container.querySelector<HTMLElement>('[data-activity="flashcard"]')!);
+    expect(container.querySelector('.flashcard-back .flashcard-word')).toHaveTextContent('кіт');
+    expect(container.querySelectorAll('.flashcard-subtitle')).toHaveLength(0);
+  });
+
+  test('keeps a true orphan usable in a live session without inventing a noun tag', async () => {
+    const customSet: CustomSet = {
+      id: 'session-true-orphan',
+      title: 'Справжній сирота',
+      lemma_keys: ['вигаданий термін'],
+      cloze_items: [],
+      created_at: '2026-07-27T12:00:00.000Z',
+      updated_at: '2026-07-27T12:00:00.000Z',
+      device_id: 'test-device',
+      revision: 1,
+    };
+    localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([customSet]));
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) return okJson({ deckVersion: 'empty', level: 'A1', items: [] });
+      if (url.includes('practice-lexemes.A1.json')) return okJson({ deckVersion: 'empty', level: 'A1', lexemes: [] });
+      if (url.includes('practice-cloze.A1.json')) return okJson({ cloze: [] });
+      if (url.includes('search-shards.json')) {
+        return okJson({
+          schema: 'atlas-search-shards', schemaVersion: 1, total: 0, shardCount: 1,
+          fullIndex: { path: '/lexicon/search-index.json', count: 0, bytes: 1, sha256: 'full' },
+          prefixMap: { в: 'u0432' },
+          shards: { u0432: { path: '/lexicon/search/u0432.json', count: 0, bytes: 1, sha256: 'empty' } },
+        });
+      }
+      if (url.includes('/lexicon/search/u0432.json') || url.includes('search-index.json')) return okJson([]);
+      return notFoundResponse();
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<LexiconPractice />);
+    await user.click(await screen.findByRole('button', { name: /Справжній сирота/ }));
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
+
+    await waitFor(() => expect(container.querySelector('[data-activity="flashcard"]')).toBeInTheDocument());
+    await user.click(container.querySelector<HTMLElement>('[data-activity="flashcard"]')!);
+    expect(container.querySelector('.flashcard-back .flashcard-word')).toHaveTextContent('вигаданий термін');
+    expect(container.querySelectorAll('.flashcard-subtitle')).toHaveLength(0);
+  });
+
   test('keeps a genuinely absent custom deck key on the orphan path', async () => {
     const customSet: CustomSet = {
       id: 'custom-orphan',

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1109,6 +1109,9 @@ describe('LexiconPractice', () => {
         return okJson({ deckVersion: 'cats', level: 'A1', lexemes: [cat] });
       }
       if (url.includes('practice-cloze.A1.json')) return okJson({ cloze: [] });
+      if (url.includes('search-index.json')) {
+        return okJson([{ l: 'кіт', s: 'кіт', g: 'atlas cat', t: 'lemma', c: 'A1' }]);
+      }
       return notFoundResponse();
     });
 
@@ -1122,12 +1125,62 @@ describe('LexiconPractice', () => {
     await user.click(container.querySelector<HTMLElement>('.daily-preview-card')!);
 
     expect(screen.getAllByText('cat').length).toBeGreaterThan(0);
+    expect(screen.queryByText('atlas cat')).not.toBeInTheDocument();
     expect(screen.getAllByText('noun').length).toBeGreaterThan(0);
     expect(screen.getByTestId('practice-preview-atlas-link')).toHaveAttribute(
       'href',
       '/lexicon/%D0%BA%D1%96%D1%82/',
     );
     expect(requested.some((url) => url.includes('practice-lexemes.A2.json'))).toBe(false);
+  });
+
+  test('falls back to the Atlas index for a custom deck word outside practice lexemes', async () => {
+    const customSet: CustomSet = {
+      id: 'custom-atlas-only-cat',
+      title: 'Коти з Атласу',
+      lemma_keys: ['кіт'],
+      cloze_items: [],
+      created_at: '2026-07-27T12:00:00.000Z',
+      updated_at: '2026-07-27T12:00:00.000Z',
+      device_id: 'test-device',
+      revision: 1,
+    };
+    localStorage.setItem('learn_ukrainian_custom_sets_v1', JSON.stringify([customSet]));
+
+    const requested: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      if (url.includes('daily-pool.json')) return okJson([]);
+      if (url.includes('practice-index.A1.json')) {
+        return okJson({ deckVersion: 'empty', level: 'A1', items: [] });
+      }
+      if (url.includes('practice-lexemes.A1.json')) {
+        return okJson({ deckVersion: 'empty', level: 'A1', lexemes: [] });
+      }
+      if (url.includes('practice-cloze.A1.json')) return okJson({ cloze: [] });
+      if (url.includes('search-index.json')) {
+        return okJson([{ l: 'кіт', s: 'кіт', g: 'cat', t: 'lemma', c: 'A1' }]);
+      }
+      return notFoundResponse();
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<LexiconPractice />);
+    await user.click(await screen.findByRole('button', { name: /Коти з Атласу/ }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('practice-daily-deck-title')).toHaveTextContent('Коти з Атласу'),
+    );
+    await user.click(container.querySelector<HTMLElement>('.daily-preview-card')!);
+
+    expect(screen.getAllByText('cat').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('practice-preview-atlas-link')).toHaveAttribute(
+      'href',
+      '/lexicon/%D0%BA%D1%96%D1%82/',
+    );
+    expect(screen.queryByText('noun')).not.toBeInTheDocument();
+    expect(requested.filter((url) => url.includes('search-index.json'))).toHaveLength(1);
   });
 
   test('keeps a genuinely absent custom deck key on the orphan path', async () => {
@@ -1153,6 +1206,7 @@ describe('LexiconPractice', () => {
         return okJson({ deckVersion: 'empty', level: 'A1', lexemes: [] });
       }
       if (url.includes('practice-cloze.A1.json')) return okJson({ cloze: [] });
+      if (url.includes('search-index.json')) return okJson([]);
       return notFoundResponse();
     });
 


### PR DESCRIPTION
## Summary
- fall back to the published Atlas search index for custom-deck words absent from practice lexemes
- preserve rich practice-lexeme precedence and unlinked orphan behavior
- cover the Atlas-only card path in unit and browser tests

## Verification
- `NODE_OPTIONS=--no-experimental-webstorage npm run test:unit -- tests/unit/LexiconPractice.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build`
- `CI=1 PLAYWRIGHT_PORT=4328 NODE_OPTIONS=--no-experimental-webstorage npx playwright test e2e/atlas-practice.spec.ts --grep "A8a"`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

No merge or auto-merge has been requested or armed.