### PR TITLE
feat(guards): layered rail-path enforcement (P6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,8 +695,11 @@ jobs:
 
       - name: Rail approval declaration
         env:
-          RAIL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-          RAIL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RAIL_EVENT_NAME: ${{ github.event_name }}
+          RAIL_BASE_SHA: >-
+            ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha ||
+                github.event.before }}
+          RAIL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           RAIL_PR_BODY: ${{ github.event.pull_request.body || '' }}
         run: |
           .venv/bin/python - <<'PY'
@@ -704,8 +707,17 @@ jobs:
           import subprocess
           import sys
 
-          from scripts.orchestration.rail_path_guard import inspect_rail_approval_declaration
+          from scripts.orchestration.rail_path_guard import (
+              RailCIEventDisposition,
+              inspect_rail_approval_declaration,
+              inspect_rail_ci_event,
+          )
 
+          event_name = os.environ.get("RAIL_EVENT_NAME", "")
+          if event_name in {"push", "workflow_dispatch"}:
+              dispatch = inspect_rail_ci_event(event_name=event_name)
+              print(f"rail approval declaration={dispatch.disposition} reason={dispatch.reason}")
+              raise SystemExit(0)
           base = os.environ.get("RAIL_BASE_SHA") or "origin/main"
           head = os.environ["RAIL_HEAD_SHA"]
           changed = subprocess.run(
@@ -717,12 +729,30 @@ jobs:
               print("rail approval declaration could not read the candidate diff", file=sys.stderr)
               raise SystemExit(2)
           try:
+              candidate_paths = [
+                  path.decode("utf-8", errors="surrogateescape")
+                  for path in changed.stdout.split(b"\0")
+                  if path
+              ]
+              dispatch = inspect_rail_ci_event(
+                  event_name=event_name,
+                  candidate_paths=candidate_paths,
+              )
+          except Exception:
+              print("rail approval declaration could not classify the candidate diff", file=sys.stderr)
+              raise SystemExit(2)
+          if dispatch.disposition is RailCIEventDisposition.DENY:
+              print(
+                  dispatch.reason + ": " + ", ".join(dispatch.rail_paths),
+                  file=sys.stderr,
+              )
+              raise SystemExit(2)
+          if dispatch.disposition is RailCIEventDisposition.SKIP:
+              print(f"rail approval declaration={dispatch.disposition} reason={dispatch.reason}")
+              raise SystemExit(0)
+          try:
               declaration = inspect_rail_approval_declaration(
-                  candidate_paths=[
-                      path.decode("utf-8", errors="surrogateescape")
-                      for path in changed.stdout.split(b"\0")
-                      if path
-                  ],
+                  candidate_paths=candidate_paths,
                   body=os.environ.get("RAIL_PR_BODY", ""),
               )
           except Exception:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ permissions:
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
   merge_group:
   push:
     branches: [main]
@@ -665,13 +666,13 @@ jobs:
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore
 
   # ---------------------------------------------------------------------
-  # 5. rail-path — CI/PR enforcement for the narrow control-rail deny-list.
-  # This job intentionally calls the shared P6 module; changed-path discovery
-  # belongs to CI, while receipt/task/head/path authorization belongs nowhere
-  # else. A PR with a rail diff and no provisioned external receipt fails closed.
+  # 5. rail-path — CI declaration check for the narrow control-rail deny-list.
+  # CI can prove only that a rail PR body has one syntactically exact receipt
+  # locator. The locator is untrusted: the merge guard re-fetches it and makes
+  # the authoritative task/head/path decision.
   # ---------------------------------------------------------------------
   rail-path:
-    name: Rail path authorization
+    name: Rail approval declaration
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -686,50 +687,54 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install rail-path check dependency
+      - name: Install rail approval declaration dependency
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install jsonschema
 
-      - name: Enforce rail-path authorization
+      - name: Rail approval declaration
         env:
           RAIL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           RAIL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          RAIL_TASK_ID: pr-${{ github.event.pull_request.number || github.sha }}
+          RAIL_PR_BODY: ${{ github.event.pull_request.body || '' }}
         run: |
           .venv/bin/python - <<'PY'
           import os
           import subprocess
           import sys
 
-          from scripts.orchestration.rail_path_guard import decide_rail_path_mutation
+          from scripts.orchestration.rail_path_guard import inspect_rail_approval_declaration
 
           base = os.environ.get("RAIL_BASE_SHA") or "origin/main"
           head = os.environ["RAIL_HEAD_SHA"]
-          task_id = os.environ["RAIL_TASK_ID"]
           changed = subprocess.run(
               ["git", "diff", "--name-only", "-z", "--diff-filter=ACDMRT", base, head],
               check=False,
               capture_output=True,
           )
           if changed.returncode != 0:
-              print("rail-path guard could not read the candidate diff", file=sys.stderr)
+              print("rail approval declaration could not read the candidate diff", file=sys.stderr)
               raise SystemExit(2)
-          decision = decide_rail_path_mutation(
-              task_id=task_id,
-              candidate_paths=[
-                  path.decode("utf-8", errors="surrogateescape")
-                  for path in changed.stdout.split(b"\0")
-                  if path
-              ],
-              head_sha=head,
-          )
-          print(f"rail-path decision={decision.kind} reason={decision.reason}")
-          if not decision.allowed:
+          try:
+              declaration = inspect_rail_approval_declaration(
+                  candidate_paths=[
+                      path.decode("utf-8", errors="surrogateescape")
+                      for path in changed.stdout.split(b"\0")
+                      if path
+                  ],
+                  body=os.environ.get("RAIL_PR_BODY", ""),
+              )
+          except Exception:
+              print("rail approval declaration could not classify the candidate diff", file=sys.stderr)
+              raise SystemExit(2)
+          print(f"rail approval declaration={declaration.kind} reason={declaration.reason}")
+          if not declaration.is_present and declaration.kind.value != "not_required":
               print(
-                  "rail-path authorization refused: "
-                  + ", ".join(decision.rail_paths),
+                  "rail approval declaration refused for: "
+                  + ", ".join(declaration.rail_paths)
+                  + "; the authoritative merge guard must re-fetch and validate "
+                    "a current receipt from the approved source",
                   file=sys.stderr,
               )
               raise SystemExit(2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,7 +665,78 @@ jobs:
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore
 
   # ---------------------------------------------------------------------
-  # 5. CI Gate — the sole required check. Every job above is unconditional,
+  # 5. rail-path — CI/PR enforcement for the narrow control-rail deny-list.
+  # This job intentionally calls the shared P6 module; changed-path discovery
+  # belongs to CI, while receipt/task/head/path authorization belongs nowhere
+  # else. A PR with a rail diff and no provisioned external receipt fails closed.
+  # ---------------------------------------------------------------------
+  rail-path:
+    name: Rail path authorization
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install rail-path check dependency
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install jsonschema
+
+      - name: Enforce rail-path authorization
+        env:
+          RAIL_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          RAIL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RAIL_TASK_ID: pr-${{ github.event.pull_request.number || github.sha }}
+        run: |
+          .venv/bin/python - <<'PY'
+          import os
+          import subprocess
+          import sys
+
+          from scripts.orchestration.rail_path_guard import decide_rail_path_mutation
+
+          base = os.environ.get("RAIL_BASE_SHA") or "origin/main"
+          head = os.environ["RAIL_HEAD_SHA"]
+          task_id = os.environ["RAIL_TASK_ID"]
+          changed = subprocess.run(
+              ["git", "diff", "--name-only", "-z", "--diff-filter=ACDMRT", base, head],
+              check=False,
+              capture_output=True,
+          )
+          if changed.returncode != 0:
+              print("rail-path guard could not read the candidate diff", file=sys.stderr)
+              raise SystemExit(2)
+          decision = decide_rail_path_mutation(
+              task_id=task_id,
+              candidate_paths=[
+                  path.decode("utf-8", errors="surrogateescape")
+                  for path in changed.stdout.split(b"\0")
+                  if path
+              ],
+              head_sha=head,
+          )
+          print(f"rail-path decision={decision.kind} reason={decision.reason}")
+          if not decision.allowed:
+              print(
+                  "rail-path authorization refused: "
+                  + ", ".join(decision.rail_paths),
+                  file=sys.stderr,
+              )
+              raise SystemExit(2)
+          PY
+
+  # ---------------------------------------------------------------------
+  # 6. CI Gate — the sole required check. Every job above is unconditional,
   #    so `skipped` is as much a failure as `failure`/`cancelled`: there is
   #    no legitimate reason for any of them to not report `success`.
   # ---------------------------------------------------------------------
@@ -720,6 +791,7 @@ jobs:
       - contracts
       - frontend
       - security
+      - rail-path
       - coverage-floor
     steps:
       - name: Report required-job results

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -789,11 +789,19 @@ def _owner_repo_from_url(url: str) -> str | None:
     return f"{m.group(1)}/{m.group(2)}" if m else None
 
 
+def _canonical_pr_number(value: object) -> str | None:
+    """Return GitHub's positive integer PR number in canonical decimal form."""
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return str(value)
+
+
 def _pr_meta(pr: str, repo: str | None = None, cwd: str | None = None) -> dict | None:
-    """`{isDraft, baseRefName, headRefOid, url}` for the PR, or None if undeterminable.
+    """Read the fields that identify the exact PR and its current body.
 
     A payload without a boolean `isDraft` is undeterminable, not "not a draft" — `{}` or
-    `isDraft: null` must never read as a green light.
+    `isDraft: null` must never read as a green light.  The receipt task binding is
+    derived only from GitHub's integer ``number``; PR-body text is not an authority input.
     """
     try:
         out = subprocess.run(
@@ -804,7 +812,7 @@ def _pr_meta(pr: str, repo: str | None = None, cwd: str | None = None) -> dict |
                 pr,
                 *_repo_args(repo),
                 "--json",
-                "isDraft,baseRefName,headRefOid,url",
+                "isDraft,baseRefName,body,headRefOid,number,url",
             ],
             capture_output=True,
             env=_gh_env(),
@@ -820,7 +828,12 @@ def _pr_meta(pr: str, repo: str | None = None, cwd: str | None = None) -> dict |
         data = json.loads(_decolorize(out.stdout or "").strip() or "{}")
     except json.JSONDecodeError:
         return None
-    if not isinstance(data, dict) or not isinstance(data.get("isDraft"), bool):
+    if (
+        not isinstance(data, dict)
+        or not isinstance(data.get("isDraft"), bool)
+        or not isinstance(data.get("body"), str)
+        or _canonical_pr_number(data.get("number")) is None
+    ):
         return None
     return data
 
@@ -958,13 +971,19 @@ def _pr_changed_paths(pr: str, repo: str | None = None, cwd: str | None = None) 
 
 
 def _rail_path_decision(pr: str, meta: dict, repo: str | None, cwd: str | None):
-    """Delegate merge-path authorization to the single shared P6 module."""
+    """Authoritatively resolve a PR-body locator through the shared P6 module."""
     head_sha = meta.get("headRefOid")
     if not isinstance(head_sha, str):
-        return None, "could not verify the PR head SHA for rail authorization"
+        return None, "could not verify the PR head SHA for rail approval"
+    pr_number = _canonical_pr_number(meta.get("number"))
+    if pr_number is None:
+        return None, "could not verify the canonical PR number for rail approval"
+    body = meta.get("body")
+    if not isinstance(body, str):
+        return None, "could not read the live PR body for rail approval"
     paths = _pr_changed_paths(pr, repo, cwd)
     if paths is None:
-        return None, "could not read changed paths for rail authorization"
+        return None, "could not read changed paths for rail approval"
     try:
         rail_guard = _load_rail_path_guard()
     except Exception:
@@ -972,10 +991,31 @@ def _rail_path_decision(pr: str, meta: dict, repo: str | None, cwd: str | None):
     if rail_guard is None:
         return None, "the shared rail-path decision module is unavailable"
     try:
-        decision = rail_guard.decide_rail_path_mutation(
-            task_id=f"pr-{pr}",
+        rail_paths = rail_guard.rail_paths_from_candidates(paths)
+    except Exception:
+        return None, "the shared rail-path classifier is unreadable"
+    if not rail_paths:
+        return rail_guard.RailPathDecision(
+            rail_guard.RailPathDecisionKind.ALLOW,
+            "non_rail_paths",
+            (),
+        ), None
+    declaration = rail_guard.parse_rail_approval_declaration(body)
+    if not declaration.is_present or declaration.receipt_id is None:
+        return rail_guard.RailPathDecision(
+            rail_guard.RailPathDecisionKind.DENY,
+            declaration.reason,
+            rail_paths,
+        ), None
+    try:
+        decision = rail_guard.decide_rail_path_mutation_with_production_receipt(
+            # Only GitHub's canonical numeric PR ID binds the merge decision.  The
+            # body supplies the untrusted receipt locator, never a task identity.
+            task_id=f"pr-{pr_number}",
             candidate_paths=paths,
             head_sha=head_sha,
+            receipt_id=declaration.receipt_id,
+            path_binding=rail_guard.RailApprovalPathBinding.PR_DIFF_EXACT_SET,
         )
     except Exception:
         return None, "the shared rail-path decision is unreadable"

--- a/agents_extensions/shared/hooks/guard-pr-merge.py
+++ b/agents_extensions/shared/hooks/guard-pr-merge.py
@@ -41,12 +41,14 @@ likewise unread — a deliberate-only shape, documented rather than papered over
 from __future__ import annotations
 
 import concurrent.futures
+import importlib.util
 import json
 import os
 import re
 import shlex
 import subprocess
 import sys
+from pathlib import Path
 from typing import NamedTuple
 
 # Agent harnesses export CLICOLOR_FORCE/FORCE_COLOR, which beat NO_COLOR and make
@@ -609,10 +611,10 @@ def _merge_args(seg: list[str]) -> list[str] | None:
     Skipped: `--disable-auto` (any spelling), which disarms auto-merge rather than
     merging anything and is exactly the remedy this hook's --auto verdict asks for.
 
-    Also skipped: a bare `--admin`, which is guard-admin-merge.py's job — but ONLY that
-    exact spelling, because that is precisely what the sibling matches. `--admin=true` is
-    a real admin merge the sibling misses, so it is judged HERE rather than falling
-    between the two hooks. Judging it cannot double-judge: the sibling never sees it.
+    A bare `--admin` is also seen by ``guard-admin-merge.py``, but it remains visible
+    here: P6 rail authorization must have no ``--admin`` bypass. The duplicate status
+    read is conservative; the command is already an explicit protection bypass and an
+    unreadable rail decision must refuse.
     """
     i, via_xargs = _invoked_start(seg)
     if seg[i : i + 3] == ["gh", "pr", "merge"]:
@@ -641,7 +643,7 @@ def _merge_args(seg: list[str]) -> list[str] | None:
     # spelling treatment (`--help=true`) rather than a bare-token check.
     if _flag_enabled(flags, "help") or "-h" in flags:
         return None
-    if "--admin" in flags or _flag_enabled(flags, "disable-auto"):
+    if _flag_enabled(flags, "disable-auto"):
         return None
     return args
 
@@ -788,14 +790,22 @@ def _owner_repo_from_url(url: str) -> str | None:
 
 
 def _pr_meta(pr: str, repo: str | None = None, cwd: str | None = None) -> dict | None:
-    """`{isDraft, baseRefName, url}` for the PR, or None if undeterminable (→ fail-closed).
+    """`{isDraft, baseRefName, headRefOid, url}` for the PR, or None if undeterminable.
 
     A payload without a boolean `isDraft` is undeterminable, not "not a draft" — `{}` or
     `isDraft: null` must never read as a green light.
     """
     try:
         out = subprocess.run(
-            ["gh", "pr", "view", pr, *_repo_args(repo), "--json", "isDraft,baseRefName,url"],
+            [
+                "gh",
+                "pr",
+                "view",
+                pr,
+                *_repo_args(repo),
+                "--json",
+                "isDraft,baseRefName,headRefOid,url",
+            ],
             capture_output=True,
             env=_gh_env(),
             cwd=cwd,
@@ -912,6 +922,66 @@ def _pr_snapshot(
         return meta_future.result(), states_future.result()
 
 
+def _load_rail_path_guard():
+    """Load the source-controlled P6 guard from a deployed merge-hook copy."""
+    here = Path(__file__).resolve()
+    for parent in (here.parent, *here.parents):
+        candidate = parent / "scripts" / "orchestration" / "rail_path_guard.py"
+        if not candidate.is_file():
+            continue
+        spec = importlib.util.spec_from_file_location("rail_path_guard", candidate)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    return None
+
+
+def _pr_changed_paths(pr: str, repo: str | None = None, cwd: str | None = None) -> list[str] | None:
+    """Return the exact PR diff paths, or ``None`` when GitHub cannot prove them."""
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "diff", pr, *_repo_args(repo), "--name-only"],
+            capture_output=True,
+            env=_gh_env(),
+            cwd=cwd,
+            text=True,
+            timeout=8,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    return [line for line in _decolorize(out.stdout).splitlines() if line]
+
+
+def _rail_path_decision(pr: str, meta: dict, repo: str | None, cwd: str | None):
+    """Delegate merge-path authorization to the single shared P6 module."""
+    head_sha = meta.get("headRefOid")
+    if not isinstance(head_sha, str):
+        return None, "could not verify the PR head SHA for rail authorization"
+    paths = _pr_changed_paths(pr, repo, cwd)
+    if paths is None:
+        return None, "could not read changed paths for rail authorization"
+    try:
+        rail_guard = _load_rail_path_guard()
+    except Exception:
+        return None, "the shared rail-path decision module is unavailable"
+    if rail_guard is None:
+        return None, "the shared rail-path decision module is unavailable"
+    try:
+        decision = rail_guard.decide_rail_path_mutation(
+            task_id=f"pr-{pr}",
+            candidate_paths=paths,
+            head_sha=head_sha,
+        )
+    except Exception:
+        return None, "the shared rail-path decision is unreadable"
+    return decision, None
+
+
 _FOOTER = (
     "GitHub will merge a draft or a red PR without complaint — branch protection stops only\n"
     "what it was configured to require, and on a free-plan private repo it cannot be configured\n"
@@ -969,6 +1039,21 @@ def _judge(args: list[str], cwd: str | None = None) -> str | None:
             "Every non-advisory check counts, whether or not GitHub marks it required —\n"
             "'required' is a config accident, red is red. Fix the failures and re-run;\n"
             "do not merge over them.",
+        )
+    rail_decision, rail_error = _rail_path_decision(pr, meta, repo, cwd)
+    if rail_error is not None or rail_decision is None:
+        return _block_msg(
+            rail_error or "rail-path authorization is unreadable",
+            "The merge guard cannot prove that this PR avoids protected rails. "
+            "Repair the receipt source or changed-path query, then retry; it fails closed.",
+        )
+    if not rail_decision.allowed:
+        paths = ", ".join(rail_decision.rail_paths) or "(unreadable path)"
+        return _block_msg(
+            f"PR {pr} rail-path authorization refused: {rail_decision.reason} ({paths})",
+            "Rail mutations require a scoped, unexpired approval receipt re-fetched from "
+            "the provisioned advisor/operator source. X-Agent, model, and tier claims do "
+            "not authorize a merge.",
         )
     if _flag_enabled(_classify(args)[0], "auto"):
         base = str(meta.get("baseRefName") or "")

--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -146,8 +146,6 @@ def _rail_write_decision(raw_targets: list[str], *, cwd: str):
     task_id = os.environ.get("LEARN_UK_RAIL_TASK_ID") or "local-hook"
     if receipt_id and not os.environ.get("LEARN_UK_RAIL_TASK_ID"):
         return None, "rail_approval_task_context_missing"
-    caller_root = _git_output(cwd, "rev-parse", "--show-toplevel")
-    caller_root_path = Path(caller_root).resolve() if caller_root is not None else None
     try:
         for raw in raw_targets:
             target = _resolve(raw, cwd).resolve()
@@ -161,9 +159,24 @@ def _rail_write_decision(raw_targets: list[str], *, cwd: str):
             root = _git_output(str(target_cwd), "rev-parse", "--show-toplevel")
             head_sha = _git_output(str(target_cwd), "rev-parse", "HEAD")
             if root is None or head_sha is None:
-                if caller_root_path is not None and target.is_relative_to(caller_root_path):
+                # `root is None` proves only that the git invocation FAILED
+                # (timeout, OSError, non-zero exit) — not that the target is
+                # outside every repository. Allow only a POSITIVELY-confirmed
+                # non-repository location: walk the target's parents to the
+                # filesystem root and require that no `.git` entry exists
+                # anywhere. Any other resolution failure fails CLOSED.
+                probe = target_cwd
+                inside_some_repo = False
+                while True:
+                    if (probe / ".git").exists():
+                        inside_some_repo = True
+                        break
+                    if probe == probe.parent:
+                        break
+                    probe = probe.parent
+                if inside_some_repo:
                     return None, "rail_path_guard_repository_unreadable"
-                continue  # A target outside every repository cannot be a repository rail path.
+                continue  # Positively confirmed: no repository anywhere above the target.
             relative_path = target.relative_to(Path(root).resolve()).as_posix()
             decision = rail_guard.decide_rail_path_mutation_with_production_receipt(
                 task_id=task_id,

--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -59,10 +59,12 @@ for one shell invocation. Prefer fixing the cwd / using a worktree instead.
 """
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import re
 import shlex
+import subprocess
 import sys
 from pathlib import Path
 
@@ -91,6 +93,89 @@ def _load_containment():
     except Exception:  # pragma: no cover - defensive fail-open
         return None
     return wc
+
+
+def _load_rail_path_guard():
+    """Load the one shared P6 decision module from source or a deployed copy.
+
+    The hook has no local approval-file escape hatch. If the module cannot be
+    loaded, the caller blocks the write rather than guessing that a target is
+    non-rail.
+    """
+    here = Path(__file__).resolve()
+    for parent in (here.parent, *here.parents):
+        candidate = parent / "scripts" / "orchestration" / "rail_path_guard.py"
+        if not candidate.is_file():
+            continue
+        spec = importlib.util.spec_from_file_location("rail_path_guard", candidate)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    return None
+
+
+def _git_output(cwd: str, *args: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", cwd, *args],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    value = completed.stdout.strip()
+    return value or None
+
+
+def _rail_write_decision(raw_targets: list[str], *, cwd: str):
+    """Classify hook write targets through the one P6 decision module."""
+    try:
+        rail_guard = _load_rail_path_guard()
+    except Exception:
+        return None, "rail_path_guard_unavailable"
+    if rail_guard is None:
+        return None, "rail_path_guard_unavailable"
+    caller_root = _git_output(cwd, "rev-parse", "--show-toplevel")
+    caller_root_path = Path(caller_root).resolve() if caller_root is not None else None
+    try:
+        for raw in raw_targets:
+            target = _resolve(raw, cwd).resolve()
+            # A payload running in one worktree can name an absolute target in
+            # another worktree. Resolve Git from the *target's* parent, not the
+            # payload cwd, or an absolute cross-worktree rail write is laundered
+            # into `.worktrees/.../agents_extensions/...` and misses the deny-list.
+            target_cwd = target if target.is_dir() else target.parent
+            while not target_cwd.exists() and target_cwd != target_cwd.parent:
+                target_cwd = target_cwd.parent
+            root = _git_output(str(target_cwd), "rev-parse", "--show-toplevel")
+            head_sha = _git_output(str(target_cwd), "rev-parse", "HEAD")
+            if root is None or head_sha is None:
+                if caller_root_path is not None and target.is_relative_to(caller_root_path):
+                    return None, "rail_path_guard_repository_unreadable"
+                continue  # A target outside every repository cannot be a repository rail path.
+            relative_path = target.relative_to(Path(root).resolve()).as_posix()
+            decision = rail_guard.decide_rail_path_mutation(
+                task_id="local-hook",
+                candidate_paths=(relative_path,),
+                head_sha=head_sha,
+            )
+            if not decision.allowed:
+                return decision, None
+        return (
+            rail_guard.decide_rail_path_mutation(
+                task_id="local-hook", candidate_paths=(), head_sha="0" * 40
+            ),
+            None,
+        )
+    except Exception:
+        return None, "rail_path_guard_decision_unreadable"
 
 
 # ---------------------------------------------------------------------------
@@ -851,8 +936,6 @@ def main() -> int:
         return 0
 
     wc = _load_containment()
-    if wc is None:
-        return 0  # can't classify without the shared predicate → allow
 
     tool_input = _tool_input(payload)
     cwd = _payload_cwd(payload)
@@ -865,6 +948,45 @@ def main() -> int:
         raw_targets = bash_write_targets(command)
     else:
         raw_targets = write_tool_targets(tool_input)
+
+    # P6 rail protection applies in every registered worktree, not only the
+    # primary checkout.  It intentionally runs before the older primary-only
+    # containment guard, and it fails closed if the module/repository/path is
+    # unreadable.  No X-Agent/model/tier metadata reaches this decision.
+    if raw_targets:
+        if tool_name == "Bash":
+            assignments, ambiguous = parse_shell_assignments(command)
+        else:
+            assignments, ambiguous = {}, set()
+        expanded_targets: list[str] = []
+        for raw in raw_targets:
+            expanded = expand_shell_target(raw, assignments, ambiguous=ambiguous)
+            if is_unresolved_shell_var(expanded):
+                sys.stderr.write(
+                    "BLOCKED by rail-path guard: unresolved_shell_variable write target; "
+                    "cannot prove it is outside a rail path.\n"
+                )
+                return 2
+            expanded_targets.append(expanded)
+        rail_decision, rail_error = _rail_write_decision(expanded_targets, cwd=cwd)
+        if rail_error is not None or rail_decision is None:
+            sys.stderr.write(
+                "BLOCKED by rail-path guard: shared decision module is unreadable "
+                f"({rail_error or 'unknown error'}); failing closed.\n"
+            )
+            return 2
+        if not rail_decision.allowed:
+            paths = ", ".join(rail_decision.rail_paths) or "(unreadable path)"
+            sys.stderr.write(
+                "BLOCKED by rail-path guard: rail mutation requires a current, "
+                "externally verified approval receipt.\n"
+                f"  reason: {rail_decision.reason}\n"
+                f"  rail paths: {paths}\n"
+            )
+            return 2
+
+    if wc is None:
+        return 0  # P6 ran above; the older primary-only predicate is unavailable.
 
     # Enforce only while the primary checkout sits on a protected branch. If the
     # human has deliberately checked the primary tree onto a feature branch, git

--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -142,6 +142,10 @@ def _rail_write_decision(raw_targets: list[str], *, cwd: str):
         return None, "rail_path_guard_unavailable"
     if rail_guard is None:
         return None, "rail_path_guard_unavailable"
+    receipt_id = os.environ.get("LEARN_UK_RAIL_APPROVAL_RECEIPT")
+    task_id = os.environ.get("LEARN_UK_RAIL_TASK_ID") or "local-hook"
+    if receipt_id and not os.environ.get("LEARN_UK_RAIL_TASK_ID"):
+        return None, "rail_approval_task_context_missing"
     caller_root = _git_output(cwd, "rev-parse", "--show-toplevel")
     caller_root_path = Path(caller_root).resolve() if caller_root is not None else None
     try:
@@ -161,16 +165,20 @@ def _rail_write_decision(raw_targets: list[str], *, cwd: str):
                     return None, "rail_path_guard_repository_unreadable"
                 continue  # A target outside every repository cannot be a repository rail path.
             relative_path = target.relative_to(Path(root).resolve()).as_posix()
-            decision = rail_guard.decide_rail_path_mutation(
-                task_id="local-hook",
+            decision = rail_guard.decide_rail_path_mutation_with_production_receipt(
+                task_id=task_id,
                 candidate_paths=(relative_path,),
                 head_sha=head_sha,
+                receipt_id=receipt_id,
             )
             if not decision.allowed:
                 return decision, None
         return (
-            rail_guard.decide_rail_path_mutation(
-                task_id="local-hook", candidate_paths=(), head_sha="0" * 40
+            rail_guard.decide_rail_path_mutation_with_production_receipt(
+                task_id=task_id,
+                candidate_paths=(),
+                head_sha="0" * 40,
+                receipt_id=receipt_id,
             ),
             None,
         )
@@ -985,6 +993,49 @@ def main() -> int:
             )
             return 2
 
+    # Git commands mutate outside shell redirections/write-tool payloads, so
+    # they need their own rail pass. This executes for every path-scoped intent
+    # before the primary-containment branch below decides whether the worktree
+    # is the protected primary or an isolated dispatch tree.
+    git_intents: list[dict[str, object]] = []
+    if tool_name == "Bash" and command:
+        try:
+            git_intents = bash_git_write_intents(command)
+            for intent in git_intents:
+                if intent.get("allowlisted"):
+                    continue
+                paths = list(intent.get("paths") or [])
+                if not paths:
+                    # Pathless whole-tree mutators (apply/am/stash pop|apply)
+                    # cannot be enumerated in this fast hook for a non-primary
+                    # worktree. The residual is covered by the CI rail-path job
+                    # + merge guard diff of actual changed files; never treat
+                    # this deliberate non-enumeration as an implicit rail allow.
+                    continue
+                git_cwd = _effective_git_cwd(intent, cwd)
+                rail_decision, rail_error = _rail_write_decision(paths, cwd=str(git_cwd))
+                if rail_error is not None or rail_decision is None:
+                    sys.stderr.write(
+                        "BLOCKED by rail-path guard: shared decision module is unreadable "
+                        f"({rail_error or 'unknown error'}); failing closed.\n"
+                    )
+                    return 2
+                if not rail_decision.allowed:
+                    paths_text = ", ".join(rail_decision.rail_paths) or "(unreadable path)"
+                    sys.stderr.write(
+                        "BLOCKED by rail-path guard: git-mediated rail mutation requires a current, "
+                        "externally verified approval receipt.\n"
+                        f"  reason: {rail_decision.reason}\n"
+                        f"  rail paths: {paths_text}\n"
+                    )
+                    return 2
+        except Exception:  # pragma: no cover - parser/OS failure must not bypass P6
+            sys.stderr.write(
+                "BLOCKED by rail-path guard: cannot inspect git-mediated write targets; "
+                "failing closed.\n"
+            )
+            return 2
+
     if wc is None:
         return 0  # P6 ran above; the older primary-only predicate is unavailable.
 
@@ -1003,7 +1054,7 @@ def main() -> int:
     allow_primary_git = os.environ.get("LEARN_UK_ALLOW_PRIMARY_GIT_WRITE", "") == "1"
     if tool_name == "Bash" and command and not allow_primary_git:
         try:
-            for intent in bash_git_write_intents(command):
+            for intent in git_intents:
                 if intent.get("allowlisted"):
                     continue
                 git_cwd = _effective_git_cwd(intent, cwd)

--- a/agents_extensions/shared/schemas/rail-approval-receipt.v1.schema.json
+++ b/agents_extensions/shared/schemas/rail-approval-receipt.v1.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "rail-approval-receipt.v1",
+  "title": "Rail approval receipt v1 schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "issuer",
+    "issued_at",
+    "expires_at",
+    "action",
+    "task_id",
+    "head_sha",
+    "owned_paths"
+  ],
+  "$defs": {
+    "opaque_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$"
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    }
+  },
+  "properties": {
+    "schema_version": {"const": "rail-approval-receipt.v1"},
+    "receipt_id": {"$ref": "#/$defs/opaque_id"},
+    "issuer": {"enum": ["operator", "advisor"]},
+    "issued_at": {"type": "string", "format": "date-time"},
+    "expires_at": {"type": "string", "format": "date-time"},
+    "action": {"const": "rail-path-mutation"},
+    "task_id": {"type": "string", "minLength": 1, "maxLength": 512},
+    "head_sha": {"$ref": "#/$defs/head_sha"},
+    "owned_paths": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    }
+  }
+}

