### PR TITLE
feat(trails): trail runner ledger/executor (P3)

### DIFF
--- a/agents_extensions/shared/schemas/trail-run-result.v1.schema.json
+++ b/agents_extensions/shared/schemas/trail-run-result.v1.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trail-run-result.v1",
+  "title": "Trail runner result v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "command",
+    "exit_class",
+    "outcome",
+    "run_id",
+    "state",
+    "cursor_step",
+    "data",
+    "error"
+  ],
+  "properties": {
+    "schema_version": {"const": "trail-run-result.v1"},
+    "command": {
+      "enum": ["begin", "status", "step", "resume", "verify-chain", "close"]
+    },
+    "exit_class": {"enum": [0, 20, 21, 22, 23, 24]},
+    "outcome": {"type": "string", "minLength": 1},
+    "run_id": {"type": ["string", "null"]},
+    "state": {"type": ["string", "null"]},
+    "cursor_step": {"type": ["string", "null"]},
+    "data": {"type": "object"},
+    "error": {"type": ["string", "null"]}
+  }
+}

--- a/scripts/orchestration/trail_runner.py
+++ b/scripts/orchestration/trail_runner.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Command-line entry point for the SQLite-authoritative TrailSpec runner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.orchestration.trails.executor import TrailExecutor
+from scripts.orchestration.trails.models import ExitClass, TrailRunnerError, TrailRunResult
+from scripts.orchestration.trails.store import TrailStore
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RUNS_DATABASE_PATH = PROJECT_ROOT / "batch_state/trails/runs.sqlite3"
+RECEIPTS_ROOT = PROJECT_ROOT / "batch_state/trails/receipts"
+TRAILS_ROOT = PROJECT_ROOT / "scripts/config/trails"
+
+
+class JsonArgumentParser(argparse.ArgumentParser):
+    """Keep malformed invocations inside the one-JSON-object public contract."""
+
+    def error(self, message: str) -> None:
+        raise TrailRunnerError(message)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build exactly the P3 invocation surface from the normative memo."""
+    parser = JsonArgumentParser(prog="trail_runner.py", add_help=False)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    begin = commands.add_parser("begin", add_help=False)
+    begin.add_argument("--trail", required=True)
+    begin.add_argument("--seat", required=True)
+    begin.add_argument("--task-family", required=True)
+    begin.add_argument("--params", required=True)
+
+    status = commands.add_parser("status", add_help=False)
+    status.add_argument("--run-id", required=True)
+
+    step = commands.add_parser("step", add_help=False)
+    step.add_argument("--run-id", required=True)
+    step.add_argument("--expected-step", required=True)
+
+    resume = commands.add_parser("resume", add_help=False)
+    resume.add_argument("--run-id", required=True)
+    resume.add_argument("--authority-receipt-id", required=True)
+
+    verify_chain = commands.add_parser("verify-chain", add_help=False)
+    verify_chain.add_argument("--run-id", required=True)
+
+    close = commands.add_parser("close", add_help=False)
+    close.add_argument("--run-id", required=True)
+    return parser
+
+
+def resolve_trail(value: str) -> Path:
+    """Resolve a trail ID to shipped configuration or accept an explicit file path."""
+    supplied = Path(value)
+    if supplied.is_file():
+        return supplied
+    candidate = TRAILS_ROOT / f"{value}.trail.yaml"
+    if candidate.is_file():
+        return candidate
+    raise TrailRunnerError(f"trail '{value}' is not a readable .trail.yaml file")
+
+
+def load_params(path_value: str) -> dict[str, Any]:
+    """Load the required JSON params object without accepting raw inline JSON."""
+    path = Path(path_value)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TrailRunnerError(f"cannot read --params JSON file '{path}': {exc}") from exc
+    if not isinstance(payload, dict):
+        raise TrailRunnerError("--params JSON must contain an object")
+    return payload
+
+
+def default_executor() -> TrailExecutor:
+    """Construct the production ledger rooted at the repository's batch state."""
+    return TrailExecutor(
+        TrailStore(RUNS_DATABASE_PATH, RECEIPTS_ROOT), project_root=PROJECT_ROOT
+    )
+
+
+def _invalid_result(command: str | None, error: str) -> TrailRunResult:
+    return TrailRunResult(
+        command=command if command in {"begin", "status", "step", "resume", "verify-chain", "close"} else "begin",
+        exit_class=ExitClass.INVALID,
+        outcome="invalid_input",
+        error=error,
+    )
+
+
+def dispatch(args: argparse.Namespace, executor: TrailExecutor) -> TrailRunResult:
+    """Call the selected verb without letting argparse print non-JSON output."""
+    if args.command == "begin":
+        return executor.begin(
+            trail_path=resolve_trail(args.trail),
+            seat=args.seat,
+            task_family=args.task_family,
+            params=load_params(args.params),
+        )
+    if args.command == "status":
+        return executor.status(run_id=args.run_id)
+    if args.command == "step":
+        return executor.step(run_id=args.run_id, expected_step=args.expected_step)
+    if args.command == "resume":
+        return executor.resume(
+            run_id=args.run_id, authority_receipt_id=args.authority_receipt_id
+        )
+    if args.command == "verify-chain":
+        return executor.verify_chain(run_id=args.run_id)
+    if args.command == "close":
+        return executor.close(run_id=args.run_id)
+    raise TrailRunnerError(f"unsupported command {args.command!r}")
+
+
+def main(argv: Sequence[str] | None = None, *, executor: TrailExecutor | None = None) -> int:
+    """Emit one JSON result object and return its contract-defined exit class."""
+    parser = build_parser()
+    command: str | None = None
+    try:
+        args = parser.parse_args(argv)
+        command = args.command
+        result = dispatch(args, executor or default_executor())
+    except TrailRunnerError as exc:
+        result = _invalid_result(command, str(exc))
+    except Exception as exc:
+        result = _invalid_result(command, f"runner failed closed: {type(exc).__name__}")
+    print(json.dumps(result.to_dict(), ensure_ascii=False, sort_keys=True))
+    return int(result.exit_class)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/trails/__init__.py
+++ b/scripts/orchestration/trails/__init__.py
@@ -1,0 +1,6 @@
+"""Authoritative TrailSpec runner ledger and executor primitives."""
+
+from .executor import TrailExecutor
+from .store import TrailStore
+
+__all__ = ["TrailExecutor", "TrailStore"]

