### PR TITLE
feat(trails): red-CI known-failures registry stage 1 — schemas + reusable validator

### DIFF
--- a/agents_extensions/shared/schemas/red-ci-known-failures.v1.schema.json
+++ b/agents_extensions/shared/schemas/red-ci-known-failures.v1.schema.json
@@ -74,6 +74,7 @@
               "properties": {
                 "required": {
                   "type": "array",
+                  "minItems": 1,
                   "items": {
                     "$ref": "#/$defs/line_matcher"
                   }

--- a/agents_extensions/shared/schemas/red-ci-known-failures.v1.schema.json
+++ b/agents_extensions/shared/schemas/red-ci-known-failures.v1.schema.json
@@ -1,0 +1,253 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "red-ci-known-failures.v1",
+  "title": "Red-CI Known Failures Registry v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "registry_version",
+    "entries"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "red-ci-known-failures.v1"
+    },
+    "registry_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/entry"
+      }
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "matcher",
+        "action",
+        "owning_issue",
+        "evidence",
+        "governance"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "matcher": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "check_name",
+            "lines"
+          ],
+          "properties": {
+            "check_name": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "exact"
+              ],
+              "properties": {
+                "exact": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "lines": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "required",
+                "accepted",
+                "require_full_coverage"
+              ],
+              "properties": {
+                "required": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/line_matcher"
+                  }
+                },
+                "accepted": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/line_matcher"
+                  }
+                },
+                "require_full_coverage": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "action": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "retry-once",
+                "note-and-proceed",
+                "stop"
+              ]
+            },
+            "stop_code": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "kind": {
+                    "const": "stop"
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "stop_code"
+                ]
+              },
+              "else": {
+                "not": {
+                  "required": [
+                    "stop_code"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "owning_issue": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence_item"
+          }
+        },
+        "governance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "added_by",
+            "added_at",
+            "added_in_pr",
+            "reviewed_by",
+            "reviewed_at",
+            "review_by"
+          ],
+          "properties": {
+            "added_by": {
+              "type": "string",
+              "minLength": 1
+            },
+            "added_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "added_in_pr": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "reviewed_by": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "reviewed_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "review_by": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    },
+    "line_matcher": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "exact",
+            "regex"
+          ]
+        },
+        "value": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_id",
+        "run_attempt",
+        "pr_number",
+        "head_sha",
+        "observed_at",
+        "signature_sha256"
+      ],
+      "properties": {
+        "run_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "run_attempt": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "pr_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "head_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "signature_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/agents_extensions/shared/schemas/red-ci-signature-receipt.v1.schema.json
+++ b/agents_extensions/shared/schemas/red-ci-signature-receipt.v1.schema.json
@@ -65,8 +65,10 @@
     },
     "normalized_signature_lines": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "extraction_version": {

--- a/agents_extensions/shared/schemas/red-ci-signature-receipt.v1.schema.json
+++ b/agents_extensions/shared/schemas/red-ci-signature-receipt.v1.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "red-ci-signature-receipt.v1",
+  "title": "Red-CI Signature Receipt v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "repository_id",
+    "repository_name",
+    "pr_number",
+    "run_id",
+    "run_attempt",
+    "head_sha",
+    "job_id",
+    "job_name",
+    "check_id",
+    "check_name",
+    "normalized_signature_lines",
+    "extraction_version",
+    "timestamp",
+    "digest"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "red-ci-signature-receipt.v1"
+    },
+    "repository_id": {
+      "type": ["integer", "string"]
+    },
+    "repository_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pr_number": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "run_id": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "run_attempt": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "job_id": {
+      "type": ["integer", "string"]
+    },
+    "job_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "check_id": {
+      "type": ["integer", "string", "null"]
+    },
+    "check_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "normalized_signature_lines": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extraction_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/scripts/orchestration/red_ci_known_failures.py
+++ b/scripts/orchestration/red_ci_known_failures.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Red-CI known-failures registry and signature-receipt stage 1 validation module."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/red-ci-known-failures.v1.schema.json"
+)
+RECEIPT_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/red-ci-signature-receipt.v1.schema.json"
+)
+
+HEX_40_RE = re.compile(r"^[0-9a-f]{40}$")
+HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class RedCIKnownFailuresValidationError(Exception):
+    """Raised when red-CI known-failures registry or signature receipt validation fails."""
+
+
+def _load_yaml_or_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise RedCIKnownFailuresValidationError(f"File not found: {path}")
+    try:
+        content = path.read_text(encoding="utf-8")
+        data = (
+            json.loads(content)
+            if path.suffix == ".json"
+            else yaml.safe_load(content)
+        )
+    except Exception as exc:
+        raise RedCIKnownFailuresValidationError(f"Parse error in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RedCIKnownFailuresValidationError(f"Root of {path} must be a mapping/dict")
+    return data
+
+
+def _load_schema(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise RedCIKnownFailuresValidationError(f"Schema file not found: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RedCIKnownFailuresValidationError(f"JSON parse error in schema {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RedCIKnownFailuresValidationError(f"Root of schema {path} must be a dict")
+    return data
+
+
+def _parse_iso_instant(val: str | datetime) -> datetime:
+    """Parse string or datetime to timezone-aware instant."""
+    if isinstance(val, datetime):
+        if val.tzinfo is None:
+            return val.replace(tzinfo=UTC)
+        return val
+    if not isinstance(val, str):
+        raise RedCIKnownFailuresValidationError(f"Invalid timestamp type: {type(val)}")
+    val_clean = val.strip()
+    if val_clean.endswith("Z") or val_clean.endswith("z"):
+        val_clean = val_clean[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(val_clean)
+    except Exception as exc:
+        raise RedCIKnownFailuresValidationError(f"Invalid ISO 8601 timestamp '{val}': {exc}") from exc
+    if dt.tzinfo is None:
+        raise RedCIKnownFailuresValidationError(f"Timestamp '{val}' must be timezone-aware")
+    return dt
+
+
+def load_and_validate_registry(
+    path: Path | str,
+    *,
+    as_of: datetime | str | None = None,
+) -> dict[str, Any]:
+    """Load and validate a red-CI known-failures registry document against schema and domain rules.
+
+    Domain rules enforced beyond JSON Schema:
+    - Unique entry IDs
+    - Anchored-regex enforcement (regex values must start with '^' and end with '$')
+    - Timestamp parsing into timezone-aware instants
+    - Expired entry enforcement relative to as_of (hard deadline)
+    """
+    path_obj = Path(path).resolve()
+    data = _load_yaml_or_json(path_obj)
+
+    registry_schema = _load_schema(REGISTRY_SCHEMA_PATH)
+    validator = Draft202012Validator(registry_schema, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        err = errors[0]
+        raise RedCIKnownFailuresValidationError(
+            f"Registry schema violation: {err.message} at {err.json_path}"
+        )
+
+    as_of_dt = (
+        datetime.now(UTC)
+        if as_of is None
+        else _parse_iso_instant(as_of)
+    )
+
+    seen_ids: set[str] = set()
+    entries = data.get("entries", [])
+    for entry in entries:
+        entry_id = entry.get("id")
+        if not entry_id:
+            raise RedCIKnownFailuresValidationError("Entry missing required 'id'")
+        if entry_id in seen_ids:
+            raise RedCIKnownFailuresValidationError(f"Duplicate entry id: '{entry_id}'")
+        seen_ids.add(entry_id)
+
+        # Matcher anchored regex enforcement
+        lines = entry.get("matcher", {}).get("lines", {})
+        all_line_matchers = lines.get("required", []) + lines.get("accepted", [])
+        for line_m in all_line_matchers:
+            if line_m.get("type") == "regex":
+                val = line_m.get("value", "")
+                if not (val.startswith("^") and val.endswith("$")):
+                    raise RedCIKnownFailuresValidationError(
+                        f"Unanchored regex in entry '{entry_id}': '{val}' "
+                        "(regex matchers must be anchored with ^...$)"
+                    )
+
+        # Parse & check timestamps
+        governance = entry.get("governance", {})
+        _parse_iso_instant(governance.get("added_at", ""))
+        _parse_iso_instant(governance.get("reviewed_at", ""))
+        review_by_dt = _parse_iso_instant(governance.get("review_by", ""))
+
+        if review_by_dt < as_of_dt:
+            raise RedCIKnownFailuresValidationError(
+                f"Registry entry '{entry_id}' expired at review_by={review_by_dt.isoformat()} "
+                f"relative to as_of={as_of_dt.isoformat()}"
+            )
+
+        for ev in entry.get("evidence", []):
+            _parse_iso_instant(ev.get("observed_at", ""))
+
+    return {
+        "ok": True,
+        "schema_version": data.get("schema_version"),
+        "registry_version": data.get("registry_version"),
+        "entries_count": len(entries),
+        "as_of": as_of_dt.isoformat(),
+        "data": data,
+    }
+
+
+def load_and_validate_receipt(path: Path | str) -> dict[str, Any]:
+    """Load and validate a red-CI signature-receipt document against schema and hex constraints."""
+    path_obj = Path(path).resolve()
+    data = _load_yaml_or_json(path_obj)
+
+    receipt_schema = _load_schema(RECEIPT_SCHEMA_PATH)
+    validator = Draft202012Validator(receipt_schema, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        err = errors[0]
+        raise RedCIKnownFailuresValidationError(
+            f"Signature receipt schema violation: {err.message} at {err.json_path}"
+        )
+
+    head_sha = data.get("head_sha", "")
+    if not HEX_40_RE.match(head_sha):
+        raise RedCIKnownFailuresValidationError(
+            f"Invalid head_sha in receipt: '{head_sha}' (must be 40 lowercase hex)"
+        )
+
+    digest = data.get("digest", "")
+    if not HEX_64_RE.match(digest):
+        raise RedCIKnownFailuresValidationError(
+            f"Invalid digest in receipt: '{digest}' (must be 64 lowercase hex)"
+        )
+
+    _parse_iso_instant(data.get("timestamp", ""))
+
+    return {
+        "ok": True,
+        "schema_version": data.get("schema_version"),
+        "pr_number": data.get("pr_number"),
+        "run_id": data.get("run_id"),
+        "head_sha": head_sha,
+        "digest": digest,
+        "data": data,
+    }

--- a/scripts/orchestration/red_ci_known_failures.py
+++ b/scripts/orchestration/red_ci_known_failures.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -80,7 +80,7 @@ def _parse_iso_instant(val: str | datetime) -> datetime:
 def load_and_validate_registry(
     path: Path | str,
     *,
-    as_of: datetime | str | None = None,
+    as_of: datetime | str,
 ) -> dict[str, Any]:
     """Load and validate a red-CI known-failures registry document against schema and domain rules.
 
@@ -102,11 +102,9 @@ def load_and_validate_registry(
             f"Registry schema violation: {err.message} at {err.json_path}"
         )
 
-    as_of_dt = (
-        datetime.now(UTC)
-        if as_of is None
-        else _parse_iso_instant(as_of)
-    )
+    # as_of is REQUIRED at this layer (glm F4): the module stays deterministic;
+    # wall-clock convenience lives only in the CLI wrapper.
+    as_of_dt = _parse_iso_instant(as_of)
 
     seen_ids: set[str] = set()
     entries = data.get("entries", [])

--- a/scripts/orchestration/red_ci_known_failures.py
+++ b/scripts/orchestration/red_ci_known_failures.py
@@ -127,6 +127,12 @@ def load_and_validate_registry(
                         f"Unanchored regex in entry '{entry_id}': '{val}' "
                         "(regex matchers must be anchored with ^...$)"
                     )
+                try:
+                    re.compile(val)
+                except re.error as exc:
+                    raise RedCIKnownFailuresValidationError(
+                        f"Malformed regex in entry '{entry_id}': '{val}' ({exc})"
+                    ) from exc
 
         # Parse & check timestamps
         governance = entry.get("governance", {})

--- a/scripts/orchestration/red_ci_known_failures.py
+++ b/scripts/orchestration/red_ci_known_failures.py
@@ -149,6 +149,20 @@ def load_and_validate_registry(
                         f"Malformed regex in entry '{entry_id}': '{val}' ({exc})"
                     ) from exc
 
+        action = entry.get("action", {})
+        if action.get("kind") == "stop":
+            # Lazy import: validate_trailspec imports this module, so a top-level
+            # import here would cycle. The STOP-code contract has ONE home
+            # (validate_trailspec.VALID_STOP_CODES) — never duplicated here.
+            from scripts.orchestration.validate_trailspec import VALID_STOP_CODES
+
+            stop_code = action.get("stop_code", "")
+            if stop_code not in VALID_STOP_CODES:
+                raise RedCIKnownFailuresValidationError(
+                    f"Unknown stop_code '{stop_code}' in entry '{entry_id}': "
+                    "must be from the published STOP-code contract"
+                )
+
         # Parse & check timestamps
         governance = entry.get("governance", {})
         _parse_iso_instant(governance.get("added_at", ""))

--- a/scripts/orchestration/red_ci_known_failures.py
+++ b/scripts/orchestration/red_ci_known_failures.py
@@ -28,6 +28,19 @@ class RedCIKnownFailuresValidationError(Exception):
     """Raised when red-CI known-failures registry or signature receipt validation fails."""
 
 
+class _StringTimestampSafeLoader(yaml.SafeLoader):
+    """SafeLoader minus implicit timestamp coercion (codex F001): PyYAML turns
+    unquoted ISO-8601 scalars into datetime objects, which the string-typed
+    schema then rejects — a normal unquoted YAML registry would be unusable.
+    Timestamps stay strings; _parse_iso_instant owns the parsing."""
+
+
+_StringTimestampSafeLoader.yaml_implicit_resolvers = {
+    key: [(tag, regexp) for tag, regexp in resolvers if tag != "tag:yaml.org,2002:timestamp"]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
 def _load_yaml_or_json(path: Path) -> dict[str, Any]:
     if not path.is_file():
         raise RedCIKnownFailuresValidationError(f"File not found: {path}")
@@ -36,7 +49,7 @@ def _load_yaml_or_json(path: Path) -> dict[str, Any]:
         data = (
             json.loads(content)
             if path.suffix == ".json"
-            else yaml.safe_load(content)
+            else yaml.load(content, Loader=_StringTimestampSafeLoader)
         )
     except Exception as exc:
         raise RedCIKnownFailuresValidationError(f"Parse error in {path}: {exc}") from exc

--- a/scripts/orchestration/red_ci_known_failures.py
+++ b/scripts/orchestration/red_ci_known_failures.py
@@ -74,7 +74,9 @@ def _parse_iso_instant(val: str | datetime) -> datetime:
     """Parse string or datetime to timezone-aware instant."""
     if isinstance(val, datetime):
         if val.tzinfo is None:
-            return val.replace(tzinfo=UTC)
+            raise RedCIKnownFailuresValidationError(
+                f"Timestamp '{val}' must be timezone-aware"
+            )
         return val
     if not isinstance(val, str):
         raise RedCIKnownFailuresValidationError(f"Invalid timestamp type: {type(val)}")

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -13,6 +13,11 @@ from typing import Any
 import yaml
 from jsonschema import Draft202012Validator, FormatChecker
 
+from scripts.orchestration.red_ci_known_failures import (
+    RedCIKnownFailuresValidationError,
+    load_and_validate_registry,
+)
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 TRAIL_SPEC_SCHEMA_PATH = (
     PROJECT_ROOT / "agents_extensions/shared/schemas/trailspec.v1.schema.json"
@@ -285,14 +290,28 @@ def validate_trail_table_refs(
     }
 
 
+def validate_registry(
+    registry_path: Path,
+    *,
+    as_of: str | datetime | None = None,
+) -> dict[str, Any]:
+    """Validate a red-CI known-failures registry document via red_ci_known_failures module."""
+    try:
+        return load_and_validate_registry(registry_path, as_of=as_of)
+    except RedCIKnownFailuresValidationError as exc:
+        raise TrailSpecValidationError(str(exc)) from exc
+
+
 def validate_trailspec(
     *,
     spec_path: Path = DEFAULT_EXAMPLE_TRAIL_PATH,
     receipt_path: Path | None = None,
+    registry_path: Path | None = None,
+    as_of: str | datetime | None = None,
     spec_schema_path: Path = TRAIL_SPEC_SCHEMA_PATH,
     receipt_schema_path: Path = STEP_RECEIPT_SCHEMA_PATH,
 ) -> dict[str, Any]:
-    """Validate trail spec file and optional step receipt file."""
+    """Validate trail spec file and optional step receipt or registry file."""
     spec_data = _load_yaml_or_json(spec_path)
     spec_summary = validate_trailspec_data(spec_data, spec_schema_path=spec_schema_path)
 
@@ -309,12 +328,14 @@ def validate_trailspec(
     }
     if receipt_summary is not None:
         res["receipt"] = receipt_summary
+    if registry_path is not None:
+        res["registry"] = validate_registry(registry_path, as_of=as_of)
     return res
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Validate TrailSpec v1 and StepReceipt v1 instances."
+        description="Validate TrailSpec v1, StepReceipt v1, and Red-CI Known Failures Registry instances."
     )
     parser.add_argument(
         "--spec",
@@ -335,6 +356,18 @@ def main(argv: list[str] | None = None) -> int:
         help="optional path to a decision-tables YAML/JSON file to validate",
     )
     parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="optional path to a red-CI known-failures registry YAML/JSON file to validate",
+    )
+    parser.add_argument(
+        "--as-of",
+        type=str,
+        default=None,
+        help="optional ISO 8601 timestamp to evaluate registry entry expirations against",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="output machine-readable JSON",
@@ -345,6 +378,8 @@ def main(argv: list[str] | None = None) -> int:
         summary = validate_trailspec(
             spec_path=args.spec.resolve(),
             receipt_path=args.receipt.resolve() if args.receipt else None,
+            registry_path=args.registry.resolve() if args.registry else None,
+            as_of=args.as_of,
         )
         if args.tables is not None:
             tables_path = args.tables.resolve()
@@ -373,6 +408,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         if "receipt" in summary:
             print(f"StepReceipt valid: step_id='{summary['receipt']['step_id']}'")
+        if "registry" in summary:
+            reg = summary["registry"]
+            print(
+                f"Registry valid: version='{reg['registry_version']}' "
+                f"entries={reg['entries_count']} as_of='{reg['as_of']}'"
+            )
     return 0
 
 

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -296,8 +297,9 @@ def validate_registry(
     as_of: str | datetime | None = None,
 ) -> dict[str, Any]:
     """Validate a red-CI known-failures registry document via red_ci_known_failures module."""
+    resolved_as_of = datetime.now(UTC) if as_of is None else as_of
     try:
-        return load_and_validate_registry(registry_path, as_of=as_of)
+        return load_and_validate_registry(registry_path, as_of=resolved_as_of)
     except RedCIKnownFailuresValidationError as exc:
         raise TrailSpecValidationError(str(exc)) from exc
 

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -209,6 +209,22 @@ def test_negative_retry_once_with_stop_code(tmp_path) -> None:
     assert "Registry schema violation" in str(exc_info2.value)
 
 
+def test_negative_malformed_regex(tmp_path) -> None:
+    """Negative domain test (codex F001): an anchored but syntactically invalid
+    regex (e.g. '^($') must fail at VALIDATION time, not detonate when the
+    registry is consumed."""
+    data = _get_valid_registry_data()
+    data["entries"][0]["matcher"]["lines"]["required"][0] = {"type": "regex", "value": "^($"}
+
+    reg_path = tmp_path / "malformed_regex.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+
+    assert "Malformed regex" in str(exc_info.value)
+
+
 def test_negative_empty_required_matchers(tmp_path) -> None:
     """Negative schema test (codex re-review F001): an entry whose
     matcher.lines.required is EMPTY would match on check_name alone, classifying

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -209,6 +209,22 @@ def test_negative_retry_once_with_stop_code(tmp_path) -> None:
     assert "Registry schema violation" in str(exc_info2.value)
 
 
+def test_negative_empty_required_matchers(tmp_path) -> None:
+    """Negative schema test (codex re-review F001): an entry whose
+    matcher.lines.required is EMPTY would match on check_name alone, classifying
+    every failure of that check as known — minItems 1 must reject it."""
+    data = _get_valid_registry_data()
+    data["entries"][0]["matcher"]["lines"]["required"] = []
+
+    reg_path = tmp_path / "empty_required.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+
+    assert "Registry schema violation" in str(exc_info.value)
+
+
 def test_negative_receipt_empty_signature_lines(tmp_path) -> None:
     """Negative schema test: a receipt with zero normalized signature lines is not a
     signature (glm F3) — minItems 1 must reject it."""

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -210,6 +210,22 @@ def test_negative_retry_once_with_stop_code(tmp_path) -> None:
     assert "Registry schema violation" in str(exc_info2.value)
 
 
+def test_negative_naive_datetime_as_of(tmp_path) -> None:
+    """codex F001: a NAIVE datetime as_of must be rejected like naive strings —
+    silently assuming UTC evaluates expiry at the wrong instant for local-time
+    callers."""
+    from datetime import datetime as _dt
+
+    data = _get_valid_registry_data()
+    reg_path = tmp_path / "naive_asof.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of=_dt(2026, 7, 28, 12, 0, 0))
+
+    assert "timezone-aware" in str(exc_info.value)
+
+
 def test_yaml_unquoted_timestamps_validate(tmp_path) -> None:
     """codex F001: a normal YAML registry with UNQUOTED ISO timestamps must
     validate — PyYAML's implicit timestamp coercion would hand datetime objects

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -1,0 +1,282 @@
+"""Tests for red-CI known-failures registry and signature-receipt stage 1 validation."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from scripts.orchestration.red_ci_known_failures import (
+    RedCIKnownFailuresValidationError,
+    load_and_validate_receipt,
+    load_and_validate_registry,
+)
+
+
+def _get_valid_registry_data() -> dict[str, Any]:
+    return {
+        "schema_version": "red-ci-known-failures.v1",
+        "registry_version": "1.0.0",
+        "entries": [
+            {
+                "id": "pytest-cache-race",
+                "matcher": {
+                    "check_name": {
+                        "exact": "CI / Test (pytest)",
+                    },
+                    "lines": {
+                        "required": [
+                            {
+                                "type": "regex",
+                                "value": r"^FAILED tests/test_cache\.py::test_parallel_cache .*$",
+                            }
+                        ],
+                        "accepted": [
+                            {
+                                "type": "regex",
+                                "value": r"^FAILED tests/test_cache\.py::test_parallel_cache .*$",
+                            }
+                        ],
+                        "require_full_coverage": True,
+                    },
+                },
+                "action": {
+                    "kind": "retry-once",
+                },
+                "owning_issue": 5885,
+                "evidence": [
+                    {
+                        "run_id": 123456789,
+                        "run_attempt": 1,
+                        "pr_number": 1234,
+                        "head_sha": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4",
+                        "observed_at": "2026-07-28T10:00:00Z",
+                        "signature_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                    }
+                ],
+                "governance": {
+                    "added_by": "developer1",
+                    "added_at": "2026-07-28T10:00:00Z",
+                    "added_in_pr": 6000,
+                    "reviewed_by": ["reviewer1"],
+                    "reviewed_at": "2026-07-28T11:00:00Z",
+                    "review_by": "2026-08-27T11:00:00Z",
+                },
+            }
+        ],
+    }
+
+
+def _get_valid_receipt_data() -> dict[str, Any]:
+    return {
+        "schema_version": "red-ci-signature-receipt.v1",
+        "repository_id": 100,
+        "repository_name": "learn-ukrainian",
+        "pr_number": 1234,
+        "run_id": 123456789,
+        "run_attempt": 1,
+        "head_sha": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4",
+        "job_id": 987654321,
+        "job_name": "test",
+        "check_id": 987654321,
+        "check_name": "CI / Test (pytest)",
+        "normalized_signature_lines": [
+            "FAILED tests/test_cache.py::test_parallel_cache - AssertError"
+        ],
+        "extraction_version": "1.0.0",
+        "timestamp": "2026-07-28T10:00:00Z",
+        "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    }
+
+
+def test_happy_path_registry(tmp_path) -> None:
+    """Happy path: valid registry fixture passes validation."""
+    reg_path = tmp_path / "registry.json"
+    reg_path.write_text(json.dumps(_get_valid_registry_data()), encoding="utf-8")
+
+    res = load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+    assert res["ok"] is True
+    assert res["entries_count"] == 1
+    assert res["registry_version"] == "1.0.0"
+
+
+def test_negative_duplicate_id(tmp_path) -> None:
+    """Negative domain test: duplicate entry IDs cause validation failure."""
+    data = _get_valid_registry_data()
+    # Add a duplicate entry with the same ID
+    data["entries"].append(data["entries"][0].copy())
+
+    reg_path = tmp_path / "dup_registry.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+
+    assert "Duplicate entry id" in str(exc_info.value)
+    assert "pytest-cache-race" in str(exc_info.value)
+
+
+def test_negative_unanchored_regex(tmp_path) -> None:
+    """Negative domain test: unanchored regex matcher (missing ^ or $) is rejected."""
+    data = _get_valid_registry_data()
+    data["entries"][0]["matcher"]["lines"]["required"][0]["value"] = (
+        r"FAILED tests/test_cache\.py::test_parallel_cache .*"
+    )
+
+    reg_path = tmp_path / "unanchored.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+
+    assert "Unanchored regex" in str(exc_info.value)
+    assert "pytest-cache-race" in str(exc_info.value)
+
+
+def test_negative_substring_style_matcher(tmp_path) -> None:
+    """Negative domain test: substring-style regex matcher (unanchored at start or end) is rejected."""
+    data = _get_valid_registry_data()
+
+    # Missing end anchor $
+    data["entries"][0]["matcher"]["lines"]["required"][0]["value"] = (
+        r"^FAILED tests/test_cache\.py::test_parallel_cache"
+    )
+
+    reg_path = tmp_path / "substring.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+
+    assert "Unanchored regex" in str(exc_info.value)
+
+
+def test_negative_missing_evidence(tmp_path) -> None:
+    """Negative schema test: entry with empty evidence array fails schema validation."""
+    data = _get_valid_registry_data()
+    data["entries"][0]["evidence"] = []
+
+    reg_path = tmp_path / "no_evidence.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+
+    assert "Registry schema violation" in str(exc_info.value)
+
+
+def test_negative_missing_governance(tmp_path) -> None:
+    """Negative schema test: entry missing governance object fails schema validation."""
+    data = _get_valid_registry_data()
+    del data["entries"][0]["governance"]
+
+    reg_path = tmp_path / "no_gov.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+
+    assert "Registry schema violation" in str(exc_info.value)
+
+
+def test_negative_stop_without_stop_code(tmp_path) -> None:
+    """Negative schema test: kind 'stop' without stop_code or 'retry-once' with stop_code fails schema validation."""
+    data = _get_valid_registry_data()
+    data["entries"][0]["action"] = {"kind": "stop"}
+
+    reg_path = tmp_path / "stop_no_code.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+
+    assert "Registry schema violation" in str(exc_info.value)
+
+    # Kind retry-once with stop_code is also invalid according to schema
+    data2 = _get_valid_registry_data()
+    data2["entries"][0]["action"] = {"kind": "retry-once", "stop_code": "STOP-ci-red"}
+
+    reg_path2 = tmp_path / "retry_with_code.json"
+    reg_path2.write_text(json.dumps(data2), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info2:
+        load_and_validate_registry(reg_path2, as_of="2026-07-28T12:00:00Z")
+
+    assert "Registry schema violation" in str(exc_info2.value)
+
+
+def test_negative_expired_entry(tmp_path) -> None:
+    """Negative domain test: expired entry (review_by < as_of) fails validation."""
+    data = _get_valid_registry_data()
+    data["entries"][0]["governance"]["review_by"] = "2026-08-01T00:00:00Z"
+
+    reg_path = tmp_path / "expired.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-08-02T00:00:00Z")
+
+    assert "expired at review_by" in str(exc_info.value)
+    assert "pytest-cache-race" in str(exc_info.value)
+
+
+def test_mixed_timezone_instants_compared_correctly(tmp_path) -> None:
+    """Mixed Z/offset ISO timestamps are compared by instant, not string ordering.
+
+    Case:
+      review_by = "2026-07-28T12:00:00+02:00"  (10:00:00 UTC)
+      as_of     = "2026-07-28T11:00:00Z"       (11:00:00 UTC)
+
+    String comparison: "2026-07-28T12:00:00+02:00" < "2026-07-28T11:00:00Z" is False.
+    Instant comparison: 10:00 UTC < 11:00 UTC is True (entry IS expired).
+
+    Instant comparison must catch this expiration.
+    """
+    data = _get_valid_registry_data()
+    data["entries"][0]["governance"]["review_by"] = "2026-07-28T12:00:00+02:00"
+
+    reg_path = tmp_path / "tz_instant.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T11:00:00Z")
+
+    assert "expired at review_by" in str(exc_info.value)
+
+
+def test_happy_path_receipt(tmp_path) -> None:
+    """Happy path: valid signature receipt fixture passes validation."""
+    rcpt_path = tmp_path / "receipt.json"
+    rcpt_path.write_text(json.dumps(_get_valid_receipt_data()), encoding="utf-8")
+
+    res = load_and_validate_receipt(rcpt_path)
+    assert res["ok"] is True
+    assert res["head_sha"] == "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+    assert len(res["digest"]) == 64
+
+
+def test_negative_receipt_bad_hex(tmp_path) -> None:
+    """Negative test: receipt with bad hex in head_sha or digest fails validation."""
+    data = _get_valid_receipt_data()
+    data["head_sha"] = "A1B2C3D4E5F67890A1B2C3D4E5F67890A1B2C3D4"  # uppercase
+
+    rcpt_path = tmp_path / "bad_sha.json"
+    rcpt_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_receipt(rcpt_path)
+
+    assert "head_sha" in str(exc_info.value) or "Signature receipt schema violation" in str(exc_info.value)
+
+    # Bad digest length
+    data2 = _get_valid_receipt_data()
+    data2["digest"] = "12345"
+
+    rcpt_path2 = tmp_path / "bad_digest.json"
+    rcpt_path2.write_text(json.dumps(data2), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info2:
+        load_and_validate_receipt(rcpt_path2)
+
+    assert "digest" in str(exc_info2.value) or "Signature receipt schema violation" in str(exc_info2.value)

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 import pytest
+import yaml
 
 from scripts.orchestration.red_ci_known_failures import (
     RedCIKnownFailuresValidationError,
@@ -207,6 +208,23 @@ def test_negative_retry_once_with_stop_code(tmp_path) -> None:
         load_and_validate_registry(reg_path2, as_of="2026-07-28T12:00:00Z")
 
     assert "Registry schema violation" in str(exc_info2.value)
+
+
+def test_yaml_unquoted_timestamps_validate(tmp_path) -> None:
+    """codex F001: a normal YAML registry with UNQUOTED ISO timestamps must
+    validate — PyYAML's implicit timestamp coercion would hand datetime objects
+    to the string-typed schema and reject the documented format."""
+    data = _get_valid_registry_data()
+    reg_path = tmp_path / "unquoted.yaml"
+    yaml_text = yaml.safe_dump(data, default_flow_style=False)
+    # safe_dump quotes nothing datetime-like here (values are strings), so
+    # strip quotes around timestamps to force the unquoted form PyYAML coerces.
+    yaml_text = yaml_text.replace("'2026-", "2026-").replace("Z'", "Z")
+    assert "'" not in yaml_text.split("added_at:")[1].splitlines()[0]
+    reg_path.write_text(yaml_text, encoding="utf-8")
+
+    res = load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+    assert res["ok"] is True
 
 
 def test_negative_malformed_regex(tmp_path) -> None:

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -210,6 +210,33 @@ def test_negative_retry_once_with_stop_code(tmp_path) -> None:
     assert "Registry schema violation" in str(exc_info2.value)
 
 
+def test_negative_unpublished_stop_code(tmp_path) -> None:
+    """codex F001: a stop entry with a code outside the published STOP-code
+    contract (e.g. a typo) must fail validation — consumers cannot interpret it."""
+    data = _get_valid_registry_data()
+    data["entries"][0]["action"] = {"kind": "stop", "stop_code": "STOP-typo"}
+
+    reg_path = tmp_path / "bad_stop_code.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError) as exc_info:
+        load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+
+    assert "Unknown stop_code" in str(exc_info.value)
+
+
+def test_stop_entry_with_published_code_validates(tmp_path) -> None:
+    """Positive twin: a stop entry using a published code passes."""
+    data = _get_valid_registry_data()
+    data["entries"][0]["action"] = {"kind": "stop", "stop_code": "STOP-manual-intervention"}
+
+    reg_path = tmp_path / "good_stop_code.json"
+    reg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    res = load_and_validate_registry(reg_path, as_of="2026-07-28T12:00:00Z")
+    assert res["ok"] is True
+
+
 def test_negative_naive_datetime_as_of(tmp_path) -> None:
     """codex F001: a NAIVE datetime as_of must be rejected like naive strings —
     silently assuming UTC evaluates expiry at the wrong instant for local-time

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -193,7 +193,10 @@ def test_negative_stop_without_stop_code(tmp_path) -> None:
 
     assert "Registry schema violation" in str(exc_info.value)
 
-    # Kind retry-once with stop_code is also invalid according to schema
+
+def test_negative_retry_once_with_stop_code(tmp_path) -> None:
+    """Negative schema test: 'retry-once' carrying a stop_code fails schema validation
+    (split from the stop-without-code case — one test, one invariant)."""
     data2 = _get_valid_registry_data()
     data2["entries"][0]["action"] = {"kind": "retry-once", "stop_code": "STOP-ci-red"}
 
@@ -204,6 +207,19 @@ def test_negative_stop_without_stop_code(tmp_path) -> None:
         load_and_validate_registry(reg_path2, as_of="2026-07-28T12:00:00Z")
 
     assert "Registry schema violation" in str(exc_info2.value)
+
+
+def test_negative_receipt_empty_signature_lines(tmp_path) -> None:
+    """Negative schema test: a receipt with zero normalized signature lines is not a
+    signature (glm F3) — minItems 1 must reject it."""
+    data = _get_valid_receipt_data()
+    data["normalized_signature_lines"] = []
+
+    rec_path = tmp_path / "empty_lines.json"
+    rec_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(RedCIKnownFailuresValidationError):
+        load_and_validate_receipt(rec_path)
 
 
 def test_negative_expired_entry(tmp_path) -> None:

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from typing import Any
 
 import pytest
@@ -422,3 +423,84 @@ def test_hash_stability() -> None:
     hash_mutated = compute_trail_hash(data_mutated)
 
     assert hash_orig != hash_mutated, "Semantic mutation must alter canonical JSON hash"
+
+
+def test_cli_registry_flag_runs_validation(tmp_path, capsys) -> None:
+    """CLI --registry mode validates red-CI known-failures registry."""
+    from scripts.orchestration.validate_trailspec import main
+
+    reg_data = {
+        "schema_version": "red-ci-known-failures.v1",
+        "registry_version": "1.0.0",
+        "entries": [
+            {
+                "id": "pytest-cache-race",
+                "matcher": {
+                    "check_name": {"exact": "CI / Test (pytest)"},
+                    "lines": {
+                        "required": [
+                            {
+                                "type": "regex",
+                                "value": r"^FAILED tests/test_cache\.py::test_parallel_cache .*$",
+                            }
+                        ],
+                        "accepted": [
+                            {
+                                "type": "regex",
+                                "value": r"^FAILED tests/test_cache\.py::test_parallel_cache .*$",
+                            }
+                        ],
+                        "require_full_coverage": True,
+                    },
+                },
+                "action": {"kind": "retry-once"},
+                "owning_issue": 5885,
+                "evidence": [
+                    {
+                        "run_id": 123456789,
+                        "run_attempt": 1,
+                        "pr_number": 1234,
+                        "head_sha": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4",
+                        "observed_at": "2026-07-28T10:00:00Z",
+                        "signature_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                    }
+                ],
+                "governance": {
+                    "added_by": "developer1",
+                    "added_at": "2026-07-28T10:00:00Z",
+                    "added_in_pr": 6000,
+                    "reviewed_by": ["reviewer1"],
+                    "reviewed_at": "2026-07-28T11:00:00Z",
+                    "review_by": "2026-08-27T11:00:00Z",
+                },
+            }
+        ],
+    }
+    reg_file = tmp_path / "valid_registry.json"
+    reg_file.write_text(json.dumps(reg_data), encoding="utf-8")
+
+    rc = main([
+        "--spec", str(DEFAULT_EXAMPLE_TRAIL_PATH),
+        "--registry", str(reg_file),
+        "--as-of", "2026-07-28T12:00:00Z",
+        "--json",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"registry"' in out
+    assert '"entries_count": 1' in out
+
+    # Test failure case
+    reg_data["entries"][0]["governance"]["review_by"] = "2026-07-01T00:00:00Z"
+    bad_reg_file = tmp_path / "expired_registry.json"
+    bad_reg_file.write_text(json.dumps(reg_data), encoding="utf-8")
+
+    rc_err = main([
+        "--spec", str(DEFAULT_EXAMPLE_TRAIL_PATH),
+        "--registry", str(bad_reg_file),
+        "--as-of", "2026-07-28T12:00:00Z",
+        "--json",
+    ])
+    assert rc_err == 1
+    err_out = capsys.readouterr().out
+    assert "expired at review_by" in err_out


### PR DESCRIPTION
## Summary
Implements Stage 1 of the red-CI known-failures registry infrastructure (Refs #5885):
- **JSON Schemas**: Created `red-ci-known-failures.v1.schema.json` and `red-ci-signature-receipt.v1.schema.json` under `agents_extensions/shared/schemas/`.
- **Reusable Validation Module**: Implemented `scripts/orchestration/red_ci_known_failures.py` with `load_and_validate_registry(path, *, as_of)` and `load_and_validate_receipt(path)`. Enforces domain rules (unique IDs, anchored-regex matchers `^...$`, ISO timestamp instant comparison, and `review_by` hard expiration deadlines).
- **CLI Integration**: Extended `scripts/orchestration/validate_trailspec.py` with `--registry PATH` and `--as-of ISO` flags.
- **Test Coverage**: Added `tests/test_red_ci_known_failures.py` covering all positive/negative invariants (duplicate ID, unanchored regex, substring matcher, missing evidence/governance, stop without stop_code, expired entry, mixed Z/offset ISO instant comparison, hex patterns) and updated `tests/test_validate_trailspec.py`.

## Evidence & Verification
Full test suite execution (`43 passed`):
```
tests/test_red_ci_known_failures.py::test_happy_path_registry PASSED     [  2%]
tests/test_red_ci_known_failures.py::test_negative_duplicate_id PASSED   [  4%]
tests/test_red_ci_known_failures.py::test_negative_unanchored_regex PASSED [  6%]
tests/test_red_ci_known_failures.py::test_negative_substring_style_matcher PASSED [  9%]
tests/test_red_ci_known_failures.py::test_negative_missing_evidence PASSED [ 11%]
tests/test_red_ci_known_failures.py::test_negative_missing_governance PASSED [ 13%]
tests/test_red_ci_known_failures.py::test_negative_stop_without_stop_code PASSED [ 16%]
tests/test_red_ci_known_failures.py::test_negative_expired_entry PASSED  [ 18%]
tests/test_red_ci_known_failures.py::test_mixed_timezone_instants_compared_correctly PASSED [ 20%]
tests/test_red_ci_known_failures.py::test_happy_path_receipt PASSED      [ 23%]
tests/test_red_ci_known_failures.py::test_negative_receipt_bad_hex PASSED [ 25%]
tests/test_validate_trailspec.py::test_cli_registry_flag_runs_validation PASSED [100%]
43 passed, 2 warnings in 0.58s
```

## Mutation Checks
1. **Disable expiry check**:
```
FAILED tests/test_red_ci_known_failures.py::test_negative_expired_entry - DID NOT RAISE RedCIKnownFailuresValidationError
FAILED tests/test_red_ci_known_failures.py::test_mixed_timezone_instants_compared_correctly - DID NOT RAISE RedCIKnownFailuresValidationError
FAILED tests/test_validate_trailspec.py::test_cli_registry_flag_runs_validation - assert 0 == 1
```
2. **Disable anchored-regex rule**:
```
FAILED tests/test_red_ci_known_failures.py::test_negative_unanchored_regex - DID NOT RAISE RedCIKnownFailuresValidationError
FAILED tests/test_red_ci_known_failures.py::test_negative_substring_style_matcher - DID NOT RAISE RedCIKnownFailuresValidationError
```

Refs #5885