### PR TITLE
feat(trails): TrailSpec v1.1 contracts — schemas + validator (P1)

### DIFF
--- a/agents_extensions/shared/schemas/command-receipt.v1.schema.json
+++ b/agents_extensions/shared/schemas/command-receipt.v1.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "command-receipt.v1",
+  "title": "CommandReceipt v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "invocation_id",
+    "run_id",
+    "trail_id",
+    "trail_version",
+    "trail_hash",
+    "step_id",
+    "resolved_command_digest",
+    "actor_outcome",
+    "exit_code",
+    "stdout_digest",
+    "stderr_digest",
+    "artifact_digests",
+    "prepared_at",
+    "completed_at",
+    "status"
+  ],
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  },
+  "properties": {
+    "schema_version": {"const": "command-receipt.v1"},
+    "invocation_id": {"type": "string", "format": "uuid"},
+    "run_id": {"type": "string", "minLength": 1},
+    "trail_id": {"type": "string", "minLength": 1},
+    "trail_version": {"type": ["string", "integer"]},
+    "trail_hash": {"$ref": "#/$defs/digest"},
+    "step_id": {"type": "string", "minLength": 1},
+    "resolved_command_digest": {"$ref": "#/$defs/digest"},
+    "actor_outcome": {"type": "string", "minLength": 1},
+    "exit_code": {"type": ["integer", "null"]},
+    "stdout_digest": {"$ref": "#/$defs/digest"},
+    "stderr_digest": {"$ref": "#/$defs/digest"},
+    "artifact_digests": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/digest"}
+    },
+    "prepared_at": {"type": "string", "format": "date-time"},
+    "completed_at": {"type": "string", "format": "date-time"},
+    "status": {"enum": ["complete", "indeterminate"]}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "complete"}}},
+      "then": {"properties": {"exit_code": {"type": "integer"}}}
+    }
+  ]
+}

--- a/agents_extensions/shared/schemas/step-receipt.v1.1.schema.json
+++ b/agents_extensions/shared/schemas/step-receipt.v1.1.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "step-receipt.v1.1",
+  "title": "StepReceipt v1.1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trail_id",
+    "trail_version",
+    "trail_hash",
+    "run_id",
+    "step_id",
+    "task_family",
+    "lineage_id",
+    "pr_head",
+    "lease_generation",
+    "predicate_exit",
+    "evidence_digest",
+    "transition_taken",
+    "timestamp",
+    "idempotency_key",
+    "invocation_id",
+    "command_receipt_digest",
+    "actor_outcome",
+    "predicate_id"
+  ],
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  },
+  "properties": {
+    "schema_version": {"const": "step-receipt.v1.1"},
+    "trail_id": {"type": "string", "minLength": 1},
+    "trail_version": {"type": ["string", "integer"]},
+    "trail_hash": {"$ref": "#/$defs/digest"},
+    "run_id": {"type": "string", "minLength": 1},
+    "step_id": {"type": "string", "minLength": 1},
+    "task_family": {"type": "string", "minLength": 1},
+    "lineage_id": {"type": ["string", "null"]},
+    "pr_head": {"type": ["string", "null"]},
+    "lease_generation": {"type": ["integer", "null"]},
+    "predicate_exit": {"type": ["integer", "null"]},
+    "evidence_digest": {"type": ["string", "null"], "pattern": "^[a-f0-9]{64}$"},
+    "transition_taken": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "idempotency_key": {"type": "string", "minLength": 1},
+    "invocation_id": {"type": "string", "format": "uuid"},
+    "command_receipt_digest": {"$ref": "#/$defs/digest"},
+    "actor_outcome": {"type": "string", "minLength": 1},
+    "predicate_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_-]*$"
+    },
+    "authority_receipt_digest": {"$ref": "#/$defs/digest"}
+  }
+}

