### PR TITLE
feat(runtime): headless kimicc harness route (Kimi K3 via Claude Code)

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -38,6 +38,21 @@ No other subprocess building anywhere else in the codebase. If you find
 yourself writing `subprocess.Popen([..., "claude", ...])` — stop. Use
 `runner.invoke()`.
 
+## KimiCC headless route
+
+The native Kimi Code lane remains the default. To opt into Kimi K3 through the
+headless Claude Code harness, dispatch `--agent kimi --harness kimicc`. The
+adapter runs `claude -p --bare` through `scripts/agent_runtime/kimicc_headless.sh`;
+that wrapper sources the same `scripts/lib/kimicc_route.sh` used by
+`start-kimicc.sh`, resolves the catalog route, applies the route guard and
+context profile, then resolves credentials immediately before `exec`.
+
+For `kimi login` OAuth, headless runs export one fresh token at spawn and never
+write `~/.claude` or an isolated Claude config. Kimi access tokens last roughly
+15 minutes, so a long-running headless call must be relaunched; unlike the
+interactive launcher, this stateless `--bare` route does not install an
+`apiKeyHelper` refresh loop.
+
 ## Add a new agent in 20 lines
 
 1. Copy `scripts/agent_runtime/adapters/_template.py` to `adapters/youragent.py`.

--- a/scripts/agent_runtime/adapters/kimi.py
+++ b/scripts/agent_runtime/adapters/kimi.py
@@ -26,6 +26,7 @@ from scripts.review.model_catalog import kimi_model_aliases
 from ..result import ParseResult
 from ..tool_calls import normalize_tool_calls, parse_json_events
 from .base import InvocationPlan
+from .kimicc import KimiccHarness
 
 _logger = logging.getLogger(__name__)
 
@@ -87,6 +88,21 @@ class KimiAdapter:
         tool_config: dict | None,
         effort: str | None = None,
     ) -> InvocationPlan:
+        config = tool_config or {}
+        harness = config.get("harness")
+        if harness == "kimicc":
+            return KimiccHarness().build_invocation(
+                prompt=prompt,
+                mode=mode,
+                cwd=cwd,
+                model=model,
+                task_id=task_id,
+                session_id=session_id,
+                tool_config=config,
+                effort=effort,
+            )
+        if harness not in (None, "native"):
+            raise ValueError(f"KimiAdapter: unsupported harness {harness!r}; expected 'native' or 'kimicc'")
         if mode not in self.supported_modes:
             raise ValueError(
                 f"KimiAdapter: unsupported mode {mode!r} "
@@ -118,7 +134,6 @@ class KimiAdapter:
         if session_id:
             cmd.extend(["--session", session_id])
 
-        config = tool_config or {}
         for skills_dir in _as_string_list(config.get("kimi_skills_dirs")):
             cmd.extend(["--skills-dir", skills_dir])
         for add_dir in _as_string_list(config.get("kimi_add_dirs")):
@@ -159,6 +174,15 @@ class KimiAdapter:
         plan: InvocationPlan | None = None,
         call_start_time: float | None = None,
     ) -> ParseResult:
+        if plan is not None and plan.metadata.get("harness") == "kimicc":
+            return KimiccHarness().parse_response(
+                stdout=stdout,
+                stderr=stderr,
+                returncode=returncode,
+                output_file=output_file,
+                plan=plan,
+                call_start_time=call_start_time,
+            )
         _ = (output_file, plan, call_start_time)
 
         events = parse_json_events(stdout, source="kimi stream-json", logger=_logger)

