### PR TITLE
fix(atlas): unblock curated admit from legacy conformance debt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= .venv/bin/python
 ALONA_V5_INPUT ?= .claude/atlas-epic/plans/alona-truth/v5-curated-with-provenance.jsonl
 ALONA_V5_DIR ?= data/lexicon
 ALONA_V5_PUBLIC_SEED := $(ALONA_V5_DIR)/alona-v5-atlas-admission-seed.json
-ALONA_V5_CANDIDATES := $(ALONA_V5_DIR)/grow_candidates.json
+ALONA_V5_CANDIDATES := $(ALONA_V5_DIR)/alona-v5-grow-candidates.json
 ALONA_V5_PRACTICE_SEED := $(ALONA_V5_DIR)/alona-v5-practice-seed.json
 ALONA_V5_REPORT := $(ALONA_V5_DIR)/alona-v5-atlas-admission-report.json
 
@@ -11,7 +11,7 @@ ALONA_V5_REPORT := $(ALONA_V5_DIR)/alona-v5-atlas-admission-report.json
 alona-v5-admit:
 	@test -f "$(ALONA_V5_INPUT)" || { echo "missing private Alona v5 input: $(ALONA_V5_INPUT)" >&2; exit 2; }
 	$(PYTHON) -m scripts.lexicon.alona_v5_atlas_admission --input "$(ALONA_V5_INPUT)" --public-seed-out "$(ALONA_V5_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --candidates-out "$(ALONA_V5_CANDIDATES)"
-	$(PYTHON) -m scripts.lexicon.promote_grow_candidates --candidates "$(ALONA_V5_CANDIDATES)" --write
+	$(PYTHON) -m scripts.lexicon.promote_grow_candidates --candidates "$(ALONA_V5_CANDIDATES)" --allow-preexisting-conformance --write
 	$(PYTHON) scripts/lexicon/enrich_manifest.py --write
 	$(PYTHON) -m scripts.lexicon.alona_v5_atlas_admission --input "$(ALONA_V5_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --practice-seed-out "$(ALONA_V5_PRACTICE_SEED)" --report-out "$(ALONA_V5_REPORT)"
 	npm --prefix site run atlas:build-db

--- a/scripts/lexicon/promote_grow_candidates.py
+++ b/scripts/lexicon/promote_grow_candidates.py
@@ -84,6 +84,7 @@ _ENRICHED_STAT_KEYS = ("enriched", "enriched_total", "enriched_count")
 _DUMMY_MODULE = ModuleInfo(track="", slug="", module_num=0, vocab_path=Path())
 
 SelfCheck = Callable[[Path], int]
+PromotedEntriesCheck = Callable[[Path, Sequence[Mapping[str, Any]]], int]
 FingerprintWriter = Callable[[Path], Any]
 
 
@@ -137,7 +138,9 @@ def promote_grow_candidates(
     approval_ledger_path: Path | None = None,
     needs_review_ledger_path: Path | None = None,
     write: bool = False,
+    allow_preexisting_conformance: bool = False,
     self_check: SelfCheck | None = None,
+    promoted_entries_check: PromotedEntriesCheck | None = None,
     fingerprint_writer: FingerprintWriter | None = None,
 ) -> PromotionResult:
     """Promote clean grow candidates and return a structured summary."""
