### PR TITLE
feat(launchers): rename start-codex-drive.sh to start-codex-driver.sh (early #5935 slice)

### DIFF
--- a/docs/projects/fleet-taxonomy/alias-audit.md
+++ b/docs/projects/fleet-taxonomy/alias-audit.md
@@ -10,7 +10,7 @@ It details the accepted spellings, the behavior when encountering unknown spelli
 |---|---|---|---|---|
 | `start-claude.sh` | `--epic <selector>` | 17 selectors (`infra`, `harness`, `infra.fleet-comms`, `devops`, `infra.devops`, `atlas`, `practice`, `practice-hub`, `atlas.practice`, `hramatka`, `hramatka.lessons`, `folk`, `seminars-folk`, `bio`, `seminars-bio`, `corpus`, `corpus-channels`) | Errors and exits 1 | `start-claude.sh:40-52`, `scripts/lib/handoff_identity.sh:23-48` |
 | `start-claudex.sh` | CLI flags | N/A (Only accepts `--subagent sol\|terra\|luna`) | Passes unknown args through to Claude CLI | `start-claudex.sh:22-31`, `start-claudex.sh:53-70` |
-| `start-codex-drive.sh` | `$1` (`<lane-or-lane.topic>`) | 17 selectors via `launcher_selector_resolve` | Errors and exits 2 | `start-codex-drive.sh:27-31`, `scripts/lib/handoff_identity.sh:23-48` |
+| `start-codex-driver.sh` | `$1` (`<lane-or-lane.topic>`) | 17 selectors via `launcher_selector_resolve` | Errors and exits 2 | `start-codex-driver.sh:27-31`, `scripts/lib/handoff_identity.sh:23-48` |
 | `start-codex.sh` | `--epic <selector>` | 17 selectors via `launcher_selector_lane` | Errors and exits 1 | `start-codex.sh:91-105`, `scripts/lib/handoff_identity.sh:23-48` |
 | `start-gemini-drive.sh` | `$1` (`<lane-or-lane.topic>`) | 17 selectors via `launcher_selector_resolve` | Errors and exits 2 | `start-gemini-drive.sh:27-31`, `scripts/lib/handoff_identity.sh:23-48` |
 | `start-gemini.sh` | `--epic <selector>` | 17 selectors via `launcher_selector_lane` | Errors and exits 1 | `start-gemini.sh:230-245`, `scripts/lib/handoff_identity.sh:23-48` |

--- a/docs/runbooks/epic-orchestrator-roster.md
+++ b/docs/runbooks/epic-orchestrator-roster.md
@@ -18,9 +18,9 @@ and cold-starts the driver, which runs the `drive-epic` skill to orchestrate its
 | Epic | Recommended seat | Run |
 | --- | --- | --- |
 | **harness / infra** | Gemini (AGY) | `./start-gemini-drive.sh infra` |
-| **harness / infra** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-drive.sh infra` |
+| **harness / infra** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-driver.sh infra` |
 | **devops** | Gemini (AGY) | `./start-gemini-drive.sh devops` |
-| **devops** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-drive.sh devops` |
+| **devops** (named alternate) | Codex / gpt-5.6-terra | `./start-codex-driver.sh devops` |
 | **corpus** (acquisition & ingestion) | Gemini (AGY) | `./start-gemini-drive.sh corpus` |
 | **atlas** (Word Atlas + Practice Hub product) | Grok 4.5 | `./start-grok-drive.sh atlas` |
 | **hramatka** (teacher lesson service) | Grok 4.5 · Sonnet-5 if judgment-heavy | `./start-grok-drive.sh hramatka` |
@@ -168,7 +168,7 @@ Everything else the driver runs to completion and reports past-tense — no "sho
 
 1. **This PR:** the `drive-epic` skill, this runbook, and the per-model driver launchers
    (`start-grok-drive.sh` / `start-gemini-drive.sh` / `start-sonnet-drive.sh`;
-   `start-codex-drive.sh` and `start-opus-drive.sh` landed after). Cross-family reviewed;
+   `start-codex-driver.sh` and `start-opus-drive.sh` landed after). Cross-family reviewed;
    advisor-looped on the skill contract.
 2. **Follow-up PR:** rewire the `start-grok.sh` / `start-gemini.sh` / `start-kimi.sh`
    cold-prompt `case` blocks to invoke `$drive-epic` (replacing the hand-written per-epic

--- a/docs/runbooks/epic-stream-handoff.md
+++ b/docs/runbooks/epic-stream-handoff.md
@@ -31,7 +31,7 @@ driver (e.g. Codex on hramatka) leaves, content dual-write alone is not enough:
 
 ### Codex DevOps zero-touch boundary
 
-`./start-codex-drive.sh devops` scans only its assigned `codex-devops` rollover
+`./start-codex-driver.sh devops` scans only its assigned `codex-devops` rollover
 namespace before acquiring `epic:5703`. Infra keeps the separate `codex-infra`
 namespace and `epic:4707` lease, so a live Infra driver does not block DevOps.
 The launcher starts a fresh task when no packet

--- a/start-codex-driver.sh
+++ b/start-codex-driver.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Codex / gpt-5.6-terra in DRIVER mode for an allowlisted lane selector.
-#   ./start-codex-drive.sh <lane-or-lane.topic> [extra flags]
+#   ./start-codex-driver.sh <lane-or-lane.topic> [extra flags]
 # Which epic routes to which model? -> docs/runbooks/epic-orchestrator-roster.md
 # Thin wrapper over start-codex.sh. The driver should load the `drive-epic` skill.
 set -euo pipefail

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -100,7 +100,7 @@ def init_repo(tmp_path: Path, *, bootstrap_sources: bool = False) -> tuple[Path,
         sources.extend(
             [
                 "start-codex.sh",
-                "start-codex-drive.sh",
+                "start-codex-driver.sh",
                 "scripts/agent_runtime/bounded_command.py",
                 "scripts/lib/thread_rollover_link.sh",
                 "scripts/lib/deploy_extensions.sh",
@@ -897,7 +897,7 @@ def test_real_codex_devops_launcher_injects_board_and_binds_exact_fresh_rollover
         }
     )
     launched = run(
-        [primary / "start-codex-drive.sh", "devops", "--model", "gpt-5.6-sol"],
+        [primary / "start-codex-driver.sh", "devops", "--model", "gpt-5.6-sol"],
         cwd=primary,
         env=env,
     )
@@ -968,7 +968,7 @@ def test_real_codex_devops_launcher_fails_before_lease_on_rollover_ambiguity(
         }
     )
     launched = run(
-        [primary / "start-codex-drive.sh", "devops", "--model", "gpt-5.6-sol"],
+        [primary / "start-codex-driver.sh", "devops", "--model", "gpt-5.6-sol"],
         cwd=primary,
         env=env,
     )
@@ -1029,7 +1029,7 @@ def test_real_codex_devops_launcher_refuses_second_live_devops_driver(
         }
     )
     launched = run(
-        [primary / "start-codex-drive.sh", "devops", "--model", "gpt-5.6-sol"],
+        [primary / "start-codex-driver.sh", "devops", "--model", "gpt-5.6-sol"],
         cwd=primary,
         env=env,
     )

--- a/tests/test_fleet_taxonomy_aliases.py
+++ b/tests/test_fleet_taxonomy_aliases.py
@@ -232,7 +232,7 @@ def test_handoff_identity_shell_resolver_unknown_selector_fails_closed(
         "start-gemini.sh",
         "start-grok.sh",
         "start-kimi.sh",
-        "start-codex-drive.sh",
+        "start-codex-driver.sh",
         "start-gemini-drive.sh",
         "start-grok-drive.sh",
         "start-opus-drive.sh",
@@ -261,8 +261,8 @@ def test_launcher_static_selector_wiring(launcher: str) -> None:
     [
         # CI-safe: start-claude.sh parses and validates --epic early before preflight checks or external CLI lookups.
         ("start-claude.sh", "--epic=invalid_selector_xyz", 1),
-        # CI-safe: start-codex-drive.sh validates $1 via launcher_selector_resolve at top of script before exec start-codex.sh.
-        ("start-codex-drive.sh", "invalid_selector_xyz", 2),
+        # CI-safe: start-codex-driver.sh validates $1 via launcher_selector_resolve at top of script before exec start-codex.sh.
+        ("start-codex-driver.sh", "invalid_selector_xyz", 2),
         # CI-safe: start-gemini-drive.sh validates $1 via launcher_selector_resolve at top of script before exec start-gemini.sh.
         ("start-gemini-drive.sh", "invalid_selector_xyz", 2),
         # CI-safe: start-grok-drive.sh validates $1 via launcher_selector_resolve at top of script before exec start-grok.sh.


### PR DESCRIPTION
## What changed
- `git mv start-codex-drive.sh start-codex-driver.sh` (executable bits preserved).
- Updated the header comment usage line in the renamed file.
- Updated all codex-only references in docs and tests.

## Rename sweep evidence
```
$ grep -rE 'start-codex-drive\\.sh' --exclude-dir=.git --exclude-dir=.worktrees . || echo 'ZERO old-name references found'\nZERO old-name references found\n```\n\n## Tests\n```\n$ .venv/bin/python -m pytest tests/test_fleet_taxonomy_aliases.py tests/orchestration/test_thread_restart_e2e.py -q\n\ntests/test_fleet_taxonomy_aliases.py .................................. [ 56%]\n.............                                                            [ 77%]\ntests/orchestration/test_thread_restart_e2e.py ..............            [100%]\n\n============================= 62 passed in 29.02s ==============================\n```\n\n## Smoke\n```\n$ ./start-codex-driver.sh --help\nUsage: start-codex-driver.sh <lane-or-lane.topic> [Codex flags]\nValid lane selectors:\n  infra | harness | infra.fleet-comms\n  devops | infra.devops\n  atlas | practice | atlas.practice\n  hramatka | hramatka.lessons\n  folk | seminars-folk\n  bio | seminars-bio\n  corpus | corpus-channels\n```\n\nOther `-drive` scripts intentionally untouched pending operator approval of the full cutover.\n\nRefs #5935