### PR TITLE
fix(practice): retain curated seed admissions

### DIFF
--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -28,7 +28,7 @@ if str(PROJECT_ROOT) not in sys.path:
 if str(AUDIT_DIR) not in sys.path:
     sys.path.insert(0, str(AUDIT_DIR))
 
-from lexeme_filter import SURFACE_CLOZE, is_practice_eligible, is_surface_admitted
+from lexeme_filter import SURFACE_CLOZE, SURFACE_PRACTICE, is_practice_eligible, is_surface_admitted
 
 from scripts.practice_deck.io import compute_deck_inputs_fingerprint, compute_deck_version
 
@@ -2476,13 +2476,27 @@ def _select_practice_lexemes(
     config: BuildConfig,
 ) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], list[dict[str, Any]], dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
     eligible = [entry for entry in entries if is_practice_eligible(entry)]
-    course_entries = [entry for entry in eligible if _course_usage(entry)]
-    fill_entries = [entry for entry in eligible if not _course_usage(entry)]
+    # A practice seed is an explicit curriculum admission, not merely a source of
+    # optional fill entries. Keep those entries ahead of ordinary course/fill
+    # selection so the per-shard size budget cannot silently discard the curated
+    # overlay from the tail of a level.
+    seed_entries = [
+        entry
+        for entry in eligible
+        if isinstance(entry.get("practice_example"), dict)
+        and is_surface_admitted(entry, SURFACE_PRACTICE)
+    ]
+    seed_entry_ids = {id(entry) for entry in seed_entries}
+    non_seed_entries = [entry for entry in eligible if id(entry) not in seed_entry_ids]
+    course_entries = [entry for entry in non_seed_entries if _course_usage(entry)]
+    fill_entries = [entry for entry in non_seed_entries if not _course_usage(entry)]
+    seed_entries.sort(key=_stable_lemma_id)
     course_entries.sort(key=_course_key)
     fill_entries.sort(
         key=lambda entry: (CEFR_RANK.get(_cefr_level(entry) or "", len(CEFR_RANK)), _stable_lemma_id(entry))
     )
-    selected = list(course_entries)
+    selected = list(seed_entries)
+    selected.extend(course_entries)
     if len(selected) < config.target:
         selected.extend(fill_entries[: config.target - len(selected)])
 

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -21,6 +21,7 @@ from scripts.audit.generate_practice_deck import (
     _eligible_decoys,
     _meaning_mc_eligible,
     _option_strategy_for_level,
+    _select_practice_lexemes,
     _stress_position,
     apply_size_budgets,
     build_practice_shards,
@@ -100,6 +101,38 @@ def test_curated_v5_seed_admits_existing_atlas_entries_with_provenance() -> None
         assert item["clozeIds"] == []
         assert lexemes[row["slug"]]["example"] == row["example"]
         assert lexemes[row["slug"]]["exampleProvenance"] == row["provenance"]
+
+
+def test_practice_seed_entries_are_selected_before_ordinary_course_entries() -> None:
+    entries = [
+        {
+            "lemma": "звичайний",
+            "url_slug": "звичайний",
+            "gloss": "ordinary",
+            "enrichment": {"cefr": {"level": "A1"}},
+            "course_usage": [{"module": "fixture"}],
+        },
+        {
+            "lemma": "насіннєвий",
+            "url_slug": "насіннєвий",
+            "gloss": "seeded",
+            "enrichment": {"cefr": {"level": "A1"}},
+            "primary_source": "source_inventory_grow",
+            "surface_admission": {"practice": True},
+            "practice_example": {
+                "text": "Це насіннєвий матеріал.",
+                "provenance": {"source_file": "fixture", "credit": "Fixture"},
+            },
+        },
+    ]
+
+    selected, _lexemes, _by_plain_lemma, _by_id = _select_practice_lexemes(
+        entries,
+        JsonVesumVerifier.from_path(VESUM),
+        BuildConfig(target=1, source_label="fixture"),
+    )
+
+    assert [entry["url_slug"] for entry, _lexeme in selected] == ["насіннєвий"]
 
 
 def test_practice_seed_validates_duplicate_attestations_but_emits_one_route_example(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Prioritize explicitly seed-admitted practice entries before ordinary course/fill candidates.
- This prevents the practice shard size budget from trimming the curated overlay from the tail of each CEFR level.
- Rebuilt the local seeded practice artifacts and refreshed the local Atlas runtime; generated artifacts and the private input remain ignored.

## Root cause
The seed merge correctly marked `surface_admission.practice=true`, yielding 647 eligible curated lemmas, but selection ordered ordinary course entries first. Shard size trimming then removed many seeded rows. The regenerated A1–C1 index now contains all 647 eligible curated lemmas.

## Local proof (ignored)
`batch_state/tasks/alona-practice-re-admit-r1.proof.json`

- seed: 680 entries / 674 unique lemmas
- eligible after merge: 647
- in practice index: 647 (95.9941%)
- previously present: 382; newly present: 265
- policy skips: 27 (26 no English gloss; 1 derived form)
- missing sample (full list is in proof): гидливий, граціозний, доглянути, загартовуватися, заражатися, заразитися, зарити, засвоюватися, засвітити, засмагати, засяяти, лоток, обставини, опік, повноліття, поголитися, пограбувати, пожертвувати, помішувати, порода, посів, похапцем, пронос, підлабузник, санчата, словесно, янголятко
- spot checks with non-empty flashcard modes: багаторічний (B1), безглуздий (B1), благати (B1), благодійність (B1), блювати (B2)

## Validation
- `.venv/bin/python -m pytest -q tests/test_makefile_practice_admit.py tests/test_curated_seed_atlas_admission.py tests/test_lexeme_filter.py tests/test_generate_practice_deck.py` — 72 passed
- `.venv/bin/ruff check scripts/audit/generate_practice_deck.py tests/test_generate_practice_deck.py`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`
- local Astro smoke: practice page, B1 index, and focused practice deep link each returned HTTP 200; exported Atlas records carry practice levels for багаторічний (B1), безглуздий (B1), and блювати (B2).

Related to #4387 and #5792. Driver seat owns cross-family review and merge; this PR intentionally does not enable auto-merge.