### PR TITLE
feat(launchers): start-codex-driver.sh --governor mode (Sol supervision prompt, #5945)

### DIFF
--- a/start-codex-driver.sh
+++ b/start-codex-driver.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Codex / gpt-5.6-terra in DRIVER mode for an allowlisted lane selector.
-#   ./start-codex-driver.sh <lane-or-lane.topic> [extra flags]
+# Codex driver launcher (sustained driver or bounded governor cycle).
+#   Sustained: ./start-codex-driver.sh <lane-or-lane.topic> [extra flags]
+#   Governor:  ./start-codex-driver.sh --governor <lane-or-lane.topic|AUTO> [extra flags]
 # Which epic routes to which model? -> docs/runbooks/epic-orchestrator-roster.md
 # Thin wrapper over start-codex.sh. The driver should load the `drive-epic` skill.
 set -euo pipefail
@@ -9,22 +10,64 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$ROOT/scripts/lib/handoff_identity.sh"
 usage() {
   echo "Usage: $(basename "$0") <lane-or-lane.topic> [Codex flags]"
+  echo "       $(basename "$0") --governor <lane-or-lane.topic|AUTO> [Codex flags]"
   launcher_selector_help
 }
 if [ $# -lt 1 ]; then
   usage >&2
   exit 2
 fi
+
+MODE="default"
+case "$1" in
+  --help|--help-launcher|-h)
+    usage
+    exit 0
+    ;;
+  --governor)
+    MODE="governor"
+    shift
+    ;;
+esac
+
+if [ $# -lt 1 ]; then
+  usage >&2
+  exit 2
+fi
+
 case "$1" in
   --help|--help-launcher|-h)
     usage
     exit 0
     ;;
 esac
+
 SELECTOR="$1"; shift
-if ! launcher_selector_resolve "$SELECTOR" >/dev/null; then
-  echo "Error: unknown lane selector '$SELECTOR'." >&2
-  launcher_selector_help >&2
-  exit 2
+
+if [ "$MODE" = "governor" ]; then
+  if [ "$SELECTOR" != "AUTO" ]; then
+    if ! launcher_selector_resolve "$SELECTOR" >/dev/null; then
+      echo "Error: unknown lane selector '$SELECTOR'." >&2
+      launcher_selector_help >&2
+      exit 2
+    fi
+  fi
+  unset SESSION_EPIC
+  PROMPT="Follow agents_extensions/shared/prompts/dynamic-area-epic-fleet-governor.md for one bounded supervision cycle. TARGET=$SELECTOR GOAL=AUTO"
+  if [ "${CODEX_DRIVER_DRY_RUN:-0}" = "1" ]; then
+    echo "CODEX_DRIVER_DRY_RUN=1: would exec $ROOT/start-codex.sh --model gpt-5.6-sol \"$PROMPT\" ${*:-}"
+    exit 0
+  fi
+  exec "$ROOT/start-codex.sh" --model gpt-5.6-sol "$PROMPT" "$@"
+else
+  if ! launcher_selector_resolve "$SELECTOR" >/dev/null; then
+    echo "Error: unknown lane selector '$SELECTOR'." >&2
+    launcher_selector_help >&2
+    exit 2
+  fi
+  if [ "${CODEX_DRIVER_DRY_RUN:-0}" = "1" ]; then
+    echo "CODEX_DRIVER_DRY_RUN=1: would exec $ROOT/start-codex.sh --epic $SELECTOR ${*:-}"
+    exit 0
+  fi
+  exec "$ROOT/start-codex.sh" --epic "$SELECTOR" "$@"
 fi
-exec "$ROOT/start-codex.sh" --epic "$SELECTOR" "$@"

--- a/start-codex-driver.sh
+++ b/start-codex-driver.sh
@@ -55,6 +55,9 @@ if [ "$MODE" = "governor" ]; then
   unset SESSION_EPIC
   PROMPT="Follow agents_extensions/shared/prompts/dynamic-area-epic-fleet-governor.md for one bounded supervision cycle. TARGET=$SELECTOR GOAL=AUTO"
   if [ "${CODEX_DRIVER_DRY_RUN:-0}" = "1" ]; then
+    # SESSION_EPIC is echoed so tests can PROVE the lease-claiming path is off
+    # (review finding: the unset guard was not observable, so its test was vacuous).
+    echo "CODEX_DRIVER_DRY_RUN=1: SESSION_EPIC=${SESSION_EPIC:-<unset>}"
     echo "CODEX_DRIVER_DRY_RUN=1: would exec $ROOT/start-codex.sh --model gpt-5.6-sol \"$PROMPT\" ${*:-}"
     exit 0
   fi

--- a/tests/test_start_codex_driver.py
+++ b/tests/test_start_codex_driver.py
@@ -55,6 +55,23 @@ def test_governor_mode_pins_model_unsets_epic_and_passes_prompt() -> None:
     assert "--epic" not in res.stdout
     assert "dynamic-area-epic-fleet-governor.md" in res.stdout
     assert "TARGET=devops GOAL=AUTO" in res.stdout