--- a/scripts/orchestration/trails/executor.py
+++ b/scripts/orchestration/trails/executor.py
@@ -1,0 +1,1043 @@
+"""Fail-closed TrailSpec v1.1 command executor.
+
+This module owns command execution, never a weak driver.  It persists a UUID
+``prepared`` invocation before spawning, evaluates only the resulting immutable
+receipt, and uses the SQLite store to make cursor changes and STOP summons
+atomic.  It deliberately exposes authority and decision-table protocols without
+implementing P4/P2 policy in this package.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Protocol
+
+import yaml
+
+from scripts.orchestration.validate_trailspec import (
+    TrailSpecValidationError,
+    compute_command_receipt_digest,
+    compute_trail_hash,
+    validate_command_receipt_data,
+    validate_step_receipt_data,
+    validate_trailspec_data,
+)
+
+from .models import (
+    AuthorityReceiptUnavailableError,
+    CommandExecution,
+    DeviationRefusedError,
+    ExitClass,
+    PreparedInvocation,
+    ReceiptChainError,
+    TrailRun,
+    TrailRunnerError,
+    TrailRunResult,
+)
+from .store import TrailStore, canonical_json, digest_json, utc_now
+
+_OUTCOME_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]*$")
+_REDACTION_PATTERNS = (
+    re.compile(r"(?i)(authorization\s*[:=]\s*(?:bearer\s+)?)\S+"),
+    re.compile(r"(?i)\b(github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+)\b"),
+    re.compile(r"(?i)\b(password|passwd|token|secret|api[_-]?key)\s*[:=]\s*\S+"),
+)
+_MAX_RECEIPT_OUTPUT = 8192
+
+
+class CommandRunner(Protocol):
+    """Injectable command boundary used by deterministic tests and production."""
+
+    def __call__(self, command: dict[str, Any], cwd: Path) -> CommandExecution:
+        """Run a fully resolved command without a shell interpolation layer."""
+
+
+class ReceiptPredicateEvaluator(Protocol):
+    """Receipt-only predicate seam; it never executes a command."""
+
+    def matching_labels(
+        self, step: dict[str, Any], command_receipt: dict[str, Any]
+    ) -> list[str]:
+        """Return the labels whose receipt clauses all match."""
+
+
+class DecisionTableEvaluator(Protocol):
+    """P2 seam for typed table predicates; P3 intentionally has no implementation."""
+
+    def evaluate(self, table_id: str, facts: dict[str, Any]) -> str:
+        """Evaluate a pinned decision table without launching a command."""
+
+
+class UnavailableDecisionTableEvaluator:
+    """P3's explicit P2 seam: table execution is unavailable until it is wired."""
+
+    def evaluate(self, table_id: str, facts: dict[str, Any]) -> str:
+        raise TrailRunnerError(
+            f"decision-table predicate '{table_id}' is unavailable until P2/P4 wiring"
+        )
+
+
+class AuthorityReceiptResolver(Protocol):
+    """P4-owned approved-source lookup, never a local JSON-file loader."""
+
+    def fetch(self, authority_receipt_id: str, run: TrailRun) -> dict[str, Any]:
+        """Re-fetch and validate an authority receipt from an approved source."""
+
+
+class UnavailableAuthorityReceiptResolver:
+    """P3's deliberate fail-closed authority implementation."""
+
+    def fetch(self, authority_receipt_id: str, run: TrailRun) -> dict[str, Any]:
+        raise AuthorityReceiptUnavailableError(
+            "authority receipt verification is unavailable until P4; local receipt files are refused"
+        )
+
+
+class DefaultReceiptPredicateEvaluator:
+    """Evaluate the v1.1 schema's simple command-receipt equality clauses."""
+
+    def matching_labels(
+        self, step: dict[str, Any], command_receipt: dict[str, Any]
+    ) -> list[str]:
+        matches: list[str] = []
+        for label, transition in step["transitions"].items():
+            clauses = transition["evidence"]["clauses"]
+            if all(
+                clause["source"] == "command_receipt"
+                and command_receipt.get(clause["field"]) == clause["value"]
+                for clause in clauses
+            ):
+                matches.append(label)
+        return matches
+
+
+def redact_and_bound_output(value: str, *, limit: int = _MAX_RECEIPT_OUTPUT) -> str:
+    """Redact credential-shaped output before producing a bounded receipt digest."""
+    redacted = value
+    for pattern in _REDACTION_PATTERNS:
+        if pattern.pattern.startswith("(?i)(authorization"):
+            redacted = pattern.sub(r"\1[REDACTED]", redacted)
+        elif pattern.pattern.startswith("(?i)\\b(password"):
+            redacted = pattern.sub(lambda match: f"{match.group(1)}=[REDACTED]", redacted)
+        else:
+            redacted = pattern.sub("[REDACTED]", redacted)
+    if len(redacted) > limit:
+        return redacted[:limit] + "[TRUNCATED]"
+    return redacted
+
+
+def _output_digest(value: str) -> str:
+    return hashlib.sha256(redact_and_bound_output(value).encode("utf-8")).hexdigest()
+
+
+def _text_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def subprocess_command_runner(command: dict[str, Any], cwd: Path) -> CommandExecution:
+    """Execute a pre-resolved argv command with a timeout and no shell."""
+    environment = os.environ.copy()
+    environment.update(command["environment"])
+    try:
+        completed = subprocess.run(
+            command["argv"],
+            cwd=cwd,
+            env=environment,
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=command["timeout_seconds"],
+        )
+    except subprocess.TimeoutExpired as exc:
+        return CommandExecution(
+            exit_code=124,
+            stdout=_text_output(exc.stdout),
+            stderr=_text_output(exc.stderr),
+            timed_out=True,
+        )
+    except OSError as exc:
+        return CommandExecution(exit_code=127, stdout="", stderr=str(exc))
+    return CommandExecution(
+        exit_code=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def _decode_stdout_token(execution: CommandExecution) -> str:
+    if execution.timed_out:
+        return "timeout"
+    token = execution.stdout.strip()
+    if _OUTCOME_TOKEN.fullmatch(token):
+        return token
+    return "unparseable-output"
+
+
+class TrailExecutor:
+    """Implement the P3 run lifecycle over one ``TrailStore``."""
+
+    def __init__(
+        self,
+        store: TrailStore,
+        *,
+        project_root: Path,
+        seat_registry_path: Path | None = None,
+        command_runner: CommandRunner = subprocess_command_runner,
+        predicate_evaluator: ReceiptPredicateEvaluator | None = None,
+        decision_table_evaluator: DecisionTableEvaluator | None = None,
+        authority_resolver: AuthorityReceiptResolver | None = None,
+        fault_hook: Callable[[str, PreparedInvocation], None] | None = None,
+    ) -> None:
+        self.store = store
+        self.project_root = project_root
+        self.seat_registry_path = seat_registry_path
+        self.command_runner = command_runner
+        self.predicate_evaluator = predicate_evaluator or DefaultReceiptPredicateEvaluator()
+        self.decision_table_evaluator = (
+            decision_table_evaluator or UnavailableDecisionTableEvaluator()
+        )
+        self.authority_resolver = authority_resolver or UnavailableAuthorityReceiptResolver()
+        self.fault_hook = fault_hook
+
+    @staticmethod
+    def _load_trail(path: Path) -> dict[str, Any]:
+        try:
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            raise TrailRunnerError(f"cannot load trail '{path}': {exc}") from exc
+        if not isinstance(loaded, dict):
+            raise TrailRunnerError(f"trail '{path}' must contain a YAML object")
+        return loaded
+
+    @staticmethod
+    def _validate_params(spec: dict[str, Any], params: dict[str, Any]) -> None:
+        declared = spec.get("parameters", {})
+        if not isinstance(declared, dict):
+            raise TrailRunnerError("trail parameters must be an object")
+        unknown = sorted(set(params) - set(declared))
+        missing = sorted(set(declared) - set(params))
+        if unknown or missing:
+            raise TrailRunnerError(
+                f"parameters do not exactly match TrailSpec: missing={missing}, unknown={unknown}"
+            )
+        for name, kind in declared.items():
+            value = params[name]
+            valid = (
+                (kind == "string" and isinstance(value, str))
+                or (kind == "integer" and isinstance(value, int) and not isinstance(value, bool))
+                or (
+                    kind == "number"
+                    and isinstance(value, (int, float))
+                    and not isinstance(value, bool)
+                )
+                or (kind == "boolean" and isinstance(value, bool))
+            )
+            if not valid:
+                raise TrailRunnerError(
+                    f"parameter '{name}' must be a TrailSpec {kind}, got {type(value).__name__}"
+                )
+
+    def begin(
+        self,
+        *,
+        trail_path: Path,
+        seat: str,
+        task_family: str,
+        params: dict[str, Any],
+    ) -> TrailRunResult:
+        """Pin a validated trail in SQLite; v1 starts an inspection-only run."""
+        spec = self._load_trail(trail_path)
+        try:
+            summary = validate_trailspec_data(
+                spec,
+                **(
+                    {"seat_registry_path": self.seat_registry_path}
+                    if self.seat_registry_path is not None
+                    else {}
+                ),
+            )
+        except TrailSpecValidationError as exc:
+            raise TrailRunnerError(str(exc)) from exc
+        if seat not in spec["seats"]:
+            raise TrailRunnerError(f"seat '{seat}' is not authorized by trail '{spec['trail_id']}'")
+        if not isinstance(task_family, str) or not task_family:
+            raise TrailRunnerError("task_family must be a non-empty string")
+        if not isinstance(params, dict):
+            raise TrailRunnerError("params must be a JSON object")
+        if spec["schema_version"] == "trailspec.v1.1":
+            self._validate_params(spec, params)
+        elif params:
+            raise TrailRunnerError("TrailSpec v1 supports inspection only and has no typed params")
+
+        run = self.store.create_run(
+            run_id=str(uuid.uuid4()),
+            spec=spec,
+            trail_hash=summary["trail_hash"],
+            seat=seat,
+            task_family=task_family,
+            params=params,
+            inspection_only=not summary["execution_eligible"],
+        )
+        self.store.project_json(
+            run_id=run.run_id,
+            filename="run.json",
+            payload={
+                "schema_version": "trail-run-pinned.v1",
+                "run_id": run.run_id,
+                "trail_id": run.trail_id,
+                "trail_version": run.trail_version,
+                "trail_hash": run.trail_hash,
+                "seat": run.seat,
+                "task_family": run.task_family,
+                "params": run.params,
+                "created_at": run.created_at,
+            },
+        )
+        outcome = "inspection_started" if run.state == "inspection" else "begun"
+        return TrailRunResult(
+            command="begin",
+            exit_class=ExitClass.OK,
+            outcome=outcome,
+            run_id=run.run_id,
+            state=run.state,
+            cursor_step=run.cursor_step_id,
+            data={
+                "trail_id": run.trail_id,
+                "trail_version": run.trail_version,
+                "trail_hash": run.trail_hash,
+                "execution_eligible": spec["schema_version"] == "trailspec.v1.1",
+            },
+        )
+
+    def status(self, *, run_id: str) -> TrailRunResult:
+        """Report SQLite-authoritative cursor and parking state."""
+        run = self.store.get_run(run_id)
+        return TrailRunResult(
+            command="status",
+            exit_class=ExitClass.OK,
+            outcome="status",
+            run_id=run.run_id,
+            state=run.state,
+            cursor_step=run.cursor_step_id,
+            data={
+                "trail_id": run.trail_id,
+                "trail_hash": run.trail_hash,
+                "cursor_generation": run.cursor_generation,
+                "parked_stop_code": run.parked_stop_code,
+                "parked_reason": run.parked_reason,
+                "terminal_outcome": run.terminal_outcome,
+                "closure_state": run.closure_state,
+                "summons": self.store.list_summons(run_id),
+            },
+        )
+
+    def _reject_v1_execution(self, command: str, run: TrailRun) -> TrailRunResult:
+        return TrailRunResult(
+            command=command,
+            exit_class=ExitClass.INVALID,
+            outcome="execution_ineligible",
+            run_id=run.run_id,
+            state=run.state,
+            cursor_step=run.cursor_step_id,
+            error="TrailSpec v1 is inspection/hash/projection only; execution and closure are refused",
+        )
+
+    @staticmethod
+    def _find_step(run: TrailRun, step_id: str) -> dict[str, Any]:
+        for step in run.spec["steps"]:
+            if step["step_id"] == step_id:
+                return step
+        raise ReceiptChainError(f"pinned trail has no step '{step_id}'")
+
+    @staticmethod
+    def _resolve_string(value: str, replacements: dict[str, str]) -> str:
+        resolved = value
+        for name, replacement in replacements.items():
+            resolved = resolved.replace("{" + name + "}", replacement)
+        if re.search(r"\{[A-Za-z_][A-Za-z0-9_]*\}", resolved):
+            raise TrailRunnerError(f"unresolved command placeholder in {value!r}")
+        return resolved
+
+    def _resolve_command(
+        self, *, run: TrailRun, step: dict[str, Any], invocation_id: str
+    ) -> dict[str, Any]:
+        command = step["command"]
+        replacements = {
+            **{name: str(value) for name, value in run.params.items()},
+            "invocation_id": invocation_id,
+        }
+        return {
+            "adapter": command["adapter"],
+            "argv": [self._resolve_string(value, replacements) for value in command["argv"]],
+            "environment": {
+                key: self._resolve_string(value, replacements)
+                for key, value in command["environment"].items()
+            },
+            "timeout_seconds": command["timeout_seconds"],
+            "mutation_class": command["mutation_class"],
+            "outcome_decoder": command["outcome_decoder"],
+        }
+
+    @staticmethod
+    def _idempotency_key(run: TrailRun, expected_step: str) -> str:
+        return digest_json(
+            {
+                "run_id": run.run_id,
+                "cursor_generation": run.cursor_generation,
+                "step_id": expected_step,
+            }
+        )
+
+    def _make_command_receipt(
+        self,
+        *,
+        run: TrailRun,
+        prepared: PreparedInvocation,
+        execution: CommandExecution,
+        actor_outcome: str,
+    ) -> dict[str, Any]:
+        return {
+            "schema_version": "command-receipt.v1",
+            "invocation_id": prepared.invocation_id,
+            "run_id": run.run_id,
+            "trail_id": run.trail_id,
+            "trail_version": run.trail_version,
+            "trail_hash": run.trail_hash,
+            "step_id": prepared.step_id,
+            "resolved_command_digest": digest_json(prepared.resolved_command),
+            "actor_outcome": actor_outcome,
+            "exit_code": execution.exit_code,
+            "stdout_digest": _output_digest(execution.stdout),
+            "stderr_digest": _output_digest(execution.stderr),
+            "artifact_digests": {},
+            "prepared_at": prepared.prepared_at,
+            "completed_at": utc_now(),
+            "status": "complete",
+        }
+
+    @staticmethod
+    def _step_receipt(
+        *,
+        run: TrailRun,
+        prepared: PreparedInvocation,
+        command_receipt: dict[str, Any],
+        label: str,
+        transition: dict[str, Any],
+    ) -> dict[str, Any]:
+        evidence = transition["evidence"]
+        return {
+            "schema_version": "step-receipt.v1.1",
+            "trail_id": run.trail_id,
+            "trail_version": run.trail_version,
+            "trail_hash": run.trail_hash,
+            "run_id": run.run_id,
+            "step_id": prepared.step_id,
+            "task_family": run.task_family,
+            "lineage_id": None,
+            "pr_head": None,
+            "lease_generation": None,
+            "predicate_exit": command_receipt["exit_code"],
+            "evidence_digest": digest_json(evidence),
+            "transition_taken": label,
+            "timestamp": utc_now(),
+            "idempotency_key": prepared.idempotency_key,
+            "invocation_id": prepared.invocation_id,
+            "command_receipt_digest": compute_command_receipt_digest(command_receipt),
+            "actor_outcome": command_receipt["actor_outcome"],
+            "predicate_id": evidence["predicate_id"],
+        }
+
+    def _project_completed_receipts(
+        self,
+        *,
+        prepared: PreparedInvocation,
+        command_receipt: dict[str, Any],
+        step_receipt: dict[str, Any] | None,
+    ) -> None:
+        prefix = f"{prepared.cursor_generation:06d}-{prepared.invocation_id}"
+        self.store.project_json(
+            run_id=prepared.run_id,
+            filename=f"command-{prefix}.json",
+            payload=command_receipt,
+        )
+        if step_receipt is not None:
+            self.store.project_json(
+                run_id=prepared.run_id,
+                filename=f"step-{prefix}.json",
+                payload=step_receipt,
+            )
+
+    def _complete_or_return_indeterminate(
+        self, **kwargs: Any
+    ) -> TrailRun | TrailRunResult:
+        """Never report a post-spawn cursor race as a generic runner failure.
+
+        A concurrent claimant can park and mark this invocation indeterminate
+        after the parent-owned process has already spawned.  The original
+        process must then also return exit 24; it may not project a receipt or
+        claim that its possible side effect completed a transition.
+        """
+        try:
+            return self.store.complete_invocation(**kwargs)
+        except ReceiptChainError as exc:
+            run_id = kwargs["prepared"].run_id
+            latest = self.store.get_run(run_id)
+            if latest.state == "parked" and latest.parked_stop_code == "STOP-unknown":
+                return TrailRunResult(
+                    command="step",
+                    exit_class=ExitClass.INDETERMINATE,
+                    outcome="indeterminate_parked",
+                    run_id=run_id,
+                    state=latest.state,
+                    cursor_step=latest.cursor_step_id,
+                    data={"stop_code": latest.parked_stop_code},
+                    error=latest.parked_reason or str(exc),
+                )
+            raise
+
+    def step(
+        self,
+        *,
+        run_id: str,
+        expected_step: str,
+        idempotency_key: str | None = None,
+    ) -> TrailRunResult:
+        """Execute exactly the current step once, or fail closed without movement."""
+        run = self.store.get_run(run_id)
+        if run.spec["schema_version"] != "trailspec.v1.1":
+            return self._reject_v1_execution("step", run)
+
+        if idempotency_key is not None:
+            prepared_key = idempotency_key
+        else:
+            if run.state != "active" or run.cursor_step_id != expected_step:
+                return TrailRunResult(
+                    command="step",
+                    exit_class=ExitClass.DEVIATION_REFUSED,
+                    outcome="deviation_refused",
+                    run_id=run.run_id,
+                    state=run.state,
+                    cursor_step=run.cursor_step_id,
+                    error=(
+                        f"step must equal exact current cursor '{run.cursor_step_id}', "
+                        f"got '{expected_step}'"
+                    ),
+                )
+            prepared_key = self._idempotency_key(run, expected_step)
+
+        if run.state == "active" and run.cursor_step_id == expected_step:
+            current_step = self._find_step(run, expected_step)
+            blocked_on = current_step.get("blocked_on")
+            if blocked_on is not None:
+                parked = self.store.park_blocked(
+                    run_id=run_id,
+                    expected_step=expected_step,
+                    stop_code=blocked_on["stop_code"],
+                    reason=blocked_on["reason"],
+                    blocked_id=blocked_on["id"],
+                )
+                return TrailRunResult(
+                    command="step",
+                    exit_class=ExitClass.BLOCKED_PARKED,
+                    outcome="blocked_parked",
+                    run_id=run_id,
+                    state=parked.state,
+                    cursor_step=parked.cursor_step_id,
+                    data={"blocked_on": blocked_on, "stop_code": parked.parked_stop_code},
+                )
+        elif idempotency_key is None:
+            # The earlier guard makes this branch defensive should this method be
+            # refactored; it maintains the exact-cursor refusal contract.
+            return TrailRunResult(
+                command="step",
+                exit_class=ExitClass.DEVIATION_REFUSED,
+                outcome="deviation_refused",
+                run_id=run.run_id,
+                state=run.state,
+                cursor_step=run.cursor_step_id,
+                error="step does not name the current active cursor",
+            )
+        else:
+            current_step = self._find_step(run, expected_step)
+
+        invocation_id = str(uuid.uuid4())
+        resolved_command = self._resolve_command(
+            run=run, step=current_step, invocation_id=invocation_id
+        )
+        try:
+            preparation, value = self.store.prepare_invocation(
+                run_id=run_id,
+                expected_step=expected_step,
+                idempotency_key=prepared_key,
+                invocation_id=invocation_id,
+                resolved_command=resolved_command,
+            )
+        except DeviationRefusedError as exc:
+            latest = self.store.get_run(run_id)
+            return TrailRunResult(
+                command="step",
+                exit_class=ExitClass.DEVIATION_REFUSED,
+                outcome="deviation_refused",
+                run_id=run_id,
+                state=latest.state,
+                cursor_step=latest.cursor_step_id,
+                error=str(exc),
+            )
+        if preparation == "replay":
+            stored = TrailRunResult.from_dict(value)  # type: ignore[arg-type]
+            return stored
+        if preparation == "indeterminate":
+            parked = value
+            assert isinstance(parked, TrailRun)
+            return TrailRunResult(
+                command="step",
+                exit_class=ExitClass.INDETERMINATE,
+                outcome="indeterminate_parked",
+                run_id=run_id,
+                state=parked.state,
+                cursor_step=parked.cursor_step_id,
+                data={"stop_code": parked.parked_stop_code},
+                error=parked.parked_reason,
+            )
+        prepared = value
+        assert isinstance(prepared, PreparedInvocation)
+        if self.fault_hook is not None:
+            self.fault_hook("after_prepared_before_spawn", prepared)
+        execution = self.command_runner(resolved_command, self.project_root)
+        if self.fault_hook is not None:
+            self.fault_hook("after_command_before_receipt", prepared)
+
+        decoder = resolved_command["outcome_decoder"]
+        actor_outcome = (
+            _decode_stdout_token(execution)
+            if decoder["source"] == "stdout-token"
+            else "artifact-decoder-unavailable"
+        )
+        command_receipt = self._make_command_receipt(
+            run=run,
+            prepared=prepared,
+            execution=execution,
+            actor_outcome=actor_outcome,
+        )
+        try:
+            validate_command_receipt_data(command_receipt)
+        except TrailSpecValidationError as exc:
+            raise ReceiptChainError(str(exc)) from exc
+
+        matches = self.predicate_evaluator.matching_labels(current_step, command_receipt)
+        if len(matches) != 1:
+            reason = (
+                "receipt predicates matched no transition"
+                if not matches
+                else f"receipt predicates matched multiple transitions: {matches}"
+            )
+            result = TrailRunResult(
+                command="step",
+                exit_class=ExitClass.STOP_PARKED,
+                outcome="stop_unknown",
+                run_id=run_id,
+                state="parked",
+                cursor_step=expected_step,
+                data={"matched_predicates": matches, "stop_code": "STOP-unknown"},
+                error=reason,
+            )
+            parked = self._complete_or_return_indeterminate(
+                prepared=prepared,
+                command_receipt=command_receipt,
+                step_receipt=None,
+                result=result.to_dict(),
+                next_state="parked",
+                next_cursor_step=expected_step,
+                parked_stop_code="STOP-unknown",
+                parked_reason=reason,
+                summon_state="stop",
+            )
+            if isinstance(parked, TrailRunResult):
+                return parked
+            self._project_completed_receipts(
+                prepared=prepared, command_receipt=command_receipt, step_receipt=None
+            )
+            return TrailRunResult(
+                command="step",
+                exit_class=ExitClass.STOP_PARKED,
+                outcome="stop_unknown",
+                run_id=run_id,
+                state=parked.state,
+                cursor_step=parked.cursor_step_id,
+                data={"matched_predicates": matches, "stop_code": parked.parked_stop_code},
+                error=reason,
+            )
+
+        label = matches[0]
+        transition = current_step["transitions"][label]
+        step_receipt = self._step_receipt(
+            run=run,
+            prepared=prepared,
+            command_receipt=command_receipt,
+            label=label,
+            transition=transition,
+        )
+        try:
+            validate_step_receipt_data(step_receipt)
+        except TrailSpecValidationError as exc:
+            raise ReceiptChainError(str(exc)) from exc
+
+        target = transition["target"]
+        if target.startswith("STOP-"):
+            result = TrailRunResult(
+                command="step",
+                exit_class=ExitClass.STOP_PARKED,
+                outcome="stop_parked",
+                run_id=run_id,
+                state="parked",
+                cursor_step=expected_step,
+                data={"transition": label, "stop_code": target},
+            )
+            parked = self._complete_or_return_indeterminate(
+                prepared=prepared,
+                command_receipt=command_receipt,
+                step_receipt=step_receipt,
+                result=result.to_dict(),
+                next_state="parked",
+                next_cursor_step=expected_step,
+                parked_stop_code=target,
+                parked_reason=f"transition '{label}' selected {target}",
+                summon_state="stop",
+            )
+            if isinstance(parked, TrailRunResult):
+                return parked
+            self._project_completed_receipts(
+                prepared=prepared,
+                command_receipt=command_receipt,
+                step_receipt=step_receipt,
+            )
+            return TrailRunResult(
+                command="step",
+                exit_class=ExitClass.STOP_PARKED,
+                outcome="stop_parked",
+                run_id=run_id,
+                state=parked.state,
+                cursor_step=parked.cursor_step_id,
+                data={"transition": label, "stop_code": parked.parked_stop_code},
+            )
+
+        if target in run.spec["terminal_outcomes"]:
+            result = TrailRunResult(
+                command="step",
+                exit_class=ExitClass.OK,
+                outcome="terminal",
+                run_id=run_id,
+                state="terminal",
+                cursor_step=None,
+                data={"transition": label, "terminal_outcome": target},
+            )
+            terminal = self._complete_or_return_indeterminate(
+                prepared=prepared,
+                command_receipt=command_receipt,
+                step_receipt=step_receipt,
+                result=result.to_dict(),
+                next_state="terminal",
+                next_cursor_step=None,
+                terminal_outcome=target,
+            )
+            if isinstance(terminal, TrailRunResult):
+                return terminal
+            self._project_completed_receipts(
+                prepared=prepared,
+                command_receipt=command_receipt,
+                step_receipt=step_receipt,
+            )
+            return TrailRunResult(
+                command="step",
+                exit_class=ExitClass.OK,
+                outcome="terminal",
+                run_id=run_id,
+                state=terminal.state,
+                cursor_step=terminal.cursor_step_id,
+                data={"transition": label, "terminal_outcome": terminal.terminal_outcome},
+            )
+
+        result = TrailRunResult(
+            command="step",
+            exit_class=ExitClass.OK,
+            outcome="advanced",
+            run_id=run_id,
+            state="active",
+            cursor_step=target,
+            data={"transition": label, "next_step": target},
+        )
+        advanced = self._complete_or_return_indeterminate(
+            prepared=prepared,
+            command_receipt=command_receipt,
+            step_receipt=step_receipt,
+            result=result.to_dict(),
+            next_state="active",
+            next_cursor_step=target,
+        )
+        if isinstance(advanced, TrailRunResult):
+            return advanced
+        self._project_completed_receipts(
+            prepared=prepared,
+            command_receipt=command_receipt,
+            step_receipt=step_receipt,
+        )
+        return TrailRunResult(
+            command="step",
+            exit_class=ExitClass.OK,
+            outcome="advanced",
+            run_id=run_id,
+            state=advanced.state,
+            cursor_step=advanced.cursor_step_id,
+            data={"transition": label, "next_step": advanced.cursor_step_id},
+        )
+
+    def resume(self, *, run_id: str, authority_receipt_id: str) -> TrailRunResult:
+        """Refuse unverified local approvals until P4 supplies approved-source verification."""
+        run = self.store.get_run(run_id)
+        if run.spec["schema_version"] != "trailspec.v1.1":
+            return self._reject_v1_execution("resume", run)
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}", authority_receipt_id):
+            return TrailRunResult(
+                command="resume",
+                exit_class=ExitClass.INVALID,
+                outcome="authority_receipt_refused",
+                run_id=run_id,
+                state=run.state,
+                cursor_step=run.cursor_step_id,
+                error="authority receipt must be an opaque approved-source identifier, not a path",
+            )
+        try:
+            self.authority_resolver.fetch(authority_receipt_id, run)
+        except AuthorityReceiptUnavailableError as exc:
+            return TrailRunResult(
+                command="resume",
+                exit_class=ExitClass.INVALID,
+                outcome="authority_unavailable",
+                run_id=run_id,
+                state=run.state,
+                cursor_step=run.cursor_step_id,
+                error=str(exc),
+            )
+        return TrailRunResult(
+            command="resume",
+            exit_class=ExitClass.INVALID,
+            outcome="authority_resume_unimplemented",
+            run_id=run_id,
+            state=run.state,
+            cursor_step=run.cursor_step_id,
+            error="P4 must bind the approved authority receipt before a parked run can resume",
+        )
+
+    def _projection_payload(self, *, run_id: str, filename: str) -> dict[str, Any]:
+        path = self.store.projection_path(run_id=run_id, filename=filename)
+        try:
+            raw = path.read_bytes()
+            payload = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ReceiptChainError(f"missing or invalid receipt projection {path}: {exc}") from exc
+        expected = (canonical_json(payload) + "\n").encode("utf-8")
+        if raw != expected:
+            raise ReceiptChainError(f"receipt projection is not immutable canonical JSON: {path}")
+        if not isinstance(payload, dict):
+            raise ReceiptChainError(f"receipt projection is not an object: {path}")
+        return payload
+
+    def _verify_chain(self, run: TrailRun) -> dict[str, Any]:
+        pinned = self._projection_payload(run_id=run.run_id, filename="run.json")
+        if (
+            pinned.get("run_id") != run.run_id
+            or pinned.get("trail_hash") != run.trail_hash
+            or pinned.get("trail_id") != run.trail_id
+        ):
+            raise ReceiptChainError("pinned run projection does not bind the SQLite run")
+        if compute_trail_hash(run.spec) != run.trail_hash:
+            raise ReceiptChainError("pinned TrailSpec hash does not match SQLite run")
+        invocations = self.store.list_invocations(run.run_id)
+        if run.spec["schema_version"] == "trailspec.v1":
+            if invocations:
+                raise ReceiptChainError("TrailSpec v1 inspection run unexpectedly has invocations")
+            return {"inspection_only": True, "invocations": 0}
+
+        current_step = run.spec["steps"][0]["step_id"]
+        saw_terminal = False
+        saw_stop = False
+        for expected_generation, invocation in enumerate(invocations):
+            if invocation["cursor_generation"] != expected_generation:
+                raise ReceiptChainError("invocation cursor generations are not contiguous")
+            if invocation["step_id"] != current_step:
+                raise ReceiptChainError(
+                    f"receipt chain expected step '{current_step}', found '{invocation['step_id']}'"
+                )
+            if invocation["status"] != "complete" or invocation["command_receipt"] is None:
+                raise ReceiptChainError(
+                    f"invocation '{invocation['invocation_id']}' lacks a complete command receipt"
+                )
+            command_receipt = invocation["command_receipt"]
+            try:
+                validate_command_receipt_data(command_receipt)
+            except TrailSpecValidationError as exc:
+                raise ReceiptChainError(str(exc)) from exc
+            if digest_json(command_receipt) != invocation["command_receipt_digest"]:
+                raise ReceiptChainError("SQLite command receipt digest does not match payload")
+            prefix = f"{expected_generation:06d}-{invocation['invocation_id']}"
+            if self._projection_payload(
+                run_id=run.run_id, filename=f"command-{prefix}.json"
+            ) != command_receipt:
+                raise ReceiptChainError("command receipt projection differs from SQLite authority")
+            expected_values = {
+                "run_id": run.run_id,
+                "trail_id": run.trail_id,
+                "trail_version": run.trail_version,
+                "trail_hash": run.trail_hash,
+                "step_id": current_step,
+                "invocation_id": invocation["invocation_id"],
+                "resolved_command_digest": invocation["resolved_command_digest"],
+            }
+            for field, expected in expected_values.items():
+                if command_receipt.get(field) != expected:
+                    raise ReceiptChainError(
+                        f"command receipt {field} does not bind its pinned invocation"
+                    )
+
+            step_receipt = self.store.get_step_receipt(invocation["invocation_id"])
+            if step_receipt is None:
+                if (
+                    expected_generation == len(invocations) - 1
+                    and run.state == "parked"
+                    and run.parked_stop_code == "STOP-unknown"
+                ):
+                    saw_stop = True
+                    continue
+                raise ReceiptChainError("complete command receipt lacks its StepReceipt")
+            try:
+                validate_step_receipt_data(step_receipt)
+            except TrailSpecValidationError as exc:
+                raise ReceiptChainError(str(exc)) from exc
+            if self._projection_payload(run_id=run.run_id, filename=f"step-{prefix}.json") != step_receipt:
+                raise ReceiptChainError("step receipt projection differs from SQLite authority")
+            step = self._find_step(run, current_step)
+            matches = self.predicate_evaluator.matching_labels(step, command_receipt)
+            if len(matches) != 1:
+                raise ReceiptChainError("stored StepReceipt has zero or multiple matching predicates")
+            label = matches[0]
+            transition = step["transitions"][label]
+            if (
+                step_receipt.get("transition_taken") != label
+                or step_receipt.get("predicate_id") != transition["evidence"]["predicate_id"]
+                or step_receipt.get("command_receipt_digest")
+                != compute_command_receipt_digest(command_receipt)
+                or step_receipt.get("actor_outcome") != command_receipt["actor_outcome"]
+                or step_receipt.get("idempotency_key") != invocation["idempotency_key"]
+            ):
+                raise ReceiptChainError("StepReceipt does not bind its matching command receipt")
+            expected_step_values = {
+                "trail_id": run.trail_id,
+                "trail_version": run.trail_version,
+                "trail_hash": run.trail_hash,
+                "run_id": run.run_id,
+                "step_id": current_step,
+                "task_family": run.task_family,
+                "invocation_id": invocation["invocation_id"],
+                "predicate_exit": command_receipt["exit_code"],
+                "evidence_digest": digest_json(transition["evidence"]),
+            }
+            for field, expected in expected_step_values.items():
+                if step_receipt.get(field) != expected:
+                    raise ReceiptChainError(
+                        f"StepReceipt {field} does not bind its pinned invocation"
+                    )
+            target = transition["target"]
+            if target.startswith("STOP-"):
+                if expected_generation != len(invocations) - 1 or run.state != "parked":
+                    raise ReceiptChainError("STOP transition did not terminally park the run")
+                if run.parked_stop_code != target:
+                    raise ReceiptChainError("run STOP code differs from its StepReceipt transition")
+                saw_stop = True
+                continue
+            if target in run.spec["terminal_outcomes"]:
+                if expected_generation != len(invocations) - 1 or run.state != "terminal":
+                    raise ReceiptChainError("terminal transition did not terminally complete the run")
+                if run.terminal_outcome != target:
+                    raise ReceiptChainError("terminal outcome differs from its StepReceipt transition")
+                saw_terminal = True
+                continue
+            current_step = target
+
+        if run.state == "active" and run.cursor_step_id != current_step:
+            raise ReceiptChainError("active run cursor does not follow its receipt chain")
+        if run.state == "terminal" and not saw_terminal:
+            raise ReceiptChainError("terminal run has no terminal StepReceipt")
+        if run.state == "parked" and not saw_stop and invocations:
+            # A blocked_on parking has no invocation and remains valid below.
+            raise ReceiptChainError("parked run has no STOP/unknown receipt evidence")
+        return {
+            "inspection_only": False,
+            "invocations": len(invocations),
+            "terminal": saw_terminal,
+            "parked": run.state == "parked",
+        }
+
+    def verify_chain(self, *, run_id: str) -> TrailRunResult:
+        """Prove the pinned SQLite and immutable-projection receipt chain matches."""
+        run = self.store.get_run(run_id)
+        try:
+            details = self._verify_chain(run)
+        except ReceiptChainError as exc:
+            return TrailRunResult(
+                command="verify-chain",
+                exit_class=ExitClass.INVALID,
+                outcome="chain_invalid",
+                run_id=run_id,
+                state=run.state,
+                cursor_step=run.cursor_step_id,
+                error=str(exc),
+            )
+        return TrailRunResult(
+            command="verify-chain",
+            exit_class=ExitClass.OK,
+            outcome="chain_verified",
+            run_id=run_id,
+            state=run.state,
+            cursor_step=run.cursor_step_id,
+            data=details,
+        )
+
+    def close(self, *, run_id: str) -> TrailRunResult:
+        """Expose the CLI verb while refusing P4-owned closure semantics."""
+        run = self.store.get_run(run_id)
+        if run.spec["schema_version"] != "trailspec.v1.1":
+            return self._reject_v1_execution("close", run)
+        chain = self.verify_chain(run_id=run_id)
+        if chain.exit_class != ExitClass.OK:
+            return TrailRunResult(
+                command="close",
+                exit_class=ExitClass.INVALID,
+                outcome="closure_refused_invalid_chain",
+                run_id=run_id,
+                state=run.state,
+                cursor_step=run.cursor_step_id,
+                error=chain.error,
+            )
+        return TrailRunResult(
+            command="close",
+            exit_class=ExitClass.INVALID,
+            outcome="closure_unavailable",
+            run_id=run_id,
+            state=run.state,
+            cursor_step=run.cursor_step_id,
+            error=(
+                "P4 closure verification is not implemented; P3 never marks a run closed "
+                "without authority, lease, head, and terminal re-observation checks"
+            ),
+        )

