### PR TITLE
docs(process): forbid fabricated epic-driver done bars

### DIFF
--- a/agents_extensions/shared/rules/operator-expectations.md
+++ b/agents_extensions/shared/rules/operator-expectations.md
@@ -13,6 +13,8 @@ tie-breakers.
 1. **Quality work.** No heuristics when a proper algorithm exists, no threshold-lowering, no
    "for now". One excellent module beats ten mediocre ones — this is education for real
    learners; bad pedagogy creates durable learner errors.
+   - No self-authored partial-done bars; no "when you want" for in-scope residual;
+     residual unfinished work is queue, not ceremony.
 2. **Best practices.** Research the established best practice BEFORE implementing or deciding —
    `docs/best-practices/`, prior art, authoritative sources, current standards. Never ship the
    first thing that works. Fix root causes, not symptoms.

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -93,7 +93,7 @@ the build/review queue. **Step 0 of any dispatch:** `gh pr list --state all --se
 carry it). If nothing genuinely fits a free lane, log it and leave it idle — never
 manufacture busywork (quality > utilization).
 
-### NO FABRICATED DONE (binding all epic drivers)
+### 2a. NO FABRICATED DONE (binding all epic drivers)
 
 - Never invent acceptance thresholds the operator, issue, or epic goal did not set.
 - Never declare a goal done while measured residual remains in the same mandate unless
@@ -102,8 +102,6 @@ manufacture busywork (quality > utilization).
 - Never relabel unfinished work as an intentional skip without issue text or tool proof.
 - Before "done" or handback, quote the tool residual count; `residual > 0` requires a
   next dispatch in the same session.
-- **Grok seat:** higher fabrication risk — enforce this harder; global
-  `~/.grok/Agents.md` mirrors this rule.
 
 ### 3. Route by model × harness fit
 Decide the lane from `/api/rules` + `model_catalog.yaml`, **never** from the provider

--- a/agents_extensions/shared/skills/drive-epic/SKILL.md
+++ b/agents_extensions/shared/skills/drive-epic/SKILL.md
@@ -93,6 +93,18 @@ the build/review queue. **Step 0 of any dispatch:** `gh pr list --state all --se
 carry it). If nothing genuinely fits a free lane, log it and leave it idle — never
 manufacture busywork (quality > utilization).
 
+### NO FABRICATED DONE (binding all epic drivers)
+
+- Never invent acceptance thresholds the operator, issue, or epic goal did not set.
+- Never declare a goal done while measured residual remains in the same mandate unless
+  tools prove it impossible or the operator accepted it on the issue.
+- Never end with "when you want" or an "optional next" for in-scope residual — dispatch it.
+- Never relabel unfinished work as an intentional skip without issue text or tool proof.
+- Before "done" or handback, quote the tool residual count; `residual > 0` requires a
+  next dispatch in the same session.
+- **Grok seat:** higher fabrication risk — enforce this harder; global
+  `~/.grok/Agents.md` mirrors this rule.
+
 ### 3. Route by model × harness fit
 Decide the lane from `/api/rules` + `model_catalog.yaml`, **never** from the provider
 name. Respect the live caps (in-flight ceilings), the language-lane restriction


### PR DESCRIPTION
## Summary

- add a binding no-fabricated-done rule to the epic-driver playbook
- add the matching operator quality-contract constraint
- retain existing `/api/rules` wiring; `operator-expectations.md` is already served

## Verification

- `git diff --check`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- targeted requirement-text search

## Known validation note

Running Markdownlint on both files reports 17 pre-existing violations in `drive-epic/SKILL.md` outside this change (lines 14 and 33–187); the new section creates none.

No auto-merge has been armed.

Rail-Approval-Receipt: rail-approval-e10094f09a674023a7ceea5c67b1287c
