### PR TITLE
fix(practice): cloze prompt not always case drill

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: d96bd79e10ec3aa18130c6dad185ed50e1df7dd98d9e7e10419b7a89274b1bd1
+  components_sha256: 6fe193ba89217996d88f1a03ec0d456227c73d7af73d1bb3dbeb4ed1d73151c1
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1141,6 +1141,19 @@ function clozeParts(item: PracticeClozeItem): [string, string] {
   return [before, after.join('___')];
 }
 
+const NON_CASE_CLOZE_POS = new Set(['adv', 'prep', 'conj', 'part', 'numr']);
+
+function isCaseClozeDrill(cloze: PracticeClozeItem, lemma: PracticeLexeme): boolean {
+  // Deterministic prompt heuristic: an NFC/casefold-equal answer is an insertion,
+  // never a case drill. Likewise, VESUM indeclinable POS tags must not receive
+  // case wording. Otherwise a changed form remains a case drill: authored clozes
+  // carry case-rule feedback and their chips may distinguish case variants.
+  const normalizedForm = cloze.form.trim().normalize('NFC').toLocaleLowerCase('uk-UA');
+  const normalizedLemma = lemma.lemma.trim().normalize('NFC').toLocaleLowerCase('uk-UA');
+  if (!normalizedForm || normalizedForm === normalizedLemma) return false;
+  return !NON_CASE_CLOZE_POS.has((lemma.pos ?? '').trim().toLocaleLowerCase());
+}
+
 function slotPromptParts(prompt: string): [string, string] {
   const [before, ...after] = prompt.split('___');
   return [before, after.join('___')];
@@ -4134,6 +4147,7 @@ function PracticeCloze({
   const cloze = selection.cloze;
   if (!cloze) return null;
   const [before, after] = clozeParts(cloze).map((part) => displayPracticeForm(part, learnerLevel));
+  const caseDrill = isCaseClozeDrill(cloze, selection.lemma);
   const optionErrors = validateClozeOptions(cloze);
   const blankText = feedback?.kind === 'correct' ? cloze.form : input.trim() || '?';
   const displayBlankText = displayPracticeForm(blankText, learnerLevel);
@@ -4149,8 +4163,12 @@ function PracticeCloze({
     <div className="lexicon-cloze" data-testid="practice-cloze">
       <p className="cz-task">
         <PracticeChromeDual
-          uk={`Поставте слово „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” у правильному відмінку.`}
-          en={`Put the word „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” in the correct case.`}
+          uk={caseDrill
+            ? `Поставте слово „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” у правильному відмінку.`
+            : `Вставте слово „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” у пропуск.`}
+          en={caseDrill
+            ? `Put the word „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” in the correct case.`
+            : `Fill in the blank with the word „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}”.`}
 
         />
       </p>

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -297,6 +297,57 @@ function sampleDeck(): PracticeDeckData {
   };
 }
 
+function indeclinableClozeDeck(): PracticeDeckData {
+  const entry = lexeme(
+    'zhodom',
+    'згодом',
+    'later',
+    {
+      nominative: 'згодом',
+      accusative: 'згодом',
+      locative: 'згодом',
+    },
+    { pos: 'adv' },
+  );
+  return {
+    deckVersion: 'test-indeclinable-cloze',
+    level: 'A2',
+    lexemes: [entry],
+    index: [{
+      lemmaId: entry.lemmaId,
+      lemma: entry.lemma,
+      cefr: 'A2',
+      modes: ['cloze'],
+      hasCloze: true,
+      clozeIds: ['zhodom-cloze-1'],
+      newOrder: 0,
+    }],
+    cloze: [{
+      clozeId: 'zhodom-cloze-1',
+      lemmaId: entry.lemmaId,
+      sentenceFrameId: 'zhodom-frame',
+      sentence: '___ він відповів.',
+      blankCase: 'accusative',
+      form: 'згодом',
+      clozeEn: 'Later, he replied.',
+      caseRule: {
+        ruleId: 'legacy-case-frame',
+        case: 'accusative',
+        caseLabel: 'знахідний',
+        trigger: 'legacy-fixture',
+        triggerLabel: 'legacy fixture',
+        feedback: 'fixture',
+      },
+      options: [
+        { optionId: 'zhodom-cloze-1:answer', label: 'згодом', lemmaId: entry.lemmaId, kind: 'answer' },
+        { optionId: 'zhodom-cloze-1:one', label: 'потім', lemmaId: 'potim', kind: 'decoy-lemma' },
+        { optionId: 'zhodom-cloze-1:two', label: 'вчора', lemmaId: 'vchora', kind: 'decoy-lemma' },
+        { optionId: 'zhodom-cloze-1:three', label: 'завтра', lemmaId: 'zavtra', kind: 'decoy-lemma' },
+      ],
+    }],
+  };
+}
+
 function heritagePracticeItem(): PracticeHeritageItem {
   return {
     heritageId: 'her-dim-fixture',
@@ -2206,6 +2257,24 @@ describe('LexiconPractice', () => {
     await waitFor(() => {
       expect(storedState().reviews).toHaveLength(1);
     });
+  });
+
+  test('cloze uses a neutral English prompt for an indeclinable adverb', () => {
+    seedRecognitionMastery('zhodom');
+    render(<LexiconPractice initialDeck={indeclinableClozeDeck()} autoStart initialMode="cloze" />);
+
+    const task = screen.getByTestId('practice-cloze').querySelector('.cz-task');
+    expect(task).toHaveTextContent('Fill in the blank with the word „згодом”.');
+    expect(task).not.toHaveTextContent('correct case');
+  });
+
+  test('cloze retains the case prompt for an inflected noun form', () => {
+    seedRecognitionMastery('knyha');
+    render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="cloze" />);
+
+    expect(screen.getByTestId('practice-cloze').querySelector('.cz-task')).toHaveTextContent(
+      'Put the word „книга” in the correct case.',
+    );
   });
 
   test('cloze renders Tatoeba attribution when present', () => {


### PR DESCRIPTION
## Summary
- choose a neutral cloze prompt when the answer is lemma-identical or has an indeclinable VESUM POS
- preserve case wording for changed noun forms
- add regression coverage for an indeclinable adverb and a noun case drill

Implements the UI half of #5917.

## Verification
- `NODE_OPTIONS=--localstorage-file=/tmp/fix-cloze-case-prompt-localstorage npm exec -- vitest run tests/unit/LexiconPractice.test.tsx -t 'neutral English prompt|retains the case prompt'`\n- `.venv/bin/python -m pytest tests/test_generate_practice_deck.py`\n- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`