--- a/scripts/orchestration/trails/executor.py
+++ b/scripts/orchestration/trails/executor.py
@@ -44,10 +44,20 @@ from .models import (
 from .store import TrailStore, canonical_json, digest_json, utc_now
 
 _OUTCOME_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]*$")
+_AUTHORIZATION_REDACTION_PATTERN = re.compile(
+    r"(?i)(authorization\s*[:=]\s*(?:bearer\s+)?)\S+"
+)
+_GITHUB_TOKEN_REDACTION_PATTERN = re.compile(
+    r"(?i)\b(github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+)\b"
+)
+_SECRET_ASSIGNMENT_REDACTION_PATTERN = re.compile(
+    r"(?i)((?:[\"'])?\b(?:password|passwd|token|secret|api[_-]?key)\b"
+    r"(?:[\"'])?\s*[:=]\s*)(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|[^,\r\n\"']+)"
+)
 _REDACTION_PATTERNS = (
-    re.compile(r"(?i)(authorization\s*[:=]\s*(?:bearer\s+)?)\S+"),
-    re.compile(r"(?i)\b(github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9]+)\b"),
-    re.compile(r"(?i)\b(password|passwd|token|secret|api[_-]?key)\s*[:=]\s*\S+"),
+    _AUTHORIZATION_REDACTION_PATTERN,
+    _GITHUB_TOKEN_REDACTION_PATTERN,
+    _SECRET_ASSIGNMENT_REDACTION_PATTERN,
 )
 _MAX_RECEIPT_OUTPUT = 8192
 
