### PR TITLE
feat(trails): T2 RB-5 session-close trail draft (live-captured shapes)

### DIFF
--- a/scripts/config/trails/decision-tables.v0.yaml
+++ b/scripts/config/trails/decision-tables.v0.yaml
@@ -115,7 +115,7 @@ tables:
       - {when: "closing a session or preparing rollover", then: "handoff carries: assignment scope · epic phase · IN-FLIGHT with watcher ids · verdict/finalize state per open PR · NEXT ACTION ordered list · operator-pending items · pace/disk at last dispatch"}
       - {when: "any of those unknown", then: "reconstruct from tool output before writing; a handoff row must never be from memory"}
       - {when: "file exceeds 40KB", then: "archive older sessions before writing more"}
-    blocked_on: "closure-gate integration lands with T1.2 (#5880 step 5)"
+    blocked_on: "runner-backed closure-gate integration (receipt-chain validation ships with the trail runner; the lease-release hooks half of T1.2 landed via #5896)"
 
   summon-vs-park:
     mode: static

--- a/scripts/config/trails/rb5-session-close.trail.yaml
+++ b/scripts/config/trails/rb5-session-close.trail.yaml
@@ -33,7 +33,7 @@
 # proceed.
 schema_version: trailspec.v1
 trail_id: rb5-session-close
-version: "0.1.0"
+version: "0.1.1"
 title: RB5 Session close — inbox drain, readiness receipts, hygiene sweep, handoff gate
 seats:
   - grok-daily
@@ -164,10 +164,13 @@ steps:
       merge continuously; live-captured 2026-07-28: origin/main moved ahead of a
       freshly-fetched local within the same session). The readiness predicate's
       branch_pushed field conflates the two directions, so this step counts only
-      the ahead direction (live shape: bare integer, "0" when clean).
-    command: sh -c 'git fetch origin --quiet 2>/dev/null; N=$(git rev-list --count origin/main..main 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
+      the ahead direction (live shape: bare integer, "0" when clean). FAILS
+      CLOSED (r1 finding): a failed fetch means the remote state could not be
+      verified, so the count is unavailable — a stale tracking ref must never
+      read as primary-clean.
+    command: sh -c 'git fetch origin --quiet 2>/dev/null || { echo count-unavailable; exit 0; }; N=$(git rev-list --count origin/main..main 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
     evidence_predicate:
-      command: sh -c 'git fetch origin --quiet 2>/dev/null; N=$(git rev-list --count origin/main..main 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
+      command: sh -c 'git fetch origin --quiet 2>/dev/null || { echo count-unavailable; exit 0; }; N=$(git rev-list --count origin/main..main 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
       success_pattern: '^(primary-clean|primary-ahead|count-unavailable)$'
     transitions:
       primary_clean: worktree_receipt
@@ -184,10 +187,13 @@ steps:
       more routes the recorded receipt to the sweep judgment — the #M-10a close
       sweep is disposition-per-worktree work this trail cannot do mechanically
       (merged-clean vs uncommitted vs other-lane-live all look alike to a count).
-    command: sh -c 'git worktree list --porcelain | tee batch_state/rb5-worktrees-{handoff_agent}.txt | grep -c "^worktree "'
+      The command emits the transition vocabulary itself (sibling sweep of the r1
+      fail-closed class: a bare count narrates the branching instead of enforcing
+      it, and a failed listing must not read as any worktree state).
+    command: sh -c 'git worktree list --porcelain > batch_state/rb5-worktrees-{handoff_agent}.txt 2>/dev/null || { echo receipt-unwritable; exit 0; }; N=$(grep -c "^worktree " batch_state/rb5-worktrees-{handoff_agent}.txt); case "$N" in 1) echo primary-only;; 0) echo receipt-unwritable;; *) echo extra-worktrees;; esac'
     evidence_predicate:
-      command: sh -c 'grep -c "^worktree " batch_state/rb5-worktrees-{handoff_agent}.txt'
-      success_pattern: '^[1-9][0-9]*$'
+      command: sh -c 'N=$(grep -c "^worktree " batch_state/rb5-worktrees-{handoff_agent}.txt 2>/dev/null); case "$N" in 1) echo primary-only;; ""|0) echo receipt-unwritable;; *) echo extra-worktrees;; esac'
+      success_pattern: '^(primary-only|extra-worktrees|receipt-unwritable)$'
     transitions:
       primary_only: handoff_gate
       extra_worktrees: sweep_judgment

