### PR TITLE
docs(eval): reconcile #2156 public benchmark governance

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -8,8 +8,8 @@
 > real-time source of truth; this page is the once-per-session orientation layer.
 
 | Field | Value |
-|---|---|
-| **Last refreshed** | 2026-07-27 (milestone layer added; May-era tier lists retired — operator-requested focus refresh; 2-seat panel applied) |
+| --- | --- |
+| **Last refreshed** | 2026-07-28 (#2156 public evaluation ownership reconciled; #4913 internal boundary retained) |
 | **Refresh trigger** | Every session handoff that lands a milestone; every stream-epic board change |
 | **Curriculum KPI** | Modules passing audit per week (curriculum streams; each milestone carries its own outcome measure) |
 | **Mission** | Full Ukrainian curriculum with decolonized pedagogy, real textbook grounding, RAG-verified vocabulary, adversarial review. Quality non-negotiable. |
@@ -22,9 +22,11 @@
 Learners and teachers are the only customers. Every stream must trace to this chain:
 
 1. **Products**: the LU curriculum site (learners) and Hramatka (teachers).
-2. **Kept honest by**: the UA eval harness (QG gates, judges, benchmarks).
+2. **Kept honest by**: internal QG machinery (#4913) and the separately owned
+   public UA-GEC calque + grammar evaluation (#2156).
 3. **Which runs on**: the fleet — build pipeline, dispatch, comms, leases, CI.
-4. **Community give-back**: the grounded-factuality benchmark release (code, not paper).
+4. **Community give-back**: the public UA-GEC calque + grammar evaluation
+   package (code and reproducible evidence, not a broad leaderboard).
 
 **The trace is falsifiable, not vibes:** every queued item names its stream milestone,
 the specific done-condition it advances, and the learner/teacher outcome that condition
@@ -43,14 +45,14 @@ is the single source of truth for membership (auditor:
 `scripts/orchestration/issue_stream_audit.py`; live view: `GET /api/issues/streams`).
 
 | Stream | Epic(s) | Scope |
-|---|---|---|
+| --- | --- | --- |
 | atlas-practice | #4387, #4700, #5331 | Word Atlas + Practice Hub product & UX |
 | atlas-intake | #4220, #4378, #5224 | Full-corpus intake into the Atlas |
 | corpus-channels | #4706 | Acquisition & ingestion (textbooks · ZNO · Ohoiko-media · press · academic) |
 | infra-harness | #4707 | Infra & fleet reliability (hooks, dispatch, routing) |
 | devops | #5703 | DevOps automation, CI, release & launcher reliability |
-| eval-harness | #4913 | UA eval harness: QG grounding/entailment gates, grammar-lexical gate, annotation, bakeoffs, cutovers |
-| benchmark-2156 | #4639 | UA LLM grounded-factuality benchmark community release |
+| eval-harness | #4913 | Internal QG schemas, validators, quality gates, product adapters, and private calibration |
+| benchmark-2156 | #2156 | Public UA-GEC-derived calque + grammar gold, standard scoring, baselines, freeze, and release |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |
 | seminars-folk | #2836 | FOLK re-research + rebuild |
 | seminars-bio | #4431, #4215 | BIO readiness + builds |
@@ -74,10 +76,10 @@ Rows below marked *(proposed)* were drafted by the infra driver on 2026-07-27 fr
 epic-board state and bind only once that stream's driver (State: the operator) confirms.
 
 | Stream | State | Current milestone | Done when |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | infra-harness | ACTIVE *(proposed)* | Weak-driver rails T1 (T1.1 slot addressing ✅ #5878; T1.2 lease lifecycle; T1.3 glm canary lane) | T1.2 + T1.3 merged with mutation-checked tests. (The fleet-comms decision packet — dual-write parity + authority-signal evidence for any future plane change, file handoff never dropped unilaterally per `fleet-comms-coordination.md` — is the NEXT milestone, not this one.) |
-| eval-harness | *(operator to set)* | Label-the-union annotation → judge qualification (#4913 board's critical path) *(proposed — driver to confirm)* | Annotation round complete + qualification scored against it per `layerb-entailment-gate-design.md`; judge-selection decisions only after |
-| benchmark-2156 | *(operator to set)* | Benchmark v1 freeze + native-expert validation (#4639 Phases 1–2: #4626 before packaging #4541) *(proposed — driver to confirm)* | v1 frozen with a tagged, reproducible run command; expert calibration pass recorded |
+| eval-harness | *(operator to set)* | Internal product-quality machinery under #4913 *(driver to confirm)* | Current internal milestone is confirmed on #4913 without absorbing public gold or release work |
+| benchmark-2156 | ACTIVE | Governance truth freeze (#5966), then held-out manifest (#5967) | #5966 merged and closed; #5967 then manifests every eligible upstream held-out UA-GEC record with provenance and exclusions |
 | atlas-practice | ACTIVE *(proposed)* | Practice Hub deck experience stable after the D10 wave (#5877–#5883) *(driver to confirm)* | A bounded soak: 7 days with no new daily-deck defect filed; then next #4700 item |
 | atlas-intake | ACTIVE *(proposed)* | 20k enrichment run with durable storage (#5884) *(driver to confirm)* | Enriched dataset persisted off-repo with a tracked pointer; refetch never needed |
 | corpus-channels | *(operator to set)* | *(VACANT — driver to set from #4706; the slot-addressing work formerly listed here is infra-harness scope)* | — |
@@ -101,7 +103,7 @@ on the infra board).
 Every shipped module must pass all three:
 
 | Pillar | What | How |
-|---|---|---|
+| --- | --- | --- |
 | **Structural** | Word count, activities, vocab, formatting, MDX render | Deterministic audit gates (`scripts/audit_module.py`, `python_qg.json`, `wiki_coverage_gate.py`) |
 | **Linguistic** | VESUM-verified words, Russianisms/Surzhyk/calques/paronyms clean, citations resolve | MCP `sources` server (`mcp__sources__*` / `mcp_sources_*`) — verify_words, check_russian_shadow, verify_source_attribution, search_style_guide |
 | **Pedagogical** | Tone, immersion balance, register, decolonization, sequence | Cross-agent reviewer per the live routing rule (`model-assignment.md` served at `/api/rules`) |

--- a/docs/decisions/2026-07-28-public-ua-eval-ownership-and-data-boundaries.md
+++ b/docs/decisions/2026-07-28-public-ua-eval-ownership-and-data-boundaries.md
@@ -1,0 +1,96 @@
+# ACCEPTED — Public Ukrainian evaluation ownership and data boundaries
+
+**Status:** ACCEPTED
+
+**Decided on:** 2026-07-28
+
+**Scope:** Public Ukrainian calque + grammar evaluation, internal quality
+machinery, Hramatka feedback, Atlas evidence, and Daily Practice data
+boundaries.
+
+## Decision
+
+GitHub epic #2156 owns the public UA-GEC-derived calque + grammar evaluation:
+public gold, standard scoring, baselines, freeze/versioning, documentation,
+and release.
+
+GitHub epic #4913 remains the internal product-quality machinery lane. It owns
+QG schemas, finding envelopes, reusable validators, internal quality gates,
+product adapters, and private calibration. Internal findings never
+automatically become public benchmark gold.
+
+Hramatka remains under #4542, with private quality calibration under #5254.
+Teachers are product users. Their accept/edit/reject actions are organic
+feedback, not unpaid annotation, approval, or automatic research gold.
+
+Atlas (#4387) supplies provenance-aware lexical and heritage evidence. Daily
+Practice (#4700) uses independently rights-cleared learner material. Neither
+product automatically supplies public benchmark gold.
+
+The stable registry key `benchmark-2156` is retained for consumer
+compatibility, but its epic mapping moves from the retired factuality
+[epic #4639](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4639)
+to canonical public-evaluation
+[epic #2156](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2156).
+
+## Shared infrastructure
+
+The lanes may share only thin, versioned infrastructure:
+
+- stable finding/event schemas and upstream tag vocabulary;
+- span normalization;
+- scorer interfaces;
+- validator/configuration versions;
+- VESUM and heritage evidence semantics;
+- provenance conventions.
+
+They do not share data inventories by default.
+
+## Data separation
+
+The following remain separate:
+
+- frozen public benchmark gold;
+- private Hramatka regression cases;
+- teacher feedback and lesson payloads;
+- Atlas source sentences;
+- Daily Practice exercise inventory;
+- model responses and results;
+- any future training data.
+
+Public benchmark cases must not enter Daily Practice or training. Atlas
+evidence may cause abstention or a contested heritage/regional warning, but it
+must not silently override upstream UA-GEC gold or become a boolean
+"Russianism truth" layer.
+
+## Current capability correction
+
+The current 52 rows are train-derived development fixtures, not public
+held-out gold. The evaluator is mock-only and the metrics are custom rather
+than standard GEC scoring. Historical issue #5608 and PRs #5610/#5633 remain
+prototype receipts; they do not satisfy #2156 completion.
+
+## Exclusions
+
+This decision excludes:
+
+- BIO, factuality, and cultural/tool-grounded fact checking;
+- synthetic corruption;
+- DPO, fine-tuning, and training;
+- broad curriculum evidence backfill;
+- a general Ukrainian leaderboard;
+- teacher/community annotation dependencies;
+- automatic transfer of Hramatka, Atlas, or Practice data into public gold.
+
+## Consequences
+
+The ordered public queue is #5966 → #5967 → #5636 → #4626 → #4541. Final
+dataset size is determined by the frozen upstream eligibility predicate, not
+an arbitrary quota. Public release requires attribution, limitations,
+contamination policy, clean-clone proof, and separation from all private or
+product data.
+
+This decision supersedes
+`2026-07-07-benchmark-public-release-parked.md` only for public calque +
+grammar evaluation ownership. The retired factuality/BIO release program
+remains excluded and closed as not planned.

--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -1,140 +1,152 @@
-# Project: Ukrainian Calque + Grammar Evaluation Harness
+# Ukrainian calque + grammar evaluation
 
-> **Status (2026-07-22):** Implementation sub-issue **[#5608](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5608)** active. Delivered **[PR #5610](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5610)** (`compile_evalset.py` & `taxonomy.yaml`) and **[PR #5612](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5612)** (`vps_dialect_ingest_standalone.py` & dialect catalog doc). Remote VPS ingestion host verified & deployed. Publication target: **UNLP 2027**.
+> **Canonical tracker:** [GitHub epic #2156](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2156)
+>
+> **Verified status (2026-07-28):** the committed 52 rows and mock evaluator are
+> development fixtures. They are not a held-out public benchmark, standard GEC
+> scorer, real-model baseline, or leaderboard.
 
-> **For future sessions: this is the canonical pick-up entrypoint.** When the user says "let's continue the eval harness work" or asks about the UNLP project, read this file first.
+## Mission
 
-## TL;DR
+Build a reproducible public minimal-edit correction evaluation for Ukrainian
+calques and grammar from UA-GEC. The final package must provide deterministic
+gold extraction, standard edit scoring, version-pinned baselines, and a
+stranger-runnable release without private product data or provider secrets.
 
-Build a **dedicated LLM evaluation harness for Ukrainian calques AND grammar errors** on top of the **UA-GEC** gold-tagged subset. Open-source, non-commercial, CC-BY-4.0 attribution preserved. **Publication target: UNLP 2027** (UNLP 2026 submission window already closed).
+Oleksiy's direction for the project is:
 
-Two coupled dimensions because (a) no dedicated harness exists for either today, (b) UA-GEC already tags both calques (F/Calque) and grammar (G/Case, G/Gender, etc.), and (c) a single harness with two scoring axes is cheaper and more useful than two separate harnesses.
+- no dedicated Ukrainian calque harness is known;
+- UA-GEC reuse is welcome;
+- the evaluation set is the highest priority;
+- a reproducible baseline harness is a close second.
 
-## Why this exists
+The project does not create a broad Ukrainian leaderboard or composite
+"Ukrainian quality" score.
 
-LLMs reliably produce Russianisms, calques, and grammar errors when generating Ukrainian text, even when prompts explicitly forbid them. The curriculum project ran into this firsthand: Claude Opus 4.7, asked to translate English → Ukrainian with explicit "avoid Russianisms," still produced 3 Russianisms in 70 words (`приймати участь`, `слідуючі пункти`, `у любий момент`). Public reproducer: `anthropics/claude-code#59146`.
+## Verified capability truth
 
-The public landscape (verified 2026-05-19):
+Repository inspection on 2026-07-28 established:
 
-- **UA-GEC** has 2,397 human-annotated F/Calque examples plus G/Case, G/Gender, F/Collocation, and other grammar/fluency tags. Only Ukrainian gold-tagged corpus with this shape. License CC BY 4.0. ([github.com/grammarly/ua-gec](https://github.com/grammarly/ua-gec))
-- **LanguageTool** has a rule-based Ukrainian module — adjacent rules, not LLM-eval-shaped.
-- **lang-uk leaderboard** benchmarks LLM *adaptation* to Ukrainian (translation/reasoning/QA/IFEval) — explicitly does NOT cover calque or grammar. ([huggingface.co/spaces/lang-uk/ukrainian-llm-leaderboard](https://huggingface.co/spaces/lang-uk/ukrainian-llm-leaderboard))
-- **Karpov & Chernodub (UNLP 2026):** *"How Far Can Prompting Go for Minimal-Edit Ukrainian Grammatical Error Correction?"* — adjacent work on UA grammar error CORRECTION. Different shape (correction, not eval-as-leaderboard).
-- **Pravopysnyk** has a synthetic *corrupter* (uk → ru → heuristic) — useful for prompt augmentation, not scoring.
-- **Curriculum project** has the *scorer* — a deterministic ~50-pattern Russianism + calque detector currently running as a build-time gate across the V7 module pipeline.
+- `data/projects/ua_eval_harness/evalset_v1.jsonl` contains 52 rows:
+  32 `F/Calque`, 12 `G/Case`, and 8 `G/Gender`;
+- all 52 source items are from UA-GEC train partitions
+  (`gec-fluency/train` or `gec-only/train`), not an upstream held-out split;
+- `compile_evalset.py` reads a pre-curated local 52-item source and does not
+  apply a frozen upstream eligibility, split, or exclusion predicate;
+- heritage protection is a five-token hard-coded seed, not a versioned
+  VESUM/heritage integration, and no current row exercises it;
+- `evaluate_model.py` implements only `mock`; every real model name raises
+  `NotImplementedError`;
+- current metrics use normalized exact sentence matching and custom
+  source/target substring checks, not standard edit alignment or F0.5.
 
-**The gap:** no LLM-evaluation harness with prompts engineered to elicit calques + grammar errors, paired with cross-model leaderboard scoring against UA-GEC gold tags. That is what we want to build.
+The mock path receives oracle data and is test-only. Its score must never be
+reported as a model baseline. The 52 rows may be used for parser/scorer
+development and regression only.
 
-## Scope
+Historical receipts remain useful but bounded:
 
-1. **Two scoring axes:** calque (F/Calque + adjacent F/* tags) AND grammar (G/* tags from UA-GEC).
-2. **UA-GEC** as the gold set. Full attribution + CC-BY-4.0 propagation.
-3. **Source-language-agnostic schema** from day one: `source_lang: ru | pl | en | …`. Russian first because that is where the empirical LLM harm concentrates today.
-4. **Permanently non-commercial open-source** (matches the curriculum project's posture; see `CLAUDE.md` non-commercial-permanent decision 2026-04-19).
-5. **Target UNLP 2027** for publication.
+- [issue #5608](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5608)
+  and [PR #5610](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5610)
+  delivered the local compiler prototype;
+- [PR #5633](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/5633)
+  delivered the mock-only evaluator prototype.
 
-## Adjacent assets we already have
+Their closed/merged states do not prove that a public benchmark or live
+baseline harness exists.
 
-These are NOT the harness, but they are the scorer-side foundation:
+## Frozen task direction
 
-- **Deterministic calque detector** — ~50 patterns + scoring function, gating every V7 module build. Russian-only, smaller pattern set than UA-GEC's gold data. Lives in `scripts/audit/` (Russianism gate). Worth wiring as one of the scorers in the harness.
-- **Multi-model writer bakeoff** — `audit/2026-05-19-multi-agent-routing-assessment/REPORT.html` covers ~12 frontier models (Claude, GPT-5.5, Gemini, Grok closed-source; DeepSeek, Qwen, Mistral, Kimi, MiniMax, Ring, GLM open). Calque/Russianism signal is graded; generation-side data the lang-uk leaderboard does not cover.
-- **VESUM** — 6.7M Ukrainian forms, used for morphological verification. Available via `mcp__sources__verify_word`.
-- **Антоненко-Давидович** — 342 structured Russianism entries + 169 prose chunks. Available via `mcp__sources__search_style_guide` and `mcp__sources__search_text source=antonenko-davydovych-yak-my-hovorymo`.
-- **СУМ-11 + Грінченко + ЕСУМ + slovnyk.me** — heritage-defense layer (`mcp__sources__search_heritage`) to avoid false-positives on authentic Ukrainian archaisms/dialectisms.
-- **UA-GEC errors index** — already MCP-exposed via `mcp__sources__search_ua_gec_errors` (filtered to F/Calque, F/Collocation, G/Case, G/Gender). 8,937 rows.
+The target is minimal-edit Ukrainian sentence correction:
 
-## Current implementation artifacts
+1. Model input contains the source sentence and versioned task instruction.
+2. Gold targets and edit spans are never model inputs.
+3. Model responses are saved before scoring.
+4. A standard edit scorer reports precision, recall, and F0.5.
+5. Exact corrected-sentence accuracy is a companion metric.
+6. Results report per-tag support, uncertainty, unchanged output, and
+   over-editing.
 
-- [PR1 curriculum QG plan](pr1-curriculum-qg-plan.md) documents the merged
-  curriculum-facing MVP.
-- [UA contact quality evidence schema](schema.md) documents
-  `ua_contact_quality_evidence.v1` and the helper module
-  `scripts/audit/qg_schema.py`.
-- [Scorer adapter boundaries](scorer-adapters.md) document the #4308
-  deterministic, UA-GEC-fixture, and LLM-placeholder adapter layer.
-- [Cost-aware curriculum QG workflow](cost-aware-qg-workflow.md) documents the
-  #4310 tiered, short-circuiting workflow and composite LLM cache key.
-  Tier-2 reviewer retries are capped at <=3 calls/module: initial + one theatre retry + one deep-read retry.
-- [Agent fleet evidence for #4307](agent-fleet-4307.md) records the concrete
-  fleet lanes used for the schema slice and the observed strengths/weaknesses.
-- [Model evidence](model-evidence.md) — per-model probe results (Gemma 4 bakeoff,
-  the opencode-vs-hermes tooled fact-check experiment) that ground routing and
-  harness-transport decisions.
-- [Leaderboard boundary](leaderboard-boundary.md) — what #2156 measures vs what is
-  delegated to the lang-uk leaderboard, plus the metadata interop bridge (#4289).
-- [Surzhyk eval scoping](surzhyk-eval-scoping.md) — #4287 fleet-reviewed task definition,
-  5-class variety taxonomy, GRAC pointer-only fixture policy, IAA pilot gate.
-- [PL/EN borrowing eval scoping](pl-en-borrowing-scoping.md) — #4288 fleet-reviewed lexical-borrowing
-  boundary (syntactic EN calques stay in #2156), harmful-vs-accepted decision rule, source landscape.
+The public set will be derived from an upstream-pinned UA-GEC held-out split.
+A frozen eligibility predicate determines all included records; final size is
+an observed result, not a quota. The manifest preserves upstream IDs,
+writer/document splits, original tags, attribution, source/reference hashes,
+and explicit inclusion/exclusion reasons.
 
-## Design TBD (these are the questions next session should answer)
+## Ownership and data boundaries
 
-### Eval shape — calque axis
+Four lanes cooperate but retain separate ownership:
 
-- Prompt-elicitation: what task family elicits calques best? (Translation EN→UK? Free generation in UK? Continuation from UK seed? Conversation-completion?)
-- Coverage: how many UA-GEC F/Calque examples form the eval set? Hold-out for validation?
-- Scoring: exact-match against gold edit-pairs? F1 over flagged spans? Semantic-equivalence aware?
-- Calibration: how do we compare LLM output to UA-GEC's human-edit format (which is corrective, not generative)?
+- **#2156 — public evaluation:** public UA-GEC-derived gold, standard scoring,
+  baselines, freeze/versioning, documentation, and release.
+- **#4913 — internal quality machinery:** QG schemas, finding envelopes,
+  validators, internal gates, product adapters, and private calibration.
+- **#4542 / #5254 — Hramatka:** teacher-facing product and private Hramatka
+  regression calibration. Teachers are users, not annotators.
+- **#4387 / #4700 — Atlas and Daily Practice:** provenance-aware
+  lexical/heritage evidence and independently rights-cleared learner material.
 
-### Eval shape — grammar axis
+These inventories remain separate:
 
-- Which G/* tags do we score? G/Case, G/Gender, G/Number, G/Aspect, G/Verb? All?
-- Same prompt family as calque axis, or separate prompts that elicit grammar mistakes specifically?
-- Joint vs separate leaderboard: one ranking with two columns, or two separate rankings?
+- frozen public benchmark gold;
+- private Hramatka regression cases;
+- teacher feedback and lesson payloads;
+- Atlas source sentences;
+- Daily Practice exercise inventory;
+- model responses and result metadata;
+- any future training data.
 
-### Models in scope
+Public gold must not enter Daily Practice or training. Product findings and
+teacher feedback may inform private regressions but never automatically become
+public gold. Atlas evidence may cause abstention or a contested-heritage
+warning; it must not silently override UA-GEC gold.
 
-- Closed-source frontier: Claude, GPT-5.5, Gemini, Grok
-- Open-source frontier: DeepSeek, Qwen, Mistral, Kimi, MiniMax
-- Plus open-weight UA-fine-tuned: Lapa, MamayLM (covered by lang-uk leaderboard)
-- Cost ceiling per full eval pass
+Only thin infrastructure may be shared: stable schemas and upstream tags, span
+normalization, scorer interfaces, validator/configuration versions,
+VESUM/heritage evidence semantics, and provenance conventions.
 
-### Repo layout
+## Ordered execution queue
 
-- Standalone repo or sub-project of `learn-ukrainian`?
-- Naming: `ua-eval-harness`? `uk-russian-shadow-eval`? `ua-gec-llm-eval`?
-- Reproducibility: requirements pinned, results-versioned, model-version-captured
+1. [#5966 — reconcile capability truth and freeze the task/data contract](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5966)
+2. [#5967 — build the deterministic held-out UA-GEC extraction manifest](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5967)
+3. [#5636 — standard GEC scorer, saved-response adapter, and baselines](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5636)
+4. [#4626 — freeze manifest, split integrity, and contamination policy](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4626)
+5. [#4541 — stranger-runnable public v0, data card, and baseline report](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4541)
 
-## Out of scope for this project
+EleutherAI/lm-eval compatibility is optional after the saved-response runner
+and standard scorer are proven. It is not a v0 prerequisite.
 
-- **Surzhyk-specific eval (spoken register)** — calques are a subset of Surzhyk patterns; an eval scoped narrowly to spoken-register Surzhyk is a different shape and could be a follow-on project.
-- **Polonisms, anglicisms as primary scope** — schema supports them via `source_lang`, but Russian is priority-1 because that is where empirical LLM harm concentrates today.
-- **General Ukrainian LLM capability** — covered by the lang-uk leaderboard; the boundary + interop bridge are documented in [leaderboard-boundary.md](leaderboard-boundary.md) (#4289). Surzhyk follow-up = #4287; polonism/anglicism expansion = #4288.
+## Non-goals
 
-## Timeline anchors (loose)
+- factuality, BIO, cultural-grounding, or seminar fact checking;
+- synthetic corruption, DPO, fine-tuning, training, or training-data creation;
+- Hramatka, Atlas, Daily Practice, curriculum, or dataset implementation in
+  the governance cycle;
+- Surzhyk, Polonism, or Anglicism expansion;
+- a new leaderboard or arbitrary dataset-size target;
+- teacher/community annotation, approval, or external-person dependency;
+- treating heritage evidence as a boolean Russianism truth layer.
 
-- **2026-05** — scoping (this doc).
-- **2026-mid to 2026-late** — eval design draft + early results.
-- **2027-Q1** — paper draft.
-- **2027-05 (typical UNLP timing)** — UNLP 2027 conference.
+## Release gates
 
-These are loose. Adjust as design firms up.
+The epic remains open until:
 
-## Cross-references
+1. the upstream eligibility predicate and held-out manifest are frozen;
+2. every eligible record has attribution and an exclusion disposition;
+3. a standard scorer accepts saved responses;
+4. identity, deterministic, and one real version-pinned model baseline run;
+5. per-tag support and uncertainty are reported;
+6. the data card, license, limitations, and contamination policy exist;
+7. clean-clone scoring is proven;
+8. no private/product data has entered public gold; and
+9. the package runs without Hramatka, teacher data, Atlas private state, or
+   provider secrets.
 
-- v1 multi-agent routing audit: `audit/2026-05-19-multi-agent-routing-assessment/REPORT.html`
-- Curriculum non-commercial-permanent decision: `CLAUDE.md` (2026-04-19)
-- UA-GEC repo: https://github.com/grammarly/ua-gec
-- UA-GEC license: CC BY 4.0
-- Anthropic Russianism reproducer: anthropics/claude-code#59146
-- UNLP: https://unlp.org.ua/
-- lang-uk leaderboard: https://huggingface.co/spaces/lang-uk/ukrainian-llm-leaderboard
-- Karpov & Chernodub (UNLP 2026 paper): TBD URL when published
-- GitHub tracker: see "Issue tracker" section below.
+## Related records
 
-## Pick-up checklist (for the next session that resumes this)
-
-When you come back to this in a week / month / quarter:
-
-1. Read this file in full.
-2. Check the GitHub issue (linked below) for any inbound comments / status changes.
-3. Check `docs/decisions/` for any related decisions filed since.
-4. Read `audit/2026-05-19-multi-agent-routing-assessment/REPORT.html` §5 (writer bakeoff) and §1 finding #4 — the closest existing data points.
-5. Confirm UNLP 2027 timing — adjust the timeline section above if dates have firmed up.
-6. If the eval design has not been drafted yet, that is the next-action item.
-7. If a draft exists, link it from the "Design TBD" sections above.
-
-## Issue tracker
-
-Primary GitHub issue: **[#2156 — Project: UA calque + grammar eval harness (UNLP 2027 target)](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2156)** (filed 2026-05-19).
+- [Ownership and data-boundary decision](../../decisions/2026-07-28-public-ua-eval-ownership-and-data-boundaries.md)
+- [Internal QG epic #4913](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4913)
+- [Hramatka epic #4542](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4542)
+- [Atlas epic #4387](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4387)
+- [Daily Practice epic #4700](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4700)
+- [UA-GEC upstream repository](https://github.com/grammarly/ua-gec)

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -1,3 +1,4 @@
+---
 # Issue-stream registry — single source of truth for "which epic defines which stream".
 # Consumed by scripts/orchestration/issue_stream_audit.py, the session-setup hook, and
 # /api/state/issues-health. docs/WORKSTREAMS.md § Streams mirrors this table.
@@ -25,11 +26,11 @@ streams:
     title: "DevOps automation, CI, release & launcher reliability"
     epics: [5703]
   eval-harness:
-    title: "UA eval harness — QG gates, grammar-lexical gate, annotation, bakeoffs"
+    title: "Internal UA quality machinery — QG gates, validators, product adapters"
     epics: [4913]
   benchmark-2156:
-    title: "Ukrainian LLM factuality benchmark — community release"
-    epics: [4639]
+    title: "Public Ukrainian calque + grammar evaluation — UA-GEC benchmark"
+    epics: [2156]
   core-quality:
     title: "Core-track deterministic quality"
     epics: [4274]


### PR DESCRIPTION
## Summary

- makes #2156 the canonical public UA-GEC calque + grammar evaluation epic while keeping #4913 internal
- records the verified prototype truth: 52 train-derived development fixtures, mock-only model path, five-token heritage seed, and custom/non-standard scoring
- preserves the stable `benchmark-2156` registry key while moving its epic mapping from retired factuality #4639 to #2156
- documents Hramatka, teacher-feedback, Atlas, Practice, model-response, and training-data separation
- records the ordered queue #5966 → #5967 → #5636 → #4626 → #4541

## Root cause

The repository and GitHub had conflated public calque/grammar evaluation, internal QG/product machinery, Hramatka, and a separate factuality/BIO release program. The stream registry mapped `benchmark-2156` to #4639 while #2156 was structurally parented under Hramatka, and documentation overstated the current 52-row prototype.

## Validation

- `66 passed` — `tests/test_issue_stream_audit.py`, `tests/test_session_streams_inventory_receipts.py`, `tests/test_research_registry.py`
- Markdown lint: 0 errors across the three changed docs
- YAML lint: clean
- `git diff --check`: clean
- staged OPSEC lint: zero leaks
- agent trailer lint: PASS
- live target stream verification: #5966, #5967, #5636, #4626, and #4541 each resolve natively and uniquely to #2156 / `benchmark-2156`; #5092 and #5254 remain uniquely under #4913 / `eval-harness`
- global stream audit still reports unrelated pre-existing debt (39 orphans, 3 multi-homed), including deliberately untouched #5917; this PR introduces none

Closes #5966
Refs #2156
Refs #4913
Refs #4542
Refs #4387
Refs #4700