### PR TITLE
docs(eval): publish stranger-runnable public v0

### DIFF
--- a/docs/projects/ua-eval-harness/DATA_CARD.uk.md
+++ b/docs/projects/ua-eval-harness/DATA_CARD.uk.md
@@ -1,0 +1,203 @@
+# Картка даних: Ukrainian Calque + Grammar Evaluation v0
+
+## Коротко
+
+`ua-gec-calque-grammar-public-v0` — публічний набір для мінімального
+виправлення українських речень із кальками та граматичними помилками. Версія
+`0.1.0` містить 677 held-out речень із UA-GEC 2.0, 918 допустимих
+annotator-references і 1 608 анотацій `F/Calque` або `G/*`.
+
+Це не загальний показник «якості української», не leaderboard і не
+тренувальний корпус.
+
+## Завдання
+
+На вхід моделі подаються лише:
+
+- стабільний item ID;
+- початкове українське речення;
+- SHA-256 початкового речення;
+- SHA-256 замороженої інструкції.
+
+Модель має повернути все речення з мінімально необхідними виправленнями.
+Gold targets, references, edit spans і scores не входять до generation input.
+Відповіді спочатку зберігають, а потім оцінюють окремо.
+
+Headline-метрика для тверджень саме про кальки — heritage-safe recall на
+анотаціях, які допускає окремий benchmark disposition. Calque precision не
+обчислюється: hypothesis-only edits не мають типів, тому їхні false positives
+не можна чесно приписати тегу кальки.
+
+Окремо звіт подає exact correction-edit precision, recall і F0.5 для всіх
+вибраних upstream-міток стандартизації та граматики. Це не heritage-safe
+calque score. True positive вимагає точного source-token span і replacement.
+Для кожного речення обирається annotator-reference з найкращим F0.5; рівність
+вирішується детерміновано. Тому результат дещо поблажливіший за strict
+single-reference score. Exact corrected-sentence accuracy є супровідною
+метрикою.
+
+## Походження й побудова
+
+Джерело: UA-GEC 2.0, commit
+`4757f72f192c4a41e4c8fb1d9690a948f87cf6d6`, partition
+`gec-fluency/test`. Публічний predicate без квоти включає кожне речення з
+принаймні однією анотацією `F/Calque` або `G/*`. Для кожного annotator target
+застосовуються лише ці in-scope edits; інші upstream edits залишаються
+незміненими.
+
+Маніфест розподіляє всі 2 690 test-речень:
+
+| Disposition | Кількість |
+| --- | ---: |
+| Включено | 677 |
+| Виключено: немає in-scope edit | 2 013 |
+| Разом | 2 690 |
+
+У test є 166 документів і 76 авторів. У train — 752 автори. Перетин авторів і
+документів між train та test дорівнює нулю. У 677 включених записах 505
+позначено upstream як native, 172 — non-native; source-language metadata:
+502 `null`, 114 `en`, 58 `ru`, 3 `pl`. Записів з upstream
+`is_sensitive=true` немає.
+
+Старі 52 train-derived приклади залишаються development-fixtures. Вони не
+входять до held-out результатів і використовуються лише слабкою
+детермінованою literal-rule baseline.
+
+## Покриття
+
+| Тег | Анотацій |
+| --- | ---: |
+| `F/Calque` | 354 |
+| `G/Case` | 391 |
+| `G/UngrammaticalStructure` | 270 |
+| `G/Prep` | 143 |
+| `G/Number` | 85 |
+| `G/Tense` | 77 |
+| `G/Gender` | 76 |
+| Інші `G/*` | 212 |
+
+Повний розподіл зберігається в held-out manifest і score reports. Support у
+per-tag звіті — усі eligible upstream annotations. Окреме
+`selected_reference_support` є denominator конкретного scored run.
+
+### Розподіл upstream `F/Calque`
+
+UA-GEC нормалізує текст до стандартної української. Тому upstream
+`F/Calque` зберігається без змін як provenance, але не вважається автоматичною
+benchmark-істиною про кальку. Окремий disposition layer охоплює всі 354
+annotator-level анотації (293 унікальні spans):
+
+| Benchmark disposition | Анотацій |
+| --- | ---: |
+| Допущено до headline calque recall | 338 |
+| Register/розмовна стандартизація | 3 |
+| Heritage conflict | 2 |
+| Contested / контекст не розв'язано | 11 |
+| Разом | 354 |
+
+Exact-style probe з pinned dict_uk/VESUM v6.8.0 виявив 49 унікальних
+collision spans: 34 `bad`, 10 `slang`, 3 `arch`, 2 `rare`. Це evidence для
+перевірки, а не автоматичне контекстне рішення. У VESUM немає окремого
+офіційного `dial` token; parser може відтворно витягувати comment-level
+`діалект` evidence, але жодна така ознака не дає автоматичного допуску.
+Невизначені cases fail closed поза headline scoring.
+
+## Базові результати
+
+| Baseline | Overall edit P | Overall edit R | Overall edit F0.5 | Headline calque R | Exact sentence |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Identity v1 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 |
+| Train-fixture literal rules v1 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 |
+| `gpt-5.6-terra` | 0.3110 | 0.1309 | 0.2439 | 0.1410 | 0.1610 |
+
+Для Terra 95% sentence-bootstrap interval становить 0.2073–0.2780 для edit
+F0.5 і 0.1344–0.1891 для exact accuracy. Усі 677 відповідей кожного run
+збережено; freeze manifest фіксує model, provider route, prompt, decoding,
+runner, response й report hashes. Provider не відкривав temperature, top-p
+або seed, тому live generation не є byte-reproducible. Повторне scoring
+збережених відповідей є детермінованим. Для Terra headline calque recall —
+33/234 = 0.1410; calque precision лишається `null`.
+
+## Права й атрибуція
+
+UA-GEC і відтворений із нього текст поширюються за CC BY 4.0. Derived
+dict_uk/VESUM evidence поширюється за CC BY-NC-SA 4.0. Повну атрибуцію,
+pinned sources, license links і опис змін наведено в
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md). Код оцінювача й пакувальні
+скрипти мають MIT license репозиторію.
+
+## Призначення
+
+Дозволені цілі:
+
+- відтворне порівняння систем мінімального виправлення українських кальок і
+  граматики;
+- дослідження edit precision/recall, over-editing і per-tag recall;
+- локальна перевірка saved responses без доступу до провайдера.
+
+Непризначені цілі:
+
+- загальна оцінка української, factuality, стилю, культурної коректності або
+  мовної компетентності людини;
+- висновки про окремих авторів чи source-language групи;
+- автоматичне оцінювання учнів, наймання або інші high-stakes рішення;
+- training, fine-tuning, synthetic corruption, DPO чи preference data;
+- Daily Practice, Hramatka, teacher feedback, Atlas або приватні canaries.
+
+## Обмеження
+
+- Gold успадковує рішення й можливий шум UA-GEC annotators, які
+  нормалізували текст до стандартної української.
+- Upstream `F/Calque` означає UA-GEC standardization label; benchmark
+  disposition є окремим рішенням про calque scoring.
+- VESUM attestation і `arch`/`bad`/`rare`/`slang` або comment-level dialect
+  evidence не розв'язують sense/context автоматично. Невизначені записи
+  збережено як `HERITAGE_CONFLICT` або `CONTESTED` і виключено з headline.
+- Повніші contextual heritage markers залежать від issue #5092; реліз не
+  заявляє нуль dialect conflicts через відсутність окремого `dial` token.
+- Набір охоплює лише `F/Calque` і `G/*` у конкретному upstream test split.
+- Best-reference policy може підвищувати score проти strict
+  single-reference evaluation.
+- Dependency-free Wagner–Fischer aligner реалізує exact-edit semantics, але
+  не заявляє byte-identical ERRANT alignment у неоднозначних випадках.
+- Tokenized M2 text зберігає upstream spacing; це не оцінка природності
+  detokenized output.
+- Низький support окремих тегів дає широкі uncertainty intervals.
+
+## Безпека, приватність і contamination
+
+Публікуються лише upstream-псевдонімні document/author IDs; реідентифікація не
+підтримується й не є дозволеним use. У вибірці немає upstream-sensitive
+записів. Провайдерні секрети не зберігаються. Aggregate reports не містять
+item text, IDs, edits або content hashes.
+
+[Політика contamination](contamination-policy.md) забороняє переносити
+held-out cases до продуктів або training inventories. Виявлений витік вимагає
+нової версії, повторної екстракції та нових baseline receipts.
+
+## Супровід і допуск змін
+
+Помилки повідомляють через GitHub issue з посиланням на release version та
+item ID, без копіювання приватних даних. Зміни приймаються лише через
+переглянутий PR, детерміновані тести й новий freeze version.
+
+Новий fixture може потрапити до майбутнього public held-out release лише якщо
+він:
+
+1. походить із rights-cleared, version-pinned upstream held-out partition;
+2. проходить наперед визначений quota-free predicate;
+3. зберігає writer/document disjointness і повну attribution;
+4. не походить із продукту, teacher feedback, приватного canary, synthetic
+   generation або training pipeline;
+5. отримує новий semantic version, baselines і cross-family review.
+
+Freeze `0.1.0` не редагують на місці. Правила PATCH/MINOR/MAJOR наведено в
+freeze manifest і contamination policy.
+
+## English reproducibility note
+
+This is a 677-item public minimal-edit Ukrainian calque and grammar correction
+evaluation derived deterministically from the pinned UA-GEC 2.0 test split.
+It is not a leaderboard or training corpus. See
+[REPRODUCING.md](REPRODUCING.md) for equivalent English setup, offline saved
+response scoring, provenance, and verification instructions.

