### PR TITLE
fix: restore A1 cloze English scaffolding

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 243de14f97648bed710952b7deefd2a6ff047e8b28cc5c95985326f84e37a106
+  components_sha256: 1dd4dbd15c6cfa9a8e572ab9f114fe6164c6d236d1b62420e728ca4875acaaf2
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1805,6 +1805,15 @@ def _heritage_availability_level(pair: dict[str, Any]) -> str:
     return _normalize_cefr(pair.get("cefrAvailability")) or HERITAGE_DEFAULT_AVAILABILITY
 
 
+def _curated_prompt_en(frame: dict[str, Any]) -> str | None:
+    """Return curator-supplied English only; never manufacture a translation."""
+    for field in ("sentence_en", "prompt_en", "sentence_with_slot_en"):
+        english = _clean_text(frame.get(field))
+        if english and not re.match(r"^context sentence for\b", english, flags=re.IGNORECASE):
+            return english
+    return None
+
+
 def _heritage_frame_errors(frame: Any, kind: str) -> list[str]:
     errors: list[str] = []
     if not isinstance(frame, dict):
@@ -2059,6 +2068,8 @@ def _build_heritage_items(
             "corrections": _clean_text_list(pair.get("corrections")),
             "sourceFamily": _clean_text(pair.get("sourceFamily")) or "",
         }
+        if prompt_en := _curated_prompt_en(frame):
+            item["promptEn"] = prompt_en
         rat_uk = _clean_text(pair.get("rationaleUk"))
         if rat_uk:
             item["rationaleUk"] = rat_uk
@@ -2158,6 +2169,8 @@ def _build_paronym_items(
             "citations": citations,
             "origin": origin,
         }
