### PR TITLE
fix(practice): contain flashcard text inside card

### DIFF
--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -397,6 +397,9 @@ const frontmatter = {
   }
 
   :global(.lexicon-practice-stage .flashcard) {
+    width: 100%;
+    max-width: 100%;
+    height: 300px;
     min-height: 300px;
   }
 
@@ -406,11 +409,26 @@ const frontmatter = {
     border-radius: 18px;
   }
 
+  :global(.lexicon-practice-stage .flashcard-front),
+  :global(.lexicon-practice-stage .flashcard-back) {
+    box-sizing: border-box;
+    min-height: 300px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: clamp(1rem, 4vw, 2rem);
+  }
 
   :global(.lexicon-practice-stage .flashcard-word) {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
     color: var(--lu-text);
-    font-size: clamp(2.2rem, 6vw, 3.4rem);
+    font-size: clamp(1.35rem, 4.2vw, 2.4rem);
     font-weight: 900;
+    line-height: 1.15;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    text-align: center;
   }
 
   :global(.rating-bar) {


### PR DESCRIPTION
## Summary
- make practice flashcards a 300px contained session card
- contain both faces and allow long headwords to wrap at a readable size

## Verification
- `npx vitest run tests/unit/k3-chrome-locale.test.ts`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`

## Manual repro
At 360px and desktop widths, open `/words-of-the-day/practice/?lemmaId=%D1%81%D0%BF%D1%80%D0%B0%D0%B2%D0%B5%D0%B4%D0%BB%D0%B8%D0%B2%D1%96%D1%81%D1%82%D1%8C`, choose Flashcards, and confirm the headword stays within the card while the rating controls remain available.

Full `astro check` is currently blocked by unrelated baseline type errors outside this change.