### PR TITLE
feat(trails): red-CI registry stage 2 — lookup CLI + extraction + aggregation

### DIFF
--- a/agents_extensions/shared/schemas/red-ci-lookup-receipt.v1.schema.json
+++ b/agents_extensions/shared/schemas/red-ci-lookup-receipt.v1.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "red-ci-lookup-receipt.v1",
+  "title": "Red-CI Lookup Receipt v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "status"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "red-ci-lookup-receipt.v1"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "matched",
+        "table-unknown"
+      ]
+    },
+    "reason": {
+      "type": "string",
+      "enum": [
+        "no-match",
+        "ambiguous",
+        "expired-match"
+      ]
+    },
+    "entry_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "retry-once",
+            "note-and-proceed",
+            "stop"
+          ]
+        },
+        "stop_code": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "stop"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "stop_code"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "stop_code"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "registry_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "signature_receipt_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "as_of_epoch": {
+      "type": "number"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "matched"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "entry_id",
+          "action",
+          "registry_sha256",
+          "signature_receipt_sha256",
+          "as_of_epoch"
+        ],
+        "not": {
+          "required": [
+            "reason"
+          ]
+        }
+      },
+      "else": {
+        "required": [
+          "reason"
+        ],
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "entry_id"
+              ]
+            },
+            {
+              "required": [
+                "action"
+              ]
+            },
+            {
+              "required": [
+                "registry_sha256"
+              ]
+            },
+            {
+              "required": [
+                "signature_receipt_sha256"
+              ]
+            },
+            {
+              "required": [
+                "as_of_epoch"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/scripts/config/trails/rb4-red-ci-triage.trail.yaml
+++ b/scripts/config/trails/rb4-red-ci-triage.trail.yaml
@@ -3,11 +3,11 @@
 # bounded-driver trial (per-seat prerequisites in the trails design).
 #
 # DRAFT STATUS: authored against today's substrate; certification waits for T1.4/5.
-# The known-failure-class signature registry does NOT exist yet — the allowlist step
-# is an enforced fail-closed gate (both present-without-lookup and absent STOP as
-# table-unknown), and NO rerun step exists in this draft: the raceless rerun
-# primitive ships with the registry design (v1 cannot express a per-claimant
-# rerun predicate — r3 review). Unknown signatures never retry-until-green.
+# The known-failure-class lookup is a fail-closed gate: an absent registry or
+# structured receipt is table-unknown, and a lookup error stops. NO rerun step exists
+# in this draft: TrailSpec v1 cannot express the per-claimant predicate required by
+# the raceless primitive. A matched retry-once is data that stops for manual handling;
+# unknown signatures never retry-until-green.
 #
 # Anti-pattern guard (RB-2 v0.7.0 discipline, seven-round-reviewed): every command is
 # a real, currently runnable repo command whose OUTPUT SHAPE was captured live
@@ -28,8 +28,8 @@
 #   instead of gh run list --branch (which could pick a newer pending run).
 schema_version: trailspec.v1
 trail_id: rb4-red-ci-triage
-version: "0.4.2"
-title: RB4 Red-CI triage — signature, allowlist, staleness, bounded rerun
+version: "0.4.3"
+title: RB4 Red-CI triage — signature, lookup, and staleness
 seats:
   - grok-daily
   - glm-trial
@@ -177,30 +177,46 @@ steps:
 
   - step_id: allowlist_match
     intent: >-
-      ENFORCED fail-closed lookup (r1 finding: the missing registry must be an
-      execution guard, not narration): the step checks for the registry file itself
-      — scripts/config/trails/red-ci-known-failures.yaml — and with it ABSENT
-      (today's state) every signature is table-unknown and stops as STOP-unknown;
-      the rerun path is mechanically UNREACHABLE until the registry AND its lookup
-      tool land: today BOTH outcomes stop as table-unknown — registry_absent, and
-      registry_present_lookup_unbuilt (a registry file with no lookup tool must not
-      be guessed against; r2 finding: transitions must match the command's actual
-      output vocabulary, and matched routes only arrive with the lookup tool). The
-      table's judgment rows (pre-existing-on-main → note + owning issue;
-      head-specific → fix round) are applied BY THE SUMMONED JUDGMENT from the
-      recorded signature receipt — deliberately not weak-seat routes. The future
-      matched-retry-once path is deliberately NOT drafted as a step: trailspec.v1
-      cannot give a rerun claim a per-claimant predicate (the r3 review proved a
-      losing claimant would read the winner's queued run status), so the raceless
-      rerun primitive ships WITH the registry + lookup tool design, reviewed
-      together — never as unreachable speculative machinery here.
-    command: sh -c 'test -f scripts/config/trails/red-ci-known-failures.yaml && echo registry-present-lookup-unbuilt || echo registry-absent'
+      ENFORCED fail-closed lookup: the checked-in registry and the structured
+      signature receipt are both required. The extraction CLI normalizes the captured
+      job failure into batch_state/rb4-signature-{pr_number}.json; text logs alone are
+      not a matchable receipt. The lookup evaluates every matching entry, records the
+      deterministic as-of instant, and never contacts GitHub itself. Missing input,
+      unknown, ambiguity, expiry, or lookup failure stops. A matched retry-once is
+      only recorded data here — TrailSpec v1 has no retry execution transition.
+    command: |-
+      sh -c '
+        REG=scripts/config/trails/red-ci-known-failures.yaml
+        RECEIPT=batch_state/rb4-signature-{pr_number}.json
+        OUT=batch_state/rb4-lookup-{pr_number}.json
+        SIGNAL=batch_state/rb4-lookup-signal-{pr_number}.txt
+        if [ ! -f "$REG" ] || [ ! -f "$RECEIPT" ]; then
+          RESULT=table-unknown
+        else
+          RUN=$(jq -r ".[0].databaseId" batch_state/rb4-run-{pr_number}.json)
+          REPO=$(gh repo view --json databaseId --jq .databaseId) || RESULT=lookup-failed
+          if [ -n "${REPO:-}" ] && [ "${RESULT:-}" != lookup-failed ]; then
+            AS_OF=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            .venv/bin/python scripts/orchestration/red_ci_known_failures.py lookup \
+              --registry "$REG" --receipt "$RECEIPT" --repository-id "$REPO" \
+              --pr {pr_number} --run-id "$RUN" --as-of "$AS_OF" --output "$OUT" \
+              >/dev/null && RESULT=$(jq -r \
+                "if .status == \"matched\" then \"matched-\" + .action.kind else \"table-unknown\" end" \
+                "$OUT") || RESULT=lookup-failed
+          fi
+        fi
+        printf "%s\n" "$RESULT" > "$SIGNAL"
+        printf "%s\n" "$RESULT"
+      '
     evidence_predicate:
-      command: sh -c 'test -f scripts/config/trails/red-ci-known-failures.yaml && echo registry-present-lookup-unbuilt || echo registry-absent'
-      success_pattern: '^(registry-present-lookup-unbuilt|registry-absent)$'
+      command: sh -c 'cat batch_state/rb4-lookup-signal-{pr_number}.txt'
+      success_pattern: '^(table-unknown|lookup-failed|matched-retry-once|matched-note-and-proceed|matched-stop)$'
     transitions:
-      registry_absent: STOP-unknown
-      registry_present_lookup_unbuilt: STOP-unknown
+      table_unknown: STOP-unknown
+      lookup_failed: STOP-precondition-failed
+      matched_retry_once: STOP-manual-intervention
+      matched_note_and_proceed: back_to_pr_lifecycle
+      matched_stop: STOP-manual-intervention
     kind: table-lookup
     table: red-ci-triage
-    blocked_on: "known-failure-class signature registry + its lookup tool (#5885)"
+    blocked_on: "operator-gated rerun primitive remains out of scope (#5885)"

--- a/scripts/orchestration/red_ci_known_failures.py
+++ b/scripts/orchestration/red_ci_known_failures.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
-"""Red-CI known-failures registry and signature-receipt stage 1 validation module."""
+"""Validate, extract, and deterministically look up red-CI failure signatures."""
 
 from __future__ import annotations
 
+import argparse
+import hashlib
 import json
+import os
 import re
-from datetime import UTC, datetime
+import sys
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -19,9 +25,56 @@ REGISTRY_SCHEMA_PATH = (
 RECEIPT_SCHEMA_PATH = (
     PROJECT_ROOT / "agents_extensions/shared/schemas/red-ci-signature-receipt.v1.schema.json"
 )
+LOOKUP_RECEIPT_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/red-ci-lookup-receipt.v1.schema.json"
+)
 
 HEX_40_RE = re.compile(r"^[0-9a-f]{40}$")
 HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+ANSI_ESCAPE_RE = re.compile(
+    r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))"
+)
+
+_RECEIPT_SOURCE_FIELDS = frozenset(
+    {
+        "repository_id",
+        "repository_name",
+        "pr_number",
+        "run_id",
+        "run_attempt",
+        "head_sha",
+        "job_id",
+        "job_name",
+        "check_id",
+        "check_name",
+        "extraction_version",
+        "timestamp",
+        "raw_signature_lines",
+    }
+)
+
+# Published STOP-code contract. validate_trailspec imports this single source so
+# direct invocation of this lookup module never depends on package import layout.
+VALID_STOP_CODES: set[str] = {
+    "STOP-timeout",
+    "STOP-verdict-timeout",
+    "STOP-contested",
+    "STOP-ci-red",
+    "STOP-lease-expired",
+    "STOP-precondition-failed",
+    "STOP-max-retries-exceeded",
+    "STOP-manual-intervention",
+    "STOP-circuit-breaker",
+    "STOP-concurrency-conflict",
+    "STOP-policy-violation",
+    "STOP-rate-limit",
+    "STOP-unrecoverable-error",
+    "STOP-quota-exceeded",
+    "STOP-stale-head",
+    "STOP-unknown",
+    "STOP-rearm-failed",
+    "STOP-hygiene-failed",
+}
 
 
 class RedCIKnownFailuresValidationError(Exception):
@@ -70,6 +123,22 @@ def _load_schema(path: Path) -> dict[str, Any]:
     return data
 
 
+def _canonical_sha256(data: Mapping[str, Any]) -> str:
+    """Hash semantic JSON data independently of source JSON/YAML formatting."""
+    canonical = json.dumps(
+        data, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def compute_signature_digest(normalized_signature_lines: Sequence[str]) -> str:
+    """Return the canonical SHA-256 binding for already-normalized signature lines."""
+    canonical = json.dumps(
+        list(normalized_signature_lines), ensure_ascii=False, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
 def _parse_iso_instant(val: str | datetime) -> datetime:
     """Parse string or datetime to timezone-aware instant."""
     if isinstance(val, datetime):
@@ -92,10 +161,21 @@ def _parse_iso_instant(val: str | datetime) -> datetime:
     return dt
 
 
+def _epoch_seconds(val: str | datetime) -> float:
+    """Return a timezone-aware timestamp as an epoch value for all comparisons."""
+    return _parse_iso_instant(val).timestamp()
+
+
+def _json_epoch(epoch: float) -> int | float:
+    """Keep whole-second epochs compact while preserving fractional precision."""
+    return int(epoch) if epoch.is_integer() else epoch
+
+
 def load_and_validate_registry(
     path: Path | str,
     *,
     as_of: datetime | str,
+    allow_expired: bool = False,
 ) -> dict[str, Any]:
     """Load and validate a red-CI known-failures registry document against schema and domain rules.
 
@@ -103,7 +183,8 @@ def load_and_validate_registry(
     - Unique entry IDs
     - Anchored-regex enforcement (regex values must start with '^' and end with '$')
     - Timestamp parsing into timezone-aware instants
-    - Expired entry enforcement relative to as_of (hard deadline)
+    - Expired entry enforcement relative to as_of (hard deadline), unless the
+      lookup caller needs to examine expired matches fail-closed
     """
     path_obj = Path(path).resolve()
     data = _load_yaml_or_json(path_obj)
@@ -120,6 +201,7 @@ def load_and_validate_registry(
     # as_of is REQUIRED at this layer (glm F4): the module stays deterministic;
     # wall-clock convenience lives only in the CLI wrapper.
     as_of_dt = _parse_iso_instant(as_of)
+    as_of_epoch = _epoch_seconds(as_of_dt)
 
     seen_ids: set[str] = set()
     entries = data.get("entries", [])
@@ -151,11 +233,6 @@ def load_and_validate_registry(
 
         action = entry.get("action", {})
         if action.get("kind") == "stop":
-            # Lazy import: validate_trailspec imports this module, so a top-level
-            # import here would cycle. The STOP-code contract has ONE home
-            # (validate_trailspec.VALID_STOP_CODES) — never duplicated here.
-            from scripts.orchestration.validate_trailspec import VALID_STOP_CODES
-
             stop_code = action.get("stop_code", "")
             if stop_code not in VALID_STOP_CODES:
                 raise RedCIKnownFailuresValidationError(
@@ -168,8 +245,9 @@ def load_and_validate_registry(
         _parse_iso_instant(governance.get("added_at", ""))
         _parse_iso_instant(governance.get("reviewed_at", ""))
         review_by_dt = _parse_iso_instant(governance.get("review_by", ""))
+        review_by_epoch = _epoch_seconds(review_by_dt)
 
-        if review_by_dt < as_of_dt:
+        if not allow_expired and review_by_epoch < as_of_epoch:
             raise RedCIKnownFailuresValidationError(
                 f"Registry entry '{entry_id}' expired at review_by={review_by_dt.isoformat()} "
                 f"relative to as_of={as_of_dt.isoformat()}"
@@ -184,15 +262,13 @@ def load_and_validate_registry(
         "registry_version": data.get("registry_version"),
         "entries_count": len(entries),
         "as_of": as_of_dt.isoformat(),
+        "as_of_epoch": _json_epoch(as_of_epoch),
         "data": data,
     }
 
 
-def load_and_validate_receipt(path: Path | str) -> dict[str, Any]:
-    """Load and validate a red-CI signature-receipt document against schema and hex constraints."""
-    path_obj = Path(path).resolve()
-    data = _load_yaml_or_json(path_obj)
-
+def validate_receipt_data(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate in-memory receipt data, including its digest/content binding."""
     receipt_schema = _load_schema(RECEIPT_SCHEMA_PATH)
     validator = Draft202012Validator(receipt_schema, format_checker=FormatChecker())
     errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
@@ -214,6 +290,12 @@ def load_and_validate_receipt(path: Path | str) -> dict[str, Any]:
             f"Invalid digest in receipt: '{digest}' (must be 64 lowercase hex)"
         )
 
+    expected_digest = compute_signature_digest(data["normalized_signature_lines"])
+    if digest != expected_digest:
+        raise RedCIKnownFailuresValidationError(
+            "Signature receipt digest does not bind normalized_signature_lines"
+        )
+
     _parse_iso_instant(data.get("timestamp", ""))
 
     return {
@@ -225,3 +307,316 @@ def load_and_validate_receipt(path: Path | str) -> dict[str, Any]:
         "digest": digest,
         "data": data,
     }
+
+
+def load_and_validate_receipt(path: Path | str) -> dict[str, Any]:
+    """Load and validate a red-CI signature-receipt document from JSON or YAML."""
+    return validate_receipt_data(_load_yaml_or_json(Path(path).resolve()))
+
+
+def _normalize_signature_lines(raw_signature_lines: Iterable[str]) -> list[str]:
+    """Strip ANSI and normalize CRLF without altering case or whitespace."""
+    normalized: list[str] = []
+    for raw_line in raw_signature_lines:
+        if not isinstance(raw_line, str):
+            raise RedCIKnownFailuresValidationError(
+                "raw_signature_lines items must all be strings"
+            )
+        clean = ANSI_ESCAPE_RE.sub("", raw_line).replace("\r\n", "\n")
+        normalized.extend(clean.split("\n"))
+    return normalized
+
+
+def extract_signature_receipt(source: Mapping[str, Any]) -> dict[str, Any]:
+    """Build a validated receipt from structured failure metadata and raw lines.
+
+    Extraction is pure and deliberately does not query GitHub. Callers provide the
+    job/check identity captured from the failing run; this function performs only
+    the permitted ANSI/CRLF normalization and binds the resulting lines by SHA-256.
+    """
+    if not isinstance(source, Mapping):
+        raise RedCIKnownFailuresValidationError("Receipt extraction input must be a mapping/dict")
+
+    if not all(isinstance(key, str) for key in source):
+        raise RedCIKnownFailuresValidationError(
+            "Receipt extraction input fields must all be strings"
+        )
+    source_keys = set(source)
+    missing = sorted(_RECEIPT_SOURCE_FIELDS - source_keys)
+    unexpected = sorted(source_keys - _RECEIPT_SOURCE_FIELDS)
+    if missing:
+        raise RedCIKnownFailuresValidationError(
+            f"Receipt extraction input missing required field(s): {', '.join(missing)}"
+        )
+    if unexpected:
+        raise RedCIKnownFailuresValidationError(
+            f"Receipt extraction input has unsupported field(s): {', '.join(unexpected)}"
+        )
+
+    raw_lines = source["raw_signature_lines"]
+    if not isinstance(raw_lines, list):
+        raise RedCIKnownFailuresValidationError("raw_signature_lines must be an array/list")
+
+    normalized_lines = _normalize_signature_lines(raw_lines)
+    receipt = {
+        "schema_version": "red-ci-signature-receipt.v1",
+        **{key: source[key] for key in _RECEIPT_SOURCE_FIELDS - {"raw_signature_lines"}},
+        "normalized_signature_lines": normalized_lines,
+        "digest": compute_signature_digest(normalized_lines),
+    }
+    validate_receipt_data(receipt)
+    return receipt
+
+
+def _line_matcher_matches(line_matcher: Mapping[str, Any], line: str) -> bool:
+    """Evaluate the already-validated exact or full-regex line matcher."""
+    if line_matcher["type"] == "exact":
+        return line == line_matcher["value"]
+    return re.fullmatch(line_matcher["value"], line) is not None
+
+
+def _entry_matches_receipt(entry: Mapping[str, Any], receipt: Mapping[str, Any]) -> bool:
+    """Return whether one entry fully covers one atomic failed-job receipt."""
+    matcher = entry["matcher"]
+    if matcher["check_name"]["exact"] != receipt["check_name"]:
+        return False
+
+    lines = receipt["normalized_signature_lines"]
+    line_matchers = matcher["lines"]
+    required = line_matchers["required"]
+    accepted = line_matchers["accepted"]
+
+    if not all(
+        any(_line_matcher_matches(required_matcher, line) for line in lines)
+        for required_matcher in required
+    ):
+        return False
+
+    return not line_matchers["require_full_coverage"] or all(
+        any(_line_matcher_matches(accepted_matcher, line) for accepted_matcher in accepted)
+        for line in lines
+    )
+
+
+def _entry_is_expired(entry: Mapping[str, Any], as_of_epoch: float) -> bool:
+    """Use epoch comparison so equivalent Z/offset instants behave identically."""
+    return _epoch_seconds(entry["governance"]["review_by"]) < as_of_epoch
+
+
+def validate_lookup_receipt_data(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a generated red-CI lookup receipt against its public schema."""
+    schema = _load_schema(LOOKUP_RECEIPT_SCHEMA_PATH)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        err = errors[0]
+        raise RedCIKnownFailuresValidationError(
+            f"Lookup receipt schema violation: {err.message} at {err.json_path}"
+        )
+    return dict(data)
+
+
+def lookup_known_failure(
+    *,
+    registry_path: Path | str,
+    receipt_path: Path | str,
+    repository_id: str,
+    pr: int,
+    run_id: int,
+    as_of: str | datetime,
+) -> dict[str, Any]:
+    """Purely match one receipt against every eligible registry entry.
+
+    A matching expired entry intentionally takes precedence over active matches:
+    expiry can never silently authorize an action. The returned retry disposition is
+    data only; this module contains no rerun operation.
+    """
+    if not repository_id.strip():
+        raise RedCIKnownFailuresValidationError("CLI repository-id must be non-empty")
+
+    receipt_summary = load_and_validate_receipt(receipt_path)
+    receipt = receipt_summary["data"]
+
+    if str(receipt["repository_id"]) != repository_id:
+        raise RedCIKnownFailuresValidationError(
+            "Receipt repository_id does not equal the CLI repository-id"
+        )
+    if receipt["pr_number"] != pr:
+        raise RedCIKnownFailuresValidationError("Receipt pr_number does not equal the CLI pr")
+    if receipt["run_id"] != run_id:
+        raise RedCIKnownFailuresValidationError("Receipt run_id does not equal the CLI run-id")
+
+    registry_summary = load_and_validate_registry(
+        registry_path, as_of=as_of, allow_expired=True
+    )
+    registry = registry_summary["data"]
+    as_of_epoch = _epoch_seconds(as_of)
+
+    active_matches: list[Mapping[str, Any]] = []
+    expired_matches: list[Mapping[str, Any]] = []
+    for entry in registry["entries"]:
+        if _entry_matches_receipt(entry, receipt):
+            if _entry_is_expired(entry, as_of_epoch):
+                expired_matches.append(entry)
+            else:
+                active_matches.append(entry)
+
+    if expired_matches:
+        result: dict[str, Any] = {
+            "schema_version": "red-ci-lookup-receipt.v1",
+            "status": "table-unknown",
+            "reason": "expired-match",
+        }
+    elif len(active_matches) > 1:
+        result = {
+            "schema_version": "red-ci-lookup-receipt.v1",
+            "status": "table-unknown",
+            "reason": "ambiguous",
+        }
+    elif not active_matches:
+        result = {
+            "schema_version": "red-ci-lookup-receipt.v1",
+            "status": "table-unknown",
+            "reason": "no-match",
+        }
+    else:
+        entry = active_matches[0]
+        result = {
+            "schema_version": "red-ci-lookup-receipt.v1",
+            "status": "matched",
+            "entry_id": entry["id"],
+            "action": entry["action"],
+            "registry_sha256": _canonical_sha256(registry),
+            "signature_receipt_sha256": _canonical_sha256(receipt),
+            "as_of_epoch": _json_epoch(as_of_epoch),
+        }
+    return validate_lookup_receipt_data(result)
+
+
+def aggregate_lookup_results(results: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    """Aggregate atomic lookup data with the red-CI fail-closed precedence rules."""
+    if not results:
+        return {"kind": "stop", "reason": "malformed"}
+
+    action_kinds: list[str] = []
+    for result in results:
+        if not isinstance(result, Mapping):
+            return {"kind": "stop", "reason": "malformed"}
+        if result.get("status") != "matched":
+            reason = result.get("reason")
+            return {
+                "kind": "stop",
+                "reason": reason if isinstance(reason, str) else "malformed",
+            }
+        action = result.get("action")
+        if not isinstance(action, Mapping) or not isinstance(action.get("kind"), str):
+            return {"kind": "stop", "reason": "malformed"}
+        action_kind = action["kind"]
+        if action_kind == "stop":
+            return {"kind": "stop", "reason": "stop"}
+        if action_kind not in {"retry-once", "note-and-proceed"}:
+            return {"kind": "stop", "reason": "malformed"}
+        action_kinds.append(action_kind)
+
+    if "retry-once" in action_kinds:
+        return {"kind": "retry-once"}
+    return {"kind": "note-and-proceed"}
+
+
+def _write_json_output(path: Path, data: Mapping[str, Any]) -> None:
+    """Atomically write a receipt without ever targeting an input file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as output_file:
+            temp_name = output_file.name
+            json.dump(data, output_file, ensure_ascii=False, indent=2, sort_keys=True)
+            output_file.write("\n")
+        os.replace(temp_name, path)
+    except OSError as exc:
+        raise RedCIKnownFailuresValidationError(f"Unable to write output {path}: {exc}") from exc
+    finally:
+        if temp_name is not None:
+            Path(temp_name).unlink(missing_ok=True)
+
+
+def _distinct_output_path(output: Path, *inputs: Path) -> Path:
+    """Reject an output path that would overwrite a registry or receipt input."""
+    resolved_output = output.resolve()
+    if any(resolved_output == input_path.resolve() for input_path in inputs):
+        raise RedCIKnownFailuresValidationError(
+            "Output path must not overwrite a registry, receipt, or extraction input"
+        )
+    return resolved_output
+
+
+def _extract_command(args: argparse.Namespace) -> int:
+    source_path = args.input.resolve()
+    output_path = _distinct_output_path(args.output, source_path)
+    receipt = extract_signature_receipt(_load_yaml_or_json(source_path))
+    _write_json_output(output_path, receipt)
+    return 0
+
+
+def _lookup_command(args: argparse.Namespace) -> int:
+    registry_path = args.registry.resolve()
+    receipt_path = args.receipt.resolve()
+    output_path = _distinct_output_path(args.output, registry_path, receipt_path)
+    result = lookup_known_failure(
+        registry_path=registry_path,
+        receipt_path=receipt_path,
+        repository_id=args.repository_id,
+        pr=args.pr,
+        run_id=args.run_id,
+        as_of=args.as_of,
+    )
+    _write_json_output(output_path, result)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the pure extraction or deterministic lookup CLI without actionable stdout."""
+    parser = argparse.ArgumentParser(
+        description="Extract and look up red-CI known-failure signature receipts."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    extract_parser = subparsers.add_parser(
+        "extract", help="normalize structured failure input into a signature receipt"
+    )
+    extract_parser.add_argument("--input", type=Path, required=True)
+    extract_parser.add_argument("--output", type=Path, required=True)
+    extract_parser.set_defaults(handler=_extract_command)
+
+    lookup_parser = subparsers.add_parser(
+        "lookup", help="look up one signature receipt without any network access"
+    )
+    lookup_parser.add_argument("--registry", type=Path, required=True)
+    lookup_parser.add_argument("--receipt", type=Path, required=True)
+    lookup_parser.add_argument("--repository-id", required=True)
+    lookup_parser.add_argument("--pr", type=int, required=True)
+    lookup_parser.add_argument("--run-id", type=int, required=True)
+    lookup_parser.add_argument("--as-of", required=True)
+    lookup_parser.add_argument("--output", type=Path, required=True)
+    lookup_parser.set_defaults(handler=_lookup_command)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except RedCIKnownFailuresValidationError as exc:
+        print(f"red-CI known-failures error: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"red-CI known-failures I/O error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -14,7 +14,11 @@ from typing import Any
 import yaml
 from jsonschema import Draft202012Validator, FormatChecker
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
 from scripts.orchestration.red_ci_known_failures import (
+    VALID_STOP_CODES,
     RedCIKnownFailuresValidationError,
     load_and_validate_registry,
 )
@@ -35,29 +39,6 @@ DECISION_TABLES_SCHEMA_PATH = (
 DEFAULT_DECISION_TABLES_PATH = (
     PROJECT_ROOT / "scripts/config/trails/decision-tables.v0.yaml"
 )
-
-# Published STOP code contract (embedded constant; pending extraction to contract package)
-VALID_STOP_CODES: set[str] = {
-    "STOP-timeout",
-    "STOP-verdict-timeout",
-    "STOP-contested",
-    "STOP-ci-red",
-    "STOP-lease-expired",
-    "STOP-precondition-failed",
-    "STOP-max-retries-exceeded",
-    "STOP-manual-intervention",
-    "STOP-circuit-breaker",
-    "STOP-concurrency-conflict",
-    "STOP-policy-violation",
-    "STOP-rate-limit",
-    "STOP-unrecoverable-error",
-    "STOP-quota-exceeded",
-    "STOP-stale-head",
-    "STOP-unknown",
-    "STOP-rearm-failed",
-    "STOP-hygiene-failed",
-}
-
 
 class TrailSpecValidationError(Exception):
     """Raised when TrailSpec or StepReceipt validation fails."""

--- a/tests/test_red_ci_known_failures.py
+++ b/tests/test_red_ci_known_failures.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from copy import deepcopy
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -10,9 +13,15 @@ import yaml
 
 from scripts.orchestration.red_ci_known_failures import (
     RedCIKnownFailuresValidationError,
+    aggregate_lookup_results,
+    compute_signature_digest,
+    extract_signature_receipt,
     load_and_validate_receipt,
     load_and_validate_registry,
+    main,
 )
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _get_valid_registry_data() -> dict[str, Any]:
@@ -87,7 +96,9 @@ def _get_valid_receipt_data() -> dict[str, Any]:
         ],
         "extraction_version": "1.0.0",
         "timestamp": "2026-07-28T10:00:00Z",
-        "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "digest": compute_signature_digest(
+            ["FAILED tests/test_cache.py::test_parallel_cache - AssertError"]
+        ),
     }
 
 
@@ -389,3 +400,409 @@ def test_negative_receipt_bad_hex(tmp_path) -> None:
         load_and_validate_receipt(rcpt_path2)
 
     assert "digest" in str(exc_info2.value) or "Signature receipt schema violation" in str(exc_info2.value)
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> Path:
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _lookup_args(
+    registry_path: Path,
+    receipt_path: Path,
+    output_path: Path,
+    *,
+    repository_id: str = "100",
+    pr: int = 1234,
+    run_id: int = 123456789,
+    as_of: str = "2026-07-28T12:00:00Z",
+) -> list[str]:
+    return [
+        "lookup",
+        "--registry",
+        str(registry_path),
+        "--receipt",
+        str(receipt_path),
+        "--repository-id",
+        repository_id,
+        "--pr",
+        str(pr),
+        "--run-id",
+        str(run_id),
+        "--as-of",
+        as_of,
+        "--output",
+        str(output_path),
+    ]
+
+
+def _write_lookup_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    registry_path = _write_json(tmp_path / "registry.json", _get_valid_registry_data())
+    receipt_path = _write_json(tmp_path / "receipt.json", _get_valid_receipt_data())
+    return registry_path, receipt_path
+
+
+def test_extract_signature_receipt_only_strips_ansi_and_normalizes_crlf() -> None:
+    """Extraction preserves case and whitespace while producing a bound digest."""
+    source = {
+        "repository_id": 100,
+        "repository_name": "learn-ukrainian",
+        "pr_number": 1234,
+        "run_id": 123456789,
+        "run_attempt": 1,
+        "head_sha": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4",
+        "job_id": 987654321,
+        "job_name": "test",
+        "check_id": 987654321,
+        "check_name": "CI / Test (pytest)",
+        "extraction_version": "1.0.0",
+        "timestamp": "2026-07-28T10:00:00Z",
+        "raw_signature_lines": [
+            "\x1b[31mFAILED TeSt  keep  spaces\x1b[0m\r\nsecond line",
+        ],
+    }
+
+    receipt = extract_signature_receipt(source)
+
+    assert receipt["normalized_signature_lines"] == [
+        "FAILED TeSt  keep  spaces",
+        "second line",
+    ]
+    assert receipt["digest"] == compute_signature_digest(receipt["normalized_signature_lines"])
+
+
+def test_extract_cli_writes_a_valid_signature_receipt(tmp_path, capsys) -> None:
+    """The receipt CLI is file-only and leaves no actionable stdout."""
+    source = {
+        "repository_id": 100,
+        "repository_name": "learn-ukrainian",
+        "pr_number": 1234,
+        "run_id": 123456789,
+        "run_attempt": 1,
+        "head_sha": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4",
+        "job_id": 987654321,
+        "job_name": "test",
+        "check_id": 987654321,
+        "check_name": "CI / Test (pytest)",
+        "extraction_version": "1.0.0",
+        "timestamp": "2026-07-28T10:00:00Z",
+        "raw_signature_lines": ["FAILED tests/test_cache.py::test_parallel_cache - AssertError"],
+    }
+    input_path = _write_json(tmp_path / "source.json", source)
+    output_path = tmp_path / "receipt.json"
+
+    rc = main(["extract", "--input", str(input_path), "--output", str(output_path)])
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+    assert json.loads(output_path.read_text(encoding="utf-8"))["schema_version"] == "red-ci-signature-receipt.v1"
+
+
+def test_extract_rejects_non_string_source_field_names() -> None:
+    """Malformed YAML mapping keys cannot bypass structured-source validation."""
+    with pytest.raises(RedCIKnownFailuresValidationError, match="fields must all be strings"):
+        extract_signature_receipt({1: "not-a-valid-source"})
+
+
+def test_negative_receipt_digest_must_bind_signature_lines(tmp_path) -> None:
+    """A valid-looking hash for different text cannot authorize a lookup."""
+    data = _get_valid_receipt_data()
+    data["normalized_signature_lines"].append("additional unknown failure")
+    receipt_path = _write_json(tmp_path / "wrong-digest.json", data)
+
+    with pytest.raises(RedCIKnownFailuresValidationError, match="does not bind"):
+        load_and_validate_receipt(receipt_path)
+
+
+def test_lookup_cli_matched_writes_quoted_receipt(tmp_path, capsys) -> None:
+    """Exit 0 writes the exact matched receipt contract, not stdout action data."""
+    registry_path, receipt_path = _write_lookup_inputs(tmp_path)
+    output_path = tmp_path / "lookup.json"
+
+    rc = main(_lookup_args(registry_path, receipt_path, output_path))
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+    lookup_receipt = json.loads(output_path.read_text(encoding="utf-8"))
+    assert lookup_receipt["status"] == "matched"
+    assert lookup_receipt["entry_id"] == "pytest-cache-race"
+    assert lookup_receipt["action"] == {"kind": "retry-once"}
+    assert lookup_receipt["as_of_epoch"] == 1785240000
+
+
+def test_lookup_cli_no_match_is_successful_table_unknown(tmp_path, capsys) -> None:
+    """Exit 0 is also correct for a valid no-match receipt."""
+    registry_path, receipt_path = _write_lookup_inputs(tmp_path)
+    receipt = _get_valid_receipt_data()
+    receipt["check_name"] = "CI / unrelated"
+    _write_json(receipt_path, receipt)
+    output_path = tmp_path / "lookup.json"
+
+    rc = main(_lookup_args(registry_path, receipt_path, output_path))
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+    assert json.loads(output_path.read_text(encoding="utf-8")) == {
+        "reason": "no-match",
+        "schema_version": "red-ci-lookup-receipt.v1",
+        "status": "table-unknown",
+    }
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        pytest.param(
+            lambda registry, receipt: registry.clear(), id="malformed-registry"
+        ),
+        pytest.param(
+            lambda registry, receipt: receipt.update({"schema_version": "receipt.v2"}),
+            id="unsupported-receipt-schema",
+        ),
+        pytest.param(
+            lambda registry, receipt: registry["entries"][0]["matcher"]["lines"][
+                "required"
+            ][0].update({"value": "FAILED unanchored"}),
+            id="unsafe-regex",
+        ),
+    ],
+)
+def test_lookup_cli_invalid_inputs_fail_nonzero_without_stdout(
+    tmp_path, capsys, mutation
+) -> None:
+    """Malformed, unsupported, and unsafe input never yields actionable stdout."""
+    registry = _get_valid_registry_data()
+    receipt = _get_valid_receipt_data()
+    mutation(registry, receipt)
+    registry_path = _write_json(tmp_path / "registry.json", registry)
+    receipt_path = _write_json(tmp_path / "receipt.json", receipt)
+    output_path = tmp_path / "lookup.json"
+
+    rc = main(_lookup_args(registry_path, receipt_path, output_path))
+
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert captured.out == ""
+    assert captured.err.startswith("red-CI known-failures error:")
+    assert not output_path.exists()
+
+
+def test_lookup_cli_identity_mismatch_fails_nonzero_without_stdout(tmp_path, capsys) -> None:
+    """A receipt for another PR cannot be reused against this lookup identity."""
+    registry_path, receipt_path = _write_lookup_inputs(tmp_path)
+    output_path = tmp_path / "lookup.json"
+
+    rc = main(_lookup_args(registry_path, receipt_path, output_path, pr=9999))
+
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert captured.out == ""
+    assert "does not equal the CLI pr" in captured.err
+    assert not output_path.exists()
+
+
+def test_lookup_cli_empty_repository_identity_fails_nonzero_without_stdout(tmp_path, capsys) -> None:
+    """An empty identity must not compare equal to a malformed receipt value."""
+    registry_path, receipt_path = _write_lookup_inputs(tmp_path)
+    output_path = tmp_path / "lookup.json"
+
+    rc = main(
+        _lookup_args(registry_path, receipt_path, output_path, repository_id="   ")
+    )
+
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert captured.out == ""
+    assert "repository-id must be non-empty" in captured.err
+    assert not output_path.exists()
+
+
+def test_lookup_cli_io_failure_is_nonzero_without_stdout(tmp_path, capsys) -> None:
+    """Output failures cannot leave a caller with an implied action."""
+    registry_path, receipt_path = _write_lookup_inputs(tmp_path)
+    non_directory = tmp_path / "not-a-directory"
+    non_directory.write_text("file", encoding="utf-8")
+
+    rc = main(_lookup_args(registry_path, receipt_path, non_directory / "lookup.json"))
+
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert captured.out == ""
+    assert "I/O error" in captured.err
+
+
+def test_lookup_ambiguous_entries_never_select_by_file_order(tmp_path) -> None:
+    """Two active matches must remain table-unknown regardless of entry order."""
+    registry = _get_valid_registry_data()
+    second_entry = deepcopy(registry["entries"][0])
+    second_entry["id"] = "pytest-cache-race-second"
+    registry["entries"].append(second_entry)
+    registry_path = _write_json(tmp_path / "registry.json", registry)
+    receipt_path = _write_json(tmp_path / "receipt.json", _get_valid_receipt_data())
+    output_path = tmp_path / "lookup.json"
+
+    assert main(_lookup_args(registry_path, receipt_path, output_path)) == 0
+    assert json.loads(output_path.read_text(encoding="utf-8"))["reason"] == "ambiguous"
+
+
+def test_lookup_expired_match_overrides_active_overlap(tmp_path) -> None:
+    """An expired overlap blocks a current matching action instead of authorizing it."""
+    registry = _get_valid_registry_data()
+    expired_entry = deepcopy(registry["entries"][0])
+    expired_entry["id"] = "expired-pytest-cache-race"
+    expired_entry["governance"]["review_by"] = "2026-07-01T00:00:00Z"
+    registry["entries"].append(expired_entry)
+    registry_path = _write_json(tmp_path / "registry.json", registry)
+    receipt_path = _write_json(tmp_path / "receipt.json", _get_valid_receipt_data())
+    output_path = tmp_path / "lookup.json"
+
+    assert main(_lookup_args(registry_path, receipt_path, output_path)) == 0
+    lookup_receipt = json.loads(output_path.read_text(encoding="utf-8"))
+    assert lookup_receipt["status"] == "table-unknown"
+    assert lookup_receipt["reason"] == "expired-match"
+
+
+def test_lookup_ignores_an_expired_entry_that_does_not_match(tmp_path) -> None:
+    """An expired unrelated entry is registry hygiene for CI, not a false match."""
+    registry = _get_valid_registry_data()
+    registry["entries"][0]["governance"]["review_by"] = "2026-07-01T00:00:00Z"
+    registry_path = _write_json(tmp_path / "registry.json", registry)
+    receipt = _get_valid_receipt_data()
+    receipt["check_name"] = "CI / unrelated"
+    receipt_path = _write_json(tmp_path / "receipt.json", receipt)
+    output_path = tmp_path / "lookup.json"
+
+    assert main(_lookup_args(registry_path, receipt_path, output_path)) == 0
+    assert json.loads(output_path.read_text(encoding="utf-8"))["reason"] == "no-match"
+
+
+@pytest.mark.parametrize(
+    ("action", "expected"),
+    [
+        pytest.param({"kind": "note-and-proceed"}, {"kind": "note-and-proceed"}),
+        pytest.param(
+            {"kind": "stop", "stop_code": "STOP-manual-intervention"},
+            {"kind": "stop", "stop_code": "STOP-manual-intervention"},
+        ),
+    ],
+)
+def test_lookup_returns_registered_actions_only_as_data(tmp_path, action, expected) -> None:
+    """Non-retry actions remain receipt data; lookup never executes them."""
+    registry = _get_valid_registry_data()
+    registry["entries"][0]["action"] = action
+    registry_path = _write_json(tmp_path / "registry.json", registry)
+    receipt_path = _write_json(tmp_path / "receipt.json", _get_valid_receipt_data())
+    output_path = tmp_path / "lookup.json"
+
+    assert main(_lookup_args(registry_path, receipt_path, output_path)) == 0
+    assert json.loads(output_path.read_text(encoding="utf-8"))["action"] == expected
+
+
+def test_direct_lookup_cli_handles_a_stop_action_without_stdout(tmp_path) -> None:
+    """The documented script-path CLI has no hidden validator import dependency."""
+    registry = _get_valid_registry_data()
+    registry["entries"][0]["action"] = {
+        "kind": "stop",
+        "stop_code": "STOP-manual-intervention",
+    }
+    registry_path = _write_json(tmp_path / "registry.json", registry)
+    receipt_path = _write_json(tmp_path / "receipt.json", _get_valid_receipt_data())
+    output_path = tmp_path / "lookup.json"
+
+    completed = subprocess.run(
+        [
+            str(PROJECT_ROOT / ".venv/bin/python"),
+            str(PROJECT_ROOT / "scripts/orchestration/red_ci_known_failures.py"),
+            *_lookup_args(registry_path, receipt_path, output_path),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout == ""
+    assert completed.stderr == ""
+    assert json.loads(output_path.read_text(encoding="utf-8"))["action"] == registry["entries"][0]["action"]
+
+
+def test_lookup_mixed_offset_expiry_never_uses_lexicographic_order(tmp_path) -> None:
+    """The same instant in Z/+02:00 forms must detect expiry by epoch value."""
+    registry = _get_valid_registry_data()
+    registry["entries"][0]["governance"]["review_by"] = "2026-07-28T12:00:00+02:00"
+    registry_path = _write_json(tmp_path / "registry.json", registry)
+    receipt_path = _write_json(tmp_path / "receipt.json", _get_valid_receipt_data())
+    output_path = tmp_path / "lookup.json"
+
+    assert (
+        main(
+            _lookup_args(
+                registry_path,
+                receipt_path,
+                output_path,
+                as_of="2026-07-28T11:00:00Z",
+            )
+        )
+        == 0
+    )
+    assert json.loads(output_path.read_text(encoding="utf-8"))["reason"] == "expired-match"
+
+
+def test_lookup_full_coverage_rejects_an_additional_unknown_failure(tmp_path) -> None:
+    """An accepted familiar line cannot hide an unknown additional failure line."""
+    registry_path = _write_json(tmp_path / "registry.json", _get_valid_registry_data())
+    receipt = _get_valid_receipt_data()
+    receipt["normalized_signature_lines"].append("ERROR unknown additional failure")
+    receipt["digest"] = compute_signature_digest(receipt["normalized_signature_lines"])
+    receipt_path = _write_json(tmp_path / "receipt.json", receipt)
+    output_path = tmp_path / "lookup.json"
+
+    assert main(_lookup_args(registry_path, receipt_path, output_path)) == 0
+    assert json.loads(output_path.read_text(encoding="utf-8"))["reason"] == "no-match"
+
+
+@pytest.mark.parametrize(
+    ("results", "expected"),
+    [
+        pytest.param([], {"kind": "stop", "reason": "malformed"}, id="empty"),
+        pytest.param(
+            [{"status": "table-unknown", "reason": "no-match"}],
+            {"kind": "stop", "reason": "no-match"},
+            id="unknown",
+        ),
+        pytest.param(
+            [{"status": "table-unknown", "reason": "ambiguous"}],
+            {"kind": "stop", "reason": "ambiguous"},
+            id="ambiguous",
+        ),
+        pytest.param(
+            [{"status": "table-unknown", "reason": "expired-match"}],
+            {"kind": "stop", "reason": "expired-match"},
+            id="expired-match",
+        ),
+        pytest.param(
+            [{"status": "matched", "action": {"kind": "stop"}}],
+            {"kind": "stop", "reason": "stop"},
+            id="stop-action",
+        ),
+        pytest.param(
+            [
+                {"status": "matched", "action": {"kind": "note-and-proceed"}},
+                {"status": "matched", "action": {"kind": "retry-once"}},
+            ],
+            {"kind": "retry-once"},
+            id="retry-once-dominates-notes",
+        ),
+        pytest.param(
+            [
+                {"status": "matched", "action": {"kind": "note-and-proceed"}},
+                {"status": "matched", "action": {"kind": "note-and-proceed"}},
+            ],
+            {"kind": "note-and-proceed"},
+            id="all-notes",
+        ),
+    ],
+)
+def test_aggregate_lookup_results_is_fail_closed(results, expected) -> None:
+    """Aggregation preserves the adopted stop/retry/note precedence exactly."""
+    assert aggregate_lookup_results(results) == expected

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -292,10 +292,22 @@ def test_negative_decision_tables_unknown_stop_code() -> None:
 
 
 _RB1_PATH = _TRAILS_DIR / "rb1-cold-start.trail.yaml"
+_RB4_PATH = _TRAILS_DIR / "rb4-red-ci-triage.trail.yaml"
 
 
 def _get_rb1_data() -> dict[str, Any]:
     return yaml.safe_load(_RB1_PATH.read_text(encoding="utf-8"))
+
+
+def test_rb4_lookup_routes_never_make_a_rerun_reachable() -> None:
+    """Stage 2 may return retry data but must not execute or route a rerun."""
+    spec = yaml.safe_load(_RB4_PATH.read_text(encoding="utf-8"))
+    lookup_step = next(step for step in spec["steps"] if step["step_id"] == "allowlist_match")
+    commands = "\n".join(step["command"] for step in spec["steps"])
+
+    assert "red_ci_known_failures.py lookup" in lookup_step["command"]
+    assert lookup_step["transitions"]["matched_retry_once"] == "STOP-manual-intervention"
+    assert "gh run rerun" not in commands
 
 
 @pytest.mark.parametrize("trail_path", _ALL_SHIPPED_TRAILS, ids=lambda p: p.stem)


### PR DESCRIPTION
## Summary

- Adds pure structured extraction into `red-ci-signature-receipt.v1`, including ANSI/CRLF-only normalization and a content-bound digest.
- Adds the deterministic, network-free `lookup` CLI and `red-ci-lookup-receipt.v1` schema. Receipt repository/PR/run identity is enforced exactly.
- Evaluates every registry entry; ambiguous and expired overlaps return `table-unknown`, with epoch-based timestamps.
- Adds fail-closed multi-failure aggregation. `retry-once` remains returned data only.
- Updates RB-4 to invoke lookup while routing every retry result to `STOP-manual-intervention`; no rerun command is reachable.

## Contract evidence

- `.venv/bin/python -m pytest tests/test_red_ci_known_failures.py tests/test_validate_trailspec.py -q` → `83 passed in 1.85s`
- `.venv/bin/ruff check scripts/orchestration/red_ci_known_failures.py scripts/orchestration/validate_trailspec.py tests/test_red_ci_known_failures.py tests/test_validate_trailspec.py` → `All checks passed!`
- Direct lookup receipt: `{"action":{"kind":"retry-once"},"as_of_epoch":1785240000,"entry_id":"pytest-cache-race",...,"status":"matched"}`
- `validate_trailspec.py --spec ...rb4-red-ci-triage.trail.yaml --tables ...decision-tables.v0.yaml --json` → `"version": "0.4.3"` and `"allowlist_match": "red-ci-triage"`.
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged` → `OPSEC check passed. Zero leaks detected.`

Refs #5885