--- a/scripts/config/trails/rb5-session-close.trail.yaml
+++ b/scripts/config/trails/rb5-session-close.trail.yaml
@@ -33,7 +33,7 @@
 # proceed.
 schema_version: trailspec.v1
 trail_id: rb5-session-close
-version: "0.1.4"
+version: "0.1.5"
 title: RB5 Session close — inbox drain, readiness receipts, hygiene sweep, handoff gate
 seats:
   - grok-daily
@@ -102,8 +102,8 @@ steps:
       stop) — the split steps read the fields this trail can act on soundly.
     command: sh -c '.venv/bin/python -m scripts.orchestration.handoff_ready --json | tee batch_state/rb5-ready-{handoff_agent}.json'
     evidence_predicate:
-      command: sh -c 'jq -e ".checks | has(\"tree_clean\")" batch_state/rb5-ready-{handoff_agent}.json'
-      success_pattern: '^true$'
+      command: sh -c 'jq -e ".checks | has(\"tree_clean\")" batch_state/rb5-ready-{handoff_agent}.json >/dev/null 2>&1 && echo snapshot-recorded || echo predicate-unavailable'
+      success_pattern: '^(snapshot-recorded|predicate-unavailable)$'
     transitions:
       snapshot_recorded: tree_clean_check
       predicate_unavailable: STOP-precondition-failed

--- a/scripts/config/trails/rb5-session-close.trail.yaml
+++ b/scripts/config/trails/rb5-session-close.trail.yaml
@@ -33,7 +33,7 @@
 # proceed.
 schema_version: trailspec.v1
 trail_id: rb5-session-close
-version: "0.1.5"
+version: "0.1.6"
 title: RB5 Session close — inbox drain, readiness receipts, hygiene sweep, handoff gate
 seats:
   - grok-daily
@@ -47,6 +47,28 @@ terminal_outcomes:
   - closed_handoff_written
   - back_to_dispatch_loop
 steps:
+  - step_id: assert_primary_checkout
+    intent: >-
+      FAIL-CLOSED entry assertion (r6 finding): every relative path in this trail
+      (.venv, batch_state) and every checkout-dependent signal (readiness tree,
+      the ahead count) assumes the PRIMARY main checkout — an assumption v0.1.5
+      narrated but never enforced, so a run from a clean feature worktree could
+      close over that worktree's own unpushed state while inspecting an
+      unrelated main ref. Discriminator (live-verified both directions
+      2026-07-28): in the primary checkout git-dir equals git-common-dir; in a
+      linked worktree they differ. The primary must also BE on main (layout A);
+      anything else stops before a single receipt is written.
+    command: sh -c 'G=$(git rev-parse --git-dir 2>/dev/null); C=$(git rev-parse --git-common-dir 2>/dev/null); B=$(git symbolic-ref --short -q HEAD); if [ -z "$G" ] || [ -z "$C" ]; then echo not-primary-checkout; elif [ "$G" != "$C" ]; then echo not-primary-checkout; elif [ "$B" != "main" ]; then echo primary-off-main; else echo primary-confirmed; fi'
+    evidence_predicate:
+      command: sh -c 'G=$(git rev-parse --git-dir 2>/dev/null); C=$(git rev-parse --git-common-dir 2>/dev/null); B=$(git symbolic-ref --short -q HEAD); if [ -z "$G" ] || [ -z "$C" ]; then echo not-primary-checkout; elif [ "$G" != "$C" ]; then echo not-primary-checkout; elif [ "$B" != "main" ]; then echo primary-off-main; else echo primary-confirmed; fi'
+      success_pattern: '^(primary-confirmed|not-primary-checkout|primary-off-main)$'
+    transitions:
+      primary_confirmed: drain_slot_inbox
+      not_primary_checkout: STOP-precondition-failed
+      primary_off_main: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
   - step_id: drain_slot_inbox
     intent: >-
       OPENING live-driver inbox drain (drive-epic 8a pattern): surface every
@@ -173,10 +195,12 @@ steps:
       the ahead direction (live shape: bare integer, "0" when clean). FAILS
       CLOSED (r1 finding): a failed fetch means the remote state could not be
       verified, so the count is unavailable — a stale tracking ref must never
