### PR TITLE
fix(bridge): review-pr runner lifecycle records + spawn fast-fail root cause

### DIFF
--- a/scripts/ai_agent_bridge/_ask_lifecycle.py
+++ b/scripts/ai_agent_bridge/_ask_lifecycle.py
@@ -132,17 +132,20 @@ class _AskTerminalRecorder:
         self.message_id = message_id
         self.written = False
 
-    def write(self, rc_or_signal: int | str, stage: str) -> None:
+    def write(self, rc_or_signal: int | str, stage: str, *, cause: str | None = None) -> None:
         if self.written:
             return
+        payload: dict[str, Any] = {
+            "rc_or_signal": rc_or_signal,
+            "stage": stage,
+            "stderr_tail": _stderr_tail(self.message_id),
+            "ended_at": _now_iso(),
+        }
+        if cause:
+            payload["cause"] = " ".join(cause.split())[:300]
         _atomic_write_json(
             _ask_state_dir(self.message_id) / "terminal.json",
-            {
-                "rc_or_signal": rc_or_signal,
-                "stage": stage,
-                "stderr_tail": _stderr_tail(self.message_id),
-                "ended_at": _now_iso(),
-            },
+            payload,
         )
         self.written = True
 
@@ -523,6 +526,7 @@ def process_background_ask(message_id: int, target: str) -> None:
         signal.signal(signum, terminal.signal_handler)
     rc_or_signal: int | str = 1
     stage = "startup"
+    options: dict[str, Any] = {}
     try:
         options = _background_options(message_id, target)
         mark_ask_processing(message_id)
@@ -550,7 +554,11 @@ def process_background_ask(message_id: int, target: str) -> None:
         if status in {"sent", "processing", "pending", None}:
             record_ask_failure(message_id, "worker ended without a reply")
             stage = "missing-reply"
-        terminal.write(rc_or_signal, stage)
+        terminal.write(
+            rc_or_signal,
+            stage,
+            cause=_ask_status(message_id) if options.get("review_pr_lifecycle") else None,
+        )
         _remove_pid_file(_ASK_AGENT, str(message_id))
         for signum, previous in previous_handlers.items():
             signal.signal(signum, previous)

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -18,6 +18,7 @@ import json
 import subprocess
 import sys
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 from agent_runtime.errors import (
@@ -62,7 +63,9 @@ def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query"
                to_model: str | None = None, effort: str | None = None,
                review: bool = False,
                background: bool = False, review_branch: str | None = None,
-               review_pr_number: int | None = None):
+               review_pr_number: int | None = None,
+               on_message_created: Callable[[int], None] | None = None,
+               review_pr_lifecycle: bool = False):
     """Send message to Claude AND invoke Claude to process it."""
     try:
         has_target = review_branch is not None or review_pr_number is not None
@@ -96,11 +99,18 @@ def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query"
         review_target=review_target_payload(review_branch, review_pr_number),
     )
     register_ask(msg_id)
+    if on_message_created is not None:
+        on_message_created(msg_id)
     if background:
         launch_background_ask(
             msg_id,
             "claude",
-            {"new_session": new_session, "no_timeout": False, "review": review},
+            {
+                "new_session": new_session,
+                "no_timeout": False,
+                "review": review,
+                "review_pr_lifecycle": review_pr_lifecycle,
+            },
         )
         return msg_id
     print(f"\n🚀 Invoking Claude to process message #{msg_id}...")

--- a/scripts/ai_agent_bridge/_codex.py
+++ b/scripts/ai_agent_bridge/_codex.py
@@ -8,6 +8,7 @@ consistent with the runtime's resume_policy="never" for Codex.
 import json
 import os
 import re
