### PR TITLE
feat(trails): executable decision tables v1 (P2)

### DIFF
--- a/agents_extensions/shared/schemas/decision-tables.v1.schema.json
+++ b/agents_extensions/shared/schemas/decision-tables.v1.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "decision-tables.v1",
+  "title": "Executable decision tables v1 schema",
+  "description": "Static rows consume only typed finite inputs and return typed outcome tokens. Row order records the v0 first-match source order; every runtime lookup requires exactly one matching row.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "matching_policy", "tables"],
+  "$defs": {
+    "input_definition": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": {"const": "boolean"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "values"],
+          "properties": {
+            "type": {"const": "enum"},
+            "values": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9-]*$"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "condition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input"],
+      "properties": {
+        "input": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "equals": {"type": ["boolean", "string"]},
+        "one_of": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": ["boolean", "string"]}
+        }
+      },
+      "oneOf": [
+        {"required": ["equals"], "not": {"required": ["one_of"]}},
+        {"required": ["one_of"], "not": {"required": ["equals"]}}
+      ]
+    },
+    "outcome": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "token"],
+          "properties": {
+            "kind": {"const": "action"},
+            "token": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]*$"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "token"],
+          "properties": {
+            "kind": {"const": "stop"},
+            "token": {
+              "type": "string",
+              "pattern": "^STOP-[a-z][a-z0-9-]*$"
+            }
+          }
+        }
+      ]
+    },
+    "static_table": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "inputs", "rows"],
+      "properties": {
+        "mode": {"const": "static"},
+        "inputs": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "pattern": "^[a-z][a-z0-9_]*$"
+          },
+          "additionalProperties": {"$ref": "#/$defs/input_definition"}
+        },
+        "rows": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "when", "outcome"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9-]*$"
+              },
+              "when": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["all"],
+                "properties": {
+                  "all": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {"$ref": "#/$defs/condition"}
+                  }
+                }
+              },
+              "outcome": {"$ref": "#/$defs/outcome"}
+            }
+          }
+        }
+      }
+    },
+    "live_lookup_table": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "procedure", "never"],
+      "properties": {
+        "mode": {"const": "live-lookup"},
+        "procedure": {"type": "string", "minLength": 1},
+        "never": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  },
+  "properties": {
+    "schema_version": {"const": "decision-tables.v1"},
+    "matching_policy": {"const": "first-match-unique"},
+    "tables": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9-]+$"
+      },
+      "additionalProperties": {
+        "oneOf": [
+          {"$ref": "#/$defs/static_table"},
+          {"$ref": "#/$defs/live_lookup_table"}
+        ]
+      }
+    }
+  }
+}

