### PR TITLE
feat(atlas): package curated v5 teacher-lesson admission locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,6 +419,11 @@ data/lexicon/grow_candidates.json
 data/lexicon/grow_needs_review.json
 data/lexicon/needs-review-triage.json
 data/lexicon/needs-review-triage-summary.md
+# Full Alona v5 admission evidence is regenerated locally from the private
+# curated JSONL.  Keep the recipe and fixture in git, not the 1,029-row output.
+data/lexicon/alona-v5-atlas-admission-seed.json
+data/lexicon/alona-v5-practice-seed.json
+data/lexicon/alona-v5-atlas-admission-report.json
 # Ohoiko corpus intake full source inventory (~31 MB, 111,200 rows): deterministic,
 # regenerable output of committed code over the private corpus (#4223). It does NOT
 # belong in git history — regenerate on demand into this path (main checkout only):

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,22 @@
 PYTHON ?= .venv/bin/python
 
-.PHONY: atlas atlas-publish practice-deck practice-deck-publish open-dataset open-dataset-publish
+ALONA_V5_INPUT ?= .claude/atlas-epic/plans/alona-truth/v5-curated-with-provenance.jsonl
+ALONA_V5_DIR ?= data/lexicon
+ALONA_V5_PUBLIC_SEED := $(ALONA_V5_DIR)/alona-v5-atlas-admission-seed.json
+ALONA_V5_CANDIDATES := $(ALONA_V5_DIR)/grow_candidates.json
+ALONA_V5_PRACTICE_SEED := $(ALONA_V5_DIR)/alona-v5-practice-seed.json
+ALONA_V5_REPORT := $(ALONA_V5_DIR)/alona-v5-atlas-admission-report.json
+
+.PHONY: alona-v5-admit atlas atlas-publish practice-deck practice-deck-publish open-dataset open-dataset-publish
+alona-v5-admit:
+	@test -f "$(ALONA_V5_INPUT)" || { echo "missing private Alona v5 input: $(ALONA_V5_INPUT)" >&2; exit 2; }
+	$(PYTHON) -m scripts.lexicon.alona_v5_atlas_admission --input "$(ALONA_V5_INPUT)" --public-seed-out "$(ALONA_V5_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --candidates-out "$(ALONA_V5_CANDIDATES)"
+	$(PYTHON) -m scripts.lexicon.promote_grow_candidates --candidates "$(ALONA_V5_CANDIDATES)" --write
+	$(PYTHON) scripts/lexicon/enrich_manifest.py --write
+	$(PYTHON) -m scripts.lexicon.alona_v5_atlas_admission --input "$(ALONA_V5_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --practice-seed-out "$(ALONA_V5_PRACTICE_SEED)" --report-out "$(ALONA_V5_REPORT)"
+	npm --prefix site run atlas:build-db
+	$(PYTHON) scripts/audit/generate_practice_deck.py --practice-seed "$(ALONA_V5_PRACTICE_SEED)"
+
 atlas:
 	$(PYTHON) -m scripts.lexicon.build_data_manifest
 	$(PYTHON) scripts/lexicon/enrich_manifest.py

