### PR TITLE
fix(trails): require table binding on table-lookup steps (post-#5886 CF F001)

### DIFF
--- a/agents_extensions/shared/schemas/trailspec.v1.schema.json
+++ b/agents_extensions/shared/schemas/trailspec.v1.schema.json
@@ -124,6 +124,23 @@
                 }
               }
             }
+          },
+          {
+            "if": {
+              "properties": {
+                "kind": {
+                  "const": "table-lookup"
+                }
+              }
+            },
+            "then": {
+              "required": ["table"],
+              "properties": {
+                "table": {
+                  "type": "string"
+                }
+              }
+            }
           }
         ]
       },

--- a/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
+++ b/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
@@ -73,6 +73,7 @@ steps:
       ci_red: red_ci_triage
       disarmed: rearm_automerge
     kind: table-lookup
+    table: review-gate-arm
     blocked_on: null
 
   - step_id: rearm_automerge

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -229,14 +229,21 @@ def validate_trail_table_refs(
     spec_data: dict[str, Any],
     tables_data: dict[str, Any],
 ) -> dict[str, Any]:
-    """Cross-document check: every table reference a trail step declares must resolve
-    to a table in the decision-tables document. A misspelled or unbound reference is a
-    validation failure, not a silent no-op."""
+    """Cross-document check: table-lookup steps must bind a resolvable decision table.
+
+    A missing, misspelled, or unbound reference is a validation failure, not a
+    silent no-op. This also fails closed for callers that bypass JSON Schema.
+    """
     known_tables = set(tables_data.get("tables", {}).keys())
     bound: dict[str, str] = {}
     for step in spec_data.get("steps", []):
         step_id = step.get("step_id", "<unknown>")
         table_ref = step.get("table")
+        if step.get("kind") == "table-lookup" and table_ref is None:
+            raise TrailSpecValidationError(
+                f"Missing table binding: table-lookup step '{step_id}' requires a non-null "
+                "table field"
+            )
         if table_ref is None:
             continue
         if table_ref not in known_tables:

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -239,10 +239,12 @@ def validate_trail_table_refs(
     for step in spec_data.get("steps", []):
         step_id = step.get("step_id", "<unknown>")
         table_ref = step.get("table")
-        if step.get("kind") == "table-lookup" and table_ref is None:
+        if step.get("kind") == "table-lookup" and (
+            not isinstance(table_ref, str) or not table_ref
+        ):
             raise TrailSpecValidationError(
-                f"Missing table binding: table-lookup step '{step_id}' requires a non-null "
-                "table field"
+                f"Missing table binding: table-lookup step '{step_id}' requires a non-empty "
+                "string table field"
             )
         if table_ref is None:
             continue

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -305,6 +305,23 @@ def test_negative_table_lookup_without_table_fails_cross_check() -> None:
     assert lookup_step["step_id"] in str(exc_info.value)
 
 
+@pytest.mark.parametrize("table_ref", [[], {}], ids=["list", "mapping"])
+def test_negative_table_lookup_non_string_table_fails_cross_check(
+    table_ref: object,
+) -> None:
+    """The cross-check must reject non-string table bindings before membership tests."""
+    spec = _get_rb1_data()
+    tables = _get_happy_tables_data()
+    lookup_step = next(step for step in spec["steps"] if step["kind"] == "table-lookup")
+    lookup_step["table"] = table_ref
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trail_table_refs(spec, tables)
+
+    assert "Missing table binding" in str(exc_info.value)
+    assert lookup_step["step_id"] in str(exc_info.value)
+
+
 def test_negative_unbound_table_ref() -> None:
     """Mutation check: a misspelled table reference must fail the cross-document check."""
     spec = _get_rb1_data()

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -278,6 +278,33 @@ def test_rb1_table_lookup_steps_bind_tables() -> None:
     assert not unbound, f"RB1 table-lookup steps without a table binding: {unbound}"
 
 
+def test_negative_table_lookup_without_table_fails_schema() -> None:
+    """A table-lookup step must name a non-null table in the TrailSpec schema."""
+    spec = _get_rb1_data()
+    lookup_step = next(step for step in spec["steps"] if step["kind"] == "table-lookup")
+    del lookup_step["table"]
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(spec)
+
+    assert "TrailSpec schema violation" in str(exc_info.value)
+    assert "table" in str(exc_info.value)
+
+
+def test_negative_table_lookup_without_table_fails_cross_check() -> None:
+    """The table cross-check fails closed even when its caller bypasses schema validation."""
+    spec = _get_rb1_data()
+    tables = _get_happy_tables_data()
+    lookup_step = next(step for step in spec["steps"] if step["kind"] == "table-lookup")
+    lookup_step["table"] = None
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trail_table_refs(spec, tables)
+
+    assert "Missing table binding" in str(exc_info.value)
+    assert lookup_step["step_id"] in str(exc_info.value)
+
+
 def test_negative_unbound_table_ref() -> None:
     """Mutation check: a misspelled table reference must fail the cross-document check."""
     spec = _get_rb1_data()


### PR DESCRIPTION
## Summary
Follow-up to merged #5886 after formal codex CF returned **CHANGES_REQUESTED** (F001): `kind: table-lookup` steps must bind a non-null `table`, and the cross-document validator must fail closed when the binding is absent.

## Changes
- Schema conditional: table-lookup requires `table`
- `validate_trail_table_refs` fails closed without binding
- RB3 `babysit_merge` binds `review-gate-arm`
- Regression tests (schema + schema-bypass)

## Verification
- `pytest tests/test_validate_trailspec.py` → 24 passed
- ruff clean

## Notes
- Auto-merge landed #5886 before sealed formal CF finished; this PR is the F001 fix of record.
- Do not arm auto-merge until formal CF re-review APPROVED.

Related: #5886, epic #4387