### PR TITLE
fix(skills): harden curriculum fleet routing

### DIFF
--- a/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-lifecycle/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: curriculum-lifecycle
-description: Run or resume the manifest-derived curriculum lifecycle for one active track. Use when an operator asks to process a track in manifest order, select built, unbuilt, stale, or one-module scope, or resume an exact coordinator run. Route every acquired module through curriculum-preparation or track-completion; do not use for an uncoordinated standalone module.
+description: Run or resume the manifest-derived curriculum lifecycle for one active track. Use when an operator asks to process a track in manifest order, select built, unbuilt, stale, or coordinator `one` scope for an explicitly named module, or resume an exact coordinator run. Route every acquired module through curriculum-preparation or track-completion; a standalone module completion belongs to track-completion instead.
 ---
 
 # Curriculum lifecycle
+
+Run repository commands from the repository root. Use canonical resource paths
+under `agents_extensions/shared/skills/`; provider-specific skill directories
+are deploy mirrors, not alternate sources.
 
 Keep the operator request short:
 
 ```text
 Use $curriculum-lifecycle for folk, terminal goal merge.
 Use $curriculum-lifecycle for c1, scope unbuilt, terminal goal certify.
-Resume $curriculum-lifecycle for bio.
+Resume $curriculum-lifecycle with run id <run-id>, owner <agent/task>.
 ```
 
 This skill is the track-level entry point. It composes the deterministic
@@ -28,9 +32,10 @@ only bounded-completion authority.
 1. Satisfy the repository issue, stream, worktree, research-classification,
    pending-decision, and quota/health preflight before mutation. Learner changes
    belong to the target track's stream epic, not the shared infrastructure epic.
-2. Require an explicit operator-selected terminal goal for every new run. If it
-   is absent, ask once before starting; never infer it from scope or history.
-   Resume uses the immutable goal in the exact recorded run.
+2. Require an explicit operator-selected terminal goal and scope for every new
+   run. If either is absent, ask once before starting; never infer it from
+   history or rely on the coordinator's `scope=all` parser default. Resume uses
+   the immutable goal and scope in the exact recorded run.
 3. For a new run, map the requested selector to one of `all`, `built`,
    `unbuilt`, `stale`, or `one`, then start exactly one manifest-backed run:
 
