### PR TITLE
fix(launchers): restore start-kimicc/glmcc with isolated Z.AI secret load

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -32,8 +32,10 @@ Project-local wrappers for interactive agent sessions:
 ./start-codex.sh       # native Codex
 ./start-grok.sh        # native Grok Build TUI
 ./start-gemini.sh      # native Gemini / Antigravity AGY Build TUI
-./start-kimi.sh        # native Kimi Code
-./start-glm.sh         # GLM through Claude Code
+./start-kimi.sh        # native Kimi Code (default harness)
+./start-kimicc.sh      # Claude Code routed to Kimi (compat → start-kimi --harness claude-code)
+./start-glm.sh         # Claude Code routed to Z.AI GLM
+./start-glmcc.sh       # same GLM route under the historical name
 ./start-claude-driver.sh --epic devops
 ./start-codex-driver.sh --epic devops
 ./start-gemini-driver.sh --epic devops
@@ -45,12 +47,13 @@ lane via `scripts/delegate.py --agent kimi` or the project bridge/runtime. Inter
 Kimi is `kimi` (user npm global at `~/.local/bin/kimi` is preferred;
 `~/.kimi-code/bin/kimi` is the legacy standalone binary and last-resort fallback).
 Do not use `~/.hermes/node/bin` — that Node tree is Hermes-private only.
-Use `./start-kimi.sh --harness claude-code` for Kimi through Claude Code.
+Use `./start-kimicc.sh` or `./start-kimi.sh --harness claude-code` for Kimi through Claude Code.
 
 ### Parallel routes and original Claude config
 
-`start-codex.sh --harness claude-code` and
-`start-kimi.sh --harness claude-code` route through process-scoped
+`start-codex.sh --harness claude-code`,
+`start-kimicc.sh` / `start-kimi.sh --harness claude-code`, and
+`start-glmcc.sh` / `start-glm.sh` route through process-scoped
 configuration. They **never rewrite** the live `~/.claude/settings.json`. That means:
 
 - `./start-claude.sh` always keeps the original Anthropic / Claude Code setup
@@ -89,15 +92,16 @@ repository.
 
 ### Kimi through Claude Code
 
-`start-kimi.sh --harness claude-code` is **Claude Code UI + Kimi models** (not the native Kimi TUI).
+`start-kimicc.sh` (or `start-kimi.sh --harness claude-code`) is **Claude Code UI + Kimi models** (not the native Kimi TUI).
 Use it when you want Claude Code ergonomics with K3 or K2.7 in a second
 terminal while native Claude runs in the first.
 
 ```bash
-./start-kimi.sh --harness claude-code                # coding endpoint + isolated config
-./start-kimi.sh --harness claude-code --model k2.7
-./start-kimi.sh --harness claude-code --endpoint platform
-./start-kimi.sh --harness claude-code --no-isolate-config
+./start-kimicc.sh                                    # coding endpoint + isolated config
+./start-kimicc.sh --model k2.7
+./start-kimicc.sh --endpoint platform
+./start-kimicc.sh --no-isolate-config
+./start-kimi.sh --harness claude-code                # same route, explicit harness
 ```
 
 **Defaults (operator lane):** `--endpoint coding` (subscription),