-      read as primary-clean.
-    command: sh -c 'git fetch origin --quiet 2>/dev/null || { echo count-unavailable; exit 0; }; N=$(git rev-list --count origin/main..main 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
+      read as primary-clean. Counts origin/main..HEAD — HEAD IS main here, the
+      entry assertion guarantees it (r6: counting the main ref from an arbitrary
+      checkout inspected the wrong subject).
+    command: sh -c 'git fetch origin --quiet 2>/dev/null || { echo count-unavailable; exit 0; }; N=$(git rev-list --count origin/main..HEAD 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
     evidence_predicate:
-      command: sh -c 'git fetch origin --quiet 2>/dev/null || { echo count-unavailable; exit 0; }; N=$(git rev-list --count origin/main..main 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
+      command: sh -c 'git fetch origin --quiet 2>/dev/null || { echo count-unavailable; exit 0; }; N=$(git rev-list --count origin/main..HEAD 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
       success_pattern: '^(primary-clean|primary-ahead|count-unavailable)$'
     transitions:
       primary_clean: worktree_receipt

--- a/scripts/config/trails/rb5-session-close.trail.yaml
+++ b/scripts/config/trails/rb5-session-close.trail.yaml
@@ -33,7 +33,7 @@
 # proceed.
 schema_version: trailspec.v1
 trail_id: rb5-session-close
-version: "0.1.1"
+version: "0.1.2"
 title: RB5 Session close — inbox drain, readiness receipts, hygiene sweep, handoff gate
 seats:
   - grok-daily
@@ -49,8 +49,11 @@ terminal_outcomes:
 steps:
   - step_id: drain_slot_inbox
     intent: >-
-      Mandatory final live-driver inbox drain (drive-epic 8a pattern): immediately
-      before writing or signalling handoff, surface every pending slot delivery.
+      OPENING live-driver inbox drain (drive-epic 8a pattern): surface every
+      pending slot delivery before the close sequence starts. The 8a
+      "immediately before handoff" guarantee is NOT this step's — deliveries can
+      arrive during the readiness and sweep interval (r2 finding), so
+      final_inbox_recheck re-proves pending: 0 right before the handoff gate.
       Live output shape: "<agent> inbox:" then "pending: N (oldest ...)". NOTE
       (live-verified in the #5915 r1 review): show is not a pure read — it expires
       stale deliveries via an UPDATE; a read-only DB fails loudly here, which is a
@@ -195,7 +198,7 @@ steps:
       command: sh -c 'N=$(grep -c "^worktree " batch_state/rb5-worktrees-{handoff_agent}.txt 2>/dev/null); case "$N" in 1) echo primary-only;; ""|0) echo receipt-unwritable;; *) echo extra-worktrees;; esac'
       success_pattern: '^(primary-only|extra-worktrees|receipt-unwritable)$'
     transitions:
-      primary_only: handoff_gate
+      primary_only: final_inbox_recheck
       extra_worktrees: sweep_judgment
       receipt_unwritable: STOP-precondition-failed
     kind: mechanical
@@ -213,9 +216,29 @@ steps:
     command: null
     evidence_predicate: null
     transitions:
-      sweep_applied: handoff_gate
+      sweep_applied: final_inbox_recheck
       own_uncommitted_work: STOP-manual-intervention
     kind: summon
+    blocked_on: null
+
+  - step_id: final_inbox_recheck
+    intent: >-
+      The 8a contract enforced at the RIGHT moment (r2 finding): deliveries that
+      arrived during the readiness and sweep interval must be consumed before the
+      handoff is written or declared — an empty inbox observed at the START of
+      the close is not an empty inbox NOW. Only pending: 0 HERE may proceed to
+      the handoff gate; a late delivery routes to judgment consumption and the
+      close re-verifies from the top (the delivery may have changed the world
+      the readiness receipts described).
+    command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
+    evidence_predicate:
+      command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
+      success_pattern: 'pending:\s+0'
+    transitions:
+      empty: handoff_gate
+      pending_deliveries: apply_deliveries
+      db_not_writable: STOP-precondition-failed
+    kind: mechanical
     blocked_on: null
 
   - step_id: handoff_gate

--- a/scripts/config/trails/rb5-session-close.trail.yaml
+++ b/scripts/config/trails/rb5-session-close.trail.yaml
@@ -33,7 +33,7 @@
 # proceed.
 schema_version: trailspec.v1
 trail_id: rb5-session-close
-version: "0.1.2"
+version: "0.1.3"
 title: RB5 Session close — inbox drain, readiness receipts, hygiene sweep, handoff gate
 seats:
   - grok-daily
@@ -57,11 +57,14 @@ steps:
       Live output shape: "<agent> inbox:" then "pending: N (oldest ...)". NOTE
       (live-verified in the #5915 r1 review): show is not a pure read — it expires
       stale deliveries via an UPDATE; a read-only DB fails loudly here, which is a
-      precondition failure, not a skip.
-    command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
+      precondition failure, not a skip. The wrapper normalizes output + exit
+      status into exactly the three transition tokens (r3 finding: raw bridge
+      output plus a boolean predicate cannot discriminate pending-work from a
+      broken DB).
+    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent} 2>&1); RC=$?; printf "%s\n" "$OUT" > batch_state/rb5-inbox-{handoff_agent}.txt; if [ "$RC" -ne 0 ]; then echo db-not-writable; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
     evidence_predicate:
