### PR TITLE
feat(trails): T2 RB-2 dispatch-loop trail draft (live-captured shapes)

### DIFF
--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -14,11 +14,14 @@
 # applied decision as a receipt line — an auditable write obligation, not a machine
 # derivation (stated per the r3 review).
 #
-# RETRY MODEL (r3 finding): trailspec.v1 has no cross-step variable rebinding, so a
-# re-fire is a NEW INVOCATION of this same trail with task_id=<old>-retry. This
-# invocation ends at the terminal `refired_new_invocation`; the -retry invocation's
-# own retry gate hits the -retry suffix on a second failure and stops with the
-# settle-status table's exact code (STOP-unrecoverable-error). Bounded, no rebinding.
+# RETRY MODEL (r3/r4 findings): trailspec.v1 has no cross-step variable rebinding,
+# so a re-fire ends THIS invocation at `refired_new_invocation` after dispatching the
+# -retry worker. What the predicate PROVES is only that the retry worker is running;
+# binding a fresh RB-2 invocation to the -retry id is an ORCHESTRATION-LAYER
+# OBLIGATION declared here (the runner that starts trails must start one per live
+# dispatch id) — when honored, a second failure hits the -retry suffix gate FIRST
+# (before any cleanup) and stops with the table's exact code. Declared, not
+# machine-proven: a v1.1 invocation-binding form is the proposed fix.
 #
 # kind-wait note (spec v1.1 carry-over): trailspec.v1 has no `wait` kind — settle
 # waiting is a summon whose documentation-predicate covers arming ONE Monitor
@@ -29,7 +32,7 @@
 # arc and multi-signal branchings collapse back into fewer steps.
 schema_version: trailspec.v1
 trail_id: rb2-dispatch-loop
-version: "0.4.0"
+version: "0.5.0"
 title: RB2 Dispatch loop — brief, dispatch, settle, finalize
 seats:
   - grok-daily
@@ -268,7 +271,7 @@ steps:
       finalize-BY-HAND (the table's words — never an automatic retry; #5855-class
       false negatives are disproven by checking the branch first); failed/crashed go
       to failure-evidence reading then cleanup then the bounded re-fire;
-      rate_limited reroutes per fallback substitutions; cancelled/dry_run are
+      rate_limited reroutes per fallback substitutions (the seat NOTES the substitution in the brief/receipt — a write obligation); cancelled/dry_run are
       terminal-not-success; a spurious settle with status still spawning/running
       re-enters the wait; anything else is unknown.
     command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
@@ -277,12 +280,12 @@ steps:
       success_pattern: '^(done|failed|timeout|silence-timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable|spawning|running)$'
     transitions:
       done: verify_deliverable_success
-      timeout: verify_deliverable_success
-      silence_timeout: verify_deliverable_success
+      timeout: verify_deliverable_attention
+      silence_timeout: verify_deliverable_attention
       needs_finalize: verify_deliverable_attention
       no_deliverable: verify_deliverable_attention
-      failed: read_failure_evidence
-      crashed: read_failure_evidence
+      failed: retry_suffix_gate
+      crashed: retry_suffix_gate
       rate_limited: route_lane
       cancelled: aborted
       dry_run: aborted
@@ -311,29 +314,32 @@ steps:
 
   - step_id: verify_deliverable_attention
     intent: >-
-      Attention path (needs_finalize / no_deliverable): the same PR check, but the
-      table's disposition for these states is finalize BY HAND — a missing PR here
-      routes to judgment, never to an automatic retry (three live #5855-class false
-      negatives this session all had real, pushed deliverables the status missed).
+      Attention path (timeout flavors + needs_finalize / no_deliverable): the same
+      PR check, but the table's disposition here is finalize BY HAND — an OPEN PR
+      also routes to judgment (a died worker's deliverable needs eyes before RB-3's
+      babysit could auto-merge it), and a missing PR runs the commit-verification
+      chain before absence is believed (three live #5855-class false negatives this
+      session all had real deliverables the status missed).
     command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
     evidence_predicate:
       command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
       success_pattern: '"number"'
     transitions:
-      pr_open: handed_to_pr_lifecycle
-      no_pr_for_branch: STOP-manual-intervention
+      pr_open: STOP-manual-intervention
+      no_pr_for_branch: commits_ahead_check
     kind: mechanical
     blocked_on: null
 
   - step_id: commits_ahead_check
     intent: >-
       Single-signal: count commits the dispatch worktree carries beyond its recorded
-      base (worktree_base_sha in the task file). Non-zero means finished-but-unpushed
-      work — judgment finalize, never a blind refire over real work. Zero falls
-      through to the dirty-tree check.
-    command: git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count {base_sha}..HEAD
+      base, read from the task file's worktree_base_sha field (live-verified key) —
+      no unbound placeholders. Non-zero means finished-but-unpushed work — judgment
+      finalize, never a blind refire over real work. Zero falls through to the
+      dirty-tree check.
+    command: sh -c 'B=$(jq -r ".worktree_base_sha" batch_state/tasks/{task_id}.json); git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count "$B"..HEAD'
     evidence_predicate:
-      command: git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count {base_sha}..HEAD
+      command: sh -c 'B=$(jq -r ".worktree_base_sha" batch_state/tasks/{task_id}.json); git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count "$B"..HEAD'
       success_pattern: '^[0-9]+$'
     transitions:
       commits_present: STOP-manual-intervention
@@ -357,14 +363,30 @@ steps:
     kind: mechanical
     blocked_on: null
 
+  - step_id: retry_suffix_gate
+    intent: >-
+      FIRST-MATCH gate for failed/crashed (r4 finding: the stop must precede any
+      cleanup): a task id already carrying -retry has consumed its single re-fire —
+      stop immediately with the table's exact code, PRESERVING the failed retry's
+      worktree and logs for forensics. Only a first-attempt id proceeds to
+      failure-evidence reading and cleanup.
+    command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo first-attempt ;; esac'
+    evidence_predicate:
+      command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo first-attempt ;; esac'
+      success_pattern: '^(already-retried|first-attempt)$'
+    transitions:
+      first_attempt: read_failure_evidence
+      already_retried: STOP-unrecoverable-error
+    kind: mechanical
+    blocked_on: null
+
   - step_id: read_failure_evidence
     intent: >-
-      The settle-status failed/crashed row's first action: read the recorded failure
-      evidence. stderr_excerpt is a real task-file field (live-verified key list);
-      extracting it into the retry receipt preserves the cause for the -retry
-      invocation's brief and for later audit. An empty excerpt is still evidence
-      (recorded as such), so both branches proceed to cleanup.
-    command: sh -c 'jq -r ".stderr_excerpt // \"(no stderr recorded)\"" batch_state/tasks/{task_id}.json | tee batch_state/rb2-failure-{task_id}.txt'
+      The settle-status row's action verbatim: read stderr_excerpt AND the logs.
+      Both the task file's stderr_excerpt field (live-verified key) and the teed
+      dispatch log are concatenated into the failure receipt, preserving the cause
+      for the -retry brief and audit. An empty excerpt is still evidence.
+    command: sh -c '{ jq -r ".stderr_excerpt // \"(no stderr recorded)\"" batch_state/tasks/{task_id}.json; echo "--- dispatch log tail ---"; tail -40 batch_state/rb2-dispatch-{task_id}.log 2>/dev/null || echo "(no dispatch log)"; } | tee batch_state/rb2-failure-{task_id}.txt'
     evidence_predicate:
       command: test -s batch_state/rb2-failure-{task_id}.txt && echo evidence-recorded
       success_pattern: '^evidence-recorded$'
@@ -376,12 +398,13 @@ steps:
 
   - step_id: cleanup_failed_worktree
     intent: >-
-      The settle-status failed/crashed row's second action: remove the failed
-      attempt's worktree before any re-fire (the dirty/commits checks upstream
-      guarantee nothing of value is inside on this path; branches without upstream
-      auto-prune on pull). The predicate proves the worktree is gone from the
-      registry.
-    command: git worktree remove --force .worktrees/dispatch/{lane}/{task_id}
+      The settle-status row's action verbatim: remove worktree AND branch (RB-3's
+      cleanup precedent chains both). The failed attempt's branch was never merged,
+      so plain -d refuses and -D is required; harnesses whose write guard blocks a
+      manual branch -D route the branch half through the dispatcher's own reap — a
+      certification-time question recorded here, not papered over. The predicate
+      proves the worktree is gone from the registry.
+    command: sh -c 'git worktree remove --force .worktrees/dispatch/{lane}/{task_id} && (git branch -D {lane}/{task_id} 2>/dev/null || echo "branch reap deferred to dispatcher (write guard)")'
     evidence_predicate:
       command: sh -c 'git worktree list | grep -c -e "dispatch/{lane}/{task_id}" || true'
       success_pattern: '^0$'
@@ -393,11 +416,11 @@ steps:
 
   - step_id: retry_gate
     intent: >-
-      One automatic re-fire, never a third — with the settle-status table's exact
-      code: a task id already carrying -retry has consumed its re-fire and stops as
-      STOP-unrecoverable-error (the table's row for a failed -retry attempt).
-      Otherwise the retry id <task_id>-retry is recorded to a receipt for the
-      re-fire step.
+      Defense-in-depth suffix re-check on the re-fire path (the authoritative
+      first-match gate is retry_suffix_gate, which runs BEFORE any cleanup): a task
+      id already carrying -retry stops as STOP-unrecoverable-error (the table's
+      exact code). Otherwise the retry id <task_id>-retry is recorded to a receipt
+      for the re-fire step.
     command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo "{task_id}-retry" > batch_state/rb2-retry-{task_id}.txt; cat batch_state/rb2-retry-{task_id}.txt ;; esac'
     evidence_predicate:
       command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) cat batch_state/rb2-retry-{task_id}.txt ;; esac'

