### PR TITLE
feat(app): render multiple-choice blocks (widget pass prerequisite, #294 item 4)

### DIFF
--- a/packages/activity-kit/src/ActivityPlayer.tsx
+++ b/packages/activity-kit/src/ActivityPlayer.tsx
@@ -126,17 +126,24 @@ export function ActivityPlayer({ activity, onComplete, isUkrainian }: ActivityPl
       {activity.type === 'multiple-choice' && (
         <Quiz
           questions={activity.payload.items.map(({ prompt, options }, index) => {
-            const correct = activity.answer_key.items.find((item) => item.index === index)?.correct;
+            const correct = activity.answer_key?.items?.find((item) => item.index === index)?.correct;
             return {
               question: prompt,
               options: options.map((text) => ({
                 text,
-                correct: text === correct || text.startsWith(`${correct})`),
+                correct: Boolean(
+                  correct &&
+                    (text === correct ||
+                      text.startsWith(`${correct})`) ||
+                      text.startsWith(correct) ||
+                      text.trim().startsWith(correct.trim()))
+                ),
               })),
             };
           })}
           instruction={activity.payload.instruction}
           isUkrainian={isUkrainian}
+          activityType="multiple-choice"
         />
       )}
       {activity.type === 'text-questions' && (

--- a/packages/activity-kit/src/ActivityPlayer.tsx
+++ b/packages/activity-kit/src/ActivityPlayer.tsx
@@ -127,18 +127,20 @@ export function ActivityPlayer({ activity, onComplete, isUkrainian }: ActivityPl
         <Quiz
           questions={activity.payload.items.map(({ prompt, options }, index) => {
             const correct = activity.answer_key?.items?.find((item) => item.index === index)?.correct;
+            const trimmedCorrect = correct?.trim();
             return {
               question: prompt,
-              options: options.map((text) => ({
-                text,
-                correct: Boolean(
-                  correct &&
-                    (text === correct ||
-                      text.startsWith(`${correct})`) ||
-                      text.startsWith(correct) ||
-                      text.trim().startsWith(correct.trim()))
-                ),
-              })),
+              options: options.map((text) => {
+                const trimmedText = text.trim();
+                return {
+                  text,
+                  correct: Boolean(
+                    trimmedCorrect &&
+                      (trimmedText === trimmedCorrect ||
+                        trimmedText.startsWith(`${trimmedCorrect})`))
+                  ),
+                };
+              }),
             };
           })}
           instruction={activity.payload.instruction}

--- a/packages/activity-kit/src/components/Activities.module.css
+++ b/packages/activity-kit/src/components/Activities.module.css
@@ -2642,3 +2642,28 @@
   background: var(--lu-state-missed);
   color: var(--lu-state-missed-fg);
 }
+
+/* block note · teacher review mode */
+.blockNote {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background-color: var(--lu-state-warning-bg, #fffbeb);
+  border: 1px solid var(--lu-state-warning-border, #fde68a);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--lu-state-warning-text, #92400e);
+}
+
+.blockNoteTitle {
+  color: var(--lu-state-warning-title, #78350f);
+}
+
+[data-theme='dark'] .blockNote {
+  background-color: var(--lu-state-missed, rgba(251, 191, 36, 0.15));
+  border-color: rgba(251, 191, 36, 0.3);
+  color: var(--lu-state-missed-fg, #fef3c7);
+}
+
+[data-theme='dark'] .blockNoteTitle {
+  color: #fde68a;
+}

--- a/packages/activity-kit/src/components/ActivityHelp.tsx
+++ b/packages/activity-kit/src/components/ActivityHelp.tsx
@@ -11,6 +11,10 @@ const HELP_TEXT: Record<string, { title: string; description: string }> = {
     title: 'Multiple Choice',
     description: 'Select the correct answer from the options provided. Only one answer is correct.',
   },
+  'multiple-choice': {
+    title: 'Multiple Choice',
+    description: 'Select the correct answer from the options provided. Only one answer is correct.',
+  },
   'fill-in': {
     title: 'Fill in the Blank',
     description: 'Choose the correct word or phrase to complete each sentence from the dropdown options.',
@@ -83,6 +87,10 @@ const HELP_TEXT: Record<string, { title: string; description: string }> = {
 
 const HELP_TEXT_UA: Record<string, { title: string; description: string }> = {
   'quiz': {
+    title: 'Вибір відповіді',
+    description: 'Виберіть правильну відповідь із запропонованих варіантів. Лише одна відповідь є правильною.',
+  },
+  'multiple-choice': {
     title: 'Вибір відповіді',
     description: 'Виберіть правильну відповідь із запропонованих варіантів. Лише одна відповідь є правильною.',
   },

--- a/packages/activity-kit/src/components/LessonViewer.tsx
+++ b/packages/activity-kit/src/components/LessonViewer.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import styles from './Activities.module.css';
 import type { LuLessonV1, LuLessonBlock } from '../lu.lesson.v1.generated';
 import type { LuLessonSupportV1 } from '../lu.lesson-support.v1.generated';
 import { ActivityPlayer } from '../ActivityPlayer';
@@ -9,6 +10,7 @@ export interface LessonViewerProps {
   lesson: LuLessonV1;
   support?: LuLessonSupportV1 | null;
   initialMode?: LessonViewerMode;
+  isUkrainian?: boolean;
   onModeChange?: (mode: LessonViewerMode) => void;
   onComplete?: (blockId: string, result: Record<string, unknown>) => void;
 }
@@ -51,6 +53,7 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({
   lesson,
   support,
   initialMode = 'teacher_review',
+  isUkrainian = false,
   onModeChange,
   onComplete,
 }) => {
@@ -136,6 +139,7 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({
               <div key={activeBlock.id} data-testid={`student-block-${activeBlock.id}`}>
                 <ActivityPlayer
                   activity={activeBlock.activity}
+                  isUkrainian={isUkrainian}
                   onComplete={(res) => onComplete && onComplete(activeBlock.id, res as Record<string, unknown>)}
                 />
               </div>
@@ -161,7 +165,7 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({
                     </span>
                   </div>
 
-                  <ActivityPlayer activity={block.activity} />
+                  <ActivityPlayer activity={block.activity} isUkrainian={isUkrainian} />
 
                   {block.answer_key && (
                     <div style={{ marginTop: '16px', padding: '12px', backgroundColor: '#f0fdf4', border: '1px solid #bbf7d0', borderRadius: '6px' }} data-testid={`answer-key-${block.id}`}>
@@ -173,8 +177,8 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({
                   )}
 
                   {block.note && (
-                    <div style={{ marginTop: '12px', padding: '10px 12px', backgroundColor: '#fffbeb', border: '1px solid #fde68a', borderRadius: '6px', fontSize: '13px', color: '#92400e' }} data-testid={`block-note-${block.id}`}>
-                      <strong style={{ color: '#78350f' }}>Note:</strong> {block.note}
+                    <div className={styles.blockNote} data-testid={`block-note-${block.id}`}>
+                      <strong className={styles.blockNoteTitle}>{isUkrainian ? 'Примітка:' : 'Note:'}</strong> {block.note}
                     </div>
                   )}
                 </div>
@@ -193,8 +197,9 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({
                 </div>
 
                 <div style={{ textAlign: 'left', maxWidth: '800px', margin: '0 auto' }}>
-                  <ActivityPlayer activity={activeBlock.activity} />
+                  <ActivityPlayer activity={activeBlock.activity} isUkrainian={isUkrainian} />
                 </div>
+
 
                 <div style={{ marginTop: '24px', display: 'flex', justifyContent: 'center', gap: '16px' }}>
                   <button
@@ -244,7 +249,7 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({
               {lesson.blocks.map((block, idx) => (
                 <div key={block.id} style={{ pageBreakInside: 'avoid' }}>
                   <h4 style={{ margin: '0 0 12px', fontSize: '16px', color: '#0f172a' }}>Task {idx + 1}</h4>
-                  <ActivityPlayer activity={block.activity} />
+                  <ActivityPlayer activity={block.activity} isUkrainian={isUkrainian} />
                 </div>
               ))}
             </div>

--- a/packages/activity-kit/src/components/LessonViewer.tsx
+++ b/packages/activity-kit/src/components/LessonViewer.tsx
@@ -171,6 +171,12 @@ export const LessonViewer: React.FC<LessonViewerProps> = ({
                       </pre>
                     </div>
                   )}
+
+                  {block.note && (
+                    <div style={{ marginTop: '12px', padding: '10px 12px', backgroundColor: '#fffbeb', border: '1px solid #fde68a', borderRadius: '6px', fontSize: '13px', color: '#92400e' }} data-testid={`block-note-${block.id}`}>
+                      <strong style={{ color: '#78350f' }}>Note:</strong> {block.note}
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/packages/activity-kit/src/components/Quiz.tsx
+++ b/packages/activity-kit/src/components/Quiz.tsx
@@ -129,17 +129,22 @@ interface QuizProps {
    * @ukrainianText false
    */
   isUkrainian?: boolean;
+  /**
+   * @schemaDescription Activity type name for data attribute and help tooltip.
+   * @ukrainianText false
+   */
+  activityType?: string;
 }
 
-export default function Quiz({ questions, instruction, children, isUkrainian }: QuizProps) {
-  const headerLabel = isUkrainian ? 'Тест' : 'Quiz';
+export default function Quiz({ questions, instruction, children, isUkrainian, activityType = 'quiz' }: QuizProps) {
+  const headerLabel = isUkrainian ? 'Тест' : (activityType === 'multiple-choice' ? 'Multiple Choice' : 'Quiz');
 
   return (
-    <div className={styles.activityContainer} data-activity="quiz">
+    <div className={styles.activityContainer} data-activity={activityType}>
       <div className={styles.activityHeader}>
         <span className={styles.activityIcon}>📝</span>
         <span>{headerLabel}</span>
-        <ActivityHelp activityType="quiz" isUkrainian={isUkrainian} />
+        <ActivityHelp activityType={activityType} isUkrainian={isUkrainian} />
       </div>
       {instruction && (
         <p className={styles.instruction}><strong>{instruction}</strong></p>

--- a/packages/activity-kit/src/fixtures/lu.activity.v1.fixtures.json
+++ b/packages/activity-kit/src/fixtures/lu.activity.v1.fixtures.json
@@ -210,5 +210,31 @@
       "generator": "hramatka-contract-golden-fixture",
       "gates": ["schema", "player-smoke"]
     }
+  },
+  {
+    "id": "golden-multiple-choice",
+    "type": "multiple-choice",
+    "title": "Оберіть відповідь",
+    "level": "b1",
+    "payload": {
+      "type": "multiple-choice",
+      "instruction": "Оберіть відповідь.",
+      "items": [
+        {
+          "prompt": "Де була перша квартира?",
+          "options": ["а) у центрі", "б) біля парку", "в) за містом"]
+        }
+      ]
+    },
+    "answer_key": {
+      "items": [
+        { "index": 0, "correct": "а" }
+      ]
+    },
+    "provenance": {
+      "source": "https://learn-ukrainian.github.io/",
+      "generator": "hramatka-contract-golden-fixture",
+      "gates": ["schema", "player-smoke"]
+    }
   }
 ]

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -58,12 +58,6 @@ test('practice matching renders a real round (>=3 pairs) for a fresh learner', a
   await expect.poll(() => page.locator('[data-activity="match-left-tile"]').count()).toBeGreaterThanOrEqual(3);
 });
 
-test('multiple-choice widget rendering case at 1440x900 viewport', async ({ page }) => {
-  await page.setViewportSize({ width: 1440, height: 900 });
-  await page.goto('/words-of-the-day/practice/');
-  await expect(page.locator('#lexicon-practice-mount .lexicon-practice')).toBeVisible();
-});
-
 test('practice mode switch starts the selected mode without inheriting the unfinished one', async ({ page }) => {
   await page.goto('/words-of-the-day/practice/');
 

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -58,6 +58,12 @@ test('practice matching renders a real round (>=3 pairs) for a fresh learner', a
   await expect.poll(() => page.locator('[data-activity="match-left-tile"]').count()).toBeGreaterThanOrEqual(3);
 });
 
+test('multiple-choice widget rendering case at 1440x900 viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/words-of-the-day/practice/');
+  await expect(page.locator('#lexicon-practice-mount .lexicon-practice')).toBeVisible();
+});
+
 test('practice mode switch starts the selected mode without inheriting the unfinished one', async ({ page }) => {
   await page.goto('/words-of-the-day/practice/');
 

--- a/site/tests/unit/ActivityKit.contract.test.tsx
+++ b/site/tests/unit/ActivityKit.contract.test.tsx
@@ -9,7 +9,7 @@ import invalidSignatureFixtures from '../../../packages/activity-kit/src/fixture
 import lessonFixture from '../../../packages/activity-kit/src/fixtures/lu.lesson.v1.fixture.json';
 import lessonSupportFixture from '../../../packages/activity-kit/src/fixtures/lu.lesson-support.v1.valid.fixture.json';
 import invalidLessonSupportFixture from '../../../packages/activity-kit/src/fixtures/lu.lesson-support.v1.invalid.fixture.json';
-import { ActivityPlayer } from '../../../packages/activity-kit/src/ActivityPlayer';
+import { ActivityPlayer, LessonViewer } from '../../../packages/activity-kit/src';
 import type {
   ActivityEditOperation,
   LuActivityV1,
@@ -34,6 +34,7 @@ const GOLDEN_TYPES = [
   'error-correction',
   'text-questions',
   'short-writing',
+  'multiple-choice',
 ] as const;
 
 const validator = `
@@ -152,8 +153,8 @@ describe('activity-kit contract', () => {
     expect(lessonSupportGenerated).toContain('vocabulary: Array<LuLessonSupportVocabularyItem>;');
   });
 
-  test('golden fixture covers all nine player-backed engine types', () => {
-    expect(fixtures).toHaveLength(9);
+  test('golden fixture covers all ten player-backed engine types', () => {
+    expect(fixtures).toHaveLength(10);
     expect(fixtures.map((fixture) => fixture.type).sort()).toEqual([...GOLDEN_TYPES].sort());
   });
 
@@ -468,5 +469,51 @@ describe('lesson document v1 contract', () => {
       notice_uk: null,
     };
     expect(lessonSchemaErrors(doc)).not.toBe('');
+  });
+
+  describe('multiple-choice render path', () => {
+    test('renders multiple-choice activity with correct option marking on interaction', () => {
+      const mcActivity = fixtures.find((f) => f.type === 'multiple-choice') as LuActivityV1;
+      expect(mcActivity).toBeDefined();
+
+      const { container } = render(<ActivityPlayer activity={mcActivity} isUkrainian />);
+      expect(container.querySelector('[data-activity="multiple-choice"]')).toBeInTheDocument();
+
+      const buttons = screen.getAllByRole('button');
+      const correctButton = buttons.find((b) => b.textContent?.includes('у центрі'));
+      expect(correctButton).toBeDefined();
+
+      fireEvent.click(correctButton!);
+
+      const feedback = container.querySelector('[data-activity="quiz-feedback"]');
+      expect(feedback).toBeInTheDocument();
+      expect(feedback?.getAttribute('data-correct')).toBe('true');
+      expect(feedback?.textContent).toContain('Правильно');
+    });
+
+    test('renders fixture-lesson containing multiple-choice block in teacher review mode with key and note display', () => {
+      const { container } = render(
+        <LessonViewer lesson={lessonFixture as unknown as LuLessonV1} initialMode="teacher_review" />
+      );
+
+      const mcBlockContainer = container.querySelector('[data-testid="answer-key-rent-04-multiple-choice"]');
+      expect(mcBlockContainer).toBeInTheDocument();
+      expect(mcBlockContainer?.textContent).toContain('Answer Key:');
+      expect(mcBlockContainer?.textContent).toContain('1 — а');
+
+      const mcNoteContainer = container.querySelector('[data-testid="block-note-rent-04-multiple-choice"]');
+      expect(mcNoteContainer).toBeInTheDocument();
+      expect(mcNoteContainer?.textContent).toContain('Note:');
+      expect(mcNoteContainer?.textContent).toContain('перевірте, чи доречні');
+    });
+
+    test('renders fixture-lesson containing multiple-choice block in student mode with zero answer leakage', () => {
+      const { container } = render(
+        <LessonViewer lesson={lessonFixture as unknown as LuLessonV1} initialMode="student" />
+      );
+
+      expect(container.querySelector('[data-testid="answer-key-rent-04-multiple-choice"]')).toBeNull();
+      expect(container.querySelector('[data-testid="block-note-rent-04-multiple-choice"]')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
### Description
This PR implements the frontend/validator-side render path for `multiple-choice` blocks in the teacher app and lesson viewer (#294 item 4).

### Round 1 Fixes Applied (Addressing PR #5914 Review Findings)
1. **Tightened Answer Matcher**: Restored tight answer matching in `packages/activity-kit/src/ActivityPlayer.tsx`. Matching strictly requires exact-match (`trimmedText === trimmedCorrect`) or letter-paren-prefix (`trimmedText.startsWith(`${trimmedCorrect})`)`). Bare `startsWith(correct)` was removed to prevent miskeying Ukrainian options that share initial letters.
2. **Removed Mislabeled E2E Test**: Removed the invalid `multiple-choice widget rendering case at 1440x900 viewport` test case from `site/e2e/atlas-practice.spec.ts`.
3. **i18n & CSS Module Tokens for Note Block**: Replaced inline hex styles in `packages/activity-kit/src/components/LessonViewer.tsx` with CSS module classes (`.blockNote` and `.blockNoteTitle`) defined in `packages/activity-kit/src/components/Activities.module.css`. Updated note header label to use dual-language i18n (`isUkrainian ? 'Примітка:' : 'Note:'`).
4. **Teacher Review Mode Gating Location**: Note block rendering is strictly gated to `teacher_review` mode in `packages/activity-kit/src/components/LessonViewer.tsx` around line 147 inside `{mode === 'teacher_review' && (...)}`. Additionally, `sanitizeLessonForStudent` explicitly sets `block.note = null` ensuring zero answer/note leakage in student mode.

### Evidence & Verification
- **Unit Test Suite**:
  ```
  RUN  v4.1.10 /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/mc-render-fix-r1/site
  ✓ tests/unit/ActivityKit.contract.test.tsx (71 tests) 3370ms
  Test Files  1 passed (1)
       Tests  71 passed (71)
  ```
- **TypeScript Typecheck**:
  ```
  packages/activity-kit / tsc --noEmit: 0 errors
  ```
- **Site Build**:
  ```
  00:10:38 [build] ✓ Completed in 27.99s.
  00:10:38 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
  00:10:38 [build] 431 page(s) built in 28.67s
  00:10:38 [build] Complete!
  ```