-      command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
-      success_pattern: 'pending:\s+0'
+      command: sh -c 'OUT=$(cat batch_state/rb5-inbox-{handoff_agent}.txt 2>/dev/null); if printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
+      success_pattern: '^(empty|pending-deliveries|db-not-writable)$'
     transitions:
       empty: readiness_snapshot
       pending_deliveries: apply_deliveries
@@ -229,16 +232,35 @@ steps:
       the close is not an empty inbox NOW. Only pending: 0 HERE may proceed to
       the handoff gate; a late delivery routes to judgment consumption and the
       close re-verifies from the top (the delivery may have changed the world
-      the readiness receipts described).
-    command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
+      the readiness receipts described). Same normalized three-token wrapper as
+      the opening drain (r3 finding).
+    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent} 2>&1); RC=$?; printf "%s\n" "$OUT" > batch_state/rb5-inbox-final-{handoff_agent}.txt; if [ "$RC" -ne 0 ]; then echo db-not-writable; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
     evidence_predicate:
-      command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
-      success_pattern: 'pending:\s+0'
+      command: sh -c 'OUT=$(cat batch_state/rb5-inbox-final-{handoff_agent}.txt 2>/dev/null); if printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
+      success_pattern: '^(empty|pending-deliveries|db-not-writable)$'
     transitions:
-      empty: handoff_gate
+      empty: write_handoff
       pending_deliveries: apply_deliveries
       db_not_writable: STOP-precondition-failed
     kind: mechanical
+    blocked_on: null
+
+  - step_id: write_handoff
+    intent: >-
+      Judgment WRITES the current-session handoff block (r3 finding: a gate that
+      only tests pre-existing non-emptiness would accept a stale handoff and a
+      fresh session would always stop — the write must be an explicit step).
+      Content comes from the handoff-completeness table rows, reconstructed from
+      tool output and THIS trail's receipts (readiness + worktrees + inbox),
+      never from memory; the 40KB archive rule applies before appending. Currency
+      of the written block is judgment's obligation here until the runner-backed
+      receipt chain can prove it mechanically.
+    command: null
+    evidence_predicate: null
+    transitions:
+      handoff_written: handoff_gate
+      cannot_reconstruct: STOP-manual-intervention
+    kind: summon
     blocked_on: null
 
   - step_id: handoff_gate

