### PR TITLE
feat(hygiene): automate merged worktree cleanup

### DIFF
--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -235,12 +235,13 @@ After a PR merges, do **not** leave dispatch worktrees forever:
 # Safe default (dry-run):
 .venv/bin/python scripts/orchestration/reap_worktrees.py
 
-# Recommended post-merge cleanup (MERGED/CLOSED + dirty auto preserve-then-reap):
+# Recommended post-merge cleanup (dirty worktrees are preserved):
 .venv/bin/python scripts/orchestration/reap_worktrees.py --apply --merged
 ```
 
-`--merged` enables `--safe-only`, auto preserve-then-reap for dirty MERGED/CLOSED
-trees, and branch prune. Open PRs are never reaped just because HEAD matches
+`--merged` restricts cleanup to exact merged-PR heads and enables branch
+pruning. Dirty trees remain untouched unless a human explicitly adds
+`--preserve-then-reap`. Open PRs are never reaped just because HEAD matches
 `origin/<branch>`.
 
 ### Hermes / DeepSeek isolation (Sol #213 class)

--- a/docs/runbooks/worktree-cleanup.md
+++ b/docs/runbooks/worktree-cleanup.md
@@ -1,0 +1,128 @@
+# Worktree cleanup
+
+This runbook covers immediate post-merge cleanup and the local macOS safety
+backstop for both Learn Ukrainian repositories.
+
+## Safety contract
+
+Cleanup is fail-closed. A worktree is preserved when any of these is true:
+
+- its pull request is open;
+- its pull-request head does not exactly match the worktree HEAD;
+- its task is active or non-terminal;
+- a live process has a working directory inside it;
+- it is dirty, locked, outside the repository's `.worktrees/` subtree, or its
+  state cannot be verified.
+
+The scheduled job never commits work on the operator's behalf and never uses
+`git worktree remove --force`. Unregistered directories with broken `.git`
+pointers are reported as recovery candidates and are never deleted
+automatically.
+
+## Immediate cleanup after merge
+
+The merge owner removes the exact worktree as soon as GitHub reports the PR
+`MERGED`. Run this from a separate shell after every agent, editor, server, and
+terminal has left the target worktree:
+
+```bash
+PRIMARY_REPO="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+cd "$PRIMARY_REPO"
+
+.venv/bin/python scripts/orchestration/reap_worktrees.py \
+  --repo-root "$PRIMARY_REPO" \
+  --apply \
+  --merged \
+  --worktree "$EXACT_WORKTREE_PATH"
+```
+
+The command revalidates GitHub PR state, the exact PR-head SHA, local HEAD,
+cleanliness, task state, and process activity. A skipped result is a blocker,
+not permission to retry with `--force`.
+
+The live-process check intentionally includes the invoking process tree. A
+cleanup launched from inside the target worktree therefore self-protects and
+must be retried from the primary checkout after that process exits. If `lsof`
+cannot inspect process working directories, apply mode fails closed; resolve
+the local macOS permission or tooling problem before retrying.
+
+The canonical PR lifecycle trail already performs worktree-first cleanup after
+merge. Other merge owners must invoke the exact command above before declaring
+closeout complete.
+
+Do not put networked worktree deletion in Git's `post-merge` hook. GitHub merges
+do not run a local hook, and a later `git pull` is not reliable ownership
+evidence for an arbitrary dispatch worktree.
+
+## Manual dual-repository sweep
+
+Dry run:
+
+```bash
+.venv/bin/python scripts/orchestration/scheduled_worktree_cleanup.py
+```
+
+Apply:
+
+```bash
+.venv/bin/python scripts/orchestration/scheduled_worktree_cleanup.py --apply
+```
+
+Each run fetches and prunes `origin`, probes process working directories, runs
+the exact-merged-PR reaper for both repository roots, reports orphaned worktree
+directories, and writes an immutable JSON receipt under:
+
+```text
+~/.codex/worktree-cleanup/receipts/v1/
+```
+
+An unavailable fetch or process-activity probe blocks apply for that
+repository. Standard output contains the same summary as the receipt.
+
+## Inspect the LaunchAgent
+
+Render the plist without writing system configuration:
+
+```bash
+.venv/bin/python scripts/orchestration/install_worktree_cleanup_launchd.py render
+```
+
+The job runs at load and every 15 minutes. It uses the public checkout's exact
+`.venv/bin/python`, passes both repository roots explicitly, and persists logs
+under:
+
+```text
+~/.codex/worktree-cleanup/logs/
+```
+
+## Install
+
+Install only after the cleanup code is merged into the public primary checkout.
+Both primary checkouts must be on `main`.
+
+```bash
+.venv/bin/python scripts/orchestration/install_worktree_cleanup_launchd.py install
+```
+
+Installation is idempotent. It writes and loads:
+
+```text
+~/Library/LaunchAgents/com.learn-ukrainian.worktree-cleanup.plist
+```
+
+Verify the persisted plist and live service:
+
+```bash
+.venv/bin/python scripts/orchestration/install_worktree_cleanup_launchd.py status
+```
+
+After installation, inspect the first receipt and confirm that protected
+worktrees appear as `skipped`, not `removed`.
+
+## Uninstall
+
+```bash
+.venv/bin/python scripts/orchestration/install_worktree_cleanup_launchd.py uninstall
+```
+
+Uninstalling preserves receipts and logs for audit and recovery.

--- a/scripts/orchestration/install_worktree_cleanup_launchd.py
+++ b/scripts/orchestration/install_worktree_cleanup_launchd.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Install the dual-repository worktree cleanup LaunchAgent on macOS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.orchestration import scheduled_worktree_cleanup
+
+LABEL = "com.learn-ukrainian.worktree-cleanup"
+DEFAULT_INTERVAL_MINUTES = 15
+LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+
+class LaunchdError(RuntimeError):
+    """The requested launchd state could not be verified."""
+
+
+def default_home() -> Path:
+    return Path.home()
+
+
+def plist_path(home: Path) -> Path:
+    return home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def state_dir(home: Path) -> Path:
+    return home / ".codex" / "worktree-cleanup"
+
+
+def build_plist(
+    *,
+    public_repo: Path,
+    private_repo: Path,
+    home: Path,
+    interval_minutes: int,
+) -> dict[str, Any]:
+    runtime = state_dir(home)
+    return {
+        "Label": LABEL,
+        "EnvironmentVariables": {"PATH": LAUNCHD_PATH},
+        "LowPriorityIO": True,
+        "ProcessType": "Background",
+        "ProgramArguments": [
+            str(public_repo / ".venv" / "bin" / "python"),
+            str(
+                public_repo
+                / "scripts"
+                / "orchestration"
+                / "scheduled_worktree_cleanup.py"
+            ),
+            "--apply",
+            "--repo-root",
+            str(public_repo),
+            "--repo-root",
+            str(private_repo),
+            "--receipt-dir",
+            str(runtime / "receipts" / "v1"),
+        ],
+        "RunAtLoad": True,
+        "StandardErrorPath": str(runtime / "logs" / "stderr.log"),
+        "StandardOutPath": str(runtime / "logs" / "stdout.log"),
+        "StartInterval": interval_minutes * 60,
+        "WorkingDirectory": str(public_repo),
+    }
+
+
+def render_plist(
+    *,
+    public_repo: Path,
+    private_repo: Path,
+    home: Path,
+    interval_minutes: int,
+) -> bytes:
+    return plistlib.dumps(
+        build_plist(
+            public_repo=public_repo,
+            private_repo=private_repo,
+            home=home,
+            interval_minutes=interval_minutes,
+        ),
+        fmt=plistlib.FMT_XML,
+        sort_keys=True,
+    )
+
+
+def _launchctl(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["/bin/launchctl", *command],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise LaunchdError("/bin/launchctl is unavailable; macOS is required") from exc
+
+
+def _domain() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _service_target() -> str:
+    return f"{_domain()}/{LABEL}"
+
+
+def _loaded_readback() -> subprocess.CompletedProcess[str]:
+    return _launchctl(["print", _service_target()])
+
+
+def _failure(action: str, result: subprocess.CompletedProcess[str]) -> LaunchdError:
+    detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+    return LaunchdError(f"launchctl {action} failed: {detail}")
+
+
+def _validate_primary(repo_root: Path, *, require_interpreter: bool = False) -> None:
+    if not (repo_root / ".git").is_dir():
+        raise LaunchdError(f"repository is not a primary checkout: {repo_root}")
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+        env=scheduled_worktree_cleanup.reap_worktrees.sanitized_git_env(),
+    )
+    if branch.returncode != 0 or branch.stdout.strip() != "main":
+        raise LaunchdError(f"repository primary must be on main: {repo_root}")
+    if require_interpreter:
+        interpreter = repo_root / ".venv" / "bin" / "python"
+        if not interpreter.is_file() or not os.access(interpreter, os.X_OK):
+            raise LaunchdError(f"required interpreter is missing: {interpreter}")
+        cleanup_script = (
+            repo_root / "scripts" / "orchestration" / "scheduled_worktree_cleanup.py"
+        )
+        if not cleanup_script.is_file():
+            raise LaunchdError(f"cleanup script is missing: {cleanup_script}")
+
+
+def install(
+    *,
+    public_repo: Path,
+    private_repo: Path,
+    home: Path,
+    interval_minutes: int,
+) -> dict[str, Any]:
+    public_repo = public_repo.resolve()
+    private_repo = private_repo.resolve()
+    _validate_primary(public_repo, require_interpreter=True)
+    _validate_primary(private_repo)
+    destination = plist_path(home)
+    content = render_plist(
+        public_repo=public_repo,
+        private_repo=private_repo,
+        home=home,
+        interval_minutes=interval_minutes,
+    )
+    runtime = state_dir(home)
+    for directory in (
+        runtime,
+        runtime / "logs",
+        runtime / "receipts",
+        runtime / "receipts" / "v1",
+    ):
+        directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(directory, 0o700)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    before = _loaded_readback()
+    was_loaded = before.returncode == 0
+    changed = not destination.is_file() or destination.read_bytes() != content
+    if changed and was_loaded:
+        bootout = _launchctl(["bootout", _service_target()])
+        if bootout.returncode != 0:
+            raise _failure("bootout", bootout)
+
+    wrote_plist = changed
+    if changed:
+        scheduled_worktree_cleanup.atomic_write(destination, content)
+    if changed or not was_loaded:
+        bootstrap = _launchctl(["bootstrap", _domain(), str(destination)])
+        if bootstrap.returncode != 0:
+            raise _failure("bootstrap", bootstrap)
+
+    readback = _loaded_readback()
+    if readback.returncode != 0:
+        raise _failure("print", readback)
+    return {
+        "action": "install",
+        "changed": changed,
+        "interval_minutes": interval_minutes,
+        "label": LABEL,
+        "loaded": True,
+        "plist_path": str(destination),
+        "private_repo": str(private_repo),
+        "public_repo": str(public_repo),
+        "wrote_plist": wrote_plist,
+    }
+
+
+def _valid_persisted_plist(
+    payload: Any,
+    *,
+    public_repo: Path,
+    private_repo: Path,
+    home: Path,
+    interval_minutes: int,
+) -> bool:
+    return payload == build_plist(
+        public_repo=public_repo,
+        private_repo=private_repo,
+        home=home,
+        interval_minutes=interval_minutes,
+    )
+
+
+def status(
+    *,
+    public_repo: Path,
+    private_repo: Path,
+    home: Path,
+    interval_minutes: int,
+) -> tuple[dict[str, Any], int]:
+    destination = plist_path(home)
+    loaded = _loaded_readback().returncode == 0
+    persisted: Any = None
+    parse_error = None
+    if destination.is_file():
+        try:
+            persisted = plistlib.loads(destination.read_bytes())
+        except Exception as exc:
+            parse_error = str(exc)
+    valid = _valid_persisted_plist(
+        persisted,
+        public_repo=public_repo.resolve(),
+        private_repo=private_repo.resolve(),
+        home=home,
+        interval_minutes=interval_minutes,
+    )
+    result = {
+        "action": "status",
+        "installed": destination.is_file(),
+        "interval_minutes": interval_minutes,
+        "label": LABEL,
+        "loaded": loaded,
+        "parse_error": parse_error,
+        "plist_path": str(destination),
+        "valid_plist": valid,
+    }
+    return result, 0 if loaded and valid else 1
+
+
+def uninstall(*, home: Path) -> dict[str, Any]:
+    destination = plist_path(home)
+    was_loaded = _loaded_readback().returncode == 0
+    if was_loaded:
+        bootout = _launchctl(["bootout", _service_target()])
+        if bootout.returncode != 0:
+            raise _failure("bootout", bootout)
+    destination.unlink(missing_ok=True)
+    return {
+        "action": "uninstall",
+        "label": LABEL,
+        "loaded": False,
+        "plist_path": str(destination),
+        "preserved_state_dir": str(state_dir(home)),
+    }
+
+
+def positive_interval(value: str) -> int:
+    try:
+        interval = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("interval must be a positive integer") from exc
+    if interval <= 0:
+        raise argparse.ArgumentTypeError("interval must be a positive integer")
+    return interval
+
+
+def build_parser() -> argparse.ArgumentParser:
+    public_repo = scheduled_worktree_cleanup.default_public_repo()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--public-repo", type=Path, default=public_repo)
+    parser.add_argument(
+        "--private-repo",
+        type=Path,
+        default=None,
+    )
+    parser.add_argument("--home", type=Path, default=default_home())
+    parser.add_argument(
+        "--interval-minutes",
+        type=positive_interval,
+        default=DEFAULT_INTERVAL_MINUTES,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("render")
+    subparsers.add_parser("install")
+    subparsers.add_parser("status")
+    subparsers.add_parser("uninstall")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    public_repo = args.public_repo.expanduser().resolve()
+    private_repo = (
+        args.private_repo.expanduser().resolve()
+        if args.private_repo is not None
+        else scheduled_worktree_cleanup.default_private_repo(public_repo).resolve()
+    )
+    home = args.home.expanduser().resolve()
+    if args.command == "render":
+        print(
+            render_plist(
+                public_repo=public_repo,
+                private_repo=private_repo,
+                home=home,
+                interval_minutes=args.interval_minutes,
+            ).decode("utf-8"),
+            end="",
+        )
+        return 0
+    if args.command == "install":
+        result = install(
+            public_repo=public_repo,
+            private_repo=private_repo,
+            home=home,
+            interval_minutes=args.interval_minutes,
+        )
+        return_code = 0
+    elif args.command == "status":
+        result, return_code = status(
+            public_repo=public_repo,
+            private_repo=private_repo,
+            home=home,
+            interval_minutes=args.interval_minutes,
+        )
+    else:
+        result = uninstall(home=home)
+        return_code = 0
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return return_code
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except LaunchdError as exc:
+        print(json.dumps({"error": str(exc)}, sort_keys=True))
+        raise SystemExit(2) from None

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -13,6 +13,7 @@ Suggested backstop:
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
 import subprocess
@@ -50,6 +51,7 @@ class WorktreeInfo:
 class PullRequestState:
     number: int | None
     state: str
+    head_sha: str | None = None
 
 
 @dataclass(frozen=True)
@@ -217,7 +219,7 @@ def _query_pr_states(repo_root: Path, branch: str | None) -> tuple[list[PullRequ
                 "--state",
                 "all",
                 "--json",
-                "number,state",
+                "number,state,headRefOid",
             ],
             cwd=repo_root,
             timeout=30,
@@ -243,13 +245,20 @@ def _query_pr_states(repo_root: Path, branch: str | None) -> tuple[list[PullRequ
             PullRequestState(
                 number=number if isinstance(number, int) else None,
                 state=state,
+                head_sha=(
+                    str(item.get("headRefOid"))
+                    if item.get("headRefOid")
+                    else None
+                ),
             )
         )
     return states, None
 
 
 def _best_pr(prs: list[PullRequestState]) -> PullRequestState | None:
-    for desired in ("MERGED", "CLOSED", "OPEN"):
+    # A branch name can be reused. Any open PR is therefore authoritative over
+    # historical merged/closed PRs for the same head name.
+    for desired in ("OPEN", "MERGED", "CLOSED"):
         for pr_state in prs:
             if pr_state.state == desired:
                 return pr_state
@@ -259,7 +268,121 @@ def _best_pr(prs: list[PullRequestState]) -> PullRequestState | None:
 def _pr_dict(pr_state: PullRequestState | None) -> dict[str, Any] | None:
     if pr_state is None:
         return None
-    return {"number": pr_state.number, "state": pr_state.state}
+    return {
+        "number": pr_state.number,
+        "state": pr_state.state,
+        "head_sha": pr_state.head_sha,
+    }
+
+
+def _pr_matches_worktree_head(
+    info: WorktreeInfo,
+    pr_state: PullRequestState | None,
+) -> bool:
+    return bool(
+        pr_state is not None
+        and pr_state.head_sha
+        and info.head
+        and pr_state.head_sha == info.head
+    )
+
+
+def _live_cwd_paths(repo_root: Path) -> set[Path] | None:
+    """Return process working directories, or ``None`` when lsof is unavailable."""
+    try:
+        proc = _run(["lsof", "-d", "cwd", "-F", "n"], cwd=repo_root, timeout=15)
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    paths: set[Path] = set()
+    for line in (proc.stdout or "").splitlines():
+        if not line.startswith("n/"):
+            continue
+        try:
+            paths.add(Path(line[1:]).resolve())
+        except OSError:
+            continue
+    return paths
+
+
+def _path_contains(parent: Path, child: Path) -> bool:
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _dispatch_task_id(repo_root: Path, info: WorktreeInfo) -> str | None:
+    dispatch_root = (repo_root / ".worktrees" / "dispatch").resolve()
+    try:
+        relative = info.path.resolve().relative_to(dispatch_root)
+    except ValueError:
+        return None
+    return relative.parts[1] if len(relative.parts) == 2 else None
+
+
+def _task_record_status(repo_root: Path, task_id: str | None) -> str | None:
+    if not task_id:
+        return None
+    task_file = repo_root / "batch_state" / "tasks" / f"{task_id}.json"
+    try:
+        payload = json.loads(task_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    status = payload.get("status") if isinstance(payload, dict) else None
+    return str(status) if status else None
+
+
+def _activity_reason(
+    *,
+    repo_root: Path,
+    info: WorktreeInfo,
+    active_ids: set[str] | None,
+    live_cwds: set[Path] | None,
+) -> str | None:
+    task_id = _dispatch_task_id(repo_root, info)
+    if task_id and active_ids is not None and task_id in active_ids:
+        return f"active dispatch task-id={task_id}"
+    task_status = _task_record_status(repo_root, task_id)
+    if task_status in {"queued", "starting", "running", "needs_finalize"}:
+        return f"non-terminal dispatch task-id={task_id} status={task_status}"
+    if live_cwds is not None:
+        worktree = info.path.resolve()
+        for cwd in live_cwds:
+            if _path_contains(worktree, cwd):
+                return f"live process cwd={cwd}"
+    return None
+
+
+def _common_git_dir(repo_root: Path) -> Path:
+    proc = _run(["git", "rev-parse", "--git-common-dir"], cwd=repo_root)
+    if proc.returncode != 0:
+        raise RuntimeError(f"cannot resolve git common dir: {_format_failure(proc)}")
+    path = Path((proc.stdout or "").strip())
+    if not path.is_absolute():
+        path = repo_root / path
+    return path.resolve()
+
+
+class _ReapLock:
+    def __init__(self, repo_root: Path) -> None:
+        self.path = _common_git_dir(repo_root) / "worktree-reaper.lock"
+        self.handle: Any = None
+
+    def __enter__(self) -> None:
+        self.handle = self.path.open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(self.handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            self.handle.close()
+            raise RuntimeError(f"another worktree cleanup holds {self.path}") from exc
+
+    def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
+        if self.handle is not None:
+            fcntl.flock(self.handle.fileno(), fcntl.LOCK_UN)
+            self.handle.close()
 
 
 def _origin_matches_head(path: Path, branch: str | None) -> bool:
@@ -312,13 +435,18 @@ def _qualifying_reason(
     now: float | None,
     active_ids: set[str] | None = None,
     safe_only: bool = False,
+    merged_pr_only: bool = False,
 ) -> str | None:
     if info.branch is not None:
         if pr_state is not None:
             pr_label = f"PR #{pr_state.number}" if pr_state.number is not None else "PR"
-            if pr_state.state == "MERGED":
+            if pr_state.state == "MERGED" and _pr_matches_worktree_head(info, pr_state):
                 return f"{pr_label} MERGED"
-            if pr_state.state == "CLOSED":
+            if (
+                not merged_pr_only
+                and pr_state.state == "CLOSED"
+                and _pr_matches_worktree_head(info, pr_state)
+            ):
                 return f"{pr_label} CLOSED"
 
         if not safe_only:
@@ -334,19 +462,14 @@ def _qualifying_reason(
             ):
                 return f"HEAD matches origin/{info.branch}"
 
+    if merged_pr_only:
+        return None
+
     # Class B: detached-HEAD worktrees under .worktrees/
     is_under_wt = is_under_worktrees(repo_root, info.path)
     clean = _worktree_clean(info.path)
-    dispatch_root = (repo_root / ".worktrees" / "dispatch").resolve()
-    is_dispatch_candidate = False
-    task_id = None
-    try:
-        rel_path = info.path.resolve().relative_to(dispatch_root)
-        if len(rel_path.parts) == 2:
-            task_id = rel_path.parts[1]
-            is_dispatch_candidate = True
-    except ValueError:
-        pass
+    task_id = _dispatch_task_id(repo_root, info)
+    is_dispatch_candidate = task_id is not None
 
     if is_under_wt and info.detached and clean is True and _is_ancestor_of_origin_main(info.path):
         has_matching_task = False
@@ -413,7 +536,7 @@ def _preserve_dirty_worktree(info: WorktreeInfo) -> str | None:
 
 def _remove_worktree(repo_root: Path, info: WorktreeInfo) -> str | None:
     proc = _run(
-        ["git", "worktree", "remove", "--force", str(info.path)],
+        ["git", "worktree", "remove", str(info.path)],
         cwd=repo_root,
     )
     if proc.returncode != 0:
@@ -442,6 +565,7 @@ def _reap_qualified_worktree(
     preserve_then_reap: bool,
     prune_merged_branches: bool,
 ) -> ReapResult:
+    expected_head = info.head
     if dirty is None:
         return ReapResult(
             path=str(info.path),
@@ -451,12 +575,7 @@ def _reap_qualified_worktree(
             dirty=None,
             pr=_pr_dict(pr_state),
         )
-    # Operator pain: MERGED/CLOSED worktrees often dirty with local notes.
-    # Auto-enable preserve-then-reap for those classes so cleanup does not
-    # require remembering an extra flag.
-    merged_or_closed = "MERGED" in reason or "CLOSED" in reason
-    effective_preserve = bool(preserve_then_reap or (dirty and merged_or_closed))
-    if dirty and not effective_preserve:
+    if dirty and not preserve_then_reap:
         return ReapResult(
             path=str(info.path),
             branch=info.branch,
@@ -465,8 +584,6 @@ def _reap_qualified_worktree(
             dirty=True,
             pr=_pr_dict(pr_state),
         )
-    preserve_then_reap = effective_preserve
-
     if not apply:
         action = "would_preserve_then_remove" if dirty else "would_remove"
         return ReapResult(
@@ -490,6 +607,41 @@ def _reap_qualified_worktree(
                 pr=_pr_dict(pr_state),
                 error=preserve_error,
             )
+        refreshed_head = _run(["git", "rev-parse", "HEAD"], cwd=info.path)
+        if refreshed_head.returncode != 0:
+            return ReapResult(
+                path=str(info.path),
+                branch=info.branch,
+                action="error",
+                reason=f"cannot verify preserved worktree HEAD: {reason}",
+                dirty=True,
+                pr=_pr_dict(pr_state),
+                error=_format_failure(refreshed_head),
+            )
+        expected_head = (refreshed_head.stdout or "").strip()
+
+    current_head_proc = _run(["git", "rev-parse", "HEAD"], cwd=info.path)
+    current_head = (current_head_proc.stdout or "").strip()
+    if current_head_proc.returncode != 0 or not expected_head or current_head != expected_head:
+        return ReapResult(
+            path=str(info.path),
+            branch=info.branch,
+            action="skipped",
+            reason=f"HEAD changed during cleanup; originally qualified because {reason}",
+            dirty=dirty,
+            pr=_pr_dict(pr_state),
+        )
+
+    current_clean = _worktree_clean(info.path)
+    if current_clean is not True:
+        return ReapResult(
+            path=str(info.path),
+            branch=info.branch,
+            action="skipped",
+            reason=f"worktree changed during cleanup; originally qualified because {reason}",
+            dirty=None if current_clean is None else True,
+            pr=_pr_dict(pr_state),
+        )
 
     remove_error = _remove_worktree(repo_root, info)
     if remove_error is not None:
@@ -504,7 +656,12 @@ def _reap_qualified_worktree(
         )
 
     branch_prune_error = None
-    if prune_merged_branches and pr_state is not None and pr_state.state == "MERGED":
+    if (
+        prune_merged_branches
+        and pr_state is not None
+        and pr_state.state == "MERGED"
+        and pr_state.head_sha == current_head
+    ):
         branch_prune_error = _prune_branch(repo_root, info.branch, force=True)
 
     if branch_prune_error is not None:
@@ -544,79 +701,106 @@ def reap_worktrees(
     target_paths: list[Path] | None = None,
     now: float | None = None,
     safe_only: bool = False,
+    live_cwds: set[Path] | None = None,
+    merged_pr_only: bool = False,
+    require_activity_probe: bool = False,
 ) -> list[ReapResult]:
     """Evaluate and optionally reap eligible worktrees."""
     repo_root = repo_root.resolve()
     targets = _target_filter(target_paths)
     results: list[ReapResult] = []
     active_ids = _active_task_ids()
+    if live_cwds is None:
+        live_cwds = _live_cwd_paths(repo_root)
+    if require_activity_probe and live_cwds is None:
+        raise RuntimeError("process-CWD activity probe unavailable; cleanup skipped")
 
-    for info in list_git_worktrees(repo_root):
-        if targets is not None and info.path.resolve() not in targets:
-            continue
-        if not is_under_worktrees(repo_root, info.path):
-            results.append(
-                ReapResult(
-                    path=str(info.path),
-                    branch=info.branch,
-                    action="skipped",
-                    reason="outside repo .worktrees/",
-                    dirty=None,
+    with _ReapLock(repo_root):
+        for info in list_git_worktrees(repo_root):
+            if targets is not None and info.path.resolve() not in targets:
+                continue
+            if not is_under_worktrees(repo_root, info.path):
+                results.append(
+                    ReapResult(
+                        path=str(info.path),
+                        branch=info.branch,
+                        action="skipped",
+                        reason="outside repo .worktrees/",
+                        dirty=None,
+                    )
                 )
-            )
-            continue
+                continue
 
-        dirty_state = _worktree_clean(info.path)
-        dirty = None if dirty_state is None else not dirty_state
-
-        pr_state = None
-        pr_error = None
-        if info.branch is not None:
-            pr_states, pr_error = _query_pr_states(repo_root, info.branch)
-            pr_state = _best_pr(pr_states)
-
-        reason = _qualifying_reason(
-            repo_root=repo_root,
-            info=info,
-            pr_state=pr_state,
-            build_age_hours=build_age_hours,
-            now=now,
-            active_ids=active_ids,
-            safe_only=safe_only,
-        )
-        if reason is None:
-            if info.branch is None:
-                reason = "detached or missing branch"
-            else:
-                reason = (
-                    f"no reap condition matched; {pr_error}"
-                    if pr_error
-                    else "no reap condition matched"
-                )
-            results.append(
-                ReapResult(
-                    path=str(info.path),
-                    branch=info.branch,
-                    action="skipped",
-                    reason=reason,
-                    dirty=dirty,
-                    pr=_pr_dict(pr_state),
-                )
-            )
-            continue
-
-        results.append(
-            _reap_qualified_worktree(
+            activity = _activity_reason(
                 repo_root=repo_root,
                 info=info,
-                reason=reason,
-                dirty=dirty,
-                pr_state=pr_state,
-                apply=apply,
-                preserve_then_reap=preserve_then_reap,
-                prune_merged_branches=prune_merged_branches,
+                active_ids=active_ids,
+                live_cwds=live_cwds,
             )
-        )
+            if activity is not None:
+                results.append(
+                    ReapResult(
+                        path=str(info.path),
+                        branch=info.branch,
+                        action="skipped",
+                        reason=activity,
+                        dirty=None,
+                    )
+                )
+                continue
+
+            dirty_state = _worktree_clean(info.path)
+            dirty = None if dirty_state is None else not dirty_state
+
+            pr_state = None
+            pr_error = None
+            if info.branch is not None:
+                pr_states, pr_error = _query_pr_states(repo_root, info.branch)
+                pr_state = _best_pr(pr_states)
+
+            reason = _qualifying_reason(
+                repo_root=repo_root,
+                info=info,
+                pr_state=pr_state,
+                build_age_hours=build_age_hours,
+                now=now,
+                active_ids=active_ids,
+                safe_only=safe_only,
+                merged_pr_only=merged_pr_only,
+            )
+            if reason is None:
+                if info.branch is None:
+                    reason = "detached or missing branch"
+                else:
+                    reason = (
+                        f"no reap condition matched; {pr_error}"
+                        if pr_error
+                        else "no reap condition matched"
+                    )
+                results.append(
+                    ReapResult(
+                        path=str(info.path),
+                        branch=info.branch,
+                        action="skipped",
+                        reason=reason,
+                        dirty=dirty,
+                        pr=_pr_dict(pr_state),
+                    )
+                )
+                continue
+
+            results.append(
+                _reap_qualified_worktree(
+                    repo_root=repo_root,
+                    info=info,
+                    reason=reason,
+                    dirty=dirty,
+                    pr_state=pr_state,
+                    apply=apply,
+                    preserve_then_reap=preserve_then_reap,
+                    prune_merged_branches=prune_merged_branches,
+                )
+            )
 
     if targets is not None:
         seen = {Path(result.path).resolve() for result in results}
@@ -751,7 +935,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--prune-merged-branches",
         action="store_true",
-        help="After removing a MERGED PR worktree, run safe 'git branch -d <branch>'.",
+        help=(
+            "Delete a local branch only after its MERGED PR head SHA exactly "
+            "matches the removed worktree HEAD."
+        ),
     )
     parser.add_argument(
         "--safe-only",
@@ -762,9 +949,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--merged",
         action="store_true",
         help=(
-            "Convenience for post-PR cleanup: enables --safe-only, "
-            "--preserve-then-reap, and --prune-merged-branches. "
-            "Dirty trees whose PR is MERGED/CLOSED are local-committed then removed."
+            "Restrict cleanup to exact MERGED PR heads and enable branch "
+            "pruning. Dirty trees remain untouched unless "
+            "--preserve-then-reap is explicit."
         ),
     )
     parser.add_argument(
@@ -787,7 +974,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     apply = bool(args.apply)
     merged_mode = bool(getattr(args, "merged", False))
-    preserve = bool(args.preserve_then_reap) or merged_mode
+    preserve = bool(args.preserve_then_reap)
     prune = bool(args.prune_merged_branches) or merged_mode
     safe_only = bool(args.safe_only) or merged_mode
     results = reap_worktrees(
@@ -798,6 +985,8 @@ def main(argv: list[str] | None = None) -> int:
         prune_merged_branches=prune,
         target_paths=args.worktree,
         safe_only=safe_only,
+        merged_pr_only=merged_mode,
+        require_activity_probe=apply,
     )
     if args.json:
         print(json.dumps([_result_payload(result) for result in results], indent=2))

--- a/scripts/orchestration/scheduled_worktree_cleanup.py
+++ b/scripts/orchestration/scheduled_worktree_cleanup.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Run fail-closed worktree cleanup for an explicit repository set.
+
+The scheduled runner fetches remote state, requires the macOS process-CWD
+probe in apply mode, delegates eligibility and deletion to the canonical
+reaper, and writes an immutable JSON receipt for every run. Orphaned
+``.worktrees/**`` directories are reported but never deleted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.orchestration import reap_worktrees
+
+SCHEMA_VERSION = "scheduled-worktree-cleanup.v1"
+DEFAULT_INTERVAL_MINUTES = 15
+
+
+def default_public_repo() -> Path:
+    return PROJECT_ROOT
+
+
+def default_private_repo(public_repo: Path) -> Path:
+    return public_repo.parent / "learn-ukrainian-infra-private"
+
+
+def default_state_dir() -> Path:
+    return Path.home() / ".codex" / "worktree-cleanup"
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _run_git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+        env=reap_worktrees.sanitized_git_env(),
+    )
+
+
+def _failure(proc: subprocess.CompletedProcess[str]) -> str:
+    detail = (proc.stderr or proc.stdout or "").strip()
+    return detail.splitlines()[-1] if detail else f"exit {proc.returncode}"
+
+
+def _registered_paths(repo_root: Path) -> set[Path]:
+    return {item.path.resolve() for item in reap_worktrees.list_git_worktrees(repo_root)}
+
+
+def find_orphaned_worktree_directories(repo_root: Path) -> list[dict[str, Any]]:
+    """Report unregistered checkout-shaped directories without deleting them."""
+    worktrees_root = repo_root / ".worktrees"
+    if not worktrees_root.is_dir():
+        return []
+    registered = _registered_paths(repo_root)
+    orphans: list[dict[str, Any]] = []
+    for directory, child_dirs, files in os.walk(worktrees_root, followlinks=False):
+        path = Path(directory)
+        if ".git" not in files:
+            if len(path.relative_to(worktrees_root).parts) >= 4:
+                child_dirs.clear()
+            continue
+        child_dirs.clear()
+        resolved = path.resolve()
+        if resolved in registered:
+            continue
+        git_file = path / ".git"
+        try:
+            first_line = git_file.read_text(encoding="utf-8").splitlines()[0]
+        except (IndexError, OSError) as exc:
+            orphans.append(
+                {
+                    "path": str(resolved),
+                    "reason": f"unreadable .git file: {exc}",
+                    "gitdir": None,
+                }
+            )
+            continue
+        prefix = "gitdir:"
+        if not first_line.startswith(prefix):
+            reason = "unrecognized .git file"
+            gitdir = None
+        else:
+            target = Path(first_line.removeprefix(prefix).strip())
+            if not target.is_absolute():
+                target = path / target
+            target = target.resolve()
+            gitdir = str(target)
+            reason = (
+                "unregistered worktree with missing gitdir"
+                if not target.exists()
+                else "unregistered worktree with existing gitdir"
+            )
+        orphans.append({"path": str(resolved), "reason": reason, "gitdir": gitdir})
+    return sorted(orphans, key=lambda item: item["path"])
+
+
+def _repo_result(repo_root: Path, *, apply: bool) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "repo_root": str(repo_root),
+        "fetch": None,
+        "activity_probe": None,
+        "results": [],
+        "orphans": [],
+        "errors": [],
+    }
+    if not (repo_root / ".git").exists():
+        result["errors"].append("repository .git metadata is missing")
+        return result
+
+    fetch = _run_git(repo_root, "fetch", "--prune", "origin")
+    result["fetch"] = {
+        "ok": fetch.returncode == 0,
+        "detail": None if fetch.returncode == 0 else _failure(fetch),
+    }
+    if fetch.returncode != 0:
+        result["errors"].append("fetch failed; cleanup skipped")
+        return result
+
+    live_cwds = reap_worktrees._live_cwd_paths(repo_root)
+    result["activity_probe"] = {
+        "available": live_cwds is not None,
+        "cwd_count": len(live_cwds or ()),
+    }
+    if apply and live_cwds is None:
+        result["errors"].append("process-CWD activity probe unavailable; apply skipped")
+        return result
+
+    try:
+        rows = reap_worktrees.reap_worktrees(
+            repo_root=repo_root,
+            apply=apply,
+            preserve_then_reap=False,
+            prune_merged_branches=True,
+            safe_only=True,
+            live_cwds=live_cwds,
+            merged_pr_only=True,
+        )
+        result["results"] = [asdict(row) for row in rows]
+        result["errors"].extend(
+            f"{row.path}: {row.error or row.reason}"
+            for row in rows
+            if row.action == "error"
+        )
+        result["orphans"] = find_orphaned_worktree_directories(repo_root)
+    except RuntimeError as exc:
+        result["errors"].append(str(exc))
+    return result
+
+
+def build_receipt(
+    repo_roots: list[Path],
+    *,
+    apply: bool,
+    observed_at: str | None = None,
+) -> dict[str, Any]:
+    timestamp = observed_at or utc_now()
+    repositories = [_repo_result(path.resolve(), apply=apply) for path in repo_roots]
+    removed = sum(
+        1
+        for repository in repositories
+        for row in repository["results"]
+        if row["action"] in {"removed", "preserved_then_removed"}
+    )
+    errors = sum(len(repository["errors"]) for repository in repositories)
+    orphans = sum(len(repository["orphans"]) for repository in repositories)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "observed_at": timestamp,
+        "mode": "apply" if apply else "dry_run",
+        "summary": {
+            "repositories": len(repositories),
+            "removed": removed,
+            "orphans_reported": orphans,
+            "errors": errors,
+        },
+        "repositories": repositories,
+    }
+
+
+def atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def ensure_private_directory(path: Path) -> None:
+    """Create every missing directory component with owner-only permissions."""
+    missing: list[Path] = []
+    current = path
+    while not current.exists():
+        missing.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    for directory in reversed(missing):
+        directory.mkdir(mode=0o700)
+        os.chmod(directory, 0o700)
+    os.chmod(path, 0o700)
+
+
+def write_receipt(receipt: dict[str, Any], receipt_dir: Path) -> Path:
+    content = json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8")
+    digest = hashlib.sha256(content).hexdigest()[:12]
+    timestamp = str(receipt["observed_at"]).replace(":", "").replace("-", "")
+    destination = receipt_dir / f"{timestamp}-{digest}.json"
+    ensure_private_directory(receipt_dir)
+    atomic_write(destination, content)
+    return destination
+
+
+def build_parser() -> argparse.ArgumentParser:
+    public_repo = default_public_repo()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        action="append",
+        type=Path,
+        default=None,
+        help="Repository root to sweep. Repeatable.",
+    )
+    parser.add_argument("--apply", action="store_true", help="Apply safe cleanup candidates.")
+    parser.add_argument(
+        "--receipt-dir",
+        type=Path,
+        default=default_state_dir() / "receipts" / "v1",
+    )
+    parser.set_defaults(
+        default_repo_roots=[public_repo, default_private_repo(public_repo)]
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_roots = args.repo_root or args.default_repo_roots
+    receipt = build_receipt(repo_roots, apply=bool(args.apply))
+    receipt_path = write_receipt(receipt, args.receipt_dir.expanduser().resolve())
+    payload = {**receipt, "receipt_path": str(receipt_path)}
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 1 if receipt["summary"]["errors"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/orchestration/test_install_worktree_cleanup_launchd.py
+++ b/tests/orchestration/test_install_worktree_cleanup_launchd.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.orchestration import install_worktree_cleanup_launchd as launchd
+
+
+def test_rendered_plist_runs_both_repositories_every_fifteen_minutes(
+    tmp_path: Path,
+) -> None:
+    public = tmp_path / "public"
+    private = tmp_path / "private"
+    home = tmp_path / "home"
+
+    payload = plistlib.loads(
+        launchd.render_plist(
+            public_repo=public,
+            private_repo=private,
+            home=home,
+            interval_minutes=15,
+        )
+    )
+
+    assert payload["Label"] == launchd.LABEL
+    assert payload["StartInterval"] == 900
+    assert payload["RunAtLoad"] is True
+    assert payload["ProgramArguments"] == [
+        str(public / ".venv" / "bin" / "python"),
+        str(public / "scripts" / "orchestration" / "scheduled_worktree_cleanup.py"),
+        "--apply",
+        "--repo-root",
+        str(public),
+        "--repo-root",
+        str(private),
+        "--receipt-dir",
+        str(home / ".codex" / "worktree-cleanup" / "receipts" / "v1"),
+    ]
+    assert "/opt/homebrew/bin" in payload["EnvironmentVariables"]["PATH"]
+
+
+def test_status_rejects_modified_program_arguments(tmp_path: Path, monkeypatch) -> None:
+    public = tmp_path / "public"
+    private = tmp_path / "private"
+    home = tmp_path / "home"
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    payload = launchd.build_plist(
+        public_repo=public,
+        private_repo=private,
+        home=home,
+        interval_minutes=15,
+    )
+    payload["ProgramArguments"] = ["/bin/sh", "-c", "echo unsafe"]
+    destination.write_bytes(plistlib.dumps(payload))
+
+    class Result:
+        returncode = 0
+        stdout = "loaded"
+        stderr = ""
+
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: Result())
+
+    result, return_code = launchd.status(
+        public_repo=public,
+        private_repo=private,
+        home=home,
+        interval_minutes=15,
+    )
+
+    assert return_code == 1
+    assert result["loaded"] is True
+    assert result["valid_plist"] is False
+
+
+def test_install_is_verified_and_idempotent(tmp_path: Path, monkeypatch) -> None:
+    public = tmp_path / "public"
+    private = tmp_path / "private"
+    home = tmp_path / "home"
+    for repo in (public, private):
+        (repo / ".git").mkdir(parents=True)
+    interpreter = public / ".venv" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+    script = public / "scripts" / "orchestration" / "scheduled_worktree_cleanup.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("# cleanup\n", encoding="utf-8")
+    monkeypatch.setattr(
+        launchd.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="main\n",
+            stderr="",
+        ),
+    )
+
+    loaded_states = iter(
+        [
+            SimpleNamespace(returncode=1, stdout="", stderr="not loaded"),
+            SimpleNamespace(returncode=0, stdout="loaded", stderr=""),
+        ]
+    )
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: next(loaded_states))
+    launchctl_calls: list[list[str]] = []
+
+    def fake_launchctl(command):
+        launchctl_calls.append(list(command))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(launchd, "_launchctl", fake_launchctl)
+
+    first = launchd.install(
+        public_repo=public,
+        private_repo=private,
+        home=home,
+        interval_minutes=15,
+    )
+
+    assert first["changed"] is True
+    assert first["loaded"] is True
+    assert launchctl_calls == [
+        [
+            "bootstrap",
+            launchd._domain(),
+            str(launchd.plist_path(home)),
+        ]
+    ]
+    expected = launchd.render_plist(
+        public_repo=public.resolve(),
+        private_repo=private.resolve(),
+        home=home,
+        interval_minutes=15,
+    )
+    assert launchd.plist_path(home).read_bytes() == expected
+
+    monkeypatch.setattr(
+        launchd,
+        "_loaded_readback",
+        lambda: SimpleNamespace(returncode=0, stdout="loaded", stderr=""),
+    )
+    launchctl_calls.clear()
+
+    second = launchd.install(
+        public_repo=public,
+        private_repo=private,
+        home=home,
+        interval_minutes=15,
+    )
+
+    assert second["changed"] is False
+    assert second["wrote_plist"] is False
+    assert launchctl_calls == []
+
+
+def test_uninstall_preserves_receipts(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    destination = launchd.plist_path(home)
+    destination.parent.mkdir(parents=True)
+    destination.write_text("plist", encoding="utf-8")
+    receipt = launchd.state_dir(home) / "receipts" / "v1" / "receipt.json"
+    receipt.parent.mkdir(parents=True)
+    receipt.write_text("{}", encoding="utf-8")
+
+    class Result:
+        returncode = 1
+        stdout = ""
+        stderr = "not loaded"
+
+    monkeypatch.setattr(launchd, "_loaded_readback", lambda: Result())
+
+    result = launchd.uninstall(home=home)
+
+    assert result["loaded"] is False
+    assert not destination.exists()
+    assert receipt.exists()
+
+
+def test_positive_interval_rejects_zero() -> None:
+    try:
+        launchd.positive_interval("0")
+    except Exception as exc:
+        assert "positive integer" in str(exc)
+    else:
+        raise AssertionError("zero interval unexpectedly accepted")

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import subprocess
@@ -74,7 +75,19 @@ def patch_gh(
         if args and args[0] == "gh":
             branch = args[args.index("--head") + 1]
             calls.append(branch)
-            payload = states_by_branch.get(branch, [])
+            payload = [dict(item) for item in states_by_branch.get(branch, [])]
+            for item in payload:
+                if item.get("headRefOid") or item.get("state") == "OPEN":
+                    continue
+                head = _REAL_RUN(
+                    ["git", "rev-parse", f"refs/heads/{branch}"],
+                    cwd=kwargs["cwd"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env=git_env(),
+                ).stdout.strip()
+                item["headRefOid"] = head
             return subprocess.CompletedProcess(args, 0, json.dumps(payload), "")
         return _REAL_RUN(args, **kwargs)
 
@@ -122,11 +135,11 @@ def test_merged_clean_removes_worktree_and_keeps_branch(
     assert_main_checkout_unchanged(repo)
 
 
-def test_merged_dirty_auto_preserve_then_reaps(
+def test_merged_dirty_is_preserved_by_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MERGED dirty trees auto preserve-then-reap (operator cleanup painpoint)."""
+    """A scheduled cleanup must never silently commit and remove dirty work."""
     repo = init_repo(tmp_path)
     worktree = add_worktree(repo, "codex/dirty")
     (worktree / "dirty.txt").write_text("not committed\n", encoding="utf-8")
@@ -135,9 +148,10 @@ def test_merged_dirty_auto_preserve_then_reaps(
     results = rw.reap_worktrees(repo_root=repo, apply=True)
 
     result = result_for(results, worktree)
-    assert result.action == "preserved_then_removed"
-    assert "PR #13 MERGED" in (result.reason or "")
-    assert not worktree.exists()
+    assert result.action == "skipped"
+    assert result.reason == "dirty; qualifies for reap because PR #13 MERGED"
+    assert worktree.exists()
+    assert (worktree / "dirty.txt").read_text(encoding="utf-8") == "not committed\n"
     assert_main_checkout_unchanged(repo)
 
 
@@ -508,13 +522,175 @@ def test_open_pr_matching_origin_is_not_reaped(
     assert_main_checkout_unchanged(repo)
 
 
-def test_merged_flag_enables_safe_preserve_prune(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_open_pr_wins_over_historical_merged_pr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/reused")
+    head = git(worktree, "rev-parse", "HEAD")
+    patch_gh(
+        monkeypatch,
+        {
+            "codex/reused": [
+                {"number": 8, "state": "MERGED", "headRefOid": head},
+                {"number": 9, "state": "OPEN", "headRefOid": head},
+            ]
+        },
+    )
+
+    result = result_for(rw.reap_worktrees(repo_root=repo, apply=True), worktree)
+
+    assert result.action == "skipped"
+    assert result.pr == {"number": 9, "state": "OPEN", "head_sha": head}
+    assert worktree.exists()
+
+
+def test_merged_pr_head_must_match_worktree_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/mismatched")
+    patch_gh(
+        monkeypatch,
+        {
+            "codex/mismatched": [
+                {"number": 10, "state": "MERGED", "headRefOid": "0" * 40}
+            ]
+        },
+    )
+
+    result = result_for(
+        rw.reap_worktrees(repo_root=repo, apply=True, safe_only=True),
+        worktree,
+    )
+
+    assert result.action == "skipped"
+    assert worktree.exists()
+
+
+def test_closed_pr_requires_matching_worktree_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    matching = add_worktree(repo, "codex/closed-matching")
+    mismatched = add_worktree(repo, "codex/closed-mismatched")
+    patch_gh(
+        monkeypatch,
+        {
+            "codex/closed-matching": [{"number": 12, "state": "CLOSED"}],
+            "codex/closed-mismatched": [
+                {"number": 13, "state": "CLOSED", "headRefOid": "0" * 40}
+            ],
+        },
+    )
+
+    results = rw.reap_worktrees(
+        repo_root=repo,
+        apply=True,
+        safe_only=True,
+        live_cwds=set(),
+    )
+
+    assert result_for(results, matching).action == "removed"
+    assert result_for(results, mismatched).action == "skipped"
+    assert not matching.exists()
+    assert mismatched.exists()
+
+
+def test_live_process_cwd_protects_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/live")
+    patch_gh(monkeypatch, {"codex/live": [{"number": 11, "state": "MERGED"}]})
+
+    result = result_for(
+        rw.reap_worktrees(
+            repo_root=repo,
+            apply=True,
+            live_cwds={worktree / "site"},
+        ),
+        worktree,
+    )
+
+    assert result.action == "skipped"
+    assert result.reason == f"live process cwd={worktree / 'site'}"
+    assert worktree.exists()
+
+
+def test_merged_flag_preserves_dirty_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     repo = init_repo(tmp_path)
     worktree = add_worktree(repo, "codex/merged-flag")
+    (worktree / "dirty.txt").write_text("keep\n", encoding="utf-8")
     patch_gh(
         monkeypatch,
         {"codex/merged-flag": [{"number": 7, "state": "MERGED"}]},
     )
     rc = rw.main(["--repo-root", str(repo), "--apply", "--merged"])
     assert rc == 0
-    assert not worktree.exists()
+    assert worktree.exists()
+    assert (worktree / "dirty.txt").read_text(encoding="utf-8") == "keep\n"
+
+
+def test_apply_cli_requires_process_activity_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    monkeypatch.setattr(rw, "_live_cwd_paths", lambda _repo: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="process-CWD activity probe unavailable",
+    ):
+        rw.main(["--repo-root", str(repo), "--apply", "--merged"])
+
+
+def test_reaper_lock_rejects_concurrent_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    lock_path = rw._common_git_dir(repo) / "worktree-reaper.lock"
+
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(RuntimeError, match="another worktree cleanup holds"):
+            rw.reap_worktrees(
+                repo_root=repo,
+                apply=True,
+                live_cwds=set(),
+            )
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def test_merged_flag_does_not_remove_settled_dispatch_without_merged_pr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    task_id = "settled-without-pr"
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    add_worktree(repo, "codex/settled-without-pr", path=worktree)
+    tasks_dir = repo / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps({"status": "failed"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    patch_gh(monkeypatch, {"codex/settled-without-pr": []})
+
+    rc = rw.main(["--repo-root", str(repo), "--apply", "--merged"])
+
+    assert rc == 0
+    assert worktree.exists()

--- a/tests/orchestration/test_scheduled_worktree_cleanup.py
+++ b/tests/orchestration/test_scheduled_worktree_cleanup.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+
+from scripts.orchestration import scheduled_worktree_cleanup as cleanup
+
+
+def _git(cwd: Path, *args: str) -> str:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+        and not key.startswith("PRE_COMMIT")
+        and key != "AGENT_NO_MERGE"
+    }
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    return proc.stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    remote = tmp_path / "origin.git"
+    repo = tmp_path / "repo"
+    _git(tmp_path, "init", "--bare", str(remote))
+    _git(tmp_path, "init", "--initial-branch=main", str(repo))
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / ".gitignore").write_text(".worktrees/\n", encoding="utf-8")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    return repo
+
+
+def test_apply_fails_closed_without_process_probe(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.setattr(cleanup.reap_worktrees, "_live_cwd_paths", lambda _repo: None)
+
+    result = cleanup._repo_result(repo, apply=True)
+
+    assert result["activity_probe"] == {"available": False, "cwd_count": 0}
+    assert result["errors"] == ["process-CWD activity probe unavailable; apply skipped"]
+    assert result["results"] == []
+
+
+def test_orphaned_broken_gitdir_is_reported_not_deleted(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    orphan = repo / ".worktrees" / "dispatch" / "codex" / "orphan"
+    orphan.mkdir(parents=True)
+    missing = tmp_path / "missing.git" / "worktrees" / "orphan"
+    (orphan / ".git").write_text(f"gitdir: {missing}\n", encoding="utf-8")
+    (orphan / "recover-me.txt").write_text("local work\n", encoding="utf-8")
+
+    result = cleanup.find_orphaned_worktree_directories(repo)
+
+    assert result == [
+        {
+            "path": str(orphan.resolve()),
+            "reason": "unregistered worktree with missing gitdir",
+            "gitdir": str(missing.resolve()),
+        }
+    ]
+    assert (orphan / "recover-me.txt").read_text(encoding="utf-8") == "local work\n"
+
+
+def test_reaper_error_marks_repository_run_failed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    worktree = repo / ".worktrees" / "dispatch" / "codex" / "failed"
+    row = cleanup.reap_worktrees.ReapResult(
+        path=str(worktree),
+        branch="codex/failed",
+        action="error",
+        reason="PR #1 MERGED",
+        dirty=False,
+        error="worktree removal failed",
+    )
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "_live_cwd_paths",
+        lambda _repo: set(),
+    )
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "reap_worktrees",
+        lambda **_kwargs: [replace(row)],
+    )
+    monkeypatch.setattr(
+        cleanup,
+        "find_orphaned_worktree_directories",
+        lambda _repo: [],
+    )
+
+    result = cleanup._repo_result(repo, apply=True)
+
+    assert result["errors"] == [f"{worktree}: worktree removal failed"]
+
+
+def test_lock_contention_marks_repository_run_failed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "_live_cwd_paths",
+        lambda _repo: set(),
+    )
+    monkeypatch.setattr(
+        cleanup.reap_worktrees,
+        "reap_worktrees",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("cleanup lock held")),
+    )
+
+    result = cleanup._repo_result(repo, apply=True)
+
+    assert result["errors"] == ["cleanup lock held"]
+
+
+def test_receipt_aggregates_both_repositories(tmp_path: Path, monkeypatch) -> None:
+    public = tmp_path / "public"
+    private = tmp_path / "private"
+
+    def fake_repo_result(repo_root: Path, *, apply: bool):
+        return {
+            "repo_root": str(repo_root),
+            "fetch": {"ok": True, "detail": None},
+            "activity_probe": {"available": True, "cwd_count": 2},
+            "results": [
+                {
+                    "action": "removed" if repo_root == public else "skipped",
+                }
+            ],
+            "orphans": [{"path": "orphan"}] if repo_root == private else [],
+            "errors": [],
+            "apply": apply,
+        }
+
+    monkeypatch.setattr(cleanup, "_repo_result", fake_repo_result)
+
+    receipt = cleanup.build_receipt(
+        [public, private],
+        apply=True,
+        observed_at="2026-07-28T20:00:00Z",
+    )
+
+    assert receipt["summary"] == {
+        "repositories": 2,
+        "removed": 1,
+        "orphans_reported": 1,
+        "errors": 0,
+    }
+    assert receipt["mode"] == "apply"
+
+
+def test_receipt_write_is_atomic_and_private(tmp_path: Path) -> None:
+    receipt = {
+        "schema_version": cleanup.SCHEMA_VERSION,
+        "observed_at": "2026-07-28T20:00:00Z",
+        "mode": "dry_run",
+        "summary": {"repositories": 0, "removed": 0, "orphans_reported": 0, "errors": 0},
+        "repositories": [],
+    }
+
+    receipt_dir = tmp_path / "state" / "receipts" / "v1"
+    path = cleanup.write_receipt(receipt, receipt_dir)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == receipt
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert (tmp_path / "state").stat().st_mode & 0o777 == 0o700
+    assert (tmp_path / "state" / "receipts").stat().st_mode & 0o777 == 0o700
+    assert receipt_dir.stat().st_mode & 0o777 == 0o700


### PR DESCRIPTION
## Summary

- harden the canonical worktree reaper with exact PR-head matching, activity
  checks, concurrency locking, race revalidation, and non-force removal
- add a fail-closed dual-repository scheduled runner with private receipts and
  report-only orphan detection
- add an idempotent macOS LaunchAgent installer for a 15-minute backstop
- document immediate merge-owner cleanup and scheduler operations

## Safety

- only exact `MERGED` PR heads are eligible in scheduled/`--merged` mode
- open, SHA-mismatched, active, dirty, locked, unverifiable, outside-subtree,
  and orphaned worktrees are preserved
- no automatic dirty-work commit and no `git worktree remove --force`
- private repository receives no tracked changes

## Verification

- `AGENT_NO_MERGE=1 .venv/bin/python -m pytest -q` on 41 focused/regression
  tests: passed
- ruff: passed
- launchd plist `plutil -lint`: passed
- agent trailer and OPSEC linters: passed
- real dual-repository apply: removed exactly the clean worktree for merged
  PR #5962, preserved/reported the orphan, zero errors
- independent cross-family review: Claude Sonnet 5, final verdict PASS

Refs #4956
