### PR TITLE
fix(bridge): expose failed background asks

### DIFF
--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
+from urllib.parse import quote
 
 from ..result import ParseResult
 from .base import InvocationPlan
@@ -72,6 +73,17 @@ _MCP_REVIEW_DENY_RULES: tuple[str, ...] = (
 GROK_ALLOWED_MODELS: frozenset[str] = frozenset({"grok-4.5"})
 GROK_BUILD_DEFAULT_MODEL = "grok-4.5"
 GROK_BUILD_DEFAULT_EFFORT = os.environ.get("LEARN_UK_GROK_BUILD_EFFORT", "high")
+
+
+def grok_session_dir(grok_home: Path, cwd: Path, session_id: str) -> Path:
+    """Return Grok's session directory for ``cwd`` and ``session_id``.
+
+    Native Grok keys sessions by the symlink-resolved working directory.  This
+    matters on macOS, where ``/tmp`` normally resolves below ``/private``.
+    Keep this in the adapter so bridge callers and trace validators use the
+    identical, documented lookup rule.
+    """
+    return grok_home / "sessions" / quote(str(cwd.resolve()), safe="") / session_id
 
 
 class GrokBuildAdapter:

--- a/scripts/ai_agent_bridge/_ask_lifecycle.py
+++ b/scripts/ai_agent_bridge/_ask_lifecycle.py
@@ -9,12 +9,16 @@ fail open so the legacy bridge never breaks on the opt-in path.
 
 from __future__ import annotations
 
+import atexit
+import contextlib
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +34,124 @@ _ASK_AGENT = "ask"
 _FLEET_REQUEST_ID_KEY = "fleet_request_id"
 # Tests may point plane storage at a tmp root without touching batch_state/.
 _PLANE_ROOT_OVERRIDE: Path | None = None
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _ask_state_root() -> Path:
+    return REPO_ROOT / "batch_state" / "asks"
+
+
+def _ask_task_key(message_id: int) -> str:
+    row = _load_ask_row(message_id)
+    task_id = str(row[0]) if row and row[0] else f"message-{message_id}"
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", task_id)[:80] or f"message-{message_id}"
+
+
+def _ask_state_dir(message_id: int) -> Path:
+    return _ask_state_root() / _ask_task_key(message_id)
+
+
+def _ask_log_path(message_id: int) -> Path:
+    return REPO_ROOT / ".mcp" / "servers" / "message-broker" / "logs" / f"ask-{message_id}.log"
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Durably replace a small lifecycle record without a partially-written file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    fd = os.open(str(temporary), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            temporary.unlink()
+
+
+def _stderr_tail(message_id: int) -> str:
+    try:
+        return _ask_log_path(message_id).read_bytes()[-2048:].decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _write_ask_launch_record(message_id: int, *, pid: int, target: str) -> None:
+    row = _load_ask_row(message_id)
+    metadata: dict[str, Any] = {}
+    if row and row[4]:
+        try:
+            decoded = json.loads(str(row[4]))
+            if isinstance(decoded, dict):
+                metadata = decoded
+        except (TypeError, json.JSONDecodeError):
+            pass
+    _atomic_write_json(
+        _ask_state_dir(message_id) / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": pid,
+            "agent": target,
+            "harness": target,
+            "model": metadata.get("to_model"),
+            "started_at": _now_iso(),
+        },
+    )
+
+
+def _read_ask_record(message_id: int, name: str) -> dict[str, Any] | None:
+    try:
+        value = json.loads((_ask_state_dir(message_id) / name).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _pid_is_alive(pid: object) -> bool:
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+class _AskTerminalRecorder:
+    """Single-write terminal artifact for a detached ask worker."""
+
+    def __init__(self, message_id: int):
+        self.message_id = message_id
+        self.written = False
+
+    def write(self, rc_or_signal: int | str, stage: str) -> None:
+        if self.written:
+            return
+        _atomic_write_json(
+            _ask_state_dir(self.message_id) / "terminal.json",
+            {
+                "rc_or_signal": rc_or_signal,
+                "stage": stage,
+                "stderr_tail": _stderr_tail(self.message_id),
+                "ended_at": _now_iso(),
+            },
+        )
+        self.written = True
+
+    def atexit(self) -> None:
+        self.write("unknown", "atexit")
+
+    def signal_handler(self, signum: int, _frame: Any) -> None:
+        self.write(signal.Signals(signum).name, "signal")
+        raise SystemExit(128 + signum)
 
 
 class AskWorkerStartupError(RuntimeError):
@@ -272,6 +394,7 @@ def launch_background_ask(message_id: int, target: str, options: dict[str, Any])
         {"message_id": message_id, "target": target, "options": options},
         pid=proc.pid,
     )
+    _write_ask_launch_record(message_id, pid=proc.pid, target=target)
 
     # A worker can die BEFORE `process_background_ask` runs — a bad adapter path, an
     # import error, a missing binary — in which case its `finally:` never executes and
@@ -362,6 +485,7 @@ def _confirm_worker_started(message_id: int, target: str, proc, log_file: Path) 
             tail = ""
         detail = tail or f"worker exited rc={rc} without writing any output"
         record_ask_failure(message_id, f"{target} worker died at startup: {detail}")
+        _AskTerminalRecorder(message_id).write(rc if rc is not None else 1, "startup")
         _remove_pid_file(_ASK_AGENT, str(message_id))
         print(
             f"❌ Ask #{message_id}: the {target} worker DIED AT STARTUP (rc={rc}) without "
@@ -391,22 +515,45 @@ def _stored_reply_is_useful(reply_id: int) -> bool:
 
 def process_background_ask(message_id: int, target: str) -> None:
     """Run one detached ask worker and leave a terminal lifecycle status."""
-    options = _background_options(message_id, target)
-    mark_ask_processing(message_id)
+    terminal = _AskTerminalRecorder(message_id)
+    atexit.register(terminal.atexit)
+    previous_handlers: dict[int, Any] = {}
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        previous_handlers[signum] = signal.getsignal(signum)
+        signal.signal(signum, terminal.signal_handler)
+    rc_or_signal: int | str = 1
+    stage = "startup"
     try:
+        options = _background_options(message_id, target)
+        mark_ask_processing(message_id)
+        stage = "processing"
         _process_target(message_id, target, options)
+        status = _ask_status(message_id)
+        if status and status.startswith("replied:"):
+            rc_or_signal = 0
+            stage = "success"
+        else:
+            stage = "missing-reply" if status in {"sent", "processing", "pending", None} else "failed"
     except (AgentStalledError, AgentTimeoutError, subprocess.TimeoutExpired, TimeoutError) as exc:
         record_ask_failure(message_id, str(exc), timed_out=True)
+        stage = "timeout"
     except SystemExit as exc:
         detail = str(exc)
         record_ask_failure(message_id, detail, timed_out=_looks_like_timeout(detail))
+        stage = "system-exit"
+        rc_or_signal = exc.code if isinstance(exc.code, int) else "SystemExit"
     except Exception as exc:  # pragma: no cover - defensive detached-worker boundary
         record_ask_failure(message_id, f"{type(exc).__name__}: {exc}")
+        stage = "exception"
     finally:
         status = _ask_status(message_id)
         if status in {"sent", "processing", "pending", None}:
             record_ask_failure(message_id, "worker ended without a reply")
+            stage = "missing-reply"
+        terminal.write(rc_or_signal, stage)
         _remove_pid_file(_ASK_AGENT, str(message_id))
+        for signum, previous in previous_handlers.items():
+            signal.signal(signum, previous)
 
 
 def print_asks(task_id: str | None = None) -> None:
@@ -439,7 +586,7 @@ def print_asks(task_id: str | None = None) -> None:
 
     print("ID  TASK  TO  STATUS  CONSUMPTION  SENT")
     for row in rows:
-        status = _display_status(str(row[3] or "sent"))
+        status = _ask_display_status(int(row[0]), str(row[3] or "sent"))
         consumption = _message_consumption_state(row[5], row[6])
         print(f"{row[0]}  {row[1] or '-'}  {row[2]}  {status}  {consumption}  {row[4]}")
 
@@ -623,6 +770,36 @@ def _display_status(status: str) -> str:
     if status.startswith("failed:"):
         return "failed"
     return status
+
+
+def _ask_display_status(message_id: int, status: str) -> str:
+    """Render durable worker-death evidence before the legacy status string."""
+    terminal = _read_ask_record(message_id, "terminal.json")
+    if terminal is not None:
+        rc_or_signal = terminal.get("rc_or_signal")
+        stage = str(terminal.get("stage") or "unknown")
+        failed = rc_or_signal not in {0, "0"} or stage in {
+            "atexit",
+            "exception",
+            "failed",
+            "missing-reply",
+            "signal",
+            "startup",
+            "system-exit",
+            "timeout",
+        }
+        if failed:
+            return f"FAILED ({stage}; retry recommended)"
+
+    launch = _read_ask_record(message_id, "launch.json")
+    if (
+        launch is not None
+        and terminal is None
+        and not status.startswith("replied:")
+        and not _pid_is_alive(launch.get("pid"))
+    ):
+        return "DIED-SILENT (retry recommended)"
+    return _display_status(status)
 
 
 def _message_consumption_state(acknowledged: int, consumed_by_live_driver: int) -> str:

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
+from typing import Any
 
 from agent_runtime import runner as agent_runner
 from agent_runtime.adapters.grok_build import (
     GROK_BUILD_DEFAULT_EFFORT,
     GROK_BUILD_DEFAULT_MODEL,
+    grok_session_dir,
 )
 from agent_runtime.errors import (
     AgentStalledError,
@@ -233,6 +236,21 @@ def process_for_grok_build(
         _handle_grok_build_error(msg, message_id, "Grok Build returned no final message")
         return
 
+    turn_status = _native_grok_turn_status(
+        session_id=getattr(result, "session_id", None),
+        cwd=checkout.path if checkout is not None else REPO_ROOT,
+    )
+    if turn_status["outcome"] != "completed":
+        _handle_grok_build_incomplete_turn(
+            msg,
+            message_id,
+            response,
+            turn_status,
+            actual_model=getattr(result, "model", None) or model,
+            effort=effort or GROK_BUILD_DEFAULT_EFFORT,
+        )
+        return
+
     print(f"\nGrok finished ({len(response)} chars)")
     provenance_data, actual_model = response_provenance(
         msg,
@@ -251,6 +269,78 @@ def process_for_grok_build(
     )
     acknowledge(message_id)
     record_ask_reply(message_id, reply_id)
+
+
+def _native_grok_turn_status(*, session_id: str | None, cwd: Path) -> dict[str, str | None]:
+    """Read Grok's authoritative last terminal event, failing closed on traces."""
+    if not session_id:
+        return {"outcome": "trace_unavailable", "cancellation_category": None}
+    grok_home = Path(os.environ.get("GROK_HOME", str(Path.home() / ".grok")))
+    events_path = grok_session_dir(grok_home, cwd, session_id) / "events.jsonl"
+    try:
+        events = []
+        for line in events_path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                event = json.loads(line)
+                if not isinstance(event, dict):
+                    raise ValueError("non-object event")
+                events.append(event)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return {"outcome": "trace_unavailable", "cancellation_category": None}
+    terminal_events = [event for event in events if event.get("type") == "turn_ended"]
+    if not terminal_events:
+        return {"outcome": "trace_unavailable", "cancellation_category": None}
+    terminal = terminal_events[-1]
+    outcome = terminal.get("outcome")
+    if not isinstance(outcome, str) or not outcome:
+        return {"outcome": "trace_unavailable", "cancellation_category": None}
+    category = terminal.get("cancellation_category")
+    return {
+        "outcome": outcome,
+        "cancellation_category": str(category) if category is not None else None,
+    }
+
+
+def _handle_grok_build_incomplete_turn(
+    msg: dict,
+    message_id: int,
+    response: str,
+    turn_status: dict[str, str | None],
+    *,
+    actual_model: str,
+    effort: str,
+) -> None:
+    """Deliver captured native text only as an explicitly typed failed turn."""
+    outcome = str(turn_status["outcome"])
+    category = turn_status.get("cancellation_category")
+    detail = outcome if outcome == "trace_unavailable" else f"{outcome}/{category or 'none'}"
+    banner = f"⚠️ TURN NOT COMPLETED ({detail})"
+    provenance_data, _ = response_provenance(
+        msg,
+        actual_model=actual_model,
+        harness="grok",
+        effort_applied=effort,
+    )
+    metadata = json.loads(provenance_data)
+    metadata.update(
+        {
+            "turn_outcome": outcome,
+            "cancellation_category": category,
+            "trace_status": "unavailable" if outcome == "trace_unavailable" else "terminal_failure",
+            "partial_response": True,
+        }
+    )
+    send_message(
+        content=f"{banner}\n\n{response}",
+        task_id=msg["task_id"],
+        msg_type="error",
+        from_llm="grok",
+        to_llm=msg["from"],
+        data=json.dumps(metadata, sort_keys=True),
+        from_model=actual_model,
+    )
+    acknowledge(message_id)
+    record_ask_failure(message_id, f"native Grok turn not completed: {detail}")
 
 
 def _fetch_grok_build_message(message_id: int) -> dict | None:

--- a/scripts/audit/layerb_judge_bridge.py
+++ b/scripts/audit/layerb_judge_bridge.py
@@ -45,7 +45,6 @@ from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
 if __package__ in {None, ""}:
     project_root = Path(__file__).resolve().parents[2]
@@ -982,18 +981,10 @@ def _read_strict_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 def _grok_session_dir(scoped_home: Path, scratch_dir: Path, session_id: str) -> Path:
-    """Return the documented Grok session directory for this fresh invocation.
+    """Return the documented Grok session directory for this fresh invocation."""
+    from scripts.agent_runtime.adapters.grok_build import grok_session_dir
 
-    The native CLI keys the session store by its REAL working directory —
-    symlinks resolved. On macOS every tempfile root is behind a symlink
-    (``/tmp`` and ``/var`` both point into ``/private``), so deriving the key
-    from the unresolved path can never match what the CLI writes. Proven
-    empirically on CLI 0.2.101 (PR #5200 debug, 2026-07-15): the CLI wrote
-    ``sessions/%2Fprivate%2Ftmp%2F...`` while the unresolved derivation
-    looked for ``sessions/%2Ftmp%2F...``.
-    """
-
-    return scoped_home / "sessions" / quote(str(Path(scratch_dir).resolve()), safe="") / session_id
+    return grok_session_dir(scoped_home, scratch_dir, session_id)
 
 
 def _value_has_grok_tool_activity(value: Any) -> bool:

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -111,6 +111,48 @@ def test_launch_background_ask_writes_state_and_uses_detached_popen(bridge_db, m
     state = json.loads((tmp_path / "pids" / f"ask-{message_id}.json").read_text())
     assert state["pid"] == 4321
     assert state["target"] == "agy"
+    launch = json.loads((tmp_path / "batch_state" / "asks" / "task-4837" / "launch.json").read_text())
+    assert launch["message_id"] == message_id
+    assert launch["pid"] == 4321
+    assert launch["agent"] == "agy"
+    assert launch["harness"] == "agy"
+    assert launch["started_at"]
+
+
+def test_background_exception_writes_well_formed_terminal_record(bridge_db, monkeypatch, tmp_path):
+    """A detached exception must leave a crash-safe terminal artifact (#5891)."""
+    message_id = _send_ask()
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(lifecycle, "_background_options", lambda *_args: {})
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_target",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("adapter exploded")),
+    )
+
+    lifecycle.process_background_ask(message_id, "agy")
+
+    terminal = json.loads((tmp_path / "batch_state" / "asks" / "task-4837" / "terminal.json").read_text())
+    assert terminal["rc_or_signal"] == 1
+    assert terminal["stage"] == "exception"
+    assert terminal["stderr_tail"] == ""
+    assert terminal["ended_at"]
+
+
+def test_background_signal_handler_writes_terminal_record(bridge_db, monkeypatch, tmp_path):
+    """SIGTERM is recorded before the detached process exits (#5891)."""
+    message_id = _send_ask()
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    recorder = lifecycle._AskTerminalRecorder(message_id)
+
+    with pytest.raises(SystemExit) as exc_info:
+        recorder.signal_handler(lifecycle.signal.SIGTERM, None)
+
+    assert exc_info.value.code == 128 + lifecycle.signal.SIGTERM
+    terminal = json.loads((tmp_path / "batch_state" / "asks" / "task-4837" / "terminal.json").read_text())
+    assert terminal["rc_or_signal"] == "SIGTERM"
+    assert terminal["stage"] == "signal"
+    assert terminal["ended_at"]
 
 
 def test_asks_lists_replied_id_and_filters_task(bridge_db, capsys):
@@ -131,6 +173,28 @@ def test_asks_lists_replied_id_and_filters_task(bridge_db, capsys):
     output = capsys.readouterr().out
     assert f"{first}  task-a  agy  replied (reply #{reply_id})" in output
     assert "task-b" not in output
+
+
+def test_asks_marks_dead_launched_worker_without_terminal_as_died_silent(bridge_db, monkeypatch, capsys, tmp_path):
+    """A vanished worker cannot remain indefinitely indistinguishable from pending."""
+    message_id = _send_ask()
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-4837"
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "opencode",
+            "harness": "opencode",
+            "model": "grok-4.5",
+            "started_at": "2026-07-27T00:00:00+00:00",
+        },
+    )
+
+    lifecycle.print_asks("task-4837")
+
+    assert "DIED-SILENT (retry recommended)" in capsys.readouterr().out
 
 
 def test_reply_link_rejects_a_response_for_another_transport(bridge_db):

--- a/tests/test_grok_build_bridge.py
+++ b/tests/test_grok_build_bridge.py
@@ -11,6 +11,97 @@ from scripts.ai_agent_bridge import _cli, _grok_build
 from scripts.ai_agent_bridge._review_worktree import ProvisionedReviewWorktree
 
 
+def _grok_bridge_message() -> dict[str, str]:
+    return {
+        "id": 7,
+        "task_id": "task-5891",
+        "from": "codex",
+        "to": "grok",
+        "type": "query",
+        "content": "answer this",
+        "data": '{"to_model": "grok-4.5"}',
+        "timestamp": "now",
+    }
+
+
+def _run_grok_turn_with_events(monkeypatch, tmp_path, events: list[dict] | None) -> list[dict]:
+    sent: list[dict] = []
+    session_dir = tmp_path / "session"
+    if events is not None:
+        session_dir.mkdir()
+        (session_dir / "events.jsonl").write_text(
+            "\n".join(json.dumps(event) for event in events), encoding="utf-8"
+        )
+    monkeypatch.setattr(_grok_build, "_fetch_grok_build_message", lambda _message_id: _grok_bridge_message())
+    monkeypatch.setattr(_grok_build, "grok_session_dir", lambda *_args: session_dir)
+    monkeypatch.setattr(_grok_build, "acknowledge", lambda *_args: None)
+    monkeypatch.setattr(_grok_build, "record_ask_reply", lambda *_args: None)
+    monkeypatch.setattr(_grok_build, "record_ask_failure", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_grok_build, "set_session", lambda *_args: None)
+    monkeypatch.setattr(
+        _grok_build.agent_runner,
+        "invoke",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            ok=True,
+            response="captured preamble",
+            session_id="session-5891",
+            model="grok-4.5",
+        ),
+    )
+    monkeypatch.setattr(_grok_build, "send_message", lambda **kwargs: sent.append(kwargs) or 8)
+
+    _grok_build.process_for_grok_build(7)
+    return sent
+
+
+def test_grok_completed_turn_keeps_normal_response(monkeypatch, tmp_path):
+    sent = _run_grok_turn_with_events(
+        monkeypatch,
+        tmp_path,
+        [{"type": "turn_ended", "outcome": "completed"}],
+    )
+
+    assert sent[-1]["msg_type"] == "response"
+    assert not sent[-1]["content"].startswith("⚠️ TURN NOT COMPLETED")
+
+
+def test_grok_cancelled_turn_is_typed_error_with_banner(monkeypatch, tmp_path):
+    """Captured preamble from a cancelled native turn must never look normal."""
+    sent = _run_grok_turn_with_events(
+        monkeypatch,
+        tmp_path,
+        [
+            {"type": "turn_ended", "outcome": "completed"},
+            {
+                "type": "turn_ended",
+                "outcome": "cancelled",
+                "cancellation_category": "permission_cancelled",
+            },
+        ],
+    )
+
+    reply = sent[-1]
+    assert reply["msg_type"] == "error"
+    assert reply["content"].startswith(
+        "⚠️ TURN NOT COMPLETED (cancelled/permission_cancelled)"
+    )
+    metadata = json.loads(reply["data"])
+    assert metadata["turn_outcome"] == "cancelled"
+    assert metadata["cancellation_category"] == "permission_cancelled"
+    assert metadata["partial_response"] is True
+
+
+def test_grok_missing_trace_is_typed_error_with_banner(monkeypatch, tmp_path):
+    sent = _run_grok_turn_with_events(monkeypatch, tmp_path, None)
+
+    reply = sent[-1]
+    assert reply["msg_type"] == "error"
+    assert reply["content"].startswith("⚠️ TURN NOT COMPLETED (trace_unavailable)")
+    metadata = json.loads(reply["data"])
+    assert metadata["turn_outcome"] == "trace_unavailable"
+    assert metadata["trace_status"] == "unavailable"
+
+
 def test_ask_grok_build_parser_accepts_first_class_args():
     parser = _cli._build_parser()
 


### PR DESCRIPTION
## Summary
- persist launch and terminal artifacts for detached asks, including signal and startup death
- render unrecorded dead workers as `DIED-SILENT` and terminal failures as `FAILED`
- reject native Grok partial text when its terminal event is cancelled or unavailable

## Verification
- `.venv/bin/python -m pytest tests/ai_agent_bridge/ tests/test_grok_build_bridge.py tests/test_grok_build_adapter.py -q` (263 passed)
- `.venv/bin/ruff check scripts/ai_agent_bridge tests/ai_agent_bridge tests/test_grok_build_bridge.py tests/test_grok_build_adapter.py`
- mutation checks: cancelled Grok marking, terminal exception/signal records, and DIED-SILENT rendering each failed when their guard was removed, then restored

Closes #5891