### PR TITLE
fix(atlas): present VESUM participles to learners

### DIFF
--- a/scripts/audit/audit_atlas_thin_enriched.py
+++ b/scripts/audit/audit_atlas_thin_enriched.py
@@ -22,7 +22,7 @@ DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts.lexicon.build_kaikki_lookup import KAIKKI_SOURCE
+from scripts.lexicon.enrich_manifest import _entry_has_learner_english_anchor
 from scripts.lexicon.manifest_io import load_manifest
 
 
@@ -31,33 +31,9 @@ def old_gate_enriched(entry: dict[str, Any]) -> bool:
     return bool(entry.get("enrichment"))
 
 
-def _has_nonempty_string(value: object) -> bool:
-    return isinstance(value, str) and bool(value.strip())
-
-
-def _has_nonempty_list(value: object) -> bool:
-    return isinstance(value, list) and any(_has_nonempty_string(item) for item in value)
-
-
 def has_learner_english_anchor(entry: dict[str, Any]) -> bool:
     """Return True when an entry has a learner-facing English meaning anchor."""
-    if _has_nonempty_string(entry.get("gloss")):
-        return True
-
-    enrichment = entry.get("enrichment")
-    if not isinstance(enrichment, dict):
-        return False
-
-    translation = enrichment.get("translation")
-    if isinstance(translation, dict) and _has_nonempty_list(translation.get("en")):
-        return True
-
-    meaning = enrichment.get("meaning")
-    if not isinstance(meaning, dict):
-        return False
-    if meaning.get("source") != KAIKKI_SOURCE:
-        return False
-    return _has_nonempty_list(meaning.get("definitions"))
+    return _entry_has_learner_english_anchor(entry)
 
 
 def thin_old_gate_entries(manifest: dict[str, Any]) -> list[dict[str, Any]]:

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -50,7 +50,7 @@ import sqlite3
 import sys
 import time
 import unicodedata
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import lru_cache
 from html.parser import HTMLParser
 from pathlib import Path
@@ -62,7 +62,7 @@ import requests
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from scripts.lexicon.build_data_manifest import _slug_for_url
+from scripts.lexicon.build_data_manifest import _lemma_key, _slug_for_url
 from scripts.lexicon.build_kaikki_lookup import KAIKKI_SOURCE
 from scripts.lexicon.build_kaikki_lookup import _clean_gloss as _clean_translation_gloss
 from scripts.lexicon.build_kaikki_lookup import lookup_key as kaikki_lookup_key
@@ -143,6 +143,7 @@ SLOVNYK_CACHE = _default_slovnyk_cache()
 
 _CYRILLIC_WORD_CHARS = "A-Za-zА-Яа-яЄєІіЇїҐґ0-9'’ʼ-"
 _LATIN_RE = re.compile(r"[A-Za-z]")
+_CYRILLIC_RE = re.compile(r"[А-Яа-яЄєІіЇїҐґ]")
 _UKRAINIAN_TEXT_RE = re.compile(r"^[А-Яа-яЄєІіЇїҐґ'’ʼ -]+$")
 _STRESS_MARK_RE = re.compile("[\u0300\u0301]")
 _NON_CACHE_CHARS_RE = re.compile(r"[^0-9A-Za-zА-Яа-яЄєІіЇїҐґ'’ʼ-]+")
@@ -817,6 +818,109 @@ def _build_verb_paradigm(forms: list[dict[str, str]]) -> dict | None:
         paradigm["imperative"] = collapsed_imperative
     if collapsed_past:
         paradigm["past"] = collapsed_past