+    # Load-bearing guard: an ambient SESSION_EPIC must be UNSET before exec so the
+    # governor never claims the epic-driver lease. The dry-run echoes the resolved
+    # value precisely so removing the `unset` line fails this assertion.
+    assert "SESSION_EPIC=<unset>" in res.stdout
+    assert "should_be_unset" not in res.stdout
+
+
+def test_governor_help_flag_after_governor_shows_usage() -> None:
+    res = _run_driver("--governor", "--help")
+    assert res.returncode == 0, res.stderr
+    assert "Usage:" in res.stdout
+
+
+def test_bare_help_flag_shows_usage() -> None:
+    res = _run_driver("--help")
+    assert res.returncode == 0, res.stderr
+    assert "Usage:" in res.stdout
 
 
 def test_governor_mode_auto_selector_bypasses_validation() -> None:

--- a/tests/test_start_codex_driver.py
+++ b/tests/test_start_codex_driver.py
@@ -1,0 +1,80 @@
+"""Contract tests for start-codex-driver.sh (sustained driver vs --governor mode)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LAUNCHER = _REPO_ROOT / "start-codex-driver.sh"
+
+
+def _clean_environ() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _run_driver(
+    *arguments: str,
+    env_override: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = _clean_environ()
+    env["CODEX_DRIVER_DRY_RUN"] = "1"
+    if env_override:
+        env.update(env_override)
+    return subprocess.run(
+        ["bash", str(_LAUNCHER), *arguments],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_default_mode_forwards_epic_without_model_pin() -> None:
+    res = _run_driver("devops")
+    assert res.returncode == 0, res.stderr
+    assert "would exec" in res.stdout
+    assert "--epic devops" in res.stdout
+    assert "--model" not in res.stdout
+
+
+def test_default_mode_forwards_extra_flags() -> None:
+    res = _run_driver("atlas", "--verbose", "--foo=bar")
+    assert res.returncode == 0, res.stderr
+    assert "--epic atlas" in res.stdout
+    assert "--verbose --foo=bar" in res.stdout
+
+
+def test_governor_mode_pins_model_unsets_epic_and_passes_prompt() -> None:
+    res = _run_driver("--governor", "devops", env_override={"SESSION_EPIC": "should_be_unset"})
+    assert res.returncode == 0, res.stderr
+    assert "would exec" in res.stdout
+    assert "--model gpt-5.6-sol" in res.stdout
+    assert "--epic" not in res.stdout
+    assert "dynamic-area-epic-fleet-governor.md" in res.stdout
+    assert "TARGET=devops GOAL=AUTO" in res.stdout
+
+
+def test_governor_mode_auto_selector_bypasses_validation() -> None:
+    res = _run_driver("--governor", "AUTO")
+    assert res.returncode == 0, res.stderr
+    assert "--model gpt-5.6-sol" in res.stdout
+    assert "TARGET=AUTO GOAL=AUTO" in res.stdout
+
+
+def test_governor_mode_missing_selector_exits_2() -> None:
+    res = _run_driver("--governor")
+    assert res.returncode == 2
+    assert "Usage:" in res.stderr
+
+
+def test_unknown_selector_fails_in_default_and_governor_modes() -> None:
+    res_def = _run_driver("unknown_selector_xyz")
+    assert res_def.returncode == 2
+    assert "Error: unknown lane selector 'unknown_selector_xyz'." in res_def.stderr
+
+    res_gov = _run_driver("--governor", "unknown_selector_xyz")
+    assert res_gov.returncode == 2
+    assert "Error: unknown lane selector 'unknown_selector_xyz'." in res_gov.stderr


### PR DESCRIPTION
Refs #5935

## Overview
Governor mode deliberately claims no epic-driver lease per the prompt's own contract.

## Modes Summary
| Mode | Command Line | Selector Validation | Model Pin | Epic Lease (`SESSION_EPIC`) | Invocation Prompt |
| --- | --- | --- | --- | --- | --- |
| Sustained Driver (Default) | `./start-codex-driver.sh <selector> [flags]` | Validated via `launcher_selector_resolve` | Unpinned | Set (`--epic <selector>`) | None |
| Bounded Governor | `./start-codex-driver.sh --governor <selector\|AUTO> [flags]` | Validated (`AUTO` bypasses validation) | `gpt-5.6-sol` | Unset (No `--epic` passed) | `Follow agents_extensions/shared/prompts/dynamic-area-epic-fleet-governor.md for one bounded supervision cycle. TARGET=<selector> GOAL=AUTO` |

## Evidence

### Pytest
```text
tests/test_start_codex_driver.py::test_default_mode_forwards_epic_without_model_pin PASSED [  1%]
tests/test_start_codex_driver.py::test_default_mode_forwards_extra_flags PASSED [  3%]
tests/test_start_codex_driver.py::test_governor_mode_pins_model_unsets_epic_and_passes_prompt PASSED [  5%]
tests/test_start_codex_driver.py::test_governor_mode_auto_selector_bypasses_validation PASSED [  7%]
tests/test_start_codex_driver.py::test_governor_mode_missing_selector_exits_2 PASSED [  9%]
tests/test_start_codex_driver.py::test_unknown_selector_fails_in_default_and_governor_modes PASSED [ 11%]
tests/test_fleet_taxonomy_aliases.py ... PASSED
======================== 54 passed, 2 warnings in 0.89s ========================
```

### Ruff Check
```text
All checks passed!
```