--- a/scripts/atlas/atlas_db.py
+++ b/scripts/atlas/atlas_db.py
@@ -284,6 +284,9 @@ def classify_entry_type(entry: dict[str, Any]) -> str:
     Multiword defaults to multiword_term (entry-model tie-breaker); idiom/proverb
     promotion happens later when phraseological evidence is attached.
     """
+    explicit_type = str(entry.get("entry_type") or "").strip()
+    if explicit_type in ARTICLE_ENTRY_TYPES:
+        return explicit_type
     lemma = str(entry.get("lemma") or "").strip()
     if " " in lemma:
         return "multiword_term"

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1032,7 +1032,7 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
     paradigm = _paradigm(entry)
     if not _verify_paradigm(lemma_plain, pos, paradigm, verifier):
         paradigm = {"cases": {}}
-    return {
+    lexeme: dict[str, Any] = {
         "lemmaId": _stable_lemma_id(entry),
         "lemma": lemma,
         "lemmaPlain": lemma_plain,
@@ -1047,6 +1047,14 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
         "paradigm": paradigm,
         "semanticBucket": _clean_text(entry.get("semantic_bucket")),
     }
+    example = entry.get("practice_example")
+    if isinstance(example, dict):
+        text = _clean_text(example.get("text"))
+        provenance = example.get("provenance")
+        if text and isinstance(provenance, dict):
+            lexeme["example"] = text
+            lexeme["exampleProvenance"] = provenance
+    return lexeme
 
 
 def _candidate_rule_id(candidate: dict[str, Any], case_name: str) -> str | None:
@@ -2863,6 +2871,91 @@ def read_manifest(path: Path) -> list[dict[str, Any]]:
     return [entry for entry in entries if isinstance(entry, dict)]
 
 
+def read_practice_seed(path: Path) -> list[dict[str, Any]]:
+    """Read a reviewed practice admission overlay.
+
+    The source Atlas entry remains authoritative for learner-facing lexical
+    metadata.  A seed can only admit an already-public Atlas slug and attach a
+    source-backed example; it cannot create a second Atlas entry or fabricate
+    a CEFR level.
+    """
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema") != "alona-v5-practice-seed-v1":
+        raise ValueError(f"unsupported practice seed schema: {path}")
+    entries = payload.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError(f"practice seed entries must be a nonempty list: {path}")
+
+    validated: list[dict[str, Any]] = []
+    for index, row in enumerate(entries):
+        if not isinstance(row, dict):
+            raise ValueError(f"practice seed entries[{index}] must be an object: {path}")
+        lemma = _clean_text(row.get("lemma"))
+        slug = _clean_text(row.get("slug"))
+        cefr = _normalize_cefr(row.get("cefr"))
+        example = _clean_text(row.get("example"))
+        provenance = row.get("provenance")
+        if not lemma or not slug or not cefr or not example or not isinstance(provenance, dict):
+            raise ValueError(
+                f"practice seed entries[{index}] requires lemma, slug, CEFR, example, and provenance: {path}"
+            )
+        if row.get("sentenceStatus") != "ok":
+            raise ValueError(f"practice seed entries[{index}] must retain sentenceStatus=ok: {path}")
+        if _clean_text(provenance.get("source_file")) is None or _clean_text(provenance.get("credit")) is None:
+            raise ValueError(f"practice seed entries[{index}] provenance lacks source_file or credit: {path}")
+        validated.append(row)
+    return validated
+
+
+def merge_practice_seed_entries(
+    entries: list[dict[str, Any]],
+    seed_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Explicitly admit reviewed seed rows without changing Atlas metadata."""
+    by_slug = {
+        slug: index
+        for index, entry in enumerate(entries)
+        if (slug := _clean_text(entry.get("url_slug"))) is not None
+    }
+    merged = list(entries)
+    applied_slugs: set[str] = set()
+    for seed in seed_rows:
+        slug = str(seed["slug"])
+        target_index = by_slug.get(slug)
+        if target_index is None:
+            raise ValueError(f"practice seed slug is not a public Atlas entry: {slug}")
+        target = merged[target_index]
+        if _plain(str(target.get("lemma") or "")) != _plain(str(seed["lemma"])):
+            raise ValueError(f"practice seed lemma does not match Atlas slug {slug}")
+        atlas_cefr = _cefr_level(target)
+        if atlas_cefr is None:
+            raise ValueError(f"practice seed Atlas entry has no CEFR level: {slug}")
+        if atlas_cefr != _normalize_cefr(seed.get("cefr")):
+            raise ValueError(f"practice seed CEFR differs from Atlas entry for {slug}")
+
+        # Several source-backed seed rows may attest one canonical Atlas route.
+        # Validate every row above, but do not fabricate multiple cards for one
+        # lexical item; the earliest seed-row example is deterministic.
+        if slug in applied_slugs:
+            continue
+        applied_slugs.add(slug)
+
+        admission = target.get("surface_admission")
+        merged_admission = dict(admission) if isinstance(admission, dict) else {}
+        merged_admission[SURFACE_CLOZE] = bool(merged_admission.get(SURFACE_CLOZE))
+        merged_admission["practice"] = True
+        merged[target_index] = {
+            **target,
+            "surface_admission": merged_admission,
+            "practice_example": {
+                "text": seed["example"],
+                "provenance": seed["provenance"],
+                "seedRow": seed.get("seedRow"),
+            },
+        }
+    return merged
+
+
 def read_atlas_db(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         raise FileNotFoundError(f"{path} not found; run npm --prefix site run atlas:build-db")
@@ -3127,6 +3220,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS)
     parser.add_argument("--paronym-pairs", type=Path, default=DEFAULT_PARONYM_PAIRS)
     parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
+    parser.add_argument(
+        "--practice-seed",
+        type=Path,
+        help="Reviewed practice admission overlay; each row must already exist in Atlas.",
+    )
     parser.add_argument("--vesum-fixture", type=Path)
     parser.add_argument("--target", type=int, default=DEFAULT_TARGET)
     parser.add_argument("--raw-limit", type=int, default=DEFAULT_RAW_LIMIT)