+    return paradigm
+
+
+def _participle_analysis(forms: Sequence[Mapping[str, object]]) -> tuple[str, str] | None:
+    """Return the unambiguous VESUM voice/aspect for a participle form set."""
+    tags = {str(row.get("tags") or "") for row in forms}
+    voices = {
+        voice
+        for marker, voice in (("pasv", "passive"), ("actv", "active"))
+        if any("adjp" in tag.split(":") and marker in tag.split(":") for tag in tags)
+    }
+    aspects = {
+        aspect
+        for marker, aspect in (("perf", "perfective"), ("imperf", "imperfective"))
+        if any(marker in tag.split(":") for tag in tags)
+    }
+    if len(voices) != 1 or len(aspects) != 1:
+        return None
+    return next(iter(voices)), next(iter(aspects))
+
+
+_PARTICIPLE_PARENT_RE = re.compile(
+    r"\b(?:дієпр\.?|дієприкметник)\b.*?\bдо\s+([А-Яа-яЄєІіЇїҐґ'’ʼ-]+)",
+    re.IGNORECASE,
+)
+
+
+def _participle_parent_from_hints(hints: Sequence[object]) -> str | None:
+    """Extract a VESUM-attested infinitive from a sourced Ukrainian definition.
+
+    A VESUM participle analysis records voice and aspect but not the generating
+    verb.  Dictionary wording such as ``Дієпр. пас. мин. ч. до прийняти`` is
+    the deterministic parent source; require an infinitive VESUM analysis
+    before presenting it to a learner.
+    """
+    for hint in hints:
+        if not isinstance(hint, str):
+            continue
+        match = _PARTICIPLE_PARENT_RE.search(strip_acute_stress(hint))
+        if not match:
+            continue
+        parent = match.group(1)
+        try:
+            analyses = verify_word(parent)
+        except Exception:
+            continue
+        if any(
+            str(row.get("pos") or "") == "verb"
+            and "inf" in str(row.get("tags") or "").split(":")
+            for row in analyses
+        ):
+            return parent
+    return None
+
+
+def _entry_participle_hints(entry: Mapping[str, object]) -> list[str]:
+    """Collect source-definition text that can name a participle's parent verb."""
+    hints: list[str] = []
+    gloss = entry.get("gloss")
+    if isinstance(gloss, str):
+        hints.append(gloss)
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, Mapping):
+        return hints
+    meaning = enrichment.get("meaning")
+    if isinstance(meaning, Mapping):
+        definitions = meaning.get("definitions")
+        if isinstance(definitions, list):
+            for definition in definitions:
+                if isinstance(definition, str):
+                    hints.append(definition)
+                elif isinstance(definition, Mapping):
+                    for key in ("text", "definition", "value"):
+                        value = definition.get(key)
+                        if isinstance(value, str):
+                            hints.append(value)
+    cards = enrichment.get("definition_cards")
+    if isinstance(cards, list):
+        for card in cards:
+            if not isinstance(card, Mapping):
+                continue
+            definitions = card.get("definitions")
+            if isinstance(definitions, list):
+                hints.extend(item for item in definitions if isinstance(item, str))
+    return hints
+
+
+def _build_participle_paradigm(
+    forms: Sequence[Mapping[str, object]],
+    *,
+    parent_hints: Sequence[object] = (),
+    available_lemmas: set[str] | None = None,
+) -> dict[str, str] | None:
+    analysis = _participle_analysis(forms)
+    if analysis is None:
+        return None
+    voice, aspect = analysis
+    paradigm: dict[str, str] = {"kind": "participle", "voice": voice, "aspect": aspect}
+    parent = _participle_parent_from_hints(parent_hints)
+    if parent:
+        paradigm["verb"] = parent
+        if available_lemmas is not None and _lemma_key(parent) in available_lemmas:
+            paradigm["verb_url_slug"] = _slug_for_url(parent)
     return paradigm
 
 
@@ -2350,7 +2454,12 @@ def _is_slovnyk_warning_candidate(entry: dict[str, Any], status: dict[str, Any])
     )
 
 