@@ -150,6 +153,7 @@ def promote_grow_candidates(
     if needs_review_ledger_path is not None:
         needs_review_ledger_path = _resolve_path(needs_review_ledger_path)
     self_check = self_check or verify_prospective_manifest
+    promoted_entries_check = promoted_entries_check or verify_promoted_entries
     fingerprint_writer = fingerprint_writer or _write_fingerprint_sidecar
 
     if not candidates_path.exists():
@@ -230,7 +234,15 @@ def promote_grow_candidates(
 
     if write:
         if promoted:
-            _validate_before_write(manifest, manifest_path, self_check)
+            if allow_preexisting_conformance:
+                _validate_promoted_entries_before_write(
+                    manifest,
+                    manifest_path,
+                    newly_promoted_entries,
+                    promoted_entries_check,
+                )
+            else:
+                _validate_before_write(manifest, manifest_path, self_check)
             _write_json_atomically(manifest_path, manifest)
             manifest_written = True
             fingerprint_writer(fingerprint_path)
@@ -288,6 +300,79 @@ def verify_prospective_manifest(manifest_path: Path) -> int:
     )
     enrichment_status = check_enrichment(manifest_path=manifest_path)
     return verify_status or enrichment_status
+
+
+def verify_promoted_entries(manifest_path: Path, entries: Sequence[Mapping[str, Any]]) -> int:
+    """Run structural and conformance safety gates only on new manifest entries.
+
+    ``--allow-preexisting-conformance`` is intended for an already hydrated
+    manifest whose legacy entries are known to fail the full §8 sweep.  It does
+    not waive those gates for a promotion: each new entry still receives the
+    same entry-local structural and conformance checks, including VESUM and
+    attribution checks where their local data sources are available.
+    """
+    promoted_manifest = {"entries": list(entries)}
+    hazards = verify_manifest.hazards(promoted_manifest, list(entries))
+    violations = verify_manifest.conformance(promoted_manifest)
+    enrichment_status = check_enrichment(manifest_path=manifest_path)
+    identity_violations = _promoted_entry_identity_violations(manifest_path, entries)
+
+    if not any(hazards.values()) and not violations and not enrichment_status and not identity_violations:
+        print("=== PROMOTED-ENTRY SAFETY GATES: CLEAN ===")
+        return 0
+
+    print("=== PROMOTED-ENTRY SAFETY GATES ===", file=sys.stderr)
+    for name, hits in hazards.items():
+        if hits:
+            print(f"  {name}: {len(hits)} — {hits[:5]}", file=sys.stderr)
+    if violations:
+        by_gate: dict[str, int] = {}
+        for violation in violations:
+            by_gate[violation.gate] = by_gate.get(violation.gate, 0) + 1
+        for gate, count in sorted(by_gate.items()):
+            examples = [
+                f"{violation.lemma}: {violation.detail}"
+                for violation in violations
+                if violation.gate == gate
+            ][:5]
+            print(f"  {gate}: {count} — {examples}", file=sys.stderr)
+    if identity_violations:
+        for violation in identity_violations:
+            print(f"  route_identity: {violation}", file=sys.stderr)
+    return 2
+
+
+def _promoted_entry_identity_violations(
+    manifest_path: Path, entries: Sequence[Mapping[str, Any]]
+) -> list[str]:
+    """Return route collisions introduced by a newly promoted entry.
+
+    The grow queue is already de-duplicated by normalized lemma, but routes are
+    indexed by ``url_slug``.  Check only collisions involving a new entry so
+    documented legacy collisions remain outside this narrowly scoped escape
+    hatch.
+    """
+    manifest = _load_manifest(manifest_path)
+    all_entries = manifest.get("entries", [])
+    if not isinstance(all_entries, list):
+        return ["prospective manifest entries is not a list"]
+
+    slug_counts: dict[str, int] = {}
+    for entry in all_entries:
+        if isinstance(entry, Mapping):
+            slug = _clean_optional_str(entry.get("url_slug"))
+            if slug:
+                slug_counts[slug] = slug_counts.get(slug, 0) + 1
+
+    violations: list[str] = []
+    for entry in entries:
+        lemma = _clean_optional_str(entry.get("lemma")) or "<missing lemma>"
+        slug = _clean_optional_str(entry.get("url_slug"))
+        if not slug:
+            violations.append(f"{lemma}: missing url_slug")
+        elif slug_counts.get(slug, 0) > 1:
+            violations.append(f"{lemma}: url_slug {slug!r} collides with an existing route")
+    return violations
 
 
 def format_summary(result: PromotionResult, *, report: bool = False, candidates_path: Path = DEFAULT_CANDIDATES) -> str:
@@ -417,6 +502,15 @@ def build_parser() -> argparse.ArgumentParser:
             "only its approve rows are promoted from needs_review (with approved_gloss)"
         ),
     )
+    parser.add_argument(
+        "--allow-preexisting-conformance",
+        action="store_true",
+        help=(
+            "Validate only newly promoted entries for structural and §8 conformance "
+            "violations. Use only when the hydrated manifest has documented legacy "
+            "conformance debt; the default validates the whole prospective manifest."
+        ),
+    )
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
         "--write",
@@ -448,6 +542,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             approval_ledger_path=args.approval_ledger,
             needs_review_ledger_path=args.needs_review_ledger,
             write=args.write,