@@ -3148,6 +3246,8 @@ def main(argv: list[str] | None = None) -> int:
         return run_broken_validator_fixtures()
 
     entries = read_manifest(args.manifest) if args.manifest else read_atlas_db(args.atlas_db)
+    if args.practice_seed:
+        entries = merge_practice_seed_entries(entries, read_practice_seed(args.practice_seed))
     allowlist = ReviewedSourceAllowlist.from_path(args.reviewed_allowlist)
     cloze_sources = read_cloze_sources(args.cloze_sources)
     heritage_pairs = read_heritage_pairs(args.heritage_pairs)

--- a/scripts/lexicon/alona_v5_atlas_admission.py
+++ b/scripts/lexicon/alona_v5_atlas_admission.py
@@ -1,0 +1,232 @@
+"""Prepare and verify the public Atlas + Practice admission for Alona v5.
+
+The operator-curated v5 JSONL is private task input. This command emits a
+public replay seed, derives only missing Atlas candidates through the existing
+grow promoter, and writes the Practice overlay only after the manifest has a
+real CEFR enrichment block. It never assigns CEFR itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.lexicon.build_data_manifest import _lemma_key, _slug_for_url
+from scripts.lexicon.grow_lexicon_from_content import _vesum_pos
+
+PRACTICE_SCHEMA = "alona-v5-practice-seed-v1"
+PUBLIC_SCHEMA = "alona-v5-atlas-admission-seed-v1"
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _canonical_lemma(value: str) -> str:
+    return value[:1].lower() + value[1:] if value else value
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not all(isinstance(row, dict) for row in rows):
+        raise ValueError(f"seed rows must be JSON objects: {path}")
+    return rows
+
+
+def normalize_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Project private/raw input to the stable public admission schema."""
+    normalized: list[dict[str, Any]] = []
+    for index, raw in enumerate(rows, start=1):
+        lemma = _text(raw.get("lemma") or raw.get("ua"))
+        gloss = _text(raw.get("gloss") or raw.get("en"))
+        if not lemma:
+            raise ValueError(f"seed row {index} has no lemma")
+        status = _text(raw.get("sentenceStatus") or raw.get("sentence_status")) or "no_hit"
+        row: dict[str, Any] = {
+            "seedRow": raw.get("seedRow") or raw.get("row") or index,
+            "lemma": _canonical_lemma(lemma),
+            "gloss": gloss,
+            "slug": _slug_for_url(_canonical_lemma(lemma)),
+            "sentenceStatus": status,
+        }
+        sentence = _text(raw.get("example") or raw.get("sentence"))
+        provenance = raw.get("provenance")
+        if sentence:
+            row["example"] = sentence
+        if isinstance(provenance, dict):
+            # The public projection never carries a path to the private source
+            # document; only corpus attestation provenance survives.
+            row["provenance"] = provenance
+        normalized.append(row)
+    return normalized
+
+
+def write_public_seed(rows: list[dict[str, Any]], path: Path) -> None:
+    payload = {
+        "schema": PUBLIC_SCHEMA,
+        "selectionNote": "All active Alona v5 curated rows; private document path omitted.",
+        "entries": rows,
+    }
+    _write_json(path, payload)
+
+
+def read_public_seed(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema") != PUBLIC_SCHEMA:
+        raise ValueError(f"unsupported Alona public seed schema: {path}")
+    entries = payload.get("entries")
+    if not isinstance(entries, list) or not all(isinstance(row, dict) for row in entries):
+        raise ValueError(f"public seed entries must be objects: {path}")
+    return entries
+
+
+def _entry_type(lemma: str) -> str:
+    words = lemma.split()
+    if len(words) < 2:
+        return "lemma"
+    # VESUM decides whether this is a verb-led expression; every other
+    # multiword head remains the entry-model's documented multiword term.
+    return "expression" if _vesum_pos(words[0]) == "verb" else "multiword_term"
+
+
+def _manifest_entries(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    entries = payload.get("entries") if isinstance(payload, dict) else None
+    if not isinstance(entries, list) or not all(isinstance(entry, dict) for entry in entries):
+        raise ValueError(f"manifest entries must be objects: {path}")
+    return entries
+
+
+def candidates_for_manifest(rows: list[dict[str, Any]], manifest_path: Path) -> dict[str, Any]:
+    manifest_entries = _manifest_entries(manifest_path)
+    existing = {_lemma_key(_text(entry.get("lemma"))) for entry in manifest_entries}
+    existing_slugs = {_text(entry.get("url_slug")) for entry in manifest_entries}
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in rows:
+        lemma = _text(row.get("lemma"))
+        key = _lemma_key(lemma)
+        if key in existing or _text(row.get("slug")) in existing_slugs or key in seen:
+            continue
+        seen.add(key)
+        candidates.append(
+            {
+                "lemma": lemma,
+                "gloss": _text(row.get("gloss")),
+                "pos": _vesum_pos(lemma),
+                "entry_type": _entry_type(lemma),
+                "primary_source": "alona_v5_curated_seed",
+            }
+        )
+    return {"auto_merge": candidates, "needs_review": []}
+
+
+def _cefr(entry: dict[str, Any]) -> tuple[str, str] | None:
+    enrichment = entry.get("enrichment")
+    value = enrichment.get("cefr") if isinstance(enrichment, dict) else None
+    level = _text(value.get("level")) if isinstance(value, dict) else _text(value)
+    if level not in {"A1", "A2", "B1", "B2", "C1", "C2"}:
+        return None
+    source = _text(value.get("source")) if isinstance(value, dict) else ""
+    return level, source or "existing manifest CEFR"
+
+
+def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    public_entries = [
+        entry
+        for entry in _manifest_entries(manifest_path)
+        if _text(entry.get("lemma")) and _text(entry.get("url_slug")) and entry.get("pos") != "grammar term"
+    ]
+    routes = {
+        _lemma_key(_text(entry.get("lemma"))): entry
+        for entry in public_entries
+    }
+    routes_by_slug = {_text(entry.get("url_slug")): entry for entry in public_entries}
+    atlas_failures: list[dict[str, Any]] = []
+    skipped_no_cefr: list[dict[str, Any]] = []
+    practice_rows: list[dict[str, Any]] = []
+    status_counts: Counter[str] = Counter()
+    cefr_sources: Counter[str] = Counter()
+    for row in rows:
+        lemma = _text(row.get("lemma"))
+        target = routes.get(_lemma_key(lemma)) or routes_by_slug.get(_text(row.get("slug")))
+        if target is None:
+            atlas_failures.append({"seedRow": row.get("seedRow"), "lemma": lemma, "reason": "missing_public_route"})
+            continue
+        status = _text(row.get("sentenceStatus"))
+        status_counts[status] += 1
+        if status != "ok":
+            continue
+        example = _text(row.get("example"))
+        provenance = row.get("provenance")
+        if not example or not isinstance(provenance, dict):
+            atlas_failures.append({"seedRow": row.get("seedRow"), "lemma": lemma, "reason": "ok_row_missing_attestation"})
+            continue
+        cefr = _cefr(target)
+        if cefr is None:
+            skipped_no_cefr.append({"seedRow": row.get("seedRow"), "lemma": lemma})
+            continue
+        level, source = cefr
+        cefr_sources[source] += 1
+        practice_rows.append({"seedRow": row.get("seedRow"), "lemma": _text(target.get("lemma")), "slug": _text(target.get("url_slug")), "cefr": level, "example": example, "provenance": provenance, "sentenceStatus": "ok"})
+    report = {
+        "schema": "alona-v5-atlas-admission-report-v1",
+        "counts": {
+            "active_seed_rows": len(rows), "unique_seed_lemmas": len({_lemma_key(_text(row.get("lemma"))) for row in rows}),
+            "public_atlas_rows": len(rows) - len(atlas_failures), "atlas_failures": len(atlas_failures),
+            "sentence_status": dict(sorted(status_counts.items())), "practice_admitted_rows": len(practice_rows),
+            "practice_skipped_no_cefr": len(skipped_no_cefr), "practice_cefr_sources": dict(sorted(cefr_sources.items())),
+        },
+        "atlas_failures": atlas_failures,
+        "practice_skipped_no_cefr": skipped_no_cefr,
+    }
+    seed = {"schema": PRACTICE_SCHEMA, "deckSlug": "alona-v5-full", "title": "Alona v5 curated practice admission", "selectionNote": "All sentence_status=ok rows whose public Atlas route has pipeline-derived CEFR. Recognition-first; no cloze targets.", "entries": practice_rows}
+    return seed, report
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="Raw v5 JSONL or public v5 seed JSON")
+    parser.add_argument("--public-seed-out", type=Path)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--candidates-out", type=Path)
+    parser.add_argument("--practice-seed-out", type=Path)
+    parser.add_argument("--report-out", type=Path)
+    args = parser.parse_args(argv)
+    rows = read_public_seed(args.input) if args.input.suffix == ".json" else normalize_rows(_read_jsonl(args.input))
+    if args.public_seed_out:
+        write_public_seed(rows, args.public_seed_out)
+    if args.candidates_out:
+        if not args.manifest:
+            parser.error("--candidates-out requires --manifest")
+        _write_json(args.candidates_out, candidates_for_manifest(rows, args.manifest))
+    if args.practice_seed_out or args.report_out:
+        if not args.manifest:
+            parser.error("practice/report output requires --manifest")
+        seed, report = prepare_practice_seed(rows, args.manifest)
+        if args.practice_seed_out:
+            _write_json(args.practice_seed_out, seed)
+        if args.report_out:
+            _write_json(args.report_out, report)
+        if report["atlas_failures"]:
+            print(f"Atlas admission has {len(report['atlas_failures'])} hard failure(s)", file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/alona_v5_atlas_admission.py
+++ b/scripts/lexicon/alona_v5_atlas_admission.py
@@ -22,6 +22,7 @@ if str(ROOT) not in sys.path:
 
 from scripts.lexicon.build_data_manifest import _lemma_key, _slug_for_url
 from scripts.lexicon.grow_lexicon_from_content import _vesum_pos
+from scripts.sync.promote_module import _write_atomically
 
 PRACTICE_SCHEMA = "alona-v5-practice-seed-v1"
 PUBLIC_SCHEMA = "alona-v5-atlas-admission-seed-v1"
@@ -194,8 +195,10 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    _write_atomically(
+        path,
+        (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8"),
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/lexicon/promote_grow_candidates.py
+++ b/scripts/lexicon/promote_grow_candidates.py
@@ -65,6 +65,10 @@ APPROVAL_LEDGER_KIND = "atlas_grow_promotion_ledger"
 NEEDS_REVIEW_LEDGER_KIND = "atlas_grow_needs_review_decisions"
 ALLOWED_LEDGER_DECISIONS = frozenset({"approve", "deferred", "reject"})
 _OPTIONAL_CANDIDATE_FIELDS = (
+    # A reviewed intake may explicitly classify a multiword expression. Keep
+    # that entry-model fact through promotion instead of flattening it into
+    # Atlas's legacy multiword fallback.
+    "entry_type",
     "heritage_status",
     "enrichment",
     "pronunciation",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,10 +1,14 @@
 {
-  "fingerprint": "a7c648c543c71b4760dd66e175ae08c538a74cb06750b57ebf214b0457c5fe2b",
+  "fingerprint": "344c2b5192fda27a1117876c9183b20588fc9fb50f300d2ad45d3c13459a552b",
   "inputs": {
     "lexicon_code": [
       {
         "path": "scripts/lexicon/__init__.py",
         "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      {
+        "path": "scripts/lexicon/alona_v5_atlas_admission.py",
+        "sha256": "d62089069184ac1b803280592a9bd08904112d7f80fba25a51372438391d3221"
       },
       {
         "path": "scripts/lexicon/anchor_curation_evidence.py",
@@ -172,7 +176,7 @@
       },
       {
         "path": "scripts/lexicon/promote_grow_candidates.py",
-        "sha256": "197d9a8c4791be86899a6b35357e97732bb58657222bc01e50598c92a2f6c5cf"
+        "sha256": "f6c2fb40fad518ea753023d9fdffba485ab56cdcac7cf1bce506a36e07f11f0b"
       },
       {
         "path": "scripts/lexicon/promote_teacher_lesson_intake.py",
@@ -219,6 +223,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 53
+    "lexicon_code_files": 54
   }
 }

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "344c2b5192fda27a1117876c9183b20588fc9fb50f300d2ad45d3c13459a552b",
+  "fingerprint": "2f4f0cbc51d552b3429212c1cfc99d66fc41d474a657ca9116b64d74784621fd",
   "inputs": {
     "lexicon_code": [
       {
@@ -8,7 +8,7 @@
       },
       {
         "path": "scripts/lexicon/alona_v5_atlas_admission.py",
-        "sha256": "d62089069184ac1b803280592a9bd08904112d7f80fba25a51372438391d3221"
+        "sha256": "5ac4de1968e4b2f3a4523f714f6922bb55d5e54ae232f7580141f79738d8ef14"
       },
       {
         "path": "scripts/lexicon/anchor_curation_evidence.py",

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -95,6 +95,8 @@ export interface PracticeLexeme {
   example?: string | null;
   /** English rendering of `example` (A1 scaffolding only). */
   exampleEn?: string | null;
+  /** Source metadata retained for reviewed static examples. */
+  exampleProvenance?: Record<string, unknown>;
 }
 
 export interface PracticeDeckEntry extends PracticeLexeme {

--- a/tests/fixtures/atlas/alona_v5_practice_seed.json
+++ b/tests/fixtures/atlas/alona_v5_practice_seed.json
@@ -1,0 +1,44 @@
+{
+  "schema": "alona-v5-practice-seed-v1",
+  "deckSlug": "alona-v5-fixture",
+  "title": "Alona v5 fixture practice admission",
+  "selectionNote": "Fixture-sized source-backed examples only.",
+  "entries": [
+    {
+      "seedRow": 1,
+      "lemma": "справедливий",
+      "slug": "справедливий",
+      "cefr": "A2",
+      "example": "Це справедливе рішення.",
+      "provenance": {
+        "source_file": "fixture-literary",
+        "credit": "Тестовий автор"
+      },
+      "sentenceStatus": "ok"
+    },
+    {
+      "seedRow": 2,
+      "lemma": "витирати",
+      "slug": "витирати",
+      "cefr": "A2",
+      "example": "Вона витирає стіл.",
+      "provenance": {
+        "source_file": "fixture-literary",
+        "credit": "Тестовий автор"
+      },
+      "sentenceStatus": "ok"
+    },
+    {
+      "seedRow": 3,
+      "lemma": "витерти",
+      "slug": "витерти",
+      "cefr": "B1",
+      "example": "Він витер дошку.",
+      "provenance": {
+        "source_file": "fixture-literary",
+        "credit": "Тестовий автор"
+      },
+      "sentenceStatus": "ok"
+    }
+  ]
+}

--- a/tests/test_alona_v5_atlas_admission.py
+++ b/tests/test_alona_v5_atlas_admission.py
@@ -1,0 +1,109 @@
+"""Alona v5 admission uses public Atlas facts rather than invented CEFR."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.lexicon import alona_v5_atlas_admission as admission
+
+
+def _manifest(path: Path, entries: list[dict[str, object]]) -> Path:
+    path.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def test_candidates_keep_explicit_verb_expression_type(tmp_path: Path, monkeypatch) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "відомий", "url_slug": "відомий", "pos": "adj"}],
+    )
+    monkeypatch.setattr(admission, "_vesum_pos", lambda word: "verb" if word == "виходити" else None)
+
+    candidates = admission.candidates_for_manifest(
+        [{"lemma": "виходити з ладу", "gloss": "to break down"}], manifest
+    )
+
+    assert candidates["auto_merge"] == [
+        {
+            "lemma": "виходити з ладу",
+            "gloss": "to break down",
+            "pos": None,
+            "entry_type": "expression",
+            "primary_source": "alona_v5_curated_seed",
+        }
+    ]
+
+
+def test_candidates_do_not_duplicate_an_existing_apostrophe_variant_route(tmp_path: Path) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [{"lemma": "з'ясувати", "url_slug": "з-ясувати", "pos": "verb"}],
+    )
+
+    candidates = admission.candidates_for_manifest(
+        [{"lemma": "з’ясувати", "gloss": "to find out", "slug": "з-ясувати"}], manifest
+    )
+
+    assert candidates == {"auto_merge": [], "needs_review": []}
+
+
+def test_normalize_rows_projects_private_v5_input_to_replayable_schema() -> None:
+    rows = admission.normalize_rows(
+        [
+            {
+                "row": 7,
+                "ua": "Вийти з ладу",
+                "en": "to break down",
+                "sentence": "Пристрій вийшов з ладу.",
+                "sentence_status": "ok",
+                "provenance": {"source_file": "ukrlib-example", "credit": "Автор"},
+                "private_source_path": ".claude/atlas-epic/plans/alona-truth/private.jsonl",
+            }
+        ]
+    )
+
+    assert rows == [
+        {
+            "seedRow": 7,
+            "lemma": "вийти з ладу",
+            "gloss": "to break down",
+            "slug": "вийти-з-ладу",
+            "sentenceStatus": "ok",
+            "example": "Пристрій вийшов з ладу.",
+            "provenance": {"source_file": "ukrlib-example", "credit": "Автор"},
+        }
+    ]
+
+
+def test_practice_seed_reports_no_hit_and_retains_duplicate_attestations(tmp_path: Path) -> None:
+    manifest = _manifest(
+        tmp_path / "manifest.json",
+        [
+            {"lemma": "відомий", "url_slug": "відомий", "pos": "adj", "enrichment": {"cefr": {"level": "A2", "source": "PULS"}}},
+            {"lemma": "рідкісний", "url_slug": "рідкісний", "pos": "adj", "enrichment": {"cefr": {"level": "B2", "source": "PULS"}}},
+            {"lemma": "неоцінений", "url_slug": "неоцінений", "pos": "adj"},
+        ],
+    )
+    provenance = {"source_file": "ukrlib-example", "credit": "Автор"}
+    rows = [
+        {"seedRow": 1, "lemma": "відомий", "sentenceStatus": "ok", "example": "Відомий приклад.", "provenance": provenance},
+        {"seedRow": 2, "lemma": "відомий", "sentenceStatus": "ok", "example": "Другий приклад.", "provenance": provenance},
+        {"seedRow": 3, "lemma": "рідкісний", "sentenceStatus": "no_hit"},
+        {"seedRow": 4, "lemma": "неоцінений", "sentenceStatus": "ok", "example": "Неоцінений приклад.", "provenance": provenance},
+    ]
+
+    seed, report = admission.prepare_practice_seed(rows, manifest)
+
+    assert len(seed["entries"]) == 2
+    assert report["counts"] == {
+        "active_seed_rows": 4,
+        "unique_seed_lemmas": 3,
+        "public_atlas_rows": 4,
+        "atlas_failures": 0,
+        "sentence_status": {"no_hit": 1, "ok": 3},
+        "practice_admitted_rows": 2,
+        "practice_skipped_no_cefr": 1,
+        "practice_cefr_sources": {"PULS": 2},
+    }
+    assert report["practice_skipped_no_cefr"] == [{"seedRow": 4, "lemma": "неоцінений"}]

--- a/tests/test_alona_v5_atlas_admission.py
+++ b/tests/test_alona_v5_atlas_admission.py
@@ -76,6 +76,24 @@ def test_normalize_rows_projects_private_v5_input_to_replayable_schema() -> None
     ]
 
 
+def test_write_json_uses_shared_atomic_write_helper(tmp_path: Path, monkeypatch) -> None:
+    output = tmp_path / "nested" / "seed.json"
+    observed: dict[str, object] = {}
+
+    def write_atomically(path: Path, content: bytes) -> None:
+        observed["path"] = path
+        observed["content"] = content
+
+    monkeypatch.setattr(admission, "_write_atomically", write_atomically)
+
+    admission._write_json(output, {"lemma": "відомий"})
+
+    assert observed == {
+        "path": output,
+        "content": b'{\n  "lemma": "\xd0\xb2\xd1\x96\xd0\xb4\xd0\xbe\xd0\xbc\xd0\xb8\xd0\xb9"\n}\n',
+    }
+
+
 def test_practice_seed_reports_no_hit_and_retains_duplicate_attestations(tmp_path: Path) -> None:
     manifest = _manifest(
         tmp_path / "manifest.json",

--- a/tests/test_atlas_db.py
+++ b/tests/test_atlas_db.py
@@ -82,6 +82,7 @@ def test_alias_helpers():
     assert atlas_db.unstressed("ро́звідка") == "розвідка"
     assert atlas_db.transliterate("розвідка") == "rozvidka"
     assert atlas_db.classify_entry_type({"lemma": "сліпа зона"}) == "multiword_term"
+    assert atlas_db.classify_entry_type({"lemma": "виходити з ладу", "entry_type": "expression"}) == "expression"
     assert atlas_db.classify_entry_type({"lemma": "розвідка"}) == "lemma"
 
 

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -23,10 +23,12 @@ from scripts.audit.generate_practice_deck import (
     apply_size_budgets,
     build_practice_shards,
     main,
+    merge_practice_seed_entries,
     read_cloze_sources,
     read_heritage_pairs,
     read_manifest,
     read_paronym_pairs,
+    read_practice_seed,
     validate_classify_item,
     validate_heritage_item,
     validate_heritage_pair,
@@ -44,11 +46,83 @@ VESUM = FIXTURES / "lexicon-practice-vesum.json"
 CLOZE_SOURCES = FIXTURES / "lexicon-practice-cloze-sources.json"
 HERITAGE_PAIRS = FIXTURES / "lexicon-practice-heritage-pairs.yaml"
 PARONYM_PAIRS = FIXTURES / "lexicon-practice-paronym-pairs.yaml"
+ALONA_V5_SEED = FIXTURES / "atlas" / "alona_v5_practice_seed.json"
 
 
 def test_default_target_preserves_committed_practice_surface() -> None:
     assert DEFAULT_TARGET >= 6000
     assert BuildConfig().target == DEFAULT_TARGET
+
+
+def test_alona_v5_seed_admits_existing_atlas_entries_with_provenance() -> None:
+    seed_rows = read_practice_seed(ALONA_V5_SEED)
+    assert len(seed_rows) == 3
+    assert {row["sentenceStatus"] for row in seed_rows} == {"ok"}
+
+    atlas_entries = [
+        {
+            "url_slug": row["slug"],
+            "lemma": row["lemma"],
+            "gloss": f"seed gloss {index}",
+            "enrichment": {"cefr": {"level": row["cefr"]}},
+            "primary_source": "source_inventory_grow",
+        }
+        for index, row in enumerate(seed_rows)
+    ]
+    merged = merge_practice_seed_entries(atlas_entries, seed_rows)
+    assert all(entry["surface_admission"]["practice"] is True for entry in merged)
+
+    shards = build_practice_shards(
+        merged,
+        ReviewedSourceAllowlist.from_payload([]),
+        JsonVesumVerifier.from_path(VESUM),
+        [],
+        BuildConfig(target=len(seed_rows), source_label="fixture"),
+        heritage_pairs=[],
+        paronym_pairs=[],
+        synonym_verdicts={"approved": [], "rejected": []},
+    )
+    indexed = {
+        item["lemmaId"]: item
+        for level in shards.values()
+        for item in level["index"]["items"]
+    }
+    lexemes = {
+        item["lemmaId"]: item
+        for level in shards.values()
+        for item in level["lexemes"]["lexemes"]
+    }
+    for row in seed_rows:
+        item = indexed[row["slug"]]
+        assert item["hasCloze"] is False
+        assert item["clozeIds"] == []
+        assert lexemes[row["slug"]]["example"] == row["example"]
+        assert lexemes[row["slug"]]["exampleProvenance"] == row["provenance"]
+
+
+def test_practice_seed_validates_duplicate_attestations_but_emits_one_route_example(tmp_path: Path) -> None:
+    seed_path = tmp_path / "seed.json"
+    provenance = {"source_file": "ukrlib-example", "credit": "Автор"}
+    seed_path.write_text(
+        json.dumps(
+            {
+                "schema": "alona-v5-practice-seed-v1",
+                "entries": [
+                    {"lemma": "слово", "slug": "слово", "cefr": "A1", "example": "Перший.", "provenance": provenance, "sentenceStatus": "ok"},
+                    {"lemma": "слово", "slug": "слово", "cefr": "A1", "example": "Другий.", "provenance": provenance, "sentenceStatus": "ok"},
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    merged = merge_practice_seed_entries(
+        [{"lemma": "слово", "url_slug": "слово", "enrichment": {"cefr": {"level": "A1"}}}],
+        read_practice_seed(seed_path),
+    )
+
+    assert merged[0]["practice_example"]["text"] == "Перший."
 
 
 def _build(config: BuildConfig | None = None, cloze_sources_path: Path | None = CLOZE_SOURCES):


### PR DESCRIPTION
## Summary

- Keeps the capability to admit the full 1,029-row Alona v5 list without committing multi-hundred-KB generated evidence.
- `make alona-v5-admit` normalizes the operator-local private JSONL, produces local replay/candidate/practice/report artifacts, promotes candidates, enriches CEFR through the existing path, rebuilds Atlas DB, and generates the Practice deck.
- Uses a three-row committed fixture for CI; generated Alona replay, practice, and report files are explicitly gitignored.

## Local operator proof (full 1,029)

1. Ensure `.claude/atlas-epic/plans/alona-truth/v5-curated-with-provenance.jsonl` is available locally.
2. Run `make alona-v5-admit` from the repository root (override `ALONA_V5_INPUT=/path/to/input.jsonl` if needed).
3. Inspect `data/lexicon/alona-v5-atlas-admission-report.json` and the generated local seeds. These paths are intentionally gitignored.

The target runs `promote_grow_candidates --write` locally; no Atlas manifest or release asset is published. Promotion remains local until the separate `atlas-publish` step.

## Verification

- `.venv/bin/python -m pytest tests/test_alona_v5_atlas_admission.py tests/test_generate_practice_deck.py tests/test_atlas_db.py -q` → `58 passed`
- `.venv/bin/ruff check scripts/atlas/atlas_db.py scripts/audit/generate_practice_deck.py scripts/lexicon/alona_v5_atlas_admission.py scripts/lexicon/promote_grow_candidates.py tests/test_alona_v5_atlas_admission.py tests/test_atlas_db.py tests/test_generate_practice_deck.py` → passed
- `make -n alona-v5-admit` confirms the local recipe; missing private input fails before writes.
- Formal CF estimate: changed file bytes `379468` + patch `34577` = `414045` bytes (< `2097152`).
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py` and `.venv/bin/python scripts/audit/lint_agent_trailer.py` → passed.

No auto-merge is armed.