### PR TITLE
fix(channels): route live slot deliveries to holder

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -982,14 +982,18 @@ def post(
     _validate_kind(kind)
     _validate_priority(priority)
     warnings: list[str] = []
+    delivery_targets: list[str] = []
     for agent in to_agents or []:
         _validate_recipient_agent(agent)
+        delivery_agent = agent
         if "-" in agent and agent not in STATIC_VALID_AGENTS:
             try:
                 from scripts.orchestration.slot_routing import resolve_slot_holder
 
                 res = resolve_slot_holder(agent)
-                if not res.has_holder:
+                if res.has_holder:
+                    delivery_agent = res.holder_agent
+                else:
                     msg = (
                         f"⚠️ channel-bridge: recipient slot '{agent}' has no live holder "
                         f"(queued at {res.queue_location})"
@@ -1000,6 +1004,7 @@ def post(
                     print(msg, file=_sys.stderr)
             except Exception:
                 pass
+        delivery_targets.append(delivery_agent)
     body = redact_text(body) or ""
     attachments = redact_value(attachments)
     monitor_state_snapshot = redact_value(monitor_state_snapshot)
@@ -1141,11 +1146,13 @@ def post(
 
         delivery_ids = []
         delivery_agents = []
-        for agent in to_agents or []:
+        seen_delivery_agents: set[str] = set()
+        for agent in delivery_targets:
             # Skip sender self-fanout: an agent does not need to "process"
             # its own reply. Channel deliveries are for other subscribers.
-            if agent == from_agent:
+            if agent == from_agent or agent in seen_delivery_agents:
                 continue
+            seen_delivery_agents.add(agent)
             delivery_agents.append(agent)
             dlv_id = _new_id()
             delivery_ids.append(dlv_id)

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -302,6 +302,38 @@ def _validate_recipient_agent(agent: str, *, assignments_path: Path | None = Non
         raise ValueError(f"Unknown delivery target '{agent}'. Expected one of {valids}.")
 
 
+def _resolve_delivery_agent(
+    agent: str,
+    *,
+    warnings: list[str],
+    warn_if_unheld: bool,
+) -> str:
+    """Resolve a slot to its live holder, retaining unheld slots unchanged."""
+    if "-" not in agent or agent in STATIC_VALID_AGENTS:
+        return agent
+
+    try:
+        from scripts.orchestration.slot_routing import resolve_slot_holder
+
+        res = resolve_slot_holder(agent)
+    except Exception:
+        return agent
+
+    if res.has_holder:
+        return res.holder_agent or agent
+
+    if warn_if_unheld:
+        msg = (
+            f"⚠️ channel-bridge: recipient slot '{agent}' has no live holder "
+            f"(queued at {res.queue_location})"
+        )
+        warnings.append(msg)
+        import sys as _sys
+
+        print(msg, file=_sys.stderr)
+    return agent
+
+
 def _validate_priority(priority: str) -> None:
     if priority not in VALID_MESSAGE_PRIORITIES:
         raise ValueError(f"Unknown priority '{priority}'. Expected one of {VALID_MESSAGE_PRIORITIES}.")
@@ -982,29 +1014,17 @@ def post(
     _validate_kind(kind)
     _validate_priority(priority)
     warnings: list[str] = []
+    resolved_from_agent = _resolve_delivery_agent(
+        from_agent,
+        warnings=warnings,
+        warn_if_unheld=False,
+    )
     delivery_targets: list[str] = []
     for agent in to_agents or []:
         _validate_recipient_agent(agent)
-        delivery_agent = agent
-        if "-" in agent and agent not in STATIC_VALID_AGENTS:
-            try:
-                from scripts.orchestration.slot_routing import resolve_slot_holder
-
-                res = resolve_slot_holder(agent)
-                if res.has_holder:
-                    delivery_agent = res.holder_agent
-                else:
-                    msg = (
-                        f"⚠️ channel-bridge: recipient slot '{agent}' has no live holder "
-                        f"(queued at {res.queue_location})"
-                    )
-                    warnings.append(msg)
-                    import sys as _sys
-
-                    print(msg, file=_sys.stderr)
-            except Exception:
-                pass
-        delivery_targets.append(delivery_agent)
+        delivery_targets.append(
+            _resolve_delivery_agent(agent, warnings=warnings, warn_if_unheld=True)
+        )
     body = redact_text(body) or ""
     attachments = redact_value(attachments)
     monitor_state_snapshot = redact_value(monitor_state_snapshot)
@@ -1150,7 +1170,7 @@ def post(
         for agent in delivery_targets:
             # Skip sender self-fanout: an agent does not need to "process"
             # its own reply. Channel deliveries are for other subscribers.
-            if agent == from_agent or agent in seen_delivery_agents:
+            if agent == resolved_from_agent or agent in seen_delivery_agents:
                 continue
             seen_delivery_agents.add(agent)
             delivery_agents.append(agent)

--- a/tests/test_bridge_channels.py
+++ b/tests/test_bridge_channels.py
@@ -546,6 +546,33 @@ def test_post_to_slots_with_shared_live_holder_delivers_once(tmp_path: Path, mon
     assert deliveries[0]["to_agent"] == "claude-infra"
 
 
+def test_post_skips_self_fanout_when_sender_and_recipient_slots_share_holder(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Sender and recipient slots sharing a holder create no self-delivery."""
+    from scripts.orchestration import slot_routing
+
+    def resolve_shared_holder(slot: str) -> slot_routing.SlotHolderResult:
+        return slot_routing.SlotHolderResult(
+            has_holder=True,
+            slot=slot,
+            holder_agent="claude-infra",
+        )
+
+    monkeypatch.setattr(slot_routing, "resolve_slot_holder", resolve_shared_holder)
+    _channels.create_channel("topic")
+    result = _channels.post(
+        "topic",
+        "claude-atlas",
+        "hello",
+        to_agents=["claude-folk"],
+        auto_snapshot=False,
+    )
+
+    assert result["delivery_ids"] == []
+    assert _channels.deliveries_for_message(result["message_id"]) == []
+
+
 def test_pending_deliveries_for_agent_filters_by_agent():
     """Verify agent queues only return their own pending deliveries."""
     _channels.create_channel("topic")

--- a/tests/test_bridge_channels.py
+++ b/tests/test_bridge_channels.py
@@ -465,6 +465,87 @@ def test_deliveries_for_message_returns_all_recipients():
     assert len(dlvs) == 2
     assert {d["to_agent"] for d in dlvs} == {"claude", "codex"}
 
+
+def test_post_to_slots_with_shared_live_holder_delivers_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Live slots sharing a holder create one delivery row in that holder's inbox."""
+    from scripts.orchestration import slot_routing
+
+    session_db_path = tmp_path / "session-streams.sqlite3"
+    conn = sqlite3.connect(session_db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                session_id TEXT PRIMARY KEY,
+                stream_id TEXT NOT NULL,
+                state TEXT NOT NULL
+            );
+            CREATE TABLE stream_leases (
+                stream_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                holder_agent TEXT NOT NULL,
+                holder_harness TEXT,
+                generation INTEGER NOT NULL,
+                expires_at TEXT NOT NULL,
+                state TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions (session_id, stream_id, state) VALUES (?, ?, ?)",
+            ("atlas-session", "epic:4387", "open"),
+        )
+        conn.execute(
+            "INSERT INTO sessions (session_id, stream_id, state) VALUES (?, ?, ?)",
+            ("folk-session", "epic:2836", "open"),
+        )
+        conn.execute(
+            """INSERT INTO stream_leases
+               (stream_id, session_id, holder_agent, holder_harness, generation, expires_at, state)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "epic:4387",
+                "atlas-session",
+                "claude-infra",
+                "claude",
+                1,
+                (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+                "active",
+            ),
+        )
+        conn.execute(
+            """INSERT INTO stream_leases
+               (stream_id, session_id, holder_agent, holder_harness, generation, expires_at, state)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "epic:2836",
+                "folk-session",
+                "claude-infra",
+                "claude",
+                1,
+                (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+                "active",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(slot_routing, "DEFAULT_SESSION_DB_PATH", session_db_path)
+    _channels.create_channel("topic")
+    result = _channels.post(
+        "topic",
+        "user",
+        "hello",
+        to_agents=["claude-atlas", "claude-folk"],
+        auto_snapshot=False,
+    )
+
+    deliveries = _channels.deliveries_for_message(result["message_id"])
+    assert len(deliveries) == 1
+    assert deliveries[0]["to_agent"] == "claude-infra"
+
+
 def test_pending_deliveries_for_agent_filters_by_agent():
     """Verify agent queues only return their own pending deliveries."""
     _channels.create_channel("topic")


### PR DESCRIPTION
## Summary
- Route deliveries addressed to a live slot holder into the holder agent’s inbox.
- Preserve queued slot delivery and warning behavior when no holder is live.
- Add a regression assertion for the persisted delivery row.

## Context
Addresses #5880.

Formal Codex CF finding F001 after merged #5878: `resolve_slot_holder` was used only to warn, while the delivery insert retained the slot name, leaving holder inboxes unable to drain those rows.

## Verification
- `.venv/bin/python -m pytest tests/test_bridge_channels.py -q` — 99 passed
- `.venv/bin/ruff check scripts/ai_agent_bridge/_channels.py tests/test_bridge_channels.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`