--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -221,6 +221,22 @@ The Ukrainian-first
 disclosure, train-fixture separation, prohibited product/training reuse, and
 semantic version-bump rules. Frozen bytes are never edited in place.
 
+## Public v0
+
+The stranger-runnable release is documented by the Ukrainian-first
+[data card](DATA_CARD.uk.md), bilingual
+[reproduction guide](REPRODUCING.md), and complete
+[third-party notices](THIRD_PARTY_NOTICES.md). A clean checkout can reproduce
+all frozen reports without provider credentials:
+
+```bash
+uv venv --python 3.12.8
+.venv/bin/python scripts/projects/ua_eval_harness/smoke_public_v0.py
+```
+
+The smoke verifies the release freeze, validates each complete saved-response
+run, re-scores all three baselines, and requires exact report-object equality.
+
 ## Ownership and data boundaries
 
 Four lanes cooperate but retain separate ownership:

--- a/docs/projects/ua-eval-harness/REPRODUCING.md
+++ b/docs/projects/ua-eval-harness/REPRODUCING.md
@@ -1,0 +1,131 @@
+# Відтворення public v0
+
+## Швидка перевірка без credentials
+
+Потрібні Git, `uv` і CPython 3.12.8. Провайдерний обліковий запис не потрібен.
+
+```bash
+git clone https://github.com/learn-ukrainian/learn-ukrainian.github.io.git
+cd learn-ukrainian.github.io
+uv venv --python 3.12.8
+.venv/bin/python scripts/projects/ua_eval_harness/smoke_public_v0.py
+```
+
+Smoke спочатку перевіряє freeze manifest і всі 21 frozen artifact hashes.
+Потім заново оцінює identity, deterministic fixture-rule і збережений
+`gpt-5.6-terra` run. Усі три нові report objects мають точно збігтися із
+закоміченими звітами.
+
+Очікуване завершення:
+
+```text
+identity: 677 responses, edit F0.5=0.0000, headline calque R=0.0000, exact=0.0000
+deterministic fixture rules: 677 responses, edit F0.5=0.0000, headline calque R=0.0000, exact=0.0000
+gpt-5.6-terra saved run: 677 responses, edit F0.5=0.2439, headline calque R=0.1410, exact=0.1610
+public v0 smoke passed: frozen scoring reproduced without provider credentials
+```
+
+`Edit F0.5` охоплює всі вибрані upstream-мітки стандартизації та граматики.
+`Headline calque R` використовує окремий heritage-safe disposition і не
+враховує підтверджені register/heritage conflicts та невирішені cases.
+Calque precision дорівнює `null`, бо hypothesis-only edits не мають типів.
+
+Окремі fail-closed команди:
+
+```bash
+.venv/bin/python scripts/projects/ua_eval_harness/verify_release_freeze.py
+
+.venv/bin/python scripts/projects/ua_eval_harness/build_scoring_dispositions.py \
+  --verify-existing
+
+.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py verify \
+  --responses data/projects/ua_eval_harness/baselines/v1/gpt-5.6-terra.responses.jsonl
+
+.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py score \
+  --responses data/projects/ua_eval_harness/baselines/v1/gpt-5.6-terra.responses.jsonl \
+  --output /tmp/ua-eval-terra-report.json
+```
+
+Остання команда записує тимчасовий звіт; вона не змінює frozen artifacts.
+
+## Відтворення dataset із pinned upstream
+
+Ця перевірка додатково потребує clone UA-GEC на точному commit:
+
+```bash
+git clone https://github.com/grammarly/ua-gec.git /tmp/ua-gec
+git -C /tmp/ua-gec checkout 4757f72f192c4a41e4c8fb1d9690a948f87cf6d6
+
+.venv/bin/python scripts/projects/ua_eval_harness/build_heldout_manifest.py \
+  --ua-gec-root /tmp/ua-gec \
+  --check
+```
+
+Екстрактор перевіряє upstream file hashes, license/version evidence,
+writer/document split, усі 2 690 sentence dispositions і точний payload hash.
+
+Для повного відтворення heritage/style disposition завантажте pinned
+dict_uk/VESUM v6.8.0 asset, SHA-256
+`e33803783ac138e6f3af2cf0e9428ba146c0ecfda7f5c41fe83ae00c7af24be9`, і
+запустіть:
+
+```bash
+.venv/bin/python scripts/projects/ua_eval_harness/build_scoring_dispositions.py \
+  --asset /path/to/dict_corp_vis.txt.bz2 \
+  --check
+```
+
+Asset та derived evidence мають CC BY-NC-SA 4.0; точний URL, revision і
+license receipt наведено в
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md). VESUM attestation/style
+markers є candidate evidence, не автоматичним contextual adjudication.
+Повніша contextual activation залишається залежністю issue #5092; public v0
+fail closed виключає unresolved records із headline scoring.
+
+## English quickstart
+
+Requirements: Git, `uv`, and CPython 3.12.8. No provider account, API key,
+private repository, product state, or live model call is required.
+
+```bash
+git clone https://github.com/learn-ukrainian/learn-ukrainian.github.io.git
+cd learn-ukrainian.github.io
+uv venv --python 3.12.8
+.venv/bin/python scripts/projects/ua_eval_harness/smoke_public_v0.py
+```
+
+The smoke verifies the immutable release manifest, validates all complete
+saved-response runs, re-scores all 677 responses in each run, and requires
+byte-equivalent report objects. It reads only the public files committed under
+`data/projects/ua_eval_harness` and the public scorer/extractor scripts.
+
+The printed overall edit F0.5 covers every selected upstream standardization
+and grammar label. Headline calque recall uses the separate heritage-safe
+benchmark disposition. Calque precision is intentionally null because
+hypothesis-only edits are untyped.
+
+To score a new saved-response file, first create a source-only request packet:
+
+```bash
+.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py prepare \
+  --output /tmp/ua-eval-requests.jsonl
+```
+
+Generate responses outside the scorer using only the request fields, then
+import them with versioned model/provider/decoding metadata:
+
+```bash
+.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py import \
+  --requests /tmp/ua-eval-requests.jsonl \
+  --model-output /tmp/model-output.jsonl \
+  --metadata /tmp/model-metadata.json \
+  --output /tmp/saved-responses.jsonl
+
+.venv/bin/python scripts/projects/ua_eval_harness/evaluate_model.py score \
+  --responses /tmp/saved-responses.jsonl \
+  --output /tmp/score-report.json
+```
+
+The importer rejects incomplete coverage, duplicate IDs, source/prompt drift,
+response tampering, and gold-shaped fields. Live generation is optional and
+outside the credential-free reproduction path.

