### PR TITLE
fix(practice): require English gloss for matching pairs

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 6bff6c36b4fba32fa6484ef0662d1afde2b6f29edb4c8a296dfb1c26aab2baf4
+  components_sha256: d96bd79e10ec3aa18130c6dad185ed50e1df7dd98d9e7e10419b7a89274b1bd1
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -457,6 +457,23 @@ def _meaning_label_is_phrase(label: str) -> bool:
     )
 
 
+def _is_english_learner_gloss(label: str) -> bool:
+    clean = label.strip()
+    if not clean:
+        return False
+    latin_letters = 0
+    cyrillic_letters = 0
+    for char in clean:
+        if not unicodedata.category(char).startswith("L"):
+            continue
+        name = unicodedata.name(char, "")
+        if "LATIN" in name:
+            latin_letters += 1
+        elif "CYRILLIC" in name:
+            cyrillic_letters += 1
+    return latin_letters > cyrillic_letters
+
+
 def _romanize_ukrainian_plain(value: str) -> str:
     return "".join(_UKRAINIAN_ROMANIZATION.get(char, char) for char in value.casefold())
 
@@ -472,6 +489,8 @@ def _is_transliteration_only_gloss(gloss_clean: str, lemma_plain: str) -> bool:
 
 def _meaning_mc_eligible(gloss_clean: str, lemma_plain: str, pos: str | None) -> bool:
     if not gloss_clean or len(gloss_clean) > MEANING_MC_MAX_CHARS:
+        return False
+    if not _is_english_learner_gloss(gloss_clean):
         return False
     if _meaning_label_is_phrase(gloss_clean):
         return False

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -667,6 +667,14 @@ function glossHeadword(entry: PracticeLexeme): string {
   return glossLabel(entry).toLocaleLowerCase('en-US').split(/\s+/)[0] ?? '';
 }
 
+export function isEnglishLearnerGloss(label: string): boolean {
+  const clean = label.trim();
+  if (!clean) return false;
+  const latinLetters = clean.match(/\p{Script=Latin}/gu)?.length ?? 0;
+  const cyrillicLetters = clean.match(/\p{Script=Cyrillic}/gu)?.length ?? 0;
+  return latinLetters > cyrillicLetters;
+}
+
 function isPhraseGloss(label: string): boolean {
   const clean = label.replace(/\s+/g, ' ').trim();
   // Count alphanumeric tokens (ignoring standalone punctuation) to match the
@@ -683,11 +691,12 @@ function isPhraseGloss(label: string): boolean {
   );
 }
 
