### PR TITLE
feat(bridge): ask retry-once watchdog + native tool contract + cancel-and-retell (#5893 items 1-3)

### DIFF
--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -143,7 +143,12 @@ def ask_agy(
         launch_background_ask(
             msg_id,
             "agy",
-            {"new_session": new_session, "no_timeout": no_timeout, "review": review},
+            {
+                "new_session": new_session,
+                "no_timeout": no_timeout,
+                "review": review,
+                "timeout_seconds": 1800,
+            },
         )
         return msg_id
     if not stdout_only:

--- a/scripts/ai_agent_bridge/_ask_contract.py
+++ b/scripts/ai_agent_bridge/_ask_contract.py
@@ -8,6 +8,14 @@ from typing import Any
 
 EFFORT_CHOICES = ("low", "medium", "high", "xhigh", "max")
 
+NATIVE_ASK_TOOL_CONTRACT = (
+    "shell commands are unavailable in this mode; answer from attached material and file reads."
+)
+
+# Documented bound for total automatic re-fires of a single ask across all hardening
+# mechanisms (retry-once watchdog + cancel-and-retell).
+MAX_TOTAL_ASK_RETRIES = 2
+
 
 def resolve_model_selection(
     *,
@@ -68,6 +76,7 @@ def response_provenance(
     effort_reason: str | None = None,
 ) -> tuple[str, str]:
     """Return data JSON and ``from_model`` for a reply from one ask lane."""
+    req_meta = request_metadata(message)
     metadata: dict[str, Any] = {
         "from_model": actual_model,
         "model_requested": requested_model(message, actual_model),
@@ -75,6 +84,12 @@ def response_provenance(
         "effort_applied": effort_applied,
         "harness": harness,
     }
+    if req_meta.get("auto_retried") or req_meta.get("auto-retried"):
+        metadata["auto_retried"] = True
+        metadata["auto-retried"] = True
+    if req_meta.get("cancel_retried") or req_meta.get("cancel-retried"):
+        metadata["cancel_retried"] = True
+        metadata["cancel-retried"] = True
     if effort_reason:
         metadata["effort_reason"] = effort_reason
     return json.dumps(metadata, sort_keys=True), actual_model

--- a/scripts/ai_agent_bridge/_ask_contract.py
+++ b/scripts/ai_agent_bridge/_ask_contract.py
@@ -86,10 +86,8 @@ def response_provenance(
     }
     if req_meta.get("auto_retried") or req_meta.get("auto-retried"):
         metadata["auto_retried"] = True
-        metadata["auto-retried"] = True
     if req_meta.get("cancel_retried") or req_meta.get("cancel-retried"):
         metadata["cancel_retried"] = True
-        metadata["cancel-retried"] = True
     if effort_reason:
         metadata["effort_reason"] = effort_reason
     return json.dumps(metadata, sort_keys=True), actual_model

--- a/scripts/ai_agent_bridge/_ask_lifecycle.py
+++ b/scripts/ai_agent_bridge/_ask_lifecycle.py
@@ -31,6 +31,7 @@ from ._config import _PARENT_ENV, PID_DIR, REPO_ROOT
 from ._db import get_db
 
 _ASK_AGENT = "ask"
+_DEFAULT_HARD_TIMEOUT_SECONDS = 900
 # Stored on the legacy messages.data JSON so reply completion can reload by id.
 _FLEET_REQUEST_ID_KEY = "fleet_request_id"
 # Tests may point plane storage at a tmp root without touching batch_state/.
@@ -594,7 +595,6 @@ def print_asks(task_id: str | None = None) -> None:
 
 def maybe_print_timeout_notice() -> None:
     """Surface newly timed-out detached asks on the next bridge CLI command."""
-    run_ask_watchdog()
     conn = get_db()
     try:
         rows = conn.execute(
@@ -641,6 +641,20 @@ def should_auto_retry_ask(message_id: int) -> bool:
         return False
     pid = launch.get("pid")
     if _pid_is_alive(pid):
+        return False
+
+    started_at_raw = launch.get("started_at")
+    if not started_at_raw or not isinstance(started_at_raw, str):
+        return False
+    try:
+        started_at = datetime.fromisoformat(started_at_raw)
+        if started_at.tzinfo is None:
+            started_at = started_at.replace(tzinfo=UTC)
+        age = (datetime.now(UTC) - started_at).total_seconds()
+        max_age = 2 * _DEFAULT_HARD_TIMEOUT_SECONDS
+        if age < 0 or age > max_age:
+            return False
+    except (ValueError, TypeError):
         return False
 
     target = str(launch.get("agent") or launch.get("harness") or "grok")
@@ -693,7 +707,6 @@ def _re_fire_ask(message_id: int) -> bool:
         return False
 
     meta = _ask_metadata(msg)
-    meta["auto-retried"] = True
     meta["auto_retried"] = True
     current_count = int(meta.get("total_retry_count") or 0)
     meta["total_retry_count"] = current_count + 1

--- a/scripts/ai_agent_bridge/_ask_lifecycle.py
+++ b/scripts/ai_agent_bridge/_ask_lifecycle.py
@@ -31,7 +31,6 @@ from ._config import _PARENT_ENV, PID_DIR, REPO_ROOT
 from ._db import get_db
 
 _ASK_AGENT = "ask"
-_DEFAULT_HARD_TIMEOUT_SECONDS = 900
 # Stored on the legacy messages.data JSON so reply completion can reload by id.
 _FLEET_REQUEST_ID_KEY = "fleet_request_id"
 # Tests may point plane storage at a tmp root without touching batch_state/.
@@ -84,7 +83,9 @@ def _stderr_tail(message_id: int) -> str:
         return ""
 
 
-def _write_ask_launch_record(message_id: int, *, pid: int, target: str) -> None:
+def _write_ask_launch_record(
+    message_id: int, *, pid: int, target: str, options: dict[str, Any] | None = None
+) -> None:
     row = _load_ask_row(message_id)
     metadata: dict[str, Any] = {}
     if row and row[4]:
@@ -94,6 +95,22 @@ def _write_ask_launch_record(message_id: int, *, pid: int, target: str) -> None:
                 metadata = decoded
         except (TypeError, json.JSONDecodeError):
             pass
+    no_timeout = bool(options.get("no_timeout", False)) if options else False
+    timeout_seconds: int | float | None = None
+    if options:
+        timeout_seconds = options.get("timeout_seconds")
+        if timeout_seconds is None:
+            timeout_seconds = options.get("timeout")
+    if timeout_seconds is None:
+        # Target-specific default hard timeout when not explicitly provided in options:
+        # AGY, Grok, Gemini, and OpenCode pool/glm/gemma default to 1800s (30m).
+        # Claude, Codex, Cursor, Hermes, Opencode default to 900s (15m).
+        timeout_seconds = (
+            1800
+            if target in {"agy", "grok", "grok-build", "gemini", "pool", "glm", "gemma"}
+            else 900
+        )
+
     _atomic_write_json(
         _ask_state_dir(message_id) / "launch.json",
         {
@@ -103,6 +120,8 @@ def _write_ask_launch_record(message_id: int, *, pid: int, target: str) -> None:
             "harness": target,
             "model": metadata.get("to_model"),
             "started_at": _now_iso(),
+            "no_timeout": no_timeout,
+            "timeout_seconds": timeout_seconds,
         },
     )
 
@@ -396,7 +415,7 @@ def launch_background_ask(message_id: int, target: str, options: dict[str, Any])
         {"message_id": message_id, "target": target, "options": options},
         pid=proc.pid,
     )
-    _write_ask_launch_record(message_id, pid=proc.pid, target=target)
+    _write_ask_launch_record(message_id, pid=proc.pid, target=target, options=options)
 
     # A worker can die BEFORE `process_background_ask` runs — a bad adapter path, an
     # import error, a missing binary — in which case its `finally:` never executes and
@@ -628,12 +647,35 @@ def _is_clean_terminal_record(message_id: int) -> bool:
     return rc in (0, "0") and stage == "success"
 
 
+def claim_ask_retry(message_id: int) -> bool:
+    """Atomically claim a retry slot for an ask via O_CREAT | O_EXCL lockfile 'retry-claim'.
+
+    Returns True if this caller successfully claimed the retry; returns False
+    silently if the claim file already exists or cannot be created.
+    """
+    state_dir = _ask_state_dir(message_id)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    claim_path = state_dir / "retry-claim"
+    try:
+        fd = os.open(str(claim_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(f"claimed_by_pid={os.getpid()}\nclaimed_at={_now_iso()}\n")
+            handle.flush()
+        return True
+    except (FileExistsError, OSError):
+        return False
+
+
 def should_auto_retry_ask(message_id: int) -> bool:
     """Return True if a background ask worker is dead without clean completion and unretried."""
     status = _ask_status(message_id)
     if status is not None and status.startswith("replied:"):
         return False
     if _is_clean_terminal_record(message_id):
+        return False
+
+    state_dir = _ask_state_dir(message_id)
+    if (state_dir / "retry-claim").exists():
         return False
 
     launch = _read_ask_record(message_id, "launch.json")
@@ -651,7 +693,19 @@ def should_auto_retry_ask(message_id: int) -> bool:
         if started_at.tzinfo is None:
             started_at = started_at.replace(tzinfo=UTC)
         age = (datetime.now(UTC) - started_at).total_seconds()
-        max_age = 2 * _DEFAULT_HARD_TIMEOUT_SECONDS
+        no_timeout = bool(launch.get("no_timeout", False))
+        if no_timeout:
+            max_age = 24 * 3600  # Generous fixed cap for no_timeout asks (24h)
+        else:
+            rec_timeout = launch.get("timeout_seconds")
+            if rec_timeout is None:
+                rec_timeout = launch.get("timeout")
+            if rec_timeout is not None and isinstance(rec_timeout, (int, float)) and rec_timeout > 0:
+                max_age = 2 * float(rec_timeout)
+            else:
+                # Fall back to 2 * 1800s (3600s) for legacy launch records lacking a timeout field.
+                # 1800s is twice the largest lane default (e.g. AGY / Gemini / OpenCode pool 1800s defaults).
+                max_age = 2 * 1800
         if age < 0 or age > max_age:
             return False
     except (ValueError, TypeError):
@@ -698,6 +752,9 @@ def run_ask_watchdog(target_message_id: int | None = None) -> list[int]:
 
 def _re_fire_ask(message_id: int) -> bool:
     """Re-fire a dead background ask worker once with auto-retried metadata."""
+    if not claim_ask_retry(message_id):
+        return False
+
     launch = _read_ask_record(message_id, "launch.json")
     if not launch:
         return False

--- a/scripts/ai_agent_bridge/_ask_lifecycle.py
+++ b/scripts/ai_agent_bridge/_ask_lifecycle.py
@@ -25,6 +25,7 @@ from typing import Any
 from agent_runtime.errors import AgentStalledError, AgentTimeoutError
 
 from . import _config
+from ._ask_contract import MAX_TOTAL_ASK_RETRIES
 from ._broker import _remove_pid_file, _write_pid_file
 from ._config import _PARENT_ENV, PID_DIR, REPO_ROOT
 from ._db import get_db
@@ -593,6 +594,7 @@ def print_asks(task_id: str | None = None) -> None:
 
 def maybe_print_timeout_notice() -> None:
     """Surface newly timed-out detached asks on the next bridge CLI command."""
+    run_ask_watchdog()
     conn = get_db()
     try:
         rows = conn.execute(
@@ -614,6 +616,115 @@ def maybe_print_timeout_notice() -> None:
         conn.commit()
     finally:
         conn.close()
+
+
+def _is_clean_terminal_record(message_id: int) -> bool:
+    """Return True if a recorded terminal artifact indicates a clean success."""
+    terminal = _read_ask_record(message_id, "terminal.json")
+    if terminal is None:
+        return False
+    rc = terminal.get("rc_or_signal")
+    stage = str(terminal.get("stage") or "")
+    return rc in (0, "0") and stage == "success"
+
+
+def should_auto_retry_ask(message_id: int) -> bool:
+    """Return True if a background ask worker is dead without clean completion and unretried."""
+    status = _ask_status(message_id)
+    if status is not None and status.startswith("replied:"):
+        return False
+    if _is_clean_terminal_record(message_id):
+        return False
+
+    launch = _read_ask_record(message_id, "launch.json")
+    if launch is None:
+        return False
+    pid = launch.get("pid")
+    if _pid_is_alive(pid):
+        return False
+
+    target = str(launch.get("agent") or launch.get("harness") or "grok")
+    msg = fetch_ask_message(message_id, target)
+    if not msg:
+        return False
+    meta = _ask_metadata(msg)
+    if meta.get("auto_retried") or meta.get("auto-retried"):
+        return False
+    total_retries = int(meta.get("total_retry_count") or 0)
+    return total_retries < MAX_TOTAL_ASK_RETRIES
+
+
+def run_ask_watchdog(target_message_id: int | None = None) -> list[int]:
+    """Inspect background asks and re-fire dead workers lacking clean completion once.
+
+    Enforces the single-retry watchdog invariant (#5893 item 1). Dead workers
+    without a reply and without a clean terminal record get re-fired with
+    'auto-retried': True in metadata. Never silent.
+    """
+    retried_ids: list[int] = []
+    conn = get_db()
+    try:
+        if target_message_id is not None:
+            rows = conn.execute(
+                "SELECT id FROM messages WHERE id = ?", (target_message_id,)
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT id FROM messages WHERE status NOT LIKE 'replied:%' ORDER BY id ASC"
+            ).fetchall()
+    finally:
+        conn.close()
+
+    for row in rows:
+        msg_id = int(row[0])
+        if should_auto_retry_ask(msg_id) and _re_fire_ask(msg_id):
+            retried_ids.append(msg_id)
+    return retried_ids
+
+
+def _re_fire_ask(message_id: int) -> bool:
+    """Re-fire a dead background ask worker once with auto-retried metadata."""
+    launch = _read_ask_record(message_id, "launch.json")
+    if not launch:
+        return False
+    target = str(launch.get("agent") or launch.get("harness") or "grok")
+    msg = fetch_ask_message(message_id, target)
+    if not msg:
+        return False
+
+    meta = _ask_metadata(msg)
+    meta["auto-retried"] = True
+    meta["auto_retried"] = True
+    current_count = int(meta.get("total_retry_count") or 0)
+    meta["total_retry_count"] = current_count + 1
+
+    conn = get_db()
+    try:
+        conn.execute(
+            "UPDATE messages SET data = ? WHERE id = ?",
+            (json.dumps(meta, sort_keys=True), message_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    options = {}
+    try:
+        options = _background_options(message_id, target)
+    except Exception:
+        options = {"no_timeout": False, "review": False, "new_session": False}
+
+    print(
+        f"🔄 Ask #{message_id} ({target}) worker dead without clean completion; "
+        f"auto-retrying once (auto-retried=True)...",
+        file=sys.stderr,
+    )
+    try:
+        launch_background_ask(message_id, target, options)
+        return True
+    except Exception as exc:
+        record_ask_failure(message_id, f"auto-retry re-fire failed: {exc}")
+        return False
 
 
 def assert_ask_content_present(msg: dict[str, Any], *, message_id: int, target: str) -> str:

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -100,7 +100,12 @@ def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query"
         launch_background_ask(
             msg_id,
             "claude",
-            {"new_session": new_session, "no_timeout": False, "review": review},
+            {
+                "new_session": new_session,
+                "no_timeout": False,
+                "review": review,
+                "timeout_seconds": 900,
+            },
         )
         return msg_id
     print(f"\n🚀 Invoking Claude to process message #{msg_id}...")

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -594,6 +594,11 @@ def _build_parser() -> argparse.ArgumentParser:
 
     asks_parser = subparsers.add_parser("asks", help="List tracked one-shot ask lifecycle states")
     asks_parser.add_argument("--task-id", help="Only show asks for this task ID")
+    asks_parser.add_argument(
+        "--watchdog",
+        action="store_true",
+        help="Run the ask watchdog to re-fire dead workers lacking clean completion once",
+    )
 
     # ask-claude
     ask_claude_parser = subparsers.add_parser(
@@ -1273,6 +1278,14 @@ def _dispatch_command(args):
     elif args.command == "process-ask":
         process_background_ask(args.message_id, args.target)
     elif args.command == "asks":
+        if getattr(args, "watchdog", False):
+            from ._ask_lifecycle import run_ask_watchdog
+
+            retried = run_ask_watchdog()
+            if retried:
+                print(f"Watchdog re-fired {len(retried)} ask(s): {', '.join(map(str, retried))}")
+            else:
+                print("Watchdog run complete: no dead asks eligible for retry.")
         print_asks(args.task_id)
     elif args.command == "ask-claude":
         _handle_ask_claude(args)

--- a/scripts/ai_agent_bridge/_codex.py
+++ b/scripts/ai_agent_bridge/_codex.py
@@ -158,7 +158,12 @@ def ask_codex(
         launch_background_ask(
             msg_id,
             "codex",
-            {"new_session": new_session, "no_timeout": no_timeout, "review": review},
+            {
+                "new_session": new_session,
+                "no_timeout": no_timeout,
+                "review": review,
+                "timeout_seconds": 1800 if no_timeout else 900,
+            },
         )
         return msg_id
     print(f"\n🚀 Invoking Codex to process message #{msg_id}...")

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -27,8 +28,20 @@ from agent_runtime.errors import (
     RateLimitedError,
 )
 
-from ._ask_contract import requested_effort, resolve_model_selection, response_provenance
-from ._ask_lifecycle import launch_background_ask, record_ask_failure, record_ask_reply, register_ask
+from ._ask_contract import (
+    MAX_TOTAL_ASK_RETRIES,
+    NATIVE_ASK_TOOL_CONTRACT,
+    requested_effort,
+    resolve_model_selection,
+    response_provenance,
+)
+from ._ask_lifecycle import (
+    _ask_metadata,
+    launch_background_ask,
+    record_ask_failure,
+    record_ask_reply,
+    register_ask,
+)
 from ._config import REPO_ROOT
 from ._db import get_db, set_session
 from ._messaging import acknowledge, send_message
@@ -241,6 +254,26 @@ def process_for_grok_build(
         cwd=checkout.path if checkout is not None else REPO_ROOT,
     )
     if turn_status["outcome"] != "completed":
+        if (
+            turn_status.get("cancellation_category") == "permission_cancelled"
+            and _can_cancel_retry(msg)
+        ):
+            print(
+                f"⚠️ Ask #{message_id}: native Grok turn ended in permission_cancelled; "
+                f"auto-retrying ONCE with refusal reason appended...",
+                file=sys.stderr,
+            )
+            if _attempt_cancel_and_retell_retry(
+                msg=msg,
+                message_id=message_id,
+                checkout=checkout,
+                model=model,
+                effort=effort or GROK_BUILD_DEFAULT_EFFORT,
+                timeout_val=timeout_val,
+                review=review,
+                turn_status=turn_status,
+            ):
+                return
         _handle_grok_build_incomplete_turn(
             msg,
             message_id,
@@ -269,6 +302,133 @@ def process_for_grok_build(
     )
     acknowledge(message_id)
     record_ask_reply(message_id, reply_id)
+
+
+def _can_cancel_retry(msg: dict) -> bool:
+    """Check whether a permission_cancelled turn can be auto-retried once."""
+    meta = _ask_metadata(msg)
+    if meta.get("cancel_retried") or meta.get("cancel-retried"):
+        return False
+    total_retries = int(meta.get("total_retry_count") or 0)
+    return total_retries < MAX_TOTAL_ASK_RETRIES
+
+
+def _attempt_cancel_and_retell_retry(
+    *,
+    msg: dict,
+    message_id: int,
+    checkout: Any,
+    model: str,
+    effort: str,
+    timeout_val: int,
+    review: bool,
+    turn_status: dict[str, str | None],
+) -> bool:
+    """Auto-retry ONCE with refusal reason appended to prompt (#5893 item 3)."""
+    meta = _ask_metadata(msg)
+    meta["cancel-retried"] = True
+    meta["cancel_retried"] = True
+    current_count = int(meta.get("total_retry_count") or 0)
+    meta["total_retry_count"] = current_count + 1
+    msg["data"] = json.dumps(meta, sort_keys=True)
+
+    conn = get_db()
+    try:
+        conn.execute(
+            "UPDATE messages SET data = ? WHERE id = ?",
+            (msg["data"], message_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cat = turn_status.get("cancellation_category") or "permission_cancelled"
+    refusal_reason = (
+        f"Tool call permission cancelled: shell commands are unavailable in this mode ({cat}); "
+        "answer from attached material and file reads."
+    )
+
+    base_prompt = _build_grok_build_prompt(
+        msg,
+        review,
+        review_branch=checkout.branch if checkout else None,
+        review_pr_number=checkout.pr_number if checkout else None,
+        review_worktree_provisioned=checkout is not None,
+    )
+    retry_prompt = append_review_prompt_evidence(
+        f"{base_prompt}\n\n[Previous turn cancelled by permission policy]: {refusal_reason}\n",
+        review=review,
+        checkout=checkout,
+        engine="grok",
+    )
+    review_tool_config = checkout.isolation_tool_config("grok") if (review and checkout) else None
+
+    try:
+        result = agent_runner.invoke(
+            "grok",
+            retry_prompt,
+            mode="read-only",
+            cwd=checkout.path if checkout is not None else REPO_ROOT,
+            model=model,
+            task_id=msg["task_id"],
+            session_id=None,
+            tool_config=review_tool_config,
+            entrypoint="bridge",
+            hard_timeout=timeout_val,
+            stall_timeout=min(600, timeout_val),
+            effort=effort,
+        )
+    except Exception as exc:
+        _handle_grok_build_error(msg, message_id, f"Cancel-and-retell retry failed: {exc}")
+        return True
+
+    if not result.ok:
+        _handle_grok_build_error(
+            msg,
+            message_id,
+            result.stderr_excerpt or "Grok Build retry returned no final message",
+        )
+        return True
+
+    response = result.response
+    if not response:
+        _handle_grok_build_error(msg, message_id, "Grok Build retry returned no final message")
+        return True
+
+    new_turn_status = _native_grok_turn_status(
+        session_id=getattr(result, "session_id", None),
+        cwd=checkout.path if checkout is not None else REPO_ROOT,
+    )
+    if new_turn_status["outcome"] != "completed":
+        _handle_grok_build_incomplete_turn(
+            msg,
+            message_id,
+            response,
+            new_turn_status,
+            actual_model=getattr(result, "model", None) or model,
+            effort=effort or GROK_BUILD_DEFAULT_EFFORT,
+        )
+        return True
+
+    print(f"\nGrok finished retried turn ({len(response)} chars)")
+    provenance_data, actual_model = response_provenance(
+        msg,
+        actual_model=getattr(result, "model", None) or model,
+        harness="grok",
+        effort_applied=getattr(result, "effort", None) or effort or GROK_BUILD_DEFAULT_EFFORT,
+    )
+    reply_id = send_message(
+        content=response,
+        task_id=msg["task_id"],
+        msg_type="response",
+        from_llm="grok",
+        to_llm=msg["from"],
+        data=provenance_data,
+        from_model=actual_model,
+    )
+    acknowledge(message_id)
+    record_ask_reply(message_id, reply_id)
+    return True
 
 
 def _native_grok_turn_status(*, session_id: str | None, cwd: Path) -> dict[str, str | None]:
@@ -401,7 +561,9 @@ def _build_grok_build_prompt(
     review_worktree_provisioned: bool = False,
 ) -> str:
     """Build the native Grok Build bridge prompt."""
-    prompt = f"""You are Grok Build (native grok CLI), receiving a message from {msg['from'].title()} via the message broker.
+    prompt = f"""{NATIVE_ASK_TOOL_CONTRACT}
+
+You are Grok Build (native grok CLI), receiving a message from {msg['from'].title()} via the message broker.
 
 ---
 Task ID: {msg['task_id'] or 'none'}

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -326,7 +326,6 @@ def _attempt_cancel_and_retell_retry(
 ) -> bool:
     """Auto-retry ONCE with refusal reason appended to prompt (#5893 item 3)."""
     meta = _ask_metadata(msg)
-    meta["cancel-retried"] = True
     meta["cancel_retried"] = True
     current_count = int(meta.get("total_retry_count") or 0)
     meta["total_retry_count"] = current_count + 1
@@ -561,9 +560,8 @@ def _build_grok_build_prompt(
     review_worktree_provisioned: bool = False,
 ) -> str:
     """Build the native Grok Build bridge prompt."""
-    prompt = f"""{NATIVE_ASK_TOOL_CONTRACT}
-
-You are Grok Build (native grok CLI), receiving a message from {msg['from'].title()} via the message broker.
+    contract = f"{NATIVE_ASK_TOOL_CONTRACT}\n\n" if not review_worktree_provisioned else ""
+    prompt = f"""{contract}You are Grok Build (native grok CLI), receiving a message from {msg['from'].title()} via the message broker.
 
 ---
 Task ID: {msg['task_id'] or 'none'}

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -37,6 +37,8 @@ from ._ask_contract import (
 )
 from ._ask_lifecycle import (
     _ask_metadata,
+    _ask_state_dir,
+    claim_ask_retry,
     launch_background_ask,
     record_ask_failure,
     record_ask_reply,
@@ -309,6 +311,9 @@ def _can_cancel_retry(msg: dict) -> bool:
     meta = _ask_metadata(msg)
     if meta.get("cancel_retried") or meta.get("cancel-retried"):
         return False
+    msg_id = msg.get("id")
+    if msg_id and (_ask_state_dir(msg_id) / "retry-claim").exists():
+        return False
     total_retries = int(meta.get("total_retry_count") or 0)
     return total_retries < MAX_TOTAL_ASK_RETRIES
 
@@ -325,6 +330,8 @@ def _attempt_cancel_and_retell_retry(
     turn_status: dict[str, str | None],
 ) -> bool:
     """Auto-retry ONCE with refusal reason appended to prompt (#5893 item 3)."""
+    if not claim_ask_retry(message_id):
+        return False
     meta = _ask_metadata(msg)
     meta["cancel_retried"] = True
     current_count = int(meta.get("total_retry_count") or 0)

--- a/scripts/ai_agent_bridge/_inbox_watch.py
+++ b/scripts/ai_agent_bridge/_inbox_watch.py
@@ -217,6 +217,7 @@ def run_watcher(
     lock = acquire_watcher_lock(agent, lock_dir)
     conn: sqlite3.Connection | None = None
     last_seen = 0
+    watchdog_warned = False
     try:
         conn = open_readonly_db(db_path)
         while True:
@@ -224,8 +225,13 @@ def run_watcher(
                 from ._ask_lifecycle import run_ask_watchdog
 
                 run_ask_watchdog()
-            except Exception:
-                pass
+            except Exception as exc:
+                if not watchdog_warned:
+                    print(
+                        f"⚠️  inbox watcher: ask watchdog failed: {type(exc).__name__}: {exc}",
+                        file=sys.stderr,
+                    )
+                    watchdog_warned = True
             events = poll_once(conn, agent, last_seen)
             last_seen = emit_notifications(events, last_seen, output)
             if once:

--- a/scripts/ai_agent_bridge/_inbox_watch.py
+++ b/scripts/ai_agent_bridge/_inbox_watch.py
@@ -220,6 +220,12 @@ def run_watcher(
     try:
         conn = open_readonly_db(db_path)
         while True:
+            try:
+                from ._ask_lifecycle import run_ask_watchdog
+
+                run_ask_watchdog()
+            except Exception:
+                pass
             events = poll_once(conn, agent, last_seen)
             last_seen = emit_notifications(events, last_seen, output)
             if once:

--- a/scripts/ai_agent_bridge/_prompts.py
+++ b/scripts/ai_agent_bridge/_prompts.py
@@ -1,6 +1,5 @@
 """Prompt building for Gemini and Claude interactions."""
 
-from ._ask_contract import NATIVE_ASK_TOOL_CONTRACT
 from ._config import REPO_ROOT
 
 
@@ -229,9 +228,7 @@ def build_claude_prompt(
     review_worktree_provisioned: bool = False,
 ) -> str:
     """Build prompt for Claude invocation."""
-    prompt = f"""{NATIVE_ASK_TOOL_CONTRACT}
-
-You are Claude, receiving a message from {msg['from'].title()} via the message broker.
+    prompt = f"""You are Claude, receiving a message from {msg['from'].title()} via the message broker.
 
 ---
 Task ID: {msg['task_id'] or 'none'}
@@ -325,9 +322,7 @@ def build_agy_prompt(
     may read the precise repository files needed to answer, but must not
     broaden that into an exploratory or write-capable task.
     """
-    prompt = f"""{NATIVE_ASK_TOOL_CONTRACT}
-
-You are Agy (Antigravity CLI, Gemini-3.6-Flash-High), receiving a message from {msg['from'].title()} via the message broker.
+    prompt = f"""You are Agy (Antigravity CLI, Gemini-3.6-Flash-High), receiving a message from {msg['from'].title()} via the message broker.
 
 {OPERATOR_CONTRACT_DIGEST}
 
@@ -380,9 +375,7 @@ def build_codex_prompt(
     review_worktree_provisioned: bool = False,
 ) -> str:
     """Build prompt for Codex invocation."""
-    prompt = f"""{NATIVE_ASK_TOOL_CONTRACT}
-
-You are Codex, receiving a message from {msg['from'].title()} via the message broker.
+    prompt = f"""You are Codex, receiving a message from {msg['from'].title()} via the message broker.
 
 {_CODEX_STANDING_RULES}
 ---

--- a/scripts/ai_agent_bridge/_prompts.py
+++ b/scripts/ai_agent_bridge/_prompts.py
@@ -1,5 +1,6 @@
 """Prompt building for Gemini and Claude interactions."""
 
+from ._ask_contract import NATIVE_ASK_TOOL_CONTRACT
 from ._config import REPO_ROOT
 
 
@@ -228,7 +229,9 @@ def build_claude_prompt(
     review_worktree_provisioned: bool = False,
 ) -> str:
     """Build prompt for Claude invocation."""
-    prompt = f"""You are Claude, receiving a message from {msg['from'].title()} via the message broker.
+    prompt = f"""{NATIVE_ASK_TOOL_CONTRACT}
+
+You are Claude, receiving a message from {msg['from'].title()} via the message broker.
 
 ---
 Task ID: {msg['task_id'] or 'none'}
@@ -322,7 +325,9 @@ def build_agy_prompt(
     may read the precise repository files needed to answer, but must not
     broaden that into an exploratory or write-capable task.
     """
-    prompt = f"""You are Agy (Antigravity CLI, Gemini-3.6-Flash-High), receiving a message from {msg['from'].title()} via the message broker.
+    prompt = f"""{NATIVE_ASK_TOOL_CONTRACT}
+
+You are Agy (Antigravity CLI, Gemini-3.6-Flash-High), receiving a message from {msg['from'].title()} via the message broker.
 
 {OPERATOR_CONTRACT_DIGEST}
 
@@ -375,7 +380,9 @@ def build_codex_prompt(
     review_worktree_provisioned: bool = False,
 ) -> str:
     """Build prompt for Codex invocation."""
-    prompt = f"""You are Codex, receiving a message from {msg['from'].title()} via the message broker.
+    prompt = f"""{NATIVE_ASK_TOOL_CONTRACT}
+
+You are Codex, receiving a message from {msg['from'].title()} via the message broker.
 
 {_CODEX_STANDING_RULES}
 ---

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -119,3 +119,27 @@ def test_every_response_provenance_shape_has_required_fields(harness: str) -> No
         "harness": harness,
         "model_requested": "requested",
     }
+
+
+def test_native_ask_tool_contract_present_in_ask_mode_and_absent_otherwise() -> None:
+    """Native ask prompt generators include NATIVE_ASK_TOOL_CONTRACT; full drivers do not (#5893)."""
+    from ai_agent_bridge._ask_contract import NATIVE_ASK_TOOL_CONTRACT
+    from ai_agent_bridge._grok_build import _build_grok_build_prompt
+    from ai_agent_bridge._prompts import (
+        _build_full_execution_prompt,
+        build_agy_prompt,
+        build_claude_prompt,
+        build_codex_prompt,
+    )
+
+    dummy_msg = {"from": "user", "task_id": "test-1", "type": "query", "content": "Hello", "data": None}
+
+    # Ask-mode prompts MUST contain NATIVE_ASK_TOOL_CONTRACT
+    assert NATIVE_ASK_TOOL_CONTRACT in _build_grok_build_prompt(dummy_msg)
+    assert NATIVE_ASK_TOOL_CONTRACT in build_agy_prompt(dummy_msg)
+    assert NATIVE_ASK_TOOL_CONTRACT in build_claude_prompt(dummy_msg)
+    assert NATIVE_ASK_TOOL_CONTRACT in build_codex_prompt(dummy_msg)
+
+    # Full driver prompt MUST NOT contain NATIVE_ASK_TOOL_CONTRACT
+    full_driver_prompt = _build_full_execution_prompt(dummy_msg, delimiters=None)
+    assert NATIVE_ASK_TOOL_CONTRACT not in full_driver_prompt

--- a/tests/ai_agent_bridge/test_ask_contract.py
+++ b/tests/ai_agent_bridge/test_ask_contract.py
@@ -122,7 +122,7 @@ def test_every_response_provenance_shape_has_required_fields(harness: str) -> No
 
 
 def test_native_ask_tool_contract_present_in_ask_mode_and_absent_otherwise() -> None:
-    """Native ask prompt generators include NATIVE_ASK_TOOL_CONTRACT; full drivers do not (#5893)."""
+    """Native grok ask prompt includes NATIVE_ASK_TOOL_CONTRACT when not review-provisioned; absent on review-provisioned, reverted builders, and full drivers (#5893)."""
     from ai_agent_bridge._ask_contract import NATIVE_ASK_TOOL_CONTRACT
     from ai_agent_bridge._grok_build import _build_grok_build_prompt
     from ai_agent_bridge._prompts import (
@@ -134,12 +134,19 @@ def test_native_ask_tool_contract_present_in_ask_mode_and_absent_otherwise() -> 
 
     dummy_msg = {"from": "user", "task_id": "test-1", "type": "query", "content": "Hello", "data": None}
 
-    # Ask-mode prompts MUST contain NATIVE_ASK_TOOL_CONTRACT
-    assert NATIVE_ASK_TOOL_CONTRACT in _build_grok_build_prompt(dummy_msg)
-    assert NATIVE_ASK_TOOL_CONTRACT in build_agy_prompt(dummy_msg)
-    assert NATIVE_ASK_TOOL_CONTRACT in build_claude_prompt(dummy_msg)
-    assert NATIVE_ASK_TOOL_CONTRACT in build_codex_prompt(dummy_msg)
+    # Present ONLY on native grok ask path without a provisioned review worktree
+    assert NATIVE_ASK_TOOL_CONTRACT in _build_grok_build_prompt(dummy_msg, review_worktree_provisioned=False)
 
-    # Full driver prompt MUST NOT contain NATIVE_ASK_TOOL_CONTRACT
+    # ABSENT on grok review-provisioned path
+    assert NATIVE_ASK_TOOL_CONTRACT not in _build_grok_build_prompt(
+        dummy_msg, review=True, review_worktree_provisioned=True
+    )
+
+    # ABSENT in the three reverted builders
+    assert NATIVE_ASK_TOOL_CONTRACT not in build_agy_prompt(dummy_msg)
+    assert NATIVE_ASK_TOOL_CONTRACT not in build_claude_prompt(dummy_msg)
+    assert NATIVE_ASK_TOOL_CONTRACT not in build_codex_prompt(dummy_msg)
+
+    # ABSENT in full driver prompt
     full_driver_prompt = _build_full_execution_prompt(dummy_msg, delimiters=None)
     assert NATIVE_ASK_TOOL_CONTRACT not in full_driver_prompt

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -491,7 +491,7 @@ def test_watchdog_refires_dead_worker_without_clean_terminal_once(bridge_db, mon
             "agent": "grok",
             "harness": "grok",
             "model": "grok-3",
-            "started_at": "2026-07-27T00:00:00+00:00",
+            "started_at": lifecycle._now_iso(),
         },
     )
 
@@ -504,7 +504,7 @@ def test_watchdog_refires_dead_worker_without_clean_terminal_once(bridge_db, mon
     re_fire_mock.assert_called_once()
     meta = lifecycle._ask_metadata(lifecycle.fetch_ask_message(message_id, "grok"))
     assert meta.get("auto_retried") is True
-    assert meta.get("auto-retried") is True
+    assert "auto-retried" not in meta
 
 
 def test_watchdog_ignores_clean_terminal_records(bridge_db, monkeypatch, tmp_path):
@@ -520,7 +520,7 @@ def test_watchdog_ignores_clean_terminal_records(bridge_db, monkeypatch, tmp_pat
             "agent": "grok",
             "harness": "grok",
             "model": "grok-3",
-            "started_at": "2026-07-27T00:00:00+00:00",
+            "started_at": lifecycle._now_iso(),
         },
     )
     lifecycle._atomic_write_json(
@@ -529,7 +529,7 @@ def test_watchdog_ignores_clean_terminal_records(bridge_db, monkeypatch, tmp_pat
             "rc_or_signal": 0,
             "stage": "success",
             "stderr_tail": "",
-            "ended_at": "2026-07-27T00:01:00+00:00",
+            "ended_at": lifecycle._now_iso(),
         },
     )
 
@@ -543,7 +543,7 @@ def test_watchdog_ignores_clean_terminal_records(bridge_db, monkeypatch, tmp_pat
 
 
 def test_watchdog_ignores_already_retried_asks(bridge_db, monkeypatch, tmp_path):
-    """An ask that was already auto-retried must NOT be retried again by watchdog (#5893)."""
+    """An ask that was already auto-retried (accepting kebab-case on read) must NOT be retried again (#5893)."""
     message_id = _send_ask("task-watchdog-retried", target="grok")
     monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
     state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-retried"
@@ -555,7 +555,7 @@ def test_watchdog_ignores_already_retried_asks(bridge_db, monkeypatch, tmp_path)
             "agent": "grok",
             "harness": "grok",
             "model": "grok-3",
-            "started_at": "2026-07-27T00:00:00+00:00",
+            "started_at": lifecycle._now_iso(),
         },
     )
 
@@ -563,7 +563,7 @@ def test_watchdog_ignores_already_retried_asks(bridge_db, monkeypatch, tmp_path)
     try:
         conn.execute(
             "UPDATE messages SET data = ? WHERE id = ?",
-            (json.dumps({"auto_retried": True, "auto-retried": True}), message_id),
+            (json.dumps({"auto-retried": True}), message_id),
         )
         conn.commit()
     finally:
@@ -576,6 +576,56 @@ def test_watchdog_ignores_already_retried_asks(bridge_db, monkeypatch, tmp_path)
 
     assert retried == []
     re_fire_mock.assert_not_called()
+
+
+def test_watchdog_ignores_stale_launch_records(bridge_db, monkeypatch, tmp_path):
+    """Launch records older than 2x hard timeout window (1800s) are NOT re-fired by watchdog (#5893)."""
+    from datetime import UTC, datetime, timedelta
+
+    message_id = _send_ask("task-watchdog-stale", target="grok")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-stale"
+    stale_timestamp = (datetime.now(UTC) - timedelta(seconds=3600)).isoformat()
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "grok",
+            "harness": "grok",
+            "model": "grok-3",
+            "started_at": stale_timestamp,
+        },
+    )
+
+    assert lifecycle.should_auto_retry_ask(message_id) is False
+    re_fire_mock = Mock()
+    monkeypatch.setattr(lifecycle, "launch_background_ask", re_fire_mock)
+    assert lifecycle.run_ask_watchdog(message_id) == []
+    re_fire_mock.assert_not_called()
+
+
+def test_watchdog_retries_fresh_launch_records(bridge_db, monkeypatch, tmp_path):
+    """Launch records within 2x hard timeout window (1800s) ARE retried by watchdog (#5893)."""
+    from datetime import UTC, datetime, timedelta
+
+    message_id = _send_ask("task-watchdog-fresh", target="grok")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-fresh"
+    fresh_timestamp = (datetime.now(UTC) - timedelta(seconds=100)).isoformat()
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "grok",
+            "harness": "grok",
+            "model": "grok-3",
+            "started_at": fresh_timestamp,
+        },
+    )
+
+    assert lifecycle.should_auto_retry_ask(message_id) is True
 
 
 def test_cancel_and_retell_native_grok_permission_cancelled(bridge_db, monkeypatch):
@@ -644,3 +694,17 @@ def test_cancel_and_retell_composes_with_watchdog_within_bound(bridge_db, monkey
 
     msg = lifecycle.fetch_ask_message(message_id, "grok")
     assert _grok_build._can_cancel_retry(msg) is False
+
+
+def test_asks_cli_watchdog_flag(bridge_db, monkeypatch, capsys):
+    """asks --watchdog executes watchdog and lists asks."""
+    from ai_agent_bridge import _cli
+
+    watchdog_mock = Mock(return_value=[])
+    monkeypatch.setattr("ai_agent_bridge._ask_lifecycle.run_ask_watchdog", watchdog_mock)
+
+    args = _cli._build_parser().parse_args(["asks", "--watchdog"])
+    _cli._dispatch_command(args)
+
+    watchdog_mock.assert_called_once()
+    assert "Watchdog run complete" in capsys.readouterr().out

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -834,3 +834,36 @@ def test_asks_cli_watchdog_flag(bridge_db, monkeypatch, capsys):
 
     watchdog_mock.assert_called_once()
     assert "Watchdog run complete" in capsys.readouterr().out
+
+
+def test_re_fire_ask_inner_claim_admits_exactly_one_caller(bridge_db, monkeypatch, tmp_path):
+    """The once-only enforcement point under concurrency is the O_EXCL claim INSIDE
+    _re_fire_ask: two callers that both already passed should_auto_retry_ask must
+    resolve to exactly one live re-fire. (r3 review mutation check showed the
+    pre-created-claim test only covers the outer should_auto_retry_ask decline —
+    removing the inner claim left it green.)"""
+    message_id = _send_ask("task-claim-inner", target="grok")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-claim-inner"
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "grok",
+            "harness": "grok",
+            "model": "grok-3",
+            "started_at": "2026-07-27T00:00:00+00:00",
+        },
+    )
+    launches: list[int] = []
+    monkeypatch.setattr(
+        lifecycle, "launch_background_ask", lambda mid, target, options: launches.append(mid)
+    )
+
+    first = lifecycle._re_fire_ask(message_id)
+    second = lifecycle._re_fire_ask(message_id)
+
+    assert first is True
+    assert second is False, "second concurrent-style caller must lose the O_EXCL claim"
+    assert launches == [message_id], "exactly one live re-fire despite two callers"

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -476,3 +476,171 @@ def test_background_ask_reply_remains_unacked_for_requester(bridge_db, monkeypat
         assert reply_row[3] == "claude-infra"
     finally:
         conn.close()
+
+
+def test_watchdog_refires_dead_worker_without_clean_terminal_once(bridge_db, monkeypatch, tmp_path):
+    """A dead background ask worker with no reply and no clean terminal gets auto-retried once (#5893)."""
+    message_id = _send_ask("task-watchdog-1", target="grok")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-1"
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "grok",
+            "harness": "grok",
+            "model": "grok-3",
+            "started_at": "2026-07-27T00:00:00+00:00",
+        },
+    )
+
+    re_fire_mock = Mock(return_value=1234)
+    monkeypatch.setattr(lifecycle, "launch_background_ask", re_fire_mock)
+
+    retried = lifecycle.run_ask_watchdog(message_id)
+
+    assert retried == [message_id]
+    re_fire_mock.assert_called_once()
+    meta = lifecycle._ask_metadata(lifecycle.fetch_ask_message(message_id, "grok"))
+    assert meta.get("auto_retried") is True
+    assert meta.get("auto-retried") is True
+
+
+def test_watchdog_ignores_clean_terminal_records(bridge_db, monkeypatch, tmp_path):
+    """Clean terminal records (rc=0, stage=success) are NOT re-fired by watchdog (#5893)."""
+    message_id = _send_ask("task-watchdog-clean", target="grok")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-clean"
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "grok",
+            "harness": "grok",
+            "model": "grok-3",
+            "started_at": "2026-07-27T00:00:00+00:00",
+        },
+    )
+    lifecycle._atomic_write_json(
+        state_dir / "terminal.json",
+        {
+            "rc_or_signal": 0,
+            "stage": "success",
+            "stderr_tail": "",
+            "ended_at": "2026-07-27T00:01:00+00:00",
+        },
+    )
+
+    re_fire_mock = Mock()
+    monkeypatch.setattr(lifecycle, "launch_background_ask", re_fire_mock)
+
+    retried = lifecycle.run_ask_watchdog(message_id)
+
+    assert retried == []
+    re_fire_mock.assert_not_called()
+
+
+def test_watchdog_ignores_already_retried_asks(bridge_db, monkeypatch, tmp_path):
+    """An ask that was already auto-retried must NOT be retried again by watchdog (#5893)."""
+    message_id = _send_ask("task-watchdog-retried", target="grok")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-retried"
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "grok",
+            "harness": "grok",
+            "model": "grok-3",
+            "started_at": "2026-07-27T00:00:00+00:00",
+        },
+    )
+
+    conn = get_db()
+    try:
+        conn.execute(
+            "UPDATE messages SET data = ? WHERE id = ?",
+            (json.dumps({"auto_retried": True, "auto-retried": True}), message_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    re_fire_mock = Mock()
+    monkeypatch.setattr(lifecycle, "launch_background_ask", re_fire_mock)
+
+    retried = lifecycle.run_ask_watchdog(message_id)
+
+    assert retried == []
+    re_fire_mock.assert_not_called()
+
+
+def test_cancel_and_retell_native_grok_permission_cancelled(bridge_db, monkeypatch):
+    """A native Grok turn ending in permission_cancelled auto-retries once with refusal reason (#5893)."""
+    from ai_agent_bridge import _grok_build
+
+    message_id = _send_ask("task-cancel-retell", target="grok")
+
+    mock_invoke_1 = Mock(ok=True, response="I tried running a shell command.", model="grok-3", effort="medium", session_id="session-123")
+    mock_invoke_2 = Mock(ok=True, response="Answer based on file content only.", model="grok-3", effort="medium", session_id="session-123")
+
+    invokes = [mock_invoke_1, mock_invoke_2]
+    prompts_captured = []
+
+    def fake_invoke(*args, **kwargs):
+        prompts_captured.append(args[1])
+        return invokes.pop(0)
+
+    monkeypatch.setattr(_grok_build.agent_runner, "invoke", fake_invoke)
+    monkeypatch.setattr(
+        _grok_build,
+        "_native_grok_turn_status",
+        Mock(
+            side_effect=[
+                {"outcome": "cancelled", "cancellation_category": "permission_cancelled"},
+                {"outcome": "completed", "cancellation_category": None},
+            ]
+        ),
+    )
+
+    _grok_build.process_for_grok_build(message_id)
+
+    assert len(prompts_captured) == 2
+    assert "[Previous turn cancelled by permission policy]: Tool call permission cancelled" in prompts_captured[1]
+
+    conn = get_db()
+    try:
+        row = conn.execute("SELECT data FROM messages WHERE message_type = 'response' AND task_id = 'task-cancel-retell'").fetchone()
+        assert row is not None
+        meta = json.loads(row[0])
+        assert meta.get("cancel_retried") is True
+    finally:
+        conn.close()
+
+
+def test_cancel_and_retell_composes_with_watchdog_within_bound(bridge_db, monkeypatch, tmp_path):
+    """Total automatic re-fires for one ask never exceed MAX_TOTAL_ASK_RETRIES = 2 (#5893)."""
+    from ai_agent_bridge import _grok_build
+    from ai_agent_bridge._ask_contract import MAX_TOTAL_ASK_RETRIES
+
+    assert MAX_TOTAL_ASK_RETRIES == 2
+
+    message_id = _send_ask("task-bound", target="grok")
+
+    conn = get_db()
+    try:
+        conn.execute(
+            "UPDATE messages SET data = ? WHERE id = ?",
+            (json.dumps({"total_retry_count": 2, "auto_retried": True}), message_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert lifecycle.should_auto_retry_ask(message_id) is False
+
+    msg = lifecycle.fetch_ask_message(message_id, "grok")
+    assert _grok_build._can_cancel_retry(msg) is False

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -63,7 +63,12 @@ def test_background_ask_sends_immediately_and_mocks_detached_spawn(bridge_db, mo
     spawn.assert_called_once_with(
         message_id,
         "agy",
-        {"new_session": False, "no_timeout": False, "review": False},
+        {
+            "new_session": False,
+            "no_timeout": False,
+            "review": False,
+            "timeout_seconds": 1800,
+        },
     )
 
 
@@ -579,13 +584,13 @@ def test_watchdog_ignores_already_retried_asks(bridge_db, monkeypatch, tmp_path)
 
 
 def test_watchdog_ignores_stale_launch_records(bridge_db, monkeypatch, tmp_path):
-    """Launch records older than 2x hard timeout window (1800s) are NOT re-fired by watchdog (#5893)."""
+    """Launch records older than 2x recorded hard timeout window are NOT re-fired by watchdog (#5893)."""
     from datetime import UTC, datetime, timedelta
 
     message_id = _send_ask("task-watchdog-stale", target="grok")
     monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
     state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-stale"
-    stale_timestamp = (datetime.now(UTC) - timedelta(seconds=3600)).isoformat()
+    stale_timestamp = (datetime.now(UTC) - timedelta(seconds=3700)).isoformat()
     lifecycle._atomic_write_json(
         state_dir / "launch.json",
         {
@@ -595,6 +600,7 @@ def test_watchdog_ignores_stale_launch_records(bridge_db, monkeypatch, tmp_path)
             "harness": "grok",
             "model": "grok-3",
             "started_at": stale_timestamp,
+            "timeout_seconds": 1800,
         },
     )
 
@@ -606,7 +612,7 @@ def test_watchdog_ignores_stale_launch_records(bridge_db, monkeypatch, tmp_path)
 
 
 def test_watchdog_retries_fresh_launch_records(bridge_db, monkeypatch, tmp_path):
-    """Launch records within 2x hard timeout window (1800s) ARE retried by watchdog (#5893)."""
+    """Launch records within 2x hard timeout window ARE retried by watchdog (#5893)."""
     from datetime import UTC, datetime, timedelta
 
     message_id = _send_ask("task-watchdog-fresh", target="grok")
@@ -622,15 +628,135 @@ def test_watchdog_retries_fresh_launch_records(bridge_db, monkeypatch, tmp_path)
             "harness": "grok",
             "model": "grok-3",
             "started_at": fresh_timestamp,
+            "timeout_seconds": 1800,
         },
     )
 
     assert lifecycle.should_auto_retry_ask(message_id) is True
 
 
-def test_cancel_and_retell_native_grok_permission_cancelled(bridge_db, monkeypatch):
+def test_watchdog_slow_lane_ask_dead_at_minute_35_is_eligible(bridge_db, monkeypatch, tmp_path):
+    """A slow-lane ask dead at minute 35 (2100s) with recorded 1800s timeout IS eligible (2x1800=3600s window)."""
+    from datetime import UTC, datetime, timedelta
+
+    message_id = _send_ask("task-watchdog-slow-lane", target="agy")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-slow-lane"
+    min35_timestamp = (datetime.now(UTC) - timedelta(seconds=2100)).isoformat()
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "agy",
+            "harness": "agy",
+            "model": "gemini-3.6-pro",
+            "started_at": min35_timestamp,
+            "timeout_seconds": 1800,
+            "no_timeout": False,
+        },
+    )
+
+    assert lifecycle.should_auto_retry_ask(message_id) is True
+
+
+def test_watchdog_legacy_record_uses_fallback(bridge_db, monkeypatch, tmp_path):
+    """Legacy launch record lacking timeout_seconds falls back to 2x1800 = 3600s window."""
+    from datetime import UTC, datetime, timedelta
+
+    message_id = _send_ask("task-watchdog-legacy", target="grok")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-legacy"
+
+    # Eligible at minute 35 (2100s < 3600s)
+    min35_timestamp = (datetime.now(UTC) - timedelta(seconds=2100)).isoformat()
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "grok",
+            "harness": "grok",
+            "model": "grok-3",
+            "started_at": min35_timestamp,
+        },
+    )
+    assert lifecycle.should_auto_retry_ask(message_id) is True
+
+    # Stale at minute 62 (3700s > 3600s)
+    min62_timestamp = (datetime.now(UTC) - timedelta(seconds=3700)).isoformat()
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "grok",
+            "harness": "grok",
+            "model": "grok-3",
+            "started_at": min62_timestamp,
+        },
+    )
+    assert lifecycle.should_auto_retry_ask(message_id) is False
+
+
+def test_watchdog_stale_beyond_own_window_not_eligible(bridge_db, monkeypatch, tmp_path):
+    """An ask with recorded timeout of 900s is NOT eligible at 1900s (> 2x900 = 1800s window)."""
+    from datetime import UTC, datetime, timedelta
+
+    message_id = _send_ask("task-watchdog-stale-window", target="claude")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-watchdog-stale-window"
+    stale_timestamp = (datetime.now(UTC) - timedelta(seconds=1900)).isoformat()
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "claude",
+            "harness": "claude",
+            "model": "claude-3-5-sonnet",
+            "started_at": stale_timestamp,
+            "timeout_seconds": 900,
+        },
+    )
+
+    assert lifecycle.should_auto_retry_ask(message_id) is False
+
+
+def test_atomic_retry_claim_prevents_concurrent_refire(bridge_db, monkeypatch, tmp_path):
+    """Atomic O_CREAT|O_EXCL retry-claim file ensures exactly one claim succeeds (#5893 item 3)."""
+    message_id = _send_ask("task-atomic-claim", target="grok")
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    state_dir = tmp_path / "batch_state" / "asks" / "task-atomic-claim"
+    lifecycle._atomic_write_json(
+        state_dir / "launch.json",
+        {
+            "message_id": message_id,
+            "pid": 999_999_999,
+            "agent": "grok",
+            "harness": "grok",
+            "model": "grok-3",
+            "started_at": lifecycle._now_iso(),
+            "timeout_seconds": 1800,
+        },
+    )
+
+    # First claim succeeds
+    assert lifecycle.claim_ask_retry(message_id) is True
+    # Second claim fails
+    assert lifecycle.claim_ask_retry(message_id) is False
+
+    # Once claimed, should_auto_retry_ask and _re_fire_ask decline
+    assert lifecycle.should_auto_retry_ask(message_id) is False
+    assert lifecycle._re_fire_ask(message_id) is False
+
+
+def test_cancel_and_retell_native_grok_permission_cancelled(bridge_db, monkeypatch, tmp_path):
     """A native Grok turn ending in permission_cancelled auto-retries once with refusal reason (#5893)."""
     from ai_agent_bridge import _grok_build
+
+    monkeypatch.setattr(_grok_build, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
 
     message_id = _send_ask("task-cancel-retell", target="grok")
 

--- a/tests/ai_agent_bridge/test_inbox_watch.py
+++ b/tests/ai_agent_bridge/test_inbox_watch.py
@@ -171,3 +171,22 @@ def test_inbox_watcher_tick_invokes_ask_watchdog(isolate_db: Path, tmp_path: Pat
         watchdog_mock.assert_called_once()
     finally:
         patch.stopall()
+
+
+def test_inbox_watcher_watchdog_failure_warns_and_continues(isolate_db: Path, tmp_path: Path, capsys: pytest.CaptureFixture):
+    """A raising ask watchdog emits a stderr warning and does not crash the watcher loop (#5893)."""
+    watchdog_mock = patch("ai_agent_bridge._ask_lifecycle.run_ask_watchdog", side_effect=RuntimeError("watchdog exploded")).start()
+    try:
+        cursor = _inbox_watch.run_watcher(
+            "grok",
+            db_path=isolate_db,
+            lock_dir=tmp_path / "locks",
+            output=io.StringIO(),
+            once=True,
+        )
+        assert cursor == 0
+        watchdog_mock.assert_called_once()
+        stderr = capsys.readouterr().err
+        assert "⚠️  inbox watcher: ask watchdog failed: RuntimeError: watchdog exploded" in stderr
+    finally:
+        patch.stopall()

--- a/tests/ai_agent_bridge/test_inbox_watch.py
+++ b/tests/ai_agent_bridge/test_inbox_watch.py
@@ -155,3 +155,19 @@ def test_cursor_does_not_advance_when_stdout_flush_fails(isolate_db: Path):
     with pytest.raises(OSError, match="stdout closed"):
         last_seen = _inbox_watch.emit_notifications(events, last_seen=last_seen, output=BrokenOutput())
     assert last_seen == 0
+
+
+def test_inbox_watcher_tick_invokes_ask_watchdog(isolate_db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The persistent inbox watcher loop invokes run_ask_watchdog on each tick (#5893)."""
+    watchdog_mock = patch("ai_agent_bridge._ask_lifecycle.run_ask_watchdog").start()
+    try:
+        _inbox_watch.run_watcher(
+            "grok",
+            db_path=isolate_db,
+            lock_dir=tmp_path / "locks",
+            output=io.StringIO(),
+            once=True,
+        )
+        watchdog_mock.assert_called_once()
+    finally:
+        patch.stopall()


### PR DESCRIPTION
Hardening wave for bridge asks (#5893 items 1–3):

1. **Retry-once watchdog (both harnesses):** Dead background ask workers with no reply and no clean terminal record get auto-retried once with `auto-retried` metadata.
2. **Native ask tool contract:** Native ask runner prepends tool contract line (`shell commands are unavailable in this mode; answer from attached material and file reads.`) to ask-mode prompts.
3. **Cancel-and-retell:** Native turns ending in `permission_cancelled` auto-retry once with refusal reason appended to prompt and marked in reply metadata.
4. Total automatic re-fires for a single ask are bounded to `MAX_TOTAL_ASK_RETRIES = 2`.

Refs #5893 (item 4 untouched pending operator ruling).