### PR TITLE
docs(design): adopt advisor memos — red-CI registry trio + durable arc layer

### DIFF
--- a/docs/projects/arc-layer/arc-layer-design.md
+++ b/docs/projects/arc-layer/arc-layer-design.md
@@ -1,0 +1,154 @@
+# Durable arc layer — long-term plans per epic, operator-visible, fleet-onboarded
+
+- **Status**: ADOPTED DESIGN (advisor memo, verbatim below) — build sequenced behind the
+  operator's #5897 decision; a limited two-epic pilot can proceed independently of #5912.
+- **Provenance**: operator directive 2026-07-28 (durable long-term arcs/plans for each area
+  and epic so other seats can develop them when the primary driving seat is unavailable;
+  fleet onboarded to them; progress visible to the operator via the Monitor API + dashboard).
+  Designed by the advisor seat (gpt-5.6-sol @ xhigh, bridge task `arc-layer-design-sol`,
+  reply msg 5554, 2026-07-28). Tracking issue: #5921.
+- **Operator calls required** (listed verbatim in §Operator calls): #5897 milestone
+  semantics · ArcSpec authority model approval · #5912 epic re-parenting timing · review
+  cadence + whether fleet-comms events ship in the initial build.
+- **Build sequence** (memo's recommendation): #5897 decision → ArcSpec schema + two-epic
+  pilot → API/UI + #5898 auditing → portfolio backfill → onboarding → optional derived
+  events.
+
+---
+
+## Sol design memo — durable arc layer (gpt-5.6-sol, 2026-07-28, verbatim)
+
+The main failure mode is split-brain: arcs must not become another backlog, handoff diary, or communications authority. The second risk is "fresh-looking aspiration"—dates get bumped while milestones remain unevidenced.
+
+### Recommendation
+
+Use one structured, reviewable ArcSpec per GitHub epic:
+
+`docs/arcs/epics/<epic-number>.arc.yaml`
+
+Do not create a second global arc registry. `scripts/config/issue_streams.yaml` already owns stream-to-epic membership. The API groups ArcSpecs by that registry.
+
+For streams with several epics, exactly one active ArcSpec carries `stream_focus: true`; its current milestone projects into #5897's per-stream milestone line. Other active epics remain visible in the detailed area view.
+
+| Layer | Authority |
+|---|---|
+| ArcSpec | Long-term destination, phases, evidence, current strategic focus |
+| GitHub epic/sub-issues | Executable queue and acceptance criteria |
+| `WORKSTREAMS.md` | Framework plus generated/checked focus projection |
+| TrailSpec | How a driver executes the loop |
+| Driver handoff + session stream | Live session continuity; file handoff remains authoritative |
+| Fleet-comms events | Notifications only, never state |
+
+An "area" should remain the stream projection of its epics, not another independently edited plan. If an area genuinely needs its own arc, represent it with an umbrella GitHub epic. This keeps one arc equal to one tracking issue.
+
+### ArcSpec content contract
+
+Require:
+
+- `schema_version`, `epic`, lifecycle state, and `stream_focus`
+- `mission`: one durable outcome sentence
+- overall success criteria
+- explicit guardrails/non-goals
+- decision references with short rationale summaries
+- ordered phases: stable ID, outcome, state, and evidence-shaped exit criteria
+- current phase and milestone: stable IDs, outcome, and `done_when`
+- one to three ordered next actions, each with an intent plus typed issue/decision/trail reference
+- typed dependencies and unblock conditions
+- evidence references for every completed phase
+- `reviewed_at` attestation
+
+Derive the owning stream and tracking URL from `issue_streams.yaml` and the epic number. Derive the actual last-change timestamp from Git. Do not manually duplicate lane names, live owners, issue titles, or `last_updated`.
+
+Golden rule: **arcs encode where, why, and what proves arrival; live systems supply who, how, and what is happening now.**
+
+### API and operator UI
+
+Use a read-only file-backed router:
+
+- `GET /api/arcs` — grouped summaries, optionally filtered by stream/state
+- `GET /api/arcs/streams/{stream}` — area detail
+- `GET /api/arcs/epics/{number}` — complete ArcSpec
+- `GET /api/arcs/epics/{number}/capsule` — bounded cold-start summary
+- `GET /api/arcs/health` — schema, coverage, drift, and freshness diagnostics
+
+The API should read the live primary checkout, validate YAML, and cache only by file digest/mtime. Return the normalized arc hash and repository SHA. A cache is an optimization, never another registry.
+
+Add an `Arcs` dashboard page showing:
+
+- streams grouped in plain language;
+- each epic's mission;
+- named phase segments—no misleading percentage because phases are unequal;
+- current milestone and next actions;
+- blocked, stale, and decision-needed badges;
+- last review time;
+- secondary links to the epic and ArcSpec.
+
+The dashboard must derive its phase bar from ArcSpec files. It must not reconstruct state from message history.
+
+### Update discipline
+
+Update an ArcSpec when strategy state changes, not at every session close:
+
+- milestone starts, completes, or changes;
+- a phase exits;
+- the arc blocks or unblocks;
+- a dependency or decision changes;
+- ordered next actions materially change;
+- mission, guardrails, or exit criteria are revised with advisor/operator approval.
+
+Session detail stays in the driver handoff and stream.
+
+Enforcement should distinguish:
+
+- **ERROR:** invalid schema, multiple current phases, completed criteria without evidence, or projection mismatch. CI-blocking.
+- **VACANT:** registered epic lacks an ArcSpec, stream focus, milestone, or next action.
+- **DRIFT:** referenced action closed/missing while still current, incompatible phase state, or dependency contradiction.
+- **STALE:** active arc has exceeded the approved review cadence.
+
+Extend #5898 for scheduled VACANT/DRIFT/STALE warnings and SessionStart summaries. Do not block unrelated PRs merely because another arc aged. Registration of a new epic without its ArcSpec can become a scoped hard failure after backfill is complete.
+
+### Fleet onboarding
+
+Keep cold-start payloads small:
+
+1. `/api/rules` adds one binding pointer: epic drivers must hydrate the exact ArcSpec before choosing work.
+2. Launchers already know `epic:N`; inject mission, phase, milestone, age, arc hash, and the capsule endpoint—roughly three lines.
+3. `drive-epic` records the consumed arc hash and milestone ID in its first state-at-start handoff/stream entry. A surfaced pointer alone is not evidence of reading.
+4. If the API is unavailable, load `docs/arcs/epics/N.arc.yaml`.
+5. Delegated briefs carry the arc hash, milestone ID, and selected action reference; children do not load the whole portfolio.
+6. Send one fleet announcement only after #5897 sign-off and arc onboarding land. Do not send competing announcements now.
+
+### Fleet-comms verdict
+
+Repo file plus API polling is sufficient for the authoritative MVP.
+
+Fleet-comms is useful afterward for low-latency, derived events such as:
+
+- `arc.milestone.changed`
+- `arc.phase.completed`
+- `arc.blocked`
+
+Emit these only after the ArcSpec change merges to `main`, with the repo SHA and arc hash. A failed or missing event must not affect correctness; the dashboard refreshes from files. Manual "milestone completed" posts must never advance the arc.
+
+This does not alter plane authority, retention, or cutover. Existing file handoffs remain authoritative in `off`, `shadow`, and `dual_write`.
+
+### Rejected
+
+- Full arcs inside `WORKSTREAMS.md`: monolithic, high-contention, and duplicates #5897.
+- One giant YAML registry: one invalid or conflicted file affects every lane.
+- Free-form Markdown as API truth: difficult to validate and invites dashboard scraping.
+- Named seat/person ownership: freezes a roster and defeats replacement-seat operation.
+- Mandatory session-close arc edits: turns strategy into a diary.
+- Database/API writes as primary state: creates split-brain with reviewed repo files.
+- Fleet-comms messages as progress authority: implies an unsupported cutover.
+- Calendar freshness alone: easily gamed; combine review age with evidence/state reconciliation.
+- Loading every arc at every cold start: unnecessary context bloat.
+
+### Operator calls required
+
+1. Sign off or reject #5897's milestone semantics; ArcSpec must project into that accepted layer.
+2. Approve the ArcSpec authority model: per-epic YAML, stream grouping from `issue_streams.yaml`, read-only API/UI, and no database authority.
+3. Decide #5912's epic re-parenting before portfolio-wide completeness becomes mandatory. A limited pilot can proceed independently.
+4. Choose the active-arc review cadence and whether fleet-comms events are included in the initial build or a later phase. Recommendation: warnings first; events after the file/API path is proven.
+
+Suggested sequence: #5897 decision → ArcSpec schema and two-epic pilot → API/UI plus #5898 auditing → portfolio backfill → onboarding → optional derived events.

--- a/docs/projects/fleet-trails/red-ci-known-failures-design.md
+++ b/docs/projects/fleet-trails/red-ci-known-failures-design.md
@@ -1,0 +1,194 @@
+# Red-CI known-failures registry + lookup tool + raceless rerun primitive — design
+
+- **Status**: ADOPTED DESIGN (advisor memo, verbatim below) — implementation staged, not started.
+- **Provenance**: designed by the advisor seat (gpt-5.6-sol @ xhigh, bridge task
+  `registry-design-sol`, reply msg 5551, 2026-07-28), commissioned by the infra lane per the
+  RB-4 (#5919) review resolution: the registry, its lookup tool, and the rerun primitive are
+  designed TOGETHER. Part of #5885.
+- **Consumers**: `scripts/config/trails/rb4-red-ci-triage.trail.yaml` (`allowlist_match` is an
+  enforced fail-closed gate on the registry file + lookup tool), the `red-ci-triage` decision
+  table, and `scripts/orchestration/validate_trailspec.py`.
+- **Integration hazards the memo found in merged RB-4** (fix before activation, tracked by the
+  infra lane): `extract_signature` bypasses `head_currency_check` (unreachable step — the
+  validator checks dangling targets, not reachability); `locate_failing_run`'s
+  `gh run list --limit 1` can select a newer pending run instead of the failing one.
+- **Operator decisions still open** (listed verbatim in §D): review horizon + evidence
+  minimums · authorized registry reviewers · single- vs multi-host claimant scope ·
+  TrailSpec v1.1 approval · disposition of the GitHub head-change TOCTOU.
+
+---
+
+## Architecture memo: red-CI known failures (gpt-5.6-sol, 2026-07-28, verbatim)
+
+### Executive decision
+
+Ship registry and lookup first, fail-closed. Do not make automatic rerun reachable under TrailSpec v1.
+
+The safe rerun design needs TrailSpec v1.1 invocation binding plus an atomic claimant ledger. Even then, a client-side head check cannot eliminate the final GitHub head-change race; that residual needs an explicit operator decision or workflow-concurrency hardening.
+
+Two existing integration hazards should be fixed before activation:
+
+- `extract_signature` currently transitions to `staleness_probe`, making `head_currency_check` unreachable. The validator checks dangling targets but not graph reachability.
+- `gh run list --branch ... --limit 1` can select a newer pending run instead of the run referenced by the failing check. Resolve the run and job from the failing check URL/ID.
+
+### A. Registry schema
+
+Use a versioned schema such as:
+
+```yaml
+schema_version: red-ci-known-failures.v1
+registry_version: "1.0.0"
+
+entries:
+  - id: pytest-cache-race
+    matcher:
+      check_name:
+        exact: "CI / Test (pytest)"
+      lines:
+        required:
+          - type: regex
+            value: 'FAILED tests/test_cache\.py::test_parallel_cache .*'
+        accepted:
+          - type: regex
+            value: 'FAILED tests/test_cache\.py::test_parallel_cache .*'
+        require_full_coverage: true
+
+    action:
+      kind: retry-once  # retry-once | note-and-proceed | stop
+      # stop_code required only for kind: stop
+
+    owning_issue: 5885
+
+    evidence:
+      - run_id: 123456789
+        run_attempt: 1
+        pr_number: 1234
+        head_sha: "40-lowercase-hex"
+        observed_at: "2026-07-28T10:00:00Z"
+        signature_sha256: "64-lowercase-hex"
+
+    governance:
+      added_by: "github-login"
+      added_at: "2026-07-28T10:00:00Z"
+      added_in_pr: 6000
+      reviewed_by: ["independent-reviewer"]
+      reviewed_at: "2026-07-28T11:00:00Z"
+      review_by: "2026-08-27T11:00:00Z"
+```
+
+Rules:
+
+- Require exact check-name matching plus full-line exact or anchored/full-match regex rules. Reject substring-only matching.
+- `required` is all-of. `accepted` must cover every normalized signature line; otherwise an additional unknown failure could be hidden by one familiar line.
+- Strip ANSI and normalize CRLF only. Do not lowercase or collapse whitespace implicitly.
+- Require unique IDs, nonempty evidence, an owning issue, governance metadata, and action-specific schema constraints.
+- Parse all timestamps into timezone-aware instants and epoch-compare them. Never lexicographically compare ISO strings.
+- `review_by` is a hard eligibility deadline, not an advisory reminder. An expired matching entry yields `table-unknown`; it never authorizes an action. Scheduled/current-time validation should also fail while expired entries remain.
+- Renewal requires a reviewed registry PR updating evidence and governance. Runtime tools never edit the registry.
+- Define `note-and-proceed` narrowly: annotate and leave RB-4 triage, while the PR remains blocked by any blocking red check. It must never mean bypassing branch protection, claiming green, or arming merge.
+
+The present bare text receipt is insufficient because it carries neither check identity nor trustworthy run binding. Introduce `red-ci-signature-receipt.v1` containing repository ID/name, PR, run ID/attempt/head SHA, job/check ID and name, normalized signature lines, extraction version, timestamp, and digest.
+
+For runs with multiple failures, lookup is per atomic failed job/signature. Aggregate fail-closed:
+
+1. Any malformed, unknown, ambiguous, expired-match, or `stop` result stops.
+2. Otherwise any `retry-once` permits one run-level retry.
+3. Only an all-`note-and-proceed` set takes that disposition.
+
+### B. Lookup contract
+
+Recommended interface:
+
+```text
+red_ci_known_failures.py lookup \
+  --registry PATH \
+  --receipt PATH \
+  --repository-id ID \
+  --pr NUMBER \
+  --run-id ID \
+  --as-of ISO_TIMESTAMP \
+  --output LOOKUP_RECEIPT
+```
+
+`--as-of` is required so results are deterministic and expiry tests are reproducible.
+
+Successful JSON:
+
+```json
+{
+  "schema_version": "red-ci-lookup-receipt.v1",
+  "status": "matched",
+  "entry_id": "pytest-cache-race",
+  "action": {"kind": "retry-once"},
+  "registry_sha256": "...",
+  "signature_receipt_sha256": "...",
+  "as_of_epoch": 1785240000
+}
+```
+
+No match:
+
+```json
+{
+  "schema_version": "red-ci-lookup-receipt.v1",
+  "status": "table-unknown",
+  "reason": "no-match"
+}
+```
+
+Contract:
+
+- Exit `0`: valid `matched` or `table-unknown`.
+- Nonzero with no actionable stdout: malformed registry, malformed receipt, identity mismatch, unsafe regex, unsupported schema, or I/O failure.
+- Receipt identity must equal CLI identity. The lookup itself remains pure and network-free.
+- Evaluate every entry. Zero eligible matches means `table-unknown`; exactly one means matched; more than one means `table-unknown` with reason `ambiguous`. Never use file order, "first match," or invented regex specificity.
+- If an expired entry would match, return `table-unknown` even if an active overlapping entry also matches.
+
+Put JSON Schema in `agents_extensions/shared/schemas/`. Put parsing, domain validation, timestamp normalization, and matching in one reusable module consumed by both the lookup CLI and `validate_trailspec.py`; do not duplicate validation. Extend `validate_trailspec.py` as the CI-facing entry point, including expiry and trail reachability checks.
+
+### C. Rerun primitive and v1/v1.1 verdict
+
+Verdict: TrailSpec v1.1 is required. Registry and lookup may ship under v1, but the retry transition remains mechanically unreachable until v1.1 is operator-approved and implemented.
+
+Minimum v1.1 addition:
+
+- Generate a stable `invocation_id` before executing the command.
+- Pass it to the command.
+- Bind the evidence predicate to that invocation's immutable command receipt/digest.
+- Never re-execute a side-effecting command as its predicate.
+- Add `invocation_id`, command-receipt digest, and actor outcome to StepReceipt.
+- Map exact primitive signals to transitions.
+
+The primitive should:
+
+1. Recompute lookup from the registry and signature receipt; require `retry-once`.
+2. Fetch live run and PR identity. Validate both SHAs independently as lowercase 40-hex, then require equality.
+3. Require the original run to be completed, failed, and `run_attempt == 1`.
+4. Atomically claim unique `(repository_id, workflow_run_id)` in a shared ignored SQLite ledger using `BEGIN IMMEDIATE` and a unique constraint. Commit the claim before the network side effect.
+5. Re-fetch and revalidate both SHAs and run state immediately before POST.
+6. Call the workflow-rerun REST endpoint and accept only its direct HTTP `201` response as evidence. Never infer success from later queued-run status. GitHub documents `201 Created` for this endpoint and confirms reruns retain the original SHA/ref.
+7. Write an immutable per-invocation receipt using exclusive creation.
+
+Ledger states should be `claimed`, `accepted`, `refused`, and `indeterminate`. A losing claimant reports `already-accepted` or `claim-in-progress`; it never reports that its own rerun fired. A crash after claim is never automatically taken over because the POST may already have succeeded.
+
+One unresolved hard limit: GitHub's documented rerun endpoint accepts a run ID but no expected-current-head conditional. Therefore a PR head can change between the last equality check and POST. A client-only primitive cannot prove absolute atomic head currency. Operator input is required to choose between:
+
+- keeping automatic rerun disabled;
+- accepting the documented final-preflight residual risk; or
+- approving workflow-concurrency hardening keyed by immutable head SHA so a stale rerun cannot cancel current-head CI.
+
+The SQLite mechanism also assumes all claimants share the canonical local runtime state. Multi-host execution requires a server-side/shared CAS coordinator; local SQLite is insufficient.
+
+### D. Packaging
+
+Use one approved design and final integration review, with staged implementation PRs:
+
+1. Registry and signature-receipt schemas, reusable validator, expiry policy, reachability validation.
+2. Structured extraction, deterministic lookup, ambiguity/multi-failure aggregation, non-rerun trail routes.
+3. Operator-approved TrailSpec v1.1, atomic ledger/primitive, adversarial concurrency and crash tests, then the retry transition.
+
+Each PR gets independent cross-family review. PR 3 also receives a combined interface/conformance review against this memo. "Reviewed together" should mean shared architecture and final integration acceptance—not one oversized PR.
+
+Rejected choices: substring matching, first-match or "most-specific" resolution, soft expiry dates, shared result files, queued-status inference, automatic takeover of uncertain claims, and any meaning of `note-and-proceed` that bypasses red CI.
+
+Operator decisions still required: maximum review horizon and evidence minimums; authorized registry reviewers; single-host versus multi-host claimant scope; v1.1 approval; and disposition of the unavoidable GitHub head-change TOCTOU.


### PR DESCRIPTION
## What

Commits two advisor (gpt-5.6-sol @ xhigh) design memos verbatim, with provenance and adoption-status headers, so the designs are durable in-repo rather than living in one session's context:

1. **`docs/projects/fleet-trails/red-ci-known-failures-design.md`** — the registry + lookup tool + raceless rerun primitive mandated by the RB-4 (#5919) review resolution. Headline decisions: registry+lookup ship first fail-closed; automatic rerun requires trailspec v1.1 (operator-gated) + an atomic claimant ledger; staged 3-PR build, each cross-family reviewed. The memo also flagged two integration hazards in merged RB-4 (unreachable `head_currency_check`; `gh run list --limit 1` mis-selection) — fix dispatched separately.
2. **`docs/projects/arc-layer/arc-layer-design.md`** — operator directive 2026-07-28: durable long-term arcs per epic (`docs/arcs/epics/<N>.arc.yaml`), read-only `/api/arcs` + dashboard page, auditor warnings, fleet onboarding via a ~3-line launcher capsule. Sequenced behind the operator's #5897 decision; a two-epic pilot can proceed independently. Tracking: #5921.

Docs-only PR — no behavior. Both memos are recorded verbatim under an ADOPTED DESIGN header that lists the operator decisions still open.

Refs #5885, #5921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)