### PR TITLE
fix(atlas): local practice refresh after admit (API + runtime export)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,8 +419,13 @@ data/lexicon/grow_candidates.json
 data/lexicon/grow_needs_review.json
 data/lexicon/needs-review-triage.json
 data/lexicon/needs-review-triage-summary.md
-# Full Alona v5 admission evidence is regenerated locally from the private
-# curated JSONL.  Keep the recipe and fixture in git, not the 1,029-row output.
+# Full curated v5 admission evidence is regenerated locally from private input.
+# Keep the recipe and fixture in git, not the generated output.
+data/lexicon/curated-v5-admission-seed.json
+data/lexicon/curated-v5-practice-seed.json
+data/lexicon/curated-v5-admission-report.json
+data/lexicon/curated-v5-grow-candidates.json
+# Retain the prior output paths for one transition cycle.
 data/lexicon/alona-v5-atlas-admission-seed.json
 data/lexicon/alona-v5-practice-seed.json
 data/lexicon/alona-v5-atlas-admission-report.json

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,37 @@
 PYTHON ?= .venv/bin/python
 
-ALONA_V5_INPUT ?= .claude/atlas-epic/plans/alona-truth/v5-curated-with-provenance.jsonl
-ALONA_V5_DIR ?= data/lexicon
-ALONA_V5_PUBLIC_SEED := $(ALONA_V5_DIR)/alona-v5-atlas-admission-seed.json
-ALONA_V5_CANDIDATES := $(ALONA_V5_DIR)/alona-v5-grow-candidates.json
-ALONA_V5_PRACTICE_SEED := $(ALONA_V5_DIR)/alona-v5-practice-seed.json
-ALONA_V5_REPORT := $(ALONA_V5_DIR)/alona-v5-atlas-admission-report.json
+CURATED_SEED_INPUT ?= .claude/atlas-epic/plans/alona-truth/v5-curated-with-provenance.jsonl
+CURATED_SEED_DIR ?= data/lexicon
+CURATED_SEED_PUBLIC_SEED := $(CURATED_SEED_DIR)/curated-v5-admission-seed.json
+CURATED_SEED_CANDIDATES := $(CURATED_SEED_DIR)/curated-v5-grow-candidates.json
+CURATED_SEED_PRACTICE_SEED := $(CURATED_SEED_DIR)/curated-v5-practice-seed.json
+CURATED_SEED_REPORT := $(CURATED_SEED_DIR)/curated-v5-admission-report.json
 
-.PHONY: alona-v5-admit atlas atlas-publish practice-deck practice-deck-publish open-dataset open-dataset-publish
-alona-v5-admit:
-	@test -f "$(ALONA_V5_INPUT)" || { echo "missing private Alona v5 input: $(ALONA_V5_INPUT)" >&2; exit 2; }
-	$(PYTHON) -m scripts.lexicon.alona_v5_atlas_admission --input "$(ALONA_V5_INPUT)" --public-seed-out "$(ALONA_V5_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --candidates-out "$(ALONA_V5_CANDIDATES)"
-	$(PYTHON) -m scripts.lexicon.promote_grow_candidates --candidates "$(ALONA_V5_CANDIDATES)" --allow-preexisting-conformance --write
+.PHONY: atlas-practice-api-hydrate atlas-export-runtime atlas-local-practice-refresh practice-admit-curated-seed atlas atlas-publish practice-deck practice-deck-publish open-dataset open-dataset-publish
+
+# Refresh practice JSON API copies + /atlas runtime for local/dev word-page CTA.
+atlas-practice-api-hydrate:
+	cd site && node --experimental-strip-types ./scripts/hydrate-lexicon-api-shards.ts
+
+atlas-export-runtime:
+	$(PYTHON) -m scripts.atlas.export_runtime_shards \
+	  --db data/atlas.db \
+	  --out-dir site/public \
+	  --base-path atlas \
+	  --deck-dir site/public/lexicon \
+	  --verify
+
+atlas-local-practice-refresh: atlas-practice-api-hydrate atlas-export-runtime
+
+practice-admit-curated-seed:
+	@test -f "$(CURATED_SEED_INPUT)" || { echo "missing private curated seed input" >&2; exit 2; }
+	$(PYTHON) -m scripts.lexicon.curated_seed_atlas_admission --input "$(CURATED_SEED_INPUT)" --public-seed-out "$(CURATED_SEED_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --candidates-out "$(CURATED_SEED_CANDIDATES)"
+	$(PYTHON) -m scripts.lexicon.promote_grow_candidates --candidates "$(CURATED_SEED_CANDIDATES)" --allow-preexisting-conformance --write
 	$(PYTHON) scripts/lexicon/enrich_manifest.py --write