@@ -42,17 +47,31 @@ only bounded-completion authority.
      [--end <slug-or-position>] [--wave-size <n>]
    ```
 
+   `scope=one` requires exactly one active `--module <slug>` and forbids
+   `--start` or `--end`. Every other scope forbids `--module`; optional range
+   bounds apply only to those non-`one` scopes.
+
    Preserve the returned `run_id` and ledger path. Do not create a replacement
    run to bypass a lease, health pause, or manifest drift.
    The goal is immutable authority, not a progress label. A legacy run without
-   one must use `migrate-terminal-goal` on its exact run id; never infer intent
-   from `complete` or `PBR_PASS_QG_PENDING` history.
+   one must use this exact transition with an operator-selected goal; never
+   infer intent from `complete` or `PBR_PASS_QG_PENDING` history:
+
+   ```bash
+   .venv/bin/python scripts/orchestration/curriculum_coordinator.py \
+     migrate-terminal-goal --run-id <run-id> --owner <agent/task> \
+     --terminal-goal <merge|certify|deploy>
+   ```
 4. Resume only the exact recorded run:
 
    ```bash
    .venv/bin/python scripts/orchestration/curriculum_coordinator.py resume \
      --run-id <run-id> --owner <agent/task>
    ```
+
+   If the exact `run_id` and owner (or the recorded `resume_command`) are
+   unavailable, stop and request them. Do not guess an identity or start a
+   replacement run.
 
    If manifest authority changed, stop and use the coordinator's explicit
    adjudication path before starting a fresh run. Never migrate old state by
@@ -73,8 +92,10 @@ only bounded-completion authority.
 
 2. Read the canonical readiness routing snapshot from the latest matching
    `MODULE_ACQUIRED` event in the returned ledger. Bind it to that event's
-   track, slug, and attempt. Route its exact `next_action` uniformly for CORE,
-   seminar, and BIO targets:
+   track, slug, and attempt. The snapshot is a routing hint, not the full typed
+   authority for requirement ownership, identity, HOLD, or partial-bundle
+   decisions. Route its exact `next_action` uniformly for CORE, seminar, and
+   BIO targets:
 
    | `next_action` | Exact next owner |
    | --- | --- |
@@ -84,11 +105,18 @@ only bounded-completion authority.
    | `certify` | `$track-completion` |
    | `stop` | State- and owner-sensitive; reviewed HOLD or partial recovery |
 
-   For `plan` or `prepare`, run the canonical evaluator once for the exact
-   acquired target and use its full typed result to resolve ownership. If any
-   current failed requirement is owned by `plan` or `preparation`, route those
-   cells through `$curriculum-preparation`; accept its returned typed result
-   without calling lifecycle recursively.
+   For `plan`, `prepare`, or `stop`, run the canonical evaluator once for the
+   exact acquired target and use its full typed result to resolve ownership:
+
+   ```bash
+   .venv/bin/python scripts/orchestration/curriculum_readiness.py \
+     --track <track> --slug <slug> \
+     > <gitignored-readiness-result.json>
+   ```
+
+   If any current failed requirement is owned by `plan` or `preparation`, route
+   those cells through `$curriculum-preparation`; accept its returned typed
+   result without calling lifecycle recursively.
 
    When every current requirement passes but a built result remains `prepare`
    solely because of `PREPARATION_IDENTITY_MISSING` or
@@ -101,15 +129,15 @@ only bounded-completion authority.
    repeat the evaluator, or loop through preparation. Fail closed on mixed or
    unknown combinations.
 
-   For `stop`, run the canonical evaluator once to validate the full typed
-   result. `PREPARATION_HOLD_ACTIVE` without a partial-bundle finding is a
-   terminal reviewed HOLD: preserve its evidence, leave the acquisition in
-   place, report the hold, and do not record module completion or reacquire. A
-   result whose state is `partial-bundle`, contains `PARTIAL_LEARNER_BUNDLE`
-   owned by `built_artifact`, and has no active HOLD goes once to
-   `$track-completion` for its existing forensic recovery. Do not reacquire.
-   Reject a result containing both routes, or any unknown stop combination,
-   without mutation or an evaluation loop.
+   For `stop`, validate that full typed result.
+   `PREPARATION_HOLD_ACTIVE` without a partial-bundle finding is a terminal
+   reviewed HOLD: preserve its evidence, leave the acquisition in place, report
+   the hold, and do not record module completion or reacquire. A result whose
+   state is `partial-bundle`, contains `PARTIAL_LEARNER_BUNDLE` owned by
+   `built_artifact`, and has no active HOLD goes once to `$track-completion` for
+   its existing forensic recovery. Do not reacquire. Reject a result containing
+   both routes, or any unknown stop combination, without mutation or an
+   evaluation loop.
 3. For `build`, `certify`, an identity-only `prepare` exception, or the exact
    partial-bundle `stop` exception, resolve the acquired track's registered
    semantic profile from the manifest. Put the typed context in a gitignored

--- a/agents_extensions/shared/skills/curriculum-lifecycle/agents/openai.yaml
+++ b/agents_extensions/shared/skills/curriculum-lifecycle/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Curriculum Lifecycle"
-  short_description: "Coordinate one curriculum track safely"
+  short_description: "Coordinate one explicit-scope curriculum track safely"
   default_prompt: "Use $curriculum-lifecycle for c1, scope unbuilt, terminal goal merge."

--- a/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
+++ b/agents_extensions/shared/skills/curriculum-preparation/SKILL.md
@@ -42,13 +42,17 @@ before mutation and require the same track, `profile_id`, `profile_version`, and
 Treat `--missing-only` as deterministic, read-only inventory only. Resolve the
 roster with `load_active_manifest()` and `load_manifest_track()` from
 `scripts.orchestration.curriculum_readiness`, evaluate the whole active track
-locally, and return the evaluator's preparation-owned missing or stale
-candidates in manifest order. This inventory intentionally excludes an
-identity-missing built module whose requirements otherwise pass; that route
-belongs to `$track-completion`. Do not mutate, call a model, silently broaden
-the canonical inventory, select an unbounded work scope, or scan another track.
-Stop after the inventory; actual preparation requires a new explicit one-target
-invocation or finite homogeneous packet with `--limit`.
+locally, and return readiness candidates in manifest order. Rows may contain
+failed requirements owned by `plan` or `preparation`, plus preparation reason
+codes such as identity drift or an active HOLD; preserve those owners and codes
+as routing signals, not blanket preparation-mutation authority. This inventory
+intentionally excludes an identity-missing built module whose requirements
+otherwise pass; that route belongs to `$track-completion`. A pure identity-drift
+row follows the same completion-owned identity route, while an active HOLD is
+report-only. Do not mutate, call a model, silently broaden the canonical
+inventory, select an unbounded work scope, or scan another track. Stop after the
+inventory; actual preparation requires a new explicit one-target invocation or
+finite homogeneous packet with `--limit`.
 
 ## Evaluate before acting
 

--- a/agents_extensions/shared/skills/curriculum-preparation/agents/openai.yaml
+++ b/agents_extensions/shared/skills/curriculum-preparation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Curriculum Preparation"
-  short_description: "Prepare missing curriculum evidence safely"
+  short_description: "Inventory or prepare prerequisite evidence safely"
   default_prompt: "Use $curriculum-preparation for c1 --missing-only."

--- a/tests/orchestration/test_prompt_contracts.py
+++ b/tests/orchestration/test_prompt_contracts.py
@@ -732,6 +732,8 @@ def test_curriculum_skills_define_one_non_recursive_preparation_handoff() -> Non
         assert f"| {action} | {owner} |" in lifecycle
 
     assert "readiness routing snapshot from the latest matching `MODULE_ACQUIRED` event" in normalized_lifecycle
+    assert "snapshot is a routing hint, not the full typed authority" in normalized_lifecycle
+    assert "scripts/orchestration/curriculum_readiness.py" in normalized_lifecycle
     assert "use its full typed result to resolve ownership" in normalized_lifecycle
     assert "If any current failed requirement is owned by `plan` or `preparation`" in normalized_lifecycle
     assert "every current requirement passes but a built result remains `prepare`" in normalized_lifecycle
@@ -747,7 +749,18 @@ def test_curriculum_skills_define_one_non_recursive_preparation_handoff() -> Non
     assert "has no active HOLD" in normalized_lifecycle
     assert "goes once to `$track-completion`" in normalized_lifecycle
     assert "Reject a result containing both routes" in normalized_lifecycle
+    assert "explicit operator-selected terminal goal and scope" in normalized_lifecycle
+    assert "coordinator's `scope=all` parser default" in normalized_lifecycle
+    assert "`scope=one` requires exactly one active `--module <slug>`" in normalized_lifecycle
+    assert "`--module`; optional range bounds apply only to those non-`one` scopes" in normalized_lifecycle
+    assert "migrate-terminal-goal --run-id <run-id> --owner <agent/task>" in normalized_lifecycle
+    assert "--terminal-goal <merge|certify|deploy>" in normalized_lifecycle
+    assert "Do not guess an identity or start a replacement run" in normalized_lifecycle
     assert "accept and validate its exact full typed result" in normalized_preparation
+    assert "failed requirements owned by `plan` or `preparation`" in normalized_preparation
+    assert "routing signals, not blanket preparation-mutation authority" in normalized_preparation
+    assert "A pure identity-drift row follows the same completion-owned identity route" in normalized_preparation
+    assert "an active HOLD is report-only" in normalized_preparation
     assert "Never start, resume, or reacquire lifecycle" in normalized_preparation
     assert "failed `plan` requirement" in normalized_preparation
     assert "build-authorized queue" in normalized_preparation


### PR DESCRIPTION
## Summary

- make curriculum lifecycle starts and resumes parameter-complete and fail closed
- clarify cross-skill ownership for one-module completion, missing readiness rows, DRIFT, and HOLD
- add exact canonical evaluator and migration commands plus focused prompt-contract coverage

## Fleet audit

- Fable: improvements justified; accepted the missing exact readiness-evaluator command
- Grok 4.5: improvements justified; accepted explicit scope, complete resume identity, routing-hint, and ownership clarifications
- GPT-5.6 Terra: improvements justified; accepted selector constraints, inventory ownership, and complete migration command
- speculative metadata expansion and new behavior were rejected to keep the patch contract-only

## Verification

- 82 affected tests passed
- canonical deploy completed and all five deployment mirrors are byte-identical
- both skill validators and skill metadata lint passed
- Ruff, diff check, agent-trailer lint, OPSEC scan, YAML syntax, and commit/push hooks passed
- independent Claude Sonnet 5 local closeout review: PASS, no findings

No epic or issue is associated with this bounded curriculum-skill maintenance change.