-def _morphology(lemma: str) -> dict | None:
+def _morphology(
+    lemma: str,
+    *,
+    parent_hints: Sequence[object] = (),
+    available_lemmas: set[str] | None = None,
+) -> dict | None:
     """Full VESUM paradigm for a single-token lemma, decoded and de-duplicated.
 
     Style/register-marked forms (нестягнені, застарілі, розмовні … — any tag token
@@ -2416,7 +2525,11 @@ def _morphology(lemma: str) -> dict | None:
         "forms": forms_out,
         "source": "VESUM",
     }
-    paradigm = _build_paradigm(pos_raw, decoded)
+    paradigm = _build_participle_paradigm(
+        forms,
+        parent_hints=parent_hints,
+        available_lemmas=available_lemmas,
+    ) or _build_paradigm(pos_raw, decoded)
     if paradigm:
         morphology["paradigm"] = paradigm
     stressed_forms = {
@@ -5124,9 +5237,23 @@ def _slovnyk_ukreng_translation(lemma: str, cache: dict[str, Any] | None) -> dic
     return block
 
 
+def _is_learner_english_text(value: object) -> bool:
+    """Accept an English learner gloss, never a Ukrainian-only dictionary note."""
+    return isinstance(value, str) and bool(value.strip()) and bool(_LATIN_RE.search(value))
+
+
+def _is_cyrillic_only_gloss(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value.strip())
+        and bool(_CYRILLIC_RE.search(value))
+        and not _LATIN_RE.search(value)
+    )
+
+
 def _entry_has_learner_english_anchor(entry: dict[str, Any]) -> bool:
     gloss = entry.get("gloss")
-    if isinstance(gloss, str) and gloss.strip():
+    if _is_learner_english_text(gloss):
         return True
     enrichment = entry.get("enrichment")
     if not isinstance(enrichment, dict):
@@ -5134,14 +5261,76 @@ def _entry_has_learner_english_anchor(entry: dict[str, Any]) -> bool:
     translation = enrichment.get("translation")
     if isinstance(translation, dict):
         terms = translation.get("en")
-        if isinstance(terms, list) and any(isinstance(term, str) and term.strip() for term in terms):
+        if isinstance(terms, list) and any(_is_learner_english_text(term) for term in terms):
             return True
     meaning = enrichment.get("meaning")
     if isinstance(meaning, dict) and meaning.get("source") == KAIKKI_SOURCE:
         definitions = meaning.get("definitions")
-        if isinstance(definitions, list) and any(isinstance(item, str) and item.strip() for item in definitions):
+        if isinstance(definitions, list) and any(_is_learner_english_text(item) for item in definitions):
             return True
     return False
+
+
+def apply_participle_presentation(
+    entry: dict[str, Any],
+    *,
+    parent_hints: Sequence[object] = (),
+    available_lemmas: set[str] | None = None,
+) -> bool:
+    """Attach VESUM-backed participle morphology to a candidate or Atlas entry.
+
+    This deliberately does not generate a gloss.  It only turns a VESUM
+    ``adjp:pasv`` / ``adjp:actv`` analysis plus an attested dictionary parent
+    into learner-facing morphology before promotion or during enrichment.
+    """
+    lemma = str(entry.get("lemma") or "").strip()
+    if not lemma:
+        return False
+    hints = [*parent_hints, *_entry_participle_hints(entry)]
+    morphology = _morphology(lemma, parent_hints=hints, available_lemmas=available_lemmas)
+    if not isinstance(morphology, dict):
+        return False
+    paradigm = morphology.get("paradigm")
+    if not isinstance(paradigm, dict) or paradigm.get("kind") != "participle":
+        return False
+    enrichment_raw = entry.get("enrichment")
+    enrichment: dict[str, Any] = dict(enrichment_raw) if isinstance(enrichment_raw, Mapping) else {}
+    enrichment["morphology"] = morphology
+    sources = list(enrichment.get("sources") or []) if isinstance(enrichment.get("sources"), list) else []
+    if "VESUM" not in sources:
+        sources.append("VESUM")
+    enrichment["sources"] = sorted(sources)
+    entry["enrichment"] = enrichment
+    return True
+
+
+def promotion_entry_gate_violations(entries: Sequence[Mapping[str, Any]]) -> list[str]:
+    """Return deterministic learner-gloss and participle violations for new entries."""
+    violations: list[str] = []
+    for entry in entries:
+        lemma = str(entry.get("lemma") or "<missing lemma>")
+        if _is_cyrillic_only_gloss(entry.get("gloss")):
+            violations.append(f"{lemma}: top-level learner gloss is Cyrillic-only; English gloss required")
+        try:
+            analyses = verify_word(lemma)
+        except Exception:
+            continue
+        analysis = _participle_analysis(analyses)
+        if analysis is None:
+            continue
+        expected_voice, expected_aspect = analysis
+        enrichment = entry.get("enrichment")
+        morphology = enrichment.get("morphology") if isinstance(enrichment, Mapping) else None
+        paradigm = morphology.get("paradigm") if isinstance(morphology, Mapping) else None
+        if not isinstance(paradigm, Mapping) or paradigm.get("kind") != "participle":
+            violations.append(f"{lemma}: VESUM participle requires participle presentation")
+            continue
+        if paradigm.get("voice") != expected_voice or paradigm.get("aspect") != expected_aspect:
+            violations.append(f"{lemma}: participle presentation disagrees with VESUM voice/aspect")
+        parent = _participle_parent_from_hints(_entry_participle_hints(entry))
+        if parent and paradigm.get("verb") != parent:
+            violations.append(f"{lemma}: VESUM participle dictionary parent {parent!r} is missing")
+    return violations
 
 
 def _fill_learner_english_anchor_from_slovnyk_cache(
@@ -5650,6 +5839,7 @@ def enrich_entry(
     pointer_antonym_relations: list[dict[str, Any]] | None = None,
     pointer_homonym_relations: list[dict[str, Any]] | None = None,
     pointer_paronym_relations: list[dict[str, Any]] | None = None,
+    available_lemmas: set[str] | None = None,
 ) -> bool:
     """Enrich a single manifest entry in place (dictionary-grounded).
     Returns True if any enrichment was attached. Extracted from enrich() so the
