### PR TITLE
feat(runtime): weak-driver trail isolation (P5)

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -98,6 +98,51 @@ level. Runner rejects invocations requesting an unsupported mode with
 `ValueError` if missing. This prevents "write to wherever Python happens
 to be running" bugs.
 
+## Weak-driver trail isolation (P5)
+
+Trail drivers are never given a shell, workspace writes, GitHub mutation, or
+ambient MCP access. A certifiable weak session must use the explicit runtime
+profile:
+
+```python
+invoke(
+    "grok",  # or "kimi" with harness="kimicc"
+    prompt,
+    mode="read-only",
+    cwd=Path.cwd(),
+    tool_config={"trail_isolation": True},
+)
+```
+
+The runner creates a private MCP configuration with exactly one `trail`
+server and exactly three visible tools:
+
+| Tool | Parent-owned P3 runner action |
+| --- | --- |
+| `trail_status` | `trail_runner.py status --run-id …` |
+| `trail_step` | `trail_runner.py step --run-id … --expected-step …` |
+| `trail_summon` | Reads the `summons` returned by `status`; P3 creates those atomically when it parks a run. |
+
+The MCP server has no generic command, begin, resume, verify-chain, or close
+tool. `trail_step` is the only execution request and P3 still validates the
+SQLite-authoritative current cursor before it launches the pinned command.
+
+The admission policy is fail-closed:
+
+- Native Grok gets a private MCP cwd, an exact three-tool allowlist, explicit
+  allows for those tools, and explicit denies for Bash, reads/writes/edits,
+  web, and discovery tools.
+- Kimi is eligible only through `tool_config={"harness": "kimicc", "trail_isolation": True}`.
+  KimiCC forwards Claude Code's exact `--tools`, `--allowedTools`,
+  `--strict-mcp-config`, and empty `--setting-sources` profile.
+- Native Kimi, GLM/opencode, Hermes Grok, and every unproven harness refuse
+  before spawn. GLM currently ignores tool restrictions, so a refusal is more
+  honest than a pretend sandbox.
+
+The boundary prevents accidental weak-driver deviation, not a malicious
+process sharing the same Unix account. CI, branch protection, and merge guards
+remain required controls.
+
 ## Stall detection — why we don't kill healthy slow calls
 
 Previous code used `subprocess.run(timeout=N)` and killed anything that

--- a/scripts/agent_runtime/adapters/glm.py
+++ b/scripts/agent_runtime/adapters/glm.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from ..errors import AgentRuntimeError
 from ..result import ParseResult
+from ..trail_isolation import TrailIsolationError, trail_isolation_requested
 from .base import InvocationPlan
 
 _logger = logging.getLogger(__name__)
@@ -95,6 +96,10 @@ class GlmAdapter:
         tool_config: dict | None = None,
         effort: str | None = None,
     ) -> InvocationPlan:
+        if trail_isolation_requested(tool_config):
+            raise TrailIsolationError(
+                "trail isolation refused for GLM: opencode does not enforce tool restrictions"
+            )
         assert_glm_egress_allowed("GlmAdapter")
 
         if mode not in self.supported_modes:

--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -35,6 +35,13 @@ from pathlib import Path
 from urllib.parse import quote
 
 from ..result import ParseResult
+from ..trail_isolation import (
+    GROK_TRAIL_DENY_TOOLS,
+    GROK_TRAIL_TOOLS,
+    TrailIsolationError,
+    assert_trail_isolation_config,
+    trail_isolation_requested,
+)
 from .base import InvocationPlan
 
 _logger = logging.getLogger(__name__)