-function isMeaningMcEligible(entry: PracticeLexeme): boolean {
+export function isMeaningMcEligible(entry: PracticeLexeme): boolean {
   const label = glossLabel(entry);
   if (entry.meaningMcEligible === false) return false;
   // Judge the CLEAN first-sense label, not the raw multi-sense gloss: a word like
   // "dog; hound" has a perfectly concise glossClean ("dog") and must stay eligible.
+  if (!isEnglishLearnerGloss(label)) return false;
   if (isPhraseGloss(label)) return false;
   if (FUNCTION_GLOSS_HEADWORDS.has(glossHeadword(entry))) return false;
   if (entry.pos && FUNCTION_POS.has(entry.pos.toLocaleLowerCase('en-US'))) return false;
@@ -821,7 +830,9 @@ function normalizeInitialDeck(initialDeck?: PracticeDeckData | PracticeLexeme[])
     const legacy = entry as PracticeLexeme & { slug?: string; example?: string | null };
     const lemmaId = legacy.lemmaId ?? legacy.slug ?? legacy.lemma;
     const glossClean = legacy.glossClean ?? cleanGloss(legacy.gloss);
-    const meaningMcEligible = legacy.meaningMcEligible ?? !isPhraseGloss(glossClean);
+    const meaningMcEligible = legacy.meaningMcEligible ?? (
+      isEnglishLearnerGloss(glossClean) && !isPhraseGloss(glossClean)
+    );
     return {
       ...entry,
       lemmaId,
@@ -962,7 +973,9 @@ function matchingPairs(selection: PracticeSelection, deck: PracticeDeckData, lea
   if (!isMeaningMcEligible(selection.lemma)) return [];
   const distractors = meaningDistractors(selection.lemma, deck, 5);
   if (distractors.length < 2) return [];
-  return [selection.lemma, ...distractors].map((entry) => ({
+  const entries = [selection.lemma, ...distractors];
+  if (!entries.every(isMeaningMcEligible)) return [];
+  return entries.map((entry) => ({
     left: displayPracticeForm(entry.lemma, learnerLevel),
     right: glossLabel(entry),
     lemmaId: entry.lemmaId,

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { State } from 'ts-fsrs';
 import { act, render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import LexiconPractice, { addDailyExamples } from '@site/src/components/LexiconPractice';
+import LexiconPractice, {
+  addDailyExamples,
+  isEnglishLearnerGloss,
+  isMeaningMcEligible,
+} from '@site/src/components/LexiconPractice';
 import { LexiconCustomDeckManager } from '@site/src/components/LexiconCustomDeckManager';
 import PracticeDailyDeck from '@site/src/components/PracticeDailyDeck';
 import PracticeSessionSummary, { type SessionSummaryStats } from '@site/src/components/PracticeSessionSummary';
@@ -1536,6 +1540,24 @@ describe('LexiconPractice', () => {
       expect(label).not.toMatch(/[?(]/);
       expect(label.trim().split(/\s+/)).toHaveLength(1);
     }
+  });
+
+  test('meaning eligibility requires a Latin-majority learner English gloss', () => {
+    expect(isEnglishLearnerGloss('justice')).toBe(true);
+    expect(isEnglishLearnerGloss('42')).toBe(false);
+    expect(isEnglishLearnerGloss('сукупність прав')).toBe(false);
+    // A short Cyrillic clarification is acceptable only while Latin remains the majority.
+    expect(isEnglishLearnerGloss('justice укр')).toBe(true);
+    expect(isEnglishLearnerGloss('justice справедливість')).toBe(false);
+
+    const ukrainianDictionaryGloss = lexeme(
+      'pravo',
+      'право',
+      'сукупність прав',
+      { nominative: 'право', accusative: 'право', locative: 'праві' },
+      { glossClean: 'сукупність прав', meaningMcEligible: true },
+    );
+    expect(isMeaningMcEligible(ukrainianDictionaryGloss)).toBe(false);
   });
 
   test('choice backfills distractors across POS when same-POS pool is too small', () => {

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -18,6 +18,7 @@ from scripts.audit.generate_practice_deck import (
     _build_paradigm_items,
     _declension_category,
     _eligible_decoys,
+    _meaning_mc_eligible,
     _option_strategy_for_level,
     _stress_position,
     apply_size_budgets,
@@ -581,6 +582,33 @@ def test_meaning_mc_eligibility_marks_clean_and_messy_glosses() -> None:
     assert lexemes["borshch"]["glossClean"] == "borshch"
     assert lexemes["borshch"]["meaningMcEligible"] is False
     assert index_items["borshch"]["modes"] == ["flashcards"]
+
+
+def test_meaning_mc_eligibility_requires_a_latin_majority_gloss() -> None:
+    assert _meaning_mc_eligible("justice", "справедливість", "noun") is True
+    assert _meaning_mc_eligible("сукупність прав", "право", "noun") is False
+    # A Latin-majority label with a brief Cyrillic clarification remains a learner English gloss.
+    assert _meaning_mc_eligible("justice укр", "справедливість", "noun") is True
+    assert _meaning_mc_eligible("justice справедливість", "справедливість", "noun") is False
+
+    entries = [
+        {
+            "lemma": "право",
+            "url_slug": "pravo",
+            "gloss": "сукупність прав",
+            "pos": "noun",
+            "primary_source": "course_vocab",
+            "cefr": "A1",
+        },
+    ]
+    shards = build_practice_shards(
+        entries, ReviewedSourceAllowlist.from_payload([]), JsonVesumVerifier({})
+    )
+    lexeme = shards["A1"]["lexemes"]["lexemes"][0]
+    index_item = shards["A1"]["index"]["items"][0]
+
+    assert lexeme["meaningMcEligible"] is False
+    assert index_item["modes"] == ["flashcards"]
 
 
 def test_option_set_validator_rejects_phrase_labels() -> None:


### PR DESCRIPTION
## Summary
- gate matching and meaning-choice labels on a Latin-majority learner English gloss at runtime and deck generation
- preserve matching for eligible English labels while excluding Ukrainian dictionary glosses
- add generator and UI regression coverage for English, Ukrainian, numeric, and mixed-script labels

## Verification
- .venv/bin/python -m pytest tests/test_generate_practice_deck.py -q
- .venv/bin/ruff check scripts/audit/generate_practice_deck.py tests/test_generate_practice_deck.py
- NODE_OPTIONS=--localstorage-file=<temporary file> npm exec -- vitest run tests/unit/LexiconPractice.test.tsx -t meaning-eligibility

Practice-deck rebuild after merge will update published eligibility flags; the runtime guard protects existing decks immediately.