--- a/scripts/config/trails/decision-tables.v1.yaml
+++ b/scripts/config/trails/decision-tables.v1.yaml
@@ -1,0 +1,320 @@
+# Executable decision tables v1 — P2 of #5885.
+#
+# Static rows only inspect typed inputs and return typed outcome tokens. Their
+# sequence preserves the v0 source ordering, but it is not an implicit conflict
+# resolver: a lookup with zero or multiple matches parks as STOP-unknown.
+# Live lookup tables retain their v0 procedure-only contract and are not
+# executable static lookups.
+---
+schema_version: decision-tables.v1
+matching_policy: first-match-unique
+tables:
+  queue-pick:
+    mode: static
+    inputs:
+      is_foreign_lane: {type: boolean}
+      has_sibling_pr: {type: boolean}
+      queue_order_derivable: {type: boolean}
+      dependencies_merged: {type: boolean}
+    rows:
+      - id: foreign-lane
+        when:
+          all:
+            - {input: is_foreign_lane, equals: true}
+        outcome: {kind: stop, token: STOP-policy-violation}
+      - id: sibling-pr
+        when:
+          all:
+            - {input: is_foreign_lane, equals: false}
+            - {input: has_sibling_pr, equals: true}
+        outcome: {kind: action, token: reconcile-sibling-pr}
+      - id: queue-order-unknown
+        when:
+          all:
+            - {input: is_foreign_lane, equals: false}
+            - {input: has_sibling_pr, equals: false}
+            - {input: queue_order_derivable, equals: false}
+        outcome: {kind: stop, token: STOP-manual-intervention}
+      - id: ready-item
+        when:
+          all:
+            - {input: is_foreign_lane, equals: false}
+            - {input: has_sibling_pr, equals: false}
+            - {input: queue_order_derivable, equals: true}
+            - {input: dependencies_merged, equals: true}
+        outcome: {kind: action, token: pick-lowest-ready-item}
+
+  review-gate-arm:
+    mode: static
+    inputs:
+      is_draft: {type: boolean}
+      current_head_reviews_terminal_published: {type: boolean}
+      reviewer_is_independent: {type: boolean}
+      requested_changes_resolved: {type: boolean}
+      has_stale_approval: {type: boolean}
+      verdicts_conflict: {type: boolean}
+      blocking_ci: {type: enum, values: [green, red]}
+      has_current_cross_family_approval: {type: boolean}
+    rows:
+      - id: draft
+        when:
+          all:
+            - {input: is_draft, equals: true}
+        outcome: {kind: action, token: hold-draft}
+      - id: review-unresolved
+        when:
+          all:
+            - {input: is_draft, equals: false}
+            - {input: current_head_reviews_terminal_published, equals: false}
+        outcome: {kind: action, token: wait-current-head-reviews}
+      - id: reviewer-not-independent
+        when:
+          all:
+            - {input: is_draft, equals: false}
+            - {input: current_head_reviews_terminal_published, equals: true}
+            - {input: reviewer_is_independent, equals: false}
+        outcome: {kind: action, token: request-independent-review}
+      - id: requested-changes-unresolved
+        when:
+          all:
+            - {input: is_draft, equals: false}
+            - {input: current_head_reviews_terminal_published, equals: true}
+            - {input: reviewer_is_independent, equals: true}
+            - {input: requested_changes_resolved, equals: false}
+        outcome: {kind: action, token: wait-requested-changes}
+      - id: stale-approval
+        when:
+          all:
+            - {input: is_draft, equals: false}
+            - {input: current_head_reviews_terminal_published, equals: true}
+            - {input: reviewer_is_independent, equals: true}
+            - {input: requested_changes_resolved, equals: true}
+            - {input: has_stale_approval, equals: true}
+        outcome: {kind: action, token: request-current-head-review}
+      - id: contested
+        when:
+          all:
+            - {input: is_draft, equals: false}
+            - {input: current_head_reviews_terminal_published, equals: true}
+            - {input: reviewer_is_independent, equals: true}
+            - {input: requested_changes_resolved, equals: true}
+            - {input: has_stale_approval, equals: false}
+            - {input: verdicts_conflict, equals: true}
+        outcome: {kind: stop, token: STOP-contested}
+      - id: blocking-ci-red
+        when:
+          all:
+            - {input: is_draft, equals: false}
+            - {input: current_head_reviews_terminal_published, equals: true}
+            - {input: reviewer_is_independent, equals: true}
+            - {input: requested_changes_resolved, equals: true}
+            - {input: has_stale_approval, equals: false}
+            - {input: verdicts_conflict, equals: false}
+            - {input: blocking_ci, equals: red}
+        outcome: {kind: action, token: delegate-red-ci-triage}
+      - id: gate-passed
+        when:
+          all:
+            - {input: is_draft, equals: false}
+            - {input: current_head_reviews_terminal_published, equals: true}
+            - {input: reviewer_is_independent, equals: true}
+            - {input: requested_changes_resolved, equals: true}
+            - {input: has_stale_approval, equals: false}
+            - {input: verdicts_conflict, equals: false}
+            - {input: blocking_ci, equals: green}
+            - {input: has_current_cross_family_approval, equals: true}
+        outcome: {kind: action, token: arm-automerge}
+
+  red-ci-triage:
+    mode: static
+    inputs:
+      known_failure_class: {type: enum, values: [matched, not-matched]}
+      reproduces_on_main: {type: boolean}
+      base_fixed_after_ci: {type: boolean}
+    rows:
+      - id: known-failure
+        when:
+          all:
+            - {input: known_failure_class, equals: matched}
+        outcome: {kind: action, token: apply-known-failure-action}
+      - id: pre-existing
+        when:
+          all:
+            - {input: known_failure_class, equals: not-matched}
+            - {input: reproduces_on_main, equals: true}
+        outcome: {kind: action, token: note-pre-existing-ci}
+      - id: base-fixed
+        when:
+          all:
+            - {input: known_failure_class, equals: not-matched}
+            - {input: reproduces_on_main, equals: false}
+            - {input: base_fixed_after_ci, equals: true}
+        outcome: {kind: action, token: update-branch}
+      - id: signature-unknown
+        when:
+          all:
+            - {input: known_failure_class, equals: not-matched}
+            - {input: reproduces_on_main, equals: false}
+            - {input: base_fixed_after_ci, equals: false}
+        outcome: {kind: stop, token: STOP-unknown}
+
+  settle-status:
+    mode: static
+    inputs:
+      task_status:
+        type: enum
+        values:
+          [done, failed, crashed, timeout, silence-timeout, rate-limited, cancelled,
+           dry-run, needs-finalize, no-deliverable, spawning, running]
+      has_retry_suffix: {type: boolean}
+    rows:
+      - id: done
+        when:
+          all:
+            - {input: task_status, equals: done}
+        outcome: {kind: action, token: finalize-deliverable}
+      - id: failed-first-attempt
+        when:
+          all:
+            - {input: task_status, one_of: [failed, crashed]}
+            - {input: has_retry_suffix, equals: false}
+        outcome: {kind: action, token: retry-once}
+      - id: failed-retry
+        when:
+          all:
+            - {input: task_status, one_of: [failed, crashed]}
+            - {input: has_retry_suffix, equals: true}
+        outcome: {kind: stop, token: STOP-unrecoverable-error}
+      - id: timeout
+        when:
+          all:
+            - {input: task_status, one_of: [timeout, silence-timeout]}
+        outcome: {kind: action, token: inspect-timeout-deliverable}
+      - id: rate-limited
+        when:
+          all:
+            - {input: task_status, equals: rate-limited}
+        outcome: {kind: action, token: reroute-fallback}
+      - id: terminal-not-success
+        when:
+          all:
+            - {input: task_status, one_of: [cancelled, dry-run]}
+        outcome: {kind: action, token: terminal-not-success}
+      - id: needs-attention
+        when:
+          all:
+            - {input: task_status, one_of: [needs-finalize, no-deliverable]}
+        outcome: {kind: action, token: finalize-attention}
+      - id: active
+        when:
+          all:
+            - {input: task_status, one_of: [spawning, running]}
+        outcome: {kind: action, token: await-settlement}
+
+  lane-routing:
+    mode: live-lookup
+    procedure: >-
+      Resolve seat from /api/rules model-assignment (routing SSOT) + model_catalog.yaml
+      floors for the task's risk class. Confirm capability with check-model before first
+      use in a session. Respect: language-lane restriction (UK content only on sanctioned
+      lanes), judge-seat exclusions, local-fanout=1, cross-family review pairing.
+    never: [route from memory of a roster, route by provider name alone, freeze model names into this file]
+
+  width:
+    mode: live-lookup
+    procedure: >-
+      Two-sided: for each candidate lane read codexbar pace stage + reserve; read disk
+      (df -h / AND du -sh <repo_root>/.worktrees). Idle lane + quota headroom + disk room →
+      widen. At/ahead of pace or thin reserve → throttle, shed to a lane with headroom.
+      No data for a lane → in-flight count + lane health, and SAY the picture is partial.
+      DISK WINS every conflict; reaping finished worktrees is capacity management.
+    never: [fixed numeric in-flight caps, quota headroom overriding disk, manufacturing work for an idle lane]
+
+  handoff-completeness:
+    mode: static
+    inputs:
+      session_closing_or_rollover: {type: boolean}
+      required_fields_known: {type: boolean}
+      file_within_size_limit: {type: boolean}
+    rows:
+      - id: closing-or-rollover
+        when:
+          all:
+            - {input: session_closing_or_rollover, equals: true}
+        outcome: {kind: action, token: write-complete-handoff}
+      - id: unknown-fields
+        when:
+          all:
+            - {input: session_closing_or_rollover, equals: false}
+            - {input: required_fields_known, equals: false}
+        outcome: {kind: action, token: reconstruct-handoff}
+      - id: file-too-large
+        when:
+          all:
+            - {input: session_closing_or_rollover, equals: false}
+            - {input: required_fields_known, equals: true}
+            - {input: file_within_size_limit, equals: false}
+        outcome: {kind: action, token: archive-handoff}
+
+  summon-vs-park:
+    mode: static
+    inputs:
+      blocker_class:
+        type: enum
+        values: [operator-decision, judgment-seat, unbuilt-tooling, interactive-babysit]
+    rows:
+      - id: operator-decision
+        when:
+          all:
+            - {input: blocker_class, equals: operator-decision}
+        outcome: {kind: action, token: park-and-notify-operator}
+      - id: judgment-seat
+        when:
+          all:
+            - {input: blocker_class, equals: judgment-seat}
+        outcome: {kind: action, token: summon-advisor}
+      - id: unbuilt-tooling
+        when:
+          all:
+            - {input: blocker_class, equals: unbuilt-tooling}
+        outcome: {kind: action, token: mark-blocked-tooling}
+      - id: interactive-babysit
+        when:
+          all:
+            - {input: blocker_class, equals: interactive-babysit}
+        outcome: {kind: action, token: monitor-babysit}
+
+  pr-ownership:
+    mode: static
+    inputs:
+      is_own_area: {type: boolean}
+      is_abandoned_green_other_lane: {type: boolean}
+      is_other_area: {type: boolean}
+      ownership_ambiguous: {type: boolean}
+    rows:
+      - id: owned
+        when:
+          all:
+            - {input: is_own_area, equals: true}
+        outcome: {kind: action, token: drive-owned-pr}
+      - id: abandoned-carve-out
+        when:
+          all:
+            - {input: is_own_area, equals: false}
+            - {input: is_abandoned_green_other_lane, equals: true}
+        outcome: {kind: action, token: verify-abandoned-carve-out}
+      - id: foreign
+        when:
+          all:
+            - {input: is_own_area, equals: false}
+            - {input: is_abandoned_green_other_lane, equals: false}
+            - {input: is_other_area, equals: true}
+        outcome: {kind: action, token: hands-off-foreign-pr}
+      - id: ambiguous
+        when:
+          all:
+            - {input: is_own_area, equals: false}
+            - {input: is_abandoned_green_other_lane, equals: false}
+            - {input: is_other_area, equals: false}
+            - {input: ownership_ambiguous, equals: true}
+        outcome: {kind: stop, token: STOP-manual-intervention}