-	$(PYTHON) -m scripts.lexicon.alona_v5_atlas_admission --input "$(ALONA_V5_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --practice-seed-out "$(ALONA_V5_PRACTICE_SEED)" --report-out "$(ALONA_V5_REPORT)"
+	$(PYTHON) -m scripts.lexicon.curated_seed_atlas_admission --input "$(CURATED_SEED_PUBLIC_SEED)" --manifest site/src/data/lexicon-manifest.json --practice-seed-out "$(CURATED_SEED_PRACTICE_SEED)" --report-out "$(CURATED_SEED_REPORT)"
 	npm --prefix site run atlas:build-db
-	$(PYTHON) scripts/audit/generate_practice_deck.py --practice-seed "$(ALONA_V5_PRACTICE_SEED)"
+	$(PYTHON) scripts/audit/generate_practice_deck.py --practice-seed "$(CURATED_SEED_PRACTICE_SEED)"
+	$(MAKE) atlas-local-practice-refresh
 
 atlas:
 	$(PYTHON) -m scripts.lexicon.build_data_manifest

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -2880,7 +2880,7 @@ def read_practice_seed(path: Path) -> list[dict[str, Any]]:
     a CEFR level.
     """
     payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict) or payload.get("schema") != "alona-v5-practice-seed-v1":
+    if not isinstance(payload, dict) or payload.get("schema") != "curated-v5-practice-seed-v1":
         raise ValueError(f"unsupported practice seed schema: {path}")
     entries = payload.get("entries")
     if not isinstance(entries, list) or not entries:

--- a/scripts/lexicon/curated_seed_atlas_admission.py
+++ b/scripts/lexicon/curated_seed_atlas_admission.py
@@ -1,4 +1,4 @@
-"""Prepare and verify the public Atlas + Practice admission for Alona v5.
+"""Prepare and verify the public Atlas + Practice admission for curated v5.
 
 The operator-curated v5 JSONL is private task input. This command emits a
 public replay seed, derives only missing Atlas candidates through the existing
@@ -24,8 +24,8 @@ from scripts.lexicon.build_data_manifest import _lemma_key, _slug_for_url
 from scripts.lexicon.grow_lexicon_from_content import _vesum_pos
 from scripts.sync.promote_module import _write_atomically
 
-PRACTICE_SCHEMA = "alona-v5-practice-seed-v1"
-PUBLIC_SCHEMA = "alona-v5-atlas-admission-seed-v1"
+PRACTICE_SCHEMA = "curated-v5-practice-seed-v1"
+PUBLIC_SCHEMA = "curated-v5-admission-seed-v1"
 
 
 def _text(value: object) -> str:
@@ -74,7 +74,7 @@ def normalize_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
 def write_public_seed(rows: list[dict[str, Any]], path: Path) -> None:
     payload = {
         "schema": PUBLIC_SCHEMA,
-        "selectionNote": "All active Alona v5 curated rows; private document path omitted.",
+        "selectionNote": "All active curated v5 rows; private document path omitted.",
         "entries": rows,
     }
     _write_json(path, payload)
@@ -83,7 +83,7 @@ def write_public_seed(rows: list[dict[str, Any]], path: Path) -> None:
 def read_public_seed(path: Path) -> list[dict[str, Any]]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict) or payload.get("schema") != PUBLIC_SCHEMA:
-        raise ValueError(f"unsupported Alona public seed schema: {path}")
+        raise ValueError(f"unsupported curated public seed schema: {path}")
     entries = payload.get("entries")
     if not isinstance(entries, list) or not all(isinstance(row, dict) for row in entries):
         raise ValueError(f"public seed entries must be objects: {path}")
@@ -125,7 +125,7 @@ def candidates_for_manifest(rows: list[dict[str, Any]], manifest_path: Path) -> 
                 "gloss": _text(row.get("gloss")),
                 "pos": _vesum_pos(lemma),
                 "entry_type": _entry_type(lemma),
-                "primary_source": "alona_v5_curated_seed",
+                "primary_source": "curated_v5_seed",
             }
         )
     return {"auto_merge": candidates, "needs_review": []}
@@ -180,7 +180,7 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
         cefr_sources[source] += 1
         practice_rows.append({"seedRow": row.get("seedRow"), "lemma": _text(target.get("lemma")), "slug": _text(target.get("url_slug")), "cefr": level, "example": example, "provenance": provenance, "sentenceStatus": "ok"})
     report = {
-        "schema": "alona-v5-atlas-admission-report-v1",
+        "schema": "curated-v5-admission-report-v1",
         "counts": {
             "active_seed_rows": len(rows), "unique_seed_lemmas": len({_lemma_key(_text(row.get("lemma"))) for row in rows}),
             "public_atlas_rows": len(rows) - len(atlas_failures), "atlas_failures": len(atlas_failures),
@@ -190,7 +190,7 @@ def prepare_practice_seed(rows: list[dict[str, Any]], manifest_path: Path) -> tu
         "atlas_failures": atlas_failures,
         "practice_skipped_no_cefr": skipped_no_cefr,
     }
-    seed = {"schema": PRACTICE_SCHEMA, "deckSlug": "alona-v5-full", "title": "Alona v5 curated practice admission", "selectionNote": "All sentence_status=ok rows whose public Atlas route has pipeline-derived CEFR. Recognition-first; no cloze targets.", "entries": practice_rows}
+    seed = {"schema": PRACTICE_SCHEMA, "deckSlug": "curated-v5-full", "title": "Curated v5 practice admission", "selectionNote": "All sentence_status=ok rows whose public Atlas route has pipeline-derived CEFR. Recognition-first; no cloze targets.", "entries": practice_rows}
     return seed, report
 
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,14 +1,10 @@
 {
-  "fingerprint": "1b9d36a499d375795e26c711575b38d34c81b08f11bcfda542ac7d82560af16f",
+  "fingerprint": "bc3cf4e01301c1bef007036a41a83185da885a61587b077137bf07b7e73d7934",
   "inputs": {
     "lexicon_code": [
       {
         "path": "scripts/lexicon/__init__.py",
         "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      },
-      {
-        "path": "scripts/lexicon/alona_v5_atlas_admission.py",
-        "sha256": "5ac4de1968e4b2f3a4523f714f6922bb55d5e54ae232f7580141f79738d8ef14"
       },
       {
         "path": "scripts/lexicon/anchor_curation_evidence.py",
@@ -69,6 +65,10 @@
       {
         "path": "scripts/lexicon/curated_ohoiko_ulp_repromote.py",
         "sha256": "f5fd62e8e4a6aa02dd01d042368c874e56a992fa8e69366148c1cb184430920a"
+      },
+      {
+        "path": "scripts/lexicon/curated_seed_atlas_admission.py",
+        "sha256": "33ddb6dc5b79dac2f48e4598e2ad9fcc89e4584711b2d0182d0161ff5e937673"
       },
       {
         "path": "scripts/lexicon/curated_textbook_jsonl_repromote.py",

--- a/tests/fixtures/atlas/curated_v5_practice_seed.json
+++ b/tests/fixtures/atlas/curated_v5_practice_seed.json
@@ -1,7 +1,7 @@
 {
-  "schema": "alona-v5-practice-seed-v1",
-  "deckSlug": "alona-v5-fixture",
-  "title": "Alona v5 fixture practice admission",
+  "schema": "curated-v5-practice-seed-v1",
+  "deckSlug": "curated-v5-fixture",
+  "title": "Curated v5 fixture practice admission",
   "selectionNote": "Fixture-sized source-backed examples only.",
   "entries": [
     {

--- a/tests/test_curated_seed_atlas_admission.py
+++ b/tests/test_curated_seed_atlas_admission.py
@@ -1,11 +1,11 @@
-"""Alona v5 admission uses public Atlas facts rather than invented CEFR."""
+"""Curated v5 admission uses public Atlas facts rather than invented CEFR."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
-from scripts.lexicon import alona_v5_atlas_admission as admission
+from scripts.lexicon import curated_seed_atlas_admission as admission
 
 
 def _manifest(path: Path, entries: list[dict[str, object]]) -> Path:
@@ -30,7 +30,7 @@ def test_candidates_keep_explicit_verb_expression_type(tmp_path: Path, monkeypat
             "gloss": "to break down",
             "pos": None,
             "entry_type": "expression",
-            "primary_source": "alona_v5_curated_seed",
+            "primary_source": "curated_v5_seed",
         }
     ]
 
@@ -58,7 +58,7 @@ def test_normalize_rows_projects_private_v5_input_to_replayable_schema() -> None
                 "sentence": "Пристрій вийшов з ладу.",
                 "sentence_status": "ok",
                 "provenance": {"source_file": "ukrlib-example", "credit": "Автор"},
-                "private_source_path": ".claude/atlas-epic/plans/alona-truth/private.jsonl",
+                "private_source_path": ".claude/atlas-epic/plans/private/seed.jsonl",
             }
         ]
     )

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -46,7 +46,7 @@ VESUM = FIXTURES / "lexicon-practice-vesum.json"
 CLOZE_SOURCES = FIXTURES / "lexicon-practice-cloze-sources.json"
 HERITAGE_PAIRS = FIXTURES / "lexicon-practice-heritage-pairs.yaml"
 PARONYM_PAIRS = FIXTURES / "lexicon-practice-paronym-pairs.yaml"
-ALONA_V5_SEED = FIXTURES / "atlas" / "alona_v5_practice_seed.json"
+CURATED_V5_SEED = FIXTURES / "atlas" / "curated_v5_practice_seed.json"
 
 
 def test_default_target_preserves_committed_practice_surface() -> None:
@@ -54,8 +54,8 @@ def test_default_target_preserves_committed_practice_surface() -> None:
     assert BuildConfig().target == DEFAULT_TARGET
 
 
-def test_alona_v5_seed_admits_existing_atlas_entries_with_provenance() -> None:
-    seed_rows = read_practice_seed(ALONA_V5_SEED)
+def test_curated_v5_seed_admits_existing_atlas_entries_with_provenance() -> None:
+    seed_rows = read_practice_seed(CURATED_V5_SEED)
     assert len(seed_rows) == 3
     assert {row["sentenceStatus"] for row in seed_rows} == {"ok"}
 
@@ -106,7 +106,7 @@ def test_practice_seed_validates_duplicate_attestations_but_emits_one_route_exam
     seed_path.write_text(
         json.dumps(
             {
-                "schema": "alona-v5-practice-seed-v1",
+                "schema": "curated-v5-practice-seed-v1",
                 "entries": [
                     {"lemma": "слово", "slug": "слово", "cefr": "A1", "example": "Перший.", "provenance": provenance, "sentenceStatus": "ok"},
                     {"lemma": "слово", "slug": "слово", "cefr": "A1", "example": "Другий.", "provenance": provenance, "sentenceStatus": "ok"},

--- a/tests/test_makefile_practice_admit.py
+++ b/tests/test_makefile_practice_admit.py
@@ -1,0 +1,24 @@
+"""The local curated admission refreshes every word-page practice surface."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_curated_admit_dry_run_refreshes_practice_api_and_atlas_runtime() -> None:
+    result = subprocess.run(
+        ["make", "-n", "practice-admit-curated-seed"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout
+    deck = output.index("generate_practice_deck.py --practice-seed")
+    hydrate = output.index("hydrate-lexicon-api-shards.ts")
+    export = output.index("scripts.atlas.export_runtime_shards")
+    assert deck < hydrate < export


### PR DESCRIPTION
## Summary
After local practice deck generation, also hydrate `public/api/lexicon` practice shards and export `/atlas` runtime so the word-page Practice CTA and client shell see updated `practiceLevels`.

Renames public admit surface to neutral curated-seed names (no private person names in Makefile/public strings).

## Why
Local admit updated DB + `public/lexicon` but CTA reads `/atlas` export; matching/practice UX depends on that refresh.

Related: #4387 #5792 #5910