@@ -5825,7 +6015,11 @@ def enrich_entry(
     cefr = _cefr(conn, lemma)
     if cefr:
         block["cefr"] = cefr
-    morph = _morphology(base)
+    morph = _morphology(
+        base,
+        parent_hints=_entry_participle_hints(entry),
+        available_lemmas=available_lemmas,
+    )
     if morph:
         block["morphology"] = morph
     entry["heritage_status"] = _finalize_heritage_status(
@@ -5992,6 +6186,11 @@ def enrich(
 
         entries = list(stream_manifest_entries_sqlite(Path(staged["path"])))
         _normalize_manifest_entries({"entries": entries})
+        available_lemmas = {
+            _lemma_key(str(entry.get("lemma") or ""))
+            for entry in entries
+            if str(entry.get("lemma") or "").strip()
+        }
 
         cefr_path = work_dir / "seals" / "cefr.sqlite"
         unique_words = cefr_candidate_words(
@@ -6061,6 +6260,7 @@ def enrich(
                     *pointer_paronym_relations.get(entry_key or "", []),
                     *corpus_for_entry.get("paronym", []),
                 ],
+                available_lemmas=available_lemmas,
             ):
                 enriched += 1
     finally:

--- a/scripts/lexicon/promote_grow_candidates.py
+++ b/scripts/lexicon/promote_grow_candidates.py
@@ -44,8 +44,11 @@ from scripts.lexicon.build_data_manifest import _lemma_key, _slug_for_url
 from scripts.lexicon.enrich_manifest import (
     _entry_has_learner_english_anchor,
     _fill_learner_english_anchor_from_slovnyk_cache,
+    _is_cyrillic_only_gloss,
     _load_slovnyk_cache_file,
     _slovnyk_cache_path,
+    apply_participle_presentation,
+    promotion_entry_gate_violations,
 )
 from scripts.lexicon.fill_from_content import ModuleInfo, _load_manifest, _manifest_entry
 from scripts.lexicon.lemma_normalization import strip_acute_stress
@@ -61,6 +64,13 @@ DEFAULT_CANDIDATES = PROJECT_ROOT / "data" / "lexicon" / "grow_candidates.json"
 DEFAULT_MANIFEST = PROJECT_ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 DEFAULT_NEEDS_REVIEW = PROJECT_ROOT / "data" / "lexicon" / "grow_needs_review.json"
 PRIMARY_SOURCE = "content_lexicon_grow"
+_CURATED_PARTICIPLE_LEARNER_GLOSSES = {
+    # Source intake records the Ukrainian dictionary cross-reference
+    # ``Дієпр. пас. мин. ч. до прийняти``.  The learner-facing meaning is
+    # intentionally English; VESUM supplies the independent POS/voice/aspect.
+    "прийнятий": ("accepted", "admitted", "adopted"),
+}
+_CURATED_PARTICIPLE_GLOSS_SOURCE = "Atlas learner curation (#5918)"
 APPROVAL_LEDGER_KIND = "atlas_grow_promotion_ledger"
 NEEDS_REVIEW_LEDGER_KIND = "atlas_grow_needs_review_decisions"
 ALLOWED_LEDGER_DECISIONS = frozenset({"approve", "deferred", "reject"})
@@ -206,6 +216,7 @@ def promote_grow_candidates(
     promoted: list[str] = []
     skipped_existing: list[str] = []
     newly_promoted_entries: list[dict[str, Any]] = []
+    newly_promoted_hints: list[tuple[dict[str, Any], tuple[str, ...]]] = []
     for candidate in promote_queue:
         lemma = strip_acute_stress(_candidate_lemma(candidate))
         key = _lemma_key(lemma)
@@ -217,6 +228,14 @@ def promote_grow_candidates(
         existing_keys.add(key)
         promoted.append(lemma)
         newly_promoted_entries.append(entry)
+        newly_promoted_hints.append((entry, _candidate_participle_hints(candidate)))
+
+    for entry, hints in newly_promoted_hints:
+        apply_participle_presentation(
+            entry,
+            parent_hints=hints,
+            available_lemmas=existing_keys,
+        )
 
     # Fill before validation: the prospective gate must inspect the exact post-fill
     # manifest state that would ship, including its translation/source enrichment.
@@ -227,6 +246,12 @@ def promote_grow_candidates(
 
     if promoted:
         _refresh_manifest_metadata(manifest)
+
+    # A dry run must surface the same deterministic admission failures as a
+    # write.  Otherwise a malformed candidate can look promotable until the
+    # irreversible step is attempted.
+    if promoted:
+        _validate_new_entry_learner_gates(newly_promoted_entries)
 
     manifest_written = False
     fingerprint_written = False
@@ -271,6 +296,9 @@ def manifest_entry_from_candidate(candidate: Mapping[str, Any]) -> dict[str, Any
     """Build one live manifest entry from a P2 enriched candidate."""
     lemma = strip_acute_stress(_candidate_lemma(candidate))
     gloss = _candidate_gloss(candidate)
+    curated_glosses = _CURATED_PARTICIPLE_LEARNER_GLOSSES.get(_lemma_key(lemma))
+    if curated_glosses and _is_cyrillic_only_gloss(gloss):
+        gloss = "; ".join(curated_glosses)
     pos = _clean_optional_str(candidate.get("pos"))
     base_entry = _manifest_entry(
         lemma,
@@ -287,6 +315,20 @@ def manifest_entry_from_candidate(candidate: Mapping[str, Any]) -> dict[str, Any
             base_entry[field] = candidate[field]
     if "pos" in candidate:
         base_entry["pos"] = candidate.get("pos")
+    if curated_glosses:
+        enrichment_raw = base_entry.get("enrichment")
+        enrichment: dict[str, Any] = dict(enrichment_raw) if isinstance(enrichment_raw, Mapping) else {}
+        translation = enrichment.get("translation")
+        if not isinstance(translation, Mapping) or not translation.get("en"):
+            enrichment["translation"] = {
+                "en": list(curated_glosses),
+                "source": _CURATED_PARTICIPLE_GLOSS_SOURCE,
+            }
+        sources = list(enrichment.get("sources") or []) if isinstance(enrichment.get("sources"), list) else []
+        if _CURATED_PARTICIPLE_GLOSS_SOURCE not in sources:
+            sources.append(_CURATED_PARTICIPLE_GLOSS_SOURCE)
+        enrichment["sources"] = sorted(sources)
+        base_entry["enrichment"] = enrichment
     return base_entry
 
 
@@ -900,6 +942,41 @@ def _candidate_gloss(candidate: Mapping[str, Any]) -> str | None:
         if gloss:
             return gloss
     return None
+
+
+def _candidate_participle_hints(candidate: Mapping[str, Any]) -> tuple[str, ...]:
+    """Keep source-definition wording available for deterministic parent lookup."""
+    hints: list[str] = []
+    for key in ("gloss", "approved_gloss"):
+        value = candidate.get(key)
+        if isinstance(value, str) and value.strip():
+            hints.append(value)
+    enrichment = candidate.get("enrichment")
+    if isinstance(enrichment, Mapping):
+        meaning = enrichment.get("meaning")
+        if isinstance(meaning, Mapping):
+            definitions = meaning.get("definitions")
+            if isinstance(definitions, list):
+                for definition in definitions:
+                    if isinstance(definition, str):
+                        hints.append(definition)
+                    elif isinstance(definition, Mapping):
+                        for key in ("text", "definition", "value"):
+                            value = definition.get(key)
+                            if isinstance(value, str):
+                                hints.append(value)
+    return tuple(hints)
+
+
+def _validate_new_entry_learner_gates(entries: Sequence[Mapping[str, Any]]) -> None:
+    """Fail closed before a promote write when learner/gloss morphology is invalid."""
+    violations = promotion_entry_gate_violations(entries)
+    if not violations:
+        return
+    print("=== NEW-ENTRY LEARNER GATES ===", file=sys.stderr)
+    for violation in violations[:20]:
+        print(f"  {violation}", file=sys.stderr)
+    raise SelfCheckError(2)
 
 
 def _meaning_text(meaning: object) -> str | None:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "76d089eb20667917bef9f39844345f967083719e0c6018e5152796b2001faf84",
+  "fingerprint": "e21a9fc99528aae2ca527e6d696a20c30a1da4e91a6d869dfa99ba21470ab485",
   "inputs": {
     "lexicon_code": [
       {
@@ -84,7 +84,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "0307b5c171f3ad3585666100c1055769013f2db18888f7a2ac36a63b78cf6f6f"
+        "sha256": "3a96223510b9ce6e1f1666bad590e24150aab09e928389e55396ceeff12e92c8"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -176,7 +176,7 @@
       },
       {
         "path": "scripts/lexicon/promote_grow_candidates.py",
-        "sha256": "c4a0fe8e365601a6208b681356a923479a49c7c34eba2752209aa7baff82861e"
+        "sha256": "d1b652b940b1812f5d256a3b3e26b0fa7592b67cd26fba6f8546c7775c8f2b35"
       },
       {
         "path": "scripts/lexicon/promote_teacher_lesson_intake.py",

--- a/site/src/lexicon/WordAtlasArticle.tsx
+++ b/site/src/lexicon/WordAtlasArticle.tsx
@@ -112,6 +112,7 @@ export default function WordAtlasArticle({
     headerStress,
     nounParadigm,
     verbParadigm,
+    participleParadigm,
     markedFormGroups,
     isFullyMarked,
     isExpressionLikeEntry,
@@ -430,6 +431,45 @@ export default function WordAtlasArticle({
                       </tbody>
                     </table>
                   ))}
+                </>
+              ) : participleParadigm ? (
+                <>
+                  <p>
+                    <strong>
+                      {participleParadigm.voice === "passive" ? "Пасивний" : "Активний"} дієприкметник
+                      {participleParadigm.aspect === "perfective" ? " доконаного виду" : " недоконаного виду"}
+                    </strong>
+                    {participleParadigm.verb && (
+                      <>
+                        {" "}від {participleParadigm.verb_url_slug ? (
+                          <a href={`/lexicon/${participleParadigm.verb_url_slug}`} className="ukr">
+                            {participleParadigm.verb}
+                          </a>
+                        ) : (
+                          <span className="ukr">{participleParadigm.verb}</span>
+                        )}
+                      </>
+                    )}
+                  </p>
+                  {!isFullyMarked && enrichment.morphology.forms.length > 0 && (
+                    <table className="paradigm-table">
+                      <caption>Форми дієприкметника</caption>
+                      <thead>
+                        <tr>
+                          <th scope="col">Форма</th>
+                          <th scope="col">Позначка</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {enrichment.morphology.forms.slice(0, 24).map((form) => (
+                          <tr key={`${form.form}-${form.label}`}>
+                            <td className="form">{form.stress ?? stressDisplay(form.form)}</td>
+                            <td className="case-name">{form.label}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
                 </>
               ) : (
                 !isFullyMarked && enrichment.morphology.forms.length > 0 && (

--- a/site/src/lib/lexicon/word-atlas-article-model.ts
+++ b/site/src/lib/lexicon/word-atlas-article-model.ts
@@ -65,7 +65,15 @@ export interface VerbParadigm {
   past?: Record<string, string>;
 }
 
-export type MorphologyParadigm = NounParadigm | VerbParadigm | { kind: "other" };
+export interface ParticipleParadigm {
+  kind: "participle";
+  voice: "active" | "passive";
+  aspect: "perfective" | "imperfective";
+  verb?: string;
+  verb_url_slug?: string;
+}
+
+export type MorphologyParadigm = NounParadigm | VerbParadigm | ParticipleParadigm | { kind: "other" };
 
 export interface Enrichment {
   stress?: { form: string; source: string };
@@ -375,6 +383,7 @@ export function buildWordAtlasArticleView(
   const paradigm = enrichment?.morphology?.paradigm ?? null;
   const nounParadigm = paradigm?.kind === "noun" ? paradigm : null;
   const verbParadigm = paradigm?.kind === "verb" ? paradigm : null;
+  const participleParadigm = paradigm?.kind === "participle" ? paradigm : null;
   const markedForms = enrichment?.morphology?.marked_forms ?? [];
   const markedFormGroups: Array<{ marker_label: string; forms: typeof markedForms }> = [];
   for (const form of markedForms) {
@@ -455,6 +464,7 @@ export function buildWordAtlasArticleView(
     headerStress,
     nounParadigm,
     verbParadigm,
+    participleParadigm,
     markedFormGroups,
     isFullyMarked,
     isExpressionLikeEntry,

--- a/site/tests/unit/atlas-participle-presentation.test.ts
+++ b/site/tests/unit/atlas-participle-presentation.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+
+import { describe, expect, test } from 'vitest';
+import { articleProps } from '../helpers/word-atlas-record';
+import { renderWordAtlasArticle } from '../helpers/render-word-atlas-article';
+
+describe('VESUM participle presentation (#5918)', () => {
+  test('renders a passive participle as a participle and links its available verb parent', () => {
+    const html = renderWordAtlasArticle(articleProps({
+      lemma: 'прийнятий',
+      url_slug: 'прийнятий',
+      gloss: 'accepted; admitted; adopted',
+      entry_type: 'lemma',
+      pos: 'adj',
+      ipa: null,
+      primary_source: 'fixture',
+      course_usage: [],
+      enrichment: {
+        morphology: {
+          pos: 'прикметник',
+          form_count: 2,
+          source: 'VESUM',
+          forms: [
+            { form: 'прийнятий', label: 'чол., називний' },
+            { form: 'прийнята', label: 'жін., називний' },
+          ],
+          paradigm: {
+            kind: 'participle',
+            voice: 'passive',
+            aspect: 'perfective',
+            verb: 'прийняти',
+            verb_url_slug: 'прийняти',
+          },
+        },
+      },
+    }));
+
+    expect(html).toContain('Пасивний дієприкметник доконаного виду');
+    expect(html).toContain('href="/lexicon/прийняти"');
+    expect(html).toContain('Форми дієприкметника');
+    expect(html).toContain('прийнята');
+  });
+});

--- a/tests/test_audit_atlas_thin_enriched.py
+++ b/tests/test_audit_atlas_thin_enriched.py
@@ -22,6 +22,7 @@ def test_has_learner_english_anchor_accepts_supported_anchor_shapes() -> None:
 
 
 def test_has_learner_english_anchor_rejects_ukrainian_only_enrichment() -> None:
+    assert not has_learner_english_anchor({"gloss": "Дієпр. пас. мин. ч. до прийняти."})
     assert not has_learner_english_anchor(
         {
             "enrichment": {

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -357,6 +357,64 @@ def test_morphology_can_use_base_form_from_pair_lemma(monkeypatch) -> None:
     assert morphology["forms"][0] == {"form": "варити", "label": "інфінітив"}
 
 
+def test_vesum_passive_participle_gets_presentation_and_verified_parent(monkeypatch) -> None:
+    """Regression fixture for «прийнятий» (adjp:pasv:perf, #5918)."""
+    rows = [
+        {"word_form": "прийнятий", "tags": "adj:m:v_naz:adjp:pasv:perf", "pos": "adj"},
+        {"word_form": "прийнята", "tags": "adj:f:v_naz:adjp:pasv:perf", "pos": "adj"},
+    ]
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: rows)
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "verify_word",
+        lambda word: (
+            [{"lemma": "прийняти", "pos": "verb", "tags": "verb:perf:inf"}]
+            if word == "прийняти"
+            else [
+                {"lemma": "прийнятий", "pos": "adj", "tags": "adj:m:v_naz:adjp:pasv:perf"}
+            ]
+        ),
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+
+    entry: dict[str, object] = {
+        "lemma": "прийнятий",
+        "gloss": "accepted; admitted; adopted",
+        "enrichment": {
+            "meaning": {"definitions": ["Дієпр. пас. мин. ч. до прийня́ти."], "source": "fixture"}
+        },
+    }
+
+    assert enrich_manifest_module.apply_participle_presentation(
+        entry,
+        available_lemmas={"прийняти", "прийнятий"},
+    )
+    paradigm = entry["enrichment"]["morphology"]["paradigm"]
+    assert paradigm == {
+        "kind": "participle",
+        "voice": "passive",
+        "aspect": "perfective",
+        "verb": "прийняти",
+        "verb_url_slug": "прийняти",
+    }
+    assert enrich_manifest_module.promotion_entry_gate_violations([entry]) == []
+
+
+def test_participle_gate_rejects_bare_adjective_and_cyrillic_gloss(monkeypatch) -> None:
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "verify_word",
+        lambda word: [{"lemma": word, "pos": "adj", "tags": "adj:m:v_naz:adjp:pasv:perf"}],
+    )
+
+    violations = enrich_manifest_module.promotion_entry_gate_violations(
+        [{"lemma": "прийнятий", "gloss": "Дієпр. пас. мин. ч. до прийняти."}]
+    )
+
+    assert any("Cyrillic-only" in violation for violation in violations)
+    assert any("requires participle presentation" in violation for violation in violations)
+
+
 # --- #4891: style-marked forms segregated out of the modern paradigm ---
 
 

--- a/tests/test_promote_grow_candidates.py
+++ b/tests/test_promote_grow_candidates.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from scripts.lexicon import enrich_manifest as enrich_manifest_module
 from scripts.lexicon import promote_grow_candidates as promote
 from scripts.lexicon.source_attribution import BALLA_LABEL, attach_official_url
 
@@ -83,6 +84,110 @@ def test_manifest_entry_prefers_curated_candidate_gloss_over_meaning() -> None:
     )
 
     assert entry["gloss"] == "pineapple"
+
+
+def test_manifest_entry_curates_english_pryjnyatyi_gloss() -> None:
+    entry = promote.manifest_entry_from_candidate(
+        _candidate(
+            lemma="прийнятий",
+            pos="adj",
+            gloss="Дієпр. пас. мин. ч. до прийня́ти.",
+            enrichment={
+                "meaning": {
+                    "definitions": ["Дієпр. пас. мин. ч. до прийня́ти."],
+                    "source": "fixture dictionary",
+                },
+                "sources": ["fixture dictionary"],
+            },
+        )
+    )
+
+    assert entry["gloss"] == "accepted; admitted; adopted"
+    assert entry["enrichment"]["translation"] == {
+        "en": ["accepted", "admitted", "adopted"],
+        "source": "Atlas learner curation (#5918)",
+    }
+
+
+def test_promote_dry_run_rejects_cyrillic_only_top_level_gloss(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("авто")])
+    before = manifest_path.read_text(encoding="utf-8")
+    candidates_path = _write_candidates(
+        tmp_path,
+        [_candidate("мама", gloss="мама", enrichment={"meaning": {"definitions": ["мама"]}})],
+        [],
+    )
+
+    with pytest.raises(promote.SelfCheckError):
+        promote.promote_grow_candidates(
+            candidates_path=candidates_path,
+            manifest_path=manifest_path,
+            needs_review_path=tmp_path / "grow_needs_review.json",
+            fingerprint_path=tmp_path / "lexicon-manifest.fingerprint.json",
+            self_check=lambda _path: 0,
+            fingerprint_writer=_fingerprint_writer,
+        )
+
+    assert manifest_path.read_text(encoding="utf-8") == before
+
+
+def test_promote_pryjnyatyi_uses_english_gloss_and_participle_presentation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    participle_forms = [
+        {"word_form": "прийнятий", "tags": "adj:m:v_naz:adjp:pasv:perf", "pos": "adj"},
+        {"word_form": "прийнята", "tags": "adj:f:v_naz:adjp:pasv:perf", "pos": "adj"},
+    ]
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: participle_forms)
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "verify_word",
+        lambda word: (
+            [{"lemma": "прийняти", "pos": "verb", "tags": "verb:perf:inf"}]
+            if word == "прийняти"
+            else [{"lemma": "прийнятий", "pos": "adj", "tags": "adj:m:v_naz:adjp:pasv:perf"}]
+        ),
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+    manifest_path = _write_manifest(tmp_path, [_entry("прийняти")])
+    candidates_path = _write_candidates(
+        tmp_path,
+        [
+            _candidate(
+                "прийнятий",
+                pos="adj",
+                gloss="Дієпр. пас. мин. ч. до прийня́ти.",
+                enrichment={
+                    "meaning": {
+                        "definitions": ["Дієпр. пас. мин. ч. до прийня́ти."],
+                        "source": "fixture dictionary",
+                    },
+                    "sources": ["fixture dictionary"],
+                },
+            )
+        ],
+        [],
+    )
+
+    promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=tmp_path / "grow_needs_review.json",
+        fingerprint_path=tmp_path / "lexicon-manifest.fingerprint.json",
+        write=True,
+        self_check=lambda _path: 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    entry = next(item for item in _read_json(manifest_path)["entries"] if item["lemma"] == "прийнятий")
+    assert entry["gloss"] == "accepted; admitted; adopted"
+    assert entry["enrichment"]["morphology"]["paradigm"] == {
+        "kind": "participle",
+        "voice": "passive",
+        "aspect": "perfective",
+        "verb": "прийняти",
+        "verb_url_slug": "прийняти",
+    }
 
 
 def test_manifest_entry_omits_provenance_when_candidate_has_none() -> None:


### PR DESCRIPTION
## Summary
- present VESUM `adjp:pasv` / `adjp:actv` forms as participles with voice, aspect, and an attested verb parent
- reject Cyrillic-only learner glosses during Atlas promotion, including dry runs
- curate `прийнятий` as “accepted; admitted; adopted” and render its participle table/link

Closes #5918
Parent: #4387

## Verification
- `.venv/bin/python -m pytest -q tests/test_lexicon_enrich_manifest.py tests/test_promote_grow_candidates.py tests/test_audit_atlas_thin_enriched.py tests/test_verify_manifest.py`
- `npm exec -- vitest run tests/unit/atlas-participle-presentation.test.ts tests/unit/atlas-runtime-shards.test.ts` (from `site/`)
- `.venv/bin/python -m ruff check …`
- `.venv/bin/python scripts/audit/lint_opsec_leaks.py --staged`

No auto-merge: awaiting the required cross-family formal review.