--- a/scripts/config/trails/rb5-session-close.trail.yaml
+++ b/scripts/config/trails/rb5-session-close.trail.yaml
@@ -1,0 +1,251 @@
+# RB-5 — session close (T2 DRAFT, extraction from drive-epic SKILL §8/§8a + the
+# handoff-completeness decision table + the machine-checked handoff-readiness
+# predicate #3138 + the #M-10a close sweep). Part of #5885.
+#
+# DRAFT STATUS: authored against today's substrate; certification waits for T1.4/5.
+# Two pieces are deliberately NOT drafted as steps (RB-4 r3/r4 precedent — never ship
+# unreachable speculative machinery):
+# - The runner-backed receipt-chain closure gate (design v2: "no receipt chain → no
+#   close"). No trail runner emits StepReceipt rows yet, so a chain-validation step
+#   could never pass; it ships WITH the trail runner. Today's close is receipt-backed
+#   by this trail's OWN tee'd receipts (readiness + worktree snapshots).
+# - The fenced lease release. The hardened SessionEnd hook owns it (T1.2, #5896,
+#   deployed): identity-fenced, symlink-refusing, fires on process exit. A driver
+#   command for it would be invented machinery.
+#
+# Fleet-comms: the file handoff stays authoritative in EVERY plane mode (mode today:
+# shadow); nothing in this trail flips cutovers or retires file handoffs.
+#
+# Anti-pattern guard (RB-2 v0.7.0 discipline): every command is a real, currently
+# runnable repo command whose OUTPUT SHAPE was captured live (2026-07-28 infra
+# session): handoff_ready --json check vocabulary ok|red|unknown with [status,
+# detail] pairs; inbox "pending: N (oldest ...)"; `git rev-list --count
+# origin/main..main` bare integer; `git worktree list --porcelain` worktree/HEAD/
+# branch triplets. Every MECHANICAL step is single-signal; the compound readiness
+# JSON is captured ONCE and split into per-field single-signal compares (the RB-4
+# probe→compare pattern).
+#
+# Live-captured hazard this trail encodes: the readiness predicate's in-flight
+# counter is repo-GLOBAL — on 2026-07-28 it flagged two dispatches that both
+# belonged to OTHER lanes (concurrent multi-lane operation is the norm). Per-lane
+# attribution is mechanically impossible until runner-emitted step receipts exist,
+# so a non-zero count routes to judgment, never to a guess and never to a silent
+# proceed.
+schema_version: trailspec.v1
+trail_id: rb5-session-close
+version: "0.1.0"
+title: RB5 Session close — inbox drain, readiness receipts, hygiene sweep, handoff gate
+seats:
+  - grok-daily
+  - glm-trial
+  - judgment
+stop_codes:
+  - STOP-precondition-failed
+  - STOP-manual-intervention
+  - STOP-unknown
+terminal_outcomes:
+  - closed_handoff_written
+  - back_to_dispatch_loop
+steps:
+  - step_id: drain_slot_inbox
+    intent: >-
+      Mandatory final live-driver inbox drain (drive-epic 8a pattern): immediately
+      before writing or signalling handoff, surface every pending slot delivery.
+      Live output shape: "<agent> inbox:" then "pending: N (oldest ...)". NOTE
+      (live-verified in the #5915 r1 review): show is not a pure read — it expires
+      stale deliveries via an UPDATE; a read-only DB fails loudly here, which is a
+      precondition failure, not a skip.
+    command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
+    evidence_predicate:
+      command: .venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent}
+      success_pattern: 'pending:\s+0'
+    transitions:
+      empty: readiness_snapshot
+      pending_deliveries: apply_deliveries
+      db_not_writable: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: apply_deliveries
+    intent: >-
+      The 8a contract is live-driver consumption, not worker acknowledgement
+      ("never claim the handoff is complete because a one-shot worker acknowledged
+      it"): judgment READS each pending delivery, APPLIES it (an action taken, a
+      queue item updated, or an unresolved request recorded in the handoff), then
+      acks with `ack --consumed-by-live-driver <id> ...` (flag live-verified to
+      exist — a #5886 review claim to the contrary was refuted by probe). Control
+      returns to the drain step to re-prove pending: 0.
+    command: null
+    evidence_predicate: null
+    transitions:
+      deliveries_consumed: drain_slot_inbox
+      cannot_apply: STOP-manual-intervention
+    kind: summon
+    blocked_on: null
+
+  - step_id: readiness_snapshot
+    intent: >-
+      Capture the machine-checked handoff-readiness predicate (#3138) ONCE into a
+      receipt; later steps split it into single-signal compares. Live shape
+      (2026-07-28): JSON with branch/pr/ready and checks.{tree_clean, no_inflight,
+      branch_pushed, pr_checks_green}, each a [status, detail] pair with status
+      vocabulary ok|red|unknown. The predicate is run, never asserted in prose
+      (#M-4); its compound `ready` boolean is deliberately NOT the signal here —
+      pr_checks_green is legitimately `unknown` at close when no PR is open, and
+      branch_pushed conflates behind-origin (benign) with ahead-of-origin (a real
+      stop) — the split steps read the fields this trail can act on soundly.
+    command: sh -c '.venv/bin/python -m scripts.orchestration.handoff_ready --json | tee batch_state/rb5-ready-{handoff_agent}.json'
+    evidence_predicate:
+      command: sh -c 'jq -e ".checks | has(\"tree_clean\")" batch_state/rb5-ready-{handoff_agent}.json'
+      success_pattern: '^true$'
+    transitions:
+      snapshot_recorded: tree_clean_check
+      predicate_unavailable: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: tree_clean_check
+    intent: >-
+      Single-signal read of checks.tree_clean from the recorded receipt. A dirty
+      tree at close is never auto-resolved — uncommitted work is never deleted and
+      never blind-committed (#M-10 class); it is judgment's to place, so the trail
+      stops.
+    command: sh -c 'V=$(jq -r ".checks.tree_clean[0] // empty" batch_state/rb5-ready-{handoff_agent}.json); case "$V" in ok) echo tree-clean;; red) echo tree-dirty;; *) echo receipt-unreadable;; esac'
+    evidence_predicate:
+      command: sh -c 'V=$(jq -r ".checks.tree_clean[0] // empty" batch_state/rb5-ready-{handoff_agent}.json); case "$V" in ok) echo tree-clean;; red) echo tree-dirty;; *) echo receipt-unreadable;; esac'
+      success_pattern: '^(tree-clean|tree-dirty|receipt-unreadable)$'
+    transitions:
+      tree_clean: inflight_check
+      tree_dirty: STOP-manual-intervention
+      receipt_unreadable: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: inflight_check
+    intent: >-
+      Single-signal read of checks.no_inflight from the recorded receipt. The
+      counter is repo-GLOBAL (live-captured 2026-07-28: it flagged two dispatches
+      that were both OTHER lanes' live work), so a non-zero count is an attribution
+      question this trail cannot answer mechanically — it routes to judgment,
+      never to a guess and never past the close.
+    command: sh -c 'V=$(jq -r ".checks.no_inflight[0] // empty" batch_state/rb5-ready-{handoff_agent}.json); case "$V" in ok) echo in-flight-none;; red) echo in-flight-present;; *) echo receipt-unreadable;; esac'
+    evidence_predicate:
+      command: sh -c 'V=$(jq -r ".checks.no_inflight[0] // empty" batch_state/rb5-ready-{handoff_agent}.json); case "$V" in ok) echo in-flight-none;; red) echo in-flight-present;; *) echo receipt-unreadable;; esac'
+      success_pattern: '^(in-flight-none|in-flight-present|receipt-unreadable)$'
+    transitions:
+      in_flight_none: primary_ahead_check
+      in_flight_present: resolve_inflight
+      receipt_unreadable: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: resolve_inflight
+    intent: >-
+      Judgment attributes each non-terminal batch_state/tasks/<id>.json row (the
+      task FILE is truth; the active-list API can omit live tasks — #5207). A live
+      dispatch of THIS seat's own means the session is not closable: the settle
+      obligation belongs to the dispatch loop, so the trail hands back. Rows all
+      confirmed other-lane (cwd/brief/epic evidence, never provider name alone)
+      proceed. Anything unattributable stops.
+    command: null
+    evidence_predicate: null
+    transitions:
+      own_dispatch_live: back_to_dispatch_loop
+      all_other_lane: primary_ahead_check
+      ownership_ambiguous: STOP-manual-intervention
+    kind: summon
+    blocked_on: "per-lane in-flight attribution needs runner-emitted step receipts (#5885)"
+
+  - step_id: primary_ahead_check
+    intent: >-
+      Unpushed local commits on the primary checkout at close violate the PRs-only
+      discipline and would strand work invisible to every other machine — that is
+      the stop this step exists for. Behind-origin is BENIGN at close (other lanes
+      merge continuously; live-captured 2026-07-28: origin/main moved ahead of a
+      freshly-fetched local within the same session). The readiness predicate's
+      branch_pushed field conflates the two directions, so this step counts only
+      the ahead direction (live shape: bare integer, "0" when clean).
+    command: sh -c 'git fetch origin --quiet 2>/dev/null; N=$(git rev-list --count origin/main..main 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
+    evidence_predicate:
+      command: sh -c 'git fetch origin --quiet 2>/dev/null; N=$(git rev-list --count origin/main..main 2>/dev/null); case "$N" in "") echo count-unavailable;; *[!0-9]*) echo count-unavailable;; 0) echo primary-clean;; *) echo primary-ahead;; esac'
+      success_pattern: '^(primary-clean|primary-ahead|count-unavailable)$'
+    transitions:
+      primary_clean: worktree_receipt
+      primary_ahead: STOP-manual-intervention
+      count_unavailable: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: worktree_receipt
+    intent: >-
+      Record the worktree estate into a receipt and read ONE signal from it: the
+      worktree count (live shape: "worktree <path>" / "HEAD <sha>" / "branch <ref>"
+      triplets, blank-line separated). Exactly one worktree (the primary) proceeds;
+      more routes the recorded receipt to the sweep judgment — the #M-10a close
+      sweep is disposition-per-worktree work this trail cannot do mechanically
+      (merged-clean vs uncommitted vs other-lane-live all look alike to a count).
+    command: sh -c 'git worktree list --porcelain | tee batch_state/rb5-worktrees-{handoff_agent}.txt | grep -c "^worktree "'
+    evidence_predicate:
+      command: sh -c 'grep -c "^worktree " batch_state/rb5-worktrees-{handoff_agent}.txt'
+      success_pattern: '^[1-9][0-9]*$'
+    transitions:
+      primary_only: handoff_gate
+      extra_worktrees: sweep_judgment
+      receipt_unwritable: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: sweep_judgment
+    intent: >-
+      Judgment applies the close-sweep rules to the recorded worktree receipt:
+      OWN worktrees that are merged and clean are reaped (worktree removal BEFORE
+      local-branch cleanup); uncommitted work is NEVER deleted (#M-10); other
+      lanes' worktrees are hands-off and get LISTED in the handoff instead
+      (live-captured 2026-07-28: 8 of 9 extra worktrees were other lanes' active
+      work — a mass sweep would have killed live dispatches). Own uncommitted
+      work found at close stops the trail — placing it is not a close-time call.
+    command: null
+    evidence_predicate: null
+    transitions:
+      sweep_applied: handoff_gate
+      own_uncommitted_work: STOP-manual-intervention
+    kind: summon
+    blocked_on: null
+
+  - step_id: handoff_gate
+    intent: >-
+      The handoff-completeness table is the content contract (every row
+      reconstructed from tool output, never memory; IN-FLIGHT with watcher ids;
+      NEXT ACTION ordered list; operator-pending items; the 40KB archive rule).
+      Prose completeness is not machine-checkable until the closure-gate
+      integration lands, so the mechanical signal here is presence+non-empty of
+      the seat's handoff file only — the seat applies the table rows to the file
+      it just wrote, and the receipt records that the gate was consulted.
+    command: sh -c 'test -s {handoff_file} && echo handoff-present || echo handoff-absent'
+    evidence_predicate:
+      command: sh -c 'test -s {handoff_file} && echo handoff-present || echo handoff-absent'
+      success_pattern: '^(handoff-present|handoff-absent)$'
+    transitions:
+      handoff_present: close_declaration
+      handoff_absent: STOP-manual-intervention
+    kind: table-lookup
+    table: handoff-completeness
+    blocked_on: "runner-backed closure-gate integration (receipt-chain validation ships with the trail runner; lease-release hooks landed with T1.2 #5896)"
+
+  - step_id: close_declaration
+    intent: >-
+      The close is declared only over this trail's own receipts — both snapshot
+      files must exist and be non-empty, so "closed clean" is receipt-backed
+      rather than asserted. The fenced lease release is NOT commanded here: the
+      hardened SessionEnd hook (T1.2, #5896) owns it on process exit. When the
+      trail runner lands, the receipt-chain closure gate supersedes this step's
+      two-file check with full-chain validation.
+    command: sh -c 'test -s batch_state/rb5-ready-{handoff_agent}.json && test -s batch_state/rb5-worktrees-{handoff_agent}.txt && echo receipts-complete || echo receipts-missing'
+    evidence_predicate:
+      command: sh -c 'test -s batch_state/rb5-ready-{handoff_agent}.json && test -s batch_state/rb5-worktrees-{handoff_agent}.txt && echo receipts-complete || echo receipts-missing'
+      success_pattern: '^(receipts-complete|receipts-missing)$'
+    transitions:
+      receipts_complete: closed_handoff_written
+      receipts_missing: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null

--- a/scripts/config/trails/rb5-session-close.trail.yaml
+++ b/scripts/config/trails/rb5-session-close.trail.yaml
@@ -33,7 +33,7 @@
 # proceed.
 schema_version: trailspec.v1
 trail_id: rb5-session-close
-version: "0.1.3"
+version: "0.1.4"
 title: RB5 Session close — inbox drain, readiness receipts, hygiene sweep, handoff gate
 seats:
   - grok-daily
@@ -61,7 +61,7 @@ steps:
       status into exactly the three transition tokens (r3 finding: raw bridge
       output plus a boolean predicate cannot discriminate pending-work from a
       broken DB).
-    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent} 2>&1); RC=$?; printf "%s\n" "$OUT" > batch_state/rb5-inbox-{handoff_agent}.txt; if [ "$RC" -ne 0 ]; then echo db-not-writable; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
+    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent} 2>&1); RC=$?; printf "%s\n" "$OUT" > batch_state/rb5-inbox-{handoff_agent}.txt || { echo db-not-writable; exit 0; }; if [ "$RC" -ne 0 ]; then echo db-not-writable; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
     evidence_predicate:
       command: sh -c 'OUT=$(cat batch_state/rb5-inbox-{handoff_agent}.txt 2>/dev/null); if printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
       success_pattern: '^(empty|pending-deliveries|db-not-writable)$'
@@ -234,7 +234,7 @@ steps:
       close re-verifies from the top (the delivery may have changed the world
       the readiness receipts described). Same normalized three-token wrapper as
       the opening drain (r3 finding).
-    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent} 2>&1); RC=$?; printf "%s\n" "$OUT" > batch_state/rb5-inbox-final-{handoff_agent}.txt; if [ "$RC" -ne 0 ]; then echo db-not-writable; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
+    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent} 2>&1); RC=$?; printf "%s\n" "$OUT" > batch_state/rb5-inbox-final-{handoff_agent}.txt || { echo db-not-writable; exit 0; }; if [ "$RC" -ne 0 ]; then echo db-not-writable; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
     evidence_predicate:
       command: sh -c 'OUT=$(cat batch_state/rb5-inbox-final-{handoff_agent}.txt 2>/dev/null); if printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
       success_pattern: '^(empty|pending-deliveries|db-not-writable)$'

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -39,6 +39,7 @@ REQUIRED_TRAIL_IDS = {
     "rb2-dispatch-loop",
     "rb3-pr-lifecycle",
     "rb4-red-ci-triage",
+    "rb5-session-close",
 }
 
 