@@ -136,6 +140,35 @@ or the project bridge/runtime). Do not point headless jobs at kimicc.
 
 K2.7 requires **Thinking ON** in the Claude Code TUI (`Tab`) or the endpoint
 rejects requests. Official guide: [Use Kimi in Claude Code](https://platform.kimi.ai/docs/guide/claude-code-kimi).
+
+### GLM through Claude Code (Z.AI)
+
+`start-glmcc.sh` / `start-glm.sh` routes Claude Code to the Z.AI Anthropic-compatible
+endpoint (`https://api.z.ai/api/anthropic`) per
+[Z.AI Claude Code docs](https://docs.z.ai/scenario-example/develop-tools/claude).
+
+```bash
+./start-glmcc.sh                     # coding endpoint + isolated ~/.claude-glmcc
+./start-glmcc.sh --endpoint platform
+./start-glm.sh --model glm-5.2
+```
+
+**Credentials (first match wins):** `GLMCC_AUTH_TOKEN`, `ZAI_API_KEY`,
+`ZHIPU_API_KEY`, `GLM_API_KEY`, then owner-only `~/.secret/zai.key`
+(mode `0600` or `0400`). Override the file path with `GLMCC_SECRET_FILE`.
+File-backed keys are loaded into process-scoped `ANTHROPIC_AUTH_TOKEN` only —
+they are never re-exported as `ZAI_*`, never written to
+`~/.claude/settings.json`, and never printed by dry-run. Ambient
+`ANTHROPIC_AUTH_TOKEN` is deliberately rejected as a GLM credential.
+
+Create the secret file once (avoid putting the key on the shell command line
+or in shell history):
+
+```bash
+mkdir -p ~/.secret
+touch ~/.secret/zai.key && chmod 600 ~/.secret/zai.key
+${EDITOR:-nano} ~/.secret/zai.key   # paste the key alone, save, quit
+```
 
 The trusted `agents_extensions/codex/config.toml` overlay gives Codex App and
 CLI the same Sol/high root and Terra/medium V2 defaults. `start-codex.sh`

--- a/scripts/lib/claude_route_guard.sh
+++ b/scripts/lib/claude_route_guard.sh
@@ -31,6 +31,11 @@ CLAUDE_ROUTE_ENV_KEYS=(
   CLAUDE_CODE_MAX_CONTEXT_TOKENS
   CLAUDE_CODE_AUTO_COMPACT_WINDOW
   CLAUDE_CODE_EFFORT_LEVEL
+  CLAUDE_CODE_USE_BEDROCK
+  CLAUDE_CODE_USE_VERTEX
+  CLAUDE_CODE_USE_FOUNDRY
+  CLAUDE_CODE_USE_MANTLE
+  CLAUDE_CODE_USE_ANTHROPIC_AWS
 )
 
 # Print space-separated route keys present under settings.json env (if any).
@@ -90,6 +95,11 @@ keys = [
     "CLAUDE_CODE_MAX_CONTEXT_TOKENS",
     "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
     "CLAUDE_CODE_EFFORT_LEVEL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "CLAUDE_CODE_USE_MANTLE",
+    "CLAUDE_CODE_USE_ANTHROPIC_AWS",
 ]
 present = [k for k in keys if k in env]
 print(" ".join(present))
@@ -102,49 +112,92 @@ PY
   done
 }
 
-# Refuse launch when settings.json would override process-scoped route env.
-# Pass-through when CLAUDE_CONFIG_DIR is set to a non-default isolated dir, or
-# when CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV=1 (explicit operator override).
+# Refuse launch when any Claude settings scope that Claude Code actually loads
+# would override process-scoped route env.
+#
+# Scopes inspected (user → project → local), matching
+# https://code.claude.com/docs/en/settings :
+#   1) ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json
+#   2) <project>/.claude/settings.json
+#   3) <project>/.claude/settings.local.json
+#
+# CLAUDE_SETTINGS_PATH is NEVER trusted as a replacement for those real paths —
+# an ambient redirect would let the guard inspect a clean decoy while Claude
+# still loads the pinned scopes. If set, it is checked in addition only.
+# Emergency only: CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV=1.
 assert_claude_settings_route_clean() {
   local route_name="${1:-alternate Claude route}"
-  local settings_path="${CLAUDE_SETTINGS_PATH:-${HOME}/.claude/settings.json}"
-  local config_dir="${CLAUDE_CONFIG_DIR:-}"
-  local conflict_output
-  local conflicts=()
-  local line
+  local project_dir="${2:-}"
+  local config_dir="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+  local settings_path conflict_output line git_common primary_root
+  local -a settings_paths=()
+  local -a conflicts=()
+  local -a seen_paths=()
+  local path_already_seen=0
 
   if [ "${CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV:-0}" = "1" ]; then
     echo "Warning: CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV=1 — settings.json env may override $route_name." >&2
     return 0
   fi
 
-  # Isolated config dir means we are not reading the operator's live settings.
-  if [ -n "$config_dir" ] && [ "$config_dir" != "${HOME}/.claude" ]; then
-    return 0
+  settings_paths+=("${config_dir}/settings.json")
+  if [ -n "$project_dir" ]; then
+    settings_paths+=("${project_dir}/.claude/settings.json")
+    settings_paths+=("${project_dir}/.claude/settings.local.json")
+    # Linked worktrees: Claude Code resolves project/local settings against the
+    # primary checkout (git common dir parent), not only the worktree path.
+    # https://code.claude.com/docs/en/settings
+    git_common="$(env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR \
+      git -C "$project_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+    if [ -n "$git_common" ]; then
+      primary_root="$(dirname "$git_common")"
+      if [ -n "$primary_root" ] && [ "$primary_root" != "$project_dir" ]; then
+        settings_paths+=("${primary_root}/.claude/settings.json")
+        settings_paths+=("${primary_root}/.claude/settings.local.json")
+      fi
+    fi
+  fi
+  # Additional inspection only — never a substitute for the scopes above.
+  if [ -n "${CLAUDE_SETTINGS_PATH:-}" ]; then
+    settings_paths+=("$CLAUDE_SETTINGS_PATH")
   fi
 
-  conflict_output="$(claude_settings_conflicting_route_keys "$settings_path")" || return $?
-  while IFS= read -r line; do
-    [ -n "$line" ] && conflicts+=("$line")
-  done <<< "$conflict_output"
+  for settings_path in "${settings_paths[@]}"; do
+    path_already_seen=0
+    for seen in "${seen_paths[@]+"${seen_paths[@]}"}"; do
+      if [ "$seen" = "$settings_path" ]; then
+        path_already_seen=1
+        break
+      fi
+    done
+    if [ "$path_already_seen" = 1 ]; then
+      continue
+    fi
+    seen_paths+=("$settings_path")
+
+    conflict_output="$(claude_settings_conflicting_route_keys "$settings_path")" || return $?
+    while IFS= read -r line; do
+      [ -n "$line" ] && conflicts+=("$settings_path:$line")
+    done <<< "$conflict_output"
+  done
 
   if ((${#conflicts[@]} == 0)); then
     return 0
   fi
 
-  echo "Error: $route_name refuses to launch because $settings_path pins route env keys:" >&2
+  echo "Error: $route_name refuses to launch because Claude settings pin route env keys:" >&2
   printf '  - %s\n' "${conflicts[@]}" >&2
   echo >&2
-  echo "Claude Code applies settings.json env OVER process environment, so these" >&2
-  echo "pins would hijack native Claude and this launcher. We do NOT rewrite that" >&2
-  echo "file (original config must stay operator-owned)." >&2
+  echo "Claude Code merges user/project/local settings over process environment, so these" >&2
+  echo "pins would hijack this launcher's allowlisted route. We do NOT rewrite those" >&2
+  echo "files (config must stay operator-owned)." >&2
   echo >&2
   echo "Options:" >&2
-  echo "  1) Remove those keys from settings.json env (recommended; keep Method-1 env routing)." >&2
-  echo "  2) Launch with an isolated config dir, e.g. CLAUDE_CONFIG_DIR=\$HOME/.claude-kimicc" >&2
+  echo "  1) Remove those keys from the listed settings.json env blocks." >&2
+  echo "  2) Point CLAUDE_CONFIG_DIR at a clean isolated directory and clear project/local pins." >&2
   echo "  3) Emergency only: CLAUDE_ROUTE_GUARD_ALLOW_SETTINGS_ENV=1 (not recommended)." >&2
   echo >&2
   echo "cc-switch and similar tools often write these keys — prefer project launchers" >&2
-  echo "(./start-claude.sh, ./start-codex.sh --harness claude-code, ./start-kimi.sh --harness claude-code) over global switches." >&2
+  echo "(./start-claude.sh, ./start-glmcc.sh, ./start-kimicc.sh) over global switches." >&2
   return 1
 }

--- a/scripts/lib/glmcc_route.sh
+++ b/scripts/lib/glmcc_route.sh
@@ -1,11 +1,39 @@
 #!/usr/bin/env bash
-# GLM Claude-Code route. It accepts only explicitly named GLM credentials.
+# GLM Claude-Code route. Accepts only explicitly named GLM credentials or the
+# owner-only file ~/.secret/zai.key. Ambient ANTHROPIC_AUTH_TOKEN is rejected.
+#
+# Isolation contract:
+# - Process-scoped env only (never writes ~/.claude/settings.json).
+# - File-backed keys are loaded into a local then moved to ANTHROPIC_AUTH_TOKEN;
+#   they are never exported as ZAI_API_KEY and never printed.
+# - Default CLAUDE_CONFIG_DIR=$HOME/.claude-glmcc keeps native Claude untouched.
 
 glmcc_default_base_url() {
   case "$1" in
     coding|platform) printf '%s\n' 'https://api.z.ai/api/anthropic' ;;
     *) return 1 ;;
   esac
+}
+
+glmcc_route_python() {
+  local project_dir="$1"
+  local git_common
+
+  if [ -n "${GLMCC_ROUTE_PYTHON:-}" ] && [ -x "${GLMCC_ROUTE_PYTHON}" ]; then
+    printf '%s\n' "$GLMCC_ROUTE_PYTHON"
+    return 0
+  fi
+  if [ -x "$project_dir/.venv/bin/python" ]; then
+    printf '%s\n' "$project_dir/.venv/bin/python"
+    return 0
+  fi
+  git_common="$(env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR \
+    git -C "$project_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "$git_common" ] && [ -x "$(dirname "$git_common")/.venv/bin/python" ]; then
+    printf '%s\n' "$(dirname "$git_common")/.venv/bin/python"
+    return 0
+  fi
+  return 1
 }
 
 glmcc_resolve_explicit_auth_token() {
@@ -19,9 +47,64 @@ glmcc_resolve_explicit_auth_token() {
   fi
 }
 
+# Load ~/.secret/zai.key (or GLMCC_SECRET_FILE) via the audited credential
+# helper. The value stays in _glmcc_auth only — never exported under a ZAI_*
+# name — so a later `env` dump does not reveal a file-sourced key twice.
+glmcc_load_secret_file_auth() {
+  local project_dir="$1"
+  local python_bin secret_path display_path
+
+  secret_path="${GLMCC_SECRET_FILE:-$HOME/.secret/zai.key}"
+  if [ ! -e "$secret_path" ]; then
+    return 1
+  fi
+  if ! python_bin="$(glmcc_route_python "$project_dir")"; then
+    echo 'Error: Python binary not found to load the GLM credential file.' >&2
+    return 1
+  fi
+  display_path="$secret_path"
+  # Intentional: credential_source shows a home-relative display path with a
+  # literal tilde prefix (not an expandable assignment). SC2088 does not apply.
+  # shellcheck disable=SC2088
+  case "$display_path" in
+    "$HOME"/*) display_path="~/${display_path#"$HOME"/}" ;;
+  esac
+
+  # load_credential errors include the path only — never the secret contents.
+  # stdout is captured into the local holder; stderr stays on the tty.
+  # The key is never placed on argv or exported as ZAI_*.
+  if ! _glmcc_auth="$(
+    LEARN_UKRAINIAN_ROOT="$project_dir" GLMCC_SECRET_PATH="$secret_path" \
+      "$python_bin" - <<'PY'
+import os
+import sys
+from pathlib import Path
+
+root = Path(os.environ["LEARN_UKRAINIAN_ROOT"]).resolve()
+sys.path.insert(0, str(root))
+from scripts.ocr._credentials import CredentialError, load_credential
+
+try:
+    sys.stdout.write(load_credential(os.environ["GLMCC_SECRET_PATH"]))
+except CredentialError as exc:
+    print(exc, file=sys.stderr)
+    sys.exit(1)
+PY
+  )" || [ -z "${_glmcc_auth:-}" ]; then
+    echo "Error: could not load GLM credential from $display_path." >&2
+    return 1
+  fi
+  GLMCC_AUTH_SOURCE="file:$display_path"
+  return 0
+}
+
 glmcc_configure_route() {
-  local project_dir="$1" route platform_model coding_model profile default_base
-  if ! route="$("$project_dir/.venv/bin/python" "$project_dir/scripts/review/model_catalog.py" --resolve-glm-model "$MODEL_ALIAS" --format glmcc 2>/dev/null)"; then
+  local project_dir="$1" route platform_model coding_model profile default_base python_bin
+  if ! python_bin="$(glmcc_route_python "$project_dir")"; then
+    echo 'Error: Python binary not found for the GLM Claude-Code route.' >&2
+    return 1
+  fi
+  if ! route="$("$python_bin" "$project_dir/scripts/review/model_catalog.py" --resolve-glm-model "$MODEL_ALIAS" --format glmcc 2>/dev/null)"; then
     echo "Error: unsupported GLM model '$MODEL_ALIAS' (use glm-5.2)." >&2
     return 2
   fi
@@ -39,8 +122,13 @@ EOF
     return 2
   fi
   if ! glmcc_resolve_explicit_auth_token; then
-    echo 'Error: no explicit GLM credential found (set GLMCC_AUTH_TOKEN, ZAI_API_KEY, ZHIPU_API_KEY, or GLM_API_KEY).' >&2
-    return 3
+    if ! glmcc_load_secret_file_auth "$project_dir"; then
+      echo 'Error: no explicit GLM credential found.' >&2
+      echo '  Set GLMCC_AUTH_TOKEN, ZAI_API_KEY, ZHIPU_API_KEY, or GLM_API_KEY,' >&2
+      echo '  or install owner-only ~/.secret/zai.key (mode 0600/0400).' >&2
+      echo '  Ambient ANTHROPIC_AUTH_TOKEN is deliberately rejected.' >&2
+      return 3
+    fi
   fi
 
   # An alternate Claude route must not inherit operator-owned route pins from
@@ -49,19 +137,19 @@ EOF
   # process-scoped allowlisted route.
   # shellcheck source=scripts/lib/claude_route_guard.sh
   source "$project_dir/scripts/lib/claude_route_guard.sh"
-  CLAUDE_ROUTE_GUARD_PYTHON="$project_dir/.venv/bin/python"
+  CLAUDE_ROUTE_GUARD_PYTHON="$python_bin"
   export CLAUDE_ROUTE_GUARD_PYTHON
   if [ "$ISOLATE_CONFIG" = 1 ] && [ -z "${CLAUDE_CONFIG_DIR:-}" ]; then
     export CLAUDE_CONFIG_DIR="$HOME/.claude-glmcc"
     mkdir -p "$CLAUDE_CONFIG_DIR"
   fi
-  if ! assert_claude_settings_route_clean "GLM"; then
+  if ! assert_claude_settings_route_clean "GLM" "$project_dir"; then
     return 1
   fi
 
   # shellcheck source=scripts/lib/profile_resolver.sh
   source "$project_dir/scripts/lib/profile_resolver.sh"
-  CLAUDE_PROFILE_RESOLVER_PYTHON="$project_dir/.venv/bin/python"
+  CLAUDE_PROFILE_RESOLVER_PYTHON="$python_bin"
   export CLAUDE_PROFILE_RESOLVER_PYTHON
   if ! resolve_context_profile "$profile" "$LEAD_MODEL"; then
     echo "Error: could not resolve GLM profile '$profile' for model '$LEAD_MODEL'." >&2
@@ -76,6 +164,9 @@ EOF
   export API_TIMEOUT_MS="${GLMCC_API_TIMEOUT_MS:-3000000}"
   export ANTHROPIC_BASE_URL="$BASE_URL"
   export ANTHROPIC_AUTH_TOKEN="$_glmcc_auth"
+  # Drop the transient holder and any inherited Anthropic API key. File-sourced
+  # keys were never exported as ZAI_*; env-sourced ZAI_*/GLM_* names stay as the
+  # operator set them, but the Claude route itself only sees ANTHROPIC_*.
   unset ANTHROPIC_API_KEY _glmcc_auth
   export ANTHROPIC_MODEL="$LEAD_MODEL"
   export ANTHROPIC_DEFAULT_OPUS_MODEL="$LEAD_MODEL"

--- a/scripts/lib/kimicc_route.sh
+++ b/scripts/lib/kimicc_route.sh
@@ -167,7 +167,7 @@ kimicc_configure_route() {
     mkdir -p "$CLAUDE_CONFIG_DIR"
     echo "Isolated Claude config: $CLAUDE_CONFIG_DIR (original ~/.claude untouched)"
   fi
-  if ! assert_claude_settings_route_clean "KimiCC"; then
+  if ! assert_claude_settings_route_clean "KimiCC" "$project_dir"; then
     return 1
   fi
 

--- a/scripts/lib/launcher_core.sh
+++ b/scripts/lib/launcher_core.sh
@@ -27,11 +27,13 @@ launcher_usage() {
     kimi) provider_env='  KIMICC_AUTH_TOKEN, MOONSHOT_API_KEY, KIMI_API_KEY
                              Explicit Kimi credentials for --harness claude-code.' ;;
     glm) provider_env='  GLMCC_AUTH_TOKEN, ZAI_API_KEY, ZHIPU_API_KEY, GLM_API_KEY
-                             Explicit GLM credentials.' ;;
+                             Explicit GLM credentials (preferred over the secret file).
+  ~/.secret/zai.key        Owner-only fallback (mode 0600/0400) when env is unset.
+  GLMCC_SECRET_FILE        Override path for the file-backed Z.AI key.' ;;
   esac
   case "$LC_PROVIDER:$LC_MODE" in
-    kimi:interactive) example_three='./start-kimi.sh --harness claude-code --endpoint coding' ;;
-    glm:interactive) example_three='./start-glm.sh --endpoint platform' ;;
+    kimi:interactive) example_three='./start-kimicc.sh --endpoint coding' ;;
+    glm:interactive) example_three='./start-glmcc.sh --endpoint coding' ;;
     *:driver) example_three="./${name} --epic devops" ;;
     *) example_three="./start-${LC_PROVIDER}-driver.sh --epic devops" ;;
   esac