--- a/scripts/orchestration/trail_predicates.py
+++ b/scripts/orchestration/trail_predicates.py
@@ -1,0 +1,134 @@
+"""Pure evaluation for executable decision-tables.v1 static lookups.
+
+This module neither invokes commands nor inspects external state.  Callers pass
+already-typed values from immutable receipts; this module returns exactly one
+configured outcome token or ``STOP-unknown``.  Its only I/O helper reads a
+decision-tables document for callers that need to load the checked-in table.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.orchestration.red_ci_known_failures import VALID_STOP_CODES
+
+STOP_UNKNOWN = "STOP-unknown"
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DECISION_TABLES_PATH = PROJECT_ROOT / "scripts/config/trails/decision-tables.v1.yaml"
+_ACTION_TOKEN = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def load_decision_tables(path: Path = DEFAULT_DECISION_TABLES_PATH) -> dict[str, Any]:
+    """Read a decision-tables YAML document without executing or observing anything else."""
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Root of {path} must be a mapping")
+    return loaded
+
+
+def evaluate_table(table: Mapping[str, Any], inputs: Mapping[str, Any]) -> str:
+    """Return one static-table outcome token, otherwise fail closed as STOP-unknown."""
+    if not isinstance(table, Mapping) or table.get("mode") != "static":
+        return STOP_UNKNOWN
+
+    declarations = table.get("inputs")
+    rows = table.get("rows")
+    if not isinstance(declarations, Mapping) or not isinstance(rows, list):
+        return STOP_UNKNOWN
+    if set(inputs) != set(declarations):
+        return STOP_UNKNOWN
+    if not _inputs_match_declarations(inputs, declarations):
+        return STOP_UNKNOWN
+
+    matching_rows = [row for row in rows if _row_matches(row, inputs, declarations)]
+    if len(matching_rows) != 1:
+        return STOP_UNKNOWN
+
+    outcome = matching_rows[0].get("outcome") if isinstance(matching_rows[0], Mapping) else None
+    if not isinstance(outcome, Mapping):
+        return STOP_UNKNOWN
+    token = outcome.get("token")
+    kind = outcome.get("kind")
+    if kind not in {"action", "stop"} or not isinstance(token, str):
+        return STOP_UNKNOWN
+    if kind == "action" and _ACTION_TOKEN.fullmatch(token):
+        return token
+    if kind == "stop" and token in VALID_STOP_CODES:
+        return token
+    return STOP_UNKNOWN
+
+
+def evaluate_named_table(
+    tables_data: Mapping[str, Any],
+    table_name: str,
+    inputs: Mapping[str, Any],
+) -> str:
+    """Look up and evaluate one named v1 static table from a loaded document."""
+    tables = tables_data.get("tables")
+    if tables_data.get("schema_version") != "decision-tables.v1" or not isinstance(tables, Mapping):
+        return STOP_UNKNOWN
+    table = tables.get(table_name)
+    if not isinstance(table, Mapping):
+        return STOP_UNKNOWN
+    return evaluate_table(table, inputs)
+
+
+def _inputs_match_declarations(inputs: Mapping[str, Any], declarations: Mapping[str, Any]) -> bool:
+    for name, declaration in declarations.items():
+        if not isinstance(name, str) or not isinstance(declaration, Mapping):
+            return False
+        value = inputs.get(name)
+        input_type = declaration.get("type")
+        if input_type == "boolean":
+            if type(value) is not bool:
+                return False
+        elif input_type == "enum":
+            values = declaration.get("values")
+            if not isinstance(value, str) or not isinstance(values, list) or value not in values:
+                return False
+        else:
+            return False
+    return True
+
+
+def _row_matches(
+    row: Any,
+    inputs: Mapping[str, Any],
+    declarations: Mapping[str, Any],
+) -> bool:
+    if not isinstance(row, Mapping):
+        return False
+    when = row.get("when")
+    if not isinstance(when, Mapping):
+        return False
+    conditions = when.get("all")
+    if not isinstance(conditions, list) or not conditions:
+        return False
+    return all(_condition_matches(condition, inputs, declarations) for condition in conditions)
+
+
+def _condition_matches(
+    condition: Any,
+    inputs: Mapping[str, Any],
+    declarations: Mapping[str, Any],
+) -> bool:
+    if not isinstance(condition, Mapping):
+        return False
+    input_name = condition.get("input")
+    if not isinstance(input_name, str) or input_name not in declarations:
+        return False
+    value = inputs[input_name]
+    if "equals" in condition and "one_of" not in condition:
+        expected = condition["equals"]
+        return type(value) is type(expected) and value == expected
+    if "one_of" in condition and "equals" not in condition:
+        expected_values = condition["one_of"]
+        return isinstance(expected_values, list) and any(
+            type(value) is type(expected) and value == expected for expected in expected_values
+        )
+    return False

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -15,6 +15,7 @@ import json
 import re
 import sys
 from datetime import UTC, datetime
+from itertools import product
 from pathlib import Path
 from typing import Any
 
@@ -53,8 +54,14 @@ DEFAULT_EXAMPLE_TRAIL_PATH = (
 DECISION_TABLES_SCHEMA_PATH = (
     PROJECT_ROOT / "agents_extensions/shared/schemas/decision-tables.v0.schema.json"
 )
+DECISION_TABLES_V1_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/decision-tables.v1.schema.json"
+)
 DEFAULT_DECISION_TABLES_PATH = (
     PROJECT_ROOT / "scripts/config/trails/decision-tables.v0.yaml"
+)
+DEFAULT_DECISION_TABLES_V1_PATH = (
+    PROJECT_ROOT / "scripts/config/trails/decision-tables.v1.yaml"
 )
 
 _TRAIL_SCHEMA_PATHS = {
@@ -64,6 +71,10 @@ _TRAIL_SCHEMA_PATHS = {
 _STEP_RECEIPT_SCHEMA_PATHS = {
     "step-receipt.v1": STEP_RECEIPT_SCHEMA_PATH,
     "step-receipt.v1.1": STEP_RECEIPT_V11_SCHEMA_PATH,
+}
+_DECISION_TABLES_SCHEMA_PATHS = {
+    "decision-tables.v0": DECISION_TABLES_SCHEMA_PATH,
+    "decision-tables.v1": DECISION_TABLES_V1_SCHEMA_PATH,
 }
 _PARAMETER_REFERENCE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
@@ -539,13 +550,116 @@ def _validate_v11_receipt_binding(
         )
 
 
+def _v1_input_domain(input_name: str, definition: dict[str, Any]) -> list[bool | str]:
+    """Return a declared finite input domain or reject a malformed static table."""
+    if definition["type"] == "boolean":
+        return [False, True]
+    if definition["type"] == "enum":
+        return definition["values"]
+    raise TrailSpecValidationError(
+        f"DecisionTables v1 input '{input_name}' has unsupported type "
+        f"{definition['type']!r}"
+    )
+
+
+def _validate_v1_condition(
+    *,
+    table_name: str,
+    row_id: str,
+    condition: dict[str, Any],
+    declarations: dict[str, Any],
+) -> None:
+    """Check that a v1 condition references a declared input using its real type."""
+    input_name = condition["input"]
+    if input_name not in declarations:
+        raise TrailSpecValidationError(
+            f"DecisionTables v1 table '{table_name}' row '{row_id}' references "
+            f"undeclared input '{input_name}'"
+        )
+    definition = declarations[input_name]
+    expected_values = (
+        [condition["equals"]]
+        if "equals" in condition
+        else condition["one_of"]
+    )
+    for expected in expected_values:
+        if definition["type"] == "boolean":
+            valid = type(expected) is bool
+        else:
+            valid = isinstance(expected, str) and expected in definition["values"]
+        if not valid:
+            raise TrailSpecValidationError(
+                f"DecisionTables v1 table '{table_name}' row '{row_id}' condition "
+                f"for input '{input_name}' has invalid typed value {expected!r}"
+            )
+
+
+def _v1_row_matches(row: dict[str, Any], candidate: dict[str, bool | str]) -> bool:
+    """Evaluate a schema-validated row against one finite-domain input tuple."""
+    for condition in row["when"]["all"]:
+        value = candidate[condition["input"]]
+        if "equals" in condition:
+            if value != condition["equals"]:
+                return False
+        elif value not in condition["one_of"]:
+            return False
+    return True
+
+
+def _validate_v1_decision_table_uniqueness(tables_data: dict[str, Any]) -> None:
+    """Reject v1 static rows that overlap in any declared typed input tuple.
+
+    Empty regions are deliberately allowed: runtime evaluation parks them as
+    STOP-unknown. This check enforces the complementary safety property that a
+    row order cannot silently choose between multiple matching outcomes.
+    """
+    for table_name, table in tables_data["tables"].items():
+        if table["mode"] != "static":
+            continue
+        declarations = table["inputs"]
+        row_ids = [row["id"] for row in table["rows"]]
+        if len(row_ids) != len(set(row_ids)):
+            raise TrailSpecValidationError(
+                f"DecisionTables v1 table '{table_name}' has duplicate row id(s)"
+            )
+        for row in table["rows"]:
+            for condition in row["when"]["all"]:
+                _validate_v1_condition(
+                    table_name=table_name,
+                    row_id=row["id"],
+                    condition=condition,
+                    declarations=declarations,
+                )
+
+        input_names = list(declarations)
+        domains = [_v1_input_domain(name, declarations[name]) for name in input_names]
+        for values in product(*domains):
+            candidate = dict(zip(input_names, values, strict=True))
+            matches = [
+                row["id"]
+                for row in table["rows"]
+                if _v1_row_matches(row, candidate)
+            ]
+            if len(matches) > 1:
+                raise TrailSpecValidationError(
+                    "DecisionTables v1 first-match uniqueness violated: "
+                    f"table '{table_name}' rows {matches} match typed inputs {candidate}"
+                )
+
+
 def validate_decision_tables_data(
     tables_data: dict[str, Any],
     *,
-    tables_schema_path: Path = DECISION_TABLES_SCHEMA_PATH,
+    tables_schema_path: Path | None = None,
 ) -> dict[str, Any]:
     """Validate a decision-tables document against schema and domain invariants."""
-    tables_schema = _load_schema(tables_schema_path)
+    resolved_schema_path = _schema_path_for(
+        tables_data,
+        paths=_DECISION_TABLES_SCHEMA_PATHS,
+        label="DecisionTables",
+        supplied_path=tables_schema_path,
+    )
+    tables_schema = _load_schema(resolved_schema_path)
     validator = Draft202012Validator(tables_schema, format_checker=FormatChecker())
     errors = sorted(validator.iter_errors(tables_data), key=lambda e: e.path)
     if errors:
@@ -557,18 +671,27 @@ def validate_decision_tables_data(
     # Invariant: any row action naming a STOP code must use the published contract list.
     for table_name, table in tables_data.get("tables", {}).items():
         for idx, row in enumerate(table.get("rows", []) or []):
-            then = row.get("then", "")
-            if then.startswith("STOP-") and then not in VALID_STOP_CODES:
+            if tables_data["schema_version"] == "decision-tables.v0":
+                token = row.get("then", "")
+            else:
+                outcome = row.get("outcome", {})
+                token = outcome.get("token", "") if isinstance(outcome, dict) else ""
+            if token.startswith("STOP-") and token not in VALID_STOP_CODES:
                 raise TrailSpecValidationError(
                     f"DecisionTables invariant violated: table '{table_name}' row {idx} "
-                    f"names unknown stop code '{then}' (must be from the published contract list)"
+                    f"names unknown stop code '{token}' (must be from the published contract list)"
                 )
+
+    if tables_data["schema_version"] == "decision-tables.v1":
+        _validate_v1_decision_table_uniqueness(tables_data)
 
     tables = tables_data.get("tables", {})
     return {
         "ok": True,
         "schema_version": tables_data.get("schema_version"),
-        "precedence": tables_data.get("precedence"),
+        "precedence": tables_data.get(
+            "precedence", tables_data.get("matching_policy")
+        ),
         "tables": sorted(tables.keys()),
         "tables_count": len(tables),
     }
@@ -577,7 +700,7 @@ def validate_decision_tables_data(
 def validate_decision_tables(
     tables_path: Path = DEFAULT_DECISION_TABLES_PATH,
     *,
-    tables_schema_path: Path = DECISION_TABLES_SCHEMA_PATH,
+    tables_schema_path: Path | None = None,
 ) -> dict[str, Any]:
     """Validate a decision-tables YAML/JSON file."""
     tables_data = _load_yaml_or_json(tables_path)

--- a/tests/test_trail_predicates.py
+++ b/tests/test_trail_predicates.py
@@ -1,0 +1,84 @@
+"""Tests for pure typed decision-table evaluation."""
+
+from __future__ import annotations
+
+import copy
+
+from scripts.orchestration.trail_predicates import (
+    STOP_UNKNOWN,
+    evaluate_named_table,
+    evaluate_table,
+    load_decision_tables,
+)
+
+
+def _queue_inputs(**overrides: object) -> dict[str, object]:
+    inputs: dict[str, object] = {
+        "is_foreign_lane": False,
+        "has_sibling_pr": False,
+        "queue_order_derivable": True,
+        "dependencies_merged": True,
+    }
+    inputs.update(overrides)
+    return inputs
+
+
+def test_static_table_returns_the_single_typed_outcome_token() -> None:
+    tables = load_decision_tables()
+
+    assert evaluate_table(tables["tables"]["queue-pick"], _queue_inputs()) == "pick-lowest-ready-item"
+
+
+def test_typed_input_enforcement_parks_invalid_boolean_and_extra_input() -> None:
+    tables = load_decision_tables()
+
+    invalid_boolean = _queue_inputs(is_foreign_lane=1)
+    assert evaluate_named_table(tables, "queue-pick", invalid_boolean) == STOP_UNKNOWN
+
+    extra_input = _queue_inputs(unexpected=True)
+    assert evaluate_named_table(tables, "queue-pick", extra_input) == STOP_UNKNOWN
+
+
+def test_unknown_enum_input_parks() -> None:
+    tables = load_decision_tables()
+    inputs = {
+        "blocker_class": "unrecognized-blocker",
+    }
+
+    assert evaluate_named_table(tables, "summon-vs-park", inputs) == STOP_UNKNOWN
+    assert (
+        evaluate_named_table(
+            tables,
+            "settle-status",
+            {"task_status": "unrecognized-status", "has_retry_suffix": False},
+        )
+        == STOP_UNKNOWN
+    )
+
+
+def test_zero_matching_rows_park() -> None:
+    tables = load_decision_tables()
+
+    result = evaluate_named_table(
+        tables,
+        "queue-pick",
+        _queue_inputs(dependencies_merged=False),
+    )
+
+    assert result == STOP_UNKNOWN
+
+
+def test_multiple_matching_rows_park() -> None:
+    tables = copy.deepcopy(load_decision_tables())
+    queue_rows = tables["tables"]["queue-pick"]["rows"]
+    queue_rows.append(copy.deepcopy(queue_rows[-1]))
+
+    assert evaluate_named_table(tables, "queue-pick", _queue_inputs()) == STOP_UNKNOWN
+
+
+def test_malformed_outcome_token_parks() -> None:
+    tables = copy.deepcopy(load_decision_tables())
+    outcome = tables["tables"]["queue-pick"]["rows"][-1]["outcome"]
+    outcome["token"] = "free form prose"
+
+    assert evaluate_named_table(tables, "queue-pick", _queue_inputs()) == STOP_UNKNOWN

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -13,6 +13,7 @@ from scripts.orchestration.red_ci_known_failures import VALID_STOP_CODES
 from scripts.orchestration.validate_trailspec import (
     COMMAND_RECEIPT_SCHEMA_PATH,
     DEFAULT_DECISION_TABLES_PATH,
+    DEFAULT_DECISION_TABLES_V1_PATH,
     DEFAULT_EXAMPLE_TRAIL_PATH,
     STEP_RECEIPT_SCHEMA_PATH,
     STEP_RECEIPT_V11_SCHEMA_PATH,
@@ -714,6 +715,10 @@ def _get_happy_tables_data() -> dict[str, Any]:
     return yaml.safe_load(DEFAULT_DECISION_TABLES_PATH.read_text(encoding="utf-8"))
 
 
+def _get_happy_v1_tables_data() -> dict[str, Any]:
+    return yaml.safe_load(DEFAULT_DECISION_TABLES_V1_PATH.read_text(encoding="utf-8"))
+
+
 def test_decision_tables_file_validates() -> None:
     """The shipped decision-tables draft must pass its schema (review finding on #5886:
     the v0 file declared itself unvalidated and sat outside all coverage)."""
@@ -762,6 +767,79 @@ def test_negative_decision_tables_unknown_stop_code() -> None:
     with pytest.raises(TrailSpecValidationError) as exc_info:
         validate_decision_tables_data(data)
     assert "STOP-made-up-code" in str(exc_info.value)
+
+
+def test_v1_decision_tables_file_validates_and_keeps_all_v0_table_names() -> None:
+    """P2's typed document is a parallel migration; v0 remains its own contract."""
+    res = validate_decision_tables(DEFAULT_DECISION_TABLES_V1_PATH)
+
+    assert res["ok"] is True
+    assert res["schema_version"] == "decision-tables.v1"
+    assert res["precedence"] == "first-match-unique"
+    for expected in ("queue-pick", "review-gate-arm", "settle-status", "width"):
+        assert expected in res["tables"], f"table '{expected}' missing from v1"
+
+
+def test_negative_v1_decision_tables_rejects_overlapping_first_match_rows() -> None:
+    """Mutation proof: row order cannot silently resolve two typed outcomes."""
+    data = _get_happy_v1_tables_data()
+    rows = data["tables"]["queue-pick"]["rows"]
+    duplicate = copy.deepcopy(rows[-1])
+    duplicate["id"] = "ready-item-duplicate"
+    rows.append(duplicate)
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_decision_tables_data(data)
+
+    assert "first-match uniqueness violated" in str(exc_info.value)
+    assert validate_decision_tables_data(_get_happy_v1_tables_data())["ok"] is True
+
+
+def test_negative_v1_decision_tables_rejects_free_form_outcome() -> None:
+    """Mutation proof: static executable rows cannot return prose."""
+    data = _get_happy_v1_tables_data()
+    data["tables"]["queue-pick"]["rows"][0]["outcome"] = "do whatever seems right"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_decision_tables_data(data)
+
+    assert "DecisionTables schema violation" in str(exc_info.value)
+    assert validate_decision_tables_data(_get_happy_v1_tables_data())["ok"] is True
+
+
+def test_negative_v1_decision_tables_rejects_unknown_stop_token() -> None:
+    """Mutation proof: typed v1 STOP outcomes use P1's 18-code vocabulary."""
+    data = _get_happy_v1_tables_data()
+    data["tables"]["queue-pick"]["rows"][0]["outcome"]["token"] = "STOP-not-published"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_decision_tables_data(data)
+
+    assert "STOP-not-published" in str(exc_info.value)
+    assert validate_decision_tables_data(_get_happy_v1_tables_data())["ok"] is True
+
+
+def test_negative_v1_decision_tables_rejects_wrongly_typed_condition() -> None:
+    """Mutation proof: a condition value must use its declared input type."""
+    data = _get_happy_v1_tables_data()
+    data["tables"]["queue-pick"]["rows"][0]["when"]["all"][0]["equals"] = "yes"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_decision_tables_data(data)
+
+    assert "invalid typed value 'yes'" in str(exc_info.value)
+    assert validate_decision_tables_data(_get_happy_v1_tables_data())["ok"] is True
+
+
+def test_v1_table_reference_integrity_uses_the_typed_document() -> None:
+    """A trail binding must resolve in either validated parallel table version."""
+    spec = _get_rb1_data()
+    tables = _get_happy_v1_tables_data()
+
+    res = validate_trail_table_refs(spec, tables)
+
+    assert res["ok"] is True
+    assert res["bound_steps"]["pick_next"] == "queue-pick"
 
 
 _RB1_PATH = _TRAILS_DIR / "rb1-cold-start.trail.yaml"


### PR DESCRIPTION
## Summary

Implements the adopted rail-system completion memo §5 P2.

- Adds the v1 typed-table schema and a parallel migration of all nine v0 table names; v0 remains intact.
- Adds pure static-table evaluation: strict typed inputs, exactly one typed outcome token, and `STOP-unknown` for unknown, zero-match, or multi-match cases.
- Dispatches table-schema validation by version; validates finite-domain overlap, the P1 18-code STOP vocabulary, and existing trail-to-table bindings.

## Evidence

- ` .venv/bin/python -m pytest tests/test_trail_predicates.py tests/test_validate_trailspec.py -q ` → `69 passed`.
- ` .venv/bin/ruff check scripts/orchestration/trail_predicates.py scripts/orchestration/validate_trailspec.py tests/test_trail_predicates.py tests/test_validate_trailspec.py ` → `All checks passed!`.
- Both `decision-tables.v0.yaml` and `decision-tables.v1.yaml` validate through `validate_trailspec.py`; each reports the same nine tables.
- ` .venv/bin/python scripts/audit/lint_agent_trailer.py ` reports the sole commit PASS; staged OPSEC audit passed.

Not verified: P3 runner execution and P7–P9 trail migrations; both are explicitly out of scope for P2.

Refs #5885