@@ -73,6 +80,17 @@ _MCP_REVIEW_DENY_RULES: tuple[str, ...] = (
 GROK_ALLOWED_MODELS: frozenset[str] = frozenset({"grok-4.5"})
 GROK_BUILD_DEFAULT_MODEL = "grok-4.5"
 GROK_BUILD_DEFAULT_EFFORT = os.environ.get("LEARN_UK_GROK_BUILD_EFFORT", "high")
+_TRAIL_ISOLATION_TOOL_CONFIG_KEYS: frozenset[str] = frozenset(
+    {
+        "allowed_tools",
+        "mcp_config_path",
+        "setting_sources",
+        "strict_mcp_config",
+        "tools",
+        "trail_isolation",
+        "trail_isolation_cwd",
+    }
+)
 
 
 def grok_session_dir(grok_home: Path, cwd: Path, session_id: str) -> Path:
@@ -109,6 +127,17 @@ class GrokBuildAdapter:
         if mode not in self.supported_modes:
             raise ValueError(f"GrokBuildAdapter: unsupported mode {mode!r} (supported: {sorted(self.supported_modes)})")
         tc = tool_config or {}
+        trail_isolation = trail_isolation_requested(tc)
+        trail_cwd: Path | None = None
+        if trail_isolation:
+            if mode != "read-only":
+                raise TrailIsolationError("Grok trail isolation requires mode='read-only'")
+            unsupported = sorted(set(tc) - _TRAIL_ISOLATION_TOOL_CONFIG_KEYS)
+            if unsupported:
+                raise TrailIsolationError(
+                    f"Grok trail isolation refuses incompatible tool_config keys: {unsupported}"
+                )
+            trail_cwd = assert_trail_isolation_config(tc, profile="grok")
         review_isolation = bool(tc.get("review_isolation"))
         review_write_root: Path | None = None
         if review_isolation:
@@ -136,7 +165,7 @@ class GrokBuildAdapter:
             prompt = _adapt_prompt_for_grok_build_mcp(prompt)
 
         cmd: list[str] = [grok_bin]
-        execution_cwd = cwd
+        execution_cwd = trail_cwd or cwd
         # Prompt: inline via -p for the common case; a hyphen-leading prompt
         # would be misparsed by clap as a flag, so route those through a temp
         # --prompt-file instead (robust for any content).
@@ -182,7 +211,9 @@ class GrokBuildAdapter:
         # parent-owned OS sandbox limits them to the sealed view; explicit deny
         # rules remove shell/write/nested execution even though headless tool
         # calls require an execution-capable permission mode.
-        if review_isolation:
+        if trail_isolation:
+            permission_mode = "default"
+        elif review_isolation:
             permission_mode = str(tc.get("permission_mode") or "bypassPermissions")
         else:
             permission_mode = "bypassPermissions" if mcp_read_only else _MODE_PERMISSION[mode]
@@ -194,7 +225,21 @@ class GrokBuildAdapter:
             cmd.append("--disable-web-search")
             for rule in _MCP_REVIEW_DENY_RULES:
                 cmd.extend(["--deny", rule])
-        if review_isolation:
+        if trail_isolation:
+            cmd.extend(
+                [
+                    "--no-plan",
+                    "--no-memory",
+                    "--no-subagents",
+                    "--disable-web-search",
+                    "--verbatim",
+                ]
+            )
+            for rule in GROK_TRAIL_DENY_TOOLS:
+                cmd.extend(["--deny", rule])
+            for rule in GROK_TRAIL_TOOLS:
+                cmd.extend(["--allow", rule])
+        elif review_isolation:
             cmd.extend(
                 [
                     "--always-approve",

--- a/scripts/agent_runtime/adapters/kimi.py
+++ b/scripts/agent_runtime/adapters/kimi.py
@@ -25,6 +25,7 @@ from scripts.review.model_catalog import kimi_model_aliases
 
 from ..result import ParseResult
 from ..tool_calls import normalize_tool_calls, parse_json_events
+from ..trail_isolation import TrailIsolationError, trail_isolation_requested
 from .base import InvocationPlan
 from .kimicc import KimiccHarness
 
@@ -90,6 +91,10 @@ class KimiAdapter:
     ) -> InvocationPlan:
         config = tool_config or {}
         harness = config.get("harness")
+        if trail_isolation_requested(config) and harness != "kimicc":
+            raise TrailIsolationError(
+                "trail isolation refused for native Kimi: native Kimi cannot prove tool admission; use KimiCC"
+            )
         if harness == "kimicc":
             return KimiccHarness().build_invocation(
                 prompt=prompt,

--- a/scripts/agent_runtime/adapters/kimicc.py
+++ b/scripts/agent_runtime/adapters/kimicc.py
@@ -16,11 +16,41 @@ from typing import Any
 from scripts.review.model_catalog import ModelCatalogError, resolve_kimi_model
 
 from ..result import ParseResult
+from ..trail_isolation import (
+    TrailIsolationError,
+    assert_trail_isolation_config,
+    trail_isolation_requested,
+)
 from .base import InvocationPlan
 from .claude import ClaudeAdapter, _default_claude_bin, _ensure_supported_claude_cli_version
 
 _HEADLESS_WRAPPER = Path(__file__).resolve().parents[1] / "kimicc_headless.sh"
-_SUPPORTED_TOOL_CONFIG_KEYS = frozenset({"agent", "allowed_tools", "max_budget_usd", "mcp_config_path"})
+_SUPPORTED_TOOL_CONFIG_KEYS = frozenset(
+    {
+        "agent",
+        "allowed_tools",
+        "max_budget_usd",
+        "mcp_config_path",
+        "tools",
+        "strict_mcp_config",
+        "setting_sources",
+        "trail_isolation",
+        "trail_isolation_cwd",
+        "runtime_route",
+    }
+)
+_TRAIL_ISOLATION_TOOL_CONFIG_KEYS = frozenset(
+    {
+        "allowed_tools",
+        "harness",
+        "mcp_config_path",
+        "setting_sources",
+        "strict_mcp_config",
+        "tools",
+        "trail_isolation",
+        "trail_isolation_cwd",
+    }
+)
 
 
 class KimiccHarness:
@@ -58,6 +88,16 @@ class KimiccHarness:
         tc: dict[str, Any] = tool_config or {}
         if tc.get("review_isolation"):
             raise ValueError("KimiccHarness does not support sealed review isolation")
+        trail_isolation = trail_isolation_requested(tc)
+        if trail_isolation:
+            if mode != "read-only":
+                raise TrailIsolationError("KimiCC trail isolation requires mode='read-only'")
+            assert_trail_isolation_config(tc, profile="kimicc")
+            unsupported = sorted(set(tc) - _TRAIL_ISOLATION_TOOL_CONFIG_KEYS)
+            if unsupported:
+                raise TrailIsolationError(
+                    f"KimiCC trail isolation refuses incompatible tool_config keys: {unsupported}"
+                )
         unsupported = sorted(set(tc) - _SUPPORTED_TOOL_CONFIG_KEYS - {"harness"})
         if unsupported:
             raise ValueError(f"KimiccHarness: unsupported tool_config keys: {unsupported}")
@@ -78,7 +118,21 @@ class KimiccHarness:
             "--prompt",
             prompt,
         ]
-        if isinstance(tc.get("mcp_config_path"), str) and tc.get("allowed_tools"):
+        if trail_isolation:
+            cmd.extend(
+                [
+                    "--mcp-config",
+                    str(tc["mcp_config_path"]),
+                    "--allowedTools",
+                    str(tc["allowed_tools"]),
+                    "--tools",
+                    str(tc["tools"]),
+                    "--strict-mcp-config",
+                    "--setting-sources",
+                    str(tc["setting_sources"]),
+                ]
+            )
+        elif isinstance(tc.get("mcp_config_path"), str) and tc.get("allowed_tools"):
             cmd.extend(["--mcp-config", str(tc["mcp_config_path"]), "--allowedTools", str(tc["allowed_tools"])])
         if tc.get("agent"):
             cmd.extend(["--agent", str(tc["agent"])])

--- a/scripts/agent_runtime/kimicc_headless.sh
+++ b/scripts/agent_runtime/kimicc_headless.sh
@@ -38,9 +38,20 @@ while (($#)); do
       PROMPT="${2:?--prompt requires a value}"
       shift 2
       ;;
-    --mcp-config|--allowedTools|--agent|--max-budget-usd|--effort)
+    --mcp-config|--allowedTools|--tools|--agent|--max-budget-usd|--effort)
       FORWARD_ARGS+=("$1" "${2:?$1 requires a value}")
       shift 2
+      ;;
+    --setting-sources)
+      # An explicit empty value is the isolation profile's way to suppress
+      # ambient user/project settings, so distinguish an empty argument from
+      # an omitted one here.
+      FORWARD_ARGS+=("$1" "${2?--setting-sources requires a value}")
+      shift 2
+      ;;
+    --strict-mcp-config)
+      FORWARD_ARGS+=("$1")
+      shift
       ;;
     -h|--help)
       usage

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -73,6 +73,7 @@ from .failover import (
 from .registry import AGENTS, get_agent_entry
 from .result import ParseResult, Result
 from .telemetry import InvocationTelemetry, resolve_invocation_telemetry
+from .trail_isolation import prepare_trail_isolation
 from .usage import has_headroom, write_record
 from .watchdog import (
     WatchdogState,
@@ -1066,7 +1067,9 @@ def _execute_invocation_plan(
     # review_isolation, replace ambient agent env + wrap argv with the
     # fail-closed OS sandbox policy. Never silently weaken.
     review_cmd = list(plan.cmd)
-    review_cwd = cwd
+    # InvocationPlan.cwd is the authoritative spawn location. Trail isolation
+    # uses this to isolate native Grok from ambient project MCP configuration.
+    review_cwd = Path(getattr(plan, "cwd", None) or cwd)
     isolation_evidence: dict | None = None
     isolation_capability_digest: str | None = None
     isolation_prompt_digest: str | None = None
@@ -2224,7 +2227,7 @@ def _invoke_with_runner_failover(
     raise AgentUnavailableError(f"Agent {agent_name!r} has an empty runner failover route set")
 
 
-def invoke(
+def _invoke_impl(
     agent_name: str,
     prompt: str,
     *,
@@ -2246,7 +2249,7 @@ def invoke(
     event_sink: Callable[..., None] | None = None,
     effort: str | None = None,
 ) -> Result:
-    """Single entry point for all agent CLI invocations.
+    """Runner implementation after any parent-owned isolation preparation.
 
     Args:
         agent_name: Registry key. Must be in AGENTS and have
@@ -2533,3 +2536,56 @@ def invoke(
         isolation_prompt_digest=execution.isolation_prompt_digest,
         isolation_prompt_transport=execution.isolation_prompt_transport,
     )
+
+
+def invoke(
+    agent_name: str,
+    prompt: str,
+    *,
+    mode: str = "read-only",
+    cwd: Path | None = None,
+    model: str | None = None,
+    task_id: str | None = None,
+    session_id: str | None = None,
+    tool_config: dict | None = None,
+    entrypoint: str = "runtime",
+    hard_timeout: int = 86400,
+    stall_timeout: int = 180,
+    stdout_silence_timeout: int | None = None,
+    initial_response_timeout: int | None = None,
+    event_sink: Callable[..., None] | None = None,
+    effort: str | None = None,
+) -> Result:
+    """Invoke an agent CLI, provisioning trail isolation before any spawn.
+
+    ``tool_config={"trail_isolation": ...}`` is handled before adapter
+    planning. Unsupported adapters refuse before spawn, while supported
+    profiles receive a private one-server MCP configuration that is removed
+    after success, refusal, timeout, or adapter error.
+    """
+    launch = prepare_trail_isolation(
+        agent_name=agent_name,
+        mode=mode,
+        tool_config=tool_config,
+    )
+    try:
+        return _invoke_impl(
+            agent_name,
+            prompt,
+            mode=mode,
+            cwd=cwd,
+            model=model,
+            task_id=task_id,
+            session_id=session_id,
+            tool_config=launch.tool_config if launch is not None else tool_config,
+            entrypoint=entrypoint,
+            hard_timeout=hard_timeout,
+            stall_timeout=stall_timeout,
+            stdout_silence_timeout=stdout_silence_timeout,
+            initial_response_timeout=initial_response_timeout,
+            event_sink=event_sink,
+            effort=effort,
+        )
+    finally:
+        if launch is not None:
+            launch.cleanup()

--- a/scripts/agent_runtime/trail_isolation.py
+++ b/scripts/agent_runtime/trail_isolation.py
@@ -1,0 +1,212 @@
+"""Fail-closed weak-driver tool isolation for TrailSpec sessions.
+
+The trail executor, not a weak model, owns command execution.  This module
+builds the private MCP configuration and adapter-specific admission profile
+used when callers request ``tool_config={"trail_isolation": ...}``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TRAIL_MCP_SERVER_NAME = "trail"
+TRAIL_TOOL_NAMES: tuple[str, ...] = ("trail_status", "trail_step", "trail_summon")
+KIMICC_TRAIL_TOOLS: tuple[str, ...] = tuple(
+    f"mcp__{TRAIL_MCP_SERVER_NAME}__{name}" for name in TRAIL_TOOL_NAMES
+)
+GROK_TRAIL_TOOLS: tuple[str, ...] = tuple(
+    f"{TRAIL_MCP_SERVER_NAME}__{name}" for name in TRAIL_TOOL_NAMES
+)
+GROK_TRAIL_DENY_TOOLS: tuple[str, ...] = (
+    "Bash",
+    "Write",
+    "Edit",
+    "MultiEdit",
+    "NotebookEdit",
+    "Read",
+    "Glob",
+    "Grep",
+    "LS",
+    "WebFetch",
+    "WebSearch",
+)
+
+
+class TrailIsolationError(ValueError):
+    """Raised when a requested weak-driver boundary cannot be proven."""
+
+
+@dataclass
+class TrailIsolationLaunch:
+    """Parent-owned temporary MCP configuration for one isolated invocation."""
+
+    tool_config: dict[str, Any]
+    root: Path
+
+    def cleanup(self) -> None:
+        """Remove the per-invocation config after the agent exits."""
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+def trail_isolation_requested(tool_config: Mapping[str, Any] | None) -> bool:
+    """Return whether a caller requested the trail isolation profile."""
+    if not tool_config or "trail_isolation" not in tool_config:
+        return False
+    return tool_config["trail_isolation"] is not None and tool_config["trail_isolation"] is not False
+
+
+def _tool_csv(tool_names: tuple[str, ...]) -> str:
+    return ",".join(tool_names)
+
+
+def _profile_for_agent(agent_name: str, tool_config: Mapping[str, Any]) -> str:
+    if agent_name in {"grok", "grok-build"}:
+        return "grok"
+    if agent_name == "kimi":
+        if tool_config.get("harness") != "kimicc":
+            raise TrailIsolationError(
+                "trail isolation refused for native Kimi: the native CLI cannot prove tool admission; use harness='kimicc'"
+            )
+        return "kimicc"
+    if agent_name == "glm":
+        raise TrailIsolationError(
+            "trail isolation refused for GLM: the opencode adapter ignores tool restrictions"
+        )
+    if agent_name == "grok-hermes":
+        raise TrailIsolationError(
+            "trail isolation refused for grok-hermes: this harness cannot prove trail tool admission"
+        )
+    raise TrailIsolationError(
+        f"trail isolation refused for {agent_name!r}: this harness cannot prove trail tool admission"
+    )
+
+
+def _write_private_mcp_config(root: Path) -> Path:
+    """Write the sole admitted stdio MCP server without using ambient config."""
+    python_bin = PROJECT_ROOT / ".venv" / "bin" / "python"
+    mcp_server = PROJECT_ROOT / "scripts" / "orchestration" / "trails" / "trail_mcp.py"
+    if not python_bin.is_file() or not os.access(python_bin, os.X_OK):
+        raise TrailIsolationError(f"trail isolation requires executable {python_bin}")
+    if not mcp_server.is_file():
+        raise TrailIsolationError(f"trail isolation MCP server missing: {mcp_server}")
+
+    config_path = root / ".mcp.json"
+    payload = {
+        "mcpServers": {
+            TRAIL_MCP_SERVER_NAME: {
+                "command": str(python_bin),
+                "args": [str(mcp_server)],
+            }
+        }
+    }
+    descriptor = os.open(
+        config_path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o400,
+    )
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=True, separators=(",", ":"))
+        handle.write("\n")
+    config_path.chmod(0o400)
+    return config_path
+
+
+def prepare_trail_isolation(
+    *,
+    agent_name: str,
+    mode: str,
+    tool_config: Mapping[str, Any] | None,
+) -> TrailIsolationLaunch | None:
+    """Provision the exact three-tool profile or refuse before any spawn.
+
+    The caller may select only the profile and, for Kimi, the KimiCC harness.
+    Ambient MCP configuration and caller-provided allow/deny lists are never
+    merged into a weak-driver invocation.
+    """
+    if not trail_isolation_requested(tool_config):
+        return None
+    if mode != "read-only":
+        raise TrailIsolationError("trail isolation requires mode='read-only'")
+
+    supplied = dict(tool_config or {})
+    allowed_input_keys = {"trail_isolation", "harness"}
+    unexpected = sorted(set(supplied) - allowed_input_keys)
+    if unexpected:
+        raise TrailIsolationError(
+            f"trail isolation refuses caller-supplied tool configuration: {unexpected}"
+        )
+    requested = supplied.get("trail_isolation")
+    if requested is not True and not isinstance(requested, dict):
+        raise TrailIsolationError("trail_isolation must be true or a configuration object")
+
+    profile = _profile_for_agent(agent_name, supplied)
+    root = Path(tempfile.mkdtemp(prefix="agent-runtime-trail-isolation-"))
+    root.chmod(0o700)
+    try:
+        mcp_config_path = _write_private_mcp_config(root)
+        tool_names = KIMICC_TRAIL_TOOLS if profile == "kimicc" else GROK_TRAIL_TOOLS
+        configured: dict[str, Any] = {
+            "trail_isolation": True,
+            "mcp_config_path": str(mcp_config_path),
+            "allowed_tools": _tool_csv(tool_names),
+            "tools": _tool_csv(tool_names),
+            "strict_mcp_config": True,
+            "setting_sources": "",
+            "trail_isolation_cwd": str(root),
+        }
+        if profile == "kimicc":
+            configured["harness"] = "kimicc"
+        return TrailIsolationLaunch(tool_config=configured, root=root)
+    except BaseException:
+        shutil.rmtree(root, ignore_errors=True)
+        raise
+
+
+def assert_trail_isolation_config(tool_config: Mapping[str, Any], *, profile: str) -> Path:
+    """Validate that an adapter received the parent-produced exact profile."""
+    if profile not in {"grok", "kimicc"}:
+        raise TrailIsolationError(f"unknown trail isolation profile {profile!r}")
+    expected_tools = GROK_TRAIL_TOOLS if profile == "grok" else KIMICC_TRAIL_TOOLS
+    expected_csv = _tool_csv(expected_tools)
+    if tool_config.get("trail_isolation") is not True:
+        raise TrailIsolationError("trail isolation profile marker is missing")
+    for key in ("allowed_tools", "tools"):
+        if tool_config.get(key) != expected_csv:
+            raise TrailIsolationError(f"trail isolation {key} is not the exact three-tool allowlist")
+    if tool_config.get("strict_mcp_config") is not True or tool_config.get("setting_sources") != "":
+        raise TrailIsolationError("trail isolation requires strict MCP config and no ambient setting sources")
+
+    root_value = tool_config.get("trail_isolation_cwd")
+    config_value = tool_config.get("mcp_config_path")
+    if not isinstance(root_value, str) or not isinstance(config_value, str):
+        raise TrailIsolationError("trail isolation private MCP configuration is missing")
+    root = Path(root_value)
+    config_path = Path(config_value)
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved_config = config_path.resolve(strict=True)
+    except OSError as exc:
+        raise TrailIsolationError("trail isolation private MCP configuration is unreadable") from exc
+    if root.is_symlink() or config_path.is_symlink() or resolved_config != resolved_root / ".mcp.json":
+        raise TrailIsolationError("trail isolation MCP configuration path is invalid")
+    try:
+        payload = json.loads(resolved_config.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TrailIsolationError("trail isolation MCP configuration is invalid JSON") from exc
+    servers = payload.get("mcpServers") if isinstance(payload, dict) else None
+    server = servers.get(TRAIL_MCP_SERVER_NAME) if isinstance(servers, dict) else None
+    expected_python = PROJECT_ROOT / ".venv" / "bin" / "python"
+    expected_server = PROJECT_ROOT / "scripts" / "orchestration" / "trails" / "trail_mcp.py"
+    if not isinstance(server, dict) or set(servers) != {TRAIL_MCP_SERVER_NAME}:
+        raise TrailIsolationError("trail isolation MCP configuration exposes an unexpected server")
+    if server.get("command") != str(expected_python) or server.get("args") != [str(expected_server)]:
+        raise TrailIsolationError("trail isolation MCP server command is not parent-owned")
+    return resolved_root

--- a/scripts/orchestration/trails/trail_mcp.py
+++ b/scripts/orchestration/trails/trail_mcp.py
@@ -1,0 +1,99 @@
+"""Three-tool MCP surface for weak TrailSpec drivers.
+
+This server never offers a shell or a generic command tool.  Every request is
+translated to one of the P3 ``trail_runner.py`` verbs, which remains the sole
+owner of SQLite state and command execution.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+TRAIL_RUNNER = PROJECT_ROOT / "scripts" / "orchestration" / "trail_runner.py"
+PYTHON_BIN = PROJECT_ROOT / ".venv" / "bin" / "python"
+_RUNNER_TIMEOUT_SECONDS = 90
+
+mcp = FastMCP(
+    "trail",
+    instructions=(
+        "Weak drivers may only inspect a pinned trail, advance its exact current step, "
+        "or inspect runner-created summons. The parent-owned TrailSpec runner executes commands."
+    ),
+)
+
+
+class TrailMcpError(RuntimeError):
+    """Raised when the parent-owned P3 runner did not return its JSON contract."""
+
+
+def _require_identifier(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TrailMcpError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _run_runner(*args: str) -> dict[str, Any]:
+    """Call one fixed P3 runner verb and preserve its JSON result verbatim."""
+    if not PYTHON_BIN.is_file() or not TRAIL_RUNNER.is_file():
+        raise TrailMcpError("parent-owned TrailSpec runner is unavailable")
+    completed = subprocess.run(
+        [str(PYTHON_BIN), str(TRAIL_RUNNER), *args],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=_RUNNER_TIMEOUT_SECONDS,
+    )
+    try:
+        payload = json.loads((completed.stdout or "").strip())
+    except json.JSONDecodeError as exc:
+        raise TrailMcpError("parent-owned TrailSpec runner emitted invalid JSON") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != "trail-run-result.v1":
+        raise TrailMcpError("parent-owned TrailSpec runner violated its result contract")
+    if payload.get("exit_class") != completed.returncode:
+        raise TrailMcpError("parent-owned TrailSpec runner exit class does not match its result")
+    return payload
+
+
+@mcp.tool(name="trail_status", description="Read the SQLite-authoritative status of one TrailSpec run.")
+def trail_status(run_id: str) -> dict[str, Any]:
+    """Return the current cursor, state, and runner-created summons for ``run_id``."""
+    return _run_runner("status", "--run-id", _require_identifier(run_id, field="run_id"))
+
+
+@mcp.tool(name="trail_step", description="Ask the parent runner to execute the exact current TrailSpec step.")
+def trail_step(run_id: str, expected_step: str) -> dict[str, Any]:
+    """Advance only an exact cursor; P3 refuses skipped or invented steps."""
+    return _run_runner(
+        "step",
+        "--run-id",
+        _require_identifier(run_id, field="run_id"),
+        "--expected-step",
+        _require_identifier(expected_step, field="expected_step"),
+    )
+
+
+@mcp.tool(name="trail_summon", description="Read summons atomically created by the parent TrailSpec runner.")
+def trail_summon(run_id: str) -> dict[str, Any]:
+    """Return P3-created escalation records without granting a new mutation verb.
+
+    P3 inserts a summon atomically when a step parks.  This tool therefore
+    deliberately maps to ``status`` rather than creating an unbound local
+    escalation or exposing P4's authority-resume mechanism.
+    """
+    return _run_runner("status", "--run-id", _require_identifier(run_id, field="run_id"))
+
+
+def main() -> None:
+    """Serve the fixed three-tool MCP contract over stdio."""
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_trail_isolation.py
+++ b/tests/test_trail_isolation.py
@@ -1,0 +1,303 @@
+"""Conformance tests for the P5 weak-driver TrailSpec tool boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime import trail_isolation
+from agent_runtime.adapters import grok_build
+from agent_runtime.adapters.glm import GlmAdapter
+from agent_runtime.adapters.grok_build import GrokBuildAdapter
+from agent_runtime.adapters.kimi import KimiAdapter
+from agent_runtime.adapters.kimicc import KimiccHarness
+from agent_runtime.runner import invoke
+from agent_runtime.trail_isolation import TrailIsolationError, prepare_trail_isolation
+
+from scripts.orchestration.trails import trail_mcp
+
+FAKE_GROK = "/usr/local/bin/grok"
+FAKE_CLAUDE = "/usr/local/bin/claude"
+
+
+def _values_after(cmd: list[str], flag: str) -> list[str]:
+    return [cmd[index + 1] for index, value in enumerate(cmd[:-1]) if value == flag]
+
+
+def _prepared_profile(agent_name: str, **tool_config: object):
+    return prepare_trail_isolation(
+        agent_name=agent_name,
+        mode="read-only",
+        tool_config={"trail_isolation": True, **tool_config},
+    )
+
+
+def test_mcp_server_exposes_only_three_fixed_tools() -> None:
+    tools = asyncio.run(trail_mcp.mcp.list_tools())
+
+    assert [tool.name for tool in tools] == ["trail_status", "trail_step", "trail_summon"]
+
+
+def test_mcp_tools_only_call_fixed_p3_runner_verbs() -> None:
+    payload = {
+        "schema_version": "trail-run-result.v1",
+        "command": "status",
+        "exit_class": 0,
+        "outcome": "status",
+        "run_id": "run-123",
+        "state": "active",
+        "cursor_step": "check",
+        "data": {"summons": []},
+        "error": None,
+    }
+    completed = subprocess.CompletedProcess([], 0, stdout=json.dumps(payload), stderr="")
+    with patch("scripts.orchestration.trails.trail_mcp.subprocess.run", return_value=completed) as run:
+        assert trail_mcp.trail_status("run-123") == payload
+        assert trail_mcp.trail_step("run-123", "check") == payload
+        assert trail_mcp.trail_summon("run-123") == payload
+
+    calls = [call.args[0] for call in run.call_args_list]
+    assert calls[0][-3:] == ["status", "--run-id", "run-123"]
+    assert calls[1][-5:] == ["step", "--run-id", "run-123", "--expected-step", "check"]
+    # Summons are P3-owned records exposed by status, never a local mutation.
+    assert calls[2][-3:] == ["status", "--run-id", "run-123"]
+    assert all(call[:2] == [str(trail_mcp.PYTHON_BIN), str(trail_mcp.TRAIL_RUNNER)] for call in calls)
+
+
+def test_grok_profile_has_one_private_server_and_exact_allowlist() -> None:
+    launch = _prepared_profile("grok")
+    assert launch is not None
+    try:
+        config_path = launch.root / ".mcp.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        assert set(config["mcpServers"]) == {"trail"}
+        assert config["mcpServers"]["trail"]["command"] == str(
+            trail_isolation.PROJECT_ROOT / ".venv" / "bin" / "python"
+        )
+        assert launch.tool_config["allowed_tools"].split(",") == list(trail_isolation.GROK_TRAIL_TOOLS)
+
+        with patch("agent_runtime.adapters.grok_build.shutil.which", return_value=FAKE_GROK):
+            plan = GrokBuildAdapter().build_invocation(
+                prompt="Run the trail.",
+                mode="read-only",
+                cwd=Path.cwd(),
+                model=None,
+                task_id="p5-test",
+                session_id=None,
+                tool_config=launch.tool_config,
+            )
+
+        assert plan.cwd == launch.root
+        assert _values_after(plan.cmd, "--tools") == [launch.tool_config["allowed_tools"]]
+        assert _values_after(plan.cmd, "--allow") == list(trail_isolation.GROK_TRAIL_TOOLS)
+        denied = _values_after(plan.cmd, "--deny")
+        assert "Bash" in denied
+        assert {"Write", "Edit", "MultiEdit", "NotebookEdit"} <= set(denied)
+        assert "mcp__unknown__mutation" not in launch.tool_config["allowed_tools"]
+        assert plan.cmd[plan.cmd.index("--permission-mode") + 1] == "default"
+    finally:
+        launch.cleanup()
+    assert not launch.root.exists()
+
+
+def test_grok_deny_check_is_mutation_honest() -> None:
+    launch = _prepared_profile("grok")
+    assert launch is not None
+    try:
+        with patch("agent_runtime.adapters.grok_build.shutil.which", return_value=FAKE_GROK):
+            with patch.object(
+                grok_build,
+                "GROK_TRAIL_DENY_TOOLS",
+                tuple(rule for rule in trail_isolation.GROK_TRAIL_DENY_TOOLS if rule != "Bash"),
+            ):
+                mutated = GrokBuildAdapter().build_invocation(
+                    prompt="Run the trail.",
+                    mode="read-only",
+                    cwd=Path.cwd(),
+                    model=None,
+                    task_id="p5-mutant",
+                    session_id=None,
+                    tool_config=launch.tool_config,
+                )
+        # This proves the preceding conformance assertion would reject a
+        # regression that dropped the Bash deny rule.
+        assert "Bash" not in _values_after(mutated.cmd, "--deny")
+    finally:
+        launch.cleanup()
+
+
+def test_grok_profile_refuses_conflicting_or_unknown_tool_config() -> None:
+    launch = _prepared_profile("grok")
+    assert launch is not None
+    try:
+        for extra in ({"review_isolation": True}, {"disallowed_tools": "Bash"}):
+            with pytest.raises(TrailIsolationError, match="incompatible tool_config"):
+                GrokBuildAdapter().build_invocation(
+                    prompt="Run the trail.",
+                    mode="read-only",
+                    cwd=Path.cwd(),
+                    model=None,
+                    task_id="p5-conflict",
+                    session_id=None,
+                    tool_config={**launch.tool_config, **extra},
+                )
+    finally:
+        launch.cleanup()
+
+
+def test_kimicc_profile_forwards_strict_three_tool_admission() -> None:
+    launch = _prepared_profile("kimi", harness="kimicc")
+    assert launch is not None
+    try:
+        with (
+            patch("agent_runtime.adapters.kimicc._default_claude_bin", return_value=FAKE_CLAUDE),
+            patch("agent_runtime.adapters.kimicc._ensure_supported_claude_cli_version"),
+        ):
+            plan = KimiccHarness().build_invocation(
+                prompt="Run the trail.",
+                mode="read-only",
+                cwd=Path.cwd(),
+                model=None,
+                task_id="p5-test",
+                session_id=None,
+                tool_config=launch.tool_config,
+            )
+
+        assert _values_after(plan.cmd, "--tools") == [launch.tool_config["tools"]]
+        assert _values_after(plan.cmd, "--allowedTools") == [launch.tool_config["allowed_tools"]]
+        assert "--strict-mcp-config" in plan.cmd
+        assert _values_after(plan.cmd, "--setting-sources") == [""]
+        assert _values_after(plan.cmd, "--mcp-config") == [launch.tool_config["mcp_config_path"]]
+        assert "Bash" not in launch.tool_config["tools"]
+        assert "Write" not in launch.tool_config["tools"]
+    finally:
+        launch.cleanup()
+
+
+def test_kimicc_profile_refuses_conflicting_or_unknown_tool_config() -> None:
+    launch = _prepared_profile("kimi", harness="kimicc")
+    assert launch is not None
+    try:
+        for extra in ({"agent": "untrusted"}, {"max_budget_usd": 1}):
+            with pytest.raises(TrailIsolationError, match="incompatible tool_config"):
+                KimiccHarness().build_invocation(
+                    prompt="Run the trail.",
+                    mode="read-only",
+                    cwd=Path.cwd(),
+                    model=None,
+                    task_id="p5-conflict",
+                    session_id=None,
+                    tool_config={**launch.tool_config, **extra},
+                )
+    finally:
+        launch.cleanup()
+
+
+def test_kimicc_wrapper_accepts_the_strict_trail_flags(tmp_path: Path) -> None:
+    launch = _prepared_profile("kimi", harness="kimicc")
+    assert launch is not None
+    try:
+        fake_claude = tmp_path / "claude"
+        fake_claude.write_text(
+            "#!/usr/bin/env bash\nprintf 'arg=%s\\n' \"$@\"\n",
+            encoding="utf-8",
+        )
+        fake_claude.chmod(0o755)
+        home = tmp_path / "home"
+        home.mkdir()
+        env = os.environ.copy()
+        env.update({"HOME": str(home), "KIMICC_CLAUDE_BIN": str(fake_claude), "KIMICC_AUTH_TOKEN": "test"})
+        result = subprocess.run(
+            [
+                str(trail_isolation.PROJECT_ROOT / "scripts/agent_runtime/kimicc_headless.sh"),
+                "--model",
+                "k3",
+                "--mode",
+                "read-only",
+                "--prompt",
+                "Run the trail.",
+                "--mcp-config",
+                str(launch.tool_config["mcp_config_path"]),
+                "--allowedTools",
+                str(launch.tool_config["allowed_tools"]),
+                "--tools",
+                str(launch.tool_config["tools"]),
+                "--strict-mcp-config",
+                "--setting-sources",
+                "",
+            ],
+            cwd=trail_isolation.PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=20,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert f"arg={launch.tool_config['tools']}" in result.stdout
+        assert "arg=--strict-mcp-config" in result.stdout
+        assert "arg=--setting-sources" in result.stdout
+    finally:
+        launch.cleanup()
+
+
+@pytest.mark.parametrize("adapter", ["glm", "grok-hermes", "claude"])
+def test_unproven_adapters_refuse_before_runner_loads_them(adapter: str) -> None:
+    with patch("agent_runtime.runner._load_adapter", side_effect=AssertionError("spawn attempted")):
+        with pytest.raises(TrailIsolationError, match="trail isolation refused"):
+            invoke(adapter, "Run the trail.", tool_config={"trail_isolation": True})
+
+
+def test_glm_and_native_kimi_refuse_the_profile_at_adapter_boundary(tmp_path: Path) -> None:
+    with pytest.raises(TrailIsolationError, match="GLM"):
+        GlmAdapter().build_invocation(
+            prompt="Run the trail.",
+            mode="read-only",
+            cwd=tmp_path,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config={"trail_isolation": True},
+        )
+    with pytest.raises(TrailIsolationError, match="native Kimi"):
+        KimiAdapter().build_invocation(
+            prompt="Run the trail.",
+            mode="read-only",
+            cwd=tmp_path,
+            model=None,
+            task_id=None,
+            session_id=None,
+            tool_config={"trail_isolation": True},
+        )
+
+
+def test_trail_isolation_rejects_write_modes_and_caller_tool_injection() -> None:
+    launch = prepare_trail_isolation(
+        agent_name="grok",
+        mode="read-only",
+        tool_config={"trail_isolation": {}},
+    )
+    assert launch is not None
+    launch.cleanup()
+    with pytest.raises(TrailIsolationError, match="mode='read-only'"):
+        prepare_trail_isolation(
+            agent_name="grok",
+            mode="workspace-write",
+            tool_config={"trail_isolation": True},
+        )
+    with pytest.raises(TrailIsolationError, match="caller-supplied tool configuration"):
+        prepare_trail_isolation(
+            agent_name="grok",
+            mode="read-only",
+            tool_config={"trail_isolation": True, "allowed_tools": "Bash"},
+        )


### PR DESCRIPTION
## Summary
- Adds a parent-owned three-tool Trail MCP surface: `trail_status`, `trail_step`, and `trail_summon`.
- Wires fail-closed isolation profiles: KimiCC and Grok receive exact admission controls; GLM, native Kimi, and unproven harnesses refuse before spawn.
- Adds per-adapter conformance and mutation-honest denial tests, plus the runtime-guide profile documentation.

## Normative basis
Implements P5 from `docs/projects/fleet-trails/rail-system-completion-memo.md` §5, applying the weak-session boundary in §2.

## Verification
- `.venv/bin/python -m pytest tests/test_agent_runtime.py tests/test_trail_isolation.py tests/test_grok_build_adapter.py tests/test_agent_runtime_glm_adapter.py tests/agent_runtime/adapters/test_kimicc_headless.py tests/agent_runtime/adapters/test_kimi_adapter.py tests/test_trail_runner.py -q` — 259 passed.
- Ruff, shell syntax, diff whitespace, X-Agent trailer, and OPSEC checks passed.

## Review routing
The sealed AGY formal-review route refused because it cannot prove its isolation constraints. An AGY advisory review found zero material issues; formal independent cross-family review is being requested through the supported Claude route. No auto-merge is armed.

Refs #5885