### PR TITLE
fix(review): exec-root sentinel must fullmatch the marker contract

### DIFF
--- a/scripts/review/isolation.py
+++ b/scripts/review/isolation.py
@@ -913,9 +913,26 @@ def _validate_private_exec_root(
     for entry in root.iterdir():
         if entry.name != REVIEW_TEMP_ROOT_MARKER_NAME:
             raise ReviewIsolationError("review_exec_root_not_empty")
-        entry_st = entry.lstat()
-        if stat.S_ISLNK(entry_st.st_mode) or not stat.S_ISREG(entry_st.st_mode):
-            raise ReviewIsolationError("review_exec_root_marker_not_regular")
+        # Mirror _has_review_temp_root_marker's semantics exactly (#5849): the
+        # sentinel must be a sole regular file (st_nlink == 1) whose bytes fullmatch
+        # the marker pattern — a hardlinked or forged marker must not pass validation
+        # here only to fail cleanup later. fd-based like the reference check so the
+        # verdict comes from fstat on the opened fd, not a racy lstat-then-open.
+        try:
+            marker_fd = os.open(entry, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError as exc:
+            # O_NOFOLLOW turns a symlinked marker into an open error — same
+            # refusal class as the old lstat symlink check.
+            raise ReviewIsolationError("review_exec_root_marker_not_regular") from exc
+        try:
+            marker_stat = os.fstat(marker_fd)
+            if not stat.S_ISREG(marker_stat.st_mode) or marker_stat.st_nlink != 1:
+                raise ReviewIsolationError("review_exec_root_marker_not_regular")
+            marker = os.read(marker_fd, _REVIEW_TEMP_ROOT_MARKER_MAX_BYTES + 1)
+        finally:
+            os.close(marker_fd)
+        if not _REVIEW_TEMP_ROOT_MARKER_RE.fullmatch(marker):
+            raise ReviewIsolationError("review_exec_root_marker_invalid")
     return root
 
 

--- a/tests/test_review_isolation.py
+++ b/tests/test_review_isolation.py
@@ -3661,3 +3661,35 @@ class TestExecRootAcceptsSentinel:
         (root / isolation.REVIEW_TEMP_ROOT_MARKER_NAME).symlink_to(outside)
         with pytest.raises(isolation.ReviewIsolationError, match="marker_not_regular"):
             self._validate(root, tmp_path)
+
+    def test_hardlinked_marker_refuses(self, tmp_path):
+        """#5849: a hardlinked sentinel (st_nlink != 1) must refuse even when its
+        content is byte-valid — mirrors _has_review_temp_root_marker."""
+        import os
+
+        import pytest
+
+        from scripts.review import isolation
+
+        root = tmp_path / "exec"
+        root.mkdir(mode=0o700)
+        marker = root / isolation.REVIEW_TEMP_ROOT_MARKER_NAME
+        marker.write_bytes(b"lu-review-root-v1:" + b"ab" * 32 + b"\n")
+        os.link(marker, tmp_path / "marker-hardlink")
+        with pytest.raises(isolation.ReviewIsolationError, match="marker_not_regular"):
+            self._validate(root, tmp_path)
+
+    def test_wrong_content_marker_refuses(self, tmp_path):
+        """#5849: a regular-file sentinel whose bytes do not fullmatch the marker
+        pattern is a forgery — refuse with the content-specific error."""
+        import pytest
+
+        from scripts.review import isolation
+
+        root = tmp_path / "exec"
+        root.mkdir(mode=0o700)
+        (root / isolation.REVIEW_TEMP_ROOT_MARKER_NAME).write_bytes(
+            b"not-a-review-root-marker\n"
+        )
+        with pytest.raises(isolation.ReviewIsolationError, match="marker_invalid"):
+            self._validate(root, tmp_path)


### PR DESCRIPTION
`_validate_private_exec_root` now mirrors `_has_review_temp_root_marker`'s semantics exactly: the sentinel must be a sole regular file (`st_nlink == 1`) whose bytes fullmatch the marker pattern — a hardlinked or forged marker can no longer pass validation and then fail cleanup. fd-based (`O_NOFOLLOW` + `fstat`) like the reference check, so there is no lstat-then-open race.

Provenance: diff authored by grok-4.5 via the opencode certification probe (bridge msg 5427); applied and TOCTOU-hardened to the module's fd idiom by claude-infra.

Verification: two refusal tests (hardlinked marker with byte-valid content; forged content) — mutation-checked by reverting only the module: exactly those two fail, restored → 5/5 class, 103/103 full isolation suite, ruff clean.

Closes #5849

🤖 Generated with [Claude Code](https://claude.com/claude-code)