### PR TITLE
feat(trails): RB-3 tightening rewrite v2.0.0 — real review flow, live-captured shapes

### DIFF
--- a/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
+++ b/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
@@ -35,7 +35,7 @@
 # this seat built; PRs reviewed-only have none and the hygiene step handles absence.
 schema_version: trailspec.v1
 trail_id: rb3-pr-lifecycle
-version: "2.0.0"
+version: "2.0.1"
 title: RB3 PR lifecycle — formal review, verdict, gate, arm, babysit, hygiene
 seats:
   - grok-daily
@@ -97,13 +97,17 @@ steps:
       normally RETURNS with the reply delivered (live shape: "✅ <Seat> finished
       (N chars)"); its true state is read from the ask ledger in the next step —
       never from the absence of an error (silent ask deaths are the #5900 class;
-      the #5893 retry-watchdog refires once).
-    command: sh -c '.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr {pr_number} --reviewer {reviewer_seat} 2>&1 | tail -5 > batch_state/rb3-review-fire-{pr_number}.txt || { echo fire-unrecorded; exit 0; }; echo review-fired'
+      the #5893 retry-watchdog refires once). The invocation's exit status is
+      captured WITHOUT a masking pipeline (r1: `| tail` made the token report
+      tail's status — the documented tee-masks-rc class): non-zero routes to the
+      stuck-request judgment, since a ledger row may or may not exist.
+    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr {pr_number} --reviewer {reviewer_seat} 2>&1); RC=$?; printf "%s\n" "$OUT" | tail -5 > batch_state/rb3-review-fire-{pr_number}.txt || { echo fire-unrecorded; exit 0; }; [ "$RC" -eq 0 ] && echo review-fired || echo fire-failed'
     evidence_predicate:
-      command: sh -c 'test -s batch_state/rb3-review-fire-{pr_number}.txt && echo review-fired || echo fire-unrecorded'
-      success_pattern: '^(review-fired|fire-unrecorded)$'
+      command: sh -c 'test -s batch_state/rb3-review-fire-{pr_number}.txt && echo fire-recorded || echo fire-unrecorded'
+      success_pattern: '^(fire-recorded|fire-unrecorded)$'
     transitions:
       review_fired: poll_request_state
+      fire_failed: resolve_stuck_request
       fire_unrecorded: STOP-precondition-failed
     kind: mechanical
     blocked_on: null
@@ -266,9 +270,11 @@ steps:
       `git pull` (manual `git branch -d/-D` is guard-BLOCKED by design — the
       v1.0.0 command could never run); the dispatch worktree (bound from the
       RB-2 record; reviewed-only PRs have none) is removed worktree-FIRST.
-      A worktree holding uncommitted content is never force-removed (#M-10) —
-      that stops for judgment.
-    command: sh -c 'if [ -n "{worktree_path}" ] && [ -d "{worktree_path}" ]; then if git -C "{worktree_path}" status --porcelain 2>/dev/null | grep -q .; then echo hygiene-blocked-dirty; exit 0; fi; git worktree remove --force "{worktree_path}" >/dev/null 2>&1 || { echo hygiene-failed; exit 0; }; fi; git pull --ff-only >/dev/null 2>&1 && echo hygiene-complete || echo hygiene-failed'
+      Removal is WITHOUT --force (r1: a pre-check-then-force pair is not atomic
+      and --force deletes what the check missed): git\'s own refusal on any
+      non-clean worktree is the guard, and that refusal stops for judgment —
+      never a second attempt with force.
+    command: sh -c 'if [ -n "{worktree_path}" ] && [ -d "{worktree_path}" ]; then git worktree remove "{worktree_path}" >/dev/null 2>&1 || { echo hygiene-blocked-dirty; exit 0; }; fi; git pull --ff-only >/dev/null 2>&1 && echo hygiene-complete || echo hygiene-failed'
     evidence_predicate:
       command: sh -c 'if [ -n "{worktree_path}" ] && [ -d "{worktree_path}" ]; then echo hygiene-failed; else git rev-parse --is-inside-work-tree >/dev/null 2>&1 && echo hygiene-complete || echo hygiene-failed; fi'
       success_pattern: '^(hygiene-complete|hygiene-failed|hygiene-blocked-dirty)$'

--- a/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
+++ b/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
@@ -35,7 +35,7 @@
 # this seat built; PRs reviewed-only have none and the hygiene step handles absence.
 schema_version: trailspec.v1
 trail_id: rb3-pr-lifecycle
-version: "2.0.1"
+version: "2.0.2"
 title: RB3 PR lifecycle — formal review, verdict, gate, arm, babysit, hygiene
 seats:
   - grok-daily
@@ -197,7 +197,7 @@ steps:
       success_pattern: '^(inputs-recorded|inputs-unavailable)$'
     transitions:
       gate_pass_arm: arm_automerge
-      gate_wait: poll_request_state
+      gate_wait: gate_wait_poll
       gate_draft: STOP-manual-intervention
       gate_stale_head: request_review
       gate_ci_red: handed_to_red_ci_triage
@@ -205,6 +205,28 @@ steps:
       inputs_unavailable: STOP-precondition-failed
     kind: table-lookup
     table: review-gate-arm
+    blocked_on: null
+
+  - step_id: gate_wait_poll
+    intent: >-
+      Dedicated paced poll for the gate's WAIT outcome (r2 finding: polling the
+      original bridge request busy-loops — by gate time that request has
+      normally replied; the blocker is some OTHER requested review of this head
+      that is not yet terminal-and-published). This step re-captures the
+      COMPLETE gate inputs fresh (same fields as gate_inputs, distinct receipt)
+      and hands back to the table, which either still waits (returning here —
+      pacing between iterations is the orchestration layer's, the trail's
+      self-loop convention) or takes a different row on the changed condition.
+      Formal-review and publication records stay seat-applied from these
+      receipts until head-bound request records land (header BLOCKED-ON).
+    command: sh -c 'gh pr view {pr_number} --json state,isDraft,headRefOid,mergeStateStatus,statusCheckRollup,autoMergeRequest > batch_state/rb3-gatewait-{pr_number}.json || { echo inputs-unavailable; exit 0; }; jq -e ".headRefOid" batch_state/rb3-gatewait-{pr_number}.json >/dev/null 2>&1 && echo inputs-recaptured || echo inputs-unavailable'
+    evidence_predicate:
+      command: sh -c 'jq -e ".headRefOid" batch_state/rb3-gatewait-{pr_number}.json >/dev/null 2>&1 && echo inputs-recaptured || echo inputs-unavailable'
+      success_pattern: '^(inputs-recaptured|inputs-unavailable)$'
+    transitions:
+      inputs_recaptured: gate_inputs
+      inputs_unavailable: STOP-precondition-failed
+    kind: mechanical
     blocked_on: null
 
   - step_id: arm_automerge

--- a/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
+++ b/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
@@ -1,120 +1,294 @@
+# RB-3 — PR lifecycle (T2 TIGHTENING REWRITE, v2.0.0, supersedes the #5860 EXAMPLE
+# trail v1.0.0). Part of #5885. Sole owner of finalize (design v2 §T2).
+#
+# WHY A REWRITE: v1.0.0 was the pre-discipline reference example and encoded
+# aspirational machinery — `gh pr edit --add-reviewer {reviewer_seat}` (review seats
+# are NOT GitHub accounts; the real flow is the bridge's formal review-pr), a stale
+# blocked_on for decision tables that have since landed (#5886), a vacuous babysit
+# predicate (success_pattern "state" matches any JSON), a wrong worktree layout
+# (.worktrees/pr-N does not exist; real layout is .worktrees/dispatch/<lane>/<task>),
+# and `git branch -d` which the repo's guard BLOCKS (local refs are pruned by the
+# post-merge hook on `git pull`; manual deletion is forbidden by design).
+#
+# Anti-pattern guard (RB-2 v0.7.0 discipline): every command is a real, currently
+# runnable repo command whose OUTPUT SHAPE was captured live (2026-07-28 infra
+# session, the #5922/#5923/#5924 arcs): `review-pr` runs the FULL review and returns
+# "✅ <Seat> finished (N chars)" + "✅ Message sent to <slot> (ID: N)", or dies
+# silently (the #5900 class — the ask retry-watchdog #5893 covers one refire);
+# `asks --task-id review-pr-N` rows are "ID TASK TO STATUS CONSUMPTION SENT" with
+# STATUS values sent | processing | replied (reply #N) | timed-out | failed;
+# `gh pr merge --auto --squash --delete-branch` is SILENT on success (rc=0) — the
+# real signal is `gh pr view --json autoMergeRequest -q .autoMergeRequest.enabledAt`
+# returning an ISO stamp ("2026-07-28T07:18:44Z") vs null; an already-green PR
+# merges IMMEDIATELY and silently on arm (state must be read after arming); the
+# babysit file is space-separated PR numbers at .agent/{handoff_agent}-babysit-prs.txt.
+#
+# Deliberately NOT drafted (RB-4 precedent — no unreachable speculative machinery):
+# - The formal-CF ledger join ("requested for THIS head" via fleet-comms
+#   formal_review_jobs + github_publications) — the review-gate-arm table documents
+#   it; head-bound request records for sealed dispatches are BLOCKED-ON T2
+#   certification (table input note). Until then the head binding is applied by the
+#   seat FROM the receipts this trail records.
+# - A `kind: wait` state — trailspec.v1 has none (v1.1 proposal, operator-gated);
+#   the poll steps self-loop with pacing owned by the orchestration layer.
+# Placeholder binding: {worktree_path} comes from the RB-2 dispatch record for heads
+# this seat built; PRs reviewed-only have none and the hygiene step handles absence.
 schema_version: trailspec.v1
 trail_id: rb3-pr-lifecycle
-version: "1.0.0"
-title: RB3 Pull Request Lifecycle Drive Loop
+version: "2.0.0"
+title: RB3 PR lifecycle — formal review, verdict, gate, arm, babysit, hygiene
 seats:
   - grok-daily
   - glm-trial
   - flash-queue
   - judgment
 stop_codes:
-  - STOP-verdict-timeout
+  - STOP-precondition-failed
+  - STOP-manual-intervention
   - STOP-contested
   - STOP-rearm-failed
   - STOP-hygiene-failed
+  - STOP-unknown
 terminal_outcomes:
-  - completed
+  - merged_and_cleaned
+  - handed_to_red_ci_triage
   - aborted
 steps:
+  - step_id: drain_slot_inbox
+    intent: >-
+      Mandatory inbox-drain substep (drive-epic 4a pattern; the design requires it
+      in RB-1/2/3/5): a verdict or coordination note that already arrived must be
+      consumed before firing a new review round. Normalized three-token wrapper
+      with a fail-closed receipt write (the RB-5 r3/r4 review classes: raw bridge
+      output cannot discriminate pending-work from a broken DB, and a failed
+      receipt write must never read as empty).
+    command: sh -c 'OUT=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for {handoff_agent} show {handoff_agent} 2>&1); RC=$?; printf "%s\n" "$OUT" > batch_state/rb3-inbox-{pr_number}.txt || { echo db-not-writable; exit 0; }; if [ "$RC" -ne 0 ]; then echo db-not-writable; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
+    evidence_predicate:
+      command: sh -c 'OUT=$(cat batch_state/rb3-inbox-{pr_number}.txt 2>/dev/null); if printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+0([^0-9]|$)"; then echo empty; elif printf "%s" "$OUT" | grep -qE "pending:[[:space:]]+[0-9]+"; then echo pending-deliveries; else echo db-not-writable; fi'
+      success_pattern: '^(empty|pending-deliveries|db-not-writable)$'
+    transitions:
+      empty: request_review
+      pending_deliveries: apply_deliveries
+      db_not_writable: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: apply_deliveries
+    intent: >-
+      Judgment reads and applies each pending delivery (a verdict already in the
+      inbox may make the review round below redundant), acks with
+      `ack --consumed-by-live-driver`, then control returns to the drain to
+      re-prove pending: 0.
+    command: null
+    evidence_predicate: null
+    transitions:
+      deliveries_consumed: drain_slot_inbox
+      cannot_apply: STOP-manual-intervention
+    kind: summon
+    blocked_on: null
+
   - step_id: request_review
-    intent: Request PR code review from assigned cross-family seat.
-    command: gh pr edit {pr_number} --add-reviewer {reviewer_seat}
+    intent: >-
+      Fire the formal cross-family review via the bridge (review seats are bridge
+      seats, never GitHub reviewers — the v1.0.0 `--add-reviewer` flow was
+      invented). {reviewer_seat} comes from the lane-routing table: outside the
+      author's model family, and never a seat whose fix instructions are under
+      review (review-gate-arm row). The invocation runs the FULL review and
+      normally RETURNS with the reply delivered (live shape: "✅ <Seat> finished
+      (N chars)"); its true state is read from the ask ledger in the next step —
+      never from the absence of an error (silent ask deaths are the #5900 class;
+      the #5893 retry-watchdog refires once).
+    command: sh -c '.venv/bin/python scripts/ai_agent_bridge/__main__.py review-pr {pr_number} --reviewer {reviewer_seat} 2>&1 | tail -5 > batch_state/rb3-review-fire-{pr_number}.txt || { echo fire-unrecorded; exit 0; }; echo review-fired'
     evidence_predicate:
-      command: gh pr view {pr_number} --json reviewRequests -q '.reviewRequests | length > 0'
-      success_pattern: "true"
+      command: sh -c 'test -s batch_state/rb3-review-fire-{pr_number}.txt && echo review-fired || echo fire-unrecorded'
+      success_pattern: '^(review-fired|fire-unrecorded)$'
     transitions:
-      success: await_verdict
-      failed: STOP-verdict-timeout
+      review_fired: poll_request_state
+      fire_unrecorded: STOP-precondition-failed
     kind: mechanical
     blocked_on: null
 
-  - step_id: await_verdict
-    intent: Wait for reviewer verdict to be submitted and sealed.
-    command: null
-    evidence_predicate: null
-    transitions:
-      verdict_received: evaluate_signals
-      timeout: STOP-verdict-timeout
-    kind: summon
-    blocked_on: null
-
-  - step_id: evaluate_signals
-    intent: Evaluate 4-signal arm table for auto-merge eligibility.
-    command: null
-    evidence_predicate: null
-    transitions:
-      arm_automerge: babysit_merge
-      signal_pending: await_verdict
-      stale_head: re_request_review
-      conflicting: STOP-contested
-    kind: summon
-    blocked_on: "T2-decision-tables"
-
-  - step_id: re_request_review
-    intent: Re-request review after new commit pushed to head.
-    command: gh pr edit {pr_number} --add-reviewer {reviewer_seat}
+  - step_id: poll_request_state
+    intent: >-
+      Read the ask ledger for this PR's review task (live row shape: "ID TASK TO
+      STATUS CONSUMPTION SENT"; STATUS vocabulary sent | processing | replied |
+      timed-out | failed). The requester OWNS its request state (drive-epic §6):
+      sent/processing self-loop (pacing is the orchestration layer's; v1 has no
+      wait kind); replied advances to the verdict read; timed-out/failed stay
+      UNRESOLVED (review-gate-arm: they never silently clear) and route to
+      judgment for an explicitly recorded cancel-or-retell.
+    command: sh -c 'ROW=$(.venv/bin/python scripts/ai_agent_bridge/__main__.py asks --task-id review-pr-{pr_number} 2>/dev/null | tail -1); printf "%s\n" "$ROW" > batch_state/rb3-askstate-{pr_number}.txt || { echo ledger-unreadable; exit 0; }; case "$ROW" in *replied*) echo replied;; *processing*|*sent*) echo in-flight;; *timed-out*|*failed*) echo request-unresolved;; *) echo ledger-unreadable;; esac'
     evidence_predicate:
-      command: gh pr view {pr_number} --json reviewRequests -q '.reviewRequests | length > 0'
-      success_pattern: "true"
+      command: sh -c 'ROW=$(cat batch_state/rb3-askstate-{pr_number}.txt 2>/dev/null); case "$ROW" in *replied*) echo replied;; *processing*|*sent*) echo in-flight;; *timed-out*|*failed*) echo request-unresolved;; *) echo ledger-unreadable;; esac'
+      success_pattern: '^(replied|in-flight|request-unresolved|ledger-unreadable)$'
     transitions:
-      success: await_verdict
-      failed: STOP-verdict-timeout
+      replied: read_verdict
+      in_flight: poll_request_state
+      request_unresolved: resolve_stuck_request
+      ledger_unreadable: STOP-precondition-failed
     kind: mechanical
     blocked_on: null
 
-  - step_id: babysit_merge
-    intent: Monitor PR auto-merge via babysitter Monitor pattern evaluating watcher outcomes over PR state, CI status, and auto-merge request.
+  - step_id: resolve_stuck_request
+    intent: >-
+      Judgment resolves a timed-out/failed review request the only honest ways:
+      cancel it with a RECORDED reason on the PR (review-gate-arm: absent that,
+      the request stays unresolved and blocks arming forever) and re-request, or
+      escalate a repeatedly-dying seat. A weak seat never quietly re-fires over
+      an unresolved request.
     command: null
-    evidence_predicate:
-      command: gh pr view {pr_number} --json state,statusCheckRollup,autoMergeRequest
-      success_pattern: "state"
+    evidence_predicate: null
     transitions:
-      merged: post_merge_hygiene
-      ci_red: red_ci_triage
-      disarmed: rearm_automerge
+      cancelled_and_rerequested: poll_request_state
+      escalated: STOP-manual-intervention
+    kind: summon
+    blocked_on: null
+
+  - step_id: read_verdict
+    intent: >-
+      Judgment reads the verdict CONTENT (never just pass/fail): findings verified
+      against the real artifact before adoption, deltas applied or refuted with
+      probes, and the verdict PUBLISHED as a PR comment naming the reviewed head
+      (publication is part of the gate — a broker reply alone is not published).
+      APPROVE bound to the current head advances to the gate table;
+      REQUEST CHANGES routes to the fix round; a reviewer-vs-author split or
+      cross-seat conflict is contested and stops.
+    command: null
+    evidence_predicate: null
+    transitions:
+      approve_current_head: gate_inputs
+      request_changes: fix_round
+      contested: STOP-contested
+    kind: summon
+    blocked_on: null
+
+  - step_id: fix_round
+    intent: >-
+      Judgment applies or dispatches the fixes (mutation-checking every guard the
+      review named, and sweeping the CLASS the finding belongs to — the #M-16
+      sibling rule), pushes to the SAME branch, and the new head re-enters the
+      review loop: a new head invalidates every prior verdict (review-gate-arm;
+      the 2026-07-27 #5886 burn).
+    command: null
+    evidence_predicate: null
+    transitions:
+      new_head_pushed: request_review
+      cannot_fix: aborted
+    kind: summon
+    blocked_on: null
+
+  - step_id: gate_inputs
+    intent: >-
+      Machine obligation = input completeness for the review-gate-arm table (the
+      RB-2 width_weigh pattern): capture draft state, current head, merge state,
+      CI rollup, and auto-merge state into ONE receipt the seat applies the table
+      rows FROM. The table itself decides (draft → never arm; any requested
+      review of THIS head not terminal-and-published → wait; stale-head verdict →
+      re-request; conflict → stop; blocking CI red → red-CI triage; all green +
+      bound verdict → arm). The formal-CF ledger join is documented in the table
+      inputs and remains seat-applied until head-bound request records land.
+    command: sh -c 'gh pr view {pr_number} --json state,isDraft,headRefOid,mergeStateStatus,statusCheckRollup,autoMergeRequest > batch_state/rb3-gate-{pr_number}.json || { echo inputs-unavailable; exit 0; }; jq -e ".headRefOid" batch_state/rb3-gate-{pr_number}.json >/dev/null 2>&1 && echo inputs-recorded || echo inputs-unavailable'
+    evidence_predicate:
+      command: sh -c 'jq -e ".headRefOid" batch_state/rb3-gate-{pr_number}.json >/dev/null 2>&1 && echo inputs-recorded || echo inputs-unavailable'
+      success_pattern: '^(inputs-recorded|inputs-unavailable)$'
+    transitions:
+      gate_pass_arm: arm_automerge
+      gate_wait: poll_request_state
+      gate_draft: STOP-manual-intervention
+      gate_stale_head: request_review
+      gate_ci_red: handed_to_red_ci_triage
+      gate_contested: STOP-contested
+      inputs_unavailable: STOP-precondition-failed
     kind: table-lookup
     table: review-gate-arm
     blocked_on: null
 
-  - step_id: rearm_automerge
-    intent: Re-arm auto-merge once blocking CI checks turn green.
-    command: gh pr merge {pr_number} --auto --squash
+  - step_id: arm_automerge
+    intent: >-
+      Arm auto-merge the moment the gate passes (#0H: a ready PR must not sit).
+      Live-captured: the arm command is SILENT on success (rc=0) — the real
+      signal is the enabledAt probe; and an already-green PR merges IMMEDIATELY
+      and silently, so state is read after arming (the documented gotcha). Never
+      armed on a draft, never over blocking red — the gate table upstream owns
+      those refusals; an arm refusal here is a hard stop, never a retry loop.
+    command: sh -c 'gh pr merge {pr_number} --auto --squash --delete-branch >/dev/null 2>&1; S=$(gh pr view {pr_number} --json state,autoMergeRequest 2>/dev/null); printf "%s\n" "$S" > batch_state/rb3-arm-{pr_number}.json || { echo arm-unrecorded; exit 0; }; case "$S" in *\"MERGED\"*) echo merged-immediately;; *enabledAt*) echo armed;; *) echo arm-refused;; esac'
     evidence_predicate:
-      command: gh pr view {pr_number} --json autoMergeRequest -q '.autoMergeRequest.enabledAt != null'
-      success_pattern: "true"
+      command: sh -c 'S=$(cat batch_state/rb3-arm-{pr_number}.json 2>/dev/null); case "$S" in *\"MERGED\"*) echo merged-immediately;; *enabledAt*) echo armed;; *) echo arm-refused;; esac'
+      success_pattern: '^(armed|merged-immediately|arm-refused)$'
     transitions:
-      rearmed: babysit_merge
-      failed: STOP-rearm-failed
+      armed: babysit_registration
+      merged_immediately: post_merge_hygiene
+      arm_refused: STOP-rearm-failed
     kind: mechanical
     blocked_on: null
 
-  - step_id: red_ci_triage
-    intent: Dispatch red-CI triage trail on build failure.
-    command: null
-    evidence_predicate: null
+  - step_id: babysit_registration
+    intent: >-
+      Register the armed PR in the babysit file (live shape: space-separated PR
+      numbers in .agent/{handoff_agent}-babysit-prs.txt) — ARMED ≠ MERGED: a PR
+      leaves the books only at state MERGED. Idempotent append; the babysit
+      check step then polls state. Persistent-watcher arming is harness-specific
+      and owned by the orchestration layer, never claimed by this trail.
+    command: sh -c 'F=.agent/{handoff_agent}-babysit-prs.txt; grep -qw "{pr_number}" "$F" 2>/dev/null || printf "%s " "{pr_number}" >> "$F" || { echo register-failed; exit 0; }; grep -qw "{pr_number}" "$F" && echo registered || echo register-failed'
+    evidence_predicate:
+      command: sh -c 'grep -qw "{pr_number}" .agent/{handoff_agent}-babysit-prs.txt && echo registered || echo register-failed'
+      success_pattern: '^(registered|register-failed)$'
     transitions:
-      triaged: evaluate_signals
-      aborted: aborted
-    kind: summon
+      registered: babysit_check
+      register_failed: STOP-precondition-failed
+    kind: mechanical
+    blocked_on: null
+
+  - step_id: babysit_check
+    intent: >-
+      One babysit poll over the armed PR (self-loop pacing owned by the
+      orchestration layer): MERGED advances to hygiene; blocking red hands off to
+      the red-CI triage trail; disarmed-but-open (enabledAt gone, not merged)
+      re-enters the GATE — never a blind re-arm, because whatever disarmed it may
+      have been a new head or a review event the gate must re-check.
+    command: sh -c 'S=$(gh pr view {pr_number} --json state,autoMergeRequest,statusCheckRollup 2>/dev/null); printf "%s\n" "$S" > batch_state/rb3-babysit-{pr_number}.json || { echo poll-failed; exit 0; }; F=$(printf "%s" "$S" | jq "[.statusCheckRollup[]? | select(.conclusion==\"FAILURE\" or .conclusion==\"TIMED_OUT\" or .conclusion==\"CANCELLED\")] | length" 2>/dev/null); case "$S" in *\"MERGED\"*) echo merged;; "") echo poll-failed;; *) if [ "${F:-0}" -gt 0 ] 2>/dev/null; then echo ci-red; elif printf "%s" "$S" | grep -q enabledAt; then echo still-armed; else echo disarmed; fi;; esac'
+    evidence_predicate:
+      command: sh -c 'S=$(cat batch_state/rb3-babysit-{pr_number}.json 2>/dev/null); test -n "$S" && echo poll-recorded || echo poll-failed'
+      success_pattern: '^(poll-recorded|poll-failed)$'
+    transitions:
+      merged: post_merge_hygiene
+      ci_red: handed_to_red_ci_triage
+      disarmed: gate_inputs
+      still_armed: babysit_check
+      poll_failed: STOP-precondition-failed
+    kind: mechanical
     blocked_on: null
 
   - step_id: post_merge_hygiene
-    intent: Perform post-merge hygiene by deleting branches, removing worktrees, and pulling latest main.
-    command: git worktree remove .worktrees/pr-{pr_number} && git branch -d {branch}
+    intent: >-
+      Real hygiene, matching the guards: the remote branch is already deleted by
+      --delete-branch; the LOCAL branch is pruned by the post-merge hook on
+      `git pull` (manual `git branch -d/-D` is guard-BLOCKED by design — the
+      v1.0.0 command could never run); the dispatch worktree (bound from the
+      RB-2 record; reviewed-only PRs have none) is removed worktree-FIRST.
+      A worktree holding uncommitted content is never force-removed (#M-10) —
+      that stops for judgment.
+    command: sh -c 'if [ -n "{worktree_path}" ] && [ -d "{worktree_path}" ]; then if git -C "{worktree_path}" status --porcelain 2>/dev/null | grep -q .; then echo hygiene-blocked-dirty; exit 0; fi; git worktree remove --force "{worktree_path}" >/dev/null 2>&1 || { echo hygiene-failed; exit 0; }; fi; git pull --ff-only >/dev/null 2>&1 && echo hygiene-complete || echo hygiene-failed'
     evidence_predicate:
-      command: test ! -d .worktrees/pr-{pr_number} && echo "cleaned"
-      success_pattern: "cleaned"
+      command: sh -c 'if [ -n "{worktree_path}" ] && [ -d "{worktree_path}" ]; then echo hygiene-failed; else git rev-parse --is-inside-work-tree >/dev/null 2>&1 && echo hygiene-complete || echo hygiene-failed; fi'
+      success_pattern: '^(hygiene-complete|hygiene-failed|hygiene-blocked-dirty)$'
     transitions:
-      success: close_pr_lifecycle
-      failed: STOP-hygiene-failed
+      hygiene_complete: finalize_note
+      hygiene_failed: STOP-hygiene-failed
+      hygiene_blocked_dirty: STOP-manual-intervention
     kind: mechanical
     blocked_on: null
 
-  - step_id: close_pr_lifecycle
-    intent: Close PR lifecycle trail and record terminal status.
+  - step_id: finalize_note
+    intent: >-
+      The lane's binding finalize discipline (2026-07-27 operator ruling): a
+      one-line update on the tracking issue naming the merged PR, plus the
+      handoff row. Prose is judgment's; the trail records that the obligation
+      was discharged, and the close is then terminal.
     command: null
     evidence_predicate: null
     transitions:
-      completed: completed
+      note_posted: merged_and_cleaned
+      cannot_post: STOP-manual-intervention
     kind: summon
-    blocked_on: "T2-receipt-writer"
+    blocked_on: null

--- a/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
+++ b/scripts/config/trails/rb3-pr-lifecycle.trail.yaml
@@ -35,7 +35,7 @@
 # this seat built; PRs reviewed-only have none and the hygiene step handles absence.
 schema_version: trailspec.v1
 trail_id: rb3-pr-lifecycle
-version: "2.0.2"
+version: "2.0.3"
 title: RB3 PR lifecycle — formal review, verdict, gate, arm, babysit, hygiene
 seats:
   - grok-daily
@@ -295,15 +295,18 @@ steps:
       Removal is WITHOUT --force (r1: a pre-check-then-force pair is not atomic
       and --force deletes what the check missed): git\'s own refusal on any
       non-clean worktree is the guard, and that refusal stops for judgment —
-      never a second attempt with force.
-    command: sh -c 'if [ -n "{worktree_path}" ] && [ -d "{worktree_path}" ]; then git worktree remove "{worktree_path}" >/dev/null 2>&1 || { echo hygiene-blocked-dirty; exit 0; }; fi; git pull --ff-only >/dev/null 2>&1 && echo hygiene-complete || echo hygiene-failed'
+      never a second attempt with force. The outcome token is RECEIPTED and the
+      predicate reads the receipt (r4: an independently re-derived predicate
+      reported success for any absent-worktree state, masking a failed pull).
+    command: sh -c 'R=hygiene-complete; if [ -n "{worktree_path}" ] && [ -d "{worktree_path}" ]; then if git worktree remove "{worktree_path}" >/dev/null 2>&1; then :; else R=hygiene-blocked-dirty; fi; fi; if [ "$R" = "hygiene-complete" ]; then git pull --ff-only >/dev/null 2>&1 || R=hygiene-failed; fi; printf "%s\n" "$R" > batch_state/rb3-hygiene-{pr_number}.txt || { echo receipt-unwritable; exit 0; }; echo "$R"'
     evidence_predicate:
-      command: sh -c 'if [ -n "{worktree_path}" ] && [ -d "{worktree_path}" ]; then echo hygiene-failed; else git rev-parse --is-inside-work-tree >/dev/null 2>&1 && echo hygiene-complete || echo hygiene-failed; fi'
-      success_pattern: '^(hygiene-complete|hygiene-failed|hygiene-blocked-dirty)$'
+      command: sh -c 'R=$(cat batch_state/rb3-hygiene-{pr_number}.txt 2>/dev/null); case "$R" in hygiene-complete|hygiene-failed|hygiene-blocked-dirty) echo "$R";; *) echo receipt-unwritable;; esac'
+      success_pattern: '^(hygiene-complete|hygiene-failed|hygiene-blocked-dirty|receipt-unwritable)$'
     transitions:
       hygiene_complete: finalize_note
       hygiene_failed: STOP-hygiene-failed
       hygiene_blocked_dirty: STOP-manual-intervention
+      receipt_unwritable: STOP-precondition-failed
     kind: mechanical
     blocked_on: null
 

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -90,8 +90,8 @@ def test_happy_path_example_trail() -> None:
     res = validate_trailspec(spec_path=DEFAULT_EXAMPLE_TRAIL_PATH)
     assert res["ok"] is True
     assert res["spec"]["trail_id"] == "rb3-pr-lifecycle"
-    assert res["spec"]["version"] == "2.0.1"
-    assert res["spec"]["steps_count"] == 13
+    assert res["spec"]["version"] == "2.0.2"
+    assert res["spec"]["steps_count"] == 14
     assert len(res["spec"]["trail_hash"]) == 64
 
 

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -90,7 +90,7 @@ def test_happy_path_example_trail() -> None:
     res = validate_trailspec(spec_path=DEFAULT_EXAMPLE_TRAIL_PATH)
     assert res["ok"] is True
     assert res["spec"]["trail_id"] == "rb3-pr-lifecycle"
-    assert res["spec"]["version"] == "2.0.0"
+    assert res["spec"]["version"] == "2.0.1"
     assert res["spec"]["steps_count"] == 13
     assert len(res["spec"]["trail_hash"]) == 64
 

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -128,8 +128,11 @@ def test_negative_non_summon_step_lacks_predicate() -> None:
 def test_negative_dangling_transition() -> None:
     """Negative invariant test: dangling transition target fails validation."""
     data = _get_happy_example_data()
-    # Corrupt a copy: set transition to non-existent step
-    data["steps"][0]["transitions"]["success"] = "non_existent_step_123"
+    # Corrupt a copy: replace a real transition of a step selected by id (not by
+    # index — step order is not part of this test's contract) with a dangling
+    # target.
+    step = next(s for s in data["steps"] if s["step_id"] == "request_review")
+    step["transitions"]["review_fired"] = "non_existent_step_123"
 
     with pytest.raises(TrailSpecValidationError) as exc_info:
         validate_trailspec_data(data, spec_schema_path=TRAIL_SPEC_SCHEMA_PATH)

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -90,8 +90,8 @@ def test_happy_path_example_trail() -> None:
     res = validate_trailspec(spec_path=DEFAULT_EXAMPLE_TRAIL_PATH)
     assert res["ok"] is True
     assert res["spec"]["trail_id"] == "rb3-pr-lifecycle"
-    assert res["spec"]["version"] == "1.0.0"
-    assert res["spec"]["steps_count"] == 9
+    assert res["spec"]["version"] == "2.0.0"
+    assert res["spec"]["steps_count"] == 13
     assert len(res["spec"]["trail_hash"]) == 64
 
 

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -90,7 +90,7 @@ def test_happy_path_example_trail() -> None:
     res = validate_trailspec(spec_path=DEFAULT_EXAMPLE_TRAIL_PATH)
     assert res["ok"] is True
     assert res["spec"]["trail_id"] == "rb3-pr-lifecycle"
-    assert res["spec"]["version"] == "2.0.2"
+    assert res["spec"]["version"] == "2.0.3"
     assert res["spec"]["steps_count"] == 14
     assert len(res["spec"]["trail_hash"]) == 64
 


### PR DESCRIPTION
## What

The RB-3 tightening pass from the T2 queue: rewrites the #5860 EXAMPLE trail (v1.0.0) at the RB-2 (#5915) / RB-4 (#5919) / RB-5 (#5922) discipline — 13 steps replacing 9.

## What v1.0.0 got wrong (all verified against the live substrate)

- `gh pr edit --add-reviewer {reviewer_seat}` — review seats are bridge seats, not GitHub accounts; the command could never route a formal review.
- `blocked_on: "T2-decision-tables"` — stale; the tables landed in #5886.
- Babysit predicate `success_pattern: "state"` — vacuous (matches any JSON).
- `.worktrees/pr-{pr_number}` — layout does not exist (real: `.worktrees/dispatch/<lane>/<task>`).
- `git branch -d {branch}` — guard-BLOCKED by design; local refs are pruned by the post-merge hook on `git pull`.

## Discipline receipts

- **Every command live-captured 2026-07-28** during this session's own PR arcs: `review-pr` return shape, ask-ledger row vocabulary (`sent|processing|replied|timed-out|failed`), the SILENT-on-success arm with the `enabledAt` probe as the real signal, the already-green-merges-immediately gotcha, the babysit file shape.
- **Gate discipline encoded**: review-gate-arm as a table-lookup with an input-completeness receipt (the RB-2 `width_weigh` pattern); disarmed-but-open re-enters the GATE, never a blind re-arm; timed-out/failed requests stay UNRESOLVED and route to a recorded cancel-or-retell (never silently cleared).
- **Fail-closed receipt writes + transition-vocabulary tokens throughout** (the RB-5 r1/r3/r4/r5 review classes, applied here from the start).
- **Deliberately NOT drafted**: the formal-CF ledger join (BLOCKED-ON head-bound request records, per the table input note) and any `kind: wait` (v1.1 proposal, operator-gated) — poll steps self-loop instead.

## Verification

- `validate_trailspec --spec` OK: 13 steps, v2.0.0, hash `1ac1d41f…`
- `tests/test_validate_trailspec.py` 30/30 in the worktree (happy-path pins updated to v2.0.0/13); ruff clean

Part of #5885 (Refs, not Closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)