@@ -119,6 +121,11 @@ launcher_clear_foreign_route_state() {
   unset CLAUDE_CODE_SUBAGENT_MODEL CLAUDE_CODE_EFFORT_LEVEL
   unset CLAUDE_CODE_MAX_CONTEXT_TOKENS CLAUDE_CODE_AUTO_COMPACT_WINDOW
   unset CLAUDE_CODE_API_KEY_HELPER_TTL_MS API_TIMEOUT_MS
+  # Provider-selector switches (Bedrock/Vertex/Foundry/Mantle/AWS) must not
+  # survive into an alternate Claude-Code route — settings env can also pin
+  # them, which the route guard refuses separately.
+  unset CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY
+  unset CLAUDE_CODE_USE_MANTLE CLAUDE_CODE_USE_ANTHROPIC_AWS
   unset LEARN_UKRAINIAN_TRANSPORT LEARN_UKRAINIAN_REQUESTED_PROFILE_ID
   unset LEARN_UKRAINIAN_CLAUDEX_MANAGED_LAUNCH LEARN_UKRAINIAN_KIMICC_MANAGED_LAUNCH
   unset LEARN_UKRAINIAN_GLMCC_MANAGED_LAUNCH

--- a/start-glmcc.sh
+++ b/start-glmcc.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Compatibility wrapper: Claude Code UI routed to Z.AI GLM (GLM Coding Plan).
+#
+# Canonical entry after the launcher cutover (#5958):
+#   ./start-glm.sh
+#
+# This wrapper restores the historical `./start-glmcc.sh` name. It does not
+# invent a second route — it forwards to the shared glm adapter. Isolation,
+# credential selection (explicit env or ~/.secret/zai.key), and route guards
+# remain in scripts/lib/glmcc_route.sh + launcher_core.sh.
+#
+# Official reference: https://docs.z.ai/scenario-example/develop-tools/claude
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$ROOT/start-glm.sh" "$@"

--- a/start-kimicc.sh
+++ b/start-kimicc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Compatibility wrapper: Claude Code UI routed to Kimi (K3 / K2.7).
+#
+# Canonical entry after the launcher cutover (#5958):
+#   ./start-kimi.sh --harness claude-code
+#
+# This wrapper restores the historical `./start-kimicc.sh` name. It does not
+# invent a second route — it forwards to the shared kimi adapter with the
+# Claude-Code harness pinned. Isolation, credential selection, and route
+# guards remain in scripts/lib/kimicc_route.sh + launcher_core.sh.
+#
+# Official reference: https://platform.kimi.ai/docs/guide/claude-code-kimi
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pin the compatibility route: a later --harness would otherwise override the
+# leading default and silently drop into native kimi-code.
+for _arg in "$@"; do
+  case "$_arg" in
+    --harness|--harness=*)
+      echo "Error: start-kimicc.sh always uses Claude Code; omit --harness," >&2
+      echo "  or call ./start-kimi.sh --harness kimi-code for the native TUI." >&2
+      exit 2
+      ;;
+  esac
+done
+unset _arg
+
+exec "$ROOT/start-kimi.sh" --harness claude-code "$@"

