### PR TITLE
fix(practice): cloze case prompt CF nits (numerals + aria)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 6fe193ba89217996d88f1a03ec0d456227c73d7af73d1bb3dbeb4ed1d73151c1
+  components_sha256: 544f49f32f591544633c501862ad87f7bcaa2fb5feef5adb93feea58456e634a
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1141,7 +1141,7 @@ function clozeParts(item: PracticeClozeItem): [string, string] {
   return [before, after.join('___')];
 }
 
-const NON_CASE_CLOZE_POS = new Set(['adv', 'prep', 'conj', 'part', 'numr']);
+const NON_CASE_CLOZE_POS = new Set(['adv', 'prep', 'conj', 'part']);
 
 function isCaseClozeDrill(cloze: PracticeClozeItem, lemma: PracticeLexeme): boolean {
   // Deterministic prompt heuristic: an NFC/casefold-equal answer is an insertion,
@@ -1278,14 +1278,6 @@ function resolvePracticeIndexItem(
 /** Pure-locale practice chrome message (both locales in DOM; CSS shows one). */
 function PureLocalePracticeMessage({ uk, en }: { uk: string; en: string }) {
   return <ChromeDual uk={uk} en={en} />;
-}
-
-/** Bare hard-stem adjective case labels (`знахідний`) → «у знахідному відмінку». */
-function casePhraseLocative(caseLabel: string): string {
-  if (caseLabel.endsWith('ий')) {
-    return `у ${caseLabel.slice(0, -2)}ому відмінку`;
-  }
-  return `у ${caseLabel} відмінку`;
 }
 
 /** Bare hard-stem adjective case labels (`знахідний`) → «у знахідний відмінок». */
@@ -4148,6 +4140,16 @@ function PracticeCloze({
   if (!cloze) return null;
   const [before, after] = clozeParts(cloze).map((part) => displayPracticeForm(part, learnerLevel));
   const caseDrill = isCaseClozeDrill(cloze, selection.lemma);
+  const displayLemma = displayPracticeForm(selection.lemma.lemma, learnerLevel);
+  const clozePrompt = caseDrill
+    ? {
+      uk: `Поставте слово „${displayLemma}” у правильному відмінку.`,
+      en: `Put the word „${displayLemma}” in the correct case.`,
+    }
+    : {
+      uk: `Вставте слово „${displayLemma}” у пропуск.`,
+      en: `Fill in the blank with the word „${displayLemma}”.`,
+    };
   const optionErrors = validateClozeOptions(cloze);
   const blankText = feedback?.kind === 'correct' ? cloze.form : input.trim() || '?';
   const displayBlankText = displayPracticeForm(blankText, learnerLevel);
@@ -4162,15 +4164,7 @@ function PracticeCloze({
   return (
     <div className="lexicon-cloze" data-testid="practice-cloze">
       <p className="cz-task">
-        <PracticeChromeDual
-          uk={caseDrill
-            ? `Поставте слово „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” у правильному відмінку.`
-            : `Вставте слово „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” у пропуск.`}
-          en={caseDrill
-            ? `Put the word „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}” in the correct case.`
-            : `Fill in the blank with the word „${displayPracticeForm(selection.lemma.lemma, learnerLevel)}”.`}
-
-        />
+        <PracticeChromeDual {...clozePrompt} />
       </p>
       <p className="cz-sentence">
         <span>{before}</span>
@@ -4214,11 +4208,7 @@ function PracticeCloze({
           autoCorrect="off"
           spellCheck={false}
           lang="uk"
-          aria-label={
-            chromeLocale === 'en'
-              ? `Answer in ${translateGrammarTerm(cloze.caseRule.caseLabel)}`
-              : `Відповідь ${casePhraseLocative(cloze.caseRule.caseLabel)}`
-          }
+          aria-label={clozePrompt[chromeLocale]}
           onChange={(event) => onInput(event.currentTarget.value)}
         />
         <button className="btn btn-accent" type="submit" disabled={answerLocked}>

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -348,6 +348,57 @@ function indeclinableClozeDeck(): PracticeDeckData {
   };
 }
 
+function numeralClozeDeck(): PracticeDeckData {
+  const entry = lexeme(
+    'dva',
+    'два',
+    'two',
+    {
+      nominative: 'два',
+      accusative: 'двох',
+      locative: 'двох',
+    },
+    { pos: 'numr' },
+  );
+  return {
+    deckVersion: 'test-numeral-cloze',
+    level: 'A2',
+    lexemes: [entry],
+    index: [{
+      lemmaId: entry.lemmaId,
+      lemma: entry.lemma,
+      cefr: 'A2',
+      modes: ['cloze'],
+      hasCloze: true,
+      clozeIds: ['dva-cloze-1'],
+      newOrder: 0,
+    }],
+    cloze: [{
+      clozeId: 'dva-cloze-1',
+      lemmaId: entry.lemmaId,
+      sentenceFrameId: 'dva-frame',
+      sentence: 'Я знаю ___ студентів.',
+      blankCase: 'accusative',
+      form: 'двох',
+      clozeEn: 'I know two students.',
+      caseRule: {
+        ruleId: 'numeral-case-fixture',
+        case: 'accusative',
+        caseLabel: 'знахідний',
+        trigger: 'fixture',
+        triggerLabel: 'fixture',
+        feedback: 'fixture',
+      },
+      options: [
+        { optionId: 'dva-cloze-1:answer', label: 'двох', lemmaId: entry.lemmaId, kind: 'answer' },
+        { optionId: 'dva-cloze-1:lemma', label: 'два', lemmaId: entry.lemmaId, kind: 'same-root-lemma' },
+        { optionId: 'dva-cloze-1:one', label: 'один', lemmaId: 'odyn', kind: 'decoy-lemma' },
+        { optionId: 'dva-cloze-1:three', label: 'три', lemmaId: 'try', kind: 'decoy-lemma' },
+      ],
+    }],
+  };
+}
+
 function heritagePracticeItem(): PracticeHeritageItem {
   return {
     heritageId: 'her-dim-fixture',
@@ -2239,7 +2290,7 @@ describe('LexiconPractice', () => {
     const status = within(screen.getByTestId('practice-cloze')).getByRole('status');
     expect(status).toHaveTextContent('Правильне слово');
     expect(status).toHaveClass('case-miss');
-    expect(screen.getByLabelText(/Відповідь у знахідному відмінку/)).toHaveValue('');
+    expect(screen.getByLabelText(/Поставте слово „книга” у правильному відмінку/)).toHaveValue('');
     expect(screen.getByRole('button', { name: 'книгу' })).not.toBeDisabled();
 
     await waitFor(() => {
@@ -2259,13 +2310,14 @@ describe('LexiconPractice', () => {
     });
   });
 
-  test('cloze uses a neutral English prompt for an indeclinable adverb', () => {
+  test('cloze uses a neutral prompt and aria-label for an adverb whose form equals its lemma', () => {
     seedRecognitionMastery('zhodom');
     render(<LexiconPractice initialDeck={indeclinableClozeDeck()} autoStart initialMode="cloze" />);
 
     const task = screen.getByTestId('practice-cloze').querySelector('.cz-task');
     expect(task).toHaveTextContent('Fill in the blank with the word „згодом”.');
     expect(task).not.toHaveTextContent('correct case');
+    expect(screen.getByLabelText('Вставте слово „згодом” у пропуск.')).toBeInTheDocument();
   });
 
   test('cloze retains the case prompt for an inflected noun form', () => {
@@ -2274,6 +2326,16 @@ describe('LexiconPractice', () => {
 
     expect(screen.getByTestId('practice-cloze').querySelector('.cz-task')).toHaveTextContent(
       'Put the word „книга” in the correct case.',
+    );
+    expect(screen.getByLabelText('Поставте слово „книга” у правильному відмінку.')).toBeInTheDocument();
+  });
+
+  test('cloze retains the case prompt for a declined numeral', () => {
+    seedRecognitionMastery('dva');
+    render(<LexiconPractice initialDeck={numeralClozeDeck()} autoStart initialMode="cloze" />);
+
+    expect(screen.getByTestId('practice-cloze').querySelector('.cz-task')).toHaveTextContent(
+      'Put the word „два” in the correct case.',
     );
   });
 
@@ -2583,7 +2645,7 @@ describe('LexiconPractice', () => {
       expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument(),
     );
     expect(screen.getByTestId('practice-cloze')).toBeInTheDocument();
-    expect(screen.getByLabelText(/Відповідь у знахідному відмінку/)).toHaveValue('');
+    expect(screen.getByLabelText(/Поставте слово „книга” у правильному відмінку/)).toHaveValue('');
     expect(screen.getByRole('button', { name: 'книгу' })).not.toBeDisabled();
     expect(screen.queryByText('✗ Не те слово')).not.toBeInTheDocument();
   });
@@ -2718,7 +2780,7 @@ describe('LexiconPractice', () => {
     // Focus session is active and serving the accusative cloze — no other case leaks in.
     const cloze = await screen.findByTestId('practice-cloze');
     expect(cloze).toBeInTheDocument();
-    expect(screen.getByLabelText(/Відповідь у знахідному відмінку/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Поставте слово „книга” у правильному відмінку/)).toBeInTheDocument();
   });
 
   test('weak-area chip whose weakness yields no items shows a UA notice, clears focus, and never strands the learner', async () => {


### PR DESCRIPTION
## Summary

- Allow declined numerals to retain the cloze case prompt.
- Reuse the visible cloze prompt as the input aria-label, including neutral fill-in wording.
- Cover numeral, adverb, and accessibility-label branches.

## Root cause

The prior non-case POS shortcut classified all numerals as indeclinable, and the input label remained case-specific after visible prompt branching.

## Validation

- `NODE_OPTIONS="--localstorage-file=$PWD/.vitest-localstorage" npx vitest run tests/unit/LexiconPractice.test.tsx -t cloze` (13 passed)
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

`astro check` remains blocked by pre-existing type errors outside this change.