+        if prompt_en := _curated_prompt_en(frame):
+            item["promptEn"] = prompt_en
         # simple shuffle using deck seed if possible; fall back to list as-is
         # (real shuffle happens via rng in caller path for determinism; here keep order stable)
         items.append(_strip_paronym_option_metadata(item) if public_options else item)

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -4174,7 +4174,9 @@ function PracticeCloze({
   const optionErrors = validateClozeOptions(cloze);
   const blankText = feedback?.kind === 'correct' ? cloze.form : input.trim() || '?';
   const displayBlankText = displayPracticeForm(blankText, learnerLevel);
-  const sentenceEnglish = postAnswerSentenceEnglish(feedback, cloze.clozeEn);
+  const usableEnglish = usablePracticeSentenceEnglish(cloze.clozeEn);
+  // A1/EN chrome gets scaffolding before an answer; the answer-key remains all-level.
+  const sentenceEnglish = feedback || showEnglishSubtitles ? usableEnglish : null;
   const blankClass = [
     'cz-blank',
     displayBlankText !== '?' ? 'filled' : '',

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -2371,8 +2371,18 @@ describe('LexiconPractice', () => {
     expect(screen.getByLabelText('Вставте слово „згодом” у пропуск.')).toBeInTheDocument();
   });
 
-  test('cloze reveals a usable sentence English only after feedback', async () => {
+  test('cloze shows a usable sentence English before feedback for A1', () => {
     seedRecognitionMastery('knyha');
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
+    render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="cloze" />);
+
+    expect(screen.getByTestId('practice-cloze-sentence-en')).toHaveTextContent('I am reading a book.');
+  });
+
+  test('cloze A2 UK chrome hides sentence English before and reveals it after incorrect feedback', async () => {
+    seedRecognitionMastery('knyha');
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A2');
+    document.documentElement.dataset.chromeLocale = 'uk';
     const user = userEvent.setup();
     render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="cloze" />);
 
@@ -2384,12 +2394,29 @@ describe('LexiconPractice', () => {
     expect(screen.getByTestId('practice-cloze-sentence-en')).toHaveTextContent('I am reading a book.');
   });
 
+  test('cloze A2 UK chrome reveals sentence English after correct feedback', async () => {
+    seedRecognitionMastery('knyha');
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A2');
+    document.documentElement.dataset.chromeLocale = 'uk';
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="cloze" />);
+
+    expect(screen.queryByTestId('practice-cloze-sentence-en')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'книгу' }));
+    await user.click(screen.getByRole('button', { name: /Перевірити/ }));
+
+    expect(screen.getByTestId('practice-cloze-sentence-en')).toHaveTextContent('I am reading a book.');
+  });
+
   test('cloze omits blank or placeholder sentence English after feedback', async () => {
     seedRecognitionMastery('knyha');
     const user = userEvent.setup();
     const deck = sampleDeck();
     deck.cloze[0] = { ...deck.cloze[0]!, clozeEn: 'Context sentence for книгу' };
     render(<LexiconPractice initialDeck={deck} autoStart initialMode="cloze" />);
+
+    expect(screen.queryByTestId('practice-cloze-sentence-en')).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'робота' }));
     await user.click(screen.getByRole('button', { name: /Перевірити/ }));

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -16,6 +16,7 @@ from scripts.audit.generate_practice_deck import (
     _build_heritage_items,
     _build_lexeme,
     _build_paradigm_items,
+    _build_paronym_items,
     _declension_category,
     _eligible_decoys,
     _meaning_mc_eligible,
@@ -473,6 +474,23 @@ def test_heritage_item_options_are_valid_and_do_not_mark_calque() -> None:
             break
 
     assert "heritage options must not visually mark the calque pre-answer" in validate_heritage_item(marked)
+
+
+def test_heritage_builder_copies_curated_prompt_en_and_suppresses_placeholders() -> None:
+    pair = _fixture_heritage_pair()
+    lexemes = _fixture_lexemes()
+    pair["frames"][0]["sentence_en"] = "I am reading a book."
+
+    item = _build_heritage_items(pair, lexemes[0], lexemes, "deck-v1")[0]
+    assert item["promptEn"] == "I am reading a book."
+
+    pair["frames"][0].pop("sentence_en")
+    item_without_en = _build_heritage_items(pair, lexemes[0], lexemes, "deck-v1")[0]
+    assert "promptEn" not in item_without_en
+
+    pair["frames"][0]["sentence_en"] = "Context sentence for книгу"
+    placeholder_item = _build_heritage_items(pair, lexemes[0], lexemes, "deck-v1")[0]
+    assert "promptEn" not in placeholder_item
 
 
 def test_heritage_pair_native_slug_must_resolve_without_native_lemma_fallback(
@@ -1177,6 +1195,35 @@ def test_paronym_pairs_emit_items_both_directions_and_validate(capsys: pytest.Ca
     assert validate_paronym_pair(pair) == []
     for it in b1_items + b2_items:
         assert validate_paronym_item(it) == []
+
+
+def test_paronym_builder_copies_optional_curated_prompt_en() -> None:
+    lex_a = {"lemmaId": "бігати", "lemma": "бігати", "cefr": "B1"}
+    lex_b = {"lemmaId": "бігти", "lemma": "бігти", "cefr": "B1"}
+    pair = {
+        "slugA": "бігати",
+        "slugB": "бігти",
+        "distinction_gloss_uk": "Бігати регулярно, бігти конкретно зараз.",
+        "citations": ["fixture-test"],
+        "frames": [{
+            "sentence_with_slot": "Він ___ вранці.",
+            "prompt_en": "He ___ in the morning.",
+            "answer_form": "бігає",
+            "confusable_form": "біжить",
+            "origin": "fixture",
+        }],
+    }
+
+    item = _build_paronym_items(pair, lex_a, lex_b, "deck-v1")[0]
+    assert item["promptEn"] == "He ___ in the morning."
+
+    pair["frames"][0].pop("prompt_en")
+    item_without_en = _build_paronym_items(pair, lex_a, lex_b, "deck-v1")[0]
+    assert "promptEn" not in item_without_en
+
+    pair["frames"][0]["prompt_en"] = "Context sentence for бігати"
+    placeholder_item = _build_paronym_items(pair, lex_a, lex_b, "deck-v1")[0]
+    assert "promptEn" not in placeholder_item
 
 
 def test_paronym_missing_slug_skips_with_warn(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- Restore A1 / EN-chrome **pre-answer** cloze English (placeholder-filtered)
- Keep **post-answer** sentence EN at all levels (heritage/paronym/cloze)
- Deck generator: optional curated `promptEn` for heritage/paronym (`sentence_en` / `prompt_en` / `sentence_with_slot_en`) — never invent EN

## Verification
- pytest `tests/test_generate_practice_deck.py` (51 passed)
- Focused Vitest LexiconPractice (124 passed)
- Ruff / OPSEC / trailer

Fixes #5960
Related: #5959, #4700, #4387