+            allow_preexisting_conformance=args.allow_preexisting_conformance,
         )
     except (SelfCheckError, ValueError) as exc:
         print(f"error: {exc}; no files written", file=sys.stderr)
@@ -928,6 +1023,20 @@ def _validate_before_write(manifest: dict[str, Any], manifest_path: Path, self_c
         temp_manifest.write_bytes(_json_bytes(manifest))
         exit_code = self_check(temp_manifest)
     if exit_code != 0:
+        raise SelfCheckError(exit_code)
+
+
+def _validate_promoted_entries_before_write(
+    manifest: dict[str, Any],
+    manifest_path: Path,
+    entries: Sequence[Mapping[str, Any]],
+    promoted_entries_check: PromotedEntriesCheck,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="atlas-grow-promote-") as tmp_dir:
+        temp_manifest = Path(tmp_dir) / manifest_path.name
+        temp_manifest.write_bytes(_json_bytes(manifest))
+        exit_code = promoted_entries_check(temp_manifest, entries)
+    if exit_code:
         raise SelfCheckError(exit_code)
 
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "2f4f0cbc51d552b3429212c1cfc99d66fc41d474a657ca9116b64d74784621fd",
+  "fingerprint": "1b9d36a499d375795e26c711575b38d34c81b08f11bcfda542ac7d82560af16f",
   "inputs": {
     "lexicon_code": [
       {
@@ -176,7 +176,7 @@
       },
       {
         "path": "scripts/lexicon/promote_grow_candidates.py",
-        "sha256": "f6c2fb40fad518ea753023d9fdffba485ab56cdcac7cf1bce506a36e07f11f0b"
+        "sha256": "c4a0fe8e365601a6208b681356a923479a49c7c34eba2752209aa7baff82861e"
       },
       {
         "path": "scripts/lexicon/promote_teacher_lesson_intake.py",

--- a/tests/test_promote_grow_candidates.py
+++ b/tests/test_promote_grow_candidates.py
@@ -411,6 +411,111 @@ def test_gate_failure_aborts_without_writing(tmp_path: Path, monkeypatch) -> Non
     assert not fingerprint_path.exists()
 
 
+def test_allow_preexisting_conformance_checks_only_promoted_entries(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("legacy")])
+    candidates_path = _write_candidates(tmp_path, [_candidate("мама")], [])
+    checked_entries: list[dict[str, object]] = []
+
+    result = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=tmp_path / "grow_needs_review.json",
+        fingerprint_path=tmp_path / "lexicon-manifest.fingerprint.json",
+        write=True,
+        allow_preexisting_conformance=True,
+        self_check=lambda _path: pytest.fail("full-manifest check must not run"),
+        promoted_entries_check=lambda _path, entries: checked_entries.extend(entries) or 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    assert result.manifest_written is True
+    assert [entry["lemma"] for entry in checked_entries] == ["мама"]
+
+
+def test_cli_allow_preexisting_conformance_uses_promoted_entry_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("legacy")])
+    candidates_path = _write_candidates(tmp_path, [_candidate("мама")], [])
+    checked_entries: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        promote,
+        "verify_prospective_manifest",
+        lambda _path: pytest.fail("full-manifest check must not run"),
+    )
+    monkeypatch.setattr(
+        promote,
+        "verify_promoted_entries",
+        lambda _path, entries: checked_entries.extend(entries) or 0,
+    )
+    monkeypatch.setattr(promote, "_write_fingerprint_sidecar", _fingerprint_writer)
+
+    code = promote.main(
+        [
+            "--candidates",
+            str(candidates_path),
+            "--manifest",
+            str(manifest_path),
+            "--needs-review",
+            str(tmp_path / "grow_needs_review.json"),
+            "--fingerprint",
+            str(tmp_path / "lexicon-manifest.fingerprint.json"),
+            "--allow-preexisting-conformance",
+            "--write",
+        ]
+    )
+
+    assert code == 0
+    assert [entry["lemma"] for entry in checked_entries] == ["мама"]
+
+
+def test_allow_preexisting_conformance_still_aborts_on_new_entry_failure(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("legacy")])
+    before = manifest_path.read_text(encoding="utf-8")
+    candidates_path = _write_candidates(tmp_path, [_candidate("мама")], [])
+    needs_review_path = tmp_path / "grow_needs_review.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+
+    with pytest.raises(promote.SelfCheckError):
+        promote.promote_grow_candidates(
+            candidates_path=candidates_path,
+            manifest_path=manifest_path,
+            needs_review_path=needs_review_path,
+            fingerprint_path=fingerprint_path,
+            write=True,
+            allow_preexisting_conformance=True,
+            promoted_entries_check=lambda _path, _entries: 2,
+            fingerprint_writer=_fingerprint_writer,
+        )
+
+    assert manifest_path.read_text(encoding="utf-8") == before
+    assert not needs_review_path.exists()
+    assert not fingerprint_path.exists()
+
+
+def test_promoted_entry_gate_keeps_full_manifest_enrichment_backstop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("legacy"), _entry("мама")])
+    monkeypatch.setattr(promote.verify_manifest, "hazards", lambda _manifest, _entries: {})
+    monkeypatch.setattr(promote.verify_manifest, "conformance", lambda _manifest: [])
+    monkeypatch.setattr(promote, "check_enrichment", lambda **_kwargs: 2)
+
+    assert promote.verify_promoted_entries(manifest_path, [_entry("мама")]) == 2
+
+
+def test_promoted_entry_gate_rejects_new_slug_collision(tmp_path: Path) -> None:
+    legacy = _entry("legacy")
+    legacy["url_slug"] = "shared-route"
+    promoted = _entry("мама")
+    promoted["url_slug"] = "shared-route"
+    manifest_path = _write_manifest(tmp_path, [legacy, promoted])
+
+    assert promote._promoted_entry_identity_violations(manifest_path, [promoted]) == [
+        "мама: url_slug 'shared-route' collides with an existing route"
+    ]
+
+
 def test_dry_run_writes_nothing(tmp_path: Path) -> None:
     manifest_path = _write_manifest(tmp_path, [_entry("авто")])
     before = manifest_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary\n- add opt-in promoted-entry-only conformance checks while retaining the global enrichment backstop\n- reject route collisions introduced by new entries\n- isolate the Alona candidate artifact from the fleet grow-candidates file\n\n## Verification\n- ============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/fix-alona-admit-promote
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0, anyio-4.14.2
timeout: 120.0s
timeout method: thread
timeout func_only: False
collected 77 items