--- a/agents_extensions/shared/schemas/rail-approval-receipt.v1.schema.json
+++ b/agents_extensions/shared/schemas/rail-approval-receipt.v1.schema.json
@@ -16,9 +16,9 @@
     "owned_paths"
   ],
   "$defs": {
-    "opaque_id": {
+    "rail_approval_receipt_id": {
       "type": "string",
-      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$"
+      "pattern": "^rail-approval-[0-9a-f]{32}$"
     },
     "head_sha": {
       "type": "string",
@@ -27,7 +27,7 @@
   },
   "properties": {
     "schema_version": {"const": "rail-approval-receipt.v1"},
-    "receipt_id": {"$ref": "#/$defs/opaque_id"},
+    "receipt_id": {"$ref": "#/$defs/rail_approval_receipt_id"},
     "issuer": {"enum": ["operator", "advisor"]},
     "issued_at": {"type": "string", "format": "date-time"},
     "expires_at": {"type": "string", "format": "date-time"},

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1532,6 +1532,39 @@ task state.
 }
 ```
 
+## Rail approval receipts — `/api/rail-approvals/`
+
+### `GET /api/rail-approvals/{receipt_id}`
+
+Read-only provisioned source for control-rail mutation approvals. Enforcement
+re-fetches this receipt for every rail decision; it never trusts a worktree
+file, an environment identity claim, or an `X-Agent` trailer as approval.
+
+Only an operator or advisor issues a receipt, explicitly and outside any agent
+workflow:
+
+```bash
+.venv/bin/python scripts/orchestration/rail_approval.py issue \
+  --task-id rail-p8-trail-migration \
+  --head-sha <40-character-current-head> \
+  --owned-path scripts/config/trails/rb1.trail.yaml \
+  --issuer operator \
+  --ttl-hours 4
+```
+
+The command prints the receipt JSON, including its opaque receipt ID, and writes
+immutable runtime state under `batch_state/`; that state is served only by
+Monitor. A write dispatch passes the opaque ID with
+`--rail-approval-receipt <id>` and re-fetches it through Monitor before it is
+admitted. It also passes the reference to the worker hook, which repeats the
+source fetch and exact task/head/path check.
+
+Monitor is the normal source. If a deployment cannot reach Monitor, its process
+bootstrap may inject a separately provisioned bridge source; it must identify
+as `source_kind="bridge"` and is subject to the same schema and exact-binding
+checks. There is no fallback to a local file, an arbitrary URL, or a caller-
+selected environment source; an unavailable source denies the rail mutation.
+
 ## Build Events — `/api/build/events/`
 
 ### `GET /api/build/events/recent?level=&slug=&limit=100`

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1552,9 +1552,9 @@ workflow:
   --ttl-hours 4
 ```
 
-The command prints the receipt JSON, including its opaque receipt ID, and writes
-immutable runtime state under `batch_state/`; that state is served only by
-Monitor. A write dispatch passes the opaque ID with
+The command prints the receipt JSON, including an ID shaped exactly as
+`rail-approval-<32 lowercase hex>`, and writes immutable runtime state under
+`batch_state/`; that state is served only by Monitor. A write dispatch passes the ID with
 `--rail-approval-receipt <id>` and re-fetches it through Monitor before it is
 admitted. It also passes the reference to the worker hook, which repeats the
 source fetch and exact task/head/path check.
@@ -1564,6 +1564,16 @@ bootstrap may inject a separately provisioned bridge source; it must identify
 as `source_kind="bridge"` and is subject to the same schema and exact-binding
 checks. There is no fallback to a local file, an arbitrary URL, or a caller-
 selected environment source; an unavailable source denies the rail mutation.
+
+For a rail-path pull request, CI checks only one standalone PR-body declaration:
+`Rail-Approval-Receipt: rail-approval-<32 lowercase hex>`. It is an untrusted
+locator, not authorization. The merge guard derives `task_id` as `pr-<GitHub PR
+number>`, re-fetches that receipt through Monitor, and applies the authoritative
+task/head/path decision. Dispatch and checkout-write layers authorize a bounded
+mutation attempt, so their receipt scope may contain that attempt. The merge
+guard sees the complete current rail diff instead and requires the receipt's
+`owned_paths` to equal that exact set; a new head or rail-path set therefore
+requires a new receipt.
 
 ## Build Events — `/api/build/events/`
 

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -81,6 +81,7 @@ from .knowledge_router import router as knowledge_router
 from .ops_router import router as ops_router
 from .preload import preload_all
 from .rag_router import router as rag_router
+from .rail_approval_router import router as rail_approval_router
 from .repository_authority import build_repository_authority
 from .resilience import get_resilience_snapshot, resilience_middleware
 from .reviewer_ghosts_router import router as reviewer_ghosts_router
@@ -180,6 +181,7 @@ app.include_router(images_router, prefix="/api/images")
 app.include_router(issues_router, prefix="/api/issues", tags=["issues"])
 app.include_router(knowledge_router, prefix="/api/knowledge", tags=["knowledge"])
 app.include_router(rag_router, prefix="/api/rag")
+app.include_router(rail_approval_router, prefix="/api/rail-approvals", tags=["rail-approvals"])
 # GH #1529 P3 — reviewer-ghost telemetry nested under /api/state so clients
 # can discover it alongside the other state-query endpoints.
 app.include_router(

--- a/scripts/api/rail_approval_router.py
+++ b/scripts/api/rail_approval_router.py
@@ -8,6 +8,7 @@ from scripts.orchestration.rail_approval import (
     RailApprovalReceiptRegistry,
     RailApprovalStoreError,
 )
+from scripts.orchestration.rail_path_guard import RAIL_APPROVAL_RECEIPT_ID
 
 router = APIRouter(tags=["rail-approvals"])
 
@@ -20,6 +21,10 @@ def get_rail_approval_registry() -> RailApprovalReceiptRegistry:
 @router.get("/{receipt_id}")
 def get_rail_approval_receipt(receipt_id: str) -> dict:
     """Return one immutable receipt for an enforcement-layer re-fetch."""
+    if RAIL_APPROVAL_RECEIPT_ID.fullmatch(receipt_id) is None:
+        # Client error, not store unavailability: a malformed id can never
+        # resolve, so it must not read as a retryable 503.
+        raise HTTPException(status_code=422, detail="malformed rail approval receipt id")
     try:
         return get_rail_approval_registry().fetch(receipt_id)
     except KeyError as exc:

--- a/scripts/api/rail_approval_router.py
+++ b/scripts/api/rail_approval_router.py
@@ -1,0 +1,28 @@
+"""Read-only Monitor API projection for human-issued rail approvals."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from scripts.orchestration.rail_approval import (
+    RailApprovalReceiptRegistry,
+    RailApprovalStoreError,
+)
+
+router = APIRouter(tags=["rail-approvals"])
+
+
+def get_rail_approval_registry() -> RailApprovalReceiptRegistry:
+    """Build the local registry only inside the provisioned Monitor process."""
+    return RailApprovalReceiptRegistry()
+
+
+@router.get("/{receipt_id}")
+def get_rail_approval_receipt(receipt_id: str) -> dict:
+    """Return one immutable receipt for an enforcement-layer re-fetch."""
+    try:
+        return get_rail_approval_registry().fetch(receipt_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="rail approval receipt not found") from exc
+    except RailApprovalStoreError as exc:
+        raise HTTPException(status_code=503, detail="rail approval store unavailable") from exc

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -877,6 +877,9 @@ def _classify_worktree_layout(path: Path | str | None) -> str | None:
 # preflight and creating a worktree from the primary checkout stay allowed.
 
 _WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
+RAIL_ADMISSION_NO_PATH_ADVISORY = (
+    "rail admission: no path declaration — rail enforcement deferred to hook/CI/merge layers"
+)
 _NO_DELIVERABLE_STATUS = "no_deliverable"
 _NO_DELIVERABLE_UNKNOWN_COMMIT_COUNT_REASON = "commit_count_unknown"
 _NO_DELIVERABLE_SHORT_RESPONSE_REASON = "write_capable_clean_worktree_zero_commits_short_response"
@@ -1132,21 +1135,24 @@ def _rail_path_admission_error(
     task_id: str,
     mode: str,
     owned_paths: Sequence[str] | None,
+    receipt_id: str | None = None,
 ) -> str | None:
     """Return a P6 refusal before write-path ownership creates any state.
 
     Receipt retrieval is deliberately not wired to a caller-provided local file:
-    P4 established that a local JSON projection is forgeable.  A provisioned
-    API/bridge caller may pass a :class:`VerifiedRailApprovalReceipt` directly
-    to the shared module; ordinary dispatch has no authority unless such a
-    trusted integration is installed, so rail claims fail closed here.
+    P4 established that a local JSON projection is forgeable.  The supplied
+    opaque ID is re-fetched only through the production Monitor API resolver.
     """
     if mode not in _WRITE_CAPABLE_MODES:
         return None
     try:
-        from scripts.orchestration.rail_path_guard import decide_rail_path_mutation
+        from scripts.orchestration.rail_path_guard import (
+            decide_rail_path_mutation_with_production_receipt,
+        )
     except ImportError:  # pragma: no cover - flat script path
-        from orchestration.rail_path_guard import decide_rail_path_mutation  # type: ignore
+        from orchestration.rail_path_guard import (  # type: ignore
+            decide_rail_path_mutation_with_production_receipt,
+        )
 
     try:
         head_sha = subprocess.run(
@@ -1161,10 +1167,11 @@ def _rail_path_admission_error(
         return f"❌ rail-path admission refused: cannot read current HEAD ({type(exc).__name__})"
     if head_sha.returncode != 0:
         return "❌ rail-path admission refused: cannot read current HEAD"
-    decision = decide_rail_path_mutation(
+    decision = decide_rail_path_mutation_with_production_receipt(
         task_id=task_id,
         candidate_paths=owned_paths or (),
         head_sha=head_sha.stdout.strip(),
+        receipt_id=receipt_id,
     )
     if decision.allowed:
         return None
@@ -1174,6 +1181,31 @@ def _rail_path_admission_error(
         f"{decision.reason}; paths={paths}. "
         "Rail mutations require a current externally verified approval receipt."
     )
+
+
+def _rail_path_admission_advisory(
+    *,
+    mode: str,
+    owned_paths: Sequence[str] | None,
+) -> str | None:
+    """State the deferred-enforcement boundary for undeclared write dispatches."""
+    if mode in _WRITE_CAPABLE_MODES and not owned_paths:
+        return RAIL_ADMISSION_NO_PATH_ADVISORY
+    return None
+
+
+def _with_rail_admission_state(
+    state: dict[str, Any],
+    *,
+    advisory: str | None,
+    receipt_id: str | None,
+) -> dict[str, Any]:
+    """Persist admission transparency without making the opaque ID authority."""
+    if advisory is not None:
+        state["rail_admission_advisory"] = advisory
+    if receipt_id is not None:
+        state["rail_approval_receipt_id"] = receipt_id
+    return state
 
 
 def _format_dirty_entries(entries: list[dict[str, str]], *, limit: int = 10) -> str:
@@ -3541,10 +3573,17 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
     # P6 rail-path admission runs before the ownership ledger. A refusal must
     # leave no task-state, worktree, branch, or claim residue for a rail write.
+    rail_admission_advisory = _rail_path_admission_advisory(
+        mode=str(args.mode),
+        owned_paths=getattr(args, "research_owned_path", None),
+    )
+    if rail_admission_advisory is not None:
+        print(rail_admission_advisory, file=sys.stderr)
     rail_admission_error = _rail_path_admission_error(
         task_id=task_id,
         mode=str(args.mode),
         owned_paths=getattr(args, "research_owned_path", None),
+        receipt_id=getattr(args, "rail_approval_receipt", None),
     )
     if rail_admission_error:
         print(rail_admission_error, file=sys.stderr)
@@ -3747,6 +3786,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             dry_run_state["harness"] = requested_harness
         if lifecycle_carrier is not None:
             dry_run_state["task_lifecycle"] = lifecycle_carrier
+        dry_run_state = _with_rail_admission_state(
+            dry_run_state,
+            advisory=rail_admission_advisory,
+            receipt_id=getattr(args, "rail_approval_receipt", None),
+        )
         dry_run_reap = _reap_runtime_tmp_lease(
             runtime_tmp_root,
             runtime_tmp_namespace_root,
@@ -3896,6 +3940,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     if lifecycle_carrier is not None:
         initial_state["task_lifecycle"] = lifecycle_carrier
     initial_state = _with_optional_research_state(initial_state, research_state)
+    initial_state = _with_rail_admission_state(
+        initial_state,
+        advisory=rail_admission_advisory,
+        receipt_id=getattr(args, "rail_approval_receipt", None),
+    )
     _write_state_atomic(state_path, initial_state)
 
     # Fix 5 (#1476 AC 5) — dispatch-start telemetry.
@@ -3990,6 +4039,14 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     worker_env["TMPDIR"] = str(runtime_tmp_root)
     worker_env["LU_RUNTIME_TMP_ROOT"] = str(runtime_tmp_root)
     worker_env["LU_RUNTIME_TMP_BASE_ROOT"] = str(runtime_tmp_namespace_root.parent)
+    rail_receipt_id = getattr(args, "rail_approval_receipt", None)
+    if rail_receipt_id is not None:
+        # These values are only opaque references/context. The hook still
+        # re-fetches and verifies the receipt through Monitor before allowing
+        # any rail target; a worker cannot turn the inherited values into
+        # authority by editing its local state or environment.
+        worker_env["LEARN_UK_RAIL_APPROVAL_RECEIPT"] = rail_receipt_id
+        worker_env["LEARN_UK_RAIL_TASK_ID"] = task_id
     if worktree_path is not None:
         _apply_worktree_git_ceiling(worker_env, worktree_path)
     if getattr(args, "allow_merge", False):
@@ -4871,6 +4928,16 @@ def build_parser() -> argparse.ArgumentParser:
             "dispatch. The file is parsed before spawn, resolved to an "
             "absolute path, hashed into task state, and revalidated by the "
             "Codex adapter before it emits --output-schema."
+        ),
+    )
+    d.add_argument(
+        "--rail-approval-receipt",
+        default=None,
+        metavar="RECEIPT_ID",
+        help=(
+            "Opaque receipt issued by scripts/orchestration/rail_approval.py. "
+            "Dispatch and hooks re-fetch it only through the provisioned Monitor API; "
+            "it never accepts a local receipt file."
         ),
     )
     d.add_argument(

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1127,6 +1127,55 @@ def _resolve_write_cwd_error(
     )
 
 
+def _rail_path_admission_error(
+    *,
+    task_id: str,
+    mode: str,
+    owned_paths: Sequence[str] | None,
+) -> str | None:
+    """Return a P6 refusal before write-path ownership creates any state.
+
+    Receipt retrieval is deliberately not wired to a caller-provided local file:
+    P4 established that a local JSON projection is forgeable.  A provisioned
+    API/bridge caller may pass a :class:`VerifiedRailApprovalReceipt` directly
+    to the shared module; ordinary dispatch has no authority unless such a
+    trusted integration is installed, so rail claims fail closed here.
+    """
+    if mode not in _WRITE_CAPABLE_MODES:
+        return None
+    try:
+        from scripts.orchestration.rail_path_guard import decide_rail_path_mutation
+    except ImportError:  # pragma: no cover - flat script path
+        from orchestration.rail_path_guard import decide_rail_path_mutation  # type: ignore
+
+    try:
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"❌ rail-path admission refused: cannot read current HEAD ({type(exc).__name__})"
+    if head_sha.returncode != 0:
+        return "❌ rail-path admission refused: cannot read current HEAD"
+    decision = decide_rail_path_mutation(
+        task_id=task_id,
+        candidate_paths=owned_paths or (),
+        head_sha=head_sha.stdout.strip(),
+    )
+    if decision.allowed:
+        return None
+    paths = ", ".join(decision.rail_paths) or "(invalid or unreadable candidate path)"
+    return (
+        "❌ rail-path admission refused before dispatch side effects: "
+        f"{decision.reason}; paths={paths}. "
+        "Rail mutations require a current externally verified approval receipt."
+    )
+
+
 def _format_dirty_entries(entries: list[dict[str, str]], *, limit: int = 10) -> str:
     shown = [f"{entry.get('xy', '').strip() or '??'} {entry.get('path', '')}" for entry in entries[:limit]]
     if len(entries) > limit:
@@ -3489,6 +3538,17 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 2
+
+    # P6 rail-path admission runs before the ownership ledger. A refusal must
+    # leave no task-state, worktree, branch, or claim residue for a rail write.
+    rail_admission_error = _rail_path_admission_error(
+        task_id=task_id,
+        mode=str(args.mode),
+        owned_paths=getattr(args, "research_owned_path", None),
+    )
+    if rail_admission_error:
+        print(rail_admission_error, file=sys.stderr)
+        return 2
 
     # Writable-path admission guard (#5643 Δ2-A WARN; #5645 REFUSE later).
     # Runs before task-state write / worktree / branch side effects so a refuse

--- a/scripts/orchestration/rail_approval.py
+++ b/scripts/orchestration/rail_approval.py
@@ -35,7 +35,7 @@ try:
     from .rail_path_guard import (
         APPROVED_ISSUERS,
         HEAD_SHA,
-        OPAQUE_RECEIPT_ID,
+        RAIL_APPROVAL_RECEIPT_ID,
         RailApprovalReceiptError,
         normalize_repository_path,
         validate_rail_approval_receipt_data,
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover - direct script invocation
     from rail_path_guard import (  # type: ignore
         APPROVED_ISSUERS,
         HEAD_SHA,
-        OPAQUE_RECEIPT_ID,
+        RAIL_APPROVAL_RECEIPT_ID,
         RailApprovalReceiptError,
         normalize_repository_path,
         validate_rail_approval_receipt_data,
@@ -80,7 +80,7 @@ def _validate_store(payload: object) -> dict[str, dict[str, Any]]:
         raise RailApprovalStoreError("rail approval store receipts must be an object")
     normalized: dict[str, dict[str, Any]] = {}
     for receipt_id, receipt in receipts.items():
-        if not isinstance(receipt_id, str) or not OPAQUE_RECEIPT_ID.fullmatch(receipt_id):
+        if not isinstance(receipt_id, str) or not RAIL_APPROVAL_RECEIPT_ID.fullmatch(receipt_id):
             raise RailApprovalStoreError("rail approval store contains an invalid receipt ID")
         try:
             verified = validate_rail_approval_receipt_data(receipt)
@@ -149,7 +149,7 @@ class RailApprovalReceiptRegistry:
         self.path = Path(path)
 
     def fetch(self, receipt_id: str) -> dict[str, Any]:
-        if not OPAQUE_RECEIPT_ID.fullmatch(receipt_id):
+        if not RAIL_APPROVAL_RECEIPT_ID.fullmatch(receipt_id):
             raise RailApprovalStoreError("rail approval receipt ID is invalid")
         receipt = _read_store(self.path).get(receipt_id)
         if receipt is None:
@@ -201,7 +201,7 @@ def create_rail_approval_receipt(
     if len(set(normalized_paths)) != len(normalized_paths):
         raise RailApprovalStoreError("rail approval owned paths must be unique")
     generated_id = receipt_id or f"rail-approval-{uuid.uuid4().hex}"
-    if not OPAQUE_RECEIPT_ID.fullmatch(generated_id):
+    if not RAIL_APPROVAL_RECEIPT_ID.fullmatch(generated_id):
         raise RailApprovalStoreError("rail approval receipt ID is invalid")
     issued_at = now().astimezone(UTC)
     receipt = {

--- a/scripts/orchestration/rail_approval.py
+++ b/scripts/orchestration/rail_approval.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Human-issued, Monitor-served approval receipts for control-rail writes.
+
+This module is deliberately an *issuance* boundary, not an agent helper.  It
+has no import-time side effect and nothing in dispatch or the hook can invoke
+``issue`` automatically.  An operator or advisor explicitly runs the CLI,
+which writes an immutable runtime-store record.  Enforcement consumers never
+read this file directly: they re-fetch its receipt through the Monitor API (or
+an equivalently provisioned bridge) via ``rail_path_guard``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import json
+import os
+import sys
+import tempfile
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+SOURCE_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(SOURCE_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(SOURCE_REPO_ROOT))
+
+from scripts.common.repo_root import main_checkout_root
+
+try:
+    from .rail_path_guard import (
+        APPROVED_ISSUERS,
+        HEAD_SHA,
+        OPAQUE_RECEIPT_ID,
+        RailApprovalReceiptError,
+        normalize_repository_path,
+        validate_rail_approval_receipt_data,
+    )
+except ImportError:  # pragma: no cover - direct script invocation
+    from rail_path_guard import (  # type: ignore
+        APPROVED_ISSUERS,
+        HEAD_SHA,
+        OPAQUE_RECEIPT_ID,
+        RailApprovalReceiptError,
+        normalize_repository_path,
+        validate_rail_approval_receipt_data,
+    )
+
+PROJECT_ROOT = main_checkout_root(SOURCE_REPO_ROOT)
+DEFAULT_RAIL_APPROVAL_STORE_PATH = (
+    PROJECT_ROOT / "batch_state" / "rail_approval_receipts.v1.json"
+)
+STORE_SCHEMA_VERSION = "rail-approval-store.v1"
+MAX_TTL_HOURS = 168
+
+
+class RailApprovalStoreError(ValueError):
+    """The operator-controlled receipt store is unreadable or inconsistent."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _rfc3339(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _validate_store(payload: object) -> dict[str, dict[str, Any]]:
+    if not isinstance(payload, Mapping):
+        raise RailApprovalStoreError("rail approval store root must be an object")
+    if payload.get("schema_version") != STORE_SCHEMA_VERSION:
+        raise RailApprovalStoreError("rail approval store schema version is invalid")
+    receipts = payload.get("receipts")
+    if not isinstance(receipts, Mapping):
+        raise RailApprovalStoreError("rail approval store receipts must be an object")
+    normalized: dict[str, dict[str, Any]] = {}
+    for receipt_id, receipt in receipts.items():
+        if not isinstance(receipt_id, str) or not OPAQUE_RECEIPT_ID.fullmatch(receipt_id):
+            raise RailApprovalStoreError("rail approval store contains an invalid receipt ID")
+        try:
+            verified = validate_rail_approval_receipt_data(receipt)
+        except RailApprovalReceiptError as exc:
+            raise RailApprovalStoreError(f"rail approval store receipt {receipt_id!r} is invalid") from exc
+        if verified["receipt_id"] != receipt_id:
+            raise RailApprovalStoreError("rail approval store receipt key does not match its payload")
+        normalized[receipt_id] = verified
+    return normalized
+
+
+@contextmanager
+def _exclusive_store_lock(path: Path):
+    """Serialize issuer writes without exposing an incomplete JSON projection."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _read_store(path: Path) -> dict[str, dict[str, Any]]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RailApprovalStoreError("rail approval store is unreadable") from exc
+    return _validate_store(payload)
+
+
+def _write_store(path: Path, receipts: Mapping[str, Mapping[str, Any]]) -> None:
+    payload = {
+        "schema_version": STORE_SCHEMA_VERSION,
+        "receipts": {receipt_id: dict(receipt) for receipt_id, receipt in sorted(receipts.items())},
+    }
+    encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+        directory_fd = os.open(str(path.parent), os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except BaseException:
+        with contextlib.suppress(FileNotFoundError):
+            Path(temporary_name).unlink()
+        raise
+
+
+class RailApprovalReceiptRegistry:
+    """Mutable only for human issuance; API clients expose immutable receipts."""
+
+    def __init__(self, path: Path | str = DEFAULT_RAIL_APPROVAL_STORE_PATH) -> None:
+        self.path = Path(path)
+
+    def fetch(self, receipt_id: str) -> dict[str, Any]:
+        if not OPAQUE_RECEIPT_ID.fullmatch(receipt_id):
+            raise RailApprovalStoreError("rail approval receipt ID is invalid")
+        receipt = _read_store(self.path).get(receipt_id)
+        if receipt is None:
+            raise KeyError(receipt_id)
+        return dict(receipt)
+
+    def issue(self, receipt: Mapping[str, Any]) -> dict[str, Any]:
+        try:
+            verified = validate_rail_approval_receipt_data(receipt)
+        except RailApprovalReceiptError as exc:
+            raise RailApprovalStoreError("refusing to issue an invalid rail approval receipt") from exc
+        receipt_id = str(verified["receipt_id"])
+        with _exclusive_store_lock(self.path):
+            receipts = _read_store(self.path)
+            if receipt_id in receipts:
+                raise RailApprovalStoreError("rail approval receipt ID already exists")
+            receipts[receipt_id] = verified
+            _write_store(self.path, receipts)
+        return dict(verified)
+
+
+def create_rail_approval_receipt(
+    *,
+    task_id: str,
+    head_sha: str,
+    owned_paths: Sequence[str],
+    issuer: str,
+    ttl_hours: int,
+    now: Callable[[], datetime] = _utc_now,
+    receipt_id: str | None = None,
+) -> dict[str, Any]:
+    """Build one schema-valid, narrowly bound receipt for explicit issuance."""
+    if issuer not in APPROVED_ISSUERS:
+        raise RailApprovalStoreError("rail approval issuer must be operator or advisor")
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise RailApprovalStoreError("rail approval task ID is required")
+    if not isinstance(head_sha, str) or not HEAD_SHA.fullmatch(head_sha):
+        raise RailApprovalStoreError("rail approval head SHA must be a 40-character lowercase SHA")
+    if isinstance(ttl_hours, bool) or not isinstance(ttl_hours, int):
+        raise RailApprovalStoreError("rail approval TTL must be an integer number of hours")
+    if not 1 <= ttl_hours <= MAX_TTL_HOURS:
+        raise RailApprovalStoreError(f"rail approval TTL must be between 1 and {MAX_TTL_HOURS} hours")
+    try:
+        normalized_paths = tuple(normalize_repository_path(path) for path in owned_paths)
+    except RailApprovalReceiptError as exc:
+        raise RailApprovalStoreError("rail approval owned paths must be exact normalized paths") from exc
+    if not normalized_paths:
+        raise RailApprovalStoreError("rail approval requires at least one owned path")
+    if len(set(normalized_paths)) != len(normalized_paths):
+        raise RailApprovalStoreError("rail approval owned paths must be unique")
+    generated_id = receipt_id or f"rail-approval-{uuid.uuid4().hex}"
+    if not OPAQUE_RECEIPT_ID.fullmatch(generated_id):
+        raise RailApprovalStoreError("rail approval receipt ID is invalid")
+    issued_at = now().astimezone(UTC)
+    receipt = {
+        "schema_version": "rail-approval-receipt.v1",
+        "receipt_id": generated_id,
+        "issuer": issuer,
+        "issued_at": _rfc3339(issued_at),
+        "expires_at": _rfc3339(issued_at + timedelta(hours=ttl_hours)),
+        "action": "rail-path-mutation",
+        "task_id": task_id,
+        "head_sha": head_sha,
+        "owned_paths": list(normalized_paths),
+    }
+    try:
+        return validate_rail_approval_receipt_data(receipt)
+    except RailApprovalReceiptError as exc:  # schema stays the final issuer contract
+        raise RailApprovalStoreError("rail approval receipt failed schema validation") from exc
+
+
+def issue_rail_approval_receipt(
+    *,
+    registry: RailApprovalReceiptRegistry,
+    task_id: str,
+    head_sha: str,
+    owned_paths: Sequence[str],
+    issuer: str,
+    ttl_hours: int,
+    now: Callable[[], datetime] = _utc_now,
+) -> dict[str, Any]:
+    """Create then atomically publish a receipt; never overwrite prior evidence."""
+    receipt = create_rail_approval_receipt(
+        task_id=task_id,
+        head_sha=head_sha,
+        owned_paths=owned_paths,
+        issuer=issuer,
+        ttl_hours=ttl_hours,
+        now=now,
+    )
+    return registry.issue(receipt)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Human-only rail-approval issuance. This command is never called by dispatch "
+            "or hook enforcement; it writes receipts for the Monitor API to serve."
+        )
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    issue = commands.add_parser("issue", help="Issue one bounded operator/advisor rail receipt.")
+    issue.add_argument("--task-id", required=True)
+    issue.add_argument("--head-sha", required=True)
+    issue.add_argument("--owned-path", action="append", required=True)
+    issue.add_argument("--issuer", required=True, choices=sorted(APPROVED_ISSUERS))
+    issue.add_argument("--ttl-hours", required=True, type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command != "issue":  # pragma: no cover - argparse keeps this unreachable
+        return 2
+    try:
+        receipt = issue_rail_approval_receipt(
+            registry=RailApprovalReceiptRegistry(),
+            task_id=args.task_id,
+            head_sha=args.head_sha,
+            owned_paths=args.owned_path,
+            issuer=args.issuer,
+            ttl_hours=args.ttl_hours,
+        )
+    except RailApprovalStoreError as exc:
+        print(f"rail approval issuance refused: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - direct operator entry point
+    raise SystemExit(main())

--- a/scripts/orchestration/rail_path_guard.py
+++ b/scripts/orchestration/rail_path_guard.py
@@ -70,7 +70,16 @@ RAIL_PATH_PATTERNS = (
 
 APPROVED_RECEIPT_SOURCE_KINDS = frozenset({"api", "bridge"})
 APPROVED_ISSUERS = frozenset({"operator", "advisor"})
-OPAQUE_RECEIPT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+# This is deliberately narrower than a generic opaque identifier.  It is the
+# one receipt grammar shared by issuance, schema validation, the PR-body
+# declaration parser, and every production receipt fetch.
+RAIL_APPROVAL_RECEIPT_ID_PATTERN = r"rail-approval-[0-9a-f]{32}"
+RAIL_APPROVAL_RECEIPT_ID = re.compile(rf"^{RAIL_APPROVAL_RECEIPT_ID_PATTERN}$")
+RAIL_APPROVAL_TRAILER_LABEL = "Rail-Approval-Receipt"
+RAIL_APPROVAL_TRAILER_PREFIX = f"{RAIL_APPROVAL_TRAILER_LABEL}:"
+RAIL_APPROVAL_TRAILER = re.compile(
+    rf"^{re.escape(RAIL_APPROVAL_TRAILER_PREFIX)} ({RAIL_APPROVAL_RECEIPT_ID_PATTERN})$"
+)
 HEAD_SHA = re.compile(r"^[0-9a-f]{40}$")
 _RECEIPT_VALIDATOR: Draft202012Validator | None = None
 
@@ -80,6 +89,23 @@ class RailPathDecisionKind(StrEnum):
 
     ALLOW = "allow"
     DENY = "deny"
+
+
+class RailApprovalDeclarationKind(StrEnum):
+    """Typed status for CI's untrusted PR-body receipt locator."""
+
+    NOT_REQUIRED = "not_required"
+    PRESENT = "present"
+    MISSING = "missing"
+    MALFORMED = "malformed"
+    MULTIPLE = "multiple"
+
+
+class RailApprovalPathBinding(StrEnum):
+    """How a receipt's owned paths bind to the current candidate paths."""
+
+    MUTATION_CONTAINMENT = "mutation_containment"
+    PR_DIFF_EXACT_SET = "pr_diff_exact_set"
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,6 +119,21 @@ class RailPathDecision:
     @property
     def allowed(self) -> bool:
         return self.kind is RailPathDecisionKind.ALLOW
+
+
+@dataclass(frozen=True, slots=True)
+class RailApprovalDeclaration:
+    """A declaration result; unlike ``RailPathDecision`` it grants no authority."""
+
+    kind: RailApprovalDeclarationKind
+    reason: str
+    rail_paths: tuple[str, ...]
+    receipt_id: str | None = None
+
+    @property
+    def is_present(self) -> bool:
+        """Whether one syntactically valid, still-untrusted locator was found."""
+        return self.kind is RailApprovalDeclarationKind.PRESENT
 
 
 class RailApprovalReceiptError(ValueError):
@@ -135,8 +176,8 @@ class MonitorRailApprovalReceiptStore:
         self._get = get or _monitor_api_get
 
     def fetch_rail_approval_receipt(self, receipt_id: str) -> Mapping[str, Any]:
-        if not OPAQUE_RECEIPT_ID.fullmatch(receipt_id):
-            raise RailApprovalReceiptError("rail approval receipt ID must be an opaque approved-source identifier")
+        if not RAIL_APPROVAL_RECEIPT_ID.fullmatch(receipt_id):
+            raise RailApprovalReceiptError("rail approval receipt ID has an invalid rail-approval shape")
         try:
             status, body, _headers = self._get(f"/api/rail-approvals/{receipt_id}")
         except RailApprovalReceiptError:
@@ -271,6 +312,83 @@ def is_rail_path(path: str) -> bool:
     return any(regex.fullmatch(path) is not None for regex in _RAIL_PATH_REGEXES)
 
 
+def rail_paths_from_candidates(candidate_paths: Sequence[str]) -> tuple[str, ...]:
+    """Normalize candidate paths and return the protected subset, fail-closed on bad input."""
+    normalized = tuple(normalize_repository_path(path) for path in candidate_paths)
+    return tuple(path for path in normalized if is_rail_path(path))
+
+
+def parse_rail_approval_declaration(body: object) -> RailApprovalDeclaration:
+    """Parse exactly one standalone PR-body receipt trailer as an untrusted locator.
+
+    This deliberately does not retrieve a receipt or make an authorization
+    decision.  CI can only attest that a syntactically exact locator is present;
+    the merge guard later re-fetches the referenced receipt from production and
+    applies all authority bindings.
+    """
+    if not isinstance(body, str):
+        return RailApprovalDeclaration(
+            RailApprovalDeclarationKind.MALFORMED,
+            "rail_approval_declaration_body_unreadable",
+            (),
+        )
+    occurrences = body.count(RAIL_APPROVAL_TRAILER_PREFIX)
+    if occurrences == 0:
+        return RailApprovalDeclaration(
+            RailApprovalDeclarationKind.MISSING,
+            "rail_approval_declaration_missing",
+            (),
+        )
+    if occurrences != 1:
+        return RailApprovalDeclaration(
+            RailApprovalDeclarationKind.MULTIPLE,
+            "rail_approval_declaration_multiple",
+            (),
+        )
+    match = next(
+        (
+            RAIL_APPROVAL_TRAILER.fullmatch(line)
+            for line in body.splitlines()
+            if RAIL_APPROVAL_TRAILER_PREFIX in line
+        ),
+        None,
+    )
+    if match is None:
+        return RailApprovalDeclaration(
+            RailApprovalDeclarationKind.MALFORMED,
+            "rail_approval_declaration_malformed",
+            (),
+        )
+    return RailApprovalDeclaration(
+        RailApprovalDeclarationKind.PRESENT,
+        "rail_approval_declaration_present",
+        (),
+        match.group(1),
+    )
+
+
+def inspect_rail_approval_declaration(
+    *,
+    candidate_paths: Sequence[str],
+    body: object,
+) -> RailApprovalDeclaration:
+    """Classify CI's diff and parse its PR-body declaration without deciding authority."""
+    rail_paths = rail_paths_from_candidates(candidate_paths)
+    if not rail_paths:
+        return RailApprovalDeclaration(
+            RailApprovalDeclarationKind.NOT_REQUIRED,
+            "non_rail_paths",
+            (),
+        )
+    declaration = parse_rail_approval_declaration(body)
+    return RailApprovalDeclaration(
+        declaration.kind,
+        declaration.reason,
+        rail_paths,
+        declaration.receipt_id,
+    )
+
+
 def validate_rail_approval_receipt_data(payload: Mapping[str, Any]) -> dict[str, Any]:
     """Schema-validate a remotely fetched P6 receipt before inspecting bindings."""
     if not isinstance(payload, Mapping):
@@ -324,9 +442,9 @@ class ApprovedRailApprovalReceiptResolver:
 
     def fetch(self, receipt_id: str) -> VerifiedRailApprovalReceipt:
         """Re-fetch a receipt; any unreadable store is an authorization failure."""
-        if not OPAQUE_RECEIPT_ID.fullmatch(receipt_id):
+        if not RAIL_APPROVAL_RECEIPT_ID.fullmatch(receipt_id):
             raise RailApprovalReceiptError(
-                "rail approval receipt ID must be an opaque approved-source identifier"
+                "rail approval receipt ID has an invalid rail-approval shape"
             )
         try:
             fetched = self.store.fetch_rail_approval_receipt(receipt_id)
@@ -379,9 +497,10 @@ def _receipt_authorizes(
     task_id: str,
     head_sha: str,
     rail_paths: tuple[str, ...],
+    path_binding: RailApprovalPathBinding,
     now: datetime,
 ) -> str | None:
-    """Return a refusal reason, or ``None`` only for an exact current binding."""
+    """Return a refusal reason, or ``None`` only for a current path binding."""
     try:
         payload = validate_rail_approval_receipt_data(receipt.payload)
     except RailApprovalReceiptError:
@@ -395,8 +514,15 @@ def _receipt_authorizes(
     if payload["head_sha"] != head_sha:
         return "rail_approval_head_mismatch"
     owned_paths = frozenset(payload["owned_paths"])
-    if any(path not in owned_paths for path in rail_paths):
-        return "rail_approval_path_mismatch"
+    rail_path_set = frozenset(rail_paths)
+    if path_binding is RailApprovalPathBinding.PR_DIFF_EXACT_SET:
+        if owned_paths != rail_path_set:
+            return "rail_approval_path_set_mismatch"
+    elif path_binding is RailApprovalPathBinding.MUTATION_CONTAINMENT:
+        if not rail_path_set.issubset(owned_paths):
+            return "rail_approval_path_mismatch"
+    else:  # Runtime callers do not get a permissive fallback for an unknown mode.
+        return "invalid_rail_approval_path_binding"
     return None
 
 
@@ -406,19 +532,23 @@ def decide_rail_path_mutation(
     candidate_paths: Sequence[str],
     head_sha: str,
     receipt: VerifiedRailApprovalReceipt | None = None,
+    path_binding: RailApprovalPathBinding = RailApprovalPathBinding.MUTATION_CONTAINMENT,
     now: Callable[[], datetime] = _utc_now,
 ) -> RailPathDecision:
-    """Allow non-rail paths; require an exact, current approval for rail paths.
+    """Allow non-rail paths; require a current approval for rail paths.
 
     ``candidate_paths`` are mutation targets, not ownership globs.  A malformed
     target is denied rather than guessed, while ordinary non-rail paths remain
-    unaffected by absent receipts.
+    unaffected by absent receipts.  Dispatch and checkout-write hooks check a
+    bounded mutation attempt, so containment permits an approved larger scope.
+    The merge guard passes ``PR_DIFF_EXACT_SET`` because it sees the complete
+    current rail diff: equality prevents a receipt for an earlier path set from
+    being reused after the PR's protected scope changes.
     """
     try:
-        normalized = tuple(normalize_repository_path(path) for path in candidate_paths)
+        rail_paths = rail_paths_from_candidates(candidate_paths)
     except RailApprovalReceiptError:
         return RailPathDecision(RailPathDecisionKind.DENY, "invalid_candidate_path", ())
-    rail_paths = tuple(path for path in normalized if is_rail_path(path))
     if not rail_paths:
         return RailPathDecision(RailPathDecisionKind.ALLOW, "non_rail_paths", ())
     if not isinstance(task_id, str) or not task_id.strip():
@@ -436,6 +566,7 @@ def decide_rail_path_mutation(
         task_id=task_id,
         head_sha=head_sha,
         rail_paths=rail_paths,
+        path_binding=path_binding,
         now=now(),
     )
     if reason is not None:
@@ -450,6 +581,7 @@ def decide_rail_path_mutation_with_production_receipt(
     head_sha: str,
     receipt_id: str | None,
     resolver: ApprovedRailApprovalReceiptResolver | None = None,
+    path_binding: RailApprovalPathBinding = RailApprovalPathBinding.MUTATION_CONTAINMENT,
     now: Callable[[], datetime] = _utc_now,
 ) -> RailPathDecision:
     """Resolve a receipt from the fixed source, then make the normal decision.
@@ -462,6 +594,7 @@ def decide_rail_path_mutation_with_production_receipt(
         task_id=task_id,
         candidate_paths=candidate_paths,
         head_sha=head_sha,
+        path_binding=path_binding,
         now=now,
     )
     if preliminary.allowed or preliminary.reason != "rail_approval_receipt_required":
@@ -482,5 +615,6 @@ def decide_rail_path_mutation_with_production_receipt(
         candidate_paths=candidate_paths,
         head_sha=head_sha,
         receipt=receipt,
+        path_binding=path_binding,
         now=now,
     )

--- a/scripts/orchestration/rail_path_guard.py
+++ b/scripts/orchestration/rail_path_guard.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Fail-closed authorization for mutations to the fleet's control rails.
+
+The guard deliberately separates *classification* from receipt retrieval.  A
+caller supplies exact candidate paths and a current commit SHA; this module
+decides whether those paths are ordinary work or rail mutations.  Rail
+mutations require a receipt that was re-fetched from a provisioned API/bridge,
+following the same authority boundary as ``trails.authority``.  A local JSON
+file, an environment claim, an X-Agent trailer, or a model name is never
+authority.
+
+The decision function is pure after a receipt has been resolved.  Receipt I/O
+is isolated in :class:`ApprovedRailApprovalReceiptResolver` so every
+enforcement layer uses the same schema and binding rules.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Protocol
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RAIL_APPROVAL_RECEIPT_SCHEMA_PATH = (
+    PROJECT_ROOT / "agents_extensions/shared/schemas/rail-approval-receipt.v1.schema.json"
+)
+
+# Every pattern is matched against the complete normalized repository-relative
+# path.  Do not replace this with substring matching: e.g. a learner document
+# mentioning ``model_catalog.yaml`` is not a control-rail mutation.
+RAIL_PATH_PATTERNS = (
+    "agents_extensions/shared/rules/**",
+    "agents_extensions/**/agents/**",
+    "agents_extensions/**/hooks/**",
+    "scripts/guardrails/**",
+    "scripts/delegate.py",
+    "scripts/agent_runtime/codex_hook_policy.py",
+    "scripts/orchestration/rail_path_guard.py",
+    "scripts/config/model_catalog.yaml",
+    "agents_extensions/shared/rules/model-assignment.md",
+    "scripts/config/fleet_taxonomy.yaml",
+    "agents_extensions/shared/schemas/fleet-taxonomy*.schema.json",
+    "scripts/config/trails/**",
+    "agents_extensions/shared/schemas/trailspec*",
+    "agents_extensions/shared/schemas/trailspec*/**",
+    "agents_extensions/shared/schemas/step-receipt*",
+    "agents_extensions/shared/schemas/step-receipt*/**",
+    "agents_extensions/shared/schemas/command-receipt*",
+    "agents_extensions/shared/schemas/command-receipt*/**",
+    "agents_extensions/shared/schemas/rail-approval-receipt*",
+    "agents_extensions/shared/schemas/rail-approval-receipt*/**",
+    ".claude/**",
+    # The CI and merge-hook implementations are enforcement layers themselves;
+    # leaving either mutable without an approval would make the other layers
+    # cosmetic rather than defense in depth.
+    ".github/workflows/ci.yml",
+    "agents_extensions/shared/hooks/guard-pr-merge.py",
+    "agents_extensions/shared/hooks/guard-primary-checkout-write.py",
+)
+
+APPROVED_RECEIPT_SOURCE_KINDS = frozenset({"api", "bridge"})
+APPROVED_ISSUERS = frozenset({"operator", "advisor"})
+OPAQUE_RECEIPT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+HEAD_SHA = re.compile(r"^[0-9a-f]{40}$")
+_RECEIPT_VALIDATOR: Draft202012Validator | None = None
+
+
+class RailPathDecisionKind(StrEnum):
+    """The typed result of a rail-path authorization decision."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+
+
+@dataclass(frozen=True, slots=True)
+class RailPathDecision:
+    """A deterministic authorization result suitable for every enforcement layer."""
+
+    kind: RailPathDecisionKind
+    reason: str
+    rail_paths: tuple[str, ...]
+
+    @property
+    def allowed(self) -> bool:
+        return self.kind is RailPathDecisionKind.ALLOW
+
+
+class RailApprovalReceiptError(ValueError):
+    """A receipt could not prove authorization for a rail mutation."""
+
+
+class RailApprovalReceiptStore(Protocol):
+    """A provisioned external receipt source, never a caller-controlled file."""
+
+    source_id: str
+    source_kind: str
+
+    def fetch_rail_approval_receipt(self, receipt_id: str) -> Mapping[str, Any]:
+        """Re-fetch one immutable approval receipt by opaque identifier."""
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedRailApprovalReceipt:
+    """A receipt schema-checked after a successful external re-fetch."""
+
+    payload: dict[str, Any]
+    source_id: str
+    digest: str
+
+    @property
+    def receipt_id(self) -> str:
+        return str(self.payload["receipt_id"])
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _parse_time(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise RailApprovalReceiptError(f"rail approval receipt {field} must be an RFC3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RailApprovalReceiptError(
+            f"rail approval receipt {field} is not an RFC3339 timestamp"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise RailApprovalReceiptError(
+            f"rail approval receipt {field} must include a timezone"
+        )
+    return parsed.astimezone(UTC)
+
+
+def _validator() -> Draft202012Validator:
+    """Load the immutable versioned schema once; never cache receipt payloads."""
+    global _RECEIPT_VALIDATOR
+    if _RECEIPT_VALIDATOR is not None:
+        return _RECEIPT_VALIDATOR
+    try:
+        schema = json.loads(RAIL_APPROVAL_RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RailApprovalReceiptError(
+            f"cannot load rail approval receipt schema: {exc}"
+        ) from exc
+    if not isinstance(schema, dict):
+        raise RailApprovalReceiptError("rail approval receipt schema root must be an object")
+    _RECEIPT_VALIDATOR = Draft202012Validator(schema, format_checker=FormatChecker())
+    return _RECEIPT_VALIDATOR
+
+
+def normalize_repository_path(value: object) -> str:
+    """Normalize one exact repository-relative path or reject it fail-closed."""
+    if not isinstance(value, str) or not value:
+        raise RailApprovalReceiptError("candidate path must be a non-empty string")
+    if "\\" in value or value.startswith("/") or "\x00" in value:
+        raise RailApprovalReceiptError("candidate path must be a relative POSIX path")
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise RailApprovalReceiptError("candidate path is not normalized")
+    if any(any(char in part for char in "*?[") for part in parts):
+        raise RailApprovalReceiptError("candidate path must be exact, not a glob")
+    return "/".join(parts)
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Compile a small POSIX path glob without substring or OS-dependent matching."""
+    pieces = pattern.split("/")
+    expression = "^"
+    for index, piece in enumerate(pieces):
+        if piece == "**":
+            if index == len(pieces) - 1:
+                expression += r"(?:/.*)?"
+            else:
+                expression += r"(?:/[^/]+)*"
+            continue
+        if index:
+            expression += "/"
+        expression += "".join(
+            "[^/]*" if char == "*" else re.escape(char)
+            for char in piece
+        )
+    return re.compile(expression + "$")
+
+
+_RAIL_PATH_REGEXES = tuple(_glob_to_regex(pattern) for pattern in RAIL_PATH_PATTERNS)
+
+
+def is_rail_path(path: str) -> bool:
+    """Return whether an exact, normalized path belongs to the narrow deny-list."""
+    return any(regex.fullmatch(path) is not None for regex in _RAIL_PATH_REGEXES)
+
+
+def validate_rail_approval_receipt_data(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Schema-validate a remotely fetched P6 receipt before inspecting bindings."""
+    if not isinstance(payload, Mapping):
+        raise RailApprovalReceiptError("rail approval source returned a non-object receipt")
+    receipt = dict(payload)
+    errors = sorted(_validator().iter_errors(receipt), key=lambda error: tuple(error.path))
+    if errors:
+        error = errors[0]
+        raise RailApprovalReceiptError(
+            f"rail approval receipt schema violation: {error.message} at {error.json_path}"
+        )
+    issued_at = _parse_time(receipt["issued_at"], field="issued_at")
+    expires_at = _parse_time(receipt["expires_at"], field="expires_at")
+    if expires_at <= issued_at:
+        raise RailApprovalReceiptError("rail approval receipt expiry must be after issue time")
+    owned_paths = tuple(receipt["owned_paths"])
+    try:
+        normalized = tuple(normalize_repository_path(path) for path in owned_paths)
+    except RailApprovalReceiptError as exc:
+        raise RailApprovalReceiptError(f"rail approval receipt owned_paths invalid: {exc}") from exc
+    if normalized != owned_paths or len(set(normalized)) != len(normalized):
+        raise RailApprovalReceiptError("rail approval receipt owned_paths must be normalized and unique")
+    return receipt
+
+
+def _receipt_digest(receipt: Mapping[str, Any]) -> str:
+    """Stable digest without importing a TrailSpec-only implementation."""
+    import hashlib
+
+    canonical = json.dumps(receipt, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class ApprovedRailApprovalReceiptResolver:
+    """Re-fetch P6 receipts from a fixed API/bridge and reject local projections."""
+
+    def __init__(
+        self,
+        store: RailApprovalReceiptStore,
+        *,
+        now: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        if getattr(store, "source_kind", None) not in APPROVED_RECEIPT_SOURCE_KINDS:
+            raise RailApprovalReceiptError(
+                "rail approval source must be a provisioned bridge or API"
+            )
+        if not isinstance(getattr(store, "source_id", None), str) or not store.source_id:
+            raise RailApprovalReceiptError("rail approval source must have a stable source_id")
+        self.store = store
+        self.now = now
+
+    def fetch(self, receipt_id: str) -> VerifiedRailApprovalReceipt:
+        """Re-fetch a receipt; any unreadable store is an authorization failure."""
+        if not OPAQUE_RECEIPT_ID.fullmatch(receipt_id):
+            raise RailApprovalReceiptError(
+                "rail approval receipt ID must be an opaque approved-source identifier"
+            )
+        try:
+            fetched = self.store.fetch_rail_approval_receipt(receipt_id)
+        except RailApprovalReceiptError:
+            raise
+        except Exception as exc:
+            raise RailApprovalReceiptError(
+                "approved rail approval source could not re-fetch receipt"
+            ) from exc
+        receipt = validate_rail_approval_receipt_data(fetched)
+        if receipt["receipt_id"] != receipt_id:
+            raise RailApprovalReceiptError(
+                "rail approval source receipt ID does not match requested ID"
+            )
+        if receipt["issuer"] not in APPROVED_ISSUERS:
+            raise RailApprovalReceiptError(
+                f"rail approval receipt issuer {receipt['issuer']!r} is not approved"
+            )
+        if _parse_time(receipt["expires_at"], field="expires_at") <= self.now().astimezone(UTC):
+            raise RailApprovalReceiptError("rail approval receipt has expired")
+        return VerifiedRailApprovalReceipt(
+            payload=receipt,
+            source_id=self.store.source_id,
+            digest=_receipt_digest(receipt),
+        )
+
+
+def _receipt_authorizes(
+    receipt: VerifiedRailApprovalReceipt,
+    *,
+    task_id: str,
+    head_sha: str,
+    rail_paths: tuple[str, ...],
+    now: datetime,
+) -> str | None:
+    """Return a refusal reason, or ``None`` only for an exact current binding."""
+    try:
+        payload = validate_rail_approval_receipt_data(receipt.payload)
+    except RailApprovalReceiptError:
+        return "invalid_rail_approval_receipt"
+    if payload["issuer"] not in APPROVED_ISSUERS:
+        return "unapproved_rail_approval_issuer"
+    if _parse_time(payload["expires_at"], field="expires_at") <= now.astimezone(UTC):
+        return "expired_rail_approval_receipt"
+    if payload["task_id"] != task_id:
+        return "rail_approval_task_mismatch"
+    if payload["head_sha"] != head_sha:
+        return "rail_approval_head_mismatch"
+    owned_paths = frozenset(payload["owned_paths"])
+    if any(path not in owned_paths for path in rail_paths):
+        return "rail_approval_path_mismatch"
+    return None
+
+
+def decide_rail_path_mutation(
+    *,
+    task_id: str,
+    candidate_paths: Sequence[str],
+    head_sha: str,
+    receipt: VerifiedRailApprovalReceipt | None = None,
+    now: Callable[[], datetime] = _utc_now,
+) -> RailPathDecision:
+    """Allow non-rail paths; require an exact, current approval for rail paths.
+
+    ``candidate_paths`` are mutation targets, not ownership globs.  A malformed
+    target is denied rather than guessed, while ordinary non-rail paths remain
+    unaffected by absent receipts.
+    """
+    try:
+        normalized = tuple(normalize_repository_path(path) for path in candidate_paths)
+    except RailApprovalReceiptError:
+        return RailPathDecision(RailPathDecisionKind.DENY, "invalid_candidate_path", ())
+    rail_paths = tuple(path for path in normalized if is_rail_path(path))
+    if not rail_paths:
+        return RailPathDecision(RailPathDecisionKind.ALLOW, "non_rail_paths", ())
+    if not isinstance(task_id, str) or not task_id.strip():
+        return RailPathDecision(RailPathDecisionKind.DENY, "invalid_task_id", rail_paths)
+    if not isinstance(head_sha, str) or not HEAD_SHA.fullmatch(head_sha):
+        return RailPathDecision(RailPathDecisionKind.DENY, "invalid_head_sha", rail_paths)
+    if receipt is None:
+        return RailPathDecision(
+            RailPathDecisionKind.DENY,
+            "rail_approval_receipt_required",
+            rail_paths,
+        )
+    reason = _receipt_authorizes(
+        receipt,
+        task_id=task_id,
+        head_sha=head_sha,
+        rail_paths=rail_paths,
+        now=now(),
+    )
+    if reason is not None:
+        return RailPathDecision(RailPathDecisionKind.DENY, reason, rail_paths)
+    return RailPathDecision(RailPathDecisionKind.ALLOW, "rail_approval_verified", rail_paths)

--- a/scripts/orchestration/rail_path_guard.py
+++ b/scripts/orchestration/rail_path_guard.py
@@ -42,7 +42,10 @@ RAIL_PATH_PATTERNS = (
     "scripts/guardrails/**",
     "scripts/delegate.py",
     "scripts/agent_runtime/codex_hook_policy.py",
+    "scripts/orchestration/rail_approval.py",
     "scripts/orchestration/rail_path_guard.py",
+    "scripts/api/main.py",
+    "scripts/api/rail_approval_router.py",
     "scripts/config/model_catalog.yaml",
     "agents_extensions/shared/rules/model-assignment.md",
     "scripts/config/fleet_taxonomy.yaml",
@@ -104,6 +107,76 @@ class RailApprovalReceiptStore(Protocol):
 
     def fetch_rail_approval_receipt(self, receipt_id: str) -> Mapping[str, Any]:
         """Re-fetch one immutable approval receipt by opaque identifier."""
+
+
+def _monitor_api_get(path: str) -> tuple[int, str, Mapping[str, str]]:
+    """Use the established Monitor client rather than a caller-chosen URL."""
+    from scripts.ai_agent_bridge.monitor_client import MonitorClient
+
+    return MonitorClient()._get(path)
+
+
+class MonitorRailApprovalReceiptStore:
+    """The provisioned Monitor API source used by production enforcement.
+
+    Receipt issuance writes the Monitor-owned runtime registry, but a caller
+    must use this API projection to fetch it.  Reading a worktree-local JSON
+    file directly would turn the receipt into a forgeable caller projection.
+    """
+
+    source_id = "monitor-api:/api/rail-approvals"
+    source_kind = "api"
+
+    def __init__(
+        self,
+        *,
+        get: Callable[[str], tuple[int, str, Mapping[str, str]]] | None = None,
+    ) -> None:
+        self._get = get or _monitor_api_get
+
+    def fetch_rail_approval_receipt(self, receipt_id: str) -> Mapping[str, Any]:
+        if not OPAQUE_RECEIPT_ID.fullmatch(receipt_id):
+            raise RailApprovalReceiptError("rail approval receipt ID must be an opaque approved-source identifier")
+        try:
+            status, body, _headers = self._get(f"/api/rail-approvals/{receipt_id}")
+        except RailApprovalReceiptError:
+            raise
+        except Exception as exc:
+            raise RailApprovalReceiptError("Monitor rail approval API could not re-fetch receipt") from exc
+        if status != 200:
+            raise RailApprovalReceiptError("Monitor rail approval API could not re-fetch receipt")
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise RailApprovalReceiptError("Monitor rail approval API returned invalid JSON") from exc
+        if not isinstance(payload, Mapping):
+            raise RailApprovalReceiptError("Monitor rail approval API returned a non-object receipt")
+        return payload
+
+
+class ProvisionedRailApprovalReceiptBridge:
+    """Adapter for a deployment-provisioned bridge when Monitor is unavailable.
+
+    This is intentionally dependency-injected at process bootstrap.  There is
+    no environment-variable URL, local-file, or user-supplied bridge fallback:
+    those would let a write caller select its own approval authority.
+    """
+
+    source_kind = "bridge"
+
+    def __init__(
+        self,
+        *,
+        source_id: str,
+        fetcher: Callable[[str], Mapping[str, Any]],
+    ) -> None:
+        if not source_id:
+            raise RailApprovalReceiptError("rail approval bridge must have a stable source_id")
+        self.source_id = source_id
+        self._fetcher = fetcher
+
+    def fetch_rail_approval_receipt(self, receipt_id: str) -> Mapping[str, Any]:
+        return self._fetcher(receipt_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -281,6 +354,25 @@ class ApprovedRailApprovalReceiptResolver:
         )
 
 
+def build_production_rail_approval_receipt_resolver(
+    *,
+    bridge: RailApprovalReceiptStore | None = None,
+) -> ApprovedRailApprovalReceiptResolver:
+    """Build the fixed production resolver without caller-selected authority.
+
+    Monitor is the ordinary production source.  A deployment with an approved
+    bridge may inject it at process bootstrap when Monitor is unavailable; the
+    bridge must carry ``source_kind='bridge'`` and is still schema/binding
+    checked by :class:`ApprovedRailApprovalReceiptResolver`.  Enforcement code
+    never falls back to a local file, arbitrary URL, or environment claim.
+    """
+    if bridge is not None:
+        if getattr(bridge, "source_kind", None) != "bridge":
+            raise RailApprovalReceiptError("rail approval fallback must be a provisioned bridge")
+        return ApprovedRailApprovalReceiptResolver(bridge)
+    return ApprovedRailApprovalReceiptResolver(MonitorRailApprovalReceiptStore())
+
+
 def _receipt_authorizes(
     receipt: VerifiedRailApprovalReceipt,
     *,
@@ -349,3 +441,46 @@ def decide_rail_path_mutation(
     if reason is not None:
         return RailPathDecision(RailPathDecisionKind.DENY, reason, rail_paths)
     return RailPathDecision(RailPathDecisionKind.ALLOW, "rail_approval_verified", rail_paths)
+
+
+def decide_rail_path_mutation_with_production_receipt(
+    *,
+    task_id: str,
+    candidate_paths: Sequence[str],
+    head_sha: str,
+    receipt_id: str | None,
+    resolver: ApprovedRailApprovalReceiptResolver | None = None,
+    now: Callable[[], datetime] = _utc_now,
+) -> RailPathDecision:
+    """Resolve a receipt from the fixed source, then make the normal decision.
+
+    This keeps dispatch and hook layers from accidentally trusting a receipt
+    payload supplied by their caller.  Source failures become denials rather
+    than exceptions that a caller might mishandle as an allow.
+    """
+    preliminary = decide_rail_path_mutation(
+        task_id=task_id,
+        candidate_paths=candidate_paths,
+        head_sha=head_sha,
+        now=now,
+    )
+    if preliminary.allowed or preliminary.reason != "rail_approval_receipt_required":
+        return preliminary
+    if receipt_id is None:
+        return preliminary
+    try:
+        receipt = (resolver or build_production_rail_approval_receipt_resolver()).fetch(receipt_id)
+    except RailApprovalReceiptError as exc:
+        reason = (
+            "expired_rail_approval_receipt"
+            if "has expired" in str(exc)
+            else "rail_approval_receipt_unreadable"
+        )
+        return RailPathDecision(RailPathDecisionKind.DENY, reason, preliminary.rail_paths)
+    return decide_rail_path_mutation(
+        task_id=task_id,
+        candidate_paths=candidate_paths,
+        head_sha=head_sha,
+        receipt=receipt,
+        now=now,
+    )

--- a/scripts/orchestration/rail_path_guard.py
+++ b/scripts/orchestration/rail_path_guard.py
@@ -60,6 +60,15 @@ RAIL_PATH_PATTERNS = (
     "agents_extensions/shared/schemas/rail-approval-receipt*",
     "agents_extensions/shared/schemas/rail-approval-receipt*/**",
     ".claude/**",
+    # Sibling deploy targets of agents_extensions/shared (deployed rule/agent/hook
+    # copies are the same tamper class as .claude/**): .gemini/** is git-tracked;
+    # .codex/** is gitignored local deploy state, so only the hook/dispatch layers
+    # ever see it — the pattern still binds there. .agent/** is DELIBERATELY not a
+    # rail path: it is per-session runtime scratch (babysit files, handoffs, tmp)
+    # written constantly by live drivers; requiring receipts for it would halt the
+    # fleet, and being gitignored it can never reach a PR diff anyway.
+    ".gemini/**",
+    ".codex/**",
     # The CI and merge-hook implementations are enforcement layers themselves;
     # leaving either mutable without an approval would make the other layers
     # cosmetic rather than defense in depth.

--- a/scripts/orchestration/rail_path_guard.py
+++ b/scripts/orchestration/rail_path_guard.py
@@ -110,6 +110,14 @@ class RailApprovalDeclarationKind(StrEnum):
     MULTIPLE = "multiple"
 
 
+class RailCIEventDisposition(StrEnum):
+    """How the rail CI job must handle one GitHub Actions event."""
+
+    DECLARATION = "declaration"
+    SKIP = "skip"
+    DENY = "deny"
+
+
 class RailApprovalPathBinding(StrEnum):
     """How a receipt's owned paths bind to the current candidate paths."""
 
@@ -143,6 +151,15 @@ class RailApprovalDeclaration:
     def is_present(self) -> bool:
         """Whether one syntactically valid, still-untrusted locator was found."""
         return self.kind is RailApprovalDeclarationKind.PRESENT
+
+
+@dataclass(frozen=True, slots=True)
+class RailCIEventDispatch:
+    """Event-scoped instruction for the non-authoritative rail CI job."""
+
+    disposition: RailCIEventDisposition
+    reason: str
+    rail_paths: tuple[str, ...] = ()
 
 
 class RailApprovalReceiptError(ValueError):
@@ -288,8 +305,6 @@ def normalize_repository_path(value: object) -> str:
     parts = value.split("/")
     if any(part in {"", ".", ".."} for part in parts):
         raise RailApprovalReceiptError("candidate path is not normalized")
-    if any(any(char in part for char in "*?[") for part in parts):
-        raise RailApprovalReceiptError("candidate path must be exact, not a glob")
     return "/".join(parts)
 
 
@@ -325,6 +340,56 @@ def rail_paths_from_candidates(candidate_paths: Sequence[str]) -> tuple[str, ...
     """Normalize candidate paths and return the protected subset, fail-closed on bad input."""
     normalized = tuple(normalize_repository_path(path) for path in candidate_paths)
     return tuple(path for path in normalized if is_rail_path(path))
+
+
+def inspect_rail_ci_event(
+    *,
+    event_name: object,
+    candidate_paths: Sequence[str] | None = None,
+) -> RailCIEventDispatch:
+    """Apply the rail CI job's event-scoped declaration policy.
+
+    Only ``pull_request`` carries a body that can declare an untrusted receipt
+    locator. Merge queues receive the exact group diff but no corresponding PR
+    body, so rail changes must be refused there; ordinary merge-queue changes
+    remain an explicit successful skip. A push to ``main`` is post-merge
+    informational only because enforcement already happened at PR time.
+    """
+    if not isinstance(event_name, str):
+        raise RailApprovalReceiptError("rail approval declaration received an unsupported CI event")
+    if event_name == "push":
+        return RailCIEventDispatch(
+            RailCIEventDisposition.SKIP,
+            "post-merge informational — enforcement happened at PR time",
+        )
+    if event_name == "workflow_dispatch":
+        return RailCIEventDispatch(
+            RailCIEventDisposition.SKIP,
+            "manual informational — enforcement happened at PR time",
+        )
+    if event_name not in {"pull_request", "merge_group"}:
+        raise RailApprovalReceiptError("rail approval declaration received an unsupported CI event")
+    if candidate_paths is None:
+        raise RailApprovalReceiptError("rail approval declaration requires candidate paths")
+
+    rail_paths = rail_paths_from_candidates(candidate_paths)
+    if event_name == "pull_request":
+        return RailCIEventDispatch(
+            RailCIEventDisposition.DECLARATION,
+            "pull-request declaration required",
+            rail_paths,
+        )
+    if rail_paths:
+        return RailCIEventDispatch(
+            RailCIEventDisposition.DENY,
+            "merge-queue flow does not carry a rail declaration; "
+            "merge rail PRs via the direct auto-merge path",
+            rail_paths,
+        )
+    return RailCIEventDispatch(
+        RailCIEventDisposition.SKIP,
+        "merge-queue diff has no rail paths; declaration check skipped",
+    )
 
 
 def parse_rail_approval_declaration(body: object) -> RailApprovalDeclaration:

--- a/tests/test_delegate_rail_path_admission.py
+++ b/tests/test_delegate_rail_path_admission.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import delegate
+
+from scripts.orchestration import rail_approval
+from scripts.orchestration import rail_path_guard as guard
 
 
 def test_dispatch_admission_refuses_rail_claim_before_ownership_ledger() -> None:
@@ -26,6 +31,104 @@ def test_dispatch_admission_leaves_non_rail_claim_unaffected() -> None:
         task_id="rail-p6-test",
         mode="workspace-write",
         owned_paths=["docs/projects/fleet-trails/rail-system-completion-memo.md"],
+    )
+
+    assert error is None
+
+
+def test_write_dispatch_without_paths_emits_and_persists_deferred_rail_advisory() -> None:
+    """F002 is honest about the hook/CI/merge layers that still enforce rails."""
+    advisory = delegate._rail_path_admission_advisory(
+        mode="workspace-write",
+        owned_paths=None,
+    )
+    assert advisory == (
+        "rail admission: no path declaration — rail enforcement deferred to hook/CI/merge layers"
+    )
+    state = delegate._with_rail_admission_state({}, advisory=advisory, receipt_id=None)
+    assert state["rail_admission_advisory"] == advisory
+
+
+def test_dry_write_dispatch_records_the_same_no_path_advisory(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """The dispatched task state retains exactly the stderr F002 advisory."""
+    monkeypatch.setattr(delegate, "_TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(delegate, "_resolve_write_cwd_error", lambda **_kwargs: None)
+    monkeypatch.setattr(delegate, "_resolve_dirty_primary_checkout_error", lambda **_kwargs: None)
+    monkeypatch.setattr(delegate, "_resolve_primary_integrity_error", lambda **_kwargs: None)
+    monkeypatch.setattr(delegate, "_warn_if_monitor_api_unreachable", lambda: None)
+    monkeypatch.setattr(delegate, "_check_capacity_hint", lambda *_args, **_kwargs: None)
+    args = delegate.build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "rail-no-path-advisory",
+            "--prompt",
+            "fixture",
+            "--mode",
+            "workspace-write",
+            "--cwd",
+            str(tmp_path),
+            "--dry-run",
+        ]
+    )
+
+    assert delegate.cmd_dispatch(args) == 0
+
+    advisory = delegate.RAIL_ADMISSION_NO_PATH_ADVISORY
+    state = delegate._read_state(delegate._state_path("rail-no-path-advisory"))
+    assert state is not None
+    assert state["rail_admission_advisory"] == advisory
+    assert advisory in capsys.readouterr().err
+
+
+def test_declared_rail_path_still_denies_without_receipt_and_has_no_advisory() -> None:
+    error = delegate._rail_path_admission_error(
+        task_id="rail-p6-test",
+        mode="workspace-write",
+        owned_paths=["agents_extensions/shared/hooks/guard-pr-merge.py"],
+    )
+    advisory = delegate._rail_path_admission_advisory(
+        mode="workspace-write",
+        owned_paths=["agents_extensions/shared/hooks/guard-pr-merge.py"],
+    )
+
+    assert error is not None
+    assert "rail_approval_receipt_required" in error
+    assert advisory is None
+
+
+def test_dispatch_admission_refetches_a_valid_production_receipt(
+    monkeypatch
+) -> None:
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=delegate._REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    receipt = rail_approval.create_rail_approval_receipt(
+        task_id="rail-p6-test",
+        head_sha=head_sha,
+        owned_paths=["agents_extensions/shared/hooks/guard-pr-merge.py"],
+        issuer="operator",
+        ttl_hours=1,
+    )
+    monkeypatch.setattr(
+        guard,
+        "_monitor_api_get",
+        lambda _path: (200, json.dumps(receipt), {}),
+    )
+
+    error = delegate._rail_path_admission_error(
+        task_id="rail-p6-test",
+        mode="workspace-write",
+        owned_paths=["agents_extensions/shared/hooks/guard-pr-merge.py"],
+        receipt_id=receipt["receipt_id"],
     )
 
     assert error is None

--- a/tests/test_delegate_rail_path_admission.py
+++ b/tests/test_delegate_rail_path_admission.py
@@ -1,0 +1,31 @@
+"""P6 dispatch-admission coverage for the shared rail-path decision module."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import delegate
+
+
+def test_dispatch_admission_refuses_rail_claim_before_ownership_ledger() -> None:
+    error = delegate._rail_path_admission_error(
+        task_id="rail-p6-test",
+        mode="workspace-write",
+        owned_paths=["agents_extensions/shared/hooks/guard-pr-merge.py"],
+    )
+
+    assert error is not None
+    assert "rail_approval_receipt_required" in error
+
+
+def test_dispatch_admission_leaves_non_rail_claim_unaffected() -> None:
+    error = delegate._rail_path_admission_error(
+        task_id="rail-p6-test",
+        mode="workspace-write",
+        owned_paths=["docs/projects/fleet-trails/rail-system-completion-memo.md"],
+    )
+
+    assert error is None

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -144,6 +144,18 @@ def test_rail_diff_refuses_merge_without_external_receipt(monkeypatch):
     )
 
 
+def test_unrelated_bracketed_filename_does_not_block_merge_guard(monkeypatch):
+    """The full PR diff is classified as literal paths, never glob patterns."""
+    assert (
+        _run(
+            monkeypatch,
+            "gh pr merge 5 --squash",
+            changed_paths=["docs/some[draft].md"],
+        )
+        == 0
+    )
+
+
 def test_rail_merge_check_is_mutation_honest(monkeypatch):
     """Removing the merge-layer call turns the same rail PR into an observable allow."""
     assert (

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -4,7 +4,8 @@ Exercises the pure decision logic in
 ``agents_extensions/shared/hooks/guard-pr-merge.py``:
 
   * `gh pr merge` detection (incl. wrappers, a positional PR number, and the
-    `--admin` / `--disable-auto` segments this hook deliberately leaves alone),
+    `--disable-auto` segment it deliberately leaves alone; P6 keeps `--admin`
+    visible so rail authorization has no bypass),
   * the quote-aware tokenizer (a `gh pr merge` inside a quoted commit body is NOT a merge),
   * failing/pending check classification against the advisory allowlist,
   * the fail-CLOSED `main()` decision (block on draft, red checks, pending-without-auto,
@@ -58,6 +59,7 @@ def _run(
     checks: tuple[list[str], list[str]] | None = ([], []),
     owner_repo: str | None = "owner/repo",
     protected: bool | None = False,
+    changed_paths: list[str] | None = None,
 ) -> int:
     """Drive main() with a simulated stdin payload + monkeypatched network calls.
 
@@ -69,9 +71,23 @@ def _run(
     monkeypatch.setattr(
         guard,
         "_pr_meta",
-        lambda p, repo=None, cwd=None: {"isDraft": False, "baseRefName": "main", "url": _URL} if meta is None else meta,
+        lambda p, repo=None, cwd=None: (
+            {
+                "isDraft": False,
+                "baseRefName": "main",
+                "headRefOid": "a" * 40,
+                "url": _URL,
+            }
+            if meta is None
+            else meta
+        ),
     )
     monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: checks)
+    monkeypatch.setattr(
+        guard,
+        "_pr_changed_paths",
+        lambda p, repo=None, cwd=None: ["README.md"] if changed_paths is None else changed_paths,
+    )
     monkeypatch.setattr(guard, "_owner_repo_from_url", lambda u: owner_repo)
     monkeypatch.setattr(guard, "_base_protected", lambda o, b: protected)
     return guard.main()
@@ -87,8 +103,8 @@ def _run(
         (["gh", "pr", "merge", "123", "--squash", "--delete-branch"], True),
         (["gh", "pr", "merge", "--auto", "--squash"], True),
         (["sudo", "gh", "pr", "merge", "5"], True),
-        # guard-admin-merge.py's job — never double-judge.
-        (["gh", "pr", "merge", "5", "--admin"], False),
+        # P6 keeps admin merges visible to the shared rail-path guard.
+        (["gh", "pr", "merge", "5", "--admin"], True),
         # Disarms auto-merge rather than merging; it is the remedy, not the offence.
         (["gh", "pr", "merge", "5", "--disable-auto"], False),
         (["gh", "pr", "view", "5"], False),
@@ -110,6 +126,33 @@ def test_is_advisory():
     assert guard._is_advisory("pip-audit (advisory)")
     assert not guard._is_advisory("boundary-and-tests")
     assert not guard._is_advisory("Test (pytest)")
+
+
+def test_rail_diff_refuses_merge_without_external_receipt(monkeypatch):
+    assert (
+        _run(
+            monkeypatch,
+            "gh pr merge 5 --squash",
+            changed_paths=["agents_extensions/shared/hooks/guard-pr-merge.py"],
+        )
+        == 2
+    )
+
+
+def test_rail_merge_check_is_mutation_honest(monkeypatch):
+    """Removing the merge-layer call turns the same rail PR into an observable allow."""
+    assert (
+        _run(
+            monkeypatch,
+            "gh pr merge 5 --squash",
+            changed_paths=["agents_extensions/shared/hooks/guard-pr-merge.py"],
+        )
+        == 2
+    )
+
+    monkeypatch.setattr(guard, "_rail_path_decision", lambda *_args, **_kwargs: (type("D", (), {"allowed": True})(), None))
+
+    assert _run(monkeypatch, "gh pr merge 5 --squash") == 0
 
 
 def test_pr_snapshot_reads_metadata_and_checks_concurrently(monkeypatch):
@@ -145,9 +188,8 @@ def test_unrelated_command_is_untouched(monkeypatch):
     assert _run(monkeypatch, "git push origin main") == 0
 
 
-def test_admin_merge_is_other_guards_job(monkeypatch):
-    # Red checks + --admin → still 0 from THIS hook; guard-admin-merge.py judges it.
-    assert _run(monkeypatch, "gh pr merge 5 --admin", checks=(["Test (pytest)"], [])) == 0
+def test_admin_merge_has_no_rail_path_bypass(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --admin", checks=(["Test (pytest)"], [])) == 2
 
 
 def test_disable_auto_is_not_a_merge(monkeypatch):
@@ -375,7 +417,7 @@ def test_disable_auto_equals_true_is_not_a_merge(monkeypatch):
 def test_admin_equals_true_is_judged_here(monkeypatch):
     # guard-admin-merge.py matches the exact token "--admin" only, so `--admin=true`
     # is invisible to it. Judging it here closes the gap between the two hooks rather
-    # than letting a red admin merge fall between them. (Bare --admin stays its job.)
+    # than letting a red admin merge fall between them. P6 also judges bare --admin.
     assert _run(monkeypatch, "gh pr merge 5 --admin=true", checks=(["Test (pytest)"], [])) == 2
 
 
@@ -518,10 +560,12 @@ def test_cross_repo_url_selector_uses_that_repo(monkeypatch):
         lambda p, repo=None, cwd=None: {
             "isDraft": False,
             "baseRefName": "main",
+            "headRefOid": "a" * 40,
             "url": "https://github.com/other/repo/pull/9",
         },
     )
     monkeypatch.setattr(guard, "_check_states", lambda p, repo=None, cwd=None: ([], []))
+    monkeypatch.setattr(guard, "_pr_changed_paths", lambda p, repo=None, cwd=None: ["README.md"])
     monkeypatch.setattr(guard, "_base_protected", lambda o, b: seen.setdefault("repo", o) and True)
     payload = json.dumps({"tool_input": {"command": "gh pr merge https://github.com/other/repo/pull/9 --auto"}})
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
@@ -615,7 +659,7 @@ def test_flag_looking_value_does_not_force_auto_path():
 
 def test_real_control_flags_still_recognized():
     assert guard._merge_args(["gh", "pr", "merge", "5", "--disable-auto"]) is None
-    assert guard._merge_args(["gh", "pr", "merge", "5", "--admin"]) is None
+    assert guard._merge_args(["gh", "pr", "merge", "5", "--admin"]) == ["5", "--admin"]
     assert guard._flag_enabled(guard._classify(["5", "--auto"])[0], "auto")
 
 

--- a/tests/test_guard_pr_merge.py
+++ b/tests/test_guard_pr_merge.py
@@ -29,9 +29,12 @@ from pathlib import Path
 
 import pytest
 
+from scripts.orchestration import rail_path_guard as shared_rail_guard
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOK_PATH = REPO_ROOT / "agents_extensions/shared" / "hooks" / "guard-pr-merge.py"
 _URL = "https://github.com/owner/repo/pull/5"
+_RECEIPT_ID = "rail-approval-" + "2" * 32
 
 
 def _load_hook():
@@ -75,7 +78,9 @@ def _run(
             {
                 "isDraft": False,
                 "baseRefName": "main",
+                "body": "",
                 "headRefOid": "a" * 40,
+                "number": 5,
                 "url": _URL,
             }
             if meta is None
@@ -153,6 +158,101 @@ def test_rail_merge_check_is_mutation_honest(monkeypatch):
     monkeypatch.setattr(guard, "_rail_path_decision", lambda *_args, **_kwargs: (type("D", (), {"allowed": True})(), None))
 
     assert _run(monkeypatch, "gh pr merge 5 --squash") == 0
+
+
+class _MergeReceiptStore:
+    source_id = "operator-approval-api"
+    source_kind = "api"
+
+    def __init__(self, receipts: dict[str, dict]) -> None:
+        self.receipts = receipts
+
+    def fetch_rail_approval_receipt(self, receipt_id: str) -> dict:
+        return self.receipts[receipt_id]
+
+
+def _merge_receipt(*, owned_paths: list[str]) -> dict:
+    return {
+        "schema_version": "rail-approval-receipt.v1",
+        "receipt_id": _RECEIPT_ID,
+        "issuer": "advisor",
+        "issued_at": "2026-07-28T00:00:00Z",
+        "expires_at": "2099-07-30T00:00:00Z",
+        "action": "rail-path-mutation",
+        "task_id": "pr-5",
+        "head_sha": "a" * 40,
+        "owned_paths": owned_paths,
+    }
+
+
+def _authoritative_rail_decision(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    body: str,
+    owned_paths: list[str],
+):
+    """Run the merge guard with a production-shaped receipt resolver seam."""
+    receipt = _merge_receipt(owned_paths=owned_paths)
+    resolver = shared_rail_guard.ApprovedRailApprovalReceiptResolver(
+        _MergeReceiptStore({_RECEIPT_ID: receipt})
+    )
+    monkeypatch.setattr(guard, "_load_rail_path_guard", lambda: shared_rail_guard)
+    monkeypatch.setattr(
+        shared_rail_guard,
+        "build_production_rail_approval_receipt_resolver",
+        lambda: resolver,
+    )
+    monkeypatch.setattr(
+        guard,
+        "_pr_changed_paths",
+        lambda *_args, **_kwargs: ["agents_extensions/shared/hooks/guard-pr-merge.py"],
+    )
+    return guard._rail_path_decision(
+        "999",
+        {
+            "headRefOid": "a" * 40,
+            "number": 5,
+            # This body value is deliberately malicious provenance. The PR ID above,
+            # rather than this text, must bind the receipt task to pr-5.
+            "body": body,
+        },
+        None,
+        None,
+    )
+
+
+def test_merge_ignores_body_task_id_and_derives_the_canonical_pr_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision, error = _authoritative_rail_decision(
+        monkeypatch,
+        body=(
+            "dispatch_task_id: pr-999\n"
+            f"Rail-Approval-Receipt: {_RECEIPT_ID}"
+        ),
+        owned_paths=["agents_extensions/shared/hooks/guard-pr-merge.py"],
+    )
+
+    assert error is None
+    assert decision.allowed is True
+    assert decision.reason == "rail_approval_verified"
+
+
+def test_merge_refuses_a_receipt_with_a_superset_of_the_current_rail_diff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision, error = _authoritative_rail_decision(
+        monkeypatch,
+        body=f"Rail-Approval-Receipt: {_RECEIPT_ID}",
+        owned_paths=[
+            "agents_extensions/shared/hooks/guard-pr-merge.py",
+            "scripts/orchestration/rail_path_guard.py",
+        ],
+    )
+
+    assert error is None
+    assert decision.allowed is False
+    assert decision.reason == "rail_approval_path_set_mismatch"
 
 
 def test_pr_snapshot_reads_metadata_and_checks_concurrently(monkeypatch):
@@ -264,8 +364,9 @@ def _fake_gh(monkeypatch, *, returncode: int, stdout: str, stderr: str = ""):
 
 
 def test_pr_meta_parses_draft(monkeypatch):
-    _fake_gh(monkeypatch, returncode=0, stdout='{"isDraft":true,"baseRefName":"main"}')
-    assert guard._pr_meta("5") == {"isDraft": True, "baseRefName": "main"}
+    payload = {"isDraft": True, "baseRefName": "main", "body": "", "number": 5}
+    _fake_gh(monkeypatch, returncode=0, stdout=json.dumps(payload))
+    assert guard._pr_meta("5") == payload
 
 
 def test_pr_meta_error_rc_is_failclosed(monkeypatch):
@@ -276,6 +377,13 @@ def test_pr_meta_error_rc_is_failclosed(monkeypatch):
 def test_pr_meta_without_isdraft_is_failclosed(monkeypatch):
     # An empty/partial payload must not read as "not a draft".
     _fake_gh(monkeypatch, returncode=0, stdout="{}")
+    assert guard._pr_meta("5") is None
+
+
+@pytest.mark.parametrize("number", ["5", 0, -1, True])
+def test_pr_meta_requires_a_github_integer_pr_number(monkeypatch, number):
+    payload = {"isDraft": False, "body": "", "number": number}
+    _fake_gh(monkeypatch, returncode=0, stdout=json.dumps(payload))
     assert guard._pr_meta("5") is None
 
 
@@ -560,7 +668,9 @@ def test_cross_repo_url_selector_uses_that_repo(monkeypatch):
         lambda p, repo=None, cwd=None: {
             "isDraft": False,
             "baseRefName": "main",
+            "body": "",
             "headRefOid": "a" * 40,
+            "number": 9,
             "url": "https://github.com/other/repo/pull/9",
         },
     )
@@ -576,11 +686,18 @@ def test_cross_repo_url_selector_uses_that_repo(monkeypatch):
 def test_pr_meta_requires_url_field(monkeypatch):
     # url is load-bearing for the protection lookup; gh must actually return it.
     _fake_gh(
-        monkeypatch, returncode=0, stdout='{"isDraft":false,"baseRefName":"main","url":"https://github.com/o/r/pull/5"}'
+        monkeypatch,
+        returncode=0,
+        stdout=(
+            '{"isDraft":false,"baseRefName":"main","body":"","number":5,'
+            '"url":"https://github.com/o/r/pull/5"}'
+        ),
     )
     assert guard._pr_meta("5") == {
         "isDraft": False,
         "baseRefName": "main",
+        "body": "",
+        "number": 5,
         "url": "https://github.com/o/r/pull/5",
     }
 
@@ -889,7 +1006,9 @@ def test_backslash_continuation_merge_detected():
 _COLORIZED_JSON = (
     "\x1b[1;37m{\x1b[m\n"
     '  \x1b[1;34m"baseRefName"\x1b[m: \x1b[32m"main"\x1b[m,\n'
+    '  \x1b[1;34m"body"\x1b[m: \x1b[32m""\x1b[m,\n'
     '  \x1b[1;34m"isDraft"\x1b[m: \x1b[35mfalse\x1b[m,\n'
+    '  \x1b[1;34m"number"\x1b[m: \x1b[33m5\x1b[m,\n'
     '  \x1b[1;34m"url"\x1b[m: \x1b[32m"https://github.com/owner/repo/pull/5"\x1b[m\n'
     "\x1b[1;37m}\x1b[m\n"
 )
@@ -911,7 +1030,9 @@ def test_decolorize_recovers_parseable_json():
     parsed = json.loads(cleaned)
     assert parsed == {
         "baseRefName": "main",
+        "body": "",
         "isDraft": False,
+        "number": 5,
         "url": "https://github.com/owner/repo/pull/5",
     }
 
@@ -934,7 +1055,9 @@ def test_colorized_pr_meta_still_parses(monkeypatch):
     monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
     assert guard._pr_meta("5") == {
         "baseRefName": "main",
+        "body": "",
         "isDraft": False,
+        "number": 5,
         "url": "https://github.com/owner/repo/pull/5",
     }
 
@@ -942,7 +1065,12 @@ def test_colorized_pr_meta_still_parses(monkeypatch):
 def test_colorized_pr_meta_honors_draft(monkeypatch):
     """The draft bit must be read THROUGH the colorization, not lost to it: a colorized
     draft payload has to still block."""
-    colorized_draft = '\x1b[1;37m{\x1b[m\x1b[1;34m"isDraft"\x1b[m: \x1b[35mtrue\x1b[m, \x1b[1;34m"baseRefName"\x1b[m: \x1b[32m"main"\x1b[m\x1b[1;37m}\x1b[m'
+    colorized_draft = (
+        '\x1b[1;37m{\x1b[m\x1b[1;34m"isDraft"\x1b[m: \x1b[35mtrue\x1b[m, '
+        '\x1b[1;34m"baseRefName"\x1b[m: \x1b[32m"main"\x1b[m, '
+        '\x1b[1;34m"body"\x1b[m: \x1b[32m""\x1b[m, '
+        '\x1b[1;34m"number"\x1b[m: \x1b[33m5\x1b[m\x1b[1;37m}\x1b[m'
+    )
     completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=colorized_draft, stderr="")
     monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: completed)
     meta = guard._pr_meta("5")

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -224,6 +224,20 @@ def test_dispatch_worktree_write_allowed(repo: Path):
     assert result.returncode == 0, result.stderr
 
 
+def test_dispatch_worktree_rail_write_is_refused_without_receipt(repo: Path):
+    """P6 local layer: worktree isolation never authorizes a control-rail write."""
+    payload = _write_payload(
+        repo,
+        "Edit",
+        ".worktrees/dispatch/claude/task-1/agents_extensions/shared/hooks/guard-pr-merge.py",
+    )
+
+    result = _run(repo, payload)
+
+    assert result.returncode == 2, result.stderr
+    assert "rail_approval_receipt_required" in result.stderr
+
+
 def test_read_only_bash_allowed(repo: Path):
     for command in ("git status", "cat curriculum/tracked.md", "git log --oneline"):
         payload = {"tool_name": "Bash", "cwd": str(repo), "tool_input": {"command": command}}
@@ -657,8 +671,8 @@ def test_bash_unresolved_shell_var_blocked_with_distinct_reason(repo: Path):
     assert "unresolved_shell_variable" in result.stderr
 
 
-def test_bash_redirect_to_claude_epic_archive_from_subdir_allowed(repo: Path):
-    """#5404: cwd inside gitignored epic dir + relative archive path allowed."""
+def test_bash_redirect_to_claude_epic_archive_from_subdir_is_rail_guarded(repo: Path):
+    """P6: all .claude paths are rail configuration even when gitignored."""
     epic = repo / ".claude" / "atlas-epic"
     epic.mkdir(parents=True, exist_ok=True)
     (epic / "archive").mkdir(exist_ok=True)
@@ -673,7 +687,8 @@ def test_bash_redirect_to_claude_epic_archive_from_subdir_allowed(repo: Path):
         "tool_input": {"command": "echo x > archive/t.md"},
     }
     result = _run(repo, payload)
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 2, result.stderr
+    assert "rail_approval_receipt_required" in result.stderr
 
 
 def test_bash_untracked_non_ignored_still_blocked(repo: Path):

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -758,3 +758,28 @@ def test_bash_shell_var_reassignment_not_expanded(repo: Path):
     # Must not allow (would dirty tracked file under bash's true binding).
     assert result.returncode == 2, result.stderr
     assert "unresolved_shell_variable" in result.stderr or "tracked_primary" in result.stderr
+
+
+def test_unreadable_git_metadata_inside_any_repo_fails_closed(tmp_path, monkeypatch):
+    """git-resolution failure for a target under ANY .git tree denies; it never
+    silently passes as 'outside every repository' (r5 review F001)."""
+    repo_like = tmp_path / "sibling-repo"
+    (repo_like / ".git").mkdir(parents=True)
+    target = repo_like / "agents_extensions" / "shared" / "rules" / "x.md"
+    target.parent.mkdir(parents=True)
+
+    monkeypatch.setattr(hook, "_git_output", lambda *_a, **_k: None)
+    decision, error = hook._rail_write_decision([str(target)], cwd=str(tmp_path))
+    assert decision is None
+    assert error == "rail_path_guard_repository_unreadable"
+
+
+def test_positively_confirmed_non_repository_target_is_not_a_rail(tmp_path, monkeypatch):
+    """A target with no .git anywhere above it is a confirmed non-repository write."""
+    target = tmp_path / "plain" / "notes.md"
+    target.parent.mkdir(parents=True)
+
+    monkeypatch.setattr(hook, "_git_output", lambda *_a, **_k: None)
+    decision, error = hook._rail_write_decision([str(target)], cwd=str(tmp_path))
+    assert error is None
+    assert decision is not None and decision.allowed

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -531,6 +531,7 @@ def test_git_apply_via_dash_c_worktree_allowed(repo: Path):
 
 
 def test_git_apply_from_worktree_cwd_allowed(repo: Path):
+    """Pinned residual: pathless worktree applies are checked by CI/merge diff layers."""
     worktree = repo / ".worktrees/dispatch/claude/task-1"
     payload = {
         "tool_name": "Bash",
@@ -539,6 +540,45 @@ def test_git_apply_from_worktree_cwd_allowed(repo: Path):
     }
     result = _run(repo, payload)
     assert result.returncode == 0, result.stderr
+
+
+def test_git_add_rail_path_in_worktree_is_refused_without_receipt(repo: Path):
+    """P6 F001: git pathspecs do not bypass rail checks outside primary."""
+    worktree = repo / ".worktrees/dispatch/claude/task-1"
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(worktree),
+        "tool_input": {
+            "command": "git add agents_extensions/shared/hooks/guard-pr-merge.py",
+        },
+    }
+
+    result = _run(repo, payload)
+
+    assert result.returncode == 2, result.stderr
+    assert "rail_approval_receipt_required" in result.stderr
+
+
+def test_git_worktree_rail_gate_mutation_is_observable(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Removing the new git-intent rail call turns this blocked write into an allow."""
+    worktree = repo / ".worktrees/dispatch/claude/task-1"
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(worktree),
+        "tool_input": {
+            "command": "git add agents_extensions/shared/hooks/guard-pr-merge.py",
+        },
+    }
+    monkeypatch.setattr(hook, "_read_payload", lambda: payload)
+
+    assert hook.main() == 2
+
+    allowed = type("_Allowed", (), {"allowed": True, "rail_paths": (), "reason": "non_rail_paths"})()
+    monkeypatch.setattr(hook, "_rail_write_decision", lambda _paths, *, cwd: (allowed, None))
+
+    assert hook.main() == 0
 
 
 def test_git_apply_dash_c_primary_from_worktree_blocked(repo: Path):

--- a/tests/test_rail_approval.py
+++ b/tests/test_rail_approval.py
@@ -131,3 +131,12 @@ def test_receipt_registry_refuses_overwriting_an_issued_receipt(tmp_path) -> Non
         assert "already exists" in str(exc)
     else:  # pragma: no cover - this must never become an overwrite allow
         raise AssertionError("receipt registry allowed an issued receipt to be overwritten")
+
+
+def test_endpoint_rejects_malformed_receipt_id_as_client_error(monkeypatch) -> None:
+    """A malformed id is a 422 client error, never a retryable 503 (r6 review P3)."""
+    app = FastAPI()
+    app.include_router(rail_approval_router.router, prefix="/api/rail-approvals")
+    client = TestClient(app)
+    response = client.get("/api/rail-approvals/not-a-receipt-id")
+    assert response.status_code == 422

--- a/tests/test_rail_approval.py
+++ b/tests/test_rail_approval.py
@@ -1,0 +1,131 @@
+"""End-to-end local coverage for P6 receipt issuance and Monitor retrieval."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from scripts.api import rail_approval_router
+from scripts.orchestration import rail_approval
+from scripts.orchestration import rail_path_guard as guard
+
+NOW = datetime(2026, 7, 29, 12, 0, tzinfo=UTC)
+HEAD = "c" * 40
+TASK = "rail-p8-trail-migration"
+PATH = "scripts/config/trails/rb1.trail.yaml"
+
+
+def _monitor_get(client: TestClient):
+    """Route the production Monitor client seam into a local in-process API."""
+
+    def fetch(path: str):
+        response = client.get(path)
+        return response.status_code, response.text, {}
+
+    return fetch
+
+
+def test_operator_cli_issue_monitor_fetch_and_exact_binding(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """Issue → Monitor API fetch → exact allow; foreign and expired remain deny."""
+    registry = rail_approval.RailApprovalReceiptRegistry(tmp_path / "receipts.json")
+    monkeypatch.setattr(rail_approval, "RailApprovalReceiptRegistry", lambda: registry)
+
+    exit_code = rail_approval.main(
+        [
+            "issue",
+            "--task-id",
+            TASK,
+            "--head-sha",
+            HEAD,
+            "--owned-path",
+            PATH,
+            "--issuer",
+            "operator",
+            "--ttl-hours",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    issued = json.loads(capsys.readouterr().out)
+    assert issued["issuer"] == "operator"
+    assert registry.fetch(issued["receipt_id"]) == issued
+
+    app = FastAPI()
+    app.include_router(rail_approval_router.router, prefix="/api/rail-approvals")
+    monkeypatch.setattr(rail_approval_router, "get_rail_approval_registry", lambda: registry)
+    client = TestClient(app)
+    served = client.get(f"/api/rail-approvals/{issued['receipt_id']}")
+    assert served.status_code == 200
+    assert served.json() == issued
+
+    assert isinstance(
+        guard.build_production_rail_approval_receipt_resolver().store,
+        guard.MonitorRailApprovalReceiptStore,
+    )
+    monitor_store = guard.MonitorRailApprovalReceiptStore(get=_monitor_get(client))
+    resolver = guard.ApprovedRailApprovalReceiptResolver(monitor_store)
+    receipt = resolver.fetch(issued["receipt_id"])
+    issued_at = datetime.fromisoformat(issued["issued_at"].replace("Z", "+00:00"))
+    expires_at = datetime.fromisoformat(issued["expires_at"].replace("Z", "+00:00"))
+    allowed = guard.decide_rail_path_mutation(
+        task_id=TASK,
+        candidate_paths=[PATH],
+        head_sha=HEAD,
+        receipt=receipt,
+        now=lambda: issued_at,
+    )
+    foreign = guard.decide_rail_path_mutation(
+        task_id="another-task",
+        candidate_paths=[PATH],
+        head_sha=HEAD,
+        receipt=receipt,
+        now=lambda: issued_at,
+    )
+
+    assert allowed.allowed is True
+    assert allowed.reason == "rail_approval_verified"
+    assert foreign.allowed is False
+    assert foreign.reason == "rail_approval_task_mismatch"
+
+    expired_resolver = guard.ApprovedRailApprovalReceiptResolver(
+        monitor_store,
+        now=lambda: expires_at + timedelta(seconds=1),
+    )
+    expired = guard.decide_rail_path_mutation_with_production_receipt(
+        task_id=TASK,
+        candidate_paths=[PATH],
+        head_sha=HEAD,
+        receipt_id=issued["receipt_id"],
+        resolver=expired_resolver,
+        now=lambda: expires_at + timedelta(seconds=1),
+    )
+
+    assert expired.allowed is False
+    assert expired.reason == "expired_rail_approval_receipt"
+
+
+def test_receipt_registry_refuses_overwriting_an_issued_receipt(tmp_path) -> None:
+    registry = rail_approval.RailApprovalReceiptRegistry(tmp_path / "receipts.json")
+    receipt = rail_approval.create_rail_approval_receipt(
+        task_id=TASK,
+        head_sha=HEAD,
+        owned_paths=[PATH],
+        issuer="advisor",
+        ttl_hours=1,
+        now=lambda: NOW,
+        receipt_id="rail-approval-fixture",
+    )
+    registry.issue(receipt)
+
+    try:
+        registry.issue(receipt)
+    except rail_approval.RailApprovalStoreError as exc:
+        assert "already exists" in str(exc)
+    else:  # pragma: no cover - this must never become an overwrite allow
+        raise AssertionError("receipt registry allowed an issued receipt to be overwritten")

--- a/tests/test_rail_approval.py
+++ b/tests/test_rail_approval.py
@@ -16,6 +16,7 @@ NOW = datetime(2026, 7, 29, 12, 0, tzinfo=UTC)
 HEAD = "c" * 40
 TASK = "rail-p8-trail-migration"
 PATH = "scripts/config/trails/rb1.trail.yaml"
+RECEIPT_ID = "rail-approval-" + "f" * 32
 
 
 def _monitor_get(client: TestClient):
@@ -54,6 +55,7 @@ def test_operator_cli_issue_monitor_fetch_and_exact_binding(
     assert exit_code == 0
     issued = json.loads(capsys.readouterr().out)
     assert issued["issuer"] == "operator"
+    assert guard.RAIL_APPROVAL_RECEIPT_ID.fullmatch(issued["receipt_id"])
     assert registry.fetch(issued["receipt_id"]) == issued
 
     app = FastAPI()
@@ -119,7 +121,7 @@ def test_receipt_registry_refuses_overwriting_an_issued_receipt(tmp_path) -> Non
         issuer="advisor",
         ttl_hours=1,
         now=lambda: NOW,
-        receipt_id="rail-approval-fixture",
+        receipt_id=RECEIPT_ID,
     )
     registry.issue(receipt)
 

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -201,6 +201,51 @@ def test_missing_receipt_binding_mutation_is_observable(monkeypatch: pytest.Monk
     assert _decide(OWNED_RAIL_PATH, receipt=receipt, task_id="other-task").allowed is True
 
 
+def _direct_payload_receipt(**overrides: object) -> guard.VerifiedRailApprovalReceipt:
+    """Build a receipt the way a direct-payload caller (delegate.py) can: NO resolver.
+
+    The resolver refuses expired/forged receipts itself, so resolver-built
+    fixtures can never exercise the decision layer's own re-checks — which are
+    load-bearing for callers that pass a VerifiedRailApprovalReceipt directly.
+    Mutation-proven: disabling the decision-layer expiry check previously left
+    the whole suite green (orchestrator probe, PR #5980).
+    """
+    return guard.VerifiedRailApprovalReceipt(
+        payload=_receipt(**overrides),
+        source_id="bridge:test",
+        digest="d" * 64,
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_reason"),
+    [
+        # Reachable ONLY via a direct payload: schema cannot see the clock.
+        # (Ordering stays valid — issued before expiry — but the window is past.)
+        (
+            {"issued_at": "2026-07-26T00:00:00Z", "expires_at": "2026-07-27T00:00:00Z"},
+            "expired_rail_approval_receipt",
+        ),
+        # Schema enum rejects a forged issuer at the decision layer's re-validation;
+        # the in-code APPROVED_ISSUERS check behind it is drift armor for the schema.
+        ({"issuer": "self-declared-model-tier"}, "invalid_rail_approval_receipt"),
+        ({"task_id": "another-task"}, "rail_approval_task_mismatch"),
+        ({"head_sha": "b" * 40}, "rail_approval_head_mismatch"),
+        ({"owned_paths": ["scripts/config/trails/other.trail.yaml"]}, "rail_approval_path_mismatch"),
+        # Structurally invalid payload (missing required field) → schema refusal.
+        ({"head_sha": None}, "invalid_rail_approval_receipt"),
+    ],
+)
+def test_decision_layer_denies_bad_direct_payloads(
+    overrides: dict, expected_reason: str
+) -> None:
+    """Every deny reason of the pure decision layer fires on a direct payload."""
+    receipt = _direct_payload_receipt(**overrides)
+    decision = _decide(OWNED_RAIL_PATH, receipt=receipt)
+    assert decision.allowed is False
+    assert decision.reason == expected_reason
+
+
 def test_ci_gate_requires_the_shared_rail_path_module() -> None:
     """Removing the CI job/wiring makes this rail-layer contract test fail."""
     workflow_path = Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml"

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -15,6 +16,7 @@ HEAD = "a" * 40
 OTHER_HEAD = "b" * 40
 TASK = "rail-p6-path-guard"
 OWNED_RAIL_PATH = "agents_extensions/shared/hooks/guard-pr-merge.py"
+RECEIPT_ID = "rail-approval-" + "1" * 32
 
 
 class _ReceiptStore:
@@ -40,7 +42,7 @@ class _LocalFileReceiptStore(_ReceiptStore):
 def _receipt(**overrides: object) -> dict:
     receipt = {
         "schema_version": "rail-approval-receipt.v1",
-        "receipt_id": "rail-approval-1",
+        "receipt_id": RECEIPT_ID,
         "issuer": "operator",
         "issued_at": "2026-07-28T00:00:00Z",
         "expires_at": "2026-07-29T00:00:00Z",
@@ -81,6 +83,15 @@ def test_rail_patterns_are_full_path_globs_not_substrings() -> None:
     assert not guard.is_rail_path("docs/notes/agents_extensions/shared/rules.md")
 
 
+def test_receipt_id_grammar_is_identical_in_code_and_the_versioned_schema() -> None:
+    schema = json.loads(guard.RAIL_APPROVAL_RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    assert guard.RAIL_APPROVAL_RECEIPT_ID.fullmatch(RECEIPT_ID)
+    assert schema["$defs"]["rail_approval_receipt_id"]["pattern"] == (
+        rf"^{guard.RAIL_APPROVAL_RECEIPT_ID_PATTERN}$"
+    )
+
+
 def test_non_rail_paths_are_unaffected_without_receipt() -> None:
     decision = _decide(
         "docs/projects/fleet-trails/rail-system-completion-memo.md",
@@ -102,6 +113,7 @@ def test_rail_path_without_receipt_is_refused() -> None:
 
 
 def test_valid_receipt_admits_exact_owned_rail_path_and_not_more() -> None:
+    """Mutation hooks retain containment semantics for bounded write attempts."""
     receipt = _verified()
 
     allowed = _decide(OWNED_RAIL_PATH, receipt=receipt)
@@ -111,6 +123,28 @@ def test_valid_receipt_admits_exact_owned_rail_path_and_not_more() -> None:
     assert allowed.reason == "rail_approval_verified"
     assert extra.allowed is False
     assert extra.reason == "rail_approval_path_mismatch"
+
+
+def test_merge_guard_requires_the_receipt_owned_paths_to_equal_the_rail_diff() -> None:
+    """A PR receipt cannot retain surplus protected paths after its diff changes."""
+    extra_rail_path = "scripts/orchestration/rail_path_guard.py"
+    superset = _verified(owned_paths=[OWNED_RAIL_PATH, extra_rail_path])
+
+    denied = _decide(
+        OWNED_RAIL_PATH,
+        receipt=superset,
+        path_binding=guard.RailApprovalPathBinding.PR_DIFF_EXACT_SET,
+    )
+    allowed = _decide(
+        OWNED_RAIL_PATH,
+        receipt=_verified(),
+        path_binding=guard.RailApprovalPathBinding.PR_DIFF_EXACT_SET,
+    )
+
+    assert denied.allowed is False
+    assert denied.reason == "rail_approval_path_set_mismatch"
+    assert allowed.allowed is True
+    assert allowed.reason == "rail_approval_verified"
 
 
 @pytest.mark.parametrize(
@@ -135,19 +169,19 @@ def test_expired_receipt_is_refused_by_external_resolver() -> None:
         expires_at="2026-07-28T00:00:00Z",
     )
     resolver = guard.ApprovedRailApprovalReceiptResolver(
-        _ReceiptStore({"rail-approval-1": expired}), now=lambda: NOW
+        _ReceiptStore({RECEIPT_ID: expired}), now=lambda: NOW
     )
 
     with pytest.raises(guard.RailApprovalReceiptError, match="has expired"):
-        resolver.fetch("rail-approval-1")
+        resolver.fetch(RECEIPT_ID)
 
 
 def test_forged_or_local_receipts_are_refused_before_decision() -> None:
     forged = _receipt(issuer="self-declared-model-tier")
     with pytest.raises(guard.RailApprovalReceiptError, match="schema violation"):
         guard.ApprovedRailApprovalReceiptResolver(
-            _ReceiptStore({"rail-approval-1": forged}), now=lambda: NOW
-        ).fetch("rail-approval-1")
+            _ReceiptStore({RECEIPT_ID: forged}), now=lambda: NOW
+        ).fetch(RECEIPT_ID)
 
     with pytest.raises(guard.RailApprovalReceiptError, match="bridge or API"):
         guard.ApprovedRailApprovalReceiptResolver(_LocalFileReceiptStore({}), now=lambda: NOW)
@@ -159,7 +193,7 @@ def test_unreadable_receipt_store_fails_closed() -> None:
     )
 
     with pytest.raises(guard.RailApprovalReceiptError, match="could not re-fetch"):
-        resolver.fetch("rail-approval-1")
+        resolver.fetch(RECEIPT_ID)
 
 
 @pytest.mark.parametrize(
@@ -175,11 +209,11 @@ def test_identity_strings_never_bypass_rail_receipt(bypass_claim: dict[str, str]
     # these claims, and the decision API does not accept identity as authority.
     forged = _receipt(**bypass_claim)
     resolver = guard.ApprovedRailApprovalReceiptResolver(
-        _ReceiptStore({"rail-approval-1": forged}), now=lambda: NOW
+        _ReceiptStore({RECEIPT_ID: forged}), now=lambda: NOW
     )
 
     with pytest.raises(guard.RailApprovalReceiptError, match="schema violation"):
-        resolver.fetch("rail-approval-1")
+        resolver.fetch(RECEIPT_ID)
 
 
 def test_missing_rail_classifier_mutation_is_observable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -199,6 +233,65 @@ def test_missing_receipt_binding_mutation_is_observable(monkeypatch: pytest.Monk
     monkeypatch.setattr(guard, "_receipt_authorizes", lambda _receipt, **_kwargs: None)
 
     assert _decide(OWNED_RAIL_PATH, receipt=receipt, task_id="other-task").allowed is True
+
+
+@pytest.mark.parametrize(
+    ("body", "kind"),
+    [
+        ("", guard.RailApprovalDeclarationKind.MISSING),
+        (
+            "Rail-Approval-Receipt: rail-approval-" + "a" * 32
+            + "\nRail-Approval-Receipt: rail-approval-"
+            + "b" * 32,
+            guard.RailApprovalDeclarationKind.MULTIPLE,
+        ),
+        (
+            "Rail-Approval-Receipt: rail-approval-" + "A" * 32,
+            guard.RailApprovalDeclarationKind.MALFORMED,
+        ),
+    ],
+)
+def test_rail_diff_declaration_rejects_absent_multiple_and_malformed_trailers(
+    monkeypatch: pytest.MonkeyPatch,
+    body: str,
+    kind: guard.RailApprovalDeclarationKind,
+) -> None:
+    """The CI declaration path cannot call the authoritative decision function."""
+    monkeypatch.setattr(
+        guard,
+        "decide_rail_path_mutation",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("CI must not decide authorization")),
+    )
+
+    declaration = guard.inspect_rail_approval_declaration(
+        candidate_paths=[OWNED_RAIL_PATH],
+        body=body,
+    )
+
+    assert declaration.kind is kind
+    assert declaration.is_present is False
+    assert declaration.receipt_id is None
+
+
+def test_rail_diff_declaration_accepts_one_exact_trailer_without_authorizing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A present declaration remains a locator, even when decision code is unavailable."""
+    monkeypatch.setattr(
+        guard,
+        "decide_rail_path_mutation",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("CI must not decide authorization")),
+    )
+    body = f"Summary\n\nRail-Approval-Receipt: {RECEIPT_ID}\n"
+
+    declaration = guard.inspect_rail_approval_declaration(
+        candidate_paths=[OWNED_RAIL_PATH],
+        body=body,
+    )
+
+    assert declaration.kind is guard.RailApprovalDeclarationKind.PRESENT
+    assert declaration.is_present is True
+    assert declaration.receipt_id == RECEIPT_ID
 
 
 def _direct_payload_receipt(**overrides: object) -> guard.VerifiedRailApprovalReceipt:
@@ -247,7 +340,7 @@ def test_decision_layer_denies_bad_direct_payloads(
 
 
 def test_ci_gate_requires_the_shared_rail_path_module() -> None:
-    """Removing the CI job/wiring makes this rail-layer contract test fail."""
+    """CI declares receipt syntax only; the merge guard remains authoritative."""
     workflow_path = Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml"
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
     rail_job = workflow["jobs"]["rail-path"]
@@ -255,5 +348,10 @@ def test_ci_gate_requires_the_shared_rail_path_module() -> None:
         str(step.get("run", "")) for step in rail_job["steps"] if isinstance(step, dict)
     )
 
-    assert "scripts.orchestration.rail_path_guard" in run_steps
+    assert rail_job["name"] == "Rail approval declaration"
+    assert "Rail approval declaration" in [step.get("name") for step in rail_job["steps"] if isinstance(step, dict)]
+    assert "edited" in workflow[True]["pull_request"]["types"]
+    assert "inspect_rail_approval_declaration" in run_steps
+    assert "decide_rail_path_mutation" not in run_steps
+    assert "build_production_rail_approval_receipt_resolver" not in run_steps
     assert "rail-path" in workflow["jobs"]["ci-gate"]["needs"]

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -355,3 +355,21 @@ def test_ci_gate_requires_the_shared_rail_path_module() -> None:
     assert "decide_rail_path_mutation" not in run_steps
     assert "build_production_rail_approval_receipt_resolver" not in run_steps
     assert "rail-path" in workflow["jobs"]["ci-gate"]["needs"]
+
+
+@pytest.mark.parametrize(
+    ("path", "is_rail"),
+    [
+        # Sibling deploy targets are the same tamper class as .claude/**.
+        (".gemini/hooks/check-claude-inbox.sh", True),
+        (".gemini/rules/critical-rules.md", True),
+        (".codex/agents/curriculum-orchestrator.toml", True),
+        # .agent/** is deliberate runtime-scratch exclusion (babysit/handoffs/tmp):
+        # requiring receipts for per-session state would halt live drivers.
+        (".agent/claude-infra-babysit-prs.txt", False),
+        (".agent/tmp/reviews/some-brief.md", False),
+    ],
+)
+def test_deploy_target_siblings_rail_classification(path: str, is_rail: bool) -> None:
+    """Deployed-copy dirs are rails; per-session runtime scratch deliberately is not."""
+    assert guard.is_rail_path(guard.normalize_repository_path(path)) is is_rail

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -83,6 +83,34 @@ def test_rail_patterns_are_full_path_globs_not_substrings() -> None:
     assert not guard.is_rail_path("docs/notes/agents_extensions/shared/rules.md")
 
 
+def test_bracketed_filenames_are_literal_path_candidates() -> None:
+    """Glob metacharacters in a filename are data, never candidate patterns."""
+    rail_path = ".claude/x[1].md"
+    non_rail_path = "docs/some[draft].md"
+
+    assert guard.normalize_repository_path(rail_path) == rail_path
+    assert guard.is_rail_path(rail_path) is True
+    assert guard.normalize_repository_path(non_rail_path) == non_rail_path
+    assert guard.is_rail_path(non_rail_path) is False
+    assert guard.rail_paths_from_candidates([rail_path, non_rail_path]) == (rail_path,)
+
+
+@pytest.mark.parametrize(
+    ("path", "message"),
+    [
+        ("", "non-empty string"),
+        ("/docs/example.md", "relative POSIX path"),
+        ("docs/../example.md", "not normalized"),
+        (r"docs\\example.md", "relative POSIX path"),
+    ],
+)
+def test_normalize_repository_path_keeps_structural_rejections(
+    path: str, message: str
+) -> None:
+    with pytest.raises(guard.RailApprovalReceiptError, match=message):
+        guard.normalize_repository_path(path)
+
+
 def test_receipt_id_grammar_is_identical_in_code_and_the_versioned_schema() -> None:
     schema = json.loads(guard.RAIL_APPROVAL_RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
 
@@ -294,6 +322,37 @@ def test_rail_diff_declaration_accepts_one_exact_trailer_without_authorizing(
     assert declaration.receipt_id == RECEIPT_ID
 
 
+def test_rail_ci_event_dispatch_is_honest_about_declaration_context() -> None:
+    pull_request = guard.inspect_rail_ci_event(
+        event_name="pull_request",
+        candidate_paths=[OWNED_RAIL_PATH],
+    )
+    merge_group_rail = guard.inspect_rail_ci_event(
+        event_name="merge_group",
+        candidate_paths=[OWNED_RAIL_PATH],
+    )
+    merge_group_non_rail = guard.inspect_rail_ci_event(
+        event_name="merge_group",
+        candidate_paths=["docs/some[draft].md"],
+    )
+    push = guard.inspect_rail_ci_event(event_name="push")
+
+    assert pull_request.disposition is guard.RailCIEventDisposition.DECLARATION
+    assert pull_request.rail_paths == (OWNED_RAIL_PATH,)
+    assert merge_group_rail.disposition is guard.RailCIEventDisposition.DENY
+    assert merge_group_rail.reason == (
+        "merge-queue flow does not carry a rail declaration; "
+        "merge rail PRs via the direct auto-merge path"
+    )
+    assert merge_group_rail.rail_paths == (OWNED_RAIL_PATH,)
+    assert merge_group_non_rail.disposition is guard.RailCIEventDisposition.SKIP
+    assert merge_group_non_rail.reason == (
+        "merge-queue diff has no rail paths; declaration check skipped"
+    )
+    assert push.disposition is guard.RailCIEventDisposition.SKIP
+    assert push.reason == "post-merge informational — enforcement happened at PR time"
+
+
 def _direct_payload_receipt(**overrides: object) -> guard.VerifiedRailApprovalReceipt:
     """Build a receipt the way a direct-payload caller (delegate.py) can: NO resolver.
 
@@ -344,6 +403,11 @@ def test_ci_gate_requires_the_shared_rail_path_module() -> None:
     workflow_path = Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml"
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
     rail_job = workflow["jobs"]["rail-path"]
+    rail_step = next(
+        step
+        for step in rail_job["steps"]
+        if isinstance(step, dict) and step.get("name") == "Rail approval declaration"
+    )
     run_steps = "\n".join(
         str(step.get("run", "")) for step in rail_job["steps"] if isinstance(step, dict)
     )
@@ -351,7 +415,17 @@ def test_ci_gate_requires_the_shared_rail_path_module() -> None:
     assert rail_job["name"] == "Rail approval declaration"
     assert "Rail approval declaration" in [step.get("name") for step in rail_job["steps"] if isinstance(step, dict)]
     assert "edited" in workflow[True]["pull_request"]["types"]
+    assert "merge_group" in workflow[True]
+    assert workflow[True]["push"]["branches"] == ["main"]
     assert "inspect_rail_approval_declaration" in run_steps
+    assert "inspect_rail_ci_event" in run_steps
+    assert "RAIL_EVENT_NAME" in run_steps
+    assert rail_step["env"]["RAIL_EVENT_NAME"] == "${{ github.event_name }}"
+    assert "github.event.merge_group.base_sha" in rail_step["env"]["RAIL_BASE_SHA"]
+    assert "github.event.merge_group.head_sha" in rail_step["env"]["RAIL_HEAD_SHA"]
+    assert 'event_name in {"push", "workflow_dispatch"}' in run_steps
+    assert "RailCIEventDisposition.DENY" in run_steps
+    assert "RailCIEventDisposition.SKIP" in run_steps
     assert "decide_rail_path_mutation" not in run_steps
     assert "build_production_rail_approval_receipt_resolver" not in run_steps
     assert "rail-path" in workflow["jobs"]["ci-gate"]["needs"]

--- a/tests/test_rail_path_guard.py
+++ b/tests/test_rail_path_guard.py
@@ -1,0 +1,214 @@
+"""Mutation-honest tests for layered rail-path authorization (P6 / #5885)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.orchestration import rail_path_guard as guard
+
+NOW = datetime(2026, 7, 28, tzinfo=UTC)
+HEAD = "a" * 40
+OTHER_HEAD = "b" * 40
+TASK = "rail-p6-path-guard"
+OWNED_RAIL_PATH = "agents_extensions/shared/hooks/guard-pr-merge.py"
+
+
+class _ReceiptStore:
+    source_id = "operator-approval-api"
+    source_kind = "api"
+
+    def __init__(self, receipts: dict[str, dict]) -> None:
+        self.receipts = receipts
+
+    def fetch_rail_approval_receipt(self, receipt_id: str) -> dict:
+        return self.receipts[receipt_id]
+
+
+class _UnreadableReceiptStore(_ReceiptStore):
+    def fetch_rail_approval_receipt(self, receipt_id: str) -> dict:
+        raise OSError("approval store unavailable")
+
+
+class _LocalFileReceiptStore(_ReceiptStore):
+    source_kind = "file"
+
+
+def _receipt(**overrides: object) -> dict:
+    receipt = {
+        "schema_version": "rail-approval-receipt.v1",
+        "receipt_id": "rail-approval-1",
+        "issuer": "operator",
+        "issued_at": "2026-07-28T00:00:00Z",
+        "expires_at": "2026-07-29T00:00:00Z",
+        "action": "rail-path-mutation",
+        "task_id": TASK,
+        "head_sha": HEAD,
+        "owned_paths": [OWNED_RAIL_PATH],
+    }
+    receipt.update(overrides)
+    return receipt
+
+
+def _verified(**overrides: object) -> guard.VerifiedRailApprovalReceipt:
+    receipt = _receipt(**overrides)
+    resolver = guard.ApprovedRailApprovalReceiptResolver(
+        _ReceiptStore({receipt["receipt_id"]: receipt}), now=lambda: NOW
+    )
+    return resolver.fetch(str(receipt["receipt_id"]))
+
+
+def _decide(*paths: str, receipt: guard.VerifiedRailApprovalReceipt | None = None, **kwargs):
+    return guard.decide_rail_path_mutation(
+        task_id=kwargs.pop("task_id", TASK),
+        candidate_paths=paths,
+        head_sha=kwargs.pop("head_sha", HEAD),
+        receipt=receipt,
+        now=lambda: NOW,
+        **kwargs,
+    )
+
+
+def test_rail_patterns_are_full_path_globs_not_substrings() -> None:
+    assert guard.is_rail_path("agents_extensions/shared/rules/model-assignment.md")
+    assert guard.is_rail_path("agents_extensions/codex/agents/infra.md")
+    assert guard.is_rail_path("scripts/config/trails/rb1.trail.yaml")
+    assert guard.is_rail_path("agents_extensions/shared/schemas/trailspec/v2/schema.json")
+    assert not guard.is_rail_path("docs/model_catalog.yaml-not-a-rail")
+    assert not guard.is_rail_path("docs/notes/agents_extensions/shared/rules.md")
+
+
+def test_non_rail_paths_are_unaffected_without_receipt() -> None:
+    decision = _decide(
+        "docs/projects/fleet-trails/rail-system-completion-memo.md",
+        task_id="",
+        head_sha="not-a-commit",
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "non_rail_paths"
+    assert decision.rail_paths == ()
+
+
+def test_rail_path_without_receipt_is_refused() -> None:
+    decision = _decide(OWNED_RAIL_PATH)
+
+    assert decision.allowed is False
+    assert decision.reason == "rail_approval_receipt_required"
+    assert decision.rail_paths == (OWNED_RAIL_PATH,)
+
+
+def test_valid_receipt_admits_exact_owned_rail_path_and_not_more() -> None:
+    receipt = _verified()
+
+    allowed = _decide(OWNED_RAIL_PATH, receipt=receipt)
+    extra = _decide("agents_extensions/shared/hooks/guard-admin-merge.py", receipt=receipt)
+
+    assert allowed.allowed is True
+    assert allowed.reason == "rail_approval_verified"
+    assert extra.allowed is False
+    assert extra.reason == "rail_approval_path_mismatch"
+
+
+@pytest.mark.parametrize(
+    "overrides, kwargs, reason",
+    [
+        ({}, {"task_id": "other-task"}, "rail_approval_task_mismatch"),
+        ({}, {"head_sha": OTHER_HEAD}, "rail_approval_head_mismatch"),
+    ],
+)
+def test_bound_receipt_mismatches_are_refused(overrides, kwargs, reason) -> None:
+    receipt = _verified(**overrides)
+
+    decision = _decide(OWNED_RAIL_PATH, receipt=receipt, **kwargs)
+
+    assert decision.allowed is False
+    assert decision.reason == reason
+
+
+def test_expired_receipt_is_refused_by_external_resolver() -> None:
+    expired = _receipt(
+        issued_at="2026-07-27T00:00:00Z",
+        expires_at="2026-07-28T00:00:00Z",
+    )
+    resolver = guard.ApprovedRailApprovalReceiptResolver(
+        _ReceiptStore({"rail-approval-1": expired}), now=lambda: NOW
+    )
+
+    with pytest.raises(guard.RailApprovalReceiptError, match="has expired"):
+        resolver.fetch("rail-approval-1")
+
+
+def test_forged_or_local_receipts_are_refused_before_decision() -> None:
+    forged = _receipt(issuer="self-declared-model-tier")
+    with pytest.raises(guard.RailApprovalReceiptError, match="schema violation"):
+        guard.ApprovedRailApprovalReceiptResolver(
+            _ReceiptStore({"rail-approval-1": forged}), now=lambda: NOW
+        ).fetch("rail-approval-1")
+
+    with pytest.raises(guard.RailApprovalReceiptError, match="bridge or API"):
+        guard.ApprovedRailApprovalReceiptResolver(_LocalFileReceiptStore({}), now=lambda: NOW)
+
+
+def test_unreadable_receipt_store_fails_closed() -> None:
+    resolver = guard.ApprovedRailApprovalReceiptResolver(
+        _UnreadableReceiptStore({}), now=lambda: NOW
+    )
+
+    with pytest.raises(guard.RailApprovalReceiptError, match="could not re-fetch"):
+        resolver.fetch("rail-approval-1")
+
+
+@pytest.mark.parametrize(
+    "bypass_claim",
+    [
+        {"X-Agent": "codex/rail-p6-path-guard"},
+        {"model": "gpt-5.6-sol"},
+        {"self_declared_tier": "advisor"},
+    ],
+)
+def test_identity_strings_never_bypass_rail_receipt(bypass_claim: dict[str, str]) -> None:
+    # A caller can label itself anything it wants. The versioned schema refuses
+    # these claims, and the decision API does not accept identity as authority.
+    forged = _receipt(**bypass_claim)
+    resolver = guard.ApprovedRailApprovalReceiptResolver(
+        _ReceiptStore({"rail-approval-1": forged}), now=lambda: NOW
+    )
+
+    with pytest.raises(guard.RailApprovalReceiptError, match="schema violation"):
+        resolver.fetch("rail-approval-1")
+
+
+def test_missing_rail_classifier_mutation_is_observable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the deny-list call is removed, this test turns red rather than passing vacuously."""
+    assert _decide(OWNED_RAIL_PATH).allowed is False
+
+    monkeypatch.setattr(guard, "is_rail_path", lambda _path: False)
+
+    assert _decide(OWNED_RAIL_PATH).allowed is True
+
+
+def test_missing_receipt_binding_mutation_is_observable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If task/head/path binding is removed, this test exposes the newly allowed write."""
+    receipt = _verified()
+    assert _decide(OWNED_RAIL_PATH, receipt=receipt, task_id="other-task").allowed is False
+
+    monkeypatch.setattr(guard, "_receipt_authorizes", lambda _receipt, **_kwargs: None)
+
+    assert _decide(OWNED_RAIL_PATH, receipt=receipt, task_id="other-task").allowed is True
+
+
+def test_ci_gate_requires_the_shared_rail_path_module() -> None:
+    """Removing the CI job/wiring makes this rail-layer contract test fail."""
+    workflow_path = Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    rail_job = workflow["jobs"]["rail-path"]
+    run_steps = "\n".join(
+        str(step.get("run", "")) for step in rail_job["steps"] if isinstance(step, dict)
+    )
+
+    assert "scripts.orchestration.rail_path_guard" in run_steps
+    assert "rail-path" in workflow["jobs"]["ci-gate"]["needs"]


### PR DESCRIPTION
## Summary

Implements package P6 from [rail-system completion memo §5](docs/projects/fleet-trails/rail-system-completion-memo.md): one typed, fail-closed rail-path decision module; P4-style externally re-fetched approval receipts; dispatch admission, local hook, CI, and merge guard wiring; no X-Agent/model/tier/--admin bypass.

## Security boundary

The receipt resolver accepts only a provisioned `api` or `bridge` source. It deliberately does not accept a local receipt file or environment identity claim. Without a provisioned source, rail writes and rail PRs fail closed. This needs a heavy independent cross-family review of record; do not enable auto-merge.

## Evidence

- ` .venv/bin/python -m pytest tests/test_rail_path_guard.py tests/test_delegate_rail_path_admission.py tests/test_guard_pr_merge.py tests/test_guard_primary_checkout_write.py tests/test_codex_hooks_contract.py -q ` → `306 passed in 11.29s`.
- ` .venv/bin/python -m pytest tests/test_delegate.py tests/test_guard_admin_merge.py tests/test_hooks_executable.py tests/test_git_hooks.py -q ` → `237 passed in 20.75s`.
- ` .venv/bin/python -m ruff check ... ` → `All checks passed!`.
- ` actionlint .github/workflows/ci.yml ` and `git diff --check` exited 0.
- ` .venv/bin/python scripts/audit/lint_opsec_leaks.py origin/main..HEAD ` → `✅ OPSEC check passed. Zero leaks detected.`
- ` .venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..HEAD ` → `✅ All 1 non-skipped commit(s) carry an X-Agent trailer.`

An AGY advisory review identified a nested schema-prefix gap; this PR adds descendant patterns and a regression test. The advisory was not the formal review gate.

Refs #5885

Operator-gated B+ follow-up: a GitHub App should publish a SHA-bound `rail-approval/verified` check after independently resolving and validating the receipt; branch protection should pin that check, and the merge guard should still re-fetch the receipt before merge. This is not implemented here and requires operator/advisor GO.

Rail-Approval-Receipt: rail-approval-896f1459641e41b58609969aaeafdb97
