### PR TITLE
feat(trails): T2 first drafts — RB-1 cold-start trail + decision tables v0

### DIFF
--- a/agents_extensions/shared/schemas/decision-tables.v0.schema.json
+++ b/agents_extensions/shared/schemas/decision-tables.v0.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "decision-tables.v0",
+  "title": "Decision tables v0 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "precedence", "tables"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "decision-tables.v0"
+    },
+    "precedence": {
+      "type": "string",
+      "const": "first-match"
+    },
+    "tables": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-z0-9-]+$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["mode"],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["static", "live-lookup"]
+          },
+          "inputs": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 1
+          },
+          "rows": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["when", "then"],
+              "properties": {
+                "when": {"type": "string", "minLength": 1},
+                "then": {"type": "string", "minLength": 1},
+                "blocked_on": {"type": ["string", "null"]}
+              }
+            }
+          },
+          "procedure": {"type": "string", "minLength": 1},
+          "never": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 1
+          },
+          "blocked_on": {"type": ["string", "null"]}
+        },
+        "allOf": [
+          {
+            "if": {"properties": {"mode": {"const": "static"}}},
+            "then": {"required": ["rows"]}
+          },
+          {
+            "if": {"properties": {"mode": {"const": "live-lookup"}}},
+            "then": {"required": ["procedure"], "not": {"required": ["rows"]}}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/agents_extensions/shared/schemas/trailspec.v1.schema.json
+++ b/agents_extensions/shared/schemas/trailspec.v1.schema.json
@@ -99,6 +99,11 @@
             "type": "string",
             "enum": ["mechanical", "table-lookup", "summon"]
           },
+          "table": {
+            "type": ["string", "null"],
+            "pattern": "^[a-z0-9-]+$",
+            "description": "For kind table-lookup: the decision-tables table this step resolves through. Cross-checked by validate_trail_table_refs."
+          },
           "blocked_on": {
             "type": ["string", "null"]
           }

--- a/scripts/config/trails/decision-tables.v0.yaml
+++ b/scripts/config/trails/decision-tables.v0.yaml
@@ -123,6 +123,6 @@ tables:
     inputs: [PR's stream epic, branch/dispatch-brief slug, lane assignments registry, driver-handoff claims]
     rows:
       - {when: "PR's epic maps to THIS seat's area", then: "yours: drive, review-gate, arm, merge, reap"}
-      - {when: "PR's epic maps to another area", then: "hands off; author-lane prefixes do not decide ownership, and author:@me is meaningless under the shared git identity"}
       - {when: "out-of-lane PR sat GREEN (CI + review) > 1 hour and its driver is absent", then: "abandoned-work carve-out MAY apply; verify the driver is truly gone before touching"}
+      - {when: "PR's epic maps to another area", then: "hands off; author-lane prefixes do not decide ownership, and author:@me is meaningless under the shared git identity"}
       - {when: "ownership genuinely ambiguous after all three inputs", then: "STOP-manual-intervention"}

--- a/scripts/config/trails/decision-tables.v0.yaml
+++ b/scripts/config/trails/decision-tables.v0.yaml
@@ -1,48 +1,53 @@
 # Decision tables v0 — the enumerated judgment seams of the drive loop (T2 DRAFT).
 # Part of #5885 (design v2, panel-approved; glm off-trail list + grok table forms).
 #
-# Contract: a trail step of kind table-lookup names ONE table here. A table either
-# resolves deterministically to exactly one action, or the row says STOP — a seat never
-# improvises between rows. Tables marked `mode: live-lookup` fix the PROCEDURE and the
-# input sources but never freeze live data (roster, pace, quotas) — the drive-epic golden
-# rule: method, never roster.
+# Contract: a trail step of kind table-lookup names ONE table here. Rows evaluate
+# TOP-DOWN and the FIRST matching row wins (`precedence: first-match` below) — exclusion
+# and stop rows therefore sit ABOVE the general pick/arm rows they guard, and an input
+# matching an earlier row never reaches a later one. A table either resolves to exactly
+# one action or the matched row says STOP — a seat never improvises between rows.
+# Tables marked `mode: live-lookup` fix the PROCEDURE and the input sources but never
+# freeze live data (roster, pace, quotas) — the drive-epic golden rule: method, never
+# roster.
 #
-# DRAFT: no schema enforces this file yet (tracked on #5885 — needed before T4
-# certification). Rows carry blocked_on markers where the input machinery is unbuilt.
+# This file validates against agents_extensions/shared/schemas/decision-tables.v0.schema.json
+# (validate_decision_tables in scripts/orchestration/validate_trailspec.py) and is covered
+# by tests/test_validate_trailspec.py.
 schema_version: decision-tables.v0
+precedence: first-match
 tables:
 
   queue-pick:
     mode: static
     inputs: [epic tracking issue checklist order, gh pr list --state all --search "<issue-nr>", lane assignment]
     rows:
-      - when: item's dependencies all MERGED and no sibling PR already carries it
-        then: pick lowest such open item in tracking-issue order
+      - when: item belongs to another lane's epic (check lane assignments + branch/brief slug + foreign driver-handoff claim)
+        then: STOP-policy-violation  # hands off; comment findings, never drive
       - when: sibling PR exists for the item (open or merged)
         then: reconcile against that PR first; an open issue is not proof of unfixed
       - when: two items tie or the order is not derivable from the tracking issue
         then: STOP-manual-intervention
-      - when: item belongs to another lane's epic (check lane assignments + branch/brief slug + foreign driver-handoff claim)
-        then: STOP-policy-violation  # hands off; comment findings, never drive
+      - when: item's dependencies all MERGED and no earlier row matched
+        then: pick lowest such open item in tracking-issue order
 
   review-gate-arm:
     mode: static
-    inputs: [cross-family verdict, verdict head SHA vs current PR head, requested-changes state, blocking CI]
+    inputs: [cross-family verdict, verdict head SHA vs current PR head, requested-changes state, blocking CI, draft state, reviewer identity]
     rows:
-      - when: cross-family APPROVE ∧ verdict bound to CURRENT head ∧ no unresolved requested-changes ∧ blocking CI green
-        then: arm auto-merge (gh pr merge --auto --squash --delete-branch) the same hour
-      - when: verdict APPROVE but head moved since verdict
-        then: re-request review on the new head; never arm on a stale-head verdict
-      - when: requested-changes unresolved (a later LGTM comment does not resolve a review thread)
-        then: wait; read the review THREAD, not the ticks
-      - when: blocking CI red
-        then: red-ci-triage table; never arm over blocking red, never admin-bypass
-      - when: verdicts conflict across seats
-        then: STOP-contested
       - when: PR is a DRAFT
         then: never arm, never merge — undraft only after the gate passes
       - when: reviewer is the author, or the arming driver specified the fix under review
         then: route to a different independent seat  # directing a fix disqualifies its reviewer
+      - when: requested-changes unresolved (a later LGTM comment does not resolve a review thread)
+        then: wait; read the review THREAD, not the ticks
+      - when: verdict APPROVE but head moved since verdict
+        then: re-request review on the new head; never arm on a stale-head verdict
+      - when: verdicts conflict across seats
+        then: STOP-contested
+      - when: blocking CI red
+        then: red-ci-triage table; never arm over blocking red, never admin-bypass
+      - when: cross-family APPROVE ∧ verdict bound to CURRENT head ∧ blocking CI green ∧ no earlier row matched
+        then: arm auto-merge (gh pr merge --auto --squash --delete-branch) the same hour
 
   red-ci-triage:
     mode: static
@@ -63,8 +68,9 @@ tables:
     inputs: ["batch_state/tasks/<id>.json status field (the file is truth; the active-list API can omit live tasks)"]
     rows:
       - {when: "done", then: "SUCCESS — finalize: read result + artifact CONTENT, verify diff rows, then review gate"}
-      - {when: "failed | crashed", then: "read stderr_excerpt + logs; transient → remove worktree+branch, re-fire once with -retry id; second failure → STOP-unrecoverable-error"}
-      - {when: "timeout | silence-timeout", then: "check worktree for finished-but-unpushed work and gh pr list FIRST (silent-exit class), then decide retry vs STOP"}
+      - {when: "failed | crashed, task id has no -retry suffix", then: "read stderr_excerpt + logs; remove worktree+branch; re-fire ONCE with a -retry task id"}
+      - {when: "failed | crashed, task id already carries -retry", then: "STOP-unrecoverable-error"}  # never a third automatic attempt
+      - {when: "timeout | silence-timeout", then: "check the worktree for finished-but-unpushed work AND gh pr list for an already-opened PR (silent-exit class); deliverable present → finalize by hand; absent → treat as the failed|crashed rows above"}
       - {when: "rate_limited", then: "reroute per fallback substitutions; note the substitution"}
       - {when: "cancelled | dry_run", then: "terminal, not success; re-fire only if the need stands"}
       - {when: "needs_finalize | no_deliverable", then: "attention states: finalize by hand; no_deliverable on a private-repo dispatch may be the #5855 false negative — verify commits before believing it"}

--- a/scripts/config/trails/decision-tables.v0.yaml
+++ b/scripts/config/trails/decision-tables.v0.yaml
@@ -1,0 +1,122 @@
+# Decision tables v0 — the enumerated judgment seams of the drive loop (T2 DRAFT).
+# Part of #5885 (design v2, panel-approved; glm off-trail list + grok table forms).
+#
+# Contract: a trail step of kind table-lookup names ONE table here. A table either
+# resolves deterministically to exactly one action, or the row says STOP — a seat never
+# improvises between rows. Tables marked `mode: live-lookup` fix the PROCEDURE and the
+# input sources but never freeze live data (roster, pace, quotas) — the drive-epic golden
+# rule: method, never roster.
+#
+# DRAFT: no schema enforces this file yet (tracked on #5885 — needed before T4
+# certification). Rows carry blocked_on markers where the input machinery is unbuilt.
+schema_version: decision-tables.v0
+tables:
+
+  queue-pick:
+    mode: static
+    inputs: [epic tracking issue checklist order, gh pr list --state all --search "<issue-nr>", lane assignment]
+    rows:
+      - when: item's dependencies all MERGED and no sibling PR already carries it
+        then: pick lowest such open item in tracking-issue order
+      - when: sibling PR exists for the item (open or merged)
+        then: reconcile against that PR first; an open issue is not proof of unfixed
+      - when: two items tie or the order is not derivable from the tracking issue
+        then: STOP-manual-intervention
+      - when: item belongs to another lane's epic (check lane assignments + branch/brief slug + foreign driver-handoff claim)
+        then: STOP-policy-violation  # hands off; comment findings, never drive
+
+  review-gate-arm:
+    mode: static
+    inputs: [cross-family verdict, verdict head SHA vs current PR head, requested-changes state, blocking CI]
+    rows:
+      - when: cross-family APPROVE ∧ verdict bound to CURRENT head ∧ no unresolved requested-changes ∧ blocking CI green
+        then: arm auto-merge (gh pr merge --auto --squash --delete-branch) the same hour
+      - when: verdict APPROVE but head moved since verdict
+        then: re-request review on the new head; never arm on a stale-head verdict
+      - when: requested-changes unresolved (a later LGTM comment does not resolve a review thread)
+        then: wait; read the review THREAD, not the ticks
+      - when: blocking CI red
+        then: red-ci-triage table; never arm over blocking red, never admin-bypass
+      - when: verdicts conflict across seats
+        then: STOP-contested
+      - when: PR is a DRAFT
+        then: never arm, never merge — undraft only after the gate passes
+      - when: reviewer is the author, or the arming driver specified the fix under review
+        then: route to a different independent seat  # directing a fix disqualifies its reviewer
+
+  red-ci-triage:
+    mode: static
+    inputs: [failing check name, failure signature from logs, base-branch state]
+    rows:
+      - when: failure signature matches a known-failure-class allowlist entry
+        then: apply that entry's action (retry-once | note-and-proceed | STOP)
+        blocked_on: "known-failure-class signature registry does not exist yet (#5885)"
+      - when: failure reproduces on origin/main (pre-existing)
+        then: note on PR; do not fix in-branch; file/link the owning issue
+      - when: base branch was fixed after this head's CI ran
+        then: gh pr update-branch — NEVER gh run rerun (rerun re-tests the stale pinned SHA; a rerun on a superseded head can cancel the live head's run via the concurrency group)
+      - when: signature unknown
+        then: STOP-unknown  # never retry-until-green
+
+  settle-status:
+    mode: static
+    inputs: ["batch_state/tasks/<id>.json status field (the file is truth; the active-list API can omit live tasks)"]
+    rows:
+      - {when: "done", then: "SUCCESS — finalize: read result + artifact CONTENT, verify diff rows, then review gate"}
+      - {when: "failed | crashed", then: "read stderr_excerpt + logs; transient → remove worktree+branch, re-fire once with -retry id; second failure → STOP-unrecoverable-error"}
+      - {when: "timeout | silence-timeout", then: "check worktree for finished-but-unpushed work and gh pr list FIRST (silent-exit class), then decide retry vs STOP"}
+      - {when: "rate_limited", then: "reroute per fallback substitutions; note the substitution"}
+      - {when: "cancelled | dry_run", then: "terminal, not success; re-fire only if the need stands"}
+      - {when: "needs_finalize | no_deliverable", then: "attention states: finalize by hand; no_deliverable on a private-repo dispatch may be the #5855 false negative — verify commits before believing it"}
+      - {when: "spawning | running", then: "not terminal; keep the Monitor settle-loop, never keyword-grep logs as completion"}
+      - {when: "any status string not in this table", then: "STOP-unknown"}
+
+  lane-routing:
+    mode: live-lookup
+    procedure: >-
+      Resolve seat from /api/rules model-assignment (routing SSOT) + model_catalog.yaml
+      floors for the task's risk class. Confirm capability with check-model before first
+      use in a session. Respect: language-lane restriction (UK content only on sanctioned
+      lanes), judge-seat exclusions, local-fanout=1, cross-family review pairing.
+    never: [route from memory of a roster, route by provider name alone, freeze model names into this file]
+
+  width:
+    mode: live-lookup
+    procedure: >-
+      Two-sided: for each candidate lane read codexbar pace stage + reserve; read disk
+      (df -h / AND du -sh <repo_root>/.worktrees). Idle lane + quota headroom + disk room →
+      widen. At/ahead of pace or thin reserve → throttle, shed to a lane with headroom.
+      No data for a lane → in-flight count + lane health, and SAY the picture is partial.
+      DISK WINS every conflict; reaping finished worktrees is capacity management.
+    never: [fixed numeric in-flight caps, quota headroom overriding disk, manufacturing work for an idle lane]
+
+  handoff-completeness:
+    mode: static
+    inputs: [lane driver-handoff file at session close or rollover]
+    rows:
+      - {when: "closing a session or preparing rollover", then: "handoff carries: assignment scope · epic phase · IN-FLIGHT with watcher ids · verdict/finalize state per open PR · NEXT ACTION ordered list · operator-pending items · pace/disk at last dispatch"}
+      - {when: "any of those unknown", then: "reconstruct from tool output before writing; a handoff row must never be from memory"}
+      - {when: "file exceeds 40KB", then: "archive older sessions before writing more"}
+    blocked_on: "closure-gate integration lands with T1.2 (#5880 step 5)"
+
+  summon-vs-park:
+    mode: static
+    inputs: [blocking condition class]
+    rows:
+      - when: blocked on a decision the OPERATOR owns (his account/quota/deploy target, or conflict with his prior order)
+        then: park the item + post ONE plain-language sentence (no jargon, no id dumps), continue other work; never a menu
+      - when: blocked on a judgment seat (architecture, contested verdicts, design)
+        then: summon via bridge ask to the advisor seats per /api/rules; park with code + bridge template; continue other work
+      - when: blocked on unbuilt tooling
+        then: blocked_on marker + file/link the tracking-issue row; never invent a substitute command
+      - when: tempted to babysit interactively
+        then: babysit = table-lookup over the babysit file with a persistent Monitor, not a foreground wait
+
+  pr-ownership:
+    mode: static
+    inputs: [PR's stream epic, branch/dispatch-brief slug, lane assignments registry, driver-handoff claims]
+    rows:
+      - {when: "PR's epic maps to THIS seat's area", then: "yours: drive, review-gate, arm, merge, reap"}
+      - {when: "PR's epic maps to another area", then: "hands off; author-lane prefixes do not decide ownership, and author:@me is meaningless under the shared git identity"}
+      - {when: "out-of-lane PR sat GREEN (CI + review) > 1 hour and its driver is absent", then: "abandoned-work carve-out MAY apply; verify the driver is truly gone before touching"}
+      - {when: "ownership genuinely ambiguous after all three inputs", then: "STOP-manual-intervention"}

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -5,12 +5,14 @@
 # certification waits for T1 (slot addressing #5878, closure primitive). Steps that
 # depend on unbuilt machinery carry an explicit blocked_on marker.
 #
-# Anti-pattern guard (the #5860 r1 lessons): every command below is a real, currently
-# runnable repo command; every predicate is falsifiable; no failure path is swallowed —
-# unknown situations exit through a STOP code, never through a happy-path transition.
+# Anti-pattern guard (the #5860 r1 lessons, re-verified in the #5886 review round):
+# every command below is a real, currently runnable repo command whose OUTPUT SHAPE was
+# captured from a live run before being encoded; every predicate is falsifiable and has
+# an evidenced outcome for its failure direction; no failure path is swallowed — unknown
+# situations exit through a STOP code, never through a happy-path transition.
 schema_version: trailspec.v1
 trail_id: rb1-cold-start
-version: "0.1.0"
+version: "0.2.0"
 title: RB1 Cold-start, orientation, and queue pick
 seats:
   - grok-daily
@@ -29,15 +31,18 @@ steps:
   - step_id: detect_rollover
     intent: >-
       Detect whether a pending thread-rollover packet exists for this seat's handoff
-      agent. Exactly one validated packet or none are the only proceed states.
+      agent. The tool emits JSON whose "status" field is the transition input; its real
+      vocabulary (captured live) is none / pending_start / ambiguous, with terminal
+      packets listed under excluded_terminal. Only none and pending_start are proceed
+      states; ambiguous or any unrecognized status is a hard stop.
     command: .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent {handoff_agent}
     evidence_predicate:
       command: .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent {handoff_agent}
-      success_pattern: '"status"'
+      success_pattern: '"status": "(none|pending_start)"'
     transitions:
-      none_pending: orient_api
-      one_pending: claim_rollover
-      multiple_or_corrupt: STOP-concurrency-conflict
+      none: orient_api
+      pending_start: claim_rollover
+      ambiguous_or_unrecognized_status: STOP-concurrency-conflict
     kind: mechanical
     blocked_on: null
 
@@ -58,87 +63,116 @@ steps:
 
   - step_id: orient_api
     intent: >-
-      Orient via the Monitor API: manifest (live context telemetry), active dispatches,
-      and this seat's inbox. API down is not fatal — fall back to files — but the fallback
-      must be said out loud in the session log, never silently absorbed.
+      Orient via the Monitor API: manifest with live context telemetry. API down is not
+      fatal, but the fallback must be EVIDENCED, not narrated: the predicate emits either
+      the live "_telemetry" payload or an API_DOWN receipt proving the offline rule files
+      exist. Neither source available means no orientation basis at all — stop.
     command: curl -sS --max-time 2 "http://127.0.0.1:8765/api/state/manifest"
     evidence_predicate:
-      command: curl -sS --max-time 2 "http://127.0.0.1:8765/api/state/manifest"
-      success_pattern: '"_telemetry"'
+      command: >-
+        curl -sS --max-time 2 "http://127.0.0.1:8765/api/state/manifest"
+        || echo "API_DOWN offline-fallback: $(ls agents_extensions/shared/rules/operator-expectations.md)"
+      success_pattern: '"_telemetry"|API_DOWN offline-fallback: agents_extensions/shared/rules/operator-expectations\.md'
     transitions:
       oriented: drain_inbox
-      api_down_fallback_stated: drain_inbox
+      api_down_fallback_evidenced: drain_inbox
+      no_orientation_source: STOP-precondition-failed
     kind: mechanical
     blocked_on: null
 
   - step_id: drain_inbox
     intent: >-
-      Required live-driver inbox drain (drive-epic 0a). List unconsumed messages for this
-      seat. Slot-identity inboxes (e.g. claude-atlas) require taxonomy step 4b.
-    command: .venv/bin/python -m scripts.ai_agent_bridge inbox --for {handoff_agent}
+      Required live-driver inbox check (drive-epic 0a). List this seat's inbox state; the
+      "pending:" count line (captured live from `inbox show`) is the transition input.
+      Slot-identity inboxes (e.g. claude-atlas) require taxonomy step 4b.
+    command: .venv/bin/python -m scripts.ai_agent_bridge inbox show {handoff_agent}
     evidence_predicate:
-      command: .venv/bin/python -m scripts.ai_agent_bridge inbox --for {handoff_agent}
-      success_pattern: '"count"'
+      command: .venv/bin/python -m scripts.ai_agent_bridge inbox show {handoff_agent}
+      success_pattern: 'pending: +[0-9]+'
     transitions:
-      empty: reconcile_git
-      messages_present: apply_inbox
+      pending_zero: reconcile_git
+      pending_nonzero: apply_inbox
     kind: mechanical
     blocked_on: "T1.1-slot-addressing (#5878) for non-static slot identities"
 
   - step_id: apply_inbox
     intent: >-
       Read and APPLY every unconsumed message, then record live consumption with
-      ack --consumed-by-live-driver (plain ack is not delivery proof). Applying a message
-      can change the queue, the width, or the lane's orders — judgment-carrying.
+      ack --consumed-by-live-driver (plain ack is not delivery proof; the flag exists —
+      verified against the current CLI). Applying a message can change the queue, the
+      width, or the lane's orders — judgment-carrying. The post-condition IS mechanical
+      and proven: after application the seat's pending count must read zero.
     command: null
-    evidence_predicate: null
+    evidence_predicate:
+      command: .venv/bin/python -m scripts.ai_agent_bridge inbox show {handoff_agent}
+      success_pattern: 'pending: +0'
     transitions:
-      applied_and_acked: reconcile_git
+      applied_and_drained: reconcile_git
       order_conflicts_with_standing_rule: STOP-manual-intervention
     kind: summon
     blocked_on: null
 
   - step_id: reconcile_git
     intent: >-
-      Reconcile the handoff's claims against reality before firing anything: fetch, compare
-      main, list open PRs and worktrees. A prior session's in-flight item may already be
-      merged — re-firing it is the top re-collision class.
+      Reconcile the handoff's claims against reality before firing anything: fetch,
+      compare main, list open PRs and worktrees. A prior session's in-flight item may
+      already be merged — re-firing it is the top re-collision class. The predicate chain
+      proves ALL FOUR commands ran (any failure breaks the && chain) and additionally
+      pins the invariant that the primary checkout sits on main — a primary moved off
+      main is the recurring #4857 incident class and must stop the trail.
     command: git fetch origin && git log --oneline -3 origin/main && gh pr list --state open --limit 20 && git worktree list
     evidence_predicate:
-      command: git fetch origin && git status --short --branch
-      success_pattern: "\\.\\.\\."
+      command: git fetch origin && git log --oneline -1 origin/main >/dev/null && gh pr list --state open --limit 20 >/dev/null && git worktree list | head -1
+      success_pattern: '\[main\]'
     transitions:
       reconciled: sweep_stale_refs
-      fetch_failed: STOP-precondition-failed
+      fetch_failed_or_primary_off_main: STOP-precondition-failed
     kind: mechanical
     blocked_on: null
 
   - step_id: sweep_stale_refs
     intent: >-
-      Session-start hygiene sweep. Reap only refs whose PR state is MERGED or whose commits
-      are contained in main (merge-base --is-ancestor is NOT valid under squash-merge).
-      Never touch another lane's live worktrees; never delete uncommitted work.
-    command: git worktree list --porcelain
+      Session-start hygiene: list every worktree and every open PR side by side. A stale
+      candidate is a worktree/branch whose PR is MERGED or CLOSED (merge-base ancestry is
+      NOT valid under squash-merge). Listing is mechanical and proven here; DECIDING and
+      REAPING carry judgment (#M-10: uncommitted work, foreign lanes) and live in
+      reap_stale_refs, which emits per-ref receipts.
+    command: git worktree list --porcelain && gh pr list --state open --limit 30
     evidence_predicate:
-      command: git worktree list --porcelain
-      success_pattern: "worktree "
+      command: git worktree list --porcelain | grep -c '^worktree '
+      success_pattern: '[0-9]'
     transitions:
-      clean: pick_next
-      own_merged_refs_reaped: pick_next
-      uncommitted_or_foreign_ambiguity: STOP-manual-intervention
+      no_stale_candidates: pick_next
+      stale_candidates_present: reap_stale_refs
     kind: table-lookup
+    blocked_on: null
+
+  - step_id: reap_stale_refs
+    intent: >-
+      Judgment seat: for each stale candidate, verify clean tree AND zero unpushed
+      commits (never delete uncommitted work; never touch another lane's live worktree),
+      then reap worktree BEFORE branch. Every reap must be receipt-backed by the actual
+      `git worktree remove` / branch-deletion command output — a candidate that resists
+      removal or shows any ambiguity is a stop, not a force flag.
+    command: null
+    evidence_predicate:
+      command: git worktree list --porcelain | grep -c '^worktree '
+      success_pattern: '[0-9]'
+    transitions:
+      reaped_with_receipts: pick_next
+      uncommitted_or_foreign_ambiguity: STOP-manual-intervention
+    kind: summon
     blocked_on: null
 
   - step_id: pick_next
     intent: >-
       Pick the next unblocked action from the lane queue via the queue-pick decision table
-      (decision-tables.v0.yaml). Deterministic pick = dependencies-merged, lowest open item
-      in the epic's tracking-issue order. Before any issue-fix pick, search existing PRs by
-      issue number — an open issue is not proof of unfixed.
+      (decision-tables.v0.yaml, first-match precedence). Before any issue-fix pick, search
+      existing PRs by issue number — an open issue is not proof of unfixed.
     command: gh pr list --state all --search "{issue_nr}" --limit 10
     evidence_predicate:
       command: gh pr list --state all --limit 1
-      success_pattern: "[0-9]"
+      success_pattern: '[0-9]'
     transitions:
       picked: route_lane
       queue_empty: idle
@@ -149,18 +183,23 @@ steps:
 
   - step_id: route_lane
     intent: >-
-      Route the picked task by model-x-harness fit using the routing decision table, which
-      is a LIVE LOOKUP against /api/rules and codexbar pace/reserve plus disk headroom —
-      the table fixes the procedure, never the roster. No capacity anywhere with quality
-      fit = idle, never a forced misroute.
-    command: codexbar usage --json --provider claude
+      Route the picked task by model-x-harness fit using the routing decision table — a
+      LIVE LOOKUP against /api/rules and codexbar pace/reserve plus disk headroom; the
+      table fixes the procedure, never the roster. The predicate emits either usable
+      quota data (the "pace"/"usage" keys of real codexbar JSON) or an explicit
+      CODEXBAR_UNAVAILABLE receipt — that receipt IS the required partial-picture
+      evidence, and routing on it must say so. No capacity anywhere with quality fit =
+      idle, never a forced misroute.
+    command: df -h / && codexbar usage --json --provider claude
     evidence_predicate:
-      command: df -h / && codexbar usage --json --provider claude
-      success_pattern: "provider"
+      command: >-
+        df -h / && (codexbar usage --json --provider claude | grep -E '"pace"|"usage"'
+        || echo "CODEXBAR_UNAVAILABLE")
+      success_pattern: '"pace"|"usage"|CODEXBAR_UNAVAILABLE'
     transitions:
       routed: ready_to_dispatch
       no_fitting_capacity: idle
-      routing_data_unavailable_partial_stated: ready_to_dispatch
+      partial_data_receipt_stated: ready_to_dispatch
       language_lane_restriction_hit: STOP-policy-violation
     kind: table-lookup
     blocked_on: null

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -32,16 +32,19 @@ steps:
     intent: >-
       Detect whether a pending thread-rollover packet exists for this seat's handoff
       agent. The tool emits JSON whose "status" field is the transition input; its real
-      vocabulary (captured live) is none / pending_start / ambiguous, with terminal
-      packets listed under excluded_terminal. Only none and pending_start are proceed
-      states; ambiguous or any unrecognized status is a hard stop.
+      vocabulary (verified in thread_handoff.py) is none / pending_start / resumed /
+      ambiguous, with terminal packets listed under excluded_terminal. Proceed states:
+      none, pending_start, and resumed (a live packet THIS thread already bound — the
+      tool itself hard-errors when the binding belongs to a different thread). Ambiguous
+      or any unrecognized status is a hard stop.
     command: .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent {handoff_agent}
     evidence_predicate:
       command: .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent {handoff_agent}
-      success_pattern: '"status": "(none|pending_start)"'
+      success_pattern: '"status": "(none|pending_start|resumed)"'
     transitions:
       none: orient_api
       pending_start: claim_rollover
+      resumed: claim_rollover
       ambiguous_or_unrecognized_status: STOP-concurrency-conflict
     kind: mechanical
     blocked_on: null
@@ -122,7 +125,7 @@ steps:
       main is the recurring #4857 incident class and must stop the trail.
     command: git fetch origin && git log --oneline -3 origin/main && gh pr list --state open --limit 20 && git worktree list
     evidence_predicate:
-      command: git fetch origin && git log --oneline -1 origin/main >/dev/null && gh pr list --state open --limit 20 >/dev/null && git worktree list | head -1
+      command: git fetch origin && git log --oneline -1 origin/main >/dev/null && gh pr list --state open --limit 20 >/dev/null && git worktree list
       success_pattern: '\[main\]'
     transitions:
       reconciled: sweep_stale_refs
@@ -132,19 +135,22 @@ steps:
 
   - step_id: sweep_stale_refs
     intent: >-
-      Session-start hygiene: list every worktree and every open PR side by side. A stale
-      candidate is a worktree/branch whose PR is MERGED or CLOSED (merge-base ancestry is
-      NOT valid under squash-merge). Listing is mechanical and proven here; DECIDING and
-      REAPING carry judgment (#M-10: uncommitted work, foreign lanes) and live in
-      reap_stale_refs, which emits per-ref receipts.
-    command: git worktree list --porcelain && gh pr list --state open --limit 30
+      Session-start hygiene: gather every worktree and every open PR head branch side by
+      side; the transition is a pr-ownership table lookup over that JOINED evidence — a
+      dispatch worktree whose branch has no open PR is a stale CANDIDATE (its final
+      MERGED/CLOSED check happens in reap_stale_refs; merge-base ancestry is NOT valid
+      under squash-merge). The predicate proves BOTH listings ran: the && chain gates the
+      gh call on worktree-list success, and the pattern matches only the gh JSON output
+      (a populated headRefName array or the literal empty array).
+    command: git worktree list --porcelain && gh pr list --state open --json headRefName --limit 30
     evidence_predicate:
-      command: git worktree list --porcelain | grep -c '^worktree '
-      success_pattern: '[0-9]'
+      command: git worktree list --porcelain >/dev/null && gh pr list --state open --json headRefName --limit 30
+      success_pattern: 'headRefName|\[\]'
     transitions:
       no_stale_candidates: pick_next
       stale_candidates_present: reap_stale_refs
     kind: table-lookup
+    table: pr-ownership
     blocked_on: null
 
   - step_id: reap_stale_refs
@@ -179,6 +185,7 @@ steps:
       ambiguous_pick: STOP-manual-intervention
       out_of_lane_item: STOP-policy-violation
     kind: table-lookup
+    table: queue-pick
     blocked_on: null
 
   - step_id: route_lane
@@ -202,4 +209,5 @@ steps:
       partial_data_receipt_stated: ready_to_dispatch
       language_lane_restriction_hit: STOP-policy-violation
     kind: table-lookup
+    table: lane-routing
     blocked_on: null

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -1,0 +1,166 @@
+# RB-1 — cold-start / orient / queue-pick (T2 DRAFT, extraction from drive-epic SKILL
+# steps 0/0a/1/2 + the infra driver's cold-start contract). Part of #5885.
+#
+# DRAFT STATUS: authored against today's substrate per the panel's draft-now ruling;
+# certification waits for T1 (slot addressing #5878, closure primitive). Steps that
+# depend on unbuilt machinery carry an explicit blocked_on marker.
+#
+# Anti-pattern guard (the #5860 r1 lessons): every command below is a real, currently
+# runnable repo command; every predicate is falsifiable; no failure path is swallowed —
+# unknown situations exit through a STOP code, never through a happy-path transition.
+schema_version: trailspec.v1
+trail_id: rb1-cold-start
+version: "0.1.0"
+title: RB1 Cold-start, orientation, and queue pick
+seats:
+  - grok-daily
+  - glm-trial
+  - judgment
+stop_codes:
+  - STOP-precondition-failed
+  - STOP-concurrency-conflict
+  - STOP-manual-intervention
+  - STOP-policy-violation
+  - STOP-unknown
+terminal_outcomes:
+  - ready_to_dispatch
+  - idle
+steps:
+  - step_id: detect_rollover
+    intent: >-
+      Detect whether a pending thread-rollover packet exists for this seat's handoff
+      agent. Exactly one validated packet or none are the only proceed states.
+    command: .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent {handoff_agent}
+    evidence_predicate:
+      command: .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent {handoff_agent}
+      success_pattern: '"status"'
+    transitions:
+      none_pending: orient_api
+      one_pending: claim_rollover
+      multiple_or_corrupt: STOP-concurrency-conflict
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: claim_rollover
+    intent: >-
+      Claim the pending packet: bind-replacement (or the native-adapter path), resume,
+      semantic snapshot, strict recall, challenge proof, confirm-started. Judgment-carrying
+      (snapshot content, binding evidence) — the thread-rollover skill owns the procedure.
+      A packet bound to another lane or an ambiguous alias-directory state is a hard stop.
+    command: null
+    evidence_predicate: null
+    transitions:
+      confirmed: orient_api
+      foreign_packet: STOP-policy-violation
+      proofs_failed: STOP-precondition-failed
+    kind: summon
+    blocked_on: null
+
+  - step_id: orient_api
+    intent: >-
+      Orient via the Monitor API: manifest (live context telemetry), active dispatches,
+      and this seat's inbox. API down is not fatal — fall back to files — but the fallback
+      must be said out loud in the session log, never silently absorbed.
+    command: curl -sS --max-time 2 "http://127.0.0.1:8765/api/state/manifest"
+    evidence_predicate:
+      command: curl -sS --max-time 2 "http://127.0.0.1:8765/api/state/manifest"
+      success_pattern: '"_telemetry"'
+    transitions:
+      oriented: drain_inbox
+      api_down_fallback_stated: drain_inbox
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: drain_inbox
+    intent: >-
+      Required live-driver inbox drain (drive-epic 0a). List unconsumed messages for this
+      seat. Slot-identity inboxes (e.g. claude-atlas) require taxonomy step 4b.
+    command: .venv/bin/python -m scripts.ai_agent_bridge inbox --for {handoff_agent}
+    evidence_predicate:
+      command: .venv/bin/python -m scripts.ai_agent_bridge inbox --for {handoff_agent}
+      success_pattern: '"count"'
+    transitions:
+      empty: reconcile_git
+      messages_present: apply_inbox
+    kind: mechanical
+    blocked_on: "T1.1-slot-addressing (#5878) for non-static slot identities"
+
+  - step_id: apply_inbox
+    intent: >-
+      Read and APPLY every unconsumed message, then record live consumption with
+      ack --consumed-by-live-driver (plain ack is not delivery proof). Applying a message
+      can change the queue, the width, or the lane's orders — judgment-carrying.
+    command: null
+    evidence_predicate: null
+    transitions:
+      applied_and_acked: reconcile_git
+      order_conflicts_with_standing_rule: STOP-manual-intervention
+    kind: summon
+    blocked_on: null
+
+  - step_id: reconcile_git
+    intent: >-
+      Reconcile the handoff's claims against reality before firing anything: fetch, compare
+      main, list open PRs and worktrees. A prior session's in-flight item may already be
+      merged — re-firing it is the top re-collision class.
+    command: git fetch origin && git log --oneline -3 origin/main && gh pr list --state open --limit 20 && git worktree list
+    evidence_predicate:
+      command: git fetch origin && git status --short --branch
+      success_pattern: "\\.\\.\\."
+    transitions:
+      reconciled: sweep_stale_refs
+      fetch_failed: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: sweep_stale_refs
+    intent: >-
+      Session-start hygiene sweep. Reap only refs whose PR state is MERGED or whose commits
+      are contained in main (merge-base --is-ancestor is NOT valid under squash-merge).
+      Never touch another lane's live worktrees; never delete uncommitted work.
+    command: git worktree list --porcelain
+    evidence_predicate:
+      command: git worktree list --porcelain
+      success_pattern: "worktree "
+    transitions:
+      clean: pick_next
+      own_merged_refs_reaped: pick_next
+      uncommitted_or_foreign_ambiguity: STOP-manual-intervention
+    kind: table-lookup
+    blocked_on: null
+
+  - step_id: pick_next
+    intent: >-
+      Pick the next unblocked action from the lane queue via the queue-pick decision table
+      (decision-tables.v0.yaml). Deterministic pick = dependencies-merged, lowest open item
+      in the epic's tracking-issue order. Before any issue-fix pick, search existing PRs by
+      issue number — an open issue is not proof of unfixed.
+    command: gh pr list --state all --search "{issue_nr}" --limit 10
+    evidence_predicate:
+      command: gh pr list --state all --limit 1
+      success_pattern: "[0-9]"
+    transitions:
+      picked: route_lane
+      queue_empty: idle
+      ambiguous_pick: STOP-manual-intervention
+      out_of_lane_item: STOP-policy-violation
+    kind: table-lookup
+    blocked_on: null
+
+  - step_id: route_lane
+    intent: >-
+      Route the picked task by model-x-harness fit using the routing decision table, which
+      is a LIVE LOOKUP against /api/rules and codexbar pace/reserve plus disk headroom —
+      the table fixes the procedure, never the roster. No capacity anywhere with quality
+      fit = idle, never a forced misroute.
+    command: codexbar usage --json --provider claude
+    evidence_predicate:
+      command: df -h / && codexbar usage --json --provider claude
+      success_pattern: "provider"
+    transitions:
+      routed: ready_to_dispatch
+      no_fitting_capacity: idle
+      routing_data_unavailable_partial_stated: ready_to_dispatch
+      language_lane_restriction_hit: STOP-policy-violation
+    kind: table-lookup
+    blocked_on: null

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -225,6 +225,34 @@ def validate_decision_tables(
     )
 
 
+def validate_trail_table_refs(
+    spec_data: dict[str, Any],
+    tables_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Cross-document check: every table reference a trail step declares must resolve
+    to a table in the decision-tables document. A misspelled or unbound reference is a
+    validation failure, not a silent no-op."""
+    known_tables = set(tables_data.get("tables", {}).keys())
+    bound: dict[str, str] = {}
+    for step in spec_data.get("steps", []):
+        step_id = step.get("step_id", "<unknown>")
+        table_ref = step.get("table")
+        if table_ref is None:
+            continue
+        if table_ref not in known_tables:
+            raise TrailSpecValidationError(
+                f"Unbound table reference: step '{step_id}' names table '{table_ref}' "
+                f"which does not exist in the decision-tables document "
+                f"(known: {sorted(known_tables)})"
+            )
+        bound[step_id] = table_ref
+    return {
+        "ok": True,
+        "trail_id": spec_data.get("trail_id"),
+        "bound_steps": bound,
+    }
+
+
 def validate_trailspec(
     *,
     spec_path: Path = DEFAULT_EXAMPLE_TRAIL_PATH,

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -23,6 +23,12 @@ STEP_RECEIPT_SCHEMA_PATH = (
 DEFAULT_EXAMPLE_TRAIL_PATH = (
     PROJECT_ROOT / "scripts/config/trails/rb3-pr-lifecycle.trail.yaml"
 )
+DECISION_TABLES_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/decision-tables.v0.schema.json"
+)
+DEFAULT_DECISION_TABLES_PATH = (
+    PROJECT_ROOT / "scripts/config/trails/decision-tables.v0.yaml"
+)
 
 # Published STOP code contract (embedded constant; pending extraction to contract package)
 VALID_STOP_CODES: set[str] = {
@@ -172,6 +178,53 @@ def validate_trailspec_data(
     }
 
 
+def validate_decision_tables_data(
+    tables_data: dict[str, Any],
+    *,
+    tables_schema_path: Path = DECISION_TABLES_SCHEMA_PATH,
+) -> dict[str, Any]:
+    """Validate a decision-tables document against schema and domain invariants."""
+    tables_schema = _load_schema(tables_schema_path)
+    validator = Draft202012Validator(tables_schema, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(tables_data), key=lambda e: e.path)
+    if errors:
+        err = errors[0]
+        raise TrailSpecValidationError(
+            f"DecisionTables schema violation: {err.message} at {err.json_path}"
+        )
+
+    # Invariant: any row action naming a STOP code must use the published contract list.
+    for table_name, table in tables_data.get("tables", {}).items():
+        for idx, row in enumerate(table.get("rows", []) or []):
+            then = row.get("then", "")
+            if then.startswith("STOP-") and then not in VALID_STOP_CODES:
+                raise TrailSpecValidationError(
+                    f"DecisionTables invariant violated: table '{table_name}' row {idx} "
+                    f"names unknown stop code '{then}' (must be from the published contract list)"
+                )
+
+    tables = tables_data.get("tables", {})
+    return {
+        "ok": True,
+        "schema_version": tables_data.get("schema_version"),
+        "precedence": tables_data.get("precedence"),
+        "tables": sorted(tables.keys()),
+        "tables_count": len(tables),
+    }
+
+
+def validate_decision_tables(
+    tables_path: Path = DEFAULT_DECISION_TABLES_PATH,
+    *,
+    tables_schema_path: Path = DECISION_TABLES_SCHEMA_PATH,
+) -> dict[str, Any]:
+    """Validate a decision-tables YAML/JSON file."""
+    tables_data = _load_yaml_or_json(tables_path)
+    return validate_decision_tables_data(
+        tables_data, tables_schema_path=tables_schema_path
+    )
+
+
 def validate_trailspec(
     *,
     spec_path: Path = DEFAULT_EXAMPLE_TRAIL_PATH,
@@ -216,6 +269,12 @@ def main(argv: list[str] | None = None) -> int:
         help="optional path to StepReceipt JSON/YAML file",
     )
     parser.add_argument(
+        "--tables",
+        type=Path,
+        default=None,
+        help="optional path to a decision-tables YAML/JSON file to validate",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="output machine-readable JSON",
@@ -227,6 +286,10 @@ def main(argv: list[str] | None = None) -> int:
             spec_path=args.spec.resolve(),
             receipt_path=args.receipt.resolve() if args.receipt else None,
         )
+        if args.tables is not None:
+            summary["decision_tables"] = validate_decision_tables(
+                args.tables.resolve()
+            )
     except TrailSpecValidationError as exc:
         if args.json:
             print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True))

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -315,8 +315,14 @@ def main(argv: list[str] | None = None) -> int:
             receipt_path=args.receipt.resolve() if args.receipt else None,
         )
         if args.tables is not None:
-            summary["decision_tables"] = validate_decision_tables(
-                args.tables.resolve()
+            tables_path = args.tables.resolve()
+            summary["decision_tables"] = validate_decision_tables(tables_path)
+            # Cross-document check: declared table references must resolve. Without
+            # this, the CLI would report success on a misspelled/unbound reference
+            # even though both documents validate independently.
+            summary["table_refs"] = validate_trail_table_refs(
+                _load_yaml_or_json(args.spec.resolve()),
+                _load_yaml_or_json(tables_path),
             )
     except TrailSpecValidationError as exc:
         if args.json:

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -9,11 +9,14 @@ import pytest
 import yaml
 
 from scripts.orchestration.validate_trailspec import (
+    DEFAULT_DECISION_TABLES_PATH,
     DEFAULT_EXAMPLE_TRAIL_PATH,
     STEP_RECEIPT_SCHEMA_PATH,
     TRAIL_SPEC_SCHEMA_PATH,
     TrailSpecValidationError,
     compute_trail_hash,
+    validate_decision_tables,
+    validate_decision_tables_data,
     validate_step_receipt_data,
     validate_trailspec,
     validate_trailspec_data,
@@ -27,10 +30,26 @@ def _get_happy_example_data() -> dict[str, Any]:
 _TRAILS_DIR = DEFAULT_EXAMPLE_TRAIL_PATH.parent
 _ALL_SHIPPED_TRAILS = sorted(_TRAILS_DIR.glob("*.trail.yaml"))
 
+# Every draft the T2 initiative has shipped so far, by trail_id. A deleted or renamed
+# draft must FAIL this list, not silently shrink the glob (review finding on #5886:
+# the glob-only guard passed as long as ANY trail remained).
+REQUIRED_TRAIL_IDS = {
+    "rb1-cold-start",
+    "rb3-pr-lifecycle",
+}
+
 
 def test_trails_dir_is_not_empty() -> None:
     """Guard the glob itself: an empty parametrization must fail, not silently pass."""
     assert _ALL_SHIPPED_TRAILS, f"no *.trail.yaml found under {_TRAILS_DIR}"
+
+
+def test_required_trail_drafts_present() -> None:
+    """Every registered draft must exist on disk — a missing draft is a failure even
+    while other trails keep the glob non-empty."""
+    found_ids = {p.name.removesuffix(".trail.yaml") for p in _ALL_SHIPPED_TRAILS}
+    missing = REQUIRED_TRAIL_IDS - found_ids
+    assert not missing, f"required trail drafts missing from {_TRAILS_DIR}: {sorted(missing)}"
 
 
 @pytest.mark.parametrize("trail_path", _ALL_SHIPPED_TRAILS, ids=lambda p: p.stem)
@@ -174,6 +193,60 @@ def test_negative_step_receipt_schema_violation() -> None:
         )
 
     assert "StepReceipt schema violation" in str(exc_info.value)
+
+
+def _get_happy_tables_data() -> dict[str, Any]:
+    return yaml.safe_load(DEFAULT_DECISION_TABLES_PATH.read_text(encoding="utf-8"))
+
+
+def test_decision_tables_file_validates() -> None:
+    """The shipped decision-tables draft must pass its schema (review finding on #5886:
+    the v0 file declared itself unvalidated and sat outside all coverage)."""
+    res = validate_decision_tables()
+    assert res["ok"] is True
+    assert res["precedence"] == "first-match"
+    for expected in ("queue-pick", "review-gate-arm", "settle-status", "width"):
+        assert expected in res["tables"], f"table '{expected}' missing from the draft"
+
+
+def test_negative_decision_tables_bad_mode() -> None:
+    """Mutation check: an unknown table mode must fail schema validation."""
+    data = _get_happy_tables_data()
+    data["tables"]["queue-pick"]["mode"] = "vibes"
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_decision_tables_data(data)
+    assert "DecisionTables schema violation" in str(exc_info.value)
+
+    restored = _get_happy_tables_data()
+    assert validate_decision_tables_data(restored)["ok"] is True
+
+
+def test_negative_decision_tables_static_requires_rows() -> None:
+    """Mutation check: a static table with its rows deleted must fail."""
+    data = _get_happy_tables_data()
+    del data["tables"]["queue-pick"]["rows"]
+    with pytest.raises(TrailSpecValidationError):
+        validate_decision_tables_data(data)
+
+
+def test_negative_decision_tables_missing_precedence() -> None:
+    """Mutation check: dropping the first-match precedence contract must fail —
+    without it the row-ordering conflicts the #5886 review found come back."""
+    data = _get_happy_tables_data()
+    del data["precedence"]
+    with pytest.raises(TrailSpecValidationError):
+        validate_decision_tables_data(data)
+
+
+def test_negative_decision_tables_unknown_stop_code() -> None:
+    """Mutation check: a row action naming an unpublished STOP code must fail."""
+    data = _get_happy_tables_data()
+    data["tables"]["queue-pick"]["rows"].append(
+        {"when": "impossible synthetic condition", "then": "STOP-made-up-code"}
+    )
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_decision_tables_data(data)
+    assert "STOP-made-up-code" in str(exc_info.value)
 
 
 def test_hash_stability() -> None:

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -294,6 +294,29 @@ def test_negative_unbound_table_ref() -> None:
     assert validate_trail_table_refs(restored, tables)["ok"] is True
 
 
+def test_cli_tables_flag_runs_cross_check(tmp_path, capsys) -> None:
+    """r3 review finding: the CLI --tables path must run the cross-document check, not
+    just the two independent validators — an unbound reference must fail the COMMAND."""
+    from scripts.orchestration.validate_trailspec import main
+
+    spec = _get_rb1_data()
+    for step in spec["steps"]:
+        if step.get("table"):
+            step["table"] = "queue-pikc"  # misspelled
+            break
+    bad_spec = tmp_path / "rb1-bad-ref.trail.yaml"
+    bad_spec.write_text(yaml.dump(spec), encoding="utf-8")
+
+    rc = main(["--spec", str(bad_spec), "--tables", str(DEFAULT_DECISION_TABLES_PATH), "--json"])
+    assert rc == 1
+    assert "queue-pikc" in capsys.readouterr().out
+
+    rc_ok = main(["--spec", str(_RB1_PATH), "--tables", str(DEFAULT_DECISION_TABLES_PATH), "--json"])
+    assert rc_ok == 0
+    out_ok = capsys.readouterr().out
+    assert '"table_refs"' in out_ok
+
+
 def test_hash_stability() -> None:
     """Test TrailSpec content hash calculation and stability across YAML formatting changes."""
     data_orig = _get_happy_example_data()

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -24,6 +24,25 @@ def _get_happy_example_data() -> dict[str, Any]:
     return yaml.safe_load(DEFAULT_EXAMPLE_TRAIL_PATH.read_text(encoding="utf-8"))
 
 
+_TRAILS_DIR = DEFAULT_EXAMPLE_TRAIL_PATH.parent
+_ALL_SHIPPED_TRAILS = sorted(_TRAILS_DIR.glob("*.trail.yaml"))
+
+
+def test_trails_dir_is_not_empty() -> None:
+    """Guard the glob itself: an empty parametrization must fail, not silently pass."""
+    assert _ALL_SHIPPED_TRAILS, f"no *.trail.yaml found under {_TRAILS_DIR}"
+
+
+@pytest.mark.parametrize("trail_path", _ALL_SHIPPED_TRAILS, ids=lambda p: p.stem)
+def test_every_shipped_trail_validates(trail_path) -> None:
+    """Every trail shipped in scripts/config/trails/ must pass the validator,
+    so a future draft cannot land unvalidated by editing only the yaml."""
+    res = validate_trailspec(spec_path=trail_path)
+    assert res["ok"] is True
+    assert res["spec"]["trail_id"] == trail_path.name.removesuffix(".trail.yaml")
+    assert res["spec"]["trail_hash"]
+
+
 def _get_happy_step_receipt_data() -> dict[str, Any]:
     return {
         "schema_version": "step-receipt.v1",

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -18,6 +18,7 @@ from scripts.orchestration.validate_trailspec import (
     validate_decision_tables,
     validate_decision_tables_data,
     validate_step_receipt_data,
+    validate_trail_table_refs,
     validate_trailspec,
     validate_trailspec_data,
 )
@@ -247,6 +248,50 @@ def test_negative_decision_tables_unknown_stop_code() -> None:
     with pytest.raises(TrailSpecValidationError) as exc_info:
         validate_decision_tables_data(data)
     assert "STOP-made-up-code" in str(exc_info.value)
+
+
+_RB1_PATH = _TRAILS_DIR / "rb1-cold-start.trail.yaml"
+
+
+def _get_rb1_data() -> dict[str, Any]:
+    return yaml.safe_load(_RB1_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("trail_path", _ALL_SHIPPED_TRAILS, ids=lambda p: p.stem)
+def test_declared_table_refs_resolve(trail_path) -> None:
+    """Every table a shipped trail declares must exist in the decision-tables draft
+    (r2 review finding on #5886: table references were unbound and unvalidatable)."""
+    spec = yaml.safe_load(trail_path.read_text(encoding="utf-8"))
+    tables = _get_happy_tables_data()
+    res = validate_trail_table_refs(spec, tables)
+    assert res["ok"] is True
+
+
+def test_rb1_table_lookup_steps_bind_tables() -> None:
+    """RB1's table-lookup steps must each name their table (RB3 predates the tables
+    draft — its retrofit is a T2-certification item on #5885, not enforced here)."""
+    spec = _get_rb1_data()
+    tables = _get_happy_tables_data()
+    res = validate_trail_table_refs(spec, tables)
+    lookup_steps = [s["step_id"] for s in spec["steps"] if s.get("kind") == "table-lookup"]
+    unbound = [s for s in lookup_steps if s not in res["bound_steps"]]
+    assert not unbound, f"RB1 table-lookup steps without a table binding: {unbound}"
+
+
+def test_negative_unbound_table_ref() -> None:
+    """Mutation check: a misspelled table reference must fail the cross-document check."""
+    spec = _get_rb1_data()
+    tables = _get_happy_tables_data()
+    for step in spec["steps"]:
+        if step.get("table"):
+            step["table"] = "queue-pikc"  # misspelled
+            break
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trail_table_refs(spec, tables)
+    assert "queue-pikc" in str(exc_info.value)
+
+    restored = _get_rb1_data()
+    assert validate_trail_table_refs(restored, tables)["ok"] is True
 
 
 def test_hash_stability() -> None:


### PR DESCRIPTION
## Summary
- **RB-1 cold-start trail** (`scripts/config/trails/rb1-cold-start.trail.yaml`): the cold-start → orient → inbox-drain → git-reconcile → queue-pick → route loop as a TrailSpec v1 state machine. Every command real and currently runnable; every mechanical step carries a falsifiable evidence predicate; unknown situations exit through STOP codes, never a happy path. `blocked_on` markers where machinery is unbuilt (slot inboxes → #5878).
- **Decision tables v0** (`decision-tables.v0.yaml`): the design's nine judgment seams. Six fully specified (queue-pick, review-gate 4-signal arm, red-CI triage, settle-status vocabulary, summon-vs-park, PR-ownership-by-stream-epic, handoff-completeness); routing + width are `live-lookup` procedures pointing at /api/rules + codexbar + disk — the trail fixes the method, never the roster.
- **Glob test**: every `*.trail.yaml` shipped under `scripts/config/trails/` is validator-checked in CI, so future drafts cannot land unvalidated. Mutation-checked both ways (corrupted trail fails; empty glob fails via a guard test).

## Verification
- `validate_trailspec.py --spec rb1-cold-start.trail.yaml` → valid, 9 steps, content hash minted.
- `pytest tests/test_validate_trailspec.py` → 11 passed; ruff clean.
- Draft status per the panel ruling: certification happens post-T1 (fault injection + adversarial plants are T4).

Part of #5885

🤖 Generated with [Claude Code](https://claude.com/claude-code)