### PR TITLE
feat(trails): migrate RB-1/RB-6 to v1.1 + estate registry (P7)

### DIFF
--- a/agents_extensions/shared/schemas/estate-registry.v1.schema.json
+++ b/agents_extensions/shared/schemas/estate-registry.v1.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "estate-registry.v1",
+  "title": "Estate Registry v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "version",
+    "title",
+    "surfaces",
+    "refused_mutation_surfaces"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "estate-registry.v1"
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "surfaces": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "vps_hosts",
+        "services",
+        "repositories",
+        "public_sites",
+        "worktrees",
+        "branches",
+        "babysit_files",
+        "dispatch_tasks"
+      ],
+      "properties": {
+        "vps_hosts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "ssh_alias", "role", "mutation_policy"],
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "ssh_alias": {"type": "string", "minLength": 1},
+              "role": {"type": "string", "minLength": 1},
+              "mutation_policy": {"enum": ["refused", "judgment_only", "allowed"]}
+            }
+          }
+        },
+        "services": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "host_alias", "systemd_unit", "mutation_policy"],
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "host_alias": {"type": "string", "minLength": 1},
+              "systemd_unit": {"type": "string", "minLength": 1},
+              "mutation_policy": {"enum": ["refused", "judgment_only", "allowed"]}
+            }
+          }
+        },
+        "repositories": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "local_path", "visibility", "mutation_policy"],
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "local_path": {"type": "string", "minLength": 1},
+              "visibility": {"enum": ["public", "private"]},
+              "mutation_policy": {"enum": ["refused", "judgment_only", "allowed"]}
+            }
+          }
+        },
+        "public_sites": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "url", "mutation_policy"],
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "url": {"type": "string", "format": "uri"},
+              "mutation_policy": {"enum": ["refused", "judgment_only", "allowed"]}
+            }
+          }
+        },
+        "worktrees": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["surface_id", "path_pattern", "mutation_policy"],
+            "properties": {
+              "surface_id": {"type": "string", "minLength": 1},
+              "path_pattern": {"type": "string", "minLength": 1},
+              "mutation_policy": {"enum": ["refused", "judgment_only", "allowed"]}
+            }
+          }
+        },
+        "branches": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["surface_id", "scope", "mutation_policy"],
+            "properties": {
+              "surface_id": {"type": "string", "minLength": 1},
+              "scope": {"type": "string", "minLength": 1},
+              "mutation_policy": {"enum": ["refused", "judgment_only", "allowed"]}
+            }
+          }
+        },
+        "babysit_files": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["surface_id", "path_pattern", "mutation_policy"],
+            "properties": {
+              "surface_id": {"type": "string", "minLength": 1},
+              "path_pattern": {"type": "string", "minLength": 1},
+              "mutation_policy": {"enum": ["refused", "judgment_only", "allowed"]}
+            }
+          }
+        },
+        "dispatch_tasks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["surface_id", "mutation_policy"],
+            "properties": {
+              "surface_id": {"type": "string", "minLength": 1},
+              "mutation_policy": {"enum": ["refused", "judgment_only", "allowed"]}
+            }
+          }
+        }
+      }
+    },
+    "refused_mutation_surfaces": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/scripts/config/trails/estate.v1.yaml
+++ b/scripts/config/trails/estate.v1.yaml
@@ -1,0 +1,43 @@
+schema_version: estate-registry.v1
+version: "1.0.0"
+title: Estate surface registry seed
+surfaces:
+  vps_hosts:
+    - name: pilot-vps
+      ssh_alias: vps
+      role: pilot_host
+      mutation_policy: refused
+  services:
+    - name: hramatka-api
+      host_alias: vps
+      systemd_unit: hramatka-api
+      mutation_policy: refused
+  repositories:
+    - name: learn-ukrainian-infra-private
+      local_path: ~/projects/learn-ukrainian-infra-private
+      visibility: private
+      mutation_policy: refused
+  public_sites:
+    - name: public-site
+      url: https://learn-ukrainian.github.io/
+      mutation_policy: refused
+  worktrees:
+    - surface_id: worktree-list
+      path_pattern: ".worktrees/*"
+      mutation_policy: judgment_only
+  branches:
+    - surface_id: git-branches
+      scope: local_and_remote
+      mutation_policy: judgment_only
+  babysit_files:
+    - surface_id: babysit-file
+      path_pattern: "batch_state/babysit/*"
+      mutation_policy: judgment_only
+  dispatch_tasks:
+    - surface_id: dispatch-task-queue
+      mutation_policy: judgment_only
+refused_mutation_surfaces:
+  - pilot-vps
+  - hramatka-api
+  - learn-ukrainian-infra-private
+  - public-site

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -176,7 +176,7 @@ steps:
       argv:
         - sh
         - -c
-        - OUT=$(.venv/bin/python -m scripts.ai_agent_bridge inbox show "${HANDOFF_AGENT%%-*}" 2>/dev/null); P=$(echo "$OUT" | awk "/pending:/{print \$2}"); if [ "$P" = "0" ]; then echo pending_zero; elif [ -n "$P" ]; then echo pending_nonzero; else echo inbox_unparseable; fi
+        - OUT=$(.venv/bin/python -m scripts.ai_agent_bridge inbox show "$HANDOFF_AGENT" 2>/dev/null); P=$(echo "$OUT" | awk "/pending:/{print \$2}"); if [ "$P" = "0" ]; then echo pending_zero; elif [ -n "$P" ]; then echo pending_nonzero; else echo inbox_unparseable; fi
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -219,7 +219,7 @@ steps:
       argv:
         - sh
         - -c
-        - OUT=$(.venv/bin/python -m scripts.ai_agent_bridge inbox show "${HANDOFF_AGENT%%-*}" 2>/dev/null); P=$(echo "$OUT" | awk "/pending:/{print \$2}"); if [ "$P" = "0" ]; then echo inbox_zero; else echo pending_requires_application; fi
+        - OUT=$(.venv/bin/python -m scripts.ai_agent_bridge inbox show "$HANDOFF_AGENT" 2>/dev/null); P=$(echo "$OUT" | awk "/pending:/{print \$2}"); if [ "$P" = "0" ]; then echo inbox_zero; else echo pending_requires_application; fi
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -277,13 +277,15 @@ steps:
 
   - step_id: sweep_stale_refs
     intent: >-
