### PR TITLE
fix(trails): RB-4 reachability + failing-run resolution + validator reachability check

### DIFF
--- a/scripts/config/trails/rb4-red-ci-triage.trail.yaml
+++ b/scripts/config/trails/rb4-red-ci-triage.trail.yaml
@@ -21,9 +21,14 @@
 #   head can CANCEL the live head's run via the workflow concurrency group.
 # - A merge checkout's content is not the branch's content — signatures must be read
 #   from the failing run's logs, never inferred from local state.
+#
+# v0.4.2 fixes:
+# - signature_recorded transition routes to head_currency_check (was unreachable).
+# - locate_failing_run parses run id from failing check row URL in batch_state/rb4-checks-{pr_number}.txt
+#   instead of gh run list --branch (which could pick a newer pending run).
 schema_version: trailspec.v1
 trail_id: rb4-red-ci-triage
-version: "0.4.1"
+version: "0.4.2"
 title: RB4 Red-CI triage — signature, allowlist, staleness, bounded rerun
 seats:
   - grok-daily
@@ -57,17 +62,20 @@ steps:
 
   - step_id: locate_failing_run
     intent: >-
-      Resolve the failing run id for the PR's branch (live shape: JSON array of
-      {databaseId, status, conclusion}; the newest run for the head branch). The run
-      id is recorded for every later step — signatures come from THIS run's logs,
-      never from local reproduction alone.
-    command: sh -c 'gh run list --branch {head_branch} --limit 1 --json databaseId,status,conclusion | tee batch_state/rb4-run-{pr_number}.json'
+      Resolve the failing run id from the FAILING row's URL field in
+      batch_state/rb4-checks-{pr_number}.txt (live shape: URL containing
+      /actions/runs/<run_id>/). The receipt is written to
+      batch_state/rb4-run-{pr_number}.json in [{"databaseId": <run_id>}] shape for
+      downstream consumers. Signatures come from THIS failing run's logs.
+    command: >-
+      sh -c 'RUN=$(awk -F"\t" "\$2==\"fail\" {print \$4}" batch_state/rb4-checks-{pr_number}.txt | sed -E -n "s|.*/actions/runs/([0-9]+).*|\1|p" | head -1); case "$RUN" in [0-9]*) printf "[{\"databaseId\": %s}]\n" "$RUN" > batch_state/rb4-run-{pr_number}.json; echo run-located;; *) echo no-failing-run;; esac'
     evidence_predicate:
-      command: jq -r '.[0].databaseId // ""' batch_state/rb4-run-{pr_number}.json
-      success_pattern: '^[0-9]+$'
+      command: >-
+        sh -c 'RUN=$(awk -F"\t" "\$2==\"fail\" {print \$4}" batch_state/rb4-checks-{pr_number}.txt | sed -E -n "s|.*/actions/runs/([0-9]+).*|\1|p" | head -1); case "$RUN" in [0-9]*) echo run-located;; *) echo no-failing-run;; esac'
+      success_pattern: '^(run-located|no-failing-run)$'
     transitions:
       run_located: extract_signature
-      no_run_for_branch: STOP-precondition-failed
+      no_failing_run: STOP-precondition-failed
     kind: mechanical
     blocked_on: null
 
@@ -83,7 +91,7 @@ steps:
       command: test -s batch_state/rb4-signature-{pr_number}.txt && echo signature-recorded
       success_pattern: '^signature-recorded$'
     transitions:
-      signature_recorded: staleness_probe
+      signature_recorded: head_currency_check
       logs_empty: STOP-manual-intervention
     kind: mechanical
     blocked_on: null

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -168,6 +168,29 @@ def validate_trailspec_data(
                     f"Dangling transition in step '{step_id}' (label '{label}'): target '{target}' does not exist in steps, stop_codes, or terminal_outcomes"
                 )
 