### PR DESCRIPTION
## What

RB-5 (session close) TrailSpec draft — the fifth T2 extraction, at the RB-2 (#5915) /
RB-4 (#5919) discipline. 11 steps: final live-driver inbox drain (drive-epic 8a) →
readiness receipt (`handoff_ready --json`, #3138) split into single-signal compares
(tree clean · in-flight · primary-ahead) → worktree receipt + sweep judgment (#M-10a,
never delete uncommitted) → handoff-completeness table gate → receipt-backed close
declaration.

## Discipline receipts

- **Every command live-captured 2026-07-28** (this infra session): readiness JSON check
  vocabulary `ok|red|unknown`; inbox `pending: N`; `rev-list --count` bare integer;
  worktree porcelain triplets.
- **Live-captured hazard encoded**: the readiness predicate's in-flight counter is
  repo-GLOBAL — today it flagged two dispatches that were both OTHER lanes' live work.
  Non-zero → judgment summon (blocked_on: per-lane attribution needs runner-emitted
  step receipts), never a guess, never a silent proceed.
- **Sound-signal split**: the predicate's compound `ready` bool is deliberately not used
  (`pr_checks_green` is legitimately `unknown` at close; `branch_pushed` conflates
  behind-origin (benign) with ahead-of-origin (real stop)) — the trail reads only the
  fields it can act on soundly and counts only the ahead direction itself.
- **Deliberately NOT drafted** (RB-4 r3/r4 precedent — no unreachable speculative
  machinery): the runner-backed receipt-chain closure gate (ships with the trail
  runner) and the fenced lease release (the hardened SessionEnd hook owns it — T1.2,
  #5896, deployed).
- Also corrects the `handoff-completeness` table's stale `blocked_on` (T1.2's
  lease-hooks half landed via #5896; outstanding = the runner-backed receipt chain).

## Verification

- `validate_trailspec --spec` OK: 11 steps, hash `9f521c36…`
- `validate_trailspec --tables` OK
- `tests/test_validate_trailspec.py` 32/32 in the worktree; ruff clean

Part of #5885 (Refs, not Closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)