tests/test_promote_grow_candidates.py ........................           [ 31%]
tests/test_alona_v5_atlas_admission.py .....                             [ 37%]
tests/test_generate_practice_deck.py ................................... [ 83%]
.............                                                            [100%]

============================== 77 passed in 1.17s ============================== (77 passed)\n- All checks passed!\n- test -f ".claude/atlas-epic/plans/alona-truth/v5-curated-with-provenance.jsonl" || { echo "missing private Alona v5 input: .claude/atlas-epic/plans/alona-truth/v5-curated-with-provenance.jsonl" >&2; exit 2; }
.venv/bin/python -m scripts.lexicon.alona_v5_atlas_admission --input ".claude/atlas-epic/plans/alona-truth/v5-curated-with-provenance.jsonl" --public-seed-out "data/lexicon/alona-v5-atlas-admission-seed.json" --manifest site/src/data/lexicon-manifest.json --candidates-out "data/lexicon/alona-v5-grow-candidates.json"
.venv/bin/python -m scripts.lexicon.promote_grow_candidates --candidates "data/lexicon/alona-v5-grow-candidates.json" --allow-preexisting-conformance --write
.venv/bin/python scripts/lexicon/enrich_manifest.py --write
.venv/bin/python -m scripts.lexicon.alona_v5_atlas_admission --input "data/lexicon/alona-v5-atlas-admission-seed.json" --manifest site/src/data/lexicon-manifest.json --practice-seed-out "data/lexicon/alona-v5-practice-seed.json" --report-out "data/lexicon/alona-v5-atlas-admission-report.json"
npm --prefix site run atlas:build-db
.venv/bin/python scripts/audit/generate_practice_deck.py --practice-seed "data/lexicon/alona-v5-practice-seed.json"\n\nThe private Alona v5 JSONL is not present in this dispatched sparse worktree, so the full write/build recipe is intentionally not run here. The recipe remains ordered promote → enrich → practice seed/report → atlas DB → practice deck.\n\nNo auto-merge armed (worker policy).