### PR TITLE
chore(gitignore): ignore local curated grow candidates artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -424,6 +424,7 @@ data/lexicon/needs-review-triage-summary.md
 data/lexicon/alona-v5-atlas-admission-seed.json
 data/lexicon/alona-v5-practice-seed.json
 data/lexicon/alona-v5-atlas-admission-report.json
+data/lexicon/alona-v5-grow-candidates.json
 # Ohoiko corpus intake full source inventory (~31 MB, 111,200 rows): deterministic,
 # regenerable output of committed code over the private corpus (#4223). It does NOT
 # belong in git history — regenerate on demand into this path (main checkout only):


### PR DESCRIPTION
## Summary
`make alona-v5-admit` writes `data/lexicon/alona-v5-grow-candidates.json` (local intermediate). Seed/practice/report were already gitignored (#5910); this path was missed when #5939 split candidates off the fleet `grow_candidates.json`.

## Do not commit
This file is machine-local promote input (292 auto_merge candidates). Same class as other `alona-v5-*` artifacts.

Fixes operator confusion: untracked `?? data/lexicon/alona-v5-grow-candidates.json` after admit run.

Related: #5910 #5939 #4387