--- a/scripts/agent_runtime/adapters/kimicc.py
+++ b/scripts/agent_runtime/adapters/kimicc.py
@@ -1,0 +1,111 @@
+"""Kimi K3 through the headless Claude Code harness.
+
+The wrapper performs catalog, profile, guard, and credential resolution at
+spawn. In particular, OAuth stays out of ``InvocationPlan.env_overrides`` so a
+fresh token is exported only to the Claude Code child. ``--bare`` intentionally
+makes this stateless: long calls must be relaunched before the roughly
+15-minute Kimi OAuth access-token lifetime.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+from scripts.review.model_catalog import ModelCatalogError, resolve_kimi_model
+
+from ..result import ParseResult
+from .base import InvocationPlan
+from .claude import ClaudeAdapter, _default_claude_bin, _ensure_supported_claude_cli_version
+
+_HEADLESS_WRAPPER = Path(__file__).resolve().parents[1] / "kimicc_headless.sh"
+_SUPPORTED_TOOL_CONFIG_KEYS = frozenset({"agent", "allowed_tools", "max_budget_usd", "mcp_config_path"})
+
+
+class KimiccHarness:
+    """Build a stateless Claude Code invocation routed through KimiCC."""
+
+    name = "kimicc"
+    default_model = "k3"
+    supported_modes = frozenset({"read-only", "workspace-write", "danger"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+        effort: str | None = None,
+    ) -> InvocationPlan:
+        if mode not in self.supported_modes:
+            raise ValueError(f"KimiccHarness: unsupported mode {mode!r}")
+        if session_id is not None:
+            raise ValueError("KimiccHarness is stateless (--bare) and does not support session resume")
+        if not _HEADLESS_WRAPPER.is_file():
+            raise RuntimeError(f"KimiccHarness wrapper not found: {_HEADLESS_WRAPPER}")
+
+        requested_model = model or self.default_model
+        try:
+            _, route = resolve_kimi_model(requested_model)
+        except ModelCatalogError as exc:
+            raise ValueError(f"KimiccHarness: {exc}") from exc
+
+        tc: dict[str, Any] = tool_config or {}
+        if tc.get("review_isolation"):
+            raise ValueError("KimiccHarness does not support sealed review isolation")
+        unsupported = sorted(set(tc) - _SUPPORTED_TOOL_CONFIG_KEYS - {"harness"})
+        if unsupported:
+            raise ValueError(f"KimiccHarness: unsupported tool_config keys: {unsupported}")
+
+        # The headless wrapper invokes the native Claude binary itself, but
+        # resolve it here so a missing harness fails before a task is spawned.
+        claude_bin = _default_claude_bin() or shutil.which("claude")
+        if not claude_bin:
+            raise RuntimeError("KimiccHarness requires the native `claude` CLI on PATH")
+        _ensure_supported_claude_cli_version((claude_bin,))
+
+        cmd = [
+            str(_HEADLESS_WRAPPER),
+            "--model",
+            route["kimicc_alias"],
+            "--mode",
+            mode,
+            "--prompt",
+            prompt,
+        ]
+        if isinstance(tc.get("mcp_config_path"), str) and tc.get("allowed_tools"):
+            cmd.extend(["--mcp-config", str(tc["mcp_config_path"]), "--allowedTools", str(tc["allowed_tools"])])
+        if tc.get("agent"):
+            cmd.extend(["--agent", str(tc["agent"])])
+        if tc.get("max_budget_usd") is not None:
+            cmd.extend(["--max-budget-usd", f"{float(tc['max_budget_usd']):.2f}"])
+        if effort:
+            cmd.extend(["--effort", effort])
+
+        return InvocationPlan(
+            cmd=cmd,
+            cwd=cwd,
+            env_overrides={"KIMICC_CLAUDE_BIN": claude_bin},
+            # --bare does not need or own a persistent Claude config. Removing
+            # an inherited config keeps this headless route operator-config-free.
+            env_unsets=("CLAUDE_CONFIG_DIR",),
+            liveness_paths=(),
+            metadata={
+                "harness": "kimicc",
+                "kimicc_alias": route["kimicc_alias"],
+                "claude_bin": claude_bin,
+                "task_id": task_id or "",
+            },
+        )
+
+    def parse_response(self, **kwargs: Any) -> ParseResult:
+        """Claude Code output uses the standard runtime stream-json contract."""
+        return ClaudeAdapter().parse_response(**kwargs)
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        return tuple(plan.liveness_paths)

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -76,6 +76,14 @@ _PROVIDER_SECRET_ALLOWLIST = {
         "GH_TOKEN",
         "OPENAI_API_KEY",
     },
+    "kimi": {
+        # Passed only to the KimiCC wrapper, which resolves the final route at
+        # spawn and exports ANTHROPIC_AUTH_TOKEN solely to its exec child.
+        "KIMICC_AUTH_TOKEN",
+        "MOONSHOT_API_KEY",
+        "KIMI_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+    },
     "bridge": {
         "GH_TOKEN",
     },
@@ -111,6 +119,17 @@ _PROVIDER_SAFE_NAME_ALLOWLIST = {
     "kimi": {
         # Native CLI executable override; it is a path, never a credential.
         "KIMI_CODE_BIN",
+        # KimiCC resolves its route and OAuth token inside the headless wrapper
+        # immediately before it execs Claude Code. These are route selectors or
+        # local credential-file paths, not token values.
+        "KIMICC_ENDPOINT",
+        "KIMICC_MODEL",
+        "KIMICC_BASE_URL",
+        "KIMICC_EFFORT_LEVEL",
+        "KIMICC_CLAUDE_BIN",
+        "KIMI_CODE_CREDENTIALS_PATH",
+        "KIMI_CODE_OAUTH_HOST",
+        "KIMI_CODE_OAUTH_MARGIN",
     },
 }
 

--- a/scripts/agent_runtime/kimicc_headless.sh
+++ b/scripts/agent_runtime/kimicc_headless.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Headless Claude Code execution on the KimiCC route.
+#
+# This wrapper is invoked only by KimiccHarness through agent_runtime. It resolves
+# auth immediately before exec so an OAuth access token is fresh for the new
+# Claude process. It intentionally never writes CLAUDE_CONFIG_DIR or installs an
+# apiKeyHelper: --bare is stateless, so runs that exceed the roughly 15-minute
+# OAuth lifetime must be relaunched.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/lib/kimicc_route.sh
+source "$PROJECT_DIR/scripts/lib/kimicc_route.sh"
+
+MODEL_ALIAS="${KIMICC_MODEL:-k3}"
+ENDPOINT="${KIMICC_ENDPOINT:-coding}"
+ISOLATE_CONFIG=0
+MODE="read-only"
+PROMPT=""
+FORWARD_ARGS=()
+
+usage() {
+  echo "Usage: kimicc_headless.sh --model ALIAS --mode MODE --prompt TEXT [Claude Code options]" >&2
+}
+
+while (($#)); do
+  case "$1" in
+    --model)
+      MODEL_ALIAS="${2:?--model requires a value}"
+      shift 2
+      ;;
+    --mode)
+      MODE="${2:?--mode requires a value}"
+      shift 2
+      ;;
+    --prompt)
+      PROMPT="${2:?--prompt requires a value}"
+      shift 2
+      ;;
+    --mcp-config|--allowedTools|--agent|--max-budget-usd|--effort)
+      FORWARD_ARGS+=("$1" "${2:?$1 requires a value}")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unsupported KimiCC headless argument '$1'." >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$PROMPT" ]; then
+  echo "Error: --prompt is required for headless KimiCC." >&2
+  usage
+  exit 2
+fi
+case "$MODE" in
+  read-only|workspace-write|danger) ;;
+  *)
+    echo "Error: unsupported KimiCC headless mode '$MODE'." >&2
+    exit 2
+    ;;
+esac
+
+export KIMICC_HEADLESS=1
+if kimicc_configure_route "$PROJECT_DIR"; then
+  :
+else
+  exit $?
+fi
+
+CLAUDE_BIN="${KIMICC_CLAUDE_BIN:-claude}"
+CMD=("$CLAUDE_BIN" -p --bare --model "$LEAD_MODEL" --output-format stream-json --verbose)
+if [ "$MODE" = "danger" ]; then
+  CMD+=(--dangerously-skip-permissions)
+fi
+CMD+=("${FORWARD_ARGS[@]}" -- "$PROMPT")
+exec "${CMD[@]}"

--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -171,6 +171,9 @@ def _hermes_configured_effort() -> str | None:
 
 
 def _resolve_model_from_plan(agent_name: str, plan: InvocationPlan) -> str | None:
+    if agent_name == "kimi" and plan.metadata.get("harness") == "kimicc":
+        alias = plan.metadata.get("kimicc_alias")
+        return str(alias).strip() if isinstance(alias, str) and alias.strip() else None
     del agent_name
     return _arg_after(plan.cmd, "-m", "--model")
 
@@ -191,6 +194,8 @@ def _resolve_effort_from_plan(agent_name: str, plan: InvocationPlan) -> str | No
         # to resolve from the plan.
         return None
     if agent_name == "kimi":
+        if plan.metadata.get("harness") == "kimicc":
+            return "max" if plan.metadata.get("kimicc_alias") == "k3" else _NOT_EXPOSED
         # K3 is always-max; the k2.7 coding models expose no effort knob.
         # Read the resolved model off the plan so telemetry never mislabels
         # an ignored caller request as effective (#5326 multi-model lane).
@@ -198,7 +203,14 @@ def _resolve_effort_from_plan(agent_name: str, plan: InvocationPlan) -> str | No
     return None
 
 
-def _resolve_model_from_defaults(agent_name: str, requested_model: str | None) -> str | None:
+def _resolve_model_from_defaults(
+    agent_name: str,
+    requested_model: str | None,
+    *,
+    harness: str | None = None,
+) -> str | None:
+    if agent_name == "kimi" and harness == "kimicc":
+        return requested_model or "k3"
     if requested_model:
         return requested_model
     if agent_name == "codex":
@@ -226,7 +238,12 @@ def _resolve_model_from_defaults(agent_name: str, requested_model: str | None) -
     return _default_model_for(agent_name)
 
 
-def _resolve_effort_from_defaults(agent_name: str, requested_effort: str | None) -> str | None:
+def _resolve_effort_from_defaults(
+    agent_name: str,
+    requested_effort: str | None,
+    *,
+    harness: str | None = None,
+) -> str | None:
     # These CLIs do not expose a per-invocation effort value.  A deliberate
     # marker is observability, not an error: warning on every dispatch made
     # routine task state look broken (#4837).
@@ -237,6 +254,8 @@ def _resolve_effort_from_defaults(agent_name: str, requested_effort: str | None)
     if agent_name in {"deepseek", "qwen"} or is_hermes_grok_seat(agent_name):
         return _hermes_configured_effort() or _NOT_EXPOSED
     if agent_name == "kimi":
+        if harness == "kimicc":
+            return requested_effort if requested_effort else "max"
         # Without a plan the resolved model is unknowable (K3 is always-max,
         # the k2.7 models expose no effort knob) — report the honest marker
         # rather than guessing.
@@ -368,6 +387,14 @@ def _resolve_cli_version(agent_name: str, plan: InvocationPlan | None = None) ->
         prefix = _cursor_version_prefix(plan.cmd) if plan is not None else ("cursor-agent",)
         return cursor_cli_version(prefix)
     if agent_name == "kimi":
+        if plan is not None and plan.metadata.get("harness") == "kimicc":
+            claude_bin = plan.metadata.get("claude_bin")
+            prefix = (
+                (str(claude_bin),)
+                if isinstance(claude_bin, str) and claude_bin
+                else ("claude",)
+            )
+            return claude_cli_version(prefix)
         if plan is not None and plan.cmd:
             bin_path = plan.cmd[0]
         else:
@@ -395,14 +422,15 @@ def resolve_dispatch_start_telemetry(
     agent_name: str,
     requested_model: str | None,
     requested_effort: str | None,
+    harness: str | None = None,
 ) -> InvocationTelemetry:
     """Best-effort telemetry for task-state initialization before spawn."""
-    model = _resolve_model_from_defaults(agent_name, requested_model)
+    model = _resolve_model_from_defaults(agent_name, requested_model, harness=harness)
     if not model:
         _warn_unknown("model", agent_name, "no explicit override or readable default")
         model = _UNKNOWN
 
-    effort = _resolve_effort_from_defaults(agent_name, requested_effort)
+    effort = _resolve_effort_from_defaults(agent_name, requested_effort, harness=harness)
     if not effort:
         _warn_unknown("effort", agent_name, "no explicit override or readable default")
         effort = _UNKNOWN

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -160,8 +160,20 @@ _DISPATCH_AGENT_CHOICES = (
     "cursor",
     "glm",
 )
+_KIMI_HARNESSES = frozenset({"native", "kimicc"})
 _MONITOR_API_BASE_URL = "http://127.0.0.1:8765"
 _logger = logging.getLogger(__name__)
+
+
+def _resolve_dispatch_harness(agent: str, harness: str | None) -> str | None:
+    """Validate the opt-in Kimi harness selector without changing its seat."""
+    if harness is None:
+        return None
+    if agent != "kimi":
+        raise ValueError("--harness is currently supported only with --agent kimi")
+    if harness not in _KIMI_HARNESSES:
+        raise ValueError(f"unsupported Kimi harness {harness!r}; expected one of {sorted(_KIMI_HARNESSES)}")
+    return harness
 
 
 def _read_github_token_from_bash_secrets(path: Path | None = None) -> str | None:
@@ -2816,6 +2828,7 @@ def _run_worker(
     provider: str | None = None,
     output_schema_path: str | None = None,
     output_schema_sha256: str | None = None,
+    harness: str | None = None,
     runtime_tmp_root: str | None = None,
     runtime_tmp_namespace_root: str | None = None,
 ) -> int:
@@ -2857,6 +2870,7 @@ def _run_worker(
             agent_name=agent,
             requested_model=model,
             requested_effort=effort,
+            harness=harness,
         )
         state.setdefault("model", start_telemetry.model)
         state.setdefault("effort", start_telemetry.effort)
@@ -2929,6 +2943,8 @@ def _run_worker(
             if output_schema_path is not None:
                 tool_config["output_schema_path"] = output_schema_path
                 tool_config["output_schema_sha256"] = output_schema_sha256
+            if harness is not None:
+                tool_config["harness"] = harness
             tool_config = tool_config or None
             result = runtime_invoke(
                 agent,
@@ -3366,6 +3382,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     from agent_runtime.telemetry import resolve_dispatch_start_telemetry
 
     task_id = args.task_id
+    try:
+        requested_harness = _resolve_dispatch_harness(args.agent, getattr(args, "harness", None))
+    except ValueError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
     state_path = _state_path(task_id)
     worktree_arg = getattr(args, "worktree", None)
     requested_branch = getattr(args, "branch", None)
@@ -3575,6 +3596,13 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     else:
         dispatch_agent = args.agent
 
+    if requested_harness is not None and dispatch_agent != "kimi":
+        print(
+            "❌ --harness kimicc requires the effective dispatch agent to remain kimi; use --force-agent.",
+            file=sys.stderr,
+        )
+        return 2
+
     _check_capacity_hint(dispatch_agent, args=args)
 
     try:
@@ -3622,6 +3650,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             agent_name=dispatch_agent,
             requested_model=args.model,
             requested_effort=getattr(args, "effort", None),
+            harness=requested_harness,
         )
         dry_run_state = {
             "task_id": task_id,
@@ -3654,6 +3683,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             "exit_code": None,
             "substitution": None,
         }
+        if requested_harness is not None:
+            dry_run_state["harness"] = requested_harness
         if lifecycle_carrier is not None:
             dry_run_state["task_lifecycle"] = lifecycle_carrier
         dry_run_reap = _reap_runtime_tmp_lease(
@@ -3751,6 +3782,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         agent_name=dispatch_agent,
         requested_model=args.model,
         requested_effort=getattr(args, "effort", None),
+        harness=requested_harness,
     )
 
     # Write initial state BEFORE forking so a fast caller can see it.
@@ -3799,6 +3831,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "exit_code": None,
         "substitution": None,
     }
+    if requested_harness is not None:
+        initial_state["harness"] = requested_harness
     if lifecycle_carrier is not None:
         initial_state["task_lifecycle"] = lifecycle_carrier
     initial_state = _with_optional_research_state(initial_state, research_state)
@@ -3861,6 +3895,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "--runtime-tmp-namespace-root",
         str(runtime_tmp_namespace_root),
     ]
+    if requested_harness is not None:
+        cmd.extend(["--harness", requested_harness])
     if keep_worktree:
         cmd.append("--keep-worktree")
     if max_budget_usd is not None:
@@ -4497,6 +4533,7 @@ def cmd_worker(args: argparse.Namespace) -> int:
         provider=getattr(args, "provider", None),
         output_schema_path=getattr(args, "output_schema", None),
         output_schema_sha256=getattr(args, "output_schema_sha256", None),
+        harness=getattr(args, "harness", None),
         silence_timeout=args.silence_timeout,
         max_budget_usd=getattr(args, "max_budget_usd", None),
         effort=args.effort,
@@ -4568,6 +4605,15 @@ def build_parser() -> argparse.ArgumentParser:
         # guard still catches programmatic Namespace bypass.
         help="Agent to run for the task: codex, gemini, claude, grok "
         "(native CLI; grok-build=alias), grok-hermes, deepseek, agy, cursor, or kimi.",
+    )
+    d.add_argument(
+        "--harness",
+        choices=sorted(_KIMI_HARNESSES),
+        default=None,
+        help=(
+            "Opt-in Kimi transport. Only valid with --agent kimi; use kimicc "
+            "for Kimi through headless Claude Code. Omit to keep native Kimi Code."
+        ),
     )
     d.add_argument("--task-id", required=True, help="Stable task identifier used for state/log files, e.g. review-123.")
     d.add_argument("--prompt", help="Prompt text, or '-' to read the prompt from stdin.")
@@ -4890,6 +4936,7 @@ def build_parser() -> argparse.ArgumentParser:
     wk = sub.add_parser("_worker", help=argparse.SUPPRESS)
     wk.add_argument("--task-id", required=True)
     wk.add_argument("--agent", required=True)
+    wk.add_argument("--harness", choices=sorted(_KIMI_HARNESSES), default=None)
     wk.add_argument("--mode", required=True)
     wk.add_argument("--cwd", required=True)
     wk.add_argument("--model", default=None)

--- a/scripts/lib/kimicc_route.sh
+++ b/scripts/lib/kimicc_route.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# Shared KimiCC route resolution for the interactive launcher and headless runtime.
+#
+# Inputs are the caller-owned ENDPOINT, MODEL_ALIAS, and ISOLATE_CONFIG globals.
+# On success this function exports the Claude Code route environment and leaves
+# the resolved, non-secret route metadata in globals consumed by the caller:
+# LEAD_MODEL, PROFILE_ID, BASE_URL, AUTH_SOURCE, AUTH_VIA_OAUTH, and AUTH_NOTE.
+#
+# KIMICC_HEADLESS=1 deliberately disables the interactive apiKeyHelper path.
+# Headless Claude Code uses --bare, so it resolves a fresh OAuth token at spawn
+# and must be relaunched for calls longer than the roughly 15-minute token life.
+
+kimicc_default_base_url() {
+  case "$1" in
+    platform) printf '%s\n' 'https://api.moonshot.ai/anthropic' ;;
+    coding) printf '%s\n' 'https://api.kimi.com/coding' ;;
+    *) return 1 ;;
+  esac
+}
+
+# Resolve an explicit auth input into globals without command substitution so
+# AUTH_SOURCE survives in the sourcing shell. OAuth is handled by the caller.
+kimicc_resolve_explicit_auth_token() {
+  _resolved_auth=""
+  AUTH_SOURCE=""
+  if [ -n "${KIMICC_AUTH_TOKEN:-}" ]; then
+    _resolved_auth="$KIMICC_AUTH_TOKEN"
+    AUTH_SOURCE="KIMICC_AUTH_TOKEN"
+    return 0
+  fi
+  if [ -n "${MOONSHOT_API_KEY:-}" ]; then
+    _resolved_auth="$MOONSHOT_API_KEY"
+    AUTH_SOURCE="MOONSHOT_API_KEY"
+    return 0
+  fi
+  if [ -n "${KIMI_API_KEY:-}" ]; then
+    _resolved_auth="$KIMI_API_KEY"
+    AUTH_SOURCE="KIMI_API_KEY"
+    return 0
+  fi
+  if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ "${ENDPOINT}" = "coding" ]; then
+    # Allow an intentionally exported coding token without re-reading OAuth state.
+    _resolved_auth="$ANTHROPIC_AUTH_TOKEN"
+    AUTH_SOURCE="ANTHROPIC_AUTH_TOKEN"
+    return 0
+  fi
+  return 1
+}
+
+kimicc_route_python() {
+  local project_dir="$1"
+  local git_common
+
+  if [ -n "${KIMICC_ROUTE_PYTHON:-}" ] && [ -x "${KIMICC_ROUTE_PYTHON}" ]; then
+    printf '%s\n' "$KIMICC_ROUTE_PYTHON"
+    return 0
+  fi
+  if [ -x "$project_dir/.venv/bin/python" ]; then
+    printf '%s\n' "$project_dir/.venv/bin/python"
+    return 0
+  fi
+  git_common="$(env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR \
+    git -C "$project_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "$git_common" ] && [ -x "$(dirname "$git_common")/.venv/bin/python" ]; then
+    printf '%s\n' "$(dirname "$git_common")/.venv/bin/python"
+    return 0
+  fi
+  return 1
+}
+
+kimicc_install_api_key_helper() {
+  local python_bin="$1"
+  local oauth_helper="$2"
+  local helper_cmd settings_path
+
+  helper_cmd="$python_bin $oauth_helper token"
+  settings_path="$CLAUDE_CONFIG_DIR/settings.json"
+  if ! KIMICC_SETTINGS_PATH="$settings_path" KIMICC_API_KEY_HELPER="$helper_cmd" \
+      "$python_bin" - <<'PY'
+import json
+import os
+import sys
+
+path = os.environ["KIMICC_SETTINGS_PATH"]
+helper = os.environ["KIMICC_API_KEY_HELPER"]
+data = {}
+if os.path.exists(path):
+    with open(path, encoding="utf-8") as fh:
+        try:
+            data = json.load(fh)
+        except json.JSONDecodeError as exc:
+            print(f"Error: {path} is not valid JSON ({exc}); refusing to modify it.", file=sys.stderr)
+            sys.exit(1)
+    if not isinstance(data, dict):
+        print(f"Error: {path} is not a JSON object; refusing to modify it.", file=sys.stderr)
+        sys.exit(1)
+data["apiKeyHelper"] = helper
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PY
+  then
+    echo "Error: could not install apiKeyHelper into $settings_path" >&2
+    return 1
+  fi
+}
+
+# Configure an Anthropic-compatible Kimi route in this shell.
+#
+# Args:
+#   $1 project root that owns the route helper and profiles.
+#   $2 optional catalog root (interactive worktree launchers preserve their
+#      historical behavior by resolving the catalog from their own script dir).
+kimicc_configure_route() {
+  local project_dir="$1"
+  local catalog_dir="${2:-$project_dir}"
+  local python_bin oauth_helper route platform_model coding_model default_base_url
+
+  if ! python_bin="$(kimicc_route_python "$catalog_dir")"; then
+    echo "Error: Python binary not found for the KimiCC route." >&2
+    return 1
+  fi
+  if ! route="$("$python_bin" "$catalog_dir/scripts/review/model_catalog.py" \
+      --resolve-kimi-model "$MODEL_ALIAS" --format kimicc 2>/dev/null)"; then
+    echo "Error: unsupported model '$MODEL_ALIAS' (use k3, k2.7, k2.7-highspeed)." >&2
+    return 2
+  fi
+  IFS=$'\t' read -r MODEL_ALIAS platform_model coding_model PROFILE_ID <<< "$route"
+  if [ -z "$MODEL_ALIAS" ] || [ -z "$platform_model" ] || [ -z "$coding_model" ] || [ -z "$PROFILE_ID" ]; then
+    echo "Error: invalid Kimi route in scripts/config/model_catalog.yaml." >&2
+    return 1
+  fi
+
+  case "$ENDPOINT" in
+    platform|coding) ;;
+    *)
+      echo "Error: unsupported endpoint '$ENDPOINT' (use platform or coding)." >&2
+      return 2
+      ;;
+  esac
+  case "$ISOLATE_CONFIG" in
+    0|1) ;;
+    *)
+      echo "Error: KIMICC_ISOLATE_CONFIG must be 0 or 1 (got '$ISOLATE_CONFIG')." >&2
+      return 2
+      ;;
+  esac
+
+  if [ "$ENDPOINT" = "platform" ]; then
+    LEAD_MODEL="$platform_model"
+  else
+    LEAD_MODEL="$coding_model"
+  fi
+  default_base_url="$(kimicc_default_base_url "$ENDPOINT")"
+  BASE_URL="${KIMICC_BASE_URL:-$default_base_url}"
+  BASE_URL="${BASE_URL%/}"
+
+  # shellcheck source=scripts/lib/claude_route_guard.sh
+  source "$project_dir/scripts/lib/claude_route_guard.sh"
+  if [ "$ISOLATE_CONFIG" = "1" ] && [ "${KIMICC_HEADLESS:-0}" != "1" ] && [ -z "${CLAUDE_CONFIG_DIR:-}" ]; then
+    export CLAUDE_CONFIG_DIR="${HOME}/.claude-kimicc"
+    mkdir -p "$CLAUDE_CONFIG_DIR"
+    echo "Isolated Claude config: $CLAUDE_CONFIG_DIR (original ~/.claude untouched)"
+  fi
+  if ! assert_claude_settings_route_clean "KimiCC"; then
+    return 1
+  fi
+
+  oauth_helper="$project_dir/scripts/lib/kimi_coding_oauth.py"
+  AUTH_VIA_OAUTH=0
+  if ! kimicc_resolve_explicit_auth_token; then
+    if [ "$ENDPOINT" = "coding" ] && [ -f "$oauth_helper" ] && [ -x "$python_bin" ]; then
+      if _resolved_auth="$("$python_bin" "$oauth_helper" token 2>/dev/null)" && [ -n "$_resolved_auth" ]; then
+        AUTH_VIA_OAUTH=1
+        AUTH_SOURCE="oauth(kimi login)"
+      fi
+    fi
+  fi
+  if [ -z "$_resolved_auth" ]; then
+    if [ "${KIMICC_DRY_RUN:-0}" = "1" ]; then
+      AUTH_NOTE="UNSET (dry-run only)"
+    else
+      echo "Error: no Kimi API credential found for the kimicc route." >&2
+      echo "  Platform (pay-as-you-go): set MOONSHOT_API_KEY, KIMI_API_KEY, or KIMICC_AUTH_TOKEN" >&2
+      echo "  Platform keys: https://platform.kimi.ai/console/api-keys" >&2
+      echo "  Subscription: run \`kimi login\`, then use --endpoint coding (OAuth is picked up automatically)." >&2
+      return 1
+    fi
+  fi
+
+  # shellcheck source=scripts/lib/profile_resolver.sh
+  source "$project_dir/scripts/lib/profile_resolver.sh"
+  CLAUDE_PROFILE_RESOLVER_PYTHON="$python_bin"
+  export CLAUDE_PROFILE_RESOLVER_PYTHON
+  if ! resolve_context_profile "$PROFILE_ID" "$LEAD_MODEL"; then
+    echo "Error: could not resolve kimicc profile '$PROFILE_ID' for model '$LEAD_MODEL'." >&2
+    return 1
+  fi
+  if [ "$LEARN_UKRAINIAN_TRUSTED" != "1" ] || [ "$LEARN_UKRAINIAN_PROFILE_ID" != "$PROFILE_ID" ]; then
+    echo "Error: kimicc profile did not resolve to a trusted contract ($LEARN_UKRAINIAN_RESOLUTION_REASON)." >&2
+    return 1
+  fi
+
+  export LEARN_UKRAINIAN_REQUESTED_PROFILE_ID="$PROFILE_ID"
+  export LEARN_UKRAINIAN_KIMICC_MANAGED_LAUNCH=1
+  export LEARN_UKRAINIAN_TRANSPORT=kimicc
+  export ANTHROPIC_BASE_URL="$BASE_URL"
+  unset ANTHROPIC_API_KEY
+
+  if [ -n "$_resolved_auth" ]; then
+    if [ "$AUTH_VIA_OAUTH" = "1" ] && [ "$ISOLATE_CONFIG" = "1" ] && [ "${KIMICC_HEADLESS:-0}" != "1" ]; then
+      if ! kimicc_install_api_key_helper "$python_bin" "$oauth_helper"; then
+        return 1
+      fi
+      export CLAUDE_CODE_API_KEY_HELPER_TTL_MS="${KIMICC_API_KEY_HELPER_TTL_MS:-300000}"
+      unset ANTHROPIC_AUTH_TOKEN
+      AUTH_NOTE="oauth(kimi login) via apiKeyHelper (auto-refresh, ttl=${CLAUDE_CODE_API_KEY_HELPER_TTL_MS}ms)"
+    else
+      export ANTHROPIC_AUTH_TOKEN="$_resolved_auth"
+      if [ "$AUTH_VIA_OAUTH" = "1" ]; then
+        if [ "${KIMICC_HEADLESS:-0}" = "1" ]; then
+          AUTH_NOTE="oauth(kimi login) — fresh token exported at headless spawn; relaunch before ~15 min"
+        else
+          AUTH_NOTE="oauth(kimi login) — short-lived token (~15 min); for long sessions relaunch with --isolate-config"
+        fi
+      else
+        AUTH_NOTE="$AUTH_SOURCE"
+      fi
+    fi
+  fi
+  unset _resolved_auth
+
+  export ANTHROPIC_MODEL="$LEAD_MODEL"
+  export ANTHROPIC_DEFAULT_OPUS_MODEL="$LEAD_MODEL"
+  export ANTHROPIC_DEFAULT_SONNET_MODEL="$LEAD_MODEL"
+  export ANTHROPIC_DEFAULT_HAIKU_MODEL="$LEAD_MODEL"
+  export ANTHROPIC_DEFAULT_FABLE_MODEL="$LEAD_MODEL"
+  export CLAUDE_CODE_SUBAGENT_MODEL="$LEAD_MODEL"
+  export ENABLE_TOOL_SEARCH=false
+  export CLAUDE_CODE_AUTO_COMPACT_WINDOW="$LEARN_UKRAINIAN_AUTO_COMPACT_CAPACITY_TOKENS"
+
+  if [ "$MODEL_ALIAS" = "k3" ]; then
+    export CLAUDE_CODE_EFFORT_LEVEL="${KIMICC_EFFORT_LEVEL:-max}"
+  elif [ -n "${KIMICC_EFFORT_LEVEL:-}" ]; then
+    export CLAUDE_CODE_EFFORT_LEVEL="$KIMICC_EFFORT_LEVEL"
+  fi
+  # The interactive launcher reads this non-secret resolution note after the
+  # helper returns; exporting also makes the shared helper's contract explicit.
+  export AUTH_NOTE
+}

--- a/scripts/review/model_catalog.py
+++ b/scripts/review/model_catalog.py
@@ -253,7 +253,8 @@ def validate_kimi_alias_consumers(project_root: Path = PROJECT_ROOT) -> None:
     """Reject local alias maps so all Kimi surfaces stay catalog-backed."""
     consumers = {
         "start-kimi.sh": ("--resolve-kimi-model", "--format native"),
-        "start-kimicc.sh": ("--resolve-kimi-model", "--format kimicc"),
+        "start-kimicc.sh": ("kimicc_configure_route",),
+        "scripts/lib/kimicc_route.sh": ("--resolve-kimi-model", "--format kimicc"),
         "scripts/agent_runtime/adapters/kimi.py": ("kimi_model_aliases()",),
     }
     for relative_path, required_snippets in consumers.items():
@@ -269,11 +270,14 @@ def validate_kimi_alias_consumers(project_root: Path = PROJECT_ROOT) -> None:
             )
 
     native_launcher = (project_root / "start-kimi.sh").read_text(encoding="utf-8")
-    if 'resolve_kimi_model() {\n  case' in native_launcher:
+    if "resolve_kimi_model() {\n  case" in native_launcher:
         raise ModelCatalogError("start-kimi.sh contains a local Kimi alias case map")
     adapter = (project_root / "scripts/agent_runtime/adapters/kimi.py").read_text(encoding="utf-8")
     if "KIMI_MODEL_ALIASES: dict[str, str] = {" in adapter:
         raise ModelCatalogError("KimiAdapter contains a local Kimi alias map")
+    kimicc_helper = (project_root / "scripts" / "lib" / "kimicc_route.sh").read_text(encoding="utf-8")
+    if 'case "$MODEL_ALIAS"' in kimicc_helper:
+        raise ModelCatalogError("KimiCC route helper contains a local Kimi alias case map")
 
 
 def _main() -> int:

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -124,45 +124,6 @@ Headless / native Kimi (not this launcher):
 EOF
 }
 
-default_base_url() {
-  case "$1" in
-    platform) printf '%s\n' 'https://api.moonshot.ai/anthropic' ;;
-    coding) printf '%s\n' 'https://api.kimi.com/coding' ;;
-    *) return 1 ;;
-  esac
-}
-
-# Resolve the auth credential into globals (no command substitution, so
-# AUTH_SOURCE survives in the caller's shell).
-_resolved_auth=""
-AUTH_SOURCE=""
-resolve_auth_token() {
-  _resolved_auth=""
-  AUTH_SOURCE=""
-  if [ -n "${KIMICC_AUTH_TOKEN:-}" ]; then
-    _resolved_auth="$KIMICC_AUTH_TOKEN"
-    AUTH_SOURCE="KIMICC_AUTH_TOKEN"
-    return 0
-  fi
-  if [ -n "${MOONSHOT_API_KEY:-}" ]; then
-    _resolved_auth="$MOONSHOT_API_KEY"
-    AUTH_SOURCE="MOONSHOT_API_KEY"
-    return 0
-  fi
-  if [ -n "${KIMI_API_KEY:-}" ]; then
-    _resolved_auth="$KIMI_API_KEY"
-    AUTH_SOURCE="KIMI_API_KEY"
-    return 0
-  fi
-  if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ "${ENDPOINT}" = "coding" ]; then
-    # Allow an already-exported coding token when operator sets it intentionally.
-    _resolved_auth="$ANTHROPIC_AUTH_TOKEN"
-    AUTH_SOURCE="ANTHROPIC_AUTH_TOKEN"
-    return 0
-  fi
-  return 1
-}
-
 while (($#)); do
   case "$1" in
     --)
@@ -217,169 +178,16 @@ while (($#)); do
   esac
 done
 
-if ! _kimicc_route="$("$SCRIPT_DIR/.venv/bin/python" "$SCRIPT_DIR/scripts/review/model_catalog.py" \
-    --resolve-kimi-model "$MODEL_ALIAS" --format kimicc 2>/dev/null)"; then
-  echo "Error: unsupported model '$MODEL_ALIAS' (use k3, k2.7, k2.7-highspeed)." >&2
-  exit 2
-fi
-IFS=$'\t' read -r MODEL_ALIAS _platform_model _coding_model PROFILE_ID <<< "$_kimicc_route"
-if [ -z "$MODEL_ALIAS" ] || [ -z "$_platform_model" ] || [ -z "$_coding_model" ] || [ -z "$PROFILE_ID" ]; then
-  echo "Error: invalid Kimi route in scripts/config/model_catalog.yaml." >&2
-  exit 1
-fi
-unset _kimicc_route
-
-case "$ENDPOINT" in
-  platform|coding) ;;
-  *)
-    echo "Error: unsupported endpoint '$ENDPOINT' (use platform or coding)." >&2
-    exit 2
-    ;;
-esac
-
-case "$ISOLATE_CONFIG" in
-  0|1) ;;
-  *)
-    echo "Error: KIMICC_ISOLATE_CONFIG must be 0 or 1 (got '$ISOLATE_CONFIG')." >&2
-    exit 2
-    ;;
-esac
-
-if [ "$ENDPOINT" = "platform" ]; then
-  LEAD_MODEL="$_platform_model"
+# shellcheck source=scripts/lib/kimicc_route.sh
+source "$SCRIPT_DIR/scripts/lib/kimicc_route.sh"
+KIMICC_ROUTE_PYTHON="$SCRIPT_DIR/.venv/bin/python"
+export KIMICC_ROUTE_PYTHON
+if kimicc_configure_route "$PROJECT_DIR" "$SCRIPT_DIR"; then
+  unset KIMICC_ROUTE_PYTHON
 else
-  LEAD_MODEL="$_coding_model"
-fi
-unset _platform_model _coding_model
-BASE_URL="${KIMICC_BASE_URL:-$(default_base_url "$ENDPOINT")}"
-BASE_URL="${BASE_URL%/}"
-
-# shellcheck source=scripts/lib/claude_route_guard.sh
-source "$PROJECT_DIR/scripts/lib/claude_route_guard.sh"
-
-if [ "$ISOLATE_CONFIG" = "1" ] && [ -z "${CLAUDE_CONFIG_DIR:-}" ]; then
-  export CLAUDE_CONFIG_DIR="${HOME}/.claude-kimicc"
-  mkdir -p "$CLAUDE_CONFIG_DIR"
-  echo "Isolated Claude config: $CLAUDE_CONFIG_DIR (original ~/.claude untouched)"
-fi
-
-if ! assert_claude_settings_route_clean "KimiCC"; then
-  exit 1
-fi
-
-# Explicit credentials win. For --endpoint coding, fall back to the
-# `kimi login` OAuth credential (subscription route): the helper prints a
-# fresh access token, refreshing it via the refresh_token grant when needed.
-KIMI_OAUTH_PY="$PROJECT_DIR/.venv/bin/python"
-KIMI_OAUTH_HELPER="$PROJECT_DIR/scripts/lib/kimi_coding_oauth.py"
-AUTH_VIA_OAUTH=0
-if ! resolve_auth_token; then
-  if [ "$ENDPOINT" = "coding" ] && [ -f "$KIMI_OAUTH_HELPER" ] && [ -x "$KIMI_OAUTH_PY" ]; then
-    if _resolved_auth="$("$KIMI_OAUTH_PY" "$KIMI_OAUTH_HELPER" token 2>/dev/null)" \
-        && [ -n "$_resolved_auth" ]; then
-      AUTH_VIA_OAUTH=1
-      AUTH_SOURCE="oauth(kimi login)"
-    fi
-  fi
-fi
-if [ -z "$_resolved_auth" ]; then
-  echo "Error: no Kimi API credential found for the kimicc route." >&2
-  echo "  Platform (pay-as-you-go): set MOONSHOT_API_KEY, KIMI_API_KEY, or KIMICC_AUTH_TOKEN" >&2
-  echo "  Platform keys: https://platform.kimi.ai/console/api-keys" >&2
-  echo "  Subscription: run \`kimi login\`, then use --endpoint coding (OAuth is picked up automatically)." >&2
-  exit 1
-fi
-
-# shellcheck source=scripts/lib/profile_resolver.sh
-source "$PROJECT_DIR/scripts/lib/profile_resolver.sh"
-if ! resolve_context_profile "$PROFILE_ID" "$LEAD_MODEL"; then
-  echo "Error: could not resolve kimicc profile '$PROFILE_ID' for model '$LEAD_MODEL'." >&2
-  exit 1
-fi
-if [ "$LEARN_UKRAINIAN_TRUSTED" != "1" ] || [ "$LEARN_UKRAINIAN_PROFILE_ID" != "$PROFILE_ID" ]; then
-  echo "Error: kimicc profile did not resolve to a trusted contract ($LEARN_UKRAINIAN_RESOLUTION_REASON)." >&2
-  exit 1
-fi
-
-export LEARN_UKRAINIAN_REQUESTED_PROFILE_ID="$PROFILE_ID"
-export LEARN_UKRAINIAN_KIMICC_MANAGED_LAUNCH=1
-export LEARN_UKRAINIAN_TRANSPORT=kimicc
-
-# Moonshot Anthropic-compatible routing (process-scoped only).
-export ANTHROPIC_BASE_URL="$BASE_URL"
-unset ANTHROPIC_API_KEY
-
-# OAuth (`kimi login`) access tokens expire after ~15 minutes. With an
-# isolated config we install an apiKeyHelper that re-mints the token on Claude
-# Code's schedule (long-session mode); without isolation the current token can
-# only be exported into the process env, which is fixed at launch.
-if [ "$AUTH_VIA_OAUTH" = "1" ] && [ "$ISOLATE_CONFIG" = "1" ]; then
-  _helper_cmd="$KIMI_OAUTH_PY $KIMI_OAUTH_HELPER token"
-  if ! KIMICC_SETTINGS_PATH="$CLAUDE_CONFIG_DIR/settings.json" KIMICC_API_KEY_HELPER="$_helper_cmd" \
-      "$KIMI_OAUTH_PY" - <<'PY'
-import json
-import os
-import sys
-
-path = os.environ["KIMICC_SETTINGS_PATH"]
-helper = os.environ["KIMICC_API_KEY_HELPER"]
-data = {}
-if os.path.exists(path):
-    with open(path, encoding="utf-8") as fh:
-        try:
-            data = json.load(fh)
-        except json.JSONDecodeError as exc:
-            print(f"Error: {path} is not valid JSON ({exc}); refusing to modify it.", file=sys.stderr)
-            sys.exit(1)
-    if not isinstance(data, dict):
-        print(f"Error: {path} is not a JSON object; refusing to modify it.", file=sys.stderr)
-        sys.exit(1)
-data["apiKeyHelper"] = helper
-os.makedirs(os.path.dirname(path), exist_ok=True)
-with open(path, "w", encoding="utf-8") as fh:
-    json.dump(data, fh, indent=2)
-    fh.write("\n")
-PY
-  then
-    echo "Error: could not install apiKeyHelper into $CLAUDE_CONFIG_DIR/settings.json" >&2
-    exit 1
-  fi
-  unset _helper_cmd
-  # Re-invoke the helper well inside the ~15 min token lifetime.
-  export CLAUDE_CODE_API_KEY_HELPER_TTL_MS="${KIMICC_API_KEY_HELPER_TTL_MS:-300000}"
-  unset ANTHROPIC_AUTH_TOKEN
-  AUTH_NOTE="oauth(kimi login) via apiKeyHelper (auto-refresh, ttl=${CLAUDE_CODE_API_KEY_HELPER_TTL_MS}ms)"
-else
-  export ANTHROPIC_AUTH_TOKEN="$_resolved_auth"
-  if [ "$AUTH_VIA_OAUTH" = "1" ]; then
-    AUTH_NOTE="oauth(kimi login) — short-lived token (~15 min); for long sessions relaunch with --isolate-config"
-  else
-    AUTH_NOTE="$AUTH_SOURCE"
-  fi
-fi
-unset _resolved_auth
-
-export ANTHROPIC_MODEL="$LEAD_MODEL"
-export ANTHROPIC_DEFAULT_OPUS_MODEL="$LEAD_MODEL"
-export ANTHROPIC_DEFAULT_SONNET_MODEL="$LEAD_MODEL"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="$LEAD_MODEL"
-export ANTHROPIC_DEFAULT_FABLE_MODEL="$LEAD_MODEL"
-export CLAUDE_CODE_SUBAGENT_MODEL="$LEAD_MODEL"
-
-# Kimi endpoint does not support Claude Code tool-search yet (official guide).
-export ENABLE_TOOL_SEARCH=false
-
-# Compaction: certified profile capacity (below true window; emergency rollover first).
-export CLAUDE_CODE_AUTO_COMPACT_WINDOW="$LEARN_UKRAINIAN_AUTO_COMPACT_CAPACITY_TOKENS"
-
-# K3 defaults to max effort on the platform guide; k2.7 always-thinks (Tab thinking in UI).
-if [ "$MODEL_ALIAS" = "k3" ]; then
-  export CLAUDE_CODE_EFFORT_LEVEL="${KIMICC_EFFORT_LEVEL:-max}"
-else
-  # Leave effort unset for k2.7 unless operator overrides; thinking must stay on in the TUI.
-  if [ -n "${KIMICC_EFFORT_LEVEL:-}" ]; then
-    export CLAUDE_CODE_EFFORT_LEVEL="$KIMICC_EFFORT_LEVEL"
-  fi
+  _kimicc_route_rc=$?
+  unset KIMICC_ROUTE_PYTHON
+  exit "$_kimicc_route_rc"
 fi
 
 echo "KimiCC: model=$LEAD_MODEL alias=$MODEL_ALIAS endpoint=$ENDPOINT profile=$PROFILE_ID"

--- a/tests/agent_runtime/adapters/test_kimi_adapter.py
+++ b/tests/agent_runtime/adapters/test_kimi_adapter.py
@@ -18,6 +18,7 @@ from scripts.agent_runtime.adapters.kimi import (
     KIMI_MODEL_ALIASES,
     KimiAdapter,
 )
+from scripts.agent_runtime.adapters.kimicc import KimiccHarness
 from scripts.agent_runtime.telemetry import resolve_invocation_telemetry
 from scripts.agent_runtime.tool_config import build_mcp_tool_config
 from scripts.audit.lint_agent_trailer import _TRAILER_RE
@@ -56,6 +57,59 @@ def test_build_invocation_uses_flagless_write_modes(tmp_path, monkeypatch, mode)
     assert plan.cmd[plan.cmd.index("-m") + 1] == KIMI_MODEL_ALIASES[KIMI_DEFAULT_MODEL]
     assert plan.cmd[plan.cmd.index("--output-format") + 1] == "stream-json"
     assert not ({"--auto", "--yolo", "--plan"} & set(plan.cmd))
+    assert plan.metadata == {}
+
+
+def test_kimicc_harness_is_opt_in_and_native_kimi_remains_default(tmp_path, monkeypatch):
+    native = _build(tmp_path, monkeypatch)
+    claude = tmp_path / "claude"
+    claude.write_text("#!/bin/sh\n", encoding="utf-8")
+    claude.chmod(0o755)
+    monkeypatch.setattr("scripts.agent_runtime.adapters.kimicc._default_claude_bin", lambda: str(claude))
+
+    kimicc = KimiAdapter().build_invocation(
+        prompt="Inspect the target.",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model=None,
+        task_id="kimi-kimicc-test",
+        session_id=None,
+        tool_config={"harness": "kimicc"},
+    )
+
+    assert native.cmd[0] == str(tmp_path / "kimi")
+    assert kimicc.cmd[0].endswith("scripts/agent_runtime/kimicc_headless.sh")
+    assert kimicc.cmd[kimicc.cmd.index("--model") + 1] == "k3"
+    assert kimicc.metadata["harness"] == "kimicc"
+    assert kimicc.env_overrides["KIMICC_CLAUDE_BIN"] == str(claude)
+    assert "CLAUDE_CONFIG_DIR" in kimicc.env_unsets
+
+
+def test_kimicc_harness_uses_claude_stream_json_parser(tmp_path, monkeypatch):
+    claude = tmp_path / "claude"
+    claude.write_text("#!/bin/sh\n", encoding="utf-8")
+    claude.chmod(0o755)
+    monkeypatch.setattr("scripts.agent_runtime.adapters.kimicc._default_claude_bin", lambda: str(claude))
+    plan = KimiccHarness().build_invocation(
+        prompt="Inspect the target.",
+        mode="read-only",
+        cwd=tmp_path,
+        model="k3",
+        task_id="kimi-kimicc-parser",
+        session_id=None,
+        tool_config={"harness": "kimicc"},
+    )
+
+    parsed = KimiAdapter().parse_response(
+        stdout=json.dumps({"type": "result", "result": "KimiCC response"}),
+        stderr="",
+        returncode=0,
+        output_file=None,
+        plan=plan,
+    )
+
+    assert parsed.ok is True
+    assert parsed.response == "KimiCC response"
 
 
 def test_mode_flag_mapping_is_empty_for_all_headless_modes():
@@ -200,6 +254,25 @@ def test_dispatch_parser_and_commit_trailer_accept_kimi():
     )
     assert args.agent == "kimi"
     assert _TRAILER_RE.search("X-Agent: kimi/kimi-smoke")
+
+
+def test_dispatch_parser_accepts_only_explicit_kimicc_harness_for_kimi():
+    args = build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            "kimi",
+            "--harness",
+            "kimicc",
+            "--task-id",
+            "kimi-kimicc-smoke",
+            "--prompt",
+            "probe",
+            "--dry-run",
+        ]
+    )
+
+    assert args.harness == "kimicc"
 
 
 def test_kimi_mcp_request_fails_closed_without_per_call_selector():

--- a/tests/agent_runtime/adapters/test_kimicc_headless.py
+++ b/tests/agent_runtime/adapters/test_kimicc_headless.py
@@ -1,0 +1,103 @@
+"""Hermetic contract tests for the KimiCC headless Claude Code wrapper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WRAPPER = _REPO_ROOT / "scripts" / "agent_runtime" / "kimicc_headless.sh"
+
+
+def _fake_claude(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'base=%s\\n' "${ANTHROPIC_BASE_URL-unset}"
+if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then printf 'auth=SET\\n'; else printf 'auth=UNSET\\n'; fi
+printf 'model=%s\\n' "${ANTHROPIC_MODEL-unset}"
+printf 'transport=%s\\n' "${LEARN_UKRAINIAN_TRANSPORT-unset}"
+printf 'arg=%s\\n' "$@"
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _clean_kimicc_env(home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    for name in (
+        "MOONSHOT_API_KEY",
+        "KIMI_API_KEY",
+        "KIMICC_AUTH_TOKEN",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "KIMI_CODE_CREDENTIALS_PATH",
+        "KIMI_CODE_OAUTH_HOST",
+        "KIMICC_ENDPOINT",
+        "KIMICC_MODEL",
+        "KIMICC_BASE_URL",
+        "CLAUDE_CONFIG_DIR",
+    ):
+        env.pop(name, None)
+    env["HOME"] = str(home)
+    return env
+
+
+def test_headless_wrapper_composes_kimicc_env_without_writing_claude_config(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    claude = tmp_path / "claude"
+    _fake_claude(claude)
+    env = _clean_kimicc_env(home)
+    env.update({"KIMICC_CLAUDE_BIN": str(claude), "KIMICC_AUTH_TOKEN": "test-route-token"})
+
+    result = subprocess.run(
+        [str(_WRAPPER), "--model", "k3", "--mode", "read-only", "--prompt", "say hi"],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "base=https://api.kimi.com/coding" in result.stdout
+    assert "auth=SET" in result.stdout
+    assert "model=k3" in result.stdout
+    assert "transport=kimicc" in result.stdout
+    assert "arg=-p" in result.stdout
+    assert "arg=--bare" in result.stdout
+    assert "arg=stream-json" in result.stdout
+    assert "arg=say hi" in result.stdout
+    assert "test-route-token" not in result.stdout
+    assert not (home / ".claude" / "settings.json").exists()
+    assert not (home / ".claude-kimicc").exists()
+
+
+def test_headless_wrapper_refuses_missing_credentials_before_claude_runs(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    claude = tmp_path / "claude"
+    _fake_claude(claude)
+    env = _clean_kimicc_env(home)
+    env.update(
+        {
+            "KIMICC_CLAUDE_BIN": str(claude),
+            "KIMI_CODE_CREDENTIALS_PATH": str(tmp_path / "missing-kimi-login.json"),
+        }
+    )
+
+    result = subprocess.run(
+        [str(_WRAPPER), "--model", "k3", "--mode", "read-only", "--prompt", "say hi"],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert result.returncode == 1
+    assert "no Kimi API credential" in result.stderr
+    assert result.stdout == ""

--- a/tests/test_agent_runtime_env_sanitize.py
+++ b/tests/test_agent_runtime_env_sanitize.py
@@ -217,6 +217,33 @@ def test_kimi_binary_override_reaches_the_native_kimi_process():
     assert env["KIMI_CODE_BIN"] == "/opt/kimi"
 
 
+def test_kimicc_route_inputs_reach_the_kimi_wrapper_only():
+    parent_env = {
+        "PATH": "/usr/bin",
+        "HOME": "/Users/example",
+        "KIMICC_AUTH_TOKEN": "test-route-token",
+        "KIMI_CODE_CREDENTIALS_PATH": "/Users/example/.kimi-code/credentials/kimi-code.json",
+        "KIMICC_ENDPOINT": "coding",
+        "KIMICC_MODEL": "k3",
+        "KIMICC_BASE_URL": "https://example.invalid/coding",
+        "KIMICC_EFFORT_LEVEL": "max",
+        "KIMICC_CLAUDE_BIN": "/opt/claude",
+        "UNRELATED": "drop-me",
+    }
+
+    with patch.dict("os.environ", parent_env, clear=True):
+        env = build_agent_env(provider="kimi")
+
+    assert env["KIMICC_AUTH_TOKEN"] == "test-route-token"
+    assert env["KIMI_CODE_CREDENTIALS_PATH"].endswith("kimi-code.json")
+    assert env["KIMICC_ENDPOINT"] == "coding"
+    assert env["KIMICC_MODEL"] == "k3"
+    assert env["KIMICC_BASE_URL"] == "https://example.invalid/coding"
+    assert env["KIMICC_EFFORT_LEVEL"] == "max"
+    assert env["KIMICC_CLAUDE_BIN"] == "/opt/claude"
+    assert "UNRELATED" not in env
+
+
 @dataclass
 class _SmokePlan:
     cmd: list[str]

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2388,6 +2388,47 @@ def test_run_worker_forwards_max_budget_usd_to_runtime(tmp_tasks_dir, tmp_path):
     assert state["max_budget_usd"] == 0.5
 
 
+def test_run_worker_selects_kimicc_harness_without_changing_kimi_agent(tmp_tasks_dir, tmp_path):
+    state_path = delegate._state_path("worker-kimicc")
+    delegate._write_state_atomic(state_path, {"task_id": "worker-kimicc", "harness": "kimicc"})
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "k3",
+            "effort": "max",
+            "cli_version": "fixture",
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result) as mock_invoke:
+        rc = delegate._run_worker(
+            task_id="worker-kimicc",
+            agent="kimi",
+            prompt="hi",
+            mode="read-only",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+            harness="kimicc",
+        )
+
+    assert rc == 0
+    assert mock_invoke.call_args.args[:2] == ("kimi", "hi")
+    assert mock_invoke.call_args.kwargs["tool_config"] == {"harness": "kimicc"}
+
+
+def test_kimicc_harness_rejects_other_agent_seats():
+    assert delegate._resolve_dispatch_harness("kimi", "kimicc") == "kimicc"
+    with pytest.raises(ValueError, match="only with --agent kimi"):
+        delegate._resolve_dispatch_harness("codex", "kimicc")
+
+
 def test_run_worker_forwards_output_schema_to_runtime(tmp_tasks_dir, tmp_path):
     state_path = delegate._state_path("worker-schema")
     delegate._write_state_atomic(state_path, {"task_id": "worker-schema"})

--- a/tests/test_dispatch_telemetry.py
+++ b/tests/test_dispatch_telemetry.py
@@ -338,6 +338,35 @@ def test_resolve_dispatch_start_telemetry_kimi_resolves_binary(tmp_path, monkeyp
     assert telemetry_with_plan.cli_version == "0.42.1"
 
 
+def test_kimicc_telemetry_records_the_headless_k3_route(tmp_path):
+    plan = InvocationPlan(
+        cmd=["kimicc_headless.sh", "--model", "k3"],
+        cwd=tmp_path,
+        metadata={"harness": "kimicc", "kimicc_alias": "k3", "claude_bin": "claude"},
+    )
+
+    with patch("agent_runtime.telemetry.claude_cli_version", return_value="2.1.220"):
+        at_dispatch = resolve_dispatch_start_telemetry(
+            agent_name="kimi",
+            requested_model=None,
+            requested_effort=None,
+            harness="kimicc",
+        )
+        after_spawn = resolve_invocation_telemetry(
+            agent_name="kimi",
+            plan=plan,
+            requested_model=None,
+            requested_effort=None,
+        )
+
+    assert (at_dispatch.model, at_dispatch.effort) == ("k3", "max")
+    assert (after_spawn.model, after_spawn.effort, after_spawn.cli_version) == (
+        "k3",
+        "max",
+        "2.1.220",
+    )
+
+
 def setup_function() -> None:
     _reset_rate_limit_cache_for_tests()
     _reset_version_cache_for_tests()

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -98,9 +98,15 @@ def test_catalog_rejects_kimi_route_without_its_friendly_alias():
 def test_kimi_alias_lint_rejects_a_reintroduced_local_adapter_map(tmp_path: Path) -> None:
     project_root = tmp_path / "project"
     (project_root / "scripts" / "agent_runtime" / "adapters").mkdir(parents=True)
-    for relative_path in ("start-kimi.sh", "start-kimicc.sh", "scripts/agent_runtime/adapters/kimi.py"):
+    for relative_path in (
+        "start-kimi.sh",
+        "start-kimicc.sh",
+        "scripts/lib/kimicc_route.sh",
+        "scripts/agent_runtime/adapters/kimi.py",
+    ):
         source = (Path(__file__).resolve().parents[1] / relative_path).read_text(encoding="utf-8")
         destination = project_root / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
         destination.write_text(source, encoding="utf-8")
     adapter_path = project_root / "scripts" / "agent_runtime" / "adapters" / "kimi.py"
     adapter_path.write_text(

--- a/tests/test_start_kimicc.py
+++ b/tests/test_start_kimicc.py
@@ -48,6 +48,7 @@ def _require_launcher_sources() -> None:
         _LAUNCHER,
         _REPO_ROOT / "scripts" / "secret_redactor.py",
         _REPO_ROOT / "scripts" / "lib" / "claude_route_guard.sh",
+        _REPO_ROOT / "scripts" / "lib" / "kimicc_route.sh",
         _REPO_ROOT / "scripts" / "lib" / "profile_resolver.sh",
         _REPO_ROOT / "scripts" / "lib" / "context_profiles.py",
         _REPO_ROOT / "scripts" / "lib" / "kimi_coding_oauth.py",
@@ -80,7 +81,7 @@ def _seed_fake_project(tmp_path: Path) -> Path:
     (project / "scripts" / "secret_redactor.py").write_text(
         secret_redactor.read_text(encoding="utf-8"), encoding="utf-8"
     )
-    for name in ("claude_route_guard.sh", "profile_resolver.sh", "context_profiles.py", "kimi_coding_oauth.py"):
+    for name in ("claude_route_guard.sh", "kimicc_route.sh", "profile_resolver.sh", "context_profiles.py", "kimi_coding_oauth.py"):
         src = _REPO_ROOT / "scripts" / "lib" / name
         dest = lib / name
         dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
@@ -483,6 +484,23 @@ def test_dry_run_resolves_route_without_launching(tmp_path: Path) -> None:
     assert "KIMICC_DRY_RUN=1: would exec" in result.stdout
     assert "auth=MOONSHOT_API_KEY" in result.stdout
     # Fake claude was never executed.
+    assert output == ""
+
+
+def test_dry_run_resolves_route_without_a_credential(tmp_path: Path) -> None:
+    output, result = _run_with_fakes(
+        tmp_path,
+        [],
+        env_overrides={
+            **_OAUTH_ENV_CLEAR,
+            "KIMICC_DRY_RUN": "1",
+            "KIMI_CODE_CREDENTIALS_PATH": str(tmp_path / "missing-oauth.json"),
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert "KimiCC: model=k3 alias=k3 endpoint=coding profile=kimicc_k3" in result.stdout
+    assert "auth=UNSET (dry-run only)" in result.stdout
+    assert "would exec" in result.stdout
     assert output == ""
 
 


### PR DESCRIPTION
## Design

Adds an opt-in `--harness kimicc` transport for `scripts/delegate.py dispatch --agent kimi`. The Kimi seat and native Kimi Code default remain unchanged; KimiCC defaults to K3 only when explicitly selected.

`scripts/lib/kimicc_route.sh` is the shared sourceable route resolver. Both `start-kimicc.sh` and the new headless wrapper use it for catalog resolution, endpoint/base URL selection, the Claude route guard, context-profile resolution, and credential handling. The runtime wrapper invokes `claude -p --bare` with the Kimi environment at spawn.

For `kimi login` OAuth, the headless wrapper exports a freshly resolved token only to its Claude Code child. It deliberately does not write `~/.claude` or an isolated config. Kimi OAuth access tokens last roughly 15 minutes, so calls that outlive that window must be relaunched; this limitation is documented in `docs/agent-runtime-guide.md`.

## Runtime-guide conformance

- Uses `agent_runtime`'s adapter/`InvocationPlan` path rather than a new subprocess call site.
- Keeps route credentials out of `InvocationPlan.env_overrides`; OAuth resolution occurs immediately before `exec`.
- Preserves a stateless `--bare` flow with no `CLAUDE_CONFIG_DIR` ownership.
- Retains native Kimi invocation behavior unless the caller explicitly passes `--harness kimicc`.

## Refactor equivalence

With `KIMICC_DRY_RUN=1`, a safe dummy credential, and an isolated config directory, before and after both exited `0`; `diff -u` exited `0`. Shared stdout:

```text
KimiCC: model=k3 alias=k3 endpoint=coding profile=kimicc_k3
        window=1048576 compact=996147
        base=https://api.kimi.com/coding (env-only; ~/.claude/settings.json not modified)
        auth=KIMICC_AUTH_TOKEN
        tip: keep ./start-claude.sh in another terminal for native Anthropic Claude
        agent=infra-orchestrator (default; override with --agent)
KIMICC_DRY_RUN=1: would exec /Users/krisztiankoos/projects/learn-ukrainian/start-claude.sh --model k3 --agent infra-orchestrator
```

## Validation

- `shellcheck -e SC1091 start-kimicc.sh scripts/lib/kimicc_route.sh scripts/agent_runtime/kimicc_headless.sh`
- `.venv/bin/ruff check` for all touched Python paths
- focused runtime suite: 269 tests collected and completed successfully
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`
- live OAuth smoke (credentials were present): headless wrapper `rc=0`; terminal result `KIMICC_SMOKE_OK`

## Not verified / handoff

- No long-running headless call beyond the OAuth lifetime was run; the documented action is to relaunch before roughly 15 minutes.
- The coding OAuth route was live-smoked; a separate pay-as-you-go platform-key smoke was not run.
- Independent review routing is still required before merge. The sealed Claude review could not initialize its checkout because of `symlink_denied:.venv`; the Grok advisory was cancelled by its provider before inspection. This PR is intentionally draft and has no auto-merge enabled.