+    # Invariant 4: Graph reachability — every step must be reachable from the first step
+    if steps:
+        first_step_id = steps[0].get("step_id")
+        step_id_to_step = {s.get("step_id"): s for s in steps if s.get("step_id")}
+
+        visited: set[str] = set()
+        queue = [first_step_id] if first_step_id in step_id_to_step else []
+        while queue:
+            curr = queue.pop()
+            if curr in visited:
+                continue
+            visited.add(curr)
+            curr_step = step_id_to_step.get(curr, {})
+            for target in curr_step.get("transitions", {}).values():
+                if target in step_id_to_step and target not in visited:
+                    queue.append(target)
+
+        unreachable = sorted(step_ids - visited)
+        if unreachable:
+            raise TrailSpecValidationError(
+                f"Unreachable step(s) {unreachable}: not reachable from start step '{first_step_id}'"
+            )
+
     trail_hash = compute_trail_hash(spec_data)
     return {
         "ok": True,

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -144,6 +144,39 @@ def test_negative_dangling_transition() -> None:
     assert res["ok"] is True
 
 
+def test_negative_unreachable_step() -> None:
+    """Negative invariant test: a spec with an unreachable/orphan step fails validation."""
+    data = _get_happy_example_data()
+    # Add an orphan step that no step transitions to
+    orphan_step = {
+        "step_id": "orphan_step_xyz",
+        "intent": "Unreachable step for testing",
+        "command": "echo orphan",
+        "evidence_predicate": {
+            "command": "echo orphan",
+            "success_pattern": "^orphan$",
+        },
+        "transitions": {
+            "success": "request_review",
+        },
+        "kind": "mechanical",
+        "blocked_on": None,
+    }
+    data["steps"].append(orphan_step)
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+
+    err_msg = str(exc_info.value)
+    assert "Unreachable step(s)" in err_msg
+    assert "orphan_step_xyz" in err_msg
+
+    # Mutation check: restore original copy -> passes
+    restored = _get_happy_example_data()
+    res = validate_trailspec_data(restored, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)
+    assert res["ok"] is True
+
+
 def test_negative_unknown_stop_code() -> None:
     """Negative invariant test: unknown stop_code not in 16-item contract list fails validation."""
     data = _get_happy_example_data()


### PR DESCRIPTION
### Summary
Fixes two integration hazards in the RB-4 red-CI triage trail (`scripts/config/trails/rb4-red-ci-triage.trail.yaml`) and adds graph reachability validation to the TrailSpec validator.

### Integration Hazards & Fixes
1. **Unreachable Step (`head_currency_check`)**:
   - `extract_signature.transitions.signature_recorded` previously pointed to `staleness_probe`, bypassing `head_currency_check`.
   - **Fix**: Updated `extract_signature.transitions.signature_recorded` to route to `head_currency_check`.
   - **Version**: Bumped trail version to `0.4.2`.

2. **Run Resolution Hazard (`locate_failing_run`)**:
   - `locate_failing_run` previously ran `gh run list --branch {head_branch} --limit 1`, which could resolve a newer pending run instead of the run the failing check belonged to.
   - **Fix**: Updated `locate_failing_run` to parse the run ID from the failing row's URL field in `batch_state/rb4-checks-{pr_number}.txt` (`awk -F"\t" "$2==\"fail\""` + regex on `/actions/runs/<id>/`).
   - The receipt written to `batch_state/rb4-run-{pr_number}.json` retains the `[{"databaseId": <id>}]` shape expected by downstream `jq` consumers.

3. **Graph Reachability Validation**:
   - Added graph reachability check to `validate_trailspec_data` in `scripts/orchestration/validate_trailspec.py`. Ensures every step is reachable from the first step by following transitions; raises `TrailSpecValidationError` listing any unreachable step IDs.
   - Added negative fixture test `test_negative_unreachable_step` in `tests/test_validate_trailspec.py`.

### Live-Captured URL Shape
```
Python (pytest) [1/4]	pending	0	https://github.com/learn-ukrainian/learn-ukrainian.github.io/actions/runs/30337678981/job/90206039426
```
The run ID segment is `/actions/runs/30337678981/`.

### Mutation Evidence
1. **Unreachable step mutation**: Reverted `signature_recorded` transition to `staleness_probe` locally -> `test_every_shipped_trail_validates[rb4-red-ci-triage.trail]` failed with:
   `TrailSpecValidationError: Unreachable step(s) ['head_currency_check']: not reachable from start step 'snapshot_checks'`
2. **Disabled reachability check mutation**: Disabled reachability check in `validate_trailspec.py` -> `test_negative_unreachable_step` failed with:
   `Failed: DID NOT RAISE <class 'scripts.orchestration.validate_trailspec.TrailSpecValidationError'>`

Refs #5885