### PR TITLE
fix(practice): show sentence English after answer

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 577d6dcd007e2d95ac31758bc2ba80e93a1c8922b89b71153e16ddf8ffadb925
+  components_sha256: dc94b8d1075b9b1f717c3a62ce9ceded4786489fee65fc5cf32fa9bf41f42c95
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: dc94b8d1075b9b1f717c3a62ce9ceded4786489fee65fc5cf32fa9bf41f42c95
+  components_sha256: 243de14f97648bed710952b7deefd2a6ff047e8b28cc5c95985326f84e37a106
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 544f49f32f591544633c501862ad87f7bcaa2fb5feef5adb93feea58456e634a
+  components_sha256: 577d6dcd007e2d95ac31758bc2ba80e93a1c8922b89b71153e16ddf8ffadb925
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -675,6 +675,12 @@ export function isEnglishLearnerGloss(label: string): boolean {
   return latinLetters > cyrillicLetters;
 }
 
+function usablePracticeSentenceEnglish(value: string | null | undefined): string | null {
+  const sentence = value?.trim();
+  if (!sentence || /^context sentence for\b/i.test(sentence)) return null;
+  return sentence;
+}
+
 function isPhraseGloss(label: string): boolean {
   const clean = label.replace(/\s+/g, ' ').trim();
   // Count alphanumeric tokens (ignoring standalone punctuation) to match the
@@ -3946,6 +3952,7 @@ function PracticeParonym({
   const [before, after] = slotPromptParts(item.prompt).map((part) => displayPracticeForm(part, learnerLevel));
   const options = paronymOptions(item);
   const slotText = feedback?.kind === 'correct' ? displayPracticeForm(item.answer, learnerLevel) : '___';
+  const sentenceEnglish = feedback ? usablePracticeSentenceEnglish(item.promptEn) : null;
   return (
     <div className="lexicon-paronym" data-testid="practice-paronym">
       <p className="paronym-task">
@@ -3958,6 +3965,11 @@ function PracticeParonym({
         </span>
         <span>{after}</span>
       </p>
+      {sentenceEnglish ? (
+        <p className="cz-translate" data-testid="practice-paronym-sentence-en" lang="en">
+          {sentenceEnglish}
+        </p>
+      ) : null}
       <ul className="lexicon-option-list mc-options">
         {options.map((option, index) => (
           <li key={`${option.label}-${index}`}>
@@ -4038,6 +4050,7 @@ function PracticeHeritage({
   const slotText = feedback?.kind === 'correct'
     ? displayPracticeForm(selectedLabel ?? item.answer, learnerLevel)
     : '___';
+  const sentenceEnglish = feedback ? usablePracticeSentenceEnglish(item.promptEn) : null;
   return (
     <div className="lexicon-heritage" data-testid="practice-heritage">
       <p className="heritage-task">
@@ -4050,6 +4063,11 @@ function PracticeHeritage({
         </span>
         <span>{after}</span>
       </p>
+      {sentenceEnglish ? (
+        <p className="cz-translate" data-testid="practice-heritage-sentence-en" lang="en">
+          {sentenceEnglish}
+        </p>
+      ) : null}
       <ul className="lexicon-option-list mc-options">
         {options.map((option, index) => (
           <li key={`${option.label}-${index}`}>
@@ -4153,6 +4171,7 @@ function PracticeCloze({
   const optionErrors = validateClozeOptions(cloze);
   const blankText = feedback?.kind === 'correct' ? cloze.form : input.trim() || '?';
   const displayBlankText = displayPracticeForm(blankText, learnerLevel);
+  const sentenceEnglish = feedback ? usablePracticeSentenceEnglish(cloze.clozeEn) : null;
   const blankClass = [
     'cz-blank',
     displayBlankText !== '?' ? 'filled' : '',
@@ -4171,8 +4190,14 @@ function PracticeCloze({
         <span className={blankClass}>{displayBlankText}</span>
         <span>{after}</span>
       </p>
-      {showEnglishSubtitles ? (
-        <p className="lexicon-cloze-translation cz-translate" lang="en">{cloze.clozeEn}</p>
+      {sentenceEnglish ? (
+        <p
+          className="lexicon-cloze-translation cz-translate"
+          data-testid="practice-cloze-sentence-en"
+          lang="en"
+        >
+          {sentenceEnglish}
+        </p>
       ) : null}
       {cloze.attribution ? (
         <p className="lexicon-cloze-attribution">

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -681,6 +681,14 @@ function usablePracticeSentenceEnglish(value: string | null | undefined): string
   return sentence;
 }
 
+function postAnswerSentenceEnglish(
+  feedback: HeritageFeedback | ParonymFeedback | ClozeFeedback | null,
+  raw: string | null | undefined,
+): string | null {
+  // Intentional all-level post-answer English answer key; this is not dual-chrome.
+  return feedback ? usablePracticeSentenceEnglish(raw) : null;
+}
+
 function isPhraseGloss(label: string): boolean {
   const clean = label.replace(/\s+/g, ' ').trim();
   // Count alphanumeric tokens (ignoring standalone punctuation) to match the
@@ -3952,7 +3960,7 @@ function PracticeParonym({
   const [before, after] = slotPromptParts(item.prompt).map((part) => displayPracticeForm(part, learnerLevel));
   const options = paronymOptions(item);
   const slotText = feedback?.kind === 'correct' ? displayPracticeForm(item.answer, learnerLevel) : '___';
-  const sentenceEnglish = feedback ? usablePracticeSentenceEnglish(item.promptEn) : null;
+  const sentenceEnglish = postAnswerSentenceEnglish(feedback, item.promptEn);
   return (
     <div className="lexicon-paronym" data-testid="practice-paronym">
       <p className="paronym-task">
@@ -4050,7 +4058,7 @@ function PracticeHeritage({
   const slotText = feedback?.kind === 'correct'
     ? displayPracticeForm(selectedLabel ?? item.answer, learnerLevel)
     : '___';
-  const sentenceEnglish = feedback ? usablePracticeSentenceEnglish(item.promptEn) : null;
+  const sentenceEnglish = postAnswerSentenceEnglish(feedback, item.promptEn);
   return (
     <div className="lexicon-heritage" data-testid="practice-heritage">
       <p className="heritage-task">
@@ -4171,7 +4179,7 @@ function PracticeCloze({
   const optionErrors = validateClozeOptions(cloze);
   const blankText = feedback?.kind === 'correct' ? cloze.form : input.trim() || '?';
   const displayBlankText = displayPracticeForm(blankText, learnerLevel);
-  const sentenceEnglish = feedback ? usablePracticeSentenceEnglish(cloze.clozeEn) : null;
+  const sentenceEnglish = postAnswerSentenceEnglish(feedback, cloze.clozeEn);
   const blankClass = [
     'cz-blank',
     displayBlankText !== '?' ? 'filled' : '',

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -85,6 +85,7 @@ import {
 import { dateSeed, deckSeed, pickDaily, type DailyWord } from '../lib/lexicon/daily';
 import { getTeacherLessonVirtualDeck, readLocalCustomSets, saveLocalCustomSet, deleteLocalCustomSet, type CustomSet } from '../lib/lexicon/custom-decks';
 import { syncCustomSetsToDrive, requestGoogleAccessToken, setInMemoryAccessToken, getInMemoryAccessToken } from '../lib/lexicon/google-drive-sync';
+import { usablePracticeSentenceEnglish } from '../lib/lexicon/practice-sentence-en';
 import { searchShardForQuery, type SearchRow, type SearchShardManifest } from '../lib/lexicon/search';
 import { LexiconCustomDeckManager } from './LexiconCustomDeckManager';
 
@@ -673,12 +674,6 @@ export function isEnglishLearnerGloss(label: string): boolean {
   const latinLetters = clean.match(/\p{Script=Latin}/gu)?.length ?? 0;
   const cyrillicLetters = clean.match(/\p{Script=Cyrillic}/gu)?.length ?? 0;
   return latinLetters > cyrillicLetters;
-}
-
-function usablePracticeSentenceEnglish(value: string | null | undefined): string | null {
-  const sentence = value?.trim();
-  if (!sentence || /^context sentence for\b/i.test(sentence)) return null;
-  return sentence;
 }
 
 function postAnswerSentenceEnglish(

--- a/site/src/components/PracticeDailyDeck.tsx
+++ b/site/src/components/PracticeDailyDeck.tsx
@@ -88,9 +88,7 @@ export default function PracticeDailyDeck({
   const showStressMarks = learnerLevel === 'A1';
   const displayLemma = (lemma: string) => (showStressMarks ? lemma : stripStressMarks(lemma));
   const currentExample = currentItem?.example?.trim() || currentLexeme?.example?.trim() || null;
-  const currentExampleEn = showStressMarks
-    ? currentItem?.exampleEn?.trim() || currentLexeme?.exampleEn?.trim() || null
-    : null;
+  const currentExampleEn = currentItem?.exampleEn?.trim() || currentLexeme?.exampleEn?.trim() || null;
 
   return (
     <div className="practice-daily-deck" data-testid="practice-daily-deck">

--- a/site/src/components/PracticeDailyDeck.tsx
+++ b/site/src/components/PracticeDailyDeck.tsx
@@ -8,6 +8,7 @@ import { formatLastSeenAgo, stripStressMarks } from '../lib/lexicon/srs';
 import { CHROME_STRINGS, type ChromeLocale, type ChromeKey } from '../lib/i18n/chrome';
 import ChromeText, { ChromeDual } from '../lib/i18n/ChromeText';
 import type { CefrLevel } from '../lib/lexicon/levels';
+import { usablePracticeSentenceEnglish } from '../lib/lexicon/practice-sentence-en';
 
 export interface PracticeDailyDeckProps {
   snapshot: DailyPracticeDeckSnapshot;
@@ -88,7 +89,7 @@ export default function PracticeDailyDeck({
   const showStressMarks = learnerLevel === 'A1';
   const displayLemma = (lemma: string) => (showStressMarks ? lemma : stripStressMarks(lemma));
   const currentExample = currentItem?.example?.trim() || currentLexeme?.example?.trim() || null;
-  const currentExampleEn = currentItem?.exampleEn?.trim() || currentLexeme?.exampleEn?.trim() || null;
+  const currentExampleEn = usablePracticeSentenceEnglish(currentItem?.exampleEn || currentLexeme?.exampleEn);
 
   return (
     <div className="practice-daily-deck" data-testid="practice-daily-deck">

--- a/site/src/lib/lexicon/practice-sentence-en.ts
+++ b/site/src/lib/lexicon/practice-sentence-en.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns displayable English practice-sentence text, excluding generator
+ * placeholders that are not learner-facing translations.
+ */
+export function usablePracticeSentenceEnglish(value: string | null | undefined): string | null {
+  const sentence = value?.trim();
+  if (!sentence || /^context sentence for\b/i.test(sentence)) return null;
+  return sentence;
+}

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -235,6 +235,8 @@ export interface PracticeHeritageItem {
   calqueLabel?: string;
   kind: 'lexical' | 'sense_restricted' | string;
   prompt: string;
+  /** Optional English meaning of the Ukrainian prompt sentence. */
+  promptEn?: string;
   answer: string;
   calque: string;
   origin?: string;
@@ -264,6 +266,8 @@ export interface PracticeParonymItem {
   frameIndex: number;
   cefr: string;
   prompt: string;
+  /** Optional English meaning of the Ukrainian prompt sentence. */
+  promptEn?: string;
   answer: string;
   options: PracticeParonymOption[];
   origin?: string;

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -849,6 +849,36 @@ describe('LexiconPractice', () => {
     expect(screen.getByTestId('practice-daily-example-en')).toHaveTextContent('Mother is reading.');
   });
 
+  test('omits placeholder daily sentence English after the card is revealed', async () => {
+    const item: DailyPracticeDeckSnapshot['items'][number] = {
+      lemmaId: 'борщ',
+      origin: 'new',
+      lemma: 'борщ',
+      gloss: 'borscht',
+      cefr: 'A2',
+      pos: 'noun',
+      example: 'Я їм борщ.',
+      exampleEn: 'Context sentence for борщ',
+    };
+
+    render(
+      <PracticeDailyDeck
+        snapshot={{ version: 2, date: '2026-06-23', level: 'A2', deckVersion: 'daily-pool', createdAt: NOW.getTime(), items: [item] }}
+        rows={{ pendingDue: [], pendingNew: [{ item, state: 'new', lastSeenAt: null }], done: [] }}
+        lexemes={new Map()}
+        atlasLemmaHref={(lemmaId) => `/lexicon/${lemmaId}/`}
+        chromeLocale="uk"
+        learnerLevel="A2"
+      />,
+    );
+
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Натисніть, щоб перевернути' }));
+
+    expect(screen.getByTestId('practice-daily-example')).toHaveTextContent('Я їм борщ.');
+    expect(screen.queryByTestId('practice-daily-example-en')).not.toBeInTheDocument();
+    expect(screen.queryByText('Context sentence for борщ')).not.toBeInTheDocument();
+  });
+
   test('renders the daily card from the pick payload when the slug is absent from the practice-lexemes map (#5852)', () => {
     const snapshot: DailyPracticeDeckSnapshot = {
       version: 2,

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1726,7 +1726,8 @@ describe('LexiconPractice', () => {
     expect(await screen.findByTestId('practice-heritage')).toBeInTheDocument();
   });
 
-  test('heritage calque miss scores again and shows cited correction', async () => {
+  test('A2 heritage calque miss scores again and reveals the sentence English answer key', async () => {
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A2');
     const user = userEvent.setup();
     render(
       <LexiconPractice

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -409,6 +409,7 @@ function heritagePracticeItem(): PracticeHeritageItem {
     calqueLabel: 'дом',
     kind: 'lexical',
     prompt: 'Я бачу ___ щодня.',
+    promptEn: 'I see ___ every day.',
     answer: 'дім',
     calque: 'дом',
     origin: 'fixture',
@@ -808,7 +809,7 @@ describe('LexiconPractice', () => {
     expect(dashboard.querySelectorAll('[data-mode]').length).toBe(11);
   });
 
-  test('renders stress marks and daily examples only on A1 default surfaces', () => {
+  test('renders stress marks only on A1, while revealed daily sentence English stays available', () => {
     const marked = lexeme('mama', 'ма́ма', 'mother', {
       nominative: 'ма́ма',
       accusative: 'ма́му',
@@ -845,7 +846,7 @@ describe('LexiconPractice', () => {
 
     expect(screen.queryByText('ма́ма')).not.toBeInTheDocument();
     expect(screen.getAllByText('мама').length).toBeGreaterThan(0);
-    expect(screen.queryByTestId('practice-daily-example-en')).not.toBeInTheDocument();
+    expect(screen.getByTestId('practice-daily-example-en')).toHaveTextContent('Mother is reading.');
   });
 
   test('renders the daily card from the pick payload when the slug is absent from the practice-lexemes map (#5852)', () => {
@@ -1743,6 +1744,7 @@ describe('LexiconPractice', () => {
     const feedback = screen.getByTestId('practice-heritage-feedback');
     expect(feedback).toHaveTextContent('⚠️ калька; у цьому значенні потрібне питоме слово');
     expect(feedback).toHaveTextContent('Джерело: Антоненко-Давидович: fixture');
+    expect(screen.getByTestId('practice-heritage-sentence-en')).toHaveTextContent('I see ___ every day.');
     await waitFor(() => {
       expect(storedState().reviews[0]).toMatchObject({
         lemmaId: 'dim',
@@ -1780,6 +1782,20 @@ describe('LexiconPractice', () => {
         rating: 'again',
       });
     });
+  });
+
+  test('heritage without promptEn keeps feedback and omits the sentence-English block', async () => {
+    const user = userEvent.setup();
+    const deck = heritageDeck();
+    delete deck.heritage![0]!.promptEn;
+    render(<LexiconPractice initialDeck={deck} autoStart initialMode="heritage" />);
+
+    await user.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /місто/ }),
+    );
+
+    expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('Ще раз');
+    expect(screen.queryByTestId('practice-heritage-sentence-en')).not.toBeInTheDocument();
   });
 
   test('heritage correct answer scores good', async () => {
@@ -1902,6 +1918,7 @@ describe('LexiconPractice', () => {
       frameIndex: 1,
       cefr: 'A1',
       prompt: 'Вранці він ___ у парку.',
+      promptEn: 'In the morning he ___ in the park.',
       answer: 'бігає',
       options: [
         { label: 'бігає' },
@@ -1987,6 +2004,7 @@ describe('LexiconPractice', () => {
 
     const feedback = screen.getByTestId('practice-paronym-feedback');
     expect(feedback).toHaveTextContent('Неправильно. бігати регулярно, бігти конкретно зараз');
+    expect(screen.getByTestId('practice-paronym-sentence-en')).toHaveTextContent('In the morning he ___ in the park.');
     await waitFor(() => {
       expect(storedState().reviews[0]).toMatchObject({
         lemmaId: 'bihate',
@@ -2013,6 +2031,7 @@ describe('LexiconPractice', () => {
     );
 
     expect(screen.getByTestId('practice-paronym-feedback')).toHaveTextContent('Правильно! бігати регулярно, бігти конкретно зараз');
+    expect(screen.getByTestId('practice-paronym-sentence-en')).toHaveTextContent('In the morning he ___ in the park.');
     await waitFor(() => {
       expect(storedState().reviews[0]).toMatchObject({
         lemmaId: 'bihate',
@@ -2290,6 +2309,7 @@ describe('LexiconPractice', () => {
     const status = within(screen.getByTestId('practice-cloze')).getByRole('status');
     expect(status).toHaveTextContent('Правильне слово');
     expect(status).toHaveClass('case-miss');
+    expect(screen.getByTestId('practice-cloze-sentence-en')).toHaveTextContent('I am reading a book.');
     expect(screen.getByLabelText(/Поставте слово „книга” у правильному відмінку/)).toHaveValue('');
     expect(screen.getByRole('button', { name: 'книгу' })).not.toBeDisabled();
 
@@ -2318,6 +2338,32 @@ describe('LexiconPractice', () => {
     expect(task).toHaveTextContent('Fill in the blank with the word „згодом”.');
     expect(task).not.toHaveTextContent('correct case');
     expect(screen.getByLabelText('Вставте слово „згодом” у пропуск.')).toBeInTheDocument();
+  });
+
+  test('cloze reveals a usable sentence English only after feedback', async () => {
+    seedRecognitionMastery('knyha');
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="cloze" />);
+
+    expect(screen.queryByTestId('practice-cloze-sentence-en')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'робота' }));
+    await user.click(screen.getByRole('button', { name: /Перевірити/ }));
+
+    expect(screen.getByTestId('practice-cloze-sentence-en')).toHaveTextContent('I am reading a book.');
+  });
+
+  test('cloze omits blank or placeholder sentence English after feedback', async () => {
+    seedRecognitionMastery('knyha');
+    const user = userEvent.setup();
+    const deck = sampleDeck();
+    deck.cloze[0] = { ...deck.cloze[0]!, clozeEn: 'Context sentence for книгу' };
+    render(<LexiconPractice initialDeck={deck} autoStart initialMode="cloze" />);
+
+    await user.click(screen.getByRole('button', { name: 'робота' }));
+    await user.click(screen.getByRole('button', { name: /Перевірити/ }));
+
+    expect(screen.queryByTestId('practice-cloze-sentence-en')).not.toBeInTheDocument();
   });
 
   test('cloze retains the case prompt for an inflected noun form', () => {
@@ -2582,6 +2628,7 @@ describe('LexiconPractice', () => {
     // Correct answers dwell identically to wrong ones — «Далі →» is required.
     expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
     expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('Правильно');
+    expect(screen.getByTestId('practice-heritage-sentence-en')).toHaveTextContent('I see ___ every day.');
     expect(document.activeElement).toBe(screen.getByTestId('practice-advance-button'));
 
     // Still on the same card after a dwell window — no timer advance.


### PR DESCRIPTION
## Summary
- reveal usable sentence English after cloze, heritage, and paronym feedback (correct **or** incorrect)
- preserve optional data fields and omit missing or generated-placeholder translations
- show existing daily flashcard example English after card reveal at every level

## Verification
- focused vitest on LexiconPractice sentence-EN paths
- git diff --check
- OPSEC

Fixes #5959
Related: #4700, #4387