### PR TITLE
feat(trails): STOP, authority, closure (P4)

### DIFF
--- a/agents_extensions/shared/schemas/trail-authority-receipt.v1.schema.json
+++ b/agents_extensions/shared/schemas/trail-authority-receipt.v1.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trail-authority-receipt.v1",
+  "title": "Trail authority receipt v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "issuer",
+    "issued_at",
+    "expires_at",
+    "action",
+    "run_id",
+    "trail_id",
+    "trail_version",
+    "trail_hash",
+    "summon_id",
+    "stop_code",
+    "step_id",
+    "cursor_generation",
+    "lease_id",
+    "lease_generation",
+    "fencing_token",
+    "pr_head"
+  ],
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "opaque_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$"
+    }
+  },
+  "properties": {
+    "schema_version": {"const": "trail-authority-receipt.v1"},
+    "receipt_id": {"$ref": "#/$defs/opaque_id"},
+    "issuer": {"$ref": "#/$defs/opaque_id"},
+    "issued_at": {"type": "string", "format": "date-time"},
+    "expires_at": {"type": "string", "format": "date-time"},
+    "action": {"const": "resume"},
+    "run_id": {"type": "string", "minLength": 1},
+    "trail_id": {"type": "string", "minLength": 1},
+    "trail_version": {"type": ["string", "integer"]},
+    "trail_hash": {"$ref": "#/$defs/digest"},
+    "summon_id": {"$ref": "#/$defs/digest"},
+    "stop_code": {"type": "string", "pattern": "^STOP-[a-z0-9-]+$"},
+    "step_id": {"type": "string", "minLength": 1},
+    "cursor_generation": {"type": "integer", "minimum": 0},
+    "lease_id": {"$ref": "#/$defs/opaque_id"},
+    "lease_generation": {"type": "integer", "minimum": 0},
+    "fencing_token": {"$ref": "#/$defs/opaque_id"},
+    "pr_head": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{40}$"
+    }
+  }
+}

--- a/agents_extensions/shared/schemas/trail-closure-attestation.v1.schema.json
+++ b/agents_extensions/shared/schemas/trail-closure-attestation.v1.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trail-closure-attestation.v1",
+  "title": "Trail closure attestation v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "trail_id",
+    "trail_version",
+    "trail_hash",
+    "terminal_outcome",
+    "chain_digest",
+    "terminal_command_receipt_digest",
+    "terminal_step_receipt_digest",
+    "observation_source",
+    "observation_id",
+    "terminal_reobservation_digest",
+    "lease_id",
+    "lease_generation",
+    "fencing_token",
+    "pr_head",
+    "authority_receipt_digests",
+    "closed_at"
+  ],
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "opaque_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$"
+    }
+  },
+  "properties": {
+    "schema_version": {"const": "trail-closure-attestation.v1"},
+    "run_id": {"type": "string", "minLength": 1},
+    "trail_id": {"type": "string", "minLength": 1},
+    "trail_version": {"type": ["string", "integer"]},
+    "trail_hash": {"$ref": "#/$defs/digest"},
+    "terminal_outcome": {"type": "string", "minLength": 1},
+    "chain_digest": {"$ref": "#/$defs/digest"},
+    "terminal_command_receipt_digest": {"$ref": "#/$defs/digest"},
+    "terminal_step_receipt_digest": {"$ref": "#/$defs/digest"},
+    "observation_source": {"$ref": "#/$defs/opaque_id"},
+    "observation_id": {"$ref": "#/$defs/opaque_id"},
+    "terminal_reobservation_digest": {"$ref": "#/$defs/digest"},
+    "lease_id": {"$ref": "#/$defs/opaque_id"},
+    "lease_generation": {"type": "integer", "minimum": 0},
+    "fencing_token": {"$ref": "#/$defs/opaque_id"},
+    "pr_head": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "authority_receipt_digests": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/digest"},
+      "uniqueItems": true
+    },
+    "closed_at": {"type": "string", "format": "date-time"}
+  }
+}