+from collections.abc import Callable
 
 from agent_runtime import runner as agent_runner
 from agent_runtime.errors import (
@@ -119,6 +120,8 @@ def ask_codex(
     background: bool = False,
     review_branch: str | None = None,
     review_pr_number: int | None = None,
+    on_message_created: Callable[[int], None] | None = None,
+    review_pr_lifecycle: bool = False,
     ):
     """Send message to Codex AND invoke Codex to process it."""
     try:
@@ -154,11 +157,18 @@ def ask_codex(
         review_target=review_target_payload(review_branch, review_pr_number),
     )
     register_ask(msg_id)
+    if on_message_created is not None:
+        on_message_created(msg_id)
     if background:
         launch_background_ask(
             msg_id,
             "codex",
-            {"new_session": new_session, "no_timeout": no_timeout, "review": review},
+            {
+                "new_session": new_session,
+                "no_timeout": no_timeout,
+                "review": review,
+                "review_pr_lifecycle": review_pr_lifecycle,
+            },
         )
         return msg_id
     print(f"\n🚀 Invoking Codex to process message #{msg_id}...")

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -310,11 +310,17 @@ def ask_pool(
         effort=effort,
     )
     register_ask(msg_id)
+    if on_message_created is not None:
+        on_message_created(msg_id)
     if background:
         launch_background_ask(
             msg_id,
             "pool",
-            {"no_timeout": no_timeout, "variant": effective_variant},
+            {
+                "no_timeout": no_timeout,
+                "variant": effective_variant,
+                "review_pr_lifecycle": review_pr_lifecycle,
+            },
         )
         return msg_id
     print(f"\n🚀 Invoking pool ({effective_model}, variant={effective_variant}) to process message #{msg_id}...")
@@ -375,6 +381,8 @@ def ask_glm(
     from_model: str | None = None,
     no_timeout: bool = False,
     background: bool = False,
+    on_message_created: Callable[[int], None] | None = None,
+    review_pr_lifecycle: bool = False,
 ) -> int:
     """Send a message AND invoke Zhipu GLM (glm-5.2) one-shot via opencode.
 

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -40,6 +40,7 @@ import os
 import re
 import shutil
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -270,6 +271,8 @@ def ask_pool(
     from_model: str | None = None,
     no_timeout: bool = False,
     background: bool = False,
+    on_message_created: Callable[[int], None] | None = None,
+    review_pr_lifecycle: bool = False,
 ) -> int:
     """Send a message AND invoke poolside.ai (laguna-s-2.1) one-shot via opencode.
 
@@ -419,8 +422,17 @@ def ask_glm(
         effort=effort,
     )
     register_ask(msg_id)
+    if on_message_created is not None:
+        on_message_created(msg_id)
     if background:
-        launch_background_ask(msg_id, "glm", {"no_timeout": no_timeout})
+        launch_background_ask(
+            msg_id,
+            "glm",
+            {
+                "no_timeout": no_timeout,
+                "review_pr_lifecycle": review_pr_lifecycle,
+            },
+        )
         return msg_id
     print(
         f"\n🚀 Invoking glm ({effective_model}) to process message #{msg_id}... [LOCAL-ONLY — data egresses to China]"

--- a/scripts/ai_agent_bridge/_review_pr.py
+++ b/scripts/ai_agent_bridge/_review_pr.py
@@ -12,6 +12,7 @@ remain on the critical review ladder only (see model_catalog.yaml).
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from typing import Any
@@ -42,6 +43,47 @@ FORMAL_CF_EFFORT: dict[str, str] = {
     REVIEWER_CLAUDE: "high",
     REVIEWER_GLM: "high",
 }
+
+
+class _ReviewPrLifecycle:
+    """Attach formal-run terminal evidence to its bridge ask without changing asks."""
+
+    def __init__(self, *, background: bool):
+        self.background = background
+        self.message_id: int | None = None
+        self._terminal: Any = None
+
+    def message_created(self, message_id: int) -> None:
+        """Write launch evidence before the adapter enters its run/spawn path."""
+        from ._ask_lifecycle import _AskTerminalRecorder, _write_ask_launch_record
+
+        self.message_id = message_id
+        _write_ask_launch_record(message_id, pid=os.getpid(), target="review-pr")
+        self._terminal = _AskTerminalRecorder(message_id)
+
+    def record_terminal(self) -> None:
+        """Write the synchronous formal review's terminal state from its ask status."""
+        if self.background or self.message_id is None or self._terminal is None:
+            return
+        from ._ask_lifecycle import _ask_status
+
+        status = _ask_status(self.message_id)
+        if status and status.startswith("replied:"):
+            self._terminal.write(0, "success")
+        elif status and (status.startswith("timed-out:") or "timeout" in status.lower()):
+            self._terminal.write(1, "timeout", cause=status)
+        else:
+            self._terminal.write(1, "failed", cause=status or "review-pr ended without a reply")
+
+    def record_spawn_failure(self, exc: BaseException) -> None:
+        """Leave the dispatch failure reason durable after an ask id exists."""
+        if self.message_id is None or self._terminal is None:
+            return
+        from ._ask_lifecycle import record_ask_failure
+
+        cause = f"{type(exc).__name__}: {exc}"
+        record_ask_failure(self.message_id, cause)
+        self._terminal.write(1, "spawn-failure" if self.background else "exception", cause=cause)
 
 _DEFAULT_CHECKLIST = """\
 ## Formal cross-family PR review (pointer-only)
@@ -144,7 +186,7 @@ def handle_review_pr(args: argparse.Namespace) -> int:
         print(prompt)
         return 0
 
-    import os
+    lifecycle = _ReviewPrLifecycle(background=bool(args.background))
     from_llm = (
         getattr(args, "from_llm", None)
         or os.environ.get("SESSION_HANDOFF_AGENT")
@@ -154,33 +196,47 @@ def handle_review_pr(args: argparse.Namespace) -> int:
     if reviewer == REVIEWER_CODEX:
         from ._codex import ask_codex
 
-        ask_codex(
-            prompt,
-            task_id=task_id,
-            msg_type="review",
-            from_llm=from_llm,
-            to_model=model,
-            effort=effort,
-            review=True,
-            review_pr_number=pr,
-            background=bool(args.background),
-            no_timeout=bool(args.no_timeout),
-        )
+        try:
+            ask_codex(
+                prompt,
+                task_id=task_id,
+                msg_type="review",
+                from_llm=from_llm,
+                to_model=model,
+                effort=effort,
+                review=True,
+                review_pr_number=pr,
+                background=bool(args.background),
+                no_timeout=bool(args.no_timeout),
+                on_message_created=lifecycle.message_created,
+                review_pr_lifecycle=True,
+            )
+        except BaseException as exc:
+            lifecycle.record_spawn_failure(exc)
+            raise
+        lifecycle.record_terminal()
         return 0
     if reviewer == REVIEWER_CLAUDE:
         from ._claude import ask_claude
 
-        ask_claude(
-            prompt,
-            task_id=task_id,
-            msg_type="review",
-            from_llm=from_llm,
-            to_model=model,
-            effort=effort,
-            review=True,
-            review_pr_number=pr,
-            background=bool(args.background),
-        )
+        try:
+            ask_claude(
+                prompt,
+                task_id=task_id,
+                msg_type="review",
+                from_llm=from_llm,
+                to_model=model,
+                effort=effort,
+                review=True,
+                review_pr_number=pr,
+                background=bool(args.background),
+                on_message_created=lifecycle.message_created,
+                review_pr_lifecycle=True,
+            )
+        except BaseException as exc:
+            lifecycle.record_spawn_failure(exc)
+            raise
+        lifecycle.record_terminal()
         return 0
     if reviewer == REVIEWER_GLM:
         from ._opencode import ask_glm
@@ -189,14 +245,21 @@ def handle_review_pr(args: argparse.Namespace) -> int:
         # Isolation: GLM/opencode path still gets RO contract + size caps via prompt;
         # sealed worktree for opencode is a follow-up (Phase 0b). Prefer --reviewer codex
         # for full #5285 sealing today.
-        ask_glm(
-            prompt,
-            task_id=task_id,
-            msg_type="review",
-            from_llm=from_llm,
-            background=bool(args.background),
-            no_timeout=bool(args.no_timeout),
-        )
+        try:
+            ask_glm(
+                prompt,
+                task_id=task_id,
+                msg_type="review",
+                from_llm=from_llm,
+                background=bool(args.background),
+                no_timeout=bool(args.no_timeout),
+                on_message_created=lifecycle.message_created,
+                review_pr_lifecycle=True,
+            )
+        except BaseException as exc:
+            lifecycle.record_spawn_failure(exc)
+            raise
+        lifecycle.record_terminal()
         return 0
     print(f"review-pr: unhandled reviewer {reviewer}", file=sys.stderr)
     return 2

--- a/scripts/ai_agent_bridge/_review_worktree.py
+++ b/scripts/ai_agent_bridge/_review_worktree.py
@@ -1859,7 +1859,10 @@ def _resolve_exact_remote_target(
             repo_root=repo_root,
             git_bin=git_bin,
             env=env,
-            remote_ref=f"refs/pull/{target.pr_number}/head",
+            # The PR ref is mutable.  Fetch the exact SHA returned by GitHub
+            # above so a concurrent push cannot turn a valid review request
+            # into a remote_oid_mismatch before snapshot materialization.
+            remote_ref=expected_head,
             remote_url=remote_url,
             destination_ref="refs/lu-review/head",
             expected_oid=expected_head,

--- a/tests/ai_agent_bridge/test_review_pr_lifecycle.py
+++ b/tests/ai_agent_bridge/test_review_pr_lifecycle.py
@@ -1,0 +1,175 @@
+"""Formal ``review-pr`` lifecycle records regressions (#5900)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ai_agent_bridge import _ask_lifecycle as lifecycle
+from scripts.ai_agent_bridge import _codex, _review_pr
+from scripts.ai_agent_bridge._db import init_db
+from scripts.ai_agent_bridge._messaging import send_message
+
+
+@pytest.fixture
+def bridge_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "messages.db"
+    monkeypatch.setattr("scripts.ai_agent_bridge._config.DB_PATH", db_path)
+    monkeypatch.setattr("scripts.ai_agent_bridge._db.DB_PATH", db_path)
+    monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)
+    conn = init_db()
+    conn.close()
+    return db_path
+
+
+def _args(*, background: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        pr="5900",
+        reviewer="codex",
+        claude_available=None,
+        model=None,
+        effort=None,
+        extra=None,
+        task_id=None,
+        dry_run=False,
+        from_llm="claude",
+        background=background,
+        no_timeout=False,
+    )
+
+
+def _review_ask() -> int:
+    message_id = send_message(
+        "Review the PR.",
+        "review-pr-5900",
+        "review",
+        from_llm="claude",
+        to_llm="codex",
+        quiet=True,
+    )
+    lifecycle.register_ask(message_id)
+    return message_id
+
+
+def test_review_pr_spawn_failure_writes_terminal_cause(
+    bridge_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failure after sending the review ask is durable rather than silent."""
+
+    def failed_spawn(*_args, on_message_created, **_kwargs):
+        on_message_created(_review_ask())
+        raise OSError("sealed snapshot runner unavailable")
+
+    monkeypatch.setattr(_codex, "ask_codex", failed_spawn)
+
+    with pytest.raises(OSError, match="sealed snapshot runner unavailable"):
+        _review_pr.handle_review_pr(_args(background=True))
+
+    terminal = json.loads(
+        (tmp_path / "batch_state" / "asks" / "review-pr-5900" / "terminal.json").read_text()
+    )
+    assert terminal["rc_or_signal"] == 1
+    assert terminal["stage"] == "spawn-failure"
+    assert terminal["cause"] == "OSError: sealed snapshot runner unavailable"
+
+
+def test_review_pr_sync_success_writes_terminal_record(
+    bridge_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A completed formal review receives the same durable success receipt."""
+
+    def successful_review(*_args, on_message_created, **_kwargs):
+        message_id = _review_ask()
+        on_message_created(message_id)
+        reply_id = send_message(
+            '{"schema_version":"code-review-findings.v1"}',
+            "review-pr-5900",
+            "response",
+            from_llm="codex",
+            to_llm="claude",
+            quiet=True,
+        )
+        assert lifecycle.record_ask_reply(message_id, reply_id) is True
+        return message_id
+
+    monkeypatch.setattr(_codex, "ask_codex", successful_review)
+
+    assert _review_pr.handle_review_pr(_args(background=False)) == 0
+
+    terminal = json.loads(
+        (tmp_path / "batch_state" / "asks" / "review-pr-5900" / "terminal.json").read_text()
+    )
+    assert terminal["rc_or_signal"] == 0
+    assert terminal["stage"] == "success"
+    assert "cause" not in terminal
+
+
+def test_review_pr_sync_exception_writes_terminal_record(
+    bridge_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An adapter exception after send cannot leave a formal review unaccounted."""
+
+    def failed_review(*_args, on_message_created, **_kwargs):
+        on_message_created(_review_ask())
+        raise RuntimeError("sealed runner crashed")
+
+    monkeypatch.setattr(_codex, "ask_codex", failed_review)
+
+    with pytest.raises(RuntimeError, match="sealed runner crashed"):
+        _review_pr.handle_review_pr(_args(background=False))
+
+    terminal = json.loads(
+        (tmp_path / "batch_state" / "asks" / "review-pr-5900" / "terminal.json").read_text()
+    )
+    assert terminal["stage"] == "exception"
+    assert terminal["cause"] == "RuntimeError: sealed runner crashed"
+
+
+def test_review_pr_sync_timeout_writes_terminal_record(
+    bridge_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A timeout reported by an adapter remains visibly terminal."""
+
+    def timed_out_review(*_args, on_message_created, **_kwargs):
+        message_id = _review_ask()
+        on_message_created(message_id)
+        lifecycle.record_ask_failure(message_id, "Codex hard timeout: 900s")
+        return message_id
+
+    monkeypatch.setattr(_codex, "ask_codex", timed_out_review)
+
+    assert _review_pr.handle_review_pr(_args(background=False)) == 0
+
+    terminal = json.loads(
+        (tmp_path / "batch_state" / "asks" / "review-pr-5900" / "terminal.json").read_text()
+    )
+    assert terminal["stage"] == "timeout"
+    assert terminal["cause"] == "failed:Codex hard timeout: 900s"
+
+
+def test_review_pr_background_worker_records_failed_status_as_cause(
+    bridge_db: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The detached path preserves the root cause in its terminal receipt."""
+    message_id = _review_ask()
+    monkeypatch.setattr(
+        lifecycle,
+        "_background_options",
+        lambda *_args: {"review_pr_lifecycle": True},
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_target",
+        lambda *_args: lifecycle.record_ask_failure(message_id, "remote_oid_mismatch:head changed"),
+    )
+
+    lifecycle.process_background_ask(message_id, "codex")
+
+    terminal = json.loads(
+        (tmp_path / "batch_state" / "asks" / "review-pr-5900" / "terminal.json").read_text()
+    )
+    assert terminal["stage"] == "failed"
+    assert terminal["cause"] == "failed:remote_oid_mismatch:head changed"

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -1966,7 +1966,7 @@ def test_pr_review_target_resolves_head_then_fetches_origin(monkeypatch: pytest.
     gh_idx = next(i for i, j in enumerate(joined) if "pr view" in j)
     fetch_idx = next(i for i, j in enumerate(joined) if "fetch" in j)
     assert fetch_idx > gh_idx
-    assert any("refs/pull/5150/head" in command for command in joined)
+    assert any(f"{sha}:refs/lu-review/head" in command for command in joined)
 
 
 def test_exact_remote_fetch_rejects_api_oid_mismatch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1986,6 +1986,46 @@ def test_exact_remote_fetch_rejects_api_oid_mismatch(monkeypatch: pytest.MonkeyP
             destination_ref="refs/lu-review/head",
             expected_oid="a" * 40,
         )
+
+
+def test_pr_snapshot_fetches_resolved_head_sha_not_moving_pr_ref(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A concurrent PR push cannot invalidate the already-resolved target (#5900)."""
+    expected_head = "a" * 40
+    expected_base = "b" * 40
+    fetched: list[str] = []
+
+    monkeypatch.setattr(
+        review_worktree,
+        "_resolve_pr_target",
+        lambda *_args, **_kwargs: ("feature/review", expected_head, "main", expected_base),
+    )
+
+    def fake_fetch(**kwargs):
+        fetched.append(kwargs["remote_ref"])
+        return str(kwargs["expected_oid"])
+
+    monkeypatch.setattr(review_worktree, "_fetch_exact_ref", fake_fetch)
+    monkeypatch.setattr(review_worktree, "_run_command", lambda *_args, **_kwargs: expected_base)
+    monkeypatch.setattr(
+        review_worktree,
+        "resolve_head_identity",
+        lambda *_args, **_kwargs: expected_base,
+    )
+
+    review_worktree._resolve_exact_remote_target(
+        review_worktree.ReviewTarget(pr_number=5900),
+        repo_root=tmp_path,
+        git_bin=Path("/usr/bin/git"),
+        gh_bin=Path("/usr/bin/gh"),
+        env={},
+        repository="learn-ukrainian/learn-ukrainian.github.io",
+        remote_url="https://github.com/learn-ukrainian/learn-ukrainian.github.io.git",
+        default_branch="main",
+    )
+
+    assert fetched == [expected_head, expected_base]
 
 
 def test_review_target_metadata_rejects_ambiguous_or_malformed_values() -> None:

--- a/tests/test_ask_pool.py
+++ b/tests/test_ask_pool.py
@@ -324,3 +324,24 @@ def test_invoke_opencode_no_token_budget_for_other_models(monkeypatch):
             # env may be present (copy), but the experimental key must NOT be set by us
             if "env" in call_kwargs:
                 assert "OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX" not in call_kwargs["env"]
+
+
+# --- #5911 lifecycle callback wiring (CI catch) ---
+
+
+def test_ask_glm_and_pool_invoke_on_message_created_callback(monkeypatch):
+    """ask_glm referenced the callback without declaring it (NameError, caught by
+    CI shard 1); ask_pool declared it without ever calling it (silently dropped
+    launch records). Pin both wirings: the callback fires with the message id."""
+    for var in _CI_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for fn, name in ((ask_glm, "glm"), (ask_pool, "pool")):
+        seen: list[int] = []
+        with (
+            patch("scripts.ai_agent_bridge._opencode.send_message", return_value=41),
+            patch("scripts.ai_agent_bridge._opencode.acknowledge"),
+            patch("scripts.ai_agent_bridge._opencode.record_ask_reply"),
+            patch("scripts.ai_agent_bridge._opencode._invoke_opencode", return_value="ok"),
+        ):
+            fn("hi", task_id="t", on_message_created=seen.append)
+        assert seen == [41], f"{name}: on_message_created not invoked with the message id"


### PR DESCRIPTION
Closes #5900

## Summary

- Fetches the exact PR head SHA resolved from GitHub, rather than the mutable `refs/pull/<N>/head` ref.
- Writes atomic `launch.json` and terminal receipts for formal `review-pr` execution, including durable causes for spawn failures, exceptions, and timeouts.
- Preserves existing ask lifecycle records; only formal review runs opt into terminal causes.

## Root cause

The sealed review flow resolved PR #5896 at `5eae444f22da5b88ad20a11a533a3232d96efdd5`, then fetched the mutable PR ref after it had advanced to `91a27d25a58a14507672efd8ba49b976f000e7b3`. The resulting `remote_oid_mismatch` failed the worker before any review ran.

## Validation

- `.venv/bin/ruff check` on every touched file
- `.venv/bin/python -m pytest tests/ai_agent_bridge/ -x -q` — 237 passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

Mutation checks confirmed each root-cause, spawn-failure, success, and background-cause guard fails when its fix is removed.