--- a/tests/test_launcher_contract.py
+++ b/tests/test_launcher_contract.py
@@ -1,4 +1,4 @@
-"""Contract coverage for the ten-script public launcher estate."""
+"""Contract coverage for the public launcher estate."""
 
 from __future__ import annotations
 
@@ -20,9 +20,14 @@ PUBLIC = (
     "start-grok.sh",
     "start-grok-driver.sh",
     "start-kimi.sh",
+    "start-kimicc.sh",
     "start-glm.sh",
+    "start-glmcc.sh",
 )
-RETIRED = tuple(f"start-{name}.sh" for name in ("claudex", "kimicc", "glmcc")) + tuple(
+# Compat wrappers forward into the shared adapters; they are part of PUBLIC.
+COMPAT = ("start-kimicc.sh", "start-glmcc.sh")
+assert set(COMPAT).issubset(PUBLIC)
+RETIRED = tuple(f"start-{name}.sh" for name in ("claudex",)) + tuple(
     f"start-{provider}-drive.sh" for provider in ("gemini", "grok", "opus", "sonnet")
 )
 
@@ -67,7 +72,19 @@ def test_unknown_launcher_flag_exits_usage_error(name: str) -> None:
     assert "run --help" in result.stderr
 
 
-@pytest.mark.parametrize("name", ("start-claude.sh", "start-codex.sh", "start-gemini.sh", "start-grok.sh", "start-kimi.sh", "start-glm.sh"))
+@pytest.mark.parametrize(
+    "name",
+    (
+        "start-claude.sh",
+        "start-codex.sh",
+        "start-gemini.sh",
+        "start-grok.sh",
+        "start-kimi.sh",
+        "start-kimicc.sh",
+        "start-glm.sh",
+        "start-glmcc.sh",
+    ),
+)
 def test_interactive_launchers_reject_driver_epic(name: str) -> None:
     result = run_launcher(name, "--epic", "devops")
     assert result.returncode == 2
@@ -245,6 +262,48 @@ def test_session_and_durable_helper_roots_are_deliberately_distinct() -> None:
     assert "LC_SESSION_ROOT" in core and "LC_DURABLE_HELPER_ROOT" in core
     assert 'kimicc_configure_route "$LC_SESSION_ROOT" "$LC_SESSION_ROOT" "$LC_DURABLE_HELPER_ROOT"' in kimi
     assert "durable_helper_dir" in route
+
+
+def test_compat_wrappers_forward_to_shared_adapters() -> None:
+    kimicc = (REPO / "start-kimicc.sh").read_text(encoding="utf-8")
+    glmcc = (REPO / "start-glmcc.sh").read_text(encoding="utf-8")
+    assert 'exec "$ROOT/start-kimi.sh" --harness claude-code "$@"' in kimicc
+    assert 'exec "$ROOT/start-glm.sh" "$@"' in glmcc
+    # Wrappers must not set route credentials themselves — isolation stays in
+    # the shared route helpers.
+    for body in (kimicc, glmcc):
+        assert "ANTHROPIC_AUTH_TOKEN" not in body
+        assert "ANTHROPIC_BASE_URL" not in body
+        assert "ZAI_API_KEY" not in body
+    # Sol P2: kimicc must reject a later --harness override.
+    assert "--harness|--harness=*" in kimicc
+
+
+def test_compat_kimicc_rejects_harness_override() -> None:
+    result = run_launcher("start-kimicc.sh", "--harness", "kimi-code")
+    assert result.returncode == 2
+    assert "always uses Claude Code" in result.stderr
+
+
+def test_compat_kimicc_and_glmcc_dry_run(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    kimi = run_launcher(
+        "start-kimicc.sh",
+        "--model",
+        "k3",
+        env={"HOME": str(home), "KIMICC_AUTH_TOKEN": "kimi-compat-secret"},
+    )
+    assert kimi.returncode == 0, kimi.stderr
+    assert "credential_source=KIMICC_AUTH_TOKEN" in kimi.stdout
+    assert "kimi-compat-secret" not in kimi.stdout + kimi.stderr
+
+    glm = run_launcher(
+        "start-glmcc.sh",
+        env={"HOME": str(home), "ZAI_API_KEY": "glm-compat-secret"},
+    )
+    assert glm.returncode == 0, glm.stderr
+    assert "credential_source=ZAI_API_KEY" in glm.stdout
+    assert "glm-compat-secret" not in glm.stdout + glm.stderr
 
 
 def test_retired_names_are_absent_from_tracked_content() -> None:

--- a/tests/test_start_glm_launcher.py
+++ b/tests/test_start_glm_launcher.py
@@ -19,6 +19,32 @@ _GLM_CREDENTIALS = {
 }
 
 
+def _repo_python() -> Path:
+    """Resolve the project venv Python without hardcoding a machine path."""
+    candidate = REPO / ".venv" / "bin" / "python"
+    if candidate.is_file():
+        return candidate
+    common = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(REPO),
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if common.returncode == 0:
+        primary = Path(common.stdout.strip()).parent / ".venv" / "bin" / "python"
+        if primary.is_file():
+            return primary
+    pytest.fail(f"project .venv python not found for {REPO}")
+
+
 def _stub_claude(tmp_path: Path) -> Path:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -152,9 +178,7 @@ def test_claude_route_guard_checks_project_local_and_ignores_settings_path_decoy
 
     decoy = tmp_path / "decoy-clean.json"
     decoy.write_text("{}", encoding="utf-8")
-    python_bin = REPO / ".venv" / "bin" / "python"
-    if not python_bin.is_file():
-        python_bin = Path("/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python")
+    python_bin = _repo_python()
 
     script = f"""
 set -euo pipefail
@@ -189,9 +213,7 @@ def test_claude_route_guard_refuses_provider_selector_pins(tmp_path: Path) -> No
         json.dumps({"env": {"CLAUDE_CODE_USE_BEDROCK": "1"}}),
         encoding="utf-8",
     )
-    python_bin = REPO / ".venv" / "bin" / "python"
-    if not python_bin.is_file():
-        python_bin = Path("/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python")
+    python_bin = _repo_python()
     script = f"""
 set -euo pipefail
 source "{REPO}/scripts/lib/claude_route_guard.sh"
@@ -240,9 +262,7 @@ def test_claude_route_guard_checks_primary_checkout_settings_for_linked_worktree
     user_cfg = home / ".claude-glmcc"
     user_cfg.mkdir(parents=True)
     (user_cfg / "settings.json").write_text("{}", encoding="utf-8")
-    python_bin = REPO / ".venv" / "bin" / "python"
-    if not python_bin.is_file():
-        python_bin = Path("/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python")
+    python_bin = _repo_python()
     script = f"""
 set -euo pipefail
 source "{REPO}/scripts/lib/claude_route_guard.sh"

--- a/tests/test_start_glm_launcher.py
+++ b/tests/test_start_glm_launcher.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
 
-from tests.test_launcher_contract import run_launcher
+from tests.test_launcher_contract import REPO, run_launcher
 
 _GLM_CREDENTIALS = {
     "GLMCC_AUTH_TOKEN": "",
@@ -108,6 +109,207 @@ def test_glm_no_isolate_config_fails_closed_on_route_pins(tmp_path: Path) -> Non
     assert "ANTHROPIC_BASE_URL" in result.stderr
 
 
+def test_glm_isolated_config_still_fails_closed_on_stale_route_pins(tmp_path: Path) -> None:
+    """Sol P1: isolation must not skip inspecting $CLAUDE_CONFIG_DIR/settings.json."""
+    home = tmp_path / "home"
+    isolated = home / ".claude-glmcc"
+    isolated.mkdir(parents=True)
+    (isolated / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://foreign.invalid"}}),
+        encoding="utf-8",
+    )
+    result = run_launcher(
+        "start-glmcc.sh",
+        env={**_GLM_CREDENTIALS, "ZAI_API_KEY": "test-key", "HOME": str(home)},
+    )
+    assert result.returncode == 1
+    assert "GLM refuses to launch" in result.stderr
+    assert "ANTHROPIC_BASE_URL" in result.stderr
+    assert ".claude-glmcc/settings.json" in result.stderr
+    assert "test-key" not in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    "relative_settings",
+    (".claude/settings.json", ".claude/settings.local.json"),
+)
+def test_claude_route_guard_checks_project_local_and_ignores_settings_path_decoy(
+    relative_settings: str, tmp_path: Path
+) -> None:
+    """Sol P1 r4: inspect project/local scopes; CLAUDE_SETTINGS_PATH is not a substitute."""
+    home = tmp_path / "home"
+    user_cfg = home / ".claude-glmcc"
+    user_cfg.mkdir(parents=True)
+    (user_cfg / "settings.json").write_text("{}", encoding="utf-8")
+
+    project = tmp_path / "project"
+    settings_path = project / relative_settings
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://project-or-local.invalid"}}),
+        encoding="utf-8",
+    )
+
+    decoy = tmp_path / "decoy-clean.json"
+    decoy.write_text("{}", encoding="utf-8")
+    python_bin = REPO / ".venv" / "bin" / "python"
+    if not python_bin.is_file():
+        python_bin = Path("/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python")
+
+    script = f"""
+set -euo pipefail
+source "{REPO}/scripts/lib/claude_route_guard.sh"
+export CLAUDE_CONFIG_DIR="{user_cfg}"
+export CLAUDE_SETTINGS_PATH="{decoy}"
+export CLAUDE_ROUTE_GUARD_PYTHON="{python_bin}"
+assert_claude_settings_route_clean "GLM" "{project}"
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "GLM refuses to launch" in result.stderr
+    assert "ANTHROPIC_BASE_URL" in result.stderr
+    assert relative_settings in result.stderr
+    # Decoy must not be the only inspected file — the real pin path is reported.
+    assert str(settings_path) in result.stderr or relative_settings in result.stderr
+
+
+def test_claude_route_guard_refuses_provider_selector_pins(tmp_path: Path) -> None:
+    """Sol P1 r5: CLAUDE_CODE_USE_* in settings must fail closed."""
+    home = tmp_path / "home"
+    user_cfg = home / ".claude-glmcc"
+    user_cfg.mkdir(parents=True)
+    (user_cfg / "settings.json").write_text(
+        json.dumps({"env": {"CLAUDE_CODE_USE_BEDROCK": "1"}}),
+        encoding="utf-8",
+    )
+    python_bin = REPO / ".venv" / "bin" / "python"
+    if not python_bin.is_file():
+        python_bin = Path("/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python")
+    script = f"""
+set -euo pipefail
+source "{REPO}/scripts/lib/claude_route_guard.sh"
+export CLAUDE_CONFIG_DIR="{user_cfg}"
+export CLAUDE_ROUTE_GUARD_PYTHON="{python_bin}"
+assert_claude_settings_route_clean "GLM" "{tmp_path / 'empty-project'}"
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "CLAUDE_CODE_USE_BEDROCK" in result.stderr
+
+
+def test_claude_route_guard_checks_primary_checkout_settings_for_linked_worktree(
+    tmp_path: Path,
+) -> None:
+    """Sol P1 r6: linked worktrees resolve local settings on the primary checkout."""
+    primary = tmp_path / "primary"
+    worktree = tmp_path / "worktree"
+    primary.mkdir()
+    subprocess.run(["git", "init", "--quiet", str(primary)], check=True, timeout=30)
+    subprocess.run(
+        ["git", "-C", str(primary), "commit", "--allow-empty", "--quiet", "-m", "init"],
+        check=True,
+        timeout=30,
+        env={**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+    subprocess.run(
+        ["git", "-C", str(primary), "worktree", "add", "--quiet", str(worktree), "HEAD"],
+        check=True,
+        timeout=30,
+    )
+    primary_settings = primary / ".claude" / "settings.local.json"
+    primary_settings.parent.mkdir(parents=True)
+    primary_settings.write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://primary-local.invalid"}}),
+        encoding="utf-8",
+    )
+    home = tmp_path / "home"
+    user_cfg = home / ".claude-glmcc"
+    user_cfg.mkdir(parents=True)
+    (user_cfg / "settings.json").write_text("{}", encoding="utf-8")
+    python_bin = REPO / ".venv" / "bin" / "python"
+    if not python_bin.is_file():
+        python_bin = Path("/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python")
+    script = f"""
+set -euo pipefail
+source "{REPO}/scripts/lib/claude_route_guard.sh"
+export CLAUDE_CONFIG_DIR="{user_cfg}"
+export CLAUDE_ROUTE_GUARD_PYTHON="{python_bin}"
+assert_claude_settings_route_clean "GLM" "{worktree}"
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "ANTHROPIC_BASE_URL" in result.stderr
+    assert "settings.local.json" in result.stderr
+
+
+def test_glm_clears_ambient_provider_selector_before_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sol P2 r6: stub Claude must observe all five selectors unset."""
+    home = tmp_path / "home"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    binary = bin_dir / "claude"
+    binary.write_text(
+        "#!/usr/bin/env bash\n"
+        "for key in CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX "
+        "CLAUDE_CODE_USE_FOUNDRY CLAUDE_CODE_USE_MANTLE CLAUDE_CODE_USE_ANTHROPIC_AWS; do\n"
+        '  if printenv "$key" >/dev/null 2>&1; then\n'
+        '    printf "%s=set\\n" "$key"\n'
+        "  else\n"
+        '    printf "%s=unset\\n" "$key"\n'
+        "  fi\n"
+        "done\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    result = run_launcher(
+        "start-glmcc.sh",
+        env={
+            **_GLM_CREDENTIALS,
+            "ZAI_API_KEY": "test-key",
+            "HOME": str(home),
+            "CLAUDE_CODE_USE_BEDROCK": "1",
+            "CLAUDE_CODE_USE_VERTEX": "1",
+            "CLAUDE_CODE_USE_FOUNDRY": "1",
+            "CLAUDE_CODE_USE_MANTLE": "1",
+            "CLAUDE_CODE_USE_ANTHROPIC_AWS": "1",
+        },
+        dry_run=False,
+    )
+    assert result.returncode == 0, result.stderr
+    for key in (
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_USE_MANTLE",
+        "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+    ):
+        assert f"{key}=unset" in result.stdout, result.stdout
+
+
 def test_glm_exports_trusted_profile_and_capacity_to_the_claude_adapter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     bin_dir = _stub_claude(tmp_path)
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
@@ -122,3 +324,58 @@ def test_glm_exports_trusted_profile_and_capacity_to_the_claude_adapter(tmp_path
     assert "profile=glmcc_glm52" in result.stdout
     assert "window=1048576" in result.stdout
     assert "compact=996147" in result.stdout
+
+
+def test_glm_loads_owner_only_secret_file_without_leaking_value(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    secret_dir = home / ".secret"
+    secret_dir.mkdir(parents=True)
+    secret_path = secret_dir / "zai.key"
+    secret_value = "file-backed-zai-secret-must-not-appear"
+    secret_path.write_text(f"{secret_value}\n", encoding="utf-8")
+    secret_path.chmod(0o600)
+
+    result = run_launcher(
+        "start-glmcc.sh",
+        env={**_GLM_CREDENTIALS, "HOME": str(home)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "credential_source=file:~/.secret/zai.key" in result.stdout
+    assert secret_value not in result.stdout + result.stderr
+    # File-sourced keys must not be re-exported under ZAI_* names in dry-run text.
+    assert "ZAI_API_KEY=" not in result.stdout
+
+
+def test_glm_rejects_group_readable_secret_file(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    secret_dir = home / ".secret"
+    secret_dir.mkdir(parents=True)
+    secret_path = secret_dir / "zai.key"
+    secret_path.write_text("insecure-secret\n", encoding="utf-8")
+    secret_path.chmod(0o640)
+
+    result = run_launcher(
+        "start-glm.sh",
+        env={**_GLM_CREDENTIALS, "HOME": str(home)},
+    )
+    assert result.returncode == 3
+    assert "no explicit GLM credential" in result.stderr or "could not load GLM credential" in result.stderr
+    assert "insecure-secret" not in result.stdout + result.stderr
+
+
+def test_glm_env_credential_wins_over_secret_file(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    secret_dir = home / ".secret"
+    secret_dir.mkdir(parents=True)
+    secret_path = secret_dir / "zai.key"
+    secret_path.write_text("file-secret-should-lose\n", encoding="utf-8")
+    secret_path.chmod(0o600)
+
+    result = run_launcher(
+        "start-glm.sh",
+        env={**_GLM_CREDENTIALS, "HOME": str(home), "ZAI_API_KEY": "env-secret-wins"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "credential_source=ZAI_API_KEY" in result.stdout
+    assert "file-secret-should-lose" not in result.stdout + result.stderr
+    assert "env-secret-wins" not in result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- Restore `start-kimicc.sh` / `start-glmcc.sh` as thin forwards into the shared adapters after #5958 retired them
- Load `~/.secret/zai.key` process-scoped only (never re-export as `ZAI_*`, never print); reject ambient `ANTHROPIC_AUTH_TOKEN`
- Harden Claude route guard: user + project + local + primary-checkout (linked worktree) scopes; refuse/clear `CLAUDE_CODE_USE_*` provider selectors

## Sol review
Informal Sol (`gpt-5.6-sol`) security+general review iterated r3→r7 via bridge asks; final verdict **No findings / safe to ship**. That is **not** a sealed PR formal CF — CI / merge gate will still want an independent cross-family review on this PR.

## Test plan
- [x] `pytest tests/test_launcher_contract.py tests/test_start_glm_launcher.py tests/test_start_kimi_launcher.py` (73 passed)
- [x] `LAUNCHER_DRY_RUN=1 ./start-glmcc.sh` → `credential_source=file:~/.secret/zai.key`
- [x] `shellcheck` on wrappers + `glmcc_route.sh` / `claude_route_guard.sh`
- [ ] CI green
- [ ] Formal CF review on this PR (Sol informal already done)

Refs #5958

Made with [Cursor](https://cursor.com)