--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -1,0 +1,249 @@
+# RB-2 — dispatch loop (T2 DRAFT, extraction from drive-epic SKILL steps 3/4/4a + the
+# infra driver's dispatch-brief checklist and settle discipline). Part of #5885.
+#
+# DRAFT STATUS: authored against today's substrate per the panel's draft-now ruling;
+# certification waits for T1.4/5. Steps that depend on unbuilt machinery carry an
+# explicit blocked_on marker.
+#
+# Anti-pattern guard (the #5860 r1 lessons, held to the RB-1 bar): every command below
+# is a real, currently runnable repo command whose OUTPUT SHAPE was captured from a live
+# run (2026-07-27/28 infra session: dispatches fix-5900/fix-5893/t13-glm-canary, the
+# write-path REFUSE + override, three live no_deliverable false negatives) before being
+# encoded; every predicate is falsifiable; unknown situations exit through a STOP code.
+#
+# kind-wait note (spec v1.1 carry-over): trailspec.v1 has no `wait` kind — the
+# await_settle step is a summon whose documentation-predicate is the Monitor settle
+# event; the transition source is the settle-status table lookup that follows it.
+schema_version: trailspec.v1
+trail_id: rb2-dispatch-loop
+version: "0.1.0"
+title: RB2 Dispatch loop — classify, brief, dispatch, settle, finalize
+seats:
+  - grok-daily
+  - glm-trial
+  - judgment
+stop_codes:
+  - STOP-precondition-failed
+  - STOP-concurrency-conflict
+  - STOP-unrecoverable-error
+  - STOP-manual-intervention
+  - STOP-unknown
+terminal_outcomes:
+  - handed_to_pr_lifecycle
+  - parked_no_capacity
+  - aborted
+steps:
+  - step_id: drain_slot_inbox
+    intent: >-
+      Mandatory inbox-drain substep (drive-epic 4a pattern): before firing new work,
+      surface pending slot deliveries for this seat. The live output shape is
+      "<agent> inbox:" followed by "pending: N (oldest ...)" — a pending count of 0
+      proceeds; a non-zero count runs one coalesced drain and re-checks. A drain that
+      leaves deliveries pending needs a human or judgment seat (delivery processing
+      spawns agents; never loop it blindly).
+    command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
+    evidence_predicate:
+      command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
+      success_pattern: 'pending:\s+0'
+    transitions:
+      empty: classify_task
+      pending_deliveries: drain_once
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: drain_once
+    intent: >-
+      Run the thread-coalesced inbox worker exactly once for this seat, then re-check.
+      Still-pending after one drain means a delivery needs handling this trail cannot
+      do mechanically.
+    command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} run {handoff_agent}
+    evidence_predicate:
+      command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
+      success_pattern: 'pending:\s+0'
+    transitions:
+      drained: classify_task
+      still_pending: STOP-manual-intervention
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: classify_task
+    intent: >-
+      Project Research Registry duty: classify the task's functional role, task family,
+      track, and owned paths FROM THE ISSUE/BRIEF TEXT (labels, title tags, named
+      files). Pass every dimension that is explicitly derivable; omit every dimension
+      that is not — a pointer-free dispatch is a legal, deliberate outcome and never a
+      reason to invent a value. This is mechanical because the rule is total: derivable
+      → pass, not derivable → omit. Never infer from provider or agent name.
+    command: gh issue view {issue_number} --json title,labels,body
+    evidence_predicate:
+      command: gh issue view {issue_number} --json title,labels
+      success_pattern: '"title"'
+    transitions:
+      classified_or_deliberately_generic: sibling_check
+      issue_unreadable: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: sibling_check
+    intent: >-
+      Dispatch-brief checklist step 0: search PRs by ISSUE REFERENCE (never title
+      words) and read the issue's timeline before briefing — open issue does not mean
+      unfixed. Live shape: a JSON array of {number, state, title}; [] proceeds. Any
+      hit referencing this issue means residual scope must be re-derived from what
+      already landed — that comparison is judgment, so the weak seat parks.
+    command: gh pr list --state all --search "{issue_number}" --json number,title,state --limit 10
+    evidence_predicate:
+      command: gh pr list --state all --search "{issue_number}" --json number --limit 10
+      success_pattern: '^\[\]$'
+    transitions:
+      no_siblings: capacity_check
+      siblings_found: STOP-manual-intervention
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: capacity_check
+    intent: >-
+      Two-sided width check per the width table: codexbar pace stage + reserve per
+      candidate lane, and disk (df -h / plus du -sh .worktrees — a dispatch worktree
+      costs roughly half a GB; DISK WINS every conflict). No pace data for a lane →
+      use in-flight count + lane health and say the picture is partial.
+    command: codexbar usage --json
+    evidence_predicate:
+      command: df -h / | tail -1
+      success_pattern: '\d+G?i?\s+\d+%'
+    transitions:
+      capacity_ok: route_lane
+      no_capacity: parked_no_capacity
+    kind: table-lookup
+    table: width
+    blocked_on: null
+
+  - step_id: route_lane
+    intent: >-
+      Resolve the seat from the served routing rule for this task family and risk
+      class per the lane-routing table (live-lookup: /api/rules model-assignment is
+      the SSOT; never route from a remembered roster). Language-lane restrictions,
+      judge-seat exclusions, and cross-family pairing bind.
+    command: curl -s --max-time 3 "http://127.0.0.1:8765/api/rules?format=markdown"
+    evidence_predicate:
+      command: curl -s -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:8765/api/rules"
+      success_pattern: '200'
+    transitions:
+      lane_resolved: author_brief
+      api_down_fallback_files: author_brief
+      no_sanctioned_lane: STOP-precondition-failed
+    kind: table-lookup
+    table: lane-routing
+    blocked_on: null
+
+  - step_id: author_brief
+    intent: >-
+      Brief content is judgment: scope boundaries, required tests and their mutation
+      checks, hard exclusions, and the #M-4 evidence preamble steer the worker's whole
+      arc. The weak seat summons judgment for brief authorship (template:
+      .agent/tmp/reviews/*-brief.md conventions — numbered steps, worktree-only work,
+      no auto-merge by worker, one-line finalize comment on the tracking issue). A task
+      whose issue lacks explicit acceptance criteria stops as a failed precondition,
+      not a guessed brief.
+    command: null
+    evidence_predicate: null
+    transitions:
+      brief_written: dispatch_worker
+      no_clear_spec: STOP-precondition-failed
+    kind: summon
+    blocked_on: null
+
+  - step_id: dispatch_worker
+    intent: >-
+      Fire the dispatch with the classified research flags, --worktree, and the brief
+      file. Live success shape ends with the bare task id on the last line and a
+      "dispatch <task>: branch=... base_sha=... path=..." line above it. Same-lane
+      spawns in the same second race — stagger ~10s. A write-path ownership REFUSE is
+      NOT one outcome: the refusal text distinguishes provable-conflict from
+      cannot-prove-disjoint ("No actual path overlap was found"), and only the latter
+      may be overridden.
+    command: .venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags}
+    evidence_predicate:
+      command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
+      success_pattern: '^(spawning|running)$'
+    transitions:
+      dispatched: arm_settle_watch
+      refuse_no_actual_overlap: override_dispatch
+      refuse_actual_overlap: STOP-concurrency-conflict
+      spawn_error: STOP-unrecoverable-error
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: override_dispatch
+    intent: >-
+      Re-run the same dispatch with --allow-path-overlap '<why this is safe>' ONLY
+      when the refusal said "No actual path overlap was found" (an undeclared active
+      writer elsewhere in the estate blocks the disjointness proof). The reason must
+      name the undeclared writer and why the write surfaces are disjoint. Admitted
+      shape: "write-path ownership: would-refuse recorded (override); admitted under
+      refuse" or "admitted; paths disjoint". A second refusal is a hard stop.
+    command: .venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags} --allow-path-overlap "{overlap_reason}"
+    evidence_predicate:
+      command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
+      success_pattern: '^(spawning|running)$'
+    transitions:
+      dispatched: arm_settle_watch
+      refused_again: STOP-concurrency-conflict
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: arm_settle_watch
+    intent: >-
+      Arm ONE Monitor settle-loop over the task status file — the file is truth (the
+      active-list API can omit live tasks). The loop polls jq -r '.status' every 60-90s
+      and emits exactly once when the status leaves {spawning, running, ""}. Never
+      keyword-grep worker logs as a completion signal; never poll with scheduled
+      wakeups when a Monitor can watch.
+    command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
+    evidence_predicate:
+      command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
+      success_pattern: '^(spawning|running|done|failed|timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable)$'
+    transitions:
+      watch_armed: await_settle
+      task_file_missing: STOP-unrecoverable-error
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: await_settle
+    intent: >-
+      Wait state (kind-wait note in the header): the seat idles on the Monitor's settle
+      event; no polling loops, no log grepping. The settle event's payload is the
+      terminal status string, which the next step routes through the settle-status
+      table. A watch that outlives its Monitor (session end, watcher reaped) is re-armed,
+      not forgotten.
+    command: null
+    evidence_predicate: null
+    transitions:
+      settle_event: finalize_settle
+      watcher_lost: arm_settle_watch
+    kind: summon
+    blocked_on: null
+
+  - step_id: finalize_settle
+    intent: >-
+      Route the terminal status through the settle-status table. Non-negotiables lived
+      this session: done still requires reading the produced CONTENT (result file, PR
+      diff) before the review gate; no_deliverable is an attention state, not a fact —
+      three consecutive false negatives (#5855 class) were disproven by checking the
+      branch head against the PR head before re-dispatching anything; timeout checks
+      the worktree for finished-but-unpushed work AND gh pr list for an already-opened
+      PR (silent-exit class); failed/crashed re-fires ONCE with a -retry task id and
+      never a third time.
+    command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
+    evidence_predicate:
+      command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
+      success_pattern: '^(done|failed|timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable)$'
+    transitions:
+      deliverable_verified_pr_open: handed_to_pr_lifecycle
+      refire_once: dispatch_worker
+      reroute_lane: route_lane
+      unrecoverable: STOP-unrecoverable-error
+      unknown_status: STOP-unknown
+    kind: table-lookup
+    table: settle-status
+    blocked_on: null

--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -32,7 +32,7 @@
 # arc and multi-signal branchings collapse back into fewer steps.
 schema_version: trailspec.v1
 trail_id: rb2-dispatch-loop
-version: "0.6.0"
+version: "0.7.0"
 title: RB2 Dispatch loop — brief, dispatch, settle, finalize
 seats:
   - grok-daily
@@ -280,8 +280,8 @@ steps:
       success_pattern: '^(done|failed|timeout|silence-timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable|spawning|running)$'
     transitions:
       done: verify_deliverable_success
-      timeout: verify_deliverable_attention
-      silence_timeout: verify_deliverable_attention
+      timeout: verify_deliverable_timeout
+      silence_timeout: verify_deliverable_timeout
       needs_finalize: verify_deliverable_attention
       no_deliverable: verify_deliverable_attention
       failed: retry_suffix_gate
@@ -308,6 +308,23 @@ steps:
       success_pattern: '"number"'
     transitions:
       pr_open: handed_to_pr_lifecycle
+      no_pr_for_branch: commits_ahead_check
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: verify_deliverable_timeout
+    intent: >-
+      Timeout path (timeout / silence-timeout): the same PR receipt check. An open
+      PR is finalize-BY-HAND (a died-at-deadline worker's deliverable needs eyes).
+      No PR routes into the commits-ahead/dirty-tree chain, whose clean-and-empty
+      outcome reaches the bounded failed/crashed retry — the table's disposition for
+      a deliverable-less timeout ("treat as the failed|crashed rows").
+    command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
+    evidence_predicate:
+      command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
+      success_pattern: '"number"'
+    transitions:
+      pr_open: STOP-manual-intervention
       no_pr_for_branch: commits_ahead_check
     kind: mechanical
     blocked_on: null

--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -2,25 +2,28 @@
 # infra driver's dispatch-brief checklist and settle discipline). Part of #5885.
 #
 # DRAFT STATUS: authored against today's substrate per the panel's draft-now ruling;
-# certification waits for T1.4/5. Steps that depend on unbuilt machinery carry an
-# explicit blocked_on marker.
+# certification waits for T1.4/5.
 #
-# Anti-pattern guard (the #5860 r1 lessons, held to the RB-1 bar and re-tightened by
-# the #5915 r1 sealed review): every command below is a real, currently runnable repo
-# command whose OUTPUT SHAPE was captured from a live run (2026-07-27/28 infra session:
-# dispatches fix-5900/fix-5893/t13-glm-canary, the write-path REFUSE + override, three
-# live no_deliverable false negatives); every transition input is derivable from that
-# step's evidence — steps whose branching needed evidence the old draft lacked were
-# SPLIT (refusal triage, deliverable verification, silent-exit check, refire gate);
-# classification correctness is not machine-checkable, so it lives in the brief summon,
-# not a mechanical step. Unknown situations exit through a published STOP code.
+# Anti-pattern guard (the #5860 r1 lessons, tightened by the #5915 r1+r2 sealed
+# reviews): every command below is a real, currently runnable repo command whose
+# OUTPUT SHAPE was captured from a live run (2026-07-27/28 infra session); every
+# MECHANICAL step is single-signal — its transition input is derivable from its own
+# predicate's output vocabulary, and branchings that need more than one signal are
+# SPLIT into single-signal steps (PR check → commits-ahead → dirty-tree chains).
+# Where proof is impossible the trail FAILS CLOSED and says so (a REFUSE that is not
+# provably benign is treated as a real conflict; no step claims to prove the
+# unprovable). Live-lookup tables (width, lane-routing) are procedures by design —
+# their steps' predicates prove the table's INPUTS were captured; the weighing itself
+# is the table's, and its output is recorded in the receipt the next step consumes.
 #
 # kind-wait note (spec v1.1 carry-over): trailspec.v1 has no `wait` kind — the
 # await_settle step is a summon whose documentation-predicate is the Monitor settle
-# event; the transition source is the settle-status table lookup that follows it.
+# event. SCHEMA NOTE for v1.1 (proposal, operator/advisor call — not built): steps
+# with per-transition evidence predicates would let multi-signal branchings stay in
+# one step; until then the split-step pattern here is the honest encoding.
 schema_version: trailspec.v1
 trail_id: rb2-dispatch-loop
-version: "0.2.0"
+version: "0.3.0"
 title: RB2 Dispatch loop — brief, dispatch, settle, finalize
 seats:
   - grok-daily
@@ -40,18 +43,17 @@ terminal_outcomes:
 steps:
   - step_id: drain_slot_inbox
     intent: >-
-      Mandatory inbox-drain substep (drive-epic 4a pattern): before firing new work,
-      surface pending slot deliveries for this seat. Live output shape is "<agent>
-      inbox:" followed by "pending: N (oldest ...)". NOTE (live-verified in the #5915
-      sealed review): show is not a pure read — it expires stale deliveries via an
-      UPDATE, so it needs a writable DB; a read-only environment fails here loudly,
-      which is a precondition failure, not a skip.
+      Mandatory inbox-drain substep (drive-epic 4a pattern): surface pending slot
+      deliveries before firing new work. Live output shape: "<agent> inbox:" then
+      "pending: N (oldest ...)". NOTE (live-verified in the #5915 r1 review): show is
+      not a pure read — it expires stale deliveries via an UPDATE; a read-only DB
+      fails loudly here, which is a precondition failure, not a skip.
     command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
     evidence_predicate:
       command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
       success_pattern: 'pending:\s+0'
     transitions:
-      empty: capacity_check
+      empty: disk_floor_check
       pending_deliveries: drain_once
       db_not_writable: STOP-precondition-failed
     kind: mechanical
@@ -59,32 +61,48 @@ steps:
 
   - step_id: drain_once
     intent: >-
-      Run the thread-coalesced inbox worker exactly once for this seat, then re-check.
-      Still-pending after one drain means a delivery needs handling this trail cannot
-      do mechanically.
+      Run the thread-coalesced inbox worker exactly once, then re-check. Still-pending
+      after one drain needs handling this trail cannot do mechanically.
     command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} run {handoff_agent}
     evidence_predicate:
       command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
       success_pattern: 'pending:\s+0'
     transitions:
-      drained: capacity_check
+      drained: disk_floor_check
       still_pending: STOP-manual-intervention
     kind: mechanical
     blocked_on: null
 
-  - step_id: capacity_check
+  - step_id: disk_floor_check
     intent: >-
-      Two-sided width check per the width table. ALL inputs the table weighs are
-      captured into one receipt before the lookup: codexbar pace stage + reserve per
-      lane, free disk, and worktree footprint (a dispatch worktree costs roughly half
-      a GB; DISK WINS every conflict). The predicate proves the receipt holds all
-      three input classes — a receipt missing any input means the lookup ran blind,
-      which the table forbids ("no data → say the picture is partial", never silently
-      proceed on nothing).
+      The width table's dominant clause ("DISK WINS every conflict") is mechanically
+      checkable on its own: free space on / must clear the floor for at least one
+      dispatch worktree (~0.5 GB each; floor set at 10G to leave estate headroom —
+      live shape of the probe: a bare avail field like "184G"). Below the floor no
+      quota argument can widen; reaping finished worktrees is the recovery.
+    command: df -h / | awk 'NR==2 {print $4}'
+    evidence_predicate:
+      command: df -h / | awk 'NR==2 {print $4}'
+      success_pattern: '^([1-9][0-9]|[0-9]{3,})[GT]i?$'
+    transitions:
+      floor_cleared: width_weigh
+      below_floor: parked_no_capacity
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: width_weigh
+    intent: >-
+      Width is a LIVE-LOOKUP table: the weighing of per-lane pace stage + reserve
+      against in-flight load is the table's procedure, not this step's predicate. The
+      step's obligation is that ALL inputs the table weighs are captured into one
+      receipt (codexbar pace rows, free disk, worktree footprint) — the ANDed
+      predicate proves each input class is present, so the lookup never runs blind
+      ("no data → say the picture is partial"). The table's output (which lanes have
+      headroom) is written into the same receipt for the routing step to consume.
     command: sh -c 'R=batch_state/rb2-width-receipt.txt; codexbar usage --json > "$R" 2>&1; df -h / >> "$R"; du -sh .worktrees >> "$R"; cat "$R"'
     evidence_predicate:
-      command: sh -c 'R=batch_state/rb2-width-receipt.txt; grep -c -e "provider" -e "%" -e ".worktrees" "$R"'
-      success_pattern: '^[3-9][0-9]*$|^[1-9][0-9]+$'
+      command: sh -c 'R=batch_state/rb2-width-receipt.txt; grep -q -e "provider" "$R" && grep -q -e "%" "$R" && grep -q -e ".worktrees" "$R" && echo all-inputs-present'
+      success_pattern: '^all-inputs-present$'
     transitions:
       capacity_ok: route_lane
       no_capacity: parked_no_capacity
@@ -95,18 +113,18 @@ steps:
 
   - step_id: route_lane
     intent: >-
-      Fetch the served routing SSOT to a receipt file and resolve the seat by APPLYING
-      its model-assignment table for this task family and risk class (lane-routing
-      table binds: language-lane restrictions, judge-seat exclusions, cross-family
-      pairing). The predicate proves the routing document was actually fetched and
-      contains the assignment section — reachability alone (an HTTP 200) is NOT
-      resolution evidence. API down → the offline fallback files under
-      agents_extensions/shared/rules/ are the same content; resolution still happens
-      from a read document, never from memory. No sanctioned lane for the family is a
-      hard stop.
+      Lane-routing is a LIVE-LOOKUP table applied to the served routing SSOT. The
+      step fetches the document to a receipt (offline fallback: the shared rules
+      file — same content) and the predicate proves the receipt is the real
+      assignment document (its live first heading is "Per-Task Model Assignment").
+      The resolved lane is recorded in the brief the next step authors — that brief
+      is the auditable resolution artifact. Capability confirmation via check-model
+      exists only for agy/kimi today (live-verified: the CLI's --agent choices);
+      other lanes rely on the routing doc + fallback substitutions. No sanctioned
+      lane for the family is a hard stop.
     command: sh -c 'curl -s --max-time 3 "http://127.0.0.1:8765/api/rules?format=markdown" -o batch_state/rb2-rules-receipt.md || cp agents_extensions/shared/rules/model-assignment.md batch_state/rb2-rules-receipt.md'
     evidence_predicate:
-      command: grep -c -i -e "model" -e "assignment" batch_state/rb2-rules-receipt.md
+      command: grep -c -e "Per-Task Model Assignment" -e "model-assignment" batch_state/rb2-rules-receipt.md
       success_pattern: '^[1-9][0-9]*$'
     transitions:
       lane_resolved: author_brief
@@ -119,17 +137,17 @@ steps:
   - step_id: author_brief
     intent: >-
       Judgment authors the brief AND the research-registry classification together —
-      they are the same cognitive act (what is this task, what does it own, what must
-      the worker prove). Registry duty: pass every dimension explicitly derivable from
-      the issue/brief text, omit every dimension that is not (pointer-free is a legal
-      deliberate outcome; never invent a value; never infer from provider or agent
-      name). Brief conventions: numbered steps, worktree-only work, #M-4 evidence
-      preamble, required tests + mutation checks, hard exclusions, no auto-merge by
-      worker, one-line finalize comment on the tracking issue. Step 0 belongs here
-      too: sibling search by ISSUE REFERENCE (gh pr list --state all --search
-      "<issue-nr>" — live shape: JSON array, [] means clear) and the issue timeline —
-      residual-scope judgment on any hit. An issue without explicit acceptance
-      criteria stops as a failed precondition, not a guessed brief.
+      the same cognitive act (what is this task, what does it own, what must the
+      worker prove). Registry duty: pass dimensions explicitly derivable from the
+      issue text, omit the rest (pointer-free is legal and deliberate; never invent;
+      never infer from provider/agent name). The resolved lane from route_lane is
+      recorded here. Brief conventions: numbered steps, worktree-only, #M-4 evidence
+      preamble, tests + mutation checks, hard exclusions, no auto-merge by worker,
+      one-line finalize comment on the tracking issue. Step 0 lives here: sibling
+      search by ISSUE REFERENCE (gh pr list --state all --search "<issue-nr>" — live
+      shape: JSON array, [] clear) + issue timeline; residual-scope judgment on any
+      hit. No explicit acceptance criteria → failed precondition, never a guessed
+      brief.
     command: null
     evidence_predicate: null
     transitions:
@@ -141,38 +159,52 @@ steps:
 
   - step_id: dispatch_worker
     intent: >-
-      Fire the dispatch with the brief and classified research flags, teeing all
-      output to a per-task log — the log is what later steps triage. Live success
-      shape ends with the bare task id and a "dispatch <task>: branch=... base_sha=...
-      path=..." line; the task state file appears with status spawning|running.
-      Same-lane spawns in the same second race — stagger ~10s.
+      Fire the dispatch, teeing all output to the per-task log later steps triage.
+      This step's OWN signal is the task state file: present with status
+      spawning|running means dispatched. Absent task file routes to the log triage
+      step — the log, not this predicate, discriminates refusal from spawn error
+      (single-signal rule).
     command: sh -c '.venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags} 2>&1 | tee batch_state/rb2-dispatch-{task_id}.log'
     evidence_predicate:
       command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
       success_pattern: '^(spawning|running)$'
     transitions:
       dispatched: arm_settle_watch
-      refused: triage_refusal
-      spawn_error: STOP-unrecoverable-error
+      no_task_file: triage_dispatch_log
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: triage_dispatch_log
+    intent: >-
+      Single-signal log triage: the teed dispatch log either contains a write-path
+      REFUSE or it does not. REFUSE present routes to the benign-refusal proof;
+      REFUSE absent with no task file is a spawn error.
+    command: grep -e "REFUSE" batch_state/rb2-dispatch-{task_id}.log
+    evidence_predicate:
+      command: grep -c -e "REFUSE" batch_state/rb2-dispatch-{task_id}.log
+      success_pattern: '^[0-9]+$'
+    transitions:
+      refuse_present: triage_refusal
+      refuse_absent_spawn_error: STOP-unrecoverable-error
     kind: mechanical
     blocked_on: null
 
   - step_id: triage_refusal
     intent: >-
-      A write-path ownership REFUSE is two different situations and the refusal text
-      is the discriminator (live-captured 2026-07-27): "No actual path overlap was
-      found" means an undeclared active writer elsewhere blocks the disjointness
-      PROOF — overridable with judgment approval; a refusal naming an actual
-      conflicting path is a real concurrency conflict and a hard stop. The predicate
-      evidences the discriminator from the teed dispatch log, so the branch is
-      derivable, not asserted.
-    command: grep -e "REFUSE" batch_state/rb2-dispatch-{task_id}.log
+      FAIL-CLOSED refusal semantics (this step does not claim to prove an actual
+      overlap — that shape has never been live-captured): the ONLY refusal proven
+      benign is the disjointness-proof gap whose live-captured text is "No actual
+      path overlap was found" (an undeclared active writer elsewhere blocks the
+      proof). That exact phrase routes to judgment for an override decision. Every
+      other refusal text is treated as a real concurrency conflict BY DESIGN —
+      conservative, and honest about what is proven.
+    command: grep -e "No actual path overlap was found" batch_state/rb2-dispatch-{task_id}.log
     evidence_predicate:
       command: grep -c -e "No actual path overlap was found" batch_state/rb2-dispatch-{task_id}.log
-      success_pattern: '^[1-9]'
+      success_pattern: '^[0-9]+$'
     transitions:
-      no_actual_overlap: approve_override
-      actual_overlap: STOP-concurrency-conflict
+      provably_benign: approve_override
+      not_provably_benign: STOP-concurrency-conflict
     kind: mechanical
     blocked_on: null
 
@@ -180,8 +212,7 @@ steps:
     intent: >-
       Judgment reviews the refusal text and the undeclared writer it names, and
       writes the override reason (who the writer is, why the write surfaces are
-      disjoint). The safety rationale is a judgment product — a weak seat never
-      self-approves an ownership override.
+      disjoint). A weak seat never self-approves an ownership override.
     command: null
     evidence_predicate: null
     transitions:
@@ -192,10 +223,9 @@ steps:
 
   - step_id: override_dispatch
     intent: >-
-      Re-run the identical dispatch with the approved --allow-path-overlap reason,
-      teeing to the same log family. Admitted shapes (live-captured): "would-refuse
-      recorded (override); admitted under refuse" or "admitted; paths disjoint". A
-      second refusal is a hard stop.
+      Re-run the identical dispatch with the approved --allow-path-overlap reason.
+      Admitted shapes (live-captured): "would-refuse recorded (override); admitted
+      under refuse" or "admitted; paths disjoint". A second refusal is a hard stop.
     command: sh -c '.venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags} --allow-path-overlap "{overlap_reason}" 2>&1 | tee batch_state/rb2-dispatch-{task_id}-override.log'
     evidence_predicate:
       command: grep -c -e "admitted under refuse" -e "admitted; paths disjoint" batch_state/rb2-dispatch-{task_id}-override.log
@@ -209,14 +239,14 @@ steps:
   - step_id: arm_settle_watch
     intent: >-
       Arm ONE Monitor settle-loop over the task status file — the file is truth (the
-      active-list API can omit live tasks). The loop polls jq -r '.status' every
-      60-90s and emits exactly once when the status leaves {spawning, running, ""}.
-      Never keyword-grep worker logs as a completion signal; never poll with scheduled
-      wakeups when a Monitor can watch.
+      active-list API can omit live tasks). Poll jq -r '.status' every 60-90s, emit
+      exactly once when status leaves {spawning, running, ""}. Never keyword-grep
+      worker logs as completion; never poll with scheduled wakeups when a Monitor can
+      watch.
     command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
     evidence_predicate:
       command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
-      success_pattern: '^(spawning|running|done|failed|timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable)$'
+      success_pattern: '^(spawning|running|done|failed|timeout|silence-timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable)$'
     transitions:
       watch_armed: await_settle
       task_file_missing: STOP-unrecoverable-error
@@ -225,11 +255,9 @@ steps:
 
   - step_id: await_settle
     intent: >-
-      Wait state (kind-wait note in the header): the seat idles on the Monitor's
-      settle event; no polling loops, no log grepping. The settle event's payload is
-      the terminal status string, which the next step routes through the settle-status
-      table. A watch that outlives its Monitor (session end, watcher reaped) is
-      re-armed, not forgotten.
+      Wait state (kind-wait header note): idle on the Monitor's settle event — its
+      payload is the terminal status string the next step routes. A watch that
+      outlives its Monitor (session end, watcher reaped) is re-armed, not forgotten.
     command: null
     evidence_predicate: null
     transitions:
@@ -240,29 +268,31 @@ steps:
 
   - step_id: finalize_settle
     intent: >-
-      Route the terminal status through the settle-status table — EVERY row of the
-      table has a distinct transition here, none are folded: done and the attention
-      states (needs_finalize, no_deliverable) go to deliverable verification
-      (no_deliverable is an attention state, not a fact — three live #5855-class false
-      negatives this session were disproven by checking the branch); timeout goes to
-      the silent-exit check; failed/crashed go to the refire gate; rate_limited
-      reroutes the lane per fallback substitutions; cancelled and dry_run are
-      terminal-not-success and end this dispatch arc; anything outside the published
-      vocabulary is unknown.
+      Route the terminal status through the settle-status table — every row mapped:
+      done and the attention states (needs_finalize, no_deliverable — an attention
+      state, not a fact; #5855-class false negatives are disproven by checking the
+      branch) AND both timeout flavors go to deliverable verification first (an open
+      PR satisfies "check gh pr list" for the silent-exit class before any worktree
+      digging); failed/crashed go to the retry mint; rate_limited reroutes per
+      fallback substitutions; cancelled/dry_run are terminal-not-success; a spurious
+      settle event with status still spawning/running re-enters the wait (the
+      table's not-terminal row); anything else is unknown.
     command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
     evidence_predicate:
       command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
-      success_pattern: '^(done|failed|timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable)$'
+      success_pattern: '^(done|failed|timeout|silence-timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable|spawning|running)$'
     transitions:
       done: verify_deliverable
       needs_finalize: verify_deliverable
       no_deliverable: verify_deliverable
-      timeout: silent_exit_check
-      failed: refire_gate
-      crashed: refire_gate
+      timeout: verify_deliverable
+      silence_timeout: verify_deliverable
+      failed: mint_retry_id
+      crashed: mint_retry_id
       rate_limited: route_lane
       cancelled: aborted
       dry_run: aborted
+      still_spawning_or_running: await_settle
       unknown_status: STOP-unknown
     kind: table-lookup
     table: settle-status
@@ -271,48 +301,80 @@ steps:
   - step_id: verify_deliverable
     intent: >-
       Deliverable verification is tool-backed, never status-backed: an open PR for
-      the dispatch branch is the deliverable receipt (live shape: JSON array with the
-      PR number). done still requires the produced CONTENT to be read before the
-      review gate — that reading is RB-3's entry. No PR for the branch routes to the
-      silent-exit check (the branch may hold pushed-but-unopened or committed-but-
-      unpushed work).
+      the dispatch branch is the deliverable receipt (live shape: JSON array with a
+      number field; [] means none). Reading the produced CONTENT before the review
+      gate is RB-3's entry. No PR routes to the commits-ahead check.
     command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
     evidence_predicate:
       command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
       success_pattern: '"number"'
     transitions:
       pr_open: handed_to_pr_lifecycle
-      no_pr_for_branch: silent_exit_check
+      no_pr_for_branch: commits_ahead_check
     kind: mechanical
     blocked_on: null
 
-  - step_id: silent_exit_check
+  - step_id: commits_ahead_check
     intent: >-
-      Silent-exit class: a worker can finish real work and die before opening the PR.
-      Inspect the dispatch worktree's history and status against its base. Work
-      present (commits ahead of base, or a dirty tree with substantive changes) is a
-      judgment finalize — summon; provably absent work falls to the refire gate.
-    command: git -C .worktrees/dispatch/{lane}/{task_id} log --oneline -5
+      Single-signal: count commits the dispatch worktree carries beyond its recorded
+      base (the dispatch line's base_sha). Non-zero means finished-but-unpushed or
+      pushed-but-unopened work — a judgment finalize, never a blind refire over real
+      work. Zero falls through to the dirty-tree check.
+    command: git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count {base_sha}..HEAD
     evidence_predicate:
-      command: git -C .worktrees/dispatch/{lane}/{task_id} status --porcelain
-      success_pattern: '.*'
+      command: git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count {base_sha}..HEAD
+      success_pattern: '^[0-9]+$'
     transitions:
-      work_present: STOP-manual-intervention
-      work_absent: refire_gate
+      commits_present: STOP-manual-intervention
+      no_commits: dirty_tree_check
     kind: mechanical
     blocked_on: null
 
-  - step_id: refire_gate
+  - step_id: dirty_tree_check
     intent: >-
-      One automatic re-fire, never a third attempt: a task id already carrying the
-      -retry suffix has consumed its re-fire and stops at the published
-      max-retries code. The suffix check is string-mechanical on the task id.
-    command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo first-attempt ;; esac'
+      Single-signal: count dirty entries in the dispatch worktree. Non-zero means
+      uncommitted work — judgment finalize (#M-10: never delete uncommitted work).
+      Zero means provably no deliverable anywhere → the retry mint.
+    command: sh -c 'git -C .worktrees/dispatch/{lane}/{task_id} status --porcelain | wc -l | tr -d " "'
     evidence_predicate:
-      command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo first-attempt ;; esac'
-      success_pattern: '^(already-retried|first-attempt)$'
+      command: sh -c 'git -C .worktrees/dispatch/{lane}/{task_id} status --porcelain | wc -l | tr -d " "'
+      success_pattern: '^[0-9]+$'
     transitions:
-      first_attempt_refire: dispatch_worker
+      dirty_entries_present: STOP-manual-intervention
+      clean_and_empty: mint_retry_id
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: mint_retry_id
+    intent: >-
+      One automatic re-fire, never a third: a task id already carrying -retry has
+      consumed its re-fire (published max-retries stop). Otherwise mint the retry id
+      by suffixing -retry and RECORD it — the retry dispatch step uses the recorded
+      id, so the original id is never re-fired (the r2 review's loop finding).
+      Cleanup of the failed attempt's worktree/branch precedes the re-fire per the
+      settle-status row.
+    command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo "{task_id}-retry" > batch_state/rb2-retry-{task_id}.txt; cat batch_state/rb2-retry-{task_id}.txt ;; esac'
+    evidence_predicate:
+      command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) cat batch_state/rb2-retry-{task_id}.txt ;; esac'
+      success_pattern: '^(already-retried|.+-retry)$'
+    transitions:
+      retry_id_minted: dispatch_retry
       already_retried: STOP-max-retries-exceeded
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: dispatch_retry
+    intent: >-
+      Re-fire ONCE under the minted -retry id (read from the retry receipt), same
+      brief, same lane, teeing to the retry log. From here the loop re-enters at the
+      settle watch on the NEW id; if the retry also fails, mint_retry_id sees the
+      -retry suffix and stops at max-retries.
+    command: sh -c 'RID=$(cat batch_state/rb2-retry-{task_id}.txt); .venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id "$RID" --prompt-file {brief_path} --worktree --mode danger {research_flags} 2>&1 | tee "batch_state/rb2-dispatch-$RID.log"'
+    evidence_predicate:
+      command: sh -c 'RID=$(cat batch_state/rb2-retry-{task_id}.txt); jq -r ".status // \"\"" "batch_state/tasks/$RID.json"'
+      success_pattern: '^(spawning|running)$'
+    transitions:
+      retry_dispatched: arm_settle_watch
+      retry_spawn_failed: STOP-unrecoverable-error
     kind: mechanical
     blocked_on: null

--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -4,26 +4,32 @@
 # DRAFT STATUS: authored against today's substrate per the panel's draft-now ruling;
 # certification waits for T1.4/5.
 #
-# Anti-pattern guard (the #5860 r1 lessons, tightened by the #5915 r1+r2 sealed
-# reviews): every command below is a real, currently runnable repo command whose
-# OUTPUT SHAPE was captured from a live run (2026-07-27/28 infra session); every
-# MECHANICAL step is single-signal — its transition input is derivable from its own
-# predicate's output vocabulary, and branchings that need more than one signal are
-# SPLIT into single-signal steps (PR check → commits-ahead → dirty-tree chains).
-# Where proof is impossible the trail FAILS CLOSED and says so (a REFUSE that is not
-# provably benign is treated as a real conflict; no step claims to prove the
-# unprovable). Live-lookup tables (width, lane-routing) are procedures by design —
-# their steps' predicates prove the table's INPUTS were captured; the weighing itself
-# is the table's, and its output is recorded in the receipt the next step consumes.
+# Anti-pattern guard (the #5860 r1 lessons, tightened across the #5915 r1-r3 sealed
+# reviews): every command is a real, currently runnable repo command whose OUTPUT
+# SHAPE was captured live (2026-07-27/28 infra session); every MECHANICAL step is
+# single-signal (transition derivable from its own predicate's vocabulary; multi-
+# signal branchings are split); where proof is impossible the trail FAILS CLOSED and
+# says so. Live-lookup tables (width, lane-routing) are procedures by design: their
+# steps' predicates prove the table's INPUTS were captured, and the SEAT records the
+# applied decision as a receipt line — an auditable write obligation, not a machine
+# derivation (stated per the r3 review).
 #
-# kind-wait note (spec v1.1 carry-over): trailspec.v1 has no `wait` kind — the
-# await_settle step is a summon whose documentation-predicate is the Monitor settle
-# event. SCHEMA NOTE for v1.1 (proposal, operator/advisor call — not built): steps
-# with per-transition evidence predicates would let multi-signal branchings stay in
-# one step; until then the split-step pattern here is the honest encoding.
+# RETRY MODEL (r3 finding): trailspec.v1 has no cross-step variable rebinding, so a
+# re-fire is a NEW INVOCATION of this same trail with task_id=<old>-retry. This
+# invocation ends at the terminal `refired_new_invocation`; the -retry invocation's
+# own retry gate hits the -retry suffix on a second failure and stops with the
+# settle-status table's exact code (STOP-unrecoverable-error). Bounded, no rebinding.
+#
+# kind-wait note (spec v1.1 carry-over): trailspec.v1 has no `wait` kind — settle
+# waiting is a summon whose documentation-predicate covers arming ONE Monitor
+# settle-loop and idling on its event (a Monitor arm is a harness action with no repo
+# command to predicate on — encoding it as mechanical was the r3 finding). SCHEMA
+# NOTE for v1.1 (proposal, operator/advisor call — not built): per-transition
+# evidence predicates + an invocation-parameter rebinding form would let the retry
+# arc and multi-signal branchings collapse back into fewer steps.
 schema_version: trailspec.v1
 trail_id: rb2-dispatch-loop
-version: "0.3.0"
+version: "0.4.0"
 title: RB2 Dispatch loop — brief, dispatch, settle, finalize
 seats:
   - grok-daily
@@ -32,13 +38,13 @@ seats:
 stop_codes:
   - STOP-precondition-failed
   - STOP-concurrency-conflict
-  - STOP-max-retries-exceeded
   - STOP-unrecoverable-error
   - STOP-manual-intervention
   - STOP-unknown
 terminal_outcomes:
   - handed_to_pr_lifecycle
   - parked_no_capacity
+  - refired_new_invocation
   - aborted
 steps:
   - step_id: drain_slot_inbox
@@ -61,8 +67,8 @@ steps:
 
   - step_id: drain_once
     intent: >-
-      Run the thread-coalesced inbox worker exactly once, then re-check. Still-pending
-      after one drain needs handling this trail cannot do mechanically.
+      Run the thread-coalesced inbox worker exactly once, then re-check.
+      Still-pending after one drain needs handling this trail cannot do mechanically.
     command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} run {handoff_agent}
     evidence_predicate:
       command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
@@ -75,11 +81,11 @@ steps:
 
   - step_id: disk_floor_check
     intent: >-
-      The width table's dominant clause ("DISK WINS every conflict") is mechanically
-      checkable on its own: free space on / must clear the floor for at least one
-      dispatch worktree (~0.5 GB each; floor set at 10G to leave estate headroom —
-      live shape of the probe: a bare avail field like "184G"). Below the floor no
-      quota argument can widen; reaping finished worktrees is the recovery.
+      The width table's dominant clause ("DISK WINS every conflict") checked alone:
+      free space on / must clear the floor for at least one dispatch worktree
+      (~0.5 GB each; floor 10G for estate headroom — live probe shape: a bare avail
+      field like "184G"). Below the floor no quota argument can widen; reaping
+      finished worktrees is the recovery.
     command: df -h / | awk 'NR==2 {print $4}'
     evidence_predicate:
       command: df -h / | awk 'NR==2 {print $4}'
@@ -93,12 +99,13 @@ steps:
   - step_id: width_weigh
     intent: >-
       Width is a LIVE-LOOKUP table: the weighing of per-lane pace stage + reserve
-      against in-flight load is the table's procedure, not this step's predicate. The
-      step's obligation is that ALL inputs the table weighs are captured into one
-      receipt (codexbar pace rows, free disk, worktree footprint) — the ANDed
-      predicate proves each input class is present, so the lookup never runs blind
-      ("no data → say the picture is partial"). The table's output (which lanes have
-      headroom) is written into the same receipt for the routing step to consume.
+      against in-flight load is the table's procedure. This step's machine obligation
+      is input completeness — the ANDed predicate proves each input class (codexbar
+      pace rows, disk, worktree footprint) is present so the lookup never runs blind.
+      The SEAT then appends the applied decision to the same receipt as a line
+      "decision: capacity_ok|no_capacity — <one-line basis>" — an auditable write
+      obligation (r3 review: the decision must be recorded, and it is recorded BY THE
+      SEAT applying the table, not derived by this predicate).
     command: sh -c 'R=batch_state/rb2-width-receipt.txt; codexbar usage --json > "$R" 2>&1; df -h / >> "$R"; du -sh .worktrees >> "$R"; cat "$R"'
     evidence_predicate:
       command: sh -c 'R=batch_state/rb2-width-receipt.txt; grep -q -e "provider" "$R" && grep -q -e "%" "$R" && grep -q -e ".worktrees" "$R" && echo all-inputs-present'
@@ -115,13 +122,12 @@ steps:
     intent: >-
       Lane-routing is a LIVE-LOOKUP table applied to the served routing SSOT. The
       step fetches the document to a receipt (offline fallback: the shared rules
-      file — same content) and the predicate proves the receipt is the real
-      assignment document (its live first heading is "Per-Task Model Assignment").
-      The resolved lane is recorded in the brief the next step authors — that brief
-      is the auditable resolution artifact. Capability confirmation via check-model
-      exists only for agy/kimi today (live-verified: the CLI's --agent choices);
-      other lanes rely on the routing doc + fallback substitutions. No sanctioned
-      lane for the family is a hard stop.
+      file — same content); the predicate proves the receipt is the real assignment
+      document (live first heading: "Per-Task Model Assignment"). The resolved lane
+      is recorded in the brief the next step authors — the auditable resolution
+      artifact. check-model capability confirmation exists only for agy/kimi today
+      (live CLI --agent choices); other lanes rely on the routing doc + fallback
+      substitutions. No sanctioned lane for the family is a hard stop.
     command: sh -c 'curl -s --max-time 3 "http://127.0.0.1:8765/api/rules?format=markdown" -o batch_state/rb2-rules-receipt.md || cp agents_extensions/shared/rules/model-assignment.md batch_state/rb2-rules-receipt.md'
     evidence_predicate:
       command: grep -c -e "Per-Task Model Assignment" -e "model-assignment" batch_state/rb2-rules-receipt.md
@@ -137,17 +143,16 @@ steps:
   - step_id: author_brief
     intent: >-
       Judgment authors the brief AND the research-registry classification together —
-      the same cognitive act (what is this task, what does it own, what must the
-      worker prove). Registry duty: pass dimensions explicitly derivable from the
-      issue text, omit the rest (pointer-free is legal and deliberate; never invent;
-      never infer from provider/agent name). The resolved lane from route_lane is
-      recorded here. Brief conventions: numbered steps, worktree-only, #M-4 evidence
-      preamble, tests + mutation checks, hard exclusions, no auto-merge by worker,
-      one-line finalize comment on the tracking issue. Step 0 lives here: sibling
-      search by ISSUE REFERENCE (gh pr list --state all --search "<issue-nr>" — live
-      shape: JSON array, [] clear) + issue timeline; residual-scope judgment on any
-      hit. No explicit acceptance criteria → failed precondition, never a guessed
-      brief.
+      the same cognitive act. Registry duty: pass dimensions explicitly derivable
+      from the issue text, omit the rest (pointer-free is legal and deliberate; never
+      invent; never infer from provider/agent name). The resolved lane from
+      route_lane is recorded here. Brief conventions: numbered steps, worktree-only,
+      #M-4 evidence preamble, tests + mutation checks, hard exclusions, no auto-merge
+      by worker, one-line finalize comment on the tracking issue. Step 0 lives here:
+      sibling search by ISSUE REFERENCE (gh pr list --state all --search "<issue-nr>"
+      — live shape: JSON array, [] clear) + issue timeline; residual-scope judgment
+      on any hit. No explicit acceptance criteria → failed precondition, never a
+      guessed brief.
     command: null
     evidence_predicate: null
     transitions:
@@ -161,15 +166,14 @@ steps:
     intent: >-
       Fire the dispatch, teeing all output to the per-task log later steps triage.
       This step's OWN signal is the task state file: present with status
-      spawning|running means dispatched. Absent task file routes to the log triage
-      step — the log, not this predicate, discriminates refusal from spawn error
-      (single-signal rule).
+      spawning|running means dispatched. Absent task file routes to log triage — the
+      log, not this predicate, discriminates refusal from spawn error.
     command: sh -c '.venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags} 2>&1 | tee batch_state/rb2-dispatch-{task_id}.log'
     evidence_predicate:
       command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
       success_pattern: '^(spawning|running)$'
     transitions:
-      dispatched: arm_settle_watch
+      dispatched: await_settle
       no_task_file: triage_dispatch_log
     kind: mechanical
     blocked_on: null
@@ -191,13 +195,11 @@ steps:
 
   - step_id: triage_refusal
     intent: >-
-      FAIL-CLOSED refusal semantics (this step does not claim to prove an actual
-      overlap — that shape has never been live-captured): the ONLY refusal proven
-      benign is the disjointness-proof gap whose live-captured text is "No actual
-      path overlap was found" (an undeclared active writer elsewhere blocks the
-      proof). That exact phrase routes to judgment for an override decision. Every
-      other refusal text is treated as a real concurrency conflict BY DESIGN —
-      conservative, and honest about what is proven.
+      FAIL-CLOSED refusal semantics (no claim to prove an actual overlap — that
+      shape has never been live-captured): the ONLY refusal proven benign is the
+      disjointness-proof gap whose live-captured text is "No actual path overlap was
+      found". That exact phrase routes to judgment for an override decision; every
+      other refusal text is treated as a real concurrency conflict BY DESIGN.
     command: grep -e "No actual path overlap was found" batch_state/rb2-dispatch-{task_id}.log
     evidence_predicate:
       command: grep -c -e "No actual path overlap was found" batch_state/rb2-dispatch-{task_id}.log
@@ -231,64 +233,56 @@ steps:
       command: grep -c -e "admitted under refuse" -e "admitted; paths disjoint" batch_state/rb2-dispatch-{task_id}-override.log
       success_pattern: '^[1-9]'
     transitions:
-      dispatched: arm_settle_watch
+      dispatched: await_settle
       refused_again: STOP-concurrency-conflict
-    kind: mechanical
-    blocked_on: null
-
-  - step_id: arm_settle_watch
-    intent: >-
-      Arm ONE Monitor settle-loop over the task status file — the file is truth (the
-      active-list API can omit live tasks). Poll jq -r '.status' every 60-90s, emit
-      exactly once when status leaves {spawning, running, ""}. Never keyword-grep
-      worker logs as completion; never poll with scheduled wakeups when a Monitor can
-      watch.
-    command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
-    evidence_predicate:
-      command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
-      success_pattern: '^(spawning|running|done|failed|timeout|silence-timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable)$'
-    transitions:
-      watch_armed: await_settle
-      task_file_missing: STOP-unrecoverable-error
     kind: mechanical
     blocked_on: null
 
   - step_id: await_settle
     intent: >-
-      Wait state (kind-wait header note): idle on the Monitor's settle event — its
-      payload is the terminal status string the next step routes. A watch that
-      outlives its Monitor (session end, watcher reaped) is re-armed, not forgotten.
+      Settle wait (kind-wait header note): the seat arms ONE Monitor settle-loop
+      over the task status file — the file is truth (the active-list API can omit
+      live tasks); poll cadence 60-90s; emit exactly once when status leaves
+      {spawning, running, ""} — then idles on the settle event, whose payload is the
+      terminal status string the next step routes. Arming a Monitor is a harness
+      action with no repo command to predicate on, which is why this whole
+      arm-and-wait is ONE summon with a documentation-predicate (r3 finding: a
+      mechanical arm step had no derivable evidence). Never keyword-grep worker logs
+      as completion; never poll with scheduled wakeups. A watch that outlives its
+      Monitor (session end, watcher reaped) is re-armed, not forgotten.
     command: null
     evidence_predicate: null
     transitions:
       settle_event: finalize_settle
-      watcher_lost: arm_settle_watch
+      watcher_lost: await_settle
     kind: summon
     blocked_on: null
 
   - step_id: finalize_settle
     intent: >-
-      Route the terminal status through the settle-status table — every row mapped:
-      done and the attention states (needs_finalize, no_deliverable — an attention
-      state, not a fact; #5855-class false negatives are disproven by checking the
-      branch) AND both timeout flavors go to deliverable verification first (an open
-      PR satisfies "check gh pr list" for the silent-exit class before any worktree
-      digging); failed/crashed go to the retry mint; rate_limited reroutes per
-      fallback substitutions; cancelled/dry_run are terminal-not-success; a spurious
-      settle event with status still spawning/running re-enters the wait (the
-      table's not-terminal row); anything else is unknown.
+      Route the terminal status through the settle-status table — every row mapped
+      with the table's own dispositions: done and both timeout flavors go to the
+      success-path deliverable check (an open PR satisfies the table's "gh pr list"
+      check before any worktree digging); the attention states needs_finalize and
+      no_deliverable go to the ATTENTION-path deliverable check whose no-PR branch is
+      finalize-BY-HAND (the table's words — never an automatic retry; #5855-class
+      false negatives are disproven by checking the branch first); failed/crashed go
+      to failure-evidence reading then cleanup then the bounded re-fire;
+      rate_limited reroutes per fallback substitutions; cancelled/dry_run are
+      terminal-not-success; a spurious settle with status still spawning/running
+      re-enters the wait; anything else is unknown.
     command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
     evidence_predicate:
       command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
       success_pattern: '^(done|failed|timeout|silence-timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable|spawning|running)$'
     transitions:
-      done: verify_deliverable
-      needs_finalize: verify_deliverable
-      no_deliverable: verify_deliverable
-      timeout: verify_deliverable
-      silence_timeout: verify_deliverable
-      failed: mint_retry_id
-      crashed: mint_retry_id
+      done: verify_deliverable_success
+      timeout: verify_deliverable_success
+      silence_timeout: verify_deliverable_success
+      needs_finalize: verify_deliverable_attention
+      no_deliverable: verify_deliverable_attention
+      failed: read_failure_evidence
+      crashed: read_failure_evidence
       rate_limited: route_lane
       cancelled: aborted
       dry_run: aborted
@@ -298,12 +292,13 @@ steps:
     table: settle-status
     blocked_on: null
 
-  - step_id: verify_deliverable
+  - step_id: verify_deliverable_success
     intent: >-
-      Deliverable verification is tool-backed, never status-backed: an open PR for
-      the dispatch branch is the deliverable receipt (live shape: JSON array with a
-      number field; [] means none). Reading the produced CONTENT before the review
-      gate is RB-3's entry. No PR routes to the commits-ahead check.
+      Success/timeout path: an open PR for the dispatch branch is the deliverable
+      receipt (live shape: JSON array with a number field; [] means none). Reading
+      the produced CONTENT before the review gate is RB-3's entry. No PR routes to
+      the commits-ahead check (silent-exit class), which may end in the bounded
+      re-fire.
     command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
     evidence_predicate:
       command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
@@ -314,12 +309,28 @@ steps:
     kind: mechanical
     blocked_on: null
 
+  - step_id: verify_deliverable_attention
+    intent: >-
+      Attention path (needs_finalize / no_deliverable): the same PR check, but the
+      table's disposition for these states is finalize BY HAND — a missing PR here
+      routes to judgment, never to an automatic retry (three live #5855-class false
+      negatives this session all had real, pushed deliverables the status missed).
+    command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
+    evidence_predicate:
+      command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
+      success_pattern: '"number"'
+    transitions:
+      pr_open: handed_to_pr_lifecycle
+      no_pr_for_branch: STOP-manual-intervention
+    kind: mechanical
+    blocked_on: null
+
   - step_id: commits_ahead_check
     intent: >-
       Single-signal: count commits the dispatch worktree carries beyond its recorded
-      base (the dispatch line's base_sha). Non-zero means finished-but-unpushed or
-      pushed-but-unopened work — a judgment finalize, never a blind refire over real
-      work. Zero falls through to the dirty-tree check.
+      base (worktree_base_sha in the task file). Non-zero means finished-but-unpushed
+      work — judgment finalize, never a blind refire over real work. Zero falls
+      through to the dirty-tree check.
     command: git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count {base_sha}..HEAD
     evidence_predicate:
       command: git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count {base_sha}..HEAD
@@ -333,48 +344,85 @@ steps:
   - step_id: dirty_tree_check
     intent: >-
       Single-signal: count dirty entries in the dispatch worktree. Non-zero means
-      uncommitted work — judgment finalize (#M-10: never delete uncommitted work).
-      Zero means provably no deliverable anywhere → the retry mint.
+      uncommitted work — judgment finalize (never delete uncommitted work). Zero
+      means provably no deliverable anywhere → the failure-evidence read precedes
+      the bounded re-fire.
     command: sh -c 'git -C .worktrees/dispatch/{lane}/{task_id} status --porcelain | wc -l | tr -d " "'
     evidence_predicate:
       command: sh -c 'git -C .worktrees/dispatch/{lane}/{task_id} status --porcelain | wc -l | tr -d " "'
       success_pattern: '^[0-9]+$'
     transitions:
       dirty_entries_present: STOP-manual-intervention
-      clean_and_empty: mint_retry_id
+      clean_and_empty: read_failure_evidence
     kind: mechanical
     blocked_on: null
 
-  - step_id: mint_retry_id
+  - step_id: read_failure_evidence
     intent: >-
-      One automatic re-fire, never a third: a task id already carrying -retry has
-      consumed its re-fire (published max-retries stop). Otherwise mint the retry id
-      by suffixing -retry and RECORD it — the retry dispatch step uses the recorded
-      id, so the original id is never re-fired (the r2 review's loop finding).
-      Cleanup of the failed attempt's worktree/branch precedes the re-fire per the
-      settle-status row.
+      The settle-status failed/crashed row's first action: read the recorded failure
+      evidence. stderr_excerpt is a real task-file field (live-verified key list);
+      extracting it into the retry receipt preserves the cause for the -retry
+      invocation's brief and for later audit. An empty excerpt is still evidence
+      (recorded as such), so both branches proceed to cleanup.
+    command: sh -c 'jq -r ".stderr_excerpt // \"(no stderr recorded)\"" batch_state/tasks/{task_id}.json | tee batch_state/rb2-failure-{task_id}.txt'
+    evidence_predicate:
+      command: test -s batch_state/rb2-failure-{task_id}.txt && echo evidence-recorded
+      success_pattern: '^evidence-recorded$'
+    transitions:
+      evidence_recorded: cleanup_failed_worktree
+      task_file_unreadable: STOP-unrecoverable-error
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: cleanup_failed_worktree
+    intent: >-
+      The settle-status failed/crashed row's second action: remove the failed
+      attempt's worktree before any re-fire (the dirty/commits checks upstream
+      guarantee nothing of value is inside on this path; branches without upstream
+      auto-prune on pull). The predicate proves the worktree is gone from the
+      registry.
+    command: git worktree remove --force .worktrees/dispatch/{lane}/{task_id}
+    evidence_predicate:
+      command: sh -c 'git worktree list | grep -c -e "dispatch/{lane}/{task_id}" || true'
+      success_pattern: '^0$'
+    transitions:
+      cleaned: retry_gate
+      removal_failed: STOP-manual-intervention
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: retry_gate
+    intent: >-
+      One automatic re-fire, never a third — with the settle-status table's exact
+      code: a task id already carrying -retry has consumed its re-fire and stops as
+      STOP-unrecoverable-error (the table's row for a failed -retry attempt).
+      Otherwise the retry id <task_id>-retry is recorded to a receipt for the
+      re-fire step.
     command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo "{task_id}-retry" > batch_state/rb2-retry-{task_id}.txt; cat batch_state/rb2-retry-{task_id}.txt ;; esac'
     evidence_predicate:
       command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) cat batch_state/rb2-retry-{task_id}.txt ;; esac'
       success_pattern: '^(already-retried|.+-retry)$'
     transitions:
-      retry_id_minted: dispatch_retry
-      already_retried: STOP-max-retries-exceeded
+      retry_id_recorded: dispatch_retry
+      already_retried: STOP-unrecoverable-error
     kind: mechanical
     blocked_on: null
 
   - step_id: dispatch_retry
     intent: >-
-      Re-fire ONCE under the minted -retry id (read from the retry receipt), same
-      brief, same lane, teeing to the retry log. From here the loop re-enters at the
-      settle watch on the NEW id; if the retry also fails, mint_retry_id sees the
-      -retry suffix and stops at max-retries.
+      Fire ONCE under the recorded -retry id (read from the receipt), same brief and
+      lane, teeing to the retry log — then this invocation ENDS at the terminal
+      refired_new_invocation. trailspec.v1 cannot rebind {task_id} mid-trail (r3
+      finding), so the -retry task is owned by a NEW invocation of this same trail
+      whose {task_id} IS the -retry id: its settle, verification, and retry gate all
+      address the right task, and its retry_gate stops on the -retry suffix —
+      bounded without rebinding.
     command: sh -c 'RID=$(cat batch_state/rb2-retry-{task_id}.txt); .venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id "$RID" --prompt-file {brief_path} --worktree --mode danger {research_flags} 2>&1 | tee "batch_state/rb2-dispatch-$RID.log"'
     evidence_predicate:
       command: sh -c 'RID=$(cat batch_state/rb2-retry-{task_id}.txt); jq -r ".status // \"\"" "batch_state/tasks/$RID.json"'
       success_pattern: '^(spawning|running)$'
     transitions:
-      retry_dispatched: arm_settle_watch
+      retry_dispatched: refired_new_invocation
       retry_spawn_failed: STOP-unrecoverable-error
     kind: mechanical
     blocked_on: null

--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -5,19 +5,23 @@
 # certification waits for T1.4/5. Steps that depend on unbuilt machinery carry an
 # explicit blocked_on marker.
 #
-# Anti-pattern guard (the #5860 r1 lessons, held to the RB-1 bar): every command below
-# is a real, currently runnable repo command whose OUTPUT SHAPE was captured from a live
-# run (2026-07-27/28 infra session: dispatches fix-5900/fix-5893/t13-glm-canary, the
-# write-path REFUSE + override, three live no_deliverable false negatives) before being
-# encoded; every predicate is falsifiable; unknown situations exit through a STOP code.
+# Anti-pattern guard (the #5860 r1 lessons, held to the RB-1 bar and re-tightened by
+# the #5915 r1 sealed review): every command below is a real, currently runnable repo
+# command whose OUTPUT SHAPE was captured from a live run (2026-07-27/28 infra session:
+# dispatches fix-5900/fix-5893/t13-glm-canary, the write-path REFUSE + override, three
+# live no_deliverable false negatives); every transition input is derivable from that
+# step's evidence — steps whose branching needed evidence the old draft lacked were
+# SPLIT (refusal triage, deliverable verification, silent-exit check, refire gate);
+# classification correctness is not machine-checkable, so it lives in the brief summon,
+# not a mechanical step. Unknown situations exit through a published STOP code.
 #
 # kind-wait note (spec v1.1 carry-over): trailspec.v1 has no `wait` kind — the
 # await_settle step is a summon whose documentation-predicate is the Monitor settle
 # event; the transition source is the settle-status table lookup that follows it.
 schema_version: trailspec.v1
 trail_id: rb2-dispatch-loop
-version: "0.1.0"
-title: RB2 Dispatch loop — classify, brief, dispatch, settle, finalize
+version: "0.2.0"
+title: RB2 Dispatch loop — brief, dispatch, settle, finalize
 seats:
   - grok-daily
   - glm-trial
@@ -25,6 +29,7 @@ seats:
 stop_codes:
   - STOP-precondition-failed
   - STOP-concurrency-conflict
+  - STOP-max-retries-exceeded
   - STOP-unrecoverable-error
   - STOP-manual-intervention
   - STOP-unknown
@@ -36,18 +41,19 @@ steps:
   - step_id: drain_slot_inbox
     intent: >-
       Mandatory inbox-drain substep (drive-epic 4a pattern): before firing new work,
-      surface pending slot deliveries for this seat. The live output shape is
-      "<agent> inbox:" followed by "pending: N (oldest ...)" — a pending count of 0
-      proceeds; a non-zero count runs one coalesced drain and re-checks. A drain that
-      leaves deliveries pending needs a human or judgment seat (delivery processing
-      spawns agents; never loop it blindly).
+      surface pending slot deliveries for this seat. Live output shape is "<agent>
+      inbox:" followed by "pending: N (oldest ...)". NOTE (live-verified in the #5915
+      sealed review): show is not a pure read — it expires stale deliveries via an
+      UPDATE, so it needs a writable DB; a read-only environment fails here loudly,
+      which is a precondition failure, not a skip.
     command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
     evidence_predicate:
       command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
       success_pattern: 'pending:\s+0'
     transitions:
-      empty: classify_task
+      empty: capacity_check
       pending_deliveries: drain_once
+      db_not_writable: STOP-precondition-failed
     kind: mechanical
     blocked_on: null
 
@@ -61,131 +67,139 @@ steps:
       command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
       success_pattern: 'pending:\s+0'
     transitions:
-      drained: classify_task
+      drained: capacity_check
       still_pending: STOP-manual-intervention
-    kind: mechanical
-    blocked_on: null
-
-  - step_id: classify_task
-    intent: >-
-      Project Research Registry duty: classify the task's functional role, task family,
-      track, and owned paths FROM THE ISSUE/BRIEF TEXT (labels, title tags, named
-      files). Pass every dimension that is explicitly derivable; omit every dimension
-      that is not — a pointer-free dispatch is a legal, deliberate outcome and never a
-      reason to invent a value. This is mechanical because the rule is total: derivable
-      → pass, not derivable → omit. Never infer from provider or agent name.
-    command: gh issue view {issue_number} --json title,labels,body
-    evidence_predicate:
-      command: gh issue view {issue_number} --json title,labels
-      success_pattern: '"title"'
-    transitions:
-      classified_or_deliberately_generic: sibling_check
-      issue_unreadable: STOP-precondition-failed
-    kind: mechanical
-    blocked_on: null
-
-  - step_id: sibling_check
-    intent: >-
-      Dispatch-brief checklist step 0: search PRs by ISSUE REFERENCE (never title
-      words) and read the issue's timeline before briefing — open issue does not mean
-      unfixed. Live shape: a JSON array of {number, state, title}; [] proceeds. Any
-      hit referencing this issue means residual scope must be re-derived from what
-      already landed — that comparison is judgment, so the weak seat parks.
-    command: gh pr list --state all --search "{issue_number}" --json number,title,state --limit 10
-    evidence_predicate:
-      command: gh pr list --state all --search "{issue_number}" --json number --limit 10
-      success_pattern: '^\[\]$'
-    transitions:
-      no_siblings: capacity_check
-      siblings_found: STOP-manual-intervention
     kind: mechanical
     blocked_on: null
 
   - step_id: capacity_check
     intent: >-
-      Two-sided width check per the width table: codexbar pace stage + reserve per
-      candidate lane, and disk (df -h / plus du -sh .worktrees — a dispatch worktree
-      costs roughly half a GB; DISK WINS every conflict). No pace data for a lane →
-      use in-flight count + lane health and say the picture is partial.
-    command: codexbar usage --json
+      Two-sided width check per the width table. ALL inputs the table weighs are
+      captured into one receipt before the lookup: codexbar pace stage + reserve per
+      lane, free disk, and worktree footprint (a dispatch worktree costs roughly half
+      a GB; DISK WINS every conflict). The predicate proves the receipt holds all
+      three input classes — a receipt missing any input means the lookup ran blind,
+      which the table forbids ("no data → say the picture is partial", never silently
+      proceed on nothing).
+    command: sh -c 'R=batch_state/rb2-width-receipt.txt; codexbar usage --json > "$R" 2>&1; df -h / >> "$R"; du -sh .worktrees >> "$R"; cat "$R"'
     evidence_predicate:
-      command: df -h / | tail -1
-      success_pattern: '\d+G?i?\s+\d+%'
+      command: sh -c 'R=batch_state/rb2-width-receipt.txt; grep -c -e "provider" -e "%" -e ".worktrees" "$R"'
+      success_pattern: '^[3-9][0-9]*$|^[1-9][0-9]+$'
     transitions:
       capacity_ok: route_lane
       no_capacity: parked_no_capacity
+      receipt_incomplete: STOP-precondition-failed
     kind: table-lookup
     table: width
     blocked_on: null
 
   - step_id: route_lane
     intent: >-
-      Resolve the seat from the served routing rule for this task family and risk
-      class per the lane-routing table (live-lookup: /api/rules model-assignment is
-      the SSOT; never route from a remembered roster). Language-lane restrictions,
-      judge-seat exclusions, and cross-family pairing bind.
-    command: curl -s --max-time 3 "http://127.0.0.1:8765/api/rules?format=markdown"
+      Fetch the served routing SSOT to a receipt file and resolve the seat by APPLYING
+      its model-assignment table for this task family and risk class (lane-routing
+      table binds: language-lane restrictions, judge-seat exclusions, cross-family
+      pairing). The predicate proves the routing document was actually fetched and
+      contains the assignment section — reachability alone (an HTTP 200) is NOT
+      resolution evidence. API down → the offline fallback files under
+      agents_extensions/shared/rules/ are the same content; resolution still happens
+      from a read document, never from memory. No sanctioned lane for the family is a
+      hard stop.
+    command: sh -c 'curl -s --max-time 3 "http://127.0.0.1:8765/api/rules?format=markdown" -o batch_state/rb2-rules-receipt.md || cp agents_extensions/shared/rules/model-assignment.md batch_state/rb2-rules-receipt.md'
     evidence_predicate:
-      command: curl -s -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:8765/api/rules"
-      success_pattern: '200'
+      command: grep -c -i -e "model" -e "assignment" batch_state/rb2-rules-receipt.md
+      success_pattern: '^[1-9][0-9]*$'
     transitions:
       lane_resolved: author_brief
-      api_down_fallback_files: author_brief
       no_sanctioned_lane: STOP-precondition-failed
+      rules_unreadable: STOP-precondition-failed
     kind: table-lookup
     table: lane-routing
     blocked_on: null
 
   - step_id: author_brief
     intent: >-
-      Brief content is judgment: scope boundaries, required tests and their mutation
-      checks, hard exclusions, and the #M-4 evidence preamble steer the worker's whole
-      arc. The weak seat summons judgment for brief authorship (template:
-      .agent/tmp/reviews/*-brief.md conventions — numbered steps, worktree-only work,
-      no auto-merge by worker, one-line finalize comment on the tracking issue). A task
-      whose issue lacks explicit acceptance criteria stops as a failed precondition,
-      not a guessed brief.
+      Judgment authors the brief AND the research-registry classification together —
+      they are the same cognitive act (what is this task, what does it own, what must
+      the worker prove). Registry duty: pass every dimension explicitly derivable from
+      the issue/brief text, omit every dimension that is not (pointer-free is a legal
+      deliberate outcome; never invent a value; never infer from provider or agent
+      name). Brief conventions: numbered steps, worktree-only work, #M-4 evidence
+      preamble, required tests + mutation checks, hard exclusions, no auto-merge by
+      worker, one-line finalize comment on the tracking issue. Step 0 belongs here
+      too: sibling search by ISSUE REFERENCE (gh pr list --state all --search
+      "<issue-nr>" — live shape: JSON array, [] means clear) and the issue timeline —
+      residual-scope judgment on any hit. An issue without explicit acceptance
+      criteria stops as a failed precondition, not a guessed brief.
     command: null
     evidence_predicate: null
     transitions:
-      brief_written: dispatch_worker
+      brief_written_and_classified: dispatch_worker
+      siblings_change_scope: STOP-manual-intervention
       no_clear_spec: STOP-precondition-failed
     kind: summon
     blocked_on: null
 
   - step_id: dispatch_worker
     intent: >-
-      Fire the dispatch with the classified research flags, --worktree, and the brief
-      file. Live success shape ends with the bare task id on the last line and a
-      "dispatch <task>: branch=... base_sha=... path=..." line above it. Same-lane
-      spawns in the same second race — stagger ~10s. A write-path ownership REFUSE is
-      NOT one outcome: the refusal text distinguishes provable-conflict from
-      cannot-prove-disjoint ("No actual path overlap was found"), and only the latter
-      may be overridden.
-    command: .venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags}
+      Fire the dispatch with the brief and classified research flags, teeing all
+      output to a per-task log — the log is what later steps triage. Live success
+      shape ends with the bare task id and a "dispatch <task>: branch=... base_sha=...
+      path=..." line; the task state file appears with status spawning|running.
+      Same-lane spawns in the same second race — stagger ~10s.
+    command: sh -c '.venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags} 2>&1 | tee batch_state/rb2-dispatch-{task_id}.log'
     evidence_predicate:
       command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
       success_pattern: '^(spawning|running)$'
     transitions:
       dispatched: arm_settle_watch
-      refuse_no_actual_overlap: override_dispatch
-      refuse_actual_overlap: STOP-concurrency-conflict
+      refused: triage_refusal
       spawn_error: STOP-unrecoverable-error
     kind: mechanical
     blocked_on: null
 
+  - step_id: triage_refusal
+    intent: >-
+      A write-path ownership REFUSE is two different situations and the refusal text
+      is the discriminator (live-captured 2026-07-27): "No actual path overlap was
+      found" means an undeclared active writer elsewhere blocks the disjointness
+      PROOF — overridable with judgment approval; a refusal naming an actual
+      conflicting path is a real concurrency conflict and a hard stop. The predicate
+      evidences the discriminator from the teed dispatch log, so the branch is
+      derivable, not asserted.
+    command: grep -e "REFUSE" batch_state/rb2-dispatch-{task_id}.log
+    evidence_predicate:
+      command: grep -c -e "No actual path overlap was found" batch_state/rb2-dispatch-{task_id}.log
+      success_pattern: '^[1-9]'
+    transitions:
+      no_actual_overlap: approve_override
+      actual_overlap: STOP-concurrency-conflict
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: approve_override
+    intent: >-
+      Judgment reviews the refusal text and the undeclared writer it names, and
+      writes the override reason (who the writer is, why the write surfaces are
+      disjoint). The safety rationale is a judgment product — a weak seat never
+      self-approves an ownership override.
+    command: null
+    evidence_predicate: null
+    transitions:
+      override_approved: override_dispatch
+      override_denied: STOP-concurrency-conflict
+    kind: summon
+    blocked_on: null
+
   - step_id: override_dispatch
     intent: >-
-      Re-run the same dispatch with --allow-path-overlap '<why this is safe>' ONLY
-      when the refusal said "No actual path overlap was found" (an undeclared active
-      writer elsewhere in the estate blocks the disjointness proof). The reason must
-      name the undeclared writer and why the write surfaces are disjoint. Admitted
-      shape: "write-path ownership: would-refuse recorded (override); admitted under
-      refuse" or "admitted; paths disjoint". A second refusal is a hard stop.
-    command: .venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags} --allow-path-overlap "{overlap_reason}"
+      Re-run the identical dispatch with the approved --allow-path-overlap reason,
+      teeing to the same log family. Admitted shapes (live-captured): "would-refuse
+      recorded (override); admitted under refuse" or "admitted; paths disjoint". A
+      second refusal is a hard stop.
+    command: sh -c '.venv/bin/python scripts/delegate.py dispatch --agent {lane} --task-id {task_id} --prompt-file {brief_path} --worktree --mode danger {research_flags} --allow-path-overlap "{overlap_reason}" 2>&1 | tee batch_state/rb2-dispatch-{task_id}-override.log'
     evidence_predicate:
-      command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
-      success_pattern: '^(spawning|running)$'
+      command: grep -c -e "admitted under refuse" -e "admitted; paths disjoint" batch_state/rb2-dispatch-{task_id}-override.log
+      success_pattern: '^[1-9]'
     transitions:
       dispatched: arm_settle_watch
       refused_again: STOP-concurrency-conflict
@@ -195,9 +209,9 @@ steps:
   - step_id: arm_settle_watch
     intent: >-
       Arm ONE Monitor settle-loop over the task status file — the file is truth (the
-      active-list API can omit live tasks). The loop polls jq -r '.status' every 60-90s
-      and emits exactly once when the status leaves {spawning, running, ""}. Never
-      keyword-grep worker logs as a completion signal; never poll with scheduled
+      active-list API can omit live tasks). The loop polls jq -r '.status' every
+      60-90s and emits exactly once when the status leaves {spawning, running, ""}.
+      Never keyword-grep worker logs as a completion signal; never poll with scheduled
       wakeups when a Monitor can watch.
     command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
     evidence_predicate:
@@ -211,11 +225,11 @@ steps:
 
   - step_id: await_settle
     intent: >-
-      Wait state (kind-wait note in the header): the seat idles on the Monitor's settle
-      event; no polling loops, no log grepping. The settle event's payload is the
-      terminal status string, which the next step routes through the settle-status
-      table. A watch that outlives its Monitor (session end, watcher reaped) is re-armed,
-      not forgotten.
+      Wait state (kind-wait note in the header): the seat idles on the Monitor's
+      settle event; no polling loops, no log grepping. The settle event's payload is
+      the terminal status string, which the next step routes through the settle-status
+      table. A watch that outlives its Monitor (session end, watcher reaped) is
+      re-armed, not forgotten.
     command: null
     evidence_predicate: null
     transitions:
@@ -226,24 +240,79 @@ steps:
 
   - step_id: finalize_settle
     intent: >-
-      Route the terminal status through the settle-status table. Non-negotiables lived
-      this session: done still requires reading the produced CONTENT (result file, PR
-      diff) before the review gate; no_deliverable is an attention state, not a fact —
-      three consecutive false negatives (#5855 class) were disproven by checking the
-      branch head against the PR head before re-dispatching anything; timeout checks
-      the worktree for finished-but-unpushed work AND gh pr list for an already-opened
-      PR (silent-exit class); failed/crashed re-fires ONCE with a -retry task id and
-      never a third time.
+      Route the terminal status through the settle-status table — EVERY row of the
+      table has a distinct transition here, none are folded: done and the attention
+      states (needs_finalize, no_deliverable) go to deliverable verification
+      (no_deliverable is an attention state, not a fact — three live #5855-class false
+      negatives this session were disproven by checking the branch); timeout goes to
+      the silent-exit check; failed/crashed go to the refire gate; rate_limited
+      reroutes the lane per fallback substitutions; cancelled and dry_run are
+      terminal-not-success and end this dispatch arc; anything outside the published
+      vocabulary is unknown.
     command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
     evidence_predicate:
       command: jq -r '.status // ""' batch_state/tasks/{task_id}.json
       success_pattern: '^(done|failed|timeout|rate_limited|cancelled|crashed|dry_run|needs_finalize|no_deliverable)$'
     transitions:
-      deliverable_verified_pr_open: handed_to_pr_lifecycle
-      refire_once: dispatch_worker
-      reroute_lane: route_lane
-      unrecoverable: STOP-unrecoverable-error
+      done: verify_deliverable
+      needs_finalize: verify_deliverable
+      no_deliverable: verify_deliverable
+      timeout: silent_exit_check
+      failed: refire_gate
+      crashed: refire_gate
+      rate_limited: route_lane
+      cancelled: aborted
+      dry_run: aborted
       unknown_status: STOP-unknown
     kind: table-lookup
     table: settle-status
+    blocked_on: null
+
+  - step_id: verify_deliverable
+    intent: >-
+      Deliverable verification is tool-backed, never status-backed: an open PR for
+      the dispatch branch is the deliverable receipt (live shape: JSON array with the
+      PR number). done still requires the produced CONTENT to be read before the
+      review gate — that reading is RB-3's entry. No PR for the branch routes to the
+      silent-exit check (the branch may hold pushed-but-unopened or committed-but-
+      unpushed work).
+    command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
+    evidence_predicate:
+      command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
+      success_pattern: '"number"'
+    transitions:
+      pr_open: handed_to_pr_lifecycle
+      no_pr_for_branch: silent_exit_check
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: silent_exit_check
+    intent: >-
+      Silent-exit class: a worker can finish real work and die before opening the PR.
+      Inspect the dispatch worktree's history and status against its base. Work
+      present (commits ahead of base, or a dirty tree with substantive changes) is a
+      judgment finalize — summon; provably absent work falls to the refire gate.
+    command: git -C .worktrees/dispatch/{lane}/{task_id} log --oneline -5
+    evidence_predicate:
+      command: git -C .worktrees/dispatch/{lane}/{task_id} status --porcelain
+      success_pattern: '.*'
+    transitions:
+      work_present: STOP-manual-intervention
+      work_absent: refire_gate
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: refire_gate
+    intent: >-
+      One automatic re-fire, never a third attempt: a task id already carrying the
+      -retry suffix has consumed its re-fire and stops at the published
+      max-retries code. The suffix check is string-mechanical on the task id.
+    command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo first-attempt ;; esac'
+    evidence_predicate:
+      command: sh -c 'case "{task_id}" in *-retry) echo already-retried ;; *) echo first-attempt ;; esac'
+      success_pattern: '^(already-retried|first-attempt)$'
+    transitions:
+      first_attempt_refire: dispatch_worker
+      already_retried: STOP-max-retries-exceeded
+    kind: mechanical
     blocked_on: null

--- a/scripts/config/trails/rb2-dispatch-loop.trail.yaml
+++ b/scripts/config/trails/rb2-dispatch-loop.trail.yaml
@@ -32,7 +32,7 @@
 # arc and multi-signal branchings collapse back into fewer steps.
 schema_version: trailspec.v1
 trail_id: rb2-dispatch-loop
-version: "0.5.0"
+version: "0.6.0"
 title: RB2 Dispatch loop — brief, dispatch, settle, finalize
 seats:
   - grok-daily
@@ -318,15 +318,34 @@ steps:
       PR check, but the table's disposition here is finalize BY HAND — an OPEN PR
       also routes to judgment (a died worker's deliverable needs eyes before RB-3's
       babysit could auto-merge it), and a missing PR runs the commit-verification
-      chain before absence is believed (three live #5855-class false negatives this
-      session all had real deliverables the status missed).
+      PROBE — recorded evidence for the human, never a route into the automatic
+      retry chain (three live #5855-class false negatives this session all had real
+      deliverables the status missed).
     command: gh pr list --state open --head {lane}/{task_id} --json number,title --limit 3
     evidence_predicate:
       command: gh pr list --state open --head {lane}/{task_id} --json number --limit 3
       success_pattern: '"number"'
     transitions:
       pr_open: STOP-manual-intervention
-      no_pr_for_branch: commits_ahead_check
+      no_pr_for_branch: attention_absence_probe
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: attention_absence_probe
+    intent: >-
+      The table's commit-verification for attention states, with the table's
+      disposition kept intact: run the commits-beyond-base probe (base bound inline
+      from worktree_base_sha) and RECORD its result into the attention receipt — then
+      finalize BY HAND regardless of the count (r5 finding: the attention path must
+      never reach the automatic retry chain; the probe informs the human, it does not
+      route). The single transition to the stop is deliberate: verification is an
+      evidence obligation here, not a branch point.
+    command: sh -c 'B=$(jq -r ".worktree_base_sha" batch_state/tasks/{task_id}.json); git -C .worktrees/dispatch/{lane}/{task_id} rev-list --count "$B"..HEAD | tee batch_state/rb2-attention-{task_id}.txt'
+    evidence_predicate:
+      command: test -s batch_state/rb2-attention-{task_id}.txt && echo probe-recorded
+      success_pattern: '^probe-recorded$'
+    transitions:
+      probe_recorded: STOP-manual-intervention
     kind: mechanical
     blocked_on: null
 
@@ -398,16 +417,16 @@ steps:
 
   - step_id: cleanup_failed_worktree
     intent: >-
-      The settle-status row's action verbatim: remove worktree AND branch (RB-3's
-      cleanup precedent chains both). The failed attempt's branch was never merged,
-      so plain -d refuses and -D is required; harnesses whose write guard blocks a
-      manual branch -D route the branch half through the dispatcher's own reap — a
-      certification-time question recorded here, not papered over. The predicate
-      proves the worktree is gone from the registry.
-    command: sh -c 'git worktree remove --force .worktrees/dispatch/{lane}/{task_id} && (git branch -D {lane}/{task_id} 2>/dev/null || echo "branch reap deferred to dispatcher (write guard)")'
+      The settle-status row's action verbatim, ENFORCED (r5 finding: no swallowed
+      branch-delete): remove the worktree, then delete the never-merged branch with
+      -D — failures are not suppressed, and the predicate proves BOTH absences
+      (worktree gone from the registry AND no branch ref remains). A harness whose
+      write guard blocks manual branch -D fails this step honestly into
+      STOP-manual-intervention — a dangling branch is never accepted as cleaned.
+    command: sh -c 'git worktree remove --force .worktrees/dispatch/{lane}/{task_id} && git branch -D {lane}/{task_id}'
     evidence_predicate:
-      command: sh -c 'git worktree list | grep -c -e "dispatch/{lane}/{task_id}" || true'
-      success_pattern: '^0$'
+      command: sh -c '(git worktree list | grep -q -e "dispatch/{lane}/{task_id}") && exit 1; (git branch --list "{lane}/{task_id}" | grep -q .) && exit 1; echo fully-cleaned'
+      success_pattern: '^fully-cleaned$'
     transitions:
       cleaned: retry_gate
       removal_failed: STOP-manual-intervention

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -36,6 +36,7 @@ _ALL_SHIPPED_TRAILS = sorted(_TRAILS_DIR.glob("*.trail.yaml"))
 # the glob-only guard passed as long as ANY trail remained).
 REQUIRED_TRAIL_IDS = {
     "rb1-cold-start",
+    "rb2-dispatch-loop",
     "rb3-pr-lifecycle",
 }
 


### PR DESCRIPTION
Second T2 runbook extraction: the dispatch loop as a TrailSpec draft at the RB-1 evidence bar. Every command's output shape was captured from live runs in this session (the write-path REFUSE + legitimate override, three live no_deliverable false negatives, the settle vocabulary, codexbar pace rows, slot-inbox pending shapes) — no invented commands, no vacuous predicates.

Structure: mandatory inbox-drain substep (panel mandate) → research-registry classification (mechanical: derivable→pass, else omit) → sibling check (step 0; hits park to judgment) → width + lane-routing table lookups → brief authorship as a summon (judgment-carrying) → dispatch with the REFUSE-vs-override distinction encoded → Monitor settle watch → settle-status table finalize. STOP codes drawn from the published 16-item contract. RB-2 added to the required-trails pin (a deletion fails the suite loudly, per the #5886 review finding).

Draft status: certification waits for T1.4/5; `kind: wait` spec note carried in the header (await_settle is a summon with a documentation-predicate until the schema grows a wait kind).

Validator: `TrailSpec valid: id='rb2-dispatch-loop' version='0.1.0' steps=12`. Tests 28/28.

Refs #5885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)