--- a/docs/projects/ua-eval-harness/THIRD_PARTY_NOTICES.md
+++ b/docs/projects/ua-eval-harness/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,63 @@
+# Third-party notices
+
+## UA-GEC 2.0
+
+The public evaluation data and source-derived saved-response artifacts include
+material from:
+
+- **Work:** UA-GEC, Ukrainian Grammatical Error Corpus, version 2.0
+- **Creators/citation:** Syvokon, Nahorna, Kuchmiichuk, and Osidach.
+  *UA-GEC*. UNLP 2023.
+- **Source repository:**
+  [grammarly/ua-gec](https://github.com/grammarly/ua-gec)
+- **Exact source revision:**
+  [`4757f72f192c4a41e4c8fb1d9690a948f87cf6d6`](https://github.com/grammarly/ua-gec/tree/4757f72f192c4a41e4c8fb1d9690a948f87cf6d6)
+- **License:** [Creative Commons Attribution 4.0 International
+  (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)
+- **Pinned license evidence:**
+  [upstream `LICENSE`](https://github.com/grammarly/ua-gec/blob/4757f72f192c4a41e4c8fb1d9690a948f87cf6d6/LICENSE)
+
+Changes made for this evaluation:
+
+- selected `gec-fluency/test` sentences deterministically when at least one
+  annotation has tag `F/Calque` or prefix `G/`;
+- created one target per annotator by applying only those in-scope edits while
+  leaving all other upstream edits unchanged;
+- preserved upstream document/author metadata, annotator indices, original
+  tags, source locators, and cryptographic receipts;
+- retained hash-only exclusion receipts for test sentences without an
+  in-scope edit;
+- generated source-only request packets, model responses, and aggregate score
+  reports for the frozen task.
+
+No endorsement by the UA-GEC creators or Grammarly is implied. Reusers of the
+UA-GEC-derived data must retain this attribution, link the CC BY 4.0 license,
+and indicate their own changes.
+
+## dict_uk / VESUM v6.8.0
+
+The benchmark-disposition evidence receipts were derived from:
+
+- **Work:** `dict_uk` / VESUM morphological dictionary, release `v6.8.0`
+- **Source repository:**
+  [brown-uk/dict_uk](https://github.com/brown-uk/dict_uk)
+- **Exact source revision:**
+  [`bcb5ccd9585a79dbbbb7c8c5e241adcd8a64f824`](https://github.com/brown-uk/dict_uk/tree/bcb5ccd9585a79dbbbb7c8c5e241adcd8a64f824)
+- **Pinned release asset:**
+  [`dict_corp_vis.txt.bz2`](https://github.com/brown-uk/dict_uk/releases/download/v6.8.0/dict_corp_vis.txt.bz2),
+  SHA-256
+  `e33803783ac138e6f3af2cf0e9428ba146c0ecfda7f5c41fe83ae00c7af24be9`
+- **License:** [Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+  International (CC BY-NC-SA 4.0)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
+
+The release does not redistribute the dictionary asset. It preserves bounded
+derived receipts for exact surface-form attestation, analysis counts,
+style-marker evidence, and receipt hashes. Those signals identify candidates;
+they do not automatically adjudicate contextual calque status.
+
+## Repository software
+
+The extractor, scorer, validators, runner, and smoke-test software are
+licensed under the repository's [MIT license](../../../LICENSE). The
+UA-GEC-derived data remains under CC BY 4.0, and VESUM-derived evidence remains
+under CC BY-NC-SA 4.0. The MIT license does not replace or narrow those terms.

--- a/scripts/projects/ua_eval_harness/smoke_public_v0.py
+++ b/scripts/projects/ua_eval_harness/smoke_public_v0.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Credential-free end-to-end smoke test for the public UA evaluation v0."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.projects.ua_eval_harness.evaluate_model import score_saved_run
+from scripts.projects.ua_eval_harness.verify_release_freeze import DEFAULT_OUTPUT, validate_freeze
+
+BASELINE_DIR = ROOT / "data/projects/ua_eval_harness/baselines/v1"
+RUNS = (
+    ("identity", BASELINE_DIR / "identity.responses.jsonl", BASELINE_DIR / "identity.report.json"),
+    (
+        "deterministic fixture rules",
+        BASELINE_DIR / "fixture-rules.responses.jsonl",
+        BASELINE_DIR / "fixture-rules.report.json",
+    ),
+    (
+        "gpt-5.6-terra saved run",
+        BASELINE_DIR / "gpt-5.6-terra.responses.jsonl",
+        BASELINE_DIR / "gpt-5.6-terra.report.json",
+    ),
+)
+
+
+class SmokeError(ValueError):
+    """The public package cannot reproduce its frozen results."""
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SmokeError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SmokeError(f"expected JSON object in {path}")
+    return value
+
+
+def run_smoke() -> list[dict[str, Any]]:
+    """Verify the freeze and reproduce every committed aggregate report."""
+    freeze = _read_json(DEFAULT_OUTPUT)
+    validate_freeze(freeze)
+    summaries: list[dict[str, Any]] = []
+    for name, responses_path, report_path in RUNS:
+        actual = score_saved_run(responses_path.relative_to(ROOT))
+        expected = _read_json(report_path)
+        if actual != expected:
+            raise SmokeError(f"re-scored report does not match frozen bytes: {name}")
+        summaries.append(
+            {
+                "name": name,
+                "responses": actual["exact_sentence"]["total"],
+                "edit_f0_5": actual["edit_correction"]["f0_5"],
+                "headline_calque_recall": actual["headline_calque"]["recall"],
+                "exact_sentence_accuracy": actual["exact_sentence"]["accuracy"],
+            }
+        )
+    return summaries
+
+
+def main() -> int:
+    try:
+        summaries = run_smoke()
+    except (SmokeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    for summary in summaries:
+        print(
+            f"{summary['name']}: {summary['responses']} responses, "
+            f"edit F0.5={summary['edit_f0_5']:.4f}, "
+            f"headline calque R={summary['headline_calque_recall']:.4f}, "
+            f"exact={summary['exact_sentence_accuracy']:.4f}"
+        )
+    print("public v0 smoke passed: frozen scoring reproduced without provider credentials")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ua_eval_public_v0.py
+++ b/tests/test_ua_eval_public_v0.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from scripts.projects.ua_eval_harness.smoke_public_v0 import run_smoke
+
+
+def test_public_v0_reproduces_all_saved_baselines() -> None:
+    summaries = run_smoke()
+
+    assert [summary["name"] for summary in summaries] == [
+        "identity",
+        "deterministic fixture rules",
+        "gpt-5.6-terra saved run",
+    ]
+    assert all(summary["responses"] == 677 for summary in summaries)
+    assert summaries[0]["edit_f0_5"] == 0.0
+    assert summaries[1]["edit_f0_5"] == 0.0
+    assert summaries[2]["edit_f0_5"] == 0.24390243902439027
+    assert summaries[0]["headline_calque_recall"] == 0.0
+    assert summaries[1]["headline_calque_recall"] == 0.0
+    assert summaries[2]["headline_calque_recall"] == 0.14102564102564102
+    assert summaries[2]["exact_sentence_accuracy"] == 0.16100443131462333


### PR DESCRIPTION
Closes #4541

## Outcome

Publishes the Ukrainian-first, stranger-runnable public v0 for the frozen UA-GEC calque + grammar evaluation.

## Evidence

- clean GitHub clone at exact head 814a7429e2 under CPython 3.12.8 reproduced all three frozen reports without credentials
- public smoke verifies the 21-artifact freeze and prints overall edit F0.5 separately from heritage-safe headline calque recall
- data card reports 354 upstream F/Calque annotations, 338 admitted, and 16 register/heritage/contested exclusions
- attribution covers pinned UA-GEC CC BY 4.0 and dict_uk/VESUM v6.8.0 CC BY-NC-SA 4.0 evidence
- reproduction guide discloses the #5092 contextual-evidence limitation and fail-closed behavior
- README wording is impersonal; required third-party creator attribution remains in THIRD_PARTY_NOTICES.md

## Verification

- public v0 smoke: passed
- 38 focused tests: passed
- Ruff: passed
- markdownlint: passed
- git diff check: passed
- OPSEC: passed
- commit trailer: passed

## Boundaries

No leaderboard, factuality/BIO, synthetic/DPO/fine-tuning/training data, teacher annotation, Hramatka/product data, private canaries, or Atlas/Daily Practice gold enters this release.