--- a/scripts/orchestration/trails/authority.py
+++ b/scripts/orchestration/trails/authority.py
@@ -1,0 +1,223 @@
+"""Approved-source authority receipts for TrailSpec summons.
+
+Authority never comes from a path, a local JSON projection, or caller-supplied
+payload.  The runner receives an approved bridge/API source at construction and
+re-fetches an opaque receipt ID from that source before it can record a receipt.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+from .models import TrailRun, TrailRunnerError
+from .store import digest_json
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+AUTHORITY_RECEIPT_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/trail-authority-receipt.v1.schema.json"
+)
+OPAQUE_RECEIPT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+APPROVED_SOURCE_KINDS = frozenset({"api", "bridge"})
+_AUTHORITY_RECEIPT_VALIDATOR: Draft202012Validator | None = None
+
+
+class AuthorityReceiptError(TrailRunnerError):
+    """Raised when an authority receipt is absent, malformed, stale, or unbound."""
+
+
+class AuthorityReceiptSource(Protocol):
+    """A provisioned bridge/API source; it is never selected from user input."""
+
+    source_id: str
+    source_kind: str
+
+    def fetch_authority_receipt(self, receipt_id: str) -> Mapping[str, Any]:
+        """Re-fetch one receipt by its opaque external identifier."""
+
+
+class LeaseObserver(Protocol):
+    """Approved external observation of the lease/fence currently held by a run."""
+
+    def observe_lease(self, run: TrailRun) -> Mapping[str, Any]:
+        """Return the current lease identity, step, and optional current PR head."""
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedAuthorityReceipt:
+    """A schema-valid receipt re-fetched and bound to the current external lease."""
+
+    payload: dict[str, Any]
+    source_id: str
+    digest: str
+
+    @property
+    def receipt_id(self) -> str:
+        return str(self.payload["receipt_id"])
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _parse_time(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise AuthorityReceiptError(f"authority receipt {field} must be an RFC3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise AuthorityReceiptError(f"authority receipt {field} is not an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise AuthorityReceiptError(f"authority receipt {field} must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _validator() -> Draft202012Validator:
+    """Build the immutable receipt validator once without caching receipt payloads."""
+    global _AUTHORITY_RECEIPT_VALIDATOR
+    if _AUTHORITY_RECEIPT_VALIDATOR is not None:
+        return _AUTHORITY_RECEIPT_VALIDATOR
+    try:
+        schema = json.loads(AUTHORITY_RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AuthorityReceiptError(f"cannot load authority receipt schema: {exc}") from exc
+    if not isinstance(schema, dict):
+        raise AuthorityReceiptError("authority receipt schema root must be an object")
+    _AUTHORITY_RECEIPT_VALIDATOR = Draft202012Validator(schema, format_checker=FormatChecker())
+    return _AUTHORITY_RECEIPT_VALIDATOR
+
+
+def validate_authority_receipt_data(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Schema-validate an externally fetched receipt before inspecting its fields."""
+    if not isinstance(payload, Mapping):
+        raise AuthorityReceiptError("authority source returned a non-object receipt")
+    receipt = dict(payload)
+    errors = sorted(
+        _validator().iter_errors(receipt),
+        key=lambda error: tuple(error.path),
+    )
+    if errors:
+        error = errors[0]
+        raise AuthorityReceiptError(
+            f"authority receipt schema violation: {error.message} at {error.json_path}"
+        )
+    issued_at = _parse_time(receipt["issued_at"], field="issued_at")
+    expires_at = _parse_time(receipt["expires_at"], field="expires_at")
+    if expires_at <= issued_at:
+        raise AuthorityReceiptError("authority receipt expiry must be after issue time")
+    return receipt
+
+
+class ApprovedAuthorityReceiptResolver:
+    """Validate receipts from a fixed bridge/API and current external lease evidence."""
+
+    def __init__(
+        self,
+        source: AuthorityReceiptSource,
+        lease_observer: LeaseObserver,
+        *,
+        approved_issuers: set[str] | frozenset[str],
+        now: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        if getattr(source, "source_kind", None) not in APPROVED_SOURCE_KINDS:
+            raise AuthorityReceiptError("authority source must be a provisioned bridge or API")
+        if not isinstance(getattr(source, "source_id", None), str) or not source.source_id:
+            raise AuthorityReceiptError("authority source must have a stable source_id")
+        if not approved_issuers:
+            raise AuthorityReceiptError("authority resolver requires at least one approved issuer")
+        self.source = source
+        self.source_id = source.source_id
+        self.lease_observer = lease_observer
+        self.approved_issuers = frozenset(approved_issuers)
+        self.now = now
+
+    def fetch(self, authority_receipt_id: str, run: TrailRun) -> dict[str, Any]:
+        """Re-fetch and bind a resume receipt; no local file path can reach this path."""
+        if not OPAQUE_RECEIPT_ID.fullmatch(authority_receipt_id):
+            raise AuthorityReceiptError("authority receipt ID must be an opaque approved-source identifier")
+        try:
+            fetched = self.source.fetch_authority_receipt(authority_receipt_id)
+        except AuthorityReceiptError:
+            raise
+        except Exception as exc:
+            raise AuthorityReceiptError("approved authority source could not re-fetch receipt") from exc
+        receipt = validate_authority_receipt_data(fetched)
+        if receipt["receipt_id"] != authority_receipt_id:
+            raise AuthorityReceiptError("authority source receipt ID does not match requested ID")
+        self._validate_common(receipt)
+        self._validate_run_binding(receipt, run)
+        self._validate_current_lease(receipt, run)
+        return receipt
+
+    def revalidate(self, receipt: Mapping[str, Any]) -> VerifiedAuthorityReceipt:
+        """Re-fetch an already stored receipt and prove the immutable payload is unchanged."""
+        stored = validate_authority_receipt_data(receipt)
+        receipt_id = str(stored["receipt_id"])
+        try:
+            fetched = self.source.fetch_authority_receipt(receipt_id)
+        except AuthorityReceiptError:
+            raise
+        except Exception as exc:
+            raise AuthorityReceiptError("approved authority source could not re-fetch receipt") from exc
+        current = validate_authority_receipt_data(fetched)
+        if digest_json(current) != digest_json(stored):
+            raise AuthorityReceiptError("re-fetched authority receipt differs from consumed evidence")
+        self._validate_common(current)
+        return VerifiedAuthorityReceipt(
+            payload=current,
+            source_id=self.source.source_id,
+            digest=digest_json(current),
+        )
+
+    def _validate_common(self, receipt: Mapping[str, Any]) -> None:
+        issuer = receipt["issuer"]
+        if issuer not in self.approved_issuers:
+            raise AuthorityReceiptError(f"authority receipt issuer {issuer!r} is not approved")
+        if _parse_time(receipt["expires_at"], field="expires_at") <= self.now().astimezone(UTC):
+            raise AuthorityReceiptError("authority receipt has expired")
+
+    @staticmethod
+    def _validate_run_binding(receipt: Mapping[str, Any], run: TrailRun) -> None:
+        expected = {
+            "run_id": run.run_id,
+            "trail_id": run.trail_id,
+            "trail_version": run.trail_version,
+            "trail_hash": run.trail_hash,
+            "step_id": run.cursor_step_id,
+            "cursor_generation": run.cursor_generation,
+        }
+        for field, value in expected.items():
+            if receipt.get(field) != value:
+                raise AuthorityReceiptError(
+                    f"authority receipt {field} does not bind the current run state"
+                )
+
+    def _validate_current_lease(self, receipt: Mapping[str, Any], run: TrailRun) -> None:
+        try:
+            observed = self.lease_observer.observe_lease(run)
+        except Exception as exc:
+            raise AuthorityReceiptError("current lease observation is unavailable") from exc
+        if not isinstance(observed, Mapping):
+            raise AuthorityReceiptError("current lease observation is not an object")
+        expected = {
+            "run_id": run.run_id,
+            "step_id": run.cursor_step_id,
+            "lease_id": receipt["lease_id"],
+            "lease_generation": receipt["lease_generation"],
+            "fencing_token": receipt["fencing_token"],
+        }
+        for field, value in expected.items():
+            if observed.get(field) != value:
+                raise AuthorityReceiptError(
+                    f"authority receipt {field} does not match current external lease"
+                )
+        receipt_head = receipt.get("pr_head")
+        if receipt_head is not None and observed.get("pr_head") != receipt_head:
+            raise AuthorityReceiptError("authority receipt PR head is stale")

--- a/scripts/orchestration/trails/closure.py
+++ b/scripts/orchestration/trails/closure.py
@@ -1,0 +1,323 @@
+"""Fail-closed terminal closure for the SQLite-authoritative Trail runner.
+
+Closure is intentionally a sequence of durable local evidence plus fresh
+external observations.  It does not claim a transaction spanning GitHub,
+fleet-comms, and SQLite: an idempotent command receipt is followed by external
+re-observation and only then by the SQLite terminal commit.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+from .authority import (
+    APPROVED_SOURCE_KINDS,
+    AuthorityReceiptError,
+    VerifiedAuthorityReceipt,
+)
+from .models import TrailRun, TrailRunnerError
+from .store import TrailStore, digest_json, utc_now
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+CLOSURE_ATTESTATION_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/trail-closure-attestation.v1.schema.json"
+)
+OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+SHA256 = re.compile(r"^[a-f0-9]{64}$")
+_CLOSURE_ATTESTATION_VALIDATOR: Draft202012Validator | None = None
+
+
+class ClosureError(TrailRunnerError):
+    """Raised when closure cannot be proven from fresh external evidence."""
+
+
+class AuthorityReceiptRevalidator(Protocol):
+    """The authority resolver's closure-time re-fetch capability."""
+
+    def revalidate(self, receipt: Mapping[str, Any]) -> VerifiedAuthorityReceipt:
+        """Re-fetch a consumed receipt and prove it remains immutable and current."""
+
+
+class TerminalObservationSource(Protocol):
+    """A provisioned bridge/API re-observer; never a local receipt projection."""
+
+    source_id: str
+    source_kind: str
+
+    def reobserve_terminal(
+        self,
+        *,
+        run: TrailRun,
+        terminal_command_receipt: Mapping[str, Any],
+        terminal_step_receipt: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        """Return fresh external terminal, lease/fence, and optional PR-head evidence."""
+
+
+@dataclass(frozen=True, slots=True)
+class ClosureCommit:
+    """One terminal closure result, either newly committed or safely replayed."""
+
+    attestation: dict[str, Any]
+    attestation_digest: str
+    replayed: bool
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _parse_time(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise ClosureError(f"closure {field} must be an RFC3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ClosureError(f"closure {field} is not an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ClosureError(f"closure {field} must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _validator() -> Draft202012Validator:
+    """Build the immutable closure validator once without caching attestations."""
+    global _CLOSURE_ATTESTATION_VALIDATOR
+    if _CLOSURE_ATTESTATION_VALIDATOR is not None:
+        return _CLOSURE_ATTESTATION_VALIDATOR
+    try:
+        schema = json.loads(CLOSURE_ATTESTATION_SCHEMA_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ClosureError(f"cannot load closure attestation schema: {exc}") from exc
+    if not isinstance(schema, dict):
+        raise ClosureError("closure attestation schema root must be an object")
+    _CLOSURE_ATTESTATION_VALIDATOR = Draft202012Validator(schema, format_checker=FormatChecker())
+    return _CLOSURE_ATTESTATION_VALIDATOR
+
+
+def validate_closure_attestation_data(attestation: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate an attestation assembled exclusively from pinned/fresh evidence."""
+    if not isinstance(attestation, Mapping):
+        raise ClosureError("closure attestation must be an object")
+    payload = dict(attestation)
+    errors = sorted(
+        _validator().iter_errors(payload),
+        key=lambda error: tuple(error.path),
+    )
+    if errors:
+        error = errors[0]
+        raise ClosureError(
+            f"closure attestation schema violation: {error.message} at {error.json_path}"
+        )
+    _parse_time(payload["closed_at"], field="closed_at")
+    return payload
+
+
+class TrailClosureGate:
+    """Re-observe and atomically terminally commit a chain that is already proven intact."""
+
+    def __init__(
+        self,
+        store: TrailStore,
+        observation_source: TerminalObservationSource,
+        *,
+        authority_resolver: AuthorityReceiptRevalidator | None = None,
+        now: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        if getattr(observation_source, "source_kind", None) not in APPROVED_SOURCE_KINDS:
+            raise ClosureError("terminal observation source must be a provisioned bridge or API")
+        if not isinstance(getattr(observation_source, "source_id", None), str) or not observation_source.source_id:
+            raise ClosureError("terminal observation source must have a stable source_id")
+        self.store = store
+        self.observation_source = observation_source
+        self.authority_resolver = authority_resolver
+        self.now = now
+
+    def existing(self, run_id: str) -> ClosureCommit | None:
+        """Return the stored immutable terminal result without another external call."""
+        stored = self.store.get_closure(run_id)
+        if stored is None:
+            return None
+        attestation = validate_closure_attestation_data(stored["attestation"])
+        if digest_json(attestation) != stored["attestation_digest"]:
+            raise ClosureError("stored closure attestation digest does not match payload")
+        return ClosureCommit(
+            attestation=attestation,
+            attestation_digest=str(stored["attestation_digest"]),
+            replayed=True,
+        )
+
+    def close(
+        self,
+        *,
+        run: TrailRun,
+        chain_digest: str,
+        terminal_invocation: Mapping[str, Any],
+        terminal_command_receipt: Mapping[str, Any],
+        terminal_step_receipt: Mapping[str, Any],
+    ) -> ClosureCommit:
+        """Re-observe external state and commit a schema-valid terminal attestation."""
+        if run.state != "terminal" or not run.terminal_outcome:
+            raise ClosureError("closure requires a terminal TrailSpec run")
+        existing = self.existing(run.run_id)
+        if existing is not None:
+            return existing
+        if terminal_invocation.get("resolved_command", {}).get("mutation_class") != "observe":
+            raise ClosureError("terminal closure requires a terminal re-observation command")
+        if not SHA256.fullmatch(chain_digest):
+            raise ClosureError("closure chain digest is invalid")
+        self._validate_authority_receipts(run)
+        observation = self._reobserve(
+            run=run,
+            terminal_command_receipt=terminal_command_receipt,
+            terminal_step_receipt=terminal_step_receipt,
+        )
+        self._validate_observation(
+            observation=observation,
+            run=run,
+            terminal_step_receipt=terminal_step_receipt,
+        )
+        authority_digests = self._authority_digests(run, observation)
+        attestation = validate_closure_attestation_data(
+            {
+                "schema_version": "trail-closure-attestation.v1",
+                "run_id": run.run_id,
+                "trail_id": run.trail_id,
+                "trail_version": run.trail_version,
+                "trail_hash": run.trail_hash,
+                "terminal_outcome": run.terminal_outcome,
+                "chain_digest": chain_digest,
+                "terminal_command_receipt_digest": digest_json(dict(terminal_command_receipt)),
+                "terminal_step_receipt_digest": digest_json(dict(terminal_step_receipt)),
+                "observation_source": self.observation_source.source_id,
+                "observation_id": observation["observation_id"],
+                "terminal_reobservation_digest": digest_json(observation),
+                "lease_id": observation["lease_id"],
+                "lease_generation": observation["lease_generation"],
+                "fencing_token": observation["fencing_token"],
+                "pr_head": observation["pr_head"],
+                "authority_receipt_digests": authority_digests,
+                "closed_at": self.now().astimezone(UTC).isoformat(timespec="microseconds").replace(
+                    "+00:00", "Z"
+                ),
+            }
+        )
+        committed = self.store.commit_closure(run_id=run.run_id, attestation=attestation)
+        committed_attestation = validate_closure_attestation_data(committed["attestation"])
+        return ClosureCommit(
+            attestation=committed_attestation,
+            attestation_digest=str(committed["attestation_digest"]),
+            replayed=committed_attestation != attestation,
+        )
+
+    def _validate_authority_receipts(self, run: TrailRun) -> None:
+        receipts = self.store.list_authority_receipts(run.run_id)
+        if receipts and self.authority_resolver is None:
+            raise ClosureError("closure has authority receipts but no approved revalidator")
+        for stored in receipts:
+            assert self.authority_resolver is not None
+            try:
+                revalidated = self.authority_resolver.revalidate(stored["receipt"])
+            except AuthorityReceiptError as exc:
+                raise ClosureError(f"authority receipt {stored['receipt_id']} cannot close: {exc}") from exc
+            if revalidated.digest != stored["receipt_digest"]:
+                raise ClosureError("re-fetched authority receipt digest differs from durable evidence")
+            if revalidated.source_id != stored["source_id"]:
+                raise ClosureError("authority receipt source differs from durable evidence")
+
+    def _authority_digests(self, run: TrailRun, observation: Mapping[str, Any]) -> list[str]:
+        digests: list[str] = []
+        for stored in self.store.list_authority_receipts(run.run_id):
+            receipt = stored["receipt"]
+            for field in ("lease_id", "lease_generation", "fencing_token"):
+                if receipt[field] != observation[field]:
+                    raise ClosureError("authority receipt lease/fence is stale at closure")
+            receipt_head = receipt.get("pr_head")
+            if receipt_head is not None and receipt_head != observation["pr_head"]:
+                raise ClosureError("authority receipt PR head is stale at closure")
+            digests.append(str(stored["receipt_digest"]))
+        return digests
+
+    def _reobserve(
+        self,
+        *,
+        run: TrailRun,
+        terminal_command_receipt: Mapping[str, Any],
+        terminal_step_receipt: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        try:
+            observed = self.observation_source.reobserve_terminal(
+                run=run,
+                terminal_command_receipt=terminal_command_receipt,
+                terminal_step_receipt=terminal_step_receipt,
+            )
+        except ClosureError:
+            raise
+        except Exception as exc:
+            raise ClosureError("terminal re-observation is unavailable") from exc
+        if not isinstance(observed, Mapping):
+            raise ClosureError("terminal re-observation is not an object")
+        return dict(observed)
+
+    def _validate_observation(
+        self,
+        *,
+        observation: Mapping[str, Any],
+        run: TrailRun,
+        terminal_step_receipt: Mapping[str, Any],
+    ) -> None:
+        required = {
+            "observation_id",
+            "observed_at",
+            "run_id",
+            "trail_id",
+            "trail_hash",
+            "terminal_outcome",
+            "lease_id",
+            "lease_generation",
+            "fencing_token",
+            "pr_head",
+            "lease_current",
+            "terminal_observed",
+        }
+        if set(observation) != required:
+            raise ClosureError("terminal re-observation has an unexpected evidence shape")
+        if not isinstance(observation["observation_id"], str) or not OPAQUE_ID.fullmatch(
+            observation["observation_id"]
+        ):
+            raise ClosureError("terminal re-observation has an invalid observation_id")
+        _parse_time(observation["observed_at"], field="observed_at")
+        expected = {
+            "run_id": run.run_id,
+            "trail_id": run.trail_id,
+            "trail_hash": run.trail_hash,
+            "terminal_outcome": run.terminal_outcome,
+        }
+        for field, value in expected.items():
+            if observation[field] != value:
+                raise ClosureError(f"terminal re-observation {field} does not bind the terminal run")
+        if observation["lease_current"] is not True or observation["terminal_observed"] is not True:
+            raise ClosureError("terminal re-observation does not prove current terminal state")
+        if not isinstance(observation["lease_id"], str) or not OPAQUE_ID.fullmatch(observation["lease_id"]):
+            raise ClosureError("terminal re-observation has an invalid lease_id")
+        if type(observation["lease_generation"]) is not int or observation["lease_generation"] < 0:
+            raise ClosureError("terminal re-observation has an invalid lease_generation")
+        if not isinstance(observation["fencing_token"], str) or not OPAQUE_ID.fullmatch(
+            observation["fencing_token"]
+        ):
+            raise ClosureError("terminal re-observation has an invalid fencing_token")
+        observed_head = observation["pr_head"]
+        if observed_head is not None and (
+            not isinstance(observed_head, str) or not re.fullmatch(r"[0-9a-f]{40}", observed_head)
+        ):
+            raise ClosureError("terminal re-observation has an invalid PR head")
+        expected_head = terminal_step_receipt.get("pr_head")
+        if observed_head != expected_head:
+            raise ClosureError("terminal re-observation current PR head differs from terminal evidence")

--- a/scripts/orchestration/trails/executor.py
+++ b/scripts/orchestration/trails/executor.py
@@ -1203,6 +1203,47 @@ class TrailExecutor:
         )
         return chain_digest, terminal_invocation, command_receipt, step_receipt
 
+    def _park_closure_guarded(
+        self, *, run_id: str, reason: str, error: str | None
+    ) -> TrailRunResult:
+        """Park terminal closure, absorbing the concurrent-closer commit race.
+
+        A second closer can commit the closure between the caller's
+        closure-state check and this park call; the store then refuses with
+        DeviationRefusedError. That race is legitimate concurrency, so it maps
+        to a typed result — close() always returns a TrailRunResult.
+        """
+        try:
+            parked = self.store.park_terminal_closure(run_id=run_id, reason=reason)
+        except DeviationRefusedError as refusal:
+            current = self.store.get_run(run_id)
+            if current.closure_state == "closed" and self.closure_gate is not None:
+                try:
+                    concurrent = self.closure_gate.existing(run_id)
+                except ClosureError:
+                    concurrent = None
+                if concurrent is not None:
+                    return self._closed_result(run_id=run_id, committed=concurrent)
+            return TrailRunResult(
+                command="close",
+                exit_class=ExitClass.INVALID,
+                outcome="closure_refused",
+                run_id=run_id,
+                state=current.state,
+                cursor_step=current.cursor_step_id,
+                error=str(refusal),
+            )
+        return TrailRunResult(
+            command="close",
+            exit_class=ExitClass.STOP_PARKED,
+            outcome="closure_parked",
+            run_id=run_id,
+            state=parked.state,
+            cursor_step=parked.cursor_step_id,
+            data={"stop_code": "STOP-unknown", "closure_state": parked.closure_state},
+            error=error,
+        )
+
     def close(self, *, run_id: str) -> TrailRunResult:
         """Close only after a complete chain and fresh external re-observation."""
         run = self.store.get_run(run_id)
@@ -1211,18 +1252,9 @@ class TrailExecutor:
         chain = self.verify_chain(run_id=run_id)
         if chain.exit_class != ExitClass.OK:
             if run.state == "terminal" and run.closure_state != "closed":
-                parked = self.store.park_terminal_closure(
+                return self._park_closure_guarded(
                     run_id=run_id,
                     reason=chain.error or "closure chain verification failed",
-                )
-                return TrailRunResult(
-                    command="close",
-                    exit_class=ExitClass.STOP_PARKED,
-                    outcome="closure_parked",
-                    run_id=run_id,
-                    state=parked.state,
-                    cursor_step=parked.cursor_step_id,
-                    data={"stop_code": "STOP-unknown", "closure_state": parked.closure_state},
                     error=chain.error,
                 )
             return TrailRunResult(
@@ -1269,16 +1301,8 @@ class TrailExecutor:
                 if concurrent is not None:
                     return self._closed_result(run_id=run_id, committed=concurrent)
             if current.state == "terminal" and current.closure_state != "closed":
-                parked = self.store.park_terminal_closure(run_id=run_id, reason=str(exc))
-                return TrailRunResult(
-                    command="close",
-                    exit_class=ExitClass.STOP_PARKED,
-                    outcome="closure_parked",
-                    run_id=run_id,
-                    state=parked.state,
-                    cursor_step=parked.cursor_step_id,
-                    data={"stop_code": "STOP-unknown", "closure_state": parked.closure_state},
-                    error=str(exc),
+                return self._park_closure_guarded(
+                    run_id=run_id, reason=str(exc), error=str(exc)
                 )
             return TrailRunResult(
                 command="close",

--- a/scripts/orchestration/trails/executor.py
+++ b/scripts/orchestration/trails/executor.py
@@ -21,6 +21,11 @@ from typing import Any, Protocol
 
 import yaml
 
+from scripts.orchestration.trail_predicates import (
+    STOP_UNKNOWN,
+    evaluate_named_table,
+    load_decision_tables,
+)
 from scripts.orchestration.validate_trailspec import (
     TrailSpecValidationError,
     compute_command_receipt_digest,
@@ -30,6 +35,8 @@ from scripts.orchestration.validate_trailspec import (
     validate_trailspec_data,
 )
 
+from .authority import AuthorityReceiptError
+from .closure import ClosureError, TrailClosureGate
 from .models import (
     AuthorityReceiptUnavailableError,
     CommandExecution,
@@ -44,6 +51,7 @@ from .models import (
 from .store import TrailStore, canonical_json, digest_json, utc_now
 
 _OUTCOME_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]*$")
+_GIT_HEAD_SHA = re.compile(r"^[0-9a-f]{40}$")
 _AUTHORIZATION_REDACTION_PATTERN = re.compile(
     r"(?i)(authorization\s*[:=]\s*(?:bearer\s+)?)\S+"
 )
@@ -79,23 +87,33 @@ class ReceiptPredicateEvaluator(Protocol):
 
 
 class DecisionTableEvaluator(Protocol):
-    """P2 seam for typed table predicates; P3 intentionally has no implementation."""
+    """Typed P2 static-table evaluation without command execution or observation."""
 
     def evaluate(self, table_id: str, facts: dict[str, Any]) -> str:
         """Evaluate a pinned decision table without launching a command."""
 
 
-class UnavailableDecisionTableEvaluator:
-    """P3's explicit P2 seam: table execution is unavailable until it is wired."""
+class TrailPredicatesDecisionTableEvaluator:
+    """Wire P2's checked-in typed tables into the P3 executor seam."""
+
+    def __init__(self, tables_path: Path | None = None) -> None:
+        self.tables_path = tables_path
+        self.tables: dict[str, Any] | None = None
 
     def evaluate(self, table_id: str, facts: dict[str, Any]) -> str:
-        raise TrailRunnerError(
-            f"decision-table predicate '{table_id}' is unavailable until P2/P4 wiring"
-        )
+        if self.tables is None:
+            self.tables = (
+                load_decision_tables()
+                if self.tables_path is None
+                else load_decision_tables(self.tables_path)
+            )
+        return evaluate_named_table(self.tables, table_id, facts)
 
 
 class AuthorityReceiptResolver(Protocol):
     """P4-owned approved-source lookup, never a local JSON-file loader."""
+
+    source_id: str
 
     def fetch(self, authority_receipt_id: str, run: TrailRun) -> dict[str, Any]:
         """Re-fetch and validate an authority receipt from an approved source."""
@@ -103,6 +121,8 @@ class AuthorityReceiptResolver(Protocol):
 
 class UnavailableAuthorityReceiptResolver:
     """P3's deliberate fail-closed authority implementation."""
+
+    source_id = "unavailable"
 
     def fetch(self, authority_receipt_id: str, run: TrailRun) -> dict[str, Any]:
         raise AuthorityReceiptUnavailableError(
@@ -208,6 +228,7 @@ class TrailExecutor:
         predicate_evaluator: ReceiptPredicateEvaluator | None = None,
         decision_table_evaluator: DecisionTableEvaluator | None = None,
         authority_resolver: AuthorityReceiptResolver | None = None,
+        closure_gate: TrailClosureGate | None = None,
         fault_hook: Callable[[str, PreparedInvocation], None] | None = None,
     ) -> None:
         self.store = store
@@ -215,10 +236,9 @@ class TrailExecutor:
         self.seat_registry_path = seat_registry_path
         self.command_runner = command_runner
         self.predicate_evaluator = predicate_evaluator or DefaultReceiptPredicateEvaluator()
-        self.decision_table_evaluator = (
-            decision_table_evaluator or UnavailableDecisionTableEvaluator()
-        )
+        self.decision_table_evaluator = decision_table_evaluator or TrailPredicatesDecisionTableEvaluator()
         self.authority_resolver = authority_resolver or UnavailableAuthorityReceiptResolver()
+        self.closure_gate = closure_gate
         self.fault_hook = fault_hook
 
     @staticmethod
@@ -258,6 +278,11 @@ class TrailExecutor:
                 raise TrailRunnerError(
                     f"parameter '{name}' must be a TrailSpec {kind}, got {type(value).__name__}"
                 )
+        pr_head = params.get("pr_head")
+        if pr_head is not None and (
+            not isinstance(pr_head, str) or not _GIT_HEAD_SHA.fullmatch(pr_head)
+        ):
+            raise TrailRunnerError("parameter 'pr_head' must be a lowercase 40-hex Git commit SHA")
 
     def begin(
         self,
@@ -350,7 +375,78 @@ class TrailExecutor:
                 "terminal_outcome": run.terminal_outcome,
                 "closure_state": run.closure_state,
                 "summons": self.store.list_summons(run_id),
+                "authority_receipts": self.store.list_authority_receipts(run_id),
             },
+        )
+
+    def evaluate_decision_table(
+        self,
+        *,
+        run_id: str,
+        expected_step: str,
+        table_id: str,
+        facts: dict[str, Any],
+    ) -> TrailRunResult:
+        """Evaluate P2's typed outcome and atomically park ambiguous/unknown input.
+
+        TrailSpec v1.1 does not yet declare table-lookup steps, so this is the
+        explicit executor seam for later migrated trails. It never runs a
+        command. P2's fail-closed token is parked with its summon in one SQLite
+        transaction.
+        """
+        run = self.store.get_run(run_id)
+        if run.spec["schema_version"] != "trailspec.v1.1":
+            return self._reject_v1_execution("step", run)
+        if run.state != "active" or run.cursor_step_id != expected_step:
+            return TrailRunResult(
+                command="step",
+                exit_class=ExitClass.DEVIATION_REFUSED,
+                outcome="deviation_refused",
+                run_id=run_id,
+                state=run.state,
+                cursor_step=run.cursor_step_id,
+                error="decision table must name the exact active cursor",
+            )
+        token = self.decision_table_evaluator.evaluate(table_id, facts)
+        if token == STOP_UNKNOWN:
+            try:
+                parked = self.store.park_stop(
+                    run_id=run_id,
+                    expected_step=expected_step,
+                    stop_code=STOP_UNKNOWN,
+                    reason=(
+                        f"decision table '{table_id}' had zero, multiple, or invalid typed matches"
+                    ),
+                )
+            except DeviationRefusedError as exc:
+                latest = self.store.get_run(run_id)
+                return TrailRunResult(
+                    command="step",
+                    exit_class=ExitClass.DEVIATION_REFUSED,
+                    outcome="deviation_refused",
+                    run_id=run_id,
+                    state=latest.state,
+                    cursor_step=latest.cursor_step_id,
+                    error=str(exc),
+                )
+            return TrailRunResult(
+                command="step",
+                exit_class=ExitClass.STOP_PARKED,
+                outcome="stop_unknown",
+                run_id=run_id,
+                state=parked.state,
+                cursor_step=parked.cursor_step_id,
+                data={"table_id": table_id, "stop_code": STOP_UNKNOWN},
+                error=parked.parked_reason,
+            )
+        return TrailRunResult(
+            command="step",
+            exit_class=ExitClass.OK,
+            outcome="decision_table_outcome",
+            run_id=run_id,
+            state=run.state,
+            cursor_step=run.cursor_step_id,
+            data={"table_id": table_id, "outcome_token": token},
         )
 
     def _reject_v1_execution(self, command: str, run: TrailRun) -> TrailRunResult:
@@ -456,7 +552,7 @@ class TrailExecutor:
             "step_id": prepared.step_id,
             "task_family": run.task_family,
             "lineage_id": None,
-            "pr_head": None,
+            "pr_head": run.params.get("pr_head"),
             "lease_generation": None,
             "predicate_exit": command_receipt["exit_code"],
             "evidence_digest": digest_json(evidence),
@@ -814,7 +910,7 @@ class TrailExecutor:
         )
 
     def resume(self, *, run_id: str, authority_receipt_id: str) -> TrailRunResult:
-        """Refuse unverified local approvals until P4 supplies approved-source verification."""
+        """Re-fetch and durably bind authority without inventing an unsafe transition."""
         run = self.store.get_run(run_id)
         if run.spec["schema_version"] != "trailspec.v1.1":
             return self._reject_v1_execution("resume", run)
@@ -828,8 +924,19 @@ class TrailExecutor:
                 cursor_step=run.cursor_step_id,
                 error="authority receipt must be an opaque approved-source identifier, not a path",
             )
+        source_id = getattr(self.authority_resolver, "source_id", None)
+        if not isinstance(source_id, str) or not source_id.strip():
+            return TrailRunResult(
+                command="resume",
+                exit_class=ExitClass.INVALID,
+                outcome="authority_receipt_refused",
+                run_id=run_id,
+                state=run.state,
+                cursor_step=run.cursor_step_id,
+                error="approved authority resolver lacks a stable external source_id",
+            )
         try:
-            self.authority_resolver.fetch(authority_receipt_id, run)
+            receipt = self.authority_resolver.fetch(authority_receipt_id, run)
         except AuthorityReceiptUnavailableError as exc:
             return TrailRunResult(
                 command="resume",
@@ -840,14 +947,45 @@ class TrailExecutor:
                 cursor_step=run.cursor_step_id,
                 error=str(exc),
             )
+        except AuthorityReceiptError as exc:
+            return TrailRunResult(
+                command="resume",
+                exit_class=ExitClass.INVALID,
+                outcome="authority_receipt_refused",
+                run_id=run_id,
+                state=run.state,
+                cursor_step=run.cursor_step_id,
+                error=str(exc),
+            )
+        try:
+            recorded = self.store.record_authority_receipt(
+                run_id=run_id,
+                receipt=receipt,
+                source_id=source_id,
+            )
+        except (DeviationRefusedError, ReceiptChainError, TrailRunnerError) as exc:
+            latest = self.store.get_run(run_id)
+            return TrailRunResult(
+                command="resume",
+                exit_class=ExitClass.INVALID,
+                outcome="authority_receipt_refused",
+                run_id=run_id,
+                state=latest.state,
+                cursor_step=latest.cursor_step_id,
+                error=str(exc),
+            )
         return TrailRunResult(
             command="resume",
-            exit_class=ExitClass.INVALID,
-            outcome="authority_resume_unimplemented",
+            exit_class=ExitClass.STOP_PARKED,
+            outcome="authority_verified_parked",
             run_id=run_id,
-            state=run.state,
+            state="parked",
             cursor_step=run.cursor_step_id,
-            error="P4 must bind the approved authority receipt before a parked run can resume",
+            data=recorded,
+            error=(
+                "authority is verified and consumed, but TrailSpec v1.1 has no approved "
+                "resume transition or override; the summon remains parked"
+            ),
         )
 
     def _projection_payload(self, *, run_id: str, filename: str) -> dict[str, Any]:
@@ -1029,13 +1167,64 @@ class TrailExecutor:
             data=details,
         )
 
+    def _terminal_closure_evidence(
+        self, run: TrailRun
+    ) -> tuple[str, dict[str, Any], dict[str, Any], dict[str, Any]]:
+        """Return a digest of the already-verified chain and its final re-observation."""
+        invocations = self.store.list_invocations(run.run_id)
+        if not invocations:
+            raise ReceiptChainError("terminal run has no invocation evidence")
+        terminal_invocation = invocations[-1]
+        command_receipt = terminal_invocation.get("command_receipt")
+        if not isinstance(command_receipt, dict):
+            raise ReceiptChainError("terminal invocation has no command receipt")
+        step_receipt = self.store.get_step_receipt(str(terminal_invocation["invocation_id"]))
+        if not isinstance(step_receipt, dict):
+            raise ReceiptChainError("terminal invocation has no StepReceipt")
+        chain_digest = digest_json(
+            {
+                "run_id": run.run_id,
+                "trail_hash": run.trail_hash,
+                "invocations": [
+                    {
+                        "invocation_id": invocation["invocation_id"],
+                        "cursor_generation": invocation["cursor_generation"],
+                        "command_receipt_digest": invocation["command_receipt_digest"],
+                        "step_receipt_digest": digest_json(step)
+                        if isinstance(
+                            step := self.store.get_step_receipt(str(invocation["invocation_id"])),
+                            dict,
+                        )
+                        else None,
+                    }
+                    for invocation in invocations
+                ],
+            }
+        )
+        return chain_digest, terminal_invocation, command_receipt, step_receipt
+
     def close(self, *, run_id: str) -> TrailRunResult:
-        """Expose the CLI verb while refusing P4-owned closure semantics."""
+        """Close only after a complete chain and fresh external re-observation."""
         run = self.store.get_run(run_id)
         if run.spec["schema_version"] != "trailspec.v1.1":
             return self._reject_v1_execution("close", run)
         chain = self.verify_chain(run_id=run_id)
         if chain.exit_class != ExitClass.OK:
+            if run.state == "terminal" and run.closure_state != "closed":
+                parked = self.store.park_terminal_closure(
+                    run_id=run_id,
+                    reason=chain.error or "closure chain verification failed",
+                )
+                return TrailRunResult(
+                    command="close",
+                    exit_class=ExitClass.STOP_PARKED,
+                    outcome="closure_parked",
+                    run_id=run_id,
+                    state=parked.state,
+                    cursor_step=parked.cursor_step_id,
+                    data={"stop_code": "STOP-unknown", "closure_state": parked.closure_state},
+                    error=chain.error,
+                )
             return TrailRunResult(
                 command="close",
                 exit_class=ExitClass.INVALID,
@@ -1045,15 +1234,87 @@ class TrailExecutor:
                 cursor_step=run.cursor_step_id,
                 error=chain.error,
             )
+        if self.closure_gate is None:
+            return TrailRunResult(
+                command="close",
+                exit_class=ExitClass.INVALID,
+                outcome="closure_unavailable",
+                run_id=run_id,
+                state=run.state,
+                cursor_step=run.cursor_step_id,
+                error=(
+                    "closure needs a provisioned bridge/API re-observer; local state and "
+                    "receipt projections are not authority"
+                ),
+            )
+        try:
+            evidence = self._terminal_closure_evidence(run)
+            committed = self.closure_gate.close(
+                run=run,
+                chain_digest=evidence[0],
+                terminal_invocation=evidence[1],
+                terminal_command_receipt=evidence[2],
+                terminal_step_receipt=evidence[3],
+            )
+        except (ClosureError, ReceiptChainError, TrailRunnerError) as exc:
+            current = self.store.get_run(run_id)
+            if current.state == "terminal" and current.closure_state == "closed":
+                # Another closer may commit while this closer loses an external
+                # observation race. SQLite is authoritative, so return the
+                # immutable committed result rather than a false refusal.
+                try:
+                    concurrent = self.closure_gate.existing(run_id)
+                except ClosureError:
+                    concurrent = None
+                if concurrent is not None:
+                    return self._closed_result(run_id=run_id, committed=concurrent)
+            if current.state == "terminal" and current.closure_state != "closed":
+                parked = self.store.park_terminal_closure(run_id=run_id, reason=str(exc))
+                return TrailRunResult(
+                    command="close",
+                    exit_class=ExitClass.STOP_PARKED,
+                    outcome="closure_parked",
+                    run_id=run_id,
+                    state=parked.state,
+                    cursor_step=parked.cursor_step_id,
+                    data={"stop_code": "STOP-unknown", "closure_state": parked.closure_state},
+                    error=str(exc),
+                )
+            return TrailRunResult(
+                command="close",
+                exit_class=ExitClass.INVALID,
+                outcome="closure_refused",
+                run_id=run_id,
+                state=current.state,
+                cursor_step=current.cursor_step_id,
+                error=str(exc),
+            )
+
+        return self._closed_result(run_id=run_id, committed=committed)
+
+    def _closed_result(self, *, run_id: str, committed: Any) -> TrailRunResult:
+        """Project a committed closure opportunistically without revising SQLite truth."""
+        projection_warning: str | None = None
+        try:
+            self.store.project_json(
+                run_id=run_id,
+                filename="closure.json",
+                payload=committed.attestation,
+            )
+        except (OSError, TrailRunnerError) as exc:
+            # SQLite is authoritative. A failed exactly-once projection cannot
+            # roll back a committed closure or truthfully turn it into a STOP.
+            projection_warning = f"closure committed; receipt projection pending: {exc}"
         return TrailRunResult(
             command="close",
-            exit_class=ExitClass.INVALID,
-            outcome="closure_unavailable",
+            exit_class=ExitClass.OK,
+            outcome="closed",
             run_id=run_id,
-            state=run.state,
-            cursor_step=run.cursor_step_id,
-            error=(
-                "P4 closure verification is not implemented; P3 never marks a run closed "
-                "without authority, lease, head, and terminal re-observation checks"
-            ),
+            state="terminal",
+            cursor_step=None,
+            data={
+                "attestation": committed.attestation,
+                "attestation_digest": committed.attestation_digest,
+            },
+            error=projection_warning,
         )

--- a/scripts/orchestration/trails/store.py
+++ b/scripts/orchestration/trails/store.py
@@ -122,10 +122,31 @@ class TrailStore:
                     created_at TEXT NOT NULL
                 );
 
+                CREATE TABLE IF NOT EXISTS trail_authority_receipts (
+                    receipt_id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL REFERENCES trail_runs(run_id),
+                    summon_id TEXT NOT NULL UNIQUE REFERENCES trail_summons(summon_id),
+                    source_id TEXT NOT NULL,
+                    issuer TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    receipt_json TEXT NOT NULL,
+                    receipt_digest TEXT NOT NULL,
+                    consumed_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS trail_closures (
+                    run_id TEXT PRIMARY KEY REFERENCES trail_runs(run_id),
+                    attestation_json TEXT NOT NULL,
+                    attestation_digest TEXT NOT NULL,
+                    committed_at TEXT NOT NULL
+                );
+
                 CREATE INDEX IF NOT EXISTS trail_invocations_by_run
                     ON trail_invocations(run_id, cursor_generation);
                 CREATE INDEX IF NOT EXISTS trail_summons_by_run
                     ON trail_summons(run_id, created_at);
+                CREATE INDEX IF NOT EXISTS trail_authority_receipts_by_run
+                    ON trail_authority_receipts(run_id, consumed_at);
                 """
             )
 
@@ -368,6 +389,32 @@ class TrailStore:
             )
             return self._get_run_locked(connection, run_id)
 
+    def park_stop(
+        self,
+        *,
+        run_id: str,
+        expected_step: str,
+        stop_code: str,
+        reason: str,
+    ) -> TrailRun:
+        """Atomically park a current cursor for a typed STOP outcome without a command."""
+        with self._immediate_transaction() as connection:
+            run = self._get_run_locked(connection, run_id)
+            if run.state != "active" or run.cursor_step_id != expected_step:
+                raise DeviationRefusedError(
+                    f"expected active current step '{expected_step}', found "
+                    f"state={run.state!r} cursor={run.cursor_step_id!r}"
+                )
+            self._park_locked(
+                connection,
+                run=run,
+                stop_code=stop_code,
+                reason=reason,
+                invocation_id=None,
+                summon_state="stop",
+            )
+            return self._get_run_locked(connection, run_id)
+
     def complete_invocation(
         self,
         *,
@@ -561,6 +608,202 @@ class TrailStore:
                 (run_id,),
             ).fetchall()
         return [dict(row) for row in rows]
+
+    def record_authority_receipt(
+        self,
+        *,
+        run_id: str,
+        receipt: dict[str, Any],
+        source_id: str,
+    ) -> dict[str, Any]:
+        """Consume one externally re-fetched receipt exactly once without inventing a transition.
+
+        P1/P3 deliberately have no resume-transition/override field.  This method
+        records the verified authority in the same transaction that consumes its
+        precise summon, but leaves the run parked until a later approved trail
+        contract supplies an executable transition.
+        """
+        receipt_id = receipt.get("receipt_id")
+        summon_id = receipt.get("summon_id")
+        if not isinstance(receipt_id, str) or not isinstance(summon_id, str):
+            raise TrailRunnerError("verified authority receipt lacks receipt_id or summon_id")
+        with self._immediate_transaction() as connection:
+            run = self._get_run_locked(connection, run_id)
+            if run.state != "parked":
+                raise DeviationRefusedError("authority receipt can only bind a currently parked run")
+            expected = {
+                "run_id": run.run_id,
+                "trail_id": run.trail_id,
+                "trail_version": run.trail_version,
+                "trail_hash": run.trail_hash,
+                "step_id": run.cursor_step_id,
+                "cursor_generation": run.cursor_generation,
+            }
+            for field, value in expected.items():
+                if receipt.get(field) != value:
+                    raise DeviationRefusedError(
+                        f"authority receipt {field} no longer binds the parked run"
+                    )
+            summon = connection.execute(
+                """
+                SELECT stop_code, authority_receipt_id FROM trail_summons
+                WHERE summon_id = ? AND run_id = ?
+                """,
+                (summon_id, run_id),
+            ).fetchone()
+            if summon is None:
+                raise DeviationRefusedError("authority receipt does not name a summon for this run")
+            if summon["authority_receipt_id"] is not None:
+                raise DeviationRefusedError("summon already has a consumed authority receipt")
+            if summon["stop_code"] != receipt.get("stop_code"):
+                raise DeviationRefusedError("authority receipt STOP code differs from summon")
+            now = utc_now()
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO trail_authority_receipts (
+                        receipt_id, run_id, summon_id, source_id, issuer, expires_at,
+                        receipt_json, receipt_digest, consumed_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        receipt_id,
+                        run_id,
+                        summon_id,
+                        source_id,
+                        receipt["issuer"],
+                        receipt["expires_at"],
+                        canonical_json(receipt),
+                        digest_json(receipt),
+                        now,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise DeviationRefusedError("authority receipt has already been consumed") from exc
+            updated = connection.execute(
+                """
+                UPDATE trail_summons
+                SET authority_receipt_id = ?, state = 'authority-verified'
+                WHERE summon_id = ? AND run_id = ? AND authority_receipt_id IS NULL
+                """,
+                (receipt_id, summon_id, run_id),
+            )
+            if updated.rowcount != 1:
+                raise ReceiptChainError("authority receipt summon consumption raced another writer")
+            return {
+                "receipt_id": receipt_id,
+                "summon_id": summon_id,
+                "receipt_digest": digest_json(receipt),
+                "source_id": source_id,
+            }
+
+    def list_authority_receipts(self, run_id: str) -> list[dict[str, Any]]:
+        """Return durably consumed authority evidence for closure re-observation."""
+        with closing(self._connect()) as connection:
+            self._get_run_locked(connection, run_id)
+            rows = connection.execute(
+                """
+                SELECT receipt_id, summon_id, source_id, issuer, expires_at, receipt_json,
+                       receipt_digest, consumed_at
+                FROM trail_authority_receipts WHERE run_id = ? ORDER BY consumed_at ASC
+                """,
+                (run_id,),
+            ).fetchall()
+        return [
+            {
+                **dict(row),
+                "receipt": json.loads(str(row["receipt_json"])),
+            }
+            for row in rows
+        ]
+
+    def get_closure(self, run_id: str) -> dict[str, Any] | None:
+        """Return the one immutable closure attestation, if terminal commit occurred."""
+        with closing(self._connect()) as connection:
+            self._get_run_locked(connection, run_id)
+            row = connection.execute(
+                "SELECT attestation_json, attestation_digest, committed_at FROM trail_closures WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "attestation": json.loads(str(row["attestation_json"])),
+            "attestation_digest": str(row["attestation_digest"]),
+            "committed_at": str(row["committed_at"]),
+        }
+
+    def commit_closure(self, *, run_id: str, attestation: dict[str, Any]) -> dict[str, Any]:
+        """Terminally commit exactly one immutable closure attestation or replay it."""
+        digest = digest_json(attestation)
+        with self._immediate_transaction() as connection:
+            run = self._get_run_locked(connection, run_id)
+            existing = connection.execute(
+                "SELECT attestation_json, attestation_digest, committed_at FROM trail_closures WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+            if existing is not None:
+                # A second closer can independently re-observe the same terminal
+                # state a few microseconds later. The first committed immutable
+                # attestation is authoritative; returning it prevents a timestamp
+                # difference from turning an idempotent terminal replay into a
+                # competing closure claim.
+                return {
+                    "attestation": json.loads(str(existing["attestation_json"])),
+                    "attestation_digest": str(existing["attestation_digest"]),
+                    "committed_at": str(existing["committed_at"]),
+                }
+            if run.state != "terminal" or not run.terminal_outcome:
+                raise DeviationRefusedError("only a terminal run can commit closure")
+            now = utc_now()
+            connection.execute(
+                """
+                INSERT INTO trail_closures (run_id, attestation_json, attestation_digest, committed_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (run_id, canonical_json(attestation), digest, now),
+            )
+            connection.execute(
+                "UPDATE trail_runs SET closure_state = 'closed', updated_at = ? WHERE run_id = ?",
+                (now, run_id),
+            )
+            return {
+                "attestation": attestation,
+                "attestation_digest": digest,
+                "committed_at": now,
+            }
+
+    def park_terminal_closure(self, *, run_id: str, reason: str) -> TrailRun:
+        """Atomically park closure while preserving the terminal command chain."""
+        with self._immediate_transaction() as connection:
+            run = self._get_run_locked(connection, run_id)
+            if run.state != "terminal":
+                raise DeviationRefusedError("only terminal runs can park closure")
+            if run.closure_state == "closed":
+                raise DeviationRefusedError("closed run cannot be re-parked for closure")
+            now = utc_now()
+            summon_id = digest_json(
+                {
+                    "kind": "closure",
+                    "run_id": run_id,
+                    "cursor_generation": run.cursor_generation,
+                    "reason": reason,
+                }
+            )
+            connection.execute(
+                """
+                INSERT OR IGNORE INTO trail_summons (
+                    summon_id, run_id, invocation_id, stop_code, reason, state,
+                    authority_receipt_id, created_at
+                ) VALUES (?, ?, NULL, 'STOP-unknown', ?, 'closure', NULL, ?)
+                """,
+                (summon_id, run_id, reason, now),
+            )
+            connection.execute(
+                "UPDATE trail_runs SET closure_state = 'parked', updated_at = ? WHERE run_id = ?",
+                (now, run_id),
+            )
+            return self._get_run_locked(connection, run_id)
 
     def project_json(self, *, run_id: str, filename: str, payload: dict[str, Any]) -> Path:
         """Write a receipt projection exactly once, rejecting mismatched replacements."""

--- a/tests/test_trail_authority.py
+++ b/tests/test_trail_authority.py
@@ -1,0 +1,392 @@
+"""P4 authority receipts: external re-fetch, state binding, and replay refusal."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.orchestration.trails import authority as authority_module
+from scripts.orchestration.trails.authority import (
+    ApprovedAuthorityReceiptResolver,
+    AuthorityReceiptError,
+)
+from scripts.orchestration.trails.executor import TrailExecutor, TrailPredicatesDecisionTableEvaluator
+from scripts.orchestration.trails.models import CommandExecution, DeviationRefusedError, ExitClass
+from scripts.orchestration.trails.store import TrailStore
+
+
+def _trail(*, terminal: bool = False) -> dict[str, Any]:
+    target = "done" if terminal else "STOP-unknown"
+    return {
+        "schema_version": "trailspec.v1.1",
+        "trail_id": "authority-fixture",
+        "version": "1.1.0",
+        "title": "authority fixture",
+        "seats": ["grok-daily"],
+        "parameters": {},
+        "stop_codes": ["STOP-unknown"],
+        "terminal_outcomes": ["done"],
+        "steps": [
+            {
+                "step_id": "start",
+                "intent": "observe one token",
+                "command": {
+                    "adapter": "shell",
+                    "argv": ["sh", "-c", "printf accepted"],
+                    "environment": {"TRAIL_INVOCATION_ID": "{invocation_id}"},
+                    "timeout_seconds": 30,
+                    "mutation_class": "observe",
+                    "outcome_decoder": {"source": "stdout-token"},
+                },
+                "transitions": {
+                    "accepted": {
+                        "target": target,
+                        "evidence": {
+                            "predicate_id": "accepted-outcome",
+                            "clauses": [
+                                {
+                                    "source": "command_receipt",
+                                    "field": "actor_outcome",
+                                    "op": "eq",
+                                    "value": "accepted",
+                                }
+                            ],
+                        },
+                    }
+                },
+            }
+        ],
+    }
+
+
+def _write_trail(tmp_path: Path, trail: dict[str, Any]) -> Path:
+    path = tmp_path / "authority.trail.yaml"
+    path.write_text(yaml.safe_dump(trail, sort_keys=False), encoding="utf-8")
+    return path
+
+
+class _AuthoritySource:
+    source_id = "fleet-api"
+    source_kind = "api"
+
+    def __init__(self, receipts: dict[str, dict[str, Any]]) -> None:
+        self.receipts = receipts
+        self.calls: list[str] = []
+
+    def fetch_authority_receipt(self, receipt_id: str) -> dict[str, Any]:
+        self.calls.append(receipt_id)
+        return copy.deepcopy(self.receipts[receipt_id])
+
+
+class _TypedFailingAuthoritySource(_AuthoritySource):
+    def fetch_authority_receipt(self, receipt_id: str) -> dict[str, Any]:
+        raise AuthorityReceiptError("authority source revoked this receipt")
+
+
+class _LeaseObserver:
+    def __init__(self) -> None:
+        self.current: dict[str, Any] = {}
+
+    def observe_lease(self, run) -> dict[str, Any]:
+        return copy.deepcopy(self.current)
+
+
+class _ResolverWithoutSourceIdentity:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def fetch(self, authority_receipt_id: str, run) -> dict[str, Any]:
+        self.calls.append(authority_receipt_id)
+        return {}
+
+
+def _executor(
+    tmp_path: Path,
+    *,
+    authority_resolver: ApprovedAuthorityReceiptResolver | None = None,
+) -> TrailExecutor:
+    seats = tmp_path / "fleet.yaml"
+    seats.write_text(
+        yaml.safe_dump({"endpoints": [{"name": "grok-daily", "state": "live"}]}),
+        encoding="utf-8",
+    )
+    return TrailExecutor(
+        TrailStore(tmp_path / "runs.sqlite3", tmp_path / "receipts"),
+        project_root=tmp_path,
+        seat_registry_path=seats,
+        command_runner=lambda command, cwd: CommandExecution(0, "accepted", ""),
+        authority_resolver=authority_resolver,
+    )
+
+
+def _begin_and_park(executor: TrailExecutor, tmp_path: Path) -> str:
+    begun = executor.begin(
+        trail_path=_write_trail(tmp_path, _trail()),
+        seat="grok-daily",
+        task_family="infra-orchestration",
+        params={},
+    )
+    assert begun.run_id is not None
+    parked = executor.step(run_id=begun.run_id, expected_step="start")
+    assert parked.exit_class == ExitClass.STOP_PARKED
+    return begun.run_id
+
+
+def _receipt(executor: TrailExecutor, run_id: str) -> dict[str, Any]:
+    run = executor.store.get_run(run_id)
+    summon = executor.store.list_summons(run_id)[0]
+    return {
+        "schema_version": "trail-authority-receipt.v1",
+        "receipt_id": "approval-1",
+        "issuer": "operator-seat",
+        "issued_at": "2026-07-28T00:00:00Z",
+        "expires_at": "2030-07-28T00:00:00Z",
+        "action": "resume",
+        "run_id": run.run_id,
+        "trail_id": run.trail_id,
+        "trail_version": run.trail_version,
+        "trail_hash": run.trail_hash,
+        "summon_id": summon["summon_id"],
+        "stop_code": summon["stop_code"],
+        "step_id": run.cursor_step_id,
+        "cursor_generation": run.cursor_generation,
+        "lease_id": "lease-1",
+        "lease_generation": 4,
+        "fencing_token": "fence-4",
+        "pr_head": None,
+    }
+
+
+def test_resume_refetches_and_consumes_one_state_bound_external_receipt(tmp_path: Path) -> None:
+    lease = _LeaseObserver()
+    source = _AuthoritySource({})
+    resolver = ApprovedAuthorityReceiptResolver(
+        source,
+        lease,
+        approved_issuers={"operator-seat"},
+    )
+    executor = _executor(tmp_path, authority_resolver=resolver)
+    run_id = _begin_and_park(executor, tmp_path)
+    receipt = _receipt(executor, run_id)
+    source.receipts[receipt["receipt_id"]] = receipt
+    lease.current = {
+        "run_id": run_id,
+        "step_id": "start",
+        "lease_id": "lease-1",
+        "lease_generation": 4,
+        "fencing_token": "fence-4",
+        "pr_head": None,
+    }
+
+    result = executor.resume(run_id=run_id, authority_receipt_id="approval-1")
+
+    assert result.exit_class == ExitClass.STOP_PARKED
+    assert result.outcome == "authority_verified_parked"
+    assert source.calls == ["approval-1"]
+    assert executor.store.get_run(run_id).state == "parked"
+    assert executor.store.list_summons(run_id)[0]["authority_receipt_id"] == "approval-1"
+    assert [row["receipt_id"] for row in executor.store.list_authority_receipts(run_id)] == [
+        "approval-1"
+    ]
+    assert executor.store.list_authority_receipts(run_id)[0]["source_id"] == "fleet-api"
+
+    replay = executor.resume(run_id=run_id, authority_receipt_id="approval-1")
+
+    assert replay.exit_class == ExitClass.INVALID
+    assert replay.outcome == "authority_receipt_refused"
+    assert len(executor.store.list_authority_receipts(run_id)) == 1
+
+
+def test_local_path_and_stale_lease_are_refused_without_consuming_a_summon(tmp_path: Path) -> None:
+    lease = _LeaseObserver()
+    source = _AuthoritySource({})
+    resolver = ApprovedAuthorityReceiptResolver(
+        source,
+        lease,
+        approved_issuers={"operator-seat"},
+    )
+    executor = _executor(tmp_path, authority_resolver=resolver)
+    run_id = _begin_and_park(executor, tmp_path)
+    before = executor.store.list_summons(run_id)
+    local_receipt = tmp_path / "approval.json"
+    local_receipt.write_text("{}", encoding="utf-8")
+
+    local = executor.resume(run_id=run_id, authority_receipt_id=str(local_receipt))
+
+    assert local.exit_class == ExitClass.INVALID
+    assert local.outcome == "authority_receipt_refused"
+    assert source.calls == []
+    assert executor.store.list_summons(run_id) == before
+
+    receipt = _receipt(executor, run_id)
+    source.receipts[receipt["receipt_id"]] = receipt
+    lease.current = {
+        "run_id": run_id,
+        "step_id": "start",
+        "lease_id": "lease-1",
+        "lease_generation": 3,
+        "fencing_token": "fence-3",
+        "pr_head": None,
+    }
+
+    stale = executor.resume(run_id=run_id, authority_receipt_id="approval-1")
+
+    assert stale.exit_class == ExitClass.INVALID
+    assert stale.outcome == "authority_receipt_refused"
+    assert executor.store.list_summons(run_id) == before
+    assert executor.store.list_authority_receipts(run_id) == []
+
+
+def test_resume_refuses_a_resolver_without_stable_external_source_identity(tmp_path: Path) -> None:
+    resolver = _ResolverWithoutSourceIdentity()
+    executor = _executor(tmp_path, authority_resolver=resolver)  # type: ignore[arg-type]
+    run_id = _begin_and_park(executor, tmp_path)
+
+    result = executor.resume(run_id=run_id, authority_receipt_id="approval-1")
+
+    assert result.exit_class == ExitClass.INVALID
+    assert result.outcome == "authority_receipt_refused"
+    assert result.error == "approved authority resolver lacks a stable external source_id"
+    assert resolver.calls == []
+    assert executor.store.list_authority_receipts(run_id) == []
+
+
+def test_unapproved_issuer_is_a_mutation_honest_refusal(tmp_path: Path) -> None:
+    lease = _LeaseObserver()
+    source = _AuthoritySource({})
+    resolver = ApprovedAuthorityReceiptResolver(
+        source,
+        lease,
+        approved_issuers={"operator-seat"},
+    )
+    executor = _executor(tmp_path, authority_resolver=resolver)
+    run_id = _begin_and_park(executor, tmp_path)
+    receipt = _receipt(executor, run_id)
+    receipt["issuer"] = "forged-local-issuer"
+    source.receipts[receipt["receipt_id"]] = receipt
+    lease.current = {
+        "run_id": run_id,
+        "step_id": "start",
+        "lease_id": "lease-1",
+        "lease_generation": 4,
+        "fencing_token": "fence-4",
+        "pr_head": None,
+    }
+
+    result = executor.resume(run_id=run_id, authority_receipt_id="approval-1")
+
+    assert result.exit_class == ExitClass.INVALID
+    assert result.outcome == "authority_receipt_refused"
+    assert executor.store.get_run(run_id).state == "parked"
+    assert executor.store.list_authority_receipts(run_id) == []
+
+
+def test_authority_revalidation_preserves_typed_source_failure_detail(tmp_path: Path) -> None:
+    source = _TypedFailingAuthoritySource({})
+    resolver = ApprovedAuthorityReceiptResolver(
+        source,
+        _LeaseObserver(),
+        approved_issuers={"operator-seat"},
+    )
+    executor = _executor(tmp_path, authority_resolver=resolver)
+    run_id = _begin_and_park(executor, tmp_path)
+
+    with pytest.raises(AuthorityReceiptError, match="authority source revoked this receipt"):
+        resolver.revalidate(_receipt(executor, run_id))
+
+
+def test_authority_schema_validator_loads_once_without_caching_receipt_payloads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _executor(tmp_path)
+    run_id = _begin_and_park(executor, tmp_path)
+    receipt = _receipt(executor, run_id)
+    schema_path = authority_module.AUTHORITY_RECEIPT_SCHEMA_PATH
+
+    class _CountingSchemaPath:
+        reads = 0
+
+        def read_text(self, *, encoding: str) -> str:
+            self.reads += 1
+            return schema_path.read_text(encoding=encoding)
+
+    counter = _CountingSchemaPath()
+    monkeypatch.setattr(authority_module, "AUTHORITY_RECEIPT_SCHEMA_PATH", counter)
+    monkeypatch.setattr(authority_module, "_AUTHORITY_RECEIPT_VALIDATOR", None)
+
+    assert authority_module.validate_authority_receipt_data(receipt) == receipt
+    assert authority_module.validate_authority_receipt_data(receipt) == receipt
+    assert counter.reads == 1
+
+
+def test_executor_table_seam_parks_p2_unknown_without_running_a_command(tmp_path: Path) -> None:
+    executor = _executor(tmp_path)
+    begun = executor.begin(
+        trail_path=_write_trail(tmp_path, _trail(terminal=True)),
+        seat="grok-daily",
+        task_family="infra-orchestration",
+        params={},
+    )
+    assert begun.run_id is not None
+
+    result = executor.evaluate_decision_table(
+        run_id=begun.run_id,
+        expected_step="start",
+        table_id="queue-pick",
+        facts={
+            "is_foreign_lane": False,
+            "has_sibling_pr": False,
+            "queue_order_derivable": True,
+            "dependencies_merged": False,
+        },
+    )
+
+    assert result.exit_class == ExitClass.STOP_PARKED
+    assert result.data == {"table_id": "queue-pick", "stop_code": "STOP-unknown"}
+    assert executor.store.list_invocations(begun.run_id) == []
+    assert len(executor.store.list_summons(begun.run_id)) == 1
+
+
+def test_executor_table_stop_race_returns_typed_deviation_refusal(tmp_path: Path) -> None:
+    executor = _executor(tmp_path)
+    begun = executor.begin(
+        trail_path=_write_trail(tmp_path, _trail(terminal=True)),
+        seat="grok-daily",
+        task_family="infra-orchestration",
+        params={},
+    )
+    assert begun.run_id is not None
+
+    def _raced_park_stop(**kwargs: Any) -> None:
+        raise DeviationRefusedError("cursor changed before decision-table STOP parking")
+
+    executor.store.park_stop = _raced_park_stop  # type: ignore[method-assign]
+    result = executor.evaluate_decision_table(
+        run_id=begun.run_id,
+        expected_step="start",
+        table_id="queue-pick",
+        facts={
+            "is_foreign_lane": False,
+            "has_sibling_pr": False,
+            "queue_order_derivable": True,
+            "dependencies_merged": False,
+        },
+    )
+
+    assert result.exit_class == ExitClass.DEVIATION_REFUSED
+    assert result.outcome == "deviation_refused"
+    assert result.state == "active"
+    assert result.cursor_step == "start"
+
+
+def test_decision_table_file_is_loaded_only_when_the_seam_is_used(tmp_path: Path) -> None:
+    evaluator = TrailPredicatesDecisionTableEvaluator(tmp_path / "missing-decision-tables.yaml")
+
+    assert evaluator.tables is None
+    with pytest.raises(FileNotFoundError):
+        evaluator.evaluate("queue-pick", {})

--- a/tests/test_trail_closure.py
+++ b/tests/test_trail_closure.py
@@ -1,0 +1,309 @@
+"""P4 closure: re-observe terminal state before the one SQLite closure commit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.orchestration.trails import closure as closure_module
+from scripts.orchestration.trails.closure import ClosureError, TrailClosureGate
+from scripts.orchestration.trails.executor import TrailExecutor
+from scripts.orchestration.trails.models import CommandExecution, ExitClass
+from scripts.orchestration.trails.store import TrailStore
+
+
+def _trail(*, pr_bound: bool = False) -> dict[str, Any]:
+    return {
+        "schema_version": "trailspec.v1.1",
+        "trail_id": "closure-fixture",
+        "version": "1.1.0",
+        "title": "closure fixture",
+        "seats": ["grok-daily"],
+        "parameters": {"pr_head": "string"} if pr_bound else {},
+        "stop_codes": ["STOP-unknown"],
+        "terminal_outcomes": ["done"],
+        "steps": [
+            {
+                "step_id": "observe-terminal",
+                "intent": "terminal re-observation",
+                "command": {
+                    "adapter": "shell",
+                    "argv": ["sh", "-c", "printf accepted"],
+                    "environment": {"TRAIL_INVOCATION_ID": "{invocation_id}"},
+                    "timeout_seconds": 30,
+                    "mutation_class": "observe",
+                    "outcome_decoder": {"source": "stdout-token"},
+                },
+                "transitions": {
+                    "accepted": {
+                        "target": "done",
+                        "evidence": {
+                            "predicate_id": "accepted-outcome",
+                            "clauses": [
+                                {
+                                    "source": "command_receipt",
+                                    "field": "actor_outcome",
+                                    "op": "eq",
+                                    "value": "accepted",
+                                }
+                            ],
+                        },
+                    }
+                },
+            }
+        ],
+    }
+
+
+class _TerminalSource:
+    source_id = "fleet-bridge"
+    source_kind = "bridge"
+
+    def __init__(self, *, lease_current: bool = True, pr_head: str | None = None) -> None:
+        self.lease_current = lease_current
+        self.pr_head = pr_head
+        self.calls = 0
+
+    def reobserve_terminal(
+        self,
+        *,
+        run,
+        terminal_command_receipt: dict[str, Any],
+        terminal_step_receipt: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls += 1
+        return {
+            "observation_id": "observe-1",
+            "observed_at": "2026-07-28T00:00:00Z",
+            "run_id": run.run_id,
+            "trail_id": run.trail_id,
+            "trail_hash": run.trail_hash,
+            "terminal_outcome": run.terminal_outcome,
+            "lease_id": "lease-1",
+            "lease_generation": 4,
+            "fencing_token": "fence-4",
+            "pr_head": self.pr_head,
+            "lease_current": self.lease_current,
+            "terminal_observed": True,
+        }
+
+
+class _CommitThenFailGate(TrailClosureGate):
+    """Simulate a second closer committing while this closer loses its response."""
+
+    def close(self, **kwargs):
+        super().close(**kwargs)
+        raise ClosureError("this closer lost the concurrent commit response")
+
+
+class _TypedFailingTerminalSource(_TerminalSource):
+    def reobserve_terminal(
+        self,
+        *,
+        run,
+        terminal_command_receipt: dict[str, Any],
+        terminal_step_receipt: dict[str, Any],
+    ) -> dict[str, Any]:
+        raise ClosureError("terminal bridge revoked the observation")
+
+
+def _executor(tmp_path: Path, source: _TerminalSource) -> TrailExecutor:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    seats = tmp_path / "fleet.yaml"
+    seats.write_text(
+        yaml.safe_dump({"endpoints": [{"name": "grok-daily", "state": "live"}]}),
+        encoding="utf-8",
+    )
+    store = TrailStore(tmp_path / "runs.sqlite3", tmp_path / "receipts")
+    return TrailExecutor(
+        store,
+        project_root=tmp_path,
+        seat_registry_path=seats,
+        command_runner=lambda command, cwd: CommandExecution(0, "accepted", ""),
+        closure_gate=TrailClosureGate(store, source),
+    )
+
+
+def _terminal_run(
+    executor: TrailExecutor,
+    tmp_path: Path,
+    *,
+    pr_head: str | None = None,
+) -> str:
+    trail_path = tmp_path / "closure.trail.yaml"
+    trail_path.write_text(
+        yaml.safe_dump(_trail(pr_bound=pr_head is not None), sort_keys=False),
+        encoding="utf-8",
+    )
+    begun = executor.begin(
+        trail_path=trail_path,
+        seat="grok-daily",
+        task_family="infra-orchestration",
+        params={"pr_head": pr_head} if pr_head is not None else {},
+    )
+    assert begun.run_id is not None
+    terminal = executor.step(run_id=begun.run_id, expected_step="observe-terminal")
+    assert terminal.outcome == "terminal"
+    return begun.run_id
+
+
+def test_close_commits_once_and_terminal_replay_does_not_reobserve(tmp_path: Path) -> None:
+    source = _TerminalSource()
+    executor = _executor(tmp_path, source)
+    run_id = _terminal_run(executor, tmp_path)
+
+    first = executor.close(run_id=run_id)
+    replay = executor.close(run_id=run_id)
+
+    assert first.exit_class == ExitClass.OK
+    assert first.outcome == "closed"
+    assert replay.to_dict() == first.to_dict()
+    assert source.calls == 1
+    assert executor.store.get_run(run_id).closure_state == "closed"
+    assert executor.store.get_closure(run_id) is not None
+    assert executor.store.projection_path(run_id=run_id, filename="closure.json").is_file()
+
+
+def test_stale_lease_parks_closure_atomically_without_changing_terminal_state(tmp_path: Path) -> None:
+    source = _TerminalSource(lease_current=False)
+    executor = _executor(tmp_path, source)
+    run_id = _terminal_run(executor, tmp_path)
+
+    result = executor.close(run_id=run_id)
+
+    run = executor.store.get_run(run_id)
+    assert result.exit_class == ExitClass.STOP_PARKED
+    assert result.outcome == "closure_parked"
+    assert run.state == "terminal"
+    assert run.closure_state == "parked"
+    summons = executor.store.list_summons(run_id)
+    assert len(summons) == 1
+    assert summons[0]["state"] == "closure"
+    assert executor.store.get_closure(run_id) is None
+
+    source.lease_current = True
+    retried = executor.close(run_id=run_id)
+
+    assert retried.exit_class == ExitClass.OK
+    assert executor.store.get_run(run_id).closure_state == "closed"
+    assert source.calls == 2
+
+
+def test_closure_preserves_a_typed_terminal_source_failure_detail(tmp_path: Path) -> None:
+    source = _TypedFailingTerminalSource()
+    executor = _executor(tmp_path, source)
+    run_id = _terminal_run(executor, tmp_path)
+
+    result = executor.close(run_id=run_id)
+
+    assert result.exit_class == ExitClass.STOP_PARKED
+    assert result.error == "terminal bridge revoked the observation"
+    assert executor.store.get_run(run_id).closure_state == "parked"
+
+
+def test_closure_schema_validator_loads_once_without_caching_attestations(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = _TerminalSource()
+    executor = _executor(tmp_path, source)
+    run_id = _terminal_run(executor, tmp_path)
+    attestation = executor.close(run_id=run_id).data["attestation"]
+    schema_path = closure_module.CLOSURE_ATTESTATION_SCHEMA_PATH
+
+    class _CountingSchemaPath:
+        reads = 0
+
+        def read_text(self, *, encoding: str) -> str:
+            self.reads += 1
+            return schema_path.read_text(encoding=encoding)
+
+    counter = _CountingSchemaPath()
+    monkeypatch.setattr(closure_module, "CLOSURE_ATTESTATION_SCHEMA_PATH", counter)
+    monkeypatch.setattr(closure_module, "_CLOSURE_ATTESTATION_VALIDATOR", None)
+
+    assert closure_module.validate_closure_attestation_data(attestation) == attestation
+    assert closure_module.validate_closure_attestation_data(attestation) == attestation
+    assert counter.reads == 1
+
+
+def test_stale_head_and_incomplete_projection_refuse_with_terminal_closure_parking(
+    tmp_path: Path,
+) -> None:
+    fresh_source = _TerminalSource(pr_head="a" * 40)
+    fresh_executor = _executor(tmp_path / "fresh", fresh_source)
+    fresh_run_id = _terminal_run(fresh_executor, tmp_path / "fresh", pr_head="a" * 40)
+
+    fresh = fresh_executor.close(run_id=fresh_run_id)
+
+    assert fresh.exit_class == ExitClass.OK
+    assert fresh.data["attestation"]["pr_head"] == "a" * 40
+
+    head_source = _TerminalSource(pr_head="b" * 40)
+    head_executor = _executor(tmp_path / "head", head_source)
+    head_run_id = _terminal_run(head_executor, tmp_path / "head", pr_head="a" * 40)
+
+    stale_head = head_executor.close(run_id=head_run_id)
+
+    assert stale_head.exit_class == ExitClass.STOP_PARKED
+    assert head_executor.store.get_run(head_run_id).closure_state == "parked"
+
+    chain_source = _TerminalSource()
+    chain_executor = _executor(tmp_path / "chain", chain_source)
+    chain_run_id = _terminal_run(chain_executor, tmp_path / "chain")
+    invocation = chain_executor.store.list_invocations(chain_run_id)[0]
+    command_path = chain_executor.store.projection_path(
+        run_id=chain_run_id,
+        filename=f"command-000000-{invocation['invocation_id']}.json",
+    )
+    command_path.write_text("{}\n", encoding="utf-8")
+
+    incomplete = chain_executor.close(run_id=chain_run_id)
+
+    assert incomplete.exit_class == ExitClass.STOP_PARKED
+    assert incomplete.outcome == "closure_parked"
+    assert chain_source.calls == 0
+    assert chain_executor.store.get_run(chain_run_id).state == "terminal"
+    assert chain_executor.store.get_run(chain_run_id).closure_state == "parked"
+
+
+def test_projection_failure_after_commit_keeps_closed_result_and_retries_later(tmp_path: Path) -> None:
+    source = _TerminalSource()
+    executor = _executor(tmp_path, source)
+    run_id = _terminal_run(executor, tmp_path)
+    projection = executor.store.projection_path(run_id=run_id, filename="closure.json")
+    projection.parent.mkdir(parents=True, exist_ok=True)
+    projection.write_text("{}\n", encoding="utf-8")
+
+    committed = executor.close(run_id=run_id)
+
+    assert committed.exit_class == ExitClass.OK
+    assert committed.outcome == "closed"
+    assert committed.error is not None
+    assert executor.store.get_run(run_id).closure_state == "closed"
+    assert source.calls == 1
+
+    projection.unlink()
+    replay = executor.close(run_id=run_id)
+
+    assert replay.exit_class == ExitClass.OK
+    assert replay.error is None
+    assert source.calls == 1
+    assert projection.is_file()
+
+
+def test_concurrent_committed_closure_is_reported_as_closed_not_refused(tmp_path: Path) -> None:
+    source = _TerminalSource()
+    executor = _executor(tmp_path, source)
+    executor.closure_gate = _CommitThenFailGate(executor.store, source)
+    run_id = _terminal_run(executor, tmp_path)
+
+    result = executor.close(run_id=run_id)
+
+    assert result.exit_class == ExitClass.OK
+    assert result.outcome == "closed"
+    assert executor.store.get_run(run_id).closure_state == "closed"
+    assert executor.store.get_closure(run_id) is not None
+    assert executor.store.projection_path(run_id=run_id, filename="closure.json").is_file()

--- a/tests/test_trail_closure.py
+++ b/tests/test_trail_closure.py
@@ -307,3 +307,77 @@ def test_concurrent_committed_closure_is_reported_as_closed_not_refused(tmp_path
     assert executor.store.get_run(run_id).closure_state == "closed"
     assert executor.store.get_closure(run_id) is not None
     assert executor.store.projection_path(run_id=run_id, filename="closure.json").is_file()
+
+
+class _FailingCloseGate(TrailClosureGate):
+    """Lose the closure response without committing (a second closer will win)."""
+
+    def close(self, **kwargs):
+        raise ClosureError("this closer lost its observation response")
+
+
+def _commit_closure_as_concurrent_winner(
+    executor: TrailExecutor, source: _TerminalSource, run_id: str
+) -> None:
+    """Commit the closure the way a second, racing closer would."""
+    run = executor.store.get_run(run_id)
+    evidence = executor._terminal_closure_evidence(run)
+    TrailClosureGate(executor.store, source).close(
+        run=run,
+        chain_digest=evidence[0],
+        terminal_invocation=evidence[1],
+        terminal_command_receipt=evidence[2],
+        terminal_step_receipt=evidence[3],
+    )
+
+
+def _install_losing_park(executor: TrailExecutor, source: _TerminalSource) -> None:
+    """Make park_terminal_closure lose the check-then-park race deterministically."""
+    original_park = executor.store.park_terminal_closure
+
+    def _losing_park(*, run_id: str, reason: str):
+        _commit_closure_as_concurrent_winner(executor, source, run_id)
+        return original_park(run_id=run_id, reason=reason)
+
+    executor.store.park_terminal_closure = _losing_park  # type: ignore[method-assign]
+
+
+def test_park_race_after_gate_error_returns_closed_result_not_crash(tmp_path: Path) -> None:
+    """A concurrent closer committing between the closed-check and the park call
+    inside close()'s except handler must yield the closed result, not an escaped
+    DeviationRefusedError (r7 F001)."""
+    source = _TerminalSource()
+    executor = _executor(tmp_path, source)
+    executor.closure_gate = _FailingCloseGate(executor.store, source)
+    run_id = _terminal_run(executor, tmp_path)
+    _install_losing_park(executor, source)
+
+    result = executor.close(run_id=run_id)
+
+    assert result.exit_class == ExitClass.OK
+    assert result.outcome == "closed"
+    assert executor.store.get_run(run_id).closure_state == "closed"
+    assert executor.store.get_closure(run_id) is not None
+
+
+def test_park_race_on_invalid_chain_returns_closed_result_not_crash(tmp_path: Path) -> None:
+    """The invalid-chain park site races the same way: a concurrent commit between
+    close()'s stale run snapshot and the park call must yield a typed result, not
+    an escaped DeviationRefusedError (r7 F002)."""
+    source = _TerminalSource()
+    executor = _executor(tmp_path, source)
+    run_id = _terminal_run(executor, tmp_path)
+    invocation = executor.store.list_invocations(run_id)[0]
+    command_path = executor.store.projection_path(
+        run_id=run_id,
+        filename=f"command-000000-{invocation['invocation_id']}.json",
+    )
+    command_path.write_text("{}\n", encoding="utf-8")
+    _install_losing_park(executor, source)
+
+    result = executor.close(run_id=run_id)
+
+    assert result.exit_class == ExitClass.OK
+    assert result.outcome == "closed"
+    assert executor.store.get_run(run_id).closure_state == "closed"
+    assert executor.store.get_closure(run_id) is not None


### PR DESCRIPTION
Refs #5885

Implements memo §2 and §5-P4.

- Authority receipt IDs are re-fetched only from provisioned bridge/API sources, schema-validated, lease/head-bound, source-identified, and consumed once in SQLite. Raw local JSON paths are refused.
- Closure reuses the complete pinned-chain check, re-observes terminal state from a provisioned bridge/API source, validates lease/fence/head and authority evidence, then commits an immutable attestation. Failed terminal closure guards atomically park closure while preserving the terminal run for a fresh re-observation.
- The P2 decision-table executor seam now returns typed outcomes and atomically parks STOP-unknown for zero/multi/invalid matches.

Evidence (cwd: dispatch worktree):
- `.venv/bin/python -m pytest -q tests/test_trail_authority.py tests/test_trail_closure.py tests/test_trail_runner.py tests/test_trail_predicates.py tests/test_validate_trailspec.py` → `110 passed in 6.63s`.
- `.venv/bin/ruff check …` → `All checks passed!`; `.venv/bin/python scripts/audit/lint_opsec_leaks.py` → `Zero leaks detected.`

Guard reasoning: a P1/P3 receipt has no approved resume transition or override, so a verified authority receipt is consumed but leaves the summon parked; unpark/re-execution is deliberately deferred rather than inventing a retry semantic. Closure retries re-perform the external observation and every gate before the only commit mutation; the terminal run is never reopened.