--- a/agents_extensions/shared/schemas/trailspec.v1.1.schema.json
+++ b/agents_extensions/shared/schemas/trailspec.v1.1.schema.json
@@ -1,0 +1,276 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trailspec.v1.1",
+  "title": "TrailSpec v1.1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trail_id",
+    "version",
+    "title",
+    "seats",
+    "parameters",
+    "steps",
+    "stop_codes",
+    "terminal_outcomes"
+  ],
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "outcome_decoder": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source"],
+          "properties": {
+            "source": {"const": "stdout-token"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "pointer"],
+          "properties": {
+            "source": {"const": "artifact-json"},
+            "pointer": {
+              "type": "string",
+              "pattern": "^/(?:[^~/]|~[01])*$"
+            }
+          }
+        }
+      ]
+    },
+    "evidence_clause": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "field", "op", "value"],
+          "properties": {
+            "source": {"const": "command_receipt"},
+            "field": {"const": "actor_outcome"},
+            "op": {"const": "eq"},
+            "value": {"type": "string", "minLength": 1}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "field", "op", "value"],
+          "properties": {
+            "source": {"const": "command_receipt"},
+            "field": {"const": "exit_code"},
+            "op": {"const": "eq"},
+            "value": {"type": "integer"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "field", "op", "value"],
+          "properties": {
+            "source": {"const": "command_receipt"},
+            "field": {"const": "status"},
+            "op": {"const": "eq"},
+            "value": {"enum": ["complete", "indeterminate"]}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "field", "op", "value"],
+          "properties": {
+            "source": {"const": "command_receipt"},
+            "field": {
+              "enum": [
+                "invocation_id",
+                "run_id",
+                "trail_id",
+                "trail_version",
+                "step_id"
+              ]
+            },
+            "op": {"const": "eq"},
+            "value": {"type": "string", "minLength": 1}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "field", "op", "value"],
+          "properties": {
+            "source": {"const": "command_receipt"},
+            "field": {
+              "enum": [
+                "trail_hash",
+                "resolved_command_digest",
+                "stdout_digest",
+                "stderr_digest"
+              ]
+            },
+            "op": {"const": "eq"},
+            "value": {"$ref": "#/$defs/digest"}
+          }
+        }
+      ]
+    }
+  },
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "trailspec.v1.1"
+    },
+    "trail_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+$",
+      "minLength": 1
+    },
+    "version": {
+      "type": ["string", "integer"]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "seats": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$"
+      },
+      "uniqueItems": true,
+      "minItems": 1
+    },
+    "parameters": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+      },
+      "additionalProperties": {
+        "enum": ["string", "integer", "number", "boolean"]
+      }
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["step_id", "intent", "command", "transitions"],
+        "properties": {
+          "step_id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_-]*$"
+          },
+          "intent": {
+            "type": "string",
+            "minLength": 1
+          },
+          "command": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "adapter",
+              "argv",
+              "environment",
+              "timeout_seconds",
+              "mutation_class",
+              "outcome_decoder"
+            ],
+            "properties": {
+              "adapter": {
+                "enum": ["shell", "typed-primitive"]
+              },
+              "argv": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "minItems": 1
+              },
+              "environment": {
+                "type": "object",
+                "additionalProperties": {"type": "string"}
+              },
+              "timeout_seconds": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "mutation_class": {
+                "enum": ["observe", "local-write", "remote-mutation"]
+              },
+              "outcome_decoder": {"$ref": "#/$defs/outcome_decoder"}
+            }
+          },
+          "transitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["target", "evidence"],
+              "properties": {
+                "target": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "evidence": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["predicate_id", "clauses"],
+                  "properties": {
+                    "predicate_id": {
+                      "type": "string",
+                      "pattern": "^[a-z][a-z0-9_-]*$"
+                    },
+                    "clauses": {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {"$ref": "#/$defs/evidence_clause"}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "blocked_on": {
+            "oneOf": [
+              {"type": "null"},
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["id", "reason", "stop_code"],
+                "properties": {
+                  "id": {"type": "string", "minLength": 1},
+                  "reason": {"type": "string", "minLength": 1},
+                  "stop_code": {
+                    "type": "string",
+                    "pattern": "^STOP-[a-z0-9-]+$"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "stop_codes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^STOP-[a-z0-9-]+$"
+      },
+      "uniqueItems": true
+    },
+    "terminal_outcomes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/scripts/orchestration/red_ci_known_failures.py
+++ b/scripts/orchestration/red_ci_known_failures.py
@@ -53,9 +53,10 @@ _RECEIPT_SOURCE_FIELDS = frozenset(
     }
 )
 
-# Published STOP-code contract. validate_trailspec imports this single source so
-# direct invocation of this lookup module never depends on package import layout.
-VALID_STOP_CODES: set[str] = {
+# Published 18-code STOP vocabulary. The historic "16" count describes trigger
+# classes only; it is not the executable vocabulary. validate_trailspec imports
+# this immutable source so direct invocation never depends on package layout.
+VALID_STOP_CODES: frozenset[str] = frozenset({
     "STOP-timeout",
     "STOP-verdict-timeout",
     "STOP-contested",
@@ -74,7 +75,7 @@ VALID_STOP_CODES: set[str] = {
     "STOP-unknown",
     "STOP-rearm-failed",
     "STOP-hygiene-failed",
-}
+})
 
 
 class RedCIKnownFailuresValidationError(Exception):

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-"""Validator for TrailSpec v1 and StepReceipt v1 schemas and state machine invariants."""
+"""Validate TrailSpec v1/v1.1 and their receipt contracts.
+
+TrailSpec v1 remains an immutable, schema-valid historical format.  The
+validator deliberately reports it as execution-ineligible: a prose predicate
+cannot be soundly compiled into an executable receipt predicate.  v1.1 adds the
+receipt-bound command and transition contracts needed by a future runner.
+"""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
+import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -27,9 +34,19 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 TRAIL_SPEC_SCHEMA_PATH = (
     PROJECT_ROOT / "agents_extensions/shared/schemas/trailspec.v1.schema.json"
 )
+TRAIL_SPEC_V11_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/trailspec.v1.1.schema.json"
+)
 STEP_RECEIPT_SCHEMA_PATH = (
     PROJECT_ROOT / "agents_extensions/shared/schemas/step-receipt.v1.schema.json"
 )
+STEP_RECEIPT_V11_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/step-receipt.v1.1.schema.json"
+)
+COMMAND_RECEIPT_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/command-receipt.v1.schema.json"
+)
+SEAT_TAXONOMY_PATH = PROJECT_ROOT / "scripts/config/fleet_communications.yaml"
 DEFAULT_EXAMPLE_TRAIL_PATH = (
     PROJECT_ROOT / "scripts/config/trails/rb3-pr-lifecycle.trail.yaml"
 )
@@ -39,6 +56,16 @@ DECISION_TABLES_SCHEMA_PATH = (
 DEFAULT_DECISION_TABLES_PATH = (
     PROJECT_ROOT / "scripts/config/trails/decision-tables.v0.yaml"
 )
+
+_TRAIL_SCHEMA_PATHS = {
+    "trailspec.v1": TRAIL_SPEC_SCHEMA_PATH,
+    "trailspec.v1.1": TRAIL_SPEC_V11_SCHEMA_PATH,
+}
+_STEP_RECEIPT_SCHEMA_PATHS = {
+    "step-receipt.v1": STEP_RECEIPT_SCHEMA_PATH,
+    "step-receipt.v1.1": STEP_RECEIPT_V11_SCHEMA_PATH,
+}
+_PARAMETER_REFERENCE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
 class TrailSpecValidationError(Exception):
     """Raised when TrailSpec or StepReceipt validation fails."""
@@ -73,6 +100,12 @@ def _load_schema(path: Path) -> dict[str, Any]:
     return data
 
 
+def _compute_canonical_json_digest(data: dict[str, Any]) -> str:
+    """Return a SHA-256 digest of semantic JSON data, independent of formatting."""
+    canonical_json = json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
+
+
 def compute_trail_hash(data: dict[str, Any]) -> str:
     """Compute canonical-JSON SHA-256 hash of a parsed TrailSpec document.
 
@@ -82,52 +115,235 @@ def compute_trail_hash(data: dict[str, Any]) -> str:
     and compute SHA-256 hex digest. This ensures hash stability across formatting/whitespace
     changes while reflecting any semantic content mutation.
     """
-    canonical_json = json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
+    return _compute_canonical_json_digest(data)
+
+
+def compute_command_receipt_digest(data: dict[str, Any]) -> str:
+    """Compute the canonical digest referenced by StepReceipt.command_receipt_digest."""
+    return _compute_canonical_json_digest(data)
+
+
+def _schema_path_for(
+    data: dict[str, Any],
+    *,
+    paths: dict[str, Path],
+    label: str,
+    supplied_path: Path | None,
+) -> Path:
+    """Resolve a versioned schema unless a caller explicitly pins one."""
+    if supplied_path is not None:
+        return supplied_path
+    version = data.get("schema_version")
+    if not isinstance(version, str) or version not in paths:
+        raise TrailSpecValidationError(
+            f"Unsupported {label} schema_version {version!r}; expected one of {sorted(paths)}"
+        )
+    return paths[version]
+
+
+def _validate_against_schema(
+    data: dict[str, Any],
+    *,
+    schema_path: Path,
+    label: str,
+) -> None:
+    schema = _load_schema(schema_path)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(data), key=lambda error: error.path)
+    if errors:
+        err = errors[0]
+        raise TrailSpecValidationError(
+            f"{label} schema violation: {err.message} at {err.json_path}"
+        )
 
 
 def validate_step_receipt_data(
     receipt_data: dict[str, Any],
     *,
-    receipt_schema_path: Path = STEP_RECEIPT_SCHEMA_PATH,
+    receipt_schema_path: Path | None = None,
 ) -> dict[str, Any]:
-    """Validate raw loaded dict against StepReceipt JSON Schema."""
-    receipt_schema = _load_schema(receipt_schema_path)
-    validator = Draft202012Validator(receipt_schema, format_checker=FormatChecker())
-    errors = sorted(validator.iter_errors(receipt_data), key=lambda e: e.path)
-    if errors:
-        err = errors[0]
-        raise TrailSpecValidationError(
-            f"StepReceipt schema violation: {err.message} at {err.json_path}"
-        )
+    """Validate raw loaded dict against the version-selected StepReceipt schema."""
+    resolved_schema_path = _schema_path_for(
+        receipt_data,
+        paths=_STEP_RECEIPT_SCHEMA_PATHS,
+        label="StepReceipt",
+        supplied_path=receipt_schema_path,
+    )
+    _validate_against_schema(
+        receipt_data, schema_path=resolved_schema_path, label="StepReceipt"
+    )
     return {
         "ok": True,
+        "schema_version": receipt_data.get("schema_version"),
         "step_id": receipt_data.get("step_id"),
         "run_id": receipt_data.get("run_id"),
     }
 
 
+def validate_command_receipt_data(
+    receipt_data: dict[str, Any],
+    *,
+    receipt_schema_path: Path = COMMAND_RECEIPT_SCHEMA_PATH,
+) -> dict[str, Any]:
+    """Validate a CommandReceipt v1 document independently of a step receipt."""
+    _validate_against_schema(
+        receipt_data, schema_path=receipt_schema_path, label="CommandReceipt"
+    )
+    return {
+        "ok": True,
+        "invocation_id": receipt_data.get("invocation_id"),
+        "step_id": receipt_data.get("step_id"),
+        "status": receipt_data.get("status"),
+    }
+
+
+def _load_eligible_seats(seat_registry_path: Path) -> set[str]:
+    """Return active seat names from the live fleet taxonomy registry.
+
+    v1.1 deliberately does not carry a static seat enum: endpoint membership
+    and state are the registry-controlled eligibility contract.  ``retired``
+    endpoints are excluded even though their historic names remain recorded.
+    """
+    registry = _load_yaml_or_json(seat_registry_path)
+    endpoints = registry.get("endpoints")
+    if not isinstance(endpoints, list):
+        raise TrailSpecValidationError(
+            f"Seat taxonomy registry {seat_registry_path} must contain an endpoints list"
+        )
+
+    eligible: set[str] = set()
+    for endpoint in endpoints:
+        if not isinstance(endpoint, dict):
+            raise TrailSpecValidationError(
+                f"Seat taxonomy registry {seat_registry_path} contains a non-mapping endpoint"
+            )
+        name = endpoint.get("name")
+        state = endpoint.get("state")
+        if not isinstance(name, str) or not name:
+            raise TrailSpecValidationError(
+                f"Seat taxonomy registry {seat_registry_path} has an endpoint without a name"
+            )
+        if state in {"live", "local_only"}:
+            eligible.add(name)
+    if not eligible:
+        raise TrailSpecValidationError(
+            f"Seat taxonomy registry {seat_registry_path} has no eligible live endpoints"
+        )
+    return eligible
+
+
+def _validate_v11_seats(spec_data: dict[str, Any], seat_registry_path: Path) -> None:
+    eligible = _load_eligible_seats(seat_registry_path)
+    unknown = sorted(set(spec_data["seats"]) - eligible)
+    if unknown:
+        raise TrailSpecValidationError(
+            "TrailSpec v1.1 seat eligibility failed: "
+            f"{unknown} not present as live/local_only endpoints in {seat_registry_path} "
+            f"(eligible: {sorted(eligible)})"
+        )
+
+
+def _validate_v11_invocation_fields(spec_data: dict[str, Any]) -> None:
+    """Enforce the static invocation binding that the runner must preserve."""
+    declared_parameters = set(spec_data["parameters"])
+    for step in spec_data["steps"]:
+        step_id = step["step_id"]
+        command = step["command"]
+        environment = command["environment"]
+        if environment.get("TRAIL_INVOCATION_ID") != "{invocation_id}":
+            raise TrailSpecValidationError(
+                f"Invocation binding violated: step '{step_id}' must set "
+                "TRAIL_INVOCATION_ID to '{invocation_id}'"
+            )
+
+        argv = command["argv"]
+        if command["adapter"] == "typed-primitive":
+            try:
+                invocation_flag_index = argv.index("--invocation-id")
+            except ValueError as exc:
+                raise TrailSpecValidationError(
+                    f"Invocation binding violated: typed-primitive step '{step_id}' "
+                    "must pass --invocation-id {invocation_id}"
+                ) from exc
+            if (
+                invocation_flag_index + 1 >= len(argv)
+                or argv[invocation_flag_index + 1] != "{invocation_id}"
+            ):
+                raise TrailSpecValidationError(
+                    f"Invocation binding violated: typed-primitive step '{step_id}' "
+                    "must pass --invocation-id {invocation_id}"
+                )
+
+        if command["adapter"] == "shell":
+            for index, token in enumerate(argv[:-1]):
+                if token == "-c" and _PARAMETER_REFERENCE.search(argv[index + 1]):
+                    raise TrailSpecValidationError(
+                        f"Unquoted parameter interpolation prohibited: shell step '{step_id}' "
+                        "must pass parameters through argv/environment, not a -c program"
+                    )
+
+        values_to_check = [*argv, *environment.values()]
+        for value in values_to_check:
+            for reference in _PARAMETER_REFERENCE.findall(value):
+                if reference != "invocation_id" and reference not in declared_parameters:
+                    raise TrailSpecValidationError(
+                        f"Undeclared command parameter '{reference}' in step '{step_id}'"
+                    )
+
+
+def _validate_v11_transition_predicates(spec_data: dict[str, Any]) -> None:
+    """Require one distinct, receipt-only predicate identity for every transition."""
+    for step in spec_data["steps"]:
+        predicate_ids: set[str] = set()
+        transitions = step["transitions"]
+        for label, transition in transitions.items():
+            evidence = transition["evidence"]
+            predicate_id = evidence["predicate_id"]
+            if predicate_id in predicate_ids:
+                raise TrailSpecValidationError(
+                    f"Exactly-one-predicate rule violated: step '{step['step_id']}' "
+                    f"reuses predicate_id '{predicate_id}' in its transition set"
+                )
+            predicate_ids.add(predicate_id)
+            for clause in evidence["clauses"]:
+                if clause["source"] != "command_receipt":
+                    raise TrailSpecValidationError(
+                        f"Predicate command-execution prohibition violated: step '{step['step_id']}' "
+                        f"transition '{label}' must reference command_receipt fields only"
+                    )
+
+
+def _transition_targets(step: dict[str, Any], *, is_v11: bool) -> list[str]:
+    transitions = step.get("transitions", {})
+    if is_v11:
+        return [transition["target"] for transition in transitions.values()]
+    return list(transitions.values())
+
+
 def validate_trailspec_data(
     spec_data: dict[str, Any],
     *,
-    spec_schema_path: Path = TRAIL_SPEC_SCHEMA_PATH,
+    spec_schema_path: Path | None = None,
+    seat_registry_path: Path = SEAT_TAXONOMY_PATH,
 ) -> dict[str, Any]:
     """Validate raw loaded dict against TrailSpec JSON Schema and domain invariants."""
-    spec_schema = _load_schema(spec_schema_path)
-    validator = Draft202012Validator(spec_schema, format_checker=FormatChecker())
-    errors = sorted(validator.iter_errors(spec_data), key=lambda e: e.path)
-    if errors:
-        err = errors[0]
-        raise TrailSpecValidationError(
-            f"TrailSpec schema violation: {err.message} at {err.json_path}"
-        )
+    resolved_schema_path = _schema_path_for(
+        spec_data,
+        paths=_TRAIL_SCHEMA_PATHS,
+        label="TrailSpec",
+        supplied_path=spec_schema_path,
+    )
+    _validate_against_schema(
+        spec_data, schema_path=resolved_schema_path, label="TrailSpec"
+    )
+    is_v11 = spec_data["schema_version"] == "trailspec.v1.1"
 
     # Invariant 1: Stop codes must be from published contract list
     declared_stop_codes = set(spec_data.get("stop_codes", []))
     invalid_stops = declared_stop_codes - VALID_STOP_CODES
     if invalid_stops:
         raise TrailSpecValidationError(
-            f"Unknown stop_code(s) {sorted(invalid_stops)}: must be from published 16-item contract list"
+            f"Unknown stop_code(s) {sorted(invalid_stops)}: must be from the published 18-code STOP vocabulary"
         )
 
     steps = spec_data.get("steps", [])
@@ -141,19 +357,37 @@ def validate_trailspec_data(
         kind = step.get("kind")
         evidence_predicate = step.get("evidence_predicate")
 
-        # Invariant 2: No silent judgment steps (kind != summon must have evidence_predicate)
-        if kind != "summon" and evidence_predicate is None:
+        # v1's prose predicate contract is retained only for backward-compatible
+        # validation. v1.1 has one receipt predicate per transition instead.
+        if not is_v11 and kind != "summon" and evidence_predicate is None:
             raise TrailSpecValidationError(
                 f"No silent judgment steps invariant violated: step '{step_id}' with kind '{kind}' lacks an evidence_predicate"
             )
 
-        # Invariant 3: Every transition target must exist in step_ids, stop_codes, or terminal_outcomes
-        transitions = step.get("transitions", {})
-        for label, target in transitions.items():
+        for label, transition in step.get("transitions", {}).items():
+            target = transition["target"] if is_v11 else transition
             if target not in valid_transition_targets:
                 raise TrailSpecValidationError(
                     f"Dangling transition in step '{step_id}' (label '{label}'): target '{target}' does not exist in steps, stop_codes, or terminal_outcomes"
                 )
+
+        if is_v11:
+            blocked_on = step.get("blocked_on")
+            if blocked_on is not None:
+                stop_code = blocked_on["stop_code"]
+                if stop_code not in VALID_STOP_CODES:
+                    raise TrailSpecValidationError(
+                        f"Blocked step '{step_id}' names unknown stop_code '{stop_code}'"
+                    )
+                if stop_code not in declared_stop_codes:
+                    raise TrailSpecValidationError(
+                        f"Blocked step '{step_id}' stop_code '{stop_code}' must be declared by the trail"
+                    )
+
+    if is_v11:
+        _validate_v11_seats(spec_data, seat_registry_path)
+        _validate_v11_invocation_fields(spec_data)
+        _validate_v11_transition_predicates(spec_data)
 
     # Invariant 4: Graph reachability — every step must be reachable from the first step
     if steps:
@@ -168,7 +402,7 @@ def validate_trailspec_data(
                 continue
             visited.add(curr)
             curr_step = step_id_to_step.get(curr, {})
-            for target in curr_step.get("transitions", {}).values():
+            for target in _transition_targets(curr_step, is_v11=is_v11):
                 if target in step_id_to_step and target not in visited:
                     queue.append(target)
 
@@ -185,7 +419,101 @@ def validate_trailspec_data(
         "version": spec_data.get("version"),
         "steps_count": len(steps),
         "trail_hash": trail_hash,
+        "execution_eligible": is_v11,
+        **(
+            {}
+            if is_v11
+            else {
+                "execution_refusal": "TrailSpec v1 is schema-valid but execution-ineligible; "
+                "the runner must refuse v1 execution and closure."
+            }
+        ),
     }
+
+
+def _validate_v11_receipt_binding(
+    spec_data: dict[str, Any],
+    step_receipt_data: dict[str, Any],
+    command_receipt_data: dict[str, Any] | None = None,
+) -> None:
+    """Bind v1.1 receipts to the immutable pinned trail and selected predicate."""
+    expected_values = {
+        "trail_id": spec_data["trail_id"],
+        "trail_version": spec_data["version"],
+        "trail_hash": compute_trail_hash(spec_data),
+    }
+    for field, expected in expected_values.items():
+        if step_receipt_data[field] != expected:
+            raise TrailSpecValidationError(
+                f"StepReceipt binding violated: {field}={step_receipt_data[field]!r} "
+                f"does not match pinned trail value {expected!r}"
+            )
+
+    step_by_id = {step["step_id"]: step for step in spec_data["steps"]}
+    step_id = step_receipt_data["step_id"]
+    step = step_by_id.get(step_id)
+    if step is None:
+        raise TrailSpecValidationError(
+            f"StepReceipt binding violated: unknown step_id '{step_id}'"
+        )
+
+    transition_taken = step_receipt_data["transition_taken"]
+    transition = step["transitions"].get(transition_taken)
+    if transition is None:
+        raise TrailSpecValidationError(
+            f"StepReceipt transition_taken must be a transition label, not a target: "
+            f"'{transition_taken}' is not a label for step '{step_id}'"
+        )
+    expected_predicate_id = transition["evidence"]["predicate_id"]
+    if step_receipt_data["predicate_id"] != expected_predicate_id:
+        raise TrailSpecValidationError(
+            f"StepReceipt predicate_id '{step_receipt_data['predicate_id']}' does not match "
+            f"transition label '{transition_taken}' predicate '{expected_predicate_id}'"
+        )
+
+    if command_receipt_data is None:
+        return
+
+    command_expected_values = {
+        **expected_values,
+        "run_id": step_receipt_data["run_id"],
+        "step_id": step_id,
+        "invocation_id": step_receipt_data["invocation_id"],
+        "actor_outcome": step_receipt_data["actor_outcome"],
+    }
+    for field, expected in command_expected_values.items():
+        if command_receipt_data[field] != expected:
+            raise TrailSpecValidationError(
+                f"CommandReceipt binding violated: {field}={command_receipt_data[field]!r} "
+                f"does not match bound StepReceipt/trail value {expected!r}"
+            )
+
+    matching_labels = [
+        label
+        for label, candidate in step["transitions"].items()
+        if all(
+            command_receipt_data[clause["field"]] == clause["value"]
+            for clause in candidate["evidence"]["clauses"]
+        )
+    ]
+    if len(matching_labels) != 1:
+        raise TrailSpecValidationError(
+            f"Exactly-one-predicate match rule violated for step '{step_id}': "
+            f"matched {matching_labels}; runner must park this invocation as STOP-unknown"
+        )
+    if transition_taken != matching_labels[0]:
+        raise TrailSpecValidationError(
+            f"StepReceipt transition_taken '{transition_taken}' does not match command "
+            f"receipt predicate result '{matching_labels[0]}'"
+        )
+
+    if (
+        compute_command_receipt_digest(command_receipt_data)
+        != step_receipt_data["command_receipt_digest"]
+    ):
+        raise TrailSpecValidationError(
+            "StepReceipt command_receipt_digest does not match the canonical CommandReceipt digest"
+        )
 
 
 def validate_decision_tables_data(
@@ -289,20 +617,57 @@ def validate_trailspec(
     *,
     spec_path: Path = DEFAULT_EXAMPLE_TRAIL_PATH,
     receipt_path: Path | None = None,
+    command_receipt_path: Path | None = None,
     registry_path: Path | None = None,
     as_of: str | datetime | None = None,
-    spec_schema_path: Path = TRAIL_SPEC_SCHEMA_PATH,
-    receipt_schema_path: Path = STEP_RECEIPT_SCHEMA_PATH,
+    spec_schema_path: Path | None = None,
+    receipt_schema_path: Path | None = None,
+    command_receipt_schema_path: Path = COMMAND_RECEIPT_SCHEMA_PATH,
+    seat_registry_path: Path = SEAT_TAXONOMY_PATH,
 ) -> dict[str, Any]:
-    """Validate trail spec file and optional step receipt or registry file."""
+    """Validate a versioned trail spec and its optional receipt projections."""
     spec_data = _load_yaml_or_json(spec_path)
-    spec_summary = validate_trailspec_data(spec_data, spec_schema_path=spec_schema_path)
+    spec_summary = validate_trailspec_data(
+        spec_data,
+        spec_schema_path=spec_schema_path,
+        seat_registry_path=seat_registry_path,
+    )
 
     receipt_summary = None
+    step_receipt_data = None
     if receipt_path is not None:
-        receipt_data = _load_yaml_or_json(receipt_path)
+        step_receipt_data = _load_yaml_or_json(receipt_path)
         receipt_summary = validate_step_receipt_data(
-            receipt_data, receipt_schema_path=receipt_schema_path
+            step_receipt_data, receipt_schema_path=receipt_schema_path
+        )
+
+    command_receipt_summary = None
+    command_receipt_data = None
+    if command_receipt_path is not None:
+        command_receipt_data = _load_yaml_or_json(command_receipt_path)
+        command_receipt_summary = validate_command_receipt_data(
+            command_receipt_data, receipt_schema_path=command_receipt_schema_path
+        )
+
+    is_v11 = spec_data["schema_version"] == "trailspec.v1.1"
+    if not is_v11 and command_receipt_data is not None:
+        raise TrailSpecValidationError(
+            "TrailSpec v1 is execution-ineligible and cannot bind a CommandReceipt"
+        )
+    if step_receipt_data is not None:
+        expected_receipt_version = "step-receipt.v1.1" if is_v11 else "step-receipt.v1"
+        if step_receipt_data["schema_version"] != expected_receipt_version:
+            raise TrailSpecValidationError(
+                f"TrailSpec {spec_data['schema_version']} requires {expected_receipt_version}, "
+                f"got {step_receipt_data['schema_version']}"
+            )
+        if is_v11:
+            _validate_v11_receipt_binding(
+                spec_data, step_receipt_data, command_receipt_data
+            )
+    elif command_receipt_data is not None:
+        raise TrailSpecValidationError(
+            "A CommandReceipt requires its bound StepReceipt v1.1"
         )
 
     res = {
@@ -311,6 +676,8 @@ def validate_trailspec(
     }
     if receipt_summary is not None:
         res["receipt"] = receipt_summary
+    if command_receipt_summary is not None:
+        res["command_receipt"] = command_receipt_summary
     if registry_path is not None:
         res["registry"] = validate_registry(registry_path, as_of=as_of)
     return res
@@ -318,7 +685,7 @@ def validate_trailspec(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Validate TrailSpec v1, StepReceipt v1, and Red-CI Known Failures Registry instances."
+        description="Validate TrailSpec v1/v1.1, receipt contracts, and Red-CI registry instances."
     )
     parser.add_argument(
         "--spec",
@@ -330,7 +697,19 @@ def main(argv: list[str] | None = None) -> int:
         "--receipt",
         type=Path,
         default=None,
-        help="optional path to StepReceipt JSON/YAML file",
+        help="optional path to version-matched StepReceipt JSON/YAML file",
+    )
+    parser.add_argument(
+        "--command-receipt",
+        type=Path,
+        default=None,
+        help="optional CommandReceipt v1 JSON/YAML file; requires --receipt and a v1.1 trail",
+    )
+    parser.add_argument(
+        "--seat-registry",
+        type=Path,
+        default=SEAT_TAXONOMY_PATH,
+        help="fleet endpoint taxonomy used for TrailSpec v1.1 seat eligibility",
     )
     parser.add_argument(
         "--tables",
@@ -361,8 +740,12 @@ def main(argv: list[str] | None = None) -> int:
         summary = validate_trailspec(
             spec_path=args.spec.resolve(),
             receipt_path=args.receipt.resolve() if args.receipt else None,
+            command_receipt_path=(
+                args.command_receipt.resolve() if args.command_receipt else None
+            ),
             registry_path=args.registry.resolve() if args.registry else None,
             as_of=args.as_of,
+            seat_registry_path=args.seat_registry.resolve(),
         )
         if args.tables is not None:
             tables_path = args.tables.resolve()
@@ -387,10 +770,18 @@ def main(argv: list[str] | None = None) -> int:
         spec_info = summary["spec"]
         print(
             f"TrailSpec valid: id='{spec_info['trail_id']}' version='{spec_info['version']}' "
-            f"steps={spec_info['steps_count']} hash={spec_info['trail_hash']}"
+            f"steps={spec_info['steps_count']} hash={spec_info['trail_hash']} "
+            f"execution_eligible={spec_info['execution_eligible']}"
         )
         if "receipt" in summary:
             print(f"StepReceipt valid: step_id='{summary['receipt']['step_id']}'")
+        if "command_receipt" in summary:
+            command_receipt = summary["command_receipt"]
+            print(
+                "CommandReceipt valid: "
+                f"step_id='{command_receipt['step_id']}' "
+                f"status='{command_receipt['status']}'"
+            )
         if "registry" in summary:
             reg = summary["registry"]
             print(

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -275,11 +275,34 @@ def _validate_v11_invocation_fields(spec_data: dict[str, Any]) -> None:
                 )
 
         if command["adapter"] == "shell":
-            for index, token in enumerate(argv[:-1]):
-                if token == "-c" and _PARAMETER_REFERENCE.search(argv[index + 1]):
+            # Fail-closed shell-invocation shape (review finding on #5963): matching
+            # only a literal "-c" token let `sh -lc`, `bash --login -c`, `-ec`, etc.
+            # smuggle parameter interpolation into a shell-interpreted program string.
+            # The shell adapter execs argv DIRECTLY, so a plain command with parameters
+            # as discrete argv elements is safe. But if argv[0] is a shell binary (or a
+            # wrapper that could reach one), the ONLY accepted shape is exactly
+            # [sh|bash, -c, <program>] and the program token may not reference
+            # parameters — every other flag spelling or layout is rejected outright.
+            _SHELL_BINARIES = {"sh", "bash", "zsh", "dash", "ksh"}
+            _WRAPPER_BINARIES = {"env", "nohup", "stdbuf", "nice", "timeout", "xargs"}
+            argv0_base = argv[0].rsplit("/", 1)[-1]
+            if argv0_base in _WRAPPER_BINARIES:
+                raise TrailSpecValidationError(
+                    f"Unsupported shell invocation shape in step '{step_id}': wrapper "
+                    f"'{argv0_base}' indirection is not allowed for the shell adapter"
+                )
+            if argv0_base in _SHELL_BINARIES:
+                if len(argv) != 3 or argv0_base not in ("sh", "bash") or argv[1] != "-c":
                     raise TrailSpecValidationError(
-                        f"Unquoted parameter interpolation prohibited: shell step '{step_id}' "
-                        "must pass parameters through argv/environment, not a -c program"
+                        f"Unsupported shell invocation shape in step '{step_id}': "
+                        "shell-binary invocations accept exactly [sh|bash, -c, "
+                        "<program>] — no other flags or argument layouts"
+                    )
+                if _PARAMETER_REFERENCE.search(argv[2]):
+                    raise TrailSpecValidationError(
+                        f"Unquoted parameter interpolation prohibited: shell step "
+                        f"'{step_id}' must pass parameters through argv/environment, "
+                        "not a -c program"
                     )
 
         values_to_check = [*argv, *environment.values()]

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -1,4 +1,4 @@
-"""Tests for TrailSpec v1 and StepReceipt v1 validation and invariants."""
+"""Tests for TrailSpec v1/v1.1 validation and receipt-contract invariants."""
 
 from __future__ import annotations
 
@@ -9,13 +9,19 @@ from typing import Any
 import pytest
 import yaml
 
+from scripts.orchestration.red_ci_known_failures import VALID_STOP_CODES
 from scripts.orchestration.validate_trailspec import (
+    COMMAND_RECEIPT_SCHEMA_PATH,
     DEFAULT_DECISION_TABLES_PATH,
     DEFAULT_EXAMPLE_TRAIL_PATH,
     STEP_RECEIPT_SCHEMA_PATH,
+    STEP_RECEIPT_V11_SCHEMA_PATH,
     TRAIL_SPEC_SCHEMA_PATH,
+    TRAIL_SPEC_V11_SCHEMA_PATH,
     TrailSpecValidationError,
+    compute_command_receipt_digest,
     compute_trail_hash,
+    validate_command_receipt_data,
     validate_decision_tables,
     validate_decision_tables_data,
     validate_step_receipt_data,
@@ -88,6 +94,118 @@ def _get_happy_step_receipt_data() -> dict[str, Any]:
     }
 
 
+def _get_happy_v11_trail_data() -> dict[str, Any]:
+    """Small, complete v1.1 trail fixture with receipt-only predicates."""
+    return {
+        "schema_version": "trailspec.v1.1",
+        "trail_id": "v11-contract-fixture",
+        "version": "1.1.0",
+        "title": "TrailSpec v1.1 contract fixture",
+        "seats": ["kimi"],
+        "parameters": {"issue_number": "integer"},
+        "steps": [
+            {
+                "step_id": "observe_issue",
+                "intent": "Observe the configured issue once.",
+                "command": {
+                    "adapter": "shell",
+                    "argv": ["issue-observer", "--issue", "{issue_number}"],
+                    "environment": {"TRAIL_INVOCATION_ID": "{invocation_id}"},
+                    "timeout_seconds": 30,
+                    "mutation_class": "observe",
+                    "outcome_decoder": {"source": "stdout-token"},
+                },
+                "transitions": {
+                    "accepted": {
+                        "target": "complete",
+                        "evidence": {
+                            "predicate_id": "accepted-outcome",
+                            "clauses": [
+                                {
+                                    "source": "command_receipt",
+                                    "field": "actor_outcome",
+                                    "op": "eq",
+                                    "value": "accepted",
+                                },
+                                {
+                                    "source": "command_receipt",
+                                    "field": "exit_code",
+                                    "op": "eq",
+                                    "value": 0,
+                                },
+                            ],
+                        },
+                    },
+                    "refused": {
+                        "target": "complete",
+                        "evidence": {
+                            "predicate_id": "refused-outcome",
+                            "clauses": [
+                                {
+                                    "source": "command_receipt",
+                                    "field": "actor_outcome",
+                                    "op": "eq",
+                                    "value": "refused",
+                                }
+                            ],
+                        },
+                    },
+                },
+                "blocked_on": None,
+            }
+        ],
+        "stop_codes": ["STOP-unknown"],
+        "terminal_outcomes": ["complete"],
+    }
+
+
+def _get_happy_command_receipt_data(trail: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": "command-receipt.v1",
+        "invocation_id": "3e99cd0b-6718-48a9-a2c9-9658a650bc55",
+        "run_id": "run-20260728-001",
+        "trail_id": trail["trail_id"],
+        "trail_version": trail["version"],
+        "trail_hash": compute_trail_hash(trail),
+        "step_id": "observe_issue",
+        "resolved_command_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "actor_outcome": "accepted",
+        "exit_code": 0,
+        "stdout_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stderr_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "artifact_digests": {},
+        "prepared_at": "2026-07-28T10:00:00Z",
+        "completed_at": "2026-07-28T10:00:01Z",
+        "status": "complete",
+    }
+
+
+def _get_happy_v11_step_receipt_data(
+    trail: dict[str, Any], command_receipt: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "schema_version": "step-receipt.v1.1",
+        "trail_id": trail["trail_id"],
+        "trail_version": trail["version"],
+        "trail_hash": compute_trail_hash(trail),
+        "run_id": command_receipt["run_id"],
+        "step_id": command_receipt["step_id"],
+        "task_family": "infra-orchestration",
+        "lineage_id": "lin-12345",
+        "pr_head": None,
+        "lease_generation": 1,
+        "predicate_exit": 0,
+        "evidence_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "transition_taken": "accepted",
+        "timestamp": "2026-07-28T10:00:02Z",
+        "idempotency_key": "idempotency-key-001",
+        "invocation_id": command_receipt["invocation_id"],
+        "command_receipt_digest": compute_command_receipt_digest(command_receipt),
+        "actor_outcome": command_receipt["actor_outcome"],
+        "predicate_id": "accepted-outcome",
+    }
+
+
 def test_happy_path_example_trail() -> None:
     """Happy path: validate the example rb3-pr-lifecycle.trail.yaml."""
     res = validate_trailspec(spec_path=DEFAULT_EXAMPLE_TRAIL_PATH)
@@ -107,6 +225,337 @@ def test_happy_path_step_receipt() -> None:
     assert res["ok"] is True
     assert res["step_id"] == "request_review"
     assert res["run_id"] == "run-20260727-001"
+
+
+def test_v1_is_schema_valid_but_execution_ineligible() -> None:
+    """v1 can be inspected and hashed, but its prose predicates cannot be executed."""
+    res = validate_trailspec_data(_get_happy_example_data())
+
+    assert res["ok"] is True
+    assert res["execution_eligible"] is False
+    assert "must refuse v1 execution and closure" in res["execution_refusal"]
+
+
+def test_v11_happy_path_binds_command_and_step_receipts(tmp_path) -> None:
+    """v1.1 validates the command/receipt chain and reports execution eligibility."""
+    trail = _get_happy_v11_trail_data()
+    command_receipt = _get_happy_command_receipt_data(trail)
+    step_receipt = _get_happy_v11_step_receipt_data(trail, command_receipt)
+
+    trail_path = tmp_path / "trail.json"
+    command_receipt_path = tmp_path / "command-receipt.json"
+    step_receipt_path = tmp_path / "step-receipt.json"
+    trail_path.write_text(json.dumps(trail), encoding="utf-8")
+    command_receipt_path.write_text(json.dumps(command_receipt), encoding="utf-8")
+    step_receipt_path.write_text(json.dumps(step_receipt), encoding="utf-8")
+
+    res = validate_trailspec(
+        spec_path=trail_path,
+        receipt_path=step_receipt_path,
+        command_receipt_path=command_receipt_path,
+    )
+
+    assert res["ok"] is True
+    assert res["spec"]["execution_eligible"] is True
+    assert res["receipt"]["schema_version"] == "step-receipt.v1.1"
+    assert res["command_receipt"]["status"] == "complete"
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["invocation_id", "command_receipt_digest", "actor_outcome", "predicate_id"],
+)
+def test_negative_v11_receipt_additions_are_required(field_name: str) -> None:
+    """Mutation check: every required v1.1 receipt addition binds its command."""
+    trail = _get_happy_v11_trail_data()
+    command_receipt = _get_happy_command_receipt_data(trail)
+    receipt = _get_happy_v11_step_receipt_data(trail, command_receipt)
+    del receipt[field_name]
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_step_receipt_data(receipt, receipt_schema_path=STEP_RECEIPT_V11_SCHEMA_PATH)
+
+    assert field_name in str(exc_info.value)
+
+
+def test_negative_v11_optional_authority_receipt_must_be_a_digest() -> None:
+    """Mutation check: optional authority evidence cannot become unbound prose."""
+    trail = _get_happy_v11_trail_data()
+    command_receipt = _get_happy_command_receipt_data(trail)
+    receipt = _get_happy_v11_step_receipt_data(trail, command_receipt)
+    receipt["authority_receipt_digest"] = "approval-in-chat"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_step_receipt_data(receipt, receipt_schema_path=STEP_RECEIPT_V11_SCHEMA_PATH)
+
+    assert "authority_receipt_digest" in str(exc_info.value)
+
+
+def test_negative_v11_receipt_transition_taken_must_be_a_label(tmp_path) -> None:
+    """Mutation check: a target value cannot be substituted for transition_taken."""
+    trail = _get_happy_v11_trail_data()
+    command_receipt = _get_happy_command_receipt_data(trail)
+    receipt = _get_happy_v11_step_receipt_data(trail, command_receipt)
+    receipt["transition_taken"] = "complete"  # target, not the "accepted" label
+
+    trail_path = tmp_path / "trail.json"
+    receipt_path = tmp_path / "receipt.json"
+    trail_path.write_text(json.dumps(trail), encoding="utf-8")
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec(spec_path=trail_path, receipt_path=receipt_path)
+
+    assert "transition_taken must be a transition label" in str(exc_info.value)
+
+
+def test_negative_v11_command_receipt_actor_must_bind(tmp_path) -> None:
+    """Mutation check: an actor outcome from another command receipt cannot bind a step."""
+    trail = _get_happy_v11_trail_data()
+    command_receipt = _get_happy_command_receipt_data(trail)
+    receipt = _get_happy_v11_step_receipt_data(trail, command_receipt)
+    command_receipt["actor_outcome"] = "refused"
+
+    trail_path = tmp_path / "trail.json"
+    command_receipt_path = tmp_path / "command-receipt.json"
+    receipt_path = tmp_path / "step-receipt.json"
+    trail_path.write_text(json.dumps(trail), encoding="utf-8")
+    command_receipt_path.write_text(json.dumps(command_receipt), encoding="utf-8")
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec(
+            spec_path=trail_path,
+            receipt_path=receipt_path,
+            command_receipt_path=command_receipt_path,
+        )
+
+    assert "actor_outcome" in str(exc_info.value)
+
+
+def test_negative_v11_command_receipt_digest_must_bind(tmp_path) -> None:
+    """Mutation check: a valid digest for a different receipt cannot bind a step."""
+    trail = _get_happy_v11_trail_data()
+    command_receipt = _get_happy_command_receipt_data(trail)
+    receipt = _get_happy_v11_step_receipt_data(trail, command_receipt)
+    receipt["command_receipt_digest"] = "0" * 64
+
+    trail_path = tmp_path / "trail.json"
+    command_receipt_path = tmp_path / "command-receipt.json"
+    receipt_path = tmp_path / "step-receipt.json"
+    trail_path.write_text(json.dumps(trail), encoding="utf-8")
+    command_receipt_path.write_text(json.dumps(command_receipt), encoding="utf-8")
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec(
+            spec_path=trail_path,
+            receipt_path=receipt_path,
+            command_receipt_path=command_receipt_path,
+        )
+
+    assert "command_receipt_digest" in str(exc_info.value)
+
+
+def test_negative_v11_command_receipt_requires_complete_exit_status() -> None:
+    """Mutation check: a complete receipt cannot hide a missing exit code."""
+    trail = _get_happy_v11_trail_data()
+    command_receipt = _get_happy_command_receipt_data(trail)
+    command_receipt["exit_code"] = None
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_command_receipt_data(
+            command_receipt, receipt_schema_path=COMMAND_RECEIPT_SCHEMA_PATH
+        )
+
+    assert "exit_code" in str(exc_info.value)
+
+
+def test_negative_v11_requires_invocation_environment() -> None:
+    """Mutation check: every command needs the runner-owned invocation environment."""
+    trail = _get_happy_v11_trail_data()
+    del trail["steps"][0]["command"]["environment"]["TRAIL_INVOCATION_ID"]
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(trail, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH)
+
+    assert "TRAIL_INVOCATION_ID" in str(exc_info.value)
+
+
+def test_negative_v11_typed_primitive_requires_invocation_flag() -> None:
+    """Mutation check: typed primitives receive both required invocation channels."""
+    trail = _get_happy_v11_trail_data()
+    command = trail["steps"][0]["command"]
+    command["adapter"] = "typed-primitive"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(trail, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH)
+
+    assert "--invocation-id" in str(exc_info.value)
+
+
+def test_negative_v11_rejects_undeclared_or_shell_interpolated_parameters() -> None:
+    """Mutation checks: parameter values are declared and never interpolated into -c."""
+    trail = _get_happy_v11_trail_data()
+    trail["steps"][0]["command"]["argv"][2] = "{unknown_parameter}"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(trail, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH)
+
+    assert "Undeclared command parameter" in str(exc_info.value)
+
+    shell_interpolated = _get_happy_v11_trail_data()
+    shell_interpolated["steps"][0]["command"]["argv"] = [
+        "sh",
+        "-c",
+        "observer --issue {issue_number}",
+    ]
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(
+            shell_interpolated, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH
+        )
+
+    assert "Unquoted parameter interpolation prohibited" in str(exc_info.value)
+
+    untyped = _get_happy_v11_trail_data()
+    untyped["parameters"]["issue_number"] = "free-form-prose"
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(untyped, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH)
+
+    assert "TrailSpec schema violation" in str(exc_info.value)
+
+
+def test_negative_v11_predicate_must_be_unique_and_receipt_only() -> None:
+    """Mutation checks: transition predicates cannot collide or execute a command."""
+    trail = _get_happy_v11_trail_data()
+    trail["steps"][0]["transitions"]["refused"]["evidence"]["predicate_id"] = (
+        "accepted-outcome"
+    )
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(trail, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH)
+
+    assert "Exactly-one-predicate rule" in str(exc_info.value)
+
+    command_predicate = _get_happy_v11_trail_data()
+    command_predicate["steps"][0]["transitions"]["accepted"]["evidence"]["clauses"][
+        0
+    ]["source"] = "shell-command"
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(
+            command_predicate, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH
+        )
+
+    assert "TrailSpec schema violation" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("case", ["zero", "multiple"])
+def test_negative_v11_command_receipt_must_match_exactly_one_predicate(
+    tmp_path, case: str
+) -> None:
+    """Mutation check: zero or multiple matching predicates park as STOP-unknown."""
+    trail = _get_happy_v11_trail_data()
+    command_receipt = _get_happy_command_receipt_data(trail)
+    step_receipt = _get_happy_v11_step_receipt_data(trail, command_receipt)
+    if case == "zero":
+        command_receipt["actor_outcome"] = "indeterminate"
+        step_receipt["actor_outcome"] = "indeterminate"
+        step_receipt["command_receipt_digest"] = compute_command_receipt_digest(command_receipt)
+    else:
+        refused_clause = trail["steps"][0]["transitions"]["refused"]["evidence"][
+            "clauses"
+        ][0]
+        refused_clause.update({"field": "exit_code", "value": 0})
+        command_receipt["trail_hash"] = compute_trail_hash(trail)
+        step_receipt["trail_hash"] = compute_trail_hash(trail)
+        step_receipt["command_receipt_digest"] = compute_command_receipt_digest(command_receipt)
+
+    trail_path = tmp_path / "trail.json"
+    command_receipt_path = tmp_path / "command-receipt.json"
+    step_receipt_path = tmp_path / "step-receipt.json"
+    trail_path.write_text(json.dumps(trail), encoding="utf-8")
+    command_receipt_path.write_text(json.dumps(command_receipt), encoding="utf-8")
+    step_receipt_path.write_text(json.dumps(step_receipt), encoding="utf-8")
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec(
+            spec_path=trail_path,
+            receipt_path=step_receipt_path,
+            command_receipt_path=command_receipt_path,
+        )
+
+    assert "Exactly-one-predicate match rule" in str(exc_info.value)
+    assert "STOP-unknown" in str(exc_info.value)
+
+
+def test_negative_v11_blocked_on_must_be_structured_and_declared() -> None:
+    """Mutation checks: blocked work is a structured STOP, not executable prose."""
+    trail = _get_happy_v11_trail_data()
+    trail["steps"][0]["blocked_on"] = "wait for an operator"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(trail, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH)
+
+    assert "TrailSpec schema violation" in str(exc_info.value)
+
+    undeclared_stop = _get_happy_v11_trail_data()
+    undeclared_stop["steps"][0]["blocked_on"] = {
+        "id": "operator-approval",
+        "reason": "Needs a current authority receipt.",
+        "stop_code": "STOP-timeout",
+    }
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(
+            undeclared_stop, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH
+        )
+
+    assert "must be declared by the trail" in str(exc_info.value)
+
+
+def test_negative_v11_seat_syntax_and_registry_eligibility(tmp_path) -> None:
+    """Seat syntax remains schema-level; eligibility comes from the mutable registry."""
+    trail = _get_happy_v11_trail_data()
+    trail["seats"] = ["not a seat"]
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(trail, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH)
+    assert "TrailSpec schema violation" in str(exc_info.value)
+
+    ineligible = _get_happy_v11_trail_data()
+    ineligible["seats"] = ["unknown-seat"]
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(ineligible, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH)
+    assert "seat eligibility failed" in str(exc_info.value)
+
+    dynamic_registry = tmp_path / "seat-registry.yaml"
+    dynamic_registry.write_text(
+        yaml.safe_dump(
+            {"endpoints": [{"name": "future-seat", "state": "live"}]},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    dynamic = _get_happy_v11_trail_data()
+    dynamic["seats"] = ["future-seat"]
+    res = validate_trailspec_data(
+        dynamic,
+        spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH,
+        seat_registry_path=dynamic_registry,
+    )
+    assert res["execution_eligible"] is True
+
+
+def test_stop_vocabulary_has_18_codes_and_never_reports_16() -> None:
+    """The published operational vocabulary is 18 codes; 16 names trigger classes."""
+    assert len(VALID_STOP_CODES) == 18
+    data = _get_happy_example_data()
+    data["stop_codes"].append("STOP-not-published")
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data)
+
+    message = str(exc_info.value)
+    assert "18-code STOP vocabulary" in message
+    assert "16-item" not in message
 
 
 def test_negative_non_summon_step_lacks_predicate() -> None:
@@ -184,7 +633,7 @@ def test_negative_unreachable_step() -> None:
 
 
 def test_negative_unknown_stop_code() -> None:
-    """Negative invariant test: unknown stop_code not in 16-item contract list fails validation."""
+    """Negative invariant test: unknown stop_code not in the 18-code vocabulary fails."""
     data = _get_happy_example_data()
     # Corrupt a copy: add an invalid stop code
     data["stop_codes"].append("STOP-FORBIDDEN-CUSTOM-CODE")

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -417,6 +417,30 @@ def test_negative_v11_rejects_undeclared_or_shell_interpolated_parameters() -> N
 
     assert "Unquoted parameter interpolation prohibited" in str(exc_info.value)
 
+    # Review finding on #5963: every alternate flag spelling that reaches a shell
+    # program string must be REJECTED as an unsupported shape, not silently accepted.
+    for bypass_argv in (
+        ["sh", "-lc", "observer --issue {issue_number}"],
+        ["sh", "-ec", "observer --issue {issue_number}"],
+        ["bash", "--login", "-c", "observer --issue {issue_number}"],
+        ["zsh", "-c", "observer --issue {issue_number}"],
+        ["/bin/bash", "-lc", "observer --issue {issue_number}"],
+        ["env", "bash", "-c", "observer --issue {issue_number}"],
+    ):
+        bypass = _get_happy_v11_trail_data()
+        bypass["steps"][0]["command"]["argv"] = bypass_argv
+        with pytest.raises(TrailSpecValidationError) as exc_info:
+            validate_trailspec_data(
+                bypass, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH
+            )
+        assert "Unsupported shell invocation shape" in str(exc_info.value), bypass_argv
+
+    # A shell-binary invocation in the exact sanctioned shape WITHOUT parameter
+    # references remains valid (the guard narrows interpolation, not shell use).
+    sanctioned = _get_happy_v11_trail_data()
+    sanctioned["steps"][0]["command"]["argv"] = ["sh", "-c", "observer --issue fixed"]
+    validate_trailspec_data(sanctioned, spec_schema_path=TRAIL_SPEC_V11_SCHEMA_PATH)
+
     untyped = _get_happy_v11_trail_data()
     untyped["parameters"]["issue_number"] = "free-form-prose"
     with pytest.raises(TrailSpecValidationError) as exc_info:


### PR DESCRIPTION
## Summary

Implements P1 of the rail-system completion plan.

- Adds immutable new contracts: `trailspec.v1.1`, `command-receipt.v1`, and `step-receipt.v1.1`.
- Adds version dispatch: v1 remains schema-valid but execution-ineligible; v1.1 validates receipt-bound commands, predicates, invocation binding, structured blockers, and dynamic seat eligibility.
- Formalizes the shared 18-code STOP vocabulary (the prior “16” refers only to trigger classes).
- Adds mutation tests for every P1 contract rule, including zero/multiple predicate matches parking as `STOP-unknown`.

## Authority and scope

Implements [completion memo §1](https://github.com/learn-ukrainian/learn-ukrainian.github.io/blob/main/docs/projects/fleet-trails/rail-system-completion-memo.md#1-trailspec-v11-contract) after the [operator’s 2026-07-28 approval on #5885](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5885#issuecomment-5107700069).

## Evidence

From `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/rail-p1-v11-contracts`:

- `.venv/bin/python -m pytest tests/test_validate_trailspec.py tests/test_red_ci_known_failures.py -q` → `103 passed in 1.20s`.
- `.venv/bin/ruff check scripts/orchestration/validate_trailspec.py scripts/orchestration/red_ci_known_failures.py tests/test_validate_trailspec.py` → `All checks passed!`.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` → `All 1 non-skipped commit(s) carry an X-Agent trailer.`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py` → `OPSEC check passed. Zero leaks detected.`

## Mutation reasoning

Each new contract has a failing mutation test: missing invocation/receipt fields, malformed authority digest, target-for-label substitution, command actor/digest mismatch, incomplete exit status, missing typed-primitive invocation flag, undeclared or shell-interpolated parameters, duplicate/non-receipt predicates, zero/multiple predicate matches, malformed or undeclared blockers, invalid/unregistered seats, and non-vocabulary STOP codes. These tests make the contract fail closed rather than merely checking happy paths.

Refs #5885

No auto-merge is armed; this is ready for an independent cross-family review.