@@ -122,10 +132,11 @@ def redact_and_bound_output(value: str, *, limit: int = _MAX_RECEIPT_OUTPUT) -> 
     """Redact credential-shaped output before producing a bounded receipt digest."""
     redacted = value
     for pattern in _REDACTION_PATTERNS:
-        if pattern.pattern.startswith("(?i)(authorization"):
+        if (
+            pattern is _AUTHORIZATION_REDACTION_PATTERN
+            or pattern is _SECRET_ASSIGNMENT_REDACTION_PATTERN
+        ):
             redacted = pattern.sub(r"\1[REDACTED]", redacted)
-        elif pattern.pattern.startswith("(?i)\\b(password"):
-            redacted = pattern.sub(lambda match: f"{match.group(1)}=[REDACTED]", redacted)
         else:
             redacted = pattern.sub("[REDACTED]", redacted)
     if len(redacted) > limit:
@@ -979,8 +990,13 @@ class TrailExecutor:
         if run.state == "terminal" and not saw_terminal:
             raise ReceiptChainError("terminal run has no terminal StepReceipt")
         if run.state == "parked" and not saw_stop and invocations:
-            # A blocked_on parking has no invocation and remains valid below.
-            raise ReceiptChainError("parked run has no STOP/unknown receipt evidence")
+            parked_step = (
+                self._find_step(run, run.cursor_step_id)
+                if run.cursor_step_id is not None
+                else None
+            )
+            if parked_step is None or parked_step.get("blocked_on") is None:
+                raise ReceiptChainError("parked run has no STOP/unknown receipt evidence")
         return {
             "inspection_only": False,
             "invocations": len(invocations),

--- a/scripts/orchestration/trails/models.py
+++ b/scripts/orchestration/trails/models.py
@@ -1,0 +1,131 @@
+"""Typed values shared by the TrailSpec runner ledger and executor.
+
+The runner's persistence boundary deliberately stores JSON documents as well as
+the small typed records below.  The JSON is the durable, schema-bound evidence;
+these records keep state transitions explicit at the Python boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any
+
+
+class ExitClass(IntEnum):
+    """Public CLI exit classes fixed by the Trail runner contract."""
+
+    OK = 0
+    STOP_PARKED = 20
+    BLOCKED_PARKED = 21
+    DEVIATION_REFUSED = 22
+    INVALID = 23
+    INDETERMINATE = 24
+
+
+@dataclass(frozen=True, slots=True)
+class TrailRun:
+    """One pinned TrailSpec run as read from the authoritative SQLite ledger."""
+
+    run_id: str
+    trail_id: str
+    trail_version: str | int
+    trail_hash: str
+    spec: dict[str, Any]
+    seat: str
+    task_family: str
+    params: dict[str, Any]
+    state: str
+    cursor_step_id: str | None
+    cursor_generation: int
+    parked_stop_code: str | None
+    parked_reason: str | None
+    terminal_outcome: str | None
+    closure_state: str
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedInvocation:
+    """An invocation claimed in SQLite before any command is spawned."""
+
+    invocation_id: str
+    run_id: str
+    step_id: str
+    cursor_generation: int
+    idempotency_key: str
+    resolved_command: dict[str, Any]
+    prepared_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExecution:
+    """The bounded command result consumed to create a CommandReceipt."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TrailRunResult:
+    """The sole JSON-object result emitted by every trail runner command."""
+
+    command: str
+    exit_class: ExitClass
+    outcome: str
+    run_id: str | None = None
+    state: str | None = None
+    cursor_step: str | None = None
+    data: dict[str, Any] | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a document conforming to trail-run-result.v1."""
+        return {
+            "schema_version": "trail-run-result.v1",
+            "command": self.command,
+            "exit_class": int(self.exit_class),
+            "outcome": self.outcome,
+            "run_id": self.run_id,
+            "state": self.state,
+            "cursor_step": self.cursor_step,
+            "data": self.data or {},
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> TrailRunResult:
+        """Restore a stored, already-emitted idempotent result."""
+        return cls(
+            command=str(payload["command"]),
+            exit_class=ExitClass(int(payload["exit_class"])),
+            outcome=str(payload["outcome"]),
+            run_id=payload.get("run_id"),
+            state=payload.get("state"),
+            cursor_step=payload.get("cursor_step"),
+            data=dict(payload.get("data") or {}),
+            error=payload.get("error"),
+        )
+
+
+class TrailRunnerError(Exception):
+    """A fail-closed runner error that maps to the public invalid-input class."""
+
+
+class DeviationRefusedError(TrailRunnerError):
+    """Raised when a request does not name the run's exact current cursor."""
+
+
+class ReceiptChainError(TrailRunnerError):
+    """Raised when a persisted receipt chain cannot be proven intact."""
+
+
+class AuthorityReceiptUnavailableError(TrailRunnerError):
+    """Raised while P4 authority verification is intentionally unavailable."""
+
+
+class InjectedCrash(BaseException):
+    """Test-only crash marker that intentionally bypasses normal error handling."""

--- a/scripts/orchestration/trails/store.py
+++ b/scripts/orchestration/trails/store.py
@@ -1,0 +1,595 @@
+"""SQLite-authoritative storage for pinned TrailSpec runs.
+
+SQLite is the source of truth.  Receipt files are immutable projections written
+from committed SQLite rows and are intentionally never consulted to advance a
+cursor.  Every method that claims, advances, or parks a run uses ``BEGIN
+IMMEDIATE`` so two weak-driver requests cannot both claim the same step.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from collections.abc import Iterator
+from contextlib import closing, contextmanager, suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    DeviationRefusedError,
+    PreparedInvocation,
+    ReceiptChainError,
+    TrailRun,
+    TrailRunnerError,
+)
+
+
+def utc_now() -> str:
+    """Return a stable UTC RFC3339 timestamp with an explicit Z suffix."""
+    return datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def canonical_json(data: Any) -> str:
+    """Serialize evidence deterministically for storage and digest comparison."""
+    return json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def digest_json(data: Any) -> str:
+    """Hash canonical JSON evidence using the TrailSpec SHA-256 convention."""
+    return hashlib.sha256(canonical_json(data).encode("utf-8")).hexdigest()
+
+
+class TrailStore:
+    """Own the runs database and its immutable receipt projection directory."""
+
+    def __init__(self, database_path: Path, receipts_root: Path) -> None:
+        self.database_path = database_path
+        self.receipts_root = receipts_root
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        self.database_path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(self.database_path, isolation_level=None, timeout=30)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.execute("PRAGMA synchronous = FULL")
+        return connection
+
+    def _initialize(self) -> None:
+        with closing(self._connect()) as connection:
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS trail_runs (
+                    run_id TEXT PRIMARY KEY,
+                    trail_id TEXT NOT NULL,
+                    trail_version TEXT NOT NULL,
+                    trail_hash TEXT NOT NULL,
+                    pinned_spec_json TEXT NOT NULL,
+                    seat TEXT NOT NULL,
+                    task_family TEXT NOT NULL,
+                    params_json TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    cursor_step_id TEXT,
+                    cursor_generation INTEGER NOT NULL,
+                    parked_stop_code TEXT,
+                    parked_reason TEXT,
+                    terminal_outcome TEXT,
+                    closure_state TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS trail_invocations (
+                    invocation_id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL REFERENCES trail_runs(run_id),
+                    step_id TEXT NOT NULL,
+                    cursor_generation INTEGER NOT NULL,
+                    idempotency_key TEXT NOT NULL,
+                    resolved_command_json TEXT NOT NULL,
+                    resolved_command_digest TEXT NOT NULL,
+                    prepared_at TEXT NOT NULL,
+                    completed_at TEXT,
+                    status TEXT NOT NULL,
+                    command_receipt_json TEXT,
+                    command_receipt_digest TEXT,
+                    result_json TEXT,
+                    UNIQUE(run_id, idempotency_key),
+                    UNIQUE(run_id, cursor_generation)
+                );
+
+                CREATE TABLE IF NOT EXISTS trail_step_receipts (
+                    invocation_id TEXT PRIMARY KEY
+                        REFERENCES trail_invocations(invocation_id),
+                    run_id TEXT NOT NULL REFERENCES trail_runs(run_id),
+                    cursor_generation INTEGER NOT NULL,
+                    receipt_json TEXT NOT NULL,
+                    receipt_digest TEXT NOT NULL,
+                    UNIQUE(run_id, cursor_generation)
+                );
+
+                CREATE TABLE IF NOT EXISTS trail_summons (
+                    summon_id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL REFERENCES trail_runs(run_id),
+                    invocation_id TEXT REFERENCES trail_invocations(invocation_id),
+                    stop_code TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    authority_receipt_id TEXT,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS trail_invocations_by_run
+                    ON trail_invocations(run_id, cursor_generation);
+                CREATE INDEX IF NOT EXISTS trail_summons_by_run
+                    ON trail_summons(run_id, created_at);
+                """
+            )
+
+    @contextmanager
+    def _immediate_transaction(self) -> Iterator[sqlite3.Connection]:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            yield connection
+            connection.execute("COMMIT")
+        except BaseException:
+            if connection.in_transaction:
+                connection.execute("ROLLBACK")
+            raise
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _run_from_row(row: sqlite3.Row) -> TrailRun:
+        spec = json.loads(row["pinned_spec_json"])
+        return TrailRun(
+            run_id=str(row["run_id"]),
+            trail_id=str(row["trail_id"]),
+            trail_version=spec["version"],
+            trail_hash=str(row["trail_hash"]),
+            spec=spec,
+            seat=str(row["seat"]),
+            task_family=str(row["task_family"]),
+            params=json.loads(row["params_json"]),
+            state=str(row["state"]),
+            cursor_step_id=row["cursor_step_id"],
+            cursor_generation=int(row["cursor_generation"]),
+            parked_stop_code=row["parked_stop_code"],
+            parked_reason=row["parked_reason"],
+            terminal_outcome=row["terminal_outcome"],
+            closure_state=str(row["closure_state"]),
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
+        )
+
+    @staticmethod
+    def _get_run_locked(connection: sqlite3.Connection, run_id: str) -> TrailRun:
+        row = connection.execute(
+            "SELECT * FROM trail_runs WHERE run_id = ?", (run_id,)
+        ).fetchone()
+        if row is None:
+            raise TrailRunnerError(f"unknown run_id '{run_id}'")
+        return TrailStore._run_from_row(row)
+
+    def create_run(
+        self,
+        *,
+        run_id: str,
+        spec: dict[str, Any],
+        trail_hash: str,
+        seat: str,
+        task_family: str,
+        params: dict[str, Any],
+        inspection_only: bool,
+    ) -> TrailRun:
+        """Persist one immutable pinned spec before returning a run identifier."""
+        steps = spec.get("steps")
+        if not isinstance(steps, list) or not steps:
+            raise TrailRunnerError("validated trail has no initial step")
+        now = utc_now()
+        state = "inspection" if inspection_only else "active"
+        cursor_step_id = None if inspection_only else steps[0]["step_id"]
+        with self._immediate_transaction() as connection:
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO trail_runs (
+                        run_id, trail_id, trail_version, trail_hash, pinned_spec_json,
+                        seat, task_family, params_json, state, cursor_step_id,
+                        cursor_generation, parked_stop_code, parked_reason,
+                        terminal_outcome, closure_state, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, NULL, 'open', ?, ?)
+                    """,
+                    (
+                        run_id,
+                        spec["trail_id"],
+                        str(spec["version"]),
+                        trail_hash,
+                        canonical_json(spec),
+                        seat,
+                        task_family,
+                        canonical_json(params),
+                        state,
+                        cursor_step_id,
+                        now,
+                        now,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise TrailRunnerError(f"run_id '{run_id}' already exists") from exc
+            return self._get_run_locked(connection, run_id)
+
+    def get_run(self, run_id: str) -> TrailRun:
+        """Read the current authoritative run state."""
+        with closing(self._connect()) as connection:
+            return self._get_run_locked(connection, run_id)
+
+    def prepare_invocation(
+        self,
+        *,
+        run_id: str,
+        expected_step: str,
+        idempotency_key: str,
+        invocation_id: str,
+        resolved_command: dict[str, Any],
+    ) -> tuple[str, PreparedInvocation | dict[str, Any] | TrailRun]:
+        """Claim a cursor once, writing ``prepared`` before a process can spawn.
+
+        Returns one of ``prepared``, ``replay``, or ``indeterminate``.  A prepared
+        prior claimant is deliberately parked rather than guessed to have died:
+        replaying a possible remote mutation is less safe than stopping the run.
+        """
+        with self._immediate_transaction() as connection:
+            prior = connection.execute(
+                """
+                SELECT invocation_id, status, result_json FROM trail_invocations
+                WHERE run_id = ? AND idempotency_key = ?
+                """,
+                (run_id, idempotency_key),
+            ).fetchone()
+            if prior is not None:
+                if prior["status"] == "complete" and prior["result_json"] is not None:
+                    return "replay", json.loads(prior["result_json"])
+                run = self._get_run_locked(connection, run_id)
+                connection.execute(
+                    """
+                    UPDATE trail_invocations SET status = 'indeterminate'
+                    WHERE invocation_id = ? AND status = 'prepared'
+                    """,
+                    (prior["invocation_id"],),
+                )
+                self._park_locked(
+                    connection,
+                    run=run,
+                    stop_code="STOP-unknown",
+                    reason=(
+                        "prepared invocation has no complete command receipt; "
+                        "the command is indeterminate and will not be replayed"
+                    ),
+                    invocation_id=None,
+                    summon_state="indeterminate",
+                )
+                return "indeterminate", self._get_run_locked(connection, run_id)
+
+            run = self._get_run_locked(connection, run_id)
+            if run.state != "active":
+                raise DeviationRefusedError(
+                    f"run '{run_id}' is {run.state}; its cursor cannot be stepped"
+                )
+            if run.cursor_step_id != expected_step:
+                raise DeviationRefusedError(
+                    f"expected current step '{run.cursor_step_id}', got '{expected_step}'"
+                )
+
+            resolved_command_json = canonical_json(resolved_command)
+            prepared_at = utc_now()
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO trail_invocations (
+                        invocation_id, run_id, step_id, cursor_generation,
+                        idempotency_key, resolved_command_json, resolved_command_digest,
+                        prepared_at, completed_at, status, command_receipt_json,
+                        command_receipt_digest, result_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, 'prepared', NULL, NULL, NULL)
+                    """,
+                    (
+                        invocation_id,
+                        run_id,
+                        expected_step,
+                        run.cursor_generation,
+                        idempotency_key,
+                        resolved_command_json,
+                        digest_json(resolved_command),
+                        prepared_at,
+                    ),
+                )
+            except sqlite3.IntegrityError:
+                # A second claimant for the same generation cannot safely infer
+                # whether the first process reached an external side effect.
+                run = self._get_run_locked(connection, run_id)
+                connection.execute(
+                    """
+                    UPDATE trail_invocations SET status = 'indeterminate'
+                    WHERE run_id = ? AND cursor_generation = ? AND status = 'prepared'
+                    """,
+                    (run_id, run.cursor_generation),
+                )
+                self._park_locked(
+                    connection,
+                    run=run,
+                    stop_code="STOP-unknown",
+                    reason="cursor claim raced another invocation; no command will be replayed",
+                    invocation_id=None,
+                    summon_state="indeterminate",
+                )
+                return "indeterminate", self._get_run_locked(connection, run_id)
+            return (
+                "prepared",
+                PreparedInvocation(
+                    invocation_id=invocation_id,
+                    run_id=run_id,
+                    step_id=expected_step,
+                    cursor_generation=run.cursor_generation,
+                    idempotency_key=idempotency_key,
+                    resolved_command=resolved_command,
+                    prepared_at=prepared_at,
+                ),
+            )
+
+    def park_blocked(
+        self,
+        *,
+        run_id: str,
+        expected_step: str,
+        stop_code: str,
+        reason: str,
+        blocked_id: str,
+    ) -> TrailRun:
+        """Atomically park a blocked step and create its open summon record."""
+        with self._immediate_transaction() as connection:
+            run = self._get_run_locked(connection, run_id)
+            if run.state != "active" or run.cursor_step_id != expected_step:
+                raise DeviationRefusedError(
+                    f"expected active current step '{expected_step}', found "
+                    f"state={run.state!r} cursor={run.cursor_step_id!r}"
+                )
+            self._park_locked(
+                connection,
+                run=run,
+                stop_code=stop_code,
+                reason=f"blocked_on {blocked_id}: {reason}",
+                invocation_id=None,
+                summon_state="blocked",
+            )
+            return self._get_run_locked(connection, run_id)
+
+    def complete_invocation(
+        self,
+        *,
+        prepared: PreparedInvocation,
+        command_receipt: dict[str, Any],
+        step_receipt: dict[str, Any] | None,
+        result: dict[str, Any],
+        next_state: str,
+        next_cursor_step: str | None,
+        terminal_outcome: str | None = None,
+        parked_stop_code: str | None = None,
+        parked_reason: str | None = None,
+        summon_state: str | None = None,
+    ) -> TrailRun:
+        """Commit a complete receipt and its cursor/parking transition together."""
+        if next_state == "parked" and (
+            not parked_stop_code or not parked_reason or not summon_state
+        ):
+            raise TrailRunnerError("parked completion requires a stop code, reason, and summon")
+        with self._immediate_transaction() as connection:
+            run = self._get_run_locked(connection, prepared.run_id)
+            invocation = connection.execute(
+                """
+                SELECT status, cursor_generation FROM trail_invocations WHERE invocation_id = ?
+                """,
+                (prepared.invocation_id,),
+            ).fetchone()
+            if invocation is None or invocation["status"] != "prepared":
+                raise ReceiptChainError(
+                    f"invocation '{prepared.invocation_id}' is not durably prepared"
+                )
+            if int(invocation["cursor_generation"]) != run.cursor_generation:
+                raise ReceiptChainError(
+                    f"cursor advanced while invocation '{prepared.invocation_id}' was executing"
+                )
+            command_receipt_json = canonical_json(command_receipt)
+            step_receipt_json = canonical_json(step_receipt) if step_receipt is not None else None
+            now = utc_now()
+            connection.execute(
+                """
+                UPDATE trail_invocations
+                SET completed_at = ?, status = 'complete', command_receipt_json = ?,
+                    command_receipt_digest = ?, result_json = ?
+                WHERE invocation_id = ?
+                """,
+                (
+                    command_receipt["completed_at"],
+                    command_receipt_json,
+                    digest_json(command_receipt),
+                    canonical_json(result),
+                    prepared.invocation_id,
+                ),
+            )
+            if step_receipt_json is not None:
+                connection.execute(
+                    """
+                    INSERT INTO trail_step_receipts (
+                        invocation_id, run_id, cursor_generation, receipt_json, receipt_digest
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        prepared.invocation_id,
+                        prepared.run_id,
+                        prepared.cursor_generation,
+                        step_receipt_json,
+                        digest_json(step_receipt),
+                    ),
+                )
+
+            if next_state == "parked":
+                self._park_locked(
+                    connection,
+                    run=run,
+                    stop_code=str(parked_stop_code),
+                    reason=str(parked_reason),
+                    invocation_id=prepared.invocation_id,
+                    summon_state=str(summon_state),
+                    updated_at=now,
+                )
+            else:
+                connection.execute(
+                    """
+                    UPDATE trail_runs
+                    SET state = ?, cursor_step_id = ?, cursor_generation = ?,
+                        parked_stop_code = NULL, parked_reason = NULL,
+                        terminal_outcome = ?, updated_at = ?
+                    WHERE run_id = ?
+                    """,
+                    (
+                        next_state,
+                        next_cursor_step,
+                        run.cursor_generation + 1,
+                        terminal_outcome,
+                        now,
+                        prepared.run_id,
+                    ),
+                )
+            return self._get_run_locked(connection, prepared.run_id)
+
+    def _park_locked(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        run: TrailRun,
+        stop_code: str,
+        reason: str,
+        invocation_id: str | None,
+        summon_state: str,
+        updated_at: str | None = None,
+    ) -> None:
+        """Update state and insert a summon inside the caller's SQLite transaction."""
+        now = updated_at or utc_now()
+        connection.execute(
+            """
+            UPDATE trail_runs
+            SET state = 'parked', parked_stop_code = ?, parked_reason = ?, updated_at = ?
+            WHERE run_id = ?
+            """,
+            (stop_code, reason, now, run.run_id),
+        )
+        summon_id = digest_json(
+            {
+                "run_id": run.run_id,
+                "cursor_generation": run.cursor_generation,
+                "stop_code": stop_code,
+                "reason": reason,
+                "invocation_id": invocation_id,
+            }
+        )
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO trail_summons (
+                summon_id, run_id, invocation_id, stop_code, reason, state,
+                authority_receipt_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?)
+            """,
+            (summon_id, run.run_id, invocation_id, stop_code, reason, summon_state, now),
+        )
+
+    def list_invocations(self, run_id: str) -> list[dict[str, Any]]:
+        """Return ordered invocation rows with JSON evidence decoded for verification."""
+        with closing(self._connect()) as connection:
+            self._get_run_locked(connection, run_id)
+            rows = connection.execute(
+                """
+                SELECT * FROM trail_invocations WHERE run_id = ?
+                ORDER BY cursor_generation ASC
+                """,
+                (run_id,),
+            ).fetchall()
+        return [
+            {
+                "invocation_id": str(row["invocation_id"]),
+                "step_id": str(row["step_id"]),
+                "cursor_generation": int(row["cursor_generation"]),
+                "idempotency_key": str(row["idempotency_key"]),
+                "resolved_command": json.loads(row["resolved_command_json"]),
+                "resolved_command_digest": str(row["resolved_command_digest"]),
+                "prepared_at": str(row["prepared_at"]),
+                "completed_at": row["completed_at"],
+                "status": str(row["status"]),
+                "command_receipt": (
+                    json.loads(row["command_receipt_json"])
+                    if row["command_receipt_json"] is not None
+                    else None
+                ),
+                "command_receipt_digest": row["command_receipt_digest"],
+                "result": json.loads(row["result_json"]) if row["result_json"] else None,
+            }
+            for row in rows
+        ]
+
+    def get_step_receipt(self, invocation_id: str) -> dict[str, Any] | None:
+        """Return the immutable StepReceipt linked to an invocation, if it exists."""
+        with closing(self._connect()) as connection:
+            row = connection.execute(
+                "SELECT receipt_json FROM trail_step_receipts WHERE invocation_id = ?",
+                (invocation_id,),
+            ).fetchone()
+        return json.loads(row["receipt_json"]) if row is not None else None
+
+    def list_summons(self, run_id: str) -> list[dict[str, Any]]:
+        """Return summon records for status and test-only atomicity inspection."""
+        with closing(self._connect()) as connection:
+            rows = connection.execute(
+                """
+                SELECT summon_id, invocation_id, stop_code, reason, state, authority_receipt_id,
+                       created_at
+                FROM trail_summons WHERE run_id = ? ORDER BY created_at ASC
+                """,
+                (run_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def project_json(self, *, run_id: str, filename: str, payload: dict[str, Any]) -> Path:
+        """Write a receipt projection exactly once, rejecting mismatched replacements."""
+        if Path(filename).name != filename or not filename.endswith(".json"):
+            raise TrailRunnerError("receipt projection filename must be a simple .json filename")
+        target_dir = self.receipts_root / run_id
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / filename
+        content = (canonical_json(payload) + "\n").encode("utf-8")
+        try:
+            descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError as exc:
+            existing = target.read_bytes()
+            if existing != content:
+                raise ReceiptChainError(
+                    f"immutable receipt projection differs: {target}"
+                ) from exc
+            return target
+        try:
+            with os.fdopen(descriptor, "wb") as receipt_file:
+                receipt_file.write(content)
+                receipt_file.flush()
+                os.fsync(receipt_file.fileno())
+        except BaseException:
+            with suppress(OSError):
+                target.unlink(missing_ok=True)
+            raise
+        return target
+
+    def projection_path(self, *, run_id: str, filename: str) -> Path:
+        """Return a deterministic projection path without trusting it as authority."""
+        return self.receipts_root / run_id / filename

--- a/tests/test_trail_runner.py
+++ b/tests/test_trail_runner.py
@@ -323,6 +323,23 @@ def test_receipt_output_is_bounded_redacted_and_never_stores_raw_secret(tmp_path
     ).hexdigest()
 
 
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("Authorization: Bearer one-word", "Authorization: Bearer [REDACTED]"),
+        ("ghp_exampletoken", "[REDACTED]"),
+        ("token=single-word", "token=[REDACTED]"),
+        ('token = "two words"', "token = [REDACTED]"),
+        ("api_key: 'spaced value'", "api_key: [REDACTED]"),
+        ('{"password": "a b c"}', '{"password": [REDACTED]}'),
+    ],
+)
+def test_redaction_covers_quoted_or_whitespace_containing_secret_values(
+    output: str, expected: str
+) -> None:
+    assert redact_and_bound_output(output) == expected
+
+
 @pytest.mark.parametrize("multiple", [False, True])
 def test_zero_and_multiple_predicate_matches_park_stop_unknown(
     tmp_path: Path, multiple: bool
@@ -387,6 +404,46 @@ def test_blocked_step_atomically_parks_and_creates_summon(tmp_path: Path) -> Non
     assert result.state == "parked"
     assert len(summons) == 1
     assert summons[0]["state"] == "blocked"
+
+
+def test_advanced_chain_can_park_on_blocked_step_and_remain_valid_for_close(
+    tmp_path: Path,
+) -> None:
+    blocked_on = {
+        "id": "operator-approval",
+        "reason": "approval is required",
+        "stop_code": "STOP-unknown",
+    }
+    trail = _trail()
+    start_step = trail["steps"][0]
+    start_step["transitions"]["accepted"]["target"] = "approval"
+    blocked_step = {
+        **start_step,
+        "step_id": "approval",
+        "intent": "wait for an operator approval",
+        "blocked_on": blocked_on,
+        "transitions": {
+            "accepted": {
+                **start_step["transitions"]["accepted"],
+                "target": "done",
+            }
+        },
+    }
+    trail["steps"].append(blocked_step)
+    executor = _executor(tmp_path)
+    run_id = _begin(executor, _write_trail(tmp_path, trail))
+
+    advanced = executor.step(run_id=run_id, expected_step="start")
+    parked = executor.step(run_id=run_id, expected_step="approval")
+    verified = executor.verify_chain(run_id=run_id)
+    closed = executor.close(run_id=run_id)
+
+    assert advanced.outcome == "advanced"
+    assert parked.exit_class == ExitClass.BLOCKED_PARKED
+    assert verified.exit_class == ExitClass.OK
+    assert verified.outcome == "chain_verified"
+    assert closed.exit_class == ExitClass.INVALID
+    assert closed.outcome == "closure_unavailable"
 
 
 def test_v1_is_inspection_only_and_execution_or_closure_is_refused(tmp_path: Path) -> None:

--- a/tests/test_trail_runner.py
+++ b/tests/test_trail_runner.py
@@ -1,0 +1,534 @@
+"""Regression tests for the P3 SQLite TrailSpec runner ledger and executor."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import uuid
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+from scripts.orchestration.trail_runner import main as trail_runner_main
+from scripts.orchestration.trails.executor import TrailExecutor, redact_and_bound_output
+from scripts.orchestration.trails.models import (
+    CommandExecution,
+    ExitClass,
+    InjectedCrash,
+    TrailRunResult,
+)
+from scripts.orchestration.trails.store import TrailStore
+
+
+def _trail(
+    *,
+    command: dict | None = None,
+    transitions: dict | None = None,
+    blocked_on: dict | None = None,
+    schema_version: str = "trailspec.v1.1",
+) -> dict:
+    if schema_version == "trailspec.v1":
+        return {
+            "schema_version": "trailspec.v1",
+            "trail_id": "legacy-runner-fixture",
+            "version": "1.0.0",
+            "title": "legacy fixture",
+            "seats": ["grok-daily"],
+            "stop_codes": ["STOP-unknown"],
+            "terminal_outcomes": ["done"],
+            "steps": [
+                {
+                    "step_id": "inspect",
+                    "intent": "inspection only",
+                    "command": None,
+                    "evidence_predicate": None,
+                    "transitions": {"inspected": "done"},
+                    "kind": "summon",
+                }
+            ],
+        }
+    return {
+        "schema_version": "trailspec.v1.1",
+        "trail_id": "runner-fixture",
+        "version": "1.1.0",
+        "title": "runner fixture",
+        "seats": ["grok-daily"],
+        "parameters": {},
+        "stop_codes": ["STOP-unknown"],
+        "terminal_outcomes": ["done"],
+        "steps": [
+            {
+                "step_id": "start",
+                "intent": "run one bounded command",
+                "command": command
+                or {
+                    "adapter": "shell",
+                    "argv": ["sh", "-c", "printf accepted"],
+                    "environment": {"TRAIL_INVOCATION_ID": "{invocation_id}"},
+                    "timeout_seconds": 30,
+                    "mutation_class": "observe",
+                    "outcome_decoder": {"source": "stdout-token"},
+                },
+                "transitions": transitions
+                or {
+                    "accepted": {
+                        "target": "done",
+                        "evidence": {
+                            "predicate_id": "accepted-outcome",
+                            "clauses": [
+                                {
+                                    "source": "command_receipt",
+                                    "field": "actor_outcome",
+                                    "op": "eq",
+                                    "value": "accepted",
+                                },
+                                {
+                                    "source": "command_receipt",
+                                    "field": "exit_code",
+                                    "op": "eq",
+                                    "value": 0,
+                                },
+                            ],
+                        },
+                    }
+                },
+                "blocked_on": blocked_on,
+            }
+        ],
+    }
+
+
+def _write_trail(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "runner.trail.yaml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _executor(tmp_path: Path, **kwargs) -> TrailExecutor:
+    seat_registry = tmp_path / "fleet.yaml"
+    seat_registry.write_text(
+        yaml.safe_dump({"endpoints": [{"name": "grok-daily", "state": "live"}]}),
+        encoding="utf-8",
+    )
+    store = TrailStore(tmp_path / "runs.sqlite3", tmp_path / "receipts")
+    return TrailExecutor(
+        store,
+        project_root=tmp_path,
+        seat_registry_path=seat_registry,
+        **kwargs,
+    )
+
+
+def _begin(executor: TrailExecutor, path: Path) -> str:
+    result = executor.begin(
+        trail_path=path,
+        seat="grok-daily",
+        task_family="infra-orchestration",
+        params={},
+    )
+    assert result.exit_class == ExitClass.OK
+    assert result.run_id is not None
+    return result.run_id
+
+
+def test_step_pre_records_uuid_and_binds_invocation_environment(tmp_path: Path) -> None:
+    observed: list[tuple[str, str, str]] = []
+    executor: TrailExecutor
+
+    def runner(command: dict, cwd: Path) -> CommandExecution:
+        invocations = executor.store.list_invocations(run_id)
+        assert len(invocations) == 1
+        invocation = invocations[0]
+        uuid.UUID(invocation["invocation_id"])
+        assert invocation["status"] == "prepared"
+        observed.append(
+            (
+                invocation["invocation_id"],
+                command["environment"]["TRAIL_INVOCATION_ID"],
+                command["argv"][-1],
+            )
+        )
+        return CommandExecution(exit_code=0, stdout="accepted", stderr="")
+
+    typed_command = {
+        "adapter": "typed-primitive",
+        "argv": ["trail-primitive", "observe", "--invocation-id", "{invocation_id}"],
+        "environment": {"TRAIL_INVOCATION_ID": "{invocation_id}"},
+        "timeout_seconds": 30,
+        "mutation_class": "observe",
+        "outcome_decoder": {"source": "stdout-token"},
+    }
+    executor = _executor(tmp_path, command_runner=runner)
+    run_id = _begin(executor, _write_trail(tmp_path, _trail(command=typed_command)))
+
+    result = executor.step(run_id=run_id, expected_step="start")
+
+    assert result.exit_class == ExitClass.OK
+    assert result.outcome == "terminal"
+    assert observed[0][0] == observed[0][1] == observed[0][2]
+    assert executor.verify_chain(run_id=run_id).exit_class == ExitClass.OK
+
+
+def test_step_refuses_skipped_repeated_or_invented_cursor_without_movement(tmp_path: Path) -> None:
+    executor = _executor(tmp_path)
+    run_id = _begin(executor, _write_trail(tmp_path, _trail()))
+
+    refused = executor.step(run_id=run_id, expected_step="invented")
+    status = executor.status(run_id=run_id)
+
+    assert refused.exit_class == ExitClass.DEVIATION_REFUSED
+    assert status.cursor_step == "start"
+    assert executor.store.list_invocations(run_id) == []
+
+
+def test_nonterminal_transition_advances_cursor_and_chain(tmp_path: Path) -> None:
+    payload = _trail()
+    payload["steps"][0]["transitions"]["accepted"]["target"] = "finish"
+    finish = json.loads(json.dumps(payload["steps"][0]))
+    finish["step_id"] = "finish"
+    finish["intent"] = "terminal re-observation"
+    finish["transitions"]["accepted"]["target"] = "done"
+    payload["steps"].append(finish)
+    executor = _executor(
+        tmp_path,
+        command_runner=lambda command, cwd: CommandExecution(0, "accepted", ""),
+    )
+    run_id = _begin(executor, _write_trail(tmp_path, payload))
+
+    advanced = executor.step(run_id=run_id, expected_step="start")
+    terminal = executor.step(run_id=run_id, expected_step="finish")
+
+    assert advanced.exit_class == ExitClass.OK
+    assert advanced.outcome == "advanced"
+    assert advanced.cursor_step == "finish"
+    assert terminal.outcome == "terminal"
+    assert executor.verify_chain(run_id=run_id).exit_class == ExitClass.OK
+
+
+def test_duplicate_explicit_idempotency_key_returns_prior_result_without_reexecution(
+    tmp_path: Path,
+) -> None:
+    calls = 0
+
+    def runner(command: dict, cwd: Path) -> CommandExecution:
+        nonlocal calls
+        calls += 1
+        return CommandExecution(exit_code=0, stdout="accepted", stderr="")
+
+    executor = _executor(tmp_path, command_runner=runner)
+    run_id = _begin(executor, _write_trail(tmp_path, _trail()))
+
+    first = executor.step(run_id=run_id, expected_step="start", idempotency_key="client-key")
+    replay = executor.step(run_id=run_id, expected_step="start", idempotency_key="client-key")
+
+    assert first.to_dict() == replay.to_dict()
+    assert calls == 1
+
+
+@pytest.mark.parametrize("window", ["before-spawn", "after-spawn", "after-side-effect"])
+def test_crash_windows_park_indeterminate_and_never_replay(
+    tmp_path: Path, window: str
+) -> None:
+    calls = 0
+    effect = tmp_path / f"{window}.effect"
+
+    def runner(command: dict, cwd: Path) -> CommandExecution:
+        nonlocal calls
+        calls += 1
+        if window == "after-spawn":
+            raise InjectedCrash("simulated crash after spawn")
+        if window == "after-side-effect":
+            effect.write_text("side effect occurred", encoding="utf-8")
+            raise InjectedCrash("simulated crash after side effect")
+        return CommandExecution(exit_code=0, stdout="accepted", stderr="")
+
+    def fault_hook(stage: str, prepared) -> None:
+        if window == "before-spawn" and stage == "after_prepared_before_spawn":
+            raise InjectedCrash("simulated crash before spawn")
+
+    executor = _executor(tmp_path, command_runner=runner, fault_hook=fault_hook)
+    run_id = _begin(executor, _write_trail(tmp_path, _trail()))
+
+    with pytest.raises(InjectedCrash):
+        executor.step(run_id=run_id, expected_step="start")
+    resumed_process = _executor(tmp_path, command_runner=runner)
+    result = resumed_process.step(run_id=run_id, expected_step="start")
+
+    assert result.exit_class == ExitClass.INDETERMINATE
+    assert resumed_process.status(run_id=run_id).state == "parked"
+    assert calls == (0 if window == "before-spawn" else 1)
+    assert effect.exists() is (window == "after-side-effect")
+
+
+def test_timeout_receipt_can_take_an_explicit_timeout_transition(tmp_path: Path) -> None:
+    timeout_transition = {
+        "timed_out": {
+            "target": "done",
+            "evidence": {
+                "predicate_id": "timed-out",
+                "clauses": [
+                    {
+                        "source": "command_receipt",
+                        "field": "actor_outcome",
+                        "op": "eq",
+                        "value": "timeout",
+                    },
+                    {
+                        "source": "command_receipt",
+                        "field": "exit_code",
+                        "op": "eq",
+                        "value": 124,
+                    },
+                ],
+            },
+        }
+    }
+    executor = _executor(
+        tmp_path,
+        command_runner=lambda command, cwd: CommandExecution(
+            exit_code=124, stdout="", stderr="timed out", timed_out=True
+        ),
+    )
+    run_id = _begin(executor, _write_trail(tmp_path, _trail(transitions=timeout_transition)))
+
+    result = executor.step(run_id=run_id, expected_step="start")
+
+    assert result.exit_class == ExitClass.OK
+    receipt = executor.store.list_invocations(run_id)[0]["command_receipt"]
+    assert receipt["exit_code"] == 124
+    assert receipt["actor_outcome"] == "timeout"
+
+
+def test_receipt_output_is_bounded_redacted_and_never_stores_raw_secret(tmp_path: Path) -> None:
+    secret = "top-secret-not-in-receipt"
+    executor = _executor(
+        tmp_path,
+        command_runner=lambda command, cwd: CommandExecution(
+            exit_code=0,
+            stdout="accepted",
+            stderr=f"Authorization: Bearer {secret}",
+        ),
+    )
+    run_id = _begin(executor, _write_trail(tmp_path, _trail()))
+
+    assert executor.step(run_id=run_id, expected_step="start").exit_class == ExitClass.OK
+    receipt = executor.store.list_invocations(run_id)[0]["command_receipt"]
+
+    assert secret not in json.dumps(receipt)
+    assert receipt["stderr_digest"] == hashlib.sha256(
+        redact_and_bound_output(f"Authorization: Bearer {secret}").encode("utf-8")
+    ).hexdigest()
+
+
+@pytest.mark.parametrize("multiple", [False, True])
+def test_zero_and_multiple_predicate_matches_park_stop_unknown(
+    tmp_path: Path, multiple: bool
+) -> None:
+    transitions = {
+        "accepted_one": {
+            "target": "done",
+            "evidence": {
+                "predicate_id": "accepted-one",
+                "clauses": [
+                    {
+                        "source": "command_receipt",
+                        "field": "actor_outcome",
+                        "op": "eq",
+                        "value": "accepted" if multiple else "not-accepted",
+                    }
+                ],
+            },
+        }
+    }
+    if multiple:
+        transitions["accepted_two"] = {
+            "target": "done",
+            "evidence": {
+                "predicate_id": "accepted-two",
+                "clauses": [
+                    {
+                        "source": "command_receipt",
+                        "field": "actor_outcome",
+                        "op": "eq",
+                        "value": "accepted",
+                    }
+                ],
+            },
+        }
+    executor = _executor(
+        tmp_path,
+        command_runner=lambda command, cwd: CommandExecution(0, "accepted", ""),
+    )
+    run_id = _begin(executor, _write_trail(tmp_path, _trail(transitions=transitions)))
+
+    result = executor.step(run_id=run_id, expected_step="start")
+
+    assert result.exit_class == ExitClass.STOP_PARKED
+    assert result.data["stop_code"] == "STOP-unknown"
+    assert len(executor.store.list_summons(run_id)) == 1
+
+
+def test_blocked_step_atomically_parks_and_creates_summon(tmp_path: Path) -> None:
+    blocked_on = {
+        "id": "operator-approval",
+        "reason": "approval is required",
+        "stop_code": "STOP-unknown",
+    }
+    executor = _executor(tmp_path)
+    run_id = _begin(executor, _write_trail(tmp_path, _trail(blocked_on=blocked_on)))
+
+    result = executor.step(run_id=run_id, expected_step="start")
+    summons = executor.store.list_summons(run_id)
+
+    assert result.exit_class == ExitClass.BLOCKED_PARKED
+    assert result.state == "parked"
+    assert len(summons) == 1
+    assert summons[0]["state"] == "blocked"
+
+
+def test_v1_is_inspection_only_and_execution_or_closure_is_refused(tmp_path: Path) -> None:
+    executor = _executor(tmp_path)
+    run_id = _begin(executor, _write_trail(tmp_path, _trail(schema_version="trailspec.v1")))
+
+    step = executor.step(run_id=run_id, expected_step="inspect")
+    close = executor.close(run_id=run_id)
+
+    assert executor.status(run_id=run_id).state == "inspection"
+    assert step.exit_class == ExitClass.INVALID
+    assert close.exit_class == ExitClass.INVALID
+    assert executor.verify_chain(run_id=run_id).exit_class == ExitClass.OK
+
+
+def test_resume_refuses_raw_local_json_authority_receipt(tmp_path: Path) -> None:
+    executor = _executor(tmp_path)
+    run_id = _begin(executor, _write_trail(tmp_path, _trail()))
+    local_receipt = tmp_path / "approval.json"
+    local_receipt.write_text("{}", encoding="utf-8")
+
+    result = executor.resume(run_id=run_id, authority_receipt_id=str(local_receipt))
+
+    assert result.exit_class == ExitClass.INVALID
+    assert result.outcome == "authority_receipt_refused"
+
+
+def test_verify_chain_detects_tampered_projection(tmp_path: Path) -> None:
+    executor = _executor(tmp_path)
+    run_id = _begin(executor, _write_trail(tmp_path, _trail()))
+    assert executor.step(run_id=run_id, expected_step="start").exit_class == ExitClass.OK
+    invocation = executor.store.list_invocations(run_id)[0]
+    receipt_path = executor.store.projection_path(
+        run_id=run_id,
+        filename=f"command-000000-{invocation['invocation_id']}.json",
+    )
+    receipt_path.write_text("{}\n", encoding="utf-8")
+
+    result = executor.verify_chain(run_id=run_id)
+
+    assert result.exit_class == ExitClass.INVALID
+    assert result.outcome == "chain_invalid"
+
+
+def test_cli_emits_one_schema_valid_json_object_and_exit_classes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    trail_path = _write_trail(tmp_path, _trail())
+    params_path = tmp_path / "params.json"
+    params_path.write_text("{}", encoding="utf-8")
+    executor = _executor(tmp_path)
+
+    exit_code = trail_runner_main(
+        [
+            "begin",
+            "--trail",
+            str(trail_path),
+            "--seat",
+            "grok-daily",
+            "--task-family",
+            "infra-orchestration",
+            "--params",
+            str(params_path),
+        ],
+        executor=executor,
+    )
+    output_lines = capsys.readouterr().out.splitlines()
+    schema = json.loads(
+        (Path(__file__).parents[1] / "agents_extensions/shared/schemas/trail-run-result.v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert exit_code == 0
+    assert len(output_lines) == 1
+    Draft202012Validator(schema).validate(json.loads(output_lines[0]))
+
+
+def test_cli_verbs_keep_the_exit_class_and_one_object_contract(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    trail_path = _write_trail(tmp_path, _trail())
+    params_path = tmp_path / "params.json"
+    params_path.write_text("{}", encoding="utf-8")
+    executor = _executor(tmp_path)
+    begin_args = [
+        "begin",
+        "--trail",
+        str(trail_path),
+        "--seat",
+        "grok-daily",
+        "--task-family",
+        "infra-orchestration",
+        "--params",
+        str(params_path),
+    ]
+    assert trail_runner_main(begin_args, executor=executor) == ExitClass.OK
+    run_id = json.loads(capsys.readouterr().out)["run_id"]
+
+    cases = [
+        (["status", "--run-id", run_id], ExitClass.OK),
+        (["step", "--run-id", run_id, "--expected-step", "start"], ExitClass.OK),
+        (["verify-chain", "--run-id", run_id], ExitClass.OK),
+        (["resume", "--run-id", run_id, "--authority-receipt-id", "approval-1"], ExitClass.INVALID),
+        (["close", "--run-id", run_id], ExitClass.INVALID),
+    ]
+    for argv, expected_exit in cases:
+        assert trail_runner_main(argv, executor=executor) == expected_exit
+        lines = capsys.readouterr().out.splitlines()
+        assert len(lines) == 1
+        payload = json.loads(lines[0])
+        assert payload["exit_class"] == expected_exit
+
+
+def test_cursor_race_stops_second_claimant_without_a_second_command(tmp_path: Path) -> None:
+    command_started = threading.Event()
+    allow_first_to_finish = threading.Event()
+    calls = 0
+
+    def runner(command: dict, cwd: Path) -> CommandExecution:
+        nonlocal calls
+        calls += 1
+        command_started.set()
+        assert allow_first_to_finish.wait(timeout=5)
+        return CommandExecution(0, "accepted", "")
+
+    executor = _executor(tmp_path, command_runner=runner)
+    run_id = _begin(executor, _write_trail(tmp_path, _trail()))
+    first_result: list[TrailRunResult] = []
+
+    def first_claimant() -> None:
+        first_result.append(executor.step(run_id=run_id, expected_step="start"))
+
+    thread = threading.Thread(target=first_claimant)
+    thread.start()
+    assert command_started.wait(timeout=5)
+    second = executor.step(run_id=run_id, expected_step="start")
+    allow_first_to_finish.set()
+    thread.join(timeout=5)
+
+    assert second.exit_class == ExitClass.INDETERMINATE
+    assert calls == 1
+    assert executor.status(run_id=run_id).state == "parked"
+    assert first_result
+    assert first_result[0].exit_class == ExitClass.INDETERMINATE


### PR DESCRIPTION
Refs #5885

Implements P3 from [rail-system completion memo §2](docs/projects/fleet-trails/rail-system-completion-memo.md#2-trail-runner) and [§5 P3](docs/projects/fleet-trails/rail-system-completion-memo.md#5-pr-sized-build-packages): SQLite-authoritative run/cursor/invocation/summon ledger, immutable receipt projections, prepared-before-spawn UUID execution, idempotency and crash parking, strict cursor/refusal behavior, and one-JSON CLI results.

P2 decision-table evaluation and P4 authority/closure verification remain explicit fail-closed seams; no TrailSpec v1 execution or closure is enabled.

Evidence from /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/rail-p3-trail-runner:
- .venv/bin/python -m pytest tests/test_trail_runner.py tests/test_validate_trailspec.py -q returned 75 passed.
- .venv/bin/ruff check scripts/orchestration/trail_runner.py scripts/orchestration/trails tests/test_trail_runner.py returned All checks passed.
- .venv/bin/python scripts/audit/lint_opsec_leaks.py returned OPSEC check passed. Zero leaks detected.

Cross-family GLM and formal Claude review are pending. No auto-merge has been enabled.