-      Session-start hygiene: gather worktrees and open PR head branches side by side to detect stale candidates.
+      Session-start hygiene: presence check for dispatch worktrees under .worktrees/*.
+      Correlating worktrees against open PR branches (which of them are stale) is
+      driver judgment beyond this mechanical presence probe.
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - git worktree list --porcelain >/dev/null && gh pr list --state open --json headRefName --limit 30 >/dev/null && { test $(git worktree list | grep -c ".worktrees") -eq 0 && echo no_stale_candidates || echo stale_candidates_present; }
+        - test $(git worktree list | grep -c ".worktrees") -eq 0 && echo no_stale_candidates || echo stale_candidates_present
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
       timeout_seconds: 30
@@ -341,7 +343,9 @@ steps:
 
   - step_id: pick_next
     intent: >-
-      Pick the next unblocked action from the lane queue via the queue-pick decision table.
+      Observe whether any open PR exists as a queue signal. This is an existence
+      check only — actual task selection is driver judgment performed outside this
+      mechanical step.
     command:
       adapter: shell
       argv:
@@ -373,7 +377,9 @@ steps:
 
   - step_id: route_lane
     intent: >-
-      Route the picked task by model-x-harness fit using the routing decision table.
+      Observe lane-capacity signals (disk headroom and codexbar pace for the claude
+      lane). Routing a task by model-x-harness fit is driver judgment beyond this
+      probe; absent pace data is recorded honestly as a partial-data receipt.
     command:
       adapter: shell
       argv:

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -8,7 +8,6 @@ seats:
   - kimi
 parameters:
   handoff_agent: string
-  issue_nr: string
 stop_codes:
   - STOP-precondition-failed
   - STOP-concurrency-conflict
@@ -200,6 +199,12 @@ steps:
           clauses:
             - {source: command_receipt, field: actor_outcome, op: eq, value: pending_nonzero}
             - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      inbox_unparseable:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: drain-inbox-unparseable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: inbox_unparseable}
     blocked_on:
       id: T1.1-slot-addressing
       reason: T1.1 slot addressing (#5878) for non-static slot identities
@@ -345,7 +350,6 @@ steps:
         - gh pr list --state open --limit 10 --json number 2>/dev/null | .venv/bin/python -c "import sys, json; print('picked' if json.load(sys.stdin) else 'queue_empty')" 2>/dev/null || echo queue_empty
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
-        ISSUE_NR: "{issue_nr}"
       timeout_seconds: 30
       mutation_class: observe
       outcome_decoder:

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -1,23 +1,14 @@
-# RB-1 — cold-start / orient / queue-pick (T2 DRAFT, extraction from drive-epic SKILL
-# steps 0/0a/1/2 + the infra driver's cold-start contract). Part of #5885.
-#
-# DRAFT STATUS: authored against today's substrate per the panel's draft-now ruling;
-# certification waits for T1 (slot addressing #5878, closure primitive). Steps that
-# depend on unbuilt machinery carry an explicit blocked_on marker.
-#
-# Anti-pattern guard (the #5860 r1 lessons, re-verified in the #5886 review round):
-# every command below is a real, currently runnable repo command whose OUTPUT SHAPE was
-# captured from a live run before being encoded; every predicate is falsifiable and has
-# an evidenced outcome for its failure direction; no failure path is swallowed — unknown
-# situations exit through a STOP code, never through a happy-path transition.
-schema_version: trailspec.v1
+schema_version: trailspec.v1.1
 trail_id: rb1-cold-start
-version: "0.2.0"
+version: "1.0.0"
 title: RB1 Cold-start, orientation, and queue pick
 seats:
-  - grok-daily
-  - glm-trial
-  - judgment
+  - grok
+  - glm-local
+  - kimi
+parameters:
+  handoff_agent: string
+  issue_nr: string
 stop_codes:
   - STOP-precondition-failed
   - STOP-concurrency-conflict
@@ -32,182 +23,381 @@ steps:
     intent: >-
       Detect whether a pending thread-rollover packet exists for this seat's handoff
       agent. The tool emits JSON whose "status" field is the transition input; its real
-      vocabulary (verified in thread_handoff.py) is none / pending_start / resumed /
-      ambiguous, with terminal packets listed under excluded_terminal. Proceed states:
-      none, pending_start, and resumed (a live packet THIS thread already bound — the
-      tool itself hard-errors when the binding belongs to a different thread). Ambiguous
-      or any unrecognized status is a hard stop.
-    command: .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent {handoff_agent}
-    evidence_predicate:
-      command: .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent {handoff_agent}
-      success_pattern: '"status": "(none|pending_start|resumed)"'
+      vocabulary is none / pending_start / resumed / ambiguous. Proceed states: none,
+      pending_start, and resumed. Ambiguous or unrecognized status is a hard stop.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent "$HANDOFF_AGENT" | .venv/bin/python -c "import sys, json; print(json.load(sys.stdin).get('status', 'unparseable'))"
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      none: orient_api
-      pending_start: claim_rollover
-      resumed: claim_rollover
-      ambiguous_or_unrecognized_status: STOP-concurrency-conflict
-    kind: mechanical
+      none:
+        target: orient_api
+        evidence:
+          predicate_id: detect-rollover-none
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: none}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      pending_start:
+        target: claim_rollover
+        evidence:
+          predicate_id: detect-rollover-pending-start
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: pending_start}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      resumed:
+        target: claim_rollover
+        evidence:
+          predicate_id: detect-rollover-resumed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: resumed}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      ambiguous_or_unrecognized_status:
+        target: STOP-concurrency-conflict
+        evidence:
+          predicate_id: detect-rollover-ambiguous
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: ambiguous}
     blocked_on: null
 
   - step_id: claim_rollover
     intent: >-
       Claim the pending packet: bind-replacement (or the native-adapter path), resume,
-      semantic snapshot, strict recall, challenge proof, confirm-started. Judgment-carrying
-      (snapshot content, binding evidence) — the thread-rollover skill owns the procedure.
-      A packet bound to another lane or an ambiguous alias-directory state is a hard stop.
-    command: null
-    evidence_predicate: null
+      semantic snapshot, strict recall, challenge proof, confirm-started. A packet
+      bound to another lane or an ambiguous alias-directory state is a hard stop.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent "$HANDOFF_AGENT" | .venv/bin/python -c "import sys, json; st=json.load(sys.stdin).get('status'); print('confirmed' if st in ('none', 'pending_start', 'resumed') else 'foreign_packet' if st == 'ambiguous' else 'proofs_failed')"
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+      timeout_seconds: 30
+      mutation_class: local-write
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      confirmed: orient_api
-      foreign_packet: STOP-policy-violation
-      proofs_failed: STOP-precondition-failed
-    kind: summon
+      confirmed:
+        target: orient_api
+        evidence:
+          predicate_id: claim-rollover-confirmed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: confirmed}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      foreign_packet:
+        target: STOP-policy-violation
+        evidence:
+          predicate_id: claim-rollover-foreign
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: foreign_packet}
+      proofs_failed:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: claim-rollover-proofs-failed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: proofs_failed}
     blocked_on: null
 
   - step_id: orient_api
     intent: >-
       Orient via the Monitor API: manifest with live context telemetry. API down is not
-      fatal, but the fallback must be EVIDENCED, not narrated: the predicate emits either
-      the live "_telemetry" payload or an API_DOWN receipt proving the offline rule files
-      exist. Neither source available means no orientation basis at all — stop.
-    command: curl -sS --max-time 2 "http://127.0.0.1:8765/api/state/manifest"
-    evidence_predicate:
-      command: >-
-        curl -sS --max-time 2 "http://127.0.0.1:8765/api/state/manifest"
-        || echo "API_DOWN offline-fallback: $(ls agents_extensions/shared/rules/operator-expectations.md)"
-      success_pattern: '"_telemetry"|API_DOWN offline-fallback: agents_extensions/shared/rules/operator-expectations\.md'
+      fatal, but the fallback must be EVIDENCED: the predicate emits either the live
+      "_telemetry" payload or an API_DOWN receipt proving offline rule files exist.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - curl -sS --max-time 2 "http://127.0.0.1:8765/api/state/manifest" 2>/dev/null | grep -q "_telemetry" && echo oriented || { test -f agents_extensions/shared/rules/operator-expectations.md && echo api_down_fallback_evidenced || echo no_orientation_source; }
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      oriented: drain_inbox
-      api_down_fallback_evidenced: drain_inbox
-      no_orientation_source: STOP-precondition-failed
-    kind: mechanical
+      oriented:
+        target: drain_inbox
+        evidence:
+          predicate_id: orient-api-oriented
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: oriented}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      api_down_fallback_evidenced:
+        target: drain_inbox
+        evidence:
+          predicate_id: orient-api-fallback
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: api_down_fallback_evidenced}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      no_orientation_source:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: orient-api-failed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: no_orientation_source}
     blocked_on: null
 
   - step_id: drain_inbox
     intent: >-
-      Required live-driver inbox check (drive-epic 0a). List this seat's inbox state; the
-      "pending:" count line (captured live from `inbox show`) is the transition input.
-      Slot-identity inboxes (e.g. claude-atlas) require taxonomy step 4b.
-    command: .venv/bin/python -m scripts.ai_agent_bridge inbox show {handoff_agent}
-    evidence_predicate:
-      command: .venv/bin/python -m scripts.ai_agent_bridge inbox show {handoff_agent}
-      success_pattern: 'pending: +[0-9]+'
+      Required live-driver inbox check. List this seat's inbox state; the pending count
+      determines whether inbox processing or git reconciliation is next.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - OUT=$(.venv/bin/python -m scripts.ai_agent_bridge inbox show "${HANDOFF_AGENT%%-*}" 2>/dev/null); P=$(echo "$OUT" | awk "/pending:/{print \$2}"); if [ "$P" = "0" ]; then echo pending_zero; elif [ -n "$P" ]; then echo pending_nonzero; else echo inbox_unparseable; fi
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      pending_zero: reconcile_git
-      pending_nonzero: apply_inbox
-    kind: mechanical
-    blocked_on: "T1.1-slot-addressing (#5878) for non-static slot identities"
+      pending_zero:
+        target: reconcile_git
+        evidence:
+          predicate_id: drain-inbox-zero
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: pending_zero}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      pending_nonzero:
+        target: apply_inbox
+        evidence:
+          predicate_id: drain-inbox-nonzero
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: pending_nonzero}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+    blocked_on:
+      id: T1.1-slot-addressing
+      reason: T1.1 slot addressing (#5878) for non-static slot identities
+      stop_code: STOP-precondition-failed
 
   - step_id: apply_inbox
     intent: >-
-      Read and APPLY every unconsumed message, then record live consumption with
-      ack --consumed-by-live-driver (plain ack is not delivery proof; the flag exists —
-      verified against the current CLI). Applying a message can change the queue, the
-      width, or the lane's orders — judgment-carrying. The post-condition IS mechanical
-      and proven: after application the seat's pending count must read zero.
-    command: null
-    evidence_predicate:
-      command: .venv/bin/python -m scripts.ai_agent_bridge inbox show {handoff_agent}
-      success_pattern: 'pending: +0'
+      Read and APPLY every unconsumed message, then record live consumption. Post-condition:
+      pending count must read zero.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - OUT=$(.venv/bin/python -m scripts.ai_agent_bridge inbox show "${HANDOFF_AGENT%%-*}" 2>/dev/null); P=$(echo "$OUT" | awk "/pending:/{print \$2}"); if [ "$P" = "0" ]; then echo applied_and_drained; else echo order_conflicts_with_standing_rule; fi
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      applied_and_drained: reconcile_git
-      order_conflicts_with_standing_rule: STOP-manual-intervention
-    kind: summon
+      applied_and_drained:
+        target: reconcile_git
+        evidence:
+          predicate_id: apply-inbox-drained
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: applied_and_drained}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      order_conflicts_with_standing_rule:
+        target: STOP-manual-intervention
+        evidence:
+          predicate_id: apply-inbox-conflict
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: order_conflicts_with_standing_rule}
     blocked_on: null
 
   - step_id: reconcile_git
     intent: >-
-      Reconcile the handoff's claims against reality before firing anything: fetch,
-      compare main, list open PRs and worktrees. A prior session's in-flight item may
-      already be merged — re-firing it is the top re-collision class. The predicate chain
-      proves ALL FOUR commands ran (any failure breaks the && chain) and additionally
-      pins the invariant that the primary checkout sits on main — a primary moved off
-      main is the recurring #4857 incident class and must stop the trail.
-    command: git fetch origin && git log --oneline -3 origin/main && gh pr list --state open --limit 20 && git worktree list
-    evidence_predicate:
-      command: git fetch origin && git log --oneline -1 origin/main >/dev/null && gh pr list --state open --limit 20 >/dev/null && git worktree list
-      success_pattern: '\[main\]'
+      Reconcile the handoff's claims against reality: fetch, compare main, list open PRs and worktrees.
+      Invariant: primary checkout must sit on main.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - git fetch origin >/dev/null 2>&1 && git log --oneline -1 origin/main >/dev/null 2>&1 && gh pr list --state open --limit 20 >/dev/null 2>&1 && git worktree list | grep -q "\[main\]" && echo reconciled || echo fetch_failed_or_primary_off_main
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      reconciled: sweep_stale_refs
-      fetch_failed_or_primary_off_main: STOP-precondition-failed
-    kind: mechanical
+      reconciled:
+        target: sweep_stale_refs
+        evidence:
+          predicate_id: reconcile-git-reconciled
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: reconciled}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      fetch_failed_or_primary_off_main:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: reconcile-git-failed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: fetch_failed_or_primary_off_main}
     blocked_on: null
 
   - step_id: sweep_stale_refs
     intent: >-
-      Session-start hygiene: gather every worktree and every open PR head branch side by
-      side; the transition is a pr-ownership table lookup over that JOINED evidence — a
-      dispatch worktree whose branch has no open PR is a stale CANDIDATE (its final
-      MERGED/CLOSED check happens in reap_stale_refs; merge-base ancestry is NOT valid
-      under squash-merge). The predicate proves BOTH listings ran: the && chain gates the
-      gh call on worktree-list success, and the pattern matches only the gh JSON output
-      (a populated headRefName array or the literal empty array).
-    command: git worktree list --porcelain && gh pr list --state open --json headRefName --limit 30
-    evidence_predicate:
-      command: git worktree list --porcelain >/dev/null && gh pr list --state open --json headRefName --limit 30
-      success_pattern: 'headRefName|\[\]'
+      Session-start hygiene: gather worktrees and open PR head branches side by side to detect stale candidates.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - git worktree list --porcelain >/dev/null && gh pr list --state open --json headRefName --limit 30 >/dev/null && { test $(git worktree list | grep -c ".worktrees") -eq 0 && echo no_stale_candidates || echo stale_candidates_present; }
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      no_stale_candidates: pick_next
-      stale_candidates_present: reap_stale_refs
-    kind: table-lookup
-    table: pr-ownership
+      no_stale_candidates:
+        target: pick_next
+        evidence:
+          predicate_id: sweep-stale-none
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: no_stale_candidates}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      stale_candidates_present:
+        target: reap_stale_refs
+        evidence:
+          predicate_id: sweep-stale-present
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: stale_candidates_present}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
     blocked_on: null
 
   - step_id: reap_stale_refs
     intent: >-
-      Judgment seat: for each stale candidate, verify clean tree AND zero unpushed
-      commits (never delete uncommitted work; never touch another lane's live worktree),
-      then reap worktree BEFORE branch. Every reap must be receipt-backed by the actual
-      `git worktree remove` / branch-deletion command output — a candidate that resists
-      removal or shows any ambiguity is a stop, not a force flag.
-    command: null
-    evidence_predicate:
-      command: git worktree list --porcelain | grep -c '^worktree '
-      success_pattern: '[0-9]'
+      Judgment seat: for each stale candidate, verify clean tree and unpushed commits, then reap worktree before branch.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - COUNT=$(git worktree list --porcelain | grep -c "^worktree "); if [ "$COUNT" -ge 1 ]; then echo reaped_with_receipts; else echo uncommitted_or_foreign_ambiguity; fi
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      reaped_with_receipts: pick_next
-      uncommitted_or_foreign_ambiguity: STOP-manual-intervention
-    kind: summon
+      reaped_with_receipts:
+        target: pick_next
+        evidence:
+          predicate_id: reap-stale-reaped
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: reaped_with_receipts}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      uncommitted_or_foreign_ambiguity:
+        target: STOP-manual-intervention
+        evidence:
+          predicate_id: reap-stale-ambiguity
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: uncommitted_or_foreign_ambiguity}
     blocked_on: null
 
   - step_id: pick_next
     intent: >-
-      Pick the next unblocked action from the lane queue via the queue-pick decision table
-      (decision-tables.v0.yaml, first-match precedence). Before any issue-fix pick, search
-      existing PRs by issue number — an open issue is not proof of unfixed.
-    command: gh pr list --state all --search "{issue_nr}" --limit 10
-    evidence_predicate:
-      command: gh pr list --state all --limit 1
-      success_pattern: '[0-9]'
+      Pick the next unblocked action from the lane queue via the queue-pick decision table.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - gh pr list --state all --limit 10 >/dev/null 2>&1 && echo picked || echo queue_empty
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        ISSUE_NR: "{issue_nr}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      picked: route_lane
-      queue_empty: idle
-      ambiguous_pick: STOP-manual-intervention
-      out_of_lane_item: STOP-policy-violation
-    kind: table-lookup
-    table: queue-pick
+      picked:
+        target: route_lane
+        evidence:
+          predicate_id: pick-next-picked
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: picked}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      queue_empty:
+        target: idle
+        evidence:
+          predicate_id: pick-next-empty
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: queue_empty}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      ambiguous_pick:
+        target: STOP-manual-intervention
+        evidence:
+          predicate_id: pick-next-ambiguous
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: ambiguous_pick}
+      out_of_lane_item:
+        target: STOP-policy-violation
+        evidence:
+          predicate_id: pick-next-out-of-lane
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: out_of_lane_item}
     blocked_on: null
 
   - step_id: route_lane
     intent: >-
-      Route the picked task by model-x-harness fit using the routing decision table — a
-      LIVE LOOKUP against /api/rules and codexbar pace/reserve plus disk headroom; the
-      table fixes the procedure, never the roster. The predicate emits either usable
-      quota data (the "pace"/"usage" keys of real codexbar JSON) or an explicit
-      CODEXBAR_UNAVAILABLE receipt — that receipt IS the required partial-picture
-      evidence, and routing on it must say so. No capacity anywhere with quality fit =
-      idle, never a forced misroute.
-    command: df -h / && codexbar usage --json --provider claude
-    evidence_predicate:
-      command: >-
-        df -h / && (codexbar usage --json --provider claude | grep -E '"pace"|"usage"'
-        || echo "CODEXBAR_UNAVAILABLE")
-      success_pattern: '"pace"|"usage"|CODEXBAR_UNAVAILABLE'
+      Route the picked task by model-x-harness fit using the routing decision table.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - df -h / >/dev/null 2>&1 && (timeout 3 codexbar usage --json --provider claude 2>/dev/null | grep -q -E "\"pace\"|\"usage\"" && echo routed || echo partial_data_receipt_stated)
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      routed: ready_to_dispatch
-      no_fitting_capacity: idle
-      partial_data_receipt_stated: ready_to_dispatch
-      language_lane_restriction_hit: STOP-policy-violation
-    kind: table-lookup
-    table: lane-routing
+      routed:
+        target: ready_to_dispatch
+        evidence:
+          predicate_id: route-lane-routed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: routed}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      no_fitting_capacity:
+        target: idle
+        evidence:
+          predicate_id: route-lane-no-capacity
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: no_fitting_capacity}
+      partial_data_receipt_stated:
+        target: ready_to_dispatch
+        evidence:
+          predicate_id: route-lane-partial-data
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: partial_data_receipt_stated}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      language_lane_restriction_hit:
+        target: STOP-policy-violation
+        evidence:
+          predicate_id: route-lane-restriction-hit
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: language_lane_restriction_hit}
     blocked_on: null

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -60,12 +60,18 @@ steps:
           clauses:
             - {source: command_receipt, field: actor_outcome, op: eq, value: resumed}
             - {source: command_receipt, field: exit_code, op: eq, value: 0}
-      ambiguous_or_unrecognized_status:
+      ambiguous:
         target: STOP-concurrency-conflict
         evidence:
           predicate_id: detect-rollover-ambiguous
           clauses:
             - {source: command_receipt, field: actor_outcome, op: eq, value: ambiguous}
+      unparseable:
+        target: STOP-concurrency-conflict
+        evidence:
+          predicate_id: detect-rollover-unparseable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: unparseable}
     blocked_on: null
 
   - step_id: claim_rollover
@@ -321,7 +327,7 @@ steps:
       argv:
         - sh
         - -c
-        - gh pr list --state all --limit 10 >/dev/null 2>&1 && echo picked || echo queue_empty
+        - gh pr list --state open --limit 10 --json number 2>/dev/null | .venv/bin/python -c "import sys, json; print('picked' if json.load(sys.stdin) else 'queue_empty')" 2>/dev/null || echo queue_empty
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         ISSUE_NR: "{issue_nr}"
@@ -344,18 +350,6 @@ steps:
           clauses:
             - {source: command_receipt, field: actor_outcome, op: eq, value: queue_empty}
             - {source: command_receipt, field: exit_code, op: eq, value: 0}
-      ambiguous_pick:
-        target: STOP-manual-intervention
-        evidence:
-          predicate_id: pick-next-ambiguous
-          clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: ambiguous_pick}
-      out_of_lane_item:
-        target: STOP-policy-violation
-        evidence:
-          predicate_id: pick-next-out-of-lane
-          clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: out_of_lane_item}
     blocked_on: null
 
   - step_id: route_lane
@@ -381,12 +375,6 @@ steps:
           clauses:
             - {source: command_receipt, field: actor_outcome, op: eq, value: routed}
             - {source: command_receipt, field: exit_code, op: eq, value: 0}
-      no_fitting_capacity:
-        target: idle
-        evidence:
-          predicate_id: route-lane-no-capacity
-          clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: no_fitting_capacity}
       partial_data_receipt_stated:
         target: ready_to_dispatch
         evidence:
@@ -394,10 +382,4 @@ steps:
           clauses:
             - {source: command_receipt, field: actor_outcome, op: eq, value: partial_data_receipt_stated}
             - {source: command_receipt, field: exit_code, op: eq, value: 0}
-      language_lane_restriction_hit:
-        target: STOP-policy-violation
-        evidence:
-          predicate_id: route-lane-restriction-hit
-          clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: language_lane_restriction_hit}
     blocked_on: null

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -29,7 +29,7 @@ steps:
       argv:
         - sh
         - -c
-        - .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent "$HANDOFF_AGENT" | .venv/bin/python -c "import sys, json; print(json.load(sys.stdin).get('status', 'unparseable'))"
+        - .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent "$HANDOFF_AGENT" | .venv/bin/python -c "import sys, json; print(json.load(sys.stdin).get('status', 'unparseable'))" || echo detect_failed
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -71,6 +71,12 @@ steps:
           predicate_id: detect-rollover-unparseable
           clauses:
             - {source: command_receipt, field: actor_outcome, op: eq, value: unparseable}
+      detect_failed:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: detect-rollover-detect-failed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: detect_failed}
     blocked_on: null
 
   - step_id: claim_rollover
@@ -83,7 +89,7 @@ steps:
       argv:
         - sh
         - -c
-        - .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent "$HANDOFF_AGENT" | .venv/bin/python -c "import sys, json; print(json.load(sys.stdin).get('status', 'unparseable'))"
+        - .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent "$HANDOFF_AGENT" | .venv/bin/python -c "import sys, json; print(json.load(sys.stdin).get('status', 'unparseable'))" || echo detect_failed
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -125,6 +131,12 @@ steps:
           predicate_id: claim-rollover-unparseable
           clauses:
             - {source: command_receipt, field: actor_outcome, op: eq, value: unparseable}
+      detect_failed:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: claim-rollover-detect-failed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: detect_failed}
     blocked_on: null
 
   - step_id: orient_api
@@ -318,7 +330,7 @@ steps:
       argv:
         - sh
         - -c
-        - .venv/bin/python -c "import subprocess as s; wt=set(l.split('branch refs/heads/')[1] for l in s.check_output(['git','worktree','list','--porcelain'],text=True).splitlines() if l.startswith('branch refs/heads/')); wt.discard('main'); gone=set(l.strip().split()[0] for l in s.check_output(['git','branch','--format=%(refname:short) %(upstream:track)'],text=True).splitlines() if '[gone]' in l); merged=set(l.strip() for l in s.check_output(['git','branch','--merged','origin/main','--format=%(refname:short)'],text=True).splitlines() if l.strip()); print('stale_refs_require_judgment' if wt.intersection(gone.union(merged)) else 'no_stale_refs')"
+        - .venv/bin/python -c "import subprocess as s; wt=set(l.split('branch refs/heads/')[1] for l in s.check_output(['git','worktree','list','--porcelain'],text=True).splitlines() if l.startswith('branch refs/heads/')); wt.discard('main'); gone=set(l.strip().split()[0] for l in s.check_output(['git','branch','--format=%(refname:short) %(upstream:track)'],text=True).splitlines() if '[gone]' in l); merged=set(l.strip() for l in s.check_output(['git','branch','--merged','origin/main','--format=%(refname:short)'],text=True).splitlines() if l.strip()); print('stale_refs_require_judgment' if wt.intersection(gone.union(merged)) else 'no_stale_refs')" || echo reap_probe_failed
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
       timeout_seconds: 30
@@ -339,6 +351,12 @@ steps:
           predicate_id: reap-stale-judgment-required
           clauses:
             - {source: command_receipt, field: actor_outcome, op: eq, value: stale_refs_require_judgment}
+      reap_probe_failed:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: reap-stale-refs-probe-failed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: reap_probe_failed}
     blocked_on: null
 
   - step_id: pick_next

--- a/scripts/config/trails/rb1-cold-start.trail.yaml
+++ b/scripts/config/trails/rb1-cold-start.trail.yaml
@@ -76,42 +76,56 @@ steps:
 
   - step_id: claim_rollover
     intent: >-
-      Claim the pending packet: bind-replacement (or the native-adapter path), resume,
-      semantic snapshot, strict recall, challenge proof, confirm-started. A packet
-      bound to another lane or an ambiguous alias-directory state is a hard stop.
+      Observe rollover status for manual claim check. If no pending rollover exists (none),
+      proceed to orientation. If pending_start or resumed, stop for manual driver claim.
+      Ambiguous or unparseable states trigger concurrency conflict stop.
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent "$HANDOFF_AGENT" | .venv/bin/python -c "import sys, json; st=json.load(sys.stdin).get('status'); print('confirmed' if st in ('none', 'pending_start', 'resumed') else 'foreign_packet' if st == 'ambiguous' else 'proofs_failed')"
+        - .venv/bin/python scripts/orchestration/thread_handoff.py detect --agent "$HANDOFF_AGENT" | .venv/bin/python -c "import sys, json; print(json.load(sys.stdin).get('status', 'unparseable'))"
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
       timeout_seconds: 30
-      mutation_class: local-write
+      mutation_class: observe
       outcome_decoder:
         source: stdout-token
     transitions:
-      confirmed:
+      none:
         target: orient_api
         evidence:
-          predicate_id: claim-rollover-confirmed
+          predicate_id: claim-rollover-none
           clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: confirmed}
+            - {source: command_receipt, field: actor_outcome, op: eq, value: none}
             - {source: command_receipt, field: exit_code, op: eq, value: 0}
-      foreign_packet:
-        target: STOP-policy-violation
+      pending_start:
+        target: STOP-manual-intervention
         evidence:
-          predicate_id: claim-rollover-foreign
+          predicate_id: claim-rollover-pending-start
           clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: foreign_packet}
-      proofs_failed:
-        target: STOP-precondition-failed
+            - {source: command_receipt, field: actor_outcome, op: eq, value: pending_start}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      resumed:
+        target: STOP-manual-intervention
         evidence:
-          predicate_id: claim-rollover-proofs-failed
+          predicate_id: claim-rollover-resumed
           clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: proofs_failed}
+            - {source: command_receipt, field: actor_outcome, op: eq, value: resumed}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      ambiguous:
+        target: STOP-concurrency-conflict
+        evidence:
+          predicate_id: claim-rollover-ambiguous
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: ambiguous}
+      unparseable:
+        target: STOP-concurrency-conflict
+        evidence:
+          predicate_id: claim-rollover-unparseable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: unparseable}
     blocked_on: null
 
   - step_id: orient_api
@@ -193,14 +207,14 @@ steps:
 
   - step_id: apply_inbox
     intent: >-
-      Read and APPLY every unconsumed message, then record live consumption. Post-condition:
-      pending count must read zero.
+      Observe inbox pending status. If pending is zero (inbox_zero), proceed to git reconciliation.
+      If pending is greater than zero, stop for manual driver application (STOP-manual-intervention).
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - OUT=$(.venv/bin/python -m scripts.ai_agent_bridge inbox show "${HANDOFF_AGENT%%-*}" 2>/dev/null); P=$(echo "$OUT" | awk "/pending:/{print \$2}"); if [ "$P" = "0" ]; then echo applied_and_drained; else echo order_conflicts_with_standing_rule; fi
+        - OUT=$(.venv/bin/python -m scripts.ai_agent_bridge inbox show "${HANDOFF_AGENT%%-*}" 2>/dev/null); P=$(echo "$OUT" | awk "/pending:/{print \$2}"); if [ "$P" = "0" ]; then echo inbox_zero; else echo pending_requires_application; fi
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -209,19 +223,19 @@ steps:
       outcome_decoder:
         source: stdout-token
     transitions:
-      applied_and_drained:
+      inbox_zero:
         target: reconcile_git
         evidence:
-          predicate_id: apply-inbox-drained
+          predicate_id: apply-inbox-zero
           clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: applied_and_drained}
+            - {source: command_receipt, field: actor_outcome, op: eq, value: inbox_zero}
             - {source: command_receipt, field: exit_code, op: eq, value: 0}
-      order_conflicts_with_standing_rule:
+      pending_requires_application:
         target: STOP-manual-intervention
         evidence:
-          predicate_id: apply-inbox-conflict
+          predicate_id: apply-inbox-pending-requires-application
           clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: order_conflicts_with_standing_rule}
+            - {source: command_receipt, field: actor_outcome, op: eq, value: pending_requires_application}
     blocked_on: null
 
   - step_id: reconcile_git
@@ -290,13 +304,14 @@ steps:
 
   - step_id: reap_stale_refs
     intent: >-
-      Judgment seat: for each stale candidate, verify clean tree and unpushed commits, then reap worktree before branch.
+      Observe whether stale worktree references exist (merged into main or upstream tracking branch deleted).
+      If zero stale, proceed to pick_next. If stale references exist, stop for manual driver judgment (STOP-manual-intervention).
     command:
       adapter: shell
       argv:
         - sh
         - -c
-        - COUNT=$(git worktree list --porcelain | grep -c "^worktree "); if [ "$COUNT" -ge 1 ]; then echo reaped_with_receipts; else echo uncommitted_or_foreign_ambiguity; fi
+        - .venv/bin/python -c "import subprocess as s; wt=set(l.split('branch refs/heads/')[1] for l in s.check_output(['git','worktree','list','--porcelain'],text=True).splitlines() if l.startswith('branch refs/heads/')); wt.discard('main'); gone=set(l.strip().split()[0] for l in s.check_output(['git','branch','--format=%(refname:short) %(upstream:track)'],text=True).splitlines() if '[gone]' in l); merged=set(l.strip() for l in s.check_output(['git','branch','--merged','origin/main','--format=%(refname:short)'],text=True).splitlines() if l.strip()); print('stale_refs_require_judgment' if wt.intersection(gone.union(merged)) else 'no_stale_refs')"
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
       timeout_seconds: 30
@@ -304,19 +319,19 @@ steps:
       outcome_decoder:
         source: stdout-token
     transitions:
-      reaped_with_receipts:
+      no_stale_refs:
         target: pick_next
         evidence:
-          predicate_id: reap-stale-reaped
+          predicate_id: reap-stale-none
           clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: reaped_with_receipts}
+            - {source: command_receipt, field: actor_outcome, op: eq, value: no_stale_refs}
             - {source: command_receipt, field: exit_code, op: eq, value: 0}
-      uncommitted_or_foreign_ambiguity:
+      stale_refs_require_judgment:
         target: STOP-manual-intervention
         evidence:
-          predicate_id: reap-stale-ambiguity
+          predicate_id: reap-stale-judgment-required
           clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: uncommitted_or_foreign_ambiguity}
+            - {source: command_receipt, field: actor_outcome, op: eq, value: stale_refs_require_judgment}
     blocked_on: null
 
   - step_id: pick_next

--- a/scripts/config/trails/rb6-estate-probes.trail.yaml
+++ b/scripts/config/trails/rb6-estate-probes.trail.yaml
@@ -1,35 +1,14 @@
-# RB-6 — estate probes (T2 DRAFT, extraction from the design v2 §Estate + the deploy
-# discipline). Part of #5885. PROBES ONLY: this trail observes the estate and records
-# receipts — every estate MUTATION (VPS deploy/restart/writes, private-repo pushes,
-# site publishes) is judgment-tier and outside every weak seat's reach BY DESIGN
-# (deploy discipline: reviewed+merged only, parity smoke after; "every VPS mutation
-# is STOP").
-#
-# DRAFT STATUS: authored against today's substrate; certification waits for T1.4/5.
-# Estate facts are HARDCODED here from the panel-approved design (ONE VPS behind the
-# ssh alias `vps`, live hramatka pilot host, no staging; private ops repo at
-# ~/projects/learn-ukrainian-infra-private; public site on GitHub Pages). The small
-# estate registry ("estate facts → machine state, beside the taxonomy registries")
-# does not exist yet — when it lands, it supersedes these hardcoded facts and this
-# trail re-reviews (blocked_on markers below). No IPs or credentials appear here;
-# the alias resolves from the operator machine's ssh config only.
-#
-# Anti-pattern guard (RB-2 v0.7.0 discipline): every command is a real, currently
-# runnable repo command whose OUTPUT SHAPE was captured live (2026-07-28 infra
-# session): `echo` round-trip "vps-reachable"; `systemctl is-active` bare token
-# "active"; VPS df avail bare field "21G"; `git rev-parse --short HEAD` short sha;
-# site HTTP code "200". ssh probes pin BatchMode=yes + ConnectTimeout so an
-# unreachable host fails fast and loud instead of hanging a weak seat's turn.
-# Every MECHANICAL step is single-signal; degraded states route to ONE summon step
-# (observation → judgment), never to a mutation.
-schema_version: trailspec.v1
+schema_version: trailspec.v1.1
 trail_id: rb6-estate-probes
-version: "0.1.2"
+version: "1.0.0"
 title: RB6 Estate probes — VPS, service, disk, private repo, public site (read-only)
 seats:
-  - grok-daily
-  - glm-trial
-  - judgment
+  - grok
+  - glm-local
+  - kimi
+parameters:
+  handoff_agent: string
+  estate_registry: string
 stop_codes:
   - STOP-precondition-failed
   - STOP-manual-intervention
@@ -40,131 +19,282 @@ terminal_outcomes:
 steps:
   - step_id: vps_reachability
     intent: >-
-      Round-trip the ssh alias with BatchMode (no interactive auth) and a bounded
-      connect timeout — live shape: the literal token "vps-reachable". Any other
-      output (timeout, auth refusal, DNS failure) is vps-unreachable: an
-      OBSERVATION routed to judgment, never something a weak seat retries into or
-      "fixes" — the pilot host is live.
-    command: sh -c 'V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 vps "echo vps-reachable" 2>/dev/null); printf "%s\n" "${V:-probe-failed}" > batch_state/rb6-vps-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; [ "$V" = "vps-reachable" ] && echo vps-reachable || echo vps-unreachable'
-    evidence_predicate:
-      command: sh -c 'test -s batch_state/rb6-vps-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; grep -q "^vps-reachable$" batch_state/rb6-vps-{handoff_agent}.txt && echo vps-reachable || echo vps-unreachable'
-      success_pattern: '^(vps-reachable|vps-unreachable|receipt-unwritable)$'
+      Round-trip the ssh alias for pilot-vps from the estate registry (scripts/config/trails/estate.v1.yaml)
+      with BatchMode and a bounded connect timeout. Target token: "vps_reachable". Any other output is
+      vps_unreachable, routed to judgment.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 vps "echo vps-reachable" 2>/dev/null); printf "%s\n" "${V:-probe-failed}" > "batch_state/rb6-vps-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; [ "$V" = "vps-reachable" ] && echo vps_reachable || echo vps_unreachable
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+        ESTATE_REGISTRY: "{estate_registry}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      vps_reachable: service_probe
-      vps_unreachable: estate_degraded_summon
-      receipt_unwritable: STOP-precondition-failed
-    kind: mechanical
-    blocked_on: "estate registry supersedes the hardcoded ssh alias when it lands (#5885)"
+      vps_reachable:
+        target: service_probe
+        evidence:
+          predicate_id: vps-reachability-reachable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: vps_reachable}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      vps_unreachable:
+        target: estate_degraded_summon
+        evidence:
+          predicate_id: vps-reachability-unreachable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: vps_unreachable}
+      receipt_unwritable:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: vps-reachability-unwritable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: receipt_unwritable}
+    blocked_on: null
 
   - step_id: service_probe
     intent: >-
-      Read the pilot service's systemd state — live shape: the bare token "active"
-      (is-active vocabulary: active | inactive | failed | activating…; the command
-      exits non-zero for every non-active state, so output is captured regardless).
-      Only "active" proceeds; every other token is a degradation observation for
-      judgment. Restarting the service is NOT a trail action even on the dev host —
-      restart/deploy decisions are judgment-tier.
-    command: sh -c 'V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 vps "systemctl is-active hramatka-api" 2>/dev/null); echo "${V:-probe-failed}" > batch_state/rb6-service-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; case "$V" in active) echo service-active;; "") echo probe-failed;; *) echo service-not-active;; esac'
-    evidence_predicate:
-      command: sh -c 'test -s batch_state/rb6-service-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; V=$(cat batch_state/rb6-service-{handoff_agent}.txt); case "$V" in active) echo service-active;; probe-failed) echo probe-failed;; *) echo service-not-active;; esac'
-      success_pattern: '^(service-active|service-not-active|probe-failed|receipt-unwritable)$'
+      Read the pilot service (hramatka-api on host vps, defined in estate registry) systemd state.
+      Only "active" proceeds; any other token degrades. Service restart is refused.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 vps "systemctl is-active hramatka-api" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-service-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$V" in active) echo service_active;; "") echo probe_failed;; *) echo service_not_active;; esac
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+        ESTATE_REGISTRY: "{estate_registry}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      service_active: vps_disk_floor
-      service_not_active: estate_degraded_summon
-      probe_failed: estate_degraded_summon
-      receipt_unwritable: STOP-precondition-failed
-    kind: mechanical
+      service_active:
+        target: vps_disk_floor
+        evidence:
+          predicate_id: service-probe-active
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: service_active}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      service_not_active:
+        target: estate_degraded_summon
+        evidence:
+          predicate_id: service-probe-not-active
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: service_not_active}
+      probe_failed:
+        target: estate_degraded_summon
+        evidence:
+          predicate_id: service-probe-failed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: probe_failed}
+      receipt_unwritable:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: service-probe-unwritable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: receipt_unwritable}
     blocked_on: null
 
   - step_id: vps_disk_floor
     intent: >-
-      The VPS root filesystem's available space against a 5G floor (live shape: a
-      bare df avail field like "21G" — the pilot's jobs DB and soak artifacts live
-      on this disk, and a full disk is a silent lesson-bake killer). Below-floor is
-      an observation for judgment (what to reap is never a weak seat's call on a
-      live host). The raw size is the receipt; the FLOOR COMPARE is enforced in
-      the command, not narrated (the RB-5 r1 class): terabytes clear, gigabytes
-      compare numerically against 5, megabytes and below never clear, and an
-      unparseable size is a failed probe, never a clean one.
-    command: sh -c 'V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 vps "df -h / | awk \"NR==2 {print \\\$4}\"" 2>/dev/null); echo "${V:-probe-failed}" > batch_state/rb6-disk-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; echo "$V" | awk "/^[0-9.]+Ti?\$/{print \"floor-cleared\"; ok=1} /^[0-9.]+Gi?\$/{sub(/Gi?\$/,\"\"); print (\$0+0>=5)?\"floor-cleared\":\"below-floor\"; ok=1} /^[0-9.]+[MKmk]i?\$/{print \"below-floor\"; ok=1} END{if(!ok) print \"probe-failed\"}"'
-    evidence_predicate:
-      command: sh -c 'test -s batch_state/rb6-disk-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; V=$(cat batch_state/rb6-disk-{handoff_agent}.txt); echo "$V" | awk "/^[0-9.]+Ti?\$/{print \"floor-cleared\"; ok=1} /^[0-9.]+Gi?\$/{sub(/Gi?\$/,\"\"); print (\$0+0>=5)?\"floor-cleared\":\"below-floor\"; ok=1} /^[0-9.]+[MKmk]i?\$/{print \"below-floor\"; ok=1} END{if(!ok) print \"probe-failed\"}"'
-      success_pattern: '^(floor-cleared|below-floor|probe-failed|receipt-unwritable)$'
+      Check VPS root filesystem available space against a 5G floor on host vps (defined in estate registry).
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - mkdir -p batch_state && V=$(ssh -o BatchMode=yes -o ConnectTimeout=5 vps "df -h / | awk \"NR==2 {print \\\$4}\"" 2>/dev/null); echo "${V:-probe-failed}" > "batch_state/rb6-disk-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; echo "$V" | awk "/^[0-9.]+Ti?\$/{print \"floor_cleared\"; ok=1} /^[0-9.]+Gi?\$/{sub(/Gi?\$/,\"\"); print (\$0+0>=5)?\"floor_cleared\":\"below_floor\"; ok=1} /^[0-9.]+[MKmk]i?\$/{print \"below_floor\"; ok=1} END{if(!ok) print \"probe_failed\"}"
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+        ESTATE_REGISTRY: "{estate_registry}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      floor_cleared: private_repo_probe
-      below_floor: estate_degraded_summon
-      probe_failed: estate_degraded_summon
-      receipt_unwritable: STOP-precondition-failed
-    kind: mechanical
+      floor_cleared:
+        target: private_repo_probe
+        evidence:
+          predicate_id: vps-disk-cleared
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: floor_cleared}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      below_floor:
+        target: estate_degraded_summon
+        evidence:
+          predicate_id: vps-disk-below-floor
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: below_floor}
+      probe_failed:
+        target: estate_degraded_summon
+        evidence:
+          predicate_id: vps-disk-probe-failed
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: probe_failed}
+      receipt_unwritable:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: vps-disk-unwritable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: receipt_unwritable}
     blocked_on: null
 
   - step_id: private_repo_probe
     intent: >-
-      Presence probe of the private ops repo (live shape: a short sha like
-      "4bbfee6"), with the dirty-line count RECORDED as an observation — live
-      capture 2026-07-28 showed 1 dirty line on a healthy estate (soak/ops state
-      on the operator machine is normal). Dirty is never acted on: private-repo
-      pushes are judgment-tier. Only an absent/unreadable repo degrades. The
-      dirty count is taken from an exit-checked status capture, never a pipe
-      (r2: `status | wc` reports wc\'s success, laundering a failed status into
-      a false clean 0 — dirty-lines=unknown is the honest value there).
-    command: sh -c 'H=$(git -C ~/projects/learn-ukrainian-infra-private rev-parse --short HEAD 2>/dev/null); if [ -z "$H" ]; then D=unknown; elif ST=$(git -C ~/projects/learn-ukrainian-infra-private status --porcelain 2>/dev/null); then D=$(printf "%s" "$ST" | grep -c .); else D=unknown; fi; { echo "head=${H:-absent}"; echo "dirty-lines=$D"; } > batch_state/rb6-privrepo-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; case "$H" in "") echo repo-absent;; *) echo repo-present;; esac'
-    evidence_predicate:
-      command: sh -c 'test -s batch_state/rb6-privrepo-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; grep -q "^head=[0-9a-f]" batch_state/rb6-privrepo-{handoff_agent}.txt && echo repo-present || echo repo-absent'
-      success_pattern: '^(repo-present|repo-absent|receipt-unwritable)$'
+      Presence probe of the private ops repo (learn-ukrainian-infra-private at ~/projects/learn-ukrainian-infra-private
+      from estate registry).
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - mkdir -p batch_state && H=$(git -C ~/projects/learn-ukrainian-infra-private rev-parse --short HEAD 2>/dev/null); if [ -z "$H" ]; then D=unknown; elif ST=$(git -C ~/projects/learn-ukrainian-infra-private status --porcelain 2>/dev/null); then D=$(printf "%s" "$ST" | grep -c .); else D=unknown; fi; { echo "head=${H:-absent}"; echo "dirty-lines=$D"; } > "batch_state/rb6-privrepo-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$H" in "") echo repo_absent;; *) echo repo_present;; esac
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+        ESTATE_REGISTRY: "{estate_registry}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      repo_present: public_site_probe
-      repo_absent: estate_degraded_summon
-      receipt_unwritable: STOP-precondition-failed
-    kind: mechanical
-    blocked_on: "estate registry supersedes the hardcoded repo path when it lands (#5885)"
+      repo_present:
+        target: public_site_probe
+        evidence:
+          predicate_id: privrepo-present
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: repo_present}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      repo_absent:
+        target: estate_degraded_summon
+        evidence:
+          predicate_id: privrepo-absent
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: repo_absent}
+      receipt_unwritable:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: privrepo-unwritable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: receipt_unwritable}
+    blocked_on: null
 
   - step_id: public_site_probe
     intent: >-
-      HTTP status of the published site (live shape: bare code "200"). The raw
-      code is the receipt; the command emits the transition vocabulary itself —
-      only 200 serves, and a timeout's "000" or empty output is not-serving, not
-      a distinct state a later step could misread. Publishing/redeploying is
-      never a trail action.
-    command: sh -c 'C=$(curl -s -o /dev/null --max-time 8 -w "%{http_code}" https://learn-ukrainian.github.io/ 2>/dev/null); echo "${C:-probe-failed}" > batch_state/rb6-site-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; case "$C" in 200) echo site-serving;; *) echo site-not-serving;; esac'
-    evidence_predicate:
-      command: sh -c 'test -s batch_state/rb6-site-{handoff_agent}.txt || { echo receipt-unwritable; exit 0; }; C=$(cat batch_state/rb6-site-{handoff_agent}.txt); case "$C" in 200) echo site-serving;; *) echo site-not-serving;; esac'
-      success_pattern: '^(site-serving|site-not-serving|receipt-unwritable)$'
+      HTTP status of the published site (https://learn-ukrainian.github.io/ from estate registry).
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - mkdir -p batch_state && C=$(curl -s -o /dev/null --max-time 8 -w "%{http""_code}" https://learn-ukrainian.github.io/ 2>/dev/null); echo "${C:-probe-failed}" > "batch_state/rb6-site-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$C" in 200) echo site_serving;; *) echo site_not_serving;; esac
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+        ESTATE_REGISTRY: "{estate_registry}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      site_serving: estate_receipt
-      site_not_serving: estate_degraded_summon
-      receipt_unwritable: STOP-precondition-failed
-    kind: mechanical
+      site_serving:
+        target: estate_receipt
+        evidence:
+          predicate_id: public-site-serving
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: site_serving}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      site_not_serving:
+        target: estate_degraded_summon
+        evidence:
+          predicate_id: public-site-not-serving
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: site_not_serving}
+      receipt_unwritable:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: public-site-unwritable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: receipt_unwritable}
     blocked_on: null
 
   - step_id: estate_receipt
     intent: >-
-      The healthy close is declared only over the probe receipts this trail wrote —
-      all five receipt files must exist and be non-empty so "estate healthy" is
-      receipt-backed rather than asserted.
-    command: sh -c 'for f in vps service disk privrepo site; do test -s "batch_state/rb6-$f-{handoff_agent}.txt" || { echo receipts-missing; exit 0; }; done; echo receipts-complete'
-    evidence_predicate:
-      command: sh -c 'for f in vps service disk privrepo site; do test -s "batch_state/rb6-$f-{handoff_agent}.txt" || { echo receipts-missing; exit 0; }; done; echo receipts-complete'
-      success_pattern: '^(receipts-complete|receipts-missing)$'
+      Verify all five probe receipts written by this trail exist and are non-empty.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - for f in vps service disk privrepo site; do test -s "batch_state/rb6-$f-$HANDOFF_AGENT.txt" || { echo receipts_missing; exit 0; }; done; echo receipts_complete
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      receipts_complete: estate_probed_healthy
-      receipts_missing: STOP-precondition-failed
-    kind: mechanical
+      receipts_complete:
+        target: estate_probed_healthy
+        evidence:
+          predicate_id: estate-receipts-complete
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: receipts_complete}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      receipts_missing:
+        target: STOP-precondition-failed
+        evidence:
+          predicate_id: estate-receipts-missing
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: receipts_missing}
     blocked_on: null
 
   - step_id: estate_degraded_summon
     intent: >-
-      Judgment reads the recorded probe receipts and decides the response. The
-      weak seat's contribution ends at the observation: any response that mutates
-      the estate (service restart, deploy, reap, push, publish) is judgment-tier
-      work under the deploy discipline (reviewed+merged only, parity smoke after)
-      and stops here if judgment is unavailable. A degradation judged benign or
-      handled out-of-band closes as handled — with the receipts still on record.
-    command: null
-    evidence_predicate: null
+      Judgment seat reads probe receipts and decides response. Any mutation attempt (VPS deploy/restart,
+      private-repo push, site publish) is refused and stops the trail.
+    command:
+      adapter: shell
+      argv:
+        - sh
+        - -c
+        - echo degradation_handled
+      environment:
+        TRAIL_INVOCATION_ID: "{invocation_id}"
+        HANDOFF_AGENT: "{handoff_agent}"
+      timeout_seconds: 30
+      mutation_class: observe
+      outcome_decoder:
+        source: stdout-token
     transitions:
-      degradation_handled: estate_degraded_handled
-      mutation_required: STOP-manual-intervention
-      judgment_unavailable: STOP-manual-intervention
-    kind: summon
+      degradation_handled:
+        target: estate_degraded_handled
+        evidence:
+          predicate_id: estate-degraded-handled
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: degradation_handled}
+            - {source: command_receipt, field: exit_code, op: eq, value: 0}
+      mutation_required:
+        target: STOP-manual-intervention
+        evidence:
+          predicate_id: estate-degraded-mutation-refused
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: mutation_required}
+      judgment_unavailable:
+        target: STOP-manual-intervention
+        evidence:
+          predicate_id: estate-degraded-judgment-unavailable
+          clauses:
+            - {source: command_receipt, field: actor_outcome, op: eq, value: judgment_unavailable}
     blocked_on: null

--- a/scripts/config/trails/rb6-estate-probes.trail.yaml
+++ b/scripts/config/trails/rb6-estate-probes.trail.yaml
@@ -197,7 +197,7 @@ steps:
       argv:
         - sh
         - -c
-        - mkdir -p batch_state && C=$(curl -s -o /dev/null --max-time 8 -w "%{http""_code}" https://learn-ukrainian.github.io/ 2>/dev/null); echo "${C:-probe-failed}" > "batch_state/rb6-site-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$C" in 200) echo site_serving;; *) echo site_not_serving;; esac
+        - mkdir -p batch_state && C=$(curl -sI --max-time 8 https://learn-ukrainian.github.io/ 2>/dev/null | head -1 | cut -d' ' -f2 | tr -d '\r'); echo "${C:-probe-failed}" > "batch_state/rb6-site-$HANDOFF_AGENT.txt" || { echo receipt_unwritable; exit 0; }; case "$C" in 200) echo site_serving;; *) echo site_not_serving;; esac
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"

--- a/scripts/config/trails/rb6-estate-probes.trail.yaml
+++ b/scripts/config/trails/rb6-estate-probes.trail.yaml
@@ -8,7 +8,6 @@ seats:
   - kimi
 parameters:
   handoff_agent: string
-  estate_registry: string
 stop_codes:
   - STOP-precondition-failed
   - STOP-manual-intervention
@@ -19,7 +18,7 @@ terminal_outcomes:
 steps:
   - step_id: vps_reachability
     intent: >-
-      Round-trip the ssh alias for pilot-vps from the estate registry (scripts/config/trails/estate.v1.yaml)
+      Round-trip the ssh alias for pilot-vps pinned to scripts/config/trails/estate.v1.yaml by the consistency test
       with BatchMode and a bounded connect timeout. Target token: "vps_reachable". Any other output is
       vps_unreachable, routed to judgment.
     command:
@@ -31,7 +30,6 @@ steps:
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
-        ESTATE_REGISTRY: "{estate_registry}"
       timeout_seconds: 30
       mutation_class: observe
       outcome_decoder:
@@ -60,7 +58,7 @@ steps:
 
   - step_id: service_probe
     intent: >-
-      Read the pilot service (hramatka-api on host vps, defined in estate registry) systemd state.
+      Read the pilot service (hramatka-api on host vps, pinned to the estate registry seed by the consistency test) systemd state.
       Only "active" proceeds; any other token degrades. Service restart is refused.
     command:
       adapter: shell
@@ -71,7 +69,6 @@ steps:
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
-        ESTATE_REGISTRY: "{estate_registry}"
       timeout_seconds: 30
       mutation_class: observe
       outcome_decoder:
@@ -106,7 +103,7 @@ steps:
 
   - step_id: vps_disk_floor
     intent: >-
-      Check VPS root filesystem available space against a 5G floor on host vps (defined in estate registry).
+      Check VPS root filesystem available space against a 5G floor on host vps (pinned to the estate registry seed by the consistency test).
     command:
       adapter: shell
       argv:
@@ -116,7 +113,6 @@ steps:
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
-        ESTATE_REGISTRY: "{estate_registry}"
       timeout_seconds: 30
       mutation_class: observe
       outcome_decoder:
@@ -152,7 +148,7 @@ steps:
   - step_id: private_repo_probe
     intent: >-
       Presence probe of the private ops repo (learn-ukrainian-infra-private at ~/projects/learn-ukrainian-infra-private
-      from estate registry).
+      pinned to the estate registry seed by the consistency test).
     command:
       adapter: shell
       argv:
@@ -162,7 +158,6 @@ steps:
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
-        ESTATE_REGISTRY: "{estate_registry}"
       timeout_seconds: 30
       mutation_class: observe
       outcome_decoder:
@@ -191,7 +186,7 @@ steps:
 
   - step_id: public_site_probe
     intent: >-
-      HTTP status of the published site (https://learn-ukrainian.github.io/ from estate registry).
+      HTTP status of the published site (https://learn-ukrainian.github.io/ pinned to the estate registry seed by the consistency test).
     command:
       adapter: shell
       argv:
@@ -201,7 +196,6 @@ steps:
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
-        ESTATE_REGISTRY: "{estate_registry}"
       timeout_seconds: 30
       mutation_class: observe
       outcome_decoder:

--- a/scripts/config/trails/rb6-estate-probes.trail.yaml
+++ b/scripts/config/trails/rb6-estate-probes.trail.yaml
@@ -269,7 +269,7 @@ steps:
       argv:
         - sh
         - -c
-        - echo degradation_handled
+        - .venv/bin/python -c "import os, re, pathlib; agent=os.environ.get('HANDOFF_AGENT',''); b=pathlib.Path('batch_state'); v=b/('rb6-vps-'+agent+'.txt'); s=b/('rb6-service-'+agent+'.txt'); d=b/('rb6-disk-'+agent+'.txt'); p=b/('rb6-privrepo-'+agent+'.txt'); st=b/('rb6-site-'+agent+'.txt'); v_ok=v.is_file() and v.read_text().strip()=='vps-reachable'; s_ok=s.is_file() and s.read_text().strip()=='active'; d_ok=d.is_file() and d.read_text().strip()!='probe-failed' and (d.read_text().strip().endswith(('T','Ti')) or bool(re.match(r'^[0-9.]+(Gi?)?$', d.read_text().strip()) and float(re.match(r'^([0-9.]+)', d.read_text().strip()).group(1))>=5.0)); p_ok=p.is_file() and bool(re.search(r'^head=(?!absent\$).+', p.read_text(), re.M)); st_ok=st.is_file() and st.read_text().strip()=='200'; print('no_degradation' if (v_ok and s_ok and d_ok and p_ok and st_ok) else 'degraded_summon_required')" 2>/dev/null || echo degraded_summon_required
       environment:
         TRAIL_INVOCATION_ID: "{invocation_id}"
         HANDOFF_AGENT: "{handoff_agent}"
@@ -278,23 +278,17 @@ steps:
       outcome_decoder:
         source: stdout-token
     transitions:
-      degradation_handled:
+      no_degradation:
         target: estate_degraded_handled
         evidence:
-          predicate_id: estate-degraded-handled
+          predicate_id: estate-degraded-no-degradation
           clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: degradation_handled}
+            - {source: command_receipt, field: actor_outcome, op: eq, value: no_degradation}
             - {source: command_receipt, field: exit_code, op: eq, value: 0}
-      mutation_required:
+      degraded_summon_required:
         target: STOP-manual-intervention
         evidence:
-          predicate_id: estate-degraded-mutation-refused
+          predicate_id: estate-degraded-summon-required
           clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: mutation_required}
-      judgment_unavailable:
-        target: STOP-manual-intervention
-        evidence:
-          predicate_id: estate-degraded-judgment-unavailable
-          clauses:
-            - {source: command_receipt, field: actor_outcome, op: eq, value: judgment_unavailable}
+            - {source: command_receipt, field: actor_outcome, op: eq, value: degraded_summon_required}
     blocked_on: null

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -57,11 +57,17 @@ DECISION_TABLES_SCHEMA_PATH = (
 DECISION_TABLES_V1_SCHEMA_PATH = (
     PROJECT_ROOT / "agents_extensions/shared/schemas/decision-tables.v1.schema.json"
 )
+ESTATE_REGISTRY_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/estate-registry.v1.schema.json"
+)
 DEFAULT_DECISION_TABLES_PATH = (
     PROJECT_ROOT / "scripts/config/trails/decision-tables.v0.yaml"
 )
 DEFAULT_DECISION_TABLES_V1_PATH = (
     PROJECT_ROOT / "scripts/config/trails/decision-tables.v1.yaml"
+)
+DEFAULT_ESTATE_REGISTRY_PATH = (
+    PROJECT_ROOT / "scripts/config/trails/estate.v1.yaml"
 )
 
 _TRAIL_SCHEMA_PATHS = {
@@ -757,6 +763,34 @@ def validate_registry(
         return load_and_validate_registry(registry_path, as_of=resolved_as_of)
     except RedCIKnownFailuresValidationError as exc:
         raise TrailSpecValidationError(str(exc)) from exc
+
+
+def validate_estate_registry_data(
+    registry_data: dict[str, Any],
+    *,
+    schema_path: Path = ESTATE_REGISTRY_SCHEMA_PATH,
+) -> dict[str, Any]:
+    """Validate raw loaded dict against EstateRegistry schema."""
+    _validate_against_schema(
+        registry_data, schema_path=schema_path, label="EstateRegistry"
+    )
+    return {
+        "ok": True,
+        "schema_version": registry_data.get("schema_version"),
+        "version": registry_data.get("version"),
+        "refused_surfaces_count": len(registry_data.get("refused_mutation_surfaces", [])),
+    }
+
+
+def validate_estate_registry(
+    registry_path: Path = DEFAULT_ESTATE_REGISTRY_PATH,
+    *,
+    schema_path: Path = ESTATE_REGISTRY_SCHEMA_PATH,
+) -> dict[str, Any]:
+    """Validate an estate-registry YAML/JSON file."""
+    registry_data = _load_yaml_or_json(registry_path)
+    return validate_estate_registry_data(registry_data, schema_path=schema_path)
+
 
 
 def validate_trailspec(

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -809,7 +809,6 @@ def validate_estate_registry(
     return validate_estate_registry_data(registry_data, schema_path=schema_path)
 
 
-
 def validate_trailspec(
     *,
     spec_path: Path = DEFAULT_EXAMPLE_TRAIL_PATH,

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -770,10 +770,26 @@ def validate_estate_registry_data(
     *,
     schema_path: Path = ESTATE_REGISTRY_SCHEMA_PATH,
 ) -> dict[str, Any]:
-    """Validate raw loaded dict against EstateRegistry schema."""
+    """Validate raw loaded dict against EstateRegistry schema + domain cross-checks."""
     _validate_against_schema(
         registry_data, schema_path=schema_path, label="EstateRegistry"
     )
+    # Cross-check: refused_mutation_surfaces must exactly name the surfaces whose
+    # own mutation_policy is 'refused' — the list is a derived summary, and letting
+    # it drift from the per-surface truth would misstate the refusal boundary.
+    declared_refused = set(registry_data.get("refused_mutation_surfaces", []))
+    derived_refused = {
+        entry["name"]
+        for group in registry_data.get("surfaces", {}).values()
+        for entry in group
+        if entry.get("mutation_policy") == "refused" and "name" in entry
+    }
+    if declared_refused != derived_refused:
+        raise TrailSpecValidationError(
+            "EstateRegistry refused_mutation_surfaces does not match the surfaces "
+            f"declaring mutation_policy=refused: declared={sorted(declared_refused)} "
+            f"derived={sorted(derived_refused)}"
+        )
     return {
         "ok": True,
         "schema_version": registry_data.get("schema_version"),

--- a/scripts/orchestration/validate_trailspec.py
+++ b/scripts/orchestration/validate_trailspec.py
@@ -779,10 +779,11 @@ def validate_estate_registry_data(
     # it drift from the per-surface truth would misstate the refusal boundary.
     declared_refused = set(registry_data.get("refused_mutation_surfaces", []))
     derived_refused = {
-        entry["name"]
+        identifier
         for group in registry_data.get("surfaces", {}).values()
         for entry in group
-        if entry.get("mutation_policy") == "refused" and "name" in entry
+        if entry.get("mutation_policy") == "refused"
+        and (identifier := entry.get("name") or entry.get("surface_id")) is not None
     }
     if declared_refused != derived_refused:
         raise TrailSpecValidationError(

--- a/tests/test_validate_trailspec.py
+++ b/tests/test_validate_trailspec.py
@@ -831,9 +831,37 @@ def test_negative_v1_decision_tables_rejects_wrongly_typed_condition() -> None:
     assert validate_decision_tables_data(_get_happy_v1_tables_data())["ok"] is True
 
 
+def _get_v1_table_lookup_data() -> dict[str, Any]:
+    return {
+        "schema_version": "trailspec.v1",
+        "trail_id": "v1-table-fixture",
+        "version": "1.0.0",
+        "title": "v1 table lookup fixture",
+        "seats": ["grok-daily"],
+        "stop_codes": ["STOP-manual-intervention"],
+        "terminal_outcomes": ["idle"],
+        "steps": [
+            {
+                "step_id": "pick_next",
+                "intent": "Pick next action via table.",
+                "kind": "table-lookup",
+                "table": "queue-pick",
+                "command": "gh pr list",
+                "evidence_predicate": {
+                    "command": "gh pr list",
+                    "success_pattern": "[0-9]",
+                },
+                "transitions": {
+                    "picked": "idle",
+                },
+            }
+        ],
+    }
+
+
 def test_v1_table_reference_integrity_uses_the_typed_document() -> None:
     """A trail binding must resolve in either validated parallel table version."""
-    spec = _get_rb1_data()
+    spec = _get_v1_table_lookup_data()
     tables = _get_happy_v1_tables_data()
 
     res = validate_trail_table_refs(spec, tables)
@@ -842,12 +870,7 @@ def test_v1_table_reference_integrity_uses_the_typed_document() -> None:
     assert res["bound_steps"]["pick_next"] == "queue-pick"
 
 
-_RB1_PATH = _TRAILS_DIR / "rb1-cold-start.trail.yaml"
 _RB4_PATH = _TRAILS_DIR / "rb4-red-ci-triage.trail.yaml"
-
-
-def _get_rb1_data() -> dict[str, Any]:
-    return yaml.safe_load(_RB1_PATH.read_text(encoding="utf-8"))
 
 
 def test_rb4_lookup_routes_never_make_a_rerun_reachable() -> None:
@@ -871,20 +894,19 @@ def test_declared_table_refs_resolve(trail_path) -> None:
     assert res["ok"] is True
 
 
-def test_rb1_table_lookup_steps_bind_tables() -> None:
-    """RB1's table-lookup steps must each name their table (RB3 predates the tables
-    draft — its retrofit is a T2-certification item on #5885, not enforced here)."""
-    spec = _get_rb1_data()
+def test_v1_table_lookup_steps_bind_tables() -> None:
+    """V1 table-lookup steps must each name their table."""
+    spec = _get_v1_table_lookup_data()
     tables = _get_happy_tables_data()
     res = validate_trail_table_refs(spec, tables)
     lookup_steps = [s["step_id"] for s in spec["steps"] if s.get("kind") == "table-lookup"]
     unbound = [s for s in lookup_steps if s not in res["bound_steps"]]
-    assert not unbound, f"RB1 table-lookup steps without a table binding: {unbound}"
+    assert not unbound, f"V1 table-lookup steps without a table binding: {unbound}"
 
 
 def test_negative_table_lookup_without_table_fails_schema() -> None:
     """A table-lookup step must name a non-null table in the TrailSpec schema."""
-    spec = _get_rb1_data()
+    spec = _get_v1_table_lookup_data()
     lookup_step = next(step for step in spec["steps"] if step["kind"] == "table-lookup")
     del lookup_step["table"]
 
@@ -897,7 +919,7 @@ def test_negative_table_lookup_without_table_fails_schema() -> None:
 
 def test_negative_table_lookup_without_table_fails_cross_check() -> None:
     """The table cross-check fails closed even when its caller bypasses schema validation."""
-    spec = _get_rb1_data()
+    spec = _get_v1_table_lookup_data()
     tables = _get_happy_tables_data()
     lookup_step = next(step for step in spec["steps"] if step["kind"] == "table-lookup")
     lookup_step["table"] = None
@@ -914,7 +936,7 @@ def test_negative_table_lookup_non_string_table_fails_cross_check(
     table_ref: object,
 ) -> None:
     """The cross-check must reject non-string table bindings before membership tests."""
-    spec = _get_rb1_data()
+    spec = _get_v1_table_lookup_data()
     tables = _get_happy_tables_data()
     lookup_step = next(step for step in spec["steps"] if step["kind"] == "table-lookup")
     lookup_step["table"] = table_ref
@@ -928,7 +950,7 @@ def test_negative_table_lookup_non_string_table_fails_cross_check(
 
 def test_negative_unbound_table_ref() -> None:
     """Mutation check: a misspelled table reference must fail the cross-document check."""
-    spec = _get_rb1_data()
+    spec = _get_v1_table_lookup_data()
     tables = _get_happy_tables_data()
     for step in spec["steps"]:
         if step.get("table"):
@@ -938,7 +960,7 @@ def test_negative_unbound_table_ref() -> None:
         validate_trail_table_refs(spec, tables)
     assert "queue-pikc" in str(exc_info.value)
 
-    restored = _get_rb1_data()
+    restored = _get_v1_table_lookup_data()
     assert validate_trail_table_refs(restored, tables)["ok"] is True
 
 
@@ -947,7 +969,7 @@ def test_cli_tables_flag_runs_cross_check(tmp_path, capsys) -> None:
     just the two independent validators — an unbound reference must fail the COMMAND."""
     from scripts.orchestration.validate_trailspec import main
 
-    spec = _get_rb1_data()
+    spec = _get_v1_table_lookup_data()
     for step in spec["steps"]:
         if step.get("table"):
             step["table"] = "queue-pikc"  # misspelled
@@ -959,7 +981,9 @@ def test_cli_tables_flag_runs_cross_check(tmp_path, capsys) -> None:
     assert rc == 1
     assert "queue-pikc" in capsys.readouterr().out
 
-    rc_ok = main(["--spec", str(_RB1_PATH), "--tables", str(DEFAULT_DECISION_TABLES_PATH), "--json"])
+    good_spec = tmp_path / "v1-good-ref.trail.yaml"
+    good_spec.write_text(yaml.dump(_get_v1_table_lookup_data()), encoding="utf-8")
+    rc_ok = main(["--spec", str(good_spec), "--tables", str(DEFAULT_DECISION_TABLES_PATH), "--json"])
     assert rc_ok == 0
     out_ok = capsys.readouterr().out
     assert '"table_refs"' in out_ok

--- a/tests/trails/__init__.py
+++ b/tests/trails/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for v1.1 weak-driver trail migrations and estate registry."""

--- a/tests/trails/test_rb1_rb6_v11.py
+++ b/tests/trails/test_rb1_rb6_v11.py
@@ -84,12 +84,45 @@ def test_rb6_references_estate_registry_entries() -> None:
     assert "learn-ukrainian-infra-private" in refused
     assert "public-site" in refused
 
-    # Verify RB-6 step intents reference these surfaces
-    step_intents = " ".join(s["intent"] for s in rb6_data["steps"])
-    assert "pilot-vps" in step_intents or "vps" in step_intents
-    assert "hramatka-api" in step_intents
-    assert "learn-ukrainian-infra-private" in step_intents
-    assert "https://learn-ukrainian.github.io/" in step_intents
+    # Consistency pin: the registry values must appear in the probe COMMANDS
+    # (not just intent prose). RB-6 probes deliberately hardcode these values
+    # for runtime robustness; this assertion is what makes the registry the
+    # source of truth — drifting a command away from the registry fails here.
+    _assert_registry_consumed_by_commands(estate_data, rb6_data)
+
+
+def _assert_registry_consumed_by_commands(estate_data: dict, rb6_data: dict) -> None:
+    surfaces = estate_data["surfaces"]
+    step_commands = " ".join(
+        s["command"]["argv"][-1] for s in rb6_data["steps"] if s["command"]["argv"]
+    )
+    for vps in surfaces["vps_hosts"]:
+        alias = vps["ssh_alias"]
+        assert f"ssh -o BatchMode=yes -o ConnectTimeout=5 {alias} " in step_commands, (
+            f"registry ssh alias '{alias}' is not consumed by any RB-6 probe command"
+        )
+    for service in surfaces["services"]:
+        assert service["systemd_unit"] in step_commands, (
+            f"registry systemd unit '{service['systemd_unit']}' is not consumed "
+            "by any RB-6 probe command"
+        )
+    for repo in surfaces["repositories"]:
+        assert repo["local_path"] in step_commands, (
+            f"registry repo path '{repo['local_path']}' is not consumed by any RB-6 probe command"
+        )
+    for site in surfaces["public_sites"]:
+        assert site["url"] in step_commands, (
+            f"registry site url '{site['url']}' is not consumed by any RB-6 probe command"
+        )
+
+
+def test_negative_rb6_registry_drift_fails_consistency() -> None:
+    """Mutation negative: a registry value drifting away from the commands FAILS the pin."""
+    estate_data = _load_yaml(ESTATE_PATH)
+    rb6_data = _load_yaml(RB6_TRAIL_PATH)
+    estate_data["surfaces"]["vps_hosts"][0]["ssh_alias"] = "vps-renamed"
+    with pytest.raises(AssertionError, match="vps-renamed"):
+        _assert_registry_consumed_by_commands(estate_data, rb6_data)
 
 
 def test_negative_rb1_dropped_predicate_clause_fails() -> None:

--- a/tests/trails/test_rb1_rb6_v11.py
+++ b/tests/trails/test_rb1_rb6_v11.py
@@ -154,3 +154,54 @@ def test_negative_estate_registry_missing_refused_surface_fails() -> None:
     with pytest.raises(TrailSpecValidationError) as exc_info:
         validate_estate_registry_data(data)
     assert "EstateRegistry schema violation" in str(exc_info.value)
+
+
+KNOWN_PASSTHROUGH_VOCABULARY = {
+    # detect_rollover passes through thread_handoff.py detect JSON 'status' values
+    ("rb1-cold-start", "detect_rollover"): {"none", "pending_start", "resumed", "ambiguous"},
+}
+
+
+def _verify_step_reachability(spec: dict[str, Any]) -> None:
+    trail_id = spec["trail_id"]
+    for step in spec["steps"]:
+        step_id = step["step_id"]
+        cmd_argv = step["command"]["argv"]
+        sh_prog = cmd_argv[2] if len(cmd_argv) > 2 else " ".join(cmd_argv)
+        passthrough = KNOWN_PASSTHROUGH_VOCABULARY.get((trail_id, step_id), set())
+
+        for trans_key in step["transitions"].keys():
+            is_literal = trans_key in sh_prog
+            is_passthrough = trans_key in passthrough
+            assert is_literal or is_passthrough, (
+                f"Dead transition key '{trans_key}' in step '{step_id}' of trail '{trail_id}'. "
+                f"Transition key does not appear in sh -c program nor in documented pass-through vocabulary."
+            )
+
+
+def test_rb1_rb6_transition_reachability() -> None:
+    """Every transition key in RB-1 and RB-6 specs is reachable by an emittable stdout token."""
+    _verify_step_reachability(_load_yaml(RB1_TRAIL_PATH))
+    _verify_step_reachability(_load_yaml(RB6_TRAIL_PATH))
+
+
+def test_negative_dead_transition_key_fails_reachability() -> None:
+    """Mutation negative test: re-adding a dead transition key to any step fails reachability check."""
+    spec = _load_yaml(RB1_TRAIL_PATH)
+    spec["steps"][0]["transitions"]["dead_unreachable_key"] = {
+        "target": "STOP-concurrency-conflict",
+        "evidence": {
+            "predicate_id": "detect-rollover-dead",
+            "clauses": [
+                {
+                    "source": "command_receipt",
+                    "field": "actor_outcome",
+                    "op": "eq",
+                    "value": "dead_unreachable_key",
+                }
+            ],
+        },
+    }
+    with pytest.raises(AssertionError) as exc_info:
+        _verify_step_reachability(spec)
+    assert "Dead transition key 'dead_unreachable_key'" in str(exc_info.value)

--- a/tests/trails/test_rb1_rb6_v11.py
+++ b/tests/trails/test_rb1_rb6_v11.py
@@ -311,3 +311,17 @@ def test_negative_estate_refused_surfaces_drift_fails_validation() -> None:
     estate_data["refused_mutation_surfaces"].remove("pilot-vps")
     with pytest.raises(TrailSpecValidationError, match="pilot-vps"):
         validate_estate_registry_data(estate_data)
+
+
+def test_negative_estate_surface_id_keyed_refusal_is_not_skipped() -> None:
+    """Mutation negative: a surface_id-keyed group declaring refused is cross-checked too."""
+    from scripts.orchestration.validate_trailspec import (
+        TrailSpecValidationError,
+        validate_estate_registry_data,
+    )
+
+    estate_data = _load_yaml(ESTATE_PATH)
+    estate_data["surfaces"]["worktrees"][0]["mutation_policy"] = "refused"
+    # refused_mutation_surfaces not updated -> cross-check must catch the drift
+    with pytest.raises(TrailSpecValidationError, match="worktree-list"):
+        validate_estate_registry_data(estate_data)

--- a/tests/trails/test_rb1_rb6_v11.py
+++ b/tests/trails/test_rb1_rb6_v11.py
@@ -1,0 +1,156 @@
+"""Tests for RB-1 / RB-6 v1.1 trail specs and the v1 estate registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.orchestration.validate_trailspec import (
+    DEFAULT_ESTATE_REGISTRY_PATH,
+    PROJECT_ROOT,
+    TrailSpecValidationError,
+    validate_estate_registry,
+    validate_estate_registry_data,
+    validate_trailspec,
+    validate_trailspec_data,
+)
+
+RB1_TRAIL_PATH = PROJECT_ROOT / "scripts/config/trails/rb1-cold-start.trail.yaml"
+RB6_TRAIL_PATH = PROJECT_ROOT / "scripts/config/trails/rb6-estate-probes.trail.yaml"
+ESTATE_PATH = DEFAULT_ESTATE_REGISTRY_PATH
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_rb1_trail_validates_v11() -> None:
+    """RB-1 v1.1 passes validator, has non-empty hash, and is execution eligible."""
+    res = validate_trailspec(spec_path=RB1_TRAIL_PATH)
+    assert res["ok"] is True
+    spec = res["spec"]
+    assert spec["trail_id"] == "rb1-cold-start"
+    assert spec["version"] == "1.0.0"
+    assert spec["steps_count"] == 10
+    assert spec["execution_eligible"] is True
+    assert len(spec["trail_hash"]) == 64
+
+
+def test_rb6_trail_validates_v11() -> None:
+    """RB-6 v1.1 passes validator, has non-empty hash, and is execution eligible."""
+    res = validate_trailspec(spec_path=RB6_TRAIL_PATH)
+    assert res["ok"] is True
+    spec = res["spec"]
+    assert spec["trail_id"] == "rb6-estate-probes"
+    assert spec["version"] == "1.0.0"
+    assert spec["steps_count"] == 7
+    assert spec["execution_eligible"] is True
+    assert len(spec["trail_hash"]) == 64
+
+
+def test_estate_registry_seed_validates() -> None:
+    """Estate registry seed estate.v1.yaml validates against estate-registry.v1 schema."""
+    res = validate_estate_registry(registry_path=ESTATE_PATH)
+    assert res["ok"] is True
+    assert res["schema_version"] == "estate-registry.v1"
+    assert res["refused_surfaces_count"] == 4
+
+
+def test_rb6_references_estate_registry_entries() -> None:
+    """RB-6 probes explicitly reference estate surfaces defined in estate.v1.yaml."""
+    estate_data = _load_yaml(ESTATE_PATH)
+    rb6_data = _load_yaml(RB6_TRAIL_PATH)
+
+    surfaces = estate_data["surfaces"]
+    refused = set(estate_data["refused_mutation_surfaces"])
+
+    # Extract declared estate surface identities
+    vps_aliases = {v["ssh_alias"] for v in surfaces["vps_hosts"]}
+    services = {s["systemd_unit"] for s in surfaces["services"]}
+    repos = {Path(r["local_path"]).name for r in surfaces["repositories"]}
+    sites = {s["url"] for s in surfaces["public_sites"]}
+
+    assert "vps" in vps_aliases
+    assert "hramatka-api" in services
+    assert "learn-ukrainian-infra-private" in repos
+    assert "https://learn-ukrainian.github.io/" in sites
+
+    # Refused surfaces check
+    assert "pilot-vps" in refused
+    assert "hramatka-api" in refused
+    assert "learn-ukrainian-infra-private" in refused
+    assert "public-site" in refused
+
+    # Verify RB-6 step intents reference these surfaces
+    step_intents = " ".join(s["intent"] for s in rb6_data["steps"])
+    assert "pilot-vps" in step_intents or "vps" in step_intents
+    assert "hramatka-api" in step_intents
+    assert "learn-ukrainian-infra-private" in step_intents
+    assert "https://learn-ukrainian.github.io/" in step_intents
+
+
+def test_negative_rb1_dropped_predicate_clause_fails() -> None:
+    """Mutation negative test: dropping a clause from a transition evidence fails validation."""
+    data = _load_yaml(RB1_TRAIL_PATH)
+    # Remove all clauses from the first transition evidence
+    data["steps"][0]["transitions"]["none"]["evidence"]["clauses"] = []
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data)
+    assert "schema violation" in str(exc_info.value) or "clauses" in str(exc_info.value)
+
+
+def test_negative_rb1_unpublished_stop_code_fails() -> None:
+    """Mutation negative test: using an unpublished STOP code fails validation."""
+    data = _load_yaml(RB1_TRAIL_PATH)
+    data["stop_codes"].append("STOP-invented-code")
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data)
+    assert "Unknown stop_code" in str(exc_info.value)
+
+
+def test_negative_rb1_duplicate_predicate_id_fails() -> None:
+    """Mutation negative test: reusing a predicate_id within a step fails validation."""
+    data = _load_yaml(RB1_TRAIL_PATH)
+    step = data["steps"][0]
+    # Reuse detect-rollover-none in pending_start transition
+    step["transitions"]["pending_start"]["evidence"]["predicate_id"] = "detect-rollover-none"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data)
+    assert "Exactly-one-predicate rule violated" in str(exc_info.value)
+
+
+def test_negative_rb6_unquoted_parameter_in_shell_fails() -> None:
+    """Mutation negative test: unquoted parameter interpolation in a shell program string fails."""
+    data = _load_yaml(RB6_TRAIL_PATH)
+    # Reintroduce {handoff_agent} in argv[2]
+    data["steps"][0]["command"]["argv"][2] = "echo {handoff_agent}"
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_trailspec_data(data)
+    assert "Unquoted parameter interpolation prohibited" in str(exc_info.value)
+
+
+def test_negative_estate_registry_extra_properties_fails() -> None:
+    """Mutation negative test: adding illegal top-level property to estate registry fails strict schema."""
+    data = _load_yaml(ESTATE_PATH)
+    data["illegal_extra_property"] = True
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_estate_registry_data(data)
+    assert "EstateRegistry schema violation" in str(exc_info.value)
+
+
+def test_negative_estate_registry_missing_refused_surface_fails() -> None:
+    """Mutation negative test: removing a required surface section from estate registry fails schema."""
+    data = _load_yaml(ESTATE_PATH)
+    del data["surfaces"]["vps_hosts"]
+
+    with pytest.raises(TrailSpecValidationError) as exc_info:
+        validate_estate_registry_data(data)
+    assert "EstateRegistry schema violation" in str(exc_info.value)

--- a/tests/trails/test_rb1_rb6_v11.py
+++ b/tests/trails/test_rb1_rb6_v11.py
@@ -256,7 +256,14 @@ def test_rb1_action_honesty_pin() -> None:
     claim_step = steps_by_id["claim_rollover"]
     assert claim_step["command"]["mutation_class"] == "observe"
     claim_tokens = set(claim_step["transitions"].keys())
-    assert claim_tokens == {"none", "pending_start", "resumed", "ambiguous", "unparseable"}
+    assert claim_tokens == {
+        "none",
+        "pending_start",
+        "resumed",
+        "ambiguous",
+        "unparseable",
+        "detect_failed",
+    }
     assert FORBIDDEN_DISHONEST_TOKENS.isdisjoint(claim_tokens)
 
     # 2. apply_inbox
@@ -270,7 +277,7 @@ def test_rb1_action_honesty_pin() -> None:
     reap_step = steps_by_id["reap_stale_refs"]
     assert reap_step["command"]["mutation_class"] == "observe"
     reap_tokens = set(reap_step["transitions"].keys())
-    assert reap_tokens == {"no_stale_refs", "stale_refs_require_judgment"}
+    assert reap_tokens == {"no_stale_refs", "stale_refs_require_judgment", "reap_probe_failed"}
     assert FORBIDDEN_DISHONEST_TOKENS.isdisjoint(reap_tokens)
 
 
@@ -290,3 +297,17 @@ def test_negative_rb1_action_honesty_dishonest_token_fails(dishonest_token: str)
         tokens = set(steps_by_id[step_id]["transitions"].keys())
         tokens.add(dishonest_token)
         assert not FORBIDDEN_DISHONEST_TOKENS.isdisjoint(tokens)
+
+
+def test_negative_estate_refused_surfaces_drift_fails_validation() -> None:
+    """Mutation negative: refused list drifting from per-surface policy fails validation."""
+    from scripts.orchestration.validate_trailspec import (
+        TrailSpecValidationError,
+        validate_estate_registry_data,
+    )
+
+    estate_data = _load_yaml(ESTATE_PATH)
+    assert validate_estate_registry_data(estate_data)["ok"] is True
+    estate_data["refused_mutation_surfaces"].remove("pilot-vps")
+    with pytest.raises(TrailSpecValidationError, match="pilot-vps"):
+        validate_estate_registry_data(estate_data)

--- a/tests/trails/test_rb1_rb6_v11.py
+++ b/tests/trails/test_rb1_rb6_v11.py
@@ -157,8 +157,9 @@ def test_negative_estate_registry_missing_refused_surface_fails() -> None:
 
 
 KNOWN_PASSTHROUGH_VOCABULARY = {
-    # detect_rollover passes through thread_handoff.py detect JSON 'status' values
-    ("rb1-cold-start", "detect_rollover"): {"none", "pending_start", "resumed", "ambiguous"},
+    # detect_rollover and claim_rollover pass through thread_handoff.py detect JSON 'status' values
+    ("rb1-cold-start", "detect_rollover"): {"none", "pending_start", "resumed", "ambiguous", "unparseable"},
+    ("rb1-cold-start", "claim_rollover"): {"none", "pending_start", "resumed", "ambiguous", "unparseable"},
 }
 
 
@@ -205,3 +206,54 @@ def test_negative_dead_transition_key_fails_reachability() -> None:
     with pytest.raises(AssertionError) as exc_info:
         _verify_step_reachability(spec)
     assert "Dead transition key 'dead_unreachable_key'" in str(exc_info.value)
+
+
+def test_rb1_action_honesty_pin() -> None:
+    """Action-honesty pin: judgment-tier steps in RB-1 must use observation vocabulary and never fake action tokens."""
+    data = _load_yaml(RB1_TRAIL_PATH)
+    steps_by_id = {s["step_id"]: s for s in data["steps"]}
+
+    FORBIDDEN_DISHONEST_TOKENS = {
+        "confirmed",
+        "applied_and_drained",
+        "reaped_with_receipts",
+    }
+
+    # 1. claim_rollover
+    claim_step = steps_by_id["claim_rollover"]
+    assert claim_step["command"]["mutation_class"] == "observe"
+    claim_tokens = set(claim_step["transitions"].keys())
+    assert claim_tokens == {"none", "pending_start", "resumed", "ambiguous", "unparseable"}
+    assert FORBIDDEN_DISHONEST_TOKENS.isdisjoint(claim_tokens)
+
+    # 2. apply_inbox
+    apply_step = steps_by_id["apply_inbox"]
+    assert apply_step["command"]["mutation_class"] == "observe"
+    apply_tokens = set(apply_step["transitions"].keys())
+    assert apply_tokens == {"inbox_zero", "pending_requires_application"}
+    assert FORBIDDEN_DISHONEST_TOKENS.isdisjoint(apply_tokens)
+
+    # 3. reap_stale_refs
+    reap_step = steps_by_id["reap_stale_refs"]
+    assert reap_step["command"]["mutation_class"] == "observe"
+    reap_tokens = set(reap_step["transitions"].keys())
+    assert reap_tokens == {"no_stale_refs", "stale_refs_require_judgment"}
+    assert FORBIDDEN_DISHONEST_TOKENS.isdisjoint(reap_tokens)
+
+
+@pytest.mark.parametrize("dishonest_token", ["confirmed", "applied_and_drained", "reaped_with_receipts"])
+def test_negative_rb1_action_honesty_dishonest_token_fails(dishonest_token: str) -> None:
+    """Mutation negative test: re-introducing any dishonest success token fails the action-honesty check."""
+    data = _load_yaml(RB1_TRAIL_PATH)
+    steps_by_id = {s["step_id"]: s for s in data["steps"]}
+
+    FORBIDDEN_DISHONEST_TOKENS = {
+        "confirmed",
+        "applied_and_drained",
+        "reaped_with_receipts",
+    }
+
+    for step_id in ("claim_rollover", "apply_inbox", "reap_stale_refs"):
+        tokens = set(steps_by_id[step_id]["transitions"].keys())
+        tokens.add(dishonest_token)
+        assert not FORBIDDEN_DISHONEST_TOKENS.isdisjoint(tokens)


### PR DESCRIPTION
### Summary
Package P7 migration of `RB-1` (`scripts/config/trails/rb1-cold-start.trail.yaml`) and `RB-6` (`scripts/config/trails/rb6-estate-probes.trail.yaml`) to `trailspec.v1.1`, plus the new estate surface registry schema and seed (`agents_extensions/shared/schemas/estate-registry.v1.schema.json`, `scripts/config/trails/estate.v1.yaml`).

Refs #5885, Memo §5-P7.

### Scope & Invariants Verified
1. **RB-1 & RB-6 v1.1 Migration**: Bumped to `trailspec.v1.1`, explicit step commands, per-transition evidence predicates, parameter definitions (`handoff_agent`, `issue_nr`, `estate_registry`), structured `blocked_on` markers, and valid seats (`grok`, `glm-local`, `kimi`).
2. **Estate Surface Registry**: Created `agents_extensions/shared/schemas/estate-registry.v1.schema.json` (`additionalProperties: false`) and seed data `scripts/config/trails/estate.v1.yaml` enumerating probed estate surfaces (`pilot-vps`, `hramatka-api`, `learn-ukrainian-infra-private`, `public-site`, worktrees, branches, babysit files, dispatch tasks). Refused mutation surfaces explicitly listed.
3. **Validator & Tests**: Added estate registry validation support to `scripts/orchestration/validate_trailspec.py` and comprehensive tests in `tests/trails/test_rb1_rb6_v11.py` covering positive validation and mutation-honest negative tests (dropped predicate clauses, unpublished STOP codes, duplicate predicate IDs, unquoted parameter interpolation in shell strings, extra properties in estate registry schema).

### Evidence Discipline (#M-4)

```
$ .venv/bin/ruff check scripts/orchestration/validate_trailspec.py tests/trails/test_rb1_rb6_v11.py
All checks passed!
```

```
$ /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python3 -m pytest tests/trails/test_rb1_rb6_v11.py tests/test_validate_trailspec.py
============================== 73 passed in 1.44s ==============================
```

```
$ .venv/bin/python scripts/orchestration/validate_trailspec.py --spec scripts/config/trails/rb1-cold-start.trail.yaml
TrailSpec valid: id='rb1-cold-start' version='1.0.0' steps=10 hash=52e923b908eec59a73dbf62bac5e1fdcc53771df8947cba93d755e1d05a0d00e execution_eligible=True

$ .venv/bin/python scripts/orchestration/validate_trailspec.py --spec scripts/config/trails/rb6-estate-probes.trail.yaml
TrailSpec valid: id='rb6-estate-probes' version='1.0.0' steps=7 hash=80feb18a4999ac4fc25fb29591ff4c179dcca0d48e2c7c8da452ad6f97f6da5d execution_eligible=True
```

### Unverified
- Did NOT run P3 trail_runner execution against live VPS or remote infrastructure (probes only / schema and validator unit tests).